### PR TITLE
client: fix concurrent retries interaction with txnError state

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1595,7 +1595,7 @@ func (ex *connExecutor) synchronizeParallelStmts(ctx context.Context) error {
 			// these writes might have been performed at the wrong epoch). Note
 			// that we don't need to lock the client.Txn because we're synchronized.
 			// See #17197.
-			ex.state.mu.txn.Proto().BumpEpoch()
+			ex.state.mu.txn.BumpEpochAfterConcurrentRetryErrorLocked()
 		case *roachpb.TxnPrevAttemptError:
 			log.Fatalf(ctx, "found symptoms of a concurrent retry, but did "+
 				"not find the final retry error: %v", errs)


### PR DESCRIPTION
The new `txnError` state was causing issues with parallel statements
and concurrent access to a txn. The issue was that SQL wanted to
retry a txn when it saw both retryable and non-retryable errors
(see `synchronizeParallelStmts` for a discussion why) while
`client.Txn` did not. This meant that SQL would retry but the
client would be stuck in a `txnError` state. This change fixes
this.

It all should be removed soon when #25329 is fixed.

Release note: None