### PR TITLE
rpc: fix TestHeartbeatHealth

### DIFF
--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -206,9 +206,24 @@ func TestHeartbeatHealth(t *testing.T) {
 		}
 	}()
 
+	lisNotLocalServer, err := net.Listen("tcp", "127.0.0.1:0")
+	defer func() {
+		netutil.FatalIfUnexpected(lisNotLocalServer.Close())
+	}()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lisLocalServer, err := net.Listen("tcp", "127.0.0.1:0")
+	defer func() {
+		netutil.FatalIfUnexpected(lisLocalServer.Close())
+	}()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	clientCtx := newTestContext(clock, stopper)
-	clientCtx.Addr = "notlocalserver"
-	clientCtx.AdvertiseAddr = "localserver"
+	clientCtx.Addr = lisNotLocalServer.Addr().String()
+	clientCtx.AdvertiseAddr = lisLocalServer.Addr().String()
 	// Make the interval shorter to speed up the test.
 	clientCtx.heartbeatInterval = 1 * time.Millisecond
 	if _, err := clientCtx.GRPCDial(remoteAddr).Connect(context.Background()); err != nil {
@@ -254,7 +269,14 @@ func TestHeartbeatHealth(t *testing.T) {
 		return clientCtx.ConnHealth(remoteAddr)
 	})
 
-	if err := clientCtx.ConnHealth("non-existent connection"); err != ErrNotHeartbeated {
+	lisNonExistentConnection, err := net.Listen("tcp", "127.0.0.1:0")
+	defer func() {
+		netutil.FatalIfUnexpected(lisNonExistentConnection.Close())
+	}()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := clientCtx.ConnHealth(lisNonExistentConnection.Addr().String()); err != ErrNotHeartbeated {
 		t.Errorf("wanted ErrNotHeartbeated, not %v", err)
 	}
 


### PR DESCRIPTION
This test was sending strings to ConnHealth not of the form host:port,
which was being validated asynchronously and sometimes caused that
validation error to be recieved before an ErrNotHeartbeated error. Now we'll use
addresses of the correct form, so we should always receive the ErrNotHeartbeated
error.

Close #27340

Release note: None