### PR TITLE
log: use fake stacktrace when test-exiting

### DIFF
--- a/pkg/cli/backtrace.go
+++ b/pkg/cli/backtrace.go
@@ -93,7 +93,7 @@ func initBacktrace(logDir string, options ...stop.Option) *stop.Stopper {
 	bcd.Register(tracer)
 
 	// Hook log.Fatal*.
-	log.SetExitFunc(func(code int) {
+	log.SetExitFunc(false /* hideStack */, func(code int) {
 		_ = bcd.Trace(tracer, fmt.Errorf("exit %d", code), nil)
 		os.Exit(code)
 	})

--- a/pkg/cmd/allocsim/main.go
+++ b/pkg/cmd/allocsim/main.go
@@ -522,7 +522,7 @@ func main() {
 	a := newAllocSim(c)
 	a.localities = localities
 
-	log.SetExitFunc(func(code int) {
+	log.SetExitFunc(false /* hideStack */, func(code int) {
 		c.Close()
 		os.Exit(code)
 	})

--- a/pkg/cmd/zerosum/main.go
+++ b/pkg/cmd/zerosum/main.go
@@ -441,7 +441,7 @@ func main() {
 	c := &localcluster.LocalCluster{Cluster: localcluster.New(cfg)}
 	defer c.Close()
 
-	log.SetExitFunc(func(code int) {
+	log.SetExitFunc(false /* hideStack */, func(code int) {
 		c.Close()
 		os.Exit(code)
 	})

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -815,8 +815,8 @@ func TestPersistHLCUpperBound(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	var fatal bool
-	defer log.SetExitFunc(os.Exit)
-	log.SetExitFunc(func(r int) {
+	defer log.ResetExitFunc()
+	log.SetExitFunc(true /* hideStack */, func(r int) {
 		defer log.Flush()
 		if r != 0 {
 			fatal = true

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -17,7 +17,6 @@ package server_test
 import (
 	"context"
 	gosql "database/sql"
-	"os"
 	"path/filepath"
 	"strconv"
 	"sync/atomic"
@@ -320,8 +319,8 @@ func TestClusterVersionMixedVersionTooOld(t *testing.T) {
 
 	exits := make(chan int, 100)
 
-	log.SetExitFunc(func(i int) { exits <- i })
-	defer log.SetExitFunc(os.Exit)
+	log.SetExitFunc(true /* hideStack */, func(i int) { exits <- i })
+	defer log.ResetExitFunc()
 
 	// Three nodes at v1.1 and a fourth one at 1.0, but all operating at v1.0.
 	versions := [][2]string{{"1.0", "1.1"}, {"1.0", "1.1"}, {"1.0", "1.1"}, {"1.0", "1.0"}}
@@ -376,8 +375,8 @@ func TestClusterVersionMixedVersionTooNew(t *testing.T) {
 
 	exits := make(chan int, 100)
 
-	log.SetExitFunc(func(i int) { exits <- i })
-	defer log.SetExitFunc(os.Exit)
+	log.SetExitFunc(true /* hideStack */, func(i int) { exits <- i })
+	defer log.ResetExitFunc()
 
 	// Three nodes at v1.1 and a fourth one (started later) at 1.1-2 (and
 	// incompatible with anything earlier).

--- a/pkg/sqlmigrations/migrations_test.go
+++ b/pkg/sqlmigrations/migrations_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -335,8 +334,8 @@ func TestLeaseExpiration(t *testing.T) {
 	defer func() { leaseRefreshInterval = oldLeaseRefreshInterval }()
 
 	exitCalled := make(chan bool)
-	log.SetExitFunc(func(int) { exitCalled <- true })
-	defer log.SetExitFunc(os.Exit)
+	log.SetExitFunc(true /* hideStack */, func(int) { exitCalled <- true })
+	defer log.ResetExitFunc()
 	// Disable stack traces to make the test output in teamcity less deceiving.
 	defer log.DisableTracebacks()()
 

--- a/pkg/util/hlc/hlc_test.go
+++ b/pkg/util/hlc/hlc_test.go
@@ -17,7 +17,6 @@ package hlc
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 	"time"
@@ -115,8 +114,8 @@ func isErrSimilar(expected *regexp.Regexp, actual error) bool {
 
 func TestHLCPhysicalClockJump(t *testing.T) {
 	var fatal bool
-	defer log.SetExitFunc(os.Exit)
-	log.SetExitFunc(func(r int) {
+	defer log.ResetExitFunc()
+	log.SetExitFunc(true /* hideStack */, func(r int) {
 		if r != 0 {
 			fatal = true
 		}
@@ -372,8 +371,8 @@ func TestHLCMonotonicityCheck(t *testing.T) {
 
 func TestHLCEnforceWallTimeWithinBoundsInNow(t *testing.T) {
 	var fatal bool
-	defer log.SetExitFunc(os.Exit)
-	log.SetExitFunc(func(r int) {
+	defer log.ResetExitFunc()
+	log.SetExitFunc(true /* hideStack */, func(r int) {
 		defer log.Flush()
 		if r != 0 {
 			fatal = true
@@ -421,8 +420,8 @@ func TestHLCEnforceWallTimeWithinBoundsInNow(t *testing.T) {
 
 func TestHLCEnforceWallTimeWithinBoundsInUpdate(t *testing.T) {
 	var fatal bool
-	defer log.SetExitFunc(os.Exit)
-	log.SetExitFunc(func(r int) {
+	defer log.ResetExitFunc()
+	log.SetExitFunc(true /* hideStack */, func(r int) {
 		defer log.Flush()
 		if r != 0 {
 			fatal = true

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -92,10 +92,9 @@ func contains(str string, t *testing.T) bool {
 	return strings.Contains(c, str)
 }
 
-// setFlags configures the logging flags and exitFunc how the test expects
-// them.
+// setFlags resets the logging flags and exit function to what tests expect.
 func setFlags() {
-	SetExitFunc(os.Exit)
+	ResetExitFunc()
 	logging.mu.Lock()
 	defer logging.mu.Unlock()
 	logging.noStderrRedirect = false
@@ -699,7 +698,7 @@ func TestFatalStacktraceStderr(t *testing.T) {
 
 	setFlags()
 	logging.stderrThreshold = Severity_NONE
-	SetExitFunc(func(int) {})
+	SetExitFunc(false /* hideStack */, func(int) {})
 
 	defer setFlags()
 	defer logging.swap(logging.newBuffers())
@@ -790,11 +789,11 @@ func TestExitOnFullDisk(t *testing.T) {
 
 	var exited sync.WaitGroup
 	exited.Add(1)
-	l := &loggingT{
-		exitFunc: func(int) {
-			exited.Done()
-		},
+	l := &loggingT{}
+	l.exitOverride.f = func(int) {
+		exited.Done()
 	}
+
 	l.file = &syncBuffer{
 		logger: l,
 		Writer: bufio.NewWriterSize(&outOfSpaceWriter{}, 1),

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -40,11 +40,25 @@ func FatalOnPanic() {
 }
 
 // SetExitFunc allows setting a function that will be called to exit the
-// process when a Fatal message is generated.
-func SetExitFunc(f func(int)) {
+// process when a Fatal message is generated. The supplied bool, if true,
+// suppresses the stack trace, which is useful for test callers wishing
+// to keep the logs reasonably clean.
+//
+// Call with a nil function to undo.
+func SetExitFunc(hideStack bool, f func(int)) {
 	logging.mu.Lock()
 	defer logging.mu.Unlock()
-	logging.exitFunc = f
+	logging.exitOverride.f = f
+	logging.exitOverride.hideStack = hideStack
+}
+
+// ResetExitFunc undoes any prior call to SetExitFunc.
+func ResetExitFunc() {
+	logging.mu.Lock()
+	defer logging.mu.Unlock()
+
+	logging.exitOverride.f = nil
+	logging.exitOverride.hideStack = false
 }
 
 // logDepth uses the PrintWith to format the output string and

--- a/pkg/util/log/secondary_log.go
+++ b/pkg/util/log/secondary_log.go
@@ -17,7 +17,6 @@ package log
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
@@ -67,7 +66,6 @@ func NewSecondaryLogger(
 			syncWrites:       forceSyncWrites || logging.syncWrites,
 			gcNotify:         make(chan struct{}, 1),
 			disableDaemons:   logging.disableDaemons,
-			exitFunc:         os.Exit,
 		},
 		forceSyncWrites: forceSyncWrites,
 	}


### PR DESCRIPTION
Having stack traces littered across tests has been a long-standing pet
peeve of mine (and presumably others). We search through logs more often
than we would like to admit, and having to skip a number of intentional
stack traces is annoying.

Make it so that whenever the logging exit func is mocked, the stack
trace indicates that.

Release note: None