### PR TITLE
optbuilder: store order by columns in separate slice in scope

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -49,35 +49,25 @@ intersect
  ├── right columns: v:4(int) u:3(int) rowid:5(int)
  ├── stats: [rows=1.42857143, distinct(1,2)=1.42857143]
  ├── key: (1,2)
- ├── project
+ ├── scan xy
  │    ├── columns: x:1(int!null) y:2(int)
  │    ├── stats: [rows=1000, distinct(1,2)=1000]
  │    ├── key: (1)
- │    ├── fd: (1)-->(2)
- │    └── scan xy
- │         ├── columns: x:1(int!null) y:2(int)
- │         ├── stats: [rows=1000, distinct(1,2)=1000]
- │         ├── key: (1)
- │         └── fd: (1)-->(2)
- └── project
+ │    └── fd: (1)-->(2)
+ └── select
       ├── columns: u:3(int!null) v:4(int!null) rowid:5(int!null)
-      ├── stats: [rows=1.42857143, distinct(3-5)=1.42857143]
+      ├── stats: [rows=1.42857143, distinct(3)=1, distinct(3-5)=1.42857143]
       ├── key: (5)
       ├── fd: ()-->(3), (5)-->(4)
-      └── select
-           ├── columns: u:3(int!null) v:4(int!null) rowid:5(int!null)
-           ├── stats: [rows=1.42857143, distinct(3)=1, distinct(3-5)=1.42857143]
-           ├── key: (5)
-           ├── fd: ()-->(3), (5)-->(4)
-           ├── scan uv
-           │    ├── columns: u:3(int) v:4(int!null) rowid:5(int!null)
-           │    ├── stats: [rows=1000, distinct(3)=700, distinct(3-5)=1000]
-           │    ├── key: (5)
-           │    └── fd: (5)-->(3,4)
-           └── filters [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
-                └── eq [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight)]
-                     ├── variable: uv.u [type=int, outer=(3)]
-                     └── const: 1 [type=int]
+      ├── scan uv
+      │    ├── columns: u:3(int) v:4(int!null) rowid:5(int!null)
+      │    ├── stats: [rows=1000, distinct(3)=700, distinct(3-5)=1000]
+      │    ├── key: (5)
+      │    └── fd: (5)-->(3,4)
+      └── filters [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
+           └── eq [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight)]
+                ├── variable: uv.u [type=int, outer=(3)]
+                └── const: 1 [type=int]
 
 build
 SELECT x, x, y FROM xy EXCEPT SELECT u, v, v FROM (SELECT * FROM uv WHERE u=1) uv
@@ -88,38 +78,29 @@ except
  ├── right columns: u:3(int) v:4(int) v:4(int)
  ├── stats: [rows=1000, distinct(1,2)=1000]
  ├── key: (1,2)
- ├── project
+ ├── scan xy
  │    ├── columns: x:1(int!null) y:2(int)
  │    ├── stats: [rows=1000, distinct(1,2)=1000]
  │    ├── key: (1)
- │    ├── fd: (1)-->(2)
- │    └── scan xy
- │         ├── columns: x:1(int!null) y:2(int)
- │         ├── stats: [rows=1000, distinct(1,2)=1000]
- │         ├── key: (1)
- │         └── fd: (1)-->(2)
+ │    └── fd: (1)-->(2)
  └── project
       ├── columns: u:3(int!null) v:4(int!null)
       ├── stats: [rows=1.42857143, distinct(3,4)=1.42857143]
       ├── fd: ()-->(3)
-      └── project
-           ├── columns: u:3(int!null) v:4(int!null)
-           ├── stats: [rows=1.42857143, distinct(3,4)=1.42857143]
-           ├── fd: ()-->(3)
-           └── select
-                ├── columns: u:3(int!null) v:4(int!null) rowid:5(int!null)
-                ├── stats: [rows=1.42857143, distinct(3)=1, distinct(3,4)=1.42857143]
-                ├── key: (5)
-                ├── fd: ()-->(3), (5)-->(4)
-                ├── scan uv
-                │    ├── columns: u:3(int) v:4(int!null) rowid:5(int!null)
-                │    ├── stats: [rows=1000, distinct(3)=700, distinct(3,4)=1000]
-                │    ├── key: (5)
-                │    └── fd: (5)-->(3,4)
-                └── filters [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
-                     └── eq [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight)]
-                          ├── variable: uv.u [type=int, outer=(3)]
-                          └── const: 1 [type=int]
+      └── select
+           ├── columns: u:3(int!null) v:4(int!null) rowid:5(int!null)
+           ├── stats: [rows=1.42857143, distinct(3)=1, distinct(3,4)=1.42857143]
+           ├── key: (5)
+           ├── fd: ()-->(3), (5)-->(4)
+           ├── scan uv
+           │    ├── columns: u:3(int) v:4(int!null) rowid:5(int!null)
+           │    ├── stats: [rows=1000, distinct(3)=700, distinct(3,4)=1000]
+           │    ├── key: (5)
+           │    └── fd: (5)-->(3,4)
+           └── filters [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
+                └── eq [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight)]
+                     ├── variable: uv.u [type=int, outer=(3)]
+                     └── const: 1 [type=int]
 
 # Propagate outer columns.
 build

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -366,14 +366,14 @@ memo (optimized)
  ├── G1: (group-by G2 G3 cols=(),ordering=+2)
  │    └── "[presentation: array_agg:3]"
  │         ├── best: (group-by G2="[ordering: +2]" G3 cols=(),ordering=+2)
- │         └── cost: 1129.66
- ├── G2: (scan a,cols=(1)) (scan a,rev,cols=(1))
+ │         └── cost: 1139.66
+ ├── G2: (scan a) (scan a,rev)
  │    ├── ""
- │    │    ├── best: (scan a,cols=(1))
- │    │    └── cost: 1030.00
+ │    │    ├── best: (scan a)
+ │    │    └── cost: 1040.00
  │    └── "[ordering: +2]"
  │         ├── best: (sort G2)
- │         └── cost: 1129.66
+ │         └── cost: 1139.66
  ├── G3: (aggregations G4)
  ├── G4: (array-agg G5)
  └── G5: (variable a.x)

--- a/pkg/sql/opt/memo/testdata/stats/groupby
+++ b/pkg/sql/opt/memo/testdata/stats/groupby
@@ -128,16 +128,11 @@ project
       ├── stats: [rows=600, distinct(2-4)=600]
       ├── key: (2-4)
       ├── fd: (3,4)~~>(2), (2-4)-->(5)
