### PR TITLE
sql: refer to "show ranges" using the "experimental" keyword

### DIFF
--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -63,7 +63,7 @@ func registerCopy(r *registry) {
 
 			rangeCount := func() int {
 				var count int
-				const q = "SELECT count(*) FROM [SHOW TESTING_RANGES FROM TABLE bank.bank]"
+				const q = "SELECT count(*) FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE bank.bank]"
 				if err := db.QueryRow(q).Scan(&count); err != nil {
 					t.Fatalf("failed to get range count: %v", err)
 				}

--- a/pkg/cmd/roachtest/large_range.go
+++ b/pkg/cmd/roachtest/large_range.go
@@ -103,7 +103,7 @@ range_max_bytes: %d
 		t.Status("checking for single range")
 		rangeCount := func() int {
 			var count int
-			const q = "SELECT count(*) FROM [SHOW TESTING_RANGES FROM TABLE bank.bank]"
+			const q = "SELECT count(*) FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE bank.bank]"
 			if err := db.QueryRow(q).Scan(&count); err != nil {
 				t.Fatalf("failed to get range count: %v", err)
 			}

--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -22,7 +22,7 @@ INSERT INTO data SELECT a, b, c::FLOAT, d::DECIMAL FROM
 
 # Verify data placement.
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE data]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE data]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /1       {1}       1
@@ -313,7 +313,7 @@ statement ok
 INSERT INTO two VALUES (1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7), (8,8), (9,9), (10,10)
 
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE one]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE one]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /0       {5}       5
@@ -321,7 +321,7 @@ NULL       /0       {5}       5
 /99        NULL     {5}       5
 
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE two]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE two]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /0       {5}       5

--- a/pkg/sql/logictest/testdata/logic_test/distsql_distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_distinct_on
@@ -62,7 +62,7 @@ ALTER TABLE abc TESTING_RELOCATE VALUES
   (ARRAY[5], '3', '4', '5')
 
 query TTITI colnames
-SELECT * FROM [SHOW TESTING_RANGES FROM TABLE xyz]
+SELECT * FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE xyz]
 ----
 Start Key  End Key  Range ID  Replicas  Lease Holder
 NULL       /2       1         {1}       1
@@ -72,7 +72,7 @@ NULL       /2       1         {1}       1
 /7         NULL     5         {5}       5
 
 query TTITI colnames
-SELECT * FROM [SHOW TESTING_RANGES FROM TABLE abc]
+SELECT * FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE abc]
 ----
 Start Key        End Key          Range ID  Replicas  Lease Holder
 NULL             /NULL/NULL/NULL  5         {5}       5

--- a/pkg/sql/logictest/testdata/logic_test/distsql_interleaved_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_interleaved_join
@@ -189,7 +189,7 @@ ALTER TABLE grandchild2 TESTING_RELOCATE
 
 # Verify data placement.
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE parent1
+SHOW EXPERIMENTAL_RANGES FROM TABLE parent1
 ----
 Start Key                   End Key                     Range ID  Replicas  Lease Holder
 NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
@@ -214,7 +214,7 @@ NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
 /38/#/56/1/78/38/#/58/1/38  NULL                        20        {5}       5
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE child1
+SHOW EXPERIMENTAL_RANGES FROM TABLE child1
 ----
 Start Key                   End Key                     Range ID  Replicas  Lease Holder
 NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
@@ -239,7 +239,7 @@ NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
 /38/#/56/1/78/38/#/58/1/38  NULL                        20        {5}       5
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE grandchild1
+SHOW EXPERIMENTAL_RANGES FROM TABLE grandchild1
 ----
 Start Key                   End Key                     Range ID  Replicas  Lease Holder
 NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
