### PR TITLE
acceptanceccl: add validators for our correctness guarantees

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"context"
 	gosql "database/sql"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
@@ -27,6 +28,33 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 )
+
+func parseMetaTimestamps(v []byte) (updated, resolved hlc.Timestamp, err error) {
+	var valueRaw struct {
+		CRDB struct {
+			Resolved string `json:"resolved"`
+			Updated  string `json:"updated"`
+		} `json:"__crdb__"`
+	}
+	if err := json.Unmarshal(v, &valueRaw); err != nil {
+		return hlc.Timestamp{}, hlc.Timestamp{}, err
+	}
+	if valueRaw.CRDB.Updated != `` {
+		var err error
+		updated, err = sql.ParseHLC(valueRaw.CRDB.Updated)
+		if err != nil {
+			return hlc.Timestamp{}, hlc.Timestamp{}, err
+		}
+	}
+	if valueRaw.CRDB.Resolved != `` {
+		var err error
+		resolved, err = sql.ParseHLC(valueRaw.CRDB.Resolved)
+		if err != nil {
+			return hlc.Timestamp{}, hlc.Timestamp{}, err
+		}
+	}
+	return updated, resolved, nil
+}
 
 // createBenchmarkChangefeed starts a changefeed with some extra hooks. It
 // watches `database.table` and outputs to `sinkURI`. The given `feedClock` is

