### PR TITLE
sql: add pg_catalog.pg_seclabel and pg_catalog.pg_shseclabel

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -112,9 +112,11 @@ test      pg_catalog          pg_proc                            public  SELECT
 test      pg_catalog          pg_range                           public  SELECT
 test      pg_catalog          pg_rewrite                         public  SELECT
 test      pg_catalog          pg_roles                           public  SELECT
+test      pg_catalog          pg_seclabel                        public  SELECT
 test      pg_catalog          pg_sequence                        public  SELECT
 test      pg_catalog          pg_settings                        public  SELECT
 test      pg_catalog          pg_shdescription                   public  SELECT
+test      pg_catalog          pg_shseclabel                      public  SELECT
 test      pg_catalog          pg_stat_activity                   public  SELECT
 test      pg_catalog          pg_tables                          public  SELECT
 test      pg_catalog          pg_tablespace                      public  SELECT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -286,9 +286,11 @@ pg_catalog          pg_proc
 pg_catalog          pg_range
 pg_catalog          pg_rewrite
 pg_catalog          pg_roles
+pg_catalog          pg_seclabel
 pg_catalog          pg_sequence
 pg_catalog          pg_settings
 pg_catalog          pg_shdescription
+pg_catalog          pg_shseclabel
 pg_catalog          pg_stat_activity
 pg_catalog          pg_tables
 pg_catalog          pg_tablespace
@@ -407,9 +409,11 @@ pg_proc
 pg_range
 pg_rewrite
 pg_roles
+pg_seclabel
 pg_sequence
 pg_settings
 pg_shdescription
+pg_shseclabel
 pg_stat_activity
 pg_tables
 pg_tablespace
@@ -535,9 +539,11 @@ system         pg_catalog          pg_proc                            SYSTEM VIE
 system         pg_catalog          pg_range                           SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_rewrite                         SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_roles                           SYSTEM VIEW  NO                  1
+system         pg_catalog          pg_seclabel                        SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_sequence                        SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_settings                        SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_shdescription                   SYSTEM VIEW  NO                  1
+system         pg_catalog          pg_shseclabel                      SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_stat_activity                   SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_tables                          SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_tablespace                      SYSTEM VIEW  NO                  1
@@ -970,88 +976,60 @@ testuser  other_db       public              SELECT          NULL
 ## information_schema.table_privileges and information_schema.role_table_grants
 
 # root can see everything
-query TTTTTTTT colnames
-SELECT * FROM system.information_schema.table_privileges ORDER BY table_name, grantee, privilege_type
+query TTTTTTTT colnames rowsort
+SELECT * FROM system.information_schema.table_privileges ORDER BY table_schema, table_name, table_schema, grantee, privilege_type
 ----
 grantor  grantee  table_catalog  table_schema        table_name                         privilege_type  is_grantable  with_hierarchy
-NULL     public   system         information_schema  administrable_role_authorizations  SELECT          NULL          NULL
-NULL     public   system         information_schema  applicable_roles                   SELECT          NULL          NULL
 NULL     public   system         crdb_internal       backward_dependencies              SELECT          NULL          NULL
 NULL     public   system         crdb_internal       builtin_functions                  SELECT          NULL          NULL
 NULL     public   system         crdb_internal       cluster_queries                    SELECT          NULL          NULL
 NULL     public   system         crdb_internal       cluster_sessions                   SELECT          NULL          NULL
 NULL     public   system         crdb_internal       cluster_settings                   SELECT          NULL          NULL
-NULL     public   system         information_schema  column_privileges                  SELECT          NULL          NULL
-NULL     public   system         information_schema  columns                            SELECT          NULL          NULL
-NULL     public   system         information_schema  constraint_column_usage            SELECT          NULL          NULL
 NULL     public   system         crdb_internal       create_statements                  SELECT          NULL          NULL
