### PR TITLE
opt: Fix panic when projecting non-covered column in sorted index join

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -433,6 +433,30 @@ SELECT * FROM noncover WHERE b = 2
 ----
 1 2 3 4
 
+# Subset of output columns, not including tested column.
+query II
+SELECT a, d FROM noncover WHERE b=2
+----
+1 4
+
+# Subset of output columns, not including tested column or order by column.
+query I
+SELECT a FROM noncover WHERE b=2 ORDER BY c DESC
+----
+1
+
+# Regression: panic when projecting non-covered column in sorted index join.
+query III
+SELECT a, b, d FROM noncover WHERE b=2 ORDER BY b
+----
+1 2 4
+
+# Use non-covered column in filtered and sorted index join.
+query II
+SELECT a, b FROM noncover WHERE b=2 AND d>3 ORDER BY b
+----
+1 2
+
 query IIII
 SELECT * FROM noncover WHERE c = 7
 ----

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -562,9 +562,10 @@ func (b *Builder) buildLookupJoin(ev memo.ExprView) (execPlan, error) {
 	needed, output := b.getColumns(md, def.Cols, def.Table)
 	res := execPlan{outputCols: output}
 
+	// Get sort *result column* ordinals. Don't confuse these with *table column*
+	// ordinals, which are used by the needed set. The sort columns should already
+	// be in the needed set, so no need to add anything further to that.
 	reqOrder := b.makeSQLOrdering(res, ev)
-
-	needed.UnionWith(ev.Physical().Ordering.ColSet())
 
 	node, err := b.factory.ConstructLookupJoin(input.root, md.Table(def.Table), needed, reqOrder)
 	if err != nil {

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -837,14 +837,14 @@ index-join  ·      ·            (x, y)              ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x FROM xy WHERE y > 0 AND y < 2 ORDER BY y
 ----
-render           ·         ·            (x)                    ·
- │               render 0  x            ·                      ·
- └── index-join  ·         ·            (x, y, rowid[hidden])  +y
-      ├── scan   ·         ·            (y, rowid[hidden])     +y
-      │          table     xy@xy_y_idx  ·                      ·
-      │          spans     /1-/2        ·                      ·
-      └── scan   ·         ·            (x, y, rowid[hidden])  ·
-·                table     xy@primary   ·                      ·
+render           ·         ·            (x)                 ·
+ │               render 0  x            ·                   ·
+ └── index-join  ·         ·            (x, y)              +y
+      ├── scan   ·         ·            (y, rowid[hidden])  +y
+      │          table     xy@xy_y_idx  ·                   ·
+      │          spans     /1-/2        ·                   ·
+      └── scan   ·         ·            (x, y)              ·
+·                table     xy@primary   ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM NULL


### PR DESCRIPTION
The execbuilder has a bug when building index joins where it mistakenly
adds extra columns to the set of needed output columns. It tries to add
optimizer ColumnIDs rather than planner column ordinals. But it's not
necessary to add any columns anyway, b/c the ordering columns should
already be part of the needed set.

Release note: None