### PR TITLE
pretty: define an algebraic soft break for brackets

### DIFF
--- a/pkg/util/pretty/document.go
+++ b/pkg/util/pretty/document.go
@@ -45,12 +45,13 @@ type Doc interface {
 	isDoc()
 }
 
-func (text) isDoc()   {}
-func (line) isDoc()   {}
-func (nilDoc) isDoc() {}
-func (concat) isDoc() {}
-func (nest) isDoc()   {}
-func (union) isDoc()  {}
+func (text) isDoc()      {}
+func (line) isDoc()      {}
+func (softbreak) isDoc() {}
+func (nilDoc) isDoc()    {}
+func (concat) isDoc()    {}
+func (nest) isDoc()      {}
+func (union) isDoc()     {}
 
 //
 // Implementations of Doc ("DOC" in paper).
@@ -75,6 +76,23 @@ type line struct{}
 
 // Line is the LINE constructor.
 var Line line
+
+// softbreak represents SOFTBREAK :: DOC -- an invisible space between
+// words that tries to break the text across lines.
+//
+// For example, text "hello" <> softbreak <> text "world"
+// flattens to "helloworld" (one word) but splits across lines as:
+//     hello
+//     world
+//
+// This is a common extension to Wadler's printer.
+//
+// Idea borrowed from Daniel Mendler's printer at
+// https://github.com/minad/wl-pprint-annotated/blob/master/src/Text/PrettyPrint/Annotated/WL.hs
+type softbreak struct{}
+
+// SoftBreak is the softbreak constructor.
+var SoftBreak softbreak
 
 // concat represents (DOC <> DOC) :: DOC -- the concatenation of two docs.
 type concat struct {
@@ -133,6 +151,8 @@ func flatten(d Doc) Doc {
 		return d
 	case line:
 		return textSpace
+	case softbreak:
+		return Nil
 	case union:
 		return flatten(t.x)
 	default:

--- a/pkg/util/pretty/pretty.go
+++ b/pkg/util/pretty/pretty.go
@@ -124,7 +124,7 @@ func (b *beExec) be(k int, xlist *iDoc) *docBest {
 			s:   string(t),
 			d:   b.be(k+len(t), z),
 		})
-	case line:
+	case line, softbreak:
 		res = b.newDocBest(docBest{
 			tag: lineB,
 			i:   d.i,

--- a/pkg/util/pretty/util.go
+++ b/pkg/util/pretty/util.go
@@ -132,27 +132,16 @@ func FoldMap(f func(a, b Doc) Doc, g func(Doc) Doc, d ...Doc) Doc {
 }
 
 // Bracket brackets x with l and r and given Nest arguments.
+// We use the "soft break" special document here so that
+// the flattened version (when grouped) does not insert
+// spaces between the parentheses and their content.
 func Bracket(n int, l string, x Doc, r string) Doc {
-	// The "straightforward" implementation of Bracket should really be:
-	//   return Group(Fold(Concat,
-	//     	Text(l),
-	//     	Nest(n, Concat(Line, x)),
-	//     	Line,
-	//     	Text(r),
-	//   ))
-	// However for efficiency we inline the effect of Group here.
-	a := Fold(Concat,
+	return Group(Fold(Concat,
 		Text(l),
-		x,
+		Nest(n, Concat(SoftBreak, x)),
+		SoftBreak,
 		Text(r),
-	)
-	b := Fold(Concat,
-		Text(l),
-		Nest(n, Concat(Line, x)),
-		Line,
-		Text(r),
-	)
-	return union{flatten(a), b}
+	))
 }
 
 // simplifyNil returns fn(a, b). nil (the Go value) is converted to Nil (the


### PR DESCRIPTION
.. and perhaps other uses later.

A soft break between two documents either concatenates them without
space (when flattened) or places them under each other with a newline.

Use this to define a simpler definition of `Bracket`.

(in reaction to https://github.com/cockroachdb/cockroach/pull/27259#discussion_r200851678)