### PR TITLE
changefeedccl: add an option to emit row and resolved timestamps

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -33,8 +33,9 @@ func init() {
 type envelopeType string
 
 const (
-	optCursor   = `cursor`
-	optEnvelope = `envelope`
+	optCursor     = `cursor`
+	optEnvelope   = `envelope`
+	optTimestamps = `timestamps`
 
 	optEnvelopeKeyOnly envelopeType = `key_only`
 	optEnvelopeRow     envelopeType = `row`
@@ -45,8 +46,9 @@ const (
 )
 
 var changefeedOptionExpectValues = map[string]bool{
-	optCursor:   true,
-	optEnvelope: true,
+	optCursor:     true,
+	optEnvelope:   true,
+	optTimestamps: false,
 }
 
 // changefeedPlanHook implements sql.PlanHookFn.

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -11,11 +11,13 @@ package changefeedccl
 import (
 	"context"
 	gosql "database/sql"
+	gojson "encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -154,6 +156,72 @@ func TestChangefeedCursor(t *testing.T) {
 	})
 }
 
+func TestChangefeedTimestamps(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer utilccl.TestingEnableEnterprise()()
+
+	ctx := context.Background()
+	s, sqlDBRaw, _ := serverutils.StartServer(t, base.TestServerArgs{
+		UseDatabase: "d",
+	})
+	defer s.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
+	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
+	sqlDB.Exec(t, `CREATE DATABASE d`)
+	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+
+	var ts0 string
+	sqlDB.QueryRow(t,
+		`BEGIN; INSERT INTO foo VALUES (0); SELECT cluster_logical_timestamp(); COMMIT`,
+	).Scan(&ts0)
+
+	rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR foo WITH timestamps`)
+	defer closeFeedRowsHack(t, sqlDB, rows)
+
+	var ts1 string
+	sqlDB.QueryRow(t,
+		`BEGIN; INSERT INTO foo VALUES (1); SELECT cluster_logical_timestamp(); COMMIT`,
+	).Scan(&ts1)
+
+	assertPayloads(t, rows, []string{
+		`foo: [0]->{"__crdb__": {"updated": "` + ts0 + `"}, "a": 0}`,
+		`foo: [1]->{"__crdb__": {"updated": "` + ts1 + `"}, "a": 1}`,
+	})
+
+	// Check that we eventually get a resolved timestamp greater than ts1.
+	for {
+		if !rows.Next() {
+			t.Fatal(`expected a resolved timestamp notification`)
+		}
+		var ignored interface{}
+		var value []byte
+		if err := rows.Scan(&ignored, &ignored, &value); err != nil {
+			t.Fatal(err)
+		}
+
+		var valueRaw struct {
+			CRDB struct {
+				Resolved string `json:"resolved"`
+			} `json:"__crdb__"`
+		}
+		if err := gojson.Unmarshal(value, &valueRaw); err != nil {
+			t.Fatal(err)
+		}
+
+		parseTimeToDecimal := func(s string) *apd.Decimal {
+			t.Helper()
+			d, _, err := apd.NewFromString(s)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return d
+		}
+		if parseTimeToDecimal(valueRaw.CRDB.Resolved).Cmp(parseTimeToDecimal(ts1)) > 0 {
+			break
+		}
+	}
+}
+
 func TestChangefeedSchemaChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer utilccl.TestingEnableEnterprise()()
@@ -226,12 +294,16 @@ func assertPayloads(t *testing.T, rows *gosql.Rows, expected []string) {
 
 	var actual []string
 	for len(actual) < len(expected) && rows.Next() {
-		var topic string
+		var topic gosql.NullString
 		var key, value []byte
 		if err := rows.Scan(&topic, &key, &value); err != nil {
 			t.Fatalf(`%+v`, err)
 		}
-		actual = append(actual, fmt.Sprintf(`%s: %s->%s`, topic, key, value))
+		if !topic.Valid {
+			// Ignore resolved timestamp notifications.
+			continue
+		}
+		actual = append(actual, fmt.Sprintf(`%s: %s->%s`, topic.String, key, value))
 	}
 	if err := rows.Err(); err != nil {
 		t.Fatalf(`%+v`, err)


### PR DESCRIPTION
I feel like I still don't have a good grasp about what the user-facing
format of these should be, but that's easy to change later once we get
some feedback. Specifying `WITH timestamp` turns on the following
behavior.

Kafka row timestamp (json):

    Key: <unchanged> Value: {"__crdb__":{"updated": ""}, <unchanged>}

Kafka resolved timestamp (json), emitted to every partition of every topic:

    Key: <empty> Value: {"__crdb__":{"resolved": ""}}

The no sink (pgwire) version is the same, except the resolved timestamp
is emitted once with NULL for topic and key.

Release note: None