### PR TITLE
sql: move lease acquisition out of tableState

### DIFF
--- a/pkg/sql/helpers_test.go
+++ b/pkg/sql/helpers_test.go
@@ -119,7 +119,7 @@ func (m *LeaseManager) AcquireAndAssertMinVersion(
 	if err := t.ensureVersion(ctx, minVersion, m); err != nil {
 		return nil, hlc.Timestamp{}, err
 	}
-	table, err := t.acquire(ctx, timestamp, m)
+	table, err := t.find(ctx, timestamp, m)
 	if err != nil {
 		return nil, hlc.Timestamp{}, err
 	}


### PR DESCRIPTION
This change removes lease acquisition from the tableState
struct and makes lease acquisition a part of LeaseStore.

Future work: Move acquireFreshest and release code paths
out of tableState.

The eventual goal is to have tableState be a simple cache of
table descriptors with the leasing code separated out and
only responsible for the expiration time of the latest descriptor
in the cache.

related to #23510

Release note: None