### PR TITLE
sql: adjust the throttling for ClearRange ops

### DIFF
--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -86,11 +86,13 @@ func registerClearRange(r *registry) {
 					return err
 				}
 
-				// Spend a few minutes reading data with a timeout to make sure the DROP
-				// above didn't brick the cluster.
+				// Spend a few minutes reading data with a timeout to make sure the
+				// DROP above didn't brick the cluster. At the time of writing,
+				// clearing all of the table data takes ~6min. We run for 2.5x that
+				// time to verify that nothing has gone wonky on the cluster.
 				//
 				// Don't lower this number, or the test may pass erroneously.
-				const minutes = 60
+				const minutes = 15
 				t.WorkerStatus("repeatedly running count(*) on small table")
 				for i := 0; i < minutes; i++ {
 					after := time.After(time.Minute)


### PR DESCRIPTION
Send ClearRange ops in larger batches and more frequently (combined for
10x more per sec). The recent fixes to the RocksDB range tombstone
implementation have alleviated some of the performance problems that
originally motivated this throttling.

Lower the duration of the clearrange roachtest as it now takes ~6min to
delete all of the data.

Release note: None