### PR TITLE
distsql: move tableReader stat collection setup out of Start

### DIFF
--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -329,16 +329,17 @@ func TestLimitScans(t *testing.T) {
 	const limit = 3
 	post := PostProcessSpec{Limit: limit}
 
-	tr, err := newTableReader(&flowCtx, 0 /* processorID */, &spec, &post, nil /* output */)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Now we're going to run the tableReader and trace it.
 	tracer := tracing.NewTracer()
 	sp := tracer.StartSpan("root", tracing.Recordable)
 	tracing.StartRecording(sp, tracing.SnowballRecording)
 	ctx := opentracing.ContextWithSpan(context.Background(), sp)
+	flowCtx.EvalCtx.CtxProvider = tree.FixedCtxProvider{Context: ctx}
+
+	tr, err := newTableReader(&flowCtx, 0 /* processorID */, &spec, &post, nil /* output */)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	tr.Start(ctx)
 	rows := 0


### PR DESCRIPTION
It makes more sense to have the tableReader instrument itself for stat
collection at the same time other setup is performed in newTableReader.

Release note: None