### PR TITLE
opt: display float costs and stats more accurately

### DIFF
--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -360,7 +360,7 @@ func (ev ExprView) formatRelational(f *opt.ExprFmtCtx, tp treeprinter.Node) {
 	}
 
 	if !f.HasFlags(opt.ExprFmtHideCost) && ev.best != normBestOrdinal {
-		tp.Childf("cost: %.2f", ev.bestExpr().cost)
+		tp.Childf("cost: %.9g", ev.bestExpr().cost)
 	}
 
 	// Format functional dependencies.

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -124,7 +124,7 @@ func TestGetStatsFromConstraint(t *testing.T) {
 	cs2 := constraint.SingleConstraint(&c2)
 	statsFunc123(
 		cs2,
-		"[rows=3333333333]",
+		"[rows=3.33333333e+09]",
 		1.0/3,
 	)
 
@@ -187,7 +187,7 @@ func TestGetStatsFromConstraint(t *testing.T) {
 	cs45 := constraint.SingleSpanConstraint(&keyCtx45, &sp45)
 	statsFunc45(
 		cs45,
-		"[rows=1000000000, distinct(4)=1]",
+		"[rows=1e+09, distinct(4)=1]",
 		1.0/10,
 	)
 }

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -23,7 +23,7 @@ SELECT * FROM a WHERE x > 1
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000]
@@ -37,7 +37,7 @@ SELECT * FROM a WHERE x >= 1
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000]
@@ -51,7 +51,7 @@ SELECT * FROM a WHERE x < 1
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000]
@@ -65,7 +65,7 @@ SELECT * FROM a WHERE x <= 1
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000]
@@ -79,7 +79,7 @@ SELECT * FROM a WHERE x = 1
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=1.43, distinct(1)=1]
+ ├── stats: [rows=1.42857143, distinct(1)=1]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000, distinct(1)=700]
@@ -93,7 +93,7 @@ SELECT * FROM a WHERE x > 1 AND x < 5
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=4.29, distinct(1)=3]
+ ├── stats: [rows=4.28571429, distinct(1)=3]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000, distinct(1)=700]
@@ -110,7 +110,7 @@ SELECT * FROM a WHERE x = 1 AND y = 5
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null)
- ├── stats: [rows=0.0020, distinct(1)=0.0020, distinct(2)=0.0020]
+ ├── stats: [rows=0.00204081633, distinct(1)=0.00204081633, distinct(2)=0.00204081633]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000, distinct(1)=700, distinct(2)=700]
@@ -127,7 +127,7 @@ SELECT * FROM a WHERE x > 1 AND x < 5 AND y >= 7 AND y <= 9
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null)
- ├── stats: [rows=0.0184, distinct(1)=0.0184, distinct(2)=0.0184]
+ ├── stats: [rows=0.0183673469, distinct(1)=0.0183673469, distinct(2)=0.0183673469]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000, distinct(1)=700, distinct(2)=700]
@@ -151,7 +151,7 @@ SELECT * FROM a WHERE x > 1 AND x < 5 AND x + y = 5
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=37.04]
+ ├── stats: [rows=37.037037]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000]
@@ -173,7 +173,7 @@ SELECT * FROM a WHERE x > 1 AND x + y >= 5 AND x + y <= 7
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=37.04]
+ ├── stats: [rows=37.037037]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000]
@@ -198,7 +198,7 @@ SELECT * FROM a WHERE x > 1.5
 ----
 select
  ├── columns: x:1(int) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000]
@@ -212,7 +212,7 @@ SELECT * FROM kuv WHERE u > 1::INT
 ----
 select
  ├── columns: k:1(int!null) u:2(float) v:3(string)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── scan kuv
@@ -230,7 +230,7 @@ SELECT * FROM kuv WHERE v <= 'foo' AND v >= 'bar'
 ----
 select
  ├── columns: k:1(int!null) u:2(float) v:3(string!null)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── scan kuv
@@ -252,7 +252,7 @@ SELECT * FROM a WHERE x IN (1, 2, 3, NULL)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=4.29, distinct(1)=3]
+ ├── stats: [rows=4.28571429, distinct(1)=3]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000, distinct(1)=700]
@@ -271,7 +271,7 @@ SELECT * FROM a WHERE x IN (NULL)
 scan a
  ├── columns: x:1(int) y:2(int)
  ├── constraint: /3: contradiction
- └── stats: [rows=333]
+ └── stats: [rows=333.333333]
 
 # Test IN in combination with another condition on the same column (which rules
 # out some of the entries in the IN condition).
@@ -280,7 +280,7 @@ SELECT * FROM a WHERE x IN (1, 3, 5, 7, 9) AND x > 6
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=2.86, distinct(1)=2]
+ ├── stats: [rows=2.85714286, distinct(1)=2]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000, distinct(1)=700]
@@ -303,7 +303,7 @@ SELECT * FROM a WHERE x IN (1, 3) AND y > 4
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null)
- ├── stats: [rows=0.9524, distinct(1)=0.9524]
+ ├── stats: [rows=0.952380952, distinct(1)=0.952380952]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000, distinct(1)=700]
@@ -323,7 +323,7 @@ SELECT * FROM a WHERE (x, y) > (1, 2)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000]
@@ -341,7 +341,7 @@ SELECT * FROM a WHERE (x, y) >= (1, 2)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000]
@@ -359,7 +359,7 @@ SELECT * FROM a WHERE (x, y) < (1, 2)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000]
@@ -377,7 +377,7 @@ SELECT * FROM a WHERE (x, y) <= (1, 2)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000]
@@ -396,7 +396,7 @@ SELECT * FROM a WHERE (x, y) >= (1, 2.5)
 ----
 select
  ├── columns: x:1(int) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000]
@@ -415,7 +415,7 @@ SELECT * FROM a WHERE (x, y) >= (1, NULL)
 ----
 select
  ├── columns: x:1(int) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000]
@@ -435,7 +435,7 @@ SELECT * FROM a WHERE (x, 1) >= (1, 2)
 ----
 select
  ├── columns: x:1(int) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000]
@@ -464,7 +464,7 @@ SELECT * FROM abc WHERE a != 5
 ----
 select
  ├── columns: a:1(int!null) b:2(bool) c:3(string)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    └── stats: [rows=1000]
@@ -478,7 +478,7 @@ SELECT * FROM abc WHERE a IS DISTINCT FROM 5
 ----
 select
  ├── columns: a:1(int) b:2(bool) c:3(string)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    └── stats: [rows=1000]
@@ -492,7 +492,7 @@ SELECT * FROM abc WHERE b != true
 ----
 select
  ├── columns: a:1(int) b:2(bool!null) c:3(string)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    └── stats: [rows=1000]
@@ -506,7 +506,7 @@ SELECT * FROM abc WHERE b != false
 ----
 select
  ├── columns: a:1(int) b:2(bool!null) c:3(string)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    └── stats: [rows=1000]
@@ -520,7 +520,7 @@ SELECT * FROM abc WHERE b IS NOT true
 ----
 select
  ├── columns: a:1(int) b:2(bool) c:3(string)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    └── stats: [rows=1000]
@@ -534,7 +534,7 @@ SELECT * FROM abc WHERE b IS NOT false
 ----
 select
  ├── columns: a:1(int) b:2(bool) c:3(string)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    └── stats: [rows=1000]
@@ -548,7 +548,7 @@ SELECT * FROM abc WHERE b
 ----
 select
  ├── columns: a:1(int) b:2(bool!null) c:3(string)
- ├── stats: [rows=1.43, distinct(2)=1]
+ ├── stats: [rows=1.42857143, distinct(2)=1]
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    └── stats: [rows=1000, distinct(2)=700]
@@ -560,7 +560,7 @@ SELECT * FROM abc WHERE NOT b
 ----
 select
  ├── columns: a:1(int) b:2(bool!null) c:3(string)
- ├── stats: [rows=1.43, distinct(2)=1]
+ ├── stats: [rows=1.42857143, distinct(2)=1]
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    └── stats: [rows=1000, distinct(2)=700]
@@ -573,7 +573,7 @@ SELECT * FROM abc WHERE a > 5 AND b
 ----
 select
  ├── columns: a:1(int!null) b:2(bool!null) c:3(string)
- ├── stats: [rows=0.4762, distinct(2)=0.4762]
+ ├── stats: [rows=0.476190476, distinct(2)=0.476190476]
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    └── stats: [rows=1000, distinct(2)=700]
@@ -588,7 +588,7 @@ SELECT * FROM abc WHERE c != 'foo'
 ----
 select
  ├── columns: a:1(int) b:2(bool) c:3(string!null)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    └── stats: [rows=1000]
@@ -602,7 +602,7 @@ SELECT * FROM abc WHERE c IS DISTINCT FROM 'foo'
 ----
 select
  ├── columns: a:1(int) b:2(bool) c:3(string)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    └── stats: [rows=1000]
@@ -616,7 +616,7 @@ SELECT * FROM (SELECT (x, y) AS col FROM a) WHERE col > (1, 2)
 ----
 select
  ├── columns: col:4(tuple{int, int}!null)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── project
  │    ├── columns: col:4(tuple{int, int})
  │    ├── stats: [rows=1000]
@@ -660,7 +660,7 @@ SELECT * FROM c WHERE (v, u) IN ((1, 2), (3, 50), (5, 100))
 scan c@v
  ├── columns: k:1(int!null) u:2(int!null) v:3(int!null)
  ├── constraint: /3/2/1: [/1/2 - /1/2] [/3/50 - /3/50] [/5/100 - /5/100]
- ├── stats: [rows=0.0061, distinct(2)=0.0061, distinct(3)=0.0061]
+ ├── stats: [rows=0.00612244898, distinct(2)=0.00612244898, distinct(3)=0.00612244898]
  ├── key: (1)
  └── fd: (1)-->(2,3)
 
@@ -671,7 +671,7 @@ SELECT * FROM c WHERE (v, u) IN ((1, 2), (3, 50), (5, NULL))
 scan c@v
  ├── columns: k:1(int!null) u:2(int!null) v:3(int!null)
  ├── constraint: /3/2/1: [/1/2 - /1/2] [/3/50 - /3/50]
- ├── stats: [rows=0.0041, distinct(2)=0.0041, distinct(3)=0.0041]
+ ├── stats: [rows=0.00408163265, distinct(2)=0.00408163265, distinct(3)=0.00408163265]
  ├── key: (1)
  └── fd: (1)-->(2,3)
 
@@ -682,13 +682,13 @@ SELECT * FROM c WHERE (v, 2) IN ((1, 2), (3, 50), (5, 100))
 ----
 select
  ├── columns: k:1(int!null) u:2(int) v:3(int!null)
