### PR TITLE
distsql: do not plan against unhealthy nodes

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -932,6 +932,7 @@ func (dsp *DistSQLPlanner) getNodeIDForScan(
 	nodeID := replInfo.NodeDesc.NodeID
 	if err := dsp.checkNodeHealthAndVersion(planCtx, replInfo.NodeDesc); err != nil {
 		log.Eventf(planCtx.ctx, "not planning on node %d. %v", nodeID, err)
+		return dsp.nodeDesc.NodeID, nil
 	}
 	return nodeID, nil
 }

--- a/pkg/sql/distsqlplan/physical_plan.go
+++ b/pkg/sql/distsqlplan/physical_plan.go
@@ -719,7 +719,7 @@ func (p *PhysicalPlan) PopulateEndpoints(nodeAddresses map[roachpb.NodeID]string
 			var ok bool
 			endpoint.TargetAddr, ok = nodeAddresses[p2.Node]
 			if !ok {
-				panic(fmt.Sprintf("node %d node in nodeAddresses map", p2.Node))
+				panic(fmt.Sprintf("node %d not in nodeAddresses map", p2.Node))
 			}
 		}
 


### PR DESCRIPTION
A bug was introduced in 0cd1da0 which allows table readers to be planned
on unhealthy or incompatible nodes for LIMIT queries. They should use
the gateway node instead. This was causing a panic in execution because
the node was not in the nodeAddresses map.

Fixes #26140

Release note (bug fix): Fixed 'node not in nodeAddresses map' panic,
which could occur when distributed queries were run on a cluster with at
least one unhealthy node.