### PR TITLE
ts: Enable Columnar Format with Cluster Version

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -59,6 +59,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>2.0-6</code></td><td>set the active cluster version in the format '<major>.<minor>'.</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>2.0-7</code></td><td>set the active cluster version in the format '<major>.<minor>'.</td></tr>
 </tbody>
 </table>

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -419,7 +419,7 @@ func TestReportUsage(t *testing.T) {
 		"diagnostics.reporting.send_crash_reports": "false",
 		"server.time_until_store_dead":             "1m30s",
 		"trace.debug.enable":                       "false",
-		"version":                                  "2.0-6",
+		"version":                                  "2.0-7",
 		"cluster.secret":                           "<redacted>",
 	} {
 		if got, ok := r.last.AlteredSettings[key]; !ok {

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -54,6 +54,7 @@ const (
 	VersionImportFormats
 	VersionSecondaryLookupJoins
 	VersionClientSideWritingFlag
+	VersionColumnarTimeSeries
 
 	// Add new versions here (step one of two).
 
@@ -225,6 +226,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// server. After, it is set only by the client.
 		Key:     VersionClientSideWritingFlag,
 		Version: roachpb.Version{Major: 2, Minor: 0, Unstable: 6},
+	},
+	{
+		// VersionColumnarTimeSeries is https://github.com/cockroachdb/cockroach/pull/26614.
+		Key:     VersionColumnarTimeSeries,
+		Version: roachpb.Version{Major: 2, Minor: 0, Unstable: 7},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -244,7 +244,7 @@ select crdb_internal.set_vmodule('')
 query T
 select crdb_internal.node_executable_version()
 ----
-2.0-6
+2.0-7
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -332,4 +332,4 @@ select * from crdb_internal.gossip_alerts
 query T
 select crdb_internal.node_executable_version()
 ----
-2.0-6
+2.0-7

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -227,7 +227,7 @@ func (tm *testModelRunner) storeInModel(r Resolution, data tspb.TimeSeriesData) 
 	}
 
 	key := resolutionModelKey(data.Name, r)
-	if tm.DB.writeColumnar {
+	if tm.DB.WriteColumnar() {
 		firstColumar, ok := tm.firstColumnarTimestamp[key]
 		if candidate := data.Datapoints[0].TimestampNanos; !ok || candidate < firstColumar {
 			tm.firstColumnarTimestamp[key] = candidate
@@ -349,7 +349,7 @@ func (tm *testModelRunner) makeQuery(
 			BudgetBytes:             math.MaxInt64 / 8,
 			EstimatedSources:        currentEstimatedSources,
 			InterpolationLimitNanos: 0,
-			Columnar:                tm.DB.writeColumnar,
+			Columnar:                tm.DB.WriteColumnar(),
 		},
 		diskResolution:   diskResolution,
 		workerMemMonitor: tm.workerMemMonitor,

--- a/pkg/ts/query_test.go
+++ b/pkg/ts/query_test.go
@@ -33,6 +33,7 @@ func runTestCaseMultipleFormats(t *testing.T, testCase func(*testing.T, testMode
 	t.Run("Row Format", func(t *testing.T) {
 		tm := newTestModelRunner(t)
 		tm.Start()
+		tm.DB.forceRowFormat = true
 		defer tm.Stop()
 		testCase(t, tm)
 	})
@@ -40,7 +41,6 @@ func runTestCaseMultipleFormats(t *testing.T, testCase func(*testing.T, testMode
 	t.Run("Column Format", func(t *testing.T) {
 		tm := newTestModelRunner(t)
 		tm.Start()
-		tm.DB.writeColumnar = true
 		defer tm.Stop()
 		testCase(t, tm)
 	})


### PR DESCRIPTION
Begin enabling the writing of columnar-formatted time series based on
the cluster version.  A new cluster version has been added to enable
this.

Release note (performance improvement): CockroachDB's internal
monitoring time series are now encoded using a more efficient on-disk
format to provide considerable space savings. Monitoring data written in
the old format will not be converted, but will still be queryable.