@@ -510,7 +510,7 @@ ALTER TABLE outer_p1 TESTING_RELOCATE
   SELECT ARRAY[(((i-3)/5)%4)::INT + 1], i FROM generate_series(3, 40, 5) AS g(i)
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE outer_p1
+SHOW EXPERIMENTAL_RANGES FROM TABLE outer_p1
 ----
 Start Key  End Key  Range ID  Replicas  Lease Holder
 NULL       /0       20        {5}       5

--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -27,13 +27,13 @@ INSERT INTO NumToStr SELECT i, to_english(i) FROM generate_series(1, 100*100) AS
 
 # Verify data placement.
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE NumToSquare]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE NumToSquare]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       NULL     {1}       1
 
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE NumToStr]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE NumToStr]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /2000    {1}       1

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -22,7 +22,7 @@ INSERT INTO data SELECT a, b, c::FLOAT, d::DECIMAL FROM
 
 # Verify data placement.
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE data]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE data]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /1       {1}       1

--- a/pkg/sql/logictest/testdata/logic_test/distsql_tighten_spans
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_tighten_spans
@@ -149,7 +149,7 @@ ALTER TABLE p2 TESTING_RELOCATE SELECT ARRAY[i], i FROM generate_series(1,3) as 
 # p1 table (interleaved table)
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE p1
+SHOW EXPERIMENTAL_RANGES FROM TABLE p1
 ----
 Start Key    End Key      Range ID  Replicas  Lease Holder
 NULL         /2           1         {1}       1
@@ -159,7 +159,7 @@ NULL         /2           1         {1}       1
 # Indexes
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM INDEX b
+SHOW EXPERIMENTAL_RANGES FROM INDEX b
 ----
 Start Key  End Key  Range ID  Replicas  Lease Holder
 NULL       /0       3         {3}       3
@@ -169,7 +169,7 @@ NULL       /0       3         {3}       3
 # p2 table (interleaved index)
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE p2
+SHOW EXPERIMENTAL_RANGES FROM TABLE p2
 ----
 Start Key  End Key    Range ID  Replicas  Lease Holder
 NULL       /0         5         {5}       5

--- a/pkg/sql/logictest/testdata/logic_test/distsql_union
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_union
@@ -27,7 +27,7 @@ ALTER TABLE xyz TESTING_RELOCATE VALUES
   (ARRAY[5], 5)
 
 query TTITI colnames
-SELECT * FROM [SHOW TESTING_RANGES FROM TABLE xyz]
+SELECT * FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE xyz]
 ----
 Start Key  End Key  Range ID  Replicas  Lease Holder
 NULL       /2       1         {1}       1

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -4,7 +4,7 @@ statement ok
 CREATE TABLE t (k1 INT, k2 INT, v INT, w INT, PRIMARY KEY (k1, k2))
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE t
+SHOW EXPERIMENTAL_RANGES FROM TABLE t
 ----
 Start Key  End Key  Range ID  Replicas  Lease Holder
 NULL       NULL     1         {1}       1
@@ -13,7 +13,7 @@ statement ok
 ALTER TABLE t SPLIT AT VALUES (1), (10)
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE t
+SHOW EXPERIMENTAL_RANGES FROM TABLE t
 ----
 Start Key  End Key  Range ID  Replicas  Lease Holder
 NULL       /1       1         {1}       1
@@ -24,7 +24,7 @@ statement ok
 ALTER TABLE t TESTING_RELOCATE VALUES (ARRAY[4], 1, 12)
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE t
+SHOW EXPERIMENTAL_RANGES FROM TABLE t
 ----
 Start Key  End Key   Range ID Replicas  Lease Holder
 NULL       /1        1        {1}       1
