### PR TITLE
pretty: teach the pretty-printer about window functions

### DIFF
--- a/pkg/sql/sem/tree/testdata/pretty/functions.align-deindent.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/functions.align-deindent.golden
@@ -1,0 +1,1058 @@
+1:
+-
+SELECT
+	min(
+		a,
+		b
+	),
+	min(
+		DISTINCT
+		a,
+		b
+	),
+	min(),
+	min() OVER (),
+	min() OVER (
+		ORDER BY
+			x
+	),
+	min() FILTER (
+		WHERE
+			x
+			> 3
+			AND y
+				< 4
+	),
+	min() FILTER (
+		WHERE
+			x
+			> 3
+			AND y
+				< 4
+	) OVER (
+		ORDER BY
+			x
+	),
+	min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+	),
+	min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	),
+	min() OVER (
+		w
+		PARTITION BY
+			a,
+			b
+		ORDER BY
+			x,
+			y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	)
+
+11:
+-----------
+SELECT min(
+		a,
+		b
+       ),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY
+			x
+       ),
+       min() FILTER (
+		WHERE
+			x
+			> 3
+			AND y
+				< 4
+       ),
+       min() FILTER (
+		WHERE
+			x
+			> 3
+			AND y
+				< 4
+       ) OVER (
+		ORDER BY
+			x
+       ),
+       min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		w
+		PARTITION BY
+			a,
+			b
+		ORDER BY
+			x,
+			y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       )
+
+15:
+---------------
+SELECT min(
+		a,
+		b
+       ),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY
+			x
+       ),
+       min() FILTER (
+		WHERE x
+		      > 3
+		  AND y
+		      < 4
+       ),
+       min() FILTER (
+		WHERE x
+		      > 3
+		  AND y
+		      < 4
+       ) OVER (
+		ORDER BY
+			x
+       ),
+       min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		w
+		PARTITION BY
+			a,
+			b
+		ORDER BY
+			x,
+			y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       )
+
+16:
+----------------
+SELECT min(
+		a,
+		b
+       ),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY
+			x
+       ),
+       min() FILTER (
+		WHERE x
+		      > 3
+		  AND y
+		      < 4
+       ),
+       min() FILTER (
+		WHERE x
+		      > 3
+		  AND y
+		      < 4
+       ) OVER (
+		ORDER BY
+			x
+       ),
+       min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       )
+
+17:
+-----------------
+SELECT min(a, b),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY
+			x
+       ),
+       min() FILTER (
+		WHERE x
+		      > 3
+		  AND y
+		      < 4
+       ),
+       min() FILTER (
+		WHERE x
+		      > 3
+		  AND y
+		      < 4
+       ) OVER (
+		ORDER BY
+			x
+       ),
+       min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       )
+
+18:
+------------------
+SELECT min(a, b),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x
+		      > 3
+		  AND y
+		      < 4
+       ),
+       min() FILTER (
+		WHERE x
+		      > 3
+		  AND y
+		      < 4
+       ) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       )
+
+19:
+-------------------
+SELECT min(a, b),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x > 3
+		  AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3
+		  AND y < 4
+       ) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       )
+
+20:
+--------------------
+SELECT min(a, b),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x > 3
+		  AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3
+		  AND y < 4
+       ) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN
+				1 FOLLOWING
+		     AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       )
+
+21:
+---------------------
+SELECT min(a, b),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x > 3
+		  AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3
+		  AND y < 4
+       ) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN
+				1 FOLLOWING
+		     AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       )
+
+22:
+----------------------
+SELECT min(a, b),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x > 3
+		  AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3
+		  AND y < 4
+       ) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN
+				1 FOLLOWING
+		     AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a,
+		             b
+		    ORDER BY x,
+		             y
+		        ROWS BETWEEN
+						1 FOLLOWING
+		             AND
+						1 FOLLOWING
+       )
+
+25:
+-------------------------
+SELECT min(a, b),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x > 3
+		  AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3
+		  AND y < 4
+       ) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN
+				1 FOLLOWING
+		     AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN
+						1 FOLLOWING
+		             AND
+						1 FOLLOWING
+       )
+
+26:
+--------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x > 3
+		  AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3
+		  AND y < 4
+       ) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN
+				1 FOLLOWING
+		     AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN
+						1 FOLLOWING
+		             AND
+						1 FOLLOWING
+       )
+
+27:
+---------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x > 3
+		  AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3
+		  AND y < 4
+       ) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN
+				1 FOLLOWING
+		     AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN
+						1 FOLLOWING
+		             AND
+						1 FOLLOWING
+       )
+
+29:
+-----------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN
+				1 FOLLOWING
+		     AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN
+						1 FOLLOWING
+		             AND
+						1 FOLLOWING
+       )
+
+31:
+-------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN
+				1 FOLLOWING
+		     AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN
+						1 FOLLOWING
+		             AND
+						1 FOLLOWING
+       )
+
+32:
+--------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN 1 FOLLOWING
+		         AND 1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN
+						1 FOLLOWING
+		             AND
+						1 FOLLOWING
+       )
+
+40:
+----------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN 1 FOLLOWING
+		         AND 1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING
+		                 AND 1 FOLLOWING
+       )
+
+41:
+-----------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN UNBOUNDED PRECEDING
+		          AND UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN 1 FOLLOWING
+		         AND 1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING
+		                 AND 1 FOLLOWING
+       )
+
+44:
+--------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN UNBOUNDED PRECEDING
+		          AND UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN 1 FOLLOWING
+		         AND 1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING
+		                 AND 1 FOLLOWING
+       )
+
+48:
+------------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN UNBOUNDED PRECEDING
+		          AND UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING
+		                 AND 1 FOLLOWING
+       )
+
+50:
+--------------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (WHERE x > 3 AND y < 4) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE BETWEEN UNBOUNDED PRECEDING
+		          AND UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING
+		                 AND 1 FOLLOWING
+       )
+
+56:
+--------------------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (WHERE x > 3 AND y < 4) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE BETWEEN UNBOUNDED PRECEDING
+		          AND UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+       )
+
+61:
+-------------------------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (WHERE x > 3 AND y < 4) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE BETWEEN UNBOUNDED PRECEDING
+		          AND UNBOUNDED FOLLOWING
+       ),
+       min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+       )
+
+62:
+--------------------------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN UNBOUNDED PRECEDING
+		          AND UNBOUNDED FOLLOWING
+       ),
+       min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+       )
+
+65:
+-----------------------------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+       ),
+       min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+       )
+
+78:
+------------------------------------------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x),
+       min() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
+       min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+       )
+
+82:
+----------------------------------------------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x),
+       min() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
+       min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+       min() OVER (
+		w PARTITION BY a, b ORDER BY x, y ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+       )
+
+94:
+----------------------------------------------------------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x),
+       min() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
+       min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+       min() OVER (w PARTITION BY a, b ORDER BY x, y ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+
+393:
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+SELECT min(a, b), min(DISTINCT a, b), min(), min() OVER (), min() OVER (ORDER BY x), min() FILTER (WHERE x > 3 AND y < 4), min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x), min() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING), min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING), min() OVER (w PARTITION BY a, b ORDER BY x, y ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)

