### PR TITLE
opt: add Index to LookupJoinDef

### DIFF
--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -255,7 +255,7 @@ func (ev ExprView) formatRelational(f *opt.ExprFmtCtx, tp treeprinter.Node) {
 	fmt.Fprintf(&buf, "%v", ev.op)
 
 	switch ev.Operator() {
-	case opt.ScanOp, opt.ShowTraceOp, opt.ShowTraceForSessionOp:
+	case opt.ScanOp, opt.LookupJoinOp, opt.ShowTraceOp, opt.ShowTraceForSessionOp:
 		formatter := ev.mem.makeExprFormatter(&buf)
 		formatter.formatPrivate(ev.Private(), formatNormal)
 	}
@@ -340,8 +340,6 @@ func (ev ExprView) formatRelational(f *opt.ExprFmtCtx, tp treeprinter.Node) {
 
 	case opt.LookupJoinOp:
 		def := ev.Private().(*LookupJoinDef)
-		tableID := def.Table
-		tp.Childf("table: %s", ev.Metadata().Table(tableID).TabName())
 		tp.Childf("key columns: %v", def.KeyCols)
 	}
 

--- a/pkg/sql/opt/memo/memo_format.go
+++ b/pkg/sql/opt/memo/memo_format.go
@@ -271,23 +271,22 @@ func (f exprFormatter) formatPrivate(private interface{}, mode formatMode) {
 	switch t := private.(type) {
 	case *ScanOpDef:
 		// Don't output name of index if it's the primary index.
-		def := private.(*ScanOpDef)
-		tab := f.mem.metadata.Table(def.Table)
-		if def.Index == opt.PrimaryIndex {
+		tab := f.mem.metadata.Table(t.Table)
+		if t.Index == opt.PrimaryIndex {
 			fmt.Fprintf(f.buf, " %s", tab.TabName())
 		} else {
-			fmt.Fprintf(f.buf, " %s@%s", tab.TabName(), tab.Index(def.Index).IdxName())
+			fmt.Fprintf(f.buf, " %s@%s", tab.TabName(), tab.Index(t.Index).IdxName())
 		}
 
 		if mode == formatMemo {
-			if tab.ColumnCount() != def.Cols.Len() {
-				fmt.Fprintf(f.buf, ",cols=%s", def.Cols)
+			if tab.ColumnCount() != t.Cols.Len() {
+				fmt.Fprintf(f.buf, ",cols=%s", t.Cols)
 			}
-			if def.Constraint != nil {
+			if t.Constraint != nil {
 				fmt.Fprintf(f.buf, ",constrained")
 			}
-			if def.HardLimit > 0 {
-				fmt.Fprintf(f.buf, ",lim=%d", def.HardLimit)
+			if t.HardLimit > 0 {
+				fmt.Fprintf(f.buf, ",lim=%d", t.HardLimit)
 			}
 		}
 
@@ -306,8 +305,15 @@ func (f exprFormatter) formatPrivate(private interface{}, mode formatMode) {
 		fmt.Fprintf(f.buf, " %s", f.mem.metadata.ColumnLabel(t))
 
 	case *LookupJoinDef:
-		tn := f.mem.metadata.Table(t.Table).TabName()
-		fmt.Fprintf(f.buf, " %s,keyCols=%v,lookupCols=%s", tn, t.KeyCols, t.LookupCols)
+		tab := f.mem.metadata.Table(t.Table)
+		if t.Index == opt.PrimaryIndex {
+			fmt.Fprintf(f.buf, " %s", tab.TabName())
+		} else {
+			fmt.Fprintf(f.buf, " %s@%s", tab.TabName(), tab.Index(t.Index).IdxName())
+		}
+		if mode == formatMemo {
+			fmt.Fprintf(f.buf, ",keyCols=%v,lookupCols=%s", t.KeyCols, t.LookupCols)
+		}
 
 	case *ExplainOpDef:
 		if mode == formatMemo {

--- a/pkg/sql/opt/memo/private_defs.go
+++ b/pkg/sql/opt/memo/private_defs.go
@@ -160,6 +160,11 @@ type LookupJoinDef struct {
 	// currently the only index used.
 	Table opt.TableID
 
+	// Index identifies the index to do lookups in (whether primary or secondary).
+	// It can be passed to the opt.Table.Index(i int) method in order to fetch the
+	// opt.Index metadata.
+	Index int
+
 	// KeyCols are the columns (produced by the input) used to create lookup keys;
 	// in the same order as the index columns (or a prefix of them).
 	KeyCols opt.ColList

--- a/pkg/sql/opt/memo/private_storage_test.go
+++ b/pkg/sql/opt/memo/private_storage_test.go
@@ -485,7 +485,7 @@ func BenchmarkPrivateStorage(b *testing.B) {
 	}
 	scanOpDef := &ScanOpDef{Table: 1, Index: 2, Cols: colSet}
 	groupByDef := &GroupByDef{GroupingCols: colSet, Ordering: ordering}
-	indexJoinDef := &LookupJoinDef{Table: 1, KeyCols: colList, LookupCols: colSet}
+	indexJoinDef := &LookupJoinDef{Table: 1, Index: 2, KeyCols: colList, LookupCols: colSet}
 	setOpColMap := &SetOpColMap{Left: colList, Right: colList, Out: colList}
 	datum := tree.NewDInt(1)
 	typ := types.Int

--- a/pkg/sql/opt/memo/testdata/logprops/lookup-join
+++ b/pkg/sql/opt/memo/testdata/logprops/lookup-join
@@ -34,9 +34,8 @@ select
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null)
  ├── stats: [rows=1, distinct(3)=1]
  ├── keys: (1) (3,4) weak(2,3)
- ├── lookup-join
+ ├── lookup-join a
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── table: a
  │    ├── key columns: [1]
  │    ├── stats: [rows=1]
  │    ├── keys: (1) weak(3,4) weak(2,3)
@@ -62,9 +61,8 @@ project
       ├── columns: x:1(int!null) y:2(int) s:3(string!null)
       ├── stats: [rows=1, distinct(3)=1]
       ├── keys: (1) weak(2,3)
-      ├── lookup-join
+      ├── lookup-join a
       │    ├── columns: x:1(int!null) y:2(int) s:3(string)
-      │    ├── table: a
       │    ├── key columns: [1]
       │    ├── stats: [rows=1]
       │    ├── keys: (1) weak(2,3)

--- a/pkg/sql/opt/memo/testdata/stats/lookup-join
+++ b/pkg/sql/opt/memo/testdata/stats/lookup-join
@@ -60,9 +60,8 @@ project
       │    ├── columns: x:1(int!null) y:2(int) s:3(string!null)
       │    ├── stats: [rows=66, distinct(3)=1, distinct(2,3)=65]
       │    ├── keys: (1)
-      │    ├── lookup-join
+      │    ├── lookup-join a
       │    │    ├── columns: x:1(int!null) y:2(int) s:3(string)
-      │    │    ├── table: a
       │    │    ├── key columns: [1]
       │    │    ├── stats: [rows=200]
       │    │    ├── keys: (1)

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -242,10 +242,9 @@ GenerateIndexScans (higher cost)
          │    ├── columns: k:1(int!null) i:2(int!null) s:4(string)
          │    ├── keys: (1)
   -      │    ├── scan a
-  +      │    ├── lookup-join
+  +      │    ├── lookup-join a
          │    │    ├── columns: k:1(int!null) i:2(int) s:4(string)
   -      │    │    └── keys: (1)
-  +      │    │    ├── table: a
   +      │    │    ├── key columns: [1]
   +      │    │    ├── keys: (1)
   +      │    │    └── scan a@secondary
@@ -580,10 +579,9 @@ GenerateIndexScans (higher cost)
     ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
     ├── keys: (1) weak(3,4)
   - ├── scan a
-  + ├── lookup-join
+  + ├── lookup-join a
     │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
   - │    └── keys: (1) weak(3,4)
-  + │    ├── table: a
   + │    ├── key columns: [1]
   + │    ├── keys: (1) weak(3,4)
   + │    └── scan a@secondary

--- a/pkg/sql/opt/xform/explorer.go
+++ b/pkg/sql/opt/xform/explorer.go
@@ -262,6 +262,7 @@ func (e *explorer) generateIndexScans(def memo.PrivateID) []memo.Expr {
 			// We scan whatever needed columns are left from the primary index.
 			def := memo.LookupJoinDef{
 				Table:      scanOpDef.Table,
+				Index:      opt.PrimaryIndex,
 				KeyCols:    pkCols,
 				LookupCols: scanOpDef.Cols.Difference(indexScanOpDef.Cols),
 			}

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -77,9 +77,8 @@ ALTER TABLE abc INJECT STATISTICS '[
 opt
 SELECT * FROM abc WHERE c = 1
 ----
-lookup-join
+lookup-join abc
  ├── columns: a:1(int!null) b:2(int) c:3(int!null)
- ├── table: abc
  ├── key columns: [1]
  ├── stats: [rows=1, distinct(3)=1]
  ├── cost: 5.01

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -600,9 +600,8 @@ project
  ├── cost: 250.50
  ├── ordering: +1
  ├── prune: (1,3,8,14-17)
- └── lookup-join
+ └── lookup-join stock
       ├── columns: stock.s_i_id:1(int!null) stock.s_w_id:2(int!null) stock.s_quantity:3(int) stock.s_dist_05:8(string) stock.s_ytd:14(int) stock.s_order_cnt:15(int) stock.s_remote_cnt:16(int) stock.s_data:17(string)
-      ├── table: stock
       ├── key columns: [2 1]
       ├── stats: [rows=333333]
       ├── cost: 250.50

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -287,9 +287,8 @@ select
 opt
 SELECT * FROM b WHERE v = 1
 ----
-lookup-join
+lookup-join b
  ├── columns: k:1(int!null) u:2(int) v:3(int!null)
- ├── table: b
  ├── key columns: [1]
  ├── keys: (1) (3)
  └── scan b@v
@@ -346,9 +345,8 @@ SELECT * FROM b WHERE v = 1 AND k+u = 1
 select
  ├── columns: k:1(int!null) u:2(int) v:3(int!null)
  ├── keys: (1) (3)
- ├── lookup-join
+ ├── lookup-join b
  │    ├── columns: k:1(int!null) u:2(int) v:3(int)
- │    ├── table: b
  │    ├── key columns: [1]
  │    ├── keys: (1) weak(3)
  │    └── scan b@v


### PR DESCRIPTION
For now, it is still always the primary index; I'm adding the field
now to avoid accumulating code that would need to be audited when we
add it.

Also changing the expr format output to put the table (or table@index)
on the same line with the op name, similar to scan.

Release note: None