### PR TITLE
storageccl: fix reuse of cmd args slice

### DIFF
--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -204,8 +204,8 @@ func addSplitSSTable(
 			}
 
 			split = true
-			first = first[:0]
-			last = last[:0]
+			first = nil
+			last = nil
 		}
 
 		if len(first) == 0 {


### PR DESCRIPTION
reusing the backing buffer after the slice was used as the start/end args
violates the expectation of the client that its args are not modified.

Fixes #26992.

Release note: none.