### PR TITLE
sql: bugfix to interleaved join planning criteria

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -360,3 +360,26 @@ END
 
 statement error duplicate key value \(p_id,c_id\)=\(1,1\) violates unique constraint "primary"
 INSERT INTO c20067 VALUES (1, 1, 'John Doe')
+
+# Regression test for #26756: ensure that interleaved table joins don't get
+# planned incorrectly given a merge join ordering caused by a constant value
+# constraint on a non-interleaved column.
+
+subtest interleaved_join_on_other_columns
+
+statement ok
+CREATE TABLE users (id INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE documents (id INT PRIMARY KEY, user_id INT NOT NULL) INTERLEAVE IN PARENT users (id)
+
+statement ok
+INSERT INTO users(id) VALUES(1)
+
+statement ok
+INSERT INTO documents(id, user_id) VALUES (0, 1)
+
+query I
+SELECT count(*) FROM users JOIN documents ON users.id=documents.user_id WHERE documents.id=0
+----
+1


### PR DESCRIPTION
Previously, interleaved joins could take place if the tables were
ancestors of each other, there was a merge join ordering on the equality
columns, and the left equality columns were a prefix of the interleaved
columns. These criteria are insufficient: the right equality columns
must also be a prefix of the interleaved columns. A case where this
wouldn't naturally hold is where the right equality columns get a merge
join ordering because they're known to be constant.

Release note (bug fix): joins across two interleaved tables no longer
return incorrect results under certain circumstances when the equality
columns aren't all part of the interleaved columns.

Fixes #25838. I verified that the new test fails before the fix was applied.