### PR TITLE
ts: Extensive Model-based testing

### DIFF
--- a/pkg/ts/memory_test.go
+++ b/pkg/ts/memory_test.go
@@ -15,6 +15,7 @@
 package ts
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -141,6 +142,17 @@ func TestGetMaxTimespan(t *testing.T) {
 				InterpolationLimitNanos: 1,
 			},
 			10,
+			"",
+		},
+		// Overflow.
+		{
+			Resolution10s,
+			QueryMemoryOptions{
+				BudgetBytes:             math.MaxInt64,
+				EstimatedSources:        1,
+				InterpolationLimitNanos: math.MaxInt64,
+			},
+			math.MaxInt64,
 			"",
 		},
 	} {

--- a/pkg/ts/model_test.go
+++ b/pkg/ts/model_test.go
@@ -1,0 +1,252 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ts
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// The data for the model test is generated for two metrics with four sources
+// each. The values are randomly generated for each timestamp, but we do input
+// a bitmap of "gaps" which determine where each data series is missing data.
+// This allows us to exercise the various gap-filling strategies of the time
+// series system.
+//
+// In the bitmap below, each column represents one of the eight series. Data
+// points will be generated for each sample period in order, with each row
+// representing one sample period. A 1 in a column means that a series gets a
+// point for that sample period; a zero represents a gap.
+var modelTestGapBitmap = [][8]int{
+	{1, 1, 1, 1, 1, 1, 0, 1},
+	{1, 1, 1, 1, 1, 1, 1, 1},
+	{1, 1, 1, 1, 0, 1, 1, 1},
+	{1, 1, 1, 1, 1, 1, 1, 1},
+	{1, 0, 1, 1, 1, 1, 1, 1},
+	{1, 1, 1, 1, 1, 1, 1, 1},
+	{1, 1, 1, 1, 1, 1, 1, 1},
+	{1, 1, 1, 1, 1, 0, 1, 1},
+	{1, 1, 1, 1, 1, 1, 1, 1},
+	{1, 1, 0, 1, 1, 1, 1, 1},
+	{1, 0, 1, 1, 1, 1, 1, 1},
+	{1, 0, 1, 1, 1, 1, 1, 1},
+	{1, 0, 0, 1, 0, 1, 1, 1},
+	{1, 0, 1, 1, 1, 1, 1, 1},
+	{1, 0, 1, 1, 1, 1, 1, 1},
+	{1, 1, 1, 1, 1, 1, 1, 1},
+	{1, 1, 1, 1, 1, 1, 1, 1},
+	{1, 1, 1, 1, 1, 1, 1, 1},
+	{1, 1, 1, 0, 1, 1, 1, 1},
+	{1, 1, 1, 1, 1, 1, 0, 1},
+	{1, 1, 1, 1, 1, 1, 0, 1},
+	{1, 1, 1, 1, 1, 1, 0, 1},
+	{1, 1, 1, 1, 1, 1, 0, 1},
+	{0, 0, 0, 0, 0, 0, 0, 0},
+	{1, 1, 1, 1, 1, 1, 0, 1},
+	{1, 1, 1, 1, 1, 1, 0, 1},
+	{1, 1, 1, 1, 1, 1, 0, 1},
+	{1, 1, 1, 1, 1, 0, 1, 1},
+	{1, 1, 1, 1, 1, 1, 1, 1},
+	{0, 0, 0, 1, 1, 1, 1, 1},
+	{1, 1, 1, 1, 1, 1, 1, 1},
+	{1, 1, 1, 1, 1, 1, 1, 1},
+	{1, 1, 1, 1, 1, 0, 1, 1},
+	{1, 1, 1, 1, 1, 1, 1, 1},
+	{1, 0, 1, 1, 1, 1, 1, 1},
+	{1, 0, 1, 1, 1, 1, 1, 1},
+	{1, 0, 0, 1, 0, 1, 1, 1},
+	{1, 0, 1, 1, 1, 1, 1, 1},
+	{1, 0, 1, 1, 1, 1, 1, 1},
+	{1, 1, 1, 1, 1, 1, 1, 1},
+	{1, 1, 1, 1, 1, 0, 0, 0},
+	{1, 1, 1, 1, 1, 1, 1, 1},
+	{1, 1, 1, 0, 1, 1, 1, 1},
+	{1, 1, 1, 1, 1, 1, 0, 1},
+	{1, 1, 1, 1, 1, 1, 0, 1},
+	{1, 1, 1, 1, 1, 1, 0, 1},
+	{0, 0, 0, 0, 0, 0, 0, 0},
+	{0, 0, 0, 0, 0, 0, 0, 0},
+	{1, 1, 1, 1, 1, 1, 0, 1},
+	{1, 1, 1, 1, 1, 1, 0, 1},
+	{1, 1, 1, 1, 1, 1, 1, 1},
+	{1, 1, 1, 1, 1, 1, 1, 1},
+	{0, 0, 0, 1, 1, 1, 1, 1},
+	{1, 0, 1, 1, 1, 1, 1, 1},
+	{1, 1, 0, 1, 1, 0, 1, 1},
+	{1, 1, 1, 1, 0, 0, 1, 1},
+	{1, 1, 1, 1, 1, 0, 1, 1},
+	{1, 1, 1, 1, 1, 0, 1, 1},
+	{1, 1, 1, 1, 1, 0, 1, 1},
+	{1, 1, 0, 1, 1, 0, 1, 1},
+}
+
+var modelTestSourceNames = []string{
+	"source1",
+	"source2",
+	"source3",
+	"source4",
+}
+
+var modelTestMetricNames = []string{
+	"metric1",
+	"metric2",
+}
+
+// modelTestDownsamplers are the downsamplers that will be exercised during
+// the model test.
+var modelTestDownsamplers = []tspb.TimeSeriesQueryAggregator{
+	tspb.TimeSeriesQueryAggregator_AVG,
+	tspb.TimeSeriesQueryAggregator_SUM,
+	tspb.TimeSeriesQueryAggregator_MAX,
+	tspb.TimeSeriesQueryAggregator_MIN,
+}
+
+// modelTestAggregators are the source aggregators that will be exercised during
+// the model test.
+var modelTestAggregators = []tspb.TimeSeriesQueryAggregator{
+	tspb.TimeSeriesQueryAggregator_AVG,
+	tspb.TimeSeriesQueryAggregator_SUM,
+	tspb.TimeSeriesQueryAggregator_MAX,
+	tspb.TimeSeriesQueryAggregator_MIN,
+}
+
+// modelTestDerivatives are the derivative options that will be exercised during
+// the model test.
+var modelTestDerivatives = []tspb.TimeSeriesQueryDerivative{
+	tspb.TimeSeriesQueryDerivative_NONE,
+	tspb.TimeSeriesQueryDerivative_DERIVATIVE,
+	tspb.TimeSeriesQueryDerivative_NON_NEGATIVE_DERIVATIVE,
+}
+
+// modelTestInterpolationLimits are the various interpolation limits that will
+// be exercised.
+var modelTestInterpolationLimits = []int64{
+	time.Second.Nanoseconds() * 1,
+	time.Minute.Nanoseconds(),     // Only two gaps in the bitmap exceed this limit.
+	5 * time.Minute.Nanoseconds(), // No gaps exceed this length.
+}
+
+// modelTestSampleDurations are the various sample durations that will be
+// exercised.
+var modelTestSampleDurations = []int64{
+	Resolution10s.SampleDuration(),
+	Resolution10s.SampleDuration() * 3,
+	Resolution10s.SlabDuration(),
+}
+
+// modelTestRowCount is the number of sample periods that will be filled for
+// the test.
+var modelTestRowCount = len(modelTestGapBitmap)
+
+// modelTestStartTime, the first time at which data is recorded in the model, is
+// set at a reasonably modern time and configured to overlap a slab boundary.
+var modelTestStartTime = Resolution10s.normalizeToSlab(
+	time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano(),
+) - (int64(modelTestRowCount/2) * Resolution10s.SampleDuration())
+
+// modelTestQueryTimes are the bounds that will be queried for the tests.
+var modelTestQueryTimes = []struct {
+	start int64
+	end   int64
+}{
+	{
+		start: modelTestStartTime,
+		end:   modelTestStartTime + time.Hour.Nanoseconds(),
+	},
+	{
+		start: modelTestStartTime + 20*Resolution10s.SampleDuration(),
+		end:   modelTestStartTime + 35*Resolution10s.SampleDuration(),
+	},
+}
+
+func TestTimeSeriesModelTest(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tm := newTestModelRunner(t)
+	tm.Start()
+	defer tm.Stop()
+
+	s1 := rand.NewSource(timeutil.Now().UnixNano())
+	r1 := rand.New(s1)
+
+	// populate model with random values according to gap bitmap.
+	for rowNum := 0; rowNum <= modelTestRowCount; rowNum++ {
+		for metricNum, metric := range modelTestMetricNames {
+			for sourceNum, source := range modelTestSourceNames {
+				// Check the gap bitmap to see if this sample period and source get a
+				// data point.
+				if modelTestGapBitmap[rowNum%len(modelTestGapBitmap)][4*metricNum+sourceNum] > 0 {
+					tm.storeTimeSeriesData(Resolution10s, []tspb.TimeSeriesData{
+						tsd(metric, source,
+							tsdp(getSampleTime(rowNum), math.Floor(r1.Float64()*10000)),
+						),
+					})
+				}
+			}
+		}
+	}
+
+	tm.assertModelCorrect()
+	{
+		// Sanity check: model should contain a datapoint for all but two sample
+		// periods (one period is fully missing from the gap bitmap).
+		query := tm.makeQuery(
+			modelTestMetricNames[0], Resolution10s, modelTestStartTime, modelTestStartTime+time.Hour.Nanoseconds(),
+		)
+		query.assertSuccess(len(modelTestGapBitmap)-2, 4)
+	}
+
+	executeQueryMatrix(t, tm)
+}
+
+// getSampleTime returns the timestamp for the numbered sample period in the
+// model test.
+func getSampleTime(n int) time.Duration {
+	return time.Duration(modelTestStartTime + int64(n)*Resolution10s.SampleDuration())
+}
+
+func executeQueryMatrix(t *testing.T, tm testModelRunner) {
+	for _, metric := range modelTestMetricNames {
+		for _, downsampler := range modelTestDownsamplers {
+			for _, aggregator := range modelTestAggregators {
+				for _, derivative := range modelTestDerivatives {
+					for _, interpolationLimit := range modelTestInterpolationLimits {
+						for _, sampleDuration := range modelTestSampleDurations {
+							for _, queryRange := range modelTestQueryTimes {
+								for srcCount := 0; srcCount <= len(modelTestSourceNames); srcCount++ {
+									query := tm.makeQuery(
+										metric, Resolution10s, queryRange.start, queryRange.end,
+									)
+									query.setDownsampler(downsampler)
+									query.setSourceAggregator(aggregator)
+									query.setDerivative(derivative)
+									query.Sources = modelTestSourceNames[:srcCount]
+									query.InterpolationLimitNanos = interpolationLimit
+									query.SampleDurationNanos = sampleDuration
+									query.assertMatchesModel()
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/pkg/ts/testmodel/db.go
+++ b/pkg/ts/testmodel/db.go
@@ -118,6 +118,7 @@ func (mdb *ModelDB) Query(
 	derivative tspb.TimeSeriesQueryDerivative,
 	slabDuration, sampleDuration, start, end, interpolationLimit, now int64,
 ) DataSeries {
+	start = normalizeTime(start, sampleDuration)
 	// Check query bounds against the provided current time. Queries in the future
 	// are disallowed; "future" is considered to be at or later than the sample
 	// period containing the current system time (represented by the "now"

--- a/pkg/ts/testmodel/db_test.go
+++ b/pkg/ts/testmodel/db_test.go
@@ -166,6 +166,27 @@ func TestModelDBQuery(t *testing.T) {
 				dp(400, 3.75e+09),
 			},
 		},
+		// Same as first query, but with interpolation disabled AND a derivative
+		// option. Exercises the interplay between derivative and interpolation.
+		{
+			seriesName:         "testmetric",
+			sources:            nil,
+			downsampler:        tspb.TimeSeriesQueryAggregator_AVG,
+			aggregator:         tspb.TimeSeriesQueryAggregator_SUM,
+			derivative:         tspb.TimeSeriesQueryDerivative_DERIVATIVE,
+			slabDuration:       1000,
+			sampleDuration:     100,
+			start:              0,
+			end:                10000,
+			interpolationLimit: 1,
+			nowNanos:           math.MaxInt64,
+			expected: DataSeries{
+				dp(100, 3.5e+09),
+				dp(200, 9e+09),
+				dp(300, 2e+09),
+				dp(400, 3.75e+09),
+			},
+		},
 		// Same as first query, but with a single source specified.
 		{
 			seriesName:         "testmetric",

--- a/pkg/ts/testmodel/functions.go
+++ b/pkg/ts/testmodel/functions.go
@@ -91,7 +91,7 @@ func AggregateVariance(data DataSeries) float64 {
 		delta2 := dp.Value - mean
 		meanSquaredDist += delta * delta2
 	}
-	return meanSquaredDist / float64(len(data)-1)
+	return meanSquaredDist / float64(len(data))
 }
 
 // getAggFunction is a convenience method used to process an aggregator option

--- a/pkg/ts/testmodel/functions_test.go
+++ b/pkg/ts/testmodel/functions_test.go
@@ -88,7 +88,7 @@ func TestAggregates(t *testing.T) {
 			first:    2,
 			last:     6,
 			avg:      4,
-			variance: 4,
+			variance: 2.6666666666666665,
 		},
 		// Negative values, variance still positive.
 		{
@@ -103,7 +103,7 @@ func TestAggregates(t *testing.T) {
 			first:    -3,
 			last:     -6,
 			avg:      -6,
-			variance: 9,
+			variance: 6,
 		},
 		// Some fairly random numbers, variance and average computed from an online
 		// calculator. Gives good confidence that the functions are actually doing
@@ -122,7 +122,7 @@ func TestAggregates(t *testing.T) {
 			first:    60,
 			last:     143,
 			avg:      113,
-			variance: 21041.5,
+			variance: 16833.2,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/ts/timeseries_test.go
+++ b/pkg/ts/timeseries_test.go
@@ -48,6 +48,7 @@ func TestToInternal(t *testing.T) {
 	tcases := []struct {
 		keyDuration    int64
 		sampleDuration int64
+		columnar       bool
 		expectedError  string
 		input          tspb.TimeSeriesData
 		expected       []roachpb.InternalTimeSeriesData
@@ -55,6 +56,7 @@ func TestToInternal(t *testing.T) {
 		{
 			time.Minute.Nanoseconds(),
 			101,
+			false,
 			"does not evenly divide key duration",
 			tsd("error.series", ""),
 			nil,
@@ -62,6 +64,7 @@ func TestToInternal(t *testing.T) {
 		{
 			time.Minute.Nanoseconds(),
 			time.Hour.Nanoseconds(),
+			false,
 			"does not evenly divide key duration",
 			tsd("error.series", ""),
 			nil,
@@ -69,6 +72,7 @@ func TestToInternal(t *testing.T) {
 		{
 			(24 * time.Hour).Nanoseconds(),
 			(20 * time.Minute).Nanoseconds(),
+			false,
 			"",
 			tsd("test.series", "",
 				tsdp(5*time.Hour+5*time.Minute, 1.0),
@@ -129,10 +133,44 @@ func TestToInternal(t *testing.T) {
 				},
 			},
 		},
+		{
+			(24 * time.Hour).Nanoseconds(),
+			(20 * time.Minute).Nanoseconds(),
+			true,
+			"",
+			tsd("test.series", "",
+				tsdp(5*time.Hour+5*time.Minute, 1.0),
+				tsdp(24*time.Hour+39*time.Minute, 2.0),
+				tsdp(10*time.Hour+10*time.Minute, 3.0),
+				tsdp(48*time.Hour, 4.0),
+				tsdp(15*time.Hour+22*time.Minute+1, 5.0),
+				tsdp(52*time.Hour+15*time.Minute, 0.0),
+			),
+			[]roachpb.InternalTimeSeriesData{
+				{
+					StartTimestampNanos: 0,
+					SampleDurationNanos: 20 * time.Minute.Nanoseconds(),
+					Offset:              []int32{15, 30, 46},
+					Last:                []float64{1.0, 3.0, 5.0},
+				},
+				{
+					StartTimestampNanos: 24 * time.Hour.Nanoseconds(),
+					SampleDurationNanos: 20 * time.Minute.Nanoseconds(),
+					Offset:              []int32{1},
+					Last:                []float64{2.0},
+				},
+				{
+					StartTimestampNanos: 48 * time.Hour.Nanoseconds(),
+					SampleDurationNanos: 20 * time.Minute.Nanoseconds(),
+					Offset:              []int32{0, 12},
+					Last:                []float64{4.0, 0.0},
+				},
+			},
+		},
 	}
 
 	for i, tc := range tcases {
-		actual, err := tc.input.ToInternal(tc.keyDuration, tc.sampleDuration, false)
+		actual, err := tc.input.ToInternal(tc.keyDuration, tc.sampleDuration, tc.columnar)
 		if !testutils.IsError(err, tc.expectedError) {
 			t.Errorf("expected error %q from case %d, got %v", tc.expectedError, i, err)
 		}


### PR DESCRIPTION
Three commits that add extensive testing based on comparison of results to the in-memory testmodel.

+ First commit just adds a test for the columnar version of `tspb.TimeSeriesData.ToInternal()`, which was missing.
+ Second commit adds explicit tests for the `makeInternalData` test functions, which are used to construct expected results for certain unit tests. The output of these functions is now verified against similar output from the test model, which has already been extensively verified.
+ Third commit is the most important - it introduces a procedural test which generates a huge number of permutations to test the output of the query system against the expected output of the the testmodel.