### PR TITLE
opt: plan inverted index queries

### DIFF
--- a/pkg/sql/opt/catalog.go
+++ b/pkg/sql/opt/catalog.go
@@ -242,7 +242,11 @@ func FormatCatalogTable(tab Table, tp treeprinter.Node) {
 // formatCatalogIndex nicely formats a catalog index using a treeprinter for
 // debugging and testing.
 func formatCatalogIndex(idx Index, isPrimary bool, tp treeprinter.Node) {
-	child := tp.Childf("INDEX %s", idx.IdxName())
+	inverted := ""
+	if idx.IsInverted() {
+		inverted = "INVERTED "
+	}
+	child := tp.Childf("%sINDEX %s", inverted, idx.IdxName())
 
 	var buf bytes.Buffer
 	colCount := idx.ColumnCount()

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -15,67 +15,67 @@ CREATE INVERTED INDEX foo_inv ON d(b)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
 ----
-index-join  ·      ·                            (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                    ·                ·
- │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
- └── scan   ·      ·                            (a, b)           ·
-·           table  d@primary                    ·                ·
+index-join  ·      ·                            (a, b)  ·
+ ├── scan   ·      ·                            (a)     ·
+ │          table  d@foo_inv                    ·       ·
+ │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
+ └── scan   ·      ·                            (a, b)  ·
+·           table  d@primary                    ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": {"b": [1]}}'
 ----
-index-join  ·      ·                                        (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                                ·                ·
- │          spans  /"a"/"b"/Arr/1-/"a"/"b"/Arr/1/PrefixEnd  ·                ·
- └── scan   ·      ·                                        (a, b)           ·
-·           table  d@primary                                ·                ·
+index-join  ·      ·                                        (a, b)  ·
+ ├── scan   ·      ·                                        (a)     ·
+ │          table  d@foo_inv                                ·       ·
+ │          spans  /"a"/"b"/Arr/1-/"a"/"b"/Arr/1/PrefixEnd  ·       ·
+ └── scan   ·      ·                                        (a, b)  ·
+·           table  d@primary                                ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": [[2]]}}';
 ----
-index-join  ·      ·                                                (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                                                (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                                        ·                ·
- │          spans  /"a"/"b"/Arr/Arr/2-/"a"/"b"/Arr/Arr/2/PrefixEnd  ·                ·
- └── scan   ·      ·                                                (a, b)           ·
-·           table  d@primary                                        ·                ·
+index-join  ·      ·                                                (a, b)  ·
+ ├── scan   ·      ·                                                (a)     ·
+ │          table  d@foo_inv                                        ·       ·
+ │          spans  /"a"/"b"/Arr/Arr/2-/"a"/"b"/Arr/Arr/2/PrefixEnd  ·       ·
+ └── scan   ·      ·                                                (a, b)  ·
+·           table  d@primary                                        ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b":true}}';
 ----
-index-join  ·      ·                             (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                             (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                     ·                ·
- │          spans  /"a"/"b"/True-/"a"/"b"/False  ·                ·
- └── scan   ·      ·                             (a, b)           ·
-·           table  d@primary                     ·                ·
+index-join  ·      ·                             (a, b)  ·
+ ├── scan   ·      ·                             (a)     ·
+ │          table  d@foo_inv                     ·       ·
+ │          spans  /"a"/"b"/True-/"a"/"b"/False  ·       ·
+ └── scan   ·      ·                             (a, b)  ·
+·           table  d@primary                     ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'[1]'
 ----
-index-join  ·      ·                        (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                ·                ·
- │          spans  /Arr/1-/Arr/1/PrefixEnd  ·                ·
- └── scan   ·      ·                        (a, b)           ·
-·           table  d@primary                ·                ·
+index-join  ·      ·                        (a, b)  ·
+ ├── scan   ·      ·                        (a)     ·
+ │          table  d@foo_inv                ·       ·
+ │          spans  /Arr/1-/Arr/1/PrefixEnd  ·       ·
+ └── scan   ·      ·                        (a, b)  ·
+·           table  d@primary                ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'[{"a": {"b": [1]}}]'
 ----
-index-join  ·      ·                                                (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                                                (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                                        ·                ·
- │          spans  /Arr/"a"/"b"/Arr/1-/Arr/"a"/"b"/Arr/1/PrefixEnd  ·                ·
- └── scan   ·      ·                                                (a, b)           ·
-·           table  d@primary                                        ·                ·
+index-join  ·      ·                                                (a, b)  ·
+ ├── scan   ·      ·                                                (a)     ·
+ │          table  d@foo_inv                                        ·       ·
+ │          spans  /Arr/"a"/"b"/Arr/1-/Arr/"a"/"b"/Arr/1/PrefixEnd  ·       ·
+ └── scan   ·      ·                                                (a, b)  ·
+·           table  d@primary                                        ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[]';
 ----
-scan  ·       ·          (a, b)  a!=NULL; b!=NULL; key(a)
+scan  ·       ·          (a, b)  ·
 ·     table   d@primary  ·       ·
 ·     spans   ALL        ·       ·
 ·     filter  b @> '[]'  ·       ·
@@ -84,30 +84,28 @@ scan  ·       ·          (a, b)  a!=NULL; b!=NULL; key(a)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{}';
 ----
-scan  ·       ·          (a, b)  a!=NULL; b!=NULL; key(a)
+scan  ·       ·          (a, b)  ·
 ·     table   d@primary  ·       ·
 ·     spans   ALL        ·       ·
 ·     filter  b @> '{}'  ·       ·
 
+
+# TODO(justin): support these as well.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->'a' = '"b"'
 ----
-index-join  ·      ·                            (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                    ·                ·
- │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
- └── scan   ·      ·                            (a, b)           ·
-·           table  d@primary                    ·                ·
+scan  ·       ·                 (a, b)  ·
+·     table   d@primary         ·       ·
+·     spans   ALL               ·       ·
+·     filter  (b->'a') = '"b"'  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where '"b"' = b->'a'
 ----
-index-join  ·      ·                            (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                    ·                ·
- │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
- └── scan   ·      ·                            (a, b)           ·
-·           table  d@primary                    ·                ·
+scan  ·       ·                 (a, b)  ·
+·     table   d@primary         ·       ·
+·     spans   ALL               ·       ·
+·     filter  (b->'a') = '"b"'  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b IS NULL
@@ -136,51 +134,55 @@ scan  ·      ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
-index-join  ·       ·                                    (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·       ·                                    (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table   d@foo_inv                            ·                ·
- │          spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd  ·                ·
- └── scan   ·       ·                                    (a, b)           ·
-·           table   d@primary                            ·                ·
-·           filter  b @> '{"a": {"b": "c"}, "f": "g"}'   ·                ·
+filter           ·       ·                                    (a, b)  ·
+ │               filter  b @> '{"a": {"b": "c"}, "f": "g"}'   ·       ·
+ └── index-join  ·       ·                                    (a, b)  ·
+      ├── scan   ·       ·                                    (a)     ·
+      │          table   d@foo_inv                            ·       ·
+      │          spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd  ·       ·
+      └── scan   ·       ·                                    (a, b)  ·
+·                table   d@primary                            ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
 ----
-index-join  ·       ·                                             (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·       ·                                             (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table   d@foo_inv                                     ·                ·
- │          spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd           ·                ·
- └── scan   ·       ·                                             (a, b)           ·
-·           table   d@primary                                     ·                ·
-·           filter  b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·                ·
+filter           ·       ·                                             (a, b)  ·
+ │               filter  b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
+ └── index-join  ·       ·                                             (a, b)  ·
+      ├── scan   ·       ·                                             (a)     ·
+      │          table   d@foo_inv                                     ·       ·
+      │          spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd           ·       ·
+      └── scan   ·       ·                                             (a, b)  ·
+·                table   d@primary                                     ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
-index-join  ·       ·                                                        (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·       ·                                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table   d@foo_inv                                                ·                ·
- │          spans   /Arr/"a"/"b"/Arr/Arr/2-/Arr/"a"/"b"/Arr/Arr/2/PrefixEnd  ·                ·
- └── scan   ·       ·                                                        (a, b)           ·
-·           table   d@primary                                                ·                ·
-·           filter  b @> '[{"a": {"b": [[2]]}}, "d"]'                        ·                ·
+filter           ·       ·                                                        (a, b)  ·
+ │               filter  b @> '[{"a": {"b": [[2]]}}, "d"]'                        ·       ·
+ └── index-join  ·       ·                                                        (a, b)  ·
+      ├── scan   ·       ·                                                        (a)     ·
+      │          table   d@foo_inv                                                ·       ·
+      │          spans   /Arr/"a"/"b"/Arr/Arr/2-/Arr/"a"/"b"/Arr/Arr/2/PrefixEnd  ·       ·
+      └── scan   ·       ·                                                        (a, b)  ·
+·                table   d@primary                                                ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": 2}'
 ----
-index-join  ·       ·                         (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·       ·                         (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table   d@foo_inv                 ·                ·
- │          spans   /"b"/2-/"b"/2/PrefixEnd   ·                ·
- └── scan   ·       ·                         (a, b)           ·
-·           table   d@primary                 ·                ·
-·           filter  b @> '{"a": {}, "b": 2}'  ·                ·
+filter           ·       ·                         (a, b)  ·
+ │               filter  b @> '{"a": {}, "b": 2}'  ·       ·
+ └── index-join  ·       ·                         (a, b)  ·
+      ├── scan   ·       ·                         (a)     ·
+      │          table   d@foo_inv                 ·       ·
+      │          spans   /"b"/2-/"b"/2/PrefixEnd   ·       ·
+      └── scan   ·       ·                         (a, b)  ·
+·                table   d@primary                 ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": {}}'
 ----
-scan  ·       ·                          (a, b)  a!=NULL; b!=NULL; key(a)
+scan  ·       ·                          (a, b)  ·
 ·     table   d@primary                  ·       ·
 ·     spans   ALL                        ·       ·
 ·     filter  b @> '{"a": {}, "b": {}}'  ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -299,83 +299,83 @@ render     ·         ·          (length)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j @> '{"a": 1}' AS r FROM t
 ----
-render     ·         ·                              (r)                                                                                     ·
- │         render 0  test.public.t.j @> '{"a": 1}'  ·                                                                                       ·
- └── scan  ·         ·                              (a[omitted], b[omitted], c[omitted], d[omitted], j, s[omitted], rowid[hidden,omitted])  rowid!=NULL; key(rowid)
-·          table     t@primary                      ·                                                                                       ·
-·          spans     ALL                            ·                                                                                       ·
+render     ·         ·                (r)  ·
+ │         render 0  j @> '{"a": 1}'  ·    ·
+ └── scan  ·         ·                (j)  ·
+·          table     t@primary        ·    ·
+·          spans     ALL              ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT '{"a": 1}' <@ j AS r FROM t
 ----
-render     ·         ·                              (r)                                                                                     ·
- │         render 0  '{"a": 1}' <@ test.public.t.j  ·                                                                                       ·
- └── scan  ·         ·                              (a[omitted], b[omitted], c[omitted], d[omitted], j, s[omitted], rowid[hidden,omitted])  rowid!=NULL; key(rowid)
-·          table     t@primary                      ·                                                                                       ·
-·          spans     ALL                            ·                                                                                       ·
+render     ·         ·                (r)  ·
+ │         render 0  j @> '{"a": 1}'  ·    ·
+ └── scan  ·         ·                (j)  ·
+·          table     t@primary        ·    ·
+·          spans     ALL              ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j->>'a' AS r FROM t
 ----
-render     ·         ·                      (r)                                                                                     ·
- │         render 0  test.public.t.j->>'a'  ·                                                                                       ·
- └── scan  ·         ·                      (a[omitted], b[omitted], c[omitted], d[omitted], j, s[omitted], rowid[hidden,omitted])  rowid!=NULL; key(rowid)
-·          table     t@primary              ·                                                                                       ·
-·          spans     ALL                    ·                                                                                       ·
+render     ·         ·          (r)  ·
+ │         render 0  j->>'a'    ·    ·
+ └── scan  ·         ·          (j)  ·
+·          table     t@primary  ·    ·
+·          spans     ALL        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j->'a' AS r FROM t
 ----
-render     ·         ·                     (r)                                                                                     ·
- │         render 0  test.public.t.j->'a'  ·                                                                                       ·
- └── scan  ·         ·                     (a[omitted], b[omitted], c[omitted], d[omitted], j, s[omitted], rowid[hidden,omitted])  rowid!=NULL; key(rowid)
-·          table     t@primary             ·                                                                                       ·
-·          spans     ALL                   ·                                                                                       ·
+render     ·         ·          (r)  ·
+ │         render 0  j->'a'     ·    ·
+ └── scan  ·         ·          (j)  ·
+·          table     t@primary  ·    ·
+·          spans     ALL        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j ? 'a' AS r FROM t
 ----
-render     ·         ·                      (r)                                                                                     ·
- │         render 0  test.public.t.j ? 'a'  ·                                                                                       ·
- └── scan  ·         ·                      (a[omitted], b[omitted], c[omitted], d[omitted], j, s[omitted], rowid[hidden,omitted])  rowid!=NULL; key(rowid)
-·          table     t@primary              ·                                                                                       ·
-·          spans     ALL                    ·                                                                                       ·
+render     ·         ·          (r)  ·
+ │         render 0  j ? 'a'    ·    ·
+ └── scan  ·         ·          (j)  ·
+·          table     t@primary  ·    ·
+·          spans     ALL        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j ?| ARRAY['a', 'b', 'c'] AS r FROM t
 ----
-render     ·         ·                                      (r)                                                                                     ·
- │         render 0  test.public.t.j ?| ARRAY['a','b','c']  ·                                                                                       ·
- └── scan  ·         ·                                      (a[omitted], b[omitted], c[omitted], d[omitted], j, s[omitted], rowid[hidden,omitted])  rowid!=NULL; key(rowid)
-·          table     t@primary                              ·                                                                                       ·
-·          spans     ALL                                    ·                                                                                       ·
+render     ·         ·                        (r)  ·
+ │         render 0  j ?| ARRAY['a','b','c']  ·    ·
+ └── scan  ·         ·                        (j)  ·
+·          table     t@primary                ·    ·
+·          spans     ALL                      ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j ?& ARRAY['a', 'b', 'c'] AS r FROM t
 ----
-render     ·         ·                                      (r)                                                                                     ·
- │         render 0  test.public.t.j ?& ARRAY['a','b','c']  ·                                                                                       ·
- └── scan  ·         ·                                      (a[omitted], b[omitted], c[omitted], d[omitted], j, s[omitted], rowid[hidden,omitted])  rowid!=NULL; key(rowid)
-·          table     t@primary                              ·                                                                                       ·
-·          spans     ALL                                    ·                                                                                       ·
+render     ·         ·                        (r)  ·
+ │         render 0  j ?& ARRAY['a','b','c']  ·    ·
+ └── scan  ·         ·                        (j)  ·
+·          table     t@primary                ·    ·
+·          spans     ALL                      ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j#>ARRAY['a'] AS r FROM t
 ----
-render     ·         ·                            (r)                                                                                     ·
- │         render 0  test.public.t.j#>ARRAY['a']  ·                                                                                       ·
- └── scan  ·         ·                            (a[omitted], b[omitted], c[omitted], d[omitted], j, s[omitted], rowid[hidden,omitted])  rowid!=NULL; key(rowid)
-·          table     t@primary                    ·                                                                                       ·
-·          spans     ALL                          ·                                                                                       ·
+render     ·         ·              (r)  ·
+ │         render 0  j#>ARRAY['a']  ·    ·
+ └── scan  ·         ·              (j)  ·
+·          table     t@primary      ·    ·
+·          spans     ALL            ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j#>>ARRAY['a'] AS r FROM t
 ----
-render     ·         ·                             (r)                                                                                     ·
- │         render 0  test.public.t.j#>>ARRAY['a']  ·                                                                                       ·
- └── scan  ·         ·                             (a[omitted], b[omitted], c[omitted], d[omitted], j, s[omitted], rowid[hidden,omitted])  rowid!=NULL; key(rowid)
-·          table     t@primary                     ·                                                                                       ·
-·          spans     ALL                           ·                                                                                       ·
+render     ·         ·               (r)  ·
+ │         render 0  j#>>ARRAY['a']  ·    ·
+ └── scan  ·         ·               (j)  ·
+·          table     t@primary       ·    ·
+·          spans     ALL             ·    ·
 
 
 query TTTTT

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -1109,9 +1109,6 @@ func (c *indexConstraintCtx) init(
 	evalCtx *tree.EvalContext,
 	factory *norm.Factory,
 ) {
-	if isInverted && len(columns) > 1 {
-		panic(fmt.Sprintf("inverted index on multiple columns"))
-	}
 	c.md = factory.Metadata()
 	c.columns = columns
 	c.notNullCols = notNullCols

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -144,7 +144,6 @@ func TestIndexConstraints(t *testing.T) {
 				}
 				b := optbuilder.NewScalar(ctx, &semaCtx, &evalCtx, f)
 				b.AllowUnsupportedExpr = true
-				b.AllowBlacklistOps = true
 				group, err := b.Build(typedExpr)
 				if err != nil {
 					return fmt.Sprintf("error: %v\n", err)

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -431,29 +431,27 @@ select
       ├── a.s !~* 'foo' [type=bool, outer=(4)]
       └── a.s ~* 'foo' [type=bool, outer=(4)]
 
-# TODO(justin): re-enable when we support JSON ops.
-# JSON comparisons (should not be negated).
-# opt
-# SELECT * FROM a WHERE
-#   NOT('[1, 2]' @> j) AND NOT(j <@ '[3, 4]') AND
-#   NOT(j ? 'foo') AND
-#   NOT(j ?| ARRAY['foo']) AND
-#   NOT(j ?& ARRAY['foo'])
-# ----
-# select
-#  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
-#  ├── key: (1)
-#  ├── fd: (1)-->(2-5)
-#  ├── scan a
-#  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
-#  │    ├── key: (1)
-#  │    └── fd: (1)-->(2-5)
-#  └── filters [type=bool, outer=(5)]
-#       ├── NOT ('[1, 2]' @> a.j) [type=bool, outer=(5)]
-#       ├── NOT ('[3, 4]' @> a.j) [type=bool, outer=(5)]
-#       ├── NOT (a.j ? 'foo') [type=bool, outer=(5)]
-#       ├── NOT (a.j ?| ARRAY['foo']) [type=bool, outer=(5)]
-#       └── NOT (a.j ?& ARRAY['foo']) [type=bool, outer=(5)]
+opt
+SELECT * FROM a WHERE
+  NOT('[1, 2]' @> j) AND NOT(j <@ '[3, 4]') AND
+  NOT(j ? 'foo') AND
+  NOT(j ?| ARRAY['foo']) AND
+  NOT(j ?& ARRAY['foo'])
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters [type=bool, outer=(5)]
+      ├── NOT ('[1, 2]' @> a.j) [type=bool, outer=(5)]
+      ├── NOT ('[3, 4]' @> a.j) [type=bool, outer=(5)]
+      ├── NOT (a.j ? 'foo') [type=bool, outer=(5)]
+      ├── NOT (a.j ?| ARRAY['foo']) [type=bool, outer=(5)]
+      └── NOT (a.j ?& ARRAY['foo']) [type=bool, outer=(5)]
 
 # --------------------------------------------------
 # EliminateNot

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -228,12 +228,6 @@ select
 # FoldNullComparisonLeft, FoldNullComparisonRight
 # --------------------------------------------------
 
-# TODO(justin): re-add to the test below when we support JSON ops.
-# null::jsonb @> '"foo"' OR '"foo"' <@ null::jsonb OR
-# null::jsonb ? 'foo' OR '{}' ? null::string OR
-# null::jsonb ?| ARRAY['foo'] OR '{}' ?| null::string[] OR
-# null::jsonb ?& ARRAY['foo'] OR '{}' ?& null::string[]
-
 # Use null::type to circumvent type checker constant folding.
 opt
 SELECT *
@@ -254,7 +248,11 @@ WHERE
     null::string ~ 'foo' OR 'foo' ~ null::string OR
     null::string !~ 'foo' OR 'foo' !~ null::string OR
     null::string ~* 'foo' OR 'foo' ~* null::string OR
-    null::string !~* 'foo' OR 'foo' !~* null::string
+    null::string !~* 'foo' OR 'foo' !~* null::string OR
+    null::jsonb @> '"foo"' OR '"foo"' <@ null::jsonb OR
+    null::jsonb ? 'foo' OR '{}' ? null::string OR
+    null::jsonb ?| ARRAY['foo'] OR '{}' ?| null::string[] OR
+    null::jsonb ?& ARRAY['foo'] OR '{}' ?& null::string[]
 ----
 scan a
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -266,31 +266,30 @@ project
       ├── a.i::DECIMAL || CAST(NULL AS DECIMAL[]) [type=decimal[], outer=(2)]
       └── CAST(NULL AS FLOAT[]) || a.i::FLOAT [type=float[], outer=(2)]
 
-# TODO(justin): re-enable when we support JSON ops.
-# opt
-# SELECT
-#     null::json || '[1, 2]' AS ra, '[1, 2]' || null::json AS rb,
-#     null::json->'foo' AS sa, '{}'::jsonb->null::string AS sb,
-#     null::json->>'foo' AS ta, '{}'::jsonb->>null::string AS tb,
-#     null::json->>'foo' AS ua, '{}'::jsonb->>null::string AS ub,
-#     null::json#>ARRAY['foo'] AS va, '{}'::jsonb#>NULL AS vb,
-#     null::json#>>ARRAY['foo'] AS wa, '{}'::jsonb#>>NULL AS wb
-# FROM a
-# ----
-# project
-#  ├── columns: ra:7(jsonb) rb:8(jsonb) sa:9(jsonb) sb:10(jsonb) ta:11(string) tb:12(string) ua:11(string) ub:12(string) va:13(jsonb) vb:14(unknown) wa:15(string) wb:14(unknown)
-#  ├── fd: ()-->(7-15)
-#  ├── scan a
-#  └── projections
-#       ├── null [type=jsonb]
-#       ├── null [type=jsonb]
-#       ├── null [type=jsonb]
-#       ├── null [type=jsonb]
-#       ├── null [type=string]
-#       ├── null [type=string]
-#       ├── null [type=jsonb]
-#       ├── null [type=unknown]
-#       └── null [type=string]
+opt
+SELECT
+    null::json || '[1, 2]' AS ra, '[1, 2]' || null::json AS rb,
+    null::json->'foo' AS sa, '{}'::jsonb->null::string AS sb,
+    null::json->>'foo' AS ta, '{}'::jsonb->>null::string AS tb,
+    null::json->>'foo' AS ua, '{}'::jsonb->>null::string AS ub,
+    null::json#>ARRAY['foo'] AS va, '{}'::jsonb#>NULL AS vb,
+    null::json#>>ARRAY['foo'] AS wa, '{}'::jsonb#>>NULL AS wb
+FROM a
+----
+project
+ ├── columns: ra:7(jsonb) rb:8(jsonb) sa:9(jsonb) sb:10(jsonb) ta:11(string) tb:12(string) ua:11(string) ub:12(string) va:13(jsonb) vb:14(unknown) wa:15(string) wb:14(unknown)
+ ├── fd: ()-->(7-15)
+ ├── scan a
+ └── projections
+      ├── null [type=jsonb]
+      ├── null [type=jsonb]
+      ├── null [type=jsonb]
+      ├── null [type=jsonb]
+      ├── null [type=string]
+      ├── null [type=string]
+      ├── null [type=jsonb]
+      ├── null [type=unknown]
+      └── null [type=string]
 
 # --------------------------------------------------
 # FoldNullInNonEmpty

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -61,13 +61,6 @@ type Builder struct {
 	// constraints).
 	AllowImpureFuncs bool
 
-	// AllowBlacklistOps is a control knob: if set, when building a scalar, if a
-	// given operator is marked as blacklisted for the optimizer, it will be let
-	// through anyway. This is used in cases where we want to use the opt code to
-	// build constraints when using the heuristic planner, but we don't want to
-	// plan such queries using the optimizer.
-	AllowBlacklistOps bool
-
 	// FmtFlags controls the way column names are formatted in test output. For
 	// example, if set to FmtAlwaysQualifyTableNames, the builder fully qualifies
 	// the table name in all column labels before adding them to the metadata.

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -62,18 +62,6 @@ var comparisonOpMap = [tree.NumComparisonOperators]binaryFactoryFunc{
 	tree.JSONSomeExists: (*norm.Factory).ConstructJsonSomeExists,
 }
 
-// TODO(justin): remove this when we can plan inverted index queries.  It's not
-// sufficient to just remove them from the above map, since the heuristic
-// planner uses the same constraint generation code.
-// Not all of these generate inverted index scans today.
-var comparisonOpBlacklist = [tree.NumComparisonOperators]bool{
-	tree.Contains:       true,
-	tree.ContainedBy:    true,
-	tree.JSONExists:     true,
-	tree.JSONAllExists:  true,
-	tree.JSONSomeExists: true,
-}
-
 // Map from tree.BinaryOperator to Factory constructor function.
 var binaryOpMap = [tree.NumBinaryOperators]binaryFactoryFunc{
 	tree.Bitand:            (*norm.Factory).ConstructBitand,
@@ -93,17 +81,6 @@ var binaryOpMap = [tree.NumBinaryOperators]binaryFactoryFunc{
 	tree.JSONFetchVal:      (*norm.Factory).ConstructFetchVal,
 	tree.JSONFetchValPath:  (*norm.Factory).ConstructFetchValPath,
 	tree.JSONFetchTextPath: (*norm.Factory).ConstructFetchTextPath,
-}
-
-// TODO(justin): remove this when we can plan inverted index queries.  It's not
-// sufficient to just remove them from the above map, since the heuristic
-// planner uses the same constraint generation code.
-// Not all of these generate inverted index scans today.
-var binaryOpBlacklist = [tree.NumBinaryOperators]bool{
-	tree.JSONFetchVal:      true,
-	tree.JSONFetchText:     true,
-	tree.JSONFetchValPath:  true,
-	tree.JSONFetchTextPath: true,
 }
 
 // Map from tree.UnaryOperator to Factory constructor function.
@@ -198,13 +175,6 @@ func (b *Builder) buildScalarHelper(
 		// select the right overload. The solution is to wrap any mismatched
 		// arguments with a CastExpr that preserves the static type.
 
-		// This check is so that the heuristic planner can plan inverted index
-		// queries, which the optimizer doesn't support.
-		blacklisted := binaryOpBlacklist[t.Operator] && !b.AllowBlacklistOps
-		if blacklisted {
-			panic(unimplementedf("operator '%s' not supported", t.Operator))
-		}
-
 		fn := binaryOpMap[t.Operator]
 		left, _ := tree.ReType(t.TypedLeft(), t.ResolvedBinOp().LeftType)
 		right, _ := tree.ReType(t.TypedRight(), t.ResolvedBinOp().RightType)
@@ -267,11 +237,7 @@ func (b *Builder) buildScalarHelper(
 
 			fn := comparisonOpMap[t.Operator]
 
-			// This check is so that the heuristic planner can plan inverted index
-			// queries, which the optimizer doesn't support.
-			include := !comparisonOpBlacklist[t.Operator] || b.AllowBlacklistOps
-
-			if fn != nil && include {
+			if fn != nil {
 				// Most comparison ops map directly to a factory method.
 				out = fn(b.factory, left, right)
 			} else if b.AllowUnsupportedExpr {

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -2176,67 +2176,66 @@ TABLE foo
  └── INDEX primary
       └── rowid int not null (hidden)
 
-# TODO(justin): re-enable when we support JSON ops.
-# build
-# SELECT a.bar @> b.baz AND b.baz @> b.baz AS r FROM foo AS a, foo AS b GROUP BY a.bar @> b.baz, b.baz
-# ----
-# project
-#  ├── columns: r:8(bool)
-#  ├── group-by
-#  │    ├── columns: foo.baz:5(jsonb) column7:7(bool)
-#  │    ├── grouping columns: foo.baz:5(jsonb) column7:7(bool)
-#  │    └── project
-#  │         ├── columns: column7:7(bool) foo.baz:5(jsonb)
-#  │         ├── inner-join
-#  │         │    ├── columns: foo.bar:1(jsonb) foo.baz:2(jsonb) foo.rowid:3(int!null) foo.bar:4(jsonb) foo.baz:5(jsonb) foo.rowid:6(int!null)
-#  │         │    ├── scan foo
-#  │         │    │    └── columns: foo.bar:1(jsonb) foo.baz:2(jsonb) foo.rowid:3(int!null)
-#  │         │    ├── scan foo
-#  │         │    │    └── columns: foo.bar:4(jsonb) foo.baz:5(jsonb) foo.rowid:6(int!null)
-#  │         │    └── true [type=bool]
-#  │         └── projections
-#  │              └── contains [type=bool]
-#  │                   ├── variable: foo.bar [type=jsonb]
-#  │                   └── variable: foo.baz [type=jsonb]
-#  └── projections
-#       └── and [type=bool]
-#            ├── variable: column7 [type=bool]
-#            └── contains [type=bool]
-#                 ├── variable: foo.baz [type=jsonb]
-#                 └── variable: foo.baz [type=jsonb]
+build
+SELECT a.bar @> b.baz AND b.baz @> b.baz AS r FROM foo AS a, foo AS b GROUP BY a.bar @> b.baz, b.baz
+----
+project
+ ├── columns: r:8(bool)
+ ├── group-by
+ │    ├── columns: foo.baz:5(jsonb) column7:7(bool)
+ │    ├── grouping columns: foo.baz:5(jsonb) column7:7(bool)
+ │    └── project
+ │         ├── columns: column7:7(bool) foo.baz:5(jsonb)
+ │         ├── inner-join
+ │         │    ├── columns: foo.bar:1(jsonb) foo.baz:2(jsonb) foo.rowid:3(int!null) foo.bar:4(jsonb) foo.baz:5(jsonb) foo.rowid:6(int!null)
+ │         │    ├── scan foo
+ │         │    │    └── columns: foo.bar:1(jsonb) foo.baz:2(jsonb) foo.rowid:3(int!null)
+ │         │    ├── scan foo
+ │         │    │    └── columns: foo.bar:4(jsonb) foo.baz:5(jsonb) foo.rowid:6(int!null)
+ │         │    └── true [type=bool]
+ │         └── projections
+ │              └── contains [type=bool]
+ │                   ├── variable: foo.bar [type=jsonb]
+ │                   └── variable: foo.baz [type=jsonb]
+ └── projections
+      └── and [type=bool]
+           ├── variable: column7 [type=bool]
+           └── contains [type=bool]
+                ├── variable: foo.baz [type=jsonb]
+                └── variable: foo.baz [type=jsonb]
 
-# build
-# SELECT a.bar @> b.baz AND b.baz @> b.baz FROM foo AS a, foo AS b GROUP BY b.baz <@ a.bar, b.baz
-# ----
-# error (42803): column "bar" must appear in the GROUP BY clause or be used in an aggregate function
+build
+SELECT a.bar @> b.baz AND b.baz @> b.baz FROM foo AS a, foo AS b GROUP BY b.baz <@ a.bar, b.baz
+----
+error (42803): column "bar" must appear in the GROUP BY clause or be used in an aggregate function
 
-# build
-# SELECT b.baz <@ a.bar AND b.baz <@ b.baz AS r FROM foo AS a, foo AS b GROUP BY b.baz <@ a.bar, b.baz
-# ----
-# project
-#  ├── columns: r:8(bool)
-#  ├── group-by
-#  │    ├── columns: foo.baz:5(jsonb) column7:7(bool)
-#  │    ├── grouping columns: foo.baz:5(jsonb) column7:7(bool)
-#  │    └── project
-#  │         ├── columns: column7:7(bool) foo.baz:5(jsonb)
-#  │         ├── inner-join
-#  │         │    ├── columns: foo.bar:1(jsonb) foo.baz:2(jsonb) foo.rowid:3(int!null) foo.bar:4(jsonb) foo.baz:5(jsonb) foo.rowid:6(int!null)
-#  │         │    ├── scan foo
-#  │         │    │    └── columns: foo.bar:1(jsonb) foo.baz:2(jsonb) foo.rowid:3(int!null)
-#  │         │    ├── scan foo
-#  │         │    │    └── columns: foo.bar:4(jsonb) foo.baz:5(jsonb) foo.rowid:6(int!null)
-#  │         │    └── true [type=bool]
-#  │         └── projections
-#  │              └── contains [type=bool]
-#  │                   ├── variable: foo.bar [type=jsonb]
-#  │                   └── variable: foo.baz [type=jsonb]
-#  └── projections
-#       └── and [type=bool]
-#            ├── variable: column7 [type=bool]
-#            └── contains [type=bool]
-#                 ├── variable: foo.baz [type=jsonb]
-#                 └── variable: foo.baz [type=jsonb]
+build
+SELECT b.baz <@ a.bar AND b.baz <@ b.baz AS r FROM foo AS a, foo AS b GROUP BY b.baz <@ a.bar, b.baz
+----
+project
+ ├── columns: r:8(bool)
+ ├── group-by
+ │    ├── columns: foo.baz:5(jsonb) column7:7(bool)
+ │    ├── grouping columns: foo.baz:5(jsonb) column7:7(bool)
+ │    └── project
+ │         ├── columns: column7:7(bool) foo.baz:5(jsonb)
+ │         ├── inner-join
+ │         │    ├── columns: foo.bar:1(jsonb) foo.baz:2(jsonb) foo.rowid:3(int!null) foo.bar:4(jsonb) foo.baz:5(jsonb) foo.rowid:6(int!null)
+ │         │    ├── scan foo
+ │         │    │    └── columns: foo.bar:1(jsonb) foo.baz:2(jsonb) foo.rowid:3(int!null)
+ │         │    ├── scan foo
+ │         │    │    └── columns: foo.bar:4(jsonb) foo.baz:5(jsonb) foo.rowid:6(int!null)
+ │         │    └── true [type=bool]
+ │         └── projections
+ │              └── contains [type=bool]
+ │                   ├── variable: foo.bar [type=jsonb]
+ │                   └── variable: foo.baz [type=jsonb]
+ └── projections
+      └── and [type=bool]
+           ├── variable: column7 [type=bool]
+           └── contains [type=bool]
+                ├── variable: foo.baz [type=jsonb]
+                └── variable: foo.baz [type=jsonb]
 
 exec-ddl
 CREATE TABLE times (t time PRIMARY KEY)

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -211,47 +211,46 @@ eq [type=bool]
  └── const: 2 [type=int]
 
 
-# TODO(justin): re-enable when we support JSON ops.
-# build-scalar vars=(jsonb)
-# @1 @> '{"a":1}'
-# ----
-# contains [type=bool]
-#  ├── variable: @1 [type=jsonb]
-#  └── const: '{"a": 1}' [type=jsonb]
+build-scalar vars=(jsonb)
+@1 @> '{"a":1}'
+----
+contains [type=bool]
+ ├── variable: @1 [type=jsonb]
+ └── const: '{"a": 1}' [type=jsonb]
 
-# build-scalar vars=(jsonb)
-# '{"a":1}' <@ @1
-# ----
-# contains [type=bool]
-#  ├── variable: @1 [type=jsonb]
-#  └── const: '{"a": 1}' [type=jsonb]
+build-scalar vars=(jsonb)
+'{"a":1}' <@ @1
+----
+contains [type=bool]
+ ├── variable: @1 [type=jsonb]
+ └── const: '{"a": 1}' [type=jsonb]
 
-# build-scalar vars=(jsonb)
-# @1 ? 'a'
-# ----
-# json-exists [type=bool]
-#  ├── variable: @1 [type=jsonb]
-#  └── const: 'a' [type=string]
+build-scalar vars=(jsonb)
+@1 ? 'a'
+----
+json-exists [type=bool]
+ ├── variable: @1 [type=jsonb]
+ └── const: 'a' [type=string]
 
-# build-scalar vars=(jsonb)
-# @1 ?| ARRAY['a', 'b', 'c']
-# ----
-# json-some-exists [type=bool]
-#  ├── variable: @1 [type=jsonb]
-#  └── array: string[] [type=string[]]
-#       ├── const: 'a' [type=string]
-#       ├── const: 'b' [type=string]
-#       └── const: 'c' [type=string]
+build-scalar vars=(jsonb)
+@1 ?| ARRAY['a', 'b', 'c']
+----
+json-some-exists [type=bool]
+ ├── variable: @1 [type=jsonb]
+ └── array: [type=string[]]
+      ├── const: 'a' [type=string]
+      ├── const: 'b' [type=string]
+      └── const: 'c' [type=string]
 
-# build-scalar vars=(jsonb)
-# @1 ?& ARRAY['a', 'b', 'c']
-# ----
-# json-all-exists [type=bool]
-#  ├── variable: @1 [type=jsonb]
-#  └── array: string[] [type=string[]]
-#       ├── const: 'a' [type=string]
-#       ├── const: 'b' [type=string]
-#       └── const: 'c' [type=string]
+build-scalar vars=(jsonb)
+@1 ?& ARRAY['a', 'b', 'c']
+----
+json-all-exists [type=bool]
+ ├── variable: @1 [type=jsonb]
+ └── array: [type=string[]]
+      ├── const: 'a' [type=string]
+      ├── const: 'b' [type=string]
+      └── const: 'c' [type=string]
 
 build-scalar
 TRUE
@@ -633,44 +632,43 @@ eq [type=bool]
       ├── const: 'bar' [type=string]
       └── const: 'baz' [type=string]
 
-# TODO(justin): re-enable when we support JSON ops.
-# build-scalar vars=(json)
-# @1->>'a' = 'b'
-# ----
-# eq [type=bool]
-#  ├── fetch-text [type=string]
-#  │    ├── variable: @1 [type=jsonb]
-#  │    └── const: 'a' [type=string]
-#  └── const: 'b' [type=string]
+build-scalar vars=(json)
+@1->>'a' = 'b'
+----
+eq [type=bool]
+ ├── fetch-text [type=string]
+ │    ├── variable: @1 [type=jsonb]
+ │    └── const: 'a' [type=string]
+ └── const: 'b' [type=string]
 
-# build-scalar vars=(json)
-# @1->'a' = '"b"'
-# ----
-# eq [type=bool]
-#  ├── fetch-val [type=jsonb]
-#  │    ├── variable: @1 [type=jsonb]
-#  │    └── const: 'a' [type=string]
-#  └── const: '"b"' [type=jsonb]
+build-scalar vars=(json)
+@1->'a' = '"b"'
+----
+eq [type=bool]
+ ├── fetch-val [type=jsonb]
+ │    ├── variable: @1 [type=jsonb]
+ │    └── const: 'a' [type=string]
+ └── const: '"b"' [type=jsonb]
 
-# build-scalar vars=(json)
-# @1#>ARRAY['a'] = '"b"'
-# ----
-# eq [type=bool]
-#  ├── fetch-val-path [type=jsonb]
-#  │    ├── variable: @1 [type=jsonb]
-#  │    └── array: string[] [type=string[]]
-#  │         └── const: 'a' [type=string]
-#  └── const: '"b"' [type=jsonb]
+build-scalar vars=(json)
+@1#>ARRAY['a'] = '"b"'
+----
+eq [type=bool]
+ ├── fetch-val-path [type=jsonb]
+ │    ├── variable: @1 [type=jsonb]
+ │    └── array: [type=string[]]
+ │         └── const: 'a' [type=string]
+ └── const: '"b"' [type=jsonb]
 
-# build-scalar vars=(json)
-# @1#>>ARRAY['a'] = 'b'
-# ----
-# eq [type=bool]
-#  ├── fetch-text-path [type=string]
-#  │    ├── variable: @1 [type=jsonb]
-#  │    └── array: string[] [type=string[]]
-#  │         └── const: 'a' [type=string]
-#  └── const: 'b' [type=string]
+build-scalar vars=(json)
+@1#>>ARRAY['a'] = 'b'
+----
+eq [type=bool]
+ ├── fetch-text-path [type=string]
+ │    ├── variable: @1 [type=jsonb]
+ │    └── array: [type=string[]]
+ │         └── const: 'a' [type=string]
+ └── const: 'b' [type=string]
 
 build-scalar vars=(json, json)
 @1 || @2

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -117,7 +117,10 @@ func (tt *Table) addColumn(def *tree.ColumnTableDef) {
 }
 
 func (tt *Table) addIndex(def *tree.IndexTableDef, typ indexType) {
-	idx := &Index{Name: tt.makeIndexName(def.Name, typ)}
+	idx := &Index{
+		Name:     tt.makeIndexName(def.Name, typ),
+		Inverted: def.Inverted,
+	}
 
 	// Add explicit columns and mark primary key columns as not null.
 	notNullIndex := true

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -246,6 +246,9 @@ type Index struct {
 	// index, which allows duplicate rows when at least one of the values is
 	// NULL. See the opt.Index.LaxKeyColumnCount for more details.
 	LaxKeyCount int
+
+	// Inverted is true when this index is an inverted index.
+	Inverted bool
 }
 
 // IdxName is part of the opt.Index interface.
@@ -255,7 +258,7 @@ func (ti *Index) IdxName() string {
 
 // IsInverted is part of the opt.Index interface.
 func (ti *Index) IsInverted() bool {
-	return false
+	return ti.Inverted
 }
 
 // ColumnCount is part of the opt.Index interface.

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -52,6 +52,27 @@ func (c *CustomFuncs) CanGenerateIndexScans(def memo.PrivateID) bool {
 		scanOpDef.HardLimit == 0
 }
 
+// CanGenerateInvertedIndexScans returns true if new index Scan operators can
+// be generated on inverted indexes. Same as CanGenerateIndexScans, but with
+// the additional check that we have at least one inverted index on the table.
+func (c *CustomFuncs) CanGenerateInvertedIndexScans(def memo.PrivateID) bool {
+	if !c.CanGenerateIndexScans(def) {
+		return false
+	}
+
+	// Don't bother matching unless there's an inverted index.
+	scanOpDef := c.e.mem.LookupPrivate(def).(*memo.ScanOpDef)
+	md := c.e.mem.Metadata()
+	tab := md.Table(scanOpDef.Table)
+	// Index 0 is the primary index and is never inverted.
+	for i, n := 1, tab.IndexCount(); i < n; i++ {
+		if tab.Index(i).IsInverted() {
+			return true
+		}
+	}
+	return false
+}
+
 // GenerateIndexScans enumerates all indexes on the scan operator's table and
 // generates an alternate scan operator for each index that includes the set of
 // needed columns.
@@ -75,7 +96,7 @@ func (c *CustomFuncs) GenerateIndexScans(def memo.PrivateID) []memo.Expr {
 	// Iterate over all secondary indexes (index 0 is the primary index).
 	for i := 1; i < tab.IndexCount(); i++ {
 		if tab.Index(i).IsInverted() {
-			// Ignore inverted indexes for now.
+			// Ignore inverted indexes.
 			continue
 		}
 		indexCols := md.IndexColumns(scanOpDef.Table, i)
@@ -135,6 +156,77 @@ func (c *CustomFuncs) GenerateIndexScans(def memo.PrivateID) []memo.Expr {
 	return c.e.exprs
 }
 
+// GenerateInvertedIndexScans enumerates all inverted indexes on the scan
+// operator's table and generates a scan for each inverted index that can
+// service the query.
+// The resulting scan operator is pre-constrained and may come with an index join.
+// The reason it's pre-constrained is that we cannot treat an inverted index in
+// the same way as a regular index, since it does not actually contain the
+// indexed column.
+func (c *CustomFuncs) GenerateInvertedIndexScans(
+	def memo.PrivateID, filter memo.GroupID,
+) []memo.Expr {
+	c.e.exprs = c.e.exprs[:0]
+	scanOpDef := c.e.mem.LookupPrivate(def).(*memo.ScanOpDef)
+	md := c.e.mem.Metadata()
+	tab := md.Table(scanOpDef.Table)
+
+	primaryIndex := md.Table(scanOpDef.Table).Index(opt.PrimaryIndex)
+	var pkColSet opt.ColSet
+	for i := 0; i < primaryIndex.KeyColumnCount(); i++ {
+		pkColSet.Add(int(md.TableColumn(scanOpDef.Table, primaryIndex.Column(i).Ordinal)))
+	}
+
+	// Iterate over all inverted indexes (index 0 is the primary index and is
+	// never inverted).
+	for i := 1; i < tab.IndexCount(); i++ {
+		if !tab.Index(i).IsInverted() {
+			continue
+		}
+
+		preDef := &memo.ScanOpDef{
+			Table: scanOpDef.Table,
+			Index: i,
+			// Though the index is marked as containing the JSONB column being
+			// indexed, it doesn't actually, and it's only valid to extract the
+			// primary key columns from it.
+			Cols: pkColSet,
+		}
+
+		constrainedScan, remainingFilter, ok := c.constrainedScanOpDef(filter, c.e.mem.InternScanOpDef(preDef), true /* isInverted */)
+		if !ok {
+			continue
+		}
+
+		// TODO(justin): We might not need to do an index join in order to get the
+		// correct columns, but it's difficult to tell at this point.
+		def := c.e.mem.InternIndexJoinDef(&memo.IndexJoinDef{
+			Table: scanOpDef.Table,
+			Cols:  scanOpDef.Cols,
+		})
+		scan := c.e.f.ConstructScan(c.e.mem.InternScanOpDef(&constrainedScan))
+
+		if c.e.mem.NormExpr(remainingFilter).Operator() == opt.TrueOp {
+			c.e.exprs = append(
+				c.e.exprs,
+				memo.Expr(memo.MakeIndexJoinExpr(scan, def)),
+			)
+		} else {
+			c.e.exprs = append(
+				c.e.exprs,
+				memo.Expr(
+					memo.MakeSelectExpr(
+						c.e.f.ConstructIndexJoin(scan, def),
+						remainingFilter,
+					),
+				),
+			)
+		}
+	}
+
+	return c.e.exprs
+}
+
 // ----------------------------------------------------------------------
 //
 // Select Rules
@@ -154,7 +246,7 @@ func (c *CustomFuncs) CanConstrainScan(def memo.PrivateID) bool {
 // constraint. If it cannot push the filter down (i.e. the resulting constraint
 // is unconstrained), then it returns ok = false in the third return value.
 func (c *CustomFuncs) constrainedScanOpDef(
-	filterGroup memo.GroupID, scanDef memo.PrivateID,
+	filterGroup memo.GroupID, scanDef memo.PrivateID, isInverted bool,
 ) (newDef memo.ScanOpDef, remainingFilter memo.GroupID, ok bool) {
 	scanOpDef := c.e.mem.LookupPrivate(scanDef).(*memo.ScanOpDef)
 
@@ -178,7 +270,7 @@ func (c *CustomFuncs) constrainedScanOpDef(
 	// Generate index constraints.
 	var ic idxconstraint.Instance
 	filter := memo.MakeNormExprView(c.e.mem, filterGroup)
-	ic.Init(filter, columns, notNullCols, false /* isInverted */, c.e.evalCtx, c.e.f)
+	ic.Init(filter, columns, notNullCols, isInverted, c.e.evalCtx, c.e.f)
 	constraint := ic.Constraint()
 	if constraint.IsUnconstrained() {
 		return memo.ScanOpDef{}, 0, false
@@ -210,7 +302,7 @@ func (c *CustomFuncs) constrainedScanOpDef(
 func (c *CustomFuncs) ConstrainScan(filterGroup memo.GroupID, scanDef memo.PrivateID) []memo.Expr {
 	c.e.exprs = c.e.exprs[:0]
 
-	newDef, remainingFilter, ok := c.constrainedScanOpDef(filterGroup, scanDef)
+	newDef, remainingFilter, ok := c.constrainedScanOpDef(filterGroup, scanDef, false /* isInverted */)
 	if !ok {
 		return nil
 	}
@@ -252,7 +344,7 @@ func (c *CustomFuncs) ConstrainIndexJoinScan(
 ) []memo.Expr {
 	c.e.exprs = c.e.exprs[:0]
 
-	newDef, remainingFilter, ok := c.constrainedScanOpDef(filterGroup, scanDef)
+	newDef, remainingFilter, ok := c.constrainedScanOpDef(filterGroup, scanDef, false /* isInverted */)
 	if !ok {
 		return nil
 	}

--- a/pkg/sql/opt/xform/rules/select.opt
+++ b/pkg/sql/opt/xform/rules/select.opt
@@ -109,3 +109,13 @@
 )
 =>
 (ConstrainIndexJoinScan $filter $scanDef $indexJoinDef)
+
+# GenerateInvertedIndexScans creates alternate expressions for filters that can
+# be serviced by an inverted index.
+[GenerateInvertedIndexScans, Explore]
+(Select
+  (Scan $def:* & (CanGenerateInvertedIndexScans $def))
+  $filter:*
+)
+=>
+(GenerateInvertedIndexScans $def $filter)

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -7,7 +7,8 @@ CREATE TABLE a
     s STRING,
     j JSON,
     INDEX s_idx (s) STORING (i, f),
-    INDEX si_idx (s DESC, i DESC) STORING (j)
+    INDEX si_idx (s DESC, i DESC) STORING (j),
+    INVERTED INDEX inv_idx_j (j)
 )
 ----
 TABLE a
@@ -23,11 +24,14 @@ TABLE a
  │    ├── k int not null
  │    ├── i int (storing)
  │    └── f float (storing)
- └── INDEX si_idx
-      ├── s string desc
-      ├── i int desc
-      ├── k int not null
-      └── j jsonb (storing)
+ ├── INDEX si_idx
+ │    ├── s string desc
+ │    ├── i int desc
+ │    ├── k int not null
+ │    └── j jsonb (storing)
+ └── INVERTED INDEX inv_idx_j
+      ├── j jsonb
+      └── k int not null
 
 # --------------------------------------------------
 # GenerateIndexScans

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -29,22 +29,28 @@ CREATE TABLE b
     k INT PRIMARY KEY,
     u INT,
     v INT,
+    j JSONB,
     INDEX u(u),
-    UNIQUE INDEX v(v)
+    UNIQUE INDEX v(v),
+    INVERTED INDEX inv_idx(j)
 )
 ----
 TABLE b
  ├── k int not null
  ├── u int
  ├── v int
+ ├── j jsonb
  ├── INDEX primary
  │    └── k int not null
  ├── INDEX u
  │    ├── u int
  │    └── k int not null
- └── INDEX v
-      ├── v int
-      └── k int not null (storing)
+ ├── INDEX v
+ │    ├── v int
+ │    └── k int not null (storing)
+ └── INVERTED INDEX inv_idx
+      ├── j jsonb
+      └── k int not null
 
 # --------------------------------------------------
 # ConstrainScan
@@ -327,9 +333,9 @@ opt
 SELECT * FROM b WHERE v >= 1 AND v <= 10
 ----
 index-join b
- ├── columns: k:1(int!null) u:2(int) v:3(int!null)
+ ├── columns: k:1(int!null) u:2(int) v:3(int!null) j:4(jsonb)
  ├── key: (1)
- ├── fd: (1)-->(2,3), (3)-->(1,2)
+ ├── fd: (1)-->(2-4), (3)-->(1,2,4)
  └── scan b@v
       ├── columns: k:1(int!null) v:3(int!null)
       ├── constraint: /3: [/1 - /10]
@@ -340,14 +346,14 @@ memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10
 ----
 memo (optimized)
- ├── G1: (select G2 G11) (index-join G3 b,cols=(1-3)) (index-join G4 b,cols=(1-3)) (index-join G5 b,cols=(1-3)) (index-join G6 b,cols=(1-3))
- │    └── "[presentation: k:1,u:2,v:3]"
- │         ├── best: (index-join G3 b,cols=(1-3))
- │         └── cost: 51.10
- ├── G2: (scan b) (scan b,rev) (index-join G7 b,cols=(1-3)) (index-join G8 b,cols=(1-3)) (index-join G9 b,cols=(1-3)) (index-join G10 b,cols=(1-3))
+ ├── G1: (select G2 G11) (index-join G3 b,cols=(1-4)) (index-join G4 b,cols=(1-4)) (index-join G5 b,cols=(1-4)) (index-join G6 b,cols=(1-4))
+ │    └── "[presentation: k:1,u:2,v:3,j:4]"
+ │         ├── best: (index-join G3 b,cols=(1-4))
+ │         └── cost: 51.30
+ ├── G2: (scan b) (scan b,rev) (index-join G7 b,cols=(1-4)) (index-join G8 b,cols=(1-4)) (index-join G9 b,cols=(1-4)) (index-join G10 b,cols=(1-4))
  │    └── ""
  │         ├── best: (scan b)
- │         └── cost: 1060.00
+ │         └── cost: 1080.00
  ├── G3: (select G9 G11) (scan b@v,cols=(1,3),constrained)
  │    └── ""
  │         ├── best: (scan b@v,cols=(1,3),constrained)
@@ -392,13 +398,13 @@ opt
 SELECT * FROM b WHERE v > 1
 ----
 select
- ├── columns: k:1(int!null) u:2(int) v:3(int!null)
+ ├── columns: k:1(int!null) u:2(int) v:3(int!null) j:4(jsonb)
  ├── key: (1)
- ├── fd: (1)-->(2,3), (3)-->(1,2)
+ ├── fd: (1)-->(2-4), (3)-->(1,2,4)
  ├── scan b
- │    ├── columns: k:1(int!null) u:2(int) v:3(int)
+ │    ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
  │    ├── key: (1)
- │    └── fd: (1)-->(2,3), (3)~~>(1,2)
+ │    └── fd: (1)-->(2-4), (3)~~>(1,2,4)
  └── filters [type=bool, outer=(3), constraints=(/3: [/2 - ]; tight)]
       └── b.v > 1 [type=bool, outer=(3), constraints=(/3: [/2 - ]; tight)]
 
@@ -406,9 +412,9 @@ opt
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k > 5
 ----
 index-join b
- ├── columns: k:1(int!null) u:2(int) v:3(int!null)
+ ├── columns: k:1(int!null) u:2(int) v:3(int!null) j:4(jsonb)
  ├── key: (1)
- ├── fd: (1)-->(2,3), (3)-->(1,2)
+ ├── fd: (1)-->(2-4), (3)-->(1,2,4)
  └── select
       ├── columns: k:1(int!null) v:3(int!null)
       ├── key: (1)
@@ -425,22 +431,22 @@ memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k > 5
 ----
 memo (optimized)
- ├── G1: (select G2 G17) (select G3 G9) (select G4 G9) (index-join G5 b,cols=(1-3)) (index-join G6 b,cols=(1-3)) (select G7 G9) (select G8 G9) (select G10 G27) (select G11 G27) (index-join G12 b,cols=(1-3)) (index-join G13 b,cols=(1-3))
- │    └── "[presentation: k:1,u:2,v:3]"
- │         ├── best: (index-join G5 b,cols=(1-3))
- │         └── cost: 24.07
- ├── G2: (scan b) (scan b,rev) (index-join G25 b,cols=(1-3)) (index-join G26 b,cols=(1-3)) (index-join G14 b,cols=(1-3)) (index-join G16 b,cols=(1-3))
+ ├── G1: (select G2 G17) (select G3 G9) (select G4 G9) (index-join G5 b,cols=(1-4)) (index-join G6 b,cols=(1-4)) (select G7 G9) (select G8 G9) (select G10 G27) (select G11 G27) (index-join G12 b,cols=(1-4)) (index-join G13 b,cols=(1-4))
+ │    └── "[presentation: k:1,u:2,v:3,j:4]"
+ │         ├── best: (index-join G5 b,cols=(1-4))
+ │         └── cost: 24.13
+ ├── G2: (scan b) (scan b,rev) (index-join G25 b,cols=(1-4)) (index-join G26 b,cols=(1-4)) (index-join G14 b,cols=(1-4)) (index-join G16 b,cols=(1-4))
  │    └── ""
  │         ├── best: (scan b)
- │         └── cost: 1060.00
+ │         └── cost: 1080.00
  ├── G3: (scan b,constrained)
  │    └── ""
  │         ├── best: (scan b,constrained)
- │         └── cost: 353.33
+ │         └── cost: 360.00
  ├── G4: (scan b,rev,constrained)
  │    └── ""
  │         ├── best: (scan b,rev,constrained)
- │         └── cost: 373.33
+ │         └── cost: 386.67
  ├── G5: (select G14 G17) (select G15 G27)
  │    └── ""
  │         ├── best: (select G15 G27)
@@ -449,23 +455,23 @@ memo (optimized)
  │    └── ""
  │         ├── best: (select G18 G27)
  │         └── cost: 10.90
- ├── G7: (index-join G19 b,cols=(1-3))
+ ├── G7: (index-join G19 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G19 b,cols=(1-3))
- │         └── cost: 2406.67
- ├── G8: (index-join G20 b,cols=(1-3))
+ │         ├── best: (index-join G19 b,cols=(1-4))
+ │         └── cost: 2413.33
+ ├── G8: (index-join G20 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G20 b,cols=(1-3))
- │         └── cost: 2446.67
+ │         ├── best: (index-join G20 b,cols=(1-4))
+ │         └── cost: 2453.33
  ├── G9: (filters G23 G24)
- ├── G10: (index-join G21 b,cols=(1-3))
+ ├── G10: (index-join G21 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G21 b,cols=(1-3))
- │         └── cost: 51.10
- ├── G11: (index-join G22 b,cols=(1-3))
+ │         ├── best: (index-join G21 b,cols=(1-4))
+ │         └── cost: 51.30
+ ├── G11: (index-join G22 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G22 b,cols=(1-3))
- │         └── cost: 51.50
+ │         ├── best: (index-join G22 b,cols=(1-4))
+ │         └── cost: 51.70
  ├── G12: (select G21 G27)
  │    └── ""
  │         ├── best: (select G21 G27)
@@ -535,13 +541,13 @@ opt
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1
 ----
 select
- ├── columns: k:1(int!null) u:2(int) v:3(int!null)
+ ├── columns: k:1(int!null) u:2(int) v:3(int!null) j:4(jsonb)
  ├── key: (1)
- ├── fd: (1)-->(2,3), (3)-->(1,2)
+ ├── fd: (1)-->(2-4), (3)-->(1,2,4)
  ├── index-join b
- │    ├── columns: k:1(int!null) u:2(int) v:3(int)
+ │    ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2,3), (3)-->(1), (3)~~>(1,2)
+ │    ├── fd: (1)-->(2-4), (3)-->(1), (3)~~>(1,2,4)
  │    └── scan b@v
  │         ├── columns: k:1(int!null) v:3(int!null)
  │         ├── constraint: /3: [/1 - /10]
@@ -555,38 +561,38 @@ SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1
 ----
 memo (optimized)
  ├── G1: (select G2 G3) (select G4 G21) (select G5 G21) (select G6 G18) (select G7 G18) (select G8 G18) (select G9 G18)
- │    └── "[presentation: k:1,u:2,v:3]"
+ │    └── "[presentation: k:1,u:2,v:3,j:4]"
  │         ├── best: (select G6 G18)
- │         └── cost: 51.20
- ├── G2: (scan b) (scan b,rev) (index-join G16 b,cols=(1-3)) (index-join G17 b,cols=(1-3)) (index-join G19 b,cols=(1-3)) (index-join G20 b,cols=(1-3))
+ │         └── cost: 51.40
+ ├── G2: (scan b) (scan b,rev) (index-join G16 b,cols=(1-4)) (index-join G17 b,cols=(1-4)) (index-join G19 b,cols=(1-4)) (index-join G20 b,cols=(1-4))
  │    └── ""
  │         ├── best: (scan b)
- │         └── cost: 1060.00
+ │         └── cost: 1080.00
  ├── G3: (filters G23 G24 G22)
- ├── G4: (index-join G10 b,cols=(1-3))
+ ├── G4: (index-join G10 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G10 b,cols=(1-3))
- │         └── cost: 2406.67
- ├── G5: (index-join G11 b,cols=(1-3))
+ │         ├── best: (index-join G10 b,cols=(1-4))
+ │         └── cost: 2413.33
+ ├── G5: (index-join G11 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G11 b,cols=(1-3))
- │         └── cost: 2446.67
- ├── G6: (index-join G12 b,cols=(1-3))
+ │         ├── best: (index-join G11 b,cols=(1-4))
+ │         └── cost: 2453.33
+ ├── G6: (index-join G12 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G12 b,cols=(1-3))
- │         └── cost: 51.10
- ├── G7: (index-join G13 b,cols=(1-3))
+ │         ├── best: (index-join G12 b,cols=(1-4))
+ │         └── cost: 51.30
+ ├── G7: (index-join G13 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G13 b,cols=(1-3))
- │         └── cost: 51.50
- ├── G8: (index-join G14 b,cols=(1-3))
+ │         ├── best: (index-join G13 b,cols=(1-4))
+ │         └── cost: 51.70
+ ├── G8: (index-join G14 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G14 b,cols=(1-3))
- │         └── cost: 51.10
- ├── G9: (index-join G15 b,cols=(1-3))
+ │         ├── best: (index-join G14 b,cols=(1-4))
+ │         └── cost: 51.30
+ ├── G9: (index-join G15 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G15 b,cols=(1-3))
- │         └── cost: 51.50
+ │         ├── best: (index-join G15 b,cols=(1-4))
+ │         └── cost: 51.70
  ├── G10: (select G16 G18)
  │    └── ""
  │         ├── best: (select G16 G18)
@@ -643,13 +649,13 @@ opt
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1 AND k > 5
 ----
 select
- ├── columns: k:1(int!null) u:2(int) v:3(int!null)
+ ├── columns: k:1(int!null) u:2(int) v:3(int!null) j:4(jsonb)
  ├── key: (1)
- ├── fd: (1)-->(2,3), (3)-->(1,2)
+ ├── fd: (1)-->(2-4), (3)-->(1,2,4)
  ├── index-join b
- │    ├── columns: k:1(int!null) u:2(int) v:3(int)
+ │    ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2,3), (3)-->(1), (3)~~>(1,2)
+ │    ├── fd: (1)-->(2-4), (3)-->(1), (3)~~>(1,2,4)
  │    └── select
  │         ├── columns: k:1(int!null) v:3(int!null)
  │         ├── key: (1)
@@ -669,56 +675,56 @@ SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1 AND k > 5
 ----
 memo (optimized)
  ├── G1: (select G2 G3) (select G4 G6) (select G5 G6) (select G7 G9) (select G8 G9) (select G10 G16) (select G11 G16) (select G12 G25) (select G13 G25) (select G14 G16) (select G15 G16)
- │    └── "[presentation: k:1,u:2,v:3]"
+ │    └── "[presentation: k:1,u:2,v:3,j:4]"
  │         ├── best: (select G10 G16)
- │         └── cost: 24.10
- ├── G2: (scan b) (scan b,rev) (index-join G23 b,cols=(1-3)) (index-join G24 b,cols=(1-3)) (index-join G26 b,cols=(1-3)) (index-join G28 b,cols=(1-3))
+ │         └── cost: 24.17
+ ├── G2: (scan b) (scan b,rev) (index-join G23 b,cols=(1-4)) (index-join G24 b,cols=(1-4)) (index-join G26 b,cols=(1-4)) (index-join G28 b,cols=(1-4))
  │    └── ""
  │         ├── best: (scan b)
- │         └── cost: 1060.00
+ │         └── cost: 1080.00
  ├── G3: (filters G35 G36 G34 G37)
  ├── G4: (scan b,constrained)
  │    └── ""
  │         ├── best: (scan b,constrained)
- │         └── cost: 353.33
+ │         └── cost: 360.00
  ├── G5: (scan b,rev,constrained)
  │    └── ""
  │         ├── best: (scan b,rev,constrained)
- │         └── cost: 373.33
+ │         └── cost: 386.67
  ├── G6: (filters G35 G36 G34)
- ├── G7: (index-join G17 b,cols=(1-3))
+ ├── G7: (index-join G17 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G17 b,cols=(1-3))
- │         └── cost: 1502.22
- ├── G8: (index-join G18 b,cols=(1-3))
+ │         ├── best: (index-join G17 b,cols=(1-4))
+ │         └── cost: 1504.44
+ ├── G8: (index-join G18 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G18 b,cols=(1-3))
- │         └── cost: 1542.22
+ │         ├── best: (index-join G18 b,cols=(1-4))
+ │         └── cost: 1544.44
  ├── G9: (filters G35 G36)
- ├── G10: (index-join G19 b,cols=(1-3))
+ ├── G10: (index-join G19 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G19 b,cols=(1-3))
- │         └── cost: 24.07
- ├── G11: (index-join G20 b,cols=(1-3))
+ │         ├── best: (index-join G19 b,cols=(1-4))
+ │         └── cost: 24.13
+ ├── G11: (index-join G20 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G20 b,cols=(1-3))
- │         └── cost: 24.47
- ├── G12: (index-join G31 b,cols=(1-3))
+ │         ├── best: (index-join G20 b,cols=(1-4))
+ │         └── cost: 24.53
+ ├── G12: (index-join G31 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G31 b,cols=(1-3))
- │         └── cost: 51.10
- ├── G13: (index-join G32 b,cols=(1-3))
+ │         ├── best: (index-join G31 b,cols=(1-4))
+ │         └── cost: 51.30
+ ├── G13: (index-join G32 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G32 b,cols=(1-3))
- │         └── cost: 51.50
- ├── G14: (index-join G21 b,cols=(1-3))
+ │         ├── best: (index-join G32 b,cols=(1-4))
+ │         └── cost: 51.70
+ ├── G14: (index-join G21 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G21 b,cols=(1-3))
- │         └── cost: 24.07
- ├── G15: (index-join G22 b,cols=(1-3))
+ │         ├── best: (index-join G21 b,cols=(1-4))
+ │         └── cost: 24.13
+ ├── G15: (index-join G22 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G22 b,cols=(1-3))
- │         └── cost: 24.47
+ │         ├── best: (index-join G22 b,cols=(1-4))
+ │         └── cost: 24.53
  ├── G16: (filters G34)
  ├── G17: (select G23 G25)
  │    └── ""
@@ -799,13 +805,13 @@ opt
 SELECT * FROM b WHERE (u, k, v) > (1, 2, 3) AND (u, k, v) < (8, 9, 10)
 ----
 select
- ├── columns: k:1(int!null) u:2(int!null) v:3(int)
+ ├── columns: k:1(int!null) u:2(int!null) v:3(int) j:4(jsonb)
  ├── key: (1)
- ├── fd: (1)-->(2,3), (3)~~>(1,2)
+ ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
  ├── index-join b
- │    ├── columns: k:1(int!null) u:2(int) v:3(int)
+ │    ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2,3), (3)~~>(1,2)
+ │    ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
  │    └── scan b@u
  │         ├── columns: k:1(int!null) u:2(int!null)
  │         ├── constraint: /2/1: [/1/2 - /8/9]
@@ -820,21 +826,21 @@ SELECT * FROM b WHERE (u, k, v) > (1, 2, 3) AND (u, k, v) < (8, 9, 10)
 ----
 memo (optimized)
  ├── G1: (select G2 G5) (select G3 G5) (select G4 G5)
- │    └── "[presentation: k:1,u:2,v:3]"
+ │    └── "[presentation: k:1,u:2,v:3,j:4]"
  │         ├── best: (select G3 G5)
- │         └── cost: 58.51
- ├── G2: (scan b) (scan b,rev) (index-join G6 b,cols=(1-3)) (index-join G7 b,cols=(1-3)) (index-join G8 b,cols=(1-3)) (index-join G9 b,cols=(1-3))
+ │         └── cost: 58.74
+ ├── G2: (scan b) (scan b,rev) (index-join G6 b,cols=(1-4)) (index-join G7 b,cols=(1-4)) (index-join G8 b,cols=(1-4)) (index-join G9 b,cols=(1-4))
  │    └── ""
  │         ├── best: (scan b)
- │         └── cost: 1060.00
- ├── G3: (index-join G10 b,cols=(1-3))
+ │         └── cost: 1080.00
+ ├── G3: (index-join G10 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G10 b,cols=(1-3))
- │         └── cost: 58.40
- ├── G4: (index-join G11 b,cols=(1-3))
+ │         ├── best: (index-join G10 b,cols=(1-4))
+ │         └── cost: 58.63
+ ├── G4: (index-join G11 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G11 b,cols=(1-3))
- │         └── cost: 58.86
+ │         ├── best: (index-join G11 b,cols=(1-4))
+ │         └── cost: 59.09
  ├── G5: (filters G12 G13)
  ├── G6: (scan b@u,cols=(1,2))
  │    └── ""
@@ -874,3 +880,124 @@ memo (optimized)
  ├── G23: (const 8)
  ├── G24: (const 9)
  └── G25: (const 10)
+
+# --------------------------------------------------
+# GenerateInvertedIndexScans
+# --------------------------------------------------
+# TODO(justin): these can be serviced without an index join.
+# Query only the primary key with no remaining filter.
+opt
+SELECT k FROM b WHERE j @> '{"a": "b"}'
+----
+project
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ └── index-join b
+      ├── columns: k:1(int!null) j:4(jsonb)
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      └── scan b@inv_idx
+           ├── columns: k:1(int!null)
+           ├── constraint: /4/1: [/'{"a": "b"}' - /'{"a": "b"}']
+           └── key: (1)
+
+# Query only the primary key with a remaining filter.
+opt
+SELECT k FROM b WHERE j @> '{"a": "b", "c": "d"}'
+----
+project
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ └── select
+      ├── columns: k:1(int!null) j:4(jsonb)
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── index-join b
+      │    ├── columns: k:1(int!null) j:4(jsonb)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(4)
+      │    └── scan b@inv_idx
+      │         ├── columns: k:1(int!null)
+      │         ├── constraint: /4/1: [/'{"a": "b"}' - /'{"a": "b"}']
+      │         └── key: (1)
+      └── filters [type=bool, outer=(4)]
+           └── b.j @> '{"a": "b", "c": "d"}' [type=bool, outer=(4)]
+
+# Query requiring an index join with no remaining filter.
+opt
+SELECT u, k FROM b WHERE j @> '{"a": "b"}'
+----
+project
+ ├── columns: u:2(int) k:1(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ └── index-join b
+      ├── columns: k:1(int!null) u:2(int) j:4(jsonb)
+      ├── key: (1)
+      ├── fd: (1)-->(2,4)
+      └── scan b@inv_idx
+           ├── columns: k:1(int!null)
+           ├── constraint: /4/1: [/'{"a": "b"}' - /'{"a": "b"}']
+           └── key: (1)
+
+opt
+SELECT j, k FROM b WHERE j @> '{"a": "b"}'
+----
+index-join b
+ ├── columns: j:4(jsonb) k:1(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(4)
+ └── scan b@inv_idx
+      ├── columns: k:1(int!null)
+      ├── constraint: /4/1: [/'{"a": "b"}' - /'{"a": "b"}']
+      └── key: (1)
+
+opt
+SELECT * FROM b WHERE j @> '{"a": "b"}'
+----
+index-join b
+ ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ └── scan b@inv_idx
+      ├── columns: k:1(int!null)
+      ├── constraint: /4/1: [/'{"a": "b"}' - /'{"a": "b"}']
+      └── key: (1)
+
+# Query requiring an index join with a remaining filter.
+# TODO(justin): push this filter into the index join.
+opt
+SELECT j, k FROM b WHERE j @> '{"a": "b", "c": "d"}'
+----
+select
+ ├── columns: j:4(jsonb) k:1(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(4)
+ ├── index-join b
+ │    ├── columns: k:1(int!null) j:4(jsonb)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(4)
+ │    └── scan b@inv_idx
+ │         ├── columns: k:1(int!null)
+ │         ├── constraint: /4/1: [/'{"a": "b"}' - /'{"a": "b"}']
+ │         └── key: (1)
+ └── filters [type=bool, outer=(4)]
+      └── b.j @> '{"a": "b", "c": "d"}' [type=bool, outer=(4)]
+
+opt
+SELECT * FROM b WHERE j @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
+----
+select
+ ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ ├── index-join b
+ │    ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ │    └── scan b@inv_idx
+ │         ├── columns: k:1(int!null)
+ │         ├── constraint: /4/1: [/'{"a": {"b": "c"}}' - /'{"a": {"b": "c"}}']
+ │         └── key: (1)
+ └── filters [type=bool, outer=(4)]
+      └── b.j @> '{"a": {"b": "c", "d": "e"}, "f": "g"}' [type=bool, outer=(4)]

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -142,7 +142,6 @@ func (p *planner) selectIndex(
 		bld := optbuilder.NewScalar(ctx, &p.semaCtx, p.EvalContext(), optimizer.Factory())
 		bld.AllowUnsupportedExpr = true
 		bld.AllowImpureFuncs = true
-		bld.AllowBlacklistOps = true
 		filterGroup, err := bld.Build(s.filter)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This commit uses this optimizer to plan inverted index queries. The
functionality is the same as in the existing planner, modulo that it
does not currently support efficient `->` filters.

Andy and I previously discussed defining the index as a path,value,pk
table, but I think for the time being that introduces a lot of
additional questions and invalidates a lot of existing assumptions, for
example, that the primary index is always covering. Open to discuss this
more if people have opinions on how it should work.

Release note: None