### PR TITLE
kv/storage: expose metrics on asynchronous concurrency limits

### DIFF
--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -1048,7 +1048,10 @@ func TestParallelSender(t *testing.T) {
 		}
 	}
 
-	psCount := s.DistSender().GetParallelSendCount()
+	getPSCount := func() int64 {
+		return s.DistSender().Metrics().AsyncSentCount.Count()
+	}
+	psCount := getPSCount()
 
 	// Batch writes to each range.
 	if err := db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
@@ -1060,7 +1063,7 @@ func TestParallelSender(t *testing.T) {
 	}); err != nil {
 		t.Errorf("unexpected error on batch put: %s", err)
 	}
-	newPSCount := s.DistSender().GetParallelSendCount()
+	newPSCount := getPSCount()
 	if c := newPSCount - psCount; c < 9 {
 		t.Errorf("expected at least 9 parallel sends; got %d", c)
 	}
@@ -1072,7 +1075,7 @@ func TestParallelSender(t *testing.T) {
 	} else if l := len(rows); l != len(splitKeys) {
 		t.Fatalf("expected %d rows; got %d", len(splitKeys), l)
 	}
-	newPSCount = s.DistSender().GetParallelSendCount()
+	newPSCount = getPSCount()
 	if c := newPSCount - psCount; c < 9 {
 		t.Errorf("expected at least 9 parallel sends; got %d", c)
 	}

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -457,6 +457,11 @@ var (
 		Name: "queue.gc.info.resolvesuccess",
 		Help: "Number of successful intent resolutions"}
 
+	// Intent resolver metrics.
+	metaIntentResolverAsyncThrottled = metric.Metadata{
+		Name: "intentresolver.async.throttled",
+		Help: "Number of intent resolution attempts not run asynchronously due to throttling"}
+
 	// Slow request metrics.
 	metaSlowCommandQueueRequests = metric.Metadata{
 		Name: "requests.slow.commandqueue",
@@ -661,6 +666,9 @@ type StoreMetrics struct {
 	GCResolveTotal               *metric.Counter
 	GCResolveSuccess             *metric.Counter
 
+	// Intent resolver metrics.
+	IntentResolverAsyncThrottled *metric.Counter
+
 	// Slow request counts.
 	SlowCommandQueueRequests *metric.Gauge
 	SlowLeaseRequests        *metric.Gauge
@@ -848,6 +856,9 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		GCPushTxn:                    metric.NewCounter(metaGCPushTxn),
 		GCResolveTotal:               metric.NewCounter(metaGCResolveTotal),
 		GCResolveSuccess:             metric.NewCounter(metaGCResolveSuccess),
+
+		// Intent resolver metrics.
+		IntentResolverAsyncThrottled: metric.NewCounter(metaIntentResolverAsyncThrottled),
 
 		// Wedge request counters.
 		SlowCommandQueueRequests: metric.NewGauge(metaSlowCommandQueueRequests),


### PR DESCRIPTION
Fixes #26841.

This change creates three new metrics:
- `distsender.batches.async.sent`
- `distsender.batches.async.throttled`
- `intentresolver.async.throttled`

The first two will allow us to track the number of batches sent asynchronously
through DistSender, along with the number of failed attempts to send
a batch asynchronously due to throttling.

The last will allow us to track the number of intent resolution attempts
that fell back to performing resolution synchronously due to throttling.