### PR TITLE
[WIP] storage: removing use of engine.NewSnapshot()

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -685,12 +685,10 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, desc := range descs {
-		snap := db.NewSnapshot()
-		defer snap.Close()
 		info, err := storage.RunGC(
 			context.Background(),
 			&desc,
-			snap,
+			db,
 			hlc.Timestamp{WallTime: timeutil.Now().UnixNano()},
 			config.GCPolicy{TTLSeconds: 24 * 60 * 60 /* 1 day */},
 			storage.NoopGCer{},

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -538,22 +538,22 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	// merge below.
 
 	// Get the range stats for both ranges now that we have data.
-	snap := store.Engine().NewSnapshot()
-	defer snap.Close()
-	msA, err := stateloader.Make(nil /* st */, lhsDesc.RangeID).LoadMVCCStats(ctx, snap)
+	readonly := store.Engine().NewReadOnly()
+	defer readonly.Close()
+	msA, err := stateloader.Make(nil /* st */, lhsDesc.RangeID).LoadMVCCStats(ctx, readonly)
 	if err != nil {
 		t.Fatal(err)
 	}
-	msB, err := stateloader.Make(nil /* st */, rhsDesc.RangeID).LoadMVCCStats(ctx, snap)
+	msB, err := stateloader.Make(nil /* st */, rhsDesc.RangeID).LoadMVCCStats(ctx, readonly)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Stats should agree with recomputation.
-	if err := verifyRecomputedStats(snap, lhsDesc, msA, manual.UnixNano()); err != nil {
+	if err := verifyRecomputedStats(readonly, lhsDesc, msA, manual.UnixNano()); err != nil {
 		t.Fatalf("failed to verify range A's stats before split: %v", err)
 	}
-	if err := verifyRecomputedStats(snap, rhsDesc, msB, manual.UnixNano()); err != nil {
+	if err := verifyRecomputedStats(readonly, rhsDesc, msB, manual.UnixNano()); err != nil {
 		t.Fatalf("failed to verify range B's stats before split: %v", err)
 	}
 
@@ -567,15 +567,15 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	replMerged := store.LookupReplica(lhsDesc.StartKey, nil)
 
 	// Get the range stats for the merged range and verify.
-	snap = store.Engine().NewSnapshot()
-	defer snap.Close()
-	msMerged, err := stateloader.Make(nil /* st */, replMerged.RangeID).LoadMVCCStats(ctx, snap)
+	readonly = store.Engine().NewReadOnly()
+	defer readonly.Close()
+	msMerged, err := stateloader.Make(nil /* st */, replMerged.RangeID).LoadMVCCStats(ctx, readonly)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Merged stats should agree with recomputation.
-	if err := verifyRecomputedStats(snap, replMerged.Desc(), msMerged, manual.UnixNano()); err != nil {
+	if err := verifyRecomputedStats(readonly, replMerged.Desc(), msMerged, manual.UnixNano()); err != nil {
 		t.Errorf("failed to verify range's stats after merge: %v", err)
 	}
 }

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -991,6 +991,7 @@ func (r *rocksDBReadOnly) NewIterator(opts IterOptions) Iterator {
 	}
 	if opts.MinTimestampHint != (hlc.Timestamp{}) {
 		// Iterators that specify timestamp bounds cannot be cached.
+		fmt.Printf("%p: NewIterator(): time-bound\n", r)
 		return newRocksDBIterator(r.parent.rdb, opts, r, r.parent)
 	}
 	iter := &r.normalIter
@@ -998,8 +999,10 @@ func (r *rocksDBReadOnly) NewIterator(opts IterOptions) Iterator {
 		iter = &r.prefixIter
 	}
 	if iter.rocksDBIterator.iter == nil {
+		fmt.Printf("%p: NewIterator(prefix=%t): create\n", r, opts.Prefix)
 		iter.rocksDBIterator.init(r.parent.rdb, opts, r, r.parent)
 	} else {
+		fmt.Printf("%p: NewIterator(prefix=%t): reuse\n", r, opts.Prefix)
 		iter.rocksDBIterator.setOptions(opts)
 	}
 	if iter.inuse {

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -496,9 +496,10 @@ func TestGCQueueProcess(t *testing.T) {
 
 	// Call RunGC with dummy functions to get current GCInfo.
 	gcInfo, err := func() (GCInfo, error) {
-		snap := tc.repl.store.Engine().NewSnapshot()
+		// TODO(peter): this should be NewReadOnly().
+		readonly := tc.repl.store.Engine().NewSnapshot()
 		desc := tc.repl.Desc()
-		defer snap.Close()
+		defer readonly.Close()
 
 		zone, err := cfg.GetZoneConfigForKey(desc.StartKey)
 		if err != nil {
@@ -507,7 +508,7 @@ func TestGCQueueProcess(t *testing.T) {
 
 		ctx := context.Background()
 		now := tc.Clock().Now()
-		return RunGC(ctx, desc, snap, now, zone.GC,
+		return RunGC(ctx, desc, readonly, now, zone.GC,
 			NoopGCer{},
 			func(ctx context.Context, intents []roachpb.Intent) error {
 				return nil
@@ -797,11 +798,12 @@ func TestGCQueueTransactionTable(t *testing.T) {
 			"but only %d are left", exp, count)
 	}
 
-	batch := tc.engine.NewSnapshot()
-	defer batch.Close()
+	// TODO(peter): this should be NewReadOnly().
+	readonly := tc.engine.NewSnapshot()
+	defer readonly.Close()
 	tc.repl.raftMu.Lock()
 	tc.repl.mu.Lock()
-	tc.repl.assertStateLocked(context.TODO(), batch) // check that in-mem and on-disk state were updated
+	tc.repl.assertStateLocked(context.TODO(), readonly) // check that in-mem and on-disk state were updated
 	tc.repl.mu.Unlock()
 	tc.repl.raftMu.Unlock()
 

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -222,6 +222,11 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 
 	rangeID := header.State.Desc.RangeID
 
+	// NB: close the replica data iterator before iterating over the entries in
+	// case snap.EngineSnap is caching iterators.
+	snap.Iter.Close()
+	snap.Iter = nil
+
 	if err := iterateEntries(ctx, snap.EngineSnap, rangeID, firstIndex, endIndex, scanFunc); err != nil {
 		return err
 	}

--- a/pkg/storage/ts_maintenance_queue.go
+++ b/pkg/storage/ts_maintenance_queue.go
@@ -151,11 +151,12 @@ func (q *timeSeriesMaintenanceQueue) process(
 	ctx context.Context, repl *Replica, _ config.SystemConfig,
 ) error {
 	desc := repl.Desc()
-	snap := repl.store.Engine().NewSnapshot()
+	readonly := repl.store.Engine().NewReadOnly()
+	defer readonly.Close()
 	now := repl.store.Clock().Now()
-	defer snap.Close()
 	if err := q.tsData.MaintainTimeSeries(
-		ctx, snap, desc.StartKey, desc.EndKey, q.db, &q.mem, TimeSeriesMaintenanceMemoryBudget, now,
+		ctx, readonly, desc.StartKey, desc.EndKey,
+		q.db, &q.mem, TimeSeriesMaintenanceMemoryBudget, now,
 	); err != nil {
 		return err
 	}

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -411,11 +411,11 @@ func (tm *testModelRunner) rollupWithMemoryContext(
 // maintain calls the same operation called by the TS maintenance queue,
 // simulating the effects in the model at the same time.
 func (tm *testModelRunner) maintain(nowNanos int64) {
-	snap := tm.Store.Engine().NewSnapshot()
-	defer snap.Close()
+	readonly := tm.Store.Engine().NewReadOnly()
+	defer readonly.Close()
 	if err := tm.DB.MaintainTimeSeries(
 		context.TODO(),
-		snap,
+		readonly,
 		roachpb.RKey(keys.TimeseriesPrefix),
 		roachpb.RKey(keys.TimeseriesKeyMax),
 		tm.LocalTestCluster.DB,

--- a/pkg/ts/pruning_test.go
+++ b/pkg/ts/pruning_test.go
@@ -276,9 +276,9 @@ func TestFindTimeSeries(t *testing.T) {
 			},
 		},
 	} {
-		snap := e.NewSnapshot()
-		actual, err := tm.DB.findTimeSeries(snap, tcase.start, tcase.end, tcase.timestamp)
-		snap.Close()
+		readonly := e.NewReadOnly()
+		actual, err := tm.DB.findTimeSeries(readonly, tcase.start, tcase.end, tcase.timestamp)
+		readonly.Close()
 		if err != nil {
 			t.Fatalf("case %d: unexpected error %q", i, err)
 		}


### PR DESCRIPTION
RocksDB snapshots touch interesting and different code paths inside of
RocksDB. In particular, snapshots change compaction logic so that
versions on either side of the snapshot are retained. RocksDB iterators
already provide snapshot-like functionality, but do so in a different
fashion by maintaining a reference to the sstables that exited at the
time they were created (and the memtables). The downside to using
iterators for snapshots is that they pin both the sstables and memtables
for their lifetime, so they are best suited for short lifetimes.

Most uses of snapshots can be easily replaced by
engine.NewReadOnly(). The snapshot used by storage.OutgoingSnapshot
deserved attention because it can be held until the snapshot is
sent. But notice that OutgoingSnapshot already held open an iterator on
the snapshot which has the same pinning behavior as a normal iterator.

Release note: None