### PR TITLE
ts: Create rollup resolutions

### DIFF
--- a/pkg/ts/iterator_test.go
+++ b/pkg/ts/iterator_test.go
@@ -147,6 +147,8 @@ func makeInternalColumnData(
 			// value.
 			if len(valuesForSample) > 1 {
 				result.Variance[count-1] = computeVariance()
+			} else {
+				valuesForSample = valuesForSample[:0]
 			}
 
 			result.Offset = append(result.Offset, offset)

--- a/pkg/ts/memory.go
+++ b/pkg/ts/memory.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
 
@@ -32,6 +33,7 @@ var (
 	sizeOfDataPoint      = int64(unsafe.Sizeof(tspb.TimeSeriesDatapoint{}))
 	sizeOfInt32          = int64(unsafe.Sizeof(int32(0)))
 	sizeOfFloat64        = int64(unsafe.Sizeof(float64(0)))
+	sizeOfTimestamp      = int64(unsafe.Sizeof(hlc.Timestamp{}))
 )
 
 // QueryMemoryOptions represents the adjustable options of a QueryMemoryContext.

--- a/pkg/ts/rollup.go
+++ b/pkg/ts/rollup.go
@@ -1,0 +1,128 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ts
+
+import (
+	"math"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
+)
+
+type rollupDatapoint struct {
+	timestampNanos int64
+	first          float64
+	last           float64
+	min            float64
+	max            float64
+	sum            float64
+	count          uint32
+	variance       float64
+}
+
+type rollupData struct {
+	name       string
+	source     string
+	datapoints []rollupDatapoint
+}
+
+func (rd *rollupData) toInternal(
+	keyDuration, sampleDuration int64,
+) ([]roachpb.InternalTimeSeriesData, error) {
+	if err := tspb.VerifySlabAndSampleDuration(keyDuration, sampleDuration); err != nil {
+		return nil, err
+	}
+
+	// This slice must be preallocated to avoid reallocation on `append` because
+	// we maintain pointers to its elements in the map below.
+	result := make([]roachpb.InternalTimeSeriesData, 0, len(rd.datapoints))
+	// Pointers because they need to mutate the stuff in the slice above.
+	resultByKeyTime := make(map[int64]*roachpb.InternalTimeSeriesData)
+
+	for _, dp := range rd.datapoints {
+		// Determine which InternalTimeSeriesData this datapoint belongs to,
+		// creating if it has not already been created for a previous sample.
+		keyTime := normalizeToPeriod(dp.timestampNanos, keyDuration)
+		itsd, ok := resultByKeyTime[keyTime]
+		if !ok {
+			result = append(result, roachpb.InternalTimeSeriesData{
+				StartTimestampNanos: keyTime,
+				SampleDurationNanos: sampleDuration,
+			})
+			itsd = &result[len(result)-1]
+			resultByKeyTime[keyTime] = itsd
+		}
+
+		itsd.Offset = append(itsd.Offset, itsd.OffsetForTimestamp(dp.timestampNanos))
+		itsd.Last = append(itsd.Last, dp.last)
+		itsd.First = append(itsd.First, dp.first)
+		itsd.Min = append(itsd.Min, dp.min)
+		itsd.Max = append(itsd.Max, dp.max)
+		itsd.Count = append(itsd.Count, dp.count)
+		itsd.Sum = append(itsd.Sum, dp.sum)
+		itsd.Variance = append(itsd.Variance, dp.variance)
+	}
+
+	return result, nil
+}
+
+func computeRollupsFromData(data tspb.TimeSeriesData, rollupPeriodNanos int64) rollupData {
+	rollup := rollupData{
+		name:   data.Name,
+		source: data.Source,
+	}
+
+	createRollupPoint := func(timestamp int64, dataSlice []tspb.TimeSeriesDatapoint) {
+		result := rollupDatapoint{
+			timestampNanos: timestamp,
+			max:            -math.MaxFloat64,
+			min:            math.MaxFloat64,
+		}
+		mean := 0.0
+		meanSquaredDist := 0.0
+		for i, dp := range dataSlice {
+			if i == 0 {
+				result.first = dp.Value
+			}
+			result.last = dp.Value
+			result.max = math.Max(result.max, dp.Value)
+			result.min = math.Min(result.min, dp.Value)
+			result.count++
+			result.sum += dp.Value
+
+			// Welford's algorithm for computing variance.
+			delta := dp.Value - mean
+			mean = mean + delta/float64(result.count)
+			delta2 := dp.Value - mean
+			meanSquaredDist = meanSquaredDist + delta*delta2
+		}
+
+		result.variance = meanSquaredDist / float64(result.count)
+		rollup.datapoints = append(rollup.datapoints, result)
+	}
+
+	dps := data.Datapoints
+	for len(dps) > 0 {
+		rollupTimestamp := normalizeToPeriod(dps[0].TimestampNanos, rollupPeriodNanos)
+		endIdx := sort.Search(len(dps), func(i int) bool {
+			return normalizeToPeriod(dps[i].TimestampNanos, rollupPeriodNanos) > rollupTimestamp
+		})
+		createRollupPoint(rollupTimestamp, dps[:endIdx])
+		dps = dps[endIdx:]
+	}
+
+	return rollup
+}

--- a/pkg/ts/rollup_test.go
+++ b/pkg/ts/rollup_test.go
@@ -1,0 +1,112 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ts
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/kr/pretty"
+)
+
+func TestComputeRollup(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for _, tc := range []struct {
+		input    tspb.TimeSeriesData
+		expected []roachpb.InternalTimeSeriesData
+	}{
+		{
+			input: ts("test.metric",
+				tsdp(10, 200),
+				tsdp(20, 300),
+				tsdp(40, 400),
+				tsdp(80, 400),
+				tsdp(97, 400),
+				tsdp(201, 41234),
+				tsdp(249, 423),
+				tsdp(424, 123),
+				tsdp(425, 342),
+				tsdp(426, 643),
+				tsdp(427, 835),
+				tsdp(1023, 999),
+				tsdp(1048, 888),
+				tsdp(1123, 999),
+				tsdp(1248, 888),
+				tsdp(1323, 999),
+				tsdp(1348, 888),
+			),
+			expected: []roachpb.InternalTimeSeriesData{
+				makeInternalColumnData(0, 50, []dataSample{
+					{10, 200},
+					{20, 300},
+					{40, 400},
+					{80, 400},
+					{97, 400},
+					{201, 41234},
+					{249, 423},
+					{424, 123},
+					{425, 342},
+					{426, 643},
+					{427, 835},
+				}),
+				makeInternalColumnData(1000, 50, []dataSample{
+					{1023, 999},
+					{1048, 888},
+					{1123, 999},
+					{1248, 888},
+					{1323, 999},
+					{1348, 888},
+				}),
+			},
+		},
+		{
+			input: ts("test.metric",
+				tsdp(1023, 999),
+				tsdp(1048, 888),
+				tsdp(1123, 999),
+				tsdp(1248, 888),
+			),
+			expected: []roachpb.InternalTimeSeriesData{
+				makeInternalColumnData(1000, 50, []dataSample{
+					{1023, 999},
+					{1048, 888},
+					{1123, 999},
+					{1248, 888},
+				}),
+			},
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			rollups := computeRollupsFromData(tc.input, 50)
+			internal, err := rollups.toInternal(1000, 50)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if a, e := internal, tc.expected; !reflect.DeepEqual(a, e) {
+				for _, diff := range pretty.Diff(a, e) {
+					t.Error(diff)
+				}
+			}
+		})
+	}
+}
+
+func TestRollupToInternal(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+}


### PR DESCRIPTION
Creates two new "rollup" resolutions, which are resolutions specifically
designated to contain rollup data. Note that the engine and query system
detect rollup data based on what is queried from disk - the resolutions
are only designated as rollups for clarity.

The two resolutions are:
+ `30mRUP`, for 30-minute sample period rollups from the 10 second
resolution.
+ `50nsRUP`, a test-only resolution which contains rollup for the 1
nanosecond test resolution.

Note that model does not store data as rollups - it always stores
original timestamps for all datapoints for all resolutions. When a query
is compared against the model, we are thus ensuring that query based on
rollup data is equivalent to a query against the original resolution.