### PR TITLE
storage: don't spuriously retry lease proposals

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -7889,6 +7889,75 @@ func TestReplicaBurstPendingCommandsAndRepropose(t *testing.T) {
 	}
 }
 
+// TestReplicaLeaseReproposal verifies that the reproposal logic is aware of the
+// fact that for lease requests, MaxLeaseIndex plays no role.
+func TestReplicaLeaseReproposal(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+
+	var tc testContext
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+	tc.Start(t, stopper)
+	repl := tc.repl
+
+	repDesc, err := repl.GetReplicaDescriptor()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var ba roachpb.BatchRequest
+	ba.Requests = nil
+
+	prevLease, _ := tc.repl.GetLease()
+	lease := prevLease
+	lease.Sequence = 0
+
+	key := roachpb.Key("a")
+
+	for i := 1; i < 10; i++ {
+		inc := incrementArgs(key, 1)
+		if _, pErr := client.SendWrapped(ctx, tc.Sender(), &inc); pErr != nil {
+			t.Fatal(pErr)
+		}
+	}
+
+	ba.Add(&roachpb.RequestLeaseRequest{
+		RequestHeader: roachpb.RequestHeader{Key: key},
+		Lease:         lease,
+		PrevLease:     prevLease,
+	})
+
+	ba.Timestamp = tc.Clock().Now()
+	proposal, pErr := repl.requestToProposal(context.Background(), makeIDKey(), ba, nil, &allSpans)
+	if pErr != nil {
+		t.Fatal(pErr)
+	}
+
+	repl.mu.Lock()
+	defer repl.mu.Unlock()
+	ai := repl.mu.state.LeaseAppliedIndex
+	if ai <= 1 {
+		// Lease index zero is special. If this assertion ever fires, just add some
+		// earlier proposals to the test.
+		t.Fatalf("test requires LeaseAppliedIndex >= 2 at this point, have %d", ai)
+	}
+	// Decrement the MaxLeaseIndex. If refreshProposalsLocked didn't know that
+	// MaxLeaseIndex doesn't matter for lease requests, it might be tempted to
+	// end the proposal early (since it would assume that it couldn't commit).
+	repl.insertProposalLocked(proposal, repDesc, lease)
+	proposal.command.MaxLeaseIndex = ai - 1
+	repl.refreshProposalsLocked(1 /* delta */, reasonTicks)
+	select {
+	case res := <-proposal.doneCh:
+		t.Fatalf("proposal unexpectedly terminated: %+v", res)
+	default:
+		// Happy case. The proposal might have been submitted to Raft again (well,
+		// for the first time in this test actually), but that's fine.
+	}
+}
+
 func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var tc testContext


### PR DESCRIPTION
When the Replica notices that an in-flight proposal has a
`MaxLeaseIndex` not strictly ahead of the `LeaseAppliedIndex`, the proposal
is considered failed (since it won't be able to apply successfully).

The one exception are lease requests, for which `MaxLeaseIndex` is
irrelevant. We weren't taking into account that exception, which resulted
in the following odd sequence of events observed when a range was woken up
from a dormant state:

1. lease gets proposed (at some bogus low `MaxLeaseIndex`) 2. Raft group
goes through elections 3. refreshProposalsLocked deletes the proposal
because it looked failed 4. lease gets proposed again 5. at apply time,
previous lease request has already updated the lease,
so new proposal fails.

In effect, this caused an extra round of consensus.

The test added in this commit prevents regression of this problem. It fails
without the change in `refreshProposalsLocked`.

Release note: None