### PR TITLE
engine,storage: replace read-only batches with type safety

### DIFF
--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -29,7 +29,7 @@ import (
 )
 
 func init() {
-	batcheval.RegisterCommand(roachpb.Export, declareKeysExport, evalExport)
+	batcheval.RegisterReadOnlyCommand(roachpb.Export, declareKeysExport, evalExport)
 }
 
 func declareKeysExport(
@@ -42,7 +42,7 @@ func declareKeysExport(
 // evalExport dumps the requested keys into files of non-overlapping key ranges
 // in a format suitable for bulk ingest.
 func evalExport(
-	ctx context.Context, batch engine.ReadWriter, cArgs batcheval.CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs batcheval.CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.ExportRequest)
 	h := cArgs.Header

--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	batcheval.RegisterCommand(roachpb.WriteBatch, batcheval.DefaultDeclareKeys, evalWriteBatch)
+	batcheval.RegisterMutatingCommand(roachpb.WriteBatch, batcheval.DefaultDeclareKeys, evalWriteBatch)
 }
 
 // evalWriteBatch applies the operations encoded in a BatchRepr. Any existing

--- a/pkg/storage/batcheval/cmd_add_sstable.go
+++ b/pkg/storage/batcheval/cmd_add_sstable.go
@@ -29,11 +29,10 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.AddSSTable, DefaultDeclareKeys, EvalAddSSTable)
+	RegisterMutatingCommand(roachpb.AddSSTable, DefaultDeclareKeys, evalAddSSTable)
 }
 
-// EvalAddSSTable evaluates an AddSSTable command.
-func EvalAddSSTable(
+func evalAddSSTable(
 	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, _ roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.AddSSTableRequest)

--- a/pkg/storage/batcheval/cmd_begin_transaction.go
+++ b/pkg/storage/batcheval/cmd_begin_transaction.go
@@ -28,7 +28,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.BeginTransaction, declareKeysBeginTransaction, BeginTransaction)
+	RegisterMutatingCommand(roachpb.BeginTransaction, declareKeysBeginTransaction, BeginTransaction)
 }
 
 // declareKeysWriteTransaction is the shared portion of

--- a/pkg/storage/batcheval/cmd_clear_range.go
+++ b/pkg/storage/batcheval/cmd_clear_range.go
@@ -37,7 +37,7 @@ import (
 const ClearRangeBytesThreshold = 512 << 10 // 512KiB
 
 func init() {
-	RegisterCommand(roachpb.ClearRange, declareKeysClearRange, ClearRange)
+	RegisterMutatingCommand(roachpb.ClearRange, declareKeysClearRange, ClearRange)
 }
 
 func declareKeysClearRange(

--- a/pkg/storage/batcheval/cmd_compute_checksum.go
+++ b/pkg/storage/batcheval/cmd_compute_checksum.go
@@ -28,7 +28,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.ComputeChecksum, declareKeysComputeChecksum, ComputeChecksum)
+	RegisterReadOnlyCommand(roachpb.ComputeChecksum, declareKeysComputeChecksum, ComputeChecksum)
 }
 
 func declareKeysComputeChecksum(
@@ -50,7 +50,7 @@ const (
 // a particular snapshot. The checksum is later verified through a
 // CollectChecksumRequest.
 func ComputeChecksum(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.ComputeChecksumRequest)
 

--- a/pkg/storage/batcheval/cmd_conditional_put.go
+++ b/pkg/storage/batcheval/cmd_conditional_put.go
@@ -23,7 +23,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.ConditionalPut, DefaultDeclareKeys, ConditionalPut)
+	RegisterMutatingCommand(roachpb.ConditionalPut, DefaultDeclareKeys, ConditionalPut)
 }
 
 // ConditionalPut sets the value for a specified key only if

--- a/pkg/storage/batcheval/cmd_delete.go
+++ b/pkg/storage/batcheval/cmd_delete.go
@@ -23,7 +23,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.Delete, DefaultDeclareKeys, Delete)
+	RegisterMutatingCommand(roachpb.Delete, DefaultDeclareKeys, Delete)
 }
 
 // Delete deletes the key and value specified by key.

