### PR TITLE
storage: fix NPE in RaftTransport

### DIFF
--- a/pkg/storage/raft_transport_unit_test.go
+++ b/pkg/storage/raft_transport_unit_test.go
@@ -1,0 +1,105 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"math/rand"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/netutil"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/pkg/errors"
+)
+
+func TestRaftTransportStartNewQueue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	st := cluster.MakeTestingClusterSettings()
+	rpcC := rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, hlc.NewClock(hlc.UnixNano, 500*time.Millisecond), stopper, &st.Version)
+
+	// mrs := &dummyMultiRaftServer{}
+
+	grpcServer := rpc.NewServer(rpcC)
+	// RegisterMultiRaftServer(grpcServer, mrs)
+
+	var addr net.Addr
+
+	resolver := func(roachpb.NodeID) (net.Addr, error) {
+		if addr == nil {
+			return nil, errors.New("no addr yet") // should not happen in this test
+		}
+		return addr, nil
+	}
+
+	tp := NewRaftTransport(
+		log.AmbientContext{Tracer: tracing.NewTracer()},
+		cluster.MakeTestingClusterSettings(),
+		resolver,
+		grpcServer,
+		rpcC,
+	)
+
+	ln, err := netutil.ListenAndServeGRPC(stopper, grpcServer, &util.UnresolvedAddr{NetworkField: "tcp", AddressField: "localhost:0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	addr = ln.Addr()
+
+	defer func() {
+		if ln != nil {
+			_ = ln.Close()
+		}
+	}()
+
+	_, existingQueue := tp.getQueue(1)
+	if existingQueue {
+		t.Fatal("queue already exists")
+	}
+	timeout := time.Duration(rand.Int63n(int64(5 * time.Millisecond)))
+	log.Infof(ctx, "running test with a ctx cancellation of %s", timeout)
+	ctxBoom, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		<-time.After(timeout)
+		_ = ln.Close()
+		ln = nil
+		wg.Done()
+	}()
+	var stats raftTransportStats
+	tp.startProcessNewQueue(ctxBoom, 1, &stats)
+
+	wg.Wait()
+}


### PR DESCRIPTION
A recent refactor left the RaftTransport vulnerable to an NPE if the
underlying connection closed. Fixed the bug and added a regression test
that randomly closes the underlying listener and/or context to shake out
similar bugs.

Fixes #26995.

Release note: None