### PR TITLE
opt/sql: fix explain analyze missing option

### DIFF
--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -42,9 +42,8 @@ func (p *planner) Explain(ctx context.Context, n *tree.Explain) (planNode, error
 			return nil, err
 		}
 		return &explainDistSQLNode{
-			plan:     plan,
-			analyze:  opts.Flags.Contains(tree.ExplainFlagAnalyze),
-			stmtType: n.Statement.StatementType(),
+			plan:    plan,
+			analyze: opts.Flags.Contains(tree.ExplainFlagAnalyze),
 		}, nil
 
 	case tree.ExplainPlan:

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -34,9 +34,6 @@ type explainDistSQLNode struct {
 	// pointing to a visual query plan with statistics will be in the row
 	// returned by the node.
 	analyze bool
-	// stmtType is the StatementType of the plan. It is needed by the
-	// distSQLWrapper when analyzing a statement.
-	stmtType tree.StatementType
 
 	run explainDistSQLRun
 }
@@ -89,10 +86,14 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 			return nil
 		})
 		execCfg := params.p.ExecCfg()
+		// tree.RowsAffected is used as the statement type passed in to the distsql
+		// receiver because it isn't necessary to process any result rows from the
+		// wrapped plan.
+		const stmtType = tree.RowsAffected
 		recv := makeDistSQLReceiver(
 			params.ctx,
 			rw,
-			n.stmtType,
+			stmtType,
 			execCfg.RangeDescriptorCache,
 			execCfg.LeaseHolderCache,
 			params.p.txn,


### PR DESCRIPTION
ConstructExplain previously ignored the ANALYZE option so any EXPLAIN
ANALYZE statement would result in execution as an EXPLAIN (DISTSQL)
statement. The ANALYZE option is now observed in ConstructExplain.

Additionally, the stmtType field from the explainDistSQLNode has been
removed because it was not necessary and it was unclear how to pass this
from the `execFactory`.

Release note: None