### PR TITLE
opt: push some filters down to both sides of LEFT and RIGHT joins

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -475,6 +475,7 @@ filter          ·         ·
       └── scan  ·         ·
 ·               table     square@primary
 ·               spans     -/5/#
+·               filter    sq > 1
 
 query TTT
 SELECT "Tree", "Field", "Description" FROM [
@@ -758,7 +759,7 @@ render          ·               ·                    (x, y, u, v)        ·
       │         spans           /3-                  ·                   ·
       └── scan  ·               ·                    (x, y, v)           +x,+y
 ·               table           xyv@primary          ·                   ·
-·               spans           ALL                  ·                   ·
+·               spans           /3-                  ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
@@ -775,7 +776,7 @@ render          ·               ·                    (x, y, u, v)        ·
       │         pred            (x = x) AND (y = y)  ·                   ·
       ├── scan  ·               ·                    (x, y, u)           +x,+y
       │         table           xyu@primary          ·                   ·
-      │         spans           ALL                  ·                   ·
+      │         spans           /3-                  ·                   ·
       └── scan  ·               ·                    (x, y, v)           +x,+y
 ·               table           xyv@primary          ·                   ·
 ·               spans           /3-                  ·                   ·
@@ -884,7 +885,7 @@ render          ·               ·                    (x, y, u, v)        ·
       │         spans           /3-                  ·                   ·
       └── scan  ·               ·                    (x, y, v)           +x,+y
 ·               table           xyv@primary          ·                   ·
-·               spans           ALL                  ·                   ·
+·               spans           /3-                  ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
@@ -901,7 +902,7 @@ render          ·               ·                    (x, y, u, v)        ·
       │         pred            (x = x) AND (y = y)  ·                   ·
       ├── scan  ·               ·                    (x, y, u)           +x,+y
       │         table           xyu@primary          ·                   ·
-      │         spans           ALL                  ·                   ·
+      │         spans           /3-                  ·                   ·
       └── scan  ·               ·                    (x, y, v)           +x,+y
 ·               table           xyv@primary          ·                   ·
 ·               spans           /3-                  ·                   ·
@@ -980,7 +981,9 @@ render          ·               ·                    (x, y, u, v)        ·
 ·               spans           ALL                  ·                   ·
 
 
-# Regression test for #20858.
+# Regression test for #20765/27431.
+# We push a filter on an equality column to both sides of a left or right outer
+# join.
 
 statement ok
 CREATE TABLE l (a INT PRIMARY KEY)
@@ -1003,7 +1006,7 @@ render          ·               ·           (a)     ·
       │         spans           /3-/3/#     ·       ·
       └── scan  ·               ·           (a)     +a
 ·               table           r@primary   ·       ·
-·               spans           ALL         ·       ·
+·               spans           /3-/3/#     ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r ON l.a = r.a WHERE l.a = 3;
@@ -1018,7 +1021,7 @@ join       ·               ·           (a, a)  ·
  │         spans           /3-/3/#     ·       ·
  └── scan  ·               ·           (a)     +a
 ·          table           r@primary   ·       ·
-·          spans           ALL         ·       ·
+·          spans           /3-/3/#     ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r USING(a) WHERE a = 3;
@@ -1032,7 +1035,7 @@ render          ·               ·            (a)     ·
       │         pred            a = a        ·       ·
       ├── scan  ·               ·            (a)     +a
       │         table           l@primary    ·       ·
-      │         spans           ALL          ·       ·
+      │         spans           /3-/3/#      ·       ·
       └── scan  ·               ·            (a)     +a
 ·               table           r@primary    ·       ·
 ·               spans           /3-/3/#      ·       ·
@@ -1047,7 +1050,7 @@ join       ·               ·            (a, a)  ·
  │         pred            a = a        ·       ·
  ├── scan  ·               ·            (a)     +a
  │         table           l@primary    ·       ·
- │         spans           ALL          ·       ·
+ │         spans           /3-/3/#      ·       ·
  └── scan  ·               ·            (a)     +a
 ·          table           r@primary    ·       ·
 ·          spans           /3-/3/#      ·       ·

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -166,6 +166,101 @@
     (ConcatFilters $on $filter)
 )
 