- ├── stats: [rows=4.29, distinct(3)=3]
+ ├── stats: [rows=4.28571429, distinct(3)=3]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── scan c@v
  │    ├── columns: k:1(int!null) u:2(int) v:3(int!null)
  │    ├── constraint: /3/2/1: [/1 - /1] [/3 - /3] [/5 - /5]
- │    ├── stats: [rows=4.29, distinct(3)=3]
+ │    ├── stats: [rows=4.28571429, distinct(3)=3]
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3)
  └── filters [type=bool, outer=(3), constraints=(/3: [/1 - /1] [/3 - /3] [/5 - /5])]
@@ -715,13 +715,13 @@ SELECT * FROM c WHERE (v, u + v) IN ((1, 2), (3, 50), (5, 100))
 ----
 select
  ├── columns: k:1(int!null) u:2(int) v:3(int!null)
- ├── stats: [rows=4.29, distinct(3)=3]
+ ├── stats: [rows=4.28571429, distinct(3)=3]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── scan c@v
  │    ├── columns: k:1(int!null) u:2(int) v:3(int!null)
  │    ├── constraint: /3/2/1: [/1 - /1] [/3 - /3] [/5 - /5]
- │    ├── stats: [rows=4.29, distinct(3)=3]
+ │    ├── stats: [rows=4.28571429, distinct(3)=3]
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3)
  └── filters [type=bool, outer=(2,3), constraints=(/3: [/1 - /1] [/3 - /3] [/5 - /5])]
@@ -747,7 +747,7 @@ SELECT * FROM c WHERE (v, u) IN ((1, 2), (k, 50), (5, 100))
 ----
 select
  ├── columns: k:1(int!null) u:2(int!null) v:3(int)
- ├── stats: [rows=4.29, distinct(2)=3]
+ ├── stats: [rows=4.28571429, distinct(2)=3]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── scan c

--- a/pkg/sql/opt/memo/testdata/logprops/constraints-null
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints-null
@@ -15,7 +15,7 @@ SELECT * FROM t WHERE a = NULL
 scan t
  ├── columns: a:1(int) b:2(bool) c:3(string)
  ├── constraint: /4: contradiction
- └── stats: [rows=333]
+ └── stats: [rows=333.333333]
 
 opt
 SELECT * FROM t WHERE a < NULL
@@ -23,14 +23,14 @@ SELECT * FROM t WHERE a < NULL
 scan t
  ├── columns: a:1(int) b:2(bool) c:3(string)
  ├── constraint: /4: contradiction
- └── stats: [rows=333]
+ └── stats: [rows=333.333333]
 
 opt
 SELECT * FROM t WHERE a IS NULL
 ----
 select
  ├── columns: a:1(int) b:2(bool) c:3(string)
- ├── stats: [rows=1.43, distinct(1)=1]
+ ├── stats: [rows=1.42857143, distinct(1)=1]
  ├── scan t
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    └── stats: [rows=1000, distinct(1)=700]
@@ -44,7 +44,7 @@ SELECT * FROM t WHERE a IS NOT NULL
 ----
 select
  ├── columns: a:1(int!null) b:2(bool) c:3(string)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan t
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    └── stats: [rows=1000]
@@ -58,7 +58,7 @@ SELECT * FROM t WHERE b IS NULL AND c IS NULL
 ----
 select
  ├── columns: a:1(int) b:2(bool) c:3(string)
- ├── stats: [rows=0.0020, distinct(2)=0.0020, distinct(3)=0.0020]
+ ├── stats: [rows=0.00204081633, distinct(2)=0.00204081633, distinct(3)=0.00204081633]
  ├── scan t
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    └── stats: [rows=1000, distinct(2)=700, distinct(3)=700]
@@ -75,7 +75,7 @@ SELECT * FROM t WHERE b IS NOT NULL AND c IS NOT NULL
 ----
 select
  ├── columns: a:1(int) b:2(bool!null) c:3(string!null)
- ├── stats: [rows=111]
+ ├── stats: [rows=111.111111]
  ├── scan t
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    └── stats: [rows=1000]
@@ -106,7 +106,7 @@ SELECT * FROM xy WHERE x > abs(y)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan xy
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000]
@@ -122,7 +122,7 @@ SELECT * FROM xy WHERE sin(x::float)::int < x
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── scan xy
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000]
@@ -140,7 +140,7 @@ SELECT * FROM xy WHERE x > y
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null)
- ├── stats: [rows=111]
+ ├── stats: [rows=111.111111]
  ├── scan xy
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000]
@@ -155,7 +155,7 @@ SELECT * FROM xy WHERE x = y
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null)
- ├── stats: [rows=111]
+ ├── stats: [rows=111.111111]
  ├── scan xy
  │    ├── columns: x:1(int) y:2(int)
  │    └── stats: [rows=1000]

--- a/pkg/sql/opt/memo/testdata/logprops/groupby
+++ b/pkg/sql/opt/memo/testdata/logprops/groupby
@@ -175,7 +175,7 @@ SELECT * FROM xyzs WHERE (SELECT sum(x) FROM (SELECT y, u FROM kuv) GROUP BY u) 
 ----
 select
  ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan xyzs

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -143,7 +143,7 @@ project
       │    │    └── select
       │    │         ├── columns: u:5(int!null)
       │    │         ├── outer: (1)
-      │    │         ├── stats: [rows=111]
+      │    │         ├── stats: [rows=111.111111]
       │    │         ├── scan uv
       │    │         │    ├── columns: u:5(int)
       │    │         │    └── stats: [rows=1000]
@@ -219,11 +219,11 @@ right-join
  │         │    │    └── offset
  │         │    │         ├── columns: uv.u:8(int!null)
  │         │    │         ├── outer: (1)
- │         │    │         ├── stats: [rows=110]
+ │         │    │         ├── stats: [rows=110.111111]
  │         │    │         ├── select
  │         │    │         │    ├── columns: uv.u:8(int!null)
  │         │    │         │    ├── outer: (1)
- │         │    │         │    ├── stats: [rows=111]
+ │         │    │         │    ├── stats: [rows=111.111111]
  │         │    │         │    ├── scan uv
  │         │    │         │    │    ├── columns: uv.u:8(int)
  │         │    │         │    │    └── stats: [rows=1000]
@@ -301,11 +301,11 @@ project
       │    │    └── offset
       │    │         ├── columns: uv.u:8(int!null)
       │    │         ├── outer: (1)
-      │    │         ├── stats: [rows=110]
+      │    │         ├── stats: [rows=110.111111]
       │    │         ├── select
       │    │         │    ├── columns: uv.u:8(int!null)
       │    │         │    ├── outer: (1)
-      │    │         │    ├── stats: [rows=111]
+      │    │         │    ├── stats: [rows=111.111111]
       │    │         │    ├── scan uv
       │    │         │    │    ├── columns: uv.u:8(int)
       │    │         │    │    └── stats: [rows=1000]
@@ -348,7 +348,7 @@ SELECT * FROM xysd WHERE EXISTS(SELECT * FROM uv WHERE v=x OFFSET 1)
 ----
 semi-join-apply
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- ├── stats: [rows=110111]
+ ├── stats: [rows=110111.111]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan xysd
@@ -359,11 +359,11 @@ semi-join-apply
  ├── offset
  │    ├── columns: u:5(int) v:6(int!null)
  │    ├── outer: (1)
- │    ├── stats: [rows=110]
+ │    ├── stats: [rows=110.111111]
  │    ├── select
  │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    ├── outer: (1)
- │    │    ├── stats: [rows=111]
+ │    │    ├── stats: [rows=111.111111]
  │    │    ├── scan uv
  │    │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    │    └── stats: [rows=1000]
@@ -402,7 +402,7 @@ SELECT * FROM xysd WHERE NOT EXISTS(SELECT * FROM uv WHERE v=x OFFSET 1)
 ----
 anti-join-apply
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- ├── stats: [rows=110111]
+ ├── stats: [rows=110111.111]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan xysd
@@ -413,11 +413,11 @@ anti-join-apply
  ├── offset
  │    ├── columns: u:5(int) v:6(int!null)
  │    ├── outer: (1)
- │    ├── stats: [rows=110]
+ │    ├── stats: [rows=110.111111]
  │    ├── select
  │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    ├── outer: (1)
- │    │    ├── stats: [rows=111]
+ │    │    ├── stats: [rows=111.111111]
  │    │    ├── scan uv
  │    │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    │    └── stats: [rows=1000]
@@ -480,7 +480,7 @@ SELECT * FROM xysd WHERE EXISTS(SELECT * FROM (SELECT x) INNER JOIN (SELECT y) O
 ----
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan xysd
@@ -494,7 +494,7 @@ select
                 ├── columns: x:5(int) y:6(int)
                 ├── outer: (1-3)
                 ├── cardinality: [0 - 1]
-                ├── stats: [rows=0.1000]
+                ├── stats: [rows=0.1]
                 ├── key: ()
                 ├── fd: ()-->(5,6)
                 ├── project
@@ -590,7 +590,7 @@ semi-join-apply
  │    ├── select
  │    │    ├── columns: u:5(int!null) v:6(int!null)
  │    │    ├── outer: (1)
- │    │    ├── stats: [rows=111]
+ │    │    ├── stats: [rows=111.111111]
  │    │    ├── scan uv
  │    │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    │    └── stats: [rows=1000]
@@ -651,7 +651,7 @@ anti-join-apply
  │    ├── select
  │    │    ├── columns: u:5(int!null) v:6(int!null)
  │    │    ├── outer: (1)
- │    │    ├── stats: [rows=111]
+ │    │    ├── stats: [rows=111.111111]
  │    │    ├── scan uv
  │    │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    │    └── stats: [rows=1000]
@@ -669,7 +669,7 @@ SELECT * FROM (VALUES (1), (2)) INNER JOIN (SELECT * FROM uv LIMIT 2) ON True
 inner-join
  ├── columns: column1:1(int) u:2(int) v:3(int!null)
  ├── cardinality: [0 - 4]
- ├── stats: [rows=0.4000]
+ ├── stats: [rows=0.4]
  ├── values
  │    ├── columns: column1:1(int)
  │    ├── cardinality: [2 - 2]
@@ -701,7 +701,7 @@ SELECT * FROM (VALUES (1), (2), (3)) LEFT JOIN (SELECT * FROM uv LIMIT 2) ON Tru
 left-join
  ├── columns: column1:1(int) u:2(int) v:3(int)
  ├── cardinality: [0 - 6]
- ├── stats: [rows=0.6000]
+ ├── stats: [rows=0.6]
  ├── values
  │    ├── columns: column1:1(int)
  │    ├── cardinality: [3 - 3]
@@ -735,7 +735,7 @@ SELECT * FROM (SELECT * FROM uv LIMIT 2) RIGHT JOIN (VALUES (1), (2), (3)) ON Tr
 right-join
  ├── columns: u:1(int) v:2(int) column1:4(int)
  ├── cardinality: [0 - 6]
- ├── stats: [rows=0.6000]
+ ├── stats: [rows=0.6]
  ├── limit
  │    ├── columns: u:1(int) v:2(int!null)
  │    ├── cardinality: [0 - 2]
@@ -769,7 +769,7 @@ SELECT * FROM (VALUES (NULL), (NULL)) a FULL JOIN (VALUES (NULL), (NULL)) b ON T
 full-join
  ├── columns: column1:1(unknown) column1:2(unknown)
  ├── cardinality: [0 - 4]
- ├── stats: [rows=0.4000]
+ ├── stats: [rows=0.4]
  ├── values
  │    ├── columns: column1:1(unknown)
  │    ├── cardinality: [2 - 2]
@@ -796,7 +796,7 @@ SELECT * FROM (VALUES (NULL), (NULL)) a FULL JOIN (VALUES (NULL), (NULL)) b ON a
 full-join
  ├── columns: column1:1(unknown) column1:2(unknown)
  ├── cardinality: [0 - 4]
- ├── stats: [rows=0.4000]
+ ├── stats: [rows=0.4]
  ├── values
  │    ├── columns: column1:1(unknown)
  │    ├── cardinality: [2 - 2]
@@ -847,7 +847,7 @@ SELECT * FROM (SELECT * FROM xysd LIMIT 1) FULL JOIN (SELECT * FROM xysd LIMIT 1
 full-join
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) x:5(int) y:6(int) s:7(string) d:8(decimal)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=0.1000]
+ ├── stats: [rows=0.1]
  ├── key: ()
  ├── fd: ()-->(1-8)
  ├── limit