-NULL     admin    system         public              descriptor                         GRANT           NULL          NULL
-NULL     admin    system         public              descriptor                         SELECT          NULL          NULL
-NULL     root     system         public              descriptor                         GRANT           NULL          NULL
-NULL     root     system         public              descriptor                         SELECT          NULL          NULL
-NULL     public   system         information_schema  enabled_roles                      SELECT          NULL          NULL
-NULL     admin    system         public              eventlog                           DELETE          NULL          NULL
-NULL     admin    system         public              eventlog                           GRANT           NULL          NULL
-NULL     admin    system         public              eventlog                           INSERT          NULL          NULL
-NULL     admin    system         public              eventlog                           SELECT          NULL          NULL
-NULL     admin    system         public              eventlog                           UPDATE          NULL          NULL
-NULL     root     system         public              eventlog                           DELETE          NULL          NULL
-NULL     root     system         public              eventlog                           GRANT           NULL          NULL
-NULL     root     system         public              eventlog                           INSERT          NULL          NULL
-NULL     root     system         public              eventlog                           SELECT          NULL          NULL
-NULL     root     system         public              eventlog                           UPDATE          NULL          NULL
 NULL     public   system         crdb_internal       forward_dependencies               SELECT          NULL          NULL
 NULL     public   system         crdb_internal       gossip_alerts                      SELECT          NULL          NULL
 NULL     public   system         crdb_internal       gossip_liveness                    SELECT          NULL          NULL
 NULL     public   system         crdb_internal       gossip_nodes                       SELECT          NULL          NULL
 NULL     public   system         crdb_internal       index_columns                      SELECT          NULL          NULL
-NULL     admin    system         public              jobs                               DELETE          NULL          NULL
-NULL     admin    system         public              jobs                               GRANT           NULL          NULL
-NULL     admin    system         public              jobs                               INSERT          NULL          NULL
-NULL     admin    system         public              jobs                               SELECT          NULL          NULL
-NULL     admin    system         public              jobs                               UPDATE          NULL          NULL
 NULL     public   system         crdb_internal       jobs                               SELECT          NULL          NULL
-NULL     root     system         public              jobs                               DELETE          NULL          NULL
-NULL     root     system         public              jobs                               GRANT           NULL          NULL
-NULL     root     system         public              jobs                               INSERT          NULL          NULL
-NULL     root     system         public              jobs                               SELECT          NULL          NULL
-NULL     root     system         public              jobs                               UPDATE          NULL          NULL
-NULL     public   system         information_schema  key_column_usage                   SELECT          NULL          NULL
 NULL     public   system         crdb_internal       kv_node_status                     SELECT          NULL          NULL
 NULL     public   system         crdb_internal       kv_store_status                    SELECT          NULL          NULL
-NULL     admin    system         public              lease                              DELETE          NULL          NULL
-NULL     admin    system         public              lease                              GRANT           NULL          NULL
-NULL     admin    system         public              lease                              INSERT          NULL          NULL
-NULL     admin    system         public              lease                              SELECT          NULL          NULL
-NULL     admin    system         public              lease                              UPDATE          NULL          NULL
-NULL     root     system         public              lease                              DELETE          NULL          NULL
-NULL     root     system         public              lease                              GRANT           NULL          NULL
-NULL     root     system         public              lease                              INSERT          NULL          NULL
-NULL     root     system         public              lease                              SELECT          NULL          NULL
-NULL     root     system         public              lease                              UPDATE          NULL          NULL
 NULL     public   system         crdb_internal       leases                             SELECT          NULL          NULL
-NULL     admin    system         public              locations                          DELETE          NULL          NULL
-NULL     admin    system         public              locations                          GRANT           NULL          NULL
-NULL     admin    system         public              locations                          INSERT          NULL          NULL
-NULL     admin    system         public              locations                          SELECT          NULL          NULL
-NULL     admin    system         public              locations                          UPDATE          NULL          NULL
-NULL     root     system         public              locations                          DELETE          NULL          NULL
-NULL     root     system         public              locations                          GRANT           NULL          NULL
-NULL     root     system         public              locations                          INSERT          NULL          NULL
-NULL     root     system         public              locations                          SELECT          NULL          NULL
-NULL     root     system         public              locations                          UPDATE          NULL          NULL
-NULL     admin    system         public              namespace                          GRANT           NULL          NULL
-NULL     admin    system         public              namespace                          SELECT          NULL          NULL
-NULL     root     system         public              namespace                          GRANT           NULL          NULL
-NULL     root     system         public              namespace                          SELECT          NULL          NULL
 NULL     public   system         crdb_internal       node_build_info                    SELECT          NULL          NULL
 NULL     public   system         crdb_internal       node_metrics                       SELECT          NULL          NULL
 NULL     public   system         crdb_internal       node_queries                       SELECT          NULL          NULL
 NULL     public   system         crdb_internal       node_runtime_info                  SELECT          NULL          NULL
 NULL     public   system         crdb_internal       node_sessions                      SELECT          NULL          NULL
 NULL     public   system         crdb_internal       node_statement_statistics          SELECT          NULL          NULL
