### PR TITLE
mvcc: remove InitPut optimization that avoids intent on duplicate value

### DIFF
--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -2189,7 +2189,8 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *client.Txn) error {
 				return txn.InitPut(ctx, "iput", "put1", false)
 			},
-			// No retries, no failure as init put short circuits if it matches older value.
+			txnCoordRetry: false,              // non-matching value means we fail txn coord retry
+			expFailure:    "unexpected value", // the failure we get is a condition failed error
 		},
 		{
 			name: "write too old with initput matching newer value",
@@ -2223,31 +2224,14 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			beforeTxnStart: func(ctx context.Context, db *client.DB) error {
 				return db.Put(ctx, "iput", "put")
 			},
-			retryable: func(ctx context.Context, txn *client.Txn) error {
-				// The first time through, this will be a noop, as put is the existing value.
-				if err := txn.InitPut(ctx, "iput", "put", true); err != nil {
-					return err
-				}
-				// Create an out-of-band tombstone on the iput, which must be refreshed
-				// when the put below experiences a write-too-old error.
-				if err := txn.DB().Del(ctx, "iput"); err != nil {
-					return err
-				}
-				// Write the version of "a" which triggers write-too-old
-				// *after* the tombstone at the "iput" key, to ensure we see the
-				// tombstone when refreshing the iput span.
-				if err := txn.DB().Put(ctx, "a", "value"); err != nil {
-					return err
-				}
-				// This command will get a write too old and refresh the init
-				// put, forcing a client-retry. On the retry, the init put
-				// will fail with a condition failed error.
-				return txn.Put(ctx, "a", "value")
+			afterTxnStart: func(ctx context.Context, db *client.DB) error {
+				return db.Del(ctx, "iput")
 			},
-			clientRetry: true,
-			// Would get a condition failed error when failing on
-			// tombstones, but the retryable is not re-executed in the
-			// test fixture.
+			retryable: func(ctx context.Context, txn *client.Txn) error {
+				return txn.InitPut(ctx, "iput", "put", true)
+			},
+			txnCoordRetry: false,              // non-matching value means we fail txn coord retry
+			expFailure:    "unexpected value", // condition failed error when failing on tombstones
 		},
 		{
 			name: "write too old with put in batch commit",

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -9652,7 +9652,7 @@ func TestReplicaLocalRetries(t *testing.T) {
 			},
 			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
 				ba.Timestamp = ts.Prev()
-				expTS = ts.Prev() // won't write on init put
+				expTS = ts.Next()
 				iput := iPutArgs(roachpb.Key("b-iput"), []byte("put2"))
 				ba.Add(&iput)
 				return


### PR DESCRIPTION
See #26599.

This change removes an optimization with InitPut where requests that
intend to write a value identical to the one that already exists will
succeed without writing an intent. This optimization was problematic
for the transactional pipelining and parallel commits proposals because
both use the presence of an intent to indicate that a write succeeded.

Release note: None