### PR TITLE
ui: move all urls to a single file

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/components/instructionsBox/index.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/components/instructionsBox/index.tsx
@@ -10,7 +10,7 @@ import {
 import { AdminUIState } from "src/redux/state";
 import { nodeStatusesSelector } from "src/redux/nodes";
 import { LocalityTier } from "src/redux/localities";
-import docsURL from "src/util/docs";
+import * as docsURL from "src/util/docs";
 import nodeMapScreenshot from "assets/nodeMapSteps/3-seeMap.png";
 import questionMap from "assets/questionMap.svg";
 import "./instructionsBox.styl";
@@ -21,8 +21,6 @@ interface InstructionsBoxProps {
   expand: () => void;
   collapse: () => void;
 }
-
-export const NODE_MAP_DOCS_URL = docsURL("enable-node-map.html");
 
 class InstructionsBox extends React.Component<InstructionsBoxProps> {
   renderExpanded() {
@@ -36,7 +34,7 @@ class InstructionsBox extends React.Component<InstructionsBoxProps> {
               See your nodes on a map!
             </span>{" "}
             <a
-              href={NODE_MAP_DOCS_URL}
+              href={docsURL.enableNodeMap}
               className="instructions-box-top-bar__setup_link"
             >
               Follow our configuration guide

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/needEnterpriseLicense.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/needEnterpriseLicense.tsx
@@ -7,11 +7,8 @@ import step3Img from "assets/nodeMapSteps/3-seeMap.png";
 import {
   NodeCanvasContainerOwnProps,
 } from "src/views/clusterviz/containers/map/nodeCanvasContainer";
-import { NODE_MAP_DOCS_URL } from "src/views/clusterviz/components/instructionsBox";
+import * as docsURL from "src/util/docs";
 import "./needEnterpriseLicense.styl";
-
-const LICENSE_DOCS_URL = "https://www.cockroachlabs.com/docs/stable/enterprise-licensing.html";
-const TRIAL_LICENSE_URL = "https://www.cockroachlabs.com/pricing/start-trial/";
 
 // This takes the same props as the NodeCanvasContainer which it is swapped out with.
 export default class NeedEnterpriseLicense extends React.Component<NodeCanvasContainerOwnProps> {
@@ -24,23 +21,23 @@ export default class NeedEnterpriseLicense extends React.Component<NodeCanvasCon
             <p className="need-license-blurb__text">
               The Node Map shows the geographical layout of your cluster, along
               with metrics and health indicators. To enable the Node Map,
-              request an <a href={LICENSE_DOCS_URL}>Enterprise trial license</a> and refer to
-              this <a href={NODE_MAP_DOCS_URL}>configuration guide</a>.
+              request an <a href={docsURL.enterpriseLicensing}>Enterprise trial license</a> and refer to
+              this <a href={docsURL.enableNodeMap}>configuration guide</a>.
             </p>
           </div>
-          <a href={TRIAL_LICENSE_URL} className="need-license-blurb__trial-link">
+          <a href={docsURL.startTrial} className="need-license-blurb__trial-link">
             GET A 30-DAY ENTERPRISE TRIAL
           </a>
         </div>
         <div className="need-license-steps">
           <Step num={1} img={step1Img}>
-            <a href={TRIAL_LICENSE_URL}>Get a trial license</a> delivered straight to your inbox.
+            <a href={docsURL.startTrial}>Get a trial license</a> delivered straight to your inbox.
           </Step>
           <Step num={2} img={step2Img}>
             Activate the trial license with two simple SQL commands.
           </Step>
           <Step num={3} img={step3Img}>
-            Refer this <a href={NODE_MAP_DOCS_URL}>configuration guide</a> to configure the Node Map.
+            Refer this <a href={docsURL.enableNodeMap}>configuration guide</a> to configure the Node Map.
           </Step>
         </div>
       </section>

--- a/pkg/ui/src/redux/alerts.ts
+++ b/pkg/ui/src/redux/alerts.ts
@@ -18,6 +18,7 @@ import {
 import { refreshCluster, refreshNodes, refreshVersion, refreshHealth } from "./apiReducers";
 import { nodeStatusesSelector, livenessByNodeIDSelector } from "./nodes";
 import { AdminUIState } from "./state";
+import * as docsURL from "src/util/docs";
 
 export enum AlertLevel {
   NOTIFICATION,
@@ -201,10 +202,7 @@ export const newVersionNotificationSelector = createSelector(
       level: AlertLevel.NOTIFICATION,
       title: "New Version Available",
       text: "A new version of CockroachDB is available.",
-      // Note that this explicitly does not use util/docs to create the link,
-      // since we want to link to the updated version, not the version currently
-      // running on the cluster.
-      link: "https://www.cockroachlabs.com/docs/stable/upgrade-cockroach-version.html",
+      link: docsURL.upgradeCockroachVersion,
       dismiss: (dispatch) => {
         const dismissedAt = moment();
         // Dismiss locally.

--- a/pkg/ui/src/util/docs.ts
+++ b/pkg/ui/src/util/docs.ts
@@ -3,6 +3,20 @@ import { getDataFromServer } from "src/util/dataFromServer";
 const version = getDataFromServer().Version || "stable";
 const docsURLBase = "https://www.cockroachlabs.com/docs/" + version;
 
-export default function docsURL(pageName: string): string {
+function docsURL(pageName: string): string {
   return `${docsURLBase}/${pageName}`;
 }
+
+export const adminUIOverview = docsURL("admin-ui-overview.html");
+export const startFlags = docsURL("start-a-node.html#flags");
+export const pauseJob = docsURL("pause-job.html");
+export const cancelJob = docsURL("cancel-job.html");
+export const enableNodeMap = docsURL("enable-node-map.html");
+
+// Note that these explicitly don't use the current version, since we want to
+// link to the most up-to-date documentation available.
+export const upgradeCockroachVersion = "https://www.cockroachlabs.com/docs/stable/upgrade-cockroach-version.html";
+export const enterpriseLicensing = "https://www.cockroachlabs.com/docs/stable/enterprise-licensing.html";
+
+// Not actually a docs URL.
+export const startTrial = "https://www.cockroachlabs.com/pricing/start-trial/";

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import _ from "lodash";
 
-import docsURL from "src/util/docs";
+import * as docsURL from "src/util/docs";
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
@@ -90,10 +90,7 @@ export default function (props: GraphDashboardProps) {
                 Control this value per node with the
                 {" "}
                 <code>
-                  <a
-                    href={docsURL("start-a-node.html#flags")}
-                    target="_blank"
-                  >
+                  <a href={docsURL.startFlags} target="_blank">
                     --store
                   </a>
                 </code>

--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -10,7 +10,7 @@ import { jobsKey, refreshJobs } from "src/redux/apiReducers";
 import { LocalSetting } from "src/redux/localsettings";
 import { AdminUIState } from "src/redux/state";
 import { TimestampToMoment } from "src/util/convert";
-import docsURL from "src/util/docs";
+import * as docsURL from "src/util/docs";
 import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
 import { ExpandableString } from "src/views/shared/components/expandableString";
 import Loading from "src/views/shared/components/loading";
@@ -165,8 +165,8 @@ interface JobsTableProps {
 const titleTooltip = (
   <span>
     Some jobs can be paused or canceled through SQL. For details, view the docs
-    on the <a href={docsURL("pause-job.html")}><code>PAUSE JOB</code></a> and <a
-    href={docsURL("cancel-job.html")}><code>CANCEL JOB</code></a> statements.
+    on the <a href={docsURL.pauseJob}><code>PAUSE JOB</code></a> and <a
+    href={docsURL.cancelJob}><code>CANCEL JOB</code></a> statements.
   </span>
 );
 

--- a/pkg/ui/src/views/login/loginPage.tsx
+++ b/pkg/ui/src/views/login/loginPage.tsx
@@ -7,7 +7,7 @@ import { withRouter, WithRouterProps } from "react-router";
 import { doLogin, LoginAPIState } from "src/redux/login";
 import { AdminUIState } from "src/redux/state";
 import { getDataFromServer } from "src/util/dataFromServer";
-import docsURL from "src/util/docs";
+import * as docsURL from "src/util/docs";
 import { trustIcon } from "src/util/trust";
 
 import logo from "assets/crdb.png";
@@ -100,7 +100,7 @@ class LoginPage extends React.Component<LoginPageProps & WithRouterProps, LoginP
               account access and password restoration.
             </p>
             <p className="aside">
-              <a href={docsURL("admin-ui-overview.html")} className="docs-link">
+              <a href={docsURL.adminUIOverview} className="docs-link">
                 <span className="docs-link__icon" dangerouslySetInnerHTML={trustIcon(docsIcon)} />
                 <span className="docs-link__text">Read the documentation</span>
               </a>


### PR DESCRIPTION
This makes it much easier to see which URLs we're baking into the product, to
validate that all of them are guaranteed to be stable.

Release note: None