### PR TITLE
opt: generalize LookupJoin operation

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -559,7 +559,8 @@ func (b *Builder) buildLookupJoin(ev memo.ExprView) (execPlan, error) {
 	md := ev.Metadata()
 	def := ev.Private().(*memo.LookupJoinDef)
 
-	needed, output := b.getColumns(md, def.Cols, def.Table)
+	cols := ev.Child(0).Logical().Relational.OutputCols.Union(def.LookupCols)
+	needed, output := b.getColumns(md, cols, def.Table)
 	res := execPlan{outputCols: output}
 
 	// Get sort *result column* ordinals. Don't confuse these with *table column*
@@ -567,7 +568,7 @@ func (b *Builder) buildLookupJoin(ev memo.ExprView) (execPlan, error) {
 	// be in the needed set, so no need to add anything further to that.
 	reqOrder := b.makeSQLOrdering(res, ev)
 
-	node, err := b.factory.ConstructLookupJoin(input.root, md.Table(def.Table), needed, reqOrder)
+	node, err := b.factory.ConstructIndexJoin(input.root, md.Table(def.Table), needed, reqOrder)
 	if err != nil {
 		return execPlan{}, err
 	}

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -817,34 +817,40 @@ CREATE TABLE xy (x INT, y INT, INDEX (y))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM NULL
 ----
-index-join  ·      ·             (x, y)              ·
- ├── scan   ·      ·             (y, rowid[hidden])  ·
- │          table  xy@xy_y_idx   ·                   ·
- │          spans  /NULL-/!NULL  ·                   ·
- └── scan   ·      ·             (x, y)              ·
-·           table  xy@primary    ·                   ·
+render           ·         ·             (x, y)                 ·
+ │               render 0  x             ·                      ·
+ │               render 1  y             ·                      ·
+ └── index-join  ·         ·             (x, y, rowid[hidden])  ·
+      ├── scan   ·         ·             (y, rowid[hidden])     ·
+      │          table     xy@xy_y_idx   ·                      ·
+      │          spans     /NULL-/!NULL  ·                      ·
+      └── scan   ·         ·             (x, y, rowid[hidden])  ·
+·                table     xy@primary    ·                      ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM 4
 ----
-index-join  ·      ·            (x, y)              ·
- ├── scan   ·      ·            (y, rowid[hidden])  ·
- │          table  xy@xy_y_idx  ·                   ·
- │          spans  /4-/5        ·                   ·
- └── scan   ·      ·            (x, y)              ·
-·           table  xy@primary   ·                   ·
+render           ·         ·            (x, y)                 ·
+ │               render 0  x            ·                      ·
+ │               render 1  y            ·                      ·
+ └── index-join  ·         ·            (x, y, rowid[hidden])  ·
+      ├── scan   ·         ·            (y, rowid[hidden])     ·
+      │          table     xy@xy_y_idx  ·                      ·
+      │          spans     /4-/5        ·                      ·
+      └── scan   ·         ·            (x, y, rowid[hidden])  ·
+·                table     xy@primary   ·                      ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x FROM xy WHERE y > 0 AND y < 2 ORDER BY y
 ----
-render           ·         ·            (x)                 ·
- │               render 0  x            ·                   ·
- └── index-join  ·         ·            (x, y)              +y
-      ├── scan   ·         ·            (y, rowid[hidden])  +y
-      │          table     xy@xy_y_idx  ·                   ·
-      │          spans     /1-/2        ·                   ·
-      └── scan   ·         ·            (x, y)              ·
-·                table     xy@primary   ·                   ·
+render           ·         ·            (x)                    ·
+ │               render 0  x            ·                      ·
+ └── index-join  ·         ·            (x, y, rowid[hidden])  +y
+      ├── scan   ·         ·            (y, rowid[hidden])     +y
+      │          table     xy@xy_y_idx  ·                      ·
+      │          spans     /1-/2        ·                      ·
+      └── scan   ·         ·            (x, y, rowid[hidden])  ·
+·                table     xy@primary   ·                      ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM NULL
@@ -879,14 +885,17 @@ scan  ·      ·          (x, y)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE (x, y) IN ((NULL, NULL), (1, NULL), (NULL, 1), (1, 1), (1, 2))
 ----
-filter           ·       ·                                                               (x, y)              ·
- │               filter  (x, y) IN ((NULL, NULL), (1, NULL), (NULL, 1), (1, 1), (1, 2))  ·                   ·
- └── index-join  ·       ·                                                               (x, y)              ·
-      ├── scan   ·       ·                                                               (y, rowid[hidden])  ·
-      │          table   xy@xy_y_idx                                                     ·                   ·
-      │          spans   /1-/3                                                           ·                   ·
-      └── scan   ·       ·                                                               (x, y)              ·
-·                table   xy@primary                                                      ·                   ·
+render                ·         ·                                                               (x, y)                 ·
+ │                    render 0  x                                                               ·                      ·
+ │                    render 1  y                                                               ·                      ·
+ └── filter           ·         ·                                                               (x, y, rowid[hidden])  ·
+      │               filter    (x, y) IN ((NULL, NULL), (1, NULL), (NULL, 1), (1, 1), (1, 2))  ·                      ·
+      └── index-join  ·         ·                                                               (x, y, rowid[hidden])  ·
+           ├── scan   ·         ·                                                               (y, rowid[hidden])     ·
+           │          table     xy@xy_y_idx                                                     ·                      ·
+           │          spans     /1-/3                                                           ·                      ·
+           └── scan   ·         ·                                                               (x, y, rowid[hidden])  ·
+·                     table     xy@primary                                                      ·                      ·
 
 # ------------------------------------------------------------------------------
 # Non-covering index
@@ -1236,11 +1245,11 @@ CREATE TABLE t3 (k INT PRIMARY KEY, v INT, w INT, INDEX v(v))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT w FROM t3 WHERE v > 0 AND v < 100 ORDER BY v
 ----
-render           ·         ·           (w)     ·
- │               render 0  w           ·       ·
- └── index-join  ·         ·           (v, w)  +v
-      ├── scan   ·         ·           (k, v)  +v
-      │          table     t3@v        ·       ·
-      │          spans     /1-/100     ·       ·
-      └── scan   ·         ·           (v, w)  ·
-·                table     t3@primary  ·       ·
+render           ·         ·           (w)        ·
+ │               render 0  w           ·          ·
+ └── index-join  ·         ·           (k, v, w)  +v
+      ├── scan   ·         ·           (k, v)     +v
+      │          table     t3@v        ·          ·
+      │          spans     /1-/100     ·          ·
+      └── scan   ·         ·           (k, v, w)  ·
+·                table     t3@primary  ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_hints
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_hints
@@ -130,12 +130,13 @@ index-join  ·      ·
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10
 ----
-index-join  ·      ·
- ├── scan   ·      ·
- │          table  abcd@cd
- │          spans  /10-/11
- └── scan   ·      ·
-·           table  abcd@primary
+render           ·      ·
+ └── index-join  ·      ·
+      ├── scan   ·      ·
+      │          table  abcd@cd
+      │          spans  /10-/11
+      └── scan   ·      ·
+·                table  abcd@primary
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd@{NO_INDEX_JOIN} WHERE c = 10

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -106,8 +106,12 @@ type Factory interface {
 	// each row in the input node.
 	ConstructOrdinality(input Node, colName string) (Node, error)
 
-	// ConstructLookupJoin returns a node that performs a lookup join.
-	ConstructLookupJoin(input Node, table opt.Table, cols ColumnOrdinalSet, reqOrder sqlbase.ColumnOrdering) (Node, error)
+	// ConstructIndexJoin returns a node that performs an index join.
+	// The input must be created by ConstructScan for the same table; cols is the
+	// set of columns produced by the index join.
+	ConstructIndexJoin(
+		input Node, table opt.Table, cols ColumnOrdinalSet, reqOrder sqlbase.ColumnOrdering,
+	) (Node, error)
 
 	// ConstructLimit returns a node that implements LIMIT and/or OFFSET on the
 	// results of the given node. If one or the other is not needed, then it is

--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -342,6 +342,7 @@ func (ev ExprView) formatRelational(f *opt.ExprFmtCtx, tp treeprinter.Node) {
 		def := ev.Private().(*LookupJoinDef)
 		tableID := def.Table
 		tp.Childf("table: %s", ev.Metadata().Table(tableID).TabName())
+		tp.Childf("key columns: %v", def.KeyCols)
 	}
 
 	if !f.HasFlags(opt.ExprFmtHideOuterCols) && !logProps.Relational.OuterCols.Empty() {

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -299,8 +299,9 @@ func (b *logicalPropsBuilder) buildLookupJoinProps(ev ExprView) props.Logical {
 	md := ev.Metadata()
 	def := ev.Private().(*LookupJoinDef)
 
-	// Lookup join output columns are stored in the definition.
-	logical.Relational.OutputCols = def.Cols
+	// Lookup join output columns are the union between the input columns and the
+	// retrieved columns.
+	logical.Relational.OutputCols = inputProps.OutputCols.Union(def.LookupCols)
 
 	// Add not-NULL columns from the table schema, and filter out any not-NULL
 	// columns from the input that are not projected by the lookup join.

--- a/pkg/sql/opt/memo/memo_format.go
+++ b/pkg/sql/opt/memo/memo_format.go
@@ -306,7 +306,8 @@ func (f exprFormatter) formatPrivate(private interface{}, mode formatMode) {
 		fmt.Fprintf(f.buf, " %s", f.mem.metadata.ColumnLabel(t))
 
 	case *LookupJoinDef:
-		fmt.Fprintf(f.buf, " %s,cols=%s", f.mem.metadata.Table(t.Table).TabName(), t.Cols)
+		tn := f.mem.metadata.Table(t.Table).TabName()
+		fmt.Fprintf(f.buf, " %s,keyCols=%v,lookupCols=%s", tn, t.KeyCols, t.LookupCols)
 
 	case *ExplainOpDef:
 		if mode == formatMemo {

--- a/pkg/sql/opt/memo/private_defs.go
+++ b/pkg/sql/opt/memo/private_defs.go
@@ -133,15 +133,40 @@ type GroupByDef struct {
 
 // LookupJoinDef defines the value of the Def private field of the LookupJoin
 // operator.
+//
+// Example 1: join between two tables
+//
+//    CREATE TABLE abc (a INT, b INT, c INT)
+//    CREATE TABLE xyz (x INT, y INT, z INT, PRIMARY KEY (x,y))
+//    SELECT * FROM abc JOIN xyz ON (a=x) AND (b=y)
+//
+//    Input: scan from table abc.
+//    Table: xyz
+//    KeyCols: a, b
+//    LookupCols: z
+//
+// Example 2: index join:
+//
+//    CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX (b))
+//    SELECT * FROM abc WHERE b=1
+//
+//    Input: scan on the index on b (returning columns a, b)
+//    Table: abc
+//    KeyCols: a
+//    LookupCols: c
+//
 type LookupJoinDef struct {
 	// Table identifies the table do to lookups in. The primary index is
 	// currently the only index used.
 	Table opt.TableID
 
-	// Cols is the set of columns the index join outputs. The set of columns
-	// which must be retrieved from the primary index is thus Cols minus the set
-	// of columns provided by the input.
-	Cols opt.ColSet
+	// KeyCols are the columns (produced by the input) used to create lookup keys;
+	// in the same order as the index columns (or a prefix of them).
+	KeyCols opt.ColList
+
+	// LookupCols is the set of columns retrieved from the index. The LookupJoin
+	// operator produces the columns in its input plus these columns.
+	LookupCols opt.ColSet
 }
 
 // ExplainOpDef defines the value of the Def private field of the Explain operator.

--- a/pkg/sql/opt/memo/private_storage.go
+++ b/pkg/sql/opt/memo/private_storage.go
@@ -238,7 +238,11 @@ func (ps *privateStorage) internLookupJoinDef(def *LookupJoinDef) PrivateID {
 	// the value is already in the map. Be careful when modifying.
 	ps.keyBuf.Reset()
 	ps.keyBuf.writeUvarint(uint64(def.Table))
-	ps.keyBuf.writeColSet(def.Cols)
+	ps.keyBuf.writeColList(def.KeyCols)
+	// Add a separator between the list and the set. Note that the column IDs
+	// cannot be 0.
+	ps.keyBuf.writeUvarint(0)
+	ps.keyBuf.writeColSet(def.LookupCols)
 	typ := (*LookupJoinDef)(nil)
 	if id, ok := ps.privatesMap[privateKey{iface: typ, str: ps.keyBuf.String()}]; ok {
 		return id

--- a/pkg/sql/opt/memo/private_storage_test.go
+++ b/pkg/sql/opt/memo/private_storage_test.go
@@ -485,7 +485,7 @@ func BenchmarkPrivateStorage(b *testing.B) {
 	}
 	scanOpDef := &ScanOpDef{Table: 1, Index: 2, Cols: colSet}
 	groupByDef := &GroupByDef{GroupingCols: colSet, Ordering: ordering}
-	indexJoinDef := &LookupJoinDef{Table: 1, Cols: colSet}
+	indexJoinDef := &LookupJoinDef{Table: 1, KeyCols: colList, LookupCols: colSet}
 	setOpColMap := &SetOpColMap{Left: colList, Right: colList, Out: colList}
 	datum := tree.NewDInt(1)
 	typ := types.Int

--- a/pkg/sql/opt/memo/testdata/logprops/lookup-join
+++ b/pkg/sql/opt/memo/testdata/logprops/lookup-join
@@ -37,6 +37,7 @@ select
  ├── lookup-join
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── table: a
+ │    ├── key columns: [1]
  │    ├── stats: [rows=1]
  │    ├── keys: (1) weak(3,4) weak(2,3)
  │    └── scan a@secondary
@@ -64,6 +65,7 @@ project
       ├── lookup-join
       │    ├── columns: x:1(int!null) y:2(int) s:3(string)
       │    ├── table: a
+      │    ├── key columns: [1]
       │    ├── stats: [rows=1]
       │    ├── keys: (1) weak(2,3)
       │    └── scan a@secondary

--- a/pkg/sql/opt/memo/testdata/stats/lookup-join
+++ b/pkg/sql/opt/memo/testdata/stats/lookup-join
@@ -63,6 +63,7 @@ project
       │    ├── lookup-join
       │    │    ├── columns: x:1(int!null) y:2(int) s:3(string)
       │    │    ├── table: a
+      │    │    ├── key columns: [1]
       │    │    ├── stats: [rows=200]
       │    │    ├── keys: (1)
       │    │    └── scan a@secondary

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -126,6 +126,22 @@ func (md *Metadata) IndexColumns(tableID TableID, indexOrdinal int) ColSet {
 	return indexCols
 }
 
+// IndexColumnsList returns the list of columns in the given index. The columns
+// are returned in the same order as they appear in the index.
+// TODO(justin): cache this value in the table metadata.
+func (md *Metadata) IndexColumnsList(tableID TableID, indexOrdinal int) ColList {
+	tab := md.Table(tableID)
+	index := tab.Index(indexOrdinal)
+
+	indexCols := make(ColList, index.ColumnCount())
+	for i := range indexCols {
+		ord := index.Column(i).Ordinal
+		indexCols[i] = md.TableColumn(tableID, ord)
+	}
+
+	return indexCols
+}
+
 // ColumnLabel returns the label of the given column. It is used for pretty-
 // printing and debugging.
 func (md *Metadata) ColumnLabel(id ColumnID) string {

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -246,6 +246,7 @@ GenerateIndexScans (higher cost)
          │    │    ├── columns: k:1(int!null) i:2(int) s:4(string)
   -      │    │    └── keys: (1)
   +      │    │    ├── table: a
+  +      │    │    ├── key columns: [1]
   +      │    │    ├── keys: (1)
   +      │    │    └── scan a@secondary
   +      │    │         ├── columns: k:1(int!null) s:4(string)
@@ -583,6 +584,7 @@ GenerateIndexScans (higher cost)
     │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
   - │    └── keys: (1) weak(3,4)
   + │    ├── table: a
+  + │    ├── key columns: [1]
   + │    ├── keys: (1) weak(3,4)
   + │    └── scan a@secondary
   + │         ├── columns: k:1(int!null) f:3(float) s:4(string) j:5(jsonb)

--- a/pkg/sql/opt/xform/explorer.go
+++ b/pkg/sql/opt/xform/explorer.go
@@ -227,7 +227,7 @@ func (e *explorer) generateIndexScans(def memo.PrivateID) []memo.Expr {
 	md := e.mem.Metadata()
 	tab := md.Table(scanOpDef.Table)
 
-	pkCols := md.IndexColumns(scanOpDef.Table, 0)
+	pkCols := md.IndexColumnsList(scanOpDef.Table, opt.PrimaryIndex)
 
 	// Iterate over all secondary indexes (index 0 is the primary index).
 	for i := 1; i < tab.IndexCount(); i++ {
@@ -243,20 +243,30 @@ func (e *explorer) generateIndexScans(def memo.PrivateID) []memo.Expr {
 			// The alternate index was missing columns, so in order to satisfy the
 			// requirements, we need to perform an index join with the primary index.
 
-			indexScanOpDef := e.mem.InternScanOpDef(&memo.ScanOpDef{
+			// We scan whatever columns we need which are available from the index,
+			// plus the PK columns. The main reason is to allow pushing of filters as
+			// much as possible.
+			scanCols := indexCols.Intersection(scanOpDef.Cols)
+			for _, c := range pkCols {
+				scanCols.Add(int(c))
+			}
+
+			indexScanOpDef := memo.ScanOpDef{
 				Table: scanOpDef.Table,
 				Index: i,
-				Cols:  indexCols.Intersection(scanOpDef.Cols).Union(pkCols),
-			})
+				Cols:  scanCols,
+			}
 
-			input := e.f.ConstructScan(indexScanOpDef)
+			input := e.f.ConstructScan(e.mem.InternScanOpDef(&indexScanOpDef))
 
-			def := e.mem.InternLookupJoinDef(&memo.LookupJoinDef{
-				Table: scanOpDef.Table,
-				Cols:  scanOpDef.Cols,
-			})
+			// We scan whatever needed columns are left from the primary index.
+			def := memo.LookupJoinDef{
+				Table:      scanOpDef.Table,
+				KeyCols:    pkCols,
+				LookupCols: scanOpDef.Cols.Difference(indexScanOpDef.Cols),
+			}
 
-			join := memo.MakeLookupJoinExpr(input, def)
+			join := memo.MakeLookupJoinExpr(input, e.mem.InternLookupJoinDef(&def))
 
 			e.exprs = append(e.exprs, memo.Expr(join))
 		}

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -80,6 +80,7 @@ SELECT * FROM abc WHERE c = 1
 lookup-join
  ├── columns: a:1(int!null) b:2(int) c:3(int!null)
  ├── table: abc
+ ├── key columns: [1]
  ├── stats: [rows=1, distinct(3)=1]
  ├── cost: 5.01
  ├── keys: (1)

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -603,6 +603,7 @@ project
  └── lookup-join
       ├── columns: stock.s_i_id:1(int!null) stock.s_w_id:2(int!null) stock.s_quantity:3(int) stock.s_dist_05:8(string) stock.s_ytd:14(int) stock.s_order_cnt:15(int) stock.s_remote_cnt:16(int) stock.s_data:17(string)
       ├── table: stock
+      ├── key columns: [2 1]
       ├── stats: [rows=333333]
       ├── cost: 250.50
       ├── keys: (1,2)

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -46,7 +46,7 @@ memo
 SELECT s, i, f FROM a ORDER BY s, k, i
 ----
 memo (optimized)
- ├── G1: (scan a,cols=(1-4)) (scan a@s_idx,cols=(1-4)) (lookup-join G2 a,cols=(1-4))
+ ├── G1: (scan a,cols=(1-4)) (scan a@s_idx,cols=(1-4)) (lookup-join G2 a,keyCols=[1],lookupCols=(3))
  │    ├── "[presentation: s:4,i:2,f:3] [ordering: +4,+1,+2]"
  │    │    ├── best: (scan a@s_idx,cols=(1-4))
  │    │    └── cost: 1000.00
@@ -65,7 +65,7 @@ memo
 SELECT s, i, f FROM a ORDER BY f
 ----
 memo (optimized)
- ├── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4)) (lookup-join G2 a,cols=(2-4))
+ ├── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4)) (lookup-join G2 a,keyCols=[1],lookupCols=(3))
  │    ├── "[presentation: s:4,i:2,f:3] [ordering: +3]"
  │    │    ├── best: (sort G1)
  │    │    └── cost: 1099.66
@@ -81,7 +81,7 @@ memo
 SELECT s, i, f FROM a ORDER BY s DESC, i
 ----
 memo (optimized)
- ├── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4)) (lookup-join G2 a,cols=(2-4))
+ ├── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4)) (lookup-join G2 a,keyCols=[1],lookupCols=(3))
  │    ├── "[presentation: s:4,i:2,f:3] [ordering: -4,+2]"
  │    │    ├── best: (sort G1)
  │    │    └── cost: 1099.66
@@ -138,7 +138,7 @@ memo (optimized)
  │    └── ""
  │         ├── best: (project G2 G3)
  │         └── cost: 1000.00
- ├── G2: (scan abc,cols=(4)) (lookup-join G4 abc,cols=(4)) (lookup-join G5 abc,cols=(4))
+ ├── G2: (scan abc,cols=(4)) (lookup-join G4 abc,keyCols=[1 2 3],lookupCols=(4)) (lookup-join G5 abc,keyCols=[1 2 3],lookupCols=(4))
  │    └── ""
  │         ├── best: (scan abc,cols=(4))
  │         └── cost: 1000.00
@@ -162,12 +162,12 @@ memo (optimized)
  │    └── "[presentation: j:5]"
  │         ├── best: (project G2 G3)
  │         └── cost: 1.00
- ├── G2: (select G4 G5) (scan a@si_idx,cols=(4,5),constrained) (lookup-join G6 a,cols=(4,5))
+ ├── G2: (select G4 G5) (scan a@si_idx,cols=(4,5),constrained) (lookup-join G6 a,keyCols=[1],lookupCols=(5))
  │    └── ""
  │         ├── best: (scan a@si_idx,cols=(4,5),constrained)
  │         └── cost: 1.00
  ├── G3: (projections a.j)
- ├── G4: (scan a,cols=(4,5)) (lookup-join G7 a,cols=(4,5)) (scan a@si_idx,cols=(4,5))
+ ├── G4: (scan a,cols=(4,5)) (lookup-join G7 a,keyCols=[1],lookupCols=(5)) (scan a@si_idx,cols=(4,5))
  │    └── ""
  │         ├── best: (scan a,cols=(4,5))
  │         └── cost: 1000.00
@@ -197,7 +197,7 @@ memo
 SELECT s, i, f FROM a ORDER BY k, i, s
 ----
 memo (optimized)
- ├── G1: (scan a,cols=(1-4)) (scan a@s_idx,cols=(1-4)) (lookup-join G2 a,cols=(1-4))
+ ├── G1: (scan a,cols=(1-4)) (scan a@s_idx,cols=(1-4)) (lookup-join G2 a,keyCols=[1],lookupCols=(3))
  │    ├── "[presentation: s:4,i:2,f:3] [ordering: +1,+2,+4]"
  │    │    ├── best: (scan a,cols=(1-4))
  │    │    └── cost: 1000.00
@@ -226,7 +226,7 @@ memo
 SELECT s, j FROM a ORDER BY s
 ----
 memo (optimized)
- ├── G1: (scan a,cols=(4,5)) (lookup-join G2 a,cols=(4,5)) (scan a@si_idx,cols=(4,5))
+ ├── G1: (scan a,cols=(4,5)) (lookup-join G2 a,keyCols=[1],lookupCols=(5)) (scan a@si_idx,cols=(4,5))
  │    ├── "[presentation: s:4,j:5] [ordering: +4]"
  │    │    ├── best: (sort G1)
  │    │    └── cost: 1099.66

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -290,6 +290,7 @@ SELECT * FROM b WHERE v = 1
 lookup-join
  ├── columns: k:1(int!null) u:2(int) v:3(int!null)
  ├── table: b
+ ├── key columns: [1]
  ├── keys: (1) (3)
  └── scan b@v
       ├── columns: k:1(int!null) v:3(int)
@@ -300,11 +301,11 @@ memo
 SELECT * FROM b WHERE v = 1
 ----
 memo (optimized)
- ├── G1: (select G2 G3) (lookup-join G4 b,cols=(1-3))
+ ├── G1: (select G2 G3) (lookup-join G4 b,keyCols=[1],lookupCols=(2))
  │    └── "[presentation: k:1,u:2,v:3]"
- │         ├── best: (lookup-join G4 b,cols=(1-3))
+ │         ├── best: (lookup-join G4 b,keyCols=[1],lookupCols=(2))
  │         └── cost: 5.01
- ├── G2: (scan b) (lookup-join G5 b,cols=(1-3)) (lookup-join G6 b,cols=(1-3))
+ ├── G2: (scan b) (lookup-join G5 b,keyCols=[1],lookupCols=(3)) (lookup-join G6 b,keyCols=[1],lookupCols=(2))
  │    └── ""
  │         ├── best: (scan b)
  │         └── cost: 1000.00
@@ -348,6 +349,7 @@ select
  ├── lookup-join
  │    ├── columns: k:1(int!null) u:2(int) v:3(int)
  │    ├── table: b
+ │    ├── key columns: [1]
  │    ├── keys: (1) weak(3)
  │    └── scan b@v
  │         ├── columns: k:1(int!null) v:3(int)
@@ -364,14 +366,14 @@ memo (optimized)
  │    └── "[presentation: k:1,u:2,v:3]"
  │         ├── best: (select G4 G5)
  │         └── cost: 5.02
- ├── G2: (scan b) (lookup-join G6 b,cols=(1-3)) (lookup-join G7 b,cols=(1-3))
+ ├── G2: (scan b) (lookup-join G6 b,keyCols=[1],lookupCols=(3)) (lookup-join G7 b,keyCols=[1],lookupCols=(2))
  │    └── ""
  │         ├── best: (scan b)
  │         └── cost: 1000.00
  ├── G3: (filters G8 G10)
- ├── G4: (lookup-join G9 b,cols=(1-3))
+ ├── G4: (lookup-join G9 b,keyCols=[1],lookupCols=(2))
  │    └── ""
- │         ├── best: (lookup-join G9 b,cols=(1-3))
+ │         ├── best: (lookup-join G9 b,keyCols=[1],lookupCols=(2))
  │         └── cost: 5.01
  ├── G5: (filters G10)
  ├── G6: (scan b@u,cols=(1,2))

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -349,8 +349,8 @@ func (ef *execFactory) ConstructOrdinality(input exec.Node, colName string) (exe
 	}, nil
 }
 
-// ConstructLookupJoin is part of the exec.Factory interface.
-func (ef *execFactory) ConstructLookupJoin(
+// ConstructIndexJoin is part of the exec.Factory interface.
+func (ef *execFactory) ConstructIndexJoin(
 	input exec.Node, table opt.Table, cols exec.ColumnOrdinalSet, reqOrder sqlbase.ColumnOrdering,
 ) (exec.Node, error) {
 	tabDesc := table.(*optTable).desc


### PR DESCRIPTION
The current LookupJoinOp is capable of expressing an index join, but
not a general join. Adjusting the private definition to identify the
key columns, and making the operator return all columns of the input
along with the looked up columns.

As a consequence, it is no longer possible to directly express an
index join where a PK column is not in the output; these cases now
require a renderNode (it is possible to collapse the renderNode in the
exec factory, but it's probably not worth it).

Release note: None

In a subsequent change I will split LookupJoin into LookupInnerJoin and LookupLeftJoin and add OnExpr.