### PR TITLE
sql: skip TestShowCreateView on testshort

### DIFF
--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -277,6 +277,9 @@ func TestShowCreateTable(t *testing.T) {
 
 func TestShowCreateView(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	if testing.Short() {
+		t.Skip("short #26969")
+	}
 
 	params, _ := tests.CreateTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)


### PR DESCRIPTION
I'm complaining in #26969 that the test takes 2.5s.

Release note: None