### PR TITLE
distsql: change default disk monitor increment to 1MiB

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -472,7 +472,7 @@ func TempStorageConfigFromEnv(
 			mon.DiskResource,
 			nil,             /* curCount */
 			nil,             /* maxHist */
-			64*1024*1024,    /* increment */
+			1024*1024,       /* increment */
 			maxSizeBytes/10, /* noteworthy */
 			st,
 		)


### PR DESCRIPTION
The previous increment was 64MiB. This was unnecessarily large and
provided too high a granularity for stat reporting.

Closes #26793

Release note: None