### PR TITLE
sql: add missing PostgreSQL built-in functions

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -672,10 +672,22 @@ has no relationship with the commit order of concurrent transactions.</p>
 <tbody>
 <tr><td><code>ascii(val: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the ASCII value for the first character in <code>val</code>.</p>
 </span></td></tr>
+<tr><td><code>bit_length(val: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of bits in <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>bit_length(val: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of bits used to represent <code>val</code>.</p>
+</span></td></tr>
 <tr><td><code>btrim(input: <a href="string.html">string</a>, trim_chars: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Removes any characters included in <code>trim_chars</code> from the beginning or end of <code>input</code> (applies recursively).</p>
 <p>For example, <code>btrim('doggie', 'eod')</code> returns <code>ggi</code>.</p>
 </span></td></tr>
 <tr><td><code>btrim(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Removes all spaces from the beginning and end of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>char_length(val: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of bytes in <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>char_length(val: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of characters in <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>character_length(val: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of bytes in <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>character_length(val: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of characters in <code>val</code>.</p>
 </span></td></tr>
 <tr><td><code>concat(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Concatenates a comma-separated list of strings.</p>
 </span></td></tr>
@@ -723,6 +735,16 @@ has no relationship with the commit order of concurrent transactions.</p>
 <p>For example, <code>overlay('doggie', 'CAT', 2)</code> returns <code>dCATie</code>.</p>
 </span></td></tr>
 <tr><td><code>overlay(input: <a href="string.html">string</a>, overlay_val: <a href="string.html">string</a>, start_pos: <a href="int.html">int</a>, end_pos: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Deletes the characters in <code>input</code> between <code>start_pos</code> and <code>end_pos</code> (count starts at 1), and then insert <code>overlay_val</code> at <code>start_pos</code>.</p>
+</span></td></tr>
+<tr><td><code>quote_ident(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Return <code>val</code> suitably quoted to serve as identifier in a SQL statement.</p>
+</span></td></tr>
+<tr><td><code>quote_literal(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Return <code>val</code> suitably quoted to serve as string literal in a SQL statement.</p>
+</span></td></tr>
+<tr><td><code>quote_literal(val: anyelement) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Coerce <code>val</code> to a string and then quote it as a literal.</p>
+</span></td></tr>
+<tr><td><code>quote_nullable(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Coerce <code>val</code> to a string and then quote it as a literal. If <code>val</code> is NULL, returns ‘NULL’.</p>
+</span></td></tr>
+<tr><td><code>quote_nullable(val: anyelement) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Coerce <code>val</code> to a string and then quote it as a literal. If <code>val</code> is NULL, returns ‘NULL’.</p>
 </span></td></tr>
 <tr><td><code>regexp_extract(input: <a href="string.html">string</a>, regex: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the first match for the Regular Expression <code>regex</code> in <code>input</code>.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -18,18 +18,81 @@ SELECT LENGTH('roach7'), LENGTH(b'roach77')
 length length
 6      7
 
-query II
-SELECT LENGTH('Hello, 世界'), LENGTH(b'Hello, 世界')
+query IIIIII
+SELECT length('Hello, 世界'), length(b'Hello, 世界'),
+       char_length('Hello, 世界'), char_length(b'Hello, 世界'),
+       character_length('Hello, 世界'), character_length(b'Hello, 世界')
 ----
-9 13
+9 13 9 13 9 13
 
 statement error unknown signature: length\(int\)
 SELECT LENGTH(23)
 
-query II
-SELECT octet_length('Hello'), octet_length(b'世界')
+query III
+SELECT octet_length('Hello'), octet_length('世界'), octet_length(b'世界')
 ----
-5 6
+5 6 6
+
+query III
+SELECT bit_length('Hello'), bit_length('世界'), bit_length(b'世界')
+----
+40 48 48
+
+query TTTTTTTT
+SELECT quote_ident('abc'), quote_ident('ab.c'), quote_ident('ab"c'), quote_ident('世界'),
+       quote_ident('array'), -- reserved keyword
+       quote_ident('family'), -- type/func name keyword
+       quote_ident('bigint'), -- col name keyword
+       quote_ident('alter') -- unreserved keyword
+----
+abc  "ab.c"  "ab""c"  世界  "array"  "family"  "bigint"  alter
+
+query TTTT
+SELECT quote_literal('abc'), quote_literal('ab''c'), quote_literal('ab"c'), quote_literal(e'ab\nc')
+----
+'abc'  e'ab\'c'  'ab"c'  e'ab\nc'
+
+query TTTTTTTT
+SELECT
+ quote_literal(123::string), quote_nullable(123::string),
+ quote_literal(123), quote_nullable(123),
+ quote_literal(true), quote_nullable(true),
+ quote_literal(123.3), quote_nullable(123.3)
+----
+'123'  '123'  '123'  '123'  'true'  'true'  '123.3'  '123.3'
+
+query TTTTTT
+SELECT
+ quote_literal('1d'::interval),	quote_nullable('1d'::interval),
+ quote_literal('2018-06-11 12:13:14'::timestamp), quote_nullable('2018-06-11 12:13:14'::timestamp),
+ quote_literal('2018-06-11'::date), quote_nullable('2018-06-11'::date)
+----
+'1d'  '1d'  '2018-06-11 12:13:14+00:00'  '2018-06-11 12:13:14+00:00'  '2018-06-11'  '2018-06-11'
+
+query TTBB
+SELECT
+ quote_literal(null::int), quote_nullable(null::int),
+ quote_literal(null::int) IS NULL, quote_nullable(null::int) IS NULL
+----
+NULL  NULL  true  false
+
+# Check that quote_literal is properly sensitive to bytea_output.
+
+query TT
+SELECT quote_literal(b'abc'), quote_nullable(b'abc')
+----
+e'\\x616263'  e'\\x616263'
+
+statement ok
+SET bytea_output = 'escape'
+
+query TT
+SELECT quote_literal(b'abc'), quote_nullable(b'abc')
+----
+'abc'  'abc'
+
+statement ok
+RESET bytea_output
 
 query T colnames
 SELECT UPPER('roacH7')
@@ -1786,3 +1849,8 @@ SELECT pg_is_xlog_replay_paused()
 ----
 pg_is_xlog_replay_paused
 false
+
+query T
+SELECT pg_catalog.pg_client_encoding()
+----
+UTF8


### PR DESCRIPTION
Fixes #26406.

Release note (sql change): CockroachDB now supports the built-in
functions `bit_length()`, `quote_ident()`, `quote_literal()`,
`quote_nullable()`, and the aliases `char_length()` and
`character_length()` for `length()`, for compatibility with
PostgreSQL.