### PR TITLE
server: persist correct cluster version on join

### DIFF
--- a/pkg/cmd/roachtest/upgrade.go
+++ b/pkg/cmd/roachtest/upgrade.go
@@ -45,7 +45,17 @@ func registerUpgrade(r *registry) {
 		c.Put(ctx, b, "./cockroach", c.Range(1, nodes))
 		// Force disable encryption.
 		// TODO(mberhault): allow it once oldVersion >= 2.1.
-		c.Start(ctx, c.Range(1, nodes), startArgsDontEncrypt)
+		start := func() {
+			c.Start(ctx, c.Range(1, nodes), startArgsDontEncrypt)
+		}
+		start()
+		time.Sleep(5 * time.Second)
+
+		// TODO(tschottdorf): this is a hack similar to the one in the mixed version
+		// test. Remove it when we have a 2.0.x binary that has #27639 fixed.
+		c.Stop(ctx, c.Range(1, nodes))
+		start()
+		time.Sleep(5 * time.Second)
 
 		const stageDuration = 30 * time.Second
 		const timeUntilStoreDead = 90 * time.Second

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -422,6 +422,13 @@ func (n *Node) bootstrap(
 	return nil
 }
 
+func (n *Node) onClusterVersionChange(cv cluster.ClusterVersion) {
+	ctx := n.AnnotateCtx(context.Background())
+	if err := n.stores.OnClusterVersionChange(ctx, cv); err != nil {
+		log.Fatal(ctx, errors.Wrapf(err, "updating cluster version to %s", cv))
+	}
+}
+
 // start starts the node by registering the storage instance for the
 // RPC service "Node" and initializing stores for each specified
 // engine. Launches periodic store gossiping in a goroutine.
@@ -435,12 +442,7 @@ func (n *Node) start(
 ) error {
 	n.initDescriptor(addr, attrs, locality)
 
-	n.storeCfg.Settings.Version.OnChange(func(cv cluster.ClusterVersion) {
-		if err := n.stores.OnClusterVersionChange(ctx, cv); err != nil {
-			log.Fatal(ctx, errors.Wrapf(err, "updating cluster version to %s", cv))
-		}
-	})
-
+	n.storeCfg.Settings.Version.OnChange(n.onClusterVersionChange)
 	if err := n.storeCfg.Settings.InitializeVersion(cv); err != nil {
 		return errors.Wrap(err, "while initializing cluster version")
 	}
@@ -652,10 +654,16 @@ func (n *Node) bootstrapStores(
 		StoreID:   firstID,
 	}
 
-	// FIXME(tschottdorf): what is this version if we're joining a cluster?
-	// I think it's our `MinSupportedVersion`, which is the best we can do
-	// but isn't technically "correct". We should be able to wait for an
-	// authoritative version from gossip here.
+	// There's a bit of an awkward dance around cluster versions here. If this node
+	// is joining an existing cluster for the first time, it doesn't have any engines
+	// set up yet, and cv below will be the MinSupportedVersion. At the same time,
+	// the Gossip update which notifies us about the real cluster version won't
+	// persist it to any engines (because none of them are bootstrapped). The correct
+	// version is likely in Settings.Version.Version(), but what if the callback fires
+	// too late? In that case that too is the MinSupportedVersion. So we just accept
+	// that we won't use the correct version here, but post-bootstrapping will invoke
+	// the callback manually, which will disseminate the correct version to all engines
+	// that still need it.
 	cv, err := n.stores.SynthesizeClusterVersion(ctx)
 	if err != nil {
 		log.Fatalf(ctx, "error retrieving cluster version for bootstrap: %s", err)
@@ -677,6 +685,9 @@ func (n *Node) bootstrapStores(
 			log.Warningf(ctx, "error doing initial gossiping: %s", err)
 		}
 	}
+	clusterVersion := n.storeCfg.Settings.Version.Version()
+	n.onClusterVersionChange(clusterVersion)
+
 	// write a new status summary after all stores have been bootstrapped; this
 	// helps the UI remain responsive when new nodes are added.
 	if err := n.writeNodeStatus(ctx, 0 /* alertTTL */); err != nil {

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -117,6 +117,7 @@ func setupMixedCluster(
 		}}
 
 	tc := testcluster.StartTestCluster(t, len(versions), base.TestClusterArgs{
+		ReplicationMode:   base.ReplicationManual, // speeds up test
 		ServerArgsPerNode: twh.args(),
 	})
 
@@ -140,6 +141,55 @@ func prev(version roachpb.Version) roachpb.Version {
 	} else {
 		// version will be at least 2.0-X, so it's safe to set new Major to be version.Major-1.
 		return roachpb.Version{Major: version.Major - 1}
+	}
+}
+
+func TestClusterVersionPersistedOnJoin(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var newVersion = cluster.BinaryServerVersion
+	var oldVersion = prev(newVersion)
+
+	// Starts 3 nodes that have cluster versions set to be oldVersion and
+	// self-declared binary version set to be newVersion with a cluster
+	// running at the new version (i.e. a very regular setup). Want to check
+	// that after joining the cluster, the second two servers persist the
+	// new version (and not the old one).
+	versions := [][2]string{{oldVersion.String(), newVersion.String()}, {oldVersion.String(), newVersion.String()}, {oldVersion.String(), newVersion.String()}}
+
+	bootstrapVersion := cluster.ClusterVersion{
+		UseVersion:     newVersion,
+		MinimumVersion: newVersion,
+	}
+
+	knobs := base.TestingKnobs{
+		Store: &storage.StoreTestingKnobs{
+			BootstrapVersion: &bootstrapVersion,
+		},
+		Upgrade: &server.UpgradeTestingKnobs{
+			DisableUpgrade: 1,
+		},
+	}
+
+	ctx := context.Background()
+	dir, finish := testutils.TempDir(t)
+	defer finish()
+	tc := setupMixedCluster(t, knobs, versions, dir)
+	defer tc.TestCluster.Stopper().Stop(ctx)
+
+	for i := 0; i < len(tc.TestCluster.Servers); i++ {
+		testutils.SucceedsSoon(t, func() error {
+			for _, engine := range tc.TestCluster.Servers[i].Engines() {
+				cv, err := storage.ReadClusterVersion(ctx, engine)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if cv.MinimumVersion != newVersion {
+					return errors.Errorf("n%d: expected version %v, got %v", i+1, newVersion, cv)
+				}
+			}
+			return nil
+		})
 	}
 }
 


### PR DESCRIPTION
Prior to this commit, when a node joined an existing cluster, it would
likely persist its MinSupportedVersion as the cluster version (even
though it would operate at the correct version). This is problematic
since this node's data directories wouldn't be regarded compatible with
the successor version of the real version, even though they are.

The problem was that the callback which receives the real cluster
version would fire before the stores were bootstrapped, and bootstrap
would erroneously pick the minimum supported version. We now "backfill"
the correct cluster version after having bootstrapped all stores.

Even though the fixtures will need to be regenerated:
Fixes #27525.

Optimistically:
Fixes #27162.

Release note: None