### PR TITLE
importccl: verify number of columns during IMPORT PGDUMP

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -59,7 +59,7 @@ func TestImportData(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)
 
-	sqlDB.Exec(t, `CREATE DATABASE d`)
+	sqlDB.Exec(t, `CREATE DATABASE d; USE d`)
 
 	tests := []struct {
 		name   string
@@ -305,6 +305,20 @@ d
 			with:   `WITH max_row_size = '5B'`,
 			err:    "line too long",
 		},
+		{
+			name:   "not enough values",
+			typ:    "PGCOPY",
+			create: "a INT, b INT",
+			data:   `1`,
+			err:    "expected 2 values, got 1",
+		},
+		{
+			name:   "too many values",
+			typ:    "PGCOPY",
+			create: "a INT, b INT",
+			data:   "1\t2\t3",
+			err:    "expected 2 values, got 3",
+		},
 
 		// Postgres DUMP
 		{
@@ -354,6 +368,42 @@ d
 			data: "CREATE TABLE t (i INT);",
 			with: `WITH max_row_size = '5B'`,
 			err:  "line too long",
+		},
+		{
+			name: "not enough values",
+			typ:  "PGDUMP",
+			data: `
+CREATE TABLE d.t (a INT, b INT);
+
+COPY t (a, b) FROM stdin;
+1
+\.
+			`,
+			err: "expected 2 values, got 1",
+		},
+		{
+			name: "too many values",
+			typ:  "PGDUMP",
+			data: `
+CREATE TABLE d.t (a INT, b INT);
+
+COPY t (a, b) FROM stdin;
+1	2	3
+\.
+			`,
+			err: "expected 2 values, got 3",
+		},
+		{
+			name: "too many cols",
+			typ:  "PGDUMP",
+			data: `
+CREATE TABLE d.t (a INT, b INT);
+
+COPY t (a, b, c) FROM stdin;
+1	2	3
+\.
+			`,
+			err: "expected 2 columns, got 3",
 		},
 
 		// Error

--- a/pkg/ccl/importccl/read_import_pgcopy.go
+++ b/pkg/ccl/importccl/read_import_pgcopy.go
@@ -265,7 +265,7 @@ func (d *pgCopyReader) readFile(
 			return makeRowErr(inputName, count, "%s", err)
 		}
 		if len(row) != len(d.conv.visibleColTypes) {
-			return makeRowErr(inputName, count, "expected %d columns, found %d", len(d.conv.visibleColTypes), len(row))
+			return makeRowErr(inputName, count, "expected %d values, got %d", len(d.conv.visibleColTypes), len(row))
 		}
 		for i, s := range row {
 			if s == nil {

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -372,7 +372,7 @@ func (m *pgDumpReader) readFile(
 			}
 			if conv != nil {
 				if expected, got := len(conv.visibleCols), len(i.Columns); expected != got {
-					return errors.Errorf("expected %d values, got %d", expected, got)
+					return errors.Errorf("expected %d columns, got %d", expected, got)
 				}
 				for colI, col := range i.Columns {
 					if string(col) != conv.visibleCols[colI].Name {
@@ -398,6 +398,9 @@ func (m *pgDumpReader) readFile(
 				}
 				switch row := row.(type) {
 				case copyData:
+					if expected, got := len(conv.visibleCols), len(row); expected != got {
+						return errors.Errorf("expected %d values, got %d", expected, got)
+					}
 					for i, s := range row {
 						if s == nil {
 							conv.datums[i] = tree.DNull


### PR DESCRIPTION
Also make error messages more consistent between PGDUMP and PGCOPY.

Release note (bug fix): Correctly verify number of COPY columns during
IMPORT PGDUMP.