### PR TITLE
engine: disable mvcc perf stats collection on tracing

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -581,13 +581,14 @@ SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE e'%1 CPut, 1 Beg
 r1: sending batch 1 CPut, 1 BeginTxn, 1 EndTxn to (n1,s1):1
 1 CPut, 1 BeginTxn, 1 EndTxn
 
-statement ok
-CREATE TABLE t.enginestats(k INT PRIMARY KEY, v INT)
-
-query T
-SELECT message FROM [ SHOW TRACE FOR SELECT * FROM t.enginestats ] WHERE message LIKE '%InternalDelete%'
-----
-engine stats: {InternalDeleteSkippedCount:0 TimeBoundNumSSTs:0}
+## TODO(tschottdorf): re-enable
+# statement ok
+# CREATE TABLE t.enginestats(k INT PRIMARY KEY, v INT)
+#
+# query T
+# SELECT message FROM [ SHOW TRACE FOR SELECT * FROM t.enginestats ] WHERE message LIKE '%InternalDelete%'
+# ----
+# engine stats: {InternalDeleteSkippedCount:0 TimeBoundNumSSTs:0}
 
 # Check that we can run set tracing regardless of the current tracing state.
 # This is convenient; sometimes it's unclear, for example, if you previously

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -32,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 const (
@@ -1666,9 +1664,13 @@ func mvccScanInternal(
 	var ownIter bool
 	var withStats bool
 	if iter == nil {
-		if sp := opentracing.SpanFromContext(ctx); sp != nil && !tracing.IsBlackHoleSpan(sp) {
-			withStats = true
-		}
+		// TODO(tschottdorf): re-enable this once performance is confirmed to not
+		// take a 10x hit on large count(*) queries.
+
+		// if sp := opentracing.SpanFromContext(ctx); sp != nil && !tracing.IsBlackHoleSpan(sp) {
+		// 	withStats = true
+		// }
+
 		iter = engine.NewIterator(IterOptions{WithStats: withStats})
 		ownIter = true
 	}


### PR DESCRIPTION
PR #24543 enabled passing back rocksdb performance stats to Go when
tracing was enabled. Unfortunately, it causes a serious performance hit
to the tune of ~10x on large count(*) queries.

This PR disables this feature for the time being.

Release note: None