-      ├── project
+      ├── scan a
       │    ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
       │    ├── stats: [rows=2000, distinct(2-4)=600]
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
-      │    └── scan a
-      │         ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
-      │         ├── stats: [rows=2000, distinct(2-4)=600]
-      │         ├── key: (1)
-      │         └── fd: (1)-->(2-4), (3,4)~~>(1,2)
+      │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
       └── aggregations [outer=(1)]
            └── max [type=int, outer=(1)]
                 └── variable: a.x [type=int, outer=(1)]
@@ -185,16 +180,11 @@ project
       │    ├── stats: [rows=600, distinct(4)=10, distinct(2-4)=600]
       │    ├── key: (2-4)
       │    ├── fd: (3,4)~~>(2), (2-4)-->(5)
-      │    ├── project
+      │    ├── scan a
       │    │    ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
       │    │    ├── stats: [rows=2000, distinct(4)=10, distinct(2-4)=600]
       │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
-      │    │    └── scan a
-      │    │         ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
-      │    │         ├── stats: [rows=2000, distinct(4)=10, distinct(2-4)=600]
-      │    │         ├── key: (1)
-      │    │         └── fd: (1)-->(2-4), (3,4)~~>(1,2)
+      │    │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
       │    └── aggregations [outer=(1)]
       │         └── max [type=int, outer=(1)]
       │              └── variable: a.x [type=int, outer=(1)]
@@ -209,36 +199,31 @@ project
 build
 SELECT sum(x), s FROM a GROUP BY s HAVING sum(x) = 5
 ----
-project
+select
  ├── columns: sum:5(decimal!null) s:4(string)
- ├── stats: [rows=1]
+ ├── stats: [rows=1, distinct(5)=1]
  ├── key: (4)
  ├── fd: ()-->(5)
- └── select
-      ├── columns: s:4(string) column5:5(decimal!null)
-      ├── stats: [rows=1, distinct(5)=1]
-      ├── key: (4)
-      ├── fd: ()-->(5)
-      ├── group-by
-      │    ├── columns: s:4(string) column5:5(decimal)
-      │    ├── grouping columns: s:4(string)
-      │    ├── stats: [rows=10, distinct(4)=10, distinct(5)=10]
-      │    ├── key: (4)
-      │    ├── fd: (4)-->(5)
-      │    ├── project
-      │    │    ├── columns: x:1(int!null) s:4(string)
-      │    │    ├── stats: [rows=2000, distinct(4)=10]
-      │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(4)
-      │    │    └── scan a
-      │    │         ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
-      │    │         ├── stats: [rows=2000, distinct(4)=10]
-      │    │         ├── key: (1)
-      │    │         └── fd: (1)-->(2-4), (3,4)~~>(1,2)
-      │    └── aggregations [outer=(1)]
-      │         └── sum [type=decimal, outer=(1)]
-      │              └── variable: a.x [type=int, outer=(1)]
-      └── filters [type=bool, outer=(5), constraints=(/5: [/5 - /5]; tight), fd=()-->(5)]
-           └── eq [type=bool, outer=(5), constraints=(/5: [/5 - /5]; tight)]
-                ├── variable: column5 [type=decimal, outer=(5)]
-                └── const: 5 [type=decimal]
+ ├── group-by
+ │    ├── columns: s:4(string) column5:5(decimal)
+ │    ├── grouping columns: s:4(string)
+ │    ├── stats: [rows=10, distinct(4)=10, distinct(5)=10]
+ │    ├── key: (4)
+ │    ├── fd: (4)-->(5)
+ │    ├── project
+ │    │    ├── columns: x:1(int!null) s:4(string)
+ │    │    ├── stats: [rows=2000, distinct(4)=10]
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(4)
+ │    │    └── scan a
+ │    │         ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
+ │    │         ├── stats: [rows=2000, distinct(4)=10]
+ │    │         ├── key: (1)
+ │    │         └── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ │    └── aggregations [outer=(1)]
+ │         └── sum [type=decimal, outer=(1)]
+ │              └── variable: a.x [type=int, outer=(1)]
+ └── filters [type=bool, outer=(5), constraints=(/5: [/5 - /5]; tight), fd=()-->(5)]
+      └── eq [type=bool, outer=(5), constraints=(/5: [/5 - /5]; tight)]
+           ├── variable: column5 [type=decimal, outer=(5)]
+           └── const: 5 [type=decimal]

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -237,36 +237,31 @@ project
 build
 SELECT sum(b.z), a.x, b.z FROM a, b GROUP BY a.x, b.z
 ----
-project
+group-by
  ├── columns: sum:8(decimal) x:1(int!null) z:6(int!null)
- ├── stats: [rows=500000]
+ ├── grouping columns: a.x:1(int!null) z:6(int!null)
+ ├── stats: [rows=500000, distinct(1,6)=500000]
  ├── key: (1,6)
  ├── fd: (1,6)-->(8)
- └── group-by
-      ├── columns: a.x:1(int!null) z:6(int!null) sum:8(decimal)
-      ├── grouping columns: a.x:1(int!null) z:6(int!null)
-      ├── stats: [rows=500000, distinct(1,6)=500000]
-      ├── key: (1,6)
-      ├── fd: (1,6)-->(8)
-      ├── project
-      │    ├── columns: a.x:1(int!null) z:6(int!null)
-      │    ├── stats: [rows=40000000, distinct(1,6)=500000]
-      │    └── inner-join
-      │         ├── columns: a.x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) b.x:5(int) z:6(int!null) rowid:7(int!null)
-      │         ├── stats: [rows=40000000, distinct(1,6)=500000]
-      │         ├── key: (1,7)
-      │         ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
-      │         ├── scan a
-      │         │    ├── columns: a.x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
-      │         │    ├── stats: [rows=4000, distinct(1)=5000]
-      │         │    ├── key: (1)
-      │         │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
-      │         ├── scan b
-      │         │    ├── columns: b.x:5(int) z:6(int!null) rowid:7(int!null)
-      │         │    ├── stats: [rows=10000, distinct(6)=100]
-      │         │    ├── key: (7)
-      │         │    └── fd: (7)-->(5,6)
-      │         └── true [type=bool]
-      └── aggregations [outer=(6)]
-           └── sum [type=decimal, outer=(6)]
-                └── variable: b.z [type=int, outer=(6)]
+ ├── project
+ │    ├── columns: a.x:1(int!null) z:6(int!null)
+ │    ├── stats: [rows=40000000, distinct(1,6)=500000]
+ │    └── inner-join
+ │         ├── columns: a.x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) b.x:5(int) z:6(int!null) rowid:7(int!null)
+ │         ├── stats: [rows=40000000, distinct(1,6)=500000]
+ │         ├── key: (1,7)
+ │         ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
+ │         ├── scan a
+ │         │    ├── columns: a.x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+ │         │    ├── stats: [rows=4000, distinct(1)=5000]
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ │         ├── scan b
+ │         │    ├── columns: b.x:5(int) z:6(int!null) rowid:7(int!null)
+ │         │    ├── stats: [rows=10000, distinct(6)=100]
+ │         │    ├── key: (7)
+ │         │    └── fd: (7)-->(5,6)
+ │         └── true [type=bool]
+ └── aggregations [outer=(6)]
+      └── sum [type=decimal, outer=(6)]
+           └── variable: b.z [type=int, outer=(6)]

