### PR TITLE
storage: factor out node dialer from RaftTransport

### DIFF
--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -1,0 +1,116 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package nodedialer
+
+import (
+	"context"
+	"net"
+	"time"
+	"unsafe"
+
+	"github.com/pkg/errors"
+	"github.com/rubyist/circuitbreaker"
+	"google.golang.org/grpc"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// No more than one failure to connect to a given node will be logged in the given interval.
+const logPerNodeFailInterval = time.Minute
+
+type wrappedBreaker struct {
+	*circuit.Breaker
+	log.EveryN
+}
+
+// A NodeAddressResolver translates NodeIDs into addresses.
+type NodeAddressResolver func(roachpb.NodeID) (net.Addr, error)
+
+// A NodeDialer wraps an *rpc.Context for dialing based on node IDs. For each node,
+// it maintains a circuit breaker that prevents rapid connection attempts and
+// provides hints to the callers on whether to log the outcome of the operation.
+type NodeDialer struct {
+	rpcContext *rpc.Context
+	resolver   NodeAddressResolver
+
+	breakers syncutil.IntMap // map[roachpb.NodeID]*wrappedBreaker
+}
+
+// NewNodeDialer initializes a NodeDialer.
+func NewNodeDialer(rpcContext *rpc.Context, resolver NodeAddressResolver) *NodeDialer {
+	return &NodeDialer{
+		rpcContext: rpcContext,
+		resolver:   resolver,
+	}
+}
+
+// DialNode returns a grpc connection to the given node. It logs whenever the
+// node first becomes unreachable or reachable.
+func (n *NodeDialer) DialNode(
+	ctx context.Context, nodeID roachpb.NodeID,
+) (_ *grpc.ClientConn, err error) {
+	breaker := n.getBreaker(nodeID)
+	// If this is the first time connecting, or if connections have been failing repeatedly,
+	// consider logging.
+	if breaker.Successes() == 0 || breaker.ConsecFailures() > 0 {
+		defer func() {
+			if err != nil {
+				// Enforce a minimum interval between warnings for failed connections.
+				if breaker.ShouldLog() {
+					log.Warningf(ctx, "unable to connect to n%d: %s", nodeID, err)
+				}
+			} else {
+				log.Infof(ctx, "connection to n%d established", nodeID)
+			}
+		}()
+	}
+
+	if !breaker.Ready() {
+		err := errors.Wrapf(circuit.ErrBreakerOpen, "unable to dial n%d", nodeID)
+		return nil, err
+	}
+
+	addr, err := n.resolver(nodeID)
+	if err != nil {
+		breaker.Fail()
+		return nil, err
+	}
+	conn, err := n.rpcContext.GRPCDial(addr.String()).Connect(ctx)
+	if err != nil {
+		breaker.Fail()
+		return nil, err
+	}
+	breaker.Success()
+	return conn, nil
+}
+
+// GetCircuitBreaker retrieves the circuit breaker for connections to the given
+// node. The breaker should not be mutated as this affects all connections
+// dialing to that node through this NodeDialer.
+func (n *NodeDialer) GetCircuitBreaker(nodeID roachpb.NodeID) *circuit.Breaker {
+	return n.getBreaker(nodeID).Breaker
+}
+
+func (n *NodeDialer) getBreaker(nodeID roachpb.NodeID) *wrappedBreaker {
+	value, ok := n.breakers.Load(int64(nodeID))
+	if !ok {
+		breaker := &wrappedBreaker{Breaker: n.rpcContext.NewBreaker(), EveryN: log.Every(logPerNodeFailInterval)}
+		value, _ = n.breakers.LoadOrStore(int64(nodeID), unsafe.Pointer(breaker))
+	}
+	return (*wrappedBreaker)(value)
+}

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/rubyist/circuitbreaker"
 )
 
 // AddReplica adds the replica to the store's replica map and to the sorted
@@ -509,4 +510,10 @@ func (nl *NodeLiveness) SetDecommissioningInternal(
 	ctx context.Context, nodeID roachpb.NodeID, liveness *Liveness, decommission bool,
 ) (changeCommitted bool, err error) {
 	return nl.setDecommissioningInternal(ctx, nodeID, liveness, decommission)
+}
+
+// GetCircuitBreaker returns the circuit breaker controlling
+// connection attempts to the specified node.
+func (t *RaftTransport) GetCircuitBreaker(nodeID roachpb.NodeID) *circuit.Breaker {
+	return t.dialer.GetCircuitBreaker(nodeID)
 }


### PR DESCRIPTION
RaftTransport wraps RPC connections between nodes with additional
circuit breaker logic to avoid spamming dead nodes (plus spamming the
logs). Upcoming work on follower reads needs similar machinery, and
there are various other components in the system that connect to other
nodes and should already be using such a mechanism.

This commit extracts this logic into a standalone component named
`NodeDialer`. In future work, a single `NodeDialer` will be shared
across a running node.

There is a semantic change in behavior that deserves being called out.
Prior to this change, the Raft circuit breakers were tripped not only
based on whether it was possible to connect to a given target node, but
also based on error codes returned from the calls, and notably
StoreNotFoundError.
This is no longer the case, as it would be at odds with the goal of
sharing these circuit breakers across multiple use cases and maintaining
the old behavior would require adding another layer of circuit breaking
inside the Raft transport.

Looking at the history of this behavior (#10266), it seems to have been
introduced because bringing a new node up under the address of an old
node could wedge the (ancient version of the) transport indefinitely as
it didn't reconnect in that case (taking the correct address from
Gossip) but kept sending messages to the wrong node. This is still fixed
with my changes; only the backoff is lost, which seems acceptable.

Release note: None