### PR TITLE
sql: add pg_catalog.pg_shdescription

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -26,7 +26,7 @@ a         public              admin      ALL
 a         public              readwrite  ALL
 a         public              root       ALL
 
-# Show that by default GRANT is retricted to the current database
+# Show that by default GRANT is restricted to the current database
 query TTTTT colnames
 SHOW GRANTS
 ----
@@ -114,6 +114,7 @@ test      pg_catalog          pg_rewrite                         public  SELECT
 test      pg_catalog          pg_roles                           public  SELECT
 test      pg_catalog          pg_sequence                        public  SELECT
 test      pg_catalog          pg_settings                        public  SELECT
+test      pg_catalog          pg_shdescription                   public  SELECT
 test      pg_catalog          pg_stat_activity                   public  SELECT
 test      pg_catalog          pg_tables                          public  SELECT
 test      pg_catalog          pg_tablespace                      public  SELECT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -288,6 +288,7 @@ pg_catalog          pg_rewrite
 pg_catalog          pg_roles
 pg_catalog          pg_sequence
 pg_catalog          pg_settings
+pg_catalog          pg_shdescription
 pg_catalog          pg_stat_activity
 pg_catalog          pg_tables
 pg_catalog          pg_tablespace
@@ -408,6 +409,7 @@ pg_rewrite
 pg_roles
 pg_sequence
 pg_settings
+pg_shdescription
 pg_stat_activity
 pg_tables
 pg_tablespace
@@ -535,6 +537,7 @@ system         pg_catalog          pg_rewrite                         SYSTEM VIE
 system         pg_catalog          pg_roles                           SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_sequence                        SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_settings                        SYSTEM VIEW  NO                  1
+system         pg_catalog          pg_shdescription                   SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_stat_activity                   SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_tables                          SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_tablespace                      SYSTEM VIEW  NO                  1
@@ -1076,6 +1079,7 @@ NULL     public   system         pg_catalog          pg_rewrite                 
 NULL     public   system         pg_catalog          pg_roles                           SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_sequence                        SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_settings                        SELECT          NULL          NULL
+NULL     public   system         pg_catalog          pg_shdescription                   SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_stat_activity                   SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_tables                          SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_tablespace                      SELECT          NULL          NULL
@@ -1266,6 +1270,7 @@ NULL     public   system         pg_catalog          pg_rewrite                 
 NULL     public   system         pg_catalog          pg_roles                           SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_sequence                        SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_settings                        SELECT          NULL          NULL
+NULL     public   system         pg_catalog          pg_shdescription                   SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_stat_activity                   SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_tables                          SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_tablespace                      SELECT          NULL          NULL

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -41,6 +41,7 @@ pg_rewrite
 pg_roles
 pg_sequence
 pg_settings
+pg_shdescription
 pg_stat_activity
 pg_tables
 pg_tablespace
@@ -102,6 +103,7 @@ pg_rewrite
 pg_roles
 pg_sequence
 pg_settings
+pg_shdescription
 pg_stat_activity
 pg_tables
 pg_tablespace
@@ -1135,6 +1137,13 @@ query OOIT colnames
 SELECT objoid, classoid, objsubid, description FROM pg_catalog.pg_description
 ----
 objoid  classoid  objsubid  description
+
+## pg_catalog.pg_shdescription
+
+query OOT colnames
+SELECT objoid, classoid, description FROM pg_catalog.pg_shdescription
+----
+objoid  classoid  description
 
 ## pg_catalog.pg_enum
 

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -156,7 +156,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   6 columns, 86 rows
+·                      size   6 columns, 87 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -219,7 +219,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         17 columns, 888 rows
+                     │                     size         17 columns, 891 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·
@@ -233,7 +233,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   8 columns, 555 rows
+·                      size   8 columns, 560 rows
 
 
 query TTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -157,7 +157,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   6 columns, 86 rows
+·                      size   6 columns, 87 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -220,7 +220,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         17 columns, 888 rows
+                     │                     size         17 columns, 891 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·
@@ -234,7 +234,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   8 columns, 555 rows
+·                      size   8 columns, 560 rows
 
 
 query TTT

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -66,6 +66,7 @@ var pgCatalog = virtualSchema{
 		pgCatalogDatabaseTable,
 		pgCatalogDependTable,
 		pgCatalogDescriptionTable,
+		pgCatalogSharedDescriptionTable,
 		pgCatalogEnumTable,
 		pgCatalogExtensionTable,
 		pgCatalogForeignDataWrapperTable,
@@ -795,6 +796,21 @@ CREATE TABLE pg_catalog.pg_description (
 	objoid OID,
 	classoid OID,
 	objsubid INT,
+	description STRING
+);
+`,
+	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		// Comments on database objects are not currently supported.
+		return nil
+	},
+}
+
+// See: https://www.postgresql.org/docs/current/static/catalog-pg-shdescription.html.
+var pgCatalogSharedDescriptionTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_shdescription (
+	objoid OID,
+	classoid OID,
 	description STRING
 );
 `,


### PR DESCRIPTION
This virtual table is required for compatibility with PGAdmin.

Closes #26376.

Release note: Added the pg_catalog.pg_shdescription table for compatibility with
Postgres tools. Note that we do not support adding descriptions to shared
database objects.