### PR TITLE
sql: make a copy of the columns in explainNode

### DIFF
--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -91,6 +91,8 @@ func (p *planner) makeExplainPlanNodeWithPlan(
 	if flags.showMetadata {
 		columns = sqlbase.ExplainPlanVerboseColumns
 	}
+	// Make a copy (to allow changes through planMutableColumns).
+	columns = append(sqlbase.ResultColumns(nil), columns...)
 
 	e := explainer{explainFlags: flags}
 


### PR DESCRIPTION
ResultColumns can be changed (via planMutableColumns); make a copy of
the explain columns.

Fixes #26498.

Release note: None