### PR TITLE
mvcc: write meta key before writing version key

### DIFF
--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1322,12 +1322,6 @@ func mvccPutInternal(
 	}
 	newMeta := &buf.newMeta
 
-	versionKey := metaKey
-	versionKey.Timestamp = timestamp
-	if err := engine.Put(versionKey, value); err != nil {
-		return err
-	}
-
 	// Write the mvcc metadata now that we have sizes for the latest
 	// versioned value. For values, the size of keys is always accounted
 	// for as mvccVersionTimestampSize. The size of the metadata key is
@@ -1347,6 +1341,20 @@ func mvccPutInternal(
 		// each versioned value. We maintain that accounting even when the MVCC
 		// metadata is implicit.
 		metaKeySize = int64(metaKey.EncodedSize())
+	}
+
+	// Write the mvcc value.
+	//
+	// NB: this was previously performed before the mvcc metadata write, but
+	// benchmarking has show that performing this write after results in a 6%
+	// throughput improvement on write-heavy workloads. The reason for this is
+	// that the meta key is always ordered before the value key and that
+	// RocksDB's skiplist memtable implementation includes a fast-path for
+	// sequential insertion patterns.
+	versionKey := metaKey
+	versionKey.Timestamp = timestamp
+	if err := engine.Put(versionKey, value); err != nil {
+		return err
 	}
 
 	// Update MVCC stats.
@@ -2201,10 +2209,10 @@ func mvccResolveWriteIntent(
 			if err != nil {
 				return false, err
 			}
-			if err = engine.Clear(origKey); err != nil {
+			if err = engine.Put(newKey, valBytes); err != nil {
 				return false, err
 			}
-			if err = engine.Put(newKey, valBytes); err != nil {
+			if err = engine.Clear(origKey); err != nil {
 				return false, err
 			}
 		}


### PR DESCRIPTION
This change switches the order that `mvccPutInternal` writes
meta keys and version keys when laying down intents. This turns
out to be important because the meta key will always sort before
the version key in RocksDB's keyspace. This has a significant
effect on the performance of `engine.ApplyBatchRepr` because
RocksDB's skiplist memtable implementation includes a fast-path for
sequential insertion patterns.

The change also makes a similar change in `mvccResolveWriteIntent`
when a resolved value has its timestamp moved forward.

## Benchmarking

This change was tested using tpcc (loadgen version) with the command
`./tpcc -load -duration=1m --no-wait -mix='newOrder=1'`. Three
interleaved trials were performed before and after the change.

#### Before:
```
_elapsed______opName__ops(total)__ops/m(cum)__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
   60.0s    newOrder        4258      4258.0     87.9     54.5    209.7    285.2    453.0   1208.0

_elapsed______opName__ops(total)__ops/m(cum)__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
   60.0s    newOrder        4306      4305.7     87.0     52.4    201.3    268.4    453.0    973.1

_elapsed______opName__ops(total)__ops/m(cum)__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
   60.0s    newOrder        4389      4388.7     85.2     52.4    201.3    268.4    419.4    973.1
```

#### After:
```
_elapsed______opName__ops(total)__ops/m(cum)__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
   60.0s    newOrder        4600      4600.0     81.4     50.3    192.9    251.7    419.4   1140.9

_elapsed______opName__ops(total)__ops/m(cum)__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
   60.0s    newOrder        4572      4572.0     81.9     50.3    192.9    260.0    436.2    805.3

_elapsed______opName__ops(total)__ops/m(cum)__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
   60.0s    newOrder        4592      4591.9     81.5     50.3    192.9    260.0    402.7    939.5
```

This shows a **6%** throughput improvement and a **5.9%** average latency
reduction.

Release note: None