### PR TITLE
sql: clean up and stabilize the output of SHOW CONSTRAINTS

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -85,14 +85,14 @@ a f b    c
 2 9 1    1
 3 9 2    1
 
-query TTTTT colnames
+query TTTTB colnames
 SHOW CONSTRAINTS FROM t
 ----
-Table  Name            Type         Column(s)  Details
-t      check_a         CHECK        a          a > 0
-t      fk_f_ref_other  FOREIGN KEY  f          other.[b]
-t      foo             UNIQUE       b          NULL
-t      primary         PRIMARY KEY  a          NULL
+table  name            type         details                               validated
+t      check_a         CHECK        CHECK (a > 0)                         true
+t      fk_f_ref_other  FOREIGN KEY  FOREIGN KEY (f) REFERENCES other (b)  true
+t      foo             UNIQUE       UNIQUE (b ASC)                        true
+t      primary         PRIMARY KEY  PRIMARY KEY (a ASC)                   true
 
 statement error CHECK
 INSERT INTO t (a, f) VALUES (-2, 9)
@@ -109,13 +109,13 @@ ALTER TABLE t ADD CONSTRAINT check_a CHECK (a > 0)
 statement error CHECK
 INSERT INTO t (a) VALUES (-3)
 
-query TTTTT
+query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a         CHECK (UNVALIDATED)  a  a > 0
-t  fk_f_ref_other  FOREIGN KEY          f  other.[b]
-t  foo             UNIQUE               b  NULL
-t  primary         PRIMARY KEY          a  NULL
+t  check_a         CHECK        CHECK (a > 0)                         false
+t  fk_f_ref_other  FOREIGN KEY  FOREIGN KEY (f) REFERENCES other (b)  true
+t  foo             UNIQUE       UNIQUE (b ASC)                        true
+t  primary         PRIMARY KEY  PRIMARY KEY (a ASC)                   true
 
 statement error duplicate constraint name
 ALTER TABLE t ADD CONSTRAINT check_a CHECK (a > 0)
@@ -124,14 +124,14 @@ ALTER TABLE t ADD CONSTRAINT check_a CHECK (a > 0)
 statement ok
 ALTER TABLE t ADD CHECK (a > 0)
 
-query TTTTT
+query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a         CHECK (UNVALIDATED)  a  a > 0
-t  check_a1        CHECK (UNVALIDATED)  a  a > 0
-t  fk_f_ref_other  FOREIGN KEY          f  other.[b]
-t  foo             UNIQUE               b  NULL
-t  primary         PRIMARY KEY          a  NULL
+t  check_a         CHECK        CHECK (a > 0)                         false
+t  check_a1        CHECK        CHECK (a > 0)                         false
+t  fk_f_ref_other  FOREIGN KEY  FOREIGN KEY (f) REFERENCES other (b)  true
+t  foo             UNIQUE       UNIQUE (b ASC)                        true
+t  primary         PRIMARY KEY  PRIMARY KEY (a ASC)                   true
 
 statement error constraint "typo" does not exist
 ALTER TABLE t VALIDATE CONSTRAINT typo
@@ -145,14 +145,14 @@ DELETE FROM t WHERE a = -2
 statement ok
 ALTER TABLE t VALIDATE CONSTRAINT check_a
 
-query TTTTT
+query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a         CHECK                a  a > 0
-t  check_a1        CHECK (UNVALIDATED)  a  a > 0
-t  fk_f_ref_other  FOREIGN KEY          f  other.[b]
-t  foo             UNIQUE               b  NULL
-t  primary         PRIMARY KEY          a  NULL
+t  check_a         CHECK        CHECK (a > 0)                         true
+t  check_a1        CHECK        CHECK (a > 0)                         false
+t  fk_f_ref_other  FOREIGN KEY  FOREIGN KEY (f) REFERENCES other (b)  true
+t  foo             UNIQUE       UNIQUE (b ASC)                        true
+t  primary         PRIMARY KEY  PRIMARY KEY (a ASC)                   true
 
 statement ok
 ALTER TABLE t DROP CONSTRAINT check_a, DROP CONSTRAINT check_a1
