### PR TITLE
opt: improve the ratchetCost epsilon test, improve costing for sort

### DIFF
--- a/pkg/sql/opt/memo/cost.go
+++ b/pkg/sql/opt/memo/cost.go
@@ -33,9 +33,14 @@ func (c Cost) Less(other Cost) bool {
 	// Two plans with the same cost can have slightly different floating point
 	// results (e.g. same subcosts being added up in a different order). So we
 	// treat plans with very similar cost as equal.
-	const epsilon = 1e-5
-
-	return c <= other-epsilon
+	//
+	// We use "units of least precision" for similarity: this is the number of
+	// representable floating point numbers in-between the two values. This is
+	// better than a fixed epsilon because the allowed error is proportional to
+	// the magnitude of the numbers. Because the mantissa is in the low bits, we
+	// can just use the bit representations as integers.
+	const ulpTolerance = 1000
+	return math.Float64bits(float64(c))+ulpTolerance <= math.Float64bits(float64(other))
 }
 
 // Sub subtracts the other cost from this cost and returns the result.

--- a/pkg/sql/opt/memo/cost_test.go
+++ b/pkg/sql/opt/memo/cost_test.go
@@ -21,15 +21,26 @@ import (
 )
 
 func TestCostLess(t *testing.T) {
-	testLess := func(left, right memo.Cost, expected bool) {
-		if left.Less(right) != expected {
-			t.Errorf("expected %v.Less(%v) to be %v, got %v", left, right, expected, !expected)
+	testCases := []struct {
+		left, right memo.Cost
+		expected    bool
+	}{
+		{0.0, 1.0, true},
+		{0.0, 1e-20, true},
+		{0.0, 0.0, false},
+		{1.0, 0.0, false},
+		{1e-20, 1.0000000000001e-20, false},
+		{1e-20, 1.000001e-20, true},
+		{1, 1.00000000000001, false},
+		{1, 1.00000001, true},
+		{1000, 1000.00000000001, false},
+		{1000, 1000.00001, true},
+	}
+	for _, tc := range testCases {
+		if tc.left.Less(tc.right) != tc.expected {
+			t.Errorf("expected %v.Less(%v) to be %v", tc.left, tc.right, tc.expected)
 		}
 	}
-
-	testLess(memo.Cost(0.0), memo.Cost(1.0), true)
-	testLess(memo.Cost(0.0), memo.Cost(0.0), false)
-	testLess(memo.Cost(1.0), memo.Cost(0.0), false)
 }
 
 func TestCostSub(t *testing.T) {

--- a/pkg/sql/opt/xform/testdata/coster/sort
+++ b/pkg/sql/opt/xform/testdata/coster/sort
@@ -37,7 +37,7 @@ SELECT f FROM a WHERE k < 0 AND k > 10 ORDER BY f DESC
 sort
  ├── columns: f:2(float!null)
  ├── stats: [rows=0]
- ├── cost: 0.01
+ ├── cost: 0
  ├── ordering: -2
  └── project
       ├── columns: f:2(float!null)

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -275,176 +275,174 @@ ON ft.ftserver = fs.oid
 WHERE ((c.relkind = 'r'::CHAR) OR (c.relkind = 'f'::CHAR)) AND (n.nspname = 'public')
 ORDER BY schemaname, tablename
 ----
-project
+sort
  ├── columns: oid:1(oid) schemaname:29(string) tablename:2(string) relacl:26(string[]) tableowner:129(string) description:130(string) relkind:17(string) cluster:92(string) hasoids:20(bool) hasindexes:13(bool) hasrules:22(bool) tablespace:33(string) param:27(string[]) hastriggers:23(bool) unlogged:15(string) ftoptions:120(string[]) srvname:122(string) reltuples:10(float) inhtable:135(bool) inhschemaname:69(string) inhtablename:42(string)
  ├── fd: (1)-->(2,3,5,10,13,15,17,20,22,23,26,27,130), (2,3)-->(1,5,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (91)-->(92,93), (92,93)-->(91), (118)-->(120), (121)-->(122), (122)-->(121), (5)-->(129), (134)-->(135) [removed: (3,5,28,32,41,43,91,93,118,121,134)]
  ├── ordering: +29,+2
- ├── sort
- │    ├── columns: pg_class.oid:1(oid) pg_class.relname:2(string) pg_class.relowner:5(oid) pg_class.reltuples:10(float) pg_class.relhasindex:13(bool) pg_class.relpersistence:15(string) pg_class.relkind:17(string) pg_class.relhasoids:20(bool) pg_class.relhasrules:22(bool) pg_class.relhastriggers:23(bool) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.nspname:29(string) spcname:33(string) pg_class.relname:42(string) pg_namespace.nspname:69(string) pg_class.relname:92(string) ftoptions:120(string[]) srvname:122(string) count:134(int) rownum:136(int!null)
- │    ├── key: (136)
- │    ├── fd: (1)-->(2,3,5,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (91)-->(92,93), (92,93)-->(91), (118)-->(120), (121)-->(122), (122)-->(121), (136)-->(1-3,5,10,13,15,17,20,22,23,26-29,32,33,41-43,69,72,91,92,118,120-122,134) [removed: (3,28,32,41,43,72,91,93,118,121)]
- │    ├── ordering: +29,+2
- │    └── group-by
- │         ├── columns: pg_class.oid:1(oid) pg_class.relname:2(string) pg_class.relowner:5(oid) pg_class.reltuples:10(float) pg_class.relhasindex:13(bool) pg_class.relpersistence:15(string) pg_class.relkind:17(string) pg_class.relhasoids:20(bool) pg_class.relhasrules:22(bool) pg_class.relhastriggers:23(bool) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.nspname:29(string) spcname:33(string) pg_class.relname:42(string) pg_namespace.nspname:69(string) pg_class.relname:92(string) ftoptions:120(string[]) srvname:122(string) count:134(int) rownum:136(int!null)
- │         ├── grouping columns: rownum:136(int!null)
- │         ├── key: (136)
- │         ├── fd: (1)-->(2,3,5,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (91)-->(92,93), (92,93)-->(91), (118)-->(120), (121)-->(122), (122)-->(121), (136)-->(1-3,5,10,13,15,17,20,22,23,26-29,32,33,41-43,69,72,91,92,118,120-122,134) [removed: (3,28,32,41,43,72,91,93,118,121)]
- │         ├── left-join
- │         │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) pg_class.oid:91(oid) pg_class.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[]) pg_foreign_server.oid:121(oid) srvname:122(string) pg_inherits.inhparent:132(oid) rownum:136(int!null)
- │         │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (68)~~>(69), (69)~~>(68), (72)-->(73,79), (91)-->(92,93), (92,93)-->(91), (118)-->(119,120), (121)-->(122), (122)-->(121), (136)-->(1-3,5,8,10,13,15,17,20,22,23,26-29,32,33,38,39,41-43,68,69,72,73,79,91,92,118-122) [removed: (93)]
- │         │    ├── row-number
- │         │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) pg_class.oid:91(oid) pg_class.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[]) pg_foreign_server.oid:121(oid) srvname:122(string) rownum:136(int!null)
- │         │    │    ├── key: (136)
- │         │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (68)~~>(69), (69)~~>(68), (72)-->(73,79), (91)-->(92,93), (92,93)-->(91), (118)-->(119,120), (121)-->(122), (122)-->(121), (136)-->(1-3,5,8,10,13,15,17,20,22,23,26-29,32,33,38,39,41-43,68,69,72,73,79,91,92,118-122) [removed: (93)]
- │         │    │    └── left-join
- │         │    │         ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) pg_class.oid:91(oid) pg_class.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[]) pg_foreign_server.oid:121(oid) srvname:122(string)
- │         │    │         ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (68)~~>(69), (69)~~>(68), (72)-->(73,79), (91)-->(92,93), (92,93)-->(91), (118)-->(119,120), (121)-->(122), (122)-->(121) [removed: (93)]
- │         │    │         ├── left-join
- │         │    │         │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) pg_class.oid:91(oid) pg_class.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[])
- │         │    │         │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (68)~~>(69), (69)~~>(68), (72)-->(73,79), (91)-->(92,93), (92,93)-->(91), (118)-->(119,120) [removed: (93)]
- │         │    │         │    ├── left-join
- │         │    │         │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) pg_class.oid:91(oid) pg_class.relname:92(string)
- │         │    │         │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (68)~~>(69), (69)~~>(68), (72)-->(73,79), (91)-->(92,93), (92,93)-->(91) [removed: (93)]
- │         │    │         │    │    ├── left-join
- │         │    │         │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool)
- │         │    │         │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (68)~~>(69), (69)~~>(68), (72)-->(73,79)
- │         │    │         │    │    │    ├── left-join
- │         │    │         │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string)
- │         │    │         │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (68)~~>(69), (69)~~>(68)
- │         │    │         │    │    │    │    ├── left-join
- │         │    │         │    │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string)
- │         │    │         │    │    │    │    │    ├── key: (1,28,32)
- │         │    │         │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32)
- │         │    │         │    │    │    │    │    ├── select
- │         │    │         │    │    │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string!null)
- │         │    │         │    │    │    │    │    │    ├── key: (1,28)
- │         │    │         │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28)
- │         │    │         │    │    │    │    │    │    ├── left-join
- │         │    │         │    │    │    │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string)
- │         │    │         │    │    │    │    │    │    │    ├── key: (1,28)
- │         │    │         │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28)
- │         │    │         │    │    │    │    │    │    │    ├── select
- │         │    │         │    │    │    │    │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[])
- │         │    │         │    │    │    │    │    │    │    │    ├── key: (1)
- │         │    │         │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
- │         │    │         │    │    │    │    │    │    │    │    ├── scan pg_class
- │         │    │         │    │    │    │    │    │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[])
- │         │    │         │    │    │    │    │    │    │    │    │    ├── key: (1)
- │         │    │         │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
- │         │    │         │    │    │    │    │    │    │    │    └── filters [type=bool, outer=(17)]
- │         │    │         │    │    │    │    │    │    │    │         └── (pg_class.relkind = 'r'::CHAR) OR (pg_class.relkind = 'f'::CHAR) [type=bool, outer=(17)]
- │         │    │         │    │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index
- │         │    │         │    │    │    │    │    │    │    │    ├── columns: pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null)
- │         │    │         │    │    │    │    │    │    │    │    ├── key: (28)
- │         │    │         │    │    │    │    │    │    │    │    └── fd: (28)-->(29), (29)-->(28)
- │         │    │         │    │    │    │    │    │    │    └── filters [type=bool, outer=(3,28), constraints=(/3: (/NULL - ]; /28: (/NULL - ])]
- │         │    │         │    │    │    │    │    │    │         └── pg_namespace.oid = pg_class.relnamespace [type=bool, outer=(3,28), constraints=(/3: (/NULL - ]; /28: (/NULL - ])]
- │         │    │         │    │    │    │    │    │    └── filters [type=bool, outer=(29), constraints=(/29: [/'public' - /'public']; tight)]
- │         │    │         │    │    │    │    │    │         └── pg_namespace.nspname = 'public' [type=bool, outer=(29), constraints=(/29: [/'public' - /'public']; tight)]
- │         │    │         │    │    │    │    │    ├── scan pg_tablespace@pg_tablespace_spcname_index
- │         │    │         │    │    │    │    │    │    ├── columns: pg_tablespace.oid:32(oid!null) spcname:33(string!null)
- │         │    │         │    │    │    │    │    │    ├── key: (32)
- │         │    │         │    │    │    │    │    │    └── fd: (32)-->(33), (33)-->(32)
- │         │    │         │    │    │    │    │    └── filters [type=bool, outer=(8,32), constraints=(/8: (/NULL - ]; /32: (/NULL - ])]
- │         │    │         │    │    │    │    │         └── pg_tablespace.oid = pg_class.reltablespace [type=bool, outer=(8,32), constraints=(/8: (/NULL - ]; /32: (/NULL - ])]
- │         │    │         │    │    │    │    ├── left-join
- │         │    │         │    │    │    │    │    ├── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null) pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string)
- │         │    │         │    │    │    │    │    ├── fd: (41)-->(42,43), (42,43)-->(41), (68)-->(69), (69)-->(68)
- │         │    │         │    │    │    │    │    ├── inner-join
- │         │    │         │    │    │    │    │    │    ├── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null) pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null)
- │         │    │         │    │    │    │    │    │    ├── fd: (41)-->(42,43), (42,43)-->(41)
- │         │    │         │    │    │    │    │    │    ├── scan pg_inherits
- │         │    │         │    │    │    │    │    │    │    └── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null)
- │         │    │         │    │    │    │    │    │    ├── scan pg_class@pg_class_relname_nsp_index
- │         │    │         │    │    │    │    │    │    │    ├── columns: pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null)
- │         │    │         │    │    │    │    │    │    │    ├── key: (41)
- │         │    │         │    │    │    │    │    │    │    └── fd: (41)-->(42,43), (42,43)-->(41)
- │         │    │         │    │    │    │    │    │    └── filters [type=bool, outer=(39,41), constraints=(/39: (/NULL - ]; /41: (/NULL - ])]
- │         │    │         │    │    │    │    │    │         └── pg_inherits.inhparent = pg_class.oid [type=bool, outer=(39,41), constraints=(/39: (/NULL - ]; /41: (/NULL - ])]
- │         │    │         │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index
- │         │    │         │    │    │    │    │    │    ├── columns: pg_namespace.oid:68(oid!null) pg_namespace.nspname:69(string!null)
- │         │    │         │    │    │    │    │    │    ├── key: (68)
- │         │    │         │    │    │    │    │    │    └── fd: (68)-->(69), (69)-->(68)
- │         │    │         │    │    │    │    │    └── filters [type=bool, outer=(43,68), constraints=(/43: (/NULL - ]; /68: (/NULL - ])]
- │         │    │         │    │    │    │    │         └── pg_namespace.oid = pg_class.relnamespace [type=bool, outer=(43,68), constraints=(/43: (/NULL - ]; /68: (/NULL - ])]
- │         │    │         │    │    │    │    └── filters [type=bool, outer=(1,38), constraints=(/1: (/NULL - ]; /38: (/NULL - ])]
- │         │    │         │    │    │    │         └── pg_inherits.inhrelid = pg_class.oid [type=bool, outer=(1,38), constraints=(/1: (/NULL - ]; /38: (/NULL - ])]
- │         │    │         │    │    │    ├── select
- │         │    │         │    │    │    │    ├── columns: indexrelid:72(oid!null) indrelid:73(oid!null) indisclustered:79(bool!null)
- │         │    │         │    │    │    │    ├── key: (72)
- │         │    │         │    │    │    │    ├── fd: (72)-->(73,79)
- │         │    │         │    │    │    │    ├── scan pg_index
- │         │    │         │    │    │    │    │    ├── columns: indexrelid:72(oid!null) indrelid:73(oid!null) indisclustered:79(bool!null)
- │         │    │         │    │    │    │    │    ├── key: (72)
- │         │    │         │    │    │    │    │    └── fd: (72)-->(73,79)
- │         │    │         │    │    │    │    └── filters [type=bool, outer=(79), constraints=(/79: [/true - /true]; tight)]
- │         │    │         │    │    │    │         └── pg_index.indisclustered = true [type=bool, outer=(79), constraints=(/79: [/true - /true]; tight)]
- │         │    │         │    │    │    └── filters [type=bool, outer=(1,73), constraints=(/1: (/NULL - ]; /73: (/NULL - ])]
- │         │    │         │    │    │         └── pg_index.indrelid = pg_class.oid [type=bool, outer=(1,73), constraints=(/1: (/NULL - ]; /73: (/NULL - ])]
- │         │    │         │    │    ├── scan pg_class@pg_class_relname_nsp_index
- │         │    │         │    │    │    ├── columns: pg_class.oid:91(oid!null) pg_class.relname:92(string!null)
- │         │    │         │    │    │    ├── key: (91)
- │         │    │         │    │    │    └── fd: (91)-->(92,93), (92,93)-->(91) [removed: (93)]
- │         │    │         │    │    └── filters [type=bool, outer=(72,91), constraints=(/72: (/NULL - ]; /91: (/NULL - ])]
- │         │    │         │    │         └── pg_class.oid = pg_index.indexrelid [type=bool, outer=(72,91), constraints=(/72: (/NULL - ]; /91: (/NULL - ])]
- │         │    │         │    ├── scan pg_foreign_table
- │         │    │         │    │    ├── columns: ftrelid:118(oid!null) ftserver:119(oid!null) ftoptions:120(string[])
- │         │    │         │    │    ├── key: (118)
- │         │    │         │    │    └── fd: (118)-->(119,120)
- │         │    │         │    └── filters [type=bool, outer=(1,118), constraints=(/1: (/NULL - ]; /118: (/NULL - ])]
- │         │    │         │         └── pg_foreign_table.ftrelid = pg_class.oid [type=bool, outer=(1,118), constraints=(/1: (/NULL - ]; /118: (/NULL - ])]
- │         │    │         ├── scan pg_foreign_server@pg_foreign_server_name_index
- │         │    │         │    ├── columns: pg_foreign_server.oid:121(oid!null) srvname:122(string!null)
- │         │    │         │    ├── key: (121)
- │         │    │         │    └── fd: (121)-->(122), (122)-->(121)
- │         │    │         └── filters [type=bool, outer=(119,121), constraints=(/119: (/NULL - ]; /121: (/NULL - ])]
- │         │    │              └── pg_foreign_table.ftserver = pg_foreign_server.oid [type=bool, outer=(119,121), constraints=(/119: (/NULL - ]; /121: (/NULL - ])]
- │         │    ├── scan pg_inherits
- │         │    │    └── columns: pg_inherits.inhparent:132(oid!null)
- │         │    └── filters [type=bool, outer=(1,132), constraints=(/1: (/NULL - ]; /132: (/NULL - ])]
- │         │         └── pg_inherits.inhparent = pg_class.oid [type=bool, outer=(1,132), constraints=(/1: (/NULL - ]; /132: (/NULL - ])]
- │         └── aggregations [outer=(1,2,5,10,13,15,17,20,22,23,26,27,29,33,42,69,92,120,122,132)]
- │              ├── count [type=int, outer=(132)]
- │              │    └── variable: pg_inherits.inhparent [type=oid, outer=(132)]
- │              ├── any-not-null [type=oid, outer=(1)]
- │              │    └── variable: pg_class.oid [type=oid, outer=(1)]
- │              ├── any-not-null [type=string, outer=(2)]
- │              │    └── variable: pg_class.relname [type=string, outer=(2)]
- │              ├── any-not-null [type=oid, outer=(5)]
- │              │    └── variable: pg_class.relowner [type=oid, outer=(5)]
- │              ├── any-not-null [type=float, outer=(10)]
- │              │    └── variable: pg_class.reltuples [type=float, outer=(10)]
- │              ├── any-not-null [type=bool, outer=(13)]
- │              │    └── variable: pg_class.relhasindex [type=bool, outer=(13)]
- │              ├── any-not-null [type=string, outer=(15)]
- │              │    └── variable: pg_class.relpersistence [type=string, outer=(15)]
- │              ├── any-not-null [type=string, outer=(17)]
- │              │    └── variable: pg_class.relkind [type=string, outer=(17)]
- │              ├── any-not-null [type=bool, outer=(20)]
- │              │    └── variable: pg_class.relhasoids [type=bool, outer=(20)]
- │              ├── any-not-null [type=bool, outer=(22)]
- │              │    └── variable: pg_class.relhasrules [type=bool, outer=(22)]
- │              ├── any-not-null [type=bool, outer=(23)]
- │              │    └── variable: pg_class.relhastriggers [type=bool, outer=(23)]
- │              ├── any-not-null [type=string[], outer=(26)]
- │              │    └── variable: pg_class.relacl [type=string[], outer=(26)]
- │              ├── any-not-null [type=string[], outer=(27)]
- │              │    └── variable: pg_class.reloptions [type=string[], outer=(27)]
- │              ├── any-not-null [type=string, outer=(29)]
- │              │    └── variable: pg_namespace.nspname [type=string, outer=(29)]
- │              ├── any-not-null [type=string, outer=(33)]
- │              │    └── variable: pg_tablespace.spcname [type=string, outer=(33)]
- │              ├── any-not-null [type=string, outer=(42)]
- │              │    └── variable: pg_class.relname [type=string, outer=(42)]
- │              ├── any-not-null [type=string, outer=(69)]
- │              │    └── variable: pg_namespace.nspname [type=string, outer=(69)]
- │              ├── any-not-null [type=string, outer=(92)]
- │              │    └── variable: pg_class.relname [type=string, outer=(92)]
- │              ├── any-not-null [type=string[], outer=(120)]
- │              │    └── variable: pg_foreign_table.ftoptions [type=string[], outer=(120)]
- │              └── any-not-null [type=string, outer=(122)]
- │                   └── variable: pg_foreign_server.srvname [type=string, outer=(122)]
- └── projections [outer=(1,2,5,10,13,15,17,20,22,23,26,27,29,33,42,69,92,120,122,134)]
-      ├── pg_get_userbyid(pg_class.relowner) [type=string, outer=(5)]
-      ├── obj_description(pg_class.oid) [type=string, outer=(1)]
-      └── count > 0 [type=bool, outer=(134)]
+ └── project
+      ├── columns: tableowner:129(string) description:130(string) inhtable:135(bool) pg_class.oid:1(oid) pg_class.relname:2(string) pg_class.reltuples:10(float) pg_class.relhasindex:13(bool) pg_class.relpersistence:15(string) pg_class.relkind:17(string) pg_class.relhasoids:20(bool) pg_class.relhasrules:22(bool) pg_class.relhastriggers:23(bool) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.nspname:29(string) spcname:33(string) pg_class.relname:42(string) pg_namespace.nspname:69(string) pg_class.relname:92(string) ftoptions:120(string[]) srvname:122(string)
+      ├── fd: (1)-->(2,3,5,10,13,15,17,20,22,23,26,27,130), (2,3)-->(1,5,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (91)-->(92,93), (92,93)-->(91), (118)-->(120), (121)-->(122), (122)-->(121), (5)-->(129), (134)-->(135) [removed: (3,5,28,32,41,43,91,93,118,121,134)]
+      ├── group-by
+      │    ├── columns: pg_class.oid:1(oid) pg_class.relname:2(string) pg_class.relowner:5(oid) pg_class.reltuples:10(float) pg_class.relhasindex:13(bool) pg_class.relpersistence:15(string) pg_class.relkind:17(string) pg_class.relhasoids:20(bool) pg_class.relhasrules:22(bool) pg_class.relhastriggers:23(bool) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.nspname:29(string) spcname:33(string) pg_class.relname:42(string) pg_namespace.nspname:69(string) pg_class.relname:92(string) ftoptions:120(string[]) srvname:122(string) count:134(int) rownum:136(int!null)
+      │    ├── grouping columns: rownum:136(int!null)
+      │    ├── key: (136)
+      │    ├── fd: (1)-->(2,3,5,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (91)-->(92,93), (92,93)-->(91), (118)-->(120), (121)-->(122), (122)-->(121), (136)-->(1-3,5,10,13,15,17,20,22,23,26-29,32,33,41-43,69,72,91,92,118,120-122,134) [removed: (3,28,32,41,43,72,91,93,118,121)]
+      │    ├── left-join
+      │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) pg_class.oid:91(oid) pg_class.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[]) pg_foreign_server.oid:121(oid) srvname:122(string) pg_inherits.inhparent:132(oid) rownum:136(int!null)
+      │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (68)~~>(69), (69)~~>(68), (72)-->(73,79), (91)-->(92,93), (92,93)-->(91), (118)-->(119,120), (121)-->(122), (122)-->(121), (136)-->(1-3,5,8,10,13,15,17,20,22,23,26-29,32,33,38,39,41-43,68,69,72,73,79,91,92,118-122) [removed: (93)]
+      │    │    ├── row-number
+      │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) pg_class.oid:91(oid) pg_class.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[]) pg_foreign_server.oid:121(oid) srvname:122(string) rownum:136(int!null)
+      │    │    │    ├── key: (136)
+      │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (68)~~>(69), (69)~~>(68), (72)-->(73,79), (91)-->(92,93), (92,93)-->(91), (118)-->(119,120), (121)-->(122), (122)-->(121), (136)-->(1-3,5,8,10,13,15,17,20,22,23,26-29,32,33,38,39,41-43,68,69,72,73,79,91,92,118-122) [removed: (93)]
+      │    │    │    └── left-join
+      │    │    │         ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) pg_class.oid:91(oid) pg_class.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[]) pg_foreign_server.oid:121(oid) srvname:122(string)
+      │    │    │         ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (68)~~>(69), (69)~~>(68), (72)-->(73,79), (91)-->(92,93), (92,93)-->(91), (118)-->(119,120), (121)-->(122), (122)-->(121) [removed: (93)]
+      │    │    │         ├── left-join
+      │    │    │         │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) pg_class.oid:91(oid) pg_class.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[])
+      │    │    │         │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (68)~~>(69), (69)~~>(68), (72)-->(73,79), (91)-->(92,93), (92,93)-->(91), (118)-->(119,120) [removed: (93)]
+      │    │    │         │    ├── left-join
+      │    │    │         │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) pg_class.oid:91(oid) pg_class.relname:92(string)
+      │    │    │         │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (68)~~>(69), (69)~~>(68), (72)-->(73,79), (91)-->(92,93), (92,93)-->(91) [removed: (93)]
+      │    │    │         │    │    ├── left-join
+      │    │    │         │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool)
+      │    │    │         │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (68)~~>(69), (69)~~>(68), (72)-->(73,79)
+      │    │    │         │    │    │    ├── left-join
+      │    │    │         │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string)
+      │    │    │         │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (68)~~>(69), (69)~~>(68)
+      │    │    │         │    │    │    │    ├── left-join
+      │    │    │         │    │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string)
+      │    │    │         │    │    │    │    │    ├── key: (1,28,32)
+      │    │    │         │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28), (32)-->(33), (33)-->(32)
+      │    │    │         │    │    │    │    │    ├── select
+      │    │    │         │    │    │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string!null)
+      │    │    │         │    │    │    │    │    │    ├── key: (1,28)
+      │    │    │         │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28)
+      │    │    │         │    │    │    │    │    │    ├── left-join
+      │    │    │         │    │    │    │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid) pg_namespace.nspname:29(string)
+      │    │    │         │    │    │    │    │    │    │    ├── key: (1,28)
+      │    │    │         │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27), (28)-->(29), (29)-->(28)
+      │    │    │         │    │    │    │    │    │    │    ├── select
+      │    │    │         │    │    │    │    │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[])
+      │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │         │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+      │    │    │         │    │    │    │    │    │    │    │    ├── scan pg_class
+      │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[])
+      │    │    │         │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │         │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+      │    │    │         │    │    │    │    │    │    │    │    └── filters [type=bool, outer=(17)]
+      │    │    │         │    │    │    │    │    │    │    │         └── (pg_class.relkind = 'r'::CHAR) OR (pg_class.relkind = 'f'::CHAR) [type=bool, outer=(17)]
+      │    │    │         │    │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index
+      │    │    │         │    │    │    │    │    │    │    │    ├── columns: pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null)
+      │    │    │         │    │    │    │    │    │    │    │    ├── key: (28)
+      │    │    │         │    │    │    │    │    │    │    │    └── fd: (28)-->(29), (29)-->(28)
+      │    │    │         │    │    │    │    │    │    │    └── filters [type=bool, outer=(3,28), constraints=(/3: (/NULL - ]; /28: (/NULL - ])]
+      │    │    │         │    │    │    │    │    │    │         └── pg_namespace.oid = pg_class.relnamespace [type=bool, outer=(3,28), constraints=(/3: (/NULL - ]; /28: (/NULL - ])]
+      │    │    │         │    │    │    │    │    │    └── filters [type=bool, outer=(29), constraints=(/29: [/'public' - /'public']; tight)]
+      │    │    │         │    │    │    │    │    │         └── pg_namespace.nspname = 'public' [type=bool, outer=(29), constraints=(/29: [/'public' - /'public']; tight)]
+      │    │    │         │    │    │    │    │    ├── scan pg_tablespace@pg_tablespace_spcname_index
+      │    │    │         │    │    │    │    │    │    ├── columns: pg_tablespace.oid:32(oid!null) spcname:33(string!null)
+      │    │    │         │    │    │    │    │    │    ├── key: (32)
+      │    │    │         │    │    │    │    │    │    └── fd: (32)-->(33), (33)-->(32)
+      │    │    │         │    │    │    │    │    └── filters [type=bool, outer=(8,32), constraints=(/8: (/NULL - ]; /32: (/NULL - ])]
+      │    │    │         │    │    │    │    │         └── pg_tablespace.oid = pg_class.reltablespace [type=bool, outer=(8,32), constraints=(/8: (/NULL - ]; /32: (/NULL - ])]
+      │    │    │         │    │    │    │    ├── left-join
+      │    │    │         │    │    │    │    │    ├── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null) pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string)
+      │    │    │         │    │    │    │    │    ├── fd: (41)-->(42,43), (42,43)-->(41), (68)-->(69), (69)-->(68)
+      │    │    │         │    │    │    │    │    ├── inner-join
+      │    │    │         │    │    │    │    │    │    ├── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null) pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null)
+      │    │    │         │    │    │    │    │    │    ├── fd: (41)-->(42,43), (42,43)-->(41)
+      │    │    │         │    │    │    │    │    │    ├── scan pg_inherits
+      │    │    │         │    │    │    │    │    │    │    └── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null)
+      │    │    │         │    │    │    │    │    │    ├── scan pg_class@pg_class_relname_nsp_index
+      │    │    │         │    │    │    │    │    │    │    ├── columns: pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null)
+      │    │    │         │    │    │    │    │    │    │    ├── key: (41)
+      │    │    │         │    │    │    │    │    │    │    └── fd: (41)-->(42,43), (42,43)-->(41)
+      │    │    │         │    │    │    │    │    │    └── filters [type=bool, outer=(39,41), constraints=(/39: (/NULL - ]; /41: (/NULL - ])]
+      │    │    │         │    │    │    │    │    │         └── pg_inherits.inhparent = pg_class.oid [type=bool, outer=(39,41), constraints=(/39: (/NULL - ]; /41: (/NULL - ])]
+      │    │    │         │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index
+      │    │    │         │    │    │    │    │    │    ├── columns: pg_namespace.oid:68(oid!null) pg_namespace.nspname:69(string!null)
+      │    │    │         │    │    │    │    │    │    ├── key: (68)
+      │    │    │         │    │    │    │    │    │    └── fd: (68)-->(69), (69)-->(68)
+      │    │    │         │    │    │    │    │    └── filters [type=bool, outer=(43,68), constraints=(/43: (/NULL - ]; /68: (/NULL - ])]
+      │    │    │         │    │    │    │    │         └── pg_namespace.oid = pg_class.relnamespace [type=bool, outer=(43,68), constraints=(/43: (/NULL - ]; /68: (/NULL - ])]
+      │    │    │         │    │    │    │    └── filters [type=bool, outer=(1,38), constraints=(/1: (/NULL - ]; /38: (/NULL - ])]
+      │    │    │         │    │    │    │         └── pg_inherits.inhrelid = pg_class.oid [type=bool, outer=(1,38), constraints=(/1: (/NULL - ]; /38: (/NULL - ])]
+      │    │    │         │    │    │    ├── select
+      │    │    │         │    │    │    │    ├── columns: indexrelid:72(oid!null) indrelid:73(oid!null) indisclustered:79(bool!null)
+      │    │    │         │    │    │    │    ├── key: (72)
+      │    │    │         │    │    │    │    ├── fd: (72)-->(73,79)
+      │    │    │         │    │    │    │    ├── scan pg_index
+      │    │    │         │    │    │    │    │    ├── columns: indexrelid:72(oid!null) indrelid:73(oid!null) indisclustered:79(bool!null)
+      │    │    │         │    │    │    │    │    ├── key: (72)
+      │    │    │         │    │    │    │    │    └── fd: (72)-->(73,79)
+      │    │    │         │    │    │    │    └── filters [type=bool, outer=(79), constraints=(/79: [/true - /true]; tight)]
+      │    │    │         │    │    │    │         └── pg_index.indisclustered = true [type=bool, outer=(79), constraints=(/79: [/true - /true]; tight)]
+      │    │    │         │    │    │    └── filters [type=bool, outer=(1,73), constraints=(/1: (/NULL - ]; /73: (/NULL - ])]
+      │    │    │         │    │    │         └── pg_index.indrelid = pg_class.oid [type=bool, outer=(1,73), constraints=(/1: (/NULL - ]; /73: (/NULL - ])]
+      │    │    │         │    │    ├── scan pg_class@pg_class_relname_nsp_index
+      │    │    │         │    │    │    ├── columns: pg_class.oid:91(oid!null) pg_class.relname:92(string!null)
+      │    │    │         │    │    │    ├── key: (91)
+      │    │    │         │    │    │    └── fd: (91)-->(92,93), (92,93)-->(91) [removed: (93)]
+      │    │    │         │    │    └── filters [type=bool, outer=(72,91), constraints=(/72: (/NULL - ]; /91: (/NULL - ])]
+      │    │    │         │    │         └── pg_class.oid = pg_index.indexrelid [type=bool, outer=(72,91), constraints=(/72: (/NULL - ]; /91: (/NULL - ])]
+      │    │    │         │    ├── scan pg_foreign_table
+      │    │    │         │    │    ├── columns: ftrelid:118(oid!null) ftserver:119(oid!null) ftoptions:120(string[])
+      │    │    │         │    │    ├── key: (118)
+      │    │    │         │    │    └── fd: (118)-->(119,120)
+      │    │    │         │    └── filters [type=bool, outer=(1,118), constraints=(/1: (/NULL - ]; /118: (/NULL - ])]
+      │    │    │         │         └── pg_foreign_table.ftrelid = pg_class.oid [type=bool, outer=(1,118), constraints=(/1: (/NULL - ]; /118: (/NULL - ])]
+      │    │    │         ├── scan pg_foreign_server@pg_foreign_server_name_index
+      │    │    │         │    ├── columns: pg_foreign_server.oid:121(oid!null) srvname:122(string!null)
+      │    │    │         │    ├── key: (121)
+      │    │    │         │    └── fd: (121)-->(122), (122)-->(121)
+      │    │    │         └── filters [type=bool, outer=(119,121), constraints=(/119: (/NULL - ]; /121: (/NULL - ])]
+      │    │    │              └── pg_foreign_table.ftserver = pg_foreign_server.oid [type=bool, outer=(119,121), constraints=(/119: (/NULL - ]; /121: (/NULL - ])]
+      │    │    ├── scan pg_inherits
+      │    │    │    └── columns: pg_inherits.inhparent:132(oid!null)
+      │    │    └── filters [type=bool, outer=(1,132), constraints=(/1: (/NULL - ]; /132: (/NULL - ])]
+      │    │         └── pg_inherits.inhparent = pg_class.oid [type=bool, outer=(1,132), constraints=(/1: (/NULL - ]; /132: (/NULL - ])]
+      │    └── aggregations [outer=(1,2,5,10,13,15,17,20,22,23,26,27,29,33,42,69,92,120,122,132)]
+      │         ├── count [type=int, outer=(132)]
+      │         │    └── variable: pg_inherits.inhparent [type=oid, outer=(132)]
+      │         ├── any-not-null [type=oid, outer=(1)]
+      │         │    └── variable: pg_class.oid [type=oid, outer=(1)]
+      │         ├── any-not-null [type=string, outer=(2)]
+      │         │    └── variable: pg_class.relname [type=string, outer=(2)]
+      │         ├── any-not-null [type=oid, outer=(5)]
+      │         │    └── variable: pg_class.relowner [type=oid, outer=(5)]
+      │         ├── any-not-null [type=float, outer=(10)]
+      │         │    └── variable: pg_class.reltuples [type=float, outer=(10)]
+      │         ├── any-not-null [type=bool, outer=(13)]
+      │         │    └── variable: pg_class.relhasindex [type=bool, outer=(13)]
+      │         ├── any-not-null [type=string, outer=(15)]
+      │         │    └── variable: pg_class.relpersistence [type=string, outer=(15)]
+      │         ├── any-not-null [type=string, outer=(17)]
+      │         │    └── variable: pg_class.relkind [type=string, outer=(17)]
+      │         ├── any-not-null [type=bool, outer=(20)]
+      │         │    └── variable: pg_class.relhasoids [type=bool, outer=(20)]
+      │         ├── any-not-null [type=bool, outer=(22)]
+      │         │    └── variable: pg_class.relhasrules [type=bool, outer=(22)]
+      │         ├── any-not-null [type=bool, outer=(23)]
+      │         │    └── variable: pg_class.relhastriggers [type=bool, outer=(23)]
+      │         ├── any-not-null [type=string[], outer=(26)]
+      │         │    └── variable: pg_class.relacl [type=string[], outer=(26)]
+      │         ├── any-not-null [type=string[], outer=(27)]
+      │         │    └── variable: pg_class.reloptions [type=string[], outer=(27)]
+      │         ├── any-not-null [type=string, outer=(29)]
+      │         │    └── variable: pg_namespace.nspname [type=string, outer=(29)]
+      │         ├── any-not-null [type=string, outer=(33)]
+      │         │    └── variable: pg_tablespace.spcname [type=string, outer=(33)]
+      │         ├── any-not-null [type=string, outer=(42)]
+      │         │    └── variable: pg_class.relname [type=string, outer=(42)]
+      │         ├── any-not-null [type=string, outer=(69)]
+      │         │    └── variable: pg_namespace.nspname [type=string, outer=(69)]
+      │         ├── any-not-null [type=string, outer=(92)]
+      │         │    └── variable: pg_class.relname [type=string, outer=(92)]
+      │         ├── any-not-null [type=string[], outer=(120)]
+      │         │    └── variable: pg_foreign_table.ftoptions [type=string[], outer=(120)]
+      │         └── any-not-null [type=string, outer=(122)]
+      │              └── variable: pg_foreign_server.srvname [type=string, outer=(122)]
+      └── projections [outer=(1,2,5,10,13,15,17,20,22,23,26,27,29,33,42,69,92,120,122,134)]
+           ├── pg_get_userbyid(pg_class.relowner) [type=string, outer=(5)]
+           ├── obj_description(pg_class.oid) [type=string, outer=(1)]
+           └── count > 0 [type=bool, outer=(134)]

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -639,7 +639,7 @@ ORDER BY c_first ASC
 sort
  ├── columns: c_id:1(int!null)
  ├── stats: [rows=6.80272109e-07]
