### PR TITLE
Makefile: track inputs of libroach[ccl] properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -684,11 +684,13 @@ $(LIBSNAPPY): $(SNAPPY_DIR)/Makefile bin/uptodate .ALWAYS_REBUILD
 $(LIBROCKSDB): $(ROCKSDB_DIR)/Makefile bin/uptodate .ALWAYS_REBUILD
 	@uptodate $@ $(ROCKSDB_SRC_DIR) || $(MAKE) --no-print-directory -C $(ROCKSDB_DIR) rocksdb
 
+libroach-inputs := $(LIBROACH_SRC_DIR) $(ROCKSDB_SRC_DIR)/include $(PROTOBUF_SRC_DIR)/src
+
 $(LIBROACH): $(LIBROACH_DIR)/Makefile bin/uptodate .ALWAYS_REBUILD
-	@uptodate $@ $(LIBROACH_SRC_DIR) || $(MAKE) --no-print-directory -C $(LIBROACH_DIR) roach
+	@uptodate $@ $(libroach-inputs) || $(MAKE) --no-print-directory -C $(LIBROACH_DIR) roach
 
 $(LIBROACHCCL): $(LIBROACH_DIR)/Makefile bin/uptodate .ALWAYS_REBUILD
-	@uptodate $@ $(LIBROACH_SRC_DIR) || $(MAKE) --no-print-directory -C $(LIBROACH_DIR) roachccl
+	@uptodate $@ $(libroach-inputs) || $(MAKE) --no-print-directory -C $(LIBROACH_DIR) roachccl
 
 # Convenient names for maintainers. Not used by other targets in the Makefile.
 .PHONY: protoc libcryptopp libjemalloc libprotobuf libsnappy librocksdb libroach libroachccl

--- a/build/variables.mk
+++ b/build/variables.mk
@@ -164,6 +164,7 @@ define VALID_VARS
   go-targets-ccl
   have-defs
   langgen-package
+  libroach-inputs
   logictest-package
   logictestccl-package
   macos-version


### PR DESCRIPTION
libroach and libroachccl access protobuf and RocksDB header files, and
thus need to be recompiled whenever those header files change.
libroach[ccl]'s CMake build system already performs the recompilation
properly; we just need to teach uptodate to consider the header files as
inputs to trigger libroach[ccl]'s build system.

Release note: None