### PR TITLE
opt: fix catalog behavior for primary index

### DIFF
--- a/pkg/sql/opt/catalog.go
+++ b/pkg/sql/opt/catalog.go
@@ -184,17 +184,22 @@ func FormatCatalogTable(tab Table, tp treeprinter.Node) {
 	}
 
 	for i := 0; i < tab.IndexCount(); i++ {
-		formatCatalogIndex(tab.Index(i), child)
+		formatCatalogIndex(tab.Index(i), i == PrimaryIndex, child)
 	}
 }
 
 // formatCatalogIndex nicely formats a catalog index using a treeprinter for
 // debugging and testing.
-func formatCatalogIndex(idx Index, tp treeprinter.Node) {
+func formatCatalogIndex(idx Index, isPrimary bool, tp treeprinter.Node) {
 	child := tp.Childf("INDEX %s", idx.IdxName())
 
 	var buf bytes.Buffer
-	for i := 0; i < idx.ColumnCount(); i++ {
+	colCount := idx.ColumnCount()
+	if isPrimary {
+		// Omit the "stored" columns from the primary index.
+		colCount = idx.UniqueColumnCount()
+	}
+	for i := 0; i < colCount; i++ {
 		buf.Reset()
 
 		idxCol := idx.Column(i)

--- a/pkg/sql/opt/memo/private_defs.go
+++ b/pkg/sql/opt/memo/private_defs.go
@@ -109,6 +109,9 @@ func (s *ScanOpDef) CanProvideOrdering(md *opt.Metadata, required props.Ordering
 	// TODO(andyk): Use UniqueColumnCount when issues with nulls are solved,
 	//              since unique index can still have duplicate nulls.
 	cnt := index.ColumnCount()
+	if s.Index == opt.PrimaryIndex {
+		cnt = index.UniqueColumnCount()
+	}
 	if len(required) < cnt {
 		cnt = len(required)
 	}

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -126,22 +126,6 @@ func (md *Metadata) IndexColumns(tableID TableID, indexOrdinal int) ColSet {
 	return indexCols
 }
 
-// IndexColumnsList returns the list of columns in the given index. The columns
-// are returned in the same order as they appear in the index.
-// TODO(justin): cache this value in the table metadata.
-func (md *Metadata) IndexColumnsList(tableID TableID, indexOrdinal int) ColList {
-	tab := md.Table(tableID)
-	index := tab.Index(indexOrdinal)
-
-	indexCols := make(ColList, index.ColumnCount())
-	for i := range indexCols {
-		ord := index.Column(i).Ordinal
-		indexCols[i] = md.TableColumn(tableID, ord)
-	}
-
-	return indexCols
-}
-
 // ColumnLabel returns the label of the given column. It is used for pretty-
 // printing and debugging.
 func (md *Metadata) ColumnLabel(id ColumnID) string {

--- a/pkg/sql/opt/xform/explorer.go
+++ b/pkg/sql/opt/xform/explorer.go
@@ -227,7 +227,11 @@ func (e *explorer) generateIndexScans(def memo.PrivateID) []memo.Expr {
 	md := e.mem.Metadata()
 	tab := md.Table(scanOpDef.Table)
 
-	pkCols := md.IndexColumnsList(scanOpDef.Table, opt.PrimaryIndex)
+	primaryIndex := md.Table(scanOpDef.Table).Index(opt.PrimaryIndex)
+	pkCols := make(opt.ColList, primaryIndex.UniqueColumnCount())
+	for i := range pkCols {
+		pkCols[i] = md.TableColumn(scanOpDef.Table, primaryIndex.Column(i).Ordinal)
+	}
 
 	// Iterate over all secondary indexes (index 0 is the primary index).
 	for i := 1; i < tab.IndexCount(); i++ {


### PR DESCRIPTION
The primary opt.Index has an odd behavior: the ColumnCount is just the
number of PK columns, unlike other indexes where it includes the
stored columns.

This change fixes this by special-casing the primary index in the
opt.Index implementation; it now acts as if the rest of the table
columns are stored columns.

Release note: None