### PR TITLE
storage: skip TestStoreRangeMergeWithData again

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -186,6 +186,8 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 func TestStoreRangeMergeWithData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	t.Skip("#27442")
+
 	for _, colocate := range []bool{false, true} {
 		for _, retries := range []int64{0, 3} {
 			t.Run(fmt.Sprintf("colocate=%v/retries=%d", colocate, retries), func(t *testing.T) {


### PR DESCRIPTION
The chaos added in 2ed1515 to force lease renewals while a merge is in
progress is too disruptive and makes the test occasionally time out. See
issue #27442 for an analysis. Skip the test for now.

Release note: None