### PR TITLE
keys: remove compatibility with pre-VersionMeta2Splits nodes

### DIFF
--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -253,9 +253,9 @@ typedef struct {
 
 MVCCStatsResult MVCCComputeStats(DBIterator* iter, DBKey start, DBKey end, int64_t now_nanos);
 
-bool MVCCIsValidSplitKey(DBSlice key, bool allow_meta2_splits);
+bool MVCCIsValidSplitKey(DBSlice key);
 DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, DBKey min_split,
-                          int64_t target_size, bool allow_meta2_splits, DBString* split_key);
+                          int64_t target_size, DBString* split_key);
 
 // DBTxn contains the fields from a roachpb.Transaction that are
 // necessary for MVCC Get and Scan operations. Note that passing a

--- a/c-deps/libroach/keys.h
+++ b/c-deps/libroach/keys.h
@@ -17,10 +17,5 @@ const std::vector<std::pair<rocksdb::Slice, rocksdb::Slice> > kSortedNoSplitSpan
   std::make_pair(rocksdb::Slice("\x03\xff\xff", 3), rocksdb::Slice("\x04", 1)),
   std::make_pair(rocksdb::Slice("", 0), rocksdb::Slice("\x03", 1)),
 };
-const std::vector<std::pair<rocksdb::Slice, rocksdb::Slice> > kSortedNoSplitSpansWithoutMeta2Splits = {
-  std::make_pair(rocksdb::Slice("\x88", 1), rocksdb::Slice("\x93", 1)),
-  std::make_pair(rocksdb::Slice("\x04\x00\x6c\x69\x76\x65\x6e\x65\x73\x73\x2d", 11), rocksdb::Slice("\x04\x00\x6c\x69\x76\x65\x6e\x65\x73\x73\x2e", 11)),
-  std::make_pair(rocksdb::Slice("", 0), rocksdb::Slice("\x04", 1)),
-};
 
 }  // namespace cockroach

--- a/pkg/keys/gen_cpp_keys.go
+++ b/pkg/keys/gen_cpp_keys.go
@@ -91,7 +91,6 @@ namespace cockroach {
 		fmt.Fprintf(f, "};\n")
 	}
 	genSortedSpans(keys.NoSplitSpans, "NoSplitSpans")
