### PR TITLE
opt: interesting orderings property

### DIFF
--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -375,8 +375,12 @@ func (ev ExprView) formatRelational(f *opt.ExprFmtCtx, tp treeprinter.Node) {
 	}
 
 	if !f.HasFlags(opt.ExprFmtHideRuleProps) {
-		if !logProps.Relational.Rule.PruneCols.Empty() {
-			tp.Childf("prune: %s", logProps.Relational.Rule.PruneCols.String())
+		r := &logProps.Relational.Rule
+		if !r.PruneCols.Empty() {
+			tp.Childf("prune: %s", r.PruneCols.String())
+		}
+		if len(r.InterestingOrderings) > 0 {
+			tp.Childf("interesting orderings: %s", r.InterestingOrderings.String())
 		}
 	}
 

--- a/pkg/sql/opt/norm/rule_props_builder.go
+++ b/pkg/sql/opt/norm/rule_props_builder.go
@@ -21,14 +21,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 )
 
-// rulePropsBuilder is a helper class that fills out the rule property structure
-// in props.Relational. See the comment for the props.Relational.Rule field for
-// more details.
+// rulePropsBuilder is a helper class that fills out some fields (those needed
+// by normalization rules) in the Rule property structure in props.Relational.
+// See the comment for the props.Relational.Rule field for more details.
 type rulePropsBuilder struct {
 	mem *memo.Memo
 }
 
-// buildProps fills the props.Relational.Rule field in the given expression's
+// buildProps fills in props.Relational.Rule fields in the given expression's
 // logical properties. Each rule property is "owned" by a family of Optgen
 // rules, like the PruneCols rules, or the Decorrelate rules, that uses that
 // property. How the rule property is derived is tightly bound to how the

--- a/pkg/sql/opt/norm/testdata/props/prune_cols
+++ b/pkg/sql/opt/norm/testdata/props/prune_cols
@@ -1,3 +1,5 @@
+# Tests for PruneCols property
+
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING)
 ----
@@ -18,10 +20,6 @@ TABLE xy
  └── INDEX primary
       └── x int not null
 
-# --------------------------------------------------
-# PruneCols property
-# --------------------------------------------------
-
 # Scan operator.
 build
 SELECT * FROM a
@@ -29,7 +27,8 @@ SELECT * FROM a
 scan a
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
  ├── keys: (1)
- └── prune: (1-4)
+ ├── prune: (1-4)
+ └── interesting orderings: (+1)
 
 # Select operator.
 build
@@ -39,10 +38,12 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string)
  ├── keys: (1)
  ├── prune: (2,4)
+ ├── interesting orderings: (+1)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
  │    ├── keys: (1)
- │    └── prune: (1-4)
+ │    ├── prune: (1-4)
+ │    └── interesting orderings: (+1)
  └── filters [type=bool, outer=(1,3), constraints=(/1: [/1 - /1]; /3: [/1.0 - /1.0]; tight)]
       └── (a.k = 1) AND (a.f = 1.0) [type=bool, outer=(1,3), constraints=(/1: [/1 - /1]; /3: [/1.0 - /1.0]; tight)]
 
@@ -54,10 +55,12 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
  ├── keys: (1)
  ├── prune: (1-4)
+ ├── interesting orderings: (+1)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
  │    ├── keys: (1)
- │    └── prune: (1-4)
+ │    ├── prune: (1-4)
+ │    └── interesting orderings: (+1)
  └── filters [type=bool]
       └── true [type=bool]
 
@@ -71,7 +74,8 @@ project
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
  │    ├── keys: (1)
- │    └── prune: (1-4)
+ │    ├── prune: (1-4)
+ │    └── interesting orderings: (+1)
  └── projections [outer=(1,2,4)]
       └── a.k + 1 [type=int, outer=(1)]
 
@@ -82,14 +86,17 @@ SELECT * FROM a INNER JOIN xy ON a.k=xy.x
 inner-join
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) x:5(int!null) y:6(int)
  ├── prune: (2-4,6)
+ ├── interesting orderings: (+1) (+5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
  │    ├── keys: (1)
- │    └── prune: (1-4)
+ │    ├── prune: (1-4)
+ │    └── interesting orderings: (+1)
  ├── scan xy
  │    ├── columns: x:5(int!null) y:6(int)
  │    ├── keys: (5)
- │    └── prune: (5,6)
+ │    ├── prune: (5,6)
+ │    └── interesting orderings: (+5)
  └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
       └── a.k = xy.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
 
@@ -100,14 +107,17 @@ SELECT * FROM a, xy
 inner-join
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) x:5(int!null) y:6(int)
  ├── prune: (1-6)
+ ├── interesting orderings: (+1) (+5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
  │    ├── keys: (1)
- │    └── prune: (1-4)
+ │    ├── prune: (1-4)
+ │    └── interesting orderings: (+1)
  ├── scan xy
  │    ├── columns: x:5(int!null) y:6(int)
  │    ├── keys: (5)
- │    └── prune: (5,6)
+ │    ├── prune: (5,6)
+ │    └── interesting orderings: (+5)
  └── true [type=bool]
 
 # ApplyJoin operator.
@@ -120,18 +130,22 @@ project
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
  ├── keys: (1)
  ├── prune: (1-4)
+ ├── interesting orderings: (+1)
  └── select
       ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) r:7(int!null)
       ├── keys: (1)
       ├── prune: (2-4)
+      ├── interesting orderings: (+1)
       ├── left-join-apply
       │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) r:7(int)
       │    ├── keys: (1)
       │    ├── prune: (2-4)
+      │    ├── interesting orderings: (+1)
       │    ├── scan a
       │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
       │    │    ├── keys: (1)
-      │    │    └── prune: (1-4)
+      │    │    ├── prune: (1-4)
+      │    │    └── interesting orderings: (+1)
       │    ├── max1-row
       │    │    ├── columns: r:7(int)
       │    │    ├── outer: (1)
@@ -144,10 +158,12 @@ project
       │    │         │    ├── columns: x:5(int!null)
       │    │         │    ├── outer: (1)
       │    │         │    ├── keys: (5)
+      │    │         │    ├── interesting orderings: (+5)
       │    │         │    ├── scan xy
       │    │         │    │    ├── columns: x:5(int!null)
       │    │         │    │    ├── keys: (5)
-      │    │         │    │    └── prune: (5)
+      │    │         │    │    ├── prune: (5)
+      │    │         │    │    └── interesting orderings: (+5)
       │    │         │    └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
       │    │         │         └── xy.x = a.k [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
       │    │         └── projections [outer=(1)]
@@ -171,24 +187,29 @@ project
       ├── columns: k:1(int!null) i:2(int)
       ├── keys: (1)
       ├── prune: (2)
+      ├── interesting orderings: (+1)
       ├── semi-join
       │    ├── columns: k:1(int!null) i:2(int)
       │    ├── keys: (1)
       │    ├── prune: (2)
+      │    ├── interesting orderings: (+1)
       │    ├── scan a
       │    │    ├── columns: k:1(int!null) i:2(int)
       │    │    ├── keys: (1)
-      │    │    └── prune: (1,2)
+      │    │    ├── prune: (1,2)
+      │    │    └── interesting orderings: (+1)
       │    ├── scan xy
       │    │    ├── columns: xy.x:7(int!null) xy.y:8(int)
       │    │    ├── keys: (7)
-      │    │    └── prune: (7,8)
+      │    │    ├── prune: (7,8)
+      │    │    └── interesting orderings: (+7)
       │    └── filters [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ])]
       │         └── a.k = xy.x [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ])]
       ├── scan xy
       │    ├── columns: xy.x:5(int!null)
       │    ├── keys: (5)
