### PR TITLE
Simplifying the GH issue template for filers

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,34 +1,17 @@
-Is this a question, feature request, or bug report?
-
-**QUESTION**
-
-Have you checked our documentation at https://cockroachlabs.com/docs/stable/? If you could not find an answer there, please consider asking your question in our community forum at https://forum.cockroachlabs.com/, as it would benefit other members of our community.
-
-Prefer live chat? Message our engineers on our Gitter channel at https://gitter.im/cockroachdb/cockroach.
-
-**FEATURE REQUEST**
-
-1. Does an issue already exist addressing this request? If yes, please add a :+1: reaction to the existing issue. If not, move on to step 2.
-
-2. Please describe the feature you are requesting, as well as your proposed use case for this feature.
-
-3. Indicate the importance of this issue to you (blocker, must-have, should-have, nice-to-have). Are you currently using any workarounds to address this issue?
+Is this a bug report or a feature request?
 
 **BUG REPORT**
 
-1. Please supply the header (i.e. the first few lines) of your most recent
-   log file **for each node in your cluster**. On most unix-based systems
-   running with defaults, this boils down to the output of
-
-     grep -F '[config]' cockroach-data/logs/cockroach.log
-
-   When log files are not available, supply the output of `cockroach version`
-   and all flags/environment variables passed to `cockroach start` instead.
-
-2. Please describe the issue you observed:
+Please describe the issue you observed:
 
 - What did you do?
 
 - What did you expect to see?
 
 - What did you see instead?
+
+**FEATURE REQUEST**
+
+Please describe the feature you are requesting, as well as your proposed use case for this feature.
+
+Prefer live chat? Message our engineers on our Gitter channel at https://gitter.im/cockroachdb/cockroach.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Is this a bug report or a feature request?
+Is this a bug report or a feature request? Prefer live chat? Message our engineers on our Gitter channel at https://gitter.im/cockroachdb/cockroach.
 
 **BUG REPORT**
 
@@ -12,6 +12,4 @@ Please describe the issue you observed:
 
 **FEATURE REQUEST**
 
-Please describe the feature you are requesting, as well as your proposed use case for this feature.
-
-Prefer live chat? Message our engineers on our Gitter channel at https://gitter.im/cockroachdb/cockroach.
+Please describe the feature you are requesting, as well as your proposed use case.


### PR DESCRIPTION
I think our current prompt asks too much from users and I fear we may be missing out on smaller complaints. Now that we have a full PM team and a support team, I think we can offload some of the burdens of discovery to CRL, and generally lower the barriers to filing issues.