### PR TITLE
sql: modify tests to have deterministic results

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -362,14 +362,24 @@ SELECT avg(d) OVER (PARTITION BY v, v, v, v, v, v, v, v, v, v) FROM kv WHERE k =
 8
 
 query IT
-SELECT k, concat_agg(s) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+SELECT k, concat_agg(s) OVER (PARTITION BY k ORDER BY w) FROM kv ORDER BY 1
 ----
-1   bab
-3   Aa
-5   NULL
-6   bab
-7   b
-8   A
+1  a
+3  a
+5  NULL
+6  b
+7  b
+8  A
+
+query IT
+SELECT k, concat_agg(s) OVER (PARTITION BY v ORDER BY w, k) FROM kv ORDER BY 1
+----
+1  ba
+3  Aa
+5  NULL
+6  bab
+7  b
+8  A
 
 query IB
 SELECT k, bool_and(b) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
@@ -528,7 +538,7 @@ INSERT INTO kv VALUES
 (11, NULL, 9, .3, DEFAULT, DEFAULT, DEFAULT)
 
 query II
-SELECT k, row_number() OVER () FROM kv ORDER BY 1
+SELECT k, row_number() OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   1
 3   2
@@ -541,7 +551,7 @@ SELECT k, row_number() OVER () FROM kv ORDER BY 1
 11  9
 
 query III
-SELECT k, v, row_number() OVER (PARTITION BY v) FROM kv ORDER BY 1
+SELECT k, v, row_number() OVER (PARTITION BY v ORDER BY k) FROM kv ORDER BY 1
 ----
 1   2     1
 3   4     1
@@ -554,7 +564,7 @@ SELECT k, v, row_number() OVER (PARTITION BY v) FROM kv ORDER BY 1
 11  NULL  2
 
 query IIII
-SELECT k, v, w, row_number() OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+SELECT k, v, w, row_number() OVER (PARTITION BY v ORDER BY w, k) FROM kv ORDER BY 1
 ----
 1   2     3  2
 3   4     5  2
@@ -567,7 +577,7 @@ SELECT k, v, w, row_number() OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
 11  NULL  9  2
 
 query IIII
-SELECT k, v, w, v - w + 2 + row_number() OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+SELECT k, v, w, v - w + 2 + row_number() OVER (PARTITION BY v ORDER BY w, k) FROM kv ORDER BY 1
 ----
 1   2     3  3
 3   4     5  3
@@ -577,6 +587,32 @@ SELECT k, v, w, v - w + 2 + row_number() OVER (PARTITION BY v ORDER BY w) FROM k
 8   4     2  5
 9   2     9  -1
 10  4     9  0
+11  NULL  9  NULL
+
+query II
+SELECT k, row_number() OVER (PARTITION BY k) FROM kv ORDER BY 1
+----
+1   1
+3   1
+5   1
+6   1
+7   1
+8   1
+9   1
+10  1
+11  1
+
+query IIII
+SELECT k, v, w, v - w + 2 + row_number() OVER (PARTITION BY v, k ORDER BY w) FROM kv ORDER BY 1
+----
+1   2     3  2
+3   4     5  2
+5   NULL  5  NULL
+6   2     3  2
+7   2     2  3
+8   4     2  5
+9   2     9  -4
+10  4     9  -2
 11  NULL  9  NULL
 
 query RIII
@@ -799,7 +835,7 @@ SELECT k, ntile(1) OVER () FROM kv ORDER BY 1
 11  1
 
 query II
-SELECT k, ntile(4) OVER () FROM kv ORDER BY 1
+SELECT k, ntile(4) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   1
 3   1
@@ -812,7 +848,7 @@ SELECT k, ntile(4) OVER () FROM kv ORDER BY 1
 11  4
 
 query II
-SELECT k, ntile(20) OVER () FROM kv ORDER BY 1
+SELECT k, ntile(20) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   1
 3   2
@@ -824,9 +860,9 @@ SELECT k, ntile(20) OVER () FROM kv ORDER BY 1
 10  8
 11  9
 
