### PR TITLE
 opt: simplify merge join orderings

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -812,10 +812,10 @@ join       ·               ·                    (x, y, u, x, y, v)  ·
  │         equality        (x, y) = (x, y)      ·                   ·
  │         mergeJoinOrder  +"(x=x)",+"(y=y)"    ·                   ·
  │         pred            (x = x) AND (y = y)  ·                   ·
- ├── scan  ·               ·                    (x, y, u)           +x,+y
+ ├── scan  ·               ·                    (x, y, u)           +y
  │         table           xyu@primary          ·                   ·
  │         spans           /1-/1/10             ·                   ·
- └── scan  ·               ·                    (x, y, v)           +x,+y
+ └── scan  ·               ·                    (x, y, v)           +y
 ·          table           xyv@primary          ·                   ·
 ·          spans           /1-/1/10             ·                   ·
 
@@ -827,10 +827,10 @@ join       ·               ·                    (x, y, u, x, y, v)  ·
  │         equality        (x, y) = (x, y)      ·                   ·
  │         mergeJoinOrder  +"(x=x)",+"(y=y)"    ·                   ·
  │         pred            (x = x) AND (y = y)  ·                   ·
- ├── scan  ·               ·                    (x, y, u)           +x,+y
+ ├── scan  ·               ·                    (x, y, u)           +y
  │         table           xyu@primary          ·                   ·
  │         spans           /1-/1/10             ·                   ·
- └── scan  ·               ·                    (x, y, v)           +x,+y
+ └── scan  ·               ·                    (x, y, v)           +y
 ·          table           xyv@primary          ·                   ·
 ·          spans           /1-/1/10             ·                   ·
 
@@ -845,7 +845,7 @@ join       ·               ·                    (x, y, u, x, y, v)  ·
  ├── scan  ·               ·                    (x, y, u)           +x,+y
  │         table           xyu@primary          ·                   ·
  │         spans           ALL                  ·                   ·
- └── scan  ·               ·                    (x, y, v)           +x,+y
+ └── scan  ·               ·                    (x, y, v)           +y
 ·          table           xyv@primary          ·                   ·
 ·          spans           /1-/1/10             ·                   ·
 
@@ -857,7 +857,7 @@ join       ·               ·                    (x, y, u, x, y, v)  ·
  │         equality        (x, y) = (x, y)      ·                   ·
  │         mergeJoinOrder  +"(x=x)",+"(y=y)"    ·                   ·
  │         pred            (x = x) AND (y = y)  ·                   ·
- ├── scan  ·               ·                    (x, y, u)           +x,+y
+ ├── scan  ·               ·                    (x, y, u)           +y
  │         table           xyu@primary          ·                   ·
  │         spans           /1-/1/10             ·                   ·
  └── scan  ·               ·                    (x, y, v)           +x,+y
@@ -940,7 +940,7 @@ join       ·               ·                    (x, y, u, x, y, v)  ·
  ├── scan  ·               ·                    (x, y, u)           +x,+y
  │         table           xyu@primary          ·                   ·
  │         spans           ALL                  ·                   ·
- └── scan  ·               ·                    (x, y, v)           +x,+y
+ └── scan  ·               ·                    (x, y, v)           +y
 ·          table           xyv@primary          ·                   ·
 ·          spans           /1-/1/10             ·                   ·
 
@@ -952,7 +952,7 @@ join       ·               ·                    (x, y, u, x, y, v)  ·
  │         equality        (x, y) = (x, y)      ·                   ·
  │         mergeJoinOrder  +"(x=x)",+"(y=y)"    ·                   ·
  │         pred            (x = x) AND (y = y)  ·                   ·
- ├── scan  ·               ·                    (x, y, u)           +x,+y
+ ├── scan  ·               ·                    (x, y, u)           +y
  │         table           xyu@primary          ·                   ·
  │         spans           /1-/1/10             ·                   ·
  └── scan  ·               ·                    (x, y, v)           +x,+y
@@ -1001,10 +1001,10 @@ render          ·               ·           (a)     ·
       │         equality        (a) = (a)   ·       ·
       │         mergeJoinOrder  +"(a=a)"    ·       ·
       │         pred            a = a       ·       ·
