### PR TITLE
opt: add type to Tuple expression to preserve labels

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -621,7 +621,7 @@ project
  │    ├── stats: [rows=1]
  │    ├── cost: 0.01
  │    ├── key: ()
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── const: 1 [type=int]
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/tuple
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tuple
@@ -95,3 +95,17 @@ scan  ·       ·                      (a, b, c)  ·
 
 statement ok
 DROP TABLE abc
+
+statement ok
+CREATE TABLE kv (k INT PRIMARY KEY, v INT)
+
+# Regression test for #27398.
+# Check that tuple type includes labels.
+query TTTTT
+EXPLAIN (VERBOSE, TYPES) SELECT x FROM (SELECT (row(v,v,v) AS a,b,c) AS x FROM kv)
+----
+render     ·         ·                                                                                   (x tuple{int AS a, int AS b, int AS c})  ·
+ │         render 0  ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]  ·                                        ·
+ └── scan  ·         ·                                                                                   (v int)                                  ·
+·          table     kv@primary                                                                          ·                                        ·
+·          spans     ALL                                                                                 ·                                        ·

--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -502,7 +502,7 @@ func (ev ExprView) FormatScalarProps(f *opt.ExprFmtCtx, buf *bytes.Buffer) {
 
 func (ev ExprView) formatScalarPrivate(buf *bytes.Buffer, private interface{}) {
 	switch ev.op {
-	case opt.NullOp:
+	case opt.NullOp, opt.TupleOp:
 		// Private is redundant with logical type property.
 		private = nil
 

--- a/pkg/sql/opt/memo/memo_format.go
+++ b/pkg/sql/opt/memo/memo_format.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
 
@@ -351,7 +352,8 @@ func (f exprFormatter) formatPrivate(private interface{}, mode formatMode) {
 			fmt.Fprintf(f.buf, " ordering=%s", t)
 		}
 
-	case *SetOpColMap:
+	case *SetOpColMap, types.T:
+		// Don't show anything, because it's mostly redundant.
 
 	default:
 		fmt.Fprintf(f.buf, " %v", private)

--- a/pkg/sql/opt/memo/private_storage.go
+++ b/pkg/sql/opt/memo/private_storage.go
@@ -83,6 +83,9 @@ func (ps *privateStorage) lookup(id PrivateID) interface{} {
 	return ps.privates[id]
 }
 
+// EmptyTupleType represents an empty types.TTuple.
+var EmptyTupleType types.TTuple
+
 // internColumnID adds the given value to storage and returns an id that can
 // later be used to retrieve the value by calling the lookup method. If the
 // value has been previously added to storage, then internColumnID always

--- a/pkg/sql/opt/memo/testdata/logprops/groupby
+++ b/pkg/sql/opt/memo/testdata/logprops/groupby
@@ -245,5 +245,5 @@ group-by
       │    └── const: 2 [type=int]
       ├── tuple [type=tuple{int}]
       │    └── const: 1 [type=int]
-      └── tuple [type=tuple{unknown}]
+      └── tuple [type=tuple{int}]
            └── null [type=unknown]

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -620,7 +620,7 @@ select
                 │    │    ├── cardinality: [1 - 1]
                 │    │    ├── stats: [rows=1]
                 │    │    ├── key: ()
-                │    │    └── tuple [type=tuple{}]
+                │    │    └── tuple [type=tuple]
                 │    └── projections [outer=(1)]
                 │         └── variable: xysd.x [type=int, outer=(1)]
                 ├── project
@@ -634,7 +634,7 @@ select
                 │    │    ├── cardinality: [1 - 1]
                 │    │    ├── stats: [rows=1]
                 │    │    ├── key: ()
-                │    │    └── tuple [type=tuple{}]
+                │    │    └── tuple [type=tuple]
                 │    └── projections [outer=(2)]
                 │         └── variable: xysd.y [type=int, outer=(2)]
                 └── filters [type=bool, outer=(3,5)]

--- a/pkg/sql/opt/memo/testdata/logprops/limit
+++ b/pkg/sql/opt/memo/testdata/logprops/limit
@@ -95,7 +95,7 @@ limit
                 │    ├── cardinality: [1 - 1]
                 │    ├── stats: [rows=1]
                 │    ├── key: ()
-                │    └── tuple [type=tuple{}]
+                │    └── tuple [type=tuple]
                 └── projections
                      └── const: 1 [type=int]
 

--- a/pkg/sql/opt/memo/testdata/logprops/offset
+++ b/pkg/sql/opt/memo/testdata/logprops/offset
@@ -68,7 +68,7 @@ offset
                 │    ├── cardinality: [1 - 1]
                 │    ├── stats: [rows=1]
                 │    ├── key: ()
-                │    └── tuple [type=tuple{}]
+                │    └── tuple [type=tuple]
                 └── projections
                      └── const: 1 [type=int]
 

--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -121,7 +121,7 @@ select
            │                                  │    ├── cardinality: [1 - 1]
            │                                  │    ├── stats: [rows=1]
            │                                  │    ├── key: ()
-           │                                  │    └── tuple [type=tuple{}]
+           │                                  │    └── tuple [type=tuple]
            │                                  └── projections [outer=(2)]
            │                                       └── variable: xysd.y [type=int, outer=(2)]
            └── const: 5 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -162,7 +162,7 @@ select
            │              │         └── projections [outer=(2,8)]
            │              │              └── variable: xy.y [type=int, outer=(2)]
            │              └── projections [outer=(11,12)]
-           │                   └── tuple [type=tuple{int, int}, outer=(11,12)]
+           │                   └── tuple [type=tuple{int AS x, int AS u}, outer=(11,12)]
            │                        ├── variable: x [type=int, outer=(11)]
            │                        └── variable: u [type=int, outer=(12)]
            └── tuple [type=tuple{int, int}]

--- a/pkg/sql/opt/memo/testdata/logprops/values
+++ b/pkg/sql/opt/memo/testdata/logprops/values
@@ -20,7 +20,7 @@ values
  ├── tuple [type=tuple{int, int}]
  │    ├── const: 3 [type=int]
  │    └── const: 4 [type=int]
- └── tuple [type=tuple{unknown, int}]
+ └── tuple [type=tuple{int, int}]
       ├── null [type=unknown]
       └── const: 5 [type=int]
 

--- a/pkg/sql/opt/memo/testdata/stats/limit
+++ b/pkg/sql/opt/memo/testdata/stats/limit
@@ -106,7 +106,7 @@ limit
                 │    ├── cardinality: [1 - 1]
                 │    ├── stats: [rows=1]
                 │    ├── key: ()
-                │    └── tuple [type=tuple{}]
+                │    └── tuple [type=tuple]
                 └── projections
                      └── const: 5 [type=int]
 

--- a/pkg/sql/opt/memo/testdata/typing
+++ b/pkg/sql/opt/memo/testdata/typing
@@ -41,7 +41,7 @@ SELECT 1 AS a, TRUE AS b, FALSE AS c, NULL AS d
 project
  ├── columns: a:1(int!null) b:2(bool!null) c:3(bool!null) d:4(unknown)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       ├── const: 1 [type=int]
       ├── true [type=bool]
@@ -285,7 +285,7 @@ SELECT length('text')
 project
  ├── columns: length:1(int)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── length('text') [type=int]
 
@@ -296,7 +296,7 @@ SELECT div(1.0, 2.0)
 project
  ├── columns: div:1(decimal)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── div(1.0, 2.0) [type=decimal]
 
@@ -313,7 +313,7 @@ SELECT greatest(1, 2, 3, 4)
 project
  ├── columns: greatest:1(int)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── greatest(1, 2, 3, 4) [type=int]
 

--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -113,7 +113,7 @@ func init() {
 		opt.NullOp:            typeAsPrivate,
 		opt.PlaceholderOp:     typeAsTypedExpr,
 		opt.UnsupportedExprOp: typeAsTypedExpr,
-		opt.TupleOp:           typeAsTuple,
+		opt.TupleOp:           typeAsPrivate,
 		opt.ProjectionsOp:     typeAsAny,
 		opt.AggregationsOp:    typeAsAny,
 		opt.MergeOnOp:         typeAsAny,
@@ -186,17 +186,6 @@ func typeAsBool(_ ExprView) types.T {
 // typeAsFirstArg returns the type of the expression's 0th argument.
 func typeAsFirstArg(ev ExprView) types.T {
 	return ev.Child(0).Logical().Scalar.Type
-}
-
-// typeAsTuple constructs a tuple type that is composed of the types of all the
-// expression's children.
-func typeAsTuple(ev ExprView) types.T {
-	types := types.TTuple{Types: make([]types.T, ev.ChildCount())}
-	for i := 0; i < ev.ChildCount(); i++ {
-		child := ev.Child(i)
-		types.Types[i] = child.Logical().Scalar.Type
-	}
-	return types
 }
 
 // typeAsTypedExpr returns the resolved type of the private field, with the

--- a/pkg/sql/opt/norm/decorrelate.go
+++ b/pkg/sql/opt/norm/decorrelate.go
@@ -358,7 +358,9 @@ func (c *CustomFuncs) ConstructBinary(op opt.Operator, left, right memo.GroupID)
 // columns.
 func (c *CustomFuncs) constructNoColsRow() memo.GroupID {
 	lb := xfunc.MakeListBuilder(&c.CustomFuncs)
-	lb.AddItem(c.f.ConstructTuple(c.f.InternList(nil)))
+	lb.AddItem(c.f.ConstructTuple(
+		c.f.InternList(nil), c.f.InternType(memo.EmptyTupleType),
+	))
 	return c.f.ConstructValues(lb.BuildList(), c.f.InternColList(opt.ColList{}))
 }
 

--- a/pkg/sql/opt/norm/norm_test.go
+++ b/pkg/sql/opt/norm/norm_test.go
@@ -82,7 +82,7 @@ func TestRuleFoldNullInEmpty(t *testing.T) {
 	f := norm.NewFactory(&evalCtx)
 
 	null := f.ConstructNull(f.InternType(types.Unknown))
-	empty := f.ConstructTuple(memo.EmptyList)
+	empty := f.ConstructTuple(memo.EmptyList, f.InternType(memo.EmptyTupleType))
 	in := f.ConstructIn(null, empty)
 	ev := memo.MakeNormExprView(f.Memo(), in)
 	if ev.Operator() != opt.FalseOp {

--- a/pkg/sql/opt/norm/testdata/props/prune_cols
+++ b/pkg/sql/opt/norm/testdata/props/prune_cols
@@ -503,7 +503,7 @@ project
  ├── values
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── subquery [type=int]
            └── max1-row

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -58,7 +58,7 @@ project
  ├── values
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── false [type=bool]
 

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -276,7 +276,7 @@ project
  ├── values
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── true [type=bool]
 
@@ -294,7 +294,7 @@ project
  ├── values
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── false [type=bool]
 
@@ -312,7 +312,7 @@ project
  ├── values
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       ├── false [type=bool]
       └── true [type=bool]
@@ -352,7 +352,7 @@ project
  ├── values
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       ├── true [type=bool]
       └── false [type=bool]

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -2263,7 +2263,7 @@ project
  │    │              │    ├── values
  │    │              │    │    ├── cardinality: [1 - 1]
  │    │              │    │    ├── key: ()
- │    │              │    │    └── tuple [type=tuple{}]
+ │    │              │    │    └── tuple [type=tuple]
  │    │              │    └── projections [outer=(1,2)]
  │    │              │         ├── a.k + 1 [type=int, outer=(1)]
  │    │              │         └── a.i + 1 [type=int, outer=(2)]
@@ -2327,7 +2327,7 @@ project
  │    │    │    │    │    ├── values
  │    │    │    │    │    │    ├── cardinality: [1 - 1]
  │    │    │    │    │    │    ├── key: ()
- │    │    │    │    │    │    └── tuple [type=tuple{}]
+ │    │    │    │    │    │    └── tuple [type=tuple]
  │    │    │    │    │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │    │    │    │         └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
  │    │    │    │    └── aggregations [outer=(9)]
@@ -2402,7 +2402,7 @@ project
  │    │    │    │    │    ├── values
  │    │    │    │    │    │    ├── cardinality: [1 - 1]
  │    │    │    │    │    │    ├── key: ()
- │    │    │    │    │    │    └── tuple [type=tuple{}]
+ │    │    │    │    │    │    └── tuple [type=tuple]
  │    │    │    │    │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │    │    │    │         └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
  │    │    │    │    └── aggregations [outer=(9)]

--- a/pkg/sql/opt/norm/testdata/rules/max1row
+++ b/pkg/sql/opt/norm/testdata/rules/max1row
@@ -33,7 +33,7 @@ project
  ├── values
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── gt [type=bool]
            ├── subquery [type=int]
@@ -55,7 +55,7 @@ project
  ├── values
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── gt [type=bool]
            ├── subquery [type=int]
@@ -80,7 +80,7 @@ project
  ├── values
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── gt [type=bool]
            ├── subquery [type=int]
@@ -106,7 +106,7 @@ project
  ├── values
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── gt [type=bool]
            ├── subquery [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/numeric
+++ b/pkg/sql/opt/norm/testdata/rules/numeric
@@ -145,7 +145,7 @@ project
  ├── values
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── const: -1 [type=int]
 
@@ -160,7 +160,7 @@ project
  ├── values
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── const: -1.0 [type=float]
 
@@ -182,7 +182,7 @@ project
  │    ├── stats: [rows=1]
  │    ├── cost: 0.01
  │    ├── key: ()
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── unary-minus [type=int]
            └── const: -9223372036854775808 [type=int]
@@ -203,7 +203,7 @@ project
  │    ├── stats: [rows=1]
  │    ├── cost: 0.01
  │    ├── key: ()
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── const: -1 [type=decimal]
 
@@ -223,7 +223,7 @@ project
  │    ├── stats: [rows=1]
  │    ├── cost: 0.01
  │    ├── key: ()
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── const: '1d' [type=interval]
 
@@ -240,6 +240,6 @@ project
  ├── values
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── const: '-9223372036854775808d' [type=interval]

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -179,6 +179,6 @@ project
            ├── values
            │    ├── cardinality: [1 - 1]
            │    ├── key: ()
-           │    └── tuple [type=tuple{}]
+           │    └── tuple [type=tuple]
            └── projections
                 └── const: 123 [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -206,7 +206,7 @@ project
  ├── values
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       ├── null [type=int]
       ├── null [type=timestamptz]

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -113,6 +113,7 @@ define Placeholder {
 [Scalar]
 define Tuple {
     Elems ExprList
+    Typ   Type
 }
 
 # Projections is a set of typed scalar expressions that will become output

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -288,7 +288,7 @@ func (b *Builder) buildScalarHelper(
 		for i := range t.D {
 			list[i] = b.buildScalarHelper(t.D[i], "", inScope, nil)
 		}
-		out = b.factory.ConstructTuple(b.factory.InternList(list))
+		out = b.factory.ConstructTuple(b.factory.InternList(list), b.factory.InternType(t.ResolvedType()))
 
 	case *tree.FuncExpr:
 		return b.buildFunction(t, label, inScope, outScope)
@@ -339,7 +339,7 @@ func (b *Builder) buildScalarHelper(
 		for i := range t.Exprs {
 			list[i] = b.buildScalarHelper(t.Exprs[i].(tree.TypedExpr), "", inScope, nil)
 		}
-		out = b.factory.ConstructTuple(b.factory.InternList(list))
+		out = b.factory.ConstructTuple(b.factory.InternList(list), b.factory.InternType(t.ResolvedType()))
 
 	case *tree.UnaryExpr:
 		out = b.buildScalarHelper(t.TypedInnerExpr(), "", inScope, nil)

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -337,7 +337,9 @@ func (b *Builder) buildFrom(from *tree.From, where *tree.Where, inScope *scope) 
 	if outScope == nil {
 		// TODO(peter): This should be a table with 1 row and 0 columns to match
 		// current cockroach behavior.
-		rows := []memo.GroupID{b.factory.ConstructTuple(b.factory.InternList(nil))}
+		rows := []memo.GroupID{b.factory.ConstructTuple(
+			b.factory.InternList(nil), b.factory.InternType(memo.EmptyTupleType),
+		)}
 		outScope = inScope.push()
 		outScope.group = b.factory.ConstructValues(
 			b.factory.InternList(rows),

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -200,7 +200,7 @@ func (b *Builder) buildSubqueryProjection(
 		}
 
 		texpr := tree.NewTypedTuple(typ, cols)
-		tup := b.factory.ConstructTuple(b.factory.InternList(colGroups))
+		tup := b.factory.ConstructTuple(b.factory.InternList(colGroups), b.factory.InternType(typ))
 		col := b.synthesizeColumn(outScope, "", texpr.ResolvedType(), texpr, tup)
 		out = b.constructProject(out, []scopeColumn{*col})
 	}

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -105,7 +105,7 @@ project
  │    ├── project
  │    │    ├── columns: column1:1(int!null) column12:12(bool!null) column15:15(bytes!null)
  │    │    ├── values
- │    │    │    └── tuple [type=tuple{}]
+ │    │    │    └── tuple [type=tuple]
  │    │    └── projections
  │    │         ├── const: 1 [type=int]
  │    │         ├── true [type=bool]
@@ -177,7 +177,7 @@ group-by
  ├── project
  │    ├── columns: column1:1(int!null)
  │    ├── values
- │    │    └── tuple [type=tuple{}]
+ │    │    └── tuple [type=tuple]
  │    └── projections
  │         └── const: 1 [type=int]
  └── aggregations
@@ -231,7 +231,7 @@ group-by
  ├── project
  │    ├── columns: column1:1(string)
  │    ├── values
- │    │    └── tuple [type=tuple{}]
+ │    │    └── tuple [type=tuple]
  │    └── projections
  │         └── cast: TEXT [type=string]
  │              └── null [type=unknown]
@@ -245,7 +245,7 @@ SELECT (SELECT COALESCE(max(1), 0) FROM kv)
 project
  ├── columns: coalesce:8(int)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── subquery [type=int]
            └── max1-row
@@ -595,7 +595,7 @@ SELECT count(*)
 group-by
  ├── columns: count:1(int)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── aggregations
       └── count-rows [type=int]
 
@@ -620,7 +620,7 @@ group-by
  ├── project
  │    ├── columns: column1:1(int!null)
  │    ├── values
- │    │    └── tuple [type=tuple{}]
+ │    │    └── tuple [type=tuple]
  │    └── projections
  │         └── const: 1 [type=int]
  └── aggregations
@@ -781,7 +781,7 @@ group-by
  │    ├── scan kv
  │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
  │    └── projections
- │         └── tuple [type=tuple{int, int, int, string}]
+ │         └── tuple [type=tuple{int AS k, int AS v, int AS w, string AS s}]
  │              ├── variable: kv.k [type=int]
  │              ├── variable: kv.v [type=int]
  │              ├── variable: kv.w [type=int]
@@ -859,7 +859,7 @@ group-by
  ├── project
  │    ├── columns: column1:1(int) column3:3(tuple{unknown, unknown})
  │    ├── values
- │    │    └── tuple [type=tuple{}]
+ │    │    └── tuple [type=tuple]
  │    └── projections
  │         ├── cast: INT [type=int]
  │         │    └── null [type=unknown]
@@ -1474,7 +1474,7 @@ project
  │    ├── project
  │    │    ├── columns: column1:1(int) column4:4(float) column7:7(decimal)
  │    │    ├── values
- │    │    │    └── tuple [type=tuple{}]
+ │    │    │    └── tuple [type=tuple]
  │    │    └── projections
  │    │         ├── cast: INT [type=int]
  │    │         │    └── const: 1 [type=int]
@@ -1505,7 +1505,7 @@ group-by
  ├── project
  │    ├── columns: column1:1(int) column3:3(float) column5:5(decimal)
  │    ├── values
- │    │    └── tuple [type=tuple{}]
+ │    │    └── tuple [type=tuple]
  │    └── projections
  │         ├── cast: INT [type=int]
  │         │    └── const: 2 [type=int]
@@ -1529,7 +1529,7 @@ group-by
  ├── project
  │    ├── columns: column1:1(int) column3:3(float) column5:5(decimal)
  │    ├── values
- │    │    └── tuple [type=tuple{}]
+ │    │    └── tuple [type=tuple]
  │    └── projections
  │         ├── cast: INT [type=int]
  │         │    └── const: 1 [type=int]
@@ -1553,7 +1553,7 @@ group-by
  ├── project
  │    ├── columns: column1:1(int) column3:3(float) column5:5(decimal)
  │    ├── values
- │    │    └── tuple [type=tuple{}]
+ │    │    └── tuple [type=tuple]
  │    └── projections
  │         ├── cast: INT [type=int]
  │         │    └── const: 1 [type=int]
@@ -1577,7 +1577,7 @@ group-by
  ├── project
  │    ├── columns: column1:1(int) column3:3(float) column5:5(decimal)
  │    ├── values
- │    │    └── tuple [type=tuple{}]
+ │    │    └── tuple [type=tuple]
  │    └── projections
  │         ├── cast: INT [type=int]
  │         │    └── const: 1 [type=int]
@@ -1614,7 +1614,7 @@ limit
  │                             ├── project
  │                             │    ├── columns: column4:4(int!null)
  │                             │    ├── values
- │                             │    │    └── tuple [type=tuple{}]
+ │                             │    │    └── tuple [type=tuple]
  │                             │    └── projections
  │                             │         └── const: 0 [type=int]
  │                             └── aggregations
@@ -1767,7 +1767,7 @@ group-by
  ├── project
  │    ├── columns: column1:1(bool!null)
  │    ├── values
- │    │    └── tuple [type=tuple{}]
+ │    │    └── tuple [type=tuple]
  │    └── projections
  │         └── true [type=bool]
  └── aggregations

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -285,7 +285,7 @@ group-by
  └── project
       ├── columns: r:1(int!null)
       ├── values
-      │    └── tuple [type=tuple{}]
+      │    └── tuple [type=tuple]
       └── projections
            └── const: 3 [type=int]
 

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -45,7 +45,7 @@ project
       │    ├── project
       │    │    ├── columns: x:1(int!null)
       │    │    ├── values
-      │    │    │    └── tuple [type=tuple{}]
+      │    │    │    └── tuple [type=tuple]
       │    │    └── projections
       │    │         └── const: 1 [type=int]
       │    ├── scan onecolumn
@@ -3074,7 +3074,7 @@ project
       ├── project
       │    ├── columns: k:5(int!null)
       │    ├── values
-      │    │    └── tuple [type=tuple{}]
+      │    │    └── tuple [type=tuple]
       │    └── projections
       │         └── const: 1 [type=int]
       └── true [type=bool]
@@ -3089,13 +3089,13 @@ select
  │    ├── project
  │    │    ├── columns: k:1(int!null)
  │    │    ├── values
- │    │    │    └── tuple [type=tuple{}]
+ │    │    │    └── tuple [type=tuple]
  │    │    └── projections
  │    │         └── const: 1 [type=int]
  │    ├── project
  │    │    ├── columns: k:2(int!null)
  │    │    ├── values
- │    │    │    └── tuple [type=tuple{}]
+ │    │    │    └── tuple [type=tuple]
  │    │    └── projections
  │    │         └── const: 2 [type=int]
  │    └── true [type=bool]

--- a/pkg/sql/opt/optbuilder/testdata/project
+++ b/pkg/sql/opt/optbuilder/testdata/project
@@ -23,7 +23,7 @@ SELECT 5 r
 project
  ├── columns: r:1(int!null)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── const: 5 [type=int]
 
@@ -265,3 +265,17 @@ project
  ├── columns: k:1(int!null)
  └── scan kv
       └── columns: t.public.kv.k:1(int!null) t.public.kv.v:2(int)
+
+# Check that tuple type includes labels.
+build
+SELECT x FROM (SELECT (row(v,v,v) AS a,b,c) AS x FROM kv)
+----
+project
+ ├── columns: x:3(tuple{int AS a, int AS b, int AS c})
+ ├── scan kv
+ │    └── columns: k:1(int!null) v:2(int)
+ └── projections
+      └── tuple [type=tuple{int AS a, int AS b, int AS c}]
+           ├── variable: kv.v [type=int]
+           ├── variable: kv.v [type=int]
+           └── variable: kv.v [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -591,7 +591,7 @@ build-scalar vars=(int[])
 ----
 eq [type=bool]
  ├── variable: @1 [type=int[]]
- └── array: int[] [type=int[]]
+ └── array: [type=int[]]
       ├── const: 1 [type=int]
       ├── const: 2 [type=int]
       └── const: 3 [type=int]
@@ -601,7 +601,7 @@ build-scalar vars=(int[])
 ----
 eq [type=bool]
  ├── variable: @1 [type=int[]]
- └── array: int[] [type=int[]]
+ └── array: [type=int[]]
       ├── const: 1 [type=int]
       ├── const: 1 [type=int]
       └── const: 1 [type=int]
@@ -611,7 +611,7 @@ build-scalar vars=(float[])
 ----
 eq [type=bool]
  ├── variable: @1 [type=float[]]
- └── array: float[] [type=float[]]
+ └── array: [type=float[]]
       ├── const: 1.0 [type=float]
       ├── const: 1.1 [type=float]
       └── const: 1.123 [type=float]
@@ -621,14 +621,14 @@ build-scalar vars=(int[])
 ----
 eq [type=bool]
  ├── variable: @1 [type=int[]]
- └── array: int[] [type=int[]]
+ └── array: [type=int[]]
 
 build-scalar vars=(string[])
 @1 = ARRAY['foo', 'bar', 'baz']
 ----
 eq [type=bool]
  ├── variable: @1 [type=string[]]
- └── array: string[] [type=string[]]
+ └── array: [type=string[]]
       ├── const: 'foo' [type=string]
       ├── const: 'bar' [type=string]
       └── const: 'baz' [type=string]
@@ -693,7 +693,7 @@ build-scalar
 ARRAY[1, 2] || NULL
 ----
 concat [type=int[]]
- ├── array: int[] [type=int[]]
+ ├── array: [type=int[]]
  │    ├── const: 1 [type=int]
  │    └── const: 2 [type=int]
  └── cast: INT[] [type=int[]]
@@ -705,7 +705,7 @@ NULL || ARRAY[1, 2]
 concat [type=int[]]
  ├── cast: INT[] [type=int[]]
  │    └── null [type=unknown]
- └── array: int[] [type=int[]]
+ └── array: [type=int[]]
       ├── const: 1 [type=int]
       └── const: 2 [type=int]
 
@@ -713,7 +713,7 @@ build-scalar
 ARRAY[1, 2] || NULL::smallint
 ----
 concat [type=int[]]
- ├── array: int[] [type=int[]]
+ ├── array: [type=int[]]
  │    ├── const: 1 [type=int]
  │    └── const: 2 [type=int]
  └── cast: SMALLINT [type=int]
@@ -725,7 +725,7 @@ NULL::oid || ARRAY[1, 2]
 concat [type=oid[]]
  ├── cast: OID [type=oid]
  │    └── null [type=unknown]
- └── array: oid[] [type=oid[]]
+ └── array: [type=oid[]]
       ├── const: 1 [type=oid]
       └── const: 2 [type=oid]
 
@@ -745,7 +745,7 @@ SELECT -((-9223372036854775808):::int)
 project
  ├── columns: "?column?":1(int)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── unary-minus [type=int]
            └── const: -9223372036854775808 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -8,7 +8,7 @@ SELECT 1
 project
  ├── columns: "?column?":1(int!null)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── const: 1 [type=int]
 
@@ -18,7 +18,7 @@ SELECT NULL
 project
  ├── columns: "?column?":1(unknown)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── null [type=unknown]
 
@@ -28,7 +28,7 @@ SELECT 1+1 AS two, 2+2 AS four
 project
  ├── columns: two:1(int!null) four:2(int!null)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       ├── const: 2 [type=int]
       └── const: 4 [type=int]
@@ -227,7 +227,7 @@ project
  ├── scan kv
  │    └── columns: k:1(string!null) v:2(string)
  └── projections
-      └── tuple [type=tuple{string, string}]
+      └── tuple [type=tuple{string AS k, string AS v}]
            ├── variable: kv.k [type=string]
            └── variable: kv.v [type=string]
 
@@ -550,7 +550,7 @@ SELECT CASE WHEN NULL THEN 1 ELSE 2 END
 project
  ├── columns: case:1(int)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── case [type=int]
            ├── true [type=bool]
@@ -584,7 +584,7 @@ SELECT 1 IN (1, 2) AS r
 project
  ├── columns: r:1(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── in [type=bool]
            ├── const: 1 [type=int]
@@ -598,7 +598,7 @@ SELECT NULL IN (1, 2) AS r
 project
  ├── columns: r:1(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── in [type=bool]
            ├── null [type=unknown]
@@ -612,11 +612,11 @@ SELECT 1 IN (NULL, 2) AS r
 project
  ├── columns: r:1(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── in [type=bool]
            ├── const: 1 [type=int]
-           └── tuple [type=tuple{unknown, int}]
+           └── tuple [type=tuple{int, int}]
                 ├── null [type=unknown]
                 └── const: 2 [type=int]
 
@@ -626,10 +626,10 @@ SELECT (1, NULL) IN ((1, 1)) AS r
 project
  ├── columns: r:1(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── in [type=bool]
-           ├── tuple [type=tuple{int, unknown}]
+           ├── tuple [type=tuple{int, int}]
            │    ├── const: 1 [type=int]
            │    └── null [type=unknown]
            └── tuple [type=tuple{tuple{int, int}}]
@@ -644,7 +644,7 @@ build
 project
  ├── columns: r:2(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── values
@@ -660,7 +660,7 @@ SELECT (1, NULL::int) IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b)) AS r
 project
  ├── columns: r:4(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── project
@@ -671,7 +671,7 @@ project
            │    │         ├── const: 1 [type=int]
            │    │         └── const: 1 [type=int]
            │    └── projections
-           │         └── tuple [type=tuple{int, int}]
+           │         └── tuple [type=tuple{int AS a, int AS b}]
            │              ├── variable: column1 [type=int]
            │              └── variable: column2 [type=int]
            └── tuple [type=tuple{int, int}]
@@ -685,7 +685,7 @@ SELECT NULL::int NOT IN (SELECT * FROM (VALUES (1)) AS t(a)) AS r
 project
  ├── columns: r:2(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── not [type=bool]
            └── any: eq [type=bool]
@@ -702,7 +702,7 @@ SELECT (1, NULL::int) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b)) AS r
 project
  ├── columns: r:4(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── not [type=bool]
            └── any: eq [type=bool]
@@ -714,7 +714,7 @@ project
                 │    │         ├── const: 1 [type=int]
                 │    │         └── const: 1 [type=int]
                 │    └── projections
-                │         └── tuple [type=tuple{int, int}]
+                │         └── tuple [type=tuple{int AS a, int AS b}]
                 │              ├── variable: column1 [type=int]
                 │              └── variable: column2 [type=int]
                 └── tuple [type=tuple{int, int}]
@@ -729,7 +729,7 @@ SELECT NULL::int IN (SELECT * FROM (VALUES (1)) AS t(a) WHERE a > 1) AS r
 project
  ├── columns: r:2(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── select
@@ -751,7 +751,7 @@ SELECT (1, NULL::int) IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b) WHERE a > 1) 
 project
  ├── columns: r:4(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── project
@@ -768,7 +768,7 @@ project
            │    │              ├── variable: column1 [type=int]
            │    │              └── const: 1 [type=int]
            │    └── projections
-           │         └── tuple [type=tuple{int, int}]
+           │         └── tuple [type=tuple{int AS a, int AS b}]
            │              ├── variable: column1 [type=int]
            │              └── variable: column2 [type=int]
            └── tuple [type=tuple{int, int}]
@@ -782,7 +782,7 @@ SELECT NULL::int NOT IN (SELECT * FROM (VALUES (1)) AS t(a) WHERE a > 1) AS r
 project
  ├── columns: r:2(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── not [type=bool]
            └── any: eq [type=bool]
@@ -805,7 +805,7 @@ SELECT (1, NULL::int) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b) WHERE a >
 project
  ├── columns: r:4(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── not [type=bool]
            └── any: eq [type=bool]
@@ -823,7 +823,7 @@ project
                 │    │              ├── variable: column1 [type=int]
                 │    │              └── const: 1 [type=int]
                 │    └── projections
-                │         └── tuple [type=tuple{int, int}]
+                │         └── tuple [type=tuple{int AS a, int AS b}]
                 │              ├── variable: column1 [type=int]
                 │              └── variable: column2 [type=int]
                 └── tuple [type=tuple{int, int}]
@@ -837,7 +837,7 @@ SELECT NULL::int NOT IN (SELECT * FROM (VALUES (1)) AS t(a) WHERE a > 1) AS r
 project
  ├── columns: r:2(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── not [type=bool]
            └── any: eq [type=bool]
@@ -860,7 +860,7 @@ SELECT (1, NULL::int) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b) WHERE a >
 project
  ├── columns: r:4(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── not [type=bool]
            └── any: eq [type=bool]
@@ -878,7 +878,7 @@ project
                 │    │              ├── variable: column1 [type=int]
                 │    │              └── const: 1 [type=int]
                 │    └── projections
-                │         └── tuple [type=tuple{int, int}]
+                │         └── tuple [type=tuple{int AS a, int AS b}]
                 │              ├── variable: column1 [type=int]
                 │              └── variable: column2 [type=int]
                 └── tuple [type=tuple{int, int}]
@@ -892,7 +892,7 @@ SELECT NULL::int NOT IN (SELECT * FROM (VALUES (1)) AS t(a) WHERE a > 1) AS r
 project
  ├── columns: r:2(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── not [type=bool]
            └── any: eq [type=bool]
@@ -915,7 +915,7 @@ SELECT (1, NULL::int) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b) WHERE a >
 project
  ├── columns: r:4(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── not [type=bool]
            └── any: eq [type=bool]
@@ -933,7 +933,7 @@ project
                 │    │              ├── variable: column1 [type=int]
                 │    │              └── const: 1 [type=int]
                 │    └── projections
-                │         └── tuple [type=tuple{int, int}]
+                │         └── tuple [type=tuple{int AS a, int AS b}]
                 │              ├── variable: column1 [type=int]
                 │              └── variable: column2 [type=int]
                 └── tuple [type=tuple{int, int}]

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -8,7 +8,7 @@ SELECT (SELECT 1 a) AS r
 project
  ├── columns: r:2(int)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── subquery [type=int]
            └── max1-row
@@ -16,7 +16,7 @@ project
                 └── project
                      ├── columns: a:1(int!null)
                      ├── values
-                     │    └── tuple [type=tuple{}]
+                     │    └── tuple [type=tuple]
                      └── projections
                           └── const: 1 [type=int]
 
@@ -26,13 +26,13 @@ SELECT 1 IN (SELECT 1 a) AS r
 project
  ├── columns: r:2(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── project
            │    ├── columns: a:1(int!null)
            │    ├── values
-           │    │    └── tuple [type=tuple{}]
+           │    │    └── tuple [type=tuple]
            │    └── projections
            │         └── const: 1 [type=int]
            └── const: 1 [type=int]
@@ -43,13 +43,13 @@ SELECT 1 IN ((((SELECT 1 a)))) AS r
 project
  ├── columns: r:2(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── project
            │    ├── columns: a:1(int!null)
            │    ├── values
-           │    │    └── tuple [type=tuple{}]
+           │    │    └── tuple [type=tuple]
            │    └── projections
            │         └── const: 1 [type=int]
            └── const: 1 [type=int]
@@ -65,7 +65,7 @@ SELECT 1 + (SELECT 1 a) AS r
 project
  ├── columns: r:2(int)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── plus [type=int]
            ├── const: 1 [type=int]
@@ -75,7 +75,7 @@ project
                      └── project
                           ├── columns: a:1(int!null)
                           ├── values
-                          │    └── tuple [type=tuple{}]
+                          │    └── tuple [type=tuple]
                           └── projections
                                └── const: 1 [type=int]
 
@@ -90,7 +90,7 @@ SELECT (1, 2, 3) IN (SELECT 1 AS a, 2 AS b, 3 AS c) AS r
 project
  ├── columns: r:5(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── project
@@ -98,13 +98,13 @@ project
            │    ├── project
            │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
            │    │    ├── values
-           │    │    │    └── tuple [type=tuple{}]
+           │    │    │    └── tuple [type=tuple]
            │    │    └── projections
            │    │         ├── const: 1 [type=int]
            │    │         ├── const: 2 [type=int]
            │    │         └── const: 3 [type=int]
            │    └── projections
-           │         └── tuple [type=tuple{int, int, int}]
+           │         └── tuple [type=tuple{int AS a, int AS b, int AS c}]
            │              ├── variable: a [type=int]
            │              ├── variable: b [type=int]
            │              └── variable: c [type=int]
@@ -119,7 +119,7 @@ SELECT (1, 2, 3) = (SELECT 1 AS a, 2 AS b, 3 AS c) AS r
 project
  ├── columns: r:5(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── eq [type=bool]
            ├── tuple [type=tuple{int, int, int}]
@@ -134,13 +134,13 @@ project
                           ├── project
                           │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
                           │    ├── values
-                          │    │    └── tuple [type=tuple{}]
+                          │    │    └── tuple [type=tuple]
                           │    └── projections
                           │         ├── const: 1 [type=int]
                           │         ├── const: 2 [type=int]
                           │         └── const: 3 [type=int]
                           └── projections
-                               └── tuple [type=tuple{int, int, int}]
+                               └── tuple [type=tuple{int AS a, int AS b, int AS c}]
                                     ├── variable: a [type=int]
                                     ├── variable: b [type=int]
                                     └── variable: c [type=int]
@@ -151,7 +151,7 @@ SELECT (1, 2, 3) != (SELECT 1 AS a, 2 AS b, 3 AS c) AS r
 project
  ├── columns: r:5(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── ne [type=bool]
            ├── tuple [type=tuple{int, int, int}]
@@ -166,13 +166,13 @@ project
                           ├── project
                           │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
                           │    ├── values
-                          │    │    └── tuple [type=tuple{}]
+                          │    │    └── tuple [type=tuple]
                           │    └── projections
                           │         ├── const: 1 [type=int]
                           │         ├── const: 2 [type=int]
                           │         └── const: 3 [type=int]
                           └── projections
-                               └── tuple [type=tuple{int, int, int}]
+                               └── tuple [type=tuple{int AS a, int AS b, int AS c}]
                                     ├── variable: a [type=int]
                                     ├── variable: b [type=int]
                                     └── variable: c [type=int]
@@ -183,7 +183,7 @@ SELECT (SELECT 1 AS x, 2 AS y, 3 AS z) = (SELECT 1 AS a, 2 AS b, 3 AS c) AS r
 project
  ├── columns: r:9(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── eq [type=bool]
            ├── subquery [type=tuple{int AS x, int AS y, int AS z}]
@@ -194,13 +194,13 @@ project
            │              ├── project
            │              │    ├── columns: x:1(int!null) y:2(int!null) z:3(int!null)
            │              │    ├── values
-           │              │    │    └── tuple [type=tuple{}]
+           │              │    │    └── tuple [type=tuple]
            │              │    └── projections
            │              │         ├── const: 1 [type=int]
            │              │         ├── const: 2 [type=int]
            │              │         └── const: 3 [type=int]
            │              └── projections
-           │                   └── tuple [type=tuple{int, int, int}]
+           │                   └── tuple [type=tuple{int AS x, int AS y, int AS z}]
            │                        ├── variable: x [type=int]
            │                        ├── variable: y [type=int]
            │                        └── variable: z [type=int]
@@ -212,13 +212,13 @@ project
                           ├── project
                           │    ├── columns: a:4(int!null) b:5(int!null) c:6(int!null)
                           │    ├── values
-                          │    │    └── tuple [type=tuple{}]
+                          │    │    └── tuple [type=tuple]
                           │    └── projections
                           │         ├── const: 1 [type=int]
                           │         ├── const: 2 [type=int]
                           │         └── const: 3 [type=int]
                           └── projections
-                               └── tuple [type=tuple{int, int, int}]
+                               └── tuple [type=tuple{int AS a, int AS b, int AS c}]
                                     ├── variable: a [type=int]
                                     ├── variable: b [type=int]
                                     └── variable: c [type=int]
@@ -229,13 +229,13 @@ SELECT (SELECT 1 x) IN (SELECT 1 y) AS z
 project
  ├── columns: z:3(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── project
            │    ├── columns: y:1(int!null)
            │    ├── values
-           │    │    └── tuple [type=tuple{}]
+           │    │    └── tuple [type=tuple]
            │    └── projections
            │         └── const: 1 [type=int]
            └── subquery [type=int]
@@ -244,7 +244,7 @@ project
                      └── project
                           ├── columns: x:2(int!null)
                           ├── values
-                          │    └── tuple [type=tuple{}]
+                          │    └── tuple [type=tuple]
                           └── projections
                                └── const: 1 [type=int]
 
@@ -254,7 +254,7 @@ SELECT (SELECT 1 a) IN (1) AS r
 project
  ├── columns: r:2(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── in [type=bool]
            ├── subquery [type=int]
@@ -263,7 +263,7 @@ project
            │         └── project
            │              ├── columns: a:1(int!null)
            │              ├── values
-           │              │    └── tuple [type=tuple{}]
+           │              │    └── tuple [type=tuple]
            │              └── projections
            │                   └── const: 1 [type=int]
            └── tuple [type=tuple{int}]
@@ -285,7 +285,7 @@ SELECT (SELECT 1 AS a, 2 AS b) IN (SELECT 1 AS c, 2 AS d) AS r
 project
  ├── columns: r:7(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── project
@@ -293,12 +293,12 @@ project
            │    ├── project
            │    │    ├── columns: c:1(int!null) d:2(int!null)
            │    │    ├── values
-           │    │    │    └── tuple [type=tuple{}]
+           │    │    │    └── tuple [type=tuple]
            │    │    └── projections
            │    │         ├── const: 1 [type=int]
            │    │         └── const: 2 [type=int]
            │    └── projections
-           │         └── tuple [type=tuple{int, int}]
+           │         └── tuple [type=tuple{int AS c, int AS d}]
            │              ├── variable: c [type=int]
            │              └── variable: d [type=int]
            └── subquery [type=tuple{int AS a, int AS b}]
@@ -309,12 +309,12 @@ project
                           ├── project
                           │    ├── columns: a:3(int!null) b:4(int!null)
                           │    ├── values
-                          │    │    └── tuple [type=tuple{}]
+                          │    │    └── tuple [type=tuple]
                           │    └── projections
                           │         ├── const: 1 [type=int]
                           │         └── const: 2 [type=int]
                           └── projections
-                               └── tuple [type=tuple{int, int}]
+                               └── tuple [type=tuple{int AS a, int AS b}]
                                     ├── variable: a [type=int]
                                     └── variable: b [type=int]
 
@@ -328,7 +328,7 @@ SELECT (SELECT 1 AS a, 2 AS b) IN ((1, 2)) AS r
 project
  ├── columns: r:4(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── in [type=bool]
            ├── subquery [type=tuple{int AS a, int AS b}]
@@ -339,15 +339,15 @@ project
            │              ├── project
            │              │    ├── columns: a:1(int!null) b:2(int!null)
            │              │    ├── values
-           │              │    │    └── tuple [type=tuple{}]
+           │              │    │    └── tuple [type=tuple]
            │              │    └── projections
            │              │         ├── const: 1 [type=int]
            │              │         └── const: 2 [type=int]
            │              └── projections
-           │                   └── tuple [type=tuple{int, int}]
+           │                   └── tuple [type=tuple{int AS a, int AS b}]
            │                        ├── variable: a [type=int]
            │                        └── variable: b [type=int]
-           └── tuple [type=tuple{tuple{int, int}}]
+           └── tuple [type=tuple{tuple{int AS a, int AS b}}]
                 └── tuple [type=tuple{int, int}]
                      ├── const: 1 [type=int]
                      └── const: 2 [type=int]
@@ -362,7 +362,7 @@ SELECT (SELECT (1, 2) AS a) IN (SELECT 1 AS b, 2 AS c) AS r
 project
  ├── columns: r:5(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── project
@@ -370,12 +370,12 @@ project
            │    ├── project
            │    │    ├── columns: b:1(int!null) c:2(int!null)
            │    │    ├── values
-           │    │    │    └── tuple [type=tuple{}]
+           │    │    │    └── tuple [type=tuple]
            │    │    └── projections
            │    │         ├── const: 1 [type=int]
            │    │         └── const: 2 [type=int]
            │    └── projections
-           │         └── tuple [type=tuple{int, int}]
+           │         └── tuple [type=tuple{int AS b, int AS c}]
            │              ├── variable: b [type=int]
            │              └── variable: c [type=int]
            └── subquery [type=tuple{int, int}]
@@ -384,7 +384,7 @@ project
                      └── project
                           ├── columns: a:3(tuple{int, int})
                           ├── values
-                          │    └── tuple [type=tuple{}]
+                          │    └── tuple [type=tuple]
                           └── projections
                                └── tuple [type=tuple{int, int}]
                                     ├── const: 1 [type=int]
@@ -396,7 +396,7 @@ SELECT (SELECT (1, 2) a) IN ((1, 2)) AS r
 project
  ├── columns: r:2(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── in [type=bool]
            ├── subquery [type=tuple{int, int}]
@@ -405,7 +405,7 @@ project
            │         └── project
            │              ├── columns: a:1(tuple{int, int})
            │              ├── values
-           │              │    └── tuple [type=tuple{}]
+           │              │    └── tuple [type=tuple]
            │              └── projections
            │                   └── tuple [type=tuple{int, int}]
            │                        ├── const: 1 [type=int]
@@ -425,13 +425,13 @@ SELECT (SELECT 1 AS a, 2 AS b) IN (SELECT (1, 2) AS c) AS r
 project
  ├── columns: r:5(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── project
            │    ├── columns: c:1(tuple{int, int})
            │    ├── values
-           │    │    └── tuple [type=tuple{}]
+           │    │    └── tuple [type=tuple]
            │    └── projections
            │         └── tuple [type=tuple{int, int}]
            │              ├── const: 1 [type=int]
@@ -444,12 +444,12 @@ project
                           ├── project
                           │    ├── columns: a:2(int!null) b:3(int!null)
                           │    ├── values
-                          │    │    └── tuple [type=tuple{}]
+                          │    │    └── tuple [type=tuple]
                           │    └── projections
                           │         ├── const: 1 [type=int]
                           │         └── const: 2 [type=int]
                           └── projections
-                               └── tuple [type=tuple{int, int}]
+                               └── tuple [type=tuple{int AS a, int AS b}]
                                     ├── variable: a [type=int]
                                     └── variable: b [type=int]
 
@@ -459,13 +459,13 @@ SELECT (SELECT (1, 2) a) IN (SELECT (1, 2) b) AS r
 project
  ├── columns: r:3(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── project
            │    ├── columns: b:1(tuple{int, int})
            │    ├── values
-           │    │    └── tuple [type=tuple{}]
+           │    │    └── tuple [type=tuple]
            │    └── projections
            │         └── tuple [type=tuple{int, int}]
            │              ├── const: 1 [type=int]
@@ -476,7 +476,7 @@ project
                      └── project
                           ├── columns: a:2(tuple{int, int})
                           ├── values
-                          │    └── tuple [type=tuple{}]
+                          │    └── tuple [type=tuple]
                           └── projections
                                └── tuple [type=tuple{int, int}]
                                     ├── const: 1 [type=int]
@@ -488,13 +488,13 @@ SELECT 1 = ANY(SELECT 1 a) AS r
 project
  ├── columns: r:2(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── project
            │    ├── columns: a:1(int!null)
            │    ├── values
-           │    │    └── tuple [type=tuple{}]
+           │    │    └── tuple [type=tuple]
            │    └── projections
            │         └── const: 1 [type=int]
            └── const: 1 [type=int]
@@ -505,7 +505,7 @@ SELECT (1, 2) = ANY(SELECT 1 AS a, 2 AS b) AS r
 project
  ├── columns: r:4(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── project
@@ -513,12 +513,12 @@ project
            │    ├── project
            │    │    ├── columns: a:1(int!null) b:2(int!null)
            │    │    ├── values
-           │    │    │    └── tuple [type=tuple{}]
+           │    │    │    └── tuple [type=tuple]
            │    │    └── projections
            │    │         ├── const: 1 [type=int]
            │    │         └── const: 2 [type=int]
            │    └── projections
-           │         └── tuple [type=tuple{int, int}]
+           │         └── tuple [type=tuple{int AS a, int AS b}]
            │              ├── variable: a [type=int]
            │              └── variable: b [type=int]
            └── tuple [type=tuple{int, int}]
@@ -531,13 +531,13 @@ SELECT 1 = SOME(SELECT 1 a) AS r
 project
  ├── columns: r:2(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── project
            │    ├── columns: a:1(int!null)
            │    ├── values
-           │    │    └── tuple [type=tuple{}]
+           │    │    └── tuple [type=tuple]
            │    └── projections
            │         └── const: 1 [type=int]
            └── const: 1 [type=int]
@@ -548,7 +548,7 @@ SELECT (1, 2) = SOME(SELECT 1 AS a, 2 AS b) AS r
 project
  ├── columns: r:4(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── project
@@ -556,12 +556,12 @@ project
            │    ├── project
            │    │    ├── columns: a:1(int!null) b:2(int!null)
            │    │    ├── values
-           │    │    │    └── tuple [type=tuple{}]
+           │    │    │    └── tuple [type=tuple]
            │    │    └── projections
            │    │         ├── const: 1 [type=int]
            │    │         └── const: 2 [type=int]
            │    └── projections
-           │         └── tuple [type=tuple{int, int}]
+           │         └── tuple [type=tuple{int AS a, int AS b}]
            │              ├── variable: a [type=int]
            │              └── variable: b [type=int]
            └── tuple [type=tuple{int, int}]
@@ -574,14 +574,14 @@ SELECT 1 = ALL(SELECT 1 a) AS r
 project
  ├── columns: r:2(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── not [type=bool]
            └── any: ne [type=bool]
                 ├── project
                 │    ├── columns: a:1(int!null)
                 │    ├── values
-                │    │    └── tuple [type=tuple{}]
+                │    │    └── tuple [type=tuple]
                 │    └── projections
                 │         └── const: 1 [type=int]
                 └── const: 1 [type=int]
@@ -592,7 +592,7 @@ SELECT (1, 2) = ALL(SELECT 1 AS a, 2 AS b) AS r
 project
  ├── columns: r:4(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── not [type=bool]
            └── any: ne [type=bool]
@@ -601,12 +601,12 @@ project
                 │    ├── project
                 │    │    ├── columns: a:1(int!null) b:2(int!null)
                 │    │    ├── values
-                │    │    │    └── tuple [type=tuple{}]
+                │    │    │    └── tuple [type=tuple]
                 │    │    └── projections
                 │    │         ├── const: 1 [type=int]
                 │    │         └── const: 2 [type=int]
                 │    └── projections
-                │         └── tuple [type=tuple{int, int}]
+                │         └── tuple [type=tuple{int AS a, int AS b}]
                 │              ├── variable: a [type=int]
                 │              └── variable: b [type=int]
                 └── tuple [type=tuple{int, int}]
@@ -649,7 +649,7 @@ SELECT (1, 2) IN (SELECT a, b FROM abc) AS r
 project
  ├── columns: r:5(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── project
@@ -659,7 +659,7 @@ project
            │    │    └── scan abc
            │    │         └── columns: a:1(int!null) b:2(int) c:3(int)
            │    └── projections
-           │         └── tuple [type=tuple{int, int}]
+           │         └── tuple [type=tuple{int AS a, int AS b}]
            │              ├── variable: abc.a [type=int]
            │              └── variable: abc.b [type=int]
            └── tuple [type=tuple{int, int}]
@@ -672,7 +672,7 @@ SELECT (1, 2) IN (SELECT a, b FROM abc WHERE false) AS r
 project
  ├── columns: r:5(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── project
@@ -686,7 +686,7 @@ project
            │    │         └── filters [type=bool]
            │    │              └── false [type=bool]
            │    └── projections
-           │         └── tuple [type=tuple{int, int}]
+           │         └── tuple [type=tuple{int AS a, int AS b}]
            │              ├── variable: abc.a [type=int]
            │              └── variable: abc.b [type=int]
            └── tuple [type=tuple{int, int}]
@@ -704,7 +704,7 @@ SELECT (SELECT a FROM abc)
 project
  ├── columns: a:4(int)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── subquery [type=int]
            └── max1-row
@@ -720,7 +720,7 @@ SELECT EXISTS (SELECT a FROM abc)
 project
  ├── columns: exists:4(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── exists [type=bool]
            └── project
@@ -734,7 +734,7 @@ SELECT (SELECT a FROM abc WHERE false)
 project
  ├── columns: a:4(int)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── subquery [type=int]
            └── max1-row
@@ -775,7 +775,7 @@ values
                 └── project
                      ├── columns: a:1(int!null)
                      ├── values
-                     │    └── tuple [type=tuple{}]
+                     │    └── tuple [type=tuple]
                      └── projections
                           └── const: 2 [type=int]
 
@@ -813,7 +813,7 @@ SELECT 1 IN (SELECT x FROM xyz ORDER BY x DESC) AS r
 project
  ├── columns: r:4(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── any: eq [type=bool]
            ├── project
@@ -916,7 +916,7 @@ SELECT EXISTS(SELECT 1 r FROM kv AS x WHERE x.k = 1)
 project
  ├── columns: exists:4(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── exists [type=bool]
            └── project
@@ -938,7 +938,7 @@ SELECT EXISTS(SELECT 1 r FROM kv WHERE k = 2)
 project
  ├── columns: exists:4(bool)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── exists [type=bool]
            └── project
@@ -1356,7 +1356,7 @@ SELECT (SELECT 1 a), (SELECT 2 b)
 project
  ├── columns: a:2(int) b:4(int)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       ├── subquery [type=int]
       │    └── max1-row
@@ -1364,7 +1364,7 @@ project
       │         └── project
       │              ├── columns: a:1(int!null)
       │              ├── values
-      │              │    └── tuple [type=tuple{}]
+      │              │    └── tuple [type=tuple]
       │              └── projections
       │                   └── const: 1 [type=int]
       └── subquery [type=int]
@@ -1373,7 +1373,7 @@ project
                 └── project
                      ├── columns: b:3(int!null)
                      ├── values
-                     │    └── tuple [type=tuple{}]
+                     │    └── tuple [type=tuple]
                      └── projections
                           └── const: 2 [type=int]
 
@@ -1384,7 +1384,7 @@ SELECT (SELECT 1 a), (SELECT a FROM abc), (SELECT 1 a), (SELECT a FROM abc)
 project
  ├── columns: a:2(int) a:6(int) a:2(int) a:6(int)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       ├── subquery [type=int]
       │    └── max1-row
@@ -1392,7 +1392,7 @@ project
       │         └── project
       │              ├── columns: a:1(int!null)
       │              ├── values
-      │              │    └── tuple [type=tuple{}]
+      │              │    └── tuple [type=tuple]
       │              └── projections
       │                   └── const: 1 [type=int]
       └── subquery [type=int]
@@ -1410,7 +1410,7 @@ SELECT (SELECT (SELECT 1 AS x) AS  a) AS r, (SELECT (SELECT 1 AS x) AS a) AS s, 
 project
  ├── columns: r:3(int) s:3(int) t:7(int)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       ├── subquery [type=int]
       │    └── max1-row
@@ -1418,7 +1418,7 @@ project
       │         └── project
       │              ├── columns: a:2(int)
       │              ├── values
-      │              │    └── tuple [type=tuple{}]
+      │              │    └── tuple [type=tuple]
       │              └── projections
       │                   └── subquery [type=int]
       │                        └── max1-row
@@ -1426,7 +1426,7 @@ project
       │                             └── project
       │                                  ├── columns: x:1(int!null)
       │                                  ├── values
-      │                                  │    └── tuple [type=tuple{}]
+      │                                  │    └── tuple [type=tuple]
       │                                  └── projections
       │                                       └── const: 1 [type=int]
       └── subquery [type=int]
@@ -1435,7 +1435,7 @@ project
                 └── project
                      ├── columns: x:6(int!null)
                      ├── values
-                     │    └── tuple [type=tuple{}]
+                     │    └── tuple [type=tuple]
                      └── projections
                           └── const: 1 [type=int]
 
@@ -1454,7 +1454,7 @@ project
                 └── project
                      ├── columns: k:3(int)
                      ├── values
-                     │    └── tuple [type=tuple{}]
+                     │    └── tuple [type=tuple]
                      └── projections
                           └── variable: kv.k [type=int]
 
@@ -1486,7 +1486,7 @@ project
                 └── project
                      ├── columns: k:5(int)
                      ├── values
-                     │    └── tuple [type=tuple{}]
+                     │    └── tuple [type=tuple]
                      └── projections
                           └── variable: t.public.kv.k [type=int]
 
@@ -1521,7 +1521,7 @@ project
                 └── project
                      ├── columns: k:5(int)
                      ├── values
-                     │    └── tuple [type=tuple{}]
+                     │    └── tuple [type=tuple]
                      └── projections
                           └── variable: db1.public.kv.k [type=int]
 
@@ -1566,7 +1566,7 @@ project
                                     └── project
                                          ├── columns: r:5(int)
                                          ├── values
-                                         │    └── tuple [type=tuple{}]
+                                         │    └── tuple [type=tuple]
                                          └── projections
                                               └── plus [type=int]
                                                    ├── variable: t.public.kv.k [type=int]
@@ -1578,7 +1578,7 @@ SELECT (SELECT k FROM kv ORDER BY v)
 project
  ├── columns: k:3(int)
  ├── values
- │    └── tuple [type=tuple{}]
+ │    └── tuple [type=tuple]
  └── projections
       └── subquery [type=int]
            └── max1-row
@@ -1810,7 +1810,7 @@ project
                      │              ├── variable: a [type=int]
                      │              └── const: 5 [type=int]
                      └── projections
-                          └── array: int[] [type=int[]]
+                          └── array: [type=int[]]
                                ├── variable: column6 [type=int]
                                ├── variable: t1.a [type=int]
                                └── variable: a [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -323,14 +323,14 @@ project
  │    ├── project
  │    │    ├── columns: a:1(int!null) b:2(unknown)
  │    │    ├── values
- │    │    │    └── tuple [type=tuple{}]
+ │    │    │    └── tuple [type=tuple]
  │    │    └── projections
  │    │         ├── const: 1 [type=int]
  │    │         └── null [type=unknown]
  │    └── project
  │         ├── columns: a:3(int!null) b:4(int!null)
  │         ├── values
- │         │    └── tuple [type=tuple{}]
+ │         │    └── tuple [type=tuple]
  │         └── projections
  │              ├── const: 2 [type=int]
  │              └── const: 4 [type=int]
@@ -350,14 +350,14 @@ project
  │    ├── project
  │    │    ├── columns: a:1(int!null) b:2(int!null)
  │    │    ├── values
- │    │    │    └── tuple [type=tuple{}]
+ │    │    │    └── tuple [type=tuple]
  │    │    └── projections
  │    │         ├── const: 1 [type=int]
  │    │         └── const: 3 [type=int]
  │    └── project
  │         ├── columns: a:3(int!null) b:4(unknown)
  │         ├── values
- │         │    └── tuple [type=tuple{}]
+ │         │    └── tuple [type=tuple]
  │         └── projections
  │              ├── const: 2 [type=int]
  │              └── null [type=unknown]

--- a/pkg/sql/opt/optbuilder/testdata/values
+++ b/pkg/sql/opt/optbuilder/testdata/values
@@ -107,10 +107,10 @@ VALUES (NULL, 1), (2, NULL)
 ----
 values
  ├── columns: column1:1(int) column2:2(int)
- ├── tuple [type=tuple{unknown, int}]
+ ├── tuple [type=tuple{int, int}]
  │    ├── null [type=unknown]
  │    └── const: 1 [type=int]
- └── tuple [type=tuple{int, unknown}]
+ └── tuple [type=tuple{int, int}]
       ├── const: 2 [type=int]
       └── null [type=unknown]
 
@@ -119,10 +119,10 @@ VALUES (NULL, 1), (2, NULL)
 ----
 values
  ├── columns: column1:1(int) column2:2(int)
- ├── tuple [type=tuple{unknown, int}]
+ ├── tuple [type=tuple{int, int}]
  │    ├── null [type=unknown]
  │    └── const: 1 [type=int]
- └── tuple [type=tuple{int, unknown}]
+ └── tuple [type=tuple{int, int}]
       ├── const: 2 [type=int]
       └── null [type=unknown]
 
@@ -141,13 +141,13 @@ project
  │    ├── tuple [type=tuple{int, int}]
  │    │    ├── const: 1 [type=int]
  │    │    └── const: 2 [type=int]
- │    ├── tuple [type=tuple{int, unknown}]
+ │    ├── tuple [type=tuple{int, int}]
  │    │    ├── const: 3 [type=int]
  │    │    └── null [type=unknown]
- │    ├── tuple [type=tuple{unknown, int}]
+ │    ├── tuple [type=tuple{int, int}]
  │    │    ├── null [type=unknown]
  │    │    └── const: 4 [type=int]
- │    └── tuple [type=tuple{unknown, unknown}]
+ │    └── tuple [type=tuple{int, int}]
  │         ├── null [type=unknown]
  │         └── null [type=unknown]
  └── projections
@@ -168,7 +168,7 @@ values
  │              └── project
  │                   ├── columns: a:1(int!null)
  │                   ├── values
- │                   │    └── tuple [type=tuple{}]
+ │                   │    └── tuple [type=tuple]
  │                   └── projections
  │                        └── const: 1 [type=int]
  └── tuple [type=tuple{int}]
@@ -178,7 +178,7 @@ values
                 └── project
                      ├── columns: b:2(int!null)
                      ├── values
-                     │    └── tuple [type=tuple{}]
+                     │    └── tuple [type=tuple]
                      └── projections
                           └── const: 2 [type=int]
 
@@ -196,6 +196,6 @@ values
                 └── project
                      ├── columns: a:1(int!null)
                      ├── values
-                     │    └── tuple [type=tuple{}]
+                     │    └── tuple [type=tuple]
                      └── projections
                           └── const: 2 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/where
+++ b/pkg/sql/opt/optbuilder/testdata/where
@@ -80,7 +80,7 @@ select
            │    ├── scan kv
            │    │    └── columns: kv.k:3(int!null) kv.v:4(int)
            │    └── projections
-           │         └── tuple [type=tuple{int, int}]
+           │         └── tuple [type=tuple{int AS k, int AS v}]
            │              ├── variable: kv.k [type=int]
            │              └── variable: kv.v [type=int]
            └── tuple [type=tuple{int, int}]
@@ -215,7 +215,7 @@ project
       └── filters [type=bool]
            └── in [type=bool]
                 ├── variable: ab.a [type=int]
-                └── tuple [type=tuple{int, int, int, unknown}]
+                └── tuple [type=tuple{int, int, int, int}]
                      ├── const: 1 [type=int]
                      ├── const: 3 [type=int]
                      ├── const: 4 [type=int]
@@ -260,14 +260,14 @@ project
                 ├── tuple [type=tuple{int, int}]
                 │    ├── variable: ab.a [type=int]
                 │    └── variable: ab.b [type=int]
-                └── tuple [type=tuple{tuple{int, int}, tuple{int, unknown}, tuple{unknown, int}}]
+                └── tuple [type=tuple{tuple{int, int}, tuple{int, int}, tuple{int, int}}]
                      ├── tuple [type=tuple{int, int}]
                      │    ├── const: 1 [type=int]
                      │    └── const: 10 [type=int]
-                     ├── tuple [type=tuple{int, unknown}]
+                     ├── tuple [type=tuple{int, int}]
                      │    ├── const: 4 [type=int]
                      │    └── null [type=unknown]
-                     └── tuple [type=tuple{unknown, int}]
+                     └── tuple [type=tuple{int, int}]
                           ├── null [type=unknown]
                           └── const: 50 [type=int]
 

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -67,7 +67,9 @@ func (b *Builder) buildValuesClause(values *tree.ValuesClause, inScope *scope) (
 			}
 		}
 
-		rows = append(rows, b.factory.ConstructTuple(b.factory.InternList(elems)))
+		rows = append(rows, b.factory.ConstructTuple(
+			b.factory.InternList(elems), b.factory.InternType(types.TTuple{Types: colTypes})),
+		)
 	}
 
 	outScope = inScope.push()

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -79,7 +79,7 @@ memo (optimized)
  ├── G10: (filters G11)
  ├── G11: (is-not G12 G13)
  ├── G12: (variable abc.b)
- └── G13: (null anyelement)
+ └── G13: (null)
 
 opt
 SELECT min(a) FROM abc
@@ -584,7 +584,7 @@ memo (optimized)
  ├── G10: (filters G11)
  ├── G11: (is-not G12 G13)
  ├── G12: (variable abc.b)
- └── G13: (null anyelement)
+ └── G13: (null)
 
 memo
 SELECT max(a) FROM abc
@@ -646,4 +646,4 @@ memo (optimized)
  ├── G10: (filters G11)
  ├── G11: (is-not G12 G13)
  ├── G12: (variable abc.b)
- └── G13: (null anyelement)
+ └── G13: (null)

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -743,8 +743,9 @@ type Tuple struct {
 // NewTypedTuple returns a new Tuple that is verified to be well-typed.
 func NewTypedTuple(typ types.TTuple, typedExprs Exprs) *Tuple {
 	return &Tuple{
-		Exprs: typedExprs,
-		typ:   typ,
+		Exprs:  typedExprs,
+		Labels: typ.Labels,
+		typ:    typ,
 	}
 }
 


### PR DESCRIPTION
Previously, the optimizer inferred the type of a Tuple expression from
the types of its elements. However, the type of a Tuple expression
may also include the labels of its elements. In order to ensure
these labels are passed through the optimizer correctly, this
commit adds the type as a Private of Tuple.

Fixes #27398

Release note: None