@@ -919,7 +919,7 @@ SELECT * FROM xysd LEFT JOIN (SELECT u, sum(v) FROM uv WHERE u IS NOT NULL GROUP
 ----
 left-join
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) sum:8(decimal)
- ├── stats: [rows=30777]
+ ├── stats: [rows=30777.1544]
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (5)-->(8)
  ├── scan xysd
@@ -930,15 +930,15 @@ left-join
  ├── group-by
  │    ├── columns: u:5(int!null) sum:8(decimal)
  │    ├── grouping columns: u:5(int!null)
- │    ├── stats: [rows=308, distinct(5)=308]
+ │    ├── stats: [rows=307.771544, distinct(5)=307.771544]
  │    ├── key: (5)
  │    ├── fd: (5)-->(8)
  │    ├── project
  │    │    ├── columns: u:5(int!null) v:6(int!null)
- │    │    ├── stats: [rows=333, distinct(5)=308]
+ │    │    ├── stats: [rows=333.333333, distinct(5)=307.771544]
  │    │    └── select
  │    │         ├── columns: u:5(int!null) v:6(int!null) rowid:7(int!null)
- │    │         ├── stats: [rows=333, distinct(5)=308]
+ │    │         ├── stats: [rows=333.333333, distinct(5)=307.771544]
  │    │         ├── key: (7)
  │    │         ├── fd: (7)-->(5,6)
  │    │         ├── scan uv
@@ -998,21 +998,21 @@ SELECT * FROM (SELECT u, sum(v) FROM uv WHERE u IS NOT NULL GROUP BY u) RIGHT JO
 ----
 right-join
  ├── columns: u:1(int) sum:4(decimal) x:5(int!null) y:6(int) s:7(string) d:8(decimal!null)
- ├── stats: [rows=30777]
+ ├── stats: [rows=30777.1544]
  ├── key: (1,5)
  ├── fd: (1)-->(4), (5)-->(6-8), (7,8)~~>(5,6)
  ├── group-by
  │    ├── columns: u:1(int!null) sum:4(decimal)
  │    ├── grouping columns: u:1(int!null)
- │    ├── stats: [rows=308, distinct(1)=308]
+ │    ├── stats: [rows=307.771544, distinct(1)=307.771544]
  │    ├── key: (1)
  │    ├── fd: (1)-->(4)
  │    ├── project
  │    │    ├── columns: u:1(int!null) v:2(int!null)
- │    │    ├── stats: [rows=333, distinct(1)=308]
+ │    │    ├── stats: [rows=333.333333, distinct(1)=307.771544]
  │    │    └── select
  │    │         ├── columns: u:1(int!null) v:2(int!null) rowid:3(int!null)
- │    │         ├── stats: [rows=333, distinct(1)=308]
+ │    │         ├── stats: [rows=333.333333, distinct(1)=307.771544]
  │    │         ├── key: (3)
  │    │         ├── fd: (3)-->(1,2)
  │    │         ├── scan uv

--- a/pkg/sql/opt/memo/testdata/logprops/lookup-join
+++ b/pkg/sql/opt/memo/testdata/logprops/lookup-join
@@ -32,19 +32,19 @@ SELECT * FROM a WHERE s = 'foo' AND x + y = 10
 ----
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null)
- ├── stats: [rows=0.4762, distinct(3)=0.4762]
+ ├── stats: [rows=0.476190476, distinct(3)=0.476190476]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)-->(1,2), (2,3)~~>(1,4)
  ├── lookup-join a
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── key columns: [1]
- │    ├── stats: [rows=1.43]
+ │    ├── stats: [rows=1.42857143]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)-->(1), (3,4)~~>(1,2), (2,3)~~>(1,4)
  │    └── scan a@secondary
  │         ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
  │         ├── constraint: /-3/4: [/'foo' - /'foo']
- │         ├── stats: [rows=1.43, distinct(3)=1]
+ │         ├── stats: [rows=1.42857143, distinct(3)=1]
  │         ├── key: (1)
  │         └── fd: (1)-->(3,4), (3,4)-->(1)
  └── filters [type=bool, outer=(1,2)]
@@ -59,22 +59,22 @@ SELECT y FROM a WHERE s = 'foo' AND x + y = 10
 ----
 project
  ├── columns: y:2(int)
- ├── stats: [rows=0.4762]
+ ├── stats: [rows=0.476190476]
  └── select
       ├── columns: x:1(int!null) y:2(int) s:3(string!null)
-      ├── stats: [rows=0.4762, distinct(3)=0.4762]
+      ├── stats: [rows=0.476190476, distinct(3)=0.476190476]
       ├── key: (1)
       ├── fd: (1)-->(2,3), (2,3)~~>(1)
       ├── lookup-join a
       │    ├── columns: x:1(int!null) y:2(int) s:3(string)
       │    ├── key columns: [1]
-      │    ├── stats: [rows=1.43]
+      │    ├── stats: [rows=1.42857143]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2,3), (2,3)~~>(1)
       │    └── scan a@secondary
       │         ├── columns: x:1(int!null) s:3(string!null)
       │         ├── constraint: /-3/4: [/'foo' - /'foo']
-      │         ├── stats: [rows=1.43, distinct(3)=1]
+      │         ├── stats: [rows=1.42857143, distinct(3)=1]
       │         ├── key: (1)
       │         └── fd: (1)-->(3)
       └── filters [type=bool, outer=(1,2)]

--- a/pkg/sql/opt/memo/testdata/logprops/max1row
+++ b/pkg/sql/opt/memo/testdata/logprops/max1row
@@ -28,7 +28,7 @@ SELECT * FROM xyzs WHERE (SELECT v FROM kuv) = 'foo'
 ----
 select
  ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan xyzs

--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -60,7 +60,7 @@ SELECT * FROM xysd WHERE (SELECT (SELECT y) FROM kuv WHERE k=x) > 5
 ----
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan xysd
@@ -81,12 +81,12 @@ select
            │         └── project
            │              ├── columns: y:9(int)
            │              ├── outer: (1,2)
-           │              ├── stats: [rows=111]
+           │              ├── stats: [rows=111.111111]
            │              ├── fd: ()-->(9)
            │              ├── select
            │              │    ├── columns: k:5(int!null) u:6(float) v:7(string)
            │              │    ├── outer: (1)
-           │              │    ├── stats: [rows=111]
+           │              │    ├── stats: [rows=111.111111]
            │              │    ├── key: (5)
            │              │    ├── fd: (5)-->(6,7)
            │              │    ├── scan kuv
@@ -206,11 +206,11 @@ project
                 └── project
                      ├── columns: xysd.y:5(int)
                      ├── outer: (1)
-                     ├── stats: [rows=111]
+                     ├── stats: [rows=111.111111]
                      └── select
                           ├── columns: x:4(int!null) xysd.y:5(int) s:6(string) d:7(decimal!null)
                           ├── outer: (1)
-                          ├── stats: [rows=111]
+                          ├── stats: [rows=111.111111]
                           ├── key: (4)
                           ├── fd: (4)-->(5-7), (6,7)~~>(4,5)
                           ├── scan xysd
@@ -254,11 +254,11 @@ project
                           └── project
                                ├── columns: xysd.y:9(int)
                                ├── outer: (1)
-                               ├── stats: [rows=111]
+                               ├── stats: [rows=111.111111]
                                └── select
                                     ├── columns: xysd.x:8(int!null) xysd.y:9(int) xysd.s:10(string) xysd.d:11(decimal!null)
                                     ├── outer: (1)
-                                    ├── stats: [rows=111]
+                                    ├── stats: [rows=111.111111]
                                     ├── key: (8)
                                     ├── fd: (8)-->(9-11), (10,11)~~>(8,9)
                                     ├── scan xysd

--- a/pkg/sql/opt/memo/testdata/logprops/scalar
+++ b/pkg/sql/opt/memo/testdata/logprops/scalar
@@ -22,7 +22,7 @@ SELECT * FROM xy WHERE x < 5
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── scan xy
@@ -75,7 +75,7 @@ SELECT * FROM xy WHERE EXISTS(SELECT * FROM uv WHERE u=x)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── scan xy
@@ -88,11 +88,11 @@ select
            └── project
                 ├── columns: u:3(int!null) v:4(int!null)
                 ├── outer: (1)
-                ├── stats: [rows=111]
+                ├── stats: [rows=111.111111]
                 └── select
                      ├── columns: u:3(int!null) v:4(int!null) rowid:5(int!null)
                      ├── outer: (1)
-                     ├── stats: [rows=111]
+                     ├── stats: [rows=111.111111]
                      ├── key: (5)
                      ├── fd: (5)-->(3,4)
                      ├── scan uv
@@ -110,7 +110,7 @@ SELECT * FROM xy WHERE y IN (SELECT v FROM uv WHERE u=x)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── scan xy
@@ -123,11 +123,11 @@ select
            ├── project
            │    ├── columns: v:4(int!null)
            │    ├── outer: (1)
