### PR TITLE
sql: implement convert_to/convert_from

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -708,6 +708,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><code>convert_from(str: <a href="bytes.html">bytes</a>, enc: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Decode the bytes in <code>str</code> into a string using encoding <code>enc</code>. Supports encodings ‘UTF8’ and ‘LATIN1’.</p>
 </span></td></tr>
+<tr><td><code>convert_to(str: <a href="string.html">string</a>, enc: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Encode the string <code>str</code> as a byte array using encoding <code>enc</code>. Supports encodings ‘UTF8’ and ‘LATIN1’.</p>
+</span></td></tr>
 <tr><td><code>decode(text: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Decodes <code>data</code> using <code>format</code> (<code>hex</code> / <code>escape</code> / <code>base64</code>).</p>
 </span></td></tr>
 <tr><td><code>encode(data: <a href="bytes.html">bytes</a>, format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Encodes <code>data</code> using <code>format</code> (<code>hex</code> / <code>escape</code> / <code>base64</code>).</p>

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -706,6 +706,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 <tr><td><code>concat_ws(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Uses the first argument as a separator between the concatenation of the subsequent arguments.</p>
 <p>For example <code>concat_ws('!','wow','great')</code> returns <code>wow!great</code>.</p>
 </span></td></tr>
+<tr><td><code>convert_from(str: <a href="bytes.html">bytes</a>, enc: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Decode the bytes in <code>str</code> into a string using encoding <code>enc</code>. Supports encodings ‘UTF8’ and ‘LATIN1’.</p>
+</span></td></tr>
 <tr><td><code>decode(text: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Decodes <code>data</code> using <code>format</code> (<code>hex</code> / <code>escape</code> / <code>base64</code>).</p>
 </span></td></tr>
 <tr><td><code>encode(data: <a href="bytes.html">bytes</a>, format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Encodes <code>data</code> using <code>format</code> (<code>hex</code> / <code>escape</code> / <code>base64</code>).</p>

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -139,6 +139,11 @@ func newDecodeError(enc string) error {
 		"invalid byte sequence for encoding %q", enc)
 }
 
+func newEncodeError(c rune, enc string) error {
+	return pgerror.NewErrorf(pgerror.CodeUntranslatableCharacterError,
+		"character %q has no representation in encoding %q", c, enc)
+}
+
 // builtins contains the built-in functions indexed by name.
 //
 // For use in other packages, see AllBuiltinNames and GetBuiltinProperties().
@@ -276,6 +281,37 @@ var builtins = map[string]builtinDefinition{
 					"invalid source encoding name %q", enc)
 			},
 			Info: "Decode the bytes in `str` into a string using encoding `enc`. " +
+				"Supports encodings 'UTF8' and 'LATIN1'.",
+		}),
+
+	// https://www.postgresql.org/docs/10/static/functions-string.html#FUNCTIONS-STRING-OTHER
+	"convert_to": makeBuiltin(tree.FunctionProperties{Category: categoryString},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"str", types.String}, {"enc", types.String}},
+			ReturnType: tree.FixedReturnType(types.Bytes),
+			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				str := string(tree.MustBeDString(args[0]))
+				enc := strings.ToLower(string(tree.MustBeDString(args[1])))
+				switch enc {
+				// All the following are aliases to each other in PostgreSQL.
+				case "utf8", "utf-8", "unicode", "cp65001":
+					return tree.NewDBytes(tree.DBytes([]byte(str))), nil
+
+					// All the following are aliases to each other in PostgreSQL.
+				case "latin1", "latin-1", "iso88591", "iso8859-1", "iso-8859-1", "cp28591":
+					res := make([]byte, 0, len(str))
+					for _, c := range str {
+						if c > 255 {
+							return nil, newEncodeError(c, "LATIN1")
+						}
+						res = append(res, byte(c))
+					}
+					return tree.NewDBytes(tree.DBytes(res)), nil
+				}
+				return nil, pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError,
+					"invalid destination encoding name %q", enc)
+			},
+			Info: "Encode the string `str` as a byte array using encoding `enc`. " +
 				"Supports encodings 'UTF8' and 'LATIN1'.",
 		}),
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -134,6 +134,11 @@ func makeBuiltin(props tree.FunctionProperties, overloads ...tree.Overload) buil
 	}
 }
 
+func newDecodeError(enc string) error {
+	return pgerror.NewErrorf(pgerror.CodeCharacterNotInRepertoireError,
+		"invalid byte sequence for encoding %q", enc)
+}
+
 // builtins contains the built-in functions indexed by name.
 //
 // For use in other packages, see AllBuiltinNames and GetBuiltinProperties().
