### PR TITLE
opt: refactor lower level of optsteps

### DIFF
--- a/pkg/sql/opt/testutils/forcing_opt.go
+++ b/pkg/sql/opt/testutils/forcing_opt.go
@@ -1,0 +1,199 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package testutils
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+// forcingOptimizer is a wrapper around an Optimizer which adds low-level
+// control, like restricting rule application or the expressions that can be
+// part of the final expression.
+type forcingOptimizer struct {
+	o *xform.Optimizer
+
+	root     memo.GroupID
+	required *props.Physical
+
+	// remaining is the number of "unused" steps remaining.
+	remaining int
+
+	// lastMatched records the name of the rule that was most recently matched
+	// by the optimizer.
+	lastMatched opt.RuleName
+
+	// lastApplied records the id of the expression that marks the portion of the
+	// tree affected by the most recent rule application. All expressions in the
+	// same memo group that are < lastApplied.Expr will assigned an infinite cost
+	// by the forcingCoster. Therefore, only expressions >= lastApplied.Expr can
+	// be in the output expression tree.
+	lastApplied memo.ExprID
+}
+
+// newForcingOptimizer creates a forcing optimizer that stops applying any rules
+// after <steps> rules are matched.
+func newForcingOptimizer(tester *OptTester, steps int) (*forcingOptimizer, error) {
+	fo := &forcingOptimizer{
+		o:           xform.NewOptimizer(&tester.evalCtx),
+		remaining:   steps,
+		lastMatched: opt.InvalidRuleName,
+		lastApplied: memo.InvalidExprID,
+	}
+
+	fo.o.NotifyOnMatchedRule(func(ruleName opt.RuleName) bool {
+		if fo.remaining == 0 {
+			return false
+		}
+		fo.remaining--
+		fo.lastMatched = ruleName
+		return true
+	})
+
+	// Hook the AppliedRule notification in order to track the portion of the
+	// expression tree affected by each transformation rule.
+	fo.lastApplied = memo.InvalidExprID
+	fo.o.NotifyOnAppliedRule(func(ruleName opt.RuleName, group memo.GroupID, added int) {
+		if added > 0 {
+			// This was an exploration rule that added one or more expressions to
+			// an existing group. Record the id of the first of those expressions.
+			// Previous expressions will be suppressed.
+			ord := memo.ExprOrdinal(fo.o.Memo().ExprCount(group) - added)
+			fo.lastApplied = memo.ExprID{Group: group, Expr: ord}
+		} else {
+			// This was a normalization that created a new memo group, or it was
+			// an exploration rule that didn't add any expressions to the group.
+			// Either way, none of the expressions in the group need to be
+			// suppressed.
+			fo.lastApplied = memo.MakeNormExprID(group)
+		}
+	})
+
+	var err error
+	fo.root, fo.required, err = tester.buildExpr(fo.o.Factory())
+	if err != nil {
+		return nil, err
+	}
+	return fo, nil
+}
+
+func (fo *forcingOptimizer) optimize() memo.ExprView {
+	return fo.o.Optimize(fo.root, fo.required)
+}
+
+// restrictToExprs sets up the optimizer to restrict the result to only those
+// containing one of the given expressions (all in the same group).
+//
+// mem is the resulting Memo obtained from another instance of forcingOptimizer, with
+// the same configuration.
+//
+// exprs is a set of ExprOrdinals (in the given group).
+func (fo *forcingOptimizer) restrictToExprs(
+	mem *memo.Memo, group memo.GroupID, exprs util.FastIntSet,
+) {
+	coster := newForcingCoster(fo.o.Coster())
+
+	restrictToGroup(coster, mem, fo.root, group)
+
+	for e := 0; e < mem.ExprCount(group); e++ {
+		if !exprs.Contains(e) {
+			coster.SuppressExpr(memo.ExprID{Group: group, Expr: memo.ExprOrdinal(e)})
+		}
+	}
+
+	fo.o.SetCoster(coster)
+}
+
+// restrictToGroup walks the memo and adds expressions which need to be
+// suppressed to the forcingCoster so that the optimization result must contain
+// an expression in the given target group.
+//
+// restrictToGroup does this by recursively traversing the memo, starting at the
+// root group. If a group expression is not an ancestor of the target group,
+// then it is suppressed. If it is an ancestor, then restrictExprs recurses on
+// any child group that is an ancestor.
+//
+// Must be called before optimize().
+func restrictToGroup(coster *forcingCoster, mem *memo.Memo, group, target memo.GroupID) {
+	if group == target {
+		return
+	}
+
+	for e := 0; e < mem.ExprCount(group); e++ {
+		eid := memo.ExprID{Group: group, Expr: memo.ExprOrdinal(e)}
+		found := false
+		expr := mem.Expr(eid)
+		for g := 0; g < expr.ChildCount(); g++ {
+			child := expr.ChildGroup(mem, g)
+			if isGroupReachable(mem, child, target) {
+				restrictToGroup(coster, mem, child, target)
+				found = true
+			}
+		}
+
+		if !found {
+			coster.SuppressExpr(eid)
+		}
+	}
+}
+
+// isGroupReachable returns true if the target group can be "reached" from the
+// given group; in other words, if the given group is the target group or one of
+// its ancestor groups.
+func isGroupReachable(mem *memo.Memo, group, target memo.GroupID) bool {
+	if group == target {
+		return true
+	}
+
+	for e := 0; e < mem.ExprCount(group); e++ {
+		eid := memo.ExprID{Group: group, Expr: memo.ExprOrdinal(e)}
+		expr := mem.Expr(eid)
+		for g := 0; g < expr.ChildCount(); g++ {
+			if isGroupReachable(mem, expr.ChildGroup(mem, g), target) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// forcingCoster implements the xform.Coster interface so that it can suppress
+// expressions in the memo that can't be part of the output tree.
+type forcingCoster struct {
+	inner      xform.Coster
+	suppressed map[memo.ExprID]bool
+}
+
+func newForcingCoster(inner xform.Coster) *forcingCoster {
+	return &forcingCoster{inner: inner, suppressed: make(map[memo.ExprID]bool)}
+}
+
+func (fc *forcingCoster) SuppressExpr(eid memo.ExprID) {
+	fc.suppressed[eid] = true
+}
+
+// ComputeCost is part of the xform.Coster interface.
+func (fc *forcingCoster) ComputeCost(candidate *memo.BestExpr, logical *props.Logical) memo.Cost {
+	if fc.suppressed[candidate.Expr()] {
+		// Suppressed expressions get assigned MaxCost so that they never have
+		// the lowest cost.
+		return memo.MaxCost
+	}
+	return fc.inner.ComputeCost(candidate, logical)
+}

--- a/pkg/sql/opt/testutils/opt_steps.go
+++ b/pkg/sql/opt/testutils/opt_steps.go
@@ -17,8 +17,7 @@ package testutils
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
+	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 // optSteps implements the stepping algorithm used by the OptTester's OptSteps
@@ -59,23 +58,11 @@ import (
 type optSteps struct {
 	tester *OptTester
 
+	fo *forcingOptimizer
+
 	// steps is the maximum number of rules that can be applied by the optimizer
 	// during the current iteration.
 	steps int
-
-	// remaining is the number of "unused" steps remaining in this iteration.
-	remaining int
-
-	// lastMatched records the name of the rule that was most recently matched
-	// by the optimizer.
-	lastMatched opt.RuleName
-
-	// lastApplied records the id of the expression that marks the portion of the
-	// tree affected by the most recent rule application. All expressions in the
-	// same memo group that are < lastApplied.Expr will assigned an infinite cost
-	// by the forcingCoster. Therefore, only expressions >= lastApplied.Expr can
-	// be in the output expression tree.
-	lastApplied memo.ExprID
 
 	// ev is the expression tree produced by the most recent optSteps iteration.
 	ev memo.ExprView
@@ -102,7 +89,7 @@ func (os *optSteps) exprView() memo.ExprView {
 // lastRuleName returns the name of the rule that was most recently matched by
 // the optimizer.
 func (os *optSteps) lastRuleName() opt.RuleName {
-	return os.lastMatched
+	return os.fo.lastMatched
 }
 
 // isBetter returns true if exprView is lower cost than the expression tree
@@ -117,7 +104,7 @@ func (os *optSteps) done() bool {
 	// remaining starts out equal to steps, and is decremented each time a rule
 	// is applied. If it never reaches zero, then all possible rules were
 	// already applied, and optimization is complete.
-	return os.remaining != 0
+	return os.fo != nil && os.fo.remaining != 0
 }
 
 // next triggers the next iteration of optSteps. If there is no error, then
@@ -128,33 +115,13 @@ func (os *optSteps) next() error {
 		panic("iteration already complete")
 	}
 
-	// Create optimizer that will run for a fixed number of steps.
-	o := os.createOptimizer(os.steps)
-	root, required, err := os.tester.buildExpr(o.Factory())
+	fo, err := newForcingOptimizer(os.tester, os.steps)
 	if err != nil {
 		return err
 	}
 
-	// Hook the AppliedRule notification in order to track the portion of the
-	// expression tree affected by each transformation rule.
-	os.lastApplied = memo.InvalidExprID
-	o.NotifyOnAppliedRule(func(ruleName opt.RuleName, group memo.GroupID, added int) {
-		if added > 0 {
-			// This was an exploration rule that added one or more expressions to
-			// an existing group. Record the id of the first of those expressions.
-			// Previous expressions will be suppressed.
-			ord := memo.ExprOrdinal(o.Memo().ExprCount(group) - added)
-			os.lastApplied = memo.ExprID{Group: group, Expr: ord}
-		} else {
-			// This was a normalization that created a new memo group, or it was
-			// an exploration rule that didn't add any expressions to the group.
-			// Either way, none of the expressions in the group need to be
-			// suppressed.
-			os.lastApplied = memo.MakeNormExprID(group)
-		}
-	})
-
-	os.ev = o.Optimize(root, required)
+	os.fo = fo
+	os.ev = fo.optimize()
 	text := os.ev.String()
 
 	// If the expression text changes, then it must have gotten better.
@@ -164,121 +131,17 @@ func (os *optSteps) next() error {
 	} else if !os.done() {
 		// The expression is not better, so suppress the lowest cost expressions
 		// so that the changed portions of the tree will be part of the output.
-		o2 := os.createOptimizer(os.steps)
-		root, required, err := os.tester.buildExpr(o2.Factory())
+		fo2, err := newForcingOptimizer(os.tester, os.steps)
 		if err != nil {
 			return err
 		}
 
-		// Set up the coster that will assign infinite costs to the expressions
-		// that need to be suppressed.
-		coster := newForcingCoster(o2.Coster())
-		os.suppressExprs(coster, o.Memo(), root)
-
-		o2.SetCoster(coster)
-		os.ev = o2.Optimize(root, required)
+		var exprs util.FastIntSet
+		exprs.AddRange(int(fo.lastApplied.Expr), fo.o.Memo().ExprCount(fo.lastApplied.Group)-1)
+		fo2.restrictToExprs(fo.o.Memo(), fo.lastApplied.Group, exprs)
+		os.ev = fo2.optimize()
 	}
 
 	os.steps++
 	return nil
-}
-
-func (os *optSteps) createOptimizer(steps int) *xform.Optimizer {
-	o := xform.NewOptimizer(&os.tester.evalCtx)
-
-	// Override NotifyOnMatchedRule to stop optimizing after "steps" rule matches.
-	os.remaining = steps
-	o.NotifyOnMatchedRule(func(ruleName opt.RuleName) bool {
-		if os.remaining == 0 {
-			return false
-		}
-		os.remaining--
-		os.lastMatched = ruleName
-		return true
-	})
-
-	return o
-}
-
-// suppressExprs walks the tree and adds expressions which need to be suppressed
-// to the forcingCoster. The expressions which need to suppressed are:
-//   1. Expressions in the same group as the lastApplied expression, but with
-//      a lower ordinal position in the group.
-//   2. Expressions in ancestor groups of the lastApplied expression that are
-//      not themselves ancestors of the lastApplied group.
-//
-// suppressExprs does this by recursively traversing the memo, starting at the
-// root group. If a group expression is not an ancestor of the last applied
-// group, then it is suppressed. If it is an ancestor, then suppressExprs
-// recurses on any child group that is an ancestor.
-func (os *optSteps) suppressExprs(coster *forcingCoster, mem *memo.Memo, group memo.GroupID) {
-	for e := 0; e < mem.ExprCount(group); e++ {
-		eid := memo.ExprID{Group: group, Expr: memo.ExprOrdinal(e)}
-		if eid.Group == os.lastApplied.Group {
-			if eid.Expr < os.lastApplied.Expr {
-				coster.SuppressExpr(eid)
-			}
-			continue
-		}
-
-		found := false
-		expr := mem.Expr(eid)
-		for g := 0; g < expr.ChildCount(); g++ {
-			child := expr.ChildGroup(mem, g)
-			if os.findLastApplied(mem, child) {
-				os.suppressExprs(coster, mem, child)
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			coster.SuppressExpr(eid)
-		}
-	}
-}
-
-// findLastApplied returns true if the given group is the last applied group or
-// one of its ancestor groups.
-func (os *optSteps) findLastApplied(mem *memo.Memo, group memo.GroupID) bool {
-	if group == os.lastApplied.Group {
-		return true
-	}
-
-	for e := 0; e < mem.ExprCount(group); e++ {
-		eid := memo.ExprID{Group: group, Expr: memo.ExprOrdinal(e)}
-		expr := mem.Expr(eid)
-		for g := 0; g < expr.ChildCount(); g++ {
-			if os.findLastApplied(mem, expr.ChildGroup(mem, g)) {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-// forcingCoster implements the xform.Coster interface so that it can suppress
-// expressions in the memo that can't be part of the output tree.
-type forcingCoster struct {
-	inner      xform.Coster
-	suppressed map[memo.ExprID]bool
-}
-
-func newForcingCoster(inner xform.Coster) *forcingCoster {
-	return &forcingCoster{inner: inner, suppressed: make(map[memo.ExprID]bool)}
-}
-
-func (fc *forcingCoster) SuppressExpr(eid memo.ExprID) {
-	fc.suppressed[eid] = true
-}
-
-// ComputeCost is part of the xform.Coster interface.
-func (fc *forcingCoster) ComputeCost(candidate *memo.BestExpr, logical *props.Logical) memo.Cost {
-	if fc.suppressed[candidate.Expr()] {
-		// Suppressed expressions get assigned MaxCost so that they never have
-		// the lowest cost.
-		return memo.MaxCost
-	}
-	return fc.inner.ComputeCost(candidate, logical)
 }


### PR DESCRIPTION
Extracting the lower level logic around setting up the optimizer for
`optsteps` into a new struct. The same low-level functionality will be
used to implement a new command focused around exploration transforms.

We also fix an edge case in `suppressExprs` (now `restrictToGroup`) -
when an expression has multiple children from which the target group
is reachable, we were only recursing on the first one.

Release note: None