### PR TITLE
opt: add tpcc-no-stats test

### DIFF
--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -374,8 +374,8 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 project
  ├── columns: c_discount:16(decimal) c_last:6(string) c_credit:14(string)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=6.80272109e-07]
- ├── cost: 8.63945578e-07
+ ├── stats: [rows=2.9154519e-06]
+ ├── cost: 3.70262391e-06
  ├── key: ()
  ├── fd: ()-->(6,14,16)
  ├── prune: (6,14,16)
@@ -383,8 +383,8 @@ project
       ├── columns: customer.c_id:1(int!null) customer.c_d_id:2(int!null) customer.c_w_id:3(int!null) customer.c_last:6(string) customer.c_credit:14(string) customer.c_discount:16(decimal)
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
-      ├── stats: [rows=6.80272109e-07, distinct(1)=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07]
-      ├── cost: 8.63945578e-07
+      ├── stats: [rows=2.9154519e-06, distinct(1)=2.9154519e-06, distinct(2)=2.9154519e-06, distinct(3)=2.9154519e-06]
+      ├── cost: 3.70262391e-06
       ├── key: ()
       ├── fd: ()-->(1-3,6,14,16)
       ├── prune: (6,14,16)
@@ -415,8 +415,8 @@ ORDER BY s_i_id
 ----
 project
  ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string) s_dist_05:8(string)
- ├── stats: [rows=5]
- ├── cost: 6.25
+ ├── stats: [rows=0.0102040816]
+ ├── cost: 0.012755102
  ├── key: (1)
  ├── fd: (1)-->(3,8,14-17)
  ├── ordering: +1
@@ -425,8 +425,8 @@ project
  └── scan stock
       ├── columns: stock.s_i_id:1(int!null) stock.s_w_id:2(int!null) stock.s_quantity:3(int) stock.s_dist_05:8(string) stock.s_ytd:14(int) stock.s_order_cnt:15(int) stock.s_remote_cnt:16(int) stock.s_data:17(string)
       ├── constraint: /2/1: [/4/900 - /4/900] [/4/1000 - /4/1000] [/4/1100 - /4/1100] [/4/1400 - /4/1400] [/4/1500 - /4/1500]
-      ├── stats: [rows=5, distinct(1)=5, distinct(2)=1]
-      ├── cost: 6.25
+      ├── stats: [rows=0.0102040816, distinct(1)=0.0102040816, distinct(2)=0.0102040816]
+      ├── cost: 0.012755102
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3,8,14-17)
       ├── ordering: +1 opt(2)
@@ -450,8 +450,8 @@ ORDER BY c_first ASC
 ----
 project
  ├── columns: c_id:1(int!null)
- ├── stats: [rows=6.80272109e-07]
- ├── cost: 7.4829932e-07
+ ├── stats: [rows=2.9154519e-06]
+ ├── cost: 3.20699708e-06
  ├── key: (1)
  ├── fd: (1)-->(4)
  ├── ordering: +4
@@ -459,8 +459,8 @@ project
  └── scan customer@customer_idx
       ├── columns: customer.c_id:1(int!null) customer.c_d_id:2(int!null) customer.c_w_id:3(int!null) customer.c_first:4(string) customer.c_last:6(string!null)
       ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
-      ├── stats: [rows=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07, distinct(6)=6.80272109e-07]
-      ├── cost: 7.4829932e-07
+      ├── stats: [rows=2.9154519e-06, distinct(2)=2.9154519e-06, distinct(3)=2.9154519e-06, distinct(6)=2.9154519e-06]
+      ├── cost: 3.20699708e-06
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4)
       ├── ordering: +4 opt(2,3,6)
@@ -484,8 +484,8 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 project
  ├── columns: c_balance:17(decimal) c_first:4(string) c_middle:5(string) c_last:6(string)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=6.80272109e-07]
- ├── cost: 8.70748299e-07
+ ├── stats: [rows=2.9154519e-06]
+ ├── cost: 3.73177843e-06
  ├── key: ()
  ├── fd: ()-->(4-6,17)
  ├── prune: (4-6,17)
@@ -493,8 +493,8 @@ project
       ├── columns: customer.c_id:1(int!null) customer.c_d_id:2(int!null) customer.c_w_id:3(int!null) customer.c_first:4(string) customer.c_middle:5(string) customer.c_last:6(string) customer.c_balance:17(decimal)
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
-      ├── stats: [rows=6.80272109e-07, distinct(1)=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07]
-      ├── cost: 8.70748299e-07
+      ├── stats: [rows=2.9154519e-06, distinct(1)=2.9154519e-06, distinct(2)=2.9154519e-06, distinct(3)=2.9154519e-06]
+      ├── cost: 3.73177843e-06
       ├── key: ()
       ├── fd: ()-->(1-6,17)
       ├── prune: (4-6,17)
@@ -508,16 +508,16 @@ ORDER BY c_first ASC
 ----
 project
  ├── columns: c_id:1(int!null) c_balance:17(decimal) c_first:4(string) c_middle:5(string)
- ├── stats: [rows=6.80272109e-07]
- ├── cost: 3.66666667e-06
+ ├── stats: [rows=2.9154519e-06]
+ ├── cost: 1.57142857e-05
  ├── key: (1)
  ├── fd: (1)-->(4,5,17)
  ├── ordering: +4
  ├── prune: (1,4,5,17)
  └── index-join customer
       ├── columns: customer.c_id:1(int!null) customer.c_d_id:2(int!null) customer.c_w_id:3(int!null) customer.c_first:4(string) customer.c_middle:5(string) customer.c_last:6(string!null) customer.c_balance:17(decimal)
