### PR TITLE
importccl: support unchecked foreign keys in IMPORT PGDUMP

### DIFF
--- a/pkg/ccl/importccl/csv_internal_test.go
+++ b/pkg/ccl/importccl/csv_internal_test.go
@@ -40,11 +40,11 @@ func TestMakeSimpleTableDescriptorErrors(t *testing.T) {
 		},
 		{
 			stmt:  "create table a (i int references b (id))",
-			error: `foreign keys not supported: FOREIGN KEY \(i\) REFERENCES b \(id\)`,
+			error: `table "b" not found`,
 		},
 		{
 			stmt:  "create table a (i int, constraint a  foreign key (i) references c (id))",
-			error: `foreign keys not supported: CONSTRAINT a FOREIGN KEY \(i\) REFERENCES c \(id\)`,
+			error: `table "c" not found`,
 		},
 		{
 			stmt: `create table a (
@@ -71,7 +71,7 @@ func TestMakeSimpleTableDescriptorErrors(t *testing.T) {
 			if !ok {
 				t.Fatal("expected CREATE TABLE statement in table file")
 			}
-			_, err = MakeSimpleTableDescriptor(ctx, st, create, defaultCSVParentID, defaultCSVTableID, 0)
+			_, err = MakeSimpleTableDescriptor(ctx, st, create, defaultCSVParentID, defaultCSVTableID, nil, 0)
 			if !testutils.IsError(err, tc.error) {
 				t.Fatalf("expected %v, got %+v", tc.error, err)
 			}

--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -39,7 +39,7 @@ func descForTable(t *testing.T, create string, parent, id sqlbase.ID) *sqlbase.T
 		t.Fatal(err)
 	}
 	stmt := parsed.(*tree.CreateTable)
-	table, err := MakeSimpleTableDescriptor(context.TODO(), nil, stmt, parent, id, testEvalCtx.StmtTimestamp.UnixNano())
+	table, err := MakeSimpleTableDescriptor(context.TODO(), nil, stmt, parent, id, nil, testEvalCtx.StmtTimestamp.UnixNano())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -125,7 +125,7 @@ func (t *partitioningTest) parse() error {
 		st := cluster.MakeTestingClusterSettings()
 		const parentID, tableID = keys.MinUserDescID, keys.MinUserDescID + 1
 		t.parsed.tableDesc, err = importccl.MakeSimpleTableDescriptor(
-			ctx, st, createTable, parentID, tableID, hlc.UnixNano())
+			ctx, st, createTable, parentID, tableID, nil, hlc.UnixNano())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
We achieve this by implementing sql.SchemaResolver with a map from the
found tables in the IMPORT and using that to resolve table names during
FK creation.

Release note (sql change): support foreign keys in IMPORT PGDUMP.