### PR TITLE
libroach: don't initialize AESCipher::Decrypt

### DIFF
--- a/c-deps/libroach/ccl/crypto_utils.cc
+++ b/c-deps/libroach/ccl/crypto_utils.cc
@@ -28,16 +28,15 @@ std::string RandomBytes(size_t length) {
   return std::string(reinterpret_cast<const char*>(data.data()), data.size());
 }
 
-AESCipher::~AESCipher() {}
+AESEncryptCipher::~AESEncryptCipher() {}
 
-size_t AESCipher::BlockSize() { return CryptoPP::AES::BLOCKSIZE; }
+size_t AESEncryptCipher::BlockSize() { return CryptoPP::AES::BLOCKSIZE; }
 
-rocksdb::Status AESCipher::Encrypt(char* data) {
+rocksdb::Status AESEncryptCipher::Encrypt(char* data) {
   enc_.ProcessBlock((byte*)data);
   return rocksdb::Status::OK();
 }
 
-rocksdb::Status AESCipher::Decrypt(char* data) {
-  enc_.ProcessBlock((byte*)data);
-  return rocksdb::Status::OK();
+rocksdb::Status AESEncryptCipher::Decrypt(char* data) {
+  return rocksdb::Status::NotSupported("this is an encrypt-only cipher");
 }

--- a/c-deps/libroach/ccl/crypto_utils.h
+++ b/c-deps/libroach/ccl/crypto_utils.h
@@ -26,13 +26,13 @@ std::string HexString(const std::string& s);
 // but to do it properly we might want to pre-read in the background.
 std::string RandomBytes(size_t length);
 
-// AES block cipher using CryptoPP.
-class AESCipher : public rocksdb_utils::BlockCipher {
+// AES block cipher using CryptoPP: encryption only.
+class AESEncryptCipher : public rocksdb_utils::BlockCipher {
  public:
   // The key must have a valid length (16/24/32 bytes) or CryptoPP will fail.
-  AESCipher(std::string key)
-      : enc_((byte*)key.data(), key.size()), dec_((byte*)key.data(), key.size()) {}
-  virtual ~AESCipher();
+  AESEncryptCipher(const std::string& key) : enc_((byte*)key.data(), key.size()) {}
+
+  virtual ~AESEncryptCipher();
 
   // Blocksize is fixed for AES.
   virtual size_t BlockSize() override;
@@ -43,9 +43,9 @@ class AESCipher : public rocksdb_utils::BlockCipher {
 
   // Decrypt a block of data.
   // Length of data is equal to BlockSize().
+  // NOT IMPLEMENTED: this is not needed for CTR mode so remains unimplemented.
   virtual rocksdb::Status Decrypt(char* data) override;
 
  private:
   CryptoPP::AES::Encryption enc_;
-  CryptoPP::AES::Decryption dec_;
 };

--- a/c-deps/libroach/ccl/ctr_stream.cc
+++ b/c-deps/libroach/ccl/ctr_stream.cc
@@ -97,7 +97,7 @@ CTRCipherStream::InitCipher(std::unique_ptr<rocksdb_utils::BlockCipher>* cipher)
         fmt::StringPrintf("unknown encryption type %d", key_->info().encryption_type()));
   }
 
-  cipher->reset(new AESCipher(key_->key()));
+  cipher->reset(new AESEncryptCipher(key_->key()));
   return rocksdb::Status::OK();
 }
 


### PR DESCRIPTION
It's not needed for CTR mode and just causes two AES objects to be
initialized instead of one.

Release note: None