-NULL     public   system         information_schema  parameters                         SELECT          NULL          NULL
 NULL     public   system         crdb_internal       partitions                         SELECT          NULL          NULL
+NULL     public   system         crdb_internal       ranges                             SELECT          NULL          NULL
+NULL     public   system         crdb_internal       schema_changes                     SELECT          NULL          NULL
+NULL     public   system         crdb_internal       session_trace                      SELECT          NULL          NULL
+NULL     public   system         crdb_internal       session_variables                  SELECT          NULL          NULL
+NULL     public   system         crdb_internal       table_columns                      SELECT          NULL          NULL
+NULL     public   system         crdb_internal       table_indexes                      SELECT          NULL          NULL
+NULL     public   system         crdb_internal       tables                             SELECT          NULL          NULL
+NULL     public   system         crdb_internal       zones                              SELECT          NULL          NULL
+NULL     public   system         information_schema  administrable_role_authorizations  SELECT          NULL          NULL
+NULL     public   system         information_schema  applicable_roles                   SELECT          NULL          NULL
+NULL     public   system         information_schema  column_privileges                  SELECT          NULL          NULL
+NULL     public   system         information_schema  columns                            SELECT          NULL          NULL
+NULL     public   system         information_schema  constraint_column_usage            SELECT          NULL          NULL
+NULL     public   system         information_schema  enabled_roles                      SELECT          NULL          NULL
+NULL     public   system         information_schema  key_column_usage                   SELECT          NULL          NULL
+NULL     public   system         information_schema  parameters                         SELECT          NULL          NULL
+NULL     public   system         information_schema  referential_constraints            SELECT          NULL          NULL
+NULL     public   system         information_schema  role_table_grants                  SELECT          NULL          NULL
+NULL     public   system         information_schema  routines                           SELECT          NULL          NULL
+NULL     public   system         information_schema  schema_privileges                  SELECT          NULL          NULL
+NULL     public   system         information_schema  schemata                           SELECT          NULL          NULL
+NULL     public   system         information_schema  sequences                          SELECT          NULL          NULL
+NULL     public   system         information_schema  statistics                         SELECT          NULL          NULL
+NULL     public   system         information_schema  table_constraints                  SELECT          NULL          NULL
+NULL     public   system         information_schema  table_privileges                   SELECT          NULL          NULL
+NULL     public   system         information_schema  tables                             SELECT          NULL          NULL
+NULL     public   system         information_schema  user_privileges                    SELECT          NULL          NULL
+NULL     public   system         information_schema  views                              SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_am                              SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_attrdef                         SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_attribute                       SELECT          NULL          NULL
@@ -1077,9 +1055,11 @@ NULL     public   system         pg_catalog          pg_proc                    
 NULL     public   system         pg_catalog          pg_range                           SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_rewrite                         SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_roles                           SELECT          NULL          NULL
+NULL     public   system         pg_catalog          pg_seclabel                        SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_sequence                        SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_settings                        SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_shdescription                   SELECT          NULL          NULL
+NULL     public   system         pg_catalog          pg_shseclabel                      SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_stat_activity                   SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_tables                          SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_tablespace                      SELECT          NULL          NULL
@@ -1088,6 +1068,54 @@ NULL     public   system         pg_catalog          pg_type                    
 NULL     public   system         pg_catalog          pg_user                            SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_user_mapping                    SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_views                           SELECT          NULL          NULL
