### PR TITLE
storage: add replica to unquiesced map only after raft group is init'd

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -3096,6 +3096,10 @@ func TestReplicaTooOldGC(t *testing.T) {
 				return nil
 			}
 			return err
+		} else if replica != nil {
+			// Make sure the replica is unquiesced so that it will tick and
+			// contact the leader to discover it's no longer part of the range.
+			replica.UnquiesceAndWakeLeader()
 		}
 		return errors.Errorf("found %s, waiting for it to be GC'd", replica)
 	})

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -496,6 +496,12 @@ func (r *Replica) GetQueueLastProcessed(ctx context.Context, queue string) (hlc.
 	return r.getQueueLastProcessed(ctx, queue)
 }
 
+func (r *Replica) UnquiesceAndWakeLeader() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.unquiesceAndWakeLeaderLocked()
+}
+
 func (nl *NodeLiveness) SetDrainingInternal(
 	ctx context.Context, liveness *Liveness, drain bool,
 ) error {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2398,11 +2398,9 @@ func (s *Store) MergeRange(
 // this store. addReplicaInternalLocked requires that the store lock is held.
 func (s *Store) addReplicaInternalLocked(repl *Replica) error {
 	if !repl.IsInitialized() {
-		return errors.Errorf("attempted to add uninitialized range %s", repl)
+		return errors.Errorf("attempted to add uninitialized replica %s", repl)
 	}
 
-	// TODO(spencer): will need to determine which range is
-	// newer, and keep that one.
 	if err := s.addReplicaToRangeMapLocked(repl); err != nil {
 		return err
 	}
@@ -2471,13 +2469,18 @@ func (s *Store) removePlaceholderLocked(ctx context.Context, rngID roachpb.Range
 }
 
 // addReplicaToRangeMapLocked adds the replica to the replicas map.
-// addReplicaToRangeMapLocked requires that the store lock is held.
 func (s *Store) addReplicaToRangeMapLocked(repl *Replica) error {
 	if _, loaded := s.mu.replicas.LoadOrStore(int64(repl.RangeID), unsafe.Pointer(repl)); loaded {
 		return errors.Errorf("%s: replica already exists", repl)
 	}
+	// Check whether the replica is unquiesced but not in the map. This
+	// can happen during splits and merges, where the uninitialized (but
+	// also unquiesced) replica is removed from the unquiesced replica
+	// map in advance of this method being called.
 	s.unquiescedReplicas.Lock()
-	s.unquiescedReplicas.m[repl.RangeID] = struct{}{}
+	if _, ok := s.unquiescedReplicas.m[repl.RangeID]; !repl.mu.quiescent && !ok {
+		s.unquiescedReplicas.m[repl.RangeID] = struct{}{}
+	}
 	s.unquiescedReplicas.Unlock()
 	return nil
 }


### PR DESCRIPTION
Previously, we were adding all newly created replicas directly to the
store's `unquiescedReplicas` map, where they'd stay, despite being
quiesced, until the raft group was lazily loaded. They'd be continually
ticked because `Replica.tick()` preemptively exits if the Raft group
hasn't yet been loaded.

This change moves adding the replica to the `unquiescedReplicas` map
until after the Raft group is first created, allowing it to be ticked
at least once.

Release note: None