### PR TITLE
distsql: refactor joinReader to implement RowSource

### DIFF
--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -148,6 +148,7 @@ func newHashJoiner(
 		numMergedColumns = len(spec.LeftEqColumns)
 	}
 	if err := h.joinerBase.init(
+		nil, /* self */
 		flowCtx,
 		processorID,
 		leftSource.OutputTypes(),

--- a/pkg/sql/distsqlrun/indexjoiner.go
+++ b/pkg/sql/distsqlrun/indexjoiner.go
@@ -1,0 +1,233 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package distsqlrun
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
+)
+
+const indexJoinerBatchSize = 100
+
+// indexJoiner performs a join between a secondary index, the `input`, and the
+// primary index of the same table, `desc`, to retrieve columns which are not
+// stored in the secondary index.
+type indexJoiner struct {
+	processorBase
+
+	input RowSource
+	desc  sqlbase.TableDescriptor
+
+	// fetcherInput wraps fetcher in a RowSource implementation and should be used
+	// to get rows from the fetcher. This enables the indexJoiner to wrap the
+	// fetcherInput with a stat collector when necessary.
+	fetcherInput RowSource
+	fetcher      sqlbase.RowFetcher
+	// fetcherReady indicates that we have started an index scan and there are
+	// potentially more rows to retrieve.
+	fetcherReady bool
+	// Batch size for fetches. Not a constant so we can lower for testing.
+	batchSize int
+
+	// keyPrefix is the primary index's key prefix.
+	keyPrefix []byte
+	// spans is the batch of spans we will next retrieve from the index.
+	spans roachpb.Spans
+
+	alloc sqlbase.DatumAlloc
+}
+
+var _ Processor = &indexJoiner{}
+var _ RowSource = &indexJoiner{}
+
+const indexJoinerProcName = "index joiner"
+
+func newIndexJoiner(
+	flowCtx *FlowCtx,
+	processorID int32,
+	spec *JoinReaderSpec,
+	input RowSource,
+	post *PostProcessSpec,
+	output RowReceiver,
+) (*indexJoiner, error) {
+	if spec.IndexIdx != 0 {
+		return nil, errors.Errorf("index join must be against primary index")
+	}
+	ij := &indexJoiner{
+		input:     input,
+		desc:      spec.Table,
+		keyPrefix: sqlbase.MakeIndexKeyPrefix(&spec.Table, spec.Table.PrimaryIndex.ID),
+		batchSize: indexJoinerBatchSize,
+	}
+	if err := ij.init(
+		ij,
+		post,
+		ij.desc.ColumnTypes(),
+		flowCtx,
+		processorID,
+		output,
+		nil, /* memMonitor */
+		procStateOpts{
+			inputsToDrain: []RowSource{ij.input},
+			trailingMetaCallback: func() []ProducerMetadata {
+				ij.internalClose()
+				if txnMeta := getTxnCoordMeta(ij.flowCtx.txn); txnMeta != nil {
+					return []ProducerMetadata{{TxnMeta: txnMeta}}
+				}
+				return nil
+			},
+		},
+	); err != nil {
+		return nil, err
+	}
+	if _, _, err := initRowFetcher(
+		&ij.fetcher,
+		&ij.desc,
+		0, /* primary index */
+		ij.desc.ColumnIdxMap(),
+		false, /* reverse */
+		ij.out.neededColumns(),
+		false, /* isCheck */
+		&ij.alloc,
+	); err != nil {
+		return nil, err
+	}
+	ij.fetcherInput = &rowFetcherWrapper{RowFetcher: &ij.fetcher}
+
+	if sp := opentracing.SpanFromContext(flowCtx.EvalCtx.Ctx()); sp != nil && tracing.IsRecording(sp) {
+		// Enable stats collection.
+		ij.input = NewInputStatCollector(ij.input)
+		ij.fetcherInput = NewInputStatCollector(ij.fetcherInput)
+		ij.finishTrace = ij.outputStatsToTrace
+	}
+
+	return ij, nil
+}
+
+// Start is part of the RowSource interface.
+func (ij *indexJoiner) Start(ctx context.Context) context.Context {
+	ij.input.Start(ctx)
+	return ij.startInternal(ctx, indexJoinerProcName)
+}
+
+// Next is part of the RowSource interface.
+func (ij *indexJoiner) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+	for ij.state == stateRunning {
+		if !ij.fetcherReady {
+			// Retrieve a batch of rows from the input.
+			for len(ij.spans) < ij.batchSize {
+				row, meta := ij.input.Next()
+				if meta != nil {
+					if meta.Err != nil {
+						ij.moveToDraining(nil /* err */)
+					}
+					return nil, meta
+				}
+				if row == nil {
+					break
+				}
+				span, err := ij.generateSpan(row)
+				if err != nil {
+					ij.moveToDraining(err)
+					return nil, ij.drainHelper()
+				}
+				ij.spans = append(ij.spans, span)
+			}
+			if len(ij.spans) == 0 {
+				// All done.
+				ij.moveToDraining(nil /* err */)
+				return nil, ij.drainHelper()
+			}
+			// Scan the primary index for this batch.
+			err := ij.fetcher.StartScan(
+				ij.ctx, ij.flowCtx.txn, ij.spans, false /* limitBatches */, 0, /* limitHint */
+				false /* traceKV */)
+			if err != nil {
+				ij.moveToDraining(err)
+				return nil, ij.drainHelper()
+			}
+			ij.fetcherReady = true
+			ij.spans = ij.spans[:0]
+		}
+		row, meta := ij.fetcherInput.Next()
+		if meta != nil {
+			ij.moveToDraining(scrub.UnwrapScrubError(meta.Err))
+			return nil, ij.drainHelper()
+		}
+		if row == nil {
+			// Done with this batch.
+			ij.fetcherReady = false
+		} else if outRow := ij.processRowHelper(row); outRow != nil {
+			return outRow, nil
+		}
+	}
+	return nil, ij.drainHelper()
+}
+
+// ConsumerDone is part of the RowSource interface.
+func (ij *indexJoiner) ConsumerDone() {
+	ij.moveToDraining(nil /* err */)
+}
+
+// ConsumerClosed is part of the RowSource interface.
+func (ij *indexJoiner) ConsumerClosed() {
+	// The consumer is done, Next() will not be called again.
+	ij.internalClose()
+}
+
+func (ij *indexJoiner) generateSpan(row sqlbase.EncDatumRow) (roachpb.Span, error) {
+	numKeyCols := len(ij.desc.PrimaryIndex.ColumnIDs)
+	if len(row) < numKeyCols {
+		return roachpb.Span{}, errors.Errorf(
+			"index join input has %d columns, expected at least %d", len(row), numKeyCols)
+	}
+	// There may be extra values on the row, e.g. to allow an ordered
+	// synchronizer to interleave multiple input streams. Will need at most
+	// numKeyCols.
+	keyRow := row[:numKeyCols]
+	types := ij.input.OutputTypes()[:numKeyCols]
+	key, err := sqlbase.MakeKeyFromEncDatums(
+		types, keyRow, &ij.desc, &ij.desc.PrimaryIndex, ij.keyPrefix, &ij.alloc)
+	if err != nil {
+		return roachpb.Span{}, err
+	}
+	return roachpb.Span{Key: key, EndKey: key.PrefixEnd()}, nil
+}
+
+// outputStatsToTrace outputs the collected indexJoiner stats to the trace. Will
+// fail silently if the indexJoiner is not collecting stats.
+func (ij *indexJoiner) outputStatsToTrace() {
+	is, ok := getInputStats(ij.flowCtx, ij.input)
+	if !ok {
+		return
+	}
+	ils, ok := getInputStats(ij.flowCtx, ij.fetcherInput)
+	if !ok {
+		return
+	}
+	jrs := &JoinReaderStats{
+		InputStats:       is,
+		IndexLookupStats: ils,
+	}
+	if sp := opentracing.SpanFromContext(ij.ctx); sp != nil {
+		tracing.SetSpanStats(sp, jrs)
+	}
+}

