### PR TITLE
opt: support scalar ColumnAccess expressions

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -52,6 +52,7 @@ func init() {
 		opt.CaseOp:            (*Builder).buildCase,
 		opt.CastOp:            (*Builder).buildCast,
 		opt.CoalesceOp:        (*Builder).buildCoalesce,
+		opt.ColumnAccessOp:    (*Builder).buildColumnAccess,
 		opt.ArrayOp:           (*Builder).buildArray,
 		opt.AnyOp:             (*Builder).buildAny,
 		opt.UnsupportedExprOp: (*Builder).buildUnsupportedExpr,
@@ -286,6 +287,21 @@ func (b *Builder) buildCoalesce(ctx *buildScalarCtx, ev memo.ExprView) (tree.Typ
 		}
 	}
 	return tree.NewTypedCoalesceExpr(exprs, ev.Logical().Scalar.Type), nil
+}
+
+func (b *Builder) buildColumnAccess(ctx *buildScalarCtx, ev memo.ExprView) (tree.TypedExpr, error) {
+	child := ev.Child(0)
+	input, err := b.buildScalar(ctx, child)
+	if err != nil {
+		return nil, err
+	}
+	childTyp := child.Logical().Scalar.Type.(types.TTuple)
+	colIdx := int(ev.Private().(memo.TupleOrdinal))
+	lbl := ""
+	if childTyp.Labels != nil {
+		lbl = childTyp.Labels[colIdx]
+	}
+	return tree.NewTypedColumnAccessExpr(input, lbl, colIdx), nil
 }
 
 func (b *Builder) buildArray(ctx *buildScalarCtx, ev memo.ExprView) (tree.TypedExpr, error) {

--- a/pkg/sql/opt/exec/execbuilder/testdata/tuple
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tuple
@@ -109,3 +109,30 @@ render     ·         ·                                                        
  └── scan  ·         ·                                                                                   (v int)                                  ·
 ·          table     kv@primary                                                                          ·                                        ·
 ·          spans     ALL                                                                                 ·                                        ·
+
+query TTTTT
+EXPLAIN (VERBOSE, TYPES) SELECT (x).a, (x).b, (x).c FROM (SELECT (row(v,v,v) AS a,b,c) AS x FROM kv)
+----
+render          ·         ·                                                                                   (a int, b int, c int)                    ·
+ │              render 0  (((x)[tuple{int AS a, int AS b, int AS c}]).a)[int]                                 ·                                        ·
+ │              render 1  (((x)[tuple{int AS a, int AS b, int AS c}]).b)[int]                                 ·                                        ·
+ │              render 2  (((x)[tuple{int AS a, int AS b, int AS c}]).c)[int]                                 ·                                        ·
+ └── render     ·         ·                                                                                   (x tuple{int AS a, int AS b, int AS c})  ·
+      │         render 0  ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]  ·                                        ·
+      └── scan  ·         ·                                                                                   (v int)                                  ·
+·               table     kv@primary                                                                          ·                                        ·
+·               spans     ALL                                                                                 ·                                        ·
+
+query TTTTT
+EXPLAIN (VERBOSE, TYPES) SELECT (x).e, (x).f, (x).g
+FROM (
+  SELECT ((1,'2',true) AS e,f,g) AS x
+)
+----
+render              ·         ·                                                                                   (e int, f string, g bool)                    ·
+ │                  render 0  (((x)[tuple{int AS e, string AS f, bool AS g}]).e)[int]                             ·                                            ·
+ │                  render 1  (((x)[tuple{int AS e, string AS f, bool AS g}]).f)[string]                          ·                                            ·
+ │                  render 2  (((x)[tuple{int AS e, string AS f, bool AS g}]).g)[bool]                            ·                                            ·
+ └── render         ·         ·                                                                                   (x tuple{int AS e, string AS f, bool AS g})  ·
+      │             render 0  (((1)[int], ('2')[string], (true)[bool]))[tuple{int AS e, string AS f, bool AS g}]  ·                                            ·
+      └── emptyrow  ·         ·                                                                                   ()                                           ·

--- a/pkg/sql/opt/memo/private_defs.go
+++ b/pkg/sql/opt/memo/private_defs.go
@@ -27,6 +27,10 @@ import (
 // indicates an unknown private.
 type PrivateID uint32
 
+// TupleOrdinal is an ordinal index into an expression of type Tuple. It is
+// used by the ColumnAccess scalar expression.
+type TupleOrdinal uint32
+
 // FuncOpDef defines the value of the Def private field of the Function
 // operator. It provides the name and return type of the function, as well as a
 // pointer to an already resolved builtin overload definition.

--- a/pkg/sql/opt/memo/private_storage.go
+++ b/pkg/sql/opt/memo/private_storage.go
@@ -118,6 +118,22 @@ func (ps *privateStorage) internColList(colList opt.ColList) PrivateID {
 	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, colList)
 }
 
+// internTupleOrdinal adds the given value to storage and returns an id that
+// can later be used to retrieve the value by calling the lookup method. If the
+// value has been previously added to storage, then internTupleOrdinal always
+// returns the same private id that was returned from the previous call.
+func (ps *privateStorage) internTupleOrdinal(tupleOrdinal TupleOrdinal) PrivateID {
+	// The below code is carefully constructed to not allocate in the case
+	// where the value is already in the map. Be careful when modifying.
+	ps.keyBuf.Reset()
+	ps.keyBuf.writeUvarint(uint64(tupleOrdinal))
+	typ := (*TupleOrdinal)(nil)
+	if id, ok := ps.privatesMap[privateKey{iface: typ, str: ps.keyBuf.String()}]; ok {
+		return id
+	}
+	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, tupleOrdinal)
+}
+
 // internOperator adds the given value to storage and returns an id that can
 // later be used to retrieve the value by calling the lookup method. If the
 // value has been previously added to storage, then internOperator always

