### PR TITLE
sem/tree: remove TestClusterTimestampConversion

### DIFF
--- a/pkg/sql/sem/tree/timeconv_test.go
+++ b/pkg/sql/sem/tree/timeconv_test.go
@@ -15,15 +15,20 @@
 package tree_test
 
 import (
-	"context"
 	"testing"
+	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
+// Test that EvalContext.GetClusterTimestamp() gets its timestamp from the
+// transaction, and also that the conversion to decimal works properly.
 func TestClusterTimestampConversion(t *testing.T) {
 	testData := []struct {
 		walltime int64
@@ -37,12 +42,34 @@ func TestClusterTimestampConversion(t *testing.T) {
 		{9223372036854775807, 2147483647, "9223372036854775807.2147483647"},
 	}
 
-	ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-	defer ctx.Mon.Stop(context.Background())
-	ctx.PrepareOnly = true
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+
+	factory := client.TxnSenderFactoryFunc(func(client.TxnType) client.TxnSender {
+		return nil
+	})
+	db := client.NewDB(
+		testutils.MakeAmbientCtx(),
+		factory,
+		clock)
+
 	for _, d := range testData {
 		ts := hlc.Timestamp{WallTime: d.walltime, Logical: d.logical}
-		ctx.Txn.Proto().OrigTimestamp = ts
+		ctx := tree.EvalContext{
+			Txn: client.NewTxnWithProto(
+				db,
+				1, /* gatewayNodeID */
+				client.RootTxn,
+				roachpb.MakeTransaction(
+					"test",
+					nil, // baseKey
+					roachpb.NormalUserPriority,
+					enginepb.SERIALIZABLE,
+					ts,
+					0, /* maxOffsetNs */
+				),
+			),
+		}
+
 		dec := ctx.GetClusterTimestamp()
 		final := dec.Text('f')
 		if final != d.expected {


### PR DESCRIPTION
I can't really tell what this test is testing exactly, but what it does
is really weird - it creates a TestingEvalCcontext and then it peeks
inside it to update the txn proto's timestamp, only to the retrieve that
timestamp and assert some serialization on it.
This is bizarre, and also changing a txn's proto like that is not going
to be a thing any more - I'm making this proto not be exposed any more,
and definitely not writable by the world. In fact, it never was intended
to be modified by clients.

If a test really needs a transaction at a particular timestamp and the
test needs to operate at a high level, there's txn.SetFixedTimestamp().
But that requires a txn to actually exist; the mocking done by
tree.NewTestingEvalContext() is not sufficient.
I'd like to remove this test...

Release note: None