-           │    ├── stats: [rows=111]
+           │    ├── stats: [rows=111.111111]
            │    └── select
            │         ├── columns: u:3(int!null) v:4(int!null) rowid:5(int!null)
            │         ├── outer: (1)
-           │         ├── stats: [rows=111]
+           │         ├── stats: [rows=111.111111]
            │         ├── key: (5)
            │         ├── fd: (5)-->(3,4)
            │         ├── scan uv

--- a/pkg/sql/opt/memo/testdata/logprops/select
+++ b/pkg/sql/opt/memo/testdata/logprops/select
@@ -40,7 +40,7 @@ SELECT * FROM xy,kuv WHERE xy.x=kuv.k
 ----
 select
  ├── columns: x:1(int!null) y:2(int) k:3(int!null) u:4(float) v:5(string)
- ├── stats: [rows=111111]
+ ├── stats: [rows=111111.111]
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4,5)
  ├── inner-join
@@ -70,7 +70,7 @@ SELECT * FROM xy WHERE EXISTS(SELECT * FROM (SELECT * FROM kuv WHERE k=y) WHERE 
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── scan xy
@@ -83,13 +83,13 @@ select
            └── select
                 ├── columns: k:3(int!null) u:4(float) v:5(string)
                 ├── outer: (1,2)
-                ├── stats: [rows=12.35]
+                ├── stats: [rows=12.345679]
                 ├── key: (3)
                 ├── fd: (3)-->(4,5)
                 ├── select
                 │    ├── columns: k:3(int!null) u:4(float) v:5(string)
                 │    ├── outer: (2)
-                │    ├── stats: [rows=111]
+                │    ├── stats: [rows=111.111111]
                 │    ├── key: (3)
                 │    ├── fd: (3)-->(4,5)
                 │    ├── scan kuv
@@ -168,10 +168,10 @@ SELECT * FROM abcd WHERE true
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  └── select
       ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int) rowid:5(int!null)
-      ├── stats: [rows=333]
+      ├── stats: [rows=333.333333]
       ├── key: (5)
       ├── fd: (5)-->(1-4)
       ├── scan abcd
@@ -187,10 +187,10 @@ SELECT * FROM abcd WHERE c IS NOT NULL
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  └── select
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) rowid:5(int!null)
-      ├── stats: [rows=333]
+      ├── stats: [rows=333.333333]
       ├── key: (5)
       ├── fd: (5)-->(1-4)
       ├── scan abcd
@@ -208,10 +208,10 @@ SELECT * FROM abcd WHERE c = d
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null)
- ├── stats: [rows=111]
+ ├── stats: [rows=111.111111]
  └── select
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null) rowid:5(int!null)
-      ├── stats: [rows=111]
+      ├── stats: [rows=111.111111]
       ├── key: (5)
       ├── fd: (5)-->(1-4)
       ├── scan abcd
@@ -229,10 +229,10 @@ SELECT * FROM abcd WHERE a > c
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int)
- ├── stats: [rows=111]
+ ├── stats: [rows=111.111111]
  └── select
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) rowid:5(int!null)
-      ├── stats: [rows=111]
+      ├── stats: [rows=111.111111]
       ├── key: (5)
       ├── fd: (5)-->(1-4)
       ├── scan abcd
@@ -250,13 +250,13 @@ SELECT * FROM (SELECT * FROM abcd WHERE a = c) WHERE b < d
 ----
 select
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null)
- ├── stats: [rows=12.35]
+ ├── stats: [rows=12.345679]
  ├── project
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int)
- │    ├── stats: [rows=111]
+ │    ├── stats: [rows=111.111111]
  │    └── select
  │         ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) rowid:5(int!null)
- │         ├── stats: [rows=111]
+ │         ├── stats: [rows=111.111111]
  │         ├── key: (5)
  │         ├── fd: (5)-->(1-4)
  │         ├── scan abcd
@@ -279,10 +279,10 @@ SELECT * FROM abcd WHERE (SELECT count(*) FROM xy WHERE y = b) > 0
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  └── select
       ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int) rowid:5(int!null)
-      ├── stats: [rows=333]
+      ├── stats: [rows=333.333333]
       ├── key: (5)
       ├── fd: (5)-->(1-4)
       ├── scan abcd
@@ -309,11 +309,11 @@ project
                 │              ├── fd: ()-->(8)
                 │              ├── project
                 │              │    ├── outer: (2)
-                │              │    ├── stats: [rows=111]
+                │              │    ├── stats: [rows=111.111111]
                 │              │    └── select
                 │              │         ├── columns: x:6(int!null) y:7(int!null)
                 │              │         ├── outer: (2)
-                │              │         ├── stats: [rows=111]
+                │              │         ├── stats: [rows=111.111111]
                 │              │         ├── key: (6)
                 │              │         ├── fd: (6)-->(7)
                 │              │         ├── scan xy

--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -47,7 +47,7 @@ intersect
  ├── columns: x:1(int!null) y:2(int) x:1(int!null)
  ├── left columns: x:1(int!null) y:2(int) x:1(int!null)
  ├── right columns: v:4(int) u:3(int) rowid:5(int)
- ├── stats: [rows=1.43, distinct(1,2)=1.43]
+ ├── stats: [rows=1.42857143, distinct(1,2)=1.42857143]
  ├── key: (1,2)
  ├── project
  │    ├── columns: x:1(int!null) y:2(int)
@@ -61,12 +61,12 @@ intersect
  │         └── fd: (1)-->(2)
  └── project
       ├── columns: u:3(int!null) v:4(int!null) rowid:5(int!null)
-      ├── stats: [rows=1.43, distinct(3-5)=1.43]
+      ├── stats: [rows=1.42857143, distinct(3-5)=1.42857143]
       ├── key: (5)
       ├── fd: (5)-->(3,4)
       └── select
            ├── columns: u:3(int!null) v:4(int!null) rowid:5(int!null)
-           ├── stats: [rows=1.43, distinct(3)=1, distinct(3-5)=1.43]
+           ├── stats: [rows=1.42857143, distinct(3)=1, distinct(3-5)=1.42857143]
            ├── key: (5)
            ├── fd: (5)-->(3,4)
            ├── scan uv
@@ -100,13 +100,13 @@ except
  │         └── fd: (1)-->(2)
  └── project
       ├── columns: u:3(int!null) v:4(int!null)
-      ├── stats: [rows=1.43, distinct(3,4)=1.43]
+      ├── stats: [rows=1.42857143, distinct(3,4)=1.42857143]
       └── project
            ├── columns: u:3(int!null) v:4(int!null)
-           ├── stats: [rows=1.43, distinct(3,4)=1.43]
+           ├── stats: [rows=1.42857143, distinct(3,4)=1.42857143]
            └── select
                 ├── columns: u:3(int!null) v:4(int!null) rowid:5(int!null)
-                ├── stats: [rows=1.43, distinct(3)=1, distinct(3,4)=1.43]
+                ├── stats: [rows=1.42857143, distinct(3)=1, distinct(3,4)=1.42857143]
                 ├── key: (5)
                 ├── fd: (5)-->(3,4)
                 ├── scan uv
@@ -125,7 +125,7 @@ SELECT * FROM xy WHERE (SELECT x, u FROM uv UNION SELECT y, v FROM uv) = (1, 2)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333]
+ ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── scan xy

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -31,16 +31,16 @@ limit
  ├── ordering: +2
  ├── sort
  │    ├── columns: y:2(int!null) b.x:3(string!null) c:5(int)
- │    ├── stats: [rows=1429]
+ │    ├── stats: [rows=1428.57143]
  │    ├── fd: (2)-->(5)
  │    ├── ordering: +2
  │    └── project
  │         ├── columns: c:5(int) y:2(int!null) b.x:3(string!null)
- │         ├── stats: [rows=1429]
+ │         ├── stats: [rows=1428.57143]
  │         ├── fd: (2)-->(5)
  │         ├── select
  │         │    ├── columns: a.x:1(int!null) y:2(int!null) b.x:3(string!null) z:4(decimal!null)
- │         │    ├── stats: [rows=1429, distinct(2)=1]
+ │         │    ├── stats: [rows=1428.57143, distinct(2)=1]
  │         │    ├── key: (1,3)
  │         │    ├── fd: (1)-->(2), (3)-->(4)
  │         │    ├── inner-join
@@ -96,18 +96,18 @@ project
  │    ├── ordering: +2
  │    ├── sort
  │    │    ├── columns: a.x:1(int!null) y:2(int!null) b.x:3(string!null)
- │    │    ├── stats: [rows=143]
+ │    │    ├── stats: [rows=142.857143]
  │    │    ├── key: (1,3)
  │    │    ├── fd: (1)-->(2)
  │    │    ├── ordering: +2
  │    │    └── inner-join
  │    │         ├── columns: a.x:1(int!null) y:2(int!null) b.x:3(string!null)
- │    │         ├── stats: [rows=143]
+ │    │         ├── stats: [rows=142.857143]
  │    │         ├── key: (1,3)
  │    │         ├── fd: (1)-->(2)
  │    │         ├── select
  │    │         │    ├── columns: a.x:1(int!null) y:2(int!null)
- │    │         │    ├── stats: [rows=1.43, distinct(2)=1]
+ │    │         │    ├── stats: [rows=1.42857143, distinct(2)=1]
  │    │         │    ├── key: (1)
  │    │         │    ├── fd: (1)-->(2)
  │    │         │    ├── scan a

--- a/pkg/sql/opt/memo/testdata/stats/limit
+++ b/pkg/sql/opt/memo/testdata/stats/limit
@@ -116,13 +116,13 @@ SELECT * FROM (SELECT * FROM a ORDER BY s LIMIT 5) WHERE s = 'foo'
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null)
  ├── cardinality: [0 - 5]
- ├── stats: [rows=1.27, distinct(3)=1]
+ ├── stats: [rows=1.26952228, distinct(3)=1]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)-->(1,2)
  ├── limit
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── cardinality: [0 - 5]
- │    ├── stats: [rows=5, distinct(3)=3.94]
+ │    ├── stats: [rows=5, distinct(3)=3.93848936]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── sort

--- a/pkg/sql/opt/memo/testdata/stats/lookup-join
+++ b/pkg/sql/opt/memo/testdata/stats/lookup-join
@@ -50,16 +50,16 @@ SELECT count(*) FROM (SELECT * FROM a WHERE s = 'foo' AND x + y = 10) GROUP BY s
 ----
 project
  ├── columns: count:5(int)
- ├── stats: [rows=65.56]
+ ├── stats: [rows=65.5555556]
  └── group-by
       ├── columns: y:2(int) s:3(string!null) count:5(int)
       ├── grouping columns: y:2(int) s:3(string!null)
