### PR TITLE
distsql: fix swapped memoryMonitor and diskMonitor in sortAllProcessor

### DIFF
--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -177,8 +177,8 @@ func newSortAllProcessor(
 			input.OutputTypes(),
 			proc.evalCtx,
 			flowCtx.TempStorage,
-			flowCtx.diskMonitor,
 			memMonitor,
+			flowCtx.diskMonitor,
 		)
 		proc.rows = &rc
 	} else {


### PR DESCRIPTION
This fixes a typo from #26357 that reversed the order
of a memoryMonitor and a diskMonitor in a call to
`diskBackedRowContainer.init`. This was causing issues
and preventing a sortAllProcessor from spilling to disk.

Release note: None