-      ├── stats: [rows=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07, distinct(6)=6.80272109e-07]
-      ├── cost: 3.66666667e-06
+      ├── stats: [rows=2.9154519e-06, distinct(2)=2.9154519e-06, distinct(3)=2.9154519e-06, distinct(6)=2.9154519e-06]
+      ├── cost: 1.57142857e-05
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4,5,17)
       ├── ordering: +4 opt(2,3,6)
@@ -526,8 +526,8 @@ project
       └── scan customer@customer_idx
            ├── columns: customer.c_id:1(int!null) customer.c_d_id:2(int!null) customer.c_w_id:3(int!null) customer.c_first:4(string) customer.c_last:6(string!null)
            ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
-           ├── stats: [rows=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07, distinct(6)=6.80272109e-07]
-           ├── cost: 7.4829932e-07
+           ├── stats: [rows=2.9154519e-06, distinct(2)=2.9154519e-06, distinct(3)=2.9154519e-06, distinct(6)=2.9154519e-06]
+           ├── cost: 3.20699708e-06
            ├── key: (1)
            ├── fd: ()-->(2,3,6), (1)-->(4)
            ├── ordering: +4 opt(2,3,6)
@@ -547,8 +547,8 @@ LIMIT 1
 project
  ├── columns: o_id:1(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=6.80272109e-07]
- ├── cost: 3.56462585e-06
+ ├── stats: [rows=2.9154519e-06]
+ ├── cost: 1.52769679e-05
  ├── key: ()
  ├── fd: ()-->(1,5,6)
  ├── prune: (1,5,6)
@@ -556,32 +556,32 @@ project
  └── limit
       ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_c_id:4(int!null) "order".o_entry_d:5(timestamp) "order".o_carrier_id:6(int)
       ├── cardinality: [0 - 1]
-      ├── stats: [rows=6.80272109e-07]
-      ├── cost: 3.56462585e-06
+      ├── stats: [rows=2.9154519e-06]
+      ├── cost: 1.52769679e-05
       ├── key: ()
       ├── fd: ()-->(1-6)
       ├── prune: (5,6)
       ├── interesting orderings: (-1)
       ├── sort
       │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_c_id:4(int!null) "order".o_entry_d:5(timestamp) "order".o_carrier_id:6(int)
-      │    ├── stats: [rows=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07, distinct(4)=6.80272109e-07]
-      │    ├── cost: 3.56462585e-06
+      │    ├── stats: [rows=2.9154519e-06, distinct(2)=2.9154519e-06, distinct(3)=2.9154519e-06, distinct(4)=2.9154519e-06]
+      │    ├── cost: 1.52769679e-05
       │    ├── key: (1)
       │    ├── fd: ()-->(2-4), (1)-->(5,6)
       │    ├── ordering: -1 opt(2-4)
       │    ├── prune: (1,5,6)
       │    └── index-join order
       │         ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_c_id:4(int!null) "order".o_entry_d:5(timestamp) "order".o_carrier_id:6(int)
-      │         ├── stats: [rows=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07, distinct(4)=6.80272109e-07]
-      │         ├── cost: 3.55782313e-06
+      │         ├── stats: [rows=2.9154519e-06, distinct(2)=2.9154519e-06, distinct(3)=2.9154519e-06, distinct(4)=2.9154519e-06]
+      │         ├── cost: 1.52478134e-05
       │         ├── key: (1)
       │         ├── fd: ()-->(2-4), (1)-->(5,6)
       │         ├── prune: (1,5,6)
       │         └── scan order@secondary
       │              ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_c_id:4(int!null)
       │              ├── constraint: /3/2/4/1: [/10/100/50 - /10/100/50]
-      │              ├── stats: [rows=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07, distinct(4)=6.80272109e-07]
-      │              ├── cost: 7.34693878e-07
+      │              ├── stats: [rows=2.9154519e-06, distinct(2)=2.9154519e-06, distinct(3)=2.9154519e-06, distinct(4)=2.9154519e-06]
+      │              ├── cost: 3.14868805e-06
       │              ├── key: (1)
       │              ├── fd: ()-->(2-4)
       │              ├── prune: (1)
@@ -595,15 +595,15 @@ WHERE ol_w_id = 10 AND ol_d_id = 100 AND ol_o_id = 1000
 ----
 project
  ├── columns: ol_i_id:5(int!null) ol_supply_w_id:6(int) ol_quantity:8(int) ol_amount:9(decimal) ol_delivery_d:7(timestamp)
- ├── stats: [rows=2.04081633e-07]
- ├── cost: 2.40816327e-07
+ ├── stats: [rows=2.9154519e-06]
+ ├── cost: 3.44023324e-06
  ├── prune: (5-9)
  ├── interesting orderings: (+6)
  └── scan order_line
       ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) order_line.ol_i_id:5(int!null) order_line.ol_supply_w_id:6(int) order_line.ol_delivery_d:7(timestamp) order_line.ol_quantity:8(int) order_line.ol_amount:9(decimal)
       ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
-      ├── stats: [rows=2.04081633e-07, distinct(1)=2.04081633e-07, distinct(2)=2.04081633e-07, distinct(3)=2.04081633e-07]
-      ├── cost: 2.40816327e-07
+      ├── stats: [rows=2.9154519e-06, distinct(1)=2.9154519e-06, distinct(2)=2.9154519e-06, distinct(3)=2.9154519e-06]
+      ├── cost: 3.44023324e-06
       ├── fd: ()-->(1-3)
       ├── prune: (5-9)
       └── interesting orderings: (+3,+2,-1) (+6,+2,+3,+1)
@@ -635,8 +635,8 @@ LIMIT 1
 project
  ├── columns: no_o_id:1(int!null)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=0.142857143]
