### PR TITLE
cli: use the right context for logging on signal

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -764,7 +764,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 	case sig := <-signalCh:
 		// This new signal is not welcome, as it interferes with the graceful
 		// shutdown process.
-		log.Shout(ctx, log.Severity_ERROR, fmt.Sprintf(
+		log.Shout(shutdownCtx, log.Severity_ERROR, fmt.Sprintf(
 			"received signal '%s' during shutdown, initiating hard shutdown%s", sig, hardShutdownHint))
 		handleSignalDuringShutdown(sig)
 		panic("unreachable")


### PR DESCRIPTION
We were using a long-gone context with a potentially finished span,
leading to log-after-finish crashes.

Fixes #26715

Release note: None