@@ -35,7 +35,7 @@ statement ok
 ALTER TABLE t SPLIT AT VALUES (5,1), (5,2), (5,3)
 
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE t]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE t]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /1       {1}       1
@@ -52,7 +52,7 @@ statement ok
 ALTER TABLE t TESTING_RELOCATE VALUES (ARRAY[3,4], 4)
 
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE t]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE t]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /1       {1}       1
@@ -66,7 +66,7 @@ statement ok
 CREATE INDEX idx ON t(v, w)
 
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM INDEX t@idx]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM INDEX t@idx]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       NULL     {1}       1
@@ -75,7 +75,7 @@ statement ok
 ALTER INDEX t@idx SPLIT AT VALUES (100,1), (100,50)
 
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM INDEX t@idx]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM INDEX t@idx]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /100/1   {1}       1
@@ -86,7 +86,7 @@ statement ok
 ALTER INDEX t@idx SPLIT AT VALUES (8), (9)
 
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM INDEX t@idx]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM INDEX t@idx]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /8       {1}       1
@@ -99,7 +99,7 @@ statement ok
 ALTER INDEX t@idx TESTING_RELOCATE VALUES (ARRAY[5], 100, 10), (ARRAY[3], 100, 11)
 
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM INDEX t@idx]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM INDEX t@idx]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /8       {1}       1
@@ -117,7 +117,7 @@ CREATE TABLE t0 (
 
 # We expect the splits for t0 to be the same as the splits for t.
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE t0]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE t0]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /1       {1}       1
@@ -131,7 +131,7 @@ statement ok
 ALTER TABLE t0 SPLIT AT VALUES (7, 8, 9)
 
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE t0]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE t0]
 ----
 Start Key      End Key        Replicas  Lease Holder
 NULL           /1             {1}       1
@@ -146,7 +146,7 @@ statement ok
 ALTER TABLE t0 SPLIT AT VALUES (11)
 
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE t0]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE t0]
 ----
 Start Key      End Key        Replicas  Lease Holder
 NULL           /1             {1}       1
@@ -159,7 +159,7 @@ NULL           /1             {1}       1
 /11            NULL           {1}       1
 
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE t]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE t]
 ----
 Start Key      End Key        Replicas  Lease Holder
 NULL           /1             {1}       1
@@ -180,7 +180,7 @@ CREATE INDEX idx on t1(v1,v2,v3) INTERLEAVE IN PARENT t(v1,v2)
 
 # We expect the splits for the index to be the same as the splits for t.
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM INDEX t1@idx]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM INDEX t1@idx]
 ----
 Start Key      End Key        Replicas  Lease Holder
 NULL           /1             {1}       1
@@ -196,7 +196,7 @@ statement ok
 ALTER INDEX t1@idx SPLIT AT VALUES (15,16)
 
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM INDEX t1@idx]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM INDEX t1@idx]
 ----
 Start Key      End Key        Replicas  Lease Holder
 NULL           /1             {1}       1

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -233,13 +233,13 @@ testuser
 
 
 query TTITI colnames
-SELECT * FROM [SHOW TESTING_RANGES FROM TABLE system.descriptor]
+SELECT * FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE system.descriptor]
 ----
 Start Key  End Key  Range ID  Replicas  Lease Holder
 NULL       NULL     1         {1}       1
 
 query TTITI colnames
-CREATE INDEX ix ON foo(x); SELECT * FROM [SHOW TESTING_RANGES FROM INDEX foo@ix]
+CREATE INDEX ix ON foo(x); SELECT * FROM [SHOW EXPERIMENTAL_RANGES FROM INDEX foo@ix]
 ----
 Start Key  End Key  Range ID  Replicas  Lease Holder
 NULL       NULL     1         {1}       1

--- a/pkg/sql/logictest/testdata/planner_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_agg
@@ -14,7 +14,7 @@ ALTER TABLE data TESTING_RELOCATE
 
 # Verify data placement.
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE data]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE data]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /1       {1}       1

--- a/pkg/sql/logictest/testdata/planner_test/distsql_distinct_on
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_distinct_on
@@ -44,7 +44,7 @@ ALTER TABLE abc TESTING_RELOCATE VALUES
   (ARRAY[5], '3', '4', '5')
 
 query TTITI colnames
