### PR TITLE
ts: Enable Rollups

### DIFF
--- a/pkg/ts/maintenance.go
+++ b/pkg/ts/maintenance.go
@@ -1,0 +1,77 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ts
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+)
+
+// ContainsTimeSeries returns true if the given key range overlaps the
+// range of possible time series keys.
+func (tsdb *DB) ContainsTimeSeries(start, end roachpb.RKey) bool {
+	return !lastTSRKey.Less(start) && !end.Less(firstTSRKey)
+}
+
+// MaintainTimeSeries provides a function that can be called from an external
+// process periodically in order to perform "maintenance" work on time series
+// data. Currently, this includes computing rollups and pruning data which has
+// exceeded its retention threshold, as well as computing low-resolution rollups
+// of data. This system was designed specifically to be used by scanner queue
+// from the storage package.
+//
+// The snapshot should be supplied by a local store, and is used only to
+// discover the names of time series which are store in that snapshot. The KV
+// client is then used to interact with data from the time series that are
+// discovered; this may result in data being deleted, but may also write new
+// data in the form of rollups.
+//
+// The snapshot is used for key discovery (as opposed to the KV client) because
+// the task of pruning time series is distributed across the cluster to the
+// individual ranges which contain that time series data. Because replicas of
+// those ranges are guaranteed to have time series data locally, we can use the
+// snapshot to quickly obtain a set of keys to be pruned with no network calls.
+func (tsdb *DB) MaintainTimeSeries(
+	ctx context.Context,
+	snapshot engine.Reader,
+	start, end roachpb.RKey,
+	db *client.DB,
+	mem *mon.BytesMonitor,
+	budgetBytes int64,
+	now hlc.Timestamp,
+) error {
+	series, err := tsdb.findTimeSeries(snapshot, start, end, now)
+	if err != nil {
+		return err
+	}
+	if tsdb.WriteRollups() {
+		qmc := MakeQueryMemoryContext(mem, mem, QueryMemoryOptions{
+			BudgetBytes: budgetBytes,
+		})
+		if err := tsdb.rollupTimeSeries(ctx, series, now, qmc); err != nil {
+			return err
+		}
+	}
+	return tsdb.pruneTimeSeries(ctx, db, series, now)
+}
+
+// Assert that DB implements the necessary interface from the storage package.
+var _ storage.TimeSeriesDataStore = (*DB)(nil)

--- a/pkg/ts/model_test.go
+++ b/pkg/ts/model_test.go
@@ -244,16 +244,7 @@ func TestTimeSeriesRollupModelTest(t *testing.T) {
 		}
 	}
 
-	for _, metric := range modelTestMetricNames {
-		// Roll-up data points before the anchor time.
-		tm.rollup(
-			modelTestAnchorTime+resolution10sDefaultPruneThreshold.Nanoseconds(),
-			timeSeriesResolutionInfo{
-				Name:       metric,
-				Resolution: Resolution10s,
-			},
-		)
-	}
+	tm.maintain(modelTestAnchorTime + resolution10sDefaultRollupThreshold.Nanoseconds())
 
 	tm.assertModelCorrect()
 	{

--- a/pkg/ts/pruning.go
+++ b/pkg/ts/pruning.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
@@ -29,41 +28,6 @@ var (
 	firstTSRKey = roachpb.RKey(keys.TimeseriesPrefix)
 	lastTSRKey  = firstTSRKey.PrefixEnd()
 )
-
-// ContainsTimeSeries returns true if the given key range overlaps the
-// range of possible time series keys.
-func (tsdb *DB) ContainsTimeSeries(start, end roachpb.RKey) bool {
-	return !lastTSRKey.Less(start) && !end.Less(firstTSRKey)
-}
-
-// PruneTimeSeries prunes old data for any time series found in the supplied
-// key range.
-//
-// The snapshot should be supplied by a local store, and is used only to
-// discover the names of time series which are store in that snapshot. The KV
-// client is then used to prune old data from the discovered series.
-//
-// The snapshot is used for key discovery (as opposed to the KV client) because
-// the task of pruning time series is distributed across the cluster to the
-// individual ranges which contain that time series data. Because replicas of
-// those ranges are guaranteed to have time series data locally, we can use the
-// snapshot to quickly obtain a set of keys to be pruned with no network calls.
-func (tsdb *DB) PruneTimeSeries(
-	ctx context.Context,
-	snapshot engine.Reader,
-	start, end roachpb.RKey,
-	db *client.DB,
-	timestamp hlc.Timestamp,
-) error {
-	series, err := tsdb.findTimeSeries(snapshot, start, end, timestamp)
-	if err != nil {
-		return err
-	}
-	return tsdb.pruneTimeSeries(ctx, db, series, timestamp)
-}
-
-// Assert that DB implements the necessary interface from the storage package.
-var _ storage.TimeSeriesDataStore = (*DB)(nil)
 
 type timeSeriesResolutionInfo struct {
 	Name       string
@@ -159,7 +123,6 @@ func (tsdb *DB) pruneTimeSeries(
 	for _, timeSeries := range timeSeriesList {
 		// Time series data for a specific resolution falls in a contiguous key
 		// range, and can be deleted with a DelRange command.
-
 		// The start key is the prefix unique to this name/resolution pair.
 		start := makeDataKeySeriesPrefix(timeSeries.Name, timeSeries.Resolution)
 


### PR DESCRIPTION
Enables rollups by calling the rollup command as part of the time series
maintenance queue process, assuming the cluster version is sufficient.
When enabled, resolutions with a target rollup are no longer simply
pruned, but rather their data is rolled-up and written to the target
resolution.

The resolution thresholds for rollups (including the new setting for
10s rollups, which will replace 10s pruning) have not yet been converted
into cluster settings.