### PR TITLE
sql: fix a pretty-print rendering bug for DISTINCT ON

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -812,6 +812,7 @@ func TestParse(t *testing.T) {
 		{`SELECT a FROM t LIMIT a OFFSET b`},
 		{`SELECT DISTINCT * FROM t`},
 		{`SELECT DISTINCT a, b FROM t`},
+		{`SELECT DISTINCT ON (a, b) c FROM t`},
 		{`SET a = 3`},
 		{`SET a = 3, 4`},
 		{`SET a = '3'`},

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -259,12 +259,16 @@ func (node SelectClause) doc(p prettyCfg) pretty.Doc {
 	if node.TableSelect {
 		return p.nestName(pretty.Text("TABLE"), p.Doc(node.From.Tables[0]))
 	}
-	sel := "SELECT"
+	sel := pretty.Text("SELECT")
 	if node.Distinct {
-		sel += " DISTINCT"
+		if node.DistinctOn != nil {
+			sel = pretty.ConcatSpace(sel, p.Doc(&node.DistinctOn))
+		} else {
+			sel = pretty.Concat(sel, pretty.Text(" DISTINCT"))
+		}
 	}
 	return pretty.Group(pretty.Stack(
-		p.nestName(pretty.Text(sel), node.Exprs.doc(p)),
+		p.nestName(sel, node.Exprs.doc(p)),
 		node.From.doc(p),
 		node.Where.doc(p),
 		node.GroupBy.doc(p),

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -87,7 +87,12 @@ func (node *SelectClause) Format(ctx *FmtCtx) {
 	} else {
 		ctx.WriteString("SELECT ")
 		if node.Distinct {
-			ctx.WriteString("DISTINCT ")
+			if node.DistinctOn != nil {
+				ctx.FormatNode(&node.DistinctOn)
+				ctx.WriteByte(' ')
+			} else {
+				ctx.WriteString("DISTINCT ")
+			}
 		}
 		ctx.FormatNode(&node.Exprs)
 		ctx.FormatNode(node.From)
@@ -436,12 +441,9 @@ type DistinctOn []Expr
 
 // Format implements the NodeFormatter interface.
 func (node *DistinctOn) Format(ctx *FmtCtx) {
-	prefix := " DISTINCT ON "
-	for _, n := range *node {
-		ctx.WriteString(prefix)
-		ctx.FormatNode(n)
-		prefix = ", "
-	}
+	ctx.WriteString("DISTINCT ON (")
+	ctx.FormatNode((*Exprs)(node))
+	ctx.WriteByte(')')
 }
 
 // OrderBy represents an ORDER By clause.

--- a/pkg/sql/sem/tree/testdata/pretty/15.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/15.golden
@@ -1,6 +1,6 @@
 1:
 -
-SELECT DISTINCT
+SELECT DISTINCT ON (pk1, pk2, x, y)
 	x,
 	y,
 	z
@@ -12,7 +12,7 @@ ORDER BY
 
 8:
 --------
-SELECT DISTINCT
+SELECT DISTINCT ON (pk1, pk2, x, y)
 	x,
 	y,
 	z
@@ -22,7 +22,7 @@ ORDER BY
 
 11:
 -----------
-SELECT DISTINCT
+SELECT DISTINCT ON (pk1, pk2, x, y)
 	x, y, z
 FROM xyz
 ORDER BY
@@ -30,22 +30,22 @@ ORDER BY
 
 13:
 -------------
-SELECT DISTINCT
+SELECT DISTINCT ON (pk1, pk2, x, y)
 	x, y, z
 FROM xyz
 ORDER BY x, y
 
-23:
------------------------
-SELECT DISTINCT x, y, z
+43:
+-------------------------------------------
+SELECT DISTINCT ON (pk1, pk2, x, y) x, y, z
 FROM xyz
 ORDER BY x, y
 
-32:
---------------------------------
-SELECT DISTINCT x, y, z FROM xyz
+52:
+----------------------------------------------------
+SELECT DISTINCT ON (pk1, pk2, x, y) x, y, z FROM xyz
 ORDER BY x, y
 
-46:
-----------------------------------------------
-SELECT DISTINCT x, y, z FROM xyz ORDER BY x, y
+66:
+------------------------------------------------------------------
+SELECT DISTINCT ON (pk1, pk2, x, y) x, y, z FROM xyz ORDER BY x, y


### PR DESCRIPTION
The DISTINCT ON clause was not pretty-printed correctly (its
pretty-printing code was simply not tested). This would impact the
correctness of reporting data, statement statistics, and
pretty-printed output, between other things.

Release note (bug fix): the DISTINCT ON clause was not reported
properly in statement statistics. This is now fixed.
