### PR TITLE
roachtest: use --sequential when generating store dumps

### DIFF
--- a/pkg/cmd/roachtest/store_gen.go
+++ b/pkg/cmd/roachtest/store_gen.go
@@ -65,7 +65,7 @@ func registerStoreGen(r *registry, args []string) {
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			c.Put(ctx, cockroach, "./cockroach")
 			c.Put(ctx, workload, "./workload")
-			c.Start(ctx)
+			c.Start(ctx, startArgs("--sequential"))
 
 			{
 				m := newMonitor(ctx, c)


### PR DESCRIPTION
This makes the mapping from cockroach node ID to roachprod node ID the
identify function.

Release note: None