### PR TITLE
 ui: error state for statement details

### DIFF
--- a/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
@@ -127,7 +127,7 @@ export default class Sidebar extends React.Component {
         </ul>
         <ul className="navigation-bar__list navigation-bar__list--bottom">
           <LoginIndicatorConnected />
-          <IconLink to="/" icon={cockroachIcon} className="cockroach" />
+          <IconLink to="/debug" icon={cockroachIcon} className="cockroach" />
         </ul>
       </nav>
     );

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -133,6 +133,26 @@ class StatementDetails extends React.Component<StatementDetailsProps> {
 
     const { stats, statement, app, distSQL, failed } = this.props.statement;
 
+    if (!stats) {
+      const sourceApp = this.props.params[appAttr];
+      const listUrl = "/statements" + (sourceApp ? "/" + sourceApp : "");
+
+      return (
+        <React.Fragment>
+          <section className="section">
+            <SqlBox value={ statement } />
+          </section>
+          <section className="section">
+            <h3>Unable to find statement</h3>
+            There are no execution statistics for this statement.{" "}
+            <Link className="back-link" to={ listUrl }>
+              Back to Statements
+            </Link>
+          </section>
+        </React.Fragment>
+      );
+    }
+
     const count = FixLong(stats.count).toInt();
     const firstAttemptCount = FixLong(stats.first_attempt_count).toInt();
 

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -12,6 +12,10 @@
     font-style italic
     color $body-color
 
+.back-link
+  text-decoration none
+  color $link-color
+
 .last-cleared-tooltip
   &__tooltip
     width 36px  // Reserve space for 10px padding around centered 16px icon


### PR DESCRIPTION
Show an error page if the statement isn't found on the statement
details page, rather than blowing up with an NPE.

Fixes: #27080
Release note (admin ui change): Fix a bug that would make the
statement details page break if a statement wasn't found.

![unable-to-find-statement](https://user-images.githubusercontent.com/793969/42176079-c25ea842-7df5-11e8-8fee-eb95dd7f71ba.png)
