### PR TITLE
opt: fix panic in generating tuple IN constraints

### DIFF
--- a/pkg/sql/opt/memo/constraint_builder.go
+++ b/pkg/sql/opt/memo/constraint_builder.go
@@ -216,6 +216,10 @@ func (cb *constraintsBuilder) buildConstraintForTupleIn(
 		}
 	}
 
+	if len(constrainedCols) == 0 {
+		return unconstrained, false
+	}
+
 	// If any of the LHS entries are not constrained then our constraints are not
 	// tight.
 	tight = (len(constrainedCols) == lhs.ChildCount())

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -645,7 +645,7 @@ CREATE TABLE c
     k INT PRIMARY KEY,
     u INT,
     v INT,
-     INDEX v (v, u)
+    INDEX v (v, u)
 )
 ----
 TABLE c
@@ -938,3 +938,26 @@ select
                 └── tuple [type=tuple{int, int}]
                      ├── const: 4 [type=int]
                      └── const: 1 [type=int]
+
+opt
+SELECT * FROM c WHERE (1, 2) IN ((1, 2))
+----
+select
+ ├── columns: k:1(int!null) u:2(int) v:3(int)
+ ├── stats: [rows=333.333333]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan c
+ │    ├── columns: k:1(int!null) u:2(int) v:3(int)
+ │    ├── stats: [rows=1000]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters [type=bool]
+      └── in [type=bool]
+           ├── tuple [type=tuple{int, int}]
+           │    ├── const: 1 [type=int]
+           │    └── const: 2 [type=int]
+           └── tuple [type=tuple{tuple{int, int}}]
+                └── tuple [type=tuple{int, int}]
+                     ├── const: 1 [type=int]
+                     └── const: 2 [type=int]


### PR DESCRIPTION
Fixes #27016.

Previously this code would panic if there were no constrainable columns.
I've added an equivalent test case to the one provided, but it will be
difficult to run the test provided until #27034 lands. I suspect the
problem there was with placeholders (it didn't panic with the old code
and the placeholders replaced with constants).

We should also consider adding prepared statement support to opt_tester
so that we can test situations like that in the future.

Release note (bug fix): Fix a panic in the optimizer with IN filters.