### PR TITLE
server: add env var hack to override default ConnResultsBufferBytes

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -386,7 +386,10 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 		},
 		TempStorageConfig: base.TempStorageConfigFromEnv(
 			ctx, st, storeSpec, "" /* parentDir */, base.DefaultTempStorageMaxSizeBytes, 0),
-		ConnResultsBufferBytes: defaultConnResultsBufferBytes,
+		// TODO(dan): Hack. Remove this env override once changefeeds have
+		// control over buffering.
+		ConnResultsBufferBytes: envutil.EnvOrDefaultInt(
+			"COCKROACH_CONN_RESULTS_BUFFER_BYTES", defaultConnResultsBufferBytes),
 	}
 	cfg.AmbientCtx.Tracer = st.Tracer
 


### PR DESCRIPTION
COCKROACH_CONN_RESULTS_BUFFER_BYTES can be used to override the default
so that changefeeds can return results directly. The real solution will
be for changefeeds to have more control over buffering but it's too late
in the stability period for that and it would be great for users to have
_some_ way to work around this for the upcoming alpha.

Release note: None