### PR TITLE
sql: support PREPARE-ing and EXECUTE-ing parallel statements

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -200,15 +200,11 @@ func (ex *connExecutor) execStmtInOpenState(
 		return ev, payload, nil
 	}
 
-	// Check if the statement is parallelized or is independent from parallel
-	// execution. If neither of these cases are true, we need to synchronize
-	// parallel execution by letting it drain before we can begin executing stmt.
-	parallelize := IsStmtParallelized(stmt)
-	_, independentFromParallelStmts := stmt.AST.(tree.IndependentFromParallelizedPriors)
-	if !(parallelize || independentFromParallelStmts) {
-		if err := ex.synchronizeParallelStmts(ctx); err != nil {
-			return makeErrEvent(err)
-		}
+	// Check if the statement should be parallelized. If not, we may need to
+	// synchronize.
+	parallelize, err := ex.maybeSynchronizeParallelStmts(ctx, stmt)
+	if err != nil {
+		return makeErrEvent(err)
 	}
 
 	switch s := stmt.AST.(type) {
@@ -309,6 +305,12 @@ func (ex *connExecutor) execStmtInOpenState(
 		stmt.ExpectedTypes = ps.Columns
 		stmt.AnonymizedStr = ps.AnonymizedStr
 		res.ResetStmtType(ps.Statement)
+
+		// Check again if the statement should be parallelized.
+		parallelize, err = ex.maybeSynchronizeParallelStmts(ctx, stmt)
+		if err != nil {
+			return makeErrEvent(err)
+		}
 	}
 
 	// For regular statements (the ones that get to this point), we don't return
@@ -428,6 +430,22 @@ func (ex *connExecutor) execStmtInOpenState(
 
 	// No event was generated.
 	return nil, nil, nil
+}
+
+// maybeSynchronizeParallelStmts check if the statement is parallelized or is
+// independent from parallel execution. If neither of these cases are true, the
+// method synchronizes parallel execution by letting it drain before returning.
+func (ex *connExecutor) maybeSynchronizeParallelStmts(
+	ctx context.Context, stmt Statement,
+) (parallelize bool, _ error) {
+	parallelize = IsStmtParallelized(stmt)
+	_, independentFromParallelStmts := stmt.AST.(tree.IndependentFromParallelizedPriors)
+	if !(parallelize || independentFromParallelStmts) {
+		if err := ex.synchronizeParallelStmts(ctx); err != nil {
+			return false, err
+		}
+	}
+	return parallelize, nil
 }
 
 // commitSQLTransaction executes a COMMIT or RELEASE SAVEPOINT statement. The

--- a/pkg/sql/logictest/testdata/logic_test/parallel_stmts
+++ b/pkg/sql/logictest/testdata/logic_test/parallel_stmts
@@ -403,3 +403,45 @@ SELECT count(*) FROM kv WHERE k = 2
 
 statement ok
 ROLLBACK
+
+
+# Parallel statements can be prepared and executed.
+
+statement ok
+PREPARE x AS INSERT INTO kv VALUES ($1, $2) RETURNING NOTHING
+
+statement ok
+BEGIN
+
+statement ok
+EXECUTE x(1, 2)
+
+statement ok
+EXECUTE x(1, 2)
+
+# We know the ParallelizeQueue was used because the error was not returned
+# when the statement was EXECUTED.
+statement error duplicate key value \(k\)=\(1\) violates unique constraint "primary"
+COMMIT
+
+statement ok
+BEGIN
+
+statement ok
+EXECUTE x(1, 2)
+
+statement ok
+EXECUTE x(2, 3)
+
+statement ok
+EXECUTE x(3, 4)
+
+statement ok
+COMMIT
+
+query II
+SELECT k, v FROM kv ORDER BY k
+----
+1  2
+2  3
+3  4

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -400,6 +400,8 @@ func (*Execute) StatementType() StatementType { return Unknown }
 // StatementTag returns a short string identifying the type of statement.
 func (*Execute) StatementTag() string { return "EXECUTE" }
 
+func (*Execute) independentFromParallelizedPriors() {}
+
 // StatementType implements the Statement interface.
 func (*Explain) StatementType() StatementType { return Rows }
 


### PR DESCRIPTION
Before this change, a parallel statement would not execute in
parallel if it was prepared using the `PREPARE` statement and
executed using the `EXECUTE` statement. This may not be very
important, but it was inconsistent.

Release note: None