-      ├── scan  ·               ·           (a)     +a
+      ├── scan  ·               ·           (a)     ·
       │         table           l@primary   ·       ·
       │         spans           /3-/3/#     ·       ·
-      └── scan  ·               ·           (a)     +a
+      └── scan  ·               ·           (a)     ·
 ·               table           r@primary   ·       ·
 ·               spans           /3-/3/#     ·       ·
 
@@ -1016,10 +1016,10 @@ join       ·               ·           (a, a)  ·
  │         equality        (a) = (a)   ·       ·
  │         mergeJoinOrder  +"(a=a)"    ·       ·
  │         pred            a = a       ·       ·
- ├── scan  ·               ·           (a)     +a
+ ├── scan  ·               ·           (a)     ·
  │         table           l@primary   ·       ·
  │         spans           /3-/3/#     ·       ·
- └── scan  ·               ·           (a)     +a
+ └── scan  ·               ·           (a)     ·
 ·          table           r@primary   ·       ·
 ·          spans           /3-/3/#     ·       ·
 
@@ -1033,10 +1033,10 @@ render          ·               ·            (a)     ·
       │         equality        (a) = (a)    ·       ·
       │         mergeJoinOrder  +"(a=a)"     ·       ·
       │         pred            a = a        ·       ·
-      ├── scan  ·               ·            (a)     +a
+      ├── scan  ·               ·            (a)     ·
       │         table           l@primary    ·       ·
       │         spans           /3-/3/#      ·       ·
-      └── scan  ·               ·            (a)     +a
+      └── scan  ·               ·            (a)     ·
 ·               table           r@primary    ·       ·
 ·               spans           /3-/3/#      ·       ·
 
@@ -1048,10 +1048,10 @@ join       ·               ·            (a, a)  ·
  │         equality        (a) = (a)    ·       ·
  │         mergeJoinOrder  +"(a=a)"     ·       ·
  │         pred            a = a        ·       ·
- ├── scan  ·               ·            (a)     +a
+ ├── scan  ·               ·            (a)     ·
  │         table           l@primary    ·       ·
  │         spans           /3-/3/#      ·       ·
- └── scan  ·               ·            (a)     +a
+ └── scan  ·               ·            (a)     ·
 ·          table           r@primary    ·       ·
 ·          spans           /3-/3/#      ·       ·
 

--- a/pkg/sql/opt/memo/private_defs.go
+++ b/pkg/sql/opt/memo/private_defs.go
@@ -315,6 +315,13 @@ type MergeOnDef struct {
 	// equality columns (to guarantee a certain output ordering). In the example
 	// above, if we can get ordering a+,b+,c+ on the left side and ordering d+,e+
 	// on the right side, we can guarantee a+,b+,c+ on the merge join results.
-	LeftEq  props.OrderingChoice
-	RightEq props.OrderingChoice
+	LeftEq  opt.Ordering
+	RightEq opt.Ordering
+
+	// LeftOrdering and RightOrdering are "simplified" versions of LeftEq/RightEq,
+	// taking into account functional dependencies. We need both versions because
+	// we need to configure execution with specific equality columns and
+	// orderings.
+	LeftOrdering  props.OrderingChoice
+	RightOrdering props.OrderingChoice
 }

