### PR TITLE
sql: Fix panic adding unique, non-indexable column

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -694,6 +694,30 @@ decomputed_column  CREATE TABLE decomputed_column (
                    FAMILY "primary" (a, b)
 )
 
+# Test for https://github.com/cockroachdb/cockroach/issues/26483
+# We try to create a unique column on an un-indexable type.
+statement ok
+CREATE TABLE b26483()
+
+statement error unimplemented: column c is of type ARRAY and thus is not indexable
+ALTER TABLE b26483 ADD COLUMN c INT[] UNIQUE
+
+# As above, but performed in a transaction
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE b26483_tx()
+
+statement ok
+ALTER TABLE b26483_tx ADD COLUMN c INT[]
+
+statement error unimplemented: column c is of type ARRAY and thus is not indexable
+CREATE INDEX on b26483_tx (c)
+
+statement ok
+ROLLBACK
+
 # Verify that auditing can be enabled by root, and cannot be disabled by non-root.
 
 statement ok

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1613,7 +1613,7 @@ func notIndexableError(cols []ColumnDescriptor, inverted bool) error {
 func checkColumnsValidForIndex(tableDesc *TableDescriptor, indexColNames []string) error {
 	invalidColumns := make([]ColumnDescriptor, 0, len(indexColNames))
 	for _, indexCol := range indexColNames {
-		for _, col := range tableDesc.Columns {
+		for _, col := range tableDesc.allNonDropColumns() {
 			if col.Name == indexCol {
 				if !columnTypeIsIndexable(col.Type) {
 					invalidColumns = append(invalidColumns, col)
@@ -1633,7 +1633,7 @@ func checkColumnsValidForInvertedIndex(tableDesc *TableDescriptor, indexColNames
 	}
 	invalidColumns := make([]ColumnDescriptor, 0, len(indexColNames))
 	for _, indexCol := range indexColNames {
-		for _, col := range tableDesc.Columns {
+		for _, col := range tableDesc.allNonDropColumns() {
 			if col.Name == indexCol {
 				if !columnTypeIsInvertedIndexable(col.Type) {
 					invalidColumns = append(invalidColumns, col)


### PR DESCRIPTION
This change updates the `checkColumnsFor...Index` functions to use
`allNonDropColumns()` to validate against any proposed mutations.  Otherwise, a
`ColumnMutation` that adds a non-indexable column followed by an
`IndexMutation` creating an index on that column would would be incorrectly
accepted, leading to a panic.

Fixes #26483

Release note (sql change): Return an error to the user instead of panicing when
trying to add a column with a unique constraint when that column's type is not
indexable.