--- a/pkg/storage/batcheval/cmd_delete_range.go
+++ b/pkg/storage/batcheval/cmd_delete_range.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.DeleteRange, DefaultDeclareKeys, DeleteRange)
+	RegisterMutatingCommand(roachpb.DeleteRange, DefaultDeclareKeys, DeleteRange)
 }
 
 // DeleteRange deletes the range of key/value pairs specified by

--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -47,7 +47,7 @@ import (
 var TxnAutoGC = true
 
 func init() {
-	RegisterCommand(roachpb.EndTransaction, declareKeysEndTransaction, evalEndTransaction)
+	RegisterMutatingCommand(roachpb.EndTransaction, declareKeysEndTransaction, evalEndTransaction)
 }
 
 func declareKeysEndTransaction(

--- a/pkg/storage/batcheval/cmd_gc.go
+++ b/pkg/storage/batcheval/cmd_gc.go
@@ -27,7 +27,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.GC, declareKeysGC, GC)
+	RegisterMutatingCommand(roachpb.GC, declareKeysGC, GC)
 }
 
 func declareKeysGC(

--- a/pkg/storage/batcheval/cmd_get.go
+++ b/pkg/storage/batcheval/cmd_get.go
@@ -24,12 +24,12 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.Get, DefaultDeclareKeys, Get)
+	RegisterReadOnlyCommand(roachpb.Get, DefaultDeclareKeys, Get)
 }
 
 // Get returns the value for a specified key.
 func Get(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.GetRequest)
 	h := cArgs.Header

--- a/pkg/storage/batcheval/cmd_heartbeat_txn.go
+++ b/pkg/storage/batcheval/cmd_heartbeat_txn.go
@@ -27,7 +27,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.HeartbeatTxn, declareKeysHeartbeatTransaction, HeartbeatTxn)
+	RegisterMutatingCommand(roachpb.HeartbeatTxn, declareKeysHeartbeatTransaction, HeartbeatTxn)
 }
 
 func declareKeysHeartbeatTransaction(

--- a/pkg/storage/batcheval/cmd_increment.go
+++ b/pkg/storage/batcheval/cmd_increment.go
@@ -23,7 +23,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.Increment, DefaultDeclareKeys, Increment)
+	RegisterMutatingCommand(roachpb.Increment, DefaultDeclareKeys, Increment)
 }
 
 // Increment increments the value (interpreted as varint64 encoded) and

--- a/pkg/storage/batcheval/cmd_init_put.go
+++ b/pkg/storage/batcheval/cmd_init_put.go
@@ -23,7 +23,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.InitPut, DefaultDeclareKeys, InitPut)
+	RegisterMutatingCommand(roachpb.InitPut, DefaultDeclareKeys, InitPut)
 }
 
 // InitPut sets the value for a specified key only if it doesn't exist. It

--- a/pkg/storage/batcheval/cmd_lease_info.go
+++ b/pkg/storage/batcheval/cmd_lease_info.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.LeaseInfo, declareKeysLeaseInfo, LeaseInfo)
+	RegisterReadOnlyCommand(roachpb.LeaseInfo, declareKeysLeaseInfo, LeaseInfo)
 }
 
 func declareKeysLeaseInfo(
@@ -36,7 +36,7 @@ func declareKeysLeaseInfo(
 
 // LeaseInfo returns information about the lease holder for the range.
 func LeaseInfo(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	reply := resp.(*roachpb.LeaseInfoResponse)
 	lease, nextLease := cArgs.EvalCtx.GetLease()

--- a/pkg/storage/batcheval/cmd_lease_request.go
+++ b/pkg/storage/batcheval/cmd_lease_request.go
@@ -23,7 +23,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.RequestLease, declareKeysRequestLease, RequestLease)
+	RegisterMutatingCommand(roachpb.RequestLease, declareKeysRequestLease, RequestLease)
 }
 
 // RequestLease sets the range lease for this range. The command fails

--- a/pkg/storage/batcheval/cmd_lease_transfer.go
+++ b/pkg/storage/batcheval/cmd_lease_transfer.go
@@ -24,7 +24,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.TransferLease, declareKeysRequestLease, TransferLease)
+	RegisterMutatingCommand(roachpb.TransferLease, declareKeysRequestLease, TransferLease)
 }
 
 // TransferLease sets the lease holder for the range.

