### PR TITLE
opt: normalize JSON fetch operations to contains

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -90,22 +90,40 @@ scan  ·       ·          (a, b)  ·
 ·     filter  b @> '{}'  ·       ·
 
 
-# TODO(justin): support these as well.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->'a' = '"b"'
 ----
-scan  ·       ·                 (a, b)  ·
-·     table   d@primary         ·       ·
-·     spans   ALL               ·       ·
-·     filter  (b->'a') = '"b"'  ·       ·
+index-join  ·      ·                            (a, b)  ·
+ ├── scan   ·      ·                            (a)     ·
+ │          table  d@foo_inv                    ·       ·
+ │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
+ └── scan   ·      ·                            (a, b)  ·
+·           table  d@primary                    ·       ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b->'a'->'c' = '"b"'
+----
+index-join  ·      ·                                    (a, b)  ·
+ ├── scan   ·      ·                                    (a)     ·
+ │          table  d@foo_inv                            ·       ·
+ │          spans  /"a"/"c"/"b"-/"a"/"c"/"b"/PrefixEnd  ·       ·
+ └── scan   ·      ·                                    (a, b)  ·
+·           table  d@primary                            ·       ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b->(NULL::STRING) = '"b"'
+----
+norows  ·  ·  (a, b)  ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where '"b"' = b->'a'
 ----
-scan  ·       ·                 (a, b)  ·
-·     table   d@primary         ·       ·
-·     spans   ALL               ·       ·
-·     filter  (b->'a') = '"b"'  ·       ·
+index-join  ·      ·                            (a, b)  ·
+ ├── scan   ·      ·                            (a)     ·
+ │          table  d@foo_inv                    ·       ·
+ │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
+ └── scan   ·      ·                            (a, b)  ·
+·           table  d@primary                    ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b IS NULL

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -159,3 +159,56 @@
 )
 =>
 (Exists $input)
+
+# NormalizeJSONFieldAccess transforms field access into a containment with a
+# simpler LHS. This allows inverted index constraints to be generated in some
+# cases.
+# The FetchVal operator also has a version with
+# integers instead of strings, but this transformation is not valid in that
+# case.
+# This transforms
+#
+#   a->'b' = '"c"'
+#
+# to
+#
+#   a @> '{"b": "c"}'
+#
+[NormalizeJSONFieldAccess, Normalize]
+(Eq
+  (FetchVal
+    $val:*
+    $key:(Const) & ^(Null) & (IsString $key)
+  )
+  $right:(Const)
+)
+=>
+(Contains
+  $val
+  (MakeSingleKeyJSONObject $key $right)
+)
+
+# NormalizeJSONContains contains transforms a field access containment into one
+# with a simpler LHS.  This transformation is only valid if the RHS is not a
+# scalar, since a JSON array "contains" a scalar which is inside of it.
+# This transforms
+#
+#   a->'b' @> '{"x": "c"}'
+#
+# to
+#
+#   a @> '{"b": {"x": "c"}}'
+#
+[NormalizeJSONContains, Normalize]
+(Contains
+  (FetchVal
+    $val:*
+    $key:(Const) & ^(Null) & (IsString $key)
+  )
+  $right:(Const) & ^(IsJSONScalar $right)
+)
+=>
+(Contains
+  $val
+  (MakeSingleKeyJSONObject $key $right)
+)

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -411,3 +411,78 @@ select
       └── exists [type=bool]
            └── scan a
                 └── columns: a.i:8(int) a.s:10(string)
+
+# --------------------------------------------------
+# NormalizeJSONFieldAccess
+# --------------------------------------------------
+opt
+SELECT * FROM a WHERE j->'a' = '"b"'::JSON
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
+ ├── key: (1)
+ ├── fd: (1)-->(2-6)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
+ └── filters [type=bool, outer=(5)]
+      └── a.j @> '{"a": "b"}' [type=bool, outer=(5)]
+
+opt
+SELECT * FROM a WHERE j->'a' @> '{"x": "b"}'::JSON
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
+ ├── key: (1)
+ ├── fd: (1)-->(2-6)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
+ └── filters [type=bool, outer=(5)]
+      └── a.j @> '{"a": {"x": "b"}}' [type=bool, outer=(5)]
+
+opt
+SELECT * FROM a WHERE j->'a'->'x' = '"b"'::JSON
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
+ ├── key: (1)
+ ├── fd: (1)-->(2-6)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
+ └── filters [type=bool, outer=(5)]
+      └── a.j @> '{"a": {"x": "b"}}' [type=bool, outer=(5)]
+
+# The transformation is not valid in this case.
+opt
+SELECT * FROM a WHERE j->2 = '"b"'::JSON
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
+ ├── key: (1)
+ ├── fd: (1)-->(2-6)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
+ └── filters [type=bool, outer=(5)]
+      └── (a.j->2) = '"b"' [type=bool, outer=(5)]
+
+# The transformation is not valid in this case, since j->'a' could be an array.
+opt
+SELECT * FROM a WHERE j->'a' @> '"b"'::JSON
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
+ ├── key: (1)
+ ├── fd: (1)-->(2-6)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
+ └── filters [type=bool, outer=(5)]
+      └── (a.j->'a') @> '"b"' [type=bool, outer=(5)]


### PR DESCRIPTION
This commit normalizes expressions of the form

    a->'b' = '"c"'

to

    a @> '{"b": "c"}'

and

    a->'b' @> '{"x": "c"}'

to

    a @> '{"b": {"x": "c"}}'

Transforming `a->'b' @> "c"` however, is not valid, because of the (strange)
semantics around containment and arrays.

This is slightly more powerful than the version that existed in the
heuristic planner, which would only do the transformation for `=`.
This allows normalizing chained accesses, such as

    a->'b'->'c' = '"x"'

to

    a @> '{"b": {"c": "x"}}'

This is useful because we only generate constraints from the containment
form.

Release note: None