### PR TITLE
importccl: correctly error when encountering a sequence operation

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -152,7 +152,10 @@ func MakeSimpleTableDescriptor(
 		}
 	}
 	semaCtx := tree.SemaContext{}
-	evalCtx := tree.EvalContext{CtxProvider: ctxProvider{ctx}}
+	evalCtx := tree.EvalContext{
+		CtxProvider: ctxProvider{ctx},
+		Sequence:    &importSequenceOperators{},
+	}
 	tableDesc, err := sql.MakeTableDesc(
 		ctx,
 		nil, /* txn */
@@ -172,6 +175,52 @@ func MakeSimpleTableDescriptor(
 	}
 
 	return &tableDesc, nil
+}
+
+var errSequenceOperators = errors.New("sequence operations unsupported")
+
+// Implements the tree.SequenceOperators interface.
+type importSequenceOperators struct {
+}
+
+// Implements the tree.EvalDatabase interface.
+func (so *importSequenceOperators) ParseQualifiedTableName(
+	ctx context.Context, sql string,
+) (*tree.TableName, error) {
+	return nil, errSequenceOperators
+}
+
+// Implements the tree.EvalDatabase interface.
+func (so *importSequenceOperators) ResolveTableName(ctx context.Context, tn *tree.TableName) error {
+	return errSequenceOperators
+}
+
+// Implements the tree.EvalDatabase interface.
+func (so *importSequenceOperators) LookupSchema(
+	ctx context.Context, dbName, scName string,
+) (bool, tree.SchemaMeta, error) {
+	return false, nil, errSequenceOperators
+}
+
+// Implements the tree.SequenceOperators interface.
+func (so *importSequenceOperators) IncrementSequence(
+	ctx context.Context, seqName *tree.TableName,
+) (int64, error) {
+	return 0, errSequenceOperators
+}
+
+// Implements the tree.SequenceOperators interface.
+func (so *importSequenceOperators) GetLatestValueInSessionForSequence(
+	ctx context.Context, seqName *tree.TableName,
+) (int64, error) {
+	return 0, errSequenceOperators
+}
+
+// Implements the tree.SequenceOperators interface.
+func (so *importSequenceOperators) SetSequenceValue(
+	ctx context.Context, seqName *tree.TableName, newVal int64, isCalled bool,
+) error {
+	return errSequenceOperators
 }
 
 const csvDatabaseName = "csv"

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -298,6 +298,12 @@ d
 			typ:    "NOPE",
 			err:    `unsupported import format`,
 		},
+		{
+			name:   "sequences",
+			create: `i int default nextval('s')`,
+			typ:    "CSV",
+			err:    `sequence operations unsupported`,
+		},
 	}
 
 	var dataString string


### PR DESCRIPTION
Implement a dummy tree.SequenceOperators. This will allow for correctly
supporting sequences in the future.

Fixes #26850

Release note (bug fix): fix a panic in IMPORT when creating a table
using a sequence operation in a column DEFAULT (like nextval).