### PR TITLE
distsqlrun: fix hashjoin memory accounting

### DIFF
--- a/pkg/sql/distsqlrun/hash_row_container.go
+++ b/pkg/sql/distsqlrun/hash_row_container.go
@@ -170,11 +170,13 @@ var _ hashRowContainer = &hashMemRowContainer{}
 
 // makeHashMemRowContainer creates a hashMemRowContainer from the given
 // rowContainer. This rowContainer must still be Close()d by the caller.
-func makeHashMemRowContainer(rowContainer *memRowContainer) hashMemRowContainer {
+func makeHashMemRowContainer(
+	mon *mon.BytesMonitor, rowContainer *memRowContainer,
+) hashMemRowContainer {
 	return hashMemRowContainer{
 		memRowContainer: rowContainer,
 		buckets:         make(map[string][]int),
-		bucketsAcc:      rowContainer.evalCtx.Mon.MakeBoundAccount(),
+		bucketsAcc:      mon.MakeBoundAccount(),
 	}
 }
 

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -686,7 +686,7 @@ func (h *hashJoiner) shouldEmitUnmatched(
 
 // initStoredRows initializes a hashRowContainer and sets h.storedRows.
 func (h *hashJoiner) initStoredRows() error {
-	storedMemRows := makeHashMemRowContainer(&h.rows[h.storedSide])
+	storedMemRows := makeHashMemRowContainer(h.MemMonitor, &h.rows[h.storedSide])
 	err := storedMemRows.Init(
 		h.Ctx,
 		shouldMark(h.storedSide, h.joinType),


### PR DESCRIPTION
Previously, hash join didn't properly attribute its bucket memory
account to its memory monitor - instead, it attributed that memory to
the eval context's memory monitor.

Release note: None