### PR TITLE
pretty: render tabs at the end of the pipeline

### DIFF
--- a/pkg/sql/sem/tree/pretty_test.go
+++ b/pkg/sql/sem/tree/pretty_test.go
@@ -141,7 +141,7 @@ func BenchmarkPrettyData(b *testing.B) {
 		b.Fatal(err)
 	}
 	var docs []pretty.Doc
-	cfg := tree.PrettyCfg{Tab: "\t", TabWidth: 4}
+	cfg := tree.PrettyCfg{IndentWidth: 4}
 	for _, m := range matches {
 		sql, err := ioutil.ReadFile(m)
 		if err != nil {
@@ -158,7 +158,7 @@ func BenchmarkPrettyData(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for _, doc := range docs {
 			for _, w := range []int{1, 30, 80} {
-				pretty.Pretty(doc, w)
+				pretty.Pretty(doc, w, true /*useTabs*/, 4 /*tabWidth*/)
 			}
 		}
 	}

--- a/pkg/util/pretty/document.go
+++ b/pkg/util/pretty/document.go
@@ -89,17 +89,15 @@ func Concat(a, b Doc) Doc {
 }
 
 // nest represents (NEST Int DOC) :: DOC -- nesting a doc "under" another.
-// NEST indents d by s at effective length n. len(s) does not have to be
-// n. This allows s to be a tab character and n can be a tab width.
+// NEST indents d at effective length n.
 type nest struct {
 	n int
-	s string
 	d Doc
 }
 
 // Nest is the NEST constructor.
-func Nest(n int, s string, d Doc) Doc {
-	return nest{n, s, d}
+func Nest(n int, d Doc) Doc {
+	return nest{n, d}
 }
 
 // union represents (DOC <|> DOC) :: DOC -- the union of two docs.
@@ -130,7 +128,7 @@ func flatten(d Doc) Doc {
 	case concat:
 		return Concat(flatten(t.a), flatten(t.b))
 	case nest:
-		return Nest(t.n, t.s, flatten(t.d))
+		return Nest(t.n, flatten(t.d))
 	case text:
 		return d
 	case line:

--- a/pkg/util/pretty/pretty_test.go
+++ b/pkg/util/pretty/pretty_test.go
@@ -16,7 +16,6 @@ package pretty_test
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/util/pretty"
 )
@@ -76,7 +75,7 @@ func Example_tree() {
 		}
 		return pretty.Fold(pretty.Concat,
 			pretty.Text("["),
-			pretty.Nest(1, " ", showTrees(ts)),
+			pretty.Nest(1, showTrees(ts)),
 			pretty.Text("]"),
 		)
 	}
@@ -89,7 +88,7 @@ func Example_tree() {
 			}
 			doc = pretty.Fold(pretty.Concat,
 				pretty.Text("("),
-				pretty.JoinNestedRight(len(t.s), strings.Repeat(" ", len(t.s)),
+				pretty.JoinNestedRight(len(t.s),
 					pretty.Text(t.op), operands...),
 				pretty.Text(")"),
 			)
@@ -98,34 +97,34 @@ func Example_tree() {
 		}
 		return pretty.Group(pretty.Concat(
 			pretty.Text(t.s),
-			pretty.Nest(len(t.s), strings.Repeat(" ", len(t.s)), doc),
+			pretty.Nest(len(t.s), doc),
 		))
 	}
 	for _, n := range []int{1, 30, 80} {
-		p := pretty.Pretty(showTree(tree), n)
+		p := pretty.Pretty(showTree(tree), n, true /*useTabs*/, 4 /*tabWidth*/)
 		fmt.Printf("%d:\n%s\n\n", n, p)
 	}
 	// Output:
 	// 1:
 	// aaa[bbbbb[ccc,
-	//           dd,
-	//           ee(some
-	//             * another[2a,
-	//                       2b]
-	//             * final)],
-	//     eee,
-	//     ffff[gg,
-	//          hhh,
-	//          ii]]
+	// 		  dd,
+	// 		  ee(some
+	// 			* another[2a,
+	// 					  2b]
+	// 			* final)],
+	// 	eee,
+	// 	ffff[gg,
+	// 		 hhh,
+	// 		 ii]]
 	//
 	// 30:
 	// aaa[bbbbb[ccc,
-	//           dd,
-	//           ee(some
-	//             * another[2a, 2b]
-	//             * final)],
-	//     eee,
-	//     ffff[gg, hhh, ii]]
+	// 		  dd,
+	// 		  ee(some
+	// 			* another[2a, 2b]
+	// 			* final)],
+	// 	eee,
+	// 	ffff[gg, hhh, ii]]
 	//
 	// 80:
 	// aaa[bbbbb[ccc, dd, ee(some * another[2a, 2b] * final)], eee, ffff[gg, hhh, ii]]

--- a/pkg/util/pretty/util.go
+++ b/pkg/util/pretty/util.go
@@ -91,15 +91,15 @@ func Stack(d ...Doc) Doc {
 	return Fold(ConcatLine, d...)
 }
 
-// JoinGroup nests joined d with divider under name.
-func JoinGroup(n int, name, divider string, d ...Doc) Doc {
-	return NestName(n, Text(name), Join(divider, d...))
+// JoinGroup nests joined d with divider under head.
+func JoinGroup(n int, head, divider string, d ...Doc) Doc {
+	return NestUnder(n, Text(head), Join(divider, d...))
 }
 
-// NestName nests nested under name.
-func NestName(n int, name, nested Doc) Doc {
+// NestUnder nests nested under head.
+func NestUnder(n int, head, nested Doc) Doc {
 	return Group(Concat(
-		name,
+		head,
 		Nest(n, Concat(
 			Line,
 			Group(nested),

--- a/pkg/util/pretty/util.go
+++ b/pkg/util/pretty/util.go
@@ -45,7 +45,7 @@ func JoinDoc(s Doc, d ...Doc) Doc {
 //       bbb
 // <sep> ccc
 //       ccc
-func JoinNestedRight(n int, s string, sep Doc, nested ...Doc) Doc {
+func JoinNestedRight(n int, sep Doc, nested ...Doc) Doc {
 	switch len(nested) {
 	case 0:
 		return Nil
@@ -55,7 +55,7 @@ func JoinNestedRight(n int, s string, sep Doc, nested ...Doc) Doc {
 		return Concat(
 			nested[0],
 			FoldMap(Concat,
-				func(a Doc) Doc { return Concat(Line, ConcatSpace(sep, Nest(n, s, Group(a)))) },
+				func(a Doc) Doc { return Concat(Line, ConcatSpace(sep, Nest(n, Group(a)))) },
 				nested[1:]...))
 	}
 }
@@ -92,15 +92,15 @@ func Stack(d ...Doc) Doc {
 }
 
 // JoinGroup nests joined d with divider under name.
-func JoinGroup(n int, s string, name, divider string, d ...Doc) Doc {
-	return NestName(n, s, Text(name), Join(divider, d...))
+func JoinGroup(n int, name, divider string, d ...Doc) Doc {
+	return NestName(n, Text(name), Join(divider, d...))
 }
 
-// NestName nests nested under name with string s.
-func NestName(n int, s string, name, nested Doc) Doc {
+// NestName nests nested under name.
+func NestName(n int, name, nested Doc) Doc {
 	return Group(Concat(
 		name,
-		Nest(n, s, Concat(
+		Nest(n, Concat(
 			Line,
 			Group(nested),
 		)),
@@ -132,7 +132,7 @@ func FoldMap(f func(a, b Doc) Doc, g func(Doc) Doc, d ...Doc) Doc {
 }
 
 // Bracket brackets x with l and r and given Nest arguments.
-func Bracket(n int, s string, l string, x Doc, r string) Doc {
+func Bracket(n int, l string, x Doc, r string) Doc {
 	a := Fold(Concat,
 		Text(l),
 		x,
@@ -140,7 +140,7 @@ func Bracket(n int, s string, l string, x Doc, r string) Doc {
 	)
 	b := Fold(Concat,
 		Text(l),
-		Nest(n, s, Concat(Line, x)),
+		Nest(n, Concat(Line, x)),
 		Line,
 		Text(r),
 	)

--- a/pkg/util/pretty/util.go
+++ b/pkg/util/pretty/util.go
@@ -133,6 +133,14 @@ func FoldMap(f func(a, b Doc) Doc, g func(Doc) Doc, d ...Doc) Doc {
 
 // Bracket brackets x with l and r and given Nest arguments.
 func Bracket(n int, l string, x Doc, r string) Doc {
+	// The "straightforward" implementation of Bracket should really be:
+	//   return Group(Fold(Concat,
+	//     	Text(l),
+	//     	Nest(n, Concat(Line, x)),
+	//     	Line,
+	//     	Text(r),
+	//   ))
+	// However for efficiency we inline the effect of Group here.
 	a := Fold(Concat,
 		Text(l),
 		x,


### PR DESCRIPTION
Prior to this patch, tabs were expanded into a string prefix early,
during the construction of the document. This caused overhead during
the selection of the best layout, as the prefixes needed to be
re-composed for each layout alternative.

This patch instead defers the expansion of tabs to the very end,
during the `layout` phase.

```
name           old time/op    new time/op    delta
PrettyData-16     200ms ± 9%     168ms ± 9%  -16.04%  (p=0.008 n=5+5)

name           old alloc/op   new alloc/op   delta
PrettyData-16    26.8MB ± 0%    22.2MB ± 0%  -17.21%  (p=0.008 n=5+5)

name           old allocs/op  new allocs/op  delta
PrettyData-16     12.1k ± 0%      6.6k ± 0%  -45.32%  (p=0.008 n=5+5)
```

Release note: None