### PR TITLE
storage: Add extra event to allocator rebalancing

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -386,6 +386,7 @@ func (a Allocator) simulateRemoveTarget(
 	defer func() {
 		a.storePool.updateLocalStoreAfterRebalance(targetStore, rangeInfo, roachpb.REMOVE_REPLICA)
 	}()
+	log.VEventf(ctx, 3, "simulating which replica would be removed after adding s%d", targetStore)
 	return a.RemoveTarget(ctx, zone, candidates, rangeInfo, disableStatsBasedRebalancing)
 }
 


### PR DESCRIPTION
Helps make the output of simulated allocator runs less confusing, since
otherwise it's not clear why we're considering removal from the range
and why the replicas being considered for removal includes one that
isn't even a real member of the range.

Release note: None

Would have made looking at the simulated allocator output from https://forum.cockroachlabs.com/t/how-to-enable-leaseholder-load-balancing/1732/3 a little more pleasant.