### PR TITLE
opt: infer constant columns from constraints

### DIFF
--- a/pkg/sql/opt/constraint/constraint.go
+++ b/pkg/sql/opt/constraint/constraint.go
@@ -474,6 +474,17 @@ func (c *Constraint) Prefix(evalCtx *tree.EvalContext) int {
 	return prefix
 }
 
+// ExtractConstCols returns a set of columns which are restricted to be
+// constant by the constraint.
+func (c *Constraint) ExtractConstCols(evalCtx *tree.EvalContext) opt.ColSet {
+	var res opt.ColSet
+	pre := c.ExactPrefix(evalCtx)
+	for i := 0; i < pre; i++ {
+		res.Add(int(c.Columns.Get(i).ID()))
+	}
+	return res
+}
+
 // ExtractNotNullCols returns a set of columns that cannot be NULL when the
 // constraint holds.
 func (c *Constraint) ExtractNotNullCols(evalCtx *tree.EvalContext) opt.ColSet {

--- a/pkg/sql/opt/constraint/constraint_set.go
+++ b/pkg/sql/opt/constraint/constraint_set.go
@@ -266,6 +266,19 @@ func (s *Set) ExtractNotNullCols(evalCtx *tree.EvalContext) opt.ColSet {
 	return res
 }
 
+// ExtractConstCols returns a set of columns which can only have one value
+// for the constraints in the set to hold.
+func (s *Set) ExtractConstCols(evalCtx *tree.EvalContext) opt.ColSet {
+	if s == Unconstrained || s == Contradiction {
+		return opt.ColSet{}
+	}
+	res := s.Constraint(0).ExtractConstCols(evalCtx)
+	for i := 1; i < s.Length(); i++ {
+		res.UnionWith(s.Constraint(i).ExtractConstCols(evalCtx))
+	}
+	return res
+}
+
 // allocConstraint allocates space for a new constraint in the set and returns
 // a pointer to it. The first constraint is stored inline, and subsequent
 // constraints are stored in the otherConstraints slice.

--- a/pkg/sql/opt/memo/constraint_builder.go
+++ b/pkg/sql/opt/memo/constraint_builder.go
@@ -224,7 +224,9 @@ func (cb *constraintsBuilder) buildConstraintForTupleIn(
 	keyCtx := constraint.KeyContext{EvalCtx: cb.evalCtx}
 	keyCtx.Columns.Init(constrainedCols)
 	var spans constraint.Spans
-	spans.Alloc(len(constrainedCols))
+	spans.Alloc(rhs.ChildCount())
+
+	keyCtx.Columns.Init(constrainedCols)
 	vals := make(tree.Datums, len(colIdxsInLHS))
 	for i, n := 0, rhs.ChildCount(); i < n; i++ {
 		val := rhs.Child(i)


### PR DESCRIPTION
This commit allows the optimizer to infer constant columns from a set of
constraints.

This could be a bit more sophisticated as some test cases I included
show, but I think what's done here is probably sufficient for most
situations.

This will probably need some changes to work well with Andy's FD change,
I'll modify this to use that once that goes in.

Release note: None.