### PR TITLE
engine: require iterators to specify an upper bound

### DIFF
--- a/c-deps/libroach/CMakeLists.txt
+++ b/c-deps/libroach/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(roach
   file_registry.cc
   getter.cc
   godefs.cc
+  iterator.cc
   ldb.cc
   merge.cc
   mvcc.cc

--- a/c-deps/libroach/batch.h
+++ b/c-deps/libroach/batch.h
@@ -37,7 +37,7 @@ struct DBBatch : public DBEngine {
   virtual DBStatus ApplyBatchRepr(DBSlice repr, bool sync);
   virtual DBSlice BatchRepr();
   virtual DBStatus Get(DBKey key, DBString* value);
-  virtual DBIterator* NewIter(rocksdb::ReadOptions*);
+  virtual DBIterator* NewIter(DBIterOptions);
   virtual DBStatus GetStats(DBStatsResult* stats);
   virtual DBString GetCompactionStats();
   virtual DBStatus GetEnvStats(DBEnvStatsResult* stats);
@@ -67,7 +67,7 @@ struct DBWriteOnlyBatch : public DBEngine {
   virtual DBStatus ApplyBatchRepr(DBSlice repr, bool sync);
   virtual DBSlice BatchRepr();
   virtual DBStatus Get(DBKey key, DBString* value);
-  virtual DBIterator* NewIter(rocksdb::ReadOptions*);
+  virtual DBIterator* NewIter(DBIterOptions);
   virtual DBStatus GetStats(DBStatsResult* stats);
   virtual DBString GetCompactionStats();
   virtual DBString GetEnvStats(DBEnvStatsResult* stats);

--- a/c-deps/libroach/encoding.cc
+++ b/c-deps/libroach/encoding.cc
@@ -158,6 +158,10 @@ std::string EncodeTimestamp(DBTimestamp ts) {
   return s;
 }
 
+bool EmptyTimestamp(DBTimestamp ts) {
+  return ts.wall_time == 0 && ts.logical == 0;
+}
+
 // MVCC keys are encoded as <key>\x00[<wall_time>[<logical>]]<#timestamp-bytes>. A
 // custom RocksDB comparator (DBComparator) is used to maintain the desired
 // ordering as these keys do not sort lexicographically correctly.

--- a/c-deps/libroach/encoding.h
+++ b/c-deps/libroach/encoding.h
@@ -79,6 +79,10 @@ WARN_UNUSED_RESULT bool DecodeTimestamp(rocksdb::Slice* timestamp, int64_t* wall
 WARN_UNUSED_RESULT bool DecodeTimestamp(rocksdb::Slice buf,
                                         cockroach::util::hlc::Timestamp* timestamp);
 
+// EmptyTimestamp returns whether ts represents an empty timestamp where both
+// the wall_time and logical components are zero.
+bool EmptyTimestamp(DBTimestamp ts);
+
 // DecodeKey splits an MVCC key into a key slice and decoded
 // timestamp. See also SplitKey if you want to do not need to decode
 // the timestamp. Returns true on success and false on any decoding

--- a/c-deps/libroach/engine.cc
+++ b/c-deps/libroach/engine.cc
@@ -160,9 +160,9 @@ DBStatus DBImpl::ApplyBatchRepr(DBSlice repr, bool sync) {
 
 DBSlice DBImpl::BatchRepr() { return ToDBSlice("unsupported"); }
 
-DBIterator* DBImpl::NewIter(rocksdb::ReadOptions* read_opts) {
-  DBIterator* iter = new DBIterator(iters);
-  iter->rep.reset(rep->NewIterator(*read_opts));
+DBIterator* DBImpl::NewIter(DBIterOptions iter_opts) {
+  DBIterator* iter = new DBIterator(iters, iter_opts);
+  iter->rep.reset(rep->NewIterator(iter->read_opts));
   return iter;
 }
 

--- a/c-deps/libroach/engine.h
+++ b/c-deps/libroach/engine.h
@@ -38,7 +38,7 @@ struct DBEngine {
   virtual DBStatus ApplyBatchRepr(DBSlice repr, bool sync) = 0;
   virtual DBSlice BatchRepr() = 0;
   virtual DBStatus Get(DBKey key, DBString* value) = 0;
-  virtual DBIterator* NewIter(rocksdb::ReadOptions*) = 0;
+  virtual DBIterator* NewIter(DBIterOptions) = 0;
   virtual DBStatus GetStats(DBStatsResult* stats) = 0;
   virtual DBString GetCompactionStats() = 0;
   virtual DBString GetEnvStats(DBEnvStatsResult* stats) = 0;
@@ -83,7 +83,7 @@ struct DBImpl : public DBEngine {
   virtual DBStatus ApplyBatchRepr(DBSlice repr, bool sync);
   virtual DBSlice BatchRepr();
   virtual DBStatus Get(DBKey key, DBString* value);
-  virtual DBIterator* NewIter(rocksdb::ReadOptions*);
+  virtual DBIterator* NewIter(DBIterOptions);
   virtual DBStatus GetStats(DBStatsResult* stats);
   virtual DBString GetCompactionStats();
   virtual DBStatus GetEnvStats(DBEnvStatsResult* stats);

--- a/c-deps/libroach/iterator.cc
+++ b/c-deps/libroach/iterator.cc
@@ -1,0 +1,79 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+
+#include "chunked_buffer.h"
+#include "encoding.h"
+#include "iterator.h"
+#include "keys.h"
+
+using namespace cockroach;
+
+DBIterator::DBIterator(std::atomic<int64_t>* iters, DBIterOptions iter_options) : iters_count(iters) {
+  read_opts.prefix_same_as_start = iter_options.prefix;
+  read_opts.total_order_seek = !iter_options.prefix;
+
+  SetUpperBound(iter_options.upper_bound);
+  read_opts.iterate_upper_bound = &upper_bound;
+
+  if (!EmptyTimestamp(iter_options.min_timestamp_hint) ||
+      !EmptyTimestamp(iter_options.max_timestamp_hint)) {
+    assert(!EmptyTimestamp(iter_options.min_timestamp_hint));
+    assert(!EmptyTimestamp(iter_options.max_timestamp_hint));
+    const std::string min = EncodeTimestamp(iter_options.min_timestamp_hint);
+    const std::string max = EncodeTimestamp(iter_options.max_timestamp_hint);
+    read_opts.table_filter = [min, max, this](const rocksdb::TableProperties& props) {
+      auto userprops = props.user_collected_properties;
+      auto tbl_min = userprops.find("crdb.ts.min");
+      if (tbl_min == userprops.end() || tbl_min->second.empty()) {
+        if (stats != nullptr) {
+          ++stats->timebound_num_ssts;
+        }
+        return true;
+      }
+      auto tbl_max = userprops.find("crdb.ts.max");
+      if (tbl_max == userprops.end() || tbl_max->second.empty()) {
+        if (stats != nullptr) {
+          ++stats->timebound_num_ssts;
+        }
+        return true;
+      }
+      // If the timestamp range of the table overlaps with the timestamp range we
+      // want to iterate, the table might contain timestamps we care about.
+      bool used = max.compare(tbl_min->second) >= 0 && min.compare(tbl_max->second) <= 0;
+      if (used && stats != nullptr) {
+        ++stats->timebound_num_ssts;
+      }
+      return used;
+    };
+  }
+
+  if (iter_options.with_stats) {
+    stats.reset(new IteratorStats());
+  }
+
+  ++(*iters_count);
+}
+
+DBIterator::~DBIterator() {
+  --(*iters_count);
+}
+
+void DBIterator::SetUpperBound(DBKey key) {
+  if (key.key.data == NULL) {
+    upper_bound_str = kMaxKey.data();
+  } else {
+    upper_bound_str = EncodeKey(key);
+  }
+  upper_bound = upper_bound_str;
+}

--- a/c-deps/libroach/iterator.h
+++ b/c-deps/libroach/iterator.h
@@ -19,15 +19,19 @@
 #include <rocksdb/iterator.h>
 #include <rocksdb/write_batch.h>
 #include "chunked_buffer.h"
-#include "encoding.h"
 
 struct DBIterator {
-  DBIterator(std::atomic<int64_t>* iters) : iters_count(iters) { ++(*iters_count); }
-  ~DBIterator() { --(*iters_count); }
+  DBIterator(std::atomic<int64_t>* iters, DBIterOptions iter_options);
+  ~DBIterator();
+  void SetUpperBound(DBKey key);
 
   std::atomic<int64_t>* const iters_count;
   std::unique_ptr<rocksdb::Iterator> rep;
   std::unique_ptr<cockroach::chunkedBuffer> kvs;
   std::unique_ptr<rocksdb::WriteBatch> intents;
   std::unique_ptr<IteratorStats> stats;
+
+  rocksdb::ReadOptions read_opts;
+  std::string upper_bound_str;
+  rocksdb::Slice upper_bound;
 };

--- a/c-deps/libroach/keys.h
+++ b/c-deps/libroach/keys.h
@@ -10,6 +10,7 @@ const rocksdb::Slice kLocalRangeIDPrefix("\x01\x69", 2);
 const rocksdb::Slice kLocalRangeIDReplicatedInfix("\x72", 1);
 const rocksdb::Slice kLocalRangeAppliedStateSuffix("\x72\x61\x73\x6b", 4);
 const rocksdb::Slice kMeta2KeyMax("\x03\xff\xff", 3);
+const rocksdb::Slice kMaxKey("\xff\xff", 2);
 
 const std::vector<std::pair<rocksdb::Slice, rocksdb::Slice> > kSortedNoSplitSpans = {
   std::make_pair(rocksdb::Slice("\x88", 1), rocksdb::Slice("\x93", 1)),

--- a/c-deps/libroach/options.cc
+++ b/c-deps/libroach/options.cc
@@ -268,9 +268,14 @@ rocksdb::Options DBMakeOptions(DBOptions db_opts) {
     // load situations we'll be using somewhat more than 1 memtable,
     // but usually not significantly more unless there is an I/O
     // throughput problem.
+    //
+    // We ensure that at least 1MB is allocated for the block cache.
+    // Some unit tests expect to see a non-zero block cache hit rate,
+    // but they use a cache that is small enough that all of it would
+    // otherwise be reserved for the memtable.
     std::lock_guard<std::mutex> guard(db_opts.cache->mu);
     const int64_t capacity = db_opts.cache->rep->GetCapacity();
-    const int64_t new_capacity = std::max<int64_t>(0, capacity - options.write_buffer_size);
+    const int64_t new_capacity = std::max<int64_t>(1 << 20, capacity - options.write_buffer_size);
     db_opts.cache->rep->SetCapacity(new_capacity);
   }
 

--- a/c-deps/libroach/snapshot.cc
+++ b/c-deps/libroach/snapshot.cc
@@ -16,6 +16,7 @@
 #include "getter.h"
 #include "iterator.h"
 #include "status.h"
+#include "encoding.h"
 
 namespace cockroach {
 
@@ -42,10 +43,10 @@ DBStatus DBSnapshot::ApplyBatchRepr(DBSlice repr, bool sync) { return FmtStatus(
 
 DBSlice DBSnapshot::BatchRepr() { return ToDBSlice("unsupported"); }
 
-DBIterator* DBSnapshot::NewIter(rocksdb::ReadOptions* read_opts) {
-  read_opts->snapshot = snapshot;
-  DBIterator* iter = new DBIterator(iters);
-  iter->rep.reset(rep->NewIterator(*read_opts));
+DBIterator* DBSnapshot::NewIter(DBIterOptions iter_options) {
+  DBIterator* iter = new DBIterator(iters, iter_options);
+  iter->read_opts.snapshot = snapshot;
+  iter->rep.reset(rep->NewIterator(iter->read_opts));
   return iter;
 }
 

--- a/c-deps/libroach/snapshot.h
+++ b/c-deps/libroach/snapshot.h
@@ -34,7 +34,7 @@ struct DBSnapshot : public DBEngine {
   virtual DBStatus ApplyBatchRepr(DBSlice repr, bool sync);
   virtual DBSlice BatchRepr();
   virtual DBStatus Get(DBKey key, DBString* value);
-  virtual DBIterator* NewIter(rocksdb::ReadOptions*);
+  virtual DBIterator* NewIter(DBIterOptions);
   virtual DBStatus GetStats(DBStatsResult* stats);
   virtual DBString GetCompactionStats();
   virtual DBStatus GetEnvStats(DBEnvStatsResult* stats);

--- a/pkg/ccl/storageccl/add_sstable.go
+++ b/pkg/ccl/storageccl/add_sstable.go
@@ -46,7 +46,7 @@ func evalAddSSTable(
 	// (Note: the expected case is that it's none or, in the case of a retry of
 	// the request, all.) So subtract out the existing mvcc stats, and add back
 	// what they'll be after the sstable is ingested.
-	existingIter := batch.NewIterator(engine.IterOptions{})
+	existingIter := batch.NewIterator(engine.IterOptions{UpperBound: args.EndKey})
 	defer existingIter.Close()
 	existingIter.Seek(mvccStartKey)
 	if ok, err := existingIter.Valid(); err != nil {

--- a/pkg/ccl/storageccl/add_sstable_test.go
+++ b/pkg/ccl/storageccl/add_sstable_test.go
@@ -354,7 +354,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 		// stats. Make sure recomputing from scratch gets the same answer as
 		// applying the diff to the stats
 		beforeStats := func() enginepb.MVCCStats {
-			iter := e.NewIterator(engine.IterOptions{})
+			iter := e.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 			defer iter.Close()
 			beforeStats, err := engine.ComputeStatsGo(iter, engine.NilKey, engine.MVCCKeyMax, nowNanos)
 			if err != nil {
@@ -373,7 +373,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 		}
 
 		afterStats := func() enginepb.MVCCStats {
-			iter := e.NewIterator(engine.IterOptions{})
+			iter := e.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 			defer iter.Close()
 			afterStats, err := engine.ComputeStatsGo(iter, engine.NilKey, engine.MVCCKeyMax, nowNanos)
 			if err != nil {

--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -168,12 +168,16 @@ func BenchmarkTimeBoundIterate(b *testing.B) {
 		b.Run(fmt.Sprintf("LoadFactor=%.2f", loadFactor), func(b *testing.B) {
 			b.Run("NormalIterator", func(b *testing.B) {
 				runIterate(b, loadFactor, func(e engine.Engine, _, _ hlc.Timestamp) engine.Iterator {
-					return e.NewIterator(engine.IterOptions{})
+					return e.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 				})
 			})
 			b.Run("TimeBoundIterator", func(b *testing.B) {
 				runIterate(b, loadFactor, func(e engine.Engine, startTime, endTime hlc.Timestamp) engine.Iterator {
-					return e.NewTimeBoundIterator(startTime, endTime, false)
+					return e.NewIterator(engine.IterOptions{
+						MinTimestampHint: startTime,
+						MaxTimestampHint: endTime,
+						UpperBound:       roachpb.KeyMax,
+					})
 				})
 			})
 		})

--- a/pkg/ccl/storageccl/engineccl/multi_iterator_test.go
+++ b/pkg/ccl/storageccl/engineccl/multi_iterator_test.go
@@ -100,7 +100,7 @@ func TestMultiIterator(t *testing.T) {
 						t.Fatalf("%+v", err)
 					}
 				}
-				iter := batch.NewIterator(engine.IterOptions{})
+				iter := batch.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 				defer iter.Close()
 				iters = append(iters, iter)
 			}

--- a/pkg/ccl/storageccl/engineccl/mvcc_test.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc_test.go
@@ -34,7 +34,11 @@ func iterateExpectErr(
 	errString string,
 ) func(*testing.T) {
 	return func(t *testing.T) {
-		iter := NewMVCCIncrementalIterator(e, startTime, endTime)
+		iter := NewMVCCIncrementalIterator(e, IterOptions{
+			StartTime:  startTime,
+			EndTime:    endTime,
+			UpperBound: endKey,
+		})
 		defer iter.Close()
 		for iter.Seek(engine.MakeMVCCMetadataKey(startKey)); ; iterFn(iter) {
 			if ok, _ := iter.Valid(); !ok || iter.UnsafeKey().Key.Compare(endKey) >= 0 {
@@ -57,7 +61,11 @@ func assertEqualKVs(
 	expected []engine.MVCCKeyValue,
 ) func(*testing.T) {
 	return func(t *testing.T) {
-		iter := NewMVCCIncrementalIterator(e, startTime, endTime)
+		iter := NewMVCCIncrementalIterator(e, IterOptions{
+			StartTime:  startTime,
+			EndTime:    endTime,
+			UpperBound: endKey,
+		})
 		defer iter.Close()
 		var kvs []engine.MVCCKeyValue
 		for iter.Seek(engine.MakeMVCCMetadataKey(startKey)); ; iterFn(iter) {
@@ -307,7 +315,7 @@ func TestMVCCIterateTimeBound(t *testing.T) {
 			defer leaktest.AfterTest(t)()
 
 			var expectedKVs []engine.MVCCKeyValue
-			iter := eng.NewIterator(engine.IterOptions{})
+			iter := eng.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 			defer iter.Close()
 			iter.Seek(engine.MVCCKey{})
 			for {

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -155,7 +155,11 @@ func evalExport(
 	var rows rowCounter
 	// TODO(dan): Move all this iteration into cpp to avoid the cgo calls.
 	// TODO(dan): Consider checking ctx periodically during the MVCCIterate call.
-	iter := engineccl.NewMVCCIncrementalIterator(batch, args.StartTime, h.Timestamp)
+	iter := engineccl.NewMVCCIncrementalIterator(batch, engineccl.IterOptions{
+		StartTime:  args.StartTime,
+		EndTime:    h.Timestamp,
+		UpperBound: args.EndKey,
+	})
 	defer iter.Close()
 	for iter.Seek(engine.MakeMVCCMetadataKey(args.Key)); ; iterFn(iter) {
 		ok, err := iter.Valid()

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -101,7 +101,7 @@ func slurpSSTablesLatestKey(
 	}
 
 	var kvs []engine.MVCCKeyValue
-	it := batch.NewIterator(engine.IterOptions{})
+	it := batch.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 	defer it.Close()
 	for it.Seek(start); ; it.NextKey() {
 		if ok, err := it.Valid(); err != nil {

--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -95,7 +95,7 @@ func clearExistingData(
 		}
 	}
 
-	iter := batch.NewIterator(engine.IterOptions{})
+	iter := batch.NewIterator(engine.IterOptions{UpperBound: end.Key})
 	defer iter.Close()
 
 	iter.Seek(start)

--- a/pkg/ccl/utilccl/sampledataccl/bankdata.go
+++ b/pkg/ccl/utilccl/sampledataccl/bankdata.go
@@ -128,7 +128,7 @@ func (b *Backup) NextKeyValues(
 			return nil, roachpb.Span{}, err
 		}
 
-		it := sst.NewIterator(engine.IterOptions{})
+		it := sst.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 		defer it.Close()
 		it.Seek(engine.MVCCKey{Key: file.Span.Key})
 

--- a/pkg/keys/gen_cpp_keys.go
+++ b/pkg/keys/gen_cpp_keys.go
@@ -73,6 +73,7 @@ namespace cockroach {
 	genKey(keys.LocalRangeIDReplicatedInfix, "LocalRangeIDReplicatedInfix")
 	genKey(keys.LocalRangeAppliedStateSuffix, "LocalRangeAppliedStateSuffix")
 	genKey(keys.Meta2KeyMax, "Meta2KeyMax")
+	genKey(keys.MaxKey, "MaxKey")
 	fmt.Fprintf(f, "\n")
 
 	genSortedSpans := func(spans []roachpb.Span, name string) {

--- a/pkg/sql/sqlbase/rowfetcher_mvcc_test.go
+++ b/pkg/sql/sqlbase/rowfetcher_mvcc_test.go
@@ -39,7 +39,7 @@ func slurpUserDataKVs(t testing.TB, e engine.Engine) []roachpb.KeyValue {
 	t.Helper()
 
 	var kvs []roachpb.KeyValue
-	it := e.NewIterator(engine.IterOptions{})
+	it := e.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 	defer it.Close()
 	for it.Seek(engine.MVCCKey{Key: keys.UserTableDataMin}); ; it.NextKey() {
 		ok, err := it.Valid()

--- a/pkg/storage/abortspan/abortspan.go
+++ b/pkg/storage/abortspan/abortspan.go
@@ -77,7 +77,7 @@ func (sc *AbortSpan) max() roachpb.Key {
 
 // ClearData removes all persisted items stored in the cache.
 func (sc *AbortSpan) ClearData(e engine.Engine) error {
-	iter := e.NewIterator(engine.IterOptions{})
+	iter := e.NewIterator(engine.IterOptions{UpperBound: sc.max()})
 	defer iter.Close()
 	b := e.NewWriteOnlyBatch()
 	defer b.Close()

--- a/pkg/storage/batcheval/cmd_clear_range.go
+++ b/pkg/storage/batcheval/cmd_clear_range.go
@@ -140,7 +140,7 @@ func computeStatsDelta(
 	// If we can't use the fast stats path, or race test is enabled,
 	// compute stats across the key span to be cleared.
 	if !fast || util.RaceEnabled {
-		iter := batch.NewIterator(engine.IterOptions{})
+		iter := batch.NewIterator(engine.IterOptions{UpperBound: to.Key})
 		computed, err := iter.ComputeStats(from, to, delta.LastUpdateNanos)
 		iter.Close()
 		if err != nil {

--- a/pkg/storage/batcheval/cmd_refresh_range.go
+++ b/pkg/storage/batcheval/cmd_refresh_range.go
@@ -44,7 +44,11 @@ func RefreshRange(
 
 	// Use a time-bounded iterator to avoid unnecessarily iterating over
 	// older data.
-	iter := batch.NewTimeBoundIterator(h.Txn.OrigTimestamp, h.Txn.Timestamp, false)
+	iter := batch.NewIterator(engine.IterOptions{
+		MinTimestampHint: h.Txn.OrigTimestamp,
+		MaxTimestampHint: h.Txn.Timestamp,
+		UpperBound:       args.EndKey,
+	})
 	defer iter.Close()
 	// Iterate over values until we discover any value written at or
 	// after the original timestamp, but before or at the current

--- a/pkg/storage/batcheval/cmd_resolve_intent_range.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_range.go
@@ -56,10 +56,14 @@ func ResolveIntentRange(
 	// Use a time-bounded iterator as an optimization if indicated.
 	var iterAndBuf engine.IterAndBuf
 	if args.MinTimestamp != (hlc.Timestamp{}) {
-		iter := batch.NewTimeBoundIterator(args.MinTimestamp, args.IntentTxn.Timestamp, false)
+		iter := batch.NewIterator(engine.IterOptions{
+			MinTimestampHint: args.MinTimestamp,
+			MaxTimestampHint: args.IntentTxn.Timestamp,
+			UpperBound:       args.EndKey,
+		})
 		iterAndBuf = engine.GetBufUsingIter(iter)
 	} else {
-		iterAndBuf = engine.GetIterAndBuf(batch)
+		iterAndBuf = engine.GetIterAndBuf(batch, engine.IterOptions{UpperBound: args.EndKey})
 	}
 	defer iterAndBuf.Cleanup()
 

--- a/pkg/storage/batcheval/cmd_truncate_log.go
+++ b/pkg/storage/batcheval/cmd_truncate_log.go
@@ -96,7 +96,7 @@ func TruncateLog(
 		//
 		// Note that any sideloaded payloads that may be removed by this truncation
 		// don't matter; they're not tracked in the raft log delta.
-		iter := batch.NewIterator(engine.IterOptions{})
+		iter := batch.NewIterator(engine.IterOptions{UpperBound: end.Key})
 		defer iter.Close()
 		// We can pass zero as nowNanos because we're only interested in SysBytes.
 		var err error

--- a/pkg/storage/client_metrics_test.go
+++ b/pkg/storage/client_metrics_test.go
@@ -134,7 +134,7 @@ func verifyRocksDBStats(t *testing.T, s *storage.Store) {
 		gauge *metric.Gauge
 		min   int64
 	}{
-		{m.RdbBlockCacheHits, 4},
+		{m.RdbBlockCacheHits, 10},
 		{m.RdbBlockCacheMisses, 0},
 		{m.RdbBlockCacheUsage, 0},
 		{m.RdbBlockCachePinnedUsage, 0},

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -382,7 +382,7 @@ func TestStoreRangeSplitIntents(t *testing.T) {
 	// Verify the transaction record is gone.
 	start := engine.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(roachpb.RKeyMin))
 	end := engine.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(roachpb.RKeyMax))
-	iter := store.Engine().NewIterator(engine.IterOptions{})
+	iter := store.Engine().NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 
 	defer iter.Close()
 	for iter.Seek(start); ; iter.Next() {

--- a/pkg/storage/engine/bench_test.go
+++ b/pkg/storage/engine/bench_test.go
@@ -155,7 +155,7 @@ func runMVCCScan(emk engineMaker, numRows, numVersions, valueSize int, reverse b
 		// Pull all of the sstables into the RocksDB cache in order to make the
 		// timings more stable. Otherwise, the first run will be penalized pulling
 		// data into the cache while later runs will not.
-		iter := eng.NewIterator(IterOptions{})
+		iter := eng.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
 		_, _ = iter.ComputeStats(MakeMVCCMetadataKey(roachpb.KeyMin), MakeMVCCMetadataKey(roachpb.KeyMax), 0)
 		iter.Close()
 	}
@@ -594,7 +594,7 @@ func runMVCCComputeStats(emk engineMaker, valueBytes int, b *testing.B) {
 	var stats enginepb.MVCCStats
 	var err error
 	for i := 0; i < b.N; i++ {
-		iter := eng.NewIterator(IterOptions{})
+		iter := eng.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
 		stats, err = iter.ComputeStats(mvccKey(roachpb.KeyMin), mvccKey(roachpb.KeyMax), 0)
 		iter.Close()
 		if err != nil {
@@ -729,7 +729,7 @@ func BenchmarkClearRange_RocksDB(b *testing.B) {
 
 func BenchmarkClearIterRange_RocksDB(b *testing.B) {
 	runBenchmarkClearRange(b, func(eng Engine, batch Batch, start, end MVCCKey) error {
-		iter := eng.NewIterator(IterOptions{})
+		iter := eng.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
 		defer iter.Close()
 		return batch.ClearIterRange(iter, start, end)
 	})

--- a/pkg/storage/engine/disk_map.go
+++ b/pkg/storage/engine/disk_map.go
@@ -225,7 +225,13 @@ func (r *RocksDBMap) NewIterator() SortedDiskMapIterator {
 	// NOTE: prefix is only false because we can't use the normal prefix
 	// extractor. This iterator still only does prefix iteration. See
 	// RocksDBMapIterator.Valid().
-	return &RocksDBMapIterator{iter: r.store.NewIterator(IterOptions{}), makeKey: r.makeKey, prefix: r.prefix}
+	return &RocksDBMapIterator{
+		iter: r.store.NewIterator(IterOptions{
+			UpperBound: roachpb.Key(r.prefix).PrefixEnd(),
+		}),
+		makeKey: r.makeKey,
+		prefix:  r.prefix,
+	}
 }
 
 // NewBatchWriter implements the SortedDiskMap interface.

--- a/pkg/storage/engine/disk_map_test.go
+++ b/pkg/storage/engine/disk_map_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -196,7 +197,7 @@ func TestRocksDBMapSandbox(t *testing.T) {
 			diskMaps[j].Close(ctx)
 			numKeysRemaining := 0
 			func() {
-				i := tempEngine.NewIterator(IterOptions{})
+				i := tempEngine.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
 				defer i.Close()
 				for i.Seek(NilKey); ; i.Next() {
 					if ok, err := i.Valid(); err != nil {

--- a/pkg/storage/engine/mvcc_stats_test.go
+++ b/pkg/storage/engine/mvcc_stats_test.go
@@ -49,7 +49,7 @@ func assertEq(t *testing.T, engine ReadWriter, debug string, ms, expMS *enginepb
 		t.Errorf("%s: diff(ms, expMS) nontrivial", debug)
 	}
 
-	it := engine.NewIterator(IterOptions{})
+	it := engine.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
 	defer it.Close()
 	from, to := MVCCKey{}, MVCCKey{Key: roachpb.KeyMax}
 
@@ -1466,7 +1466,7 @@ func TestMVCCComputeStatsError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	iter := engine.NewIterator(IterOptions{})
+	iter := engine.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
 	defer iter.Close()
 	for _, mvccStatsTest := range mvccStatsTests {
 		t.Run(mvccStatsTest.name, func(t *testing.T) {

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -3832,7 +3832,7 @@ func TestMVCCGarbageCollect(t *testing.T) {
 	}
 
 	// Verify aggregated stats match computed stats after GC.
-	iter := engine.NewIterator(IterOptions{})
+	iter := engine.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
 	defer iter.Close()
 	for _, mvccStatsTest := range mvccStatsTests {
 		t.Run(mvccStatsTest.name, func(t *testing.T) {

--- a/pkg/storage/engine/rocksdb_iter_stats_test.go
+++ b/pkg/storage/engine/rocksdb_iter_stats_test.go
@@ -41,10 +41,8 @@ func TestIterStats(t *testing.T) {
 	defer batch.Close()
 
 	testCases := []Iterator{
-		db.NewIterator(IterOptions{WithStats: true}),
-		db.NewTimeBoundIterator(hlc.Timestamp{}, hlc.Timestamp{WallTime: 999}, true /* withStats */),
-		batch.NewIterator(IterOptions{WithStats: true}),
-		batch.NewTimeBoundIterator(hlc.Timestamp{}, hlc.Timestamp{WallTime: 999}, true /* withStats */),
+		db.NewIterator(IterOptions{UpperBound: roachpb.KeyMax, WithStats: true}),
+		batch.NewIterator(IterOptions{UpperBound: roachpb.KeyMax, WithStats: true}),
 	}
 
 	defer func() {

--- a/pkg/storage/rditer/replica_data_iter.go
+++ b/pkg/storage/rditer/replica_data_iter.go
@@ -90,14 +90,8 @@ func makeReplicaKeyRanges(
 func NewReplicaDataIterator(
 	d *roachpb.RangeDescriptor, e engine.Reader, replicatedOnly bool,
 ) *ReplicaDataIterator {
-	return WrapWithReplicaDataIterator(d, e.NewIterator(engine.IterOptions{}), replicatedOnly)
-}
+	it := e.NewIterator(engine.IterOptions{UpperBound: d.EndKey.AsRawKey()})
 
-// WrapWithReplicaDataIterator creates a ReplicaDataIterator for the given
-// replica that wraps the provided iterator.
-func WrapWithReplicaDataIterator(
-	d *roachpb.RangeDescriptor, it engine.SimpleIterator, replicatedOnly bool,
-) *ReplicaDataIterator {
 	rangeFunc := MakeAllKeyRanges
 	if replicatedOnly {
 		rangeFunc = MakeReplicatedKeyRanges

--- a/pkg/storage/rditer/stats.go
+++ b/pkg/storage/rditer/stats.go
@@ -26,7 +26,7 @@ import (
 func ComputeStatsForRange(
 	d *roachpb.RangeDescriptor, e engine.Reader, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
-	iter := e.NewIterator(engine.IterOptions{})
+	iter := e.NewIterator(engine.IterOptions{UpperBound: d.EndKey.AsRawKey()})
 	defer iter.Close()
 
 	ms := enginepb.MVCCStats{}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5642,7 +5642,7 @@ func optimizePuts(
 	if firstUnoptimizedIndex < optimizePutThreshold { // don't bother if below this threshold
 		return origReqs
 	}
-	iter := batch.NewIterator(engine.IterOptions{})
+	iter := batch.NewIterator(engine.IterOptions{UpperBound: maxKey})
 	defer iter.Close()
 
 	// If there are enough puts in the run to justify calling seek,

--- a/pkg/storage/replica_consistency.go
+++ b/pkg/storage/replica_consistency.go
@@ -375,7 +375,7 @@ func (r *Replica) sha512(
 	snapshot *roachpb.RaftSnapshotData,
 ) (*replicaHash, error) {
 	// Iterate over all the data in the range.
-	iter := snap.NewIterator(engine.IterOptions{})
+	iter := snap.NewIterator(engine.IterOptions{UpperBound: desc.EndKey.AsRawKey()})
 	defer iter.Close()
 
 	var alloc bufalloc.ByteAllocator

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -543,7 +543,7 @@ func (r *Replica) handleReplicatedEvalResult(
 				end := engine.MakeMVCCMetadataKey(
 					keys.RaftLogKey(r.RangeID, newTruncState.Index).PrefixEnd(),
 				)
-				iter := r.store.Engine().NewIterator(engine.IterOptions{})
+				iter := r.store.Engine().NewIterator(engine.IterOptions{UpperBound: end.Key})
 				// Clear the log entries. Intentionally don't use range deletion
 				// tombstones (ClearRange()) due to performance concerns connected
 				// to having many range deletion tombstones. There is a chance that

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -643,7 +643,7 @@ func clearRangeData(
 	batch engine.Batch,
 	destroyData bool,
 ) error {
-	iter := eng.NewIterator(engine.IterOptions{})
+	iter := eng.NewIterator(engine.IterOptions{UpperBound: desc.EndKey.AsRawKey()})
 	defer iter.Close()
 
 	// It is expensive for there to be many range deletion tombstones in the same

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -237,12 +237,6 @@ func (s spanSetReader) NewIterator(opts engine.IterOptions) engine.Iterator {
 	return &Iterator{s.r.NewIterator(opts), s.spans, nil, false}
 }
 
-func (s spanSetReader) NewTimeBoundIterator(
-	start, end hlc.Timestamp, withStats bool,
-) engine.Iterator {
-	return &Iterator{s.r.NewTimeBoundIterator(start, end, withStats), s.spans, nil, false}
-}
-
 type spanSetWriter struct {
 	w     engine.Writer
 	spans *SpanSet

--- a/pkg/storage/stateloader/stateloader.go
+++ b/pkg/storage/stateloader/stateloader.go
@@ -499,7 +499,7 @@ func (rsl StateLoader) SetTxnSpanGCThreshold(
 
 // LoadLastIndex loads the last index.
 func (rsl StateLoader) LoadLastIndex(ctx context.Context, reader engine.Reader) (uint64, error) {
-	iter := reader.NewIterator(engine.IterOptions{})
+	iter := reader.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 	defer iter.Close()
 
 	var lastIndex uint64

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1163,7 +1163,9 @@ func IterateIDPrefixKeys(
 	f func(_ roachpb.RangeID) (more bool, _ error),
 ) error {
 	rangeID := roachpb.RangeID(1)
-	iter := eng.NewIterator(engine.IterOptions{})
+	iter := eng.NewIterator(engine.IterOptions{
+		UpperBound: keys.LocalRangeIDPrefix.PrefixEnd().AsRawKey(),
+	})
 	defer iter.Close()
 
 	for {

--- a/pkg/ts/pruning.go
+++ b/pkg/ts/pruning.go
@@ -84,9 +84,6 @@ func (tsdb *DB) findTimeSeries(
 ) ([]timeSeriesResolutionInfo, error) {
 	var results []timeSeriesResolutionInfo
 
-	iter := snapshot.NewIterator(engine.IterOptions{})
-	defer iter.Close()
-
 	// Set start boundary for the search, which is the lesser of the range start
 	// key and the beginning of time series data.
 	start := engine.MakeMVCCMetadataKey(startKey.AsRawKey())
@@ -104,6 +101,9 @@ func (tsdb *DB) findTimeSeries(
 	}
 
 	thresholds := tsdb.computeThresholds(now.WallTime)
+
+	iter := snapshot.NewIterator(engine.IterOptions{UpperBound: endKey.AsRawKey()})
+	defer iter.Close()
 
 	for iter.Seek(next); ; iter.Seek(next) {
 		if ok, err := iter.Valid(); err != nil {


### PR DESCRIPTION
As promised. The issue the first commit fixes took longer than I'd like to admit to track down.

I've done my best to keep the patch as small as possible in case we want to backport to 2.0. The changes to the C++ DBIterator are unfortunately large, though. Open to less disruptive ways of plumbing the upper bound there, but I'm not seeing anything obvious.

---

While investigating range deletion performance issues, we realized that
large swaths of contiguous tombstones can cause massive performance
issues when seeking. Seeks of more than 15 minutes (!) were observed on
one cluster [0]. The problem is that every key overlapping the range
deletion tombstone must be loaded from disk, decompressed, and compared
with the sequence number of the tombstone until a key is found that is
not covered by the tombstone. If contiguous keys representing hundreds
of gigabytes are covered by tombstones, RocksDB will need to scan
hundreds of gigabytes of data. Needless to say, performance suffers.

We have plans to improve seek performance in the face of range deletion
tombstones upstream, but we can mitigate the issue locally, too.
Iteration outside of tests is nearly always in the context of a range or
some bounded span of local keys. By plumbing knowledge of the upper
bound we care about for each scan to RocksDB, we can invalidate the
iterator early, once the upper bound has been exceeded, rather than
scanning over potentially hundreds of gigabytes of deleted keys just to
find a key that we don't care about.

To ensure we don't forget to specify an upper bound in a critical path,
this commit requires that all iterators are either prefix iterators or
declare their upper bound. This makes iterating in tests rather irksome,
but I think the tradeoff is worthwhile.

[0]: https://github.com/cockroachdb/cockroach/issues/24029#issuecomment-395442284