### PR TITLE
[WIP] opt: enforce FDs on distinct counts

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -106,13 +106,13 @@ SELECT count(*), y, x FROM a WHERE x > 0 AND x <= 100 GROUP BY x, y
 group-by
  ├── columns: count:5(int) y:2(int) x:1(int!null)
  ├── grouping columns: x:1(int!null) y:2(int)
- ├── stats: [rows=148.109074, distinct(1,2)=148.109074]
+ ├── stats: [rows=100, distinct(1,2)=100]
  ├── key: (1)
  ├── fd: (1)-->(2,5)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
  │    ├── constraint: /1: [/1 - /100]
- │    ├── stats: [rows=150, distinct(1)=100, distinct(1,2)=148.109074]
+ │    ├── stats: [rows=150, distinct(1)=100, distinct(1,2)=100]
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── aggregations

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -403,3 +403,106 @@ project
                 │    ├── variable: tab0.col0 [type=int, outer=(2)]
                 │    └── const: 1 [type=int]
                 └── variable: case [type=bool, outer=(27)]
+
+exec-ddl
+CREATE TABLE c (x INT PRIMARY KEY, y INT, z INT, w INT)
+----
+TABLE c
+ ├── x int not null
+ ├── y int
+ ├── z int
+ ├── w int
+ └── INDEX primary
+      └── x int not null
+
+exec-ddl
+CREATE TABLE d (x INT PRIMARY KEY, y INT, s INT, t INT, UNIQUE (s DESC, t))
+----
+TABLE d
+ ├── x int not null
+ ├── y int
+ ├── s int
+ ├── t int
+ ├── INDEX primary
+ │    └── x int not null
+ └── INDEX secondary
+      ├── s int desc
+      ├── t int
+      └── x int not null (storing)
+
+
+
+
+
+exec-ddl
+CREATE TABLE f (x INT PRIMARY KEY, z INT NOT NULL)
+----
+TABLE f
+ ├── x int not null
+ ├── z int not null
+ └── INDEX primary
+      └── x int not null
+
+# These are intentionally incorrect statistics (where a dependent of an FD has higher distinct count)
+exec-ddl
+ALTER TABLE f INJECT STATISTICS '[
+  {
+    "columns": ["x"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 5000
+  },
+  {
+    "columns": ["z"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000
+  }
+]'
+----
+
+opt
+SELECT x,z from f WHERE z >= 500 AND z <= 1000 AND x = 1000
+----
+select
+ ├── columns: x:1(int!null) z:2(int!null)
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=0.0004, distinct(1)=0.0004, distinct(2)=0.0004]
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ ├── scan f
+ │    ├── columns: x:1(int!null) z:2(int!null)
+ │    ├── constraint: /1: [/1000 - /1000]
+ │    ├── cardinality: [0 - 1]
+ │    ├── stats: [rows=2, distinct(1)=1]
+ │    ├── key: ()
+ │    └── fd: ()-->(1,2)
+ └── filters [type=bool, outer=(2), constraints=(/2: [/1000 - /1000]; tight), fd=()-->(2)]
+      └── eq [type=bool, outer=(2), constraints=(/2: [/1000 - /1000]; tight)]
+           ├── variable: f.z [type=int, outer=(2)]
+           └── const: 1000 [type=int]
+
+opt
+SELECT y,t FROM d WHERE s < 1000 AND s > 0 AND x > 301 AND x < 1000
+----
+project
+ ├── columns: y:2(int) t:4(int)
+ ├── stats: [rows=696.005714]
+ └── select
+      ├── columns: x:1(int!null) y:2(int) s:3(int!null) t:4(int)
+      ├── stats: [rows=696.005714, distinct(1)=696.005714, distinct(3)=696.005714]
+      ├── key: (1)
+      ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+      ├── scan d
+      │    ├── columns: x:1(int!null) y:2(int) s:3(int) t:4(int)
+      │    ├── constraint: /1: [/302 - /999]
+      │    ├── stats: [rows=698, distinct(1)=698]
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
+      └── filters [type=bool, outer=(3), constraints=(/3: [/1 - /999]; tight)]
+           ├── lt [type=bool, outer=(3), constraints=(/3: (/NULL - /999]; tight)]
+           │    ├── variable: d.s [type=int, outer=(3)]
+           │    └── const: 1000 [type=int]
+           └── gt [type=bool, outer=(3), constraints=(/3: [/1 - ]; tight)]
+                ├── variable: d.s [type=int, outer=(3)]
+                └── const: 0 [type=int]

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -506,7 +506,7 @@ func (f *FuncDepSet) ReduceCols(cols opt.ColSet) opt.ColSet {
 	for i, ok := cols.Next(0); ok; i, ok = cols.Next(i + 1) {
 		cols.Remove(i)
 		removed.Add(i)
-		if !f.inClosureOf(removed, cols, true /* strict */) {
+		if !f.InClosureOf(removed, cols, true /* strict */) {
 			// The column is not functionally determined by the other columns, so
 			// retain it in the set.
 			cols.Add(i)
@@ -1218,13 +1218,13 @@ func (f *FuncDepSet) colsAreKey(cols opt.ColSet, strict bool) bool {
 	//   cols  = (b,c)
 	//
 	// and yet both column sets form keys for the relation.
-	return f.inClosureOf(f.key, cols, strict)
+	return f.InClosureOf(f.key, cols, strict)
 }
 
-// inClosureOf computes the strict or lax closure of the "in" column set, and
+// InClosureOf computes the strict or lax closure of the "in" column set, and
 // returns true if the "cols" columns are all contained in the resulting
 // closure.
-func (f *FuncDepSet) inClosureOf(cols, in opt.ColSet, strict bool) bool {
+func (f *FuncDepSet) InClosureOf(cols, in opt.ColSet, strict bool) bool {
 	// Short-circuit if the "in" set already contains all the columns.
 	if cols.SubsetOf(in) {
 		return true


### PR DESCRIPTION
A dependent in a functional dependency can not
have more distinct rows than it's determinant.
This PR enforces that logic.

-This PR exposes InClosureOf as a public
method in func_dep.go.

Release note: None