+# PushSelectCondLeftIntoJoinLeftAndRight applies to the case when a condition
+# bound by the left side of a join can be mapped to the right side using
+# equality columns from the ON condition of the join. It pushes the original
+# filter to the left side, and the mapped filter to the right side.
+# For example, consider this query:
+#
+#   SELECT * FROM l LEFT JOIN r ON l.x = r.x WHERE l.x = 5;
+#
+# This can safely be converted to:
+#
+#   SELECT * FROM (SELECT * FROM l WHERE l.x = 5)
+#   LEFT JOIN (SELECT * FROM r WHERE r.x = 5) ON l.x = r.x;
+#
+# It's not normally correct to push filters from the SELECT clause to
+# the right side of a LEFT JOIN, since those rows might still show up
+# in the output as NULL-extended rows from the left side. In this case,
+# however, for any rows removed from the right side, the matching rows are
+# also removed from the left side (and thus removed from the output).
+# To ensure that this is the case, it's important that the filter only refers
+# to columns on the left side that have corresponding equivalent columns on
+# the right side.
+[PushSelectCondLeftIntoJoinLeftAndRight, Normalize]
+(Select
+    $input:(InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply |
+            SemiJoin | SemiJoinApply | AntiJoin | AntiJoinApply
+        $left:*
+        $right:*
+        $on:*
+    )
+    (Filters
+        $list:[
+            ...
+            $condition:* &
+                (IsBoundBy $condition $left) &
+                (CanMap $on $condition $right)
+            ...
+        ]
+    )
+)
+=>
+(Select
+    ((OpName $input)
+        (Select
+            $left
+            (Filters [$condition])
+        )
+        (Select
+            $right
+            (Filters [(Map $on $condition $right)])
+        )
+        $on
+    )
+    (Filters (RemoveListItem $list $condition))
+)
+
+# PushSelectCondRightIntoJoinLeftAndRight is symmetric with
+# PushSelectCondLeftIntoJoinLeftAndRight. It applies to the case when a
+# condition bound by the right side of a join can be mapped to the left side
+# using equality columns from the ON condition of the join. It pushes the
+# original filter to the right side, and the mapped filter to the left side.
+# See the comments above PushSelectCondLeftIntoJoinLeftAndRight for more
+# details.
+[PushSelectCondRightIntoJoinLeftAndRight, Normalize]
+(Select
+    $input:(InnerJoin | InnerJoinApply | RightJoin | RightJoinApply
+        $left:*
+        $right:*
+        $on:*
+    )
+    (Filters
+        $list:[
+            ...
+            $condition:* &
+                (IsBoundBy $condition $right) &
+                (CanMap $on $condition $left)
+            ...
+        ]
+    )
+)
+=>
+(Select
+    ((OpName $input)
+        (Select
+            $left
+            (Filters [(Map $on $condition $left)])
+        )
+        (Select
+            $right
+            (Filters [$condition])
+        )
+        $on
+    )
+    (Filters (RemoveListItem $list $condition))
+)
+
 # PushSelectIntoJoinLeft pushes Select filter conditions into the left side of
 # an input Join. This is possible in the case of InnerJoin, LeftJoin, SemiJoin,
 # and AntiJoin, as long as the condition has no dependencies on the right side

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -377,6 +377,136 @@ inner-join
       └── a.k > xy.y [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ])]
 
 # --------------------------------------------------