@@ -376,12 +376,12 @@ a   x     y     z     d     e     f
 31  NULL  1.3   1.4   NULL  NULL  NULL
 33  2.0   2.1   2.2   NULL  NULL  NULL
 
-query TTTTT
+query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  primary  PRIMARY KEY  a  NULL
-t  t_d_key  UNIQUE       d  NULL
-t  t_e_key  UNIQUE       e  NULL
+t  primary  PRIMARY KEY  PRIMARY KEY (a ASC)  true
+t  t_d_key  UNIQUE       UNIQUE (d ASC)       true
+t  t_e_key  UNIQUE       UNIQUE (e ASC)       true
 
 # Subsequent operations succeed because the table is empty
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -168,11 +168,11 @@ CREATE TABLE "user content".review_stats (
   CONSTRAINT reviewfk FOREIGN KEY (id) REFERENCES "user content"."customer reviews"
 )
 
-query TTTTT
+query TTTTB
 SHOW CONSTRAINTS FROM "user content".review_stats
 ----
-review_stats  primary   PRIMARY KEY  id  NULL
-review_stats  reviewfk  FOREIGN KEY  id  customer reviews.[id]
+review_stats  primary   PRIMARY KEY  PRIMARY KEY (id ASC)                                 true
+review_stats  reviewfk  FOREIGN KEY  FOREIGN KEY (id) REFERENCES "customer reviews" (id)  true
 
 statement error pgcode 23503 foreign key violation: value \[5\] not found in customer reviews@primary \[id\]
 INSERT INTO "user content".review_stats (id, upvotes) VALUES (5, 1)
@@ -186,10 +186,10 @@ DELETE FROM "user content"."customer reviews" WHERE id = 2
 statement ok
 ALTER TABLE "user content".review_stats DROP CONSTRAINT reviewfk
 
-query TTTTT
+query TTTTB
 SHOW CONSTRAINTS FROM "user content".review_stats
 ----
-review_stats  primary   PRIMARY KEY  id  NULL
+review_stats  primary  PRIMARY KEY  PRIMARY KEY (id ASC)  true
 
 statement ok
 DELETE FROM "user content"."customer reviews"
@@ -292,20 +292,20 @@ UPDATE products SET upc = 'blah' WHERE sku = '780'
 statement ok
 ALTER TABLE delivery ADD FOREIGN KEY (item) REFERENCES products (upc)
 
-query TTTTT
+query TTTTB
 SHOW CONSTRAINTS FROM delivery
 ----
-delivery  fk_item_ref_products   FOREIGN KEY (UNVALIDATED)  item             products.[upc]
-delivery  fk_order_ref_orders    FOREIGN KEY                order, shipment  orders.[id shipment]
+delivery  fk_item_ref_products  FOREIGN KEY  FOREIGN KEY (item) REFERENCES products (upc)                      false
+delivery  fk_order_ref_orders   FOREIGN KEY  FOREIGN KEY ("order", shipment) REFERENCES orders (id, shipment)  true
 
 statement error pgcode 23503 foreign key violation: "delivery" row item='885155001450' has no match in "products"
 ALTER TABLE delivery VALIDATE CONSTRAINT fk_item_ref_products
 
-query TTTTT
+query TTTTB
 SHOW CONSTRAINTS FROM delivery
 ----
-delivery  fk_item_ref_products   FOREIGN KEY (UNVALIDATED)  item             products.[upc]
-delivery  fk_order_ref_orders    FOREIGN KEY                order, shipment  orders.[id shipment]
+delivery  fk_item_ref_products  FOREIGN KEY  FOREIGN KEY (item) REFERENCES products (upc)                      false
+delivery  fk_order_ref_orders   FOREIGN KEY  FOREIGN KEY ("order", shipment) REFERENCES orders (id, shipment)  true
 
 statement ok
 UPDATE products SET upc = '885155001450' WHERE sku = '780'