--- a/pkg/sql/opt/memo/testdata/stats/set
+++ b/pkg/sql/opt/memo/testdata/stats/set
@@ -126,16 +126,11 @@ union
  ├── right columns: b.x:4(int) z:5(int) b.s:6(string) rowid:7(int)
  ├── stats: [rows=15000, distinct(8-11)=15000]
  ├── key: (8-11)
- ├── project
+ ├── scan a
  │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:3(string)
  │    ├── stats: [rows=5000, distinct(1-3)=5000]
  │    ├── key: (1)
- │    ├── fd: (1)-->(2,3)
- │    └── scan a
- │         ├── columns: a.x:1(int!null) a.y:2(int) a.s:3(string)
- │         ├── stats: [rows=5000, distinct(1-3)=5000]
- │         ├── key: (1)
- │         └── fd: (1)-->(2,3)
+ │    └── fd: (1)-->(2,3)
  └── scan b
       ├── columns: b.x:4(int) z:5(int!null) b.s:6(string) rowid:7(int!null)
       ├── stats: [rows=10000, distinct(4-7)=10000]
@@ -150,16 +145,11 @@ union-all
  ├── left columns: a.x:1(int) a.y:2(int) a.s:3(string) a.x:1(int)
  ├── right columns: b.x:4(int) z:5(int) b.s:6(string) rowid:7(int)
  ├── stats: [rows=15000]
- ├── project
+ ├── scan a
  │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:3(string)
  │    ├── stats: [rows=5000]
  │    ├── key: (1)
- │    ├── fd: (1)-->(2,3)
- │    └── scan a
- │         ├── columns: a.x:1(int!null) a.y:2(int) a.s:3(string)
- │         ├── stats: [rows=5000]
- │         ├── key: (1)
- │         └── fd: (1)-->(2,3)
+ │    └── fd: (1)-->(2,3)
  └── scan b
       ├── columns: b.x:4(int) z:5(int!null) b.s:6(string) rowid:7(int!null)
       ├── stats: [rows=10000]

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1042,36 +1042,40 @@ project
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(10)
       │    │    ├── sort
-      │    │    │    ├── columns: column9:9(string!null)
+      │    │    │    ├── columns: column8:8(int) column9:9(string!null)
       │    │    │    ├── outer: (1)
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(9)
+      │    │    │    ├── fd: ()-->(8,9)
       │    │    │    ├── ordering: +8 opt(9)
       │    │    │    └── limit
-      │    │    │         ├── columns: column9:9(string!null)
+      │    │    │         ├── columns: column8:8(int) column9:9(string!null)
       │    │    │         ├── outer: (1)
       │    │    │         ├── cardinality: [0 - 1]
       │    │    │         ├── key: ()
-      │    │    │         ├── fd: ()-->(9)
+      │    │    │         ├── fd: ()-->(8,9)
       │    │    │         ├── select
-      │    │    │         │    ├── columns: column9:9(string!null)
+      │    │    │         │    ├── columns: column8:8(int) column9:9(string!null)
       │    │    │         │    ├── outer: (1)
       │    │    │         │    ├── fd: ()-->(9)
       │    │    │         │    ├── project
-      │    │    │         │    │    ├── columns: column9:9(string)
+      │    │    │         │    │    ├── columns: column9:9(string) column8:8(int)
       │    │    │         │    │    ├── outer: (1)
       │    │    │         │    │    ├── fd: ()-->(9)
       │    │    │         │    │    ├── select
-      │    │    │         │    │    │    ├── columns: y:7(int!null)
+      │    │    │         │    │    │    ├── columns: x:6(int!null) y:7(int!null)
       │    │    │         │    │    │    ├── outer: (1)
+      │    │    │         │    │    │    ├── key: (6)
       │    │    │         │    │    │    ├── fd: ()-->(7)
       │    │    │         │    │    │    ├── scan xy
-      │    │    │         │    │    │    │    └── columns: y:7(int)
+      │    │    │         │    │    │    │    ├── columns: x:6(int!null) y:7(int)
+      │    │    │         │    │    │    │    ├── key: (6)
+      │    │    │         │    │    │    │    └── fd: (6)-->(7)
       │    │    │         │    │    │    └── filters [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
       │    │    │         │    │    │         └── xy.y = a.k [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ])]
-      │    │    │         │    │    └── projections [outer=(7)]
-      │    │    │         │    │         └── xy.y::STRING [type=string, outer=(7)]
+      │    │    │         │    │    └── projections [outer=(6,7)]
+      │    │    │         │    │         ├── xy.y::STRING [type=string, outer=(7)]
+      │    │    │         │    │         └── xy.x + xy.y [type=int, outer=(6,7)]
       │    │    │         │    └── filters [type=bool, outer=(9), constraints=(/9: (/NULL - ]; tight)]
       │    │    │         │         └── column9 IS NOT NULL [type=bool, outer=(9), constraints=(/9: (/NULL - ]; tight)]
       │    │    │         └── const: 1 [type=int]

--- a/pkg/sql/opt/optbuilder/distinct.go
+++ b/pkg/sql/opt/optbuilder/distinct.go
@@ -16,6 +16,7 @@ package optbuilder
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
@@ -39,7 +40,7 @@ func (b *Builder) buildDistinct(
 	}
 
 	outScope = inScope.replace()
-	outScope.physicalProps = inScope.physicalProps
+	outScope.copyPhysicalProps(inScope)
 
 	// Distinct is equivalent to group by without any aggregations.
 	var groupCols opt.ColSet
