### PR TITLE
workload: make schema and dataset setup idempotent

### DIFF
--- a/pkg/ccl/workloadccl/roachmartccl/roachmart.go
+++ b/pkg/ccl/workloadccl/roachmartccl/roachmart.go
@@ -61,7 +61,7 @@ const (
 	defaultUsers  = 10000
 	defaultOrders = 100000
 
-	zoneLocationsStmt = `INSERT INTO system.locations VALUES
+	zoneLocationsStmt = `UPSERT INTO system.locations VALUES
 		('zone', 'us-east1-b', 33.0641249, -80.0433347),
 		('zone', 'us-west1-b', 45.6319052, -121.2010282),
 		('zone', 'europe-west2-b', 51.509865, 0)

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -20,6 +20,7 @@ import (
 	gosql "database/sql"
 	"math/rand"
 	"net/url"
+	"strings"
 	"sync"
 
 	"fmt"
@@ -209,7 +210,12 @@ func (w *tpcc) Hooks() workload.Hooks {
 			}
 			for _, fkStmt := range fkStmts {
 				if _, err := sqlDB.Exec(fkStmt); err != nil {
-					return err
+					// If the statement failed because the fk already exists,
+					// ignore it. Return the error for any other reason.
+					const duplFKErr = "columns cannot be used by multiple foreign key constraints"
+					if !strings.Contains(err.Error(), duplFKErr) {
+						return err
+					}
 				}
 			}
 			return nil


### PR DESCRIPTION
This change adjusts workload setup such that it can now be
performed multiple times without issue. This makes workload
much easier to run from multiple nodes at a time because
initialization coordination is no longer necessary.

Release note: None