### PR TITLE
 sql/parser: remove the now-unused a_expr_const non-terminal 

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1294,8 +1294,16 @@ table_constraint ::=
 	| constraint_elem
 
 d_expr ::=
-	column_path_with_star
-	| a_expr_const
+	'ICONST'
+	| 'FCONST'
+	| 'SCONST'
+	| 'BCONST'
+	| const_typename 'SCONST'
+	| interval
+	| 'TRUE'
+	| 'FALSE'
+	| 'NULL'
+	| column_path_with_star
 	| '@' iconst64
 	| 'PLACEHOLDER'
 	| '(' a_expr ')' '.' '*'
@@ -1568,22 +1576,38 @@ constraint_elem ::=
 	| 'PRIMARY' 'KEY' '(' index_params ')'
 	| 'FOREIGN' 'KEY' '(' name_list ')' 'REFERENCES' table_name opt_column_list reference_actions
 
+const_typename ::=
+	numeric
+	| bit_without_length
+	| character_without_length
+	| const_datetime
+	| const_json
+	| 'BLOB'
+	| 'BYTES'
+	| 'BYTEA'
+	| 'TEXT'
+	| 'NAME'
+	| 'SERIAL'
+	| 'SERIAL2'
+	| 'SERIAL4'
+	| 'SERIAL8'
+	| 'SMALLSERIAL'
+	| 'UUID'
+	| 'INET'
+	| 'BIGSERIAL'
+	| 'OID'
+	| 'OIDVECTOR'
+	| 'INT2VECTOR'
+	| 'identifier'
+
+interval ::=
+	const_interval 'SCONST' opt_interval
+
 column_path_with_star ::=
 	column_path
 	| name '.' unrestricted_name '.' unrestricted_name '.' '*'
 	| name '.' unrestricted_name '.' '*'
 	| name '.' '*'
-
-a_expr_const ::=
-	'ICONST'
-	| 'FCONST'
-	| 'SCONST'
-	| 'BCONST'
-	| const_typename 'SCONST'
-	| interval
-	| 'TRUE'
-	| 'FALSE'
-	| 'NULL'
 
 iconst64 ::=
 	'ICONST'
@@ -1614,30 +1638,6 @@ when_clause_list ::=
 case_default ::=
 	'ELSE' a_expr
 	| 
-
-const_typename ::=
-	numeric
-	| bit_without_length
-	| character_without_length
-	| const_datetime
-	| const_json
-	| 'BLOB'
-	| 'BYTES'
-	| 'BYTEA'
-	| 'TEXT'
-	| 'NAME'
-	| 'SERIAL'
-	| 'SERIAL2'
-	| 'SERIAL4'
-	| 'SERIAL8'
-	| 'SMALLSERIAL'
-	| 'UUID'
-	| 'INET'
-	| 'BIGSERIAL'
-	| 'OID'
-	| 'OIDVECTOR'
-	| 'INT2VECTOR'
-	| 'identifier'
 
 bit_with_length ::=
 	'BIT' opt_varying '(' iconst64 ')'
@@ -1783,12 +1783,50 @@ reference_actions ::=
 	| reference_on_delete reference_on_update
 	| 
 
+numeric ::=
+	'INT'
+	| 'INT2'
+	| 'INT4'
+	| 'INT8'
+	| 'INT64'
+	| 'INTEGER'
+	| 'SMALLINT'
+	| 'BIGINT'
+	| 'REAL'
+	| 'FLOAT4'
+	| 'FLOAT8'
+	| 'FLOAT' opt_float
+	| 'DOUBLE' 'PRECISION'
+	| 'DECIMAL' opt_numeric_modifiers
+	| 'DEC' opt_numeric_modifiers
+	| 'NUMERIC' opt_numeric_modifiers
+	| 'BOOLEAN'
+	| 'BOOL'
+
+bit_without_length ::=
+	'BIT' opt_varying
+
+character_without_length ::=
+	character_base
+
+const_datetime ::=
+	'DATE'
+	| 'TIME'
+	| 'TIME' 'WITHOUT' 'TIME' 'ZONE'
+	| 'TIMETZ'
+	| 'TIME' 'WITH' 'TIME' 'ZONE'
+	| 'TIMESTAMP'
+	| 'TIMESTAMP' 'WITHOUT' 'TIME' 'ZONE'
+	| 'TIMESTAMPTZ'
+	| 'TIMESTAMP' 'WITH' 'TIME' 'ZONE'
+
+const_json ::=
+	'JSON'
+	| 'JSONB'
+
 column_path ::=
 	name
 	| prefixed_column_path
-
-interval ::=
-	const_interval 'SCONST' opt_interval
 
 func_application ::=
 	func_name '(' ')'
@@ -1841,47 +1879,6 @@ opt_slice_bound ::=
 
 when_clause ::=
 	'WHEN' a_expr 'THEN' a_expr
