### PR TITLE
storage,server: Expand use of NodeDialer

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -257,6 +257,13 @@ func (c *Connection) setInitialHeartbeatDone() {
 	})
 }
 
+// Health returns an error indicating the success or failure of the
+// connection's latest heartbeat. Returns ErrNotHeartbeated if the
+// first heartbeat has not completed.
+func (c *Connection) Health() error {
+	return c.heartbeatResult.Load().(heartbeatResult).err
+}
+
 // Context contains the fields required by the rpc framework.
 type Context struct {
 	*base.Config
@@ -548,7 +555,7 @@ func (ctx *Context) ConnHealth(target string) error {
 		return nil
 	}
 	conn := ctx.GRPCDial(target)
-	return conn.heartbeatResult.Load().(heartbeatResult).err
+	return conn.Health()
 }
 
 func (ctx *Context) runHeartbeat(

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -38,32 +38,30 @@ type wrappedBreaker struct {
 	log.EveryN
 }
 
-// A NodeAddressResolver translates NodeIDs into addresses.
-type NodeAddressResolver func(roachpb.NodeID) (net.Addr, error)
+// An AddressResolver translates NodeIDs into addresses.
+type AddressResolver func(roachpb.NodeID) (net.Addr, error)
 
-// A NodeDialer wraps an *rpc.Context for dialing based on node IDs. For each node,
+// A Dialer wraps an *rpc.Context for dialing based on node IDs. For each node,
 // it maintains a circuit breaker that prevents rapid connection attempts and
 // provides hints to the callers on whether to log the outcome of the operation.
-type NodeDialer struct {
+type Dialer struct {
 	rpcContext *rpc.Context
-	resolver   NodeAddressResolver
+	resolver   AddressResolver
 
 	breakers syncutil.IntMap // map[roachpb.NodeID]*wrappedBreaker
 }
 
-// NewNodeDialer initializes a NodeDialer.
-func NewNodeDialer(rpcContext *rpc.Context, resolver NodeAddressResolver) *NodeDialer {
-	return &NodeDialer{
+// New initializes a Dialer.
+func New(rpcContext *rpc.Context, resolver AddressResolver) *Dialer {
+	return &Dialer{
 		rpcContext: rpcContext,
 		resolver:   resolver,
 	}
 }
 
-// DialNode returns a grpc connection to the given node. It logs whenever the
+// Dial returns a grpc connection to the given node. It logs whenever the
 // node first becomes unreachable or reachable.
-func (n *NodeDialer) DialNode(
-	ctx context.Context, nodeID roachpb.NodeID,
-) (_ *grpc.ClientConn, err error) {
+func (n *Dialer) Dial(ctx context.Context, nodeID roachpb.NodeID) (_ *grpc.ClientConn, err error) {
 	breaker := n.getBreaker(nodeID)
 	// If this is the first time connecting, or if connections have been failing repeatedly,
 	// consider logging.
@@ -102,11 +100,11 @@ func (n *NodeDialer) DialNode(
 // GetCircuitBreaker retrieves the circuit breaker for connections to the given
 // node. The breaker should not be mutated as this affects all connections
 // dialing to that node through this NodeDialer.
-func (n *NodeDialer) GetCircuitBreaker(nodeID roachpb.NodeID) *circuit.Breaker {
+func (n *Dialer) GetCircuitBreaker(nodeID roachpb.NodeID) *circuit.Breaker {
 	return n.getBreaker(nodeID).Breaker
 }
 
-func (n *NodeDialer) getBreaker(nodeID roachpb.NodeID) *wrappedBreaker {
+func (n *Dialer) getBreaker(nodeID roachpb.NodeID) *wrappedBreaker {
 	value, ok := n.breakers.Load(int64(nodeID))
 	if !ok {
 		breaker := &wrappedBreaker{Breaker: n.rpcContext.NewBreaker(), EveryN: log.Every(logPerNodeFailInterval)}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -50,6 +50,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/debug"
 	"github.com/cockroachdb/cockroach/pkg/server/heapprofiler"
@@ -136,6 +137,7 @@ type Server struct {
 	rpcContext         *rpc.Context
 	grpc               *grpc.Server
 	gossip             *gossip.Gossip
+	nodeDialer         *nodedialer.Dialer
 	nodeLiveness       *storage.NodeLiveness
 	storePool          *storage.StorePool
 	tcsFactory         *kv.TxnCoordSenderFactory
@@ -239,6 +241,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		s.stopper,
 		s.registry,
 	)
+	s.nodeDialer = nodedialer.New(s.rpcContext, storage.GossipAddressResolver(s.gossip))
 
 	// A custom RetryOptions is created which uses stopper.ShouldQuiesce() as
 	// the Closer. This prevents infinite retry loops from occurring during
@@ -314,7 +317,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	)
 
 	s.raftTransport = storage.NewRaftTransport(
-		s.cfg.AmbientCtx, st, storage.GossipAddressResolver(s.gossip), s.grpc, s.rpcContext,
+		s.cfg.AmbientCtx, st, s.nodeDialer, s.grpc, s.rpcContext,
 	)
 
 	// Set up internal memory metrics for use by internal SQL executors.
@@ -407,6 +410,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		Gossip:                  s.gossip,
 		NodeLiveness:            s.nodeLiveness,
 		Transport:               s.raftTransport,
+		NodeDialer:              s.nodeDialer,
 		RPCContext:              s.rpcContext,
 		ScanInterval:            s.cfg.ScanInterval,
 		ScanMaxIdleTime:         s.cfg.ScanMaxIdleTime,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -317,7 +317,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	)
 
 	s.raftTransport = storage.NewRaftTransport(
-		s.cfg.AmbientCtx, st, s.nodeDialer, s.grpc, s.rpcContext,
+		s.cfg.AmbientCtx, st, s.nodeDialer, s.grpc, s.stopper,
 	)
 
 	// Set up internal memory metrics for use by internal SQL executors.

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
@@ -2585,7 +2586,7 @@ func TestReplicaGCRace(t *testing.T) {
 	// there are two (this one and the one actually used by the store).
 	fromTransport := storage.NewRaftTransport(log.AmbientContext{Tracer: mtc.storeConfig.Settings.Tracer},
 		cluster.MakeTestingClusterSettings(),
-		storage.GossipAddressResolver(fromStore.Gossip()),
+		nodedialer.New(mtc.rpcContext, storage.GossipAddressResolver(fromStore.Gossip())),
 		nil, /* grpcServer */
 		mtc.rpcContext,
 	)
@@ -2993,7 +2994,7 @@ func TestReplicateRemovedNodeDisruptiveElection(t *testing.T) {
 	// there are two (this one and the one actually used by the store).
 	transport0 := storage.NewRaftTransport(log.AmbientContext{Tracer: mtc.storeConfig.Settings.Tracer},
 		cluster.MakeTestingClusterSettings(),
-		storage.GossipAddressResolver(mtc.gossips[0]),
+		nodedialer.New(mtc.rpcContext, storage.GossipAddressResolver(mtc.gossips[0])),
 		nil, /* grpcServer */
 		mtc.rpcContext,
 	)

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2588,7 +2588,7 @@ func TestReplicaGCRace(t *testing.T) {
 		cluster.MakeTestingClusterSettings(),
 		nodedialer.New(mtc.rpcContext, storage.GossipAddressResolver(fromStore.Gossip())),
 		nil, /* grpcServer */
-		mtc.rpcContext,
+		mtc.transportStopper,
 	)
 	errChan := errorChannelTestHandler(make(chan *roachpb.Error, 1))
 	fromTransport.Listen(fromStore.StoreID(), errChan)
@@ -2996,7 +2996,7 @@ func TestReplicateRemovedNodeDisruptiveElection(t *testing.T) {
 		cluster.MakeTestingClusterSettings(),
 		nodedialer.New(mtc.rpcContext, storage.GossipAddressResolver(mtc.gossips[0])),
 		nil, /* grpcServer */
-		mtc.rpcContext,
+		mtc.transportStopper,
 	)
 	errChan := errorChannelTestHandler(make(chan *roachpb.Error, 1))
 	transport0.Listen(mtc.stores[0].StoreID(), errChan)

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -289,7 +289,7 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 	m.nodeDialer = nodedialer.New(m.rpcContext, m.getNodeIDAddress)
 	m.transport = storage.NewRaftTransport(
 		log.AmbientContext{Tracer: st.Tracer}, st,
-		m.nodeDialer, nil, m.rpcContext,
+		m.nodeDialer, nil, m.transportStopper,
 	)
 
 	for idx := 0; idx < numStores; idx++ {

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -190,7 +191,8 @@ type multiTestContext struct {
 		nodeIDtoAddr map[roachpb.NodeID]net.Addr
 	}
 
-	transport *storage.RaftTransport
+	nodeDialer *nodedialer.Dialer
+	transport  *storage.RaftTransport
 
 	// The per-store clocks slice normally contains aliases of
 	// multiTestContext.clock, but it may be populated before Start() to
@@ -284,8 +286,10 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 			})
 		}
 	}
+	m.nodeDialer = nodedialer.New(m.rpcContext, m.getNodeIDAddress)
 	m.transport = storage.NewRaftTransport(
-		log.AmbientContext{Tracer: st.Tracer}, st, m.getNodeIDAddress, nil, m.rpcContext,
+		log.AmbientContext{Tracer: st.Tracer}, st,
+		m.nodeDialer, nil, m.rpcContext,
 	)
 
 	for idx := 0; idx < numStores; idx++ {
@@ -621,6 +625,7 @@ func (m *multiTestContext) makeStoreConfig(i int) storage.StoreConfig {
 		cfg = storage.TestStoreConfig(m.clocks[i])
 		m.storeConfig = &cfg
 	}
+	cfg.NodeDialer = m.nodeDialer
 	cfg.Transport = m.transport
 	cfg.Gossip = m.gossips[i]
 	cfg.TestingKnobs.DisableSplitQueue = true

--- a/pkg/storage/raft_transport_test.go
+++ b/pkg/storage/raft_transport_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -149,7 +150,7 @@ func (rttc *raftTransportTestContext) AddNodeWithoutGossip(
 	transport := storage.NewRaftTransport(
 		log.AmbientContext{Tracer: tracing.NewTracer()},
 		cluster.MakeTestingClusterSettings(),
-		storage.GossipAddressResolver(rttc.gossip),
+		nodedialer.New(rttc.nodeRPCContext, storage.GossipAddressResolver(rttc.gossip)),
 		grpcServer,
 		rttc.nodeRPCContext,
 	)

--- a/pkg/storage/raft_transport_test.go
+++ b/pkg/storage/raft_transport_test.go
@@ -152,7 +152,7 @@ func (rttc *raftTransportTestContext) AddNodeWithoutGossip(
 		cluster.MakeTestingClusterSettings(),
 		nodedialer.New(rttc.nodeRPCContext, storage.GossipAddressResolver(rttc.gossip)),
 		grpcServer,
-		rttc.nodeRPCContext,
+		rttc.stopper,
 	)
 	rttc.transports[nodeID] = transport
 	ln, err := netutil.ListenAndServeGRPC(stopper, grpcServer, addr)

--- a/pkg/storage/raft_transport_unit_test.go
+++ b/pkg/storage/raft_transport_unit_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -63,7 +64,7 @@ func TestRaftTransportStartNewQueue(t *testing.T) {
 	tp := NewRaftTransport(
 		log.AmbientContext{Tracer: tracing.NewTracer()},
 		cluster.MakeTestingClusterSettings(),
-		resolver,
+		nodedialer.New(rpcC, resolver),
 		grpcServer,
 		rpcC,
 	)

--- a/pkg/storage/raft_transport_unit_test.go
+++ b/pkg/storage/raft_transport_unit_test.go
@@ -66,7 +66,7 @@ func TestRaftTransportStartNewQueue(t *testing.T) {
 		cluster.MakeTestingClusterSettings(),
 		nodedialer.New(rpcC, resolver),
 		grpcServer,
-		rpcC,
+		stopper,
 	)
 
 	ln, err := netutil.ListenAndServeGRPC(stopper, grpcServer, &util.UnresolvedAddr{NetworkField: "tcp", AddressField: "localhost:0"})

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1134,11 +1134,7 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	for _, rep := range r.mu.state.Desc.Replicas {
 		// Only consider followers that that have "healthy" RPC connections.
 
-		addr, err := r.store.cfg.Transport.resolver(rep.NodeID)
-		if err != nil {
-			continue
-		}
-		if err := r.store.cfg.Transport.rpcContext.ConnHealth(addr.String()); err != nil {
+		if err := r.store.cfg.NodeDialer.ConnHealth(rep.NodeID); err != nil {
 			continue
 		}
 

--- a/pkg/storage/replica_consistency.go
+++ b/pkg/storage/replica_consistency.go
@@ -177,15 +177,10 @@ type ConsistencyCheckResult struct {
 func (r *Replica) collectChecksumFromReplica(
 	ctx context.Context, replica roachpb.ReplicaDescriptor, id uuid.UUID, checksum []byte,
 ) (CollectChecksumResponse, error) {
-	addr, err := r.store.cfg.Transport.resolver(replica.NodeID)
-	if err != nil {
-		return CollectChecksumResponse{}, errors.Wrapf(err, "could not resolve node ID %d",
-			replica.NodeID)
-	}
-	conn, err := r.store.cfg.Transport.rpcContext.GRPCDial(addr.String()).Connect(ctx)
+	conn, err := r.store.cfg.NodeDialer.Dial(ctx, replica.NodeID)
 	if err != nil {
 		return CollectChecksumResponse{},
-			errors.Wrapf(err, "could not dial node ID %d address %s", replica.NodeID, addr)
+			errors.Wrapf(err, "could not dial node ID %d", replica.NodeID)
 	}
 	client := NewConsistencyClient(conn)
 	req := &CollectChecksumRequest{

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -25,6 +25,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/util/limit"
 
 	"github.com/coreos/etcd/raft"
@@ -556,6 +557,7 @@ type StoreConfig struct {
 	NodeLiveness *NodeLiveness
 	StorePool    *StorePool
 	Transport    *RaftTransport
+	NodeDialer   *nodedialer.Dialer
 	RPCContext   *rpc.Context
 
 	// SQLExecutor is used by the store to execute SQL statements.


### PR DESCRIPTION
Add a NodeDialer to Server and use it in storage.

The NodeDialer was previously only used in raft_transport, now it is used for other purposes in storage too.