### PR TITLE
engine: link against shlwapi on Windows

### DIFF
--- a/pkg/ccl/storageccl/engineccl/rocksdb.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb.go
@@ -27,7 +27,7 @@ import (
 // #cgo LDFLAGS: -lsnappy
 // #cgo LDFLAGS: -lcryptopp
 // #cgo linux LDFLAGS: -lrt -lpthread
-// #cgo windows LDFLAGS: -lrpcrt4
+// #cgo windows LDFLAGS: -lshlwapi -lrpcrt4
 //
 // #include <stdlib.h>
 // #include <libroachccl.h>

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -57,7 +57,7 @@ import (
 // #cgo LDFLAGS: -lrocksdb
 // #cgo LDFLAGS: -lsnappy
 // #cgo linux LDFLAGS: -lrt -lpthread
-// #cgo windows LDFLAGS: -lrpcrt4
+// #cgo windows LDFLAGS: -lshlwapi -lrpcrt4
 //
 // #include <stdlib.h>
 // #include <libroach.h>


### PR DESCRIPTION
RocksDB 5.13.4, which we upgraded to in 846083073, uses the PathIsRelative
function on Windows, which requires linking against the Shell Lightweight
Utility Functions library (shlwapi).

RocksDB had allegedly depended upon the Shell Lightweight Utility Functions
library (shlwapi) on Windows for as long as the Windows port existed (see
facebook/rocksdb@18285c1e2), but this appears to be the first actual use of a
function from it.

Release note: None