### PR TITLE
distsqlrun: remove local sort implementation

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1077,10 +1077,7 @@ func (dsp *DistSQLPlanner) selectRenders(
 // addSorters adds sorters corresponding to a sortNode and updates the plan to
 // reflect the sort node.
 func (dsp *DistSQLPlanner) addSorters(p *physicalPlan, n *sortNode) {
-
-	matchLen := planPhysicalProps(n.plan).computeMatch(n.ordering)
-
-	if matchLen < len(n.ordering) {
+	if n.matchLen < len(n.ordering) {
 		// Sorting is needed; we add a stage of sorting processors.
 		ordering := distsqlrun.ConvertToMappedSpecOrdering(n.ordering, p.planToStreamColMap)
 
@@ -1088,7 +1085,7 @@ func (dsp *DistSQLPlanner) addSorters(p *physicalPlan, n *sortNode) {
 			distsqlrun.ProcessorCoreUnion{
 				Sorter: &distsqlrun.SorterSpec{
 					OutputOrdering:   ordering,
-					OrderingMatchLen: uint32(matchLen),
+					OrderingMatchLen: uint32(n.matchLen),
 				},
 			},
 			distsqlrun.PostProcessSpec{},

--- a/pkg/sql/distsqlrun/data.go
+++ b/pkg/sql/distsqlrun/data.go
@@ -59,11 +59,18 @@ func ConvertToMappedSpecOrdering(
 			}
 		}
 		specOrdering.Columns[i].ColIdx = uint32(colIdx)
-		if c.Direction == encoding.Ascending {
-			specOrdering.Columns[i].Direction = Ordering_Column_ASC
-		} else {
-			specOrdering.Columns[i].Direction = Ordering_Column_DESC
-		}
+		specOrdering.Columns[i].Direction = ConvertOrdering(c.Direction)
 	}
 	return specOrdering
+}
+
+func ConvertOrdering(direction encoding.Direction) Ordering_Column_Direction {
+	switch direction {
+	case encoding.Ascending:
+		return Ordering_Column_ASC
+	case encoding.Descending:
+		return Ordering_Column_DESC
+	default:
+		panic(fmt.Sprintf("Invalid direction %d", direction))
+	}
 }

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -941,7 +941,7 @@ func newProcessor(
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
-		return newSorter(ctx, flowCtx, processorID, core.Sorter, inputs[0], post, outputs[0])
+		return NewSorter(ctx, flowCtx, processorID, core.Sorter, inputs[0], post, outputs[0])
 	}
 	if core.Distinct != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -367,24 +367,7 @@ func (ds *ServerImpl) setupFlow(
 			*req.EvalContext.SeqState.LastSeqIncremented)
 	}
 
-	// TODO(radu): we should sanity check some of these fields.
-	flowCtx := FlowCtx{
-		Settings:       ds.Settings,
-		AmbientContext: ds.AmbientContext,
-		stopper:        ds.Stopper,
-		id:             req.Flow.FlowID,
-		EvalCtx:        evalCtx,
-		rpcCtx:         ds.RPCContext,
-		gossip:         ds.Gossip,
-		txn:            txn,
-		clientDB:       ds.DB,
-		executor:       ds.Executor,
-		testingKnobs:   ds.TestingKnobs,
-		nodeID:         nodeID,
-		TempStorage:    ds.TempStorage,
-		diskMonitor:    ds.DiskMonitor,
-		JobRegistry:    ds.ServerConfig.JobRegistry,
-	}
+	flowCtx := ds.MakeFlowContext(req.Flow.FlowID, evalCtx, txn, nodeID)
 
 	ctx = flowCtx.AnnotateCtx(ctx)
 
@@ -397,6 +380,27 @@ func (ds *ServerImpl) setupFlow(
 		return ctx, nil, err
 	}
 	return ctx, f, nil
+}
+
+func (ds *ServerImpl) MakeFlowContext(id FlowID, evalCtx tree.EvalContext, txn *client.Txn, nodeID roachpb.NodeID) FlowCtx {
+	// TODO(radu): we should sanity check some of these fields.
+	return FlowCtx{
+		Settings:       ds.Settings,
+		AmbientContext: ds.AmbientContext,
+		stopper:        ds.Stopper,
+		id:             id,
+		EvalCtx:        evalCtx,
+		rpcCtx:         ds.RPCContext,
+		gossip:         ds.Gossip,
+		txn:            txn,
+		clientDB:       ds.DB,
+		executor:       ds.Executor,
+		testingKnobs:   ds.TestingKnobs,
+		nodeID:         nodeID,
+		TempStorage:    ds.TempStorage,
+		diskMonitor:    ds.DiskMonitor,
+		JobRegistry:    ds.ServerConfig.JobRegistry,
+	}
 }
 
 // SetupSyncFlow sets up a synchronous flow, connecting the sync response

