### PR TITLE
builder.sh use host network

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -176,6 +176,7 @@ vols="${vols} --volume=${gocache}/docker/pkg:/go/pkg${delegated_volume_mode}"
 docker run --privileged -i ${tty-} ${ccache} --rm \
   -u "${uid_gid}" \
   ${vols} \
+  --network host \
   --workdir="/go/src/github.com/cockroachdb/cockroach" \
   --env="TMPDIR=/go/src/github.com/cockroachdb/cockroach/artifacts" \
   --env="PAGER=cat" \


### PR DESCRIPTION
Hi guys,

In file [builder.sh](https://github.com/cockroachdb/cockroach/blob/master/build/builder.sh#L176-L183), in some machine, I wasn't able to connect to the internet from within builder container (so it fail to clone github)

I suspect it could be NAT error (not sure, the container too lack of network tools), try everything in https://github.com/moby/moby/issues/13381, doesn't work.

The easiest way is to drop default bridge network, but using host network directly (https://docs.docker.com/network/host/)

Side effect:
```
The host networking driver only works on Linux hosts, and is not supported on Docker for Mac, Docker for Windows, or Docker EE for Windows Server.
```