### PR TITLE
ui: General Query Manager Saga

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1162,7 +1162,7 @@ ui-test-watch: $(UI_CCL_DLLS) $(UI_CCL_MANIFESTS)
 
 .PHONY: ui-test-debug
 ui-test-debug: $(UI_DLLS) $(UI_MANIFESTS)
-	$(NODE_RUN) -C $(UI_ROOT) $(KARMA) start --browsers Chrome --no-single-run --debug --auto-watch
+	$(NODE_RUN) -C pkg/ui $(KARMA) start --browsers Chrome --no-single-run --debug --auto-watch
 
 pkg/ui/distccl/bindata.go: $(UI_CCL_DLLS) $(UI_CCL_MANIFESTS) $(UI_JS_CCL) $(shell find pkg/ui/ccl -type f)
 pkg/ui/distoss/bindata.go: $(UI_OSS_DLLS) $(UI_OSS_MANIFESTS) $(UI_JS_OSS)

--- a/pkg/ui/src/redux/queryManager/saga.spec.ts
+++ b/pkg/ui/src/redux/queryManager/saga.spec.ts
@@ -1,0 +1,347 @@
+import { assert } from "chai";
+import moment from "moment";
+
+import { delay, channel } from "redux-saga";
+import { call } from "redux-saga/effects";
+import { expectSaga, testSaga } from "redux-saga-test-plan";
+
+import {
+    refresh,
+    autoRefresh,
+    stopAutoRefresh,
+    ManagedQuerySagaState,
+    processQueryManagementAction,
+    queryManagerSaga,
+    timeToNextRefresh,
+    getMoment,
+    DEFAULT_REFRESH_INTERVAL,
+    DEFAULT_RETRY_DELAY,
+} from "./saga";
+
+import {
+    queryManagerReducer,
+} from "./reducer";
+
+describe("Query Management Saga", function() {
+    let queryCounterCalled = 0;
+    const testQueryCounter = {
+        id: "testQueryCounter",
+        refreshInterval: moment.duration(50),
+        retryDelay: moment.duration(500),
+        querySaga: function* () {
+            yield call(delay, 0);
+            yield call(() => queryCounterCalled++);
+        },
+    };
+
+    const sentinelError = new Error("error");
+    let queryErrorCalled = 0;
+    const testQueryError = {
+        id: "testQueryError",
+        refreshInterval: moment.duration(500),
+        retryDelay: moment.duration(50),
+        querySaga: function* (): IterableIterator<void> {
+            queryErrorCalled++;
+            throw sentinelError;
+        },
+    };
+
+    beforeEach(function() {
+        queryCounterCalled = 0;
+        queryErrorCalled = 0;
+    });
+
+    describe("integration tests", function() {
+        describe("REFRESH action", function() {
+            it("immediately runs a saga when refresh is called", function() {
+                return expectSaga(queryManagerSaga)
+                    .dispatch(refresh(testQueryCounter))
+                    .run()
+                    .then(() => {
+                        assert.equal(queryCounterCalled, 1);
+                    });
+            });
+            it("does not run refresh again if query is currently in progress", function() {
+                return expectSaga(queryManagerSaga)
+                    .dispatch(refresh(testQueryCounter))
+                    .dispatch(refresh(testQueryCounter))
+                    .run()
+                    .then(() => {
+                        assert.equal(queryCounterCalled, 1);
+                    });
+            });
+            it("does refresh again if query is allowed to finish.", function() {
+                return expectSaga(queryManagerSaga)
+                    .dispatch(refresh(testQueryCounter))
+                    .delay(10)
+                    .dispatch(refresh(testQueryCounter))
+                    .run()
+                    .then(() => {
+                        assert.equal(queryCounterCalled, 2);
+                    });
+            });
+            it("correctly records error (and does not retry).", function() {
+                return expectSaga(queryManagerSaga)
+                    .withReducer(queryManagerReducer)
+                    .dispatch(refresh(testQueryError))
+                    .run()
+                    .then(runResult => {
+                        assert.isObject(runResult.storeState[testQueryError.id]);
+                        assert.equal(runResult.storeState[testQueryError.id].lastError, sentinelError);
+                        assert.isFalse(runResult.storeState[testQueryError.id].isRunning);
+                    });
+            });
+            it("immediately runs a saga if refresh is called even if AUTO_REFRESH wait is active", function () {
+                return expectSaga(queryManagerSaga)
+                    .dispatch(autoRefresh(testQueryCounter))
+                    .delay(10)
+                    .dispatch(refresh(testQueryCounter))
+                    .dispatch(stopAutoRefresh(testQueryCounter))
+                    .run()
+                    .then(() => {
+                        assert.equal(queryCounterCalled, 2);
+                    });
+            });
+        });
+        describe("AUTO_REFRESH/STOP_AUTO_REFRESH action", function() {
+            it("immediately runs if query result is out of date", function() {
+                return expectSaga(queryManagerSaga)
+                    .dispatch(autoRefresh(testQueryCounter))
+                    .dispatch(stopAutoRefresh(testQueryCounter))
+                    .run()
+                    .then(() => {
+                        assert.equal(queryCounterCalled, 1);
+                    });
+            });
+            it("does not run again if query result is considered current.", function() {
+                return expectSaga(queryManagerSaga)
+                    .dispatch(refresh(testQueryCounter))
+                    .dispatch(autoRefresh(testQueryCounter))
+                    .dispatch(stopAutoRefresh(testQueryCounter))
+                    .run()
+                    .then(() => {
+                        assert.equal(queryCounterCalled, 1);
+                    });
+            });
+            it("runs again after a delay while refresh refcount is positive.", function() {
+                const tester = expectSaga(queryManagerSaga);
+
+                // A query which stops itself by dispatching a stopAutoRefresh
+                // after being called some number of times.
+                let queryCalled = 0;
+                const selfStopQuery = {
+                    id: "selfStopQuery",
+                    querySaga: function* (): IterableIterator<void> {
+                        queryCalled++;
+                        if (queryCalled > 3) {
+                            tester.dispatch(stopAutoRefresh(selfStopQuery));
+                        }
+                    },
+                };
+                tester
+                    .dispatch(autoRefresh(testQueryCounter))
+                    .dispatch(autoRefresh(testQueryCounter))
+                    .dispatch(autoRefresh(testQueryCounter))
+                    .run()
+                    .then(() => {
+                        assert.equal(queryCalled, 5);
+                    });
+            });
+            it("Uses retry delay when errors are encountered", function() {
+                return expectSaga(queryManagerSaga)
+                    .dispatch(autoRefresh(testQueryError))
+                    .run({timeout: 200})
+                    .then(() => {
+                        // RefreshTimeout is high enough that it would only be
+                        // called once.
+                        assert.isAtLeast(queryErrorCalled, 3);
+                    });
+            });
+            it("sets inRunning flag on reducer when query is running.", function() {
+                const neverResolveQuery = {
+                    id: "explicitResolveQuery",
+                    refreshInterval: moment.duration(0),
+                    querySaga: function* (): IterableIterator<Promise<void>> {
+                        yield new Promise((_resolve, _reject) => {});
+                    },
+                };
+                return expectSaga(queryManagerSaga)
+                    .withReducer(queryManagerReducer)
+                    .dispatch(refresh(neverResolveQuery))
+                    .dispatch(refresh(testQueryCounter))
+                    .run({timeout: 10})
+                    .then(runResult => {
+                        assert.isTrue(runResult.storeState[neverResolveQuery.id].isRunning);
+                        assert.isFalse(runResult.storeState[testQueryCounter.id].isRunning);
+                        assert.equal(queryCounterCalled, 1);
+                    });
+            });
+            it("continues to count AUTO_REFRESH refcounts even while query is running", function() {
+                let queryCalledCount = 0;
+                let resolveQuery: () => void;
+                const explicitResolveQuery = {
+                    id: "explicitResolveQuery",
+                    refreshInterval: moment.duration(0),
+                    querySaga: function* (): IterableIterator<Promise<void>> {
+                        queryCalledCount++;
+                        yield new Promise((resolve, _reject) => {
+                            resolveQuery = resolve;
+                        });
+                    },
+                };
+                return async function() {
+                    const tester = expectSaga(queryManagerSaga)
+                        .dispatch(refresh(explicitResolveQuery));
+
+                    const testFinished = tester.run();
+                    await delay(0);
+
+                    // Query is now in progress, waiting on explicit resolve to
+                    // complete. Dispatch two autoRefresh requests, which should
+                    // still be serviced.
+                    tester
+                        .dispatch(autoRefresh(explicitResolveQuery))
+                        .dispatch(autoRefresh(explicitResolveQuery));
+
+                    // resolve the query, which should result in the query
+                    // immediately being called again due to the auto-refresh
+                    // count.
+                    await delay(0);
+                    resolveQuery();
+
+                    // Dispatch stopAutoRefresh and resolve the query. This
+                    // should still result in the query being called again,
+                    // because autoRefresh has not been fully decremented.
+                    tester
+                        .dispatch(stopAutoRefresh(explicitResolveQuery));
+                    await delay(0);
+                    resolveQuery();
+
+                    // Fully decrement stopAutoRefresh and resolve the query.
+                    // Query should not be called again.
+                    tester
+                        .dispatch(stopAutoRefresh(explicitResolveQuery));
+                    await delay(0);
+                    resolveQuery();
+                    await testFinished;
+
+                    assert.equal(queryCalledCount, 3);
+                }();
+            });
+        });
+    });
+
+    describe("component unit tests", function() {
+        describe("processQueryManagementAction", function() {
+            it("initially processes first action", function() {
+                const state = new ManagedQuerySagaState();
+                state.channel = channel<any>();
+                testSaga(processQueryManagementAction, state)
+                    .next()
+                    .take(state.channel);
+            });
+            it("correctly handles REFRESH action", function() {
+                const state = new ManagedQuerySagaState();
+                state.channel = channel<any>();
+                testSaga(processQueryManagementAction, state)
+                    .next()
+                    .take(state.channel)
+                    .next(refresh(testQueryCounter))
+                    .isDone();
+                const expected = new ManagedQuerySagaState();
+                expected.channel = state.channel;
+                expected.shouldRefreshQuery = true;
+                assert.deepEqual(state, expected);
+            });
+            it("correctly handles AUTO_REFRESH action", function() {
+                const state = new ManagedQuerySagaState();
+                state.channel = channel<any>();
+                testSaga(processQueryManagementAction, state)
+                    .next()
+                    .take(state.channel)
+                    .next(autoRefresh(testQueryCounter))
+                    .isDone();
+                const expected = new ManagedQuerySagaState();
+                expected.channel = state.channel;
+                expected.autoRefreshCount = 1;
+                assert.equal(state.autoRefreshCount, 1);
+                assert.deepEqual(state, expected);
+            });
+            it("correctly handles STOP_AUTO_REFRESH action", function() {
+                const state = new ManagedQuerySagaState();
+                state.channel = channel<any>();
+                testSaga(processQueryManagementAction, state)
+                    .next()
+                    .take(state.channel)
+                    .next(stopAutoRefresh(testQueryCounter))
+                    .isDone();
+                const expected = new ManagedQuerySagaState();
+                expected.channel = state.channel;
+                expected.autoRefreshCount = -1;
+                assert.equal(state.autoRefreshCount, -1);
+                assert.deepEqual(state, expected);
+            });
+        });
+
+        describe("timeToNextRefresh", function() {
+            it("returns 0 if the query has never run.", function() {
+                const state = new ManagedQuerySagaState();
+                testSaga(timeToNextRefresh, state)
+                    .next()
+                    .returns(0);
+            });
+            it("applies refresh interval if specified.", function() {
+                const state = new ManagedQuerySagaState();
+                state.query = testQueryCounter;
+                state.queryCompletedAt = moment(5000);
+                testSaga(timeToNextRefresh, state)
+                    .next()
+                    .call(getMoment)
+                    .next(5030)
+                    .returns(testQueryCounter.refreshInterval.asMilliseconds() - 30);
+            });
+            it("applies default refresh interval if none specified.", function() {
+                const state = new ManagedQuerySagaState();
+                state.query = {
+                    id: "defaultQuery",
+                    querySaga: function* () {
+                        return null;
+                    },
+                };
+                state.queryCompletedAt = moment(5000);
+                testSaga(timeToNextRefresh, state)
+                    .next()
+                    .call(getMoment)
+                    .next(5030)
+                    .returns(DEFAULT_REFRESH_INTERVAL.asMilliseconds() - 30);
+            });
+            it("applies retry delay in error case if specified.", function() {
+                const state = new ManagedQuerySagaState();
+                state.query = testQueryCounter;
+                state.queryCompletedAt = moment(5000);
+                state.lastAttemptFailed = true;
+                testSaga(timeToNextRefresh, state)
+                    .next()
+                    .call(getMoment)
+                    .next(5030)
+                    .returns(testQueryCounter.retryDelay.asMilliseconds() - 30);
+            });
+            it("applies default retry delay in error case if none specified.", function() {
+                const state = new ManagedQuerySagaState();
+                state.query = {
+                    id: "defaultQuery",
+                    querySaga: function* () {
+                        return null;
+                    },
+                };
+                state.queryCompletedAt = moment(5000);
+                state.lastAttemptFailed = true;
+                testSaga(timeToNextRefresh, state)
+                    .next()
+                    .call(getMoment)
+                    .next(5030)
+                    .returns(DEFAULT_RETRY_DELAY.asMilliseconds() - 30);
+            });
+        });
+    });
+});

