### PR TITLE
storage: remove unnecessary locking around Store.GetReplica

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2487,12 +2487,11 @@ func (s *Store) removeReplicaImpl(
 	}
 	rep.mu.Unlock()
 
-	// TODO(peter): Could use s.mu.RLock here?
-	s.mu.Lock()
 	if _, err := s.GetReplica(rep.RangeID); err != nil {
-		s.mu.Unlock()
 		return err
 	}
+
+	s.mu.Lock()
 	if !opts.AllowPlaceholders {
 		if placeholder := s.getOverlappingKeyRangeLocked(desc); placeholder != rep {
 			// This is a fatal error because uninitialized replicas shouldn't make it


### PR DESCRIPTION
Since Store.mu.replicas was switched to use a sync.Map in 20930f4, it is
no longer required to hold Store.mu when calling Store.GetReplica.
Remove a vestgial lock acquisition in Store.removeReplicaImpl.

Release note: None