--- a/pkg/sql/opt/memo/private_storage.go
+++ b/pkg/sql/opt/memo/private_storage.go
@@ -368,8 +368,12 @@ func (ps *privateStorage) internMergeOnDef(def *MergeOnDef) PrivateID {
 	// the value is already in the map. Be careful when modifying.
 	ps.keyBuf.Reset()
 	ps.keyBuf.writeUvarint(uint64(def.JoinType))
-	ps.keyBuf.writeOrderingChoice(&def.LeftEq)
-	ps.keyBuf.writeOrderingChoice(&def.RightEq)
+	ps.keyBuf.writeOrdering(def.LeftEq)
+	ps.keyBuf.writeOrdering(def.RightEq)
+	ps.keyBuf.writeUvarint(0)
+	ps.keyBuf.writeOrderingChoice(&def.LeftOrdering)
+	ps.keyBuf.writeUvarint(0)
+	ps.keyBuf.writeOrderingChoice(&def.RightOrdering)
 	typ := (*MergeOnDef)(nil)
 	if id, ok := ps.privatesMap[privateKey{iface: typ, str: ps.keyBuf.String()}]; ok {
 		return id

--- a/pkg/sql/opt/memo/private_storage_test.go
+++ b/pkg/sql/opt/memo/private_storage_test.go
@@ -466,8 +466,10 @@ func TestPrivateStorageAllocations(t *testing.T) {
 	scanOpDef := &ScanOpDef{Table: 1, Index: 2, Cols: colSet}
 	groupByDef := &GroupByDef{GroupingCols: colSet, Ordering: props.ParseOrderingChoice("+1")}
 	mergeOnDef := &MergeOnDef{
-		LeftEq:  props.ParseOrderingChoice("+1,+2,+3"),
-		RightEq: props.ParseOrderingChoice("+4,+5,+6"),
+		LeftEq:        opt.Ordering{+1, +2, +3},
+		RightEq:       opt.Ordering{+4, +5, +6},
+		LeftOrdering:  props.ParseOrderingChoice("+1,+2,+3"),
+		RightOrdering: props.ParseOrderingChoice("+4,+5,+6"),
 	}
 	indexJoinDef := &IndexJoinDef{Table: 1, Cols: colSet}
 	lookupJoinDef := &LookupJoinDef{Table: 1, Index: 2, KeyCols: colList, LookupCols: colSet}
@@ -521,8 +523,10 @@ func BenchmarkPrivateStorage(b *testing.B) {
 	scanOpDef := &ScanOpDef{Table: 1, Index: 2, Cols: colSet}
 	groupByDef := &GroupByDef{GroupingCols: colSet, Ordering: props.ParseOrderingChoice("+1")}
 	mergeOnDef := &MergeOnDef{
-		LeftEq:  props.ParseOrderingChoice("+1,+2,+3"),
-		RightEq: props.ParseOrderingChoice("+4,+5,+6"),
+		LeftEq:        opt.Ordering{+1, +2, +3},
+		RightEq:       opt.Ordering{+4, +5, +6},
+		LeftOrdering:  props.ParseOrderingChoice("+1,+2,+3"),
+		RightOrdering: props.ParseOrderingChoice("+4,+5,+6"),
 	}
 	indexJoinDef := &IndexJoinDef{Table: 1, Cols: colSet}
 	lookupJoinDef := &LookupJoinDef{Table: 1, Index: 2, KeyCols: colList, LookupCols: colSet}

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1412,12 +1412,12 @@ semi-join (merge)
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: ()-->(4), (1)-->(2,3,5)
- │    ├── ordering: +1
+ │    ├── ordering: +1 opt(4)
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1
+ │    │    └── ordering: +1 opt(4)
  │    └── filters [type=bool, outer=(2,4), constraints=(/2: [/2 - ]; /4: [/'foo' - /'foo']; tight), fd=()-->(4)]
  │         ├── a.s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
  │         └── a.i > 1 [type=bool, outer=(2), constraints=(/2: [/2 - ]; tight)]
@@ -1552,12 +1552,12 @@ anti-join (merge)
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: ()-->(4), (1)-->(2,3,5)
- │    ├── ordering: +1
+ │    ├── ordering: +1 opt(4)
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1
+ │    │    └── ordering: +1 opt(4)
  │    └── filters [type=bool, outer=(2,4), constraints=(/2: [/2 - ]; /4: [/'foo' - /'foo']; tight), fd=()-->(4)]
  │         ├── a.s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
  │         └── a.i > 1 [type=bool, outer=(2), constraints=(/2: [/2 - ]; tight)]

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -125,12 +125,12 @@ right-join (merge)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string!null) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: ()-->(4), (1)-->(2,3,5)
- │    ├── ordering: +1
+ │    ├── ordering: +1 opt(4)
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1
+ │    │    └── ordering: +1 opt(4)
  │    └── filters [type=bool, outer=(2,4), constraints=(/4: [/'foo' - /'foo']), fd=()-->(4)]
  │         ├── (a.i < 0) OR (a.i > 10) [type=bool, outer=(2)]
  │         └── a.s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
@@ -183,12 +183,12 @@ semi-join (merge)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string!null) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: ()-->(4), (1)-->(2,3,5)
- │    ├── ordering: +1
+ │    ├── ordering: +1 opt(4)
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1
+ │    │    └── ordering: +1 opt(4)
  │    └── filters [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
  │         └── a.s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
  ├── scan b
@@ -267,12 +267,12 @@ left-join (merge)
  │    ├── columns: k:3(int!null) i:4(int) f:5(float) s:6(string!null) j:7(jsonb)
  │    ├── key: (3)
  │    ├── fd: ()-->(6), (3)-->(4,5,7)
- │    ├── ordering: +3
+ │    ├── ordering: +3 opt(6)
  │    ├── scan a
  │    │    ├── columns: k:3(int!null) i:4(int) f:5(float) s:6(string) j:7(jsonb)
  │    │    ├── key: (3)
  │    │    ├── fd: (3)-->(4-7)
- │    │    └── ordering: +3
+ │    │    └── ordering: +3 opt(6)
  │    └── filters [type=bool, outer=(4,6), constraints=(/6: [/'foo' - /'foo']), fd=()-->(6)]
  │         ├── (a.i < 0) OR (a.i > 10) [type=bool, outer=(4)]
  │         └── a.s = 'foo' [type=bool, outer=(6), constraints=(/6: [/'foo' - /'foo']; tight)]

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -530,12 +530,12 @@ semi-join (merge)
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: ()-->(2), (1)-->(3-5)
- │    ├── ordering: +1
+ │    ├── ordering: +1 opt(2)
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1
+ │    │    └── ordering: +1 opt(2)
  │    └── filters [type=bool, outer=(2), constraints=(/2: [/0 - /0]; tight), fd=()-->(2)]
  │         └── a.i = 0 [type=bool, outer=(2), constraints=(/2: [/0 - /0]; tight)]
  ├── scan xy
@@ -561,12 +561,12 @@ anti-join (merge)
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: ()-->(2), (1)-->(3-5)
- │    ├── ordering: +1
+ │    ├── ordering: +1 opt(2)
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1
+ │    │    └── ordering: +1 opt(2)
  │    └── filters [type=bool, outer=(2), constraints=(/2: [/0 - /0]; tight), fd=()-->(2)]
  │         └── a.i = 0 [type=bool, outer=(2), constraints=(/2: [/0 - /0]; tight)]
  ├── scan xy

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -192,9 +192,9 @@ func (o *Optimizer) buildChildPhysicalProps(
 			mergeOn := o.mem.NormExpr(mexpr.AsMergeJoin().MergeOn())
 			def := o.mem.LookupPrivate(mergeOn.AsMergeOn().Def()).(*memo.MergeOnDef)
 			if nth == 0 {
-				childProps.Ordering = def.LeftEq
+				childProps.Ordering = def.LeftOrdering
 			} else {
-				childProps.Ordering = def.RightEq
+				childProps.Ordering = def.RightOrdering
 			}
 		}
 		// ************************* WARNING *************************

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -85,17 +85,13 @@ project
  │    │    ├── key columns: [2] = [3]
  │    │    ├── key: (3)
  │    │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2)
- │    │    ├── ordering: +2
- │    │    ├── sort
+ │    │    ├── ordering: +(2|3) opt(1)
+ │    │    ├── scan phone_register
  │    │    │    ├── columns: phone_id:1(int!null) person_id:2(int!null)
+ │    │    │    ├── constraint: /1/2: [/1 - /1]
  │    │    │    ├── key: (2)
  │    │    │    ├── fd: ()-->(1)
- │    │    │    ├── ordering: +2
- │    │    │    └── scan phone_register
- │    │    │         ├── columns: phone_id:1(int!null) person_id:2(int!null)
- │    │    │         ├── constraint: /1/2: [/1 - /1]
- │    │    │         ├── key: (2)
- │    │    │         └── fd: ()-->(1)
+ │    │    │    └── ordering: +2 opt(1)
  │    │    └── filters [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]), fd=(2)==(3), (3)==(2)]
  │    │         └── phone_register.person_id = phone.id [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ])]
  │    ├── scan phone
