### PR TITLE
roachtest: workaround for kv/splits failure

### DIFF
--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -181,7 +181,8 @@ func registerKVSplits(r *registry) {
 			nodes := c.nodes - 1
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
-			c.Start(ctx, c.Range(1, nodes), startArgs("--env=COCKROACH_MEMPROF_INTERVAL=1m"))
+			c.Start(ctx, c.Range(1, nodes),
+				startArgs("--env=COCKROACH_MEMPROF_INTERVAL=1m", "--args=--cache=256MiB"))
 
 			t.Status("running workload")
 			m := newMonitor(ctx, c, c.Range(1, nodes))


### PR DESCRIPTION
The kv/splits/nodes=3 roachtest creates a 3 node cluster and then splits
an empty table over and over until 500k ranges are
created. Unfortunately, 2.1 uses slightly more memory per range than 2.0
and the result is that this test went from passing to failing in some
bizarre ways (liveness failures and then apparent killing by some
external system). The long term fix is to use less memory per range,
probably by evicting idle ranges from memory completely, or replacing
them with a minimal stub. In the short term, we can set the RocksDB
cache size for the test lower to free up 3GB of memory for the test.

Fixes #26081

Release note: None