### PR TITLE
sql: help the user understand unsupported correlation

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -212,8 +212,11 @@ func (ex *connExecutor) prepare(
 		if optimizerPlanned, err := p.optionallyUseOptimizer(ctx, ex.sessionData, stmt); err != nil {
 			return err
 		} else if !optimizerPlanned {
+			isCorrelated := p.curPlan.isCorrelated
+			log.VEventf(ctx, 1, "query is correlated: %v", isCorrelated)
 			// Fallback if the optimizer was not enabled or used.
 			if err := p.prepare(ctx, stmt.AST); err != nil {
+				enhanceErrWithCorrelation(err, isCorrelated)
 				return err
 			}
 		}

--- a/pkg/sql/logictest/testdata/logic_test/subquery_correlated
+++ b/pkg/sql/logictest/testdata/logic_test/subquery_correlated
@@ -683,3 +683,9 @@ SELECT c.c_id, o.o_id
 FROM c
 INNER JOIN o
 ON c.c_id=o.c_id AND o.ship = (SELECT min(o.ship) FROM o WHERE o.c_id=c.c_id);
+
+statement error HINT: some correlated subqueries are not supported yet
+SELECT * FROM pg_class a WHERE EXISTS (SELECT * FROM pg_class b WHERE a.oid = b.oid)
+
+statement error HINT: some correlated subqueries are not supported yet
+SELECT * FROM pg_class a WHERE EXISTS (SELECT * FROM o WHERE a.oid = o.o_id::oid)

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -76,6 +76,15 @@ type Builder struct {
 	// case.
 	FmtFlags tree.FmtFlags
 
+	// IsCorrelated is set to true during semantic analysis if a scalar variable was
+	// pulled from an outer scope, that is, if the query was found to be correlated.
+	IsCorrelated bool
+
+	// UsingVirtualTable is set to true during semantic analysis if a
+	// FROM clause refers to a virtual table.
+	// TODO(andyk/knz): Remove when the builder supports virtual tables.
+	UsingVirtualTable bool
+
 	factory *norm.Factory
 	stmt    tree.Statement
 

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -185,6 +185,10 @@ func (b *Builder) finishBuildScalar(
 func (b *Builder) finishBuildScalarRef(
 	col *scopeColumn, label string, inScope, outScope *scope,
 ) (out memo.GroupID) {
+	isOuterColumn := inScope.isOuterColumn(col.id)
+	// Remember whether the query was correlated for later.
+	b.IsCorrelated = b.IsCorrelated || isOuterColumn
+
 	// If this is not a projection context, then wrap the column reference with
 	// a Variable expression that can be embedded in outer expression(s).
 	if outScope == nil {
@@ -193,7 +197,7 @@ func (b *Builder) finishBuildScalarRef(
 
 	// Outer columns must be wrapped in a variable expression and assigned a new
 	// column id before projection.
-	if inScope.isOuterColumn(col.id) {
+	if isOuterColumn {
 		// Avoid synthesizing a new column if possible.
 		existing := outScope.findExistingCol(col)
 		if existing == nil {

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -72,9 +72,11 @@ func (b *Builder) buildTable(texpr tree.TableExpr, inScope *scope) (outScope *sc
 			panic(builderError{err})
 		}
 
-		// TODO(andyk): Re-enable virtual tables when we can fully support them.
+		// TODO(andyk,knz): Remove this determination once virtual tables
+		// are fully supported by the optimizer.
+		// See corresponding code in sql.makeOptimizerPlan().
 		if tab.IsVirtualTable() {
-			panic(unimplementedf("virtual tables are not supported"))
+			b.UsingVirtualTable = true
 		}
 
 		return b.buildScan(tab, tn, inScope)

--- a/pkg/sql/pgwire/pgerror/errors.go
+++ b/pkg/sql/pgwire/pgerror/errors.go
@@ -17,6 +17,9 @@ package pgerror
 import (
 	"bytes"
 	"fmt"
+	"strings"
+
+	"github.com/lib/pq"
 
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	"github.com/pkg/errors"
@@ -26,6 +29,34 @@ var _ error = &Error{}
 
 func (pg *Error) Error() string {
 	return pg.Message
+}
+
+// FullError can be used when the hint and/or detail are to be tested.
+func FullError(err error) string {
+	var errString string
+	if pqErr, ok := err.(*pq.Error); ok {
+		errString = formatMsgHintDetail("pq: ", pqErr.Message, pqErr.Hint, pqErr.Detail)
+	} else if pg, ok := GetPGCause(err); ok {
+		errString = formatMsgHintDetail("", err.Error(), pg.Hint, pg.Detail)
+	} else {
+		errString = err.Error()
+	}
+	return errString
+}
+
+func formatMsgHintDetail(prefix, msg, hint, detail string) string {
+	var b strings.Builder
+	b.WriteString(prefix)
+	b.WriteString(msg)
+	if hint != "" {
+		b.WriteString("\nHINT: ")
+		b.WriteString(hint)
+	}
+	if detail != "" {
+		b.WriteString("\nDETAIL: ")
+		b.WriteString(detail)
+	}
+	return b.String()
 }
 
 // NewErrorWithDepthf creates an Error and extracts the context

--- a/pkg/testutils/error.go
+++ b/pkg/testutils/error.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
 )
 
@@ -32,7 +33,8 @@ func IsError(err error, re string) bool {
 	if err == nil || re == "" {
 		return false
 	}
-	matched, merr := regexp.MatchString(re, err.Error())
+	errString := pgerror.FullError(err)
+	matched, merr := regexp.MatchString(re, errString)
 	if merr != nil {
 		return false
 	}


### PR DESCRIPTION
Fixes #24684.

Prior to this patch, a client trying to use an unsupported correlated
query would encounter an obscure error like "column v does not exist"
or "no data source matches prefix".

Given that the new optimizer code can determine whether a query is
correlated, we can use this information to enhance the error message.

Before:

```
> select * from pg_class a where exists (select * from pg_class b where a.oid = b.oid);
pq: no data source matches prefix: a

> select * from pg_class a where exists (select * from kv where v::oid = oid);
pq: column "oid" does not exist
```

After:

```
> select * from pg_class a where exists (select * from pg_class b where a.oid = b.oid);
pq: no data source matches prefix: a
HINT: some correlated subqueries are not supported yet - see
      #3288

> select * from pg_class a where exists (select * from kv where v::oid = oid);
pq: column "oid" does not exist
HINT: some correlated subqueries are not supported yet - see
      #3288
```

Note: some correlated queries do not benefit from this improvement,
specifically those for which the optimizer code aborts early before it
has detected correlation (e.g. because of some other unrelated
feature).

Release note (sql change): CockroachDB will now report a hint in the
error message if it encounters a correlated query that it does not
support yet.
