### PR TITLE
sql: correctly convert HLC time to AS OF SYSTEM TIME

### DIFF
--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -139,6 +139,10 @@ func TestAsOfTime(t *testing.T) {
 	if _, err := db.Query("SELECT a FROM d.t AS OF SYSTEM TIME 1e40"); !testutils.IsError(err, "value out of range") {
 		t.Fatal(err)
 	}
+	if _, err := db.Query("SELECT a FROM d.t AS OF SYSTEM TIME 1.4"); !testutils.IsError(err,
+		`parsing argument: strconv.ParseInt: parsing "4000000000": value out of range`) {
+		t.Fatal(err)
+	}
 
 	// Verify logical parts parse with < 10 digits.
 	if _, err := db.Query("SELECT a FROM d.t AS OF SYSTEM TIME 1.123456789"); !testutils.IsError(err, `pq: relation "d.t" does not exist`) {

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -448,8 +448,8 @@ func CountLeases(
 		)
 	}
 
-	stmt := fmt.Sprintf(`SELECT count(1) FROM system.lease AS OF SYSTEM TIME %d.%d WHERE `,
-		at.WallTime, at.Logical) +
+	stmt := fmt.Sprintf(`SELECT count(1) FROM system.lease AS OF SYSTEM TIME %s WHERE `,
+		at.AsOfSystemTime()) +
 		strings.Join(whereClauses, " OR ")
 	values, err := executor.QueryRow(
 		ctx, "count-leases", nil /* txn */, stmt, at.GoTime(),

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -155,8 +155,7 @@ func (n *showFingerprintsNode) Next(params runParams) (bool, error) {
 	// like the outter one.
 	if params.p.asOfSystemTime {
 		ts := params.p.txn.OrigTimestamp()
-		tsStr := fmt.Sprintf("%d.%d", ts.WallTime, ts.Logical)
-		sql = sql + " AS OF SYSTEM TIME " + tsStr
+		sql = sql + " AS OF SYSTEM TIME " + ts.AsOfSystemTime()
 	}
 
 	fingerprintCols, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryRow(

--- a/pkg/util/hlc/timestamp.go
+++ b/pkg/util/hlc/timestamp.go
@@ -39,6 +39,11 @@ func (t Timestamp) String() string {
 	return fmt.Sprintf("%d.%09d,%d", t.WallTime/1E9, t.WallTime%1E9, t.Logical)
 }
 
+// AsOfSystemTime returns a string to be used in an AS OF SYSTEM TIME query.
+func (t Timestamp) AsOfSystemTime() string {
+	return fmt.Sprintf("%d.%010d", t.WallTime, t.Logical)
+}
+
 // Less compares two timestamps.
 func (t LegacyTimestamp) Less(s LegacyTimestamp) bool {
 	return Timestamp(t).Less(Timestamp(s))

--- a/pkg/util/hlc/timestamp_test.go
+++ b/pkg/util/hlc/timestamp_test.go
@@ -72,3 +72,19 @@ func TestTimestampPrev(t *testing.T) {
 		}
 	}
 }
+
+func TestAsOfSystemTime(t *testing.T) {
+	testCases := []struct {
+		ts  Timestamp
+		exp string
+	}{
+		{makeTS(145, 0), "145.0000000000"},
+		{makeTS(145, 123), "145.0000000123"},
+		{makeTS(145, 1123456789), "145.1123456789"},
+	}
+	for i, c := range testCases {
+		if exp := c.ts.AsOfSystemTime(); exp != c.exp {
+			t.Errorf("%d: expected %s; got %s", i, c.exp, exp)
+		}
+	}
+}


### PR DESCRIPTION
fixes #27229

Release note: None