### PR TITLE
storage: avoid repeat allocations in DetachEndTxns

### DIFF
--- a/pkg/storage/batcheval/result/result.go
+++ b/pkg/storage/batcheval/result/result.go
@@ -98,9 +98,14 @@ func (lResult *LocalResult) DetachEndTxns(alwaysOnly bool) []EndTxnIntents {
 	}
 	var r []EndTxnIntents
 	if lResult.EndTxns != nil {
-		for _, eti := range *lResult.EndTxns {
-			if !alwaysOnly || eti.Always {
-				r = append(r, eti)
+		r = *lResult.EndTxns
+		if alwaysOnly {
+			// If alwaysOnly, filter away any !Always EndTxnIntents.
+			r = r[:0]
+			for _, eti := range *lResult.EndTxns {
+				if eti.Always {
+					r = append(r, eti)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
We call `LocalResult.DetachEndTxns` at least once for every write command.
Previously, this method would allocate any time `LocalResult.EndTxns != nil`,
which roughly corresponded to every `EndTransactionRequest`. This was a little
crazy because most of the time (`alwaysOnly=false`) the method could just return
`LocalResult.EndTxns`. Furthermore, even when `alwaysOnly=true`, we can still
avoid the slice allocation.

Release note: None