### PR TITLE
sql: Support tuple column access and tuple stars

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1253,7 +1253,7 @@ SELECT OVERLAY(foo.* PLACING 'string' FROM 'string') FROM (VALUES (1)) AS foo(x)
 query error cannot use "nonexistent.\*" without a FROM clause
 SELECT nonexistent.* IS NOT TRUE
 
-query error unsupported comparison operator: <tuple{int}> IS DISTINCT FROM <bool>
+query error unsupported comparison operator: <tuple{int AS x}> IS DISTINCT FROM <bool>
 SELECT foo.* IS NOT TRUE FROM (VALUES (1)) AS foo(x)
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -182,7 +182,7 @@ query error no data source matches pattern: bar.kv.\*
 SELECT bar.kv.* FROM kv
 
 # Don't panic with invalid names (#8024)
-query error cannot subscript type tuple\{string, string\} because it is not an array
+query error cannot subscript type tuple\{string AS k, string AS v\} because it is not an array
 SELECT kv.*[1] FROM kv
 
 query T colnames

--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -454,10 +454,10 @@ SELECT (('a')).x
 query error pq: unnest\(\): cannot determine type of empty array. Consider annotating with the desired type, for example ARRAY\[\]:::int\[\]
 SELECT (unnest(ARRAY[])).*
 
-query I colnames
+query error type int is not composite
 SELECT (unnest(ARRAY[]:::INT[])).*
-----
-unnest
+
+subtest multi_column
 
 query TI colnames
 SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).*
@@ -483,7 +483,7 @@ n
 2
 3
 
-query error pq: could not identify column "other" in record data type
+query error pq: could not identify column "other" in tuple{string AS x, int AS n}
 SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).other
 
 query T colnames
@@ -521,16 +521,28 @@ c 1
 b 2
 a 3
 
-subtest 24866
+query I colnames
+SELECT (i.keys).n FROM (SELECT information_schema._pg_expandarray(ARRAY[3,2,1]) AS keys) AS i
+----
+n
+1
+2
+3
 
-# TODO(bram): #24866
-# query I colnames
-# SELECT (i.keys).n FROM (SELECT information_schema._pg_expandarray(ARRAY[3,2,1]) AS keys) AS i;
-# ----
-# n
-# 3
-# 2
-# 1
+query II colnames
+SELECT (i.keys).* FROM (SELECT information_schema._pg_expandarray(ARRAY[3,2,1]) AS keys) AS i
+----
+x  n
+3  1
+2  2
+1  3
+
+query T
+SELECT ((i.keys).*, 123) FROM (SELECT information_schema._pg_expandarray(ARRAY[3,2,1]) AS keys) AS i
+----
+((3, 1),123)
+((2, 2),123)
+((1, 3),123)
 
 subtest generate_subscripts
 
@@ -777,15 +789,16 @@ vals       1
 vals       2
 vals       3
 
-query T
-SELECT information_schema._pg_expandarray(indkey) FROM pg_index ORDER BY x, n
+query TT colnames
+SELECT relname, information_schema._pg_expandarray(indkey) FROM pg_class, pg_index WHERE pg_class.oid = pg_index.indrelid ORDER BY relname, x, n
 ----
-(1,1)
-(1,2)
-(2,1)
-(2,1)
-(2,2)
-(3,1)
+relname    information_schema._pg_expandarray
+ordered_t  (1,1)
+t          (2,1)
+u          (2,1)
+vals       (1,1)
+vals       (2,2)
+vals       (3,1)
 
 # The following query needs indclass to become an oidvector.
 # See bug #26504.
@@ -798,8 +811,10 @@ SELECT information_schema._pg_expandarray(indkey) FROM pg_index ORDER BY x, n
 #     pg_index
 # ----
 
+subtest correlated_json_object_keys
+
 statement ok
-CREATE TABLE j(x INT, y JSON);
+CREATE TABLE j(x INT PRIMARY KEY, y JSON);
   INSERT INTO j VALUES
      (1, '{"a":123,"b":456}'),
      (2, '{"c":111,"d":222}')