--- a/pkg/storage/batcheval/cmd_merge.go
+++ b/pkg/storage/batcheval/cmd_merge.go
@@ -23,7 +23,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.Merge, DefaultDeclareKeys, Merge)
+	RegisterMutatingCommand(roachpb.Merge, DefaultDeclareKeys, Merge)
 }
 
 // Merge is used to merge a value into an existing key. Merge is an

--- a/pkg/storage/batcheval/cmd_push_txn.go
+++ b/pkg/storage/batcheval/cmd_push_txn.go
@@ -31,7 +31,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.PushTxn, declareKeysPushTransaction, PushTxn)
+	RegisterMutatingCommand(roachpb.PushTxn, declareKeysPushTransaction, PushTxn)
 }
 
 func declareKeysPushTransaction(

--- a/pkg/storage/batcheval/cmd_put.go
+++ b/pkg/storage/batcheval/cmd_put.go
@@ -24,7 +24,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.Put, DefaultDeclareKeys, Put)
+	RegisterMutatingCommand(roachpb.Put, DefaultDeclareKeys, Put)
 }
 
 // Put sets the value for a specified key.

--- a/pkg/storage/batcheval/cmd_query_intent.go
+++ b/pkg/storage/batcheval/cmd_query_intent.go
@@ -27,14 +27,14 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.QueryIntent, DefaultDeclareKeys, QueryIntent)
+	RegisterReadOnlyCommand(roachpb.QueryIntent, DefaultDeclareKeys, QueryIntent)
 }
 
 // QueryIntent checks if an intent exists for the specified
 // transaction at the given key. If the intent is missing,
 // the request reacts according to its IfMissing field.
 func QueryIntent(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.QueryIntentRequest)
 	h := cArgs.Header

--- a/pkg/storage/batcheval/cmd_query_txn.go
+++ b/pkg/storage/batcheval/cmd_query_txn.go
@@ -28,7 +28,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.QueryTxn, declareKeysQueryTransaction, QueryTxn)
+	RegisterReadOnlyCommand(roachpb.QueryTxn, declareKeysQueryTransaction, QueryTxn)
 }
 
 func declareKeysQueryTransaction(
@@ -46,7 +46,7 @@ func declareKeysQueryTransaction(
 // other txns which are waiting on this transaction in order
 // to find dependency cycles.
 func QueryTxn(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.QueryTxnRequest)
 	reply := resp.(*roachpb.QueryTxnResponse)

--- a/pkg/storage/batcheval/cmd_range_stats.go
+++ b/pkg/storage/batcheval/cmd_range_stats.go
@@ -23,12 +23,12 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.RangeStats, DefaultDeclareKeys, RangeStats)
+	RegisterReadOnlyCommand(roachpb.RangeStats, DefaultDeclareKeys, RangeStats)
 }
 
 // RangeStats returns the MVCC statistics for a range.
 func RangeStats(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	reply := resp.(*roachpb.RangeStatsResponse)
 	reply.MVCCStats = cArgs.EvalCtx.GetMVCCStats()

--- a/pkg/storage/batcheval/cmd_recompute_stats.go
+++ b/pkg/storage/batcheval/cmd_recompute_stats.go
@@ -29,7 +29,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.RecomputeStats, declareKeysRecomputeStats, RecomputeStats)
+	RegisterReadOnlyCommand(roachpb.RecomputeStats, declareKeysRecomputeStats, RecomputeStats)
 }
 
 func declareKeysRecomputeStats(
@@ -57,7 +57,7 @@ func declareKeysRecomputeStats(
 // RecomputeStats recomputes the MVCCStats stored for this range and adjust them accordingly,
 // returning the MVCCStats delta obtained in the process.
 func RecomputeStats(
-	ctx context.Context, _ engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, _ engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	desc := cArgs.EvalCtx.Desc()
 	args := cArgs.Args.(*roachpb.RecomputeStatsRequest)

--- a/pkg/storage/batcheval/cmd_refresh.go
+++ b/pkg/storage/batcheval/cmd_refresh.go
@@ -25,14 +25,14 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.Refresh, DefaultDeclareKeys, Refresh)
+	RegisterReadOnlyCommand(roachpb.Refresh, DefaultDeclareKeys, Refresh)
 }
 
 // Refresh checks the key for more recently written values than the
 // txn's original timestamp and less recently than the txn's current
 // timestamp.
 func Refresh(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.RefreshRequest)
 	h := cArgs.Header

--- a/pkg/storage/batcheval/cmd_refresh_range.go
+++ b/pkg/storage/batcheval/cmd_refresh_range.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.RefreshRange, DefaultDeclareKeys, RefreshRange)
+	RegisterReadOnlyCommand(roachpb.RefreshRange, DefaultDeclareKeys, RefreshRange)
 }
 
 // RefreshRange scans the key range specified by start key through end
