### PR TITLE
distsql: add flow setup cluster settings and improve debuggability

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -48,7 +48,9 @@
 <tr><td><code>sql.defaults.distsql</code></td><td>enumeration</td><td><code>1</code></td><td>Default distributed SQL execution mode [off = 0, auto = 1, on = 2]</td></tr>
 <tr><td><code>sql.defaults.optimizer</code></td><td>enumeration</td><td><code>1</code></td><td>Default cost-based optimizer mode [off = 0, on = 1, local = 2]</td></tr>
 <tr><td><code>sql.distsql.distribute_index_joins</code></td><td>boolean</td><td><code>true</code></td><td>if set, for index joins we instantiate a join reader on every node that has a stream; if not set, we use a single join reader</td></tr>
+<tr><td><code>sql.distsql.flow_stream_timeout</code></td><td>duration</td><td><code>10s</code></td><td>amount of time incoming streams wait for a flow to be set up before erroring out</td></tr>
 <tr><td><code>sql.distsql.interleaved_joins.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set we plan interleaved table joins instead of merge joins when possible</td></tr>
+<tr><td><code>sql.distsql.max_running_flows</code></td><td>integer</td><td><code>500</code></td><td>maximum number of concurrent flows that can be run on a node</td></tr>
 <tr><td><code>sql.distsql.merge_joins.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set, we plan merge joins when possible</td></tr>
 <tr><td><code>sql.distsql.temp_storage.joins</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable use of disk for distributed sql joins</td></tr>
 <tr><td><code>sql.distsql.temp_storage.sorts</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable use of disk for distributed sql sorts</td></tr>

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -471,7 +471,7 @@ func (f *Flow) Start(ctx context.Context, doneFn func()) error {
 	f.waitGroup.Add(len(f.inboundStreams))
 
 	if err := f.flowRegistry.RegisterFlow(
-		ctx, f.id, f, f.inboundStreams, flowStreamDefaultTimeout,
+		ctx, f.id, f, f.inboundStreams, settingFlowStreamTimeout.Get(&f.FlowCtx.Settings.SV),
 	); err != nil {
 		if f.syncFlowConsumer != nil {
 			// For sync flows, the error goes to the consumer.

--- a/pkg/sql/distsqlrun/flow_registry.go
+++ b/pkg/sql/distsqlrun/flow_registry.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -28,9 +29,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-// flowStreamDefaultTimeout is the amount of time incoming streams wait for a flow to
-// be set up before erroring out.
-const flowStreamDefaultTimeout time.Duration = 10 * time.Second
+var settingFlowStreamTimeout = settings.RegisterNonNegativeDurationSetting(
+	"sql.distsql.flow_stream_timeout",
+	"amount of time incoming streams wait for a flow to be set up before erroring out",
+	10*time.Second,
+)
 
 // expectedConnectionTime is the expected time taken by a flow to connect to its
 // consumers.

--- a/pkg/sql/distsqlrun/flow_registry_test.go
+++ b/pkg/sql/distsqlrun/flow_registry_test.go
@@ -95,9 +95,11 @@ func TestFlowRegistry(t *testing.T) {
 		t.Error("looked up unregistered flow")
 	}
 
+	const flowStreamTimeout = 10 * time.Second
+
 	ctx := context.Background()
 	if err := reg.RegisterFlow(
-		ctx, id1, f1, nil /* inboundStreams */, flowStreamDefaultTimeout,
+		ctx, id1, f1, nil /* inboundStreams */, flowStreamTimeout,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +119,7 @@ func TestFlowRegistry(t *testing.T) {
 	go func() {
 		time.Sleep(jiffy)
 		if err := reg.RegisterFlow(
-			ctx, id1, f1, nil /* inboundStreams */, flowStreamDefaultTimeout,
+			ctx, id1, f1, nil /* inboundStreams */, flowStreamTimeout,
 		); err != nil {
 			t.Error(err)
 		}
@@ -152,7 +154,7 @@ func TestFlowRegistry(t *testing.T) {
 
 	time.Sleep(jiffy)
 	if err := reg.RegisterFlow(
-		ctx, id2, f2, nil /* inboundStreams */, flowStreamDefaultTimeout,
+		ctx, id2, f2, nil /* inboundStreams */, flowStreamTimeout,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -181,7 +183,7 @@ func TestFlowRegistry(t *testing.T) {
 
 	wg1.Wait()
 	if err := reg.RegisterFlow(
-		ctx, id3, f3, nil /* inboundStreams */, flowStreamDefaultTimeout,
+		ctx, id3, f3, nil /* inboundStreams */, flowStreamTimeout,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +194,7 @@ func TestFlowRegistry(t *testing.T) {
 	go func() {
 		time.Sleep(jiffy)
 		if err := reg.RegisterFlow(
-			ctx, id4, f4, nil /* inboundStreams */, flowStreamDefaultTimeout,
+			ctx, id4, f4, nil /* inboundStreams */, flowStreamTimeout,
 		); err != nil {
 			t.Error(err)
 		}

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -179,7 +179,7 @@ func NewServer(ctx context.Context, cfg ServerConfig) *ServerImpl {
 		ServerConfig:  cfg,
 		regexpCache:   tree.NewRegexpCache(512),
 		flowRegistry:  makeFlowRegistry(cfg.NodeID.Get()),
-		flowScheduler: newFlowScheduler(cfg.AmbientContext, cfg.Stopper, cfg.Metrics),
+		flowScheduler: newFlowScheduler(cfg.AmbientContext, cfg.Stopper, cfg.Settings, cfg.Metrics),
 		memMonitor: mon.MakeMonitor(
 			"distsql",
 			mon.MemoryResource,
@@ -487,7 +487,8 @@ func (ds *ServerImpl) flowStreamInt(ctx context.Context, stream DistSQL_FlowStre
 		log.Infof(ctx, "connecting inbound stream %s/%d", flowID.Short(), streamID)
 	}
 	f, receiver, cleanup, err := ds.flowRegistry.ConnectInboundStream(
-		ctx, flowID, streamID, stream, flowStreamDefaultTimeout)
+		ctx, flowID, streamID, stream, settingFlowStreamTimeout.Get(&ds.Settings.SV),
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change adds flow setup-related cluster settings to give users the flexibility of increasing the default flow stream timeout to avoid inbound stream connection errors as well as controlling the maximum number of running flows on a node. Log messages have also been added to the flow scheduler to provide more insight into its operations and improve debugging.