-SELECT * FROM [SHOW TESTING_RANGES FROM TABLE xyz]
+SELECT * FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE xyz]
 ----
 Start Key  End Key  Range ID  Replicas  Lease Holder
 NULL       /2       1         {1}       1
@@ -54,7 +54,7 @@ NULL       /2       1         {1}       1
 /7         NULL     5         {5}       5
 
 query TTITI colnames
-SELECT * FROM [SHOW TESTING_RANGES FROM TABLE abc]
+SELECT * FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE abc]
 ----
 Start Key        End Key          Range ID  Replicas  Lease Holder
 NULL             /NULL/NULL/NULL  5         {5}       5

--- a/pkg/sql/logictest/testdata/planner_test/distsql_indexjoin
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_indexjoin
@@ -13,7 +13,7 @@ ALTER INDEX t@v TESTING_RELOCATE
   SELECT ARRAY[i+1], (i * 10)::int FROM generate_series(0, 4) AS g(i)
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM INDEX t@v
+SHOW EXPERIMENTAL_RANGES FROM INDEX t@v
 ----
 Start Key  End Key  Range ID  Replicas  Lease Holder
 NULL       /10      1         {1}       1

--- a/pkg/sql/logictest/testdata/planner_test/distsql_interleaved_join
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_interleaved_join
@@ -104,7 +104,7 @@ ALTER TABLE grandchild2 TESTING_RELOCATE
 
 # Verify data placement.
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE parent1
+SHOW EXPERIMENTAL_RANGES FROM TABLE parent1
 ----
 Start Key                   End Key                     Range ID  Replicas  Lease Holder
 NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
@@ -129,7 +129,7 @@ NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
 /38/#/56/1/78/38/#/58/1/38  NULL                        20        {5}       5
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE child1
+SHOW EXPERIMENTAL_RANGES FROM TABLE child1
 ----
 Start Key                   End Key                     Range ID  Replicas  Lease Holder
 NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
@@ -154,7 +154,7 @@ NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
 /38/#/56/1/78/38/#/58/1/38  NULL                        20        {5}       5
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE grandchild1
+SHOW EXPERIMENTAL_RANGES FROM TABLE grandchild1
 ----
 Start Key                   End Key                     Range ID  Replicas  Lease Holder
 NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
@@ -360,7 +360,7 @@ ALTER TABLE outer_p1 TESTING_RELOCATE
   SELECT ARRAY[(((i-3)/5)%4)::INT + 1], i FROM generate_series(3, 40, 5) AS g(i)
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE outer_p1
+SHOW EXPERIMENTAL_RANGES FROM TABLE outer_p1
 ----
 Start Key  End Key  Range ID  Replicas  Lease Holder
 NULL       /0       20        {5}       5

--- a/pkg/sql/logictest/testdata/planner_test/distsql_join
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_join
@@ -14,7 +14,7 @@ ALTER TABLE data TESTING_RELOCATE
 
 # Verify data placement.
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE data
+SHOW EXPERIMENTAL_RANGES FROM TABLE data
 ----
 Start Key  End Key  Range ID  Replicas  Lease Holder
 NULL       /1       1         {1}       1

--- a/pkg/sql/logictest/testdata/planner_test/distsql_misc
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_misc
@@ -68,7 +68,7 @@ ALTER TABLE data TESTING_RELOCATE
 
 # Verify data placement.
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE data]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE data]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /1       {1}       1

--- a/pkg/sql/logictest/testdata/planner_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_numtables
@@ -24,13 +24,13 @@ ALTER TABLE NumToStr TESTING_RELOCATE
 
 # Verify data placement.
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE NumToSquare]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE NumToSquare]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       NULL     {1}       1
 
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE NumToStr]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE NumToStr]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /2000    {1}       1

