### PR TITLE
kv: Allow multiple rollbacks to be sent 

### DIFF
--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -935,7 +935,7 @@ func TestTxnCoordIdempotentCleanup(t *testing.T) {
 	// succeeds, which it may not if the previous cleanup has already
 	// terminated the heartbeat goroutine)
 	ba = txn.NewBatch()
-	ba.AddRawRequest(&roachpb.EndTransactionRequest{})
+	ba.AddRawRequest(&roachpb.EndTransactionRequest{Commit: true})
 	err := txn.Run(context.TODO(), ba)
 	assertTransactionAbortedError(t, err)
 }

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -205,6 +205,7 @@ CREATE TABLE t.public.test (k INT PRIMARY KEY, v TEXT);
 			// any errors.
 			// TODO(andrei): Figure out a better way to test for non-blocking.
 			// Use a trace when the client-side tracing story gets good enough.
+			// There's a bit of difficulty because the cleanup is async.
 			txCheck, err := mainDB.Begin()
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
... through a TxnCoordSender.
Before this patch, the TCS would reject everything coming after a
rollback. At the same time, client.Txn would retry a rollback if the
context with which it sent the first one was canceled while the request
was in flight (as an extension of allowing rollbacks to be sent with a
canceled context, which is generally useful - upon detecting
cancelation, clients should do cleanup).

Fixes #26524

Release note: None