@@ -317,11 +317,11 @@ UPDATE products SET upc = 'blah' WHERE sku = '780'
 statement ok
 ALTER TABLE delivery VALIDATE CONSTRAINT fk_item_ref_products
 
-query TTTTT
+query TTTTB
 SHOW CONSTRAINTS FROM delivery
 ----
-delivery  fk_item_ref_products   FOREIGN KEY        item             products.[upc]
-delivery  fk_order_ref_orders    FOREIGN KEY        order, shipment  orders.[id shipment]
+delivery  fk_item_ref_products  FOREIGN KEY  FOREIGN KEY (item) REFERENCES products (upc)                      true
+delivery  fk_order_ref_orders   FOREIGN KEY  FOREIGN KEY ("order", shipment) REFERENCES orders (id, shipment)  true
 
 statement ok
 ALTER TABLE "user content"."customer reviews"
@@ -390,13 +390,13 @@ SELECT COUNT(*) FROM delivery
 statement ok
 TRUNCATE delivery, products, orders, "user content"."customer reviews"
 
-query TTTTT colnames
+query TTTTB colnames
 SHOW CONSTRAINTS FROM orders
 ----
-Table   Name                        Type         Column(s)   Details
-orders  fk_product_ref_products     FOREIGN KEY  product     products.[sku]
-orders  primary                     PRIMARY KEY  id, shipment          NULL
-orders  valid_customer              FOREIGN KEY  customer    customers.[id]
+table   name                     type         details                                                                                validated
+orders  fk_product_ref_products  FOREIGN KEY  FOREIGN KEY (product) REFERENCES products (sku) ON DELETE RESTRICT ON UPDATE RESTRICT  true
+orders  primary                  PRIMARY KEY  PRIMARY KEY (id ASC, shipment ASC)                                                     true
+orders  valid_customer           FOREIGN KEY  FOREIGN KEY (customer) REFERENCES customers (id)                                       true
 
 statement error "products_upc_key" is referenced by foreign key from table "delivery"
 DROP INDEX products@products_upc_key
@@ -676,13 +676,13 @@ CREATE TABLE domain_modules (
   CONSTRAINT domain_modules_uq UNIQUE (domain_id, module_id)
 )
 
-query TTTTT
+query TTTTB
 SHOW CONSTRAINTS FROM domain_modules
 ----