-      │    └── prune: (5)
+      │    ├── prune: (5)
+      │    └── interesting orderings: (+5)
       └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
            └── a.k = xy.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
 
@@ -207,24 +228,29 @@ project
       ├── columns: k:1(int!null) i:2(int)
       ├── keys: (1)
       ├── prune: (2)
+      ├── interesting orderings: (+1)
       ├── anti-join
       │    ├── columns: k:1(int!null) i:2(int)
       │    ├── keys: (1)
       │    ├── prune: (2)
+      │    ├── interesting orderings: (+1)
       │    ├── scan a
       │    │    ├── columns: k:1(int!null) i:2(int)
       │    │    ├── keys: (1)
-      │    │    └── prune: (1,2)
+      │    │    ├── prune: (1,2)
+      │    │    └── interesting orderings: (+1)
       │    ├── scan xy
       │    │    ├── columns: xy.x:7(int!null) xy.y:8(int)
       │    │    ├── keys: (7)
-      │    │    └── prune: (7,8)
+      │    │    ├── prune: (7,8)
+      │    │    └── interesting orderings: (+7)
       │    └── filters [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ])]
       │         └── a.k = xy.x [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ])]
       ├── scan xy
       │    ├── columns: xy.x:5(int!null)
       │    ├── keys: (5)
-      │    └── prune: (5)
+      │    ├── prune: (5)
+      │    └── interesting orderings: (+5)
       └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
            └── a.k = xy.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
 
@@ -242,7 +268,8 @@ project
       ├── prune: (5,6)
       ├── scan a
       │    ├── columns: i:2(int) f:3(float) s:4(string)
-      │    └── prune: (2-4)
+      │    ├── prune: (2-4)
+      │    └── interesting orderings: ()
       └── aggregations [outer=(2)]
            ├── count-rows [type=int]
            └── sum [type=decimal, outer=(2)]
@@ -258,7 +285,8 @@ group-by
  ├── prune: (5,6)
  ├── scan a
  │    ├── columns: i:2(int)
- │    └── prune: (2)
+ │    ├── prune: (2)
+ │    └── interesting orderings: ()
  └── aggregations [outer=(2)]
       ├── count-rows [type=int]
       └── sum [type=decimal, outer=(2)]
@@ -274,7 +302,8 @@ group-by
  ├── keys: weak(3,4)
  └── scan a
       ├── columns: f:3(float) s:4(string)
-      └── prune: (3,4)
+      ├── prune: (3,4)
+      └── interesting orderings: ()
 
 # UnionAll operator (don't allow pruning).
 opt
@@ -290,15 +319,18 @@ union-all
  │    ├── columns: a.k:1(int!null) a.i:2(int)
  │    ├── constraint: /1: [/1 - /1]
  │    ├── keys: (1)
- │    └── prune: (2)
+ │    ├── prune: (2)
+ │    └── interesting orderings: (+1)
  └── select
       ├── columns: x:5(int!null) y:6(int!null)
       ├── keys: (5)
       ├── prune: (5)
+      ├── interesting orderings: (+5)
       ├── scan xy
       │    ├── columns: x:5(int!null) y:6(int)
       │    ├── keys: (5)
-      │    └── prune: (5,6)
+      │    ├── prune: (5,6)
+      │    └── interesting orderings: (+5)
       └── filters [type=bool, outer=(6), constraints=(/6: [/2 - /2]; tight)]
            └── xy.y = 2 [type=bool, outer=(6), constraints=(/6: [/2 - /2]; tight)]
 
@@ -322,7 +354,8 @@ explain
  └── scan a
       ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
       ├── keys: (1)
-      └── prune: (1-4)
+      ├── prune: (1-4)
+      └── interesting orderings: (+1)
 
 # Limit operator.
 build
@@ -333,10 +366,12 @@ limit
  ├── cardinality: [0 - 1]
  ├── keys: (1)
  ├── prune: (1-4)
+ ├── interesting orderings: (+1)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
  │    ├── keys: (1)
- │    └── prune: (1-4)
+ │    ├── prune: (1-4)
+ │    └── interesting orderings: (+1)
  └── const: 1 [type=int]
 
 # Limit operator with ordering.
@@ -349,6 +384,7 @@ limit
  ├── keys: (1)
  ├── ordering: -4,+2
  ├── prune: (1,3)
+ ├── interesting orderings: (-4,+2)
  ├── sort
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
  │    ├── keys: (1)
@@ -368,10 +404,12 @@ offset
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
  ├── keys: (1)
  ├── prune: (1-4)
+ ├── interesting orderings: (+1)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
  │    ├── keys: (1)
- │    └── prune: (1-4)
+ │    ├── prune: (1-4)
+ │    └── interesting orderings: (+1)
  └── const: 1 [type=int]
 
 # Offset operator with ordering.
@@ -383,6 +421,7 @@ offset
  ├── keys: (1)
  ├── ordering: -4,+2
  ├── prune: (1,3)
+ ├── interesting orderings: (-4,+2)
  ├── sort
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
  │    ├── keys: (1)
@@ -416,7 +455,8 @@ project
                      ├── scan a
                      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
                      │    ├── keys: (1)
-                     │    └── prune: (1-4)
+                     │    ├── prune: (1-4)
+                     │    └── interesting orderings: (+1)
                      └── projections
                           └── const: 1 [type=int]
 
@@ -431,7 +471,8 @@ row-number
  └── scan a
       ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
       ├── keys: (1)
-      └── prune: (1-4)
+      ├── prune: (1-4)
+      └── interesting orderings: (+1)
 
 # RowNumber operator with ordering.
 build

--- a/pkg/sql/opt/ordering.go
+++ b/pkg/sql/opt/ordering.go
@@ -113,6 +113,16 @@ func (o Ordering) Provides(required Ordering) bool {
 	return true
 }
 
