### PR TITLE
sql: make SHOW TRACE FOR SESSION idempotent

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -591,11 +591,11 @@ CREATE TABLE crdb_internal.session_trace (
                                    -- (dummy) message on a span.
                                    -- NULL if the span was not finished at the time
                                    -- the trace has been collected.
-  operation   STRING NULL,         -- The span's operation. Set only on
-                                   -- the first (dummy) message in a span.
+  operation   STRING NULL,         -- The span's operation.
   loc         STRING NOT NULL,     -- The file name / line number prefix, if any.
   tag         STRING NOT NULL,     -- The logging tag, if any.
-  message     STRING NOT NULL      -- The logged message.
+  message     STRING NOT NULL,     -- The logged message.
+  age         INTERVAL NOT NULL    -- The age of this message relative to the beginning of the trace.
 );
 `,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -123,10 +123,10 @@ SELECT * FROM crdb_internal.node_statement_statistics WHERE node_id < 0
 ----
 node_id  application_name  flags  key  anonymized  count  first_attempt_count  max_retries  last_error  rows_avg  rows_var  parse_lat_avg  parse_lat_var  plan_lat_avg  plan_lat_var  run_lat_avg  run_lat_var  service_lat_avg  service_lat_var  overhead_lat_avg  overhead_lat_var
 
-query IITTTTTT colnames
+query IITTTTTTT colnames
 SELECT * FROM crdb_internal.session_trace WHERE span_idx < 0
 ----
-span_idx  message_idx  timestamp  duration  operation  loc  tag  message
+span_idx  message_idx  timestamp  duration  operation  loc  tag  message age
 
 query TTTT colnames
 SELECT * FROM crdb_internal.cluster_settings WHERE name = ''

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -219,7 +219,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         17 columns, 900 rows
+                     │                     size         17 columns, 901 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -220,7 +220,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         17 columns, 900 rows
+                     │                     size         17 columns, 901 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·

--- a/pkg/sql/show_trace_replica.go
+++ b/pkg/sql/show_trace_replica.go
@@ -28,6 +28,15 @@ import (
 // tracing (via SHOW TRACE) to report the replicas of all kv events that occur
 // during its execution. It is used as the top-level node for SHOW
 // EXPERIMENTAL_REPLICA TRACE FOR statements.
+//
+// TODO(dan): This works by selecting trace lines matching certain event
+// logs in command execution, which is possibly brittle. A much better
+// system would be to set the `ReturnRangeInfo` flag on all kv requests and
+// use the `RangeInfo`s that come back. Unfortunately, we wanted to get
+// _some_ version of this into 2.0 for partitioning users, but the RangeInfo
+// plumbing would have sunk the project. It's also possible that the
+// sovereignty work may require the RangeInfo plumbing and we should revisit
+// this then.
 type showTraceReplicaNode struct {
 	optColumnsSlot
 
@@ -37,18 +46,6 @@ type showTraceReplicaNode struct {
 	run struct {
 		values tree.Datums
 	}
-}
-
-func (p *planner) makeShowTraceReplicaNode(plan *showTraceNode) planNode {
-	// TODO(dan): This works by selecting trace lines matching certain event
-	// logs in command execution, which is possibly brittle. A much better
-	// system would be to set the `ReturnRangeInfo` flag on all kv requests and
-	// use the `RangeInfo`s that come back. Unfortunately, we wanted to get
-	// _some_ version of this into 2.0 for partitioning users, but the RangeInfo
-	// plumbing would have sunk the project. It's also possible that the
-	// sovereignty work may require the RangeInfo plumbing and we should revisit
-	// this then.
-	return &showTraceReplicaNode{plan: plan}
 }
 
 func (n *showTraceReplicaNode) startExec(params runParams) error {

--- a/pkg/sql/sqlbase/result_columns.go
+++ b/pkg/sql/sqlbase/result_columns.go
@@ -122,7 +122,7 @@ var ExplainOptColumns = ResultColumns{
 // ShowTraceColumns are the result columns of a SHOW [KV] TRACE statement.
 var ShowTraceColumns = ResultColumns{
 	{Name: "timestamp", Typ: types.TimestampTZ},
-	{Name: "age", Typ: types.Interval},
+	{Name: "age", Typ: types.Interval}, // Note GetTraceAgeColumnIdx below.
 	{Name: "message", Typ: types.String},
 	{Name: "tag", Typ: types.String},
 	{Name: "loc", Typ: types.String},
@@ -133,10 +133,19 @@ var ShowTraceColumns = ResultColumns{
 // ShowCompactTraceColumns are the result columns of a
 // SHOW COMPACT [KV] TRACE statement.
 var ShowCompactTraceColumns = ResultColumns{
-	{Name: "age", Typ: types.Interval},
+	{Name: "age", Typ: types.Interval}, // Note GetTraceAgeColumnIdx below.
 	{Name: "message", Typ: types.String},
 	{Name: "tag", Typ: types.String},
 	{Name: "operation", Typ: types.String},
+}
+
+// GetTraceAgeColumnIdx retrieves the index of the age column
+// depending on whether the compact format is used.
+func GetTraceAgeColumnIdx(compact bool) int {
+	if compact {
+		return 0
+	}
+	return 1
 }
 
 // ShowReplicaTraceColumns are the result columns of a


### PR DESCRIPTION
Fixes #26745.

Prior to this patch, the code for SHOW TRACE would overwrite the trace
results in-place to perform sorting and filtering. This means that
invoking SHOW SESSION TRACE multiple times would return different
results every time.

This patch solves the issue by ensuring the filtering, if requested,
is done on a copy of the data, and sorting is done using a regular
sortNode.

In addition, this patch hoists the generation of operation strings and
the age column to the virtual table generation, instead of restricting
it to the output of SHOW TRACE. This simplifies the code.

Release note (bug fix): using `SHOW TRACE FOR SESSION` multiple times
without intervening `SET tracing` statement now properly outputs the
trace without introducing extraneous duplicate rows.