-# THe value of 'w' in the first row will be 3.
+# The value of 'w' in the first row will be 3.
 query II
-SELECT k, ntile(w) OVER () FROM kv ORDER BY 1
+SELECT k, ntile(w) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   1
 3   1
@@ -839,7 +875,7 @@ SELECT k, ntile(w) OVER () FROM kv ORDER BY 1
 11  3
 
 query III
-SELECT k, v, ntile(3) OVER (PARTITION BY v) FROM kv ORDER BY 1
+SELECT k, v, ntile(3) OVER (PARTITION BY v ORDER BY k) FROM kv ORDER BY 1
 ----
 1   2     1
 3   4     1
@@ -852,7 +888,7 @@ SELECT k, v, ntile(3) OVER (PARTITION BY v) FROM kv ORDER BY 1
 11  NULL  2
 
 query IIII
-SELECT k, v, w, ntile(6) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+SELECT k, v, w, ntile(6) OVER (PARTITION BY v ORDER BY w, k) FROM kv ORDER BY 1
 ----
 1   2     3  2
 3   4     5  2
@@ -865,7 +901,46 @@ SELECT k, v, w, ntile(6) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
 11  NULL  9  2
 
 query II
-SELECT k, lag(9) OVER () FROM kv ORDER BY 1
+SELECT k, ntile(w) OVER (PARTITION BY k) FROM kv ORDER BY 1
+----
+1   1
+3   1
+5   1
+6   1
+7   1
+8   1
+9   1
+10  1
+11  1
+
+query III
+SELECT k, v, ntile(3) OVER (PARTITION BY v, k) FROM kv ORDER BY 1
+----
+1   2     1
+3   4     1
+5   NULL  1
+6   2     1
+7   2     1
+8   4     1
+9   2     1
+10  4     1
+11  NULL  1
+
+query IIII
+SELECT k, v, w, ntile(6) OVER (PARTITION BY v, k ORDER BY w) FROM kv ORDER BY 1
+----
+1   2     3  1
+3   4     5  1
+5   NULL  5  1
+6   2     3  1
+7   2     2  1
+8   4     2  1
+9   2     9  1
+10  4     9  1
+11  NULL  9  1
+
+query II
+SELECT k, lag(9) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   NULL
 3   9
@@ -878,7 +953,7 @@ SELECT k, lag(9) OVER () FROM kv ORDER BY 1
 11  9
 
 query II
-SELECT k, lead(9) OVER () FROM kv ORDER BY 1
+SELECT k, lead(9) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   9
 3   9
@@ -891,7 +966,7 @@ SELECT k, lead(9) OVER () FROM kv ORDER BY 1
 11  NULL
 
 query II
-SELECT k, lag(k) OVER () FROM kv ORDER BY 1
+SELECT k, lag(k) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   NULL
 3   1
@@ -904,7 +979,7 @@ SELECT k, lag(k) OVER () FROM kv ORDER BY 1
 11  10
 
 query II
-SELECT k, lag(k) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+SELECT k, lag(k) OVER (PARTITION BY v ORDER BY w, k) FROM kv ORDER BY 1
 ----
 1   7
 3   8
@@ -917,7 +992,7 @@ SELECT k, lag(k) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
 11  5
 
 query II
-SELECT k, lead(k) OVER () FROM kv ORDER BY 1
+SELECT k, lead(k) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   3
 3   5
@@ -930,7 +1005,7 @@ SELECT k, lead(k) OVER () FROM kv ORDER BY 1
 11  NULL
 
 query II
-SELECT k, lead(k) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+SELECT k, lead(k) OVER (PARTITION BY v ORDER BY w, k) FROM kv ORDER BY 1
 ----
 1   6
 3   10
@@ -943,7 +1018,7 @@ SELECT k, lead(k) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
 11  NULL
 
 query II
-SELECT k, lag(k, 3) OVER () FROM kv ORDER BY 1
+SELECT k, lag(k, 3) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   NULL
 3   NULL
@@ -969,7 +1044,7 @@ SELECT k, lag(k, 3) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
 11  NULL
 
 query II
