### PR TITLE
sql: fix the ordering of SRF projections

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -159,6 +159,24 @@ r
 9
 12
 
+subtest srf_ordering
+
+statement ok
+CREATE TABLE ordered_t(x INT PRIMARY KEY);
+  INSERT INTO ordered_t VALUES (0), (1)
+
+query II colnames
+SELECT x, generate_series(3, x, -1) FROM ordered_t ORDER BY 1, 2;
+----
+x  generate_series
+0  0
+0  1
+0  2
+0  3
+1  1
+1  2
+1  3
+
 subtest unnest
 
 query I colnames
@@ -751,16 +769,18 @@ SELECT count(*) FROM (SELECT generate_series(1,x) FROM vals)
 query TI colnames
 SELECT relname, unnest(indkey) FROM pg_class, pg_index WHERE pg_class.oid = pg_index.indrelid ORDER BY relname, unnest
 ----
-relname  unnest
-t        2
-u        2
-vals     1
-vals     2
-vals     3
+relname    unnest
+ordered_t  1
+t          2
+u          2
+vals       1
+vals       2
+vals       3
 
 query T
 SELECT information_schema._pg_expandarray(indkey) FROM pg_index ORDER BY x, n
 ----
+(1,1)
 (1,2)
 (2,1)
 (2,1)

--- a/pkg/sql/logictest/testdata/planner_test/srfs
+++ b/pkg/sql/logictest/testdata/planner_test/srfs
@@ -131,3 +131,22 @@ render            ·                                            (generate_series
       └── scan    ·                                            (a, rowid[hidden,omitted])
 ·                 t@primary                                    ·
 ·                 ALL                                          ·
+
+subtest srf_source_order
+
+# Check that SRFs do not abuse their source's ordering.
+
+statement ok
+CREATE TABLE v(x INT PRIMARY KEY)
+
+query TTTTT
+EXPLAIN(VERBOSE) SELECT x, generate_series(3, x, -1) FROM v
+ORDER BY 1, 2;
+----
+sort              ·         ·                                        (x, generate_series)  x!=NULL; +x,+generate_series
+ │                order     +x,+generate_series                      ·                     ·
+ └── project set  ·         ·                                        (x, generate_series)  x!=NULL; +x
+      │           render 0  generate_series(3, test.public.v.x, -1)  ·                     ·
+      └── scan    ·         ·                                        (x)                   x!=NULL; key(x); +x
+·                 table     v@primary                                ·                     ·
+·                 spans     ALL                                      ·                     ·

--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -44,11 +44,7 @@ func planPhysicalProps(plan planNode) physicalProps {
 			return planPhysicalProps(n.source)
 		}
 	case *projectSetNode:
-		// We can pass through properties because projectSetNode preserves
-		// all input columns, and they come first.
-		// TODO(knz): the result is ordered by any of the underlying
-		// SRF orders, not just the source first.
-		return planPhysicalProps(n.source)
+		return n.props
 
 	case *filterNode:
 		return n.props

--- a/pkg/sql/project_set.go
+++ b/pkg/sql/project_set.go
@@ -69,6 +69,9 @@ type projectSetNode struct {
 	// each entry in `exprs`.
 	numColsPerGen []int
 
+	// props are the ordering, key props etc.
+	props physicalProps
+
 	run projectSetRun
 }
 
@@ -338,4 +341,13 @@ func (n *projectSetNode) Close(ctx context.Context) {
 			gen.Close()
 		}
 	}
+}
+
+func (n *projectSetNode) computePhysicalProps() {
+	// We can pass through properties because projectSetNode preserves
+	// all input columns, and they come first.
+	n.props = planPhysicalProps(n.source)
+	// However any key in the source is destroyed because rows may repeat
+	// multiple times.
+	n.props.weakKeys = nil
 }


### PR DESCRIPTION
Prior to this patch, a project set operator would incorrectly report a
key property on the columns from its data source, if the data source
had a key already. This is incorrect because the result of a SRF
projection can repeat rows from the source.

Fixes #26701.
Bug found by @solongordon.

Release note: None