### PR TITLE
lint: speed up TestCrlfmt

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -242,7 +242,7 @@
   branch = "master"
   name = "github.com/cockroachdb/crlfmt"
   packages = ["."]
-  revision = "ea27cb9045ae7c4e7e63926df6300454e3d6f3d8"
+  revision = "5895607e5ea790fcbb640260129a12d277b34e46"
 
 [[projects]]
   branch = "master"

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -719,7 +719,7 @@ func TestLint(t *testing.T) {
 	t.Run("TestCrlfmt", func(t *testing.T) {
 		t.Parallel()
 		ignore := `\.(pb(\.gw)?)|(\.og)\.go|/testdata/`
-		cmd, stderr, filter, err := dirCmd(pkgDir, "crlfmt", "-ignore", ignore, "-tab", "2", ".")
+		cmd, stderr, filter, err := dirCmd(pkgDir, "crlfmt", "-fast", "-ignore", ignore, "-tab", "2", ".")
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Pass the -fast flag to crlfmt, which instructs it to skip running
goimports/gofmt. It takes over 90s to run crlfmt without the -fast flag;
with the flag, it takes only 2s.

Note that this patch does not reduce lint coverage. The linter already
runs gofmt in a separate test. Goimports does not enforce any particular
ordering on the imports, beyond the sorting that gofmt mandates, so
there's nothing to be lost by skipping it.

Release note: None