- ├── cost: 0.0100007483
+ ├── cost: 7.55102041e-07
  ├── ordering: +4
  ├── prune: (1,4)
  └── project
@@ -695,7 +695,7 @@ ORDER BY c_first ASC
 sort
  ├── columns: c_id:1(int!null) c_balance:17(decimal) c_first:4(string) c_middle:5(string)
  ├── stats: [rows=6.80272109e-07]
- ├── cost: 0.0100036327
+ ├── cost: 3.63945578e-06
  ├── ordering: +4
  ├── prune: (1,4,5,17)
  └── project
@@ -733,7 +733,7 @@ project
  ├── columns: o_id:1(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=6.80272109e-07]
- ├── cost: 0.0100035306
+ ├── cost: 3.53741497e-06
  ├── key: ()
  ├── fd: ()-->(1,5,6)
  ├── ordering: -1
@@ -743,7 +743,7 @@ project
       ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_c_id:4(int!null) "order".o_entry_d:5(timestamp) "order".o_carrier_id:6(int)
       ├── cardinality: [0 - 1]
       ├── stats: [rows=6.80272109e-07]
-      ├── cost: 0.0100035306
+      ├── cost: 3.53741497e-06
       ├── key: ()
       ├── fd: ()-->(1-6)
       ├── ordering: -1
