### PR TITLE
optbuilder: Fix optbuilder to build correctly typed subqueries

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -1582,9 +1582,11 @@ project
  └── projections
       └── subquery [type=int]
            └── max1-row
-                ├── columns: kv.k:1(int!null) v:2(string)
-                └── scan kv
-                     └── columns: kv.k:1(int!null) v:2(string)
+                ├── columns: kv.k:1(int!null)
+                └── project
+                     ├── columns: kv.k:1(int!null)
+                     └── scan kv
+                          └── columns: kv.k:1(int!null) v:2(string)
 
 exec-ddl
 CREATE TABLE t1 (a INT)
@@ -1855,3 +1857,51 @@ project
                                               └── div [type=decimal]
                                                    ├── variable: column9 [type=int]
                                                    └── variable: column10 [type=int]
+
+exec-ddl
+CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
+----
+TABLE a
+ ├── k int not null
+ ├── i int
+ ├── f float
+ ├── s string
+ ├── j jsonb
+ └── INDEX primary
+      └── k int not null
+
+# Regression test for #27330. Ensure that the subquery only returns one column
+# and is correctly typed.
+build
+SELECT *
+FROM a
+WHERE 'bar'=(SELECT max(s) FROM a GROUP BY i ORDER BY i LIMIT 1)
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── scan a
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ └── filters [type=bool]
+      └── eq [type=bool]
+           ├── const: 'bar' [type=string]
+           └── subquery [type=string]
+                └── max1-row
+                     ├── columns: max:11(string)
+                     └── project
+                          ├── columns: max:11(string)
+                          └── limit
+                               ├── columns: a.i:7(int) max:11(string)
+                               ├── sort
+                               │    ├── columns: a.i:7(int) max:11(string)
+                               │    ├── ordering: +7
+                               │    └── group-by
+                               │         ├── columns: a.i:7(int) max:11(string)
+                               │         ├── grouping columns: a.i:7(int)
+                               │         ├── project
+                               │         │    ├── columns: a.i:7(int) a.s:9(string)
+                               │         │    └── scan a
+                               │         │         └── columns: a.k:6(int!null) a.i:7(int) a.f:8(float) a.s:9(string) a.j:10(jsonb)
+                               │         └── aggregations
+                               │              └── max [type=string]
+                               │                   └── variable: a.s [type=string]
+                               └── const: 1 [type=int]


### PR DESCRIPTION
The typing of some subqueries was incorrect because the `ORDER BY`
columns were being projected along with the output columns of the
subquery. This commit adds logic to detect when the `ORDER BY` columns
should not be projected, and wraps the underlying expression in a
`Project` operation to remove the excess columns. This fixes the
issue with incorrect typing.

Fixes #27330

Release note: None