### PR TITLE
opt: make data-driven tests emit file info on own line

### DIFF
--- a/pkg/testutils/datadriven/datadriven.go
+++ b/pkg/testutils/datadriven/datadriven.go
@@ -89,9 +89,9 @@ func RunTest(t *testing.T, path string, f func(d *TestData) string) {
 				r.emit(actual)
 			}
 		} else if d.Expected != actual {
-			t.Fatalf("%s: %s\nexpected:\n%s\nfound:\n%s", d.Pos, d.Input, d.Expected, actual)
+			t.Fatalf("\n%s: %s\nexpected:\n%s\nfound:\n%s", d.Pos, d.Input, d.Expected, actual)
 		} else if testing.Verbose() {
-			fmt.Printf("%s:\n%s\n----\n%s", d.Pos, d.Input, actual)
+			fmt.Printf("\n%s:\n%s\n----\n%s", d.Pos, d.Input, actual)
 		}
 	}
 


### PR DESCRIPTION
This patch ensures that error messages produced by datadriven.go place
the position information on its own line. This is necessary because
some editors / IDEs only recognize error location information when it
is not prefixed.

Release note: None