### PR TITLE
storage: extract replica unlinking into store method

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5165,12 +5165,7 @@ func (r *Replica) acquireSplitLock(
 			rightRng.mu.destroyStatus.Set(errors.Errorf("%s: failed to initialize", rightRng), destroyReasonRemoved)
 			rightRng.mu.Unlock()
 			r.store.mu.Lock()
-			r.store.unquiescedReplicas.Lock()
-			delete(r.store.unquiescedReplicas.m, rightRng.RangeID)
-			r.store.unquiescedReplicas.Unlock()
-			r.store.mu.replicas.Delete(int64(rightRng.RangeID))
-			delete(r.store.mu.uninitReplicas, rightRng.RangeID)
-			r.store.replicaQueues.Delete(int64(rightRng.RangeID))
+			r.store.unlinkReplicaByRangeIDLocked(rightRng.RangeID)
 			r.store.mu.Unlock()
 		}
 		rightRng.raftMu.Unlock()


### PR DESCRIPTION
Extract some code that was duplicated in three places into a dedicated
helper method. Prerequisite for #27061.

Release note: None