### PR TITLE
release-2.0: sql: fix a pretty-print rendering bug for DISTINCT ON

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -760,6 +760,7 @@ func TestParse(t *testing.T) {
 		{`SELECT a FROM t LIMIT a OFFSET b`},
 		{`SELECT DISTINCT * FROM t`},
 		{`SELECT DISTINCT a, b FROM t`},
+		{`SELECT DISTINCT ON (a, b) c FROM t`},
 		{`SET a = 3`},
 		{`SET a = 3, 4`},
 		{`SET a = '3'`},

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -87,7 +87,12 @@ func (node *SelectClause) Format(ctx *FmtCtx) {
 	} else {
 		ctx.WriteString("SELECT ")
 		if node.Distinct {
-			ctx.WriteString("DISTINCT ")
+			if node.DistinctOn != nil {
+				ctx.FormatNode(&node.DistinctOn)
+				ctx.WriteByte(' ')
+			} else {
+				ctx.WriteString("DISTINCT ")
+			}
 		}
 		ctx.FormatNode(&node.Exprs)
 		ctx.FormatNode(node.From)
@@ -438,12 +443,9 @@ type DistinctOn []Expr
 
 // Format implements the NodeFormatter interface.
 func (node *DistinctOn) Format(ctx *FmtCtx) {
-	prefix := " DISTINCT ON "
-	for _, n := range *node {
-		ctx.WriteString(prefix)
-		ctx.FormatNode(n)
-		prefix = ", "
-	}
+	ctx.WriteString("DISTINCT ON (")
+	ctx.FormatNode((*Exprs)(node))
+	ctx.WriteByte(')')
 }
 
 // OrderBy represents an ORDER By clause.


### PR DESCRIPTION
Backport 1/1 commits from #27221.

/cc @cockroachdb/release

---

The DISTINCT ON clause was not pretty-printed correctly (its
pretty-printing code was simply not tested). This would impact the
correctness of reporting data, statement statistics, and
pretty-printed output, between other things.

Release note (bug fix): the DISTINCT ON clause was not reported
properly in statement statistics. This is now fixed.