+NULL     admin    system         public              descriptor                         GRANT           NULL          NULL
+NULL     admin    system         public              descriptor                         SELECT          NULL          NULL
+NULL     root     system         public              descriptor                         GRANT           NULL          NULL
+NULL     root     system         public              descriptor                         SELECT          NULL          NULL
+NULL     admin    system         public              eventlog                           DELETE          NULL          NULL
+NULL     admin    system         public              eventlog                           GRANT           NULL          NULL
+NULL     admin    system         public              eventlog                           INSERT          NULL          NULL
+NULL     admin    system         public              eventlog                           SELECT          NULL          NULL
+NULL     admin    system         public              eventlog                           UPDATE          NULL          NULL
+NULL     root     system         public              eventlog                           DELETE          NULL          NULL
+NULL     root     system         public              eventlog                           GRANT           NULL          NULL
+NULL     root     system         public              eventlog                           INSERT          NULL          NULL
+NULL     root     system         public              eventlog                           SELECT          NULL          NULL
+NULL     root     system         public              eventlog                           UPDATE          NULL          NULL
+NULL     admin    system         public              jobs                               DELETE          NULL          NULL
+NULL     admin    system         public              jobs                               GRANT           NULL          NULL
+NULL     admin    system         public              jobs                               INSERT          NULL          NULL
+NULL     admin    system         public              jobs                               SELECT          NULL          NULL
+NULL     admin    system         public              jobs                               UPDATE          NULL          NULL
+NULL     root     system         public              jobs                               DELETE          NULL          NULL
+NULL     root     system         public              jobs                               GRANT           NULL          NULL
+NULL     root     system         public              jobs                               INSERT          NULL          NULL
+NULL     root     system         public              jobs                               SELECT          NULL          NULL
+NULL     root     system         public              jobs                               UPDATE          NULL          NULL
+NULL     admin    system         public              lease                              DELETE          NULL          NULL
+NULL     admin    system         public              lease                              GRANT           NULL          NULL
+NULL     admin    system         public              lease                              INSERT          NULL          NULL
+NULL     admin    system         public              lease                              SELECT          NULL          NULL
+NULL     admin    system         public              lease                              UPDATE          NULL          NULL
+NULL     root     system         public              lease                              DELETE          NULL          NULL
+NULL     root     system         public              lease                              GRANT           NULL          NULL
+NULL     root     system         public              lease                              INSERT          NULL          NULL
+NULL     root     system         public              lease                              SELECT          NULL          NULL
+NULL     root     system         public              lease                              UPDATE          NULL          NULL
+NULL     admin    system         public              locations                          DELETE          NULL          NULL
+NULL     admin    system         public              locations                          GRANT           NULL          NULL
+NULL     admin    system         public              locations                          INSERT          NULL          NULL
+NULL     admin    system         public              locations                          SELECT          NULL          NULL
+NULL     admin    system         public              locations                          UPDATE          NULL          NULL
+NULL     root     system         public              locations                          DELETE          NULL          NULL
+NULL     root     system         public              locations                          GRANT           NULL          NULL
+NULL     root     system         public              locations                          INSERT          NULL          NULL
+NULL     root     system         public              locations                          SELECT          NULL          NULL
+NULL     root     system         public              locations                          UPDATE          NULL          NULL
+NULL     admin    system         public              namespace                          GRANT           NULL          NULL
+NULL     admin    system         public              namespace                          SELECT          NULL          NULL
+NULL     root     system         public              namespace                          GRANT           NULL          NULL
+NULL     root     system         public              namespace                          SELECT          NULL          NULL
 NULL     admin    system         public              rangelog                           DELETE          NULL          NULL
 NULL     admin    system         public              rangelog                           GRANT           NULL          NULL
 NULL     admin    system         public              rangelog                           INSERT          NULL          NULL
@@ -1098,8 +1126,6 @@ NULL     root     system         public              rangelog                   
 NULL     root     system         public              rangelog                           INSERT          NULL          NULL
 NULL     root     system         public              rangelog                           SELECT          NULL          NULL
 NULL     root     system         public              rangelog                           UPDATE          NULL          NULL
-NULL     public   system         crdb_internal       ranges                             SELECT          NULL          NULL
-NULL     public   system         information_schema  referential_constraints            SELECT          NULL          NULL
 NULL     admin    system         public              role_members                       DELETE          NULL          NULL
 NULL     admin    system         public              role_members                       GRANT           NULL          NULL
 NULL     admin    system         public              role_members                       INSERT          NULL          NULL
@@ -1110,14 +1136,6 @@ NULL     root     system         public              role_members               
 NULL     root     system         public              role_members                       INSERT          NULL          NULL
 NULL     root     system         public              role_members                       SELECT          NULL          NULL
 NULL     root     system         public              role_members                       UPDATE          NULL          NULL
