### PR TITLE
sql: Check CHECK constraints on upsert when updating a conflicting row

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -506,3 +506,62 @@ query IIII rowsort
 SELECT * FROM tu
 ----
 1 NULL NULL NULL
+
+subtest check
+
+statement ok
+CREATE TABLE ab(
+    a INT PRIMARY KEY, 
+    b INT, CHECK (b < 1)
+)
+
+statement count 1
+INSERT INTO ab(a, b) VALUES (1, 0);
+
+statement error pq: failed to satisfy CHECK constraint \(b < 1\)
+INSERT INTO ab(a, b) VALUES (1, 0) ON CONFLICT(a) DO UPDATE SET b=12312313;
+
+statement count 1
+INSERT INTO ab(a, b) VALUES (1, 0) ON CONFLICT(a) DO UPDATE SET b=-1;
+
+statement ok 
+CREATE TABLE abc_check(
+    a INT PRIMARY KEY, 
+    b INT, 
+    c INT, 
+    CHECK (b < 1),
+    CHECK (c > 1)
+)
+
+statement count 1
+INSERT INTO abc_check(a, b, c) VALUES (1, 0, 2);
+
+statement error pq: failed to satisfy CHECK constraint \(b < 1\)
+INSERT INTO abc_check(a, b, c) VALUES (1, 0, 2) ON CONFLICT(a) DO UPDATE SET b=12312313;
+
+statement error pq: failed to satisfy CHECK constraint \(b < 1\)
+INSERT INTO abc_check(a, b, c) VALUES (1, 0, 2) ON CONFLICT(a) DO UPDATE SET (b, c) = (1, 1);
+
+statement error pq: failed to satisfy CHECK constraint \(c > 1\)
+INSERT INTO abc_check(a, b, c) VALUES (1, 0, 2) ON CONFLICT(a) DO UPDATE SET (b, c) = (-1, 1);
+
+statement count 1
+INSERT INTO abc_check(a, b, c) VALUES (2, 0, 3);
+
+statement error pq: failed to satisfy CHECK constraint \(b < 1\)
+INSERT INTO abc_check(c, a, b) VALUES (3, 2, 0) ON CONFLICT(a) DO UPDATE SET b=12312313;
+
+statement error pq: failed to satisfy CHECK constraint \(b < 1\)
+INSERT INTO abc_check(a, c) VALUES (2, 3) ON CONFLICT(a) DO UPDATE SET b=12312313;
+
+statement error pq: failed to satisfy CHECK constraint \(c > 1\)
+INSERT INTO abc_check(a, c) VALUES (2, 3) ON CONFLICT(a) DO UPDATE SET c=1;
+
+statement error pq: failed to satisfy CHECK constraint \(c > 1\)
+INSERT INTO abc_check(c, a) VALUES (3, 2) ON CONFLICT(a) DO UPDATE SET c=1;
+
+statement error pq: failed to satisfy CHECK constraint \(b < 1\)
+INSERT INTO abc_check(c, a) VALUES (3, 2) ON CONFLICT(a) DO UPDATE SET b=123123123;
+
+statement error pq: failed to satisfy CHECK constraint \(b < 1\)
+INSERT INTO abc_check(c, a) VALUES (3, 2) ON CONFLICT(a) DO UPDATE SET b=123123123;


### PR DESCRIPTION
* Before: On a table with a CHECK constraint, such as:

    ```
    CREATE TABLE ex(foo INT PRIMARY KEY, bar INT, CHECK (bar < 2)
    ```

    an upsert on the table would not properly check the CHECK constraints,
    e.g.

    ```
    INSERT INTO ex(foo, bar) VALUES(1, 2);
    INSERT INTO ex(foo, bar) VALUES(1, 2) ON CONFLICT (foo) DO UPDATE SET
        bar = 3
    ```

    would update the row, violating the check constraint.

* After: On attempting such an operation, CockroachDB now throws the
proper database error "failed to satisfy CHECK constraint ..."

Release note (sql change): CHECK constraints are now checked when
updating a conflicting row in INSERT ... ON CONFLICT DO UPDATE
statements.

closes #23699 