### PR TITLE
cherrypick-2.0: Add early checks for context cancellation

### DIFF
--- a/pkg/kv/transport.go
+++ b/pkg/kv/transport.go
@@ -229,6 +229,13 @@ func (gt *grpcTransport) send(
 	ctx context.Context, client batchClient,
 ) (*roachpb.BatchResponse, error) {
 	reply, err := func() (*roachpb.BatchResponse, error) {
+		// Bail out early if the context is already canceled. (GRPC will
+		// detect this pretty quickly, but the first check of the context
+		// in the local server comes pretty late)
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
 		gt.opts.metrics.SentCount.Inc(1)
 		if localServer := gt.rpcContext.GetLocalInternalServerForAddr(client.remoteAddr); localServer != nil {
 			log.VEvent(ctx, 2, "sending request to local server")

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -803,6 +803,9 @@ func RunGC(
 			return GCInfo{}, err
 		} else if !ok {
 			break
+		} else if ctx.Err() != nil {
+			// Stop iterating if our context has expired.
+			return GCInfo{}, err
 		}
 		iterKey := iter.Key()
 		if !iterKey.IsValue() || !iterKey.Key.Equal(expBaseKey) {


### PR DESCRIPTION
Cherry-picks 2/3 commits from #26643. The other commit is left out because the batching logic in release-2.0 is different and doesn't have the same continue-after-error problem. 