### PR TITLE
release-2.0: storage/engine: RocksDB clear range hack

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2368,7 +2368,33 @@ func dbClear(rdb *C.DBEngine, key MVCCKey) error {
 }
 
 func dbClearRange(rdb *C.DBEngine, start, end MVCCKey) error {
-	return statusToError(C.DBDeleteRange(rdb, goToCKey(start), goToCKey(end)))
+	if err := statusToError(C.DBDeleteRange(rdb, goToCKey(start), goToCKey(end))); err != nil {
+		return err
+	}
+	// This is a serious hack. RocksDB generates sstables which cover an
+	// excessively large amount of the key space when range tombstones are
+	// present. The crux of the problem is that the logic for determining sstable
+	// boundaries depends on actual keys being present. So we help that logic
+	// along by adding deletions of the first key covered by the range tombstone,
+	// and a key near the end of the range (previous is difficult). See
+	// TestRocksDBDeleteRangeCompaction which verifies that either this hack is
+	// working, or the upstream problem was fixed in RocksDB.
+	if err := dbClear(rdb, start); err != nil {
+		return err
+	}
+	prev := make(roachpb.Key, len(end.Key))
+	copy(prev, end.Key)
+	if n := len(prev) - 1; prev[n] > 0 {
+		prev[n]--
+	} else {
+		prev = prev[:n]
+	}
+	if start.Key.Compare(prev) < 0 {
+		if err := dbClear(rdb, MakeMVCCMetadataKey(prev)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func dbClearIterRange(rdb *C.DBEngine, iter Iterator, start, end MVCCKey) error {

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -1029,3 +1029,138 @@ func TestRocksDBOptions(t *testing.T) {
 		}
 	}
 }
+
+// Verify that range tombstones do not result in sstables that cover an
+// exessively large portion of the key space.
+func TestRocksDBDeleteRangeCompaction(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	db := setupMVCCInMemRocksDB(t, "delrange").(InMem)
+	defer db.Close()
+
+	makeKey := func(prefix string, i int) roachpb.Key {
+		return roachpb.Key(fmt.Sprintf("%s%09d", prefix, i))
+	}
+
+	rnd, _ := randutil.NewPseudoRand()
+
+	// Create sstables in L6 that are half the L6 target size. Any smaller and
+	// RocksDB might choose to compact them.
+	const targetSize = 64 << 20
+	const numEntries = 10000
+	const keySize = 10
+	const valueSize = (targetSize / numEntries) - keySize
+
+	for _, p := range "abc" {
+		sst, err := MakeRocksDBSstFileWriter()
+		if err != nil {
+			t.Fatal(sst)
+		}
+		defer sst.Close()
+
+		for i := 0; i < numEntries; i++ {
+			kv := MVCCKeyValue{
+				Key: MVCCKey{
+					Key: makeKey(string(p), i),
+				},
+				Value: randutil.RandBytes(rnd, valueSize),
+			}
+			if err := sst.Add(kv); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		sstContents, err := sst.Finish()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		filename := fmt.Sprintf("ingest")
+		if err := db.WriteFile(filename, sstContents); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := db.IngestExternalFile(context.Background(), filename, true, true); err != nil {
+			t.Fatal(err)
+		}
+		if testing.Verbose() {
+			fmt.Printf("ingested %s\n", string(p))
+		}
+	}
+
+	getSSTables := func() string {
+		ssts := db.GetSSTables()
+		sort.Slice(ssts, func(i, j int) bool {
+			a, b := ssts[i], ssts[j]
+			if a.Level < b.Level {
+				return true
+			}
+			if a.Level > b.Level {
+				return false
+			}
+			return a.Start.Less(b.Start)
+		})
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "\n")
+		for i := range ssts {
+			fmt.Fprintf(&buf, "%d: %s - %s\n",
+				ssts[i].Level, ssts[i].Start.Key, ssts[i].End.Key)
+		}
+		return buf.String()
+	}
+
+	verifySSTables := func(expected string) {
+		actual := getSSTables()
+		if expected != actual {
+			t.Fatalf("expected%sgot%s", expected, actual)
+		}
+		if testing.Verbose() {
+			fmt.Printf("%s", actual)
+		}
+	}
+
+	// After setup there should be 3 sstables.
+	verifySSTables(`
+6: "a000000000" - "a000009999"
+6: "b000000000" - "b000009999"
+6: "c000000000" - "c000009999"
+`)
+
+	// Generate a batch which writes to the very first key, and then deletes the
+	// range of keys covered by the last sstable.
+	batch := db.NewBatch()
+	if err := batch.Put(MakeMVCCMetadataKey(makeKey("a", 0)), []byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+	if err := batch.ClearRange(MakeMVCCMetadataKey(makeKey("c", 0)),
+		MakeMVCCMetadataKey(makeKey("c", numEntries))); err != nil {
+		t.Fatal(err)
+	}
+	if err := batch.Commit(true); err != nil {
+		t.Fatal(err)
+	}
+	batch.Close()
+	if err := db.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	// After flushing, there is a single additional L0 table that covers the
+	// entire key range.
+	verifySSTables(`
+0: "a000000000" - "c000010000"
+6: "a000000000" - "a000009999"
+6: "b000000000" - "b000009999"
+6: "c000000000" - "c000009999"
+`)
+
+	// Compacting the key range covering the last sstable should result in that
+	// sstable being deleted. Prior to the hack in dbClearRange, all of the
+	// sstables would be compacted resulting in 2 L6 sstables with different
+	// boundaries than the ones below.
+	_ = db.CompactRange(makeKey("c", 0), makeKey("c", numEntries), false)
+	verifySSTables(`
+5: "a000000000" - "a000000000"
+6: "a000000000" - "a000009999"
+6: "b000000000" - "b000009999"
+`)
+}


### PR DESCRIPTION
Backport 1/1 commits from #26576.

/cc @cockroachdb/release

---

Whenever we perform a ClearRange operation, also Clear the first key and
"last" key covered by the range tombstone. This allows the RocksDB
compaction code to generate better boundaries for sstables containing
range tombstones and avoids generating sstables which cover an
excessively large portion of the key space.

See #24029

Release note: None
