### PR TITLE
sql: properly reject nested generators in ROWS FROM

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -360,12 +360,12 @@ CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN ((SELECT 1))
 )
 
-statement error PARTITION p1: impure functions are not allowed in partition
+statement error PARTITION p1: now\(\): impure functions are not allowed in partition
 CREATE TABLE t (a TIMESTAMP PRIMARY KEY) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (now())
 )
 
-statement error PARTITION p1: impure functions are not allowed in partition
+statement error PARTITION p1: uuid_v4\(\): impure functions are not allowed in partition
 CREATE TABLE t (a TIMESTAMP PRIMARY KEY) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (uuid_v4() || 'foo')
 )

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -86,7 +86,7 @@ CREATE TABLE foo (x, y, z) AS SELECT catalog_name, schema_name, sql_path FROM in
 statement error pq: unexpected type coltypes.TTuple
 CREATE TABLE foo2 (x) AS (VALUES(ROW()))
 
-statement error pq: generator functions are not allowed in VALUES
+statement error generator functions are not allowed in VALUES
 CREATE TABLE foo2 (x) AS (VALUES(generate_series(1,3)))
 
 statement error pq: value type unknown cannot be used for table columns

--- a/pkg/sql/logictest/testdata/logic_test/rows_from
+++ b/pkg/sql/logictest/testdata/logic_test/rows_from
@@ -67,3 +67,8 @@ x     n     generate_series
 NULL  NULL  13
 NULL  NULL  14
 NULL  NULL  15
+
+# Regression test for #27389.
+
+statement error pg_get_keywords\(\): set-returning functions must appear at the top level of FROM
+SELECT * FROM ROWS FROM(generate_series(length((pg_get_keywords()).word),10));

--- a/pkg/sql/project_set.go
+++ b/pkg/sql/project_set.go
@@ -115,7 +115,8 @@ func (p *planner) ProjectSet(
 	defer p.semaCtx.Properties.Restore(p.semaCtx.Properties)
 
 	// Ensure there are no aggregate or window functions in the clause.
-	p.semaCtx.Properties.Require("FROM", tree.RejectAggregates|tree.RejectWindowApplications)
+	p.semaCtx.Properties.Require("FROM",
+		tree.RejectAggregates|tree.RejectWindowApplications|tree.RejectNestedGenerators)
 
 	// Analyze the provided expressions.
 	n.ivarHelper = tree.MakeIndexedVarHelper(n, len(srcCols))


### PR DESCRIPTION
Fixes #27389.

Prior to this patch, invalid uses of SRFs as arguments to other
functions in ROWS FROM were not properly rejected, and were only
caught at evaluation time (i.e. much too late).

This patch fixes it by rejecting these uses early.

Release note (bug fix): invalid uses of set-generating functions in
FROM clauses are now reported with the same error code as PostgreSQL.