- ├── cost: 0.152857143
+ ├── stats: [rows=0.00204081633]
+ ├── cost: 0.00218367347
  ├── key: ()
  ├── fd: ()-->(1)
  ├── prune: (1)
@@ -644,15 +644,15 @@ project
  └── limit
       ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
       ├── cardinality: [0 - 1]
-      ├── stats: [rows=0.142857143]
-      ├── cost: 0.152857143
+      ├── stats: [rows=0.00204081633]
+      ├── cost: 0.00218367347
       ├── key: ()
       ├── fd: ()-->(1-3)
       ├── interesting orderings: (+1)
       ├── sort
       │    ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
-      │    ├── stats: [rows=0.142857143, distinct(2)=0.142857143, distinct(3)=0.142857143]
-      │    ├── cost: 0.152857143
+      │    ├── stats: [rows=0.00204081633, distinct(2)=0.00204081633, distinct(3)=0.00204081633]
+      │    ├── cost: 0.00218367347
       │    ├── key: (1)
       │    ├── fd: ()-->(2,3)
       │    ├── ordering: +1 opt(2,3)
@@ -660,8 +660,8 @@ project
       │    └── scan new_order
       │         ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
       │         ├── constraint: /3/2/-1: [/10/100 - /10/100]
-      │         ├── stats: [rows=0.142857143, distinct(2)=0.142857143, distinct(3)=0.142857143]
-      │         ├── cost: 0.151428571
+      │         ├── stats: [rows=0.00204081633, distinct(2)=0.00204081633, distinct(3)=0.00204081633]
+      │         ├── cost: 0.00216326531
       │         ├── key: (1)
       │         ├── fd: ()-->(2,3)
       │         └── prune: (1)
@@ -676,15 +676,15 @@ group-by
  ├── columns: sum:11(decimal)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 2.32653061e-07
+ ├── cost: 3.32361516e-06
  ├── key: ()
  ├── fd: ()-->(11)
  ├── prune: (11)
  ├── scan order_line
  │    ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) order_line.ol_amount:9(decimal)
  │    ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
- │    ├── stats: [rows=2.04081633e-07, distinct(1)=2.04081633e-07, distinct(2)=2.04081633e-07, distinct(3)=2.04081633e-07]
- │    ├── cost: 2.32653061e-07
+ │    ├── stats: [rows=2.9154519e-06, distinct(1)=2.9154519e-06, distinct(2)=2.9154519e-06, distinct(3)=2.9154519e-06]
+ │    ├── cost: 3.32361516e-06
  │    ├── fd: ()-->(1-3)
  │    ├── prune: (9)
  │    └── interesting orderings: (+3,+2,-1)
@@ -708,8 +708,8 @@ WHERE d_w_id = 10 AND d_id = 100
 project
  ├── columns: d_next_o_id:11(int)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=0.142857143]
- ├── cost: 0.162857143
+ ├── stats: [rows=0.00204081633]
+ ├── cost: 0.00232653061
  ├── key: ()
  ├── fd: ()-->(11)
  ├── prune: (11)
@@ -717,8 +717,8 @@ project
       ├── columns: district.d_id:1(int!null) district.d_w_id:2(int!null) district.d_next_o_id:11(int)
       ├── constraint: /2/1: [/10/100 - /10/100]
       ├── cardinality: [0 - 1]
-      ├── stats: [rows=0.142857143, distinct(1)=0.142857143, distinct(2)=0.142857143]
-      ├── cost: 0.162857143
+      ├── stats: [rows=0.00204081633, distinct(1)=0.00204081633, distinct(2)=0.00204081633]
+      ├── cost: 0.00232653061
       ├── key: ()
       ├── fd: ()-->(1,2,11)
       ├── prune: (11)
@@ -755,28 +755,28 @@ group-by
  ├── columns: count:28(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 0.0163475102
+ ├── cost: 0.0003030404
  ├── key: ()
  ├── fd: ()-->(28)
  ├── prune: (28)
  ├── group-by
  │    ├── columns: stock.s_i_id:11(int!null)
  │    ├── grouping columns: stock.s_i_id:11(int!null)
- │    ├── stats: [rows=28752.8606, distinct(11)=28752.8606]
- │    ├── cost: 0.0163475102
+ │    ├── stats: [rows=0.476141881, distinct(11)=0.476141881]
+ │    ├── cost: 0.0003030404
  │    ├── key: (11)
  │    └── inner-join (lookup stock)
  │         ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) order_line.ol_i_id:5(int!null) stock.s_i_id:11(int!null) stock.s_w_id:12(int!null) stock.s_quantity:13(int!null)
  │         ├── key columns: [3 5] = [12 11]
- │         ├── stats: [rows=0.0136054422, distinct(11)=28752.8606]
- │         ├── cost: 0.0163475102
+ │         ├── stats: [rows=2.77662085e-06, distinct(11)=0.476141881]
+ │         ├── cost: 0.0003030404
  │         ├── fd: ()-->(2,3,12), (11)-->(13), (5)==(11), (11)==(5), (3)==(12), (12)==(3)
  │         ├── interesting orderings: (+3,+2,-1)
  │         ├── scan order_line
  │         │    ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) order_line.ol_i_id:5(int!null)
  │         │    ├── constraint: /3/2/-1/4: [/10/100/999 - /10/100/980]
- │         │    ├── stats: [rows=4.08163265e-06, distinct(1)=4.08163265e-06, distinct(2)=4.08163265e-06, distinct(3)=4.08163265e-06]
- │         │    ├── cost: 4.65306122e-06
+ │         │    ├── stats: [rows=5.83090379e-05, distinct(1)=5.83090379e-05, distinct(2)=5.83090379e-05, distinct(3)=5.83090379e-05]
+ │         │    ├── cost: 6.64723032e-05
  │         │    ├── fd: ()-->(2,3)
  │         │    ├── prune: (5)
  │         │    └── interesting orderings: (+3,+2,-1)
