### PR TITLE
opt: fix GroupBy ordering issue

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -556,6 +556,11 @@ SELECT array_agg(k), array_agg(s) FROM (SELECT k, s FROM kv ORDER BY k)
 {1,3,5,6,7,8} {"a","a",NULL,"b","b","A"}
 
 query T
+SELECT array_agg(k) || 1 FROM (SELECT k FROM kv ORDER BY k)
+----
+{1,3,5,6,7,8,1}
+
+query T
 SELECT array_agg(s) FROM kv WHERE s IS NULL
 ----
 {NULL}

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -740,22 +740,26 @@ project
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(9)
-      │    │    ├── project
+      │    │    ├── sort
       │    │    │    ├── columns: column8:8(string)
       │    │    │    ├── outer: (1)
-      │    │    │    ├── select
-      │    │    │    │    ├── columns: x:6(int!null) y:7(int)
-      │    │    │    │    ├── outer: (1)
-      │    │    │    │    ├── key: (6)
-      │    │    │    │    ├── fd: (6)-->(7)
-      │    │    │    │    ├── scan xy
-      │    │    │    │    │    ├── columns: x:6(int!null) y:7(int)
-      │    │    │    │    │    ├── key: (6)
-      │    │    │    │    │    └── fd: (6)-->(7)
-      │    │    │    │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
-      │    │    │    │         └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
-      │    │    │    └── projections [outer=(7)]
-      │    │    │         └── xy.y::STRING [type=string, outer=(7)]
+      │    │    │    ├── ordering: +7
+      │    │    │    └── project
+      │    │    │         ├── columns: column8:8(string)
+      │    │    │         ├── outer: (1)
+      │    │    │         ├── select
+      │    │    │         │    ├── columns: x:6(int!null) y:7(int)
+      │    │    │         │    ├── outer: (1)
+      │    │    │         │    ├── key: (6)
+      │    │    │         │    ├── fd: (6)-->(7)
+      │    │    │         │    ├── scan xy
+      │    │    │         │    │    ├── columns: x:6(int!null) y:7(int)
+      │    │    │         │    │    ├── key: (6)
+      │    │    │         │    │    └── fd: (6)-->(7)
+      │    │    │         │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+      │    │    │         │         └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+      │    │    │         └── projections [outer=(7)]
+      │    │    │              └── xy.y::STRING [type=string, outer=(7)]
       │    │    └── aggregations [outer=(8)]
       │    │         └── max [type=string, outer=(8)]
       │    │              └── variable: column8 [type=string, outer=(8)]

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -976,6 +976,29 @@ group-by
            └── variable: kv.k [type=int]
 
 build
+SELECT array_agg(k) || 1 FROM (SELECT k FROM kv ORDER BY s)
+----
+project
+ ├── columns: "?column?":6(int[])
+ ├── group-by
+ │    ├── columns: column5:5(int[])
+ │    ├── ordering: +4
+ │    ├── sort
+ │    │    ├── columns: k:1(int!null) s:4(string)
+ │    │    ├── ordering: +4
+ │    │    └── project
+ │    │         ├── columns: k:1(int!null) s:4(string)
+ │    │         └── scan kv
+ │    │              └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    └── aggregations
+ │         └── array-agg [type=int[]]
+ │              └── variable: kv.k [type=int]
+ └── projections
+      └── concat [type=int[]]
+           ├── variable: column5 [type=int[]]
+           └── const: 1 [type=int]
+
+build
 SELECT array_agg(s) FROM kv WHERE s IS NULL
 ----
 group-by


### PR DESCRIPTION
There is a special fast path in `buildChildProps` where we exit early
if we don't have any required properties and the operator can't "add"
any. I've been bit by this special path in `buildChildProps` a bunch
of times: if you forget to add an exception, the errors can be subtle:
they only show up when there is no required property (in particular,
top-level expressions always have a presentation so they wouldn't be
affected).

This time I noticed we are missing an exception for `GroupBy`. Fixing,
adding some relevant tests, and adding a big warning comment to help
prevent this from happening in the future.

Release note: None