### PR TITLE
cli: support encrypted stores in debug commands.

### DIFF
--- a/pkg/ccl/baseccl/encryption_spec.go
+++ b/pkg/ccl/baseccl/encryption_spec.go
@@ -11,6 +11,7 @@ package baseccl
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -219,4 +220,25 @@ func PopulateStoreSpecWithEncryption(
 		}
 	}
 	return nil
+}
+
+// EncryptionOptionsForStore takes a store directory and returns its ExtraOptions
+// if a matching entry if found in the StoreEncryptionSpecList.
+// The caller should appropriately set UseFileRegistry on a non-nil result.
+func EncryptionOptionsForStore(
+	dir string, encryptionSpecs StoreEncryptionSpecList,
+) ([]byte, error) {
+	// We need an absolute path, but the input may have come in relative.
+	path, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not find absolute path for %s ", dir)
+	}
+
+	for _, es := range encryptionSpecs.Specs {
+		if es.Path == path {
+			return es.toEncryptionOptions()
+		}
+	}
+
+	return nil, nil
 }

--- a/pkg/ccl/cliccl/debug.go
+++ b/pkg/ccl/cliccl/debug.go
@@ -1,0 +1,43 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package cliccl
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/ccl/baseccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/cliccl/cliflagsccl"
+	"github.com/cockroachdb/cockroach/pkg/cli"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+)
+
+// This does not define new commands, only adds the encryption flag to debug commands in
+// `pkg/cli/debug.go` and registers a callback to generate encryption options.
+
+func init() {
+	for _, cmd := range cli.DebugCmdsForRocksDB {
+		// storeEncryptionSpecs is in start.go.
+		cli.VarFlag(cmd.Flags(), &storeEncryptionSpecs, cliflagsccl.EnterpriseEncryption)
+	}
+
+	cli.PopulateRocksDBConfigHook = fillEncryptionOptionsForStore
+}
+
+// fillEncryptionOptionsForStore fills the RocksDBConfig fields
+// based on the --enterprise-encryption flag value.
+func fillEncryptionOptionsForStore(cfg *engine.RocksDBConfig) error {
+	opts, err := baseccl.EncryptionOptionsForStore(cfg.Dir, storeEncryptionSpecs)
+	if err != nil {
+		return err
+	}
+
+	if opts != nil {
+		cfg.ExtraOptions = opts
+		cfg.UseFileRegistry = true
+	}
+	return nil
+}


### PR DESCRIPTION
Add the `--enterprise-encryption` flag to debug commands that open
rocksdb. The flag is as specified in the start command.

There are a few TODOs left:
* support the ldb tool somehow
* add tests for this, it'll need to be interactive tests in ccl/

Release note: None