### PR TITLE
ui: properly segregate/aggregate app sql stats

### DIFF
--- a/pkg/ui/src/index.tsx
+++ b/pkg/ui/src/index.tsx
@@ -134,6 +134,7 @@ ReactDOM.render(
         </Route>
         <Route path="statement">
           <IndexRedirect to="/statements" />
+          <Route path={ `:${appAttr}/:${statementAttr}` } component={ StatementDetails } />
           <Route path={ `:${statementAttr}` } component={ StatementDetails } />
         </Route>
 

--- a/pkg/ui/src/index.tsx
+++ b/pkg/ui/src/index.tsx
@@ -1,16 +1,9 @@
-/// <reference path="../node_modules/protobufjs/stub-node.d.ts" />
-
 import "nvd3/build/nv.d3.min.css";
 import "react-select/dist/react-select.css";
 import "styl/app.styl";
 
 import "src/polyfills";
-
-import * as protobuf from "protobufjs/minimal";
-import Long from "long";
-
-protobuf.util.Long = Long as any;
-protobuf.configure();
+import "src/protobufInit";
 
 import React from "react";
 import * as ReactDOM from "react-dom";

--- a/pkg/ui/src/index.tsx
+++ b/pkg/ui/src/index.tsx
@@ -131,10 +131,10 @@ ReactDOM.render(
         <Route path="statements">
           <IndexRoute component={ StatementsPage } />
           <Route path={ `:${appAttr}` } component={ StatementsPage } />
+          <Route path={ `:${appAttr}/:${statementAttr}` } component={ StatementDetails } />
         </Route>
         <Route path="statement">
           <IndexRedirect to="/statements" />
-          <Route path={ `:${appAttr}/:${statementAttr}` } component={ StatementDetails } />
           <Route path={ `:${statementAttr}` } component={ StatementDetails } />
         </Route>
 

--- a/pkg/ui/src/protobufInit.ts
+++ b/pkg/ui/src/protobufInit.ts
@@ -1,0 +1,7 @@
+/// <reference path="../node_modules/protobufjs/stub-node.d.ts" />
+
+import * as protobuf from "protobufjs/minimal";
+import Long from "long";
+
+protobuf.util.Long = Long as any;
+protobuf.configure();

--- a/pkg/ui/src/util/appStats.spec.ts
+++ b/pkg/ui/src/util/appStats.spec.ts
@@ -99,7 +99,7 @@ describe("flattenStatementStats", () => {
     assert.equal(flattened.length, stats.length);
 
     for (let i = 0; i < flattened.length; i++) {
-      assert.equal(flattened[i].query, stats[i].key.query);
+      assert.equal(flattened[i].statement, stats[i].key.query);
       assert.equal(flattened[i].app, stats[i].key.app);
       assert.equal(flattened[i].distSQL, stats[i].key.distSQL);
       assert.equal(flattened[i].failed, stats[i].key.failed);

--- a/pkg/ui/src/util/appStats.spec.ts
+++ b/pkg/ui/src/util/appStats.spec.ts
@@ -1,0 +1,71 @@
+import { assert } from "chai";
+
+import { addNumericStats, NumericStat } from "./appStats";
+
+// record is implemented here so we can write the below test as a direct
+// analog of the one in pkg/roachpb/app_stats_test.go.  It's here rather
+// than in the main source file because we don't actually need it for the
+// application to use.
+function record(l: NumericStat, count: number, val: number) {
+  const delta = val - l.mean;
+  l.mean += delta / count;
+  l.squared_diffs += delta * (val - l.mean);
+}
+
+function emptyStats() {
+  return {
+    mean: 0,
+    squared_diffs: 0,
+  };
+}
+
+describe("addNumericStats", () => {
+  it("adds two numeric stats together", () => {
+    const aData = [1.1, 3.3, 2.2];
+    const bData = [2.0, 3.0, 5.5, 1.2];
+
+    let countA = 0;
+    let countB = 0;
+    let countAB = 0;
+
+    let sumA = 0;
+    let sumB = 0;
+    let sumAB = 0;
+
+    const a = emptyStats();
+    const b = emptyStats();
+    const ab = emptyStats();
+
+    aData.forEach(v => {
+      countA++;
+      sumA += v;
+      record(a, countA, v);
+    });
+
+    bData.forEach(v => {
+      countB++;
+      sumB += v;
+      record(b, countB, v);
+    });
+
+    bData.concat(aData).forEach(v => {
+      countAB++;
+      sumAB += v;
+      record(ab, countAB, v);
+    });
+
+    assert.approximately(a.mean, 2.2, 0.0000001);
+    assert.approximately(a.mean, sumA / countA, 0.0000001);
+    assert.approximately(b.mean, sumB / countB, 0.0000001);
+    assert.approximately(ab.mean, sumAB / countAB, 0.0000001);
+
+    const combined = addNumericStats(a, b, countA, countB);
+
+    assert.approximately(combined.mean, ab.mean, 0.0000001);
+    assert.approximately(combined.squared_diffs, ab.squared_diffs, 0.0000001);
+
+    const reversed = addNumericStats(b, a, countB, countA);
+
+    assert.deepEqual(reversed, combined);
+  });
+});

--- a/pkg/ui/src/util/appStats.spec.ts
+++ b/pkg/ui/src/util/appStats.spec.ts
@@ -1,6 +1,7 @@
 import { assert } from "chai";
+import Long from "long";
 
-import { addNumericStats, NumericStat } from "./appStats";
+import { addNumericStats, NumericStat, flattenStatementStats, StatementStatistics, combineStatementStats } from "./appStats";
 
 // record is implemented here so we can write the below test as a direct
 // analog of the one in pkg/roachpb/app_stats_test.go.  It's here rather
@@ -67,5 +68,137 @@ describe("addNumericStats", () => {
     const reversed = addNumericStats(b, a, countB, countA);
 
     assert.deepEqual(reversed, combined);
+  });
+});
+
+describe("flattenStatementStats", () => {
+  it("flattens CollectedStatementStatistics to ExecutionStatistics", () => {
+    const stats = [
+      {
+        key: {
+          query: "SELECT * FROM foobar",
+          app: "foobar",
+          distSQL: true,
+          failed: false,
+        },
+        stats: {},
+      },
+      {
+        key: {
+          query: "UPDATE foobar SET name = 'baz' WHERE id = 42",
+          app: "bazzer",
+          distSQL: false,
+          failed: true,
+        },
+        stats: {},
+      },
+    ];
+
+    const flattened = flattenStatementStats(stats);
+
+    assert.equal(flattened.length, stats.length);
+
+    for (let i = 0; i < flattened.length; i++) {
+      assert.equal(flattened[i].query, stats[i].key.query);
+      assert.equal(flattened[i].app, stats[i].key.app);
+      assert.equal(flattened[i].distSQL, stats[i].key.distSQL);
+      assert.equal(flattened[i].failed, stats[i].key.failed);
+
+      assert.equal(flattened[i].stats, stats[i].stats);
+    }
+  });
+});
+
+function randomInt(max: number): number {
+  return Math.floor(Math.random() * max);
+}
+
+function randomFloat(scale: number): number {
+  return Math.random() * scale;
+}
+
+function randomStat(scale: number = 1): NumericStat {
+  return {
+    mean: randomFloat(scale),
+    squared_diffs: randomFloat(scale * 0.3),
+  };
+}
+
+function randomStats(): StatementStatistics {
+  const count = randomInt(1000);
+  // tslint:disable:variable-name
+  const first_attempt_count = randomInt(count);
+  const max_retries = randomInt(count - first_attempt_count);
+  // tslint:enable:variable-name
+
+  return {
+    count: Long.fromNumber(count),
+    first_attempt_count: Long.fromNumber(first_attempt_count),
+    max_retries: Long.fromNumber(max_retries),
+    num_rows: randomStat(100),
+    parse_lat: randomStat(),
+    plan_lat: randomStat(),
+    run_lat: randomStat(),
+    service_lat: randomStat(),
+    overhead_lat: randomStat(),
+    last_err: "",
+    last_err_redacted: "",
+  };
+}
+
+describe("combineStatementStats", () => {
+  it("combines statement statistics", () => {
+    const a = randomStats();
+    const b = randomStats();
+    const c = randomStats();
+
+    const ab = combineStatementStats([a, b]);
+    const ac = combineStatementStats([a, c]);
+    const bc = combineStatementStats([b, c]);
+
+    // tslint:disable:variable-name
+    const ab_c = combineStatementStats([ab, c]);
+    const ac_b = combineStatementStats([ac, b]);
+    const bc_a = combineStatementStats([bc, a]);
+    // tslint:enable:variable-name
+
+    assert.equal(ab_c.count.toString(), ac_b.count.toString());
+    assert.equal(ab_c.count.toString(), bc_a.count.toString());
+
+    assert.equal(ab_c.first_attempt_count.toString(), ac_b.first_attempt_count.toString());
+    assert.equal(ab_c.first_attempt_count.toString(), bc_a.first_attempt_count.toString());
+
+    assert.equal(ab_c.max_retries.toString(), ac_b.max_retries.toString());
+    assert.equal(ab_c.max_retries.toString(), bc_a.max_retries.toString());
+
+    assert.approximately(ab_c.num_rows.mean, ac_b.num_rows.mean, 0.0000001);
+    assert.approximately(ab_c.num_rows.mean, bc_a.num_rows.mean, 0.0000001);
+    assert.approximately(ab_c.num_rows.squared_diffs, ac_b.num_rows.squared_diffs, 0.0000001);
+    assert.approximately(ab_c.num_rows.squared_diffs, bc_a.num_rows.squared_diffs, 0.0000001);
+
+    assert.approximately(ab_c.parse_lat.mean, ac_b.parse_lat.mean, 0.0000001);
+    assert.approximately(ab_c.parse_lat.mean, bc_a.parse_lat.mean, 0.0000001);
+    assert.approximately(ab_c.parse_lat.squared_diffs, ac_b.parse_lat.squared_diffs, 0.0000001);
+    assert.approximately(ab_c.parse_lat.squared_diffs, bc_a.parse_lat.squared_diffs, 0.0000001);
+
+    assert.approximately(ab_c.plan_lat.mean, ac_b.plan_lat.mean, 0.0000001);
+    assert.approximately(ab_c.plan_lat.mean, bc_a.plan_lat.mean, 0.0000001);
+    assert.approximately(ab_c.plan_lat.squared_diffs, ac_b.plan_lat.squared_diffs, 0.0000001);
+    assert.approximately(ab_c.plan_lat.squared_diffs, bc_a.plan_lat.squared_diffs, 0.0000001);
+
+    assert.approximately(ab_c.run_lat.mean, ac_b.run_lat.mean, 0.0000001);
+    assert.approximately(ab_c.run_lat.mean, bc_a.run_lat.mean, 0.0000001);
+    assert.approximately(ab_c.run_lat.squared_diffs, ac_b.run_lat.squared_diffs, 0.0000001);
+    assert.approximately(ab_c.run_lat.squared_diffs, bc_a.run_lat.squared_diffs, 0.0000001);
+
+    assert.approximately(ab_c.service_lat.mean, ac_b.service_lat.mean, 0.0000001);
+    assert.approximately(ab_c.service_lat.mean, bc_a.service_lat.mean, 0.0000001);
+    assert.approximately(ab_c.service_lat.squared_diffs, ac_b.service_lat.squared_diffs, 0.0000001);
+    assert.approximately(ab_c.service_lat.squared_diffs, bc_a.service_lat.squared_diffs, 0.0000001);
+
+    assert.approximately(ab_c.overhead_lat.mean, ac_b.overhead_lat.mean, 0.0000001);
+    assert.approximately(ab_c.overhead_lat.mean, bc_a.overhead_lat.mean, 0.0000001);
+    assert.approximately(ab_c.overhead_lat.squared_diffs, ac_b.overhead_lat.squared_diffs, 0.0000001);
+    assert.approximately(ab_c.overhead_lat.squared_diffs, bc_a.overhead_lat.squared_diffs, 0.0000001);
   });
 });

--- a/pkg/ui/src/util/appStats.ts
+++ b/pkg/ui/src/util/appStats.ts
@@ -65,7 +65,7 @@ export function aggregateStatementStats(statementStats: CollectedStatementStatis
 }
 
 export interface ExecutionStatistics {
-  query: string;
+  statement: string;
   app: string;
   distSQL: boolean;
   failed: boolean;
@@ -74,7 +74,7 @@ export interface ExecutionStatistics {
 
 export function flattenStatementStats(statementStats: CollectedStatementStatistics[]): ExecutionStatistics[] {
   return statementStats.map(stmt => ({
-    query: stmt.key.query,
+    statement: stmt.key.query,
     app: stmt.key.app,
     distSQL: stmt.key.distSQL,
     failed: stmt.key.failed,

--- a/pkg/ui/src/util/appStats.ts
+++ b/pkg/ui/src/util/appStats.ts
@@ -1,4 +1,9 @@
+import _ from "lodash";
+import * as protos from "src/js/protos";
 import { FixLong } from "src/util/fixLong";
+
+type StatementStatistics = protos.cockroach.sql.StatementStatistics$Properties;
+type CollectedStatementStatistics = protos.cockroach.sql.CollectedStatementStatistics$Properties;
 
 export interface NumericStat {
   mean?: number;
@@ -15,4 +20,46 @@ export function stdDev(stat: NumericStat, count: number) {
 
 export function stdDevLong(stat: NumericStat, count: number | Long) {
   return stdDev(stat, FixLong(count).toInt());
+}
+
+export function addNumericStats(a: NumericStat, b: NumericStat, countA: number, countB: number) {
+  const total = countA + countB;
+  const delta = b.mean - a.mean;
+
+  return {
+    mean: ((a.mean * countA) + (b.mean * countB)) / total,
+    squared_diffs: (a.squared_diffs + b.squared_diffs) + delta * delta * countA * countB / total,
+  };
+}
+
+export function addStatementStats(a: StatementStatistics, b: StatementStatistics) {
+  const countA = FixLong(a.count).toInt();
+  const countB = FixLong(b.count).toInt();
+  return {
+    count: a.count.add(b.count),
+    first_attempt_count: a.first_attempt_count.add(b.first_attempt_count),
+    max_retries: a.max_retries.greaterThan(b.max_retries) ? a.max_retries : b.max_retries,
+    num_rows: addNumericStats(a.num_rows, b.num_rows, countA, countB),
+    parse_lat: addNumericStats(a.parse_lat, b.parse_lat, countA, countB),
+    plan_lat: addNumericStats(a.plan_lat, b.plan_lat, countA, countB),
+    run_lat: addNumericStats(a.run_lat, b.run_lat, countA, countB),
+    service_lat: addNumericStats(a.service_lat, b.service_lat, countA, countB),
+    overhead_lat: addNumericStats(a.overhead_lat, b.overhead_lat, countA, countB),
+  };
+}
+
+export function aggregateStatementStats(statementStats: CollectedStatementStatistics[]) {
+  const statements = {};
+  statementStats.forEach(
+    (statement: CollectedStatementStatistics$Properties) => {
+      const matches = statements[statement.key.query] || (statements[statement.key.query] = []);
+      matches.push(statement);
+  });
+
+  return _.values(statements).map(statements =>
+    _.reduce(statements, (a, b) => ({
+      key: a.key,
+      stats: addStatementStats(a.stats, b.stats),
+    }))
+  );
 }

--- a/pkg/ui/src/util/appStats.ts
+++ b/pkg/ui/src/util/appStats.ts
@@ -19,7 +19,7 @@ export function variance(stat: NumericStat, count: number) {
 }
 
 export function stdDev(stat: NumericStat, count: number) {
-  return Math.sqrt(variance(stat, count));
+  return Math.sqrt(variance(stat, count)) || 0;
 }
 
 export function stdDevLong(stat: NumericStat, count: number | Long) {

--- a/pkg/ui/src/util/appStats.ts
+++ b/pkg/ui/src/util/appStats.ts
@@ -1,3 +1,7 @@
+// This file significantly duplicates the algorithms available in
+// pkg/roachpb/app_stats.go, in particular the functions on NumericStats
+// to compute variance and add together NumericStats.
+
 import _ from "lodash";
 import * as protos from "src/js/protos";
 import { FixLong } from "src/util/fixLong";

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -32,6 +32,7 @@ const latencyBars = [
 ];
 
 const latencyStdDev = bar("latency-overall-dev", "Latency Std. Dev.", (d: StatementStatistics) => stdDevLong(d.stats.service_lat, d.stats.count));
+const rowsStdDev = bar("rows-dev", "Rows Std. Dev.", (d: StatementStatistics) => stdDevLong(d.stats.num_rows, d.stats.count));
 
 function bar(name: string, title: string, value: (d: StatementStatistics) => number) {
   return { name, title, value };
@@ -134,7 +135,7 @@ export function approximify(value: number) {
 }
 
 export const countBarChart = makeBarChart("Execution Count", countBars, approximify);
-export const rowsBarChart = makeBarChart("Rows Affected.  Mean", rowsBars, approximify);
+export const rowsBarChart = makeBarChart("Rows Affected.  Mean", rowsBars, approximify, rowsStdDev);
 export const latencyBarChart = makeBarChart("Latency.  Mean", latencyBars, v => Duration(v * 1e9), latencyStdDev);
 
 export function countBreakdown(s: StatementStatistics) {

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -38,6 +38,7 @@ function bar(name: string, title: string, value: (d: StatementStatistics) => num
 }
 
 function makeBarChart(
+  title: string,
   accessors: { name: string, title: string, value: (d: StatementStatistics) => number }[],
   formatter: (d: number) => string = (x) => `${x}`,
   stdDevAccessor?: { name: string, title: string, value: (d: StatementStatistics) => number },
@@ -97,11 +98,18 @@ function makeBarChart(
         );
       }
 
+      let titleText = title + ": " + formatter(sum);
+      if (stdDevAccessor) {
+        titleText += " Std. Dev.: " + formatter(stdDevAccessor.value(d));
+      }
+
       return (
         <div className={ "bar-chart" + (rows.length === 0 ? " bar-chart--singleton" : "") }>
-          <div className="label">{ formatter(getTotal(d)) }</div>
-          { bars }
-          { renderStdDev() }
+          <ToolTipWrapper text={ titleText }>
+            <div className="label">{ formatter(getTotal(d)) }</div>
+            { bars }
+            { renderStdDev() }
+          </ToolTipWrapper>
         </div>
       );
     };
@@ -125,9 +133,9 @@ export function approximify(value: number) {
   return "" + Math.round(value);
 }
 
-export const countBarChart = makeBarChart(countBars, approximify);
-export const rowsBarChart = makeBarChart(rowsBars, approximify);
-export const latencyBarChart = makeBarChart(latencyBars, v => Duration(v * 1e9), latencyStdDev);
+export const countBarChart = makeBarChart("Execution Count", countBars, approximify);
+export const rowsBarChart = makeBarChart("Rows Affected.  Mean", rowsBars, approximify);
+export const latencyBarChart = makeBarChart("Latency.  Mean", latencyBars, v => Duration(v * 1e9), latencyStdDev);
 
 export function countBreakdown(s: StatementStatistics) {
   const count = longToInt(s.stats.count);

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -99,7 +99,10 @@ function makeBarChart(
 
       let titleText = title + ": " + formatter(sum);
       if (stdDevAccessor) {
-        titleText += " Std. Dev.: " + formatter(stdDevAccessor.value(d));
+        const sd = stdDevAccessor.value(d);
+        if (sd) {
+          titleText += " Std. Dev.: " + formatter(sd);
+        }
       }
 
       return (

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -2,6 +2,8 @@ import d3 from "d3";
 import _ from "lodash";
 import React from "react";
 
+import { ToolTipWrapper } from "src/views/shared/components/toolTip";
+
 import { stdDevLong } from "src/util/appStats";
 import { Duration } from "src/util/format";
 import { FixLong } from "src/util/fixLong";
@@ -141,11 +143,12 @@ export function countBreakdown(s: StatementStatistics) {
     firstAttemptsBarChart() {
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <div
-            className="count-first-try bar-chart__bar"
-            style={{ width: scale(firstAttempts) + "%" }}
-            title={ "First Try Count: " + firstAttempts }
-          />
+          <ToolTipWrapper text={"First Try Count: " + firstAttempts}>
+            <div
+              className="count-first-try bar-chart__bar"
+              style={{ width: scale(firstAttempts) + "%" }}
+            />
+          </ToolTipWrapper>
         </div>
       );
     },
@@ -153,11 +156,12 @@ export function countBreakdown(s: StatementStatistics) {
     retriesBarChart() {
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <div
-            className="count-retry bar-chart__bar"
-            style={{ width: scale(retries) + "%", position: "absolute", right: "0" }}
-            title={ "Retry Count: " + retries }
-          />
+          <ToolTipWrapper text={ "Retry Count: " + retries }>
+            <div
+              className="count-retry bar-chart__bar"
+              style={{ width: scale(retries) + "%", position: "absolute", right: "0" }}
+            />
+          </ToolTipWrapper>
         </div>
       );
     },
@@ -165,11 +169,12 @@ export function countBreakdown(s: StatementStatistics) {
     maxRetriesBarChart() {
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <div
-            className="count-retry bar-chart__bar"
-            style={{ width: scale(maxRetries) + "%", position: "absolute", right: "0" }}
-            title={ "Max Retries: " + retries }
-          />
+          <ToolTipWrapper text={ "Max Retries: " + retries }>
+            <div
+              className="count-retry bar-chart__bar"
+              style={{ width: scale(maxRetries) + "%", position: "absolute", right: "0" }}
+            />
+          </ToolTipWrapper>
         </div>
       );
     },
@@ -180,6 +185,8 @@ export function rowsBreakdown(s: StatementStatistics) {
   const mean = s.stats.num_rows.mean;
   const sd = stdDevLong(s.stats.num_rows, s.stats.count);
 
+  const format = (v: number) => "" + (Math.round(v * 100) / 100);
+
   const scale = d3.scale.linear()
       .domain([0, mean + sd])
       .range([0, 100]);
@@ -189,19 +196,19 @@ export function rowsBreakdown(s: StatementStatistics) {
       const width = scale(clamp(mean - sd));
       const right = scale(mean);
       const spread = scale(sd + (sd > mean ? mean : sd));
-      const title = "Row Count.  Mean: " + mean + " Std.Dev.: " + sd;
+      const title = "Row Count.  Mean: " + format(mean) + " Std.Dev.: " + format(sd);
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <div
-            className="rows bar-chart__bar"
-            style={{ width: right + "%", position: "absolute", left: 0 }}
-            title={ title }
-          />
-          <div
-            className="rows-dev bar-chart__bar bar-chart__bar--dev"
-            style={{ width: spread + "%", position: "absolute", left: width + "%" }}
-            title={ title }
-          />
+          <ToolTipWrapper text={ title }>
+            <div
+              className="rows bar-chart__bar"
+              style={{ width: right + "%", position: "absolute", left: 0 }}
+            />
+            <div
+              className="rows-dev bar-chart__bar bar-chart__bar--dev"
+              style={{ width: spread + "%", position: "absolute", left: width + "%" }}
+            />
+          </ToolTipWrapper>
         </div>
       );
     },
@@ -232,6 +239,8 @@ export function latencyBreakdown(s: StatementStatistics) {
     overallMean + overallSd,
   );
 
+  const format = (v: number) => Duration(v * 1e9);
+
   const scale = d3.scale.linear()
     .domain([0, max])
     .range([0, 100]);
@@ -241,19 +250,19 @@ export function latencyBreakdown(s: StatementStatistics) {
       const width = scale(clamp(parseMean - parseSd));
       const right = scale(parseMean);
       const spread = scale(parseSd + (parseSd > parseMean ? parseMean : parseSd));
-      const title = "Parse Latency.  Mean: " + parseMean + " Std. Dev.: " + parseSd;
+      const title = "Parse Latency.  Mean: " + format(parseMean) + " Std. Dev.: " + format(parseSd);
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <div
-            className="latency-parse bar-chart__bar"
-            style={{ width: right + "%", position: "absolute", left: 0 }}
-            title={ title }
-          />
-          <div
-            className="latency-parse-dev bar-chart__bar bar-chart__bar--dev"
-            style={{ width: spread + "%", position: "absolute", left: width + "%" }}
-            title={ title }
-          />
+          <ToolTipWrapper text={ title }>
+            <div
+              className="latency-parse bar-chart__bar"
+              style={{ width: right + "%", position: "absolute", left: 0 }}
+            />
+            <div
+              className="latency-parse-dev bar-chart__bar bar-chart__bar--dev"
+              style={{ width: spread + "%", position: "absolute", left: width + "%" }}
+            />
+          </ToolTipWrapper>
         </div>
       );
     },
@@ -263,19 +272,19 @@ export function latencyBreakdown(s: StatementStatistics) {
       const width = scale(clamp(planMean - planSd));
       const right = scale(planMean);
       const spread = scale(planSd + (planSd > planMean ? planMean : planSd));
-      const title = "Plan Latency.  Mean: " + planMean + " Std. Dev.: " + planSd;
+      const title = "Plan Latency.  Mean: " + format(planMean) + " Std. Dev.: " + format(planSd);
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <div
-            className="latency-plan bar-chart__bar"
-            style={{ width: right + "%", position: "absolute", left: left + "%" }}
-            title={ title }
-          />
-          <div
-            className="latency-plan-dev bar-chart__bar bar-chart__bar--dev"
-            style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
-            title={ title }
-          />
+          <ToolTipWrapper text={ title }>
+            <div
+              className="latency-plan bar-chart__bar"
+              style={{ width: right + "%", position: "absolute", left: left + "%" }}
+            />
+            <div
+              className="latency-plan-dev bar-chart__bar bar-chart__bar--dev"
+              style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
+            />
+          </ToolTipWrapper>
         </div>
       );
     },
@@ -285,19 +294,19 @@ export function latencyBreakdown(s: StatementStatistics) {
       const width = scale(clamp(runMean - runSd));
       const right = scale(runMean);
       const spread = scale(runSd + (runSd > runMean ? runMean : runSd));
-      const title = "Run Latency.  Mean: " + runMean + " Std. Dev.: " + runSd;
+      const title = "Run Latency.  Mean: " + format(runMean) + " Std. Dev.: " + format(runSd);
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <div
-            className="latency-run bar-chart__bar"
-            style={{ width: right + "%", position: "absolute", left: left + "%" }}
-            title={ title }
-          />
-          <div
-            className="latency-run-dev bar-chart__bar bar-chart__bar--dev"
-            style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
-            title={ title }
-          />
+          <ToolTipWrapper text={ title }>
+            <div
+              className="latency-run bar-chart__bar"
+              style={{ width: right + "%", position: "absolute", left: left + "%" }}
+            />
+            <div
+              className="latency-run-dev bar-chart__bar bar-chart__bar--dev"
+              style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
+            />
+          </ToolTipWrapper>
         </div>
       );
     },
@@ -307,19 +316,19 @@ export function latencyBreakdown(s: StatementStatistics) {
       const width = scale(clamp(overheadMean - overheadSd));
       const right = scale(overheadMean);
       const spread = scale(overheadSd + (overheadSd > overheadMean ? overheadMean : overheadSd));
-      const title = "Overhead Latency.  Mean: " + overheadMean + " Std. Dev.: " + overheadSd;
+      const title = "Overhead Latency.  Mean: " + format(overheadMean) + " Std. Dev.: " + format(overheadSd);
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <div
-            className="latency-overhead bar-chart__bar"
-            style={{ width: right + "%", position: "absolute", left: left + "%" }}
-            title={ title }
-          />
-          <div
-            className="latency-overhead-dev bar-chart__bar bar-chart__bar--dev"
-            style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
-            title={ title }
-          />
+          <ToolTipWrapper text={ title }>
+            <div
+              className="latency-overhead bar-chart__bar"
+              style={{ width: right + "%", position: "absolute", left: left + "%" }}
+            />
+            <div
+              className="latency-overhead-dev bar-chart__bar bar-chart__bar--dev"
+              style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
+            />
+          </ToolTipWrapper>
         </div>
       );
     },
@@ -331,34 +340,31 @@ export function latencyBreakdown(s: StatementStatistics) {
       const overhead = scale(overheadMean);
       const width = scale(clamp(overallMean - overallSd));
       const spread = scale(overallSd + (overallSd > overallMean ? overallMean : overallSd));
-      const title = "Overall Latency.  Mean: " + overallMean + " Std. Dev.: " + overallSd;
+      const title = "Overall Latency.  Mean: " + format(overallMean) + " Std. Dev.: " + format(overallSd);
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <div
-            className="latency-parse bar-chart__bar"
-            style={{ width: parse + "%", position: "absolute", left: 0 }}
-            title={ title }
-          />
-          <div
-            className="latency-plan bar-chart__bar"
-            style={{ width: plan + "%", position: "absolute", left: parse + "%" }}
-            title={ title }
-          />
-          <div
-            className="latency-run bar-chart__bar"
-            style={{ width: run + "%", position: "absolute", left: parse + plan + "%" }}
-            title={ title }
-          />
-          <div
-            className="latency-overhead bar-chart__bar"
-            style={{ width: overhead + "%", position: "absolute", left: parse + plan + run + "%" }}
-            title={ title }
-          />
-          <div
-            className="latency-overall-dev bar-chart__bar bar-chart__bar--dev"
-            style={{ width: spread + "%", position: "absolute", left: width + "%" }}
-            title={ title }
-          />
+          <ToolTipWrapper text={ title }>
+            <div
+              className="latency-parse bar-chart__bar"
+              style={{ width: parse + "%", position: "absolute", left: 0 }}
+            />
+            <div
+              className="latency-plan bar-chart__bar"
+              style={{ width: plan + "%", position: "absolute", left: parse + "%" }}
+            />
+            <div
+              className="latency-run bar-chart__bar"
+              style={{ width: run + "%", position: "absolute", left: parse + plan + "%" }}
+            />
+            <div
+              className="latency-overhead bar-chart__bar"
+              style={{ width: overhead + "%", position: "absolute", left: parse + plan + run + "%" }}
+            />
+            <div
+              className="latency-overall-dev bar-chart__bar bar-chart__bar--dev"
+              style={{ width: spread + "%", position: "absolute", left: width + "%" }}
+            />
+          </ToolTipWrapper>
         </div>
       );
     },

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -294,8 +294,41 @@ export function latencyBreakdown(s: StatementStatistics) {
     },
 
     overallBarChart() {
+      const parse = scale(parseMean);
+      const plan = scale(planMean);
+      const run = scale(runMean);
+      const overhead = scale(overheadMean);
+      const width = scale(clamp(overallMean - overallSd));
+      const spread = scale(overallSd + (overallSd > overallMean ? overallMean : overallSd));
+      const title = "Overall Latency.  Mean: " + overallMean + " Std. Dev.: " + overallSd;
       return (
-        <div>Unimplemented.</div>
+        <div className="bar-chart bar-chart--breakdown">
+          <div
+            className="latency-parse bar-chart__bar"
+            style={{ width: parse + "%", position: "absolute", left: 0 }}
+            title={ title }
+          />
+          <div
+            className="latency-plan bar-chart__bar"
+            style={{ width: plan + "%", position: "absolute", left: parse + "%" }}
+            title={ title }
+          />
+          <div
+            className="latency-run bar-chart__bar"
+            style={{ width: run + "%", position: "absolute", left: parse + plan + "%" }}
+            title={ title }
+          />
+          <div
+            className="latency-overhead bar-chart__bar"
+            style={{ width: overhead + "%", position: "absolute", left: parse + plan + run + "%" }}
+            title={ title }
+          />
+          <div
+            className="latency-overall-dev bar-chart__bar bar-chart__bar--dev"
+            style={{ width: spread + "%", position: "absolute", left: width + "%" }}
+            title={ title }
+          />
+        </div>
       );
     },
   };

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -163,17 +163,12 @@ export function rowsBreakdown(s: StatementStatistics) {
         <div className="bar-chart bar-chart--breakdown">
           <div
             className="rows bar-chart__bar"
-            style={{ width: width + "%" }}
+            style={{ width: right + "%", position: "absolute", left: 0 }}
             title={ title }
           />
           <div
             className="rows-dev bar-chart__bar"
-            style={{ width: spread + "%" }}
-            title={ title }
-          />
-          <div
-            className="rows bar-chart__bar"
-            style={{ width: 1, position: "absolute", left: right + "%" }}
+            style={{ width: spread + "%", position: "absolute", left: width + "%" }}
             title={ title }
           />
         </div>
@@ -220,17 +215,12 @@ export function latencyBreakdown(s: StatementStatistics) {
         <div className="bar-chart bar-chart--breakdown">
           <div
             className="latency-parse bar-chart__bar"
-            style={{ width: width + "%", position: "absolute", left: 0 }}
+            style={{ width: right + "%", position: "absolute", left: 0 }}
             title={ title }
           />
           <div
             className="latency-parse-dev bar-chart__bar"
             style={{ width: spread + "%", position: "absolute", left: width + "%" }}
-            title={ title }
-          />
-          <div
-            className="latency-parse bar-chart__bar"
-            style={{ width: 1, position: "absolute", left: right + "%" }}
             title={ title }
           />
         </div>
@@ -240,24 +230,19 @@ export function latencyBreakdown(s: StatementStatistics) {
     planBarChart() {
       const left = scale(parseMean);
       const width = scale(clamp(planMean - planSd));
-      const right = scale(parseMean + planMean);
+      const right = scale(planMean);
       const spread = scale(planSd + (planSd > planMean ? planMean : planSd));
       const title = "Plan Latency.  Mean: " + planMean + " Std. Dev.: " + planSd;
       return (
         <div className="bar-chart bar-chart--breakdown">
           <div
             className="latency-plan bar-chart__bar"
-            style={{ width: width + "%", position: "absolute", left: left + "%" }}
+            style={{ width: right + "%", position: "absolute", left: left + "%" }}
             title={ title }
           />
           <div
             className="latency-plan-dev bar-chart__bar"
             style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
-            title={ title }
-          />
-          <div
-            className="latency-plan bar-chart__bar"
-            style={{ width: 1, position: "absolute", left: right + "%" }}
             title={ title }
           />
         </div>
@@ -267,24 +252,19 @@ export function latencyBreakdown(s: StatementStatistics) {
     runBarChart() {
       const left = scale(parseMean + planMean);
       const width = scale(clamp(runMean - runSd));
-      const right = scale(parseMean + planMean + runMean);
+      const right = scale(runMean);
       const spread = scale(runSd + (runSd > runMean ? runMean : runSd));
       const title = "Run Latency.  Mean: " + runMean + " Std. Dev.: " + runSd;
       return (
         <div className="bar-chart bar-chart--breakdown">
           <div
             className="latency-run bar-chart__bar"
-            style={{ width: width + "%", position: "absolute", left: left + "%" }}
+            style={{ width: right + "%", position: "absolute", left: left + "%" }}
             title={ title }
           />
           <div
             className="latency-run-dev bar-chart__bar"
             style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
-            title={ title }
-          />
-          <div
-            className="latency-run bar-chart__bar"
-            style={{ width: 1, position: "absolute", left: right + "%" }}
             title={ title }
           />
         </div>
@@ -294,24 +274,19 @@ export function latencyBreakdown(s: StatementStatistics) {
     overheadBarChart() {
       const left = scale(parseMean + planMean + runMean);
       const width = scale(clamp(overheadMean - overheadSd));
-      const right = scale(parseMean + planMean + runMean + overheadMean);
+      const right = scale(overheadMean);
       const spread = scale(overheadSd + (overheadSd > overheadMean ? overheadMean : overheadSd));
       const title = "Overhead Latency.  Mean: " + overheadMean + " Std. Dev.: " + overheadSd;
       return (
         <div className="bar-chart bar-chart--breakdown">
           <div
             className="latency-overhead bar-chart__bar"
-            style={{ width: width + "%", position: "absolute", left: left + "%" }}
+            style={{ width: right + "%", position: "absolute", left: left + "%" }}
             title={ title }
           />
           <div
             className="latency-overhead-dev bar-chart__bar"
             style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
-            title={ title }
-          />
-          <div
-            className="latency-overhead bar-chart__bar"
-            style={{ width: 1, position: "absolute", left: right + "%" }}
             title={ title }
           />
         </div>

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -167,7 +167,7 @@ export function rowsBreakdown(s: StatementStatistics) {
             title={ title }
           />
           <div
-            className="rows-dev bar-chart__bar"
+            className="rows-dev bar-chart__bar bar-chart__bar--dev"
             style={{ width: spread + "%", position: "absolute", left: width + "%" }}
             title={ title }
           />
@@ -219,7 +219,7 @@ export function latencyBreakdown(s: StatementStatistics) {
             title={ title }
           />
           <div
-            className="latency-parse-dev bar-chart__bar"
+            className="latency-parse-dev bar-chart__bar bar-chart__bar--dev"
             style={{ width: spread + "%", position: "absolute", left: width + "%" }}
             title={ title }
           />
@@ -241,7 +241,7 @@ export function latencyBreakdown(s: StatementStatistics) {
             title={ title }
           />
           <div
-            className="latency-plan-dev bar-chart__bar"
+            className="latency-plan-dev bar-chart__bar bar-chart__bar--dev"
             style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
             title={ title }
           />
@@ -263,7 +263,7 @@ export function latencyBreakdown(s: StatementStatistics) {
             title={ title }
           />
           <div
-            className="latency-run-dev bar-chart__bar"
+            className="latency-run-dev bar-chart__bar bar-chart__bar--dev"
             style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
             title={ title }
           />
@@ -285,7 +285,7 @@ export function latencyBreakdown(s: StatementStatistics) {
             title={ title }
           />
           <div
-            className="latency-overhead-dev bar-chart__bar"
+            className="latency-overhead-dev bar-chart__bar bar-chart__bar--dev"
             style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
             title={ title }
           />

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -16,33 +16,33 @@ const longToInt = (d: number | Long) => FixLong(d).toInt();
 const clamp = (i: number) => i < 0 ? 0 : i;
 
 const countBars = [
-  bar("count-first-try", "First Try Count", (d: StatementStatistics) => longToInt(d.stats.first_attempt_count)),
-  bar("count-retry", "Retry Count", (d: StatementStatistics) => longToInt(d.stats.count) - longToInt(d.stats.first_attempt_count)),
+  bar("count-first-try", (d: StatementStatistics) => longToInt(d.stats.first_attempt_count)),
+  bar("count-retry", (d: StatementStatistics) => longToInt(d.stats.count) - longToInt(d.stats.first_attempt_count)),
 ];
 
 const rowsBars = [
-  bar("rows", "Mean Number of Rows", (d: StatementStatistics) => d.stats.num_rows.mean),
+  bar("rows", (d: StatementStatistics) => d.stats.num_rows.mean),
 ];
 
 const latencyBars = [
-  bar("latency-parse", "Mean Parse Latency", (d: StatementStatistics) => d.stats.parse_lat.mean),
-  bar("latency-plan", "Mean Planning Latency", (d: StatementStatistics) => d.stats.plan_lat.mean),
-  bar("latency-run", "Mean Run Latency", (d: StatementStatistics) => d.stats.run_lat.mean),
-  bar("latency-overhead", "Mean Overhead Latency", (d: StatementStatistics) => d.stats.overhead_lat.mean),
+  bar("latency-parse", (d: StatementStatistics) => d.stats.parse_lat.mean),
+  bar("latency-plan", (d: StatementStatistics) => d.stats.plan_lat.mean),
+  bar("latency-run", (d: StatementStatistics) => d.stats.run_lat.mean),
+  bar("latency-overhead", (d: StatementStatistics) => d.stats.overhead_lat.mean),
 ];
 
-const latencyStdDev = bar("latency-overall-dev", "Latency Std. Dev.", (d: StatementStatistics) => stdDevLong(d.stats.service_lat, d.stats.count));
-const rowsStdDev = bar("rows-dev", "Rows Std. Dev.", (d: StatementStatistics) => stdDevLong(d.stats.num_rows, d.stats.count));
+const latencyStdDev = bar("latency-overall-dev", (d: StatementStatistics) => stdDevLong(d.stats.service_lat, d.stats.count));
+const rowsStdDev = bar("rows-dev", (d: StatementStatistics) => stdDevLong(d.stats.num_rows, d.stats.count));
 
-function bar(name: string, title: string, value: (d: StatementStatistics) => number) {
-  return { name, title, value };
+function bar(name: string, value: (d: StatementStatistics) => number) {
+  return { name, value };
 }
 
 function makeBarChart(
   title: string,
-  accessors: { name: string, title: string, value: (d: StatementStatistics) => number }[],
+  accessors: { name: string, value: (d: StatementStatistics) => number }[],
   formatter: (d: number) => string = (x) => `${x}`,
-  stdDevAccessor?: { name: string, title: string, value: (d: StatementStatistics) => number },
+  stdDevAccessor?: { name: string, value: (d: StatementStatistics) => number },
 ) {
   return function barChart(rows: StatementStatistics[] = []) {
     function getTotal(d: StatementStatistics) {
@@ -66,7 +66,7 @@ function makeBarChart(
       }
 
       let sum = 0;
-      const bars = accessors.map(({ name, title, value }) => {
+      const bars = accessors.map(({ name, value }) => {
         const v = value(d);
         sum += v;
         return (
@@ -74,7 +74,6 @@ function makeBarChart(
             key={ name + v }
             className={ name + " bar-chart__bar" }
             style={{ width: scale(v) + "%" }}
-            title={ title + ": " + v }
           />
         );
       });
@@ -84,7 +83,7 @@ function makeBarChart(
           return null;
         }
 
-        const { name, title, value } = stdDevAccessor;
+        const { name, value } = stdDevAccessor;
 
         const stddev = value(d);
         const width = stddev + (stddev > sum ? sum : stddev);
@@ -94,7 +93,6 @@ function makeBarChart(
           <div
             className={ name + " bar-chart__bar bar-chart__bar--dev" }
             style={{ width: scale(width) + "%", left: scale(left) + "%" }}
-            title={ title + ": " + stddev }
           />
         );
       }

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -10,11 +10,12 @@ import Loading from "src/views/shared/components/loading";
 import spinner from "assets/spinner.gif";
 import { refreshQueries } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
+import { NumericStat, stdDev, combineStatementStats, flattenStatementStats, StatementStatistics, ExecutionStatistics } from "src/util/appStats";
 import { statementAttr, appAttr } from "src/util/constants";
 import { FixLong } from "src/util/fixLong";
 import { Duration } from "src/util/format";
 import { intersperse } from "src/util/intersperse";
-import { NumericStat, stdDev, combineStatementStats, flattenStatementStats, StatementStatistics, ExecutionStatistics } from "src/util/appStats";
+import { Pick } from "src/util/pick";
 import { SqlBox } from "src/views/shared/components/sql/box";
 import { SummaryBar, SummaryHeadlineStat } from "src/views/shared/components/summaryBar";
 
@@ -259,9 +260,11 @@ function renderBools(bools: boolean[]) {
   return "(both included)";
 }
 
-const selectStatement = createSelector(
-  (state: AdminUIState) => state.cachedData.queries.data && state.cachedData.queries.data.queries,
-  (_state: AdminUIState, props: RouterState) => props,
+type QueriesState = Pick<AdminUIState, "cachedData", "queries">;
+
+export const selectStatement = createSelector(
+  (state: QueriesState) => state.cachedData.queries.data && state.cachedData.queries.data.queries,
+  (_state: QueriesState, props: { params: { [key: string]: string } }) => props,
   (queries, props) => {
     if (!queries) {
       return null;

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -14,7 +14,7 @@ import { statementAttr, appAttr } from "src/util/constants";
 import { FixLong } from "src/util/fixLong";
 import { Duration } from "src/util/format";
 import { intersperse } from "src/util/intersperse";
-import { NumericStat, stdDev, combineStatementStats, flattenStatementStats, StatementStatistics } from "src/util/appStats";
+import { NumericStat, stdDev, combineStatementStats, flattenStatementStats, StatementStatistics, ExecutionStatistics } from "src/util/appStats";
 import { SqlBox } from "src/views/shared/components/sql/box";
 import { SummaryBar, SummaryHeadlineStat } from "src/views/shared/components/summaryBar";
 
@@ -268,10 +268,18 @@ const selectStatement = createSelector(
     }
 
     const statement = props.params[statementAttr];
-    const app = props.params[appAttr];
+    let app = props.params[appAttr];
+    let predicate = (stmt: ExecutionStatistics) => stmt.statement === statement;
+
+    if (app) {
+        if (app === "(unset)") {
+            app = "";
+        }
+        predicate = (stmt: ExecutionStatistics) => stmt.statement === statement && stmt.app === app;
+    }
 
     const statements = flattenStatementStats(queries);
-    const results = _.filter(statements, stmt => stmt.statement === statement && (!app || stmt.app === app));
+    const results = _.filter(statements, predicate);
 
     return {
       statement,

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -137,7 +137,7 @@ class StatementDetails extends React.Component<StatementDetailsProps> {
 
     const { firstAttemptsBarChart, retriesBarChart, maxRetriesBarChart } = countBreakdown(this.props.statement);
     const { rowsBarChart } = rowsBreakdown(this.props.statement);
-    const { parseBarChart, planBarChart, runBarChart, overheadBarChart } = latencyBreakdown(this.props.statement);
+    const { parseBarChart, planBarChart, runBarChart, overheadBarChart, overallBarChart } = latencyBreakdown(this.props.statement);
 
     return (
       <div className="content l-columns">
@@ -182,7 +182,7 @@ class StatementDetails extends React.Component<StatementDetailsProps> {
                 { name: "Plan", value: stats.plan_lat, bar: planBarChart },
                 { name: "Run", value: stats.run_lat, bar: runBarChart },
                 { name: "Overhead", value: stats.overhead_lat, bar: overheadBarChart },
-                { name: "Overall", value: stats.service_lat },
+                { name: "Overall", value: stats.service_lat, bar: overallBarChart },
               ]}
             />
           </section>

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -190,7 +190,7 @@ class StatementDetails extends React.Component<StatementDetailsProps> {
             <h3>Row Count</h3>
             <NumericStatTable
               count={ count }
-              format={ (v: number) => "" + Math.round(v) }
+              format={ (v: number) => "" + (Math.round(v * 100) / 100) }
               rows={[
                 { name: "Rows", value: stats.num_rows, bar: rowsBarChart },
               ]}

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -12,6 +12,31 @@
     font-style italic
     color $body-color
 
+.last-cleared-tooltip
+  &__tooltip
+    width 36px  // Reserve space for 10px padding around centered 16px icon
+    height 16px
+    display inline-block
+
+  &__tooltip-hover-area
+    width 100%
+    padding 0px 10px
+
+  &__info-icon
+    width 16px
+    height 16px
+    border-radius 50%
+    border 1px solid $tooltip-color
+    font-size 12px
+    line-height 14px  // Visual tweak to vertically center the "i"
+    text-align center
+    color $tooltip-color
+
+  .hover-tooltip--hovered &__info-icon
+    border-color $body-color
+    color $body-color
+
+
 .app-name
   &__unset
     color $tooltip-color

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -91,6 +91,14 @@
     background-color lighten($alert-color, 50%)
     border-left 1px solid lighten($alert-color, 50%)
 
+  .latency-overall
+    background-color $body-color
+    border-left 1px solid $body-color
+
+  .latency-overall-dev
+    background-color lighten($body-color, 50%)
+    border-left 1px solid lighten($body-color, 50%)
+
 .numeric-stats-table
   @extend $table-base
 

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -53,6 +53,8 @@
   .rows-dev
     background-color lighten($link-color, 50%)
     border-left 1px solid lighten($link-color, 50%)
+    height 0.6em
+    top 0.2em
 
   .latency-parse
     background-color $alert-color
@@ -61,6 +63,8 @@
   .latency-parse-dev
     background-color lighten($alert-color, 50%)
     border-left 1px solid lighten($alert-color, 50%)
+    height 0.6em
+    top 0.2em
 
   .latency-plan
     background-color $warning-color
@@ -69,6 +73,8 @@
   .latency-plan-dev
     background-color lighten($warning-color, 50%)
     border-left 1px solid lighten($warning-color, 50%)
+    height 0.6em
+    top 0.2em
 
   .latency-run
     background-color $link-color
@@ -77,6 +83,8 @@
   .latency-run-dev
     background-color lighten($link-color, 50%)
     border-left 1px solid lighten($link-color, 50%)
+    height 0.6em
+    top 0.2em
 
   .latency-overhead
     background-color $alert-color
@@ -85,6 +93,8 @@
   .latency-overhead-dev
     background-color lighten($alert-color, 50%)
     border-left 1px solid lighten($alert-color, 50%)
+    height 0.6em
+    top 0.2em
 
 .numeric-stats-table
   @extend $table-base

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -38,6 +38,11 @@
     height 100%
     margin-left -1px
 
+    &--dev
+      position absolute
+      height 60%
+      top 20%
+
   .count-first-try
     background-color $link-color
     border-left 1px solid $link-color
@@ -53,8 +58,6 @@
   .rows-dev
     background-color lighten($link-color, 50%)
     border-left 1px solid lighten($link-color, 50%)
-    height 0.6em
-    top 0.2em
 
   .latency-parse
     background-color $alert-color
@@ -63,8 +66,6 @@
   .latency-parse-dev
     background-color lighten($alert-color, 50%)
     border-left 1px solid lighten($alert-color, 50%)
-    height 0.6em
-    top 0.2em
 
   .latency-plan
     background-color $warning-color
@@ -73,8 +74,6 @@
   .latency-plan-dev
     background-color lighten($warning-color, 50%)
     border-left 1px solid lighten($warning-color, 50%)
-    height 0.6em
-    top 0.2em
 
   .latency-run
     background-color $link-color
@@ -83,8 +82,6 @@
   .latency-run-dev
     background-color lighten($link-color, 50%)
     border-left 1px solid lighten($link-color, 50%)
-    height 0.6em
-    top 0.2em
 
   .latency-overhead
     background-color $alert-color
@@ -93,8 +90,6 @@
   .latency-overhead-dev
     background-color lighten($alert-color, 50%)
     border-left 1px solid lighten($alert-color, 50%)
-    height 0.6em
-    top 0.2em
 
 .numeric-stats-table
   @extend $table-base

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -36,6 +36,10 @@
     border-color $body-color
     color $body-color
 
+.bar-tooltip
+  &__tooptip-hover-area
+    width 100%
+    height 100%
 
 .app-name
   &__unset
@@ -60,13 +64,13 @@
 
   &__bar
     display inline-block
-    height 100%
+    height 1em
     margin-left -1px
 
     &--dev
       position absolute
-      height 60%
-      top 20%
+      height 0.6em
+      top 0.2em
 
   .count-first-try
     background-color $link-color

--- a/pkg/ui/src/views/statements/statementsPage.spec.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.spec.tsx
@@ -1,0 +1,268 @@
+import { assert } from "chai";
+import Long from "long";
+import moment from "moment";
+
+import "src/protobufInit";
+import * as protos from "src/js/protos";
+import { CollectedStatementStatistics } from "src/util/appStats";
+import { appAttr } from "src/util/constants";
+import { selectStatements, selectApps, selectTotalFingerprints, selectLastReset } from "./statementsPage";
+
+describe("selectStatements", () => {
+  it("returns null if the queries data is invalid", () => {
+    const state = makeInvalidState();
+    const props = makeEmptyRouteProps();
+
+    const result = selectStatements(state, props);
+
+    assert.isNull(result);
+  });
+
+  it("returns the statements currently loaded", () => {
+    const stmtA = makeFingerprint(1);
+    const stmtB = makeFingerprint(2, "foobar");
+    const stmtC = makeFingerprint(3, "another");
+    const state = makeStateWithQueries([stmtA, stmtB, stmtC]);
+    const props = makeEmptyRouteProps();
+
+    const result = selectStatements(state, props);
+
+    assert.equal(result.length, 3);
+
+    const expectedFingerprints = [stmtA, stmtB, stmtC].map(stmt => stmt.key.query);
+    expectedFingerprints.sort();
+    const actualFingerprints = result.map(stmt => stmt.statement);
+    actualFingerprints.sort();
+    assert.deepEqual(actualFingerprints, expectedFingerprints);
+  });
+
+  it("coalesces statements from different apps", () => {
+    const stmtA = makeFingerprint(1);
+    const stmtB = makeFingerprint(1, "foobar");
+    const stmtC = makeFingerprint(1, "another");
+    const sumCount = stmtA.stats.count.add(stmtB.stats.count.add(stmtC.stats.count)).toNumber();
+    const state = makeStateWithQueries([stmtA, stmtB, stmtC]);
+    const props = makeEmptyRouteProps();
+
+    const result = selectStatements(state, props);
+
+    assert.equal(result.length, 1);
+    assert.equal(result[0].statement, stmtA.key.query);
+    assert.equal(result[0].stats.count.toNumber(), sumCount);
+  });
+
+  it("coalesces statements with differing distSQL and failed values", () => {
+    const state = makeStateWithQueries([
+      makeFingerprint(1, "", false, false),
+      makeFingerprint(1, "", false, true),
+      makeFingerprint(1, "", true, false),
+      makeFingerprint(1, "", true, true),
+    ]);
+    const props = makeEmptyRouteProps();
+
+    const result = selectStatements(state, props);
+
+    assert.equal(result.length, 1);
+  });
+
+  it("filters out statements when app param is set", () => {
+    const state = makeStateWithQueries([
+      makeFingerprint(1, "foo"),
+      makeFingerprint(2, "bar"),
+      makeFingerprint(3, "baz"),
+    ]);
+    const props = makeRoutePropsWithApp("foo");
+
+    const result = selectStatements(state, props);
+
+    assert.equal(result.length, 1);
+  });
+
+  it("filters out statements with app set when app param is \"(unset)\"", () => {
+    const state = makeStateWithQueries([
+      makeFingerprint(1, ""),
+      makeFingerprint(2, "bar"),
+      makeFingerprint(3, "baz"),
+    ]);
+    const props = makeRoutePropsWithApp("(unset)");
+
+    const result = selectStatements(state, props);
+
+    assert.equal(result.length, 1);
+  });
+});
+
+describe("selectApps", () => {
+  it("returns an empty array if the queries data is invalid", () => {
+    const state = makeInvalidState();
+
+    const result = selectApps(state);
+
+    assert.deepEqual(result, []);
+  });
+
+  it("returns all the apps that appear in the statements", () => {
+    const state = makeStateWithQueries([
+      makeFingerprint(1),
+      makeFingerprint(1, "foobar"),
+      makeFingerprint(2, "foobar"),
+      makeFingerprint(3, "cockroach sql"),
+    ]);
+
+    const result = selectApps(state);
+
+    assert.deepEqual(result, ["(unset)", "foobar", "cockroach sql"]);
+  });
+});
+
+describe("selectTotalFingerprints", () => {
+  it("returns zero if the queries data is invalid", () => {
+    const state = makeInvalidState();
+
+    const result = selectTotalFingerprints(state);
+
+    assert.equal(result, 0);
+  });
+
+  it("returns the number of statement fingerprints", () => {
+    const state = makeStateWithQueries([
+      makeFingerprint(1),
+      makeFingerprint(2),
+      makeFingerprint(3),
+    ]);
+
+    const result = selectTotalFingerprints(state);
+
+    assert.equal(result, 3);
+  });
+
+  it("coalesces statements from different apps", () => {
+    const state = makeStateWithQueries([
+      makeFingerprint(1),
+      makeFingerprint(1, "foobar"),
+      makeFingerprint(1, "another"),
+    ]);
+
+    const result = selectTotalFingerprints(state);
+
+    assert.equal(result, 1);
+  });
+
+  it("coalesces statements with differing distSQL and failed keys", () => {
+    const state = makeStateWithQueries([
+      makeFingerprint(1, "", false, false),
+      makeFingerprint(1, "", false, true),
+      makeFingerprint(1, "", true, false),
+      makeFingerprint(1, "", true, true),
+    ]);
+
+    const result = selectTotalFingerprints(state);
+
+    assert.equal(result, 1);
+  });
+});
+
+describe("selectLastReset", () => {
+  it("returns \"unknown\" if the queries data is invalid", () => {
+    const state = makeInvalidState();
+
+    const result = selectLastReset(state);
+
+    assert.equal(result, "unknown");
+  });
+
+  it("returns the formatted timestamp if valid", () => {
+    const timestamp = 92951700;
+    const state = makeStateWithLastReset(timestamp);
+
+    const result = selectLastReset(state);
+
+    assert.equal(moment.utc(result).unix(), timestamp);
+  });
+});
+
+function makeFingerprint(id: number, app: string = "", distSQL: boolean = false, failed: boolean = false) {
+  return {
+    key: {
+      query: "SELECT * FROM table_" + id + " WHERE true",
+      app,
+      distSQL,
+      failed,
+    },
+    stats: makeStats(),
+  };
+}
+
+function makeStats() {
+  return {
+    count: Long.fromNumber(1),
+    first_attempt_count: Long.fromNumber(1),
+    max_retries: Long.fromNumber(0),
+    num_rows: makeStat(),
+    parse_lat: makeStat(),
+    plan_lat: makeStat(),
+    run_lat: makeStat(),
+    overhead_lat: makeStat(),
+    service_lat: makeStat(),
+  };
+}
+
+function makeStat() {
+  return {
+    mean: 10,
+    squared_diffs: 1,
+  };
+}
+
+function makeInvalidState() {
+  return {
+    cachedData: {
+      queries: {
+        inFlight: true,
+        valid: false,
+      },
+    },
+  };
+}
+
+function makeStateWithQueriesAndLastReset(queries: CollectedStatementStatistics[], lastReset: number) {
+  return {
+    cachedData: {
+      queries: {
+        data: protos.cockroach.server.serverpb.QueriesResponse.fromObject({
+          queries,
+          last_reset: {
+            seconds: lastReset,
+            nanos: 0,
+          },
+        }),
+        inFlight: false,
+        valid: true,
+      },
+    },
+  };
+}
+
+function makeStateWithQueries(queries: CollectedStatementStatistics[]) {
+  return makeStateWithQueriesAndLastReset(queries, 0);
+}
+
+function makeStateWithLastReset(lastReset: number) {
+  return makeStateWithQueriesAndLastReset([], lastReset);
+}
+
+function makeRoutePropsWithParams(params: { [key: string]: string }) {
+  return {
+    params,
+  };
+}
+
+function makeEmptyRouteProps() {
+  return makeRoutePropsWithParams({});
+}
+
+function makeRoutePropsWithApp(app: string) {
+  return makeRoutePropsWithParams({
+    [appAttr]: app,
+  });
+}

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -43,11 +43,12 @@ interface StatementsPageState {
   sortSetting: SortSetting;
 }
 
-function StatementLink(props: { statement: string }) {
+function StatementLink(props: { statement: string, app: string }) {
   const summary = summarize(props.statement);
+  const base = props.app ? `/statement/${props.app}` : "/statement";
 
   return (
-    <Link to={ `/statement/${encodeURIComponent(props.statement)}` }>
+    <Link to={ `${base}/${encodeURIComponent(props.statement)}` }>
       <div title={ props.statement }>{ shortStatement(summary, props.statement) }</div>
     </Link>
   );
@@ -71,7 +72,7 @@ function calculateCumulativeTime(query: CollectedStatementStatistics$Properties)
   return count * latency;
 }
 
-function makeStatementsColumns(statements: CollectedStatementStatistics$Properties[])
+function makeStatementsColumns(statements: CollectedStatementStatistics$Properties[], selectedApp: string)
     : ColumnDescriptor<CollectedStatementStatistics$Properties>[] {
   const countBar = countBarChart(statements);
   const rowsBar = rowsBarChart(statements);
@@ -81,7 +82,7 @@ function makeStatementsColumns(statements: CollectedStatementStatistics$Properti
     {
       title: "Statement",
       className: "statements-table__col-query-text",
-      cell: (query) => <StatementLink statement={ query.key.query } />,
+      cell: (query) => <StatementLink statement={ query.key.query } app={ selectedApp } />,
       sort: (query) => query.key.query,
     },
     {
@@ -173,7 +174,7 @@ class StatementsPage extends React.Component<StatementsPageProps & RouteProps, S
         <StatementsSortedTable
           className="statements-table"
           data={queries}
-          columns={makeStatementsColumns(queries)}
+          columns={makeStatementsColumns(queries, selectedApp)}
           sortSetting={this.state.sortSetting}
           onChangeSortSetting={this.changeSortSetting}
         />
@@ -185,7 +186,9 @@ class StatementsPage extends React.Component<StatementsPageProps & RouteProps, S
     return (
       <section className="section" style={{ maxWidth: "none" }}>
         <Helmet>
-          <title>Statements</title>
+          <title>
+            { this.props.params[appAttr] ? this.props.params[appAttr] + " App | Statements" : "Statements"}
+          </title>
         </Helmet>
 
         <h1 style={{ marginBottom: 20 }}>Statements</h1>

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -42,7 +42,7 @@ interface StatementsPageProps {
   valid: boolean;
   statements: AggregateStatistics[];
   apps: string[];
-  totalStatements: number;
+  totalFingerprints: number;
   lastReset: string;
   refreshQueries: typeof refreshQueries;
 }
@@ -179,7 +179,7 @@ class StatementsPage extends React.Component<StatementsPageProps & RouteProps, S
 
         <div className="statements__last-hour-note" style={{ marginTop: 20 }}>
           {this.props.statements.length}
-          {selectedApp ? ` of ${this.props.totalStatements} ` : " "}
+          {selectedApp ? ` of ${this.props.totalFingerprints} ` : " "}
           statement fingerprints.
           Last cleared {this.props.lastReset}.
           <div className="last-cleared-tooltip__tooltip">
@@ -226,6 +226,8 @@ class StatementsPage extends React.Component<StatementsPageProps & RouteProps, S
 
 }
 
+// selectStatements returns the array of AggregateStatistics to show on the
+// StatementsPage, based on if the appAttr route parameter is set.
 const selectStatements = createSelector(
   (state: AdminUIState) => state.cachedData.queries,
   (_state: AdminUIState, props: RouteProps) => props,
@@ -262,6 +264,8 @@ const selectStatements = createSelector(
   },
 );
 
+// selectApps returns the array of all apps with statement statistics present
+// in the data.
 const selectApps = createSelector(
   (state: AdminUIState) => state.cachedData.queries,
   (state: CachedDataReducerState<QueriesResponseMessage>) => {
@@ -284,7 +288,9 @@ const selectApps = createSelector(
   },
 );
 
-const selectTotalStatements = createSelector(
+// selectTotalFingerprints returns the count of distinct statement fingerprints
+// present in the data.
+const selectTotalFingerprints = createSelector(
   (state: AdminUIState) => state.cachedData.queries,
   (state: CachedDataReducerState<QueriesResponseMessage>) => {
     if (!state.data) {
@@ -295,6 +301,8 @@ const selectTotalStatements = createSelector(
   },
 );
 
+// selectLastReset returns a string displaying the last time the statement
+// statistics were reset.
 const selectLastReset = createSelector(
   (state: AdminUIState) => state.cachedData.queries,
   (state: CachedDataReducerState<QueriesResponseMessage>) => {
@@ -311,7 +319,7 @@ const StatementsPageConnected = connect(
   (state: AdminUIState, props: RouteProps) => ({
     statements: selectStatements(state, props),
     apps: selectApps(state),
-    totalStatements: selectTotalStatements(state),
+    totalFingerprints: selectTotalFingerprints(state),
     lastReset: selectLastReset(state),
     valid: state.cachedData.queries.valid,
   }),

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -9,7 +9,7 @@ import spinner from "assets/spinner.gif";
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import { AdminUIState } from "src/redux/state";
 import { FixLong } from "src/util/fixLong";
-import Print from "src/views/reports/containers/range/print";
+import { PrintTime } from "src/views/reports/containers/range/print";
 import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
 import Loading from "src/views/shared/components/loading";
 import { PageConfig, PageConfigItem } from "src/views/shared/components/pageconfig";
@@ -20,7 +20,9 @@ import { refreshQueries } from "src/redux/apiReducers";
 import { QueriesResponseMessage } from "src/util/api";
 import { aggregateStatementStats, flattenStatementStats, combineStatementStats, StatementStatistics, ExecutionStatistics } from "src/util/appStats";
 import { appAttr } from "src/util/constants";
+import { TimestampToMoment } from "src/util/convert";
 import { Duration } from "src/util/format";
+import { Pick } from "src/util/pick";
 import { summarize, StatementSummary } from "src/util/sql/summarize";
 
 import { countBarChart, rowsBarChart, latencyBarChart } from "./barCharts";
@@ -223,14 +225,15 @@ class StatementsPage extends React.Component<StatementsPageProps & RouteProps, S
       </section>
     );
   }
-
 }
+
+type QueriesState = Pick<AdminUIState, "cachedData", "queries">;
 
 // selectStatements returns the array of AggregateStatistics to show on the
 // StatementsPage, based on if the appAttr route parameter is set.
-const selectStatements = createSelector(
-  (state: AdminUIState) => state.cachedData.queries,
-  (_state: AdminUIState, props: RouteProps) => props,
+export const selectStatements = createSelector(
+  (state: QueriesState) => state.cachedData.queries,
+  (_state: QueriesState, props: { params: { [key: string]: string } }) => props,
   (state: CachedDataReducerState<QueriesResponseMessage>, props: RouteProps) => {
     if (!state.data) {
       return null;
@@ -266,8 +269,8 @@ const selectStatements = createSelector(
 
 // selectApps returns the array of all apps with statement statistics present
 // in the data.
-const selectApps = createSelector(
-  (state: AdminUIState) => state.cachedData.queries,
+export const selectApps = createSelector(
+  (state: QueriesState) => state.cachedData.queries,
   (state: CachedDataReducerState<QueriesResponseMessage>) => {
     if (!state.data) {
       return [];
@@ -290,8 +293,8 @@ const selectApps = createSelector(
 
 // selectTotalFingerprints returns the count of distinct statement fingerprints
 // present in the data.
-const selectTotalFingerprints = createSelector(
-  (state: AdminUIState) => state.cachedData.queries,
+export const selectTotalFingerprints = createSelector(
+  (state: QueriesState) => state.cachedData.queries,
   (state: CachedDataReducerState<QueriesResponseMessage>) => {
     if (!state.data) {
       return 0;
@@ -303,20 +306,20 @@ const selectTotalFingerprints = createSelector(
 
 // selectLastReset returns a string displaying the last time the statement
 // statistics were reset.
-const selectLastReset = createSelector(
-  (state: AdminUIState) => state.cachedData.queries,
+export const selectLastReset = createSelector(
+  (state: QueriesState) => state.cachedData.queries,
   (state: CachedDataReducerState<QueriesResponseMessage>) => {
     if (!state.data) {
       return "unknown";
     }
 
-    return Print.Timestamp(state.data.last_reset);
+    return PrintTime(TimestampToMoment(state.data.last_reset));
   },
 );
 
 // tslint:disable-next-line:variable-name
 const StatementsPageConnected = connect(
-  (state: AdminUIState, props: RouteProps) => ({
+  (state: QueriesState, props: RouteProps) => ({
     statements: selectStatements(state, props),
     apps: selectApps(state),
     totalFingerprints: selectTotalFingerprints(state),

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -15,6 +15,7 @@ import Loading from "src/views/shared/components/loading";
 import { PageConfig, PageConfigItem } from "src/views/shared/components/pageconfig";
 import { ColumnDescriptor, SortedTable } from "src/views/shared/components/sortedtable";
 import { SortSetting } from "src/views/shared/components/sortabletable";
+import { ToolTipWrapper } from "src/views/shared/components/toolTip";
 import { refreshQueries } from "src/redux/apiReducers";
 import { QueriesResponseMessage } from "src/util/api";
 import { aggregateStatementStats, flattenStatementStats, combineStatementStats, StatementStatistics, ExecutionStatistics } from "src/util/appStats";
@@ -155,6 +156,14 @@ class StatementsPage extends React.Component<StatementsPageProps & RouteProps, S
     const appOptions = [{ value: "", label: "All" }];
     this.props.apps.forEach(app => appOptions.push({ value: app, label: app }));
 
+    const lastClearedHelpText = (
+      <React.Fragment>
+        Statement history is cleared once an hour by default, which can be
+        configured with the cluster setting{" "}
+        <code><pre style={{ display: "inline-block" }}>diagnostics.reporting.interval</pre></code>.
+      </React.Fragment>
+    );
+
     return (
       <div className="statements">
         <PageConfig>
@@ -173,10 +182,13 @@ class StatementsPage extends React.Component<StatementsPageProps & RouteProps, S
           {selectedApp ? ` of ${this.props.totalStatements} ` : " "}
           statement fingerprints.
           Last cleared {this.props.lastReset}.
-          <br />
-          Statement history is cleared once an hour by default, configured by
-          the cluster setting{" "}
-          <code><pre style={{ display: "inline-block" }}>diagnostics.reporting.interval</pre></code>.
+          <div className="last-cleared-tooltip__tooltip">
+            <ToolTipWrapper text={lastClearedHelpText}>
+              <div className="last-cleared-tooltip__tooltip-hover-area">
+                <div className="last-cleared-tooltip__info-icon">i</div>
+              </div>
+            </ToolTipWrapper>
+          </div>
         </div>
 
         <StatementsSortedTable

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -52,7 +52,7 @@ interface StatementsPageState {
 
 function StatementLink(props: { statement: string, app: string }) {
   const summary = summarize(props.statement);
-  const base = props.app ? `/statement/${props.app}` : "/statement";
+  const base = props.app ? `/statements/${props.app}` : "/statement";
 
   return (
     <Link to={ `${base}/${encodeURIComponent(props.statement)}` }>

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -172,8 +172,11 @@ class StatementsPage extends React.Component<StatementsPageProps & RouteProps, S
           {this.props.statements.length}
           {selectedApp ? ` of ${this.props.totalStatements} ` : " "}
           statement fingerprints.
-          Query history is cleared once an hour;
-          last cleared {this.props.lastReset}.
+          Last cleared {this.props.lastReset}.
+          <br />
+          Statement history is cleared once an hour by default, configured by
+          the cluster setting{" "}
+          <code><pre style={{ display: "inline-block" }}>diagnostics.reporting.interval</pre></code>.
         </div>
 
         <StatementsSortedTable

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -152,7 +152,7 @@ class StatementsPage extends React.Component<StatementsPageProps & RouteProps, S
     }
 
     const selectedApp = this.props.params[appAttr] || "";
-    const appOptions = [{ value: "", label: "All" }, { value: "(unset)", label: "(unset)"  }];
+    const appOptions = [{ value: "", label: "All" }];
     this.props.apps.forEach(app => appOptions.push({ value: app, label: app }));
 
     return (
@@ -254,15 +254,18 @@ const selectApps = createSelector(
       return [];
     }
 
+    let sawBlank = false;
     const apps: { [app: string]: boolean } = {};
     state.data.queries.forEach(
       (statement: CollectedStatementStatistics$Properties) => {
         if (statement.key.app) {
           apps[statement.key.app] = true;
+        } else {
+          sawBlank = true;
         }
       },
     );
-    return Object.keys(apps);
+    return (sawBlank ? ["(unset)"] : []).concat(Object.keys(apps));
   },
 );
 

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -59,7 +59,13 @@ function StatementLink(props: { statement: string, app: string }) {
 
   return (
     <Link to={ `${base}/${encodeURIComponent(props.statement)}` }>
-      <div title={ props.statement }>{ shortStatement(summary, props.statement) }</div>
+      <div className="__tooltip">
+        <ToolTipWrapper text={ <pre style={{ whiteSpace: "pre-wrap" }}>{ props.statement }</pre> }>
+          <div className="last-cleared-tooltip__tooltip-hover-area">
+            { shortStatement(summary, props.statement) }
+          </div>
+        </ToolTipWrapper>
+      </div>
     </Link>
   );
 }


### PR DESCRIPTION
Previously we had been a bit lazy about the apps that statement statistics roll into, but feedback highlighted that the app was an important distinction for users.  This adds support for apps to the statements list and details pages.

The statements list now has a filter above the list to choose an app:
<img width="548" alt="screen shot 2018-06-25 at 1 04 56 pm" src="https://user-images.githubusercontent.com/793969/41864643-aeba45bc-7878-11e8-85ff-60d39d71beb6.png">

The details page now lists all apps a query appears in (when viewing all apps) or just the stats relevant to a single app.
<img width="466" alt="screen shot 2018-06-25 at 1 05 05 pm" src="https://user-images.githubusercontent.com/793969/41864691-d196db7c-7878-11e8-89d5-32717753a935.png">

Fixes: #26990 