### PR TITLE
parser,changefeedccl: partial update of CHANGEFEED syntax to match rfc

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -260,6 +260,7 @@ create_ddl_stmt ::=
 	| create_table_as_stmt
 	| create_view_stmt
 	| create_sequence_stmt
+	| create_changefeed_stmt
 
 create_stats_stmt ::=
 	'CREATE' 'STATISTICS' statistics_name 'ON' name_list 'FROM' table_name
@@ -648,6 +649,7 @@ unreserved_keyword ::=
 	| 'CACHE'
 	| 'CANCEL'
 	| 'CASCADE'
+	| 'CHANGEFEED'
 	| 'CLUSTER'
 	| 'COLUMNS'
 	| 'COMMENT'
@@ -680,7 +682,6 @@ unreserved_keyword ::=
 	| 'EXECUTE'
 	| 'EXPERIMENTAL'
 	| 'EXPERIMENTAL_AUDIT'
-	| 'EXPERIMENTAL_CHANGEFEED'
 	| 'EXPERIMENTAL_FINGERPRINTS'
 	| 'EXPERIMENTAL_RANGES'
 	| 'EXPERIMENTAL_RELOCATE'
@@ -905,6 +906,9 @@ create_view_stmt ::=
 create_sequence_stmt ::=
 	'CREATE' 'SEQUENCE' sequence_name opt_sequence_option_list
 	| 'CREATE' 'SEQUENCE' 'IF' 'NOT' 'EXISTS' sequence_name opt_sequence_option_list