--- a/pkg/sql/logictest/testdata/planner_test/distsql_tighten_spans
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_tighten_spans
@@ -97,7 +97,7 @@ ALTER TABLE p2 TESTING_RELOCATE SELECT ARRAY[i], i FROM generate_series(1,3) as 
 # p1 table (interleaved table)
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE p1
+SHOW EXPERIMENTAL_RANGES FROM TABLE p1
 ----
 Start Key    End Key      Range ID  Replicas  Lease Holder
 NULL         /2           1         {1}       1
@@ -107,7 +107,7 @@ NULL         /2           1         {1}       1
 # Indexes
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM INDEX b
+SHOW EXPERIMENTAL_RANGES FROM INDEX b
 ----
 Start Key  End Key  Range ID  Replicas  Lease Holder
 NULL       /0       3         {3}       3
@@ -117,7 +117,7 @@ NULL       /0       3         {3}       3
 # p2 table (interleaved index)
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE p2
+SHOW EXPERIMENTAL_RANGES FROM TABLE p2
 ----
 Start Key  End Key    Range ID  Replicas  Lease Holder
 NULL       /0         5         {5}       5

--- a/pkg/sql/logictest/testdata/planner_test/distsql_union
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_union
@@ -19,7 +19,7 @@ ALTER TABLE xyz TESTING_RELOCATE VALUES
   (ARRAY[5], 5)
 
 query TTITI colnames
-SELECT * FROM [SHOW TESTING_RANGES FROM TABLE xyz]
+SELECT * FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE xyz]
 ----
 Start Key  End Key  Range ID  Replicas  Lease Holder
 NULL       /2       1         {1}       1

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
@@ -14,7 +14,7 @@ ALTER TABLE data TESTING_RELOCATE
 
 # Verify data placement.
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE data]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE data]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /1       {1}       1

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
@@ -46,7 +46,7 @@
 #   (ARRAY[5], '3', '4', '5')
 # 
 # query TTITI colnames
-# SELECT * FROM [SHOW TESTING_RANGES FROM TABLE xyz]
+# SELECT * FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE xyz]
 # ----
 # Start Key  End Key  Range ID  Replicas  Lease Holder
 # NULL       /2       1         {1}       1
@@ -56,7 +56,7 @@
 # /7         NULL     5         {5}       5
 # 
 # query TTITI colnames
-# SELECT * FROM [SHOW TESTING_RANGES FROM TABLE abc]
+# SELECT * FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE abc]
 # ----
 # Start Key        End Key          Range ID  Replicas  Lease Holder
 # NULL             /NULL/NULL/NULL  5         {5}       5

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_indexjoin
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_indexjoin
@@ -13,7 +13,7 @@ ALTER INDEX t@v TESTING_RELOCATE
   SELECT ARRAY[i+1], (i * 10)::int FROM generate_series(0, 4) AS g(i)
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM INDEX t@v
+SHOW EXPERIMENTAL_RANGES FROM INDEX t@v
 ----
 Start Key  End Key  Range ID  Replicas  Lease Holder
 NULL       /10      1         {1}       1

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
@@ -104,7 +104,7 @@ ALTER TABLE grandchild2 TESTING_RELOCATE
 
 # Verify data placement.
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE parent1
+SHOW EXPERIMENTAL_RANGES FROM TABLE parent1
 ----
 Start Key                   End Key                     Range ID  Replicas  Lease Holder
 NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
@@ -129,7 +129,7 @@ NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
 /38/#/56/1/78/38/#/58/1/38  NULL                        20        {5}       5
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE child1
+SHOW EXPERIMENTAL_RANGES FROM TABLE child1
 ----
 Start Key                   End Key                     Range ID  Replicas  Lease Holder
 NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
@@ -154,7 +154,7 @@ NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
 /38/#/56/1/78/38/#/58/1/38  NULL                        20        {5}       5
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE grandchild1
+SHOW EXPERIMENTAL_RANGES FROM TABLE grandchild1
 ----
 Start Key                   End Key                     Range ID  Replicas  Lease Holder
 NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
@@ -361,7 +361,7 @@ NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
 #   SELECT ARRAY[(((i-3)/5)%4)::INT + 1], i FROM generate_series(3, 40, 5) AS g(i)
 # 
 # query TTITI colnames