--- a/pkg/ui/src/redux/queryManager/saga.ts
+++ b/pkg/ui/src/redux/queryManager/saga.ts
@@ -1,0 +1,328 @@
+import moment from "moment";
+import { Action } from "redux";
+import { channel, delay, Task, Channel } from "redux-saga";
+import {
+    call, cancel, fork, join, put, race, take,
+} from "redux-saga/effects";
+
+import { queryBegin, queryComplete, queryError } from "./reducer";
+
+export const DEFAULT_REFRESH_INTERVAL = moment.duration(10, "s");
+export const DEFAULT_RETRY_DELAY = moment.duration(2, "s");
+
+/**
+ * A ManagedQuery describes an asynchronous query that can have its execution
+ * managed by the query management saga.
+ *
+ * Managed queries are executed by dispatching redux actions:
+ * + refresh(query) can be used to immediately run the query.
+ * + autoRefresh(query) will begin automatically refreshing the query
+ *   automatically on a cadence.
+ * + stopAutoRefresh(query) will stop automatically refreshing the query.
+ *
+ * Note that "autoRefresh" and "stopAutoRefresh" events are counted; the
+ * query will refresh as long as there is at least one auto_refresh() action
+ * that has not been canceled by a stop_auto_refresh().
+ */
+interface ManagedQuery {
+    // A string ID that distinguishes this query from all other queries.
+    id: string;
+    // The interval at which this query should be refreshed if it is being
+    // auto-refreshed. Default is ten seconds.
+    refreshInterval?: moment.Duration;
+    // The delay after which an auto-refreshing query will be retried after
+    // a failure. Default is two seconds.
+    retryDelay?: moment.Duration;
+    // A redux saga task that should execute the query and put its results into
+    // the store. This method can yield any of the normal redux saga effects.
+    querySaga: () => IterableIterator<any>;
+}
+
+export const QUERY_REFRESH = "cockroachui/query/QUERY_REFRESH";
+export const QUERY_AUTO_REFRESH = "cockroachui/query/QUERY_AUTO_REFRESH";
+export const QUERY_STOP_AUTO_REFRESH = "cockroachui/query/QUERY_STOP_AUTO_REFRESH";
+
+interface QueryRefreshAction extends Action {
+    type: typeof QUERY_REFRESH;
+    query: ManagedQuery;
+}
+
+interface QueryAutoRefreshAction extends Action {
+    type: typeof QUERY_AUTO_REFRESH;
+    query: ManagedQuery;
+}
+
+interface QueryStopRefreshAction extends Action {
+    type: typeof QUERY_STOP_AUTO_REFRESH;
+    query: ManagedQuery;
+}
+
+type QueryManagementAction =
+    QueryRefreshAction | QueryAutoRefreshAction | QueryStopRefreshAction;
+
+/**
+ * refresh indicates that a managed query should run immediately.
+ */
+export function refresh(query: ManagedQuery): QueryRefreshAction {
+    return {
+        type: QUERY_REFRESH,
+        query: query,
+    };
+}
+
+/**
+ * autoRefresh indicates that a managed query should start automatically
+ * refreshing on a regular cadence.
+ */
+export function autoRefresh(query: ManagedQuery): QueryAutoRefreshAction {
+    return {
+        type: QUERY_AUTO_REFRESH,
+        query: query,
+    };
+}
+
+/**
+ * stopAutoRefresh indicates that a managed query no longer needs to automatically
+ * refresh.
+ */
+export function stopAutoRefresh(query: ManagedQuery): QueryStopRefreshAction {
+    return {
+        type: QUERY_STOP_AUTO_REFRESH,
+        query: query,
+    };
+}
+
+/**
+ * Contains state information about a managed query which has been run by the
+ * manager.
+ */
+export class ManagedQuerySagaState {
+    // The query being managed.
+    query: ManagedQuery;
+    // The saga task which is managing this query, either running it or
+    // auto-refreshing it. If the auto-refresh count drops to zero, this saga
+    // may complete (the manager will start a new saga if the query starts
+    // again).
+    sagaTask: Task;
+    // A saga channel that the main query management saga will use to dispatch
+    // events to the query-specific saga.
+    channel: Channel<QueryManagementAction>;
+    // The number of components currently requesting that this query be
+    // auto-refreshed. This is the result of incrementing on autoRefresh()
+    // actions and decrementing on stopAutoRefresh() actions.
+    autoRefreshCount: number = 0;
+    // If true, the query saga needs to run the underlying query immediately. If
+    // this is false, the saga will delay until it needs to be refreshed (or
+    // will exit if autoRefreshCount is zero,)
+    shouldRefreshQuery: boolean;
+    // Contains the time at which the query last completed, either successfully
+    // or with an error.
+    queryCompletedAt: moment.Moment;
+    // True if the last attempt to run this query ended in an error.
+    lastAttemptFailed: boolean;
+}
+
+/**
+ * Contains state needed by a running query manager saga.
+ */
+export class QueryManagerSagaState {
+    private queryStates: {[queryId: string]: ManagedQuerySagaState} = {};
+
+    // Retrieve the ManagedQuerySagaState for the query with the given id.
+    // Creates a new state object if the given id has not yet been encountered.
+    getQueryState(query: ManagedQuery) {
+        const { id } = query;
+        if (!this.queryStates.hasOwnProperty(id)) {
+            this.queryStates[id] = new ManagedQuerySagaState();
+            this.queryStates[id].query = query;
+        }
+        return this.queryStates[id];
+    }
+}
+
+/**
+ * The top-level saga responsible for dispatching events to the child sagas
+ * which manage individual queries.
+ */
+export function *queryManagerSaga() {
+    const queryManagerState = new QueryManagerSagaState();
+
+    while (true) {
+        const qmAction: QueryManagementAction = yield take(
+            [QUERY_REFRESH, QUERY_AUTO_REFRESH, QUERY_STOP_AUTO_REFRESH],
+        );
+
+        // Fork a saga to manage this query if it is not already running.
+        const state = queryManagerState.getQueryState(qmAction.query);
+        if (!taskIsRunning(state.sagaTask)) {
+            state.channel = channel<QueryManagementAction>();
+            state.sagaTask = yield fork(managedQuerySaga, state);
+        }
+        yield put(state.channel, qmAction);
+    }
+}
+
+/**
+ * Saga used to manages the execution of an individual query.
+ */
+export function *managedQuerySaga(state: ManagedQuerySagaState) {
+    // Process the initial action.
+    yield call(processQueryManagementAction, state);
+
+    // Run loop while we either need to run the query immediately, or if there
+    // are any components requesting this query should auto refresh.
+    while (state.shouldRefreshQuery || state.autoRefreshCount > 0) {
+        if (state.shouldRefreshQuery) {
+            yield call(refreshQuery, state);
+        }
+
+        if (state.autoRefreshCount > 0) {
+            yield call(waitForNextRefresh, state);
+        }
+    }
+}
+
+/**
+ * Processes the next QueryManagementAction dispatched to this query.
+ */
+export function *processQueryManagementAction(state: ManagedQuerySagaState) {
+    const { type } = (yield take(state.channel)) as QueryManagementAction;
+    switch (type) {
+        case QUERY_REFRESH:
+            state.shouldRefreshQuery = true;
+            break;
+        case QUERY_AUTO_REFRESH:
+            state.autoRefreshCount += 1;
+            break;
+        case QUERY_STOP_AUTO_REFRESH:
+            state.autoRefreshCount -= 1;
+            break;
+        default:
+            break;
+    }
+}
+
+/**
+ * refreshQuery is the execution state of the query management saga
+ * when the query is being executed.
+ */
+export function *refreshQuery(state: ManagedQuerySagaState) {
+    const queryTask = yield fork(runQuery, state);
+    while (queryTask.isRunning()) {
+        // While the query is running, we still need to increment or
+        // decrement the auto-refresh count.
+        yield race({
+            finished: join(queryTask),
+            nextAction: call(processQueryManagementAction, state),
+        });
+    }
+    state.shouldRefreshQuery = false;
+}
+
+/**
+ * waitForNextRefresh is the execution state of the query management saga
+ * when it is waiting to automatically refresh.
+ */
+export function *waitForNextRefresh(state: ManagedQuerySagaState) {
+    // If this query should be auto-refreshed, compute the time until
+    // the query is out of date. If the request is already out of date,
+    // refresh the query immediately.
+    const delayTime = yield call(timeToNextRefresh, state);
+    if (delayTime <= 0) {
+        state.shouldRefreshQuery = true;
+        return;
+    }
+
+    const delayTask = yield fork(delayGenerator, delayTime);
+    while (delayTask.isRunning()) {
+        yield race({
+            finished: join(delayTask),
+            nextAction: call(processQueryManagementAction, state),
+        });
+        // If a request comes in to run the query immediately, or if the
+        // auto-refresh count drops to zero, cancel the delay task.
+        if (state.shouldRefreshQuery || state.autoRefreshCount <= 0) {
+            yield cancel(delayTask);
+            return;
+        }
+    }
+
+    state.shouldRefreshQuery = true;
+}
+
+/**
+ * Calculates the number of milliseconds until the given query needs to be
+ * refreshed.
+ */
+export function *timeToNextRefresh(state: ManagedQuerySagaState) {
+    if (!state.queryCompletedAt) {
+        return 0;
+    }
+
+    let interval: moment.Duration;
+    if (state.lastAttemptFailed) {
+        interval = state.query.retryDelay || DEFAULT_RETRY_DELAY;
+    } else {
+        interval = state.query.refreshInterval || DEFAULT_REFRESH_INTERVAL;
+    }
+
+    // Yielding to moment lets us easily mock time in tests.
+    const now: moment.Moment = yield call(getMoment);
+    const dueAt = state.queryCompletedAt.clone().add(interval);
+    return dueAt.diff(now);
+}
+
+/**
+ * Runs the underlying query of the supplied managed query.
+ *
+ * This task will catch any errors thrown by the query.
+ *
+ * This task is also responsible for putting information about the query into
+ * the query management reducer (the saga itself doesn't use the information in
+ * the reducer; it is provided in order to give visibility to other components
+ * in the system).
+ */
+export function *runQuery(state: ManagedQuerySagaState) {
+    const { id, querySaga } = state.query;
+
+    let err: Error;
+    try {
+        yield put(queryBegin(id));
+        yield call(querySaga);
+    } catch (e) {
+        err = e;
+    }
+
+    // Yielding to moment lets us easily mock time in tests.
+    state.queryCompletedAt = yield call(getMoment);
+    if (err) {
+        state.lastAttemptFailed = true;
+        yield put(queryError(id, err, state.queryCompletedAt));
+    } else {
+        state.lastAttemptFailed = false;
+        yield put(queryComplete(id, state.queryCompletedAt));
+    }
+}
+
+// getMoment is a function that can be dispatched to redux-saga's "call" effect.
+// Saga doesn't like using the bare moment object because moment is also an
+// object and Saga chooses the wrong overload.
+export function getMoment() {
+    return moment();
+}
+
+// delayGenerator wraps the delay function so that it can be forked. Note that
+// redux saga itself does support forking arbitrary promise-returning functions,
+// but redux-saga-test-plan does not.
+// https://github.com/jfairbank/redux-saga-test-plan/issues/139
+function *delayGenerator(delayTime: number) {
+    yield call(delay, delayTime);
+}
+
+/**
+ * Utility that returns true if the provided task is running. Helpful for use
+ * when a task-containing variable may be null.
+ */
+function taskIsRunning(task: Task | null) {
+    return task && task.isRunning();
+}


### PR DESCRIPTION
Infrastructure for a general query manager saga - manages limited
dispatch, timed refresh and error retries for arbitrary queries
expressed as sagas. This is intended to replace the thunk-based
infrastructure for all current queries, excepting the metrics queries
(which are already handled in a saga).

Has the following features:

+ Each query is an object with a unique ID, a saga function which
  expresses the body of the query, and optional refresh and retry delays.
+ Queries can be dispatched with one of two actions:
  + "Refresh", which refreshes the query immediately.
  + "AutoRefresh", which refreshes it periodically on a interval.
  AutoRefresh is reference counted, and is paired with "StopAutoRefresh".
  The intention is that these would be fired in react components when they
  mount and unmount.
+ Only one instance of a query can be running at a time.
+ Error results are stored in a central location by the query manager.
  Individual queries are responsible for storing results in the redux
  store, giving greater flexibility for more complicated queries in the
  future.

Release note: None.