-SELECT k, lead(k, 3) OVER () FROM kv ORDER BY 1
+SELECT k, lead(k, 3) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   6
 3   7
@@ -995,7 +1070,7 @@ SELECT k, lead(k, 3) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
 11  NULL
 
 query II
-SELECT k, lag(k, -5) OVER () FROM kv ORDER BY 1
+SELECT k, lag(k, -5) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   8
 3   9
@@ -1008,7 +1083,7 @@ SELECT k, lag(k, -5) OVER () FROM kv ORDER BY 1
 11  NULL
 
 query II
-SELECT k, lead(k, -5) OVER () FROM kv ORDER BY 1
+SELECT k, lead(k, -5) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   NULL
 3   NULL
@@ -1073,7 +1148,7 @@ SELECT k, lead(k, NULL::INT) OVER () FROM kv ORDER BY 1
 11  NULL
 
 query II
-SELECT k, lag(k, w) OVER () FROM kv ORDER BY 1
+SELECT k, lag(k, w) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   NULL
 3   NULL
@@ -1086,7 +1161,7 @@ SELECT k, lag(k, w) OVER () FROM kv ORDER BY 1
 11  NULL
 
 query II
-SELECT k, lag(k, w) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+SELECT k, lag(k, w) OVER (PARTITION BY v ORDER BY w, k) FROM kv ORDER BY 1
 ----
 1   NULL
 3   NULL
@@ -1099,7 +1174,7 @@ SELECT k, lag(k, w) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
 11  NULL
 
 query II
-SELECT k, lead(k, w) OVER () FROM kv ORDER BY 1
+SELECT k, lead(k, w) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   6
 3   9
@@ -1112,7 +1187,7 @@ SELECT k, lead(k, w) OVER () FROM kv ORDER BY 1
 11  NULL
 
 query II
-SELECT k, lead(k, w) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+SELECT k, lead(k, w) OVER (PARTITION BY v ORDER BY w, k) FROM kv ORDER BY 1
 ----
 1   NULL
 3   NULL
@@ -1137,7 +1212,7 @@ query error unknown signature: lead\(int, int, string\)
 SELECT k, lead(k, 1, s) OVER () FROM kv ORDER BY 1
 
 query II
-SELECT k, lag(k, 3, -99) OVER () FROM kv ORDER BY 1
+SELECT k, lag(k, 3, -99) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   -99
 3   -99
@@ -1150,7 +1225,7 @@ SELECT k, lag(k, 3, -99) OVER () FROM kv ORDER BY 1
 11  8
 
 query II
-SELECT k, lead(k, 3, -99) OVER () FROM kv ORDER BY 1
+SELECT k, lead(k, 3, -99) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   6
 3   7
@@ -1163,7 +1238,7 @@ SELECT k, lead(k, 3, -99) OVER () FROM kv ORDER BY 1
 11  -99
 
 query II
-SELECT k, lag(k, 3, v) OVER () FROM kv ORDER BY 1
+SELECT k, lag(k, 3, v) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   2
 3   4
@@ -1176,7 +1251,7 @@ SELECT k, lag(k, 3, v) OVER () FROM kv ORDER BY 1
 11  8
 
 query II
-SELECT k, lead(k, 3, v) OVER () FROM kv ORDER BY 1
+SELECT k, lead(k, 3, v) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   6
 3   7
@@ -1199,6 +1274,162 @@ SELECT k, (lag(k, 5, w) OVER w + lead(k, 3, v) OVER w) FROM kv WINDOW w AS () OR
 8   12
 9   5
 10  9
