### PR TITLE
opt: Expose additional key column information for index metadata

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -577,3 +577,24 @@ SELECT pk, col0 FROM tab1 WHERE (col3 BETWEEN 66 AND 87) ORDER BY 1 DESC
 5 69
 3 70
 2 87
+
+# Use a unique index with a nullable column. Rows with a NULL value for that
+# column will have the PK columns added to the key, whereas rows with a non-NULL
+# value will not. Ensure that when the index is used, it returns all rows.
+statement ok
+CREATE TABLE abc (a INT, b INT, c INT, PRIMARY KEY(a, b), UNIQUE INDEX c (c))
+
+statement ok
+INSERT INTO abc (a, b, c) VALUES (0, 1, NULL);
+INSERT INTO abc (a, b, c) VALUES (0, 2, NULL);
+INSERT INTO abc (a, b, c) VALUES (1, 1, NULL);
+INSERT INTO abc (a, b, c) VALUES (1, 2, NULL);
+INSERT INTO abc (a, b, c) VALUES (2, 1, 1);
+INSERT INTO abc (a, b, c) VALUES (2, 2, 2);
+
+query III rowsort
+SELECT * FROM abc WHERE (c IS NULL OR c=2) AND a>0
+----
+1  1  NULL
+1  2  NULL
+2  2  2

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -787,10 +787,28 @@ render     ·         ·              (c)     ·
 ·          table     abc@abc_c_idx  ·       ·
 ·          spans     /1/3-/1/4      ·       ·
 
-# Verify we don't create constraints on implicit columns when they are not part
-# of the key (unique index).
+# Verify we don't create constraints on implicit columns when they may be part
+# of the key (unique index on nullable column).
 statement ok
 CREATE TABLE def (d INT, e INT, f INT, PRIMARY KEY(d,e), UNIQUE INDEX(f))
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT f FROM def WHERE f = 1 and d = 3
+----
+render     ·         ·              (f)     ·
+ │         render 0  f              ·       ·
+ └── scan  ·         ·              (d, f)  ·
+·          table     def@def_f_key  ·       ·
+·          spans     /1-/2          ·       ·
+·          filter    d = 3          ·       ·
+
+statement ok
+DROP TABLE def
+
+# Verify we don't create constraints on implicit columns when they are not part
+# of the key (unique index on not-null column).
+statement ok
+CREATE TABLE def (d INT, e INT, f INT NOT NULL, PRIMARY KEY(d,e), UNIQUE INDEX(f))
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT f FROM def WHERE f = 1 and d = 3

--- a/pkg/sql/opt/memo/private_defs.go
+++ b/pkg/sql/opt/memo/private_defs.go
@@ -106,11 +106,11 @@ func (s *ScanOpDef) CanProvideOrdering(md *opt.Metadata, required opt.Ordering) 
 	// 2. The index columns are a prefix of the ordering columns (this
 	//    works because the columns are always a key, so any additional
 	//    columns are unnecessary).