-
-numeric ::=
-	'INT'
-	| 'INT2'
-	| 'INT4'
-	| 'INT8'
-	| 'INT64'
-	| 'INTEGER'
-	| 'SMALLINT'
-	| 'BIGINT'
-	| 'REAL'
-	| 'FLOAT4'
-	| 'FLOAT8'
-	| 'FLOAT' opt_float
-	| 'DOUBLE' 'PRECISION'
-	| 'DECIMAL' opt_numeric_modifiers
-	| 'DEC' opt_numeric_modifiers
-	| 'NUMERIC' opt_numeric_modifiers
-	| 'BOOLEAN'
-	| 'BOOL'
-
-bit_without_length ::=
-	'BIT' opt_varying
-
-character_without_length ::=
-	character_base
-
-const_datetime ::=
-	'DATE'
-	| 'TIME'
-	| 'TIME' 'WITHOUT' 'TIME' 'ZONE'
-	| 'TIMETZ'
-	| 'TIME' 'WITH' 'TIME' 'ZONE'
-	| 'TIMESTAMP'
-	| 'TIMESTAMP' 'WITHOUT' 'TIME' 'ZONE'
-	| 'TIMESTAMPTZ'
-	| 'TIMESTAMP' 'WITH' 'TIME' 'ZONE'
-
-const_json ::=
-	'JSON'
-	| 'JSONB'
 
 opt_varying ::=
 	'VARYING'
@@ -1996,6 +1993,15 @@ reference_on_update ::=
 reference_on_delete ::=
 	'ON' 'DELETE' reference_action
 
+opt_float ::=
+	'(' 'ICONST' ')'
+	| 
+
+opt_numeric_modifiers ::=
+	'(' iconst64 ')'
+	| '(' iconst64 ',' iconst64 ')'
+	| 
+
 prefixed_column_path ::=
 	name '.' unrestricted_name
 	| name '.' unrestricted_name '.' unrestricted_name
@@ -2028,15 +2034,6 @@ special_function ::=
 	| 'TRIM' '(' trim_list ')'
 	| 'GREATEST' '(' expr_list ')'
 	| 'LEAST' '(' expr_list ')'
-
-opt_float ::=
-	'(' 'ICONST' ')'
-	| 
-
-opt_numeric_modifiers ::=
-	'(' iconst64 ')'
-	| '(' iconst64 ',' iconst64 ')'
-	| 
 
 window_definition ::=
 	window_name 'AS' window_specification

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -856,7 +856,7 @@ func newNameFromStr(s string) *tree.Name {
 %type <*tree.IndexHints> opt_index_hints
 %type <*tree.IndexHints> index_hints_param
 %type <*tree.IndexHints> index_hints_param_list
-%type <tree.Expr> a_expr b_expr c_expr a_expr_const d_expr
+%type <tree.Expr> a_expr b_expr c_expr d_expr
 %type <tree.Expr> substr_from substr_for
 %type <tree.Expr> in_expr
 %type <tree.Expr> having_clause
@@ -6798,11 +6798,48 @@ c_expr:
 //     |  array_subscripts
 
 d_expr:
-  column_path_with_star
+  ICONST
+  {
+    $$.val = $1.numVal()
+  }
+| FCONST
+  {
+    $$.val = $1.numVal()
+  }
+| SCONST
+  {
+    $$.val = tree.NewStrVal($1)
+  }
+| BCONST
+  {
+    $$.val = tree.NewBytesStrVal($1)
+  }
+| func_name '(' expr_list opt_sort_clause_err ')' SCONST { return unimplemented(sqllex, "func const") }
+| const_typename SCONST
+  {
+    $$.val = &tree.CastExpr{Expr: tree.NewStrVal($2), Type: $1.colType(), SyntaxMode: tree.CastPrepend}
+  }
+| interval
+  {
+    $$.val = $1.expr()
+  }
+| const_interval '(' ICONST ')' SCONST { return unimplemented(sqllex, "expr_const const_interval") }
+| TRUE
+  {
+    $$.val = tree.MakeDBool(true)
+  }
+| FALSE
+  {
+    $$.val = tree.MakeDBool(false)
+  }
+| NULL
+  {
+    $$.val = tree.DNull
+  }
+| column_path_with_star
   {
     $$.val = tree.Expr($1.unresolvedName())
   }
-| a_expr_const
 | '@' iconst64
   {
     colNum := $2.int64()
@@ -7711,46 +7748,6 @@ name_list:
   }
 
 // Constants
-a_expr_const:
-  ICONST
-  {
-    $$.val = $1.numVal()
-  }
-| FCONST
-  {
-    $$.val = $1.numVal()
-  }
-| SCONST
-  {
-    $$.val = tree.NewStrVal($1)
-  }
-| BCONST
-  {
-    $$.val = tree.NewBytesStrVal($1)
-  }
-| func_name '(' expr_list opt_sort_clause_err ')' SCONST { return unimplemented(sqllex, "func const") }
-| const_typename SCONST
-  {
-    $$.val = &tree.CastExpr{Expr: tree.NewStrVal($2), Type: $1.colType(), SyntaxMode: tree.CastPrepend}
-  }
-| interval
-  {
-    $$.val = $1.expr()
-  }
-| const_interval '(' ICONST ')' SCONST { return unimplemented(sqllex, "expr_const const_interval") }
-| TRUE
-  {
-    $$.val = tree.MakeDBool(true)
-  }
-| FALSE
-  {
-    $$.val = tree.MakeDBool(false)
-  }
-| NULL
-  {
-    $$.val = tree.DNull
-  }
-
 signed_iconst:
   ICONST
 | '+' ICONST


### PR DESCRIPTION
First 3 commits from  #27212, #27206 and  #27213