### PR TITLE
opt: Add support for virtual (system) tables

### DIFF
--- a/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
+++ b/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
@@ -40,7 +40,7 @@ send "PS1=':''/# '\r"
 eexpect ":/# "
 
 # Set the max memory usage to the baseline plus some margin.
-send "ulimit -v [ expr {2*$vmem+400} ]\r"
+send "ulimit -v [ expr {3*$vmem/2} ]\r"
 eexpect ":/# "
 
 # Start a server with this limit set. The server will now run in the foreground.
@@ -68,7 +68,7 @@ eexpect root@
 # Disable query distribution to force in-memory computation.
 send "set distsql=off;\r"
 eexpect SET
-send "select * from information_schema.columns as a, information_schema.columns as b,  information_schema.columns as c,  information_schema.columns as d limit 10;\r"
+send "select * from (select * from information_schema.columns as a, information_schema.columns as b) full join (select * from information_schema.columns as c, information_schema.columns as d) on true limit 10;\r"
 
 # Check that the query crashed the server
 set spawn_id $shell_spawn_id
@@ -100,7 +100,7 @@ send "select 1;\r"
 eexpect root@
 send "set database=system;\r"
 eexpect root@
-send "select * from  information_schema.columns as a,  information_schema.columns as b,  information_schema.columns as c,  information_schema.columns as d limit 10;\r"
+send "select * from (select * from information_schema.columns as a, information_schema.columns as b) full join (select * from information_schema.columns as c, information_schema.columns as d) on true limit 10;\r"
 eexpect "memory budget exceeded"
 eexpect root@
 

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -79,7 +79,7 @@ func (p *planner) getVirtualDataSource(
 		return planDataSource{}, err
 	}
 
