### PR TITLE
distsqlrun: remove duplicate hashmap lookup

### DIFF
--- a/pkg/sql/distsqlrun/hash_row_container.go
+++ b/pkg/sql/distsqlrun/hash_row_container.go
@@ -218,7 +218,7 @@ func (h *hashMemRowContainer) addRowToBucket(
 		return err
 	}
 
-	_, ok := h.buckets[string(encoded)]
+	bucket, ok := h.buckets[string(encoded)]
 
 	usage := sizeOfRowIdx
 	if !ok {
@@ -230,7 +230,7 @@ func (h *hashMemRowContainer) addRowToBucket(
 		return err
 	}
 
-	h.buckets[string(encoded)] = append(h.buckets[string(encoded)], rowIdx)
+	h.buckets[string(encoded)] = append(bucket, rowIdx)
 	return nil
 }
 


### PR DESCRIPTION
```
name                                 old time/op    new time/op    delta
HashJoiner/spill=false/rows=65536-8    72.6ms ± 2%    68.8ms ± 2%  -5.27%  (p=0.000 n=10+10)

name                                 old speed      new speed      delta
HashJoiner/spill=false/rows=65536-8  14.5MB/s ± 2%  15.3MB/s ± 2%  +5.55%  (p=0.000 n=10+10)

name                                 old alloc/op   new alloc/op   delta
HashJoiner/spill=false/rows=65536-8    22.3MB ± 0%    22.3MB ± 0%    ~     (p=0.853 n=10+10)

name                                 old allocs/op  new allocs/op  delta
HashJoiner/spill=false/rows=65536-8      142k ± 0%      142k ± 0%    ~     (p=0.781 n=10+10)
```

Release note: None