### PR TITLE
sql: do not hide statements from collected statistics

### DIFF
--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -894,25 +894,15 @@ func TestStatusAPIStatements(t *testing.T) {
 	statements := []struct {
 		stmt          string
 		fingerprinted string
-		notInStats    bool
 	}{
-		{
-			stmt: `CREATE DATABASE roachblog`,
-		},
-		{
-			stmt:       `USE roachblog`,
-			notInStats: true,
-		},
-		{
-			stmt: `CREATE TABLE posts (id INT PRIMARY KEY, body TEXT)`,
-		},
+		{stmt: `CREATE DATABASE roachblog`},
+		{stmt: `SET database = roachblog`},
+		{stmt: `CREATE TABLE posts (id INT PRIMARY KEY, body TEXT)`},
 		{
 			stmt:          `INSERT INTO posts VALUES (1, 'foo')`,
 			fingerprinted: `INSERT INTO posts VALUES (_, _)`,
 		},
-		{
-			stmt: `SELECT * FROM posts`,
-		},
+		{stmt: `SELECT * FROM posts`},
 	}
 
 	for _, stmt := range statements {
@@ -928,9 +918,6 @@ func TestStatusAPIStatements(t *testing.T) {
 	// See if the statements returned are what we executed.
 	var expectedStatements []string
 	for _, stmt := range statements {
-		if stmt.notInStats {
-			continue
-		}
 		var expectedStmt = stmt.stmt
 		if stmt.fingerprinted != "" {
 			expectedStmt = stmt.fingerprinted

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -539,6 +539,8 @@ func TestReportUsage(t *testing.T) {
 		`[false,false] SET CLUSTER SETTING "cluster.organization" = _`,
 		`[false,false] SET CLUSTER SETTING "diagnostics.reporting.send_crash_reports" = _`,
 		`[false,false] SET CLUSTER SETTING "server.time_until_store_dead" = _`,
+		`[false,false] SET application_name = DEFAULT`,
+		`[false,false] SET application_name = _`,
 		`[false,false] UPDATE _ SET _ = _ + _`,
 		`[false,true] CREATE TABLE _ (_ INT PRIMARY KEY, _ INT, INDEX (_) INTERLEAVE IN PARENT _ (_))`,
 		`[false,true] SELECT _ / $1`,
@@ -587,11 +589,13 @@ func TestReportUsage(t *testing.T) {
 			`SELECT crdb_internal.force_error(_, $1)`,
 			`SET CLUSTER SETTING "server.time_until_store_dead" = _`,
 			`SET CLUSTER SETTING "diagnostics.reporting.send_crash_reports" = _`,
+			`SET application_name = _`,
 		},
 		elemName: {
 			`SELECT _ FROM _ WHERE (_ = _) AND (lower(_) = lower(_))`,
 			`UPDATE _ SET _ = _ + _`,
 			`SET CLUSTER SETTING "cluster.organization" = _`,
+			`SET application_name = DEFAULT`,
 		},
 	} {
 		hashedAppName := sql.HashForReporting(clusterSecret, appName)

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -107,12 +107,6 @@ func (a *appStats) recordStatement(
 		return
 	}
 
-	// Some statements like SET, SHOW etc are not useful to collect
-	// stats about. Ignore them.
-	if _, ok := stmt.AST.(tree.HiddenFromStats); ok {
-		return
-	}
-
 	// Extend the statement key with a character that indicated whether
 	// there was an error and/or whether the query was distributed, so
 	// that we use separate buckets for the different situations.

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -13,6 +13,7 @@ SELECT count > 0 FROM crdb_internal.node_statement_statistics WHERE application_
 ----
 true
 true
+true
 
 # Check that node_statement_statistics report per statement
 
@@ -119,6 +120,8 @@ SELECT x FROM test WHERE y IN (_, _, _ + x, _, _)                 ·
 SELECT x FROM test WHERE y NOT IN (_, _)                          ·
 SET CLUSTER SETTING "debug.panic_on_failed_assertions" = DEFAULT  ·
 SET CLUSTER SETTING "debug.panic_on_failed_assertions" = _        ·
+SET application_name = _                                          ·
+SET distsql = "on"                                                ·
 
 # Check that names are anonymized properly:
 # - virtual table names are preserved, but not the db prefix (#22700)
@@ -141,6 +144,8 @@ SELECT _ FROM _ WHERE _ IN (_, _, _ + _, _, _)
 SELECT _ FROM _ WHERE _ NOT IN (_, _)
 SET CLUSTER SETTING "debug.panic_on_failed_assertions" = DEFAULT
 SET CLUSTER SETTING "debug.panic_on_failed_assertions" = _
+SET application_name = _
+SET distsql = _
 
 # Check that the latency measurements looks reasonable, protecting
 # against failure to measure (#22877).

--- a/pkg/sql/sem/tree/set.go
+++ b/pkg/sql/sem/tree/set.go
@@ -37,7 +37,11 @@ func (node *SetVar) Format(ctx *FmtCtx) {
 		ctx.FormatNode(&node.Values)
 		ctx.WriteString(")")
 	} else {
-		ctx.FormatNameP(&node.Name)
+		// Session var names never contain PII and should be distinguished
+		// for feature tracking purposes.
+		deAnonCtx := *ctx
+		deAnonCtx.flags &= ^FmtAnonymize
+		deAnonCtx.FormatNameP(&node.Name)
 		ctx.WriteString(" = ")
 		ctx.FormatNode(&node.Values)
 	}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -117,12 +117,6 @@ func CanWriteData(stmt Statement) bool {
 	return false
 }
 
-// HiddenFromStats is a pseudo-interface to be implemented
-// by statements that should not show up in per-app statistics.
-type HiddenFromStats interface {
-	hiddenFromStats()
-}
-
 // HiddenFromShowQueries is a pseudo-interface to be implemented
 // by statements that should not show up in SHOW QUERIES (and are hence
 // not cancellable using CANCEL QUERIES either). Usually implemented by
@@ -213,8 +207,6 @@ func (*BeginTransaction) StatementType() StatementType { return Ack }
 // StatementTag returns a short string identifying the type of statement.
 func (*BeginTransaction) StatementTag() string { return "BEGIN" }
 
-func (*BeginTransaction) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*ControlJobs) StatementType() StatementType { return RowsAffected }
 
@@ -246,8 +238,6 @@ func (*CommitTransaction) StatementType() StatementType { return Ack }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*CommitTransaction) StatementTag() string { return "COMMIT" }
-
-func (*CommitTransaction) hiddenFromStats() {}
 
 // StatementType implements the Statement interface.
 func (*CopyFrom) StatementType() StatementType { return CopyIn }
@@ -338,8 +328,6 @@ func (n *Deallocate) StatementTag() string {
 	return "DEALLOCATE"
 }
 
-func (*Deallocate) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*Discard) StatementType() StatementType { return Ack }
 
@@ -408,8 +396,6 @@ func (*Explain) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*Explain) StatementTag() string { return "EXPLAIN" }
 
-func (*Explain) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*Export) StatementType() StatementType { return Rows }
 
@@ -422,15 +408,11 @@ func (*Grant) StatementType() StatementType { return DDL }
 // StatementTag returns a short string identifying the type of statement.
 func (*Grant) StatementTag() string { return "GRANT" }
 
-func (*Grant) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*GrantRole) StatementType() StatementType { return DDL }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*GrantRole) StatementTag() string { return "GRANT" }
-
-func (*GrantRole) hiddenFromStats() {}
 
 // StatementType implements the Statement interface.
 func (n *Insert) StatementType() StatementType { return n.Returning.statementType() }