--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -126,6 +126,7 @@ func init() {
 		opt.CastOp:            typeCast,
 		opt.SubqueryOp:        typeSubquery,
 		opt.ArrayOp:           typeAsPrivate,
+		opt.ColumnAccessOp:    typeColumnAccess,
 
 		// Override default typeAsAggregate behavior for aggregate functions with
 		// a large number of possible overloads or where ReturnType depends on
@@ -291,6 +292,12 @@ func typeAsPrivate(ev ExprView) types.T {
 func typeSubquery(ev ExprView) types.T {
 	colID, _ := ev.Child(0).Logical().Relational.OutputCols.Next(0)
 	return ev.Metadata().ColumnType(opt.ColumnID(colID))
+}
+
+func typeColumnAccess(ev ExprView) types.T {
+	colIdx := ev.Private().(TupleOrdinal)
+	typ := ev.Child(0).Logical().Scalar.Type.(types.TTuple)
+	return typ.Types[colIdx]
 }
 
 // overload encapsulates information about a binary operator overload, to be

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -515,6 +515,15 @@ define Coalesce {
     Args ExprList
 }
 
+# ColumnAccess is a scalar expression that returns a column from the given
+# input expression (which is assumed to be of type Tuple). Idx is the ordinal
+# index of the column in Input.
+[Scalar]
+define ColumnAccess {
+    Input Expr
+    Idx   TupleOrdinal
+}
+
 # UnsupportedExpr is used for interfacing with the old planner code. It can
 # encapsulate a TypedExpr that is otherwise not supported by the optimizer.
 [Scalar]

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -255,6 +255,12 @@ func (b *Builder) buildScalarHelper(
 		}
 		out = b.factory.ConstructCoalesce(b.factory.InternList(args))
 
+	case *tree.ColumnAccessExpr:
+		input := b.buildScalarHelper(inScope.resolveType(t.Expr, types.Any), "", inScope, nil)
+		out = b.factory.ConstructColumnAccess(
+			input, b.factory.InternTupleOrdinal(memo.TupleOrdinal(t.ColIndex)),
+		)
+
 	case *tree.ComparisonExpr:
 		if sub, ok := t.Right.(*subquery); ok && sub.multiRow {
 			out, _ = b.buildMultiRowSubquery(t, inScope)

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1059,3 +1059,36 @@ build
 SELECT * FROM a AS t(a, b, c)
 ----
 error (42P10): source "t" has 2 columns available but 3 columns specified
+
+build
+SELECT (x).e, (x).f, (x).g
+FROM (
+  SELECT ((1,'2',true) AS e,f,g) AS x
+)
+----
+project
+ ├── columns: e:2(int) f:3(string) g:4(bool)
+ ├── project
+ │    ├── columns: x:1(tuple{int AS e, string AS f, bool AS g})
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    └── projections
+ │         └── tuple [type=tuple{int AS e, string AS f, bool AS g}]
+ │              ├── const: 1 [type=int]
+ │              ├── const: '2' [type=string]
+ │              └── true [type=bool]
+ └── projections
+      ├── column-access: 0 [type=int]
+      │    └── variable: x [type=tuple{int AS e, string AS f, bool AS g}]
+      ├── column-access: 1 [type=string]
+      │    └── variable: x [type=tuple{int AS e, string AS f, bool AS g}]
+      └── column-access: 2 [type=bool]
+           └── variable: x [type=tuple{int AS e, string AS f, bool AS g}]
+
+build
+SELECT (((x, y) AS x, y)).x FROM a
+----
+project
+ ├── columns: x:1(int!null)
+ └── scan a
+      └── columns: x:1(int!null) y:2(float)

--- a/pkg/sql/opt/optgen/cmd/optgen/utils.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/utils.go
@@ -78,6 +78,8 @@ func mapPrivateType(typ string) string {
 		return "*memo.ShowTraceOpDef"
 	case "MergeOnDef":
 		return "*memo.MergeOnDef"
+	case "TupleOrdinal":
+		return "memo.TupleOrdinal"
 	case "Datum":
 		return "tree.Datum"
 	case "Type":

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1565,7 +1565,7 @@ func NewTypedColumnAccessExpr(expr TypedExpr, colName string, colIdx int) *Colum
 		Expr:           expr,
 		ColName:        colName,
 		ColIndex:       colIdx,
-		typeAnnotation: typeAnnotation{typ: expr.ResolvedType()},
+		typeAnnotation: typeAnnotation{typ: expr.ResolvedType().(types.TTuple).Types[colIdx]},
 	}
 }
 


### PR DESCRIPTION
This commit adds support for the `ColumnAccess` scalar expression:
```
  define ColumnAccess {
      Input Expr
      Idx   ColIdx
  }
```
`ColumnAccess` is a scalar expression that returns a column from the given
input expression (which is assumed to be of type Tuple). `Idx` is the ordinal
index of the column in `Input`.

cc @knz

Release note: None