-NULL     public   system         information_schema  role_table_grants                  SELECT          NULL          NULL
-NULL     public   system         information_schema  routines                           SELECT          NULL          NULL
-NULL     public   system         crdb_internal       schema_changes                     SELECT          NULL          NULL
-NULL     public   system         information_schema  schema_privileges                  SELECT          NULL          NULL
-NULL     public   system         information_schema  schemata                           SELECT          NULL          NULL
-NULL     public   system         information_schema  sequences                          SELECT          NULL          NULL
-NULL     public   system         crdb_internal       session_trace                      SELECT          NULL          NULL
-NULL     public   system         crdb_internal       session_variables                  SELECT          NULL          NULL
 NULL     admin    system         public              settings                           DELETE          NULL          NULL
 NULL     admin    system         public              settings                           GRANT           NULL          NULL
 NULL     admin    system         public              settings                           INSERT          NULL          NULL
@@ -1128,11 +1146,6 @@ NULL     root     system         public              settings                   
 NULL     root     system         public              settings                           INSERT          NULL          NULL
 NULL     root     system         public              settings                           SELECT          NULL          NULL
 NULL     root     system         public              settings                           UPDATE          NULL          NULL
-NULL     public   system         information_schema  statistics                         SELECT          NULL          NULL
-NULL     public   system         crdb_internal       table_columns                      SELECT          NULL          NULL
-NULL     public   system         information_schema  table_constraints                  SELECT          NULL          NULL
-NULL     public   system         crdb_internal       table_indexes                      SELECT          NULL          NULL
-NULL     public   system         information_schema  table_privileges                   SELECT          NULL          NULL
 NULL     admin    system         public              table_statistics                   DELETE          NULL          NULL
 NULL     admin    system         public              table_statistics                   GRANT           NULL          NULL
 NULL     admin    system         public              table_statistics                   INSERT          NULL          NULL
@@ -1143,8 +1156,6 @@ NULL     root     system         public              table_statistics           
 NULL     root     system         public              table_statistics                   INSERT          NULL          NULL
 NULL     root     system         public              table_statistics                   SELECT          NULL          NULL
 NULL     root     system         public              table_statistics                   UPDATE          NULL          NULL
-NULL     public   system         crdb_internal       tables                             SELECT          NULL          NULL
-NULL     public   system         information_schema  tables                             SELECT          NULL          NULL
 NULL     admin    system         public              ui                                 DELETE          NULL          NULL
 NULL     admin    system         public              ui                                 GRANT           NULL          NULL
 NULL     admin    system         public              ui                                 INSERT          NULL          NULL
@@ -1155,7 +1166,6 @@ NULL     root     system         public              ui                         
 NULL     root     system         public              ui                                 INSERT          NULL          NULL
 NULL     root     system         public              ui                                 SELECT          NULL          NULL
 NULL     root     system         public              ui                                 UPDATE          NULL          NULL
-NULL     public   system         information_schema  user_privileges                    SELECT          NULL          NULL
 NULL     admin    system         public              users                              DELETE          NULL          NULL
 NULL     admin    system         public              users                              GRANT           NULL          NULL
 NULL     admin    system         public              users                              INSERT          NULL          NULL
@@ -1166,7 +1176,6 @@ NULL     root     system         public              users                      
 NULL     root     system         public              users                              INSERT          NULL          NULL
 NULL     root     system         public              users                              SELECT          NULL          NULL
 NULL     root     system         public              users                              UPDATE          NULL          NULL
-NULL     public   system         information_schema  views                              SELECT          NULL          NULL
 NULL     admin    system         public              web_sessions                       DELETE          NULL          NULL
 NULL     admin    system         public              web_sessions                       GRANT           NULL          NULL
 NULL     admin    system         public              web_sessions                       INSERT          NULL          NULL
@@ -1182,7 +1191,6 @@ NULL     admin    system         public              zones                      
 NULL     admin    system         public              zones                              INSERT          NULL          NULL
 NULL     admin    system         public              zones                              SELECT          NULL          NULL
 NULL     admin    system         public              zones                              UPDATE          NULL          NULL
-NULL     public   system         crdb_internal       zones                              SELECT          NULL          NULL
 NULL     root     system         public              zones                              DELETE          NULL          NULL
 NULL     root     system         public              zones                              GRANT           NULL          NULL
 NULL     root     system         public              zones                              INSERT          NULL          NULL
