### PR TITLE
rpc: avoid clock offset fatal on unvalidated connection

### DIFF
--- a/pkg/rpc/heartbeat_test.go
+++ b/pkg/rpc/heartbeat_test.go
@@ -162,17 +162,22 @@ func TestClockOffsetMismatch(t *testing.T) {
 		}
 	}()
 
+	ctx := context.Background()
+
 	clock := hlc.NewClock(hlc.UnixNano, 250*time.Millisecond)
 	hs := &HeartbeatService{
 		clock:              clock,
 		remoteClockMonitor: newRemoteClockMonitor(clock, time.Hour, 0),
+		clusterID:          &base.ClusterIDContainer{},
 		version:            &cluster.MakeTestingClusterSettings().Version,
 	}
+	hs.clusterID.Set(ctx, uuid.Nil)
 
 	request := &PingRequest{
 		Ping:           "testManual",
 		Addr:           "test",
 		MaxOffsetNanos: (500 * time.Millisecond).Nanoseconds(),
+		ServerVersion:  hs.version.Version().MinimumVersion,
 	}
 	response, err := hs.Ping(context.Background(), request)
 	t.Fatalf("should not have reached but got response=%v err=%v", response, err)


### PR DESCRIPTION
I think we were seeing rare flakes in CI in which a heartbeat service
got connections from another test that used a different clock offset
due to port reuse.
Since the assertion didn't wait for the connection to be validated (i.e.
cluster versions matching), this could crash. This is only a theory,
but we're never able to reproduce these failures.

There are lots of places that use a 1ns maxoffset, including
bootstrapCluster. If we continue to see these failures, we should make
all of those unique numbers to lend credibility to the port reuse
theory.

Speculatively:
Fixes #27555.

Release note: None