### PR TITLE
workload: interrupt worker loops when ramp period finishes

### DIFF
--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -203,7 +203,7 @@ func (o *kvOp) run(ctx context.Context) error {
 			args[i] = o.g.readKey()
 		}
 		start := timeutil.Now()
-		rows, err := o.readStmt.Query(args...)
+		rows, err := o.readStmt.QueryContext(ctx, args...)
 		if err != nil {
 			return err
 		}
@@ -220,7 +220,7 @@ func (o *kvOp) run(ctx context.Context) error {
 		args[j+1] = randomBlock(o.config, o.g.rand())
 	}
 	start := timeutil.Now()
-	_, err := o.writeStmt.Exec(args...)
+	_, err := o.writeStmt.ExecContext(ctx, args...)
 	o.hists.Get(`write`).Record(timeutil.Since(start))
 	return err
 }

--- a/pkg/workload/tpcc/stock_level.go
+++ b/pkg/workload/tpcc/stock_level.go
@@ -51,7 +51,9 @@ type stockLevel struct{}
 
 var _ tpccTx = stockLevel{}
 
-func (s stockLevel) run(config *tpcc, db *gosql.DB, wID int) (interface{}, error) {
+func (s stockLevel) run(
+	ctx context.Context, config *tpcc, db *gosql.DB, wID int,
+) (interface{}, error) {
 	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 
 	// 2.8.1.2: The threshold of minimum quantity in stock is selected at random
@@ -62,7 +64,7 @@ func (s stockLevel) run(config *tpcc, db *gosql.DB, wID int) (interface{}, error
 	}
 
 	if err := crdb.ExecuteTx(
-		context.Background(),
+		ctx,
 		db,
 		config.txOpts,
 		func(tx *gosql.Tx) error {
@@ -76,7 +78,7 @@ func (s stockLevel) run(config *tpcc, db *gosql.DB, wID int) (interface{}, error
 			}
 
 			var dNextOID int
-			if err := tx.QueryRow(fmt.Sprintf(`
+			if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
 				SELECT d_next_o_id
 				FROM district
 				WHERE d_w_id = %[1]d AND d_id = %[2]d`,
@@ -89,7 +91,7 @@ func (s stockLevel) run(config *tpcc, db *gosql.DB, wID int) (interface{}, error
 			// the threshold.
 			// Note: we don't use count(DISTINCT s_i_id) because DISTINCT inside
 			// aggregates is not yet supported by the optimizer.
-			return tx.QueryRow(fmt.Sprintf(`
+			return tx.QueryRowContext(ctx, fmt.Sprintf(`
 			  SELECT count(*) FROM (
 			  	SELECT DISTINCT s_i_id
 			  	FROM order_line

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -220,11 +220,10 @@ func (w *tpcc) Hooks() workload.Hooks {
 			}
 			return nil
 		},
-		PostRun: func(start time.Time) error {
+		PostRun: func(startElapsed time.Duration) error {
 			w.auditor.runChecks()
 			const totalHeader = "\n_elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)"
 			fmt.Println(totalHeader)
-			startElapsed := timeutil.Since(start)
 
 			const newOrderName = `newOrder`
 			w.reg.Tick(func(t workload.HistogramTick) {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -101,9 +101,9 @@ type Hooks struct {
 	// loaded. It called after restoring a fixture. This, for example, is where
 	// creating foreign keys should go. Implementations should be idempotent.
 	PostLoad func(*gosql.DB) error
-	// PostRun is called after workload run has ended, with the start time of the
+	// PostRun is called after workload run has ended, with the duration of the
 	// run. This is where any post-run special printing or validation can be done.
-	PostRun func(time.Time) error
+	PostRun func(time.Duration) error
 	// CheckConsistency is called to run generator-specific consistency checks.
 	// These are expected to pass after the initial data load as well as after
 	// running queryload.


### PR DESCRIPTION
This change fixes an issue that allowed tpcc to achieve over 100%
efficiency. This was possible because we weren't interrupting workers
when the load gen ramp period finished. This allowed long operations
like newOrder (which waits for over 18 seconds) to complete immediately
after the ramp period finished and we began recording stats, which
shouldn't have been possible.

Release note: None