### PR TITLE
server, build: add time series for disk and net IO stats

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1018,6 +1018,16 @@
   revision = "836a144573533ea4da4e6929c235fd348aed1c80"
 
 [[projects]]
+  name = "github.com/shirou/gopsutil"
+  packages = [
+    "disk",
+    "internal/common",
+    "net",
+  ]
+  revision = "4a180b209f5f494e5923cfce81ea30ba23915877"
+  version = "v2.18.06"
+
+[[projects]]
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
@@ -1308,6 +1318,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b827f3b21201b3e823cb4ad015a30496788510cf54dfdb3533cc8b79b0ea553f"
+  inputs-digest = "7356b2f481042b2b79a78bd5541e8c7d40e8073cbb5d6c6f0854c9dcfd9455b0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -431,7 +431,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	s.recorder = status.NewMetricsRecorder(s.clock, s.nodeLiveness, s.rpcContext, s.gossip, st)
 	s.registry.AddMetricStruct(s.rpcContext.RemoteClocks.Metrics())
 
-	s.runtime = status.MakeRuntimeStatSampler(s.clock)
+	s.runtime = status.MakeRuntimeStatSampler(ctx, s.clock)
 	s.registry.AddMetricStruct(s.runtime)
 
 	s.node = NewNode(

--- a/pkg/server/status/runtime_test.go
+++ b/pkg/server/status/runtime_test.go
@@ -1,0 +1,156 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package status
+
+import (
+	"reflect"
+	"testing"
+
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/shirou/gopsutil/disk"
+	"github.com/shirou/gopsutil/net"
+)
+
+func TestSumDiskCounters(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	counters := map[string]disk.IOCountersStat{
+		"disk0": {
+			ReadBytes:      1,
+			ReadTime:       1,
+			ReadCount:      1,
+			IopsInProgress: 1,
+			WriteBytes:     1,
+			WriteTime:      1,
+			WriteCount:     1,
+		},
+		"disk1": {
+			ReadBytes:      1,
+			ReadTime:       1,
+			ReadCount:      1,
+			IopsInProgress: 1,
+			WriteBytes:     1,
+			WriteTime:      1,
+			WriteCount:     1,
+		},
+	}
+	summed := sumDiskCounters(counters)
+	expected := disk.IOCountersStat{
+		ReadBytes:      2,
+		ReadTime:       2,
+		ReadCount:      2,
+		WriteBytes:     2,
+		WriteTime:      2,
+		WriteCount:     2,
+		IopsInProgress: 2,
+	}
+	if !reflect.DeepEqual(summed, expected) {
+		t.Fatalf("expected %+v; got %+v", expected, summed)
+	}
+}
+
+func TestSumNetCounters(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	counters := []net.IOCountersStat{
+		{
+			PacketsSent: 1,
+			PacketsRecv: 1,
+			BytesSent:   1,
+			BytesRecv:   1,
+		},
+		{
+			PacketsSent: 1,
+			PacketsRecv: 1,
+			BytesSent:   1,
+			BytesRecv:   1,
+		},
+	}
+	summed := sumNetworkCounters(counters)
+	expected := net.IOCountersStat{
+		PacketsSent: 2,
+		PacketsRecv: 2,
+		BytesSent:   2,
+		BytesRecv:   2,
+	}
+	if !reflect.DeepEqual(summed, expected) {
+		t.Fatalf("expected %+v; got %+v", expected, summed)
+	}
+}
+
+func TestSubtractDiskCounters(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	from := disk.IOCountersStat{
+		ReadBytes:      3,
+		ReadTime:       3,
+		ReadCount:      3,
+		WriteBytes:     3,
+		WriteTime:      3,
+		WriteCount:     3,
+		IopsInProgress: 3,
+	}
+	sub := disk.IOCountersStat{
+		ReadBytes:      1,
+		ReadTime:       1,
+		ReadCount:      1,
+		IopsInProgress: 1,
+		WriteBytes:     1,
+		WriteTime:      1,
+		WriteCount:     1,
+	}
+	expected := disk.IOCountersStat{
+		ReadBytes:      2,
+		ReadTime:       2,
+		ReadCount:      2,
+		WriteBytes:     2,
+		WriteTime:      2,
+		WriteCount:     2,
+		IopsInProgress: 2,
+	}
+	subtractDiskCounters(&from, sub)
+	if !reflect.DeepEqual(from, expected) {
+		fmt.Println()
+	}
+}
+
+func TestSubtractNetCounters(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	from := net.IOCountersStat{
+		PacketsSent: 3,
+		PacketsRecv: 3,
+		BytesSent:   3,
+		BytesRecv:   3,
+	}
+	sub := net.IOCountersStat{
+		PacketsSent: 1,
+		PacketsRecv: 1,
+		BytesSent:   1,
+		BytesRecv:   1,
+	}
+	expected := net.IOCountersStat{
+		PacketsSent: 2,
+		PacketsRecv: 2,
+		BytesSent:   2,
+		BytesRecv:   2,
+	}
+	subtractNetworkCounters(&from, sub)
+	if !reflect.DeepEqual(from, expected) {
+		fmt.Println()
+	}
+}


### PR DESCRIPTION
Use new library `gopsutil` to gather IO stats from the host kernel and save them as time series.

Caveat: these counters are for the entire host over its lifetime, not the cockroach process's lifetime. As such, the first value cockroach records may be very high, and if we plot these charts as derivatives, the derivative from zero to the first recorded data point will be much higher than subsequent derivatives, making a plot where it's hard to see changes after that.

A future commit will gather per-process IO stats, but gopsutil only provides that on Linux.

Release note (admin ui change): gather disk and network IO statistics and
save them as time series.