### PR TITLE
sql: fix panic when renaming a scalar source

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -273,9 +273,20 @@ func renameSource(
 			// And we only pluck the name if the projection is done over the
 			// unary table.
 			if _, ok := vg.source.(*unaryNode); ok {
-				// And there is just one column in the result.
-				if tType, ok := vg.funcs[0].ResolvedType().(types.TTuple); ok &&
-					len(tType.Types) == 1 {
+				shouldRename := false
+				isGenerator := vg.funcs[0] != nil
+				if isGenerator {
+					// And there is just one column in the result.
+					if tType, ok := vg.funcs[0].ResolvedType().(types.TTuple); ok &&
+						len(tType.Types) == 1 {
+						shouldRename = true
+					}
+				} else {
+					// It's also legal to select from a scalar function, and we can
+					// rename the column in that case as well.
+					shouldRename = true
+				}
+				if shouldRename {
 					colAlias = tree.NameList{as.Alias}
 				}
 			}

--- a/pkg/sql/logictest/testdata/logic_test/select_table_alias
+++ b/pkg/sql/logictest/testdata/logic_test/select_table_alias
@@ -117,3 +117,15 @@ SELECT ab.rowid FROM ab AS foo (foo1)
 
 query error source "foo" has 2 columns available but 3 columns specified
 SELECT * FROM ab AS foo (foo1, foo2, foo3)
+
+query T colnames
+SELECT * FROM to_english(3) AS x
+----
+x
+three
+
+query T colnames
+TABLE ROWS FROM (to_english(3)) AS x;
+----
+x
+three


### PR DESCRIPTION
Quite an edge case, found with RSG.

Release note (bug fix): fixed a panic that could occur when renaming a
scalar function used as a data source.