### PR TITLE
distsql: refactor hashJoiner to implement RowSource

### DIFF
--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -72,9 +72,14 @@ func TestHashJoiner(t *testing.T) {
 
 	for _, c := range testCases {
 		// testFunc is a helper function that runs a hashJoin with the current
-		// test case after running the provided setup function.
-		testFunc := func(t *testing.T, setup func(h *hashJoiner)) error {
-			for _, side := range [2]joinSide{leftSide, rightSide} {
+		// test case.
+		// flowCtxSetup can optionally be provided to set up additional testing
+		// knobs in the flowCtx before instantiating a hashJoiner and hjSetup can
+		// optionally be provided to modify the hashJoiner after instantiation but
+		// before Run().
+		testFunc := func(t *testing.T, flowCtxSetup func(f *FlowCtx), hjSetup func(h *hashJoiner)) error {
+			side := rightSide
+			for i := 0; i < 2; i++ {
 				leftInput := NewRowBuffer(c.leftTypes, c.leftInput, RowBufferArgs{})
 				rightInput := NewRowBuffer(c.rightTypes, c.rightInput, RowBufferArgs{})
 				out := &RowBuffer{}
@@ -83,6 +88,9 @@ func TestHashJoiner(t *testing.T) {
 					EvalCtx:     evalCtx,
 					TempStorage: tempEngine,
 					diskMonitor: &diskMonitor,
+				}
+				if flowCtxSetup != nil {
+					flowCtxSetup(&flowCtx)
 				}
 				post := PostProcessSpec{Projection: true, OutputColumns: c.outCols}
 				spec := &HashJoinerSpec{
@@ -96,9 +104,15 @@ func TestHashJoiner(t *testing.T) {
 					return err
 				}
 				outTypes := h.OutputTypes()
-				setup(h)
-				h.forcedStoredSide = &side
+				if hjSetup != nil {
+					hjSetup(h)
+				}
+				// Only force the other side after running the buffering logic once.
+				if i == 1 {
+					h.forcedStoredSide = &side
+				}
 				h.Run(context.Background(), nil /* wg */)
+				side = otherSide(h.storedSide)
 
 				if !out.ProducerClosed {
 					return errors.New("output RowReceiver not closed")
@@ -114,7 +128,7 @@ func TestHashJoiner(t *testing.T) {
 		// Run test with a variety of initial buffer sizes.
 		for _, initialBuffer := range []int64{0, 32, 64, 128, 1024 * 1024} {
 			t.Run(fmt.Sprintf("InitialBuffer=%d", initialBuffer), func(t *testing.T) {
-				if err := testFunc(t, func(h *hashJoiner) {
+				if err := testFunc(t, nil, func(h *hashJoiner) {
 					h.initialBufferSize = initialBuffer
 				}); err != nil {
 					t.Fatal(err)
@@ -125,10 +139,14 @@ func TestHashJoiner(t *testing.T) {
 		// Run tests with a probability of the run failing with a memory error.
 		// These verify that the hashJoiner falls back to disk correctly in all
 		// cases.
-		for _, memFailPoint := range []hashJoinPhase{buffer, build} {
+		for _, memFailPoint := range []hashJoinerState{hjBuilding, hjConsumingStoredSide} {
+			name := "Building"
+			if memFailPoint == hjConsumingStoredSide {
+				name = "ConsumingStoredSide"
+			}
 			for i := 0; i < 5; i++ {
-				t.Run(fmt.Sprintf("MemFailPoint=%s", memFailPoint), func(t *testing.T) {
-					if err := testFunc(t, func(h *hashJoiner) {
+				t.Run(fmt.Sprintf("MemFailPoint=%s", name), func(t *testing.T) {
+					if err := testFunc(t, nil, func(h *hashJoiner) {
 						h.testingKnobMemFailPoint = memFailPoint
 						h.testingKnobFailProbability = 0.5
 					}); err != nil {
@@ -141,9 +159,9 @@ func TestHashJoiner(t *testing.T) {
 		// Run test with a variety of memory limits.
 		for _, memLimit := range []int64{1, 256, 512, 1024, 2048} {
 			t.Run(fmt.Sprintf("MemLimit=%d", memLimit), func(t *testing.T) {
-				if err := testFunc(t, func(h *hashJoiner) {
-					h.flowCtx.testingKnobs.MemoryLimitBytes = memLimit
-				}); err != nil {
+				if err := testFunc(t, func(f *FlowCtx) {
+					f.testingKnobs.MemoryLimitBytes = memLimit
+				}, nil); err != nil {
 					t.Fatal(err)
 				}
 			})
@@ -458,6 +476,10 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 		Settings: st,
 		EvalCtx:  evalCtx,
 	}
+
+	// Disable external storage for this test to avoid initializing temp storage
+	// infrastructure.
+	settingUseTempStorageJoins.Override(&st.SV, false)
 
 	post := PostProcessSpec{Projection: true, OutputColumns: outCols}
 	h, err := newHashJoiner(&flowCtx, 0 /* processorID */, &spec, leftInput, rightInput, &post, out)


### PR DESCRIPTION
Closes #26843

This change includes some additional improvements:
    - Construct a hashRowContainer early. We would previously consume a
      whole side in the buffer phase then construct a hashRowContainer,
      meaning we would have to re-encode datums to construct buckets.
      If we know we will store a certain side and have not yet fully
      consumed that side, we can avoid this re-encoding of all remaining
      rows by directly inserting into a hashRowContainer.
    - Remove unnecessary copies. During a check for nulls in equality
      columns, we would previously copy a row if it had no nulls to be
      used later. This copy is unnecessary as rows are already copied by
      the underlying row container.
    - Fix a potential memory error when building the sored side.

Release note: None

Microbenchmarks show a significant improvement in allocations but nothing really in latency (expected since the microbenchmark doesn't use `RowChannel`s):
```
BENCHES=BenchmarkHashJoiner 'TESTFLAGS=-count 10 -benchmem'
name                                 old time/op    new time/op    delta
HashJoiner/spill=true/rows=256-8       4.72ms ±59%    4.52ms ±62%     ~     (p=0.796 n=10+10)
HashJoiner/spill=true/rows=4096-8      44.1ms ±53%    44.3ms ±50%     ~     (p=1.000 n=10+10)
HashJoiner/spill=true/rows=65536-8      262ms ± 9%     242ms ± 8%   -7.83%  (p=0.011 n=9+9)
HashJoiner/spill=false/rows=0-8        6.08µs ±15%    3.19µs ± 4%  -47.58%  (p=0.000 n=10+10)
HashJoiner/spill=false/rows=4-8        9.41µs ± 9%    9.67µs ± 8%     ~     (p=0.218 n=10+10)
HashJoiner/spill=false/rows=16-8       19.2µs ± 4%    19.3µs ± 4%     ~     (p=0.739 n=10+10)
HashJoiner/spill=false/rows=256-8       218µs ± 2%     217µs ± 2%     ~     (p=0.631 n=10+10)
HashJoiner/spill=false/rows=4096-8     3.49ms ± 1%    3.51ms ± 2%     ~     (p=0.247 n=10+10)
HashJoiner/spill=false/rows=65536-8    66.5ms ± 6%    67.5ms ± 2%     ~     (p=0.190 n=10+10)

name                                 old speed      new speed      delta
HashJoiner/spill=true/rows=256-8      847kB/s ±49%   911kB/s ±59%     ~     (p=0.779 n=9+9)
HashJoiner/spill=true/rows=4096-8    1.68MB/s ±87%  1.63MB/s ±80%     ~     (p=0.988 n=10+10)
HashJoiner/spill=true/rows=65536-8   4.01MB/s ± 9%  4.35MB/s ± 7%   +8.31%  (p=0.011 n=9+9)
HashJoiner/spill=false/rows=4-8      6.82MB/s ± 8%  6.64MB/s ± 8%     ~     (p=0.225 n=10+10)
HashJoiner/spill=false/rows=16-8     13.3MB/s ± 4%  13.2MB/s ± 4%     ~     (p=0.697 n=10+10)
HashJoiner/spill=false/rows=256-8    18.8MB/s ± 2%  18.8MB/s ± 2%     ~     (p=0.591 n=10+10)
HashJoiner/spill=false/rows=4096-8   18.8MB/s ± 1%  18.7MB/s ± 2%     ~     (p=0.256 n=10+10)
HashJoiner/spill=false/rows=65536-8  15.8MB/s ± 6%  15.5MB/s ± 2%     ~     (p=0.190 n=10+10)

name                                 old alloc/op   new alloc/op   delta
HashJoiner/spill=true/rows=256-8       45.4kB ± 0%    22.6kB ± 0%  -50.25%  (p=0.000 n=9+7)
HashJoiner/spill=true/rows=4096-8       790kB ± 0%     399kB ± 0%  -49.57%  (p=0.000 n=10+9)
HashJoiner/spill=true/rows=65536-8     12.7MB ± 0%     6.5MB ± 0%  -49.34%  (p=0.000 n=9+9)
HashJoiner/spill=false/rows=0-8        4.69kB ± 0%    4.90kB ± 0%   +4.44%  (p=0.000 n=10+10)
HashJoiner/spill=false/rows=4-8        8.05kB ± 0%    8.28kB ± 0%   +2.80%  (p=0.000 n=10+10)
HashJoiner/spill=false/rows=16-8       11.2kB ± 0%    10.7kB ± 0%   -4.85%  (p=0.000 n=8+7)
HashJoiner/spill=false/rows=256-8      92.5kB ± 0%    68.9kB ± 0%  -25.51%  (p=0.000 n=10+10)
HashJoiner/spill=false/rows=4096-8     1.39MB ± 0%    1.00MB ± 0%  -28.21%  (p=0.000 n=9+10)
HashJoiner/spill=false/rows=65536-8    22.3MB ± 0%    16.0MB ± 0%  -28.26%  (p=0.000 n=10+10)

name                                 old allocs/op  new allocs/op  delta
HashJoiner/spill=true/rows=256-8          850 ± 0%       826 ± 0%   -2.82%  (p=0.000 n=10+10)
HashJoiner/spill=true/rows=4096-8       12.9k ± 0%     12.4k ± 0%   -3.91%  (p=0.000 n=10+10)
HashJoiner/spill=true/rows=65536-8       206k ± 0%      198k ± 0%   -3.97%  (p=0.000 n=10+9)
HashJoiner/spill=false/rows=0-8          18.0 ± 0%      21.0 ± 0%  +16.67%  (p=0.000 n=10+10)
HashJoiner/spill=false/rows=4-8          35.0 ± 0%      39.0 ± 0%  +11.43%  (p=0.000 n=10+10)
HashJoiner/spill=false/rows=16-8         62.0 ± 0%      65.0 ± 0%   +4.84%  (p=0.000 n=10+10)
HashJoiner/spill=false/rows=256-8         593 ± 0%       566 ± 0%   -4.55%  (p=0.000 n=10+10)
HashJoiner/spill=false/rows=4096-8      8.89k ± 0%     8.38k ± 0%   -5.70%  (p=0.000 n=10+10)
HashJoiner/spill=false/rows=65536-8      142k ± 0%      134k ± 0%   -5.78%  (p=0.000 n=10+10)
```

Large-scale tests with a 4-node cluster don't really show an improvement which is kind of surprising because the query I was testing with was a `hashJoin` followed by an `aggregator` on each node. This change should remove a `RowChannel` between the `hashJoiner` and `aggregator` in this case. Might look more into this.