### PR TITLE
sql: use pretty printer for SHOW SYNTAX

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -288,3 +288,10 @@ code      42601
 file      sql/show_syntax.go
 function  runShowSyntax
 detail    source SQL: foo ^
+
+query T
+SELECT text FROM [SHOW SYNTAX 'select a, b from c as something inner join d on e=f and g=h*2+1 union all select a or b and c and d or e']
+----
+SELECT a, b
+FROM c AS something INNER JOIN d ON e = f AND g = h * 2 + 1
+UNION ALL SELECT a OR b AND c AND d OR e

--- a/pkg/sql/show_syntax.go
+++ b/pkg/sql/show_syntax.go
@@ -126,7 +126,7 @@ func runShowSyntax(
 		}
 	} else {
 		for _, stmt := range stmts {
-			if err := report(ctx, "sql", tree.AsStringWithFlags(stmt, tree.FmtParsable)); err != nil {
+			if err := report(ctx, "sql", tree.Pretty(stmt)); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Release note (sql change): use a width-aware pretty printer for SHOW
SYNTAX.