### PR TITLE
opt: Decorrelate additional queries

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -351,46 +351,44 @@ group         ·            ·                (max int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT min(y) FROM xyz WHERE x = 1
 ----
-group           ·            ·                (min int)       ·
- │              aggregate 0  any_not_null(y)  ·               ·
- └── limit      ·            ·                (x int, y int)  ·
-      │         count        (1)[int]         ·               ·
-      └── scan  ·            ·                (x int, y int)  ·
-·               table        xyz@xy           ·               ·
-·               spans        /1/!NULL-/2      ·               ·
+group      ·            ·                (min int)       ·
+ │         aggregate 0  any_not_null(y)  ·               ·
+ └── scan  ·            ·                (x int, y int)  ·
+·          table        xyz@xy           ·               ·
+·          spans        /1/!NULL-/2      ·               ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT max(y) FROM xyz WHERE x = 1
 ----
-group           ·            ·                (max int)       ·
- │              aggregate 0  any_not_null(y)  ·               ·
- └── limit      ·            ·                (x int, y int)  ·
-      │         count        (1)[int]         ·               ·
-      └── scan  ·            ·                (x int, y int)  ·
-·               table        xyz@xy           ·               ·
-·               spans        /1/!NULL-/2      ·               ·
+group      ·            ·                (max int)       ·
+ │         aggregate 0  any_not_null(y)  ·               ·
+ └── scan  ·            ·                (x int, y int)  ·
+·          table        xyz@xy           ·               ·
+·          spans        /1/!NULL-/2      ·               ·
 
 query TTTTT
-EXPLAIN (TYPES) SELECT min(y) FROM xyz WHERE x = 7
+EXPLAIN (TYPES) SELECT min(y) FROM xyz WHERE z = 7
 ----
-group           ·            ·                (min int)       ·
- │              aggregate 0  any_not_null(y)  ·               ·
- └── limit      ·            ·                (x int, y int)  ·
-      │         count        (1)[int]         ·               ·
-      └── scan  ·            ·                (x int, y int)  ·
-·               table        xyz@xy           ·               ·
-·               spans        /7/!NULL-/8      ·               ·
+group           ·            ·                            (min int)         ·
+ │              aggregate 0  any_not_null(y)              ·                 ·
+ └── limit      ·            ·                            (y int, z float)  +y
+      │         count        (1)[int]                     ·                 ·
+      └── scan  ·            ·                            (y int, z float)  +y
+·               table        xyz@zyx                      ·                 ·
+·               spans        /7/!NULL-/7.000000000000001  ·                 ·
 
 query TTTTT
-EXPLAIN (TYPES) SELECT max(y) FROM xyz WHERE x = 7
+EXPLAIN (TYPES) SELECT max(y) FROM xyz WHERE z = 7
 ----
-group           ·            ·                (max int)       ·
- │              aggregate 0  any_not_null(y)  ·               ·
- └── limit      ·            ·                (x int, y int)  ·
-      │         count        (1)[int]         ·               ·
-      └── scan  ·            ·                (x int, y int)  ·
-·               table        xyz@xy           ·               ·
-·               spans        /7/!NULL-/8      ·               ·
+group                ·            ·                            (max int)         ·
+ │                   aggregate 0  any_not_null(y)              ·                 ·
+ └── limit           ·            ·                            (y int, z float)  -y
+      │              count        (1)[int]                     ·                 ·
+      └── sort       ·            ·                            (y int, z float)  -y
+           │         order        -y                           ·                 ·
+           └── scan  ·            ·                            (y int, z float)  ·
+·                    table        xyz@zyx                      ·                 ·
+·                    spans        /7/!NULL-/7.000000000000001  ·                 ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT min(x) FROM xyz WHERE (y, z) = (2, 3.0)

--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -369,7 +369,7 @@ func (ev ExprView) formatRelational(f *opt.ExprFmtCtx, tp treeprinter.Node) {
 	if !f.HasFlags(opt.ExprFmtHideRowCard) {
 		if logProps.Relational.Cardinality != props.AnyCardinality {
 			// Suppress cardinality for Scan ops if it's redundant with Limit field.
-			if ev.Operator() != opt.ScanOp || !logProps.Relational.Cardinality.CanBeZero() {
+			if ev.Operator() != opt.ScanOp || ev.Private().(*ScanOpDef).HardLimit == 0 {
 				tp.Childf("cardinality: %s", logProps.Relational.Cardinality)
 			}
 		}

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -188,11 +188,12 @@ func (b *logicalPropsBuilder) buildSelectProps(ev ExprView) props.Logical {
 
 	// Functional Dependencies
 	// -----------------------
-	// Start with copy of FuncDepSet from input, add FDs from the WHERE clause,
-	// modify with any additional not-null columns, then possibly simplify by
-	// calling ProjectCols.
+	// Start with copy of FuncDepSet from input, add FDs from the WHERE clause
+	// and outer columns, modify with any additional not-null columns, then
+	// possibly simplify by calling ProjectCols.
 	relational.FuncDeps.CopyFrom(&inputProps.FuncDeps)
 	relational.FuncDeps.AddFrom(&filterProps.FuncDeps)
+	b.applyOuterColConstants(relational)
 	relational.FuncDeps.MakeNotNull(relational.NotNullCols)
 	relational.FuncDeps.ProjectCols(relational.OutputCols)
 
@@ -352,22 +353,28 @@ func (b *logicalPropsBuilder) buildJoinProps(ev ExprView) props.Logical {
 	// Start with FDs from left side, and modify based on join type.
 	relational.FuncDeps.CopyFrom(&leftProps.FuncDeps)
 
+	// Anti and semi joins only inherit FDs from left side, since right side
+	// simply acts like a filter.
 	switch ev.Operator() {
 	case opt.SemiJoinOp, opt.SemiJoinApplyOp:
 		// Add FDs from the ON predicate, which include equivalent columns and
-		// constant columns. Remove any FDs involving columns from the right side.
+		// constant columns. Any outer columns become constants as well.
 		relational.FuncDeps.AddFrom(&onProps.FuncDeps)
+		b.applyOuterColConstants(relational)
+		relational.FuncDeps.MakeNotNull(relational.NotNullCols)
+
+		// Call ProjectCols to remove any FDs involving columns from the right side.
 		relational.FuncDeps.ProjectCols(relational.OutputCols)
-		fallthrough
 
 	case opt.AntiJoinOp, opt.AntiJoinApplyOp:
-		// Inherit FDs from left side, since right side simply acts like a filter.
-		relational.FuncDeps.MakeNotNull(relational.NotNullCols)
+		// Anti-joins inherit FDs from left input, and nothing more, since the
+		// right input is not projected, and the ON predicate doesn't filter rows
+		// in the usual way.
 
 	default:
 		// Joins are modeled as consisting of several steps:
 		//   1. Compute cartesian product of left and right inputs.
-		//   2. Apply ON predicate filter on resulting rows.
+		//   2. For inner joins, apply ON predicate filter on resulting rows.
 		//   3. For outer joins, add non-matching rows, extended with NULL values
 		//      for the null-supplying side of the join.
 		if ev.IsJoinApply() {
@@ -383,6 +390,7 @@ func (b *logicalPropsBuilder) buildJoinProps(ev ExprView) props.Logical {
 			// Add FDs from the ON predicate, which include equivalent columns and
 			// constant columns.
 			relational.FuncDeps.AddFrom(&onProps.FuncDeps)
+			b.applyOuterColConstants(relational)
 
 		case opt.RightJoinOp, opt.RightJoinApplyOp:
 			relational.FuncDeps.MakeOuter(leftProps.OutputCols, notNullCols)
@@ -405,7 +413,8 @@ func (b *logicalPropsBuilder) buildJoinProps(ev ExprView) props.Logical {
 			if !relational.OutputCols.Intersects(notNullCols) {
 				relational.FuncDeps.ClearKey()
 			}
-			relational.FuncDeps.MakeOuter(relational.OutputCols, notNullCols)
+			relational.FuncDeps.MakeOuter(leftProps.OutputCols, notNullCols)
+			relational.FuncDeps.MakeOuter(rightProps.OutputCols, notNullCols)
 		}
 
 		relational.FuncDeps.MakeNotNull(relational.NotNullCols)
@@ -943,7 +952,7 @@ func (b *logicalPropsBuilder) buildScalarProps(ev ExprView) props.Logical {
 	// By default, union outer cols from all children, both relational and scalar.
 	for i := 0; i < ev.ChildCount(); i++ {
 		childLogical := &ev.childGroup(i).logical
-		logical.Scalar.OuterCols.UnionWith(childLogical.OuterCols())
+		scalar.OuterCols.UnionWith(childLogical.OuterCols())
 
 		// Propagate HasCorrelatedSubquery up the scalar expression tree.
 		if childLogical.Scalar != nil && childLogical.Scalar.HasCorrelatedSubquery {
@@ -1129,4 +1138,12 @@ func (b *logicalPropsBuilder) applyNotNullConstraint(
 			relational.NotNullCols = notNullCols
 		}
 	}
+}
+
+// applyOuterColConstants adds all outer columns and columns equivalent to them
+// to the FD set in the relational properties. References to outer columns act
+// like constants, since they are the same for all rows in the inner relation.
+func (b *logicalPropsBuilder) applyOuterColConstants(relational *props.Relational) {
+	equivCols := relational.FuncDeps.ComputeEquivClosure(relational.OuterCols)
+	relational.FuncDeps.AddConstants(equivCols)
 }

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -142,6 +142,9 @@ func (b *logicalPropsBuilder) buildScanProps(ev ExprView) props.Logical {
 	// since those are created by exploration patterns and won't ever be the
 	// basis for the logical props on a newly created memo group.
 	relational.Cardinality = props.AnyCardinality
+	if relational.FuncDeps.HasMax1Row() {
+		relational.Cardinality = relational.Cardinality.AtMost(1)
+	}
 
 	// Statistics
 	// ----------
@@ -197,6 +200,9 @@ func (b *logicalPropsBuilder) buildSelectProps(ev ExprView) props.Logical {
 	// -----------
 	// Select filter can filter any or all rows.
 	relational.Cardinality = inputProps.Cardinality.AsLowAs(0)
+	if relational.FuncDeps.HasMax1Row() {
+		relational.Cardinality = relational.Cardinality.AtMost(1)
+	}
 
 	// Statistics
 	// ----------
@@ -415,6 +421,9 @@ func (b *logicalPropsBuilder) buildJoinProps(ev ExprView) props.Logical {
 	relational.Cardinality = b.makeJoinCardinality(
 		ev, leftProps.Cardinality, rightProps.Cardinality,
 	)
+	if relational.FuncDeps.HasMax1Row() {
+		relational.Cardinality = relational.Cardinality.AtMost(1)
+	}
 
 	// Statistics
 	// ----------
@@ -519,6 +528,9 @@ func (b *logicalPropsBuilder) buildGroupByProps(ev ExprView) props.Logical {
 		// has. However, if the input has at least one row, then at least one row
 		// will also be returned by GroupBy.
 		relational.Cardinality = inputProps.Cardinality.AsLowAs(1)
+		if relational.FuncDeps.HasMax1Row() {
+			relational.Cardinality = relational.Cardinality.AtMost(1)
+		}
 	}
 
 	// Statistics

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -23,6 +23,18 @@ TABLE uv
  └── INDEX primary
       └── rowid int not null (hidden)
 
+exec-ddl
+CREATE TABLE mn (m INT PRIMARY KEY, n INT, UNIQUE (n))
+----
+TABLE mn
+ ├── m int not null
+ ├── n int
+ ├── INDEX primary
+ │    └── m int not null
+ └── INDEX secondary
+      ├── n int
+      └── m int not null (storing)
+
 # Inner-join.
 build
 SELECT *, rowid FROM xysd INNER JOIN uv ON x=u
@@ -83,6 +95,60 @@ project
  │    └── true [type=bool]
  └── projections [outer=(5)]
       └── variable: column1 [type=int, outer=(5)]
+
+# Inner-join nested in inner-join with outer column reference to top-level join.
+opt
+SELECT * FROM xysd WHERE (SELECT v FROM uv WHERE (SELECT m FROM mn WHERE m=y)=x)=x
+----
+project
+ ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+ ├── stats: [rows=100]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ └── inner-join-apply
+      ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) v:6(int!null)
+      ├── stats: [rows=100]
+      ├── key: (1)
+      ├── fd: (1)-->(2-4,6), (3,4)~~>(1,2)
+      ├── scan xysd
+      │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+      │    ├── stats: [rows=1000]
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
+      ├── max1-row
+      │    ├── columns: v:6(int!null)
+      │    ├── outer: (1,2)
+      │    ├── cardinality: [0 - 1]
+      │    ├── stats: [rows=1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(6)
+      │    └── project
+      │         ├── columns: v:6(int!null)
+      │         ├── outer: (1,2)
+      │         ├── stats: [rows=100000]
+      │         └── inner-join
+      │              ├── columns: v:6(int!null) m:8(int!null)
+      │              ├── outer: (1,2)
+      │              ├── stats: [rows=100000]
+      │              ├── fd: ()-->(8)
+      │              ├── scan uv
+      │              │    ├── columns: v:6(int!null)
+      │              │    └── stats: [rows=1000]
+      │              ├── scan mn
+      │              │    ├── columns: m:8(int!null)
+      │              │    ├── stats: [rows=1000]
+      │              │    └── key: (8)
+      │              └── filters [type=bool, outer=(1,2,8), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(1,8), (8)==(1,2), (1)==(2,8)]
+      │                   ├── eq [type=bool, outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ])]
+      │                   │    ├── variable: mn.m [type=int, outer=(8)]
+      │                   │    └── variable: xysd.y [type=int, outer=(2)]
+      │                   └── eq [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
+      │                        ├── variable: xysd.x [type=int, outer=(1)]
+      │                        └── variable: mn.m [type=int, outer=(8)]
+      └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+           └── eq [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+                ├── variable: xysd.x [type=int, outer=(1)]
+                └── variable: uv.v [type=int, outer=(6)]
 
 # Left-join.
 build
@@ -145,6 +211,7 @@ project
       │    │         ├── columns: u:5(int!null)
       │    │         ├── outer: (1)
       │    │         ├── stats: [rows=111.111111]
+      │    │         ├── fd: ()-->(5)
       │    │         ├── scan uv
       │    │         │    ├── columns: u:5(int)
       │    │         │    └── stats: [rows=1000]
@@ -221,10 +288,12 @@ right-join
  │         │    │         ├── columns: uv.u:8(int!null)
  │         │    │         ├── outer: (1)
  │         │    │         ├── stats: [rows=110.111111]
+ │         │    │         ├── fd: ()-->(8)
  │         │    │         ├── select
  │         │    │         │    ├── columns: uv.u:8(int!null)
  │         │    │         │    ├── outer: (1)
  │         │    │         │    ├── stats: [rows=111.111111]
+ │         │    │         │    ├── fd: ()-->(8)
  │         │    │         │    ├── scan uv
  │         │    │         │    │    ├── columns: uv.u:8(int)
  │         │    │         │    │    └── stats: [rows=1000]
@@ -278,7 +347,7 @@ project
  └── full-join-apply
       ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) uv.u:5(int) uv.v:6(int) uv.u:8(int)
       ├── stats: [rows=100000]
-      ├── fd: (1)-->(2-4), (3,4)~~>(1,2), ()~~>(8)
+      ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
       ├── scan xysd
       │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
       │    ├── stats: [rows=1000]
@@ -303,10 +372,12 @@ project
       │    │         ├── columns: uv.u:8(int!null)
       │    │         ├── outer: (1)
       │    │         ├── stats: [rows=110.111111]
+      │    │         ├── fd: ()-->(8)
       │    │         ├── select
       │    │         │    ├── columns: uv.u:8(int!null)
       │    │         │    ├── outer: (1)
       │    │         │    ├── stats: [rows=111.111111]
+      │    │         │    ├── fd: ()-->(8)
       │    │         │    ├── scan uv
       │    │         │    │    ├── columns: uv.u:8(int)
       │    │         │    │    └── stats: [rows=1000]
@@ -361,10 +432,12 @@ semi-join-apply
  │    ├── columns: u:5(int) v:6(int!null)
  │    ├── outer: (1)
  │    ├── stats: [rows=110.111111]
+ │    ├── fd: ()-->(6)
  │    ├── select
  │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    ├── outer: (1)
  │    │    ├── stats: [rows=111.111111]
+ │    │    ├── fd: ()-->(6)
  │    │    ├── scan uv
  │    │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    │    └── stats: [rows=1000]
@@ -373,6 +446,42 @@ semi-join-apply
  │    │              ├── variable: uv.v [type=int, outer=(6)]
  │    │              └── variable: xysd.x [type=int, outer=(1)]
  │    └── const: 1 [type=int]
+ └── true [type=bool]
+
+# Semi-join nested in semi-join with outer column reference to top-level join.
+opt
+SELECT * FROM xysd WHERE EXISTS(SELECT * FROM uv WHERE EXISTS(SELECT * FROM mn WHERE x=m AND x=v))
+----
+semi-join-apply
+ ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+ ├── stats: [rows=100000000]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ ├── scan xysd
+ │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+ │    ├── stats: [rows=1000]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ ├── semi-join
+ │    ├── columns: u:5(int) v:6(int!null)
+ │    ├── outer: (1)
+ │    ├── stats: [rows=100000]
+ │    ├── fd: ()-->(6)
+ │    ├── scan uv
+ │    │    ├── columns: u:5(int) v:6(int!null)
+ │    │    └── stats: [rows=1000]
+ │    ├── scan mn
+ │    │    ├── columns: m:8(int!null) n:9(int)
+ │    │    ├── stats: [rows=1000]
+ │    │    ├── key: (8)
+ │    │    └── fd: (8)-->(9), (9)~~>(8)
+ │    └── filters [type=bool, outer=(1,6,8), constraints=(/1: (/NULL - ]; /6: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(6,8), (8)==(1,6), (6)==(1,8)]
+ │         ├── eq [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
+ │         │    ├── variable: xysd.x [type=int, outer=(1)]
+ │         │    └── variable: mn.m [type=int, outer=(8)]
+ │         └── eq [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+ │              ├── variable: xysd.x [type=int, outer=(1)]
+ │              └── variable: uv.v [type=int, outer=(6)]
  └── true [type=bool]
 
 # Anti-join.
@@ -415,10 +524,12 @@ anti-join-apply
  │    ├── columns: u:5(int) v:6(int!null)
  │    ├── outer: (1)
  │    ├── stats: [rows=110.111111]
+ │    ├── fd: ()-->(6)
  │    ├── select
  │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    ├── outer: (1)
  │    │    ├── stats: [rows=111.111111]
+ │    │    ├── fd: ()-->(6)
  │    │    ├── scan uv
  │    │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    │    └── stats: [rows=1000]
@@ -588,10 +699,12 @@ semi-join-apply
  │    ├── outer: (1)
  │    ├── cardinality: [0 - 5]
  │    ├── stats: [rows=5]
+ │    ├── fd: ()-->(5)
  │    ├── select
  │    │    ├── columns: u:5(int!null) v:6(int!null)
  │    │    ├── outer: (1)
  │    │    ├── stats: [rows=111.111111]
+ │    │    ├── fd: ()-->(5)
  │    │    ├── scan uv
  │    │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    │    └── stats: [rows=1000]
@@ -649,10 +762,12 @@ anti-join-apply
  │    ├── outer: (1)
  │    ├── cardinality: [0 - 5]
  │    ├── stats: [rows=5]
+ │    ├── fd: ()-->(5)
  │    ├── select
  │    │    ├── columns: u:5(int!null) v:6(int!null)
  │    │    ├── outer: (1)
  │    │    ├── stats: [rows=111.111111]
+ │    │    ├── fd: ()-->(5)
  │    │    ├── scan uv
  │    │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    │    └── stats: [rows=1000]

--- a/pkg/sql/opt/memo/testdata/logprops/limit
+++ b/pkg/sql/opt/memo/testdata/logprops/limit
@@ -157,17 +157,17 @@ project
 
 # Test very high limit (> max uint32).
 opt
-SELECT s, x FROM xyzs WHERE x=1 LIMIT 4294967296
+SELECT s, x FROM xyzs WHERE s='foo' LIMIT 4294967296
 ----
 limit
- ├── columns: s:4(string) x:1(int!null)
- ├── stats: [rows=1]
- ├── key: ()
- ├── fd: ()-->(1,4)
- ├── scan xyzs
- │    ├── columns: x:1(int!null) s:4(string)
- │    ├── constraint: /1: [/1 - /1]
- │    ├── stats: [rows=1, distinct(1)=1]
- │    ├── key: ()
- │    └── fd: ()-->(1,4)
+ ├── columns: s:4(string!null) x:1(int!null)
+ ├── stats: [rows=1.42857143]
+ ├── key: (1)
+ ├── fd: ()-->(4)
+ ├── scan xyzs@secondary
+ │    ├── columns: x:1(int!null) s:4(string!null)
+ │    ├── constraint: /-4/3: [/'foo' - /'foo']
+ │    ├── stats: [rows=1.42857143, distinct(4)=1]
+ │    ├── key: (1)
+ │    └── fd: ()-->(4)
  └── const: 4294967296 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/offset
+++ b/pkg/sql/opt/memo/testdata/logprops/offset
@@ -172,28 +172,28 @@ offset
 
 # Test very high offset (> max uint32).
 opt
-SELECT s, x FROM (SELECT * FROM xyzs LIMIT 100) WHERE x=1 OFFSET 4294967296
+SELECT s, x FROM (SELECT * FROM xyzs LIMIT 100) WHERE s='foo' OFFSET 4294967296
 ----
 offset
- ├── columns: s:4(string) x:1(int!null)
+ ├── columns: s:4(string!null) x:1(int!null)
  ├── cardinality: [0 - 0]
  ├── stats: [rows=0]
- ├── key: ()
- ├── fd: ()-->(1,4)
+ ├── key: (1)
+ ├── fd: ()-->(4)
  ├── select
- │    ├── columns: x:1(int!null) s:4(string)
+ │    ├── columns: x:1(int!null) s:4(string!null)
  │    ├── cardinality: [0 - 100]
- │    ├── stats: [rows=1, distinct(1)=1]
- │    ├── key: ()
- │    ├── fd: ()-->(1,4)
+ │    ├── stats: [rows=1.0223419, distinct(4)=1]
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4)
  │    ├── scan xyzs@secondary
  │    │    ├── columns: x:1(int!null) s:4(string)
  │    │    ├── limit: 100
- │    │    ├── stats: [rows=100, distinct(1)=100]
+ │    │    ├── stats: [rows=100, distinct(4)=97.8146353]
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(4)
- │    └── filters [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
- │         └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
- │              ├── variable: xyzs.x [type=int, outer=(1)]
- │              └── const: 1 [type=int]
+ │    └── filters [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+ │         └── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
+ │              ├── variable: xyzs.s [type=string, outer=(4)]
+ │              └── const: 'foo' [type=string]
  └── const: 4294967296 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -81,14 +81,17 @@ select
            │         └── project
            │              ├── columns: y:9(int)
            │              ├── outer: (1,2)
+           │              ├── cardinality: [0 - 1]
            │              ├── stats: [rows=111.111111]
+           │              ├── key: ()
            │              ├── fd: ()-->(9)
            │              ├── select
            │              │    ├── columns: k:5(int!null) u:6(float) v:7(string)
            │              │    ├── outer: (1)
+           │              │    ├── cardinality: [0 - 1]
            │              │    ├── stats: [rows=111.111111]
-           │              │    ├── key: (5)
-           │              │    ├── fd: (5)-->(6,7)
+           │              │    ├── key: ()
+           │              │    ├── fd: ()-->(5-7)
            │              │    ├── scan kuv
            │              │    │    ├── columns: k:5(int!null) u:6(float) v:7(string)
            │              │    │    ├── stats: [rows=1000]
@@ -206,13 +209,17 @@ project
                 └── project
                      ├── columns: xysd.y:5(int)
                      ├── outer: (1)
+                     ├── cardinality: [0 - 1]
                      ├── stats: [rows=111.111111]
+                     ├── key: ()
+                     ├── fd: ()-->(5)
                      └── select
                           ├── columns: x:4(int!null) xysd.y:5(int) s:6(string) d:7(decimal!null)
                           ├── outer: (1)
+                          ├── cardinality: [0 - 1]
                           ├── stats: [rows=111.111111]
-                          ├── key: (4)
-                          ├── fd: (4)-->(5-7), (6,7)~~>(4,5)
+                          ├── key: ()
+                          ├── fd: ()-->(4-7)
                           ├── scan xysd
                           │    ├── columns: x:4(int!null) xysd.y:5(int) s:6(string) d:7(decimal!null)
                           │    ├── stats: [rows=1000]
@@ -254,13 +261,17 @@ project
                           └── project
                                ├── columns: xysd.y:9(int)
                                ├── outer: (1)
+                               ├── cardinality: [0 - 1]
                                ├── stats: [rows=111.111111]
+                               ├── key: ()
+                               ├── fd: ()-->(9)
                                └── select
                                     ├── columns: xysd.x:8(int!null) xysd.y:9(int) xysd.s:10(string) xysd.d:11(decimal!null)
                                     ├── outer: (1)
+                                    ├── cardinality: [0 - 1]
                                     ├── stats: [rows=111.111111]
-                                    ├── key: (8)
-                                    ├── fd: (8)-->(9-11), (10,11)~~>(8,9)
+                                    ├── key: ()
+                                    ├── fd: ()-->(8-11)
                                     ├── scan xysd
                                     │    ├── columns: xysd.x:8(int!null) xysd.y:9(int) xysd.s:10(string) xysd.d:11(decimal!null)
                                     │    ├── stats: [rows=1000]

--- a/pkg/sql/opt/memo/testdata/logprops/scalar
+++ b/pkg/sql/opt/memo/testdata/logprops/scalar
@@ -89,12 +89,13 @@ select
                 ├── columns: u:3(int!null) v:4(int!null)
                 ├── outer: (1)
                 ├── stats: [rows=111.111111]
+                ├── fd: ()-->(3)
                 └── select
                      ├── columns: u:3(int!null) v:4(int!null) rowid:5(int!null)
                      ├── outer: (1)
                      ├── stats: [rows=111.111111]
                      ├── key: (5)
-                     ├── fd: (5)-->(3,4)
+                     ├── fd: ()-->(3), (5)-->(4)
                      ├── scan uv
                      │    ├── columns: u:3(int) v:4(int!null) rowid:5(int!null)
                      │    ├── stats: [rows=1000]
@@ -129,7 +130,7 @@ select
            │         ├── outer: (1)
            │         ├── stats: [rows=111.111111]
            │         ├── key: (5)
-           │         ├── fd: (5)-->(3,4)
+           │         ├── fd: ()-->(3), (5)-->(4)
            │         ├── scan uv
            │         │    ├── columns: u:3(int) v:4(int!null) rowid:5(int!null)
            │         │    ├── stats: [rows=1000]

--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -61,6 +61,7 @@ SELECT s, x FROM a WHERE x=1
 scan a
  ├── columns: s:3(string) x:1(int!null)
  ├── constraint: /1: [/1 - /1]
+ ├── cardinality: [0 - 1]
  ├── stats: [rows=1, distinct(1)=1]
  ├── key: ()
  └── fd: ()-->(1,3)

--- a/pkg/sql/opt/memo/testdata/logprops/select
+++ b/pkg/sql/opt/memo/testdata/logprops/select
@@ -84,15 +84,17 @@ select
            └── select
                 ├── columns: k:3(int!null) u:4(float) v:5(string)
                 ├── outer: (1,2)
+                ├── cardinality: [0 - 1]
                 ├── stats: [rows=12.345679]
-                ├── key: (3)
-                ├── fd: (3)-->(4,5)
+                ├── key: ()
+                ├── fd: ()-->(3-5)
                 ├── select
                 │    ├── columns: k:3(int!null) u:4(float) v:5(string)
                 │    ├── outer: (2)
+                │    ├── cardinality: [0 - 1]
                 │    ├── stats: [rows=111.111111]
-                │    ├── key: (3)
-                │    ├── fd: (3)-->(4,5)
+                │    ├── key: ()
+                │    ├── fd: ()-->(3-5)
                 │    ├── scan kuv
                 │    │    ├── columns: k:3(int!null) u:4(float) v:5(string)
                 │    │    ├── stats: [rows=1000]
@@ -319,7 +321,7 @@ project
                 │              │         ├── outer: (2)
                 │              │         ├── stats: [rows=111.111111]
                 │              │         ├── key: (6)
-                │              │         ├── fd: (6)-->(7)
+                │              │         ├── fd: ()-->(7)
                 │              │         ├── scan xy
                 │              │         │    ├── columns: x:6(int!null) y:7(int)
                 │              │         │    ├── stats: [rows=1000]

--- a/pkg/sql/opt/memo/testdata/logprops/select
+++ b/pkg/sql/opt/memo/testdata/logprops/select
@@ -22,6 +22,7 @@ SELECT * FROM xy WHERE x=1
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
+ ├── cardinality: [0 - 1]
  ├── stats: [rows=1, distinct(1)=1]
  ├── key: ()
  ├── fd: ()-->(1,2)

--- a/pkg/sql/opt/memo/testdata/stats/ordinality
+++ b/pkg/sql/opt/memo/testdata/stats/ordinality
@@ -135,6 +135,7 @@ SELECT * FROM (SELECT * FROM a WITH ORDINALITY) WHERE ordinality = 2
 ----
 select
  ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)
+ ├── cardinality: [0 - 1]
  ├── stats: [rows=1, distinct(3)=1]
  ├── key: ()
  ├── fd: ()-->(1-3)

--- a/pkg/sql/opt/norm/check_expr.go
+++ b/pkg/sql/opt/norm/check_expr.go
@@ -26,18 +26,7 @@ import (
 // this code in regular builds).
 func (f *Factory) checkExpr(ev memo.ExprView) {
 	// Check logical properties.
-	relational := ev.Logical().Relational
-	if relational != nil {
-		if !relational.NotNullCols.SubsetOf(relational.OutputCols) {
-			panic(fmt.Sprintf("not null cols %s not a subset of output cols %s",
-				relational.NotNullCols, relational.OutputCols))
-		}
-		if relational.OuterCols.Intersects(relational.OutputCols) {
-			panic(fmt.Sprintf("outer cols %s intersect output cols %s",
-				relational.OuterCols, relational.OutputCols))
-		}
-		relational.FuncDeps.Verify()
-	}
+	ev.Logical().Verify()
 
 	switch ev.Operator() {
 	case opt.ProjectionsOp:

--- a/pkg/sql/opt/norm/prune_cols.go
+++ b/pkg/sql/opt/norm/prune_cols.go
@@ -45,7 +45,8 @@ func (c *CustomFuncs) NeededCols3(group1, group2, group3 memo.GroupID) opt.ColSe
 func (c *CustomFuncs) NeededColsGroupBy(aggs memo.GroupID, def memo.PrivateID) opt.ColSet {
 	groupByDef := c.f.mem.LookupPrivate(def).(*memo.GroupByDef)
 	colSet := groupByDef.GroupingCols.Union(groupByDef.Ordering.ColSet())
-	return c.OuterCols(aggs).Union(colSet)
+	colSet.UnionWith(c.OuterCols(aggs))
+	return colSet
 }
 
 // NeededColsLimit unions the columns needed by Projections with the columns in

--- a/pkg/sql/opt/norm/testdata/props/prune_cols
+++ b/pkg/sql/opt/norm/testdata/props/prune_cols
@@ -139,7 +139,7 @@ inner-join
 opt
 SELECT *
 FROM a
-WHERE (SELECT k+1 AS r FROM xy WHERE x=k) = 1
+WHERE (SELECT k+1 AS r FROM xy WHERE y=k) = 1
 ----
 project
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
@@ -177,17 +177,16 @@ project
       │    │         ├── fd: ()-->(7)
       │    │         ├── prune: (7)
       │    │         ├── select
-      │    │         │    ├── columns: x:5(int!null)
+      │    │         │    ├── columns: y:6(int!null)
       │    │         │    ├── outer: (1)
-      │    │         │    ├── key: (5)
-      │    │         │    ├── interesting orderings: (+5)
+      │    │         │    ├── fd: ()-->(6)
+      │    │         │    ├── interesting orderings: ()
       │    │         │    ├── scan xy
-      │    │         │    │    ├── columns: x:5(int!null)
-      │    │         │    │    ├── key: (5)
-      │    │         │    │    ├── prune: (5)
-      │    │         │    │    └── interesting orderings: (+5)
-      │    │         │    └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
-      │    │         │         └── xy.x = a.k [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+      │    │         │    │    ├── columns: y:6(int)
+      │    │         │    │    ├── prune: (6)
+      │    │         │    │    └── interesting orderings: ()
+      │    │         │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+      │    │         │         └── xy.y = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
       │    │         └── projections [outer=(1)]
       │    │              └── a.k + 1 [type=int, outer=(1)]
       │    └── filters [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]

--- a/pkg/sql/opt/norm/testdata/props/prune_cols
+++ b/pkg/sql/opt/norm/testdata/props/prune_cols
@@ -37,6 +37,7 @@ SELECT * FROM a WHERE k=1 AND f=1.0
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string)
+ ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-4)
  ├── prune: (2,4)
@@ -360,6 +361,7 @@ union-all
  ├── scan a
  │    ├── columns: a.k:1(int!null) a.i:2(int)
  │    ├── constraint: /1: [/1 - /1]
+ │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1,2)
  │    ├── prune: (2)

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -713,7 +713,7 @@ Initial expression
                   ├── columns: x:6(int!null) y:7(int!null)
                   ├── outer: (2)
                   ├── key: (6)
-                  ├── fd: (6)-->(7)
+                  ├── fd: ()-->(7)
                   ├── scan xy
                   │    ├── columns: x:6(int!null) y:7(int)
                   │    ├── key: (6)
@@ -739,7 +739,7 @@ HoistSelectExists
   -                ├── columns: x:6(int!null) y:7(int!null)
   -                ├── outer: (2)
   -                ├── key: (6)
-  -                ├── fd: (6)-->(7)
+  -                ├── fd: ()-->(7)
   -                ├── scan xy
   -                │    ├── columns: x:6(int!null) y:7(int)
   -                │    ├── key: (6)
@@ -755,7 +755,7 @@ HoistSelectExists
   + │    │    ├── columns: x:6(int!null) y:7(int!null)
   + │    │    ├── outer: (2)
   + │    │    ├── key: (6)
-  + │    │    ├── fd: (6)-->(7)
+  + │    │    ├── fd: ()-->(7)
   + │    │    ├── scan xy
   + │    │    │    ├── columns: x:6(int!null) y:7(int)
   + │    │    │    ├── key: (6)
@@ -788,7 +788,7 @@ TryDecorrelateSelect
   + │    ├── scan xy
   + │    │    ├── columns: x:6(int!null) y:7(int)
     │    │    ├── key: (6)
-  - │    │    ├── fd: (6)-->(7)
+  - │    │    ├── fd: ()-->(7)
   - │    │    ├── scan xy
   - │    │    │    ├── columns: x:6(int!null) y:7(int)
   - │    │    │    ├── key: (6)
@@ -1332,8 +1332,6 @@ TryDecorrelateProjectSelect
   - │    │    │    │    │    └── true [type=bool]
   + │    │    │    │    │    └── left-join-apply
   + │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
-  + │    │    │    │    │         ├── key: (1,3)
-  + │    │    │    │    │         ├── fd: (3)-->(9)
   + │    │    │    │    │         ├── scan xy
   + │    │    │    │    │         │    ├── columns: x:1(int!null)
   + │    │    │    │    │         │    └── key: (1)
@@ -1385,8 +1383,8 @@ DecorrelateJoin
   - │    │    │    │    │    └── left-join-apply
   + │    │    │    │    │    └── left-join
     │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
-    │    │    │    │    │         ├── key: (1,3)
-    │    │    │    │    │         ├── fd: (3)-->(9)
+  + │    │    │    │    │         ├── key: (1,3)
+  + │    │    │    │    │         ├── fd: (3)-->(9)
     │    │    │    │    │         ├── scan xy
     │    │    │    │    │         │    ├── columns: x:1(int!null)
     │    │    │    │    │         │    └── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -211,11 +211,13 @@ SELECT * FROM a WHERE (1, (2, 'foo')) = (k, (i, s))
 ----
 select
  ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null) j:5(jsonb)
+ ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── constraint: /1: [/1 - /1]
+ │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    └── fd: ()-->(1-5)
  └── filters [type=bool, outer=(2,4), constraints=(/2: [/2 - /2]; /4: [/'foo' - /'foo']; tight), fd=()-->(2,4)]

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -150,7 +150,7 @@ semi-join-apply
  │    │    │    ├── columns: x:6(int!null) y:7(int!null)
  │    │    │    ├── outer: (1)
  │    │    │    ├── key: (6)
- │    │    │    ├── fd: (6)-->(7)
+ │    │    │    ├── fd: ()-->(7)
  │    │    │    ├── scan xy
  │    │    │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    │    │    ├── key: (6)
@@ -190,7 +190,7 @@ anti-join-apply
  │    │    │    ├── columns: x:6(int!null) y:7(int!null)
  │    │    │    ├── outer: (1)
  │    │    │    ├── key: (6)
- │    │    │    ├── fd: (6)-->(7)
+ │    │    │    ├── fd: ()-->(7)
  │    │    │    ├── scan xy
  │    │    │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    │    │    ├── key: (6)
@@ -201,6 +201,35 @@ anti-join-apply
  │    └── filters [type=bool, outer=(7), constraints=(/7: [/10 - /10]; tight), fd=()-->(7)]
  │         └── xy.y = 10 [type=bool, outer=(7), constraints=(/7: [/10 - /10]; tight)]
  └── true [type=bool]
+
+# Decorrelate Select with reference to outer column and no limit.
+opt
+SELECT * FROM a WHERE (SELECT y FROM xy WHERE x=i) > 100
+----
+project
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ └── inner-join
+      ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int!null)
+      ├── key: (1)
+      ├── fd: (1)-->(2-5), (6)-->(7), (2)==(6), (6)==(2)
+      ├── scan a
+      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2-5)
+      ├── select
+      │    ├── columns: x:6(int!null) y:7(int!null)
+      │    ├── key: (6)
+      │    ├── fd: (6)-->(7)
+      │    ├── scan xy
+      │    │    ├── columns: x:6(int!null) y:7(int)
+      │    │    ├── key: (6)
+      │    │    └── fd: (6)-->(7)
+      │    └── filters [type=bool, outer=(7), constraints=(/7: [/101 - ]; tight)]
+      │         └── xy.y > 100 [type=bool, outer=(7), constraints=(/7: [/101 - ]; tight)]
+      └── filters [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+           └── xy.x = a.i [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
 
 # Decorrelate Select with LeftJoinApply.
 opt
@@ -959,11 +988,15 @@ project
       │    │    ├── project
       │    │    │    ├── columns: column8:8(string)
       │    │    │    ├── outer: (1)
+      │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    ├── key: ()
+      │    │    │    ├── fd: ()-->(8)
       │    │    │    ├── select
       │    │    │    │    ├── columns: x:6(int!null) y:7(int)
       │    │    │    │    ├── outer: (1)
-      │    │    │    │    ├── key: (6)
-      │    │    │    │    ├── fd: (6)-->(7)
+      │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    ├── key: ()
+      │    │    │    │    ├── fd: ()-->(6,7)
       │    │    │    │    ├── scan xy
       │    │    │    │    │    ├── columns: x:6(int!null) y:7(int)
       │    │    │    │    │    ├── key: (6)
@@ -981,77 +1014,72 @@ project
 
 # Don't decorrelate when the group by input is ordered.
 opt
-SELECT * FROM a WHERE 'foo'=(SELECT max(y::string) FROM (SELECT * FROM xy ORDER BY y) WHERE x=k)
+SELECT * FROM a WHERE 'foo'=(SELECT max(y::string) FROM (SELECT * FROM xy ORDER BY x+y) WHERE y=k)
 ----
 project
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  └── inner-join-apply
-      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) max:9(string!null)
+      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) max:10(string!null)
       ├── key: (1)
-      ├── fd: (1)-->(2-5,9)
+      ├── fd: (1)-->(2-5,10)
       ├── scan a
       │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
       │    ├── key: (1)
       │    └── fd: (1)-->(2-5)
       ├── select
-      │    ├── columns: max:9(string!null)
+      │    ├── columns: max:10(string!null)
       │    ├── outer: (1)
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
-      │    ├── fd: ()-->(9)
+      │    ├── fd: ()-->(10)
       │    ├── group-by
-      │    │    ├── columns: max:9(string)
-      │    │    ├── ordering: +7
+      │    │    ├── columns: max:10(string)
+      │    │    ├── ordering: +8 opt(9)
       │    │    ├── outer: (1)
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(9)
+      │    │    ├── fd: ()-->(10)
       │    │    ├── sort
-      │    │    │    ├── columns: column8:8(string!null)
+      │    │    │    ├── columns: column9:9(string!null)
       │    │    │    ├── outer: (1)
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(8)
-      │    │    │    ├── ordering: +7
+      │    │    │    ├── fd: ()-->(9)
+      │    │    │    ├── ordering: +8 opt(9)
       │    │    │    └── limit
-      │    │    │         ├── columns: column8:8(string!null)
+      │    │    │         ├── columns: column9:9(string!null)
       │    │    │         ├── outer: (1)
       │    │    │         ├── cardinality: [0 - 1]
       │    │    │         ├── key: ()
-      │    │    │         ├── fd: ()-->(8)
-      │    │    │         ├── sort
-      │    │    │         │    ├── columns: column8:8(string!null)
+      │    │    │         ├── fd: ()-->(9)
+      │    │    │         ├── select
+      │    │    │         │    ├── columns: column9:9(string!null)
       │    │    │         │    ├── outer: (1)
-      │    │    │         │    ├── ordering: -8
-      │    │    │         │    └── select
-      │    │    │         │         ├── columns: column8:8(string!null)
-      │    │    │         │         ├── outer: (1)
-      │    │    │         │         ├── project
-      │    │    │         │         │    ├── columns: column8:8(string)
-      │    │    │         │         │    ├── outer: (1)
-      │    │    │         │         │    ├── select
-      │    │    │         │         │    │    ├── columns: x:6(int!null) y:7(int)
-      │    │    │         │         │    │    ├── outer: (1)
-      │    │    │         │         │    │    ├── key: (6)
-      │    │    │         │         │    │    ├── fd: (6)-->(7)
-      │    │    │         │         │    │    ├── scan xy
-      │    │    │         │         │    │    │    ├── columns: x:6(int!null) y:7(int)
-      │    │    │         │         │    │    │    ├── key: (6)
-      │    │    │         │         │    │    │    └── fd: (6)-->(7)
-      │    │    │         │         │    │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-      │    │    │         │         │    │         └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
-      │    │    │         │         │    └── projections [outer=(7)]
-      │    │    │         │         │         └── xy.y::STRING [type=string, outer=(7)]
-      │    │    │         │         └── filters [type=bool, outer=(8), constraints=(/8: (/NULL - ]; tight)]
-      │    │    │         │              └── column8 IS NOT NULL [type=bool, outer=(8), constraints=(/8: (/NULL - ]; tight)]
+      │    │    │         │    ├── fd: ()-->(9)
+      │    │    │         │    ├── project
+      │    │    │         │    │    ├── columns: column9:9(string)
+      │    │    │         │    │    ├── outer: (1)
+      │    │    │         │    │    ├── fd: ()-->(9)
+      │    │    │         │    │    ├── select
+      │    │    │         │    │    │    ├── columns: y:7(int!null)
+      │    │    │         │    │    │    ├── outer: (1)
+      │    │    │         │    │    │    ├── fd: ()-->(7)
+      │    │    │         │    │    │    ├── scan xy
+      │    │    │         │    │    │    │    └── columns: y:7(int)
+      │    │    │         │    │    │    └── filters [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+      │    │    │         │    │    │         └── xy.y = a.k [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ])]
+      │    │    │         │    │    └── projections [outer=(7)]
+      │    │    │         │    │         └── xy.y::STRING [type=string, outer=(7)]
+      │    │    │         │    └── filters [type=bool, outer=(9), constraints=(/9: (/NULL - ]; tight)]
+      │    │    │         │         └── column9 IS NOT NULL [type=bool, outer=(9), constraints=(/9: (/NULL - ]; tight)]
       │    │    │         └── const: 1 [type=int]
-      │    │    └── aggregations [outer=(8)]
-      │    │         └── any-not-null [type=string, outer=(8)]
-      │    │              └── variable: column8 [type=string, outer=(8)]
-      │    └── filters [type=bool, outer=(9), constraints=(/9: [/'foo' - /'foo']; tight), fd=()-->(9)]
-      │         └── max = 'foo' [type=bool, outer=(9), constraints=(/9: [/'foo' - /'foo']; tight)]
+      │    │    └── aggregations [outer=(9)]
+      │    │         └── any-not-null [type=string, outer=(9)]
+      │    │              └── variable: column9 [type=string, outer=(9)]
+      │    └── filters [type=bool, outer=(10), constraints=(/10: [/'foo' - /'foo']; tight), fd=()-->(10)]
+      │         └── max = 'foo' [type=bool, outer=(10), constraints=(/10: [/'foo' - /'foo']; tight)]
       └── true [type=bool]
 
 
@@ -1362,6 +1390,7 @@ project
       │    ├── select
       │    │    ├── columns: y:7(int!null)
       │    │    ├── outer: (1)
+      │    │    ├── fd: ()-->(7)
       │    │    ├── scan xy
       │    │    │    └── columns: y:7(int)
       │    │    └── filters [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
@@ -1415,6 +1444,7 @@ project
       │    ├── select
       │    │    ├── columns: xy.y:7(int!null)
       │    │    ├── outer: (1)
+      │    │    ├── fd: ()-->(7)
       │    │    ├── scan xy
       │    │    │    └── columns: xy.y:7(int)
       │    │    └── filters [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
@@ -1478,6 +1508,7 @@ project
       │    ├── select
       │    │    ├── columns: xy.y:10(int!null)
       │    │    ├── outer: (1)
+      │    │    ├── fd: ()-->(10)
       │    │    ├── scan xy
       │    │    │    └── columns: xy.y:10(int)
       │    │    └── filters [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
@@ -1687,29 +1718,22 @@ SELECT (SELECT x FROM xy WHERE x=k) FROM a
 ----
 project
  ├── columns: x:8(int)
- ├── left-join-apply
+ ├── left-join (merge)
  │    ├── columns: k:1(int!null) xy.x:6(int)
- │    ├── key: (1)
- │    ├── fd: (1)-->(6)
+ │    ├── key: (1,6)
  │    ├── scan a
  │    │    ├── columns: k:1(int!null)
- │    │    └── key: (1)
- │    ├── max1-row
+ │    │    ├── key: (1)
+ │    │    └── ordering: +1
+ │    ├── scan xy
  │    │    ├── columns: xy.x:6(int!null)
- │    │    ├── outer: (1)
- │    │    ├── cardinality: [0 - 1]
- │    │    ├── key: ()
- │    │    ├── fd: ()-->(6)
- │    │    └── select
- │    │         ├── columns: xy.x:6(int!null)
- │    │         ├── outer: (1)
- │    │         ├── key: (6)
- │    │         ├── scan xy
- │    │         │    ├── columns: xy.x:6(int!null)
- │    │         │    └── key: (6)
- │    │         └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
- │    │              └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
- │    └── true [type=bool]
+ │    │    ├── key: (6)
+ │    │    └── ordering: +6
+ │    └── merge-on
+ │         ├── left ordering: +1
+ │         ├── right ordering: +6
+ │         └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │              └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
  └── projections [outer=(6)]
       └── variable: xy.x [type=int, outer=(6)]
 
@@ -1729,44 +1753,34 @@ project
  ├── fd: ()-->(6,12,15,18)
  ├── group-by
  │    ├── columns: k:1(int!null) xy.x:7(int) count:21(int)
- │    ├── grouping columns: k:1(int!null)
- │    ├── key: (1)
- │    ├── fd: (1)-->(7,21)
+ │    ├── grouping columns: k:1(int!null) xy.x:7(int)
+ │    ├── key: (1,7)
+ │    ├── fd: (1,7)-->(21)
  │    ├── left-join
  │    │    ├── columns: k:1(int!null) xy.x:7(int) xy.y:20(int)
- │    │    ├── fd: (1)-->(7)
- │    │    ├── left-join-apply
+ │    │    ├── left-join (merge)
  │    │    │    ├── columns: k:1(int!null) xy.x:7(int)
- │    │    │    ├── key: (1)
- │    │    │    ├── fd: (1)-->(7)
+ │    │    │    ├── key: (1,7)
  │    │    │    ├── scan a
  │    │    │    │    ├── columns: k:1(int!null)
- │    │    │    │    └── key: (1)
- │    │    │    ├── max1-row
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    └── ordering: +1
+ │    │    │    ├── scan xy
  │    │    │    │    ├── columns: xy.x:7(int!null)
- │    │    │    │    ├── outer: (1)
- │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    ├── key: ()
- │    │    │    │    ├── fd: ()-->(7)
- │    │    │    │    └── select
- │    │    │    │         ├── columns: xy.x:7(int!null)
- │    │    │    │         ├── outer: (1)
- │    │    │    │         ├── key: (7)
- │    │    │    │         ├── scan xy
- │    │    │    │         │    ├── columns: xy.x:7(int!null)
- │    │    │    │         │    └── key: (7)
- │    │    │    │         └── filters [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
- │    │    │    │              └── xy.x = a.k [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ])]
- │    │    │    └── true [type=bool]
+ │    │    │    │    ├── key: (7)
+ │    │    │    │    └── ordering: +7
+ │    │    │    └── merge-on
+ │    │    │         ├── left ordering: +1
+ │    │    │         ├── right ordering: +7
+ │    │    │         └── filters [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+ │    │    │              └── xy.x = a.k [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ])]
  │    │    ├── scan xy
  │    │    │    └── columns: xy.y:20(int)
  │    │    └── filters [type=bool, outer=(1,20), constraints=(/1: (/NULL - ]; /20: (/NULL - ]), fd=(1)==(20), (20)==(1)]
  │    │         └── xy.y = a.k [type=bool, outer=(1,20), constraints=(/1: (/NULL - ]; /20: (/NULL - ])]
- │    └── aggregations [outer=(7,20)]
- │         ├── count [type=int, outer=(20)]
- │         │    └── variable: xy.y [type=int, outer=(20)]
- │         └── any-not-null [type=int, outer=(7)]
- │              └── variable: xy.x [type=int, outer=(7)]
+ │    └── aggregations [outer=(20)]
+ │         └── count [type=int, outer=(20)]
+ │              └── variable: xy.y [type=int, outer=(20)]
  └── projections [outer=(7,21)]
       ├── const: 5 [type=int]
       ├── variable: xy.x [type=int, outer=(7)]
@@ -1811,6 +1825,7 @@ group-by
  │    │    │    └── select
  │    │    │         ├── columns: y:7(int!null)
  │    │    │         ├── outer: (2)
+ │    │    │         ├── fd: ()-->(7)
  │    │    │         ├── scan xy
  │    │    │         │    └── columns: y:7(int)
  │    │    │         └── filters [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -208,10 +208,12 @@ SELECT * FROM a WHERE (SELECT x FROM (SELECT * FROM xy LIMIT 1) WHERE k=x) > 100
 ----
 project
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-5)
  └── inner-join (merge)
       ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null)
+      ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(1-6)
       ├── scan a
@@ -266,6 +268,7 @@ semi-join-apply
  │    ├── scan uv
  │    │    ├── columns: u:8(int!null) v:9(int)
  │    │    ├── constraint: /8: [/10 - /10]
+ │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    └── fd: ()-->(8,9)
  │    └── filters [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
@@ -337,10 +340,12 @@ SELECT * FROM a WHERE (SELECT y+1 AS r FROM (SELECT * FROM xy LIMIT 1) WHERE x=k
 ----
 project
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-5)
  └── inner-join (merge)
       ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null)
+      ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(1-6)
       ├── scan a
@@ -1373,19 +1378,23 @@ WHERE k=10 AND (SELECT y FROM xy WHERE y=k LIMIT 1) = i AND (SELECT x FROM xy LI
 ----
 project
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-5)
  └── inner-join-apply
       ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) xy.y:7(int!null)
+      ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(1-5,7)
       ├── select
       │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+      │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(1-5)
       │    ├── scan a
       │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
       │    │    ├── constraint: /1: [/10 - /10]
+      │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()
       │    │    └── fd: ()-->(1-5)
       │    └── filters [type=bool]
@@ -2266,15 +2275,18 @@ SELECT * FROM a WHERE k=10 AND i < ANY(SELECT y FROM xy) AND s='foo'
 ----
 semi-join
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string!null) j:5(jsonb)
+ ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-5)
  ├── select
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string!null) j:5(jsonb)
+ │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-5)
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    │    ├── constraint: /1: [/10 - /10]
+ │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    └── fd: ()-->(1-5)
  │    └── filters [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -801,12 +801,10 @@ SELECT * FROM a JOIN b ON a.k = b.x AND b.x * a.i = (SELECT min(a.k) FROM b)
 ----
 project
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
- ├── key: (1,6)
- ├── fd: (1)-->(2-5), (6)-->(7)
+ ├── fd: (1)-->(2-5)
  └── inner-join-apply
       ├── columns: a.k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) b.x:6(int!null) b.y:7(int) min:11(int)
-      ├── key: (1,6)
-      ├── fd: (1)-->(2-5), (6)-->(7,11)
+      ├── fd: (1)-->(2-5)
       ├── scan a
       │    ├── columns: a.k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
       │    ├── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -193,11 +193,13 @@ SELECT k, i FROM a WHERE k=1 AND i<5
 ----
 select
  ├── columns: k:1(int!null) i:2(int!null)
+ ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1,2)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int)
  │    ├── constraint: /1: [/1 - /1]
+ │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    └── fd: ()-->(1,2)
  └── filters [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
@@ -244,19 +246,23 @@ SELECT i FROM (SELECT k, i, s, f/2.0 f FROM a WHERE k = 5) a2 WHERE i::float = f
 ----
 project
  ├── columns: i:2(int)
+ ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(2)
  └── select
       ├── columns: i:2(int) f:5(float!null)
+      ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(2,5)
       ├── project
       │    ├── columns: f:5(float) i:2(int)
+      │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(2,5)
       │    ├── scan a
       │    │    ├── columns: k:1(int!null) i:2(int) a.f:3(float)
       │    │    ├── constraint: /1: [/5 - /5]
+      │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()
       │    │    └── fd: ()-->(1-3)
       │    └── projections [outer=(2,3)]

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -962,6 +962,7 @@ SELECT * FROM (SELECT i, count(*) FROM a GROUP BY i) a WHERE i=1
 group-by
  ├── columns: i:2(int!null) count:6(int)
  ├── grouping columns: i:2(int!null)
+ ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(2,6)
  ├── select
@@ -981,6 +982,7 @@ SELECT * FROM (SELECT i FROM a GROUP BY i) a WHERE i=1
 group-by
  ├── columns: i:2(int!null)
  ├── grouping columns: i:2(int!null)
+ ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(2)
  └── select
@@ -1070,6 +1072,7 @@ SELECT k FROM b WHERE k IS NULL
 scan b
  ├── columns: k:1(int!null)
  ├── constraint: /1: contradiction
+ ├── cardinality: [0 - 1]
  ├── key: ()
  └── fd: ()-->(1)
 

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -75,12 +75,15 @@ where phoneregis0_.phone_id=1;
 ----
 project
  ├── columns: phone_id1_2_0_:1(int!null) person_i2_2_0_:2(int!null) formula159_0_:11(timestamp) id1_1_1_:3(int!null) number2_1_1_:4(string) since3_1_1_:5(timestamp) type4_1_1_:6(int)
- ├── key: (3)
- ├── fd: ()-->(1), (3)-->(4-6,11), (2)==(3), (3)==(2)
- ├── left-join-apply
- │    ├── columns: phone_id:1(int!null) person_id:2(int!null) phone.id:3(int!null) phone.number:4(string) phone.since:5(timestamp) phone.type:6(int) phone.since:9(timestamp)
- │    ├── key: (3)
- │    ├── fd: ()-->(1), (3)-->(4-6,9), (2)==(3), (3)==(2)
+ ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2)
+ ├── right-join
+ │    ├── columns: phone_id:1(int!null) person_id:2(int!null) phone.id:3(int!null) phone.number:4(string) phone.since:5(timestamp) phone.type:6(int) phone.id:7(int) phone.since:9(timestamp)
+ │    ├── key: (3,7)
+ │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2), (7)-->(9)
+ │    ├── scan phone
+ │    │    ├── columns: phone.id:7(int!null) phone.since:9(timestamp)
+ │    │    ├── key: (7)
+ │    │    └── fd: (7)-->(9)
  │    ├── inner-join (merge)
  │    │    ├── columns: phone_id:1(int!null) person_id:2(int!null) phone.id:3(int!null) phone.number:4(string) phone.since:5(timestamp) phone.type:6(int)
  │    │    ├── key: (3)
@@ -105,27 +108,8 @@ project
  │    │         ├── right ordering: +3
  │    │         └── filters [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]), fd=(2)==(3), (3)==(2)]
  │    │              └── phone_register.person_id = phone.id [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ])]
