### PR TITLE
sql: drain result channel in distSQLWrapper

### DIFF
--- a/pkg/sql/distsql_wrapper.go
+++ b/pkg/sql/distsql_wrapper.go
@@ -99,5 +99,8 @@ func (n *distSQLWrapper) Values() tree.Datums {
 }
 
 func (n *distSQLWrapper) Close(ctx context.Context) {
+	// Make sure the channel is drained and closed.
+	for range n.resultRows {
+	}
 	n.plan.Close(ctx)
 }


### PR DESCRIPTION
This ensures that the goroutine executing the distSQL query has
finished before we proceed with a close. This avoids scenarios in which
we could potentially be closing resources before the goroutine was
finished using them (e.g. spans).

Found while investigating #26500

Release note: None