### PR TITLE
cli: add sqlfmt subcommand

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -163,6 +163,7 @@ func init() {
 		genCmd,
 		versionCmd,
 		debugCmd,
+		sqlfmtCmd,
 	)
 }
 

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1796,6 +1796,7 @@ Available Commands:
   gen         generate auxiliary files
   version     output version information
   debug       debugging commands
+  sqlfmt      format SQL statements
   help        Help about any command
 
 Flags:
@@ -2385,4 +2386,45 @@ func Example_pretty_print_numerical_strings() {
 	// | aaaaa | non-numerical string      |
 	// +-------+---------------------------+
 	// (4 rows)
+}
+
+func Example_sqlfmt() {
+	c := newCLITest(cliTestParams{noServer: true})
+	defer c.cleanup()
+
+	c.RunWithArgs([]string{"sqlfmt", "-e", ";"})
+	c.RunWithArgs([]string{"sqlfmt", "-e", "delete from t"})
+	c.RunWithArgs([]string{"sqlfmt", "-e", "delete from t", "-e", "update t set a = 1"})
+	c.RunWithArgs([]string{"sqlfmt", "--print-width=10", "-e", "select 1,2,3 from a,b,c;;;select 4"})
+	c.RunWithArgs([]string{"sqlfmt", "--print-width=10", "--tab-width=2", "--use-spaces", "-e", "select 1,2,3 from a,b,c;;;select 4"})
+	c.RunWithArgs([]string{"sqlfmt", "-e", "select (1+2)+3"})
+	c.RunWithArgs([]string{"sqlfmt", "--no-simplify", "-e", "select (1+2)+3"})
+
+	// Output:
+	// sqlfmt -e ;
+	// sqlfmt -e delete from t
+	// DELETE FROM t
+	// sqlfmt -e delete from t -e update t set a = 1
+	// DELETE FROM t;
+	// UPDATE t SET a = 1;
+	// sqlfmt --print-width=10 -e select 1,2,3 from a,b,c;;;select 4
+	// SELECT
+	// 	1,
+	// 	2,
+	// 	3
+	// FROM
+	// 	a,
+	// 	b,
+	// 	c;
+	// SELECT 4;
+	// sqlfmt --print-width=10 --tab-width=2 --use-spaces -e select 1,2,3 from a,b,c;;;select 4
+	// SELECT
+	//   1, 2, 3
+	// FROM
+	//   a, b, c;
+	// SELECT 4;
+	// sqlfmt -e select (1+2)+3
+	// SELECT 1 + 2 + 3
+	// sqlfmt --no-simplify -e select (1+2)+3
+	// SELECT (1 + 2) + 3
 }

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -720,4 +720,24 @@ in the history of the cluster.`,
 When no node ID is specified, also lists all nodes that have been decommissioned
 in the history of the cluster.`,
 	}
+
+	SQLFmtLen = FlagInfo{
+		Name:        "print-width",
+		Description: `The line length where sqlfmt will try to wrap.`,
+	}
+
+	SQLFmtSpaces = FlagInfo{
+		Name:        "use-spaces",
+		Description: `Indent with spaces instead of tabs.`,
+	}
+
+	SQLFmtTabWidth = FlagInfo{
+		Name:        "tab-width",
+		Description: `Number of spaces per indentation level.`,
+	}
+
+	SQLFmtNoSimplify = FlagInfo{
+		Name:        "no-simplify",
+		Description: `Don't simplify output.`,
+	}
 )

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	isatty "github.com/mattn/go-isatty"
@@ -114,6 +115,12 @@ func initCLIDefaults() {
 	nodeCtx.statusShowStats = false
 	nodeCtx.statusShowAll = false
 	nodeCtx.statusShowDecommission = false
+
+	sqlfmtCtx.len = tree.DefaultPrettyWidth
+	sqlfmtCtx.useSpaces = false
+	sqlfmtCtx.tabWidth = 4
+	sqlfmtCtx.noSimplify = false
+	sqlfmtCtx.execStmts = nil
 
 	initPreFlagsDefaults()
 }
