### PR TITLE
distsqlrun: reuse memcontainer memory in sortChunks

### DIFF
--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -430,9 +430,8 @@ func (s *sortTopKProcessor) ConsumerClosed() {
 type sortChunksProcessor struct {
 	sorterBase
 
-	rows     memRowContainer
-	alloc    sqlbase.DatumAlloc
-	rowAlloc sqlbase.EncDatumRowAlloc
+	rows  memRowContainer
+	alloc sqlbase.DatumAlloc
 
 	// sortChunksProcessor accumulates rows that are equal on a prefix, until it
 	// encounters a row that is greater. It stores that greater row in nextChunkRow
@@ -519,8 +518,6 @@ func (s *sortChunksProcessor) fill() (bool, error) {
 		return false, err
 	}
 
-	defer s.rows.Sort(ctx)
-
 	// We will accumulate rows to form a chunk such that they all share the same values
 	// as prefix for the first s.matchLen ordering columns.
 	for {
@@ -540,7 +537,7 @@ func (s *sortChunksProcessor) fill() (bool, error) {
 			return false, err
 		}
 		if chunkCompleted {
-			s.nextChunkRow = s.rowAlloc.CopyRow(nextChunkRow)
+			s.nextChunkRow = nextChunkRow
 			break
 		}
 
@@ -548,6 +545,8 @@ func (s *sortChunksProcessor) fill() (bool, error) {
 			return false, err
 		}
 	}
+
+	s.rows.Sort(ctx)
 
 	return true, nil
 }
@@ -563,7 +562,10 @@ func (s *sortChunksProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	for s.state == stateRunning {
 		// If we don't have an active chunk, clear and refill it.
 		if s.rows.Len() == 0 {
-			s.rows.Clear(s.rows.evalCtx.Ctx())
+			if err := s.rows.UnsafeReset(s.rows.evalCtx.Ctx()); err != nil {
+				s.moveToDraining(err)
+				break
+			}
 			valid, err := s.fill()
 			if !valid || err != nil {
 				s.moveToDraining(err)


### PR DESCRIPTION
Previously, the sortChunks processor would completely Clear its row
container when moving to a new chunk. This was very inefficient in the
case of small chunks, because every new chunk would need to allocate a
ton of memory - the row container tries to amortize allocations by
making a big allocation up front, but in this case it's a pessimization
to do that.

To solve this, we introduce a new Reset method on the row container
which permits resetting the row container without releasing its
allocating container space.

```
name                                     old time/op    new time/op     delta
SortChunks/rows=65536,ChunkSize=1-8         113ms ± 1%       15ms ± 1%   -86.41%  (p=0.000 n=8+10)
SortChunks/rows=65536,ChunkSize=4-8        43.6ms ± 1%     18.5ms ± 4%   -57.51%  (p=0.000 n=10+10)
SortChunks/rows=65536,ChunkSize=16-8       31.4ms ± 1%     24.2ms ± 2%   -22.74%  (p=0.000 n=10+10)
SortChunks/rows=65536,ChunkSize=64-8       33.5ms ± 2%     33.1ms ± 1%    -1.05%  (p=0.035 n=10+10)
SortChunks/rows=65536,ChunkSize=256-8      40.1ms ± 1%     39.8ms ± 1%    -0.63%  (p=0.022 n=9+10)
SortChunks/rows=65536,ChunkSize=1024-8     46.5ms ± 2%     46.2ms ± 2%      ~     (p=0.182 n=9+10)
SortChunks/rows=65536,ChunkSize=4096-8     52.8ms ± 1%     52.6ms ± 1%      ~     (p=0.055 n=10+8)
SortChunks/rows=65536,ChunkSize=16384-8    60.3ms ± 1%     59.5ms ± 2%    -1.36%  (p=0.001 n=10+10)
SortChunks/rows=65536,ChunkSize=65536-8    68.2ms ± 2%     68.7ms ± 2%      ~     (p=0.190 n=10+10)

name                                     old speed      new speed       delta
SortChunks/rows=65536,ChunkSize=1-8      9.24MB/s ± 1%  67.97MB/s ± 1%  +635.48%  (p=0.000 n=8+10)
SortChunks/rows=65536,ChunkSize=4-8      24.0MB/s ± 1%   56.6MB/s ± 4%  +135.43%  (p=0.000 n=10+10)
SortChunks/rows=65536,ChunkSize=16-8     33.4MB/s ± 1%   43.3MB/s ± 2%   +29.43%  (p=0.000 n=10+10)
SortChunks/rows=65536,ChunkSize=64-8     31.3MB/s ± 2%   31.6MB/s ± 1%    +1.06%  (p=0.034 n=10+10)
SortChunks/rows=65536,ChunkSize=256-8    26.2MB/s ± 2%   26.3MB/s ± 1%      ~     (p=0.093 n=10+10)
SortChunks/rows=65536,ChunkSize=1024-8   22.6MB/s ± 1%   22.7MB/s ± 2%      ~     (p=0.264 n=8+10)
SortChunks/rows=65536,ChunkSize=4096-8   19.8MB/s ± 1%   20.0MB/s ± 1%      ~     (p=0.064 n=10+8)
SortChunks/rows=65536,ChunkSize=16384-8  17.4MB/s ± 1%   17.6MB/s ± 2%    +1.39%  (p=0.001 n=10+10)
SortChunks/rows=65536,ChunkSize=65536-8  15.4MB/s ± 2%   15.3MB/s ± 2%      ~     (p=0.171 n=10+10)

name                                     old alloc/op   new alloc/op    delta
SortChunks/rows=65536,ChunkSize=1-8         143MB ± 0%        0MB ± 0%  -100.00%  (p=0.000 n=9+9)
SortChunks/rows=65536,ChunkSize=4-8        35.7MB ± 0%      0.0MB ± 0%   -99.98%  (p=0.000 n=9+10)
SortChunks/rows=65536,ChunkSize=16-8       8.92MB ± 0%     0.01MB ± 0%   -99.93%  (p=0.000 n=9+10)
SortChunks/rows=65536,ChunkSize=64-8       2.23MB ± 0%     2.13MB ± 0%    -4.40%  (p=0.001 n=8+9)
SortChunks/rows=65536,ChunkSize=256-8      2.17MB ± 0%     2.15MB ± 0%    -1.13%  (p=0.000 n=10+10)
SortChunks/rows=65536,ChunkSize=1024-8     2.16MB ± 0%     2.15MB ± 0%    -0.29%  (p=0.000 n=10+9)
SortChunks/rows=65536,ChunkSize=4096-8     2.15MB ± 0%     2.15MB ± 0%    -0.07%  (p=0.000 n=10+8)
SortChunks/rows=65536,ChunkSize=16384-8    2.47MB ± 0%     2.28MB ± 0%    -7.71%  (p=0.000 n=9+10)
SortChunks/rows=65536,ChunkSize=65536-8    2.25MB ± 0%     2.25MB ± 0%      ~     (p=0.087 n=10+10)

name                                     old allocs/op  new allocs/op   delta
SortChunks/rows=65536,ChunkSize=1-8          135k ± 0%         0k ± 0%   -99.99%  (p=0.000 n=9+10)
SortChunks/rows=65536,ChunkSize=4-8         33.8k ± 0%       0.0k ± 0%   -99.96%  (p=0.000 n=10+10)
SortChunks/rows=65536,ChunkSize=16-8        8.46k ± 0%      0.01k ± 0%   -99.83%  (p=0.000 n=10+10)
SortChunks/rows=65536,ChunkSize=64-8        2.12k ± 0%      2.06k ± 0%    -3.01%  (p=0.000 n=10+10)
SortChunks/rows=65536,ChunkSize=256-8       1.82k ± 0%      1.80k ± 0%    -0.88%  (p=0.000 n=10+10)
SortChunks/rows=65536,ChunkSize=1024-8      1.10k ± 0%      1.10k ± 0%    -0.36%  (p=0.000 n=10+10)
SortChunks/rows=65536,ChunkSize=4096-8        477 ± 0%        476 ± 0%    -0.21%  (p=0.000 n=10+9)
SortChunks/rows=65536,ChunkSize=16384-8       189 ± 0%        117 ± 0%   -38.10%  (p=0.000 n=10+10)
SortChunks/rows=65536,ChunkSize=65536-8      69.0 ± 0%       69.4 ± 1%      ~     (p=0.087 n=10+10)
```

Release note (performance improvement): improve performance of
sortChunks processor