@@ -456,15 +438,11 @@ func (*Prepare) StatementType() StatementType { return Ack }
 // StatementTag returns a short string identifying the type of statement.
 func (*Prepare) StatementTag() string { return "PREPARE" }
 
-func (*Prepare) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*ReleaseSavepoint) StatementType() StatementType { return Ack }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*ReleaseSavepoint) StatementTag() string { return "RELEASE" }
-
-func (*ReleaseSavepoint) hiddenFromStats() {}
 
 // StatementType implements the Statement interface.
 func (*RenameColumn) StatementType() StatementType { return DDL }
@@ -522,15 +500,11 @@ func (*Revoke) StatementType() StatementType { return DDL }
 // StatementTag returns a short string identifying the type of statement.
 func (*Revoke) StatementTag() string { return "REVOKE" }
 
-func (*Revoke) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*RevokeRole) StatementType() StatementType { return DDL }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*RevokeRole) StatementTag() string { return "REVOKE" }
-
-func (*RevokeRole) hiddenFromStats() {}
 
 // StatementType implements the Statement interface.
 func (*RollbackToSavepoint) StatementType() StatementType { return Ack }
@@ -538,15 +512,11 @@ func (*RollbackToSavepoint) StatementType() StatementType { return Ack }
 // StatementTag returns a short string identifying the type of statement.
 func (*RollbackToSavepoint) StatementTag() string { return "ROLLBACK" }
 