- │    ├── max1-row
- │    │    ├── columns: phone.since:9(timestamp)
- │    │    ├── outer: (2)
- │    │    ├── cardinality: [0 - 1]
- │    │    ├── key: ()
- │    │    ├── fd: ()-->(9)
- │    │    └── project
- │    │         ├── columns: phone.since:9(timestamp)
- │    │         ├── outer: (2)
- │    │         └── select
- │    │              ├── columns: phone.id:7(int!null) phone.since:9(timestamp)
- │    │              ├── outer: (2)
- │    │              ├── key: (7)
- │    │              ├── fd: (7)-->(9)
- │    │              ├── scan phone
- │    │              │    ├── columns: phone.id:7(int!null) phone.since:9(timestamp)
- │    │              │    ├── key: (7)
- │    │              │    └── fd: (7)-->(9)
- │    │              └── filters [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
- │    │                   └── phone.id = phone_register.person_id [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
- │    └── true [type=bool]
+ │    └── filters [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
+ │         └── phone.id = phone_register.person_id [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
  └── projections [outer=(1-6,9)]
       └── variable: phone.since [type=timestamp, outer=(9)]
 
@@ -1294,8 +1278,7 @@ project
  ├── fd: (1)-->(2-6)
  └── inner-join-apply
       ├── columns: person.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null) phone.id:7(int!null) phone.person_id:10(int) phone.order_id:11(int!null) max:17(int!null)
-      ├── key: (1,7)
-      ├── fd: (1)-->(2-6), (7)-->(10,11,17), (11)==(17), (17)==(11)
+      ├── fd: (1)-->(2-6)
       ├── scan person
       │    ├── columns: person.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null)
       │    ├── key: (1)
@@ -1841,12 +1824,15 @@ where
 ----
 project
  ├── columns: newspape1_23_0_:1(int!null) news_new2_23_0_:2(int!null) formula140_0_:9(string) news_id1_21_1_:3(int!null) detail2_21_1_:4(string) title3_21_1_:5(string)
- ├── key: (3)
- ├── fd: ()-->(1), (3)-->(4,5,9), (2)==(3), (3)==(2)
- ├── left-join-apply
- │    ├── columns: newspaper_id:1(int!null) news_news_id:2(int!null) news.news_id:3(int!null) news.detail:4(string) news.title:5(string) news.title:8(string)
- │    ├── key: (3)
- │    ├── fd: ()-->(1), (3)-->(4,5,8), (2)==(3), (3)==(2)
+ ├── fd: ()-->(1), (3)-->(4,5), (2)==(3), (3)==(2)
+ ├── right-join
+ │    ├── columns: newspaper_id:1(int!null) news_news_id:2(int!null) news.news_id:3(int!null) news.detail:4(string) news.title:5(string) news.news_id:6(int) news.title:8(string)
+ │    ├── key: (3,6)
+ │    ├── fd: ()-->(1), (3)-->(4,5), (2)==(3), (3)==(2), (6)-->(8)
+ │    ├── scan news
+ │    │    ├── columns: news.news_id:6(int!null) news.title:8(string)
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(8)
  │    ├── inner-join (merge)
  │    │    ├── columns: newspaper_id:1(int!null) news_news_id:2(int!null) news.news_id:3(int!null) news.detail:4(string) news.title:5(string)
  │    │    ├── key: (3)
@@ -1871,27 +1857,8 @@ project
  │    │         ├── right ordering: +2
  │    │         └── filters [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]), fd=(2)==(3), (3)==(2)]
  │    │              └── newspaper_news.news_news_id = news.news_id [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ])]