+# PushSelectCondLeftIntoJoinLeftAndRight
+#   + PushSelectCondRightIntoJoinLeftAndRight
+# --------------------------------------------------
+
+# Only the filters bound by the left side are mapped and pushed down.
+opt
+SELECT * FROM a LEFT JOIN xy ON a.k=xy.x WHERE a.k > 5 AND (xy.x = 6 OR xy.x IS NULL)
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
+ ├── key: (1,6)
+ ├── fd: (1)-->(2-5), (6)-->(7)
+ ├── left-join (merge)
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
+ │    ├── key: (1,6)
+ │    ├── fd: (1)-->(2-5), (6)-->(7)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    ├── constraint: /1: [/6 - ]
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-5)
+ │    │    └── ordering: +1
+ │    ├── scan xy
+ │    │    ├── columns: x:6(int!null) y:7(int)
+ │    │    ├── constraint: /6: [/6 - ]
+ │    │    ├── key: (6)
+ │    │    ├── fd: (6)-->(7)
+ │    │    └── ordering: +6
+ │    └── merge-on
+ │         ├── left ordering: +1
+ │         ├── right ordering: +6
+ │         └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │              └── a.k = xy.x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+ └── filters [type=bool, outer=(6)]
+      └── (xy.x = 6) OR (xy.x IS NULL) [type=bool, outer=(6)]
+
+opt
+SELECT * FROM a WHERE EXISTS (SELECT * FROM xy WHERE a.k=xy.x) AND a.k > 5
+----
+semi-join (merge)
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── constraint: /1: [/6 - ]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    └── ordering: +1
+ ├── scan xy
+ │    ├── columns: x:6(int!null) y:7(int)
+ │    ├── constraint: /6: [/6 - ]
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(7)
+ │    └── ordering: +6
+ └── merge-on
+      ├── left ordering: +1
+      ├── right ordering: +6
+      └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+           └── a.k = xy.x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+
+opt
+SELECT * FROM a WHERE NOT EXISTS (SELECT * FROM xy WHERE a.k=xy.x) AND a.k > 5
+----
+anti-join (merge)
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── constraint: /1: [/6 - ]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    └── ordering: +1
+ ├── scan xy
+ │    ├── columns: x:6(int!null) y:7(int)
+ │    ├── constraint: /6: [/6 - ]
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(7)
+ │    └── ordering: +6
+ └── merge-on
+      ├── left ordering: +1
+      ├── right ordering: +6
+      └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+           └── a.k = xy.x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+
+# Only the filters bound by the right side are mapped and pushed down.
+opt
+SELECT * FROM a RIGHT JOIN xy ON a.k=xy.x AND a.i=xy.y
+WHERE xy.x + xy.y > 5 AND (xy.x + a.i = 6 OR xy.x IS NULL) AND (xy.y % 2 = 0) AND xy.x >= 10
+----
+select
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+ ├── key: (1,6)
+ ├── fd: (1)-->(2-5), (6)-->(7)
+ ├── right-join
+ │    ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+ │    ├── key: (1,6)
+ │    ├── fd: (1)-->(2-5), (6)-->(7)
+ │    ├── select
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-5)
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    ├── constraint: /1: [/10 - ]
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2-5)
+ │    │    └── filters [type=bool, outer=(1,2)]
+ │    │         ├── (a.k + a.i) > 5 [type=bool, outer=(1,2)]
+ │    │         └── (a.i % 2) = 0 [type=bool, outer=(2)]
+ │    ├── select
+ │    │    ├── columns: x:6(int!null) y:7(int)
+ │    │    ├── key: (6)
+ │    │    ├── fd: (6)-->(7)
+ │    │    ├── scan xy
+ │    │    │    ├── columns: x:6(int!null) y:7(int)
+ │    │    │    ├── constraint: /6: [/10 - ]
+ │    │    │    ├── key: (6)
+ │    │    │    └── fd: (6)-->(7)
+ │    │    └── filters [type=bool, outer=(6,7)]
+ │    │         ├── (xy.x + xy.y) > 5 [type=bool, outer=(6,7)]
+ │    │         └── (xy.y % 2) = 0 [type=bool, outer=(7)]
+ │    └── filters [type=bool, outer=(1,2,6,7), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /6: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(6), (6)==(1), (2)==(7), (7)==(2)]
+ │         ├── a.k = xy.x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+ │         └── a.i = xy.y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
+ └── filters [type=bool, outer=(2,6)]
+      └── ((xy.x + a.i) = 6) OR (xy.x IS NULL) [type=bool, outer=(2,6)]
+
+# --------------------------------------------------
 # PushSelectIntoJoinLeft
 # --------------------------------------------------
 opt


### PR DESCRIPTION
This commit adds two normalization rules:

1. `PushSelectCondLeftIntoJoinLeftAndRight` applies to the case when a condition
   bound by the left side of a `LEFT JOIN` can be mapped to the right side using
   equality columns from the `ON` condition of the join. It pushes the original
   filter to the left side, and the mapped filter to the right side. 
   For example, consider this query: 
  ``` SELECT * FROM l LEFT JOIN r ON l.x = r.x WHERE l.x = 5; ```
   This can safely be converted to:
  ``` SELECT * FROM (SELECT * FROM l WHERE l.x = 5)```
   ```LEFT JOIN (SELECT * FROM r WHERE r.x = 5) ON l.x = r.x; ```
   It's not normally correct to push filters from the `SELECT` clause to
   the right side of a `LEFT JOIN`, since those rows might still show up
   in the output as NULL-extended rows from the left side. In this case,
   however, for any rows removed from the right side, the matching rows are
   also removed from the left side (and thus removed from the output).

2. `PushSelectCondRightIntoJoinLeftAndRight` is symmetric with
   `PushSelectCondLeftIntoJoinLeftAndRight`. It applies to the case when a
   condition bound by the right side of a `RIGHT JOIN` can be mapped to the left side
   using equality columns from the `ON` condition of the join. It pushes the
   original filter to the right side, and the mapped filter to the left side.

Fixes #27431

Release note: None