-	genSortedSpans(keys.NoSplitSpansWithoutMeta2Splits, "NoSplitSpansWithoutMeta2Splits")
 
 	fmt.Fprintf(f, `
 }  // namespace cockroach

--- a/pkg/keys/spans.go
+++ b/pkg/keys/spans.go
@@ -34,9 +34,6 @@ var (
 	//   Meta1KeyMax, which would allow meta1 to get out of order.
 	Meta2MaxSpan = roachpb.Span{Key: Meta2KeyMax, EndKey: MetaMax}
 
-	// MetaSpan holds all the addressing records.
-	MetaSpan = roachpb.Span{Key: roachpb.KeyMin, EndKey: MetaMax}
-
 	// NodeLivenessSpan holds the liveness records for nodes in the cluster.
 	NodeLivenessSpan = roachpb.Span{Key: NodeLivenessPrefix, EndKey: NodeLivenessKeyMax}
 
@@ -49,12 +46,7 @@ var (
 	// NodeLivenessSpan: liveness information on nodes in the cluster.
 	// SystemConfigSpan: system objects which will be gossiped.
 	NoSplitSpans = []roachpb.Span{Meta1Span, Meta2MaxSpan, NodeLivenessSpan, SystemConfigSpan}
-
-	// NoSplitSpansWithoutMeta2Splits describes the ranges that were never
-	// to be split before we supported meta2 splits.
-	NoSplitSpansWithoutMeta2Splits = []roachpb.Span{MetaSpan, NodeLivenessSpan, SystemConfigSpan}
 )
 
 // Silence unused warnings. These variables are actually used by gen_cpp_keys.go.
 var _ = NoSplitSpans
-var _ = NoSplitSpansWithoutMeta2Splits

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -21,11 +21,20 @@ import (
 // VersionKey is a unique identifier for a version of CockroachDB.
 type VersionKey int
 
-// Version constants. To add a version:
+// Version constants.
+//
+// To add a version:
 //   - Add it at the end of this block.
 //   - Add it at the end of the `Versions` block below.
 //   - For major or minor versions, bump BinaryMinimumSupportedVersion. For
 //     example, if introducing the `1.4` release, bump it from `1.2` to `1.3`.
+//
+// To delete a version.
+//   - Remove its associated runtime checks.
+//   - Mark it as "unused" when it is only referenced in this file.
+//   - If the version key after a major or minor version is unused, remove it
+//     and its associated keyedVersion.
+//     - Apply recursively.
 const (
 	VersionBase VersionKey = iota
 	VersionRaftLogTruncationBelowRaft
@@ -34,17 +43,17 @@ const (
 	Version1_1
 	VersionRaftLastIndex
 	VersionMVCCNetworkStats
-	VersionMeta2Splits
+	VersionMeta2Splits // unused
 	VersionRPCNetworkStats
 	VersionRPCVersionCheck
 	VersionClearRange
 	VersionPartitioning
-	VersionLeaseSequence
+	VersionLeaseSequence // unused
 	VersionUnreplicatedTombstoneKey
 	VersionRecomputeStats
 	VersionNoRaftProposalKeys
 	VersionTxnSpanRefresh
-	VersionReadUncommittedRangeLookups
+	VersionReadUncommittedRangeLookups // unused
 	VersionPerReplicaZoneConstraints
 	VersionLeasePreferences
 	Version2_0

--- a/pkg/storage/engine/bench_test.go
+++ b/pkg/storage/engine/bench_test.go
@@ -619,7 +619,7 @@ func runMVCCFindSplitKey(emk engineMaker, valueBytes int, b *testing.B) {
 	var err error
 	for i := 0; i < b.N; i++ {
 		_, err = MVCCFindSplitKey(context.Background(), eng, roachpb.RKeyMin,
-			roachpb.RKeyMax, rangeBytes/2, true /* allowMeta2Splits */)
+			roachpb.RKeyMax, rangeBytes/2)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -98,12 +98,8 @@ type Iterator interface {
 	ComputeStats(start, end MVCCKey, nowNanos int64) (enginepb.MVCCStats, error)
 	// FindSplitKey finds a key from the given span such that the left side of
 	// the split is roughly targetSize bytes. The returned key will never be
-	// chosen from the key ranges listed in keys.NoSplitSpans if
-	// allowMeta2Splits is true and keys.NoSplitSpansWithoutMeta2Splits if
-	// allowMeta2Splits is false.
-	//
-	// TODO(nvanbenschoten): remove allowMeta2Splits in version 2.1.
-	FindSplitKey(start, end, minSplitKey MVCCKey, targetSize int64, allowMeta2Splits bool) (MVCCKey, error)
+	// chosen from the key ranges listed in keys.NoSplitSpans.
+	FindSplitKey(start, end, minSplitKey MVCCKey, targetSize int64) (MVCCKey, error)
 	// MVCCGet retrieves the value for the key at the specified timestamp. The
 	// value is returned in batch repr format with the key being present as the
 	// empty string. If an intent exists at the specified key, it will be

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -2526,14 +2526,9 @@ func MVCCGarbageCollect(
 
 // MVCCFindSplitKey finds a key from the given span such that the left side of
 // the split is roughly targetSize bytes. The returned key will never be chosen
-// from the key ranges listed in keys.NoSplitSpans (or listed in
-// keys.NoSplitSpansWithoutMeta2Splits if allowMeta2Splits is false).
+// from the key ranges listed in keys.NoSplitSpans.
 func MVCCFindSplitKey(
-	ctx context.Context,
-	engine Reader,
-	key, endKey roachpb.RKey,
-	targetSize int64,
-	allowMeta2Splits bool,
+	ctx context.Context, engine Reader, key, endKey roachpb.RKey, targetSize int64,
 ) (roachpb.Key, error) {
 	if key.Less(roachpb.RKey(keys.LocalMax)) {
 		key = roachpb.RKey(keys.LocalMax)
@@ -2601,8 +2596,7 @@ func MVCCFindSplitKey(
 		MakeMVCCMetadataKey(key.AsRawKey()),
 		MakeMVCCMetadataKey(endKey.AsRawKey()),
 		MakeMVCCMetadataKey(minSplitKey.AsRawKey()),
-		targetSize,
-		allowMeta2Splits)
+		targetSize)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1380,10 +1380,10 @@ func (r *batchIterator) ComputeStats(
 }
 
 func (r *batchIterator) FindSplitKey(
-	start, end, minSplitKey MVCCKey, targetSize int64, allowMeta2Splits bool,
+	start, end, minSplitKey MVCCKey, targetSize int64,
 ) (MVCCKey, error) {
 	r.batch.flushMutations()
-	return r.iter.FindSplitKey(start, end, minSplitKey, targetSize, allowMeta2Splits)
+	return r.iter.FindSplitKey(start, end, minSplitKey, targetSize)
 }
 
 func (r *batchIterator) MVCCGet(
@@ -2059,11 +2059,11 @@ func (r *rocksDBIterator) ComputeStats(
 }
 
 func (r *rocksDBIterator) FindSplitKey(
-	start, end, minSplitKey MVCCKey, targetSize int64, allowMeta2Splits bool,
+	start, end, minSplitKey MVCCKey, targetSize int64,
 ) (MVCCKey, error) {
 	var splitKey C.DBString
 	status := C.MVCCFindSplitKey(r.iter, goToCKey(start), goToCKey(end), goToCKey(minSplitKey),
-		C.int64_t(targetSize), C.bool(allowMeta2Splits), &splitKey)
+		C.int64_t(targetSize), &splitKey)
 	if err := statusToError(status); err != nil {
 		return MVCCKey{}, err
 	}
@@ -2713,8 +2713,8 @@ func (r *RocksDB) DeleteDirAndFiles(dir string) error {
 // ranges cannot be split (the meta1 span and the system DB span); split keys
 // chosen within any of these ranges are considered invalid. And a split key
 // equal to Meta2KeyMax (\x03\xff\xff) is considered invalid.
-func IsValidSplitKey(key roachpb.Key, allowMeta2Splits bool) bool {
-	return bool(C.MVCCIsValidSplitKey(goToCSlice(key), C._Bool(allowMeta2Splits)))
+func IsValidSplitKey(key roachpb.Key) bool {
+	return bool(C.MVCCIsValidSplitKey(goToCSlice(key)))
 }
 
 // lockFile sets a lock on the specified file using RocksDB's file locking interface.

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -3080,21 +3080,7 @@ func (r *Replica) insertProposalLocked(
 	}
 	proposal.command.MaxLeaseIndex = r.mu.lastAssignedLeaseIndex
 	proposal.command.ProposerReplica = proposerReplica
-
-	// If the proposerLease has a sequence number then we can send this through
-	// Raft instead of sending the entire Lease through Raft.
-	//
-	// NB: We can't check IsMinSupported(VersionLeaseSequence) here because its
-	// value may not have been the same when a lease request was evaluated,
-	// meaning that we have no guarantee that a new lease isn't being proposed
-	// without a sequence number. If we started sending only lease sequence
-	// numbers in this case, we wouldn't be able to distinguish the old and the
-	// new lease.
-	if proposerLease.Sequence != 0 {
-		proposal.command.ProposerLeaseSequence = proposerLease.Sequence
-	} else {
-		proposal.command.DeprecatedProposerLease = &proposerLease
-	}
+	proposal.command.ProposerLeaseSequence = proposerLease.Sequence
 
 	if log.V(4) {
 		log.Infof(proposal.ctx, "submitting proposal %x: maxLeaseIndex=%d",

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -161,12 +161,12 @@ func (s *Iterator) ComputeStats(
 
 // FindSplitKey is part of the engine.Iterator interface.
 func (s *Iterator) FindSplitKey(
-	start, end, minSplitKey engine.MVCCKey, targetSize int64, allowMeta2Splits bool,
+	start, end, minSplitKey engine.MVCCKey, targetSize int64,
 ) (engine.MVCCKey, error) {
 	if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: start.Key, EndKey: end.Key}); err != nil {
 		return engine.MVCCKey{}, err
 	}
-	return s.i.FindSplitKey(start, end, minSplitKey, targetSize, allowMeta2Splits)
+	return s.i.FindSplitKey(start, end, minSplitKey, targetSize)
 }
 
 // MVCCGet is part of the engine.Iterator interface.


### PR DESCRIPTION
This change removes the compatibility layer introduced with
`VersionMeta2Splits` that conditionally decided whether
splitting meta2 ranges was permitted. In doing so, it cleans
up some plumbing code that is no longer needed in 2.1 binaries.

Release note: None