+// CommonPrefix returns the longest ordering that is a prefix of both orderings.
+func (o Ordering) CommonPrefix(other Ordering) Ordering {
+	for i := range o {
+		if i >= len(other) || o[i] != other[i] {
+			return o[:i]
+		}
+	}
+	return o
+}
+
 // Equals returns true if the two orderings are identical.
 func (o Ordering) Equals(rhs Ordering) bool {
 	if len(o) != len(rhs) {
@@ -125,4 +135,81 @@ func (o Ordering) Equals(rhs Ordering) bool {
 		}
 	}
 	return true
+}
+
+// OrderingSet is a set of orderings, with the restriction that no ordering
+// is a prefix of another ordering in the set.
+type OrderingSet []Ordering
+
+// Copy returns a copy of the set which can be independently modified.
+func (os OrderingSet) Copy() OrderingSet {
+	res := make(OrderingSet, len(os))
+	copy(res, os)
+	return res
+}
+
+// Add an ordering to the list, checking whether it is a prefix of another
+// ordering (or vice-versa).
+func (os *OrderingSet) Add(o Ordering) {
+	for i := range *os {
+		prefix := (*os)[i].CommonPrefix(o)
+		if len(prefix) == len(o) {
+			// o is equal to, or a prefix of os[i]. Do nothing.
+			return
+		}
+		if len(prefix) == len((*os)[i]) {
+			// os[i] is a prefix of o; replace it.
+			(*os)[i] = o
+			return
+		}
+	}
+	*os = append(*os, o)
+}
+
+// RestrictToPrefix keeps only the orderings that have the required ordering as
+// a prefix.
+func (os *OrderingSet) RestrictToPrefix(required Ordering) {
+	res := (*os)[:0]
+	for _, o := range *os {
+		if o.Provides(required) {
+			res = append(res, o)
+		}
+	}
+	*os = res
+}
+
+// RestrictToCols keeps only the orderings (or prefixes of them) that refer to
+// columns in the given set.
+func (os *OrderingSet) RestrictToCols(cols ColSet) {
+	old := *os
+	*os = old[:0]
+	for _, o := range old {
+		// Find the longest prefix of the ordering that contains
+		// only columns in the set.
+		prefix := 0
+		for _, c := range o {
+			if !cols.Contains(int(c.ID())) {
+				break
+			}
+			prefix++
+		}
+		if prefix > 0 {
+			// This function appends at most one element; it is ok to operate on the
+			// same slice.
+			os.Add(o[:prefix])
+		}
+	}
+}
+
+func (os OrderingSet) String() string {
+	var buf bytes.Buffer
+	for i, o := range os {
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		buf.WriteByte('(')
+		buf.WriteString(o.String())
+		buf.WriteByte(')')
+	}
+	return buf.String()
 }

--- a/pkg/sql/opt/ordering_test.go
+++ b/pkg/sql/opt/ordering_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 func TestOrdering(t *testing.T) {
@@ -55,4 +56,58 @@ func TestOrdering(t *testing.T) {
 	if (opt.Ordering{}).Equals(ordering) {
 		t.Error("empty ordering should not equal ordering")
 	}
+}
+
+func TestOrderingSet(t *testing.T) {
+	expect := func(s opt.OrderingSet, exp string) {
+		t.Helper()
+		if actual := s.String(); actual != exp {
+			t.Errorf("expected %s; got %s", exp, actual)
+		}
+	}
+	var s opt.OrderingSet
+	expect(s, "")
+	s.Add(opt.Ordering{1, 2})
+	expect(s, "(+1,+2)")
+	s.Add(opt.Ordering{1, -2, 3})
+	expect(s, "(+1,+2) (+1,-2,+3)")
+	// Add an ordering that already exists.
+	s.Add(opt.Ordering{1, -2, 3})
+	expect(s, "(+1,+2) (+1,-2,+3)")
+	// Add an ordering that is a prefix of an existing ordering.
+	s.Add(opt.Ordering{1, -2})
+	expect(s, "(+1,+2) (+1,-2,+3)")
+	// Add an ordering that has an existing ordering as a prefix.
+	s.Add(opt.Ordering{1, 2, 5})
+	expect(s, "(+1,+2,+5) (+1,-2,+3)")
+
+	s2 := s.Copy()
+	s2.RestrictToPrefix(opt.Ordering{1})
+	expect(s2, "(+1,+2,+5) (+1,-2,+3)")
+	s2 = s.Copy()
+	s2.RestrictToPrefix(opt.Ordering{1, 2})
+	expect(s2, "(+1,+2,+5)")
+	s2 = s.Copy()
+	s2.RestrictToPrefix(opt.Ordering{2})
+	expect(s2, "")
+
+	s2 = s.Copy()
+	s2.RestrictToCols(util.MakeFastIntSet(1, 2, 3, 5))
+	expect(s2, "(+1,+2,+5) (+1,-2,+3)")
+
+	s2 = s.Copy()
+	s2.RestrictToCols(util.MakeFastIntSet(1, 2, 3))
+	expect(s2, "(+1,+2) (+1,-2,+3)")
+
+	s2 = s.Copy()
+	s2.RestrictToCols(util.MakeFastIntSet(1, 2))
+	expect(s2, "(+1,+2) (+1,-2)")
+
+	s2 = s.Copy()
+	s2.RestrictToCols(util.MakeFastIntSet(1, 3))
+	expect(s2, "(+1)")
+
+	s2 = s.Copy()
+	s2.RestrictToCols(util.MakeFastIntSet(2, 3))
+	expect(s2, "")
 }

--- a/pkg/sql/opt/ordering_test.go
+++ b/pkg/sql/opt/ordering_test.go
@@ -15,6 +15,7 @@
 package opt_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
@@ -55,6 +56,19 @@ func TestOrdering(t *testing.T) {
 
 	if (opt.Ordering{}).Equals(ordering) {
 		t.Error("empty ordering should not equal ordering")
+	}
+
+	common := ordering.CommonPrefix(opt.Ordering{1})
+	if exp := (opt.Ordering{1}); !reflect.DeepEqual(common, exp) {
+		t.Errorf("expected common prefix %s, got %s", exp, common)
+	}
+	common = ordering.CommonPrefix(opt.Ordering{1, 2, 3})
+	if exp := (opt.Ordering{1}); !reflect.DeepEqual(common, exp) {
+		t.Errorf("expected common prefix %s, got %s", exp, common)
+	}
+	common = ordering.CommonPrefix(opt.Ordering{1, 5, 6})
+	if exp := (opt.Ordering{1, 5}); !reflect.DeepEqual(common, exp) {
+		t.Errorf("expected common prefix %s, got %s", exp, common)
 	}
 }
 

--- a/pkg/sql/opt/props/logical.go
+++ b/pkg/sql/opt/props/logical.go
@@ -148,6 +148,19 @@ type Relational struct {
 		// not capable of filtering columns (like Explain) will not add any of
 		// their columns to this set.
 		PruneCols opt.ColSet
+
+		// InterestingOrderings is a list of orderings that potentially could be
+		// provided by the operator without sorting. Interesting orderings normally
+		// come from scans (index orders) and are bubbled up through some operators.
+		//
+		// Note that all prefixes of an interesting order are "interesting"; the
+		// list doesn't need to contain orderings that are prefixes of some other
+		// ordering in the list.
+		//
+		// Since this property is only useful for a few specific cases (like merge
+		// joins), it is calculated lazily. Once it is calculated, it is not nil
+		// (even if there are no interesting orderings).
+		InterestingOrderings opt.OrderingSet
 	}
 }
 

--- a/pkg/sql/opt/testutils/opt_tester.go
+++ b/pkg/sql/opt/testutils/opt_tester.go
@@ -170,6 +170,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			}
 			return fmt.Sprintf("error: %s\n", text)
 		}
+		fillInLazyProps(ev)
 		return ev.FormatString(ot.Flags.ExprFormat)
 
 	case "opt":
@@ -177,6 +178,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 		if err != nil {
 			d.Fatalf(tb, "%v", err)
 		}
+		fillInLazyProps(ev)
 		return ev.FormatString(ot.Flags.ExprFormat)
 
 	case "optsteps":
@@ -196,6 +198,17 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 	default:
 		d.Fatalf(tb, "unsupported command: %s", d.Cmd)
 		return ""
