### PR TITLE
sql: properly reject invalid uses of composite variable names

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -248,3 +248,12 @@ SELECT * FROM generate_series(1,1000000)
 # Test that statement_timeout can be set with an interval string.
 statement ok
 SET statement_timeout = '0ms'
+
+# Test that composite variable names get rejected properly, especially
+# when "tracing" is used as prefix.
+
+statement error unknown variable: "blah.blah"
+SET blah.blah = 123
+
+statement error unknown variable: "tracing.blah"
+SET tracing.blah = 123

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2606,7 +2606,8 @@ generic_set:
   {
     // We need to recognize the "set tracing" specially here; couldn't make "set
     // tracing" a different grammar rule because of ambiguity.
-    if $1.strs()[0] == "tracing" {
+    varName := $1.strs()
+    if len(varName) == 1 && varName[0] == "tracing" {
       $$.val = &tree.SetTracing{Values: $3.exprs()}
     } else {
       $$.val = &tree.SetVar{Name: strings.Join($1.strs(), "."), Values: $3.exprs()}
@@ -2614,7 +2615,8 @@ generic_set:
   }
 | var_name '=' var_list
   {
-    if $1.strs()[0] == "tracing" {
+    varName := $1.strs()
+    if len(varName) == 1 && varName[0] == "tracing" {
       $$.val = &tree.SetTracing{Values: $3.exprs()}
     } else {
       $$.val = &tree.SetVar{Name: strings.Join($1.strs(), "."), Values: $3.exprs()}


### PR DESCRIPTION
A "long" variable name of the form `tracing.xxx` is invalid and must
be rejected. Prior to this patch, `tracing.xxx` was (incorrectly)
understood as an alias to `tracing`. This patch fixes it.

Release note (bug fix): SET now properly rejects attempts to use
invalid variable names starting with "tracing.".