### PR TITLE
sql: Add support for specifying window frames for window functions

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2017,7 +2017,7 @@ func_name ::=
 	| prefixed_column_path
 
 window_specification ::=
-	'(' opt_existing_window_name opt_partition_clause opt_sort_clause ')'
+	'(' opt_existing_window_name opt_partition_clause opt_sort_clause opt_frame_clause ')'
 
 window_name ::=
 	name
@@ -2090,6 +2090,11 @@ opt_partition_clause ::=
 	'PARTITION' 'BY' expr_list
 	| 
 
+opt_frame_clause ::=
+	'RANGE' frame_extent
+	| 'ROWS' frame_extent
+	| 
+
 extract_list ::=
 	extract_arg 'FROM' a_expr
 	| expr_list
@@ -2129,6 +2134,10 @@ rowsfrom_item ::=
 partition_name ::=
 	unrestricted_name
 
+frame_extent ::=
+	frame_bound
+	| 'BETWEEN' frame_bound 'AND' frame_bound
+
 extract_arg ::=
 	'identifier'
 	| 'YEAR'
@@ -2146,3 +2155,10 @@ substr_from ::=
 
 substr_for ::=
 	'FOR' a_expr
+
+frame_bound ::=
+	'UNBOUNDED' 'PRECEDING'
+	| 'UNBOUNDED' 'FOLLOWING'
+	| 'CURRENT' 'ROW'
+	| a_expr 'PRECEDING'
+	| a_expr 'FOLLOWING'

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -282,7 +282,7 @@ SELECT rank() FROM kv
 query error unknown signature: rank\(int\)
 SELECT rank(22) FROM kv
 
-query error window function calls cannot be nested under avg\(\)
+query error window function calls cannot be nested
 SELECT avg(avg(k) OVER ()) OVER () FROM kv ORDER BY 1
 
 query error OVER specified, but round\(\) is neither a window function nor an aggregate function