@@ -33,7 +33,7 @@ func init() {
 // the txn's original timestamp and less recently than the txn's
 // current timestamp.
 func RefreshRange(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.RefreshRangeRequest)
 	h := cArgs.Header

--- a/pkg/storage/batcheval/cmd_resolve_intent.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent.go
@@ -26,7 +26,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.ResolveIntent, declareKeysResolveIntent, ResolveIntent)
+	RegisterMutatingCommand(roachpb.ResolveIntent, declareKeysResolveIntent, ResolveIntent)
 }
 
 func declareKeysResolveIntentCombined(

--- a/pkg/storage/batcheval/cmd_resolve_intent_range.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_range.go
@@ -24,7 +24,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.ResolveIntentRange, declareKeysResolveIntentRange, ResolveIntentRange)
+	RegisterMutatingCommand(roachpb.ResolveIntentRange, declareKeysResolveIntentRange, ResolveIntentRange)
 }
 
 func declareKeysResolveIntentRange(

--- a/pkg/storage/batcheval/cmd_reverse_scan.go
+++ b/pkg/storage/batcheval/cmd_reverse_scan.go
@@ -24,7 +24,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.ReverseScan, DefaultDeclareKeys, ReverseScan)
+	RegisterReadOnlyCommand(roachpb.ReverseScan, DefaultDeclareKeys, ReverseScan)
 }
 
 // ReverseScan scans the key range specified by start key through
@@ -32,7 +32,7 @@ func init() {
 // maxKeys stores the number of scan results remaining for this batch
 // (MaxInt64 for no limit).
 func ReverseScan(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.ReverseScanRequest)
 	h := cArgs.Header

--- a/pkg/storage/batcheval/cmd_scan.go
+++ b/pkg/storage/batcheval/cmd_scan.go
@@ -24,7 +24,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.Scan, DefaultDeclareKeys, Scan)
+	RegisterReadOnlyCommand(roachpb.Scan, DefaultDeclareKeys, Scan)
 }
 
 // Scan scans the key range specified by start key through end key
