### PR TITLE
release-1.1: build: speed up nightly stress jobs

### DIFF
--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -12,8 +12,8 @@ build/builder.sh go install ./pkg/cmd/github-post
 build/builder.sh env COCKROACH_NIGHTLY_STRESS=true \
 		 make stress \
 		 PKG="$PKG" GOFLAGS="${GOFLAGS:-}" TAGS="${TAGS:-}" \
-		 TESTTIMEOUT=30m TESTFLAGS='-test.v' \
-		 STRESSFLAGS='-maxtime 15m -maxfails 1 -stderr' \
+		 TESTTIMEOUT=45m TESTFLAGS='-test.v' \
+		 STRESSFLAGS='-maxruns 100 -maxfails 1 -stderr' \
 		 2>&1 \
     | tee artifacts/stress.log \
     || exit_status=$?


### PR DESCRIPTION
Backport 1/2 commits from #27284.

/cc @cockroachdb/release

---

As discussed on Slack. See individual commit messages for details.
