### PR TITLE
server: Unskip TestSystemConfigGossip

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -418,7 +418,6 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 
 func TestSystemConfigGossip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#12351")
 
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.TODO())


### PR DESCRIPTION
It has long since been fixed, presumably by the many improvements to the
sqlmigrations infrastructure.

Fixes #12351

Release note: None