### PR TITLE
opt: exploration rule for MAX(x) on index

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -341,11 +341,12 @@ group      ·            ·                  (min int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT max(x) FROM xyz
 ----
-group      ·            ·       (max int)  ·
- │         aggregate 0  max(x)  ·          ·
- └── scan  ·            ·       (x int)    ·
-·          table        xyz@xy  ·          ·
-·          spans        ALL     ·          ·
+group         ·            ·                (max int)  ·
+ │            aggregate 0  any_not_null(x)  ·          ·
+ └── revscan  ·            ·                (x int)    ·
+·             table        xyz@xy           ·          ·
+·             spans        ALL              ·          ·
+·             limit        1                ·          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT min(y) FROM xyz WHERE x = 1
@@ -361,11 +362,13 @@ group           ·            ·                (min int)       ·
 query TTTTT
 EXPLAIN (TYPES) SELECT max(y) FROM xyz WHERE x = 1
 ----
-group      ·            ·       (max int)       ·
- │         aggregate 0  max(y)  ·               ·
- └── scan  ·            ·       (x int, y int)  ·
-·          table        xyz@xy  ·               ·
-·          spans        /1-/2   ·               ·
+group           ·            ·                (max int)       ·
+ │              aggregate 0  any_not_null(y)  ·               ·
+ └── limit      ·            ·                (x int, y int)  ·
+      │         count        (1)[int]         ·               ·
+      └── scan  ·            ·                (x int, y int)  ·
+·               table        xyz@xy           ·               ·
+·               spans        /1/!NULL-/2      ·               ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT min(y) FROM xyz WHERE x = 7
@@ -381,11 +384,13 @@ group           ·            ·                (min int)       ·
 query TTTTT
 EXPLAIN (TYPES) SELECT max(y) FROM xyz WHERE x = 7
 ----
-group      ·            ·       (max int)       ·
- │         aggregate 0  max(y)  ·               ·
- └── scan  ·            ·       (x int, y int)  ·
-·          table        xyz@xy  ·               ·
-·          spans        /7-/8   ·               ·
+group           ·            ·                (max int)       ·
+ │              aggregate 0  any_not_null(y)  ·               ·
+ └── limit      ·            ·                (x int, y int)  ·
+      │         count        (1)[int]         ·               ·
+      └── scan  ·            ·                (x int, y int)  ·
+·               table        xyz@xy           ·               ·
+·               spans        /7/!NULL-/8      ·               ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT min(x) FROM xyz WHERE (y, z) = (2, 3.0)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1004,27 +1004,46 @@ project
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(9)
       │    │    ├── sort
-      │    │    │    ├── columns: column8:8(string)
+      │    │    │    ├── columns: column8:8(string!null)
       │    │    │    ├── outer: (1)
+      │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    ├── key: ()
+      │    │    │    ├── fd: ()-->(8)
       │    │    │    ├── ordering: +7
-      │    │    │    └── project
-      │    │    │         ├── columns: column8:8(string)
+      │    │    │    └── limit
+      │    │    │         ├── columns: column8:8(string!null)
       │    │    │         ├── outer: (1)
-      │    │    │         ├── select
-      │    │    │         │    ├── columns: x:6(int!null) y:7(int)
+      │    │    │         ├── cardinality: [0 - 1]
+      │    │    │         ├── key: ()
+      │    │    │         ├── fd: ()-->(8)
+      │    │    │         ├── sort
+      │    │    │         │    ├── columns: column8:8(string!null)
       │    │    │         │    ├── outer: (1)
-      │    │    │         │    ├── key: (6)
-      │    │    │         │    ├── fd: (6)-->(7)
-      │    │    │         │    ├── scan xy
-      │    │    │         │    │    ├── columns: x:6(int!null) y:7(int)
-      │    │    │         │    │    ├── key: (6)
-      │    │    │         │    │    └── fd: (6)-->(7)
-      │    │    │         │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-      │    │    │         │         └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
-      │    │    │         └── projections [outer=(7)]
-      │    │    │              └── xy.y::STRING [type=string, outer=(7)]
+      │    │    │         │    ├── ordering: -8
+      │    │    │         │    └── select
+      │    │    │         │         ├── columns: column8:8(string!null)
+      │    │    │         │         ├── outer: (1)
+      │    │    │         │         ├── project
+      │    │    │         │         │    ├── columns: column8:8(string)
+      │    │    │         │         │    ├── outer: (1)
+      │    │    │         │         │    ├── select
+      │    │    │         │         │    │    ├── columns: x:6(int!null) y:7(int)
+      │    │    │         │         │    │    ├── outer: (1)
+      │    │    │         │         │    │    ├── key: (6)
+      │    │    │         │         │    │    ├── fd: (6)-->(7)
+      │    │    │         │         │    │    ├── scan xy
+      │    │    │         │         │    │    │    ├── columns: x:6(int!null) y:7(int)
+      │    │    │         │         │    │    │    ├── key: (6)
+      │    │    │         │         │    │    │    └── fd: (6)-->(7)
+      │    │    │         │         │    │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+      │    │    │         │         │    │         └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+      │    │    │         │         │    └── projections [outer=(7)]
+      │    │    │         │         │         └── xy.y::STRING [type=string, outer=(7)]
+      │    │    │         │         └── filters [type=bool, outer=(8), constraints=(/8: (/NULL - ]; tight)]
+      │    │    │         │              └── column8 IS NOT NULL [type=bool, outer=(8), constraints=(/8: (/NULL - ]; tight)]
+      │    │    │         └── const: 1 [type=int]
       │    │    └── aggregations [outer=(8)]
-      │    │         └── max [type=string, outer=(8)]
+      │    │         └── any-not-null [type=string, outer=(8)]
       │    │              └── variable: column8 [type=string, outer=(8)]
       │    └── filters [type=bool, outer=(9), constraints=(/9: [/'foo' - /'foo']; tight), fd=()-->(9)]
       │         └── max = 'foo' [type=bool, outer=(9), constraints=(/9: [/'foo' - /'foo']; tight)]

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -451,11 +451,20 @@ func (c *CustomFuncs) MakeOne() memo.GroupID {
 	return c.e.f.ConstructConst(c.e.f.InternDatum(tree.NewDInt(1)))
 }
 
-// MakeAscOrderingChoiceFromColumn constructs a new OrderingChoice with
-// one element in the sequence: the columnID in the ascending direction.
-func (c *CustomFuncs) MakeAscOrderingChoiceFromColumn(col memo.PrivateID) memo.PrivateID {
+// MakeOrderingChoiceFromColumn constructs a new OrderingChoice with
+// one element in the sequence: the columnID in the order defined by
+// (MIN/MAX) operator. This function was originally created to be used
+// with the Replace(Min|Max)WithLimit exploration rules.
+func (c *CustomFuncs) MakeOrderingChoiceFromColumn(
+	op opt.Operator, col memo.PrivateID,
+) memo.PrivateID {
 	oc := props.OrderingChoice{}
-	oc.AppendCol(c.ExtractColID(col), false /* descending */)
+	switch op {
+	case opt.MinOp:
+		oc.AppendCol(c.ExtractColID(col), false /* descending */)
+	case opt.MaxOp:
+		oc.AppendCol(c.ExtractColID(col), true /* descending */)
+	}
 	return c.e.f.InternOrderingChoice(&oc)
 }
 

--- a/pkg/sql/opt/xform/rules/groupby.opt
+++ b/pkg/sql/opt/xform/rules/groupby.opt
@@ -17,7 +17,31 @@
             (Filters [(IsNot $variable (Null (AnyType)))])
         )
         (MakeOne)
-        (MakeAscOrderingChoiceFromColumn $col)
+        (MakeOrderingChoiceFromColumn Min $col)
+    )
+    (Aggregations [(AnyNotNull $variable)] $cols)
+    $def
+)
+
+# ReplaceMaxWithLimit is analogous to the ReplaceMinWithLimit rule.
+# Due to limitations with OpName in exploration rules, the rule
+# had to be duplicated with minor modifications (we replace occurrences
+# of Min with Max)
+[ReplaceMaxWithLimit, Explore]
+(GroupBy
+    $input:*
+    (Aggregations [(Max $variable:(Variable $col:*))] $cols:*)
+    $def:* & (IsScalarGroupBy $def)
+)
+=>
+(GroupBy
+    (Limit
+        (Select
+            $input
+            (Filters [(IsNot $variable (Null (AnyType)))])
+        )
+        (MakeOne)
+        (MakeOrderingChoiceFromColumn Max $col)
     )
     (Aggregations [(AnyNotNull $variable)] $cols)
     $def

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -15,6 +15,73 @@ TABLE abc
       └── a string not null
 
 opt
+select max(a) FROM abc
+----
+group-by
+ ├── columns: max:5(string)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(5)
+ ├── scan abc,rev
+ │    ├── columns: a:1(string!null)
+ │    ├── limit: 1
+ │    ├── key: ()
+ │    └── fd: ()-->(1)
+ └── aggregations [outer=(1)]
+      └── any-not-null [type=string, outer=(1)]
+           └── variable: abc.a [type=string, outer=(1)]
+
+opt
+select max(b) FROM abc
+----
+group-by
+ ├── columns: max:5(float)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(5)
+ ├── scan abc
+ │    └── columns: b:2(float)
+ └── aggregations [outer=(2)]
+      └── max [type=float, outer=(2)]
+           └── variable: abc.b [type=float, outer=(2)]
+
+memo
+select max(b) from abc
+----
+memo (optimized)
+ ├── G1: (group-by G9 G2 cols=()) (group-by G3 G4 cols=())
+ │    └── "[presentation: max:5]"
+ │         ├── best: (group-by G9 G2 cols=())
+ │         └── cost: 1050.00
+ ├── G2: (aggregations G5)
+ ├── G3: (limit G6 G7 ordering=-2)
+ │    └── ""
+ │         ├── best: (limit G6="[ordering: -2]" G7 ordering=-2)
+ │         └── cost: 1087.94
+ ├── G4: (aggregations G8)
+ ├── G5: (max G12)
+ ├── G6: (select G9 G10)
+ │    ├── ""
+ │    │    ├── best: (select G9 G10)
+ │    │    └── cost: 1060.00
+ │    └── "[ordering: -2]"
+ │         ├── best: (sort G6)
+ │         └── cost: 1087.94
+ ├── G7: (const 1)
+ ├── G8: (any-not-null G12)
+ ├── G9: (scan abc,cols=(2)) (scan abc,rev,cols=(2))
+ │    ├── ""
+ │    │    ├── best: (scan abc,cols=(2))
+ │    │    └── cost: 1050.00
+ │    └── "[ordering: -2]"
+ │         ├── best: (sort G9)
+ │         └── cost: 1149.66
+ ├── G10: (filters G11)
+ ├── G11: (is-not G12 G13)
+ ├── G12: (variable abc.b)
+ └── G13: (null anyelement)
+
+opt
 SELECT min(a) FROM abc
 ----
 group-by
@@ -98,6 +165,88 @@ group-by
       └── any-not-null [type=int, outer=(2)]
            └── variable: xyz.y [type=int, outer=(2)]
 
+# ReplaceMaxWithLimit has the same behavior with max() as
+# the previous min() query because x is a unique key
+opt
+SELECT max(y) FROM xyz where x=7
+----
+group-by
+ ├── columns: max:4(int)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(4)
+ ├── limit
+ │    ├── columns: x:1(int!null) y:2(int!null)
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2)
+ │    ├── scan xyz@xy
+ │    │    ├── columns: x:1(int!null) y:2(int!null)
+ │    │    ├── constraint: /1/2: (/7/NULL - /7]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(1,2)
+ │    └── const: 1 [type=int]
+ └── aggregations [outer=(2)]
+      └── any-not-null [type=int, outer=(2)]
+           └── variable: xyz.y [type=int, outer=(2)]
+
+# We expect ReplaceMinWithLimit not to be preferred here.
+# This is because we know nothing about the ordering of y
+# on the index xy after a scan on xy with x>7.
+opt
+SELECT min(y) FROM xyz WHERE x>7
+----
+group-by
+ ├── columns: min:4(int)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(4)
+ ├── scan xyz@xy
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── constraint: /1/2: [/8 - ]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── aggregations [outer=(2)]
+      └── min [type=int, outer=(2)]
+           └── variable: xyz.y [type=int, outer=(2)]
+
+# We expect ReplaceMaxWithLimit not to be preferred here.
+# This is because we know nothing about the ordering of y
+# on the index xy after a scan on xy with x>7
+opt
+SELECT max(y) FROM xyz WHERE x>7
+----
+group-by
+ ├── columns: max:4(int)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(4)
+ ├── scan xyz@xy
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── constraint: /1/2: [/8 - ]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── aggregations [outer=(2)]
+      └── max [type=int, outer=(2)]
+           └── variable: xyz.y [type=int, outer=(2)]
+
+opt
+SELECT max(x) FROM xyz
+----
+group-by
+ ├── columns: max:4(int)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(4)
+ ├── scan xyz@xy,rev
+ │    ├── columns: x:1(int!null)
+ │    ├── limit: 1
+ │    ├── key: ()
+ │    └── fd: ()-->(1)
+ └── aggregations [outer=(1)]
+      └── any-not-null [type=int, outer=(1)]
+           └── variable: xyz.x [type=int, outer=(1)]
+
 opt
 SELECT min(x) FROM xyz
 ----
