### PR TITLE
settings: bump minimum supported version to v2.0

### DIFF
--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -242,7 +242,7 @@ var (
 	// this binary. If this binary is started using a store marked with an older
 	// version than BinaryMinimumSupportedVersion, then the binary will exit with
 	// an error.
-	BinaryMinimumSupportedVersion = VersionByKey(Version1_1)
+	BinaryMinimumSupportedVersion = VersionByKey(Version2_0)
 
 	// BinaryServerVersion is the version of this binary.
 	//


### PR DESCRIPTION
We're currently shipping v2.1 alphas, so enforce a minimum binary
version of v2.0. This ensures that no one can upgrade directly from
v1.1 to v2.1. Instead, they need to make a pit sop in v2.0.

Release note: None