@@ -752,7 +752,7 @@ project
       ├── sort
       │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_c_id:4(int!null) "order".o_entry_d:5(timestamp) "order".o_carrier_id:6(int)
       │    ├── stats: [rows=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07, distinct(4)=6.80272109e-07]
-      │    ├── cost: 0.0100035306
+      │    ├── cost: 3.53741497e-06
       │    ├── key: (1-3)
       │    ├── fd: (1-3)-->(4-6)
       │    ├── ordering: -1
@@ -822,7 +822,7 @@ project
  ├── columns: no_o_id:1(int!null)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=0.142857143]
- ├── cost: 0.161428571
+ ├── cost: 0.152857143
  ├── key: ()
  ├── fd: ()-->(1)
  ├── ordering: +1
@@ -832,7 +832,7 @@ project
       ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
       ├── cardinality: [0 - 1]
       ├── stats: [rows=0.142857143]
-      ├── cost: 0.161428571
+      ├── cost: 0.152857143
       ├── key: ()
       ├── fd: ()-->(1-3)
       ├── ordering: +1
@@ -840,7 +840,7 @@ project
       ├── sort
       │    ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
       │    ├── stats: [rows=0.142857143, distinct(2)=0.142857143, distinct(3)=0.142857143]
-      │    ├── cost: 0.161428571
+      │    ├── cost: 0.152857143
       │    ├── key: (1-3)
       │    ├── ordering: +1
       │    ├── prune: (1)


### PR DESCRIPTION
#### opt: improve the ratchetCost epsilon test

The epsilon tolerance in ratchetCost doesn't work well when the values
are very small (and we see very small costs when we have constraints
on many columns). The error needs to be relative to the magnitude of
the numbers.

This change improves this by using the bit representation of the
floats to constrain how many "units of least precision" there can be
between the two values.

This issue doesn't currently affect many existing tests; but it is
more problematic with some upcoming changes in costing.

Release note: None

#### opt: improve costing for sort

The current costing for sort imposes a fixed minimum cost on a sort.
There are cases where our row counts and costs are very small (e.g.
multi-column constraints) and this fixed cost is very large in
relation to other costs.

This change removes this fixed minimum cost, and instead always adds a
cost proportional to the number of rows.

