### PR TITLE
kv: Don't treat context cancellation as a SendError

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -1294,6 +1294,20 @@ func (ds *DistSender) sendToReplicas(
 			log.VErrEventf(ctx, 1, "application error: %s", br.Error)
 		}
 
+		// Has the caller given up?
+		if ctx.Err() != nil {
+			errMsg := fmt.Sprintf("context done during DistSender.Send: %s", ctx.Err())
+			log.Eventf(ctx, errMsg)
+			if ambiguousError != nil {
+				return nil, roachpb.NewAmbiguousResultError(errMsg)
+			}
+			// Don't consider this a SendError, because SendErrors indicate that we
+			// were unable to reach a replica that could serve the request, and they
+			// cause range cache evictions. Context cancellations just mean the
+			// sender changed its mind or the request timed out.
+			return nil, ctx.Err()
+		}
+
 		if transport.IsExhausted() {
 			if ambiguousError != nil {
 				return nil, roachpb.NewAmbiguousResultError(fmt.Sprintf("error=%s [exhausted]", ambiguousError))
@@ -1306,16 +1320,6 @@ func (ds *DistSender) sendToReplicas(
 			return nil, roachpb.NewSendError(
 				fmt.Sprintf("sending to all %d replicas failed; last error: %v %v", len(replicas), br, err),
 			)
-		}
-
-		// Has the caller given up?
-		if ctx.Err() != nil {
-			errMsg := fmt.Sprintf("context done during DistSender.Send: %s", ctx.Err())
-			log.Eventf(ctx, errMsg)
-			if ambiguousError != nil {
-				return nil, roachpb.NewAmbiguousResultError(errMsg)
-			}
-			return nil, roachpb.NewSendError(errMsg)
 		}
 
 		ds.metrics.NextReplicaErrCount.Inc(1)


### PR DESCRIPTION
SendErrors cause range descriptors to be evicted from the range cache,
but happen innocuously all the time as requests like HeartbeatTxns are
cancelled because they're no longer needed.

This was part of the cause of range 1 getting thousands of qps on 30
node TPC-C testing, as initially called out in the comments on #26608.

Release note: None

---------------------------

`kv` is probably the package I'm least familiar with all the details of, so this may be a bad way of accomplishing this. If so, please let me know. If it's reasonable, I'll add a test that context cancellations don't affect the contents of the range cache.