-func (*RollbackToSavepoint) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*RollbackTransaction) StatementType() StatementType { return Ack }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*RollbackTransaction) StatementTag() string { return "ROLLBACK" }
-
-func (*RollbackTransaction) hiddenFromStats() {}
 
 // StatementType implements the Statement interface.
 func (*Savepoint) StatementType() StatementType { return Ack }
@@ -584,8 +554,6 @@ func (*SetVar) StatementType() StatementType { return Ack }
 // StatementTag returns a short string identifying the type of statement.
 func (*SetVar) StatementTag() string { return "SET" }
 
-func (*SetVar) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*SetClusterSetting) StatementType() StatementType { return Ack }
 
@@ -598,15 +566,11 @@ func (*SetTransaction) StatementType() StatementType { return Ack }
 // StatementTag returns a short string identifying the type of statement.
 func (*SetTransaction) StatementTag() string { return "SET TRANSACTION" }
 
-func (*SetTransaction) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*SetTracing) StatementType() StatementType { return Ack }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*SetTracing) StatementTag() string { return "SET TRACING" }
-
-func (*SetTracing) hiddenFromStats() {}
 
 // observerStatement implements the ObserverStatement interface.
 func (*SetTracing) observerStatement() {}
@@ -623,15 +587,12 @@ func (*SetSessionCharacteristics) StatementType() StatementType { return Ack }
 // StatementTag returns a short string identifying the type of statement.
 func (*SetSessionCharacteristics) StatementTag() string { return "SET" }
 
-func (*SetSessionCharacteristics) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*ShowVar) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowVar) StatementTag() string { return "SHOW" }
 
-func (*ShowVar) hiddenFromStats()                   {}
 func (*ShowVar) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
@@ -640,7 +601,6 @@ func (*ShowClusterSetting) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowClusterSetting) StatementTag() string { return "SHOW" }
 
-func (*ShowClusterSetting) hiddenFromStats()                   {}
 func (*ShowClusterSetting) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
@@ -649,15 +609,11 @@ func (*ShowColumns) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowColumns) StatementTag() string { return "SHOW COLUMNS" }
 
-func (*ShowColumns) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*ShowCreate) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowCreate) StatementTag() string { return "SHOW CREATE" }
-
-func (*ShowCreate) hiddenFromStats() {}
 
 // StatementType implements the Statement interface.
 func (*ShowBackup) StatementType() StatementType { return Rows }
@@ -665,15 +621,11 @@ func (*ShowBackup) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowBackup) StatementTag() string { return "SHOW BACKUP" }
 
-func (*ShowBackup) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*ShowDatabases) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowDatabases) StatementTag() string { return "SHOW DATABASES" }
-
-func (*ShowDatabases) hiddenFromStats() {}
 
 // StatementType implements the Statement interface.
 func (*ShowTraceForSession) StatementType() StatementType { return Rows }
@@ -681,15 +633,11 @@ func (*ShowTraceForSession) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowTraceForSession) StatementTag() string { return "SHOW TRACE FOR SESSION" }
 
-func (*ShowTraceForSession) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*ShowGrants) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowGrants) StatementTag() string { return "SHOW GRANTS" }
-
-func (*ShowGrants) hiddenFromStats() {}
 
 // StatementType implements the Statement interface.
 func (*ShowIndex) StatementType() StatementType { return Rows }