@@ -1237,7 +1233,7 @@ semi-join (merge)
  ├── sort
  │    ├── columns: person_id:10(int) order_id:11(int!null)
  │    ├── fd: ()-->(11)
- │    ├── ordering: +10
+ │    ├── ordering: +10 opt(11)
  │    └── select
  │         ├── columns: person_id:10(int) order_id:11(int!null)
  │         ├── fd: ()-->(11)
@@ -1466,10 +1462,10 @@ semi-join (merge)
  ├── select
  │    ├── columns: person_id:7(int!null) addresses:8(string!null)
  │    ├── fd: ()-->(8)
- │    ├── ordering: +7
+ │    ├── ordering: +7 opt(8)
  │    ├── scan person_addresses
  │    │    ├── columns: person_id:7(int!null) addresses:8(string)
- │    │    └── ordering: +7
+ │    │    └── ordering: +7 opt(8)
  │    └── filters [type=bool, outer=(8), constraints=(/8: [/'Home address' - /'Home address']; tight), fd=()-->(8)]
  │         └── person_addresses.addresses = 'Home address' [type=bool, outer=(8), constraints=(/8: [/'Home address' - /'Home address']; tight)]
  └── merge-on
@@ -1850,17 +1846,13 @@ project
  │    │    ├── key columns: [2] = [3]
  │    │    ├── key: (3)
  │    │    ├── fd: ()-->(1), (3)-->(4,5), (2)==(3), (3)==(2)