-# SHOW TESTING_RANGES FROM TABLE outer_p1
+# SHOW EXPERIMENTAL_RANGES FROM TABLE outer_p1
 # ----
 # Start Key  End Key  Range ID  Replicas  Lease Holder
 # NULL       /0       20        {5}       5

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
@@ -14,7 +14,7 @@ ALTER TABLE data TESTING_RELOCATE
 
 # Verify data placement.
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE data
+SHOW EXPERIMENTAL_RANGES FROM TABLE data
 ----
 Start Key  End Key  Range ID  Replicas  Lease Holder
 NULL       /1       1         {1}       1

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
@@ -70,7 +70,7 @@ ALTER TABLE data TESTING_RELOCATE
 
 # Verify data placement.
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE data]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE data]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /1       {1}       1

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -24,13 +24,13 @@ ALTER TABLE NumToStr TESTING_RELOCATE
 
 # Verify data placement.
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE NumToSquare]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE NumToSquare]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       NULL     {1}       1
 
 query TTTI colnames
-SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE NumToStr]
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE NumToStr]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /2000    {1}       1

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
@@ -97,7 +97,7 @@ ALTER TABLE p2 TESTING_RELOCATE SELECT ARRAY[i], i FROM generate_series(1,3) as 
 # p1 table (interleaved table)
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE p1
+SHOW EXPERIMENTAL_RANGES FROM TABLE p1
 ----
 Start Key    End Key      Range ID  Replicas  Lease Holder
 NULL         /2           1         {1}       1
@@ -107,7 +107,7 @@ NULL         /2           1         {1}       1
 # Indexes
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM INDEX b
+SHOW EXPERIMENTAL_RANGES FROM INDEX b
 ----
 Start Key  End Key  Range ID  Replicas  Lease Holder
 NULL       /0       3         {3}       3
@@ -117,7 +117,7 @@ NULL       /0       3         {3}       3
 # p2 table (interleaved index)
 
 query TTITI colnames
-SHOW TESTING_RANGES FROM TABLE p2
+SHOW EXPERIMENTAL_RANGES FROM TABLE p2
 ----
 Start Key  End Key    Range ID  Replicas  Lease Holder
 NULL       /0         5         {5}       5

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_union
@@ -19,7 +19,7 @@ ALTER TABLE xyz TESTING_RELOCATE VALUES
   (ARRAY[5], 5)
 
 query TTITI colnames
-SELECT * FROM [SHOW TESTING_RANGES FROM TABLE xyz]
+SELECT * FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE xyz]
 ----
 Start Key  End Key  Range ID  Replicas  Lease Holder
 NULL       /2       1         {1}       1

