### PR TITLE
builder/mkrelease: specify BUILDTYPE=release

### DIFF
--- a/build/builder/mkrelease.sh
+++ b/build/builder/mkrelease.sh
@@ -91,4 +91,4 @@ case "${1-}" in
 esac
 
 shift
-(set -x && CGO_ENABLED=1 make "${args[@]}" "$@")
+(set -x && CGO_ENABLED=1 make BUILDTYPE=release "${args[@]}" "$@")


### PR DESCRIPTION
mkrelease was failing to pass BUILDTYPE=release, which notably meant it was
building RocksDB with -march=native instead of -march=generic.

Fixes #27356.

Release note: None