### PR TITLE
sql: add metric for queries run with optimizer

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -268,7 +268,9 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 	return &Server{
 		cfg: cfg,
 		EngineMetrics: EngineMetrics{
-			DistSQLSelectCount: metric.NewCounter(MetaDistSQLSelect),
+			DistSQLSelectCount:  metric.NewCounter(MetaDistSQLSelect),
+			SQLOptCount:         metric.NewCounter(MetaSQLOpt),
+			SQLOptFallbackCount: metric.NewCounter(MetaSQLOptFallback),
 			// TODO(mrtracy): See HistogramWindowInterval in server/config.go for the 6x factor.
 			DistSQLExecLatency: metric.NewLatency(MetaDistSQLExecLatency,
 				6*metricsSampleInterval),

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -656,7 +656,7 @@ func (ex *connExecutor) execStmtInParallel(
 		planner.statsCollector.PhaseTimes()[plannerEndExecStmt] = timeutil.Now()
 
 		ex.recordStatementSummary(
-			planner, stmt, false /* distSQLUsed*/, ex.extraTxnState.autoRetryCounter,
+			planner, stmt, false /* distSQLUsed*/, false /* optUsed */, ex.extraTxnState.autoRetryCounter,
 			res.RowsAffected(), err, &ex.server.EngineMetrics,
 		)
 		if ex.server.cfg.TestingKnobs.AfterExecute != nil {
@@ -807,8 +807,9 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		return err
 	}
 	ex.recordStatementSummary(
-		planner, stmt, useDistSQL, ex.extraTxnState.autoRetryCounter,
-		res.RowsAffected(), res.Err(), &ex.server.EngineMetrics,
+		planner, stmt, useDistSQL, optimizerPlanned,
+		ex.extraTxnState.autoRetryCounter, res.RowsAffected(), res.Err(),
+		&ex.server.EngineMetrics,
 	)
 	if ex.server.cfg.TestingKnobs.AfterExecute != nil {
 		ex.server.cfg.TestingKnobs.AfterExecute(ctx, stmt.String(), res.Err())

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -176,6 +176,18 @@ var (
 		Measurement: "Latency",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
+	MetaSQLOpt = metric.Metadata{
+		Name:        "sql.optimizer.count",
+		Help:        "Number of statements which ran with the cost-based optimizer",
+		Measurement: "SQL Statements",
+		Unit:        metric.Unit_COUNT,
+	}
+	MetaSQLOptFallback = metric.Metadata{
+		Name:        "sql.optimizer.fallback.count",
+		Help:        "Number of statements which the cost-based optimizer was unable to plan",
+		Measurement: "SQL Statements",
+		Unit:        metric.Unit_COUNT,
+	}
 	MetaDistSQLSelect = metric.Metadata{
 		Name:        "sql.distsql.select.count",
 		Help:        "Number of DistSQL SELECT statements",

--- a/pkg/sql/metric_util_test.go
+++ b/pkg/sql/metric_util_test.go
@@ -29,6 +29,7 @@ func initializeQueryCounter(s serverutils.TestServerInterface) queryCounter {
 	return queryCounter{
 		txnBeginCount:      s.MustGetSQLCounter(sql.MetaTxnBegin.Name),
 		selectCount:        s.MustGetSQLCounter(sql.MetaSelect.Name),
+		optCount:           s.MustGetSQLCounter(sql.MetaSQLOpt.Name),
 		distSQLSelectCount: s.MustGetSQLCounter(sql.MetaDistSQLSelect.Name),
 		updateCount:        s.MustGetSQLCounter(sql.MetaUpdate.Name),
 		insertCount:        s.MustGetSQLCounter(sql.MetaInsert.Name),


### PR DESCRIPTION
Suggested by @knz.

Release note (sql change): A new metric sql.optimizer.count has been
added which tracks the number of queries with with the experimental
cost-based optimizer.