### PR TITLE
libroach: disable core file when encryption is requested.

### DIFF
--- a/c-deps/libroach/ccl/crypto_utils.cc
+++ b/c-deps/libroach/ccl/crypto_utils.cc
@@ -11,6 +11,13 @@
 #include <cryptopp/hex.h>
 #include <cryptopp/osrng.h>
 #include <cryptopp/sha.h>
+#include "../fmt.h"
+
+#ifndef _WIN32
+#include <sys/resource.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#endif
 
 std::string HexString(const std::string& s) {
   std::string value;
@@ -61,3 +68,30 @@ rocksdb_utils::BlockCipher* NewAESEncryptCipher(const enginepbccl::SecretKey* ke
 }
 
 bool UsesAESNI() { return CryptoPP::UsesAESNI(); }
+
+rocksdb::Status DisableCoreFile() {
+#ifdef _WIN32
+  return rocksdb::Status::NotSupported("preventing crash reports is not supported on Windows");
+#else
+  // We can't use prlimit on OSX. Use setrlimit and getrlimit instead.
+  rlimit lim;
+  int ret = getrlimit(RLIMIT_CORE, &lim);
+  if (ret != 0) {
+    return rocksdb::Status::NotSupported(
+        fmt::StringPrintf("failed to get core size rlimit: %s", strerror(errno)));
+  }
+
+  if (lim.rlim_cur == 0 && lim.rlim_max == 0) {
+    return rocksdb::Status::OK();
+  }
+
+  rlimit new_lim = {0, 0};
+  ret = setrlimit(RLIMIT_CORE, &new_lim);
+  if (ret != 0) {
+    return rocksdb::Status::NotSupported(
+        fmt::StringPrintf("failed to set core size rlimit: %s", strerror(errno)));
+  }
+
+  return rocksdb::Status::OK();
+#endif
+}

--- a/c-deps/libroach/ccl/crypto_utils.h
+++ b/c-deps/libroach/ccl/crypto_utils.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <rocksdb/status.h>
 #include <string>
 #include "../rocksdbutils/env_encryption.h"
 #include "ccl/storageccl/engineccl/enginepbccl/key_registry.pb.h"
@@ -32,3 +33,7 @@ rocksdb_utils::BlockCipher* NewAESEncryptCipher(const enginepbccl::SecretKey* ke
 
 // Returns true if CryptoPP is using AES-NI.
 bool UsesAESNI();
+
+// DisableCoreFile sets the maximum size of a core file to 0. Returns success
+// if successfully called.
+rocksdb::Status DisableCoreFile();

--- a/c-deps/libroach/ccl/crypto_utils_test.cc
+++ b/c-deps/libroach/ccl/crypto_utils_test.cc
@@ -10,3 +10,27 @@
 #include "crypto_utils.h"
 
 TEST(CryptoUtils, HasAESNI) { EXPECT_TRUE(UsesAESNI()); }
+
+#ifdef _WIN32
+
+TEST(CryptoUtils, DisableCoreDumps) {
+  EXPECT_ERR(DisableCoreFile(), ".* not supported on Windows");
+}
+
+#else
+
+#include <sys/resource.h>
+#include <sys/time.h>
+#include <sys/types.h>
+
+TEST(CryptoUtils, DisableCoreDumps) {
+  rlimit lim = {1 << 10, 2 << 10};
+  ASSERT_EQ(0, setrlimit(RLIMIT_CORE, &lim));
+
+  EXPECT_OK(DisableCoreFile());
+  ASSERT_EQ(0, getrlimit(RLIMIT_CORE, &lim));
+  EXPECT_EQ(0, lim.rlim_cur);
+  EXPECT_EQ(0, lim.rlim_max);
+}
+
+#endif


### PR DESCRIPTION
Set core size soft/max limits to 0 when encryption-at-rest is enabled.

This spits out a loud warning on stdout (similar to warning about lack
of AES instruction set support) when the `(set|get)rlimit` calls fail,
or when running on Windows.

Release note (enterprise change): disable core dumps when enabling encryption