### PR TITLE
opt: support SRFs in the FROM clause

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -92,13 +92,6 @@ SELECT job_id FROM crdb_internal.jobs
 ----
 
 query I rowsort
-SELECT * FROM generate_series(1, 3)
-----
-1
-2
-3
-
-query I rowsort
 SELECT generate_series(1, 2)
 ----
 1
@@ -119,9 +112,6 @@ SELECT * FROM tview
 
 query error pq: virtual tables are not supported
 SELECT job_id FROM crdb_internal.jobs
-
-query error pq: not yet implemented: table expr: \*tree\.RowsFromExpr
-SELECT * FROM generate_series(1, 3)
 
 query error pq: generator functions are not supported
 SELECT generate_series(1, 2)

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -1,21 +1,31 @@
-# LogicTest: local
-#
-# TODO(radu): enable once SRF's are supported
-#
-#subtest generate_series
-#
-#query TTT
-#EXPLAIN SELECT * FROM generate_series(1, 3)
-#----
-#generator  ·  ·
-#
-#query TTT
-#EXPLAIN SELECT * FROM generate_series(1, 2), generate_series(1, 2)
-#----
-#join            ·     ·
-# │              type  cross
-# ├── generator  ·     ·
-# └── generator  ·     ·
+# LogicTest: local-opt
+
+subtest generate_series
+
+query TTT
+EXPLAIN SELECT * FROM generate_series(1, 3)
+----
+project set    ·  ·
+ └── emptyrow  ·  ·
+
+query TTT
+EXPLAIN SELECT * FROM generate_series(1, 2), generate_series(1, 2)
+----
+join                ·     ·
+ │                  type  cross
+ ├── project set    ·     ·
+ │    └── emptyrow  ·     ·
+ └── project set    ·     ·
+      └── emptyrow  ·     ·
+
+query TTT
+EXPLAIN SELECT * FROM ROWS FROM (cos(1))
+----
+project set    ·  ·
+ └── emptyrow  ·  ·
+
+
+# TODO(radu): enable once SRF's are supported in the Select list.
 #
 #query TTT
 #EXPLAIN SELECT generate_series(1, 3)

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -131,6 +131,11 @@ type Factory interface {
 	// set to nil.
 	ConstructLimit(input Node, limit, offset tree.TypedExpr) (Node, error)
 
+	// ConstructProjectSet returns a node that performs a lateral cross join
+	// between the output of the given node and the functional zip of the given
+	// expressions.
+	ConstructProjectSet(n Node, exprs tree.TypedExprs, cols sqlbase.ResultColumns) (Node, error)
+
 	// RenameColumns modifies the column names of a node.
 	RenameColumns(input Node, colNames []string) (Node, error)
 

--- a/pkg/sql/opt/memo/testdata/stats/srfs
+++ b/pkg/sql/opt/memo/testdata/stats/srfs
@@ -1,0 +1,58 @@
+opt
+SELECT a.*, b.*, c.* FROM upper('abc') a
+JOIN ROWS FROM (upper('def'), generate_series(1, 3), upper('ghi')) b ON true
+JOIN generate_series(1, 4) c ON true
+----
+inner-join
+ ├── columns: a:1(string) upper:2(string) generate_series:3(int) upper:4(string) c:5(int)
+ ├── stats: [rows=1000000]
+ ├── inner-join
+ │    ├── columns: upper:1(string) upper:2(string) generate_series:3(int) upper:4(string)
+ │    ├── stats: [rows=1000]
+ │    ├── zip
+ │    │    ├── columns: upper:2(string) generate_series:3(int) upper:4(string)
+ │    │    ├── stats: [rows=1000]
+ │    │    ├── function: upper [type=string]
+ │    │    │    └── const: 'def' [type=string]
+ │    │    ├── function: generate_series [type=tuple{int AS generate_series}]
+ │    │    │    ├── const: 1 [type=int]
+ │    │    │    └── const: 3 [type=int]
+ │    │    └── function: upper [type=string]
+ │    │         └── const: 'ghi' [type=string]
+ │    ├── zip
+ │    │    ├── columns: upper:1(string)
+ │    │    ├── stats: [rows=1]
+ │    │    └── function: upper [type=string]
+ │    │         └── const: 'abc' [type=string]
+ │    └── true [type=bool]
+ ├── zip
+ │    ├── columns: generate_series:5(int)
+ │    ├── stats: [rows=1000]
+ │    └── function: generate_series [type=tuple{int AS generate_series}]
+ │         ├── const: 1 [type=int]
+ │         └── const: 4 [type=int]
+ └── true [type=bool]
+
+opt
+SELECT * FROM (SELECT * FROM upper('abc') a, generate_series(1, 2) b) GROUP BY a, b
+----
+group-by
+ ├── columns: a:1(string) b:2(int)
+ ├── grouping columns: upper:1(string) generate_series:2(int)
+ ├── stats: [rows=700, distinct(1,2)=700]
+ ├── key: (1,2)
+ └── inner-join
+      ├── columns: upper:1(string) generate_series:2(int)
+      ├── stats: [rows=1000, distinct(1,2)=700]
+      ├── zip
+      │    ├── columns: generate_series:2(int)
+      │    ├── stats: [rows=1000, distinct(2)=700]
+      │    └── function: generate_series [type=tuple{int AS generate_series}]
+      │         ├── const: 1 [type=int]
+      │         └── const: 2 [type=int]
+      ├── zip
+      │    ├── columns: upper:1(string)
+      │    ├── stats: [rows=1, distinct(1)=1]
+      │    └── function: upper [type=string]
+      │         └── const: 'abc' [type=string]
+      └── true [type=bool]

--- a/pkg/sql/opt/norm/rule_props_builder.go
+++ b/pkg/sql/opt/norm/rule_props_builder.go
@@ -91,6 +91,9 @@ func (b *rulePropsBuilder) buildProps(ev memo.ExprView) {
 		// IndexJoin is constructed. Additionally, there is not currently a
 		// PruneCols rule for these operators.
 
+	case opt.ZipOp:
+		b.buildZipProps(ev)
+
 	case opt.ExplainOp, opt.ShowTraceForSessionOp:
 		// Don't allow any columns to be pruned, since that would trigger the
 		// creation of a wrapper Project around the Explain (it's not capable
@@ -213,4 +216,10 @@ func (b *rulePropsBuilder) buildRowNumberProps(ev memo.ExprView) {
 	// not used as an ordering column. The new row number column cannot be pruned
 	// without adding an additional Project operator, so don't add it to the set.
 	relational.Rule.PruneCols = inputProps.Rule.PruneCols.Difference(ordering)
+}
+
+func (b *rulePropsBuilder) buildZipProps(ev memo.ExprView) {
+	// Don't allow any columns to be pruned, since that would trigger the
+	// creation of a wrapper Project around the Zip, and there's not yet a
+	// PruneCols rule for Zip.
 }

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -64,8 +64,8 @@ define Select {
 # synthesized output columns.
 [Relational]
 define Project {
-    Input           Expr
-    Projections     Expr
+    Input       Expr
+    Projections Expr
 }
 
 # InnerJoin creates a result set that combines columns from its left and right
@@ -366,4 +366,30 @@ define ShowTraceForSession {
 define RowNumber {
     Input    Expr
     Def      RowNumberDef
+}
+
+# Zip represents a functional zip over generators a,b,c, which returns tuples of
+# values from a,b,c picked "simultaneously". NULLs are used when a generator is
+# "shorter" than another. In SQL, these generators can be either a generator
+# function such as generate_series(), or a scalar function such as
+# upper(). For example, consider this query:
+#
+#    SELECT * FROM ROWS FROM (generate_series(0, 1), upper('abc'));
+#
+# It is equivalent to (Zip [(Function generate_series), (Function upper)]).
+# It produces:
+#
+#     generate_series | upper
+#    -----------------+-------
+#                   0 | ABC
+#                   1 | NULL
+#
+# In the Zip operation, Funcs represents the list of functions, and Cols
+# represents the columns output by the functions. Funcs and Cols might not be
+# the same length since a single function may output multiple columns
+# (e.g., pg_get_keywords() outputs three columns).
+[Relational]
+define Zip {
+    Funcs ExprList
+    Cols  ColList
 }

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -164,7 +164,7 @@ func (b *Builder) finishBuildScalar(
 	if col := outScope.findExistingCol(texpr); col != nil {
 		col = outScope.appendColumn(col, label)
 		col.group = group
-		return
+		return group
 	}
 
 	b.synthesizeColumn(outScope, label, texpr.ResolvedType(), texpr, group)

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -419,7 +419,7 @@ func (b *Builder) buildFunction(
 	}
 
 	// TODO(andyk): Re-enable impure functions once we can properly handle them.
-	if def.Impure && !b.AllowImpureFuncs {
+	if def.Impure && !isGenerator(def) && !b.AllowImpureFuncs {
 		panic(unimplementedf("impure functions are not supported"))
 	}
 
@@ -432,6 +432,10 @@ func (b *Builder) buildFunction(
 	out = b.factory.ConstructFunction(
 		b.factory.InternList(argList), b.factory.InternFuncOpDef(&funcDef),
 	)
+
+	if isGenerator(def) {
+		return b.finishBuildGeneratorFunction(f, out, inScope, outScope)
+	}
 
 	return b.finishBuildScalar(f, out, label, inScope, outScope)
 }

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -1,0 +1,87 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package optbuilder
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+// buildZip builds a set of memo groups which represent a functional zip over
+// the given expressions.
+//
+// Reminder, for context: the functional zip over iterators a,b,c
+// returns tuples of values from a,b,c picked "simultaneously". NULLs
+// are used when an iterator is "shorter" than another. For example:
+//
+//    zip([1,2,3], ['a','b']) = [(1,'a'), (2,'b'), (3, null)]
+//
+func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
+	outScope = inScope.push()
+
+	// Build each of the provided expressions.
+	elems := make([]memo.GroupID, len(exprs))
+	for i, expr := range exprs {
+		b.assertNoAggregationOrWindowing(expr, "FROM")
+
+		// Output column names should exactly match the original expression, so we
+		// have to determine the output column name before we perform type
+		// checking.
+		_, label, err := tree.ComputeColNameInternal(b.semaCtx.SearchPath, expr)
+		if err != nil {
+			panic(builderError{err})
+		}
+
+		// Set the flag to allow generator functions. It needs to be reset for each
+		// expression since it is set to false once an SRF is seen to disallow
+		// nested SRFs.
+		// TODO(rytaft): This is a temporary solution and will need to change once
+		// we support SRFs in the SELECT list.
+		inScope.allowGeneratorFunc = true
+
+		texpr := inScope.resolveType(expr, types.Any)
+		elems[i] = b.buildScalarHelper(texpr, label, inScope, outScope)
+	}
+
+	// Get the output columns of the Zip operation and construct the Zip.
+	colList := make(opt.ColList, len(outScope.cols))
+	for i := 0; i < len(colList); i++ {
+		colList[i] = outScope.cols[i].id
+	}
+	outScope.group = b.factory.ConstructZip(
+		b.factory.InternList(elems), b.factory.InternColList(colList),
+	)
+
+	return outScope
+}
+
+// finishBuildGeneratorFunction finishes building a set-generating function
+// (SRF) such as generate_series() or unnest(). It synthesizes new columns in
+// outScope for each of the SRF's output columns.
+func (b *Builder) finishBuildGeneratorFunction(
+	f *tree.FuncExpr, group memo.GroupID, inScope, outScope *scope,
+) (out memo.GroupID) {
+	typ := f.ResolvedType().(types.TTuple)
+
+	// Add scope columns. Use the tuple labels in the SRF's return type as column
+	// labels.
+	for i := range typ.Types {
+		b.synthesizeColumn(outScope, typ.Labels[i], typ.Types[i], nil, group)
+	}
+
+	return group
+}

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -400,37 +400,75 @@ error (42P01): no data source matches prefix: a
 build
 SELECT generate_series FROM generate_series(1, 100) ORDER BY ARRAY[generate_series]
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+error (0A000): can't order by column type int[]
 
 build
 SELECT ARRAY[generate_series] FROM generate_series(1, 100) ORDER BY ARRAY[generate_series]
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+error (0A000): can't order by column type int[]
 
 build
 SELECT ARRAY[generate_series] FROM generate_series(1, 100) ORDER BY 1
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+error (0A000): can't order by column type int[]
 
 build
 SELECT ARRAY[generate_series] AS a FROM generate_series(1, 100) ORDER BY a
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+error (0A000): can't order by column type int[]
 
 build
 SELECT generate_series, ARRAY[generate_series] FROM generate_series(1, 1) ORDER BY 1
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+sort
+ ├── columns: generate_series:1(int) array:2(int[])
+ ├── ordering: +1
+ └── project
+      ├── columns: array:2(int[]) generate_series:1(int)
+      ├── zip
+      │    ├── columns: generate_series:1(int)
+      │    └── function: generate_series [type=tuple{int AS generate_series}]
+      │         ├── const: 1 [type=int]
+      │         └── const: 1 [type=int]
+      └── projections
+           └── array: [type=int[]]
+                └── variable: generate_series [type=int]
 
 build
 SELECT generate_series, ARRAY[generate_series] FROM generate_series(1, 1) ORDER BY generate_series
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+sort
+ ├── columns: generate_series:1(int) array:2(int[])
+ ├── ordering: +1
+ └── project
+      ├── columns: array:2(int[]) generate_series:1(int)
+      ├── zip
+      │    ├── columns: generate_series:1(int)
+      │    └── function: generate_series [type=tuple{int AS generate_series}]
+      │         ├── const: 1 [type=int]
+      │         └── const: 1 [type=int]
+      └── projections
+           └── array: [type=int[]]
+                └── variable: generate_series [type=int]
 
 build
 SELECT generate_series, ARRAY[generate_series] FROM generate_series(1, 1) ORDER BY -generate_series
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+sort
+ ├── columns: generate_series:1(int) array:2(int[])
+ ├── ordering: +3
+ └── project
+      ├── columns: array:2(int[]) column3:3(int) generate_series:1(int)
+      ├── zip
+      │    ├── columns: generate_series:1(int)
+      │    └── function: generate_series [type=tuple{int AS generate_series}]
+      │         ├── const: 1 [type=int]
+      │         └── const: 1 [type=int]
+      └── projections
+           ├── array: [type=int[]]
+           │    └── variable: generate_series [type=int]
+           └── unary-minus [type=int]
+                └── variable: generate_series [type=int]
 
 
 # Sort should be skipped if the ORDER BY clause is constant.

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -5,27 +5,57 @@
 build
 SELECT * FROM generate_series(1, 3)
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+zip
+ ├── columns: generate_series:1(int)
+ └── function: generate_series [type=tuple{int AS generate_series}]
+      ├── const: 1 [type=int]
+      └── const: 3 [type=int]
 
 build
 SELECT * FROM generate_series(1, 2), generate_series(1, 2)
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+inner-join
+ ├── columns: generate_series:1(int) generate_series:2(int)
+ ├── zip
+ │    ├── columns: generate_series:1(int)
+ │    └── function: generate_series [type=tuple{int AS generate_series}]
+ │         ├── const: 1 [type=int]
+ │         └── const: 2 [type=int]
+ ├── zip
+ │    ├── columns: generate_series:2(int)
+ │    └── function: generate_series [type=tuple{int AS generate_series}]
+ │         ├── const: 1 [type=int]
+ │         └── const: 2 [type=int]
+ └── true [type=bool]
 
 build
 SELECT * FROM pg_catalog.generate_series(1, 3)
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+zip
+ ├── columns: generate_series:1(int)
+ └── function: generate_series [type=tuple{int AS generate_series}]
+      ├── const: 1 [type=int]
+      └── const: 3 [type=int]
 
 build
 SELECT * FROM generate_series(1, 1) AS c(x)
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+zip
+ ├── columns: x:1(int)
+ └── function: generate_series [type=tuple{int AS generate_series}]
+      ├── const: 1 [type=int]
+      └── const: 1 [type=int]
 
 build
 SELECT * FROM generate_series(1, 1) WITH ORDINALITY AS c(x, y)
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+row-number
+ ├── columns: x:1(int) y:2(int!null)
+ └── zip
+      ├── columns: generate_series:1(int)
+      └── function: generate_series [type=tuple{int AS generate_series}]
+           ├── const: 1 [type=int]
+           └── const: 1 [type=int]
 
 build
 SELECT * FROM (VALUES (1)) LIMIT generate_series(1, 3)
@@ -60,12 +90,46 @@ TABLE u
 build
 SELECT t.*, u.*, a.*, b.* FROM t, u, generate_series(1, 2) AS a, generate_series(3, 4) AS b
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+project
+ ├── columns: a:1(string) b:3(string) a:5(int) b:6(int)
+ └── inner-join
+      ├── columns: a:1(string) t.rowid:2(int!null) b:3(string) u.rowid:4(int!null) generate_series:5(int) generate_series:6(int)
+      ├── inner-join
+      │    ├── columns: a:1(string) t.rowid:2(int!null) b:3(string) u.rowid:4(int!null) generate_series:5(int)
+      │    ├── inner-join
+      │    │    ├── columns: a:1(string) t.rowid:2(int!null) b:3(string) u.rowid:4(int!null)
+      │    │    ├── scan t
+      │    │    │    └── columns: a:1(string) t.rowid:2(int!null)
+      │    │    ├── scan u
+      │    │    │    └── columns: b:3(string) u.rowid:4(int!null)
+      │    │    └── true [type=bool]
+      │    ├── zip
+      │    │    ├── columns: generate_series:5(int)
+      │    │    └── function: generate_series [type=tuple{int AS generate_series}]
+      │    │         ├── const: 1 [type=int]
+      │    │         └── const: 2 [type=int]
+      │    └── true [type=bool]
+      ├── zip
+      │    ├── columns: generate_series:6(int)
+      │    └── function: generate_series [type=tuple{int AS generate_series}]
+      │         ├── const: 3 [type=int]
+      │         └── const: 4 [type=int]
+      └── true [type=bool]
 
 build
 SELECT 3 + x FROM generate_series(1,2) AS a(x)
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+project
+ ├── columns: "?column?":2(int)
+ ├── zip
+ │    ├── columns: generate_series:1(int)
+ │    └── function: generate_series [type=tuple{int AS generate_series}]
+ │         ├── const: 1 [type=int]
+ │         └── const: 2 [type=int]
+ └── projections
+      └── plus [type=int]
+           ├── const: 3 [type=int]
+           └── variable: generate_series [type=int]
 
 build
 SELECT 3 + (3 * generate_series(1,3))
@@ -77,7 +141,12 @@ error (0A000): generator functions are not supported
 build
 SELECT * from unnest(ARRAY[1,2])
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+zip
+ ├── columns: unnest:1(int)
+ └── function: unnest [type=tuple{int AS unnest}]
+      └── array: [type=int[]]
+           ├── const: 1 [type=int]
+           └── const: 2 [type=int]
 
 build
 SELECT unnest(ARRAY[1,2]), unnest(ARRAY['a', 'b'])
@@ -123,7 +192,18 @@ error (42703): column "generate_series" does not exist
 build
 SELECT * from generate_series(1, (select * from generate_series(1, 0)))
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+zip
+ ├── columns: generate_series:2(int)
+ └── function: generate_series [type=tuple{int AS generate_series}]
+      ├── const: 1 [type=int]
+      └── subquery [type=int]
+           └── max1-row
+                ├── columns: generate_series:1(int)
+                └── zip
+                     ├── columns: generate_series:1(int)
+                     └── function: generate_series [type=tuple{int AS generate_series}]
+                          ├── const: 1 [type=int]
+                          └── const: 0 [type=int]
 
 # The following query is designed to produce a null array argument to unnest
 # in a way that the type system can't detect before evaluation.
@@ -138,14 +218,50 @@ error (0A000): generator functions are not supported
 build
 SELECT * FROM pg_get_keywords() WHERE word IN ('alter', 'and', 'between', 'cross') ORDER BY word
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+sort
+ ├── columns: word:1(string!null) catcode:2(string) catdesc:3(string)
+ ├── ordering: +1
+ └── select
+      ├── columns: word:1(string!null) catcode:2(string) catdesc:3(string)
+      ├── zip
+      │    ├── columns: word:1(string) catcode:2(string) catdesc:3(string)
+      │    └── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
+      └── filters [type=bool]
+           └── in [type=bool]
+                ├── variable: word [type=string]
+                └── tuple [type=tuple{string, string, string, string}]
+                     ├── const: 'alter' [type=string]
+                     ├── const: 'and' [type=string]
+                     ├── const: 'between' [type=string]
+                     └── const: 'cross' [type=string]
 
 # Postgres enables renaming both the source and the column name for
 # single-column generators, but not for multi-column generators.
 build
 SELECT a.*, b.*, c.* FROM generate_series(1,1) a, unnest(ARRAY[1]) b, pg_get_keywords() c LIMIT 0
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+limit
+ ├── columns: a:1(int) b:2(int) word:3(string) catcode:4(string) catdesc:5(string)
+ ├── inner-join
+ │    ├── columns: generate_series:1(int) unnest:2(int) word:3(string) catcode:4(string) catdesc:5(string)
+ │    ├── inner-join
+ │    │    ├── columns: generate_series:1(int) unnest:2(int)
+ │    │    ├── zip
+ │    │    │    ├── columns: generate_series:1(int)
+ │    │    │    └── function: generate_series [type=tuple{int AS generate_series}]
+ │    │    │         ├── const: 1 [type=int]
+ │    │    │         └── const: 1 [type=int]
+ │    │    ├── zip
+ │    │    │    ├── columns: unnest:2(int)
+ │    │    │    └── function: unnest [type=tuple{int AS unnest}]
+ │    │    │         └── array: [type=int[]]
+ │    │    │              └── const: 1 [type=int]
+ │    │    └── true [type=bool]
+ │    ├── zip
+ │    │    ├── columns: word:3(string) catcode:4(string) catdesc:5(string)
+ │    │    └── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
+ │    └── true [type=bool]
+ └── const: 0 [type=int]
 
 # Beware of multi-valued SRFs in render position (#19149)
 build
@@ -171,14 +287,21 @@ error (0A000): generator functions are not supported
 build
 SELECT * FROM upper('abc')
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+zip
+ ├── columns: upper:1(string)
+ └── function: upper [type=string]
+      └── const: 'abc' [type=string]
 
 # current_schema
 
 build
 SELECT * FROM current_schema() WITH ORDINALITY AS a(b)
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+row-number
+ ├── columns: b:1(string) ordinality:2(int!null)
+ └── zip
+      ├── columns: current_schema:1(string)
+      └── function: current_schema [type=string]
 
 # expandArray
 
@@ -190,7 +313,12 @@ error (0A000): generator functions are not supported
 build
 SELECT * FROM information_schema._pg_expandarray(ARRAY['b', 'a'])
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+zip
+ ├── columns: x:1(string) n:2(int)
+ └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
+      └── array: [type=string[]]
+           ├── const: 'b' [type=string]
+           └── const: 'a' [type=string]
 
 # srf_accessor
 
@@ -227,21 +355,108 @@ error (0A000): generator functions are not supported
 build
 SELECT temp.n from information_schema._pg_expandarray(ARRAY['c','b','a']) AS temp;
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+project
+ ├── columns: n:2(int)
+ └── zip
+      ├── columns: x:1(string) n:2(int)
+      └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
+           └── array: [type=string[]]
+                ├── const: 'c' [type=string]
+                ├── const: 'b' [type=string]
+                └── const: 'a' [type=string]
 
 build
 SELECT temp.* from information_schema._pg_expandarray(ARRAY['c','b','a']) AS temp;
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+zip
+ ├── columns: x:1(string) n:2(int)
+ └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
+      └── array: [type=string[]]
+           ├── const: 'c' [type=string]
+           ├── const: 'b' [type=string]
+           └── const: 'a' [type=string]
 
 build
 SELECT * from information_schema._pg_expandarray(ARRAY['c','b','a']) AS temp;
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+zip
+ ├── columns: x:1(string) n:2(int)
+ └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
+      └── array: [type=string[]]
+           ├── const: 'c' [type=string]
+           ├── const: 'b' [type=string]
+           └── const: 'a' [type=string]
 
 # generate_subscripts
 
 build
 SELECT * FROM generate_subscripts(ARRAY[3,2,1])
 ----
-error (0A000): not yet implemented: table expr: *tree.RowsFromExpr
+zip
+ ├── columns: generate_subscripts:1(int)
+ └── function: generate_subscripts [type=tuple{int AS generate_subscripts}]
+      └── array: [type=int[]]
+           ├── const: 3 [type=int]
+           ├── const: 2 [type=int]
+           └── const: 1 [type=int]
+
+# Zip with multiple SRFs.
+build
+SELECT * FROM
+ROWS FROM (generate_series(0, 1), generate_series(1, 3), pg_get_keywords(), unnest(ARRAY['a', 'b', 'c']))
+----
+zip
+ ├── columns: generate_series:1(int) generate_series:2(int) word:3(string) catcode:4(string) catdesc:5(string) unnest:6(string)
+ ├── function: generate_series [type=tuple{int AS generate_series}]
+ │    ├── const: 0 [type=int]
+ │    └── const: 1 [type=int]
+ ├── function: generate_series [type=tuple{int AS generate_series}]
+ │    ├── const: 1 [type=int]
+ │    └── const: 3 [type=int]
+ ├── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
+ └── function: unnest [type=tuple{string AS unnest}]
+      └── array: [type=string[]]
+           ├── const: 'a' [type=string]
+           ├── const: 'b' [type=string]
+           └── const: 'c' [type=string]
+
+# Don't rename columns if the zip contains two functions.
+build
+SELECT a.*, b.*, c.* FROM upper('abc') a
+JOIN ROWS FROM (upper('def'), generate_series(1, 3)) b ON true
+JOIN generate_series(1, 4) c ON true
+----
+inner-join
+ ├── columns: a:1(string) upper:2(string) generate_series:3(int) c:4(int)
+ ├── inner-join
+ │    ├── columns: upper:1(string) upper:2(string) generate_series:3(int)
+ │    ├── zip
+ │    │    ├── columns: upper:1(string)
+ │    │    └── function: upper [type=string]
+ │    │         └── const: 'abc' [type=string]
+ │    ├── zip
+ │    │    ├── columns: upper:2(string) generate_series:3(int)
+ │    │    ├── function: upper [type=string]
+ │    │    │    └── const: 'def' [type=string]
+ │    │    └── function: generate_series [type=tuple{int AS generate_series}]
+ │    │         ├── const: 1 [type=int]
+ │    │         └── const: 3 [type=int]
+ │    └── filters [type=bool]
+ │         └── true [type=bool]
+ ├── zip
+ │    ├── columns: generate_series:4(int)
+ │    └── function: generate_series [type=tuple{int AS generate_series}]
+ │         ├── const: 1 [type=int]
+ │         └── const: 4 [type=int]
+ └── filters [type=bool]
+      └── true [type=bool]
+
+build
+SELECT * FROM ROWS FROM (generate_series(generate_series(1,2),3))
+----
+error (0A000): generator functions are not supported
+
+build
+SELECT * FROM ROWS FROM (generate_series((generate_series(1,2)).generate_series,3))
+----
+error (0A000): generator functions are not supported

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -479,6 +479,41 @@ func (ef *execFactory) ConstructLimit(
 	}, nil
 }
 
+// ConstructProjectSet is part of the exec.Factory interface.
+func (ef *execFactory) ConstructProjectSet(
+	n exec.Node, exprs tree.TypedExprs, cols sqlbase.ResultColumns,
+) (exec.Node, error) {
+	src := asDataSource(n)
+	p := &projectSetNode{
+		source:          src.plan,
+		sourceInfo:      src.info,
+		columns:         cols,
+		numColsInSource: len(src.info.SourceColumns),
+		exprs:           exprs,
+		funcs:           make([]*tree.FuncExpr, len(exprs)),
+		numColsPerGen:   make([]int, len(exprs)),
+		run: projectSetRun{
+			gens:      make([]tree.ValueGenerator, len(exprs)),
+			done:      make([]bool, len(exprs)),
+			rowBuffer: make(tree.Datums, len(cols)),
+		},
+	}
+
+	for i, expr := range exprs {
+		if tFunc, ok := expr.(*tree.FuncExpr); ok && tFunc.IsGeneratorApplication() {
+			// Set-generating functions: generate_series() etc.
+			tType := expr.ResolvedType().(types.TTuple)
+			p.funcs[i] = tFunc
+			p.numColsPerGen[i] = len(tType.Types)
+		} else {
+			// A simple non-generator expression.
+			p.numColsPerGen[i] = 1
+		}
+	}
+
+	return p, nil
+}
+
 // ConstructPlan is part of the exec.Factory interface.
 func (ef *execFactory) ConstructPlan(
 	root exec.Node, subqueries []exec.Subquery,


### PR DESCRIPTION
This commit adds support for SRFs and scalar functions in the `FROM` clause by
adding a new relational operator called `Zip`.

`Zip` represents a functional zip over iterators a,b,c, which returns tuples of
values from a,b,c picked "simultaneously". NULLs are used when an iterator is
"shorter" than another. For example:

    zip([1,2,3], ['a','b']) = [(1,'a'), (2,'b'), (3, null)]

Given an SRF or scalar function in the `FROM` clause, the optbuilder
builds a relational `Zip` operator with the function(s) as iterators. The optimizer
calculates basic logical properties and statistics for the `Zip`, but currently does
not attempt to optimize the expression. The exec builder converts a `Zip` operator
back to a `projectSetNode` so it can be executed.

A subsequent PR will support SRFs in the `SELECT` list.

Release note: None