### PR TITLE
storage/compactor: avoid over-aggregating suggested compactions

### DIFF
--- a/pkg/storage/compactor/settings.go
+++ b/pkg/storage/compactor/settings.go
@@ -69,7 +69,7 @@ var thresholdBytes = settings.RegisterByteSizeSetting(
 	256<<20, // more than 256MiB will trigger
 )
 
-// ThresholdBytesUsedFraction is the fraction of total logical
+// thresholdBytesUsedFraction is the fraction of total logical
 // bytes used which are up for suggested reclamation, after which
 // the compactor will begin processing (taking compactor min
 // interval into account). Note that this threshold handles the case


### PR DESCRIPTION
Stop aggregating suggested compactions as soon as the bytes
threshold (`compactor.threshold_bytes == 256MiB`) is reached. Previously
we would aggregate suggested compactions to be as large as possible
which could result in a compaction covering 10s of gigabytes of
data. There was not much point in aggregating compactions this large as
DBCompactRange would turn around and break the compactions at L6 sstable
boundaries. Experimentally it appears to be better to have the
compaction queue avoid overly large compations.

Release note: None