### PR TITLE
storage: only acquire read lock when checking for in-progress merge

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -186,7 +187,7 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	for _, colocate := range []bool{false, true} {
-		for _, retries := range []int{0, 3} {
+		for _, retries := range []int64{0, 3} {
 			t.Run(fmt.Sprintf("colocate=%v/retries=%d", colocate, retries), func(t *testing.T) {
 				mergeWithData(t, colocate, retries)
 			})
@@ -194,17 +195,16 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 	}
 }
 
-func mergeWithData(t *testing.T, colocate bool, retries int) {
+func mergeWithData(t *testing.T, colocate bool, retries int64) {
 	ctx := context.Background()
 	sc := storage.TestStoreConfig(nil)
 	sc.TestingKnobs.DisableReplicateQueue = true
 
 	// Maybe inject some retryable errors when the merge transaction commits.
 	sc.TestingKnobs.TestingRequestFilter = func(ba roachpb.BatchRequest) *roachpb.Error {
-		if retries > 0 {
-			for _, req := range ba.Requests {
-				if et := req.GetEndTransaction(); et != nil && et.InternalCommitTrigger.GetMergeTrigger() != nil {
-					retries--
+		for _, req := range ba.Requests {
+			if et := req.GetEndTransaction(); et != nil && et.InternalCommitTrigger.GetMergeTrigger() != nil {
+				if atomic.AddInt64(&retries, -1) >= 0 {
 					return roachpb.NewError(roachpb.NewTransactionRetryError(roachpb.RETRY_SERIALIZABLE))
 				}
 			}
@@ -357,8 +357,8 @@ func mergeWithData(t *testing.T, colocate bool, retries int) {
 		t.Fatalf("expected get on rhs to fail after merge, but got err=%v", err)
 	}
 
-	if retries != 0 {
-		t.Fatalf("%d retries remaining (expected zero)", retries)
+	if atomic.LoadInt64(&retries) >= 0 {
+		t.Fatalf("%d retries remaining (expected less than zero)", retries)
 	}
 }
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2357,9 +2357,9 @@ func (r *Replica) beginCmds(
 			fn(ba, storagebase.CommandQueueBeginExecuting)
 		}
 
-		r.mu.Lock()
+		r.mu.RLock()
 		mergeCompleteCh := r.mu.mergeComplete
-		r.mu.Unlock()
+		r.mu.RUnlock()
 		if mergeCompleteCh != nil {
 			// The replica is being merged into its left-hand neighbor. This request
 			// cannot proceed until the merge completes, signaled by the closing of


### PR DESCRIPTION
Replica.mu is a reader-writer lock, so we can be slightly more efficient
when we check to see whether a merge is in progress by only acquiring a
read lock.

Release note: None