### PR TITLE
sql: proactively lease (some) tables

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -54,6 +54,7 @@
 <tr><td><code>sql.metrics.statement_details.dump_to_logs</code></td><td>boolean</td><td><code>false</code></td><td>dump collected statement statistics to node logs when periodically cleared</td></tr>
 <tr><td><code>sql.metrics.statement_details.enabled</code></td><td>boolean</td><td><code>true</code></td><td>collect per-statement query statistics</td></tr>
 <tr><td><code>sql.metrics.statement_details.threshold</code></td><td>duration</td><td><code>0s</code></td><td>minimum execution time to cause statistics to be collected</td></tr>
+<tr><td><code>sql.tables.proactive_lease_limit</code></td><td>integer</td><td><code>50</code></td><td>maximum number of tables to proactively lease</td></tr>
 <tr><td><code>sql.trace.log_statement_execute</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable logging of executed statements</td></tr>
 <tr><td><code>sql.trace.session_eventlog.enabled</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable session tracing</td></tr>
 <tr><td><code>sql.trace.txn.enable_threshold</code></td><td>duration</td><td><code>0s</code></td><td>duration beyond which all transactions are traced (set to 0 to disable)</td></tr>

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1662,6 +1662,8 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 			log.Error(ctx, err)
 		}
 	}
+	// Warm up table leases.
+	s.leaseMgr.PreLeaseTables(ctx, s.db)
 
 	log.Event(ctx, "server ready")
 

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -658,6 +659,7 @@ func (t *tableState) acquire(
 	// acquisition and us getting control again.
 	s := t.mu.active.findNewest()
 	for ; s == nil || s.hasExpired(timestamp); s = t.mu.active.findNewest() {
+		start := timeutil.Now()
 		var resultChan <-chan singleflight.Result
 		resultChan, _ = t.mu.group.DoChan(acquireGroupKey, func() (interface{}, error) {
 			return t.acquireNodeLease(ctx, m, hlc.Timestamp{})
@@ -667,6 +669,7 @@ func (t *tableState) acquire(
 			m.testingKnobs.LeaseStoreTestingKnobs.LeaseAcquireResultBlockEvent(LeaseAcquireBlock)
 		}
 		result := <-resultChan
+		log.VEventf(ctx, 2, "acquired lease on %d, took %v", t.id, timeutil.Since(start))
 		t.mu.Lock()
 		if result.Err != nil {
 			return nil, result.Err
@@ -1525,6 +1528,7 @@ func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, g *gossip.G
 		descKeyPrefix := keys.MakeTablePrefix(uint32(sqlbase.DescriptorTable.ID))
 		cfgFilter := gossip.MakeSystemConfigDeltaFilter(descKeyPrefix)
 		gossipUpdateC := g.RegisterSystemConfigChannel()
+		ticker := time.NewTicker(base.DefaultTableDescriptorLeaseRenewalTimeout)
 		for {
 			select {
 			case <-gossipUpdateC:
@@ -1573,10 +1577,58 @@ func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, g *gossip.G
 				if m.testingKnobs.TestingLeasesRefreshedEvent != nil {
 					m.testingKnobs.TestingLeasesRefreshedEvent(cfg)
 				}
-
+			case <-ticker.C:
+				m.PreLeaseTables(ctx, db)
 			case <-s.ShouldStop():
 				return
 			}
 		}
 	})
+}
+
+// preLeaseTableLimit is the upper-limit on the number of tables that will be
+// leased proactively, in the background, to keep fresh leases available even
+// before a query is issued that would trigger a lease acquisition. The default
+// value is ideally high enough that most clusters just have all tables leased
+// all the time, but prevents unintended blow-up for clusters that have very
+// large numbers of tables. If a table isn't pre-leased, any traffic to it will
+// still cause a lease to be maintained, so it is OK if this value is smaller
+// than the total number of tables -- it is mostly about making the initial,
+// out-of-box experience avoid the first-use delay.
+var preLeaseTableLimit = settings.RegisterIntSetting(
+	"sql.tables.proactive_lease_limit",
+	"maximum number of tables to proactively lease",
+	50,
+)
+
+// PreLeaseTables attempts to acquire leases on a configured number of tables
+// so that they already have active leases when the first user query that uses
+// them is processed, so that it will not need to block on lease acquisition.
+func (m *LeaseManager) PreLeaseTables(ctx context.Context, db *client.DB) {
+	limit := preLeaseTableLimit.Get(&m.execCfg.Settings.SV)
+	if limit <= 0 {
+		return
+	}
+
+	if err := db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		res, _, err := m.LeaseStore.execCfg.InternalExecutor.Query(
+			ctx, "list-tables", txn,
+			`SELECT id FROM system.namespace WHERE "parentID" > 0 LIMIT $1 ORDER BY id DESC`,
+			limit,
+		)
+		if err != nil {
+			return err
+		}
+		log.VEventf(ctx, 1, "pre-leasing %d tables", len(res))
+		now := txn.OrigTimestamp()
+		for _, i := range res {
+			id := sqlbase.ID(tree.MustBeDInt(i[0]))
+			if _, _, err := m.Acquire(ctx, now, id); err != nil {
+				log.Warning(ctx, errors.Wrapf(err, "failed to pre-lease table %d", id))
+			}
+		}
+		return nil
+	}); err != nil {
+		log.Warning(ctx, errors.Wrap(err, "failed to pre-lease tables"))
+	}
 }


### PR DESCRIPTION
Any traffic to a table already preserves an active lease, with leases
that are nearing expiration already automatically refreshed when used,
but if a gap in traffic allows leases to lapse, the first query after
that gap will incur the extra latency of re-acquiring leases.

This proactively leases (a configurable) number of tables, which should
mean that the first user-facing query does not need to block on
acquisition of a fresh table lease.

The limit on the number of proactively leased tables should ideally be
high enough that all tables are always leased, at least when getting
started with new proof-of-concept or demonstration deployment. Having a
limit prevents unintended blow-up for clusters that have a large number
of tables, but does meant that if a cluster grows to have more tables,
some may not be proactively leased. However, in produciton cluster that
is serving traffic, the mechanism mentioned above should still mean
that any table actually in-use remains leased regardless of this limit.

A follow-up could allow explictly configuring additional individual
tables that should be proactively leased in case the above limit kicks
in, though simply sending them periodic traffic would also work.

Release note: none.