--- a/pkg/sql/sem/tree/testdata/pretty/functions.align-only.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/functions.align-only.golden
@@ -1,0 +1,1113 @@
+1:
+-
+SELECT
+	min(
+		a,
+		b
+	),
+	min(
+		DISTINCT
+		a,
+		b
+	),
+	min(),
+	min() OVER (),
+	min() OVER (
+		ORDER BY
+			x
+	),
+	min() FILTER (
+		WHERE
+			x
+			> 3
+			AND y
+				< 4
+	),
+	min() FILTER (
+		WHERE
+			x
+			> 3
+			AND y
+				< 4
+	) OVER (
+		ORDER BY
+			x
+	),
+	min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+	),
+	min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	),
+	min() OVER (
+		w
+		PARTITION BY
+			a,
+			b
+		ORDER BY
+			x,
+			y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	)
+
+11:
+-----------
+SELECT min(
+		a,
+		b
+       ),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY
+			x
+       ),
+       min() FILTER (
+		WHERE
+			x
+			> 3
+			AND y
+				< 4
+       ),
+       min() FILTER (
+		WHERE
+			x
+			> 3
+			AND y
+				< 4
+       ) OVER (
+		ORDER BY
+			x
+       ),
+       min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		w
+		PARTITION BY
+			a,
+			b
+		ORDER BY
+			x,
+			y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       )
+
+15:
+---------------
+SELECT min(
+		a,
+		b
+       ),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY
+			x
+       ),
+       min() FILTER (
+		WHERE x
+		      > 3
+		      AND y
+				< 4
+       ),
+       min() FILTER (
+		WHERE x
+		      > 3
+		      AND y
+				< 4
+       ) OVER (
+		ORDER BY
+			x
+       ),
+       min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		w
+		PARTITION BY
+			a,
+			b
+		ORDER BY
+			x,
+			y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       )
+
+16:
+----------------
+SELECT min(
+		a,
+		b
+       ),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY
+			x
+       ),
+       min() FILTER (
+		WHERE x
+		      > 3
+		      AND y
+				< 4
+       ),
+       min() FILTER (
+		WHERE x
+		      > 3
+		      AND y
+				< 4
+       ) OVER (
+		ORDER BY
+			x
+       ),
+       min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       )
+
+17:
+-----------------
+SELECT min(a, b),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY
+			x
+       ),
+       min() FILTER (
+		WHERE x
+		      > 3
+		      AND y
+				< 4
+       ),
+       min() FILTER (
+		WHERE x
+		      > 3
+		      AND y
+				< 4
+       ) OVER (
+		ORDER BY
+			x
+       ),
+       min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       )
+
+18:
+------------------
+SELECT min(a, b),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x
+		      > 3
+		      AND y
+				< 4
+       ),
+       min() FILTER (
+		WHERE x
+		      > 3
+		      AND y
+				< 4
+       ) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       )
+
+19:
+-------------------
+SELECT min(a, b),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x > 3
+		      AND y
+				< 4
+       ),
+       min() FILTER (
+		WHERE x > 3
+		      AND y
+				< 4
+       ) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       )
+
+20:
+--------------------
+SELECT min(a, b),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x > 3
+		      AND y
+				< 4
+       ),
+       min() FILTER (
+		WHERE x > 3
+		      AND y
+				< 4
+       ) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN
+				1 FOLLOWING
+		     AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       )
+
+21:
+---------------------
+SELECT min(a, b),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x > 3
+		      AND y
+				< 4
+       ),
+       min() FILTER (
+		WHERE x > 3
+		      AND y
+				< 4
+       ) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN
+				1 FOLLOWING
+		     AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+       )
+
+22:
+----------------------
+SELECT min(a, b),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x > 3
+		      AND y
+				< 4
+       ),
+       min() FILTER (
+		WHERE x > 3
+		      AND y
+				< 4
+       ) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN
+				1 FOLLOWING
+		     AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a,
+		             b
+		    ORDER BY x,
+		             y
+		        ROWS BETWEEN
+						1 FOLLOWING
+		             AND
+						1 FOLLOWING
+       )
+
+23:
+-----------------------
+SELECT min(a, b),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x > 3
+		      AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3
+		      AND y < 4
+       ) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN
+				1 FOLLOWING
+		     AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a,
+		             b
+		    ORDER BY x,
+		             y
+		        ROWS BETWEEN
+						1 FOLLOWING
+		             AND
+						1 FOLLOWING
+       )
+
+25:
+-------------------------
+SELECT min(a, b),
+       min(
+		DISTINCT
+		a,
+		b
+       ),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x > 3
+		      AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3
+		      AND y < 4
+       ) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN
+				1 FOLLOWING
+		     AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN
+						1 FOLLOWING
+		             AND
+						1 FOLLOWING
+       )
+
+26:
+--------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x > 3
+		      AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3
+		      AND y < 4
+       ) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN
+				1 FOLLOWING
+		     AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN
+						1 FOLLOWING
+		             AND
+						1 FOLLOWING
+       )
+
+27:
+---------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x > 3
+		      AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3
+		      AND y < 4
+       ) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN
+				1 FOLLOWING
+		     AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN
+						1 FOLLOWING
+		             AND
+						1 FOLLOWING
+       )
+
+29:
+-----------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (
+		ORDER BY x
+       ),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN
+				1 FOLLOWING
+		     AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN
+						1 FOLLOWING
+		             AND
+						1 FOLLOWING
+       )
+
+31:
+-------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN
+				1 FOLLOWING
+		     AND
+				1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN
+						1 FOLLOWING
+		             AND
+						1 FOLLOWING
+       )
+
+32:
+--------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN 1 FOLLOWING
+		         AND 1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN
+						1 FOLLOWING
+		             AND
+						1 FOLLOWING
+       )
+
+40:
+----------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN
+				UNBOUNDED PRECEDING
+		      AND
+				UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN 1 FOLLOWING
+		         AND 1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING
+		                 AND 1 FOLLOWING
+       )
+
+41:
+-----------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN UNBOUNDED PRECEDING
+		          AND UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN 1 FOLLOWING
+		         AND 1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING
+		                 AND 1 FOLLOWING
+       )
+
+44:
+--------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN UNBOUNDED PRECEDING
+		          AND UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN 1 FOLLOWING
+		         AND 1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING
+		                 AND 1 FOLLOWING
+       )
+
+48:
+------------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (
+		WHERE x > 3 AND y < 4
+       ) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN UNBOUNDED PRECEDING
+		          AND UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING
+		                 AND 1 FOLLOWING
+       )
+
+50:
+--------------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (WHERE x > 3 AND y < 4) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE BETWEEN UNBOUNDED PRECEDING
+		          AND UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING
+		                 AND 1 FOLLOWING
+       )
+
+56:
+--------------------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (WHERE x > 3 AND y < 4) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE BETWEEN UNBOUNDED PRECEDING
+		          AND UNBOUNDED FOLLOWING
+       ),
+       min() OVER (
+		ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+       ),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+       )
+
+61:
+-------------------------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (WHERE x > 3 AND y < 4) OVER (
+		ORDER BY x
+       ),
+       min() OVER (
+		RANGE BETWEEN UNBOUNDED PRECEDING
+		          AND UNBOUNDED FOLLOWING
+       ),
+       min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+       )
+
+62:
+--------------------------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN UNBOUNDED PRECEDING
+		          AND UNBOUNDED FOLLOWING
+       ),
+       min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+       )
+
+65:
+-----------------------------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x),
+       min() OVER (
+		RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+       ),
+       min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+       )
+
+78:
+------------------------------------------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x),
+       min() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
+       min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+       min() OVER (
+		             w
+		PARTITION BY a, b
+		    ORDER BY x, y
+		        ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+       )
+
+82:
+----------------------------------------------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x),
+       min() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
+       min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+       min() OVER (
+		w PARTITION BY a, b ORDER BY x, y ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+       )
+
+94:
+----------------------------------------------------------------------------------------------
+SELECT min(a, b),
+       min(DISTINCT a, b),
+       min(),
+       min() OVER (),
+       min() OVER (ORDER BY x),
+       min() FILTER (WHERE x > 3 AND y < 4),
+       min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x),
+       min() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
+       min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+       min() OVER (w PARTITION BY a, b ORDER BY x, y ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+
+393:
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+SELECT min(a, b), min(DISTINCT a, b), min(), min() OVER (), min() OVER (ORDER BY x), min() FILTER (WHERE x > 3 AND y < 4), min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x), min() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING), min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING), min() OVER (w PARTITION BY a, b ORDER BY x, y ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)

