### PR TITLE
storage: Disable a spammy log line in allocator_test

### DIFF
--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -5266,7 +5266,9 @@ func TestAllocatorFullDisks(t *testing.T) {
 						false,
 					)
 					if target != nil {
-						log.Infof(ctx, "rebalancing to %v; details: %s", target, details)
+						if log.V(1) {
+							log.Infof(ctx, "rebalancing to %v; details: %s", target, details)
+						}
 						testStores[k].rebalance(&testStores[int(target.StoreID)], rangeSize)
 					}
 				}


### PR DESCRIPTION
This line accounts for 60% of the data logged during a test run of the
full storage package (50MB before this change, 20MB after), and 25% of
the lines (20k vs 15k).

Release note: None