### PR TITLE
cherrypick-2.0: importccl: correctly error when encountering a sequence operation

### DIFF
--- a/pkg/ccl/importccl/csv_test.go
+++ b/pkg/ccl/importccl/csv_test.go
@@ -762,6 +762,14 @@ func TestImportStmt(t *testing.T) {
 			``,
 			`invalid option "into_db"`,
 		},
+		{
+			"sequences",
+			`IMPORT TABLE t (a int default nextval('s')) CSV DATA (%s)`,
+			nil,
+			files,
+			``,
+			`sequence operations unsupported`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			intodb := fmt.Sprintf(`csv%d`, i)


### PR DESCRIPTION
Cherrypick #27122 
Fixes #26850

Release note (bug fix): fix a panic in IMPORT when creating a table
using a sequence operation in a column DEFAULT (like nextval).