### PR TITLE
storageccl: re-split Import SSTables on range mismatch errors

### DIFF
--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -84,6 +84,10 @@ type sstBatcher struct {
 	splits []roachpb.Key
 	// nextSplitIdx is index of first key in splits > batchStartKey.
 	nextSplitIdx int
+
+	// checkpoint is the *source* key at which the current batch started (ie. the
+	// key to which the source should be rewound to retry the batch).
+	checkpoint roachpb.Key
 }
 
 func (b *sstBatcher) add(key engine.MVCCKey, value []byte) error {
@@ -139,9 +143,11 @@ func (b *sstBatcher) shouldFlush(nextKey roachpb.Key) bool {
 	return b.sstWriter.DataSize >= b.maxSize
 }
 
-func (b *sstBatcher) flush(ctx context.Context, db *client.DB) error {
+func (b *sstBatcher) flush(
+	ctx context.Context, db *client.DB, checkpoint []byte,
+) (roachpb.Key, error) {
 	if b.sstWriter.DataSize == 0 {
-		return nil
+		return nil, nil
 	}
 	start := roachpb.Key(append([]byte(nil), b.batchStartKey...))
 	// The end key of the WriteBatch request is exclusive, but batchEndKey is
@@ -150,18 +156,19 @@ func (b *sstBatcher) flush(ctx context.Context, db *client.DB) error {
 
 	sstBytes, err := b.sstWriter.Finish()
 	if err != nil {
-		return errors.Wrapf(err, "finishing constructed sstable")
+		return nil, errors.Wrapf(err, "finishing constructed sstable")
 	}
 	if err := AddSSTable(ctx, db, start, end, sstBytes); err != nil {
 		if mismatch, ok := errors.Cause(err).(*roachpb.RangeKeyMismatchError); ok {
 			b.addSplit(mismatch)
+			return b.checkpoint, err
 		}
-		// TODO(dt): retry with the updated splits.
-		return err
+		return nil, err
 	}
 	b.rowCounter.DataSize = b.sstWriter.DataSize
 	b.totalRows.Add(b.rowCounter.BulkOpSummary)
-	return nil
+	b.checkpoint = append(b.checkpoint[:0], checkpoint...)
+	return nil, nil
 }
 
 func (b *sstBatcher) Close() {
@@ -254,6 +261,7 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 		return nil, err
 	}
 	defer batcher.Close()
+	batcher.checkpoint = append(batcher.checkpoint, args.DataSpan.Key...)
 
 	startKeyMVCC, endKeyMVCC := engine.MVCCKey{Key: args.DataSpan.Key}, engine.MVCCKey{Key: args.DataSpan.EndKey}
 	iter := engineccl.MakeMultiIterator(iters)
@@ -263,77 +271,96 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 	var keyScratch, valueScratch []byte
 
 	for {
-		ok, err := iter.Valid()
-		if err != nil {
-			return nil, err
-		}
-		if !ok {
-			break
-		}
-
-		if args.EndTime != (hlc.Timestamp{}) {
-			// TODO(dan): If we have to skip past a lot of versions to find the
-			// latest one before args.EndTime, then this could be slow.
-			if args.EndTime.Less(iter.UnsafeKey().Timestamp) {
-				iter.Next()
-				continue
-			}
-		}
-
-		if !ok || !iter.UnsafeKey().Less(endKeyMVCC) {
-			break
-		}
-		if len(iter.UnsafeValue()) == 0 {
-			// Value is deleted.
-			iter.NextKey()
-			continue
-		}
-
-		keyScratch = append(keyScratch[:0], iter.UnsafeKey().Key...)
-		valueScratch = append(valueScratch[:0], iter.UnsafeValue()...)
-		key := engine.MVCCKey{Key: keyScratch, Timestamp: iter.UnsafeKey().Timestamp}
-		value := roachpb.Value{RawBytes: valueScratch}
-		iter.NextKey()
-
-		key.Key, ok, err = kr.RewriteKey(key.Key)
-		if err != nil {
-			return nil, err
-		}
-		if !ok {
-			// If the key rewriter didn't match this key, it's not data for the
-			// table(s) we're interested in.
-			if log.V(3) {
-				log.Infof(ctx, "skipping %s %s", key.Key, value.PrettyPrint())
-			}
-			continue
-		}
-
-		// Check if we need to flush current batch *before* adding the next k/v --
-		// the batcher may want to flush the keys it already has, either because it
-		// is full or because it wants this key in a separate batch due to splits.
-		if batcher.shouldFlush(key.Key) {
-			if err := batcher.flush(ctx, db); err != nil {
-				return nil, errors.Wrapf(err, "import [%s, %s)", startKeyMVCC.Key, endKeyMVCC.Key)
-			}
-			if err := batcher.reset(); err != nil {
+		for {
+			ok, err := iter.Valid()
+			if err != nil {
 				return nil, err
 			}
-		}
+			if !ok {
+				break
+			}
 
-		// Rewriting the key means the checksum needs to be updated.
-		value.ClearChecksum()
-		value.InitChecksum(key.Key)
+			if args.EndTime != (hlc.Timestamp{}) {
+				// TODO(dan): If we have to skip past a lot of versions to find the
+				// latest one before args.EndTime, then this could be slow.
+				if args.EndTime.Less(iter.UnsafeKey().Timestamp) {
+					iter.Next()
+					continue
+				}
+			}
 
-		if log.V(3) {
-			log.Infof(ctx, "Put %s -> %s", key.Key, value.PrettyPrint())
+			if !ok || !iter.UnsafeKey().Less(endKeyMVCC) {
+				break
+			}
+			if len(iter.UnsafeValue()) == 0 {
+				// Value is deleted.
+				iter.NextKey()
+				continue
+			}
+
+			keyScratch = append(keyScratch[:0], iter.UnsafeKey().Key...)
+			valueScratch = append(valueScratch[:0], iter.UnsafeValue()...)
+			key := engine.MVCCKey{Key: keyScratch, Timestamp: iter.UnsafeKey().Timestamp}
+			value := roachpb.Value{RawBytes: valueScratch}
+			iter.NextKey()
+
+			key.Key, ok, err = kr.RewriteKey(key.Key)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				// If the key rewriter didn't match this key, it's not data for the
+				// table(s) we're interested in.
+				if log.V(3) {
+					log.Infof(ctx, "skipping %s %s", key.Key, value.PrettyPrint())
+				}
+				continue
+			}
+
+			// Check if we need to flush current batch *before* adding the next k/v --
+			// the batcher may want to flush the keys it already has, either because it
+			// is full or because it wants this key in a separate batch due to splits.
+			if batcher.shouldFlush(key.Key) {
+				if retry, err := batcher.flush(ctx, db, keyScratch); err != nil {
+					if retry != nil {
+						log.VEventf(ctx, 2, "sst rejected, retrying from %v", retry)
+						if err := batcher.reset(); err != nil {
+							return nil, err
+						}
+						iter.Seek(engine.MVCCKey{Key: retry})
+						continue
+					}
+					return nil, errors.Wrapf(err, "import [%s, %s)", startKeyMVCC.Key, endKeyMVCC.Key)
+				}
+				if err := batcher.reset(); err != nil {
+					return nil, err
+				}
+			}
+
+			// Rewriting the key means the checksum needs to be updated.
+			value.ClearChecksum()
+			value.InitChecksum(key.Key)
+
+			if log.V(3) {
+				log.Infof(ctx, "Put %s -> %s", key.Key, value.PrettyPrint())
+			}
+			if err := batcher.add(key, value.RawBytes); err != nil {
+				return nil, errors.Wrapf(err, "adding to batch: %s -> %s", key, value.PrettyPrint())
+			}
 		}
-		if err := batcher.add(key, value.RawBytes); err != nil {
-			return nil, errors.Wrapf(err, "adding to batch: %s -> %s", key, value.PrettyPrint())
+		// Flush out the last batch.
+		if retry, err := batcher.flush(ctx, db, nil); err != nil {
+			if retry != nil {
+				log.VEventf(ctx, 2, "sst rejected, retrying from %v", retry)
+				if err := batcher.reset(); err != nil {
+					return nil, err
+				}
+				iter.Seek(engine.MVCCKey{Key: retry})
+				continue
+			}
+			return nil, err
 		}
-	}
-	// Flush out the last batch.
-	if err := batcher.flush(ctx, db); err != nil {
-		return nil, err
+		break
 	}
 	log.Event(ctx, "done")
 	return &roachpb.ImportResponse{Imported: batcher.totalRows}, nil

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -689,6 +689,11 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 		return resp.reply, resp.pErr
 	}
 
+	if ba.IsUnsplittable() {
+		mismatch := roachpb.NewRangeKeyMismatchError(rs.Key.AsRawKey(), rs.EndKey.AsRawKey(), ri.Desc())
+		return nil, roachpb.NewError(mismatch)
+	}
+
 	// Make an empty slice of responses which will be populated with responses
 	// as they come in via Combine().
 	br = &roachpb.BatchResponse{

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -103,14 +103,15 @@ func (rc ReadConsistencyType) SupportsBatch(ba BatchRequest) error {
 }
 
 const (
-	isAdmin    = 1 << iota // admin cmds don't go through raft, but run on lease holder
-	isRead                 // read-only cmds don't go through raft, but may run on lease holder
-	isWrite                // write cmds go through raft and must be proposed on lease holder
-	isTxn                  // txn commands may be part of a transaction
-	isTxnWrite             // txn write cmds start heartbeat and are marked for intent resolution
-	isRange                // range commands may span multiple keys
-	isReverse              // reverse commands traverse ranges in descending direction
-	isAlone                // requests which must be alone in a batch
+	isAdmin        = 1 << iota // admin cmds don't go through raft, but run on lease holder
+	isRead                     // read-only cmds don't go through raft, but may run on lease holder
+	isWrite                    // write cmds go through raft and must be proposed on lease holder
+	isTxn                      // txn commands may be part of a transaction
+	isTxnWrite                 // txn write cmds start heartbeat and are marked for intent resolution
+	isRange                    // range commands may span multiple keys
+	isReverse                  // reverse commands traverse ranges in descending direction
+	isAlone                    // requests which must be alone in a batch
+	isUnsplittable             // range command that must not be split during sending
 	// Requests for acquiring a lease skip the (proposal-time) check that the
 	// proposing replica has a valid lease.
 	skipLeaseCheck
@@ -1075,7 +1076,7 @@ func (*WriteBatchRequest) flags() int               { return isWrite | isRange }
 func (*ExportRequest) flags() int                   { return isRead | isRange | updatesReadTSCache }
 func (*ImportRequest) flags() int                   { return isAdmin | isAlone }
 func (*AdminScatterRequest) flags() int             { return isAdmin | isAlone | isRange }
-func (*AddSSTableRequest) flags() int               { return isWrite | isAlone | isRange }
+func (*AddSSTableRequest) flags() int               { return isWrite | isAlone | isRange | isUnsplittable }
 
 // RefreshRequest and RefreshRangeRequest both list
 // updates(Read)TSCache, though they actually update the read or write

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -117,6 +117,11 @@ func (ba *BatchRequest) IsTransactionWrite() bool {
 	return ba.hasFlag(isTxnWrite)
 }
 
+// IsUnsplittable returns true iff the BatchRequest an un-splittable request.
+func (ba *BatchRequest) IsUnsplittable() bool {
+	return ba.hasFlag(isUnsplittable)
+}
+
 // IsSingleRequest returns true iff the BatchRequest contains a single request.
 func (ba *BatchRequest) IsSingleRequest() bool {
 	return len(ba.Requests) == 1


### PR DESCRIPTION
Previously an ImportRequest would fail to add SSTables that spanned the boundries of the target range(s). This reattempts the AddSSTable call with re-chunked SSTables that avoid spanning the bounds returned in range mismatch errors from prior SSTable application attempts.

This uses the `unsplittable` flag implemented (but untested) in #24299 to return range mismatch errors from `AddSSTable` to `evalImport` which can then update its cache of split points, before retrying with updated chunking using those split points.

Closes #24299.

This error currently happens rarely in practice -- we usually explicitly split ranges immediately before sending an Import with matching boundsto them. Usually the empty, just-split range has no reason to split again, so the Import usually succeeds.

However in some cases, like resuming a prior RESTORE, we may be re-Importing into ranges that are *not* empty and could have split at points other than those picked by the RESTORE statement.

Fixes #17819.

Release note: none.