### PR TITLE
libroach: more accurate encryption file statistics.

### DIFF
--- a/c-deps/libroach/ccl/ctr_stream.cc
+++ b/c-deps/libroach/ccl/ctr_stream.cc
@@ -22,27 +22,34 @@ CTRCipherStreamCreator::~CTRCipherStreamCreator() {}
 rocksdb::Status CTRCipherStreamCreator::InitSettingsAndCreateCipherStream(
     std::string* settings, std::unique_ptr<rocksdb_utils::BlockAccessCipherStream>* result) {
   auto key = key_manager_->CurrentKey();
-  if (key == nullptr || key->info().encryption_type() == enginepbccl::Plaintext) {
-    // Plaintext: don't set "settings".
-    (*result) = std::unique_ptr<rocksdb_utils::BlockAccessCipherStream>(new PlaintextStream());
-    return rocksdb::Status::OK();
-  }
 
   // Create the settings.
   enginepbccl::EncryptionSettings enc_settings;
-  enc_settings.set_encryption_type(key->info().encryption_type());
-  enc_settings.set_key_id(key->info().key_id());
 
-  // Let's get 16 random bytes. 12 for the nonce, 4 for the counter.
-  std::string random_bytes = RandomBytes(16);
-  assert(random_bytes.size() == 16);
+  if (key == nullptr || key->info().encryption_type() == enginepbccl::Plaintext) {
+    // Plaintext algorithm: only encryption_type is specified.
+    enc_settings.set_encryption_type(enginepbccl::Plaintext);
 
-  // First 12 bytes for the nonce.
-  enc_settings.set_nonce(random_bytes.substr(0, 12));
-  // Last 4 as an unsigned int32 for the counter.
-  uint32_t counter;
-  memcpy(&counter, random_bytes.data() + 12, 4);
-  enc_settings.set_counter(counter);
+    result->reset(new PlaintextStream());
+  } else {
+    // AES encryption: generate parameters and store in settings.
+    enc_settings.set_encryption_type(key->info().encryption_type());
+    enc_settings.set_key_id(key->info().key_id());
+
+    // Let's get 16 random bytes. 12 for the nonce, 4 for the counter.
+    std::string random_bytes = RandomBytes(16);
+    assert(random_bytes.size() == 16);
+
+    // First 12 bytes for the nonce.
+    enc_settings.set_nonce(random_bytes.substr(0, 12));
+    // Last 4 as an unsigned int32 for the counter.
+    uint32_t counter;
+    memcpy(&counter, random_bytes.data() + 12, 4);
+    enc_settings.set_counter(counter);
+
+    result->reset(
+        new CTRCipherStream(std::move(key), enc_settings.nonce(), enc_settings.counter()));
+  }
 
   // Serialize enc_settings directly into the passed settings pointer. This will be ignored
   // on error.
@@ -50,7 +57,6 @@ rocksdb::Status CTRCipherStreamCreator::InitSettingsAndCreateCipherStream(
     return rocksdb::Status::InvalidArgument("failed to serialize encryption settings");
   }
 
-  result->reset(new CTRCipherStream(std::move(key), enc_settings.nonce(), enc_settings.counter()));
   return rocksdb::Status::OK();
 }
 
