### PR TITLE
build: upgrade to go1.10.3

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20180709-143159
+version=20180715-164923
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -147,8 +147,8 @@ ENV PATH $PATH:/x-tools/x86_64-apple-darwin13/bin
 # releases of Go will no longer be run in CI once it is changed. Consider
 # bumping the minimum allowed version of Go in /build/go-version-chech.sh.
 RUN apt-get install -y --no-install-recommends golang \
- && curl -fsSL https://storage.googleapis.com/golang/go1.10.src.tar.gz -o golang.tar.gz \
- && echo 'f3de49289405fda5fd1483a8fe6bd2fa5469e005fd567df64485c4fa000c7f24 golang.tar.gz' | sha256sum -c - \
+ && curl -fsSL https://storage.googleapis.com/golang/go1.10.3.src.tar.gz -o golang.tar.gz \
+ && echo '567b1cc66c9704d1c019c50bef946272e911ec6baf244310f87f4e678be155f2 golang.tar.gz' | sha256sum -c - \
  && tar -C /usr/local -xzf golang.tar.gz \
  && rm golang.tar.gz \
  && cd /usr/local/go/src \


### PR DESCRIPTION
go1.10 has a bug in its test2json tool that causes test names with colons in
them to be misparsed (golang/go#23920). This was causing the nightly stress
issue poster to incorrectly post dozens of issues about tests that had not
actually failed. Upgrade the builder to go1.10.3, which includes a fix for the
test2json tool.

Fix #27498.

Release note: None