### PR TITLE
 sql,opt: propagate composite types (labeled tuples)

### DIFF
--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/pkg/errors"
@@ -325,11 +326,11 @@ func selectPartitionExprsByName(
 		return nil
 	}
 
-	var colVars tree.TypedExprs
+	var colVars tree.Exprs
 	{
 		// The recursive calls of selectPartitionExprsByName don't pass though
 		// the column ordinal references, so reconstruct them here.
-		colVars = make(tree.TypedExprs, len(prefixDatums)+int(partDesc.NumColumns))
+		colVars = make(tree.Exprs, len(prefixDatums)+int(partDesc.NumColumns))
 		for i := range colVars {
 			col, err := tableDesc.FindActiveColumnByID(idxDesc.ColumnIDs[i])
 			if err != nil {
@@ -363,7 +364,8 @@ func selectPartitionExprsByName(
 				// When len(allDatums) < len(colVars), the missing elements are DEFAULTs, so
 				// we can simply exclude them from the expr.
 				partValueExpr := tree.NewTypedComparisonExpr(tree.EQ,
-					tree.NewTypedTuple(colVars[:len(allDatums)]), tree.NewDTuple(allDatums...))
+					tree.NewTypedTuple(types.TTuple{}, colVars[:len(allDatums)]),
+					tree.NewDTuple(types.TTuple{}, allDatums...))
 				partValueExprs[len(t.Datums)] = append(partValueExprs[len(t.Datums)], exprAndPartName{
 					expr: partValueExpr,
 					name: l.Name,

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -27,8 +27,8 @@ SELECT 1 + (SELECT 1)
 ----
 2
 
-query error unsupported binary operator: <int> \+ <tuple{int, int}>
-SELECT 1 + (SELECT 1, 2)
+query error unsupported binary operator: <int> \+ <tuple{int AS a, int AS b}>
+SELECT 1 + (SELECT 1 AS a, 2 AS b)
 
 query B
 SELECT (1, 2, 3) IN (SELECT 1, 2, 3)
@@ -145,11 +145,11 @@ true
 query error pgcode 42601 subquery must return only one column, found 2
 SELECT (SELECT 1, 2)
 
-query error unsupported comparison operator: <int> IN <tuple{tuple{int, int}}>
-SELECT 1 IN (SELECT 1, 2)
+query error unsupported comparison operator: <int> IN <tuple{tuple{int AS a, int AS b}}>
+SELECT 1 IN (SELECT 1 AS a, 2 AS b)
 
 query error unsupported comparison operator: <tuple{int, int}> IN <tuple{int}>
-SELECT (1, 2) IN (SELECT 1)
+SELECT (1, 2) IN (SELECT 1 AS a)
 
 statement ok
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
@@ -160,7 +160,7 @@ INSERT INTO abc VALUES (1, 2, 3), (4, 5, 6)
 statement ok
 ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))
 
-query error unsupported comparison operator: <tuple{int, int}> IN <tuple{tuple{int, int, int}}>
+query error unsupported comparison operator: <tuple{int, int}> IN <tuple{tuple{int AS a, int AS b, int AS c}}>
 SELECT (1, 2) IN (SELECT * FROM abc)
 
 query B

--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -114,7 +114,7 @@ func (b *Builder) buildTuple(ctx *buildScalarCtx, ev memo.ExprView) (tree.TypedE
 		return memo.ExtractConstDatum(ev), nil
 	}
 
-	typedExprs := make([]tree.TypedExpr, ev.ChildCount())
+	typedExprs := make(tree.Exprs, ev.ChildCount())
 	var err error
 	for i := 0; i < ev.ChildCount(); i++ {
 		typedExprs[i], err = b.buildScalar(ctx, ev.Child(i))
@@ -122,7 +122,8 @@ func (b *Builder) buildTuple(ctx *buildScalarCtx, ev memo.ExprView) (tree.TypedE
 			return nil, err
 		}
 	}
-	return tree.NewTypedTuple(typedExprs), nil
+	typ := ev.Logical().Scalar.Type.(types.TTuple)
+	return tree.NewTypedTuple(typ, typedExprs), nil
 }
 
 func (b *Builder) buildBoolean(ctx *buildScalarCtx, ev memo.ExprView) (tree.TypedExpr, error) {

--- a/pkg/sql/opt/memo/extract.go
+++ b/pkg/sql/opt/memo/extract.go
@@ -45,7 +45,8 @@ func ExtractConstDatum(ev ExprView) tree.Datum {
 		for i := range datums {
 			datums[i] = ExtractConstDatum(ev.Child(i))
 		}
-		return tree.NewDTuple(datums...)
+		typ := ev.Logical().Scalar.Type.(types.TTuple)
+		return tree.NewDTuple(typ, datums...)
 
 	case opt.ArrayOp:
 		elementType := ev.Logical().Scalar.Type.(types.TArray).Typ

--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -119,14 +119,14 @@ select
  │    └── keys: (1)
  └── filters [type=bool, outer=(1,2)]
       └── eq [type=bool, outer=(1,2)]
-           ├── subquery [type=tuple{int, int}, outer=(1,2)]
+           ├── subquery [type=tuple{int AS x, int AS u}, outer=(1,2)]
            │    └── max1-row
-           │         ├── columns: column13:13(tuple{int, int})
+           │         ├── columns: column13:13(tuple{int AS x, int AS u})
            │         ├── outer: (1,2)
            │         ├── cardinality: [0 - 1]
            │         ├── stats: [rows=1]
            │         └── project
-           │              ├── columns: column13:13(tuple{int, int})
+           │              ├── columns: column13:13(tuple{int AS x, int AS u})
            │              ├── outer: (1,2)
            │              ├── stats: [rows=1400]
            │              ├── union

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -668,7 +668,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column3:3(tuple{int, int})
+           │    ├── columns: column3:3(tuple{int AS a, int AS b})
            │    ├── values
            │    │    ├── columns: column1:1(int) column2:2(int)
            │    │    └── tuple [type=tuple{int, int}]
@@ -711,7 +711,7 @@ project
       └── not [type=bool]
            └── any: eq [type=bool]
                 ├── project
-                │    ├── columns: column3:3(tuple{int, int})
+                │    ├── columns: column3:3(tuple{int AS a, int AS b})
                 │    ├── values
                 │    │    ├── columns: column1:1(int) column2:2(int)
                 │    │    └── tuple [type=tuple{int, int}]
@@ -759,7 +759,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column3:3(tuple{int, int})
+           │    ├── columns: column3:3(tuple{int AS a, int AS b})
            │    ├── select
            │    │    ├── columns: column1:1(int!null) column2:2(int)
            │    │    ├── values
@@ -814,7 +814,7 @@ project
       └── not [type=bool]
            └── any: eq [type=bool]
                 ├── project
-                │    ├── columns: column3:3(tuple{int, int})
+                │    ├── columns: column3:3(tuple{int AS a, int AS b})
                 │    ├── select
                 │    │    ├── columns: column1:1(int!null) column2:2(int)
                 │    │    ├── values
@@ -869,7 +869,7 @@ project
       └── not [type=bool]
            └── any: eq [type=bool]
                 ├── project
-                │    ├── columns: column3:3(tuple{int, int})
+                │    ├── columns: column3:3(tuple{int AS a, int AS b})
                 │    ├── select
                 │    │    ├── columns: column1:1(int!null) column2:2(int)
                 │    │    ├── values
@@ -924,7 +924,7 @@ project
       └── not [type=bool]
            └── any: eq [type=bool]
                 ├── project
-                │    ├── columns: column3:3(tuple{int, int})
+                │    ├── columns: column3:3(tuple{int AS a, int AS b})
                 │    ├── select
                 │    │    ├── columns: column1:1(int!null) column2:2(int)
                 │    │    ├── values

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -80,9 +80,9 @@ project
                                └── const: 1 [type=int]
 
 build
-SELECT 1 + (SELECT 1, 2) AS r
+SELECT 1 + (SELECT 1 AS a, 2 AS b) AS r
 ----
-error (22023): unsupported binary operator: <int> + <tuple{int, int}>
+error (22023): unsupported binary operator: <int> + <tuple{int AS a, int AS b}>
 
 build
 SELECT (1, 2, 3) IN (SELECT 1 AS a, 2 AS b, 3 AS c) AS r
@@ -94,7 +94,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column4:4(tuple{int, int, int})
+           │    ├── columns: column4:4(tuple{int AS a, int AS b, int AS c})
            │    ├── project
            │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
            │    │    ├── values
@@ -126,11 +126,11 @@ project
            │    ├── const: 1 [type=int]
            │    ├── const: 2 [type=int]
            │    └── const: 3 [type=int]
-           └── subquery [type=tuple{int, int, int}]
+           └── subquery [type=tuple{int AS a, int AS b, int AS c}]
                 └── max1-row
-                     ├── columns: column4:4(tuple{int, int, int})
+                     ├── columns: column4:4(tuple{int AS a, int AS b, int AS c})
                      └── project
-                          ├── columns: column4:4(tuple{int, int, int})
+                          ├── columns: column4:4(tuple{int AS a, int AS b, int AS c})
                           ├── project
                           │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
                           │    ├── values
@@ -158,11 +158,11 @@ project
            │    ├── const: 1 [type=int]
            │    ├── const: 2 [type=int]
            │    └── const: 3 [type=int]
-           └── subquery [type=tuple{int, int, int}]
+           └── subquery [type=tuple{int AS a, int AS b, int AS c}]
                 └── max1-row
-                     ├── columns: column4:4(tuple{int, int, int})
+                     ├── columns: column4:4(tuple{int AS a, int AS b, int AS c})
                      └── project
-                          ├── columns: column4:4(tuple{int, int, int})
+                          ├── columns: column4:4(tuple{int AS a, int AS b, int AS c})
                           ├── project
                           │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
                           │    ├── values
@@ -186,11 +186,11 @@ project
  │    └── tuple [type=tuple{}]
  └── projections
       └── eq [type=bool]
-           ├── subquery [type=tuple{int, int, int}]
+           ├── subquery [type=tuple{int AS x, int AS y, int AS z}]
            │    └── max1-row
-           │         ├── columns: column7:7(tuple{int, int, int})
+           │         ├── columns: column7:7(tuple{int AS x, int AS y, int AS z})
            │         └── project
-           │              ├── columns: column7:7(tuple{int, int, int})
+           │              ├── columns: column7:7(tuple{int AS x, int AS y, int AS z})
            │              ├── project
            │              │    ├── columns: x:1(int!null) y:2(int!null) z:3(int!null)
            │              │    ├── values
@@ -204,11 +204,11 @@ project
            │                        ├── variable: x [type=int]
            │                        ├── variable: y [type=int]
            │                        └── variable: z [type=int]
-           └── subquery [type=tuple{int, int, int}]
+           └── subquery [type=tuple{int AS a, int AS b, int AS c}]
                 └── max1-row
-                     ├── columns: column8:8(tuple{int, int, int})
+                     ├── columns: column8:8(tuple{int AS a, int AS b, int AS c})
                      └── project
-                          ├── columns: column8:8(tuple{int, int, int})
+                          ├── columns: column8:8(tuple{int AS a, int AS b, int AS c})
                           ├── project
                           │    ├── columns: a:4(int!null) b:5(int!null) c:6(int!null)
                           │    ├── values
@@ -289,7 +289,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column5:5(tuple{int, int})
+           │    ├── columns: column5:5(tuple{int AS c, int AS d})
            │    ├── project
            │    │    ├── columns: c:1(int!null) d:2(int!null)
            │    │    ├── values
@@ -301,11 +301,11 @@ project
            │         └── tuple [type=tuple{int, int}]
            │              ├── variable: c [type=int]
            │              └── variable: d [type=int]
-           └── subquery [type=tuple{int, int}]
+           └── subquery [type=tuple{int AS a, int AS b}]
                 └── max1-row
-                     ├── columns: column6:6(tuple{int, int})
+                     ├── columns: column6:6(tuple{int AS a, int AS b})
                      └── project
-                          ├── columns: column6:6(tuple{int, int})
+                          ├── columns: column6:6(tuple{int AS a, int AS b})
                           ├── project
                           │    ├── columns: a:3(int!null) b:4(int!null)
                           │    ├── values
@@ -331,11 +331,11 @@ project
  │    └── tuple [type=tuple{}]
  └── projections
       └── in [type=bool]
-           ├── subquery [type=tuple{int, int}]
+           ├── subquery [type=tuple{int AS a, int AS b}]
            │    └── max1-row
-           │         ├── columns: column3:3(tuple{int, int})
+           │         ├── columns: column3:3(tuple{int AS a, int AS b})
            │         └── project
-           │              ├── columns: column3:3(tuple{int, int})
+           │              ├── columns: column3:3(tuple{int AS a, int AS b})
            │              ├── project
            │              │    ├── columns: a:1(int!null) b:2(int!null)
            │              │    ├── values
@@ -366,7 +366,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column4:4(tuple{int, int})
+           │    ├── columns: column4:4(tuple{int AS b, int AS c})
            │    ├── project
            │    │    ├── columns: b:1(int!null) c:2(int!null)
            │    │    ├── values
@@ -436,11 +436,11 @@ project
            │         └── tuple [type=tuple{int, int}]
            │              ├── const: 1 [type=int]
            │              └── const: 2 [type=int]
-           └── subquery [type=tuple{int, int}]
+           └── subquery [type=tuple{int AS a, int AS b}]
                 └── max1-row
-                     ├── columns: column4:4(tuple{int, int})
+                     ├── columns: column4:4(tuple{int AS a, int AS b})
                      └── project
-                          ├── columns: column4:4(tuple{int, int})
+                          ├── columns: column4:4(tuple{int AS a, int AS b})
                           ├── project
                           │    ├── columns: a:2(int!null) b:3(int!null)
                           │    ├── values
@@ -509,7 +509,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column3:3(tuple{int, int})
+           │    ├── columns: column3:3(tuple{int AS a, int AS b})
            │    ├── project
            │    │    ├── columns: a:1(int!null) b:2(int!null)
            │    │    ├── values
@@ -552,7 +552,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column3:3(tuple{int, int})
+           │    ├── columns: column3:3(tuple{int AS a, int AS b})
            │    ├── project
            │    │    ├── columns: a:1(int!null) b:2(int!null)
            │    │    ├── values
@@ -597,7 +597,7 @@ project
       └── not [type=bool]
            └── any: ne [type=bool]
                 ├── project
-                │    ├── columns: column3:3(tuple{int, int})
+                │    ├── columns: column3:3(tuple{int AS a, int AS b})
                 │    ├── project
                 │    │    ├── columns: a:1(int!null) b:2(int!null)
                 │    │    ├── values
@@ -621,7 +621,7 @@ error (42601): subquery must return only one column, found 2
 build
 SELECT 1 IN (SELECT 1 AS a, 2 AS b) AS r
 ----
-error (22023): unsupported comparison operator: <int> IN <tuple{tuple{int, int}}>
+error (22023): unsupported comparison operator: <int> IN <tuple{tuple{int AS a, int AS b}}>
 
 build
 SELECT (1, 2) IN (SELECT 1 AS a) AS r
@@ -641,7 +641,7 @@ TABLE abc
 build
 SELECT (1, 2) IN (SELECT * FROM abc) AS r
 ----
-error (22023): unsupported comparison operator: <tuple{int, int}> IN <tuple{tuple{int, int, int}}>
+error (22023): unsupported comparison operator: <tuple{int, int}> IN <tuple{tuple{int AS a, int AS b, int AS c}}>
 
 build
 SELECT (1, 2) IN (SELECT a, b FROM abc) AS r
@@ -653,7 +653,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column4:4(tuple{int, int})
+           │    ├── columns: column4:4(tuple{int AS a, int AS b})
            │    ├── project
            │    │    ├── columns: a:1(int!null) b:2(int)
            │    │    └── scan abc
@@ -676,7 +676,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column4:4(tuple{int, int})
+           │    ├── columns: column4:4(tuple{int AS a, int AS b})
            │    ├── project
            │    │    ├── columns: a:1(int!null) b:2(int)
            │    │    └── select

--- a/pkg/sql/opt/optbuilder/testdata/where
+++ b/pkg/sql/opt/optbuilder/testdata/where
@@ -76,7 +76,7 @@ select
  └── filters [type=bool]
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column5:5(tuple{int, int})
+           │    ├── columns: column5:5(tuple{int AS k, int AS v})
            │    ├── scan kv
            │    │    └── columns: kv.k:3(int!null) kv.v:4(int)
            │    └── projections

--- a/pkg/sql/opt_decompose.go
+++ b/pkg/sql/opt_decompose.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 // splitOrExpr flattens a tree of OR expressions returning all of the child
@@ -708,7 +709,7 @@ func simplifyOneAndInExpr(
 				return tree.NewTypedComparisonExpr(
 					tree.In,
 					left.TypedLeft(),
-					tree.NewDTuple(values...).SetSorted(),
+					tree.NewDTuple(types.TTuple{}, values...).SetSorted(),
 				), nil
 
 			case tree.GT:
@@ -722,7 +723,7 @@ func simplifyOneAndInExpr(
 						return tree.NewTypedComparisonExpr(
 							tree.In,
 							left.TypedLeft(),
-							tree.NewDTuple(values...).SetSorted(),
+							tree.NewDTuple(types.TTuple{}, values...).SetSorted(),
 						), nil
 					}
 				}
@@ -735,7 +736,7 @@ func simplifyOneAndInExpr(
 						return tree.NewTypedComparisonExpr(
 							tree.In,
 							left.TypedLeft(),
-							tree.NewDTuple(values...).SetSorted(),
+							tree.NewDTuple(types.TTuple{}, values...).SetSorted(),
 						), nil
 					}
 				}
@@ -750,7 +751,7 @@ func simplifyOneAndInExpr(
 					return tree.NewTypedComparisonExpr(
 						tree.In,
 						left.TypedLeft(),
-						tree.NewDTuple(values...).SetSorted(),
+						tree.NewDTuple(types.TTuple{}, values...).SetSorted(),
 					), nil
 				}
 				return left, nil
@@ -767,7 +768,7 @@ func simplifyOneAndInExpr(
 					return tree.NewTypedComparisonExpr(
 						tree.In,
 						left.TypedLeft(),
-						tree.NewDTuple(values...).SetSorted(),
+						tree.NewDTuple(types.TTuple{}, values...).SetSorted(),
 					), nil
 				}
 				return left, nil
@@ -783,7 +784,7 @@ func simplifyOneAndInExpr(
 			return tree.NewTypedComparisonExpr(
 				tree.In,
 				left.TypedLeft(),
-				tree.NewDTuple(intersection...).SetSorted(),
+				tree.NewDTuple(types.TTuple{}, intersection...).SetSorted(),
 			), nil
 		}
 	}
@@ -947,7 +948,7 @@ func simplifyOneOrExpr(
 			return tree.NewTypedComparisonExpr(
 				tree.In,
 				lcmpLeft,
-				tree.NewDTuple(ldatum, rdatum).SetSorted(),
+				tree.NewDTuple(types.TTuple{}, ldatum, rdatum).SetSorted(),
 			), nil, true
 		case tree.NE:
 			// a = x OR a != y
@@ -1284,7 +1285,7 @@ func simplifyOneOrInExpr(
 			return tree.NewTypedComparisonExpr(
 				tree.In,
 				left.TypedLeft(),
-				tree.NewDTuple(merged...).SetSorted(),
+				tree.NewDTuple(types.TTuple{}, merged...).SetSorted(),
 			), nil
 
 		case tree.NE, tree.GT, tree.GE, tree.LT, tree.LE:
@@ -1346,7 +1347,7 @@ func simplifyOneOrInExpr(
 			return tree.NewTypedComparisonExpr(
 				tree.In,
 				left.TypedLeft(),
-				tree.NewDTuple(merged...).SetSorted(),
+				tree.NewDTuple(types.TTuple{}, merged...).SetSorted(),
 			), nil
 		}
 	}
@@ -1388,7 +1389,7 @@ func simplifyComparisonExpr(
 				return tree.NewTypedComparisonExpr(
 					tree.In,
 					left,
-					tree.NewDTuple(right.(tree.Datum)).SetSorted(),
+					tree.NewDTuple(types.TTuple{}, right.(tree.Datum)).SetSorted(),
 				), true
 			}
 			return n, true

--- a/pkg/sql/pgwire/types_test.go
+++ b/pkg/sql/pgwire/types_test.go
@@ -307,7 +307,7 @@ func benchmarkWriteTuple(b *testing.B, format pgwirebase.FormatCode) {
 	i := tree.NewDInt(1234)
 	f := tree.NewDFloat(12.34)
 	s := tree.NewDString("testing")
-	t := tree.NewDTuple(i, f, s)
+	t := tree.NewDTuple(types.TTuple{}, i, f, s)
 	benchmarkWriteType(b, t, format)
 }
 

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -2473,24 +2473,36 @@ func (d *DJSON) Size() uintptr {
 type DTuple struct {
 	D Datums
 
+	// sorted indicates that the values in D are pre-sorted.
+	// This is used to accelerate IN comparisons.
 	sorted bool
+
+	// typ is the tuple's type.
+	//
+	// The Types sub-field can be initially uninitialized, and is then
+	// populated upon first invocation of ResolvedTypes(). If
+	// initialized it must have the same arity as D.
+	//
+	// The Labels sub-field can be left nil. If populated, it must have
+	// the same arity as D.
+	//
+	// TODO(knz): this ought to be a pointer when #26680 is resolved.
+	// Also when it becomes a pointer a nil value should be valid and
+	// the tuple type auto-computed when ResolvedType() is called the
+	// first time.
+	typ types.TTuple
 }
 
 // NewDTuple creates a *DTuple with the provided datums. When creating a new
 // DTuple with Datums that are known to be sorted in ascending order, chain
 // this call with DTuple.SetSorted.
-func NewDTuple(d ...Datum) *DTuple {
-	return &DTuple{D: d}
+func NewDTuple(typ types.TTuple, d ...Datum) *DTuple {
+	return &DTuple{D: d, typ: typ}
 }
 
 // NewDTupleWithLen creates a *DTuple with the provided length.
-func NewDTupleWithLen(l int) *DTuple {
-	return &DTuple{D: make(Datums, l)}
-}
-
-// NewDTupleWithCap creates a *DTuple with the provided capacity.
-func NewDTupleWithCap(c int) *DTuple {
-	return &DTuple{D: make(Datums, 0, c)}
+func NewDTupleWithLen(typ types.TTuple, l int) *DTuple {
+	return &DTuple{D: make(Datums, l), typ: typ}
 }
 
 // AsDTuple attempts to retrieve a *DTuple from an Expr, returning a *DTuple and
@@ -2509,11 +2521,13 @@ func AsDTuple(e Expr) (*DTuple, bool) {
 
 // ResolvedType implements the TypedExpr interface.
 func (d *DTuple) ResolvedType() types.T {
-	typ := types.TTuple{Types: make([]types.T, len(d.D))}
-	for i, v := range d.D {
-		typ.Types[i] = v.ResolvedType()
+	if d.typ.Types == nil {
+		d.typ.Types = make([]types.T, len(d.D))
+		for i, v := range d.D {
+			d.typ.Types[i] = v.ResolvedType()
+		}
 	}
-	return typ
+	return d.typ
 }
 
 // Compare implements the Datum interface.
@@ -2556,7 +2570,7 @@ func (d *DTuple) Prev(ctx *EvalContext) (Datum, bool) {
 	// zero or more values that are a minimum and a maximum value of the
 	// same type exists, and the first element before that has a prev
 	// value.
-	res := NewDTupleWithLen(len(d.D))
+	res := NewDTupleWithLen(d.typ, len(d.D))
 	copy(res.D, d.D)
 	for i := len(res.D) - 1; i >= 0; i-- {
 		if !res.D[i].IsMin(ctx) {
@@ -2587,7 +2601,7 @@ func (d *DTuple) Next(ctx *EvalContext) (Datum, bool) {
 	// zero or more values that are a maximum and a minimum value of the
 	// same type exists, and the first element before that has a next
 	// value.
-	res := NewDTupleWithLen(len(d.D))
+	res := NewDTupleWithLen(d.typ, len(d.D))
 	copy(res.D, d.D)
 	for i := len(res.D) - 1; i >= 0; i-- {
 		if !res.D[i].IsMax(ctx) {
@@ -2606,7 +2620,7 @@ func (d *DTuple) Next(ctx *EvalContext) (Datum, bool) {
 
 // Max implements the Datum interface.
 func (d *DTuple) Max(ctx *EvalContext) (Datum, bool) {
-	res := NewDTupleWithLen(len(d.D))
+	res := NewDTupleWithLen(d.typ, len(d.D))
 	for i, v := range d.D {
 		m, ok := v.Max(ctx)
 		if !ok {
@@ -2619,7 +2633,7 @@ func (d *DTuple) Max(ctx *EvalContext) (Datum, bool) {
 
 // Min implements the Datum interface.
 func (d *DTuple) Min(ctx *EvalContext) (Datum, bool) {
-	res := NewDTupleWithLen(len(d.D))
+	res := NewDTupleWithLen(d.typ, len(d.D))
 	for i, v := range d.D {
 		m, ok := v.Min(ctx)
 		if !ok {
@@ -2655,6 +2669,7 @@ func (*DTuple) AmbiguousFormat() bool { return false }
 
 // Format implements the NodeFormatter interface.
 // TODO(bram): We don't format tuples in the same way as postgres. See #25522.
+// TODO(knz): this is broken if the tuple is labeled. See #26624.
 func (d *DTuple) Format(ctx *FmtCtx) {
 	if ctx.HasFlags(FmtParsable) && (len(d.D) == 0) {
 		ctx.WriteString("ROW()")

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3483,7 +3483,7 @@ func (expr *FuncExpr) EvalArgsAndGetGenerator(ctx *EvalContext) (ValueGenerator,
 }
 
 // evalArgs evaluates just the function application's arguments.
-// A 1st result bool true indicates NULL should be propagated.
+// The returned bool indicates that the NULL should be propagated.
 func (expr *FuncExpr) evalArgs(ctx *EvalContext) (bool, Datums, error) {
 	args := make(Datums, len(expr.Exprs))
 	for i, e := range expr.Exprs {
@@ -3726,13 +3726,13 @@ func (expr *ColumnItem) Eval(ctx *EvalContext) (Datum, error) {
 
 // Eval implements the TypedExpr interface.
 func (t *Tuple) Eval(ctx *EvalContext) (Datum, error) {
-	tuple := NewDTupleWithCap(len(t.Exprs))
-	for _, v := range t.Exprs {
+	tuple := NewDTupleWithLen(t.typ, len(t.Exprs))
+	for i, v := range t.Exprs {
 		d, err := v.(TypedExpr).Eval(ctx)
 		if err != nil {
 			return nil, err
 		}
-		tuple.D = append(tuple.D, d)
+		tuple.D[i] = d
 	}
 	return tuple, nil
 }

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -730,20 +730,15 @@ type Tuple struct {
 	// ROW ( ... ).
 	Row bool
 
-	types types.TTuple
+	typ types.TTuple
 }
 
 // NewTypedTuple returns a new Tuple that is verified to be well-typed.
-func NewTypedTuple(typedExprs TypedExprs) *Tuple {
-	node := &Tuple{
-		Exprs: make(Exprs, len(typedExprs)),
-		types: types.TTuple{Types: make([]types.T, len(typedExprs))},
+func NewTypedTuple(typ types.TTuple, typedExprs Exprs) *Tuple {
+	return &Tuple{
+		Exprs: typedExprs,
+		typ:   typ,
 	}
-	for i := range typedExprs {
-		node.Exprs[i] = typedExprs[i].(Expr)
-		node.types.Types[i] = typedExprs[i].ResolvedType()
-	}
-	return node
 }
 
 // Format implements the NodeFormatter interface.
@@ -773,7 +768,7 @@ func (node *Tuple) Format(ctx *FmtCtx) {
 
 // ResolvedType implements the TypedExpr interface.
 func (node *Tuple) ResolvedType() types.T {
-	return node.types
+	return node.typ
 }
 
 // Truncate returns a new Tuple that contains only a prefix of the original
@@ -784,7 +779,7 @@ func (node *Tuple) Truncate(prefix int) *Tuple {
 	return &Tuple{
 		Exprs: append(Exprs(nil), node.Exprs[:prefix]...),
 		Row:   node.Row,
-		types: types.TTuple{Types: append([]types.T(nil), node.types.Types[:prefix]...)},
+		typ:   types.TTuple{Types: append([]types.T(nil), node.typ.Types[:prefix]...)},
 	}
 }
 
@@ -796,11 +791,11 @@ func (node *Tuple) Project(set util.FastIntSet) *Tuple {
 	t := &Tuple{
 		Exprs: make(Exprs, 0, set.Len()),
 		Row:   node.Row,
-		types: types.TTuple{Types: make([]types.T, 0, set.Len())},
+		typ:   types.TTuple{Types: make([]types.T, 0, set.Len())},
 	}
 	for i, ok := set.Next(0); ok; i, ok = set.Next(i + 1) {
 		t.Exprs = append(t.Exprs, node.Exprs[i])
-		t.types.Types = append(t.types.Types, node.types.Types[i])
+		t.typ.Types = append(t.typ.Types, node.typ.Types[i])
 	}
 	return t
 }

--- a/pkg/sql/sem/tree/normalize_test.go
+++ b/pkg/sql/sem/tree/normalize_test.go
@@ -234,6 +234,12 @@ func TestNormalizeExpr(t *testing.T) {
 		{`j->'s' = jv`, `(j->'s') = jv`},
 		{`j->s = jv`, `(j->s) = jv`},
 		{`j->2 = '"jv"'::JSONB`, `(j->2) = '"jv"'`},
+		// We want to check that constant-folded tuples preserve their
+		// labels.  However unfortunately the pretty-printed repr of a
+		// tuple does not include the labels. So use pg_typeof to reveal
+		// them.
+		// TODO(knz): simplify this when bug #26624 is solved.
+		{`pg_typeof((ROW (1) AS a))`, `'tuple{int AS a}'`},
 	}
 
 	semaCtx := tree.MakeSemaContext(true /* privileged */)

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1016,7 +1016,7 @@ func (expr *Tuple) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, erro
 		)
 	}
 
-	expr.types = types.TTuple{Types: make([]types.T, len(expr.Exprs))}
+	expr.typ = types.TTuple{Types: make([]types.T, len(expr.Exprs))}
 	for i, subExpr := range expr.Exprs {
 		desiredElem := types.Any
 		if t, ok := desired.(types.TTuple); ok && len(t.Types) > i {
@@ -1027,7 +1027,7 @@ func (expr *Tuple) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, erro
 			return nil, err
 		}
 		expr.Exprs[i] = typedExpr
-		expr.types.Types[i] = typedExpr.ResolvedType()
+		expr.typ.Types[i] = typedExpr.ResolvedType()
 	}
 	// Copy the labels if there are any.
 	if len(expr.Labels) > 0 {
@@ -1042,9 +1042,9 @@ func (expr *Tuple) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, erro
 			}
 		}
 
-		expr.types.Labels = make([]string, len(expr.Labels))
+		expr.typ.Labels = make([]string, len(expr.Labels))
 		for i := range expr.Labels {
-			expr.types.Labels[i] = lex.NormalizeName(expr.Labels[i])
+			expr.typ.Labels[i] = lex.NormalizeName(expr.Labels[i])
 		}
 	}
 	return expr, nil
@@ -1229,7 +1229,7 @@ func typeCheckAndRequireTupleElems(
 	ctx *SemaContext, expr Expr, required types.T,
 ) (TypedExpr, error) {
 	tuple := expr.(*Tuple)
-	tuple.types = types.TTuple{Types: make([]types.T, len(tuple.Exprs))}
+	tuple.typ = types.TTuple{Types: make([]types.T, len(tuple.Exprs))}
 	for i, subExpr := range tuple.Exprs {
 		// Require that the sub expression is equivalent (or may be inferred) to the required type.
 		typedExpr, err := typeCheckAndRequire(ctx, subExpr, required, "tuple element")
@@ -1237,7 +1237,7 @@ func typeCheckAndRequireTupleElems(
 			return nil, err
 		}
 		tuple.Exprs[i] = typedExpr
-		tuple.types.Types[i] = typedExpr.ResolvedType()
+		tuple.typ.Types[i] = typedExpr.ResolvedType()
 	}
 	return tuple, nil
 }
@@ -1434,10 +1434,10 @@ func typeCheckComparisonOp(
 		typedLeft := typedSubExprs[0]
 		typedSubExprs = typedSubExprs[1:]
 
-		rightTuple.types = types.TTuple{Types: make([]types.T, len(typedSubExprs))}
+		rightTuple.typ = types.TTuple{Types: make([]types.T, len(typedSubExprs))}
 		for i, typedExpr := range typedSubExprs {
 			rightTuple.Exprs[i] = typedExpr
-			rightTuple.types.Types[i] = retType
+			rightTuple.typ.Types[i] = retType
 		}
 		if switched {
 			return rightTuple, typedLeft, fn, false, nil
@@ -1747,8 +1747,8 @@ func typeCheckTupleComparison(
 	if err := checkTupleHasLength(right, tupLen); err != nil {
 		return nil, nil, err
 	}
-	left.types = types.TTuple{Types: make([]types.T, tupLen)}
-	right.types = types.TTuple{Types: make([]types.T, tupLen)}
+	left.typ = types.TTuple{Types: make([]types.T, tupLen)}
+	right.typ = types.TTuple{Types: make([]types.T, tupLen)}
 	for elemIdx := range left.Exprs {
 		leftSubExpr := left.Exprs[elemIdx]
 		rightSubExpr := right.Exprs[elemIdx]
@@ -1759,9 +1759,9 @@ func typeCheckTupleComparison(
 				&exps, elemIdx+1, err)
 		}
 		left.Exprs[elemIdx] = leftSubExprTyped
-		left.types.Types[elemIdx] = leftSubExprTyped.ResolvedType()
+		left.typ.Types[elemIdx] = leftSubExprTyped.ResolvedType()
 		right.Exprs[elemIdx] = rightSubExprTyped
-		right.types.Types[elemIdx] = rightSubExprTyped.ResolvedType()
+		right.typ.Types[elemIdx] = rightSubExprTyped.ResolvedType()
 	}
 	return left, right, nil
 }
@@ -1818,7 +1818,7 @@ func typeCheckSameTypedTupleExprs(
 		resTypes.Types[elemIdx] = resType
 	}
 	for tupleIdx, expr := range exprs {
-		expr.(*Tuple).types = resTypes
+		expr.(*Tuple).typ = resTypes
 		typedExprs[tupleIdx] = expr.(TypedExpr)
 	}
 	return typedExprs, resTypes, nil


### PR DESCRIPTION
Needed to resolve #24866.

This patch adds more complete support for composite types (labeled
tuples) by ensuring the following:

- tuple labels are preserved during constant folding of tuple
  expressions.
- tuple labels are preserved during expression transformations
  in optimizations.
- subqueries in scalar contexts receive a composite type with labels.

Note that there is currently a bug in DTuple serialization which break
composite literals in distributed execution, so the composite type
support is not fully ready yet.
This is tracked as separate bug #26624.

Release note: None