### PR TITLE
ui: depend on babel-polyfill

### DIFF
--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "analytics-node": "^3.0.0",
+    "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.5",
     "combokeys": "^2.4.6",
     "highlight.js": "^9.10.0",
@@ -28,7 +29,6 @@
     "redux": "^3.6.0",
     "redux-saga": "^0.15.6",
     "redux-thunk": "^2.2.0",
-    "regenerator-runtime": "^0.11.0",
     "reselect": "^3.0.0",
     "whatwg-fetch": "^2.0.3"
   },

--- a/pkg/ui/src/polyfills.ts
+++ b/pkg/ui/src/polyfills.ts
@@ -1,10 +1,4 @@
 // This file imports polyfills necessary for both the unit tests and the
 // deployed bundle.
-//
-// If you're tempted to instead import babel-polyfill, which bundles the most
-// common polyfills, fair warning: babel-polyfill, jsdom, and Node 6 are
-// mutually incompatible.
-//
-// TODO(benesch): reevaluate babel-polyfill when we upgrade to Node 8.
 
-import "regenerator-runtime/runtime";
+import "babel-polyfill";

--- a/pkg/ui/src/util/api.ts
+++ b/pkg/ui/src/util/api.ts
@@ -3,7 +3,6 @@
  */
 
 import _ from "lodash";
-import "whatwg-fetch"; // needed for jsdom?
 import moment from "moment";
 
 import * as protos from "src/js/protos";

--- a/pkg/ui/src/util/cockroachlabsAPI.ts
+++ b/pkg/ui/src/util/cockroachlabsAPI.ts
@@ -2,7 +2,6 @@
  * This module contains all the REST endpoints for communicating with the admin UI.
  */
 
-import "whatwg-fetch"; // needed for jsdom?
 import moment from "moment";
 
 import {

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -976,6 +976,14 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
 babel-preset-env@^1.2.2:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.3.3.tgz#5913407784e3d98de2aa814a3ef9059722b34e0b"
@@ -1045,6 +1053,13 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0:
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
+
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
 
 babel-template@^6.24.1:
   version "6.24.1"
@@ -1849,6 +1864,10 @@ core-js@^1.0.0:
 core-js@^2.2.0, core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
+
+core-js@^2.5.0:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -5899,6 +5918,10 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz#8c4367a904b51ea62a908ac310bf99ff90a82a3e"
+
+regenerator-runtime@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
 regenerator-runtime@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
babel-polyfill is the standard means of importing the necessary set of
polyfills for the configured babel preset. We were previously forced to
manually importing the polyfills we needed because the combination of
Node 6, JSDom, and babel-polyfill was broken. Since we're no longer
using JSDom (see 7e89701), we can use babel-polyfill.

Release note: None