- │    ├── max1-row
- │    │    ├── columns: news.title:8(string)
- │    │    ├── outer: (2)
- │    │    ├── cardinality: [0 - 1]
- │    │    ├── key: ()
- │    │    ├── fd: ()-->(8)
- │    │    └── project
- │    │         ├── columns: news.title:8(string)
- │    │         ├── outer: (2)
- │    │         └── select
- │    │              ├── columns: news.news_id:6(int!null) news.title:8(string)
- │    │              ├── outer: (2)
- │    │              ├── key: (6)
- │    │              ├── fd: (6)-->(8)
- │    │              ├── scan news
- │    │              │    ├── columns: news.news_id:6(int!null) news.title:8(string)
- │    │              │    ├── key: (6)
- │    │              │    └── fd: (6)-->(8)
- │    │              └── filters [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
- │    │                   └── news.news_id = newspaper_news.news_news_id [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
- │    └── true [type=bool]
+ │    └── filters [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+ │         └── news.news_id = newspaper_news.news_news_id [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
  └── projections [outer=(1-5,8)]
       └── variable: news.title [type=string, outer=(8)]
 
@@ -1968,107 +1935,65 @@ WHERE ref0_.generationuser_id = 1;
 ----
 project
  ├── columns: generati1_2_0_:1(int!null) ref_id2_2_0_:2(int!null) formula131_0_:11(string) formula132_0_:16(string) formula133_0_:21(string) id1_0_1_:3(int!null) age2_0_1_:4(string) culture3_0_1_:5(string) descript4_0_1_:6(string)
- ├── key: (3)
- ├── fd: ()-->(1), (3)-->(4-6,11,16,21), (2)==(3), (3)==(2)
- ├── left-join-apply
- │    ├── columns: generationuser_id:1(int!null) ref_id:2(int!null) generationgroup.id:3(int!null) generationgroup.age:4(string) generationgroup.culture:5(string) generationgroup.description:6(string) generationgroup.age:8(string) generationgroup.culture:14(string) generationgroup.description:20(string)
- │    ├── key: (3)
- │    ├── fd: ()-->(1), (3)-->(4-6,8,14,20), (2)==(3), (3)==(2)
- │    ├── left-join-apply
+ ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2)
+ ├── left-join
+ │    ├── columns: generationuser_id:1(int!null) ref_id:2(int!null) generationgroup.id:3(int!null) generationgroup.age:4(string) generationgroup.culture:5(string) generationgroup.description:6(string) generationgroup.age:8(string) generationgroup.culture:14(string) generationgroup.id:17(int) generationgroup.description:20(string)
+ │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2), (17)-->(20)
+ │    ├── project
  │    │    ├── columns: generationuser_id:1(int!null) ref_id:2(int!null) generationgroup.id:3(int!null) generationgroup.age:4(string) generationgroup.culture:5(string) generationgroup.description:6(string) generationgroup.age:8(string) generationgroup.culture:14(string)
- │    │    ├── key: (3)
- │    │    ├── fd: ()-->(1), (3)-->(4-6,8,14), (2)==(3), (3)==(2)
- │    │    ├── left-join-apply
- │    │    │    ├── columns: generationuser_id:1(int!null) ref_id:2(int!null) generationgroup.id:3(int!null) generationgroup.age:4(string) generationgroup.culture:5(string) generationgroup.description:6(string) generationgroup.age:8(string)
- │    │    │    ├── key: (3)
- │    │    │    ├── fd: ()-->(1), (3)-->(4-6,8), (2)==(3), (3)==(2)
- │    │    │    ├── inner-join (merge)
- │    │    │    │    ├── columns: generationuser_id:1(int!null) ref_id:2(int!null) generationgroup.id:3(int!null) generationgroup.age:4(string) generationgroup.culture:5(string) generationgroup.description:6(string)
- │    │    │    │    ├── key: (3)
- │    │    │    │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2)
- │    │    │    │    ├── scan generationgroup
- │    │    │    │    │    ├── columns: generationgroup.id:3(int!null) generationgroup.age:4(string) generationgroup.culture:5(string) generationgroup.description:6(string)
- │    │    │    │    │    ├── key: (3)
- │    │    │    │    │    ├── fd: (3)-->(4-6)
- │    │    │    │    │    └── ordering: +3
- │    │    │    │    ├── sort
- │    │    │    │    │    ├── columns: generationuser_id:1(int!null) ref_id:2(int!null)
- │    │    │    │    │    ├── key: (2)
- │    │    │    │    │    ├── fd: ()-->(1)
- │    │    │    │    │    ├── ordering: +2
- │    │    │    │    │    └── scan generationuser_generationgroup
- │    │    │    │    │         ├── columns: generationuser_id:1(int!null) ref_id:2(int!null)
- │    │    │    │    │         ├── constraint: /1/2: [/1 - /1]
- │    │    │    │    │         ├── key: (2)
- │    │    │    │    │         └── fd: ()-->(1)
- │    │    │    │    └── merge-on
- │    │    │    │         ├── left ordering: +3
- │    │    │    │         ├── right ordering: +2
- │    │    │    │         └── filters [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]), fd=(2)==(3), (3)==(2)]
- │    │    │    │              └── generationuser_generationgroup.ref_id = generationgroup.id [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ])]
- │    │    │    ├── max1-row
- │    │    │    │    ├── columns: generationgroup.age:8(string)
- │    │    │    │    ├── outer: (2)
- │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    ├── key: ()
- │    │    │    │    ├── fd: ()-->(8)
- │    │    │    │    └── project
- │    │    │    │         ├── columns: generationgroup.age:8(string)
- │    │    │    │         ├── outer: (2)
- │    │    │    │         └── select
- │    │    │    │              ├── columns: generationgroup.id:7(int!null) generationgroup.age:8(string)
- │    │    │    │              ├── outer: (2)
- │    │    │    │              ├── key: (7)
- │    │    │    │              ├── fd: (7)-->(8)
- │    │    │    │              ├── scan generationgroup
- │    │    │    │              │    ├── columns: generationgroup.id:7(int!null) generationgroup.age:8(string)
- │    │    │    │              │    ├── key: (7)
- │    │    │    │              │    └── fd: (7)-->(8)
- │    │    │    │              └── filters [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
- │    │    │    │                   └── generationgroup.id = generationuser_generationgroup.ref_id [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
- │    │    │    └── true [type=bool]
- │    │    ├── max1-row
- │    │    │    ├── columns: generationgroup.culture:14(string)
- │    │    │    ├── outer: (2)
- │    │    │    ├── cardinality: [0 - 1]
- │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(14)
- │    │    │    └── project
- │    │    │         ├── columns: generationgroup.culture:14(string)
- │    │    │         ├── outer: (2)
- │    │    │         └── select
- │    │    │              ├── columns: generationgroup.id:12(int!null) generationgroup.culture:14(string)
- │    │    │              ├── outer: (2)
- │    │    │              ├── key: (12)
- │    │    │              ├── fd: (12)-->(14)
- │    │    │              ├── scan generationgroup
- │    │    │              │    ├── columns: generationgroup.id:12(int!null) generationgroup.culture:14(string)
- │    │    │              │    ├── key: (12)
- │    │    │              │    └── fd: (12)-->(14)
- │    │    │              └── filters [type=bool, outer=(2,12), constraints=(/2: (/NULL - ]; /12: (/NULL - ]), fd=(2)==(12), (12)==(2)]
- │    │    │                   └── generationgroup.id = generationuser_generationgroup.ref_id [type=bool, outer=(2,12), constraints=(/2: (/NULL - ]; /12: (/NULL - ])]
- │    │    └── true [type=bool]
- │    ├── max1-row
- │    │    ├── columns: generationgroup.description:20(string)
- │    │    ├── outer: (2)
- │    │    ├── cardinality: [0 - 1]
- │    │    ├── key: ()
- │    │    ├── fd: ()-->(20)
- │    │    └── project
- │    │         ├── columns: generationgroup.description:20(string)
- │    │         ├── outer: (2)
- │    │         └── select
- │    │              ├── columns: generationgroup.id:17(int!null) generationgroup.description:20(string)
- │    │              ├── outer: (2)
- │    │              ├── key: (17)
- │    │              ├── fd: (17)-->(20)
- │    │              ├── scan generationgroup
- │    │              │    ├── columns: generationgroup.id:17(int!null) generationgroup.description:20(string)
- │    │              │    ├── key: (17)
- │    │              │    └── fd: (17)-->(20)
- │    │              └── filters [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ]), fd=(2)==(17), (17)==(2)]
- │    │                   └── generationgroup.id = generationuser_generationgroup.ref_id [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ])]
- │    └── true [type=bool]
+ │    │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2)
+ │    │    └── left-join
+ │    │         ├── columns: generationuser_id:1(int!null) ref_id:2(int!null) generationgroup.id:3(int!null) generationgroup.age:4(string) generationgroup.culture:5(string) generationgroup.description:6(string) generationgroup.age:8(string) generationgroup.id:12(int) generationgroup.culture:14(string)
+ │    │         ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2), (12)-->(14)
+ │    │         ├── project
+ │    │         │    ├── columns: generationuser_id:1(int!null) ref_id:2(int!null) generationgroup.id:3(int!null) generationgroup.age:4(string) generationgroup.culture:5(string) generationgroup.description:6(string) generationgroup.age:8(string)
+ │    │         │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2)
+ │    │         │    └── right-join
+ │    │         │         ├── columns: generationuser_id:1(int!null) ref_id:2(int!null) generationgroup.id:3(int!null) generationgroup.age:4(string) generationgroup.culture:5(string) generationgroup.description:6(string) generationgroup.id:7(int) generationgroup.age:8(string)
+ │    │         │         ├── key: (3,7)
+ │    │         │         ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2), (7)-->(8)
+ │    │         │         ├── scan generationgroup
+ │    │         │         │    ├── columns: generationgroup.id:7(int!null) generationgroup.age:8(string)
+ │    │         │         │    ├── key: (7)
+ │    │         │         │    └── fd: (7)-->(8)
+ │    │         │         ├── inner-join (merge)
+ │    │         │         │    ├── columns: generationuser_id:1(int!null) ref_id:2(int!null) generationgroup.id:3(int!null) generationgroup.age:4(string) generationgroup.culture:5(string) generationgroup.description:6(string)
+ │    │         │         │    ├── key: (3)
+ │    │         │         │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2)
+ │    │         │         │    ├── scan generationgroup
+ │    │         │         │    │    ├── columns: generationgroup.id:3(int!null) generationgroup.age:4(string) generationgroup.culture:5(string) generationgroup.description:6(string)
+ │    │         │         │    │    ├── key: (3)
+ │    │         │         │    │    ├── fd: (3)-->(4-6)
+ │    │         │         │    │    └── ordering: +3
+ │    │         │         │    ├── sort
+ │    │         │         │    │    ├── columns: generationuser_id:1(int!null) ref_id:2(int!null)
+ │    │         │         │    │    ├── key: (2)
+ │    │         │         │    │    ├── fd: ()-->(1)
+ │    │         │         │    │    ├── ordering: +2
+ │    │         │         │    │    └── scan generationuser_generationgroup
+ │    │         │         │    │         ├── columns: generationuser_id:1(int!null) ref_id:2(int!null)
+ │    │         │         │    │         ├── constraint: /1/2: [/1 - /1]
+ │    │         │         │    │         ├── key: (2)
+ │    │         │         │    │         └── fd: ()-->(1)
+ │    │         │         │    └── merge-on
+ │    │         │         │         ├── left ordering: +3
+ │    │         │         │         ├── right ordering: +2
+ │    │         │         │         └── filters [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]), fd=(2)==(3), (3)==(2)]
+ │    │         │         │              └── generationuser_generationgroup.ref_id = generationgroup.id [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ])]
+ │    │         │         └── filters [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
+ │    │         │              └── generationgroup.id = generationuser_generationgroup.ref_id [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
+ │    │         ├── scan generationgroup
+ │    │         │    ├── columns: generationgroup.id:12(int!null) generationgroup.culture:14(string)
+ │    │         │    ├── key: (12)
+ │    │         │    └── fd: (12)-->(14)
+ │    │         └── filters [type=bool, outer=(2,12), constraints=(/2: (/NULL - ]; /12: (/NULL - ]), fd=(2)==(12), (12)==(2)]
+ │    │              └── generationgroup.id = generationuser_generationgroup.ref_id [type=bool, outer=(2,12), constraints=(/2: (/NULL - ]; /12: (/NULL - ])]
+ │    ├── scan generationgroup
+ │    │    ├── columns: generationgroup.id:17(int!null) generationgroup.description:20(string)
+ │    │    ├── key: (17)
+ │    │    └── fd: (17)-->(20)
+ │    └── filters [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ]), fd=(2)==(17), (17)==(2)]
+ │         └── generationgroup.id = generationuser_generationgroup.ref_id [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ])]
  └── projections [outer=(1-6,8,14,20)]
       ├── variable: generationgroup.age [type=string, outer=(8)]
       ├── variable: generationgroup.culture [type=string, outer=(14)]

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -351,6 +351,7 @@ project
  │    │    │         │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index
  │    │    │         │    │    │    │    │    │    │    ├── columns: pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null)
  │    │    │         │    │    │    │    │    │    │    ├── constraint: /29: [/'public' - /'public']
