### PR TITLE
storage: test transactions that span merges

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
+	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -375,6 +376,38 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	writeRandomDataToRange(t, store, aDesc.RangeID, []byte("aaa"))
 	writeRandomDataToRange(t, store, bDesc.RangeID, []byte("ccc"))
 
+	// Litter some abort span records. txn1 will leave a record on the LHS, txn2
+	// will leave a record on the RHS, and txn3 will leave a record on both. This
+	// tests whether the merge code properly accounts for merging abort span
+	// records for the same transaction.
+	txn1 := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+	if err := txn1.Put(ctx, "a-txn1", "val"); err != nil {
+		t.Fatal(err)
+	}
+	txn2 := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+	if err := txn2.Put(ctx, "c-txn2", "val"); err != nil {
+		t.Fatal(err)
+	}
+	txn3 := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+	if err := txn3.Put(ctx, "a-txn3", "val"); err != nil {
+		t.Fatal(err)
+	}
+	if err := txn3.Put(ctx, "c-txn3", "val"); err != nil {
+		t.Fatal(err)
+	}
+	hiPriTxn := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+	hiPriTxn.InternalSetPriority(roachpb.MaxTxnPriority)
+	for _, key := range []string{"a-txn1", "c-txn2", "a-txn3", "c-txn3"} {
+		if err := hiPriTxn.Put(ctx, key, "val"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := hiPriTxn.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	// Leave txn1-txn3 open so that their abort span records exist during the
+	// merge below.
+
 	// Get the range stats for both ranges now that we have data.
 	snap := store.Engine().NewSnapshot()
 	defer snap.Close()
@@ -416,6 +449,189 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	if err := verifyRecomputedStats(snap, replMerged.Desc(), msMerged, manual.UnixNano()); err != nil {
 		t.Errorf("failed to verify range's stats after merge: %v", err)
 	}
+}
+
+func TestStoreRangeMergeInFlightTxns(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	sc := storage.TestStoreConfig(nil)
+	sc.TestingKnobs.DisableReplicateQueue = true
+	mtc := &multiTestContext{storeConfig: &sc}
+	mtc.Start(t, 2)
+	defer mtc.Stop()
+	store := mtc.stores[0]
+
+	// Create two adjacent ranges. The left-hand range has exactly one replica,
+	// on the first store, and the right-hand range has exactly one replica,
+	// on the second store
+	setupReplicas := func() (lhsDesc, rhsDesc *roachpb.RangeDescriptor, err error) {
+		lhsDesc, rhsDesc, pErr := createSplitRanges(store)
+		if pErr != nil {
+			return nil, nil, pErr.GoError()
+		}
+		mtc.replicateRange(rhsDesc.RangeID, 1)
+		mtc.transferLease(ctx, rhsDesc.RangeID, 0, 1)
+		mtc.unreplicateRange(rhsDesc.RangeID, 0)
+		return lhsDesc, rhsDesc, nil
+	}
+
+	// Verify that a transaction can span a merge.
+	t.Run("valid", func(t *testing.T) {
+		lhsDesc, _, err := setupReplicas()
+		if err != nil {
+			t.Fatal(err)
+		}
+		lhsKey, rhsKey := roachpb.Key("aa"), roachpb.Key("cc")
+
+		txn := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+		// Put the key on the RHS side first so ownership of the transaction record
+		// will need to transfer to the LHS range during the merge.
+		if err := txn.Put(ctx, rhsKey, t.Name()); err != nil {
+			t.Fatal(err)
+		}
+		if err := txn.Put(ctx, lhsKey, t.Name()); err != nil {
+			t.Fatal(err)
+		}
+		args := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
+		if _, err := client.SendWrapped(ctx, store.TestSender(), args); err != nil {
+			t.Fatal(err)
+		}
+		if err := txn.Commit(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		for _, key := range []roachpb.Key{lhsKey, rhsKey} {
+			kv, err := store.DB().Get(ctx, key)
+			if err != nil {
+				t.Fatal(err)
+			} else if string(kv.ValueBytes()) != t.Name() {
+				t.Fatalf("actual value %q did not match expected value %q", kv.ValueBytes(), t.Name())
+			}
+		}
+	})
+
+	// Verify that a transaction's abort span records are preserved when the
+	// transaction spans a merge.
+	t.Run("abort-span", func(t *testing.T) {
+		lhsDesc, _, err := setupReplicas()
+		if err != nil {
+			t.Fatal(err)
+		}
+		rhsKey := roachpb.Key("cc")
+
+		// Create a transaction that will be aborted before the merge but won't
+		// realize until after the merge.
+		txn1 := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+		// Put the key on the RHS side so ownership of the transaction record and
+		// abort span records will need to transfer to the LHS during the merge.
+		if err := txn1.Put(ctx, rhsKey, t.Name()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create and commit a txn that aborts txn1.
+		txn2 := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+		txn2.InternalSetPriority(roachpb.MaxTxnPriority)
+		if err := txn2.Put(ctx, rhsKey, "muhahahah"); err != nil {
+			t.Fatal(err)
+		}
+		if err := txn2.Commit(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		// Complete the merge.
+		args := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
+		if _, err := client.SendWrapped(ctx, store.TestSender(), args); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := txn1.Get(ctx, rhsKey); !testutils.IsError(err, "txn aborted") {
+			t.Fatalf("expected 'txn aborted' error but got %v", err)
+		}
+	})
+
+	// Verify that the transaction wait queue on the right-hand range in a merge
+	// is cleared if the merge commits.
+	t.Run("wait-queue", func(t *testing.T) {
+		lhsDesc, rhsDesc, err := setupReplicas()
+		if err != nil {
+			t.Fatal(err)
+		}
+		rhsKey := roachpb.Key("cc")
+
+		// Set a timeout, and set the the transaction liveness threshold to
+		// something much larger than our timeout. We want transactions to get stuck
+		// in the transaction wait queue and trigger the timeout if we forget to
+		// clear it.
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, testutils.DefaultSucceedsSoonDuration)
+		defer cancel()
+		defer func(old time.Duration) { txnwait.TxnLivenessThreshold = old }(txnwait.TxnLivenessThreshold)
+		txnwait.TxnLivenessThreshold = 2 * testutils.DefaultSucceedsSoonDuration
+
+		// Create a transaction that won't complete until after the merge.
+		txn1 := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+		// Put the key on the RHS side so ownership of the transaction record and
+		// abort span records will need to transfer to the LHS during the merge.
+		if err := txn1.Put(ctx, rhsKey, t.Name()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create a txn that will conflict with txn1.
+		txn2 := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+		txn2ErrCh := make(chan error)
+		go func() {
+			txn2ErrCh <- txn2.Put(ctx, rhsKey, "muhahahah")
+		}()
+
+		// Wait for txn2 to realize it conflicts with txn1 and enter its wait queue.
+		{
+			repl, err := mtc.stores[1].GetReplica(rhsDesc.RangeID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for {
+				if _, ok := repl.GetTxnWaitQueue().TrackedTxns()[txn1.ID()]; ok {
+					break
+				}
+				select {
+				case <-time.After(10 * time.Millisecond):
+				case <-ctx.Done():
+					t.Fatal("timed out waiting for txn2 to enter wait queue")
+				}
+			}
+		}
+
+		// Complete the merge.
+		args := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
+		if _, err := client.SendWrapped(ctx, store.TestSender(), args); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := txn1.Commit(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		kv, pErr := store.DB().Get(ctx, rhsKey)
+		if pErr != nil {
+			t.Fatal(pErr)
+		} else if string(kv.ValueBytes()) != t.Name() {
+			t.Fatalf("actual value %q did not match expected value %q", kv.ValueBytes(), t.Name())
+		}
+
+		// Now that txn1 has committed, txn2's put operation should complete.
+		select {
+		case err := <-txn2ErrCh:
+			if err != nil {
+				t.Fatal(err)
+			}
+		case <-ctx.Done():
+			t.Fatal("timed out waiting for txn2 to complete put")
+		}
+
+		if err := txn2.Commit(ctx); err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 func TestInvalidGetSnapshotForMergeRequest(t *testing.T) {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2719,7 +2719,9 @@ func (r *Replica) maybeWatchForMerge(ctx context.Context) error {
 				log.Fatalf(ctx, "unexpected error when removing merged replica: %s", err)
 			}
 
-			// TODO(benesch): drain the RHS txn wait queue.
+			// Clear the wait queue to redirect the queued transactions to the
+			// left-hand replica, if necessary.
+			r.txnWaitQueue.Clear(true /* disable */)
 		}
 		// Unblock pending requests. If the merge committed, the requests will
 		// notice that the replica has been destroyed and return an appropriate


### PR DESCRIPTION
Add tests to verify the correct behavior of transactions that span a
merge. In the process, resolve TODOs about a) copying the abort span
from the RHS to the LHS during a merge, and b) clearing the RHS's
transaction wait queue.

Fixes #27091.