### PR TITLE
cli: learn to dump a store's SSTs in JSON

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -669,6 +669,12 @@ If specified, print the system config contents. Beware that the output will be
 long and not particularly human-readable.`,
 	}
 
+	JSON = FlagInfo{
+		Name: "json",
+		Description: `
+Format output as JSON.`,
+	}
+
 	Decommission = FlagInfo{
 		Name: "decommission",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -93,6 +93,7 @@ func initCLIDefaults() {
 	debugCtx.inputFile = ""
 	debugCtx.printSystemConfig = false
 	debugCtx.ballastSize = base.SizeSpec{}
+	debugCtx.json = false
 
 	zoneCtx.zoneConfig = ""
 	zoneCtx.zoneDisableReplication = false
@@ -199,6 +200,9 @@ var debugCtx struct {
 
 	// debug ballast
 	ballastSize base.SizeSpec
+
+	// debug sstables
+	json bool
 }
 
 // zoneCtx captures the command-line parameters of the `zone` command.

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -92,7 +92,6 @@ func initCLIDefaults() {
 	debugCtx.replicated = false
 	debugCtx.inputFile = ""
 	debugCtx.printSystemConfig = false
-	debugCtx.maxResults = 1000
 	debugCtx.ballastSize = base.SizeSpec{}
 
 	zoneCtx.zoneConfig = ""
@@ -186,14 +185,20 @@ var dumpCtx struct {
 // debugCtx captures the command-line parameters of the `debug` command.
 // Defaults set by InitCLIDefaults() above.
 var debugCtx struct {
-	startKey, endKey  engine.MVCCKey
-	values            bool
-	sizes             bool
-	replicated        bool
+	// debug keys
+	startKey, endKey engine.MVCCKey
+	values           bool
+	sizes            bool
+
+	// debug range-data
+	replicated bool
+
+	// debug gossip-values
 	inputFile         string
-	ballastSize       base.SizeSpec
 	printSystemConfig bool
-	maxResults        int64
+
+	// debug ballast
+	ballastSize base.SizeSpec
 }
 
 // zoneCtx captures the command-line parameters of the `zone` command.

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"math"
 	"os"
@@ -1005,7 +1006,12 @@ func runDebugSSTables(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("%s", db.GetSSTables())
+	sstables := db.GetSSTables()
+	if debugCtx.json {
+		encoder := json.NewEncoder(os.Stdout)
+		return encoder.Encode(sstables)
+	}
+	fmt.Printf("%s", sstables)
 	return nil
 }
 

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -387,6 +387,10 @@ func init() {
 		f := debugBallastCmd.Flags()
 		VarFlag(f, &debugCtx.ballastSize, cliflags.Size)
 	}
+	{
+		f := debugSSTablesCmd.Flags()
+		BoolFlag(f, &debugCtx.json, cliflags.JSON, debugCtx.json)
+	}
 }
 
 func extraServerFlagInit() {

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -17,6 +17,7 @@ package engine
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"sync"
@@ -145,6 +146,17 @@ func (k MVCCKey) String() string {
 		return k.Key.String()
 	}
 	return fmt.Sprintf("%s/%s", k.Key, k.Timestamp)
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (k MVCCKey) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Raw    []byte
+		Pretty string
+	}{
+		Raw:    k.Key,
+		Pretty: k.Key.String(),
+	})
 }
 
 // MVCCKeyValue contains the raw bytes of the value for a key.


### PR DESCRIPTION
Add a '--json' flag to the 'debug sstables' command. The JSON output can
be significantly more verbose than the standard summary that's printed,
as it's not meant for direct human consumption.

Release note: None