### PR TITLE
libroach: don't expose cryptopp includes in headers.

### DIFF
--- a/c-deps/libroach/ccl/crypto_utils.cc
+++ b/c-deps/libroach/ccl/crypto_utils.cc
@@ -28,15 +28,34 @@ std::string RandomBytes(size_t length) {
   return std::string(reinterpret_cast<const char*>(data.data()), data.size());
 }
 
-AESEncryptCipher::~AESEncryptCipher() {}
+class AESEncryptCipher : public rocksdb_utils::BlockCipher {
+ public:
+  // The key must have a valid length (16/24/32 bytes) or CryptoPP will fail.
+  AESEncryptCipher(const std::string& key) : enc_((byte*)key.data(), key.size()) {}
 
-size_t AESEncryptCipher::BlockSize() { return CryptoPP::AES::BLOCKSIZE; }
+  ~AESEncryptCipher() {}
 
-rocksdb::Status AESEncryptCipher::Encrypt(char* data) {
-  enc_.ProcessBlock((byte*)data);
-  return rocksdb::Status::OK();
-}
+  // Blocksize is fixed for AES.
+  size_t BlockSize() { return CryptoPP::AES::BLOCKSIZE; }
 
-rocksdb::Status AESEncryptCipher::Decrypt(char* data) {
-  return rocksdb::Status::NotSupported("this is an encrypt-only cipher");
+  // Encrypt a block of data.
+  // Length of data is equal to BlockSize().
+  rocksdb::Status Encrypt(char* data) {
+    enc_.ProcessBlock((byte*)data);
+    return rocksdb::Status::OK();
+  }
+
+  // Decrypt a block of data.
+  // Length of data is equal to BlockSize().
+  // NOT IMPLEMENTED: this is not needed for CTR mode so remains unimplemented.
+  rocksdb::Status Decrypt(char* data) {
+    return rocksdb::Status::NotSupported("this is an encrypt-only cipher");
+  }
+
+ private:
+  CryptoPP::AES::Encryption enc_;
+};
+
+rocksdb_utils::BlockCipher* NewAESEncryptCipher(const enginepbccl::SecretKey* key) {
+  return new AESEncryptCipher(key->key());
 }

--- a/c-deps/libroach/ccl/ctr_stream.cc
+++ b/c-deps/libroach/ccl/ctr_stream.cc
@@ -97,7 +97,7 @@ CTRCipherStream::InitCipher(std::unique_ptr<rocksdb_utils::BlockCipher>* cipher)
         fmt::StringPrintf("unknown encryption type %d", key_->info().encryption_type()));
   }
 
-  cipher->reset(new AESEncryptCipher(key_->key()));
+  cipher->reset(NewAESEncryptCipher(key_.get()));
   return rocksdb::Status::OK();
 }
 


### PR DESCRIPTION
Move AESEncryptCipher to crypto_utils.cc to avoid exposing cryptopp
includes to everything else. This will make it easier to swap out.

Release note: None