-      ├── stats: [rows=65.56, distinct(2,3)=65.56]
+      ├── stats: [rows=65.5555556, distinct(2,3)=65.5555556]
       ├── key: (2,3)
       ├── fd: (2,3)-->(5)
       ├── select
       │    ├── columns: x:1(int!null) y:2(int) s:3(string!null)
-      │    ├── stats: [rows=66.67, distinct(3)=1, distinct(2,3)=65.56]
+      │    ├── stats: [rows=66.6666667, distinct(3)=1, distinct(2,3)=65.5555556]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2,3)
       │    ├── lookup-join a

--- a/pkg/sql/opt/memo/testdata/stats/project
+++ b/pkg/sql/opt/memo/testdata/stats/project
@@ -149,7 +149,7 @@ SELECT * FROM (SELECT y + 3 AS v FROM a) WHERE v >= 1 AND v <= 100
 ----
 select
  ├── columns: v:5(int!null)
- ├── stats: [rows=143, distinct(5)=100]
+ ├── stats: [rows=142.857143, distinct(5)=100]
  ├── project
  │    ├── columns: v:5(int)
  │    ├── stats: [rows=2000, distinct(5)=1400]
@@ -204,7 +204,7 @@ SELECT * FROM a WHERE EXISTS (SELECT s < v FROM kuv GROUP BY s < v)
 ----
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- ├── stats: [rows=667]
+ ├── stats: [rows=666.666667]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan a

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -106,13 +106,13 @@ SELECT count(*), y, x FROM a WHERE x > 0 AND x <= 100 GROUP BY x, y
 group-by
  ├── columns: count:5(int) y:2(int) x:1(int!null)
  ├── grouping columns: x:1(int!null) y:2(int)
- ├── stats: [rows=148, distinct(1,2)=148]
+ ├── stats: [rows=148.109074, distinct(1,2)=148.109074]
  ├── key: (1)
  ├── fd: (1)-->(2,5)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
  │    ├── constraint: /1: [/1 - /100]
- │    ├── stats: [rows=150, distinct(1)=100, distinct(1,2)=148]
+ │    ├── stats: [rows=150, distinct(1)=100, distinct(1,2)=148.109074]
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── aggregations

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -63,10 +63,10 @@ SELECT * FROM b WHERE x = 1 AND z = 2 AND rowid >= 5 AND rowid <= 8
 ----
 project
  ├── columns: x:1(int!null) z:2(int!null)
- ├── stats: [rows=0]
+ ├── stats: [rows=8e-06]
  └── select
       ├── columns: x:1(int!null) z:2(int!null) rowid:3(int!null)
-      ├── stats: [rows=0, distinct(1)=0, distinct(2)=0, distinct(3)=0]
+      ├── stats: [rows=8e-06, distinct(1)=8e-06, distinct(2)=8e-06, distinct(3)=8e-06]
       ├── key: (3)
       ├── fd: (3)-->(1,2)
       ├── scan b
@@ -97,7 +97,7 @@ SELECT * FROM a WHERE x + y < 10
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=1333]
+ ├── stats: [rows=1333.33333]
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── scan a
@@ -218,14 +218,14 @@ SELECT y FROM idx WHERE y < 5 AND z < 10
 ----
 project
  ├── columns: y:2(int!null)
- ├── stats: [rows=111]
+ ├── stats: [rows=111.111111]
  └── select
       ├── columns: y:2(int!null) z:3(int!null)
-      ├── stats: [rows=111]
+      ├── stats: [rows=111.111111]
       ├── scan idx@yz
       │    ├── columns: y:2(int!null) z:3(int)
       │    ├── constraint: /-2/3/1: (/4/NULL - /NULL)
-      │    └── stats: [rows=333]
+      │    └── stats: [rows=333.333333]
       └── filters [type=bool, outer=(3), constraints=(/3: (/NULL - /9]; tight)]
            └── lt [type=bool, outer=(3), constraints=(/3: (/NULL - /9]; tight)]
                 ├── variable: idx.z [type=int, outer=(3)]

--- a/pkg/sql/opt/memo/testdata/stats/set
+++ b/pkg/sql/opt/memo/testdata/stats/set
@@ -558,7 +558,7 @@ SELECT * FROM (SELECT y, s FROM a EXCEPT ALL SELECT z, s FROM b) WHERE y = 5
 ----
 select
  ├── columns: y:2(int!null) s:3(string)
- ├── stats: [rows=12.50, distinct(2)=1]
+ ├── stats: [rows=12.5, distinct(2)=1]
  ├── except-all
  │    ├── columns: y:2(int) a.s:3(string)
  │    ├── left columns: y:2(int) a.s:3(string)

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -24,23 +24,23 @@ SELECT k, x FROM a INNER JOIN b ON k=x WHERE d=1.0
 ----
 project
  ├── columns: k:1(int!null) x:5(int)
- ├── stats: [rows=143]
- ├── cost: 2120.01
+ ├── stats: [rows=142.857143]
+ ├── cost: 2120.01429
  └── inner-join
       ├── columns: k:1(int!null) d:4(decimal!null) x:5(int)
-      ├── stats: [rows=143]
-      ├── cost: 2120.01
+      ├── stats: [rows=142.857143]
+      ├── cost: 2120.01429
       ├── fd: (1)-->(4)
       ├── select
       │    ├── columns: k:1(int!null) d:4(decimal!null)
-      │    ├── stats: [rows=1.43, distinct(4)=1]
-      │    ├── cost: 1070.00
+      │    ├── stats: [rows=1.42857143, distinct(4)=1]
+      │    ├── cost: 1070
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
       │    ├── scan a
       │    │    ├── columns: k:1(int!null) d:4(decimal!null)
       │    │    ├── stats: [rows=1000, distinct(4)=700]
-      │    │    ├── cost: 1060.00
+      │    │    ├── cost: 1060
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(4)
       │    └── filters [type=bool, outer=(4), constraints=(/4: [/1.0 - /1.0]; tight)]
@@ -48,7 +48,7 @@ project
       ├── scan b
       │    ├── columns: x:5(int)
       │    ├── stats: [rows=1000]
-      │    └── cost: 1040.00
+      │    └── cost: 1040
       └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
            └── a.k = b.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
 
@@ -83,14 +83,14 @@ SELECT * FROM abc WHERE c = 1
 lookup-join abc
  ├── columns: a:1(int!null) b:2(int) c:3(int!null)
  ├── key columns: [1]
- ├── stats: [rows=1.43, distinct(3)=1]
- ├── cost: 7.27
+ ├── stats: [rows=1.42857143, distinct(3)=1]
+ ├── cost: 7.27142857
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  └── scan abc@c_idx
       ├── columns: a:1(int!null) c:3(int!null)
       ├── constraint: /3/1: [/1 - /1]
-      ├── stats: [rows=1.43, distinct(3)=1]
-      ├── cost: 1.49
+      ├── stats: [rows=1.42857143, distinct(3)=1]
+      ├── cost: 1.48571429
       ├── key: (1)
       └── fd: (1)-->(3)

--- a/pkg/sql/opt/xform/testdata/coster/scan
+++ b/pkg/sql/opt/xform/testdata/coster/scan
@@ -15,6 +15,6 @@ SELECT k, s FROM a
 scan a
  ├── columns: k:1(int!null) s:3(string)
  ├── stats: [rows=1000]
- ├── cost: 1060.00
+ ├── cost: 1060
  ├── key: (1)
  └── fd: (1)-->(3)

--- a/pkg/sql/opt/xform/testdata/coster/select
+++ b/pkg/sql/opt/xform/testdata/coster/select
@@ -14,14 +14,14 @@ SELECT k, s FROM a WHERE s >= 'foo'
 ----
 select
  ├── columns: k:1(int!null) s:3(string!null)
- ├── stats: [rows=333]
- ├── cost: 1070.00
+ ├── stats: [rows=333.333333]
+ ├── cost: 1070
  ├── key: (1)
  ├── fd: (1)-->(3)
  ├── scan a
  │    ├── columns: k:1(int!null) s:3(string)
  │    ├── stats: [rows=1000]
- │    ├── cost: 1060.00
+ │    ├── cost: 1060
  │    ├── key: (1)
  │    └── fd: (1)-->(3)
  └── filters [type=bool, outer=(3), constraints=(/3: [/'foo' - ]; tight)]

--- a/pkg/sql/opt/xform/testdata/coster/sort
+++ b/pkg/sql/opt/xform/testdata/coster/sort
@@ -23,12 +23,12 @@ SELECT f FROM a ORDER BY f DESC
 sort
  ├── columns: f:2(float!null)
  ├── stats: [rows=1000]
- ├── cost: 1149.66
+ ├── cost: 1149.65784
  ├── ordering: -2
  └── scan a
       ├── columns: f:2(float!null)
       ├── stats: [rows=1000]
-      └── cost: 1050.00
+      └── cost: 1050
 
 # Test sort on 0 rows.
 opt
@@ -42,10 +42,10 @@ sort
  └── project
       ├── columns: f:2(float!null)
       ├── stats: [rows=0]
-      ├── cost: 0.00
+      ├── cost: 0
       └── scan a
            ├── columns: k:1(int!null) f:2(float!null)
            ├── constraint: /1/-2: contradiction
            ├── stats: [rows=0]
-           ├── cost: 0.00
+           ├── cost: 0
            └── key: (1,2)

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -564,14 +564,14 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 ----
 project
  ├── columns: c_discount:16(decimal) c_last:6(string) c_credit:14(string)
- ├── stats: [rows=0]
- ├── cost: 0.00
+ ├── stats: [rows=6.80272109e-07]
+ ├── cost: 8.63945578e-07
  ├── prune: (6,14,16)
  └── scan customer
       ├── columns: customer.c_id:1(int!null) customer.c_d_id:2(int!null) customer.c_w_id:3(int!null) customer.c_last:6(string) customer.c_credit:14(string) customer.c_discount:16(decimal)
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
-      ├── stats: [rows=0, distinct(1)=0, distinct(2)=0, distinct(3)=0]
-      ├── cost: 0.00
+      ├── stats: [rows=6.80272109e-07, distinct(1)=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07]
+      ├── cost: 8.63945578e-07
       ├── key: (1-3)
       ├── fd: (1-3)-->(6,14,16)
       ├── prune: (6,14,16)
@@ -603,7 +603,7 @@ ORDER BY s_i_id
 sort
  ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string) s_dist_05:8(string)
  ├── stats: [rows=5]
- ├── cost: 6.37
+ ├── cost: 6.3660964
  ├── ordering: +1
  ├── prune: (1,3,8,14-17)
  └── project