@@ -818,21 +818,21 @@ group-by
  ├── columns: count:22(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 124.5
+ ├── cost: 2964.75
  ├── key: ()
  ├── fd: ()-->(22)
  ├── prune: (22)
  ├── inner-join
  │    ├── columns: warehouse.w_id:1(int!null) warehouse.w_ytd:9(decimal!null) district.d_w_id:11(int!null) sum_d_ytd:21(decimal!null)
- │    ├── stats: [rows=10]
- │    ├── cost: 124.5
+ │    ├── stats: [rows=70000]
+ │    ├── cost: 2964.75
  │    ├── key: (11)
  │    ├── fd: (1)-->(9), (11)-->(21), (1)==(11), (11)==(1)
  │    ├── interesting orderings: (+1) (+11)
  │    ├── scan warehouse
  │    │    ├── columns: warehouse.w_id:1(int!null) warehouse.w_ytd:9(decimal)
- │    │    ├── stats: [rows=10]
- │    │    ├── cost: 11.1
+ │    │    ├── stats: [rows=1000]
+ │    │    ├── cost: 1110
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(9)
  │    │    ├── prune: (1,9)
@@ -840,16 +840,16 @@ group-by
  │    ├── group-by
  │    │    ├── columns: district.d_w_id:11(int!null) sum_d_ytd:21(decimal)
  │    │    ├── grouping columns: district.d_w_id:11(int!null)
- │    │    ├── stats: [rows=10, distinct(11)=10]
- │    │    ├── cost: 113
+ │    │    ├── stats: [rows=700, distinct(11)=700]
+ │    │    ├── cost: 1130
  │    │    ├── key: (11)
  │    │    ├── fd: (11)-->(21)
  │    │    ├── prune: (21)
  │    │    ├── interesting orderings: (+11)
  │    │    ├── scan district
  │    │    │    ├── columns: district.d_w_id:11(int!null) district.d_ytd:19(decimal)
- │    │    │    ├── stats: [rows=100, distinct(11)=10]
- │    │    │    ├── cost: 113
+ │    │    │    ├── stats: [rows=1000, distinct(11)=700]
+ │    │    │    ├── cost: 1130
  │    │    │    ├── prune: (11,19)
  │    │    │    └── interesting orderings: (+11)
  │    │    └── aggregations [outer=(19)]
@@ -872,8 +872,8 @@ ORDER BY d_w_id, d_id
 ----
 scan district
  ├── columns: d_next_o_id:11(int)
- ├── stats: [rows=100]
- ├── cost: 114
+ ├── stats: [rows=1000]
+ ├── cost: 1140
  ├── key: (1,2)
  ├── fd: (1,2)-->(11)
  ├── ordering: +2,+1
@@ -888,8 +888,8 @@ ORDER BY no_w_id, no_d_id
 ----
 sort
  ├── columns: max:4(int)
- ├── stats: [rows=100, distinct(2,3)=100]
- ├── cost: 95406.6439
+ ├── stats: [rows=1000, distinct(2,3)=1000]
+ ├── cost: 1159.65784
  ├── key: (2,3)
  ├── fd: (2,3)-->(4)
  ├── ordering: +3,+2
@@ -897,15 +897,15 @@ sort
  └── group-by
       ├── columns: new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null) max:4(int)
       ├── grouping columns: new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
-      ├── stats: [rows=100, distinct(2,3)=100]
-      ├── cost: 95400
+      ├── stats: [rows=1000, distinct(2,3)=1000]
+      ├── cost: 1060
       ├── key: (2,3)
       ├── fd: (2,3)-->(4)
       ├── prune: (4)
       ├── scan new_order
       │    ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
-      │    ├── stats: [rows=90000, distinct(2,3)=100]
-      │    ├── cost: 95400
+      │    ├── stats: [rows=1000, distinct(2,3)=1000]
+      │    ├── cost: 1060
       │    ├── key: (1-3)
       │    ├── prune: (1-3)
       │    └── interesting orderings: (+3,+2,-1)
@@ -921,8 +921,8 @@ ORDER BY o_w_id, o_d_id
 ----
 sort
  ├── columns: max:9(int)
- ├── stats: [rows=100, distinct(2,3)=100]
- ├── cost: 321006.644
+ ├── stats: [rows=1000, distinct(2,3)=1000]
+ ├── cost: 1169.65784
  ├── key: (2,3)
  ├── fd: (2,3)-->(9)
  ├── ordering: +3,+2
@@ -930,15 +930,15 @@ sort
  └── group-by
       ├── columns: "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) max:9(int)
       ├── grouping columns: "order".o_d_id:2(int!null) "order".o_w_id:3(int!null)
-      ├── stats: [rows=100, distinct(2,3)=100]
-      ├── cost: 321000
+      ├── stats: [rows=1000, distinct(2,3)=1000]
+      ├── cost: 1070
       ├── key: (2,3)
       ├── fd: (2,3)-->(9)
       ├── prune: (9)
       ├── scan order@order_idx
       │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null)
-      │    ├── stats: [rows=300000, distinct(2,3)=100]
-      │    ├── cost: 321000
+      │    ├── stats: [rows=1000, distinct(2,3)=1000]
+      │    ├── cost: 1070
       │    ├── key: (1-3)
       │    ├── prune: (1-3)
       │    └── interesting orderings: (+3,+2,-1)
@@ -960,30 +960,30 @@ group-by
  ├── columns: count:8(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 95401
+ ├── cost: 1070
  ├── key: ()
  ├── fd: ()-->(8)
  ├── prune: (8)
  ├── select
  │    ├── columns: new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null) column4:4(int) column5:5(int) column6:6(int)
