### PR TITLE
sql: lowercase session var name in test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -36,7 +36,7 @@ statement ok
 SET database = ""
 
 query T colnames
-SHOW DATABASE
+SHOW database
 ----
 database
 ·


### PR DESCRIPTION
Found while working on #26840.

Release note: None