+11  NULL
+
+query II
+SELECT k, lag(k) OVER (PARTITION BY k) FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   NULL
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lead(k) OVER (PARTITION BY k) FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   NULL
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lag(k, 0) OVER (PARTITION BY k) FROM kv ORDER BY 1
+----
+1   1
+3   3
+5   5
+6   6
+7   7
+8   8
+9   9
+10  10
+11  11
+
+query II
+SELECT k, lead(k, 0) OVER (PARTITION BY k) FROM kv ORDER BY 1
+----
+1   1
+3   3
+5   5
+6   6
+7   7
+8   8
+9   9
+10  10
+11  11
+
+query II
+SELECT k, lag(k, -5) OVER (PARTITION BY k) FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   NULL
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lead(k, -5) OVER (PARTITION BY k) FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   NULL
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lag(k, w - w) OVER (PARTITION BY k) FROM kv ORDER BY 1
+----
+1   1
+3   3
+5   5
+6   6
+7   7
+8   8
+9   9
+10  10
+11  11
+
+query II
+SELECT k, lead(k, w - w) OVER (PARTITION BY k) FROM kv ORDER BY 1
+----
+1   1
+3   3
+5   5
+6   6
+7   7
+8   8
+9   9
+10  10
+11  11
+
+query II
+SELECT k, lag(k, 3, -99) OVER (PARTITION BY k) FROM kv ORDER BY 1
+----
+1   -99
+3   -99
+5   -99
+6   -99
+7   -99
+8   -99
+9   -99
+10  -99
+11  -99
+
+query II
+SELECT k, lead(k, 3, -99) OVER (PARTITION BY k) FROM kv ORDER BY 1
+----
+1   -99
+3   -99
+5   -99
+6   -99
+7   -99
+8   -99
+9   -99
+10  -99
+11  -99
+
+query II
+SELECT k, lag(k, 3, v) OVER (PARTITION BY k) FROM kv ORDER BY 1
+----
+1   2
+3   4
+5   NULL
+6   2
+7   2
+8   4
+9   2
+10  4
+11  NULL
+
+query II
+SELECT k, lead(k, 3, v) OVER (PARTITION BY k) FROM kv ORDER BY 1
+----
+1   2
+3   4
+5   NULL
+6   2
+7   2
+8   4
+9   2
+10  4
 11  NULL
 
 query II
@@ -1241,7 +1472,7 @@ SELECT k, first_value(199.9 * 23.3) OVER () FROM kv ORDER BY 1
 11  4657.67
 
 query II
-SELECT k, first_value(v) OVER () FROM kv ORDER BY 1
+SELECT k, first_value(v) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   2
 3   2
@@ -1278,6 +1509,19 @@ SELECT k, v, w, first_value(w) OVER (PARTITION BY v ORDER BY w DESC) FROM kv ORD
 9   2     9  9
 10  4     9  9
 11  NULL  9  9
+
+query II
+SELECT k, first_value(v) OVER (PARTITION BY k) FROM kv ORDER BY 1
+----
+1   2
+3   4
+5   NULL
+6   2
+7   2
+8   4
+9   2
+10  4
+11  NULL
 
 query II
 SELECT k, last_value(NULL::INT) OVER () FROM kv ORDER BY 1
@@ -1319,16 +1563,16 @@ SELECT k, last_value(199.9 * 23.3) OVER () FROM kv ORDER BY 1
 11  4657.67
 
 query II
-SELECT k, last_value(v) OVER () FROM kv ORDER BY 1
+SELECT k, last_value(v) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
-1   NULL
-3   NULL
+1   2
+3   4
 5   NULL
-6   NULL
-7   NULL
-8   NULL
-9   NULL
-10  NULL
+6   2
+7   2
+8   4
+9   2
+10  4
 11  NULL
 
 query IIII
@@ -1356,6 +1600,19 @@ SELECT k, v, w, last_value(w) OVER (PARTITION BY v ORDER BY w DESC) FROM kv ORDE
 9   2     9  9
 10  4     9  9
 11  NULL  9  9
+
+query II
+SELECT k, last_value(v) OVER (PARTITION BY k) FROM kv ORDER BY 1
+----
+1   2
+3   4
+5   NULL
+6   2
+7   2
+8   4
+9   2
+10  4
+11  NULL
 
 query error could not parse "FOO" as type int
 SELECT k, nth_value(v, 'FOO') OVER () FROM kv ORDER BY 1
@@ -1419,17 +1676,17 @@ SELECT k, nth_value(199.9 * 23.3, 7) OVER () FROM kv ORDER BY 1
 11  4657.67
 
 query II