+ │    │    │         │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │         │    │    │    │    │    │    │    ├── key: ()
  │    │    │         │    │    │    │    │    │    │    └── fd: ()-->(28,29)
  │    │    │         │    │    │    │    │    │    └── filters [type=bool, outer=(3,28), constraints=(/3: (/NULL - ]; /28: (/NULL - ]), fd=(3)==(28), (28)==(3)]

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -351,6 +351,7 @@ project
  │    │    │         │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index
  │    │    │         │    │    │    │    │    │    │    ├── columns: pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null)
  │    │    │         │    │    │    │    │    │    │    ├── constraint: /29: [/'public' - /'public']
+ │    │    │         │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │         │    │    │    │    │    │    │    ├── key: ()
  │    │    │         │    │    │    │    │    │    │    └── fd: ()-->(28,29)
  │    │    │         │    │    │    │    │    │    └── filters [type=bool, outer=(3,28), constraints=(/3: (/NULL - ]; /28: (/NULL - ]), fd=(3)==(28), (28)==(3)]

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -544,6 +544,7 @@ SELECT w_tax FROM warehouse WHERE w_id = 10
 ----
 project
  ├── columns: w_tax:8(decimal)
+ ├── cardinality: [0 - 1]
  ├── stats: [rows=1]
  ├── cost: 1.11
  ├── key: ()
