### PR TITLE
roachtest: provide a timeout for tests

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -43,25 +43,15 @@ func registerImportTPCC(r *registry) {
 			c.Run(ctx, c.Node(1), cmd)
 			return nil
 		})
-		// To diagnose #26132.
-		done := make(chan struct{})
-		go func() {
-			m.Wait()
-			close(done)
-		}()
-
-		select {
-		case <-done:
-		case <-time.After(5 * time.Hour):
-			t.Fatal("timed out making fixture")
-		}
+		m.Wait()
 	}
 
 	const warehouses = 1000
 	const numNodes = 4
 	r.Add(testSpec{
-		Name:  fmt.Sprintf("import/tpcc/warehouses=%d/nodes=%d", warehouses, numNodes),
-		Nodes: nodes(numNodes),
+		Name:    fmt.Sprintf("import/tpcc/warehouses=%d/nodes=%d", warehouses, numNodes),
+		Nodes:   nodes(numNodes),
+		Timeout: 5 * time.Hour,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runImportTPCC(ctx, t, c, warehouses)
 		},

--- a/pkg/cmd/roachtest/large_range.go
+++ b/pkg/cmd/roachtest/large_range.go
@@ -38,9 +38,10 @@ func registerLargeRange(r *registry) {
 	const numNodes = 3
 
 	r.Add(testSpec{
-		Name:   fmt.Sprintf("largerange/splits/size=%s,nodes=%d", bytesStr(size), numNodes),
-		Nodes:  nodes(numNodes),
-		Stable: true, // DO NOT COPY to new tests
+		Name:    fmt.Sprintf("largerange/splits/size=%s,nodes=%d", bytesStr(size), numNodes),
+		Nodes:   nodes(numNodes),
+		Timeout: 5 * time.Hour,
+		Stable:  true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runLargeRangeSplits(ctx, t, c, size)
 		},
@@ -96,21 +97,8 @@ range_max_bytes: %d
 		// NB: workload init does not wait for upreplication after creating the
 		// schema but before populating it. This is ok because upreplication
 		// occurs much faster than we can actually create a large range.
-		//
-		// NB: the bespoke timeout mechanism below serves to diagnose #26109.
-		// We don't get the logs if the test fails due to GCE removing the
-		// hardware out from under us.
-		done := make(chan struct{})
-		go func() {
-			c.Run(ctx, c.Node(1), fmt.Sprintf("./workload init bank "+
-				"--rows=%d --payload-bytes=%d --ranges=1 {pgurl:1-%d}", rows, payload, c.nodes))
-			close(done)
-		}()
-		select {
-		case <-done:
-		case <-time.After(5 * time.Hour):
-			t.Fatal("test got stuck while initializing dataset")
-		}
+		c.Run(ctx, c.Node(1), fmt.Sprintf("./workload init bank "+
+			"--rows=%d --payload-bytes=%d --ranges=1 {pgurl:1-%d}", rows, payload, c.nodes))
 
 		t.Status("checking for single range")
 		rangeCount := func() int {

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -59,6 +59,11 @@ func makeFilterRE(filter []string) *regexp.Regexp {
 type testSpec struct {
 	Skip string // if non-empty, test will be skipped
 	Name string
+	// The maximum duration the test is allowed to run before it is considered
+	// failed. If not specified, the default timeout is 10m before the test's
+	// associated cluster expires. The timeout is always truncated to 10m before
+	// the test's cluster expires.
+	Timeout time.Duration
 	// MinVersion indicates the minimum cockroach version that is required for
 	// the test to be run. If MinVersion is less than the version specified
 	// --cockroach-version, Skip will be populated causing the test to be
@@ -172,6 +177,10 @@ func (r *registry) prepareSpec(spec *testSpec, depth int) error {
 
 	if (spec.Run != nil) == (len(spec.SubTests) > 0) {
 		return fmt.Errorf("%s: must specify only one of Run or SubTests", spec.Name)
+	}
+
+	if spec.Run == nil && spec.Timeout > 0 {
+		return fmt.Errorf("%s: timeouts only apply to tests specifying Run", spec.Name)
 	}
 
 	if depth > 0 && len(spec.Nodes) > 0 {
@@ -481,19 +490,27 @@ func (t *test) WorkerProgress(frac float64) {
 }
 
 func (t *test) Fatal(args ...interface{}) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	t.mu.output = append(t.mu.output, t.decorate(fmt.Sprint(args...))...)
-	t.mu.failed = true
+	t.print(args...)
 	runtime.Goexit()
 }
 
 func (t *test) Fatalf(format string, args ...interface{}) {
+	t.printf(format, args...)
+	runtime.Goexit()
+}
+
+func (t *test) print(args ...interface{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.mu.output = append(t.mu.output, t.decorate(fmt.Sprint(args...))...)
+	t.mu.failed = true
+}
+
+func (t *test) printf(format string, args ...interface{}) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.mu.output = append(t.mu.output, t.decorate(fmt.Sprintf(format, args...))...)
 	t.mu.failed = true
-	runtime.Goexit()
 }
 
 func (t *test) decorate(s string) string {
@@ -637,21 +654,27 @@ func (r *registry) run(spec *testSpec, filter *regexp.Regexp, c *cluster, done f
 				}
 
 				if t.Failed() {
+					t.mu.Lock()
+					output := t.mu.output
+					failLoc := t.mu.failLoc
+					t.mu.Unlock()
+
 					if teamCity {
 						fmt.Fprintf(
 							r.out, "##teamcity[testFailed name='%s' details='%s' flowId='%s']\n",
-							t.Name(), teamCityEscape(string(t.mu.output)), t.Name(),
+							t.Name(), teamCityEscape(string(output)), t.Name(),
 						)
 					}
-					fmt.Fprintf(r.out, "--- FAIL: %s %s(%s)\n%s", t.Name(), stability, dstr, t.mu.output)
+
+					fmt.Fprintf(r.out, "--- FAIL: %s %s(%s)\n%s", t.Name(), stability, dstr, output)
 					if issues.CanPost() {
-						authorEmail := getAuthorEmail(t.mu.failLoc.file, t.mu.failLoc.line)
+						authorEmail := getAuthorEmail(failLoc.file, failLoc.line)
 						branch := "<unknown branch>"
 						if b := os.Getenv("TC_BUILD_BRANCH"); b != "" {
 							branch = b
 						}
 						if err := issues.Post(context.Background(), " on "+branch, "roachtest",
-							t.Name(), string(t.mu.output), authorEmail); err != nil {
+							t.Name(), string(output), authorEmail); err != nil {
 							fmt.Fprintf(r.out, "failed to post issue: %s\n", err)
 						}
 					}
@@ -715,12 +738,39 @@ func (r *registry) run(spec *testSpec, filter *regexp.Regexp, c *cluster, done f
 
 		if t.spec.Run != nil {
 			if !dryrun {
+				timeout := time.Hour
 				if c != nil {
 					defer func() {
 						c.FetchLogs(ctx)
 					}()
+
+					timeout = c.expiration.Add(-10 * time.Minute).Sub(timeutil.Now())
 				}
-				t.spec.Run(ctx, t, c)
+
+				if t.spec.Timeout > 0 && timeout > t.spec.Timeout {
+					timeout = t.spec.Timeout
+				}
+				done := make(chan struct{})
+				defer func() {
+					close(done)
+				}()
+
+				runCtx, cancel := context.WithCancel(ctx)
+
+				go func() {
+					defer cancel()
+
+					select {
+					case <-time.After(timeout):
+						t.printf("test timed out (%s)", timeout)
+						if !debug && c != nil && c.destroyed != nil {
+							c.Destroy(ctx)
+						}
+					case <-done:
+					}
+				}()
+
+				t.spec.Run(runCtx, t, c)
 			}
 		} else {
 			for i := range t.spec.SubTests {


### PR DESCRIPTION
Added `testSpec.Timeout` which is the maximum duration the test is
allowd to run before it is considered failed. If not specified, the
default is 10m before the test's associated cluster expires. The timeout
is always truncated to 10m before the test's cluster expires.

Fixes #26230

Release note: None