### PR TITLE
storage: handle lease acquisition during merge

### DIFF
--- a/pkg/storage/batcheval/cmd_get_snapshot_for_merge.go
+++ b/pkg/storage/batcheval/cmd_get_snapshot_for_merge.go
@@ -147,6 +147,6 @@ func GetSnapshotForMerge(
 	reply.Data = snapBatch.Repr()
 
 	return result.Result{
-		Local: result.LocalResult{SetMerging: true},
+		Local: result.LocalResult{MaybeWatchForMerge: true},
 	}, nil
 }

--- a/pkg/storage/batcheval/cmd_lease.go
+++ b/pkg/storage/batcheval/cmd_lease.go
@@ -152,6 +152,11 @@ func evalNewLease(
 		pd.Replicated.PrevLeaseProposal = prevLease.ProposedTS
 	}
 
+	// Upon acquisition of a new lease, we're responsible for checking whether
+	// there is a merge in progress. (If there is, we cannot serve traffic unless
+	// the merge aborts.)
+	pd.Local.MaybeWatchForMerge = true
+
 	pd.Local.LeaseMetricsResult = new(result.LeaseMetricsType)
 	if isTransfer {
 		*pd.Local.LeaseMetricsResult = result.LeaseTransferSuccess

--- a/pkg/storage/batcheval/result/result.go
+++ b/pkg/storage/batcheval/result/result.go
@@ -66,9 +66,8 @@ type LocalResult struct {
 	MaybeAddToSplitQueue bool
 	// Call MaybeGossipNodeLiveness with the specified Span, if set.
 	MaybeGossipNodeLiveness *roachpb.Span
-	// Indicate that all traffic must be blocked until the merge transaction
-	// between this range and its left neighbor completes.
-	SetMerging bool
+	// Call maybeWatchForMerge.
+	MaybeWatchForMerge bool
 
 	// Set when transaction record(s) are updated, after calls to
 	// EndTransaction or PushTxn. This is a pointer to allow the zero
@@ -76,13 +75,13 @@ type LocalResult struct {
 	UpdatedTxns *[]*roachpb.Transaction
 }
 
-// DetachSetMerging returns and falsifies the SetMerging flag from the local
-// result.
-func (lResult *LocalResult) DetachSetMerging() bool {
+// DetachMaybeWatchForMerge returns and falsifies the MaybeWatchForMerge flag
+// from the local result.
+func (lResult *LocalResult) DetachMaybeWatchForMerge() bool {
 	if lResult == nil {
 		return false
-	} else if lResult.SetMerging {
-		lResult.SetMerging = false
+	} else if lResult.MaybeWatchForMerge {
+		lResult.MaybeWatchForMerge = false
 		return true
 	}
 	return false
@@ -323,7 +322,7 @@ func (p *Result) MergeAndDestroy(q Result) error {
 	coalesceBool(&p.Local.GossipFirstRange, &q.Local.GossipFirstRange)
 	coalesceBool(&p.Local.MaybeGossipSystemConfig, &q.Local.MaybeGossipSystemConfig)
 	coalesceBool(&p.Local.MaybeAddToSplitQueue, &q.Local.MaybeAddToSplitQueue)
-	coalesceBool(&p.Local.SetMerging, &q.Local.SetMerging)
+	coalesceBool(&p.Local.MaybeWatchForMerge, &q.Local.MaybeWatchForMerge)
 
 	if q.Local.UpdatedTxns != nil {
 		if p.Local.UpdatedTxns == nil {

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -1179,14 +1179,7 @@ func (m *multiTestContext) transferLeaseNonFatal(
 	// advanced recently, so all the liveness records (including the destination)
 	// are expired. In that case, the simple fact that the transfer succeeded
 	// doesn't mean that the destination now has a usable lease.
-	m.mu.RLock()
-	nl := m.nodeLivenesses[dest]
-	m.mu.RUnlock()
-	l, err := nl.Self()
-	if err != nil {
-		return err
-	}
-	if err := nl.Heartbeat(ctx, l); err != nil {
+	if err := m.heartbeatLiveness(ctx, dest); err != nil {
 		return err
 	}
 
@@ -1194,11 +1187,22 @@ func (m *multiTestContext) transferLeaseNonFatal(
 	if err != nil {
 		return err
 	}
-	if err := sourceRepl.AdminTransferLease(context.Background(), m.idents[dest].StoreID); err != nil {
+	if err := sourceRepl.AdminTransferLease(ctx, m.idents[dest].StoreID); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func (m *multiTestContext) heartbeatLiveness(ctx context.Context, store int) error {
+	m.mu.RLock()
+	nl := m.nodeLivenesses[store]
+	m.mu.RUnlock()
+	l, err := nl.Self()
+	if err != nil {
+		return err
+	}
+	return nl.Heartbeat(ctx, l)
 }
 
 // advanceClock advances the mtc's manual clock such that all

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2649,8 +2649,6 @@ func (r *Replica) limitTxnMaxTimestamp(
 // maybeWatchForMerge checks whether a merge of this replica into its left
 // neighbor is in its critical phase and, if so, arranges to block all requests
 // until the merge completes.
-//
-// TODO(benesch): Ensure this is called in the lease acquisition path.
 func (r *Replica) maybeWatchForMerge(ctx context.Context) error {
 	desc := r.Desc()
 	descKey := keys.RangeDescriptorKey(desc.StartKey)
@@ -2798,7 +2796,7 @@ func (r *Replica) executeReadOnlyBatch(
 	defer readOnly.Close()
 	br, result, pErr = evaluateBatch(ctx, storagebase.CmdIDKey(""), readOnly, rec, nil, ba)
 
-	if result.Local.DetachSetMerging() {
+	if result.Local.DetachMaybeWatchForMerge() {
 		if err := r.maybeWatchForMerge(ctx); err != nil {
 			return nil, roachpb.NewError(err)
 		}

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -827,6 +827,15 @@ func (r *Replica) handleLocalEvalResult(ctx context.Context, lResult result.Loca
 		}
 	}
 
+	if lResult.DetachMaybeWatchForMerge() {
+		if err := r.maybeWatchForMerge(ctx); err != nil {
+			// If maybeWatchForMerge fails, we do not know whether there is an
+			// in-progress merge that would prevent us from serving traffic. We cannot
+			// safely proceed.
+			log.Fatal(ctx, err)
+		}
+	}
+
 	if (lResult != result.LocalResult{}) {
 		log.Fatalf(ctx, "unhandled field in LocalEvalResult: %s", pretty.Diff(lResult, result.LocalResult{}))
 	}


### PR DESCRIPTION
Ensure that, upon acquiring a lease, replicas check whether a merge is
in progress and, if so, block all traffic unless the merge aborts. Add a
test to exercise this scenario.

Release note: None