### PR TITLE
storage: add InitialHeartBeatFailedError as a structured error

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -362,8 +362,10 @@ communicate with a secure cluster\).
 		// up the stack as a roachpb.NewError(roachpb.NewSendError(.)).
 		// Error returned directly from GRPC.
 		{`quit`, styled(
-			`Failed to connect to the node: initial connection heartbeat failed: rpc error: ` +
-				`code = Unavailable desc = all SubConns are in TransientFailure`),
+			`Failed to connect to the node: initial connection heartbeat failed: rpc ` +
+				`error: code = Unavailable desc = all SubConns are in TransientFailure, ` +
+				`latest connection error: connection error: desc = "transport: Error while dialing dial tcp .*: ` +
+				`connect: connection refused"`),
 		},
 		// Going through the SQL client libraries gives a *net.OpError which
 		// we also handle.

--- a/pkg/cli/error.go
+++ b/pkg/cli/error.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 )
 
 // MaybeDecorateGRPCError catches grpc errors and provides a more helpful error
@@ -64,6 +65,8 @@ communicate with a secure cluster).
 		case *roachpb.SendError:
 			return connDropped()
 		case *net.OpError:
+			return connDropped()
+		case *netutil.InitialHeartbeatFailedError:
 			return connDropped()
 		}
 

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -246,7 +247,7 @@ func (c *Connection) Connect(ctx context.Context) (*grpc.ClientConn, error) {
 	// If connection is invalid, return latest heartbeat error.
 	h := c.heartbeatResult.Load().(heartbeatResult)
 	if !h.everSucceeded {
-		return nil, errors.Wrap(h.err, "initial connection heartbeat failed")
+		return nil, netutil.NewInitialHeartBeatFailedError(h.err)
 	}
 	return c.grpcConn, nil
 }

--- a/pkg/util/grpcutil/grpc_util.go
+++ b/pkg/util/grpcutil/grpc_util.go
@@ -89,6 +89,9 @@ func RequestDidNotStart(err error) bool {
 	if _, ok := err.(connectionNotReadyError); ok {
 		return true
 	}
+	if _, ok := err.(netutil.InitialHeartbeatFailedError); ok {
+		return true
+	}
 	s, ok := status.FromError(err)
 	if !ok {
 		// This is a non-gRPC error; assume nothing.

--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -17,6 +17,7 @@ package netutil
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -157,5 +158,23 @@ func IsClosedConnection(err error) bool {
 func FatalIfUnexpected(err error) {
 	if err != nil && !IsClosedConnection(err) {
 		log.Fatal(context.TODO(), err)
+	}
+}
+
+// InitialHeartbeatFailedError indicates that while attempting a GRPC
+// connection to a node, we aren't successful and have never seen a
+// heartbeat over that connection before.
+type InitialHeartbeatFailedError struct {
+	WrappedErr error
+}
+
+func (e InitialHeartbeatFailedError) Error() string {
+	return fmt.Sprintf("initial connection heartbeat failed: %s", e.WrappedErr)
+}
+
+// NewInitialHeartBeatFailedError creates a new InitialHeartbeatFailedError.
+func NewInitialHeartBeatFailedError(cause error) *InitialHeartbeatFailedError {
+	return &InitialHeartbeatFailedError{
+		WrappedErr: cause,
 	}
 }


### PR DESCRIPTION
This patch makes the GRPC Connect function return a structured error
when it's unable to connect and has never seen a heartbeat on that
connection. Before it returned an ambiguous error which prevented the
range descrptor cache from evicting stale entries upstream. In some cases
this could lead to a node being unable to find nodes that have replicas
for a given range because its cache is stale, but it doesn't refresh it
because there's an ambiguous error.

Closes #27109

Release note: None