### PR TITLE
importccl: ignore OWNER TO statements in IMPORT PGDUMP

### DIFF
--- a/pkg/ccl/importccl/pg_testdata_helpers_test.go
+++ b/pkg/ccl/importccl/pg_testdata_helpers_test.go
@@ -239,7 +239,7 @@ func pgdump(t *testing.T, dest string, tables ...string) {
 		t.Fatal(err)
 	}
 
-	args := []string{`-U`, `postgres`, `-h`, `127.0.0.1`, `-d`, `test`, `--no-owner`, `--no-privileges`}
+	args := []string{`-U`, `postgres`, `-h`, `127.0.0.1`, `-d`, `test`, `--no-privileges`}
 	for _, table := range tables {
 		args = append(args, `-t`, table)
 	}

--- a/pkg/ccl/importccl/testdata/pgdump/db.sql
+++ b/pkg/ccl/importccl/testdata/pgdump/db.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: second; Type: TABLE; Schema: public; Owner: -
+-- Name: second; Type: TABLE; Schema: public; Owner: postgres
 --
 
 CREATE TABLE public.second (
@@ -29,8 +29,10 @@ CREATE TABLE public.second (
 );
 
 
+ALTER TABLE public.second OWNER TO postgres;
+
 --
--- Name: simple; Type: TABLE; Schema: public; Owner: -
+-- Name: simple; Type: TABLE; Schema: public; Owner: postgres
 --
 
 CREATE TABLE public.simple (
@@ -40,8 +42,10 @@ CREATE TABLE public.simple (
 );
 
 
+ALTER TABLE public.simple OWNER TO postgres;
+
 --
--- Data for Name: second; Type: TABLE DATA; Schema: public; Owner: -
+-- Data for Name: second; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
 COPY public.second (i, s) FROM stdin;
@@ -56,7 +60,7 @@ COPY public.second (i, s) FROM stdin;
 
 
 --
--- Data for Name: simple; Type: TABLE DATA; Schema: public; Owner: -
+-- Data for Name: simple; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
 COPY public.simple (i, s, b) FROM stdin;
@@ -93,7 +97,7 @@ COPY public.simple (i, s, b) FROM stdin;
 
 
 --
--- Name: second second_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: second second_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
 ALTER TABLE ONLY public.second
@@ -101,7 +105,7 @@ ALTER TABLE ONLY public.second
 
 
 --
--- Name: simple simple_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: simple simple_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
 ALTER TABLE ONLY public.simple
@@ -109,14 +113,14 @@ ALTER TABLE ONLY public.simple
 
 
 --
--- Name: simple_b_s_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: simple_b_s_idx; Type: INDEX; Schema: public; Owner: postgres
 --
 
 CREATE UNIQUE INDEX simple_b_s_idx ON public.simple USING btree (b, s);
 
 
 --
--- Name: simple_s_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: simple_s_idx; Type: INDEX; Schema: public; Owner: postgres
 --
 
 CREATE INDEX simple_s_idx ON public.simple USING btree (s);

--- a/pkg/ccl/importccl/testdata/pgdump/second.sql
+++ b/pkg/ccl/importccl/testdata/pgdump/second.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: second; Type: TABLE; Schema: public; Owner: -
+-- Name: second; Type: TABLE; Schema: public; Owner: postgres
 --
 
 CREATE TABLE public.second (
@@ -29,8 +29,10 @@ CREATE TABLE public.second (
 );
 
 
+ALTER TABLE public.second OWNER TO postgres;
+
 --
--- Data for Name: second; Type: TABLE DATA; Schema: public; Owner: -
+-- Data for Name: second; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
 COPY public.second (i, s) FROM stdin;
@@ -45,7 +47,7 @@ COPY public.second (i, s) FROM stdin;
 
 
 --
--- Name: second second_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: second second_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
 ALTER TABLE ONLY public.second

--- a/pkg/ccl/importccl/testdata/pgdump/simple.sql
+++ b/pkg/ccl/importccl/testdata/pgdump/simple.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: simple; Type: TABLE; Schema: public; Owner: -
+-- Name: simple; Type: TABLE; Schema: public; Owner: postgres
 --
 
 CREATE TABLE public.simple (
@@ -30,8 +30,10 @@ CREATE TABLE public.simple (
 );
 
 
+ALTER TABLE public.simple OWNER TO postgres;
+
 --
--- Data for Name: simple; Type: TABLE DATA; Schema: public; Owner: -
+-- Data for Name: simple; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
 COPY public.simple (i, s, b) FROM stdin;
@@ -68,7 +70,7 @@ COPY public.simple (i, s, b) FROM stdin;
 
 
 --
--- Name: simple simple_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: simple simple_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
 ALTER TABLE ONLY public.simple
@@ -76,14 +78,14 @@ ALTER TABLE ONLY public.simple
 
 
 --
--- Name: simple_b_s_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: simple_b_s_idx; Type: INDEX; Schema: public; Owner: postgres
 --
 
 CREATE UNIQUE INDEX simple_b_s_idx ON public.simple USING btree (b, s);
 
 
 --
--- Name: simple_s_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: simple_s_idx; Type: INDEX; Schema: public; Owner: postgres
 --
 
 CREATE INDEX simple_s_idx ON public.simple USING btree (s);


### PR DESCRIPTION
Use a regexp here instead of implementing them in the parser because we
don't want to fully support these statements in our executor yet.

Release note (sql change): IMPORT PGDUMP no longer requires the --no-owner
flag from pg_dump.