### PR TITLE
opt: add EXPLAIN (OPT)

### DIFF
--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -55,6 +55,9 @@ func (p *planner) Explain(ctx context.Context, n *tree.Explain) (planNode, error
 		p.semaCtx.Placeholders.PermitUnassigned()
 		return p.makeExplainPlanNode(ctx, &opts, n.Statement)
 
+	case tree.ExplainOpt:
+		return nil, errors.New("EXPLAIN (OPT) only supported with the cost-based optimizer")
+
 	default:
 		return nil, fmt.Errorf("unsupported EXPLAIN mode: %d", opts.Mode)
 	}

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -716,3 +716,6 @@ render              ·         ·                                           ("x[
  └── render         ·         ·                                           (x int[])     x=CONST
       │             render 0  (ARRAY[(1)[int],(2)[int],(3)[int]])[int[]]  ·             ·
       └── emptyrow  ·         ·                                           ()            ·
+
+statement error EXPLAIN \(OPT\) only supported with the cost-based optimizer
+EXPLAIN (OPT) SELECT 1

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -16,6 +16,7 @@ package execbuilder
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -175,8 +176,13 @@ func (b *Builder) buildValues(ev memo.ExprView) (execPlan, error) {
 			}
 		}
 	}
+	return b.constructValues(md, rows, cols)
+}
 
-	resultCols := make(sqlbase.ResultColumns, numCols)
+func (b *Builder) constructValues(
+	md *opt.Metadata, rows [][]tree.TypedExpr, cols opt.ColList,
+) (execPlan, error) {
+	resultCols := make(sqlbase.ResultColumns, len(cols))
 	for i, col := range cols {
 		resultCols[i].Name = md.ColumnLabel(col)
 		resultCols[i].Typ = md.ColumnType(col)
@@ -644,15 +650,27 @@ func (b *Builder) applyPresentation(
 }
 
 func (b *Builder) buildExplain(ev memo.ExprView) (execPlan, error) {
+	def := ev.Private().(*memo.ExplainOpDef)
+	if def.Options.Mode == tree.ExplainOpt {
+		// Special case: EXPLAIN (OPT). Put the formatted expression in
+		// a valuesNode.
+		textRows := strings.Split(strings.Trim(ev.Child(0).String(), "\n"), "\n")
+		rows := make([][]tree.TypedExpr, len(textRows))
+		for i := range textRows {
+			rows[i] = []tree.TypedExpr{tree.NewDString(textRows[i])}
+		}
+		return b.constructValues(ev.Metadata(), rows, def.ColList)
+	}
+
 	input, err := b.buildRelational(ev.Child(0))
 	if err != nil {
 		return execPlan{}, err
 	}
+
 	plan, err := b.factory.ConstructPlan(input.root, b.subqueries)
 	if err != nil {
 		return execPlan{}, err
 	}
-	def := ev.Private().(*memo.ExplainOpDef)
 	node, err := b.factory.ConstructExplain(&def.Options, plan)
 	if err != nil {
 		return execPlan{}, err

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -597,3 +597,23 @@ render              ·         ·                                           ("x[
  └── render         ·         ·                                           (x int[])     x=CONST
       │             render 0  (ARRAY[(1)[int],(2)[int],(3)[int]])[int[]]  ·             ·
       └── emptyrow  ·         ·                                           ()            ·
+
+query T
+EXPLAIN (OPT) SELECT 1
+----
+project
+ ├── columns: "1":1(int!null)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 0.01
+ ├── prune: (1)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── cost: 0.01
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── const: 1 [type=int]
+
+statement error aggregates with DISTINCT are not supported yet
+EXPLAIN (OPT) SELECT SUM(DISTINCT x) FROM (VALUES (1), (1), (2)) AS t(x)

--- a/pkg/sql/opt/optbuilder/explain.go
+++ b/pkg/sql/opt/optbuilder/explain.go
@@ -48,6 +48,9 @@ func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope 
 	case tree.ExplainDistSQL:
 		cols = sqlbase.ExplainDistSQLColumns
 
+	case tree.ExplainOpt:
+		cols = sqlbase.ExplainOptColumns
+
 	default:
 		panic(fmt.Errorf("unsupported EXPLAIN mode: %d", opts.Mode))
 	}

--- a/pkg/sql/sem/tree/explain.go
+++ b/pkg/sql/sem/tree/explain.go
@@ -76,15 +76,21 @@ type ExplainMode uint8
 const (
 	// ExplainPlan shows information about the planNode tree for a query.
 	ExplainPlan ExplainMode = iota
+
 	// ExplainDistSQL shows the physical distsql plan for a query and whether a
 	// query would be run in "auto" DISTSQL mode. See sql/explain_distsql.go for
 	// details.
 	ExplainDistSQL
+
+	// ExplainOpt shows the optimized relational expression (from the cost-based
+	// optimizer).
+	ExplainOpt
 )
 
 var explainModeStrings = map[string]ExplainMode{
 	"plan":    ExplainPlan,
 	"distsql": ExplainDistSQL,
+	"opt":     ExplainOpt,
 }
 
 // Explain flags.

--- a/pkg/sql/sqlbase/result_columns.go
+++ b/pkg/sql/sqlbase/result_columns.go
@@ -113,6 +113,12 @@ var ExplainDistSQLColumns = ResultColumns{
 	{Name: "JSON", Typ: types.String, Hidden: true},
 }
 
+// ExplainOptColumns are the result columns of an
+// EXPLAIN (OPT) statement.
+var ExplainOptColumns = ResultColumns{
+	{Name: "text", Typ: types.String},
+}
+
 // ShowTraceColumns are the result columns of a SHOW [KV] TRACE statement.
 var ShowTraceColumns = ResultColumns{
 	{Name: "timestamp", Typ: types.TimestampTZ},


### PR DESCRIPTION
Adding an `EXPLAIN (OPT)` statement which returns the optimized
expression tree. If the statement is not supported by the optimizer,
returns the relevant error (this can be checked to see if a statement
is supported by the optimizer, similar to `EXPLAIN (DISTSQL)`).

Release note: None