### PR TITLE
distsqlrun: fast-path for hash join on 1 column

### DIFF
--- a/pkg/sql/sqlbase/encoded_datum.go
+++ b/pkg/sql/sqlbase/encoded_datum.go
@@ -267,6 +267,16 @@ func (ed *EncDatum) Encode(
 	}
 }
 
+// Encoded returns the encoded datum in the given ordering, if the cached
+// ordering matches the given ordering.
+func (ed *EncDatum) Encoded(enc DatumEncoding) ([]byte, bool) {
+	if ed.encoded != nil && enc == ed.encoding {
+		// We already have an encoding that matches that we can use.
+		return ed.encoded, true
+	}
+	return nil, false
+}
+
 // Compare returns:
 //    -1 if the receiver is less than rhs,
 //    0  if the receiver is equal to rhs,


### PR DESCRIPTION
Normally, during build and probe, a hash join must build hash keys from
each input row by concatenating the encodings of all of the equality
columns. In the common single-column hash join case, this is inefficient -
the key encoding of the only equality column is copied into a scratch
buffer before being used as a hash key.

Now, if there's only a single equality column, and the available
encoding of that equality column is correct, we directly use the
available encoding as the hash key instead of having to copy it.

Release note (performance improvement): improve single column hash join
performance