### PR TITLE
[wip] sql: StatusServer/AdminServer RPCs in crdb_internal

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -894,6 +894,8 @@ may increase either contention or retry errors, or both.</p>
 </span></td></tr>
 <tr><td><code>crdb_internal.set_vmodule(vmodule_string: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used for internal debugging purposes. Incorrect use can severely impact performance.</p>
 </span></td></tr>
+<tr><td><code>crdb_internal.simulate_allocator(req: jsonb) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Simulate an allocator run.</p>
+</span></td></tr>
 <tr><td><code>current_database() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the current database.</p>
 </span></td></tr>
 <tr><td><code>current_schema() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the current schema.</p>

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2503,6 +2503,24 @@ may increase either contention or retry errors, or both.`,
 		},
 	),
 
+	"crdb_internal.simulate_allocator": makeBuiltin(
+		tree.FunctionProperties{Category: categorySystemInfo},
+		tree.Overload{
+			Types:      tree.ArgTypes{{Name: "req", Typ: types.JSON}},
+			ReturnType: tree.FixedReturnType(types.JSON),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				handler, ok := ctx.JSONEndpoints["simulate_allocator"]
+				if !ok {
+					return nil, errors.New("unknown handler")
+				}
+				req := args[0].(*tree.DJSON).JSON
+				resp, err := handler(ctx.Ctx(), req)
+				return tree.NewDJSON(resp), err
+			},
+			Info: "Simulate an allocator run.",
+		},
+	),
+
 	"crdb_internal.cluster_id": makeBuiltin(
 		tree.FunctionProperties{Category: categorySystemInfo},
 		tree.Overload{

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2488,6 +2488,9 @@ type EvalContext struct {
 	// evaluation. It can change over the course of evaluation, such as on a
 	// per-row basis.
 	ActiveMemAcc *mon.BoundAccount
+
+	// JSONEndpoints ...
+	JSONEndpoints map[string]func(context.Context, json.JSON) (json.JSON, error)
 }
 
 // MakeTestingEvalContext returns an EvalContext that includes a MemoryMonitor.


### PR DESCRIPTION
This is an exploration of whether we want to/should do this more than a
work in progress. My understanding is that we would generally like debug
and administrative commands to be accessible from SQL (at least in an
experimental manner); for debug purposes it would be nice to be able
to poke around freely.

I tried to look at this for #26068 (online RocksDB compactions) for
which we'd like to introduce some version of
`crdb_internal.compact(node_id, from, to)`.

The compaction command would likely live on `serverpb.AdminServer`, and
the question that remains is how to hook that up with a SQL builtin.

Hooking this up is a bit difficult:

1. the builtins can't refer to `serverpb` due to import conflicts
(`serverpb` imports various other protos, including from `config`).
2. the naive way of hooking it up (that done in this PR so far) is
poorly maintainable and a bit intransparent; the `crdb_internal`
methods should really be autogenerated from the server interface.
3. It's unclear to me whether evaluation is the right time to send
   RPCs.

Before I address the bullets above and make this code something I would
even consider merging, I wanted to show what I had and gauge buy-in.

In this PR, I have a toy hookup for the allocator simulator endpoint.
It allows this to work:

```
select jsonb_pretty(
  crdb_internal.simulate_allocator('{"node_id": "1", "range_ids": [1]}'::json));
```

It would be easier to add an online version of `./cockroach debug
compact` and to call it a day, but I expect the availability from SQL to
reduce friction.  Plus, the expressivity of SQL can be helpful. For
example, when trying to trigger an online compaction of a given table,
we can just look up the raw key span from `crdb_internal.tables` and
compact it in one elegant command; on the command-line, this involves
awkward copy-pasting.

The other immediate such command that I would like to introduce is one
that retrieves the MVCCStats for any desired key span, and to optionally
recompute stats. It's been difficult in the past to account for the
live bytes shown in the UI.

cc @a-robinson for #25073, which would be easy to plumb into this
framework if it introduced itself on `AdminServer` as well.

Release note: None