### PR TITLE
libroach,storage/engine: move the clear range hack into C++

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2440,33 +2440,7 @@ func dbClear(rdb *C.DBEngine, key MVCCKey) error {
 }
 
 func dbClearRange(rdb *C.DBEngine, start, end MVCCKey) error {
-	if err := statusToError(C.DBDeleteRange(rdb, goToCKey(start), goToCKey(end))); err != nil {
-		return err
-	}
-	// This is a serious hack. RocksDB generates sstables which cover an
-	// excessively large amount of the key space when range tombstones are
-	// present. The crux of the problem is that the logic for determining sstable
-	// boundaries depends on actual keys being present. So we help that logic
-	// along by adding deletions of the first key covered by the range tombstone,
-	// and a key near the end of the range (previous is difficult). See
-	// TestRocksDBDeleteRangeCompaction which verifies that either this hack is
-	// working, or the upstream problem was fixed in RocksDB.
-	if err := dbClear(rdb, start); err != nil {
-		return err
-	}
-	prev := make(roachpb.Key, len(end.Key))
-	copy(prev, end.Key)
-	if n := len(prev) - 1; prev[n] > 0 {
-		prev[n]--
-	} else {
-		prev = prev[:n]
-	}
-	if start.Key.Compare(prev) < 0 {
-		if err := dbClear(rdb, MakeMVCCMetadataKey(prev)); err != nil {
-			return err
-		}
-	}
-	return nil
+	return statusToError(C.DBDeleteRange(rdb, goToCKey(start), goToCKey(end)))
 }
 
 func dbClearIterRange(rdb *C.DBEngine, iter Iterator, start, end MVCCKey) error {


### PR DESCRIPTION
Move the clear range hack into C++ and extend it to find actual keys for
the start and end key deletions instead of using the provided keys. This
works around two additional gotchas with RocksDB. See the comments in
code for more details.

Release note: None