### PR TITLE
opt/optbuilder: allow aggregation in order by

### DIFF
--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -319,7 +319,7 @@ func (s *scope) startAggFunc() (aggInScope *scope, aggOutScope *scope) {
 		}
 	}
 
-	panic(unimplementedf("woops the aggregate semantic analysis is incomplete"))
+	panic(fmt.Errorf("aggregate function is not allowed in this context"))
 }
 
 // endAggFunc is called when the builder finishes building an aggregate

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -276,7 +276,7 @@ func (b *Builder) buildSelectClause(
 	outScope = fromScope
 
 	var projectionsScope *scope
-	if b.needsAggregation(sel) {
+	if b.needsAggregation(sel, orderBy) {
 		outScope, projectionsScope = b.buildAggregation(sel, orderBy, fromScope)
 	} else {
 		projectionsScope = fromScope.replace()

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -2628,3 +2628,24 @@ project
       └── aggregations
            └── max [type=decimal]
                 └── variable: column6 [type=decimal]
+
+# Regression test for #26419
+build
+SELECT 123 FROM kv ORDER BY max(v)
+----
+sort
+ ├── columns: "123":5(int!null)
+ ├── ordering: +6
+ └── project
+      ├── columns: "123":5(int!null) column6:6(int)
+      ├── group-by
+      │    ├── columns: column6:6(int)
+      │    ├── project
+      │    │    ├── columns: v:2(int)
+      │    │    └── scan kv
+      │    │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+      │    └── aggregations
+      │         └── max [type=int]
+      │              └── variable: kv.v [type=int]
+      └── projections
+           └── const: 123 [type=int]


### PR DESCRIPTION
This commit fixes the optimizer so that it allows aggregations
in the `ORDER BY` clause, even if there are no aggregates in
the `SELECT` list and there is no `GROUP BY` clause. This change
is made for compatibility with Postgres.

Fixes #26457

Release note: None