### PR TITLE
cli/sql: support prompt customization

### DIFF
--- a/pkg/cli/interactive_tests/test_txn_prompt.tcl
+++ b/pkg/cli/interactive_tests/test_txn_prompt.tcl
@@ -18,27 +18,6 @@ eexpect "\n> select 1;\r\n"
 eexpect root@
 end_test
 
-start_test "Check prompt update statements are disabled when smart_prompt is not set"
-send "\r"
-eexpect "> SHOW TRANSACTION STATUS"
-eexpect root@
-send "\\unset smart_prompt\r"
-send "set application_name=test;\r"
-eexpect "> set application_name=test;"
-eexpect "SET"
-expect {
-    "SHOW" {
-	report "unexpected SHOW"
-	exit 1
-    }
-    root@ {}
-}
-
-# reset settings for later tests
-send "\\unset echo\r"
-send "\\set smart_prompt\r"
-end_test
-
 start_test "Check database prompt."
 send "CREATE DATABASE IF NOT EXISTS testdb;\r"
 eexpect "\nCREATE DATABASE\r\n"

--- a/pkg/cli/interactive_tests/test_txn_prompt.tcl
+++ b/pkg/cli/interactive_tests/test_txn_prompt.tcl
@@ -11,6 +11,122 @@ eexpect ":/# "
 send "$argv sql\r"
 eexpect root@
 
+###START tests prompt customization
+
+start_test "Check that invalid prompt patterns cause an error."
+send "\\set prompt1 %?\r"
+eexpect "unrecognized format code in prompt"
+
+# Reset to default.
+send "\\unset prompt1\r"
+eexpect root@
+end_test
+
+start_test "Check that one can use % signs in the prompt."
+send "\\set prompt1 abc%%def\r"
+eexpect "abc%def"
+
+# Reset to default.
+send "\\unset prompt1\r"
+eexpect root@
+end_test
+
+start_test "Check that one can use all prompt customization keys."
+send "SET database = 'defaultdb';\r"
+eexpect "\nSET\r\n"
+eexpect root@
+send "\\set prompt1 %%M:%M:%%m:%m:%%>:%>:%%n:%n:%%/:%/:%%x:%x>\r"
+eexpect %M::26257:%m::%>:26257:%n:root:%/:defaultdb:%x:
+
+# Reset to default.
+send "\\unset prompt1\r"
+eexpect root@
+end_test
+
+start_test "Check that one can use %M 'full host' key." 
+send "\\set prompt1 FULLHOST:%M>\r"
+eexpect FULLHOST::26257
+
+# Reset to default.
+send "\\unset prompt1\r"
+eexpect root@
+end_test
+
+start_test "Check that one can use %m 'host name' key." 
+send "\\set prompt1 HOSTNAME:%m>\r"
+eexpect HOSTNAME:
+
+# Reset to default.
+send "\\unset prompt1\r"
+eexpect root@
+end_test
+
+start_test "Check that one can use %> 'port number' key." 
+send "\\set prompt1 PORT:%>>\r"
+eexpect PORT:26257
+
+# Reset to default.
+send "\\unset prompt1\r"
+eexpect root@
+end_test
+
+
+start_test "Check that one can use %n 'user name' key." 
+send "\\set prompt1 USER:%n>\r"
+eexpect USER:root
+
+# Reset to default.
+send "\\unset prompt1\r"
+eexpect root@
+end_test
+
+
+start_test "Check that one can use %/ 'database' key." 
+send "\\set prompt1 DATABASE:%/>\r"
+eexpect DATABASE:defaultdb
+
+# Reset to default.
+send "\\unset prompt1\r"
+eexpect root@
+end_test
+
+
+start_test "Check that one can use %x 'txn status' key." 
+send "\\set prompt1 txnStatus:%x>\r"
+eexpect txnStatus:
+
+# Reset to default.
+send "\\unset prompt1\r"
+eexpect root@
+end_test
+
+start_test "Check none define keys." 
+send "\\set prompt1 #&@ \r"
+eexpect #&@
+
+# Reset to default.
+send "\\unset prompt1\r"
+eexpect root@
+end_test
+
+start_test "Check continuePrompt working as expected."  
+send "\\set prompt1 ### \r"
+eexpect ###
+
+send "SET database \r"
+eexpect "\r\n -> "
+send "defaultdb;\r" 
+eexpect ###
+# Reset to default.
+send "\\unset prompt1\r"
+eexpect root@
+end_test 
+
+
+
+###END tests prompt customization
+
+
 start_test "Check option to echo statements"
 send "\\set echo\r"
 send "select 1;\r"

--- a/pkg/cli/interactive_tests/test_txn_prompt.tcl
+++ b/pkg/cli/interactive_tests/test_txn_prompt.tcl
@@ -100,7 +100,7 @@ send "\\unset prompt1\r"
 eexpect root@
 end_test
 
-start_test "Check none define keys." 
+start_test "Check prompts that contain no formatting codes." 
 send "\\set prompt1 #&@ \r"
 eexpect #&@
 
@@ -121,10 +121,6 @@ eexpect ###
 send "\\unset prompt1\r"
 eexpect root@
 end_test 
-
-
-
-###END tests prompt customization
 
 
 start_test "Check option to echo statements"

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -641,7 +641,7 @@ func (c *cliState) refreshDatabaseName() (string, bool) {
 		c.lastKnownTxnStatus == " ?" /* Unknown */) {
 		return "", false
 	}
- 
+
 	dbVal, hasVal := c.conn.getServerValue("database name", `SHOW DATABASE`)
 	if !hasVal {
 		return "", false


### PR DESCRIPTION
this pull request related to issue https://github.com/cockroachdb/cockroach/issues/24494
Now we able to change the default prompt with custom pattern
which may contain :- 
1. full host name using `%M`
2. host name `%m`
3. port  `%>` 
4. user name `%n`
5. Database `%/`
6. Transaction status `%x`

the command will be like 
 1. To set `\set PROMPT1 %M:%m:%>:%n:%/:%x>`
 2. To unset `\unset PROMPT1`

notes: 
1. i writh code gives ability to use to repeat the key with no problem so he able to do some thing like that `\set PROMPT1 %M:%/:%n:%/>` to make the PROMPT `localhost:26257:bankdb:root:bankdb>`

2. the issue was refer to postgres custom prompt [here](https://www.postgresql.org/docs/9.5/static/app-psql.html#APP-PSQL-PROMPTING) i have a problem to know about some keys and how to implement , the keys are :-  `%~ ,%# ,%R ,%l ,%digits ,%:name: ,%``command`` ,%[ ... %]` , no problem to implement them again if they are required

3. I need to create test cases but i didn't find go test file to test `\set` args , i found file with extension `.tcl` , but i don't understand how it work and i searched about it with no result , it will be great if you help me with it or provide tutorial link about  .


finally it's my first pull request wit cockroachdb , I am so happy to start contributing with this brilliant idea 
so please feel free to tell me any comment to write more amazing code 