- │    ├── stats: [rows=33.3333333]
- │    ├── cost: 95401
+ │    ├── stats: [rows=333.333333]
+ │    ├── cost: 1070
  │    ├── key: (2,3)
  │    ├── fd: (2,3)-->(4-6)
  │    ├── interesting orderings: (+3,+2)
  │    ├── group-by
  │    │    ├── columns: new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null) column4:4(int) column5:5(int) column6:6(int)
  │    │    ├── grouping columns: new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
- │    │    ├── stats: [rows=100, distinct(2,3)=100]
- │    │    ├── cost: 95400
+ │    │    ├── stats: [rows=1000, distinct(2,3)=1000]
+ │    │    ├── cost: 1060
  │    │    ├── key: (2,3)
  │    │    ├── fd: (2,3)-->(4-6)
  │    │    ├── prune: (4-6)
  │    │    ├── interesting orderings: (+3,+2)
  │    │    ├── scan new_order
  │    │    │    ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
- │    │    │    ├── stats: [rows=90000, distinct(2,3)=100]
- │    │    │    ├── cost: 95400
+ │    │    │    ├── stats: [rows=1000, distinct(2,3)=1000]
+ │    │    │    ├── cost: 1060
  │    │    │    ├── key: (1-3)
  │    │    │    ├── prune: (1-3)
  │    │    │    └── interesting orderings: (+3,+2,-1)
@@ -1012,8 +1012,8 @@ ORDER BY o_w_id, o_d_id
 ----
 sort
  ├── columns: sum:9(decimal)
- ├── stats: [rows=100, distinct(2,3)=100]
- ├── cost: 333006.644
+ ├── stats: [rows=1000, distinct(2,3)=1000]
+ ├── cost: 1209.65784
  ├── key: (2,3)
  ├── fd: (2,3)-->(9)
  ├── ordering: +3,+2
@@ -1021,15 +1021,15 @@ sort
  └── group-by
       ├── columns: "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) sum:9(decimal)
       ├── grouping columns: "order".o_d_id:2(int!null) "order".o_w_id:3(int!null)
-      ├── stats: [rows=100, distinct(2,3)=100]
-      ├── cost: 333000
+      ├── stats: [rows=1000, distinct(2,3)=1000]
+      ├── cost: 1110
       ├── key: (2,3)
       ├── fd: (2,3)-->(9)
       ├── prune: (9)
       ├── scan order
       │    ├── columns: "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_ol_cnt:7(int)
-      │    ├── stats: [rows=300000, distinct(2,3)=100]
-      │    ├── cost: 333000
+      │    ├── stats: [rows=1000, distinct(2,3)=1000]
+      │    ├── cost: 1110
       │    ├── prune: (2,3,7)
       │    └── interesting orderings: (+3,+2)
       └── aggregations [outer=(7)]
@@ -1044,8 +1044,8 @@ ORDER BY ol_w_id, ol_d_id
 ----
 sort
  ├── columns: count:11(int)
- ├── stats: [rows=100, distinct(2,3)=100]
- ├── cost: 1070006.64
+ ├── stats: [rows=1000, distinct(2,3)=1000]
+ ├── cost: 1169.65784
  ├── key: (2,3)
  ├── fd: (2,3)-->(11)
  ├── ordering: +3,+2
@@ -1053,15 +1053,15 @@ sort
  └── group-by
       ├── columns: order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) count:11(int)
       ├── grouping columns: order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null)
-      ├── stats: [rows=100, distinct(2,3)=100]
-      ├── cost: 1070000
+      ├── stats: [rows=1000, distinct(2,3)=1000]
+      ├── cost: 1070
       ├── key: (2,3)
       ├── fd: (2,3)-->(11)
       ├── prune: (11)
       ├── scan order_line@order_line_fk
       │    ├── columns: order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null)
-      │    ├── stats: [rows=1000000, distinct(2,3)=100]
-      │    ├── cost: 1070000
+      │    ├── stats: [rows=1000, distinct(2,3)=1000]
+      │    ├── cost: 1070
       │    ├── prune: (2,3)
       │    └── interesting orderings: (+3,+2)
       └── aggregations
@@ -1076,34 +1076,34 @@ except-all
  ├── columns: no_w_id:3(int!null) no_d_id:2(int!null) no_o_id:1(int!null)
  ├── left columns: new_order.no_w_id:3(int!null) new_order.no_d_id:2(int!null) new_order.no_o_id:1(int!null)
  ├── right columns: "order".o_w_id:6(int) "order".o_d_id:5(int) "order".o_id:4(int)
- ├── stats: [rows=90000]
- ├── cost: 422400
+ ├── stats: [rows=1000]
+ ├── cost: 2150
  ├── scan new_order
  │    ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
- │    ├── stats: [rows=90000]
- │    ├── cost: 95400
+ │    ├── stats: [rows=1000]
+ │    ├── cost: 1060
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
  │    └── interesting orderings: (+3,+2,-1)
  └── project
       ├── columns: "order".o_id:4(int!null) "order".o_d_id:5(int!null) "order".o_w_id:6(int!null)
       ├── stats: [rows=1.42857143]
-      ├── cost: 327000
+      ├── cost: 1090
       ├── key: (4-6)
       ├── prune: (4-6)
       ├── interesting orderings: (+6,+5,-4)
       └── select
            ├── columns: "order".o_id:4(int!null) "order".o_d_id:5(int!null) "order".o_w_id:6(int!null) "order".o_carrier_id:9(int)
            ├── stats: [rows=1.42857143, distinct(9)=1]
