### PR TITLE
docs: fix the "global matching" regex flag to "g"

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -777,8 +777,12 @@ has no relationship with the commit order of concurrent transactions.</p>
 <td>Case-sensitive matching</td>
 </tr>
 <tr>
+<td><strong>g</strong></td>
+<td>Global matching (match each substring instead of only the first)</td>
+</tr>
+<tr>
 <td><strong>i</strong></td>
-<td>Global matching (match each substring instead of only the first).</td>
+<td>Case-insensitive matching</td>
 </tr>
 <tr>
 <td><strong>m</strong> or <strong>n</strong></td>

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1049,7 +1049,8 @@ CockroachDB supports the following flags:
 | Flag           | Description                                                       |
 |----------------|-------------------------------------------------------------------|
 | **c**          | Case-sensitive matching                                           |
-| **i**          | Global matching (match each substring instead of only the first). |
+| **g**          | Global matching (match each substring instead of only the first)  |
+| **i**          | Case-insensitive matching                                         |
 | **m** or **n** | Newline-sensitive (see below)                                     |
 | **p**          | Partial newline-sensitive matching (see below)                    |
 | **s**          | Newline-insensitive (default)                                     |


### PR DESCRIPTION
Also reinstate "i" as the "case-insensitive" flag and preserve alphabetical order of flags in table.

Closes #27107.