### PR TITLE
storage: Respect the ReturnRangeInfo options on Admin requests

### DIFF
--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1449,6 +1449,21 @@ func TestRangeInfo(t *testing.T) {
 		t.Errorf("on put reply, expected %+v; got %+v", expRangeInfos, reply.Header().RangeInfos)
 	}
 
+	// Verify range info on an admin request.
+	adminArgs := &roachpb.AdminTransferLeaseRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key: splitKey.AsRawKey(),
+		},
+		Target: rhsLease.Replica.StoreID,
+	}
+	reply, pErr = client.SendWrappedWith(context.Background(), mtc.distSenders[0], h, adminArgs)
+	if pErr != nil {
+		t.Fatal(pErr)
+	}
+	if !reflect.DeepEqual(reply.Header().RangeInfos, expRangeInfos) {
+		t.Errorf("on admin reply, expected %+v; got %+v", expRangeInfos, reply.Header().RangeInfos)
+	}
+
 	// Verify multiple range infos on a scan request.
 	scanArgs := roachpb.ScanRequest{
 		RequestHeader: roachpb.RequestHeader{

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2585,6 +2585,11 @@ func (r *Replica) executeAdminBatch(
 	if pErr != nil {
 		return nil, pErr
 	}
+
+	if ba.Header.ReturnRangeInfo {
+		returnRangeInfo(resp, r)
+	}
+
 	br := &roachpb.BatchResponse{}
 	br.Add(resp)
 	br.Txn = resp.Header().Txn

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -96,16 +96,7 @@ func evaluateCommand(
 	}
 
 	if h.ReturnRangeInfo {
-		header := reply.Header()
-		lease, _ := rec.GetLease()
-		desc := rec.Desc()
-		header.RangeInfos = []roachpb.RangeInfo{
-			{
-				Desc:  *desc,
-				Lease: lease,
-			},
-		}
-		reply.SetHeader(header)
+		returnRangeInfo(reply, rec)
 	}
 
 	// TODO(peter): We'd like to assert that the hlc clock is always updated
@@ -133,6 +124,19 @@ func evaluateCommand(
 	}
 
 	return pd, pErr
+}
+
+func returnRangeInfo(reply roachpb.Response, rec batcheval.EvalContext) {
+	header := reply.Header()
+	lease, _ := rec.GetLease()
+	desc := rec.Desc()
+	header.RangeInfos = []roachpb.RangeInfo{
+		{
+			Desc:  *desc,
+			Lease: lease,
+		},
+	}
+	reply.SetHeader(header)
 }
 
 // AdminSplit divides the range into into two ranges using args.SplitKey.


### PR DESCRIPTION
This would have been nice to have for the implementation of
EXPERIMENTAL_RELOCATE LEASE in #26436 to make it easier to obtain the
range information for each range whose lease is transferred by the
command. Instead, a separate range lookup must be issued. This would
also be useful for EXPERIMENTAL_RELOCATE and any other statements that
operate on ranges and then return which ranges were operated on (except
SCATTER, whose implementation is already special-cased to always return
the needed info).

With this included in v2.1, we can start using it where appropriate in
the v2.2 release.

Release note: None