-	// TODO(andyk): Use UniqueColumnCount when issues with nulls are solved,
+	// TODO(andyk): Use LaxKeyColumnCount when issues with nulls are solved,
 	//              since unique index can still have duplicate nulls.
 	cnt := index.ColumnCount()
 	if s.Index == opt.PrimaryIndex {
-		cnt = index.UniqueColumnCount()
+		cnt = index.KeyColumnCount()
 	}
 	if len(required) < cnt {
 		cnt = len(required)

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -203,13 +203,14 @@ type Index struct {
 	Name    string
 	Columns []opt.IndexColumn
 
-	// Unique is the number of columns that make up the unique key for the
-	// index. The columns are always a non-empty prefix of the Columns
-	// collection, so Unique is > 0 and < len(Columns). Note that this is even
-	// true for indexes that were not declared as unique, since primary key
-	// columns will be implicitly added to the index in order to ensure it is
-	// always unique.
-	Unique int
+	// KeyCount is the number of columns that make up the unique key for the
+	// index. See the opt.Index.KeyColumnCount for more details.
+	KeyCount int
+
+	// LaxKeyCount is the number of columns that make up a lax key for the
+	// index, which allows duplicate rows when at least one of the values is
+	// NULL. See the opt.Index.LaxKeyColumnCount for more details.
+	LaxKeyCount int
 }
 
 // IdxName is part of the opt.Index interface.
@@ -227,9 +228,14 @@ func (ti *Index) ColumnCount() int {
 	return len(ti.Columns)
 }
 
-// UniqueColumnCount is part of the opt.Index interface.
-func (ti *Index) UniqueColumnCount() int {
-	return ti.Unique
+// KeyColumnCount is part of the opt.Index interface.
+func (ti *Index) KeyColumnCount() int {
+	return ti.KeyCount
+}
+
+// LaxKeyColumnCount is part of the opt.Index interface.
+func (ti *Index) LaxKeyColumnCount() int {
+	return ti.LaxKeyCount
 }
 
 // Column is part of the opt.Index interface.

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -59,7 +59,7 @@ func (c *CustomFuncs) GenerateIndexScans(def memo.PrivateID) []memo.Expr {
 	tab := md.Table(scanOpDef.Table)
 
 	primaryIndex := md.Table(scanOpDef.Table).Index(opt.PrimaryIndex)
-	pkCols := make(opt.ColList, primaryIndex.UniqueColumnCount())
+	pkCols := make(opt.ColList, primaryIndex.KeyColumnCount())
 	for i := range pkCols {
 		pkCols[i] = md.TableColumn(scanOpDef.Table, primaryIndex.Column(i).Ordinal)
 	}
@@ -140,9 +140,12 @@ func (c *CustomFuncs) constrainedScanOpDef(
 	scanOpDef := c.e.mem.LookupPrivate(scanDef).(*memo.ScanOpDef)
 
 	// Fill out data structures needed to initialize the idxconstraint library.
+	// Use LaxKeyColumnCount, since all columns <= LaxKeyColumnCount are
+	// guaranteed to be part of each row's key (i.e. not stored in row's value,
+	// which does not take part in an index scan).
 	md := c.e.mem.Metadata()
 	index := md.Table(scanOpDef.Table).Index(scanOpDef.Index)
-	columns := make([]opt.OrderingColumn, index.UniqueColumnCount())
+	columns := make([]opt.OrderingColumn, index.LaxKeyColumnCount())
 	var notNullCols opt.ColSet
 	for i := range columns {
 		col := index.Column(i)

--- a/pkg/sql/opt/xform/interesting_orderings.go
+++ b/pkg/sql/opt/xform/interesting_orderings.go
@@ -68,7 +68,7 @@ func interestingOrderingsForScan(ev memo.ExprView) opt.OrderingSet {
 		if index.IsInverted() {
 			continue
 		}
-		numIndexCols := index.UniqueColumnCount()
+		numIndexCols := index.KeyColumnCount()
 		o := make(opt.Ordering, 0, numIndexCols)
 		for j := 0; j < numIndexCols; j++ {
 			indexCol := index.Column(j)

--- a/pkg/sql/opt/xform/testdata/ruleprops/orderings
+++ b/pkg/sql/opt/xform/testdata/ruleprops/orderings
@@ -61,7 +61,7 @@ project
       ├── key: (4)
       ├── fd: (4)-->(1-3), (3)~~>(1,2,4)
       ├── prune: (1-4)
-      └── interesting orderings: (+4) (+1,+2,+4) (+3)
+      └── interesting orderings: (+4) (+1,+2,+4) (+3,+4)
 
 build
 SELECT b, c FROM abc
@@ -76,7 +76,7 @@ project
       ├── key: (4)
       ├── fd: (4)-->(1-3), (3)~~>(1,2,4)
       ├── prune: (1-4)
-      └── interesting orderings: (+4) (+1,+2,+4) (+3)
+      └── interesting orderings: (+4) (+1,+2,+4) (+3,+4)
 
 # GroupBy operator.
 opt

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -210,7 +210,8 @@ type optIndex struct {
 	storedCols []sqlbase.ColumnID
 
 	numCols       int
-	numUniqueCols int
+	numKeyCols    int
+	numLaxKeyCols int
 }
 
 var _ opt.Index = &optIndex{}
@@ -243,10 +244,34 @@ func (oi *optIndex) init(tab *optTable, desc *sqlbase.IndexDescriptor) {
 		oi.numCols = len(desc.ColumnIDs) + len(desc.ExtraColumnIDs) + len(desc.StoreColumnIDs)
 	}
 
-	// If index is not unique, extra key columns are added.
-	oi.numUniqueCols = len(desc.ColumnIDs)
-	if !desc.Unique {
-		oi.numUniqueCols += len(desc.ExtraColumnIDs)
+	if desc.Unique {
+		notNull := true
+		for _, id := range desc.ColumnIDs {
+			ord := tab.lookupColumnOrdinal(id)
+			if tab.desc.Columns[ord].Nullable {
+				notNull = false
+				break
+			}
+		}
+
+		if notNull {
+			// Unique index with no null columns: columns from index are sufficient
+			// to form a key without needing extra primary key columns. There is no
+			// separate lax key.
+			oi.numLaxKeyCols = len(desc.ColumnIDs)
+			oi.numKeyCols = oi.numLaxKeyCols
+		} else {
+			// Unique index with at least one nullable column: extra primary key
+			// columns will be added to the row key when one of the unique index
+			// columns has a NULL value.
+			oi.numLaxKeyCols = len(desc.ColumnIDs)
+			oi.numKeyCols = oi.numLaxKeyCols + len(desc.ExtraColumnIDs)
+		}
+	} else {
+		// Non-unique index: extra primary key columns are always added to the row
+		// key. There is no separate lax key.
+		oi.numLaxKeyCols = len(desc.ColumnIDs) + len(desc.ExtraColumnIDs)
+		oi.numKeyCols = oi.numLaxKeyCols
 	}
 }
 
@@ -265,9 +290,14 @@ func (oi *optIndex) ColumnCount() int {
 	return oi.numCols
 }
 
-// UniqueColumnCount is part of the opt.Index interface.
-func (oi *optIndex) UniqueColumnCount() int {
-	return oi.numUniqueCols
+// KeyColumnCount is part of the opt.Index interface.
+func (oi *optIndex) KeyColumnCount() int {
+	return oi.numKeyCols
+}
+
+// LaxKeyColumnCount is part of the opt.Index interface.
+func (oi *optIndex) LaxKeyColumnCount() int {
+	return oi.numLaxKeyCols
 }
 
 // Column is part of the opt.Index interface.


### PR DESCRIPTION
The UniqueColumnCount method on the Index metadata interface isn't
sufficient to discover which index columns are part of its strict
key and its lax key (if it has a separate lax key). Sometimes, we
need to know one and sometimes the other. UniqueColumnCount does
not consistently report one or the other; instead it reports an
unhelpful mishmash of the two.

This commit separates the two cases:

  Index.KeyColumnCount    - #cols to make strict key (nulls equal)
  Index.LaxKeyColumnCount - #cols to make lax key (nulls not equal)

Release note: None