### PR TITLE
build: fix TeamCity race builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -381,9 +381,12 @@ ROCKSDB_SRC_DIR  := $(C_DEPS_DIR)/rocksdb
 SNAPPY_SRC_DIR   := $(C_DEPS_DIR)/snappy
 LIBROACH_SRC_DIR := $(C_DEPS_DIR)/libroach
 
+# Derived build variants.
 use-stdmalloc          := $(findstring stdmalloc,$(TAGS))
 use-msan               := $(findstring msan,$(GOFLAGS))
-use-rocksdb-assertions := $(findstring race,$(GOFLAGS))
+
+# User-requested build variants.
+USE_ROCKSDB_ASSERTIONS :=
 
 BUILD_DIR := $(GOPATH)/native/$(TARGET_TRIPLE)
 
@@ -399,7 +402,7 @@ endif
 CRYPTOPP_DIR := $(BUILD_DIR)/cryptopp$(if $(use-msan),_msan)
 JEMALLOC_DIR := $(BUILD_DIR)/jemalloc$(if $(use-msan),_msan)
 PROTOBUF_DIR := $(BUILD_DIR)/protobuf$(if $(use-msan),_msan)
-ROCKSDB_DIR  := $(BUILD_DIR)/rocksdb$(if $(use-msan),_msan)$(if $(use-stdmalloc),_stdmalloc)$(if $(use-rocksdb-assertions),_assert)
+ROCKSDB_DIR  := $(BUILD_DIR)/rocksdb$(if $(use-msan),_msan)$(if $(use-stdmalloc),_stdmalloc)$(if $(USE_ROCKSDB_ASSERTIONS),_assert)
 SNAPPY_DIR   := $(BUILD_DIR)/snappy$(if $(use-msan),_msan)
 LIBROACH_DIR := $(BUILD_DIR)/libroach$(if $(use-msan),_msan)
 # Can't share with protobuf because protoc is always built for the host.

--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -39,7 +39,7 @@ run build/builder.sh env \
     PKG="$pkgspec" \
     TESTTIMEOUT=45m \
     TESTFLAGS='-v' \
-    ENABLE_ROCKSDB_ASSERTIONS=1 2>&1 \
+    USE_ROCKSDB_ASSERTIONS=1 2>&1 \
 	| tee artifacts/testrace.log \
 	| go-test-teamcity
 tc_end_block "Run Go tests under race detector"

--- a/build/variables.mk
+++ b/build/variables.mk
@@ -137,6 +137,7 @@ define VALID_VARS
   UI_TS_CCL
   UI_TS_OSS
   UNAME
+  USE_ROCKSDB_ASSERTIONS
   WEBPACK
   WEBPACK_DASHBOARD
   WEBPACK_DEV_SERVER
@@ -173,7 +174,6 @@ define VALID_VARS
   term-reset
   testbins
   use-msan
-  use-rocksdb-assertions
   use-stdmalloc
   xcmake-flags
   xconfigure-flags


### PR DESCRIPTION
38899a8 refactored the Makefile in a way that broke TeamCity race
builds. The breakage was not immediately noticed because race tests are
only run for modified Go packages, and 38899a8 modified no Go packages.

Release note: None