### PR TITLE
sql: various RSG improvements and new tests

### DIFF
--- a/pkg/internal/rsg/rsg_test.go
+++ b/pkg/internal/rsg/rsg_test.go
@@ -1,0 +1,155 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package rsg
+
+import (
+	"fmt"
+	"testing"
+)
+
+const yaccExample = `
+name:
+  IDENT
+| unreserved_keyword
+| col_name_keyword
+
+unreserved_keyword:
+  ABORT
+| ACTION
+| ADD
+| ADMIN
+
+col_name_keyword:
+  ANNOTATE_TYPE
+| BETWEEN
+| BIGINT
+| BIT
+
+column_name:         name
+
+constraint_name:     name
+
+column_def:
+  column_name typename col_qual_list
+  {
+    tableDef, err := tree.NewColumnTableDef(tree.Name($1), $2.colType(), $3.colQuals())
+    if err != nil {
+      sqllex.Error(err.Error())
+      return 1
+    }
+    $$.val = tableDef
+  }
+
+col_qual_list:
+  col_qual_list col_qualification
+  {
+    $$.val = append($1.colQuals(), $2.colQual())
+  }
+| /* EMPTY */
+  {
+    $$.val = []tree.NamedColumnQualification(nil)
+  }
+
+col_qualification:
+  CONSTRAINT constraint_name col_qualification_elem
+  {
+    $$.val = tree.NamedColumnQualification{Name: tree.Name($2), Qualification: $3.colQualElem()}
+  }
+| col_qualification_elem
+  {
+    $$.val = tree.NamedColumnQualification{Qualification: $1.colQualElem()}
+  }
+
+col_qualification_elem:
+  NOT NULL
+  {
+    $$.val = tree.NotNullConstraint{}
+  }
+| NULL
+  {
+    $$.val = tree.NullConstraint{}
+  }
+| UNIQUE
+  {
+    $$.val = tree.UniqueConstraint{}
+  }
+| PRIMARY KEY
+  {
+    $$.val = tree.PrimaryKeyConstraint{}
+  }
+`
+
+func getRSG(t *testing.T) *RSG {
+	r, err := NewRSG(1, yaccExample, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+func TestGenerate(t *testing.T) {
+	tests := []struct {
+		root        string
+		depth       int
+		repetitions int
+		expected    []string
+	}{
+		{
+			root:        "column_def",
+			depth:       20,
+			repetitions: 10,
+			expected: []string{
+				"BIT typename",
+				"ANNOTATE_TYPE typename CONSTRAINT ADD PRIMARY KEY NULL",
+				"ident typename PRIMARY KEY CONSTRAINT ident NULL",
+				"BETWEEN typename NULL",
+				"ADD typename",
+				"ABORT typename",
+				"ACTION typename",
+				"BIGINT typename",
+				"ident typename",
+				"BETWEEN typename CONSTRAINT ident UNIQUE",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%s-%d-%d", tc.root, tc.depth, tc.repetitions), func(t *testing.T) {
+			r := getRSG(t)
+
+			out := make([]string, tc.repetitions)
+			for i := range out {
+				out[i] = r.Generate(tc.root, tc.depth)
+			}
+
+			// Enable to help with writing tests.
+			if false {
+				for _, o := range out {
+					fmt.Printf("%q,\n", o)
+				}
+				return
+			}
+
+			if len(out) != len(tc.expected) {
+				t.Fatal("unexpected")
+			}
+			for i, o := range out {
+				if o != tc.expected[i] {
+					t.Fatalf("got %q, expected %q", o, tc.expected[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -246,7 +246,7 @@ func BenchmarkFormatRandomStatements(b *testing.B) {
 	if err != nil {
 		b.Fatalf("error reading grammar: %v", err)
 	}
-	r, err := rsg.NewRSG(timeutil.Now().UnixNano(), string(yBytes))
+	r, err := rsg.NewRSG(timeutil.Now().UnixNano(), string(yBytes), false)
 	if err != nil {
 		b.Fatalf("error instantiating RSG: %v", err)
 	}


### PR DESCRIPTION
Allow tests to flag that they allow duplicate values to be produced
instead of guaranteeing uniqueness.

Prevent runaway processes from attempting to generate strings forever
by panicing when a hard coded limit of tries is reached.

Fix a very old bug in generate that prevented empty productions from
being returned. This has already begun finding new kinds of bugs that
were missed before and should allow for more complicated expressions to
be produced now (since they previously were thought to be errors).

Add a simple test framework for internal RSG tests.

Add two new RSG tests: column schema changes and database mutations. Each
has already found bugs.

Release note: None