+	}
+}
+
+// Fills in lazily-derived properties (for display).
+func fillInLazyProps(ev memo.ExprView) {
+	if !ev.IsScalar() {
+		// Make sure the interesting orderings are calculated.
+		xform.GetInterestingOrderings(ev)
+	}
+	for i := 0; i < ev.ChildCount(); i++ {
+		fillInLazyProps(ev.Child(i))
 	}
 }
 

--- a/pkg/sql/opt/xform/interesting_orderings.go
+++ b/pkg/sql/opt/xform/interesting_orderings.go
@@ -1,0 +1,142 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package xform
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+)
+
+// GetInterestingOrderings calculates and returns the
+// props.Logical.Rule.InterestingOrderings property of a relational operator.
+func GetInterestingOrderings(ev memo.ExprView) opt.OrderingSet {
+	l := ev.Logical().Relational
+	if l.Rule.InterestingOrderings != nil {
+		return l.Rule.InterestingOrderings
+	}
+
+	var res opt.OrderingSet
+	switch ev.Operator() {
+	case opt.ScanOp:
+		res = interestingOrderingsForScan(ev)
+
+	case opt.SelectOp, opt.LookupJoinOp:
+		// Pass through child orderings.
+		res = GetInterestingOrderings(ev.Child(0))
+
+	case opt.ProjectOp:
+		res = interestingOrderingsForProject(ev)
+
+	case opt.GroupByOp:
+		res = interestingOrderingsForGroupBy(ev)
+
+	case opt.LimitOp, opt.OffsetOp:
+		res = interestingOrderingsForLimit(ev)
+
+	default:
+		if ev.IsJoin() {
+			res = interestingOrderingsForJoin(ev)
+			break
+		}
+
+		res = opt.OrderingSet{}
+	}
+
+	l.Rule.InterestingOrderings = res
+	return res
+}
+
+func interestingOrderingsForScan(ev memo.ExprView) opt.OrderingSet {
+	def := ev.Private().(*memo.ScanOpDef)
+	md := ev.Metadata()
+	tab := md.Table(def.Table)
+	ord := make(opt.OrderingSet, 0, tab.IndexCount())
+	for i := 0; i < tab.IndexCount(); i++ {
+		index := tab.Index(i)
+		if index.IsInverted() {
+			continue
+		}
+		numIndexCols := index.UniqueColumnCount()
+		o := make(opt.Ordering, 0, numIndexCols)
+		for j := 0; j < numIndexCols; j++ {
+			indexCol := index.Column(j)
+			colID := md.TableColumn(def.Table, indexCol.Ordinal)
+			if !def.Cols.Contains(int(colID)) {
+				break
+			}
+			o = append(o, opt.MakeOrderingColumn(colID, indexCol.Descending))
+		}
+		ord.Add(o)
+	}
+	return ord
+}
+
+func interestingOrderingsForProject(ev memo.ExprView) opt.OrderingSet {
+	inOrd := GetInterestingOrderings(ev.Child(0))
+	passthroughCols := ev.Child(1).Private().(*memo.ProjectionsOpDef).PassthroughCols
+	res := inOrd.Copy()
+	res.RestrictToCols(passthroughCols)
+	return res
+}
+
+func interestingOrderingsForGroupBy(ev memo.ExprView) opt.OrderingSet {
+	def := ev.Private().(*memo.GroupByDef)
+	if def.GroupingCols.Empty() {
+		// This is a scalar group-by, returning a single row.
+		return nil
+	}
+
+	res := GetInterestingOrderings(ev.Child(0)).Copy()
+	if def.Ordering != nil {
+		res.RestrictToPrefix(def.Ordering)
+		if len(res) == 0 {
+			res.Add(def.Ordering)
+		}
+	}
+
+	// We can only keep orderings on grouping columns.
+	res.RestrictToCols(def.GroupingCols)
+	return res
+}
+
+func interestingOrderingsForLimit(ev memo.ExprView) opt.OrderingSet {
+	res := GetInterestingOrderings(ev.Child(0))
+	ord := ev.Private().(opt.Ordering)
+	if ord.Empty() {
+		return res
+	}
+	res = res.Copy()
+	res.RestrictToPrefix(ord)
+	if len(res) == 0 {
+		res.Add(ord)
+	}
+	return res
+}
+
+func interestingOrderingsForJoin(ev memo.ExprView) opt.OrderingSet {
+	if ev.Operator() == opt.SemiJoinOp || ev.Operator() == opt.AntiJoinOp {
+		// TODO(radu): perhaps take into account right-side interesting orderings on
+		// equality columns.
+		return GetInterestingOrderings(ev.Child(0))
+	}
+	// For a join, we could conceivably preserve the order of one side (even with
+	// hash-join, depending on which side we store).
+	ordLeft := GetInterestingOrderings(ev.Child(0))
+	ordRight := GetInterestingOrderings(ev.Child(1))
+	ord := make(opt.OrderingSet, 0, len(ordLeft)+len(ordRight))
+	ord = append(ord, ordLeft...)
+	ord = append(ord, ordRight...)
+	return ord
+}

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -42,6 +42,21 @@ func TestPhysicalPropsFactory(t *testing.T) {
 	runDataDrivenTest(t, "testdata/physprops/", opt.ExprFmtHideAll)
 }
 
+// TestRuleProps files can be run separately like this:
+//   make test PKG=./pkg/sql/opt/xform TESTS="TestRuleProps/orderings"
+//   ...
+func TestRuleProps(t *testing.T) {
+	datadriven.Walk(t, "testdata/ruleprops", func(t *testing.T, path string) {
+		catalog := testcat.New()
+		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+			tester := testutils.NewOptTester(catalog, d.Input)
+			tester.Flags.ExprFormat = opt.ExprFmtHideStats | opt.ExprFmtHideCost |
+				opt.ExprFmtHideQualifications | opt.ExprFmtHideScalars
+			return tester.RunCommand(t, d)
+		})
+	})
+}
+
 // TestRules files can be run separately like this:
 //   make test PKG=./pkg/sql/opt/xform TESTS="TestRules/scan"
 //   make test PKG=./pkg/sql/opt/xform TESTS="TestRules/select"

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -553,7 +553,8 @@ project
       ├── stats: [rows=1, distinct(1)=1]
       ├── cost: 1.11
       ├── keys: (1)
-      └── prune: (8)
+      ├── prune: (8)
+      └── interesting orderings: (+1)
 
 opt format=show-all
 SELECT c_discount, c_last, c_credit
@@ -571,7 +572,8 @@ project
       ├── stats: [rows=0, distinct(1)=0, distinct(2)=0, distinct(3)=0]
       ├── cost: 0.00
       ├── keys: (1-3)
-      └── prune: (6,14,16)
+      ├── prune: (6,14,16)
+      └── interesting orderings: (+3,+2,+1) (+3,+2,+6)
 
 opt format=show-all
 SELECT i_price, i_name, i_data
@@ -586,7 +588,8 @@ scan item
  ├── cost: 13.08
  ├── keys: (1)
  ├── ordering: +1
- └── prune: (3-5)
+ ├── prune: (3-5)
+ └── interesting orderings: (+1)
 
 opt format=show-all
 SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_05
@@ -611,7 +614,8 @@ sort
            ├── stats: [rows=50, distinct(1)=5]
            ├── cost: 62.50
            ├── keys: (1,2)