@@ -124,6 +273,24 @@ group-by
  ├── key: ()
  ├── fd: ()-->(4)
  ├── scan xyz@xy
+ │    ├── columns: x:1(int!null)
+ │    ├── constraint: /1/2: [/0 - /0] [/4 - /4] [/7 - /7]
+ │    ├── limit: 1
+ │    ├── key: ()
+ │    └── fd: ()-->(1)
+ └── aggregations [outer=(1)]
+      └── any-not-null [type=int, outer=(1)]
+           └── variable: xyz.x [type=int, outer=(1)]
+
+opt
+SELECT max(x) FROM xyz WHERE x in (0, 4, 7)
+----
+group-by
+ ├── columns: max:4(int)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(4)
+ ├── scan xyz@xy,rev
  │    ├── columns: x:1(int!null)
  │    ├── constraint: /1/2: [/0 - /0] [/4 - /4] [/7 - /7]
  │    ├── limit: 1
@@ -187,6 +354,24 @@ project
            └── min [type=int, outer=(2)]
                 └── variable: xyz.y [type=int, outer=(2)]
 
+# ReplaceMaxWithLimit does not apply when there is
+# a grouping column
+opt
+SELECT max(y) FROM xyz GROUP BY y
+----
+project
+ ├── columns: max:4(int)
+ └── group-by
+      ├── columns: y:2(int) max:4(int)
+      ├── grouping columns: y:2(int)
+      ├── key: (2)
+      ├── fd: (2)-->(4)
+      ├── scan xyz@xy
+      │    └── columns: y:2(int)
+      └── aggregations [outer=(2)]
+           └── max [type=int, outer=(2)]
+                └── variable: xyz.y [type=int, outer=(2)]
+
 # ReplaceMinWithLimit does not apply when there is
 # a grouping column
 opt