-SELECT k, nth_value(v, 8) OVER () FROM kv ORDER BY 1
+SELECT k, nth_value(v, 8) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
-1   4
-3   4
-5   4
-6   4
-7   4
-8   4
-9   4
-10  4
-11  4
+1  NULL
+3  NULL
+5  NULL
+6  NULL
+7  NULL
+8  NULL
+9  NULL
+10 4
+11 4
 
 query IIII
 SELECT k, v, w, nth_value(w, 2) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
@@ -1458,23 +1715,23 @@ SELECT k, v, w, nth_value(w, 2) OVER (PARTITION BY v ORDER BY w DESC) FROM kv OR
 11  NULL  9  NULL
 
 query II
-SELECT k, nth_value(v, k) OVER () FROM kv ORDER BY 1
+SELECT k, nth_value(v, k) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
 1   2
 3   NULL
-5   2
-6   4
-7   2
-8   4
+5   NULL
+6   NULL
+7   NULL
+8   NULL
 9   NULL
 10  NULL
 11  NULL
 
 query II
-SELECT k, nth_value(v, v) OVER () FROM kv ORDER BY 1
+SELECT k, nth_value(v, v) OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
-1   4
-3   2
+1   NULL
+3   NULL
 5   NULL
 6   4
 7   4
@@ -1482,6 +1739,33 @@ SELECT k, nth_value(v, v) OVER () FROM kv ORDER BY 1
 9   4
 10  2
 11  NULL
+
+query II
+SELECT k, nth_value(v, 1) OVER (PARTITION BY k) FROM kv ORDER BY 1
+----
+1   2
+3   4
+5   NULL
+6   2
+7   2
+8   4
+9   2
+10  4
+11  NULL
+
+query II
+SELECT k, nth_value(v, v) OVER (PARTITION BY k) FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   NULL
+9   NULL
+10  NULL
+11  NULL
+
 
 statement ok
 INSERT INTO kv VALUES (12, -1, DEFAULT, DEFAULT, DEFAULT, DEFAULT)
@@ -1724,7 +2008,7 @@ Kindle Fire      150.00   150.00  700.00
 Samsung          200.00   150.00  700.00
 
 query TTRT
-SELECT group_name, product_name, price, min(price) OVER (PARTITION BY group_name ROWS CURRENT ROW) AS min_over_single_row FROM products ORDER BY group_id;
+SELECT group_name, product_name, price, min(price) OVER (PARTITION BY group_name ROWS CURRENT ROW) AS min_over_single_row FROM products ORDER BY group_id
 ----
 Smartphone  Microsoft Lumia   200.00               200.00
 Smartphone  HTC One           400.00               400.00
@@ -1739,7 +2023,7 @@ Tablet      Kindle Fire       150.00               150.00
 Tablet      Samsung           200.00               200.00
 
 query TTRR
-SELECT group_name, product_name, price, avg(price) OVER (PARTITION BY group_name ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING) AS running_avg FROM products ORDER BY group_id;
+SELECT group_name, product_name, price, avg(price) OVER (PARTITION BY group_name ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING) AS running_avg FROM products ORDER BY group_id
 ----
 Smartphone  Microsoft Lumia   200.00  600.00
 Smartphone  HTC One           400.00  700.00
@@ -1754,7 +2038,7 @@ Tablet      Kindle Fire       150.00  200.00
 Tablet      Samsung           200.00  NULL
 
 query TRRRRR
-SELECT product_name, price, min(price) OVER (PARTITION BY group_name ROWS UNBOUNDED PRECEDING), max(price) OVER (PARTITION BY group_name ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING), sum(price) OVER (PARTITION BY group_name ROWS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING), avg(price) OVER (PARTITION BY group_name ROWS CURRENT ROW) FROM products ORDER BY group_id;
+SELECT product_name, price, min(price) OVER (PARTITION BY group_name ROWS UNBOUNDED PRECEDING), max(price) OVER (PARTITION BY group_name ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING), sum(price) OVER (PARTITION BY group_name ROWS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING), avg(price) OVER (PARTITION BY group_name ROWS CURRENT ROW) FROM products ORDER BY group_id
 ----
 Microsoft Lumia  200.00   200.00   400.00   2000.00  200.00
 HTC One          400.00   200.00   500.00   2000.00  400.00

