### PR TITLE
storage: fix inclusive vs. exclusive error in blind put optimization

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5644,7 +5644,11 @@ func optimizePuts(
 	if firstUnoptimizedIndex < optimizePutThreshold { // don't bother if below this threshold
 		return origReqs
 	}
-	iter := batch.NewIterator(engine.IterOptions{UpperBound: maxKey})
+	iter := batch.NewIterator(engine.IterOptions{
+		// We want to include maxKey in our scan. Since UpperBound is exclusive, we
+		// need to set it to the key after maxKey.
+		UpperBound: maxKey.Next(),
+	})
 	defer iter.Close()
 
 	// If there are enough puts in the run to justify calling seek,

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1738,6 +1738,16 @@ func TestOptimizePuts(t *testing.T) {
 				true, true, true, true, true, false, false, false, false, false,
 			},
 		},
+		// Existing key at 09, ten puts, expect first nine puts are blind.
+		{
+			roachpb.Key("09"),
+			[]roachpb.Request{
+				&pArgs[0], &pArgs[1], &pArgs[2], &pArgs[3], &pArgs[4], &pArgs[5], &pArgs[6], &pArgs[7], &pArgs[8], &pArgs[9],
+			},
+			[]bool{
+				true, true, true, true, true, true, true, true, true, false,
+			},
+		},
 		// No existing key, ten puts + inc + ten cputs.
 		{
 			nil,


### PR DESCRIPTION
optimizePuts was checking for keys in the (inclusive) range [minKey,
maxKey] using an iterator whose upper bound was set to maxKey. This was
incorrect, as iterator upper bounds are exclusive, and so the iterator
would always exclude maxKey from results, even when maxKey existed. This
could result in an incorrect blind put to maxKey.

This commit properly converts the inclusive bound to an exclusive bound
by calling Next. It also adds a test case to TestOptimizePuts that
reliably fails without this fix. The test that discovered this bug,
TestRaceWithBackfill, did so only by chance.

Fix #27239.

Release note: None