### PR TITLE
pretty: capture all options in a struct

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -116,10 +116,11 @@ func initCLIDefaults() {
 	nodeCtx.statusShowAll = false
 	nodeCtx.statusShowDecommission = false
 
-	sqlfmtCtx.len = tree.DefaultPrettyWidth
-	sqlfmtCtx.useSpaces = false
-	sqlfmtCtx.tabWidth = 4
-	sqlfmtCtx.noSimplify = false
+	cfg := tree.DefaultPrettyCfg()
+	sqlfmtCtx.len = cfg.LineWidth
+	sqlfmtCtx.useSpaces = !cfg.UseTabs
+	sqlfmtCtx.tabWidth = cfg.IndentWidth
+	sqlfmtCtx.noSimplify = !cfg.Simplify
 	sqlfmtCtx.execStmts = nil
 
 	initPreFlagsDefaults()

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -369,10 +369,11 @@ func init() {
 
 	// sqlfmt command.
 	VarFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.execStmts, cliflags.Execute)
-	IntFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.len, cliflags.SQLFmtLen, tree.DefaultPrettyWidth)
-	BoolFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.useSpaces, cliflags.SQLFmtSpaces, false)
-	IntFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.tabWidth, cliflags.SQLFmtTabWidth, 4)
-	BoolFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.noSimplify, cliflags.SQLFmtNoSimplify, true)
+	cfg := tree.DefaultPrettyCfg()
+	IntFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.len, cliflags.SQLFmtLen, cfg.LineWidth)
+	BoolFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.useSpaces, cliflags.SQLFmtSpaces, !cfg.UseTabs)
+	IntFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.tabWidth, cliflags.SQLFmtTabWidth, cfg.IndentWidth)
+	BoolFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.noSimplify, cliflags.SQLFmtNoSimplify, !cfg.Simplify)
 
 	// Debug commands.
 	{

--- a/pkg/cli/sqlfmt.go
+++ b/pkg/cli/sqlfmt.go
@@ -68,8 +68,14 @@ func runSQLFmt(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	cfg := tree.DefaultPrettyCfg()
+	cfg.UseTabs = !sqlfmtCtx.useSpaces
+	cfg.LineWidth = sqlfmtCtx.len
+	cfg.IndentWidth = sqlfmtCtx.tabWidth
+	cfg.Simplify = !sqlfmtCtx.noSimplify
+
 	for _, s := range sl {
-		fmt.Print(tree.PrettyWithOpts(s, sqlfmtCtx.len, !sqlfmtCtx.useSpaces, sqlfmtCtx.tabWidth, !sqlfmtCtx.noSimplify))
+		fmt.Print(cfg.Pretty(s))
 		if len(sl) > 1 {
 			fmt.Print(";")
 		}

--- a/pkg/sql/sem/tree/pretty_test.go
+++ b/pkg/sql/sem/tree/pretty_test.go
@@ -46,6 +46,7 @@ func TestPrettyData(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	cfg := tree.DefaultPrettyCfg()
 	for _, m := range matches {
 		m := m
 		t.Run(filepath.Base(m), func(t *testing.T) {
@@ -71,7 +72,9 @@ func TestPrettyData(t *testing.T) {
 			g, _ := errgroup.WithContext(context.Background())
 			worker := func() error {
 				for i := range work {
-					res[i-1] = tree.PrettyWithOpts(stmt, i, true, 4, true)
+					thisCfg := cfg
+					thisCfg.LineWidth = i
+					res[i-1] = thisCfg.Pretty(stmt)
 				}
 				return nil
 			}
@@ -106,7 +109,7 @@ func TestPrettyData(t *testing.T) {
 				t.Fatal(err)
 			}
 			if string(expect) != got {
-				t.Fatalf("unexpected:\n%s", got)
+				t.Fatalf("expected:\n%s\ngot:\n%s", expect, got)
 			}
 
 			sqlutils.VerifyStatementPrettyRoundtrip(t, string(sql))
@@ -141,7 +144,7 @@ func BenchmarkPrettyData(b *testing.B) {
 		b.Fatal(err)
 	}
 	var docs []pretty.Doc
-	cfg := tree.PrettyCfg{IndentWidth: 4}
+	cfg := tree.DefaultPrettyCfg()
 	for _, m := range matches {
 		sql, err := ioutil.ReadFile(m)
 		if err != nil {

--- a/pkg/testutils/sqlutils/pretty.go
+++ b/pkg/testutils/sqlutils/pretty.go
@@ -30,9 +30,12 @@ func VerifyStatementPrettyRoundtrip(t *testing.T, sql string) {
 	if err != nil {
 		t.Fatalf("%s: %s", err, sql)
 	}
+	cfg := tree.DefaultPrettyCfg()
+	// Be careful to not simplify otherwise the tests won't round trip.
+	cfg.Simplify = false
 	for _, origStmt := range stmts {
 		// Be careful to not simplify otherwise the tests won't round trip.
-		prettyStmt := tree.PrettyWithOpts(origStmt, tree.DefaultPrettyWidth, true, 4, false /* simplify */)
+		prettyStmt := cfg.Pretty(origStmt)
 		parsedPretty, err := parser.ParseOne(prettyStmt)
 		if err != nil {
 			t.Fatalf("%s: %s", err, prettyStmt)


### PR DESCRIPTION
This patch makes `PrettyCfg` hold all customizable options. This way
we do not need `PrettyWithOpts` and the possible instability of its
argument list.

Small perf boost:

```
name           old time/op    new time/op    delta
PrettyData-16     180ms ±12%     155ms ±13%    ~     (p=0.056 n=5+5)

name           old alloc/op   new alloc/op   delta
PrettyData-16    22.6MB ± 0%    21.2MB ± 0%  -5.96%  (p=0.008 n=5+5)

name           old allocs/op  new allocs/op  delta
PrettyData-16     6.76k ± 0%     6.34k ± 0%  -6.12%  (p=0.008 n=5+5)
```

Release note: None