@@ -638,20 +638,20 @@ ORDER BY c_first ASC
 ----
 sort
  ├── columns: c_id:1(int!null)
- ├── stats: [rows=0]
- ├── cost: 0.01
+ ├── stats: [rows=6.80272109e-07]
+ ├── cost: 0.0100007483
  ├── ordering: +4
  ├── prune: (1,4)
  └── project
       ├── columns: customer.c_id:1(int!null) customer.c_first:4(string)
-      ├── stats: [rows=0]
-      ├── cost: 0.00
+      ├── stats: [rows=6.80272109e-07]
+      ├── cost: 7.4829932e-07
       ├── prune: (1,4)
       └── scan customer@customer_idx
            ├── columns: customer.c_id:1(int!null) customer.c_d_id:2(int!null) customer.c_w_id:3(int!null) customer.c_first:4(string) customer.c_last:6(string!null)
            ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
-           ├── stats: [rows=0, distinct(2)=0, distinct(3)=0, distinct(6)=0]
-           ├── cost: 0.00
+           ├── stats: [rows=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07, distinct(6)=6.80272109e-07]
+           ├── cost: 7.4829932e-07
            ├── key: (1-3)
            ├── fd: (1-3)-->(4,6)
            ├── prune: (1,4)
@@ -673,14 +673,14 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 ----
 project
  ├── columns: c_balance:17(decimal) c_first:4(string) c_middle:5(string) c_last:6(string)
- ├── stats: [rows=0]
- ├── cost: 0.00
+ ├── stats: [rows=6.80272109e-07]
+ ├── cost: 8.70748299e-07
  ├── prune: (4-6,17)
  └── scan customer
       ├── columns: customer.c_id:1(int!null) customer.c_d_id:2(int!null) customer.c_w_id:3(int!null) customer.c_first:4(string) customer.c_middle:5(string) customer.c_last:6(string) customer.c_balance:17(decimal)
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
-      ├── stats: [rows=0, distinct(1)=0, distinct(2)=0, distinct(3)=0]
-      ├── cost: 0.00
+      ├── stats: [rows=6.80272109e-07, distinct(1)=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07]
+      ├── cost: 8.70748299e-07
       ├── key: (1-3)
       ├── fd: (1-3)-->(4-6,17)
       ├── prune: (4-6,17)
@@ -694,20 +694,20 @@ ORDER BY c_first ASC
 ----
 sort
  ├── columns: c_id:1(int!null) c_balance:17(decimal) c_first:4(string) c_middle:5(string)
- ├── stats: [rows=0]
- ├── cost: 0.01
+ ├── stats: [rows=6.80272109e-07]
+ ├── cost: 0.0100036327
  ├── ordering: +4
  ├── prune: (1,4,5,17)
  └── project
       ├── columns: customer.c_id:1(int!null) customer.c_first:4(string) customer.c_middle:5(string) customer.c_balance:17(decimal)
-      ├── stats: [rows=0]
-      ├── cost: 0.00
+      ├── stats: [rows=6.80272109e-07]
+      ├── cost: 3.63265306e-06
       ├── prune: (1,4,5,17)
       └── lookup-join customer
            ├── columns: customer.c_id:1(int!null) customer.c_d_id:2(int!null) customer.c_w_id:3(int!null) customer.c_first:4(string) customer.c_middle:5(string) customer.c_last:6(string!null) customer.c_balance:17(decimal)
            ├── key columns: [3 2 1]
-           ├── stats: [rows=0, distinct(2)=0, distinct(3)=0, distinct(6)=0]
-           ├── cost: 0.00
+           ├── stats: [rows=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07, distinct(6)=6.80272109e-07]
+           ├── cost: 3.63265306e-06
            ├── key: (1-3)
            ├── fd: (1-3)-->(4-6,17)
            ├── prune: (1,4,5,17)
@@ -715,8 +715,8 @@ sort
            └── scan customer@customer_idx
                 ├── columns: customer.c_id:1(int!null) customer.c_d_id:2(int!null) customer.c_w_id:3(int!null) customer.c_first:4(string) customer.c_last:6(string!null)
                 ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
-                ├── stats: [rows=0, distinct(2)=0, distinct(3)=0, distinct(6)=0]
-                ├── cost: 0.00
+                ├── stats: [rows=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07, distinct(6)=6.80272109e-07]
+                ├── cost: 7.4829932e-07
                 ├── key: (1-3)
                 ├── fd: (1-3)-->(4,6)
                 ├── prune: (1,4)
@@ -732,8 +732,8 @@ LIMIT 1
 project
  ├── columns: o_id:1(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=0]
- ├── cost: 0.01
+ ├── stats: [rows=6.80272109e-07]
+ ├── cost: 0.0100035306
  ├── key: ()
  ├── fd: ()-->(1,5,6)
  ├── ordering: -1
@@ -742,8 +742,8 @@ project
  └── limit
       ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_c_id:4(int!null) "order".o_entry_d:5(timestamp) "order".o_carrier_id:6(int)
       ├── cardinality: [0 - 1]
-      ├── stats: [rows=0]
-      ├── cost: 0.01
+      ├── stats: [rows=6.80272109e-07]
+      ├── cost: 0.0100035306
       ├── key: ()
       ├── fd: ()-->(1-6)
       ├── ordering: -1
@@ -751,8 +751,8 @@ project
       ├── interesting orderings: (-1)
       ├── sort
       │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_c_id:4(int!null) "order".o_entry_d:5(timestamp) "order".o_carrier_id:6(int)
-      │    ├── stats: [rows=0, distinct(2)=0, distinct(3)=0, distinct(4)=0]
-      │    ├── cost: 0.01
+      │    ├── stats: [rows=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07, distinct(4)=6.80272109e-07]
+      │    ├── cost: 0.0100035306
       │    ├── key: (1-3)
       │    ├── fd: (1-3)-->(4-6)
       │    ├── ordering: -1
@@ -760,16 +760,16 @@ project
       │    └── lookup-join order
       │         ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_c_id:4(int!null) "order".o_entry_d:5(timestamp) "order".o_carrier_id:6(int)
       │         ├── key columns: [3 2 1]
-      │         ├── stats: [rows=0, distinct(2)=0, distinct(3)=0, distinct(4)=0]
-      │         ├── cost: 0.00
+      │         ├── stats: [rows=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07, distinct(4)=6.80272109e-07]
+      │         ├── cost: 3.53061224e-06
       │         ├── key: (1-3)
       │         ├── fd: (1-3)-->(4-6)
       │         ├── prune: (1,5,6)
       │         └── scan order@secondary
       │              ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_c_id:4(int!null)
       │              ├── constraint: /3/2/4/1: [/10/100/50 - /10/100/50]
-      │              ├── stats: [rows=0, distinct(2)=0, distinct(3)=0, distinct(4)=0]
-      │              ├── cost: 0.00
+      │              ├── stats: [rows=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07, distinct(4)=6.80272109e-07]
+      │              ├── cost: 7.34693878e-07
       │              ├── key: (1-3)
       │              ├── fd: (1-3)-->(4)
       │              ├── prune: (1)
@@ -783,15 +783,15 @@ WHERE ol_w_id = 10 AND ol_d_id = 100 AND ol_o_id = 1000
 ----
 project
  ├── columns: ol_i_id:5(int!null) ol_supply_w_id:6(int) ol_quantity:8(int) ol_amount:9(decimal) ol_delivery_d:7(timestamp)
- ├── stats: [rows=0]
- ├── cost: 0.00
+ ├── stats: [rows=2.04081633e-07]
+ ├── cost: 2.40816327e-07
  ├── prune: (5-9)
  ├── interesting orderings: (+6)
  └── scan order_line
       ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) order_line.ol_i_id:5(int!null) order_line.ol_supply_w_id:6(int) order_line.ol_delivery_d:7(timestamp) order_line.ol_quantity:8(int) order_line.ol_amount:9(decimal)
       ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
-      ├── stats: [rows=0, distinct(1)=0, distinct(2)=0, distinct(3)=0]
-      ├── cost: 0.00
+      ├── stats: [rows=2.04081633e-07, distinct(1)=2.04081633e-07, distinct(2)=2.04081633e-07, distinct(3)=2.04081633e-07]
+      ├── cost: 2.40816327e-07
       ├── prune: (5-9)
       └── interesting orderings: (+3,+2,-1) (+6,+2,+3,+1)
 
@@ -821,8 +821,8 @@ LIMIT 1
 project
  ├── columns: no_o_id:1(int!null)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=0.1429]
- ├── cost: 0.16
+ ├── stats: [rows=0.142857143]
+ ├── cost: 0.161428571
  ├── key: ()
  ├── fd: ()-->(1)
  ├── ordering: +1
@@ -831,24 +831,24 @@ project
  └── limit
       ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
       ├── cardinality: [0 - 1]
-      ├── stats: [rows=0.1429]
-      ├── cost: 0.16
+      ├── stats: [rows=0.142857143]
+      ├── cost: 0.161428571
       ├── key: ()
       ├── fd: ()-->(1-3)
       ├── ordering: +1
       ├── interesting orderings: (+1)
       ├── sort
       │    ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
-      │    ├── stats: [rows=0.1429, distinct(2)=0.1429, distinct(3)=0.1429]
-      │    ├── cost: 0.16
+      │    ├── stats: [rows=0.142857143, distinct(2)=0.142857143, distinct(3)=0.142857143]
+      │    ├── cost: 0.161428571
       │    ├── key: (1-3)
       │    ├── ordering: +1
       │    ├── prune: (1)
       │    └── scan new_order
       │         ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
       │         ├── constraint: /3/2/1: [/10/100 - /10/100]
-      │         ├── stats: [rows=0.1429, distinct(2)=0.1429, distinct(3)=0.1429]
-      │         ├── cost: 0.15
+      │         ├── stats: [rows=0.142857143, distinct(2)=0.142857143, distinct(3)=0.142857143]
+      │         ├── cost: 0.151428571
       │         ├── key: (1-3)
       │         └── prune: (1)
       └── const: 1 [type=int]
@@ -862,15 +862,15 @@ group-by
  ├── columns: sum:11(decimal)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 0.00
+ ├── cost: 2.32653061e-07
  ├── key: ()
  ├── fd: ()-->(11)
  ├── prune: (11)
  ├── scan order_line
  │    ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) order_line.ol_amount:9(decimal)
  │    ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
- │    ├── stats: [rows=0, distinct(1)=0, distinct(2)=0, distinct(3)=0]
- │    ├── cost: 0.00
+ │    ├── stats: [rows=2.04081633e-07, distinct(1)=2.04081633e-07, distinct(2)=2.04081633e-07, distinct(3)=2.04081633e-07]
+ │    ├── cost: 2.32653061e-07
  │    ├── prune: (9)
  │    └── interesting orderings: (+3,+2,-1)
  └── aggregations [outer=(9)]
