### PR TITLE
sql: Fix a root span leak in the InternalExecutor

### DIFF
--- a/pkg/sql/conn_fsm.go
+++ b/pkg/sql/conn_fsm.go
@@ -265,7 +265,7 @@ var TxnStateTransitions = Compile(Pattern{
 			Next:        stateNoTxn{},
 			Action: func(args Args) error {
 				ts := args.Extended.(*txnState)
-				ts.finishSQLTxn(args.Ctx)
+				ts.finishSQLTxn()
 				ts.setAdvanceInfo(
 					advanceOne, noRewind, args.Payload.(eventTxnFinishPayload).toEvent())
 				return nil
@@ -401,7 +401,7 @@ var TxnStateTransitions = Compile(Pattern{
 			Next:        stateNoTxn{},
 			Action: func(args Args) error {
 				ts := args.Extended.(*txnState)
-				ts.finishSQLTxn(ts.Ctx)
+				ts.finishSQLTxn()
 				ts.setAdvanceInfo(
 					advanceOne, noRewind, args.Payload.(eventTxnFinishPayload).toEvent())
 				return nil
@@ -426,7 +426,7 @@ var TxnStateTransitions = Compile(Pattern{
 			Next:        stateOpen{ImplicitTxn: False, RetryIntent: True},
 			Action: func(args Args) error {
 				ts := args.Extended.(*txnState)
-				ts.finishSQLTxn(args.Ctx)
+				ts.finishSQLTxn()
 
 				payload := args.Payload.(eventTxnStartPayload)
 
@@ -452,7 +452,7 @@ var TxnStateTransitions = Compile(Pattern{
 			Next:        stateNoTxn{},
 			Action: func(args Args) error {
 				ts := args.Extended.(*txnState)
-				ts.finishSQLTxn(args.Ctx)
+				ts.finishSQLTxn()
 				ts.setAdvanceInfo(
 					advanceOne, noRewind, args.Payload.(eventTxnFinishPayload).toEvent())
 				return nil
@@ -485,7 +485,7 @@ var TxnStateTransitions = Compile(Pattern{
 			Next:        stateNoTxn{},
 			Action: func(args Args) error {
 				ts := args.Extended.(*txnState)
-				ts.finishSQLTxn(args.Ctx)
+				ts.finishSQLTxn()
 				ts.setAdvanceInfo(
 					advanceOne, noRewind, args.Payload.(eventTxnFinishPayload).toEvent())
 				return nil
@@ -510,7 +510,7 @@ var TxnStateTransitions = Compile(Pattern{
 func cleanupAndFinish(args Args) error {
 	ts := args.Extended.(*txnState)
 	ts.mu.txn.CleanupOnError(ts.Ctx, args.Payload.(payloadWithError).errorCause())
-	ts.finishSQLTxn(args.Ctx)
+	ts.finishSQLTxn()
 	ts.setAdvanceInfo(skipBatch, noRewind, txnAborted)
 	return nil
 }
@@ -555,7 +555,7 @@ var BoundTxnStateTransitions = Compile(Pattern{
 			Next: stateInternalError{},
 			Action: func(args Args) error {
 				ts := args.Extended.(*txnState)
-				ts.finishSQLTxn(args.Ctx)
+				ts.finishSQLTxn()
 				ts.setAdvanceInfo(skipBatch, noRewind, txnAborted)
 				return nil
 			},
@@ -564,7 +564,7 @@ var BoundTxnStateTransitions = Compile(Pattern{
 			Next: stateInternalError{},
 			Action: func(args Args) error {
 				ts := args.Extended.(*txnState)
-				ts.finishSQLTxn(args.Ctx)
+				ts.finishSQLTxn()
 				ts.setAdvanceInfo(skipBatch, noRewind, txnAborted)
 				return nil
 			},

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -211,6 +211,11 @@ func (ie *internalExecutorImpl) initConnEx(
 		if err := ex.run(ctx, nil /* cancel */); err != nil {
 			errCallback(err)
 		}
+		closeMode := normalClose
+		if txn != nil {
+			closeMode = externalTxnClose
+		}
+		ex.close(ctx, closeMode)
 		wg.Done()
 	}()
 	return stmtBuf, &wg


### PR DESCRIPTION
Before this patch, there was a bug - an InternalExecutor running inside
a higher-level txn was never finishing the span that it created. This
lead to, for example, never-ending traces in /debug/requests. This
happened because these particular InternalExecutors are a bit of a weird
beast - we init their txnState manually but we neuter them such that
they never call finishSQLTxn() - which, among others, finishes that
span.
This patch adds a specialized connExec.close() path that does some
cleanup.

Fixes #26531

Release note: None