### PR TITLE
importccl: skip TestImportCSVStmt on testshort

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -441,6 +441,9 @@ func bzipFile(t *testing.T, dir, in string) string {
 
 func TestImportCSVStmt(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	if testing.Short() {
+		t.Skip("short")
+	}
 
 	const (
 		nodes       = 3


### PR DESCRIPTION
Takes multiple cores for 11s.

Release note: None