--- a/pkg/sql/distsqlrun/sorter_test.go
+++ b/pkg/sql/distsqlrun/sorter_test.go
@@ -316,7 +316,7 @@ func TestSorter(t *testing.T) {
 					var s Processor
 					if !testingForceSortAll {
 						var err error
-						s, err = newSorter(context.Background(), &flowCtx, 0 /* processorID */, &c.spec, in, &c.post, out)
+						s, err = NewSorter(context.Background(), &flowCtx, 0 /* processorID */, &c.spec, in, &c.post, out)
 						if err != nil {
 							t.Fatal(err)
 						}
@@ -385,7 +385,7 @@ func BenchmarkSortAll(b *testing.B) {
 			b.SetBytes(int64(numRows * numCols * 8))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				s, err := newSorter(
+				s, err := NewSorter(
 					context.Background(), &flowCtx, 0 /* processorID */, &spec, input, &post, &RowDisposer{},
 				)
 				if err != nil {
@@ -424,7 +424,7 @@ func BenchmarkSortLimit(b *testing.B) {
 				b.SetBytes(int64(numRows * numCols * 8))
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					s, err := newSorter(
+					s, err := NewSorter(
 						context.Background(), &flowCtx, 0 /* processorID */, &spec, input, &post, &RowDisposer{},
 					)
 					if err != nil {
@@ -471,7 +471,7 @@ func BenchmarkSortChunks(b *testing.B) {
 				b.SetBytes(int64(numRows * numCols * 8))
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					s, err := newSorter(context.Background(), &flowCtx, 0 /* processorID */, &spec, input, &post, &RowDisposer{})
+					s, err := NewSorter(context.Background(), &flowCtx, 0 /* processorID */, &spec, input, &post, &RowDisposer{})
 					if err != nil {
 						b.Fatal(err)
 					}

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -310,6 +310,7 @@ func doExpandPlan(
 		// ordering.
 		match := planPhysicalProps(n.plan).computeMatch(n.ordering)
 		n.needSort = (match < len(n.ordering))
+		n.matchLen = match
 
 	case *distinctNode:
 		plan, err = expandDistinctNode(ctx, p, params, n)

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -74,11 +74,10 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 
 	case *sortNode:
 		if n.needSort && numRows != math.MaxInt64 {
-			v := p.newSortValues(n.ordering, planColumns(n.plan), int(numRows))
 			if soft {
-				n.run.sortStrategy = newIterativeSortStrategy(v)
+				n.strategy = "iterative"
 			} else {
-				n.run.sortStrategy = newSortTopKStrategy(v, numRows)
+				n.strategy = fmt.Sprintf("top %d", numRows)
 			}
 		}
 		if n.needSort {

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
@@ -32,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 type planMaker interface {
@@ -96,6 +98,14 @@ func (r *runParams) EvalContext() *tree.EvalContext {
 // SessionData gives convenient access to the runParam's SessionData.
 func (r *runParams) SessionData() *sessiondata.SessionData {
 	return r.extendedEvalCtx.SessionData
+}
+
+func (r *runParams) LocalFlowCtx() distsqlrun.FlowCtx {
+	flowID := distsqlrun.FlowID{UUID: uuid.MakeV4()}
+	return r.extendedEvalCtx.ExecCfg.DistSQLSrv.MakeFlowContext(
+		flowID, r.extendedEvalCtx.EvalContext,
+		r.extendedEvalCtx.Txn, r.extendedEvalCtx.NodeID,
+	)
 }
 
 // planNode defines the interface for executing a query or portion of a query.

--- a/pkg/sql/row_source_to_plan_node.go
+++ b/pkg/sql/row_source_to_plan_node.go
@@ -38,10 +38,10 @@ type rowSourceToPlanNode struct {
 
 var _ planNode = &rowSourceToPlanNode{}
 
-func makeRowSourceToPlanNode(s distsqlrun.RowSource) *rowSourceToPlanNode {
+func makeRowSourceToPlanNode(s distsqlrun.RowSource) rowSourceToPlanNode {
 	row := make(tree.Datums, len(s.OutputTypes()))
 
-	return &rowSourceToPlanNode{
+	return rowSourceToPlanNode{
 		source:   s,
 		datumRow: row,
 	}

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -15,12 +15,11 @@
 package sql
 
 import (
-	"container/heap"
 	"context"
-	"sort"
 
 	"github.com/pkg/errors"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -32,13 +31,17 @@ import (
 // sortNode represents a node that sorts the rows returned by its
 // sub-node.
 type sortNode struct {
+	rowSourceToPlanNode
+
 	plan     planNode
 	columns  sqlbase.ResultColumns
 	ordering sqlbase.ColumnOrdering
 
-	needSort bool
+	// strategy is a human-readable summary of the strategy this sorter will use.
+	strategy string
 
-	run sortRun
+	needSort bool
+	matchLen int
 }
 
 // orderBy constructs a sortNode based on the ORDER BY clause.
@@ -215,88 +218,37 @@ func (p *planner) orderBy(
 	return &sortNode{columns: columns, ordering: ordering}, nil
 }
 
-// sortRun contains the run-time state of sortNode during local
-// execution.
-type sortRun struct {
-	sortStrategy sortingStrategy
-	valueIter    valueIterator
-}
+func (n *sortNode) startExec(params runParams) error {
+	flowCtx := params.LocalFlowCtx()
 
-func (n *sortNode) Next(params runParams) (bool, error) {
-	cancelChecker := params.p.cancelChecker
+	ordering := distsqlrun.Ordering{
+		Columns: make([]distsqlrun.Ordering_Column, len(n.ordering)),
+	}
+	for i := range ordering.Columns {
+		ordering.Columns[i].ColIdx = uint32(n.ordering[i].ColIdx)
+		ordering.Columns[i].Direction = distsqlrun.ConvertOrdering(n.ordering[i].Direction)
+	}
+	spec := &distsqlrun.SorterSpec{
+		OutputOrdering:   ordering,
+		OrderingMatchLen: uint32(n.matchLen),
+	}
+	input, err := makePlanNodeToRowSource(n.plan, params)
+	if err != nil {
+		return err
+	}
+	post := &distsqlrun.PostProcessSpec{} // post is not used as we only use the processor for the core distinct logic.
+	var output distsqlrun.RowReceiver     // output is never used as distinct is only run as a RowSource.
 
-	for n.needSort {
-		if vn, ok := n.plan.(*valuesNode); ok {
-			// The plan we wrap is already a values node. Just sort it.
-			v := &sortValues{
-				ordering: n.ordering,
-				rows:     vn.rows,
-				evalCtx:  params.EvalContext(),
-			}
-			n.run.sortStrategy = newSortAllStrategy(v)
-			n.run.sortStrategy.Finish(params.ctx, cancelChecker)
-			// Sorting is done. Relinquish the reference on the row container,
-			// so as to avoid closing it twice.
-			n.run.sortStrategy = nil
-			// Fall through -- the remainder of the work is done by the
-			// valuesNode itself.
-			n.needSort = false
-			break
-		} else if n.run.sortStrategy == nil {
-			v := params.p.newSortValues(n.ordering, planColumns(n.plan), 0 /*capacity*/)
-			n.run.sortStrategy = newSortAllStrategy(v)
-		}
-
-		if err := cancelChecker.Check(); err != nil {
-			return false, err
-		}
-
-		// TODO(andrei): If we're scanning an index with a prefix matching an
-		// ordering prefix, we should only accumulate values for equal fields
-		// in this prefix, then sort the accumulated chunk and output.
-		// TODO(irfansharif): matching column ordering speed-ups from distsql,
-		// when implemented, could be repurposed and used here.
-		next, err := n.plan.Next(params)
-		if err != nil {
-			return false, err
-		}
-		if !next {
-			n.run.sortStrategy.Finish(params.ctx, cancelChecker)
-			n.run.valueIter = n.run.sortStrategy
-			n.needSort = false
-			break
-		}
-
-		values := n.plan.Values()
-		if err := n.run.sortStrategy.Add(params.ctx, values); err != nil {
-			return false, err
-		}
+	sorter, err := distsqlrun.NewSorter(params.ctx, &flowCtx, 0, spec, input, post, output)
+	if err != nil {
+		return err
 	}
 
-	// Check again, in case sort returned early due to a cancellation.
-	if err := cancelChecker.Check(); err != nil {
-		return false, err
-	}
+	n.rowSourceToPlanNode = makeRowSourceToPlanNode(sorter)
 
-	if n.run.valueIter == nil {
-		n.run.valueIter = n.plan
-	}
-	return n.run.valueIter.Next(params)
-}
+	n.rowSourceToPlanNode.source.Start(params.ctx)
 
-func (n *sortNode) Values() tree.Datums {
-	// If an ordering expression was used the number of columns in each row might
-	// differ from the number of columns requested, so trim the result.
-	return n.run.valueIter.Values()[:len(n.columns)]
-}
-
-func (n *sortNode) Close(ctx context.Context) {
-	n.plan.Close(ctx)
-	if n.run.sortStrategy != nil {
-		n.run.sortStrategy.Close(ctx)
-	}
-	// n.run.valueIter points to either n.plan or n.run.sortStrategy and thus has already
-	// been closed.
+	return nil
 }
 
 func ensureColumnOrderable(c sqlbase.ResultColumn) error {
@@ -501,341 +453,4 @@ func (p *planner) colIndex(numOriginalCols int, expr tree.Expr, context string) 
 		ord--
 	}
 	return int(ord), nil
-}
-
-// valueIterator provides iterative access to a value source's values and
-// debug values. It is a subset of the planNode interface, so all methods
-// should conform to the comments expressed in the planNode definition.
-type valueIterator interface {
-	Next(runParams) (bool, error)
-	Values() tree.Datums
-	Close(ctx context.Context)
-}
-
-type sortingStrategy interface {
-	valueIterator
-	// Add adds a single value to the sortingStrategy. It guarantees that
-	// if it decided to store the provided value, that it will make a deep
-	// copy of it.
-	Add(context.Context, tree.Datums) error
-	// Finish terminates the sorting strategy, allowing for postprocessing
-	// after all values have been provided to the strategy. The method should
-	// not be called more than once, and should only be called after all Add
-	// calls have occurred.
-	Finish(context.Context, *sqlbase.CancelChecker)
-}
-
-// sortAllStrategy reads in all values into the wrapped valuesNode and
-// uses sort.Sort to sort all values in-place. It has a worst-case time
-// complexity of O(n*log(n)) and a worst-case space complexity of O(n).
-//
-// The strategy is intended to be used when all values need to be sorted.
-type sortAllStrategy struct {
-	vNode *sortValues
-}
-
-func newSortAllStrategy(vNode *sortValues) sortingStrategy {
-	return &sortAllStrategy{
-		vNode: vNode,
-	}
-}
-
-func (ss *sortAllStrategy) Add(ctx context.Context, values tree.Datums) error {
-	_, err := ss.vNode.rows.AddRow(ctx, values)
-	return err
-}
-
-func (ss *sortAllStrategy) Finish(ctx context.Context, cancelChecker *sqlbase.CancelChecker) {
-	ss.vNode.SortAll(cancelChecker)
-}
-
-func (ss *sortAllStrategy) Next(params runParams) (bool, error) {
-	return ss.vNode.Next(params)
-}
-
-func (ss *sortAllStrategy) Values() tree.Datums {
-	return ss.vNode.Values()
-}
-
-func (ss *sortAllStrategy) Close(ctx context.Context) {
-	ss.vNode.Close(ctx)
-}
-
-// iterativeSortStrategy reads in all values into the wrapped sortValues
-// and turns the underlying slice into a min-heap. It then pops a value
-// off of the heap for each call to Next, meaning that it only needs to
-// sort the number of values needed, instead of the entire slice. If the
-// underlying value source provides n rows and the strategy produce only
-// k rows, it has a worst-case time complexity of O(n + k*log(n)) and a
-// worst-case space complexity of O(n).
-//
-// The strategy is intended to be used when an unknown number of values
-// need to be sorted, but that most likely not all values need to be sorted.
-type iterativeSortStrategy struct {
-	vNode      *sortValues
-	lastVal    tree.Datums
-	nextRowIdx int
-}
-
-func newIterativeSortStrategy(vNode *sortValues) sortingStrategy {
-	return &iterativeSortStrategy{
-		vNode: vNode,
-	}
-}
-
-func (ss *iterativeSortStrategy) Add(ctx context.Context, values tree.Datums) error {
-	_, err := ss.vNode.rows.AddRow(ctx, values)
-	return err
-}
-
-func (ss *iterativeSortStrategy) Finish(context.Context, *sqlbase.CancelChecker) {
-	ss.vNode.InitMinHeap()
-}
-
-func (ss *iterativeSortStrategy) Next(runParams) (bool, error) {
-	if ss.vNode.Len() == 0 {
-		return false, nil
-	}
-	ss.lastVal = ss.vNode.PopValues()
-	ss.nextRowIdx++
-	return true, nil
-}
-
-func (ss *iterativeSortStrategy) Values() tree.Datums {
-	return ss.lastVal
-}
-
-func (ss *iterativeSortStrategy) Close(ctx context.Context) {
-	ss.vNode.Close(ctx)
-}
-
-// sortTopKStrategy creates a max-heap in its wrapped sortValues and keeps
-// this heap populated with only the top k values seen. It accomplishes this
-// by comparing new values (before the deep copy) with the top of the heap.
-// If the new value is less than the current top, the top will be replaced
-// and the heap will be fixed. If not, the new value is dropped. When finished,
-// all values in the heap are popped, sorting the values correctly in-place.
-// It has a worst-case time complexity of O(n*log(k)) and a worst-case space
-// complexity of O(k).
-//
-// The strategy is intended to be used when exactly k values need to be sorted,
-// where k is known before sorting begins.
-//
-// TODO(nvanbenschoten): There are better algorithms that can achieve a sorted
-// top k in a worst-case time complexity of O(n + k*log(k)) while maintaining
-// a worst-case space complexity of O(k). For instance, the top k can be found
-// in linear time, and then this can be sorted in linearithmic time.
-type sortTopKStrategy struct {
-	vNode *sortValues
-	topK  int64
-}
-
-func newSortTopKStrategy(vNode *sortValues, topK int64) sortingStrategy {
-	ss := &sortTopKStrategy{
-		vNode: vNode,
-		topK:  topK,
-	}
-	ss.vNode.InitMaxHeap()
-	return ss
-}
-
-func (ss *sortTopKStrategy) Add(ctx context.Context, values tree.Datums) error {
-	switch {
-	case int64(ss.vNode.Len()) < ss.topK:
-		// The first k values all go into the max-heap.
-		if err := ss.vNode.PushValues(ctx, values); err != nil {
-			return err
-		}
-	case ss.vNode.ValuesLess(values, ss.vNode.rows.At(0)):
-		// Once the heap is full, only replace the top
-		// value if a new value is less than it. If so
-		// replace and fix the heap.
-		if err := ss.vNode.rows.Replace(ctx, 0, values); err != nil {
-			return err
-		}
-		heap.Fix(ss.vNode, 0)
-	}
-	return nil
-}
-
-func (ss *sortTopKStrategy) Finish(ctx context.Context, cancelChecker *sqlbase.CancelChecker) {
-	// Pop all values in the heap, resulting in the inverted ordering
-	// being sorted in reverse. Therefore, the slice is ordered correctly
-	// in-place.
-	for ss.vNode.Len() > 0 {
-		if cancelChecker.Check() != nil {
-			return
-		}
-		heap.Pop(ss.vNode)
-	}
-	ss.vNode.ResetLen()
-}
-
-func (ss *sortTopKStrategy) Next(params runParams) (bool, error) {
-	return ss.vNode.Next(params)
-}
-
-func (ss *sortTopKStrategy) Values() tree.Datums {
-	return ss.vNode.Values()
-}
-
-func (ss *sortTopKStrategy) Close(ctx context.Context) {
-	ss.vNode.Close(ctx)
-}
-
-// TODO(pmattis): If the result set is large, we might need to perform the
-// sort on disk. There is no point in doing this while we're buffering the
-// entire result set in memory. If/when we start streaming results back to
-// the client we should revisit.
-//
-// type onDiskSortStrategy struct{}
-
-// sortValues is a reduced form of valuesNode for use in a sortStrategy.
-type sortValues struct {
-	// invertSorting inverts the sorting predicate.
-	invertSorting bool
-	// ordering indicates the desired ordering of each column in the rows
-	ordering sqlbase.ColumnOrdering
-	// rows contains the columns during sorting.
-	rows *sqlbase.RowContainer
-
-	// evalCtx is needed because we use datum.Compare() which needs it,
-	// and the sort.Interface and heap.Interface do not allow
-	// introducing extra parameters into the Less() method.
-	evalCtx *tree.EvalContext
-
-	// rowsPopped is used for heaps, it indicates the number of rows
-	// that were "popped". These rows are still part of the underlying
-	// sqlbase.RowContainer, in the range [rows.Len()-n.rowsPopped,
-	// rows.Len).
-	rowsPopped int
-
-	// nextRow is used while iterating.
-	nextRow int
-}
-
-var _ valueIterator = &sortValues{}
-var _ sort.Interface = &sortValues{}
-var _ heap.Interface = &sortValues{}
-
-func (p *planner) newSortValues(
-	ordering sqlbase.ColumnOrdering, columns sqlbase.ResultColumns, capacity int,
-) *sortValues {
-	return &sortValues{
-		ordering: ordering,
-		rows: sqlbase.NewRowContainer(
-			p.EvalContext().Mon.MakeBoundAccount(),
-			sqlbase.ColTypeInfoFromResCols(columns),
-			capacity,
-		),
-		evalCtx: p.EvalContext(),
-	}
-}
-
-// Values implement the valuesIterator interface.
-func (n *sortValues) Values() tree.Datums {
-	return n.rows.At(n.nextRow - 1)
-}
-
-// Next implements the valuesIterator interface.
-func (n *sortValues) Next(runParams) (bool, error) {
-	if n.nextRow >= n.rows.Len() {
-		return false, nil
-	}
-	n.nextRow++
-	return true, nil
-}
-
-// Close implements the valuesIterator interface.
-func (n *sortValues) Close(ctx context.Context) {
-	n.rows.Close(ctx)
-}
-
-// Len implements the sort.Interface interface.
-func (n *sortValues) Len() int {
-	return n.rows.Len() - n.rowsPopped
-}
-
-// ValuesLess returns the comparison result between the two provided
-// Datums slices in the context of the sortValues ordering.
-func (n *sortValues) ValuesLess(ra, rb tree.Datums) bool {
-	return sqlbase.CompareDatums(n.ordering, n.evalCtx, ra, rb) < 0
-}
-
-// Less implements the sort.Interface interface.
-func (n *sortValues) Less(i, j int) bool {
-	// TODO(pmattis): An alternative to this type of field-based comparison would
-	// be to construct a sort-key per row using encodeTableKey(). Using a
-	// sort-key approach would likely fit better with a disk-based sort.
-	ra, rb := n.rows.At(i), n.rows.At(j)
-	return n.invertSorting != n.ValuesLess(ra, rb)
-}
-
-// Swap implements the sort.Interface interface.
-func (n *sortValues) Swap(i, j int) {
-	n.rows.Swap(i, j)
-}
-
-// Push implements the heap.Interface interface.
-func (n *sortValues) Push(x interface{}) {
-	// We can't push to the heap via heap.Push because that doesn't
-	// allow us to return an error. Instead we use PushValues(), which
-	// adds the value *then* calls heap.Push.  By the time control
-	// arrives here, the value is already added, so there is nothing
-	// left to do.
-}
-
-// PushValues pushes the given Datums value into the heap
-// representation of the sortValues.
-func (n *sortValues) PushValues(ctx context.Context, values tree.Datums) error {
-	_, err := n.rows.AddRow(ctx, values)
-	// We still need to call heap.Push() to sort the heap.
-	heap.Push(n, nil)
-	return err
-}
-
-// Pop implements the heap.Interface interface.
-func (n *sortValues) Pop() interface{} {
-	if n.rowsPopped >= n.rows.Len() {
-		panic("no more rows to pop")
-	}
-	n.rowsPopped++
-	// Returning a Datums as an interface{} involves an allocation. Luckily, the
-	// value of Pop is only used for the return value of heap.Pop, which we can
-	// avoid using.
-	return nil
-}
-
-// PopValues pops the top Datums value off the heap representation
-// of the sortValues. We avoid using heap.Pop() directly to
-// avoid allocating an interface{}.
-func (n *sortValues) PopValues() tree.Datums {
-	heap.Pop(n)
-	// Return the last popped row.
-	return n.rows.At(n.rows.Len() - n.rowsPopped)
-}
-
-// ResetLen resets the length to that of the underlying row
-// container. This resets the effect that popping values had on the
-// sortValues's visible length.
-func (n *sortValues) ResetLen() {
-	n.rowsPopped = 0
-}
-
-// SortAll sorts all values in the sortValues.rows slice.
-func (n *sortValues) SortAll(cancelChecker *sqlbase.CancelChecker) {
-	n.invertSorting = false
-	sqlbase.Sort(n, cancelChecker)
-}
-
-// InitMaxHeap initializes the sortValues.rows slice as a max-heap.
-func (n *sortValues) InitMaxHeap() {
-	n.invertSorting = true
-	heap.Init(n)
-}
-
-// InitMinHeap initializes the sortValues.rows slice as a min-heap.
-func (n *sortValues) InitMinHeap() {
-	n.invertSorting = false
-	heap.Init(n)
 }

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -273,11 +273,8 @@ func (v *planVisitor) visit(plan planNode) {
 				order.addOrderColumn(o.ColIdx, o.Direction)
 			}
 			v.observer.attr(name, "order", order.AsString(columns))
-			switch ss := n.run.sortStrategy.(type) {
-			case *iterativeSortStrategy:
-				v.observer.attr(name, "strategy", "iterative")
-			case *sortTopKStrategy:
-				v.observer.attr(name, "strategy", fmt.Sprintf("top %d", ss.topK))
+			if n.strategy != "" {
+				v.observer.attr(name, "strategy", n.strategy)
 			}
 		}
 		v.visit(n.plan)


### PR DESCRIPTION
The local sortNode now invokes the distributed sort processor.

Release note: None