### PR TITLE
server: check all meta records during decommissioning

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -684,8 +684,7 @@ Takes any of the following values:
 <PRE>
 
   - all:  waits until all target nodes' replica counts have dropped to zero.
-    This is the default. Use this unless you are targeting down nodes. In the presence
-    of down nodes, this will likely wait forever.
+    This is the default.
   - none: marks the targets as decommissioning, but does not wait for the process to complete.
     Use when polling manually from an external system.
 

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -503,7 +503,7 @@ func (txn *Txn) Iterate(
 	for {
 		rows, err := txn.Scan(ctx, begin, end, int64(pageSize))
 		if err != nil {
-			return errors.Wrap(err, "scanning meta2 keys")
+			return err
 		}
 		if len(rows) == 0 {
 			return nil

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1316,7 +1316,7 @@ func (s *adminServer) DecommissionStatus(
 		for _, nodeID := range nodeIDs {
 			replicaCounts[nodeID] = 0
 		}
-		return txn.Iterate(ctx, keys.Meta2Prefix, keys.MetaMax, pageSize,
+		return txn.Iterate(ctx, keys.MetaMin, keys.MetaMax, pageSize,
 			func(rows []client.KeyValue) error {
 				rangeDesc := roachpb.RangeDescriptor{}
 				for _, row := range rows {


### PR DESCRIPTION
By scanning only the meta2 information, replicas of the meta2 ranges
itself would be ignored. Include meta1 in the scan to address this.

This wasn't released, so no release note has been added. I can add a test
to this if requested, but there wasn't a straightforward way to do so and
this is not the kind of bug that would regress, so it seemed that my time
would better be spent elsewhere.

Release note: None