-           ├── cost: 327000
+           ├── cost: 1090
            ├── key: (4-6)
            ├── fd: ()-->(9)
            ├── prune: (4-6)
            ├── interesting orderings: (+6,+5,-4) (+6,+5,+9,+4)
            ├── scan order@order_idx
            │    ├── columns: "order".o_id:4(int!null) "order".o_d_id:5(int!null) "order".o_w_id:6(int!null) "order".o_carrier_id:9(int)
-           │    ├── stats: [rows=300000, distinct(9)=210000]
-           │    ├── cost: 324000
+           │    ├── stats: [rows=1000, distinct(9)=700]
+           │    ├── cost: 1080
            │    ├── key: (4-6)
            │    ├── fd: (4-6)-->(9)
            │    ├── prune: (4-6,9)
@@ -1123,26 +1123,26 @@ except-all
  ├── left columns: "order".o_w_id:3(int!null) "order".o_d_id:2(int!null) "order".o_id:1(int!null)
  ├── right columns: new_order.no_w_id:11(int) new_order.no_d_id:10(int) new_order.no_o_id:9(int)
  ├── stats: [rows=1.42857143]
- ├── cost: 422400
+ ├── cost: 2150
  ├── project
  │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null)
  │    ├── stats: [rows=1.42857143]
- │    ├── cost: 327000
+ │    ├── cost: 1090
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    └── select
  │         ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_carrier_id:6(int)
  │         ├── stats: [rows=1.42857143, distinct(6)=1]
- │         ├── cost: 327000
+ │         ├── cost: 1090
  │         ├── key: (1-3)
  │         ├── fd: ()-->(6)
  │         ├── prune: (1-3)
  │         ├── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
  │         ├── scan order@order_idx
  │         │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_carrier_id:6(int)
- │         │    ├── stats: [rows=300000, distinct(6)=210000]
- │         │    ├── cost: 324000
+ │         │    ├── stats: [rows=1000, distinct(6)=700]
+ │         │    ├── cost: 1080
  │         │    ├── key: (1-3)
  │         │    ├── fd: (1-3)-->(6)
  │         │    ├── prune: (1-3,6)
@@ -1153,8 +1153,8 @@ except-all
  │                   └── null [type=unknown]
  └── scan new_order
       ├── columns: new_order.no_o_id:9(int!null) new_order.no_d_id:10(int!null) new_order.no_w_id:11(int!null)
-      ├── stats: [rows=90000]
-      ├── cost: 95400
+      ├── stats: [rows=1000]
+      ├── cost: 1060
       ├── key: (9-11)
       ├── prune: (9-11)
       └── interesting orderings: (+11,+10,-9)
@@ -1177,12 +1177,12 @@ except-all
  ├── columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null) o_ol_cnt:7(int)
  ├── left columns: "order".o_w_id:3(int!null) "order".o_d_id:2(int!null) "order".o_id:1(int!null) "order".o_ol_cnt:7(int)
  ├── right columns: order_line.ol_w_id:11(int) order_line.ol_d_id:10(int) order_line.ol_o_id:9(int) count:19(int)
- ├── stats: [rows=300000]
- ├── cost: 1416000
+ ├── stats: [rows=1000]
+ ├── cost: 2200
  ├── scan order
  │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_ol_cnt:7(int)
- │    ├── stats: [rows=300000]
- │    ├── cost: 336000
+ │    ├── stats: [rows=1000]
+ │    ├── cost: 1120
  │    ├── key: (1-3)
  │    ├── fd: (1-3)-->(7)
  │    ├── prune: (1-3,7)
@@ -1190,16 +1190,16 @@ except-all
  └── group-by
       ├── columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null) count:19(int)
       ├── grouping columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null)
-      ├── stats: [rows=100000, distinct(9-11)=100000]
-      ├── cost: 1080000
+      ├── stats: [rows=1000, distinct(9-11)=1000]
+      ├── cost: 1080
       ├── key: (9-11)
       ├── fd: (9-11)-->(19)
       ├── prune: (19)
       ├── interesting orderings: (+11,+10,-9)
       ├── scan order_line@order_line_fk
       │    ├── columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null)
-      │    ├── stats: [rows=1000000, distinct(9-11)=100000]
-      │    ├── cost: 1080000
+      │    ├── stats: [rows=1000, distinct(9-11)=1000]
+      │    ├── cost: 1080
       │    ├── prune: (9-11)
       │    └── interesting orderings: (+11,+10,-9)
       └── aggregations
@@ -1223,29 +1223,29 @@ except-all
  ├── columns: ol_w_id:3(int!null) ol_d_id:2(int!null) ol_o_id:1(int!null) count:11(int)
  ├── left columns: order_line.ol_w_id:3(int!null) order_line.ol_d_id:2(int!null) order_line.ol_o_id:1(int!null) count:11(int)
  ├── right columns: "order".o_w_id:14(int) "order".o_d_id:13(int) "order".o_id:12(int) "order".o_ol_cnt:18(int)
- ├── stats: [rows=100000]
- ├── cost: 1416000
+ ├── stats: [rows=1000]
+ ├── cost: 2200
  ├── group-by
  │    ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) count:11(int)
  │    ├── grouping columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null)
- │    ├── stats: [rows=100000, distinct(1-3)=100000]
- │    ├── cost: 1080000
+ │    ├── stats: [rows=1000, distinct(1-3)=1000]
+ │    ├── cost: 1080
  │    ├── key: (1-3)
  │    ├── fd: (1-3)-->(11)
  │    ├── prune: (11)
  │    ├── interesting orderings: (+3,+2,-1)
  │    ├── scan order_line@order_line_fk
  │    │    ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null)
