### PR TITLE
sql: sensible error when column default dropped in transaction

### DIFF
--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -94,21 +94,19 @@ func (cb *ColumnBackfiller) Init(evalCtx *tree.EvalContext, desc sqlbase.TableDe
 	}
 
 	cb.updateCols = append(cb.added, dropped...)
-	if len(dropped) > 0 || len(defaultExprs) > 0 || len(computedExprs) > 0 {
-		// Populate default or computed values.
-		cb.updateExprs = make([]tree.TypedExpr, len(cb.updateCols))
-		for j, col := range cb.added {
-			if col.IsComputed() {
-				cb.updateExprs[j] = computedExprs[j]
-			} else if defaultExprs == nil || defaultExprs[j] == nil {
-				cb.updateExprs[j] = tree.DNull
-			} else {
-				cb.updateExprs[j] = defaultExprs[j]
-			}
+	// Populate default or computed values.
+	cb.updateExprs = make([]tree.TypedExpr, len(cb.updateCols))
+	for j, col := range cb.added {
+		if col.IsComputed() {
+			cb.updateExprs[j] = computedExprs[j]
+		} else if defaultExprs == nil || defaultExprs[j] == nil {
+			cb.updateExprs[j] = tree.DNull
+		} else {
+			cb.updateExprs[j] = defaultExprs[j]
 		}
-		for j := range dropped {
-			cb.updateExprs[j+len(cb.added)] = tree.DNull
-		}
+	}
+	for j := range dropped {
+		cb.updateExprs[j+len(cb.added)] = tree.DNull
 	}
 
 	// We need all the columns.

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -535,6 +535,23 @@ ALTER TABLE add_default ADD g OID DEFAULT 'foo'::regclass::oid
 statement error cannot access virtual schema in anonymous database
 ALTER TABLE add_default ADD g INT DEFAULT 'foo'::regtype::INT
 
+subtest 26422
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE add_default ADD fee FLOAT NOT NULL DEFAULT 2.99
+
+statement ok
+ALTER TABLE add_default ALTER COLUMN fee DROP DEFAULT
+
+statement error null value in column "fee" violates not-null constraint
+COMMIT
+
+statement error pgcode 42703 column "fee" does not exist
+ALTER TABLE add_default DROP fee
+
 # Multiple columns can be added at once with heterogeneous DEFAULT usage
 statement ok
 CREATE TABLE d (a INT PRIMARY KEY)


### PR DESCRIPTION
The COMMIT statement used to return
error: got 0 values but expected 1

The column backfiller's updateExprs[] was not being
initialized properly. A NULL default value reflects now in
a proper initialization of the default value to tree.DNull.

related to #26422

Release note: None