@@ -227,6 +412,27 @@ group-by
       └── min [type=int, outer=(1)]
            └── variable: xyz.x [type=int, outer=(1)]
 
+
+# ReplaceMaxWithLimit does not apply on multiple aggregations
+# on different columns
+opt
+SELECT max(y), max(x) FROM xyz
+----
+group-by
+ ├── columns: max:4(int) max:5(int)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(4,5)
+ ├── scan xyz@xy
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── aggregations [outer=(1,2)]
+      ├── max [type=int, outer=(2)]
+      │    └── variable: xyz.y [type=int, outer=(2)]
+      └── max [type=int, outer=(1)]
+           └── variable: xyz.x [type=int, outer=(1)]
+
 # ReplaceMinWithLimit does not apply with
 # multiple grouping columns
 opt
@@ -249,6 +455,28 @@ project
            └── min [type=int, outer=(2)]
                 └── variable: xyz.y [type=int, outer=(2)]
 
+# ReplaceMaxWithLimit does not apply with
+# multiple grouping columns
+opt
+SELECT x,max(y) FROM xyz GROUP BY x,y
+----
+project
+ ├── columns: x:1(int!null) max:4(int)
+ ├── key: (1)
+ ├── fd: (1)-->(4)
+ └── group-by
+      ├── columns: x:1(int!null) y:2(int) max:4(int)
+      ├── grouping columns: x:1(int!null) y:2(int)
+      ├── key: (1)
+      ├── fd: (1)-->(2,4)
+      ├── scan xyz@xy
+      │    ├── columns: x:1(int!null) y:2(int)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── aggregations [outer=(2)]
+           └── max [type=int, outer=(2)]
+                └── variable: xyz.y [type=int, outer=(2)]
+
 # ReplaceMinWithLimit does not apply to non-scalar
 # aggregates
 opt