- │    │    ├── stats: [rows=1000000, distinct(1-3)=100000]
- │    │    ├── cost: 1080000
+ │    │    ├── stats: [rows=1000, distinct(1-3)=1000]
+ │    │    ├── cost: 1080
  │    │    ├── prune: (1-3)
  │    │    └── interesting orderings: (+3,+2,-1)
  │    └── aggregations
  │         └── count-rows [type=int]
  └── scan order
       ├── columns: "order".o_id:12(int!null) "order".o_d_id:13(int!null) "order".o_w_id:14(int!null) "order".o_ol_cnt:18(int)
-      ├── stats: [rows=300000]
-      ├── cost: 336000
+      ├── stats: [rows=1000]
+      ├── cost: 1120
       ├── key: (12-14)
       ├── fd: (12-14)-->(18)
       ├── prune: (12-14,18)
@@ -1272,23 +1272,23 @@ group-by
  ├── columns: count:19(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 1477000.04
+ ├── cost: 2240.04
  ├── key: ()
  ├── fd: ()-->(19)
  ├── prune: (19)
  ├── select
  │    ├── columns: "order".o_id:1(int) "order".o_d_id:2(int) "order".o_w_id:3(int) order_line.ol_o_id:9(int) order_line.ol_d_id:10(int) order_line.ol_w_id:11(int)
  │    ├── stats: [rows=0.0680272109]
- │    ├── cost: 1477000.04
+ │    ├── cost: 2240.04
  │    ├── full-join (merge)
  │    │    ├── columns: "order".o_id:1(int) "order".o_d_id:2(int) "order".o_w_id:3(int) order_line.ol_o_id:9(int) order_line.ol_d_id:10(int) order_line.ol_w_id:11(int)
  │    │    ├── stats: [rows=0.204081633]
- │    │    ├── cost: 1477000.04
+ │    │    ├── cost: 2240.03796
  │    │    ├── reject-nulls: (1-3,9-11)
  │    │    ├── sort
  │    │    │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null)
  │    │    │    ├── stats: [rows=1.42857143]
- │    │    │    ├── cost: 327000.007
+ │    │    │    ├── cost: 1090.00735
  │    │    │    ├── key: (1-3)
  │    │    │    ├── ordering: +3,+2,-1
  │    │    │    ├── prune: (1-3)
@@ -1296,22 +1296,22 @@ group-by
  │    │    │    └── project
  │    │    │         ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null)
  │    │    │         ├── stats: [rows=1.42857143]
- │    │    │         ├── cost: 327000
+ │    │    │         ├── cost: 1090
  │    │    │         ├── key: (1-3)
  │    │    │         ├── prune: (1-3)
  │    │    │         ├── interesting orderings: (+3,+2,-1)
  │    │    │         └── select
  │    │    │              ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_carrier_id:6(int)
  │    │    │              ├── stats: [rows=1.42857143, distinct(6)=1]
- │    │    │              ├── cost: 327000
+ │    │    │              ├── cost: 1090
  │    │    │              ├── key: (1-3)
  │    │    │              ├── fd: ()-->(6)
  │    │    │              ├── prune: (1-3)
  │    │    │              ├── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
  │    │    │              ├── scan order@order_idx
  │    │    │              │    ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_carrier_id:6(int)
- │    │    │              │    ├── stats: [rows=300000, distinct(6)=210000]
- │    │    │              │    ├── cost: 324000
+ │    │    │              │    ├── stats: [rows=1000, distinct(6)=700]
+ │    │    │              │    ├── cost: 1080
  │    │    │              │    ├── key: (1-3)
  │    │    │              │    ├── fd: (1-3)-->(6)
  │    │    │              │    ├── prune: (1-3,6)
@@ -1323,22 +1323,22 @@ group-by
  │    │    ├── project
  │    │    │    ├── columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null)
  │    │    │    ├── stats: [rows=1.42857143]
- │    │    │    ├── cost: 1150000
+ │    │    │    ├── cost: 1150
  │    │    │    ├── ordering: +11,+10,-9
  │    │    │    ├── prune: (9-11)
  │    │    │    ├── interesting orderings: (+11,+10,-9)
  │    │    │    └── select
  │    │    │         ├── columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null) order_line.ol_delivery_d:15(timestamp)
  │    │    │         ├── stats: [rows=1.42857143, distinct(15)=1]
- │    │    │         ├── cost: 1150000
+ │    │    │         ├── cost: 1150
  │    │    │         ├── fd: ()-->(15)
  │    │    │         ├── ordering: +11,+10,-9 opt(15)
  │    │    │         ├── prune: (9-11)
  │    │    │         ├── interesting orderings: (+11,+10,-9)
  │    │    │         ├── scan order_line
  │    │    │         │    ├── columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null) order_line.ol_delivery_d:15(timestamp)
- │    │    │         │    ├── stats: [rows=1000000, distinct(15)=700000]
- │    │    │         │    ├── cost: 1140000
+ │    │    │         │    ├── stats: [rows=1000, distinct(15)=700]
+ │    │    │         │    ├── cost: 1140
  │    │    │         │    ├── ordering: +11,+10,-9 opt(15)
  │    │    │         │    ├── prune: (9-11,15)
  │    │    │         │    └── interesting orderings: (+11,+10,-9)

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -26,17 +26,6 @@ TABLE warehouse
       └── w_id int not null
 
 exec-ddl