@@ -58,13 +64,13 @@ rocksdb::Status CTRCipherStreamCreator::InitSettingsAndCreateCipherStream(
 rocksdb::Status CTRCipherStreamCreator::CreateCipherStreamFromSettings(
     const std::string& settings, std::unique_ptr<rocksdb_utils::BlockAccessCipherStream>* result) {
   enginepbccl::EncryptionSettings enc_settings;
-  if (!enc_settings.ParseFromString(settings)) {
+  if (settings.size() > 0 && !enc_settings.ParseFromString(settings)) {
     return rocksdb::Status::InvalidArgument("failed to parse encryption settings");
   }
 
   if (settings.size() == 0 || enc_settings.encryption_type() == enginepbccl::Plaintext) {
-    // Plaintext.
-    (*result) = std::unique_ptr<rocksdb_utils::BlockAccessCipherStream>(new PlaintextStream());
+    // No entry (pre-registry file therefore plaintext) or plaintext algorithm.
+    result->reset(new PlaintextStream());
     return rocksdb::Status::OK();
   }
 

--- a/c-deps/libroach/ccl/ctr_stream.h
+++ b/c-deps/libroach/ccl/ctr_stream.h
@@ -22,6 +22,8 @@ class CTRCipherStreamCreator final : public rocksdb_utils::CipherStreamCreator {
       : key_manager_(key_mgr), env_type_(env_type) {}
   virtual ~CTRCipherStreamCreator();
 
+  // Initialize 'settings' based on the current encryption algorithm and key
+  // and assign a new cipher stream to 'result'.
   virtual rocksdb::Status InitSettingsAndCreateCipherStream(
       std::string* settings,
       std::unique_ptr<rocksdb_utils::BlockAccessCipherStream>* result) override;

--- a/c-deps/libroach/ccl/db.cc
+++ b/c-deps/libroach/ccl/db.cc
@@ -82,6 +82,7 @@ class CCLEnvStatsHandler : public EnvStatsHandler {
   virtual rocksdb::Status GetFileEntryKeyID(const enginepb::FileEntry* entry,
                                             std::string* id) override {
     if (entry == nullptr) {
+      // No file entry: file written in plaintext before the file registry was used.
       *id = kPlainKeyID;
       return rocksdb::Status::OK();
     }
@@ -91,7 +92,7 @@ class CCLEnvStatsHandler : public EnvStatsHandler {
       return rocksdb::Status::InvalidArgument("failed to parse encryption settings");
     }
 
-    if (enc_settings.key_id() == "") {
+    if (enc_settings.encryption_type() == enginepbccl::Plaintext) {
       *id = kPlainKeyID;
     } else {
       *id = enc_settings.key_id();

--- a/c-deps/libroach/ccl/encrypted_env_test.cc
+++ b/c-deps/libroach/ccl/encrypted_env_test.cc
@@ -215,10 +215,10 @@ TEST(EncryptedEnv, FileOps) {
   EXPECT_OK(checkFileEntry(*file_registry, file1, enginepbccl::AES128_CTR));
   EXPECT_OK(checkFileEntry(*file_registry, file2, enginepbccl::AES128_CTR));
 
-  // Create a new file. This should delete the previous file entry.
+  // Create a new file. This should overwrite the previous file entry.
   std::string contents3("we're in plaintext!");
   ASSERT_OK(rocksdb::WriteStringToFile(encrypted_env.get(), contents3, file1, false));
-  EXPECT_OK(checkNoFileEntry(*file_registry, file1));
+  EXPECT_OK(checkFileEntry(*file_registry, file1, enginepbccl::Plaintext));
   EXPECT_OK(checkFileEntry(*file_registry, file2, enginepbccl::AES128_CTR));
   EXPECT_OK(checkFileContents(encrypted_env.get(), file1, contents3));
   // Check with the plain env.

--- a/c-deps/libroach/env_manager.h
+++ b/c-deps/libroach/env_manager.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <rocksdb/env.h>
-#include "file_registry.h"
+#include "../file_registry.h"
 #include "rocksdbutils/env_encryption.h"
 
 namespace cockroach {

--- a/c-deps/libroach/file_registry.h
+++ b/c-deps/libroach/file_registry.h
@@ -14,22 +14,29 @@
 
 #pragma once
 
+#include <libroach.h>
 #include <mutex>
+#include <rocksdb/db.h>
 #include <rocksdb/env.h>
 #include <string>
+#include <unordered_map>
 #include "protos/storage/engine/enginepb/file_registry.pb.h"
 
 namespace enginepb = cockroach::storage::engine::enginepb;
 
 namespace cockroach {
 
+struct EnvManager;
+
 // Name of the registry file.
 static const std::string kFileRegistryFilename = "COCKROACHDB_REGISTRY";
 
+// Class to compute file stats.
+class FileStats;
+
 // FileRegistry keeps track of encryption information per file.
-// Plaintext files are not registered for two reasons:
-// - they may be missing if transitioning from a non-registry version
-// - we don't want to add the extra file rewrite in non-encrypted setups
+// Plaintext files created before use of the file registry will not have an entry.
+// All files created after enabling the file registry are guaranteed to have an entry.
 //
 // All paths given to FileRegistry should be absolute paths. It converts
 // paths within `db_dir` to relative paths internally.
@@ -40,23 +47,24 @@ class FileRegistry {
   FileRegistry(rocksdb::Env* env, const std::string& db_dir, bool read_only);
   ~FileRegistry() {}
 
-  const std::string db_dir() { return db_dir_; }
+  const std::string db_dir() const { return db_dir_; }
 
   // Returns OK if the registry file does not exist.
   // An error could mean the file exists, or I/O error.
-  rocksdb::Status CheckNoRegistryFile();
+  rocksdb::Status CheckNoRegistryFile() const;
 
   // Load the file registry. Errors on file reading/parsing issues.
   // OK if the file does not exist or is empty.
   rocksdb::Status Load();
 
   // Returns a hash-set of all used env types.
-  std::unordered_set<int> GetUsedEnvTypes();
+  std::unordered_set<int> GetUsedEnvTypes() const;
 
   // Returns the FileEntry for the specified file.
   // If 'relative' is true, the path is relative to 'db_dir'.
+  // A 'nullptr' result indicates a plaintext file.
   std::unique_ptr<enginepb::FileEntry> GetFileEntry(const std::string& filename,
-                                                    bool relative = false);
+                                                    bool relative = false) const;
 
   // Insert 'entry' under 'filename' and persist the registry.
   rocksdb::Status SetFileEntry(const std::string& filename,
@@ -77,13 +85,16 @@ class FileRegistry {
   // path, else return 'path'.
   // This assumes sanitized paths (no symlinks, no relative paths) and uses a naive
   // prefix removal.
-  std::string TransformPath(const std::string& path);
+  std::string TransformPath(const std::string& path) const;
+
+  // Returns a shared pointer to the FileRegistry proto.
+  std::shared_ptr<const enginepb::FileRegistry> GetFileRegistry() const;
 
  private:
-  rocksdb::Env* env_;
-  std::string db_dir_;
-  bool read_only_;
-  std::string registry_path_;
+  rocksdb::Env* const env_;
+  const std::string db_dir_;
+  const bool read_only_;
+  const std::string registry_path_;
 
   // Write 'reg' to the registry file, and swap with registry_ if successful. mu_ is held.
   rocksdb::Status PersistRegistryLocked(std::unique_ptr<enginepb::FileRegistry> reg);
@@ -91,8 +102,75 @@ class FileRegistry {
   // The registry is read-only and can only be swapped for another one, it cannot be mutated in
   // place. mu_ must be held for any registry access.
   // TODO(mberhault): use a shared_mutex for multiple read-only holders.
-  std::mutex mu_;
-  std::unique_ptr<enginepb::FileRegistry> registry_;
+  mutable std::mutex mu_;
+  std::shared_ptr<const enginepb::FileRegistry> registry_;
+};
+
+// FileStats builds statistics about file counts and sizes.
+//
+// WARNING: It is not thread-safe and should not be reused.
+//
+// It looks up files in use by merging files reported by RocksDB with
+// our own file registry. Files that do not have a known size from the
+// listing helpers will be stated.
+//
+// It can then serve basic statictics about file/byte count matching
+// the current encryption key.
+//
+// Some caveats:
+// - files created before using the file registry will not be found
+//   in the registry and will reported in "total".
+// - RocksDB keeps older copies of files around (eg: OPTIONS file from
+//   previous run) which may not have the latest key even if the current
+//   file is properly encrypted.
+//
+// TODO(mberhault): we can improve usability/accuracy by:
+// - having a notion of "unknown" to cover files not in the registry
+// - use knowledge of file nomenclature to omit older files that
+//   are not longer live (better would be to force them to be rewritten/deleted)
+// TODO(mberhault): cache file information (especially stated size)
+// if stats computation becomes frequent.
+class FileStats {
+ public:
+  FileStats(EnvManager* env_mgr);
+  ~FileStats();
+
+  // Get the list of files from RocksDB and our own file registry.
+  // Lookup encryption settings and size for all files.
+  rocksdb::Status GetFiles(rocksdb::DB* const rep);
+
+  // Fill in basic stats for files of a given EnvType and KeyID.
+  // This fills in the count of files and bytes for:
+  // - total: env as requested, or no file entry
+  // - active_key: active key is the requested one
+  // TODO(mberhault): introduce a concept of "unknown" to distinguish
+  // between "no file entry" and "this env type but not this key".
+  rocksdb::Status GetStatsForEnvAndKey(enginepb::EnvType env_type, const std::string& active_key_id,
+                                       DBEnvStatsResult* result);
+
+ private:
+  // Called by GetRocksdDBFiles with RocksDB deletions disabled.
+  rocksdb::Status GetFilesInternal(rocksdb::DB* const rep);
+
+  // Various helpers to get file lists.
+  rocksdb::Status GetLiveFiles(rocksdb::DB* const rep);
+  rocksdb::Status GetWalFiles(rocksdb::DB* const rep);
+  void GetLiveFilesMetadata(rocksdb::DB* const rep);
+  rocksdb::Status FillRegistryEntries();
+  void StatFilesForSize();
+  std::string FixRocksDBPath(const std::string& filename);
+
+  struct FileInfo {
+    FileInfo() : has_size(false), size(0), has_entry(false) {}
+    bool has_size;
+    uint64_t size;
+    bool has_entry;
+    enginepb::FileEntry entry;
+  };
+
+  EnvManager* env_mgr_;
+  const std::string db_dir_;
+  std::unordered_map<std::string, FileInfo> files_;
 };
 
 }  // namespace cockroach

--- a/c-deps/libroach/rocksdbutils/env_encryption.cc
+++ b/c-deps/libroach/rocksdbutils/env_encryption.cc
@@ -22,7 +22,6 @@
 
 #include <algorithm>
 
-#include "../file_registry.h"
 #include "../fmt.h"
 #include "../plaintext_stream.h"
 #include "aligned_buffer.h"
@@ -572,19 +571,11 @@ class EncryptedEnv : public rocksdb::EnvWrapper {
       return status;
     }
 
-    if (encryption_settings.size() == 0) {
-      // Plaintext: delete registry entry if is exists.
-      return file_registry_->MaybeDeleteEntry(fname);
-    } else {
-      // Encryption settings specified: create a FileEntry and save it, overwriting any existing
-      // one.
-      std::unique_ptr<enginepb::FileEntry> new_entry(new enginepb::FileEntry());
-      new_entry->set_env_type(stream_creator_->GetEnvType());
-      new_entry->set_encryption_settings(encryption_settings);
-      return file_registry_->SetFileEntry(fname, std::move(new_entry));
-    }
-
-    return rocksdb::Status::OK();
+    // Create a FileEntry and save it, overwriting any existing one.
+    std::unique_ptr<enginepb::FileEntry> new_entry(new enginepb::FileEntry());
+    new_entry->set_env_type(stream_creator_->GetEnvType());
+    new_entry->set_encryption_settings(encryption_settings);
+    return file_registry_->SetFileEntry(fname, std::move(new_entry));
   }
 
  private:


### PR DESCRIPTION
Address TODOs from #26802 for more accurate file count/size calculation.

Specifically:
- plaintext files now have an entry in the file_registry
- traverse file_registry when counting files
- disable rocksdb deletions during the scan

Still some TODOs to improve usability (eg: report "unknown" files, logic for older versions of files that stick around) but this should already drastically improve file stats reporting.

Release note: None