### PR TITLE
storage: avoid expensive recomputation of store metrics during rebalancing

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -544,7 +544,7 @@ func (n *Node) startStores(
 		if s.Ident.ClusterID == (uuid.UUID{}) || s.Ident.NodeID == 0 {
 			return errors.Errorf("unidentified store: %s", s)
 		}
-		capacity, err := s.Capacity()
+		capacity, err := s.Capacity(false /* useCached */)
 		if err != nil {
 			return errors.Errorf("could not query store capacity: %s", err)
 		}
@@ -673,7 +673,7 @@ func (n *Node) bootstrapStores(
 		log.Infof(ctx, "bootstrapped store %s", s)
 		// Done regularly in Node.startGossip, but this cuts down the time
 		// until this store is used for range allocations.
-		if err := s.GossipStore(ctx); err != nil {
+		if err := s.GossipStore(ctx, false /* useCached */); err != nil {
 			log.Warningf(ctx, "error doing initial gossiping: %s", err)
 		}
 	}
@@ -761,7 +761,7 @@ func (n *Node) startGossip(ctx context.Context, stopper *stop.Stopper) {
 // gossipStores broadcasts each store and dead replica to the gossip network.
 func (n *Node) gossipStores(ctx context.Context) {
 	if err := n.stores.VisitStores(func(s *storage.Store) error {
-		if err := s.GossipStore(ctx); err != nil {
+		if err := s.GossipStore(ctx, false /* useCached */); err != nil {
 			return err
 		}
 		return s.GossipDeadReplicas(ctx)

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -587,7 +587,7 @@ func TestNodeStatusWritten(t *testing.T) {
 
 	expectedStoreStatuses := make(map[roachpb.StoreID]status.StoreStatus)
 	if err := ts.node.stores.VisitStores(func(s *storage.Store) error {
-		desc, err := s.Descriptor()
+		desc, err := s.Descriptor(false /* useCached */)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -737,7 +737,7 @@ func TestStartNodeWithLocality(t *testing.T) {
 		// Check the store to make sure the locality was propagated to its
 		// nodeDescriptor.
 		if err := node.stores.VisitStores(func(store *storage.Store) error {
-			desc, err := store.Descriptor()
+			desc, err := store.Descriptor(false /* useCached */)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -76,7 +76,7 @@ var recordHistogramQuantiles = []quantile{
 // directly in order to simplify testing.
 type storeMetrics interface {
 	StoreID() roachpb.StoreID
-	Descriptor() (*roachpb.StoreDescriptor, error)
+	Descriptor(bool) (*roachpb.StoreDescriptor, error)
 	MVCCStats() enginepb.MVCCStats
 	Registry() *metric.Registry
 }
@@ -456,7 +456,7 @@ func (mr *MetricsRecorder) GenerateNodeStatus(ctx context.Context) *NodeStatus {
 		})
 
 		// Gather descriptor from store.
-		descriptor, err := mr.mu.stores[storeID].Descriptor()
+		descriptor, err := mr.mu.stores[storeID].Descriptor(false /* useCached */)
 		if err != nil {
 			log.Errorf(context.TODO(), "Could not record status summaries: Store %d could not return descriptor, error: %s", storeID, err)
 			continue

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -93,7 +93,7 @@ func (fs fakeStore) StoreID() roachpb.StoreID {
 	return fs.storeID
 }
 
-func (fs fakeStore) Descriptor() (*roachpb.StoreDescriptor, error) {
+func (fs fakeStore) Descriptor(_ bool) (*roachpb.StoreDescriptor, error) {
 	return &fs.desc, nil
 }
 

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2693,7 +2693,7 @@ func TestStoreRangeRemoveDead(t *testing.T) {
 	origReplicas := getRangeMetadata(roachpb.RKeyMin, mtc, t).Replicas
 
 	for _, s := range mtc.stores {
-		if err := s.GossipStore(context.Background()); err != nil {
+		if err := s.GossipStore(context.Background(), false /* useCached */); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -2729,7 +2729,7 @@ func TestStoreRangeRemoveDead(t *testing.T) {
 
 			// Keep gossiping the alive stores.
 			for _, s := range mtc.stores[:3] {
-				if err := s.GossipStore(context.Background()); err != nil {
+				if err := s.GossipStore(context.Background(), false /* useCached */); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1609,7 +1609,7 @@ func TestCampaignOnLazyRaftGroupInitialization(t *testing.T) {
 			desc: "past idle replica campaign timeout",
 			prepFn: func(t *testing.T) {
 				for _, s := range mtc.stores {
-					if err := s.GossipStore(context.TODO()); err != nil {
+					if err := s.GossipStore(context.TODO(), false /* useCached */); err != nil {
 						t.Fatal(err)
 					}
 				}
@@ -1623,7 +1623,7 @@ func TestCampaignOnLazyRaftGroupInitialization(t *testing.T) {
 			desc: "lease expired all replicas should campaign",
 			prepFn: func(t *testing.T) {
 				for _, s := range mtc.stores {
-					if err := s.GossipStore(context.TODO()); err != nil {
+					if err := s.GossipStore(context.TODO(), false /* useCached */); err != nil {
 						t.Fatal(err)
 					}
 				}

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -2719,7 +2719,7 @@ func TestStoreCapacityAfterSplit(t *testing.T) {
 	cfg.TestingKnobs.DisableSplitQueue = true
 	s := createTestStoreWithConfig(t, stopper, cfg)
 
-	cap, err := s.Capacity()
+	cap, err := s.Capacity(false /* useCached */)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2746,7 +2746,7 @@ func TestStoreCapacityAfterSplit(t *testing.T) {
 		t.Fatal(pErr)
 	}
 
-	cap, err = s.Capacity()
+	cap, err = s.Capacity(false /* useCached */)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2784,7 +2784,7 @@ func TestStoreCapacityAfterSplit(t *testing.T) {
 		t.Fatal(pErr)
 	}
 
-	cap, err = s.Capacity()
+	cap, err = s.Capacity(false /* useCached */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -163,7 +163,7 @@ func createTestStoreWithEngine(
 
 	// Connect to gossip and gossip the store's capacity.
 	<-store.Gossip().Connected
-	if err := store.GossipStore(ctx); err != nil {
+	if err := store.GossipStore(ctx, false /* useCached */); err != nil {
 		t.Fatal(err)
 	}
 	// Wait for the store's single range to have quorum before proceeding.
@@ -371,7 +371,7 @@ func (m *multiTestContext) gossipStores() {
 	timestamps := make(map[string]int64)
 	for i := 0; i < len(m.stores); i++ {
 		<-m.gossips[i].Connected
-		if err := m.stores[i].GossipStore(context.Background()); err != nil {
+		if err := m.stores[i].GossipStore(context.Background(), false /* useCached */); err != nil {
 			m.t.Fatal(err)
 		}
 		infoStatus := m.gossips[i].GetInfoStatus()

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -529,6 +529,14 @@ type Store struct {
 
 	scheduler *raftScheduler
 
+	// cachedCapacity caches information on store capacity to prevent
+	// expensive recomputations in case leases or replicas are rapidly
+	// rebalancing.
+	cachedCapacity struct {
+		syncutil.Mutex
+		roachpb.StoreCapacity
+	}
+
 	counts struct {
 		// Number of placeholders removed due to error.
 		removedPlaceholders int32
@@ -892,8 +900,12 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 	s.compactor = compactor.NewCompactor(
 		s.cfg.Settings,
 		s.engine.(engine.WithSSTables),
-		s.Capacity,
-		func(ctx context.Context) { s.asyncGossipStore(ctx, "compactor-initiated rocksdb compaction") },
+		func() (roachpb.StoreCapacity, error) {
+			return s.Capacity(false /* useCached */)
+		},
+		func(ctx context.Context) {
+			s.asyncGossipStore(ctx, "compactor-initiated rocksdb compaction", false /* useCached */)
+		},
 	)
 	s.metrics.registry.AddMetricStruct(s.compactor.Metrics)
 
@@ -1644,11 +1656,11 @@ func (s *Store) systemGossipUpdate(cfg config.SystemConfig) {
 	})
 }
 
-func (s *Store) asyncGossipStore(ctx context.Context, reason string) {
+func (s *Store) asyncGossipStore(ctx context.Context, reason string, useCached bool) {
 	if err := s.stopper.RunAsyncTask(
 		ctx, fmt.Sprintf("storage.Store: gossip on %s", reason),
 		func(ctx context.Context) {
-			if err := s.GossipStore(ctx); err != nil {
+			if err := s.GossipStore(ctx, useCached); err != nil {
 				log.Warningf(ctx, "error gossiping on %s: %s", reason, err)
 			}
 		}); err != nil {
@@ -1657,7 +1669,7 @@ func (s *Store) asyncGossipStore(ctx context.Context, reason string) {
 }
 
 // GossipStore broadcasts the store on the gossip network.
-func (s *Store) GossipStore(ctx context.Context) error {
+func (s *Store) GossipStore(ctx context.Context, useCached bool) error {
 	// This should always return immediately and acts as a sanity check that we
 	// don't try to gossip before we're connected.
 	select {
@@ -1670,7 +1682,7 @@ func (s *Store) GossipStore(ctx context.Context) error {
 	// recursively triggering a gossip of the store capacity.
 	syncutil.StoreFloat64(&s.gossipWritesPerSecondVal, -1)
 
-	storeDesc, err := s.Descriptor()
+	storeDesc, err := s.Descriptor(useCached)
 	if err != nil {
 		return errors.Wrapf(err, "problem getting store descriptor for store %+v", s.Ident)
 	}
@@ -1694,8 +1706,10 @@ func (s *Store) GossipStore(ctx context.Context) error {
 type capacityChangeEvent int
 
 const (
-	rangeChangeEvent capacityChangeEvent = iota
-	leaseChangeEvent
+	rangeAddEvent capacityChangeEvent = iota
+	rangeRemoveEvent
+	leaseAddEvent
+	leaseRemoveEvent
 )
 
 // maybeGossipOnCapacityChange decrements the countdown on range
@@ -1703,15 +1717,31 @@ const (
 // immediate gossip of this store's descriptor, to include updated
 // capacity information.
 func (s *Store) maybeGossipOnCapacityChange(ctx context.Context, cce capacityChangeEvent) {
-	if s.cfg.TestingKnobs.DisableLeaseCapacityGossip && cce == leaseChangeEvent {
+	if s.cfg.TestingKnobs.DisableLeaseCapacityGossip && (cce == leaseAddEvent || cce == leaseRemoveEvent) {
 		return
 	}
-	if (cce == rangeChangeEvent && atomic.AddInt32(&s.gossipRangeCountdown, -1) == 0) ||
-		(cce == leaseChangeEvent && atomic.AddInt32(&s.gossipLeaseCountdown, -1) == 0) {
+
+	// Incrementally adjust stats to keep them up to date even if the
+	// capacity is gossiped, but isn't due yet to be recomputed from scratch.
+	s.cachedCapacity.Lock()
+	switch cce {
+	case rangeAddEvent:
+		s.cachedCapacity.RangeCount++
+	case rangeRemoveEvent:
+		s.cachedCapacity.RangeCount--
+	case leaseAddEvent:
+		s.cachedCapacity.LeaseCount++
+	case leaseRemoveEvent:
+		s.cachedCapacity.LeaseCount--
+	}
+	s.cachedCapacity.Unlock()
+
+	if ((cce == rangeAddEvent || cce == rangeRemoveEvent) && atomic.AddInt32(&s.gossipRangeCountdown, -1) == 0) ||
+		((cce == leaseAddEvent || cce == leaseRemoveEvent) && atomic.AddInt32(&s.gossipLeaseCountdown, -1) == 0) {
 		// Reset countdowns to avoid unnecessary gossiping.
 		atomic.StoreInt32(&s.gossipRangeCountdown, 0)
 		atomic.StoreInt32(&s.gossipLeaseCountdown, 0)
-		s.asyncGossipStore(ctx, "capacity change")
+		s.asyncGossipStore(ctx, "capacity change", true /* useCached */)
 	}
 }
 
@@ -1725,7 +1755,7 @@ func (s *Store) recordNewWritesPerSecond(newVal float64) {
 		return
 	}
 	if newVal < oldVal*.5 || newVal > oldVal*1.5 {
-		s.asyncGossipStore(context.TODO(), "writes-per-second change")
+		s.asyncGossipStore(context.TODO(), "writes-per-second change", false /* useCached */)
 	}
 }
 
@@ -2281,7 +2311,7 @@ func (s *Store) SplitRange(ctx context.Context, origRng, newRng *Replica) error 
 
 	// Add the range to metrics and maybe gossip on capacity change.
 	s.metrics.ReplicaCount.Inc(1)
-	s.maybeGossipOnCapacityChange(ctx, rangeChangeEvent)
+	s.maybeGossipOnCapacityChange(ctx, rangeAddEvent)
 
 	return s.processRangeDescriptorUpdateLocked(ctx, origRng)
 }
@@ -2530,7 +2560,7 @@ func (s *Store) removeReplicaImpl(
 	}
 	delete(s.mu.replicaPlaceholders, rep.RangeID)
 	// TODO(peter): Could release s.mu.Lock() here.
-	s.maybeGossipOnCapacityChange(ctx, rangeChangeEvent)
+	s.maybeGossipOnCapacityChange(ctx, rangeRemoveEvent)
 	s.scanner.RemoveReplica(rep)
 
 	return nil
@@ -2587,7 +2617,7 @@ func (s *Store) processRangeDescriptorUpdateLocked(ctx context.Context, repl *Re
 
 	// Add the range to metrics and maybe gossip on capacity change.
 	s.metrics.ReplicaCount.Inc(1)
-	s.maybeGossipOnCapacityChange(ctx, rangeChangeEvent)
+	s.maybeGossipOnCapacityChange(ctx, rangeAddEvent)
 
 	return nil
 }
@@ -2601,21 +2631,31 @@ func (s *Store) Attrs() roachpb.Attributes {
 // this does not include reservations.
 // Note that Capacity() has the side effect of updating some of the store's
 // internal statistics about its replicas.
-func (s *Store) Capacity() (roachpb.StoreCapacity, error) {
+func (s *Store) Capacity(useCached bool) (roachpb.StoreCapacity, error) {
+	if useCached {
+		s.cachedCapacity.Lock()
+		capacity := s.cachedCapacity.StoreCapacity
+		s.cachedCapacity.Unlock()
+		if capacity != (roachpb.StoreCapacity{}) {
+			return capacity, nil
+		}
+	}
+
 	capacity, err := s.engine.Capacity()
 	if err != nil {
 		return capacity, err
 	}
 
-	capacity.RangeCount = int32(s.ReplicaCount())
-
 	now := s.cfg.Clock.Now()
 	var leaseCount int32
+	var rangeCount int32
 	var logicalBytes int64
 	var totalWritesPerSecond float64
-	bytesPerReplica := make([]float64, 0, capacity.RangeCount)
-	writesPerReplica := make([]float64, 0, capacity.RangeCount)
+	replicaCount := s.metrics.ReplicaCount.Value()
+	bytesPerReplica := make([]float64, 0, replicaCount)
+	writesPerReplica := make([]float64, 0, replicaCount)
 	newStoreReplicaVisitor(s).Visit(func(r *Replica) bool {
+		rangeCount++
 		if r.OwnsValidLease(now) {
 			leaseCount++
 		}
@@ -2631,12 +2671,17 @@ func (s *Store) Capacity() (roachpb.StoreCapacity, error) {
 		}
 		return true
 	})
+	capacity.RangeCount = rangeCount
 	capacity.LeaseCount = leaseCount
 	capacity.LogicalBytes = logicalBytes
 	capacity.WritesPerSecond = totalWritesPerSecond
 	capacity.BytesPerReplica = roachpb.PercentilesFromData(bytesPerReplica)
 	capacity.WritesPerReplica = roachpb.PercentilesFromData(writesPerReplica)
 	s.recordNewWritesPerSecond(totalWritesPerSecond)
+
+	s.cachedCapacity.Lock()
+	s.cachedCapacity.StoreCapacity = capacity
+	s.cachedCapacity.Unlock()
 
 	return capacity, nil
 }
@@ -2674,8 +2719,8 @@ func (s *Store) MVCCStats() enginepb.MVCCStats {
 
 // Descriptor returns a StoreDescriptor including current store
 // capacity information.
-func (s *Store) Descriptor() (*roachpb.StoreDescriptor, error) {
-	capacity, err := s.Capacity()
+func (s *Store) Descriptor(useCached bool) (*roachpb.StoreDescriptor, error) {
+	capacity, err := s.Capacity(useCached)
 	if err != nil {
 		return nil, err
 	}
@@ -3943,7 +3988,7 @@ func (s *Store) tryGetOrCreateReplica(
 }
 
 func (s *Store) updateCapacityGauges() error {
-	desc, err := s.Descriptor()
+	desc, err := s.Descriptor(false /* useCached */)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -3107,7 +3107,7 @@ func TestReserveSnapshotFullnessLimit(t *testing.T) {
 
 	ctx := context.Background()
 
-	desc, err := s.Descriptor()
+	desc, err := s.Descriptor(false /* useCached */)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
If a node is down and the rejoins, any of its leases will be lost and a
period of rebalancing will begin where the number of leases being
rebalanced exceeds the 1% threshold of total replicas fairly often. With
10,000 nodes on my laptop, this was happening more than once a second.
It turns out that recomputing the avg QPS stats and checking for lease
ownership is pretty expensive when repeated every second across 10,000
ranges.

This change caches the store capacity stats in cases where changes to
the range or lease counts is the activity prompting the store to re-
gossip capacity to better cluster-wide rebalancing decisions.

Release note (performance improvement): in periods of lease rebalancing
on clusters with many ranges, this change reduces unnecessary CPU usage.