-           └── prune: (3,8,14-17)
+           ├── prune: (3,8,14-17)
+           └── interesting orderings: (+2,+1) (+1,+2)
 
 # --------------------------------------------------
 # 2.5 The Payment Transaction
@@ -645,7 +649,8 @@ sort
            ├── stats: [rows=0, distinct(2)=0, distinct(3)=0, distinct(6)=0]
            ├── cost: 0.00
            ├── keys: (1-3)
-           └── prune: (1,4)
+           ├── prune: (1,4)
+           └── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
 
 # --------------------------------------------------
 # 2.6 The Order Status Transaction
@@ -672,7 +677,8 @@ project
       ├── stats: [rows=0, distinct(1)=0, distinct(2)=0, distinct(3)=0]
       ├── cost: 0.00
       ├── keys: (1-3)
-      └── prune: (4-6,17)
+      ├── prune: (4-6,17)
+      └── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
 
 opt format=show-all
 SELECT c_id, c_balance, c_first, c_middle
@@ -698,13 +704,15 @@ sort
            ├── cost: 0.00
            ├── keys: (1-3)
            ├── prune: (1,4,5,17)
+           ├── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
            └── scan customer@customer_idx
                 ├── columns: customer.c_id:1(int!null) customer.c_d_id:2(int!null) customer.c_w_id:3(int!null) customer.c_first:4(string) customer.c_last:6(string!null)
                 ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
                 ├── stats: [rows=0, distinct(2)=0, distinct(3)=0, distinct(6)=0]
                 ├── cost: 0.00
                 ├── keys: (1-3)
-                └── prune: (1,4)
+                ├── prune: (1,4)
+                └── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
 
 opt format=show-all
 SELECT o_id, o_entry_d, o_carrier_id
@@ -720,6 +728,7 @@ project
  ├── cost: 0.01
  ├── ordering: -1
  ├── prune: (1,5,6)
+ ├── interesting orderings: (-1)
  └── limit
       ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_c_id:4(int!null) "order".o_entry_d:5(timestamp) "order".o_carrier_id:6(int)
       ├── cardinality: [0 - 1]
@@ -728,6 +737,7 @@ project
       ├── keys: (1-3)
       ├── ordering: -1
       ├── prune: (5,6)
+      ├── interesting orderings: (-1)
       ├── sort
       │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_c_id:4(int!null) "order".o_entry_d:5(timestamp) "order".o_carrier_id:6(int)
       │    ├── stats: [rows=0, distinct(2)=0, distinct(3)=0, distinct(4)=0]
@@ -748,7 +758,8 @@ project
       │              ├── stats: [rows=0, distinct(2)=0, distinct(3)=0, distinct(4)=0]
       │              ├── cost: 0.00
       │              ├── keys: (1-3)
-      │              └── prune: (1)
+      │              ├── prune: (1)
+      │              └── interesting orderings: (+3,+2,-1) (+3,+2,+4,+1)
       └── const: 1 [type=int]
 
 opt format=show-all
@@ -761,12 +772,14 @@ project
  ├── stats: [rows=0]
  ├── cost: 0.00
  ├── prune: (5-9)
+ ├── interesting orderings: (+6)
  └── scan order_line
       ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) order_line.ol_i_id:5(int!null) order_line.ol_supply_w_id:6(int) order_line.ol_delivery_d:7(timestamp) order_line.ol_quantity:8(int) order_line.ol_amount:9(decimal)
       ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
       ├── stats: [rows=0, distinct(1)=0, distinct(2)=0, distinct(3)=0]
       ├── cost: 0.00
-      └── prune: (5-9)
+      ├── prune: (5-9)
+      └── interesting orderings: (+3,+2,-1) (+6,+2,+3,+1)
 
 # --------------------------------------------------
 # 2.7 The Delivery Transaction
@@ -798,6 +811,7 @@ project
  ├── cost: 0.16
  ├── ordering: +1
  ├── prune: (1)
+ ├── interesting orderings: (+1)
  └── limit
       ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
       ├── cardinality: [0 - 1]
@@ -805,6 +819,7 @@ project
       ├── cost: 0.16
       ├── keys: (1-3)
       ├── ordering: +1
+      ├── interesting orderings: (+1)
       ├── sort
       │    ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
       │    ├── stats: [rows=0.1429, distinct(2)=0.1429, distinct(3)=0.1429]
@@ -837,7 +852,8 @@ group-by
  │    ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
  │    ├── stats: [rows=0, distinct(1)=0, distinct(2)=0, distinct(3)=0]
  │    ├── cost: 0.00
- │    └── prune: (9)
+ │    ├── prune: (9)
+ │    └── interesting orderings: (+3,+2,-1)
  └── aggregations [outer=(9)]
       └── sum [type=decimal, outer=(9)]
            └── variable: order_line.ol_amount [type=decimal, outer=(9)]
@@ -866,7 +882,8 @@ project
       ├── stats: [rows=0.1429, distinct(1)=0.1429, distinct(2)=0.1429]
       ├── cost: 0.16
       ├── keys: (1,2)
-      └── prune: (11)
+      ├── prune: (11)
+      └── interesting orderings: (+2,+1)
 
 # TODO(andyk): re-enable when we support COUNT DISTINCT.
 #opt format=show-all
@@ -908,17 +925,20 @@ group-by
  │    ├── columns: warehouse.w_id:1(int) warehouse.w_ytd:9(decimal!null) district.d_w_id:11(int) sum_d_ytd:21(decimal!null)
  │    ├── stats: [rows=1.11]
  │    ├── cost: 124.40
+ │    ├── interesting orderings: (+1) (+11)
  │    ├── full-join
  │    │    ├── columns: warehouse.w_id:1(int) warehouse.w_ytd:9(decimal) district.d_w_id:11(int) sum_d_ytd:21(decimal)
  │    │    ├── stats: [rows=10]
  │    │    ├── cost: 124.30
  │    │    ├── prune: (9,21)
+ │    │    ├── interesting orderings: (+1) (+11)
  │    │    ├── scan warehouse
  │    │    │    ├── columns: warehouse.w_id:1(int!null) warehouse.w_ytd:9(decimal)
  │    │    │    ├── stats: [rows=10]
  │    │    │    ├── cost: 11.10
  │    │    │    ├── keys: (1)
- │    │    │    └── prune: (1,9)
+ │    │    │    ├── prune: (1,9)
+ │    │    │    └── interesting orderings: (+1)
  │    │    ├── group-by
  │    │    │    ├── columns: district.d_w_id:11(int!null) sum_d_ytd:21(decimal)
  │    │    │    ├── grouping columns: district.d_w_id:11(int!null)
@@ -926,11 +946,13 @@ group-by
  │    │    │    ├── cost: 113.00
  │    │    │    ├── keys: (11)
  │    │    │    ├── prune: (21)
+ │    │    │    ├── interesting orderings: (+11)
  │    │    │    ├── scan district
  │    │    │    │    ├── columns: district.d_w_id:11(int!null) district.d_ytd:19(decimal)
  │    │    │    │    ├── stats: [rows=100, distinct(11)=10]
  │    │    │    │    ├── cost: 113.00
- │    │    │    │    └── prune: (11,19)
+ │    │    │    │    ├── prune: (11,19)
+ │    │    │    │    └── interesting orderings: (+11)
  │    │    │    └── aggregations [outer=(19)]
  │    │    │         └── sum [type=decimal, outer=(19)]
  │    │    │              └── variable: district.d_ytd [type=decimal, outer=(19)]