@@ -892,14 +892,14 @@ WHERE d_w_id = 10 AND d_id = 100
 ----
 project
  ├── columns: d_next_o_id:11(int)
- ├── stats: [rows=0.1429]
- ├── cost: 0.16
+ ├── stats: [rows=0.142857143]
+ ├── cost: 0.162857143
  ├── prune: (11)
  └── scan district
       ├── columns: district.d_id:1(int!null) district.d_w_id:2(int!null) district.d_next_o_id:11(int)
       ├── constraint: /2/1: [/10/100 - /10/100]
-      ├── stats: [rows=0.1429, distinct(1)=0.1429, distinct(2)=0.1429]
-      ├── cost: 0.16
+      ├── stats: [rows=0.142857143, distinct(1)=0.142857143, distinct(2)=0.142857143]
+      ├── cost: 0.162857143
       ├── key: (1,2)
       ├── fd: (1,2)-->(11)
       ├── prune: (11)
@@ -939,21 +939,21 @@ group-by
  ├── columns: count:22(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 124.40
+ ├── cost: 124.4
  ├── key: ()
  ├── fd: ()-->(22)
  ├── prune: (22)
  ├── select
  │    ├── columns: warehouse.w_id:1(int) warehouse.w_ytd:9(decimal!null) district.d_w_id:11(int) sum_d_ytd:21(decimal!null)
- │    ├── stats: [rows=1.11]
- │    ├── cost: 124.40
+ │    ├── stats: [rows=1.11111111]
+ │    ├── cost: 124.4
  │    ├── key: (1,11)
  │    ├── fd: (1)-->(9), (11)-->(21)
  │    ├── interesting orderings: (+1) (+11)
  │    ├── full-join
  │    │    ├── columns: warehouse.w_id:1(int) warehouse.w_ytd:9(decimal) district.d_w_id:11(int) sum_d_ytd:21(decimal)
  │    │    ├── stats: [rows=10]
- │    │    ├── cost: 124.30
+ │    │    ├── cost: 124.3
  │    │    ├── key: (1,11)
  │    │    ├── fd: (1)-->(9), (11)-->(21)
  │    │    ├── prune: (9,21)
@@ -961,7 +961,7 @@ group-by
  │    │    ├── scan warehouse
  │    │    │    ├── columns: warehouse.w_id:1(int!null) warehouse.w_ytd:9(decimal)
  │    │    │    ├── stats: [rows=10]
- │    │    │    ├── cost: 11.10
+ │    │    │    ├── cost: 11.1
  │    │    │    ├── key: (1)
  │    │    │    ├── fd: (1)-->(9)
  │    │    │    ├── prune: (1,9)
@@ -970,7 +970,7 @@ group-by
  │    │    │    ├── columns: district.d_w_id:11(int!null) sum_d_ytd:21(decimal)
  │    │    │    ├── grouping columns: district.d_w_id:11(int!null)
  │    │    │    ├── stats: [rows=10, distinct(11)=10]
- │    │    │    ├── cost: 113.00
+ │    │    │    ├── cost: 113
  │    │    │    ├── key: (11)
  │    │    │    ├── fd: (11)-->(21)
  │    │    │    ├── prune: (21)
@@ -978,7 +978,7 @@ group-by
  │    │    │    ├── scan district
  │    │    │    │    ├── columns: district.d_w_id:11(int!null) district.d_ytd:19(decimal)
  │    │    │    │    ├── stats: [rows=100, distinct(11)=10]
- │    │    │    │    ├── cost: 113.00
+ │    │    │    │    ├── cost: 113
  │    │    │    │    ├── prune: (11,19)
  │    │    │    │    └── interesting orderings: (+11)
  │    │    │    └── aggregations [outer=(19)]
@@ -1003,7 +1003,7 @@ ORDER BY d_w_id, d_id
 scan district
  ├── columns: d_next_o_id:11(int)
  ├── stats: [rows=100]
- ├── cost: 114.00
+ ├── cost: 114
  ├── key: (1,2)
  ├── fd: (1,2)-->(11)
  ├── ordering: +2,+1
@@ -1019,7 +1019,7 @@ ORDER BY no_w_id, no_d_id
 sort
  ├── columns: max:4(int)
  ├── stats: [rows=100, distinct(2,3)=100]
- ├── cost: 95406.64
+ ├── cost: 95406.6439
  ├── key: (2,3)
  ├── fd: (2,3)-->(4)
  ├── ordering: +3,+2
@@ -1028,14 +1028,14 @@ sort
       ├── columns: new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null) max:4(int)
       ├── grouping columns: new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
       ├── stats: [rows=100, distinct(2,3)=100]
-      ├── cost: 95400.00
+      ├── cost: 95400
       ├── key: (2,3)
       ├── fd: (2,3)-->(4)
       ├── prune: (4)
       ├── scan new_order
       │    ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
       │    ├── stats: [rows=90000, distinct(2,3)=100]
-      │    ├── cost: 95400.00
+      │    ├── cost: 95400
       │    ├── key: (1-3)
       │    ├── prune: (1-3)
       │    └── interesting orderings: (+3,+2,+1)
@@ -1052,7 +1052,7 @@ ORDER BY o_w_id, o_d_id
 sort
  ├── columns: max:9(int)
  ├── stats: [rows=100, distinct(2,3)=100]
- ├── cost: 321006.64
+ ├── cost: 321006.644
  ├── key: (2,3)
  ├── fd: (2,3)-->(9)
  ├── ordering: +3,+2
@@ -1061,14 +1061,14 @@ sort
       ├── columns: "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) max:9(int)
       ├── grouping columns: "order".o_d_id:2(int!null) "order".o_w_id:3(int!null)
       ├── stats: [rows=100, distinct(2,3)=100]
-      ├── cost: 321000.00
+      ├── cost: 321000
       ├── key: (2,3)
       ├── fd: (2,3)-->(9)
       ├── prune: (9)
       ├── scan order@order_idx
       │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null)
       │    ├── stats: [rows=300000, distinct(2,3)=100]
-      │    ├── cost: 321000.00
+      │    ├── cost: 321000
       │    ├── key: (1-3)
       │    ├── prune: (1-3)
       │    └── interesting orderings: (+3,+2,-1)
@@ -1090,14 +1090,14 @@ group-by
  ├── columns: count:8(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 95401.00
+ ├── cost: 95401
  ├── key: ()
  ├── fd: ()-->(8)
  ├── prune: (8)
  ├── select
  │    ├── columns: new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null) column4:4(int) column5:5(int) column6:6(int)
- │    ├── stats: [rows=33.33]
- │    ├── cost: 95401.00
+ │    ├── stats: [rows=33.3333333]
+ │    ├── cost: 95401
  │    ├── key: (2,3)
  │    ├── fd: (2,3)-->(4-6)
  │    ├── interesting orderings: (+3,+2)
@@ -1105,7 +1105,7 @@ group-by
  │    │    ├── columns: new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null) column4:4(int) column5:5(int) column6:6(int)
  │    │    ├── grouping columns: new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
  │    │    ├── stats: [rows=100, distinct(2,3)=100]
- │    │    ├── cost: 95400.00
+ │    │    ├── cost: 95400
  │    │    ├── key: (2,3)
  │    │    ├── fd: (2,3)-->(4-6)
  │    │    ├── prune: (4-6)
@@ -1113,7 +1113,7 @@ group-by
  │    │    ├── scan new_order
  │    │    │    ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
  │    │    │    ├── stats: [rows=90000, distinct(2,3)=100]
- │    │    │    ├── cost: 95400.00
+ │    │    │    ├── cost: 95400
  │    │    │    ├── key: (1-3)
  │    │    │    ├── prune: (1-3)
  │    │    │    └── interesting orderings: (+3,+2,+1)
@@ -1143,7 +1143,7 @@ ORDER BY o_w_id, o_d_id
 sort
  ├── columns: sum:9(decimal)
  ├── stats: [rows=100, distinct(2,3)=100]
- ├── cost: 333006.64
+ ├── cost: 333006.644
  ├── key: (2,3)
  ├── fd: (2,3)-->(9)
  ├── ordering: +3,+2
@@ -1152,14 +1152,14 @@ sort
       ├── columns: "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) sum:9(decimal)
       ├── grouping columns: "order".o_d_id:2(int!null) "order".o_w_id:3(int!null)
       ├── stats: [rows=100, distinct(2,3)=100]
-      ├── cost: 333000.00
+      ├── cost: 333000
       ├── key: (2,3)
       ├── fd: (2,3)-->(9)
       ├── prune: (9)
       ├── scan order
       │    ├── columns: "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_ol_cnt:7(int)
       │    ├── stats: [rows=300000, distinct(2,3)=100]
-      │    ├── cost: 333000.00
+      │    ├── cost: 333000
       │    ├── prune: (2,3,7)
       │    └── interesting orderings: (+3,+2)
       └── aggregations [outer=(7)]
@@ -1184,14 +1184,14 @@ sort
       ├── columns: order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) count:11(int)
       ├── grouping columns: order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null)
       ├── stats: [rows=100, distinct(2,3)=100]
-      ├── cost: 1070000.00
+      ├── cost: 1070000
       ├── key: (2,3)
       ├── fd: (2,3)-->(11)
       ├── prune: (11)
       ├── scan order_line@order_line_fk
       │    ├── columns: order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null)
       │    ├── stats: [rows=1000000, distinct(2,3)=100]
-      │    ├── cost: 1070000.00
+      │    ├── cost: 1070000
       │    ├── prune: (2,3)
       │    └── interesting orderings: (+3,+2)
       └── aggregations
@@ -1207,25 +1207,25 @@ except-all
  ├── left columns: new_order.no_w_id:3(int!null) new_order.no_d_id:2(int!null) new_order.no_o_id:1(int!null)
  ├── right columns: "order".o_w_id:6(int) "order".o_d_id:5(int) "order".o_id:4(int)
  ├── stats: [rows=90000]
- ├── cost: 422400.00
+ ├── cost: 422400
  ├── scan new_order
  │    ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
  │    ├── stats: [rows=90000]
- │    ├── cost: 95400.00
+ │    ├── cost: 95400
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
  │    └── interesting orderings: (+3,+2,+1)
  └── project
       ├── columns: "order".o_id:4(int!null) "order".o_d_id:5(int!null) "order".o_w_id:6(int!null)
-      ├── stats: [rows=1.43]
-      ├── cost: 327000.00
+      ├── stats: [rows=1.42857143]
+      ├── cost: 327000
       ├── key: (4-6)
       ├── prune: (4-6)
       ├── interesting orderings: (+6,+5,-4)
       └── select
            ├── columns: "order".o_id:4(int!null) "order".o_d_id:5(int!null) "order".o_w_id:6(int!null) "order".o_carrier_id:9(int)