--- a/pkg/sql/scatter_test.go
+++ b/pkg/sql/scatter_test.go
@@ -49,7 +49,7 @@ func TestScatterRandomizeLeases(t *testing.T) {
 	r.Exec(t, "ALTER TABLE test.t SPLIT AT (SELECT i*10 FROM generate_series(1, 99) AS g(i))")
 
 	getLeaseholders := func() (map[int]int, error) {
-		rows := r.Query(t, `SELECT "Range ID", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE test.t]`)
+		rows := r.Query(t, `SELECT "Range ID", "Lease Holder" FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE test.t]`)
 		leaseholders := make(map[int]int)
 		numRows := 0
 		for ; rows.Next(); numRows++ {

--- a/pkg/sql/show_ranges.go
+++ b/pkg/sql/show_ranges.go
@@ -12,9 +12,9 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// This file implements the SHOW TESTING_RANGES statement:
-//   SHOW TESTING_RANGES FROM TABLE t
-//   SHOW TESTING_RANGES FROM INDEX t@idx
+// This file implements the SHOW EXPERIMENTAL_RANGES statement:
+//   SHOW EXPERIMENTAL_RANGES FROM TABLE t
+//   SHOW EXPERIMENTAL_RANGES FROM INDEX t@idx
 //
 // These statements show the ranges corresponding to the given table or index,
 // along with the list of replicas and the lease holder.
@@ -118,14 +118,14 @@ func (n *showRangesNode) Next(params runParams) (bool, error) {
 	// We do not attempt to identify the encoding directions for pretty
 	// printing a split key since it's possible for a key from an arbitrary
 	// table in the same interleaved hierarchy to appear in SHOW
-	// TESTING_RANGE. Consider the interleaved hierarchy
+	// EXPERIMENTAL_RANGES. Consider the interleaved hierarchy
 	//    parent1		      (pid1)
 	//	  child1	      (pid1, cid1)
 	//	      grandchild1     (pid1, cid1, gcid1)
 	//	  child2	      (pid1, cid2, cid3)
 	//	      grandchild2     (pid1, cid2, cid3, gcid2)
 	// and the result of
-	//    SHOW TESTING_RANGES FROM TABLE grandchild1
+	//    SHOW EXPERIMENTAL_RANGES FROM TABLE grandchild1
 	// It is possible for a split key for grandchild2 to show up.
 	// Traversing up the InterleaveDescriptor is futile since we do not
 	// know the SharedPrefixLen in between each interleaved sentinel of a

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -1235,7 +1235,7 @@ func prettyPrintValueImpl(valDirs []Direction, b []byte, sep string) (string, bo
 //  - For non-table keys, we never have NotNull.
 //  - For table keys, we always explicitly pass in Ascending and Descending for
 //    all key values, including NotNulls. The only case we do not pass in
-//    direction is during a SHOW TESTING_RANGE ON TABLE parent and there exists
+//    direction is during a SHOW EXPERIMENTAL_RANGES ON TABLE parent and there exists
 //    an interleaved split key. Note that interleaved keys cannot have NotNull
 //    values except for the interleaved sentinel.
 //
@@ -1243,7 +1243,7 @@ func prettyPrintValueImpl(valDirs []Direction, b []byte, sep string) (string, bo
 // non-table keys encode values with Ascending.
 //
 // The only case where we end up defaulting direction for table keys is for
-// interleaved split keys in SHOW TESTING_RANGE ON TABLE parent. Since
+// interleaved split keys in SHOW EXPERIMENTAL_RANGES ON TABLE parent. Since
 // interleaved prefixes are defined on the primary key (and primary key values
 // are always encoded Ascending), this will always print out the correct key
 // even if we don't have directions for the child index's columns.

--- a/pkg/workload/bank/bank_test.go
+++ b/pkg/workload/bank/bank_test.go
@@ -61,7 +61,7 @@ func TestBank(t *testing.T) {
 
 			var rangeCount int
 			sqlDB.QueryRow(t,
-				fmt.Sprintf(`SELECT count(*) FROM [SHOW TESTING_RANGES FROM TABLE %s]`, bankTable.Name),
+				fmt.Sprintf(`SELECT count(*) FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE %s]`, bankTable.Name),
 			).Scan(&rangeCount)
 			if rangeCount != test.expectedRanges {
 				t.Errorf("got %d ranges expected %d", rangeCount, test.expectedRanges)

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -109,7 +109,7 @@ func TestSplits(t *testing.T) {
 
 			var actual int
 			sqlDB.QueryRow(
-				t, `SELECT count(*) FROM [SHOW TESTING_RANGES FROM TABLE test.bank]`,
+				t, `SELECT count(*) FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE test.bank]`,
 			).Scan(&actual)
 			if ranges != actual {
 				t.Errorf(`expected %d got %d`, ranges, actual)


### PR DESCRIPTION
On the way to address #26840.

Both the syntax `SHOW TESTING_RANGES` and `SHOW EXPERIMENTAL_RANGES`
are recognized, but only the latter is canonical. Ensure it is used
throughout.

Release note: None