### PR TITLE
opt: don't let experimental_force_lookup_join disable the optimizer

### DIFF
--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -545,13 +545,6 @@ func (p *planner) optionallyUseOptimizer(
 		log.VEvent(ctx, 1, "optimizer disabled")
 		return false, nil
 	}
-	// TODO(radu): for now, the experimental force lookup join flag does not work
-	// with the optimizer. Turn the optimizer off for the query so the flag can
-	// still function.
-	if sd.OptimizerMode != sessiondata.OptimizerAlways && sd.LookupJoinEnabled {
-		log.VEvent(ctx, 1, "lookup join requested; not using optimizer")
-		return false, nil
-	}
 
 	log.VEvent(ctx, 1, "generating optimizer plan")
 


### PR DESCRIPTION
Removing the piece of code that disables the optimizer when this flag
is set. Note that the flag-specific code already has logic to detect
when the plan is created by the optimizer, in which case it doesn't do
anything.

If we have customers using this flag and the optimizer doesn't address
their usecase, they will need to disable the optimizer.

Note that it's ok to keep using the flag (e.g. in TPCC loadgen), which
is useful if the same load generator is run against different versions
of CRDB.

Release note: None