### PR TITLE
lint: ensure the output of TestGofmtSimplify is not broken

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -691,6 +691,7 @@ func TestLint(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		var buf bytes.Buffer
 		if err := stream.ForEach(
 			stream.Sequence(
 				filter,
@@ -699,9 +700,13 @@ func TestLint(t *testing.T) {
 				}),
 				stream.Xargs("gofmt", "-s", "-d", "-l"),
 			), func(s string) {
-				t.Errorf("\n%s", s)
+				fmt.Fprintln(&buf, s)
 			}); err != nil {
 			t.Error(err)
+		}
+		errs := buf.String()
+		if len(errs) > 0 {
+			t.Errorf("\n%s", errs)
 		}
 
 		if err := cmd.Wait(); err != nil {


### PR DESCRIPTION
This patch makes sures the output of the underlying `gofmt` command is
not broken up in multiple parts.

Release note: None