### PR TITLE
sql: Remove excessive allocation in upsert conflict index enumeration

### DIFF
--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -762,9 +762,9 @@ func upsertExprsAndIndex(
 	if indexMatch(tableDesc.PrimaryIndex) {
 		return onConflict.Exprs, &tableDesc.PrimaryIndex, nil
 	}
-	for _, index := range tableDesc.Indexes {
-		if indexMatch(index) {
-			return onConflict.Exprs, &index, nil
+	for i := range tableDesc.Indexes {
+		if indexMatch(tableDesc.Indexes[i]) {
+			return onConflict.Exprs, &tableDesc.Indexes[i], nil
 		}
 	}
 	return nil, nil, fmt.Errorf("there is no unique or exclusion constraint matching the ON CONFLICT specification")


### PR DESCRIPTION
Release note: none

closes #26367 