- │    │    ├── ordering: +2
- │    │    ├── sort
+ │    │    ├── ordering: +(2|3) opt(1)
+ │    │    ├── scan newspaper_news
  │    │    │    ├── columns: newspaper_id:1(int!null) news_news_id:2(int!null)
+ │    │    │    ├── constraint: /1/2: [/1 - /1]
  │    │    │    ├── key: (2)
  │    │    │    ├── fd: ()-->(1)
- │    │    │    ├── ordering: +2
- │    │    │    └── scan newspaper_news
- │    │    │         ├── columns: newspaper_id:1(int!null) news_news_id:2(int!null)
- │    │    │         ├── constraint: /1/2: [/1 - /1]
- │    │    │         ├── key: (2)
- │    │    │         └── fd: ()-->(1)
+ │    │    │    └── ordering: +2 opt(1)
  │    │    └── filters [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]), fd=(2)==(3), (3)==(2)]
  │    │         └── newspaper_news.news_news_id = news.news_id [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ])]
  │    └── merge-on
@@ -1971,17 +1963,13 @@ project
  │    │         │         │    ├── key columns: [2] = [3]
  │    │         │         │    ├── key: (3)
  │    │         │         │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2)
- │    │         │         │    ├── ordering: +2
- │    │         │         │    ├── sort
+ │    │         │         │    ├── ordering: +(2|3) opt(1)
+ │    │         │         │    ├── scan generationuser_generationgroup
  │    │         │         │    │    ├── columns: generationuser_id:1(int!null) ref_id:2(int!null)
+ │    │         │         │    │    ├── constraint: /1/2: [/1 - /1]
  │    │         │         │    │    ├── key: (2)
  │    │         │         │    │    ├── fd: ()-->(1)
- │    │         │         │    │    ├── ordering: +2
- │    │         │         │    │    └── scan generationuser_generationgroup
- │    │         │         │    │         ├── columns: generationuser_id:1(int!null) ref_id:2(int!null)
- │    │         │         │    │         ├── constraint: /1/2: [/1 - /1]
- │    │         │         │    │         ├── key: (2)
- │    │         │         │    │         └── fd: ()-->(1)
+ │    │         │         │    │    └── ordering: +2 opt(1)
  │    │         │         │    └── filters [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]), fd=(2)==(3), (3)==(2)]
  │    │         │         │         └── generationuser_generationgroup.ref_id = generationgroup.id [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ])]
  │    │         │         └── merge-on

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -681,7 +681,7 @@ memo (optimized)
  ├── G6: (variable abc.a)
  └── G7: (variable kfloat.k)
 
