### PR TITLE
storage: test lease renewal during merge transaction

### DIFF
--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1061,7 +1061,7 @@ func (*AddSSTableRequest) flags() int       { return isWrite | isAlone | isRange
 func (*RefreshRequest) flags() int      { return isRead | isTxn | updatesReadTSCache }
 func (*RefreshRangeRequest) flags() int { return isRead | isTxn | isRange | updatesReadTSCache }
 
-func (*GetSnapshotForMergeRequest) flags() int { return isRead | updatesReadTSCache }
+func (*GetSnapshotForMergeRequest) flags() int { return isRead | isAlone | updatesReadTSCache }
 
 // Keys returns credentials in an aws.Config.
 func (b *ExportStorage_S3) Keys() *aws.Config {

--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -1861,6 +1861,10 @@ func (*RefreshRangeResponse) Descriptor() ([]byte, []int) { return fileDescripto
 // that ensure there is no moment in time where the ranges involved in the merge
 // could both process commands for the same keys. See the comment on
 // GetSnapshotForMerge for details.
+//
+// GetSnapshotForMerge may return stale data when used outside of a merge
+// transaction. As a rule of thumb, it is incorrect to call GetSnapshotForMerge,
+// except from its carefully-chosen location within a merge transaction.
 type GetSnapshotForMergeRequest struct {
 	RequestHeader `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
 	// The range descriptor for the left-hand side of the merge. Used by the

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1226,6 +1226,10 @@ message RefreshRangeResponse {
 // that ensure there is no moment in time where the ranges involved in the merge
 // could both process commands for the same keys. See the comment on
 // GetSnapshotForMerge for details.
+//
+// GetSnapshotForMerge may return stale data when used outside of a merge
+// transaction. As a rule of thumb, it is incorrect to call GetSnapshotForMerge,
+// except from its carefully-chosen location within a merge transaction.
 message GetSnapshotForMergeRequest {
   option (gogoproto.equal) = true;
 

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -163,6 +163,16 @@ func (ba *BatchRequest) IsSingleEndTransactionRequest() bool {
 	return false
 }
 
+// IsSingleGetSnapshotForMergeRequest returns true iff the batch contains a
+// single request, and that request is an GetSnapshotForMergeRequest.
+func (ba *BatchRequest) IsSingleGetSnapshotForMergeRequest() bool {
+	if ba.IsSingleRequest() {
+		_, ok := ba.Requests[0].GetInner().(*GetSnapshotForMergeRequest)
+		return ok
+	}
+	return false
+}
+
 // GetPrevLeaseForLeaseRequest returns the previous lease, at the time
 // of proposal, for a request lease or transfer lease request. If the
 // batch does not contain a single lease request, this method will panic.


### PR DESCRIPTION
A lease renewal during a merge transaction can cause GetSnapshotForMerge
to be executed on a replica that has already noticed that a merge is in
progress. This is a safe and expected case, but the previous
implementation did not handle it correctly. See the comments within the
patch for a more detailed explanation of the subtleties involved.

TestStoreRangeMergeWithData is adjusted to force these lease
renewals for reliable test coverage. They otherwise happened only rarely
under stress.

Release note: None