### PR TITLE
WIP distsql: add subquery support in distsql

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -925,7 +925,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 		&ex.sessionTracing,
 	)
 	ex.server.cfg.DistSQLPlanner.PlanAndRun(
-		ctx, planner.txn, planner.curPlan.plan, recv, planner.ExtendedEvalContext(),
+		ctx, planner.txn, planner, planner.curPlan.plan, recv, planner.ExtendedEvalContext(),
 	)
 	return recv.commErr
 }

--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -289,11 +289,17 @@ func checkDistAggregationInfo(
 
 	if info.FinalRendering != nil {
 		h := tree.MakeTypesOnlyIndexedVarHelper(sqlbase.ColumnTypesToDatumTypes(finalOutputTypes))
-		expr, err := info.FinalRendering(&h, varIdxs)
+		renderExpr, err := info.FinalRendering(&h, varIdxs)
 		if err != nil {
 			t.Fatal(err)
 		}
-		finalProc.Post.RenderExprs = []distsqlrun.Expression{MakeExpression(expr, nil, nil)}
+		var expr distsqlrun.Expression
+		expr, err = MakeExpression(renderExpr, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		finalProc.Post.RenderExprs = []distsqlrun.Expression{expr}
+
 	}
 
 	procs = append(procs, finalProc)

--- a/pkg/sql/distsqlplan/physical_plan_test.go
+++ b/pkg/sql/distsqlplan/physical_plan_test.go
@@ -199,7 +199,7 @@ func TestProjectionAndRendering(t *testing.T) {
 			resultTypes: "A,B,C,D",
 
 			action: func(p *PhysicalPlan) {
-				p.AddRendering(
+				if err := p.AddRendering(
 					[]tree.TypedExpr{
 						&tree.IndexedVar{Idx: 10},
 						&tree.IndexedVar{Idx: 11},
@@ -209,7 +209,9 @@ func TestProjectionAndRendering(t *testing.T) {
 					nil,
 					[]int{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2, 3},
 					[]sqlbase.ColumnType{strToType("A"), strToType("B"), strToType("C"), strToType("D")},
-				)
+				); err != nil {
+					t.Fatal(err)
+				}
 			},
 
 			expPost:        distsqlrun.PostProcessSpec{},
@@ -222,7 +224,7 @@ func TestProjectionAndRendering(t *testing.T) {
 			resultTypes: "A,B,C,D",
 
 			action: func(p *PhysicalPlan) {
-				p.AddRendering(
+				if err := p.AddRendering(
 					[]tree.TypedExpr{
 						&tree.IndexedVar{Idx: 11},
 						&tree.IndexedVar{Idx: 13},
@@ -231,7 +233,10 @@ func TestProjectionAndRendering(t *testing.T) {
 					nil,
 					[]int{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2, 3},
 					[]sqlbase.ColumnType{strToType("B"), strToType("D"), strToType("C")},
-				)
+				); err != nil {
+					t.Fatal(err)
+				}
+
 			},
 
 			expPost: distsqlrun.PostProcessSpec{
@@ -248,7 +253,7 @@ func TestProjectionAndRendering(t *testing.T) {
 			ordering:    "3",
 
 			action: func(p *PhysicalPlan) {
-				p.AddRendering(
+				if err := p.AddRendering(
 					[]tree.TypedExpr{
 						&tree.BinaryExpr{
 							Operator: tree.Plus,
@@ -259,7 +264,9 @@ func TestProjectionAndRendering(t *testing.T) {
 					nil,
 					[]int{0, 1, 2},
 					[]sqlbase.ColumnType{strToType("X")},
-				)
+				); err != nil {
+					t.Fatal(err)
+				}
 			},
 
 			expPost: distsqlrun.PostProcessSpec{
@@ -279,7 +286,7 @@ func TestProjectionAndRendering(t *testing.T) {
 			ordering:    "0,-3",
 
 			action: func(p *PhysicalPlan) {
-				p.AddRendering(
+				if err := p.AddRendering(
 					[]tree.TypedExpr{
 						&tree.BinaryExpr{
 							Operator: tree.Plus,
@@ -291,7 +298,9 @@ func TestProjectionAndRendering(t *testing.T) {
 					nil,
 					[]int{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2},
 					[]sqlbase.ColumnType{strToType("X"), strToType("A")},
-				)
+				); err != nil {
+					t.Fatal(err)
+				}
 			},
 
 			expPost: distsqlrun.PostProcessSpec{

--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -23,7 +23,7 @@ WITH t AS (SELECT * FROM y WHERE a < 3)
 
 
 # Using a CTE inside a subquery
-query I
+query I rowsort
 WITH t(x) AS (SELECT a FROM x)
   SELECT * FROM y WHERE a IN (SELECT x FROM t)
 ----

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -515,15 +515,6 @@ func (p *planner) prepareForDistSQLSupportCheck(
 ) (bool, error) {
 	// Trigger limit propagation.
 	p.setUnlimited(p.curPlan.plan)
-	// We don't support subqueries yet.
-	if len(p.curPlan.subqueryPlans) > 0 {
-		if returnError {
-			err := newQueryNotSupportedError("subqueries not supported yet")
-			log.VEventf(ctx, 1, "query not supported for distSQL: %s", err)
-			return false, err
-		}
-		return false, nil
-	}
 	return true, nil
 }
 

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -119,7 +119,7 @@ func (dsp *DistSQLPlanner) Exec(ctx context.Context, localPlanner interface{}, s
 		p.ExtendedEvalContext().Tracing,
 	)
 	dsp.PlanAndRun(
-		ctx, p.Txn(), p.curPlan.plan, recv, p.ExtendedEvalContext(),
+		ctx, p.Txn(), p, p.curPlan.plan, recv, p.ExtendedEvalContext(),
 	)
 	return nil
 }


### PR DESCRIPTION
WIP as I'm still failing a couple tests, but the general structure seems right to me.

Subqueries are now supported in DistSQL via a naive execution strategy
of fully evaluating the subqueries and lexically substituting the
resulting expressions for the subqueries in the plan nodes before
physically planning the query. This is only done for queries that are
not already decorrelated, and thus does not affect subqueries that are
optimized before the physical planning stage.

Release note (sql change): Subqueries are now supported in the
Distributed SQL execution engine.