### PR TITLE
cli: Fix ordering of columns in node status

### DIFF
--- a/pkg/acceptance/decommission_test.go
+++ b/pkg/acceptance/decommission_test.go
@@ -138,7 +138,7 @@ func testDecommissionInner(
 	decommissionFooter := []string{"All target nodes report that they hold no more data. Please verify cluster health before removing the nodes."}
 	decommissionFooterLive := []string{"Decommissioning finished. Please verify cluster health before removing the nodes."}
 
-	statusHeader := []string{"id", "address", "build", "updated_at", "started_at", "is_live"}
+	statusHeader := []string{"id", "address", "build", "started_at", "updated_at", "is_live"}
 
 	log.Info(ctx, "decommissioning first node from the second, polling the status manually")
 	retryOpts := retry.Options{

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -80,8 +80,8 @@ var baseNodeColumnHeaders = []string{
 	"id",
 	"address",
 	"build",
-	"updated_at",
 	"started_at",
+	"updated_at",
 	"is_live",
 }
 


### PR DESCRIPTION
The header and data for columns updated_at and started_at were swapped.
Example output before:
```
$ cockroach node status --insecure
+----+--------------------+------------------------------------------+
| id |      address       |                  build                   |
updated_at            |            started_at            | is_live |
+----+--------------------+------------------------------------------+
|  1 | neeral-M51AC:26257 | v2.1.0-alpha.20180604-872-g50ae724       |
2018-06-28 00:52:49.925433+00:00 | 2018-06-28 00:52:49.925691+00:00 |
true    |
|  2 | neeral-M51AC:25262 | v2.1.0-alpha.20180604-848-ga22c68d-dirty |
2018-06-27 22:18:44.617039+00:00 | 2018-06-28 00:42:54.651608+00:00 |
false   |
|  3 | neeral-M51AC:25263 | v2.1.0-alpha.20180604-849-g1782ff9-dirty |
2018-06-28 00:19:53.20144+00:00  | 2018-06-28 00:53:07.018604+00:00 |
true    |
|  4 | neeral-M51AC:25264 | v2.1.0-alpha.20180604-849-g1782ff9-dirty |
2018-06-28 00:19:59.773341+00:00 | 2018-06-28 00:52:59.80999+00:00  |
true    |
|  5 | neeral-M51AC:25265 | v2.1.0-alpha.20180604-849-g1782ff9-dirty |
2018-06-28 00:20:01.927442+00:00 | 2018-06-28 00:53:01.962355+00:00 |
true    |
+----+--------------------+------------------------------------------+
```