### PR TITLE
storage: optimistically resolve pending prereqs in cmdQ before canceling

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1128,7 +1128,7 @@ func TestRefreshPendingCommands(t *testing.T) {
 }
 
 // Test that when a Raft group is not able to establish a quorum, its Raft log
-// does not grow without bound. It tests two different scenerios where this used
+// does not grow without bound. It tests two different scenarios where this used
 // to be possible (see #27772):
 // 1. The leader proposes a command and cannot establish a quorum. The leader
 //    continually re-proposes the command.

--- a/pkg/storage/command_queue.go
+++ b/pkg/storage/command_queue.go
@@ -144,10 +144,19 @@ func (c *cmd) String() string {
 	return buf.String()
 }
 
+// PrereqLen returns the number of immediate prerequisite command that the
+// command is waiting on.
+func (c *cmd) PrereqLen() int {
+	if c == nil {
+		return 0
+	}
+	return len(*c.prereqs)
+}
+
 // PendingPrereq returns the prerequisite command that should be waited on next,
 // or nil if the receiver has no more prerequisites to wait on.
 func (c *cmd) PendingPrereq() *cmd {
-	if len(*c.prereqs) == 0 {
+	if c.PrereqLen() == 0 {
 		return nil
 	}
 	return (*c.prereqs)[0]
@@ -229,6 +238,30 @@ func (c *cmd) ResolvePendingPrereq() {
 	// especially during cascade command cancellation.
 	(*c.prereqs)[0] = nil
 	(*c.prereqs) = (*c.prereqs)[1:]
+}
+
+// OptimisticallyResolvePrereqs removes all prerequisite in the cmd's prereq
+// slice that have already finished without blocking on pending commands.
+// Prerequisite commands that are still pending or that were canceled are left
+// in the prereq slice.
+func (c *cmd) OptimisticallyResolvePrereqs() {
+	j := 0
+	for i, pre := range *c.prereqs {
+		select {
+		case <-pre.pending:
+			if len(*pre.prereqs) == 0 {
+				// Nil to allow GC.
+				(*c.prereqs)[i] = nil
+				continue
+			}
+			// Command canceled. Don't expand.
+		default:
+			// Command still pending.
+		}
+		(*c.prereqs)[j] = pre
+		j++
+	}
+	(*c.prereqs) = (*c.prereqs)[:j]
 }
 
 // NewCommandQueue returns a new command queue. The boolean specifies whether


### PR DESCRIPTION
In a privately reported issue we have seen cases where cascading
cancellations of commands in the CommandQueue can cause an OOM
in `storage.(*cmd).ResolvePendingPrereq`. This is caused by a quadratic
blowup of prerequisites as canceled commands transfer their prerequisites
to their dependents.

This change introduces a measure to bound this quadratic blowup by
adding in a new optimistic resolution step to command cancellation,
during which time a command will optimistically resolve all prerequisites
that have already finished without blocking on any pending commands. This
should improve the cascading cancellation scenario because it will
allow a command to trim its prerequisite list before passing it on
to its dependents. Notably, since we consider all commands in the
prereq list instead of just the first, like we usually do, a single
pending command at the front of the list can't allow the rest of the
prereq list to grow full of finished/canceled commands.

Release note: None