### PR TITLE
compactor: purge suggestions that have live data

### DIFF
--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -118,6 +118,8 @@ type Iterator interface {
 	MVCCScan(start, end roachpb.Key, max int64, timestamp hlc.Timestamp,
 		txn *roachpb.Transaction, consistent, reverse, tombstone bool,
 	) (kvs []byte, numKvs int64, intents []byte, err error)
+	// SetUpperBound installs a new upper bound for this iterator.
+	SetUpperBound(roachpb.Key)
 
 	Stats() IteratorStats
 }

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1404,6 +1404,10 @@ func (r *batchIterator) MVCCScan(
 	return r.iter.MVCCScan(start, end, max, timestamp, txn, consistent, reverse, tombstones)
 }
 
+func (r *batchIterator) SetUpperBound(key roachpb.Key) {
+	r.iter.SetUpperBound(key)
+}
+
 func (r *batchIterator) Key() MVCCKey {
 	return r.iter.Key()
 }
@@ -2148,6 +2152,10 @@ func (r *rocksDBIterator) MVCCScan(
 	}
 	kvs = copyFromSliceVector(state.data.bufs, state.data.len)
 	return kvs, int64(state.data.count), cSliceToGoBytes(state.intents), nil
+}
+
+func (r *rocksDBIterator) SetUpperBound(key roachpb.Key) {
+	C.DBIterSetUpperBound(r.iter, goToCKey(MakeMVCCMetadataKey(key)))
 }
 
 func copyFromSliceVector(bufs *C.DBSlice, len C.int32_t) []byte {

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -193,6 +193,11 @@ func (s *Iterator) MVCCScan(
 	return s.i.MVCCScan(start, end, max, timestamp, txn, consistent, reverse, tombstones)
 }
 
+// SetUpperBound is part of the engine.Iterator interface.
+func (s *Iterator) SetUpperBound(key roachpb.Key) {
+	s.i.SetUpperBound(key)
+}
+
 type spanSetReader struct {
 	r     engine.Reader
 	spans *SpanSet


### PR DESCRIPTION
While debugging #24029 we discovered that RESTORE generates massive
numbers of suggested compactions as it splits and scatters ranges. As
the cluster rebalances, every removed replica leaves behind a range
deletion tombstone and a suggested compaction over the keys it covered.

Occasionally, the replica chosen for rebalancing will be a member of the
last range of the cluster. This range extends from wherever the restore
has last split the table it's restoring to the very last key. Suppose
we're restoring a table with 10,000 ranges evenly distributed across
primary keys from 1-10,000. If a replica in the last range gets
rebalanced early in the restore—say, after only the first 500 ranges
have been split off—at least one node in the cluster will have a
suggested compaction for a range like the following:

    /Table/51/1/500 - /Max

This creates a huge problem! The restore will eventually create 9500
more ranges in that keyspan, each about 32MiB in size. Some of those
ranges will necessarily rebalance back onto the node with the suggested
compaction. By the time the compaction queue gets around to processing
the suggestion, there might be hundreds of gigabytes within the range.

In our 2TB (replicated) store dump, snapshotted immediately after a
RESTORE, there were two such massive suggested compactions, each of
which took over 1h to complete. This bogs down the compaction queue with
unnecessary work and makes it especially dangerous to initiate a DROP
TABLE (#24029), as the incoming range deletion tombstones will pile up
until the prior compaction finishes, and the cluster grinds to a halt in
the meantime.

The same problem happens whenever any replica is rebalanced away and
back before the compaction queue has a chance to compact away the range
deletion tombstone, though the impact is limited because the keyspan is
smaller.

This commit prevents the compaction queue from getting bogged down with
suggestions based on outdated information. At the time the suggestion is
considered for compaction, the queue checks whether the key span
suggested has any live keys. The sign of even a single key is a good
indicator that something has changed—usually that the replica, or one of
its split children, has been rebalanced back onto the node. The
compaction queue now deletes this suggestion instead of acting on it.

This is a crucial piece of the fix to #24029. The other half, #26449,
involves rate-limiting ClearRange requests.

I suspect this change will have a nice performance boost for RESTORE.
Anecdotally we've noticed that restores slow down over time. I'm willing
to bet its because nonsense suggested compactions start hogging disk
I/O.

Release note: None