### PR TITLE
kv: fix intent tracking

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -126,12 +126,9 @@ type TxnCoordSender struct {
 	mu struct {
 		syncutil.Mutex
 
-		// tracking is set if the TxnCoordSender has a heartbeat loop running for
-		// the transaction record. It also means that the TxnCoordSender is
-		// accumulating intents for the transaction.
-		// tracking is set by the client just before a BeginTransaction request is
-		// sent. If set, an EndTransaction will also be sent eventually to clean up.
-		tracking bool
+		// hbRunning is set if the TxnCoordSender has a heartbeat loop running for
+		// the transaction record.
+		hbRunning bool
 
 		// meta contains all coordinator state which may be passed between
 		// distributed TxnCoordSenders via MetaRelease() and MetaAugment().
@@ -442,17 +439,13 @@ func (tc *TxnCoordSender) Send(
 
 		_, hasBegin := ba.GetArg(roachpb.BeginTransaction)
 		if hasBegin {
-			// If there's a BeginTransaction, we need to start the heartbeat loop and
-			// intent tracking.
+			// If there's a BeginTransaction, we need to start the heartbeat loop.
 			// Perhaps surprisingly, this needs to be done even if the batch has both
 			// a BeginTransaction and an EndTransaction. Although on batch success the
-			// heartbeat loop will be stopped right away, on error we might need both
-			// the intents and the heartbeat loop:
-			// - on retriable error, we need to keep around the intents for cleanup in
-			// subsequent epochs.
-			// - on non-retriable error, we need to keep around the intents as the
-			// client is expected to send an EndTransaction(commit=false) to cleanup.
-			if err := tc.startTracking(ctx); err != nil {
+			// heartbeat loop will be stopped right away, on retriable errors we need the
+			// heartbeat loop: the intents and txn record should be kept in place just
+			// like for non-1PC txns.
+			if err := tc.startHeartbeatLoop(ctx); err != nil {
 				return nil, roachpb.NewError(err)
 			}
 		}
@@ -1028,7 +1021,7 @@ func (tc *TxnCoordSender) heartbeatLoop(ctx context.Context) {
 			tc.mu.txnEnd = nil
 		}
 		duration, restarts, status := tc.finalTxnStatsLocked()
-		tc.mu.tracking = false
+		tc.mu.hbRunning = false
 		tc.mu.Unlock()
 		tc.updateStats(duration, restarts, status)
 	}()
@@ -1232,12 +1225,12 @@ func (tc *TxnCoordSender) heartbeat(ctx context.Context) bool {
 	return true
 }
 
-// startTracking starts a heartbeat loop and tracking of intents.
-func (tc *TxnCoordSender) startTracking(ctx context.Context) error {
+// startHeartbeatLoop starts a heartbeat loop in a different goroutine.
+func (tc *TxnCoordSender) startHeartbeatLoop(ctx context.Context) error {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 
-	tc.mu.tracking = true
+	tc.mu.hbRunning = true
 	tc.mu.firstUpdateNanos = tc.clock.PhysicalNow()
 
 	// Only heartbeat the txn record if we're the root transaction.
@@ -1269,7 +1262,7 @@ func (tc *TxnCoordSender) startTracking(ctx context.Context) error {
 func (tc *TxnCoordSender) IsTracking() bool {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
-	return tc.mu.tracking
+	return tc.mu.hbRunning
 }
 
 // updateState updates the transaction state in both the success and
@@ -1420,12 +1413,11 @@ func (tc *TxnCoordSender) updateState(
 	// a serializable retry error. We can use the set of read spans to
 	// avoid retrying the transaction if all the spans can be updated to
 	// the current transaction timestamp.
-	if tc.mu.tracking {
-		// Adding the intents even on error reduces the likelihood of dangling
-		// intents blocking concurrent writers for extended periods of time.
-		// See #3346.
-		tc.appendAndCondenseIntentsLocked(ctx, ba, br)
-	}
+	//
+	// Adding the intents even on error reduces the likelihood of dangling
+	// intents blocking concurrent writers for extended periods of time.
+	// See #3346.
+	tc.appendAndCondenseIntentsLocked(ctx, ba, br)
 
 	// Update our record of this transaction, even on error.
 	tc.mu.meta.Txn.Update(&newTxn)

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -1999,3 +1999,54 @@ func TestOnePCErrorTracking(t *testing.T) {
 		return nil
 	})
 }
+
+// Test that the TxnCoordSender accumulates intents even if it hasn't seen a
+// BeginTransaction. It didn't use to.
+// The TxnCoordSender can send (and get a response for) a write before it sees a
+// BeginTransaction because of racing requests going through the client.Txn. One
+// of them will get a BeginTransaction, but others might overtake it and get to
+// the TxnCoordSender first.
+func TestIntentTrackingBeforeBeginTransaction(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+	ambient := log.AmbientContext{Tracer: tracing.NewTracer()}
+	sender := &mockSender{}
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	factory := NewTxnCoordSenderFactory(
+		ambient,
+		cluster.MakeTestingClusterSettings(),
+		sender,
+		clock,
+		false, /* linearizable */
+		stopper,
+		MakeTxnMetrics(metric.TestSampleInterval),
+	)
+	key := roachpb.Key("a")
+	txn := roachpb.MakeTransaction(
+		"test txn",
+		key,
+		roachpb.UserPriority(0),
+		enginepb.SERIALIZABLE,
+		clock.Now(),
+		clock.MaxOffset().Nanoseconds(),
+	)
+	tcs := factory.New(client.RootTxn, &txn)
+	txnHeader := roachpb.Header{
+		Txn: &txn,
+	}
+	if _, pErr := client.SendWrappedWith(
+		ctx, tcs, txnHeader, &roachpb.PutRequest{
+			RequestHeader: roachpb.RequestHeader{
+				Key: key,
+			},
+		},
+	); pErr != nil {
+		t.Fatal(pErr)
+	}
+
+	if numSpans := len(tcs.GetMeta().Intents); numSpans != 1 {
+		t.Fatalf("expected 1 intent span, got: %d", numSpans)
+	}
+}


### PR DESCRIPTION
I've introduced a bug in #26497 - if there's concurrent writing requests
going though a single client.Txn, it can be that some of the intents
are not tracked correctly. Before this patch, intents started being
tracked when the TxnCoordSender sees a BeginTransaction. Even through
the client.Txn attaches an EndTransaction to the first writing requests
that it sees, a 2nd request might pass through and get to the
TxnCoordSender before that BeginTxn. In fact, it might even get a
response before the TxnCoordSender sees the BeginTxn, in which case we
wouldn't have recorded its intents.
This patch makes the TxnCoordSender track intents from all writing
requests. The BeginTxn doesn't matter for tracking intents any more. It
continues to matter for starting the heartbeat loop. We could
alternatively move to starting the hb loop when seeing the first write,
but I didn't do it.

Fixes #26538

Release note: None