### PR TITLE
cli: Deprecate --wait=live in `node decommission`

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -686,9 +686,6 @@ Takes any of the following values:
   - all:  waits until all target nodes' replica counts have dropped to zero.
     This is the default. Use this unless you are targeting down nodes. In the presence
     of down nodes, this will likely wait forever.
-  - live: waits until all live target nodes' replica counts have dropped to zero.
-    Use this when targeting down nodes only. When the process returns, manually verify
-    that the cluster is fully replicated before proceeding with node removal.
   - none: marks the targets as decommissioning, but does not wait for the process to complete.
     Use when polling manually from an external system.
 

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -493,6 +493,31 @@ func (txn *Txn) ReverseScan(
 	return txn.scan(ctx, begin, end, maxRows, true)
 }
 
+// Iterate performs a paginated scan and applying the function f to every page.
+// The semantics of retrieval and ordering are the same as for Scan. Note that
+// Txn auto-retries the transaction if necessary. Hence, the paginated data
+// must not be used for side-effects before the txn has committed.
+func (txn *Txn) Iterate(
+	ctx context.Context, begin, end interface{}, pageSize int, f func([]KeyValue) error,
+) error {
+	for {
+		rows, err := txn.Scan(ctx, begin, end, int64(pageSize))
+		if err != nil {
+			return errors.Wrap(err, "scanning meta2 keys")
+		}
+		if len(rows) == 0 {
+			return nil
+		}
+		if err := f(rows); err != nil {
+			return errors.Wrap(err, "running iterate callback")
+		}
+		if len(rows) < pageSize {
+			return nil
+		}
+		begin = rows[len(rows)-1].Key.Next()
+	}
+}
+
 // Del deletes one or more keys.
 //
 // key can be either a byte slice or a string.

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -1310,21 +1309,30 @@ func (s *adminServer) DecommissionStatus(
 
 	// Compute the replica counts for the target nodes only. This map doubles as
 	// a lookup table to check whether we care about a given node.
-	replicaCounts := make(map[roachpb.NodeID]int64)
-	for _, nodeID := range nodeIDs {
-		replicaCounts[nodeID] = math.MaxInt64
-	}
-
-	for _, nodeStatus := range ns.Nodes {
-		nodeID := nodeStatus.Desc.NodeID
-		if _, ok := replicaCounts[nodeID]; !ok {
-			continue // not interested in this node
+	var replicaCounts map[roachpb.NodeID]int64
+	if err := s.server.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		const pageSize = 10000
+		replicaCounts = make(map[roachpb.NodeID]int64)
+		for _, nodeID := range nodeIDs {
+			replicaCounts[nodeID] = 0
 		}
-		var replicas float64
-		for _, storeStatus := range nodeStatus.StoreStatuses {
-			replicas += storeStatus.Metrics["replicas"]
-		}
-		replicaCounts[nodeID] = int64(replicas)
+		return txn.Iterate(ctx, keys.Meta2Prefix, keys.MetaMax, pageSize,
+			func(rows []client.KeyValue) error {
+				rangeDesc := roachpb.RangeDescriptor{}
+				for _, row := range rows {
+					if err := row.ValueProto(&rangeDesc); err != nil {
+						return errors.Wrapf(err, "%s: unable to unmarshal range descriptor", row.Key)
+					}
+					for _, r := range rangeDesc.Replicas {
+						if _, ok := replicaCounts[r.NodeID]; ok {
+							replicaCounts[r.NodeID]++
+						}
+					}
+				}
+				return nil
+			})
+	}); err != nil {
+		return nil, err
 	}
 
 	var res serverpb.DecommissionStatusResponse

--- a/pkg/server/serverpb/admin.pb.go
+++ b/pkg/server/serverpb/admin.pb.go
@@ -699,11 +699,12 @@ func (*DecommissionStatusResponse) ProtoMessage()               {}
 func (*DecommissionStatusResponse) Descriptor() ([]byte, []int) { return fileDescriptorAdmin, []int{24} }
 
 type DecommissionStatusResponse_Status struct {
-	NodeID          github_com_cockroachdb_cockroach_pkg_roachpb.NodeID `protobuf:"varint,1,opt,name=node_id,json=nodeId,proto3,casttype=github.com/cockroachdb/cockroach/pkg/roachpb.NodeID" json:"node_id,omitempty"`
-	IsLive          bool                                                `protobuf:"varint,2,opt,name=is_live,json=isLive,proto3" json:"is_live,omitempty"`
-	ReplicaCount    int64                                               `protobuf:"varint,3,opt,name=replica_count,json=replicaCount,proto3" json:"replica_count,omitempty"`
-	Decommissioning bool                                                `protobuf:"varint,4,opt,name=decommissioning,proto3" json:"decommissioning,omitempty"`
-	Draining        bool                                                `protobuf:"varint,5,opt,name=draining,proto3" json:"draining,omitempty"`
+	NodeID github_com_cockroachdb_cockroach_pkg_roachpb.NodeID `protobuf:"varint,1,opt,name=node_id,json=nodeId,proto3,casttype=github.com/cockroachdb/cockroach/pkg/roachpb.NodeID" json:"node_id,omitempty"`
+	IsLive bool                                                `protobuf:"varint,2,opt,name=is_live,json=isLive,proto3" json:"is_live,omitempty"`
+	// The number of replicas on the node, computed by scanning meta2 ranges.
+	ReplicaCount    int64 `protobuf:"varint,3,opt,name=replica_count,json=replicaCount,proto3" json:"replica_count,omitempty"`
+	Decommissioning bool  `protobuf:"varint,4,opt,name=decommissioning,proto3" json:"decommissioning,omitempty"`
+	Draining        bool  `protobuf:"varint,5,opt,name=draining,proto3" json:"draining,omitempty"`
 }
 
 func (m *DecommissionStatusResponse_Status) Reset()         { *m = DecommissionStatusResponse_Status{} }

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -376,6 +376,7 @@ message DecommissionStatusResponse {
     int32 node_id = 1 [ (gogoproto.customname) = "NodeID",
                         (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"];
     bool is_live = 2;
+    // The number of replicas on the node, computed by scanning meta2 ranges.
     int64 replica_count = 3;
     bool decommissioning = 4;
     bool draining = 5;


### PR DESCRIPTION
Refer to issue #26880.

When you try to decommission a node that is down, today one has to use
`decommission --wait=live`, which does not verify whether the down node
is part of any ranges, and manually verify that the cluster has
up-replicated all ranges elsewhere. This is far from ideal, in particular
since there is no automated way to reliably check this.

`--wait=live` is deprecated and its behaviour replaced by that of
`--wait=all`. Instead of relying on metrics for replica counts, which
may be stale, look at authoritive source - range metadata.

Release note (cli change):
Deprecate `--wait=live` parameter for `node decommission`. `--wait=all`
is the default behaviour. This ensures CockroachDB checks ranges are on
the node to be decommissioned are not under-replicated before the node
is decommissioned.