### PR TITLE
build: assert clean for submodules

### DIFF
--- a/build/teamcity-assert-clean.sh
+++ b/build/teamcity-assert-clean.sh
@@ -10,6 +10,6 @@ if [[ "$(git status --porcelain 2>&1)" != "" ]]; then
   git status >&2 || true
   git diff -a >&2 || true
   echo "Nuking build cruft. Please teach this build to clean up after itself." >&2
-  run docker run --volume="$root:/nuke" --workdir="/nuke" golang:stretch git clean -fdx >&2
+  run docker run --volume="$root:/nuke" --workdir="/nuke" golang:stretch /bin/bash -c "git clean -ffdx ; git submodule foreach --recursive git clean -xffd" >&2
   exit 1
 fi


### PR DESCRIPTION
I saw failing builds due to a dirty `c-deps/protobuf` directory; this
isn't cleaned up by the prior version of the script (and it also does
not tell you the diff). This new one will.

Also added a second `-f` to `git clean` which does not stop in nested
repos (excluding submodules). We don't need that but it seemed right
to add it.

Release note: None