@@ -552,6 +553,7 @@ project
  └── scan warehouse
       ├── columns: warehouse.w_id:1(int!null) warehouse.w_tax:8(decimal)
       ├── constraint: /1: [/10 - /10]
+      ├── cardinality: [0 - 1]
       ├── stats: [rows=1, distinct(1)=1]
       ├── cost: 1.11
       ├── key: ()
@@ -566,6 +568,7 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 ----
 project
  ├── columns: c_discount:16(decimal) c_last:6(string) c_credit:14(string)
+ ├── cardinality: [0 - 1]
  ├── stats: [rows=6.80272109e-07]
  ├── cost: 8.63945578e-07
  ├── key: ()
@@ -574,6 +577,7 @@ project
  └── scan customer
       ├── columns: customer.c_id:1(int!null) customer.c_d_id:2(int!null) customer.c_w_id:3(int!null) customer.c_last:6(string) customer.c_credit:14(string) customer.c_discount:16(decimal)
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
+      ├── cardinality: [0 - 1]
       ├── stats: [rows=6.80272109e-07, distinct(1)=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07]
       ├── cost: 8.63945578e-07
       ├── key: ()
@@ -674,6 +678,7 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 ----
 project
  ├── columns: c_balance:17(decimal) c_first:4(string) c_middle:5(string) c_last:6(string)