@@ -232,4 +239,14 @@ var nodeCtx struct {
 	statusShowStats        bool
 	statusShowDecommission bool
 	statusShowAll          bool
+}
+
+// sqlfmtCtx captures the command-line parameters of the `sqlfmt` command.
+// Defaults set by InitCLIDefaults() above.
+var sqlfmtCtx struct {
+	len        int
+	useSpaces  bool
+	tabWidth   int
+	noSimplify bool
+	execStmts  statementsValue
 }

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
@@ -365,6 +366,13 @@ func init() {
 		f := cmd.Flags()
 		VarFlag(f, &cliCtx.tableDisplayFormat, cliflags.TableDisplayFormat)
 	}
+
+	// sqlfmt command.
+	VarFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.execStmts, cliflags.Execute)
+	IntFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.len, cliflags.SQLFmtLen, tree.DefaultPrettyWidth)
+	BoolFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.useSpaces, cliflags.SQLFmtSpaces, false)
+	IntFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.tabWidth, cliflags.SQLFmtTabWidth, 4)
+	BoolFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.noSimplify, cliflags.SQLFmtNoSimplify, true)
 
 	// Debug commands.
 	{

--- a/pkg/cli/sqlfmt.go
+++ b/pkg/cli/sqlfmt.go
@@ -1,0 +1,79 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// TODO(mjibson): This subcommand has more flags than I would prefer. My
+// goal is to have it have just -e and nothing else. gofmt initially started
+// with tabs/spaces and width specifiers but later regretted that decision
+// and removed them. I would like to get to the point where we achieve SQL
+// formatting nirvana and we make this an opinionated formatter with few or
+// zero options, hopefully before 2.1.
+
+var sqlfmtCmd = &cobra.Command{
+	Use:   "sqlfmt",
+	Short: "format SQL statements",
+	Long:  "Formats SQL statements from stdin to line length n.",
+	RunE:  runSQLFmt,
+}
+
+func runSQLFmt(cmd *cobra.Command, args []string) error {
+	if sqlfmtCtx.len < 1 {
+		return errors.Errorf("line length must be > 0: %d", sqlfmtCtx.len)
+	}
+	if sqlfmtCtx.tabWidth < 1 {
+		return errors.Errorf("tab width must be > 0: %d", sqlfmtCtx.tabWidth)
+	}
+
+	var sl tree.StatementList
+	if len(sqlfmtCtx.execStmts) != 0 {
+		for _, exec := range sqlfmtCtx.execStmts {
+			stmts, err := parser.Parse(exec)
+			if err != nil {
+				return err
+			}
+			sl = append(sl, stmts...)
+		}
+	} else {
+		in, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+		sl, err = parser.Parse(string(in))
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, s := range sl {
+		fmt.Print(tree.PrettyWithOpts(s, sqlfmtCtx.len, !sqlfmtCtx.useSpaces, sqlfmtCtx.tabWidth, !sqlfmtCtx.noSimplify))
+		if len(sl) > 1 {
+			fmt.Print(";")
+		}
+		fmt.Println()
+	}
+	return nil
+}


### PR DESCRIPTION
Add a sqlfmt command to pretty print SQL with various options supported by
our pretty printer. Current defaults (use tabs, tab width=4) are subject
to debate in other PRs, as we are just using the existing defaults here.

This subcommand has more flags than I would prefer. My goal is to have it
have just -e and nothing else. gofmt initially started with tabs/spaces
and width specifiers but later regretted that decision and removed them. I
would like to get to the point where we achieve SQL formatting nirvana
and we make this an opinionated formatter with few or zero options,
hopefully before 2.1.

Release note (cli change): add sqlfmt subcommand for formatting SQL.