--- a/pkg/ccl/changefeedccl/validations_test.go
+++ b/pkg/ccl/changefeedccl/validations_test.go
@@ -1,0 +1,124 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"context"
+	gosql "database/sql"
+	"math/rand"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/bank"
+)
+
+func TestValidations(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer utilccl.TestingEnableEnterprise()()
+
+	ctx := context.Background()
+	s, sqlDBRaw, _ := serverutils.StartServer(t, base.TestServerArgs{
+		UseDatabase: "bank",
+	})
+	defer s.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
+	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
+
+	t.Run("bank", func(t *testing.T) {
+		const numRows, numRanges, payloadBytes, maxTransfer = 10, 10, 10, 999
+		sqlDB.Exec(t, `CREATE DATABASE bank`)
+		gen := bank.FromConfig(numRows, payloadBytes, numRanges)
+		if _, err := workload.Setup(ctx, sqlDB.DB, gen, 0, 0); err != nil {
+			t.Fatal(err)
+		}
+
+		rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR bank WITH timestamps`)
+		defer closeFeedRowsHack(t, sqlDB, rows)
+
+		var done int64
+		g := ctxgroup.WithContext(ctx)
+		g.GoCtx(func(ctx context.Context) error {
+			for {
+				if atomic.LoadInt64(&done) > 0 {
+					return nil
+				}
+
+				// TODO(dan): This bit is copied from the bank workload. It's
+				// currently much easier to do this than to use the real Ops,
+				// which is silly. Fixme.
+				from := rand.Intn(numRows)
+				to := rand.Intn(numRows)
+				for from == to {
+					to = rand.Intn(numRows)
+				}
+				amount := rand.Intn(maxTransfer)
+				if _, err := sqlDB.DB.Exec(`UPDATE bank.bank
+					SET balance = CASE id WHEN $1 THEN balance-$3 WHEN $2 THEN balance+$3 END
+					WHERE id IN ($1, $2)
+				`, from, to, amount); err != nil {
+					return err
+				}
+			}
+		})
+
+		const requestedResolved = 100
+		var numResolved, rowsSinceResolved int
+		v := Validators{
+			NewOrderValidator(`bank`),
+			NewFingerprintValidator(sqlDB.DB, `bank`, `fprint`, []string{`pgwire`}),
+		}
+		sqlDB.Exec(t, `CREATE TABLE fprint (id INT PRIMARY KEY, balance INT, payload STRING)`)
+		for {
+			if !rows.Next() {
+				t.Fatal(`expected more rows`)
+			}
+			var topic gosql.NullString
+			var key, value []byte
+			if err := rows.Scan(&topic, &key, &value); err != nil {
+				t.Fatalf(`%+v`, err)
+			}
+			updated, resolved, err := parseMetaTimestamps(value)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if topic.Valid {
+				v.NoteRow(`pgwire`, string(key), string(value), updated)
+				rowsSinceResolved++
+			} else {
+				if rowsSinceResolved > 0 {
+					if err := v.NoteResolved(`pgwire`, resolved); err != nil {
+						t.Fatal(err)
+					}
+
+					numResolved++
+					if numResolved > requestedResolved {
+						atomic.StoreInt64(&done, 1)
+						break
+					}
+				}
+				rowsSinceResolved = 0
+			}
+		}
+		for _, f := range v.Failures() {
+			t.Error(f)
+		}
+
+		if err := g.Wait(); err != nil {
+			t.Errorf(`%+v`, err)
+		}
+	})
+}

--- a/pkg/ccl/changefeedccl/validator.go
+++ b/pkg/ccl/changefeedccl/validator.go
@@ -1,0 +1,296 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"bytes"
+	gosql "database/sql"
+	gojson "encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/pkg/errors"
+)
+
+// Validator checks for violations of our changefeed ordering and delivery
+// guarantees in a single table.
+type Validator interface {
+	// NoteRow accepts a changed row entry.
+	NoteRow(partition string, key, value string, updated hlc.Timestamp)
+	// NoteResolved accepts a resolved timestamp entry.
+	NoteResolved(partition string, resolved hlc.Timestamp) error
+	// Failures returns any violations seen so far.
+	Failures() []string
+}
+
+type orderValidator struct {
+	topic           string
+	partitionForKey map[string]string
+	keyTimestamps   map[string][]hlc.Timestamp
+	resolved        map[string]hlc.Timestamp
+
+	failures []string
+}
+
+// NewOrderValidator returns a Validator that checks the row and resolved
+// timestamp ordering guarantees. It also asserts that keys have an affinity to
+// a single partition.
+//
+// Once a row with has been emitted with some timestamp, no previously unseen
+// versions of that row will be emitted with a lower timestamp.
+//
+// Once a resolved timestamp has been emitted, no previously unseen rows with a
+// lower update timestamp will be emitted on that partition.
+func NewOrderValidator(topic string) Validator {
+	return &orderValidator{
+		topic:           topic,
+		partitionForKey: make(map[string]string),
+		keyTimestamps:   make(map[string][]hlc.Timestamp),
+		resolved:        make(map[string]hlc.Timestamp),
+	}
+}
+
+// NoteRow implements the Validator interface.
+func (v *orderValidator) NoteRow(
+	partition string, key, ignoredValue string, updated hlc.Timestamp,
+) {
+	if prev, ok := v.partitionForKey[key]; ok && prev != partition {
+		v.failures = append(v.failures, fmt.Sprintf(
+			`key [%s] received on two partitions: %s and %s`, key, prev, partition,
+		))
+		return
+	}
+	v.partitionForKey[key] = partition
+
+	timestamps := v.keyTimestamps[key]
+	timestampsIdx := sort.Search(len(timestamps), func(i int) bool {
+		return !timestamps[i].Less(updated)
+	})
+	seen := timestampsIdx < len(timestamps) && timestamps[timestampsIdx] == updated
+
+	if !seen && len(timestamps) > 0 && updated.Less(timestamps[len(timestamps)-1]) {
+		v.failures = append(v.failures, fmt.Sprintf(
+			`topic %s partition %s: saw new row timestamp %s after %s was seen`,
+			v.topic, partition,
+			updated.AsOfSystemTime(), timestamps[len(timestamps)-1].AsOfSystemTime(),
+		))
+	}
+	if !seen && updated.Less(v.resolved[partition]) {
+		v.failures = append(v.failures, fmt.Sprintf(
+			`topic %s partition %s: saw new row timestamp %s after %s was resolved`,
+			v.topic, partition, updated.AsOfSystemTime(), v.resolved[partition].AsOfSystemTime(),
+		))
+	}
+
+	if !seen {
+		v.keyTimestamps[key] = append(
+			append(timestamps[:timestampsIdx], updated), timestamps[timestampsIdx:]...)
+	}
+}
+
+// NoteResolved implements the Validator interface.
+func (v *orderValidator) NoteResolved(partition string, resolved hlc.Timestamp) error {
+	prev := v.resolved[partition]
+	if prev.Less(resolved) {
+		v.resolved[partition] = resolved
+	}
+	return nil
+}
+
+func (v *orderValidator) Failures() []string {
+	return v.failures
+}
+
+type validatorRow struct {
+	key, value string
+	updated    hlc.Timestamp
+}
+
+// fingerprintValidator verifies that recreating a table from its changefeed
+// will fingerprint the same at all "interesting" points in time.
+type fingerprintValidator struct {
+	sqlDB                  *gosql.DB
+	origTable, fprintTable string
+	partitionResolved      map[string]hlc.Timestamp
+	resolved               hlc.Timestamp
+
+	buffer []validatorRow
+
+	failures []string
+}
+
+// NewFingerprintValidator returns a new FingerprintValidator that uses
+// `fprintTable` as scratch space to recreate `origTable`.
+func NewFingerprintValidator(
+	sqlDB *gosql.DB, origTable, fprintTable string, partitions []string,
+) Validator {
+	v := &fingerprintValidator{
+		sqlDB:       sqlDB,
+		origTable:   origTable,
+		fprintTable: fprintTable,
+	}
+	v.partitionResolved = make(map[string]hlc.Timestamp)
+	for _, partition := range partitions {
+		v.partitionResolved[partition] = hlc.Timestamp{}
+	}
+	return v
+}
+
+// NoteRow implements the Validator interface.
+func (v *fingerprintValidator) NoteRow(
+	ignoredPartition string, key, value string, updated hlc.Timestamp,
+) {
+	v.buffer = append(v.buffer, validatorRow{
+		key:     key,
+		value:   value,
+		updated: updated,
+	})
+}
+
+// NoteResolved implements the Validator interface.
+func (v *fingerprintValidator) NoteResolved(partition string, resolved hlc.Timestamp) error {
+	if r, ok := v.partitionResolved[partition]; !ok {
+		return errors.Errorf(`unknown partition: %s`, partition)
+	} else if !r.Less(resolved) {
+		return nil
+	}
+	v.partitionResolved[partition] = resolved
+
+	// Check if this partition's resolved timestamp advancing has advanced the
+	// overall topic resolved timestamp. This is O(n^2) but could be better with
+	// a heap, if necessary.
+	newResolved := resolved
+	for _, r := range v.partitionResolved {
+		if r.Less(newResolved) {
+			newResolved = r
+		}
+	}
+	if !v.resolved.Less(newResolved) {
+		return nil
+	}
+	v.resolved = newResolved
+
+	// NB: Intentionally not stable sort because it shouldn't matter.
+	sort.Slice(v.buffer, func(i, j int) bool {
+		return v.buffer[i].updated.Less(v.buffer[j].updated)
+	})
+
+	// var lastUpdated hlc.Timestamp
+	for len(v.buffer) > 0 {
+		if v.resolved.Less(v.buffer[0].updated) {
+			break
+		}
+		row := v.buffer[0]
+		v.buffer = v.buffer[1:]
+
+		// TODO(dan): The following should be enabled (and the tests
+		// unskipped once #27101 is fixed.
+		// if row.updated != lastUpdated {
+		// 	if lastUpdated != (hlc.Timestamp{}) {
+		// 		if err := v.fingerprint(lastUpdated); err != nil {
+		// 			return err
+		// 		}
+		// 	}
+		// 	if err := v.fingerprint(row.updated.Prev()); err != nil {
+		// 		return err
+		// 	}
+		// }
+		// lastUpdated = row.updated
+
+		value := make(map[string]interface{})
+		if err := gojson.Unmarshal([]byte(row.value), &value); err != nil {
+			return err
+		}
+
+		var stmtBuf bytes.Buffer
+		var args []interface{}
+		fmt.Fprintf(&stmtBuf, `UPSERT INTO %s (`, v.fprintTable)
+		for col, colValue := range value {
+			if col == `__crdb__` {
+				continue
+			}
+			if len(args) != 0 {
+				stmtBuf.WriteString(`,`)
+			}
+			stmtBuf.WriteString(col)
+			args = append(args, colValue)
+		}
+		stmtBuf.WriteString(`) VALUES (`)
+		for i := range args {
+			if i != 0 {
+				stmtBuf.WriteString(`,`)
+			}
+			fmt.Fprintf(&stmtBuf, `$%d`, i+1)
+		}
+		stmtBuf.WriteString(`)`)
+		if len(args) > 0 {
+			if _, err := v.sqlDB.Exec(stmtBuf.String(), args...); err != nil {
+				return errors.Wrap(err, stmtBuf.String())
+			}
+		}
+	}
+
+	return v.fingerprint(v.resolved)
+}
+
+func (v *fingerprintValidator) fingerprint(ts hlc.Timestamp) error {
+	var orig string
+	if err := v.sqlDB.QueryRow(`SELECT IFNULL(fingerprint, '') FROM [
+		SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE ` + v.origTable + `
+	] AS OF SYSTEM TIME '` + ts.AsOfSystemTime() + `'`).Scan(&orig); err != nil {
+		return err
+	}
+	var check string
+	if err := v.sqlDB.QueryRow(`SELECT IFNULL(fingerprint, '') FROM [
+		SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE ` + v.fprintTable + `
+	]`).Scan(&check); err != nil {
+		return err
+	}
+	if orig != check {
+		v.failures = append(v.failures, fmt.Sprintf(
+			`fingerprints did not match at %s: %s vs %s`, ts.AsOfSystemTime(), orig, check))
+	}
+	return nil
+}
+
+// Failures implements the Validator interface.
+func (v *fingerprintValidator) Failures() []string {
+	return v.failures
+}
+
+// Validators abstracts over running multiple `Validator`s at once on the same
+// feed.
+type Validators []Validator
+
+// NoteRow implements the Validator interface.
+func (vs Validators) NoteRow(partition string, key, value string, updated hlc.Timestamp) {
+	for _, v := range vs {
+		v.NoteRow(partition, key, value, updated)
+	}
+}
+
+// NoteResolved implements the Validator interface.
+func (vs Validators) NoteResolved(partition string, resolved hlc.Timestamp) error {
+	for _, v := range vs {
+		if err := v.NoteResolved(partition, resolved); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Failures implements the Validator interface.
+func (vs Validators) Failures() []string {
+	var f []string
+	for _, v := range vs {
+		f = append(f, v.Failures()...)
+	}
+	return f
+}

--- a/pkg/ccl/changefeedccl/validator_test.go
+++ b/pkg/ccl/changefeedccl/validator_test.go
@@ -1,0 +1,252 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func ts(i int64) hlc.Timestamp {
+	return hlc.Timestamp{WallTime: i}
+}
+
+func noteResolved(t *testing.T, v Validator, partition string, resolved hlc.Timestamp) {
+	t.Helper()
+	if err := v.NoteResolved(partition, resolved); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertValidatorFailures(t *testing.T, v Validator, expected ...string) {
+	t.Helper()
+	if f := v.Failures(); !reflect.DeepEqual(f, expected) {
+		t.Errorf(`got %v expected %v`, f, expected)
+	}
+}
+
+func TestOrderValidator(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	const ignored = `ignored`
+
+	t.Run(`empty`, func(t *testing.T) {
+		v := NewOrderValidator(`t1`)
+		if f := v.Failures(); f != nil {
+			t.Fatalf("got %v expected %v", f, nil)
+		}
+	})
+	t.Run(`dupe okay`, func(t *testing.T) {
+		v := NewOrderValidator(`t1`)
+		v.NoteRow(`p1`, `k1`, ignored, ts(1))
+		v.NoteRow(`p1`, `k1`, ignored, ts(2))
+		v.NoteRow(`p1`, `k1`, ignored, ts(1))
+		assertValidatorFailures(t, v)
+	})
+	t.Run(`key on two partitions`, func(t *testing.T) {
+		v := NewOrderValidator(`t1`)
+		v.NoteRow(`p1`, `k1`, ignored, ts(2))
+		v.NoteRow(`p2`, `k1`, ignored, ts(1))
+		assertValidatorFailures(t, v,
+			`key [k1] received on two partitions: p1 and p2`,
+		)
+	})
+	t.Run(`new key with lower timestamp`, func(t *testing.T) {
+		v := NewOrderValidator(`t1`)
+		v.NoteRow(`p1`, `k1`, ignored, ts(2))
+		v.NoteRow(`p1`, `k1`, ignored, ts(1))
+		assertValidatorFailures(t, v,
+			`topic t1 partition p1: saw new row timestamp 1.0000000000 after 2.0000000000 was seen`,
+		)
+	})
+	t.Run(`new key after resolved`, func(t *testing.T) {
+		v := NewOrderValidator(`t1`)
+		noteResolved(t, v, `p2`, ts(3))
+		// Okay because p2 saw the resolved timestamp but p1 didn't.
+		v.NoteRow(`p1`, `k1`, ignored, ts(1))
+		noteResolved(t, v, `p1`, ts(3))
+		// This one is not okay.
+		v.NoteRow(`p1`, `k1`, ignored, ts(2))
+		// Still okay because we've seen it before.
+		v.NoteRow(`p1`, `k1`, ignored, ts(1))
+		assertValidatorFailures(t, v,
+			`topic t1 partition p1`+
+				`: saw new row timestamp 2.0000000000 after 3.0000000000 was resolved`,
+		)
+	})
+}
+
+func TestFingerprintValidator(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	const ignored = `ignored`
+
+	ctx := context.Background()
+	s, sqlDBRaw, _ := serverutils.StartServer(t, base.TestServerArgs{UseDatabase: "d"})
+	defer s.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
+	sqlDB.Exec(t, `CREATE DATABASE d`)
+	sqlDB.Exec(t, `CREATE TABLE foo (k INT PRIMARY KEY, v INT)`)
+
+	tsRaw := make([]string, 5)
+	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&tsRaw[0])
+	sqlDB.QueryRow(t,
+		`UPSERT INTO foo VALUES (1, 1) RETURNING cluster_logical_timestamp()`,
+	).Scan(&tsRaw[1])
+	sqlDB.QueryRow(t,
+		`UPSERT INTO foo VALUES (1, 2), (2, 2) RETURNING cluster_logical_timestamp()`,
+	).Scan(&tsRaw[2])
+	sqlDB.QueryRow(t,
+		`UPSERT INTO foo VALUES (1, 3) RETURNING cluster_logical_timestamp()`,
+	).Scan(&tsRaw[3])
+	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&tsRaw[4])
+	ts := make([]hlc.Timestamp, len(tsRaw))
+	for i := range tsRaw {
+		var err error
+		ts[i], err = sql.ParseHLC(tsRaw[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run(`empty`, func(t *testing.T) {
+		sqlDB.Exec(t, `CREATE TABLE empty (k INT PRIMARY KEY, v INT)`)
+		v := NewFingerprintValidator(sqlDB.DB, `foo`, `empty`, []string{`p`})
+		noteResolved(t, v, `p`, ts[0])
+		assertValidatorFailures(t, v)
+	})
+	t.Run(`wrong_data`, func(t *testing.T) {
+		sqlDB.Exec(t, `CREATE TABLE wrong_data (k INT PRIMARY KEY, v INT)`)
+		v := NewFingerprintValidator(sqlDB.DB, `foo`, `wrong_data`, []string{`p`})
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":10}`, ts[1])
+		noteResolved(t, v, `p`, ts[1])
+		assertValidatorFailures(t, v,
+			`fingerprints did not match at `+ts[1].AsOfSystemTime()+
+				`: 590700560494856539 vs -2774220564100127343`,
+		)
+	})
+	t.Run(`all_resolved`, func(t *testing.T) {
+		sqlDB.Exec(t, `CREATE TABLE all_resolved (k INT PRIMARY KEY, v INT)`)
+		v := NewFingerprintValidator(sqlDB.DB, `foo`, `all_resolved`, []string{`p`})
+		if err := v.NoteResolved(`p`, ts[0]); err != nil {
+			t.Fatal(err)
+		}
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":1}`, ts[1])
+		noteResolved(t, v, `p`, ts[1])
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":2}`, ts[2])
+		v.NoteRow(ignored, `[1]`, `{"k":2,"v":2}`, ts[2])
+		noteResolved(t, v, `p`, ts[2])
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":3}`, ts[3])
+		noteResolved(t, v, `p`, ts[3])
+		noteResolved(t, v, `p`, ts[4])
+		assertValidatorFailures(t, v)
+	})
+	t.Run(`rows_unsorted`, func(t *testing.T) {
+		sqlDB.Exec(t, `CREATE TABLE rows_unsorted (k INT PRIMARY KEY, v INT)`)
+		v := NewFingerprintValidator(sqlDB.DB, `foo`, `rows_unsorted`, []string{`p`})
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":3}`, ts[3])
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":2}`, ts[2])
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":1}`, ts[1])
+		v.NoteRow(ignored, `[1]`, `{"k":2,"v":2}`, ts[2])
+		noteResolved(t, v, `p`, ts[4])
+		assertValidatorFailures(t, v)
+	})
+	t.Run(`missed_initial`, func(t *testing.T) {
+		t.Skip("#27101")
+		sqlDB.Exec(t, `CREATE TABLE missed_initial (k INT PRIMARY KEY, v INT)`)
+		v := NewFingerprintValidator(sqlDB.DB, `foo`, `missed_initial`, []string{`p`})
+		// Intentionally missing {"k":1,"v":1}.
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":2}`, ts[2])
+		v.NoteRow(ignored, `[1]`, `{"k":2,"v":2}`, ts[2])
+		noteResolved(t, v, `p`, ts[2])
+		assertValidatorFailures(t, v,
+			`fingerprints did not match at `+ts[2].AsOfSystemTime(),
+		)
+	})
+	t.Run(`missed_middle`, func(t *testing.T) {
+		t.Skip("#27101")
+		sqlDB.Exec(t, `CREATE TABLE missed_middle (k INT PRIMARY KEY, v INT)`)
+		v := NewFingerprintValidator(sqlDB.DB, `foo`, `missed_middle`, []string{`p`})
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":1}`, ts[1])
+		// Intentionally missing {"k":1,"v":2}.
+		v.NoteRow(ignored, `[1]`, `{"k":2,"v":2}`, ts[2])
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":3}`, ts[3])
+		noteResolved(t, v, `p`, ts[3])
+		assertValidatorFailures(t, v,
+			`fingerprints did not match at `+ts[3].AsOfSystemTime(),
+		)
+	})
+	t.Run(`unknown_partition`, func(t *testing.T) {
+		v := NewFingerprintValidator(sqlDB.DB, `foo`, `unknown_partition`, []string{`p`})
+		if err := v.NoteResolved(`nope`, ts[1]); !testutils.IsError(err, `unknown partition`) {
+			t.Fatalf(`expected "unknown partition" error got: %+v`, err)
+		}
+	})
+	t.Run(`resolved_unsorted`, func(t *testing.T) {
+		sqlDB.Exec(t, `CREATE TABLE resolved_unsorted (k INT PRIMARY KEY, v INT)`)
+		v := NewFingerprintValidator(sqlDB.DB, `foo`, `resolved_unsorted`, []string{`p`})
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":1}`, ts[1])
+		noteResolved(t, v, `p`, ts[1])
+		noteResolved(t, v, `p`, ts[1])
+		noteResolved(t, v, `p`, ts[0])
+		assertValidatorFailures(t, v)
+	})
+	t.Run(`two_partitions`, func(t *testing.T) {
+		sqlDB.Exec(t, `CREATE TABLE two_partitions (k INT PRIMARY KEY, v INT)`)
+		v := NewFingerprintValidator(sqlDB.DB, `foo`, `two_partitions`, []string{`p0`, `p1`})
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":1}`, ts[1])
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":2}`, ts[2])
+		// Intentionally missing {"k":2,"v":2}.
+		noteResolved(t, v, `p0`, ts[2])
+		noteResolved(t, v, `p0`, ts[4])
+		// p1 has not been closed, so no failures yet.
+		assertValidatorFailures(t, v)
+		noteResolved(t, v, `p1`, ts[2])
+		assertValidatorFailures(t, v,
+			`fingerprints did not match at `+ts[2].AsOfSystemTime()+
+				`: 1099511631581 vs 590700560494856536`,
+		)
+	})
+}
+
+func TestValidators(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	const ignored = `ignored`
+
+	t.Run(`empty`, func(t *testing.T) {
+		v := Validators{
+			NewOrderValidator(`t1`),
+			NewOrderValidator(`t2`),
+		}
+		if f := v.Failures(); f != nil {
+			t.Fatalf("got %v expected %v", f, nil)
+		}
+	})
+	t.Run(`failures`, func(t *testing.T) {
+		v := Validators{
+			NewOrderValidator(`t1`),
+			NewOrderValidator(`t2`),
+		}
+		noteResolved(t, v, `p1`, ts(2))
+		v.NoteRow(`p1`, `k1`, ignored, ts(1))
+		assertValidatorFailures(t, v,
+			`topic t1 partition p1`+
+				`: saw new row timestamp 1.0000000000 after 2.0000000000 was resolved`,
+			`topic t2 partition p1`+
+				`: saw new row timestamp 1.0000000000 after 2.0000000000 was resolved`,
+		)
+	})
+}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -669,6 +669,16 @@ func (p *planner) EvalAsOfTimestamp(
 	return ts, nil
 }
 
+// ParseHLC parses the string representation of an `hlc.Timestamp` that is
+// accepted by `AS OF SYSTEM TIME`.
+func ParseHLC(s string) (hlc.Timestamp, error) {
+	dec, _, err := apd.NewFromString(s)
+	if err != nil {
+		return hlc.Timestamp{}, err
+	}
+	return decimalToHLC(dec)
+}
+
 func decimalToHLC(d *apd.Decimal) (hlc.Timestamp, error) {
 	// Format the decimal into a string and split on `.` to extract the nanosecond
 	// walltime and logical tick parts.


### PR DESCRIPTION
We've made a set of guarantees about the ordering and delivery of
changefeed messages. This commit adds two validators that, checks for
behavior in a feed that violates these guarantees (a bit like Jepsen
tests for serializability anomolies). It also adds a test that hooks the
validators up to the bank workload.

Release note: None