+ ├── cardinality: [0 - 1]
  ├── stats: [rows=6.80272109e-07]
  ├── cost: 8.70748299e-07
  ├── key: ()
@@ -682,6 +687,7 @@ project
  └── scan customer
       ├── columns: customer.c_id:1(int!null) customer.c_d_id:2(int!null) customer.c_w_id:3(int!null) customer.c_first:4(string) customer.c_middle:5(string) customer.c_last:6(string) customer.c_balance:17(decimal)
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
+      ├── cardinality: [0 - 1]
       ├── stats: [rows=6.80272109e-07, distinct(1)=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07]
       ├── cost: 8.70748299e-07
       ├── key: ()
@@ -896,6 +902,7 @@ WHERE d_w_id = 10 AND d_id = 100
 ----
 project
  ├── columns: d_next_o_id:11(int)
+ ├── cardinality: [0 - 1]
  ├── stats: [rows=0.142857143]
  ├── cost: 0.162857143
  ├── key: ()
@@ -904,6 +911,7 @@ project
  └── scan district
       ├── columns: district.d_id:1(int!null) district.d_w_id:2(int!null) district.d_next_o_id:11(int)
       ├── constraint: /2/1: [/10/100 - /10/100]
+      ├── cardinality: [0 - 1]
       ├── stats: [rows=0.142857143, distinct(1)=0.142857143, distinct(2)=0.142857143]
       ├── cost: 0.162857143
       ├── key: ()

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -372,8 +372,7 @@ project
       │         │    │    ├── fd: (1)-->(3)
       │         │    │    └── inner-join-apply
       │         │    │         ├── columns: p_partkey:1(int!null) p_mfgr:3(string) p_type:5(string) p_size:6(int!null) supplier.s_suppkey:10(int!null) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_nationkey:13(int!null) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string) partsupp.ps_partkey:17(int!null) partsupp.ps_suppkey:18(int!null) partsupp.ps_supplycost:20(float!null) min:48(float!null)
