### PR TITLE
opt: don't push limit through project when ordering on synthesized column

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -198,11 +198,11 @@ SELECT y FROM (SELECT y FROM NumToStr ORDER BY y LIMIT 5) AS a WHERE y <> 2
 5
 
 statement error memory budget exceeded
-SELECT y, str, repeat('test', y) FROM NumToStr ORDER BY str
+SELECT y, str, repeat('test', y) AS res FROM NumToStr ORDER BY res
 
 # Verify we use the "top K" strategy and thus don't hit OOM as above.
 statement ok
-SELECT y, str, repeat('test', y) FROM NumToStr ORDER BY str LIMIT 10
+SELECT y, str, repeat('test', y) AS res FROM NumToStr ORDER BY res LIMIT 10
 
 # Regression test for #20481.
 query I

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -157,6 +157,42 @@ SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT x FROM (SELECT x, 2*x, x+1 FROM NumT
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJyMj7FqxDAQRPt8RZhaELtVde01uXCkCyoUazgMtuTsriDh0L8HW0VIEUg5M9J77B25JD7HlQr_hhHBYZMyUbXIXvUH5_QJPzjMeau218FhKkL4O2y2hfB4je8Lr4yJ8jTAIdHivBzYTeY1ytcp19WKftQohMOlmn88jQjNoVT7IavFG-HH5v5vv1K3kpW_xH-RhxYcmG7sF2qpMvFFynRoerwc_44iUa2vYw_n3KcW2sN3AAAA___R0mt-
 
+query TTTTT
+EXPLAIN (VERBOSE) SELECT y, str, repeat('test', y) AS res FROM NumToStr ORDER BY res
+----
+render               ·         ·                  (y, str, res)                        ·
+ │                   render 0  "numtostr.y"       ·                                    ·
+ │                   render 1  "numtostr.str"     ·                                    ·
+ │                   render 2  res                ·                                    ·
+ └── sort            ·         ·                  (res, "numtostr.y", "numtostr.str")  +res
+      │              order     +res               ·                                    ·
+      └── render     ·         ·                  (res, "numtostr.y", "numtostr.str")  ·
+           │         render 0  repeat('test', y)  ·                                    ·
+           │         render 1  y                  ·                                    ·
+           │         render 2  str                ·                                    ·
+           └── scan  ·         ·                  (y, str)                             ·
+·                    table     numtostr@primary   ·                                    ·
+·                    spans     ALL                ·                                    ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT y, str, repeat('test', y) AS res FROM NumToStr ORDER BY res LIMIT 10
+----
+render                    ·         ·                  (y, str, res)                        ·
+ │                        render 0  "numtostr.y"       ·                                    ·
+ │                        render 1  "numtostr.str"     ·                                    ·
+ │                        render 2  res                ·                                    ·
+ └── limit                ·         ·                  (res, "numtostr.y", "numtostr.str")  +res
+      │                   count     10                 ·                                    ·
+      └── sort            ·         ·                  (res, "numtostr.y", "numtostr.str")  +res
+           │              order     +res               ·                                    ·
+           └── render     ·         ·                  (res, "numtostr.y", "numtostr.str")  ·
+                │         render 0  repeat('test', y)  ·                                    ·
+                │         render 1  y                  ·                                    ·
+                │         render 2  str                ·                                    ·
+                └── scan  ·         ·                  (y, str)                             ·
+·                         table     numtostr@primary   ·                                    ·
+·                         spans     ALL                ·                                    ·
+
 # Regression test for #20481.
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT count(*) FROM (SELECT 1 AS one FROM NumToSquare WHERE x > 10 ORDER BY xsquared LIMIT 10)]

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -395,6 +395,18 @@ func (c *CustomFuncs) LimitGeMaxRows(limit memo.PrivateID, input memo.GroupID) b
 	return limitVal >= 0 && maxRows < math.MaxUint32 && limitVal >= int64(maxRows)
 }
 
+// HasColsInOrdering returns true if all columns that appear in an ordering
+// are output columns of the given group.
+func (c *CustomFuncs) HasColsInOrdering(input memo.GroupID, ordering memo.PrivateID) bool {
+	outCols := c.OutputCols(input)
+	for _, ordCol := range c.ExtractOrdering(ordering) {
+		if !outCols.Contains(int(ordCol.ID())) {
+			return false
+		}
+	}
+	return true
+}
+
 // ----------------------------------------------------------------------
 //
 // Boolean Rules