@@ -956,7 +978,8 @@ scan district
  ├── cost: 114.00
  ├── keys: (1,2)
  ├── ordering: +2,+1
- └── prune: (1,2,11)
+ ├── prune: (1,2,11)
+ └── interesting orderings: (+2,+1)
 
 opt format=show-all
 SELECT max(no_o_id)
@@ -983,7 +1006,8 @@ sort
       │    ├── stats: [rows=90000, distinct(2,3)=100]
       │    ├── cost: 95400.00
       │    ├── keys: (1-3)
-      │    └── prune: (1-3)
+      │    ├── prune: (1-3)
+      │    └── interesting orderings: (+3,+2,+1)
       └── aggregations [outer=(1)]
            └── max [type=int, outer=(1)]
                 └── variable: new_order.no_o_id [type=int, outer=(1)]
@@ -1013,7 +1037,8 @@ sort
       │    ├── stats: [rows=300000, distinct(2,3)=100]
       │    ├── cost: 321000.00
       │    ├── keys: (1-3)
-      │    └── prune: (1-3)
+      │    ├── prune: (1-3)
+      │    └── interesting orderings: (+3,+2,-1)
       └── aggregations [outer=(1)]
            └── max [type=int, outer=(1)]
                 └── variable: "order".o_id [type=int, outer=(1)]
@@ -1039,6 +1064,7 @@ group-by
  │    ├── stats: [rows=33.33]
  │    ├── cost: 95401.00
  │    ├── keys: (2,3)
+ │    ├── interesting orderings: (+3,+2)
  │    ├── group-by
  │    │    ├── columns: new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null) column4:4(int) column5:5(int) column6:6(int)
  │    │    ├── grouping columns: new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
@@ -1046,12 +1072,14 @@ group-by
  │    │    ├── cost: 95400.00
  │    │    ├── keys: (2,3)
  │    │    ├── prune: (4-6)
+ │    │    ├── interesting orderings: (+3,+2)
  │    │    ├── scan new_order
  │    │    │    ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
  │    │    │    ├── stats: [rows=90000, distinct(2,3)=100]
  │    │    │    ├── cost: 95400.00
  │    │    │    ├── keys: (1-3)
- │    │    │    └── prune: (1-3)
+ │    │    │    ├── prune: (1-3)
+ │    │    │    └── interesting orderings: (+3,+2,+1)
  │    │    └── aggregations [outer=(1)]
  │    │         ├── max [type=int, outer=(1)]
  │    │         │    └── variable: new_order.no_o_id [type=int, outer=(1)]
@@ -1093,7 +1121,8 @@ sort
       │    ├── columns: "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_ol_cnt:7(int)
       │    ├── stats: [rows=300000, distinct(2,3)=100]
       │    ├── cost: 333000.00
-      │    └── prune: (2,3,7)
+      │    ├── prune: (2,3,7)
+      │    └── interesting orderings: (+3,+2)
       └── aggregations [outer=(7)]
            └── sum [type=decimal, outer=(7)]
                 └── variable: "order".o_ol_cnt [type=int, outer=(7)]
@@ -1122,7 +1151,8 @@ sort
       │    ├── columns: order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null)
       │    ├── stats: [rows=1000000, distinct(2,3)=100]
       │    ├── cost: 1070000.00
-      │    └── prune: (2,3)
+      │    ├── prune: (2,3)
+      │    └── interesting orderings: (+3,+2)
       └── aggregations
            └── count-rows [type=int]
 
@@ -1142,25 +1172,29 @@ except-all
  │    ├── stats: [rows=90000]
  │    ├── cost: 95400.00
  │    ├── keys: (1-3)
- │    └── prune: (1-3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+3,+2,+1)
  └── project
       ├── columns: "order".o_id:4(int!null) "order".o_d_id:5(int!null) "order".o_w_id:6(int!null)
       ├── stats: [rows=1.43]
       ├── cost: 327000.00
       ├── keys: (4-6)
       ├── prune: (4-6)
+      ├── interesting orderings: (+6,+5,-4)
       └── select
            ├── columns: "order".o_id:4(int!null) "order".o_d_id:5(int!null) "order".o_w_id:6(int!null) "order".o_carrier_id:9(int)
            ├── stats: [rows=1.43, distinct(9)=1]
            ├── cost: 327000.00
            ├── keys: (4-6)
            ├── prune: (4-6)
+           ├── interesting orderings: (+6,+5,-4) (+6,+5,+9,+4)
            ├── scan order@order_idx
            │    ├── columns: "order".o_id:4(int!null) "order".o_d_id:5(int!null) "order".o_w_id:6(int!null) "order".o_carrier_id:9(int)
            │    ├── stats: [rows=300000, distinct(9)=210000]
            │    ├── cost: 324000.00
            │    ├── keys: (4-6)
-           │    └── prune: (4-6,9)
+           │    ├── prune: (4-6,9)
+           │    └── interesting orderings: (+6,+5,-4) (+6,+5,+9,+4)
            └── filters [type=bool, outer=(9), constraints=(/9: [/NULL - /NULL]; tight)]
                 └── is [type=bool, outer=(9), constraints=(/9: [/NULL - /NULL]; tight)]
                      ├── variable: "order".o_carrier_id [type=int, outer=(9)]
@@ -1183,18 +1217,21 @@ except-all
  │    ├── cost: 327000.00
  │    ├── keys: (1-3)
  │    ├── prune: (1-3)
+ │    ├── interesting orderings: (+3,+2,-1)
  │    └── select
  │         ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_carrier_id:6(int)
  │         ├── stats: [rows=1.43, distinct(6)=1]
  │         ├── cost: 327000.00
  │         ├── keys: (1-3)
  │         ├── prune: (1-3)
+ │         ├── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
  │         ├── scan order@order_idx
  │         │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_carrier_id:6(int)
  │         │    ├── stats: [rows=300000, distinct(6)=210000]
  │         │    ├── cost: 324000.00
  │         │    ├── keys: (1-3)
- │         │    └── prune: (1-3,6)
+ │         │    ├── prune: (1-3,6)
+ │         │    └── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
  │         └── filters [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL]; tight)]
  │              └── is [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL]; tight)]
  │                   ├── variable: "order".o_carrier_id [type=int, outer=(6)]
@@ -1204,7 +1241,8 @@ except-all
       ├── stats: [rows=90000]
       ├── cost: 95400.00
       ├── keys: (9-11)
-      └── prune: (9-11)
+      ├── prune: (9-11)
+      └── interesting orderings: (+11,+10,+9)
 
 opt format=show-all
 (
@@ -1231,7 +1269,8 @@ except-all
  │    ├── stats: [rows=300000]
  │    ├── cost: 336000.00
  │    ├── keys: (1-3)
- │    └── prune: (1-3,7)
+ │    ├── prune: (1-3,7)
+ │    └── interesting orderings: (+3,+2,-1)
  └── group-by
       ├── columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null) count:19(int)
       ├── grouping columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null)
@@ -1239,11 +1278,13 @@ except-all
       ├── cost: 1080000.00
       ├── keys: (9-11)
       ├── prune: (19)
