### PR TITLE
sqlmigrations: simplify descriptor validation to get around #26422

### DIFF
--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -693,7 +693,10 @@ func upgradeDescsWithFn(
 							// days, while upgrading to a new version can take as little as a
 							// few minutes.
 							table.UpVersion = true
-							if err := table.Validate(ctx, txn, nil); err != nil {
+							// Use ValidateTable() instead of Validate()
+							// because of #26422. We still do not know why
+							// a table can reference a dropped database.
+							if err := table.ValidateTable(nil); err != nil {
 								return err
 							}
 


### PR DESCRIPTION
This validation is fine because the function itself is only
upgrading the format.

related to #26422

Release note: None