### PR TITLE
sql-2.0: ensure that serializable means serializable

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -255,6 +255,16 @@ SHOW transaction_isolation
 ----
 snapshot
 
+# Set it back and check it's kept properly.
+
+statement ok
+SET transaction_isolation = 'serializable'
+
+query T
+SHOW TRANSACTION ISOLATION LEVEL
+----
+serializable
+
 statement ok
 COMMIT
 

--- a/pkg/sql/sem/tree/txn.go
+++ b/pkg/sql/sem/tree/txn.go
@@ -40,7 +40,7 @@ var isolationLevelNames = [...]string{
 // IsolationLevelMap is a map from string isolation level name to isolation
 // level, in the lowercase format that set isolation_level supports.
 var IsolationLevelMap = map[string]IsolationLevel{
-	"serializable": SnapshotIsolation,
+	"serializable": SerializableIsolation,
 	"snapshot":     SnapshotIsolation,
 }
 


### PR DESCRIPTION
Prior to this patch SET transaction_isolation would always set the iso
level to SNAPSHOT regardless of the value passed. This patch fixes it.

Release note (bug fix): the pg-specific syntax `SET
transaction_isolation` did not support any setting other than SNAPSHOT
properly. (This bug did not affect the standard SQL `SET TRANSACTION
ISOLATION LEVEL`.) This is now fixed.