### PR TITLE
storage: stop serializing store.RemoveReplica with snapshot application

### DIFF
--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -43,7 +43,7 @@ const (
 
 	// Messages that provide detail about why a preemptive snapshot was rejected.
 	snapshotStoreTooFullMsg = "store almost out of disk space"
-	snapshotApplySemBusyMsg = "store busy applying snapshots and/or removing replicas"
+	snapshotApplySemBusyMsg = "store busy applying snapshots"
 	storeDrainingMsg        = "store is draining"
 
 	// IntersectingSnapshotMsg is part of the error message returned from


### PR DESCRIPTION
Clearing replica data now uses RocksDB range deletion tombstones, so it
is no longer I/O intensive. As such, it no longer makes sense to
serialize the operation with snapshot application.

Release note: None