--- a/pkg/sql/distsqlrun/indexjoiner_test.go
+++ b/pkg/sql/distsqlrun/indexjoiner_test.go
@@ -1,0 +1,161 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package distsqlrun
+
+import (
+	"testing"
+
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestIndexJoiner(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+
+	// Create a table where each row is:
+	//
+	//  |     a    |     b    |         sum         |         s           |
+	//  |-----------------------------------------------------------------|
+	//  | rowId/10 | rowId%10 | rowId/10 + rowId%10 | IntToEnglish(rowId) |
+
+	aFn := func(row int) tree.Datum {
+		return tree.NewDInt(tree.DInt(row / 10))
+	}
+	bFn := func(row int) tree.Datum {
+		return tree.NewDInt(tree.DInt(row % 10))
+	}
+	sumFn := func(row int) tree.Datum {
+		return tree.NewDInt(tree.DInt(row/10 + row%10))
+	}
+
+	sqlutils.CreateTable(t, sqlDB, "t",
+		"a INT, b INT, sum INT, s STRING, PRIMARY KEY (a,b), INDEX bs (b,s)",
+		99,
+		sqlutils.ToRowFn(aFn, bFn, sumFn, sqlutils.RowEnglishFn))
+
+	td := sqlbase.GetTableDescriptor(kvDB, "test", "t")
+
+	v := [10]sqlbase.EncDatum{}
+	for i := range v {
+		v[i] = intEncDatum(i)
+	}
+
+	testCases := []struct {
+		description string
+		post        PostProcessSpec
+		input       sqlbase.EncDatumRows
+		outputTypes []sqlbase.ColumnType
+		expected    sqlbase.EncDatumRows
+	}{
+		{
+			description: "Test selecting rows using the primary index",
+			post: PostProcessSpec{
+				Projection:    true,
+				OutputColumns: []uint32{0, 1, 2},
+			},
+			input: sqlbase.EncDatumRows{
+				{v[0], v[2]},
+				{v[0], v[5]},
+				{v[1], v[0]},
+				{v[1], v[5]},
+			},
+			outputTypes: threeIntCols,
+			expected: sqlbase.EncDatumRows{
+				{v[0], v[2], v[2]},
+				{v[0], v[5], v[5]},
+				{v[1], v[0], v[1]},
+				{v[1], v[5], v[6]},
+			},
+		},
+		{
+			description: "Test duplicate rows in input stream on index join",
+			post: PostProcessSpec{
+				Projection:    true,
+				OutputColumns: []uint32{0, 1, 2},
+			},
+			input: sqlbase.EncDatumRows{
+				{v[0], v[2]},
+				{v[0], v[2]},
+				{v[0], v[5]},
+				{v[0], v[5]},
+				{v[0], v[2]},
+			},
+			outputTypes: threeIntCols,
+			expected: sqlbase.EncDatumRows{
+				{v[0], v[2], v[2]},
+				{v[0], v[2], v[2]},
+				{v[0], v[5], v[5]},
+				{v[0], v[5], v[5]},
+				{v[0], v[2], v[2]},
+			},
+		},
+		{
+			description: "Test a filter in the post process spec and using a secondary index",
+			post: PostProcessSpec{
+				Filter:        Expression{Expr: "@3 <= 5"}, // sum <= 5
+				Projection:    true,
+				OutputColumns: []uint32{3},
+			},
+			input: sqlbase.EncDatumRows{
+				{v[0], v[1]},
+				{v[2], v[5]},
+				{v[0], v[5]},
+				{v[2], v[1]},
+				{v[3], v[4]},
+				{v[1], v[3]},
+				{v[5], v[1]},
+				{v[5], v[0]},
+			},
+			outputTypes: []sqlbase.ColumnType{strType},
+			expected: sqlbase.EncDatumRows{
+				{strEncDatum("one")},
+				{strEncDatum("five")},
+				{strEncDatum("two-one")},
+				{strEncDatum("one-three")},
+				{strEncDatum("five-zero")},
+			},
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.description, func(t *testing.T) {
+			spec := JoinReaderSpec{
+				Table:    *td,
+				IndexIdx: 0,
+			}
+			txn := client.NewTxn(s.DB(), s.NodeID(), client.RootTxn)
+			runProcessorTest(
+				t,
+				ProcessorCoreUnion{JoinReader: &spec},
+				c.post,
+				twoIntCols,
+				c.input,
+				c.outputTypes,
+				c.expected,
+				txn,
+			)
+		})
+	}
+}

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner.go
@@ -401,7 +401,9 @@ func (irj *interleavedReaderJoiner) Run(ctx context.Context, wg *sync.WaitGroup)
 
 	irj.sendMisplannedRangesMetadata(ctx)
 	sendTraceData(ctx, irj.out.output)
-	sendTxnCoordMetaMaybe(irj.flowCtx.txn, irj.out.output)
+	if txnMeta := getTxnCoordMeta(irj.flowCtx.txn); txnMeta != nil {
+		irj.out.output.Push(nil /* row */, &ProducerMetadata{TxnMeta: txnMeta})
+	}
 	irj.out.Close()
 }
 

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner.go
@@ -164,6 +164,7 @@ func newInterleavedReaderJoiner(
 
 	// TODO(richardwu): Generalize this to 2+ tables.
 	if err := irj.joinerBase.init(
+		nil, /* self */
 		flowCtx,
 		processorID,
 		irj.tables[0].post.outputTypes,

--- a/pkg/sql/distsqlrun/joinerbase.go
+++ b/pkg/sql/distsqlrun/joinerbase.go
@@ -47,6 +47,7 @@ type joinerBase struct {
 // opts is passed along to the underlying processorBase. The zero value is used
 // if the processor using the joinerBase is not implementing RowSource.
 func (jb *joinerBase) init(
+	self RowSource,
 	flowCtx *FlowCtx,
 	processorID int32,
 	leftTypes []sqlbase.ColumnType,
@@ -106,7 +107,7 @@ func (jb *joinerBase) init(
 	outputTypes := condTypes[:outputSize]
 
 	if err := jb.processorBase.init(
-		nil, post, outputTypes, flowCtx, processorID, output, nil /* memMonitor */, opts,
+		self, post, outputTypes, flowCtx, processorID, output, nil /* memMonitor */, opts,
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
@@ -27,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/opentracing/opentracing-go"
 )
 
 // TODO(radu): we currently create one batch at a time and run the KV operations
@@ -35,18 +35,9 @@ import (
 // nodes that "own" the respective ranges, and send out flows on those nodes.
 const joinReaderBatchSize = 100
 
-// A joinReader can perform an index join or a lookup join. Specifying a
-// non-empty value for lookupCols indicates it is a lookup join.
-//
-// For an index join, the `input`, considered to be the left side, is subset of
-// rows of the `desc` table where the first n columns correspond to the n
-// columns of the index. These come from a secondary index. The right side comes
-// from a primary index.
-//
-// For a lookup join, the input is another table and the columns which match the
-// index are specified in the `lookupCols` field. If the index is a secondary
-// index which does not cover the needed output columns, a second lookup will be
-// performed to retrieve those columns from the primary index.
+// joinReader performs a lookup join between `input` and the specified `index`.
+// `lookupCols` specifies the input columns which will be used for the index
+// lookup.
 type joinReader struct {
 	joinerBase
 
@@ -111,38 +102,30 @@ func newJoinReader(
 		return nil, err
 	}
 	jr.colIdxMap = jr.desc.ColumnIdxMap()
-	if jr.isLookupJoin() {
-		indexCols := make([]uint32, len(jr.index.ColumnIDs))
-		for i, columnID := range jr.index.ColumnIDs {
-			indexCols[i] = uint32(columnID)
-		}
-		if err := jr.joinerBase.init(
-			flowCtx,
-			processorID,
-			input.OutputTypes(),
-			jr.desc.ColumnTypes(),
-			spec.Type,
-			spec.OnExpr,
-			jr.lookupCols,
-			indexCols,
-			0, /* numMergedColumns */
-			post,
-			output,
-			procStateOpts{}, // joinReader doesn't implement RowSource and so doesn't use it.
-		); err != nil {
-			return nil, err
-		}
-		if spec.IndexFilterExpr.Expr != "" {
-			err := jr.indexFilter.init(spec.IndexFilterExpr, jr.desc.ColumnTypes(), jr.evalCtx)
-			if err != nil {
-				return nil, err
-			}
-		}
-	} else {
-		if err := jr.processorBase.init(
-			nil, post, jr.desc.ColumnTypes(), flowCtx, processorID, output, nil, /* memMonitor */
-			procStateOpts{}, // joinReader doesn't implement RowSource and so doesn't use it.
-		); err != nil {
+
+	indexCols := make([]uint32, len(jr.index.ColumnIDs))
+	for i, columnID := range jr.index.ColumnIDs {
+		indexCols[i] = uint32(columnID)
+	}
+	if err := jr.joinerBase.init(
+		flowCtx,
+		processorID,
+		input.OutputTypes(),
+		jr.desc.ColumnTypes(),
+		spec.Type,
+		spec.OnExpr,
+		jr.lookupCols,
+		indexCols,
+		0, /* numMergedColumns */
+		post,
+		output,
+		procStateOpts{}, // joinReader doesn't implement RowSource and so doesn't use it.
+	); err != nil {
+		return nil, err
+	}
+	if spec.IndexFilterExpr.Expr != "" {
+		err := jr.indexFilter.init(spec.IndexFilterExpr, jr.desc.ColumnTypes(), jr.evalCtx)
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -234,9 +217,6 @@ func getPrimaryColumnTypes(table *sqlbase.TableDescriptor) ([]sqlbase.ColumnType
 // from the right side of the join (jr.desc).
 func (jr *joinReader) neededRightCols() util.FastIntSet {
 	neededCols := jr.out.neededColumns()
-	if !jr.isLookupJoin() {
-		return neededCols
-	}
 
 	// Get the columns from the right side of the join and shift them over by
 	// the size of the left side so the right side starts at 0.
@@ -269,27 +249,19 @@ func (jr *joinReader) generateKey(
 ) (roachpb.Key, error) {
 	index := jr.index
 	numKeyCols := len(index.ColumnIDs)
-	if !jr.isLookupJoin() && len(row) < numKeyCols {
-		return nil, errors.Errorf("joinReader input has %d columns, expected at least %d",
-			len(row), numKeyCols)
-	}
+
 	// There may be extra values on the row, e.g. to allow an ordered synchronizer
 	// to interleave multiple input streams.
 	// Will need at most numKeyCols.
 	keyRow := make(sqlbase.EncDatumRow, 0, numKeyCols)
 	types := make([]sqlbase.ColumnType, 0, numKeyCols)
-	if jr.isLookupJoin() {
-		if len(lookupCols) > numKeyCols {
-			return nil, errors.Errorf("%d equality columns specified, expecting at most %d",
-				len(jr.lookupCols), numKeyCols)
-		}
-		for _, id := range lookupCols {
-			keyRow = append(keyRow, row[id])
-			types = append(types, jr.inputTypes[id])
-		}
-	} else {
-		keyRow = row[:numKeyCols]
-		types = jr.inputTypes[:numKeyCols]
+	if len(lookupCols) > numKeyCols {
+		return nil, errors.Errorf("%d equality columns specified, expecting at most %d",
+			len(jr.lookupCols), numKeyCols)
+	}
+	for _, id := range lookupCols {
+		keyRow = append(keyRow, row[id])
+		types = append(types, jr.inputTypes[id])
 	}
 
 	return sqlbase.MakeKeyFromEncDatums(types, keyRow, &jr.desc, index, keyPrefix, alloc)
@@ -365,28 +337,18 @@ func (jr *joinReader) mainLoop(ctx context.Context) error {
 				Key:    key,
 				EndKey: key.PrefixEnd(),
 			}
-			if jr.isLookupJoin() {
-				rows = append(rows, jr.out.rowAlloc.CopyRow(row))
-				if spanToRowIndices[key.String()] == nil {
-					spans = append(spans, span)
-				}
-				spanToRowIndices[key.String()] = append(spanToRowIndices[key.String()], rowIdx)
-				rowIdx++
-			} else {
+			rows = append(rows, jr.out.rowAlloc.CopyRow(row))
+			if spanToRowIndices[key.String()] == nil {
 				spans = append(spans, span)
 			}
+			spanToRowIndices[key.String()] = append(spanToRowIndices[key.String()], rowIdx)
+			rowIdx++
 		}
 
 		// TODO(radu): we are consuming all results from a fetch before starting
 		// the next batch. We could start the next batch early while we are
 		// outputting rows.
-		var earlyExit bool
-		var err error
-		if jr.isLookupJoin() {
-			earlyExit, err = jr.lookupJoinLookup(ctx, txn, spans, rows, spanToRowIndices)
-		} else {
-			earlyExit, err = jr.indexJoinLookup(ctx, txn, spans)
-		}
+		earlyExit, err := jr.lookupJoinLookup(ctx, txn, spans, rows, spanToRowIndices)
 		if err != nil {
 			return err
 		} else if earlyExit {
@@ -400,45 +362,6 @@ func (jr *joinReader) mainLoop(ctx context.Context) error {
 			return nil
 		}
 	}
-}
-
-// A joinReader performs a lookup join if lookup columns were specified,
-// otherwise it performs an index join.
-func (jr *joinReader) isLookupJoin() bool {
-	return len(jr.lookupCols) > 0
-}
-
-// indexJoinLookup performs an index lookup for the purposes of an index join.
-// It fetches the specified spans from the primary index and emits the results.
-//
-// Returns false if more rows need to be produced, true otherwise. If true is
-// returned, both the inputs and the output have been drained and closed, except
-// if an error is returned.
-func (jr *joinReader) indexJoinLookup(
-	ctx context.Context, txn *client.Txn, spans roachpb.Spans,
-) (bool, error) {
-	// TODO(radu,andrei,knz): set the traceKV flag when requested by the session.
-	err := jr.fetcher.StartScan(
-		ctx, txn, spans, false /* limitBatches */, 0 /* limitHint */, false /* traceKV */)
-	if err != nil {
-		log.Errorf(ctx, "scan error: %s", err)
-		return true, err
-	}
-	for {
-		row, meta := jr.fetcherInput.Next()
-		if meta != nil {
-			return true, scrub.UnwrapScrubError(meta.Err)
-		}
-		if row == nil {
-			// Done with this batch.
-			break
-		}
-		// Emit the row; stop if no more rows are needed.
-		if !emitHelper(ctx, &jr.out, row, nil /* meta */, jr.pushTrailingMeta, jr.input) {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 // lookupJoinLookup performs an index lookup for the purposes of a lookup join.

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -16,7 +16,6 @@ package distsqlrun
 
 import (
 	"context"
-	"sync"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -35,11 +34,30 @@ import (
 // nodes that "own" the respective ranges, and send out flows on those nodes.
 const joinReaderBatchSize = 100
 
+// joinReaderState represents the state of the processor.
+type joinReaderState int
+
+const (
+	jrStateUnknown joinReaderState = iota
+	// jrReadingInput means that a batch of rows is being read from the input.
+	jrReadingInput
+	// jrPerformingLookup means we are performing an index lookup for the current
+	// input row batch.
+	jrPerformingLookup
+	// jrEmittingRows means we are emitting the results of the index lookup.
+	jrEmittingRows
+)
+
 // joinReader performs a lookup join between `input` and the specified `index`.
 // `lookupCols` specifies the input columns which will be used for the index
 // lookup.
 type joinReader struct {
 	joinerBase
+
+	// runningState represents the state of the joinReader. This is in addition to
+	// processorBase.state - the runningState is only relevant when
+	// processorBase.state == stateRunning.
+	runningState joinReaderState
 
 	desc      sqlbase.TableDescriptor
 	index     *sqlbase.IndexDescriptor
@@ -48,10 +66,11 @@ type joinReader struct {
 	// fetcherInput wraps fetcher in a RowSource implementation and should be used
 	// to get rows from the fetcher. This enables the joinReader to wrap the
 	// fetcherInput with a stat collector when necessary.
-	fetcherInput RowSource
-	fetcher      sqlbase.RowFetcher
-	alloc        sqlbase.DatumAlloc
-	rowAlloc     sqlbase.EncDatumRowAlloc
+	fetcherInput   RowSource
+	fetcher        sqlbase.RowFetcher
+	indexKeyPrefix []byte
+	alloc          sqlbase.DatumAlloc
+	rowAlloc       sqlbase.EncDatumRowAlloc
 
 	input      RowSource
 	inputTypes []sqlbase.ColumnType
@@ -74,9 +93,17 @@ type joinReader struct {
 
 	// Batch size for fetches. Not a constant so we can lower for testing.
 	batchSize int
+
+	// State variables for each batch of input rows.
+	inputRows            sqlbase.EncDatumRows
+	keyToInputRowIndices map[string][]int
+	emitted              []bool
+	finalLookupBatch     bool
+	toEmit               sqlbase.EncDatumRows
 }
 
 var _ Processor = &joinReader{}
+var _ RowSource = &joinReader{}
 
 const joinReaderProcName = "join reader"
 
@@ -89,15 +116,17 @@ func newJoinReader(
 	output RowReceiver,
 ) (*joinReader, error) {
 	jr := &joinReader{
-		desc:       spec.Table,
-		input:      input,
-		inputTypes: input.OutputTypes(),
-		lookupCols: spec.LookupColumns,
-		batchSize:  joinReaderBatchSize,
+		desc:                 spec.Table,
+		input:                input,
+		inputTypes:           input.OutputTypes(),
+		lookupCols:           spec.LookupColumns,
+		batchSize:            joinReaderBatchSize,
+		keyToInputRowIndices: make(map[string][]int),
 	}
 
 	var err error
-	jr.index, _, err = jr.desc.FindIndexByIndexIdx(int(spec.IndexIdx))
+	var isSecondary bool
+	jr.index, isSecondary, err = jr.desc.FindIndexByIndexIdx(int(spec.IndexIdx))
 	if err != nil {
 		return nil, err
 	}
@@ -108,6 +137,7 @@ func newJoinReader(
 		indexCols[i] = uint32(columnID)
 	}
 	if err := jr.joinerBase.init(
+		jr,
 		flowCtx,
 		processorID,
 		input.OutputTypes(),
@@ -119,7 +149,16 @@ func newJoinReader(
 		0, /* numMergedColumns */
 		post,
 		output,
-		procStateOpts{}, // joinReader doesn't implement RowSource and so doesn't use it.
+		procStateOpts{
+			inputsToDrain: []RowSource{jr.input},
+			trailingMetaCallback: func() []ProducerMetadata {
+				jr.internalClose()
+				if txnMeta := getTxnCoordMeta(jr.flowCtx.txn); txnMeta != nil {
+					return []ProducerMetadata{{TxnMeta: txnMeta}}
+				}
+				return nil
+			},
+		},
 	); err != nil {
 		return nil, err
 	}
@@ -138,8 +177,7 @@ func newJoinReader(
 		collectingStats = true
 	}
 
-	if jr.index == &jr.desc.PrimaryIndex ||
-		jr.neededRightCols().SubsetOf(getIndexColSet(jr.index, jr.colIdxMap)) {
+	if !isSecondary || jr.neededRightCols().SubsetOf(getIndexColSet(jr.index, jr.colIdxMap)) {
 		// jr.index includes all the needed output columns, so only need one lookup.
 		neededIndexColumns = jr.neededRightCols()
 	} else {
@@ -178,7 +216,10 @@ func newJoinReader(
 	if collectingStats {
 		jr.input = NewInputStatCollector(jr.input)
 		jr.fetcherInput = NewInputStatCollector(jr.fetcherInput)
+		jr.finishTrace = jr.outputStatsToTrace
 	}
+
+	jr.indexKeyPrefix = sqlbase.MakeIndexKeyPrefix(&jr.desc, jr.index.ID)
 
 	// TODO(radu): verify the input types match the index key types
 	return jr, nil
@@ -244,153 +285,105 @@ func (jr *joinReader) neededRightCols() util.FastIntSet {
 // Generate a key to create a span for a given row.
 // If lookup columns are specified will use those to collect the relevant
 // columns. Otherwise the first rows are assumed to correspond with the index.
-func (jr *joinReader) generateKey(
-	row sqlbase.EncDatumRow, alloc *sqlbase.DatumAlloc, keyPrefix []byte, lookupCols columns,
-) (roachpb.Key, error) {
-	index := jr.index
-	numKeyCols := len(index.ColumnIDs)
+func (jr *joinReader) generateKey(row sqlbase.EncDatumRow) (roachpb.Key, error) {
+	numKeyCols := len(jr.index.ColumnIDs)
 
 	// There may be extra values on the row, e.g. to allow an ordered synchronizer
 	// to interleave multiple input streams.
 	// Will need at most numKeyCols.
 	keyRow := make(sqlbase.EncDatumRow, 0, numKeyCols)
 	types := make([]sqlbase.ColumnType, 0, numKeyCols)
-	if len(lookupCols) > numKeyCols {
-		return nil, errors.Errorf("%d equality columns specified, expecting at most %d",
-			len(jr.lookupCols), numKeyCols)
+
+	if len(jr.lookupCols) > numKeyCols {
+		return nil, errors.Errorf(
+			"%d lookup columns specified, expecting at most %d", len(jr.lookupCols), numKeyCols)
 	}
-	for _, id := range lookupCols {
+	for _, id := range jr.lookupCols {
 		keyRow = append(keyRow, row[id])
 		types = append(types, jr.inputTypes[id])
 	}
 
-	return sqlbase.MakeKeyFromEncDatums(types, keyRow, &jr.desc, index, keyPrefix, alloc)
+	return sqlbase.MakeKeyFromEncDatums(
+		types, keyRow, &jr.desc, jr.index, jr.indexKeyPrefix, &jr.alloc)
 }
 
-func (jr *joinReader) pushTrailingMeta(ctx context.Context) {
-	// TODO(asubiotto): Once joinReader implements RowSource, set
-	// processorBase.finishTrace = jr.outputStatsToTrace
-	jr.outputStatsToTrace()
-	sendTraceData(ctx, jr.out.output)
-	sendTxnCoordMetaMaybe(jr.flowCtx.txn, jr.out.output)
+// Next is part of the RowSource interface.
+func (jr *joinReader) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+	// The lookup join is implemented as follows:
+	// - Read the input rows in batches.
+	// - For each batch, map the the rows onto index keys and perform an index
+	//   lookup for those keys. Note that multiple rows may map to the same key.
+	// - Retrieve the index lookup results in batches, since the index scan may
+	//   return more rows than the input batch size.
+	// - If the index is a secondary index which does not contain all the needed
+	//   output columns, perform a second lookup on the primary index.
+	// - Join the index rows with the corresponding input rows and buffer the
+	//   results in jr.toEmit.
+	for jr.state == stateRunning {
+		var row sqlbase.EncDatumRow
+		var meta *ProducerMetadata
+		switch jr.runningState {
+		case jrReadingInput:
+			jr.runningState, meta = jr.readInput()
+		case jrPerformingLookup:
+			jr.runningState, meta = jr.performLookup()
+		case jrEmittingRows:
+			jr.runningState, row, meta = jr.emitRow()
+		default:
+			log.Fatalf(jr.ctx, "unsupported state: %d", jr.runningState)
+		}
+		if row != nil || meta != nil {
+			return row, meta
+		}
+	}
+	return nil, jr.drainHelper()
 }
 
-// mainLoop runs the mainLoop and returns any error.
-//
-// If no error is returned, the input has been drained and the output has been
-// closed. If an error is returned, the input hasn't been drained; the caller
-// should drain and close the output. The caller should also pass the returned
-// error to the consumer.
-func (jr *joinReader) mainLoop(ctx context.Context) error {
-	primaryKeyPrefix := sqlbase.MakeIndexKeyPrefix(&jr.desc, jr.index.ID)
+// readInput reads the next batch of input rows and starts an index scan.
+func (jr *joinReader) readInput() (joinReaderState, *ProducerMetadata) {
+	// Read the next batch of input rows.
+	for len(jr.inputRows) < jr.batchSize {
+		row, meta := jr.input.Next()
+		if meta != nil {
+			if meta.Err != nil {
+				jr.moveToDraining(nil /* err */)
+				return jrStateUnknown, meta
+			}
+			return jrReadingInput, meta
+		}
+		if row == nil {
+			break
+		}
+		jr.inputRows = append(jr.inputRows, jr.rowAlloc.CopyRow(row))
+	}
 
-	var alloc sqlbase.DatumAlloc
-	var rows []sqlbase.EncDatumRow
+	if len(jr.inputRows) == 0 {
+		// We're done.
+		jr.moveToDraining(nil)
+		return jrStateUnknown, jr.drainHelper()
+	}
+
+	// Start the index lookup. We maintain a map from index key to the
+	// corresponding input rows so we can join the index results to the
+	// inputs.
 	var spans roachpb.Spans
-
-	txn := jr.flowCtx.txn
-	if txn == nil {
-		log.Fatalf(ctx, "joinReader outside of txn")
-	}
-
-	log.VEventf(ctx, 1, "starting")
-	if log.V(1) {
-		defer log.Infof(ctx, "exiting")
-	}
-
-	for {
-		// TODO(radu): figure out how to send smaller batches if the source has
-		// a soft limit (perhaps send the batch out if we don't get a result
-		// within a certain amount of time).
-		rowIdx := 0
-		rows = rows[:0]
-		spans = spans[:0]
-		spanToRowIndices := make(map[string][]int, joinReaderBatchSize)
-		for len(spans) < jr.batchSize {
-			row, meta := jr.input.Next()
-			if meta != nil {
-				if meta.Err != nil {
-					return meta.Err
-				}
-				if !emitHelper(ctx, &jr.out, nil /* row */, meta, jr.pushTrailingMeta, jr.input) {
-					return nil
-				}
-				continue
-			}
-			if row == nil {
-				if len(spans) == 0 {
-					// No fetching needed since we have collected no spans and
-					// the input has signaled that no more records are coming.
-					jr.pushTrailingMeta(jr.ctx)
-					jr.out.Close()
-					return nil
-				}
-				break
-			}
-
-			key, err := jr.generateKey(row, &alloc, primaryKeyPrefix, jr.lookupCols)
-			if err != nil {
-				return err
-			}
-
-			span := roachpb.Span{
-				Key:    key,
-				EndKey: key.PrefixEnd(),
-			}
-			rows = append(rows, jr.out.rowAlloc.CopyRow(row))
-			if spanToRowIndices[key.String()] == nil {
-				spans = append(spans, span)
-			}
-			spanToRowIndices[key.String()] = append(spanToRowIndices[key.String()], rowIdx)
-			rowIdx++
-		}
-
-		// TODO(radu): we are consuming all results from a fetch before starting
-		// the next batch. We could start the next batch early while we are
-		// outputting rows.
-		earlyExit, err := jr.lookupJoinLookup(ctx, txn, spans, rows, spanToRowIndices)
+	for i, inputRow := range jr.inputRows {
+		key, err := jr.generateKey(inputRow)
 		if err != nil {
-			return err
-		} else if earlyExit {
-			return nil
+			jr.moveToDraining(err)
+			return jrStateUnknown, jr.drainHelper()
 		}
-
-		if len(spans) != jr.batchSize {
-			// This was the last batch.
-			jr.pushTrailingMeta(ctx)
-			jr.out.Close()
-			return nil
+		if jr.keyToInputRowIndices[key.String()] == nil {
+			spans = append(spans, roachpb.Span{Key: key, EndKey: key.PrefixEnd()})
 		}
+		jr.keyToInputRowIndices[key.String()] = append(jr.keyToInputRowIndices[key.String()], i)
 	}
-}
-
-// lookupJoinLookup performs an index lookup for the purposes of a lookup join.
-// `spans` is the set of spans which should be fetched from the index. `rows` is
-// the corresponding input rows. `spanToRowIndices` maps span keys onto the
-// corresponding `rows` indices.
-//
-// Note that if jr.primaryFetcher is non-nil, this function will perform two
-// lookups: one to fetch rows from a secondary index, and a second to fetch the
-// corresponding primary rows. This is for lookup joins on a secondary index
-// which does not cover all the needed output columns. (Due to batching it may
-// actually perform multiple primary lookups.)
-//
-// Returns false if more rows need to be produced, true otherwise. If true is
-// returned, both the inputs and the output have been drained and closed, except
-// if an error is returned.
-func (jr *joinReader) lookupJoinLookup(
-	ctx context.Context,
-	txn *client.Txn,
-	spans roachpb.Spans,
-	rows []sqlbase.EncDatumRow,
-	spanToRowIndices map[string][]int,
-) (bool, error) {
-	// TODO(radu,andrei,knz): set the traceKV flag when requested by the session.
 	err := jr.fetcher.StartScan(
-		ctx, txn, spans, false /* limitBatches */, 0 /* limitHint */, false /* traceKV */)
+		jr.ctx, jr.flowCtx.txn, spans, false /* limitBatches */, 0, /* limitHint */
+		false /* traceKV */)
 	if err != nil {
-		log.Errorf(ctx, "scan error: %s", err)
-		return true, err
+		jr.moveToDraining(err)
+		return jrStateUnknown, jr.drainHelper()
 	}
 
 	// If this is an outer join, track emitted rows so we can emit unmatched rows
@@ -398,108 +391,123 @@ func (jr *joinReader) lookupJoinLookup(
 	// there are multiple reasons a row might not be emitted: the index lookup
 	// might return no corresponding rows, or all the rows it returns might fail
 	// the ON condition, which is applied in the render step.)
-	var emitted []bool
 	if jr.joinType == sqlbase.LeftOuterJoin {
-		emitted = make([]bool, len(rows))
+		jr.emitted = make([]bool, len(jr.inputRows))
 	}
 
-	// lookupRow represents an index key and the corresponding row.
+	return jrPerformingLookup, nil
+}
+
+// performLookup reads the next batch of index rows (performing a second lookup
+// against the primary index if necessary), joins them to the corresponding
+// input rows, and adds the results to jr.toEmit.
+func (jr *joinReader) performLookup() (joinReaderState, *ProducerMetadata) {
+	// lookupRow represents an index key and the corresponding index row.
 	type lookupRow struct {
 		key string
 		row sqlbase.EncDatumRow
 	}
-	lookupRows := make([]lookupRow, 0, joinReaderBatchSize)
+	lookupRows := make([]lookupRow, 0, jr.batchSize)
 
-	// The index scan may have returned more rows than len(spans), so process the
-	// results in batches.
-	for {
-		// Get the next batch of lookup results.
-		lookupRows = lookupRows[:0]
-		for len(lookupRows) < joinReaderBatchSize {
-			key := jr.fetcher.IndexKeyString(len(jr.lookupCols))
-			row, meta := jr.fetcherInput.Next()
-			if meta != nil {
-				return true, scrub.UnwrapScrubError(meta.Err)
-			}
-			if row == nil {
-				// Done with this batch.
-				break
-			}
-			lookupRows = append(lookupRows, lookupRow{key, jr.rowAlloc.CopyRow(row)})
+	// Read the next batch of index rows.
+	for len(lookupRows) < jr.batchSize {
+		key := jr.fetcher.IndexKeyString(len(jr.lookupCols))
+		indexRow, meta := jr.fetcherInput.Next()
+		if meta != nil {
+			jr.moveToDraining(scrub.UnwrapScrubError(meta.Err))
+			return jrStateUnknown, jr.drainHelper()
 		}
-
-		if jr.primaryFetcher != nil {
-			// The lookup was on a non-covering secondary index, so we need to do a
-			// second lookup against the primary index and replace our previous
-			// results with the primary rows.
-			// TODO(solon): Allocate this up front rather than once per batch.
-			secondaryIndexRows := make([]sqlbase.EncDatumRow, len(lookupRows))
-			for i := range lookupRows {
-				secondaryIndexRows[i] = lookupRows[i].row
-			}
-			primaryRows, err := jr.primaryLookup(ctx, txn, secondaryIndexRows)
-			if err != nil {
-				return false, err
-			}
-			for i := range primaryRows {
-				lookupRows[i].row = primaryRows[i]
-			}
-		}
-
-		// Iterate over the lookup results, map them to the input rows, and emit the
-		// rendered rows.
-		for _, lookupRow := range lookupRows {
-			if jr.indexFilter.expr != nil {
-				// Apply index filter.
-				res, err := jr.indexFilter.evalFilter(lookupRow.row)
-				if err != nil {
-					return false, err
-				}
-				if !res {
-					continue
-				}
-			}
-			for _, rowIdx := range spanToRowIndices[lookupRow.key] {
-				renderedRow, err := jr.render(rows[rowIdx], lookupRow.row)
-				if err != nil {
-					return false, err
-				}
-				if renderedRow == nil {
-					continue
-				}
-
-				// Emit the row; stop if no more rows are needed.
-				if !emitHelper(
-					ctx, &jr.out, renderedRow, nil /* meta */, jr.pushTrailingMeta, jr.input,
-				) {
-					return true, nil
-				}
-				if emitted != nil {
-					emitted[rowIdx] = true
-				}
-			}
-		}
-
-		if len(lookupRows) < joinReaderBatchSize {
-			// This was the last batch.
+		if indexRow == nil {
+			// Done with this input batch.
+			jr.finalLookupBatch = true
 			break
 		}
+		lookupRows = append(lookupRows, lookupRow{key: key, row: jr.rowAlloc.CopyRow(indexRow)})
 	}
 
-	if emitted != nil {
-		// Emit unmatched rows.
-		for i := 0; i < len(rows); i++ {
-			if !emitted[i] {
-				renderedRow := jr.renderUnmatchedRow(rows[i], leftSide)
-				if !emitHelper(
-					ctx, &jr.out, renderedRow, nil /* meta */, jr.pushTrailingMeta, jr.input,
-				) {
-					return true, nil
+	if jr.primaryFetcher != nil {
+		// The lookup was on a non-covering secondary index, so we need to do a
+		// second lookup against the primary index and replace our previous
+		// results with the primary rows.
+		// TODO(solon): Allocate this up front rather than once per batch.
+		secondaryIndexRows := make([]sqlbase.EncDatumRow, len(lookupRows))
+		for i := range lookupRows {
+			secondaryIndexRows[i] = lookupRows[i].row
+		}
+		primaryRows, err := jr.primaryLookup(jr.ctx, jr.flowCtx.txn, secondaryIndexRows)
+		if err != nil {
+			jr.moveToDraining(err)
+			return jrStateUnknown, jr.drainHelper()
+		}
+		for i := range primaryRows {
+			lookupRows[i].row = primaryRows[i]
+		}
+	}
+
+	// Iterate over the lookup results, map them to the input rows, and emit the
+	// rendered rows.
+	for _, lookupRow := range lookupRows {
+		if jr.indexFilter.expr != nil {
+			// Apply index filter.
+			res, err := jr.indexFilter.evalFilter(lookupRow.row)
+			if err != nil {
+				jr.moveToDraining(err)
+				return jrStateUnknown, jr.drainHelper()
+			}
+			if !res {
+				continue
+			}
+		}
+		for _, inputRowIdx := range jr.keyToInputRowIndices[lookupRow.key] {
+			renderedRow, err := jr.render(jr.inputRows[inputRowIdx], lookupRow.row)
+			if err != nil {
+				jr.moveToDraining(err)
+				return jrStateUnknown, jr.drainHelper()
+			}
+			if renderedRow != nil {
+				if row := jr.processRowHelper(renderedRow); row != nil {
+					jr.toEmit = append(jr.toEmit, jr.out.rowAlloc.CopyRow(row))
+					if jr.emitted != nil {
+						jr.emitted[inputRowIdx] = true
+					}
 				}
 			}
 		}
 	}
-	return false, nil
+
+	if jr.finalLookupBatch && jr.emitted != nil {
+		// Emit unmatched rows.
+		for i := 0; i < len(jr.inputRows); i++ {
+			if !jr.emitted[i] {
+				if renderedRow := jr.renderUnmatchedRow(jr.inputRows[i], leftSide); renderedRow != nil {
+					if row := jr.processRowHelper(renderedRow); row != nil {
+						jr.toEmit = append(jr.toEmit, jr.out.rowAlloc.CopyRow(row))
+					}
+				}
+			}
+		}
+	}
+
+	return jrEmittingRows, nil
+}
+
+// emitRow returns the next row from jr.toEmit, if present. Otherwise it
+// prepares for another input batch.
+func (jr *joinReader) emitRow() (joinReaderState, sqlbase.EncDatumRow, *ProducerMetadata) {
+	if len(jr.toEmit) == 0 {
+		if jr.finalLookupBatch {
+			// Ready for another input batch. Reset state.
+			jr.inputRows = jr.inputRows[:0]
+			jr.keyToInputRowIndices = make(map[string][]int)
+			jr.finalLookupBatch = false
+			return jrReadingInput, nil, nil
+		}
+		// Process the next index lookup batch.
+		return jrPerformingLookup, nil, nil
+	}
+	row := jr.toEmit[0]
+	jr.toEmit = jr.toEmit[1:]
+	return jrEmittingRows, row, nil
 }
 
 // primaryLookup looks up the corresponding primary index rows, given a batch of
@@ -573,24 +581,26 @@ func (jr *joinReader) primaryLookup(
 	return outRows, nil
 }
 
-// Run is part of the processor interface.
-func (jr *joinReader) Run(ctx context.Context, wg *sync.WaitGroup) {
-	if wg != nil {
-		defer wg.Done()
-	}
-
+// Start is part of the RowSource interface.
+func (jr *joinReader) Start(ctx context.Context) context.Context {
 	jr.input.Start(ctx)
 	jr.fetcherInput.Start(ctx)
 	if jr.primaryFetcherInput != nil {
 		jr.primaryFetcherInput.Start(ctx)
 	}
-	ctx = jr.startInternal(ctx, joinReaderProcName)
-	defer tracing.FinishSpan(jr.span)
+	jr.runningState = jrReadingInput
+	return jr.startInternal(ctx, joinReaderProcName)
+}
 
-	err := jr.mainLoop(ctx)
-	if err != nil {
-		DrainAndClose(ctx, jr.out.output, err /* cause */, jr.pushTrailingMeta, jr.input)
-	}
+// ConsumerDone is part of the RowSource interface.
+func (jr *joinReader) ConsumerDone() {
+	jr.moveToDraining(nil /* err */)
+}
+
+// ConsumerClosed is part of the RowSource interface.
+func (jr *joinReader) ConsumerClosed() {
+	// The consumer is done, Next() will not be called again.
+	jr.internalClose()
 }
 
 var _ DistSQLSpanStats = &JoinReaderStats{}

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -81,37 +81,6 @@ func TestJoinReader(t *testing.T) {
 		expected        string
 	}{
 		{
-			description: "Test selecting rows using the primary index",
-			post: PostProcessSpec{
-				Projection:    true,
-				OutputColumns: []uint32{0, 1, 2},
-			},
-			input: [][]tree.Datum{
-				{aFn(2), bFn(2)},
-				{aFn(5), bFn(5)},
-				{aFn(10), bFn(10)},
-				{aFn(15), bFn(15)},
-			},
-			outputTypes: threeIntCols,
-			expected:    "[[0 2 2] [0 5 5] [1 0 1] [1 5 6]]",
-		},
-		{
-			description: "Test duplicate rows in input stream on index join",
-			post: PostProcessSpec{
-				Projection:    true,
-				OutputColumns: []uint32{0, 1, 2},
-			},
-			input: [][]tree.Datum{
-				{aFn(2), bFn(2)},
-				{aFn(2), bFn(2)},
-				{aFn(5), bFn(5)},
-				{aFn(5), bFn(5)},
-				{aFn(2), bFn(2)},
-			},
-			outputTypes: threeIntCols,
-			expected:    "[[0 2 2] [0 2 2] [0 5 5] [0 5 5] [0 2 2]]",
-		},
-		{
 			description: "Test selecting columns from second table",
 			post: PostProcessSpec{
 				Projection:    true,
@@ -143,26 +112,6 @@ func TestJoinReader(t *testing.T) {
 			lookupCols:  []uint32{0, 1},
 			outputTypes: threeIntCols,
 			expected:    "[[0 2 2] [0 2 2] [0 5 5] [1 0 0] [1 5 5]]",
-		},
-		{
-			description: "Test a filter in the post process spec and using a secondary index",
-			post: PostProcessSpec{
-				Filter:        Expression{Expr: "@3 <= 5"}, // sum <= 5
-				Projection:    true,
-				OutputColumns: []uint32{3},
-			},
-			input: [][]tree.Datum{
-				{aFn(1), bFn(1)},
-				{aFn(25), bFn(25)},
-				{aFn(5), bFn(5)},
-				{aFn(21), bFn(21)},
-				{aFn(34), bFn(34)},
-				{aFn(13), bFn(13)},
-				{aFn(51), bFn(51)},
-				{aFn(50), bFn(50)},
-			},
-			outputTypes: []sqlbase.ColumnType{strType},
-			expected:    "[['one'] ['five'] ['two-one'] ['one-three'] ['five-zero']]",
 		},
 		{
 			description: "Test lookup join with onExpr",

--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -17,7 +17,6 @@ package distsqlrun
 import (
 	"context"
 	"errors"
-	"sync"
 
 	"fmt"
 
@@ -83,7 +82,7 @@ func newMergeJoiner(
 	}
 
 	if err := m.joinerBase.init(
-		flowCtx, processorID, leftSource.OutputTypes(), rightSource.OutputTypes(),
+		m /* self */, flowCtx, processorID, leftSource.OutputTypes(), rightSource.OutputTypes(),
 		spec.Type, spec.OnExpr, leftEqCols, rightEqCols, 0, post, output,
 		procStateOpts{
 			inputsToDrain: []RowSource{leftSource, rightSource},
@@ -112,18 +111,6 @@ func newMergeJoiner(
 	}
 
 	return m, nil
-}
-
-// Run is part of the Processor interface.
-func (m *mergeJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
-	if m.out.output == nil {
-		panic("mergeJoiner output not initialized for emitting rows")
-	}
-	ctx = m.Start(ctx)
-	Run(ctx, m, m.out.output)
-	if wg != nil {
-		wg.Done()
-	}
 }
 
 // Start is part of the RowSource interface.

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -935,6 +935,10 @@ func newProcessor(
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
+		if len(core.JoinReader.LookupColumns) == 0 {
+			return newIndexJoiner(
+				flowCtx, processorID, core.JoinReader, inputs[0], post, outputs[0])
+		}
 		return newJoinReader(flowCtx, processorID, core.JoinReader, inputs[0], post, outputs[0])
 	}
 	if core.Sorter != nil {

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -737,6 +737,7 @@ var procNameToLogTag = map[string]string{
 	distinctProcName:                "distinct",
 	hashAggregatorProcName:          "hashAgg",
 	hashJoinerProcName:              "hashJoiner",
+	indexJoinerProcName:             "indexJoiner",
 	interleavedReaderJoinerProcName: "interleaveReaderJoiner",
 	joinReaderProcName:              "joinReader",
 	mergeJoinerProcName:             "mergeJoiner",

--- a/pkg/sql/distsqlrun/project_set_test.go
+++ b/pkg/sql/distsqlrun/project_set_test.go
@@ -110,6 +110,7 @@ func TestProjectSet(t *testing.T) {
 				c.input,
 				append(c.inputTypes, c.spec.GeneratedColumns...), /* outputTypes */
 				c.expected,
+				nil,
 			)
 		})
 	}

--- a/pkg/sql/distsqlrun/zigzagjoiner.go
+++ b/pkg/sql/distsqlrun/zigzagjoiner.go
@@ -16,7 +16,6 @@ package distsqlrun
 
 import (
 	"context"
-	"sync"
 
 	"github.com/pkg/errors"
 
@@ -276,6 +275,7 @@ func newZigzagJoiner(
 	leftEqCols := make([]uint32, 0, len(spec.EqColumns[0].Columns))
 	rightEqCols := make([]uint32, 0, len(spec.EqColumns[1].Columns))
 	err := z.joinerBase.init(
+		z, /* self */
 		flowCtx,
 		processorID,
 		leftColumnTypes,
@@ -312,18 +312,6 @@ func newZigzagJoiner(
 	}
 	z.side = 0
 	return z, nil
-}
-
-// Run is part of the processor interface.
-func (z *zigzagJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
-	if z.out.output == nil {
-		panic("zigzagJoiner output not initialized for emitting rows")
-	}
-	z.Start(ctx)
-	Run(z.ctx, z, z.out.output)
-	if wg != nil {
-		wg.Done()
-	}
 }
 
 // Start is part of the RowSource interface.


### PR DESCRIPTION
`joinReader` now implements RowSource. As part of this refactor, I pulled out index joins into their own processor, `indexJoiner`, which also implements RowSource. The first commit does this split. The second is the RowSource refactor for `joinReader`.