### PR TITLE
release-2.0: importccl: set descriptor DropTime during failed IMPORT

### DIFF
--- a/pkg/ccl/importccl/csv.go
+++ b/pkg/ccl/importccl/csv.go
@@ -1719,6 +1719,13 @@ func (r *importResumer) OnFailOrCancel(ctx context.Context, txn *client.Txn, job
 	}
 	b := txn.NewBatch()
 	tableDesc := details.Desc
+	// If the DropTime if set, a table uses RangeClear for fast data removal. This
+	// operation starts at DropTime + the GC TTL. If we used now() here, it would
+	// not clean up data until the TTL from the time of the error. Instead, use 1
+	// (that is, 1ns past the epoch) to allow this to be cleaned up as soon as
+	// possible. This is safe since the table data was never visible to users,
+	// and so we don't need to preserve MVCC semantics.
+	tableDesc.DropTime = 1
 	tableDesc.State = sqlbase.TableDescriptor_DROP
 	b.CPut(sqlbase.MakeDescMetadataKey(tableDesc.ID), sqlbase.WrapDescriptor(tableDesc), nil)
 	return txn.Run(ctx, b)


### PR DESCRIPTION
Backport 1/1 commits from #26959.

/cc @cockroachdb/release

---

This allows ClearRange to be used instead of the 1.1-era batch deletions.

Release note (bug fix): failed IMPORTs will now begin to clean up
partially imported data immediatily and in a faster manner.