@@ -812,26 +827,72 @@ SELECT x, y->>json_object_keys(y) FROM j
 2  111
 2  222
 
+subtest correlated_multi_column
 
-# The following needs some more tuple support to work. #24866
-# query TTI
-# SELECT   a.attname, a.atttypid, atttypmod
-#     FROM pg_catalog.pg_class ct
-#     JOIN pg_catalog.pg_attribute a ON (ct.oid = a.attrelid)
-#     JOIN pg_catalog.pg_namespace n ON (ct.relnamespace = n.oid)
-#     JOIN (
-#       SELECT i.indexrelid, i.indrelid, i.indisprimary,
-#              information_schema._pg_expandarray(i.indkey) AS keys
-#         FROM pg_catalog.pg_index i
-#         ) i ON (a.attnum = (i.keys).x AND a.attrelid = i.indrelid)
-#    WHERE true
-#      AND n.nspname = 'information_schema'
-#      AND ct.relname = 'columns'
-#      AND i.indisprimary
-# ORDER BY a.attnum
-# ----
+query TTI colnames
+SELECT tbl, idx, (i.keys).n
+  FROM (SELECT ct.relname AS tbl, ct2.relname AS idx, information_schema._pg_expandarray(indkey) AS keys
+          FROM pg_index ix
+          JOIN pg_class ct ON ix.indrelid = ct.oid AND ct.relname = 'vals'
+	  JOIN pg_class ct2 ON ix.indexrelid = ct2.oid) AS i
+ORDER BY 1,2,3
+----
+tbl   idx      n
+vals  primary  1
+vals  woo      1
+vals  woo      2
 
-# Ditto #24866
+subtest dbviz_example_query
+
+# DbVisualizer query from #24649 listed in #16971.
+query TTI
+SELECT   a.attname, a.atttypid, atttypmod
+    FROM pg_catalog.pg_class ct
+    JOIN pg_catalog.pg_attribute a ON (ct.oid = a.attrelid)
+    JOIN pg_catalog.pg_namespace n ON (ct.relnamespace = n.oid)
+    JOIN (
+      SELECT i.indexrelid, i.indrelid, i.indisprimary,
+             information_schema._pg_expandarray(i.indkey) AS keys
+        FROM pg_catalog.pg_index i
+        ) i ON (a.attnum = (i.keys).x AND a.attrelid = i.indrelid)
+   WHERE true
+     AND n.nspname = 'public'
+     AND ct.relname = 'j'
+     AND i.indisprimary
+ORDER BY a.attnum
+----
+x  20  -1
+
+subtest metabase_confluent_example_query
+
+# Test from metabase listed on #16971.
+# Also Kafka Confluent sink query from #25854.
+query TTTTIT
+SELECT NULL AS TABLE_CAT,
+       n.nspname AS TABLE_SCHEM,
+       ct.relname AS TABLE_NAME,
+       a.attname AS COLUMN_NAME,
+       (i.keys).n AS KEY_SEQ,
+       ci.relname AS PK_NAME
+    FROM pg_catalog.pg_class ct
+    JOIN pg_catalog.pg_attribute a ON (ct.oid = a.attrelid)
+    JOIN pg_catalog.pg_namespace n ON (ct.relnamespace = n.oid)
+    JOIN (SELECT i.indexrelid,
+                 i.indrelid,
+             i.indisprimary,
+             information_schema._pg_expandarray(i.indkey) AS keys
+        FROM pg_catalog.pg_index i) i ON (a.attnum = (i.keys).x AND a.attrelid = i.indrelid)
+    JOIN pg_catalog.pg_class ci ON (ci.oid = i.indexrelid)
+   WHERE true AND ct.relname = 'j' AND i.indisprimary
+ORDER BY table_name, pk_name, key_seq
+----
+NULL  public  j  x  1  primary
+
+subtest liquibase_example_query
+
+# # Test from #24713 (Liquibase) listed on #16971.
+# # TODO(knz) Needs support for pg_get_indexdef with 3 arguments,
+# # see #26629.
 # query TTTBTTIITTTTT
 # SELECT NULL AS table_cat,
 #        n.nspname AS table_schem,