-      │         │    │         ├── key: (1,10,17,18)
-      │         │    │         ├── fd: ()-->(6), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20,48), (20)==(48), (48)==(20)
+      │         │    │         ├── fd: ()-->(6), (1)-->(3,5), (10)-->(11-16)
       │         │    │         ├── inner-join
       │         │    │         │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string) p_type:5(string) p_size:6(int!null) supplier.s_suppkey:10(int!null) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_nationkey:13(int!null) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string)
       │         │    │         │    ├── key: (1,10)

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -143,7 +143,7 @@ TABLE xyz
       └── x int not null
 
 opt
-SELECT min(y) FROM xyz where x=7
+SELECT min(y) FROM xyz where z=7
 ----
 group-by
  ├── columns: min:4(int)
@@ -151,24 +151,24 @@ group-by
  ├── key: ()
  ├── fd: ()-->(4)
  ├── limit
- │    ├── columns: x:1(int!null) y:2(int!null)
+ │    ├── columns: y:2(int!null) z:3(float!null)
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
- │    ├── fd: ()-->(1,2)
- │    ├── scan xyz@xy
- │    │    ├── columns: x:1(int!null) y:2(int!null)
- │    │    ├── constraint: /1/2: (/7/NULL - /7]
- │    │    ├── key: ()
- │    │    └── fd: ()-->(1,2)
+ │    ├── fd: ()-->(2,3)
+ │    ├── scan xyz@zyx
+ │    │    ├── columns: y:2(int!null) z:3(float!null)
+ │    │    ├── constraint: /3/2/1: (/7.0/NULL - /7.0]
+ │    │    ├── fd: ()-->(3)
+ │    │    └── ordering: +2 opt(3)
  │    └── const: 1 [type=int]
  └── aggregations [outer=(2)]
       └── any-not-null [type=int, outer=(2)]
            └── variable: xyz.y [type=int, outer=(2)]
 
 # ReplaceMaxWithLimit has the same behavior with max() as
