### PR TITLE
acceptance: un-special-case single-node clusters

### DIFF
--- a/pkg/acceptance/util_cluster.go
+++ b/pkg/acceptance/util_cluster.go
@@ -135,6 +135,7 @@ func StartCluster(ctx context.Context, t *testing.T, cfg cluster.TestConfig) (c 
 			LogDir:     logDir,
 			NumNodes:   len(cfg.Nodes),
 			PerNodeCfg: perNodeCfg,
+			NoWait:     cfg.NoWait,
 		}
 
 		l := localcluster.New(clusterCfg)


### PR DESCRIPTION
Previously, single node clusters would start without waiting for the
server to be ready, which was necessary for TestRapidRestarts. But
this is surprising to tests who want the default behavior.

Plumb the NoWait boolean into LocalCluster so that we can only enable
the fast starts when they're actually requested.

Somewhat optimistically but pretty sure:
Fixes #25244.

Release note: None