### PR TITLE
storage: Improve GC queue with canceled context

### DIFF
--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -800,7 +800,15 @@ func RunGC(
 						// chunk and start a new one.
 						if batchGCKeysBytes >= gcKeyVersionChunkBytes {
 							batchGCKeys = append(batchGCKeys, roachpb.GCRequest_GCKey{Key: expBaseKey, Timestamp: keys[i].Timestamp})
-							if err := gcer.GC(ctx, batchGCKeys); err != nil {
+
+							err := gcer.GC(ctx, batchGCKeys)
+
+							// Succeed or fail, allow releasing the memory backing batchGCKeys.
+							iter.ResetAllocator()
+							batchGCKeys = nil
+							batchGCKeysBytes = 0
+
+							if err != nil {
 								// Even though we are batching the GC process, it's
 								// safe to continue because we bumped the GC
 								// thresholds. We may leave some inconsistent history
@@ -808,10 +816,6 @@ func RunGC(
 								log.Warning(ctx, err)
 								return
 							}
-							// Allow releasing the memory backing batchGCKeys.
-							iter.ResetAllocator()
-							batchGCKeys = nil
-							batchGCKeysBytes = 0
 						}
 					}
 					// Add the key to the batch at the GC timestamp, unless it was already added.

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -835,6 +835,9 @@ func RunGC(
 			return GCInfo{}, err
 		} else if !ok {
 			break
+		} else if ctx.Err() != nil {
+			// Stop iterating if our context has expired.
+			return GCInfo{}, err
 		}
 		iterKey := iter.Key()
 		if !iterKey.IsValue() || !iterKey.Key.Equal(expBaseKey) {


### PR DESCRIPTION
If the GC queue reaches its deadline, it will at a minimum spam the logs because it retries frequently and logs its errors without aborting. We've seen at least one report in which this is correlated with rapid memory spikes in the command queue, which I think may happen because we don't check for cancellation until too late on some paths.

The first commit is technically redundant with the third, but I think it's good to have the extra cancellation check at a lower level to guard against any possible similar issues.