@@ -876,7 +937,7 @@ SELECT x, y->>json_object_keys(y) FROM j
 # JOIN pg_catalog.pg_am am ON (ci.relam = am.oid)
 # WHERE TRUE
 #   AND n.nspname = 'public'
-#   AND ct.relname = 'act_de_databasechangelog'
+#   AND ct.relname = 'j'
 # ORDER BY non_unique,
 #          TYPE,
 #          index_name,

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -679,6 +679,8 @@ SELECT (((ROW(pow(1, 10.0) + 9) AS t1), 'a' || 'b') AS t2, t3) = (((ROW(sqrt(100
 a     b
 true  true
 
+subtest labeled_tuple_errors
+
 query error pq: tuples \(\(\(\(1, 2\) AS a, b\), 'equal'\) AS c, d\), \(\(\(\(1, 'huh'\) AS e, f\), 'equal'\) AS g, h\) are not comparable at index 1: tuples \(\(1, 2\) AS a, b\), \(\(1, 'huh'\) AS e, f\) are not comparable at index 2: unsupported comparison operator: <int> = <string>
 SELECT ((((1, 2) AS a, b), 'equal') AS c, d) = ((((1, 'huh') AS e, f), 'equal') AS g, h)
 
@@ -709,9 +711,13 @@ SELECT ((((((1, '2', 3) AS a, b, c), ((4,'5') AS a, b), (ROW(6) AS a)) AS a, b, 
 r
 (((1, '2', 3), (4, '5'), (6)),(7, 8),('9'))
 
-### Accessing a specific column
+subtest labeled_tuple_column_access
 
 ## base working case
+
+# Accessing a specific column
+query error pq: could not identify column "x" in tuple{int AS a, int AS b, int AS c}
+SELECT (((1,2,3) AS a,b,c)).x
 
 query ITBITB colnames
 SELECT (((1,'2',true) AS a,b,c)).a
@@ -724,7 +730,7 @@ SELECT (((1,'2',true) AS a,b,c)).a
 a  b  c     a  b  c
 1  2  true  1  2  true
 
-## A collection of error cases
+subtest labeled_tuple_column_access_errors
 
 # column doesn't exist
 query error pq: could not identify column "x" in tuple{int AS a, int AS b, int AS c}
@@ -744,33 +750,92 @@ SELECT ((1,2,3)).x
 query error pq: type tuple{int, int, int} is not composite
 SELECT ((1,2,3)).*
 
-# Non unique labels
-query error pq: found duplicate tuple label: "a"
-SELECT (((1,'2',true) AS a,b,a)).a
-
-## The following are all cases that will be addressed in future work
-
 # Accessing all the columns
-query error pq: star expansion of tuples is not supported
+
+query ITB colnames
 SELECT (((1,'2',true) AS a,b,c)).*
+----
+a  b  c
+1  2  true
 
-query error pq: star expansion of tuples is not supported
+query ITB colnames
 SELECT ((ROW(1,'2',true) AS a,b,c)).*
+----
+a  b  c
+1  2  true
 
-# From a Subquery
-query error pq: unimplemented: cannot access column "e" in non-tuple expression
-SELECT ((t)).e, ((t)).f, ((t)).g
+query T
+SELECT (((ROW(1,'2',true) AS a,b,c)).*, 456)
+----
+((1, '2', true),456)
+
+query I colnames
+SELECT ((ROW(1) AS a)).*
+----
+a
+1
+
+
+subtest literal_labeled_tuple_in_subquery
+
+query ITB colnames
+SELECT (x).e, (x).f, (x).g
 FROM (
-  SELECT ((1,'2',true) AS e,f,g) AS t
+  SELECT ((1,'2',true) AS e,f,g) AS x
 )
+----
+e  f  g
+1  2  true
 
-# From a table directly
+query ITB colnames
+SELECT (x).*
+FROM (
+  SELECT ((1,'2',true) AS e,f,g) AS x
+)
+----
+e  f  g
+1  2  true
+
+subtest labeled_tuples_derived_from_relational_subquery_schema
+
+# Needed until #26627 is resolved.
+statement ok
+set distsql=off
+
+query IT
+  SELECT (x).a, (x).b
+    FROM (SELECT (ROW(a, b) AS a, b) AS x FROM (VALUES (1, 'one')) AS t(a, b))
+----
+1 one
+
 statement ok
 CREATE TABLE t (a int, b string)
 
 statement ok
 INSERT INTO t VALUES (1, 'one'), (2, 'two')
 
+query IT
+  SELECT (x).a, (x).b
+    FROM (SELECT (ROW(a, b) AS a, b) AS x FROM t)
+ORDER BY 1
+   LIMIT 1
+----
+1 one
+
+statement ok
+set distsql=auto
+
+subtest labeled_column_access_from_table
+
+query IT colnames
+SELECT (t.*).* FROM t ORDER BY 1,2
+----
+a  b
+1  one
+2  two
+
+
+# Pending #26719
 query error pq: column "t" does not exist
 SELECT (t).a FROM t
 

--- a/pkg/sql/logictest/testdata/planner_test/aggregate
+++ b/pkg/sql/logictest/testdata/planner_test/aggregate
@@ -72,18 +72,18 @@ group           ·            ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(DISTINCT a.*) FROM kv a, kv b
 ----
-group                ·            ·                             (count)                                                       ·
- │                   aggregate 0  count(DISTINCT (k, v, w, s))  ·                                                             ·
- └── render          ·            ·                             ("(k, v, w, s)")                                              ·
-      │              render 0     (a.k, a.v, a.w, a.s)          ·                                                             ·
-      └── join       ·            ·                             (k, v, w, s, k[omitted], v[omitted], w[omitted], s[omitted])  ·
-           │         type         cross                         ·                                                             ·
-           ├── scan  ·            ·                             (k, v, w, s)                                                  k!=NULL; key(k)
-           │         table        kv@primary                    ·                                                             ·
-           │         spans        ALL                           ·                                                             ·
-           └── scan  ·            ·                             (k[omitted], v[omitted], w[omitted], s[omitted])              k!=NULL; key(k)
-·                    table        kv@primary                    ·                                                             ·
-·                    spans        ALL                           ·                                                             ·
+group                ·            ·                                             (count)                                                       ·
+ │                   aggregate 0  count(DISTINCT ((k, v, w, s) AS k, v, w, s))  ·                                                             ·
+ └── render          ·            ·                                             ("((k, v, w, s) AS k, v, w, s)")                              ·
+      │              render 0     ((a.k, a.v, a.w, a.s) AS k, v, w, s)          ·                                                             ·
+      └── join       ·            ·                                             (k, v, w, s, k[omitted], v[omitted], w[omitted], s[omitted])  ·
+           │         type         cross                                         ·                                                             ·
+           ├── scan  ·            ·                                             (k, v, w, s)                                                  k!=NULL; key(k)
+           │         table        kv@primary                                    ·                                                             ·
+           │         spans        ALL                                           ·                                                             ·
+           └── scan  ·            ·                                             (k[omitted], v[omitted], w[omitted], s[omitted])              k!=NULL; key(k)
+·                    table        kv@primary                                    ·                                                             ·
+·                    spans        ALL                                           ·                                                             ·
 
 query TTT
 SELECT "Tree", "Field", "Description" FROM [

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -171,18 +171,18 @@ group      ·            ·           (count int, sum decimal, max int)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(DISTINCT a.*) FROM kv a, kv b
 ----
-group                ·            ·                             (count)                                                       ·
- │                   aggregate 0  count(DISTINCT (k, v, w, s))  ·                                                             ·
- └── render          ·            ·                             ("(k, v, w, s)")                                              ·
-      │              render 0     (a.k, a.v, a.w, a.s)          ·                                                             ·
-      └── join       ·            ·                             (k, v, w, s, k[omitted], v[omitted], w[omitted], s[omitted])  ·
-           │         type         cross                         ·                                                             ·
-           ├── scan  ·            ·                             (k, v, w, s)                                                  k!=NULL; key(k)
-           │         table        kv@primary                    ·                                                             ·
-           │         spans        ALL                           ·                                                             ·
-           └── scan  ·            ·                             (k[omitted], v[omitted], w[omitted], s[omitted])              k!=NULL; key(k)
-·                    table        kv@primary                    ·                                                             ·
-·                    spans        ALL                           ·                                                             ·
+group                ·            ·                                             (count)                                                       ·
+ │                   aggregate 0  count(DISTINCT ((k, v, w, s) AS k, v, w, s))  ·                                                             ·
+ └── render          ·            ·                                             ("((k, v, w, s) AS k, v, w, s)")                              ·
+      │              render 0     ((a.k, a.v, a.w, a.s) AS k, v, w, s)          ·                                                             ·
+      └── join       ·            ·                                             (k, v, w, s, k[omitted], v[omitted], w[omitted], s[omitted])  ·
+           │         type         cross                                         ·                                                             ·
+           ├── scan  ·            ·                                             (k, v, w, s)                                                  k!=NULL; key(k)
+           │         table        kv@primary                                    ·                                                             ·
+           │         spans        ALL                                           ·                                                             ·
+           └── scan  ·            ·                                             (k[omitted], v[omitted], w[omitted], s[omitted])              k!=NULL; key(k)
+·                    table        kv@primary                                    ·                                                             ·
+·                    spans        ALL                                           ·                                                             ·
 
 query TTT
 SELECT "Tree", "Field", "Description" FROM [

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -801,7 +801,7 @@ SELECT count(kv.*) FROM kv
 group-by
  ├── columns: count:6(int)
  ├── project
- │    ├── columns: column5:5(tuple{int, int, int, string})
+ │    ├── columns: column5:5(tuple{int AS k, int AS v, int AS w, string AS s})
  │    ├── scan kv
  │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
  │    └── projections
@@ -812,7 +812,7 @@ group-by
  │              └── variable: kv.s [type=string]
  └── aggregations
       └── count [type=int]
-           └── variable: column5 [type=tuple{int, int, int, string}]
+           └── variable: column5 [type=tuple{int AS k, int AS v, int AS w, string AS s}]
 
 build
 SELECT count((k, v)) FROM kv LIMIT 1

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -225,7 +225,7 @@ build
 SELECT (kv.*) AS r FROM kv
 ----
 project
- ├── columns: r:3(tuple{string, string})
+ ├── columns: r:3(tuple{string AS k, string AS v})
  ├── scan kv
  │    └── columns: k:1(string!null) v:2(string)
  └── projections
@@ -257,7 +257,7 @@ error (42P01): no data source matches pattern: bar.kv.*
 build
 SELECT kv.*[1] FROM kv
 ----
-error (42804): cannot subscript type tuple{string, string} because it is not an array
+error (42804): cannot subscript type tuple{string AS k, string AS v} because it is not an array
 
 build
 SELECT ARRAY[]

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -197,12 +197,12 @@ error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
 build
 SELECT (1).*
 ----
-error (42804): type int is not composite
+error (42809): type int is not composite
 
 build
 SELECT ('a').*
 ----
-error (42804): type string is not composite
+error (42809): type string is not composite
 
 build
 SELECT (unnest(ARRAY[]:::INT[])).*

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -26,16 +26,62 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
-// expandStar expands expr into a list of columns if expr
-// corresponds to a "*" or "<table>.*".
-func (b *Builder) expandStar(expr tree.Expr, inScope *scope) (exprs []tree.TypedExpr) {
+func checkFrom(expr tree.Expr, inScope *scope) {
 	if len(inScope.cols) == 0 {
 		panic(builderError{pgerror.NewErrorf(pgerror.CodeInvalidNameError,
 			"cannot use %q without a FROM clause", tree.ErrString(expr))})
 	}
+}
 
+// expandStar expands expr into a list of columns if expr
+// corresponds to a "*", "<table>.*" or "(Expr).*".
+func (b *Builder) expandStar(
+	expr tree.Expr, inScope *scope,
+) (labels []string, exprs []tree.TypedExpr) {
 	switch t := expr.(type) {
+	case *tree.TupleStar:
+		texpr := inScope.resolveType(t.Expr, types.Any)
+		typ := texpr.ResolvedType()
+		tType, ok := typ.(types.TTuple)
+		if !ok || tType.Labels == nil {
+			panic(builderError{tree.NewTypeIsNotCompositeError(typ)})
+		}
+
+		// If the sub-expression is a tuple constructor, we'll de-tuplify below.
+		// Otherwise we'll re-evaluate the expression multiple times.
+		//
+		// The following query generates a tuple constructor:
+		//     SELECT (kv.*).* FROM kv
+		//     -- the inner star expansion (scope.VisitPre) first expands to
+		//     SELECT (((kv.k, kv.v) as k,v)).* FROM kv
+		//     -- then the inner tuple constructor detuplifies here to:
+		//     SELECT kv.k, kv.v FROM kv
+		//
+		// The following query generates a scalar var with tuple type that
+		// is not a tuple constructor:
+		//
+		//     SELECT (SELECT pg_get_keywords() AS x LIMIT 1).*
+		//     -- does not detuplify, one gets instead:
+		//     SELECT (SELECT pg_get_keywords() AS x LIMIT 1).word,
+		//            (SELECT pg_get_keywords() AS x LIMIT 1).catcode,
+		//            (SELECT pg_get_keywords() AS x LIMIT 1).catdesc
+		//     -- (and we hope a later opt will merge the subqueries)
+		tTuple, isTuple := texpr.(*tree.Tuple)
+
+		labels = tType.Labels
+		exprs = make([]tree.TypedExpr, len(tType.Types))
+		for i := range tType.Types {
+			if isTuple {
+				// De-tuplify: ((a,b,c)).* -> a, b, c
+				exprs[i] = tTuple.Exprs[i].(tree.TypedExpr)
+			} else {
+				// Can't de-tuplify: (Expr).* -> (Expr).a, (Expr).b, (Expr).c
+				exprs[i] = tree.NewTypedColumnAccessExpr(texpr, tType.Labels[i], i)
+			}
+		}
+
 	case *tree.AllColumnsSelector:
+		checkFrom(expr, inScope)
 		src, _, err := t.Resolve(b.ctx, inScope)
 		if err != nil {
 			panic(builderError{err})
@@ -44,30 +90,37 @@ func (b *Builder) expandStar(expr tree.Expr, inScope *scope) (exprs []tree.Typed
 			col := inScope.cols[i]
 			if col.table == *src && !col.hidden {
 				exprs = append(exprs, &col)
+				labels = append(labels, string(col.name))
 			}
 		}
 
 	case tree.UnqualifiedStar:
+		checkFrom(expr, inScope)
 		for i := range inScope.cols {
 			col := inScope.cols[i]
 			if !col.hidden {
 				exprs = append(exprs, &col)
+				labels = append(labels, string(col.name))
 			}
 		}
+
+	default:
+		panic(fmt.Sprintf("unhandled type: %T", expr))
 	}
 
-	return exprs
+	return labels, exprs
 }
 
-// expandStarAndResolveType expands expr into a list of columns if expr
-// corresponds to a "*" or "<table>.*". Otherwise, expandStarAndResolveType
-// resolves the type of expr and returns it as a []TypedExpr.
+// expandStarAndResolveType expands expr into a list of columns if
+// expr corresponds to a "*", "<table>.*" or "(Expr).*". Otherwise,
+// expandStarAndResolveType resolves the type of expr and returns it
+// as a []TypedExpr.
 func (b *Builder) expandStarAndResolveType(
 	expr tree.Expr, inScope *scope,
 ) (exprs []tree.TypedExpr) {
 	switch t := expr.(type) {
-	case *tree.AllColumnsSelector, tree.UnqualifiedStar:
-		exprs = b.expandStar(expr, inScope)
+	case *tree.AllColumnsSelector, tree.UnqualifiedStar, *tree.TupleStar:
+		_, exprs = b.expandStar(expr, inScope)
 
 	case *tree.UnresolvedName:
 		vn, err := t.NormalizeVarName()

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6792,7 +6792,7 @@ d_expr:
 // TODO(knz/jordan): extend this for compound types. See explanation above.
 | '(' a_expr ')' '.' '*'
   {
-    $$.val = &tree.ColumnAccessExpr{Expr: $2.expr(), Star: true }
+    $$.val = &tree.TupleStar{Expr: $2.expr()}
   }
 | '(' a_expr ')' '.' unrestricted_name
   {

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -484,7 +484,7 @@ func (s *expandArrayValueGenerator) Next() (bool, error) {
 func (s *expandArrayValueGenerator) Values() tree.Datums {
 	// Expand array's index is 1 based.
 	s.buf[0] = s.avg.array.Array[s.avg.nextIndex]
-	*s.buf[1].(*tree.DInt) = tree.DInt(s.avg.nextIndex + 1)
+	s.buf[1] = tree.NewDInt(tree.DInt(s.avg.nextIndex + 1))
 	return s.buf[:]
 }
 
@@ -560,7 +560,7 @@ func (s *subscriptsValueGenerator) Next() (bool, error) {
 // Values implements the tree.ValueGenerator interface.
 func (s *subscriptsValueGenerator) Values() tree.Datums {
 	// Generate Subscript's indexes are 1 based.
-	*s.buf[0].(*tree.DInt) = tree.DInt(s.avg.nextIndex + 1)
+	s.buf[0] = tree.NewDInt(tree.DInt(s.avg.nextIndex + 1))
 	return s.buf[:]
 }
 

--- a/pkg/sql/sem/tree/col_name.go
+++ b/pkg/sql/sem/tree/col_name.go
@@ -164,9 +164,7 @@ func ComputeColNameInternal(sp sessiondata.SearchPath, target Expr) (int, string
 		return 2, "iferror", nil
 
 	case *ColumnAccessExpr:
-		if !e.Star {
-			return 2, e.ColName, nil
-		}
+		return 2, e.ColName, nil
 
 	case *DBool:
 		// PostgreSQL implements the "true" and "false" literals

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3410,9 +3410,11 @@ func (expr *CollateExpr) Eval(ctx *EvalContext) (Datum, error) {
 
 // Eval implements the TypedExpr interface.
 func (expr *ColumnAccessExpr) Eval(ctx *EvalContext) (Datum, error) {
-	return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
-		"programmer error: column access expressions must be replaced before evaluation",
-	)
+	d, err := expr.Expr.(TypedExpr).Eval(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.(*DTuple).D[expr.ColIndex], nil
 }
 
 // Eval implements the TypedExpr interface.
@@ -3716,6 +3718,11 @@ func (expr *UnresolvedName) Eval(ctx *EvalContext) (Datum, error) {
 
 // Eval implements the TypedExpr interface.
 func (expr *AllColumnsSelector) Eval(ctx *EvalContext) (Datum, error) {
+	return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unhandled type %T", expr)
+}
+
+// Eval implements the TypedExpr interface.
+func (expr *TupleStar) Eval(ctx *EvalContext) (Datum, error) {
 	return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unhandled type %T", expr)
 }
 

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -144,6 +144,11 @@ func TestTypeCheck(t *testing.T) {
 		{`((ROW (1) AS a)).a`, `1:::INT`},
 		{`((('1', 2) AS a, b)).a`, `'1':::STRING`},
 		{`((('1', 2) AS a, b)).b`, `2:::INT`},
+		{`(pg_get_keywords()).word`, `(pg_get_keywords()).word`},
+		{`(generate_series(1,3)).generate_series`, `(generate_series(1:::INT, 3:::INT)).generate_series`},
+		{`(generate_series(1,3)).*`, `generate_series(1:::INT, 3:::INT)`},
+		{`((ROW (1) AS a)).*`, `(ROW(1:::INT) AS a)`},
+		{`((('1'||'', 1+1) AS a, b)).*`, `(('1':::STRING, 2:::INT) AS a, b)`},
 
 		// These outputs, while bizarre looking, are correct and expected. The
 		// type annotation is caused by the call to tree.Serialize, which formats the
@@ -243,12 +248,8 @@ func TestTypeCheckError(t *testing.T) {
 			`could not identify column "x" in tuple{int AS a, string AS b}`,
 		},
 		{
-			`((ROW (1) AS a)).*`,
-			`star expansion of tuples is not supported`,
-		},
-		{
-			`((('1', 2) AS a, b)).*`,
-			`star expansion of tuples is not supported`,
+			`(pg_get_keywords()).foo`,
+			`could not identify column "foo" in tuple{string AS word, string AS catcode, string AS catdesc}`,
 		},
 	}
 	for _, d := range testData {

--- a/pkg/sql/sem/tree/var_name.go
+++ b/pkg/sql/sem/tree/var_name.go
@@ -46,6 +46,7 @@ type VarName interface {
 var _ VarName = &UnresolvedName{}
 var _ VarName = UnqualifiedStar{}
 var _ VarName = &AllColumnsSelector{}
+var _ VarName = &TupleStar{}
 var _ VarName = &ColumnItem{}
 
 // UnqualifiedStar corresponds to a standalone '*' in a scalar

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -159,6 +159,17 @@ func (expr *ColumnAccessExpr) Walk(v Visitor) Expr {
 	return expr
 }
 
+// Walk implements the Expr interface.
+func (expr *TupleStar) Walk(v Visitor) Expr {
+	e, changed := WalkExpr(v, expr.Expr)
+	if changed {
+		exprCopy := *expr
+		exprCopy.Expr = e
+		return &exprCopy
+	}
+	return expr
+}
+
 // CopyNode makes a copy of this Expr without recursing in any child Exprs.
 func (expr *CoalesceExpr) CopyNode() *CoalesceExpr {
 	exprCopy := *expr

--- a/pkg/sql/targets.go
+++ b/pkg/sql/targets.go
@@ -67,7 +67,9 @@ func (p *planner) computeRenderAllowingStars(
 		return nil, nil, false, err
 	}
 
-	if hasStar, cols, typedExprs, err := sqlbase.CheckRenderStar(ctx, target, info, ivarHelper); err != nil {
+	if hasStar, cols, typedExprs, err := sqlbase.CheckRenderStar(
+		ctx, p.analyzeExpr, target, info, ivarHelper,
+	); err != nil {
 		return nil, nil, false, err
 	} else if hasStar {
 		return cols, typedExprs, hasStar, nil


### PR DESCRIPTION
First commits from #26621.
Completes the fix to #24866 by re-activating disabled tests.
This work is yet another step towards #16971. It would actually fix #16971 if it were not for #26627, #26624 and #26629.

This work is yet another step towards #16971.

The labeled tuples introduced in #25283 can now be accessed using
their labels or using a star, e.g. `(E).*`.

Release note (sql change): Labeled tuples can now be accessed using
their labels (e.g. `SELECT (x).word FROM (SELECT pg_expand_keywords()
AS x)` or a star (e.g. `SELECT (x).* FROM (SELECT pg_expand_keywords()
AS x)`).

Fixes #26720.