@@ -32,7 +32,7 @@ func init() {
 // stores the number of scan results remaining for this batch
 // (MaxInt64 for no limit).
 func Scan(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.ScanRequest)
 	h := cArgs.Header

--- a/pkg/storage/batcheval/cmd_subsume.go
+++ b/pkg/storage/batcheval/cmd_subsume.go
@@ -29,7 +29,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.Subsume, declareKeysSubsume, Subsume)
+	RegisterMutatingCommand(roachpb.Subsume, declareKeysSubsume, Subsume)
 }
 
 func declareKeysSubsume(

--- a/pkg/storage/batcheval/cmd_truncate_log.go
+++ b/pkg/storage/batcheval/cmd_truncate_log.go
@@ -32,7 +32,7 @@ import (
 )
 
 func init() {
-	RegisterCommand(roachpb.TruncateLog, declareKeysTruncateLog, TruncateLog)
+	RegisterMutatingCommand(roachpb.TruncateLog, declareKeysTruncateLog, TruncateLog)
 }
 
 func declareKeysTruncateLog(

--- a/pkg/storage/batcheval/intent.go
+++ b/pkg/storage/batcheval/intent.go
@@ -29,7 +29,7 @@ import (
 // RangeLookups and since this is how they currently collect intent values, this
 // is ok for now.
 func CollectIntentRows(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, intents []roachpb.Intent,
+	ctx context.Context, batch engine.Reader, cArgs CommandArgs, intents []roachpb.Intent,
 ) ([]roachpb.KeyValue, error) {
 	if len(intents) == 0 {
 		return nil, nil

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -153,9 +153,8 @@ func shouldNotPanic(t *testing.T, f func(), funcName string) {
 	f()
 }
 
-// TestReadOnlyBasics verifies that for a read-only ReadWriter (obtained via
-// engine.NewReadOnly()) all Reader methods work, and all Writer methods panic
-// as "not implemented". Also basic iterating functionality is verified.
+// TestIterCacherBasics verifies that an iterator cacher (obtained via
+// engine.NewIterCacher()) can read, write, and iterate successfully.
 func TestReadOnlyBasics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
@@ -163,15 +162,16 @@ func TestReadOnlyBasics(t *testing.T) {
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(e)
 
-	b := e.NewReadOnly()
+	b := e.NewIterCacher()
 	if b.Closed() {
-		t.Fatal("read-only is expectedly found to be closed")
+		t.Fatal("iter-cacher is expectedly found to be closed")
 	}
 	a := mvccKey("a")
 	getVal := &roachpb.Value{}
 	successTestCases := []func(){
 		func() { _, _ = b.Get(a) },
 		func() { _, _, _, _ = b.GetProto(a, getVal) },
+		func() { _ = b.Put(a, []byte("val")) },
 		func() { _ = b.Iterate(a, a, func(MVCCKeyValue) (bool, error) { return true, nil }) },
 		func() { b.NewIterator(IterOptions{UpperBound: roachpb.KeyMax}).Close() },
 		func() {
@@ -185,28 +185,16 @@ func TestReadOnlyBasics(t *testing.T) {
 	defer func() {
 		b.Close()
 		if !b.Closed() {
-			t.Fatal("even after calling Close, a read-only should not be closed")
+			t.Fatal("rocksDBIterCacher is not closed after calling Close")
 		}
-		shouldPanic(t, func() { b.Close() }, "Close", "closing an already-closed rocksDBReadOnly")
-		for i, f := range successTestCases {
-			shouldPanic(t, f, string(i), "using a closed rocksDBReadOnly")
-		}
+		shouldPanic(t, func() { b.Close() }, "Close", "closing an already-closed rocksDBIterCacher")
+		shouldPanic(t, func() {
+			b.NewIterator(IterOptions{}).Close()
+		}, "NewIterator", "using a closed rocksDBIterCacher")
 	}()
 
 	for i, f := range successTestCases {
 		shouldNotPanic(t, f, string(i))
-	}
-
-	// For a read-only ReadWriter, all Writer methods should panic.
-	failureTestCases := []func(){
-		func() { _ = b.ApplyBatchRepr(nil, false) },
-		func() { _ = b.Clear(a) },
-		func() { _ = b.ClearRange(a, a) },
-		func() { _ = b.Merge(a, nil) },
-		func() { _ = b.Put(a, nil) },
-	}
-	for i, f := range failureTestCases {
-		shouldPanic(t, f, string(i), "not implemented")
 	}
 
 	if err := e.Put(mvccKey("a"), []byte("value")); err != nil {

--- a/pkg/storage/engine/bench_rocksdb_test.go
+++ b/pkg/storage/engine/bench_rocksdb_test.go
@@ -124,22 +124,24 @@ func BenchmarkIterOnBatch_RocksDB(b *testing.B) {
 	}
 }
 
-// BenchmarkIterOnReadOnly_RocksDB is a microbenchmark that measures the performance of creating an iterator
-// and seeking to a key if a read-only ReadWriter that caches the RocksDB iterator is used
-func BenchmarkIterOnReadOnly_RocksDB(b *testing.B) {
+// BenchmarkIterOnIterCacher_RocksDB is a microbenchmark that measures the
+// performance of creating an iterator and seeking to a key if the iterator-
+// caching wrapper is used.
+func BenchmarkIterOnIterCacher_RocksDB(b *testing.B) {
 	for _, writes := range []int{10, 100, 1000, 10000} {
 		b.Run(fmt.Sprintf("writes=%d", writes), func(b *testing.B) {
-			benchmarkIterOnReadWriter(b, writes, Engine.NewReadOnly, true)
+			benchmarkIterOnReader(b, writes, Engine.NewIterCacher, true)
 		})
 	}
 }
 
-// BenchmarkIterOnEngine_RocksDB is a microbenchmark that measures the performance of creating an iterator
-// and seeking to a key without caching is used (see BenchmarkIterOnReadOnly_RocksDB)
+// BenchmarkIterOnEngine_RocksDB is a microbenchmark that measures the
+// performance of creating an iterator and seeking to a key without caching is
+// used (see BenchmarkIterOnIterCacher_RocksDB).
 func BenchmarkIterOnEngine_RocksDB(b *testing.B) {
 	for _, writes := range []int{10, 100, 1000, 10000} {
 		b.Run(fmt.Sprintf("writes=%d", writes), func(b *testing.B) {
-			benchmarkIterOnReadWriter(b, writes, func(e Engine) ReadWriter { return e }, false)
+			benchmarkIterOnReader(b, writes, func(e Engine) Engine { return e }, false)
 		})
 	}
 }

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -272,11 +272,9 @@ type Engine interface {
 	// this engine. Batched engines accumulate all mutations and apply
 	// them atomically on a call to Commit().
 	NewBatch() Batch
-	// NewReadOnly returns a new instance of a ReadWriter that wraps
-	// this engine. This wrapper panics when unexpected operations (e.g., write
-	// operations) are executed on it and caches iterators to avoid the overhead
-	// of creating multiple iterators for batched reads.
-	NewReadOnly() ReadWriter
+	// NewIterCacher returns an engine that wraps this engine. This
+	// wrapper reuses the same iterator object for its lifetime.
+	NewIterCacher() Engine
 	// NewWriteOnlyBatch returns a new instance of a batched engine which wraps
 	// this engine. A write-only batch accumulates all mutations and applies them
 	// atomically on a call to Commit(). Read operations return an error.

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -948,24 +948,22 @@ func (r *RocksDB) NewSnapshot() Reader {
 	}
 }
 
-// NewReadOnly returns a new ReadWriter wrapping this rocksdb engine.
-func (r *RocksDB) NewReadOnly() ReadWriter {
-	return &rocksDBReadOnly{
-		parent:   r,
-		isClosed: false,
-	}
+// NewIterCacher returns a new Engine wrapping this RocksDB engine that caches
+// its iterators.
+func (r *RocksDB) NewIterCacher() Engine {
+	return &rocksDBIterCacher{RocksDB: r}
 }
 
-type rocksDBReadOnly struct {
-	parent     *RocksDB
+type rocksDBIterCacher struct {
+	*RocksDB
 	prefixIter reusableIterator
 	normalIter reusableIterator
 	isClosed   bool
 }
 
-func (r *rocksDBReadOnly) Close() {
+func (r *rocksDBIterCacher) Close() {
 	if r.isClosed {
-		panic("closing an already-closed rocksDBReadOnly")
+		panic("closing an already-closed rocksDBIterCacher")
 	}
 	r.isClosed = true
 	if i := &r.prefixIter.rocksDBIterator; i.iter != nil {
@@ -976,52 +974,28 @@ func (r *rocksDBReadOnly) Close() {
 	}
 }
 
-// Read-only batches are not committed
-func (r *rocksDBReadOnly) Closed() bool {
+func (r *rocksDBIterCacher) Closed() bool {
 	return r.isClosed
 }
 
-func (r *rocksDBReadOnly) Get(key MVCCKey) ([]byte, error) {
+// NewIterator returns an iterator over the underlying engine. Note that the
+// returned iterator is cached and re-used for the lifetime of the
+// rocksDBIterCacher. A panic will be thrown if multiple prefix or normal
+// (non-prefix) iterators are used simultaneously on the same rocksDBIterCacher.
+func (r *rocksDBIterCacher) NewIterator(opts IterOptions) Iterator {
 	if r.isClosed {
-		panic("using a closed rocksDBReadOnly")
-	}
-	return dbGet(r.parent.rdb, key)
-}
-
-func (r *rocksDBReadOnly) GetProto(
-	key MVCCKey, msg protoutil.Message,
-) (ok bool, keyBytes, valBytes int64, err error) {
-	if r.isClosed {
-		panic("using a closed rocksDBReadOnly")
-	}
-	return dbGetProto(r.parent.rdb, key, msg)
-}
-
-func (r *rocksDBReadOnly) Iterate(start, end MVCCKey, f func(MVCCKeyValue) (bool, error)) error {
-	if r.isClosed {
-		panic("using a closed rocksDBReadOnly")
-	}
-	return dbIterate(r.parent.rdb, r, start, end, f)
-}
-
-// NewIterator returns an iterator over the underlying engine. Note
-// that the returned iterator is cached and re-used for the lifetime of the
-// rocksDBReadOnly. A panic will be thrown if multiple prefix or normal (non-prefix)
-// iterators are used simultaneously on the same rocksDBReadOnly.
-func (r *rocksDBReadOnly) NewIterator(opts IterOptions) Iterator {
-	if r.isClosed {
-		panic("using a closed rocksDBReadOnly")
+		panic("using a closed rocksDBIterCacher")
 	}
 	if opts.MinTimestampHint != (hlc.Timestamp{}) {
 		// Iterators that specify timestamp bounds cannot be cached.
-		return newRocksDBIterator(r.parent.rdb, opts, r, r.parent)
+		return newRocksDBIterator(r.rdb, opts, r, r.RocksDB)
 	}
 	iter := &r.normalIter
 	if opts.Prefix {
 		iter = &r.prefixIter
 	}
 	if iter.rocksDBIterator.iter == nil {
-		iter.rocksDBIterator.init(r.parent.rdb, opts, r, r.parent)
+		iter.rocksDBIterator.init(r.rdb, opts, r, r.RocksDB)
 	} else {
 		iter.rocksDBIterator.setOptions(opts)
 	}
@@ -1030,42 +1004,6 @@ func (r *rocksDBReadOnly) NewIterator(opts IterOptions) Iterator {
 	}
 	iter.inuse = true
 	return iter
-}
-
-// Writer methods are not implemented for rocksDBReadOnly. Ideally, the code could be refactored so that
-// a Reader could be supplied to evaluateBatch
-
-// Writer is the write interface to an engine's data.
-func (r *rocksDBReadOnly) ApplyBatchRepr(repr []byte, sync bool) error {
-	panic("not implemented")
-}
-
-func (r *rocksDBReadOnly) Clear(key MVCCKey) error {
-	panic("not implemented")
-}
-
-func (r *rocksDBReadOnly) ClearRange(start, end MVCCKey) error {
-	panic("not implemented")
-}
-
-func (r *rocksDBReadOnly) ClearIterRange(iter Iterator, start, end MVCCKey) error {
-	panic("not implemented")
-}
-
-func (r *rocksDBReadOnly) Merge(key MVCCKey, value []byte) error {
-	panic("not implemented")
-}
-
-func (r *rocksDBReadOnly) Put(key MVCCKey, value []byte) error {
-	panic("not implemented")
-}
-
-func (r *rocksDBReadOnly) LogData(data []byte) error {
-	panic("not implemented")
-}
-
-func (r *rocksDBReadOnly) LogLogicalOp(op MVCCLogicalOpType, details MVCCLogicalOpDetails) {
-	panic("not implemented")
 }
 
 // NewBatch returns a new batch wrapping this rocksdb engine.

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -520,10 +520,10 @@ func SetMockAddSSTable() (undo func()) {
 	}
 
 	batcheval.UnregisterCommand(roachpb.AddSSTable)
-	batcheval.RegisterCommand(roachpb.AddSSTable, batcheval.DefaultDeclareKeys, evalAddSSTable)
+	batcheval.RegisterMutatingCommand(roachpb.AddSSTable, batcheval.DefaultDeclareKeys, evalAddSSTable)
 	return func() {
 		batcheval.UnregisterCommand(roachpb.AddSSTable)
-		batcheval.RegisterCommand(roachpb.AddSSTable, prev.DeclareKeys, prev.Eval)
+		batcheval.RegisterMutatingCommand(roachpb.AddSSTable, prev.DeclareKeys, prev.EvalMutating)
 	}
 }
 

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -91,7 +91,11 @@ func evaluateCommand(
 			MaxKeys: maxKeys,
 			Stats:   ms,
 		}
-		pd, err = cmd.Eval(ctx, batch, cArgs, reply)
+		if cmd.EvalReadOnly != nil {
+			pd, err = cmd.EvalReadOnly(ctx, batch, cArgs, reply)
+		} else {
+			pd, err = cmd.EvalMutating(ctx, batch, cArgs, reply)
+		}
 	} else {
 		err = errors.Errorf("unrecognized command %s", args.Method())
 	}

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -81,13 +81,13 @@ func (r *replicaRaftStorage) InitialState() (raftpb.HardState, raftpb.ConfState,
 // and this method will always return at least one entry even if it exceeds
 // maxBytes. Sideloaded proposals count towards maxBytes with their payloads inlined.
 func (r *replicaRaftStorage) Entries(lo, hi, maxBytes uint64) ([]raftpb.Entry, error) {
-	readonly := r.store.Engine().NewReadOnly()
-	defer readonly.Close()
+	eng := r.store.Engine().NewIterCacher()
+	defer eng.Close()
 	ctx := r.AnnotateCtx(context.TODO())
 	if r.raftMu.sideloaded == nil {
 		return nil, errors.New("sideloaded storage is uninitialized")
 	}
-	return entries(ctx, r.mu.stateLoader, readonly, r.RangeID, r.store.raftEntryCache,
+	return entries(ctx, r.mu.stateLoader, eng, r.RangeID, r.store.raftEntryCache,
 		r.raftMu.sideloaded, lo, hi, maxBytes)
 }
 
@@ -258,10 +258,10 @@ func (r *replicaRaftStorage) Term(i uint64) (uint64, error) {
 	if e, ok := r.store.raftEntryCache.Get(r.RangeID, i); ok {
 		return e.Term, nil
 	}
-	readonly := r.store.Engine().NewReadOnly()
-	defer readonly.Close()
+	eng := r.store.Engine().NewIterCacher()
+	defer eng.Close()
 	ctx := r.AnnotateCtx(context.TODO())
-	return term(ctx, r.mu.stateLoader, readonly, r.RangeID, r.store.raftEntryCache, i)
+	return term(ctx, r.mu.stateLoader, eng, r.RangeID, r.store.raftEntryCache, i)
 }
 
 // raftTermLocked requires that r.mu is locked for reading.


### PR DESCRIPTION
Please let me know what you think of this approach! I'd like to get buy-in before I spend any more time on this. I'm expecting a few lint failures but tests in storage and storage/engine passed.

---

I've become convinced that read-only batches, as created by
Engine.NewReadOnly, are the wrong abstraction. They conflate two
unrelated goals:

  1. Ensure read-only commands do not accidentally write data.
  2. Improve performance of code paths that can reuse iterators by
     caching the iterator object returned by NewIterator.

The fact that Engine.NewReadOnly must return a ReadWriter, instead of a
Reader, to satisfy both of these goals is evidence that these two goals
should be addressed separately.

To better accomplish the first goal, we can leverage the Go type system.
This commit adjusts command registration so that commands declare up
front whether they are read-only or mutating. Read-only commands take an
engine.Reader, while mutating commands take an engine.ReadWriter. This
prevents accidental writes at compile time, whereas the read-only batch
could only check for misuse at runtime.

To accomplish the second goal, this commit replaces read-only batches
with an engine wrapper, rocksDBIterCacher, that does nothing but cache
iterators. This wrapper might also prove useful to cache iterators in
code paths that wish to perform mutations but do not need a full-fledged
batch.

Release note: None