### PR TITLE
opt: avoid divide by zero in stats calculation

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -380,7 +380,7 @@ func (sb *statisticsBuilder) selectivityFromDistinctCounts(
 func (sb *statisticsBuilder) applySelectivityToColStat(
 	colStat *props.ColumnStatistic, inputRows float64,
 ) {
-	if sb.s.Selectivity == 0 {
+	if sb.s.Selectivity == 0 || colStat.DistinctCount == 0 {
 		colStat.DistinctCount = 0
 		return
 	}

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -219,3 +219,163 @@ project
            └── lt [type=bool, outer=(3), constraints=(/3: (/NULL - /9]; tight)]
                 ├── variable: idx.z [type=int, outer=(3)]
                 └── const: 10 [type=int]
+
+# Regression: certain queries could cause a NaN expected number of rows via a divide-by-zero.
+exec-ddl
+CREATE TABLE tab0(pk INTEGER PRIMARY KEY, col0 INTEGER, col1 FLOAT, col2 TEXT, col3 INTEGER, col4 FLOAT, col5 TEXT)
+----
+TABLE tab0
+ ├── pk int not null
+ ├── col0 int
+ ├── col1 float
+ ├── col2 string
+ ├── col3 int
+ ├── col4 float
+ ├── col5 string
+ └── INDEX primary
+      └── pk int not null
+
+opt
+SELECT pk FROM tab0 WHERE
+  col0 = 1 AND
+  col0 = 2 AND
+  (col0 = 1 OR col0 IN (SELECT col3 FROM tab0)) AND
+  (col0 = 1 OR col0 IN (SELECT col3 FROM tab0))
+----
+project
+ ├── columns: pk:1(int!null)
+ ├── stats: [rows=0]
+ ├── keys: (1)
+ └── select
+      ├── columns: tab0.pk:1(int!null) tab0.col0:2(int) case:27(bool)
+      ├── stats: [rows=0]
+      ├── keys: (1)
+      ├── project
+      │    ├── columns: case:27(bool) tab0.pk:1(int!null) tab0.col0:2(int)
+      │    ├── stats: [rows=0]
+      │    ├── keys: (1)
+      │    ├── group-by
+      │    │    ├── columns: tab0.pk:1(int!null) tab0.col0:2(int) bool_or:26(bool)
+      │    │    ├── grouping columns: tab0.pk:1(int!null)
+      │    │    ├── stats: [rows=0, distinct(1)=0]
+      │    │    ├── keys: (1)
+      │    │    ├── left-join
+      │    │    │    ├── columns: tab0.pk:1(int!null) tab0.col0:2(int) tab0.col3:19(int) case:24(bool) notnull:25(bool)
+      │    │    │    ├── stats: [rows=0, distinct(1)=0]
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: tab0.pk:1(int!null) tab0.col0:2(int) case:24(bool)
+      │    │    │    │    ├── stats: [rows=0, distinct(1)=0]
+      │    │    │    │    ├── keys: (1)
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: case:24(bool) tab0.pk:1(int!null) tab0.col0:2(int)
+      │    │    │    │    │    ├── stats: [rows=0, distinct(1)=0]
+      │    │    │    │    │    ├── keys: (1)
+      │    │    │    │    │    ├── group-by
+      │    │    │    │    │    │    ├── columns: tab0.pk:1(int!null) tab0.col0:2(int) bool_or:23(bool)
+      │    │    │    │    │    │    ├── grouping columns: tab0.pk:1(int!null)
+      │    │    │    │    │    │    ├── stats: [rows=0, distinct(1)=0]
+      │    │    │    │    │    │    ├── keys: (1)
+      │    │    │    │    │    │    ├── left-join
+      │    │    │    │    │    │    │    ├── columns: tab0.pk:1(int!null) tab0.col0:2(int) tab0.col3:12(int) notnull:22(bool)
+      │    │    │    │    │    │    │    ├── stats: [rows=0, distinct(1)=0]
+      │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │    ├── columns: tab0.pk:1(int!null) tab0.col0:2(int)
+      │    │    │    │    │    │    │    │    ├── stats: [rows=0, distinct(1)=0]
+      │    │    │    │    │    │    │    │    ├── keys: (1)
+      │    │    │    │    │    │    │    │    ├── scan tab0
+      │    │    │    │    │    │    │    │    │    ├── columns: tab0.pk:1(int!null) tab0.col0:2(int)
+      │    │    │    │    │    │    │    │    │    ├── stats: [rows=1000, distinct(1)=1000]
+      │    │    │    │    │    │    │    │    │    └── keys: (1)
+      │    │    │    │    │    │    │    │    └── filters [type=bool, outer=(2), constraints=(contradiction; tight)]
+      │    │    │    │    │    │    │    │         ├── eq [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
+      │    │    │    │    │    │    │    │         │    ├── variable: tab0.col0 [type=int, outer=(2)]
+      │    │    │    │    │    │    │    │         │    └── const: 1 [type=int]
+      │    │    │    │    │    │    │    │         └── eq [type=bool, outer=(2), constraints=(/2: [/2 - /2]; tight)]
+      │    │    │    │    │    │    │    │              ├── variable: tab0.col0 [type=int, outer=(2)]
+      │    │    │    │    │    │    │    │              └── const: 2 [type=int]
+      │    │    │    │    │    │    │    ├── project
+      │    │    │    │    │    │    │    │    ├── columns: notnull:22(bool) tab0.col3:12(int)
+      │    │    │    │    │    │    │    │    ├── stats: [rows=1000]
+      │    │    │    │    │    │    │    │    ├── scan tab0
+      │    │    │    │    │    │    │    │    │    ├── columns: tab0.col3:12(int)
+      │    │    │    │    │    │    │    │    │    └── stats: [rows=1000]
+      │    │    │    │    │    │    │    │    └── projections [outer=(12)]
+      │    │    │    │    │    │    │    │         └── is-not [type=bool, outer=(12)]
+      │    │    │    │    │    │    │    │              ├── variable: tab0.col3 [type=int, outer=(12)]
+      │    │    │    │    │    │    │    │              └── null [type=unknown]
+      │    │    │    │    │    │    │    └── filters [type=bool, outer=(2,12)]
+      │    │    │    │    │    │    │         └── is-not [type=bool, outer=(2,12)]
+      │    │    │    │    │    │    │              ├── eq [type=bool, outer=(2,12)]
+      │    │    │    │    │    │    │              │    ├── variable: tab0.col0 [type=int, outer=(2)]
+      │    │    │    │    │    │    │              │    └── variable: tab0.col3 [type=int, outer=(12)]
+      │    │    │    │    │    │    │              └── false [type=bool]
+      │    │    │    │    │    │    └── aggregations [outer=(2,22)]
+      │    │    │    │    │    │         ├── bool-or [type=bool, outer=(22)]
+      │    │    │    │    │    │         │    └── variable: notnull [type=bool, outer=(22)]
+      │    │    │    │    │    │         └── any-not-null [type=int, outer=(2)]
+      │    │    │    │    │    │              └── variable: tab0.col0 [type=int, outer=(2)]
+      │    │    │    │    │    └── projections [outer=(1,2,23)]
+      │    │    │    │    │         └── case [type=bool, outer=(2,23)]
+      │    │    │    │    │              ├── true [type=bool]
+      │    │    │    │    │              ├── when [type=bool, outer=(2,23)]
+      │    │    │    │    │              │    ├── and [type=bool, outer=(2,23)]
+      │    │    │    │    │              │    │    ├── variable: bool_or [type=bool, outer=(23)]
+      │    │    │    │    │              │    │    └── is-not [type=bool, outer=(2)]
+      │    │    │    │    │              │    │         ├── variable: tab0.col0 [type=int, outer=(2)]
+      │    │    │    │    │              │    │         └── null [type=unknown]
+      │    │    │    │    │              │    └── true [type=bool]
+      │    │    │    │    │              ├── when [type=bool, outer=(23)]
+      │    │    │    │    │              │    ├── is [type=bool, outer=(23)]
+      │    │    │    │    │              │    │    ├── variable: bool_or [type=bool, outer=(23)]
+      │    │    │    │    │              │    │    └── null [type=unknown]
+      │    │    │    │    │              │    └── false [type=bool]
+      │    │    │    │    │              └── null [type=unknown]
+      │    │    │    │    └── filters [type=bool, outer=(2,24)]
+      │    │    │    │         └── or [type=bool, outer=(2,24)]
+      │    │    │    │              ├── eq [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
+      │    │    │    │              │    ├── variable: tab0.col0 [type=int, outer=(2)]
+      │    │    │    │              │    └── const: 1 [type=int]
+      │    │    │    │              └── variable: case [type=bool, outer=(24)]
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: notnull:25(bool) tab0.col3:19(int)
+      │    │    │    │    ├── stats: [rows=1000]
+      │    │    │    │    ├── scan tab0
+      │    │    │    │    │    ├── columns: tab0.col3:19(int)
+      │    │    │    │    │    └── stats: [rows=1000]
+      │    │    │    │    └── projections [outer=(19)]
+      │    │    │    │         └── is-not [type=bool, outer=(19)]
+      │    │    │    │              ├── variable: tab0.col3 [type=int, outer=(19)]
+      │    │    │    │              └── null [type=unknown]
+      │    │    │    └── filters [type=bool, outer=(2,19)]
+      │    │    │         └── is-not [type=bool, outer=(2,19)]
+      │    │    │              ├── eq [type=bool, outer=(2,19)]
+      │    │    │              │    ├── variable: tab0.col0 [type=int, outer=(2)]
+      │    │    │              │    └── variable: tab0.col3 [type=int, outer=(19)]
+      │    │    │              └── false [type=bool]
+      │    │    └── aggregations [outer=(2,25)]
+      │    │         ├── bool-or [type=bool, outer=(25)]
+      │    │         │    └── variable: notnull [type=bool, outer=(25)]
+      │    │         └── any-not-null [type=int, outer=(2)]
+      │    │              └── variable: tab0.col0 [type=int, outer=(2)]
+      │    └── projections [outer=(1,2,26)]
+      │         └── case [type=bool, outer=(2,26)]
+      │              ├── true [type=bool]
+      │              ├── when [type=bool, outer=(2,26)]
+      │              │    ├── and [type=bool, outer=(2,26)]
+      │              │    │    ├── variable: bool_or [type=bool, outer=(26)]
+      │              │    │    └── is-not [type=bool, outer=(2)]
+      │              │    │         ├── variable: tab0.col0 [type=int, outer=(2)]
+      │              │    │         └── null [type=unknown]
+      │              │    └── true [type=bool]
+      │              ├── when [type=bool, outer=(26)]
+      │              │    ├── is [type=bool, outer=(26)]
+      │              │    │    ├── variable: bool_or [type=bool, outer=(26)]
+      │              │    │    └── null [type=unknown]
+      │              │    └── false [type=bool]
+      │              └── null [type=unknown]
+      └── filters [type=bool, outer=(2,27)]
+           └── or [type=bool, outer=(2,27)]
+                ├── eq [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
+                │    ├── variable: tab0.col0 [type=int, outer=(2)]
+                │    └── const: 1 [type=int]
+                └── variable: case [type=bool, outer=(27)]


### PR DESCRIPTION
This was unearthed by a nightly test failure, and I was unable to find a
smaller repro than the one I got to just by reducing the nightly test
that failed. Suggestions for a smaller test case welcome.

The problem here was that calculating the selectivity was ending up
doing a divide-by-zero, which caused the row count to be NaN, which in
turn caused the cost to be +Inf, which messes up the plan selection.

Release note: None