### PR TITLE
roachtest: skip disk space test on 2.0

### DIFF
--- a/pkg/cmd/roachtest/disk_space.go
+++ b/pkg/cmd/roachtest/disk_space.go
@@ -308,8 +308,9 @@ func registerDiskUsage(r *registry) {
 		}
 		r.Add(
 			testSpec{
-				Name:  fmt.Sprintf("disk_space/tc=%s", testCase.name),
-				Nodes: nodes(numNodes),
+				Name:       fmt.Sprintf("disk_space/tc=%s", testCase.name),
+				Nodes:      nodes(numNodes),
+				MinVersion: "2.1", // cockroach debug ballast
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					if local {
 						duration = 30 * time.Minute


### PR DESCRIPTION
It can't succeed there due to lack of the `./cockroach debug ballast`
command.

Reminder to myself: need to actually backport this to release-2.0.

Release note: None