@@ -267,6 +495,28 @@ project
       │    └── fd: (1)-->(2)
       └── aggregations [outer=(1,2)]
            ├── min [type=int, outer=(1)]
+           │    └── variable: xyz.x [type=int, outer=(1)]
+           └── count [type=int, outer=(2)]
+                └── variable: xyz.y [type=int, outer=(2)]
+
+# ReplaceMaxWithLimit does not apply to non-scalar
+# aggregates
+opt
+SELECT max(x), count(y) FROM xyz GROUP BY x,y
+----
+project
+ ├── columns: max:4(int) count:5(int)
+ └── group-by
+      ├── columns: x:1(int!null) y:2(int) max:4(int) count:5(int)
+      ├── grouping columns: x:1(int!null) y:2(int)
+      ├── key: (1)
+      ├── fd: (1)-->(2,4,5)
+      ├── scan xyz@xy
+      │    ├── columns: x:1(int!null) y:2(int)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── aggregations [outer=(1,2)]
+           ├── max [type=int, outer=(1)]
            │    └── variable: xyz.x [type=int, outer=(1)]
            └── count [type=int, outer=(2)]
                 └── variable: xyz.y [type=int, outer=(2)]
@@ -326,6 +576,68 @@ memo (optimized)
  │    │    ├── best: (scan abc,cols=(2))
  │    │    └── cost: 1050.00
  │    └── "[ordering: +2]"