-domain_modules  domain_modules_domain_id_fk  FOREIGN KEY  domain_id             domains.[id]
-domain_modules  domain_modules_module_id_fk  FOREIGN KEY  module_id             modules.[id]
-domain_modules  domain_modules_uq            UNIQUE       domain_id, module_id  NULL
-domain_modules  primary                      PRIMARY KEY  id                    NULL
+domain_modules  domain_modules_domain_id_fk  FOREIGN KEY  FOREIGN KEY (domain_id) REFERENCES domains (id)  true
+domain_modules  domain_modules_module_id_fk  FOREIGN KEY  FOREIGN KEY (module_id) REFERENCES modules (id)  true
+domain_modules  domain_modules_uq            UNIQUE       UNIQUE (domain_id ASC, module_id ASC)            true
+domain_modules  primary                      PRIMARY KEY  PRIMARY KEY (id ASC)                             true
 
 statement ok
 CREATE TABLE tx (

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -170,10 +170,10 @@ SHOW INDEXES FROM information_schema.tables
 ----
 Table  Name  Unique  Seq  Column  Direction  Storing  Implicit
 
-query TTTTT colnames
+query TTTTB colnames
 SHOW CONSTRAINTS FROM information_schema.tables
 ----
-Table   Name     Type  Column(s)  Details
+table  name  type  details  validated
 
 query TTTTT colnames
 SHOW GRANTS ON information_schema.tables

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -142,10 +142,10 @@ SHOW INDEXES FROM pg_catalog.pg_namespace
 ----
 Table  Name  Unique  Seq  Column  Direction  Storing  Implicit
 
-query TTTTT colnames
+query TTTTB colnames
 SHOW CONSTRAINTS FROM pg_catalog.pg_namespace
 ----
-Table         Name     Type  Column(s)  Details
+table  name  type  details  validated
 
 query TTTTT colnames
 SHOW GRANTS ON pg_catalog.pg_namespace

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -100,11 +100,11 @@ SELECT * FROM [SHOW INDEX FROM system.descriptor]
 Table       Name     Unique  Seq  Column  Direction  Storing  Implicit
 descriptor  primary  true    1    id      ASC        false    false
 
-query TTTTT colnames
+query TTTTB colnames
 SELECT * FROM [SHOW CONSTRAINT FROM system.descriptor]
 ----
-Table       Name     Type         Column(s)  Details
-descriptor  primary  PRIMARY KEY  id         NULL
+table       name     type         details               validated
+descriptor  primary  PRIMARY KEY  PRIMARY KEY (id ASC)  true
 
 query TTBITTBB colnames
 SELECT * FROM [SHOW KEYS FROM system.descriptor]

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -215,14 +215,14 @@ CREATE TABLE test.dupe_generated (
   CHECK (foo < 10)
 )
 
-query TTTTT colnames
+query TTTTB colnames
 SHOW CONSTRAINTS FROM test.dupe_generated
 ----
-Table           Name        Type         Column(s)   Details
-dupe_generated  check_bar   CHECK        bar        bar > 2
-dupe_generated  check_foo   CHECK        foo        foo > 2
-dupe_generated  check_foo1  CHECK        foo        foo < 10
-dupe_generated  check_foo2  CHECK        foo        foo > 1
+table           name        type   details           validated
+dupe_generated  check_bar   CHECK  CHECK (bar > 2)   true
+dupe_generated  check_foo   CHECK  CHECK (foo > 2)   true
+dupe_generated  check_foo1  CHECK  CHECK (foo < 10)  true
+dupe_generated  check_foo2  CHECK  CHECK (foo > 1)   true
 
 statement ok
 CREATE TABLE test.named_constraints (
@@ -265,16 +265,16 @@ test.public.named_constraints  CREATE TABLE named_constraints (
                                CONSTRAINT ck1 CHECK (length(nickname) < 10)
 )
 
-query TTTTT colnames
+query TTTTB colnames
 SHOW CONSTRAINTS FROM test.named_constraints
 ----
-Table              Name  Type         Column(s)       Details
-named_constraints  bar   UNIQUE       id, name        NULL
-named_constraints  ck1   CHECK        nickname        length(nickname) < 10
-named_constraints  ck2   CHECK        name, nickname  length(nickname) < length(name)
-named_constraints  pk    PRIMARY KEY  id              NULL
-named_constraints  uq    UNIQUE       email           NULL
-named_constraints  uq2   UNIQUE       username        NULL
+table              name  type         details                                  validated
+named_constraints  bar   UNIQUE       UNIQUE (id ASC, name ASC)                true
+named_constraints  ck1   CHECK        CHECK (length(nickname) < 10)            true
+named_constraints  ck2   CHECK        CHECK (length(nickname) < length(name))  true
+named_constraints  pk    PRIMARY KEY  PRIMARY KEY (id ASC)                     true
+named_constraints  uq    UNIQUE       UNIQUE (email ASC)                       true
+named_constraints  uq2   UNIQUE       UNIQUE (username ASC)                    true
 
 statement error duplicate constraint name: "pk"
 CREATE TABLE test.dupe_named_constraints (

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -247,10 +247,22 @@ render            ·     ·
 query TTT
 EXPLAIN SHOW CONSTRAINTS FROM foo
 ----
-sort         ·      ·
- │           order  +"Table",+"Name"
- └── values  ·      ·
-·            size   5 columns, 0 rows
+sort                             ·         ·
+ │                               order     +"table",+name
+ └── render                      ·         ·
+      └── join                   ·         ·
+           │                     type      inner
+           │                     equality  (relnamespace, oid) = (oid, conrelid)
+           ├── filter            ·         ·
+           │    └── values       ·         ·
+           │                     size      27 columns, 91 rows
+           └── join              ·         ·
+                │                type      cross
+                ├── filter       ·         ·
+                │    └── values  ·         ·
+                │                size      4 columns, 4 rows
+                └── values       ·         ·
+·                                size      26 columns, 0 rows
 
 query TTT
 EXPLAIN SHOW USERS

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -248,10 +248,22 @@ render            ·     ·
 query TTT
 EXPLAIN SHOW CONSTRAINTS FROM foo
 ----
-sort         ·      ·
- │           order  +"Table",+"Name"
- └── values  ·      ·
-·            size   5 columns, 0 rows
+sort                             ·         ·
+ │                               order     +"table",+name
+ └── render                      ·         ·
+      └── join                   ·         ·
+           │                     type      inner
+           │                     equality  (relnamespace, oid) = (oid, conrelid)
+           ├── filter            ·         ·
+           │    └── values       ·         ·
+           │                     size      27 columns, 91 rows
+           └── join              ·         ·
+                │                type      cross
+                ├── filter       ·         ·
+                │    └── values  ·         ·
+                │                size      4 columns, 4 rows
+                └── values       ·         ·
+·                                size      26 columns, 0 rows
 
 query TTT
 EXPLAIN SHOW USERS

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -740,7 +740,7 @@ func TestPGPreparedQuery(t *testing.T) {
 			baseTest.Results("crdb_internal").Others(3),
 		},
 		"SHOW CONSTRAINTS FROM system.users": {
-			baseTest.Results("users", "primary", "PRIMARY KEY", "username", gosql.NullString{}),
+			baseTest.Results("users", "primary", "PRIMARY KEY", "PRIMARY KEY (username ASC)", true),
 		},
 		"SHOW TIME ZONE": {
 			baseTest.Results("UTC"),


### PR DESCRIPTION
Requested by @jseldess. cc @bdarnell since this is technically "backward-incompatible" (although the previous code was documented as "in dev" / "experimental").

This also uses the same `showTableDetails` code as many other `SHOW`
statements and thus simplifies the implementation.

Prior to this patch:

```
root@:26257/defaultdb> show constraints from kv;
+-------+------------+---------------------+-----------+---------+
| Table |    Name    |        Type         | Column(s) | Details |
+-------+------------+---------------------+-----------+---------+
| kv    | kv_v_k_key | UNIQUE              | v, k      | NULL    |
| kv    | primary    | PRIMARY KEY         | k         | NULL    |
| kv    | v          | CHECK (UNVALIDATED) | v         | v > 3   |
+-------+------------+---------------------+-----------+---------+
```

Several problems:

- capitals in name mandate quoting
- silly parentheses in the columns column may confuse clients
- hard to connect the information in the columns/details columns to
  the definition of the constraint in CREATE TABLE
- the validation state is not easily queryable.

After this patch:

```
root@:26257/defaultdb> show constraints from kv;
+-------+------------+-------------+-----------------------+-----------+
| table |    name    |    type     |        details        | validated |
+-------+------------+-------------+-----------------------+-----------+
| kv    | kv_v_k_key | UNIQUE      | UNIQUE (v ASC, k ASC) |   true    |
| kv    | primary    | PRIMARY KEY | PRIMARY KEY (k ASC)   |   true    |
| kv    | v          | CHECK       | CHECK (v > 3)         |   false   |
+-------+------------+-------------+-----------------------+-----------+
```

- simple column names
- details column uses same syntax as CREATE TABLE
- validated column is boolean

Release note (backward-incompatible change): The output columns for
the statement `SHOW CONSTRAINTS`, which was previously experimental,
was changed. The new interface will now be considered stable.