--- a/pkg/sql/logictest/testdata/logic_test/window_local
+++ b/pkg/sql/logictest/testdata/logic_test/window_local
@@ -1,0 +1,458 @@
+# LogicTest: local local-opt local-parallel-stmts
+
+statement ok
+CREATE TABLE kv (
+  -- don't add column "a"
+  k INT PRIMARY KEY,
+  v INT,
+  w INT,
+  f FLOAT,
+  d DECIMAL,
+  s STRING,
+  b BOOL,
+  FAMILY (k, v, w, f, b),
+  FAMILY (d),
+  FAMILY (s)
+)
+
+statement OK
+INSERT INTO kv VALUES
+(1, 2, 3, 1.0, 1, 'a', true),
+(3, 4, 5, 2, 8, 'a', true),
+(5, NULL, 5, 9.9, -321, NULL, false),
+(6, 2, 3, 4.4, 4.4, 'b', true),
+(7, 2, 2, 6, 7.9, 'b', true),
+(8, 4, 2, 3, 3, 'A', false)
+
+query IT
+SELECT k, concat_agg(s) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1  bab
+3  Aa
+5  NULL
+6  bab
+7  b
+8  A
+
+statement OK
+INSERT INTO kv VALUES
+(9, 2, 9, .1, DEFAULT, DEFAULT, DEFAULT),
+(10, 4, 9, .2, DEFAULT, DEFAULT, DEFAULT),
+(11, NULL, 9, .3, DEFAULT, DEFAULT, DEFAULT)
+
+query II
+SELECT k, row_number() OVER () FROM kv ORDER BY 1
+----
+1   1
+3   2
+5   3
+6   4
+7   5
+8   6
+9   7
+10  8
+11  9
+
+query III
+SELECT k, v, row_number() OVER (PARTITION BY v) FROM kv ORDER BY 1
+----
+1   2     1
+3   4     1
+5   NULL  1
+6   2     2
+7   2     3
+8   4     2
+9   2     4
+10  4     3
+11  NULL  2
+
+query IIII
+SELECT k, v, w, row_number() OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1   2     3  2
+3   4     5  2
+5   NULL  5  1
+6   2     3  3
+7   2     2  1
+8   4     2  1
+9   2     9  4
+10  4     9  3
+11  NULL  9  2
+
+query IIII
+SELECT k, v, w, v - w + 2 + row_number() OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1   2     3  3
+3   4     5  3
+5   NULL  5  NULL
+6   2     3  4
+7   2     2  3
+8   4     2  5
+9   2     9  -1
+10  4     9  0
+11  NULL  9  NULL
+
+query II
+SELECT k, ntile(4) OVER () FROM kv ORDER BY 1
+----
+1   1
+3   1
+5   1
+6   2
+7   2
+8   3
+9   3
+10  4
+11  4
+
+query II
+SELECT k, ntile(20) OVER () FROM kv ORDER BY 1
+----
+1   1
+3   2
+5   3
+6   4
+7   5
+8   6
+9   7
+10  8
+11  9
+
+# The value of 'w' in the first row will be 3.
+query II
+SELECT k, ntile(w) OVER () FROM kv ORDER BY 1
+----
+1   1
+3   1
+5   1
+6   2
+7   2
+8   2
+9   3
+10  3
+11  3
+
+query III
+SELECT k, v, ntile(3) OVER (PARTITION BY v) FROM kv ORDER BY 1
+----
+1   2     1
+3   4     1
+5   NULL  1
+6   2     1
+7   2     2
+8   4     2
+9   2     3
+10  4     3
+11  NULL  2
+
+query IIII
+SELECT k, v, w, ntile(6) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1   2     3  2
+3   4     5  2
+5   NULL  5  1
+6   2     3  3
+7   2     2  1
+8   4     2  1
+9   2     9  4
+10  4     9  3
+11  NULL  9  2
+
+query II
+SELECT k, lag(9) OVER () FROM kv ORDER BY 1
+----
+1   NULL
+3   9
+5   9
+6   9
+7   9
+8   9
+9   9
+10  9
+11  9
+
+query II
+SELECT k, lead(9) OVER () FROM kv ORDER BY 1
+----
+1   9
+3   9
+5   9
+6   9
+7   9
+8   9
+9   9
+10  9
+11  NULL
+
+query II
+SELECT k, lag(k) OVER () FROM kv ORDER BY 1
+----
+1   NULL
+3   1
+5   3
+6   5
+7   6
+8   7
+9   8
+10  9
+11  10
+
+query II
+SELECT k, lag(k) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1   7
+3   8
+5   NULL
+6   1
+7   NULL
+8   NULL
+9   6
+10  3
+11  5
+
+query II
+SELECT k, lead(k) OVER () FROM kv ORDER BY 1
+----
+1   3
+3   5
+5   6
+6   7
+7   8
+8   9
+9   10
+10  11
+11  NULL
+
+query II
+SELECT k, lead(k) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1   6
+3   10
+5   11
+6   9
+7   1
+8   3
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lag(k, 3) OVER () FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   1
+7   3
+8   5
+9   6
+10  7
+11  8
+
+query II
+SELECT k, lead(k, 3) OVER () FROM kv ORDER BY 1
+----
+1   6
+3   7
+5   8
+6   9
+7   10
+8   11
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lag(k, -5) OVER () FROM kv ORDER BY 1
+----
+1   8
+3   9
+5   10
+6   11
+7   NULL
+8   NULL
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lead(k, -5) OVER () FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   1
+9   3
+10  5
+11  6
+
+query II
+SELECT k, lag(k, w) OVER () FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   1
+7   5
+8   6
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lag(k, w) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   NULL
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lead(k, w) OVER () FROM kv ORDER BY 1
+----
+1   6
+3   9
+5   10
+6   9
+7   9
+8   10
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lead(k, w) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   6
+8   10
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lag(k, 3, -99) OVER () FROM kv ORDER BY 1
+----
+1   -99
+3   -99
+5   -99
+6   1
+7   3
+8   5
+9   6
+10  7
+11  8
+
+query II
+SELECT k, lead(k, 3, -99) OVER () FROM kv ORDER BY 1
+----
+1   6
+3   7
+5   8
+6   9
+7   10
+8   11
+9   -99
+10  -99
+11  -99
+
+query II
+SELECT k, lag(k, 3, v) OVER () FROM kv ORDER BY 1
+----
+1   2
+3   4
+5   NULL
+6   1
+7   3
+8   5
+9   6
+10  7
+11  8
+
+query II
+SELECT k, lead(k, 3, v) OVER () FROM kv ORDER BY 1
+----
+1   6
+3   7
+5   8
+6   9
+7   10
+8   11
+9   2
+10  4
+11  NULL
+
+query II
+SELECT k, first_value(v) OVER () FROM kv ORDER BY 1
+----
+1   2
+3   2
+5   2
+6   2
+7   2
+8   2
+9   2
+10  2
+11  2
+
+query II
+SELECT k, last_value(v) OVER () FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   NULL
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, nth_value(v, 8) OVER () FROM kv ORDER BY 1
+----
+1   4
+3   4
+5   4
+6   4
+7   4
+8   4
+9   4
+10  4
+11  4
+
+query II
+SELECT k, nth_value(v, k) OVER () FROM kv ORDER BY 1
+----
+1   2
+3   NULL
+5   2
+6   4
+7   2
+8   4
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, nth_value(v, v) OVER () FROM kv ORDER BY 1
+----
+1   4
+3   2
+5   NULL
+6   4
+7   4
+8   2
+9   4
+10  2
+11  NULL


### PR DESCRIPTION
When using window functions in DistSQL, if ORDER BY
clause is not specified, rows will be processed in
arbitrary order which forces order-dependent window
functions like `row_number()` to not have a consistent
output.

Also remove a few unnecessary semicolons.

Release note: None