+ │         ├── best: (sort G9)
+ │         └── cost: 1149.66
+ ├── G10: (filters G11)
+ ├── G11: (is-not G12 G13)
+ ├── G12: (variable abc.b)
+ └── G13: (null anyelement)
+
+memo
+SELECT max(a) FROM abc
+----
+memo (optimized)
+ ├── G1: (group-by G6 G2 cols=()) (group-by G3 G4 cols=())
+ │    └── "[presentation: max:5]"
+ │         ├── best: (group-by G3 G4 cols=())
+ │         └── cost: 1.10
+ ├── G2: (aggregations G5)
+ ├── G3: (limit G6 G7 ordering=-1) (scan abc,rev,cols=(1),lim=1)
+ │    └── ""
+ │         ├── best: (scan abc,rev,cols=(1),lim=1)
+ │         └── cost: 1.10
+ ├── G4: (aggregations G8)
+ ├── G5: (max G9)
+ ├── G6: (scan abc,cols=(1)) (scan abc,rev,cols=(1))
+ │    ├── ""
+ │    │    ├── best: (scan abc,cols=(1))
+ │    │    └── cost: 1050.00
+ │    └── "[ordering: -1]"
+ │         ├── best: (scan abc,rev,cols=(1))
+ │         └── cost: 1100.00
+ ├── G7: (const 1)
+ ├── G8: (any-not-null G9)
+ └── G9: (variable abc.a)
+
+memo
+SELECT max(b) FROM abc
+----
+memo (optimized)
+ ├── G1: (group-by G9 G2 cols=()) (group-by G3 G4 cols=())
+ │    └── "[presentation: max:5]"
+ │         ├── best: (group-by G9 G2 cols=())
+ │         └── cost: 1050.00
+ ├── G2: (aggregations G5)
+ ├── G3: (limit G6 G7 ordering=-2)
+ │    └── ""
+ │         ├── best: (limit G6="[ordering: -2]" G7 ordering=-2)
+ │         └── cost: 1087.94
+ ├── G4: (aggregations G8)
+ ├── G5: (max G12)
+ ├── G6: (select G9 G10)
+ │    ├── ""
+ │    │    ├── best: (select G9 G10)
+ │    │    └── cost: 1060.00
+ │    └── "[ordering: -2]"
+ │         ├── best: (sort G6)
+ │         └── cost: 1087.94
+ ├── G7: (const 1)
+ ├── G8: (any-not-null G12)
+ ├── G9: (scan abc,cols=(2)) (scan abc,rev,cols=(2))
+ │    ├── ""
+ │    │    ├── best: (scan abc,cols=(2))
+ │    │    └── cost: 1050.00
+ │    └── "[ordering: -2]"
  │         ├── best: (sort G9)
  │         └── cost: 1149.66
  ├── G10: (filters G11)


### PR DESCRIPTION
This PR is a follow up to #26905 and #27110. It adds an exploration
rule to replace MAX(x) with LIMIT 1 on a sorted index. Given the a
ddition of reverse scans to the optimizer in #27110, the
MAX(x) -> LIMIT 1 transformation is now feasible.

Note that the exploration rule ReplaceMinWithLimit is effectively
copied over to ReplaceMaxWithLimit. Ideally OpName would
have been used and the rule would be in the form below. However,
due to limitations of OpName in explorations rules, this was
not feasible.

```
[ReplaceMinMaxWithLimit, Explore]
(GroupBy
    $input:*
    (Aggregations [$op:(Max|Max $variable:(Variable $col:*))] $cols:*)
    $def:* & (IsScalarGroupBy $def)
)
=>
(GroupBy
    (Limit
        (Select
            $input
            (Filters [(IsNot $variable (Null (AnyType)))])
        )
        (MakeOne)
        (MakeOrderingChoiceFromColumn (OpName $op) $col)
    )
    (Aggregations [(AnyNotNull $variable)] $cols)
    $def
)
```