### PR TITLE
roachpb: replace `gogoproto.onlyone` with `oneof` in BatchRequest/BatchResponse

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -534,8 +534,9 @@ func checkInProgressBackupRestore(
 	params := base.TestClusterArgs{}
 	params.ServerArgs.Knobs.Store = &storage.StoreTestingKnobs{
 		TestingResponseFilter: func(ba roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
-			for _, res := range br.Responses {
-				if res.Export != nil || res.Import != nil {
+			for _, ru := range br.Responses {
+				switch ru.GetInner().(type) {
+				case *roachpb.ExportResponse, *roachpb.ImportResponse:
 					<-allowResponse
 				}
 			}

--- a/pkg/kv/transport_race.go
+++ b/pkg/kv/transport_race.go
@@ -19,7 +19,7 @@ package kv
 
 import (
 	"context"
-	"encoding/gob"
+	"encoding/json"
 	"io/ioutil"
 	"math/rand"
 	"sync/atomic"
@@ -74,7 +74,7 @@ func GRPCTransportFactory(
 				// are evicted in FIFO order.
 				const size = 1000
 				bas := make([]*roachpb.BatchRequest, size)
-				encoder := gob.NewEncoder(ioutil.Discard)
+				encoder := json.NewEncoder(ioutil.Discard)
 				for {
 					iters++
 					start := timeutil.Now()

--- a/pkg/kv/truncate_test.go
+++ b/pkg/kv/truncate_test.go
@@ -148,7 +148,7 @@ func TestTruncate(t *testing.T) {
 
 		original := roachpb.BatchRequest{Requests: make([]roachpb.RequestUnion, len(goldenOriginal.Requests))}
 		for i, request := range goldenOriginal.Requests {
-			original.Requests[i].SetValue(request.GetInner().ShallowCopy())
+			original.Requests[i].MustSetInner(request.GetInner().ShallowCopy())
 		}
 
 		desc := &roachpb.RangeDescriptor{

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -446,22 +446,12 @@ func (*NoopResponse) Verify(_ Request) error {
 	return nil
 }
 
-// GetInner returns the Request contained in the union.
-func (ru RequestUnion) GetInner() Request {
-	return ru.GetValue().(Request)
-}
-
-// GetInner returns the Response contained in the union.
-func (ru ResponseUnion) GetInner() Response {
-	return ru.GetValue().(Response)
-}
-
 // MustSetInner sets the Request contained in the union. It panics if the
 // request is not recognized by the union type. The RequestUnion is reset
 // before being repopulated.
 func (ru *RequestUnion) MustSetInner(args Request) {
 	ru.Reset()
-	if !ru.SetValue(args) {
+	if !ru.SetInner(args) {
 		panic(fmt.Sprintf("%T excludes %T", ru, args))
 	}
 }
@@ -471,7 +461,7 @@ func (ru *RequestUnion) MustSetInner(args Request) {
 // before being repopulated.
 func (ru *ResponseUnion) MustSetInner(reply Response) {
 	ru.Reset()
-	if !ru.SetValue(reply) {
+	if !ru.SetInner(reply) {
 		panic(fmt.Sprintf("%T excludes %T", ru, reply))
 	}
 }

--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -1908,46 +1908,48 @@ func (*GetSnapshotForMergeResponse) Descriptor() ([]byte, []int) { return fileDe
 // Be cautious about deprecating fields as doing so can lead to inconsistencies
 // between replicas.
 type RequestUnion struct {
-	Get                 *GetRequest                 `protobuf:"bytes,1,opt,name=get" json:"get,omitempty"`
-	Put                 *PutRequest                 `protobuf:"bytes,2,opt,name=put" json:"put,omitempty"`
-	ConditionalPut      *ConditionalPutRequest      `protobuf:"bytes,3,opt,name=conditional_put,json=conditionalPut" json:"conditional_put,omitempty"`
-	Increment           *IncrementRequest           `protobuf:"bytes,4,opt,name=increment" json:"increment,omitempty"`
-	Delete              *DeleteRequest              `protobuf:"bytes,5,opt,name=delete" json:"delete,omitempty"`
-	DeleteRange         *DeleteRangeRequest         `protobuf:"bytes,6,opt,name=delete_range,json=deleteRange" json:"delete_range,omitempty"`
-	ClearRange          *ClearRangeRequest          `protobuf:"bytes,38,opt,name=clear_range,json=clearRange" json:"clear_range,omitempty"`
-	Scan                *ScanRequest                `protobuf:"bytes,7,opt,name=scan" json:"scan,omitempty"`
-	BeginTransaction    *BeginTransactionRequest    `protobuf:"bytes,8,opt,name=begin_transaction,json=beginTransaction" json:"begin_transaction,omitempty"`
-	EndTransaction      *EndTransactionRequest      `protobuf:"bytes,9,opt,name=end_transaction,json=endTransaction" json:"end_transaction,omitempty"`
-	AdminSplit          *AdminSplitRequest          `protobuf:"bytes,10,opt,name=admin_split,json=adminSplit" json:"admin_split,omitempty"`
-	AdminMerge          *AdminMergeRequest          `protobuf:"bytes,11,opt,name=admin_merge,json=adminMerge" json:"admin_merge,omitempty"`
-	AdminTransferLease  *AdminTransferLeaseRequest  `protobuf:"bytes,29,opt,name=admin_transfer_lease,json=adminTransferLease" json:"admin_transfer_lease,omitempty"`
-	AdminChangeReplicas *AdminChangeReplicasRequest `protobuf:"bytes,35,opt,name=admin_change_replicas,json=adminChangeReplicas" json:"admin_change_replicas,omitempty"`
-	HeartbeatTxn        *HeartbeatTxnRequest        `protobuf:"bytes,12,opt,name=heartbeat_txn,json=heartbeatTxn" json:"heartbeat_txn,omitempty"`
-	Gc                  *GCRequest                  `protobuf:"bytes,13,opt,name=gc" json:"gc,omitempty"`
-	PushTxn             *PushTxnRequest             `protobuf:"bytes,14,opt,name=push_txn,json=pushTxn" json:"push_txn,omitempty"`
-	ResolveIntent       *ResolveIntentRequest       `protobuf:"bytes,16,opt,name=resolve_intent,json=resolveIntent" json:"resolve_intent,omitempty"`
-	ResolveIntentRange  *ResolveIntentRangeRequest  `protobuf:"bytes,17,opt,name=resolve_intent_range,json=resolveIntentRange" json:"resolve_intent_range,omitempty"`
-	Merge               *MergeRequest               `protobuf:"bytes,18,opt,name=merge" json:"merge,omitempty"`
-	TruncateLog         *TruncateLogRequest         `protobuf:"bytes,19,opt,name=truncate_log,json=truncateLog" json:"truncate_log,omitempty"`
-	RequestLease        *RequestLeaseRequest        `protobuf:"bytes,20,opt,name=request_lease,json=requestLease" json:"request_lease,omitempty"`
-	ReverseScan         *ReverseScanRequest         `protobuf:"bytes,21,opt,name=reverse_scan,json=reverseScan" json:"reverse_scan,omitempty"`
-	ComputeChecksum     *ComputeChecksumRequest     `protobuf:"bytes,22,opt,name=compute_checksum,json=computeChecksum" json:"compute_checksum,omitempty"`
-	CheckConsistency    *CheckConsistencyRequest    `protobuf:"bytes,24,opt,name=check_consistency,json=checkConsistency" json:"check_consistency,omitempty"`
-	Noop                *NoopRequest                `protobuf:"bytes,25,opt,name=noop" json:"noop,omitempty"`
-	InitPut             *InitPutRequest             `protobuf:"bytes,26,opt,name=init_put,json=initPut" json:"init_put,omitempty"`
-	TransferLease       *TransferLeaseRequest       `protobuf:"bytes,28,opt,name=transfer_lease,json=transferLease" json:"transfer_lease,omitempty"`
-	LeaseInfo           *LeaseInfoRequest           `protobuf:"bytes,30,opt,name=lease_info,json=leaseInfo" json:"lease_info,omitempty"`
-	WriteBatch          *WriteBatchRequest          `protobuf:"bytes,31,opt,name=write_batch,json=writeBatch" json:"write_batch,omitempty"`
-	Export              *ExportRequest              `protobuf:"bytes,32,opt,name=export" json:"export,omitempty"`
-	Import              *ImportRequest              `protobuf:"bytes,34,opt,name=import" json:"import,omitempty"`
-	QueryTxn            *QueryTxnRequest            `protobuf:"bytes,33,opt,name=query_txn,json=queryTxn" json:"query_txn,omitempty"`
-	QueryIntent         *QueryIntentRequest         `protobuf:"bytes,42,opt,name=query_intent,json=queryIntent" json:"query_intent,omitempty"`
-	AdminScatter        *AdminScatterRequest        `protobuf:"bytes,36,opt,name=admin_scatter,json=adminScatter" json:"admin_scatter,omitempty"`
-	AddSstable          *AddSSTableRequest          `protobuf:"bytes,37,opt,name=add_sstable,json=addSstable" json:"add_sstable,omitempty"`
-	RecomputeStats      *RecomputeStatsRequest      `protobuf:"bytes,39,opt,name=recompute_stats,json=recomputeStats" json:"recompute_stats,omitempty"`
-	Refresh             *RefreshRequest             `protobuf:"bytes,40,opt,name=refresh" json:"refresh,omitempty"`
-	RefreshRange        *RefreshRangeRequest        `protobuf:"bytes,41,opt,name=refresh_range,json=refreshRange" json:"refresh_range,omitempty"`
-	GetSnapshotForMerge *GetSnapshotForMergeRequest `protobuf:"bytes,43,opt,name=get_snapshot_for_merge,json=getSnapshotForMerge" json:"get_snapshot_for_merge,omitempty"`
+	// Types that are valid to be assigned to Value:
+	//	*RequestUnion_Get
+	//	*RequestUnion_Put
+	//	*RequestUnion_ConditionalPut
+	//	*RequestUnion_Increment
+	//	*RequestUnion_Delete
+	//	*RequestUnion_DeleteRange
+	//	*RequestUnion_ClearRange
+	//	*RequestUnion_Scan
+	//	*RequestUnion_BeginTransaction
+	//	*RequestUnion_EndTransaction
+	//	*RequestUnion_AdminSplit
+	//	*RequestUnion_AdminMerge
+	//	*RequestUnion_AdminTransferLease
+	//	*RequestUnion_AdminChangeReplicas
+	//	*RequestUnion_HeartbeatTxn
+	//	*RequestUnion_Gc
+	//	*RequestUnion_PushTxn
+	//	*RequestUnion_ResolveIntent
+	//	*RequestUnion_ResolveIntentRange
+	//	*RequestUnion_Merge
+	//	*RequestUnion_TruncateLog
+	//	*RequestUnion_RequestLease
+	//	*RequestUnion_ReverseScan
+	//	*RequestUnion_ComputeChecksum
+	//	*RequestUnion_CheckConsistency
+	//	*RequestUnion_Noop
+	//	*RequestUnion_InitPut
+	//	*RequestUnion_TransferLease
+	//	*RequestUnion_LeaseInfo
+	//	*RequestUnion_WriteBatch
+	//	*RequestUnion_Export
+	//	*RequestUnion_Import
+	//	*RequestUnion_QueryTxn
+	//	*RequestUnion_QueryIntent
+	//	*RequestUnion_AdminScatter
+	//	*RequestUnion_AddSstable
+	//	*RequestUnion_RecomputeStats
+	//	*RequestUnion_Refresh
+	//	*RequestUnion_RefreshRange
+	//	*RequestUnion_GetSnapshotForMerge
+	Value isRequestUnion_Value `protobuf_oneof:"value"`
 }
 
 func (m *RequestUnion) Reset()                    { *m = RequestUnion{} }
@@ -1955,54 +1957,2528 @@ func (m *RequestUnion) String() string            { return proto.CompactTextStri
 func (*RequestUnion) ProtoMessage()               {}
 func (*RequestUnion) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{85} }
 
+type isRequestUnion_Value interface {
+	isRequestUnion_Value()
+	MarshalTo([]byte) (int, error)
+	Size() int
+}
+
+type RequestUnion_Get struct {
+	Get *GetRequest `protobuf:"bytes,1,opt,name=get,oneof"`
+}
+type RequestUnion_Put struct {
+	Put *PutRequest `protobuf:"bytes,2,opt,name=put,oneof"`
+}
+type RequestUnion_ConditionalPut struct {
+	ConditionalPut *ConditionalPutRequest `protobuf:"bytes,3,opt,name=conditional_put,json=conditionalPut,oneof"`
+}
+type RequestUnion_Increment struct {
+	Increment *IncrementRequest `protobuf:"bytes,4,opt,name=increment,oneof"`
+}
+type RequestUnion_Delete struct {
+	Delete *DeleteRequest `protobuf:"bytes,5,opt,name=delete,oneof"`
+}
+type RequestUnion_DeleteRange struct {
+	DeleteRange *DeleteRangeRequest `protobuf:"bytes,6,opt,name=delete_range,json=deleteRange,oneof"`
+}
+type RequestUnion_ClearRange struct {
+	ClearRange *ClearRangeRequest `protobuf:"bytes,38,opt,name=clear_range,json=clearRange,oneof"`
+}
+type RequestUnion_Scan struct {
+	Scan *ScanRequest `protobuf:"bytes,7,opt,name=scan,oneof"`
+}
+type RequestUnion_BeginTransaction struct {
+	BeginTransaction *BeginTransactionRequest `protobuf:"bytes,8,opt,name=begin_transaction,json=beginTransaction,oneof"`
+}
+type RequestUnion_EndTransaction struct {
+	EndTransaction *EndTransactionRequest `protobuf:"bytes,9,opt,name=end_transaction,json=endTransaction,oneof"`
+}
+type RequestUnion_AdminSplit struct {
+	AdminSplit *AdminSplitRequest `protobuf:"bytes,10,opt,name=admin_split,json=adminSplit,oneof"`
+}
+type RequestUnion_AdminMerge struct {
+	AdminMerge *AdminMergeRequest `protobuf:"bytes,11,opt,name=admin_merge,json=adminMerge,oneof"`
+}
+type RequestUnion_AdminTransferLease struct {
+	AdminTransferLease *AdminTransferLeaseRequest `protobuf:"bytes,29,opt,name=admin_transfer_lease,json=adminTransferLease,oneof"`
+}
+type RequestUnion_AdminChangeReplicas struct {
+	AdminChangeReplicas *AdminChangeReplicasRequest `protobuf:"bytes,35,opt,name=admin_change_replicas,json=adminChangeReplicas,oneof"`
+}
+type RequestUnion_HeartbeatTxn struct {
+	HeartbeatTxn *HeartbeatTxnRequest `protobuf:"bytes,12,opt,name=heartbeat_txn,json=heartbeatTxn,oneof"`
+}
+type RequestUnion_Gc struct {
+	Gc *GCRequest `protobuf:"bytes,13,opt,name=gc,oneof"`
+}
+type RequestUnion_PushTxn struct {
+	PushTxn *PushTxnRequest `protobuf:"bytes,14,opt,name=push_txn,json=pushTxn,oneof"`
+}
+type RequestUnion_ResolveIntent struct {
+	ResolveIntent *ResolveIntentRequest `protobuf:"bytes,16,opt,name=resolve_intent,json=resolveIntent,oneof"`
+}
+type RequestUnion_ResolveIntentRange struct {
+	ResolveIntentRange *ResolveIntentRangeRequest `protobuf:"bytes,17,opt,name=resolve_intent_range,json=resolveIntentRange,oneof"`
+}
+type RequestUnion_Merge struct {
+	Merge *MergeRequest `protobuf:"bytes,18,opt,name=merge,oneof"`
+}
+type RequestUnion_TruncateLog struct {
+	TruncateLog *TruncateLogRequest `protobuf:"bytes,19,opt,name=truncate_log,json=truncateLog,oneof"`
+}
+type RequestUnion_RequestLease struct {
+	RequestLease *RequestLeaseRequest `protobuf:"bytes,20,opt,name=request_lease,json=requestLease,oneof"`
+}
+type RequestUnion_ReverseScan struct {
+	ReverseScan *ReverseScanRequest `protobuf:"bytes,21,opt,name=reverse_scan,json=reverseScan,oneof"`
+}
+type RequestUnion_ComputeChecksum struct {
+	ComputeChecksum *ComputeChecksumRequest `protobuf:"bytes,22,opt,name=compute_checksum,json=computeChecksum,oneof"`
+}
+type RequestUnion_CheckConsistency struct {
+	CheckConsistency *CheckConsistencyRequest `protobuf:"bytes,24,opt,name=check_consistency,json=checkConsistency,oneof"`
+}
+type RequestUnion_Noop struct {
+	Noop *NoopRequest `protobuf:"bytes,25,opt,name=noop,oneof"`
+}
+type RequestUnion_InitPut struct {
+	InitPut *InitPutRequest `protobuf:"bytes,26,opt,name=init_put,json=initPut,oneof"`
+}
+type RequestUnion_TransferLease struct {
+	TransferLease *TransferLeaseRequest `protobuf:"bytes,28,opt,name=transfer_lease,json=transferLease,oneof"`
+}
+type RequestUnion_LeaseInfo struct {
+	LeaseInfo *LeaseInfoRequest `protobuf:"bytes,30,opt,name=lease_info,json=leaseInfo,oneof"`
+}
+type RequestUnion_WriteBatch struct {
+	WriteBatch *WriteBatchRequest `protobuf:"bytes,31,opt,name=write_batch,json=writeBatch,oneof"`
+}
+type RequestUnion_Export struct {
+	Export *ExportRequest `protobuf:"bytes,32,opt,name=export,oneof"`
+}
+type RequestUnion_Import struct {
+	Import *ImportRequest `protobuf:"bytes,34,opt,name=import,oneof"`
+}
+type RequestUnion_QueryTxn struct {
+	QueryTxn *QueryTxnRequest `protobuf:"bytes,33,opt,name=query_txn,json=queryTxn,oneof"`
+}
+type RequestUnion_QueryIntent struct {
+	QueryIntent *QueryIntentRequest `protobuf:"bytes,42,opt,name=query_intent,json=queryIntent,oneof"`
+}
+type RequestUnion_AdminScatter struct {
+	AdminScatter *AdminScatterRequest `protobuf:"bytes,36,opt,name=admin_scatter,json=adminScatter,oneof"`
+}
+type RequestUnion_AddSstable struct {
+	AddSstable *AddSSTableRequest `protobuf:"bytes,37,opt,name=add_sstable,json=addSstable,oneof"`
+}
+type RequestUnion_RecomputeStats struct {
+	RecomputeStats *RecomputeStatsRequest `protobuf:"bytes,39,opt,name=recompute_stats,json=recomputeStats,oneof"`
+}
+type RequestUnion_Refresh struct {
+	Refresh *RefreshRequest `protobuf:"bytes,40,opt,name=refresh,oneof"`
+}
+type RequestUnion_RefreshRange struct {
+	RefreshRange *RefreshRangeRequest `protobuf:"bytes,41,opt,name=refresh_range,json=refreshRange,oneof"`
+}
+type RequestUnion_GetSnapshotForMerge struct {
+	GetSnapshotForMerge *GetSnapshotForMergeRequest `protobuf:"bytes,43,opt,name=get_snapshot_for_merge,json=getSnapshotForMerge,oneof"`
+}
+
+func (*RequestUnion_Get) isRequestUnion_Value()                 {}
+func (*RequestUnion_Put) isRequestUnion_Value()                 {}
+func (*RequestUnion_ConditionalPut) isRequestUnion_Value()      {}
+func (*RequestUnion_Increment) isRequestUnion_Value()           {}
+func (*RequestUnion_Delete) isRequestUnion_Value()              {}
+func (*RequestUnion_DeleteRange) isRequestUnion_Value()         {}
+func (*RequestUnion_ClearRange) isRequestUnion_Value()          {}
+func (*RequestUnion_Scan) isRequestUnion_Value()                {}
+func (*RequestUnion_BeginTransaction) isRequestUnion_Value()    {}
+func (*RequestUnion_EndTransaction) isRequestUnion_Value()      {}
+func (*RequestUnion_AdminSplit) isRequestUnion_Value()          {}
+func (*RequestUnion_AdminMerge) isRequestUnion_Value()          {}
+func (*RequestUnion_AdminTransferLease) isRequestUnion_Value()  {}
+func (*RequestUnion_AdminChangeReplicas) isRequestUnion_Value() {}
+func (*RequestUnion_HeartbeatTxn) isRequestUnion_Value()        {}
+func (*RequestUnion_Gc) isRequestUnion_Value()                  {}
+func (*RequestUnion_PushTxn) isRequestUnion_Value()             {}
+func (*RequestUnion_ResolveIntent) isRequestUnion_Value()       {}
+func (*RequestUnion_ResolveIntentRange) isRequestUnion_Value()  {}
+func (*RequestUnion_Merge) isRequestUnion_Value()               {}
+func (*RequestUnion_TruncateLog) isRequestUnion_Value()         {}
+func (*RequestUnion_RequestLease) isRequestUnion_Value()        {}
+func (*RequestUnion_ReverseScan) isRequestUnion_Value()         {}
+func (*RequestUnion_ComputeChecksum) isRequestUnion_Value()     {}
+func (*RequestUnion_CheckConsistency) isRequestUnion_Value()    {}
+func (*RequestUnion_Noop) isRequestUnion_Value()                {}
+func (*RequestUnion_InitPut) isRequestUnion_Value()             {}
+func (*RequestUnion_TransferLease) isRequestUnion_Value()       {}
+func (*RequestUnion_LeaseInfo) isRequestUnion_Value()           {}
+func (*RequestUnion_WriteBatch) isRequestUnion_Value()          {}
+func (*RequestUnion_Export) isRequestUnion_Value()              {}
+func (*RequestUnion_Import) isRequestUnion_Value()              {}
+func (*RequestUnion_QueryTxn) isRequestUnion_Value()            {}
+func (*RequestUnion_QueryIntent) isRequestUnion_Value()         {}
+func (*RequestUnion_AdminScatter) isRequestUnion_Value()        {}
+func (*RequestUnion_AddSstable) isRequestUnion_Value()          {}
+func (*RequestUnion_RecomputeStats) isRequestUnion_Value()      {}
+func (*RequestUnion_Refresh) isRequestUnion_Value()             {}
+func (*RequestUnion_RefreshRange) isRequestUnion_Value()        {}
+func (*RequestUnion_GetSnapshotForMerge) isRequestUnion_Value() {}
+
+func (m *RequestUnion) GetValue() isRequestUnion_Value {
+	if m != nil {
+		return m.Value
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetGet() *GetRequest {
+	if x, ok := m.GetValue().(*RequestUnion_Get); ok {
+		return x.Get
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetPut() *PutRequest {
+	if x, ok := m.GetValue().(*RequestUnion_Put); ok {
+		return x.Put
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetConditionalPut() *ConditionalPutRequest {
+	if x, ok := m.GetValue().(*RequestUnion_ConditionalPut); ok {
+		return x.ConditionalPut
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetIncrement() *IncrementRequest {
+	if x, ok := m.GetValue().(*RequestUnion_Increment); ok {
+		return x.Increment
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetDelete() *DeleteRequest {
+	if x, ok := m.GetValue().(*RequestUnion_Delete); ok {
+		return x.Delete
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetDeleteRange() *DeleteRangeRequest {
+	if x, ok := m.GetValue().(*RequestUnion_DeleteRange); ok {
+		return x.DeleteRange
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetClearRange() *ClearRangeRequest {
+	if x, ok := m.GetValue().(*RequestUnion_ClearRange); ok {
+		return x.ClearRange
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetScan() *ScanRequest {
+	if x, ok := m.GetValue().(*RequestUnion_Scan); ok {
+		return x.Scan
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetBeginTransaction() *BeginTransactionRequest {
+	if x, ok := m.GetValue().(*RequestUnion_BeginTransaction); ok {
+		return x.BeginTransaction
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetEndTransaction() *EndTransactionRequest {
+	if x, ok := m.GetValue().(*RequestUnion_EndTransaction); ok {
+		return x.EndTransaction
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetAdminSplit() *AdminSplitRequest {
+	if x, ok := m.GetValue().(*RequestUnion_AdminSplit); ok {
+		return x.AdminSplit
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetAdminMerge() *AdminMergeRequest {
+	if x, ok := m.GetValue().(*RequestUnion_AdminMerge); ok {
+		return x.AdminMerge
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetAdminTransferLease() *AdminTransferLeaseRequest {
+	if x, ok := m.GetValue().(*RequestUnion_AdminTransferLease); ok {
+		return x.AdminTransferLease
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetAdminChangeReplicas() *AdminChangeReplicasRequest {
+	if x, ok := m.GetValue().(*RequestUnion_AdminChangeReplicas); ok {
+		return x.AdminChangeReplicas
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetHeartbeatTxn() *HeartbeatTxnRequest {
+	if x, ok := m.GetValue().(*RequestUnion_HeartbeatTxn); ok {
+		return x.HeartbeatTxn
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetGc() *GCRequest {
+	if x, ok := m.GetValue().(*RequestUnion_Gc); ok {
+		return x.Gc
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetPushTxn() *PushTxnRequest {
+	if x, ok := m.GetValue().(*RequestUnion_PushTxn); ok {
+		return x.PushTxn
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetResolveIntent() *ResolveIntentRequest {
+	if x, ok := m.GetValue().(*RequestUnion_ResolveIntent); ok {
+		return x.ResolveIntent
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetResolveIntentRange() *ResolveIntentRangeRequest {
+	if x, ok := m.GetValue().(*RequestUnion_ResolveIntentRange); ok {
+		return x.ResolveIntentRange
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetMerge() *MergeRequest {
+	if x, ok := m.GetValue().(*RequestUnion_Merge); ok {
+		return x.Merge
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetTruncateLog() *TruncateLogRequest {
+	if x, ok := m.GetValue().(*RequestUnion_TruncateLog); ok {
+		return x.TruncateLog
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetRequestLease() *RequestLeaseRequest {
+	if x, ok := m.GetValue().(*RequestUnion_RequestLease); ok {
+		return x.RequestLease
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetReverseScan() *ReverseScanRequest {
+	if x, ok := m.GetValue().(*RequestUnion_ReverseScan); ok {
+		return x.ReverseScan
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetComputeChecksum() *ComputeChecksumRequest {
+	if x, ok := m.GetValue().(*RequestUnion_ComputeChecksum); ok {
+		return x.ComputeChecksum
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetCheckConsistency() *CheckConsistencyRequest {
+	if x, ok := m.GetValue().(*RequestUnion_CheckConsistency); ok {
+		return x.CheckConsistency
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetNoop() *NoopRequest {
+	if x, ok := m.GetValue().(*RequestUnion_Noop); ok {
+		return x.Noop
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetInitPut() *InitPutRequest {
+	if x, ok := m.GetValue().(*RequestUnion_InitPut); ok {
+		return x.InitPut
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetTransferLease() *TransferLeaseRequest {
+	if x, ok := m.GetValue().(*RequestUnion_TransferLease); ok {
+		return x.TransferLease
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetLeaseInfo() *LeaseInfoRequest {
+	if x, ok := m.GetValue().(*RequestUnion_LeaseInfo); ok {
+		return x.LeaseInfo
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetWriteBatch() *WriteBatchRequest {
+	if x, ok := m.GetValue().(*RequestUnion_WriteBatch); ok {
+		return x.WriteBatch
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetExport() *ExportRequest {
+	if x, ok := m.GetValue().(*RequestUnion_Export); ok {
+		return x.Export
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetImport() *ImportRequest {
+	if x, ok := m.GetValue().(*RequestUnion_Import); ok {
+		return x.Import
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetQueryTxn() *QueryTxnRequest {
+	if x, ok := m.GetValue().(*RequestUnion_QueryTxn); ok {
+		return x.QueryTxn
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetQueryIntent() *QueryIntentRequest {
+	if x, ok := m.GetValue().(*RequestUnion_QueryIntent); ok {
+		return x.QueryIntent
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetAdminScatter() *AdminScatterRequest {
+	if x, ok := m.GetValue().(*RequestUnion_AdminScatter); ok {
+		return x.AdminScatter
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetAddSstable() *AddSSTableRequest {
+	if x, ok := m.GetValue().(*RequestUnion_AddSstable); ok {
+		return x.AddSstable
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetRecomputeStats() *RecomputeStatsRequest {
+	if x, ok := m.GetValue().(*RequestUnion_RecomputeStats); ok {
+		return x.RecomputeStats
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetRefresh() *RefreshRequest {
+	if x, ok := m.GetValue().(*RequestUnion_Refresh); ok {
+		return x.Refresh
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetRefreshRange() *RefreshRangeRequest {
+	if x, ok := m.GetValue().(*RequestUnion_RefreshRange); ok {
+		return x.RefreshRange
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetGetSnapshotForMerge() *GetSnapshotForMergeRequest {
+	if x, ok := m.GetValue().(*RequestUnion_GetSnapshotForMerge); ok {
+		return x.GetSnapshotForMerge
+	}
+	return nil
+}
+
+// XXX_OneofFuncs is for the internal use of the proto package.
+func (*RequestUnion) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
+	return _RequestUnion_OneofMarshaler, _RequestUnion_OneofUnmarshaler, _RequestUnion_OneofSizer, []interface{}{
+		(*RequestUnion_Get)(nil),
+		(*RequestUnion_Put)(nil),
+		(*RequestUnion_ConditionalPut)(nil),
+		(*RequestUnion_Increment)(nil),
+		(*RequestUnion_Delete)(nil),
+		(*RequestUnion_DeleteRange)(nil),
+		(*RequestUnion_ClearRange)(nil),
+		(*RequestUnion_Scan)(nil),
+		(*RequestUnion_BeginTransaction)(nil),
+		(*RequestUnion_EndTransaction)(nil),
+		(*RequestUnion_AdminSplit)(nil),
+		(*RequestUnion_AdminMerge)(nil),
+		(*RequestUnion_AdminTransferLease)(nil),
+		(*RequestUnion_AdminChangeReplicas)(nil),
+		(*RequestUnion_HeartbeatTxn)(nil),
+		(*RequestUnion_Gc)(nil),
+		(*RequestUnion_PushTxn)(nil),
+		(*RequestUnion_ResolveIntent)(nil),
+		(*RequestUnion_ResolveIntentRange)(nil),
+		(*RequestUnion_Merge)(nil),
+		(*RequestUnion_TruncateLog)(nil),
+		(*RequestUnion_RequestLease)(nil),
+		(*RequestUnion_ReverseScan)(nil),
+		(*RequestUnion_ComputeChecksum)(nil),
+		(*RequestUnion_CheckConsistency)(nil),
+		(*RequestUnion_Noop)(nil),
+		(*RequestUnion_InitPut)(nil),
+		(*RequestUnion_TransferLease)(nil),
+		(*RequestUnion_LeaseInfo)(nil),
+		(*RequestUnion_WriteBatch)(nil),
+		(*RequestUnion_Export)(nil),
+		(*RequestUnion_Import)(nil),
+		(*RequestUnion_QueryTxn)(nil),
+		(*RequestUnion_QueryIntent)(nil),
+		(*RequestUnion_AdminScatter)(nil),
+		(*RequestUnion_AddSstable)(nil),
+		(*RequestUnion_RecomputeStats)(nil),
+		(*RequestUnion_Refresh)(nil),
+		(*RequestUnion_RefreshRange)(nil),
+		(*RequestUnion_GetSnapshotForMerge)(nil),
+	}
+}
+
+func _RequestUnion_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
+	m := msg.(*RequestUnion)
+	// value
+	switch x := m.Value.(type) {
+	case *RequestUnion_Get:
+		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Get); err != nil {
+			return err
+		}
+	case *RequestUnion_Put:
+		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Put); err != nil {
+			return err
+		}
+	case *RequestUnion_ConditionalPut:
+		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ConditionalPut); err != nil {
+			return err
+		}
+	case *RequestUnion_Increment:
+		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Increment); err != nil {
+			return err
+		}
+	case *RequestUnion_Delete:
+		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Delete); err != nil {
+			return err
+		}
+	case *RequestUnion_DeleteRange:
+		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.DeleteRange); err != nil {
+			return err
+		}
+	case *RequestUnion_ClearRange:
+		_ = b.EncodeVarint(38<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ClearRange); err != nil {
+			return err
+		}
+	case *RequestUnion_Scan:
+		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Scan); err != nil {
+			return err
+		}
+	case *RequestUnion_BeginTransaction:
+		_ = b.EncodeVarint(8<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.BeginTransaction); err != nil {
+			return err
+		}
+	case *RequestUnion_EndTransaction:
+		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.EndTransaction); err != nil {
+			return err
+		}
+	case *RequestUnion_AdminSplit:
+		_ = b.EncodeVarint(10<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.AdminSplit); err != nil {
+			return err
+		}
+	case *RequestUnion_AdminMerge:
+		_ = b.EncodeVarint(11<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.AdminMerge); err != nil {
+			return err
+		}
+	case *RequestUnion_AdminTransferLease:
+		_ = b.EncodeVarint(29<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.AdminTransferLease); err != nil {
+			return err
+		}
+	case *RequestUnion_AdminChangeReplicas:
+		_ = b.EncodeVarint(35<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.AdminChangeReplicas); err != nil {
+			return err
+		}
+	case *RequestUnion_HeartbeatTxn:
+		_ = b.EncodeVarint(12<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.HeartbeatTxn); err != nil {
+			return err
+		}
+	case *RequestUnion_Gc:
+		_ = b.EncodeVarint(13<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Gc); err != nil {
+			return err
+		}
+	case *RequestUnion_PushTxn:
+		_ = b.EncodeVarint(14<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.PushTxn); err != nil {
+			return err
+		}
+	case *RequestUnion_ResolveIntent:
+		_ = b.EncodeVarint(16<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ResolveIntent); err != nil {
+			return err
+		}
+	case *RequestUnion_ResolveIntentRange:
+		_ = b.EncodeVarint(17<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ResolveIntentRange); err != nil {
+			return err
+		}
+	case *RequestUnion_Merge:
+		_ = b.EncodeVarint(18<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Merge); err != nil {
+			return err
+		}
+	case *RequestUnion_TruncateLog:
+		_ = b.EncodeVarint(19<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.TruncateLog); err != nil {
+			return err
+		}
+	case *RequestUnion_RequestLease:
+		_ = b.EncodeVarint(20<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.RequestLease); err != nil {
+			return err
+		}
+	case *RequestUnion_ReverseScan:
+		_ = b.EncodeVarint(21<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ReverseScan); err != nil {
+			return err
+		}
+	case *RequestUnion_ComputeChecksum:
+		_ = b.EncodeVarint(22<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ComputeChecksum); err != nil {
+			return err
+		}
+	case *RequestUnion_CheckConsistency:
+		_ = b.EncodeVarint(24<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.CheckConsistency); err != nil {
+			return err
+		}
+	case *RequestUnion_Noop:
+		_ = b.EncodeVarint(25<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Noop); err != nil {
+			return err
+		}
+	case *RequestUnion_InitPut:
+		_ = b.EncodeVarint(26<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.InitPut); err != nil {
+			return err
+		}
+	case *RequestUnion_TransferLease:
+		_ = b.EncodeVarint(28<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.TransferLease); err != nil {
+			return err
+		}
+	case *RequestUnion_LeaseInfo:
+		_ = b.EncodeVarint(30<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.LeaseInfo); err != nil {
+			return err
+		}
+	case *RequestUnion_WriteBatch:
+		_ = b.EncodeVarint(31<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.WriteBatch); err != nil {
+			return err
+		}
+	case *RequestUnion_Export:
+		_ = b.EncodeVarint(32<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Export); err != nil {
+			return err
+		}
+	case *RequestUnion_Import:
+		_ = b.EncodeVarint(34<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Import); err != nil {
+			return err
+		}
+	case *RequestUnion_QueryTxn:
+		_ = b.EncodeVarint(33<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.QueryTxn); err != nil {
+			return err
+		}
+	case *RequestUnion_QueryIntent:
+		_ = b.EncodeVarint(42<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.QueryIntent); err != nil {
+			return err
+		}
+	case *RequestUnion_AdminScatter:
+		_ = b.EncodeVarint(36<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.AdminScatter); err != nil {
+			return err
+		}
+	case *RequestUnion_AddSstable:
+		_ = b.EncodeVarint(37<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.AddSstable); err != nil {
+			return err
+		}
+	case *RequestUnion_RecomputeStats:
+		_ = b.EncodeVarint(39<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.RecomputeStats); err != nil {
+			return err
+		}
+	case *RequestUnion_Refresh:
+		_ = b.EncodeVarint(40<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Refresh); err != nil {
+			return err
+		}
+	case *RequestUnion_RefreshRange:
+		_ = b.EncodeVarint(41<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.RefreshRange); err != nil {
+			return err
+		}
+	case *RequestUnion_GetSnapshotForMerge:
+		_ = b.EncodeVarint(43<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.GetSnapshotForMerge); err != nil {
+			return err
+		}
+	case nil:
+	default:
+		return fmt.Errorf("RequestUnion.Value has unexpected type %T", x)
+	}
+	return nil
+}
+
+func _RequestUnion_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
+	m := msg.(*RequestUnion)
+	switch tag {
+	case 1: // value.get
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(GetRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_Get{msg}
+		return true, err
+	case 2: // value.put
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(PutRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_Put{msg}
+		return true, err
+	case 3: // value.conditional_put
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ConditionalPutRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_ConditionalPut{msg}
+		return true, err
+	case 4: // value.increment
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(IncrementRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_Increment{msg}
+		return true, err
+	case 5: // value.delete
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(DeleteRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_Delete{msg}
+		return true, err
+	case 6: // value.delete_range
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(DeleteRangeRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_DeleteRange{msg}
+		return true, err
+	case 38: // value.clear_range
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ClearRangeRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_ClearRange{msg}
+		return true, err
+	case 7: // value.scan
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ScanRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_Scan{msg}
+		return true, err
+	case 8: // value.begin_transaction
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(BeginTransactionRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_BeginTransaction{msg}
+		return true, err
+	case 9: // value.end_transaction
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(EndTransactionRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_EndTransaction{msg}
+		return true, err
+	case 10: // value.admin_split
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(AdminSplitRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_AdminSplit{msg}
+		return true, err
+	case 11: // value.admin_merge
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(AdminMergeRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_AdminMerge{msg}
+		return true, err
+	case 29: // value.admin_transfer_lease
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(AdminTransferLeaseRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_AdminTransferLease{msg}
+		return true, err
+	case 35: // value.admin_change_replicas
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(AdminChangeReplicasRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_AdminChangeReplicas{msg}
+		return true, err
+	case 12: // value.heartbeat_txn
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(HeartbeatTxnRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_HeartbeatTxn{msg}
+		return true, err
+	case 13: // value.gc
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(GCRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_Gc{msg}
+		return true, err
+	case 14: // value.push_txn
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(PushTxnRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_PushTxn{msg}
+		return true, err
+	case 16: // value.resolve_intent
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ResolveIntentRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_ResolveIntent{msg}
+		return true, err
+	case 17: // value.resolve_intent_range
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ResolveIntentRangeRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_ResolveIntentRange{msg}
+		return true, err
+	case 18: // value.merge
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(MergeRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_Merge{msg}
+		return true, err
+	case 19: // value.truncate_log
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(TruncateLogRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_TruncateLog{msg}
+		return true, err
+	case 20: // value.request_lease
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(RequestLeaseRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_RequestLease{msg}
+		return true, err
+	case 21: // value.reverse_scan
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ReverseScanRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_ReverseScan{msg}
+		return true, err
+	case 22: // value.compute_checksum
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ComputeChecksumRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_ComputeChecksum{msg}
+		return true, err
+	case 24: // value.check_consistency
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(CheckConsistencyRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_CheckConsistency{msg}
+		return true, err
+	case 25: // value.noop
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(NoopRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_Noop{msg}
+		return true, err
+	case 26: // value.init_put
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(InitPutRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_InitPut{msg}
+		return true, err
+	case 28: // value.transfer_lease
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(TransferLeaseRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_TransferLease{msg}
+		return true, err
+	case 30: // value.lease_info
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(LeaseInfoRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_LeaseInfo{msg}
+		return true, err
+	case 31: // value.write_batch
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(WriteBatchRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_WriteBatch{msg}
+		return true, err
+	case 32: // value.export
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ExportRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_Export{msg}
+		return true, err
+	case 34: // value.import
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ImportRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_Import{msg}
+		return true, err
+	case 33: // value.query_txn
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(QueryTxnRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_QueryTxn{msg}
+		return true, err
+	case 42: // value.query_intent
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(QueryIntentRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_QueryIntent{msg}
+		return true, err
+	case 36: // value.admin_scatter
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(AdminScatterRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_AdminScatter{msg}
+		return true, err
+	case 37: // value.add_sstable
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(AddSSTableRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_AddSstable{msg}
+		return true, err
+	case 39: // value.recompute_stats
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(RecomputeStatsRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_RecomputeStats{msg}
+		return true, err
+	case 40: // value.refresh
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(RefreshRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_Refresh{msg}
+		return true, err
+	case 41: // value.refresh_range
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(RefreshRangeRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_RefreshRange{msg}
+		return true, err
+	case 43: // value.get_snapshot_for_merge
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(GetSnapshotForMergeRequest)
+		err := b.DecodeMessage(msg)
+		m.Value = &RequestUnion_GetSnapshotForMerge{msg}
+		return true, err
+	default:
+		return false, nil
+	}
+}
+
+func _RequestUnion_OneofSizer(msg proto.Message) (n int) {
+	m := msg.(*RequestUnion)
+	// value
+	switch x := m.Value.(type) {
+	case *RequestUnion_Get:
+		s := proto.Size(x.Get)
+		n += proto.SizeVarint(1<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_Put:
+		s := proto.Size(x.Put)
+		n += proto.SizeVarint(2<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_ConditionalPut:
+		s := proto.Size(x.ConditionalPut)
+		n += proto.SizeVarint(3<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_Increment:
+		s := proto.Size(x.Increment)
+		n += proto.SizeVarint(4<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_Delete:
+		s := proto.Size(x.Delete)
+		n += proto.SizeVarint(5<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_DeleteRange:
+		s := proto.Size(x.DeleteRange)
+		n += proto.SizeVarint(6<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_ClearRange:
+		s := proto.Size(x.ClearRange)
+		n += proto.SizeVarint(38<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_Scan:
+		s := proto.Size(x.Scan)
+		n += proto.SizeVarint(7<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_BeginTransaction:
+		s := proto.Size(x.BeginTransaction)
+		n += proto.SizeVarint(8<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_EndTransaction:
+		s := proto.Size(x.EndTransaction)
+		n += proto.SizeVarint(9<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_AdminSplit:
+		s := proto.Size(x.AdminSplit)
+		n += proto.SizeVarint(10<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_AdminMerge:
+		s := proto.Size(x.AdminMerge)
+		n += proto.SizeVarint(11<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_AdminTransferLease:
+		s := proto.Size(x.AdminTransferLease)
+		n += proto.SizeVarint(29<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_AdminChangeReplicas:
+		s := proto.Size(x.AdminChangeReplicas)
+		n += proto.SizeVarint(35<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_HeartbeatTxn:
+		s := proto.Size(x.HeartbeatTxn)
+		n += proto.SizeVarint(12<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_Gc:
+		s := proto.Size(x.Gc)
+		n += proto.SizeVarint(13<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_PushTxn:
+		s := proto.Size(x.PushTxn)
+		n += proto.SizeVarint(14<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_ResolveIntent:
+		s := proto.Size(x.ResolveIntent)
+		n += proto.SizeVarint(16<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_ResolveIntentRange:
+		s := proto.Size(x.ResolveIntentRange)
+		n += proto.SizeVarint(17<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_Merge:
+		s := proto.Size(x.Merge)
+		n += proto.SizeVarint(18<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_TruncateLog:
+		s := proto.Size(x.TruncateLog)
+		n += proto.SizeVarint(19<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_RequestLease:
+		s := proto.Size(x.RequestLease)
+		n += proto.SizeVarint(20<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_ReverseScan:
+		s := proto.Size(x.ReverseScan)
+		n += proto.SizeVarint(21<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_ComputeChecksum:
+		s := proto.Size(x.ComputeChecksum)
+		n += proto.SizeVarint(22<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_CheckConsistency:
+		s := proto.Size(x.CheckConsistency)
+		n += proto.SizeVarint(24<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_Noop:
+		s := proto.Size(x.Noop)
+		n += proto.SizeVarint(25<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_InitPut:
+		s := proto.Size(x.InitPut)
+		n += proto.SizeVarint(26<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_TransferLease:
+		s := proto.Size(x.TransferLease)
+		n += proto.SizeVarint(28<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_LeaseInfo:
+		s := proto.Size(x.LeaseInfo)
+		n += proto.SizeVarint(30<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_WriteBatch:
+		s := proto.Size(x.WriteBatch)
+		n += proto.SizeVarint(31<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_Export:
+		s := proto.Size(x.Export)
+		n += proto.SizeVarint(32<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_Import:
+		s := proto.Size(x.Import)
+		n += proto.SizeVarint(34<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_QueryTxn:
+		s := proto.Size(x.QueryTxn)
+		n += proto.SizeVarint(33<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_QueryIntent:
+		s := proto.Size(x.QueryIntent)
+		n += proto.SizeVarint(42<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_AdminScatter:
+		s := proto.Size(x.AdminScatter)
+		n += proto.SizeVarint(36<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_AddSstable:
+		s := proto.Size(x.AddSstable)
+		n += proto.SizeVarint(37<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_RecomputeStats:
+		s := proto.Size(x.RecomputeStats)
+		n += proto.SizeVarint(39<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_Refresh:
+		s := proto.Size(x.Refresh)
+		n += proto.SizeVarint(40<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_RefreshRange:
+		s := proto.Size(x.RefreshRange)
+		n += proto.SizeVarint(41<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *RequestUnion_GetSnapshotForMerge:
+		s := proto.Size(x.GetSnapshotForMerge)
+		n += proto.SizeVarint(43<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case nil:
+	default:
+		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
+	}
+	return n
+}
+
 // A ResponseUnion contains exactly one of the responses.
 // The values added here must match those in RequestUnion.
 type ResponseUnion struct {
-	Get                 *GetResponse                 `protobuf:"bytes,1,opt,name=get" json:"get,omitempty"`
-	Put                 *PutResponse                 `protobuf:"bytes,2,opt,name=put" json:"put,omitempty"`
-	ConditionalPut      *ConditionalPutResponse      `protobuf:"bytes,3,opt,name=conditional_put,json=conditionalPut" json:"conditional_put,omitempty"`
-	Increment           *IncrementResponse           `protobuf:"bytes,4,opt,name=increment" json:"increment,omitempty"`
-	Delete              *DeleteResponse              `protobuf:"bytes,5,opt,name=delete" json:"delete,omitempty"`
-	DeleteRange         *DeleteRangeResponse         `protobuf:"bytes,6,opt,name=delete_range,json=deleteRange" json:"delete_range,omitempty"`
-	ClearRange          *ClearRangeResponse          `protobuf:"bytes,38,opt,name=clear_range,json=clearRange" json:"clear_range,omitempty"`
-	Scan                *ScanResponse                `protobuf:"bytes,7,opt,name=scan" json:"scan,omitempty"`
-	BeginTransaction    *BeginTransactionResponse    `protobuf:"bytes,8,opt,name=begin_transaction,json=beginTransaction" json:"begin_transaction,omitempty"`
-	EndTransaction      *EndTransactionResponse      `protobuf:"bytes,9,opt,name=end_transaction,json=endTransaction" json:"end_transaction,omitempty"`
-	AdminSplit          *AdminSplitResponse          `protobuf:"bytes,10,opt,name=admin_split,json=adminSplit" json:"admin_split,omitempty"`
-	AdminMerge          *AdminMergeResponse          `protobuf:"bytes,11,opt,name=admin_merge,json=adminMerge" json:"admin_merge,omitempty"`
-	AdminTransferLease  *AdminTransferLeaseResponse  `protobuf:"bytes,29,opt,name=admin_transfer_lease,json=adminTransferLease" json:"admin_transfer_lease,omitempty"`
-	AdminChangeReplicas *AdminChangeReplicasResponse `protobuf:"bytes,35,opt,name=admin_change_replicas,json=adminChangeReplicas" json:"admin_change_replicas,omitempty"`
-	HeartbeatTxn        *HeartbeatTxnResponse        `protobuf:"bytes,12,opt,name=heartbeat_txn,json=heartbeatTxn" json:"heartbeat_txn,omitempty"`
-	Gc                  *GCResponse                  `protobuf:"bytes,13,opt,name=gc" json:"gc,omitempty"`
-	PushTxn             *PushTxnResponse             `protobuf:"bytes,14,opt,name=push_txn,json=pushTxn" json:"push_txn,omitempty"`
-	ResolveIntent       *ResolveIntentResponse       `protobuf:"bytes,16,opt,name=resolve_intent,json=resolveIntent" json:"resolve_intent,omitempty"`
-	ResolveIntentRange  *ResolveIntentRangeResponse  `protobuf:"bytes,17,opt,name=resolve_intent_range,json=resolveIntentRange" json:"resolve_intent_range,omitempty"`
-	Merge               *MergeResponse               `protobuf:"bytes,18,opt,name=merge" json:"merge,omitempty"`
-	TruncateLog         *TruncateLogResponse         `protobuf:"bytes,19,opt,name=truncate_log,json=truncateLog" json:"truncate_log,omitempty"`
-	RequestLease        *RequestLeaseResponse        `protobuf:"bytes,20,opt,name=request_lease,json=requestLease" json:"request_lease,omitempty"`
-	ReverseScan         *ReverseScanResponse         `protobuf:"bytes,21,opt,name=reverse_scan,json=reverseScan" json:"reverse_scan,omitempty"`
-	ComputeChecksum     *ComputeChecksumResponse     `protobuf:"bytes,22,opt,name=compute_checksum,json=computeChecksum" json:"compute_checksum,omitempty"`
-	CheckConsistency    *CheckConsistencyResponse    `protobuf:"bytes,24,opt,name=check_consistency,json=checkConsistency" json:"check_consistency,omitempty"`
-	Noop                *NoopResponse                `protobuf:"bytes,25,opt,name=noop" json:"noop,omitempty"`
-	InitPut             *InitPutResponse             `protobuf:"bytes,26,opt,name=init_put,json=initPut" json:"init_put,omitempty"`
-	LeaseInfo           *LeaseInfoResponse           `protobuf:"bytes,30,opt,name=lease_info,json=leaseInfo" json:"lease_info,omitempty"`
-	WriteBatch          *WriteBatchResponse          `protobuf:"bytes,31,opt,name=write_batch,json=writeBatch" json:"write_batch,omitempty"`
-	Export              *ExportResponse              `protobuf:"bytes,32,opt,name=export" json:"export,omitempty"`
-	Import              *ImportResponse              `protobuf:"bytes,34,opt,name=import" json:"import,omitempty"`
-	QueryTxn            *QueryTxnResponse            `protobuf:"bytes,33,opt,name=query_txn,json=queryTxn" json:"query_txn,omitempty"`
-	QueryIntent         *QueryIntentResponse         `protobuf:"bytes,42,opt,name=query_intent,json=queryIntent" json:"query_intent,omitempty"`
-	AdminScatter        *AdminScatterResponse        `protobuf:"bytes,36,opt,name=admin_scatter,json=adminScatter" json:"admin_scatter,omitempty"`
-	AddSstable          *AddSSTableResponse          `protobuf:"bytes,37,opt,name=add_sstable,json=addSstable" json:"add_sstable,omitempty"`
-	RecomputeStats      *RecomputeStatsResponse      `protobuf:"bytes,39,opt,name=recompute_stats,json=recomputeStats" json:"recompute_stats,omitempty"`
-	Refresh             *RefreshResponse             `protobuf:"bytes,40,opt,name=refresh" json:"refresh,omitempty"`
-	RefreshRange        *RefreshRangeResponse        `protobuf:"bytes,41,opt,name=refresh_range,json=refreshRange" json:"refresh_range,omitempty"`
-	GetSnapshotForMerge *GetSnapshotForMergeResponse `protobuf:"bytes,43,opt,name=get_snapshot_for_merge,json=getSnapshotForMerge" json:"get_snapshot_for_merge,omitempty"`
+	// Types that are valid to be assigned to Value:
+	//	*ResponseUnion_Get
+	//	*ResponseUnion_Put
+	//	*ResponseUnion_ConditionalPut
+	//	*ResponseUnion_Increment
+	//	*ResponseUnion_Delete
+	//	*ResponseUnion_DeleteRange
+	//	*ResponseUnion_ClearRange
+	//	*ResponseUnion_Scan
+	//	*ResponseUnion_BeginTransaction
+	//	*ResponseUnion_EndTransaction
+	//	*ResponseUnion_AdminSplit
+	//	*ResponseUnion_AdminMerge
+	//	*ResponseUnion_AdminTransferLease
+	//	*ResponseUnion_AdminChangeReplicas
+	//	*ResponseUnion_HeartbeatTxn
+	//	*ResponseUnion_Gc
+	//	*ResponseUnion_PushTxn
+	//	*ResponseUnion_ResolveIntent
+	//	*ResponseUnion_ResolveIntentRange
+	//	*ResponseUnion_Merge
+	//	*ResponseUnion_TruncateLog
+	//	*ResponseUnion_RequestLease
+	//	*ResponseUnion_ReverseScan
+	//	*ResponseUnion_ComputeChecksum
+	//	*ResponseUnion_CheckConsistency
+	//	*ResponseUnion_Noop
+	//	*ResponseUnion_InitPut
+	//	*ResponseUnion_LeaseInfo
+	//	*ResponseUnion_WriteBatch
+	//	*ResponseUnion_Export
+	//	*ResponseUnion_Import
+	//	*ResponseUnion_QueryTxn
+	//	*ResponseUnion_QueryIntent
+	//	*ResponseUnion_AdminScatter
+	//	*ResponseUnion_AddSstable
+	//	*ResponseUnion_RecomputeStats
+	//	*ResponseUnion_Refresh
+	//	*ResponseUnion_RefreshRange
+	//	*ResponseUnion_GetSnapshotForMerge
+	Value isResponseUnion_Value `protobuf_oneof:"value"`
 }
 
 func (m *ResponseUnion) Reset()                    { *m = ResponseUnion{} }
 func (m *ResponseUnion) String() string            { return proto.CompactTextString(m) }
 func (*ResponseUnion) ProtoMessage()               {}
 func (*ResponseUnion) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{86} }
+
+type isResponseUnion_Value interface {
+	isResponseUnion_Value()
+	MarshalTo([]byte) (int, error)
+	Size() int
+}
+
+type ResponseUnion_Get struct {
+	Get *GetResponse `protobuf:"bytes,1,opt,name=get,oneof"`
+}
+type ResponseUnion_Put struct {
+	Put *PutResponse `protobuf:"bytes,2,opt,name=put,oneof"`
+}
+type ResponseUnion_ConditionalPut struct {
+	ConditionalPut *ConditionalPutResponse `protobuf:"bytes,3,opt,name=conditional_put,json=conditionalPut,oneof"`
+}
+type ResponseUnion_Increment struct {
+	Increment *IncrementResponse `protobuf:"bytes,4,opt,name=increment,oneof"`
+}
+type ResponseUnion_Delete struct {
+	Delete *DeleteResponse `protobuf:"bytes,5,opt,name=delete,oneof"`
+}
+type ResponseUnion_DeleteRange struct {
+	DeleteRange *DeleteRangeResponse `protobuf:"bytes,6,opt,name=delete_range,json=deleteRange,oneof"`
+}
+type ResponseUnion_ClearRange struct {
+	ClearRange *ClearRangeResponse `protobuf:"bytes,38,opt,name=clear_range,json=clearRange,oneof"`
+}
+type ResponseUnion_Scan struct {
+	Scan *ScanResponse `protobuf:"bytes,7,opt,name=scan,oneof"`
+}
+type ResponseUnion_BeginTransaction struct {
+	BeginTransaction *BeginTransactionResponse `protobuf:"bytes,8,opt,name=begin_transaction,json=beginTransaction,oneof"`
+}
+type ResponseUnion_EndTransaction struct {
+	EndTransaction *EndTransactionResponse `protobuf:"bytes,9,opt,name=end_transaction,json=endTransaction,oneof"`
+}
+type ResponseUnion_AdminSplit struct {
+	AdminSplit *AdminSplitResponse `protobuf:"bytes,10,opt,name=admin_split,json=adminSplit,oneof"`
+}
+type ResponseUnion_AdminMerge struct {
+	AdminMerge *AdminMergeResponse `protobuf:"bytes,11,opt,name=admin_merge,json=adminMerge,oneof"`
+}
+type ResponseUnion_AdminTransferLease struct {
+	AdminTransferLease *AdminTransferLeaseResponse `protobuf:"bytes,29,opt,name=admin_transfer_lease,json=adminTransferLease,oneof"`
+}
+type ResponseUnion_AdminChangeReplicas struct {
+	AdminChangeReplicas *AdminChangeReplicasResponse `protobuf:"bytes,35,opt,name=admin_change_replicas,json=adminChangeReplicas,oneof"`
+}
+type ResponseUnion_HeartbeatTxn struct {
+	HeartbeatTxn *HeartbeatTxnResponse `protobuf:"bytes,12,opt,name=heartbeat_txn,json=heartbeatTxn,oneof"`
+}
+type ResponseUnion_Gc struct {
+	Gc *GCResponse `protobuf:"bytes,13,opt,name=gc,oneof"`
+}
+type ResponseUnion_PushTxn struct {
+	PushTxn *PushTxnResponse `protobuf:"bytes,14,opt,name=push_txn,json=pushTxn,oneof"`
+}
+type ResponseUnion_ResolveIntent struct {
+	ResolveIntent *ResolveIntentResponse `protobuf:"bytes,16,opt,name=resolve_intent,json=resolveIntent,oneof"`
+}
+type ResponseUnion_ResolveIntentRange struct {
+	ResolveIntentRange *ResolveIntentRangeResponse `protobuf:"bytes,17,opt,name=resolve_intent_range,json=resolveIntentRange,oneof"`
+}
+type ResponseUnion_Merge struct {
+	Merge *MergeResponse `protobuf:"bytes,18,opt,name=merge,oneof"`
+}
+type ResponseUnion_TruncateLog struct {
+	TruncateLog *TruncateLogResponse `protobuf:"bytes,19,opt,name=truncate_log,json=truncateLog,oneof"`
+}
+type ResponseUnion_RequestLease struct {
+	RequestLease *RequestLeaseResponse `protobuf:"bytes,20,opt,name=request_lease,json=requestLease,oneof"`
+}
+type ResponseUnion_ReverseScan struct {
+	ReverseScan *ReverseScanResponse `protobuf:"bytes,21,opt,name=reverse_scan,json=reverseScan,oneof"`
+}
+type ResponseUnion_ComputeChecksum struct {
+	ComputeChecksum *ComputeChecksumResponse `protobuf:"bytes,22,opt,name=compute_checksum,json=computeChecksum,oneof"`
+}
+type ResponseUnion_CheckConsistency struct {
+	CheckConsistency *CheckConsistencyResponse `protobuf:"bytes,24,opt,name=check_consistency,json=checkConsistency,oneof"`
+}
+type ResponseUnion_Noop struct {
+	Noop *NoopResponse `protobuf:"bytes,25,opt,name=noop,oneof"`
+}
+type ResponseUnion_InitPut struct {
+	InitPut *InitPutResponse `protobuf:"bytes,26,opt,name=init_put,json=initPut,oneof"`
+}
+type ResponseUnion_LeaseInfo struct {
+	LeaseInfo *LeaseInfoResponse `protobuf:"bytes,30,opt,name=lease_info,json=leaseInfo,oneof"`
+}
+type ResponseUnion_WriteBatch struct {
+	WriteBatch *WriteBatchResponse `protobuf:"bytes,31,opt,name=write_batch,json=writeBatch,oneof"`
+}
+type ResponseUnion_Export struct {
+	Export *ExportResponse `protobuf:"bytes,32,opt,name=export,oneof"`
+}
+type ResponseUnion_Import struct {
+	Import *ImportResponse `protobuf:"bytes,34,opt,name=import,oneof"`
+}
+type ResponseUnion_QueryTxn struct {
+	QueryTxn *QueryTxnResponse `protobuf:"bytes,33,opt,name=query_txn,json=queryTxn,oneof"`
+}
+type ResponseUnion_QueryIntent struct {
+	QueryIntent *QueryIntentResponse `protobuf:"bytes,42,opt,name=query_intent,json=queryIntent,oneof"`
+}
+type ResponseUnion_AdminScatter struct {
+	AdminScatter *AdminScatterResponse `protobuf:"bytes,36,opt,name=admin_scatter,json=adminScatter,oneof"`
+}
+type ResponseUnion_AddSstable struct {
+	AddSstable *AddSSTableResponse `protobuf:"bytes,37,opt,name=add_sstable,json=addSstable,oneof"`
+}
+type ResponseUnion_RecomputeStats struct {
+	RecomputeStats *RecomputeStatsResponse `protobuf:"bytes,39,opt,name=recompute_stats,json=recomputeStats,oneof"`
+}
+type ResponseUnion_Refresh struct {
+	Refresh *RefreshResponse `protobuf:"bytes,40,opt,name=refresh,oneof"`
+}
+type ResponseUnion_RefreshRange struct {
+	RefreshRange *RefreshRangeResponse `protobuf:"bytes,41,opt,name=refresh_range,json=refreshRange,oneof"`
+}
+type ResponseUnion_GetSnapshotForMerge struct {
+	GetSnapshotForMerge *GetSnapshotForMergeResponse `protobuf:"bytes,43,opt,name=get_snapshot_for_merge,json=getSnapshotForMerge,oneof"`
+}
+
+func (*ResponseUnion_Get) isResponseUnion_Value()                 {}
+func (*ResponseUnion_Put) isResponseUnion_Value()                 {}
+func (*ResponseUnion_ConditionalPut) isResponseUnion_Value()      {}
+func (*ResponseUnion_Increment) isResponseUnion_Value()           {}
+func (*ResponseUnion_Delete) isResponseUnion_Value()              {}
+func (*ResponseUnion_DeleteRange) isResponseUnion_Value()         {}
+func (*ResponseUnion_ClearRange) isResponseUnion_Value()          {}
+func (*ResponseUnion_Scan) isResponseUnion_Value()                {}
+func (*ResponseUnion_BeginTransaction) isResponseUnion_Value()    {}
+func (*ResponseUnion_EndTransaction) isResponseUnion_Value()      {}
+func (*ResponseUnion_AdminSplit) isResponseUnion_Value()          {}
+func (*ResponseUnion_AdminMerge) isResponseUnion_Value()          {}
+func (*ResponseUnion_AdminTransferLease) isResponseUnion_Value()  {}
+func (*ResponseUnion_AdminChangeReplicas) isResponseUnion_Value() {}
+func (*ResponseUnion_HeartbeatTxn) isResponseUnion_Value()        {}
+func (*ResponseUnion_Gc) isResponseUnion_Value()                  {}
+func (*ResponseUnion_PushTxn) isResponseUnion_Value()             {}
+func (*ResponseUnion_ResolveIntent) isResponseUnion_Value()       {}
+func (*ResponseUnion_ResolveIntentRange) isResponseUnion_Value()  {}
+func (*ResponseUnion_Merge) isResponseUnion_Value()               {}
+func (*ResponseUnion_TruncateLog) isResponseUnion_Value()         {}
+func (*ResponseUnion_RequestLease) isResponseUnion_Value()        {}
+func (*ResponseUnion_ReverseScan) isResponseUnion_Value()         {}
+func (*ResponseUnion_ComputeChecksum) isResponseUnion_Value()     {}
+func (*ResponseUnion_CheckConsistency) isResponseUnion_Value()    {}
+func (*ResponseUnion_Noop) isResponseUnion_Value()                {}
+func (*ResponseUnion_InitPut) isResponseUnion_Value()             {}
+func (*ResponseUnion_LeaseInfo) isResponseUnion_Value()           {}
+func (*ResponseUnion_WriteBatch) isResponseUnion_Value()          {}
+func (*ResponseUnion_Export) isResponseUnion_Value()              {}
+func (*ResponseUnion_Import) isResponseUnion_Value()              {}
+func (*ResponseUnion_QueryTxn) isResponseUnion_Value()            {}
+func (*ResponseUnion_QueryIntent) isResponseUnion_Value()         {}
+func (*ResponseUnion_AdminScatter) isResponseUnion_Value()        {}
+func (*ResponseUnion_AddSstable) isResponseUnion_Value()          {}
+func (*ResponseUnion_RecomputeStats) isResponseUnion_Value()      {}
+func (*ResponseUnion_Refresh) isResponseUnion_Value()             {}
+func (*ResponseUnion_RefreshRange) isResponseUnion_Value()        {}
+func (*ResponseUnion_GetSnapshotForMerge) isResponseUnion_Value() {}
+
+func (m *ResponseUnion) GetValue() isResponseUnion_Value {
+	if m != nil {
+		return m.Value
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetGet() *GetResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_Get); ok {
+		return x.Get
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetPut() *PutResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_Put); ok {
+		return x.Put
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetConditionalPut() *ConditionalPutResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_ConditionalPut); ok {
+		return x.ConditionalPut
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetIncrement() *IncrementResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_Increment); ok {
+		return x.Increment
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetDelete() *DeleteResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_Delete); ok {
+		return x.Delete
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetDeleteRange() *DeleteRangeResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_DeleteRange); ok {
+		return x.DeleteRange
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetClearRange() *ClearRangeResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_ClearRange); ok {
+		return x.ClearRange
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetScan() *ScanResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_Scan); ok {
+		return x.Scan
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetBeginTransaction() *BeginTransactionResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_BeginTransaction); ok {
+		return x.BeginTransaction
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetEndTransaction() *EndTransactionResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_EndTransaction); ok {
+		return x.EndTransaction
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetAdminSplit() *AdminSplitResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_AdminSplit); ok {
+		return x.AdminSplit
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetAdminMerge() *AdminMergeResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_AdminMerge); ok {
+		return x.AdminMerge
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetAdminTransferLease() *AdminTransferLeaseResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_AdminTransferLease); ok {
+		return x.AdminTransferLease
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetAdminChangeReplicas() *AdminChangeReplicasResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_AdminChangeReplicas); ok {
+		return x.AdminChangeReplicas
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetHeartbeatTxn() *HeartbeatTxnResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_HeartbeatTxn); ok {
+		return x.HeartbeatTxn
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetGc() *GCResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_Gc); ok {
+		return x.Gc
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetPushTxn() *PushTxnResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_PushTxn); ok {
+		return x.PushTxn
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetResolveIntent() *ResolveIntentResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_ResolveIntent); ok {
+		return x.ResolveIntent
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetResolveIntentRange() *ResolveIntentRangeResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_ResolveIntentRange); ok {
+		return x.ResolveIntentRange
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetMerge() *MergeResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_Merge); ok {
+		return x.Merge
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetTruncateLog() *TruncateLogResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_TruncateLog); ok {
+		return x.TruncateLog
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetRequestLease() *RequestLeaseResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_RequestLease); ok {
+		return x.RequestLease
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetReverseScan() *ReverseScanResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_ReverseScan); ok {
+		return x.ReverseScan
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetComputeChecksum() *ComputeChecksumResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_ComputeChecksum); ok {
+		return x.ComputeChecksum
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetCheckConsistency() *CheckConsistencyResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_CheckConsistency); ok {
+		return x.CheckConsistency
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetNoop() *NoopResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_Noop); ok {
+		return x.Noop
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetInitPut() *InitPutResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_InitPut); ok {
+		return x.InitPut
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetLeaseInfo() *LeaseInfoResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_LeaseInfo); ok {
+		return x.LeaseInfo
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetWriteBatch() *WriteBatchResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_WriteBatch); ok {
+		return x.WriteBatch
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetExport() *ExportResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_Export); ok {
+		return x.Export
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetImport() *ImportResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_Import); ok {
+		return x.Import
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetQueryTxn() *QueryTxnResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_QueryTxn); ok {
+		return x.QueryTxn
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetQueryIntent() *QueryIntentResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_QueryIntent); ok {
+		return x.QueryIntent
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetAdminScatter() *AdminScatterResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_AdminScatter); ok {
+		return x.AdminScatter
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetAddSstable() *AddSSTableResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_AddSstable); ok {
+		return x.AddSstable
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetRecomputeStats() *RecomputeStatsResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_RecomputeStats); ok {
+		return x.RecomputeStats
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetRefresh() *RefreshResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_Refresh); ok {
+		return x.Refresh
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetRefreshRange() *RefreshRangeResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_RefreshRange); ok {
+		return x.RefreshRange
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetGetSnapshotForMerge() *GetSnapshotForMergeResponse {
+	if x, ok := m.GetValue().(*ResponseUnion_GetSnapshotForMerge); ok {
+		return x.GetSnapshotForMerge
+	}
+	return nil
+}
+
+// XXX_OneofFuncs is for the internal use of the proto package.
+func (*ResponseUnion) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
+	return _ResponseUnion_OneofMarshaler, _ResponseUnion_OneofUnmarshaler, _ResponseUnion_OneofSizer, []interface{}{
+		(*ResponseUnion_Get)(nil),
+		(*ResponseUnion_Put)(nil),
+		(*ResponseUnion_ConditionalPut)(nil),
+		(*ResponseUnion_Increment)(nil),
+		(*ResponseUnion_Delete)(nil),
+		(*ResponseUnion_DeleteRange)(nil),
+		(*ResponseUnion_ClearRange)(nil),
+		(*ResponseUnion_Scan)(nil),
+		(*ResponseUnion_BeginTransaction)(nil),
+		(*ResponseUnion_EndTransaction)(nil),
+		(*ResponseUnion_AdminSplit)(nil),
+		(*ResponseUnion_AdminMerge)(nil),
+		(*ResponseUnion_AdminTransferLease)(nil),
+		(*ResponseUnion_AdminChangeReplicas)(nil),
+		(*ResponseUnion_HeartbeatTxn)(nil),
+		(*ResponseUnion_Gc)(nil),
+		(*ResponseUnion_PushTxn)(nil),
+		(*ResponseUnion_ResolveIntent)(nil),
+		(*ResponseUnion_ResolveIntentRange)(nil),
+		(*ResponseUnion_Merge)(nil),
+		(*ResponseUnion_TruncateLog)(nil),
+		(*ResponseUnion_RequestLease)(nil),
+		(*ResponseUnion_ReverseScan)(nil),
+		(*ResponseUnion_ComputeChecksum)(nil),
+		(*ResponseUnion_CheckConsistency)(nil),
+		(*ResponseUnion_Noop)(nil),
+		(*ResponseUnion_InitPut)(nil),
+		(*ResponseUnion_LeaseInfo)(nil),
+		(*ResponseUnion_WriteBatch)(nil),
+		(*ResponseUnion_Export)(nil),
+		(*ResponseUnion_Import)(nil),
+		(*ResponseUnion_QueryTxn)(nil),
+		(*ResponseUnion_QueryIntent)(nil),
+		(*ResponseUnion_AdminScatter)(nil),
+		(*ResponseUnion_AddSstable)(nil),
+		(*ResponseUnion_RecomputeStats)(nil),
+		(*ResponseUnion_Refresh)(nil),
+		(*ResponseUnion_RefreshRange)(nil),
+		(*ResponseUnion_GetSnapshotForMerge)(nil),
+	}
+}
+
+func _ResponseUnion_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
+	m := msg.(*ResponseUnion)
+	// value
+	switch x := m.Value.(type) {
+	case *ResponseUnion_Get:
+		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Get); err != nil {
+			return err
+		}
+	case *ResponseUnion_Put:
+		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Put); err != nil {
+			return err
+		}
+	case *ResponseUnion_ConditionalPut:
+		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ConditionalPut); err != nil {
+			return err
+		}
+	case *ResponseUnion_Increment:
+		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Increment); err != nil {
+			return err
+		}
+	case *ResponseUnion_Delete:
+		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Delete); err != nil {
+			return err
+		}
+	case *ResponseUnion_DeleteRange:
+		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.DeleteRange); err != nil {
+			return err
+		}
+	case *ResponseUnion_ClearRange:
+		_ = b.EncodeVarint(38<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ClearRange); err != nil {
+			return err
+		}
+	case *ResponseUnion_Scan:
+		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Scan); err != nil {
+			return err
+		}
+	case *ResponseUnion_BeginTransaction:
+		_ = b.EncodeVarint(8<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.BeginTransaction); err != nil {
+			return err
+		}
+	case *ResponseUnion_EndTransaction:
+		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.EndTransaction); err != nil {
+			return err
+		}
+	case *ResponseUnion_AdminSplit:
+		_ = b.EncodeVarint(10<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.AdminSplit); err != nil {
+			return err
+		}
+	case *ResponseUnion_AdminMerge:
+		_ = b.EncodeVarint(11<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.AdminMerge); err != nil {
+			return err
+		}
+	case *ResponseUnion_AdminTransferLease:
+		_ = b.EncodeVarint(29<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.AdminTransferLease); err != nil {
+			return err
+		}
+	case *ResponseUnion_AdminChangeReplicas:
+		_ = b.EncodeVarint(35<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.AdminChangeReplicas); err != nil {
+			return err
+		}
+	case *ResponseUnion_HeartbeatTxn:
+		_ = b.EncodeVarint(12<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.HeartbeatTxn); err != nil {
+			return err
+		}
+	case *ResponseUnion_Gc:
+		_ = b.EncodeVarint(13<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Gc); err != nil {
+			return err
+		}
+	case *ResponseUnion_PushTxn:
+		_ = b.EncodeVarint(14<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.PushTxn); err != nil {
+			return err
+		}
+	case *ResponseUnion_ResolveIntent:
+		_ = b.EncodeVarint(16<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ResolveIntent); err != nil {
+			return err
+		}
+	case *ResponseUnion_ResolveIntentRange:
+		_ = b.EncodeVarint(17<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ResolveIntentRange); err != nil {
+			return err
+		}
+	case *ResponseUnion_Merge:
+		_ = b.EncodeVarint(18<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Merge); err != nil {
+			return err
+		}
+	case *ResponseUnion_TruncateLog:
+		_ = b.EncodeVarint(19<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.TruncateLog); err != nil {
+			return err
+		}
+	case *ResponseUnion_RequestLease:
+		_ = b.EncodeVarint(20<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.RequestLease); err != nil {
+			return err
+		}
+	case *ResponseUnion_ReverseScan:
+		_ = b.EncodeVarint(21<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ReverseScan); err != nil {
+			return err
+		}
+	case *ResponseUnion_ComputeChecksum:
+		_ = b.EncodeVarint(22<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ComputeChecksum); err != nil {
+			return err
+		}
+	case *ResponseUnion_CheckConsistency:
+		_ = b.EncodeVarint(24<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.CheckConsistency); err != nil {
+			return err
+		}
+	case *ResponseUnion_Noop:
+		_ = b.EncodeVarint(25<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Noop); err != nil {
+			return err
+		}
+	case *ResponseUnion_InitPut:
+		_ = b.EncodeVarint(26<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.InitPut); err != nil {
+			return err
+		}
+	case *ResponseUnion_LeaseInfo:
+		_ = b.EncodeVarint(30<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.LeaseInfo); err != nil {
+			return err
+		}
+	case *ResponseUnion_WriteBatch:
+		_ = b.EncodeVarint(31<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.WriteBatch); err != nil {
+			return err
+		}
+	case *ResponseUnion_Export:
+		_ = b.EncodeVarint(32<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Export); err != nil {
+			return err
+		}
+	case *ResponseUnion_Import:
+		_ = b.EncodeVarint(34<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Import); err != nil {
+			return err
+		}
+	case *ResponseUnion_QueryTxn:
+		_ = b.EncodeVarint(33<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.QueryTxn); err != nil {
+			return err
+		}
+	case *ResponseUnion_QueryIntent:
+		_ = b.EncodeVarint(42<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.QueryIntent); err != nil {
+			return err
+		}
+	case *ResponseUnion_AdminScatter:
+		_ = b.EncodeVarint(36<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.AdminScatter); err != nil {
+			return err
+		}
+	case *ResponseUnion_AddSstable:
+		_ = b.EncodeVarint(37<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.AddSstable); err != nil {
+			return err
+		}
+	case *ResponseUnion_RecomputeStats:
+		_ = b.EncodeVarint(39<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.RecomputeStats); err != nil {
+			return err
+		}
+	case *ResponseUnion_Refresh:
+		_ = b.EncodeVarint(40<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Refresh); err != nil {
+			return err
+		}
+	case *ResponseUnion_RefreshRange:
+		_ = b.EncodeVarint(41<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.RefreshRange); err != nil {
+			return err
+		}
+	case *ResponseUnion_GetSnapshotForMerge:
+		_ = b.EncodeVarint(43<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.GetSnapshotForMerge); err != nil {
+			return err
+		}
+	case nil:
+	default:
+		return fmt.Errorf("ResponseUnion.Value has unexpected type %T", x)
+	}
+	return nil
+}
+
+func _ResponseUnion_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
+	m := msg.(*ResponseUnion)
+	switch tag {
+	case 1: // value.get
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(GetResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_Get{msg}
+		return true, err
+	case 2: // value.put
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(PutResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_Put{msg}
+		return true, err
+	case 3: // value.conditional_put
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ConditionalPutResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_ConditionalPut{msg}
+		return true, err
+	case 4: // value.increment
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(IncrementResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_Increment{msg}
+		return true, err
+	case 5: // value.delete
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(DeleteResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_Delete{msg}
+		return true, err
+	case 6: // value.delete_range
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(DeleteRangeResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_DeleteRange{msg}
+		return true, err
+	case 38: // value.clear_range
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ClearRangeResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_ClearRange{msg}
+		return true, err
+	case 7: // value.scan
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ScanResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_Scan{msg}
+		return true, err
+	case 8: // value.begin_transaction
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(BeginTransactionResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_BeginTransaction{msg}
+		return true, err
+	case 9: // value.end_transaction
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(EndTransactionResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_EndTransaction{msg}
+		return true, err
+	case 10: // value.admin_split
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(AdminSplitResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_AdminSplit{msg}
+		return true, err
+	case 11: // value.admin_merge
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(AdminMergeResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_AdminMerge{msg}
+		return true, err
+	case 29: // value.admin_transfer_lease
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(AdminTransferLeaseResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_AdminTransferLease{msg}
+		return true, err
+	case 35: // value.admin_change_replicas
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(AdminChangeReplicasResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_AdminChangeReplicas{msg}
+		return true, err
+	case 12: // value.heartbeat_txn
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(HeartbeatTxnResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_HeartbeatTxn{msg}
+		return true, err
+	case 13: // value.gc
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(GCResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_Gc{msg}
+		return true, err
+	case 14: // value.push_txn
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(PushTxnResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_PushTxn{msg}
+		return true, err
+	case 16: // value.resolve_intent
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ResolveIntentResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_ResolveIntent{msg}
+		return true, err
+	case 17: // value.resolve_intent_range
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ResolveIntentRangeResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_ResolveIntentRange{msg}
+		return true, err
+	case 18: // value.merge
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(MergeResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_Merge{msg}
+		return true, err
+	case 19: // value.truncate_log
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(TruncateLogResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_TruncateLog{msg}
+		return true, err
+	case 20: // value.request_lease
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(RequestLeaseResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_RequestLease{msg}
+		return true, err
+	case 21: // value.reverse_scan
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ReverseScanResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_ReverseScan{msg}
+		return true, err
+	case 22: // value.compute_checksum
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ComputeChecksumResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_ComputeChecksum{msg}
+		return true, err
+	case 24: // value.check_consistency
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(CheckConsistencyResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_CheckConsistency{msg}
+		return true, err
+	case 25: // value.noop
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(NoopResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_Noop{msg}
+		return true, err
+	case 26: // value.init_put
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(InitPutResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_InitPut{msg}
+		return true, err
+	case 30: // value.lease_info
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(LeaseInfoResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_LeaseInfo{msg}
+		return true, err
+	case 31: // value.write_batch
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(WriteBatchResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_WriteBatch{msg}
+		return true, err
+	case 32: // value.export
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ExportResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_Export{msg}
+		return true, err
+	case 34: // value.import
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ImportResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_Import{msg}
+		return true, err
+	case 33: // value.query_txn
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(QueryTxnResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_QueryTxn{msg}
+		return true, err
+	case 42: // value.query_intent
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(QueryIntentResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_QueryIntent{msg}
+		return true, err
+	case 36: // value.admin_scatter
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(AdminScatterResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_AdminScatter{msg}
+		return true, err
+	case 37: // value.add_sstable
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(AddSSTableResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_AddSstable{msg}
+		return true, err
+	case 39: // value.recompute_stats
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(RecomputeStatsResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_RecomputeStats{msg}
+		return true, err
+	case 40: // value.refresh
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(RefreshResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_Refresh{msg}
+		return true, err
+	case 41: // value.refresh_range
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(RefreshRangeResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_RefreshRange{msg}
+		return true, err
+	case 43: // value.get_snapshot_for_merge
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(GetSnapshotForMergeResponse)
+		err := b.DecodeMessage(msg)
+		m.Value = &ResponseUnion_GetSnapshotForMerge{msg}
+		return true, err
+	default:
+		return false, nil
+	}
+}
+
+func _ResponseUnion_OneofSizer(msg proto.Message) (n int) {
+	m := msg.(*ResponseUnion)
+	// value
+	switch x := m.Value.(type) {
+	case *ResponseUnion_Get:
+		s := proto.Size(x.Get)
+		n += proto.SizeVarint(1<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_Put:
+		s := proto.Size(x.Put)
+		n += proto.SizeVarint(2<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_ConditionalPut:
+		s := proto.Size(x.ConditionalPut)
+		n += proto.SizeVarint(3<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_Increment:
+		s := proto.Size(x.Increment)
+		n += proto.SizeVarint(4<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_Delete:
+		s := proto.Size(x.Delete)
+		n += proto.SizeVarint(5<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_DeleteRange:
+		s := proto.Size(x.DeleteRange)
+		n += proto.SizeVarint(6<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_ClearRange:
+		s := proto.Size(x.ClearRange)
+		n += proto.SizeVarint(38<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_Scan:
+		s := proto.Size(x.Scan)
+		n += proto.SizeVarint(7<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_BeginTransaction:
+		s := proto.Size(x.BeginTransaction)
+		n += proto.SizeVarint(8<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_EndTransaction:
+		s := proto.Size(x.EndTransaction)
+		n += proto.SizeVarint(9<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_AdminSplit:
+		s := proto.Size(x.AdminSplit)
+		n += proto.SizeVarint(10<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_AdminMerge:
+		s := proto.Size(x.AdminMerge)
+		n += proto.SizeVarint(11<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_AdminTransferLease:
+		s := proto.Size(x.AdminTransferLease)
+		n += proto.SizeVarint(29<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_AdminChangeReplicas:
+		s := proto.Size(x.AdminChangeReplicas)
+		n += proto.SizeVarint(35<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_HeartbeatTxn:
+		s := proto.Size(x.HeartbeatTxn)
+		n += proto.SizeVarint(12<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_Gc:
+		s := proto.Size(x.Gc)
+		n += proto.SizeVarint(13<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_PushTxn:
+		s := proto.Size(x.PushTxn)
+		n += proto.SizeVarint(14<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_ResolveIntent:
+		s := proto.Size(x.ResolveIntent)
+		n += proto.SizeVarint(16<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_ResolveIntentRange:
+		s := proto.Size(x.ResolveIntentRange)
+		n += proto.SizeVarint(17<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_Merge:
+		s := proto.Size(x.Merge)
+		n += proto.SizeVarint(18<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_TruncateLog:
+		s := proto.Size(x.TruncateLog)
+		n += proto.SizeVarint(19<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_RequestLease:
+		s := proto.Size(x.RequestLease)
+		n += proto.SizeVarint(20<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_ReverseScan:
+		s := proto.Size(x.ReverseScan)
+		n += proto.SizeVarint(21<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_ComputeChecksum:
+		s := proto.Size(x.ComputeChecksum)
+		n += proto.SizeVarint(22<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_CheckConsistency:
+		s := proto.Size(x.CheckConsistency)
+		n += proto.SizeVarint(24<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_Noop:
+		s := proto.Size(x.Noop)
+		n += proto.SizeVarint(25<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_InitPut:
+		s := proto.Size(x.InitPut)
+		n += proto.SizeVarint(26<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_LeaseInfo:
+		s := proto.Size(x.LeaseInfo)
+		n += proto.SizeVarint(30<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_WriteBatch:
+		s := proto.Size(x.WriteBatch)
+		n += proto.SizeVarint(31<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_Export:
+		s := proto.Size(x.Export)
+		n += proto.SizeVarint(32<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_Import:
+		s := proto.Size(x.Import)
+		n += proto.SizeVarint(34<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_QueryTxn:
+		s := proto.Size(x.QueryTxn)
+		n += proto.SizeVarint(33<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_QueryIntent:
+		s := proto.Size(x.QueryIntent)
+		n += proto.SizeVarint(42<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_AdminScatter:
+		s := proto.Size(x.AdminScatter)
+		n += proto.SizeVarint(36<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_AddSstable:
+		s := proto.Size(x.AddSstable)
+		n += proto.SizeVarint(37<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_RecomputeStats:
+		s := proto.Size(x.RecomputeStats)
+		n += proto.SizeVarint(39<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_Refresh:
+		s := proto.Size(x.Refresh)
+		n += proto.SizeVarint(40<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_RefreshRange:
+		s := proto.Size(x.RefreshRange)
+		n += proto.SizeVarint(41<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *ResponseUnion_GetSnapshotForMerge:
+		s := proto.Size(x.GetSnapshotForMerge)
+		n += proto.SizeVarint(43<<3 | proto.WireBytes)
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case nil:
+	default:
+		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
+	}
+	return n
+}
 
 // A Header is attached to a BatchRequest, encapsulating routing and auxiliary
 // information required for executing it.
@@ -7320,453 +9796,605 @@ func (m *RequestUnion) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.Value != nil {
+		nn132, err := m.Value.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += nn132
+	}
+	return i, nil
+}
+
+func (m *RequestUnion_Get) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.Get != nil {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.Get.Size()))
-		n132, err := m.Get.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n132
-	}
-	if m.Put != nil {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.Put.Size()))
-		n133, err := m.Put.MarshalTo(dAtA[i:])
+		n133, err := m.Get.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n133
 	}
-	if m.ConditionalPut != nil {
-		dAtA[i] = 0x1a
+	return i, nil
+}
+func (m *RequestUnion_Put) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.Put != nil {
+		dAtA[i] = 0x12
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.ConditionalPut.Size()))
-		n134, err := m.ConditionalPut.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.Put.Size()))
+		n134, err := m.Put.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n134
 	}
-	if m.Increment != nil {
-		dAtA[i] = 0x22
+	return i, nil
+}
+func (m *RequestUnion_ConditionalPut) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.ConditionalPut != nil {
+		dAtA[i] = 0x1a
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.Increment.Size()))
-		n135, err := m.Increment.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.ConditionalPut.Size()))
+		n135, err := m.ConditionalPut.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n135
 	}
-	if m.Delete != nil {
-		dAtA[i] = 0x2a
+	return i, nil
+}
+func (m *RequestUnion_Increment) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.Increment != nil {
+		dAtA[i] = 0x22
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.Delete.Size()))
-		n136, err := m.Delete.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.Increment.Size()))
+		n136, err := m.Increment.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n136
 	}
-	if m.DeleteRange != nil {
-		dAtA[i] = 0x32
+	return i, nil
+}
+func (m *RequestUnion_Delete) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.Delete != nil {
+		dAtA[i] = 0x2a
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.DeleteRange.Size()))
-		n137, err := m.DeleteRange.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.Delete.Size()))
+		n137, err := m.Delete.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n137
 	}
-	if m.Scan != nil {
-		dAtA[i] = 0x3a
+	return i, nil
+}
+func (m *RequestUnion_DeleteRange) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.DeleteRange != nil {
+		dAtA[i] = 0x32
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.Scan.Size()))
-		n138, err := m.Scan.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.DeleteRange.Size()))
+		n138, err := m.DeleteRange.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n138
 	}
-	if m.BeginTransaction != nil {
-		dAtA[i] = 0x42
+	return i, nil
+}
+func (m *RequestUnion_Scan) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.Scan != nil {
+		dAtA[i] = 0x3a
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.BeginTransaction.Size()))
-		n139, err := m.BeginTransaction.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.Scan.Size()))
+		n139, err := m.Scan.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n139
 	}
-	if m.EndTransaction != nil {
-		dAtA[i] = 0x4a
+	return i, nil
+}
+func (m *RequestUnion_BeginTransaction) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.BeginTransaction != nil {
+		dAtA[i] = 0x42
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.EndTransaction.Size()))
-		n140, err := m.EndTransaction.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.BeginTransaction.Size()))
+		n140, err := m.BeginTransaction.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n140
 	}
-	if m.AdminSplit != nil {
-		dAtA[i] = 0x52
+	return i, nil
+}
+func (m *RequestUnion_EndTransaction) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.EndTransaction != nil {
+		dAtA[i] = 0x4a
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.AdminSplit.Size()))
-		n141, err := m.AdminSplit.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.EndTransaction.Size()))
+		n141, err := m.EndTransaction.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n141
 	}
-	if m.AdminMerge != nil {
-		dAtA[i] = 0x5a
+	return i, nil
+}
+func (m *RequestUnion_AdminSplit) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.AdminSplit != nil {
+		dAtA[i] = 0x52
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.AdminMerge.Size()))
-		n142, err := m.AdminMerge.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.AdminSplit.Size()))
+		n142, err := m.AdminSplit.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n142
 	}
-	if m.HeartbeatTxn != nil {
-		dAtA[i] = 0x62
+	return i, nil
+}
+func (m *RequestUnion_AdminMerge) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.AdminMerge != nil {
+		dAtA[i] = 0x5a
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.HeartbeatTxn.Size()))
-		n143, err := m.HeartbeatTxn.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.AdminMerge.Size()))
+		n143, err := m.AdminMerge.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n143
 	}
-	if m.Gc != nil {
-		dAtA[i] = 0x6a
+	return i, nil
+}
+func (m *RequestUnion_HeartbeatTxn) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.HeartbeatTxn != nil {
+		dAtA[i] = 0x62
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.Gc.Size()))
-		n144, err := m.Gc.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.HeartbeatTxn.Size()))
+		n144, err := m.HeartbeatTxn.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n144
 	}
-	if m.PushTxn != nil {
-		dAtA[i] = 0x72
+	return i, nil
+}
+func (m *RequestUnion_Gc) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.Gc != nil {
+		dAtA[i] = 0x6a
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.PushTxn.Size()))
-		n145, err := m.PushTxn.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.Gc.Size()))
+		n145, err := m.Gc.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n145
 	}
+	return i, nil
+}
+func (m *RequestUnion_PushTxn) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.PushTxn != nil {
+		dAtA[i] = 0x72
+		i++
+		i = encodeVarintApi(dAtA, i, uint64(m.PushTxn.Size()))
+		n146, err := m.PushTxn.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n146
+	}
+	return i, nil
+}
+func (m *RequestUnion_ResolveIntent) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.ResolveIntent != nil {
 		dAtA[i] = 0x82
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.ResolveIntent.Size()))
-		n146, err := m.ResolveIntent.MarshalTo(dAtA[i:])
+		n147, err := m.ResolveIntent.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n146
+		i += n147
 	}
+	return i, nil
+}
+func (m *RequestUnion_ResolveIntentRange) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.ResolveIntentRange != nil {
 		dAtA[i] = 0x8a
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.ResolveIntentRange.Size()))
-		n147, err := m.ResolveIntentRange.MarshalTo(dAtA[i:])
+		n148, err := m.ResolveIntentRange.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n147
+		i += n148
 	}
+	return i, nil
+}
+func (m *RequestUnion_Merge) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.Merge != nil {
 		dAtA[i] = 0x92
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.Merge.Size()))
-		n148, err := m.Merge.MarshalTo(dAtA[i:])
+		n149, err := m.Merge.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n148
+		i += n149
 	}
+	return i, nil
+}
+func (m *RequestUnion_TruncateLog) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.TruncateLog != nil {
 		dAtA[i] = 0x9a
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.TruncateLog.Size()))
-		n149, err := m.TruncateLog.MarshalTo(dAtA[i:])
+		n150, err := m.TruncateLog.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n149
+		i += n150
 	}
+	return i, nil
+}
+func (m *RequestUnion_RequestLease) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.RequestLease != nil {
 		dAtA[i] = 0xa2
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.RequestLease.Size()))
-		n150, err := m.RequestLease.MarshalTo(dAtA[i:])
+		n151, err := m.RequestLease.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n150
+		i += n151
 	}
+	return i, nil
+}
+func (m *RequestUnion_ReverseScan) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.ReverseScan != nil {
 		dAtA[i] = 0xaa
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.ReverseScan.Size()))
-		n151, err := m.ReverseScan.MarshalTo(dAtA[i:])
+		n152, err := m.ReverseScan.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n151
+		i += n152
 	}
+	return i, nil
+}
+func (m *RequestUnion_ComputeChecksum) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.ComputeChecksum != nil {
 		dAtA[i] = 0xb2
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.ComputeChecksum.Size()))
-		n152, err := m.ComputeChecksum.MarshalTo(dAtA[i:])
+		n153, err := m.ComputeChecksum.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n152
+		i += n153
 	}
+	return i, nil
+}
+func (m *RequestUnion_CheckConsistency) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.CheckConsistency != nil {
 		dAtA[i] = 0xc2
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.CheckConsistency.Size()))
-		n153, err := m.CheckConsistency.MarshalTo(dAtA[i:])
+		n154, err := m.CheckConsistency.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n153
+		i += n154
 	}
+	return i, nil
+}
+func (m *RequestUnion_Noop) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.Noop != nil {
 		dAtA[i] = 0xca
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.Noop.Size()))
-		n154, err := m.Noop.MarshalTo(dAtA[i:])
+		n155, err := m.Noop.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n154
+		i += n155
 	}
+	return i, nil
+}
+func (m *RequestUnion_InitPut) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.InitPut != nil {
 		dAtA[i] = 0xd2
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.InitPut.Size()))
-		n155, err := m.InitPut.MarshalTo(dAtA[i:])
+		n156, err := m.InitPut.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n155
+		i += n156
 	}
+	return i, nil
+}
+func (m *RequestUnion_TransferLease) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.TransferLease != nil {
 		dAtA[i] = 0xe2
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.TransferLease.Size()))
-		n156, err := m.TransferLease.MarshalTo(dAtA[i:])
+		n157, err := m.TransferLease.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n156
+		i += n157
 	}
+	return i, nil
+}
+func (m *RequestUnion_AdminTransferLease) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.AdminTransferLease != nil {
 		dAtA[i] = 0xea
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.AdminTransferLease.Size()))
-		n157, err := m.AdminTransferLease.MarshalTo(dAtA[i:])
+		n158, err := m.AdminTransferLease.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n157
+		i += n158
 	}
+	return i, nil
+}
+func (m *RequestUnion_LeaseInfo) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.LeaseInfo != nil {
 		dAtA[i] = 0xf2
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.LeaseInfo.Size()))
-		n158, err := m.LeaseInfo.MarshalTo(dAtA[i:])
+		n159, err := m.LeaseInfo.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n158
+		i += n159
 	}
+	return i, nil
+}
+func (m *RequestUnion_WriteBatch) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.WriteBatch != nil {
 		dAtA[i] = 0xfa
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.WriteBatch.Size()))
-		n159, err := m.WriteBatch.MarshalTo(dAtA[i:])
+		n160, err := m.WriteBatch.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n159
+		i += n160
 	}
+	return i, nil
+}
+func (m *RequestUnion_Export) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.Export != nil {
 		dAtA[i] = 0x82
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.Export.Size()))
-		n160, err := m.Export.MarshalTo(dAtA[i:])
+		n161, err := m.Export.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n160
+		i += n161
 	}
+	return i, nil
+}
+func (m *RequestUnion_QueryTxn) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.QueryTxn != nil {
 		dAtA[i] = 0x8a
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.QueryTxn.Size()))
-		n161, err := m.QueryTxn.MarshalTo(dAtA[i:])
+		n162, err := m.QueryTxn.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n161
+		i += n162
 	}
+	return i, nil
+}
+func (m *RequestUnion_Import) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.Import != nil {
 		dAtA[i] = 0x92
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.Import.Size()))
-		n162, err := m.Import.MarshalTo(dAtA[i:])
+		n163, err := m.Import.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n162
+		i += n163
 	}
+	return i, nil
+}
+func (m *RequestUnion_AdminChangeReplicas) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.AdminChangeReplicas != nil {
 		dAtA[i] = 0x9a
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.AdminChangeReplicas.Size()))
-		n163, err := m.AdminChangeReplicas.MarshalTo(dAtA[i:])
+		n164, err := m.AdminChangeReplicas.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n163
+		i += n164
 	}
+	return i, nil
+}
+func (m *RequestUnion_AdminScatter) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.AdminScatter != nil {
 		dAtA[i] = 0xa2
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.AdminScatter.Size()))
-		n164, err := m.AdminScatter.MarshalTo(dAtA[i:])
+		n165, err := m.AdminScatter.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n164
+		i += n165
 	}
+	return i, nil
+}
+func (m *RequestUnion_AddSstable) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.AddSstable != nil {
 		dAtA[i] = 0xaa
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.AddSstable.Size()))
-		n165, err := m.AddSstable.MarshalTo(dAtA[i:])
+		n166, err := m.AddSstable.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n165
+		i += n166
 	}
+	return i, nil
+}
+func (m *RequestUnion_ClearRange) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.ClearRange != nil {
 		dAtA[i] = 0xb2
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.ClearRange.Size()))
-		n166, err := m.ClearRange.MarshalTo(dAtA[i:])
+		n167, err := m.ClearRange.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n166
+		i += n167
 	}
+	return i, nil
+}
+func (m *RequestUnion_RecomputeStats) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.RecomputeStats != nil {
 		dAtA[i] = 0xba
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.RecomputeStats.Size()))
-		n167, err := m.RecomputeStats.MarshalTo(dAtA[i:])
+		n168, err := m.RecomputeStats.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n167
+		i += n168
 	}
+	return i, nil
+}
+func (m *RequestUnion_Refresh) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.Refresh != nil {
 		dAtA[i] = 0xc2
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.Refresh.Size()))
-		n168, err := m.Refresh.MarshalTo(dAtA[i:])
+		n169, err := m.Refresh.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n168
+		i += n169
 	}
+	return i, nil
+}
+func (m *RequestUnion_RefreshRange) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.RefreshRange != nil {
 		dAtA[i] = 0xca
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.RefreshRange.Size()))
-		n169, err := m.RefreshRange.MarshalTo(dAtA[i:])
+		n170, err := m.RefreshRange.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n169
+		i += n170
 	}
+	return i, nil
+}
+func (m *RequestUnion_QueryIntent) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.QueryIntent != nil {
 		dAtA[i] = 0xd2
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.QueryIntent.Size()))
-		n170, err := m.QueryIntent.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n170
-	}
-	if m.GetSnapshotForMerge != nil {
-		dAtA[i] = 0xda
-		i++
-		dAtA[i] = 0x2
-		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.GetSnapshotForMerge.Size()))
-		n171, err := m.GetSnapshotForMerge.MarshalTo(dAtA[i:])
+		n171, err := m.QueryIntent.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
@@ -7774,7 +10402,22 @@ func (m *RequestUnion) MarshalTo(dAtA []byte) (int, error) {
 	}
 	return i, nil
 }
-
+func (m *RequestUnion_GetSnapshotForMerge) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.GetSnapshotForMerge != nil {
+		dAtA[i] = 0xda
+		i++
+		dAtA[i] = 0x2
+		i++
+		i = encodeVarintApi(dAtA, i, uint64(m.GetSnapshotForMerge.Size()))
+		n172, err := m.GetSnapshotForMerge.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n172
+	}
+	return i, nil
+}
 func (m *ResponseUnion) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -7790,441 +10433,573 @@ func (m *ResponseUnion) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.Value != nil {
+		nn173, err := m.Value.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += nn173
+	}
+	return i, nil
+}
+
+func (m *ResponseUnion_Get) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.Get != nil {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.Get.Size()))
-		n172, err := m.Get.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n172
-	}
-	if m.Put != nil {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.Put.Size()))
-		n173, err := m.Put.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n173
-	}
-	if m.ConditionalPut != nil {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.ConditionalPut.Size()))
-		n174, err := m.ConditionalPut.MarshalTo(dAtA[i:])
+		n174, err := m.Get.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n174
 	}
-	if m.Increment != nil {
-		dAtA[i] = 0x22
+	return i, nil
+}
+func (m *ResponseUnion_Put) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.Put != nil {
+		dAtA[i] = 0x12
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.Increment.Size()))
-		n175, err := m.Increment.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.Put.Size()))
+		n175, err := m.Put.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n175
 	}
-	if m.Delete != nil {
-		dAtA[i] = 0x2a
+	return i, nil
+}
+func (m *ResponseUnion_ConditionalPut) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.ConditionalPut != nil {
+		dAtA[i] = 0x1a
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.Delete.Size()))
-		n176, err := m.Delete.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.ConditionalPut.Size()))
+		n176, err := m.ConditionalPut.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n176
 	}
-	if m.DeleteRange != nil {
-		dAtA[i] = 0x32
+	return i, nil
+}
+func (m *ResponseUnion_Increment) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.Increment != nil {
+		dAtA[i] = 0x22
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.DeleteRange.Size()))
-		n177, err := m.DeleteRange.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.Increment.Size()))
+		n177, err := m.Increment.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n177
 	}
-	if m.Scan != nil {
-		dAtA[i] = 0x3a
+	return i, nil
+}
+func (m *ResponseUnion_Delete) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.Delete != nil {
+		dAtA[i] = 0x2a
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.Scan.Size()))
-		n178, err := m.Scan.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.Delete.Size()))
+		n178, err := m.Delete.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n178
 	}
-	if m.BeginTransaction != nil {
-		dAtA[i] = 0x42
+	return i, nil
+}
+func (m *ResponseUnion_DeleteRange) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.DeleteRange != nil {
+		dAtA[i] = 0x32
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.BeginTransaction.Size()))
-		n179, err := m.BeginTransaction.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.DeleteRange.Size()))
+		n179, err := m.DeleteRange.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n179
 	}
-	if m.EndTransaction != nil {
-		dAtA[i] = 0x4a
+	return i, nil
+}
+func (m *ResponseUnion_Scan) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.Scan != nil {
+		dAtA[i] = 0x3a
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.EndTransaction.Size()))
-		n180, err := m.EndTransaction.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.Scan.Size()))
+		n180, err := m.Scan.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n180
 	}
-	if m.AdminSplit != nil {
-		dAtA[i] = 0x52
+	return i, nil
+}
+func (m *ResponseUnion_BeginTransaction) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.BeginTransaction != nil {
+		dAtA[i] = 0x42
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.AdminSplit.Size()))
-		n181, err := m.AdminSplit.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.BeginTransaction.Size()))
+		n181, err := m.BeginTransaction.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n181
 	}
-	if m.AdminMerge != nil {
-		dAtA[i] = 0x5a
+	return i, nil
+}
+func (m *ResponseUnion_EndTransaction) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.EndTransaction != nil {
+		dAtA[i] = 0x4a
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.AdminMerge.Size()))
-		n182, err := m.AdminMerge.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.EndTransaction.Size()))
+		n182, err := m.EndTransaction.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n182
 	}
-	if m.HeartbeatTxn != nil {
-		dAtA[i] = 0x62
+	return i, nil
+}
+func (m *ResponseUnion_AdminSplit) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.AdminSplit != nil {
+		dAtA[i] = 0x52
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.HeartbeatTxn.Size()))
-		n183, err := m.HeartbeatTxn.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.AdminSplit.Size()))
+		n183, err := m.AdminSplit.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n183
 	}
-	if m.Gc != nil {
-		dAtA[i] = 0x6a
+	return i, nil
+}
+func (m *ResponseUnion_AdminMerge) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.AdminMerge != nil {
+		dAtA[i] = 0x5a
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.Gc.Size()))
-		n184, err := m.Gc.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.AdminMerge.Size()))
+		n184, err := m.AdminMerge.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n184
 	}
-	if m.PushTxn != nil {
-		dAtA[i] = 0x72
+	return i, nil
+}
+func (m *ResponseUnion_HeartbeatTxn) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.HeartbeatTxn != nil {
+		dAtA[i] = 0x62
 		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.PushTxn.Size()))
-		n185, err := m.PushTxn.MarshalTo(dAtA[i:])
+		i = encodeVarintApi(dAtA, i, uint64(m.HeartbeatTxn.Size()))
+		n185, err := m.HeartbeatTxn.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n185
 	}
+	return i, nil
+}
+func (m *ResponseUnion_Gc) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.Gc != nil {
+		dAtA[i] = 0x6a
+		i++
+		i = encodeVarintApi(dAtA, i, uint64(m.Gc.Size()))
+		n186, err := m.Gc.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n186
+	}
+	return i, nil
+}
+func (m *ResponseUnion_PushTxn) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.PushTxn != nil {
+		dAtA[i] = 0x72
+		i++
+		i = encodeVarintApi(dAtA, i, uint64(m.PushTxn.Size()))
+		n187, err := m.PushTxn.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n187
+	}
+	return i, nil
+}
+func (m *ResponseUnion_ResolveIntent) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.ResolveIntent != nil {
 		dAtA[i] = 0x82
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.ResolveIntent.Size()))
-		n186, err := m.ResolveIntent.MarshalTo(dAtA[i:])
+		n188, err := m.ResolveIntent.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n186
+		i += n188
 	}
+	return i, nil
+}
+func (m *ResponseUnion_ResolveIntentRange) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.ResolveIntentRange != nil {
 		dAtA[i] = 0x8a
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.ResolveIntentRange.Size()))
-		n187, err := m.ResolveIntentRange.MarshalTo(dAtA[i:])
+		n189, err := m.ResolveIntentRange.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n187
+		i += n189
 	}
+	return i, nil
+}
+func (m *ResponseUnion_Merge) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.Merge != nil {
 		dAtA[i] = 0x92
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.Merge.Size()))
-		n188, err := m.Merge.MarshalTo(dAtA[i:])
+		n190, err := m.Merge.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n188
+		i += n190
 	}
+	return i, nil
+}
+func (m *ResponseUnion_TruncateLog) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.TruncateLog != nil {
 		dAtA[i] = 0x9a
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.TruncateLog.Size()))
-		n189, err := m.TruncateLog.MarshalTo(dAtA[i:])
+		n191, err := m.TruncateLog.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n189
+		i += n191
 	}
+	return i, nil
+}
+func (m *ResponseUnion_RequestLease) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.RequestLease != nil {
 		dAtA[i] = 0xa2
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.RequestLease.Size()))
-		n190, err := m.RequestLease.MarshalTo(dAtA[i:])
+		n192, err := m.RequestLease.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n190
+		i += n192
 	}
+	return i, nil
+}
+func (m *ResponseUnion_ReverseScan) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.ReverseScan != nil {
 		dAtA[i] = 0xaa
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.ReverseScan.Size()))
-		n191, err := m.ReverseScan.MarshalTo(dAtA[i:])
+		n193, err := m.ReverseScan.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n191
+		i += n193
 	}
+	return i, nil
+}
+func (m *ResponseUnion_ComputeChecksum) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.ComputeChecksum != nil {
 		dAtA[i] = 0xb2
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.ComputeChecksum.Size()))
-		n192, err := m.ComputeChecksum.MarshalTo(dAtA[i:])
+		n194, err := m.ComputeChecksum.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n192
+		i += n194
 	}
+	return i, nil
+}
+func (m *ResponseUnion_CheckConsistency) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.CheckConsistency != nil {
 		dAtA[i] = 0xc2
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.CheckConsistency.Size()))
-		n193, err := m.CheckConsistency.MarshalTo(dAtA[i:])
+		n195, err := m.CheckConsistency.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n193
+		i += n195
 	}
+	return i, nil
+}
+func (m *ResponseUnion_Noop) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.Noop != nil {
 		dAtA[i] = 0xca
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.Noop.Size()))
-		n194, err := m.Noop.MarshalTo(dAtA[i:])
+		n196, err := m.Noop.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n194
+		i += n196
 	}
+	return i, nil
+}
+func (m *ResponseUnion_InitPut) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.InitPut != nil {
 		dAtA[i] = 0xd2
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.InitPut.Size()))
-		n195, err := m.InitPut.MarshalTo(dAtA[i:])
+		n197, err := m.InitPut.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n195
+		i += n197
 	}
+	return i, nil
+}
+func (m *ResponseUnion_AdminTransferLease) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.AdminTransferLease != nil {
 		dAtA[i] = 0xea
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.AdminTransferLease.Size()))
-		n196, err := m.AdminTransferLease.MarshalTo(dAtA[i:])
+		n198, err := m.AdminTransferLease.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n196
+		i += n198
 	}
+	return i, nil
+}
+func (m *ResponseUnion_LeaseInfo) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.LeaseInfo != nil {
 		dAtA[i] = 0xf2
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.LeaseInfo.Size()))
-		n197, err := m.LeaseInfo.MarshalTo(dAtA[i:])
+		n199, err := m.LeaseInfo.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n197
+		i += n199
 	}
+	return i, nil
+}
+func (m *ResponseUnion_WriteBatch) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.WriteBatch != nil {
 		dAtA[i] = 0xfa
 		i++
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.WriteBatch.Size()))
-		n198, err := m.WriteBatch.MarshalTo(dAtA[i:])
+		n200, err := m.WriteBatch.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n198
+		i += n200
 	}
+	return i, nil
+}
+func (m *ResponseUnion_Export) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.Export != nil {
 		dAtA[i] = 0x82
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.Export.Size()))
-		n199, err := m.Export.MarshalTo(dAtA[i:])
+		n201, err := m.Export.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n199
+		i += n201
 	}
+	return i, nil
+}
+func (m *ResponseUnion_QueryTxn) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.QueryTxn != nil {
 		dAtA[i] = 0x8a
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.QueryTxn.Size()))
-		n200, err := m.QueryTxn.MarshalTo(dAtA[i:])
+		n202, err := m.QueryTxn.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n200
+		i += n202
 	}
+	return i, nil
+}
+func (m *ResponseUnion_Import) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.Import != nil {
 		dAtA[i] = 0x92
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.Import.Size()))
-		n201, err := m.Import.MarshalTo(dAtA[i:])
+		n203, err := m.Import.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n201
+		i += n203
 	}
+	return i, nil
+}
+func (m *ResponseUnion_AdminChangeReplicas) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.AdminChangeReplicas != nil {
 		dAtA[i] = 0x9a
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.AdminChangeReplicas.Size()))
-		n202, err := m.AdminChangeReplicas.MarshalTo(dAtA[i:])
+		n204, err := m.AdminChangeReplicas.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n202
+		i += n204
 	}
+	return i, nil
+}
+func (m *ResponseUnion_AdminScatter) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.AdminScatter != nil {
 		dAtA[i] = 0xa2
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.AdminScatter.Size()))
-		n203, err := m.AdminScatter.MarshalTo(dAtA[i:])
+		n205, err := m.AdminScatter.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n203
+		i += n205
 	}
+	return i, nil
+}
+func (m *ResponseUnion_AddSstable) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.AddSstable != nil {
 		dAtA[i] = 0xaa
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.AddSstable.Size()))
-		n204, err := m.AddSstable.MarshalTo(dAtA[i:])
+		n206, err := m.AddSstable.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n204
+		i += n206
 	}
+	return i, nil
+}
+func (m *ResponseUnion_ClearRange) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.ClearRange != nil {
 		dAtA[i] = 0xb2
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.ClearRange.Size()))
-		n205, err := m.ClearRange.MarshalTo(dAtA[i:])
+		n207, err := m.ClearRange.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n205
+		i += n207
 	}
+	return i, nil
+}
+func (m *ResponseUnion_RecomputeStats) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.RecomputeStats != nil {
 		dAtA[i] = 0xba
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.RecomputeStats.Size()))
-		n206, err := m.RecomputeStats.MarshalTo(dAtA[i:])
+		n208, err := m.RecomputeStats.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n206
+		i += n208
 	}
+	return i, nil
+}
+func (m *ResponseUnion_Refresh) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.Refresh != nil {
 		dAtA[i] = 0xc2
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.Refresh.Size()))
-		n207, err := m.Refresh.MarshalTo(dAtA[i:])
+		n209, err := m.Refresh.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n207
+		i += n209
 	}
+	return i, nil
+}
+func (m *ResponseUnion_RefreshRange) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
 	if m.RefreshRange != nil {
 		dAtA[i] = 0xca
 		i++
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.RefreshRange.Size()))
-		n208, err := m.RefreshRange.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n208
-	}
-	if m.QueryIntent != nil {
-		dAtA[i] = 0xd2
-		i++
-		dAtA[i] = 0x2
-		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.QueryIntent.Size()))
-		n209, err := m.QueryIntent.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n209
-	}
-	if m.GetSnapshotForMerge != nil {
-		dAtA[i] = 0xda
-		i++
-		dAtA[i] = 0x2
-		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.GetSnapshotForMerge.Size()))
-		n210, err := m.GetSnapshotForMerge.MarshalTo(dAtA[i:])
+		n210, err := m.RefreshRange.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
@@ -8232,7 +11007,38 @@ func (m *ResponseUnion) MarshalTo(dAtA []byte) (int, error) {
 	}
 	return i, nil
 }
-
+func (m *ResponseUnion_QueryIntent) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.QueryIntent != nil {
+		dAtA[i] = 0xd2
+		i++
+		dAtA[i] = 0x2
+		i++
+		i = encodeVarintApi(dAtA, i, uint64(m.QueryIntent.Size()))
+		n211, err := m.QueryIntent.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n211
+	}
+	return i, nil
+}
+func (m *ResponseUnion_GetSnapshotForMerge) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.GetSnapshotForMerge != nil {
+		dAtA[i] = 0xda
+		i++
+		dAtA[i] = 0x2
+		i++
+		i = encodeVarintApi(dAtA, i, uint64(m.GetSnapshotForMerge.Size()))
+		n212, err := m.GetSnapshotForMerge.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n212
+	}
+	return i, nil
+}
 func (m *Header) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -8251,19 +11057,19 @@ func (m *Header) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintApi(dAtA, i, uint64(m.Timestamp.Size()))
-	n211, err := m.Timestamp.MarshalTo(dAtA[i:])
+	n213, err := m.Timestamp.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n211
+	i += n213
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintApi(dAtA, i, uint64(m.Replica.Size()))
-	n212, err := m.Replica.MarshalTo(dAtA[i:])
+	n214, err := m.Replica.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n212
+	i += n214
 	if m.RangeID != 0 {
 		dAtA[i] = 0x18
 		i++
@@ -8279,11 +11085,11 @@ func (m *Header) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x2a
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.Txn.Size()))
-		n213, err := m.Txn.MarshalTo(dAtA[i:])
+		n215, err := m.Txn.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n213
+		i += n215
 	}
 	if m.ReadConsistency != 0 {
 		dAtA[i] = 0x30
@@ -8324,11 +11130,11 @@ func (m *Header) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x62
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.ScanOptions.Size()))
-		n214, err := m.ScanOptions.MarshalTo(dAtA[i:])
+		n216, err := m.ScanOptions.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n214
+		i += n216
 	}
 	return i, nil
 }
@@ -8351,11 +11157,11 @@ func (m *BatchRequest) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintApi(dAtA, i, uint64(m.Header.Size()))
-	n215, err := m.Header.MarshalTo(dAtA[i:])
+	n217, err := m.Header.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n215
+	i += n217
 	if len(m.Requests) > 0 {
 		for _, msg := range m.Requests {
 			dAtA[i] = 0x12
@@ -8389,11 +11195,11 @@ func (m *BatchResponse) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintApi(dAtA, i, uint64(m.BatchResponse_Header.Size()))
-	n216, err := m.BatchResponse_Header.MarshalTo(dAtA[i:])
+	n218, err := m.BatchResponse_Header.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n216
+	i += n218
 	if len(m.Responses) > 0 {
 		for _, msg := range m.Responses {
 			dAtA[i] = 0x12
@@ -8428,38 +11234,38 @@ func (m *BatchResponse_Header) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintApi(dAtA, i, uint64(m.Error.Size()))
-		n217, err := m.Error.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n217
-	}
-	dAtA[i] = 0x12
-	i++
-	i = encodeVarintApi(dAtA, i, uint64(m.Timestamp.Size()))
-	n218, err := m.Timestamp.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n218
-	if m.Txn != nil {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintApi(dAtA, i, uint64(m.Txn.Size()))
-		n219, err := m.Txn.MarshalTo(dAtA[i:])
+		n219, err := m.Error.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n219
 	}
-	dAtA[i] = 0x2a
+	dAtA[i] = 0x12
 	i++
-	i = encodeVarintApi(dAtA, i, uint64(m.Now.Size()))
-	n220, err := m.Now.MarshalTo(dAtA[i:])
+	i = encodeVarintApi(dAtA, i, uint64(m.Timestamp.Size()))
+	n220, err := m.Timestamp.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n220
+	if m.Txn != nil {
+		dAtA[i] = 0x1a
+		i++
+		i = encodeVarintApi(dAtA, i, uint64(m.Txn.Size()))
+		n221, err := m.Txn.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n221
+	}
+	dAtA[i] = 0x2a
+	i++
+	i = encodeVarintApi(dAtA, i, uint64(m.Now.Size()))
+	n222, err := m.Now.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n222
 	if len(m.CollectedSpans) > 0 {
 		for _, msg := range m.CollectedSpans {
 			dAtA[i] = 0x32
@@ -9688,331 +12494,732 @@ func (m *GetSnapshotForMergeResponse) Size() (n int) {
 func (m *RequestUnion) Size() (n int) {
 	var l int
 	_ = l
-	if m.Get != nil {
-		l = m.Get.Size()
-		n += 1 + l + sovApi(uint64(l))
-	}
-	if m.Put != nil {
-		l = m.Put.Size()
-		n += 1 + l + sovApi(uint64(l))
-	}
-	if m.ConditionalPut != nil {
-		l = m.ConditionalPut.Size()
-		n += 1 + l + sovApi(uint64(l))
-	}
-	if m.Increment != nil {
-		l = m.Increment.Size()
-		n += 1 + l + sovApi(uint64(l))
-	}
-	if m.Delete != nil {
-		l = m.Delete.Size()
-		n += 1 + l + sovApi(uint64(l))
-	}
-	if m.DeleteRange != nil {
-		l = m.DeleteRange.Size()
-		n += 1 + l + sovApi(uint64(l))
-	}
-	if m.Scan != nil {
-		l = m.Scan.Size()
-		n += 1 + l + sovApi(uint64(l))
-	}
-	if m.BeginTransaction != nil {
-		l = m.BeginTransaction.Size()
-		n += 1 + l + sovApi(uint64(l))
-	}
-	if m.EndTransaction != nil {
-		l = m.EndTransaction.Size()
-		n += 1 + l + sovApi(uint64(l))
-	}
-	if m.AdminSplit != nil {
-		l = m.AdminSplit.Size()
-		n += 1 + l + sovApi(uint64(l))
-	}
-	if m.AdminMerge != nil {
-		l = m.AdminMerge.Size()
-		n += 1 + l + sovApi(uint64(l))
-	}
-	if m.HeartbeatTxn != nil {
-		l = m.HeartbeatTxn.Size()
-		n += 1 + l + sovApi(uint64(l))
-	}
-	if m.Gc != nil {
-		l = m.Gc.Size()
-		n += 1 + l + sovApi(uint64(l))
-	}
-	if m.PushTxn != nil {
-		l = m.PushTxn.Size()
-		n += 1 + l + sovApi(uint64(l))
-	}
-	if m.ResolveIntent != nil {
-		l = m.ResolveIntent.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.ResolveIntentRange != nil {
-		l = m.ResolveIntentRange.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.Merge != nil {
-		l = m.Merge.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.TruncateLog != nil {
-		l = m.TruncateLog.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.RequestLease != nil {
-		l = m.RequestLease.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.ReverseScan != nil {
-		l = m.ReverseScan.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.ComputeChecksum != nil {
-		l = m.ComputeChecksum.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.CheckConsistency != nil {
-		l = m.CheckConsistency.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.Noop != nil {
-		l = m.Noop.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.InitPut != nil {
-		l = m.InitPut.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.TransferLease != nil {
-		l = m.TransferLease.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.AdminTransferLease != nil {
-		l = m.AdminTransferLease.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.LeaseInfo != nil {
-		l = m.LeaseInfo.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.WriteBatch != nil {
-		l = m.WriteBatch.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.Export != nil {
-		l = m.Export.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.QueryTxn != nil {
-		l = m.QueryTxn.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.Import != nil {
-		l = m.Import.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.AdminChangeReplicas != nil {
-		l = m.AdminChangeReplicas.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.AdminScatter != nil {
-		l = m.AdminScatter.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.AddSstable != nil {
-		l = m.AddSstable.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.ClearRange != nil {
-		l = m.ClearRange.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.RecomputeStats != nil {
-		l = m.RecomputeStats.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.Refresh != nil {
-		l = m.Refresh.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.RefreshRange != nil {
-		l = m.RefreshRange.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.QueryIntent != nil {
-		l = m.QueryIntent.Size()
-		n += 2 + l + sovApi(uint64(l))
-	}
-	if m.GetSnapshotForMerge != nil {
-		l = m.GetSnapshotForMerge.Size()
-		n += 2 + l + sovApi(uint64(l))
+	if m.Value != nil {
+		n += m.Value.Size()
 	}
 	return n
 }
 
-func (m *ResponseUnion) Size() (n int) {
+func (m *RequestUnion_Get) Size() (n int) {
 	var l int
 	_ = l
 	if m.Get != nil {
 		l = m.Get.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_Put) Size() (n int) {
+	var l int
+	_ = l
 	if m.Put != nil {
 		l = m.Put.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_ConditionalPut) Size() (n int) {
+	var l int
+	_ = l
 	if m.ConditionalPut != nil {
 		l = m.ConditionalPut.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_Increment) Size() (n int) {
+	var l int
+	_ = l
 	if m.Increment != nil {
 		l = m.Increment.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_Delete) Size() (n int) {
+	var l int
+	_ = l
 	if m.Delete != nil {
 		l = m.Delete.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_DeleteRange) Size() (n int) {
+	var l int
+	_ = l
 	if m.DeleteRange != nil {
 		l = m.DeleteRange.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_Scan) Size() (n int) {
+	var l int
+	_ = l
 	if m.Scan != nil {
 		l = m.Scan.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_BeginTransaction) Size() (n int) {
+	var l int
+	_ = l
 	if m.BeginTransaction != nil {
 		l = m.BeginTransaction.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_EndTransaction) Size() (n int) {
+	var l int
+	_ = l
 	if m.EndTransaction != nil {
 		l = m.EndTransaction.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_AdminSplit) Size() (n int) {
+	var l int
+	_ = l
 	if m.AdminSplit != nil {
 		l = m.AdminSplit.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_AdminMerge) Size() (n int) {
+	var l int
+	_ = l
 	if m.AdminMerge != nil {
 		l = m.AdminMerge.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_HeartbeatTxn) Size() (n int) {
+	var l int
+	_ = l
 	if m.HeartbeatTxn != nil {
 		l = m.HeartbeatTxn.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_Gc) Size() (n int) {
+	var l int
+	_ = l
 	if m.Gc != nil {
 		l = m.Gc.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_PushTxn) Size() (n int) {
+	var l int
+	_ = l
 	if m.PushTxn != nil {
 		l = m.PushTxn.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_ResolveIntent) Size() (n int) {
+	var l int
+	_ = l
 	if m.ResolveIntent != nil {
 		l = m.ResolveIntent.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_ResolveIntentRange) Size() (n int) {
+	var l int
+	_ = l
 	if m.ResolveIntentRange != nil {
 		l = m.ResolveIntentRange.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_Merge) Size() (n int) {
+	var l int
+	_ = l
 	if m.Merge != nil {
 		l = m.Merge.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_TruncateLog) Size() (n int) {
+	var l int
+	_ = l
 	if m.TruncateLog != nil {
 		l = m.TruncateLog.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_RequestLease) Size() (n int) {
+	var l int
+	_ = l
 	if m.RequestLease != nil {
 		l = m.RequestLease.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_ReverseScan) Size() (n int) {
+	var l int
+	_ = l
 	if m.ReverseScan != nil {
 		l = m.ReverseScan.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_ComputeChecksum) Size() (n int) {
+	var l int
+	_ = l
 	if m.ComputeChecksum != nil {
 		l = m.ComputeChecksum.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_CheckConsistency) Size() (n int) {
+	var l int
+	_ = l
 	if m.CheckConsistency != nil {
 		l = m.CheckConsistency.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_Noop) Size() (n int) {
+	var l int
+	_ = l
 	if m.Noop != nil {
 		l = m.Noop.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_InitPut) Size() (n int) {
+	var l int
+	_ = l
 	if m.InitPut != nil {
 		l = m.InitPut.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_TransferLease) Size() (n int) {
+	var l int
+	_ = l
+	if m.TransferLease != nil {
+		l = m.TransferLease.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *RequestUnion_AdminTransferLease) Size() (n int) {
+	var l int
+	_ = l
 	if m.AdminTransferLease != nil {
 		l = m.AdminTransferLease.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_LeaseInfo) Size() (n int) {
+	var l int
+	_ = l
 	if m.LeaseInfo != nil {
 		l = m.LeaseInfo.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_WriteBatch) Size() (n int) {
+	var l int
+	_ = l
 	if m.WriteBatch != nil {
 		l = m.WriteBatch.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_Export) Size() (n int) {
+	var l int
+	_ = l
 	if m.Export != nil {
 		l = m.Export.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_QueryTxn) Size() (n int) {
+	var l int
+	_ = l
 	if m.QueryTxn != nil {
 		l = m.QueryTxn.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_Import) Size() (n int) {
+	var l int
+	_ = l
 	if m.Import != nil {
 		l = m.Import.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_AdminChangeReplicas) Size() (n int) {
+	var l int
+	_ = l
 	if m.AdminChangeReplicas != nil {
 		l = m.AdminChangeReplicas.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_AdminScatter) Size() (n int) {
+	var l int
+	_ = l
 	if m.AdminScatter != nil {
 		l = m.AdminScatter.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_AddSstable) Size() (n int) {
+	var l int
+	_ = l
 	if m.AddSstable != nil {
 		l = m.AddSstable.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_ClearRange) Size() (n int) {
+	var l int
+	_ = l
 	if m.ClearRange != nil {
 		l = m.ClearRange.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_RecomputeStats) Size() (n int) {
+	var l int
+	_ = l
 	if m.RecomputeStats != nil {
 		l = m.RecomputeStats.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_Refresh) Size() (n int) {
+	var l int
+	_ = l
 	if m.Refresh != nil {
 		l = m.Refresh.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_RefreshRange) Size() (n int) {
+	var l int
+	_ = l
 	if m.RefreshRange != nil {
 		l = m.RefreshRange.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_QueryIntent) Size() (n int) {
+	var l int
+	_ = l
 	if m.QueryIntent != nil {
 		l = m.QueryIntent.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	return n
+}
+func (m *RequestUnion_GetSnapshotForMerge) Size() (n int) {
+	var l int
+	_ = l
 	if m.GetSnapshotForMerge != nil {
 		l = m.GetSnapshotForMerge.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
 	return n
 }
+func (m *ResponseUnion) Size() (n int) {
+	var l int
+	_ = l
+	if m.Value != nil {
+		n += m.Value.Size()
+	}
+	return n
+}
 
+func (m *ResponseUnion_Get) Size() (n int) {
+	var l int
+	_ = l
+	if m.Get != nil {
+		l = m.Get.Size()
+		n += 1 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_Put) Size() (n int) {
+	var l int
+	_ = l
+	if m.Put != nil {
+		l = m.Put.Size()
+		n += 1 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_ConditionalPut) Size() (n int) {
+	var l int
+	_ = l
+	if m.ConditionalPut != nil {
+		l = m.ConditionalPut.Size()
+		n += 1 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_Increment) Size() (n int) {
+	var l int
+	_ = l
+	if m.Increment != nil {
+		l = m.Increment.Size()
+		n += 1 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_Delete) Size() (n int) {
+	var l int
+	_ = l
+	if m.Delete != nil {
+		l = m.Delete.Size()
+		n += 1 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_DeleteRange) Size() (n int) {
+	var l int
+	_ = l
+	if m.DeleteRange != nil {
+		l = m.DeleteRange.Size()
+		n += 1 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_Scan) Size() (n int) {
+	var l int
+	_ = l
+	if m.Scan != nil {
+		l = m.Scan.Size()
+		n += 1 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_BeginTransaction) Size() (n int) {
+	var l int
+	_ = l
+	if m.BeginTransaction != nil {
+		l = m.BeginTransaction.Size()
+		n += 1 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_EndTransaction) Size() (n int) {
+	var l int
+	_ = l
+	if m.EndTransaction != nil {
+		l = m.EndTransaction.Size()
+		n += 1 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_AdminSplit) Size() (n int) {
+	var l int
+	_ = l
+	if m.AdminSplit != nil {
+		l = m.AdminSplit.Size()
+		n += 1 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_AdminMerge) Size() (n int) {
+	var l int
+	_ = l
+	if m.AdminMerge != nil {
+		l = m.AdminMerge.Size()
+		n += 1 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_HeartbeatTxn) Size() (n int) {
+	var l int
+	_ = l
+	if m.HeartbeatTxn != nil {
+		l = m.HeartbeatTxn.Size()
+		n += 1 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_Gc) Size() (n int) {
+	var l int
+	_ = l
+	if m.Gc != nil {
+		l = m.Gc.Size()
+		n += 1 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_PushTxn) Size() (n int) {
+	var l int
+	_ = l
+	if m.PushTxn != nil {
+		l = m.PushTxn.Size()
+		n += 1 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_ResolveIntent) Size() (n int) {
+	var l int
+	_ = l
+	if m.ResolveIntent != nil {
+		l = m.ResolveIntent.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_ResolveIntentRange) Size() (n int) {
+	var l int
+	_ = l
+	if m.ResolveIntentRange != nil {
+		l = m.ResolveIntentRange.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_Merge) Size() (n int) {
+	var l int
+	_ = l
+	if m.Merge != nil {
+		l = m.Merge.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_TruncateLog) Size() (n int) {
+	var l int
+	_ = l
+	if m.TruncateLog != nil {
+		l = m.TruncateLog.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_RequestLease) Size() (n int) {
+	var l int
+	_ = l
+	if m.RequestLease != nil {
+		l = m.RequestLease.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_ReverseScan) Size() (n int) {
+	var l int
+	_ = l
+	if m.ReverseScan != nil {
+		l = m.ReverseScan.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_ComputeChecksum) Size() (n int) {
+	var l int
+	_ = l
+	if m.ComputeChecksum != nil {
+		l = m.ComputeChecksum.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_CheckConsistency) Size() (n int) {
+	var l int
+	_ = l
+	if m.CheckConsistency != nil {
+		l = m.CheckConsistency.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_Noop) Size() (n int) {
+	var l int
+	_ = l
+	if m.Noop != nil {
+		l = m.Noop.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_InitPut) Size() (n int) {
+	var l int
+	_ = l
+	if m.InitPut != nil {
+		l = m.InitPut.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_AdminTransferLease) Size() (n int) {
+	var l int
+	_ = l
+	if m.AdminTransferLease != nil {
+		l = m.AdminTransferLease.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_LeaseInfo) Size() (n int) {
+	var l int
+	_ = l
+	if m.LeaseInfo != nil {
+		l = m.LeaseInfo.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_WriteBatch) Size() (n int) {
+	var l int
+	_ = l
+	if m.WriteBatch != nil {
+		l = m.WriteBatch.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_Export) Size() (n int) {
+	var l int
+	_ = l
+	if m.Export != nil {
+		l = m.Export.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_QueryTxn) Size() (n int) {
+	var l int
+	_ = l
+	if m.QueryTxn != nil {
+		l = m.QueryTxn.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_Import) Size() (n int) {
+	var l int
+	_ = l
+	if m.Import != nil {
+		l = m.Import.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_AdminChangeReplicas) Size() (n int) {
+	var l int
+	_ = l
+	if m.AdminChangeReplicas != nil {
+		l = m.AdminChangeReplicas.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_AdminScatter) Size() (n int) {
+	var l int
+	_ = l
+	if m.AdminScatter != nil {
+		l = m.AdminScatter.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_AddSstable) Size() (n int) {
+	var l int
+	_ = l
+	if m.AddSstable != nil {
+		l = m.AddSstable.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_ClearRange) Size() (n int) {
+	var l int
+	_ = l
+	if m.ClearRange != nil {
+		l = m.ClearRange.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_RecomputeStats) Size() (n int) {
+	var l int
+	_ = l
+	if m.RecomputeStats != nil {
+		l = m.RecomputeStats.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_Refresh) Size() (n int) {
+	var l int
+	_ = l
+	if m.Refresh != nil {
+		l = m.Refresh.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_RefreshRange) Size() (n int) {
+	var l int
+	_ = l
+	if m.RefreshRange != nil {
+		l = m.RefreshRange.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_QueryIntent) Size() (n int) {
+	var l int
+	_ = l
+	if m.QueryIntent != nil {
+		l = m.QueryIntent.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
+func (m *ResponseUnion_GetSnapshotForMerge) Size() (n int) {
+	var l int
+	_ = l
+	if m.GetSnapshotForMerge != nil {
+		l = m.GetSnapshotForMerge.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	return n
+}
 func (m *Header) Size() (n int) {
 	var l int
 	_ = l
@@ -10116,423 +13323,6 @@ func sovApi(x uint64) (n int) {
 }
 func sozApi(x uint64) (n int) {
 	return sovApi(uint64((x << 1) ^ uint64((int64(x) >> 63))))
-}
-func (this *RequestUnion) GetValue() interface{} {
-	if this.Get != nil {
-		return this.Get
-	}
-	if this.Put != nil {
-		return this.Put
-	}
-	if this.ConditionalPut != nil {
-		return this.ConditionalPut
-	}
-	if this.Increment != nil {
-		return this.Increment
-	}
-	if this.Delete != nil {
-		return this.Delete
-	}
-	if this.DeleteRange != nil {
-		return this.DeleteRange
-	}
-	if this.Scan != nil {
-		return this.Scan
-	}
-	if this.BeginTransaction != nil {
-		return this.BeginTransaction
-	}
-	if this.EndTransaction != nil {
-		return this.EndTransaction
-	}
-	if this.AdminSplit != nil {
-		return this.AdminSplit
-	}
-	if this.AdminMerge != nil {
-		return this.AdminMerge
-	}
-	if this.HeartbeatTxn != nil {
-		return this.HeartbeatTxn
-	}
-	if this.Gc != nil {
-		return this.Gc
-	}
-	if this.PushTxn != nil {
-		return this.PushTxn
-	}
-	if this.ResolveIntent != nil {
-		return this.ResolveIntent
-	}
-	if this.ResolveIntentRange != nil {
-		return this.ResolveIntentRange
-	}
-	if this.Merge != nil {
-		return this.Merge
-	}
-	if this.TruncateLog != nil {
-		return this.TruncateLog
-	}
-	if this.RequestLease != nil {
-		return this.RequestLease
-	}
-	if this.ReverseScan != nil {
-		return this.ReverseScan
-	}
-	if this.ComputeChecksum != nil {
-		return this.ComputeChecksum
-	}
-	if this.CheckConsistency != nil {
-		return this.CheckConsistency
-	}
-	if this.Noop != nil {
-		return this.Noop
-	}
-	if this.InitPut != nil {
-		return this.InitPut
-	}
-	if this.TransferLease != nil {
-		return this.TransferLease
-	}
-	if this.AdminTransferLease != nil {
-		return this.AdminTransferLease
-	}
-	if this.LeaseInfo != nil {
-		return this.LeaseInfo
-	}
-	if this.WriteBatch != nil {
-		return this.WriteBatch
-	}
-	if this.Export != nil {
-		return this.Export
-	}
-	if this.QueryTxn != nil {
-		return this.QueryTxn
-	}
-	if this.Import != nil {
-		return this.Import
-	}
-	if this.AdminChangeReplicas != nil {
-		return this.AdminChangeReplicas
-	}
-	if this.AdminScatter != nil {
-		return this.AdminScatter
-	}
-	if this.AddSstable != nil {
-		return this.AddSstable
-	}
-	if this.ClearRange != nil {
-		return this.ClearRange
-	}
-	if this.RecomputeStats != nil {
-		return this.RecomputeStats
-	}
-	if this.Refresh != nil {
-		return this.Refresh
-	}
-	if this.RefreshRange != nil {
-		return this.RefreshRange
-	}
-	if this.QueryIntent != nil {
-		return this.QueryIntent
-	}
-	if this.GetSnapshotForMerge != nil {
-		return this.GetSnapshotForMerge
-	}
-	return nil
-}
-
-func (this *RequestUnion) SetValue(value interface{}) bool {
-	switch vt := value.(type) {
-	case *GetRequest:
-		this.Get = vt
-	case *PutRequest:
-		this.Put = vt
-	case *ConditionalPutRequest:
-		this.ConditionalPut = vt
-	case *IncrementRequest:
-		this.Increment = vt
-	case *DeleteRequest:
-		this.Delete = vt
-	case *DeleteRangeRequest:
-		this.DeleteRange = vt
-	case *ScanRequest:
-		this.Scan = vt
-	case *BeginTransactionRequest:
-		this.BeginTransaction = vt
-	case *EndTransactionRequest:
-		this.EndTransaction = vt
-	case *AdminSplitRequest:
-		this.AdminSplit = vt
-	case *AdminMergeRequest:
-		this.AdminMerge = vt
-	case *HeartbeatTxnRequest:
-		this.HeartbeatTxn = vt
-	case *GCRequest:
-		this.Gc = vt
-	case *PushTxnRequest:
-		this.PushTxn = vt
-	case *ResolveIntentRequest:
-		this.ResolveIntent = vt
-	case *ResolveIntentRangeRequest:
-		this.ResolveIntentRange = vt
-	case *MergeRequest:
-		this.Merge = vt
-	case *TruncateLogRequest:
-		this.TruncateLog = vt
-	case *RequestLeaseRequest:
-		this.RequestLease = vt
-	case *ReverseScanRequest:
-		this.ReverseScan = vt
-	case *ComputeChecksumRequest:
-		this.ComputeChecksum = vt
-	case *CheckConsistencyRequest:
-		this.CheckConsistency = vt
-	case *NoopRequest:
-		this.Noop = vt
-	case *InitPutRequest:
-		this.InitPut = vt
-	case *TransferLeaseRequest:
-		this.TransferLease = vt
-	case *AdminTransferLeaseRequest:
-		this.AdminTransferLease = vt
-	case *LeaseInfoRequest:
-		this.LeaseInfo = vt
-	case *WriteBatchRequest:
-		this.WriteBatch = vt
-	case *ExportRequest:
-		this.Export = vt
-	case *QueryTxnRequest:
-		this.QueryTxn = vt
-	case *ImportRequest:
-		this.Import = vt
-	case *AdminChangeReplicasRequest:
-		this.AdminChangeReplicas = vt
-	case *AdminScatterRequest:
-		this.AdminScatter = vt
-	case *AddSSTableRequest:
-		this.AddSstable = vt
-	case *ClearRangeRequest:
-		this.ClearRange = vt
-	case *RecomputeStatsRequest:
-		this.RecomputeStats = vt
-	case *RefreshRequest:
-		this.Refresh = vt
-	case *RefreshRangeRequest:
-		this.RefreshRange = vt
-	case *QueryIntentRequest:
-		this.QueryIntent = vt
-	case *GetSnapshotForMergeRequest:
-		this.GetSnapshotForMerge = vt
-	default:
-		return false
-	}
-	return true
-}
-func (this *ResponseUnion) GetValue() interface{} {
-	if this.Get != nil {
-		return this.Get
-	}
-	if this.Put != nil {
-		return this.Put
-	}
-	if this.ConditionalPut != nil {
-		return this.ConditionalPut
-	}
-	if this.Increment != nil {
-		return this.Increment
-	}
-	if this.Delete != nil {
-		return this.Delete
-	}
-	if this.DeleteRange != nil {
-		return this.DeleteRange
-	}
-	if this.Scan != nil {
-		return this.Scan
-	}
-	if this.BeginTransaction != nil {
-		return this.BeginTransaction
-	}
-	if this.EndTransaction != nil {
-		return this.EndTransaction
-	}
-	if this.AdminSplit != nil {
-		return this.AdminSplit
-	}
-	if this.AdminMerge != nil {
-		return this.AdminMerge
-	}
-	if this.HeartbeatTxn != nil {
-		return this.HeartbeatTxn
-	}
-	if this.Gc != nil {
-		return this.Gc
-	}
-	if this.PushTxn != nil {
-		return this.PushTxn
-	}
-	if this.ResolveIntent != nil {
-		return this.ResolveIntent
-	}
-	if this.ResolveIntentRange != nil {
-		return this.ResolveIntentRange
-	}
-	if this.Merge != nil {
-		return this.Merge
-	}
-	if this.TruncateLog != nil {
-		return this.TruncateLog
-	}
-	if this.RequestLease != nil {
-		return this.RequestLease
-	}
-	if this.ReverseScan != nil {
-		return this.ReverseScan
-	}
-	if this.ComputeChecksum != nil {
-		return this.ComputeChecksum
-	}
-	if this.CheckConsistency != nil {
-		return this.CheckConsistency
-	}
-	if this.Noop != nil {
-		return this.Noop
-	}
-	if this.InitPut != nil {
-		return this.InitPut
-	}
-	if this.AdminTransferLease != nil {
-		return this.AdminTransferLease
-	}
-	if this.LeaseInfo != nil {
-		return this.LeaseInfo
-	}
-	if this.WriteBatch != nil {
-		return this.WriteBatch
-	}
-	if this.Export != nil {
-		return this.Export
-	}
-	if this.QueryTxn != nil {
-		return this.QueryTxn
-	}
-	if this.Import != nil {
-		return this.Import
-	}
-	if this.AdminChangeReplicas != nil {
-		return this.AdminChangeReplicas
-	}
-	if this.AdminScatter != nil {
-		return this.AdminScatter
-	}
-	if this.AddSstable != nil {
-		return this.AddSstable
-	}
-	if this.ClearRange != nil {
-		return this.ClearRange
-	}
-	if this.RecomputeStats != nil {
-		return this.RecomputeStats
-	}
-	if this.Refresh != nil {
-		return this.Refresh
-	}
-	if this.RefreshRange != nil {
-		return this.RefreshRange
-	}
-	if this.QueryIntent != nil {
-		return this.QueryIntent
-	}
-	if this.GetSnapshotForMerge != nil {
-		return this.GetSnapshotForMerge
-	}
-	return nil
-}
-
-func (this *ResponseUnion) SetValue(value interface{}) bool {
-	switch vt := value.(type) {
-	case *GetResponse:
-		this.Get = vt
-	case *PutResponse:
-		this.Put = vt
-	case *ConditionalPutResponse:
-		this.ConditionalPut = vt
-	case *IncrementResponse:
-		this.Increment = vt
-	case *DeleteResponse:
-		this.Delete = vt
-	case *DeleteRangeResponse:
-		this.DeleteRange = vt
-	case *ScanResponse:
-		this.Scan = vt
-	case *BeginTransactionResponse:
-		this.BeginTransaction = vt
-	case *EndTransactionResponse:
-		this.EndTransaction = vt
-	case *AdminSplitResponse:
-		this.AdminSplit = vt
-	case *AdminMergeResponse:
-		this.AdminMerge = vt
-	case *HeartbeatTxnResponse:
-		this.HeartbeatTxn = vt
-	case *GCResponse:
-		this.Gc = vt
-	case *PushTxnResponse:
-		this.PushTxn = vt
-	case *ResolveIntentResponse:
-		this.ResolveIntent = vt
-	case *ResolveIntentRangeResponse:
-		this.ResolveIntentRange = vt
-	case *MergeResponse:
-		this.Merge = vt
-	case *TruncateLogResponse:
-		this.TruncateLog = vt
-	case *RequestLeaseResponse:
-		this.RequestLease = vt
-	case *ReverseScanResponse:
-		this.ReverseScan = vt
-	case *ComputeChecksumResponse:
-		this.ComputeChecksum = vt
-	case *CheckConsistencyResponse:
-		this.CheckConsistency = vt
-	case *NoopResponse:
-		this.Noop = vt
-	case *InitPutResponse:
-		this.InitPut = vt
-	case *AdminTransferLeaseResponse:
-		this.AdminTransferLease = vt
-	case *LeaseInfoResponse:
-		this.LeaseInfo = vt
-	case *WriteBatchResponse:
-		this.WriteBatch = vt
-	case *ExportResponse:
-		this.Export = vt
-	case *QueryTxnResponse:
-		this.QueryTxn = vt
-	case *ImportResponse:
-		this.Import = vt
-	case *AdminChangeReplicasResponse:
-		this.AdminChangeReplicas = vt
-	case *AdminScatterResponse:
-		this.AdminScatter = vt
-	case *AddSSTableResponse:
-		this.AddSstable = vt
-	case *ClearRangeResponse:
-		this.ClearRange = vt
-	case *RecomputeStatsResponse:
-		this.RecomputeStats = vt
-	case *RefreshResponse:
-		this.Refresh = vt
-	case *RefreshRangeResponse:
-		this.RefreshRange = vt
-	case *QueryIntentResponse:
-		this.QueryIntent = vt
-	case *GetSnapshotForMergeResponse:
-		this.GetSnapshotForMerge = vt
-	default:
-		return false
-	}
-	return true
 }
 func (m *RangeInfo) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
@@ -21548,12 +24338,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Get == nil {
-				m.Get = &GetRequest{}
-			}
-			if err := m.Get.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &GetRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_Get{v}
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
@@ -21581,12 +24370,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Put == nil {
-				m.Put = &PutRequest{}
-			}
-			if err := m.Put.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &PutRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_Put{v}
 			iNdEx = postIndex
 		case 3:
 			if wireType != 2 {
@@ -21614,12 +24402,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.ConditionalPut == nil {
-				m.ConditionalPut = &ConditionalPutRequest{}
-			}
-			if err := m.ConditionalPut.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &ConditionalPutRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_ConditionalPut{v}
 			iNdEx = postIndex
 		case 4:
 			if wireType != 2 {
@@ -21647,12 +24434,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Increment == nil {
-				m.Increment = &IncrementRequest{}
-			}
-			if err := m.Increment.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &IncrementRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_Increment{v}
 			iNdEx = postIndex
 		case 5:
 			if wireType != 2 {
@@ -21680,12 +24466,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Delete == nil {
-				m.Delete = &DeleteRequest{}
-			}
-			if err := m.Delete.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &DeleteRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_Delete{v}
 			iNdEx = postIndex
 		case 6:
 			if wireType != 2 {
@@ -21713,12 +24498,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.DeleteRange == nil {
-				m.DeleteRange = &DeleteRangeRequest{}
-			}
-			if err := m.DeleteRange.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &DeleteRangeRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_DeleteRange{v}
 			iNdEx = postIndex
 		case 7:
 			if wireType != 2 {
@@ -21746,12 +24530,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Scan == nil {
-				m.Scan = &ScanRequest{}
-			}
-			if err := m.Scan.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &ScanRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_Scan{v}
 			iNdEx = postIndex
 		case 8:
 			if wireType != 2 {
@@ -21779,12 +24562,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.BeginTransaction == nil {
-				m.BeginTransaction = &BeginTransactionRequest{}
-			}
-			if err := m.BeginTransaction.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &BeginTransactionRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_BeginTransaction{v}
 			iNdEx = postIndex
 		case 9:
 			if wireType != 2 {
@@ -21812,12 +24594,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.EndTransaction == nil {
-				m.EndTransaction = &EndTransactionRequest{}
-			}
-			if err := m.EndTransaction.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &EndTransactionRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_EndTransaction{v}
 			iNdEx = postIndex
 		case 10:
 			if wireType != 2 {
@@ -21845,12 +24626,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.AdminSplit == nil {
-				m.AdminSplit = &AdminSplitRequest{}
-			}
-			if err := m.AdminSplit.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &AdminSplitRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_AdminSplit{v}
 			iNdEx = postIndex
 		case 11:
 			if wireType != 2 {
@@ -21878,12 +24658,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.AdminMerge == nil {
-				m.AdminMerge = &AdminMergeRequest{}
-			}
-			if err := m.AdminMerge.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &AdminMergeRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_AdminMerge{v}
 			iNdEx = postIndex
 		case 12:
 			if wireType != 2 {
@@ -21911,12 +24690,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.HeartbeatTxn == nil {
-				m.HeartbeatTxn = &HeartbeatTxnRequest{}
-			}
-			if err := m.HeartbeatTxn.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &HeartbeatTxnRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_HeartbeatTxn{v}
 			iNdEx = postIndex
 		case 13:
 			if wireType != 2 {
@@ -21944,12 +24722,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Gc == nil {
-				m.Gc = &GCRequest{}
-			}
-			if err := m.Gc.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &GCRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_Gc{v}
 			iNdEx = postIndex
 		case 14:
 			if wireType != 2 {
@@ -21977,12 +24754,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.PushTxn == nil {
-				m.PushTxn = &PushTxnRequest{}
-			}
-			if err := m.PushTxn.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &PushTxnRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_PushTxn{v}
 			iNdEx = postIndex
 		case 16:
 			if wireType != 2 {
@@ -22010,12 +24786,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.ResolveIntent == nil {
-				m.ResolveIntent = &ResolveIntentRequest{}
-			}
-			if err := m.ResolveIntent.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &ResolveIntentRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_ResolveIntent{v}
 			iNdEx = postIndex
 		case 17:
 			if wireType != 2 {
@@ -22043,12 +24818,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.ResolveIntentRange == nil {
-				m.ResolveIntentRange = &ResolveIntentRangeRequest{}
-			}
-			if err := m.ResolveIntentRange.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &ResolveIntentRangeRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_ResolveIntentRange{v}
 			iNdEx = postIndex
 		case 18:
 			if wireType != 2 {
@@ -22076,12 +24850,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Merge == nil {
-				m.Merge = &MergeRequest{}
-			}
-			if err := m.Merge.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &MergeRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_Merge{v}
 			iNdEx = postIndex
 		case 19:
 			if wireType != 2 {
@@ -22109,12 +24882,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.TruncateLog == nil {
-				m.TruncateLog = &TruncateLogRequest{}
-			}
-			if err := m.TruncateLog.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &TruncateLogRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_TruncateLog{v}
 			iNdEx = postIndex
 		case 20:
 			if wireType != 2 {
@@ -22142,12 +24914,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.RequestLease == nil {
-				m.RequestLease = &RequestLeaseRequest{}
-			}
-			if err := m.RequestLease.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &RequestLeaseRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_RequestLease{v}
 			iNdEx = postIndex
 		case 21:
 			if wireType != 2 {
@@ -22175,12 +24946,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.ReverseScan == nil {
-				m.ReverseScan = &ReverseScanRequest{}
-			}
-			if err := m.ReverseScan.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &ReverseScanRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_ReverseScan{v}
 			iNdEx = postIndex
 		case 22:
 			if wireType != 2 {
@@ -22208,12 +24978,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.ComputeChecksum == nil {
-				m.ComputeChecksum = &ComputeChecksumRequest{}
-			}
-			if err := m.ComputeChecksum.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &ComputeChecksumRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_ComputeChecksum{v}
 			iNdEx = postIndex
 		case 24:
 			if wireType != 2 {
@@ -22241,12 +25010,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.CheckConsistency == nil {
-				m.CheckConsistency = &CheckConsistencyRequest{}
-			}
-			if err := m.CheckConsistency.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &CheckConsistencyRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_CheckConsistency{v}
 			iNdEx = postIndex
 		case 25:
 			if wireType != 2 {
@@ -22274,12 +25042,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Noop == nil {
-				m.Noop = &NoopRequest{}
-			}
-			if err := m.Noop.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &NoopRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_Noop{v}
 			iNdEx = postIndex
 		case 26:
 			if wireType != 2 {
@@ -22307,12 +25074,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.InitPut == nil {
-				m.InitPut = &InitPutRequest{}
-			}
-			if err := m.InitPut.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &InitPutRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_InitPut{v}
 			iNdEx = postIndex
 		case 28:
 			if wireType != 2 {
@@ -22340,12 +25106,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.TransferLease == nil {
-				m.TransferLease = &TransferLeaseRequest{}
-			}
-			if err := m.TransferLease.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &TransferLeaseRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_TransferLease{v}
 			iNdEx = postIndex
 		case 29:
 			if wireType != 2 {
@@ -22373,12 +25138,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.AdminTransferLease == nil {
-				m.AdminTransferLease = &AdminTransferLeaseRequest{}
-			}
-			if err := m.AdminTransferLease.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &AdminTransferLeaseRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_AdminTransferLease{v}
 			iNdEx = postIndex
 		case 30:
 			if wireType != 2 {
@@ -22406,12 +25170,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.LeaseInfo == nil {
-				m.LeaseInfo = &LeaseInfoRequest{}
-			}
-			if err := m.LeaseInfo.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &LeaseInfoRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_LeaseInfo{v}
 			iNdEx = postIndex
 		case 31:
 			if wireType != 2 {
@@ -22439,12 +25202,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.WriteBatch == nil {
-				m.WriteBatch = &WriteBatchRequest{}
-			}
-			if err := m.WriteBatch.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &WriteBatchRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_WriteBatch{v}
 			iNdEx = postIndex
 		case 32:
 			if wireType != 2 {
@@ -22472,12 +25234,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Export == nil {
-				m.Export = &ExportRequest{}
-			}
-			if err := m.Export.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &ExportRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_Export{v}
 			iNdEx = postIndex
 		case 33:
 			if wireType != 2 {
@@ -22505,12 +25266,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.QueryTxn == nil {
-				m.QueryTxn = &QueryTxnRequest{}
-			}
-			if err := m.QueryTxn.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &QueryTxnRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_QueryTxn{v}
 			iNdEx = postIndex
 		case 34:
 			if wireType != 2 {
@@ -22538,12 +25298,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Import == nil {
-				m.Import = &ImportRequest{}
-			}
-			if err := m.Import.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &ImportRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_Import{v}
 			iNdEx = postIndex
 		case 35:
 			if wireType != 2 {
@@ -22571,12 +25330,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.AdminChangeReplicas == nil {
-				m.AdminChangeReplicas = &AdminChangeReplicasRequest{}
-			}
-			if err := m.AdminChangeReplicas.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &AdminChangeReplicasRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_AdminChangeReplicas{v}
 			iNdEx = postIndex
 		case 36:
 			if wireType != 2 {
@@ -22604,12 +25362,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.AdminScatter == nil {
-				m.AdminScatter = &AdminScatterRequest{}
-			}
-			if err := m.AdminScatter.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &AdminScatterRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_AdminScatter{v}
 			iNdEx = postIndex
 		case 37:
 			if wireType != 2 {
@@ -22637,12 +25394,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.AddSstable == nil {
-				m.AddSstable = &AddSSTableRequest{}
-			}
-			if err := m.AddSstable.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &AddSSTableRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_AddSstable{v}
 			iNdEx = postIndex
 		case 38:
 			if wireType != 2 {
@@ -22670,12 +25426,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.ClearRange == nil {
-				m.ClearRange = &ClearRangeRequest{}
-			}
-			if err := m.ClearRange.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &ClearRangeRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_ClearRange{v}
 			iNdEx = postIndex
 		case 39:
 			if wireType != 2 {
@@ -22703,12 +25458,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.RecomputeStats == nil {
-				m.RecomputeStats = &RecomputeStatsRequest{}
-			}
-			if err := m.RecomputeStats.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &RecomputeStatsRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_RecomputeStats{v}
 			iNdEx = postIndex
 		case 40:
 			if wireType != 2 {
@@ -22736,12 +25490,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Refresh == nil {
-				m.Refresh = &RefreshRequest{}
-			}
-			if err := m.Refresh.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &RefreshRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_Refresh{v}
 			iNdEx = postIndex
 		case 41:
 			if wireType != 2 {
@@ -22769,12 +25522,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.RefreshRange == nil {
-				m.RefreshRange = &RefreshRangeRequest{}
-			}
-			if err := m.RefreshRange.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &RefreshRangeRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_RefreshRange{v}
 			iNdEx = postIndex
 		case 42:
 			if wireType != 2 {
@@ -22802,12 +25554,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.QueryIntent == nil {
-				m.QueryIntent = &QueryIntentRequest{}
-			}
-			if err := m.QueryIntent.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &QueryIntentRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_QueryIntent{v}
 			iNdEx = postIndex
 		case 43:
 			if wireType != 2 {
@@ -22835,12 +25586,11 @@ func (m *RequestUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.GetSnapshotForMerge == nil {
-				m.GetSnapshotForMerge = &GetSnapshotForMergeRequest{}
-			}
-			if err := m.GetSnapshotForMerge.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &GetSnapshotForMergeRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &RequestUnion_GetSnapshotForMerge{v}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -22918,12 +25668,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Get == nil {
-				m.Get = &GetResponse{}
-			}
-			if err := m.Get.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &GetResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_Get{v}
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
@@ -22951,12 +25700,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Put == nil {
-				m.Put = &PutResponse{}
-			}
-			if err := m.Put.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &PutResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_Put{v}
 			iNdEx = postIndex
 		case 3:
 			if wireType != 2 {
@@ -22984,12 +25732,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.ConditionalPut == nil {
-				m.ConditionalPut = &ConditionalPutResponse{}
-			}
-			if err := m.ConditionalPut.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &ConditionalPutResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_ConditionalPut{v}
 			iNdEx = postIndex
 		case 4:
 			if wireType != 2 {
@@ -23017,12 +25764,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Increment == nil {
-				m.Increment = &IncrementResponse{}
-			}
-			if err := m.Increment.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &IncrementResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_Increment{v}
 			iNdEx = postIndex
 		case 5:
 			if wireType != 2 {
@@ -23050,12 +25796,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Delete == nil {
-				m.Delete = &DeleteResponse{}
-			}
-			if err := m.Delete.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &DeleteResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_Delete{v}
 			iNdEx = postIndex
 		case 6:
 			if wireType != 2 {
@@ -23083,12 +25828,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.DeleteRange == nil {
-				m.DeleteRange = &DeleteRangeResponse{}
-			}
-			if err := m.DeleteRange.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &DeleteRangeResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_DeleteRange{v}
 			iNdEx = postIndex
 		case 7:
 			if wireType != 2 {
@@ -23116,12 +25860,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Scan == nil {
-				m.Scan = &ScanResponse{}
-			}
-			if err := m.Scan.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &ScanResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_Scan{v}
 			iNdEx = postIndex
 		case 8:
 			if wireType != 2 {
@@ -23149,12 +25892,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.BeginTransaction == nil {
-				m.BeginTransaction = &BeginTransactionResponse{}
-			}
-			if err := m.BeginTransaction.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &BeginTransactionResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_BeginTransaction{v}
 			iNdEx = postIndex
 		case 9:
 			if wireType != 2 {
@@ -23182,12 +25924,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.EndTransaction == nil {
-				m.EndTransaction = &EndTransactionResponse{}
-			}
-			if err := m.EndTransaction.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &EndTransactionResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_EndTransaction{v}
 			iNdEx = postIndex
 		case 10:
 			if wireType != 2 {
@@ -23215,12 +25956,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.AdminSplit == nil {
-				m.AdminSplit = &AdminSplitResponse{}
-			}
-			if err := m.AdminSplit.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &AdminSplitResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_AdminSplit{v}
 			iNdEx = postIndex
 		case 11:
 			if wireType != 2 {
@@ -23248,12 +25988,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.AdminMerge == nil {
-				m.AdminMerge = &AdminMergeResponse{}
-			}
-			if err := m.AdminMerge.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &AdminMergeResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_AdminMerge{v}
 			iNdEx = postIndex
 		case 12:
 			if wireType != 2 {
@@ -23281,12 +26020,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.HeartbeatTxn == nil {
-				m.HeartbeatTxn = &HeartbeatTxnResponse{}
-			}
-			if err := m.HeartbeatTxn.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &HeartbeatTxnResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_HeartbeatTxn{v}
 			iNdEx = postIndex
 		case 13:
 			if wireType != 2 {
@@ -23314,12 +26052,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Gc == nil {
-				m.Gc = &GCResponse{}
-			}
-			if err := m.Gc.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &GCResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_Gc{v}
 			iNdEx = postIndex
 		case 14:
 			if wireType != 2 {
@@ -23347,12 +26084,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.PushTxn == nil {
-				m.PushTxn = &PushTxnResponse{}
-			}
-			if err := m.PushTxn.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &PushTxnResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_PushTxn{v}
 			iNdEx = postIndex
 		case 16:
 			if wireType != 2 {
@@ -23380,12 +26116,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.ResolveIntent == nil {
-				m.ResolveIntent = &ResolveIntentResponse{}
-			}
-			if err := m.ResolveIntent.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &ResolveIntentResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_ResolveIntent{v}
 			iNdEx = postIndex
 		case 17:
 			if wireType != 2 {
@@ -23413,12 +26148,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.ResolveIntentRange == nil {
-				m.ResolveIntentRange = &ResolveIntentRangeResponse{}
-			}
-			if err := m.ResolveIntentRange.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &ResolveIntentRangeResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_ResolveIntentRange{v}
 			iNdEx = postIndex
 		case 18:
 			if wireType != 2 {
@@ -23446,12 +26180,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Merge == nil {
-				m.Merge = &MergeResponse{}
-			}
-			if err := m.Merge.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &MergeResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_Merge{v}
 			iNdEx = postIndex
 		case 19:
 			if wireType != 2 {
@@ -23479,12 +26212,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.TruncateLog == nil {
-				m.TruncateLog = &TruncateLogResponse{}
-			}
-			if err := m.TruncateLog.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &TruncateLogResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_TruncateLog{v}
 			iNdEx = postIndex
 		case 20:
 			if wireType != 2 {
@@ -23512,12 +26244,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.RequestLease == nil {
-				m.RequestLease = &RequestLeaseResponse{}
-			}
-			if err := m.RequestLease.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &RequestLeaseResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_RequestLease{v}
 			iNdEx = postIndex
 		case 21:
 			if wireType != 2 {
@@ -23545,12 +26276,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.ReverseScan == nil {
-				m.ReverseScan = &ReverseScanResponse{}
-			}
-			if err := m.ReverseScan.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &ReverseScanResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_ReverseScan{v}
 			iNdEx = postIndex
 		case 22:
 			if wireType != 2 {
@@ -23578,12 +26308,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.ComputeChecksum == nil {
-				m.ComputeChecksum = &ComputeChecksumResponse{}
-			}
-			if err := m.ComputeChecksum.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &ComputeChecksumResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_ComputeChecksum{v}
 			iNdEx = postIndex
 		case 24:
 			if wireType != 2 {
@@ -23611,12 +26340,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.CheckConsistency == nil {
-				m.CheckConsistency = &CheckConsistencyResponse{}
-			}
-			if err := m.CheckConsistency.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &CheckConsistencyResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_CheckConsistency{v}
 			iNdEx = postIndex
 		case 25:
 			if wireType != 2 {
@@ -23644,12 +26372,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Noop == nil {
-				m.Noop = &NoopResponse{}
-			}
-			if err := m.Noop.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &NoopResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_Noop{v}
 			iNdEx = postIndex
 		case 26:
 			if wireType != 2 {
@@ -23677,12 +26404,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.InitPut == nil {
-				m.InitPut = &InitPutResponse{}
-			}
-			if err := m.InitPut.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &InitPutResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_InitPut{v}
 			iNdEx = postIndex
 		case 29:
 			if wireType != 2 {
@@ -23710,12 +26436,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.AdminTransferLease == nil {
-				m.AdminTransferLease = &AdminTransferLeaseResponse{}
-			}
-			if err := m.AdminTransferLease.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &AdminTransferLeaseResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_AdminTransferLease{v}
 			iNdEx = postIndex
 		case 30:
 			if wireType != 2 {
@@ -23743,12 +26468,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.LeaseInfo == nil {
-				m.LeaseInfo = &LeaseInfoResponse{}
-			}
-			if err := m.LeaseInfo.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &LeaseInfoResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_LeaseInfo{v}
 			iNdEx = postIndex
 		case 31:
 			if wireType != 2 {
@@ -23776,12 +26500,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.WriteBatch == nil {
-				m.WriteBatch = &WriteBatchResponse{}
-			}
-			if err := m.WriteBatch.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &WriteBatchResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_WriteBatch{v}
 			iNdEx = postIndex
 		case 32:
 			if wireType != 2 {
@@ -23809,12 +26532,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Export == nil {
-				m.Export = &ExportResponse{}
-			}
-			if err := m.Export.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &ExportResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_Export{v}
 			iNdEx = postIndex
 		case 33:
 			if wireType != 2 {
@@ -23842,12 +26564,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.QueryTxn == nil {
-				m.QueryTxn = &QueryTxnResponse{}
-			}
-			if err := m.QueryTxn.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &QueryTxnResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_QueryTxn{v}
 			iNdEx = postIndex
 		case 34:
 			if wireType != 2 {
@@ -23875,12 +26596,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Import == nil {
-				m.Import = &ImportResponse{}
-			}
-			if err := m.Import.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &ImportResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_Import{v}
 			iNdEx = postIndex
 		case 35:
 			if wireType != 2 {
@@ -23908,12 +26628,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.AdminChangeReplicas == nil {
-				m.AdminChangeReplicas = &AdminChangeReplicasResponse{}
-			}
-			if err := m.AdminChangeReplicas.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &AdminChangeReplicasResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_AdminChangeReplicas{v}
 			iNdEx = postIndex
 		case 36:
 			if wireType != 2 {
@@ -23941,12 +26660,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.AdminScatter == nil {
-				m.AdminScatter = &AdminScatterResponse{}
-			}
-			if err := m.AdminScatter.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &AdminScatterResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_AdminScatter{v}
 			iNdEx = postIndex
 		case 37:
 			if wireType != 2 {
@@ -23974,12 +26692,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.AddSstable == nil {
-				m.AddSstable = &AddSSTableResponse{}
-			}
-			if err := m.AddSstable.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &AddSSTableResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_AddSstable{v}
 			iNdEx = postIndex
 		case 38:
 			if wireType != 2 {
@@ -24007,12 +26724,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.ClearRange == nil {
-				m.ClearRange = &ClearRangeResponse{}
-			}
-			if err := m.ClearRange.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &ClearRangeResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_ClearRange{v}
 			iNdEx = postIndex
 		case 39:
 			if wireType != 2 {
@@ -24040,12 +26756,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.RecomputeStats == nil {
-				m.RecomputeStats = &RecomputeStatsResponse{}
-			}
-			if err := m.RecomputeStats.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &RecomputeStatsResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_RecomputeStats{v}
 			iNdEx = postIndex
 		case 40:
 			if wireType != 2 {
@@ -24073,12 +26788,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Refresh == nil {
-				m.Refresh = &RefreshResponse{}
-			}
-			if err := m.Refresh.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &RefreshResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_Refresh{v}
 			iNdEx = postIndex
 		case 41:
 			if wireType != 2 {
@@ -24106,12 +26820,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.RefreshRange == nil {
-				m.RefreshRange = &RefreshRangeResponse{}
-			}
-			if err := m.RefreshRange.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &RefreshRangeResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_RefreshRange{v}
 			iNdEx = postIndex
 		case 42:
 			if wireType != 2 {
@@ -24139,12 +26852,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.QueryIntent == nil {
-				m.QueryIntent = &QueryIntentResponse{}
-			}
-			if err := m.QueryIntent.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &QueryIntentResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_QueryIntent{v}
 			iNdEx = postIndex
 		case 43:
 			if wireType != 2 {
@@ -24172,12 +26884,11 @@ func (m *ResponseUnion) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.GetSnapshotForMerge == nil {
-				m.GetSnapshotForMerge = &GetSnapshotForMergeResponse{}
-			}
-			if err := m.GetSnapshotForMerge.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			v := &GetSnapshotForMergeResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			m.Value = &ResponseUnion_GetSnapshotForMerge{v}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -25040,351 +27751,353 @@ var (
 func init() { proto.RegisterFile("roachpb/api.proto", fileDescriptorApi) }
 
 var fileDescriptorApi = []byte{
-	// 5522 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xdc, 0x7c, 0x4d, 0x8c, 0x1b, 0xc9,
-	0x75, 0xbf, 0x9a, 0xe4, 0xcc, 0x90, 0x8f, 0x1f, 0xea, 0xa9, 0x91, 0x46, 0xd4, 0x48, 0x2b, 0x8e,
-	0xb8, 0x92, 0x56, 0xd2, 0x7a, 0x47, 0x96, 0xf4, 0xdf, 0xbf, 0xbd, 0x1f, 0x8e, 0x77, 0xc8, 0x19,
-	0x8d, 0x28, 0x69, 0x66, 0xb4, 0x45, 0x8e, 0x76, 0xd7, 0x8e, 0xdd, 0xe9, 0xe9, 0xae, 0xe1, 0xb4,
-	0x45, 0x76, 0x73, 0xbb, 0x9b, 0x9a, 0x19, 0x01, 0x41, 0x02, 0x24, 0x80, 0x03, 0xc3, 0x30, 0x02,
-	0xc4, 0x08, 0x02, 0x04, 0x41, 0x0c, 0xe4, 0x90, 0x53, 0x9c, 0x04, 0x08, 0x10, 0x20, 0x07, 0xfb,
-	0x92, 0xc3, 0x06, 0x08, 0x02, 0x27, 0x80, 0x8d, 0x20, 0x40, 0x06, 0xc9, 0x24, 0x07, 0x23, 0x39,
-	0xe6, 0xb6, 0xa7, 0xa0, 0xbe, 0xc8, 0x26, 0xd9, 0x4d, 0x52, 0x72, 0x2f, 0xb2, 0xc9, 0x89, 0xac,
-	0x57, 0xf5, 0x5e, 0x55, 0xbd, 0x7a, 0xf5, 0xea, 0x57, 0x55, 0xaf, 0x1a, 0xe6, 0x5d, 0x47, 0x37,
-	0xf6, 0x3b, 0xbb, 0xb7, 0xf4, 0x8e, 0xb5, 0xd2, 0x71, 0x1d, 0xdf, 0x41, 0xf3, 0x86, 0x63, 0x3c,
-	0x65, 0xe4, 0x15, 0x91, 0xb9, 0x84, 0x64, 0x29, 0x53, 0xf7, 0x75, 0x5e, 0x6c, 0xe9, 0x8c, 0xa4,
-	0x11, 0xd7, 0x75, 0x5c, 0x4f, 0x50, 0x17, 0x25, 0xb5, 0x4d, 0x7c, 0x3d, 0x50, 0xba, 0xec, 0xf9,
-	0x8e, 0xab, 0x37, 0xc9, 0x2d, 0x62, 0x37, 0x2d, 0x5b, 0xfe, 0xd0, 0x72, 0xcf, 0x0c, 0x43, 0x94,
-	0x79, 0x75, 0x5c, 0x99, 0xbb, 0xa2, 0x50, 0xb1, 0xeb, 0x5b, 0xad, 0x5b, 0xfb, 0x2d, 0xe3, 0x96,
-	0x6f, 0xb5, 0x89, 0xe7, 0xeb, 0xed, 0x8e, 0xc8, 0x59, 0x66, 0x39, 0xbe, 0xab, 0x1b, 0x96, 0xdd,
-	0xbc, 0xe5, 0x12, 0xc3, 0x71, 0x4d, 0x62, 0x6a, 0x5e, 0x47, 0xb7, 0x65, 0x93, 0x9b, 0x4e, 0xd3,
-	0x61, 0x7f, 0x6f, 0xd1, 0x7f, 0x9c, 0x5a, 0xfe, 0x35, 0xc8, 0x60, 0xdd, 0x6e, 0x92, 0x9a, 0xbd,
-	0xe7, 0xa0, 0x77, 0x21, 0x65, 0x12, 0xcf, 0x28, 0x2a, 0xcb, 0xca, 0xf5, 0xec, 0x9d, 0xf2, 0xca,
-	0x88, 0x2e, 0x56, 0x58, 0xd9, 0x35, 0xe2, 0x19, 0xae, 0xd5, 0xf1, 0x1d, 0xb7, 0x92, 0xfa, 0xe4,
-	0xb8, 0x74, 0x0a, 0x33, 0x2e, 0xf4, 0xff, 0x60, 0xa6, 0x45, 0x74, 0x8f, 0x14, 0x13, 0x8c, 0xbd,
-	0x18, 0xc2, 0xfe, 0x88, 0xe6, 0x0b, 0x26, 0x5e, 0xb8, 0xfc, 0x1c, 0xf2, 0x98, 0x7c, 0xdc, 0x25,
-	0x9e, 0x7f, 0x9f, 0xe8, 0x26, 0x71, 0xd1, 0x79, 0x48, 0x3e, 0x25, 0x47, 0xc5, 0xe4, 0xb2, 0x72,
-	0x3d, 0x57, 0x99, 0xfb, 0xf4, 0xb8, 0x94, 0x7c, 0x48, 0x8e, 0x30, 0xa5, 0xa1, 0x65, 0x98, 0x23,
-	0xb6, 0xa9, 0xd1, 0xec, 0xd4, 0x60, 0xf6, 0x2c, 0xb1, 0xcd, 0x87, 0xe4, 0x08, 0x2d, 0x41, 0xda,
-	0xa3, 0xd2, 0x6c, 0x83, 0x14, 0x67, 0x96, 0x95, 0xeb, 0x33, 0xb8, 0x97, 0x7e, 0x3b, 0xf5, 0xf3,
-	0x1f, 0x94, 0x94, 0x07, 0xa9, 0xb4, 0xa2, 0x26, 0x1e, 0xa4, 0xd2, 0x09, 0x35, 0x59, 0xfe, 0x6e,
-	0x12, 0x0a, 0x98, 0x78, 0x1d, 0xc7, 0xf6, 0x88, 0xa8, 0xfd, 0x8b, 0x90, 0xf4, 0x0f, 0x6d, 0x56,
-	0x7b, 0xf6, 0xce, 0xa5, 0x90, 0x2e, 0x34, 0x5c, 0xdd, 0xf6, 0x74, 0xc3, 0xb7, 0x1c, 0x1b, 0xd3,
-	0xa2, 0xe8, 0xcb, 0x90, 0x75, 0x89, 0xd7, 0x6d, 0x13, 0xa6, 0x6c, 0xd6, 0xb0, 0xec, 0x9d, 0x73,
-	0x21, 0x9c, 0xf5, 0x8e, 0x6e, 0x63, 0xe0, 0x65, 0xe9, 0x7f, 0x74, 0x1e, 0xd2, 0x76, 0xb7, 0x4d,
-	0xbb, 0xe3, 0xb1, 0xc6, 0x26, 0xf1, 0x9c, 0xdd, 0x6d, 0x3f, 0x24, 0x47, 0x1e, 0xaa, 0x42, 0xd6,
-	0xa5, 0xaa, 0xd6, 0x2c, 0x7b, 0xcf, 0xf1, 0x8a, 0xb3, 0xcb, 0xc9, 0xeb, 0xd9, 0x3b, 0x17, 0xa3,
-	0x06, 0x84, 0x0e, 0x9e, 0xd0, 0x2a, 0xb8, 0x92, 0xe0, 0xa1, 0x3a, 0xe4, 0x45, 0xcb, 0x5c, 0xa2,
-	0x7b, 0x8e, 0x5d, 0x9c, 0x5b, 0x56, 0xae, 0x17, 0xee, 0xac, 0x84, 0x89, 0x19, 0xd0, 0x02, 0x4d,
-	0x76, 0xdb, 0x04, 0x33, 0x2e, 0x9c, 0x73, 0x03, 0xa9, 0xf2, 0x47, 0x90, 0x0b, 0xe6, 0x22, 0x04,
-	0x05, 0xbc, 0x5e, 0xdf, 0xd9, 0x5c, 0xd7, 0x76, 0xb6, 0x1e, 0x6e, 0x6d, 0x7f, 0xb0, 0xa5, 0x9e,
-	0x42, 0x67, 0x40, 0x15, 0xb4, 0x87, 0xeb, 0x1f, 0x69, 0x8f, 0x6a, 0x9b, 0xb5, 0x86, 0xaa, 0xa0,
-	0xf3, 0x70, 0x56, 0x50, 0xf1, 0xea, 0xd6, 0xc6, 0xba, 0x56, 0xd9, 0xde, 0xd9, 0x5a, 0x5b, 0xc5,
-	0x1f, 0xa9, 0x89, 0xa5, 0xd4, 0x6f, 0xfd, 0xd1, 0xa5, 0x53, 0xe5, 0x27, 0x00, 0x1b, 0xc4, 0x17,
-	0xd6, 0x80, 0x2a, 0x30, 0xbb, 0xcf, 0x5a, 0x23, 0xcc, 0x71, 0x39, 0xb4, 0xd9, 0x01, 0xcb, 0xa9,
-	0xa4, 0xa9, 0x06, 0x7e, 0x72, 0x5c, 0x52, 0xb0, 0xe0, 0xe4, 0x43, 0x5e, 0xfe, 0xb1, 0x02, 0x59,
-	0x26, 0x98, 0xf7, 0x11, 0x55, 0x87, 0x24, 0x5f, 0x9e, 0xa8, 0x90, 0x51, 0xd1, 0x68, 0x05, 0x66,
-	0x9e, 0xe9, 0xad, 0xee, 0x38, 0x6b, 0x7f, 0x42, 0xf3, 0x31, 0x2f, 0x86, 0xde, 0x81, 0x9c, 0x65,
-	0xfb, 0xc4, 0xf6, 0x35, 0xce, 0x96, 0x9c, 0xc0, 0x96, 0xe5, 0xa5, 0x59, 0xa2, 0xfc, 0x57, 0x0a,
-	0xc0, 0xe3, 0x6e, 0x9c, 0xaa, 0xa1, 0xb3, 0x75, 0xaa, 0xf6, 0xcb, 0xd9, 0xca, 0x7b, 0xb1, 0x08,
-	0xb3, 0x96, 0xdd, 0xb2, 0x6c, 0xde, 0xfe, 0x34, 0x16, 0x29, 0x74, 0x06, 0x66, 0x76, 0x5b, 0x96,
-	0x6d, 0x32, 0xf3, 0x4f, 0x63, 0x9e, 0x10, 0xea, 0xc7, 0x90, 0x65, 0x6d, 0x8f, 0x51, 0xfb, 0xe5,
-	0x7f, 0x57, 0xe0, 0x6c, 0xd5, 0xb1, 0x4d, 0x8b, 0xce, 0x43, 0xbd, 0xf5, 0xb9, 0xd0, 0xcd, 0x9b,
-	0x90, 0x21, 0x87, 0x9d, 0x29, 0x87, 0x37, 0x4d, 0x0e, 0x3b, 0xec, 0xdf, 0x58, 0xd5, 0x7d, 0x03,
-	0x16, 0x87, 0x7b, 0x19, 0xa7, 0x16, 0xff, 0x41, 0x81, 0x42, 0xcd, 0xb6, 0xfc, 0xcf, 0x85, 0xfa,
-	0x7a, 0x7a, 0x48, 0x06, 0xf4, 0x80, 0x6e, 0x82, 0xba, 0xa7, 0x5b, 0xad, 0x6d, 0xbb, 0xe1, 0xb4,
-	0x77, 0x3d, 0xdf, 0xb1, 0x89, 0x27, 0x14, 0x35, 0x42, 0x17, 0x3a, 0x7b, 0x02, 0xa7, 0x7b, 0x7d,
-	0x8a, 0x53, 0x59, 0xcf, 0x41, 0xad, 0xd9, 0x86, 0x4b, 0xda, 0xc4, 0x8e, 0x55, 0x5b, 0x17, 0x21,
-	0x63, 0x49, 0xb9, 0x4c, 0x63, 0x49, 0xdc, 0x27, 0x88, 0x3e, 0x75, 0x61, 0x3e, 0x50, 0x77, 0x9c,
-	0x6e, 0xec, 0x02, 0x64, 0x6c, 0x72, 0xa0, 0xf5, 0xc7, 0x2b, 0x89, 0xd3, 0x36, 0x39, 0xe0, 0x6e,
-	0xe7, 0x23, 0xc8, 0xaf, 0x91, 0x16, 0xf1, 0x49, 0xfc, 0x3e, 0x79, 0x07, 0x0a, 0x52, 0x74, 0x9c,
-	0x83, 0xf4, 0x07, 0x0a, 0x20, 0x21, 0x97, 0xae, 0x83, 0x71, 0x8e, 0x53, 0x89, 0xae, 0xf3, 0x7e,
-	0xd7, 0xb5, 0xf9, 0x82, 0xcd, 0xad, 0x14, 0x38, 0x89, 0xad, 0xd9, 0x7d, 0xdf, 0x98, 0x0a, 0xfa,
-	0xc6, 0x1e, 0xee, 0xa0, 0x88, 0xe3, 0x00, 0x16, 0x06, 0x9a, 0x17, 0xef, 0x50, 0xa6, 0x58, 0xcb,
-	0x12, 0xcb, 0xc9, 0x20, 0x34, 0x62, 0xc4, 0xf2, 0x37, 0x60, 0xbe, 0xda, 0x22, 0xba, 0x1b, 0xb7,
-	0x5a, 0xc4, 0x70, 0x7e, 0x04, 0x28, 0x28, 0x3e, 0xce, 0x21, 0xb5, 0x20, 0x5b, 0x37, 0x74, 0x7b,
-	0xbb, 0x43, 0x9d, 0xa0, 0x87, 0xee, 0xc2, 0xa2, 0xe7, 0x3b, 0x1d, 0x4d, 0xf7, 0x35, 0x8e, 0x90,
-	0x76, 0x9d, 0xae, 0x6d, 0xea, 0xee, 0x11, 0xab, 0x23, 0x8d, 0x17, 0x68, 0xee, 0xaa, 0xcf, 0x1a,
-	0x52, 0x11, 0x59, 0x74, 0xec, 0xda, 0x96, 0xad, 0x51, 0x20, 0xd3, 0xf2, 0x3d, 0x61, 0xe7, 0xd0,
-	0xb6, 0x6c, 0xcc, 0x29, 0xa2, 0x17, 0x06, 0xaf, 0x2a, 0x76, 0xf5, 0xf0, 0xc1, 0x7f, 0x90, 0x4a,
-	0x27, 0xd5, 0x54, 0xf9, 0xef, 0x14, 0xc8, 0xf1, 0x5a, 0xe2, 0x1c, 0xfc, 0x37, 0x21, 0xe5, 0x3a,
-	0x07, 0x7c, 0xf0, 0xb3, 0x77, 0x2e, 0x84, 0x88, 0x78, 0x48, 0x8e, 0x82, 0x5e, 0x97, 0x15, 0x47,
-	0x15, 0x10, 0x38, 0x43, 0x63, 0xdc, 0xc9, 0x69, 0xb9, 0x81, 0x73, 0x61, 0xe7, 0xc0, 0x2b, 0x7f,
-	0x0b, 0x10, 0x26, 0xcf, 0x88, 0xeb, 0x91, 0xcf, 0x5e, 0x79, 0x3f, 0x55, 0x60, 0x61, 0xa0, 0xb2,
-	0xff, 0x23, 0x3a, 0xfc, 0x75, 0x05, 0xce, 0x55, 0xf7, 0x89, 0xf1, 0xb4, 0xea, 0xd8, 0x9e, 0xe5,
-	0xf9, 0xc4, 0x36, 0x8e, 0xe2, 0x74, 0x5e, 0x17, 0x20, 0x73, 0x60, 0xf9, 0xfb, 0x9a, 0x69, 0xed,
-	0xed, 0x31, 0xf3, 0x4f, 0xe3, 0x34, 0x25, 0xac, 0x59, 0x7b, 0x7b, 0xc2, 0xf8, 0x35, 0x28, 0x8e,
-	0xb6, 0x20, 0xde, 0x05, 0xf4, 0x2c, 0x26, 0x86, 0xd3, 0xee, 0x74, 0x7d, 0x52, 0xf7, 0x75, 0xdf,
-	0x8b, 0xb3, 0x83, 0xe7, 0x60, 0xce, 0x74, 0x8f, 0x34, 0xb7, 0x6b, 0x8b, 0xee, 0xcd, 0x9a, 0xee,
-	0x11, 0xee, 0xda, 0xa2, 0x73, 0x7f, 0xa9, 0xc0, 0xe2, 0x70, 0xe5, 0x71, 0x9a, 0xce, 0x87, 0x90,
-	0xd5, 0x4d, 0xba, 0xe1, 0x36, 0x49, 0xcb, 0xd7, 0x05, 0xf0, 0xb9, 0x1d, 0x90, 0x24, 0x76, 0xf7,
-	0x2b, 0x7c, 0x5b, 0xbf, 0x22, 0x77, 0xf7, 0x2b, 0x9b, 0x4f, 0xaa, 0x55, 0xd6, 0x9e, 0x35, 0xca,
-	0x28, 0x2d, 0x83, 0xc9, 0x62, 0x94, 0xb2, 0x01, 0xe7, 0x2a, 0xa4, 0x69, 0xd9, 0xc1, 0x7d, 0x67,
-	0xec, 0xee, 0x5b, 0x83, 0xe2, 0x68, 0x25, 0x71, 0x8e, 0xfd, 0xdf, 0x27, 0xe1, 0xec, 0xba, 0x6d,
-	0x7e, 0x36, 0x9d, 0xa0, 0x2b, 0xaf, 0xe1, 0xb4, 0xdb, 0x96, 0x2f, 0xc7, 0x9e, 0xa7, 0xd0, 0x5b,
-	0x90, 0x36, 0x89, 0x6e, 0xf6, 0xf6, 0x2b, 0xd9, 0x3b, 0xaf, 0x04, 0xa4, 0x77, 0x7d, 0xab, 0xb5,
-	0xb2, 0xdf, 0x32, 0x56, 0x1a, 0xf2, 0x2c, 0x05, 0xf7, 0x8a, 0xa3, 0x5f, 0x81, 0x73, 0x74, 0x7a,
-	0xba, 0xb6, 0xde, 0xd2, 0xb8, 0x34, 0xcd, 0x77, 0xad, 0x66, 0x93, 0xb8, 0x62, 0x87, 0x7f, 0x3d,
-	0xa4, 0x9d, 0x35, 0xc1, 0x51, 0x65, 0x0c, 0x0d, 0x5e, 0x1e, 0x9f, 0xb5, 0xc2, 0xc8, 0xe8, 0xbd,
-	0xde, 0x86, 0xd0, 0xeb, 0xe8, 0xb6, 0x57, 0x9c, 0x61, 0x7e, 0x23, 0xea, 0xe0, 0x40, 0x58, 0x86,
-	0xf0, 0x34, 0x94, 0xe2, 0xa1, 0x5b, 0x14, 0x91, 0x7c, 0xdc, 0xb5, 0x5c, 0xa2, 0xdd, 0xee, 0x18,
-	0xc5, 0x59, 0xda, 0xf7, 0x4a, 0xe1, 0xe4, 0xb8, 0x04, 0x98, 0x93, 0x6f, 0x3f, 0xae, 0x52, 0x84,
-	0xc2, 0xff, 0x77, 0x0c, 0x74, 0x1d, 0x54, 0xdb, 0xd1, 0x5c, 0xb2, 0xe7, 0x12, 0x6f, 0x5f, 0x54,
-	0x9b, 0x66, 0x1a, 0x2b, 0xd8, 0x0e, 0xe6, 0x64, 0x2e, 0x7a, 0x11, 0x66, 0x3b, 0x8e, 0xe5, 0x39,
-	0x76, 0x31, 0xc3, 0x35, 0xca, 0x53, 0x3d, 0x8f, 0x3c, 0xa7, 0xa6, 0xcb, 0xbf, 0xa3, 0xc0, 0xe2,
-	0xf0, 0x98, 0xc6, 0x39, 0xa7, 0xae, 0x83, 0xea, 0xd8, 0x44, 0xeb, 0xec, 0xeb, 0x1e, 0x11, 0x63,
-	0x20, 0x90, 0x55, 0xc1, 0xb1, 0xc9, 0x63, 0x4a, 0xe6, 0x1a, 0x1d, 0x58, 0x21, 0x7e, 0x43, 0x81,
-	0xf9, 0x55, 0xb3, 0x6d, 0xd9, 0xf5, 0x4e, 0xcb, 0x8a, 0x15, 0xa8, 0x5f, 0x81, 0x8c, 0x47, 0x65,
-	0xb2, 0xf3, 0xa7, 0xc4, 0xe0, 0xf9, 0x53, 0x9a, 0xe5, 0x3c, 0x24, 0x47, 0x7d, 0x3c, 0x14, 0x6c,
-	0x44, 0x9c, 0x53, 0xe9, 0x1b, 0xa2, 0x7f, 0x9b, 0xc4, 0xfd, 0x8c, 0x90, 0x5c, 0x50, 0x7c, 0x9c,
-	0x2d, 0xff, 0x8e, 0x02, 0xe7, 0x99, 0x6c, 0x66, 0x32, 0x7b, 0xc4, 0x65, 0xc7, 0x81, 0x71, 0x0e,
-	0xd1, 0xab, 0x30, 0xeb, 0xeb, 0x6e, 0x93, 0x70, 0x47, 0x30, 0x53, 0xc9, 0x7e, 0x7a, 0x5c, 0x9a,
-	0xab, 0xfb, 0x8e, 0x4b, 0x6a, 0x6b, 0x58, 0x64, 0x89, 0x7e, 0xea, 0xb0, 0x14, 0xd6, 0x96, 0x38,
-	0xfb, 0xfb, 0x5f, 0x8a, 0xa8, 0xa3, 0xba, 0xcf, 0x61, 0x71, 0xa7, 0x65, 0x19, 0x7a, 0xac, 0xcb,
-	0xde, 0x3a, 0x64, 0x0d, 0x26, 0x5c, 0xf3, 0x8f, 0x3a, 0x7c, 0x03, 0x57, 0xb8, 0x73, 0x25, 0x54,
-	0x10, 0xab, 0x9c, 0xb7, 0xa4, 0x71, 0xd4, 0x21, 0x18, 0x8c, 0xde, 0x7f, 0xb4, 0x06, 0x73, 0x5c,
-	0x39, 0x12, 0xbe, 0x8c, 0x11, 0x41, 0x27, 0x7a, 0x83, 0x15, 0x16, 0x3e, 0x49, 0xb2, 0x0a, 0xc5,
-	0xee, 0xc2, 0x85, 0xd0, 0x4e, 0xc7, 0xa9, 0xd9, 0xdf, 0x55, 0x60, 0xe1, 0x3e, 0xd1, 0x5d, 0x7f,
-	0x97, 0xe8, 0x7e, 0xe3, 0x30, 0xd6, 0xc5, 0xe4, 0x4d, 0x48, 0xda, 0xce, 0x81, 0x58, 0xc2, 0xc7,
-	0xaf, 0x17, 0x42, 0x01, 0xb4, 0xbc, 0xe8, 0xfc, 0xd7, 0xe1, 0xcc, 0x60, 0xbb, 0xe2, 0xec, 0xf5,
-	0x9f, 0x27, 0x21, 0xb3, 0x51, 0x8d, 0xb3, 0xaf, 0xef, 0x8a, 0x2d, 0x23, 0x1f, 0xf4, 0xb0, 0x03,
-	0xff, 0x5e, 0x7d, 0x2b, 0x1b, 0xd5, 0x87, 0xe4, 0x48, 0x02, 0x5f, 0xca, 0x85, 0x56, 0x21, 0xe3,
-	0xef, 0xd3, 0x35, 0xc3, 0x69, 0x99, 0x62, 0x55, 0x9c, 0x4a, 0x5f, 0x7d, 0x2e, 0xd4, 0x82, 0xb3,
-	0xfe, 0xa1, 0xcd, 0x96, 0x22, 0xad, 0x69, 0x68, 0x7d, 0x71, 0x33, 0xd3, 0x88, 0x5b, 0xa2, 0xe2,
-	0x4e, 0x8e, 0x4b, 0xa8, 0x71, 0x68, 0xd3, 0x75, 0x6b, 0xa3, 0xda, 0x90, 0x02, 0x30, 0xf2, 0x05,
-	0xcd, 0xe8, 0xd1, 0x96, 0x9e, 0xc2, 0x0c, 0xeb, 0x85, 0xbc, 0x63, 0x50, 0x42, 0xee, 0x18, 0x68,
-	0xa7, 0x64, 0x05, 0x2f, 0x62, 0x04, 0x7d, 0x2e, 0x6e, 0x0a, 0xc2, 0x20, 0xde, 0x07, 0xa0, 0x2a,
-	0x8c, 0xd3, 0x0c, 0x7e, 0x94, 0x84, 0xc2, 0xe3, 0xae, 0xb7, 0x1f, 0xb3, 0xdd, 0x57, 0x01, 0x3a,
-	0x5d, 0x6f, 0x9f, 0xb8, 0x9a, 0x7f, 0x68, 0x8b, 0x9e, 0x4f, 0xb8, 0x00, 0x91, 0x5d, 0xe7, 0x7c,
-	0x8d, 0x43, 0x1b, 0x6d, 0x0b, 0x21, 0x44, 0xeb, 0xdf, 0xa2, 0xdc, 0x9c, 0x02, 0x06, 0x37, 0x0e,
-	0xed, 0x4d, 0xd2, 0xc3, 0xbf, 0x5c, 0x20, 0xa1, 0x02, 0xdf, 0x85, 0x39, 0x9a, 0xd0, 0x7c, 0xe7,
-	0x45, 0x2c, 0x6c, 0x96, 0xf2, 0x34, 0x1c, 0x39, 0x97, 0x67, 0x5e, 0x6c, 0x2e, 0xa3, 0x77, 0x20,
-	0xc3, 0x2b, 0xa5, 0x3e, 0x75, 0x96, 0xf9, 0xd4, 0x30, 0x4d, 0x88, 0x41, 0x60, 0xde, 0x34, 0xcd,
-	0x6a, 0xa4, 0xbe, 0xf4, 0x0c, 0xcc, 0xec, 0x39, 0xae, 0x41, 0xd8, 0x6d, 0x4b, 0x1a, 0xf3, 0x44,
-	0x0f, 0x38, 0xa5, 0xd5, 0x4c, 0xf9, 0xf7, 0x15, 0x38, 0xdd, 0x1b, 0xc0, 0x38, 0x11, 0x53, 0x75,
-	0x40, 0xfb, 0x2f, 0x3e, 0x84, 0x54, 0xe3, 0xe5, 0x1f, 0x26, 0xe0, 0xf4, 0xfb, 0x5d, 0xe2, 0x1e,
-	0xc5, 0x6c, 0x5f, 0x15, 0x7e, 0xb3, 0x96, 0x78, 0x49, 0x9b, 0x60, 0x77, 0x6d, 0xd7, 0xe0, 0xf4,
-	0x81, 0x6e, 0xf9, 0xda, 0x9e, 0xe3, 0x6a, 0xdd, 0x8e, 0xa9, 0xfb, 0xf2, 0x1e, 0x22, 0x4f, 0xc9,
-	0xf7, 0x1c, 0x77, 0x87, 0x11, 0x11, 0x01, 0xf4, 0xd4, 0x76, 0x0e, 0x6c, 0x8d, 0x92, 0x2d, 0xbb,
-	0x49, 0xf5, 0xe1, 0x15, 0x53, 0xec, 0x60, 0xec, 0x4b, 0xff, 0x74, 0x5c, 0xba, 0xdb, 0xb4, 0xfc,
-	0xfd, 0xee, 0xee, 0x8a, 0xe1, 0xb4, 0x6f, 0xf5, 0x1a, 0x62, 0xee, 0xf6, 0xff, 0xdf, 0xea, 0x3c,
-	0x6d, 0xde, 0x62, 0x57, 0xaa, 0xdd, 0xae, 0x65, 0xae, 0xec, 0xec, 0xd4, 0xd6, 0xb0, 0xca, 0x44,
-	0x7e, 0xc0, 0x25, 0x36, 0x0e, 0x6d, 0xb9, 0xe0, 0x7d, 0xaa, 0x80, 0xda, 0x57, 0x58, 0x9c, 0xe3,
-	0xb9, 0x0e, 0xd9, 0x8f, 0xbb, 0xc4, 0xb5, 0x88, 0xf9, 0xc2, 0x03, 0x0a, 0x82, 0x91, 0xce, 0xa1,
-	0xaf, 0x41, 0x6e, 0x40, 0x0f, 0xc9, 0x5f, 0x4c, 0x0f, 0xd9, 0x83, 0xbe, 0x0a, 0xca, 0x3f, 0x4a,
-	0x00, 0x62, 0x9d, 0xaf, 0xf1, 0xc3, 0x8c, 0xcf, 0x99, 0xc1, 0x3c, 0x01, 0xb0, 0xf6, 0xb4, 0xb6,
-	0xe5, 0x79, 0x96, 0xdd, 0x64, 0xb6, 0x52, 0xb8, 0xf3, 0xa5, 0x90, 0xb6, 0x8c, 0x76, 0x61, 0xa5,
-	0xb6, 0xb7, 0xc9, 0xd9, 0x2a, 0x64, 0x5f, 0x7f, 0x66, 0x39, 0x2e, 0xce, 0x58, 0x92, 0x54, 0xae,
-	0xc0, 0xfc, 0x48, 0x3e, 0x2a, 0x00, 0xac, 0x6d, 0x6b, 0x5b, 0xdb, 0x8d, 0xfb, 0xb5, 0xad, 0x0d,
-	0xf5, 0x14, 0x52, 0x21, 0x87, 0xd7, 0x1b, 0x3b, 0x78, 0x4b, 0x5b, 0xc7, 0x78, 0x1b, 0xab, 0x0a,
-	0xca, 0xc2, 0xdc, 0x63, 0xbc, 0xfe, 0x64, 0x7d, 0xab, 0xa1, 0x26, 0x84, 0xf5, 0xfc, 0x2a, 0x2c,
-	0x0c, 0x54, 0x1e, 0xa7, 0xfd, 0x5c, 0x86, 0xdc, 0x9e, 0xd3, 0xb5, 0x4d, 0x8d, 0xef, 0x1a, 0xc5,
-	0xee, 0x38, 0xcb, 0x68, 0xbc, 0xbe, 0xf2, 0xb7, 0x13, 0x70, 0x06, 0x13, 0xcf, 0x69, 0x3d, 0x23,
-	0xf1, 0x8f, 0xe0, 0x36, 0x88, 0x33, 0x2e, 0xed, 0x17, 0x19, 0xc8, 0x0c, 0x97, 0xc1, 0x57, 0x83,
-	0x59, 0xcf, 0xd7, 0xfd, 0xae, 0x27, 0x86, 0xf2, 0xca, 0xf8, 0xb9, 0x50, 0x67, 0x65, 0xb1, 0xe0,
-	0x09, 0x6c, 0x6a, 0x53, 0xa3, 0x9b, 0xda, 0xf2, 0x2f, 0xc3, 0xd9, 0x21, 0x45, 0xc4, 0xb9, 0x68,
-	0xff, 0x2c, 0x01, 0xe7, 0x07, 0xc5, 0xc7, 0x7d, 0x3f, 0xf1, 0xbf, 0x43, 0xd9, 0xe8, 0x3e, 0xe4,
-	0xdb, 0x96, 0xad, 0xf5, 0x31, 0xd6, 0x0b, 0x2c, 0xce, 0x39, 0xba, 0x5f, 0x1b, 0x84, 0x59, 0x74,
-	0x1f, 0x17, 0xa6, 0xd7, 0x38, 0xc7, 0xae, 0x00, 0xb9, 0x2d, 0xc7, 0xe9, 0xc8, 0x72, 0xe5, 0x3c,
-	0x64, 0x79, 0x9a, 0x0d, 0x48, 0xf9, 0x7b, 0x0a, 0xe4, 0xe2, 0xde, 0x8c, 0xbf, 0xdc, 0x1d, 0xaa,
-	0x50, 0x49, 0x03, 0xf2, 0x9f, 0xc1, 0xee, 0xfd, 0x8f, 0x15, 0x40, 0x0d, 0xb7, 0x6b, 0x1b, 0xba,
-	0x4f, 0x1e, 0x39, 0xcd, 0x38, 0x3b, 0x7b, 0x06, 0x66, 0x2c, 0xdb, 0x24, 0x87, 0xac, 0xb3, 0x29,
-	0xcc, 0x13, 0xe8, 0x36, 0xa4, 0x45, 0x0c, 0x0c, 0xbf, 0x13, 0x4e, 0x56, 0x16, 0x4f, 0x8e, 0x4b,
-	0x73, 0x3c, 0xe2, 0x65, 0xed, 0xd3, 0xfe, 0x5f, 0x3c, 0xc7, 0x83, 0x5e, 0xe4, 0xad, 0xf9, 0xd7,
-	0x60, 0x61, 0xa0, 0xa1, 0x71, 0x6a, 0xe1, 0x87, 0x09, 0x58, 0x10, 0xdd, 0x89, 0xfd, 0xf4, 0xe2,
-	0xa5, 0x02, 0xa8, 0xd0, 0x57, 0x00, 0x3a, 0x2e, 0x79, 0xa6, 0x71, 0xd6, 0xe4, 0x54, 0xac, 0x19,
-	0xca, 0xc1, 0x08, 0xe8, 0x43, 0x38, 0x4d, 0xe7, 0x63, 0xc7, 0x75, 0x3a, 0x8e, 0x47, 0x81, 0x86,
-	0x37, 0x1d, 0xd0, 0x9e, 0x3f, 0x39, 0x2e, 0xe5, 0x37, 0x2d, 0xfb, 0xb1, 0x60, 0x6c, 0xd4, 0x31,
-	0x9d, 0xd8, 0xbd, 0xa4, 0x44, 0x47, 0x3f, 0x55, 0xe0, 0xcc, 0x67, 0x76, 0xde, 0xf3, 0x3f, 0xa1,
-	0xb1, 0xde, 0x72, 0xa1, 0xb2, 0x64, 0xcd, 0xde, 0x73, 0xe2, 0x3f, 0x85, 0xfb, 0x9e, 0x02, 0xf3,
-	0x01, 0xf1, 0x71, 0x82, 0x82, 0x97, 0x0b, 0xd3, 0xfb, 0x3a, 0x85, 0x09, 0x41, 0xb3, 0x8f, 0x73,
-	0x52, 0xfd, 0x66, 0x02, 0x16, 0xab, 0xfc, 0x6e, 0x86, 0x5d, 0x41, 0x79, 0xdd, 0x76, 0x9c, 0x56,
-	0x52, 0x84, 0xb9, 0x67, 0xc4, 0xf5, 0x2c, 0x87, 0x2f, 0x8b, 0x79, 0x2c, 0x93, 0xe8, 0x5b, 0x90,
-	0x35, 0x44, 0x85, 0xd2, 0xcb, 0xe4, 0x2a, 0x35, 0x2a, 0xe0, 0x25, 0xc1, 0xf1, 0xc9, 0x71, 0x09,
-	0x64, 0x17, 0x6a, 0x6b, 0x18, 0xa4, 0xf4, 0x9a, 0xc9, 0x42, 0x13, 0x6d, 0xbd, 0xe3, 0xed, 0x3b,
-	0xf2, 0x18, 0xbb, 0x97, 0x16, 0x83, 0xfe, 0x4d, 0x38, 0x37, 0xa2, 0x85, 0x38, 0xd5, 0xfc, 0xb7,
-	0x73, 0x90, 0x5f, 0x3f, 0xec, 0x38, 0xae, 0x5f, 0xe7, 0x58, 0x00, 0xad, 0x41, 0xba, 0xe3, 0x3a,
-	0xcf, 0x2c, 0x29, 0xb8, 0x10, 0x7a, 0xad, 0x31, 0xc0, 0xf3, 0x58, 0x94, 0xc7, 0x3d, 0x4e, 0x84,
-	0x21, 0xf3, 0xc8, 0x31, 0xf4, 0xd6, 0x3d, 0xab, 0x25, 0xad, 0x6a, 0x65, 0x92, 0x98, 0x95, 0x1e,
-	0xc7, 0x63, 0xdd, 0xdf, 0x97, 0x93, 0xac, 0x47, 0x44, 0x1b, 0x90, 0xbe, 0xef, 0xfb, 0x1d, 0x9a,
-	0x29, 0x66, 0xe8, 0xd5, 0x89, 0x22, 0x29, 0x83, 0x90, 0xd4, 0x63, 0x46, 0x18, 0xe6, 0x37, 0x1c,
-	0xa7, 0xd9, 0x22, 0xd5, 0x96, 0xd3, 0x35, 0xab, 0x8e, 0xbd, 0x67, 0x35, 0x85, 0x87, 0xbb, 0x32,
-	0x51, 0xe2, 0x46, 0xb5, 0x8e, 0x47, 0xd9, 0xd1, 0x57, 0x21, 0x5d, 0xbf, 0x2b, 0x44, 0x71, 0xf8,
-	0xf2, 0xea, 0x44, 0x51, 0xf5, 0xbb, 0xb8, 0xc7, 0x84, 0xee, 0x43, 0x76, 0xf5, 0x79, 0xd7, 0x25,
-	0x42, 0xc6, 0x2c, 0x93, 0x71, 0x6d, 0xa2, 0x0c, 0xc6, 0x83, 0x83, 0xac, 0x4b, 0x37, 0x20, 0x3f,
-	0xa0, 0x49, 0x84, 0x20, 0xd5, 0xa1, 0x4a, 0xa3, 0xc3, 0x99, 0xc1, 0xec, 0x3f, 0x37, 0xaf, 0xa5,
-	0x6b, 0x90, 0xa2, 0x5a, 0xa1, 0xd3, 0x61, 0x57, 0xf7, 0xc8, 0x8e, 0x6b, 0x89, 0x42, 0x32, 0x29,
-	0xca, 0xfd, 0xb5, 0x02, 0x89, 0xfa, 0x5d, 0x0a, 0xe0, 0x76, 0xbb, 0xc6, 0x53, 0xe2, 0x8b, 0x52,
-	0x22, 0xc5, 0x80, 0x9d, 0x4b, 0xf6, 0x2c, 0xbe, 0x5a, 0x67, 0xb0, 0x48, 0xa1, 0x57, 0x00, 0x74,
-	0xc3, 0x20, 0x9e, 0xa7, 0xc9, 0xf0, 0xdd, 0x0c, 0xce, 0x70, 0xca, 0x43, 0x72, 0x44, 0xd9, 0x3c,
-	0x62, 0xb8, 0x84, 0x1b, 0x7f, 0x06, 0x8b, 0x14, 0x65, 0xf3, 0x49, 0xbb, 0xa3, 0xf9, 0xce, 0x53,
-	0x62, 0x33, 0x6d, 0x66, 0x70, 0x86, 0x52, 0x1a, 0x94, 0x40, 0x67, 0x0d, 0xb1, 0xcd, 0x8e, 0x63,
-	0xd9, 0x3e, 0x53, 0x53, 0x06, 0xf7, 0xd2, 0x54, 0xa4, 0x4b, 0x9a, 0x96, 0x08, 0x6c, 0xcd, 0x60,
-	0x91, 0x12, 0xdd, 0xd8, 0x86, 0xe4, 0x46, 0xb5, 0xfe, 0xc2, 0xdd, 0x40, 0x90, 0xd2, 0xbb, 0xc2,
-	0xe8, 0x32, 0x98, 0xfd, 0x17, 0x02, 0xbf, 0xad, 0xc0, 0x0c, 0x53, 0x3d, 0xba, 0x08, 0x19, 0xc3,
-	0xb1, 0x7d, 0xdd, 0xb2, 0xc5, 0xbc, 0xc9, 0xe0, 0x3e, 0x21, 0x52, 0xf2, 0x65, 0xc8, 0xe9, 0x86,
-	0xe1, 0x74, 0x6d, 0x5f, 0xb3, 0xf5, 0x36, 0x11, 0x35, 0x64, 0x05, 0x6d, 0x4b, 0x6f, 0x13, 0x54,
-	0x02, 0x99, 0xec, 0x05, 0x39, 0x67, 0x30, 0x08, 0x52, 0xef, 0x76, 0x49, 0xb8, 0x8b, 0x3f, 0x51,
-	0x60, 0xfe, 0x03, 0xd7, 0xf2, 0x49, 0x45, 0xf7, 0x8d, 0xfd, 0x38, 0x1d, 0xe6, 0xdb, 0x90, 0x31,
-	0x75, 0x5f, 0xe7, 0x01, 0xcd, 0x89, 0xb1, 0x01, 0xcd, 0x72, 0xbe, 0xd1, 0xf2, 0x2c, 0xa8, 0x19,
-	0x41, 0x8a, 0xfe, 0xe7, 0xbe, 0x14, 0xb3, 0xff, 0xfd, 0x9b, 0xa5, 0x60, 0x73, 0xe3, 0xf4, 0x6c,
-	0xff, 0x9c, 0x90, 0x9e, 0x2d, 0x4e, 0x35, 0xbc, 0x07, 0x73, 0x62, 0xd3, 0x24, 0x94, 0xb0, 0x3c,
-	0x69, 0x86, 0xca, 0x1b, 0x11, 0xc1, 0x86, 0x2a, 0x00, 0x9e, 0xaf, 0xbb, 0x3e, 0xdb, 0xee, 0x4c,
-	0x75, 0x05, 0x2d, 0x3d, 0x21, 0x63, 0xa3, 0x54, 0xb4, 0x05, 0xd9, 0xf6, 0x33, 0xc3, 0xd0, 0xf6,
-	0xac, 0x96, 0x2f, 0x6e, 0x9f, 0x0b, 0x03, 0x42, 0x64, 0x4b, 0x36, 0x9f, 0x54, 0xab, 0xf7, 0x58,
-	0x21, 0x7e, 0x09, 0xdc, 0x4f, 0x63, 0xa0, 0x12, 0xf8, 0x7f, 0xf4, 0x05, 0x10, 0x41, 0x6b, 0x9a,
-	0xe7, 0xf9, 0x6c, 0xc2, 0xa5, 0x2b, 0xf9, 0x93, 0xe3, 0x52, 0x06, 0x33, 0x6a, 0xbd, 0xde, 0xc0,
-	0x19, 0x5e, 0xa0, 0xee, 0xc9, 0x95, 0xe9, 0xbb, 0x0a, 0xe4, 0x2b, 0xdd, 0xd6, 0xd3, 0xed, 0x4e,
-	0xbd, 0xdb, 0x6e, 0xeb, 0xee, 0x11, 0xba, 0x20, 0x4d, 0xc4, 0x7a, 0x4e, 0x98, 0x8a, 0x93, 0xc2,
-	0x06, 0xac, 0xe7, 0x84, 0xda, 0x80, 0x08, 0xa4, 0xa1, 0x74, 0x1e, 0x25, 0xf3, 0x2a, 0xe4, 0x19,
-	0xac, 0xd7, 0x88, 0xed, 0xbb, 0x16, 0xe1, 0x9b, 0xca, 0x24, 0xce, 0x31, 0xe2, 0x3a, 0xa7, 0xa1,
-	0xab, 0x50, 0xf0, 0x8e, 0x3c, 0x9f, 0xb4, 0x35, 0xfe, 0x82, 0x81, 0x63, 0xd1, 0x24, 0xce, 0x73,
-	0x2a, 0xe6, 0xc4, 0xf2, 0x9f, 0x25, 0xa1, 0x20, 0x87, 0x3b, 0x4e, 0x68, 0x54, 0x81, 0x99, 0x3d,
-	0xab, 0x45, 0x64, 0x04, 0x50, 0xb4, 0x43, 0x96, 0x92, 0x56, 0xa8, 0xdb, 0x95, 0x40, 0x89, 0xb1,
-	0xc6, 0x31, 0xe4, 0x4b, 0x3f, 0x51, 0x20, 0xc5, 0x56, 0xc1, 0xdb, 0x90, 0x62, 0x73, 0x50, 0x99,
-	0x66, 0x0e, 0xb2, 0xa2, 0x3d, 0xff, 0x9f, 0xe8, 0xfb, 0x7f, 0xe6, 0x7b, 0xf7, 0xf5, 0x37, 0x6f,
-	0xdf, 0x61, 0xc3, 0x9d, 0xc3, 0x22, 0x85, 0x2a, 0x90, 0x26, 0xac, 0x3f, 0xc4, 0x14, 0x6b, 0x50,
-	0x98, 0x85, 0x0f, 0x0c, 0xbc, 0x9c, 0xef, 0x92, 0x0f, 0x9d, 0x87, 0x24, 0xb5, 0xa3, 0x39, 0x7e,
-	0x95, 0x72, 0x72, 0x5c, 0x4a, 0x52, 0x0b, 0xa2, 0x34, 0x7e, 0x21, 0xff, 0x20, 0x95, 0x4e, 0xa9,
-	0x33, 0xe5, 0xbf, 0x48, 0x41, 0xbe, 0xd6, 0x8e, 0x7b, 0x86, 0xae, 0x0e, 0x0e, 0x58, 0x18, 0x44,
-	0x18, 0xa8, 0x34, 0x64, 0xbc, 0x06, 0x7c, 0x5d, 0xf2, 0xc5, 0x7c, 0x5d, 0x8d, 0x2e, 0x40, 0xe2,
-	0xf9, 0x06, 0xad, 0xff, 0xf5, 0x89, 0xf5, 0x37, 0xf4, 0xdd, 0x16, 0xc1, 0x94, 0x47, 0xde, 0x54,
-	0x70, 0x01, 0xe8, 0x97, 0xd8, 0x3a, 0xc7, 0x8d, 0x66, 0x76, 0x7a, 0xa3, 0x99, 0x23, 0xb6, 0xc9,
-	0x4c, 0xe6, 0x50, 0x58, 0xcc, 0x97, 0x21, 0x69, 0x5a, 0xe3, 0x54, 0x1a, 0xe6, 0xaf, 0x28, 0xcb,
-	0x04, 0xc3, 0x49, 0x05, 0x0d, 0xa7, 0x77, 0x9b, 0x91, 0x54, 0x53, 0x4b, 0xdb, 0x00, 0xfd, 0x5e,
-	0xa1, 0x65, 0x98, 0x75, 0x5a, 0x26, 0x05, 0xd3, 0xb4, 0x09, 0xf9, 0x4a, 0xe6, 0xe4, 0xb8, 0x34,
-	0xb3, 0xdd, 0x32, 0x6b, 0x6b, 0x78, 0xc6, 0x69, 0x99, 0x35, 0x93, 0xbd, 0x7a, 0x21, 0x07, 0x1a,
-	0x7b, 0x68, 0xc4, 0xa2, 0x28, 0xf0, 0x9c, 0x4d, 0x0e, 0xd6, 0x88, 0x67, 0x04, 0x57, 0x37, 0x61,
-	0x36, 0x7f, 0xa8, 0x40, 0x41, 0x6a, 0x30, 0xde, 0x99, 0x9e, 0xb6, 0xda, 0xc2, 0xf2, 0x93, 0x2f,
-	0x66, 0xf9, 0x92, 0x4f, 0x44, 0xf4, 0x7e, 0x47, 0x81, 0x05, 0x1e, 0xea, 0x61, 0xe8, 0x3e, 0xf5,
-	0xb5, 0x31, 0x9a, 0xf7, 0x0d, 0x50, 0x5d, 0xdd, 0x36, 0x9d, 0xb6, 0xf5, 0x9c, 0xf0, 0xdd, 0xaa,
-	0x27, 0xce, 0x70, 0x4f, 0xf7, 0xe8, 0x6c, 0x3b, 0x26, 0x37, 0xdb, 0xff, 0xa1, 0xc0, 0x99, 0xc1,
-	0xc6, 0xc4, 0xa9, 0xb4, 0x87, 0x30, 0xcb, 0x0e, 0x5a, 0xe4, 0x74, 0x7b, 0x23, 0x44, 0x48, 0x58,
-	0xed, 0xfc, 0x91, 0x52, 0xcf, 0xe0, 0x99, 0x88, 0xa5, 0xf7, 0x60, 0x86, 0x91, 0x5f, 0xc2, 0xc7,
-	0x09, 0xcd, 0x7f, 0x0c, 0xf3, 0xab, 0xa6, 0x59, 0xaf, 0x0b, 0xeb, 0x8b, 0x4f, 0xed, 0x12, 0xc2,
-	0x24, 0xc2, 0x20, 0x4c, 0xb0, 0xca, 0x38, 0x21, 0x4c, 0x07, 0x0a, 0x22, 0x02, 0x2b, 0xe6, 0x93,
-	0xb5, 0x03, 0x8a, 0xb9, 0x84, 0xd9, 0xf0, 0x44, 0xff, 0xa1, 0x44, 0xaf, 0xc6, 0x38, 0x7b, 0xd2,
-	0x85, 0x05, 0x29, 0x37, 0xee, 0x33, 0xee, 0x71, 0xdd, 0x61, 0x27, 0x14, 0xc1, 0x6a, 0xe3, 0xec,
-	0xd3, 0x9f, 0x2a, 0xb0, 0xb4, 0x41, 0xfc, 0xba, 0xd8, 0xb0, 0xdf, 0x73, 0xdc, 0xd8, 0x4f, 0x7c,
-	0x37, 0x00, 0x5a, 0x64, 0x4f, 0x44, 0xb5, 0x0b, 0xc0, 0x39, 0xfd, 0x13, 0xcc, 0x0c, 0xe5, 0x65,
-	0x59, 0x42, 0x1d, 0x3f, 0x53, 0xe0, 0x42, 0x68, 0x8b, 0xe3, 0xf4, 0x08, 0x21, 0x33, 0x05, 0x7d,
-	0x13, 0x18, 0xda, 0xd4, 0x3c, 0x5f, 0xf7, 0x3d, 0xe1, 0x5c, 0xbf, 0xf0, 0x22, 0x91, 0xb0, 0x95,
-	0x79, 0x11, 0xd6, 0x91, 0xe9, 0x91, 0x70, 0x86, 0x8a, 0x64, 0x7f, 0xcb, 0xff, 0xb9, 0x08, 0x39,
-	0xa1, 0xcb, 0x1d, 0xdb, 0x72, 0x6c, 0x74, 0x0b, 0x92, 0x4d, 0xb1, 0xbd, 0xcb, 0x86, 0x02, 0xe3,
-	0xfe, 0xa3, 0x42, 0x4c, 0x4b, 0x52, 0x86, 0x4e, 0xd7, 0x0f, 0x09, 0xee, 0xe8, 0x5f, 0xec, 0xf7,
-	0x19, 0x3a, 0x5d, 0x1f, 0xbd, 0x0f, 0xa7, 0x8d, 0xfe, 0x33, 0x2c, 0x8d, 0x32, 0x27, 0x23, 0x83,
-	0x40, 0x43, 0x9f, 0xa5, 0xe1, 0x82, 0x31, 0x40, 0x46, 0xab, 0xc1, 0x57, 0x3f, 0xa9, 0xc8, 0x33,
-	0x84, 0xe1, 0x17, 0x47, 0x81, 0xa7, 0x41, 0xe8, 0xcb, 0x30, 0x6b, 0xb2, 0xb7, 0x24, 0xe2, 0x0c,
-	0x22, 0xcc, 0xe8, 0x06, 0x9e, 0xef, 0x60, 0x51, 0x1e, 0xdd, 0x87, 0x1c, 0xff, 0x27, 0x8c, 0x6d,
-	0x36, 0xf2, 0x80, 0x65, 0xf4, 0x2d, 0x0d, 0xce, 0x9a, 0x7d, 0x1a, 0xba, 0x03, 0x29, 0xcf, 0xd0,
-	0xf9, 0x06, 0x3c, 0xfc, 0x6a, 0x3a, 0xf0, 0x26, 0x00, 0xb3, 0xb2, 0xe8, 0x03, 0x98, 0xdf, 0x25,
-	0x4d, 0xcb, 0xd6, 0xfc, 0xfe, 0xe5, 0x11, 0x0b, 0x43, 0x1d, 0xbc, 0xaf, 0xea, 0x2d, 0xc2, 0xe1,
-	0xd1, 0xcf, 0x58, 0xdd, 0x1d, 0xca, 0xa0, 0xc3, 0xc4, 0x30, 0x54, 0x40, 0x6c, 0x26, 0x72, 0x98,
-	0x42, 0xa3, 0x91, 0x71, 0x81, 0x0c, 0x90, 0xd1, 0x3a, 0x64, 0x75, 0xba, 0xa2, 0x69, 0x2c, 0xbe,
-	0xb3, 0x08, 0x91, 0xe7, 0x46, 0x23, 0x21, 0xa7, 0x18, 0xf4, 0x1e, 0xa9, 0x2f, 0xa6, 0x4d, 0xe7,
-	0x60, 0x31, 0x3b, 0x5e, 0x4c, 0xd0, 0xb5, 0x08, 0x31, 0x8c, 0x84, 0x1e, 0x42, 0x7e, 0x5f, 0x46,
-	0x97, 0xb1, 0x5b, 0xbe, 0x5c, 0xe4, 0xc1, 0x51, 0x48, 0x74, 0x1c, 0xce, 0xed, 0x07, 0x88, 0xe8,
-	0x0b, 0x90, 0x68, 0x1a, 0xc5, 0x3c, 0x93, 0x70, 0x71, 0x5c, 0xe4, 0x17, 0x4e, 0x34, 0x0d, 0xf4,
-	0x2e, 0xa4, 0x79, 0x48, 0xcc, 0xa1, 0x5d, 0x2c, 0x44, 0x3a, 0x8c, 0xc1, 0xb0, 0x24, 0xcc, 0x42,
-	0x77, 0x68, 0x5d, 0x5b, 0x50, 0x70, 0xf9, 0x25, 0x9d, 0xbc, 0x8a, 0x56, 0x99, 0x8c, 0xd7, 0xc2,
-	0x9d, 0xce, 0xc8, 0x6d, 0x34, 0xce, 0xbb, 0x41, 0x2a, 0xfa, 0x26, 0x9c, 0x19, 0x94, 0x27, 0x0c,
-	0x79, 0x7e, 0xc4, 0xdb, 0x84, 0x4b, 0x0d, 0xda, 0x33, 0x72, 0x47, 0xb2, 0xd0, 0x9b, 0x30, 0xc3,
-	0x47, 0x0a, 0x31, 0x81, 0xa5, 0xb0, 0xdd, 0x76, 0x70, 0x90, 0x78, 0x69, 0x3a, 0xaf, 0x7c, 0x71,
-	0xf1, 0xa4, 0xb5, 0x9c, 0x66, 0x71, 0x21, 0x72, 0x5e, 0x8d, 0x5e, 0xa4, 0xe1, 0xac, 0xdf, 0xa7,
-	0xd1, 0x91, 0x76, 0x39, 0x5d, 0xdc, 0x52, 0x9c, 0x89, 0x1c, 0xe9, 0x90, 0xdb, 0x28, 0x9c, 0x73,
-	0x03, 0x44, 0xda, 0x2c, 0x97, 0xbf, 0x99, 0xd1, 0xd8, 0x64, 0x3d, 0x1b, 0xd9, 0xac, 0xd1, 0x77,
-	0x3c, 0x38, 0xeb, 0xf6, 0x69, 0xa8, 0x01, 0xaa, 0x78, 0x43, 0xa1, 0xc9, 0x93, 0xed, 0xe2, 0x22,
-	0x93, 0x76, 0x23, 0xd4, 0x13, 0x86, 0x1d, 0xe9, 0xe3, 0xd3, 0xc6, 0x20, 0x9d, 0x3a, 0x04, 0x26,
-	0x4d, 0x33, 0xfa, 0x4f, 0x4f, 0x8a, 0xc5, 0x48, 0x87, 0x10, 0xf1, 0x4e, 0x06, 0xab, 0xc6, 0x50,
-	0x06, 0xf5, 0x4e, 0xb6, 0xe3, 0x74, 0x8a, 0xe7, 0x23, 0xbd, 0x53, 0xe0, 0x1e, 0x17, 0xb3, 0xb2,
-	0xd4, 0xd0, 0x2d, 0xdb, 0xf2, 0x99, 0x93, 0x5f, 0x8a, 0x34, 0xf4, 0xc1, 0x57, 0xb3, 0x78, 0xce,
-	0xe2, 0x69, 0x6a, 0xe8, 0xbe, 0xb8, 0xec, 0x12, 0x03, 0x77, 0x31, 0xd2, 0xd0, 0xc3, 0x6e, 0xc5,
-	0x70, 0xde, 0x0f, 0x52, 0xa9, 0xa1, 0x73, 0xc7, 0x31, 0x24, 0xf5, 0x95, 0x48, 0x43, 0x8f, 0x0c,
-	0xb0, 0xc6, 0x48, 0x1f, 0xc9, 0x42, 0x15, 0x0a, 0x3a, 0x74, 0x8f, 0x7f, 0x67, 0xa0, 0x78, 0x29,
-	0x72, 0x1d, 0x1a, 0xbe, 0xea, 0xa2, 0x78, 0x43, 0x50, 0xa8, 0x73, 0x63, 0x38, 0x4c, 0xdb, 0xd5,
-	0x7d, 0x63, 0xbf, 0x58, 0x8a, 0x74, 0x6e, 0x23, 0x87, 0x95, 0x18, 0x0e, 0x7a, 0x24, 0xba, 0x9c,
-	0xf1, 0x43, 0x85, 0xe2, 0xf2, 0x84, 0xcd, 0x6b, 0x6f, 0x39, 0xe3, 0xe5, 0xd1, 0x57, 0x21, 0xf3,
-	0x71, 0x97, 0xb8, 0x47, 0xcc, 0x39, 0x5d, 0x8e, 0x04, 0x4e, 0x43, 0x41, 0x6d, 0x38, 0xfd, 0xb1,
-	0x20, 0xd0, 0xaa, 0xf9, 0xae, 0xae, 0x58, 0x8e, 0xac, 0x7a, 0x60, 0x1f, 0x8f, 0x45, 0x79, 0xa4,
-	0xc3, 0x59, 0x3e, 0x3e, 0x22, 0x0a, 0xdb, 0x15, 0xe1, 0xce, 0xc5, 0x57, 0x99, 0xa0, 0xc8, 0x1d,
-	0x52, 0x68, 0x44, 0x38, 0x5e, 0xd0, 0x47, 0xf3, 0xa8, 0x2b, 0x10, 0x4b, 0x10, 0xdf, 0x55, 0x15,
-	0xaf, 0x44, 0xba, 0x82, 0x90, 0x7d, 0x28, 0xce, 0xe9, 0x01, 0x22, 0x5f, 0x88, 0x4c, 0xcd, 0xf3,
-	0x7c, 0xba, 0x83, 0x29, 0x5e, 0x1d, 0xb3, 0x10, 0x0d, 0xed, 0xac, 0xd8, 0xa3, 0xa4, 0x3a, 0xe7,
-	0x63, 0x61, 0xe7, 0x2d, 0xa2, 0xbb, 0xc2, 0xed, 0x5e, 0x8b, 0x14, 0x33, 0xf2, 0xe6, 0x14, 0x83,
-	0xd1, 0x23, 0xd1, 0x05, 0xdb, 0x95, 0x8f, 0xb2, 0x04, 0x5e, 0x7c, 0x2d, 0x72, 0xc1, 0x0e, 0x7d,
-	0x3b, 0x86, 0x0b, 0xee, 0x00, 0x19, 0xbd, 0x03, 0x73, 0xe2, 0x7d, 0x4b, 0xf1, 0xfa, 0x18, 0x5c,
-	0x1b, 0xdc, 0x68, 0x61, 0xc9, 0xc1, 0xbd, 0x2e, 0x7f, 0x1c, 0xc3, 0x3b, 0x76, 0x63, 0x8c, 0xd7,
-	0x1d, 0xd9, 0xe1, 0x50, 0xaf, 0xdb, 0x27, 0x52, 0xaf, 0xcb, 0xad, 0x52, 0xac, 0x78, 0x37, 0x23,
-	0xbd, 0xee, 0x68, 0xf0, 0x19, 0x66, 0x71, 0x7f, 0x82, 0x86, 0x76, 0x61, 0xb1, 0x49, 0x7c, 0x4d,
-	0xde, 0x16, 0xb2, 0xe8, 0x47, 0xbe, 0x3c, 0xbd, 0x1e, 0x69, 0x65, 0xd1, 0x9b, 0x15, 0xbc, 0xd0,
-	0x1c, 0xcd, 0x7b, 0x3b, 0xf5, 0x09, 0x3f, 0x74, 0x39, 0xad, 0xaa, 0x0f, 0x52, 0xe9, 0x73, 0x6a,
-	0xf1, 0x41, 0x2a, 0x7d, 0x41, 0xbd, 0x58, 0xfe, 0x9b, 0x45, 0xc8, 0xcb, 0x6d, 0x00, 0x87, 0xdb,
-	0x5f, 0x0c, 0xc2, 0xed, 0x4b, 0x51, 0x70, 0x9b, 0x73, 0x70, 0xbc, 0xfd, 0xc5, 0x20, 0xde, 0xbe,
-	0x14, 0x85, 0xb7, 0x25, 0x07, 0x05, 0xdc, 0x38, 0x0a, 0x70, 0xdf, 0x98, 0x02, 0x70, 0x0b, 0x41,
-	0xc3, 0x88, 0xbb, 0x32, 0x8a, 0xb8, 0xaf, 0x8c, 0x47, 0xdc, 0x42, 0x50, 0x00, 0x72, 0xbf, 0x35,
-	0x04, 0xb9, 0x2f, 0x8f, 0x81, 0xdc, 0x82, 0x5b, 0x62, 0xee, 0x5a, 0x28, 0xe6, 0xbe, 0x36, 0x09,
-	0x73, 0x0b, 0x29, 0x03, 0xa0, 0xfb, 0xee, 0x00, 0xe8, 0x2e, 0x45, 0x82, 0x6e, 0xc1, 0xcb, 0x51,
-	0xf7, 0x87, 0xd1, 0xa8, 0xfb, 0xf5, 0xa9, 0x50, 0xb7, 0x90, 0x36, 0x0a, 0xbb, 0x71, 0x14, 0xec,
-	0xbe, 0x31, 0x05, 0xec, 0x96, 0x83, 0x35, 0x84, 0xbb, 0xef, 0x85, 0xe1, 0xee, 0xab, 0x13, 0x70,
-	0xb7, 0x90, 0x15, 0x04, 0xde, 0xf7, 0xc2, 0x80, 0xf7, 0xd5, 0x09, 0xc0, 0x7b, 0x40, 0x0e, 0x47,
-	0xde, 0x8f, 0xc2, 0x91, 0xf7, 0x6b, 0x13, 0x91, 0xb7, 0x90, 0x35, 0x08, 0xbd, 0xdf, 0x08, 0x40,
-	0xef, 0x57, 0x22, 0xa0, 0xb7, 0x60, 0xa4, 0xd8, 0xfb, 0x2b, 0x23, 0xd8, 0xbb, 0x3c, 0x0e, 0x7b,
-	0x0b, 0xce, 0x1e, 0xf8, 0xde, 0x8e, 0x00, 0xdf, 0xd7, 0x27, 0x83, 0x6f, 0x21, 0x6a, 0x08, 0x7d,
-	0x6b, 0x63, 0xd1, 0xf7, 0x1b, 0x53, 0xa2, 0x6f, 0x21, 0x3b, 0x0c, 0x7e, 0xff, 0xff, 0x41, 0xf8,
-	0xbd, 0x1c, 0x0d, 0xbf, 0x85, 0x10, 0x81, 0xbf, 0x6b, 0xa1, 0xf8, 0xfb, 0xda, 0x24, 0xfc, 0x2d,
-	0xe7, 0x58, 0x10, 0x80, 0x3f, 0x0a, 0x07, 0xe0, 0xaf, 0x4d, 0x04, 0xe0, 0x72, 0xc0, 0x07, 0x10,
-	0x78, 0x2d, 0x14, 0x81, 0x5f, 0x9b, 0x84, 0xc0, 0x65, 0xc3, 0x82, 0x10, 0x7c, 0x27, 0x12, 0x82,
-	0xdf, 0x9c, 0x06, 0x82, 0x0b, 0x91, 0x23, 0x18, 0xfc, 0xc3, 0x68, 0x0c, 0xfe, 0xfa, 0x54, 0x18,
-	0x5c, 0xba, 0x87, 0x11, 0x10, 0x7e, 0x77, 0x00, 0x84, 0x97, 0x22, 0x41, 0xb8, 0xf4, 0x56, 0x0c,
-	0x85, 0x7f, 0x65, 0x04, 0x85, 0x97, 0xc7, 0xa1, 0x70, 0x69, 0xf2, 0x12, 0x86, 0x6b, 0x63, 0x61,
-	0xf3, 0x1b, 0x53, 0xc2, 0x66, 0x69, 0xa1, 0x21, 0xb8, 0xb9, 0x1a, 0x82, 0x9b, 0xaf, 0x8c, 0xc7,
-	0xcd, 0x72, 0x35, 0xe9, 0x03, 0xe7, 0x7b, 0x61, 0xc0, 0xf9, 0xea, 0x04, 0xe0, 0x2c, 0x9d, 0x53,
-	0x00, 0x39, 0xbf, 0x35, 0x84, 0x9c, 0x2f, 0x4f, 0xbc, 0xb7, 0xec, 0x41, 0xe7, 0xf7, 0x46, 0xa1,
-	0xf3, 0xab, 0x63, 0xa1, 0xb3, 0xe0, 0xef, 0x63, 0xe7, 0xb7, 0x86, 0xb0, 0xf3, 0xe5, 0x31, 0xd8,
-	0x59, 0x56, 0x2e, 0xc0, 0xf3, 0xee, 0x78, 0xf0, 0xbc, 0x32, 0x2d, 0x78, 0x16, 0x62, 0x43, 0xd1,
-	0xf3, 0xa3, 0x70, 0xf4, 0xfc, 0xda, 0x94, 0x57, 0x17, 0x43, 0xf0, 0xf9, 0x5e, 0x18, 0x7c, 0xbe,
-	0x3a, 0x01, 0x3e, 0xf7, 0x97, 0x93, 0x1e, 0x7e, 0xbe, 0x17, 0x86, 0x9f, 0xaf, 0x4e, 0xc0, 0xcf,
-	0x52, 0x4e, 0x00, 0x40, 0xe3, 0x28, 0x00, 0x7d, 0x63, 0x0a, 0x00, 0x2d, 0x97, 0xde, 0x21, 0x04,
-	0xfd, 0xee, 0x30, 0x82, 0x2e, 0x8f, 0x43, 0xd0, 0x72, 0xe6, 0x49, 0x08, 0xfd, 0x28, 0x1c, 0x42,
-	0xbf, 0x36, 0x11, 0x42, 0xf7, 0xfd, 0x66, 0x00, 0x43, 0xd7, 0x42, 0x31, 0xf4, 0xb5, 0x49, 0x18,
-	0x5a, 0xfa, 0xcd, 0x20, 0x88, 0x36, 0x26, 0x80, 0xe8, 0x95, 0x69, 0x41, 0xb4, 0xb4, 0xb6, 0x17,
-	0x40, 0xd1, 0x0f, 0x52, 0xe9, 0x8b, 0xea, 0x2b, 0xe5, 0xef, 0xcf, 0xc0, 0xec, 0x7d, 0x79, 0x71,
-	0x1d, 0x78, 0x65, 0xa8, 0xbc, 0xcc, 0x2b, 0x43, 0xb4, 0x46, 0xc7, 0x89, 0x59, 0xb9, 0x40, 0xd6,
-	0x63, 0xde, 0xec, 0x8e, 0x5c, 0x17, 0x48, 0xd6, 0x97, 0x08, 0xb2, 0x46, 0x6f, 0x42, 0xbe, 0xeb,
-	0x11, 0x57, 0xeb, 0xb8, 0x96, 0xe3, 0x5a, 0x3e, 0x0f, 0x53, 0x52, 0x2a, 0xea, 0xa7, 0xc7, 0xa5,
-	0xdc, 0x8e, 0x47, 0xdc, 0xc7, 0x82, 0x8e, 0x73, 0xdd, 0x40, 0x4a, 0x7e, 0x59, 0x71, 0x66, 0xfa,
-	0x2f, 0x2b, 0xbe, 0x0f, 0xaa, 0x4b, 0x74, 0x73, 0x60, 0x49, 0xe2, 0xaf, 0xf1, 0xc2, 0x57, 0x4e,
-	0xdd, 0x0c, 0xac, 0x3b, 0xec, 0x55, 0xde, 0x69, 0x77, 0x90, 0x88, 0x6e, 0xc3, 0xd9, 0xb6, 0x7e,
-	0xc8, 0xdf, 0x9b, 0xca, 0xf5, 0x9d, 0x5d, 0xe0, 0xa7, 0x59, 0x9c, 0x09, 0x6a, 0xeb, 0x87, 0xec,
-	0x33, 0x8d, 0x3c, 0x8b, 0x7d, 0xd6, 0xe9, 0x2a, 0x14, 0x4c, 0xcb, 0xf3, 0x2d, 0xdb, 0x90, 0x5f,
-	0x6a, 0xe0, 0x9f, 0x44, 0xc8, 0x4b, 0x2a, 0xff, 0x62, 0xc2, 0x4d, 0x98, 0x17, 0x61, 0x35, 0xfd,
-	0x0f, 0x37, 0x32, 0xdc, 0x9a, 0xa6, 0xad, 0xa0, 0x19, 0xfd, 0xef, 0x6c, 0x56, 0xe1, 0x74, 0x53,
-	0xf7, 0xc9, 0x81, 0x7e, 0xa4, 0xd9, 0x8e, 0xc9, 0x74, 0x9f, 0x65, 0xef, 0xd5, 0x2f, 0x9c, 0x1c,
-	0x97, 0xf2, 0x1b, 0x3c, 0x6b, 0xcb, 0x31, 0xf9, 0x08, 0xcc, 0xf2, 0x7f, 0x38, 0xdf, 0x0c, 0x64,
-	0x98, 0x68, 0x15, 0x72, 0x14, 0x4b, 0x68, 0x0e, 0xff, 0x30, 0x92, 0x40, 0xa4, 0x51, 0x47, 0xf0,
-	0xe2, 0xf3, 0x49, 0x38, 0xeb, 0xf5, 0x13, 0xe2, 0x3b, 0x0e, 0xdf, 0x57, 0x20, 0x37, 0x10, 0x42,
-	0xf6, 0xce, 0xd0, 0xd5, 0xd0, 0xf9, 0x70, 0x94, 0x1b, 0x15, 0x92, 0x91, 0x16, 0x8a, 0x95, 0xd7,
-	0xc4, 0xa5, 0x68, 0xcc, 0xc4, 0x76, 0x94, 0xf2, 0x62, 0x5d, 0xb2, 0xbd, 0x9d, 0xfa, 0xbd, 0x1f,
-	0x94, 0x4e, 0x95, 0x7f, 0x9e, 0x84, 0xfc, 0x60, 0xa8, 0x58, 0x6d, 0xa8, 0x5d, 0x61, 0x4e, 0x65,
-	0x80, 0x23, 0xba, 0x95, 0x6b, 0x90, 0x71, 0x45, 0x21, 0xd9, 0xcc, 0xe5, 0x31, 0x17, 0x60, 0xc1,
-	0x76, 0xf6, 0x19, 0x97, 0x7e, 0x9c, 0xe8, 0x4d, 0xe8, 0x15, 0x98, 0x61, 0x9f, 0x82, 0x15, 0x4d,
-	0x0b, 0x8b, 0xaa, 0x5e, 0xa7, 0xf9, 0x98, 0x17, 0xa3, 0x0e, 0xa0, 0xf1, 0x52, 0xcf, 0x8c, 0x7b,
-	0x84, 0x97, 0xf8, 0x54, 0xe9, 0x4b, 0x3e, 0x87, 0xad, 0xd3, 0xdd, 0x78, 0xab, 0x45, 0x0c, 0x5f,
-	0x7c, 0x51, 0x56, 0x7e, 0x90, 0xf4, 0xca, 0xb0, 0x08, 0xf1, 0xfd, 0xd9, 0x15, 0x2c, 0xbe, 0x3f,
-	0x1b, 0xb8, 0xb9, 0x2f, 0xf4, 0x44, 0xb0, 0xf9, 0xc2, 0xe3, 0x3b, 0xf8, 0x50, 0xdf, 0xac, 0xc3,
-	0x42, 0xc8, 0xec, 0x45, 0x05, 0x80, 0xea, 0xf6, 0x56, 0xbd, 0x56, 0x6f, 0xac, 0x6f, 0x35, 0xe4,
-	0x67, 0x45, 0x57, 0xd7, 0xb4, 0x9d, 0xad, 0xea, 0xf6, 0xe6, 0x66, 0xad, 0xd1, 0x58, 0x5f, 0x53,
-	0x15, 0xa4, 0x42, 0xae, 0xb6, 0x15, 0x28, 0x27, 0xbe, 0x26, 0x7a, 0xf3, 0x03, 0xc8, 0x06, 0x1e,
-	0xe8, 0x22, 0x04, 0x85, 0xc7, 0x3b, 0xf5, 0xfb, 0x5a, 0xa3, 0xb6, 0xb9, 0x5e, 0x6f, 0xac, 0x6e,
-	0x3e, 0x56, 0x4f, 0xd1, 0x0a, 0x18, 0x6d, 0xb5, 0xb2, 0x8d, 0x1b, 0xaa, 0xd2, 0x4b, 0x37, 0xb6,
-	0x77, 0xaa, 0xf7, 0xd5, 0x44, 0x2f, 0xfd, 0xfe, 0xce, 0x3a, 0xfe, 0x48, 0x4d, 0x0a, 0xc1, 0x3a,
-	0x9c, 0x0d, 0x8d, 0x88, 0x46, 0x59, 0x98, 0xdb, 0xb1, 0xd9, 0x23, 0x51, 0xf5, 0x14, 0xca, 0x07,
-	0x82, 0xa2, 0x55, 0x05, 0xa5, 0x79, 0xf0, 0xad, 0x9a, 0x40, 0xb3, 0x90, 0xa8, 0xdf, 0x55, 0x93,
-	0xe8, 0x34, 0x64, 0x03, 0x91, 0xc5, 0x6a, 0x0a, 0x65, 0x44, 0x78, 0xa9, 0x3a, 0x73, 0xf3, 0x32,
-	0x04, 0xa2, 0xf7, 0x10, 0xc0, 0xec, 0x23, 0xdd, 0x27, 0x9e, 0xaf, 0x9e, 0x42, 0x73, 0x90, 0x5c,
-	0x6d, 0xb5, 0x54, 0xe5, 0xce, 0x87, 0x90, 0x96, 0x9f, 0x9b, 0x41, 0x8f, 0x60, 0x86, 0x23, 0xc1,
-	0x52, 0xf4, 0x8c, 0x60, 0x73, 0x6b, 0x69, 0x79, 0xd2, 0x94, 0x29, 0x9f, 0xaa, 0x5c, 0xfe, 0xe4,
-	0x5f, 0x2f, 0x9d, 0xfa, 0xe4, 0xe4, 0x92, 0xf2, 0x93, 0x93, 0x4b, 0xca, 0x3f, 0x9e, 0x5c, 0x52,
-	0xfe, 0xe5, 0xe4, 0x92, 0xf2, 0xdb, 0xff, 0x76, 0xe9, 0xd4, 0xd7, 0xe6, 0x04, 0xcb, 0xee, 0x2c,
-	0xfb, 0x78, 0xf0, 0xdd, 0xff, 0x0e, 0x00, 0x00, 0xff, 0xff, 0x9b, 0xa5, 0xf6, 0x67, 0x41, 0x59,
-	0x00, 0x00,
+	// 5568 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xdc, 0x5c, 0x5d, 0x6c, 0x1b, 0xcb,
+	0x75, 0xd6, 0x92, 0x94, 0x44, 0x1e, 0xfe, 0x98, 0x1a, 0xff, 0xd1, 0xb2, 0xaf, 0x29, 0xf3, 0xda,
+	0xbe, 0xb6, 0x6f, 0x22, 0xd7, 0x72, 0x8c, 0xa4, 0xf7, 0xe6, 0x4f, 0xa4, 0x74, 0x45, 0x5a, 0x57,
+	0x3f, 0x77, 0x48, 0xf9, 0xc6, 0x37, 0x4d, 0x36, 0xab, 0xdd, 0x11, 0xb5, 0x31, 0xb9, 0x4b, 0xef,
+	0x2e, 0x2d, 0xc9, 0x40, 0xd1, 0x02, 0x2d, 0x90, 0x22, 0x08, 0x82, 0x02, 0x0d, 0x8a, 0xa2, 0x45,
+	0xd1, 0x00, 0x7d, 0xe8, 0x53, 0xd3, 0x16, 0x28, 0x50, 0xa0, 0x0f, 0xc9, 0x4b, 0x1f, 0xf2, 0x50,
+	0x14, 0x69, 0x81, 0x04, 0x45, 0x81, 0x0a, 0xad, 0xda, 0x87, 0xa0, 0xaf, 0x7d, 0xbb, 0x4f, 0xc5,
+	0xfc, 0xec, 0x0f, 0xc9, 0x5d, 0x92, 0x76, 0xf6, 0xa2, 0x69, 0x9f, 0xc8, 0x39, 0x33, 0xe7, 0xcc,
+	0xcc, 0x99, 0x33, 0x67, 0xbe, 0x99, 0x39, 0xb3, 0xb0, 0x60, 0x99, 0x8a, 0x7a, 0xd8, 0xdb, 0xbf,
+	0xaf, 0xf4, 0xf4, 0xe5, 0x9e, 0x65, 0x3a, 0x26, 0x5a, 0x50, 0x4d, 0xf5, 0x19, 0x23, 0x2f, 0x8b,
+	0xcc, 0x45, 0xe4, 0x96, 0xd2, 0x14, 0x47, 0xe1, 0xc5, 0x16, 0x2f, 0xb8, 0x34, 0x62, 0x59, 0xa6,
+	0x65, 0x0b, 0xea, 0x25, 0x97, 0xda, 0x25, 0x8e, 0x12, 0x28, 0x5d, 0xb1, 0x1d, 0xd3, 0x52, 0xda,
+	0xe4, 0x3e, 0x31, 0xda, 0xba, 0xe1, 0xfe, 0xd0, 0x72, 0x2f, 0x54, 0x55, 0x94, 0x79, 0x73, 0x5c,
+	0x99, 0x87, 0xa2, 0x50, 0xa9, 0xef, 0xe8, 0x9d, 0xfb, 0x87, 0x1d, 0xf5, 0xbe, 0xa3, 0x77, 0x89,
+	0xed, 0x28, 0xdd, 0x9e, 0xc8, 0x59, 0x62, 0x39, 0x8e, 0xa5, 0xa8, 0xba, 0xd1, 0xbe, 0x6f, 0x11,
+	0xd5, 0xb4, 0x34, 0xa2, 0xc9, 0x76, 0x4f, 0x31, 0xdc, 0x26, 0xb7, 0xcd, 0xb6, 0xc9, 0xfe, 0xde,
+	0xa7, 0xff, 0x38, 0xb5, 0xf2, 0x1b, 0x90, 0xc1, 0x8a, 0xd1, 0x26, 0x0d, 0xe3, 0xc0, 0x44, 0x9f,
+	0x87, 0x94, 0x46, 0x6c, 0xb5, 0x24, 0x2d, 0x49, 0x77, 0xb2, 0x2b, 0x95, 0xe5, 0x11, 0x5d, 0x2c,
+	0xb3, 0xb2, 0x6b, 0xc4, 0x56, 0x2d, 0xbd, 0xe7, 0x98, 0x56, 0x35, 0xf5, 0xe3, 0xd3, 0xf2, 0x0c,
+	0x66, 0x5c, 0xe8, 0x33, 0x30, 0xdb, 0x21, 0x8a, 0x4d, 0x4a, 0x09, 0xc6, 0x5e, 0x0a, 0x61, 0x7f,
+	0x9f, 0xe6, 0x0b, 0x26, 0x5e, 0xb8, 0xf2, 0x12, 0xf2, 0x98, 0x3c, 0xef, 0x13, 0xdb, 0xa9, 0x13,
+	0x45, 0x23, 0x16, 0xba, 0x02, 0xc9, 0x67, 0xe4, 0xa4, 0x94, 0x5c, 0x92, 0xee, 0xe4, 0xaa, 0xf3,
+	0x1f, 0x9f, 0x96, 0x93, 0x9b, 0xe4, 0x04, 0x53, 0x1a, 0x5a, 0x82, 0x79, 0x62, 0x68, 0x32, 0xcd,
+	0x4e, 0x0d, 0x66, 0xcf, 0x11, 0x43, 0xdb, 0x24, 0x27, 0x68, 0x11, 0xd2, 0x36, 0x95, 0x66, 0xa8,
+	0xa4, 0x34, 0xbb, 0x24, 0xdd, 0x99, 0xc5, 0x5e, 0xfa, 0x9d, 0xd4, 0xcf, 0xbf, 0x5f, 0x96, 0x1e,
+	0xa7, 0xd2, 0x52, 0x31, 0xf1, 0x38, 0x95, 0x4e, 0x14, 0x93, 0x95, 0xef, 0x24, 0xa1, 0x80, 0x89,
+	0xdd, 0x33, 0x0d, 0x9b, 0x88, 0xda, 0x7f, 0x05, 0x92, 0xce, 0xb1, 0xc1, 0x6a, 0xcf, 0xae, 0x5c,
+	0x0f, 0xe9, 0x42, 0xcb, 0x52, 0x0c, 0x5b, 0x51, 0x1d, 0xdd, 0x34, 0x30, 0x2d, 0x8a, 0x3e, 0x07,
+	0x59, 0x8b, 0xd8, 0xfd, 0x2e, 0x61, 0xca, 0x66, 0x0d, 0xcb, 0xae, 0x5c, 0x0e, 0xe1, 0x6c, 0xf6,
+	0x14, 0x03, 0x03, 0x2f, 0x4b, 0xff, 0xa3, 0x2b, 0x90, 0x36, 0xfa, 0x5d, 0xda, 0x1d, 0x9b, 0x35,
+	0x36, 0x89, 0xe7, 0x8d, 0x7e, 0x77, 0x93, 0x9c, 0xd8, 0xa8, 0x06, 0x59, 0x8b, 0xaa, 0x5a, 0xd6,
+	0x8d, 0x03, 0xd3, 0x2e, 0xcd, 0x2d, 0x25, 0xef, 0x64, 0x57, 0xae, 0x45, 0x0d, 0x08, 0x1d, 0x3c,
+	0xa1, 0x55, 0xb0, 0x5c, 0x82, 0x8d, 0x9a, 0x90, 0x17, 0x2d, 0xb3, 0x88, 0x62, 0x9b, 0x46, 0x69,
+	0x7e, 0x49, 0xba, 0x53, 0x58, 0x59, 0x0e, 0x13, 0x33, 0xa0, 0x05, 0x9a, 0xec, 0x77, 0x09, 0x66,
+	0x5c, 0x38, 0x67, 0x05, 0x52, 0x95, 0xa7, 0x90, 0x0b, 0xe6, 0x22, 0x04, 0x05, 0xbc, 0xde, 0xdc,
+	0xdb, 0x5a, 0x97, 0xf7, 0xb6, 0x37, 0xb7, 0x77, 0x3e, 0xdc, 0x2e, 0xce, 0xa0, 0x0b, 0x50, 0x14,
+	0xb4, 0xcd, 0xf5, 0xa7, 0xf2, 0xfb, 0x8d, 0xad, 0x46, 0xab, 0x28, 0xa1, 0x2b, 0x70, 0x51, 0x50,
+	0xf1, 0xea, 0xf6, 0xc6, 0xba, 0x5c, 0xdd, 0xd9, 0xdb, 0x5e, 0x5b, 0xc5, 0x4f, 0x8b, 0x89, 0xc5,
+	0xd4, 0xef, 0xfc, 0xe9, 0xf5, 0x99, 0xca, 0x13, 0x80, 0x0d, 0xe2, 0x08, 0x6b, 0x40, 0x55, 0x98,
+	0x3b, 0x64, 0xad, 0x11, 0xe6, 0xb8, 0x14, 0xda, 0xec, 0x80, 0xe5, 0x54, 0xd3, 0x54, 0x03, 0x3f,
+	0x39, 0x2d, 0x4b, 0x58, 0x70, 0xf2, 0x21, 0xaf, 0xfc, 0x48, 0x82, 0x2c, 0x13, 0xcc, 0xfb, 0x88,
+	0x6a, 0x43, 0x92, 0x6f, 0x4c, 0x54, 0xc8, 0xa8, 0x68, 0xb4, 0x0c, 0xb3, 0x2f, 0x94, 0x4e, 0x7f,
+	0x9c, 0xb5, 0x3f, 0xa1, 0xf9, 0x98, 0x17, 0x43, 0xef, 0x42, 0x4e, 0x37, 0x1c, 0x62, 0x38, 0x32,
+	0x67, 0x4b, 0x4e, 0x60, 0xcb, 0xf2, 0xd2, 0x2c, 0x51, 0xf9, 0x5b, 0x09, 0x60, 0xb7, 0x1f, 0xa7,
+	0x6a, 0xe8, 0x6c, 0x9d, 0xaa, 0xfd, 0xee, 0x6c, 0xe5, 0xbd, 0xb8, 0x04, 0x73, 0xba, 0xd1, 0xd1,
+	0x0d, 0xde, 0xfe, 0x34, 0x16, 0x29, 0x74, 0x01, 0x66, 0xf7, 0x3b, 0xba, 0xa1, 0x31, 0xf3, 0x4f,
+	0x63, 0x9e, 0x10, 0xea, 0xc7, 0x90, 0x65, 0x6d, 0x8f, 0x51, 0xfb, 0x95, 0xff, 0x94, 0xe0, 0x62,
+	0xcd, 0x34, 0x34, 0x9d, 0xce, 0x43, 0xa5, 0xf3, 0x4b, 0xa1, 0x9b, 0x47, 0x90, 0x21, 0xc7, 0xbd,
+	0x29, 0x87, 0x37, 0x4d, 0x8e, 0x7b, 0xec, 0xdf, 0x58, 0xd5, 0x7d, 0x0d, 0x2e, 0x0d, 0xf7, 0x32,
+	0x4e, 0x2d, 0xfe, 0x93, 0x04, 0x85, 0x86, 0xa1, 0x3b, 0xbf, 0x14, 0xea, 0xf3, 0xf4, 0x90, 0x0c,
+	0xe8, 0x01, 0xdd, 0x83, 0xe2, 0x81, 0xa2, 0x77, 0x76, 0x8c, 0x96, 0xd9, 0xdd, 0xb7, 0x1d, 0xd3,
+	0x20, 0xb6, 0x50, 0xd4, 0x08, 0x5d, 0xe8, 0xec, 0x09, 0x9c, 0xf3, 0xfa, 0x14, 0xa7, 0xb2, 0x5e,
+	0x42, 0xb1, 0x61, 0xa8, 0x16, 0xe9, 0x12, 0x23, 0x56, 0x6d, 0x5d, 0x83, 0x8c, 0xee, 0xca, 0x65,
+	0x1a, 0x4b, 0x62, 0x9f, 0x20, 0xfa, 0xd4, 0x87, 0x85, 0x40, 0xdd, 0x71, 0xba, 0xb1, 0xab, 0x90,
+	0x31, 0xc8, 0x91, 0xec, 0x8f, 0x57, 0x12, 0xa7, 0x0d, 0x72, 0xc4, 0xdd, 0xce, 0x53, 0xc8, 0xaf,
+	0x91, 0x0e, 0x71, 0x48, 0xfc, 0x3e, 0x79, 0x0f, 0x0a, 0xae, 0xe8, 0x38, 0x07, 0xe9, 0x8f, 0x25,
+	0x40, 0x42, 0x2e, 0x5d, 0x07, 0xe3, 0x1c, 0xa7, 0x32, 0x5d, 0xe7, 0x9d, 0xbe, 0x65, 0xf0, 0x05,
+	0x9b, 0x5b, 0x29, 0x70, 0x12, 0x5b, 0xb3, 0x7d, 0xdf, 0x98, 0x0a, 0xfa, 0x46, 0x0f, 0x77, 0x50,
+	0xc4, 0x71, 0x04, 0xe7, 0x07, 0x9a, 0x17, 0xef, 0x50, 0xa6, 0x58, 0xcb, 0x12, 0x4b, 0xc9, 0x20,
+	0x34, 0x62, 0xc4, 0xca, 0xd7, 0x60, 0xa1, 0xd6, 0x21, 0x8a, 0x15, 0xb7, 0x5a, 0xc4, 0x70, 0x3e,
+	0x05, 0x14, 0x14, 0x1f, 0xe7, 0x90, 0xea, 0x90, 0x6d, 0xaa, 0x8a, 0xb1, 0xd3, 0xa3, 0x4e, 0xd0,
+	0x46, 0x0f, 0xe1, 0x92, 0xed, 0x98, 0x3d, 0x59, 0x71, 0x64, 0x8e, 0x90, 0xf6, 0xcd, 0xbe, 0xa1,
+	0x29, 0xd6, 0x09, 0xab, 0x23, 0x8d, 0xcf, 0xd3, 0xdc, 0x55, 0x87, 0x35, 0xa4, 0x2a, 0xb2, 0xe8,
+	0xd8, 0x75, 0x75, 0x43, 0xa6, 0x40, 0xa6, 0xe3, 0xd8, 0xc2, 0xce, 0xa1, 0xab, 0x1b, 0x98, 0x53,
+	0x44, 0x2f, 0x54, 0x5e, 0x55, 0xec, 0xea, 0xe1, 0x83, 0xff, 0x38, 0x95, 0x4e, 0x16, 0x53, 0x95,
+	0x7f, 0x90, 0x20, 0xc7, 0x6b, 0x89, 0x73, 0xf0, 0x1f, 0x41, 0xca, 0x32, 0x8f, 0xf8, 0xe0, 0x67,
+	0x57, 0xae, 0x86, 0x88, 0xd8, 0x24, 0x27, 0x41, 0xaf, 0xcb, 0x8a, 0xa3, 0x2a, 0x08, 0x9c, 0x21,
+	0x33, 0xee, 0xe4, 0xb4, 0xdc, 0xc0, 0xb9, 0xb0, 0x79, 0x64, 0x57, 0xbe, 0x09, 0x08, 0x93, 0x17,
+	0xc4, 0xb2, 0xc9, 0x27, 0xaf, 0xbc, 0x9f, 0x4a, 0x70, 0x7e, 0xa0, 0xb2, 0xff, 0x27, 0x3a, 0xfc,
+	0x4d, 0x09, 0x2e, 0xd7, 0x0e, 0x89, 0xfa, 0xac, 0x66, 0x1a, 0xb6, 0x6e, 0x3b, 0xc4, 0x50, 0x4f,
+	0xe2, 0x74, 0x5e, 0x57, 0x21, 0x73, 0xa4, 0x3b, 0x87, 0xb2, 0xa6, 0x1f, 0x1c, 0x30, 0xf3, 0x4f,
+	0xe3, 0x34, 0x25, 0xac, 0xe9, 0x07, 0x07, 0xc2, 0xf8, 0x65, 0x28, 0x8d, 0xb6, 0x20, 0xde, 0x05,
+	0xf4, 0x22, 0x26, 0xaa, 0xd9, 0xed, 0xf5, 0x1d, 0xd2, 0x74, 0x14, 0xc7, 0x8e, 0xb3, 0x83, 0x97,
+	0x61, 0x5e, 0xb3, 0x4e, 0x64, 0xab, 0x6f, 0x88, 0xee, 0xcd, 0x69, 0xd6, 0x09, 0xee, 0x1b, 0xa2,
+	0x73, 0x7f, 0x23, 0xc1, 0xa5, 0xe1, 0xca, 0xe3, 0x34, 0x9d, 0xaf, 0x40, 0x56, 0xd1, 0xe8, 0x86,
+	0x5b, 0x23, 0x1d, 0x47, 0x11, 0xc0, 0xe7, 0x41, 0x40, 0x92, 0xd8, 0xdd, 0x2f, 0xf3, 0x6d, 0xfd,
+	0xb2, 0xbb, 0xbb, 0x5f, 0xde, 0x7a, 0x52, 0xab, 0xb1, 0xf6, 0xac, 0x51, 0x46, 0xd7, 0x32, 0x98,
+	0x2c, 0x46, 0xa9, 0xa8, 0x70, 0xb9, 0x4a, 0xda, 0xba, 0x11, 0xdc, 0x77, 0xc6, 0xee, 0xbe, 0x65,
+	0x28, 0x8d, 0x56, 0x12, 0xe7, 0xd8, 0xff, 0x63, 0x12, 0x2e, 0xae, 0x1b, 0xda, 0x27, 0xd3, 0x09,
+	0xba, 0xf2, 0xaa, 0x66, 0xb7, 0xab, 0x3b, 0xee, 0xd8, 0xf3, 0x14, 0xfa, 0x55, 0x48, 0x6b, 0x44,
+	0xd1, 0xbc, 0xfd, 0x4a, 0x76, 0xe5, 0x8d, 0x80, 0xf4, 0xbe, 0xa3, 0x77, 0x96, 0x0f, 0x3b, 0xea,
+	0x72, 0xcb, 0x3d, 0x4b, 0xc1, 0x5e, 0x71, 0xf4, 0x0d, 0xb8, 0x4c, 0xa7, 0xa7, 0x65, 0x28, 0x1d,
+	0x99, 0x4b, 0x93, 0x1d, 0x4b, 0x6f, 0xb7, 0x89, 0x25, 0x76, 0xf8, 0x77, 0x42, 0xda, 0xd9, 0x10,
+	0x1c, 0x35, 0xc6, 0xd0, 0xe2, 0xe5, 0xf1, 0x45, 0x3d, 0x8c, 0x8c, 0xbe, 0xec, 0x6d, 0x08, 0xed,
+	0x9e, 0x62, 0xd8, 0xa5, 0x59, 0xe6, 0x37, 0xa2, 0x0e, 0x0e, 0x84, 0x65, 0x08, 0x4f, 0x43, 0x29,
+	0x36, 0xba, 0x4f, 0x11, 0xc9, 0xf3, 0xbe, 0x6e, 0x11, 0xf9, 0x41, 0x4f, 0x2d, 0xcd, 0xd1, 0xbe,
+	0x57, 0x0b, 0x67, 0xa7, 0x65, 0xc0, 0x9c, 0xfc, 0x60, 0xb7, 0x46, 0x11, 0x0a, 0xff, 0xdf, 0x53,
+	0xd1, 0x1d, 0x28, 0x1a, 0xa6, 0x6c, 0x91, 0x03, 0x8b, 0xd8, 0x87, 0xa2, 0xda, 0x34, 0xd3, 0x58,
+	0xc1, 0x30, 0x31, 0x27, 0x73, 0xd1, 0x97, 0x60, 0xae, 0x67, 0xea, 0xb6, 0x69, 0x94, 0x32, 0x5c,
+	0xa3, 0x3c, 0xe5, 0x79, 0xe4, 0xf9, 0x62, 0xba, 0xf2, 0x7b, 0x12, 0x5c, 0x1a, 0x1e, 0xd3, 0x38,
+	0xe7, 0xd4, 0x1d, 0x28, 0x9a, 0x06, 0x91, 0x7b, 0x87, 0x8a, 0x4d, 0xc4, 0x18, 0x08, 0x64, 0x55,
+	0x30, 0x0d, 0xb2, 0x4b, 0xc9, 0x5c, 0xa3, 0x03, 0x2b, 0xc4, 0x6f, 0x49, 0xb0, 0xb0, 0xaa, 0x75,
+	0x75, 0xa3, 0xd9, 0xeb, 0xe8, 0xb1, 0x02, 0xf5, 0x9b, 0x90, 0xb1, 0xa9, 0x4c, 0x76, 0xfe, 0x94,
+	0x18, 0x3c, 0x7f, 0x4a, 0xb3, 0x9c, 0x4d, 0x72, 0xe2, 0xe3, 0xa1, 0x60, 0x23, 0xe2, 0x9c, 0x4a,
+	0x5f, 0x13, 0xfd, 0xdb, 0x22, 0xd6, 0x27, 0x84, 0xe4, 0x82, 0xe2, 0xe3, 0x6c, 0xf9, 0xb7, 0x25,
+	0xb8, 0xc2, 0x64, 0x33, 0x93, 0x39, 0x20, 0x16, 0x3b, 0x0e, 0x8c, 0x73, 0x88, 0xde, 0x84, 0x39,
+	0x47, 0xb1, 0xda, 0x84, 0x3b, 0x82, 0xd9, 0x6a, 0xf6, 0xe3, 0xd3, 0xf2, 0x7c, 0xd3, 0x31, 0x2d,
+	0xd2, 0x58, 0xc3, 0x22, 0x4b, 0xf4, 0x53, 0x81, 0xc5, 0xb0, 0xb6, 0xc4, 0xd9, 0xdf, 0xff, 0x96,
+	0x44, 0x1d, 0xb5, 0x43, 0x0e, 0x8b, 0x7b, 0x1d, 0x5d, 0x55, 0x62, 0x5d, 0xf6, 0xd6, 0x21, 0xab,
+	0x32, 0xe1, 0xb2, 0x73, 0xd2, 0xe3, 0x1b, 0xb8, 0xc2, 0xca, 0xcd, 0x50, 0x41, 0xac, 0x72, 0xde,
+	0x92, 0xd6, 0x49, 0x8f, 0x60, 0x50, 0xbd, 0xff, 0x68, 0x0d, 0xe6, 0xb9, 0x72, 0x5c, 0xf8, 0x32,
+	0x46, 0x04, 0x9d, 0xe8, 0x2d, 0x56, 0x58, 0xf8, 0x24, 0x97, 0x55, 0x28, 0x76, 0x1f, 0xae, 0x86,
+	0x76, 0x3a, 0x4e, 0xcd, 0xfe, 0xbe, 0x04, 0xe7, 0xeb, 0x44, 0xb1, 0x9c, 0x7d, 0xa2, 0x38, 0xad,
+	0xe3, 0x58, 0x17, 0x93, 0x47, 0x90, 0x34, 0xcc, 0x23, 0xb1, 0x84, 0x8f, 0x5f, 0x2f, 0x84, 0x02,
+	0x68, 0x79, 0xd1, 0xf9, 0xaf, 0xc2, 0x85, 0xc1, 0x76, 0xc5, 0xd9, 0xeb, 0xbf, 0x4a, 0x42, 0x66,
+	0xa3, 0x16, 0x67, 0x5f, 0x3f, 0x2f, 0xb6, 0x8c, 0x7c, 0xd0, 0xc3, 0x0e, 0xfc, 0xbd, 0xfa, 0x96,
+	0x37, 0x6a, 0x9b, 0xe4, 0xc4, 0x05, 0xbe, 0x94, 0x0b, 0xad, 0x42, 0xc6, 0x39, 0xa4, 0x6b, 0x86,
+	0xd9, 0xd1, 0xc4, 0xaa, 0x38, 0x95, 0xbe, 0x7c, 0x2e, 0xd4, 0x81, 0x8b, 0xce, 0xb1, 0xc1, 0x96,
+	0x22, 0xb9, 0xad, 0xca, 0xbe, 0xb8, 0xd9, 0x69, 0xc4, 0x2d, 0x52, 0x71, 0x67, 0xa7, 0x65, 0xd4,
+	0x3a, 0x36, 0xe8, 0xba, 0xb5, 0x51, 0x6b, 0xb9, 0x02, 0x30, 0x72, 0x04, 0x4d, 0xf5, 0x68, 0x8b,
+	0xcf, 0x60, 0x96, 0xf5, 0xc2, 0xbd, 0x63, 0x90, 0x42, 0xee, 0x18, 0x68, 0xa7, 0xdc, 0x0a, 0x5e,
+	0xc5, 0x08, 0x7c, 0x2e, 0x6e, 0x0a, 0xc2, 0x20, 0x3e, 0x00, 0xa0, 0x2a, 0x8c, 0xd3, 0x0c, 0x7e,
+	0x98, 0x84, 0xc2, 0x6e, 0xdf, 0x3e, 0x8c, 0xd9, 0xee, 0x6b, 0x00, 0xbd, 0xbe, 0x7d, 0x48, 0x2c,
+	0xd9, 0x39, 0x36, 0x44, 0xcf, 0x27, 0x5c, 0x80, 0xb8, 0x5d, 0xe7, 0x7c, 0xad, 0x63, 0x03, 0xed,
+	0x08, 0x21, 0x44, 0xf6, 0x6f, 0x51, 0xee, 0x4d, 0x01, 0x83, 0x5b, 0xc7, 0xc6, 0x16, 0xf1, 0xf0,
+	0x2f, 0x17, 0x48, 0xa8, 0xc0, 0xcf, 0xc3, 0x3c, 0x4d, 0xc8, 0x8e, 0xf9, 0x2a, 0x16, 0x36, 0x47,
+	0x79, 0x5a, 0xa6, 0x3b, 0x97, 0x67, 0x5f, 0x6d, 0x2e, 0xa3, 0x77, 0x21, 0xc3, 0x2b, 0xa5, 0x3e,
+	0x75, 0x8e, 0xf9, 0xd4, 0x30, 0x4d, 0x88, 0x41, 0x60, 0xde, 0x34, 0xcd, 0x6a, 0xa4, 0xbe, 0xf4,
+	0x02, 0xcc, 0x1e, 0x98, 0x96, 0x4a, 0xd8, 0x6d, 0x4b, 0x1a, 0xf3, 0x84, 0x07, 0x9c, 0xd2, 0xc5,
+	0x4c, 0xe5, 0x8f, 0x24, 0x38, 0xe7, 0x0d, 0x60, 0x9c, 0x88, 0xa9, 0x36, 0xa0, 0xfd, 0x57, 0x1f,
+	0x42, 0xaa, 0xf1, 0xca, 0x0f, 0x12, 0x70, 0xee, 0x83, 0x3e, 0xb1, 0x4e, 0x62, 0xb6, 0xaf, 0x2a,
+	0xbf, 0x59, 0x4b, 0xbc, 0xa6, 0x4d, 0xb0, 0xbb, 0xb6, 0xdb, 0x70, 0xee, 0x48, 0xd1, 0x1d, 0xf9,
+	0xc0, 0xb4, 0xe4, 0x7e, 0x4f, 0x53, 0x1c, 0xf7, 0x1e, 0x22, 0x4f, 0xc9, 0xef, 0x99, 0xd6, 0x1e,
+	0x23, 0x22, 0x02, 0xe8, 0x99, 0x61, 0x1e, 0x19, 0x32, 0x25, 0xeb, 0x46, 0x9b, 0xea, 0xc3, 0x2e,
+	0xa5, 0xd8, 0xc1, 0xd8, 0x67, 0xff, 0xe5, 0xb4, 0xfc, 0xb0, 0xad, 0x3b, 0x87, 0xfd, 0xfd, 0x65,
+	0xd5, 0xec, 0xde, 0xf7, 0x1a, 0xa2, 0xed, 0xfb, 0xff, 0xef, 0xf7, 0x9e, 0xb5, 0xef, 0xb3, 0x2b,
+	0xd5, 0x7e, 0x5f, 0xd7, 0x96, 0xf7, 0xf6, 0x1a, 0x6b, 0xb8, 0xc8, 0x44, 0x7e, 0xc8, 0x25, 0xb6,
+	0x8e, 0x0d, 0x77, 0xc1, 0xfb, 0x58, 0x82, 0xa2, 0xaf, 0xb0, 0x38, 0xc7, 0x73, 0x1d, 0xb2, 0xcf,
+	0xfb, 0xc4, 0xd2, 0x89, 0xf6, 0xca, 0x03, 0x0a, 0x82, 0x91, 0xce, 0xa1, 0x8f, 0x20, 0x37, 0xa0,
+	0x87, 0xe4, 0x2f, 0xa6, 0x87, 0xec, 0x91, 0xaf, 0x82, 0xca, 0x0f, 0x13, 0x80, 0x58, 0xe7, 0x1b,
+	0xfc, 0x30, 0xe3, 0x97, 0xcc, 0x60, 0x9e, 0x00, 0xe8, 0x07, 0x72, 0x57, 0xb7, 0x6d, 0xdd, 0x68,
+	0x33, 0x5b, 0x29, 0xac, 0x7c, 0x36, 0xa4, 0x2d, 0xa3, 0x5d, 0x58, 0x6e, 0x1c, 0x6c, 0x71, 0xb6,
+	0x2a, 0x39, 0x54, 0x5e, 0xe8, 0xa6, 0x85, 0x33, 0xba, 0x4b, 0xaa, 0x54, 0x61, 0x61, 0x24, 0x1f,
+	0x15, 0x00, 0xd6, 0x76, 0xe4, 0xed, 0x9d, 0x56, 0xbd, 0xb1, 0xbd, 0x51, 0x9c, 0x41, 0x45, 0xc8,
+	0xe1, 0xf5, 0xd6, 0x1e, 0xde, 0x96, 0xd7, 0x31, 0xde, 0xc1, 0x45, 0x09, 0x65, 0x61, 0x7e, 0x17,
+	0xaf, 0x3f, 0x59, 0xdf, 0x6e, 0x15, 0x13, 0xc2, 0x7a, 0x7e, 0x1d, 0xce, 0x0f, 0x54, 0x1e, 0xa7,
+	0xfd, 0xdc, 0x80, 0xdc, 0x81, 0xd9, 0x37, 0x34, 0x99, 0xef, 0x1a, 0xc5, 0xee, 0x38, 0xcb, 0x68,
+	0xbc, 0xbe, 0xca, 0xb7, 0x12, 0x70, 0x01, 0x13, 0xdb, 0xec, 0xbc, 0x20, 0xf1, 0x8f, 0xe0, 0x0e,
+	0x88, 0x33, 0x2e, 0xf9, 0x17, 0x19, 0xc8, 0x0c, 0x97, 0xc1, 0x57, 0x83, 0x39, 0xdb, 0x51, 0x9c,
+	0xbe, 0x2d, 0x86, 0xf2, 0xe6, 0xf8, 0xb9, 0xd0, 0x64, 0x65, 0xb1, 0xe0, 0x09, 0x6c, 0x6a, 0x53,
+	0xa3, 0x9b, 0xda, 0xca, 0xaf, 0xc1, 0xc5, 0x21, 0x45, 0xc4, 0xb9, 0x68, 0xff, 0x2c, 0x01, 0x57,
+	0x06, 0xc5, 0xc7, 0x7d, 0x3f, 0xf1, 0x7f, 0x43, 0xd9, 0xa8, 0x0e, 0xf9, 0xae, 0x6e, 0xc8, 0x3e,
+	0xc6, 0x7a, 0x85, 0xc5, 0x39, 0x47, 0xf7, 0x6b, 0x83, 0x30, 0x8b, 0xee, 0xe3, 0xc2, 0xf4, 0x1a,
+	0xe7, 0xd8, 0x15, 0x20, 0xb7, 0x6d, 0x9a, 0x3d, 0xb7, 0x5c, 0x25, 0x0f, 0x59, 0x9e, 0x66, 0x03,
+	0x52, 0xf9, 0xae, 0x04, 0xb9, 0xb8, 0x37, 0xe3, 0xaf, 0x77, 0x87, 0x2a, 0x54, 0xd2, 0x82, 0xfc,
+	0x27, 0xb0, 0x7b, 0xff, 0x33, 0x09, 0x50, 0xcb, 0xea, 0x1b, 0xaa, 0xe2, 0x90, 0xf7, 0xcd, 0x76,
+	0x9c, 0x9d, 0xbd, 0x00, 0xb3, 0xba, 0xa1, 0x91, 0x63, 0xd6, 0xd9, 0x14, 0xe6, 0x09, 0xf4, 0x00,
+	0xd2, 0x22, 0x06, 0x86, 0xdf, 0x09, 0x27, 0xab, 0x97, 0xce, 0x4e, 0xcb, 0xf3, 0x3c, 0xe2, 0x65,
+	0xed, 0x63, 0xff, 0x2f, 0x9e, 0xe7, 0x41, 0x2f, 0xee, 0xad, 0xf9, 0x47, 0x70, 0x7e, 0xa0, 0xa1,
+	0x71, 0x6a, 0xe1, 0x07, 0x09, 0x38, 0x2f, 0xba, 0x13, 0xfb, 0xe9, 0xc5, 0x6b, 0x05, 0x50, 0xa1,
+	0x2f, 0x00, 0xf4, 0x2c, 0xf2, 0x42, 0xe6, 0xac, 0xc9, 0xa9, 0x58, 0x33, 0x94, 0x83, 0x11, 0xd0,
+	0x57, 0xe0, 0x1c, 0x9d, 0x8f, 0x3d, 0xcb, 0xec, 0x99, 0x36, 0x05, 0x1a, 0xf6, 0x74, 0x40, 0x7b,
+	0xe1, 0xec, 0xb4, 0x9c, 0xdf, 0xd2, 0x8d, 0x5d, 0xc1, 0xd8, 0x6a, 0x62, 0x3a, 0xb1, 0xbd, 0xa4,
+	0x8b, 0x8e, 0x7e, 0x2a, 0xc1, 0x85, 0x4f, 0xec, 0xbc, 0xe7, 0x7f, 0x43, 0x63, 0xde, 0x72, 0x51,
+	0x64, 0xc9, 0x86, 0x71, 0x60, 0xc6, 0x7f, 0x0a, 0xf7, 0x5d, 0x09, 0x16, 0x02, 0xe2, 0xe3, 0x04,
+	0x05, 0xaf, 0x17, 0xa6, 0xf7, 0x55, 0x0a, 0x13, 0x82, 0x66, 0x1f, 0xe7, 0xa4, 0xfa, 0xed, 0x04,
+	0x5c, 0xaa, 0xf1, 0xbb, 0x19, 0x76, 0x05, 0x65, 0xf7, 0xbb, 0x71, 0x5a, 0x49, 0x09, 0xe6, 0x5f,
+	0x10, 0xcb, 0xd6, 0x4d, 0xbe, 0x2c, 0xe6, 0xb1, 0x9b, 0x44, 0xdf, 0x84, 0xac, 0x2a, 0x2a, 0x74,
+	0xbd, 0x4c, 0xae, 0xda, 0xa0, 0x02, 0x5e, 0x13, 0x1c, 0x9f, 0x9d, 0x96, 0xc1, 0xed, 0x42, 0x63,
+	0x0d, 0x83, 0x2b, 0xbd, 0xa1, 0xb1, 0xd0, 0x44, 0x43, 0xe9, 0xd9, 0x87, 0xa6, 0x7b, 0x8c, 0xed,
+	0xa5, 0xc5, 0xa0, 0x7f, 0x1d, 0x2e, 0x8f, 0x68, 0x21, 0x4e, 0x35, 0xff, 0xfd, 0x3c, 0xe4, 0xd7,
+	0x8f, 0x7b, 0xa6, 0xe5, 0x34, 0x39, 0x16, 0x40, 0x6b, 0x90, 0xee, 0x59, 0xe6, 0x0b, 0xdd, 0x15,
+	0x5c, 0x08, 0xbd, 0xd6, 0x18, 0xe0, 0xd9, 0x15, 0xe5, 0xb1, 0xc7, 0x89, 0x30, 0x64, 0xde, 0x37,
+	0x55, 0xa5, 0xf3, 0x9e, 0xde, 0x71, 0xad, 0x6a, 0x79, 0x92, 0x98, 0x65, 0x8f, 0x63, 0x57, 0x71,
+	0x0e, 0xdd, 0x49, 0xe6, 0x11, 0xd1, 0x06, 0xa4, 0xeb, 0x8e, 0xd3, 0xa3, 0x99, 0x62, 0x86, 0xde,
+	0x9a, 0x28, 0x92, 0x32, 0x08, 0x49, 0x1e, 0x33, 0xc2, 0xb0, 0xb0, 0x61, 0x9a, 0xed, 0x0e, 0xa9,
+	0x75, 0xcc, 0xbe, 0x56, 0x33, 0x8d, 0x03, 0xbd, 0x2d, 0x3c, 0xdc, 0xcd, 0x89, 0x12, 0x37, 0x6a,
+	0x4d, 0x3c, 0xca, 0x8e, 0xbe, 0x04, 0xe9, 0xe6, 0x43, 0x21, 0x8a, 0xc3, 0x97, 0x37, 0x27, 0x8a,
+	0x6a, 0x3e, 0xc4, 0x1e, 0x13, 0xaa, 0x43, 0x76, 0xf5, 0x65, 0xdf, 0x22, 0x42, 0xc6, 0x1c, 0x93,
+	0x71, 0x7b, 0xa2, 0x0c, 0xc6, 0x83, 0x83, 0xac, 0x8b, 0x77, 0x21, 0x3f, 0xa0, 0x49, 0x84, 0x20,
+	0xd5, 0xa3, 0x4a, 0xa3, 0xc3, 0x99, 0xc1, 0xec, 0x3f, 0x37, 0xaf, 0xc5, 0xdb, 0x90, 0xa2, 0x5a,
+	0xa1, 0xd3, 0x61, 0x5f, 0xb1, 0xc9, 0x9e, 0xa5, 0x8b, 0x42, 0x6e, 0x52, 0x94, 0xfb, 0x3b, 0x09,
+	0x12, 0xcd, 0x87, 0x14, 0xc0, 0xed, 0xf7, 0xd5, 0x67, 0xc4, 0x11, 0xa5, 0x44, 0x8a, 0x01, 0x3b,
+	0x8b, 0x1c, 0xe8, 0x7c, 0xb5, 0xce, 0x60, 0x91, 0x42, 0x6f, 0x00, 0x28, 0xaa, 0x4a, 0x6c, 0x5b,
+	0x76, 0xc3, 0x77, 0x33, 0x38, 0xc3, 0x29, 0x9b, 0xe4, 0x84, 0xb2, 0xd9, 0x44, 0xb5, 0x08, 0x37,
+	0xfe, 0x0c, 0x16, 0x29, 0xca, 0xe6, 0x90, 0x6e, 0x4f, 0x76, 0xcc, 0x67, 0xc4, 0x60, 0xda, 0xcc,
+	0xe0, 0x0c, 0xa5, 0xb4, 0x28, 0x81, 0xce, 0x1a, 0x62, 0x68, 0x3d, 0x53, 0x37, 0x1c, 0xa6, 0xa6,
+	0x0c, 0xf6, 0xd2, 0x54, 0xa4, 0x45, 0xda, 0xba, 0x08, 0x6c, 0xcd, 0x60, 0x91, 0x12, 0xdd, 0xd8,
+	0x81, 0xe4, 0x46, 0xad, 0xf9, 0xca, 0xdd, 0x40, 0x90, 0x52, 0xfa, 0xc2, 0xe8, 0x32, 0x98, 0xfd,
+	0x17, 0x02, 0xbf, 0x25, 0xc1, 0x2c, 0x53, 0x3d, 0xba, 0x06, 0x19, 0xd5, 0x34, 0x1c, 0x45, 0x37,
+	0xc4, 0xbc, 0xc9, 0x60, 0x9f, 0x10, 0x29, 0xf9, 0x06, 0xe4, 0x14, 0x55, 0x35, 0xfb, 0x86, 0x23,
+	0x1b, 0x4a, 0x97, 0x88, 0x1a, 0xb2, 0x82, 0xb6, 0xad, 0x74, 0x09, 0x2a, 0x83, 0x9b, 0xf4, 0x82,
+	0x9c, 0x33, 0x18, 0x04, 0xc9, 0xbb, 0x5d, 0x12, 0xee, 0xe2, 0xcf, 0x25, 0x58, 0xf8, 0xd0, 0xd2,
+	0x1d, 0x52, 0x55, 0x1c, 0xf5, 0x30, 0x4e, 0x87, 0xf9, 0x0e, 0x64, 0x34, 0xc5, 0x51, 0x78, 0x40,
+	0x73, 0x62, 0x6c, 0x40, 0xb3, 0x3b, 0xdf, 0x68, 0x79, 0x16, 0xd4, 0x8c, 0x20, 0x45, 0xff, 0x73,
+	0x5f, 0x8a, 0xd9, 0x7f, 0xff, 0x66, 0x29, 0xd8, 0xdc, 0x38, 0x3d, 0xdb, 0xbf, 0x26, 0x5c, 0xcf,
+	0x16, 0xa7, 0x1a, 0xbe, 0x0c, 0xf3, 0x62, 0xd3, 0x24, 0x94, 0xb0, 0x34, 0x69, 0x86, 0xba, 0x37,
+	0x22, 0x82, 0x0d, 0x55, 0x01, 0x6c, 0x47, 0xb1, 0x1c, 0xb6, 0xdd, 0x99, 0xea, 0x0a, 0xda, 0xf5,
+	0x84, 0x8c, 0x8d, 0x52, 0xd1, 0x36, 0x64, 0xbb, 0x2f, 0x54, 0x55, 0x3e, 0xd0, 0x3b, 0x8e, 0xb8,
+	0x7d, 0x2e, 0x0c, 0x08, 0x71, 0x5b, 0xb2, 0xf5, 0xa4, 0x56, 0x7b, 0x8f, 0x15, 0xe2, 0x97, 0xc0,
+	0x7e, 0x1a, 0x03, 0x95, 0xc0, 0xff, 0xa3, 0x4f, 0x81, 0x08, 0x5a, 0x93, 0x6d, 0xdb, 0x61, 0x13,
+	0x2e, 0x5d, 0xcd, 0x9f, 0x9d, 0x96, 0x33, 0x98, 0x51, 0x9b, 0xcd, 0x16, 0xce, 0xf0, 0x02, 0x4d,
+	0xdb, 0x5d, 0x99, 0xbe, 0x23, 0x41, 0xbe, 0xda, 0xef, 0x3c, 0xdb, 0xe9, 0x35, 0xfb, 0xdd, 0xae,
+	0x62, 0x9d, 0xa0, 0xab, 0xae, 0x89, 0xe8, 0x2f, 0x09, 0x53, 0x71, 0x52, 0xd8, 0x80, 0xfe, 0x92,
+	0x50, 0x1b, 0x10, 0x81, 0x34, 0x94, 0xce, 0xa3, 0x64, 0xde, 0x84, 0x3c, 0x83, 0xf5, 0x32, 0x31,
+	0x1c, 0x4b, 0x27, 0x7c, 0x53, 0x99, 0xc4, 0x39, 0x46, 0x5c, 0xe7, 0x34, 0x74, 0x0b, 0x0a, 0xf6,
+	0x89, 0xed, 0x90, 0xae, 0xcc, 0x5f, 0x30, 0x70, 0x2c, 0x9a, 0xc4, 0x79, 0x4e, 0xc5, 0x9c, 0x58,
+	0xf9, 0xcb, 0x24, 0x14, 0xdc, 0xe1, 0x8e, 0x13, 0x1a, 0x55, 0x61, 0xf6, 0x40, 0xef, 0x10, 0x37,
+	0x02, 0x28, 0xda, 0x21, 0xbb, 0x92, 0x96, 0xa9, 0xdb, 0x75, 0x81, 0x12, 0x63, 0x8d, 0x63, 0xc8,
+	0x17, 0x7f, 0x22, 0x41, 0x8a, 0xad, 0x82, 0x0f, 0x20, 0xc5, 0xe6, 0xa0, 0x34, 0xcd, 0x1c, 0x64,
+	0x45, 0x3d, 0xff, 0x9f, 0xf0, 0xfd, 0x3f, 0xf3, 0xbd, 0x87, 0xca, 0xa3, 0x07, 0x2b, 0x6c, 0xb8,
+	0x73, 0x58, 0xa4, 0x50, 0x15, 0xd2, 0x84, 0xf5, 0x87, 0x68, 0x62, 0x0d, 0x0a, 0xb3, 0xf0, 0x81,
+	0x81, 0x77, 0xe7, 0xbb, 0xcb, 0x87, 0xae, 0x40, 0x92, 0xda, 0xd1, 0x3c, 0xbf, 0x4a, 0x39, 0x3b,
+	0x2d, 0x27, 0xa9, 0x05, 0x51, 0x1a, 0xbf, 0x90, 0x7f, 0x9c, 0x4a, 0xa7, 0x8a, 0xb3, 0x95, 0xbf,
+	0x4e, 0x41, 0xbe, 0xd1, 0x8d, 0x7b, 0x86, 0xae, 0x0e, 0x0e, 0x58, 0x18, 0x44, 0x18, 0xa8, 0x34,
+	0x64, 0xbc, 0x06, 0x7c, 0x5d, 0xf2, 0xd5, 0x7c, 0x5d, 0x83, 0x2e, 0x40, 0xe2, 0xf9, 0x06, 0xad,
+	0xff, 0xed, 0x89, 0xf5, 0xb7, 0x94, 0xfd, 0x0e, 0xc1, 0x94, 0xc7, 0xbd, 0xa9, 0xe0, 0x02, 0xd0,
+	0x17, 0xd9, 0x3a, 0xc7, 0x8d, 0x66, 0x6e, 0x7a, 0xa3, 0x99, 0x27, 0x86, 0xc6, 0x4c, 0xe6, 0x58,
+	0x58, 0xcc, 0xe7, 0x20, 0xa9, 0xe9, 0xe3, 0x54, 0x1a, 0xe6, 0xaf, 0x28, 0xcb, 0x04, 0xc3, 0x49,
+	0x05, 0x0d, 0xc7, 0xbb, 0xcd, 0x48, 0x16, 0x53, 0x8b, 0x3b, 0x00, 0x7e, 0xaf, 0xd0, 0x12, 0xcc,
+	0x99, 0x1d, 0x8d, 0x82, 0x69, 0xda, 0x84, 0x7c, 0x35, 0x73, 0x76, 0x5a, 0x9e, 0xdd, 0xe9, 0x68,
+	0x8d, 0x35, 0x3c, 0x6b, 0x76, 0xb4, 0x86, 0xc6, 0x5e, 0xbd, 0x90, 0x23, 0x99, 0x3d, 0x34, 0x62,
+	0x51, 0x14, 0x78, 0xde, 0x20, 0x47, 0x6b, 0xc4, 0x56, 0x83, 0xab, 0x9b, 0x30, 0x9b, 0x3f, 0x91,
+	0xa0, 0xe0, 0x6a, 0x30, 0xde, 0x99, 0x9e, 0xd6, 0xbb, 0xc2, 0xf2, 0x93, 0xaf, 0x66, 0xf9, 0x2e,
+	0x9f, 0x88, 0xe8, 0xfd, 0xb6, 0x04, 0xe7, 0x79, 0xa8, 0x87, 0xaa, 0x38, 0xd4, 0xd7, 0xc6, 0x68,
+	0xde, 0x77, 0xa1, 0x68, 0x29, 0x86, 0x66, 0x76, 0xf5, 0x97, 0x84, 0xef, 0x56, 0x6d, 0x71, 0x86,
+	0x7b, 0xce, 0xa3, 0xb3, 0xed, 0x98, 0xbb, 0xd9, 0xfe, 0x2f, 0x09, 0x2e, 0x0c, 0x36, 0x26, 0x4e,
+	0xa5, 0x6d, 0xc2, 0x1c, 0x3b, 0x68, 0x71, 0xa7, 0xdb, 0xa7, 0x43, 0x84, 0x84, 0xd5, 0xce, 0x1f,
+	0x29, 0x79, 0x06, 0xcf, 0x44, 0x2c, 0x7e, 0x19, 0x66, 0x19, 0xf9, 0x35, 0x7c, 0x9c, 0xd0, 0xfc,
+	0x73, 0x58, 0x58, 0xd5, 0xb4, 0x66, 0x53, 0x58, 0x5f, 0x7c, 0x6a, 0x77, 0x21, 0x4c, 0x22, 0x0c,
+	0xc2, 0x04, 0xab, 0x8c, 0x13, 0xc2, 0xf4, 0xa0, 0x20, 0x22, 0xb0, 0x62, 0x3e, 0x59, 0x3b, 0xa2,
+	0x98, 0x4b, 0x98, 0x0d, 0x4f, 0xf8, 0x0f, 0x25, 0xbc, 0x1a, 0xe3, 0xec, 0x49, 0x1f, 0xce, 0xbb,
+	0x72, 0xe3, 0x3e, 0xe3, 0x1e, 0xd7, 0x1d, 0x76, 0x42, 0x11, 0xac, 0x36, 0xce, 0x3e, 0xfd, 0x85,
+	0x04, 0x8b, 0x1b, 0xc4, 0x69, 0x8a, 0x0d, 0xfb, 0x7b, 0xa6, 0x15, 0xfb, 0x89, 0xef, 0x06, 0x40,
+	0x87, 0x1c, 0x88, 0xa8, 0x76, 0x01, 0x38, 0xa7, 0x7f, 0x82, 0x99, 0xa1, 0xbc, 0x2c, 0x4b, 0xa8,
+	0xe3, 0x67, 0x12, 0x5c, 0x0d, 0x6d, 0x71, 0x9c, 0x1e, 0x21, 0x64, 0xa6, 0xa0, 0xaf, 0x03, 0x43,
+	0x9b, 0xb2, 0xed, 0x28, 0x8e, 0x2d, 0x9c, 0xeb, 0xa7, 0x5e, 0x25, 0x12, 0xb6, 0xba, 0x20, 0xc2,
+	0x3a, 0x32, 0x1e, 0x09, 0x67, 0xa8, 0x48, 0xf6, 0xb7, 0xf2, 0xc3, 0xcb, 0x90, 0x13, 0xba, 0xdc,
+	0x33, 0x74, 0xd3, 0x40, 0x0f, 0x20, 0xd9, 0x16, 0xdb, 0xbb, 0x6c, 0x28, 0x30, 0xf6, 0x1f, 0x15,
+	0xd6, 0x67, 0x30, 0x2d, 0x4b, 0x59, 0x7a, 0x7d, 0x27, 0x24, 0xbc, 0xc3, 0xbf, 0xda, 0x0f, 0xb2,
+	0xf4, 0xfa, 0x0e, 0x6a, 0xc2, 0x39, 0xd5, 0x7f, 0x8a, 0x25, 0x53, 0xf6, 0x64, 0x64, 0x20, 0x68,
+	0xe8, 0xd3, 0xb4, 0xfa, 0x0c, 0x2e, 0xa8, 0x03, 0x19, 0xa8, 0x16, 0x7c, 0xfb, 0x93, 0x8a, 0x3c,
+	0x49, 0x18, 0x7e, 0x77, 0x54, 0x9f, 0x09, 0x3c, 0x11, 0x42, 0xef, 0xc0, 0x9c, 0xc6, 0xde, 0x94,
+	0x88, 0xb3, 0x88, 0x30, 0xe3, 0x1b, 0x78, 0xc6, 0x53, 0x9f, 0xc1, 0x82, 0x03, 0x3d, 0x86, 0x1c,
+	0xff, 0x27, 0xcc, 0x6e, 0x2e, 0xf2, 0xa8, 0x65, 0xf4, 0x55, 0x4d, 0x7d, 0x06, 0x67, 0x35, 0x9f,
+	0x8a, 0x3e, 0x03, 0x29, 0x5b, 0x55, 0xf8, 0x66, 0x3c, 0xfc, 0x9a, 0x3a, 0xf0, 0x3e, 0xa0, 0x4e,
+	0x7d, 0xb9, 0xaa, 0x18, 0xe8, 0x29, 0x2c, 0xec, 0x93, 0xb6, 0x6e, 0xc8, 0x8e, 0x7f, 0x95, 0xc4,
+	0x82, 0x52, 0x07, 0x6f, 0xaf, 0xbc, 0x25, 0x39, 0x3c, 0x16, 0xba, 0x3e, 0x83, 0x8b, 0xfb, 0x43,
+	0x59, 0x74, 0xc8, 0x18, 0xa6, 0x0a, 0x08, 0xce, 0x44, 0x0e, 0x59, 0x68, 0x74, 0x32, 0x1d, 0x32,
+	0x32, 0x90, 0x81, 0x36, 0x20, 0xab, 0xd0, 0x35, 0x4e, 0x66, 0x11, 0x9f, 0x25, 0x88, 0x3c, 0x49,
+	0x1a, 0x09, 0x42, 0xad, 0xb3, 0xc0, 0x6e, 0x97, 0xe8, 0x0b, 0xea, 0xd2, 0x79, 0x59, 0xca, 0x8e,
+	0x17, 0x14, 0x74, 0x37, 0x9e, 0x20, 0x46, 0x44, 0x5b, 0x90, 0x3f, 0x74, 0x63, 0xce, 0xd8, 0xdd,
+	0x5f, 0x2e, 0xf2, 0x38, 0x29, 0x24, 0x66, 0xae, 0x3e, 0x83, 0x73, 0x87, 0x01, 0x32, 0x5a, 0x86,
+	0x44, 0x5b, 0x2d, 0xe5, 0x99, 0x8c, 0x6b, 0xe3, 0x22, 0xc2, 0xea, 0x33, 0x38, 0xd1, 0x56, 0x29,
+	0x72, 0xe5, 0xc1, 0x32, 0xc7, 0x46, 0xa9, 0x10, 0xe9, 0x4a, 0x06, 0x03, 0x96, 0xea, 0x33, 0x98,
+	0x85, 0xf5, 0xd0, 0xfa, 0x76, 0xa1, 0x60, 0xf1, 0x0b, 0x3c, 0xf7, 0x9a, 0xba, 0xc8, 0xa4, 0xbc,
+	0x15, 0xee, 0x90, 0x46, 0x6e, 0xaa, 0xeb, 0x33, 0x38, 0x6f, 0x05, 0xe9, 0xe8, 0x1b, 0x70, 0x61,
+	0x50, 0xa2, 0x30, 0xee, 0x85, 0x11, 0x5f, 0x14, 0x2e, 0x77, 0xd0, 0xc6, 0x91, 0x35, 0x92, 0x89,
+	0x3e, 0x0b, 0xb3, 0x7c, 0xd4, 0x10, 0x13, 0x59, 0x0e, 0xdb, 0x8d, 0x0f, 0x0e, 0x18, 0x2f, 0x4f,
+	0xe7, 0x9b, 0x23, 0xae, 0xa6, 0xe4, 0x8e, 0xd9, 0x2e, 0x9d, 0x8f, 0x9c, 0x6f, 0xa3, 0x57, 0x6d,
+	0x74, 0xbe, 0x39, 0x3e, 0x95, 0x8e, 0xbb, 0xc5, 0x73, 0xc4, 0x4d, 0xc6, 0x85, 0xc8, 0x71, 0x0f,
+	0xb9, 0xb1, 0xa2, 0xe3, 0x6e, 0x05, 0xc8, 0xb4, 0x69, 0x16, 0x7f, 0x59, 0x23, 0xb3, 0x69, 0x7c,
+	0x31, 0xb2, 0x69, 0xa3, 0xaf, 0x7d, 0x68, 0xd3, 0x2c, 0x9f, 0x8a, 0x9e, 0x40, 0x51, 0xbc, 0xb5,
+	0x90, 0xdd, 0x13, 0xf0, 0xd2, 0x25, 0x26, 0xef, 0x6e, 0xa8, 0xb7, 0x0c, 0x3b, 0xfa, 0xaf, 0xcf,
+	0xe0, 0x73, 0xea, 0x60, 0x0e, 0x75, 0x16, 0x4c, 0x9e, 0xac, 0xfa, 0x8f, 0x54, 0x4a, 0xa5, 0x48,
+	0x67, 0x11, 0xf1, 0xa2, 0x86, 0x3a, 0x0b, 0x75, 0x28, 0x8b, 0x7a, 0x2f, 0xc3, 0x34, 0x7b, 0xa5,
+	0x2b, 0x91, 0xde, 0x2b, 0x70, 0xe7, 0x4b, 0xbd, 0x17, 0x2d, 0x4d, 0x8d, 0x5f, 0x37, 0x74, 0x87,
+	0x2d, 0x07, 0x8b, 0x91, 0xc6, 0x3f, 0xf8, 0xc6, 0x96, 0x1a, 0xbf, 0xce, 0x29, 0xd4, 0xf8, 0x1d,
+	0x71, 0x39, 0x26, 0x06, 0xf1, 0x5a, 0xa4, 0xf1, 0x87, 0xdd, 0xa2, 0x51, 0xe3, 0x77, 0x82, 0x74,
+	0x6a, 0xfc, 0xdc, 0xad, 0x0c, 0xc9, 0x7d, 0x23, 0xd2, 0xf8, 0x23, 0x43, 0xb2, 0xa9, 0xf1, 0x2b,
+	0x23, 0x99, 0x68, 0x8d, 0x02, 0x15, 0xc5, 0xe6, 0xdf, 0x26, 0x28, 0x5d, 0x8f, 0x5c, 0xb5, 0x86,
+	0xaf, 0xc7, 0xea, 0x0c, 0xa5, 0x08, 0x1a, 0x75, 0x7f, 0x0c, 0xbd, 0xc9, 0xfb, 0x8a, 0xa3, 0x1e,
+	0x96, 0xca, 0x91, 0xee, 0x6f, 0xe4, 0x88, 0x93, 0xba, 0xbf, 0x23, 0x8f, 0x48, 0x97, 0x3f, 0x7e,
+	0x18, 0x51, 0x5a, 0x9a, 0xb0, 0xe9, 0x0d, 0x2c, 0x7f, 0x9c, 0x03, 0xad, 0x42, 0xe6, 0x79, 0x9f,
+	0x58, 0x27, 0xcc, 0x79, 0xdd, 0x88, 0x84, 0x5c, 0x43, 0xe1, 0x70, 0xf5, 0x19, 0x9c, 0x7e, 0x2e,
+	0x48, 0xb4, 0x7a, 0xbe, 0x23, 0x2c, 0x55, 0x22, 0xab, 0x1f, 0x38, 0x03, 0xa0, 0xd5, 0x73, 0x0e,
+	0xa4, 0xc2, 0x45, 0x3e, 0x56, 0x22, 0x86, 0xdb, 0x12, 0xc1, 0xd2, 0xa5, 0x37, 0x99, 0xa8, 0xc8,
+	0xfd, 0x55, 0x68, 0x3c, 0x79, 0x7d, 0x06, 0x9f, 0x57, 0x46, 0x73, 0xa9, 0x9b, 0x10, 0x0b, 0x16,
+	0xdf, 0x95, 0x95, 0x6e, 0x46, 0xba, 0x89, 0x90, 0x7d, 0x2c, 0x75, 0x13, 0x4a, 0x80, 0xcc, 0x97,
+	0x2d, 0x4d, 0xb6, 0x6d, 0x87, 0xee, 0x81, 0x4a, 0xb7, 0xc6, 0x2c, 0x5b, 0x43, 0x7b, 0x33, 0xbe,
+	0x6c, 0x69, 0x4d, 0xce, 0x49, 0x05, 0xa9, 0x1d, 0xa2, 0x58, 0xc2, 0x39, 0xdf, 0x8e, 0x14, 0x34,
+	0xf2, 0x6e, 0x95, 0x0a, 0x52, 0x3d, 0x22, 0x5d, 0xe6, 0x2d, 0xf7, 0x69, 0x97, 0x40, 0x9d, 0x6f,
+	0x45, 0x2e, 0xf3, 0xa1, 0x2f, 0xd0, 0xe8, 0x32, 0x6f, 0x0d, 0x64, 0xa0, 0x2f, 0xc0, 0xbc, 0x78,
+	0x27, 0x53, 0xba, 0x33, 0x06, 0x1f, 0x07, 0x37, 0x6c, 0x74, 0x5e, 0x0b, 0x1e, 0xee, 0x9b, 0xf9,
+	0x33, 0x1b, 0xde, 0xbd, 0xbb, 0x63, 0x7c, 0xf3, 0xc8, 0x5e, 0x89, 0xfb, 0x66, 0x9f, 0x4c, 0x7d,
+	0x33, 0xb7, 0x53, 0xb1, 0x42, 0xde, 0x8b, 0xf4, 0xcd, 0xa3, 0x81, 0x6c, 0xd4, 0x37, 0x3f, 0xf7,
+	0xa9, 0x48, 0x83, 0x4b, 0x6d, 0xe2, 0xc8, 0xee, 0xdd, 0x23, 0x8b, 0xa5, 0xe4, 0x8b, 0xd9, 0xdb,
+	0x91, 0x56, 0x17, 0xbd, 0xf5, 0xa1, 0x56, 0xd7, 0x1e, 0xcd, 0xad, 0xce, 0x8b, 0xf8, 0x95, 0xc7,
+	0xa9, 0xf4, 0xb9, 0x62, 0xf1, 0x71, 0x2a, 0x7d, 0xb9, 0x58, 0x7a, 0x9c, 0x4a, 0x5f, 0x2d, 0x5e,
+	0xab, 0xfc, 0xe1, 0x65, 0xc8, 0xbb, 0x3b, 0x0b, 0x8e, 0xe0, 0x57, 0x82, 0x08, 0xfe, 0x7a, 0x14,
+	0x82, 0x17, 0x7b, 0x11, 0x01, 0xe1, 0x57, 0x82, 0x10, 0xfe, 0x7a, 0x14, 0x84, 0xf7, 0x79, 0x28,
+	0x86, 0x6f, 0x45, 0x61, 0xf8, 0xbb, 0x53, 0x60, 0x78, 0x4f, 0xd4, 0x30, 0x88, 0x5f, 0x1b, 0x05,
+	0xf1, 0x37, 0xc7, 0x83, 0x78, 0x4f, 0x54, 0x00, 0xc5, 0xbf, 0x3b, 0x84, 0xe2, 0x6f, 0x8c, 0x41,
+	0xf1, 0x1e, 0xbf, 0x0b, 0xe3, 0x37, 0x43, 0x61, 0xfc, 0xed, 0x49, 0x30, 0xde, 0x93, 0x33, 0x80,
+	0xe3, 0x1f, 0x0d, 0xe0, 0xf8, 0x72, 0x24, 0x8e, 0xf7, 0xb8, 0x39, 0x90, 0xff, 0x28, 0x1a, 0xc8,
+	0xbf, 0x3d, 0x15, 0x90, 0xf7, 0xe4, 0x8d, 0x22, 0xf9, 0x56, 0x14, 0x92, 0xbf, 0x3b, 0x05, 0x92,
+	0xf7, 0x07, 0x6e, 0x08, 0xca, 0xd7, 0xc3, 0xa0, 0xfc, 0xad, 0x09, 0x50, 0xde, 0x93, 0x16, 0xc4,
+	0xf2, 0xf5, 0x30, 0x2c, 0x7f, 0x6b, 0x02, 0x96, 0x1f, 0x92, 0xc4, 0xc1, 0xfc, 0x76, 0x38, 0x98,
+	0x7f, 0x6b, 0x22, 0x98, 0xf7, 0xa4, 0x0d, 0xa2, 0xf9, 0xfb, 0x01, 0x34, 0xff, 0x46, 0x04, 0x9a,
+	0xf7, 0x58, 0x29, 0x9c, 0xff, 0xd2, 0x08, 0x9c, 0xaf, 0x8c, 0x83, 0xf3, 0x1e, 0xaf, 0x87, 0xe7,
+	0x3f, 0x88, 0xc0, 0xf3, 0x77, 0x26, 0xe3, 0x79, 0x4f, 0xd8, 0x10, 0xa0, 0x57, 0xc6, 0x02, 0xfa,
+	0x4f, 0x4f, 0x09, 0xe8, 0x3d, 0xe9, 0x61, 0x88, 0xfe, 0x73, 0x83, 0x88, 0x7e, 0x29, 0x1a, 0xd1,
+	0x7b, 0x62, 0x04, 0xa4, 0xdf, 0x0c, 0x85, 0xf4, 0xb7, 0x27, 0x41, 0x7a, 0x7f, 0xee, 0x05, 0x31,
+	0xfd, 0x76, 0x38, 0xa6, 0x7f, 0x6b, 0x22, 0xa6, 0xf7, 0x87, 0x7f, 0x00, 0xd4, 0x6f, 0x86, 0x82,
+	0xfa, 0xdb, 0x93, 0x40, 0xbd, 0xdf, 0xb8, 0x20, 0xaa, 0xff, 0x30, 0x12, 0xd5, 0xdf, 0x9b, 0x06,
+	0xd5, 0x7b, 0x42, 0x47, 0x60, 0xfd, 0x47, 0xd1, 0xb0, 0xfe, 0xed, 0xa9, 0x60, 0xbd, 0xef, 0x3a,
+	0x46, 0x70, 0xfd, 0xa3, 0x01, 0x5c, 0x5f, 0x8e, 0xc4, 0xf5, 0xbe, 0x37, 0x63, 0xc0, 0xfe, 0x4b,
+	0x23, 0xc0, 0xbe, 0x32, 0x0e, 0xd8, 0xfb, 0xd3, 0xc0, 0x45, 0xf6, 0xca, 0x58, 0x1c, 0xfe, 0xe9,
+	0x29, 0x71, 0xb8, 0x6f, 0xb3, 0x21, 0x40, 0x7c, 0x3d, 0x04, 0x88, 0xdf, 0x1c, 0x0f, 0xc4, 0xfd,
+	0x95, 0xc7, 0x47, 0xe2, 0xf5, 0x30, 0x24, 0x7e, 0x6b, 0x02, 0x12, 0xf7, 0x9d, 0x57, 0x00, 0x8a,
+	0xbf, 0x3b, 0x04, 0xc5, 0x6f, 0x4c, 0xbc, 0x40, 0x0d, 0x60, 0xf1, 0xea, 0x28, 0x16, 0x7f, 0x73,
+	0x2c, 0x16, 0xf7, 0x24, 0xf8, 0x60, 0xfc, 0xdd, 0x21, 0x30, 0x7e, 0x63, 0x0c, 0x18, 0xf7, 0x1b,
+	0x20, 0xd0, 0xb8, 0x36, 0x1e, 0x8d, 0x2f, 0x4f, 0x8b, 0xc6, 0x3d, 0xc1, 0xa1, 0x70, 0x7c, 0x3b,
+	0x1c, 0x8e, 0xbf, 0x35, 0xe5, 0x5d, 0xca, 0x08, 0x1e, 0xaf, 0x87, 0xe1, 0xf1, 0x5b, 0x13, 0xf0,
+	0x78, 0x70, 0xe9, 0xf1, 0x00, 0x79, 0x3d, 0x0c, 0x90, 0xdf, 0x9a, 0x00, 0xc8, 0x7d, 0x49, 0x01,
+	0x44, 0xde, 0x8a, 0x42, 0xe4, 0x77, 0xa7, 0x40, 0xe4, 0xfe, 0x72, 0x3d, 0x04, 0xc9, 0xbf, 0x38,
+	0x0c, 0xc9, 0x2b, 0xe3, 0x20, 0xb9, 0x3f, 0x23, 0x5d, 0x4c, 0xbe, 0x1d, 0x8e, 0xc9, 0xdf, 0x9a,
+	0x88, 0xc9, 0x83, 0xbe, 0x35, 0x00, 0xca, 0x37, 0x43, 0x41, 0xf9, 0xed, 0x49, 0xa0, 0xdc, 0xf7,
+	0xad, 0x41, 0x54, 0x4e, 0x26, 0xa0, 0xf2, 0xe5, 0x69, 0x51, 0xb9, 0x6f, 0x7d, 0xaf, 0x06, 0xcb,
+	0x1f, 0xa7, 0xd2, 0xd7, 0x8a, 0x6f, 0x54, 0xbe, 0x37, 0x0b, 0x73, 0x75, 0xf7, 0x72, 0x3d, 0xf0,
+	0x12, 0x52, 0x7a, 0x9d, 0x97, 0x90, 0x68, 0x8d, 0x0e, 0x19, 0x33, 0x7c, 0x01, 0xd4, 0xc7, 0xbc,
+	0x2b, 0x1e, 0xb9, 0xd2, 0x70, 0x59, 0x5f, 0x23, 0x10, 0x1c, 0x3d, 0x82, 0x7c, 0xdf, 0x26, 0x96,
+	0xdc, 0xb3, 0x74, 0xd3, 0xd2, 0x1d, 0x1e, 0x4a, 0x25, 0x55, 0x8b, 0x1f, 0x9f, 0x96, 0x73, 0x7b,
+	0x36, 0xb1, 0x76, 0x05, 0x1d, 0xe7, 0xfa, 0x81, 0x94, 0xfb, 0xf5, 0xc7, 0xd9, 0xe9, 0xbf, 0xfe,
+	0xf8, 0x01, 0x14, 0x2d, 0xa2, 0x68, 0x03, 0x2b, 0x17, 0x7f, 0x31, 0x18, 0xbe, 0xc8, 0x2a, 0x5a,
+	0x60, 0x71, 0x62, 0x2f, 0x07, 0xcf, 0x59, 0x83, 0x44, 0xf4, 0x00, 0x2e, 0x76, 0x95, 0x63, 0xfe,
+	0x26, 0xd6, 0x05, 0x03, 0x2c, 0xc8, 0x20, 0xcd, 0x62, 0x61, 0x50, 0x57, 0x39, 0x66, 0x9f, 0x92,
+	0xe4, 0x59, 0xec, 0xd3, 0x53, 0xb7, 0xa0, 0xa0, 0xe9, 0xb6, 0xa3, 0x1b, 0xaa, 0xfb, 0x35, 0x09,
+	0xfe, 0xd9, 0x86, 0xbc, 0x4b, 0xe5, 0x5f, 0x75, 0xb8, 0x07, 0x0b, 0x22, 0xf4, 0xc7, 0xff, 0xb8,
+	0x24, 0x83, 0xbd, 0x69, 0xda, 0x0a, 0x9a, 0xe1, 0x7f, 0x0b, 0xb4, 0x06, 0xe7, 0xda, 0x8a, 0x43,
+	0x8e, 0x94, 0x13, 0xd9, 0x30, 0x35, 0xa6, 0xfb, 0x2c, 0x7b, 0x53, 0x7f, 0xf5, 0xec, 0xb4, 0x9c,
+	0xdf, 0xe0, 0x59, 0xdb, 0xa6, 0xc6, 0x47, 0x60, 0x8e, 0xff, 0xc3, 0xf9, 0x76, 0x20, 0x43, 0x43,
+	0xab, 0x90, 0xa3, 0xb0, 0x43, 0x36, 0xf9, 0xc7, 0x9b, 0x04, 0x98, 0x8d, 0xba, 0x1a, 0x10, 0x9f,
+	0x78, 0xc2, 0x59, 0xdb, 0x4f, 0x88, 0x6f, 0x4d, 0x7c, 0x4f, 0x82, 0xdc, 0x40, 0x98, 0xdb, 0xbb,
+	0x43, 0xd7, 0x57, 0x57, 0xc2, 0x01, 0x72, 0x54, 0xd8, 0x48, 0x5a, 0x28, 0xd6, 0xbd, 0xca, 0x2e,
+	0x47, 0x03, 0x2c, 0xb6, 0x45, 0x75, 0x2f, 0xff, 0x5d, 0xb6, 0x77, 0x52, 0x7f, 0xf0, 0xfd, 0xf2,
+	0x4c, 0xe5, 0xe7, 0x49, 0xc8, 0x0f, 0x86, 0xb3, 0x35, 0x86, 0xda, 0x15, 0xe6, 0x5d, 0x06, 0x38,
+	0xa2, 0x5b, 0xb9, 0x06, 0x19, 0x4b, 0x14, 0x72, 0x9b, 0xb9, 0x34, 0xe6, 0x92, 0x2e, 0xd8, 0x4e,
+	0x9f, 0x71, 0xf1, 0x47, 0x09, 0x6f, 0x42, 0x2f, 0xc3, 0x2c, 0xfb, 0x5c, 0xad, 0x68, 0x5a, 0x58,
+	0xe4, 0xf7, 0x3a, 0xcd, 0xc7, 0xbc, 0x18, 0x75, 0x00, 0xad, 0xd7, 0x7a, 0x0a, 0xed, 0x11, 0x5e,
+	0xe3, 0x73, 0xaa, 0xaf, 0xf9, 0x64, 0x97, 0x5d, 0xcf, 0x75, 0x3a, 0x44, 0x75, 0xc4, 0x57, 0x6f,
+	0xdd, 0x8f, 0xa6, 0xde, 0x1c, 0x16, 0x21, 0xbe, 0x91, 0xbb, 0x8c, 0xc5, 0x37, 0x72, 0x03, 0xd1,
+	0x05, 0x05, 0x4f, 0x04, 0x9b, 0x2f, 0x3c, 0x06, 0x85, 0x0f, 0xf5, 0xbd, 0x26, 0x9c, 0x0f, 0x99,
+	0xbd, 0xa8, 0x00, 0x50, 0xdb, 0xd9, 0x6e, 0x36, 0x9a, 0xad, 0xf5, 0xed, 0x96, 0xfb, 0xe9, 0xd3,
+	0xd5, 0x35, 0x79, 0x6f, 0xbb, 0xb6, 0xb3, 0xb5, 0xd5, 0x68, 0xb5, 0xd6, 0xd7, 0x8a, 0x12, 0x2a,
+	0x42, 0xae, 0xb1, 0x1d, 0x28, 0x27, 0xbe, 0x78, 0x7a, 0xef, 0x43, 0xc8, 0x06, 0x1e, 0x11, 0x23,
+	0x04, 0x85, 0xdd, 0xbd, 0x66, 0x5d, 0x6e, 0x35, 0xb6, 0xd6, 0x9b, 0xad, 0xd5, 0xad, 0xdd, 0xe2,
+	0x0c, 0xad, 0x80, 0xd1, 0x56, 0xab, 0x3b, 0xb8, 0x55, 0x94, 0xbc, 0x74, 0x6b, 0x67, 0xaf, 0x56,
+	0x2f, 0x26, 0xbc, 0xf4, 0x07, 0x7b, 0xeb, 0xf8, 0x69, 0x31, 0x29, 0x04, 0x2b, 0x70, 0x31, 0x34,
+	0x6a, 0x1b, 0x65, 0x61, 0x7e, 0xcf, 0x60, 0x0f, 0x59, 0x8b, 0x33, 0x28, 0x1f, 0x08, 0xdc, 0x2e,
+	0x4a, 0x28, 0xcd, 0x03, 0x84, 0x8b, 0x09, 0x34, 0x07, 0x89, 0xe6, 0xc3, 0x62, 0x12, 0x9d, 0x83,
+	0x6c, 0x20, 0xfa, 0xb9, 0x98, 0x42, 0x19, 0x11, 0x02, 0x5b, 0x9c, 0xbd, 0x77, 0x03, 0x02, 0x11,
+	0x86, 0x08, 0x60, 0xee, 0x7d, 0xc5, 0x21, 0xb6, 0x53, 0x9c, 0x41, 0xf3, 0x90, 0x5c, 0xed, 0x74,
+	0x8a, 0xd2, 0xca, 0x57, 0x20, 0xed, 0x7e, 0x12, 0x07, 0xbd, 0x0f, 0xb3, 0x1c, 0x24, 0x96, 0xa3,
+	0x67, 0x04, 0x9b, 0x5b, 0x8b, 0x4b, 0x93, 0xa6, 0x4c, 0x65, 0xa6, 0x7a, 0xe3, 0xc7, 0xff, 0x7e,
+	0x7d, 0xe6, 0xc7, 0x67, 0xd7, 0xa5, 0x9f, 0x9c, 0x5d, 0x97, 0xfe, 0xf9, 0xec, 0xba, 0xf4, 0x6f,
+	0x67, 0xd7, 0xa5, 0xdf, 0xfd, 0x8f, 0xeb, 0x33, 0x1f, 0xcd, 0x0b, 0x96, 0xfd, 0x39, 0xf6, 0x81,
+	0xe3, 0x87, 0xff, 0x13, 0x00, 0x00, 0xff, 0xff, 0x19, 0x82, 0x99, 0x44, 0xe5, 0x59, 0x00, 0x00,
 }

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1258,101 +1258,96 @@ message GetSnapshotForMergeResponse {
 // Be cautious about deprecating fields as doing so can lead to inconsistencies
 // between replicas.
 message RequestUnion {
-  option (gogoproto.onlyone) = true;
-
-  GetRequest get = 1;
-  PutRequest put = 2;
-  ConditionalPutRequest conditional_put = 3;
-  IncrementRequest increment = 4;
-  DeleteRequest delete = 5;
-  DeleteRangeRequest delete_range = 6;
-  ClearRangeRequest clear_range = 38;
-  ScanRequest scan = 7;
-  BeginTransactionRequest begin_transaction = 8;
-  EndTransactionRequest end_transaction = 9;
-  AdminSplitRequest admin_split = 10;
-  AdminMergeRequest admin_merge = 11;
-  AdminTransferLeaseRequest admin_transfer_lease = 29;
-  AdminChangeReplicasRequest admin_change_replicas = 35;
-  HeartbeatTxnRequest heartbeat_txn = 12;
-  GCRequest gc = 13;
-  PushTxnRequest push_txn = 14;
-  reserved 15;
-  ResolveIntentRequest resolve_intent = 16;
-  ResolveIntentRangeRequest resolve_intent_range = 17;
-  MergeRequest merge = 18;
-  TruncateLogRequest truncate_log = 19;
-  RequestLeaseRequest request_lease = 20;
-  ReverseScanRequest reverse_scan = 21;
-  ComputeChecksumRequest compute_checksum = 22;
-  reserved 23;
-  CheckConsistencyRequest check_consistency = 24;
-  NoopRequest noop = 25;
-  InitPutRequest init_put = 26;
-  reserved 27;
-  TransferLeaseRequest transfer_lease = 28;
-  LeaseInfoRequest lease_info = 30;
-  WriteBatchRequest write_batch = 31;
-  ExportRequest export = 32;
-  ImportRequest import = 34;
-  QueryTxnRequest query_txn = 33;
-  QueryIntentRequest query_intent = 42;
-  AdminScatterRequest admin_scatter = 36;
-  AddSSTableRequest add_sstable = 37;
-  RecomputeStatsRequest recompute_stats = 39;
-  RefreshRequest refresh = 40;
-  RefreshRangeRequest refresh_range = 41;
-  GetSnapshotForMergeRequest get_snapshot_for_merge = 43;
+  oneof value {
+    GetRequest get = 1;
+    PutRequest put = 2;
+    ConditionalPutRequest conditional_put = 3;
+    IncrementRequest increment = 4;
+    DeleteRequest delete = 5;
+    DeleteRangeRequest delete_range = 6;
+    ClearRangeRequest clear_range = 38;
+    ScanRequest scan = 7;
+    BeginTransactionRequest begin_transaction = 8;
+    EndTransactionRequest end_transaction = 9;
+    AdminSplitRequest admin_split = 10;
+    AdminMergeRequest admin_merge = 11;
+    AdminTransferLeaseRequest admin_transfer_lease = 29;
+    AdminChangeReplicasRequest admin_change_replicas = 35;
+    HeartbeatTxnRequest heartbeat_txn = 12;
+    GCRequest gc = 13;
+    PushTxnRequest push_txn = 14;
+    ResolveIntentRequest resolve_intent = 16;
+    ResolveIntentRangeRequest resolve_intent_range = 17;
+    MergeRequest merge = 18;
+    TruncateLogRequest truncate_log = 19;
+    RequestLeaseRequest request_lease = 20;
+    ReverseScanRequest reverse_scan = 21;
+    ComputeChecksumRequest compute_checksum = 22;
+    CheckConsistencyRequest check_consistency = 24;
+    NoopRequest noop = 25;
+    InitPutRequest init_put = 26;
+    TransferLeaseRequest transfer_lease = 28;
+    LeaseInfoRequest lease_info = 30;
+    WriteBatchRequest write_batch = 31;
+    ExportRequest export = 32;
+    ImportRequest import = 34;
+    QueryTxnRequest query_txn = 33;
+    QueryIntentRequest query_intent = 42;
+    AdminScatterRequest admin_scatter = 36;
+    AddSSTableRequest add_sstable = 37;
+    RecomputeStatsRequest recompute_stats = 39;
+    RefreshRequest refresh = 40;
+    RefreshRangeRequest refresh_range = 41;
+    GetSnapshotForMergeRequest get_snapshot_for_merge = 43;
+  }
+  reserved 15, 23, 27;
 }
 
 // A ResponseUnion contains exactly one of the responses.
 // The values added here must match those in RequestUnion.
 message ResponseUnion {
-  option (gogoproto.onlyone) = true;
-
-  GetResponse get = 1;
-  PutResponse put = 2;
-  ConditionalPutResponse conditional_put = 3;
-  IncrementResponse increment = 4;
-  DeleteResponse delete = 5;
-  DeleteRangeResponse delete_range = 6;
-  ClearRangeResponse clear_range = 38;
-  ScanResponse scan = 7;
-  BeginTransactionResponse begin_transaction = 8;
-  EndTransactionResponse end_transaction = 9;
-  AdminSplitResponse admin_split = 10;
-  AdminMergeResponse admin_merge = 11;
-  AdminTransferLeaseResponse admin_transfer_lease = 29;
-  AdminChangeReplicasResponse admin_change_replicas = 35;
-  HeartbeatTxnResponse heartbeat_txn = 12;
-  GCResponse gc = 13;
-  PushTxnResponse push_txn = 14;
-  reserved 15;
-  ResolveIntentResponse resolve_intent = 16;
-  ResolveIntentRangeResponse resolve_intent_range = 17;
-  MergeResponse merge = 18;
-  TruncateLogResponse truncate_log = 19;
-  RequestLeaseResponse request_lease = 20;
-  ReverseScanResponse reverse_scan = 21;
-  ComputeChecksumResponse compute_checksum = 22;
-  reserved 23;
-  CheckConsistencyResponse check_consistency = 24;
-  NoopResponse noop = 25;
-  InitPutResponse init_put = 26;
-  reserved 27;
-  reserved 28; // TransferLease and RequestLease both use RequestLeaseResponse
-  LeaseInfoResponse lease_info = 30;
-  WriteBatchResponse write_batch = 31;
-  ExportResponse export = 32;
-  ImportResponse import = 34;
-  QueryTxnResponse query_txn = 33;
-  QueryIntentResponse query_intent = 42;
-  AdminScatterResponse admin_scatter = 36;
-  AddSSTableResponse add_sstable = 37;
-  RecomputeStatsResponse recompute_stats = 39;
-  RefreshResponse refresh = 40;
-  RefreshRangeResponse refresh_range = 41;
-  GetSnapshotForMergeResponse get_snapshot_for_merge = 43;
+  oneof value {
+    GetResponse get = 1;
+    PutResponse put = 2;
+    ConditionalPutResponse conditional_put = 3;
+    IncrementResponse increment = 4;
+    DeleteResponse delete = 5;
+    DeleteRangeResponse delete_range = 6;
+    ClearRangeResponse clear_range = 38;
+    ScanResponse scan = 7;
+    BeginTransactionResponse begin_transaction = 8;
+    EndTransactionResponse end_transaction = 9;
+    AdminSplitResponse admin_split = 10;
+    AdminMergeResponse admin_merge = 11;
+    AdminTransferLeaseResponse admin_transfer_lease = 29;
+    AdminChangeReplicasResponse admin_change_replicas = 35;
+    HeartbeatTxnResponse heartbeat_txn = 12;
+    GCResponse gc = 13;
+    PushTxnResponse push_txn = 14;
+    ResolveIntentResponse resolve_intent = 16;
+    ResolveIntentRangeResponse resolve_intent_range = 17;
+    MergeResponse merge = 18;
+    TruncateLogResponse truncate_log = 19;
+    RequestLeaseResponse request_lease = 20;
+    ReverseScanResponse reverse_scan = 21;
+    ComputeChecksumResponse compute_checksum = 22;
+    CheckConsistencyResponse check_consistency = 24;
+    NoopResponse noop = 25;
+    InitPutResponse init_put = 26;
+    LeaseInfoResponse lease_info = 30;
+    WriteBatchResponse write_batch = 31;
+    ExportResponse export = 32;
+    ImportResponse import = 34;
+    QueryTxnResponse query_txn = 33;
+    QueryIntentResponse query_intent = 42;
+    AdminScatterResponse admin_scatter = 36;
+    AddSSTableResponse add_sstable = 37;
+    RecomputeStatsResponse recompute_stats = 39;
+    RefreshResponse refresh = 40;
+    RefreshRangeResponse refresh_range = 41;
+    GetSnapshotForMergeResponse get_snapshot_for_merge = 43;
+  }
+  reserved 15, 23, 27, 28;
 }
 
 // A Header is attached to a BatchRequest, encapsulating routing and auxiliary

--- a/pkg/roachpb/api_test.go
+++ b/pkg/roachpb/api_test.go
@@ -108,7 +108,7 @@ func TestMustSetInner(t *testing.T) {
 	if m := req.GetInner().Method(); m != EndTransaction {
 		t.Fatalf("unexpected request: %s in %+v", m, req)
 	}
-	if _, isET := res.GetValue().(*EndTransactionResponse); !isET {
+	if _, isET := res.GetInner().(*EndTransactionResponse); !isET {
 		t.Fatalf("unexpected response union: %+v", res)
 	}
 }

--- a/pkg/roachpb/batch_generated.go
+++ b/pkg/roachpb/batch_generated.go
@@ -9,96 +9,450 @@ import (
 	"strconv"
 )
 
+// GetInner returns the Request contained in the union.
+func (ru RequestUnion) GetInner() Request {
+	switch t := ru.GetValue().(type) {
+	case *RequestUnion_Get:
+		return t.Get
+	case *RequestUnion_Put:
+		return t.Put
+	case *RequestUnion_ConditionalPut:
+		return t.ConditionalPut
+	case *RequestUnion_Increment:
+		return t.Increment
+	case *RequestUnion_Delete:
+		return t.Delete
+	case *RequestUnion_DeleteRange:
+		return t.DeleteRange
+	case *RequestUnion_ClearRange:
+		return t.ClearRange
+	case *RequestUnion_Scan:
+		return t.Scan
+	case *RequestUnion_BeginTransaction:
+		return t.BeginTransaction
+	case *RequestUnion_EndTransaction:
+		return t.EndTransaction
+	case *RequestUnion_AdminSplit:
+		return t.AdminSplit
+	case *RequestUnion_AdminMerge:
+		return t.AdminMerge
+	case *RequestUnion_AdminTransferLease:
+		return t.AdminTransferLease
+	case *RequestUnion_AdminChangeReplicas:
+		return t.AdminChangeReplicas
+	case *RequestUnion_HeartbeatTxn:
+		return t.HeartbeatTxn
+	case *RequestUnion_Gc:
+		return t.Gc
+	case *RequestUnion_PushTxn:
+		return t.PushTxn
+	case *RequestUnion_ResolveIntent:
+		return t.ResolveIntent
+	case *RequestUnion_ResolveIntentRange:
+		return t.ResolveIntentRange
+	case *RequestUnion_Merge:
+		return t.Merge
+	case *RequestUnion_TruncateLog:
+		return t.TruncateLog
+	case *RequestUnion_RequestLease:
+		return t.RequestLease
+	case *RequestUnion_ReverseScan:
+		return t.ReverseScan
+	case *RequestUnion_ComputeChecksum:
+		return t.ComputeChecksum
+	case *RequestUnion_CheckConsistency:
+		return t.CheckConsistency
+	case *RequestUnion_Noop:
+		return t.Noop
+	case *RequestUnion_InitPut:
+		return t.InitPut
+	case *RequestUnion_TransferLease:
+		return t.TransferLease
+	case *RequestUnion_LeaseInfo:
+		return t.LeaseInfo
+	case *RequestUnion_WriteBatch:
+		return t.WriteBatch
+	case *RequestUnion_Export:
+		return t.Export
+	case *RequestUnion_Import:
+		return t.Import
+	case *RequestUnion_QueryTxn:
+		return t.QueryTxn
+	case *RequestUnion_QueryIntent:
+		return t.QueryIntent
+	case *RequestUnion_AdminScatter:
+		return t.AdminScatter
+	case *RequestUnion_AddSstable:
+		return t.AddSstable
+	case *RequestUnion_RecomputeStats:
+		return t.RecomputeStats
+	case *RequestUnion_Refresh:
+		return t.Refresh
+	case *RequestUnion_RefreshRange:
+		return t.RefreshRange
+	case *RequestUnion_GetSnapshotForMerge:
+		return t.GetSnapshotForMerge
+	default:
+		return nil
+	}
+}
+
+// GetInner returns the Response contained in the union.
+func (ru ResponseUnion) GetInner() Response {
+	switch t := ru.GetValue().(type) {
+	case *ResponseUnion_Get:
+		return t.Get
+	case *ResponseUnion_Put:
+		return t.Put
+	case *ResponseUnion_ConditionalPut:
+		return t.ConditionalPut
+	case *ResponseUnion_Increment:
+		return t.Increment
+	case *ResponseUnion_Delete:
+		return t.Delete
+	case *ResponseUnion_DeleteRange:
+		return t.DeleteRange
+	case *ResponseUnion_ClearRange:
+		return t.ClearRange
+	case *ResponseUnion_Scan:
+		return t.Scan
+	case *ResponseUnion_BeginTransaction:
+		return t.BeginTransaction
+	case *ResponseUnion_EndTransaction:
+		return t.EndTransaction
+	case *ResponseUnion_AdminSplit:
+		return t.AdminSplit
+	case *ResponseUnion_AdminMerge:
+		return t.AdminMerge
+	case *ResponseUnion_AdminTransferLease:
+		return t.AdminTransferLease
+	case *ResponseUnion_AdminChangeReplicas:
+		return t.AdminChangeReplicas
+	case *ResponseUnion_HeartbeatTxn:
+		return t.HeartbeatTxn
+	case *ResponseUnion_Gc:
+		return t.Gc
+	case *ResponseUnion_PushTxn:
+		return t.PushTxn
+	case *ResponseUnion_ResolveIntent:
+		return t.ResolveIntent
+	case *ResponseUnion_ResolveIntentRange:
+		return t.ResolveIntentRange
+	case *ResponseUnion_Merge:
+		return t.Merge
+	case *ResponseUnion_TruncateLog:
+		return t.TruncateLog
+	case *ResponseUnion_RequestLease:
+		return t.RequestLease
+	case *ResponseUnion_ReverseScan:
+		return t.ReverseScan
+	case *ResponseUnion_ComputeChecksum:
+		return t.ComputeChecksum
+	case *ResponseUnion_CheckConsistency:
+		return t.CheckConsistency
+	case *ResponseUnion_Noop:
+		return t.Noop
+	case *ResponseUnion_InitPut:
+		return t.InitPut
+	case *ResponseUnion_LeaseInfo:
+		return t.LeaseInfo
+	case *ResponseUnion_WriteBatch:
+		return t.WriteBatch
+	case *ResponseUnion_Export:
+		return t.Export
+	case *ResponseUnion_Import:
+		return t.Import
+	case *ResponseUnion_QueryTxn:
+		return t.QueryTxn
+	case *ResponseUnion_QueryIntent:
+		return t.QueryIntent
+	case *ResponseUnion_AdminScatter:
+		return t.AdminScatter
+	case *ResponseUnion_AddSstable:
+		return t.AddSstable
+	case *ResponseUnion_RecomputeStats:
+		return t.RecomputeStats
+	case *ResponseUnion_Refresh:
+		return t.Refresh
+	case *ResponseUnion_RefreshRange:
+		return t.RefreshRange
+	case *ResponseUnion_GetSnapshotForMerge:
+		return t.GetSnapshotForMerge
+	default:
+		return nil
+	}
+}
+
+// SetInner sets the Request in the union.
+func (ru *RequestUnion) SetInner(r Request) bool {
+	var union isRequestUnion_Value
+	switch t := r.(type) {
+	case *GetRequest:
+		union = &RequestUnion_Get{t}
+	case *PutRequest:
+		union = &RequestUnion_Put{t}
+	case *ConditionalPutRequest:
+		union = &RequestUnion_ConditionalPut{t}
+	case *IncrementRequest:
+		union = &RequestUnion_Increment{t}
+	case *DeleteRequest:
+		union = &RequestUnion_Delete{t}
+	case *DeleteRangeRequest:
+		union = &RequestUnion_DeleteRange{t}
+	case *ClearRangeRequest:
+		union = &RequestUnion_ClearRange{t}
+	case *ScanRequest:
+		union = &RequestUnion_Scan{t}
+	case *BeginTransactionRequest:
+		union = &RequestUnion_BeginTransaction{t}
+	case *EndTransactionRequest:
+		union = &RequestUnion_EndTransaction{t}
+	case *AdminSplitRequest:
+		union = &RequestUnion_AdminSplit{t}
+	case *AdminMergeRequest:
+		union = &RequestUnion_AdminMerge{t}
+	case *AdminTransferLeaseRequest:
+		union = &RequestUnion_AdminTransferLease{t}
+	case *AdminChangeReplicasRequest:
+		union = &RequestUnion_AdminChangeReplicas{t}
+	case *HeartbeatTxnRequest:
+		union = &RequestUnion_HeartbeatTxn{t}
+	case *GCRequest:
+		union = &RequestUnion_Gc{t}
+	case *PushTxnRequest:
+		union = &RequestUnion_PushTxn{t}
+	case *ResolveIntentRequest:
+		union = &RequestUnion_ResolveIntent{t}
+	case *ResolveIntentRangeRequest:
+		union = &RequestUnion_ResolveIntentRange{t}
+	case *MergeRequest:
+		union = &RequestUnion_Merge{t}
+	case *TruncateLogRequest:
+		union = &RequestUnion_TruncateLog{t}
+	case *RequestLeaseRequest:
+		union = &RequestUnion_RequestLease{t}
+	case *ReverseScanRequest:
+		union = &RequestUnion_ReverseScan{t}
+	case *ComputeChecksumRequest:
+		union = &RequestUnion_ComputeChecksum{t}
+	case *CheckConsistencyRequest:
+		union = &RequestUnion_CheckConsistency{t}
+	case *NoopRequest:
+		union = &RequestUnion_Noop{t}
+	case *InitPutRequest:
+		union = &RequestUnion_InitPut{t}
+	case *TransferLeaseRequest:
+		union = &RequestUnion_TransferLease{t}
+	case *LeaseInfoRequest:
+		union = &RequestUnion_LeaseInfo{t}
+	case *WriteBatchRequest:
+		union = &RequestUnion_WriteBatch{t}
+	case *ExportRequest:
+		union = &RequestUnion_Export{t}
+	case *ImportRequest:
+		union = &RequestUnion_Import{t}
+	case *QueryTxnRequest:
+		union = &RequestUnion_QueryTxn{t}
+	case *QueryIntentRequest:
+		union = &RequestUnion_QueryIntent{t}
+	case *AdminScatterRequest:
+		union = &RequestUnion_AdminScatter{t}
+	case *AddSSTableRequest:
+		union = &RequestUnion_AddSstable{t}
+	case *RecomputeStatsRequest:
+		union = &RequestUnion_RecomputeStats{t}
+	case *RefreshRequest:
+		union = &RequestUnion_Refresh{t}
+	case *RefreshRangeRequest:
+		union = &RequestUnion_RefreshRange{t}
+	case *GetSnapshotForMergeRequest:
+		union = &RequestUnion_GetSnapshotForMerge{t}
+	default:
+		return false
+	}
+	ru.Value = union
+	return true
+}
+
+// SetInner sets the Response in the union.
+func (ru *ResponseUnion) SetInner(r Response) bool {
+	var union isResponseUnion_Value
+	switch t := r.(type) {
+	case *GetResponse:
+		union = &ResponseUnion_Get{t}
+	case *PutResponse:
+		union = &ResponseUnion_Put{t}
+	case *ConditionalPutResponse:
+		union = &ResponseUnion_ConditionalPut{t}
+	case *IncrementResponse:
+		union = &ResponseUnion_Increment{t}
+	case *DeleteResponse:
+		union = &ResponseUnion_Delete{t}
+	case *DeleteRangeResponse:
+		union = &ResponseUnion_DeleteRange{t}
+	case *ClearRangeResponse:
+		union = &ResponseUnion_ClearRange{t}
+	case *ScanResponse:
+		union = &ResponseUnion_Scan{t}
+	case *BeginTransactionResponse:
+		union = &ResponseUnion_BeginTransaction{t}
+	case *EndTransactionResponse:
+		union = &ResponseUnion_EndTransaction{t}
+	case *AdminSplitResponse:
+		union = &ResponseUnion_AdminSplit{t}
+	case *AdminMergeResponse:
+		union = &ResponseUnion_AdminMerge{t}
+	case *AdminTransferLeaseResponse:
+		union = &ResponseUnion_AdminTransferLease{t}
+	case *AdminChangeReplicasResponse:
+		union = &ResponseUnion_AdminChangeReplicas{t}
+	case *HeartbeatTxnResponse:
+		union = &ResponseUnion_HeartbeatTxn{t}
+	case *GCResponse:
+		union = &ResponseUnion_Gc{t}
+	case *PushTxnResponse:
+		union = &ResponseUnion_PushTxn{t}
+	case *ResolveIntentResponse:
+		union = &ResponseUnion_ResolveIntent{t}
+	case *ResolveIntentRangeResponse:
+		union = &ResponseUnion_ResolveIntentRange{t}
+	case *MergeResponse:
+		union = &ResponseUnion_Merge{t}
+	case *TruncateLogResponse:
+		union = &ResponseUnion_TruncateLog{t}
+	case *RequestLeaseResponse:
+		union = &ResponseUnion_RequestLease{t}
+	case *ReverseScanResponse:
+		union = &ResponseUnion_ReverseScan{t}
+	case *ComputeChecksumResponse:
+		union = &ResponseUnion_ComputeChecksum{t}
+	case *CheckConsistencyResponse:
+		union = &ResponseUnion_CheckConsistency{t}
+	case *NoopResponse:
+		union = &ResponseUnion_Noop{t}
+	case *InitPutResponse:
+		union = &ResponseUnion_InitPut{t}
+	case *LeaseInfoResponse:
+		union = &ResponseUnion_LeaseInfo{t}
+	case *WriteBatchResponse:
+		union = &ResponseUnion_WriteBatch{t}
+	case *ExportResponse:
+		union = &ResponseUnion_Export{t}
+	case *ImportResponse:
+		union = &ResponseUnion_Import{t}
+	case *QueryTxnResponse:
+		union = &ResponseUnion_QueryTxn{t}
+	case *QueryIntentResponse:
+		union = &ResponseUnion_QueryIntent{t}
+	case *AdminScatterResponse:
+		union = &ResponseUnion_AdminScatter{t}
+	case *AddSSTableResponse:
+		union = &ResponseUnion_AddSstable{t}
+	case *RecomputeStatsResponse:
+		union = &ResponseUnion_RecomputeStats{t}
+	case *RefreshResponse:
+		union = &ResponseUnion_Refresh{t}
+	case *RefreshRangeResponse:
+		union = &ResponseUnion_RefreshRange{t}
+	case *GetSnapshotForMergeResponse:
+		union = &ResponseUnion_GetSnapshotForMerge{t}
+	default:
+		return false
+	}
+	ru.Value = union
+	return true
+}
+
 type reqCounts [40]int32
 
 // getReqCounts returns the number of times each
 // request type appears in the batch.
 func (ba *BatchRequest) getReqCounts() reqCounts {
 	var counts reqCounts
-	for _, r := range ba.Requests {
-		switch {
-		case r.Get != nil:
+	for _, ru := range ba.Requests {
+		switch ru.GetValue().(type) {
+		case *RequestUnion_Get:
 			counts[0]++
-		case r.Put != nil:
+		case *RequestUnion_Put:
 			counts[1]++
-		case r.ConditionalPut != nil:
+		case *RequestUnion_ConditionalPut:
 			counts[2]++
-		case r.Increment != nil:
+		case *RequestUnion_Increment:
 			counts[3]++
-		case r.Delete != nil:
+		case *RequestUnion_Delete:
 			counts[4]++
-		case r.DeleteRange != nil:
+		case *RequestUnion_DeleteRange:
 			counts[5]++
-		case r.ClearRange != nil:
+		case *RequestUnion_ClearRange:
 			counts[6]++
-		case r.Scan != nil:
+		case *RequestUnion_Scan:
 			counts[7]++
-		case r.BeginTransaction != nil:
+		case *RequestUnion_BeginTransaction:
 			counts[8]++
-		case r.EndTransaction != nil:
+		case *RequestUnion_EndTransaction:
 			counts[9]++
-		case r.AdminSplit != nil:
+		case *RequestUnion_AdminSplit:
 			counts[10]++
-		case r.AdminMerge != nil:
+		case *RequestUnion_AdminMerge:
 			counts[11]++
-		case r.AdminTransferLease != nil:
+		case *RequestUnion_AdminTransferLease:
 			counts[12]++
-		case r.AdminChangeReplicas != nil:
+		case *RequestUnion_AdminChangeReplicas:
 			counts[13]++
-		case r.HeartbeatTxn != nil:
+		case *RequestUnion_HeartbeatTxn:
 			counts[14]++
-		case r.Gc != nil:
+		case *RequestUnion_Gc:
 			counts[15]++
-		case r.PushTxn != nil:
+		case *RequestUnion_PushTxn:
 			counts[16]++
-		case r.ResolveIntent != nil:
+		case *RequestUnion_ResolveIntent:
 			counts[17]++
-		case r.ResolveIntentRange != nil:
+		case *RequestUnion_ResolveIntentRange:
 			counts[18]++
-		case r.Merge != nil:
+		case *RequestUnion_Merge:
 			counts[19]++
-		case r.TruncateLog != nil:
+		case *RequestUnion_TruncateLog:
 			counts[20]++
-		case r.RequestLease != nil:
+		case *RequestUnion_RequestLease:
 			counts[21]++
-		case r.ReverseScan != nil:
+		case *RequestUnion_ReverseScan:
 			counts[22]++
-		case r.ComputeChecksum != nil:
+		case *RequestUnion_ComputeChecksum:
 			counts[23]++
-		case r.CheckConsistency != nil:
+		case *RequestUnion_CheckConsistency:
 			counts[24]++
-		case r.Noop != nil:
+		case *RequestUnion_Noop:
 			counts[25]++
-		case r.InitPut != nil:
+		case *RequestUnion_InitPut:
 			counts[26]++
-		case r.TransferLease != nil:
+		case *RequestUnion_TransferLease:
 			counts[27]++
-		case r.LeaseInfo != nil:
+		case *RequestUnion_LeaseInfo:
 			counts[28]++
-		case r.WriteBatch != nil:
+		case *RequestUnion_WriteBatch:
 			counts[29]++
-		case r.Export != nil:
+		case *RequestUnion_Export:
 			counts[30]++
-		case r.Import != nil:
+		case *RequestUnion_Import:
 			counts[31]++
-		case r.QueryTxn != nil:
+		case *RequestUnion_QueryTxn:
 			counts[32]++
-		case r.QueryIntent != nil:
+		case *RequestUnion_QueryIntent:
 			counts[33]++
-		case r.AdminScatter != nil:
+		case *RequestUnion_AdminScatter:
 			counts[34]++
-		case r.AddSstable != nil:
+		case *RequestUnion_AddSstable:
 			counts[35]++
-		case r.RecomputeStats != nil:
+		case *RequestUnion_RecomputeStats:
 			counts[36]++
-		case r.Refresh != nil:
+		case *RequestUnion_Refresh:
 			counts[37]++
-		case r.RefreshRange != nil:
+		case *RequestUnion_RefreshRange:
 			counts[38]++
-		case r.GetSnapshotForMerge != nil:
+		case *RequestUnion_GetSnapshotForMerge:
 			counts[39]++
 		default:
-			panic(fmt.Sprintf("unsupported request: %+v", r))
+			panic(fmt.Sprintf("unsupported request: %+v", ru))
 		}
 	}
 	return counts
@@ -170,6 +524,165 @@ func (ba *BatchRequest) Summary() string {
 	return buf.String()
 }
 
+// The following types are used to group the allocations of Responses
+// and their corresponding isResponseUnion_Value union wrappers together.
+type getResponseAlloc struct {
+	union ResponseUnion_Get
+	resp  GetResponse
+}
+type putResponseAlloc struct {
+	union ResponseUnion_Put
+	resp  PutResponse
+}
+type conditionalPutResponseAlloc struct {
+	union ResponseUnion_ConditionalPut
+	resp  ConditionalPutResponse
+}
+type incrementResponseAlloc struct {
+	union ResponseUnion_Increment
+	resp  IncrementResponse
+}
+type deleteResponseAlloc struct {
+	union ResponseUnion_Delete
+	resp  DeleteResponse
+}
+type deleteRangeResponseAlloc struct {
+	union ResponseUnion_DeleteRange
+	resp  DeleteRangeResponse
+}
+type clearRangeResponseAlloc struct {
+	union ResponseUnion_ClearRange
+	resp  ClearRangeResponse
+}
+type scanResponseAlloc struct {
+	union ResponseUnion_Scan
+	resp  ScanResponse
+}
+type beginTransactionResponseAlloc struct {
+	union ResponseUnion_BeginTransaction
+	resp  BeginTransactionResponse
+}
+type endTransactionResponseAlloc struct {
+	union ResponseUnion_EndTransaction
+	resp  EndTransactionResponse
+}
+type adminSplitResponseAlloc struct {
+	union ResponseUnion_AdminSplit
+	resp  AdminSplitResponse
+}
+type adminMergeResponseAlloc struct {
+	union ResponseUnion_AdminMerge
+	resp  AdminMergeResponse
+}
+type adminTransferLeaseResponseAlloc struct {
+	union ResponseUnion_AdminTransferLease
+	resp  AdminTransferLeaseResponse
+}
+type adminChangeReplicasResponseAlloc struct {
+	union ResponseUnion_AdminChangeReplicas
+	resp  AdminChangeReplicasResponse
+}
+type heartbeatTxnResponseAlloc struct {
+	union ResponseUnion_HeartbeatTxn
+	resp  HeartbeatTxnResponse
+}
+type gCResponseAlloc struct {
+	union ResponseUnion_Gc
+	resp  GCResponse
+}
+type pushTxnResponseAlloc struct {
+	union ResponseUnion_PushTxn
+	resp  PushTxnResponse
+}
+type resolveIntentResponseAlloc struct {
+	union ResponseUnion_ResolveIntent
+	resp  ResolveIntentResponse
+}
+type resolveIntentRangeResponseAlloc struct {
+	union ResponseUnion_ResolveIntentRange
+	resp  ResolveIntentRangeResponse
+}
+type mergeResponseAlloc struct {
+	union ResponseUnion_Merge
+	resp  MergeResponse
+}
+type truncateLogResponseAlloc struct {
+	union ResponseUnion_TruncateLog
+	resp  TruncateLogResponse
+}
+type requestLeaseResponseAlloc struct {
+	union ResponseUnion_RequestLease
+	resp  RequestLeaseResponse
+}
+type reverseScanResponseAlloc struct {
+	union ResponseUnion_ReverseScan
+	resp  ReverseScanResponse
+}
+type computeChecksumResponseAlloc struct {
+	union ResponseUnion_ComputeChecksum
+	resp  ComputeChecksumResponse
+}
+type checkConsistencyResponseAlloc struct {
+	union ResponseUnion_CheckConsistency
+	resp  CheckConsistencyResponse
+}
+type noopResponseAlloc struct {
+	union ResponseUnion_Noop
+	resp  NoopResponse
+}
+type initPutResponseAlloc struct {
+	union ResponseUnion_InitPut
+	resp  InitPutResponse
+}
+type leaseInfoResponseAlloc struct {
+	union ResponseUnion_LeaseInfo
+	resp  LeaseInfoResponse
+}
+type writeBatchResponseAlloc struct {
+	union ResponseUnion_WriteBatch
+	resp  WriteBatchResponse
+}
+type exportResponseAlloc struct {
+	union ResponseUnion_Export
+	resp  ExportResponse
+}
+type importResponseAlloc struct {
+	union ResponseUnion_Import
+	resp  ImportResponse
+}
+type queryTxnResponseAlloc struct {
+	union ResponseUnion_QueryTxn
+	resp  QueryTxnResponse
+}
+type queryIntentResponseAlloc struct {
+	union ResponseUnion_QueryIntent
+	resp  QueryIntentResponse
+}
+type adminScatterResponseAlloc struct {
+	union ResponseUnion_AdminScatter
+	resp  AdminScatterResponse
+}
+type addSSTableResponseAlloc struct {
+	union ResponseUnion_AddSstable
+	resp  AddSSTableResponse
+}
+type recomputeStatsResponseAlloc struct {
+	union ResponseUnion_RecomputeStats
+	resp  RecomputeStatsResponse
+}
+type refreshResponseAlloc struct {
+	union ResponseUnion_Refresh
+	resp  RefreshResponse
+}
+type refreshRangeResponseAlloc struct {
+	union ResponseUnion_RefreshRange
+	resp  RefreshRangeResponse
+}
+type getSnapshotForMergeResponseAlloc struct {
+	union ResponseUnion_GetSnapshotForMerge
+	resp  GetSnapshotForMergeResponse
+}
+
 // CreateReply creates replies for each of the contained requests, wrapped in a
 // BatchResponse. The response objects are batch allocated to minimize
 // allocation overhead.
@@ -179,288 +692,328 @@ func (ba *BatchRequest) CreateReply() *BatchResponse {
 
 	counts := ba.getReqCounts()
 
-	var buf0 []GetResponse
-	var buf1 []PutResponse
-	var buf2 []ConditionalPutResponse
-	var buf3 []IncrementResponse
-	var buf4 []DeleteResponse
-	var buf5 []DeleteRangeResponse
-	var buf6 []ClearRangeResponse
-	var buf7 []ScanResponse
-	var buf8 []BeginTransactionResponse
-	var buf9 []EndTransactionResponse
-	var buf10 []AdminSplitResponse
-	var buf11 []AdminMergeResponse
-	var buf12 []AdminTransferLeaseResponse
-	var buf13 []AdminChangeReplicasResponse
-	var buf14 []HeartbeatTxnResponse
-	var buf15 []GCResponse
-	var buf16 []PushTxnResponse
-	var buf17 []ResolveIntentResponse
-	var buf18 []ResolveIntentRangeResponse
-	var buf19 []MergeResponse
-	var buf20 []TruncateLogResponse
-	var buf21 []RequestLeaseResponse
-	var buf22 []ReverseScanResponse
-	var buf23 []ComputeChecksumResponse
-	var buf24 []CheckConsistencyResponse
-	var buf25 []NoopResponse
-	var buf26 []InitPutResponse
-	var buf27 []RequestLeaseResponse
-	var buf28 []LeaseInfoResponse
-	var buf29 []WriteBatchResponse
-	var buf30 []ExportResponse
-	var buf31 []ImportResponse
-	var buf32 []QueryTxnResponse
-	var buf33 []QueryIntentResponse
-	var buf34 []AdminScatterResponse
-	var buf35 []AddSSTableResponse
-	var buf36 []RecomputeStatsResponse
-	var buf37 []RefreshResponse
-	var buf38 []RefreshRangeResponse
-	var buf39 []GetSnapshotForMergeResponse
+	var buf0 []getResponseAlloc
+	var buf1 []putResponseAlloc
+	var buf2 []conditionalPutResponseAlloc
+	var buf3 []incrementResponseAlloc
+	var buf4 []deleteResponseAlloc
+	var buf5 []deleteRangeResponseAlloc
+	var buf6 []clearRangeResponseAlloc
+	var buf7 []scanResponseAlloc
+	var buf8 []beginTransactionResponseAlloc
+	var buf9 []endTransactionResponseAlloc
+	var buf10 []adminSplitResponseAlloc
+	var buf11 []adminMergeResponseAlloc
+	var buf12 []adminTransferLeaseResponseAlloc
+	var buf13 []adminChangeReplicasResponseAlloc
+	var buf14 []heartbeatTxnResponseAlloc
+	var buf15 []gCResponseAlloc
+	var buf16 []pushTxnResponseAlloc
+	var buf17 []resolveIntentResponseAlloc
+	var buf18 []resolveIntentRangeResponseAlloc
+	var buf19 []mergeResponseAlloc
+	var buf20 []truncateLogResponseAlloc
+	var buf21 []requestLeaseResponseAlloc
+	var buf22 []reverseScanResponseAlloc
+	var buf23 []computeChecksumResponseAlloc
+	var buf24 []checkConsistencyResponseAlloc
+	var buf25 []noopResponseAlloc
+	var buf26 []initPutResponseAlloc
+	var buf27 []requestLeaseResponseAlloc
+	var buf28 []leaseInfoResponseAlloc
+	var buf29 []writeBatchResponseAlloc
+	var buf30 []exportResponseAlloc
+	var buf31 []importResponseAlloc
+	var buf32 []queryTxnResponseAlloc
+	var buf33 []queryIntentResponseAlloc
+	var buf34 []adminScatterResponseAlloc
+	var buf35 []addSSTableResponseAlloc
+	var buf36 []recomputeStatsResponseAlloc
+	var buf37 []refreshResponseAlloc
+	var buf38 []refreshRangeResponseAlloc
+	var buf39 []getSnapshotForMergeResponseAlloc
 
 	for i, r := range ba.Requests {
-		switch {
-		case r.Get != nil:
+		switch r.GetValue().(type) {
+		case *RequestUnion_Get:
 			if buf0 == nil {
-				buf0 = make([]GetResponse, counts[0])
+				buf0 = make([]getResponseAlloc, counts[0])
 			}
-			br.Responses[i].Get = &buf0[0]
+			buf0[0].union.Get = &buf0[0].resp
+			br.Responses[i].Value = &buf0[0].union
 			buf0 = buf0[1:]
-		case r.Put != nil:
+		case *RequestUnion_Put:
 			if buf1 == nil {
-				buf1 = make([]PutResponse, counts[1])
+				buf1 = make([]putResponseAlloc, counts[1])
 			}
-			br.Responses[i].Put = &buf1[0]
+			buf1[0].union.Put = &buf1[0].resp
+			br.Responses[i].Value = &buf1[0].union
 			buf1 = buf1[1:]
-		case r.ConditionalPut != nil:
+		case *RequestUnion_ConditionalPut:
 			if buf2 == nil {
-				buf2 = make([]ConditionalPutResponse, counts[2])
+				buf2 = make([]conditionalPutResponseAlloc, counts[2])
 			}
-			br.Responses[i].ConditionalPut = &buf2[0]
+			buf2[0].union.ConditionalPut = &buf2[0].resp
+			br.Responses[i].Value = &buf2[0].union
 			buf2 = buf2[1:]
-		case r.Increment != nil:
+		case *RequestUnion_Increment:
 			if buf3 == nil {
-				buf3 = make([]IncrementResponse, counts[3])
+				buf3 = make([]incrementResponseAlloc, counts[3])
 			}
-			br.Responses[i].Increment = &buf3[0]
+			buf3[0].union.Increment = &buf3[0].resp
+			br.Responses[i].Value = &buf3[0].union
 			buf3 = buf3[1:]
-		case r.Delete != nil:
+		case *RequestUnion_Delete:
 			if buf4 == nil {
-				buf4 = make([]DeleteResponse, counts[4])
+				buf4 = make([]deleteResponseAlloc, counts[4])
 			}
-			br.Responses[i].Delete = &buf4[0]
+			buf4[0].union.Delete = &buf4[0].resp
+			br.Responses[i].Value = &buf4[0].union
 			buf4 = buf4[1:]
-		case r.DeleteRange != nil:
+		case *RequestUnion_DeleteRange:
 			if buf5 == nil {
-				buf5 = make([]DeleteRangeResponse, counts[5])
+				buf5 = make([]deleteRangeResponseAlloc, counts[5])
 			}
-			br.Responses[i].DeleteRange = &buf5[0]
+			buf5[0].union.DeleteRange = &buf5[0].resp
+			br.Responses[i].Value = &buf5[0].union
 			buf5 = buf5[1:]
-		case r.ClearRange != nil:
+		case *RequestUnion_ClearRange:
 			if buf6 == nil {
-				buf6 = make([]ClearRangeResponse, counts[6])
+				buf6 = make([]clearRangeResponseAlloc, counts[6])
 			}
-			br.Responses[i].ClearRange = &buf6[0]
+			buf6[0].union.ClearRange = &buf6[0].resp
+			br.Responses[i].Value = &buf6[0].union
 			buf6 = buf6[1:]
-		case r.Scan != nil:
+		case *RequestUnion_Scan:
 			if buf7 == nil {
-				buf7 = make([]ScanResponse, counts[7])
+				buf7 = make([]scanResponseAlloc, counts[7])
 			}
-			br.Responses[i].Scan = &buf7[0]
+			buf7[0].union.Scan = &buf7[0].resp
+			br.Responses[i].Value = &buf7[0].union
 			buf7 = buf7[1:]
-		case r.BeginTransaction != nil:
+		case *RequestUnion_BeginTransaction:
 			if buf8 == nil {
-				buf8 = make([]BeginTransactionResponse, counts[8])
+				buf8 = make([]beginTransactionResponseAlloc, counts[8])
 			}
-			br.Responses[i].BeginTransaction = &buf8[0]
+			buf8[0].union.BeginTransaction = &buf8[0].resp
+			br.Responses[i].Value = &buf8[0].union
 			buf8 = buf8[1:]
-		case r.EndTransaction != nil:
+		case *RequestUnion_EndTransaction:
 			if buf9 == nil {
-				buf9 = make([]EndTransactionResponse, counts[9])
+				buf9 = make([]endTransactionResponseAlloc, counts[9])
 			}
-			br.Responses[i].EndTransaction = &buf9[0]
+			buf9[0].union.EndTransaction = &buf9[0].resp
+			br.Responses[i].Value = &buf9[0].union
 			buf9 = buf9[1:]
-		case r.AdminSplit != nil:
+		case *RequestUnion_AdminSplit:
 			if buf10 == nil {
-				buf10 = make([]AdminSplitResponse, counts[10])
+				buf10 = make([]adminSplitResponseAlloc, counts[10])
 			}
-			br.Responses[i].AdminSplit = &buf10[0]
+			buf10[0].union.AdminSplit = &buf10[0].resp
+			br.Responses[i].Value = &buf10[0].union
 			buf10 = buf10[1:]
-		case r.AdminMerge != nil:
+		case *RequestUnion_AdminMerge:
 			if buf11 == nil {
-				buf11 = make([]AdminMergeResponse, counts[11])
+				buf11 = make([]adminMergeResponseAlloc, counts[11])
 			}
-			br.Responses[i].AdminMerge = &buf11[0]
+			buf11[0].union.AdminMerge = &buf11[0].resp
+			br.Responses[i].Value = &buf11[0].union
 			buf11 = buf11[1:]
-		case r.AdminTransferLease != nil:
+		case *RequestUnion_AdminTransferLease:
 			if buf12 == nil {
-				buf12 = make([]AdminTransferLeaseResponse, counts[12])
+				buf12 = make([]adminTransferLeaseResponseAlloc, counts[12])
 			}
-			br.Responses[i].AdminTransferLease = &buf12[0]
+			buf12[0].union.AdminTransferLease = &buf12[0].resp
+			br.Responses[i].Value = &buf12[0].union
 			buf12 = buf12[1:]
-		case r.AdminChangeReplicas != nil:
+		case *RequestUnion_AdminChangeReplicas:
 			if buf13 == nil {
-				buf13 = make([]AdminChangeReplicasResponse, counts[13])
+				buf13 = make([]adminChangeReplicasResponseAlloc, counts[13])
 			}
-			br.Responses[i].AdminChangeReplicas = &buf13[0]
+			buf13[0].union.AdminChangeReplicas = &buf13[0].resp
+			br.Responses[i].Value = &buf13[0].union
 			buf13 = buf13[1:]
-		case r.HeartbeatTxn != nil:
+		case *RequestUnion_HeartbeatTxn:
 			if buf14 == nil {
-				buf14 = make([]HeartbeatTxnResponse, counts[14])
+				buf14 = make([]heartbeatTxnResponseAlloc, counts[14])
 			}
-			br.Responses[i].HeartbeatTxn = &buf14[0]
+			buf14[0].union.HeartbeatTxn = &buf14[0].resp
+			br.Responses[i].Value = &buf14[0].union
 			buf14 = buf14[1:]
-		case r.Gc != nil:
+		case *RequestUnion_Gc:
 			if buf15 == nil {
-				buf15 = make([]GCResponse, counts[15])
+				buf15 = make([]gCResponseAlloc, counts[15])
 			}
-			br.Responses[i].Gc = &buf15[0]
+			buf15[0].union.Gc = &buf15[0].resp
+			br.Responses[i].Value = &buf15[0].union
 			buf15 = buf15[1:]
-		case r.PushTxn != nil:
+		case *RequestUnion_PushTxn:
 			if buf16 == nil {
-				buf16 = make([]PushTxnResponse, counts[16])
+				buf16 = make([]pushTxnResponseAlloc, counts[16])
 			}
-			br.Responses[i].PushTxn = &buf16[0]
+			buf16[0].union.PushTxn = &buf16[0].resp
+			br.Responses[i].Value = &buf16[0].union
 			buf16 = buf16[1:]
-		case r.ResolveIntent != nil:
+		case *RequestUnion_ResolveIntent:
 			if buf17 == nil {
-				buf17 = make([]ResolveIntentResponse, counts[17])
+				buf17 = make([]resolveIntentResponseAlloc, counts[17])
 			}
-			br.Responses[i].ResolveIntent = &buf17[0]
+			buf17[0].union.ResolveIntent = &buf17[0].resp
+			br.Responses[i].Value = &buf17[0].union
 			buf17 = buf17[1:]
-		case r.ResolveIntentRange != nil:
+		case *RequestUnion_ResolveIntentRange:
 			if buf18 == nil {
-				buf18 = make([]ResolveIntentRangeResponse, counts[18])
+				buf18 = make([]resolveIntentRangeResponseAlloc, counts[18])
 			}
-			br.Responses[i].ResolveIntentRange = &buf18[0]
+			buf18[0].union.ResolveIntentRange = &buf18[0].resp
+			br.Responses[i].Value = &buf18[0].union
 			buf18 = buf18[1:]
-		case r.Merge != nil:
+		case *RequestUnion_Merge:
 			if buf19 == nil {
-				buf19 = make([]MergeResponse, counts[19])
+				buf19 = make([]mergeResponseAlloc, counts[19])
 			}
-			br.Responses[i].Merge = &buf19[0]
+			buf19[0].union.Merge = &buf19[0].resp
+			br.Responses[i].Value = &buf19[0].union
 			buf19 = buf19[1:]
-		case r.TruncateLog != nil:
+		case *RequestUnion_TruncateLog:
 			if buf20 == nil {
-				buf20 = make([]TruncateLogResponse, counts[20])
+				buf20 = make([]truncateLogResponseAlloc, counts[20])
 			}
-			br.Responses[i].TruncateLog = &buf20[0]
+			buf20[0].union.TruncateLog = &buf20[0].resp
+			br.Responses[i].Value = &buf20[0].union
 			buf20 = buf20[1:]
-		case r.RequestLease != nil:
+		case *RequestUnion_RequestLease:
 			if buf21 == nil {
-				buf21 = make([]RequestLeaseResponse, counts[21])
+				buf21 = make([]requestLeaseResponseAlloc, counts[21])
 			}
-			br.Responses[i].RequestLease = &buf21[0]
+			buf21[0].union.RequestLease = &buf21[0].resp
+			br.Responses[i].Value = &buf21[0].union
 			buf21 = buf21[1:]
-		case r.ReverseScan != nil:
+		case *RequestUnion_ReverseScan:
 			if buf22 == nil {
-				buf22 = make([]ReverseScanResponse, counts[22])
+				buf22 = make([]reverseScanResponseAlloc, counts[22])
 			}
-			br.Responses[i].ReverseScan = &buf22[0]
+			buf22[0].union.ReverseScan = &buf22[0].resp
+			br.Responses[i].Value = &buf22[0].union
 			buf22 = buf22[1:]
-		case r.ComputeChecksum != nil:
+		case *RequestUnion_ComputeChecksum:
 			if buf23 == nil {
-				buf23 = make([]ComputeChecksumResponse, counts[23])
+				buf23 = make([]computeChecksumResponseAlloc, counts[23])
 			}
-			br.Responses[i].ComputeChecksum = &buf23[0]
+			buf23[0].union.ComputeChecksum = &buf23[0].resp
+			br.Responses[i].Value = &buf23[0].union
 			buf23 = buf23[1:]
-		case r.CheckConsistency != nil:
+		case *RequestUnion_CheckConsistency:
 			if buf24 == nil {
-				buf24 = make([]CheckConsistencyResponse, counts[24])
+				buf24 = make([]checkConsistencyResponseAlloc, counts[24])
 			}
-			br.Responses[i].CheckConsistency = &buf24[0]
+			buf24[0].union.CheckConsistency = &buf24[0].resp
+			br.Responses[i].Value = &buf24[0].union
 			buf24 = buf24[1:]
-		case r.Noop != nil:
+		case *RequestUnion_Noop:
 			if buf25 == nil {
-				buf25 = make([]NoopResponse, counts[25])
+				buf25 = make([]noopResponseAlloc, counts[25])
 			}
-			br.Responses[i].Noop = &buf25[0]
+			buf25[0].union.Noop = &buf25[0].resp
+			br.Responses[i].Value = &buf25[0].union
 			buf25 = buf25[1:]
-		case r.InitPut != nil:
+		case *RequestUnion_InitPut:
 			if buf26 == nil {
-				buf26 = make([]InitPutResponse, counts[26])
+				buf26 = make([]initPutResponseAlloc, counts[26])
 			}
-			br.Responses[i].InitPut = &buf26[0]
+			buf26[0].union.InitPut = &buf26[0].resp
+			br.Responses[i].Value = &buf26[0].union
 			buf26 = buf26[1:]
-		case r.TransferLease != nil:
+		case *RequestUnion_TransferLease:
 			if buf27 == nil {
-				buf27 = make([]RequestLeaseResponse, counts[27])
+				buf27 = make([]requestLeaseResponseAlloc, counts[27])
 			}
-			br.Responses[i].RequestLease = &buf27[0]
+			buf27[0].union.RequestLease = &buf27[0].resp
+			br.Responses[i].Value = &buf27[0].union
 			buf27 = buf27[1:]
-		case r.LeaseInfo != nil:
+		case *RequestUnion_LeaseInfo:
 			if buf28 == nil {
-				buf28 = make([]LeaseInfoResponse, counts[28])
+				buf28 = make([]leaseInfoResponseAlloc, counts[28])
 			}
-			br.Responses[i].LeaseInfo = &buf28[0]
+			buf28[0].union.LeaseInfo = &buf28[0].resp
+			br.Responses[i].Value = &buf28[0].union
 			buf28 = buf28[1:]
-		case r.WriteBatch != nil:
+		case *RequestUnion_WriteBatch:
 			if buf29 == nil {
-				buf29 = make([]WriteBatchResponse, counts[29])
+				buf29 = make([]writeBatchResponseAlloc, counts[29])
 			}
-			br.Responses[i].WriteBatch = &buf29[0]
+			buf29[0].union.WriteBatch = &buf29[0].resp
+			br.Responses[i].Value = &buf29[0].union
 			buf29 = buf29[1:]
-		case r.Export != nil:
+		case *RequestUnion_Export:
 			if buf30 == nil {
-				buf30 = make([]ExportResponse, counts[30])
+				buf30 = make([]exportResponseAlloc, counts[30])
 			}
-			br.Responses[i].Export = &buf30[0]
+			buf30[0].union.Export = &buf30[0].resp
+			br.Responses[i].Value = &buf30[0].union
 			buf30 = buf30[1:]
-		case r.Import != nil:
+		case *RequestUnion_Import:
 			if buf31 == nil {
-				buf31 = make([]ImportResponse, counts[31])
+				buf31 = make([]importResponseAlloc, counts[31])
 			}
-			br.Responses[i].Import = &buf31[0]
+			buf31[0].union.Import = &buf31[0].resp
+			br.Responses[i].Value = &buf31[0].union
 			buf31 = buf31[1:]
-		case r.QueryTxn != nil:
+		case *RequestUnion_QueryTxn:
 			if buf32 == nil {
-				buf32 = make([]QueryTxnResponse, counts[32])
+				buf32 = make([]queryTxnResponseAlloc, counts[32])
 			}
-			br.Responses[i].QueryTxn = &buf32[0]
+			buf32[0].union.QueryTxn = &buf32[0].resp
+			br.Responses[i].Value = &buf32[0].union
 			buf32 = buf32[1:]
-		case r.QueryIntent != nil:
+		case *RequestUnion_QueryIntent:
 			if buf33 == nil {
-				buf33 = make([]QueryIntentResponse, counts[33])
+				buf33 = make([]queryIntentResponseAlloc, counts[33])
 			}
-			br.Responses[i].QueryIntent = &buf33[0]
+			buf33[0].union.QueryIntent = &buf33[0].resp
+			br.Responses[i].Value = &buf33[0].union
 			buf33 = buf33[1:]
-		case r.AdminScatter != nil:
+		case *RequestUnion_AdminScatter:
 			if buf34 == nil {
-				buf34 = make([]AdminScatterResponse, counts[34])
+				buf34 = make([]adminScatterResponseAlloc, counts[34])
 			}
-			br.Responses[i].AdminScatter = &buf34[0]
+			buf34[0].union.AdminScatter = &buf34[0].resp
+			br.Responses[i].Value = &buf34[0].union
 			buf34 = buf34[1:]
-		case r.AddSstable != nil:
+		case *RequestUnion_AddSstable:
 			if buf35 == nil {
-				buf35 = make([]AddSSTableResponse, counts[35])
+				buf35 = make([]addSSTableResponseAlloc, counts[35])
 			}
-			br.Responses[i].AddSstable = &buf35[0]
+			buf35[0].union.AddSstable = &buf35[0].resp
+			br.Responses[i].Value = &buf35[0].union
 			buf35 = buf35[1:]
-		case r.RecomputeStats != nil:
+		case *RequestUnion_RecomputeStats:
 			if buf36 == nil {
-				buf36 = make([]RecomputeStatsResponse, counts[36])
+				buf36 = make([]recomputeStatsResponseAlloc, counts[36])
 			}
-			br.Responses[i].RecomputeStats = &buf36[0]
+			buf36[0].union.RecomputeStats = &buf36[0].resp
+			br.Responses[i].Value = &buf36[0].union
 			buf36 = buf36[1:]
-		case r.Refresh != nil:
+		case *RequestUnion_Refresh:
 			if buf37 == nil {
-				buf37 = make([]RefreshResponse, counts[37])
+				buf37 = make([]refreshResponseAlloc, counts[37])
 			}
-			br.Responses[i].Refresh = &buf37[0]
+			buf37[0].union.Refresh = &buf37[0].resp
+			br.Responses[i].Value = &buf37[0].union
 			buf37 = buf37[1:]
-		case r.RefreshRange != nil:
+		case *RequestUnion_RefreshRange:
 			if buf38 == nil {
-				buf38 = make([]RefreshRangeResponse, counts[38])
+				buf38 = make([]refreshRangeResponseAlloc, counts[38])
 			}
-			br.Responses[i].RefreshRange = &buf38[0]
+			buf38[0].union.RefreshRange = &buf38[0].resp
+			br.Responses[i].Value = &buf38[0].union
 			buf38 = buf38[1:]
-		case r.GetSnapshotForMerge != nil:
+		case *RequestUnion_GetSnapshotForMerge:
 			if buf39 == nil {
-				buf39 = make([]GetSnapshotForMergeResponse, counts[39])
+				buf39 = make([]getSnapshotForMergeResponseAlloc, counts[39])
 			}
-			br.Responses[i].GetSnapshotForMerge = &buf39[0]
+			buf39[0].union.GetSnapshotForMerge = &buf39[0].resp
+			br.Responses[i].Value = &buf39[0].union
 			buf39 = buf39[1:]
 		default:
 			panic(fmt.Sprintf("unsupported request: %+v", r))

--- a/pkg/roachpb/string_test.go
+++ b/pkg/roachpb/string_test.go
@@ -68,9 +68,13 @@ func TestBatchRequestString(t *testing.T) {
 	)
 	br.Txn = &txn
 	for i := 0; i < 100; i++ {
-		br.Requests = append(br.Requests, roachpb.RequestUnion{Get: &roachpb.GetRequest{}})
+		var ru roachpb.RequestUnion
+		ru.MustSetInner(&roachpb.GetRequest{})
+		br.Requests = append(br.Requests, ru)
 	}
-	br.Requests = append(br.Requests, roachpb.RequestUnion{EndTransaction: &roachpb.EndTransactionRequest{}})
+	var ru roachpb.RequestUnion
+	ru.MustSetInner(&roachpb.EndTransactionRequest{})
+	br.Requests = append(br.Requests, ru)
 
 	e := fmt.Sprintf(`[txn: %s], Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), ... 76 skipped ..., Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), EndTransaction(commit:false) [/Min]`,
 		br.Txn.Short())

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5416,8 +5416,11 @@ func (r *Replica) evaluateWriteBatch(
 
 			br.Txn = &clonedTxn
 			// Add placeholder responses for begin & end transaction requests.
-			br.Responses = append([]roachpb.ResponseUnion{{BeginTransaction: &roachpb.BeginTransactionResponse{}}}, br.Responses...)
-			br.Responses = append(br.Responses, roachpb.ResponseUnion{EndTransaction: &roachpb.EndTransactionResponse{OnePhaseCommit: true}})
+			resps := make([]roachpb.ResponseUnion, len(br.Responses)+2)
+			resps[0].MustSetInner(&roachpb.BeginTransactionResponse{})
+			copy(resps[1:], br.Responses)
+			resps[len(resps)-1].MustSetInner(&roachpb.EndTransactionResponse{OnePhaseCommit: true})
+			br.Responses = resps
 			return batch, ms, br, res, nil
 		}
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -383,9 +383,9 @@ func createReplicaSets(replicaNumbers []roachpb.StoreID) []roachpb.ReplicaDescri
 func TestIsOnePhaseCommit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	txnReqs := []roachpb.RequestUnion{
-		{BeginTransaction: &roachpb.BeginTransactionRequest{}},
-		{Put: &roachpb.PutRequest{}},
-		{EndTransaction: &roachpb.EndTransactionRequest{}},
+		{Value: &roachpb.RequestUnion_BeginTransaction{BeginTransaction: &roachpb.BeginTransactionRequest{}}},
+		{Value: &roachpb.RequestUnion_Put{Put: &roachpb.PutRequest{}}},
+		{Value: &roachpb.RequestUnion_EndTransaction{EndTransaction: &roachpb.EndTransactionRequest{}}},
 	}
 	testCases := []struct {
 		bu      []roachpb.RequestUnion
@@ -397,8 +397,8 @@ func TestIsOnePhaseCommit(t *testing.T) {
 	}{
 		{[]roachpb.RequestUnion{}, false, false, false, enginepb.SERIALIZABLE, false},
 		{[]roachpb.RequestUnion{}, true, false, false, enginepb.SERIALIZABLE, false},
-		{[]roachpb.RequestUnion{{Get: &roachpb.GetRequest{}}}, true, false, false, enginepb.SERIALIZABLE, false},
-		{[]roachpb.RequestUnion{{Put: &roachpb.PutRequest{}}}, true, false, false, enginepb.SERIALIZABLE, false},
+		{[]roachpb.RequestUnion{{Value: &roachpb.RequestUnion_Get{Get: &roachpb.GetRequest{}}}}, true, false, false, enginepb.SERIALIZABLE, false},
+		{[]roachpb.RequestUnion{{Value: &roachpb.RequestUnion_Put{Put: &roachpb.PutRequest{}}}}, true, false, false, enginepb.SERIALIZABLE, false},
 		{txnReqs[0 : len(txnReqs)-1], true, false, false, enginepb.SERIALIZABLE, false},
 		{txnReqs[1:], true, false, false, enginepb.SERIALIZABLE, false},
 		{txnReqs, true, false, false, enginepb.SERIALIZABLE, true},

--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -112,8 +112,9 @@ func RunJob(
 // discussion on RunJob for where this might be useful.
 func BulkOpResponseFilter(allowProgressIota *chan struct{}) storagebase.ReplicaResponseFilter {
 	return func(ba roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
-		for _, res := range br.Responses {
-			if res.Export != nil || res.Import != nil || res.AddSstable != nil {
+		for _, ru := range br.Responses {
+			switch ru.GetInner().(type) {
+			case *roachpb.ExportResponse, *roachpb.ImportResponse, *roachpb.AddSSTableResponse:
 				<-*allowProgressIota
 			}
 		}


### PR DESCRIPTION
All Requests and Responses pass through RequestUnion/ResponseUnion structs
when they are added to BatchRequests/BatchResponses. In order to ensure
that only one Request type can be assigned to one of these RequestUnion
or ResponseUnion structs, we currently use gogoproto's approach to tagged
unions: the `gogoproto.onlyone` option.

This option was introduced before proto3. Proto3
then added the `oneof` option, which for all intents and purposes addresses
the same issue: https://developers.google.com/protocol-buffers/docs/proto#oneof.
However, there is one major difference between the two options, which
is in their generated code. `gogoproto.onlyone` will generate
a single flat struct with pointers to each possible variant type.
`oneof` will generate a union interface and an interface "wrapper"
struct for each variant type. The effect of this is that `onlyone`
will generate code that looks like this:

```
type Union struct {
    Variant1 *Variant1Type
    Variant2 *Variant2Type
    ...
}
```

While `oneof` will generate code the looks like this:

```
type Union struct {
    Value isUnion_Value
}

type isUnion_Value interface {
    ...
}

type Union_Variant1 struct {
    Variant1 *Variant1Type
}

type Union_Variant2 struct {
    Variant2 *Variant2Type
}
```

There are pretty obvious tradeoffs to each. For one, `oneof` introduces an
extra layer of indirection, which forces an extra allocation. It also doesn't
generate particularly useful setters and getters. On the other hand, `onlyone`
creates a large struct that grows linearly with the number of variants.
Neither approach is great, and there has been **A LOT** of discussion on this:
- https://github.com/golang/protobuf/issues/78
- https://github.com/golang/protobuf/issues/283
- https://github.com/gogo/protobuf/issues/103
- https://github.com/gogo/protobuf/issues/168

Clearly neither approach is ideal, ergonomically or with regard to performance.
However, over time, the tradeoff has been getting worse for us and it's time we
consider switching over to `oneof` in `RequestUnion` and `ResponseUnion`. These
structs have gotten huge as more and more request variants have been added:
`RequestUnion` has grown to **328 bytes** and `ResponseUnion` has grown to **320 bytes**.
It has gotten to the point where the wasted space is non-negligible.

This change switches over to `oneof` to shrink these union structs down to more
manageable sizes (16 bytes each). The downside of this is that in reducing the struct
size we end up introducing an extra allocation. This isn't great, but we can avoid
the extra allocation in some places (like `BatchRequest.CreateReply`) by grouping
the allocation with that of the Request/Response itself. We've seen previous cases
like #4216 where adding in an extra allocation/indirection is a net-win if it
reduces a commonly used struct's size significantly.

The other downside to this change is that the ergonomics of `oneof` aren't quite
as nice as `gogo.onlyone`. Specifically, `gogo.onlyone` generates getters and
setters called `GetValue` and `SetValue` that provide access to the wrapped
`interface{}`, which we can assert to a `Request`. `oneof` doesn't provide
such facilities. This was the cause of a lot of the discussions linked above.
While it we be nice for this to be resolved upstream, I think we've waited long
enough (~3 years) for a resolution to those discussions. For now, we'll just
generate the getters and setters ourselves.

This change demonstrated about a **5%** improvement when running kv95 on my local
laptop. When run on a three-node GCE cluster (4 vCPUs), the improvements were
less pronounced but still present. kv95 showed a throughput improvement of **2.4%**.
Running kv100 showed a much more dramatic improvement of **18%** on the three-node
GCE cluster. I think this is because kv100 is essentially a hot loop where all reads miss
because the cluster remains empty, so it's the best-case scenario for this change. Still,
the impact was shocking.

Release note (performance improvement): Reduce the memory size of commonly used
Request and Response objects.