### PR TITLE
opt: fix crash related to ordering with equivalent columns

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -805,3 +805,19 @@ sort       ·      ·
 #           └── scan  ·               ·                  (k, v)                          k!=NULL; weak-key(k,v); -v,+k
 #·                    table           kv@foo             ·                               ·
 #·                    spans           ALL                ·                               ·
+
+statement ok
+CREATE TABLE xyz (x INT, y INT, z INT, INDEX(z,y))
+
+# Verify that we set up the ordering of the inner scan correctly (see #27347).
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM xyz WHERE z=1 AND x=y ORDER BY x;
+----
+filter           ·       ·                (x, y, z)              ·
+ │               filter  x = y            ·                      ·
+ └── index-join  ·       ·                (x, y, z)              +x
+      ├── scan   ·       ·                (y, z, rowid[hidden])  +y
+      │          table   xyz@xyz_z_y_idx  ·                      ·
+      │          spans   /1-/2            ·                      ·
+      └── scan   ·       ·                (x, y, z)              ·
+·                table   xyz@primary      ·                      ·

--- a/pkg/sql/opt/norm/rules/limit.opt
+++ b/pkg/sql/opt/norm/rules/limit.opt
@@ -25,7 +25,7 @@ $input
 )
 =>
 (Project
-    (Limit $input $limit $ordering)
+    (Limit $input $limit (ProjectOrdering $input $ordering))
     $projections
 )
 
@@ -40,6 +40,6 @@ $input
 )
 =>
 (Project
-    (Offset $input $offset $ordering)
+    (Offset $input $offset (ProjectOrdering $input $ordering))
     $projections
 )

--- a/pkg/sql/opt/norm/rules/prune_cols.opt
+++ b/pkg/sql/opt/norm/rules/prune_cols.opt
@@ -105,9 +105,9 @@
 =>
 (Project
     (Limit
-        (PruneCols $input (NeededColsLimit $projections $ordering))
+        $newInput:(PruneCols $input (NeededColsLimit $projections $ordering))
         $limit
-        $ordering
+        (ProjectOrdering $newInput $ordering)
     )
     $projections
 )
@@ -129,9 +129,9 @@
 =>
 (Project
     (Offset
-        (PruneCols $input (NeededColsLimit $projections $ordering))
+        $newInput:(PruneCols $input (NeededColsLimit $projections $ordering))
         $offset
-        $ordering
+        (ProjectOrdering $newInput $ordering)
     )
     $projections
 )
@@ -211,9 +211,9 @@
 )
 =>
 (GroupBy
-    (PruneCols $input (NeededColsGroupBy $aggregations $def))
+    $newInput:(PruneCols $input (NeededColsGroupBy $aggregations $def))
     $aggregations
-    $def
+    (ProjectOrderingGroupBy $newInput $def)
 )
 
 # PruneValuesCols discards Values columns that are never used.
@@ -237,8 +237,8 @@
 =>
 (Project
     (RowNumber
-        (PruneCols $input (NeededColsRowNumber $projections $def))
-        $def
+        $newInput:(PruneCols $input (NeededColsRowNumber $projections $def))
+        (ProjectOrderingRowNumber $newInput $def)
     )
     $projections
 )

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -34,7 +34,7 @@ limit
  ├── ordering: +4,+5 opt(6)
  ├── sort
  │    ├── columns: d:4(int) e:5(int)
- │    ├── ordering: +4,+5 opt(6)
+ │    ├── ordering: +4,+5
  │    └── scan abcde
  │         └── columns: d:4(int) e:5(int)
  └── const: 10 [type=int]

--- a/pkg/sql/opt/xfunc/custom_funcs.go
+++ b/pkg/sql/opt/xfunc/custom_funcs.go
@@ -277,10 +277,3 @@ func (c *CustomFuncs) CandidateKey(group memo.GroupID) (key opt.ColSet, ok bool)
 func (c *CustomFuncs) IsColNotNull(col memo.PrivateID, input memo.GroupID) bool {
 	return c.LookupLogical(input).Relational.NotNullCols.Contains(int(c.ExtractColID(col)))
 }
-
-// HasColsInOrdering returns true if all columns that appear in an ordering are
-// output columns of the given group.
-func (c *CustomFuncs) HasColsInOrdering(group memo.GroupID, ordering memo.PrivateID) bool {
-	outCols := c.OutputCols(group)
-	return c.ExtractOrdering(ordering).SubsetOfCols(outCols)
-}


### PR DESCRIPTION
opt: fix crash related to ordering with equivalent columns

Found a crash that happens when an OrderingChoice refers to columns
other than the output columns of an operator.

This change fixes this by trimming down the columns in the
OrderingChoice when passing the requirement down. Also adding an
assertion for this condition.

The new assertion uncovered various cases where the `OrderingChoice`
stored in the private of an operator referred to columns not produced
by its input. Added an assertion for this in `checkExpr` and fixed up
a few rules.

The current `Ordering.SubsetOfCols` is renamed to `CanProject` and a
`SubsetOfCols` now implements the "strict" version of the check.

Fixes #27347.

Release note: None