@@ -242,6 +247,37 @@ var builtins = map[string]builtinDefinition{
 				"returns `wow!great`.",
 		},
 	),
+
+	// https://www.postgresql.org/docs/10/static/functions-string.html#FUNCTIONS-STRING-OTHER
+	"convert_from": makeBuiltin(tree.FunctionProperties{Category: categoryString},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"str", types.Bytes}, {"enc", types.String}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				str := []byte(tree.MustBeDBytes(args[0]))
+				enc := strings.ToLower(string(tree.MustBeDString(args[1])))
+				switch enc {
+				// All the following are aliases to each other in PostgreSQL.
+				case "utf8", "utf-8", "unicode", "cp65001":
+					if !utf8.Valid(str) {
+						return nil, newDecodeError("UTF8")
+					}
+					return tree.NewDString(string(str)), nil
+
+					// All the following are aliases to each other in PostgreSQL.
+				case "latin1", "latin-1", "iso88591", "iso8859-1", "iso-8859-1", "cp28591":
+					var buf strings.Builder
+					for _, c := range str {
+						buf.WriteRune(rune(c))
+					}
+					return tree.NewDString(buf.String()), nil
+				}
+				return nil, pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError,
+					"invalid source encoding name %q", enc)
+			},
+			Info: "Decode the bytes in `str` into a string using encoding `enc`. " +
+				"Supports encodings 'UTF8' and 'LATIN1'.",
+		}),
 
 	"gen_random_uuid": makeBuiltin(
 		tree.FunctionProperties{

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -1398,6 +1398,9 @@ func TestEval(t *testing.T) {
 		{`convert_from('\xE290A4'::bytea, 'utf8')`, `e'\U00002424'`},
 		{`convert_from('\x2424'::bytea, 'latin1')`, `'$$'`},
 		{`convert_from('\xaaaa'::bytea, 'latin1')`, `e'\u00AA\u00AA'`},
+		{`convert_to('abå', 'latin1')`, `'\x6162e5'`},
+		{`convert_to('abå', 'utf8')`, `'\x6162c3a5'`},
+		{`convert_to('ab漢', 'utf8')`, `'\x6162e6bca2'`},
 	}
 	ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	// We have to manually close this account because we're doing the evaluations
@@ -1661,6 +1664,8 @@ func TestEvalError(t *testing.T) {
 		{`similar_to_escape('a(b)c', '%((_)_', '(')`, `error parsing regexp: unexpected )`},
 		{`convert_from('\xaaaa'::bytea, 'woo')`, `convert_from(): invalid source encoding name "woo"`},
 		{`convert_from('\xaaaa'::bytea, 'utf8')`, `convert_from(): invalid byte sequence for encoding "UTF8"`},
+		{`convert_to('abc', 'woo')`, `convert_to(): invalid destination encoding name "woo"`},
+		{`convert_to('漢', 'latin1')`, `convert_to(): character '漢' has no representation in encoding "LATIN1"`},
 	}
 	for _, d := range testData {
 		expr, err := parser.ParseExpr(d.expr)

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -1395,6 +1395,9 @@ func TestEval(t *testing.T) {
 		{`'192.168.162.1'::inet << '192.168.200.95/17'::inet`, `true`},
 		{`'192.168.2.1'::inet <<= '192.168.2.1'::inet`, `true`},
 		{`'192.168.200.95'::inet && '192.168.2.1/8'::inet`, `true`},
+		{`convert_from('\xE290A4'::bytea, 'utf8')`, `e'\U00002424'`},
+		{`convert_from('\x2424'::bytea, 'latin1')`, `'$$'`},
+		{`convert_from('\xaaaa'::bytea, 'latin1')`, `e'\u00AA\u00AA'`},
 	}
 	ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	// We have to manually close this account because we're doing the evaluations
@@ -1656,6 +1659,8 @@ func TestEvalError(t *testing.T) {
 		{`like_escape('abc', '%b漢', '漢')`, `LIKE pattern must not end with escape character`},
 		{`similar_to_escape('abc', '-a-b-c', '-')`, `error parsing regexp: invalid escape sequence`},
 		{`similar_to_escape('a(b)c', '%((_)_', '(')`, `error parsing regexp: unexpected )`},
+		{`convert_from('\xaaaa'::bytea, 'woo')`, `convert_from(): invalid source encoding name "woo"`},
+		{`convert_from('\xaaaa'::bytea, 'utf8')`, `convert_from(): invalid byte sequence for encoding "UTF8"`},
 	}
 	for _, d := range testData {
 		expr, err := parser.ParseExpr(d.expr)


### PR DESCRIPTION
Fixes  #26267.

For docs: these built-in functions must be mentioned in the docs for the types string and bytes.


cc @bdarnell 