### PR TITLE
ui: Add lease transfers to graph of range operations

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -84,6 +84,7 @@ export default function (props: GraphDashboardProps) {
         <Metric name="cr.store.range.splits" title="Splits" nonNegativeRate />
         <Metric name="cr.store.range.adds" title="Adds" nonNegativeRate />
         <Metric name="cr.store.range.removes" title="Removes" nonNegativeRate />
+        <Metric name="cr.store.leases.transfers.success" title="Lease Transfers" nonNegativeRate />
       </Axis>
     </LineGraph>,
 


### PR DESCRIPTION
Release note (admin ui change): Lease transfers are now shown in the
Range Operations graph on the Replication dashboard.

------------------

For example, after restarting a small local cluster:

<img width="1072" alt="screen shot 2018-06-12 at 2 09 27 pm" src="https://user-images.githubusercontent.com/7085343/41311583-485abadc-6e4a-11e8-90e0-e79a84c820e3.png">
