### PR TITLE
sql/tree: clean up the type checking rule for ColumnAccessExpr

### DIFF
--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -533,7 +533,11 @@ func (expr *TupleStar) ResolvedType() types.T {
 
 // TypeCheck implements the Expr interface.
 func (expr *ColumnAccessExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, error) {
-	subExpr, err := expr.Expr.TypeCheck(ctx, desired)
+	// If the context requires types T, we need to ask "Any tuple with
+	// at least this label and the element type T for this label" from
+	// the sub-expression. Of course, our type system does not support
+	// this. So drop the type constraint instead.
+	subExpr, err := expr.Expr.TypeCheck(ctx, types.Any)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #27643.

The sub-expression should not be typed with the desired type of the
*result* of the indexing operator. It ought to be typed with a tuple
 type containing the desired type at the right position, but the
 desired type logic does not support.

This is a cosmetic fix: there are no built-in functions that both
return a tuple type and are overloaded on the return type; and the
tuple constructor ignores any desired type that is not TTuple, so the
previous incorrect code was not observable and the change is not
either.

Release note: None