### PR TITLE
roachtest: remove the clock/monotonic/non_persistent test

### DIFF
--- a/pkg/cmd/roachtest/clock_monotonic.go
+++ b/pkg/cmd/roachtest/clock_monotonic.go
@@ -106,14 +106,6 @@ type clockMonotonicityTestCase struct {
 func makeClockMonotonicTests() testSpec {
 	testCases := []clockMonotonicityTestCase{
 		{
-			// Without enabling the feature to persist wall time, wall time is
-			// currently non monotonic on backward clock jumps when a node is down.
-			name:                     "non_persistent",
-			offset:                   -60 * time.Second,
-			persistWallTimeInterval:  0,
-			expectIncreasingWallTime: false,
-		},
-		{
 			name:                     "persistent",
 			offset:                   -60 * time.Second,
 			persistWallTimeInterval:  500 * time.Millisecond,


### PR DESCRIPTION
This test was trying to verify some behavior following a clock jump when
we weren't persisting the clock. But with a significant clock jump, the
process might fail to start. Or it could start and do something
else (but definitely not work due to the clock offset). The test isn't
adding value, so rather than whack-a-mole we're removing it.

Fixes #26118

Release note: None