### PR TITLE
engine: Fix TS Merge consistency error

### DIFF
--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -227,6 +227,10 @@ DBIterState DBIterPrev(DBIterator* iter, bool skip_current_key_versions);
 // Go code.
 DBStatus DBMergeOne(DBSlice existing, DBSlice update, DBString* new_value);
 
+// Implements the partial merge operator on a single pair of values. update is
+// merged with existing. This method is provided for invocation from Go code.
+DBStatus DBPartialMergeOne(DBSlice existing, DBSlice update, DBString* new_value);
+
 // NB: The function (cStatsToGoStats) that converts these to the go
 // representation is unfortunately duplicated in engine and engineccl. If this
 // struct is changed, both places need to be updated.

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2333,6 +2333,19 @@ func goMerge(existing, update []byte) ([]byte, error) {
 	return cStringToGoBytes(result), nil
 }
 
+// goPartialMerge takes existing and update byte slices that are expected to
+// be marshaled roachpb.Values and performs a partial merge using C++ code,
+// marshaled roachpb.Value or an error.
+func goPartialMerge(existing, update []byte) ([]byte, error) {
+	var result C.DBString
+	status := C.DBPartialMergeOne(goToCSlice(existing), goToCSlice(update), &result)
+	if status.data != nil {
+		return nil, errors.Errorf("%s: existing=%q, update=%q",
+			cStringToGoString(status), existing, update)
+	}
+	return cStringToGoBytes(result), nil
+}
+
 func emptyKeyError() error {
 	return errors.Errorf("attempted access to empty key")
 }

--- a/pkg/ts/timeseries_test.go
+++ b/pkg/ts/timeseries_test.go
@@ -155,7 +155,7 @@ func TestDiscardEarlierSamples(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out, err := engine.MergeInternalTimeSeriesData(internal...)
+	out, err := engine.MergeInternalTimeSeriesData(true /* mergeIntoNil */, false /* usePartialMerge */, internal...)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Recent changes to the C++ code for time series merges introduced the
possibility of inconsistent and incorrect merges, due to improper
consideration of Partial Merge operations. RocksDB uses a shorter
"Partial Merge" to combine multiple right-side operands before combining
them with the existing left-side value; however, in our case this
resulted in situations where the wrong eventual value would be reached
if the partial merge involved both column- and row-formatted data.

This commit fixes the two cases where this occurred by converting data
to columnar in the places that were missed; also significantly expands
the scope of existing merge test cases to exercise the partial merge
path. I have verified that the expanded test cases would have caught
this issue.

Fixes #26679
Fixes #26676

Release note: None