### PR TITLE
sql: Add 'chr' builtin

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -682,7 +682,7 @@ has no relationship with the commit order of concurrent transactions.</p>
 <table>
 <thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>ascii(val: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the ASCII value for the first character in <code>val</code>.</p>
+<tr><td><code>ascii(val: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the character code of the first character in <code>val</code>. Despite the name, the function supports Unicode too.</p>
 </span></td></tr>
 <tr><td><code>bit_length(val: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of bits in <code>val</code>.</p>
 </span></td></tr>
@@ -700,6 +700,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 <tr><td><code>character_length(val: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of bytes in <code>val</code>.</p>
 </span></td></tr>
 <tr><td><code>character_length(val: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of characters in <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>chr(val: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the character with the code given in <code>val</code>. Inverse function of <code>ascii()</code>.</p>
 </span></td></tr>
 <tr><td><code>concat(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Concatenates a comma-separated list of strings.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -283,6 +283,24 @@ query error ascii\(\): the input string must not be empty
 select ascii('')
 
 query T
+select chr(122)
+----
+z
+
+query T
+select chr(ascii('Z'))
+----
+Z
+
+query T
+select chr(31109)
+----
+禅
+
+query error chr\(\): input value must be >= 0
+SELECT chr(-1)
+
+query T
 SELECT md5('abc')
 ----
 900150983cd24fb0d6963f7d28e17f72

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -63,6 +63,9 @@ var (
 	errLogOfNegNumber   = pgerror.NewError(pgerror.CodeInvalidArgumentForLogarithmError, "cannot take logarithm of a negative number")
 	errLogOfZero        = pgerror.NewError(pgerror.CodeInvalidArgumentForLogarithmError, "cannot take logarithm of zero")
 	errZeroIP           = pgerror.NewError(pgerror.CodeInvalidParameterValueError, "zero length IP")
+	errChrValueTooSmall = pgerror.NewError(pgerror.CodeInvalidParameterValueError, "input value must be >= 0")
+	errChrValueTooLarge = pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError,
+		"input value must be <= %d (maximum Unicode code point)", utf8.MaxRune)
 )
 
 const errInsufficientArgsFmtString = "unknown signature: %s()"
@@ -660,7 +663,28 @@ var builtins = map[string]builtinDefinition{
 				return tree.NewDInt(tree.DInt(ch)), nil
 			}
 			return nil, errEmptyInputString
-		}, types.Int, "Calculates the ASCII value for the first character in `val`.")),
+		}, types.Int, "Returns the character code of the first character in `val`. Despite the name, the function supports Unicode too.")),
+
+	"chr": makeBuiltin(tree.FunctionProperties{Category: categoryString},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"val", types.Int}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				x := tree.MustBeDInt(args[0])
+				var answer string
+				switch {
+				case x < 0:
+					return nil, errChrValueTooSmall
+				case x > utf8.MaxRune:
+					return nil, errChrValueTooLarge
+				default:
+					answer = string(rune(x))
+				}
+				return tree.NewDString(answer), nil
+			},
+			Info: "Returns the character with the code given in `val`. Inverse function of `ascii()`.",
+		},
+	),
 
 	"md5": hashBuiltin(
 		func() hash.Hash { return md5.New() },


### PR DESCRIPTION
This change adds a basic implementation of the `chr()` builtin function, similar to the one provided by Postgres.

Also added some basic logic tests, including inversion from `ascii()` output, and bounds checking on the input (0 to utf8.MaxRune).

Release note (sql): Add the `chr()` builtin function (the inverse of
`ascii()`).