### PR TITLE
importccl: remove IMPORT formats from grammar

### DIFF
--- a/docs/generated/sql/bnf/export_stmt.bnf
+++ b/docs/generated/sql/bnf/export_stmt.bnf
@@ -1,2 +1,2 @@
 export_stmt ::=
-	'EXPORT' 'INTO' CSV file_location opt_with_options 'FROM' (| 'select_stmt' | 'TABLE' 'table_name')
+	'EXPORT' 'INTO' import_format file_location opt_with_options 'FROM' (| 'select_stmt' | 'TABLE' 'table_name')

--- a/docs/generated/sql/bnf/import_table.bnf
+++ b/docs/generated/sql/bnf/import_table.bnf
@@ -1,5 +1,5 @@
 import_stmt ::=
-	'IMPORT' import_bundle_format '(' string_or_placeholder ')'
-	| 'IMPORT' 'TABLE' table_name 'FROM' import_bundle_format '(' string_or_placeholder ')'
-	| 'IMPORT' 'TABLE' table_name 'CREATE' 'USING' string_or_placeholder import_data_format 'DATA' '(' string_or_placeholder_list ')' opt_with_options
-	| 'IMPORT' 'TABLE' table_name '(' table_elem_list ')' import_data_format 'DATA' '(' string_or_placeholder_list ')' opt_with_options
+	'IMPORT' import_format '(' string_or_placeholder ')'
+	| 'IMPORT' 'TABLE' table_name 'FROM' import_format '(' string_or_placeholder ')'
+	| 'IMPORT' 'TABLE' table_name 'CREATE' 'USING' string_or_placeholder import_format 'DATA' '(' string_or_placeholder_list ')' opt_with_options
+	| 'IMPORT' 'TABLE' table_name '(' table_elem_list ')' import_format 'DATA' '(' string_or_placeholder_list ')' opt_with_options

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -86,7 +86,7 @@ explain_stmt ::=
 	| 'EXPLAIN' 'ANALYZE' '(' explain_option_list ')' explainable_stmt
 
 export_stmt ::=
-	'EXPORT' 'INTO' import_data_format string_or_placeholder opt_with_options 'FROM' select_stmt
+	'EXPORT' 'INTO' import_format string_or_placeholder opt_with_options 'FROM' select_stmt
 
 grant_stmt ::=
 	'GRANT' privileges 'ON' targets 'TO' name_list
@@ -98,10 +98,10 @@ insert_stmt ::=
 	| opt_with_clause 'INSERT' 'INTO' insert_target insert_rest on_conflict returning_clause
 
 import_stmt ::=
-	'IMPORT' import_bundle_format '(' string_or_placeholder ')'
-	| 'IMPORT' 'TABLE' table_name 'FROM' import_bundle_format '(' string_or_placeholder ')'
-	| 'IMPORT' 'TABLE' table_name 'CREATE' 'USING' string_or_placeholder import_data_format 'DATA' '(' string_or_placeholder_list ')' opt_with_options
-	| 'IMPORT' 'TABLE' table_name '(' table_elem_list ')' import_data_format 'DATA' '(' string_or_placeholder_list ')' opt_with_options
+	'IMPORT' import_format '(' string_or_placeholder ')'
+	| 'IMPORT' 'TABLE' table_name 'FROM' import_format '(' string_or_placeholder ')'
+	| 'IMPORT' 'TABLE' table_name 'CREATE' 'USING' string_or_placeholder import_format 'DATA' '(' string_or_placeholder_list ')' opt_with_options
+	| 'IMPORT' 'TABLE' table_name '(' table_elem_list ')' import_format 'DATA' '(' string_or_placeholder_list ')' opt_with_options
 
 pause_stmt ::=
 	'PAUSE' 'JOB' a_expr
@@ -329,11 +329,8 @@ explainable_stmt ::=
 explain_option_list ::=
 	( explain_option_name ) ( ( ',' explain_option_name ) )*
 
-import_data_format ::=
-	import_bundle_format
-	| 'CSV'
-	| 'MYSQLOUTFILE'
-	| 'PGCOPY'
+import_format ::=
+	name
 
 privileges ::=
 	'ALL'
@@ -357,10 +354,6 @@ insert_rest ::=
 on_conflict ::=
 	'ON' 'CONFLICT' opt_conf_expr 'DO' 'UPDATE' 'SET' set_clause_list where_clause
 	| 'ON' 'CONFLICT' opt_conf_expr 'DO' 'NOTHING'
-
-import_bundle_format ::=
-	'MYSQLDUMP'
-	| 'PGDUMP'
 
 string_or_placeholder_list ::=
 	( string_or_placeholder ) ( ( ',' string_or_placeholder ) )*
@@ -665,7 +658,6 @@ unreserved_keyword ::=
 	| 'CONSTRAINTS'
 	| 'COPY'
 	| 'COVERING'
-	| 'CSV'
 	| 'CUBE'
 	| 'CURRENT'
 	| 'CYCLE'
@@ -734,8 +726,6 @@ unreserved_keyword ::=
 	| 'MATCH'
 	| 'MINUTE'
 	| 'MONTH'
-	| 'MYSQLDUMP'
-	| 'MYSQLOUTFILE'
 	| 'NAMES'
 	| 'NAN'
 	| 'NAME'
@@ -759,8 +749,6 @@ unreserved_keyword ::=
 	| 'PASSWORD'
 	| 'PAUSE'
 	| 'PHYSICAL'
-	| 'PGCOPY'
-	| 'PGDUMP'
 	| 'PLANS'
 	| 'PRECEDING'
 	| 'PREPARE'

--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -72,7 +72,7 @@ func exportPlanHook(
 	}
 
 	if exportStmt.FileFormat != "CSV" {
-		return nil, nil, nil, errors.Errorf("unsupported import format: %q", exportStmt.FileFormat)
+		return nil, nil, nil, errors.Errorf("unsupported export format: %q", exportStmt.FileFormat)
 	}
 
 	optsFn, err := p.TypeAsStringOpts(exportStmt.Options, exportOptionExpectValues)

--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -72,7 +72,6 @@ func exportPlanHook(
 	}
 
 	if exportStmt.FileFormat != "CSV" {
-		// not possible with current parser rules.
 		return nil, nil, nil, errors.Errorf("unsupported import format: %q", exportStmt.FileFormat)
 	}
 

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -496,7 +496,6 @@ func importPlanHook(
 				evalCtx := &p.ExtendedEvalContext().EvalContext
 				tableDescs, err = readPostgresCreateTable(reader, evalCtx, p.ExecCfg().Settings, match, parentID, walltime)
 			default:
-				// should be unreachable based on current parser rules.
 				return errors.Errorf("non-bundle format %q does not support reading schemas", format.Format.String())
 			}
 			if err != nil {
@@ -513,7 +512,6 @@ func importPlanHook(
 			jobDesc = descStr
 		} else {
 			if table == nil {
-				// should be unreachable based on current parser rules.
 				return errors.Errorf("non-bundle format %q should always have a table name", importStmt.FileFormat)
 			}
 			var create *tree.CreateTable

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -290,6 +290,14 @@ d
 				`SELECT * from d.t`: {{"1", "STR"}, {"2", "NULL"}, {"NULL", ","}},
 			},
 		},
+
+		// Error
+		{
+			name:   "unsupported import format",
+			create: `b bytes`,
+			typ:    "NOPE",
+			err:    `unsupported import format`,
+		},
 	}
 
 	var dataString string


### PR DESCRIPTION
This allows us to add new formats without changing the grammar rules.

Release note: None