+
+create_changefeed_stmt ::=
+	'CREATE' 'CHANGEFEED' 'FOR' targets 'INTO' string_or_placeholder opt_with_options
 
 statistics_name ::=
 	name

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -32,6 +32,7 @@ func init() {
 type envelopeType string
 
 const (
+	optCursor   = `cursor`
 	optEnvelope = `envelope`
 
 	optEnvelopeKeyOnly envelopeType = `key_only`
@@ -42,6 +43,7 @@ const (
 )
 
 var changefeedOptionExpectValues = map[string]bool{
+	optCursor:   true,
 	optEnvelope: true,
 }
 
@@ -83,9 +85,10 @@ func changefeedPlanHook(
 
 		now := p.ExecCfg().Clock.Now()
 		var highwater hlc.Timestamp
-		if changefeedStmt.AsOf.Expr != nil {
+		if cursor, ok := opts[optCursor]; ok {
+			asOf := tree.AsOfClause{Expr: tree.NewStrVal(cursor)}
 			var err error
-			if highwater, err = sql.EvalAsOfTimestamp(nil, changefeedStmt.AsOf, now); err != nil {
+			if highwater, err = sql.EvalAsOfTimestamp(nil, asOf, now); err != nil {
 				return err
 			}
 		}

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -983,10 +983,12 @@ func TestParse(t *testing.T) {
 		{`EXPORT INTO CSV 's3://my/path/%part%.csv' WITH delimiter = '|' FROM SELECT a, sum(b) FROM c WHERE d = 1 ORDER BY sum(b) DESC LIMIT 10`},
 		{`SET ROW (1, true, NULL)`},
 
-		{`CREATE EXPERIMENTAL_CHANGEFEED EMIT TABLE foo TO 'sink'`},
-		{`CREATE EXPERIMENTAL_CHANGEFEED EMIT TABLE foo TO 'sink' WITH topic_prefix = 'bar'`},
-		{`CREATE EXPERIMENTAL_CHANGEFEED EMIT DATABASE foo TO 'sink'`},
-		{`CREATE EXPERIMENTAL_CHANGEFEED EMIT TABLE foo TO 'sink' AS OF SYSTEM TIME '1'`},
+		{`CREATE CHANGEFEED FOR TABLE foo INTO 'sink'`},
+		// TODO(dan): Implement.
+		// {`CREATE CHANGEFEED FOR TABLE foo VALUES FROM (1) TO (2) INTO 'sink'`},
+		// {`CREATE CHANGEFEED FOR TABLE foo PARTITION bar, baz INTO 'sink'`},
+		{`CREATE CHANGEFEED FOR DATABASE foo INTO 'sink'`},
+		{`CREATE CHANGEFEED FOR TABLE foo INTO 'sink' WITH bar = 'baz'`},
 
 		// Regression for #15926
 		{`SELECT * FROM ((t1 NATURAL JOIN t2 WITH ORDINALITY AS o1)) WITH ORDINALITY AS o2`},
@@ -1335,8 +1337,8 @@ func TestParse2(t *testing.T) {
 		{`RESTORE DATABASE foo FROM bar`,
 			`RESTORE DATABASE foo FROM 'bar'`},
 
-		{`CREATE EXPERIMENTAL_CHANGEFEED EMIT DATABASE foo TO sink`,
-			`CREATE EXPERIMENTAL_CHANGEFEED EMIT DATABASE foo TO 'sink'`},
+		{`CREATE CHANGEFEED FOR TABLE foo INTO sink`,
+			`CREATE CHANGEFEED FOR TABLE foo INTO 'sink'`},
 
 		{`SHOW ALL CLUSTER SETTINGS`, `SHOW CLUSTER SETTING all`},
 
@@ -1406,8 +1408,7 @@ func TestParse2(t *testing.T) {
 		{`RESTORE foo FROM 'bar' WITH key1, key2 = 'value'`,
 			`RESTORE TABLE foo FROM 'bar' WITH key1, key2 = 'value'`},
 
-		{`CREATE EXPERIMENTAL_CHANGEFEED EMIT foo TO 'sink'`,
-			`CREATE EXPERIMENTAL_CHANGEFEED EMIT TABLE foo TO 'sink'`},
+		{`CREATE CHANGEFEED FOR foo INTO 'sink'`, `CREATE CHANGEFEED FOR TABLE foo INTO 'sink'`},
 
 		{`GRANT SELECT ON foo TO root`,
 			`GRANT SELECT ON TABLE foo TO root`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -459,7 +459,7 @@ func newNameFromStr(s string) *tree.Name {
 %token <str> BACKUP BEGIN BETWEEN BIGINT BIGSERIAL BIT
 %token <str> BLOB BOOL BOOLEAN BOTH BY BYTEA BYTES
 
-%token <str> CACHE CANCEL CASCADE CASE CAST CHAR
+%token <str> CACHE CANCEL CASCADE CASE CAST CHANGEFEED CHAR
 %token <str> CHARACTER CHARACTERISTICS CHECK
 %token <str> CLUSTER COALESCE COLLATE COLLATION COLUMN COLUMNS COMMENT COMMIT
 %token <str> COMMITTED COMPACT CONCAT CONFIGURATION CONFIGURATIONS CONFIGURE
@@ -473,7 +473,7 @@ func newNameFromStr(s string) *tree.Name {
 %token <str> DISCARD DISTINCT DO DOUBLE DROP
 
 %token <str> ELSE EMIT ENCODING END ESCAPE EXCEPT
-%token <str> EXISTS EXPERIMENTAL_CHANGEFEED EXECUTE EXPERIMENTAL
+%token <str> EXISTS EXECUTE EXPERIMENTAL
 %token <str> EXPERIMENTAL_FINGERPRINTS EXPERIMENTAL_REPLICA
 %token <str> EXPERIMENTAL_AUDIT
 %token <str> EXPLAIN EXPORT EXTRACT EXTRACT_DURATION
@@ -1917,17 +1917,12 @@ create_stats_stmt:
 | CREATE STATISTICS error // SHOW HELP: CREATE STATISTICS
 
 create_changefeed_stmt:
-  CREATE EXPERIMENTAL_CHANGEFEED EMIT targets TO string_or_placeholder opt_as_of_clause opt_with_options
+  CREATE CHANGEFEED FOR targets INTO string_or_placeholder opt_with_options
   {
-    /* SKIP DOC */
-    // TODO(dan): This reuses the `AS OF SYSTEM TIME` syntax for convenience,
-    // but it means something different here than SELECT and BACKUP. On the
-    // other hand, RESTORE already stretches the definition a bit. Revisit.
     $$.val = &tree.CreateChangefeed{
       Targets: $4.targetList(),
       SinkURI: $6.expr(),
-      AsOf: $7.asOfClause(),
-      Options: $8.kvOptions(),
+      Options: $7.kvOptions(),
     }
   }
 
@@ -7940,6 +7935,7 @@ unreserved_keyword:
 | CACHE
 | CANCEL
 | CASCADE
+| CHANGEFEED
 | CLUSTER
 | COLUMNS
 | COMMENT
@@ -7972,7 +7968,6 @@ unreserved_keyword:
 | EXECUTE
 | EXPERIMENTAL
 | EXPERIMENTAL_AUDIT
-| EXPERIMENTAL_CHANGEFEED
 | EXPERIMENTAL_FINGERPRINTS
 | EXPERIMENTAL_RANGES
 | EXPERIMENTAL_RELOCATE

--- a/pkg/sql/sem/tree/changefeed.go
+++ b/pkg/sql/sem/tree/changefeed.go
@@ -18,7 +18,6 @@ package tree
 type CreateChangefeed struct {
 	Targets TargetList
 	SinkURI Expr
-	AsOf    AsOfClause
 	Options KVOptions
 }
 
@@ -26,14 +25,10 @@ var _ Statement = &CreateChangefeed{}
 
 // Format implements the NodeFormatter interface.
 func (node *CreateChangefeed) Format(ctx *FmtCtx) {
-	ctx.WriteString("CREATE EXPERIMENTAL_CHANGEFEED EMIT ")
+	ctx.WriteString("CREATE CHANGEFEED FOR ")
 	ctx.FormatNode(&node.Targets)
-	ctx.WriteString(" TO ")
+	ctx.WriteString(" INTO ")
 	ctx.FormatNode(node.SinkURI)
-	if node.AsOf.Expr != nil {
-		ctx.WriteString(" ")
-		ctx.FormatNode(&node.AsOf)
-	}
 	if node.Options != nil {
 		ctx.WriteString(" WITH ")
 		ctx.FormatNode(&node.Options)


### PR DESCRIPTION
Updating the easy parts of the grammar first. Still TODO is the
changefeed name as well as targeting partitions/ranges of primary keys.

Release note: None