### PR TITLE
sql: add metric `sql.failure.count`

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2019,6 +2019,7 @@ type StatementCounters struct {
 	DdlCount         *metric.Counter
 	MiscCount        *metric.Counter
 	QueryCount       *metric.Counter
+	FailureCount     *metric.Counter
 }
 
 func makeStatementCounters() StatementCounters {
@@ -2034,6 +2035,7 @@ func makeStatementCounters() StatementCounters {
 		DdlCount:         metric.NewCounter(MetaDdl),
 		MiscCount:        metric.NewCounter(MetaMisc),
 		QueryCount:       metric.NewCounter(MetaQuery),
+		FailureCount:     metric.NewCounter(MetaFailure),
 	}
 }
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -90,6 +90,10 @@ func (ex *connExecutor) execStmt(
 		ev, payload = ex.execStmtInNoTxnState(ctx, stmt)
 	case stateOpen:
 		ev, payload, err = ex.execStmtInOpenState(ctx, stmt, pinfo, res)
+		switch ev.(type) {
+		case eventNonRetriableErr:
+			ex.server.StatementCounters.FailureCount.Inc(1)
+		}
 	case stateAborted, stateRestartWait:
 		ev, payload = ex.execStmtInAbortedState(ctx, stmt, res)
 	case stateCommitWait:

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -169,6 +169,9 @@ var (
 	MetaQuery = metric.Metadata{
 		Name: "sql.query.count",
 		Help: "Number of SQL queries"}
+	MetaFailure = metric.Metadata{
+		Name: "sql.failure.count",
+		Help: "Number of statements resulting in a planning or runtime error"}
 )
 
 // NodeInfo contains metadata about the executing node and cluster.


### PR DESCRIPTION
Counts the number of queries which result in an error.

Touches #14148

I am not sure whether this interacts with retries in the right way (or even what the right way is). It seems that this would result in the counter getting incremented once for every time a statement is retried and fails. Maybe that's ok, or maybe it should count as a single failure.