### PR TITLE
storage: test ClearRange command

### DIFF
--- a/pkg/storage/batcheval/cmd_clear_range.go
+++ b/pkg/storage/batcheval/cmd_clear_range.go
@@ -30,11 +30,11 @@ import (
 	"github.com/kr/pretty"
 )
 
-// clearRangeBytesThreshold is the threshold over which the ClearRange
+// ClearRangeBytesThreshold is the threshold over which the ClearRange
 // command will use engine.ClearRange to efficiently perform a range
 // deletion. Otherwise, will revert to iterating through the values
 // and clearing them individually with engine.Clear.
-const clearRangeBytesThreshold = 512 << 10 // 512KiB
+const ClearRangeBytesThreshold = 512 << 10 // 512KiB
 
 func init() {
 	RegisterCommand(roachpb.ClearRange, declareKeysClearRange, ClearRange)
@@ -79,8 +79,8 @@ func ClearRange(
 	// If the total size of data to be cleared is less than
 	// clearRangeBytesThreshold, clear the individual values manually,
 	// instead of using a range tombstone (inefficient for small ranges).
-	if total := statsDelta.Total(); total < clearRangeBytesThreshold {
-		log.VEventf(ctx, 2, "delta=%d < threshold=%d; using non-range clear", total, clearRangeBytesThreshold)
+	if total := statsDelta.Total(); total < ClearRangeBytesThreshold {
+		log.VEventf(ctx, 2, "delta=%d < threshold=%d; using non-range clear", total, ClearRangeBytesThreshold)
 		if err := batch.Iterate(
 			from, to,
 			func(kv engine.MVCCKeyValue) (bool, error) {

--- a/pkg/storage/batcheval/cmd_clear_range_test.go
+++ b/pkg/storage/batcheval/cmd_clear_range_test.go
@@ -61,8 +61,8 @@ func TestCmdClearRangeBytesThreshold(t *testing.T) {
 	valueStr := strings.Repeat("0123456789", 1024)
 	var value roachpb.Value
 	value.SetString(valueStr) // 10KiB
-	halfFull := clearRangeBytesThreshold / (2 * len(valueStr))
-	overFull := clearRangeBytesThreshold/len(valueStr) + 1
+	halfFull := ClearRangeBytesThreshold / (2 * len(valueStr))
+	overFull := ClearRangeBytesThreshold/len(valueStr) + 1
 	tests := []struct {
 		keyCount           int
 		expClearCount      int

--- a/pkg/storage/track_raft_protos.go
+++ b/pkg/storage/track_raft_protos.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/compactor"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -47,6 +48,9 @@ func TrackRaftProtos() func() []reflect.Type {
 		// Replica destroyed errors are written to disk, but they are
 		// deliberately per-replica values.
 		funcName((stateloader.StateLoader).SetReplicaDestroyedError),
+		// Compactions are suggested below Raft, but they are local to a store and
+		// thus not subject to Raft consistency requirements.
+		funcName((*compactor.Compactor).Suggest),
 	}
 
 	belowRaftProtos := struct {


### PR DESCRIPTION
This PR resolves half of the test failures in #25160. (Range merges generate suggested compactions below Raft, which trips over the same protobuf compatibility requirements that we're whitelisting against here.)

---

Add a test for the ClearRange command that executes it on an actual
store. This exposes that one path through the command generates a
serializes a new protobuf, storagebase.SuggestedCompaction, downstream
of Raft. Since this protobuf is written to an unreplicated, store-local
key it's not subject to the strict compatibility requirements of most
downstream-of-Raft protobufs; accordingly, whitelist it in the protobuf
compatibility checker.

Release note: None