+      ├── interesting orderings: (+11,+10,-9)
       ├── scan order_line@order_line_fk
       │    ├── columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null)
       │    ├── stats: [rows=1000000, distinct(9-11)=100000]
       │    ├── cost: 1080000.00
-      │    └── prune: (9-11)
+      │    ├── prune: (9-11)
+      │    └── interesting orderings: (+11,+10,-9)
       └── aggregations
            └── count-rows [type=int]
 
@@ -1274,11 +1315,13 @@ except-all
  │    ├── cost: 1080000.00
  │    ├── keys: (1-3)
  │    ├── prune: (11)
+ │    ├── interesting orderings: (+3,+2,-1)
  │    ├── scan order_line@order_line_fk
  │    │    ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null)
  │    │    ├── stats: [rows=1000000, distinct(1-3)=100000]
  │    │    ├── cost: 1080000.00
- │    │    └── prune: (1-3)
+ │    │    ├── prune: (1-3)
+ │    │    └── interesting orderings: (+3,+2,-1)
  │    └── aggregations
  │         └── count-rows [type=int]
  └── scan order
@@ -1286,7 +1329,8 @@ except-all
       ├── stats: [rows=300000]
       ├── cost: 336000.00
       ├── keys: (12-14)
-      └── prune: (12-14,18)
+      ├── prune: (12-14,18)
+      └── interesting orderings: (+14,+13,-12)
 
 opt format=show-all
 SELECT count(*)
@@ -1315,28 +1359,33 @@ group-by
  │    ├── columns: "order".o_id:1(int) "order".o_d_id:2(int) "order".o_w_id:3(int) order_line.ol_o_id:9(int) order_line.ol_d_id:10(int) order_line.ol_w_id:11(int)
  │    ├── stats: [rows=0.0680]
  │    ├── cost: 1477000.03
+ │    ├── interesting orderings: (+3,+2,-1) (+11,+10,-9)
  │    ├── full-join
  │    │    ├── columns: "order".o_id:1(int) "order".o_d_id:2(int) "order".o_w_id:3(int) order_line.ol_o_id:9(int) order_line.ol_d_id:10(int) order_line.ol_w_id:11(int)
  │    │    ├── stats: [rows=0.2041]
  │    │    ├── cost: 1477000.03
+ │    │    ├── interesting orderings: (+3,+2,-1) (+11,+10,-9)
  │    │    ├── project
  │    │    │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null)
  │    │    │    ├── stats: [rows=1.43]
  │    │    │    ├── cost: 327000.00
  │    │    │    ├── keys: (1-3)
  │    │    │    ├── prune: (1-3)
+ │    │    │    ├── interesting orderings: (+3,+2,-1)
  │    │    │    └── select
  │    │    │         ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_carrier_id:6(int)
  │    │    │         ├── stats: [rows=1.43, distinct(6)=1]
  │    │    │         ├── cost: 327000.00
  │    │    │         ├── keys: (1-3)
  │    │    │         ├── prune: (1-3)
+ │    │    │         ├── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
  │    │    │         ├── scan order@order_idx
  │    │    │         │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_carrier_id:6(int)
  │    │    │         │    ├── stats: [rows=300000, distinct(6)=210000]
  │    │    │         │    ├── cost: 324000.00
  │    │    │         │    ├── keys: (1-3)
- │    │    │         │    └── prune: (1-3,6)
+ │    │    │         │    ├── prune: (1-3,6)
+ │    │    │         │    └── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
  │    │    │         └── filters [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL]; tight)]
  │    │    │              └── is [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL]; tight)]
  │    │    │                   ├── variable: "order".o_carrier_id [type=int, outer=(6)]
@@ -1346,16 +1395,19 @@ group-by
  │    │    │    ├── stats: [rows=1.43]
  │    │    │    ├── cost: 1150000.00
  │    │    │    ├── prune: (9-11)
+ │    │    │    ├── interesting orderings: (+11,+10,-9)
  │    │    │    └── select
  │    │    │         ├── columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null) order_line.ol_delivery_d:15(timestamp)
  │    │    │         ├── stats: [rows=1.43, distinct(15)=1]
  │    │    │         ├── cost: 1150000.00
  │    │    │         ├── prune: (9-11)
+ │    │    │         ├── interesting orderings: (+11,+10,-9)
  │    │    │         ├── scan order_line
  │    │    │         │    ├── columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null) order_line.ol_delivery_d:15(timestamp)
  │    │    │         │    ├── stats: [rows=1000000, distinct(15)=700000]
  │    │    │         │    ├── cost: 1140000.00
- │    │    │         │    └── prune: (9-11,15)
+ │    │    │         │    ├── prune: (9-11,15)
+ │    │    │         │    └── interesting orderings: (+11,+10,-9)
  │    │    │         └── filters [type=bool, outer=(15), constraints=(/15: [/NULL - /NULL]; tight)]
  │    │    │              └── is [type=bool, outer=(15), constraints=(/15: [/NULL - /NULL]; tight)]
  │    │    │                   ├── variable: order_line.ol_delivery_d [type=timestamp, outer=(15)]

