### PR TITLE
kubernetes: Config files + setup script for secure multiregion clusters

### DIFF
--- a/cloud/kubernetes/README.md
+++ b/cloud/kubernetes/README.md
@@ -71,6 +71,13 @@ deployment until node-local storage has been more rigorously hardened.
 
 Secure mode currently works by requesting node/client certificates from the kubernetes controller at pod initialization time.
 
+### Geographically distributed clusters
+
+The configuration files and instructions in this directory are limited to
+deployments that exist entirely within a single Kubernetes cluster. If you'd
+like to deploy CockroachDB across multiple geographically distributed Kubernetes
+clusters, see the [multiregion subdirectory](multiregion).
+
 ## Creating your kubernetes cluster
 
 ### Locally on minikube

--- a/cloud/kubernetes/multiregion/README.md
+++ b/cloud/kubernetes/multiregion/README.md
@@ -1,0 +1,86 @@
+# Running CockroachDB across multiple Kubernetes clusters
+
+The script and configuration files in this directory enable deploying
+CockroachDB across multiple Kubernetes clusters that are spread across different
+geographic regions. It deploys a CockroachDB
+[StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/)
+into each separate cluster, and links them together using DNS.
+
+To use the configuration provided here, check out this repository (or otherwise
+download a copy of this directory), fill in the constants at the top of
+[setup.py](setup.py) with the relevant information about your Kubernetes
+clusters, optionally make any desired modifications to
+[cockroachdb-statefulset-secure.yaml](cockroachdb-statefulset-secure.yaml) as
+explained in [our Kubernetes performance tuning
+guide](https://www.cockroachlabs.com/docs/stable/kubernetes-performance.html),
+then finally run [setup.py](setup.py).
+
+You should see a lot of output as it does its thing, hopefully ending after
+printing out `job "cluster-init-secure" created`. This implies that everything
+was created successfully, and you should soon see the CockroachDB cluster
+initialized with 3 pods in the "READY" state in each Kubernetes cluster. At this
+point you can manage the StatefulSet in each cluster independently if you so
+desire, scaling up the number of replicas, changing their resource requests, or
+making other modifications as you please.
+
+If anything goes wrong along the way, please let us know via any of the [normal
+troubleshooting
+channels](https://www.cockroachlabs.com/docs/stable/support-resources.html).
+While we believe this creates a highly available, maintainable multi-region
+deployment, it is still pushing the boundaries of how Kubernetes is typically
+used, so feedback and issue reports are very appreciated.
+
+## Limitations
+
+### Pod-to-pod connectivity
+
+The deployment outlined in this directory relies on pod IP addresses being
+routable even across Kubernetes clusters and regions. This achieves optimal
+performance, particularly when compared to alternative solutions that route all packets between clusters through load balancers, but means that it won't work in certain environments.
+
+This requirement is satisfied by clusters deployed in cloud environments such as Google Kubernetes Engine, and
+can also be satisfied by on-prem environments depending on the [Kubernetes networking setup](https://kubernetes.io/docs/concepts/cluster-administration/networking/) used. If you want to test whether your cluster will work, you can run this basic network test:
+
+```shell
+$ kubectl run network-test --image=alpine --restart=Never -- sleep 999999
+pod "network-test" created
+$ kubectl describe pod network-test | grep IP
+IP:           THAT-PODS-IP-ADDRESS
+$ kubectl config use-context YOUR-OTHER-CLUSTERS-CONTEXT-HERE
+$ kubectl run -it network-test --image=alpine --restart=Never -- ping THAT-PODS-IP-ADDRESS
+If you don't see a command prompt, try pressing enter.
+64 bytes from 10.12.14.10: seq=1 ttl=62 time=0.570 ms
+64 bytes from 10.12.14.10: seq=2 ttl=62 time=0.449 ms
+64 bytes from 10.12.14.10: seq=3 ttl=62 time=0.635 ms
+64 bytes from 10.12.14.10: seq=4 ttl=62 time=0.722 ms
+64 bytes from 10.12.14.10: seq=5 ttl=62 time=0.504 ms
+...
+```
+
+If the pods can directly connect, you should see successful ping output like the
+above. If they can't, you won't see any successful ping responses. Make sure to
+delete the `network-test` pod in each cluster when you're done!
+
+### Exposing DNS servers to the Internet
+
+As currently configured, the way that the DNS servers from each Kubernetes
+cluster are hooked together is by exposing them via a load balanced IP address
+that's visible to the public Internet. This is because [Google Cloud Platform's Internal Load Balancers do not currently support clients in one region using a load balancer in another region](https://cloud.google.com/compute/docs/load-balancing/internal/#deploying_internal_load_balancing_with_clients_across_vpn_or_interconnect). 
+
+None of the services in your Kubernetes cluster will be made accessible, but
+their names could leak out to a motivated attacker. If this is unacceptable,
+please let us know and we can demonstrate other options. [Your voice could also
+help convince Google to allow clients from one region to use an Internal Load
+Balancer in another](https://issuetracker.google.com/issues/111021512),
+eliminating the problem.
+
+## Cleaning up
+
+To remove all the resources created in your clusters by [setup.py](setup.py),
+copy the parameters you provided at the top of [setup.py](setup.py) to the top
+of [teardown.py](teardown.py) and run [teardown.py](teardown.py).
+
+## More information
+
+For more information on running CockroachDB in Kubernetes, please see the [README
+in the parent directory](../README.md).

--- a/cloud/kubernetes/multiregion/client-secure.yaml
+++ b/cloud/kubernetes/multiregion/client-secure.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cockroachdb-client-secure
+  labels:
+    app: cockroachdb-client
+spec:
+  serviceAccountName: cockroachdb
+  containers:
+  - name: cockroachdb-client
+    image: cockroachdb/cockroach:v2.0.5
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+    - name: client-certs
+      mountPath: /cockroach-certs
+    # Keep a pod open indefinitely so kubectl exec can be used to get a shell to it
+    # and run cockroach client commands, such as cockroach sql, cockroach node status, etc.
+    command:
+    - sleep
+    - "2147483648" # 2^31
+  # This pod isn't doing anything important, so don't bother waiting to terminate it.
+  terminationGracePeriodSeconds: 0
+  volumes:
+  - name: client-certs
+    secret:
+      secretName: cockroachdb.client.root
+      defaultMode: 256

--- a/cloud/kubernetes/multiregion/cluster-init-secure.yaml
+++ b/cloud/kubernetes/multiregion/cluster-init-secure.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cluster-init-secure
+  labels:
+    app: cockroachdb
+spec:
+  template:
+    spec:
+      serviceAccountName: cockroachdb
+      containers:
+      - name: cluster-init
+        image: cockroachdb/cockroach:v2.0.5
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: client-certs
+          mountPath: /cockroach-certs
+        command:
+          - "/cockroach/cockroach"
+          - "init"
+          - "--certs-dir=/cockroach-certs"
+          - "--host=cockroachdb-0.cockroachdb"
+      restartPolicy: OnFailure
+      volumes:
+      - name: client-certs
+        secret:
+          secretName: cockroachdb.client.root
+          defaultMode: 256

--- a/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure.yaml
@@ -1,0 +1,224 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cockroachdb
+  labels:
+    app: cockroachdb
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: cockroachdb
+  labels:
+    app: cockroachdb
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cockroachdb
+  labels:
+    app: cockroachdb
+rules:
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - create
+  - get
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: cockroachdb
+  labels:
+    app: cockroachdb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cockroachdb
+subjects:
+- kind: ServiceAccount
+  name: cockroachdb
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cockroachdb
+  labels:
+    app: cockroachdb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cockroachdb
+subjects:
+- kind: ServiceAccount
+  name: cockroachdb
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # This service is meant to be used by clients of the database. It exposes a ClusterIP that will
+  # automatically load balance connections to the different database pods.
+  name: cockroachdb-public
+  labels:
+    app: cockroachdb
+spec:
+  ports:
+  # The main port, served by gRPC, serves Postgres-flavor SQL, internode
+  # traffic and the cli.
+  - port: 26257
+    targetPort: 26257
+    name: grpc
+  # The secondary port serves the UI as well as health and debug endpoints.
+  - port: 8080
+    targetPort: 8080
+    name: http
+  selector:
+    app: cockroachdb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # This service only exists to create DNS entries for each pod in the stateful
+  # set such that they can resolve each other's IP addresses. It does not
+  # create a load-balanced ClusterIP and should not be used directly by clients
+  # in most circumstances.
+  name: cockroachdb
+  labels:
+    app: cockroachdb
+  annotations:
+    # Use this annotation in addition to the actual publishNotReadyAddresses
+    # field below because the annotation will stop being respected soon but the
+    # field is broken in some versions of Kubernetes:
+    # https://github.com/kubernetes/kubernetes/issues/58662
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    # Enable automatic monitoring of all instances when Prometheus is running in the cluster.
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "_status/vars"
+    prometheus.io/port: "8080"
+spec:
+  ports:
+  - port: 26257
+    targetPort: 26257
+    name: grpc
+  - port: 8080
+    targetPort: 8080
+    name: http
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other CockroachDB pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector:
+    app: cockroachdb
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: cockroachdb-budget
+  labels:
+    app: cockroachdb
+spec:
+  selector:
+    matchLabels:
+      app: cockroachdb
+  maxUnavailable: 1
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: cockroachdb
+spec:
+  serviceName: "cockroachdb"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: cockroachdb
+    spec:
+      serviceAccountName: cockroachdb
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - cockroachdb
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: cockroachdb
+        image: cockroachdb/cockroach:v2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 26257
+          name: grpc
+        - containerPort: 8080
+          name: http
+        livenessProbe:
+          httpGet:
+            path: "/health"
+            port: http
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: "/health?ready=1"
+            port: http
+            scheme: HTTPS
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          failureThreshold: 2
+        volumeMounts:
+        - name: datadir
+          mountPath: /cockroach/cockroach-data
+        - name: certs
+          mountPath: /cockroach/cockroach-certs
+        env:
+        - name: COCKROACH_CHANNEL
+          value: kubernetes-secure
+        command:
+          - "/bin/bash"
+          - "-ecx"
+          # The use of qualified `hostname -f` is crucial:
+          # Other nodes aren't able to look up the unqualified hostname.
+          - "exec /cockroach/cockroach start --logtostderr --certs-dir /cockroach/cockroach-certs --advertise-host $(hostname -f) --http-host 0.0.0.0 --join JOINLIST --locality LOCALITYLIST --cache 25% --max-sql-memory 25%"
+      # No pre-stop hook is required, a SIGTERM plus some time is all that's
+      # needed for graceful shutdown of a node.
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: datadir
+        persistentVolumeClaim:
+          claimName: datadir
+      - name: certs
+        secret:
+          secretName: cockroachdb.node
+          defaultMode: 256
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+    spec:
+      accessModes:
+        - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: 100Gi

--- a/cloud/kubernetes/multiregion/dns-lb.yaml
+++ b/cloud/kubernetes/multiregion/dns-lb.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    # TODO: Check whether AWS/Azure can use internal load balancers. Google
+    # can't, unfortunately.
+    # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    # service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+    # cloud.google.com/load-balancer-type: "Internal"
+  labels:
+    k8s-app: kube-dns
+  name: kube-dns-lb
+  namespace: kube-system
+spec:
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  selector:
+    k8s-app: kube-dns
+  sessionAffinity: None
+  type: LoadBalancer

--- a/cloud/kubernetes/multiregion/example-app-secure.yaml
+++ b/cloud/kubernetes/multiregion/example-app-secure.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: example-secure
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: loadgen
+    spec:
+      serviceAccountName: cockroachdb
+      volumes:
+      - name: client-certs
+        secret:
+          secretName: cockroachdb.client.root
+          defaultMode: 256
+      containers:
+      - name: loadgen
+        image: cockroachdb/loadgen-kv:0.1
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: client-certs
+          mountPath: /cockroach-certs
+        command:
+          - "/kv"
+          - "postgres://root@cockroachdb-public:26257/kv?sslmode=verify-full&sslcert=/cockroach-certs/client.root.crt&sslkey=/cockroach-certs/client.root.key&sslrootcert=/cockroach-certs/ca.crt"

--- a/cloud/kubernetes/multiregion/external-name-svc.yaml
+++ b/cloud/kubernetes/multiregion/external-name-svc.yaml
@@ -1,0 +1,59 @@
+# This file contains the definitions needed to expose cockroachdb in a namespace
+# other than the one it's running in.
+# To use this file:
+# 1. Replace "YOUR_ZONE_HERE" in this file with the name of the namespace that
+#    cockroachdb is running in in the given cluster.
+# 2. Create a secret containing the certificates in the namespace that you want
+#    to expose the service in (the "default" namespace is assumed by the
+#    certificate creation commands in setup.py):
+#      kubectl create secret generic cockroachdb.client.root --namespace=YOUR_ZONE_HERE --from-file=certs
+# 3. Create the resources in this cluster:
+#      kubectl apply -f external-name-svc.yaml
+#
+# After completing these steps, you should be able to access the cockroachdb
+# cluster at the name `cockroachdb-public` in the default Kubernetes namespace
+# (or at the name `cockroachdb-public.default` from any namespace).
+kind: Service
+apiVersion: v1
+metadata:
+  name: cockroachdb-public
+spec:
+  type: ExternalName
+  externalName: cockroachdb-public.YOUR_ZONE_HERE.svc.cluster.local
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cockroachdb
+  labels:
+    app: cockroachdb
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: cockroachdb
+  labels:
+    app: cockroachdb
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: cockroachdb
+  labels:
+    app: cockroachdb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cockroachdb
+subjects:
+- kind: ServiceAccount
+  name: cockroachdb
+  namespace: default

--- a/cloud/kubernetes/multiregion/setup.py
+++ b/cloud/kubernetes/multiregion/setup.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+
+import distutils.spawn
+import json
+import os
+from subprocess import check_call,check_output
+from sys import exit
+from time import sleep
+
+# Before running the script, fill in appropriate values for all the parameters
+# above the dashed line.
+
+# Fill in the `contexts` map with the zones of your clusters and their
+# corresponding kubectl context names.
+#
+# To get the names of your kubectl "contexts" for each of your clusters, run:
+#   kubectl config get-contexts
+#
+# example:
+# contexts = {
+#     'us-central1-a': 'gke_cockroach-alex_us-central1-a_my-cluster',
+#     'us-central1-b': 'gke_cockroach-alex_us-central1-b_my-cluster',
+#     'us-west1-b': 'gke_cockroach-alex_us-west1-b_my-cluster',
+# }
+contexts = {
+        "a":"",
+}
+
+# Fill in the `regions` map with the zones and corresponding regions of your
+# clusters.
+#
+# Setting regions is optional, but recommended, because it improves cockroach's
+# ability to diversify data placement if you use more than one zone in the same
+# region. If you aren't specifying regions, just leave the map empty.
+#
+# example:
+# regions = {
+#     'us-central1-a': 'us-central1',
+#     'us-central1-b': 'us-central1',
+#     'us-west1-b': 'us-west1',
+# }
+regions = {
+}
+
+# Paths to directories in which to store certificates and generated YAML files.
+certs_dir = './certs'
+ca_key_dir = './my-safe-directory'
+generated_files_dir = './generated'
+
+# Path to the cockroach binary on your local machine that you want to use
+# generate certificates. Defaults to trying to find cockroach in your PATH.
+cockroach_path = 'cockroach'
+
+# ------------------------------------------------------------------------------
+
+# First, do some basic input validation.
+if len(contexts) == 0:
+    exit("must provide at least one Kubernetes cluster in the `contexts` map at the top of the script")
+
+if len(regions) != 0 and len(regions) != len(contexts):
+    exit("regions not specified for all kubectl contexts (%d regions, %d contexts)" % (len(regions), len(contexts)))
+
+try:
+    check_call(["which", cockroach_path])
+except:
+    exit("no binary found at provided path '" + cockroach_path + "'; please put a cockroach binary in your path or change the cockroach_path variable")
+
+for zone, context in contexts.items():
+    try:
+        check_call(['kubectl', 'get', 'pods', zone, '--context', context])
+    except:
+        exit("unable to make basic API call using kubectl context '%s' for cluster in zone '%s'; please check if the context is correct and your Kubernetes cluster is working" % (context, zone))
+
+# Set up the necessary directories and certificates. Ignore errors because they may already exist.
+try:
+    os.mkdir(certs_dir)
+except OSError:
+    pass
+try:
+    os.mkdir(ca_key_dir)
+except OSError:
+    pass
+try:
+    os.mkdir(generated_files_dir)
+except OSError:
+    pass
+
+check_call([cockroach_path, 'cert', 'create-ca', '--certs-dir', certs_dir, '--ca-key', ca_key_dir+'/ca.key'])
+check_call([cockroach_path, 'cert', 'create-client', 'root', '--certs-dir', certs_dir, '--ca-key', ca_key_dir+'/ca.key'])
+
+# For each cluster, create secrets containing the node and client certificates.
+# Also create a load balancer to each cluster's DNS pods.
+for zone, context in contexts.items():
+    check_call(['kubectl', 'create', 'namespace', zone, '--context', context])
+    check_call(['kubectl', 'create', 'secret', 'generic', 'cockroachdb.client.root', '--namespace', zone, '--from-file', certs_dir, '--context', context])
+    check_call([cockroach_path, 'cert', 'create-node', '--certs-dir', certs_dir, '--ca-key', ca_key_dir+'/ca.key', 'localhost', '127.0.0.1', 'cockroachdb-public', 'cockroachdb-public.default' 'cockroachdb-public.'+zone, 'cockroachdb-public.%s.svc.cluster.local' % (zone), '*.cockroachdb', '*.cockroachdb.'+zone, '*.cockroachdb.%s.svc.cluster.local' % (zone)])
+    check_call(['kubectl', 'create', 'secret', 'generic', 'cockroachdb.node', '--namespace', zone, '--from-file', certs_dir, '--context', context])
+    check_call('rm %s/node.*' % (certs_dir), shell=True)
+
+    check_call(['kubectl', 'apply', '-f', 'dns-lb.yaml', '--context', context])
+
+# Set up each cluster to forward DNS requests for zone-scoped namespaces to the
+# relevant cluster's DNS server, using load balancers in order to create a
+# static IP for each cluster's DNS endpoint.
+dns_ips = dict()
+for zone, context in contexts.items():
+    external_ip = ''
+    while True:
+        external_ip = check_output(['kubectl', 'get', 'svc', 'kube-dns-lb', '--namespace', 'kube-system', '--context', context, '--template', '{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}'])
+        if external_ip:
+            break
+        print  'Waiting for DNS load balancer IP in %s...' % (zone)
+        sleep(10)
+    print 'DNS endpoint for zone %s: %s' % (zone, external_ip)
+    dns_ips[zone] = external_ip
+
+# Update each cluster's DNS configuration with an appropriate configmap. Note
+# that we have to leave the local cluster out of its own configmap to avoid
+# infinite recursion through the load balancer IP. We then have to delete the
+# existing DNS pods in order for the new configuration to take effect.
+for zone, context in contexts.items():
+    remote_dns_ips = dict()
+    for z, ip in dns_ips.items():
+        if z == zone:
+            continue
+        remote_dns_ips[z+'.svc.cluster.local'] = [ip]
+    config_filename = '%s/dns-configmap-%s.yaml' % (generated_files_dir, zone)
+    with open(config_filename, 'w') as f:
+        f.write("""\
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-dns
+  namespace: kube-system
+data:
+  stubDomains: |
+    %s
+""" % (json.dumps(remote_dns_ips)))
+    check_call(['kubectl', 'apply', '-f', config_filename, '--namespace', 'kube-system', '--context', context])
+    check_call(['kubectl', 'delete', 'pods', '-l', 'k8s-app=kube-dns', '--namespace', 'kube-system', '--context', context])
+
+# Generate the join string to be used.
+join_addrs = []
+for zone in contexts:
+    for i in range(3):
+        join_addrs.append('cockroachdb-%d.cockroachdb.%s' % (i, zone))
+join_str = ','.join(join_addrs)
+
+# Create the cockroach resources in each cluster.
+for zone, context in contexts.items():
+    if zone in regions:
+        locality = 'region=%s,zone=%s' % (regions[zone], zone)
+    else:
+        locality = 'zone=%s' % (zone)
+    yaml_file = '%s/cockroachdb-statefulset-%s.yaml' % (generated_files_dir, zone)
+    with open(yaml_file, 'w') as f:
+        check_call(['sed', 's/JOINLIST/%s/g;s/LOCALITYLIST/%s/g' % (join_str, locality), 'cockroachdb-statefulset-secure.yaml'], stdout=f)
+    check_call(['kubectl', 'apply', '-f', yaml_file, '--namespace', zone, '--context', context])
+
+# Finally, initialize the cluster.
+print 'Sleeping 30 seconds before attempting to initialize cluster to give time for volumes to be created and pods started.'
+sleep(30)
+for zone, context in contexts.items():
+    check_call(['kubectl', 'create', '-f', 'cluster-init-secure.yaml', '--namespace', zone, '--context', context])
+    # We only need run the init command in one zone given that all the zones are
+    # joined together as one cluster.
+    break

--- a/cloud/kubernetes/multiregion/teardown.py
+++ b/cloud/kubernetes/multiregion/teardown.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+from shutil import rmtree
+from subprocess import call
+
+# Before running the script, fill in appropriate values for all the parameters
+# above the dashed line. You should use the same values when tearing down a
+# cluster that you used when setting it up.
+
+# To get the names of your kubectl "contexts" for each of your clusters, run:
+#   kubectl config get-contexts
+contexts = {
+    'us-central1-a': 'gke_cockroach-alex_us-central1-a_dns',
+    'us-central1-b': 'gke_cockroach-alex_us-central1-b_dns',
+    'us-west1-b': 'gke_cockroach-alex_us-west1-b_dns',
+}
+
+certs_dir = './certs'
+ca_key_dir = './my-safe-directory'
+generated_files_dir = './generated'
+
+# ------------------------------------------------------------------------------
+
+# Delete each cluster's special zone-scoped namespace, which transitively
+# deletes all resources that were created in the namespace, along with the few
+# other resources we created that weren't in that namespace
+for zone, context in contexts.items():
+    call(['kubectl', 'delete', 'namespace', zone, '--context', context])
+    call(['kubectl', 'delete', '-f', 'dns-lb.yaml', '--context', context])
+    call(['kubectl', 'delete', 'configmap', 'kube-dns', '--namespace', 'kube-system', '--context', context])
+    # Restart the DNS pods to clear out our stub-domains configuration.
+    call(['kubectl', 'delete', 'pods', '-l', 'k8s-app=kube-dns', '--namespace', 'kube-system', '--context', context])
+
+try:
+    rmtree(certs_dir)
+except OSError:
+    pass
+try:
+    rmtree(ca_key_dir)
+except OSError:
+    pass
+try:
+    rmtree(generated_files_dir)
+except OSError:
+    pass


### PR DESCRIPTION
tl;dr fill in a few constants at the top of secure.sh and then run it,
and you'll have a working secure multiregion cluster. Only tested on GKE
so far.

This relies on linking together each cluster's DNS servers so that
they're able to defer requests to each other for a special zone-scoped
namespace. This is a little hacky, but very maintainable and survivable
even if all the nodes in a cluster are taken down and brought back up
again later with different IP addresses.

The big caveat that I learned after I thought I was done, though, is
that GCE's internal load balancers only work within a region.
Unfortunately I had done my prototyping all within one region, with each
cluster just in a different zone. To get around this, I've had to switch
from exposing each DNS server on an internal IP to exposing them on
external IPs, which some users may not like, and which might tip the
scales in favor of a different solution. I'd be happy to discuss the
alternatives (hooking up a CoreDNS instance in each cluster to every
cluster's apiserver, or using istio multicluster) with anyone
interested.

I've only handled the secure cluster case in the script, but it can be
easily modified to also handle insecure clusters as an option. I should
translate the script to python for that, though. It's already more bash
than I'd want to ask people to use (and it requires bash v4, which macos
doesn't ship with by default).

Release note (general change): Configuration files and a setup script
for secure multiregion deployments on Kubernetes are now provided.

Fixes https://github.com/cockroachdb/cockroach/issues/25189