### PR TITLE
sql: only set PlaceholderInfo type if not already set

### DIFF
--- a/pkg/sql/sem/tree/placeholders.go
+++ b/pkg/sql/sem/tree/placeholders.go
@@ -145,11 +145,13 @@ func (p *PlaceholderInfo) Value(name string) (TypedExpr, bool) {
 // SetType assigns a known type to a placeholder.
 // Reports an error if another type was previously assigned.
 func (p *PlaceholderInfo) SetType(name string, typ types.T) error {
-	t, ok := p.Types[name]
-	if ok && !typ.Equivalent(t) {
-		return pgerror.NewErrorf(
-			pgerror.CodeDatatypeMismatchError,
-			"placeholder %s already has type %s, cannot assign %s", name, t, typ)
+	if t, ok := p.Types[name]; ok {
+		if !typ.Equivalent(t) {
+			return pgerror.NewErrorf(
+				pgerror.CodeDatatypeMismatchError,
+				"placeholder %s already has type %s, cannot assign %s", name, t, typ)
+		}
+		return nil
 	}
 	p.Types[name] = typ
 	if _, ok := p.TypeHints[name]; !ok {


### PR DESCRIPTION
Fixes #23171.

This change fixes a `concurrent map read and map write` panic.
The panic was caused because a shared map that is populated during
statement preparation was being updated during statement execution.
However, this update was unnecessary because we were simply replacing
a value with itself. This change fixes the issue.

Release note: None