### PR TITLE
sql: make crdb_internal.jobs and SHOW JOBS tolerant of data errors

### DIFF
--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -791,7 +791,7 @@ func TestShowJobs(t *testing.T) {
 	var out row
 	sqlDB.QueryRow(t, `
       SELECT id, type, status, created, description, started, finished, modified,
-             fraction_completed, username, error, coordinator_id
+             fraction_completed, username, ifnull(error, ''), coordinator_id
         FROM crdb_internal.jobs`).Scan(
 		&out.id, &out.typ, &out.status, &out.created, &out.description, &out.started,
 		&out.finished, &out.modified, &out.fractionCompleted, &out.username,
@@ -800,5 +800,96 @@ func TestShowJobs(t *testing.T) {
 	if !reflect.DeepEqual(in, out) {
 		diff := strings.Join(pretty.Diff(in, out), "\n")
 		t.Fatalf("in job did not match out job:\n%s", diff)
+	}
+}
+
+func TestShowJobsWithError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	params, _ := tests.CreateTestServerParams()
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.TODO())
+
+	// Create at least 4 row, ensuring the last 3 rows are corrupted.
+	if _, err := sqlDB.Exec(`
+     -- Ensure there is at least one row in system.jobs.
+     CREATE TABLE foo(x INT); ALTER TABLE foo ADD COLUMN y INT;
+     -- Create a corrupted payload field from the first row.
+     INSERT INTO system.jobs(id, status, payload, progress) SELECT id+1, status, '\xaaaa'::BYTES, progress FROM system.jobs ORDER BY id LIMIT 1;
+     -- Create a corrupted progress field.
+     INSERT INTO system.jobs(id, status, payload, progress) SELECT id+2, status, payload, '\xaaaa'::BYTES FROM system.jobs ORDER BY id LIMIT 1;
+     INSERT INTO system.jobs(id, status, payload, progress) SELECT id+3, status, payload, NULL::BYTES FROM system.jobs ORDER BY id LIMIT 1;
+     -- Corrupt both fields.
+     INSERT INTO system.jobs(id, status, payload, progress) SELECT id+4, status, '\xaaaa'::BYTES, '\xaaaa'::BYTES FROM system.jobs ORDER BY id LIMIT 1;
+     INSERT INTO system.jobs(id, status, payload, progress) SELECT id+5, status, '\xaaaa'::BYTES, NULL::BYTES FROM system.jobs ORDER BY id LIMIT 1;
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Extract the last 4 rows from the query.
+	rows, err := sqlDB.Query(`
+  WITH a AS (SELECT id, description, fraction_completed, error FROM [SHOW JOBS] ORDER BY id DESC LIMIT 6)
+  SELECT ifnull(description, 'NULL'), ifnull(fraction_completed, -1)::string, ifnull(error,'NULL') FROM a ORDER BY id ASC`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	var desc, frac, errStr string
+
+	rowNum := 0
+	if !rows.Next() {
+		t.Fatalf("%d too few rows", rowNum)
+	}
+	if err := rows.Scan(&desc, &frac, &errStr); err != nil {
+		t.Fatalf("%d: %v", rowNum, err)
+	}
+	t.Logf("row %d: %q %q %v", rowNum, desc, errStr, frac)
+	if desc == "NULL" || errStr != "" || frac[0] == '-' {
+		t.Fatalf("%d: invalid row", rowNum)
+	}
+	rowNum++
+
+	if !rows.Next() {
+		t.Fatalf("%d: too few rows", rowNum)
+	}
+	if err := rows.Scan(&desc, &frac, &errStr); err != nil {
+		t.Fatalf("%d: %v", rowNum, err)
+	}
+	t.Logf("row %d: %q %q %v", rowNum, desc, errStr, frac)
+	if desc != "NULL" || !strings.HasPrefix(errStr, "error decoding payload") || frac[0] == '-' {
+		t.Fatalf("%d: invalid row", rowNum)
+	}
+	rowNum++
+
+	for k := 0; k < 2; k++ {
+		if !rows.Next() {
+			t.Fatalf("%d: too few rows", rowNum)
+		}
+		if err := rows.Scan(&desc, &frac, &errStr); err != nil {
+			t.Fatalf("%d: %v", rowNum, err)
+		}
+		t.Logf("row %d: %q %q %v", rowNum, desc, errStr, frac)
+		if desc == "NULL" || !strings.HasPrefix(errStr, "error decoding progress") || frac[0] != '-' {
+			t.Fatalf("%d: invalid row", rowNum)
+		}
+		rowNum++
+	}
+
+	for k := 0; k < 2; k++ {
+		if !rows.Next() {
+			t.Fatalf("%d: too few rows", rowNum)
+		}
+		if err := rows.Scan(&desc, &frac, &errStr); err != nil {
+			t.Fatalf("%d: %v", rowNum, err)
+		}
+		t.Logf("row: %q %q %v", desc, errStr, frac)
+		if desc != "NULL" ||
+			!strings.Contains(errStr, "error decoding payload") ||
+			!strings.Contains(errStr, "error decoding progress") ||
+			frac[0] != '-' {
+			t.Fatalf("%d: invalid row", rowNum)
+		}
+		rowNum++
 	}
 }


### PR DESCRIPTION
Fixes #27427.

Prior to this patch, an invalid or incomplete entry in `system.jobs`
would cause `crdb_internal.jobs` and `SHOW JOBS` to choke violently
and refuse to say anything about anything (and fail the query entirely
instead).

This patch corrects the issue by populating the `error` column adequately.

Release note (sql change): SHOW JOBS is now able to report results
even when a job entry is incomplete or incorrect.