### PR TITLE
storage/engine: add BenchmarkRocksDBDeleteRangeIterate

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -960,7 +960,24 @@ func runDebugSSTables(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("%s", db.GetSSTables())
+	sstables := db.GetSSTables()
+	fmt.Printf("%s", sstables)
+
+	sort.Slice(sstables, func(i, j int) bool {
+		a, b := sstables[i], sstables[j]
+		if a.Level < b.Level {
+			return true
+		}
+		if a.Level > b.Level {
+			return false
+		}
+		return a.Start.Less(b.Start)
+	})
+	fmt.Printf("\n")
+	for i := range sstables {
+		fmt.Printf("%d: %s - %s\n",
+			sstables[i].Level, sstables[i].Start.Key, sstables[i].End.Key)
+	}
 	return nil
 }
 

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -18,6 +18,8 @@ package main
 import (
 	"context"
 	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 func registerClearRange(r *registry) {
@@ -79,7 +81,7 @@ func registerClearRange(r *registry) {
 				// above didn't brick the cluster.
 				//
 				// Don't lower this number, or the test may pass erroneously.
-				const minutes = 20
+				const minutes = 60
 				t.WorkerStatus("repeatedly running COUNT(*) on small table")
 				for i := 0; i < minutes; i++ {
 					after := time.After(time.Minute)
@@ -90,10 +92,11 @@ func registerClearRange(r *registry) {
 						return err
 					}
 					// If we can't aggregate over 80kb in 10s, the database is far from usable.
+					start := timeutil.Now()
 					if err := conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM tinybank.bank`).Scan(&count); err != nil {
 						return err
 					}
-					c.l.printf("read %d rows\n", count)
+					c.l.printf("read %d rows in %0.1fs\n", count, timeutil.Since(start).Seconds())
 					t.WorkerProgress(float64(i+1) / float64(minutes))
 					select {
 					case <-after:

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -34,8 +34,8 @@ func registerClearRange(r *registry) {
 			// Created via:
 			// roachtest --cockroach cockroach-v2.0.1 store-gen --stores=10 bank \
 			//           --payload-bytes=10240 --ranges=0 --rows=65104166
-			fixtureURL := `gs://cockroach-fixtures/workload/bank/version=1.0.0,payload-bytes=10240,ranges=0,rows=65104166,seed=1`
-			location := storeDirURL(fixtureURL, c.nodes, "2.0")
+			fixtureURL := `gs://cockroach-fixtures/workload/bank/version=1.0.0,payload-bytes=10240,ranges=0,rows=65104166,seed=2`
+			location := storeDirURL(fixtureURL, c.nodes, "2.0-6")
 
 			// Download this store dump, which measures around 2TB (across all nodes).
 			if err := downloadStoreDumps(ctx, c, location, c.nodes); err != nil {
@@ -43,7 +43,7 @@ func registerClearRange(r *registry) {
 			}
 
 			c.Put(ctx, cockroach, "./cockroach")
-			c.Start(ctx)
+			c.Start(ctx, startArgs("--args=--vmodule=rocksdb=3"))
 
 			// Also restore a much smaller table. We'll use it to run queries against
 			// the cluster after having dropped the large table above, verifying that

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -330,6 +330,85 @@ func DropTableDesc(
 	})
 }
 
+// truncateTable deletes all of the data in the specified table.
+func (sc *SchemaChanger) truncateTable(
+	ctx context.Context,
+	lease *sqlbase.TableDescriptor_SchemaChangeLease,
+	table *sqlbase.TableDescriptor,
+	evalCtx *extendedEvalContext,
+) error {
+	// If DropTime isn't set, assume this drop request is from a version
+	// 1.1 server and invoke legacy code that uses DeleteRange and range GC.
+	if table.DropTime == 0 {
+		return truncateTableInChunks(ctx, table, sc.db, false /* traceKV */)
+	}
+
+	tableKey := roachpb.RKey(keys.MakeTablePrefix(uint32(table.ID)))
+	tableSpan := roachpb.RSpan{Key: tableKey, EndKey: tableKey.PrefixEnd()}
+
+	// ClearRange requests lays down RocksDB range deletion tombstones that have
+	// serious performance implications (#24029). It is crucial that a single
+	// store never has more than a few dozen tombstones. The logic below attempts
+	// to bound the number of tombstones in one store by sending the ClearRange
+	// requests to each range in the table in small, sequential batches, rather
+	// than letting DistSender send them all in parallel, to hopefully give the
+	// compaction queue time to compact the range tombstones away in between
+	// requests.
+	//
+	// As written, this approach has several deficiencies. It does not actually
+	// wait for the compaction queue to compact the tombstones away before sending
+	// the next request. It is likely insufficient if multiple DROP TABLEs are in
+	// flight at once. It does not save its progress in case the coordinator goes
+	// down. These deficiences could be addressed, but this code is only a
+	// stopgap: we expect that RocksDB tombstones can be made cheap enough that we
+	// won't need to rate limit ClearRange commands in the near future.
+
+	// A batch size of 50 allows a 2TB table (after replication) to DROP
+	// successfully in 90 minutes on a 10 node cluster without causing a major
+	// performance hit. It could certainly use more tuning.
+	const batchSize = 50
+
+	var n int
+	lastKey := tableSpan.Key
+	ri := kv.NewRangeIterator(sc.execCfg.DistSender)
+	for ri.Seek(ctx, tableSpan.Key, kv.Ascending); ; ri.Next(ctx) {
+		if !ri.Valid() {
+			return ri.Error().GoError()
+		}
+
+		// This call is a no-op unless the lease is nearly expired.
+		if err := sc.ExtendLease(ctx, lease); err != nil {
+			return err
+		}
+
+		if n++; n >= batchSize || !ri.NeedAnother(tableSpan) {
+			endKey := ri.Desc().EndKey
+			if tableSpan.EndKey.Less(endKey) {
+				endKey = tableSpan.EndKey
+			}
+			var b client.Batch
+			b.AddRawRequest(&roachpb.ClearRangeRequest{
+				RequestHeader: roachpb.RequestHeader{
+					Key:    lastKey.AsRawKey(),
+					EndKey: endKey.AsRawKey(),
+				},
+			})
+			log.VEventf(ctx, 2, "ClearRange %s - %s", lastKey, endKey)
+			if err := sc.db.Run(ctx, &b); err != nil {
+				return err
+			}
+			n = 0
+			lastKey = endKey
+		}
+
+		if !ri.NeedAnother(tableSpan) {
+			break
+		}
+	}
+
+	return nil
+}
+
 // maybe Add/Drop a table depending on the state of a table descriptor.
 // This method returns true if the table is deleted.
 func (sc *SchemaChanger) maybeAddDrop(
@@ -337,6 +416,7 @@ func (sc *SchemaChanger) maybeAddDrop(
 	inSession bool,
 	lease *sqlbase.TableDescriptor_SchemaChangeLease,
 	table *sqlbase.TableDescriptor,
+	evalCtx *extendedEvalContext,
 ) (bool, error) {
 	if table.Dropped() {
 		if err := sc.ExtendLease(ctx, lease); err != nil {
@@ -371,7 +451,7 @@ func (sc *SchemaChanger) maybeAddDrop(
 			}
 		}
 		// Do all the hard work of deleting the table data and the table ID.
-		if err := truncateTableInChunks(ctx, table, sc.db, false /* traceKV */); err != nil {
+		if err := sc.truncateTable(ctx, lease, table, evalCtx); err != nil {
 			return false, err
 		}
 
@@ -501,7 +581,7 @@ func (sc *SchemaChanger) exec(
 		}
 	}
 
-	if drop, err := sc.maybeAddDrop(ctx, inSession, &lease, tableDesc); err != nil {
+	if drop, err := sc.maybeAddDrop(ctx, inSession, &lease, tableDesc, evalCtx); err != nil {
 		return err
 	} else if drop {
 		needRelease = false

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -366,7 +366,7 @@ func (sc *SchemaChanger) truncateTable(
 	// A batch size of 50 allows a 2TB table (after replication) to DROP
 	// successfully in 90 minutes on a 10 node cluster without causing a major
 	// performance hit. It could certainly use more tuning.
-	const batchSize = 50
+	const batchSize = 20
 
 	var n int
 	lastKey := tableSpan.Key
@@ -393,12 +393,13 @@ func (sc *SchemaChanger) truncateTable(
 					EndKey: endKey.AsRawKey(),
 				},
 			})
-			log.VEventf(ctx, 2, "ClearRange %s - %s", lastKey, endKey)
+			log.Infof(ctx, "ClearRange %s - %s", lastKey, endKey)
 			if err := sc.db.Run(ctx, &b); err != nil {
 				return err
 			}
 			n = 0
 			lastKey = endKey
+			time.Sleep(time.Second)
 		}
 
 		if !ri.NeedAnother(tableSpan) {

--- a/pkg/storage/compactor/compactor.go
+++ b/pkg/storage/compactor/compactor.go
@@ -204,27 +204,8 @@ func (c *Compactor) processSuggestions(ctx context.Context) (bool, error) {
 	ctx, cleanup := tracing.EnsureContext(ctx, c.st.Tracer, "process suggested compactions")
 	defer cleanup()
 
-	// Collect all suggestions.
-	var suggestions []storagebase.SuggestedCompaction
-	var totalBytes int64
-	if err := c.eng.Iterate(
-		engine.MVCCKey{Key: keys.LocalStoreSuggestedCompactionsMin},
-		engine.MVCCKey{Key: keys.LocalStoreSuggestedCompactionsMax},
-		func(kv engine.MVCCKeyValue) (bool, error) {
-			var sc storagebase.SuggestedCompaction
-			var err error
-			sc.StartKey, sc.EndKey, err = keys.DecodeStoreSuggestedCompactionKey(kv.Key.Key)
-			if err != nil {
-				return false, errors.Wrapf(err, "failed to decode suggested compaction key")
-			}
-			if err := protoutil.Unmarshal(kv.Value, &sc.Compaction); err != nil {
-				return false, err
-			}
-			suggestions = append(suggestions, sc)
-			totalBytes += sc.Bytes
-			return false, nil // continue iteration
-		},
-	); err != nil {
+	suggestions, totalBytes, err := c.fetchSuggestions(ctx)
+	if err != nil {
 		return false, err
 	}
 
@@ -299,6 +280,66 @@ func (c *Compactor) processSuggestions(ctx context.Context) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// fetchSuggestions loads the persisted suggested compactions from the store.
+func (c *Compactor) fetchSuggestions(
+	ctx context.Context,
+) (suggestions []storagebase.SuggestedCompaction, totalBytes int64, err error) {
+	dataIter := c.eng.NewIterator(engine.IterOptions{})
+	defer dataIter.Close()
+
+	delBatch := c.eng.NewBatch()
+	defer delBatch.Close()
+
+	err = c.eng.Iterate(
+		engine.MVCCKey{Key: keys.LocalStoreSuggestedCompactionsMin},
+		engine.MVCCKey{Key: keys.LocalStoreSuggestedCompactionsMax},
+		func(kv engine.MVCCKeyValue) (bool, error) {
+			var sc storagebase.SuggestedCompaction
+			var err error
+			sc.StartKey, sc.EndKey, err = keys.DecodeStoreSuggestedCompactionKey(kv.Key.Key)
+			if err != nil {
+				return false, errors.Wrapf(err, "failed to decode suggested compaction key")
+			}
+			if err := protoutil.Unmarshal(kv.Value, &sc.Compaction); err != nil {
+				return false, err
+			}
+
+			dataIter.Seek(engine.MakeMVCCMetadataKey(sc.StartKey))
+			if ok, err := dataIter.Valid(); err != nil {
+				return false, err
+			} else if ok && dataIter.UnsafeKey().Less(engine.MakeMVCCMetadataKey(sc.EndKey)) {
+				// The suggested compaction span has live keys remaining. This is a
+				// strong indicator that compacting this range will be significantly
+				// more expensive than we expected when the compaction was suggested, as
+				// compactions are only suggested when a ClearRange request has removed
+				// all the keys in the span. Perhaps a replica was rebalanced away then
+				// back?
+				//
+				// Since we can't guarantee that this compaction will be an easy win,
+				// purge it to avoid bogging down the compaction queue.
+				log.Infof(ctx, "purging suggested compaction for range %s - %s that contains live data",
+					sc.StartKey, sc.EndKey)
+				if err := delBatch.Clear(kv.Key); err != nil {
+					log.Fatal(ctx, err) // should never happen on a batch
+				}
+				c.Metrics.BytesSkipped.Inc(sc.Bytes)
+			} else {
+				suggestions = append(suggestions, sc)
+				totalBytes += sc.Bytes
+			}
+
+			return false, nil // continue iteration
+		},
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+	if err := delBatch.Commit(true); err != nil {
+		log.Warningf(ctx, "unable to delete suggested compaction records: %s", err)
+	}
+	return suggestions, totalBytes, nil
 }
 
 // processCompaction sends CompactRange requests to the storage engine if the

--- a/pkg/storage/compactor/compactor_test.go
+++ b/pkg/storage/compactor/compactor_test.go
@@ -66,6 +66,7 @@ func (we *wrappedEngine) GetSSTables() engine.SSTableInfos {
 		{Level: 2, Size: 100, Start: key("k"), End: key("o")},
 		{Level: 2, Size: 100, Start: key("r"), End: key("t")},
 		// Level 6.
+		{Level: 6, Size: 200, Start: key("0"), End: key("9")},
 		{Level: 6, Size: 201, Start: key("a"), End: key("c")},
 		{Level: 6, Size: 200, Start: key("d"), End: key("f")},
 		{Level: 6, Size: 300, Start: key("h"), End: key("r")},
@@ -160,6 +161,27 @@ func TestCompactorThresholds(t *testing.T) {
 			expBytesCompacted: thresholdBytes.Default(),
 			expCompactions: []roachpb.Span{
 				{Key: key("a"), EndKey: key("b")},
+			},
+		},
+		// Single suggestion which is over absolute bytes threshold should not
+		// trigger a compaction if the span contains keys.
+		{
+			name: "outdated single suggestion over absolute threshold",
+			suggestions: []storagebase.SuggestedCompaction{
+				{
+					StartKey: key("0"), EndKey: key("9"),
+					Compaction: storagebase.Compaction{
+						Bytes:            thresholdBytes.Default(),
+						SuggestedAtNanos: nowNanos,
+					},
+				},
+			},
+			logicalBytes:      thresholdBytes.Default() * 100, // not going to trigger fractional threshold
+			availableBytes:    thresholdBytes.Default() * 100, // not going to trigger fractional threshold
+			expBytesCompacted: 0,
+			expCompactions:    nil,
+			expUncompacted: []roachpb.Span{
+				{Key: key("0"), EndKey: key("9")},
 			},
 		},
 		// Single suggestion over the fractional threshold.
@@ -331,6 +353,40 @@ func TestCompactorThresholds(t *testing.T) {
 				{Key: key("a"), EndKey: key("f")},
 			},
 		},
+		// Double suggestion with non-excessive gap, but there are live keys in the
+		// gap.
+		//
+		// NOTE: when a suggestion itself contains live keys, we skip the compaction
+		// because amounts of data may have been added to the span since the
+		// compaction was proposed. When only the gap contains live keys, however,
+		// it's still desirable to compact: the individual suggestions are empty, so
+		// we can assume there's lots of data to reclaim by compacting, and the
+		// aggregator is very careful not to jump gaps that span too many SSTs.
+		{
+			name: "double suggestion over gap with live keys",
+			suggestions: []storagebase.SuggestedCompaction{
+				{
+					StartKey: key("0"), EndKey: key("4"),
+					Compaction: storagebase.Compaction{
+						Bytes:            thresholdBytes.Default(),
+						SuggestedAtNanos: nowNanos,
+					},
+				},
+				{
+					StartKey: key("6"), EndKey: key("9"),
+					Compaction: storagebase.Compaction{
+						Bytes:            thresholdBytes.Default(),
+						SuggestedAtNanos: nowNanos,
+					},
+				},
+			},
+			logicalBytes:      thresholdBytes.Default() * 100, // not going to trigger fractional threshold
+			availableBytes:    thresholdBytes.Default() * 100, // not going to trigger fractional threshold
+			expBytesCompacted: thresholdBytes.Default() * 2,
+			expCompactions: []roachpb.Span{
+				{Key: key("0"), EndKey: key("9")},
+			},
+		},
 		// Double suggestion with excessive gap.
 		{
 			name: "double suggestion with excessive gap",
@@ -472,6 +528,12 @@ func TestCompactorThresholds(t *testing.T) {
 			defer cleanup()
 			// Shorten wait times for compactor processing.
 			minInterval.Override(&compactor.st.SV, time.Millisecond)
+
+			// Add a key so we can test that suggestions that span live data are
+			// ignored.
+			if err := we.Put(engine.MakeMVCCMetadataKey(key("5")), nil); err != nil {
+				t.Fatal(err)
+			}
 
 			for _, sc := range test.suggestions {
 				compactor.Suggest(context.Background(), sc)

--- a/pkg/storage/compactor/settings.go
+++ b/pkg/storage/compactor/settings.go
@@ -53,7 +53,7 @@ var enabled = settings.RegisterBoolSetting(
 var minInterval = settings.RegisterDurationSetting(
 	"compactor.min_interval",
 	"minimum time interval to wait before compacting",
-	2*time.Minute,
+	15*time.Second,
 )
 
 // thresholdBytes is the threshold in bytes of suggested

--- a/pkg/storage/compactor/settings.go
+++ b/pkg/storage/compactor/settings.go
@@ -53,7 +53,7 @@ var enabled = settings.RegisterBoolSetting(
 var minInterval = settings.RegisterDurationSetting(
 	"compactor.min_interval",
 	"minimum time interval to wait before compacting",
-	15*time.Second,
+	1*time.Second,
 )
 
 // thresholdBytes is the threshold in bytes of suggested

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2413,7 +2413,33 @@ func dbClear(rdb *C.DBEngine, key MVCCKey) error {
 }
 
 func dbClearRange(rdb *C.DBEngine, start, end MVCCKey) error {
-	return statusToError(C.DBDeleteRange(rdb, goToCKey(start), goToCKey(end)))
+	if err := statusToError(C.DBDeleteRange(rdb, goToCKey(start), goToCKey(end))); err != nil {
+		return err
+	}
+	// This is a serious hack. RocksDB generates sstables which cover an
+	// excessively large amount of the key space when range tombstones are
+	// present. The crux of the problem is that the logic for determining sstable
+	// boundaries depends on actual keys being present. So we help that logic
+	// along by adding deletions of the first key covered by the range tombstone,
+	// and a key near the end of the range (previous is difficult). See
+	// TestRocksDBDeleteRangeCompaction which verifies that either this hack is
+	// working, or the upstream problem was fixed in RocksDB.
+	if err := dbClear(rdb, start); err != nil {
+		return err
+	}
+	prev := make(roachpb.Key, len(end.Key))
+	copy(prev, end.Key)
+	if n := len(prev) - 1; prev[n] > 0 {
+		prev[n]--
+	} else {
+		prev = prev[:n]
+	}
+	if start.Key.Compare(prev) < 0 {
+		if err := dbClear(rdb, MVCCKey{Key: prev}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func dbClearIterRange(rdb *C.DBEngine, iter Iterator, start, end MVCCKey) error {

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -1113,3 +1113,70 @@ func TestRocksDBFileNotFoundError(t *testing.T) {
 		t.Fatalf("expected IsNotExist, but got %v (%T)", err, err)
 	}
 }
+
+func BenchmarkRocksDBDeleteRangeIterate(b *testing.B) {
+	for _, entries := range []int{10, 1000, 100000} {
+		b.Run(fmt.Sprintf("entries=%d", entries), func(b *testing.B) {
+			db := setupMVCCInMemRocksDB(b, "unused").(InMem)
+			defer db.Close()
+
+			makeKey := func(i int) roachpb.Key {
+				return roachpb.Key(fmt.Sprintf("%09d", i))
+			}
+
+			// Create an SST with N entries and ingest it. This is a fast way to get a
+			// lof of entries into RocksDB.
+			{
+				sst, err := MakeRocksDBSstFileWriter()
+				if err != nil {
+					b.Fatal(sst)
+				}
+				defer sst.Close()
+
+				for i := 0; i < entries; i++ {
+					kv := MVCCKeyValue{
+						Key: MVCCKey{
+							Key: makeKey(i),
+						},
+					}
+					if err := sst.Add(kv); err != nil {
+						b.Fatal(err)
+					}
+				}
+
+				sstContents, err := sst.Finish()
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				filename := fmt.Sprintf("ingest")
+				if err := db.WriteFile(filename, sstContents); err != nil {
+					b.Fatal(err)
+				}
+
+				db.IngestExternalFiles(context.Background(), []string{filename}, true)
+			}
+
+			// Create a range tombstone that overlaps all of these entries.
+			from := makeKey(0)
+			to := makeKey(entries)
+			if err := db.ClearRange(MakeMVCCMetadataKey(from), MakeMVCCMetadataKey(to)); err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				iter := db.NewIterator(IterOptions{})
+				iter.Seek(MakeMVCCMetadataKey(from))
+				ok, err := iter.Valid()
+				if err != nil {
+					b.Fatal(err)
+				}
+				if ok {
+					b.Fatal("unexpected key found")
+				}
+				iter.Close()
+			}
+		})
+	}
+}

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -1183,3 +1183,138 @@ func BenchmarkRocksDBDeleteRangeIterate(b *testing.B) {
 		})
 	}
 }
+
+// Verify that range tombstones do not result in sstables that cover an
+// exessively large portion of the key space.
+func TestRocksDBDeleteRangeCompaction(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	db := setupMVCCInMemRocksDB(t, "delrange").(InMem)
+	defer db.Close()
+
+	makeKey := func(prefix string, i int) roachpb.Key {
+		return roachpb.Key(fmt.Sprintf("%s%09d", prefix, i))
+	}
+
+	rnd, _ := randutil.NewPseudoRand()
+
+	// Create sstables in L6 that are half the L6 target size. Any smaller and
+	// RocksDB might choose to compact them.
+	const targetSize = 64 << 20
+	const numEntries = 10000
+	const keySize = 10
+	const valueSize = (targetSize / numEntries) - keySize
+
+	for _, p := range "abc" {
+		sst, err := MakeRocksDBSstFileWriter()
+		if err != nil {
+			t.Fatal(sst)
+		}
+		defer sst.Close()
+
+		for i := 0; i < numEntries; i++ {
+			kv := MVCCKeyValue{
+				Key: MVCCKey{
+					Key: makeKey(string(p), i),
+				},
+				Value: randutil.RandBytes(rnd, valueSize),
+			}
+			if err := sst.Add(kv); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		sstContents, err := sst.Finish()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		filename := fmt.Sprintf("ingest")
+		if err := db.WriteFile(filename, sstContents); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := db.IngestExternalFiles(context.Background(), []string{filename}, true); err != nil {
+			t.Fatal(err)
+		}
+		if testing.Verbose() {
+			fmt.Printf("ingested %s\n", string(p))
+		}
+	}
+
+	getSSTables := func() string {
+		ssts := db.GetSSTables()
+		sort.Slice(ssts, func(i, j int) bool {
+			a, b := ssts[i], ssts[j]
+			if a.Level < b.Level {
+				return true
+			}
+			if a.Level > b.Level {
+				return false
+			}
+			return a.Start.Less(b.Start)
+		})
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "\n")
+		for i := range ssts {
+			fmt.Fprintf(&buf, "%d: %s - %s\n",
+				ssts[i].Level, ssts[i].Start.Key, ssts[i].End.Key)
+		}
+		return buf.String()
+	}
+
+	verifySSTables := func(expected string) {
+		actual := getSSTables()
+		if expected != actual {
+			t.Fatalf("expected%sgot%s", expected, actual)
+		}
+		if testing.Verbose() {
+			fmt.Printf("%s", actual)
+		}
+	}
+
+	// After setup there should be 3 sstables.
+	verifySSTables(`
+6: "a000000000" - "a000009999"
+6: "b000000000" - "b000009999"
+6: "c000000000" - "c000009999"
+`)
+
+	// Generate a batch which writes to the very first key, and then deletes the
+	// range of keys covered by the last sstable.
+	batch := db.NewBatch()
+	if err := batch.Put(MakeMVCCMetadataKey(makeKey("a", 0)), []byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+	if err := batch.ClearRange(MakeMVCCMetadataKey(makeKey("c", 0)),
+		MakeMVCCMetadataKey(makeKey("c", numEntries))); err != nil {
+		t.Fatal(err)
+	}
+	if err := batch.Commit(true); err != nil {
+		t.Fatal(err)
+	}
+	batch.Close()
+	if err := db.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	// After flushing, there is a single additional L0 table that covers the
+	// entire key range.
+	verifySSTables(`
+0: "a000000000" - "c000010000"
+6: "a000000000" - "a000009999"
+6: "b000000000" - "b000009999"
+6: "c000000000" - "c000009999"
+`)
+
+	// Compacting the key range covering the last sstable should result in that
+	// sstable being deleted. Prior to the hack in dbClearRange, all of the
+	// sstables would be compacted resulting in 2 L6 sstables with different
+	// boundaries than the ones below.
+	_ = db.CompactRange(makeKey("c", 0), makeKey("c", numEntries), false)
+	verifySSTables(`
+5: "a000000000" - "a000000000"
+6: "a000000000" - "a000009999"
+6: "b000000000" - "b000009999"
+`)
+}


### PR DESCRIPTION
Demonstrate the performance problem with iterating through a range
tombstone.

```
name                                        time/op
RocksDBDeleteRangeIterate/entries=10-8      5.36µs ±10%
RocksDBDeleteRangeIterate/entries=1000-8    85.2µs ± 2%
RocksDBDeleteRangeIterate/entries=100000-8  7.93ms ± 3%
```

See #24029

Release note: None