### PR TITLE
roachpb: create new isPrefix request flag

### DIFF
--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -111,6 +111,7 @@ const (
 	isRange                    // range commands may span multiple keys
 	isReverse                  // reverse commands traverse ranges in descending direction
 	isAlone                    // requests which must be alone in a batch
+	isPrefix                   // requests which should be grouped with the next request in a batch
 	isUnsplittable             // range command that must not be split during sending
 	// Requests for acquiring a lease skip the (proposal-time) check that the
 	// proposing replica has a valid lease.
@@ -1043,10 +1044,10 @@ func (*QueryTxnRequest) flags() int            { return isRead | isAlone }
 // QueryIntent only updates the read timestamp cache when attempting
 // to prevent an intent that is found missing from ever being written
 // in the future. See QueryIntentRequest_PREVENT.
-func (*QueryIntentRequest) flags() int        { return isRead | updatesReadTSCache }
+func (*QueryIntentRequest) flags() int        { return isRead | isPrefix | updatesReadTSCache }
 func (*ResolveIntentRequest) flags() int      { return isWrite }
 func (*ResolveIntentRangeRequest) flags() int { return isWrite | isRange }
-func (*NoopRequest) flags() int               { return isRead } // slightly special
+func (*NoopRequest) flags() int               { return 0 }
 func (*TruncateLogRequest) flags() int        { return isWrite }
 func (*MergeRequest) flags() int              { return isWrite }
 


### PR DESCRIPTION
Addresses a TODO in #26599.

This change introduces a new `isHeader` request flag, which indicates that
a request should be grouped with the next request in a batch, if possible.
It then adds this flag to `QueryIntentRequest`.

The change also cleans up `BatchRequest.Split`, for some definition of clean.
To do so, it tries to rationalize the incompatibility between `isAlone`
requests and requests that are compatible with all other requests. It does
so by favoring `isAlone` requests, giving them a stricter contract.

Release note: None