### PR TITLE
backport-2.0: sql: bugfix to interleaved join planning criteria

### DIFF
--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -385,12 +385,15 @@ func useInterleavedJoin(n *joinNode) bool {
 	}
 
 	var ancestorEqIndices []int
+	var descendantEqIndices []int
 	// We are guaranteed that both of the sources are scan nodes from
 	// n.interleavedNodes().
 	if ancestor == n.left.plan.(*scanNode) {
 		ancestorEqIndices = n.pred.leftEqualityIndices
+		descendantEqIndices = n.pred.rightEqualityIndices
 	} else {
 		ancestorEqIndices = n.pred.rightEqualityIndices
+		descendantEqIndices = n.pred.leftEqualityIndices
 	}
 
 	// We want full 1-1 correspondence between our join columns and the
@@ -405,9 +408,9 @@ func useInterleavedJoin(n *joinNode) bool {
 
 	// We iterate through the ordering given by n.mergeJoinOrdering and check
 	// if the columns have a 1-1 correspondence to the interleaved
-	// ancestor's primary index columns (i.e. interleave prefix).  We
-	// naively return false if any part of the ordering does not
-	// correspond.
+	// ancestor's primary index columns (i.e. interleave prefix) as well as the
+	// descendant's primary index columns. We naively return false if any part
+	// of the ordering does not correspond.
 	for i, info := range n.mergeJoinOrdering {
 		colID := ancestor.index.ColumnIDs[i]
 		// info.ColIdx refers to i in ancestorEqIndices[i], which refers
@@ -415,7 +418,8 @@ func useInterleavedJoin(n *joinNode) bool {
 		// the index in scanNode.resultColumns. To convert the colID
 		// from the index descriptor, we can use the map provided by
 		// colIdxMap.
-		if ancestorEqIndices[info.ColIdx] != ancestor.colIdxMap[colID] {
+		if ancestorEqIndices[info.ColIdx] != ancestor.colIdxMap[colID] ||
+			descendantEqIndices[info.ColIdx] != descendant.colIdxMap[colID] {
 			// The column in the ordering does not correspond to
 			// the column in the interleave prefix.
 			// We should not try to do an interleaved join.

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -377,3 +377,26 @@ END
 
 statement error duplicate key value \(p_id,c_id\)=\(1,1\) violates unique constraint "primary"
 INSERT INTO c20067 VALUES (1, 1, 'John Doe')
+
+# Regression test for #26756: ensure that interleaved table joins don't get
+# planned incorrectly given a merge join ordering caused by a constant value
+# constraint on a non-interleaved column.
+
+subtest interleaved_join_on_other_columns
+
+statement ok
+CREATE TABLE users (id INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE documents (id INT PRIMARY KEY, user_id INT NOT NULL) INTERLEAVE IN PARENT users (id)
+
+statement ok
+INSERT INTO users(id) VALUES(1)
+
+statement ok
+INSERT INTO documents(id, user_id) VALUES (0, 1)
+
+query I
+SELECT count(*) FROM users JOIN documents ON users.id=documents.user_id WHERE documents.id=0
+----
+1


### PR DESCRIPTION
Backport 1/1 commits from #26756.

/cc @cockroachdb/release

---

Previously, interleaved joins could take place if the tables were
ancestors of each other, there was a merge join ordering on the equality
columns, and the left equality columns were a prefix of the interleaved
columns. These criteria are insufficient: the right equality columns
must also be a prefix of the interleaved columns. A case where this
wouldn't naturally hold is where the right equality columns get a merge
join ordering because they're known to be constant.

Release note (bug fix): joins across two interleaved tables no longer
return incorrect results under certain circumstances when the equality
columns aren't all part of the interleaved columns.

Fixes #25838. I verified that the new test fails before the fix was applied.
