### PR TITLE
server: general correctness fixes for ListSessions / Ranges / upgradeStatus

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -831,9 +831,11 @@ func (g *Gossip) getNodeDescriptorLocked(nodeID roachpb.NodeID) (*roachpb.NodeDe
 		}
 		// Don't return node descriptors that are empty, because that's meant to
 		// indicate that the node has been removed from the cluster.
-		if !(nodeDescriptor.NodeID == 0 && nodeDescriptor.Address.IsEmpty()) {
-			return nodeDescriptor, nil
+		if nodeDescriptor.NodeID == 0 || nodeDescriptor.Address.IsEmpty() {
+			return nil, errors.Errorf("node %d has been removed from the cluster", nodeID)
 		}
+
+		return nodeDescriptor, nil
 	}
 
 	return nil, errors.Errorf("unable to look up descriptor for node %d", nodeID)

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -102,7 +102,7 @@ func TestGossipOverwriteNode(t *testing.T) {
 	// Quiesce the stopper now to ensure that the update has propagated before
 	// checking whether node 1 has been removed from the infoStore.
 	stopper.Quiesce(context.TODO())
-	expectedErr := "unable to look up descriptor for node"
+	expectedErr := "node.*has been removed from the cluster"
 	if val, err := g.GetNodeDescriptor(node1.NodeID); !testutils.IsError(err, expectedErr) {
 		t.Errorf("expected error %q fetching node %d; got error %v and node %+v",
 			expectedErr, node1.NodeID, err, val)
@@ -154,7 +154,7 @@ func TestGossipMoveNode(t *testing.T) {
 	} else if !proto.Equal(movedNode, val) {
 		t.Errorf("expected node %+v, got %+v", movedNode, val)
 	}
-	expectedErr := "unable to look up descriptor for node"
+	expectedErr := "node.*has been removed from the cluster"
 	if val, err := g.GetNodeDescriptor(replacedNode.NodeID); !testutils.IsError(err, expectedErr) {
 		t.Errorf("expected error %q fetching node %d; got error %v and node %+v",
 			expectedErr, replacedNode.NodeID, err, val)

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1089,7 +1089,9 @@ func (s *adminServer) Health(
 	return &serverpb.HealthResponse{}, nil
 }
 
-// Liveness returns the liveness state of all nodes on the cluster.
+// Liveness returns the liveness state of all nodes on the cluster
+// known to gossip. To reach all nodes in the cluster, consider
+// using (statusServer).NodesWithLiveness instead.
 func (s *adminServer) Liveness(
 	context.Context, *serverpb.LivenessRequest,
 ) (*serverpb.LivenessResponse, error) {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -587,6 +587,11 @@ func (ts *TestServer) GetNode() *Node {
 	return ts.node
 }
 
+// GetNodeLiveness exposes the Server's nodeLiveness.
+func (ts *TestServer) GetNodeLiveness() *storage.NodeLiveness {
+	return ts.nodeLiveness
+}
+
 // DistSender exposes the Server's DistSender.
 func (ts *TestServer) DistSender() *kv.DistSender {
 	return ts.distSender

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -739,17 +739,18 @@ func populateQueriesTable(
 	for _, rpcErr := range response.Errors {
 		log.Warning(ctx, rpcErr.Message)
 		if rpcErr.NodeID != 0 {
-			// Add a row with this node ID, and nulls for all other columns
+			// Add a row with this node ID, the error for query, and
+			// nulls for all other columns.
 			if err := addRow(
-				tree.DNull,
-				tree.NewDInt(tree.DInt(rpcErr.NodeID)),
-				tree.DNull,
-				tree.DNull,
-				tree.DNull,
-				tree.DNull,
-				tree.DNull,
-				tree.DNull,
-				tree.DNull,
+				tree.DNull,                             // query ID
+				tree.NewDInt(tree.DInt(rpcErr.NodeID)), // node ID
+				tree.DNull,                             // username
+				tree.DNull,                             // start
+				tree.NewDString("-- "+rpcErr.Message),  // query
+				tree.DNull,                             // client_address
+				tree.DNull,                             // application_name
+				tree.DNull,                             // distributed
+				tree.DNull,                             // phase
 			); err != nil {
 				return err
 			}
@@ -857,18 +858,21 @@ func populateSessionsTable(
 	for _, rpcErr := range response.Errors {
 		log.Warning(ctx, rpcErr.Message)
 		if rpcErr.NodeID != 0 {
-			// Add a row with this node ID, and nulls for all other columns
+			// Add a row with this node ID, error in active queries, and nulls
+			// for all other columns.
 			if err := addRow(
-				tree.NewDInt(tree.DInt(rpcErr.NodeID)),
-				tree.DNull,
-				tree.DNull,
-				tree.DNull,
-				tree.DNull,
-				tree.DNull,
-				tree.DNull,
-				tree.DNull,
-				tree.DNull,
-				tree.DNull,
+				tree.NewDInt(tree.DInt(rpcErr.NodeID)), // node ID
+				tree.DNull,                             // session ID
+				tree.DNull,                             // username
+				tree.DNull,                             // client address
+				tree.DNull,                             // application name
+				tree.NewDString("-- "+rpcErr.Message),  // active queries
+				tree.DNull,                             // last active query
+				tree.DNull,                             // session start
+				tree.DNull,                             // oldest_query_start
+				tree.DNull,                             // kv_txn
+				tree.DNull,                             // alloc_bytes
+				tree.DNull,                             // max_alloc_bytes
 			); err != nil {
 				return err
 			}


### PR DESCRIPTION
Prior to this patch, various parts of the code what were attempting to
"iterate over all nodes in the cluster" were confused and would
either:

- skip over nodes that are known to exist in KV but for which gossip
  information was currently unavailable, or
- fail to skip over removed nodes (dead + decommissioned) or
- incorrectly skip over temporarily failed nodes.

This patch comprehensively addresses this class of issues by:

- tweaking `(*NodeLiveness).GetIsLiveMap()` to exclude decommissioned
  nodes upfront.
- documenting `(*NodeLiveness).GetLivenessStatusMap()` better, to
  mention it includes decommissioned nodes and does not include
  all nodes known to KV.
- providing a new method `(*statusServer).NodesWithLiveness()` which
  always includes all nodes known in KV, not just those for which
  gossip information is available.
- ensuring that `(*Server).upgradeStatus()` does not incorrectly skip
  over temporarily dead nodes or nodes yet unknown to gossip by
  using the new `NodesWithLiveness()` method appropriately.
- providing a new method `(*statusServer).iterateNodes()` which does
  "the right thing" via `NodesWithLiveness()` and using it for
  the status RPCs `ListSessions()` and `Range()`.

Additionally this patch makes SHOW QUERIES and SHOW SESSIONS report
error details when it fails to query information from a node.

Release note (bug fix): the server will not finalize a version upgrade
automatically and erroneously if there are nodes temporarily inactive
in the cluster.

Release note (sql change): SHOW CLUSTER QUERIES/SESSIONS now report
the details of the error upon failing to gather data from other nodes.

Fixes #22863.
Fixes #26852.
Fixes #26897.