### PR TITLE
roachtest: disable encryption on tests that can't handle it.

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -33,7 +33,9 @@ func registerCDC(r *registry) {
 
 		c.Put(ctx, cockroach, "./cockroach", crdbNodes)
 		c.Put(ctx, workload, "./workload", workloadNode)
-		c.Start(ctx, crdbNodes)
+		// Force encryption off as we do not have a good way to detect whether it is enabled
+		// for the `debug compact` call below.
+		c.Start(ctx, crdbNodes, startArgsDontEncrypt)
 
 		t.Status("loading initial data")
 		c.Run(ctx, workloadNode, fmt.Sprintf(
@@ -44,7 +46,7 @@ func registerCDC(r *registry) {
 		// fixed. See #26870
 		c.Stop(ctx, crdbNodes)
 		c.Run(ctx, crdbNodes, `./cockroach debug compact /mnt/data1/cockroach/`)
-		c.Start(ctx, crdbNodes)
+		c.Start(ctx, crdbNodes, startArgsDontEncrypt)
 
 		t.Status("installing kafka")
 		c.Run(ctx, kafkaNode, `curl https://packages.confluent.io/archive/4.0/confluent-oss-4.0.0-2.11.tar.gz | tar -xzv`)

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -699,6 +699,11 @@ func startArgs(extraArgs ...string) option {
 	return roachprodArgOption(extraArgs)
 }
 
+// startArgsDontEncrypt will pass '--encrypt=false' to roachprod regardless of the
+// --encrypt flag on roachtest. This is useful for tests that cannot pass with
+// encryption enabled.
+var startArgsDontEncrypt = startArgs("--encrypt=false")
+
 // stopArgs specifies extra arguments that are passed to `roachprod` during `c.Stop`.
 func stopArgs(extraArgs ...string) option {
 	return roachprodArgOption(extraArgs)

--- a/pkg/cmd/roachtest/upgrade.go
+++ b/pkg/cmd/roachtest/upgrade.go
@@ -43,7 +43,9 @@ func registerUpgrade(r *registry) {
 		}
 
 		c.Put(ctx, b, "./cockroach", c.Range(1, nodes))
-		c.Start(ctx, c.Range(1, nodes))
+		// Force disable encryption.
+		// TODO(mberhault): allow it once oldVersion >= 2.1.
+		c.Start(ctx, c.Range(1, nodes), startArgsDontEncrypt)
 
 		const stageDuration = 30 * time.Second
 		const timeUntilStoreDead = 90 * time.Second
@@ -129,7 +131,7 @@ func registerUpgrade(r *registry) {
 				t.Fatal(err)
 			}
 			c.Put(ctx, cockroach, "./cockroach", c.Node(i))
-			c.Start(ctx, c.Node(i))
+			c.Start(ctx, c.Node(i), startArgsDontEncrypt)
 			if err := sleep(stageDuration); err != nil {
 				t.Fatal(err)
 			}
@@ -151,7 +153,7 @@ func registerUpgrade(r *registry) {
 			t.Fatal(err)
 		}
 		c.Put(ctx, cockroach, "./cockroach", c.Node(nodes))
-		c.Start(ctx, c.Node(nodes))
+		c.Start(ctx, c.Node(nodes), startArgsDontEncrypt)
 		if err := sleep(stageDuration); err != nil {
 			t.Fatal(err)
 		}
@@ -192,7 +194,7 @@ func registerUpgrade(r *registry) {
 		}
 
 		// Restart the previously stopped node.
-		c.Start(ctx, c.Node(nodes-1))
+		c.Start(ctx, c.Node(nodes-1), startArgsDontEncrypt)
 		if err := sleep(stageDuration); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -48,7 +48,9 @@ func registerVersion(r *registry) {
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 
 		c.Put(ctx, b, "./cockroach", c.Range(1, nodes))
-		c.Start(ctx, c.Range(1, nodes))
+		// Force disable encryption.
+		// TODO(mberhault): allow it once version >= 2.1.
+		c.Start(ctx, c.Range(1, nodes), startArgsDontEncrypt)
 
 		stageDuration := 10 * time.Minute
 		buffer := 10 * time.Minute
@@ -167,7 +169,7 @@ func registerVersion(r *registry) {
 					return err
 				}
 				c.Put(ctx, cockroach, "./cockroach", c.Node(i))
-				c.Start(ctx, c.Node(i))
+				c.Start(ctx, c.Node(i), startArgsDontEncrypt)
 				if err := sleepAndCheck(); err != nil {
 					return err
 				}
@@ -188,7 +190,7 @@ func registerVersion(r *registry) {
 
 			// Do upgrade for the last node.
 			c.Put(ctx, cockroach, "./cockroach", c.Node(nodes))
-			c.Start(ctx, c.Node(nodes))
+			c.Start(ctx, c.Node(nodes), startArgsDontEncrypt)
 			if err := sleepAndCheck(); err != nil {
 				return err
 			}
@@ -200,7 +202,7 @@ func registerVersion(r *registry) {
 					return err
 				}
 				c.Put(ctx, b, "./cockroach", c.Node(i))
-				c.Start(ctx, c.Node(i))
+				c.Start(ctx, c.Node(i), startArgsDontEncrypt)
 				if err := sleepAndCheck(); err != nil {
 					return err
 				}
@@ -213,7 +215,7 @@ func registerVersion(r *registry) {
 					return err
 				}
 				c.Put(ctx, cockroach, "./cockroach", c.Node(i))
-				c.Start(ctx, c.Node(i))
+				c.Start(ctx, c.Node(i), startArgsDontEncrypt)
 				if err := sleepAndCheck(); err != nil {
 					return err
 				}


### PR DESCRIPTION
Two cases make encryption always fail:
- old versions (<= 2.0)
- uses of debug commands that open the rocksdb instance (needs
  encryption flags)

Release note: None