### PR TITLE
jobs: stop storing stale jobs.Record in jobs.Job

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -1075,7 +1075,7 @@ type backupResumer struct {
 func (b *backupResumer) Resume(
 	ctx context.Context, job *jobs.Job, phs interface{}, resultsCh chan<- tree.Datums,
 ) error {
-	details := job.Record.Details.(jobspb.BackupDetails)
+	details := job.Details().(jobspb.BackupDetails)
 	p := phs.(sql.PlanHookState)
 
 	if len(details.BackupDescriptor) == 0 {
@@ -1132,7 +1132,7 @@ func (b *backupResumer) OnTerminal(
 ) {
 	// Attempt to delete BACKUP-CHECKPOINT.
 	if err := func() error {
-		details := job.Record.Details.(jobspb.BackupDetails)
+		details := job.Details().(jobspb.BackupDetails)
 		conf, err := storageccl.ExportStorageConfFromURI(details.URI)
 		if err != nil {
 			return err

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -231,7 +231,7 @@ func (b *changefeedResumer) Resume(
 	ctx context.Context, job *jobs.Job, planHookState interface{}, startedCh chan<- tree.Datums,
 ) error {
 	execCfg := planHookState.(sql.PlanHookState).ExecCfg()
-	details := job.Record.Details.(jobspb.ChangefeedDetails)
+	details := job.Details().(jobspb.ChangefeedDetails)
 	progress := job.Progress().Details.(*jobspb.Progress_Changefeed).Changefeed
 	return runChangefeedFlow(ctx, execCfg, details, *progress, startedCh, job.Progressed)
 }

--- a/pkg/ccl/importccl/sst_writer_proc.go
+++ b/pkg/ccl/importccl/sst_writer_proc.go
@@ -100,7 +100,7 @@ func (sp *sstWriter) Run(ctx context.Context, wg *sync.WaitGroup) {
 		if err != nil {
 			return err
 		}
-		samples := job.Payload().Details.(*jobspb.Payload_Import).Import.Samples
+		samples := job.Details().(jobspb.ImportDetails).Samples
 
 		// Sort incoming KVs, which will be from multiple spans, into a single
 		// RocksDB instance.

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -551,7 +551,7 @@ func (sc *SchemaChanger) backfillIndexes(
 ) error {
 	// Pick a read timestamp for our index backfill, or reuse the previously
 	// stored one.
-	details := *sc.job.Payload().Details.(*jobspb.Payload_SchemaChange).SchemaChange
+	details := sc.job.Details().(jobspb.SchemaChangeDetails)
 	if details.ReadAsOf == (hlc.Timestamp{}) {
 		details.ReadAsOf = sc.clock.Now()
 		if err := sc.job.SetDetails(ctx, details); err != nil {

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -244,7 +244,7 @@ func LoadCSV(
 
 	// Determine if we need to run the sampling plan or not.
 
-	details := job.Record.Details.(jobspb.ImportDetails)
+	details := job.Details().(jobspb.ImportDetails)
 	samples := details.Samples
 	var parsedTables map[sqlbase.ID]*sqlbase.TableDescriptor
 	if samples == nil {
@@ -460,7 +460,7 @@ func LoadCSV(
 		func(ts hlc.Timestamp) {},
 	)
 
-	defer log.VEventf(ctx, 1, "finished job %s", job.Record.Description)
+	defer log.VEventf(ctx, 1, "finished job %s", job.Payload().Description)
 	return db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		dsp.Run(&planCtx, txn, &p, recv, evalCtx)
 		return resultRows.Err()
@@ -594,7 +594,7 @@ func (dsp *DistSQLPlanner) loadCSVSamplingPlan(
 		nil, /* txn - the flow does not read or write the database */
 		func(ts hlc.Timestamp) {},
 	)
-	log.VEventf(ctx, 1, "begin sampling phase of job %s", job.Record.Description)
+	log.VEventf(ctx, 1, "begin sampling phase of job %s", job.Payload().Description)
 	// Clear the stage 2 data in case this function is ever restarted (it shouldn't be).
 	samples = nil
 	dsp.Run(planCtx, nil, &p, recv, evalCtx)
@@ -602,7 +602,7 @@ func (dsp *DistSQLPlanner) loadCSVSamplingPlan(
 		return nil, nil, err
 	}
 
-	log.VEventf(ctx, 1, "generated %d splits; begin routing for job %s", len(samples), job.Record.Description)
+	log.VEventf(ctx, 1, "generated %d splits; begin routing for job %s", len(samples), job.Payload().Description)
 
 	return samples, parsedTables, nil
 }

--- a/pkg/sql/distsqlrun/backfiller.go
+++ b/pkg/sql/distsqlrun/backfiller.go
@@ -154,9 +154,9 @@ func GetResumeSpansFromJob(
 	if err != nil {
 		return nil, errors.Wrapf(err, "can't find job %d", jobID)
 	}
-	details, ok := job.Record.Details.(jobspb.SchemaChangeDetails)
+	details, ok := job.Details().(jobspb.SchemaChangeDetails)
 	if !ok {
-		return nil, errors.Errorf("expected SchemaChangeDetails job type, got %T", job.Record.Details)
+		return nil, errors.Errorf("expected SchemaChangeDetails job type, got %T", job.Details())
 	}
 	return details.ResumeSpanList[mutationIdx].ResumeSpans, nil
 }
@@ -190,9 +190,9 @@ func SetResumeSpansInJob(
 		return errors.Wrapf(err, "can't find job %d", jobID)
 	}
 
-	details, ok := job.Record.Details.(jobspb.SchemaChangeDetails)
+	details, ok := job.Details().(jobspb.SchemaChangeDetails)
 	if !ok {
-		return errors.Errorf("expected SchemaChangeDetails job type, got %T", job.Record.Details)
+		return errors.Errorf("expected SchemaChangeDetails job type, got %T", job.Details())
 	}
 	details.ResumeSpanList[mutationIdx].ResumeSpans = spans
 	return job.WithTxn(txn).SetDetails(ctx, details)

--- a/pkg/sql/jobs/jobspb/wrap.go
+++ b/pkg/sql/jobs/jobspb/wrap.go
@@ -17,8 +17,6 @@ package jobspb
 import (
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // Details is a marker interface for job details proto structs.
@@ -86,47 +84,39 @@ func WrapProgressDetails(details ProgressDetails) interface {
 
 // UnwrapDetails returns the details object stored within the payload's Details
 // field, discarding the protobuf wrapper struct.
-//
-// Unlike in WrapPayloadDetails, an unknown details type may simply indicate
-// that the Payload originated on a node aware of more details types, and so the
-// error is returned to the caller.
-func (p *Payload) UnwrapDetails() (Details, error) {
+func (p *Payload) UnwrapDetails() Details {
 	switch d := p.Details.(type) {
 	case *Payload_Backup:
-		return *d.Backup, nil
+		return *d.Backup
 	case *Payload_Restore:
-		return *d.Restore, nil
+		return *d.Restore
 	case *Payload_SchemaChange:
-		return *d.SchemaChange, nil
+		return *d.SchemaChange
 	case *Payload_Import:
-		return *d.Import, nil
+		return *d.Import
 	case *Payload_Changefeed:
-		return *d.Changefeed, nil
+		return *d.Changefeed
 	default:
-		return nil, errors.Errorf("jobspb.Payload: unsupported details type %T", d)
+		return nil
 	}
 }
 
 // UnwrapDetails returns the details object stored within the progress' Details
 // field, discarding the protobuf wrapper struct.
-//
-// Unlike in WrapProgressDetails, an unknown details type may simply indicate
-// that the Payload originated on a node aware of more details types, and so the
-// error is returned to the caller.
-func (p *Progress) UnwrapDetails() (ProgressDetails, error) {
+func (p *Progress) UnwrapDetails() ProgressDetails {
 	switch d := p.Details.(type) {
 	case *Progress_Backup:
-		return *d.Backup, nil
+		return *d.Backup
 	case *Progress_Restore:
-		return *d.Restore, nil
+		return *d.Restore
 	case *Progress_SchemaChange:
-		return *d.SchemaChange, nil
+		return *d.SchemaChange
 	case *Progress_Import:
-		return *d.Import, nil
+		return *d.Import
 	case *Progress_Changefeed:
-		return *d.Changefeed, nil
+		return *d.Changefeed
 	default:
-		return nil, errors.Errorf("jobs.Progress: unsupported details type %T", d)
+		return nil
 	}
 }
 


### PR DESCRIPTION
For historical reasons, the jobs.Record struct used to create a new job
remained publicly accessible after job creation, as jobs.Job.Record,
even though the data it contained might have been changed in the
underlying system.jobs row.

Luckily, all information in jobs.Job.Record is also available in the job
payload, accessible via jobs.Job.Payload(), and the payload *is* kept up
to date.

This commit refactors job initialization so that we do not need to keep
the job record around, forcing all users through the always up-to-date
job payload.

Release note: None