### PR TITLE
roachtest: skip tests run on expired clusters

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -49,19 +49,20 @@ import (
 )
 
 var (
-	local       bool
-	artifacts   string
-	cockroach   string
-	encrypt     bool
-	workload    string
-	roachprod   string
-	buildTag    string
-	clusterName string
-	clusterID   string
-	clusterWipe bool
-	username    = os.Getenv("ROACHPROD_USER")
-	zonesF      string
-	teamCity    bool
+	local                 bool
+	artifacts             string
+	cockroach             string
+	encrypt               bool
+	workload              string
+	roachprod             string
+	buildTag              string
+	clusterName           string
+	clusterID             string
+	clusterWipe           bool
+	username              = os.Getenv("ROACHPROD_USER")
+	zonesF                string
+	teamCity              bool
+	testingSkipValidation bool
 )
 
 func ifLocal(trueVal, falseVal string) string {
@@ -507,7 +508,7 @@ func newCluster(ctx context.Context, t testI, nodes []nodeSpec) *cluster {
 			t.Fatal(err)
 			return nil
 		}
-	} else {
+	} else if !testingSkipValidation {
 		// Perform validation on the existing cluster.
 		c.status("checking that existing cluster matches spec")
 		sargs := []string{roachprod, "list", c.name, "--json"}

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -745,11 +745,16 @@ func (r *registry) run(spec *testSpec, filter *regexp.Regexp, c *cluster, done f
 					}()
 
 					timeout = c.expiration.Add(-10 * time.Minute).Sub(timeutil.Now())
+					if timeout <= 0 {
+						t.spec.Skip = fmt.Sprintf("cluster expired (%s)", timeout)
+						return
+					}
 				}
 
 				if t.spec.Timeout > 0 && timeout > t.spec.Timeout {
 					timeout = t.spec.Timeout
 				}
+
 				done := make(chan struct{})
 				defer func() {
 					close(done)


### PR DESCRIPTION
Check to see if the cluster is expired before starting a test. Tests are
skipped if the cluster is expired which prevents 1 timed out test from
causing a cascade of issues to be posted for subsequent subtests.

Fixes #27166

Release note: None