### PR TITLE
kv: Don't heartbeat transactions that are lacking an anchor key

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -1086,6 +1086,10 @@ func (tc *TxnCoordSender) heartbeat(ctx context.Context) bool {
 		return false
 	}
 
+	if txn.Key == nil {
+		return true
+	}
+
 	ba := roachpb.BatchRequest{}
 	ba.Txn = &txn
 


### PR DESCRIPTION
When running TPC-C 10k on a 30 node cluster without partitioning, range
1 was receiving thousands of qps while all other ranges were receiving
no more than low hundreds of qps (more details in #26608. Part of it was
context cancellations causing range descriptors to be evicted from the
range cache (#26764), but an even bigger part of it was HeartbeatTxns
being sent for transactions with no anchor key, accounting for thousands
of QPS even after #26764 was fixed.

This causes the same outcome as the old code without the load, because
without this change we'd just send the request and get back a
REASON_TXN_NOT_FOUND error, which would cause the function to return
true.

It's possible that we should instead avoid the heartbeat loop at all for
transactions without a key, or that we should put in more effort to
prevent such requests from even counting as transactions (a la #26741,
which perhaps makes this change unnecessary?). Advice would be great.

Release note: None