### PR TITLE
ts: Add Rollup Computation and Querying

### DIFF
--- a/pkg/ts/db.go
+++ b/pkg/ts/db.go
@@ -29,8 +29,10 @@ import (
 )
 
 var (
-	resolution1nsDefaultPruneThreshold = time.Second
-	resolution10sDefaultPruneThreshold = 30 * 24 * time.Hour
+	resolution1nsDefaultPruneThreshold  = time.Second
+	resolution10sDefaultPruneThreshold  = 30 * 24 * time.Hour
+	resolution30mDefaultPruneThreshold  = 365 * 24 * time.Hour
+	resolution50nsDefaultPruneThreshold = 1 * time.Millisecond
 )
 
 // TimeseriesStorageEnabled controls whether to store timeseries data to disk.
@@ -68,8 +70,10 @@ type DB struct {
 // NewDB creates a new DB instance.
 func NewDB(db *client.DB, settings *cluster.Settings) *DB {
 	pruneThresholdByResolution := map[Resolution]func() int64{
-		Resolution10s: func() int64 { return Resolution10StoreDuration.Get(&settings.SV).Nanoseconds() },
-		resolution1ns: func() int64 { return resolution1nsDefaultPruneThreshold.Nanoseconds() },
+		Resolution10s:  func() int64 { return Resolution10StoreDuration.Get(&settings.SV).Nanoseconds() },
+		Resolution30m:  func() int64 { return resolution30mDefaultPruneThreshold.Nanoseconds() },
+		resolution1ns:  func() int64 { return resolution1nsDefaultPruneThreshold.Nanoseconds() },
+		resolution50ns: func() int64 { return resolution50nsDefaultPruneThreshold.Nanoseconds() },
 	}
 	return &DB{
 		db:                         db,

--- a/pkg/ts/query_test.go
+++ b/pkg/ts/query_test.go
@@ -242,6 +242,10 @@ func TestQueryDownsampling(t *testing.T) {
 
 			query.Sources = []string{"source2"}
 			query.assertSuccess(4, 1)
+
+			query.Sources = nil
+			query.SampleDurationNanos = 50
+			query.assertSuccess(2, 2)
 		}
 
 		// Query boundaries don't align to downsample period.

--- a/pkg/ts/resolution.go
+++ b/pkg/ts/resolution.go
@@ -111,6 +111,19 @@ func (r Resolution) IsRollup() bool {
 	return r == Resolution30m || r == resolution50ns
 }
 
+// TargetRollupResolution returns a target resolution that data from this
+// resolution should be rolled up into in lieu of deletion. For example,
+// Resolution10s has a target rollup resolution of Resolution30m.
+func (r Resolution) TargetRollupResolution() (Resolution, bool) {
+	switch r {
+	case Resolution10s:
+		return Resolution30m, true
+	case resolution1ns:
+		return resolution50ns, true
+	}
+	return r, false
+}
+
 func normalizeToPeriod(timestampNanos int64, period int64) int64 {
 	return timestampNanos - timestampNanos%period
 }

--- a/pkg/ts/rollup.go
+++ b/pkg/ts/rollup.go
@@ -15,11 +15,15 @@
 package ts
 
 import (
+	"context"
 	"math"
 	"sort"
+	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
 type rollupDatapoint struct {
@@ -91,8 +95,6 @@ func computeRollupsFromData(data tspb.TimeSeriesData, rollupPeriodNanos int64) r
 			max:            -math.MaxFloat64,
 			min:            math.MaxFloat64,
 		}
-		mean := 0.0
-		meanSquaredDist := 0.0
 		for i, dp := range dataSlice {
 			if i == 0 {
 				result.first = dp.Value
@@ -100,17 +102,26 @@ func computeRollupsFromData(data tspb.TimeSeriesData, rollupPeriodNanos int64) r
 			result.last = dp.Value
 			result.max = math.Max(result.max, dp.Value)
 			result.min = math.Min(result.min, dp.Value)
+
+			if result.count > 0 {
+				result.variance = computeParallelVariance(
+					parallelVarianceArgs{
+						count:    result.count,
+						average:  result.sum / float64(result.count),
+						variance: result.variance,
+					},
+					parallelVarianceArgs{
+						count:    1,
+						average:  dp.Value,
+						variance: 0,
+					},
+				)
+			}
+
 			result.count++
 			result.sum += dp.Value
-
-			// Welford's algorithm for computing variance.
-			delta := dp.Value - mean
-			mean = mean + delta/float64(result.count)
-			delta2 := dp.Value - mean
-			meanSquaredDist = meanSquaredDist + delta*delta2
 		}
 
-		result.variance = meanSquaredDist / float64(result.count)
 		rollup.datapoints = append(rollup.datapoints, result)
 	}
 
@@ -125,4 +136,192 @@ func computeRollupsFromData(data tspb.TimeSeriesData, rollupPeriodNanos int64) r
 	}
 
 	return rollup
+}
+
+func (db *DB) rollupTimeSeries(
+	ctx context.Context,
+	timeSeriesList []timeSeriesResolutionInfo,
+	now hlc.Timestamp,
+	qmc QueryMemoryContext,
+) error {
+	thresholds := db.computeThresholds(now.WallTime)
+	for _, timeSeries := range timeSeriesList {
+		// Only process rollup if this resolution has a target rollup resolution.
+		targetResolution, ok := timeSeries.Resolution.TargetRollupResolution()
+		if !ok {
+			continue
+		}
+
+		// Query from beginning of time up to the threshold for this resolution.
+		threshold := thresholds[timeSeries.Resolution]
+
+		// Create an initial targetSpan to find data for this series, starting at
+		// the beginning of time and ending with the threshold time. Queries use
+		// MaxSpanRequestKeys to limit the number of rows in memory at one time,
+		// and will use ResumeSpan to issue additional queries if necessary.
+		targetSpan := roachpb.Span{
+			Key: MakeDataKey(timeSeries.Name, "" /* source */, timeSeries.Resolution, 0),
+			EndKey: MakeDataKey(
+				timeSeries.Name, "" /* source */, timeSeries.Resolution, threshold,
+			),
+		}
+
+		// For each row, generate a rollup datapoint and add it to the correct
+		// rollupData object.
+		rollupDataMap := make(map[string]rollupData)
+
+		account := qmc.workerMonitor.MakeBoundAccount()
+		defer account.Close(ctx)
+
+		childQmc := QueryMemoryContext{
+			workerMonitor:      qmc.workerMonitor,
+			resultAccount:      &account,
+			QueryMemoryOptions: qmc.QueryMemoryOptions,
+		}
+		for querySpan := targetSpan; querySpan.Valid(); {
+			var err error
+			querySpan, err = db.queryAndComputeRollupsForSpan(
+				ctx, timeSeries, querySpan, targetResolution, rollupDataMap, childQmc,
+			)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Write computed rollupDataMap to disk
+		var rollupDataSlice []rollupData
+		for _, data := range rollupDataMap {
+			rollupDataSlice = append(rollupDataSlice, data)
+		}
+		if err := db.storeRollup(ctx, targetResolution, rollupDataSlice); err != nil {
+			return err
+		}
+
+		// Issue a prune command to delete the higher-resolution data.
+		// Time series data for a specific resolution falls in a contiguous key
+		// range, and can be deleted with a DelRange command.
+		b := &client.Batch{}
+		b.AddRawRequest(&roachpb.DeleteRangeRequest{
+			RequestHeader: roachpb.RequestHeader{
+				Key:    targetSpan.Key,
+				EndKey: targetSpan.EndKey,
+			},
+			Inline: true,
+		})
+		if err := db.db.Run(ctx, b); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// queryAndComputeRollupsForSpan queries time series data from the provided
+// span, up to a maximum limit of rows based on memory limits.
+func (db *DB) queryAndComputeRollupsForSpan(
+	ctx context.Context,
+	series timeSeriesResolutionInfo,
+	span roachpb.Span,
+	targetResolution Resolution,
+	rollupDataMap map[string]rollupData,
+	qmc QueryMemoryContext,
+) (roachpb.Span, error) {
+	b := &client.Batch{}
+	b.Header.MaxSpanRequestKeys = qmc.GetMaxRollupSlabs(series.Resolution)
+	b.Scan(span.Key, span.EndKey)
+	if err := db.db.Run(ctx, b); err != nil {
+		return roachpb.Span{}, err
+	}
+
+	// Convert result data into a map of source strings to ordered spans of
+	// time series data.
+	diskAccount := qmc.workerMonitor.MakeBoundAccount()
+	defer diskAccount.Close(ctx)
+	sourceSpans, err := convertKeysToSpans(ctx, b.Results[0].Rows, &diskAccount)
+	if err != nil {
+		return roachpb.Span{}, err
+	}
+
+	// For each source, iterate over the data span and compute
+	// rollupDatapoints.
+	for source, span := range sourceSpans {
+		rollup, ok := rollupDataMap[source]
+		if !ok {
+			rollup = rollupData{
+				name:   series.Name,
+				source: source,
+			}
+			if err := qmc.resultAccount.Grow(ctx, int64(unsafe.Sizeof(rollup))); err != nil {
+				return roachpb.Span{}, err
+			}
+		}
+
+		var end timeSeriesSpanIterator
+		for start := makeTimeSeriesSpanIterator(span); start.isValid(); start = end {
+			rollupPeriod := targetResolution.SampleDuration()
+			sampleTimestamp := normalizeToPeriod(start.timestamp, rollupPeriod)
+			datapoint := rollupDatapoint{
+				timestampNanos: sampleTimestamp,
+				max:            -math.MaxFloat64,
+				min:            math.MaxFloat64,
+				first:          start.first(),
+			}
+			if err := qmc.resultAccount.Grow(ctx, int64(unsafe.Sizeof(datapoint))); err != nil {
+				return roachpb.Span{}, err
+			}
+			for end = start; end.isValid() && normalizeToPeriod(end.timestamp, rollupPeriod) == sampleTimestamp; end.forward() {
+				datapoint.last = end.last()
+				datapoint.max = math.Max(datapoint.max, end.max())
+				datapoint.min = math.Min(datapoint.min, end.min())
+
+				// Chan et al. algorithm for computing parallel variance. This allows
+				// the combination of two previously computed sample variances into a
+				// variance for the combined sample; this is needed when further
+				// downsampling previously downsampled variance values.
+				if datapoint.count > 0 {
+					datapoint.variance = computeParallelVariance(
+						parallelVarianceArgs{
+							count:    end.count(),
+							average:  end.average(),
+							variance: end.variance(),
+						},
+						parallelVarianceArgs{
+							count:    datapoint.count,
+							average:  datapoint.sum / float64(datapoint.count),
+							variance: datapoint.variance,
+						},
+					)
+				}
+
+				datapoint.count += end.count()
+				datapoint.sum += end.sum()
+			}
+			rollup.datapoints = append(rollup.datapoints, datapoint)
+		}
+		rollupDataMap[source] = rollup
+	}
+	return b.Results[0].ResumeSpan, nil
+}
+
+type parallelVarianceArgs struct {
+	count    uint32
+	average  float64
+	variance float64
+}
+
+// computeParallelVariance computes the combined variance of two previously
+// computed sample variances. This is an implementation of the Chan et al.
+// algorithm for computing parallel variance. This allows the combination of two
+// previously computed sample variances into a variance for the combined sample;
+// this is needed when further downsampling previously downsampled variance
+// values. Note that it is exactly equivalent to the more widely used Welford's
+// algorithm when either variance set has a count of one.
+func computeParallelVariance(left, right parallelVarianceArgs) float64 {
+	leftCount := float64(left.count)
+	rightCount := float64(right.count)
+	totalCount := leftCount + rightCount
+	averageDelta := left.average - right.average
+	leftSumOfSquareDeviations := left.variance * leftCount
+	rightSumOfSquareDeviations := right.variance * rightCount
+	totalSumOfSquareDeviations := leftSumOfSquareDeviations + rightSumOfSquareDeviations + (averageDelta*averageDelta)*rightCount*leftCount/totalCount
+	return totalSumOfSquareDeviations / totalCount
 }

--- a/pkg/ts/rollup_test.go
+++ b/pkg/ts/rollup_test.go
@@ -15,16 +15,38 @@
 package ts
 
 import (
+	"context"
+	"fmt"
+	"math"
 	"reflect"
+	"sort"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/kr/pretty"
 )
 
-func TestComputeRollup(t *testing.T) {
+type itsdByTimestamp []roachpb.InternalTimeSeriesData
+
+func (bt itsdByTimestamp) Len() int {
+	return len(bt)
+}
+
+func (bt itsdByTimestamp) Less(i int, j int) bool {
+	return bt[i].StartTimestampNanos < bt[j].StartTimestampNanos
+}
+
+func (bt itsdByTimestamp) Swap(i int, j int) {
+	bt[i], bt[j] = bt[j], bt[i]
+}
+
+func TestComputeRollupFromData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	for _, tc := range []struct {
@@ -103,10 +125,196 @@ func TestComputeRollup(t *testing.T) {
 					t.Error(diff)
 				}
 			}
+
+			// Compare expected to test model output; the notion of rollups is
+			// implemented on top of the testmodel, and though it is simple we need to
+			// exercise it here.
+			tm := newTestModelRunner(t)
+			tm.Start()
+			defer tm.Stop()
+
+			tm.storeInModel(resolution1ns, tc.input)
+			tm.rollup(math.MaxInt64, timeSeriesResolutionInfo{
+				Name:       "test.metric",
+				Resolution: resolution1ns,
+			})
+
+			var modelActual []roachpb.InternalTimeSeriesData
+			layout := tm.getModelDiskLayout()
+			for _, data := range layout {
+				var val roachpb.InternalTimeSeriesData
+				if err := data.GetProto(&val); err != nil {
+					t.Fatal(err)
+				}
+				modelActual = append(modelActual, val)
+			}
+			sort.Sort(itsdByTimestamp(modelActual))
+
+			if a, e := modelActual, tc.expected; !reflect.DeepEqual(a, e) {
+				for _, diff := range pretty.Diff(a, e) {
+					t.Error(diff)
+				}
+			}
 		})
 	}
 }
 
-func TestRollupToInternal(t *testing.T) {
+func TestRollupBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	tm := newTestModelRunner(t)
+	tm.Start()
+	defer tm.Stop()
+
+	series1a := tsd("test.metric", "a")
+	series1b := tsd("test.metric", "b")
+	series2 := tsd("test.othermetric", "a")
+	for i := 0; i < 500; i++ {
+		series1a.Datapoints = append(series1a.Datapoints, tsdp(time.Duration(i), float64(i)))
+		series1b.Datapoints = append(series1b.Datapoints, tsdp(time.Duration(i), float64(i)))
+		series2.Datapoints = append(series2.Datapoints, tsdp(time.Duration(i), float64(i)))
+	}
+
+	tm.storeTimeSeriesData(resolution1ns, []tspb.TimeSeriesData{series1a, series1b, series2})
+	tm.assertKeyCount(150)
+	tm.assertModelCorrect()
+
+	tm.rollup(250+resolution1nsDefaultPruneThreshold.Nanoseconds(), timeSeriesResolutionInfo{
+		Name:       "test.metric",
+		Resolution: resolution1ns,
+	})
+	tm.assertKeyCount(102)
+	tm.assertModelCorrect()
+
+	// Specialty test - rollup only the real series, not the model, and ensure
+	// that the query remains the same.
+	memOpts := QueryMemoryOptions{
+		// Large budget, but not maximum to avoid overflows.
+		BudgetBytes:             math.MaxInt64,
+		EstimatedSources:        1, // Not needed for rollups
+		InterpolationLimitNanos: 0,
+		Columnar:                tm.DB.WriteColumnar(),
+	}
+	if err := tm.DB.rollupTimeSeries(
+		context.TODO(),
+		[]timeSeriesResolutionInfo{
+			{
+				Name:       "test.othermetric",
+				Resolution: resolution1ns,
+			},
+		},
+		hlc.Timestamp{
+			WallTime: 500 + resolution1nsDefaultPruneThreshold.Nanoseconds(),
+			Logical:  0,
+		},
+		MakeQueryMemoryContext(tm.workerMemMonitor, tm.resultMemMonitor, memOpts),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	{
+		query := tm.makeQuery("test.othermetric", resolution1ns, 0, 500)
+		query.SampleDurationNanos = 50
+		query.assertSuccess(10, 1)
+	}
+}
+
+func TestRollupMemoryConstraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tm := newTestModelRunner(t)
+	tm.Start()
+	defer tm.Stop()
+
+	series1 := tsd("test.metric", "a")
+	series2 := tsd("test.othermetric", "a")
+	for i := 0; i < 500; i++ {
+		series1.Datapoints = append(series1.Datapoints, tsdp(time.Duration(i), float64(i)))
+		series2.Datapoints = append(series2.Datapoints, tsdp(time.Duration(i), float64(i)))
+	}
+
+	tm.storeTimeSeriesData(resolution1ns, []tspb.TimeSeriesData{series1, series2})
+	tm.assertKeyCount(100)
+	tm.assertModelCorrect()
+
+	// Construct a memory monitor that will be used to measure the high-water
+	// mark of memory usage for the rollup process.
+	adjustedMon := mon.MakeMonitor(
+		"timeseries-test-worker-adjusted",
+		mon.MemoryResource,
+		nil,
+		nil,
+		1,
+		math.MaxInt64,
+		cluster.MakeTestingClusterSettings(),
+	)
+	adjustedMon.Start(context.TODO(), tm.workerMemMonitor, mon.BoundAccount{})
+	defer adjustedMon.Stop(context.TODO())
+
+	// Roll up time series with the new monitor to measure high-water mark
+	// of
+	qmc := MakeQueryMemoryContext(&adjustedMon, &adjustedMon, QueryMemoryOptions{
+		// Large budget, but not maximum to avoid overflows.
+		BudgetBytes:      math.MaxInt64,
+		EstimatedSources: 1, // Not needed for rollups
+		Columnar:         tm.DB.WriteColumnar(),
+	})
+	tm.rollupWithMemoryContext(qmc, 500+resolution1nsDefaultPruneThreshold.Nanoseconds(), timeSeriesResolutionInfo{
+		Name:       "test.othermetric",
+		Resolution: resolution1ns,
+	})
+
+	tm.assertKeyCount(51)
+	tm.assertModelCorrect()
+
+	// Ensure that we used at least 50 slabs worth of memory at one time.
+	if a, e := adjustedMon.MaximumBytes(), 50*qmc.computeSizeOfSlab(resolution1ns); a < e {
+		t.Fatalf("memory usage for query was %d, wanted at least %d", a, e)
+	}
+
+	// Limit testing: set multiple constraints on memory and ensure that they
+	// are being respected through chunking.
+	for i, limit := range []int64{
+		25 * qmc.computeSizeOfSlab(resolution1ns),
+		10 * qmc.computeSizeOfSlab(resolution1ns),
+	} {
+		// Generate a new series.
+		seriesName := fmt.Sprintf("metric.series%d", i)
+		seriesData := tsd(seriesName, "a")
+		for j := 0; j < 500; j++ {
+			seriesData.Datapoints = append(seriesData.Datapoints, tsdp(time.Duration(j), float64(j)))
+		}
+		tm.storeTimeSeriesData(resolution1ns, []tspb.TimeSeriesData{seriesData})
+		tm.assertModelCorrect()
+		tm.assertKeyCount(51 + i /* rollups from previous iterations */ + 50)
+
+		// Restart monitor to clear query memory options.
+		adjustedMon.Stop(context.TODO())
+		adjustedMon.Start(context.TODO(), tm.workerMemMonitor, mon.BoundAccount{})
+
+		qmc := MakeQueryMemoryContext(&adjustedMon, &adjustedMon, QueryMemoryOptions{
+			// Large budget, but not maximum to avoid overflows.
+			BudgetBytes:      limit,
+			EstimatedSources: 1, // Not needed for rollups
+			Columnar:         tm.DB.WriteColumnar(),
+		})
+		tm.rollupWithMemoryContext(qmc, 500+resolution1nsDefaultPruneThreshold.Nanoseconds(), timeSeriesResolutionInfo{
+			Name:       seriesName,
+			Resolution: resolution1ns,
+		})
+
+		tm.assertKeyCount(51 + i + 1)
+		tm.assertModelCorrect()
+
+		// Check budget was not exceeded.  Computation of budget usage is not exact
+		// in the case of rollups, due to the fact that results are tracked with
+		// the same monitor but may vary in size based on the specific input
+		// rows. Because of this, allow up to 20% over limit.
+		if a, e := float64(adjustedMon.MaximumBytes()), float64(limit)*1.2; a > e {
+			t.Fatalf("memory usage for query was %f, wanted a limit of %f", a, e)
+		}
+
+		// Check that budget was used.
+		if a, e := float64(adjustedMon.MaximumBytes()), float64(limit)*0.95; a < e {
+			t.Fatalf("memory usage for query was %f, wanted at least %f", a, e)
+		}
+	}
 }


### PR DESCRIPTION
This commit adds the computation of rollups from existing resolutions.
The computation process queries a limited number of rows from a source
resolution, computes rollup data from those sources and stores it in the
target resolution, and then deletes the rolled-up data from the original
resolution. This is an alternative to pruning which allows keeping some
data on time series (at a lower data resolution) for an extended period
of time.

This commit also adds the ability to transparently query rollup data
when querying at a lower resolution that has a rollup available. If the
requested downsampling period can be satisfied with the rollup for a
resolution, then the rollup resolution will be queried first.

Note that the rollup process is not yet enabled: the last step is to
add it into the existing TimeSeriesMaintenanceQueue.

Release note: None.