### PR TITLE
roachtest: test 32 node import/restore

### DIFF
--- a/pkg/cmd/roachtest/disk_space.go
+++ b/pkg/cmd/roachtest/disk_space.go
@@ -122,7 +122,7 @@ func runDiskUsage(t *test, c *cluster, duration time.Duration, tc diskUsageTestC
 	clusterDiskUsage := func() int {
 		totalDiskUsage := 0
 		for i := 1; i <= numNodes; i++ {
-			diskUsageOnNodeI, err := getDiskUsageInByte(ctx, c, i)
+			diskUsageOnNodeI, err := getDiskUsageInBytes(ctx, c, c.l, i)
 			if err != nil {
 				t.Fatalf("Failed to get disk usage on node %d, error: %v", i, err)
 			}

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -86,7 +86,7 @@ func registerDrop(r *registry) {
 			}
 
 			for j := 1; j <= nodes; j++ {
-				size, err := getDiskUsageInByte(ctx, c, j)
+				size, err := getDiskUsageInBytes(ctx, c, c.l, j)
 				if err != nil {
 					return err
 				}
@@ -127,7 +127,7 @@ func registerDrop(r *registry) {
 				sizeReport = ""
 				allNodesSpaceCleared = true
 				for j := 1; j <= nodes; j++ {
-					size, err := getDiskUsageInByte(ctx, c, j)
+					size, err := getDiskUsageInBytes(ctx, c, c.l, j)
 					if err != nil {
 						return err
 					}

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -16,30 +16,227 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
+// HealthChecker runs a regular check that verifies that a specified subset
+// of (CockroachDB) nodes look "very healthy". That is, there are no stuck
+// proposals, liveness problems, or whatever else might get added in the
+// future.
+type HealthChecker struct {
+	c      *cluster
+	nodes  nodeListOption
+	doneCh chan struct{}
+}
+
+// NewHealthChecker returns a populated HealthChecker.
+func NewHealthChecker(c *cluster, nodes nodeListOption) *HealthChecker {
+	return &HealthChecker{
+		c:      c,
+		nodes:  nodes,
+		doneCh: make(chan struct{}),
+	}
+}
+
+// Done signals the HeatlthChecker's Runner to shut down.
+func (hc *HealthChecker) Done() {
+	close(hc.doneCh)
+}
+
+type gossipAlert struct {
+	NodeID, StoreID       int
+	Category, Description string
+	Value                 float64
+}
+
+type gossipAlerts []gossipAlert
+
+func (g gossipAlerts) String() string {
+	var buf bytes.Buffer
+	tw := tabwriter.NewWriter(&buf, 2, 1, 2, ' ', 0)
+
+	for _, a := range g {
+		fmt.Fprintf(tw, "n%d/s%d\t%.2f\t%s\t%s\n", a.NodeID, a.StoreID, a.Value, a.Category, a.Description)
+	}
+	_ = tw.Flush()
+	return buf.String()
+}
+
+// Runner makes sure the gossip_alerts table is empty at all times.
+//
+// TODO(tschottdorf): actually let this fail the test instead of logging complaints.
+func (hc *HealthChecker) Runner(ctx context.Context) (err error) {
+	logger, err := hc.c.l.ChildLogger("health")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		logger.Printf("health check terminated with %v\n", err)
+	}()
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-hc.doneCh:
+			return nil
+		case <-ticker.C:
+		}
+
+		tBegin := timeutil.Now()
+
+		nodeIdx := 1 + rand.Intn(len(hc.nodes))
+		db, err := hc.c.ConnE(ctx, nodeIdx)
+		if err != nil {
+			return err
+		}
+		// TODO(tschottdorf): remove replicate queue failures when the cluster first starts.
+		// Ditto queue.raftsnapshot.process.failure.
+		rows, err := db.QueryContext(ctx, `SELECT * FROM crdb_internal.gossip_alerts WHERE description != 'queue.replicate.process.failure' AND description != 'ranges.underreplicated' AND description != 'queue.raftsnapshot.process.failure' ORDER BY node_id ASC, store_id ASC`)
+		_ = db.Close()
+		if err != nil {
+			return err
+		}
+		var rr gossipAlerts
+		for rows.Next() {
+			var a gossipAlert
+			if err := rows.Scan(&a.NodeID, &a.StoreID, &a.Category, &a.Description, &a.Value); err != nil {
+				return err
+			}
+			rr = append(rr, a)
+		}
+		if len(rr) > 0 {
+			logger.Printf(rr.String() + "\n")
+			// TODO(tschottdorf): see method comment.
+			// return errors.New(rr.String())
+		}
+
+		if elapsed := timeutil.Since(tBegin); elapsed > 10*time.Second {
+			return errors.Errorf("health check against node %d took %s", nodeIdx, elapsed)
+		}
+	}
+}
+
+// DiskUsageLogger regularly logs the disk spaced used by the nodes in the cluster.
+type DiskUsageLogger struct {
+	c      *cluster
+	doneCh chan struct{}
+}
+
+// NewDiskUsageLogger populates a DiskUsageLogger.
+func NewDiskUsageLogger(c *cluster) *DiskUsageLogger {
+	return &DiskUsageLogger{
+		c:      c,
+		doneCh: make(chan struct{}),
+	}
+}
+
+// Done instructs the Runner to terminate.
+func (dul *DiskUsageLogger) Done() {
+	close(dul.doneCh)
+}
+
+// Runner runs in a loop until Done() is called and prints the cluster-wide per
+// node disk usage in descending order.
+func (dul *DiskUsageLogger) Runner(ctx context.Context) error {
+	logger, err := dul.c.l.ChildLogger("diskusage")
+	if err != nil {
+		return err
+	}
+	quietLogger, err := dul.c.l.ChildLogger("diskusage-exec", quietStdout, quietStderr)
+	if err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-dul.doneCh:
+			return nil
+		case <-ticker.C:
+		}
+
+		type usage struct {
+			nodeNum int
+			bytes   int
+		}
+
+		var bytesUsed []usage
+		for i := 1; i <= dul.c.nodes; i++ {
+			cur, err := getDiskUsageInBytes(ctx, dul.c, quietLogger, i)
+			if err != nil {
+				// This can trigger spuriously as compactions remove files out from under `du`.
+				logger.Printf("%s", errors.Wrapf(err, "node #%d", i))
+				cur = -1
+			}
+			bytesUsed = append(bytesUsed, usage{
+				nodeNum: i,
+				bytes:   cur,
+			})
+		}
+		sort.Slice(bytesUsed, func(i, j int) bool { return bytesUsed[i].bytes > bytesUsed[j].bytes }) // descending
+
+		var s []string
+		for _, usage := range bytesUsed {
+			s = append(s, fmt.Sprintf("n#%d: %s", usage.nodeNum, humanizeutil.IBytes(int64(usage.bytes))))
+		}
+
+		logger.Printf("%s\n", strings.Join(s, ", "))
+	}
+}
+
 func registerRestore(r *registry) {
-	r.Add(testSpec{
-		Name:   `restore2TB`,
-		Nodes:  nodes(10),
-		Stable: true, // DO NOT COPY to new tests
-		Run: func(ctx context.Context, t *test, c *cluster) {
-			c.Put(ctx, cockroach, "./cockroach")
-			c.Start(ctx)
-			m := newMonitor(ctx, c)
-			m.Go(func(ctx context.Context) error {
-				t.Status(`running restore`)
-				c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "CREATE DATABASE restore2tb"`)
-				// TODO(dan): It'd be nice if we could keep track over time of how
-				// long this next line took.
-				c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
+	for _, nodeCount := range []int{10, 32} {
+		r.Add(testSpec{
+			Name:   fmt.Sprintf("restore2TB/nodes=%d", nodeCount),
+			Nodes:  nodes(nodeCount),
+			Stable: true, // DO NOT COPY to new tests
+			Run: func(ctx context.Context, t *test, c *cluster) {
+				c.Put(ctx, cockroach, "./cockroach")
+				c.Start(ctx)
+				m := newMonitor(ctx, c)
+
+				// Run the disk usage logger in the monitor to guarantee its
+				// having terminated when the test ends.
+				dul := NewDiskUsageLogger(c)
+				m.Go(dul.Runner)
+				hc := NewHealthChecker(c, c.All())
+				m.Go(hc.Runner)
+
+				m.Go(func(ctx context.Context) error {
+					defer dul.Done()
+					defer hc.Done()
+					t.Status(`running restore`)
+					c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "CREATE DATABASE restore2tb"`)
+					// TODO(dan): It'd be nice if we could keep track over time of how
+					// long this next line took.
+					c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
 				RESTORE csv.bank FROM
 				'gs://cockroach-fixtures/workload/bank/version=1.0.0,payload-bytes=10240,ranges=0,rows=65104166,seed=1/bank'
 				WITH into_db = 'restore2tb'"`)
-				return nil
-			})
-			m.Wait()
-		},
-	})
+					return nil
+				})
+				m.Wait()
+			},
+		})
+	}
 }


### PR DESCRIPTION
30+ node clusters have been repeat offenders in internal investigations,
mostly due to getting into a state in which heartbeats fail and Raft
commands get stuck, and more specifically triggered by backup/restore
activity. The hope is that this test can reproduce some of that.

For starters, add some logging that prints whenever the gossip_alerts
table is nonempty (which hints at stuck proposals, liveness errors,
etc). The intention is to make this fail the tests in the future.

Additionally, regularly print the disk usage stats because that's
something some users have shown interest in understanding better.

Release note: None