-	columns, constructor := virtual.getPlanInfo(ctx)
+	columns, constructor := virtual.getPlanInfo()
 
 	// Define the name of the source visible in EXPLAIN(NOEXPAND).
 	sourceName := tree.MakeTableNameWithSchema(

--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -110,9 +110,6 @@ SELECT count(*) FILTER (WHERE v>10) FROM t
 query error pq: views and sequences are not supported
 SELECT * FROM tview
 
-query error pq: virtual tables are not supported
-SELECT job_id FROM crdb_internal.jobs
-
 query error pq: generator functions are not supported
 SELECT generate_series(1, 2)
 

--- a/pkg/sql/logictest/testdata/logic_test/subquery_correlated
+++ b/pkg/sql/logictest/testdata/logic_test/subquery_correlated
@@ -685,7 +685,6 @@ INNER JOIN o
 ON c.c_id=o.c_id AND o.ship = (SELECT min(o.ship) FROM o WHERE o.c_id=c.c_id);
 
 statement error HINT: some correlated subqueries are not supported yet
-SELECT * FROM pg_class a WHERE EXISTS (SELECT * FROM pg_class b WHERE a.oid = b.oid)
-
-statement error HINT: some correlated subqueries are not supported yet
-SELECT * FROM pg_class a WHERE EXISTS (SELECT * FROM o WHERE a.oid = o.o_id::oid)
+SELECT (SELECT c_id FROM o AS OF SYSTEM TIME '-0ns')
+FROM c
+WHERE EXISTS(SELECT * FROM o WHERE o.c_id=c.c_id)

--- a/pkg/sql/opt/catalog.go
+++ b/pkg/sql/opt/catalog.go
@@ -31,9 +31,6 @@ import (
 // ColumnName is the type of a column name.
 type ColumnName string
 
-// TableName is the type of a table name.
-type TableName string
-
 // PrimaryIndex selects the primary index of a table when calling the
 // Table.Index method. Every table is guaranteed to have a unique primary
 // index, even if it meant adding a hidden unique rowid column.
@@ -181,8 +178,10 @@ type TableStatistic interface {
 // Table is an interface to a database table, exposing only the information
 // needed by the query optimizer.
 type Table interface {
-	// TabName returns the name of the table.
-	TabName() TableName
+	// TabName returns the fully normalized, fully qualified, and fully resolved
+	// name of the table. The ExplicitCatalog and ExplicitSchema fields will
+	// always be true, since both names are always specified.
+	TabName() *tree.TableName
 
 	// IsVirtualTable returns true if this table is a special system table that
 	// constructs its rows "on the fly" when it's queried. An example is the
@@ -225,7 +224,7 @@ type Catalog interface {
 // FormatCatalogTable nicely formats a catalog table using a treeprinter for
 // debugging and testing.
 func FormatCatalogTable(tab Table, tp treeprinter.Node) {
-	child := tp.Childf("TABLE %s", tab.TabName())
+	child := tp.Childf("TABLE %s", tab.TabName().TableName)
 
 	var buf bytes.Buffer
 	for i := 0; i < tab.ColumnCount(); i++ {

--- a/pkg/sql/opt/exec/execbuilder/testdata/information_schema
+++ b/pkg/sql/opt/exec/execbuilder/testdata/information_schema
@@ -1,0 +1,14 @@
+# LogicTest: local-opt
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM system.information_schema.schemata
+----
+values  ·     ·                  (catalog_name, schema_name, default_character_set_name, sql_path)  ·
+·       size  4 columns, 4 rows  ·                                                                  ·
+
+query TTT
+EXPLAIN SELECT * FROM system.information_schema.tables WHERE table_name='foo'
+----
+filter       ·     ·
+ └── values  ·     ·
+·            size  6 columns, 102 rows

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -68,6 +68,11 @@ type Factory interface {
 		reqOrder sqlbase.ColumnOrdering,
 	) (Node, error)
 
+	// ConstructVirtualScan returns a node that represents the scan of a virtual
+	// table. Virtual tables are system tables that are populated "on the fly"
+	// with rows synthesized from system metadata and other state.
+	ConstructVirtualScan(table opt.Table) (Node, error)
+
 	// ConstructFilter returns a node that applies a filter on the results of
 	// the given input node.
 	ConstructFilter(n Node, filter tree.TypedExpr) (Node, error)

--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -265,7 +265,7 @@ func (ev ExprView) formatRelational(f *opt.ExprFmtCtx, tp treeprinter.Node) {
 		formatter.formatPrivate(def, formatNormal)
 		buf.WriteByte(')')
 
-	case opt.ScanOp, opt.IndexJoinOp, opt.ShowTraceForSessionOp:
+	case opt.ScanOp, opt.VirtualScanOp, opt.IndexJoinOp, opt.ShowTraceForSessionOp:
 		fmt.Fprintf(&buf, "%v", ev.op)
 		formatter.formatPrivate(ev.Private(), formatNormal)
 

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -53,6 +53,9 @@ func (b *logicalPropsBuilder) buildRelationalProps(ev ExprView) props.Logical {
 	case opt.ScanOp:
 		return b.buildScanProps(ev)
 
+	case opt.VirtualScanOp:
+		return b.buildVirtualScanProps(ev)
+
 	case opt.SelectOp:
 		return b.buildSelectProps(ev)
 
@@ -153,6 +156,42 @@ func (b *logicalPropsBuilder) buildScanProps(ev ExprView) props.Logical {
 	// ----------
 	b.sb.init(b.evalCtx, &relational.Stats, relational, ev, &keyBuffer{})
 	b.sb.buildScan(def)
+
+	return logical
+}
+
+func (b *logicalPropsBuilder) buildVirtualScanProps(ev ExprView) props.Logical {
+	logical := props.Logical{Relational: &props.Relational{}}
+	relational := logical.Relational
+
+	def := ev.Private().(*VirtualScanOpDef)
+
+	// Output Columns
+	// --------------
+	// VirtualScan output columns are stored in the definition.
+	relational.OutputCols = def.Cols
+
+	// Not Null Columns
+	// ----------------
+	// All columns are assumed to be nullable.
+
+	// Outer Columns
+	// -------------
+	// VirtualScan operator never has outer columns.
+
+	// Functional Dependencies
+	// -----------------------
+	// VirtualScan operator has an empty FD set.
+
+	// Cardinality
+	// -----------
+	// Don't make any assumptions about cardinality of output.
+	relational.Cardinality = props.AnyCardinality
+
+	// Statistics
+	// ----------
+	b.sb.init(b.evalCtx, &relational.Stats, relational, ev, &keyBuffer{})
+	b.sb.buildVirtualScan(def)
 
 	return logical
 }

--- a/pkg/sql/opt/memo/memo_format.go
+++ b/pkg/sql/opt/memo/memo_format.go
@@ -273,9 +273,9 @@ func (f exprFormatter) formatPrivate(private interface{}, mode formatMode) {
 		// Don't output name of index if it's the primary index.
 		tab := f.mem.metadata.Table(t.Table)
 		if t.Index == opt.PrimaryIndex {
-			fmt.Fprintf(f.buf, " %s", tab.TabName())
+			fmt.Fprintf(f.buf, " %s", tab.TabName().TableName)
 		} else {
-			fmt.Fprintf(f.buf, " %s@%s", tab.TabName(), tab.Index(t.Index).IdxName())
+			fmt.Fprintf(f.buf, " %s@%s", tab.TabName().TableName, tab.Index(t.Index).IdxName())
 		}
 		if t.Reverse {
 			fmt.Fprintf(f.buf, ",rev")
@@ -291,6 +291,10 @@ func (f exprFormatter) formatPrivate(private interface{}, mode formatMode) {
 				fmt.Fprintf(f.buf, ",lim=%d", t.HardLimit)
 			}
 		}
+
+	case *VirtualScanOpDef:
+		tab := f.mem.metadata.Table(t.Table)
+		fmt.Fprintf(f.buf, " %s", tab.TabName())
 
 	case *RowNumberDef:
 		if !t.Ordering.Any() {
@@ -308,7 +312,7 @@ func (f exprFormatter) formatPrivate(private interface{}, mode formatMode) {
 
 	case *IndexJoinDef:
 		tab := f.mem.metadata.Table(t.Table)
-		fmt.Fprintf(f.buf, " %s", tab.TabName())
+		fmt.Fprintf(f.buf, " %s", tab.TabName().TableName)
 		if mode == formatMemo {
 			fmt.Fprintf(f.buf, ",cols=%s", t.Cols)
 		}
@@ -316,9 +320,9 @@ func (f exprFormatter) formatPrivate(private interface{}, mode formatMode) {
 	case *LookupJoinDef:
 		tab := f.mem.metadata.Table(t.Table)
 		if t.Index == opt.PrimaryIndex {
-			fmt.Fprintf(f.buf, " %s", tab.TabName())
+			fmt.Fprintf(f.buf, " %s", tab.TabName().TableName)
 		} else {
-			fmt.Fprintf(f.buf, " %s@%s", tab.TabName(), tab.Index(t.Index).IdxName())
+			fmt.Fprintf(f.buf, " %s@%s", tab.TabName().TableName, tab.Index(t.Index).IdxName())
 		}
 		if mode == formatMemo {
 			fmt.Fprintf(f.buf, ",keyCols=%v,lookupCols=%s", t.KeyCols, t.LookupCols)

--- a/pkg/sql/opt/memo/private_defs.go
+++ b/pkg/sql/opt/memo/private_defs.go
@@ -102,6 +102,20 @@ type ScanOpDef struct {
 	HardLimit int64
 }
 
+// VirtualScanOpDef defines the value of the Def private field of the
+// VirtualScan operator.
+type VirtualScanOpDef struct {
+	// Table identifies the virtual table to synthesize and scan. It is an id
+	// that can be passed to the Metadata.Table method in order to fetch
+	// opt.Table metadata.
+	Table opt.TableID
+
+	// Cols specifies the set of columns that the VirtualScan operator projects.
+	// This is always every column in the virtual table (i.e. never a subset even
+	// if all columns are not needed).
+	Cols opt.ColSet
+}
+
 // CanProvideOrdering returns true if the scan operator returns rows that
 // satisfy the given required ordering.
 func (s *ScanOpDef) CanProvideOrdering(md *opt.Metadata, required *props.OrderingChoice) bool {

--- a/pkg/sql/opt/memo/private_storage.go
+++ b/pkg/sql/opt/memo/private_storage.go
@@ -248,6 +248,24 @@ func (ps *privateStorage) internScanOpDef(def *ScanOpDef) PrivateID {
 	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, def)
 }
 
+// internVirtualScanOpDef adds the given value to storage and returns an id that
+// can later be used to retrieve the value by calling the lookup method. If the
+// value has been previously added to storage, then internVirtualScanOpDef
+// always  returns the same private id that was returned from the previous call.
+func (ps *privateStorage) internVirtualScanOpDef(def *VirtualScanOpDef) PrivateID {
+	// The below code is carefully constructed to not allocate in the case where
+	// the value is already in the map. Be careful when modifying.
+	ps.keyBuf.Reset()
+	ps.keyBuf.writeUvarint(uint64(def.Table))
+	ps.keyBuf.writeColSet(def.Cols)
+
+	typ := (*VirtualScanOpDef)(nil)
+	if id, ok := ps.privatesMap[privateKey{iface: typ, str: ps.keyBuf.String()}]; ok {
+		return id
+	}
+	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, def)
+}
+
 // internGroupByDef adds the given value to storage and returns an id that can
 // later be used to retrieve the value by calling the lookup method. If the
 // value has been previously added to storage, then internGroupByDef always

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -226,6 +226,9 @@ func (sb *statisticsBuilder) colStat(colSet opt.ColSet) *props.ColumnStatistic {
 	case opt.ScanOp:
 		return sb.colStatScan(colSet)
 
+	case opt.VirtualScanOp:
+		return sb.colStatVirtualScan(colSet)
+
 	case opt.SelectOp:
 		return sb.colStatSelect(colSet)
 
@@ -352,6 +355,24 @@ func (sb *statisticsBuilder) colStatScan(colSet opt.ColSet) *props.ColumnStatist
 	}
 
 	return colStat
+}
+
+// VirtualScan
+// -----------
+
+func (sb *statisticsBuilder) buildVirtualScan(def *VirtualScanOpDef) {
+	s := sb.makeTableStatistics(def.Table)
+	sb.s.RowCount = s.RowCount
+}
+
+func (sb *statisticsBuilder) colStatVirtualScan(colSet opt.ColSet) *props.ColumnStatistic {
+	def := sb.ev.Private().(*VirtualScanOpDef)
+	inputStatsBuilder := statisticsBuilder{
+		s:      sb.makeTableStatistics(def.Table),
+		props:  sb.props,
+		keyBuf: sb.keyBuf,
+	}
+	return sb.copyColStat(&inputStatsBuilder, colSet)
 }
 
 // Select

--- a/pkg/sql/opt/memo/testdata/logprops/virtual-scan
+++ b/pkg/sql/opt/memo/testdata/logprops/virtual-scan
@@ -1,0 +1,67 @@
+exec-ddl
+CREATE TABLE system.information_schema.schemata (
+	CATALOG_NAME               STRING NOT NULL,
+	SCHEMA_NAME                STRING NOT NULL,
+	DEFAULT_CHARACTER_SET_NAME STRING,
+	SQL_PATH                   STRING
+)
+----
+TABLE schemata
+ ├── catalog_name string not null
+ ├── schema_name string not null
+ ├── default_character_set_name string
+ └── sql_path string
+
+exec-ddl
+CREATE TABLE system.information_schema.tables (
+	TABLE_CATALOG      STRING NOT NULL,
+	TABLE_SCHEMA       STRING NOT NULL,
+	TABLE_NAME         STRING NOT NULL,
+	TABLE_TYPE         STRING NOT NULL,
+	IS_INSERTABLE_INTO STRING NOT NULL,
+	VERSION            INT
+)
+----
+TABLE tables
+ ├── table_catalog string not null
+ ├── table_schema string not null
+ ├── table_name string not null
+ ├── table_type string not null
+ ├── is_insertable_into string not null
+ └── version int
+
+build
+SELECT catalog_name, sql_path
+FROM (SELECT * FROM system.information_schema.schemata WHERE SCHEMA_NAME='public')
+LEFT JOIN system.information_schema.tables
+ON CATALOG_NAME=TABLE_CATALOG AND SCHEMA_NAME=TABLE_SCHEMA
+----
+project
+ ├── columns: catalog_name:1(string) sql_path:4(string)
+ ├── stats: [rows=142.857143]
+ └── left-join
+      ├── columns: catalog_name:1(string) schema_name:2(string!null) default_character_set_name:3(string) sql_path:4(string) table_catalog:5(string) table_schema:6(string) table_name:7(string) table_type:8(string) is_insertable_into:9(string) version:10(int)
+      ├── stats: [rows=142.857143]
+      ├── fd: ()-->(2)
+      ├── select
+      │    ├── columns: catalog_name:1(string) schema_name:2(string!null) default_character_set_name:3(string) sql_path:4(string)
+      │    ├── stats: [rows=1.42857143, distinct(2)=1]
+      │    ├── fd: ()-->(2)
+      │    ├── virtual-scan system.information_schema.schemata
+      │    │    ├── columns: catalog_name:1(string) schema_name:2(string) default_character_set_name:3(string) sql_path:4(string)
+      │    │    └── stats: [rows=1000, distinct(2)=700]
+      │    └── filters [type=bool, outer=(2), constraints=(/2: [/'public' - /'public']; tight), fd=()-->(2)]
+      │         └── eq [type=bool, outer=(2), constraints=(/2: [/'public' - /'public']; tight)]
+      │              ├── variable: system.information_schema.schemata.schema_name [type=string, outer=(2)]
+      │              └── const: 'public' [type=string]
+      ├── virtual-scan system.information_schema.tables
+      │    ├── columns: table_catalog:5(string) table_schema:6(string) table_name:7(string) table_type:8(string) is_insertable_into:9(string) version:10(int)
+      │    └── stats: [rows=1000]
+      └── filters [type=bool, outer=(1,2,5,6), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /5: (/NULL - ]; /6: (/NULL - ])]
+           └── and [type=bool, outer=(1,2,5,6), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /5: (/NULL - ]; /6: (/NULL - ])]
+                ├── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+                │    ├── variable: system.information_schema.schemata.catalog_name [type=string, outer=(1)]
+                │    └── variable: system.information_schema.tables.table_catalog [type=string, outer=(5)]
+                └── eq [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
+                     ├── variable: system.information_schema.schemata.schema_name [type=string, outer=(2)]
+                     └── variable: system.information_schema.tables.table_schema [type=string, outer=(6)]

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -183,7 +183,7 @@ func (md *Metadata) AddTable(tab Table) TableID {
 func (md *Metadata) AddTableWithName(tab Table, tabName string) TableID {
 	tabID := TableID(md.NumColumns() + 1)
 	if tabName == "" {
-		tabName = string(tab.TabName())
+		tabName = string(tab.TabName().TableName)
 	}
 
 	for i := 0; i < tab.ColumnCount(); i++ {

--- a/pkg/sql/opt/norm/rule_props_builder.go
+++ b/pkg/sql/opt/norm/rule_props_builder.go
@@ -94,9 +94,9 @@ func (b *rulePropsBuilder) buildProps(ev memo.ExprView) {
 	case opt.ZipOp:
 		b.buildZipProps(ev)
 
-	case opt.ExplainOp, opt.ShowTraceForSessionOp:
+	case opt.VirtualScanOp, opt.ExplainOp, opt.ShowTraceForSessionOp:
 		// Don't allow any columns to be pruned, since that would trigger the
-		// creation of a wrapper Project around the Explain (it's not capable
+		// creation of a wrapper Project around the operator (they're not capable
 		// of pruning columns or of passing through Project operators).
 
 	default:

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -21,13 +21,29 @@
 #             step in some important transformations (like eliminating
 #             subqueries).
 
-# Scan returns a result set containing every row in the specified table, by
-# scanning one of the table's indexes according to its ordering. The private
-# Def field is an *opt.ScanOpDef that identifies the table and index to scan,
-# as well as the subset of columns to project from it.
+# Scan returns a result set containing every row in a table by scanning one of
+# the table's indexes according to its ordering. The private Def field is an
+# *opt.ScanOpDef that identifies the table and index to scan, as well as the
+# subset of columns to project from it.
 [Relational]
 define Scan {
     Def ScanOpDef
+}
+
+# VirtualScan returns a result set containing every row in a virtual table.
+# Virtual tables are system tables that are populated "on the fly" with rows
+# synthesized from system metadata and other state. An example is the
+# "information_schema.tables" virtual table which returns one row for each
+# accessible system or user table.
+#
+# VirtualScan has many of the same characteristics as the Scan operator.
+# However, virtual tables do not have indexes or keys, and the physical operator
+# used to scan virtual tables does not support limits or constraints. Therefore,
+# nearly all the rules that apply to Scan do not apply to VirtualScan, so it
+# makes sense to have a separate operator.
+[Relational]
+define VirtualScan {
+    Def VirtualScanOpDef
 }
 
 # Values returns a manufactured result set containing a constant number of rows.

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -80,11 +80,6 @@ type Builder struct {
 	// pulled from an outer scope, that is, if the query was found to be correlated.
 	IsCorrelated bool
 
-	// UsingVirtualTable is set to true during semantic analysis if a
-	// FROM clause refers to a virtual table.
-	// TODO(andyk/knz): Remove when the builder supports virtual tables.
-	UsingVirtualTable bool
-
 	factory *norm.Factory
 	stmt    tree.Statement
 

--- a/pkg/sql/opt/optgen/cmd/optgen/utils.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/utils.go
@@ -62,6 +62,8 @@ func mapPrivateType(typ string) string {
 		return "*memo.ProjectionsOpDef"
 	case "ScanOpDef":
 		return "*memo.ScanOpDef"
+	case "VirtualScanOpDef":
+		return "*memo.VirtualScanOpDef"
 	case "GroupByDef":
 		return "*memo.GroupByDef"
 	case "IndexJoinDef":

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -56,6 +56,13 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 	tc.qualifyTableName(tn)
 
 	tab := &Table{Name: *tn}
+
+	// Assume that every table in the "system" catalog is a virtual table. This
+	// is a simplified assumption for testing purposes.
+	if tn.CatalogName == "system" {
+		tab.IsVirtual = true
+	}
+
 	// Add the columns.
 	for _, def := range stmt.Defs {
 		switch def := def.(type) {
@@ -81,7 +88,7 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 	}
 
 	// If there is no primary index, add the hidden rowid column.
-	if len(tab.Indexes) == 0 {
+	if len(tab.Indexes) == 0 && !tab.IsVirtual {
 		rowid := &Column{Name: "rowid", Type: types.Int, Hidden: true}
 		tab.Columns = append(tab.Columns, rowid)
 		tab.addPrimaryColumnIndex(rowid.Name)

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -165,10 +165,11 @@ func (tc *Catalog) qualifyTableName(name *tree.TableName) {
 
 // Table implements the opt.Table interface for testing purposes.
 type Table struct {
-	Name    tree.TableName
-	Columns []*Column
-	Indexes []*Index
-	Stats   TableStats
+	Name      tree.TableName
+	Columns   []*Column
+	Indexes   []*Index
+	Stats     TableStats
+	IsVirtual bool
 }
 
 var _ opt.Table = &Table{}
@@ -180,13 +181,13 @@ func (tt *Table) String() string {
 }
 
 // TabName is part of the opt.Table interface.
-func (tt *Table) TabName() opt.TableName {
-	return opt.TableName(tt.Name.TableName)
+func (tt *Table) TabName() *tree.TableName {
+	return &tt.Name
 }
 
 // IsVirtualTable is part of the opt.Table interface.
 func (tt *Table) IsVirtualTable() bool {
-	return false
+	return tt.IsVirtual
 }
 
 // ColumnCount is part of the opt.Table interface.

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -79,6 +79,9 @@ func (c *coster) ComputeCost(candidate *memo.BestExpr, logical *props.Logical) m
 	case opt.ScanOp:
 		cost = c.computeScanCost(candidate, logical)
 
+	case opt.VirtualScanOp:
+		cost = c.computeVirtualScanCost(candidate, logical)
+
 	case opt.SelectOp:
 		cost = c.computeSelectCost(candidate, logical)
 
@@ -146,6 +149,15 @@ func (c *coster) computeScanCost(candidate *memo.BestExpr, logical *props.Logica
 		perRowCost *= 2
 	}
 	return rowCount * (seqIOCostFactor + perRowCost)
+}
+
+func (c *coster) computeVirtualScanCost(
+	candidate *memo.BestExpr, logical *props.Logical,
+) memo.Cost {
+	// Virtual tables are generated on-the-fly according to system metadata that
+	// is assumed to be in memory.
+	rowCount := memo.Cost(logical.Relational.Stats.RowCount)
+	return rowCount * cpuCostFactor
 }
 
 // rowScanCost is the CPU cost to scan one row, which depends on the number of

--- a/pkg/sql/opt/xform/testdata/coster/virtual-scan
+++ b/pkg/sql/opt/xform/testdata/coster/virtual-scan
@@ -1,0 +1,28 @@
+exec-ddl
+CREATE TABLE system.information_schema.schemata (
+	CATALOG_NAME               STRING NOT NULL,
+	SCHEMA_NAME                STRING NOT NULL,
+	DEFAULT_CHARACTER_SET_NAME STRING,
+	SQL_PATH                   STRING
+)
+----
+TABLE schemata
+ ├── catalog_name string not null
+ ├── schema_name string not null
+ ├── default_character_set_name string
+ └── sql_path string
+
+opt
+SELECT * FROM system.information_schema.schemata WHERE SCHEMA_NAME='public'
+----
+select
+ ├── columns: catalog_name:1(string) schema_name:2(string!null) default_character_set_name:3(string) sql_path:4(string)
+ ├── stats: [rows=1.42857143, distinct(2)=1]
+ ├── cost: 20
+ ├── fd: ()-->(2)
+ ├── virtual-scan system.information_schema.schemata
+ │    ├── columns: catalog_name:1(string) schema_name:2(string) default_character_set_name:3(string) sql_path:4(string)
+ │    ├── stats: [rows=1000, distinct(2)=700]
+ │    └── cost: 10
+ └── filters [type=bool, outer=(2), constraints=(/2: [/'public' - /'public']; tight), fd=()-->(2)]
+      └── system.information_schema.schemata.schema_name = 'public' [type=bool, outer=(2), constraints=(/2: [/'public' - /'public']; tight)]

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -103,9 +103,7 @@ var errInvalidDbPrefix = pgerror.NewError(pgerror.CodeUndefinedObjectError,
 // valuesNode for the virtual table. We use deferred construction here
 // so as to avoid populating a RowContainer during query preparation,
 // where we can't guarantee it will be Close()d in case of error.
-func (e virtualTableEntry) getPlanInfo(
-	ctx context.Context,
-) (sqlbase.ResultColumns, virtualTableConstructor) {
+func (e virtualTableEntry) getPlanInfo() (sqlbase.ResultColumns, virtualTableConstructor) {
 	var columns sqlbase.ResultColumns
 	for _, col := range e.desc.Columns {
 		columns = append(columns, sqlbase.ResultColumn{


### PR DESCRIPTION
Virtual tables are system tables that are populated "on the fly"
with rows synthesized from system metadata and other state. An
example is the "information_schema.tables" virtual table which
returns one row for each accessible system or user table.

The commit defines a new VirtualScan operator that has many of
the same characteristics of the Scan operator. However, virtual
tables do not have indexes or keys, and the physical operator used
to scan virtual tables does not support limits or constraints.
Therefore, nearly all the rules that apply to Scan do not apply to
VirtualScan, so it makes sense to have a separate operator.

Release note: None