### PR TITLE
Makefile: learn that roachtest depends on generated code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1411,7 +1411,7 @@ logictest-package = ./pkg/sql/logictest
 logictestccl-package = ./pkg/ccl/logictestccl
 
 # Additional dependencies for binaries that depend on generated code.
-bin/workload bin/docgen: $(SQLPARSER_TARGETS) $(PROTOBUF_TARGETS)
+bin/workload bin/docgen bin/roachtest: $(SQLPARSER_TARGETS) $(PROTOBUF_TARGETS)
 
 $(bins): bin/%: bin/%.d | bin/prereqs bin/.submodules-initialized
 	@echo go install -v $*


### PR DESCRIPTION
Since bd821a7 the roachtest command depends on generated code. Teach the
Makefile this.

The Makefile will one day be smart enough to deduce this on its own, but
for now it's simpler to explicitly list the commands that require
generated code. Note that the simple but coarse solution of assuming
that all commands depend on generated code is inviable as some of these
commands are used to generate the code in the first place.

Release note: None