-ALTER TABLE warehouse INJECT STATISTICS '[
-  {
-    "columns": ["w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 10,
-    "distinct_count": 10
-  }
-]'
-----
-
-exec-ddl
 CREATE TABLE district
 (
     d_id         integer       not null,
@@ -69,17 +58,6 @@ TABLE district
  └── INDEX primary
       ├── d_w_id int not null
       └── d_id int not null
-
-exec-ddl
-ALTER TABLE district INJECT STATISTICS '[
-  {
-    "columns": ["d_w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 100,
-    "distinct_count": 10
-  }
-]'
-----
 
 exec-ddl
 CREATE TABLE customer
@@ -144,35 +122,6 @@ TABLE customer
       └── c_id int not null
 
 exec-ddl
-ALTER TABLE customer INJECT STATISTICS '[
-  {
-    "columns": ["c_w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 300000,
-    "distinct_count": 10
-  },
-  {
-    "columns": ["c_w_id", "c_d_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 300000,
-    "distinct_count": 100
-  },
-  {
-    "columns": ["c_w_id", "c_d_id", "c_last"],
-    "created_at": "2018-01-01 1:30:00.00000+00:00",
-    "row_count": 300000,
-    "distinct_count": 100000
-  },
-  {
-    "columns": ["c_w_id", "c_d_id", "c_last", "c_first"],
-    "created_at": "2018-01-01 1:30:00.00000+00:00",
-    "row_count": 300000,
-    "distinct_count": 300000
-  }
-]'
-----
-
-exec-ddl
 CREATE TABLE history
 (
     rowid    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -211,29 +160,6 @@ TABLE history
       ├── h_c_d_id int
       ├── h_c_id int
       └── rowid uuid not null
-
-exec-ddl
-ALTER TABLE history INJECT STATISTICS '[
-  {
-    "columns": ["h_w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 30000000,
-    "distinct_count": 10
-  },
-  {
-    "columns": ["h_w_id", "h_d_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 30000000,
-    "distinct_count": 100
-  },
-  {
-    "columns": ["h_w_id", "h_d_id", "h_c_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 30000000,
-    "distinct_count": 30000000
-  }
-]'
-----
 
 exec-ddl
 CREATE TABLE "order"
@@ -277,35 +203,6 @@ TABLE order
       └── o_id int not null
 
 exec-ddl
-ALTER TABLE "order" INJECT STATISTICS '[
-  {
-    "columns": ["o_w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 300000,
-    "distinct_count": 10
-  },
-  {
-    "columns": ["o_w_id", "o_d_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 300000,
-    "distinct_count": 100
-  },
-  {
-    "columns": ["o_w_id", "o_d_id", "o_carrier_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 300000,
-    "distinct_count": 1000
-  },
-  {
-    "columns": ["o_w_id", "o_d_id", "o_c_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 300000,
-    "distinct_count": 300000
-  }
-]'
-----
-
-exec-ddl
 CREATE TABLE new_order
 (
     no_o_id  integer   not null,
@@ -322,23 +219,6 @@ TABLE new_order
       ├── no_w_id int not null
       ├── no_d_id int not null
       └── no_o_id int not null desc
-
-exec-ddl
-ALTER TABLE new_order INJECT STATISTICS '[
-  {
-    "columns": ["no_w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 90000,
-    "distinct_count": 10
-  },
-  {
-    "columns": ["no_w_id", "no_d_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 90000,
-    "distinct_count": 100
-  }
-]'
-----
 
 exec-ddl
 CREATE TABLE item
@@ -359,17 +239,6 @@ TABLE item
  ├── i_data string
  └── INDEX primary
       └── i_id int not null
-
-exec-ddl
-ALTER TABLE item INJECT STATISTICS '[
-  {
-    "columns": ["i_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 100000,
-    "distinct_count": 100000
-  }
-]'
-----
 
 exec-ddl
 CREATE TABLE stock
@@ -423,23 +292,6 @@ TABLE stock
       └── s_w_id int not null
 
 exec-ddl
-ALTER TABLE stock INJECT STATISTICS '[
-  {
-    "columns": ["s_w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1000000,
-    "distinct_count": 10
-  },
-  {
-    "columns": ["s_i_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1000000,
-    "distinct_count": 100000
-  }
-]'
-----
-
-exec-ddl
 CREATE TABLE order_line
 (
     ol_o_id         integer   not null,
@@ -480,53 +332,6 @@ TABLE order_line
       ├── ol_w_id int not null
       ├── ol_o_id int not null
       └── ol_number int not null
-
-exec-ddl
-ALTER TABLE order_line INJECT STATISTICS '[
-  {
-    "columns": ["ol_w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1000000,
-    "distinct_count": 10
-  },
-  {
-    "columns": ["ol_w_id", "ol_d_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1000000,
-    "distinct_count": 100
-  },
-  {
-    "columns": ["ol_w_id", "ol_d_id", "ol_o_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1000000,
-    "distinct_count": 100000
-  },
-  {
-    "columns": ["ol_supply_w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1000000,
-    "distinct_count": 10
-  },
-  {
-    "columns": ["ol_supply_w_id", "ol_d_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1000000,
-    "distinct_count": 100
-  },
-  {
-    "columns": ["ol_supply_w_id", "ol_d_id", "ol_w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1000000,
-    "distinct_count": 1000
-  },
-  {
-    "columns": ["ol_supply_w_id", "ol_d_id", "ol_w_id", "ol_o_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1000000,
-        "distinct_count": 100000
-  }
-]'
-----
 
 # --------------------------------------------------
 # 2.4 The New Order Transaction


### PR DESCRIPTION
#### opt: fork the tpcc testcases

We won't have stats enabled by default, so we want to know what plans
we generate without stats. Forking the tpcc cases and removing the
statistic injection. The test outputs are unchanged and will be
updated in the following commit (so the diffs are visible).

We also add a modified version of a query that we don't yet support
because of DISTINCT aggregate.

Release note: None

#### opt: update test outputs for tpcc-no-stats

Changes when rewriting the outputs for `tpcc-no-stats`. Surprisingly,
none of the plans change (just the absolute costs).

Release note: None
