### PR TITLE
kv: interrupt DistSender replica retry loop on ctx cancelation

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -1308,6 +1308,16 @@ func (ds *DistSender) sendToReplicas(
 			)
 		}
 
+		// Has the caller given up?
+		if ctx.Err() != nil {
+			errMsg := fmt.Sprintf("context done during DistSender.Send: %s", ctx.Err())
+			log.Eventf(ctx, errMsg)
+			if ambiguousError != nil {
+				return nil, roachpb.NewAmbiguousResultError(errMsg)
+			}
+			return nil, roachpb.NewSendError(errMsg)
+		}
+
 		ds.metrics.NextReplicaErrCount.Inc(1)
 		log.VEventf(ctx, 2, "error: %v %v; trying next peer %s", br, err, transport.NextReplica())
 		br, err = transport.SendNext(ctx)


### PR DESCRIPTION
The recent #26340 made transport.SendNext() synchronous and incidentally
removed the DistSender's observance of context cancelation. That's not
good - in case a Send returns because of context cancelation, the
DistSender will keep trying other replicas until the transport is
exhausted. Worse yet, if the transport's implementation is such that it
never becomes exhausted when the ctx is canceled (e.g. if the SendNext()
implementation were to detect the canceled ctx and return immediately
without "burning" a replica - as I happened to be doing in another PR
for the multiTestContext transport), then the DistSender would loop
forever. This patch introduces a check for canceled ctx in between
replica attempts.

Release note: None