-# the previous min() query because x is a unique key
+# the previous min() query because z is the prefix of a unique key
 opt
-SELECT max(y) FROM xyz where x=7
+SELECT max(y) FROM xyz where z=7
 ----
 group-by
  ├── columns: max:4(int)
@@ -176,15 +176,18 @@ group-by
  ├── key: ()
  ├── fd: ()-->(4)
  ├── limit
- │    ├── columns: x:1(int!null) y:2(int!null)
+ │    ├── columns: y:2(int!null) z:3(float!null)
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
- │    ├── fd: ()-->(1,2)
- │    ├── scan xyz@xy
- │    │    ├── columns: x:1(int!null) y:2(int!null)
- │    │    ├── constraint: /1/2: (/7/NULL - /7]
- │    │    ├── key: ()
- │    │    └── fd: ()-->(1,2)
+ │    ├── fd: ()-->(2,3)
+ │    ├── sort
+ │    │    ├── columns: y:2(int!null) z:3(float!null)
+ │    │    ├── fd: ()-->(3)
+ │    │    ├── ordering: -2 opt(3)
+ │    │    └── scan xyz@zyx
+ │    │         ├── columns: y:2(int!null) z:3(float!null)
+ │    │         ├── constraint: /3/2/1: (/7.0/NULL - /7.0]
+ │    │         └── fd: ()-->(3)
  │    └── const: 1 [type=int]
  └── aggregations [outer=(2)]
       └── any-not-null [type=int, outer=(2)]

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -56,6 +56,7 @@ SELECT k FROM a WHERE k = 1
 scan a
  ├── columns: k:1(int!null)
  ├── constraint: /1: [/1 - /1]
+ ├── cardinality: [0 - 1]
  ├── key: ()
  └── fd: ()-->(1)
 
@@ -115,11 +116,13 @@ SELECT k FROM a WHERE u = 1 AND k = 5
 ----
 project
  ├── columns: k:1(int!null)
+ ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
  └── scan a@u
       ├── columns: k:1(int!null) u:2(int!null)
       ├── constraint: /2/1: [/1/5 - /1/5]
+      ├── cardinality: [0 - 1]
       ├── key: ()
       └── fd: ()-->(1,2)
 
@@ -215,15 +218,18 @@ SELECT k FROM a WHERE u = 1 AND v = 5
 ----
 project
  ├── columns: k:1(int!null)
+ ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
  └── select
       ├── columns: k:1(int!null) u:2(int!null) v:3(int!null)
+      ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(1-3)
       ├── scan a@v
       │    ├── columns: k:1(int!null) u:2(int) v:3(int!null)
       │    ├── constraint: /3: [/5 - /5]
+      │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(1-3)
       └── filters [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]


### PR DESCRIPTION
This PR consists of two commits that allow additional decorrelation:

1. Infer cardinality <= 1 from functional dependencies
2. Treat outer column refs as constants

Together they allow queries like this to be decorrelated:

SELECT * FROM xy WHERE (SELECT z FROM xz WHERE xz.x=xy.x) > 1

The Hibernate test suite has examples of this pattern.