### PR TITLE
opt: access-check observing schemas in opt

### DIFF
--- a/pkg/cli/interactive_tests/test_audit_log.tcl
+++ b/pkg/cli/interactive_tests/test_audit_log.tcl
@@ -35,13 +35,11 @@ eexpect root@
 system "grep -q 'helloworld.*:READWRITE.*INSERT.*OK' $logfile"
 end_test
 
-# TODO(justin): re-enable this once we properly do privilege checks on
-# observing schemas.
-# start_test "Check that errors get logged too"
-# send "SELECT nonexistent FROM helloworld;\r"
-# eexpect root@
-# system "grep -q 'helloworld.*:READ}.*SELECT.*ERROR' $logfile"
-# end_test
+start_test "Check that errors get logged too"
+send "SELECT nonexistent FROM helloworld;\r"
+eexpect root@
+system "grep -q 'helloworld.*:READ}.*SELECT.*ERROR' $logfile"
+end_test
 
 # Flush and truncate the logs. The test below must not see the log entries that
 # were already generated above.

--- a/pkg/sql/logictest/testdata/logic_test/privileges_table
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_table
@@ -63,6 +63,9 @@ SHOW GRANTS ON t
 statement error pq: user testuser has no privileges on relation t
 SHOW COLUMNS FROM t
 
+statement error pq: user testuser does not have SELECT privilege on relation t
+SELECT r FROM t
+
 statement error user testuser does not have GRANT privilege on relation t
 GRANT ALL ON t TO bar
 

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -348,6 +348,10 @@ func (p *planner) makePlan(ctx context.Context, stmt Statement) error {
 // makeOptimizerPlan is an alternative to makePlan which uses the (experimental)
 // optimizer.
 func (p *planner) makeOptimizerPlan(ctx context.Context, stmt Statement) error {
+	// This will get overwritten if we successfully create a plan, but if we
+	// error we need access to the AST.
+	p.curPlan = planTop{AST: stmt.AST}
+
 	// Start with fast check to see if top-level statement is supported.
 	switch stmt.AST.(type) {
 	case *tree.ParenSelect, *tree.Select, *tree.SelectClause,

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -47,6 +47,15 @@ type SchemaResolver interface {
 
 var _ SchemaResolver = &planner{}
 
+// LogicalSchema encapsulates the interfaces needed to be able to both look up
+// schema objects and also resolve permissions on them.
+type LogicalSchema interface {
+	SchemaResolver
+	AuthorizationAccessor
+}
+
+var _ LogicalSchema = &planner{}
+
 // ResolveDatabase looks up a database name.
 func ResolveDatabase(
 	ctx context.Context, sc SchemaResolver, dbName string, required bool,


### PR DESCRIPTION
Fixes #27036.

Previously we would only privilege check access to tables when
execbuilding a plan. This meant that a user could determine the columns
present in a table by issuing a query referencing non-existent columns.
In addition, these accesses would not be audit logged. This change
performs access checks when looking up a table.

In addition, we fix an issue where we would not log the correct
statement string in audit logging when using the optimizer.

Before the 2.1 launch we should do a thorough audit to make sure
the optimizer isn't leaking info where the existing planner was not.

Release note (sql change): fix permissions and audit logging issues with
the optimizer.