### PR TITLE
backport-2.0: server: persist correct cluster version on join

### DIFF
--- a/pkg/storage/stores.go
+++ b/pkg/storage/stores.go
@@ -414,8 +414,6 @@ func SynthesizeClusterVersionFromEngines(
 		origin string
 	}
 
-	// FIXME(tschottdorf): If we don't find anything, this should return v1.0, but
-	// we have to guarantee first that you always find something (should be OK).
 	maxMinVersion := originVersion{
 		Version: minSupportedVersion,
 		origin:  "(no store)",
@@ -548,8 +546,24 @@ func (ls *Stores) engines() []engine.Engine {
 }
 
 // OnClusterVersionChange is invoked when the running node receives a notification
-// indicating that the cluster version has changed.
+// indicating that the cluster version has changed. It checks the currently persisted
+// version and updates if it is older than the provided update.
 func (ls *Stores) OnClusterVersionChange(ctx context.Context, cv cluster.ClusterVersion) error {
+	// Grab a lock to make sure that there aren't two interleaved invocations of
+	// this method that result in clobbering of an update.
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	synthCV, err := ls.SynthesizeClusterVersion(ctx)
+	if err != nil {
+		return errors.Wrap(err, "reading persisted cluster version")
+	}
+	// If the update downgrades the minimum version, ignore it. Must be a
+	// reordering (this method is called from multiple goroutines via
+	// `(*Node).onClusterVersionChange)`). Note that we do carry out the upgrade if
+	// the MinVersion is identical, to backfill the engines that may still need it.
+	if cv.MinimumVersion.Less(synthCV.MinimumVersion) {
+		return nil
+	}
 	if err := ls.WriteClusterVersion(ctx, cv); err != nil {
 		return errors.Wrap(err, "writing cluster version")
 	}


### PR DESCRIPTION
Backport 1/2 commits from #27639.

I had to adapt the test, and I have verified that it fails without the main change.

/cc @cockroachdb/release

---

Prior to this commit, when a node joined an existing cluster, it would
likely persist its MinSupportedVersion as the cluster version (even
though it would operate at the correct version). This is problematic
since this node's data directories wouldn't be regarded compatible with
the successor version of the real version, even though they are.

The problem was that the callback which receives the real cluster
version would fire before the stores were bootstrapped, and bootstrap
would erroneously pick the minimum supported version. We now "backfill"
the correct cluster version after having bootstrapped all stores.

Even though the fixtures will need to be regenerated:
Fixes #27525.

Optimistically:
Fixes #27162.

Release note: None
