### PR TITLE
roachtest: fix store dump version

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -369,7 +369,7 @@ func registerTPCCBench(r *registry) {
 
 			LoadWarehouses:  1000,
 			EstimatedMax:    325,
-			StoreDirVersion: "2.0-6",
+			StoreDirVersion: "2.0-5",
 		},
 		{
 			Nodes: 3,
@@ -394,7 +394,7 @@ func registerTPCCBench(r *registry) {
 
 			LoadWarehouses:  5000,
 			EstimatedMax:    500,
-			StoreDirVersion: "2.0-6",
+			StoreDirVersion: "2.0-5",
 		},
 		// objective 3, key result 2.
 		{


### PR DESCRIPTION
This store dump version was accidentally broken in #25541.

Release note: None