-# We should only pick up one equivalency
+# We should only pick up one equivalency.
 opt
 SELECT * FROM abc JOIN xyz ON a=x AND a=y
 ----
@@ -700,6 +700,42 @@ inner-join (merge)
       └── filters [type=bool, outer=(1,5,6), constraints=(/1: (/NULL - ]; /5: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(5,6), (5)==(1,6), (6)==(1,5)]
            ├── abc.a = xyz.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
            └── abc.a = xyz.y [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+
+# Verify that the required orderings are simplified: the equality columns are
+# (u,t)=(x,z) but we are able to utilize indexes on s,t,u and y,z.
+opt
+SELECT * FROM (SELECT * FROM stu WHERE s = u) JOIN (SELECT * FROM xyz WHERE x = y) ON u=x AND t=z
+----
+inner-join (merge)
+ ├── columns: s:1(int!null) t:2(int!null) u:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
+ ├── fd: (1)==(3-5), (3)==(1,4,5), (4)==(1,3,5), (5)==(1,3,4), (2)==(6), (6)==(2)
+ ├── select
+ │    ├── columns: s:1(int!null) t:2(int!null) u:3(int!null)
+ │    ├── key: (2,3)
+ │    ├── fd: (1)==(3), (3)==(1)
+ │    ├── ordering: +(1|3),+2
+ │    ├── scan stu
+ │    │    ├── columns: s:1(int!null) t:2(int!null) u:3(int!null)
+ │    │    ├── key: (1-3)
+ │    │    └── ordering: +(1|3),+2
+ │    └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+ │         └── stu.s = stu.u [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+ ├── select
+ │    ├── columns: x:4(int!null) y:5(int!null) z:6(int)
+ │    ├── fd: (4)==(5), (5)==(4)
+ │    ├── ordering: +(4|5),+6
+ │    ├── scan xyz@yz
+ │    │    ├── columns: x:4(int) y:5(int!null) z:6(int)
+ │    │    ├── constraint: /5/6/7: (/NULL - ]
+ │    │    └── ordering: +(4|5),+6
+ │    └── filters [type=bool, outer=(4,5), constraints=(/4: (/NULL - ]; /5: (/NULL - ]), fd=(4)==(5), (5)==(4)]
+ │         └── xyz.x = xyz.y [type=bool, outer=(4,5), constraints=(/4: (/NULL - ]; /5: (/NULL - ])]
+ └── merge-on
+      ├── left equality columns: +3,+2
+      ├── right equality columns: +4,+6
+      └── filters [type=bool, outer=(2-4,6), constraints=(/2: (/NULL - ]; /3: (/NULL - ]; /4: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(4), (4)==(3), (2)==(6), (6)==(2)]
+           ├── stu.u = xyz.x [type=bool, outer=(3,4), constraints=(/3: (/NULL - ]; /4: (/NULL - ])]
+           └── stu.t = xyz.z [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
 
 # --------------------------------------------------
 # GenerateLookupJoin

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -731,8 +731,8 @@ inner-join (merge)
  │    └── filters [type=bool, outer=(4,5), constraints=(/4: (/NULL - ]; /5: (/NULL - ]), fd=(4)==(5), (5)==(4)]
  │         └── xyz.x = xyz.y [type=bool, outer=(4,5), constraints=(/4: (/NULL - ]; /5: (/NULL - ])]
  └── merge-on
-      ├── left equality columns: +3,+2
-      ├── right equality columns: +4,+6
+      ├── left ordering: +3,+2
+      ├── right ordering: +4,+6
       └── filters [type=bool, outer=(2-4,6), constraints=(/2: (/NULL - ]; /3: (/NULL - ]; /4: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(4), (4)==(3), (2)==(6), (6)==(2)]
            ├── stu.u = xyz.x [type=bool, outer=(3,4), constraints=(/3: (/NULL - ]; /4: (/NULL - ])]
            └── stu.t = xyz.z [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]


### PR DESCRIPTION
We simplify the required orderings for the inputs using the
corresponding FDs. This allows more choices and potentially better
plans.

Note that we still have to remember the orderings on all the equality
columns since we have to configure the mergejoiner with this
information.

Release note: None