### PR TITLE
release-2.0: ui: make sure we identify the cluster

### DIFF
--- a/pkg/ui/src/redux/analytics.ts
+++ b/pkg/ui/src/redux/analytics.ts
@@ -238,6 +238,8 @@ history.listen((location) => {
   }
   lastPageLocation = location;
   analytics.page(location);
+  // Identify the cluster.
+  analytics.identify();
 });
 
 // Record the initial page that was accessed; listen won't fire for the first


### PR DESCRIPTION
Backport 1/1 commits from #27132.

/cc @cockroachdb/release

---

In #24996 I accidentally moved the identify call rather than copying it,
meaning we frequently failed to issue the identify.  This fixes that
by trying to identify on every page if we have not yet.

Release note: None