-           ├── stats: [rows=1.43, distinct(9)=1]
-           ├── cost: 327000.00
+           ├── stats: [rows=1.42857143, distinct(9)=1]
+           ├── cost: 327000
            ├── key: (4-6)
            ├── fd: (4-6)-->(9)
            ├── prune: (4-6)
@@ -1233,7 +1233,7 @@ except-all
            ├── scan order@order_idx
            │    ├── columns: "order".o_id:4(int!null) "order".o_d_id:5(int!null) "order".o_w_id:6(int!null) "order".o_carrier_id:9(int)
            │    ├── stats: [rows=300000, distinct(9)=210000]
-           │    ├── cost: 324000.00
+           │    ├── cost: 324000
            │    ├── key: (4-6)
            │    ├── fd: (4-6)-->(9)
            │    ├── prune: (4-6,9)
@@ -1252,19 +1252,19 @@ except-all
  ├── columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null)
  ├── left columns: "order".o_w_id:3(int!null) "order".o_d_id:2(int!null) "order".o_id:1(int!null)
  ├── right columns: new_order.no_w_id:11(int) new_order.no_d_id:10(int) new_order.no_o_id:9(int)
- ├── stats: [rows=1.43]
- ├── cost: 422400.00
+ ├── stats: [rows=1.42857143]
+ ├── cost: 422400
  ├── project
  │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null)
- │    ├── stats: [rows=1.43]
- │    ├── cost: 327000.00
+ │    ├── stats: [rows=1.42857143]
+ │    ├── cost: 327000
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    └── select
  │         ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_carrier_id:6(int)
- │         ├── stats: [rows=1.43, distinct(6)=1]
- │         ├── cost: 327000.00
+ │         ├── stats: [rows=1.42857143, distinct(6)=1]
+ │         ├── cost: 327000
  │         ├── key: (1-3)
  │         ├── fd: (1-3)-->(6)
  │         ├── prune: (1-3)
@@ -1272,7 +1272,7 @@ except-all
  │         ├── scan order@order_idx
  │         │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_carrier_id:6(int)
  │         │    ├── stats: [rows=300000, distinct(6)=210000]
- │         │    ├── cost: 324000.00
+ │         │    ├── cost: 324000
  │         │    ├── key: (1-3)
  │         │    ├── fd: (1-3)-->(6)
  │         │    ├── prune: (1-3,6)
@@ -1284,7 +1284,7 @@ except-all
  └── scan new_order
       ├── columns: new_order.no_o_id:9(int!null) new_order.no_d_id:10(int!null) new_order.no_w_id:11(int!null)
       ├── stats: [rows=90000]
-      ├── cost: 95400.00
+      ├── cost: 95400
       ├── key: (9-11)
       ├── prune: (9-11)
       └── interesting orderings: (+11,+10,+9)
@@ -1308,11 +1308,11 @@ except-all
  ├── left columns: "order".o_w_id:3(int!null) "order".o_d_id:2(int!null) "order".o_id:1(int!null) "order".o_ol_cnt:7(int)
  ├── right columns: order_line.ol_w_id:11(int) order_line.ol_d_id:10(int) order_line.ol_o_id:9(int) count:19(int)
  ├── stats: [rows=300000]
- ├── cost: 1416000.00
+ ├── cost: 1416000
  ├── scan order
  │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_ol_cnt:7(int)
  │    ├── stats: [rows=300000]
- │    ├── cost: 336000.00
+ │    ├── cost: 336000
  │    ├── key: (1-3)
  │    ├── fd: (1-3)-->(7)
  │    ├── prune: (1-3,7)
@@ -1321,7 +1321,7 @@ except-all
       ├── columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null) count:19(int)
       ├── grouping columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null)
       ├── stats: [rows=100000, distinct(9-11)=100000]
-      ├── cost: 1080000.00
+      ├── cost: 1080000
       ├── key: (9-11)
       ├── fd: (9-11)-->(19)
       ├── prune: (19)
@@ -1329,7 +1329,7 @@ except-all
       ├── scan order_line@order_line_fk
       │    ├── columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null)
       │    ├── stats: [rows=1000000, distinct(9-11)=100000]
-      │    ├── cost: 1080000.00
+      │    ├── cost: 1080000
       │    ├── prune: (9-11)
       │    └── interesting orderings: (+11,+10,-9)
       └── aggregations
@@ -1354,12 +1354,12 @@ except-all
  ├── left columns: order_line.ol_w_id:3(int!null) order_line.ol_d_id:2(int!null) order_line.ol_o_id:1(int!null) count:11(int)
  ├── right columns: "order".o_w_id:14(int) "order".o_d_id:13(int) "order".o_id:12(int) "order".o_ol_cnt:18(int)
  ├── stats: [rows=100000]
- ├── cost: 1416000.00
+ ├── cost: 1416000
  ├── group-by
  │    ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) count:11(int)
  │    ├── grouping columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null)
  │    ├── stats: [rows=100000, distinct(1-3)=100000]
- │    ├── cost: 1080000.00
+ │    ├── cost: 1080000
  │    ├── key: (1-3)
  │    ├── fd: (1-3)-->(11)
  │    ├── prune: (11)
@@ -1367,7 +1367,7 @@ except-all
  │    ├── scan order_line@order_line_fk
  │    │    ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null)
  │    │    ├── stats: [rows=1000000, distinct(1-3)=100000]
- │    │    ├── cost: 1080000.00
+ │    │    ├── cost: 1080000
  │    │    ├── prune: (1-3)
  │    │    └── interesting orderings: (+3,+2,-1)
  │    └── aggregations
@@ -1375,7 +1375,7 @@ except-all
  └── scan order
       ├── columns: "order".o_id:12(int!null) "order".o_d_id:13(int!null) "order".o_w_id:14(int!null) "order".o_ol_cnt:18(int)
       ├── stats: [rows=300000]
-      ├── cost: 336000.00
+      ├── cost: 336000
       ├── key: (12-14)
       ├── fd: (12-14)-->(18)
       ├── prune: (12-14,18)
@@ -1408,25 +1408,25 @@ group-by
  ├── prune: (19)
  ├── select
  │    ├── columns: "order".o_id:1(int) "order".o_d_id:2(int) "order".o_w_id:3(int) order_line.ol_o_id:9(int) order_line.ol_d_id:10(int) order_line.ol_w_id:11(int)
- │    ├── stats: [rows=0.0680]
+ │    ├── stats: [rows=0.0680272109]
  │    ├── cost: 1477000.03
  │    ├── interesting orderings: (+3,+2,-1) (+11,+10,-9)
  │    ├── full-join
  │    │    ├── columns: "order".o_id:1(int) "order".o_d_id:2(int) "order".o_w_id:3(int) order_line.ol_o_id:9(int) order_line.ol_d_id:10(int) order_line.ol_w_id:11(int)
- │    │    ├── stats: [rows=0.2041]
+ │    │    ├── stats: [rows=0.204081633]
  │    │    ├── cost: 1477000.03
  │    │    ├── interesting orderings: (+3,+2,-1) (+11,+10,-9)
  │    │    ├── project
  │    │    │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null)
- │    │    │    ├── stats: [rows=1.43]
- │    │    │    ├── cost: 327000.00
+ │    │    │    ├── stats: [rows=1.42857143]
+ │    │    │    ├── cost: 327000
  │    │    │    ├── key: (1-3)
  │    │    │    ├── prune: (1-3)
  │    │    │    ├── interesting orderings: (+3,+2,-1)
  │    │    │    └── select
  │    │    │         ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_carrier_id:6(int)
- │    │    │         ├── stats: [rows=1.43, distinct(6)=1]
- │    │    │         ├── cost: 327000.00
+ │    │    │         ├── stats: [rows=1.42857143, distinct(6)=1]
+ │    │    │         ├── cost: 327000
  │    │    │         ├── key: (1-3)
  │    │    │         ├── fd: (1-3)-->(6)
  │    │    │         ├── prune: (1-3)
@@ -1434,7 +1434,7 @@ group-by
  │    │    │         ├── scan order@order_idx
  │    │    │         │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_carrier_id:6(int)
  │    │    │         │    ├── stats: [rows=300000, distinct(6)=210000]
- │    │    │         │    ├── cost: 324000.00
+ │    │    │         │    ├── cost: 324000
  │    │    │         │    ├── key: (1-3)
  │    │    │         │    ├── fd: (1-3)-->(6)
  │    │    │         │    ├── prune: (1-3,6)
@@ -1445,20 +1445,20 @@ group-by
  │    │    │                   └── null [type=unknown]
  │    │    ├── project
  │    │    │    ├── columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null)
- │    │    │    ├── stats: [rows=1.43]
- │    │    │    ├── cost: 1150000.00
+ │    │    │    ├── stats: [rows=1.42857143]
+ │    │    │    ├── cost: 1150000
  │    │    │    ├── prune: (9-11)
  │    │    │    ├── interesting orderings: (+11,+10,-9)
  │    │    │    └── select
  │    │    │         ├── columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null) order_line.ol_delivery_d:15(timestamp)
- │    │    │         ├── stats: [rows=1.43, distinct(15)=1]
- │    │    │         ├── cost: 1150000.00
+ │    │    │         ├── stats: [rows=1.42857143, distinct(15)=1]
+ │    │    │         ├── cost: 1150000
  │    │    │         ├── prune: (9-11)
  │    │    │         ├── interesting orderings: (+11,+10,-9)
  │    │    │         ├── scan order_line
  │    │    │         │    ├── columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null) order_line.ol_delivery_d:15(timestamp)
  │    │    │         │    ├── stats: [rows=1000000, distinct(15)=700000]
- │    │    │         │    ├── cost: 1140000.00
+ │    │    │         │    ├── cost: 1140000
  │    │    │         │    ├── prune: (9-11,15)
  │    │    │         │    └── interesting orderings: (+11,+10,-9)
  │    │    │         └── filters [type=bool, outer=(15), constraints=(/15: [/NULL - /NULL]; tight)]


### PR DESCRIPTION
The costs and stats are not very useful when the values are small
(which tends to happen when there are multi-column constraints).

Switching the display of floats to use `%.9g`. This show us a bunch of
significant digits regardless of the scale while still displaying
integers without a decimal point:
```
           Value | %.9g
               0 | 0
 0.0000000001234 | 1.234e-10
        0.001234 | 0.001234
             0.1 | 0.1
               1 | 1
          1.0001 | 1.0001
       1234.5678 | 1234.5678
        12345678 | 12345678
       200000000 | 200000000
```

Release note: None
