### PR TITLE
changefeedccl: add a setting to avoid interfering with active traffic

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -32,14 +32,25 @@ import (
 	"github.com/pkg/errors"
 )
 
-var changefeedPollInterval = settings.RegisterDurationSetting(
+// TODO(dan): Should these be cluster settings or WITH options? We probably
+// wouldn't want to switch to the latter until after `ALTER CHANGEFEED` is
+// implemented (so that they can be adjusted on an already created changefeed).
+// Either way, they are going away once we switch to RangeFeed so maybe it
+// doesn't matter.
+var changefeedPollInterval = settings.RegisterNonNegativeDurationSetting(
 	"changefeed.experimental_poll_interval",
 	"polling interval for the prototype changefeed implementation",
 	1*time.Second,
 )
+var changefeedReadBehindInterval = settings.RegisterNonNegativeDurationSetting(
+	"changefeed.experimental_readbehind_interval",
+	"how far behind realtime the prototype changefeed implementation polls",
+	10*time.Second,
+)
 
 func init() {
 	changefeedPollInterval.Hide()
+	changefeedReadBehindInterval.Hide()
 }
 
 type changedKVs struct {
@@ -147,21 +158,64 @@ func exportRequestPoll(
 			return ret, nil
 		}
 
-		pollDuration := changefeedPollInterval.Get(&execCfg.Settings.SV)
-		pollDuration = pollDuration - timeutil.Since(timeutil.Unix(0, highwater.WallTime))
-		if pollDuration > 0 {
-			log.VEventf(ctx, 1, `sleeping for %s`, pollDuration)
-			select {
-			case <-ctx.Done():
-				return changedKVs{}, ctx.Err()
-			case <-time.After(pollDuration):
+		pollInterval := changefeedPollInterval.Get(&execCfg.Settings.SV)
+		readBehind := changefeedReadBehindInterval.Get(&execCfg.Settings.SV)
+
+		// This code attempts to figure out what the next poll's highwater mark
+		// should be and at what time we should start that poll.
+		// - nextHighwater needs to be at least readBehind in the past
+		// - nextHighwater needs to be at least pollInterval greater than
+		//   highwater
+		//   - note that if the changefeed has just started or restarted, then
+		//     nextHighwater-highwater may (and should) be much greater than
+		//     pollInterval, but we can't just blindly set it to now-readBehind
+		//     because that could be before highwater
+		// - busy waiting should be avoided
+		// - this should all still work when pollInterval and readBehind are
+		//   being adjusted by the user
+		// - the sleep should never be overly long, so the changefeed stays
+		//   responsive to pollInterval and readBehind adjustments
+		//   - TODO(dan): this is not true of the current implementation. fixme
+		nextHighwater := hlc.Timestamp{WallTime: highwater.WallTime + pollInterval.Nanoseconds()}
+		nextPoll := timeutil.Unix(0, nextHighwater.WallTime).Add(readBehind)
+		if now := execCfg.Clock.PhysicalTime(); now.After(nextPoll) {
+			// The last poll took longer than the polling interval (or this is
+			// the first poll), so the proposed nextHighwater needs to be
+			// adjusted.
+			nextHighwater.WallTime = now.Add(-readBehind).UnixNano()
+			nextPoll = now
+			if nextHighwater.Less(highwater) {
+				// NB:
+				// now > highwater + pollInterval + readBehind
+				// nextHighwater = now - readBehind
+				//
+				// substituting:
+				// nextHighwater + readBehind > highwater + pollInterval + readBehind
+				//
+				// which guarantees that nextHighwater is greater than highwater
+				// as long as pollInterval isn't negative (which the setting
+				// enforces).
+				//
+				// TODO(dan): It feels like there should be a way to structure
+				// this code to be more obvious, but after trying for a bit, I
+				// haven't found it. Any suggestions?
+				panic(`unreachable`)
 			}
 		}
 
-		nextHighwater := execCfg.Clock.Now()
+		if sleep := nextPoll.Sub(execCfg.Clock.PhysicalTime()); sleep > 0 {
+			log.VEventf(ctx, 1, `sleeping for %s`, sleep)
+			select {
+			case <-ctx.Done():
+				return changedKVs{}, ctx.Err()
+			case <-time.After(sleep):
+			}
+		}
+
 		log.VEventf(ctx, 1, `changefeed poll [%s,%s): %s`,
 			highwater, nextHighwater, time.Duration(nextHighwater.WallTime-highwater.WallTime))
 
+		pollStart := execCfg.Clock.PhysicalTime()
 		// TODO(dan): Send these out in parallel.
 		for _, span := range spans {
 			header := roachpb.Header{Timestamp: nextHighwater}
@@ -180,8 +234,7 @@ func exportRequestPoll(
 				buffer.append(changedKVs{sst: file.SST})
 			}
 		}
-		log.VEventf(ctx, 2, `poll took %s`,
-			time.Duration(execCfg.Clock.Now().WallTime-nextHighwater.WallTime))
+		log.VEventf(ctx, 2, `poll took %s`, execCfg.Clock.PhysicalTime().Sub(pollStart))
 
 		// There is guaranteed to be at least one entry in buffer because we
 		// always append the resolved timestamp.

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -15,6 +15,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
@@ -22,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 func TestChangefeedBasics(t *testing.T) {
@@ -37,6 +39,7 @@ func TestChangefeedBasics(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
 	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_readbehind_interval = '0ns'`)
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
 	sqlDB.Exec(t, `INSERT INTO foo VALUES (0, 'initial')`)
@@ -80,6 +83,7 @@ func TestChangefeedEnvelope(t *testing.T) {
 	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
 
 	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_readbehind_interval = '0ns'`)
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
 	sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'a')`)
@@ -109,6 +113,7 @@ func TestChangefeedMultiTable(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
 	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_readbehind_interval = '0ns'`)
 
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
@@ -138,6 +143,7 @@ func TestChangefeedCursor(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
 	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_readbehind_interval = '0ns'`)
 
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
@@ -218,7 +224,60 @@ func TestChangefeedErrors(t *testing.T) {
 	); !testutils.IsError(err, `omit the SINK clause`) {
 		t.Fatalf(`expected 'omit the SINK clause' error got: %+v`, err)
 	}
+	if _, err := sqlDB.DB.Exec(
+		`CREATE CHANGEFEED FOR foo WITH cursor=$1`, timeutil.Now().Add(time.Second),
+	); !testutils.IsError(err, `cannot specify timestamp in the future`) {
+		t.Fatalf(`expected 'cannot specify timestamp in the future' error got: %+v`, err)
+	}
+}
 
+func TestChangefeedReadBehind(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer utilccl.TestingEnableEnterprise()()
+
+	ctx := context.Background()
+	s, sqlDBRaw, _ := serverutils.StartServer(t, base.TestServerArgs{
+		UseDatabase: "d",
+		// TODO(dan): HACK until the changefeed can control pgwire flushing.
+		ConnResultsBufferBytes: 1,
+	})
+	defer s.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
+	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_readbehind_interval = '20ms'`)
+
+	sqlDB.Exec(t, `CREATE DATABASE d`)
+	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+	sqlDB.Exec(t, `INSERT INTO foo VALUES (0)`)
+
+	rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR foo`)
+	defer closeFeedRowsHack(t, sqlDB, rows)
+
+	// Open a transaction that can't be pushed (by reading
+	// cluster_logical_timestamp), hold it for some amount of time that is less
+	// than the readbehind interval, and then commit it and verify that we don't
+	// need a transaction restart.
+	tx, err := sqlDB.DB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ts string
+	if err := tx.QueryRow(`SELECT cluster_logical_timestamp()`).Scan(&ts); err != nil {
+		t.Fatal(err)
+	}
+	// TODO(dan): Wait for some resolved timestamps instead.
+	time.Sleep(10 * time.Millisecond)
+	if _, err := tx.Exec(`INSERT INTO foo VALUES (1)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	assertPayloads(t, rows, []string{
+		`foo: [0]->{"a": 0}`,
+		`foo: [1]->{"a": 1}`,
+	})
 }
 
 func assertPayloads(t *testing.T, rows *gosql.Rows, expected []string) {

--- a/pkg/ccl/changefeedccl/kafka_test.go
+++ b/pkg/ccl/changefeedccl/kafka_test.go
@@ -55,6 +55,7 @@ func TestChangefeedPauseUnpause(t *testing.T) {
 	k := newTestKafkaProducer()
 	testKafkaProducersHook[t.Name()] = k
 	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_readbehind_interval = '0ns'`)
 
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)


### PR DESCRIPTION
The `changefeed.experimental_readbehind_interval` cluster setting can be
used to make a changefeed do all reads some time in the past. This is
set to 10s by default, which should large enough to avoid interaction
with production traffic. This setting is not necessary once we switch to
RangeFeed and will be removed.

Release note: None