### PR TITLE
distsql: fix NULL handling in lookup joins

### DIFF
--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -59,6 +59,11 @@ func TestJoinReader(t *testing.T) {
 		99,
 		sqlutils.ToRowFn(aFn, bFn, sumFn, sqlutils.RowEnglishFn))
 
+	// Insert a row for NULL testing.
+	if _, err := sqlDB.Exec("INSERT INTO test.t VALUES (10, 0, NULL, NULL)"); err != nil {
+		t.Fatal(err)
+	}
+
 	tdSecondary := sqlbase.GetTableDescriptor(kvDB, "test", "t")
 
 	sqlutils.CreateTable(t, sqlDB, "t2",
@@ -208,6 +213,20 @@ func TestJoinReader(t *testing.T) {
 			joinType:        sqlbase.LeftOuterJoin,
 			outputTypes:     []sqlbase.ColumnType{intType, intType},
 			expected:        "[[2 3] [10 NULL]]",
+		},
+		{
+			description: "Test lookup join on secondary index with NULL lookup value",
+			indexIdx:    1,
+			post: PostProcessSpec{
+				Projection:    true,
+				OutputColumns: []uint32{0},
+			},
+			input: [][]tree.Datum{
+				{tree.NewDInt(0), tree.DNull},
+			},
+			lookupCols:  []uint32{0, 1},
+			outputTypes: oneIntCol,
+			expected:    "[]",
 		},
 	}
 	for _, td := range []*sqlbase.TableDescriptor{tdSecondary, tdFamily} {

--- a/pkg/sql/logictest/testdata/logic_test/distsql_lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_lookup_join
@@ -34,6 +34,10 @@ statement ok
 CREATE TABLE distsql_lookup_test_2 (d INT, e INT, f INT, PRIMARY KEY (f, e));
 INSERT INTO distsql_lookup_test_2 VALUES (1, 1, 2), (2, 1, 1), (NULL, 2, 1)
 
+statement ok
+CREATE TABLE distsql_lookup_test_3 (g INT, h INT, INDEX g_idx (g));
+INSERT INTO distsql_lookup_test_3 VALUES (NULL, 1)
+
 query IIIIII rowsort
 SELECT * FROM distsql_lookup_test_1 JOIN distsql_lookup_test_2 ON f = b
 ----
@@ -82,6 +86,11 @@ SELECT a, b, e FROM distsql_lookup_test_1 JOIN distsql_lookup_test_2 ON f = b WH
 1  1  1
 2  1  1
 2  1  2
+
+# Test lookup join on NULL column. (https://github.com/cockroachdb/cockroach/issues/27032)
+query I
+SELECT h FROM distsql_lookup_test_1 JOIN distsql_lookup_test_3@g_idx ON b = g
+----
 
 # Ensure join performs properly on input that has more than 100 rows.
 query I


### PR DESCRIPTION
joinReader was improperly considering NULL values to be equal when
performing index lookups. Input rows with null lookup columns are now
discarded.

Fixes #27032.

Release note (bug fix): Fixed NULL equality handling in experimental
lookup join feature.