--- a/pkg/sql/sem/tree/testdata/pretty/functions.ref.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/functions.ref.golden
@@ -1,0 +1,845 @@
+1:
+-
+SELECT
+	min(
+		a,
+		b
+	),
+	min(
+		DISTINCT
+		a,
+		b
+	),
+	min(),
+	min() OVER (),
+	min() OVER (
+		ORDER BY
+			x
+	),
+	min() FILTER (
+		WHERE
+			x
+			> 3
+			AND y
+				< 4
+	),
+	min() FILTER (
+		WHERE
+			x
+			> 3
+			AND y
+				< 4
+	) OVER (
+		ORDER BY
+			x
+	),
+	min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+	),
+	min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	),
+	min() OVER (
+		w
+		PARTITION BY
+			a,
+			b
+		ORDER BY
+			x,
+			y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	)
+
+14:
+--------------
+SELECT
+	min(a, b),
+	min(
+		DISTINCT
+		a,
+		b
+	),
+	min(),
+	min() OVER (),
+	min() OVER (
+		ORDER BY
+			x
+	),
+	min() FILTER (
+		WHERE
+			x
+			> 3
+			AND y
+				< 4
+	),
+	min() FILTER (
+		WHERE
+			x
+			> 3
+			AND y
+				< 4
+	) OVER (
+		ORDER BY
+			x
+	),
+	min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+	),
+	min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	),
+	min() OVER (
+		w
+		PARTITION BY
+			a,
+			b
+		ORDER BY
+			x,
+			y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	)
+
+16:
+----------------
+SELECT
+	min(a, b),
+	min(
+		DISTINCT
+		a,
+		b
+	),
+	min(),
+	min() OVER (),
+	min() OVER (
+		ORDER BY
+			x
+	),
+	min() FILTER (
+		WHERE
+			x
+			> 3
+			AND y
+				< 4
+	),
+	min() FILTER (
+		WHERE
+			x
+			> 3
+			AND y
+				< 4
+	) OVER (
+		ORDER BY
+			x
+	),
+	min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+	),
+	min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	),
+	min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	)
+
+17:
+-----------------
+SELECT
+	min(a, b),
+	min(
+		DISTINCT
+		a,
+		b
+	),
+	min(),
+	min() OVER (),
+	min() OVER (
+		ORDER BY
+			x
+	),
+	min() FILTER (
+		WHERE
+			x > 3
+			AND y
+				< 4
+	),
+	min() FILTER (
+		WHERE
+			x > 3
+			AND y
+				< 4
+	) OVER (
+		ORDER BY
+			x
+	),
+	min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+	),
+	min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	),
+	min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	)
+
+18:
+------------------
+SELECT
+	min(a, b),
+	min(
+		DISTINCT
+		a,
+		b
+	),
+	min(),
+	min() OVER (),
+	min() OVER (
+		ORDER BY x
+	),
+	min() FILTER (
+		WHERE
+			x > 3
+			AND y
+				< 4
+	),
+	min() FILTER (
+		WHERE
+			x > 3
+			AND y
+				< 4
+	) OVER (
+		ORDER BY x
+	),
+	min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+	),
+	min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	),
+	min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	)
+
+21:
+---------------------
+SELECT
+	min(a, b),
+	min(
+		DISTINCT
+		a,
+		b
+	),
+	min(),
+	min() OVER (),
+	min() OVER (
+		ORDER BY x
+	),
+	min() FILTER (
+		WHERE
+			x > 3
+			AND y < 4
+	),
+	min() FILTER (
+		WHERE
+			x > 3
+			AND y < 4
+	) OVER (
+		ORDER BY x
+	),
+	min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+	),
+	min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	),
+	min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	)
+
+23:
+-----------------------
+SELECT
+	min(a, b),
+	min(DISTINCT a, b),
+	min(),
+	min() OVER (),
+	min() OVER (
+		ORDER BY x
+	),
+	min() FILTER (
+		WHERE
+			x > 3
+			AND y < 4
+	),
+	min() FILTER (
+		WHERE
+			x > 3
+			AND y < 4
+	) OVER (
+		ORDER BY x
+	),
+	min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+	),
+	min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	),
+	min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	)
+
+24:
+------------------------
+SELECT
+	min(a, b),
+	min(DISTINCT a, b),
+	min(),
+	min() OVER (),
+	min() OVER (
+		ORDER BY x
+	),
+	min() FILTER (
+		WHERE
+			x > 3
+			AND y < 4
+	),
+	min() FILTER (
+		WHERE
+			x > 3
+			AND y < 4
+	) OVER (ORDER BY x),
+	min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+	),
+	min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	),
+	min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	)
+
+27:
+---------------------------
+SELECT
+	min(a, b),
+	min(DISTINCT a, b),
+	min(),
+	min() OVER (),
+	min() OVER (
+		ORDER BY x
+	),
+	min() FILTER (
+		WHERE
+			x > 3 AND y < 4
+	),
+	min() FILTER (
+		WHERE
+			x > 3 AND y < 4
+	) OVER (ORDER BY x),
+	min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+	),
+	min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	),
+	min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	)
+
+28:
+----------------------------
+SELECT
+	min(a, b),
+	min(DISTINCT a, b),
+	min(),
+	min() OVER (),
+	min() OVER (ORDER BY x),
+	min() FILTER (
+		WHERE
+			x > 3 AND y < 4
+	),
+	min() FILTER (
+		WHERE
+			x > 3 AND y < 4
+	) OVER (ORDER BY x),
+	min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+	),
+	min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	),
+	min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	)
+
+29:
+-----------------------------
+SELECT
+	min(a, b),
+	min(DISTINCT a, b),
+	min(),
+	min() OVER (),
+	min() OVER (ORDER BY x),
+	min() FILTER (
+		WHERE x > 3 AND y < 4
+	),
+	min() FILTER (
+		WHERE x > 3 AND y < 4
+	) OVER (ORDER BY x),
+	min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+	),
+	min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	),
+	min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	)
+
+41:
+-----------------------------------------
+SELECT
+	min(a, b),
+	min(DISTINCT a, b),
+	min(),
+	min() OVER (),
+	min() OVER (ORDER BY x),
+	min() FILTER (WHERE x > 3 AND y < 4),
+	min() FILTER (
+		WHERE x > 3 AND y < 4
+	) OVER (ORDER BY x),
+	min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+	),
+	min() OVER (
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	),
+	min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN
+				1 FOLLOWING
+			AND
+				1 FOLLOWING
+	)
+
+47:
+-----------------------------------------------
+SELECT
+	min(a, b),
+	min(DISTINCT a, b),
+	min(),
+	min() OVER (),
+	min() OVER (ORDER BY x),
+	min() FILTER (WHERE x > 3 AND y < 4),
+	min() FILTER (WHERE x > 3 AND y < 4) OVER (
+		ORDER BY x
+	),
+	min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+	),
+	min() OVER (
+		ROWS
+			BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+	),
+	min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+	)
+
+48:
+------------------------------------------------
+SELECT
+	min(a, b),
+	min(DISTINCT a, b),
+	min(),
+	min() OVER (),
+	min() OVER (ORDER BY x),
+	min() FILTER (WHERE x > 3 AND y < 4),
+	min() FILTER (WHERE x > 3 AND y < 4) OVER (
+		ORDER BY x
+	),
+	min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+	),
+	min() OVER (
+		ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+	),
+	min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+	)
+
+58:
+----------------------------------------------------------
+SELECT
+	min(a, b),
+	min(DISTINCT a, b),
+	min(),
+	min() OVER (),
+	min() OVER (ORDER BY x),
+	min() FILTER (WHERE x > 3 AND y < 4),
+	min() FILTER (WHERE x > 3 AND y < 4) OVER (
+		ORDER BY x
+	),
+	min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+	),
+	min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+	min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+	)
+
+59:
+-----------------------------------------------------------
+SELECT
+	min(a, b),
+	min(DISTINCT a, b),
+	min(),
+	min() OVER (),
+	min() OVER (ORDER BY x),
+	min() FILTER (WHERE x > 3 AND y < 4),
+	min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x),
+	min() OVER (
+		RANGE
+			BETWEEN
+				UNBOUNDED PRECEDING
+			AND
+				UNBOUNDED FOLLOWING
+	),
+	min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+	min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+	)
+
+63:
+---------------------------------------------------------------
+SELECT
+	min(a, b),
+	min(DISTINCT a, b),
+	min(),
+	min() OVER (),
+	min() OVER (ORDER BY x),
+	min() FILTER (WHERE x > 3 AND y < 4),
+	min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x),
+	min() OVER (
+		RANGE
+			BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+	),
+	min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+	min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+	)
+
+65:
+-----------------------------------------------------------------
+SELECT
+	min(a, b),
+	min(DISTINCT a, b),
+	min(),
+	min() OVER (),
+	min() OVER (ORDER BY x),
+	min() FILTER (WHERE x > 3 AND y < 4),
+	min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x),
+	min() OVER (
+		RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+	),
+	min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+	min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+	)
+
+75:
+---------------------------------------------------------------------------
+SELECT
+	min(a, b),
+	min(DISTINCT a, b),
+	min(),
+	min() OVER (),
+	min() OVER (ORDER BY x),
+	min() FILTER (WHERE x > 3 AND y < 4),
+	min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x),
+	min() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
+	min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+	min() OVER (
+		w
+		PARTITION BY
+			a, b
+		ORDER BY
+			x, y
+		ROWS
+			BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+	)
+
+82:
+----------------------------------------------------------------------------------
+SELECT
+	min(a, b),
+	min(DISTINCT a, b),
+	min(),
+	min() OVER (),
+	min() OVER (ORDER BY x),
+	min() FILTER (WHERE x > 3 AND y < 4),
+	min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x),
+	min() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
+	min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+	min() OVER (
+		w PARTITION BY a, b ORDER BY x, y ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+	)
+
+91:
+-------------------------------------------------------------------------------------------
+SELECT
+	min(a, b),
+	min(DISTINCT a, b),
+	min(),
+	min() OVER (),
+	min() OVER (ORDER BY x),
+	min() FILTER (WHERE x > 3 AND y < 4),
+	min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x),
+	min() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
+	min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+	min() OVER (w PARTITION BY a, b ORDER BY x, y ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+
+390:
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+SELECT
+	min(a, b), min(DISTINCT a, b), min(), min() OVER (), min() OVER (ORDER BY x), min() FILTER (WHERE x > 3 AND y < 4), min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x), min() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING), min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING), min() OVER (w PARTITION BY a, b ORDER BY x, y ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+
+393:
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+SELECT min(a, b), min(DISTINCT a, b), min(), min() OVER (), min() OVER (ORDER BY x), min() FILTER (WHERE x > 3 AND y < 4), min() FILTER (WHERE x > 3 AND y < 4) OVER (ORDER BY x), min() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING), min() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING), min() OVER (w PARTITION BY a, b ORDER BY x, y ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)

--- a/pkg/sql/sem/tree/testdata/pretty/functions.sql
+++ b/pkg/sql/sem/tree/testdata/pretty/functions.sql
@@ -1,0 +1,11 @@
+select
+	min(a,b),
+	min(distinct a,b),
+	min(),
+	min() over (),
+	min() over (order by x),
+	min() filter (where x >3 and y < 4),
+	min() filter (where x >3 and y < 4) over (order by x),
+	min() over (range between unbounded preceding and unbounded following),
+	min() over (rows between 1 following and 1 following),
+	min() over (w partition by a,b order by x,y rows between 1 following and 1 following)


### PR DESCRIPTION
First commits from #27694 and #27696.

This was previously missing entirely.

This patch also ensures that the behavior is sane if a function has
zero arguments or an empty window clause.