@@ -697,15 +645,12 @@ func (*ShowIndex) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowIndex) StatementTag() string { return "SHOW INDEX" }
 
-func (*ShowIndex) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*ShowQueries) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowQueries) StatementTag() string { return "SHOW QUERIES" }
 
-func (*ShowQueries) hiddenFromStats()                   {}
 func (*ShowQueries) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
@@ -714,7 +659,6 @@ func (*ShowJobs) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowJobs) StatementTag() string { return "SHOW JOBS" }
 
-func (*ShowJobs) hiddenFromStats()                   {}
 func (*ShowJobs) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
@@ -723,15 +667,12 @@ func (*ShowRoleGrants) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowRoleGrants) StatementTag() string { return "SHOW GRANTS ON ROLE" }
 
-func (*ShowRoleGrants) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*ShowSessions) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowSessions) StatementTag() string { return "SHOW SESSIONS" }
 
-func (*ShowSessions) hiddenFromStats()                   {}
 func (*ShowSessions) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
@@ -740,15 +681,11 @@ func (*ShowTableStats) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowTableStats) StatementTag() string { return "SHOW STATISTICS" }
 
-func (*ShowTableStats) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*ShowHistogram) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowHistogram) StatementTag() string { return "SHOW HISTOGRAM" }
-
-func (*ShowHistogram) hiddenFromStats() {}
 
 // StatementType implements the Statement interface.
 func (*ShowSyntax) StatementType() StatementType { return Rows }
@@ -757,7 +694,6 @@ func (*ShowSyntax) StatementType() StatementType { return Rows }
 func (*ShowSyntax) StatementTag() string { return "SHOW SYNTAX" }
 
 func (*ShowSyntax) observerStatement()                 {}
-func (*ShowSyntax) hiddenFromStats()                   {}
 func (*ShowSyntax) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
@@ -767,7 +703,6 @@ func (*ShowTransactionStatus) StatementType() StatementType { return Rows }
 func (*ShowTransactionStatus) StatementTag() string { return "SHOW TRANSACTION STATUS" }
 
 func (*ShowTransactionStatus) observerStatement()                 {}
-func (*ShowTransactionStatus) hiddenFromStats()                   {}
 func (*ShowTransactionStatus) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
@@ -776,15 +711,11 @@ func (*ShowUsers) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowUsers) StatementTag() string { return "SHOW USERS" }
 
-func (*ShowUsers) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*ShowRoles) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowRoles) StatementTag() string { return "SHOW ROLES" }
-
-func (*ShowRoles) hiddenFromStats() {}
 
 // StatementType implements the Statement interface.
 func (*ShowZoneConfig) StatementType() StatementType { return Rows }
@@ -798,8 +729,6 @@ func (*ShowRanges) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowRanges) StatementTag() string { return "SHOW EXPERIMENTAL_RANGES" }
 
-func (*ShowRanges) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*ShowFingerprints) StatementType() StatementType { return Rows }
 
@@ -812,23 +741,17 @@ func (*ShowConstraints) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowConstraints) StatementTag() string { return "SHOW CONSTRAINTS" }
 
-func (*ShowConstraints) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*ShowTables) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowTables) StatementTag() string { return "SHOW TABLES" }
 
-func (*ShowTables) hiddenFromStats() {}
-
 // StatementType implements the Statement interface.
 func (*ShowSchemas) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowSchemas) StatementTag() string { return "SHOW SCHEMAS" }
-
-func (*ShowSchemas) hiddenFromStats() {}
 
 // StatementType implements the Statement interface.
 func (*Split) StatementType() StatementType { return Rows }


### PR DESCRIPTION
Prior to this patch I had worked with the mistaken assumption that we
did not want to "pollute" the stats with statements that are executed
often in a predictable fashion.

It turns out that this choice was wrong because there is much more
diversity of usage than I had expected. To study this diversity we
really want to see everything.

So this patch unhides the statements from the statistics.

Release note (sql change): more statement types are now reported in
the collected statement statistics (those visible in the web UI, and
those reported to Cockroach Labs if the reporting option is enabled).