### PR TITLE
lint: ensure that TestCrlfmt errors are not split

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -724,10 +724,15 @@ func TestLint(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		var buf bytes.Buffer
 		if err := stream.ForEach(filter, func(s string) {
-			t.Errorf("\n%s", s)
+			fmt.Fprintln(&buf, s)
 		}); err != nil {
 			t.Error(err)
+		}
+		errs := buf.String()
+		if len(errs) > 0 {
+			t.Errorf("\n%s", errs)
 		}
 
 		if err := cmd.Wait(); err != nil {


### PR DESCRIPTION
Fixes  #26928

There's an unrelated problem, that `crlfmt` always prints out color escape sequences even when its output is not a terminal, but we'll fix that separately.