@@ -65,6 +66,8 @@ func (b *Builder) buildDistinct(
 		}
 	}
 
-	outScope.group = b.constructGroupBy(inScope.group, groupCols, nil /* cols */, outScope)
+	outScope.group = b.constructGroupBy(
+		inScope.group, groupCols, nil /* cols */, props.OrderingChoice{},
+	)
 	return outScope
 }

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -144,22 +144,12 @@ func (b *Builder) buildOrdering(order *tree.Order, inScope, projectionsScope, or
 	}
 }
 
-// buildOrderByProject adds any columns from orderByScope to projectionsScope
-// that are not already present in projectionsScope. buildOrderByProject also
-// sets the ordering and presentation properties on the projectionsScope.
-// These properties later become part of the required physical properties
-// returned by Build.
+// buildOrderByProject adds columns from orderByScope to the orderByCols slice
+// of projectionsScope. buildOrderByProject also sets the ordering and
+// presentation properties on the projectionsScope. These properties later
+// become part of the required physical properties returned by Build.
 func (b *Builder) buildOrderByProject(projectionsScope, orderByScope *scope) {
-	for i := range orderByScope.cols {
-		col := &orderByScope.cols[i]
-
-		// Only append order by columns that aren't already present.
-		if findColByIndex(projectionsScope.cols, col.id) == nil {
-			projectionsScope.cols = append(projectionsScope.cols, *col)
-			projectionsScope.cols[len(projectionsScope.cols)-1].hidden = true
-		}
-	}
-
+	projectionsScope.orderByCols = append(projectionsScope.orderByCols, orderByScope.cols...)
 	projectionsScope.physicalProps.Ordering = orderByScope.physicalProps.Ordering
 	projectionsScope.setPresentation()
 }

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -30,7 +30,9 @@ func (b *Builder) constructProjectForScope(inScope, projectionsScope *scope) {
 	if projectionsScope.hasSameColumns(inScope) {
 		projectionsScope.group = inScope.group
 	} else {
-		projectionsScope.group = b.constructProject(inScope.group, projectionsScope.cols)
+		projectionsScope.group = b.constructProject(
+			inScope.group, append(projectionsScope.cols, projectionsScope.orderByCols...),
+		)
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -41,6 +41,10 @@ type scope struct {
 	groupby       groupby
 	physicalProps props.Physical
 
+	// orderByCols contains all the columns specified by the ORDER BY clause.
+	// There may be some overlap with the columns in cols.
+	orderByCols []scopeColumn
+
 	// group is the memo.GroupID of the relational operator built with this scope.
 	group memo.GroupID
 
@@ -113,6 +117,26 @@ func (s *scope) appendColumn(col *scopeColumn, label string) *scopeColumn {
 		newCol.name = tree.Name(label)
 	}
 	return newCol
+}
+
+// copyPhysicalProps copies the physicalProps from the src scope to this scope.
+func (s *scope) copyPhysicalProps(src *scope) {
+	s.physicalProps.Presentation = src.physicalProps.Presentation
+	s.copyOrdering(src)
+}
+
+// copyOrdering copies the ordering and orderByCols from the src scope to this
+// scope. The groups in the new columns are reset to 0.
+func (s *scope) copyOrdering(src *scope) {
+	s.physicalProps.Ordering = src.physicalProps.Ordering
+
+	l := len(s.orderByCols)
+	s.orderByCols = append(s.orderByCols, src.orderByCols...)
+	// We want to reset the groups, as these become pass-through columns in the
+	// new scope.
+	for i := l; i < len(s.orderByCols); i++ {
+		s.orderByCols[i].group = 0
+	}
 }
 
 // setPresentation sets s.physicalProps.Presentation (if not already set).
@@ -217,11 +241,15 @@ func (s *scope) hasColumn(id opt.ColumnID) bool {
 	return false
 }
 
-// colSet returns a ColSet of all the columns in this scope.
+// colSet returns a ColSet of all the columns in this scope, including
+// orderByCols.
 func (s *scope) colSet() opt.ColSet {
 	var colSet opt.ColSet
 	for i := range s.cols {
 		colSet.Add(int(s.cols[i].id))
+	}
+	for i := range s.orderByCols {
+		colSet.Add(int(s.orderByCols[i].id))
 	}
 	return colSet
 }
@@ -681,8 +709,8 @@ func (s *scope) replaceSubquery(sub *tree.Subquery, multiRow bool, desiredColumn
 	outScope := s.builder.buildStmt(sub.Select, s)
 
 	// Treat the subquery result as an anonymous data source (i.e. column names
-	// are not qualified). Remove any hidden columns added by the subquery's
-	// ORDER BY clause.
+	// are not qualified). Remove hidden columns, as they are not accessible
+	// outside the subquery.
 	outScope.setTableAlias("")
 	outScope.removeHiddenCols()
 

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -217,18 +217,19 @@ func (s *scope) hasColumn(id opt.ColumnID) bool {
 	return false
 }
 
-// hasSameColumns returns true if this scope has the same columns
-// as the other scope (in the same order).
-func (s *scope) hasSameColumns(other *scope) bool {
-	if len(s.cols) != len(other.cols) {
-		return false
-	}
+// colSet returns a ColSet of all the columns in this scope.
+func (s *scope) colSet() opt.ColSet {
+	var colSet opt.ColSet
 	for i := range s.cols {
-		if s.cols[i].id != other.cols[i].id {
-			return false
-		}
+		colSet.Add(int(s.cols[i].id))
 	}
-	return true
+	return colSet
+}
+
+// hasSameColumns returns true if this scope has the same columns
+// as the other scope.
+func (s *scope) hasSameColumns(other *scope) bool {
+	return s.colSet().Equals(other.colSet())
 }
 
 // removeHiddenCols removes hidden columns from the scope.

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -88,8 +88,8 @@ func (b *Builder) buildTable(texpr tree.TableExpr, inScope *scope) (outScope *sc
 		outScope = b.buildStmt(source.Select, inScope)
 
 		// Treat the subquery result as an anonymous data source (i.e. column names
-		// are not qualified). Remove any hidden columns added by the subquery's
-		// ORDER BY clause.
+		// are not qualified). Remove hidden columns, as they are not accessible
+		// outside the subquery.
 		outScope.setTableAlias("")
 		outScope.removeHiddenCols()
 

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -59,42 +59,40 @@ build
 SELECT min(v), max(v), count(v), sum_int(1), avg(v), sum(v), stddev(v),
   variance(v), bool_and(v = 1), bool_and(v = 1), xor_agg(s::bytes) FROM kv
 ----
-project
+group-by
  ├── columns: min:5(int) max:6(int) count:7(int) sum_int:9(int) avg:10(decimal) sum:11(decimal) stddev:12(decimal) variance:13(decimal) bool_and:15(bool) bool_and:15(bool) xor_agg:17(bytes)
- └── group-by
-      ├── columns: min:5(int) max:6(int) count:7(int) sum_int:9(int) avg:10(decimal) sum:11(decimal) stddev:12(decimal) variance:13(decimal) bool_and:15(bool) xor_agg:17(bytes)
-      ├── project
-      │    ├── columns: column8:8(int!null) column14:14(bool) column16:16(bytes) v:2(int)
-      │    ├── scan kv
-      │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
-      │    └── projections
-      │         ├── const: 1 [type=int]
-      │         ├── eq [type=bool]
-      │         │    ├── variable: kv.v [type=int]
-      │         │    └── const: 1 [type=int]
-      │         └── cast: BYTES [type=bytes]
-      │              └── variable: kv.s [type=string]
-      └── aggregations
-           ├── min [type=int]
-           │    └── variable: kv.v [type=int]
-           ├── max [type=int]
-           │    └── variable: kv.v [type=int]
-           ├── count [type=int]
-           │    └── variable: kv.v [type=int]
-           ├── sum-int [type=int]
-           │    └── variable: column8 [type=int]
-           ├── avg [type=decimal]
-           │    └── variable: kv.v [type=int]
-           ├── sum [type=decimal]
-           │    └── variable: kv.v [type=int]
-           ├── std-dev [type=decimal]
-           │    └── variable: kv.v [type=int]
-           ├── variance [type=decimal]
-           │    └── variable: kv.v [type=int]
-           ├── bool-and [type=bool]
-           │    └── variable: column14 [type=bool]
-           └── xor-agg [type=bytes]
-                └── variable: column16 [type=bytes]
+ ├── project
+ │    ├── columns: column8:8(int!null) column14:14(bool) column16:16(bytes) v:2(int)
+ │    ├── scan kv
+ │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    └── projections
+ │         ├── const: 1 [type=int]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: kv.v [type=int]
+ │         │    └── const: 1 [type=int]
+ │         └── cast: BYTES [type=bytes]
+ │              └── variable: kv.s [type=string]
+ └── aggregations
+      ├── min [type=int]
+      │    └── variable: kv.v [type=int]
+      ├── max [type=int]
+      │    └── variable: kv.v [type=int]
+      ├── count [type=int]
+      │    └── variable: kv.v [type=int]
+      ├── sum-int [type=int]
+      │    └── variable: column8 [type=int]
+      ├── avg [type=decimal]
+      │    └── variable: kv.v [type=int]
+      ├── sum [type=decimal]
+      │    └── variable: kv.v [type=int]
+      ├── std-dev [type=decimal]
+      │    └── variable: kv.v [type=int]
+      ├── variance [type=decimal]
+      │    └── variable: kv.v [type=int]
+      ├── bool-and [type=bool]
+      │    └── variable: column14 [type=bool]
+      └── xor-agg [type=bytes]
+           └── variable: column16 [type=bytes]
 
 build
 SELECT min(1), count(1), max(1), sum_int(1), avg(1)::float, sum(1), stddev(1),
@@ -283,33 +281,29 @@ error (22023): unsupported comparison operator: <string> < <int>
 build
 SELECT count(*), k FROM kv GROUP BY k
 ----
-project
+group-by
  ├── columns: count:5(int) k:1(int!null)
- └── group-by
-      ├── columns: k:1(int!null) count:5(int)
-      ├── grouping columns: k:1(int!null)
-      ├── project
-      │    ├── columns: k:1(int!null)
-      │    └── scan kv
-      │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
-      └── aggregations
-           └── count-rows [type=int]
+ ├── grouping columns: k:1(int!null)
+ ├── project
+ │    ├── columns: k:1(int!null)
+ │    └── scan kv
+ │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ └── aggregations
+      └── count-rows [type=int]
 
 # GROUP BY specified using column index works.
 build
 SELECT count(*), k FROM kv GROUP BY 2
 ----
-project
+group-by
  ├── columns: count:5(int) k:1(int!null)
- └── group-by
-      ├── columns: k:1(int!null) count:5(int)
-      ├── grouping columns: k:1(int!null)
-      ├── project
-      │    ├── columns: k:1(int!null)
-      │    └── scan kv
-      │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
-      └── aggregations
-           └── count-rows [type=int]
+ ├── grouping columns: k:1(int!null)
+ ├── project
+ │    ├── columns: k:1(int!null)
+ │    └── scan kv
+ │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ └── aggregations
+      └── count-rows [type=int]
 
 build
 SELECT * FROM kv GROUP BY v, count(w)
@@ -355,113 +349,99 @@ error (42601): non-integer constant in GROUP BY: 'a'
 build
 SELECT count(*), kv.s FROM kv GROUP BY s
 ----
-project
+group-by
  ├── columns: count:5(int) s:4(string)
- └── group-by
-      ├── columns: s:4(string) count:5(int)
-      ├── grouping columns: s:4(string)
-      ├── project
-      │    ├── columns: s:4(string)
-      │    └── scan kv
-      │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
-      └── aggregations
-           └── count-rows [type=int]
+ ├── grouping columns: s:4(string)
+ ├── project
+ │    ├── columns: s:4(string)
+ │    └── scan kv
+ │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ └── aggregations
+      └── count-rows [type=int]
 
 build
 SELECT count(*), s FROM kv GROUP BY kv.s
 ----
-project
+group-by
  ├── columns: count:5(int) s:4(string)
- └── group-by
-      ├── columns: s:4(string) count:5(int)
-      ├── grouping columns: s:4(string)
-      ├── project
-      │    ├── columns: s:4(string)
-      │    └── scan kv
-      │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
-      └── aggregations
-           └── count-rows [type=int]
+ ├── grouping columns: s:4(string)
+ ├── project
+ │    ├── columns: s:4(string)
+ │    └── scan kv
+ │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ └── aggregations
+      └── count-rows [type=int]
 
 build
 SELECT count(*), kv.s FROM kv GROUP BY kv.s
 ----
-project
+group-by
  ├── columns: count:5(int) s:4(string)
- └── group-by
-      ├── columns: s:4(string) count:5(int)
-      ├── grouping columns: s:4(string)
-      ├── project
-      │    ├── columns: s:4(string)
-      │    └── scan kv
-      │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
-      └── aggregations
-           └── count-rows [type=int]
+ ├── grouping columns: s:4(string)
+ ├── project
+ │    ├── columns: s:4(string)
+ │    └── scan kv
+ │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ └── aggregations
+      └── count-rows [type=int]
 
 build
 SELECT count(*), s FROM kv GROUP BY s
 ----
-project
+group-by
  ├── columns: count:5(int) s:4(string)
- └── group-by
-      ├── columns: s:4(string) count:5(int)
-      ├── grouping columns: s:4(string)
-      ├── project
-      │    ├── columns: s:4(string)
-      │    └── scan kv
-      │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
-      └── aggregations
-           └── count-rows [type=int]
+ ├── grouping columns: s:4(string)
+ ├── project
+ │    ├── columns: s:4(string)
+ │    └── scan kv
+ │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ └── aggregations
+      └── count-rows [type=int]
 
 # Grouping by more than one column works.
 build
 SELECT v, count(*), w FROM kv GROUP BY v, w
 ----
-project
+group-by
  ├── columns: v:2(int) count:5(int) w:3(int)
- └── group-by
-      ├── columns: v:2(int) w:3(int) count:5(int)
-      ├── grouping columns: v:2(int) w:3(int)
-      ├── project
-      │    ├── columns: v:2(int) w:3(int)
-      │    └── scan kv
-      │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
-      └── aggregations
-           └── count-rows [type=int]
+ ├── grouping columns: v:2(int) w:3(int)
+ ├── project
+ │    ├── columns: v:2(int) w:3(int)
+ │    └── scan kv
+ │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ └── aggregations
+      └── count-rows [type=int]
 
 # Grouping by more than one column using column numbers works.
 build
 SELECT v, count(*), w FROM kv GROUP BY 1, 3
 ----
-project
+group-by
  ├── columns: v:2(int) count:5(int) w:3(int)
- └── group-by
-      ├── columns: v:2(int) w:3(int) count:5(int)
-      ├── grouping columns: v:2(int) w:3(int)
-      ├── project
-      │    ├── columns: v:2(int) w:3(int)
-      │    └── scan kv
-      │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
-      └── aggregations
-           └── count-rows [type=int]
+ ├── grouping columns: v:2(int) w:3(int)
+ ├── project
+ │    ├── columns: v:2(int) w:3(int)
+ │    └── scan kv
+ │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ └── aggregations
+      └── count-rows [type=int]
 
 # Selecting and grouping on a function expression works.
 build
 SELECT count(*), upper(s) FROM kv GROUP BY upper(s)
 ----
-project
+group-by
  ├── columns: count:6(int) upper:5(string)
- └── group-by
-      ├── columns: column5:5(string) count:6(int)
-      ├── grouping columns: column5:5(string)
-      ├── project
-      │    ├── columns: column5:5(string)
-      │    ├── scan kv
-      │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
-      │    └── projections
-      │         └── function: upper [type=string]
-      │              └── variable: kv.s [type=string]
-      └── aggregations
-           └── count-rows [type=int]
+ ├── grouping columns: column5:5(string)
+ ├── project
+ │    ├── columns: column5:5(string)
+ │    ├── scan kv
+ │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    └── projections
+ │         └── function: upper [type=string]
+ │              └── variable: kv.s [type=string]
+ └── aggregations
+      └── count-rows [type=int]
 
 # Selecting and grouping on a constant works.
 build
@@ -528,21 +508,19 @@ error (42803): column "s" must appear in the GROUP BY clause or be used in an ag
 build
 SELECT count(*), k+v AS r FROM kv GROUP BY k+v
 ----
-project
+group-by
  ├── columns: count:6(int) r:5(int)
- └── group-by
-      ├── columns: column5:5(int) count:6(int)
-      ├── grouping columns: column5:5(int)
-      ├── project
-      │    ├── columns: column5:5(int)
-      │    ├── scan kv
-      │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
-      │    └── projections
-      │         └── plus [type=int]
-      │              ├── variable: kv.k [type=int]
-      │              └── variable: kv.v [type=int]
-      └── aggregations
-           └── count-rows [type=int]
+ ├── grouping columns: column5:5(int)
+ ├── project
+ │    ├── columns: column5:5(int)
+ │    ├── scan kv
+ │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    └── projections
+ │         └── plus [type=int]
+ │              ├── variable: kv.k [type=int]
+ │              └── variable: kv.v [type=int]
+ └── aggregations
+      └── count-rows [type=int]
 
 
 # Selecting a more complex expression, made up of things which are each grouped, works.
@@ -596,22 +574,20 @@ error (42803): aggregate function calls cannot be nested
 build
 SELECT count(kv.k) AS count_1, kv.v + kv.w AS lx FROM kv GROUP BY kv.v + kv.w
 ----
-project
+group-by
  ├── columns: count_1:6(int) lx:5(int)
- └── group-by
-      ├── columns: column5:5(int) count_1:6(int)
-      ├── grouping columns: column5:5(int)
-      ├── project
-      │    ├── columns: column5:5(int) k:1(int!null)
-      │    ├── scan kv
-      │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
-      │    └── projections
-      │         └── plus [type=int]
-      │              ├── variable: kv.v [type=int]
-      │              └── variable: kv.w [type=int]
-      └── aggregations
-           └── count [type=int]
-                └── variable: kv.k [type=int]
+ ├── grouping columns: column5:5(int)
+ ├── project
+ │    ├── columns: column5:5(int) k:1(int!null)
+ │    ├── scan kv
+ │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    └── projections
+ │         └── plus [type=int]
+ │              ├── variable: kv.v [type=int]
+ │              └── variable: kv.w [type=int]
+ └── aggregations
+      └── count [type=int]
+           └── variable: kv.k [type=int]
 
 build
 SELECT count(*)
@@ -1881,10 +1857,8 @@ project
  ├── group-by
  │    ├── columns: a:1(int!null) b:2(int)
  │    ├── grouping columns: a:1(int!null) b:2(int)
- │    └── project
- │         ├── columns: a:1(int!null) b:2(int)
- │         └── scan ab
- │              └── columns: a:1(int!null) b:2(int)
+ │    └── scan ab
+ │         └── columns: a:1(int!null) b:2(int)
  └── projections
       └── tuple [type=tuple{int, int}]
            ├── variable: ab.b [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -2647,3 +2647,44 @@ sort
       │              └── variable: kv.v [type=int]
       └── projections
            └── const: 123 [type=int]
+
+# Check that ordering columns are projected correctly.
+build
+SELECT array_agg(y) FROM (SELECT * FROM xyz ORDER BY x+y)
+----
+group-by
+ ├── columns: array_agg:5(int[])
+ ├── ordering: +4
+ ├── sort
+ │    ├── columns: y:2(int) column4:4(int)
+ │    ├── ordering: +4
+ │    └── project
+ │         ├── columns: y:2(int) column4:4(int)
+ │         └── project
+ │              ├── columns: column4:4(int) x:1(int!null) y:2(int) z:3(float)
+ │              ├── scan xyz
+ │              │    └── columns: x:1(int!null) y:2(int) z:3(float)
+ │              └── projections
+ │                   └── plus [type=int]
+ │                        ├── variable: xyz.x [type=int]
+ │                        └── variable: xyz.y [type=int]
+ └── aggregations
+      └── array-agg [type=int[]]
+           └── variable: xyz.y [type=int]
+
+build
+SELECT array_agg(y) FROM (SELECT * FROM xyz ORDER BY x DESC)
+----
+group-by
+ ├── columns: array_agg:4(int[])
+ ├── ordering: -1
+ ├── sort
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── ordering: -1
+ │    └── project
+ │         ├── columns: x:1(int!null) y:2(int)
+ │         └── scan xyz
+ │              └── columns: x:1(int!null) y:2(int) z:3(float)
+ └── aggregations
+      └── array-agg [type=int[]]
+           └── variable: xyz.y [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/explain
+++ b/pkg/sql/opt/optbuilder/testdata/explain
@@ -93,7 +93,5 @@ project
       └── sort
            ├── columns: x:1(int!null) x:1(int!null) y:2(int)
            ├── ordering: +2
-           └── project
-                ├── columns: x:1(int!null) y:2(int)
-                └── scan xy
-                     └── columns: x:1(int!null) y:2(int)
+           └── scan xy
+                └── columns: x:1(int!null) y:2(int)

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -54,25 +54,23 @@ select
 build
 SELECT max(k), min(v) FROM kv HAVING min(v) > 2
 ----
-project
+select
  ├── columns: max:6(int) min:5(int!null)
- └── select
-      ├── columns: column5:5(int!null) max:6(int)
-      ├── group-by
-      │    ├── columns: column5:5(int) max:6(int)
-      │    ├── project
-      │    │    ├── columns: k:1(int!null) v:2(int)
-      │    │    └── scan kv
-      │    │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
-      │    └── aggregations
-      │         ├── min [type=int]
-      │         │    └── variable: kv.v [type=int]
-      │         └── max [type=int]
-      │              └── variable: kv.k [type=int]
-      └── filters [type=bool]
-           └── gt [type=bool]
-                ├── variable: column5 [type=int]
-                └── const: 2 [type=int]
+ ├── group-by
+ │    ├── columns: column5:5(int) max:6(int)
+ │    ├── project
+ │    │    ├── columns: k:1(int!null) v:2(int)
+ │    │    └── scan kv
+ │    │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    └── aggregations
+ │         ├── min [type=int]
+ │         │    └── variable: kv.v [type=int]
+ │         └── max [type=int]
+ │              └── variable: kv.k [type=int]
+ └── filters [type=bool]
+      └── gt [type=bool]
+           ├── variable: column5 [type=int]
+           └── const: 2 [type=int]
 
 build
 SELECT max(k), min(v) FROM kv HAVING max(v) > 2
@@ -130,27 +128,25 @@ error (42803): column "k" must appear in the GROUP BY clause or be used in an ag
 build
 SELECT count(*), k+w AS r FROM kv GROUP BY k+w HAVING (k+w) > 5
 ----
-project
+select
  ├── columns: count:6(int) r:5(int!null)
- └── select
-      ├── columns: column5:5(int!null) count:6(int)
-      ├── group-by
-      │    ├── columns: column5:5(int) count:6(int)
-      │    ├── grouping columns: column5:5(int)
-      │    ├── project
-      │    │    ├── columns: column5:5(int)
-      │    │    ├── scan kv
-      │    │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
-      │    │    └── projections
-      │    │         └── plus [type=int]
-      │    │              ├── variable: kv.k [type=int]
-      │    │              └── variable: kv.w [type=int]
-      │    └── aggregations
-      │         └── count-rows [type=int]
-      └── filters [type=bool]
-           └── gt [type=bool]
-                ├── variable: column5 [type=int]
-                └── const: 5 [type=int]
+ ├── group-by
+ │    ├── columns: column5:5(int) count:6(int)
+ │    ├── grouping columns: column5:5(int)
+ │    ├── project
+ │    │    ├── columns: column5:5(int)
+ │    │    ├── scan kv
+ │    │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    │    └── projections
+ │    │         └── plus [type=int]
+ │    │              ├── variable: kv.k [type=int]
+ │    │              └── variable: kv.w [type=int]
+ │    └── aggregations
+ │         └── count-rows [type=int]
+ └── filters [type=bool]
+      └── gt [type=bool]
+           ├── variable: column5 [type=int]
+           └── const: 5 [type=int]
 
 build
 SELECT count(*), k+w FROM kv GROUP BY k+w HAVING (k+v) > 5

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -709,15 +709,17 @@ sort
  ├── columns: b:2(int!null) c:3(int!null)
  ├── ordering: +2,+3
  └── project
-      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
-      └── select
-           ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
-           ├── scan abc
-           │    └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
-           └── filters [type=bool]
-                └── eq [type=bool]
-                     ├── variable: abc.a [type=int]
-                     └── const: 1 [type=int]
+      ├── columns: b:2(int!null) c:3(int!null)
+      └── project
+           ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+           └── select
+                ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+                ├── scan abc
+                │    └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+                └── filters [type=bool]
+                     └── eq [type=bool]
+                          ├── variable: abc.a [type=int]
+                          └── const: 1 [type=int]
 
 build
 SELECT a FROM abc ORDER BY INDEX abc@bc

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -214,10 +214,8 @@ SELECT a, b, b FROM t ORDER BY c
 sort
  ├── columns: a:1(int!null) b:2(int) b:2(int)
  ├── ordering: +3
- └── project
-      ├── columns: a:1(int!null) b:2(int) c:3(bool)
-      └── scan t
-           └── columns: a:1(int!null) b:2(int) c:3(bool)
+ └── scan t
+      └── columns: a:1(int!null) b:2(int) c:3(bool)
 
 build
 SELECT * FROM t ORDER BY (b, t.*)

--- a/pkg/sql/opt/optbuilder/testdata/project
+++ b/pkg/sql/opt/optbuilder/testdata/project
@@ -44,10 +44,8 @@ scan a
 build
 SELECT a.y, a.x FROM a
 ----
-project
- ├── columns: y:2(float) x:1(int!null)
- └── scan a
-      └── columns: x:1(int!null) y:2(float)
+scan a
+ └── columns: y:2(float) x:1(int!null)
 
 build
 SELECT * FROM a

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -97,10 +97,8 @@ select
 build
 SELECT *,* FROM abc
 ----
-project
- ├── columns: a:1(int!null) b:2(int) c:3(int) a:1(int!null) b:2(int) c:3(int)
- └── scan abc
-      └── columns: a:1(int!null) b:2(int) c:3(int)
+scan abc
+ └── columns: a:1(int!null) b:2(int) c:3(int) a:1(int!null) b:2(int) c:3(int)
 
 build
 SELECT a,a,a,a FROM abc
@@ -303,10 +301,8 @@ TABLE kw
 build
 SELECT *, "from", kw."from" FROM kw
 ----
-project
- ├── columns: from:1(int!null) from:1(int!null) from:1(int!null)
- └── scan kw
-      └── columns: from:1(int!null)
+scan kw
+ └── columns: from:1(int!null) from:1(int!null) from:1(int!null)
 
 exec-ddl
 CREATE TABLE xyzw (

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -1179,19 +1179,17 @@ values
 build
 SELECT foo.a, a, column2, foo.column2 FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three')) AS foo (a)
 ----
-project
+values
  ├── columns: a:1(int) a:1(int) column2:2(string) column2:2(string)
- └── values
-      ├── columns: column1:1(int) column2:2(string)
-      ├── tuple [type=tuple{int, string}]
-      │    ├── const: 1 [type=int]
-      │    └── const: 'one' [type=string]
-      ├── tuple [type=tuple{int, string}]
-      │    ├── const: 2 [type=int]
-      │    └── const: 'two' [type=string]
-      └── tuple [type=tuple{int, string}]
-           ├── const: 3 [type=int]
-           └── const: 'three' [type=string]
+ ├── tuple [type=tuple{int, string}]
+ │    ├── const: 1 [type=int]
+ │    └── const: 'one' [type=string]
+ ├── tuple [type=tuple{int, string}]
+ │    ├── const: 2 [type=int]
+ │    └── const: 'two' [type=string]
+ └── tuple [type=tuple{int, string}]
+      ├── const: 3 [type=int]
+      └── const: 'three' [type=string]
 
 build
 SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz WHERE x = 7)

--- a/pkg/sql/opt/optbuilder/union.go
+++ b/pkg/sql/opt/optbuilder/union.go
@@ -33,8 +33,7 @@ func (b *Builder) buildUnion(clause *tree.UnionClause, inScope *scope) (outScope
 	leftScope := b.buildSelect(clause.Left, inScope)
 	rightScope := b.buildSelect(clause.Right, inScope)
 
-	// Remove any hidden columns added by any "inner" ORDER BY clauses
-	// (which will be ignored).
+	// Remove any hidden columns, as they are not included in the Union.
 	leftScope.removeHiddenCols()
 	rightScope.removeHiddenCols()
 

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -328,17 +328,6 @@ func colsToColList(cols []scopeColumn) opt.ColList {
 	return colList
 }
 
-func findColByIndex(cols []scopeColumn, id opt.ColumnID) *scopeColumn {
-	for i := range cols {
-		col := &cols[i]
-		if col.id == id {
-			return col
-		}
-	}
-
-	return nil
-}
-
 func (b *Builder) assertNoAggregationOrWindowing(expr tree.Expr, op string) {
 	exprTransformCtx := transform.ExprTransformContext{}
 	if exprTransformCtx.AggregateInExpr(expr, b.semaCtx.SearchPath) {

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -301,18 +301,23 @@ project
 opt
 SELECT k FROM (SELECT k FROM a ORDER BY u LIMIT 1) a WHERE k = 1
 ----
-select
+project
  ├── columns: k:1(int!null)
  ├── cardinality: [0 - 1]
  ├── key: ()
- ├── fd: ()-->(1,2)
- ├── scan a@u
- │    ├── columns: k:1(int!null) u:2(int)
- │    ├── limit: 1
- │    ├── key: ()
- │    └── fd: ()-->(1,2)
- └── filters [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
-      └── a.k = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
+ ├── fd: ()-->(1)
+ └── select
+      ├── columns: k:1(int!null) u:2(int)
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(1,2)
+      ├── scan a@u
+      │    ├── columns: k:1(int!null) u:2(int)
+      │    ├── limit: 1
+      │    ├── key: ()
+      │    └── fd: ()-->(1,2)
+      └── filters [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+           └── a.k = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
 
 # --------------------------------------------------
 # PushFilterIntoLookupJoinNoRemainder


### PR DESCRIPTION
This commit adds a new slice to `scope` called `orderByCols`. `orderByCols`
contains all the columns specified by the `ORDER BY` clause (these columns may
or may not be projected in the `SELECT` list). There are a couple of advantages
to this change:

- `ORDER BY` columns that are not projected in the select list do not
  need to be stored in scope.cols, and therefore do not need to be
  marked as "hidden". The "hidden" flag is reserved for the `rowid` column
  and redundant columns in a natural/using join.

- Since hidden columns are removed from the scope when a subquery is
  used as a table in the `FROM` clause, the order by columns were not
  previously accessible outside the subquery. This was a problem because
  users can specify the order of input to aggregations with ordered subqueries,
  and the ordering columns must be projected in order for the input to be
  sorted correctly. For example, consider this query:
  ```
    SELECT array_agg(y) FROM (SELECT * FROM xyz ORDER BY x+y)
  ```
  The column `x+y` is not projected by the subquery, but the GroupBy
  operator has an ordering on `x+y` to ensure that the array produced
  by array_agg has the expected ordering. Since this will result in a sort
  directly below the GroupBy, `x+y` must be projected by the subquery.

Fixes #27131