### PR TITLE
storage: up verbosity on log message

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -3396,7 +3396,9 @@ func (r *Replica) quiesce() bool {
 func (r *Replica) quiesceLocked() bool {
 	ctx := r.AnnotateCtx(context.TODO())
 	if len(r.mu.proposals) != 0 {
-		log.Infof(ctx, "not quiescing: %d pending commands", len(r.mu.proposals))
+		if log.V(3) {
+			log.Infof(ctx, "not quiescing: %d pending commands", len(r.mu.proposals))
+		}
 		return false
 	}
 	if !r.mu.quiescent {


### PR DESCRIPTION
I am not sure why this was logged at Info level in the first place.
I ran into this seeing it in production logs, around 91 times per 10mb
of log.

Release note: None