### PR TITLE
pretty: make the code clearer and faster

### DIFF
--- a/pkg/util/pretty/document.go
+++ b/pkg/util/pretty/document.go
@@ -42,9 +42,6 @@ import (
 // referenced paper. This is the abstract representation constructed
 // by the pretty-printing code.
 type Doc interface {
-	// All Docs can uniquely convert themselves into a string so they can be
-	// memoized during better calculation.
-	String() string
 	isDoc()
 }
 
@@ -54,13 +51,6 @@ func (nilDoc) isDoc() {}
 func (concat) isDoc() {}
 func (nest) isDoc()   {}
 func (union) isDoc()  {}
-
-func (d text) String() string   { return fmt.Sprintf("(TEXT %q)", string(d)) }
-func (line) String() string     { return "LINE" }
-func (nilDoc) String() string   { return "NIL" }
-func (d concat) String() string { return fmt.Sprintf("(%s :<> %s)", d.a, d.b) }
-func (d nest) String() string   { return fmt.Sprintf("(NEST %d %s)", d.n, d.d) }
-func (d union) String() string  { return fmt.Sprintf("(%s :<|> %s)", d.x, d.y) }
 
 //
 // Implementations of Doc ("DOC" in paper).

--- a/pkg/util/pretty/document.go
+++ b/pkg/util/pretty/document.go
@@ -28,13 +28,19 @@
 // side. The paper then describes various performance improvements that reduce
 // the search space of the best function such that it can complete in O(n)
 // instead of O(n^2) time, where n is the number of nodes.
+//
+// For example code with SQL to experiment further, refer to
+// https://github.com/knz/prettier/
+//
 package pretty
 
 import (
 	"fmt"
 )
 
-// Doc represents a document as described by the referenced paper.
+// Doc represents a document as described by the type "DOC" in the
+// referenced paper. This is the abstract representation constructed
+// by the pretty-printing code.
 type Doc interface {
 	// All Docs can uniquely convert themselves into a string so they can be
 	// memoized during better calculation.
@@ -48,81 +54,77 @@ func (nilDoc) isDoc() {}
 func (concat) isDoc() {}
 func (nest) isDoc()   {}
 func (union) isDoc()  {}
-func (textX) isDoc()  {}
-func (lineX) isDoc()  {}
 
-func (d text) String() string   { return fmt.Sprintf("(%q)", string(d)) }
+func (d text) String() string   { return fmt.Sprintf("(TEXT %q)", string(d)) }
 func (line) String() string     { return "LINE" }
 func (nilDoc) String() string   { return "NIL" }
 func (d concat) String() string { return fmt.Sprintf("(%s :<> %s)", d.a, d.b) }
 func (d nest) String() string   { return fmt.Sprintf("(NEST %d %s)", d.n, d.d) }
 func (d union) String() string  { return fmt.Sprintf("(%s :<|> %s)", d.x, d.y) }
-func (d textX) String() string  { return fmt.Sprintf("(%q TEXTX %s)", d.s, d.d) }
-func (d lineX) String() string  { return fmt.Sprintf("(%q LINEX %s)", d.s, d.d) }
 
+//
+// Implementations of Doc ("DOC" in paper).
+//
+
+// nilDoc represents NIL :: DOC -- the empty doc.
 type nilDoc struct{}
 
-// Nil is the empty Doc.
+// Nil is the NIL constructor.
 var Nil nilDoc
 
+// text represents (TEXT s) :: DOC -- a simple text string.
 type text string
 
-// Text creates a string Doc.
+// Text is the TEXT constructor.
 func Text(s string) Doc {
 	return text(s)
 }
 
+// line represents LINE :: DOC -- a "soft line" that can be flattened to a space.
 type line struct{}
 
-// Line is either a newline or a space if flattened onto a single line.
+// Line is the LINE constructor.
 var Line line
 
+// concat represents (DOC <> DOC) :: DOC -- the concatenation of two docs.
 type concat struct {
 	a, b Doc
 }
 
-// fnNotNil runs returns fn(a, b). nil (the Go value) is converted to Nil (the
-// Doc). If either Doc is Nil, the other Doc is returned without invoking fn.
-func concatFn(a, b Doc, fn func(Doc, Doc) Doc) Doc {
-	if a == nil {
-		a = Nil
-	}
-	if b == nil {
-		b = Nil
-	}
-	if a == Nil {
-		return b
-	}
-	if b == Nil {
-		return a
-	}
-	return fn(a, b)
-}
-
-// Concat concatenates two Docs.
+// Concat is the <> constructor.
+// This uses simplifyNil to avoid actually inserting NIL docs
+// in the abstract tree.
 func Concat(a, b Doc) Doc {
-	return concatFn(a, b, func(a, b Doc) Doc {
-		return concat{a, b}
-	})
+	return simplifyNil(a, b, func(a, b Doc) Doc { return concat{a, b} })
 }
 
-// Fill concatenates a list of docs with spaces if possible,
-// otherwise with newlines.
-// See linked paper pp 14-15.
-// func Fill(d ...Doc) Doc {
-// 	switch len(d) {
-// 	case 0:
-// 		return Nil
-// 	case 1:
-// 		return d[0]
-// 	default:
-// 		rest := Fill(d[1:]...)
-// 		return union{
-// 			ConcatSpace(flatten(d[0]), rest),
-// 			ConcatLine(d[0], rest),
-// 		}
-// 	}
-// }
+// nest represents (NEST Int DOC) :: DOC -- nesting a doc "under" another.
+// NEST indents d by s at effective length n. len(s) does not have to be
+// n. This allows s to be a tab character and n can be a tab width.
+type nest struct {
+	n int
+	s string
+	d Doc
+}
+
+// Nest is the NEST constructor.
+func Nest(n int, s string, d Doc) Doc {
+	return nest{n, s, d}
+}
+
+// union represents (DOC <|> DOC) :: DOC -- the union of two docs.
+// <|> is really the union of two sets of layouts. x and y must flatten to the
+// same layout. Additionally, no first line of a document in x is shorter
+// than some first line of a document in y; or, equivalently, every first
+// line in x is at least as long as every first line in y.
+//
+// The main use of the union is via the Group operator defined below.
+//
+// We do not provide a public constructor as this type is not
+// exported.
+type union struct {
+	x, y Doc
+}
 
 // Group will format d on one line if possible.
 func Group(d Doc) Doc {
@@ -148,36 +150,4 @@ func flatten(d Doc) Doc {
 	default:
 		panic(fmt.Errorf("unknown type: %T", d))
 	}
-}
-
-type nest struct {
-	n int
-	s string
-	d Doc
-}
-
-// Nest indents d by s at effective length n. len(s) does not have to be
-// n. This allows s to be a tab character and n can be a tab width.
-func Nest(n int, s string, d Doc) Doc {
-	return nest{n, s, d}
-}
-
-// Doc types below are not directly accessible to users.
-
-// union is the union of two sets of layouts. x and y must flatten to the
-// same layout. Additionally, no first line of a document in x is shorter
-// than some first line of a document in y; or, equivalently, every first
-// line in x is at least as long as every first line in y.
-type union struct {
-	x, y Doc
-}
-
-type textX struct {
-	s string
-	d Doc
-}
-
-type lineX struct {
-	s string
-	d Doc
 }

--- a/pkg/util/pretty/pretty.go
+++ b/pkg/util/pretty/pretty.go
@@ -15,7 +15,6 @@
 package pretty
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 )
@@ -28,32 +27,18 @@ import (
 // "Doc" in the referenced paper (not "DOC"). This is the
 // less-abstract representation constructed during "best layout"
 // selection.
-type docBest interface {
-	String() string
-	isDocBest()
+type docBest struct {
+	tag docBestType
+	s   string
+	d   *docBest
 }
 
-func (nilDocB) String() string { return "Nil" }
-func (d textB) String() string { return fmt.Sprintf("(%q `Text` %s)", d.s, d.d) }
-func (d lineB) String() string { return fmt.Sprintf("(%q `Line` %s)", d.s, d.d) }
+type docBestType int
 
-func (nilDocB) isDocBest() {}
-func (textB) isDocBest()   {}
-func (lineB) isDocBest()   {}
-
-type nilDocB struct{}
-
-var nilB nilDocB
-
-type textB struct {
-	s string
-	d docBest
-}
-
-type lineB struct {
-	s string
-	d docBest
-}
+const (
+	textB docBestType = iota
+	lineB
+)
 
 // Pretty returns a pretty-printed string for the Doc d at line length n.
 func Pretty(d Doc, n int) string {
@@ -64,133 +49,191 @@ func Pretty(d Doc, n int) string {
 }
 
 // w is the max line width.
-func best(w int, x Doc) docBest {
+func best(w int, x Doc) *docBest {
 	b := beExec{
-		w:     w,
-		cache: make(map[cacheKey]docBest),
+		w:        w,
+		memoBe:   make(map[beArgs]*docBest),
+		memoiDoc: make(map[iDoc]*iDoc),
 	}
-	return b.be(0, iDoc{0, "", x})
+	return b.be(0, &iDoc{0, "", x, nil})
 }
 
+// iDoc represents the type [(Int,DOC)] in the paper,
+// extended with arbitrary string prefixes (not just int).
+// We'll use linked lists because this makes the
+// recursion more efficient than slices.
 type iDoc struct {
-	i int
-	s string
-	d Doc
-}
-
-func (i iDoc) String() string {
-	return fmt.Sprintf("{%d: %s}", i.i, i.d)
-}
-
-type cacheKey struct {
-	k int
-	s string
+	i    int
+	s    string
+	d    Doc
+	next *iDoc
 }
 
 type beExec struct {
+	// w is the available line width.
 	w int
-	// cache is a memoized cache used during better calculation.
-	cache map[cacheKey]docBest
-	buf   bytes.Buffer
+
+	// memoBe internalizes the results of the be function, so that the
+	// same value is not computed multiple times.
+	memoBe map[beArgs]*docBest
+
+	// memo internalizes iDoc objects to ensure they are unique in memory,
+	// and we can use pointer-pointer comparisons.
+	memoiDoc map[iDoc]*iDoc
+
+	// docAlloc speeds up the allocations of be()'s return values
+	// by (*beExec).newDocBest() defined below.
+	docAlloc []docBest
+
+	// idocAlloc speeds up the allocations by (*beExec).iDoc() defined
+	// below.
+	idocAlloc []iDoc
 }
 
-func (b beExec) be(k int, x ...iDoc) docBest {
-	if len(x) == 0 {
-		return nilB
+func (b *beExec) be(k int, xlist *iDoc) *docBest {
+	// Shortcut: be k [] = Nil
+	if xlist == nil {
+		return nil
 	}
-	d := x[0]
-	z := x[1:]
+
+	// If we've computed this result before, short cut here too.
+	memoKey := beArgs{k: k, d: xlist}
+	if cached, ok := b.memoBe[memoKey]; ok {
+		return cached
+	}
+
+	// General case.
+
+	d := *xlist
+	z := xlist.next
+
+	// Note: we'll need to memoize the result below.
+	var res *docBest
+
 	switch t := d.d.(type) {
 	case nilDoc:
-		return b.be(k, z...)
+		res = b.be(k, z)
 	case concat:
-		return b.be(k, append([]iDoc{{d.i, d.s, t.a}, {d.i, d.s, t.b}}, z...)...)
+		res = b.be(k, b.iDoc(d.i, d.s, t.a, b.iDoc(d.i, d.s, t.b, z)))
 	case nest:
-		x[0] = iDoc{
-			d: t.d,
-			s: d.s + t.s,
-			i: d.i + t.n,
-		}
-		return b.be(k, x...)
+		res = b.be(k, b.iDoc(d.i+t.n, d.s+t.s, t.d, z))
 	case text:
-		return textB{
-			s: string(t),
-			d: b.be(k+len(t), z...),
-		}
+		res = b.newDocBest(docBest{
+			tag: textB,
+			s:   string(t),
+			d:   b.be(k+len(t), z),
+		})
 	case line:
-		return lineB{
-			s: d.s,
-			d: b.be(d.i, z...),
-		}
+		res = b.newDocBest(docBest{
+			tag: lineB,
+			s:   d.s,
+			d:   b.be(d.i, z),
+		})
 	case union:
-		// Use a memoized version of the Doc and check if it's been through this
-		// function before. There may be a faster implementation that converts this
-		// function to an iterative style, but this current implementation is almost
-		// identical to the paper (as this in done automatically in Haskell) and is
-		// fast enough.
-		for _, xd := range x {
-			b.buf.WriteString(xd.String())
-		}
-		key := cacheKey{
-			k: k,
-			s: b.buf.String(),
-		}
-		b.buf.Reset()
-		cached, ok := b.cache[key]
-		if ok {
-			return cached
-		}
-
-		n := append([]iDoc{{d.i, d.s, t.x}}, z...)
-		res := better(b.w, k,
-			b.be(k, n...),
-			func() docBest {
-				n[0].d = t.y
-				return b.be(k, n...)
+		res = better(b.w, k,
+			b.be(k, b.iDoc(d.i, d.s, t.x, z)),
+			// We eta-lift the second argument to avoid eager evaluation.
+			func() *docBest {
+				return b.be(k, b.iDoc(d.i, d.s, t.y, z))
 			},
 		)
-		b.cache[key] = res
-		return res
 	default:
 		panic(fmt.Errorf("unknown type: %T", d.d))
 	}
+
+	// Memoize so we don't compute the same result twice.
+	b.memoBe[memoKey] = res
+
+	return res
 }
 
-func better(w, k int, x docBest, y func() docBest) docBest {
+// newDocBest makes a new docBest on the heap. Allocations
+// are batched for more efficiency.
+func (b *beExec) newDocBest(d docBest) *docBest {
+	buf := &b.docAlloc
+	if len(*buf) == 0 {
+		*buf = make([]docBest, 100)
+	}
+	r := &(*buf)[0]
+	*r = d
+	*buf = (*buf)[1:]
+	return r
+}
+
+// iDoc retrieves the unique instance of iDoc in memory for the given
+// values of i, s, d and z. The object is constructed if it does not
+// exist yet.
+//
+// The results of this function guarantee that the pointer addresses
+// are equal if the arguments used to construct the value were equal.
+func (b *beExec) iDoc(i int, s string, d Doc, z *iDoc) *iDoc {
+	idoc := iDoc{i, s, d, z}
+	if m, ok := b.memoiDoc[idoc]; ok {
+		return m
+	}
+	r := b.newiDoc(idoc)
+	b.memoiDoc[idoc] = r
+	return r
+}
+
+// newiDoc makes a new iDoc on the heap. Allocations are batched
+// for more efficiency. Do not use this directly! Instead
+// use the iDoc() method defined above.
+func (b *beExec) newiDoc(d iDoc) *iDoc {
+	buf := &b.idocAlloc
+	if len(*buf) == 0 {
+		*buf = make([]iDoc, 100)
+	}
+	r := &(*buf)[0]
+	*r = d
+	*buf = (*buf)[1:]
+	return r
+}
+
+type beArgs struct {
+	k int
+	d *iDoc
+}
+
+func better(w, k int, x *docBest, y func() *docBest) *docBest {
 	if fits(w-k, x) {
 		return x
 	}
 	return y()
 }
 
-func fits(w int, x docBest) bool {
+func fits(w int, x *docBest) bool {
 	if w < 0 {
 		return false
 	}
-	switch t := x.(type) {
-	case nilDocB:
+	if x == nil {
+		// Nil doc.
 		return true
+	}
+	switch x.tag {
 	case textB:
-		return fits(w-len(t.s), t.d)
+		return fits(w-len(x.s), x.d)
 	case lineB:
 		return true
 	default:
-		panic(fmt.Errorf("unknown type: %T", x))
+		panic(fmt.Errorf("unknown type: %d", x.tag))
 	}
 }
 
-func layout(sb *strings.Builder, d docBest) {
-	switch d := d.(type) {
-	case nilDocB:
-		// ignore
+func layout(sb *strings.Builder, d *docBest) {
+	if d == nil {
+		// Nil doc: no output.
+		return
+	}
+	switch d.tag {
 	case textB:
 		sb.WriteString(d.s)
 		layout(sb, d.d)
 	case lineB:
-		sb.WriteString("\n")
+		sb.WriteByte('\n')
 		sb.WriteString(d.s)
 		layout(sb, d.d)
 	default:
-		panic(fmt.Errorf("unknown type: %T", d))
+		panic(fmt.Errorf("unknown type: %d", d.tag))
 	}
 }

--- a/pkg/util/pretty/util.go
+++ b/pkg/util/pretty/util.go
@@ -62,7 +62,7 @@ func JoinNestedRight(n int, s string, sep Doc, nested ...Doc) Doc {
 
 // ConcatLine concatenates two Docs with a Line.
 func ConcatLine(a, b Doc) Doc {
-	return concatFn(a, b, func(a, b Doc) Doc {
+	return simplifyNil(a, b, func(a, b Doc) Doc {
 		return Concat(
 			a,
 			Concat(
@@ -75,7 +75,7 @@ func ConcatLine(a, b Doc) Doc {
 
 // ConcatSpace concatenates two Docs with a space.
 func ConcatSpace(a, b Doc) Doc {
-	return concatFn(a, b, func(a, b Doc) Doc {
+	return simplifyNil(a, b, func(a, b Doc) Doc {
 		return Concat(
 			a,
 			Concat(
@@ -145,4 +145,22 @@ func Bracket(n int, s string, l string, x Doc, r string) Doc {
 		Text(r),
 	)
 	return union{flatten(a), b}
+}
+
+// simplifyNil returns fn(a, b). nil (the Go value) is converted to Nil (the
+// Doc). If either Doc is Nil, the other Doc is returned without invoking fn.
+func simplifyNil(a, b Doc, fn func(Doc, Doc) Doc) Doc {
+	if a == nil {
+		a = Nil
+	}
+	if b == nil {
+		b = Nil
+	}
+	if a == Nil {
+		return b
+	}
+	if b == Nil {
+		return a
+	}
+	return fn(a, b)
 }


### PR DESCRIPTION
```
name           old time/op    new time/op    delta
PrettyData-16     1.79s ±31%     0.13s ± 3%  -92.50%  (p=0.008 n=5+5)

name           old alloc/op   new alloc/op   delta
PrettyData-16     630MB ± 1%      24MB ± 0%  -96.15%  (p=0.008 n=5+5)

name           old allocs/op  new allocs/op  delta
PrettyData-16     4.27M ± 0%     0.01M ± 0%  -99.74%  (p=0.008 n=5+5)
```