--- a/pkg/sql/opt/norm/rules/limit.opt
+++ b/pkg/sql/opt/norm/rules/limit.opt
@@ -21,7 +21,7 @@ $input
 (Limit
     (Project $input:* $projections:*)
     $limit:*
-    $ordering:*
+    $ordering:* & (HasColsInOrdering $input $ordering)
 )
 =>
 (Project
@@ -36,7 +36,7 @@ $input
 (Offset
     (Project $input:* $projections:*)
     $offset:*
-    $ordering:*
+    $ordering:* & (HasColsInOrdering $input $ordering)
 )
 =>
 (Project

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -103,6 +103,47 @@ project
  └── projections [outer=(1,3)]
       └── a.f * 2.0 [type=float, outer=(3)]
 
+opt
+SELECT k, f*2.0 AS r FROM a ORDER BY k LIMIT 5
+----
+project
+ ├── columns: k:1(int!null) r:6(float)
+ ├── cardinality: [0 - 5]
+ ├── keys: (1)
+ ├── ordering: +1
+ ├── scan a
+ │    ├── columns: k:1(int!null) f:3(float)
+ │    ├── limit: 5
+ │    ├── keys: (1)
+ │    └── ordering: +1
+ └── projections [outer=(1,3)]
+      └── a.f * 2.0 [type=float, outer=(3)]
+
+# Don't push the limit through project when the ordering is on a
+# synthesized column.
+opt
+SELECT k, f*2.0 AS r FROM a ORDER BY r LIMIT 5 
+----
+limit
+ ├── columns: k:1(int!null) r:6(float)
+ ├── cardinality: [0 - 5]
+ ├── keys: (1)
+ ├── ordering: +6
+ ├── sort
+ │    ├── columns: k:1(int!null) r:6(float)
+ │    ├── keys: (1)
+ │    ├── ordering: +6
+ │    └── project
+ │         ├── columns: r:6(float) k:1(int!null)
+ │         ├── keys: (1)
+ │         ├── scan a
+ │         │    ├── columns: k:1(int!null) f:3(float)
+ │         │    └── keys: (1)
+ │         └── projections [outer=(1,3)]
+ │              └── a.f * 2.0 [type=float, outer=(3)]
+ └── const: 5 [type=int]
+
+
 # Detect PushLimitIntoProject and FilterUnusedLimitCols dependency cycle.
 opt
 SELECT f, f+1.1 AS r FROM (SELECT f, i FROM a GROUP BY f, i) a ORDER BY f LIMIT 5
@@ -174,6 +215,48 @@ project
  │    └── const: 5 [type=int]
  └── projections [outer=(1,3)]
       └── a.f * 2.0 [type=float, outer=(3)]
+
+opt
+SELECT k, f*2.0 AS r FROM a ORDER BY k OFFSET 5
+----
+project
+ ├── columns: k:1(int!null) r:6(float)
+ ├── keys: (1)
+ ├── ordering: +1
+ ├── offset
+ │    ├── columns: k:1(int!null) f:3(float)
+ │    ├── keys: (1)
+ │    ├── ordering: +1
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) f:3(float)
+ │    │    ├── keys: (1)
+ │    │    └── ordering: +1
+ │    └── const: 5 [type=int]
+ └── projections [outer=(1,3)]
+      └── a.f * 2.0 [type=float, outer=(3)]
+
+# Don't push the offset through project when the ordering is on a
+# synthesized column.
+opt
+SELECT k, f*2.0 AS r FROM a ORDER BY r OFFSET 5
+----
+offset
+ ├── columns: k:1(int!null) r:6(float)
+ ├── keys: (1)
+ ├── ordering: +6
+ ├── sort
+ │    ├── columns: k:1(int!null) r:6(float)
+ │    ├── keys: (1)
+ │    ├── ordering: +6
+ │    └── project
+ │         ├── columns: r:6(float) k:1(int!null)
+ │         ├── keys: (1)
+ │         ├── scan a
+ │         │    ├── columns: k:1(int!null) f:3(float)
+ │         │    └── keys: (1)
+ │         └── projections [outer=(1,3)]
+ │              └── a.f * 2.0 [type=float, outer=(3)]
+ └── const: 5 [type=int]
 
 # Detect PushOffsetIntoProject and FilterUnusedOffsetCols dependency cycle.
 opt


### PR DESCRIPTION
It is invalid to push limit/offset through a projection if the
ordering depends on a synthesized column. Fix the rules to check for
this.

Release note: None