### PR TITLE
sql: skip flaky TestSessionFinishRollsBackTxn

### DIFF
--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -86,6 +86,7 @@ select * from crdb_internal.node_runtime_info;
 // in that txn being rolled back.
 func TestSessionFinishRollsBackTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("26524")
 	aborter := NewTxnAborter()
 	defer aborter.Close(t)
 	params, _ := tests.CreateTestServerParams()


### PR DESCRIPTION
Copying from #26524
What's going on here is that this test relies on a rollback (kv-level)
working with a canceled context. It never really worked (the first
rollback attempt failed), however certain canceled contexts were also
stopping the heartbeat loop as a byproduct, and that was doing its own
cleanup. The recent #26479 changed things, however - there would be no
more stopping of the heartbeat loop after a failed rollback attempt.
This is a legit enough regression from #26479, but it's being fixed in
the imminent #23055 which makes the rollbacks with canceled contexts
work properly.

Touches #26524

Release note: None