### PR TITLE
cherrypick-2.0: fix panic with UNION ALL

### DIFF
--- a/pkg/sql/distsqlplan/physical_plan.go
+++ b/pkg/sql/distsqlplan/physical_plan.go
@@ -242,9 +242,9 @@ func (p *PhysicalPlan) AddSingleGroupStage(
 	p.MergeOrdering = distsqlrun.Ordering{}
 }
 
-// GetLastStagePost returns the PostProcessSpec for the processors in the last
-// stage (ResultRouters).
-func (p *PhysicalPlan) GetLastStagePost() distsqlrun.PostProcessSpec {
+// CheckLastStagePost checks that the processors of the last stage of the
+// PhysicalPlan have identical post-processing, returning an error if not.
+func (p *PhysicalPlan) CheckLastStagePost() error {
 	post := p.Processors[p.ResultRouters[0]].Spec.Post
 
 	// All processors of a stage should be identical in terms of post-processing;
@@ -253,16 +253,25 @@ func (p *PhysicalPlan) GetLastStagePost() distsqlrun.PostProcessSpec {
 		pi := &p.Processors[p.ResultRouters[i]].Spec.Post
 		if pi.Filter != post.Filter || pi.Projection != post.Projection ||
 			len(pi.OutputColumns) != len(post.OutputColumns) {
-			panic(fmt.Sprintf("inconsistent post-processing: %v vs %v", post, pi))
+			return errors.Errorf("inconsistent post-processing: %v vs %v", post, pi)
 		}
 		for j, col := range pi.OutputColumns {
 			if col != post.OutputColumns[j] {
-				panic(fmt.Sprintf("inconsistent post-processing: %v vs %v", post, pi))
+				return errors.Errorf("inconsistent post-processing: %v vs %v", post, pi)
 			}
 		}
 	}
 
-	return post
+	return nil
+}
+
+// GetLastStagePost returns the PostProcessSpec for the processors in the last
+// stage (ResultRouters).
+func (p *PhysicalPlan) GetLastStagePost() distsqlrun.PostProcessSpec {
+	if err := p.CheckLastStagePost(); err != nil {
+		panic(err)
+	}
+	return p.Processors[p.ResultRouters[0]].Spec.Post
 }
 
 // SetLastStagePost changes the PostProcess spec of the processors in the last

--- a/pkg/sql/distsqlplan/physical_plan.go
+++ b/pkg/sql/distsqlplan/physical_plan.go
@@ -763,7 +763,7 @@ func MergeResultTypes(left, right []sqlbase.ColumnType) ([]sqlbase.ColumnType, e
 			merged[i] = leftType
 		} else if leftType.SemanticType == sqlbase.ColumnType_NULL {
 			merged[i] = rightType
-		} else if leftType.Equal(rightType) {
+		} else if leftType.Equivalent(rightType) {
 			merged[i] = leftType
 		} else {
 			return nil, errors.Errorf("conflicting ColumnTypes: %v and %v", leftType, rightType)

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -248,3 +248,14 @@ CREATE TABLE b (a INTEGER PRIMARY KEY)
 
 query I
 SELECT * FROM a UNION ALL SELECT * FROM b
+
+
+# Make sure that UNION ALL doesn't crash when its two children have different
+# post-processing stages.
+
+statement ok
+CREATE TABLE c (a INT PRIMARY KEY, b INT)
+
+query I
+SELECT a FROM a WHERE a > 2 UNION ALL (SELECT a FROM c WHERE b > 2) LIMIT 1;
+----

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -237,3 +237,14 @@ union             ·     ·
  └── render       ·     ·
       └── values  ·     ·
 ·                 size  3 columns, 6 rows
+
+# Check that UNION permits columns of different visible types
+
+statement ok
+CREATE TABLE a (a INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE b (a INTEGER PRIMARY KEY)
+
+query I
+SELECT * FROM a UNION ALL SELECT * FROM b

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2134,6 +2134,13 @@ func (c *ColumnType) elementColumnType() *ColumnType {
 	return &result
 }
 
+// Equivalent checks whether a column type is equivalent to another, excluding
+// its VisibleType type alias, which doesn't effect equality.
+func (c *ColumnType) Equivalent(other ColumnType) bool {
+	other.VisibleType = c.VisibleType
+	return c.Equal(other)
+}
+
 // SQLString returns the SQL string corresponding to the type.
 func (c *ColumnType) SQLString() string {
 	switch c.SemanticType {


### PR DESCRIPTION
Cherry-pick https://github.com/cockroachdb/cockroach/pull/25720 and https://github.com/cockroachdb/cockroach/pull/25747. There was a merge conflict to do with the metadata test receiver, which is not present in 2.0, so that code was removed.

Fixes #27200