### PR TITLE
Makefile: don't globally install binaries during lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -955,10 +955,10 @@ lint: override TAGS += lint
 lint: ## Run all style checkers and linters.
 lint: bin/returncheck
 	@if [ -t 1 ]; then echo '$(yellow)NOTE: `make lint` is very slow! Perhaps `make lintshort`?$(term-reset)'; fi
-	@# Run 'go install' to ensure we have compiled object files available for all
+	@# Run 'go build -i' to ensure we have compiled object files available for all
 	@# packages. In Go 1.10, only 'go vet' recompiles on demand. For details:
 	@# https://groups.google.com/forum/#!msg/golang-dev/qfa3mHN4ZPA/X2UzjNV1BAAJ.
-	$(XGO) install -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' $(PKG)
+	$(XGO) build -i -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' $(PKG)
 	$(XGO) test ./pkg/testutils/lint -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run 'TestLint/$(TESTS)'
 
 .PHONY: lintshort

--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -23,7 +23,15 @@ fi
 tc_end_block "Ensure generated code is up-to-date"
 
 tc_start_block "Lint"
-run build/builder.sh make lint 2>&1 | tee artifacts/lint.log | go-test-teamcity
+# Disable ccache so that Go doesn't try to install dependencies into GOROOT,
+# where it doesn't have write permissions. (Using ccache busts the Go package
+# cache because it appears to the Go toolchain as a different C compiler than
+# the toolchain was compiled with.) We've already built the C dependencies
+# above, so we're not losing anything by turning it off.
+#
+# TODO(benesch): once GOPATH/pkg goes away because Go static analysis tools can
+# rebuild on demand, remove this. Upstream issue: golang/go#25650.
+COCKROACH_BUILDER_CCACHE= run build/builder.sh make lint 2>&1 | tee artifacts/lint.log | go-test-teamcity
 tc_end_block "Lint"
 
 tc_start_block "Test web UI"


### PR DESCRIPTION
The build system takes pains to scope all binaries it installs to
REPO/bin to avoid polluting the user's GOPATH/bin with binaries that are
internal to the Cockroach build system.

The lint target was violating this rule by running 'go install
./pkg/...', which installed every package in the repository into
GOPATH/bin. This commit adjusts the rule to run 'go build ./pkg/...'
instead, which installs the necessary .a files into GOPATH/pkg without
installing any binaries into GOPATH/bin.

Fix #26633.

Release note: None