### PR TITLE
storage: deflake TestReplicateQueueDownReplicate

### DIFF
--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -177,7 +178,12 @@ func TestReplicateQueueDownReplicate(t *testing.T) {
 	// using the replicate queue, and to ensure that's the case, the test
 	// cluster needs to be kept in auto replication mode.
 	tc := testcluster.StartTestCluster(t, replicaCount+2,
-		base.TestClusterArgs{ReplicationMode: base.ReplicationAuto},
+		base.TestClusterArgs{
+			ReplicationMode: base.ReplicationAuto,
+			ServerArgs: base.TestServerArgs{
+				ScanMinIdleTime: time.Millisecond,
+			},
+		},
 	)
 	defer tc.Stopper().Stop(context.Background())
 


### PR DESCRIPTION
PR #27441 slowed down this test to the point of flakiness by introducing
a minimum scanner idle interval of one second.

There might be more of these bugs lurking; #27441 updated only very few
tests. Should we set a more aggressive timing by default in
TestCluster/TestServer?

Fixes #27541.

Release note: None