@@ -1514,3 +1514,212 @@ SELECT max(i) * (1/j) * (row_number() OVER (ORDER BY max(i))) FROM (SELECT 1 AS 
 # regression test for #23798 until #10495 is fixed.
 statement error function reserved for internal use
 SELECT final_variance(1.2, 1.2, 123) OVER (PARTITION BY k) FROM kv
+
+
+statement ok
+CREATE TABLE products (
+  group_id serial PRIMARY KEY,
+  group_name VARCHAR (255) NOT NULL,
+  product_name VARCHAR (255) NOT NULL,
+  price DECIMAL (11, 2),
+  priceInt INT,
+  priceFloat FLOAT
+)
+
+statement ok
+INSERT INTO products (group_name, product_name, price, priceInt, priceFloat) VALUES
+('Smartphone', 'Microsoft Lumia', 200, 200, 200),
+('Smartphone', 'HTC One', 400, 400, 400),
+('Smartphone', 'Nexus', 500, 500, 500),
+('Smartphone', 'iPhone', 900, 900, 900),
+('Laptop', 'HP Elite', 1200, 1200, 1200),
+('Laptop', 'Lenovo Thinkpad', 700, 700, 700),
+('Laptop', 'Sony VAIO', 700, 700, 700),
+('Laptop', 'Dell', 800, 800, 800),
+('Tablet', 'iPad', 700, 700, 700),
+('Tablet', 'Kindle Fire', 150, 150, 150),
+('Tablet', 'Samsung', 200, 200, 200)
+
+statement error cannot copy window "w" because it has a frame clause
+SELECT price, max(price) OVER (w ORDER BY price) AS max_price FROM products WINDOW w AS (PARTITION BY price ROWS UNBOUNDED PRECEDING);
+
+statement error frame starting offset must not be negative
+SELECT price, avg(price) OVER (PARTITION BY price ROWS -1 PRECEDING) AS avg_price FROM products;
+
+statement error frame ending offset must not be negative
+SELECT price, avg(price) OVER (PARTITION BY price ROWS BETWEEN 1 FOLLOWING AND -1 FOLLOWING) AS avg_price FROM products;
+
+statement error frame ending offset must not be negative
+SELECT product_name, price, min(price) OVER (PARTITION BY group_name ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS min_over_three, max(price) OVER (PARTITION BY group_name ROWS BETWEEN UNBOUNDED PRECEDING AND -1 FOLLOWING) AS max_over_partition FROM products ORDER BY group_id;
+
+statement error incompatible window frame start type: decimal
+SELECT avg(price) OVER (PARTITION BY group_name ROWS 1.5 PRECEDING) AS avg_price FROM products;
+
+statement error incompatible window frame start type: decimal
+SELECT avg(price) OVER (PARTITION BY group_name ROWS BETWEEN 1.5 PRECEDING AND UNBOUNDED FOLLOWING) AS avg_price FROM products;
+
+statement error incompatible window frame end type: decimal
+SELECT avg(price) OVER (PARTITION BY group_name ROWS BETWEEN UNBOUNDED PRECEDING AND 1.5 FOLLOWING) AS avg_price FROM products;
+
+query TRT
+SELECT product_name, price, first_value(product_name) OVER w AS first FROM products WHERE price = 200 OR price = 700 WINDOW w as (PARTITION BY price ORDER BY product_name RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) ORDER BY price, product_name;
+----
+Microsoft Lumia  200.00  Microsoft Lumia
+Samsung          200.00  Microsoft Lumia
+Lenovo Thinkpad  700.00  Lenovo Thinkpad
+Sony VAIO        700.00  Lenovo Thinkpad
+iPad             700.00  Lenovo Thinkpad
+
+query TRT
+SELECT product_name, price, last_value(product_name) OVER w AS last FROM products WHERE price = 200 OR price = 700 WINDOW w as (PARTITION BY price ORDER BY product_name RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) ORDER BY price, product_name;
+----
+Microsoft Lumia  200.00  Samsung
+Samsung          200.00  Samsung
+Lenovo Thinkpad  700.00  iPad
+Sony VAIO        700.00  iPad
+iPad             700.00  iPad
+
+query TRT
+SELECT product_name, price, nth_value(product_name, 2) OVER w AS second FROM products WHERE price = 200 OR price = 700 WINDOW w as (PARTITION BY price ORDER BY product_name RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) ORDER BY price, product_name;
+----
+Microsoft Lumia  200.00  Samsung
+Samsung          200.00  NULL
+Lenovo Thinkpad  700.00  Sony VAIO
+Sony VAIO        700.00  iPad
+iPad             700.00  NULL
+
+query TTRR
+SELECT product_name, group_name, price, avg(price) OVER (PARTITION BY group_name ORDER BY price, product_name ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS avg_of_three FROM products ORDER BY group_name, price, product_name;
+----
+Lenovo Thinkpad  Laptop       700.00                 700.00
+Sony VAIO        Laptop       700.00  733.33333333333333333
+Dell             Laptop       800.00                 900.00
+HP Elite         Laptop      1200.00                1000.00
+Microsoft Lumia  Smartphone   200.00                 300.00
+HTC One          Smartphone   400.00  366.66666666666666667
+Nexus            Smartphone   500.00                 600.00
+iPhone           Smartphone   900.00                 700.00
+Kindle Fire      Tablet       150.00                 175.00
+Samsung          Tablet       200.00                 350.00
+iPad             Tablet       700.00                 450.00
+
+query TTRR
+SELECT product_name, group_name, price, avg(priceFloat) OVER (PARTITION BY group_name ORDER BY price, product_name ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS avg_of_three_floats FROM products ORDER BY group_name, price, product_name;
+----
+Lenovo Thinkpad  Laptop      700.00   700
+Sony VAIO        Laptop      700.00   733.3333333333334
+Dell             Laptop      800.00   900
+HP Elite         Laptop      1200.00  1000
+Microsoft Lumia  Smartphone  200.00   300
+HTC One          Smartphone  400.00   366.6666666666667
+Nexus            Smartphone  500.00   600
+iPhone           Smartphone  900.00   700
+Kindle Fire      Tablet      150.00   175
+Samsung          Tablet      200.00   350
+iPad             Tablet      700.00   450
+
+query TTRR
+SELECT product_name, group_name, price, avg(priceInt) OVER (PARTITION BY group_name ORDER BY price, product_name ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS avg_of_three_ints FROM products ORDER BY group_name, price, product_name;
+----
+Lenovo Thinkpad  Laptop      700.00   700
+Sony VAIO        Laptop      700.00   733.33333333333333333
+Dell             Laptop      800.00   900
+HP Elite         Laptop      1200.00  1000
+Microsoft Lumia  Smartphone  200.00   300
+HTC One          Smartphone  400.00   366.66666666666666667
+Nexus            Smartphone  500.00   600
+iPhone           Smartphone  900.00   700
+Kindle Fire      Tablet      150.00   175
+Samsung          Tablet      200.00   350
+iPad             Tablet      700.00   450
+
+query TTRR
+SELECT group_name, product_name, price, avg(price) OVER (PARTITION BY group_name ROWS (SELECT count(*) FROM PRODUCTS WHERE price = 200) PRECEDING) AS running_avg_of_three FROM products ORDER BY group_id;
+----
+Smartphone  Microsoft Lumia  200.00   200.00
+Smartphone  HTC One          400.00   300.00
+Smartphone  Nexus            500.00   366.66666666666666667
+Smartphone  iPhone           900.00   600.00
+Laptop      HP Elite         1200.00  1200.00
+Laptop      Lenovo Thinkpad  700.00   950.00
+Laptop      Sony VAIO        700.00   866.66666666666666667
+Laptop      Dell             800.00   733.33333333333333333
+Tablet      iPad             700.00   700.00
+Tablet      Kindle Fire      150.00   425.00
+Tablet      Samsung          200.00   350.00
+
+query TTRR
+SELECT group_name, product_name, price, sum(price) OVER (PARTITION BY group_name ROWS 2 PRECEDING) AS running_sum FROM products ORDER BY group_id;
+----
+Smartphone  Microsoft Lumia  200.00   200.00
+Smartphone  HTC One          400.00   600.00
+Smartphone  Nexus            500.00   1100.00
+Smartphone  iPhone           900.00   1800.00
+Laptop      HP Elite         1200.00  1200.00
+Laptop      Lenovo Thinkpad  700.00   1900.00
+Laptop      Sony VAIO        700.00   2600.00
+Laptop      Dell             800.00   2200.00
+Tablet      iPad             700.00   700.00
+Tablet      Kindle Fire      150.00   850.00
+Tablet      Samsung          200.00   1050.00
+
+query TTRT
+SELECT group_name, product_name, price, array_agg(price) OVER (PARTITION BY group_name ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING) AS array_agg_price FROM products ORDER BY group_id;
+----
+Smartphone  Microsoft Lumia  200.00   {200.00,400.00,500.00}
+Smartphone  HTC One          400.00   {200.00,400.00,500.00,900.00}
+Smartphone  Nexus            500.00   {400.00,500.00,900.00}
+Smartphone  iPhone           900.00   {500.00,900.00}
+Laptop      HP Elite         1200.00  {1200.00,700.00,700.00}
+Laptop      Lenovo Thinkpad  700.00   {1200.00,700.00,700.00,800.00}
+Laptop      Sony VAIO        700.00   {700.00,700.00,800.00}
+Laptop      Dell             800.00   {700.00,800.00}
+Tablet      iPad             700.00   {700.00,150.00,200.00}
+Tablet      Kindle Fire      150.00   {700.00,150.00,200.00}
+Tablet      Samsung          200.00   {150.00,200.00}
+
+query TTRR
+SELECT group_name, product_name, price, avg(price) OVER (PARTITION BY group_name RANGE UNBOUNDED PRECEDING) AS avg_price FROM products ORDER BY group_id;
+----
+Smartphone  Microsoft Lumia  200.00   500.00
+Smartphone  HTC One          400.00   500.00
+Smartphone  Nexus            500.00   500.00
+Smartphone  iPhone           900.00   500.00
+Laptop      HP Elite         1200.00  850.00
+Laptop      Lenovo Thinkpad  700.00   850.00
+Laptop      Sony VAIO        700.00   850.00
+Laptop      Dell             800.00   850.00
+Tablet      iPad             700.00   350.00
+Tablet      Kindle Fire      150.00   350.00
+Tablet      Samsung          200.00   350.00
+
+query TTRT
+SELECT group_name, product_name, price, min(price) OVER (PARTITION BY group_name ROWS BETWEEN 1 PRECEDING AND 2 PRECEDING) AS min_over_empty_frame FROM products ORDER BY group_id;
+----
+Smartphone  Microsoft Lumia   200.00  NULL
+Smartphone  HTC One           400.00  NULL
+Smartphone  Nexus             500.00  NULL
+Smartphone  iPhone            900.00  NULL
+Laptop      HP Elite         1200.00  NULL
+Laptop      Lenovo Thinkpad   700.00  NULL
+Laptop      Sony VAIO         700.00  NULL
+Laptop      Dell              800.00  NULL
+Tablet      iPad              700.00  NULL
+Tablet      Kindle Fire       150.00  NULL
+Tablet      Samsung           200.00  NULL
+
+
+query TRRR
+SELECT product_name, price, min(price) OVER (PARTITION BY group_name ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS min_over_three, max(price) OVER (PARTITION BY group_name ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS max_over_partition FROM products ORDER BY group_id;
+----
+Microsoft Lumia  200.00   200.00  900.00
+HTC One          400.00   200.00  900.00
+Nexus            500.00   400.00  900.00
+iPhone           900.00   500.00  900.00
+HP Elite         1200.00  700.00  1200.00
+Lenovo Thinkpad  700.00   700.00  1200.00
+Sony VAIO        700.00   700.00  1200.00
+Dell             800.00   700.00  1200.00
+iPad             700.00   150.00  700.00
+Kindle Fire      150.00   150.00  700.00
+Samsung          200.00   150.00  700.00

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -756,6 +756,34 @@ func TestParse(t *testing.T) {
 		{`SELECT avg(1) OVER (PARTITION BY b ORDER BY c) FROM t`},
 		{`SELECT avg(1) OVER (w PARTITION BY b ORDER BY c) FROM t`},
 
+		{`SELECT avg(1) OVER (ROWS UNBOUNDED PRECEDING) FROM t`},
+		{`SELECT avg(1) OVER (ROWS 1 PRECEDING) FROM t`},
+		{`SELECT avg(1) OVER (ROWS CURRENT ROW) FROM t`},
+		{`SELECT avg(1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) FROM t`},
+		{`SELECT avg(1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM t`},
+		{`SELECT avg(1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING) FROM t`},
+		{`SELECT avg(1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM t`},
+		{`SELECT avg(1) OVER (ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) FROM t`},
+		{`SELECT avg(1) OVER (ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) FROM t`},
+		{`SELECT avg(1) OVER (ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM t`},
+		{`SELECT avg(1) OVER (ROWS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING) FROM t`},
+		{`SELECT avg(1) OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW) FROM t`},
+		{`SELECT avg(1) OVER (ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) FROM t`},
+		{`SELECT avg(1) OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) FROM t`},
+		{`SELECT avg(1) OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING) FROM t`},
+		{`SELECT avg(1) OVER (ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING) FROM t`},
+		{`SELECT avg(1) OVER (RANGE UNBOUNDED PRECEDING) FROM t`},
+		{`SELECT avg(1) OVER (RANGE CURRENT ROW) FROM t`},
+		{`SELECT avg(1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM t`},
+		{`SELECT avg(1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM t`},
+		{`SELECT avg(1) OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW) FROM t`},
+		{`SELECT avg(1) OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) FROM t`},
+		{`SELECT avg(1) OVER (w ROWS UNBOUNDED PRECEDING) FROM t`},
+		{`SELECT avg(1) OVER (PARTITION BY b ROWS UNBOUNDED PRECEDING) FROM t`},
+		{`SELECT avg(1) OVER (ORDER BY c ROWS UNBOUNDED PRECEDING) FROM t`},
+		{`SELECT avg(1) OVER (PARTITION BY b ORDER BY c ROWS UNBOUNDED PRECEDING) FROM t`},
+		{`SELECT avg(1) OVER (w PARTITION BY b ORDER BY c ROWS UNBOUNDED PRECEDING) FROM t`},
+
 		{`SELECT a FROM t UNION SELECT 1 FROM t`},
 		{`SELECT a FROM t UNION SELECT 1 FROM t UNION SELECT 1 FROM t`},
 		{`SELECT a FROM t UNION ALL SELECT 1 FROM t`},
@@ -1988,6 +2016,83 @@ HINT: try \h RESTORE`,
 SELECT max(a ORDER BY b) FROM ab
                        ^
 HINT: See: https://github.com/cockroachdb/cockroach/issues/23620`,
+		},
+		{
+			`SELECT avg(1) OVER (RANGE 1 PRECEDING) FROM t`,
+			`RANGE PRECEDING is only supported with UNBOUNDED at or near "preceding"
+SELECT avg(1) OVER (RANGE 1 PRECEDING) FROM t
+                            ^
+`,
+		},
+		{
+			`SELECT avg(1) OVER (RANGE BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING) FROM t`,
+			`RANGE FOLLOWING is only supported with UNBOUNDED at or near "following"
+SELECT avg(1) OVER (RANGE BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING) FROM t
+                                                            ^
+`,
+		},
+		{
+			`SELECT avg(1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) FROM t`,
+			`RANGE PRECEDING is only supported with UNBOUNDED at or near "preceding"
+SELECT avg(1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) FROM t
+                                                            ^
+`,
+		},
+		{
+			`SELECT avg(1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING) FROM t`,
+			`RANGE FOLLOWING is only supported with UNBOUNDED at or near "following"
+SELECT avg(1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING) FROM t
+                                                            ^
+`,
+		},
+		{
+			`SELECT avg(1) OVER (ROWS UNBOUNDED FOLLOWING) FROM t`,
+			`frame start cannot be UNBOUNDED FOLLOWING at or near "following"
+SELECT avg(1) OVER (ROWS UNBOUNDED FOLLOWING) FROM t
+                                   ^
+`,
+		},
+		{
+			`SELECT avg(1) OVER (ROWS 1 FOLLOWING) FROM t`,
+			`frame starting from following row cannot end with current row at or near "following"
+SELECT avg(1) OVER (ROWS 1 FOLLOWING) FROM t
+                           ^
+`,
+		},
+		{
+			`SELECT avg(1) OVER (ROWS BETWEEN UNBOUNDED FOLLOWING AND UNBOUNDED FOLLOWING) FROM t`,
+			`frame start cannot be UNBOUNDED FOLLOWING at or near "following"
+SELECT avg(1) OVER (ROWS BETWEEN UNBOUNDED FOLLOWING AND UNBOUNDED FOLLOWING) FROM t
+                                                                   ^
+`,
+		},
+		{
+			`SELECT avg(1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED PRECEDING) FROM t`,
+			`frame end cannot be UNBOUNDED PRECEDING at or near "preceding"
+SELECT avg(1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED PRECEDING) FROM t
+                                                                   ^
+`,
+		},
+		{
+			`SELECT avg(1) OVER (ROWS BETWEEN CURRENT ROW AND 1 PRECEDING) FROM t`,
+			`frame starting from current row cannot have preceding rows at or near "preceding"
+SELECT avg(1) OVER (ROWS BETWEEN CURRENT ROW AND 1 PRECEDING) FROM t
+                                                   ^
+`,
+		},
+		{
+			`SELECT avg(1) OVER (ROWS BETWEEN 1 FOLLOWING AND 1 PRECEDING) FROM t`,
+			`frame starting from following row cannot have preceding rows at or near "preceding"
+SELECT avg(1) OVER (ROWS BETWEEN 1 FOLLOWING AND 1 PRECEDING) FROM t
+                                                   ^
+`,
+		},
+		{
+			`SELECT avg(1) OVER (ROWS BETWEEN 1 FOLLOWING AND CURRENT ROW) FROM t`,
+			`frame starting from following row cannot have preceding rows at or near "row"
+SELECT avg(1) OVER (ROWS BETWEEN 1 FOLLOWING AND CURRENT ROW) FROM t
+                                                         ^
+`,
 		},
 	}
 	for _, d := range testData {

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -156,7 +156,7 @@ var aggregates = map[string]builtinDefinition{
 			ReturnType:    tree.FixedReturnType(types.Int),
 			AggregateFunc: newCountRowsAggregate,
 			WindowFunc: func(params []types.T, evalCtx *tree.EvalContext) tree.WindowFunc {
-				return newAggregateWindow(newCountRowsAggregate(params, evalCtx))
+				return newFramableAggregateWindow(newCountRowsAggregate(params, evalCtx))
 			},
 			Info: "Calculates the number of rows.",
 		},
@@ -318,7 +318,7 @@ func makeAggOverloadWithReturnType(
 		ReturnType:    retType,
 		AggregateFunc: f,
 		WindowFunc: func(params []types.T, evalCtx *tree.EvalContext) tree.WindowFunc {
-			return newAggregateWindow(f(params, evalCtx))
+			return newFramableAggregateWindow(f(params, evalCtx))
 		},
 		Info: info,
 	}

--- a/pkg/sql/sem/builtins/window_builtins.go
+++ b/pkg/sql/sem/builtins/window_builtins.go
@@ -125,6 +125,7 @@ func makeWindowOverload(
 }
 
 var _ tree.WindowFunc = &aggregateWindowFunc{}
+var _ tree.WindowFunc = &framableAggregateWindowFunc{}
 var _ tree.WindowFunc = &rowNumberWindow{}
 var _ tree.WindowFunc = &rankWindow{}
 var _ tree.WindowFunc = &denseRankWindow{}
@@ -143,21 +144,17 @@ type aggregateWindowFunc struct {
 	peerRes tree.Datum
 }
 
-func newAggregateWindow(agg tree.AggregateFunc) tree.WindowFunc {
-	return &aggregateWindowFunc{agg: agg}
-}
-
 func (w *aggregateWindowFunc) Compute(
-	ctx context.Context, evalCtx *tree.EvalContext, wf tree.WindowFrame,
+	ctx context.Context, evalCtx *tree.EvalContext, wfr *tree.WindowFrameRun,
 ) (tree.Datum, error) {
-	if !wf.FirstInPeerGroup() {
+	if !wfr.FirstInPeerGroup() {
 		return w.peerRes, nil
 	}
 
 	// Accumulate all values in the peer group at the same time, as these
 	// must return the same value.
-	for i := 0; i < wf.PeerRowCount; i++ {
-		args := wf.ArgsWithRowOffset(i)
+	for i := 0; i < wfr.PeerRowCount; i++ {
+		args := wfr.ArgsWithRowOffset(i)
 		var value tree.Datum
 		// COUNT_ROWS takes no arguments.
 		if len(args) > 0 {
@@ -169,7 +166,6 @@ func (w *aggregateWindowFunc) Compute(
 	}
 
 	// Retrieve the value for the entire peer group, save it, and return it.
-
 	peerRes, err := w.agg.Result()
 	if err != nil {
 		return nil, err
@@ -182,6 +178,71 @@ func (w *aggregateWindowFunc) Close(ctx context.Context, evalCtx *tree.EvalConte
 	w.agg.Close(ctx)
 }
 
+// framableAggregateWindowFunc is a wrapper around aggregateWindowFunc that allows
+// to reset the aggregate by creating a new instance via a provided constructor.
+type framableAggregateWindowFunc struct {
+	agg            *aggregateWindowFunc
+	aggConstructor func(*tree.EvalContext) tree.AggregateFunc
+}
+
+func newFramableAggregateWindow(agg tree.AggregateFunc) tree.WindowFunc {
+	return &framableAggregateWindowFunc{agg: &aggregateWindowFunc{agg: agg}}
+}
+
+func (w *framableAggregateWindowFunc) Compute(
+	ctx context.Context, evalCtx *tree.EvalContext, wfr *tree.WindowFrameRun,
+) (tree.Datum, error) {
+	if !wfr.FirstInPeerGroup() {
+		return w.agg.peerRes, nil
+	}
+	if w.aggConstructor == nil {
+		// No constructor is given, so we use default approach.
+		return w.agg.Compute(ctx, evalCtx, wfr)
+	}
+
+	// When aggConstructor is provided, we want to dispose of the old aggregate function
+	// and construct a new one for the computation.
+	w.agg.Close(ctx, evalCtx)
+	*w.agg = aggregateWindowFunc{w.aggConstructor(evalCtx), tree.DNull}
+
+	// Accumulate all values in the window frame.
+	for i := wfr.FrameStartIdx(); i < wfr.FrameEndIdx(); i++ {
+		args := wfr.ArgsByRowIdx(i)
+		var value tree.Datum
+		// COUNT_ROWS takes no arguments.
+		if len(args) > 0 {
+			value = args[0]
+		}
+		if err := w.agg.agg.Add(ctx, value); err != nil {
+			return nil, err
+		}
+	}
+
+	// Retrieve the value for the entire peer group, save it, and return it.
+	peerRes, err := w.agg.agg.Result()
+	if err != nil {
+		return nil, err
+	}
+	w.agg.peerRes = peerRes
+	return w.agg.peerRes, nil
+}
+
+func (w *framableAggregateWindowFunc) Close(ctx context.Context, evalCtx *tree.EvalContext) {
+	w.agg.Close(ctx, evalCtx)
+}
+
+// AddAggregateConstructorToFramableAggregate adds provided constructor to framableAggregateWindowFunc
+// so that aggregates can be 'reset' when computing values over a window frame.
+func AddAggregateConstructorToFramableAggregate(
+	windowFunc tree.WindowFunc, aggConstructor func(*tree.EvalContext) tree.AggregateFunc,
+) {
+	// We only want to add aggConstructor to framableAggregateWindowFunc's since
+	// all non-aggregates builtins specific to window functions support framing "natively".
+	if framableAgg, ok := windowFunc.(*framableAggregateWindowFunc); ok {
+		framableAgg.aggConstructor = aggConstructor
+	}
+}
+
 // rowNumberWindow computes the number of the current row within its partition,
 // counting from 1.
 type rowNumberWindow struct{}
@@ -191,9 +252,9 @@ func newRowNumberWindow([]types.T, *tree.EvalContext) tree.WindowFunc {
 }
 
 func (rowNumberWindow) Compute(
-	_ context.Context, _ *tree.EvalContext, wf tree.WindowFrame,
+	_ context.Context, _ *tree.EvalContext, wfr *tree.WindowFrameRun,
 ) (tree.Datum, error) {
-	return tree.NewDInt(tree.DInt(wf.RowIdx + 1 /* one-indexed */)), nil
+	return tree.NewDInt(tree.DInt(wfr.RowIdx + 1 /* one-indexed */)), nil
 }
 
 func (rowNumberWindow) Close(context.Context, *tree.EvalContext) {}
@@ -208,10 +269,10 @@ func newRankWindow([]types.T, *tree.EvalContext) tree.WindowFunc {
 }
 
 func (w *rankWindow) Compute(
-	_ context.Context, _ *tree.EvalContext, wf tree.WindowFrame,
+	_ context.Context, _ *tree.EvalContext, wfr *tree.WindowFrameRun,
 ) (tree.Datum, error) {
-	if wf.FirstInPeerGroup() {
-		w.peerRes = tree.NewDInt(tree.DInt(wf.Rank()))
+	if wfr.FirstInPeerGroup() {
+		w.peerRes = tree.NewDInt(tree.DInt(wfr.Rank()))
 	}
 	return w.peerRes, nil
 }
@@ -229,9 +290,9 @@ func newDenseRankWindow([]types.T, *tree.EvalContext) tree.WindowFunc {
 }
 
 func (w *denseRankWindow) Compute(
-	_ context.Context, _ *tree.EvalContext, wf tree.WindowFrame,
+	_ context.Context, _ *tree.EvalContext, wfr *tree.WindowFrameRun,
 ) (tree.Datum, error) {
-	if wf.FirstInPeerGroup() {
+	if wfr.FirstInPeerGroup() {
 		w.denseRank++
 		w.peerRes = tree.NewDInt(tree.DInt(w.denseRank))
 	}
@@ -253,16 +314,16 @@ func newPercentRankWindow([]types.T, *tree.EvalContext) tree.WindowFunc {
 var dfloatZero = tree.NewDFloat(0)
 
 func (w *percentRankWindow) Compute(
-	_ context.Context, _ *tree.EvalContext, wf tree.WindowFrame,
+	_ context.Context, _ *tree.EvalContext, wfr *tree.WindowFrameRun,
 ) (tree.Datum, error) {
 	// Return zero if there's only one row, per spec.
-	if wf.RowCount() <= 1 {
+	if wfr.PartitionSize() <= 1 {
 		return dfloatZero, nil
 	}
 
-	if wf.FirstInPeerGroup() {
+	if wfr.FirstInPeerGroup() {
 		// (rank - 1) / (total rows - 1)
-		w.peerRes = tree.NewDFloat(tree.DFloat(wf.Rank()-1) / tree.DFloat(wf.RowCount()-1))
+		w.peerRes = tree.NewDFloat(tree.DFloat(wfr.Rank()-1) / tree.DFloat(wfr.PartitionSize()-1))
 	}
 	return w.peerRes, nil
 }
@@ -280,11 +341,11 @@ func newCumulativeDistWindow([]types.T, *tree.EvalContext) tree.WindowFunc {
 }
 
 func (w *cumulativeDistWindow) Compute(
-	_ context.Context, _ *tree.EvalContext, wf tree.WindowFrame,
+	_ context.Context, _ *tree.EvalContext, wfr *tree.WindowFrameRun,
 ) (tree.Datum, error) {
-	if wf.FirstInPeerGroup() {
+	if wfr.FirstInPeerGroup() {
 		// (number of rows preceding or peer with current row) / (total rows)
-		w.peerRes = tree.NewDFloat(tree.DFloat(wf.FrameSize()) / tree.DFloat(wf.RowCount()))
+		w.peerRes = tree.NewDFloat(tree.DFloat(wfr.DefaultFrameSize()) / tree.DFloat(wfr.PartitionSize()))
 	}
 	return w.peerRes, nil
 }
@@ -308,13 +369,13 @@ var errInvalidArgumentForNtile = pgerror.NewErrorf(
 	pgerror.CodeInvalidParameterValueError, "argument of ntile() must be greater than zero")
 
 func (w *ntileWindow) Compute(
-	_ context.Context, _ *tree.EvalContext, wf tree.WindowFrame,
+	_ context.Context, _ *tree.EvalContext, wfr *tree.WindowFrameRun,
 ) (tree.Datum, error) {
 	if w.ntile == nil {
 		// If this is the first call to ntileWindow.Compute, set up the buckets.
-		total := wf.RowCount()
+		total := wfr.PartitionSize()
 
-		arg := wf.Args()[0]
+		arg := wfr.Args()[0]
 		if arg == tree.DNull {
 			// per spec: If argument is the null value, then the result is the null value.
 			return tree.DNull, nil
@@ -378,11 +439,11 @@ func makeLeadLagWindowConstructor(
 }
 
 func (w *leadLagWindow) Compute(
-	_ context.Context, _ *tree.EvalContext, wf tree.WindowFrame,
+	_ context.Context, _ *tree.EvalContext, wfr *tree.WindowFrameRun,
 ) (tree.Datum, error) {
 	offset := 1
 	if w.withOffset {
-		offsetArg := wf.Args()[1]
+		offsetArg := wfr.Args()[1]
 		if offsetArg == tree.DNull {
 			return tree.DNull, nil
 		}
@@ -392,16 +453,16 @@ func (w *leadLagWindow) Compute(
 		offset *= -1
 	}
 
-	if targetRow := wf.RowIdx + offset; targetRow < 0 || targetRow >= wf.RowCount() {
+	if targetRow := wfr.RowIdx + offset; targetRow < 0 || targetRow >= wfr.PartitionSize() {
 		// Target row is out of the partition; supply default value if provided,
 		// otherwise return NULL.
 		if w.withDefault {
-			return wf.Args()[2], nil
+			return wfr.Args()[2], nil
 		}
 		return tree.DNull, nil
 	}
 
-	return wf.ArgsWithRowOffset(offset)[0], nil
+	return wfr.ArgsWithRowOffset(offset)[0], nil
 }
 
 func (w *leadLagWindow) Close(context.Context, *tree.EvalContext) {}
@@ -414,9 +475,9 @@ func newFirstValueWindow([]types.T, *tree.EvalContext) tree.WindowFunc {
 }
 
 func (firstValueWindow) Compute(
-	_ context.Context, _ *tree.EvalContext, wf tree.WindowFrame,
+	_ context.Context, _ *tree.EvalContext, wfr *tree.WindowFrameRun,
 ) (tree.Datum, error) {
-	return wf.Rows[0].Row[wf.ArgIdxStart], nil
+	return wfr.Rows[wfr.FrameStartIdx()].Row[wfr.ArgIdxStart], nil
 }
 
 func (firstValueWindow) Close(context.Context, *tree.EvalContext) {}
@@ -429,9 +490,9 @@ func newLastValueWindow([]types.T, *tree.EvalContext) tree.WindowFunc {
 }
 
 func (lastValueWindow) Compute(
-	_ context.Context, _ *tree.EvalContext, wf tree.WindowFrame,
+	_ context.Context, _ *tree.EvalContext, wfr *tree.WindowFrameRun,
 ) (tree.Datum, error) {
-	return wf.Rows[wf.FrameSize()-1].Row[wf.ArgIdxStart], nil
+	return wfr.Rows[wfr.FrameEndIdx()-1].Row[wfr.ArgIdxStart], nil
 }
 
 func (lastValueWindow) Close(context.Context, *tree.EvalContext) {}
@@ -448,9 +509,9 @@ var errInvalidArgumentForNthValue = pgerror.NewErrorf(
 	pgerror.CodeInvalidParameterValueError, "argument of nth_value() must be greater than zero")
 
 func (nthValueWindow) Compute(
-	_ context.Context, _ *tree.EvalContext, wf tree.WindowFrame,
+	_ context.Context, _ *tree.EvalContext, wfr *tree.WindowFrameRun,
 ) (tree.Datum, error) {
-	arg := wf.Args()[1]
+	arg := wfr.Args()[1]
 	if arg == tree.DNull {
 		return tree.DNull, nil
 	}
@@ -460,12 +521,10 @@ func (nthValueWindow) Compute(
 		return nil, errInvalidArgumentForNthValue
 	}
 
-	// per spec: Only consider the rows within the "window frame", which by default contains
-	// the rows from the start of the partition through the last peer of the current row.
-	if nth > wf.FrameSize() {
+	if nth > wfr.FrameSize() {
 		return tree.DNull, nil
 	}
-	return wf.Rows[nth-1].Row[wf.ArgIdxStart], nil
+	return wfr.Rows[wfr.FrameStartIdx()+nth-1].Row[wfr.ArgIdxStart], nil
 }
 
 func (nthValueWindow) Close(context.Context, *tree.EvalContext) {}

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -758,6 +758,24 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, e
 			}
 			expr.WindowDef.OrderBy[i].Expr = typedOrderBy
 		}
+		if expr.WindowDef.Frame != nil {
+			bounds := expr.WindowDef.Frame.Bounds
+			startBound, endBound := bounds.StartBound, bounds.EndBound
+			if startBound.OffsetExpr != nil {
+				typedStartOffsetExpr, err := typeCheckAndRequire(ctx, startBound.OffsetExpr, types.Int, "window frame start")
+				if err != nil {
+					return nil, err
+				}
+				startBound.OffsetExpr = typedStartOffsetExpr
+			}
+			if endBound != nil && endBound.OffsetExpr != nil {
+				typedEndOffsetExpr, err := typeCheckAndRequire(ctx, endBound.OffsetExpr, types.Int, "window frame end")
+				if err != nil {
+					return nil, err
+				}
+				endBound.OffsetExpr = typedEndOffsetExpr
+			}
+		}
 	} else {
 		// Make sure the window function builtins are used as window function applications.
 		if def.Class == WindowClass {

--- a/pkg/sql/sem/tree/window_funs.go
+++ b/pkg/sql/sem/tree/window_funs.go
@@ -14,7 +14,9 @@
 
 package tree
 
-import "context"
+import (
+	"context"
+)
 
 // IndexedRow is a row with a corresponding index.
 type IndexedRow struct {
@@ -22,12 +24,15 @@ type IndexedRow struct {
 	Row Datums
 }
 
-// WindowFrame is a view into a subset of data over which calculations are made.
-type WindowFrame struct {
+// WindowFrameRun contains the runtime state of window frame during calculations.
+type WindowFrameRun struct {
 	// constant for all calls to WindowFunc.Add
-	Rows        []IndexedRow
-	ArgIdxStart int // the index which arguments to the window function begin
-	ArgCount    int // the number of window function arguments
+	Rows             []IndexedRow
+	ArgIdxStart      int          // the index which arguments to the window function begin
+	ArgCount         int          // the number of window function arguments
+	Frame            *WindowFrame // If non-nil, Frame represents the frame specification of this window. If nil, default frame is used.
+	StartBoundOffset int
+	EndBoundOffset   int
 
 	// changes for each row (each call to WindowFunc.Add)
 	RowIdx int // the current row index
@@ -37,39 +42,165 @@ type WindowFrame struct {
 	PeerRowCount int // the number of rows in the current peer group
 }
 
-// Rank returns the rank of this frame.
-func (wf WindowFrame) Rank() int {
-	return wf.RowIdx + 1
+// FrameStartIdx returns the index of starting row in the frame (which is the first to be included).
+func (wfr WindowFrameRun) FrameStartIdx() int {
+	if wfr.Frame == nil {
+		return 0
+	}
+	switch wfr.Frame.Mode {
+	case RANGE:
+		switch wfr.Frame.Bounds.StartBound.BoundType {
+		case UnboundedPreceding:
+			return 0
+		case ValuePreceding:
+			// TODO(yuzefovich): Currently, it is not supported, and this case should not be reached.
+			panic("unsupported WindowFrameBoundType in RANGE mode")
+		case CurrentRow:
+			// Spec: in RANGE mode CURRENT ROW means that the frame starts with the current row's first peer.
+			return wfr.FirstPeerIdx
+		case ValueFollowing:
+			// TODO(yuzefovich): Currently, it is not supported, and this case should not be reached.
+			panic("unsupported WindowFrameBoundType in RANGE mode")
+		default:
+			panic("unexpected WindowFrameBoundType in RANGE mode")
+		}
+	case ROWS:
+		switch wfr.Frame.Bounds.StartBound.BoundType {
+		case UnboundedPreceding:
+			return 0
+		case ValuePreceding:
+			idx := wfr.RowIdx - wfr.StartBoundOffset
+			if idx < 0 {
+				idx = 0
+			}
+			return idx
+		case CurrentRow:
+			return wfr.RowIdx
+		case ValueFollowing:
+			idx := wfr.RowIdx + wfr.StartBoundOffset
+			if idx >= wfr.PartitionSize() {
+				idx = wfr.unboundedFollowing()
+			}
+			return idx
+		default:
+			panic("unexpected WindowFrameBoundType in ROWS mode")
+		}
+	default:
+		panic("unexpected WindowFrameMode")
+	}
 }
 
-// RowCount returns the number of rows in this frame.
-func (wf WindowFrame) RowCount() int {
-	return len(wf.Rows)
+// FrameEndIdx returns the index of the first row after the frame.
+func (wfr WindowFrameRun) FrameEndIdx() int {
+	if wfr.Frame == nil {
+		return wfr.DefaultFrameSize()
+	}
+	switch wfr.Frame.Mode {
+	case RANGE:
+		if wfr.Frame.Bounds.EndBound == nil {
+			// We're using default value of CURRENT ROW when EndBound is omitted.
+			// Spec: in RANGE mode CURRENT ROW means that the frame ends with the current row's last peer.
+			return wfr.DefaultFrameSize()
+		}
+		switch wfr.Frame.Bounds.EndBound.BoundType {
+		case ValuePreceding:
+			// TODO(yuzefovich): Currently, it is not supported, and this case should not be reached.
+			panic("unsupported WindowFrameBoundType in RANGE mode")
+		case CurrentRow:
+			return wfr.DefaultFrameSize()
+		case ValueFollowing:
+			// TODO(yuzefovich): Currently, it is not supported, and this case should not be reached.
+			panic("unsupported WindowFrameBoundType in RANGE mode")
+		case UnboundedFollowing:
+			return wfr.unboundedFollowing()
+		default:
+			panic("unexpected WindowFrameBoundType in RANGE mode")
+		}
+	case ROWS:
+		if wfr.Frame.Bounds.EndBound == nil {
+			// We're using default value of CURRENT ROW when EndBound is omitted.
+			return wfr.RowIdx + 1
+		}
+		switch wfr.Frame.Bounds.EndBound.BoundType {
+		case ValuePreceding:
+			idx := wfr.RowIdx - wfr.EndBoundOffset + 1
+			if idx < 0 {
+				idx = 0
+			}
+			return idx
+		case CurrentRow:
+			return wfr.RowIdx + 1
+		case ValueFollowing:
+			idx := wfr.RowIdx + wfr.EndBoundOffset + 1
+			if idx >= wfr.PartitionSize() {
+				idx = wfr.unboundedFollowing()
+			}
+			return idx
+		case UnboundedFollowing:
+			return wfr.unboundedFollowing()
+		default:
+			panic("unexpected WindowFrameBoundType in ROWS mode")
+		}
+	default:
+		panic("unexpected WindowFrameMode")
+	}
 }
 
-// FrameSize returns the size of this frame.
-// TODO(nvanbenschoten): This definition only holds while we don't support
-// frame specification (RANGE or ROWS) in the OVER clause.
-func (wf WindowFrame) FrameSize() int {
-	return wf.FirstPeerIdx + wf.PeerRowCount
+// FrameSize returns the number of rows in the current frame.
+func (wfr WindowFrameRun) FrameSize() int {
+	if wfr.Frame == nil {
+		return wfr.DefaultFrameSize()
+	}
+	size := wfr.FrameEndIdx() - wfr.FrameStartIdx()
+	if size <= 0 {
+		size = 0
+	}
+	return size
+}
+
+// Rank returns the rank of the current row.
+func (wfr WindowFrameRun) Rank() int {
+	return wfr.RowIdx + 1
+}
+
+// PartitionSize returns the number of rows in the current partition.
+func (wfr WindowFrameRun) PartitionSize() int {
+	return len(wfr.Rows)
+}
+
+// unboundedFollowing returns the index of the "first row beyond" the partition
+// so that current frame contains all the rows till the end of the partition.
+func (wfr WindowFrameRun) unboundedFollowing() int {
+	return wfr.PartitionSize()
+}
+
+// DefaultFrameSize returns the size of default window frame which contains
+// the rows from the start of the partition through the last peer of the current row.
+func (wfr WindowFrameRun) DefaultFrameSize() int {
+	return wfr.FirstPeerIdx + wfr.PeerRowCount
 }
 
 // FirstInPeerGroup returns if the current row is the first in its peer group.
-func (wf WindowFrame) FirstInPeerGroup() bool {
-	return wf.RowIdx == wf.FirstPeerIdx
+func (wfr WindowFrameRun) FirstInPeerGroup() bool {
+	return wfr.RowIdx == wfr.FirstPeerIdx
 }
 
 // Args returns the current argument set in the window frame.
-func (wf WindowFrame) Args() Datums {
-	return wf.ArgsWithRowOffset(0)
+func (wfr WindowFrameRun) Args() Datums {
+	return wfr.ArgsWithRowOffset(0)
 }
 
-// ArgsWithRowOffset returns the argumnent set at the given offset in the window frame.
-func (wf WindowFrame) ArgsWithRowOffset(offset int) Datums {
-	return wf.Rows[wf.RowIdx+offset].Row[wf.ArgIdxStart : wf.ArgIdxStart+wf.ArgCount]
+// ArgsWithRowOffset returns the argument set at the given offset in the window frame.
+func (wfr WindowFrameRun) ArgsWithRowOffset(offset int) Datums {
+	return wfr.Rows[wfr.RowIdx+offset].Row[wfr.ArgIdxStart : wfr.ArgIdxStart+wfr.ArgCount]
 }
 
-// WindowFunc performs a computation on each row using data from a provided WindowFrame.
+// ArgsByRowIdx returns the argument set of the row at idx.
+func (wfr WindowFrameRun) ArgsByRowIdx(idx int) Datums {
+	return wfr.Rows[idx].Row[wfr.ArgIdxStart : wfr.ArgIdxStart+wfr.ArgCount]
+}
+
+// WindowFunc performs a computation on each row using data from a provided WindowFrameRun.
 type WindowFunc interface {
 	// Compute computes the window function for the provided window frame, given the
 	// current state of WindowFunc. The method should be called sequentially for every
@@ -77,7 +208,7 @@ type WindowFunc interface {
 	// because there is an implicit carried dependency between each row and all those
 	// that have come before it (like in an AggregateFunc). As such, this approach does
 	// not present any exploitable associativity/commutativity for optimization.
-	Compute(context.Context, *EvalContext, WindowFrame) (Datum, error)
+	Compute(context.Context, *EvalContext, *WindowFrameRun) (Datum, error)
 
 	// Close allows the window function to free any memory it requested during execution,
 	// such as during the execution of an aggregation like CONCAT_AGG or ARRAY_AGG.


### PR DESCRIPTION
WIP on #26464:
ROWS mode is fully supported whereas RANGE works only with
UNBOUNDED PRECEDING/CURRENT ROW/UNBOUNDED FOLLOWING boundaries
(same as in PostgreSQL). Current implementation of aggregate functions
is naive (it simply computes the value of aggregate directly and
discards all the previous computations which results in quadratic time).

Release note: None