### PR TITLE
opt: fix distinct value calculation for stats

### DIFF
--- a/pkg/sql/opt/constraint/constraint_set.go
+++ b/pkg/sql/opt/constraint/constraint_set.go
@@ -43,16 +43,20 @@ var Contradiction = &Set{contradiction: true}
 // expression tree each time.
 //
 // A few examples:
-//  - @1 > 10
-//      /@1: (/10 - ]
+//  - @1 >= 10
+//      /@1: [/10 - ]
 //
 //  - @1 > 10 AND @2 = 5
-//      /@1: (/10 - ]
+//      /@1: [/11 - ]
 //      /@2: [/5 - /5]
 //
 //  - (@1 = 10 AND @2 > 5) OR (@1 = 20 AND @2 > 0)
 //      /@1: [/10 - /10] [/20 - /20]
-//      /@2: [/0 - ]
+//      /@2: [/1 - ]
+//
+//  - @1 > 10.5 AND @2 != 'foo'
+//      /@1: (10.5 - ]
+//      /@2: [ - 'foo') ('foo' - ]
 //
 type Set struct {
 	// firstConstraint holds the first constraint in the set and otherConstraints

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -464,17 +464,14 @@ render     ·         ·          (b)     ·
 ·          table     abcd@abcd  ·       ·
 ·          spans     /1/4-/1/5  ·       ·
 
-# TODO(radu): this should use the abcd index. Both scans are estimate to return
-# the same number of rows; investigate this.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b FROM abcd WHERE (a, b) IN ((1, 4), (2, 9))
 ----
-render     ·         ·                           (b)     ·
- │         render 0  b                           ·       ·
- └── scan  ·         ·                           (a, b)  ·
-·          table     abcd@adb                    ·       ·
-·          spans     /1-/3                       ·       ·
-·          filter    (a, b) IN ((1, 4), (2, 9))  ·       ·
+render     ·         ·                     (b)     ·
+ │         render 0  b                     ·       ·
+ └── scan  ·         ·                     (a, b)  ·
+·          table     abcd@abcd             ·       ·
+·          spans     /1/4-/1/5 /2/9-/2/10  ·       ·
 
 statement ok
 CREATE TABLE ab (

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -414,74 +414,80 @@ func (sb *statisticsBuilder) applySelectivity(inputRows float64) {
 func (sb *statisticsBuilder) updateDistinctCountsFromConstraint(
 	c *constraint.Constraint, inputStatsBuilder *statisticsBuilder,
 ) (applied bool) {
-	// All of the columns that are part of the exact prefix have exactly one
-	// distinct value.
-	exactPrefix := c.ExactPrefix(sb.evalCtx)
-	for i := 0; i < exactPrefix; i++ {
-		sb.ensureColStat(c.Columns.Get(i).ID(), 1 /* distinctCount */, inputStatsBuilder)
+	// All of the columns that are part of the prefix have a finite number of
+	// distinct values.
+	prefix := c.Prefix(sb.evalCtx)
+
+	// If there are any other columns beyond the prefix, we may be able to
+	// determine the number of distinct values for the first one. For example:
+	//   /a/b/c: [/1/2/3 - /1/2/3] [/1/4/5 - /1/4/8]
+	//       -> Column a has DistinctCount = 1.
+	//       -> Column b has DistinctCount = 2.
+	//       -> Column c has DistinctCount = 5.
+	for col := 0; col <= prefix; col++ {
+		// All columns should have at least one distinct value.
+		distinctCount := 1.0
+
+		var val tree.Datum
+		for i := 0; i < c.Spans.Count(); i++ {
+			sp := c.Spans.Get(i)
+			if sp.StartKey().Length() <= col || sp.EndKey().Length() <= col {
+				// We can't determine the distinct count for this column. For example,
+				// the number of distinct values for column b in the constraint
+				// /a/b: [/1/1 - /1] cannot be determined.
+				return applied
+			}
+			startVal := sp.StartKey().Value(col)
+			endVal := sp.EndKey().Value(col)
+			if startVal.Compare(sb.evalCtx, endVal) != 0 {
+				// TODO(rytaft): are there other types we should handle here
+				// besides int?
+				if startVal.ResolvedType() == types.Int && endVal.ResolvedType() == types.Int {
+					start := int(*startVal.(*tree.DInt))
+					end := int(*endVal.(*tree.DInt))
+					// We assume that both start and end boundaries are inclusive. This
+					// should be the case for integer valued columns (due to normalization
+					// by constraint.PreferInclusive).
+					if c.Columns.Get(col).Ascending() {
+						distinctCount += float64(end - start)
+					} else {
+						distinctCount += float64(start - end)
+					}
+				} else {
+					// We can't determine the distinct count for this column. For example,
+					// the number of distinct values in the constraint
+					// /a: [/'cherry' - /'mango'] cannot be determined.
+					return applied
+				}
+			}
+			if i != 0 {
+				compare := startVal.Compare(sb.evalCtx, val)
+				ascending := c.Columns.Get(col).Ascending()
+				if (compare > 0 && ascending) || (compare < 0 && !ascending) {
+					// This check is needed to ensure that we calculate the correct distinct
+					// value count for constraints such as:
+					//   /a/b: [/1/2 - /1/2] [/1/4 - /1/4] [/2 - /2]
+					// We should only increment the distinct count for column "a" once we
+					// reach the third span.
+					distinctCount++
+				} else if compare != 0 {
+					// This can happen if we have a prefix, but not an exact prefix. For
+					// example:
+					//   /a/b: [/1/2 - /1/4] [/3/2 - /3/5] [/6/0 - /6/0]
+					// In this case, /a is a prefix, but not an exact prefix. Trying to
+					// figure out the distinct count for column b may be more trouble
+					// than it's worth. For now, don't bother trying.
+					return applied
+				}
+			}
+			val = endVal
+		}
+
+		sb.ensureColStat(c.Columns.Get(col).ID(), distinctCount, inputStatsBuilder)
 		applied = true
 	}
 
-	// If there are no other columns beyond the exact prefix, we are done.
-	if exactPrefix >= c.Columns.Count() {
-		return applied
-	}
-
-	// If there are any other columns beyond the exact prefix, we may be able to
-	// determine the number of distinct values for the first one. For example:
-	//   /a/b/c: [/1/2/3 - /1/2/3] [/1/2/5 - /1/2/8]
-	//       -> Columns a and b have DistinctCount = 1.
-	//       -> Column c has DistinctCount = 5.
-	col := exactPrefix
-	// All columns should have at least one distinct value.
-	distinctCount := 1.0
-
-	var val tree.Datum
-	for i := 0; i < c.Spans.Count(); i++ {
-		sp := c.Spans.Get(i)
-		if sp.StartKey().Length() <= col || sp.EndKey().Length() <= col {
-			// We can't determine the distinct count for this column. For example,
-			// the number of distinct values for column b in the constraint
-			// /a/b: [/1/1 - /1] cannot be determined.
-			return applied
-		}
-		startVal := sp.StartKey().Value(col)
-		endVal := sp.EndKey().Value(col)
-		if startVal.Compare(sb.evalCtx, endVal) != 0 {
-			// TODO(rytaft): are there other types we should handle here
-			// besides int?
-			if startVal.ResolvedType() == types.Int && endVal.ResolvedType() == types.Int {
-				start := int(*startVal.(*tree.DInt))
-				end := int(*endVal.(*tree.DInt))
-				// We assume that both start and end boundaries are inclusive. This
-				// should be the case for integer valued columns (due to normalization
-				// by constraint.PreferInclusive).
-				if c.Columns.Get(col).Ascending() {
-					distinctCount += float64(end - start)
-				} else {
-					distinctCount += float64(start - end)
-				}
-			} else {
-				// We can't determine the distinct count for this column. For example,
-				// the number of distinct values in the constraint
-				// /a: [/'cherry' - /'mango'] cannot be determined.
-				return applied
-			}
-		}
-		if i == 0 {
-			val = startVal
-		} else if startVal.Compare(sb.evalCtx, val) != 0 {
-			// This check is needed to ensure that we calculate the correct distinct
-			// value count for constraints such as:
-			//   /a/b: [/1/2 - /1/2] [/1/4 - /1/4] [/2 - /2]
-			// We should only increment the distinct count for column "a" once we
-			// reach the third span.
-			distinctCount++
-		}
-	}
-
-	sb.ensureColStat(c.Columns.Get(col).ID(), distinctCount, inputStatsBuilder)
-	return true /* applied */
+	return applied
 }
 
 func (sb *statisticsBuilder) buildScan(def *ScanOpDef) {

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -233,42 +233,6 @@ func (sb *statisticsBuilder) colStatMetadata(colSet opt.ColSet) *props.ColumnSta
 	return colStat
 }
 
-// ColumnStatistics is a slice of ColumnStatistic values.
-type ColumnStatistics []props.ColumnStatistic
-
-// Len returns the number of ColumnStatistic values.
-func (c ColumnStatistics) Len() int { return len(c) }
-
-// Less is part of the Sorter interface.
-func (c ColumnStatistics) Less(i, j int) bool {
-	if c[i].Cols.Len() != c[j].Cols.Len() {
-		return c[i].Cols.Len() < c[j].Cols.Len()
-	}
-
-	prev := 0
-	for {
-		nextI, ok := c[i].Cols.Next(prev)
-		if !ok {
-			return false
-		}
-
-		// No need to check if ok since both ColSets are the same length and
-		// so far have had the same elements.
-		nextJ, _ := c[j].Cols.Next(prev)
-
-		if nextI != nextJ {
-			return nextI < nextJ
-		}
-
-		prev = nextI
-	}
-}
-
-// Swap is part of the Sorter interface.
-func (c ColumnStatistics) Swap(i, j int) {
-	c[i], c[j] = c[j], c[i]
-}
-
 const (
 	// This is the value used for inequality filters such as x < 1 in
 	// "Access Path Selection in a Relational Database Management System"

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -101,6 +101,8 @@ func TestGetStatsFromConstraint(t *testing.T) {
 	c12 := constraint.ParseConstraint(&evalCtx, "/1/2/3: [/1/2 - /1/3] [/1/4 - /1]")
 	c123 := constraint.ParseConstraint(&evalCtx, "/1/2/3: [/1/2/3 - /1/2/3] [/1/2/5 - /1/2/8]")
 	c32 := constraint.ParseConstraint(&evalCtx, "/3/-2: [/5/3 - /5/2]")
+	c321 := constraint.ParseConstraint(&evalCtx, "/-3/2/1: [/5/3/1 - /5/3/4] [/3/5/1 - /3/5/4]")
+	c312 := constraint.ParseConstraint(&evalCtx, "/3/1/-2: [/5/3/8 - /5/3/6] [/9/5/4 - /9/5/1]")
 
 	// /4/5: [/'apple'/'cherry' - /'apple'/'mango']
 	appleCherry := constraint.MakeCompositeKey(tree.NewDString("apple"), tree.NewDString("cherry"))
@@ -152,6 +154,20 @@ func TestGetStatsFromConstraint(t *testing.T) {
 		cs32,
 		"[rows=80000, distinct(2)=2, distinct(3)=1]",
 		2.0/250000,
+	)
+
+	cs321 := constraint.SingleConstraint(&c321)
+	statsFunc123(
+		cs321,
+		"[rows=160000, distinct(2)=2, distinct(3)=2]",
+		4.0/250000,
+	)
+
+	cs312 := constraint.SingleConstraint(&c312)
+	statsFunc123(
+		cs312,
+		"[rows=2240, distinct(1)=2, distinct(2)=7, distinct(3)=2]",
+		28.0/125000000,
 	)
 
 	cs := cs3.Intersect(&evalCtx, cs123)

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -17,15 +17,12 @@ package memo
 import (
 	"testing"
 
-	"strings"
-
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
 
 // Most of the functionality in statistics.go is tested by the data-driven
@@ -118,63 +115,63 @@ func TestGetStatsFromConstraint(t *testing.T) {
 	cs1 := constraint.SingleConstraint(&c1)
 	statsFunc123(
 		cs1,
-		"stats: [rows=140000000, distinct(1)=7]",
+		"[rows=140000000, distinct(1)=7]",
 		7.0/500,
 	)
 
 	cs2 := constraint.SingleConstraint(&c2)
 	statsFunc123(
 		cs2,
-		"stats: [rows=3333333333]",
+		"[rows=3333333333]",
 		1.0/3,
 	)
 
 	cs3 := constraint.SingleConstraint(&c3)
 	statsFunc123(
 		cs3,
-		"stats: [rows=20000000, distinct(3)=1]",
+		"[rows=20000000, distinct(3)=1]",
 		1.0/500,
 	)
 
 	cs12 := constraint.SingleConstraint(&c12)
 	statsFunc123(
 		cs12,
-		"stats: [rows=20000000, distinct(1)=1]",
+		"[rows=20000000, distinct(1)=1]",
 		1.0/500,
 	)
 
 	cs123 := constraint.SingleConstraint(&c123)
 	statsFunc123(
 		cs123,
-		"stats: [rows=400, distinct(1)=1, distinct(2)=1, distinct(3)=5]",
+		"[rows=400, distinct(1)=1, distinct(2)=1, distinct(3)=5]",
 		5.0/125000000,
 	)
 
 	cs32 := constraint.SingleConstraint(&c32)
 	statsFunc123(
 		cs32,
-		"stats: [rows=80000, distinct(2)=2, distinct(3)=1]",
+		"[rows=80000, distinct(2)=2, distinct(3)=1]",
 		2.0/250000,
 	)
 
 	cs := cs3.Intersect(&evalCtx, cs123)
 	statsFunc123(
 		cs,
-		"stats: [rows=80, distinct(1)=1, distinct(2)=1, distinct(3)=1]",
+		"[rows=80, distinct(1)=1, distinct(2)=1, distinct(3)=1]",
 		1.0/125000000,
 	)
 
 	cs = cs32.Intersect(&evalCtx, cs123)
 	statsFunc123(
 		cs,
-		"stats: [rows=80, distinct(1)=1, distinct(2)=1, distinct(3)=1]",
+		"[rows=80, distinct(1)=1, distinct(2)=1, distinct(3)=1]",
 		1.0/125000000,
 	)
 
 	cs45 := constraint.SingleSpanConstraint(&keyCtx45, &sp45)
 	statsFunc45(
 		cs45,
-		"stats: [rows=1000000000, distinct(4)=1]",
+		"[rows=1000000000, distinct(4)=1]",
 		1.0/10,
 	)
 }
@@ -215,12 +212,7 @@ func testStats(
 ) {
 	t.Helper()
 
-	ev := ExprView{}
-
-	tp := treeprinter.New()
-	ev.formatStats(tp, sb.s)
-	actual := strings.TrimSpace(tp.String())
-
+	actual := sb.s.String()
 	if actual != expectedStats {
 		t.Fatalf("\nexpected: %s\nactual  : %s", expectedStats, actual)
 	}

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -660,7 +660,7 @@ SELECT * FROM c WHERE (v, u) IN ((1, 2), (3, 50), (5, 100))
 scan c@v
  ├── columns: k:1(int!null) u:2(int!null) v:3(int!null)
  ├── constraint: /3/2/1: [/1/2 - /1/2] [/3/50 - /3/50] [/5/100 - /5/100]
- ├── stats: [rows=4.29, distinct(3)=3]
+ ├── stats: [rows=0.0061, distinct(2)=0.0061, distinct(3)=0.0061]
  ├── key: (1)
  └── fd: (1)-->(2,3)
 
@@ -671,7 +671,7 @@ SELECT * FROM c WHERE (v, u) IN ((1, 2), (3, 50), (5, NULL))
 scan c@v
  ├── columns: k:1(int!null) u:2(int!null) v:3(int!null)
  ├── constraint: /3/2/1: [/1/2 - /1/2] [/3/50 - /3/50]
- ├── stats: [rows=2.86, distinct(3)=2]
+ ├── stats: [rows=0.0041, distinct(2)=0.0041, distinct(3)=0.0041]
  ├── key: (1)
  └── fd: (1)-->(2,3)
 

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -602,20 +602,20 @@ ORDER BY s_i_id
 ----
 sort
  ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string) s_dist_05:8(string)
- ├── stats: [rows=50]
- ├── cost: 65.32
+ ├── stats: [rows=5]
+ ├── cost: 6.37
  ├── ordering: +1
  ├── prune: (1,3,8,14-17)
  └── project
       ├── columns: stock.s_i_id:1(int!null) stock.s_quantity:3(int) stock.s_dist_05:8(string) stock.s_ytd:14(int) stock.s_order_cnt:15(int) stock.s_remote_cnt:16(int) stock.s_data:17(string)
-      ├── stats: [rows=50]
-      ├── cost: 62.50
+      ├── stats: [rows=5]
+      ├── cost: 6.25
       ├── prune: (1,3,8,14-17)
       └── scan stock
            ├── columns: stock.s_i_id:1(int!null) stock.s_w_id:2(int!null) stock.s_quantity:3(int) stock.s_dist_05:8(string) stock.s_ytd:14(int) stock.s_order_cnt:15(int) stock.s_remote_cnt:16(int) stock.s_data:17(string)
            ├── constraint: /2/1: [/4/900 - /4/900] [/4/1000 - /4/1000] [/4/1100 - /4/1100] [/4/1400 - /4/1400] [/4/1500 - /4/1500]
-           ├── stats: [rows=50, distinct(1)=5]
-           ├── cost: 62.50
+           ├── stats: [rows=5, distinct(1)=5, distinct(2)=1]
+           ├── cost: 6.25
            ├── key: (1,2)
            ├── fd: (1,2)-->(3,8,14-17)
            ├── prune: (3,8,14-17)


### PR DESCRIPTION
This commit Fixes the distinct value calculation for cases
where a constraint does not have an exact prefix, but it is
still possible to determine the number of distinct values.
For example, the constraint `/a/b: [/2/3 - /2/3] [/4/5 - /4/8]`
has no exact prefix, but it is easy to determine that column
a has 2 distinct values, and column b has 5 distinct values.