### PR TITLE
 storage: test injecting failure into merge transactions

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
@@ -47,50 +46,56 @@ func adminMergeArgs(key roachpb.Key) *roachpb.AdminMergeRequest {
 	}
 }
 
+// createSplitRanges issues an AdminSplit command for the key "b". It returns
+// the descriptors for the ranges to the left and right of the split.
 func createSplitRanges(
-	store *storage.Store,
-) (*roachpb.RangeDescriptor, *roachpb.RangeDescriptor, *roachpb.Error) {
+	ctx context.Context, store *storage.Store,
+) (*roachpb.RangeDescriptor, *roachpb.RangeDescriptor, error) {
 	args := adminSplitArgs(roachpb.Key("b"))
-	if _, err := client.SendWrapped(context.Background(), store.TestSender(), args); err != nil {
-		return nil, nil, err
+	if _, err := client.SendWrapped(ctx, store.TestSender(), args); err != nil {
+		return nil, nil, err.GoError()
 	}
 
-	rangeADesc := store.LookupReplica([]byte("a"), nil).Desc()
-	rangeBDesc := store.LookupReplica([]byte("c"), nil).Desc()
+	lhsDesc := store.LookupReplica(roachpb.RKey("a"), nil).Desc()
+	rhsDesc := store.LookupReplica(roachpb.RKey("c"), nil).Desc()
 
-	if bytes.Equal(rangeADesc.StartKey, rangeBDesc.StartKey) {
-		log.Errorf(context.TODO(), "split ranges keys are equal %q!=%q", rangeADesc.StartKey, rangeBDesc.StartKey)
+	if bytes.Equal(lhsDesc.StartKey, rhsDesc.StartKey) {
+		return nil, nil, fmt.Errorf("split ranges have the same start key: %q = %q",
+			lhsDesc.StartKey, rhsDesc.StartKey)
 	}
 
-	return rangeADesc, rangeBDesc, nil
+	return lhsDesc, rhsDesc, nil
 }
 
 // TestStoreRangeMergeTwoEmptyRanges tries to merge two empty ranges together.
 func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
+	defer stopper.Stop(ctx)
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
-	if _, _, err := createSplitRanges(store); err != nil {
-		t.Fatal(err)
-	}
-
-	// Merge the b range back into the a range.
-	args := adminMergeArgs(roachpb.KeyMin)
-	_, err := client.SendWrapped(context.Background(), store.TestSender(), args)
+	lhsDesc, _, err := createSplitRanges(ctx, store)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Verify the merge by looking up keys from both ranges.
-	replicaA := store.LookupReplica([]byte("a"), nil)
-	replicaB := store.LookupReplica([]byte("c"), nil)
+	// Merge the RHS back into the LHS.
+	args := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
+	_, pErr := client.SendWrapped(ctx, store.TestSender(), args)
+	if pErr != nil {
+		t.Fatal(pErr)
+	}
 
-	if !reflect.DeepEqual(replicaA, replicaB) {
-		t.Fatalf("ranges were not merged %s!=%s", replicaA, replicaB)
+	// Verify the merge by looking up keys from both ranges.
+	lhsRepl := store.LookupReplica(roachpb.RKey("a"), nil)
+	rhsRepl := store.LookupReplica(roachpb.RKey("c"), nil)
+
+	if !reflect.DeepEqual(lhsRepl, rhsRepl) {
+		t.Fatalf("ranges were not merged: %s != %s", lhsRepl, rhsRepl)
 	}
 }
 
@@ -99,10 +104,11 @@ func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	ctx := context.Background()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
+	defer stopper.Stop(ctx)
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	scan := func() map[string]struct{} {
@@ -121,32 +127,32 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 	content := roachpb.Key("testing!")
 
 	// Write some values left of the proposed split key.
-	pArgs := putArgs([]byte("aaa"), content)
-	if _, err := client.SendWrapped(context.Background(), store.TestSender(), pArgs); err != nil {
-		t.Fatal(err)
+	pArgs := putArgs(roachpb.Key("aaa"), content)
+	if _, pErr := client.SendWrapped(ctx, store.TestSender(), pArgs); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Collect all the keys.
 	preKeys := scan()
 
 	// Split the range.
-	_, bDesc, err := createSplitRanges(store)
+	lhsDesc, rhsDesc, err := createSplitRanges(ctx, store)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Write some values right of the split key.
-	pArgs = putArgs([]byte("ccc"), content)
-	if _, err := client.SendWrappedWith(context.Background(), store.TestSender(), roachpb.Header{
-		RangeID: bDesc.RangeID,
-	}, pArgs); err != nil {
-		t.Fatal(err)
+	pArgs = putArgs(roachpb.Key("ccc"), content)
+	if _, pErr := client.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{
+		RangeID: rhsDesc.RangeID,
+	}, pArgs); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Merge the b range back into the a range.
-	args := adminMergeArgs(roachpb.KeyMin)
-	if _, err := client.SendWrapped(context.Background(), store.TestSender(), args); err != nil {
-		t.Fatal(err)
+	args := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
+	if _, pErr := client.SendWrapped(ctx, store.TestSender(), args); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Collect all the keys again.
@@ -157,14 +163,14 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 		delete(postKeys, k)
 	}
 
-	tombstoneKey := string(keys.RaftTombstoneKey(bDesc.RangeID))
+	tombstoneKey := string(keys.RaftTombstoneKey(rhsDesc.RangeID))
 	if _, ok := postKeys[tombstoneKey]; !ok {
 		t.Errorf("tombstone key (%s) missing after merge", roachpb.Key(tombstoneKey))
 	}
 	delete(postKeys, tombstoneKey)
 
 	// Keep only the subsumed range's local keys.
-	localRangeKeyPrefix := string(keys.MakeRangeIDPrefix(bDesc.RangeID))
+	localRangeKeyPrefix := string(keys.MakeRangeIDPrefix(rhsDesc.RangeID))
 	for k := range postKeys {
 		if !strings.HasPrefix(k, localRangeKeyPrefix) {
 			delete(postKeys, k)
@@ -181,8 +187,8 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 	}
 }
 
-// TestStoreRangeMergeWithData attempts to merge two collocate ranges
-// each containing data.
+// TestStoreRangeMergeWithData attempts to merge two ranges, each containing
+// data.
 func TestStoreRangeMergeWithData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -197,12 +203,12 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 
 func mergeWithData(t *testing.T, colocate bool, retries int64) {
 	ctx := context.Background()
-	sc := storage.TestStoreConfig(nil)
-	sc.TestingKnobs.DisableReplicateQueue = true
+	storeCfg := storage.TestStoreConfig(nil)
+	storeCfg.TestingKnobs.DisableReplicateQueue = true
 
 	// Maybe inject some retryable errors when the merge transaction commits.
 	var mtc *multiTestContext
-	sc.TestingKnobs.TestingRequestFilter = func(ba roachpb.BatchRequest) *roachpb.Error {
+	storeCfg.TestingKnobs.TestingRequestFilter = func(ba roachpb.BatchRequest) *roachpb.Error {
 		for _, req := range ba.Requests {
 			if et := req.GetEndTransaction(); et != nil && et.InternalCommitTrigger.GetMergeTrigger() != nil {
 				if atomic.AddInt64(&retries, -1) >= 0 {
@@ -220,7 +226,7 @@ func mergeWithData(t *testing.T, colocate bool, retries int64) {
 		return nil
 	}
 
-	mtc = &multiTestContext{storeConfig: &sc}
+	mtc = &multiTestContext{storeConfig: &storeCfg}
 
 	var store1, store2 *storage.Store
 	if colocate {
@@ -232,45 +238,45 @@ func mergeWithData(t *testing.T, colocate bool, retries int64) {
 	}
 	defer mtc.Stop()
 
-	aDesc, bDesc, pErr := createSplitRanges(store1)
+	lhsDesc, rhsDesc, pErr := createSplitRanges(ctx, store1)
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
 
 	if !colocate {
-		mtc.replicateRange(bDesc.RangeID, 1)
-		mtc.transferLease(ctx, bDesc.RangeID, 0, 1)
-		mtc.unreplicateRange(bDesc.RangeID, 0)
+		mtc.replicateRange(rhsDesc.RangeID, 1)
+		mtc.transferLease(ctx, rhsDesc.RangeID, 0, 1)
+		mtc.unreplicateRange(rhsDesc.RangeID, 0)
 	}
 
-	content := roachpb.Key("testing!")
+	content := []byte("testing!")
 
 	// Write some values left and right of the proposed split key.
-	pArgs := putArgs([]byte("aaa"), content)
-	if _, err := client.SendWrapped(ctx, store1.TestSender(), pArgs); err != nil {
-		t.Fatal(err)
+	pArgs := putArgs(roachpb.Key("aaa"), content)
+	if _, pErr := client.SendWrapped(ctx, store1.TestSender(), pArgs); pErr != nil {
+		t.Fatal(pErr)
 	}
-	pArgs = putArgs([]byte("ccc"), content)
-	if _, err := client.SendWrappedWith(ctx, store2.TestSender(), roachpb.Header{
-		RangeID: bDesc.RangeID,
-	}, pArgs); err != nil {
-		t.Fatal(err)
+	pArgs = putArgs(roachpb.Key("ccc"), content)
+	if _, pErr := client.SendWrappedWith(ctx, store2.TestSender(), roachpb.Header{
+		RangeID: rhsDesc.RangeID,
+	}, pArgs); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Confirm the values are there.
-	gArgs := getArgs([]byte("aaa"))
-	if reply, err := client.SendWrapped(ctx, store1.TestSender(), gArgs); err != nil {
-		t.Fatal(err)
+	gArgs := getArgs(roachpb.Key("aaa"))
+	if reply, pErr := client.SendWrapped(ctx, store1.TestSender(), gArgs); pErr != nil {
+		t.Fatal(pErr)
 	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
 		t.Fatal(err)
 	} else if !bytes.Equal(replyBytes, content) {
 		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
 	}
-	gArgs = getArgs([]byte("ccc"))
-	if reply, err := client.SendWrappedWith(ctx, store2.TestSender(), roachpb.Header{
-		RangeID: bDesc.RangeID,
-	}, gArgs); err != nil {
-		t.Fatal(err)
+	gArgs = getArgs(roachpb.Key("ccc"))
+	if reply, pErr := client.SendWrappedWith(ctx, store2.TestSender(), roachpb.Header{
+		RangeID: rhsDesc.RangeID,
+	}, gArgs); pErr != nil {
+		t.Fatal(pErr)
 	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
 		t.Fatal(err)
 	} else if !bytes.Equal(replyBytes, content) {
@@ -278,48 +284,46 @@ func mergeWithData(t *testing.T, colocate bool, retries int64) {
 	}
 
 	// Merge the b range back into the a range.
-	args := adminMergeArgs(roachpb.KeyMin)
-	if _, err := client.SendWrapped(ctx, store1.TestSender(), args); err != nil {
-		t.Fatal(err)
+	args := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
+	if _, pErr := client.SendWrapped(ctx, store1.TestSender(), args); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Verify no intents remains on range descriptor keys.
-	for _, key := range []roachpb.Key{keys.RangeDescriptorKey(aDesc.StartKey), keys.RangeDescriptorKey(bDesc.StartKey)} {
+	for _, key := range []roachpb.Key{keys.RangeDescriptorKey(lhsDesc.StartKey), keys.RangeDescriptorKey(rhsDesc.StartKey)} {
 		if _, _, err := engine.MVCCGet(ctx, store1.Engine(), key, store1.Clock().Now(), true, nil); err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	// Verify the merge by looking up keys from both ranges.
-	rangeA := store1.LookupReplica([]byte("a"), nil)
-	rangeB := store1.LookupReplica([]byte("c"), nil)
-	rangeADesc := rangeA.Desc()
-	rangeBDesc := rangeB.Desc()
+	lhsRepl := store1.LookupReplica(roachpb.RKey("a"), nil)
+	rhsRepl := store1.LookupReplica(roachpb.RKey("c"), nil)
 
-	if !reflect.DeepEqual(rangeA, rangeB) {
-		t.Fatalf("ranges were not merged %+v=%+v", rangeADesc, rangeBDesc)
+	if lhsRepl != rhsRepl {
+		t.Fatalf("ranges were not merged %+v=%+v", lhsRepl.Desc(), rhsRepl.Desc())
 	}
-	if !bytes.Equal(rangeADesc.StartKey, roachpb.RKeyMin) {
-		t.Fatalf("The start key is not equal to KeyMin %q=%q", rangeADesc.StartKey, roachpb.RKeyMin)
+	if startKey := lhsRepl.Desc().StartKey; !bytes.Equal(startKey, roachpb.RKeyMin) {
+		t.Fatalf("The start key is not equal to KeyMin %q=%q", startKey, roachpb.RKeyMin)
 	}
-	if !bytes.Equal(rangeADesc.EndKey, roachpb.RKeyMax) {
-		t.Fatalf("The end key is not equal to KeyMax %q=%q", rangeADesc.EndKey, roachpb.RKeyMax)
+	if endKey := rhsRepl.Desc().EndKey; !bytes.Equal(endKey, roachpb.RKeyMax) {
+		t.Fatalf("The end key is not equal to KeyMax %q=%q", endKey, roachpb.RKeyMax)
 	}
 
 	// Try to get values from after the merge.
-	gArgs = getArgs([]byte("aaa"))
-	if reply, err := client.SendWrapped(ctx, store1.TestSender(), gArgs); err != nil {
-		t.Fatal(err)
+	gArgs = getArgs(roachpb.Key("aaa"))
+	if reply, pErr := client.SendWrapped(ctx, store1.TestSender(), gArgs); pErr != nil {
+		t.Fatal(pErr)
 	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
 		t.Fatal(err)
 	} else if !bytes.Equal(replyBytes, content) {
 		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
 	}
-	gArgs = getArgs([]byte("ccc"))
-	if reply, err := client.SendWrappedWith(ctx, store1.TestSender(), roachpb.Header{
-		RangeID: rangeB.RangeID,
-	}, gArgs); err != nil {
-		t.Fatal(err)
+	gArgs = getArgs(roachpb.Key("ccc"))
+	if reply, pErr := client.SendWrappedWith(ctx, store1.TestSender(), roachpb.Header{
+		RangeID: rhsRepl.RangeID,
+	}, gArgs); pErr != nil {
+		t.Fatal(pErr)
 	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
 		t.Fatal(err)
 	} else if !bytes.Equal(replyBytes, content) {
@@ -327,42 +331,42 @@ func mergeWithData(t *testing.T, colocate bool, retries int64) {
 	}
 
 	// Put new values after the merge on both sides.
-	pArgs = putArgs([]byte("aaaa"), content)
-	if _, err := client.SendWrapped(ctx, store1.TestSender(), pArgs); err != nil {
-		t.Fatal(err)
+	pArgs = putArgs(roachpb.Key("aaaa"), content)
+	if _, pErr := client.SendWrapped(ctx, store1.TestSender(), pArgs); pErr != nil {
+		t.Fatal(pErr)
 	}
-	pArgs = putArgs([]byte("cccc"), content)
-	if _, err := client.SendWrappedWith(ctx, store1.TestSender(), roachpb.Header{
-		RangeID: rangeB.RangeID,
-	}, pArgs); err != nil {
-		t.Fatal(err)
+	pArgs = putArgs(roachpb.Key("cccc"), content)
+	if _, pErr := client.SendWrappedWith(ctx, store1.TestSender(), roachpb.Header{
+		RangeID: rhsRepl.RangeID,
+	}, pArgs); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Try to get the newly placed values.
-	gArgs = getArgs([]byte("aaaa"))
-	if reply, err := client.SendWrapped(ctx, store1.TestSender(), gArgs); err != nil {
-		t.Fatal(err)
+	gArgs = getArgs(roachpb.Key("aaaa"))
+	if reply, pErr := client.SendWrapped(ctx, store1.TestSender(), gArgs); pErr != nil {
+		t.Fatal(pErr)
 	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
 		t.Fatal(err)
 	} else if !bytes.Equal(replyBytes, content) {
 		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
 	}
-	gArgs = getArgs([]byte("cccc"))
-	if reply, err := client.SendWrapped(ctx, store1.TestSender(), gArgs); err != nil {
-		t.Fatal(err)
+	gArgs = getArgs(roachpb.Key("cccc"))
+	if reply, pErr := client.SendWrapped(ctx, store1.TestSender(), gArgs); pErr != nil {
+		t.Fatal(pErr)
 	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
 		t.Fatal(err)
 	} else if !bytes.Equal(replyBytes, content) {
 		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
 	}
 
-	gArgs = getArgs([]byte("cccc"))
-	if _, err := client.SendWrappedWith(ctx, store2, roachpb.Header{
-		RangeID: bDesc.RangeID,
+	gArgs = getArgs(roachpb.Key("cccc"))
+	if _, pErr := client.SendWrappedWith(ctx, store2, roachpb.Header{
+		RangeID: rhsDesc.RangeID,
 	}, gArgs); !testutils.IsPError(
-		err, `r2 was not found`,
+		pErr, `r2 was not found`,
 	) {
-		t.Fatalf("expected get on rhs to fail after merge, but got err=%v", err)
+		t.Fatalf("expected get on rhs to fail after merge, but got err=%v", pErr)
 	}
 
 	if atomic.LoadInt64(&retries) >= 0 {
@@ -370,45 +374,47 @@ func mergeWithData(t *testing.T, colocate bool, retries int64) {
 	}
 }
 
-// TestStoreRangeMergeLastRange verifies that merging the last range
-// fails.
+// TestStoreRangeMergeLastRange verifies that merging the last range fails.
 func TestStoreRangeMergeLastRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
+	defer stopper.Stop(ctx)
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// Merge last range.
-	args := adminMergeArgs(roachpb.KeyMin)
-	if _, pErr := client.SendWrapped(context.Background(), store.TestSender(), args); !testutils.IsPError(pErr, "cannot merge final range") {
+	_, pErr := client.SendWrapped(ctx, store.TestSender(), adminMergeArgs(roachpb.KeyMin))
+	if !testutils.IsPError(pErr, "cannot merge final range") {
 		t.Fatalf("expected 'cannot merge final range' error; got %s", pErr)
 	}
 }
 
-// TestStoreRangeMergeStats starts by splitting a range, then writing random data
-// to both sides of the split. It then merges the ranges and verifies the merged
-// range has stats consistent with recomputations.
+// TestStoreRangeMergeStats starts by splitting a range, then writing random
+// data to both sides of the split. It then merges the ranges and verifies the
+// merged range has stats consistent with recomputations.
 func TestStoreRangeMergeStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
 	manual := hlc.NewManualClock(123)
 	storeCfg := storage.TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
+	defer stopper.Stop(ctx)
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
-	ctx := context.Background()
 
 	// Split the range.
-	aDesc, bDesc, pErr := createSplitRanges(store)
-	if pErr != nil {
-		t.Fatal(pErr)
+	lhsDesc, rhsDesc, err := createSplitRanges(ctx, store)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// Write some values left and right of the proposed split key.
-	writeRandomDataToRange(t, store, aDesc.RangeID, []byte("aaa"))
-	writeRandomDataToRange(t, store, bDesc.RangeID, []byte("ccc"))
+	writeRandomDataToRange(t, store, lhsDesc.RangeID, []byte("aaa"))
+	writeRandomDataToRange(t, store, rhsDesc.RangeID, []byte("ccc"))
 
 	// Litter some abort span records. txn1 will leave a record on the LHS, txn2
 	// will leave a record on the RHS, and txn3 will leave a record on both. This
@@ -445,31 +451,31 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	// Get the range stats for both ranges now that we have data.
 	snap := store.Engine().NewSnapshot()
 	defer snap.Close()
-	msA, err := stateloader.Make(nil /* st */, aDesc.RangeID).LoadMVCCStats(ctx, snap)
+	msA, err := stateloader.Make(nil /* st */, lhsDesc.RangeID).LoadMVCCStats(ctx, snap)
 	if err != nil {
 		t.Fatal(err)
 	}
-	msB, err := stateloader.Make(nil /* st */, bDesc.RangeID).LoadMVCCStats(ctx, snap)
+	msB, err := stateloader.Make(nil /* st */, rhsDesc.RangeID).LoadMVCCStats(ctx, snap)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Stats should agree with recomputation.
-	if err := verifyRecomputedStats(snap, aDesc, msA, manual.UnixNano()); err != nil {
+	if err := verifyRecomputedStats(snap, lhsDesc, msA, manual.UnixNano()); err != nil {
 		t.Fatalf("failed to verify range A's stats before split: %v", err)
 	}
-	if err := verifyRecomputedStats(snap, bDesc, msB, manual.UnixNano()); err != nil {
+	if err := verifyRecomputedStats(snap, rhsDesc, msB, manual.UnixNano()); err != nil {
 		t.Fatalf("failed to verify range B's stats before split: %v", err)
 	}
 
 	manual.Increment(100)
 
 	// Merge the b range back into the a range.
-	args := adminMergeArgs(roachpb.KeyMin)
+	args := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
 	if _, err := client.SendWrapped(ctx, store.TestSender(), args); err != nil {
 		t.Fatal(err)
 	}
-	replMerged := store.LookupReplica(aDesc.StartKey, nil)
+	replMerged := store.LookupReplica(lhsDesc.StartKey, nil)
 
 	// Get the range stats for the merged range and verify.
 	snap = store.Engine().NewSnapshot()
@@ -489,9 +495,9 @@ func TestStoreRangeMergeInFlightTxns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	sc := storage.TestStoreConfig(nil)
-	sc.TestingKnobs.DisableReplicateQueue = true
-	mtc := &multiTestContext{storeConfig: &sc}
+	storeCfg := storage.TestStoreConfig(nil)
+	storeCfg.TestingKnobs.DisableReplicateQueue = true
+	mtc := &multiTestContext{storeConfig: &storeCfg}
 	mtc.Start(t, 2)
 	defer mtc.Stop()
 	store := mtc.stores[0]
@@ -500,9 +506,9 @@ func TestStoreRangeMergeInFlightTxns(t *testing.T) {
 	// on the first store, and the right-hand range has exactly one replica,
 	// on the second store
 	setupReplicas := func() (lhsDesc, rhsDesc *roachpb.RangeDescriptor, err error) {
-		lhsDesc, rhsDesc, pErr := createSplitRanges(store)
-		if pErr != nil {
-			return nil, nil, pErr.GoError()
+		lhsDesc, rhsDesc, err = createSplitRanges(ctx, store)
+		if err != nil {
+			return nil, nil, err
 		}
 		mtc.replicateRange(rhsDesc.RangeID, 1)
 		mtc.transferLease(ctx, rhsDesc.RangeID, 0, 1)
@@ -528,8 +534,8 @@ func TestStoreRangeMergeInFlightTxns(t *testing.T) {
 			t.Fatal(err)
 		}
 		args := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
-		if _, err := client.SendWrapped(ctx, store.TestSender(), args); err != nil {
-			t.Fatal(err)
+		if _, pErr := client.SendWrapped(ctx, store.TestSender(), args); pErr != nil {
+			t.Fatal(pErr)
 		}
 		if err := txn.Commit(ctx); err != nil {
 			t.Fatal(err)
@@ -575,8 +581,8 @@ func TestStoreRangeMergeInFlightTxns(t *testing.T) {
 
 		// Complete the merge.
 		args := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
-		if _, err := client.SendWrapped(ctx, store.TestSender(), args); err != nil {
-			t.Fatal(err)
+		if _, pErr := client.SendWrapped(ctx, store.TestSender(), args); pErr != nil {
+			t.Fatal(pErr)
 		}
 		if _, err := txn1.Get(ctx, rhsKey); !testutils.IsError(err, "txn aborted") {
 			t.Fatalf("expected 'txn aborted' error but got %v", err)
@@ -637,8 +643,8 @@ func TestStoreRangeMergeInFlightTxns(t *testing.T) {
 
 		// Complete the merge.
 		args := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
-		if _, err := client.SendWrapped(ctx, store.TestSender(), args); err != nil {
-			t.Fatal(err)
+		if _, pErr := client.SendWrapped(ctx, store.TestSender(), args); pErr != nil {
+			t.Fatal(pErr)
 		}
 
 		if err := txn1.Commit(ctx); err != nil {
@@ -700,7 +706,7 @@ func TestStoreRangeMergeRHSLeaseExpiration(t *testing.T) {
 
 	// Install a hook to observe when a get request for a special key,
 	// rhsSentinel, exits the command queue.
-	rhsSentinel := []byte("rhs-sentinel")
+	rhsSentinel := roachpb.Key("rhs-sentinel")
 	getExitedCommandQueue := make(chan struct{})
 	storeCfg.TestingKnobs.OnCommandQueueAction = func(ba *roachpb.BatchRequest, action storagebase.CommandQueueAction) {
 		if action == storagebase.CommandQueueBeginExecuting {
@@ -720,7 +726,7 @@ func TestStoreRangeMergeRHSLeaseExpiration(t *testing.T) {
 	// the RHS on both stores and give the second store the lease. The LHS is
 	// largely irrelevant. What matters is that the RHS exists on two stores so we
 	// can transfer its lease during the merge.
-	lhsDesc, rhsDesc, err := createSplitRanges(mtc.stores[0])
+	lhsDesc, rhsDesc, err := createSplitRanges(ctx, mtc.stores[0])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -731,8 +737,8 @@ func TestStoreRangeMergeRHSLeaseExpiration(t *testing.T) {
 	mergeErr := make(chan error)
 	go func() {
 		args := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
-		_, err := client.SendWrapped(ctx, mtc.stores[0].TestSender(), args)
-		mergeErr <- err.GoError()
+		_, pErr := client.SendWrapped(ctx, mtc.stores[0].TestSender(), args)
+		mergeErr <- pErr.GoError()
 	}()
 
 	// Wait for the merge transaction to send its EndTransaction request. It won't
@@ -760,10 +766,10 @@ func TestStoreRangeMergeRHSLeaseExpiration(t *testing.T) {
 	// should notice the second store's lease is expired and try to acquire it.
 	getErr := make(chan error)
 	go func() {
-		_, err := client.SendWrappedWith(ctx, mtc.stores[0].TestSender(), roachpb.Header{
+		_, pErr := client.SendWrappedWith(ctx, mtc.stores[0].TestSender(), roachpb.Header{
 			RangeID: rhsDesc.RangeID,
 		}, getArgs(rhsSentinel))
-		getErr <- err.GoError()
+		getErr <- pErr.GoError()
 	}()
 
 	// Wait for the get request to fall out of the command queue, which is as far
@@ -791,34 +797,35 @@ func TestStoreRangeMergeRHSLeaseExpiration(t *testing.T) {
 func TestInvalidGetSnapshotForMergeRequest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	ctx := context.Background()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
+	defer stopper.Stop(ctx)
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// A GetSnapshotForMerge request that succeeds when it shouldn't will wedge a
 	// store because it waits for a merge that is not actually in progress. Set a
 	// short timeout to limit the damage.
-	ctx, cancel := context.WithTimeout(context.Background(), testutils.DefaultSucceedsSoonDuration)
+	ctx, cancel := context.WithTimeout(ctx, testutils.DefaultSucceedsSoonDuration)
 	defer cancel()
 
-	aDesc, bDesc, pErr := createSplitRanges(store)
-	if pErr != nil {
-		t.Fatal(pErr)
+	lhsDesc, rhsDesc, err := createSplitRanges(ctx, store)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	getSnapArgs := roachpb.GetSnapshotForMergeRequest{
-		RequestHeader: roachpb.RequestHeader{Key: bDesc.StartKey.AsRawKey()},
-		LeftRange:     *aDesc,
+		RequestHeader: roachpb.RequestHeader{Key: rhsDesc.StartKey.AsRawKey()},
+		LeftRange:     *lhsDesc,
 	}
 
 	// GetSnapshotForMerge from a non-neighboring LHS should fail.
 	{
 		badArgs := getSnapArgs
 		badArgs.LeftRange.EndKey = append(roachpb.RKey{}, badArgs.LeftRange.EndKey...).Next()
-		_, pErr = client.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{
-			RangeID: bDesc.RangeID,
+		_, pErr := client.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{
+			RangeID: rhsDesc.RangeID,
 		}, &badArgs)
 		if exp := "ranges are not adjacent"; !testutils.IsPError(pErr, exp) {
 			t.Fatalf("expected %q error, but got %v", exp, pErr)
@@ -826,8 +833,8 @@ func TestInvalidGetSnapshotForMergeRequest(t *testing.T) {
 	}
 
 	// GetSnapshotForMerge without an intent on the local range descriptor should fail.
-	_, pErr = client.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{
-		RangeID: bDesc.RangeID,
+	_, pErr := client.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{
+		RangeID: rhsDesc.RangeID,
 	}, &getSnapArgs)
 	if exp := "range missing intent on its local descriptor"; !testutils.IsPError(pErr, exp) {
 		t.Fatalf("expected %q error, but got %v", exp, pErr)
@@ -835,14 +842,14 @@ func TestInvalidGetSnapshotForMergeRequest(t *testing.T) {
 
 	// GetSnapshotForMerge when a non-deletion intent is present on the
 	// local range descriptor should fail.
-	err := store.DB().Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		if err := txn.Put(ctx, keys.RangeDescriptorKey(bDesc.StartKey), "garbage"); err != nil {
+	err = store.DB().Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		if err := txn.Put(ctx, keys.RangeDescriptorKey(rhsDesc.StartKey), "garbage"); err != nil {
 			return err
 		}
 		// NB: GetSnapshotForMerge intentionally takes place outside of the txn so
 		// that it sees an intent rather than the value the txn just wrote.
 		_, pErr := client.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{
-			RangeID: bDesc.RangeID,
+			RangeID: rhsDesc.RangeID,
 		}, &getSnapArgs)
 		if exp := "non-deletion intent on local range descriptor"; !testutils.IsPError(pErr, exp) {
 			return fmt.Errorf("expected %q error, but got %v", exp, pErr)
@@ -855,38 +862,36 @@ func TestInvalidGetSnapshotForMergeRequest(t *testing.T) {
 }
 
 func BenchmarkStoreRangeMerge(b *testing.B) {
+	ctx := context.Background()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
+	defer stopper.Stop(ctx)
 	store := createTestStoreWithConfig(b, stopper, storeCfg)
 
-	// Perform initial split of ranges.
-	sArgs := adminSplitArgs(roachpb.Key("b"))
-	if _, err := client.SendWrapped(context.Background(), store.TestSender(), sArgs); err != nil {
+	lhsDesc, rhsDesc, err := createSplitRanges(ctx, store)
+	if err != nil {
 		b.Fatal(err)
 	}
 
 	// Write some values left and right of the proposed split key.
-	aDesc := store.LookupReplica([]byte("a"), nil).Desc()
-	bDesc := store.LookupReplica([]byte("c"), nil).Desc()
-	writeRandomDataToRange(b, store, aDesc.RangeID, []byte("aaa"))
-	writeRandomDataToRange(b, store, bDesc.RangeID, []byte("ccc"))
+	writeRandomDataToRange(b, store, lhsDesc.RangeID, []byte("aaa"))
+	writeRandomDataToRange(b, store, rhsDesc.RangeID, []byte("ccc"))
 
 	// Create args to merge the b range back into the a range.
-	mArgs := adminMergeArgs(roachpb.KeyMin)
+	mArgs := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		// Merge the ranges.
 		b.StartTimer()
-		if _, err := client.SendWrapped(context.Background(), store.TestSender(), mArgs); err != nil {
+		if _, err := client.SendWrapped(ctx, store.TestSender(), mArgs); err != nil {
 			b.Fatal(err)
 		}
 
 		// Split the range.
 		b.StopTimer()
-		if _, err := client.SendWrapped(context.Background(), store.TestSender(), sArgs); err != nil {
+		if _, _, err := createSplitRanges(ctx, store); err != nil {
 			b.Fatal(err)
 		}
 	}


### PR DESCRIPTION
The first commit is just cleanup. The second commit is the actual test. (@ben this PR is unrelated to the issue we just discussed in person; I'll send another PR for that soon.)

Fix #27392.