### PR TITLE
sql: Separate addCheck/checkAll and runCheck calls

### DIFF
--- a/pkg/sql/sqlbase/fk.go
+++ b/pkg/sql/sqlbase/fk.go
@@ -425,7 +425,7 @@ func makeFKInsertHelper(
 	return h, nil
 }
 
-func (h fkInsertHelper) checkAll(ctx context.Context, row tree.Datums) error {
+func (h fkInsertHelper) addAllIdxChecks(ctx context.Context, row tree.Datums) error {
 	if len(h.fks) == 0 {
 		return nil
 	}
@@ -434,7 +434,7 @@ func (h fkInsertHelper) checkAll(ctx context.Context, row tree.Datums) error {
 			return err
 		}
 	}
-	return h.checker.runCheck(ctx, nil, row)
+	return nil
 }
 
 // CollectSpans implements the FkSpanCollector interface.
@@ -521,7 +521,7 @@ func makeFKDeleteHelper(
 	return h, nil
 }
 
-func (h fkDeleteHelper) checkAll(ctx context.Context, row tree.Datums) error {
+func (h fkDeleteHelper) addAllIdxChecks(ctx context.Context, row tree.Datums) error {
 	if len(h.fks) == 0 {
 		return nil
 	}
@@ -530,7 +530,7 @@ func (h fkDeleteHelper) checkAll(ctx context.Context, row tree.Datums) error {
 			return err
 		}
 	}
-	return h.checker.runCheck(ctx, row, nil /* newRow */)
+	return nil
 }
 
 // CollectSpans implements the FkSpanCollector interface.
@@ -578,7 +578,7 @@ func (fks fkUpdateHelper) addCheckForIndex(indexID IndexID, descriptorType Index
 	}
 }
 
-func (fks fkUpdateHelper) runIndexChecks(
+func (fks fkUpdateHelper) addIndexChecks(
 	ctx context.Context, oldValues, newValues tree.Datums,
 ) error {
 	for indexID := range fks.indexIDsToCheck {
@@ -589,10 +589,11 @@ func (fks fkUpdateHelper) runIndexChecks(
 			return err
 		}
 	}
-	if len(fks.inbound.fks) == 0 && len(fks.outbound.fks) == 0 {
-		return nil
-	}
-	return fks.checker.runCheck(ctx, oldValues, newValues)
+	return nil
+}
+
+func (fks fkUpdateHelper) hasFKs() bool {
+	return len(fks.inbound.fks) > 0 || len(fks.outbound.fks) > 0
 }
 
 // CollectSpans implements the FkSpanCollector interface.

--- a/pkg/sql/sqlbase/rowwriter.go
+++ b/pkg/sql/sqlbase/rowwriter.go
@@ -159,6 +159,7 @@ type RowInserter struct {
 	Helper                rowHelper
 	InsertCols            []ColumnDescriptor
 	InsertColIDtoRowIndex map[ColumnID]int
+	CheckFKs              checkFKConstraints
 	Fks                   fkInsertHelper
 
 	// For allocation avoidance.
@@ -195,6 +196,7 @@ func MakeRowInserter(
 		InsertCols:            insertCols,
 		InsertColIDtoRowIndex: ColIDtoRowIndexFromCols(insertCols),
 		marshaled:             make([]roachpb.Value, len(insertCols)),
+		CheckFKs:              checkFKs,
 	}
 
 	for i, col := range tableDesc.PrimaryIndex.ColumnIDs {
@@ -291,8 +293,11 @@ func (ri *RowInserter) InsertRow(
 		}
 	}
 
-	if checkFKs == CheckFKs {
-		if err := ri.Fks.checkAll(ctx, values); err != nil {
+	if ri.CheckFKs == CheckFKs && checkFKs == CheckFKs {
+		if err := ri.Fks.addAllIdxChecks(ctx, values); err != nil {
+			return err
+		}
+		if err := ri.Fks.checker.runCheck(ctx, nil, values); err != nil {
 			return err
 		}
 	}
@@ -815,7 +820,13 @@ func (ru *RowUpdater) UpdateRow(
 		}
 
 		if checkFKs == CheckFKs {
-			if err := ru.Fks.runIndexChecks(ctx, oldValues, ru.newValues); err != nil {
+			if err := ru.Fks.addIndexChecks(ctx, oldValues, ru.newValues); err != nil {
+				return nil, err
+			}
+			if !ru.Fks.hasFKs() {
+				return ru.newValues, nil
+			}
+			if err := ru.Fks.checker.runCheck(ctx, oldValues, ru.newValues); err != nil {
 				return nil, err
 			}
 		}
@@ -912,7 +923,13 @@ func (ru *RowUpdater) UpdateRow(
 	}
 
 	if checkFKs == CheckFKs {
-		if err := ru.Fks.runIndexChecks(ctx, oldValues, ru.newValues); err != nil {
+		if err := ru.Fks.addIndexChecks(ctx, oldValues, ru.newValues); err != nil {
+			return nil, err
+		}
+		if !ru.Fks.hasFKs() {
+			return ru.newValues, nil
+		}
+		if err := ru.Fks.checker.runCheck(ctx, oldValues, ru.newValues); err != nil {
 			return nil, err
 		}
 	}
@@ -938,6 +955,7 @@ type RowDeleter struct {
 	FetchCols            []ColumnDescriptor
 	FetchColIDtoRowIndex map[ColumnID]int
 	Fks                  fkDeleteHelper
+	CheckFKs             checkFKConstraints
 	cascader             *cascader
 	// For allocation avoidance.
 	key roachpb.Key
@@ -1027,6 +1045,7 @@ func makeRowDeleterWithoutCascader(
 		Helper:               newRowHelper(tableDesc, indexes),
 		FetchCols:            fetchCols,
 		FetchColIDtoRowIndex: fetchColIDtoRowIndex,
+		CheckFKs:             checkFKs,
 	}
 	if checkFKs == CheckFKs {
 		var err error
@@ -1091,8 +1110,11 @@ func (rd *RowDeleter) DeleteRow(
 			return err
 		}
 	}
-	if checkFKs == CheckFKs {
-		return rd.Fks.checkAll(ctx, values)
+	if rd.CheckFKs == CheckFKs && checkFKs == CheckFKs {
+		if err := rd.Fks.addAllIdxChecks(ctx, values); err != nil {
+			return err
+		}
+		return rd.Fks.checker.runCheck(ctx, values, nil)
 	}
 	return nil
 }
@@ -1102,8 +1124,13 @@ func (rd *RowDeleter) DeleteRow(
 func (rd *RowDeleter) DeleteIndexRow(
 	ctx context.Context, b *client.Batch, idx *IndexDescriptor, values []tree.Datum, traceKV bool,
 ) error {
-	if err := rd.Fks.checkAll(ctx, values); err != nil {
-		return err
+	if rd.CheckFKs == CheckFKs {
+		if err := rd.Fks.addAllIdxChecks(ctx, values); err != nil {
+			return err
+		}
+		if err := rd.Fks.checker.runCheck(ctx, values, nil); err != nil {
+			return err
+		}
 	}
 	secondaryIndexEntry, err := EncodeSecondaryIndex(
 		rd.Helper.TableDesc, idx, rd.FetchColIDtoRowIndex, values)


### PR DESCRIPTION
Before, when fk{Insert,Update,Delete}Helper would add the foreign key
checks necessary for a single row, it would run them right after.

This change separates the two functionalities so that eventually the
checks could be run at a different place from where they are
accumulated, e.g. at the end of a mutation batch.

Release note: None