### PR TITLE
mkrelease: statically link windows release binaries

### DIFF
--- a/build/builder/mkrelease.sh
+++ b/build/builder/mkrelease.sh
@@ -83,6 +83,7 @@ case "${1-}" in
       XGOARCH=amd64
       XCMAKE_SYSTEM_NAME=Windows
       TARGET_TRIPLE=x86_64-w64-mingw32
+      LDFLAGS=-static
       SUFFIX=-windows-6.2-amd64
     ) ;;
 


### PR DESCRIPTION
This got lost in 38899a8. Static linking is necessary to bundle MinGW-only
libraries into the Windows binary. The binary is otherwise only
executable from within a MinGW environment.

Fix #27435.

Release note: None

---

At this point I deserve to win an award for most broken refactor.