--- a/pkg/sql/opt/xform/testdata/ruleprops/orderings
+++ b/pkg/sql/opt/xform/testdata/ruleprops/orderings
@@ -1,0 +1,254 @@
+# Tests for InterestingOrderings property.
+
+exec-ddl
+CREATE TABLE abc (a INT, b INT, c INT, INDEX (a, b), UNIQUE INDEX (c))
+----
+TABLE abc
+ ├── a int
+ ├── b int
+ ├── c int
+ ├── rowid int not null (hidden)
+ ├── INDEX primary
+ │    └── rowid int not null (hidden)
+ ├── INDEX secondary
+ │    ├── a int
+ │    ├── b int
+ │    └── rowid int not null (hidden)
+ └── INDEX secondary
+      ├── c int
+      └── rowid int not null (hidden) (storing)
+
+# Scan operator.
+opt
+SELECT * FROM abc
+----
+scan abc
+ ├── columns: a:1(int) b:2(int) c:3(int)
+ ├── keys: weak(3)
+ ├── prune: (1-3)
+ └── interesting orderings: (+1,+2) (+3)
+
+opt
+SELECT a, c FROM abc
+----
+scan abc
+ ├── columns: a:1(int) c:3(int)
+ ├── keys: weak(3)
+ ├── prune: (1,3)
+ └── interesting orderings: (+1) (+3)
+
+opt
+SELECT b, c FROM abc
+----
+scan abc
+ ├── columns: b:2(int) c:3(int)
+ ├── keys: weak(3)
+ ├── prune: (2,3)
+ └── interesting orderings: (+3)
+
+
+# Project operator (we use build instead of opt).
+build
+SELECT a, c FROM abc
+----
+project
+ ├── columns: a:1(int) c:3(int)
+ ├── keys: weak(3)
+ ├── prune: (1,3)
+ ├── interesting orderings: (+1) (+3)
+ └── scan abc
+      ├── columns: a:1(int) b:2(int) c:3(int) rowid:4(int!null)
+      ├── keys: (4) weak(3)
+      ├── prune: (1-4)
+      └── interesting orderings: (+4) (+1,+2,+4) (+3)
+
+build
+SELECT b, c FROM abc
+----
+project
+ ├── columns: b:2(int) c:3(int)
+ ├── keys: weak(3)
+ ├── prune: (2,3)
+ ├── interesting orderings: (+3)
+ └── scan abc
+      ├── columns: a:1(int) b:2(int) c:3(int) rowid:4(int!null)
+      ├── keys: (4) weak(3)
+      ├── prune: (1-4)
+      └── interesting orderings: (+4) (+1,+2,+4) (+3)
+
+# GroupBy operator.
+opt
+SELECT min(b), a FROM abc GROUP BY a
+----
+group-by
+ ├── columns: min:5(int) a:1(int)
+ ├── grouping columns: a:1(int)
+ ├── keys: weak(1)
+ ├── prune: (5)
+ ├── interesting orderings: (+1)
+ ├── scan abc@secondary
+ │    ├── columns: a:1(int) b:2(int)
+ │    ├── prune: (1,2)
+ │    └── interesting orderings: (+1,+2)
+ └── aggregations [outer=(2)]
+      └── min [type=int, outer=(2)]
+           └── variable: abc.b [type=int, outer=(2)]
+
+opt
+SELECT min(b), c FROM abc GROUP BY c
+----
+group-by
+ ├── columns: min:5(int) c:3(int)
+ ├── grouping columns: c:3(int)
+ ├── keys: weak(3)
+ ├── prune: (5)
+ ├── interesting orderings: (+3)
+ ├── scan abc
+ │    ├── columns: b:2(int) c:3(int)
+ │    ├── keys: weak(3)
+ │    ├── prune: (2,3)
+ │    └── interesting orderings: (+3)
+ └── aggregations [outer=(2)]
+      └── min [type=int, outer=(2)]
+           └── variable: abc.b [type=int, outer=(2)]
+
+# GroupBy with required ordering.
+opt
+SELECT array_agg(a), b, c FROM (SELECT * FROM abc ORDER BY b, a) GROUP BY b, c
+----
+group-by
+ ├── columns: array_agg:5(int[]) b:2(int) c:3(int)
+ ├── grouping columns: b:2(int) c:3(int)
+ ├── ordering: +2,+1
+ ├── keys: weak(3)
+ ├── prune: (5)
+ ├── interesting orderings: (+2)
+ ├── sort
+ │    ├── columns: a:1(int) b:2(int) c:3(int)
+ │    ├── keys: weak(3)
+ │    ├── ordering: +2,+1
+ │    ├── prune: (1-3)
+ │    └── scan abc
+ │         ├── columns: a:1(int) b:2(int) c:3(int)
+ │         ├── keys: weak(3)
+ │         └── prune: (1-3)
+ └── aggregations [outer=(1)]
+      └── array-agg [type=int[], outer=(1)]
+           └── variable: abc.a [type=int, outer=(1)]
+
+# LookupJoin operator.
+opt
+SELECT * FROM abc WHERE a = 1
+----
+lookup-join abc
+ ├── columns: a:1(int!null) b:2(int) c:3(int)
+ ├── key columns: [4]
+ ├── keys: weak(3)
+ ├── prune: (2,3)
+ ├── interesting orderings: (+4) (+1,+2,+4)
+ └── scan abc@secondary
+      ├── columns: a:1(int!null) b:2(int) rowid:4(int!null)
+      ├── constraint: /1/2/4: [/1 - /1]
+      ├── keys: (4)
+      ├── prune: (2,4)
+      └── interesting orderings: (+4) (+1,+2,+4)
+
+# Limit operator.
+opt
+SELECT * FROM abc ORDER BY a LIMIT 10
+----
+lookup-join abc
+ ├── columns: a:1(int) b:2(int) c:3(int)
+ ├── key columns: [4]
+ ├── cardinality: [0 - 10]
+ ├── keys: weak(3)
+ ├── ordering: +1
+ ├── prune: (2,3)
+ ├── interesting orderings: (+4) (+1,+2,+4)
+ └── scan abc@secondary
+      ├── columns: a:1(int) b:2(int) rowid:4(int!null)
+      ├── limit: 10
+      ├── keys: (4)
+      ├── ordering: +1
+      ├── prune: (2,4)
+      └── interesting orderings: (+4) (+1,+2,+4)
+
+opt
+SELECT * FROM abc ORDER BY b LIMIT 10
+----
+limit
+ ├── columns: a:1(int) b:2(int) c:3(int)
+ ├── cardinality: [0 - 10]
+ ├── keys: weak(3)
+ ├── ordering: +2
+ ├── prune: (1,3)
+ ├── interesting orderings: (+2)
+ ├── sort
+ │    ├── columns: a:1(int) b:2(int) c:3(int)
+ │    ├── keys: weak(3)
+ │    ├── ordering: +2
+ │    ├── prune: (1-3)
+ │    └── scan abc
+ │         ├── columns: a:1(int) b:2(int) c:3(int)
+ │         ├── keys: weak(3)
+ │         └── prune: (1-3)
+ └── const: 10 [type=int]
+
+opt
+SELECT * FROM abc ORDER BY a OFFSET 10
+----
+offset
+ ├── columns: a:1(int) b:2(int) c:3(int)
+ ├── keys: weak(3)
+ ├── ordering: +1
+ ├── prune: (2,3)
+ ├── interesting orderings: (+1)
+ ├── sort
+ │    ├── columns: a:1(int) b:2(int) c:3(int)
+ │    ├── keys: weak(3)
+ │    ├── ordering: +1
+ │    ├── prune: (1-3)
+ │    └── scan abc
+ │         ├── columns: a:1(int) b:2(int) c:3(int)
+ │         ├── keys: weak(3)
+ │         └── prune: (1-3)
+ └── const: 10 [type=int]
+
+exec-ddl
+CREATE TABLE xyz (x INT, y INT, z INT, INDEX(z), UNIQUE INDEX(x,y))
+----
+TABLE xyz
+ ├── x int
+ ├── y int
+ ├── z int
+ ├── rowid int not null (hidden)
+ ├── INDEX primary
+ │    └── rowid int not null (hidden)
+ ├── INDEX secondary
+ │    ├── z int
+ │    └── rowid int not null (hidden)
+ └── INDEX secondary
+      ├── x int
+      ├── y int
+      └── rowid int not null (hidden) (storing)
+
+# Join operator.
+opt
+SELECT * FROM abc JOIN xyz ON a=x 
+----
+inner-join
+ ├── columns: a:1(int) b:2(int) c:3(int) x:5(int) y:6(int) z:7(int)
+ ├── prune: (2,3,6,7)
+ ├── interesting orderings: (+1,+2) (+3) (+7) (+5,+6)
+ ├── scan abc
+ │    ├── columns: a:1(int) b:2(int) c:3(int)
+ │    ├── keys: weak(3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1,+2) (+3)
+ ├── scan xyz
+ │    ├── columns: x:5(int) y:6(int) z:7(int)
+ │    ├── keys: weak(5,6)
+ │    ├── prune: (5-7)
+ │    └── interesting orderings: (+7) (+5,+6)
+ └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+      └── abc.a = xyz.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]


### PR DESCRIPTION
Introducing an InterestingOrderings rule property. These are orderings
that could potentially be generated by expressions in a certain group
cheaper than resorting. These will be used to create merge joins. In
the future, they can be useful for other things, like streaming
group-by.

The property is lazily calculated; in the test for the properties, we
make sure to fill them in so they appear in the test output.

Release note: None