### PR TITLE
workload: introduce Ledger workload

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all.go
+++ b/pkg/ccl/workloadccl/allccl/all.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/workload/interleavedpartitioned"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/jsonload"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/kv"
+	_ "github.com/cockroachdb/cockroach/pkg/workload/ledger"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/querybench"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/queue"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpcc"

--- a/pkg/workload/ledger/balance.go
+++ b/pkg/workload/ledger/balance.go
@@ -16,11 +16,9 @@
 package ledger
 
 import (
-	"context"
 	gosql "database/sql"
 	"math/rand"
 
-	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -32,13 +30,6 @@ func (bal balance) run(config *ledger, db *gosql.DB) (interface{}, error) {
 	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 	cID := config.randCustomer(rng)
 
-	err := crdb.ExecuteTx(
-		context.Background(),
-		db,
-		nil, /* txopts */
-		func(tx *gosql.Tx) error {
-			_, err := getBalance(config, tx, cID)
-			return err
-		})
+	_, err := getBalance(db, config, cID, config.historicalBalance)
 	return nil, err
 }

--- a/pkg/workload/ledger/balance.go
+++ b/pkg/workload/ledger/balance.go
@@ -18,16 +18,13 @@ package ledger
 import (
 	gosql "database/sql"
 	"math/rand"
-
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 type balance struct{}
 
 var _ ledgerTx = balance{}
 
-func (bal balance) run(config *ledger, db *gosql.DB) (interface{}, error) {
-	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+func (bal balance) run(config *ledger, db *gosql.DB, rng *rand.Rand) (interface{}, error) {
 	cID := config.randCustomer(rng)
 
 	_, err := getBalance(db, config, cID, config.historicalBalance)

--- a/pkg/workload/ledger/balance.go
+++ b/pkg/workload/ledger/balance.go
@@ -1,0 +1,44 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package ledger
+
+import (
+	"context"
+	gosql "database/sql"
+	"math/rand"
+
+	"github.com/cockroachdb/cockroach-go/crdb"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+type balance struct{}
+
+var _ ledgerTx = balance{}
+
+func (bal balance) run(config *ledger, db *gosql.DB) (interface{}, error) {
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+	cID := config.randCustomer(rng)
+
+	err := crdb.ExecuteTx(
+		context.Background(),
+		db,
+		nil, /* txopts */
+		func(tx *gosql.Tx) error {
+			_, err := getBalance(config, tx, cID)
+			return err
+		})
+	return nil, err
+}

--- a/pkg/workload/ledger/ddls.go
+++ b/pkg/workload/ledger/ddls.go
@@ -1,0 +1,64 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ledger
+
+const (
+	ledgerCustomerSchema = `(
+		id                          INT           NOT NULL PRIMARY KEY DEFAULT unique_rowid(),
+		identifier                  STRING(255)   NOT NULL,
+		"name"                      STRING(255)       NULL,
+		currency_code               STRING(3)     NOT NULL,
+		is_system_customer          BOOL          NOT NULL,
+		is_active                   BOOL          NOT NULL,
+		created                     TIMESTAMP     NOT NULL DEFAULT clock_timestamp(),
+		balance                     DECIMAL(20,3) NOT NULL DEFAULT 0:::DECIMAL,
+		credit_limit                DECIMAL(20,3)     NULL,
+		sequence_number             INT               NULL DEFAULT (-1):::INT,
+
+		INDEX        customer_identifier_active_idx (identifier ASC, is_active ASC),
+		UNIQUE INDEX customer_ide_cur_ia_idx        (identifier ASC, currency_code ASC, is_active ASC)
+	)`
+	ledgerTransactionSchema = `(
+		external_id                STRING(255) NOT NULL PRIMARY KEY,
+		tcomment                   STRING(255)     NULL,
+		context                    STRING(255)     NULL,
+		transaction_type_reference INT         NOT NULL,
+		username                   STRING(255)     NULL,
+		created_ts                 TIMESTAMP   NOT NULL,
+		systimestamp               TIMESTAMP   NOT NULL DEFAULT clock_timestamp(),
+		reversed_by                STRING(255)     NULL,
+		response                   BYTES           NULL
+	)`
+	ledgerEntrySchema = `(
+		id             INT           NOT NULL PRIMARY KEY DEFAULT unique_rowid(),
+		amount         DECIMAL(20,3)     NULL,
+		customer_id    INT               NULL REFERENCES customer,
+		transaction_id STRING(255)   NOT NULL REFERENCES transaction,
+		system_amount  DECIMAL(24,7)     NULL,
+		created_ts     TIMESTAMP     NOT NULL,
+		money_type     STRING(1)     NOT NULL,
+
+		INDEX entry_auto_index_fk_customer    (customer_id ASC),
+		INDEX entry_auto_index_fk_transaction (transaction_id ASC)
+	)`
+	ledgerSessionSchema = `(
+		session_id       STRING                   NOT NULL PRIMARY KEY,
+		expiry_timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
+		data             STRING                   NOT NULL,
+		last_update      TIMESTAMP                NOT NULL,
+
+		INDEX expiry_timestamp_idx (expiry_timestamp ASC)
+	)`
+)

--- a/pkg/workload/ledger/ddls.go
+++ b/pkg/workload/ledger/ddls.go
@@ -48,17 +48,12 @@ const (
 		transaction_id STRING(255)   NOT NULL REFERENCES transaction,
 		system_amount  DECIMAL(24,7)     NULL,
 		created_ts     TIMESTAMP     NOT NULL,
-		money_type     STRING(1)     NOT NULL,
-
-		INDEX entry_auto_index_fk_customer    (customer_id ASC),
-		INDEX entry_auto_index_fk_transaction (transaction_id ASC)
+		money_type     STRING(1)     NOT NULL
 	)`
 	ledgerSessionSchema = `(
 		session_id       STRING                   NOT NULL PRIMARY KEY,
 		expiry_timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
 		data             STRING                   NOT NULL,
-		last_update      TIMESTAMP                NOT NULL,
-
-		INDEX expiry_timestamp_idx (expiry_timestamp ASC)
+		last_update      TIMESTAMP                NOT NULL
 	)`
 )

--- a/pkg/workload/ledger/ddls.go
+++ b/pkg/workload/ledger/ddls.go
@@ -44,8 +44,8 @@ const (
 	ledgerEntrySchema = `(
 		id             INT           NOT NULL PRIMARY KEY DEFAULT unique_rowid(),
 		amount         DECIMAL(20,3)     NULL,
-		customer_id    INT               NULL REFERENCES customer,
-		transaction_id STRING(255)   NOT NULL REFERENCES transaction,
+		customer_id    INT               NULL,
+		transaction_id STRING(255)   NOT NULL,
 		system_amount  DECIMAL(24,7)     NULL,
 		created_ts     TIMESTAMP     NOT NULL,
 		money_type     STRING(1)     NOT NULL

--- a/pkg/workload/ledger/deposit.go
+++ b/pkg/workload/ledger/deposit.go
@@ -55,10 +55,8 @@ func (bal deposit) run(config *ledger, db *gosql.DB) (interface{}, error) {
 				return err
 			}
 
-			cIDs := [4]int{
+			cIDs := [2]int{
 				cID,
-				randInt(rng, 0, config.customers-1),
-				randInt(rng, 0, config.customers-1),
 				randInt(rng, 0, config.customers-1),
 			}
 			return insertEntries(config, tx, rng, cIDs, tID)

--- a/pkg/workload/ledger/deposit.go
+++ b/pkg/workload/ledger/deposit.go
@@ -40,20 +40,20 @@ func (bal deposit) run(config *ledger, db *gosql.DB, rng *rand.Rand) (interface{
 				return err
 			}
 
-			if err := getSession(tx, config, rng); err != nil {
-				return err
-			}
-
 			amount := randAmount(rng)
 			c.balance += amount
 			c.sequence++
 
-			tID, err := insertTransaction(tx, config, rng, c.identifier)
-			if err != nil {
+			if err := updateBalance(tx, config, c); err != nil {
 				return err
 			}
 
-			if err := updateBalance(tx, config, c); err != nil {
+			if err := getSession(tx, config, rng); err != nil {
+				return err
+			}
+
+			tID, err := insertTransaction(tx, config, rng, c.identifier)
+			if err != nil {
 				return err
 			}
 

--- a/pkg/workload/ledger/deposit.go
+++ b/pkg/workload/ledger/deposit.go
@@ -1,0 +1,67 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package ledger
+
+import (
+	"context"
+	gosql "database/sql"
+	"math/rand"
+
+	"github.com/cockroachdb/cockroach-go/crdb"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+type deposit struct{}
+
+var _ ledgerTx = deposit{}
+
+func (bal deposit) run(config *ledger, db *gosql.DB) (interface{}, error) {
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+	cID := randInt(rng, 0, config.customers-1)
+
+	err := crdb.ExecuteTx(
+		context.Background(),
+		db,
+		nil, /* txopts */
+		func(tx *gosql.Tx) error {
+			c, err := getBalance(config, tx, cID)
+			if err != nil {
+				return err
+			}
+
+			amount := randAmount(rng)
+			c.balance += amount
+			c.sequence++
+
+			tID, err := insertTransaction(config, tx, rng, c.identifier)
+			if err != nil {
+				return err
+			}
+
+			if err := updateBalance(config, tx, c); err != nil {
+				return err
+			}
+
+			cIDs := [4]int{
+				cID,
+				randInt(rng, 0, config.customers-1),
+				randInt(rng, 0, config.customers-1),
+				randInt(rng, 0, config.customers-1),
+			}
+			return insertEntries(config, tx, rng, cIDs, tID)
+		})
+	return nil, err
+}

--- a/pkg/workload/ledger/deposit.go
+++ b/pkg/workload/ledger/deposit.go
@@ -42,6 +42,10 @@ func (bal deposit) run(config *ledger, db *gosql.DB) (interface{}, error) {
 				return err
 			}
 
+			if err := getSession(tx, config, rng); err != nil {
+				return err
+			}
+
 			amount := randAmount(rng)
 			c.balance += amount
 			c.sequence++

--- a/pkg/workload/ledger/deposit.go
+++ b/pkg/workload/ledger/deposit.go
@@ -21,15 +21,13 @@ import (
 	"math/rand"
 
 	"github.com/cockroachdb/cockroach-go/crdb"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 type deposit struct{}
 
 var _ ledgerTx = deposit{}
 
-func (bal deposit) run(config *ledger, db *gosql.DB) (interface{}, error) {
-	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+func (bal deposit) run(config *ledger, db *gosql.DB, rng *rand.Rand) (interface{}, error) {
 	cID := randInt(rng, 0, config.customers-1)
 
 	err := crdb.ExecuteTx(

--- a/pkg/workload/ledger/deposit.go
+++ b/pkg/workload/ledger/deposit.go
@@ -37,7 +37,7 @@ func (bal deposit) run(config *ledger, db *gosql.DB) (interface{}, error) {
 		db,
 		nil, /* txopts */
 		func(tx *gosql.Tx) error {
-			c, err := getBalance(config, tx, cID)
+			c, err := getBalance(tx, config, cID, false /* historical */)
 			if err != nil {
 				return err
 			}
@@ -46,12 +46,12 @@ func (bal deposit) run(config *ledger, db *gosql.DB) (interface{}, error) {
 			c.balance += amount
 			c.sequence++
 
-			tID, err := insertTransaction(config, tx, rng, c.identifier)
+			tID, err := insertTransaction(tx, config, rng, c.identifier)
 			if err != nil {
 				return err
 			}
 
-			if err := updateBalance(config, tx, c); err != nil {
+			if err := updateBalance(tx, config, c); err != nil {
 				return err
 			}
 
@@ -59,7 +59,7 @@ func (bal deposit) run(config *ledger, db *gosql.DB) (interface{}, error) {
 				cID,
 				randInt(rng, 0, config.customers-1),
 			}
-			return insertEntries(config, tx, rng, cIDs, tID)
+			return insertEntries(tx, config, rng, cIDs, tID)
 		})
 	return nil, err
 }

--- a/pkg/workload/ledger/generate.go
+++ b/pkg/workload/ledger/generate.go
@@ -18,6 +18,7 @@ package ledger
 import (
 	"encoding/binary"
 	"hash"
+	"math"
 	"math/rand"
 	"strconv"
 
@@ -53,6 +54,12 @@ func (w *ledger) ledgerCustomerInitialRow(rowIdx int) []interface{} {
 	}
 }
 
+func (w *ledger) ledgerCustomerSplitRow(splitIdx int) []interface{} {
+	return []interface{}{
+		(splitIdx + 1) * (w.customers / w.splits),
+	}
+}
+
 func (w *ledger) ledgerTransactionInitialRow(rowIdx int) []interface{} {
 	rng := w.rngPool.Get().(*rand.Rand)
 	defer w.rngPool.Put(rng)
@@ -71,6 +78,14 @@ func (w *ledger) ledgerTransactionInitialRow(rowIdx int) []interface{} {
 		randTimestamp(rng), // systimestamp
 		nil,                // reversed_by
 		randResponse(rng),  // response
+	}
+}
+
+func (w *ledger) ledgerTransactionSplitRow(splitIdx int) []interface{} {
+	rng := rand.New(rand.NewSource(w.seed + int64(splitIdx)))
+	u := uuid.FromUint128(uint128.FromInts(rng.Uint64(), rng.Uint64()))
+	return []interface{}{
+		paymentIDPrefix + u.String(),
 	}
 }
 
@@ -109,6 +124,12 @@ func (w *ledger) ledgerEntryInitialRow(rowIdx int) []interface{} {
 	}
 }
 
+func (w *ledger) ledgerEntrySplitRow(splitIdx int) []interface{} {
+	return []interface{}{
+		(splitIdx + 1) * (int(math.MaxInt64) / w.splits),
+	}
+}
+
 func (w *ledger) ledgerSessionInitialRow(rowIdx int) []interface{} {
 	rng := w.rngPool.Get().(*rand.Rand)
 	defer w.rngPool.Put(rng)
@@ -118,6 +139,13 @@ func (w *ledger) ledgerSessionInitialRow(rowIdx int) []interface{} {
 		randTimestamp(rng),   // expiry_timestamp
 		randSessionData(rng), // data
 		randTimestamp(rng),   // last_update
+	}
+}
+
+func (w *ledger) ledgerSessionSplitRow(splitIdx int) []interface{} {
+	rng := rand.New(rand.NewSource(w.seed + int64(splitIdx)))
+	return []interface{}{
+		randSessionID(rng),
 	}
 }
 

--- a/pkg/workload/ledger/generate.go
+++ b/pkg/workload/ledger/generate.go
@@ -1,0 +1,142 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package ledger
+
+import (
+	"encoding/binary"
+	"hash"
+	"math/rand"
+	"strconv"
+
+	"github.com/cockroachdb/cockroach/pkg/util/uint128"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+const (
+	numTxnsPerCustomer    = 2
+	numEntriesPerTxn      = 4
+	numEntriesPerCustomer = numTxnsPerCustomer * numEntriesPerTxn
+
+	paymentIDPrefix  = "payment:"
+	txnTypeReference = 400
+	cashMoneyType    = "C"
+)
+
+func (w *ledger) ledgerCustomerInitialRow(rowIdx int) []interface{} {
+	rng := w.rngPool.Get().(*rand.Rand)
+	defer w.rngPool.Put(rng)
+
+	return []interface{}{
+		rowIdx,               // id
+		strconv.Itoa(rowIdx), // identifier
+		nil,                  // name
+		randCurrencyCode(rng), // currency_code
+		true,               // is_system_customer
+		true,               // is_active
+		randTimestamp(rng), // created
+		0,                  // balance
+		nil,                // credit_limit
+		-1,                 // sequence
+	}
+}
+
+func (w *ledger) ledgerTransactionInitialRow(rowIdx int) []interface{} {
+	rng := w.rngPool.Get().(*rand.Rand)
+	defer w.rngPool.Put(rng)
+
+	h := w.hashPool.Get().(hash.Hash64)
+	defer w.hashPool.Put(h)
+	defer h.Reset()
+
+	return []interface{}{
+		w.ledgerStablePaymentID(rowIdx), // external_id
+		nil,                // tcomment
+		randContext(rng),   // context
+		txnTypeReference,   // transaction_type_reference
+		randUsername(rng),  // username
+		randTimestamp(rng), // created_ts
+		randTimestamp(rng), // systimestamp
+		nil,                // reversed_by
+		randResponse(rng),  // response
+	}
+}
+
+func (w *ledger) ledgerEntryInitialRow(rowIdx int) []interface{} {
+	rng := w.rngPool.Get().(*rand.Rand)
+	defer w.rngPool.Put(rng)
+
+	// Alternate.
+	debit := rowIdx%2 == 0
+
+	var amount float64
+	if debit {
+		amount = -float64(rowIdx) / 100
+	} else {
+		amount = float64(rowIdx-1) / 100
+	}
+
+	systemAmount := 88.122259
+	if debit {
+		systemAmount *= -1
+	}
+
+	cRowIdx := rowIdx / numEntriesPerCustomer
+
+	tRowIdx := rowIdx / numEntriesPerTxn
+	tID := w.ledgerStablePaymentID(tRowIdx)
+
+	return []interface{}{
+		rng.Int(),          // id
+		amount,             // amount
+		cRowIdx,            // customer_id
+		tID,                // transaction_id
+		systemAmount,       // system_amount
+		randTimestamp(rng), // created_ts
+		cashMoneyType,      // money_type
+	}
+}
+
+func (w *ledger) ledgerSessionInitialRow(rowIdx int) []interface{} {
+	rng := w.rngPool.Get().(*rand.Rand)
+	defer w.rngPool.Put(rng)
+
+	return []interface{}{
+		randSessionID(rng),   // session_id
+		randTimestamp(rng),   // expiry_timestamp
+		randSessionData(rng), // data
+		randTimestamp(rng),   // last_update
+	}
+}
+
+func (w *ledger) ledgerStablePaymentID(tRowIdx int) string {
+	h := w.hashPool.Get().(hash.Hash64)
+	defer w.hashPool.Put(h)
+	defer h.Reset()
+
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, uint64(tRowIdx))
+	if _, err := h.Write(b); err != nil {
+		panic(err)
+	}
+	hi := h.Sum64()
+	if _, err := h.Write(b); err != nil {
+		panic(err)
+	}
+	low := h.Sum64()
+
+	u := uuid.FromUint128(uint128.FromInts(hi, low))
+	return paymentIDPrefix + u.String()
+}

--- a/pkg/workload/ledger/ledger.go
+++ b/pkg/workload/ledger/ledger.go
@@ -36,6 +36,7 @@ type ledger struct {
 	customers     int
 	parallelStmts bool
 	interleaved   bool
+	inlineArgs    bool
 	splits        int
 	mix           string
 
@@ -63,6 +64,7 @@ var ledgerMeta = workload.Meta{
 		g.flags.IntVar(&g.customers, `customers`, 1000, `Number of customers`)
 		g.flags.BoolVar(&g.parallelStmts, `parallel-stmts`, false, `Use parallel statement execution`)
 		g.flags.BoolVar(&g.interleaved, `interleaved`, false, `Use interleaved tables`)
+		g.flags.BoolVar(&g.inlineArgs, `inline-args`, false, `Use inline query arguments`)
 		g.flags.IntVar(&g.splits, `splits`, 0, `Number of splits to perform before starting normal operations`)
 		g.flags.StringVar(&g.mix, `mix`,
 			`balance=50,withdrawal=37,deposit=12,reversal=0`,

--- a/pkg/workload/ledger/ledger.go
+++ b/pkg/workload/ledger/ledger.go
@@ -32,14 +32,15 @@ type ledger struct {
 	flags     workload.Flags
 	connFlags *workload.ConnFlags
 
-	seed          int64
-	customers     int
-	parallelStmts bool
-	interleaved   bool
-	inlineArgs    bool
-	splits        int
-	fks           bool
-	mix           string
+	seed              int64
+	customers         int
+	parallelStmts     bool
+	interleaved       bool
+	inlineArgs        bool
+	splits            int
+	fks               bool
+	historicalBalance bool
+	mix               string
 
 	txs  []tx
 	deck []int // contains indexes into the txs slice
@@ -68,6 +69,7 @@ var ledgerMeta = workload.Meta{
 		g.flags.BoolVar(&g.inlineArgs, `inline-args`, false, `Use inline query arguments`)
 		g.flags.IntVar(&g.splits, `splits`, 0, `Number of splits to perform before starting normal operations`)
 		g.flags.BoolVar(&g.fks, `fks`, true, `Add the foreign keys`)
+		g.flags.BoolVar(&g.historicalBalance, `historical-balance`, false, `Perform balance txns using historical reads`)
 		g.flags.StringVar(&g.mix, `mix`,
 			`balance=50,withdrawal=37,deposit=12,reversal=0`,
 			`Weights for the transaction mix.`)

--- a/pkg/workload/ledger/ledger.go
+++ b/pkg/workload/ledger/ledger.go
@@ -191,11 +191,13 @@ func (w *ledger) Ops(urls []string, reg *workload.HistogramRegistry) (workload.Q
 
 	w.reg = reg
 	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	now := timeutil.Now().UnixNano()
 	for i := 0; i < w.connFlags.Concurrency; i++ {
 		worker := &worker{
 			config:   w,
 			hists:    reg.GetHandle(),
 			db:       db,
+			rng:      rand.New(rand.NewSource(now + int64(i))),
 			deckPerm: append([]int(nil), w.deck...),
 			permIdx:  len(w.deck),
 		}

--- a/pkg/workload/ledger/ledger.go
+++ b/pkg/workload/ledger/ledger.go
@@ -1,0 +1,175 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ledger
+
+import (
+	gosql "database/sql"
+	"hash/fnv"
+	"math/rand"
+	"strings"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload"
+)
+
+type ledger struct {
+	flags     workload.Flags
+	connFlags *workload.ConnFlags
+
+	seed          int64
+	customers     int
+	parallelStmts bool
+	interleaved   bool
+	mix           string
+
+	txs  []tx
+	deck []int // contains indexes into the txs slice
+
+	reg      *workload.HistogramRegistry
+	rngPool  *sync.Pool
+	hashPool *sync.Pool
+}
+
+func init() {
+	workload.Register(ledgerMeta)
+}
+
+var ledgerMeta = workload.Meta{
+	Name:        `ledger`,
+	Description: `Ledger simulates an accounting system using double-entry bookkeeping`,
+	Version:     `1.0.0`,
+	New: func() workload.Generator {
+		g := &ledger{}
+		g.flags.FlagSet = pflag.NewFlagSet(`ledger`, pflag.ContinueOnError)
+		g.connFlags = workload.NewConnFlags(&g.flags)
+		g.flags.Int64Var(&g.seed, `seed`, 1, `Random number generator seed`)
+		g.flags.IntVar(&g.customers, `customers`, 1000, `Number of customers`)
+		g.flags.BoolVar(&g.parallelStmts, `parallel-stmts`, false, `Use parallel statement execution`)
+		g.flags.BoolVar(&g.interleaved, `interleaved`, false, `Use interleaved tables`)
+		g.flags.StringVar(&g.mix, `mix`,
+			`balance=50,withdrawal=37,deposit=12,reversal=0`,
+			`Weights for the transaction mix.`)
+		return g
+	},
+}
+
+// Meta implements the Generator interface.
+func (*ledger) Meta() workload.Meta { return ledgerMeta }
+
+// Flags implements the Flagser interface.
+func (w *ledger) Flags() workload.Flags { return w.flags }
+
+// Hooks implements the Hookser interface.
+func (w *ledger) Hooks() workload.Hooks {
+	return workload.Hooks{
+		Validate: func() error {
+			if w.interleaved {
+				return errors.Errorf("interleaved tables are not yet supported")
+			}
+			return initializeMix(w)
+		},
+	}
+}
+
+// Tables implements the Generator interface.
+func (w *ledger) Tables() []workload.Table {
+	if w.rngPool == nil {
+		w.rngPool = &sync.Pool{
+			New: func() interface{} { return rand.New(rand.NewSource(timeutil.Now().UnixNano())) },
+		}
+	}
+	if w.hashPool == nil {
+		w.hashPool = &sync.Pool{
+			New: func() interface{} { return fnv.New64() },
+		}
+	}
+
+	customer := workload.Table{
+		Name:   `customer`,
+		Schema: ledgerCustomerSchema,
+		InitialRows: workload.Tuples(
+			w.customers,
+			w.ledgerCustomerInitialRow,
+		),
+		// TODO(nvanbenschoten): pre-split tables.
+		// Splits: workload.Tuples(),
+	}
+	transaction := workload.Table{
+		Name:   `transaction`,
+		Schema: ledgerTransactionSchema,
+		InitialRows: workload.Tuples(
+			numTxnsPerCustomer*w.customers,
+			w.ledgerTransactionInitialRow,
+		),
+		// TODO(nvanbenschoten): pre-split tables.
+		// Splits: workload.Tuples(),
+	}
+	entry := workload.Table{
+		Name:   `entry`,
+		Schema: ledgerEntrySchema,
+		InitialRows: workload.Tuples(
+			numEntriesPerCustomer*w.customers,
+			w.ledgerEntryInitialRow,
+		),
+		// TODO(nvanbenschoten): pre-split tables.
+		// Splits: workload.Tuples(),
+	}
+	session := workload.Table{
+		Name:   `session`,
+		Schema: ledgerSessionSchema,
+		InitialRows: workload.Tuples(
+			w.customers,
+			w.ledgerSessionInitialRow,
+		),
+		// TODO(nvanbenschoten): pre-split tables.
+		// Splits: workload.Tuples(),
+	}
+	return []workload.Table{
+		customer, transaction, entry, session,
+	}
+}
+
+// Ops implements the Opser interface.
+func (w *ledger) Ops(urls []string, reg *workload.HistogramRegistry) (workload.QueryLoad, error) {
+	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
+	if err != nil {
+		return workload.QueryLoad{}, err
+	}
+	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
+	if err != nil {
+		return workload.QueryLoad{}, err
+	}
+	// Allow a maximum of concurrency+1 connections to the database.
+	db.SetMaxOpenConns(w.connFlags.Concurrency + 1)
+	db.SetMaxIdleConns(w.connFlags.Concurrency + 1)
+
+	w.reg = reg
+	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	for i := 0; i < w.connFlags.Concurrency; i++ {
+		worker := &worker{
+			config:   w,
+			hists:    reg.GetHandle(),
+			db:       db,
+			deckPerm: append([]int(nil), w.deck...),
+			permIdx:  len(w.deck),
+		}
+		ql.WorkerFns = append(ql.WorkerFns, worker.run)
+	}
+	return ql, nil
+}

--- a/pkg/workload/ledger/ops_util.go
+++ b/pkg/workload/ledger/ops_util.go
@@ -113,8 +113,8 @@ func insertTransaction(
 	return tID, err
 }
 
-func insertEntries(config *ledger, tx *gosql.Tx, rng *rand.Rand, cIDs [4]int, tID string) error {
-	amount1, amount2 := randAmount(rng), randAmount(rng)
+func insertEntries(config *ledger, tx *gosql.Tx, rng *rand.Rand, cIDs [2]int, tID string) error {
+	amount1 := randAmount(rng)
 	sysAmount := 88.433571
 	ts := timeutil.Now()
 
@@ -123,13 +123,9 @@ func insertEntries(config *ledger, tx *gosql.Tx, rng *rand.Rand, cIDs [4]int, tI
 			amount, system_amount, created_ts, transaction_id, customer_id, money_type
 		) VALUES
 			($1 , $2 , $3 , $4 , $5 , $6 ),
-			($7 , $8 , $9 , $10, $11, $12),
-			($13, $14, $15, $16, $17, $18),
-			($19, $20, $21, $22, $23, $24)`),
+			($7 , $8 , $9 , $10, $11, $12)`),
 		amount1, sysAmount, ts, tID, cIDs[0], cashMoneyType,
 		-amount1, -sysAmount, ts, tID, cIDs[1], cashMoneyType,
-		amount2, sysAmount, ts, tID, cIDs[2], cashMoneyType,
-		-amount2, -sysAmount, ts, tID, cIDs[3], cashMoneyType,
 	)
 	return err
 }

--- a/pkg/workload/ledger/ops_util.go
+++ b/pkg/workload/ledger/ops_util.go
@@ -1,0 +1,166 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package ledger
+
+import (
+	gosql "database/sql"
+	"math/rand"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func maybeParallelize(config *ledger, stmt string) string {
+	if config.parallelStmts {
+		return stmt + " RETURNING NOTHING"
+	}
+	return stmt
+}
+
+type customer struct {
+	id               int
+	identifier       string
+	name             gosql.NullString
+	currencyCode     string
+	isSystemCustomer bool
+	isActive         bool
+	created          time.Time
+	balance          float64
+	creditLimit      gosql.NullFloat64
+	sequence         int
+}
+
+func getBalance(config *ledger, tx *gosql.Tx, id int) (customer, error) {
+	rows, err := tx.Query(`
+		SELECT
+			id,
+			identifier,
+			"name",
+			currency_code,
+			is_system_customer,
+			is_active,
+			created,
+			balance,
+			credit_limit,
+			sequence_number
+		FROM customer
+		WHERE id = $1 AND IS_ACTIVE = true`,
+		id)
+	if err != nil {
+		return customer{}, err
+	}
+	defer rows.Close()
+
+	var c customer
+	for rows.Next() {
+		if err := rows.Scan(
+			&c.id,
+			&c.identifier,
+			&c.name,
+			&c.currencyCode,
+			&c.isSystemCustomer,
+			&c.isActive,
+			&c.created,
+			&c.balance,
+			&c.creditLimit,
+			&c.sequence,
+		); err != nil {
+			return customer{}, err
+		}
+	}
+	return c, rows.Err()
+}
+
+func updateBalance(config *ledger, tx *gosql.Tx, c customer) error {
+	_, err := tx.Exec(maybeParallelize(config, `
+		UPDATE customer SET
+			balance         = $1,
+			credit_limit    = $2,
+			is_active       = $3,
+			name            = $4,
+			sequence_number = $5
+		WHERE id = $6`),
+		c.balance, c.creditLimit, c.isActive, c.name, c.sequence, c.id,
+	)
+	return err
+}
+
+func insertTransaction(
+	config *ledger, tx *gosql.Tx, rng *rand.Rand, username string,
+) (string, error) {
+	tID := randPaymentID(rng)
+	_, err := tx.Exec(maybeParallelize(config, `
+		INSERT INTO transaction (
+			tcomment, context, response, reversed_by, created_ts, 
+			transaction_type_reference, username, external_id
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`),
+		nil, randContext(rng), randResponse(rng), nil,
+		timeutil.Now(), txnTypeReference, username, tID,
+	)
+	return tID, err
+}
+
+func insertEntries(config *ledger, tx *gosql.Tx, rng *rand.Rand, cIDs [4]int, tID string) error {
+	amount1, amount2 := randAmount(rng), randAmount(rng)
+	sysAmount := 88.433571
+	ts := timeutil.Now()
+
+	_, err := tx.Exec(maybeParallelize(config, `
+		INSERT INTO entry (
+			amount, system_amount, created_ts, transaction_id, customer_id, money_type
+		) VALUES
+			($1 , $2 , $3 , $4 , $5 , $6 ),
+			($7 , $8 , $9 , $10, $11, $12),
+			($13, $14, $15, $16, $17, $18),
+			($19, $20, $21, $22, $23, $24)`),
+		amount1, sysAmount, ts, tID, cIDs[0], cashMoneyType,
+		-amount1, -sysAmount, ts, tID, cIDs[1], cashMoneyType,
+		amount2, sysAmount, ts, tID, cIDs[2], cashMoneyType,
+		-amount2, -sysAmount, ts, tID, cIDs[3], cashMoneyType,
+	)
+	return err
+}
+
+func getSession(config *ledger, tx *gosql.Tx, id int) error {
+	rows, err := tx.Query(`
+		SELECT
+			session_id,
+			expiry_timestamp,
+			data,
+			last_update
+		FROM session
+		WHERE session_id = ?`,
+		id)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		// No-op.
+	}
+	return rows.Err()
+}
+
+func insertSession(config *ledger, tx *gosql.Tx, rng *rand.Rand) error {
+	_, err := tx.Exec(maybeParallelize(config, `
+		INSERT INTO session (
+			data, expiry_timestamp, last_update, session_id
+		) VALUES (?, ?, ?, ?)`),
+		randSessionData(rng), randTimestamp(rng), timeutil.Now(), randSessionID(rng),
+	)
+	return err
+}

--- a/pkg/workload/ledger/random.go
+++ b/pkg/workload/ledger/random.go
@@ -1,0 +1,105 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package ledger
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+const letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+const aChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+
+// randInt returns a number within [min, max] inclusive.
+func randInt(rng *rand.Rand, min, max int) int {
+	return rng.Intn(max-min+1) + min
+}
+
+func randStringFromAlphabet(rng *rand.Rand, minLen, maxLen int, alphabet string) string {
+	size := maxLen
+	if maxLen-minLen != 0 {
+		size = randInt(rng, minLen, maxLen)
+	}
+	if size == 0 {
+		return ""
+	}
+
+	b := make([]byte, size)
+	for i := range b {
+		b[i] = alphabet[rng.Intn(len(alphabet))]
+	}
+	return string(b)
+}
+
+// randAString generates a random alphanumeric string of length between min and
+// max inclusive.
+func randAString(rng *rand.Rand, min, max int) string {
+	return randStringFromAlphabet(rng, min, max, aChars)
+}
+
+// randPaymentID produces a random payment id string.
+func randPaymentID(rng *rand.Rand) string {
+	uuidStr := uuid.MakeV4().String()
+	return paymentIDPrefix + uuidStr
+}
+
+// randContext produces a random context string.
+func randContext(rng *rand.Rand) string {
+	return randAString(rng, 56, 56)
+}
+
+// randUsername produces a random username string.
+func randUsername(rng *rand.Rand) string {
+	return randAString(rng, 18, 20)
+}
+
+// randResponse produces a random transaction response string.
+func randResponse(rng *rand.Rand) string {
+	return randAString(rng, 400, 400)
+}
+
+// randCurrencyCode produces a random currency code string.
+func randCurrencyCode(rng *rand.Rand) string {
+	return randStringFromAlphabet(rng, 3, 3, letters)
+}
+
+// randTimestamp produces a random timestamp.
+func randTimestamp(rng *rand.Rand) time.Time {
+	return timeutil.Unix(rng.Int63n(1600000000), rng.Int63())
+}
+
+// randSessionID produces a random session ID string.
+func randSessionID(rng *rand.Rand) string {
+	return randAString(rng, 60, 62)
+}
+
+// randSessionData produces a random session data string.
+func randSessionData(rng *rand.Rand) string {
+	return randAString(rng, 160, 160)
+}
+
+// randAmount produces a random amount string.
+func randAmount(rng *rand.Rand) float64 {
+	return float64(randInt(rng, 100, 100000)) / 100
+}
+
+// randCustomer returns a random customer ID.
+func (w ledger) randCustomer(rng *rand.Rand) int {
+	return randInt(rng, 0, w.customers-1)
+}

--- a/pkg/workload/ledger/reversal.go
+++ b/pkg/workload/ledger/reversal.go
@@ -18,6 +18,7 @@ package ledger
 import (
 	"context"
 	gosql "database/sql"
+	"math/rand"
 
 	"github.com/cockroachdb/cockroach-go/crdb"
 )
@@ -26,7 +27,7 @@ type reversal struct{}
 
 var _ ledgerTx = reversal{}
 
-func (reversal) run(config *ledger, db *gosql.DB) (interface{}, error) {
+func (reversal) run(config *ledger, db *gosql.DB, rng *rand.Rand) (interface{}, error) {
 	err := crdb.ExecuteTx(
 		context.Background(),
 		db,

--- a/pkg/workload/ledger/reversal.go
+++ b/pkg/workload/ledger/reversal.go
@@ -1,0 +1,40 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package ledger
+
+import (
+	"context"
+	gosql "database/sql"
+
+	"github.com/cockroachdb/cockroach-go/crdb"
+)
+
+type reversal struct{}
+
+var _ ledgerTx = reversal{}
+
+func (reversal) run(config *ledger, db *gosql.DB) (interface{}, error) {
+	err := crdb.ExecuteTx(
+		context.Background(),
+		db,
+		nil, /* txopts */
+		func(tx *gosql.Tx) error {
+			// TODO(nvanbenschoten): complete this transaction
+			// if we want to support this operation.
+			return nil
+		})
+	return nil, err
+}

--- a/pkg/workload/ledger/withdrawal.go
+++ b/pkg/workload/ledger/withdrawal.go
@@ -37,7 +37,7 @@ func (withdrawal) run(config *ledger, db *gosql.DB) (interface{}, error) {
 		db,
 		nil, /* txopts */
 		func(tx *gosql.Tx) error {
-			c, err := getBalance(config, tx, cID)
+			c, err := getBalance(tx, config, cID, false /* historical */)
 			if err != nil {
 				return err
 			}
@@ -51,12 +51,12 @@ func (withdrawal) run(config *ledger, db *gosql.DB) (interface{}, error) {
 			}
 			c.sequence++
 
-			tID, err := insertTransaction(config, tx, rng, c.identifier)
+			tID, err := insertTransaction(tx, config, rng, c.identifier)
 			if err != nil {
 				return err
 			}
 
-			if err := updateBalance(config, tx, c); err != nil {
+			if err := updateBalance(tx, config, c); err != nil {
 				return err
 			}
 
@@ -64,7 +64,7 @@ func (withdrawal) run(config *ledger, db *gosql.DB) (interface{}, error) {
 				cID,
 				randInt(rng, 0, config.customers-1),
 			}
-			if err := insertEntries(config, tx, rng, cIDs, tID); err != nil {
+			if err := insertEntries(tx, config, rng, cIDs, tID); err != nil {
 				return err
 			}
 

--- a/pkg/workload/ledger/withdrawal.go
+++ b/pkg/workload/ledger/withdrawal.go
@@ -42,8 +42,6 @@ func (withdrawal) run(config *ledger, db *gosql.DB) (interface{}, error) {
 				return err
 			}
 
-			// TODO(nvanbenschoten): query for game session?
-
 			amount := randAmount(rng)
 			c.balance -= amount
 			if c.balance < 0 {
@@ -68,8 +66,7 @@ func (withdrawal) run(config *ledger, db *gosql.DB) (interface{}, error) {
 				return err
 			}
 
-			// TODO(nvanbenschoten): insert new game session?
-			return nil
+			return insertSession(tx, config, rng)
 		})
 	return nil, err
 }

--- a/pkg/workload/ledger/withdrawal.go
+++ b/pkg/workload/ledger/withdrawal.go
@@ -47,12 +47,12 @@ func (withdrawal) run(config *ledger, db *gosql.DB, rng *rand.Rand) (interface{}
 			}
 			c.sequence++
 
-			tID, err := insertTransaction(tx, config, rng, c.identifier)
-			if err != nil {
+			if err := updateBalance(tx, config, c); err != nil {
 				return err
 			}
 
-			if err := updateBalance(tx, config, c); err != nil {
+			tID, err := insertTransaction(tx, config, rng, c.identifier)
+			if err != nil {
 				return err
 			}
 

--- a/pkg/workload/ledger/withdrawal.go
+++ b/pkg/workload/ledger/withdrawal.go
@@ -1,0 +1,77 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package ledger
+
+import (
+	"context"
+	gosql "database/sql"
+	"math/rand"
+
+	"github.com/cockroachdb/cockroach-go/crdb"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+type withdrawal struct{}
+
+var _ ledgerTx = withdrawal{}
+
+func (withdrawal) run(config *ledger, db *gosql.DB) (interface{}, error) {
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+	cID := randInt(rng, 0, config.customers-1)
+
+	err := crdb.ExecuteTx(
+		context.Background(),
+		db,
+		nil, /* txopts */
+		func(tx *gosql.Tx) error {
+			c, err := getBalance(config, tx, cID)
+			if err != nil {
+				return err
+			}
+
+			// TODO(nvanbenschoten): query for game session?
+
+			amount := randAmount(rng)
+			c.balance -= amount
+			if c.balance < 0 {
+				c.balance = 0
+			}
+			c.sequence++
+
+			tID, err := insertTransaction(config, tx, rng, c.identifier)
+			if err != nil {
+				return err
+			}
+
+			if err := updateBalance(config, tx, c); err != nil {
+				return err
+			}
+
+			cIDs := [4]int{
+				cID,
+				randInt(rng, 0, config.customers-1),
+				randInt(rng, 0, config.customers-1),
+				randInt(rng, 0, config.customers-1),
+			}
+			if err := insertEntries(config, tx, rng, cIDs, tID); err != nil {
+				return err
+			}
+
+			// TODO(nvanbenschoten): insert new game session?
+			return nil
+		})
+	return nil, err
+}

--- a/pkg/workload/ledger/withdrawal.go
+++ b/pkg/workload/ledger/withdrawal.go
@@ -60,10 +60,8 @@ func (withdrawal) run(config *ledger, db *gosql.DB) (interface{}, error) {
 				return err
 			}
 
-			cIDs := [4]int{
+			cIDs := [2]int{
 				cID,
-				randInt(rng, 0, config.customers-1),
-				randInt(rng, 0, config.customers-1),
 				randInt(rng, 0, config.customers-1),
 			}
 			if err := insertEntries(config, tx, rng, cIDs, tID); err != nil {

--- a/pkg/workload/ledger/withdrawal.go
+++ b/pkg/workload/ledger/withdrawal.go
@@ -21,15 +21,13 @@ import (
 	"math/rand"
 
 	"github.com/cockroachdb/cockroach-go/crdb"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 type withdrawal struct{}
 
 var _ ledgerTx = withdrawal{}
 
-func (withdrawal) run(config *ledger, db *gosql.DB) (interface{}, error) {
-	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+func (withdrawal) run(config *ledger, db *gosql.DB, rng *rand.Rand) (interface{}, error) {
 	cID := randInt(rng, 0, config.customers-1)
 
 	err := crdb.ExecuteTx(

--- a/pkg/workload/ledger/worker.go
+++ b/pkg/workload/ledger/worker.go
@@ -32,12 +32,13 @@ type worker struct {
 	hists  *workload.Histograms
 	db     *gosql.DB
 
+	rng      *rand.Rand
 	deckPerm []int
 	permIdx  int
 }
 
 type ledgerTx interface {
-	run(config *ledger, db *gosql.DB) (interface{}, error)
+	run(config *ledger, db *gosql.DB, rng *rand.Rand) (interface{}, error)
 }
 
 type tx struct {
@@ -118,7 +119,7 @@ func (w *worker) run(ctx context.Context) error {
 	w.permIdx++
 
 	start := timeutil.Now()
-	if _, err := t.run(w.config, w.db); err != nil {
+	if _, err := t.run(w.config, w.db, w.rng); err != nil {
 		return errors.Wrapf(err, "error in %s", t.name)
 	}
 	w.hists.Get(t.name).Record(timeutil.Since(start))

--- a/pkg/workload/ledger/worker.go
+++ b/pkg/workload/ledger/worker.go
@@ -1,0 +1,126 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package ledger
+
+import (
+	"context"
+	gosql "database/sql"
+	"math/rand"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/pkg/errors"
+)
+
+type worker struct {
+	config *ledger
+	hists  *workload.Histograms
+	db     *gosql.DB
+
+	deckPerm []int
+	permIdx  int
+}
+
+type ledgerTx interface {
+	run(config *ledger, db *gosql.DB) (interface{}, error)
+}
+
+type tx struct {
+	ledgerTx
+	weight int    // percent likelihood that each transaction type is run
+	name   string // display name
+}
+
+var allTxs = [...]tx{
+	{
+		ledgerTx: balance{}, name: "balance",
+	},
+	{
+		ledgerTx: withdrawal{}, name: "withdrawal",
+	},
+	{
+		ledgerTx: deposit{}, name: "deposit",
+	},
+	{
+		ledgerTx: reversal{}, name: "reversal",
+	},
+}
+
+func initializeMix(config *ledger) error {
+	config.txs = append([]tx(nil), allTxs[0:]...)
+	nameToTx := make(map[string]int, len(allTxs))
+	for i, tx := range config.txs {
+		nameToTx[tx.name] = i
+	}
+
+	items := strings.Split(config.mix, `,`)
+	totalWeight := 0
+	for _, item := range items {
+		kv := strings.Split(item, `=`)
+		if len(kv) != 2 {
+			return errors.Errorf(`Invalid mix %s: %s is not a k=v pair`, config.mix, item)
+		}
+		txName, weightStr := kv[0], kv[1]
+
+		weight, err := strconv.Atoi(weightStr)
+		if err != nil {
+			return errors.Errorf(
+				`Invalid percentage mix %s: %s is not an integer`, config.mix, weightStr)
+		}
+
+		i, ok := nameToTx[txName]
+		if !ok {
+			return errors.Errorf(
+				`Invalid percentage mix %s: no such transaction %s`, config.mix, txName)
+		}
+
+		config.txs[i].weight = weight
+		totalWeight += weight
+	}
+
+	config.deck = make([]int, 0, totalWeight)
+	for i, t := range config.txs {
+		for j := 0; j < t.weight; j++ {
+			config.deck = append(config.deck, i)
+		}
+	}
+
+	return nil
+}
+
+func (w *worker) run(ctx context.Context) error {
+	if w.permIdx == len(w.deckPerm) {
+		rand.Shuffle(len(w.deckPerm), func(i, j int) {
+			w.deckPerm[i], w.deckPerm[j] = w.deckPerm[j], w.deckPerm[i]
+		})
+		w.permIdx = 0
+	}
+	// Move through our permutation slice until its exhausted, using each value to
+	// to index into our deck of transactions, which contains indexes into the
+	// txs slice.
+	opIdx := w.deckPerm[w.permIdx]
+	t := w.config.txs[opIdx]
+	w.permIdx++
+
+	start := timeutil.Now()
+	if _, err := t.run(w.config, w.db); err != nil {
+		return errors.Wrapf(err, "error in %s", t.name)
+	}
+	w.hists.Get(t.name).Record(timeutil.Since(start))
+	return nil
+}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -225,6 +225,8 @@ func ApproxDatumSize(x interface{}) int64 {
 		return 0
 	}
 	switch t := x.(type) {
+	case bool:
+		return 1
 	case int:
 		if t < 0 {
 			t = -t


### PR DESCRIPTION
This change introduces a new workload called Ledger. Ledger simulates
an accounting system using double-entry bookkeeping. It is made up of
a simple schema containing 4 tables:
- `customer`
- `transaction`
- `entry`
- `session`

Release note: None