@@ -1268,9 +1276,11 @@ NULL     public   system         pg_catalog          pg_proc                    
 NULL     public   system         pg_catalog          pg_range                           SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_rewrite                         SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_roles                           SELECT          NULL          NULL
+NULL     public   system         pg_catalog          pg_seclabel                        SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_sequence                        SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_settings                        SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_shdescription                   SELECT          NULL          NULL
+NULL     public   system         pg_catalog          pg_shseclabel                      SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_stat_activity                   SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_tables                          SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_tablespace                      SELECT          NULL          NULL

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -39,9 +39,11 @@ pg_proc
 pg_range
 pg_rewrite
 pg_roles
+pg_seclabel
 pg_sequence
 pg_settings
 pg_shdescription
+pg_shseclabel
 pg_stat_activity
 pg_tables
 pg_tablespace
@@ -101,9 +103,11 @@ pg_proc
 pg_range
 pg_rewrite
 pg_roles
+pg_seclabel
 pg_sequence
 pg_settings
 pg_shdescription
+pg_shseclabel
 pg_stat_activity
 pg_tables
 pg_tablespace
@@ -1456,3 +1460,17 @@ SELECT unnest((SELECT proargtypes FROM pg_proc WHERE proname='split_part'));
 #attname   atttypid  typname
 #a         20        int8
 #b         20        int2
+
+subtest pg_catalog.pg_seclabel
+
+query OOOTT colnames
+SELECT objoid, classoid, objsubid, provider, label FROM pg_catalog.pg_seclabel
+----
+objoid  classoid  objsubid  provider  label
+
+subtest pg_catalog.pg_shseclabel
+
+query OOTT colnames
+SELECT objoid, classoid, provider, label FROM pg_catalog.pg_shseclabel
+----
+objoid  classoid  provider  label

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -156,7 +156,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   6 columns, 87 rows
+·                      size   6 columns, 89 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -219,7 +219,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         17 columns, 891 rows
+                     │                     size         17 columns, 900 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·
@@ -233,7 +233,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   8 columns, 560 rows
+·                      size   8 columns, 570 rows
 
 
 query TTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -157,7 +157,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   6 columns, 87 rows
+·                      size   6 columns, 89 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -220,7 +220,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         17 columns, 891 rows
+                     │                     size         17 columns, 900 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·
@@ -234,7 +234,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   8 columns, 560 rows
+·                      size   8 columns, 570 rows
 
 
 query TTT

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -92,6 +92,8 @@ var pgCatalog = virtualSchema{
 		pgCatalogTypeTable,
 		pgCatalogViewsTable,
 		pgCatalogStatActivityTable,
+		pgCatalogSecurityLabelTable,
+		pgCatalogSharedSecurityLabelTable,
 	},
 	// Postgres's catalogs are ill-defined when there is no current
 	// database set. Simply reject any attempts to use them in that
@@ -1932,6 +1934,38 @@ CREATE TABLE pg_catalog.pg_stat_activity (
 	backend_xid INTEGER,
 	backend_xmin INTEGER,
 	query TEXT
+)
+`,
+	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		return nil
+	},
+}
+
+//
+// See https://www.postgresql.org/docs/current/static/catalog-pg-seclabel.html
+var pgCatalogSecurityLabelTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_seclabel (
+	objoid OID,
+	classoid OID,
+	objsubid INTEGER,
+	provider TEXT,
+	label TEXT
+)
+`,
+	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		return nil
+	},
+}
+
+// See https://www.postgresql.org/docs/current/static/catalog-pg-shseclabel.html
+var pgCatalogSharedSecurityLabelTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_shseclabel (
+	objoid OID,
+	classoid OID,
+	provider TEXT,
+	label TEXT
 )
 `,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {


### PR DESCRIPTION
Both of these tables are required for Postgres compatibility, specifically with
PGAdmin.

See https://www.postgresql.org/docs/current/static/catalog-pg-seclabel.html and
https://www.postgresql.org/docs/current/static/catalog-pg-shseclabel.html.

We do not support security labels so both these virtual tables are empty.

Fixes 

Release note (sql change): Added the pg_catalog.pg_seclabel and
pg_catalog.pg_shseclabel tables for compatibility with Postgres tools. Note that
we do not support adding security labels.