### PR TITLE
storage: remove some legacy replica tombstone code for v2.1

### DIFF
--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -48,8 +48,8 @@ const (
 	VersionRPCVersionCheck
 	VersionClearRange
 	VersionPartitioning
-	VersionLeaseSequence // unused
-	VersionUnreplicatedTombstoneKey
+	VersionLeaseSequence            // unused
+	VersionUnreplicatedTombstoneKey // unused
 	VersionRecomputeStats
 	VersionNoRaftProposalKeys
 	VersionTxnSpanRefresh

--- a/pkg/storage/migrations.go
+++ b/pkg/storage/migrations.go
@@ -23,9 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
-// clearLegacyTombstone removes the legacy tombstone for the given rangeID, taking
-// care to do this without reading from the engine (as is required by one of the
-// callers).
+// clearLegacyTombstone removes the legacy tombstone for the given rangeID.
 func clearLegacyTombstone(eng engine.Writer, rangeID roachpb.RangeID) error {
 	return eng.Clear(engine.MakeMVCCMetadataKey(keys.RaftTombstoneIncorrectLegacyKey(rangeID)))
 }

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -873,9 +873,6 @@ func (r *Replica) setTombstoneKey(
 	r.mu.Unlock()
 
 	tombstoneKey := keys.RaftTombstoneKey(desc.RangeID)
-	if !r.store.cfg.Settings.Version.IsMinSupported(cluster.VersionUnreplicatedTombstoneKey) {
-		tombstoneKey = keys.RaftTombstoneIncorrectLegacyKey(desc.RangeID)
-	}
 	tombstone := &roachpb.RaftTombstone{
 		NextReplicaID: nextReplicaID,
 	}


### PR DESCRIPTION
This is important for range merges. Merges will destroy replicas beneath Raft, which means serializing a RaftTombstone protobuf beneath Raft. It's much easier to prove that this is safe when the protobuf is only written to unreplicated key space.

---

v2.1 is always able to run the replica tombstone migration at boot, so
we can remove quite a bit of the code paths that deal with legacy
replica tombstones. Specifically, a v2.1 node is guaranteed that its
local store has no legacy tombstones after boot.

Specifically:

    * When writing a tombstone, we no longer need to write the legacy
      tombstone. We need only to write the new tombstone.

    * When performing a consistency check, we no longer need to skip
      over legacy tombstones.

    * When receiving a snapshot, we no longer need to worry about
      removing a pre-existing legacy tombstone. Notably it is possible for
      a snapshot to contain a legacy tombstone in a mixed 2.0-2.1 cluster
      (a comment in the old code indicated differently), so we must
      continue to purge legacy tombstones from incoming snapshots.

Release note: None