### PR TITLE
server: deflake TestAdminAPITableStats

### DIFF
--- a/pkg/server/admin_cluster_test.go
+++ b/pkg/server/admin_cluster_test.go
@@ -88,7 +88,7 @@ func TestAdminAPITableStats(t *testing.T) {
 	// this to occur, and for full replication.
 	testutils.SucceedsSoon(t, func() error {
 		if err := httputil.GetJSON(client, url, &tsResponse); err != nil {
-			return err
+			t.Fatal(err)
 		}
 		if len(tsResponse.MissingNodes) != 0 {
 			return errors.Errorf("missing nodes: %+v", tsResponse.MissingNodes)
@@ -102,14 +102,12 @@ func TestAdminAPITableStats(t *testing.T) {
 		if a, e := tsResponse.ReplicaCount, int64(nodeCount); a != e {
 			return errors.Errorf("expected %d replicas, found %d", e, a)
 		}
+		if a, e := tsResponse.Stats.KeyCount, int64(30); a < e {
+			return errors.Errorf("expected at least %d total keys, found %d", e, a)
+		}
 		return nil
 	})
 
-	// These two conditions *must* be true, given that the above
-	// SucceedsSoon has succeeded.
-	if a, e := tsResponse.Stats.KeyCount, int64(20); a < e {
-		t.Fatalf("expected at least 20 total keys, found %d", a)
-	}
 	if len(tsResponse.MissingNodes) > 0 {
 		t.Fatalf("expected no missing nodes, found %v", tsResponse.MissingNodes)
 	}


### PR DESCRIPTION
The test writes 10 keys and wants to check that they are fully
replicated, i.e. that there are at least 20 keys across the replicas.
But if the first couple of keys are written before the range has
upreplicated in the first place, numbers smaller than 20 are possible.
Instead, retry the condition until the writes are fully replicated, i.e.
30 keys are visible.

Fixes #25831.

Release note: None