### PR TITLE
vendor: bump cloud.google.com/go dep

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -12,7 +12,8 @@
     "internal/version",
     "storage",
   ]
-  revision = "094187a3a68a589c8217a46b90af0efae38542b9"
+  revision = "0fd7230b2a7505833d5f69b75cbd6c9582401479"
+  version = "v0.23.0"
 
 [[projects]]
   name = "github.com/Azure/azure-sdk-for-go"
@@ -1297,6 +1298,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "bea31ac3645efde6e281cd477725432516f4a1c98bc0600d50f4a4daed069fb0"
+  inputs-digest = "a718d1cdb47e3857a4335d58ac3041c233a4d1990f7619d61b2062d780623674"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -65,12 +65,6 @@ ignored = [
   name = "github.com/rubyist/circuitbreaker"
   branch = "master"
 
-# https://github.com/GoogleCloudPlatform/google-cloud-go/issues/784
-# Remove this when that commit is in a tagged release.
-[[constraint]]
-  name = "cloud.google.com/go"
-  revision = "094187a3a68a589c8217a46b90af0efae38542b9"
-
 # https://github.com/xwb1989/sqlparser/issues/31
 # https://github.com/xwb1989/sqlparser/issues/32
 [[constraint]]


### PR DESCRIPTION
The needed commit in this repo is now in a versioned release so we can
remove the constraint.

Release note: None