### PR TITLE
 changefeedccl: use the async kafka producer

### DIFF
--- a/pkg/ccl/ccl_init.go
+++ b/pkg/ccl/ccl_init.go
@@ -12,11 +12,11 @@ package ccl
 // import of this package enables building a binary with CCL features.
 
 import (
-	// ccl init hooks
+	// ccl init hooks. Don't include cliccl here, it pulls in pkg/cli, which
+	// does weird things at init time.
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/buildccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl"
-	_ "github.com/cockroachdb/cockroach/pkg/ccl/cliccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/importccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/roleccl"

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -12,7 +12,6 @@ import (
 	"bytes"
 	"context"
 	gosql "database/sql"
-	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
@@ -28,33 +27,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 )
-
-func parseMetaTimestamps(v []byte) (updated, resolved hlc.Timestamp, err error) {
-	var valueRaw struct {
-		CRDB struct {
-			Resolved string `json:"resolved"`
-			Updated  string `json:"updated"`
-		} `json:"__crdb__"`
-	}
-	if err := json.Unmarshal(v, &valueRaw); err != nil {
-		return hlc.Timestamp{}, hlc.Timestamp{}, err
-	}
-	if valueRaw.CRDB.Updated != `` {
-		var err error
-		updated, err = sql.ParseHLC(valueRaw.CRDB.Updated)
-		if err != nil {
-			return hlc.Timestamp{}, hlc.Timestamp{}, err
-		}
-	}
-	if valueRaw.CRDB.Resolved != `` {
-		var err error
-		resolved, err = sql.ParseHLC(valueRaw.CRDB.Resolved)
-		if err != nil {
-			return hlc.Timestamp{}, hlc.Timestamp{}, err
-		}
-	}
-	return updated, resolved, nil
-}
 
 // createBenchmarkChangefeed starts a changefeed with some extra hooks. It
 // watches `database.table` and outputs to `sinkURI`. The given `feedClock` is

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -1,0 +1,119 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/pkg/errors"
+)
+
+type asyncProducerMock struct {
+	inputCh     chan *sarama.ProducerMessage
+	successesCh chan *sarama.ProducerMessage
+	errorsCh    chan *sarama.ProducerError
+}
+
+func (p asyncProducerMock) Input() chan<- *sarama.ProducerMessage     { return p.inputCh }
+func (p asyncProducerMock) Successes() <-chan *sarama.ProducerMessage { return p.successesCh }
+func (p asyncProducerMock) Errors() <-chan *sarama.ProducerError      { return p.errorsCh }
+func (p asyncProducerMock) Close() error                              { panic(`unimplemented`) }
+func (p asyncProducerMock) AsyncClose() {
+	close(p.inputCh)
+	close(p.successesCh)
+	close(p.errorsCh)
+}
+
+func TestKafkaSink(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	p := asyncProducerMock{
+		inputCh:     make(chan *sarama.ProducerMessage, 1),
+		successesCh: make(chan *sarama.ProducerMessage, 1),
+		errorsCh:    make(chan *sarama.ProducerError, 1),
+	}
+	sink := &kafkaSink{
+		producer:   p,
+		topicsSeen: make(map[string]struct{}),
+	}
+	sink.start()
+	defer func() {
+		if err := sink.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// No inflight
+	if err := sink.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Timeout
+	if err := sink.EmitRow(ctx, `t`, []byte(`1`), nil); err != nil {
+		t.Fatal(err)
+	}
+	m1 := <-p.inputCh
+	for i := 0; i < 2; i++ {
+		timeoutCtx, cancel := context.WithTimeout(ctx, time.Millisecond)
+		defer cancel()
+		if err := sink.Flush(timeoutCtx); !testutils.IsError(err, `context deadline exceeded`) {
+			t.Fatalf(`expected "context deadline exceeded" error got: %+v`, err)
+		}
+	}
+	go func() { p.successesCh <- m1 }()
+	if err := sink.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check no inflight again now that we've sent something
+	if err := sink.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mixed success and error.
+	if err := sink.EmitRow(ctx, `t`, []byte(`2`), nil); err != nil {
+		t.Fatal(err)
+	}
+	m2 := <-p.inputCh
+	if err := sink.EmitRow(ctx, `t`, []byte(`3`), nil); err != nil {
+		t.Fatal(err)
+	}
+	m3 := <-p.inputCh
+	if err := sink.EmitRow(ctx, `t`, []byte(`4`), nil); err != nil {
+		t.Fatal(err)
+	}
+	m4 := <-p.inputCh
+	go func() { p.successesCh <- m2 }()
+	go func() {
+		p.errorsCh <- &sarama.ProducerError{
+			Msg: m3,
+			Err: errors.New("m3"),
+		}
+	}()
+	go func() { p.successesCh <- m4 }()
+	if err := sink.Flush(ctx); !testutils.IsError(err, `m3`) {
+		t.Fatalf(`expected "m3" error got: %+v`, err)
+	}
+
+	// Check simple success again after error
+	if err := sink.EmitRow(ctx, `t`, []byte(`5`), nil); err != nil {
+		t.Fatal(err)
+	}
+	m5 := <-p.inputCh
+	go func() { p.successesCh <- m5 }()
+	if err := sink.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/ccl/changefeedccl/validations_test.go
+++ b/pkg/ccl/changefeedccl/validations_test.go
@@ -90,7 +90,7 @@ func TestValidations(t *testing.T) {
 			if err := rows.Scan(&topic, &key, &value); err != nil {
 				t.Fatalf(`%+v`, err)
 			}
-			updated, resolved, err := parseMetaTimestamps(value)
+			updated, resolved, err := ParseJSONValueTimestamps(value)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cmd/cockroach/main.go
+++ b/pkg/cmd/cockroach/main.go
@@ -20,7 +20,8 @@
 package main
 
 import (
-	_ "github.com/cockroachdb/cockroach/pkg/ccl" // ccl init hooks
+	_ "github.com/cockroachdb/cockroach/pkg/ccl"        // ccl init hooks
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/cliccl" // cliccl init hooks
 	"github.com/cockroachdb/cockroach/pkg/cli"
 	_ "github.com/cockroachdb/cockroach/pkg/ui/distccl" // ccl web UI init hook
 )


### PR DESCRIPTION
Release note (enterprise change): CHANGEFEEDs now use an asynchronous
Kafka producer, increasing throughput.