### PR TITLE
roachpb, encoding: fix pretty-print of bytes values

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -28,7 +28,6 @@ import (
 	"strconv"
 	"sync"
 	"time"
-	"unicode"
 
 	"github.com/pkg/errors"
 
@@ -656,10 +655,10 @@ func (v Value) PrettyPrint() string {
 	case ValueType_BYTES:
 		var data []byte
 		data, err = v.GetBytes()
-		printable := len(bytes.TrimLeftFunc(data, unicode.IsPrint)) == 0
-		if printable {
+		if encoding.PrintableBytes(data) {
 			buf.WriteString(string(data))
 		} else {
+			buf.WriteString("0x")
 			buf.WriteString(hex.EncodeToString(data))
 		}
 	case ValueType_TIME:

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -1323,6 +1323,10 @@ func TestValuePrettyPrint(t *testing.T) {
 	tupleBytes := encoding.EncodeBytesValue(encoding.EncodeIntValue(nil, 1, 8), 2, []byte("foo"))
 	tupleValue.SetTuple(tupleBytes)
 
+	var bytesValuePrintable, bytesValueNonPrintable Value
+	bytesValuePrintable.SetBytes([]byte("abc"))
+	bytesValueNonPrintable.SetBytes([]byte{0x89})
+
 	var errValue Value
 	errValue.SetInt(7)
 	errValue.setTag(ValueType_FLOAT)
@@ -1341,9 +1345,11 @@ func TestValuePrettyPrint(t *testing.T) {
 		{timeValue, "/TIME/2016-06-29T16:02:50.000000005Z"},
 		{decimalValue, "/DECIMAL/6.28"},
 		{durationValue, "/DURATION/1mon2d3ns"},
-		{MakeValueFromBytes([]byte{0x1, 0x2, 0xF, 0xFF}), "/BYTES/01020fff"},
+		{MakeValueFromBytes([]byte{0x1, 0x2, 0xF, 0xFF}), "/BYTES/0x01020fff"},
 		{MakeValueFromString("foo"), "/BYTES/foo"},
 		{tupleValue, "/TUPLE/1:1:Int/8/2:3:Bytes/foo"},
+		{bytesValuePrintable, "/BYTES/abc"},
+		{bytesValueNonPrintable, "/BYTES/0x89"},
 		{errValue, "/<err: float64 value should be exactly 8 bytes: 1>"},
 		{errTagValue, "/<err: unknown tag: 99>"},
 	}

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -284,7 +284,7 @@ dist sender  r1: sending batch 1 Scan to (n1,s1):1
 sql txn      fetched: /kv/primary/2/v -> /3
 sql txn      Put /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
 sql txn      Del /Table/54/2/3/0
-sql txn      CPut /Table/54/2/2/0 -> /BYTES/Š
+sql txn      CPut /Table/54/2/2/0 -> /BYTES/0x8a
 dist sender  querying next range at /Table/54/1/2/0
 dist sender  r1: sending batch 1 Put, 1 CPut, 1 Del, 1 BeginTxn, 1 EndTxn to (n1,s1):1
 dist sender  querying next range at /Table/54/1/2/0

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -1856,8 +1856,9 @@ func TestPrettyPrintValueEncoded(t *testing.T) {
 			time.Date(2016, 6, 29, 16, 2, 50, 5, time.UTC)), "2016-06-29T16:02:50.000000005Z"},
 		{EncodeDurationValue(nil, NoColumnID,
 			duration.Duration{Months: 1, Days: 2, Nanos: 3}), "1mon2d3ns"},
-		{EncodeBytesValue(nil, NoColumnID, []byte{0x1, 0x2, 0xF, 0xFF}), "01020fff"},
-		{EncodeBytesValue(nil, NoColumnID, []byte("foo")), "foo"},
+		{EncodeBytesValue(nil, NoColumnID, []byte{0x1, 0x2, 0xF, 0xFF}), "0x01020fff"},
+		{EncodeBytesValue(nil, NoColumnID, []byte("foo")), "foo"}, // printable bytes
+		{EncodeBytesValue(nil, NoColumnID, []byte{0x89}), "0x89"}, // non-printable bytes
 		{EncodeIPAddrValue(nil, NoColumnID, ipAddr), ip},
 		{EncodeUUIDValue(nil, NoColumnID, u), uuidStr},
 	}


### PR DESCRIPTION
Prior to this patch, the pretty-printing code did not handle invalid
UTF-8 sequences correctly: it considered them always printable, which
is unfortunate given that most byte sequences are more likely than not
to contain mostly non-printable, invalid UTF-8 sequences.

This patch corrects the problem by properly hex-escaping strings
containing invalid UTF-8 sequences.

Release note (bug fix): the output of debug and tracing commands is
not any more corrupted when byte array values contain invalid UTF-8
sequences.

Fixes #26768.