### PR TITLE
opt: Add more external queries with correlated subqueries

### DIFF
--- a/pkg/sql/opt/xform/testdata/external/activerecord
+++ b/pkg/sql/opt/xform/testdata/external/activerecord
@@ -181,24 +181,94 @@ TABLE pg_type
       ├── typnamespace oid not null
       └── oid oid not null (storing)
 
-# TODO(andyk): Need to analyze subquery filter to prove that only one row can be
-#              returned from the subquery.
-#opt
-#SELECT a.attname,
-#  format_type(a.atttypid, a.atttypmod),
-#  pg_get_expr(d.adbin, d.adrelid),
-#  a.attnotnull,
-#  a.atttypid,
-#  a.atttypmod,
-#  (SELECT c.collname
-#   FROM pg_collation c, pg_type t
-#   WHERE c.oid = a.attcollation
-#   AND t.oid = a.atttypid
-#   AND a.attcollation <> t.typcollation),
-#   col_description(a.attrelid, a.attnum) AS comment
-#FROM pg_attribute a LEFT JOIN pg_attrdef d
-#ON a.attrelid = d.adrelid AND a.attnum = d.adnum
-#WHERE a.attrelid = '"numbers"'::regclass
-#AND a.attnum > 0 AND NOT a.attisdropped
-#ORDER BY a.attnum
-#----
+# TODO(andyk): Need to decorrelate LeftJoin -> Project complex.
+opt
+SELECT a.attname,
+  format_type(a.atttypid, a.atttypmod),
+  pg_get_expr(d.adbin, d.adrelid),
+  a.attnotnull,
+  a.atttypid,
+  a.atttypmod,
+  (SELECT c.collname
+   FROM pg_collation c, pg_type t
+   WHERE c.oid = a.attcollation
+   AND t.oid = a.atttypid
+   AND a.attcollation <> t.typcollation),
+   col_description(a.attrelid, a.attnum) AS comment
+FROM pg_attribute a LEFT JOIN pg_attrdef d
+ON a.attrelid = d.adrelid AND a.attnum = d.adnum
+WHERE a.attrelid = '"numbers"'::regclass
+AND a.attnum > 0 AND NOT a.attisdropped
+ORDER BY a.attnum
+----
+sort
+ ├── columns: attname:2(string!null) format_type:27(string) pg_get_expr:28(string) attnotnull:13(bool!null) atttypid:3(oid!null) atttypmod:9(int!null) collname:67(string) comment:68(string)
+ ├── fd: (3,9)-->(27)
+ ├── ordering: +6
+ └── project
+      ├── columns: format_type:27(string) pg_get_expr:28(string) collname:67(string) comment:68(string) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null)
+      ├── fd: (3,9)-->(27)
+      ├── left-join-apply
+      │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null) adrelid:23(oid) adnum:24(int) adbin:25(string) pg_collation.collname:30(string)
+      │    ├── key: (1,6,23,24)
+      │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18), (23,24)-->(25), (1,6,23,24)-->(30)
+      │    ├── right-join
+      │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null) adrelid:23(oid) adnum:24(int) adbin:25(string)
+      │    │    ├── key: (1,6,23,24)
+      │    │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18), (23,24)-->(25)
+      │    │    ├── select
+      │    │    │    ├── columns: adrelid:23(oid!null) adnum:24(int!null) adbin:25(string)
+      │    │    │    ├── key: (23,24)
+      │    │    │    ├── fd: (23,24)-->(25)
+      │    │    │    ├── scan pg_attrdef
+      │    │    │    │    ├── columns: adrelid:23(oid!null) adnum:24(int!null) adbin:25(string)
+      │    │    │    │    ├── key: (23,24)
+      │    │    │    │    └── fd: (23,24)-->(25)
+      │    │    │    └── filters [type=bool, outer=(23,24), constraints=(/23: (/NULL - ]; /24: [/1 - ])]
+      │    │    │         ├── pg_attrdef.adrelid = '"numbers"'::REGCLASS [type=bool, outer=(23), constraints=(/23: (/NULL - ])]
+      │    │    │         └── pg_attrdef.adnum > 0 [type=bool, outer=(24), constraints=(/24: [/1 - ]; tight)]
+      │    │    ├── select
+      │    │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null)
+      │    │    │    ├── key: (1,6)
+      │    │    │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18)
+      │    │    │    ├── scan pg_attribute
+      │    │    │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null)
+      │    │    │    │    ├── key: (1,6)
+      │    │    │    │    └── fd: (1,6)-->(2,3,9,13,15,18), (1,2)-->(3,6,9,13,15,18)
+      │    │    │    └── filters [type=bool, outer=(1,6,15), constraints=(/1: (/NULL - ]; /6: [/1 - ]; /15: [/false - /false]), fd=()-->(15)]
+      │    │    │         ├── pg_attribute.attrelid = '"numbers"'::REGCLASS [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+      │    │    │         ├── pg_attribute.attnum > 0 [type=bool, outer=(6), constraints=(/6: [/1 - ]; tight)]
+      │    │    │         └── NOT pg_attribute.attisdropped [type=bool, outer=(15), constraints=(/15: [/false - /false]; tight)]
+      │    │    └── filters [type=bool, outer=(1,6,23,24), constraints=(/1: (/NULL - ]; /6: (/NULL - ]; /23: (/NULL - ]; /24: (/NULL - ]), fd=(1)==(23), (23)==(1), (6)==(24), (24)==(6)]
+      │    │         ├── pg_attribute.attrelid = pg_attrdef.adrelid [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ])]
+      │    │         └── pg_attribute.attnum = pg_attrdef.adnum [type=bool, outer=(6,24), constraints=(/6: (/NULL - ]; /24: (/NULL - ])]
+      │    ├── project
+      │    │    ├── columns: pg_collation.collname:30(string!null)
+      │    │    ├── outer: (3,18)
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(30)
+      │    │    └── inner-join
+      │    │         ├── columns: pg_collation.oid:29(oid!null) pg_collation.collname:30(string!null) pg_type.oid:36(oid!null) typcollation:63(oid!null)
+      │    │         ├── outer: (3,18)
+      │    │         ├── cardinality: [0 - 1]
+      │    │         ├── key: ()
+      │    │         ├── fd: ()-->(29,30,36,63)
+      │    │         ├── scan pg_collation@pg_collation_name_enc_nsp_index
+      │    │         │    ├── columns: pg_collation.oid:29(oid!null) pg_collation.collname:30(string!null)
+      │    │         │    ├── key: (29)
+      │    │         │    └── fd: (29)-->(30)
+      │    │         ├── scan pg_type
+      │    │         │    ├── columns: pg_type.oid:36(oid!null) typcollation:63(oid!null)
+      │    │         │    ├── key: (36)
+      │    │         │    └── fd: (36)-->(63)
+      │    │         └── filters [type=bool, outer=(3,18,29,36,63), constraints=(/3: (/NULL - ]; /18: (/NULL - ]; /29: (/NULL - ]; /36: (/NULL - ]; /63: (/NULL - ]), fd=(18)==(29), (29)==(18), (3)==(36), (36)==(3)]
+      │    │              ├── pg_collation.oid = pg_attribute.attcollation [type=bool, outer=(18,29), constraints=(/18: (/NULL - ]; /29: (/NULL - ])]
+      │    │              ├── pg_type.oid = pg_attribute.atttypid [type=bool, outer=(3,36), constraints=(/3: (/NULL - ]; /36: (/NULL - ])]
+      │    │              └── pg_attribute.attcollation != pg_type.typcollation [type=bool, outer=(18,63), constraints=(/18: (/NULL - ]; /63: (/NULL - ])]
+      │    └── true [type=bool]
+      └── projections [outer=(1-3,6,9,13,23,25,30)]
+           ├── format_type(pg_attribute.atttypid, pg_attribute.atttypmod) [type=string, outer=(3,9)]
+           ├── pg_get_expr(pg_attrdef.adbin, pg_attrdef.adrelid) [type=string, outer=(23,25)]
+           ├── variable: pg_collation.collname [type=string, outer=(30)]
+           └── col_description(pg_attribute.attrelid, pg_attribute.attnum) [type=string, outer=(1,6)]

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -2101,3 +2101,702 @@ project
 exec-ddl
 drop table TAuction2, TBid2;
 ----
+
+# ------------------------------------------------------------------------------
+# Query #11
+#   org.hibernate.test.cid.CompositeIdTest
+#   TODO(andyk): Need to decorrelate LeftJoin -> Project complex.
+# ------------------------------------------------------------------------------
+exec-ddl
+CREATE TABLE customer (
+  customerid VARCHAR(10) NOT NULL,
+  name VARCHAR(100) NOT NULL,
+  address VARCHAR(200) NOT NULL,
+  PRIMARY KEY (customerid)
+);
+----
+TABLE customer
+ ├── customerid string not null
+ ├── name string not null
+ ├── address string not null
+ └── INDEX primary
+      └── customerid string not null
+
+exec-ddl
+CREATE TABLE customerorder (
+  customerid VARCHAR(10) NOT NULL,
+  ordernumber INT4 NOT NULL,
+  orderdate DATE NOT NULL,
+  PRIMARY KEY (customerid, ordernumber)
+);
+----
+TABLE customerorder
+ ├── customerid string not null
+ ├── ordernumber int not null
+ ├── orderdate date not null
+ └── INDEX primary
+      ├── customerid string not null
+      └── ordernumber int not null
+
+exec-ddl
+CREATE TABLE lineitem (
+  customerid VARCHAR(10) NOT NULL,
+  ordernumber INT4 NOT NULL,
+  productid VARCHAR(10) NOT NULL,
+  quantity INT4,
+  PRIMARY KEY (customerid, ordernumber, productid)
+);
+----
+TABLE lineitem
+ ├── customerid string not null
+ ├── ordernumber int not null
+ ├── productid string not null
+ ├── quantity int
+ └── INDEX primary
+      ├── customerid string not null
+      ├── ordernumber int not null
+      └── productid string not null
+
+exec-ddl
+CREATE TABLE product (
+  productid VARCHAR(10) NOT NULL,
+  description VARCHAR(200) NOT NULL,
+  cost NUMERIC(19,2),
+  numberavailable INT4,
+  PRIMARY KEY (productid)
+);
+----
+TABLE product
+ ├── productid string not null
+ ├── description string not null
+ ├── cost decimal
+ ├── numberavailable int
+ └── INDEX primary
+      └── productid string not null
+
+opt
+SELECT
+  order0_.customerid AS customer1_1_0_,
+  order0_.ordernumber AS ordernum2_1_0_,
+  order0_.orderdate AS orderdat3_1_0_,
+  (
+    SELECT
+      sum(li.quantity * p.cost)
+    FROM
+      lineitem AS li, product AS p
+    WHERE
+      li.productid = p.productid
+      AND li.customerid = order0_.customerid
+      AND li.ordernumber = order0_.ordernumber
+  )
+    AS formula101_0_,
+  lineitems1_.customerid AS customer1_2_1_,
+  lineitems1_.ordernumber AS ordernum2_2_1_,
+  lineitems1_.productid AS producti3_2_1_,
+  lineitems1_.customerid AS customer1_2_2_,
+  lineitems1_.ordernumber AS ordernum2_2_2_,
+  lineitems1_.productid AS producti3_2_2_,
+  lineitems1_.quantity AS quantity4_2_2_
+FROM
+  customerorder AS order0_
+  LEFT JOIN lineitem AS lineitems1_
+  ON
+    order0_.customerid = lineitems1_.customerid
+    AND order0_.ordernumber = lineitems1_.ordernumber
+WHERE
+  order0_.customerid = 'c111' AND order0_.ordernumber = 0;
+----
+project
+ ├── columns: customer1_1_0_:1(string) ordernum2_1_0_:2(int) orderdat3_1_0_:3(date) formula101_0_:18(decimal) customer1_2_1_:4(string) ordernum2_2_1_:5(int) producti3_2_1_:6(string) customer1_2_2_:4(string) ordernum2_2_2_:5(int) producti3_2_2_:6(string) quantity4_2_2_:7(int)
+ ├── key: (6)
+ ├── fd: ()-->(1-3), (6)-->(4,5,7,18), ()~~>(4,5)
+ ├── group-by
+ │    ├── columns: customerorder.customerid:1(string) customerorder.ordernumber:2(int) orderdate:3(date) lineitem.customerid:4(string) lineitem.ordernumber:5(int) lineitem.productid:6(string) lineitem.quantity:7(int) sum:17(decimal)
+ │    ├── grouping columns: lineitem.productid:6(string)
+ │    ├── key: (6)
+ │    ├── fd: ()-->(1-3), (6)-->(1-5,7,17), ()~~>(4,5)
+ │    ├── left-join-apply
+ │    │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date!null) lineitem.customerid:4(string) lineitem.ordernumber:5(int) lineitem.productid:6(string) lineitem.quantity:7(int) column16:16(decimal)
+ │    │    ├── fd: ()-->(1-3), (6)-->(4,5,7), ()~~>(4,5)
+ │    │    ├── left-join (merge)
+ │    │    │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date!null) lineitem.customerid:4(string) lineitem.ordernumber:5(int) lineitem.productid:6(string) lineitem.quantity:7(int)
+ │    │    │    ├── key: (6)
+ │    │    │    ├── fd: ()-->(1-3), (6)-->(4,5,7), ()~~>(4,5)
+ │    │    │    ├── scan customerorder
+ │    │    │    │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date!null)
+ │    │    │    │    ├── constraint: /1/2: [/'c111'/0 - /'c111'/0]
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    └── fd: ()-->(1-3)
+ │    │    │    ├── scan lineitem
+ │    │    │    │    ├── columns: lineitem.customerid:4(string!null) lineitem.ordernumber:5(int!null) lineitem.productid:6(string!null) lineitem.quantity:7(int)
+ │    │    │    │    ├── constraint: /4/5/6: [/'c111'/0 - /'c111'/0]
+ │    │    │    │    ├── key: (6)
+ │    │    │    │    └── fd: ()-->(4,5), (6)-->(7)
+ │    │    │    └── merge-on
+ │    │    │         ├── left ordering: +1,+2
+ │    │    │         ├── right ordering: +4,+5
+ │    │    │         └── filters [type=bool, outer=(1,2,4,5), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /4: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(4), (4)==(1), (2)==(5), (5)==(2)]
+ │    │    │              ├── customerorder.customerid = lineitem.customerid [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ])]
+ │    │    │              └── customerorder.ordernumber = lineitem.ordernumber [type=bool, outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ])]
+ │    │    ├── project
+ │    │    │    ├── columns: column16:16(decimal)
+ │    │    │    ├── outer: (1,2)
+ │    │    │    ├── inner-join
+ │    │    │    │    ├── columns: lineitem.customerid:8(string!null) lineitem.ordernumber:9(int!null) lineitem.productid:10(string!null) lineitem.quantity:11(int) product.productid:12(string!null) cost:14(decimal)
+ │    │    │    │    ├── outer: (1,2)
+ │    │    │    │    ├── key: (12)
+ │    │    │    │    ├── fd: ()-->(8,9), (10)-->(11), (12)-->(14), (10)==(12), (12)==(10)
+ │    │    │    │    ├── scan lineitem
+ │    │    │    │    │    ├── columns: lineitem.customerid:8(string!null) lineitem.ordernumber:9(int!null) lineitem.productid:10(string!null) lineitem.quantity:11(int)
+ │    │    │    │    │    ├── key: (8-10)
+ │    │    │    │    │    └── fd: (8-10)-->(11)
+ │    │    │    │    ├── scan product
+ │    │    │    │    │    ├── columns: product.productid:12(string!null) cost:14(decimal)
+ │    │    │    │    │    ├── key: (12)
+ │    │    │    │    │    └── fd: (12)-->(14)
+ │    │    │    │    └── filters [type=bool, outer=(1,2,8-10,12), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /8: (/NULL - ]; /9: (/NULL - ]; /10: (/NULL - ]; /12: (/NULL - ]), fd=(10)==(12), (12)==(10), (1)==(8), (8)==(1), (2)==(9), (9)==(2)]
+ │    │    │    │         ├── lineitem.productid = product.productid [type=bool, outer=(10,12), constraints=(/10: (/NULL - ]; /12: (/NULL - ])]
+ │    │    │    │         ├── lineitem.customerid = customerorder.customerid [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
+ │    │    │    │         └── lineitem.ordernumber = customerorder.ordernumber [type=bool, outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ])]
+ │    │    │    └── projections [outer=(11,14)]
+ │    │    │         └── lineitem.quantity * product.cost [type=decimal, outer=(11,14)]
+ │    │    └── true [type=bool]
+ │    └── aggregations [outer=(1-5,7,16)]
+ │         ├── sum [type=decimal, outer=(16)]
+ │         │    └── variable: column16 [type=decimal, outer=(16)]
+ │         ├── any-not-null [type=string, outer=(1)]
+ │         │    └── variable: customerorder.customerid [type=string, outer=(1)]
+ │         ├── any-not-null [type=int, outer=(2)]
+ │         │    └── variable: customerorder.ordernumber [type=int, outer=(2)]
+ │         ├── any-not-null [type=date, outer=(3)]
+ │         │    └── variable: customerorder.orderdate [type=date, outer=(3)]
+ │         ├── any-not-null [type=string, outer=(4)]
+ │         │    └── variable: lineitem.customerid [type=string, outer=(4)]
+ │         ├── any-not-null [type=int, outer=(5)]
+ │         │    └── variable: lineitem.ordernumber [type=int, outer=(5)]
+ │         └── any-not-null [type=int, outer=(7)]
+ │              └── variable: lineitem.quantity [type=int, outer=(7)]
+ └── projections [outer=(1-7,17)]
+      └── variable: sum [type=decimal, outer=(17)]
+
+opt
+SELECT
+  customer0_.customerid AS customer1_0_0_,
+  orders1_.customerid AS customer1_1_1_,
+  orders1_.ordernumber AS ordernum2_1_1_,
+  lineitems2_.customerid AS customer1_2_2_,
+  lineitems2_.ordernumber AS ordernum2_2_2_,
+  lineitems2_.productid AS producti3_2_2_,
+  product3_.productid AS producti1_3_3_,
+  customer0_.name AS name2_0_0_,
+  customer0_.address AS address3_0_0_,
+  orders1_.orderdate AS orderdat3_1_1_,
+  (
+    SELECT
+      sum(li.quantity * p.cost)
+    FROM
+      lineitem AS li, product AS p
+    WHERE
+      li.productid = p.productid
+      AND li.customerid = orders1_.customerid
+      AND li.ordernumber = orders1_.ordernumber
+  )
+    AS formula103_1_,
+  orders1_.customerid AS customer1_1_0__,
+  orders1_.ordernumber AS ordernum2_1_0__,
+  orders1_.ordernumber AS ordernum2_0__,
+  lineitems2_.quantity AS quantity4_2_2_,
+  lineitems2_.customerid AS customer1_2_1__,
+  lineitems2_.ordernumber AS ordernum2_2_1__,
+  lineitems2_.productid AS producti3_2_1__,
+  product3_.description AS descript2_3_3_,
+  product3_.cost AS cost3_3_3_,
+  product3_.numberavailable AS numberav4_3_3_,
+  (
+    SELECT
+      sum(li.quantity)
+    FROM
+      lineitem AS li
+    WHERE
+      li.productid = product3_.productid
+  )
+    AS formula104_3_
+FROM
+  customer AS customer0_
+  LEFT JOIN customerorder AS orders1_
+  ON customer0_.customerid = orders1_.customerid
+  LEFT JOIN lineitem AS lineitems2_
+  ON
+    orders1_.customerid = lineitems2_.customerid
+    AND orders1_.ordernumber = lineitems2_.ordernumber
+  LEFT JOIN product AS product3_ ON lineitems2_.productid = product3_.productid;
+----
+project
+ ├── columns: customer1_0_0_:1(string!null) customer1_1_1_:4(string) ordernum2_1_1_:5(int) customer1_2_2_:7(string) ordernum2_2_2_:8(int) producti3_2_2_:9(string) producti1_3_3_:11(string) name2_0_0_:2(string) address3_0_0_:3(string) orderdat3_1_1_:6(date) formula103_1_:25(decimal) customer1_1_0__:4(string) ordernum2_1_0__:5(int) ordernum2_0__:5(int) quantity4_2_2_:10(int) customer1_2_1__:7(string) ordernum2_2_1__:8(int) producti3_2_1__:9(string) descript2_3_3_:12(string) cost3_3_3_:13(decimal) numberav4_3_3_:14(int) formula104_3_:31(decimal)
+ ├── key: (1,4,5,7-9,11)
+ ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9,11)-->(2,3,6,10,12-14,25,31)
+ ├── group-by
+ │    ├── columns: customer.customerid:1(string!null) name:2(string) address:3(string) customerorder.customerid:4(string) customerorder.ordernumber:5(int) orderdate:6(date) lineitem.customerid:7(string) lineitem.ordernumber:8(int) lineitem.productid:9(string) lineitem.quantity:10(int) product.productid:11(string) product.description:12(string) product.cost:13(decimal) product.numberavailable:14(int) sum:24(decimal) sum:30(decimal)
+ │    ├── grouping columns: customer.customerid:1(string!null) customerorder.customerid:4(string) customerorder.ordernumber:5(int) lineitem.customerid:7(string) lineitem.ordernumber:8(int) lineitem.productid:9(string) product.productid:11(string)
+ │    ├── key: (1,4,5,7-9,11)
+ │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9,11)-->(2,3,6,10,12-14,24,30)
+ │    ├── left-join
+ │    │    ├── columns: customer.customerid:1(string!null) name:2(string) address:3(string) customerorder.customerid:4(string) customerorder.ordernumber:5(int) orderdate:6(date) lineitem.customerid:7(string) lineitem.ordernumber:8(int) lineitem.productid:9(string) lineitem.quantity:10(int) product.productid:11(string) product.description:12(string) product.cost:13(decimal) product.numberavailable:14(int) sum:24(decimal) lineitem.productid:28(string) lineitem.quantity:29(int)
+ │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9,11)-->(2,3,6,10,12-14,24)
+ │    │    ├── group-by
+ │    │    │    ├── columns: customer.customerid:1(string!null) name:2(string) address:3(string) customerorder.customerid:4(string) customerorder.ordernumber:5(int) orderdate:6(date) lineitem.customerid:7(string) lineitem.ordernumber:8(int) lineitem.productid:9(string) lineitem.quantity:10(int) product.productid:11(string) product.description:12(string) product.cost:13(decimal) product.numberavailable:14(int) sum:24(decimal)
+ │    │    │    ├── grouping columns: customer.customerid:1(string!null) customerorder.customerid:4(string) customerorder.ordernumber:5(int) lineitem.customerid:7(string) lineitem.ordernumber:8(int) lineitem.productid:9(string) product.productid:11(string)
+ │    │    │    ├── key: (1,4,5,7-9,11)
+ │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9,11)-->(2,3,6,10,12-14,24)
+ │    │    │    ├── left-join-apply
+ │    │    │    │    ├── columns: customer.customerid:1(string!null) name:2(string!null) address:3(string!null) customerorder.customerid:4(string) customerorder.ordernumber:5(int) orderdate:6(date) lineitem.customerid:7(string) lineitem.ordernumber:8(int) lineitem.productid:9(string) lineitem.quantity:10(int) product.productid:11(string) product.description:12(string) product.cost:13(decimal) product.numberavailable:14(int) column23:23(decimal)
+ │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14)
+ │    │    │    │    ├── left-join
+ │    │    │    │    │    ├── columns: customer.customerid:1(string!null) name:2(string!null) address:3(string!null) customerorder.customerid:4(string) customerorder.ordernumber:5(int) orderdate:6(date) lineitem.customerid:7(string) lineitem.ordernumber:8(int) lineitem.productid:9(string) lineitem.quantity:10(int) product.productid:11(string) product.description:12(string) product.cost:13(decimal) product.numberavailable:14(int)
+ │    │    │    │    │    ├── key: (1,4,5,7-9,11)
+ │    │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14)
+ │    │    │    │    │    ├── left-join
+ │    │    │    │    │    │    ├── columns: customer.customerid:1(string!null) name:2(string!null) address:3(string!null) customerorder.customerid:4(string) customerorder.ordernumber:5(int) orderdate:6(date) lineitem.customerid:7(string) lineitem.ordernumber:8(int) lineitem.productid:9(string) lineitem.quantity:10(int)
+ │    │    │    │    │    │    ├── key: (1,4,5,7-9)
+ │    │    │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10)
+ │    │    │    │    │    │    ├── left-join (merge)
+ │    │    │    │    │    │    │    ├── columns: customer.customerid:1(string!null) name:2(string!null) address:3(string!null) customerorder.customerid:4(string) customerorder.ordernumber:5(int) orderdate:6(date)
+ │    │    │    │    │    │    │    ├── key: (1,4,5)
+ │    │    │    │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6)
+ │    │    │    │    │    │    │    ├── scan customer
+ │    │    │    │    │    │    │    │    ├── columns: customer.customerid:1(string!null) name:2(string!null) address:3(string!null)
+ │    │    │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3)
+ │    │    │    │    │    │    │    │    └── ordering: +1
+ │    │    │    │    │    │    │    ├── scan customerorder
+ │    │    │    │    │    │    │    │    ├── columns: customerorder.customerid:4(string!null) customerorder.ordernumber:5(int!null) orderdate:6(date!null)
+ │    │    │    │    │    │    │    │    ├── key: (4,5)
+ │    │    │    │    │    │    │    │    ├── fd: (4,5)-->(6)
+ │    │    │    │    │    │    │    │    └── ordering: +4
+ │    │    │    │    │    │    │    └── merge-on
+ │    │    │    │    │    │    │         ├── left ordering: +1
+ │    │    │    │    │    │    │         ├── right ordering: +4
+ │    │    │    │    │    │    │         └── filters [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+ │    │    │    │    │    │    │              └── customer.customerid = customerorder.customerid [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ])]
+ │    │    │    │    │    │    ├── scan lineitem
+ │    │    │    │    │    │    │    ├── columns: lineitem.customerid:7(string!null) lineitem.ordernumber:8(int!null) lineitem.productid:9(string!null) lineitem.quantity:10(int)
+ │    │    │    │    │    │    │    ├── key: (7-9)
+ │    │    │    │    │    │    │    └── fd: (7-9)-->(10)
+ │    │    │    │    │    │    └── filters [type=bool, outer=(4,5,7,8), constraints=(/4: (/NULL - ]; /5: (/NULL - ]; /7: (/NULL - ]; /8: (/NULL - ]), fd=(4)==(7), (7)==(4), (5)==(8), (8)==(5)]
+ │    │    │    │    │    │         ├── customerorder.customerid = lineitem.customerid [type=bool, outer=(4,7), constraints=(/4: (/NULL - ]; /7: (/NULL - ])]
+ │    │    │    │    │    │         └── customerorder.ordernumber = lineitem.ordernumber [type=bool, outer=(5,8), constraints=(/5: (/NULL - ]; /8: (/NULL - ])]
+ │    │    │    │    │    ├── scan product
+ │    │    │    │    │    │    ├── columns: product.productid:11(string!null) product.description:12(string!null) product.cost:13(decimal) product.numberavailable:14(int)
+ │    │    │    │    │    │    ├── key: (11)
+ │    │    │    │    │    │    └── fd: (11)-->(12-14)
+ │    │    │    │    │    └── filters [type=bool, outer=(9,11), constraints=(/9: (/NULL - ]; /11: (/NULL - ]), fd=(9)==(11), (11)==(9)]
+ │    │    │    │    │         └── lineitem.productid = product.productid [type=bool, outer=(9,11), constraints=(/9: (/NULL - ]; /11: (/NULL - ])]
+ │    │    │    │    ├── project
+ │    │    │    │    │    ├── columns: column23:23(decimal)
+ │    │    │    │    │    ├── outer: (4,5)
+ │    │    │    │    │    ├── inner-join
+ │    │    │    │    │    │    ├── columns: lineitem.customerid:15(string!null) lineitem.ordernumber:16(int!null) lineitem.productid:17(string!null) lineitem.quantity:18(int) product.productid:19(string!null) product.cost:21(decimal)
+ │    │    │    │    │    │    ├── outer: (4,5)
+ │    │    │    │    │    │    ├── key: (19)
+ │    │    │    │    │    │    ├── fd: ()-->(15,16), (17)-->(18), (19)-->(21), (17)==(19), (19)==(17)
+ │    │    │    │    │    │    ├── scan lineitem
+ │    │    │    │    │    │    │    ├── columns: lineitem.customerid:15(string!null) lineitem.ordernumber:16(int!null) lineitem.productid:17(string!null) lineitem.quantity:18(int)
+ │    │    │    │    │    │    │    ├── key: (15-17)
+ │    │    │    │    │    │    │    └── fd: (15-17)-->(18)
+ │    │    │    │    │    │    ├── scan product
+ │    │    │    │    │    │    │    ├── columns: product.productid:19(string!null) product.cost:21(decimal)
+ │    │    │    │    │    │    │    ├── key: (19)
+ │    │    │    │    │    │    │    └── fd: (19)-->(21)
+ │    │    │    │    │    │    └── filters [type=bool, outer=(4,5,15-17,19), constraints=(/4: (/NULL - ]; /5: (/NULL - ]; /15: (/NULL - ]; /16: (/NULL - ]; /17: (/NULL - ]; /19: (/NULL - ]), fd=(17)==(19), (19)==(17), (4)==(15), (15)==(4), (5)==(16), (16)==(5)]
+ │    │    │    │    │    │         ├── lineitem.productid = product.productid [type=bool, outer=(17,19), constraints=(/17: (/NULL - ]; /19: (/NULL - ])]
+ │    │    │    │    │    │         ├── lineitem.customerid = customerorder.customerid [type=bool, outer=(4,15), constraints=(/4: (/NULL - ]; /15: (/NULL - ])]
+ │    │    │    │    │    │         └── lineitem.ordernumber = customerorder.ordernumber [type=bool, outer=(5,16), constraints=(/5: (/NULL - ]; /16: (/NULL - ])]
+ │    │    │    │    │    └── projections [outer=(18,21)]
+ │    │    │    │    │         └── lineitem.quantity * product.cost [type=decimal, outer=(18,21)]
+ │    │    │    │    └── true [type=bool]
+ │    │    │    └── aggregations [outer=(2,3,6,10,12-14,23)]
+ │    │    │         ├── sum [type=decimal, outer=(23)]
+ │    │    │         │    └── variable: column23 [type=decimal, outer=(23)]
+ │    │    │         ├── any-not-null [type=string, outer=(2)]
+ │    │    │         │    └── variable: customer.name [type=string, outer=(2)]
+ │    │    │         ├── any-not-null [type=string, outer=(3)]
+ │    │    │         │    └── variable: customer.address [type=string, outer=(3)]
+ │    │    │         ├── any-not-null [type=date, outer=(6)]
+ │    │    │         │    └── variable: customerorder.orderdate [type=date, outer=(6)]
+ │    │    │         ├── any-not-null [type=int, outer=(10)]
+ │    │    │         │    └── variable: lineitem.quantity [type=int, outer=(10)]
+ │    │    │         ├── any-not-null [type=string, outer=(12)]
+ │    │    │         │    └── variable: product.description [type=string, outer=(12)]
+ │    │    │         ├── any-not-null [type=decimal, outer=(13)]
+ │    │    │         │    └── variable: product.cost [type=decimal, outer=(13)]
+ │    │    │         └── any-not-null [type=int, outer=(14)]
+ │    │    │              └── variable: product.numberavailable [type=int, outer=(14)]
+ │    │    ├── scan lineitem
+ │    │    │    └── columns: lineitem.productid:28(string!null) lineitem.quantity:29(int)
+ │    │    └── filters [type=bool, outer=(11,28), constraints=(/11: (/NULL - ]; /28: (/NULL - ]), fd=(11)==(28), (28)==(11)]
+ │    │         └── lineitem.productid = product.productid [type=bool, outer=(11,28), constraints=(/11: (/NULL - ]; /28: (/NULL - ])]
+ │    └── aggregations [outer=(2,3,6,10,12-14,24,29)]
+ │         ├── sum [type=decimal, outer=(29)]
+ │         │    └── variable: lineitem.quantity [type=int, outer=(29)]
+ │         ├── any-not-null [type=string, outer=(2)]
+ │         │    └── variable: customer.name [type=string, outer=(2)]
+ │         ├── any-not-null [type=string, outer=(3)]
+ │         │    └── variable: customer.address [type=string, outer=(3)]
+ │         ├── any-not-null [type=date, outer=(6)]
+ │         │    └── variable: customerorder.orderdate [type=date, outer=(6)]
+ │         ├── any-not-null [type=int, outer=(10)]
+ │         │    └── variable: lineitem.quantity [type=int, outer=(10)]
+ │         ├── any-not-null [type=string, outer=(12)]
+ │         │    └── variable: product.description [type=string, outer=(12)]
+ │         ├── any-not-null [type=decimal, outer=(13)]
+ │         │    └── variable: product.cost [type=decimal, outer=(13)]
+ │         ├── any-not-null [type=int, outer=(14)]
+ │         │    └── variable: product.numberavailable [type=int, outer=(14)]
+ │         └── any-not-null [type=decimal, outer=(24)]
+ │              └── variable: sum [type=decimal, outer=(24)]
+ └── projections [outer=(1-14,24,30)]
+      ├── variable: sum [type=decimal, outer=(24)]
+      └── variable: sum [type=decimal, outer=(30)]
+
+opt
+SELECT
+  order0_.customerid AS customer1_1_0_,
+  order0_.ordernumber AS ordernum2_1_0_,
+  order0_.orderdate AS orderdat3_1_0_,
+  (
+    SELECT
+      sum(li.quantity * p.cost)
+    FROM
+      lineitem AS li, product AS p
+    WHERE
+      li.productid = p.productid
+      AND li.customerid = order0_.customerid
+      AND li.ordernumber = order0_.ordernumber
+  )
+    AS formula105_0_,
+  lineitems1_.customerid AS customer1_2_1_,
+  lineitems1_.ordernumber AS ordernum2_2_1_,
+  lineitems1_.productid AS producti3_2_1_,
+  lineitems1_.customerid AS customer1_2_2_,
+  lineitems1_.ordernumber AS ordernum2_2_2_,
+  lineitems1_.productid AS producti3_2_2_,
+  lineitems1_.quantity AS quantity4_2_2_
+FROM
+  customerorder AS order0_
+  LEFT JOIN lineitem AS lineitems1_
+  ON
+    order0_.customerid = lineitems1_.customerid
+    AND order0_.ordernumber = lineitems1_.ordernumber
+WHERE
+  order0_.customerid = 'c111' AND order0_.ordernumber = 0;
+----
+project
+ ├── columns: customer1_1_0_:1(string) ordernum2_1_0_:2(int) orderdat3_1_0_:3(date) formula105_0_:18(decimal) customer1_2_1_:4(string) ordernum2_2_1_:5(int) producti3_2_1_:6(string) customer1_2_2_:4(string) ordernum2_2_2_:5(int) producti3_2_2_:6(string) quantity4_2_2_:7(int)
+ ├── key: (6)
+ ├── fd: ()-->(1-3), (6)-->(4,5,7,18), ()~~>(4,5)
+ ├── group-by
+ │    ├── columns: customerorder.customerid:1(string) customerorder.ordernumber:2(int) orderdate:3(date) lineitem.customerid:4(string) lineitem.ordernumber:5(int) lineitem.productid:6(string) lineitem.quantity:7(int) sum:17(decimal)
+ │    ├── grouping columns: lineitem.productid:6(string)
+ │    ├── key: (6)
+ │    ├── fd: ()-->(1-3), (6)-->(1-5,7,17), ()~~>(4,5)
+ │    ├── left-join-apply
+ │    │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date!null) lineitem.customerid:4(string) lineitem.ordernumber:5(int) lineitem.productid:6(string) lineitem.quantity:7(int) column16:16(decimal)
+ │    │    ├── fd: ()-->(1-3), (6)-->(4,5,7), ()~~>(4,5)
+ │    │    ├── left-join (merge)
+ │    │    │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date!null) lineitem.customerid:4(string) lineitem.ordernumber:5(int) lineitem.productid:6(string) lineitem.quantity:7(int)
+ │    │    │    ├── key: (6)
+ │    │    │    ├── fd: ()-->(1-3), (6)-->(4,5,7), ()~~>(4,5)
+ │    │    │    ├── scan customerorder
+ │    │    │    │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date!null)
+ │    │    │    │    ├── constraint: /1/2: [/'c111'/0 - /'c111'/0]
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    └── fd: ()-->(1-3)
+ │    │    │    ├── scan lineitem
+ │    │    │    │    ├── columns: lineitem.customerid:4(string!null) lineitem.ordernumber:5(int!null) lineitem.productid:6(string!null) lineitem.quantity:7(int)
+ │    │    │    │    ├── constraint: /4/5/6: [/'c111'/0 - /'c111'/0]
+ │    │    │    │    ├── key: (6)
+ │    │    │    │    └── fd: ()-->(4,5), (6)-->(7)
+ │    │    │    └── merge-on
+ │    │    │         ├── left ordering: +1,+2
+ │    │    │         ├── right ordering: +4,+5
+ │    │    │         └── filters [type=bool, outer=(1,2,4,5), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /4: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(4), (4)==(1), (2)==(5), (5)==(2)]
+ │    │    │              ├── customerorder.customerid = lineitem.customerid [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ])]
+ │    │    │              └── customerorder.ordernumber = lineitem.ordernumber [type=bool, outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ])]
+ │    │    ├── project
+ │    │    │    ├── columns: column16:16(decimal)
+ │    │    │    ├── outer: (1,2)
+ │    │    │    ├── inner-join
+ │    │    │    │    ├── columns: lineitem.customerid:8(string!null) lineitem.ordernumber:9(int!null) lineitem.productid:10(string!null) lineitem.quantity:11(int) product.productid:12(string!null) cost:14(decimal)
+ │    │    │    │    ├── outer: (1,2)
+ │    │    │    │    ├── key: (12)
+ │    │    │    │    ├── fd: ()-->(8,9), (10)-->(11), (12)-->(14), (10)==(12), (12)==(10)
+ │    │    │    │    ├── scan lineitem
+ │    │    │    │    │    ├── columns: lineitem.customerid:8(string!null) lineitem.ordernumber:9(int!null) lineitem.productid:10(string!null) lineitem.quantity:11(int)
+ │    │    │    │    │    ├── key: (8-10)
+ │    │    │    │    │    └── fd: (8-10)-->(11)
+ │    │    │    │    ├── scan product
+ │    │    │    │    │    ├── columns: product.productid:12(string!null) cost:14(decimal)
+ │    │    │    │    │    ├── key: (12)
+ │    │    │    │    │    └── fd: (12)-->(14)
+ │    │    │    │    └── filters [type=bool, outer=(1,2,8-10,12), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /8: (/NULL - ]; /9: (/NULL - ]; /10: (/NULL - ]; /12: (/NULL - ]), fd=(10)==(12), (12)==(10), (1)==(8), (8)==(1), (2)==(9), (9)==(2)]
+ │    │    │    │         ├── lineitem.productid = product.productid [type=bool, outer=(10,12), constraints=(/10: (/NULL - ]; /12: (/NULL - ])]
+ │    │    │    │         ├── lineitem.customerid = customerorder.customerid [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
+ │    │    │    │         └── lineitem.ordernumber = customerorder.ordernumber [type=bool, outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ])]
+ │    │    │    └── projections [outer=(11,14)]
+ │    │    │         └── lineitem.quantity * product.cost [type=decimal, outer=(11,14)]
+ │    │    └── true [type=bool]
+ │    └── aggregations [outer=(1-5,7,16)]
+ │         ├── sum [type=decimal, outer=(16)]
+ │         │    └── variable: column16 [type=decimal, outer=(16)]
+ │         ├── any-not-null [type=string, outer=(1)]
+ │         │    └── variable: customerorder.customerid [type=string, outer=(1)]
+ │         ├── any-not-null [type=int, outer=(2)]
+ │         │    └── variable: customerorder.ordernumber [type=int, outer=(2)]
+ │         ├── any-not-null [type=date, outer=(3)]
+ │         │    └── variable: customerorder.orderdate [type=date, outer=(3)]
+ │         ├── any-not-null [type=string, outer=(4)]
+ │         │    └── variable: lineitem.customerid [type=string, outer=(4)]
+ │         ├── any-not-null [type=int, outer=(5)]
+ │         │    └── variable: lineitem.ordernumber [type=int, outer=(5)]
+ │         └── any-not-null [type=int, outer=(7)]
+ │              └── variable: lineitem.quantity [type=int, outer=(7)]
+ └── projections [outer=(1-7,17)]
+      └── variable: sum [type=decimal, outer=(17)]
+
+opt
+SELECT
+  order0_.customerid AS customer1_10_,
+  order0_.ordernumber AS ordernum2_10_,
+  order0_.orderdate AS orderdat3_10_,
+  (
+    SELECT
+      sum(li.quantity * p.cost)
+    FROM
+      lineitem AS li, product AS p
+    WHERE
+      li.productid = p.productid
+      AND li.customerid = order0_.customerid
+      AND li.ordernumber = order0_.ordernumber
+  )
+    AS formula273_
+FROM
+  customerorder AS order0_;
+----
+project
+ ├── columns: customer1_10_:1(string!null) ordernum2_10_:2(int!null) orderdat3_10_:3(date) formula273_:14(decimal)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3,14)
+ ├── group-by
+ │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date) sum:13(decimal)
+ │    ├── grouping columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null)
+ │    ├── key: (1,2)
+ │    ├── fd: (1,2)-->(3,13)
+ │    ├── left-join-apply
+ │    │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date!null) column12:12(decimal)
+ │    │    ├── fd: (1,2)-->(3)
+ │    │    ├── scan customerorder
+ │    │    │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date!null)
+ │    │    │    ├── key: (1,2)
+ │    │    │    └── fd: (1,2)-->(3)
+ │    │    ├── project
+ │    │    │    ├── columns: column12:12(decimal)
+ │    │    │    ├── outer: (1,2)
+ │    │    │    ├── inner-join
+ │    │    │    │    ├── columns: lineitem.customerid:4(string!null) lineitem.ordernumber:5(int!null) lineitem.productid:6(string!null) quantity:7(int) product.productid:8(string!null) cost:10(decimal)
+ │    │    │    │    ├── outer: (1,2)
+ │    │    │    │    ├── key: (8)
+ │    │    │    │    ├── fd: ()-->(4,5), (6)-->(7), (8)-->(10), (6)==(8), (8)==(6)
+ │    │    │    │    ├── scan lineitem
+ │    │    │    │    │    ├── columns: lineitem.customerid:4(string!null) lineitem.ordernumber:5(int!null) lineitem.productid:6(string!null) quantity:7(int)
+ │    │    │    │    │    ├── key: (4-6)
+ │    │    │    │    │    └── fd: (4-6)-->(7)
+ │    │    │    │    ├── scan product
+ │    │    │    │    │    ├── columns: product.productid:8(string!null) cost:10(decimal)
+ │    │    │    │    │    ├── key: (8)
+ │    │    │    │    │    └── fd: (8)-->(10)
+ │    │    │    │    └── filters [type=bool, outer=(1,2,4-6,8), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /4: (/NULL - ]; /5: (/NULL - ]; /6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6), (1)==(4), (4)==(1), (2)==(5), (5)==(2)]
+ │    │    │    │         ├── lineitem.productid = product.productid [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ])]
+ │    │    │    │         ├── lineitem.customerid = customerorder.customerid [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ])]
+ │    │    │    │         └── lineitem.ordernumber = customerorder.ordernumber [type=bool, outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ])]
+ │    │    │    └── projections [outer=(7,10)]
+ │    │    │         └── lineitem.quantity * product.cost [type=decimal, outer=(7,10)]
+ │    │    └── true [type=bool]
+ │    └── aggregations [outer=(3,12)]
+ │         ├── sum [type=decimal, outer=(12)]
+ │         │    └── variable: column12 [type=decimal, outer=(12)]
+ │         └── any-not-null [type=date, outer=(3)]
+ │              └── variable: customerorder.orderdate [type=date, outer=(3)]
+ └── projections [outer=(1-3,13)]
+      └── variable: sum [type=decimal, outer=(13)]
+
+exec-ddl
+drop table customer, customerorder, lineitem, product
+----
+
+# ------------------------------------------------------------------------------
+# Query #12
+#   org.hibernate.test.criteria.CriteriaQueryTest
+#   TODO(andyk): Need to map SemiJoinApply to InnerJoinApply for decorrelation.
+# ------------------------------------------------------------------------------
+exec-ddl
+CREATE TABLE student (
+  studentid INT8 NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  address_city VARCHAR(255),
+  address_state VARCHAR(255),
+  preferredcoursecode VARCHAR(255),
+  PRIMARY KEY (studentid)
+);
+----
+TABLE student
+ ├── studentid int not null
+ ├── name string not null
+ ├── address_city string
+ ├── address_state string
+ ├── preferredcoursecode string
+ └── INDEX primary
+      └── studentid int not null
+
+exec-ddl
+CREATE TABLE enrolment (
+  studentid INT8 NOT NULL,
+  coursecode VARCHAR(255) NOT NULL,
+  semester INT2 NOT NULL,
+  year INT2 NOT NULL,
+  PRIMARY KEY (studentid, coursecode)
+);
+----
+TABLE enrolment
+ ├── studentid int not null
+ ├── coursecode string not null
+ ├── semester int not null
+ ├── year int not null
+ └── INDEX primary
+      ├── studentid int not null
+      └── coursecode string not null
+
+opt
+SELECT
+  this_.studentid AS studenti1_26_0_,
+  this_.name AS name2_26_0_,
+  this_.address_city AS address_3_26_0_,
+  this_.address_state AS address_4_26_0_,
+  this_.preferredcoursecode AS preferre5_26_0_
+FROM
+  student AS this_
+WHERE
+  EXISTS(
+    SELECT
+      enrolment_.studentid AS y0_
+    FROM
+      enrolment AS enrolment_
+    WHERE
+      enrolment_.year
+      = (
+          SELECT
+            max(maxstudentenrolment_.year) AS y0_
+          FROM
+            enrolment AS maxstudentenrolment_
+          WHERE
+            this_.preferredcoursecode = maxstudentenrolment_.coursecode
+        )
+  );
+----
+semi-join-apply
+ ├── columns: studenti1_26_0_:1(int!null) name2_26_0_:2(string!null) address_3_26_0_:3(string) address_4_26_0_:4(string) preferre5_26_0_:5(string)
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan student
+ │    ├── columns: student.studentid:1(int!null) name:2(string!null) address_city:3(string) address_state:4(string) preferredcoursecode:5(string)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── select
+ │    ├── columns: enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null) enrolment.year:9(int!null) y0_:14(int!null)
+ │    ├── outer: (5)
+ │    ├── key: (6,7)
+ │    ├── fd: (6,7)-->(9,14), (9)==(14), (14)==(9)
+ │    ├── group-by
+ │    │    ├── columns: enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null) enrolment.year:9(int) y0_:14(int)
+ │    │    ├── grouping columns: enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null)
+ │    │    ├── outer: (5)
+ │    │    ├── key: (6,7)
+ │    │    ├── fd: (6,7)-->(9,14)
+ │    │    ├── inner-join
+ │    │    │    ├── columns: enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null) enrolment.year:9(int!null) enrolment.coursecode:11(string!null) enrolment.year:13(int!null)
+ │    │    │    ├── outer: (5)
+ │    │    │    ├── fd: ()-->(11), (6,7)-->(9)
+ │    │    │    ├── scan enrolment
+ │    │    │    │    ├── columns: enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null) enrolment.year:9(int!null)
+ │    │    │    │    ├── key: (6,7)
+ │    │    │    │    └── fd: (6,7)-->(9)
+ │    │    │    ├── scan enrolment
+ │    │    │    │    └── columns: enrolment.coursecode:11(string!null) enrolment.year:13(int!null)
+ │    │    │    └── filters [type=bool, outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ]), fd=(5)==(11), (11)==(5)]
+ │    │    │         └── student.preferredcoursecode = enrolment.coursecode [type=bool, outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ])]
+ │    │    └── aggregations [outer=(9,13)]
+ │    │         ├── max [type=int, outer=(13)]
+ │    │         │    └── variable: enrolment.year [type=int, outer=(13)]
+ │    │         └── any-not-null [type=int, outer=(9)]
+ │    │              └── variable: enrolment.year [type=int, outer=(9)]
+ │    └── filters [type=bool, outer=(9,14), constraints=(/9: (/NULL - ]; /14: (/NULL - ]), fd=(9)==(14), (14)==(9)]
+ │         └── enrolment.year = y0_ [type=bool, outer=(9,14), constraints=(/9: (/NULL - ]; /14: (/NULL - ])]
+ └── true [type=bool]
+
+exec-ddl
+drop table student, enrolment
+----
+
+# ------------------------------------------------------------------------------
+# Query #13
+#   org.hibernate.test.subselectfetch.SubselectFetchWithFormulaTest
+#   TODO(andyk): Need to decorrelate LeftJoin -> Project complex.
+# ------------------------------------------------------------------------------
+exec-ddl
+CREATE TABLE t_name (id INT4 NOT NULL, c_name VARCHAR(255), PRIMARY KEY (id));
+----
+TABLE t_name
+ ├── id int not null
+ ├── c_name string
+ └── INDEX primary
+      └── id int not null
+
+opt
+SELECT
+  this_.id AS id1_0_0_,
+  this_.c_name AS c_name2_0_0_,
+  (SELECT length(this_.c_name) FROM t_name WHERE this_.id = t_name.id)
+    AS formula0_0_
+FROM
+  t_name AS this_;
+----
+project
+ ├── columns: id1_0_0_:1(int!null) c_name2_0_0_:2(string) formula0_0_:6(int)
+ ├── fd: (1)-->(2)
+ ├── left-join-apply
+ │    ├── columns: t_name.id:1(int!null) t_name.c_name:2(string) t_name.id:3(int) length:5(int)
+ │    ├── key: (1,3)
+ │    ├── fd: (1)-->(2), (1,3)-->(5)
+ │    ├── scan t_name
+ │    │    ├── columns: t_name.id:1(int!null) t_name.c_name:2(string)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    ├── project
+ │    │    ├── columns: length:5(int) t_name.id:3(int!null)
+ │    │    ├── outer: (2)
+ │    │    ├── key: (3)
+ │    │    ├── fd: ()-->(5)
+ │    │    ├── scan t_name
+ │    │    │    ├── columns: t_name.id:3(int!null)
+ │    │    │    └── key: (3)
+ │    │    └── projections [outer=(2,3)]
+ │    │         └── length(t_name.c_name) [type=int, outer=(2)]
+ │    └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+ │         └── t_name.id = t_name.id [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+ └── projections [outer=(1,2,5)]
+      └── variable: length [type=int, outer=(5)]
+
+exec-ddl
+drop table t_name
+----

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -1,0 +1,3288 @@
+# Correlated subquery cases derived from OpenStack Compute (nova):
+#   https://github.com/openstack/nova
+
+exec-ddl
+create table flavors
+(
+	id Integer primary key,
+	name String(255) not null,
+	memory_mb Integer not null,
+	vcpus Integer not null,
+	root_gb Integer,
+	ephemeral_gb Integer,
+	flavorid String(255) not null,
+	swap Integer default 0 not null,
+	rxtx_factor Float default 1,
+	vcpu_weight Integer,
+	disabled Boolean default false,
+	is_public Boolean default true,
+	description Text,
+	created_at Timestamp,
+	updated_at Timestamp,
+	unique (flavorid),
+	unique (name)
+)
+----
+TABLE flavors
+ ├── id int not null
+ ├── name string not null
+ ├── memory_mb int not null
+ ├── vcpus int not null
+ ├── root_gb int
+ ├── ephemeral_gb int
+ ├── flavorid string not null
+ ├── swap int not null
+ ├── rxtx_factor float
+ ├── vcpu_weight int
+ ├── disabled bool
+ ├── is_public bool
+ ├── description string
+ ├── created_at timestamp
+ ├── updated_at timestamp
+ ├── INDEX primary
+ │    └── id int not null
+ ├── INDEX secondary
+ │    ├── flavorid string not null
+ │    └── id int not null (storing)
+ └── INDEX secondary
+      ├── name string not null
+      └── id int not null (storing)
+
+exec-ddl
+create table flavor_projects
+(
+    id Integer primary key,
+    flavor_id Integer not null,
+    project_id String(255) not null,
+	created_at Timestamp,
+	updated_at Timestamp,
+    foreign key (flavor_id) references flavors (id),
+    unique (flavor_id, project_id)
+)
+----
+TABLE flavor_projects
+ ├── id int not null
+ ├── flavor_id int not null
+ ├── project_id string not null
+ ├── created_at timestamp
+ ├── updated_at timestamp
+ ├── INDEX primary
+ │    └── id int not null
+ └── INDEX secondary
+      ├── flavor_id int not null
+      ├── project_id string not null
+      └── id int not null (storing)
+
+exec-ddl
+create table flavor_extra_specs
+(
+    id Integer primary key,
+    key String(255) not null,
+    value String(255),
+    flavor_id Integer not null,
+	created_at Timestamp,
+	updated_at Timestamp,
+    foreign key (flavor_id) references flavors (id),
+    unique index flavor_extra_specs_flavor_id_key_idx (flavor_id, key)
+)
+----
+TABLE flavor_extra_specs
+ ├── id int not null
+ ├── key string not null
+ ├── value string
+ ├── flavor_id int not null
+ ├── created_at timestamp
+ ├── updated_at timestamp
+ ├── INDEX primary
+ │    └── id int not null
+ └── INDEX flavor_extra_specs_flavor_id_key_idx
+      ├── flavor_id int not null
+      ├── key string not null
+      └── id int not null (storing)
+
+exec-ddl
+create table instance_types
+(
+    id Integer primary key,
+    name String(255),
+    memory_mb Integer not null,
+    vcpus Integer not null,
+    root_gb Integer,
+    ephemeral_gb Integer,
+    flavorid String(255),
+    swap Integer not null default 0,
+    rxtx_factor Float default 1,
+    vcpu_weight Integer,
+    disabled Boolean default False,
+    is_public Boolean default True,
+    deleted Boolean,
+	deleted_at Timestamp,
+	created_at Timestamp,
+	updated_at Timestamp,
+    unique (flavorid, deleted),
+    unique (name, deleted)
+)
+----
+TABLE instance_types
+ ├── id int not null
+ ├── name string
+ ├── memory_mb int not null
+ ├── vcpus int not null
+ ├── root_gb int
+ ├── ephemeral_gb int
+ ├── flavorid string
+ ├── swap int not null
+ ├── rxtx_factor float
+ ├── vcpu_weight int
+ ├── disabled bool
+ ├── is_public bool
+ ├── deleted bool
+ ├── deleted_at timestamp
+ ├── created_at timestamp
+ ├── updated_at timestamp
+ ├── INDEX primary
+ │    └── id int not null
+ ├── INDEX secondary
+ │    ├── flavorid string
+ │    ├── deleted bool
+ │    └── id int not null (storing)
+ └── INDEX secondary
+      ├── name string
+      ├── deleted bool
+      └── id int not null (storing)
+
+exec-ddl
+create table instance_type_projects
+(
+    id Integer primary key,
+    instance_type_id Integer not null,
+    project_id String(255),
+    deleted Boolean,
+	deleted_at Timestamp,
+	created_at Timestamp,
+	updated_at Timestamp,
+    foreign key (instance_type_id) references instance_types (id),
+    unique (instance_type_id, project_id, deleted)
+)
+----
+TABLE instance_type_projects
+ ├── id int not null
+ ├── instance_type_id int not null
+ ├── project_id string
+ ├── deleted bool
+ ├── deleted_at timestamp
+ ├── created_at timestamp
+ ├── updated_at timestamp
+ ├── INDEX primary
+ │    └── id int not null
+ └── INDEX secondary
+      ├── instance_type_id int not null
+      ├── project_id string
+      ├── deleted bool
+      └── id int not null (storing)
+
+exec-ddl
+create table instance_type_extra_specs
+(
+    id Integer primary key,
+    key String(255),
+    value String(255),
+    instance_type_id Integer not null,
+    deleted Boolean,
+	deleted_at Timestamp,
+	created_at Timestamp,
+	updated_at Timestamp,
+    foreign key (instance_type_id) references instance_types (id),
+    index instance_type_extra_specs_instance_type_id_key_idx (instance_type_id, key),
+    unique (instance_type_id, key, deleted)
+)
+----
+TABLE instance_type_extra_specs
+ ├── id int not null
+ ├── key string
+ ├── value string
+ ├── instance_type_id int not null
+ ├── deleted bool
+ ├── deleted_at timestamp
+ ├── created_at timestamp
+ ├── updated_at timestamp
+ ├── INDEX primary
+ │    └── id int not null
+ ├── INDEX instance_type_extra_specs_instance_type_id_key_idx
+ │    ├── instance_type_id int not null
+ │    ├── key string
+ │    └── id int not null
+ └── INDEX secondary
+      ├── instance_type_id int not null
+      ├── key string
+      ├── deleted bool
+      └── id int not null (storing)
+
+opt
+select anon_1.flavors_created_at as anon_1_flavors_created_at,
+       anon_1.flavors_updated_at as anon_1_flavors_updated_at,
+       anon_1.flavors_id as anon_1_flavors_id,
+       anon_1.flavors_name as anon_1_flavors_name,
+       anon_1.flavors_memory_mb as anon_1_flavors_memory_mb,
+       anon_1.flavors_vcpus as anon_1_flavors_vcpus,
+       anon_1.flavors_root_gb as anon_1_flavors_root_gb,
+       anon_1.flavors_ephemeral_gb as anon_1_flavors_ephemeral_gb,
+       anon_1.flavors_flavorid as anon_1_flavors_flavorid,
+       anon_1.flavors_swap as anon_1_flavors_swap,
+       anon_1.flavors_rxtx_factor as anon_1_flavors_rxtx_factor,
+       anon_1.flavors_vcpu_weight as anon_1_flavors_vcpu_weight,
+       anon_1.flavors_disabled as anon_1_flavors_disabled,
+       anon_1.flavors_is_public as anon_1_flavors_is_public,
+       flavor_extra_specs_1.created_at as flavor_extra_specs_1_created_at,
+       flavor_extra_specs_1.updated_at as flavor_extra_specs_1_updated_at,
+       flavor_extra_specs_1.id as flavor_extra_specs_1_id,
+       flavor_extra_specs_1."key" as flavor_extra_specs_1_key,
+       flavor_extra_specs_1.value as flavor_extra_specs_1_value,
+       flavor_extra_specs_1.flavor_id as flavor_extra_specs_1_flavor_id
+from (select flavors.created_at as flavors_created_at,
+             flavors.updated_at as flavors_updated_at,
+             flavors.id as flavors_id,
+             flavors.name as flavors_name,
+             flavors.memory_mb as flavors_memory_mb,
+             flavors.vcpus as flavors_vcpus,
+             flavors.root_gb as flavors_root_gb,
+             flavors.ephemeral_gb as flavors_ephemeral_gb,
+             flavors.flavorid as flavors_flavorid,
+             flavors.swap as flavors_swap,
+             flavors.rxtx_factor as flavors_rxtx_factor,
+             flavors.vcpu_weight as flavors_vcpu_weight,
+             flavors.disabled as flavors_disabled,
+             flavors.is_public as flavors_is_public
+      from flavors
+      where (flavors.is_public = true
+             or (exists (select 1
+                         from flavor_projects
+                         where flavor_projects.flavor_id = flavors.id
+                               and flavor_projects.project_id = $1)))
+            and flavors.flavorid = $2
+      order by flavors.id asc
+      offset $3 rows
+      limit $4)
+     as anon_1
+     left join flavor_extra_specs as flavor_extra_specs_1
+     on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
+order by anon_1.flavors_id asc
+----
+sort
+ ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── key: (1,25)
+ ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+ ├── ordering: +1
+ └── right-join
+      ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:25(int) key:26(string) value:27(string) flavor_extra_specs.flavor_id:28(int) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+      ├── key: (1,25)
+      ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+      ├── scan flavor_extra_specs
+      │    ├── columns: flavor_extra_specs.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs.flavor_id:28(int!null) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+      │    ├── key: (25)
+      │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
+      ├── project
+      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    └── limit
+      │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         ├── key: (1)
+      │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         ├── offset
+      │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         │    ├── key: (1)
+      │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    ├── ordering: +1
+      │         │    ├── sort
+      │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         │    │    ├── key: (1)
+      │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    │    ├── ordering: +1
+      │         │    │    └── select
+      │         │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         │    │         ├── key: (1)
+      │         │    │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    │         ├── group-by
+      │         │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         │    │         │    ├── grouping columns: flavors.id:1(int!null)
+      │         │    │         │    ├── key: (1)
+      │         │    │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    │         │    ├── left-join (merge)
+      │         │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+      │         │    │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
+      │         │    │         │    │    ├── select
+      │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │         │    │         │    │    │    ├── key: (1)
+      │         │    │         │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    │         │    │    │    ├── ordering: +1
+      │         │    │         │    │    │    ├── scan flavors
+      │         │    │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │         │    │         │    │    │    │    ├── key: (1)
+      │         │    │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    │         │    │    │    │    └── ordering: +1
+      │         │    │         │    │    │    └── filters [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
+      │         │    │         │    │    │         └── flavors.flavorid = $2 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+      │         │    │         │    │    │    ├── fd: ()-->(22)
+      │         │    │         │    │    │    ├── ordering: +17 opt(22)
+      │         │    │         │    │    │    ├── select
+      │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │         │    │         │    │    │    │    ├── key: (17,18)
+      │         │    │         │    │    │    │    ├── ordering: +17
+      │         │    │         │    │    │    │    ├── scan flavor_projects@secondary
+      │         │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │         │    │         │    │    │    │    │    ├── key: (17,18)
+      │         │    │         │    │    │    │    │    └── ordering: +17
+      │         │    │         │    │    │    │    └── filters [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+      │         │    │         │    │    │    │         └── flavor_projects.project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+      │         │    │         │    │    │    └── projections [outer=(17)]
+      │         │    │         │    │    │         └── true [type=bool]
+      │         │    │         │    │    └── merge-on
+      │         │    │         │    │         ├── left ordering: +1
+      │         │    │         │    │         ├── right ordering: +17
+      │         │    │         │    │         └── filters [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
+      │         │    │         │    │              └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ])]
+      │         │    │         │    └── aggregations [outer=(2-12,14,15,22)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(22)]
+      │         │    │         │         │    └── variable: true [type=bool, outer=(22)]
+      │         │    │         │         ├── any-not-null [type=string, outer=(2)]
+      │         │    │         │         │    └── variable: flavors.name [type=string, outer=(2)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(3)]
+      │         │    │         │         │    └── variable: flavors.memory_mb [type=int, outer=(3)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(4)]
+      │         │    │         │         │    └── variable: flavors.vcpus [type=int, outer=(4)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(5)]
+      │         │    │         │         │    └── variable: flavors.root_gb [type=int, outer=(5)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(6)]
+      │         │    │         │         │    └── variable: flavors.ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │         ├── any-not-null [type=string, outer=(7)]
+      │         │    │         │         │    └── variable: flavors.flavorid [type=string, outer=(7)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(8)]
+      │         │    │         │         │    └── variable: flavors.swap [type=int, outer=(8)]
+      │         │    │         │         ├── any-not-null [type=float, outer=(9)]
+      │         │    │         │         │    └── variable: flavors.rxtx_factor [type=float, outer=(9)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(10)]
+      │         │    │         │         │    └── variable: flavors.vcpu_weight [type=int, outer=(10)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(11)]
+      │         │    │         │         │    └── variable: flavors.disabled [type=bool, outer=(11)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(12)]
+      │         │    │         │         │    └── variable: flavors.is_public [type=bool, outer=(12)]
+      │         │    │         │         ├── any-not-null [type=timestamp, outer=(14)]
+      │         │    │         │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
+      │         │    │         │         └── any-not-null [type=timestamp, outer=(15)]
+      │         │    │         │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
+      │         │    │         └── filters [type=bool, outer=(12,23)]
+      │         │    │              └── (flavors.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,23)]
+      │         │    └── placeholder: $3 [type=int]
+      │         └── placeholder: $4 [type=int]
+      └── filters [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
+           └── flavor_extra_specs.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ])]
+
+opt
+select anon_1.flavors_created_at as anon_1_flavors_created_at,
+       anon_1.flavors_updated_at as anon_1_flavors_updated_at,
+       anon_1.flavors_id as anon_1_flavors_id,
+       anon_1.flavors_name as anon_1_flavors_name,
+       anon_1.flavors_memory_mb as anon_1_flavors_memory_mb,
+       anon_1.flavors_vcpus as anon_1_flavors_vcpus,
+       anon_1.flavors_root_gb as anon_1_flavors_root_gb,
+       anon_1.flavors_ephemeral_gb as anon_1_flavors_ephemeral_gb,
+       anon_1.flavors_flavorid as anon_1_flavors_flavorid,
+       anon_1.flavors_swap as anon_1_flavors_swap,
+       anon_1.flavors_rxtx_factor as anon_1_flavors_rxtx_factor,
+       anon_1.flavors_vcpu_weight as anon_1_flavors_vcpu_weight,
+       anon_1.flavors_disabled as anon_1_flavors_disabled,
+       anon_1.flavors_is_public as anon_1_flavors_is_public,
+       flavor_extra_specs_1.created_at as flavor_extra_specs_1_created_at,
+       flavor_extra_specs_1.updated_at as flavor_extra_specs_1_updated_at,
+       flavor_extra_specs_1.id as flavor_extra_specs_1_id,
+       flavor_extra_specs_1."key" as flavor_extra_specs_1_key,
+       flavor_extra_specs_1.value as flavor_extra_specs_1_value,
+       flavor_extra_specs_1.flavor_id as flavor_extra_specs_1_flavor_id
+from (select flavors.created_at as flavors_created_at,
+             flavors.updated_at as flavors_updated_at,
+             flavors.id as flavors_id,
+             flavors.name as flavors_name,
+             flavors.memory_mb as flavors_memory_mb,
+             flavors.vcpus as flavors_vcpus,
+             flavors.root_gb as flavors_root_gb,
+             flavors.ephemeral_gb as flavors_ephemeral_gb,
+             flavors.flavorid as flavors_flavorid,
+             flavors.swap as flavors_swap,
+             flavors.rxtx_factor as flavors_rxtx_factor,
+             flavors.vcpu_weight as flavors_vcpu_weight,
+             flavors.disabled as flavors_disabled,
+             flavors.is_public as flavors_is_public
+      from flavors
+      where (flavors.is_public = true
+             or (exists (select 1
+                         from flavor_projects
+                         where flavor_projects.flavor_id = flavors.id
+                               and flavor_projects.project_id = $1)))
+            and flavors.disabled = false
+            and (flavors.is_public = true
+                 or (exists (select 1
+                             from flavor_projects
+                             where flavor_projects.flavor_id = flavors.id
+                                   and flavor_projects.project_id = $2)))
+      order by flavors.flavorid asc, flavors.id asc
+      offset $3 rows
+      limit $4)
+     as anon_1
+     left join flavor_extra_specs as flavor_extra_specs_1
+     on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
+order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
+----
+sort
+ ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:38(timestamp) flavor_extra_specs_1_updated_at:39(timestamp) flavor_extra_specs_1_id:34(int) flavor_extra_specs_1_key:35(string) flavor_extra_specs_1_value:36(string) flavor_extra_specs_1_flavor_id:37(int)
+ ├── key: (1,34)
+ ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35-39), (35,37)-->(34,36,38,39)
+ ├── ordering: +7 opt(11)
+ └── right-join
+      ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:34(int) key:35(string) value:36(string) flavor_extra_specs.flavor_id:37(int) flavor_extra_specs.created_at:38(timestamp) flavor_extra_specs.updated_at:39(timestamp)
+      ├── key: (1,34)
+      ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35-39), (35,37)-->(34,36,38,39)
+      ├── scan flavor_extra_specs
+      │    ├── columns: flavor_extra_specs.id:34(int!null) key:35(string!null) value:36(string) flavor_extra_specs.flavor_id:37(int!null) flavor_extra_specs.created_at:38(timestamp) flavor_extra_specs.updated_at:39(timestamp)
+      │    ├── key: (34)
+      │    └── fd: (34)-->(35-39), (35,37)-->(34,36,38,39)
+      ├── project
+      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    ├── key: (1)
+      │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │    └── limit
+      │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:32(bool)
+      │         ├── key: (1)
+      │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         ├── offset
+      │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:32(bool)
+      │         │    ├── key: (1)
+      │         │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    ├── ordering: +7 opt(11)
+      │         │    ├── sort
+      │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:32(bool)
+      │         │    │    ├── key: (1)
+      │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    │    ├── ordering: +7 opt(11)
+      │         │    │    └── select
+      │         │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:32(bool)
+      │         │    │         ├── key: (1)
+      │         │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    │         ├── group-by
+      │         │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:32(bool)
+      │         │    │         │    ├── grouping columns: flavors.id:1(int!null)
+      │         │    │         │    ├── key: (1)
+      │         │    │         │    ├── fd: ()-->(11), (1)-->(2-12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    │         │    ├── left-join (merge)
+      │         │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:23(int) true:31(bool)
+      │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(31)
+      │         │    │         │    │    ├── sort
+      │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │         │    │         │    │    │    ├── key: (1)
+      │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    │         │    │    │    ├── ordering: +1 opt(11)
+      │         │    │         │    │    │    └── project
+      │         │    │         │    │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │         │    │         │    │    │         ├── key: (1)
+      │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    │         │    │    │         └── select
+      │         │    │         │    │    │              ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:29(bool)
+      │         │    │         │    │    │              ├── key: (1)
+      │         │    │         │    │    │              ├── fd: ()-->(11), (1)-->(2-10,12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    │         │    │    │              ├── group-by
+      │         │    │         │    │    │              │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:29(bool)
+      │         │    │         │    │    │              │    ├── grouping columns: flavors.id:1(int!null)
+      │         │    │         │    │    │              │    ├── key: (1)
+      │         │    │         │    │    │              │    ├── fd: ()-->(11), (1)-->(2-12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    │         │    │    │              │    ├── left-join (merge)
+      │         │    │         │    │    │              │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:28(bool)
+      │         │    │         │    │    │              │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(28)
+      │         │    │         │    │    │              │    │    ├── select
+      │         │    │         │    │    │              │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │         │    │         │    │    │              │    │    │    ├── key: (1)
+      │         │    │         │    │    │              │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    │         │    │    │              │    │    │    ├── ordering: +1 opt(11)
+      │         │    │         │    │    │              │    │    │    ├── scan flavors
+      │         │    │         │    │    │              │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │         │    │         │    │    │              │    │    │    │    ├── key: (1)
+      │         │    │         │    │    │              │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    │         │    │    │              │    │    │    │    └── ordering: +1 opt(11)
+      │         │    │         │    │    │              │    │    │    └── filters [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
+      │         │    │         │    │    │              │    │    │         └── flavors.disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight)]
+      │         │    │         │    │    │              │    │    ├── project
+      │         │    │         │    │    │              │    │    │    ├── columns: true:28(bool!null) flavor_projects.flavor_id:17(int!null)
+      │         │    │         │    │    │              │    │    │    ├── fd: ()-->(28)
+      │         │    │         │    │    │              │    │    │    ├── ordering: +17 opt(28)
+      │         │    │         │    │    │              │    │    │    ├── select
+      │         │    │         │    │    │              │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) flavor_projects.project_id:18(string!null)
+      │         │    │         │    │    │              │    │    │    │    ├── key: (17,18)
+      │         │    │         │    │    │              │    │    │    │    ├── ordering: +17
+      │         │    │         │    │    │              │    │    │    │    ├── scan flavor_projects@secondary
+      │         │    │         │    │    │              │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) flavor_projects.project_id:18(string!null)
+      │         │    │         │    │    │              │    │    │    │    │    ├── key: (17,18)
+      │         │    │         │    │    │              │    │    │    │    │    └── ordering: +17
+      │         │    │         │    │    │              │    │    │    │    └── filters [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+      │         │    │         │    │    │              │    │    │    │         └── flavor_projects.project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+      │         │    │         │    │    │              │    │    │    └── projections [outer=(17)]
+      │         │    │         │    │    │              │    │    │         └── true [type=bool]
+      │         │    │         │    │    │              │    │    └── merge-on
+      │         │    │         │    │    │              │    │         ├── left ordering: +1
+      │         │    │         │    │    │              │    │         ├── right ordering: +17
+      │         │    │         │    │    │              │    │         └── filters [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
+      │         │    │         │    │    │              │    │              └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ])]
+      │         │    │         │    │    │              │    └── aggregations [outer=(2-12,14,15,28)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=bool, outer=(28)]
+      │         │    │         │    │    │              │         │    └── variable: true [type=bool, outer=(28)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=string, outer=(2)]
+      │         │    │         │    │    │              │         │    └── variable: flavors.name [type=string, outer=(2)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=int, outer=(3)]
+      │         │    │         │    │    │              │         │    └── variable: flavors.memory_mb [type=int, outer=(3)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=int, outer=(4)]
+      │         │    │         │    │    │              │         │    └── variable: flavors.vcpus [type=int, outer=(4)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=int, outer=(5)]
+      │         │    │         │    │    │              │         │    └── variable: flavors.root_gb [type=int, outer=(5)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=int, outer=(6)]
+      │         │    │         │    │    │              │         │    └── variable: flavors.ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=string, outer=(7)]
+      │         │    │         │    │    │              │         │    └── variable: flavors.flavorid [type=string, outer=(7)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=int, outer=(8)]
+      │         │    │         │    │    │              │         │    └── variable: flavors.swap [type=int, outer=(8)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=float, outer=(9)]
+      │         │    │         │    │    │              │         │    └── variable: flavors.rxtx_factor [type=float, outer=(9)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=int, outer=(10)]
+      │         │    │         │    │    │              │         │    └── variable: flavors.vcpu_weight [type=int, outer=(10)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=bool, outer=(11)]
+      │         │    │         │    │    │              │         │    └── variable: flavors.disabled [type=bool, outer=(11)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=bool, outer=(12)]
+      │         │    │         │    │    │              │         │    └── variable: flavors.is_public [type=bool, outer=(12)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=timestamp, outer=(14)]
+      │         │    │         │    │    │              │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
+      │         │    │         │    │    │              │         └── any-not-null [type=timestamp, outer=(15)]
+      │         │    │         │    │    │              │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
+      │         │    │         │    │    │              └── filters [type=bool, outer=(12,29)]
+      │         │    │         │    │    │                   └── (flavors.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,29)]
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: true:31(bool!null) flavor_projects.flavor_id:23(int!null)
+      │         │    │         │    │    │    ├── fd: ()-->(31)
+      │         │    │         │    │    │    ├── ordering: +23 opt(31)
+      │         │    │         │    │    │    ├── select
+      │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) flavor_projects.project_id:24(string!null)
+      │         │    │         │    │    │    │    ├── key: (23,24)
+      │         │    │         │    │    │    │    ├── ordering: +23
+      │         │    │         │    │    │    │    ├── scan flavor_projects@secondary
+      │         │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) flavor_projects.project_id:24(string!null)
+      │         │    │         │    │    │    │    │    ├── key: (23,24)
+      │         │    │         │    │    │    │    │    └── ordering: +23
+      │         │    │         │    │    │    │    └── filters [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
+      │         │    │         │    │    │    │         └── flavor_projects.project_id = $2 [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
+      │         │    │         │    │    │    └── projections [outer=(23)]
+      │         │    │         │    │    │         └── true [type=bool]
+      │         │    │         │    │    └── merge-on
+      │         │    │         │    │         ├── left ordering: +1
+      │         │    │         │    │         ├── right ordering: +23
+      │         │    │         │    │         └── filters [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ]), fd=(1)==(23), (23)==(1)]
+      │         │    │         │    │              └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ])]
+      │         │    │         │    └── aggregations [outer=(2-12,14,15,31)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(31)]
+      │         │    │         │         │    └── variable: true [type=bool, outer=(31)]
+      │         │    │         │         ├── any-not-null [type=string, outer=(2)]
+      │         │    │         │         │    └── variable: flavors.name [type=string, outer=(2)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(3)]
+      │         │    │         │         │    └── variable: flavors.memory_mb [type=int, outer=(3)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(4)]
+      │         │    │         │         │    └── variable: flavors.vcpus [type=int, outer=(4)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(5)]
+      │         │    │         │         │    └── variable: flavors.root_gb [type=int, outer=(5)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(6)]
+      │         │    │         │         │    └── variable: flavors.ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │         ├── any-not-null [type=string, outer=(7)]
+      │         │    │         │         │    └── variable: flavors.flavorid [type=string, outer=(7)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(8)]
+      │         │    │         │         │    └── variable: flavors.swap [type=int, outer=(8)]
+      │         │    │         │         ├── any-not-null [type=float, outer=(9)]
+      │         │    │         │         │    └── variable: flavors.rxtx_factor [type=float, outer=(9)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(10)]
+      │         │    │         │         │    └── variable: flavors.vcpu_weight [type=int, outer=(10)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(11)]
+      │         │    │         │         │    └── variable: flavors.disabled [type=bool, outer=(11)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(12)]
+      │         │    │         │         │    └── variable: flavors.is_public [type=bool, outer=(12)]
+      │         │    │         │         ├── any-not-null [type=timestamp, outer=(14)]
+      │         │    │         │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
+      │         │    │         │         └── any-not-null [type=timestamp, outer=(15)]
+      │         │    │         │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
+      │         │    │         └── filters [type=bool, outer=(12,32)]
+      │         │    │              └── (flavors.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,32)]
+      │         │    └── placeholder: $3 [type=int]
+      │         └── placeholder: $4 [type=int]
+      └── filters [type=bool, outer=(1,37), constraints=(/1: (/NULL - ]; /37: (/NULL - ]), fd=(1)==(37), (37)==(1)]
+           └── flavor_extra_specs.flavor_id = flavors.id [type=bool, outer=(1,37), constraints=(/1: (/NULL - ]; /37: (/NULL - ])]
+
+opt
+select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
+       anon_1.instance_types_updated_at as anon_1_instance_types_updated_at,
+       anon_1.instance_types_deleted_at as anon_1_instance_types_deleted_at,
+       anon_1.instance_types_deleted as anon_1_instance_types_deleted,
+       anon_1.instance_types_id as anon_1_instance_types_id,
+       anon_1.instance_types_name as anon_1_instance_types_name,
+       anon_1.instance_types_memory_mb as anon_1_instance_types_memory_mb,
+       anon_1.instance_types_vcpus as anon_1_instance_types_vcpus,
+       anon_1.instance_types_root_gb as anon_1_instance_types_root_gb,
+       anon_1.instance_types_ephemeral_gb as anon_1_instance_types_ephemeral_gb,
+       anon_1.instance_types_flavorid as anon_1_instance_types_flavorid,
+       anon_1.instance_types_swap as anon_1_instance_types_swap,
+       anon_1.instance_types_rxtx_factor as anon_1_instance_types_rxtx_factor,
+       anon_1.instance_types_vcpu_weight as anon_1_instance_types_vcpu_weight,
+       anon_1.instance_types_disabled as anon_1_instance_types_disabled,
+       anon_1.instance_types_is_public as anon_1_instance_types_is_public,
+       instance_type_extra_specs_1.created_at as instance_type_extra_specs_1_created_at,
+       instance_type_extra_specs_1.updated_at as instance_type_extra_specs_1_updated_at,
+       instance_type_extra_specs_1.deleted_at as instance_type_extra_specs_1_deleted_at,
+       instance_type_extra_specs_1.deleted as instance_type_extra_specs_1_deleted,
+       instance_type_extra_specs_1.id as instance_type_extra_specs_1_id,
+       instance_type_extra_specs_1."key" as instance_type_extra_specs_1_key,
+       instance_type_extra_specs_1.value as instance_type_extra_specs_1_value,
+       instance_type_extra_specs_1.instance_type_id as instance_type_extra_specs_1_instance_type_id
+from (select instance_types.created_at as instance_types_created_at,
+             instance_types.updated_at as instance_types_updated_at,
+             instance_types.deleted_at as instance_types_deleted_at,
+             instance_types.deleted as instance_types_deleted,
+             instance_types.id as instance_types_id,
+             instance_types.name as instance_types_name,
+             instance_types.memory_mb as instance_types_memory_mb,
+             instance_types.vcpus as instance_types_vcpus,
+             instance_types.root_gb as instance_types_root_gb,
+             instance_types.ephemeral_gb as instance_types_ephemeral_gb,
+             instance_types.flavorid as instance_types_flavorid,
+             instance_types.swap as instance_types_swap,
+             instance_types.rxtx_factor as instance_types_rxtx_factor,
+             instance_types.vcpu_weight as instance_types_vcpu_weight,
+             instance_types.disabled as instance_types_disabled,
+             instance_types.is_public as instance_types_is_public
+      from instance_types
+      where instance_types.deleted = $1
+            and (instance_types.is_public = true
+                 or (exists (select 1
+                             from instance_type_projects
+                             where instance_type_projects.instance_type_id = instance_types.id
+                                   and instance_type_projects.deleted = $2
+                                   and instance_type_projects.deleted = $3
+                                   and instance_type_projects.project_id = $4)))
+      order by instance_types.flavorid asc, instance_types.id asc
+      offset $5 rows
+      limit $6)
+     as anon_1
+     left join instance_type_extra_specs as instance_type_extra_specs_1
+     on instance_type_extra_specs_1.instance_type_id = anon_1.instance_types_id
+        and instance_type_extra_specs_1.deleted = $7
+order by anon_1.instance_types_flavorid asc,
+         anon_1.instance_types_id asc
+----
+sort
+ ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
+ ├── key: (1,28)
+ ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ ├── ordering: +7,+1
+ └── right-join
+      ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      ├── key: (1,28)
+      ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      ├── select
+      │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool!null) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      │    ├── key: (28)
+      │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    ├── scan instance_type_extra_specs
+      │    │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      │    │    ├── key: (28)
+      │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    └── filters [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      │         └── instance_type_extra_specs.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      ├── project
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    └── limit
+      │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         ├── key: (1)
+      │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         ├── offset
+      │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         │    ├── key: (1)
+      │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    ├── ordering: +7,+1
+      │         │    ├── sort
+      │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         │    │    ├── key: (1)
+      │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │    ├── ordering: +7,+1
+      │         │    │    └── select
+      │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         │    │         ├── key: (1)
+      │         │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         ├── group-by
+      │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+      │         │    │         │    ├── key: (1)
+      │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    ├── left-join (merge)
+      │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+      │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+      │         │    │         │    │    ├── select
+      │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │    ├── key: (1)
+      │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    │    │    ├── ordering: +1
+      │         │    │         │    │    │    ├── scan instance_types
+      │         │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │    │    ├── key: (1)
+      │         │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    │    │    │    └── ordering: +1
+      │         │    │         │    │    │    └── filters [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │         │    │         │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │         │    │         │    │    │    ├── fd: ()-->(25)
+      │         │    │         │    │    │    ├── ordering: +18 opt(25)
+      │         │    │         │    │    │    ├── select
+      │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+      │         │    │         │    │    │    │    ├── ordering: +18
+      │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
+      │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │         │    │         │    │    │    │    │    └── ordering: +18
+      │         │    │         │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $3 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │         │    │         │    │    │    │         └── instance_type_projects.project_id = $4 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │         │    │         │    │    │    └── projections [outer=(18)]
+      │         │    │         │    │    │         └── true [type=bool]
+      │         │    │         │    │    └── merge-on
+      │         │    │         │    │         ├── left ordering: +1
+      │         │    │         │    │         ├── right ordering: +18
+      │         │    │         │    │         └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+      │         │    │         │    │              └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+      │         │    │         │    └── aggregations [outer=(2-16,25)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(25)]
+      │         │    │         │         │    └── variable: true [type=bool, outer=(25)]
+      │         │    │         │         ├── any-not-null [type=string, outer=(2)]
+      │         │    │         │         │    └── variable: instance_types.name [type=string, outer=(2)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(3)]
+      │         │    │         │         │    └── variable: instance_types.memory_mb [type=int, outer=(3)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(4)]
+      │         │    │         │         │    └── variable: instance_types.vcpus [type=int, outer=(4)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(5)]
+      │         │    │         │         │    └── variable: instance_types.root_gb [type=int, outer=(5)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(6)]
+      │         │    │         │         │    └── variable: instance_types.ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │         ├── any-not-null [type=string, outer=(7)]
+      │         │    │         │         │    └── variable: instance_types.flavorid [type=string, outer=(7)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(8)]
+      │         │    │         │         │    └── variable: instance_types.swap [type=int, outer=(8)]
+      │         │    │         │         ├── any-not-null [type=float, outer=(9)]
+      │         │    │         │         │    └── variable: instance_types.rxtx_factor [type=float, outer=(9)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(10)]
+      │         │    │         │         │    └── variable: instance_types.vcpu_weight [type=int, outer=(10)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(11)]
+      │         │    │         │         │    └── variable: instance_types.disabled [type=bool, outer=(11)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(12)]
+      │         │    │         │         │    └── variable: instance_types.is_public [type=bool, outer=(12)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(13)]
+      │         │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+      │         │    │         │         ├── any-not-null [type=timestamp, outer=(14)]
+      │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+      │         │    │         │         ├── any-not-null [type=timestamp, outer=(15)]
+      │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+      │         │    │         │         └── any-not-null [type=timestamp, outer=(16)]
+      │         │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+      │         │    │         └── filters [type=bool, outer=(12,26)]
+      │         │    │              └── (instance_types.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,26)]
+      │         │    └── placeholder: $5 [type=int]
+      │         └── placeholder: $6 [type=int]
+      └── filters [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
+           └── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
+
+opt
+select instance_types.created_at as instance_types_created_at,
+       instance_types.updated_at as instance_types_updated_at,
+       instance_types.deleted_at as instance_types_deleted_at,
+       instance_types.deleted as instance_types_deleted,
+       instance_types.id as instance_types_id,
+       instance_types.name as instance_types_name,
+       instance_types.memory_mb as instance_types_memory_mb,
+       instance_types.vcpus as instance_types_vcpus,
+       instance_types.root_gb as instance_types_root_gb,
+       instance_types.ephemeral_gb as instance_types_ephemeral_gb,
+       instance_types.flavorid as instance_types_flavorid,
+       instance_types.swap as instance_types_swap,
+       instance_types.rxtx_factor as instance_types_rxtx_factor,
+       instance_types.vcpu_weight as instance_types_vcpu_weight,
+       instance_types.disabled as instance_types_disabled,
+       instance_types.is_public as instance_types_is_public,
+       instance_type_extra_specs_1.created_at as instance_type_extra_specs_1_created_at,
+       instance_type_extra_specs_1.updated_at as instance_type_extra_specs_1_updated_at,
+       instance_type_extra_specs_1.deleted_at as instance_type_extra_specs_1_deleted_at,
+       instance_type_extra_specs_1.deleted as instance_type_extra_specs_1_deleted,
+       instance_type_extra_specs_1.id as instance_type_extra_specs_1_id,
+       instance_type_extra_specs_1."key" as instance_type_extra_specs_1_key,
+       instance_type_extra_specs_1.value as instance_type_extra_specs_1_value,
+       instance_type_extra_specs_1.instance_type_id as instance_type_extra_specs_1_instance_type_id
+from instance_types
+     left join instance_type_extra_specs as instance_type_extra_specs_1
+     on instance_type_extra_specs_1.instance_type_id = instance_types.id
+        and instance_type_extra_specs_1.deleted = $1
+where instance_types.deleted = $2
+      and (instance_types.is_public = true
+           or (exists (select 1
+                       from instance_type_projects
+                       where instance_type_projects.instance_type_id = instance_types.id
+                             and instance_type_projects.deleted = $3
+                             and instance_type_projects.project_id = $4)))
+order by instance_types.flavorid asc, instance_types.id asc
+----
+sort
+ ├── columns: instance_types_created_at:15(timestamp) instance_types_updated_at:16(timestamp) instance_types_deleted_at:14(timestamp) instance_types_deleted:13(bool) instance_types_id:1(int!null) instance_types_name:2(string) instance_types_memory_mb:3(int) instance_types_vcpus:4(int) instance_types_root_gb:5(int) instance_types_ephemeral_gb:6(int) instance_types_flavorid:7(string) instance_types_swap:8(int) instance_types_rxtx_factor:9(float) instance_types_vcpu_weight:10(int) instance_types_disabled:11(bool) instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:23(timestamp) instance_type_extra_specs_1_updated_at:24(timestamp) instance_type_extra_specs_1_deleted_at:22(timestamp) instance_type_extra_specs_1_deleted:21(bool) instance_type_extra_specs_1_id:17(int) instance_type_extra_specs_1_key:18(string) instance_type_extra_specs_1_value:19(string) instance_type_extra_specs_1_instance_type_id:20(int)
+ ├── key: (1,17)
+ ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (17)-->(18-24), (18,20,21)~~>(17,19,22-24)
+ ├── ordering: +7,+1
+ └── right-join
+      ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:17(int) key:18(string) value:19(string) instance_type_extra_specs.instance_type_id:20(int) instance_type_extra_specs.deleted:21(bool) instance_type_extra_specs.deleted_at:22(timestamp) instance_type_extra_specs.created_at:23(timestamp) instance_type_extra_specs.updated_at:24(timestamp)
+      ├── key: (1,17)
+      ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (17)-->(18-24), (18,20,21)~~>(17,19,22-24)
+      ├── select
+      │    ├── columns: instance_type_extra_specs.id:17(int!null) key:18(string) value:19(string) instance_type_extra_specs.instance_type_id:20(int!null) instance_type_extra_specs.deleted:21(bool!null) instance_type_extra_specs.deleted_at:22(timestamp) instance_type_extra_specs.created_at:23(timestamp) instance_type_extra_specs.updated_at:24(timestamp)
+      │    ├── key: (17)
+      │    ├── fd: (17)-->(18-24), (18,20,21)~~>(17,19,22-24)
+      │    ├── scan instance_type_extra_specs
+      │    │    ├── columns: instance_type_extra_specs.id:17(int!null) key:18(string) value:19(string) instance_type_extra_specs.instance_type_id:20(int!null) instance_type_extra_specs.deleted:21(bool) instance_type_extra_specs.deleted_at:22(timestamp) instance_type_extra_specs.created_at:23(timestamp) instance_type_extra_specs.updated_at:24(timestamp)
+      │    │    ├── key: (17)
+      │    │    └── fd: (17)-->(18-24), (18,20,21)~~>(17,19,22-24)
+      │    └── filters [type=bool, outer=(21), constraints=(/21: (/NULL - ])]
+      │         └── instance_type_extra_specs.deleted = $1 [type=bool, outer=(21), constraints=(/21: (/NULL - ])]
+      ├── project
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    └── select
+      │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:34(bool)
+      │         ├── key: (1)
+      │         ├── fd: (1)-->(2-16,34), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         ├── group-by
+      │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:34(bool)
+      │         │    ├── grouping columns: instance_types.id:1(int!null)
+      │         │    ├── key: (1)
+      │         │    ├── fd: (1)-->(2-16,34), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    ├── left-join (merge)
+      │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:26(int) true:33(bool)
+      │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(33)
+      │         │    │    ├── select
+      │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │    │    ├── key: (1)
+      │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │    │    ├── ordering: +1
+      │         │    │    │    ├── scan instance_types
+      │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │    │    │    ├── key: (1)
+      │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │    │    │    └── ordering: +1
+      │         │    │    │    └── filters [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │         │    │    │         └── instance_types.deleted = $2 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │         │    │    ├── project
+      │         │    │    │    ├── columns: true:33(bool!null) instance_type_projects.instance_type_id:26(int!null)
+      │         │    │    │    ├── fd: ()-->(33)
+      │         │    │    │    ├── ordering: +26 opt(33)
+      │         │    │    │    ├── select
+      │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
+      │         │    │    │    │    ├── ordering: +26
+      │         │    │    │    │    ├── scan instance_type_projects@secondary
+      │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) project_id:27(string) instance_type_projects.deleted:28(bool)
+      │         │    │    │    │    │    └── ordering: +26
+      │         │    │    │    │    └── filters [type=bool, outer=(27,28), constraints=(/27: (/NULL - ]; /28: (/NULL - ])]
+      │         │    │    │    │         ├── instance_type_projects.deleted = $3 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
+      │         │    │    │    │         └── instance_type_projects.project_id = $4 [type=bool, outer=(27), constraints=(/27: (/NULL - ])]
+      │         │    │    │    └── projections [outer=(26)]
+      │         │    │    │         └── true [type=bool]
+      │         │    │    └── merge-on
+      │         │    │         ├── left ordering: +1
+      │         │    │         ├── right ordering: +26
+      │         │    │         └── filters [type=bool, outer=(1,26), constraints=(/1: (/NULL - ]; /26: (/NULL - ]), fd=(1)==(26), (26)==(1)]
+      │         │    │              └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,26), constraints=(/1: (/NULL - ]; /26: (/NULL - ])]
+      │         │    └── aggregations [outer=(2-16,33)]
+      │         │         ├── any-not-null [type=bool, outer=(33)]
+      │         │         │    └── variable: true [type=bool, outer=(33)]
+      │         │         ├── any-not-null [type=string, outer=(2)]
+      │         │         │    └── variable: instance_types.name [type=string, outer=(2)]
+      │         │         ├── any-not-null [type=int, outer=(3)]
+      │         │         │    └── variable: instance_types.memory_mb [type=int, outer=(3)]
+      │         │         ├── any-not-null [type=int, outer=(4)]
+      │         │         │    └── variable: instance_types.vcpus [type=int, outer=(4)]
+      │         │         ├── any-not-null [type=int, outer=(5)]
+      │         │         │    └── variable: instance_types.root_gb [type=int, outer=(5)]
+      │         │         ├── any-not-null [type=int, outer=(6)]
+      │         │         │    └── variable: instance_types.ephemeral_gb [type=int, outer=(6)]
+      │         │         ├── any-not-null [type=string, outer=(7)]
+      │         │         │    └── variable: instance_types.flavorid [type=string, outer=(7)]
+      │         │         ├── any-not-null [type=int, outer=(8)]
+      │         │         │    └── variable: instance_types.swap [type=int, outer=(8)]
+      │         │         ├── any-not-null [type=float, outer=(9)]
+      │         │         │    └── variable: instance_types.rxtx_factor [type=float, outer=(9)]
+      │         │         ├── any-not-null [type=int, outer=(10)]
+      │         │         │    └── variable: instance_types.vcpu_weight [type=int, outer=(10)]
+      │         │         ├── any-not-null [type=bool, outer=(11)]
+      │         │         │    └── variable: instance_types.disabled [type=bool, outer=(11)]
+      │         │         ├── any-not-null [type=bool, outer=(12)]
+      │         │         │    └── variable: instance_types.is_public [type=bool, outer=(12)]
+      │         │         ├── any-not-null [type=bool, outer=(13)]
+      │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+      │         │         ├── any-not-null [type=timestamp, outer=(14)]
+      │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+      │         │         ├── any-not-null [type=timestamp, outer=(15)]
+      │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+      │         │         └── any-not-null [type=timestamp, outer=(16)]
+      │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+      │         └── filters [type=bool, outer=(12,34)]
+      │              └── (instance_types.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,34)]
+      └── filters [type=bool, outer=(1,20), constraints=(/1: (/NULL - ]; /20: (/NULL - ]), fd=(1)==(20), (20)==(1)]
+           └── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,20), constraints=(/1: (/NULL - ]; /20: (/NULL - ])]
+
+opt
+select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
+       anon_1.instance_types_updated_at as anon_1_instance_types_updated_at,
+       anon_1.instance_types_deleted_at as anon_1_instance_types_deleted_at,
+       anon_1.instance_types_deleted as anon_1_instance_types_deleted,
+       anon_1.instance_types_id as anon_1_instance_types_id,
+       anon_1.instance_types_name as anon_1_instance_types_name,
+       anon_1.instance_types_memory_mb as anon_1_instance_types_memory_mb,
+       anon_1.instance_types_vcpus as anon_1_instance_types_vcpus,
+       anon_1.instance_types_root_gb as anon_1_instance_types_root_gb,
+       anon_1.instance_types_ephemeral_gb as anon_1_instance_types_ephemeral_gb,
+       anon_1.instance_types_flavorid as anon_1_instance_types_flavorid,
+       anon_1.instance_types_swap as anon_1_instance_types_swap,
+       anon_1.instance_types_rxtx_factor as anon_1_instance_types_rxtx_factor,
+       anon_1.instance_types_vcpu_weight as anon_1_instance_types_vcpu_weight,
+       anon_1.instance_types_disabled as anon_1_instance_types_disabled,
+       anon_1.instance_types_is_public as anon_1_instance_types_is_public,
+       instance_type_extra_specs_1.created_at as instance_type_extra_specs_1_created_at,
+       instance_type_extra_specs_1.updated_at as instance_type_extra_specs_1_updated_at,
+       instance_type_extra_specs_1.deleted_at as instance_type_extra_specs_1_deleted_at,
+       instance_type_extra_specs_1.deleted as instance_type_extra_specs_1_deleted,
+       instance_type_extra_specs_1.id as instance_type_extra_specs_1_id,
+       instance_type_extra_specs_1."key" as instance_type_extra_specs_1_key,
+       instance_type_extra_specs_1.value as instance_type_extra_specs_1_value,
+       instance_type_extra_specs_1.instance_type_id as instance_type_extra_specs_1_instance_type_id
+from (select instance_types.created_at as instance_types_created_at,
+             instance_types.updated_at as instance_types_updated_at,
+             instance_types.deleted_at as instance_types_deleted_at,
+             instance_types.deleted as instance_types_deleted,
+             instance_types.id as instance_types_id,
+             instance_types.name as instance_types_name,
+             instance_types.memory_mb as instance_types_memory_mb,
+             instance_types.vcpus as instance_types_vcpus,
+             instance_types.root_gb as instance_types_root_gb,
+             instance_types.ephemeral_gb as instance_types_ephemeral_gb,
+             instance_types.flavorid as instance_types_flavorid,
+             instance_types.swap as instance_types_swap,
+             instance_types.rxtx_factor as instance_types_rxtx_factor,
+             instance_types.vcpu_weight as instance_types_vcpu_weight,
+             instance_types.disabled as instance_types_disabled,
+             instance_types.is_public as instance_types_is_public
+      from instance_types
+      where instance_types.deleted = $1
+            and (instance_types.is_public = true
+                 or (exists (select 1
+                             from instance_type_projects
+                             where instance_type_projects.instance_type_id = instance_types.id
+                                   and instance_type_projects.deleted = $2
+                                   and instance_type_projects.project_id = $3)))
+            and instance_types.name = $4
+      offset $5 rows
+      limit $6)
+     as anon_1
+     left join instance_type_extra_specs as instance_type_extra_specs_1
+     on instance_type_extra_specs_1.instance_type_id = anon_1.instance_types_id
+        and instance_type_extra_specs_1.deleted = $7
+----
+right-join
+ ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
+ ├── key: (1,28)
+ ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ ├── select
+ │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool!null) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+ │    ├── key: (28)
+ │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ │    ├── scan instance_type_extra_specs
+ │    │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+ │    │    ├── key: (28)
+ │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ │    └── filters [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+ │         └── instance_type_extra_specs.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+ ├── project
+ │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+ │    └── limit
+ │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+ │         ├── offset
+ │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+ │         │    ├── key: (1)
+ │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+ │         │    ├── select
+ │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+ │         │    │    ├── key: (1)
+ │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+ │         │    │    ├── group-by
+ │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+ │         │    │    │    ├── grouping columns: instance_types.id:1(int!null)
+ │         │    │    │    ├── key: (1)
+ │         │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+ │         │    │    │    ├── left-join
+ │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+ │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), ()~~>(25)
+ │         │    │    │    │    ├── index-join instance_types
+ │         │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │         │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+ │         │    │    │    │    │    └── select
+ │         │    │    │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string!null) instance_types.deleted:13(bool!null)
+ │         │    │    │    │    │         ├── key: (1)
+ │         │    │    │    │    │         ├── fd: (1)-->(2,13), (2,13)-->(1)
+ │         │    │    │    │    │         ├── scan instance_types@secondary
+ │         │    │    │    │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string!null) instance_types.deleted:13(bool)
+ │         │    │    │    │    │         │    ├── constraint: /2/13: (/NULL - ]
+ │         │    │    │    │    │         │    ├── key: (1)
+ │         │    │    │    │    │         │    └── fd: (1)-->(2,13), (2,13)~~>(1)
+ │         │    │    │    │    │         └── filters [type=bool, outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ])]
+ │         │    │    │    │    │              ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+ │         │    │    │    │    │              └── instance_types.name = $4 [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
+ │         │    │    │    │    ├── project
+ │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+ │         │    │    │    │    │    ├── fd: ()-->(25)
+ │         │    │    │    │    │    ├── select
+ │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+ │         │    │    │    │    │    │    ├── scan instance_type_projects@secondary
+ │         │    │    │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+ │         │    │    │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+ │         │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+ │         │    │    │    │    │    │         └── instance_type_projects.project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+ │         │    │    │    │    │    └── projections [outer=(18)]
+ │         │    │    │    │    │         └── true [type=bool]
+ │         │    │    │    │    └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+ │         │    │    │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+ │         │    │    │    └── aggregations [outer=(2-16,25)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(25)]
+ │         │    │    │         │    └── variable: true [type=bool, outer=(25)]
+ │         │    │    │         ├── any-not-null [type=string, outer=(2)]
+ │         │    │    │         │    └── variable: instance_types.name [type=string, outer=(2)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(3)]
+ │         │    │    │         │    └── variable: instance_types.memory_mb [type=int, outer=(3)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(4)]
+ │         │    │    │         │    └── variable: instance_types.vcpus [type=int, outer=(4)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(5)]
+ │         │    │    │         │    └── variable: instance_types.root_gb [type=int, outer=(5)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(6)]
+ │         │    │    │         │    └── variable: instance_types.ephemeral_gb [type=int, outer=(6)]
+ │         │    │    │         ├── any-not-null [type=string, outer=(7)]
+ │         │    │    │         │    └── variable: instance_types.flavorid [type=string, outer=(7)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(8)]
+ │         │    │    │         │    └── variable: instance_types.swap [type=int, outer=(8)]
+ │         │    │    │         ├── any-not-null [type=float, outer=(9)]
+ │         │    │    │         │    └── variable: instance_types.rxtx_factor [type=float, outer=(9)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(10)]
+ │         │    │    │         │    └── variable: instance_types.vcpu_weight [type=int, outer=(10)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(11)]
+ │         │    │    │         │    └── variable: instance_types.disabled [type=bool, outer=(11)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(12)]
+ │         │    │    │         │    └── variable: instance_types.is_public [type=bool, outer=(12)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(13)]
+ │         │    │    │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+ │         │    │    │         ├── any-not-null [type=timestamp, outer=(14)]
+ │         │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+ │         │    │    │         ├── any-not-null [type=timestamp, outer=(15)]
+ │         │    │    │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+ │         │    │    │         └── any-not-null [type=timestamp, outer=(16)]
+ │         │    │    │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+ │         │    │    └── filters [type=bool, outer=(12,26)]
+ │         │    │         └── (instance_types.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,26)]
+ │         │    └── placeholder: $5 [type=int]
+ │         └── placeholder: $6 [type=int]
+ └── filters [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
+      └── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
+
+opt
+select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
+       anon_1.instance_types_updated_at as anon_1_instance_types_updated_at,
+       anon_1.instance_types_deleted_at as anon_1_instance_types_deleted_at,
+       anon_1.instance_types_deleted as anon_1_instance_types_deleted,
+       anon_1.instance_types_id as anon_1_instance_types_id,
+       anon_1.instance_types_name as anon_1_instance_types_name,
+       anon_1.instance_types_memory_mb as anon_1_instance_types_memory_mb,
+       anon_1.instance_types_vcpus as anon_1_instance_types_vcpus,
+       anon_1.instance_types_root_gb as anon_1_instance_types_root_gb,
+       anon_1.instance_types_ephemeral_gb as anon_1_instance_types_ephemeral_gb,
+       anon_1.instance_types_flavorid as anon_1_instance_types_flavorid,
+       anon_1.instance_types_swap as anon_1_instance_types_swap,
+       anon_1.instance_types_rxtx_factor as anon_1_instance_types_rxtx_factor,
+       anon_1.instance_types_vcpu_weight as anon_1_instance_types_vcpu_weight,
+       anon_1.instance_types_disabled as anon_1_instance_types_disabled,
+       anon_1.instance_types_is_public as anon_1_instance_types_is_public,
+       instance_type_extra_specs_1.created_at as instance_type_extra_specs_1_created_at,
+       instance_type_extra_specs_1.updated_at as instance_type_extra_specs_1_updated_at,
+       instance_type_extra_specs_1.deleted_at as instance_type_extra_specs_1_deleted_at,
+       instance_type_extra_specs_1.deleted as instance_type_extra_specs_1_deleted,
+       instance_type_extra_specs_1.id as instance_type_extra_specs_1_id,
+       instance_type_extra_specs_1."key" as instance_type_extra_specs_1_key,
+       instance_type_extra_specs_1.value as instance_type_extra_specs_1_value,
+       instance_type_extra_specs_1.instance_type_id as instance_type_extra_specs_1_instance_type_id
+from (select instance_types.created_at as instance_types_created_at,
+             instance_types.updated_at as instance_types_updated_at,
+             instance_types.deleted_at as instance_types_deleted_at,
+             instance_types.deleted as instance_types_deleted,
+             instance_types.id as instance_types_id,
+             instance_types.name as instance_types_name,
+             instance_types.memory_mb as instance_types_memory_mb,
+             instance_types.vcpus as instance_types_vcpus,
+             instance_types.root_gb as instance_types_root_gb,
+             instance_types.ephemeral_gb as instance_types_ephemeral_gb,
+             instance_types.flavorid as instance_types_flavorid,
+             instance_types.swap as instance_types_swap,
+             instance_types.rxtx_factor as instance_types_rxtx_factor,
+             instance_types.vcpu_weight as instance_types_vcpu_weight,
+             instance_types.disabled as instance_types_disabled,
+             instance_types.is_public as instance_types_is_public
+      from instance_types
+      where instance_types.deleted = $1
+            and (instance_types.is_public = true
+                 or (exists (select 1
+                             from instance_type_projects
+                             where instance_type_projects.instance_type_id = instance_types.id
+                                   and instance_type_projects.deleted = $2
+                                   and instance_type_projects.project_id = $3)))
+            and instance_types.id = $4
+      offset $5 rows
+      limit $6)
+     as anon_1
+     left join instance_type_extra_specs as instance_type_extra_specs_1
+     on instance_type_extra_specs_1.instance_type_id = anon_1.instance_types_id
+        and instance_type_extra_specs_1.deleted = $7
+----
+right-join
+ ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
+ ├── key: (1,28)
+ ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ ├── select
+ │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool!null) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+ │    ├── key: (28)
+ │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ │    ├── scan instance_type_extra_specs
+ │    │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+ │    │    ├── key: (28)
+ │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ │    └── filters [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+ │         └── instance_type_extra_specs.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+ ├── project
+ │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │    └── limit
+ │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         ├── offset
+ │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+ │         │    ├── key: (1)
+ │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         │    ├── select
+ │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+ │         │    │    ├── key: (1)
+ │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         │    │    ├── group-by
+ │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+ │         │    │    │    ├── grouping columns: instance_types.id:1(int!null)
+ │         │    │    │    ├── key: (1)
+ │         │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         │    │    │    ├── left-join (merge)
+ │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+ │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+ │         │    │    │    │    ├── select
+ │         │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │         │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         │    │    │    │    │    ├── ordering: +1
+ │         │    │    │    │    │    ├── scan instance_types
+ │         │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │         │    │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         │    │    │    │    │    │    └── ordering: +1
+ │         │    │    │    │    │    └── filters [type=bool, outer=(1,13), constraints=(/1: (/NULL - ]; /13: (/NULL - ])]
+ │         │    │    │    │    │         ├── instance_types.id = $4 [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+ │         │    │    │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+ │         │    │    │    │    ├── project
+ │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+ │         │    │    │    │    │    ├── fd: ()-->(25)
+ │         │    │    │    │    │    ├── ordering: +18 opt(25)
+ │         │    │    │    │    │    ├── select
+ │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+ │         │    │    │    │    │    │    ├── ordering: +18
+ │         │    │    │    │    │    │    ├── scan instance_type_projects@secondary
+ │         │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+ │         │    │    │    │    │    │    │    └── ordering: +18
+ │         │    │    │    │    │    │    └── filters [type=bool, outer=(18-20), constraints=(/18: (/NULL - ]; /19: (/NULL - ]; /20: (/NULL - ])]
+ │         │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+ │         │    │    │    │    │    │         ├── instance_type_projects.project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+ │         │    │    │    │    │    │         └── instance_type_projects.instance_type_id = $4 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+ │         │    │    │    │    │    └── projections [outer=(18)]
+ │         │    │    │    │    │         └── true [type=bool]
+ │         │    │    │    │    └── merge-on
+ │         │    │    │    │         ├── left ordering: +1
+ │         │    │    │    │         ├── right ordering: +18
+ │         │    │    │    │         └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+ │         │    │    │    │              └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+ │         │    │    │    └── aggregations [outer=(2-16,25)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(25)]
+ │         │    │    │         │    └── variable: true [type=bool, outer=(25)]
+ │         │    │    │         ├── any-not-null [type=string, outer=(2)]
+ │         │    │    │         │    └── variable: instance_types.name [type=string, outer=(2)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(3)]
+ │         │    │    │         │    └── variable: instance_types.memory_mb [type=int, outer=(3)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(4)]
+ │         │    │    │         │    └── variable: instance_types.vcpus [type=int, outer=(4)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(5)]
+ │         │    │    │         │    └── variable: instance_types.root_gb [type=int, outer=(5)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(6)]
+ │         │    │    │         │    └── variable: instance_types.ephemeral_gb [type=int, outer=(6)]
+ │         │    │    │         ├── any-not-null [type=string, outer=(7)]
+ │         │    │    │         │    └── variable: instance_types.flavorid [type=string, outer=(7)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(8)]
+ │         │    │    │         │    └── variable: instance_types.swap [type=int, outer=(8)]
+ │         │    │    │         ├── any-not-null [type=float, outer=(9)]
+ │         │    │    │         │    └── variable: instance_types.rxtx_factor [type=float, outer=(9)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(10)]
+ │         │    │    │         │    └── variable: instance_types.vcpu_weight [type=int, outer=(10)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(11)]
+ │         │    │    │         │    └── variable: instance_types.disabled [type=bool, outer=(11)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(12)]
+ │         │    │    │         │    └── variable: instance_types.is_public [type=bool, outer=(12)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(13)]
+ │         │    │    │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+ │         │    │    │         ├── any-not-null [type=timestamp, outer=(14)]
+ │         │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+ │         │    │    │         ├── any-not-null [type=timestamp, outer=(15)]
+ │         │    │    │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+ │         │    │    │         └── any-not-null [type=timestamp, outer=(16)]
+ │         │    │    │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+ │         │    │    └── filters [type=bool, outer=(12,26)]
+ │         │    │         └── (instance_types.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,26)]
+ │         │    └── placeholder: $5 [type=int]
+ │         └── placeholder: $6 [type=int]
+ └── filters [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
+      └── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
+
+opt
+select anon_1.flavors_created_at as anon_1_flavors_created_at,
+       anon_1.flavors_updated_at as anon_1_flavors_updated_at,
+       anon_1.flavors_id as anon_1_flavors_id,
+       anon_1.flavors_name as anon_1_flavors_name,
+       anon_1.flavors_memory_mb as anon_1_flavors_memory_mb,
+       anon_1.flavors_vcpus as anon_1_flavors_vcpus,
+       anon_1.flavors_root_gb as anon_1_flavors_root_gb,
+       anon_1.flavors_ephemeral_gb as anon_1_flavors_ephemeral_gb,
+       anon_1.flavors_flavorid as anon_1_flavors_flavorid,
+       anon_1.flavors_swap as anon_1_flavors_swap,
+       anon_1.flavors_rxtx_factor as anon_1_flavors_rxtx_factor,
+       anon_1.flavors_vcpu_weight as anon_1_flavors_vcpu_weight,
+       anon_1.flavors_disabled as anon_1_flavors_disabled,
+       anon_1.flavors_is_public as anon_1_flavors_is_public,
+       flavor_extra_specs_1.created_at as flavor_extra_specs_1_created_at,
+       flavor_extra_specs_1.updated_at as flavor_extra_specs_1_updated_at,
+       flavor_extra_specs_1.id as flavor_extra_specs_1_id,
+       flavor_extra_specs_1."key" as flavor_extra_specs_1_key,
+       flavor_extra_specs_1.value as flavor_extra_specs_1_value,
+       flavor_extra_specs_1.flavor_id as flavor_extra_specs_1_flavor_id
+from (select flavors.created_at as flavors_created_at,
+             flavors.updated_at as flavors_updated_at,
+             flavors.id as flavors_id,
+             flavors.name as flavors_name,
+             flavors.memory_mb as flavors_memory_mb,
+             flavors.vcpus as flavors_vcpus,
+             flavors.root_gb as flavors_root_gb,
+             flavors.ephemeral_gb as flavors_ephemeral_gb,
+             flavors.flavorid as flavors_flavorid,
+             flavors.swap as flavors_swap,
+             flavors.rxtx_factor as flavors_rxtx_factor,
+             flavors.vcpu_weight as flavors_vcpu_weight,
+             flavors.disabled as flavors_disabled,
+             flavors.is_public as flavors_is_public
+      from flavors
+      where (flavors.is_public = true
+             or (exists (select 1
+                         from flavor_projects
+                         where flavor_projects.flavor_id = flavors.id
+                               and flavor_projects.project_id = $1)))
+            and flavors.name = $2
+      offset $3 rows
+      limit $4)
+     as anon_1
+     left join flavor_extra_specs as flavor_extra_specs_1
+     on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
+----
+right-join
+ ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── key: (1,25)
+ ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+ ├── scan flavor_extra_specs
+ │    ├── columns: flavor_extra_specs.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs.flavor_id:28(int!null) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+ │    ├── key: (25)
+ │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
+ ├── project
+ │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │    └── limit
+ │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         ├── offset
+ │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+ │         │    ├── key: (1)
+ │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    ├── select
+ │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+ │         │    │    ├── key: (1)
+ │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    │    ├── group-by
+ │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+ │         │    │    │    ├── grouping columns: flavors.id:1(int!null)
+ │         │    │    │    ├── key: (1)
+ │         │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    │    │    ├── left-join (merge)
+ │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+ │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
+ │         │    │    │    │    ├── select
+ │         │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │         │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    │    │    │    │    ├── ordering: +1
+ │         │    │    │    │    │    ├── scan flavors
+ │         │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │         │    │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    │    │    │    │    │    └── ordering: +1
+ │         │    │    │    │    │    └── filters [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
+ │         │    │    │    │    │         └── flavors.name = $2 [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
+ │         │    │    │    │    ├── project
+ │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+ │         │    │    │    │    │    ├── fd: ()-->(22)
+ │         │    │    │    │    │    ├── ordering: +17 opt(22)
+ │         │    │    │    │    │    ├── select
+ │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+ │         │    │    │    │    │    │    ├── key: (17,18)
+ │         │    │    │    │    │    │    ├── ordering: +17
+ │         │    │    │    │    │    │    ├── scan flavor_projects@secondary
+ │         │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+ │         │    │    │    │    │    │    │    ├── key: (17,18)
+ │         │    │    │    │    │    │    │    └── ordering: +17
+ │         │    │    │    │    │    │    └── filters [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+ │         │    │    │    │    │    │         └── flavor_projects.project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+ │         │    │    │    │    │    └── projections [outer=(17)]
+ │         │    │    │    │    │         └── true [type=bool]
+ │         │    │    │    │    └── merge-on
+ │         │    │    │    │         ├── left ordering: +1
+ │         │    │    │    │         ├── right ordering: +17
+ │         │    │    │    │         └── filters [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
+ │         │    │    │    │              └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ])]
+ │         │    │    │    └── aggregations [outer=(2-12,14,15,22)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(22)]
+ │         │    │    │         │    └── variable: true [type=bool, outer=(22)]
+ │         │    │    │         ├── any-not-null [type=string, outer=(2)]
+ │         │    │    │         │    └── variable: flavors.name [type=string, outer=(2)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(3)]
+ │         │    │    │         │    └── variable: flavors.memory_mb [type=int, outer=(3)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(4)]
+ │         │    │    │         │    └── variable: flavors.vcpus [type=int, outer=(4)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(5)]
+ │         │    │    │         │    └── variable: flavors.root_gb [type=int, outer=(5)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(6)]
+ │         │    │    │         │    └── variable: flavors.ephemeral_gb [type=int, outer=(6)]
+ │         │    │    │         ├── any-not-null [type=string, outer=(7)]
+ │         │    │    │         │    └── variable: flavors.flavorid [type=string, outer=(7)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(8)]
+ │         │    │    │         │    └── variable: flavors.swap [type=int, outer=(8)]
+ │         │    │    │         ├── any-not-null [type=float, outer=(9)]
+ │         │    │    │         │    └── variable: flavors.rxtx_factor [type=float, outer=(9)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(10)]
+ │         │    │    │         │    └── variable: flavors.vcpu_weight [type=int, outer=(10)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(11)]
+ │         │    │    │         │    └── variable: flavors.disabled [type=bool, outer=(11)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(12)]
+ │         │    │    │         │    └── variable: flavors.is_public [type=bool, outer=(12)]
+ │         │    │    │         ├── any-not-null [type=timestamp, outer=(14)]
+ │         │    │    │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
+ │         │    │    │         └── any-not-null [type=timestamp, outer=(15)]
+ │         │    │    │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
+ │         │    │    └── filters [type=bool, outer=(12,23)]
+ │         │    │         └── (flavors.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,23)]
+ │         │    └── placeholder: $3 [type=int]
+ │         └── placeholder: $4 [type=int]
+ └── filters [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
+      └── flavor_extra_specs.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ])]
+
+opt
+select anon_1.flavors_created_at as anon_1_flavors_created_at,
+       anon_1.flavors_updated_at as anon_1_flavors_updated_at,
+       anon_1.flavors_id as anon_1_flavors_id,
+       anon_1.flavors_name as anon_1_flavors_name,
+       anon_1.flavors_memory_mb as anon_1_flavors_memory_mb,
+       anon_1.flavors_vcpus as anon_1_flavors_vcpus,
+       anon_1.flavors_root_gb as anon_1_flavors_root_gb,
+       anon_1.flavors_ephemeral_gb as anon_1_flavors_ephemeral_gb,
+       anon_1.flavors_flavorid as anon_1_flavors_flavorid,
+       anon_1.flavors_swap as anon_1_flavors_swap,
+       anon_1.flavors_rxtx_factor as anon_1_flavors_rxtx_factor,
+       anon_1.flavors_vcpu_weight as anon_1_flavors_vcpu_weight,
+       anon_1.flavors_disabled as anon_1_flavors_disabled,
+       anon_1.flavors_is_public as anon_1_flavors_is_public,
+       flavor_extra_specs_1.created_at as flavor_extra_specs_1_created_at,
+       flavor_extra_specs_1.updated_at as flavor_extra_specs_1_updated_at,
+       flavor_extra_specs_1.id as flavor_extra_specs_1_id,
+       flavor_extra_specs_1."key" as flavor_extra_specs_1_key,
+       flavor_extra_specs_1.value as flavor_extra_specs_1_value,
+       flavor_extra_specs_1.flavor_id as flavor_extra_specs_1_flavor_id
+from (select flavors.created_at as flavors_created_at,
+             flavors.updated_at as flavors_updated_at,
+             flavors.id as flavors_id,
+             flavors.name as flavors_name,
+             flavors.memory_mb as flavors_memory_mb,
+             flavors.vcpus as flavors_vcpus,
+             flavors.root_gb as flavors_root_gb,
+             flavors.ephemeral_gb as flavors_ephemeral_gb,
+             flavors.flavorid as flavors_flavorid,
+             flavors.swap as flavors_swap,
+             flavors.rxtx_factor as flavors_rxtx_factor,
+             flavors.vcpu_weight as flavors_vcpu_weight,
+             flavors.disabled as flavors_disabled,
+             flavors.is_public as flavors_is_public
+      from flavors
+      where (flavors.is_public = true
+             or (exists (select 1
+                         from flavor_projects
+                         where flavor_projects.flavor_id = flavors.id
+                               and flavor_projects.project_id = $1)))
+            and flavors.flavorid = $2
+      offset $3 rows
+      limit $4)
+     as anon_1
+     left join flavor_extra_specs as flavor_extra_specs_1
+     on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
+----
+right-join
+ ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── key: (1,25)
+ ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+ ├── scan flavor_extra_specs
+ │    ├── columns: flavor_extra_specs.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs.flavor_id:28(int!null) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+ │    ├── key: (25)
+ │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
+ ├── project
+ │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │    └── limit
+ │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         ├── offset
+ │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+ │         │    ├── key: (1)
+ │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    ├── select
+ │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+ │         │    │    ├── key: (1)
+ │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    │    ├── group-by
+ │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+ │         │    │    │    ├── grouping columns: flavors.id:1(int!null)
+ │         │    │    │    ├── key: (1)
+ │         │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    │    │    ├── left-join (merge)
+ │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+ │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
+ │         │    │    │    │    ├── select
+ │         │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │         │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    │    │    │    │    ├── ordering: +1
+ │         │    │    │    │    │    ├── scan flavors
+ │         │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │         │    │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    │    │    │    │    │    └── ordering: +1
+ │         │    │    │    │    │    └── filters [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
+ │         │    │    │    │    │         └── flavors.flavorid = $2 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
+ │         │    │    │    │    ├── project
+ │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+ │         │    │    │    │    │    ├── fd: ()-->(22)
+ │         │    │    │    │    │    ├── ordering: +17 opt(22)
+ │         │    │    │    │    │    ├── select
+ │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+ │         │    │    │    │    │    │    ├── key: (17,18)
+ │         │    │    │    │    │    │    ├── ordering: +17
+ │         │    │    │    │    │    │    ├── scan flavor_projects@secondary
+ │         │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+ │         │    │    │    │    │    │    │    ├── key: (17,18)
+ │         │    │    │    │    │    │    │    └── ordering: +17
+ │         │    │    │    │    │    │    └── filters [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+ │         │    │    │    │    │    │         └── flavor_projects.project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+ │         │    │    │    │    │    └── projections [outer=(17)]
+ │         │    │    │    │    │         └── true [type=bool]
+ │         │    │    │    │    └── merge-on
+ │         │    │    │    │         ├── left ordering: +1
+ │         │    │    │    │         ├── right ordering: +17
+ │         │    │    │    │         └── filters [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
+ │         │    │    │    │              └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ])]
+ │         │    │    │    └── aggregations [outer=(2-12,14,15,22)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(22)]
+ │         │    │    │         │    └── variable: true [type=bool, outer=(22)]
+ │         │    │    │         ├── any-not-null [type=string, outer=(2)]
+ │         │    │    │         │    └── variable: flavors.name [type=string, outer=(2)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(3)]
+ │         │    │    │         │    └── variable: flavors.memory_mb [type=int, outer=(3)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(4)]
+ │         │    │    │         │    └── variable: flavors.vcpus [type=int, outer=(4)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(5)]
+ │         │    │    │         │    └── variable: flavors.root_gb [type=int, outer=(5)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(6)]
+ │         │    │    │         │    └── variable: flavors.ephemeral_gb [type=int, outer=(6)]
+ │         │    │    │         ├── any-not-null [type=string, outer=(7)]
+ │         │    │    │         │    └── variable: flavors.flavorid [type=string, outer=(7)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(8)]
+ │         │    │    │         │    └── variable: flavors.swap [type=int, outer=(8)]
+ │         │    │    │         ├── any-not-null [type=float, outer=(9)]
+ │         │    │    │         │    └── variable: flavors.rxtx_factor [type=float, outer=(9)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(10)]
+ │         │    │    │         │    └── variable: flavors.vcpu_weight [type=int, outer=(10)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(11)]
+ │         │    │    │         │    └── variable: flavors.disabled [type=bool, outer=(11)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(12)]
+ │         │    │    │         │    └── variable: flavors.is_public [type=bool, outer=(12)]
+ │         │    │    │         ├── any-not-null [type=timestamp, outer=(14)]
+ │         │    │    │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
+ │         │    │    │         └── any-not-null [type=timestamp, outer=(15)]
+ │         │    │    │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
+ │         │    │    └── filters [type=bool, outer=(12,23)]
+ │         │    │         └── (flavors.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,23)]
+ │         │    └── placeholder: $3 [type=int]
+ │         └── placeholder: $4 [type=int]
+ └── filters [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
+      └── flavor_extra_specs.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ])]
+
+opt
+select anon_1.flavors_created_at as anon_1_flavors_created_at,
+       anon_1.flavors_updated_at as anon_1_flavors_updated_at,
+       anon_1.flavors_id as anon_1_flavors_id,
+       anon_1.flavors_name as anon_1_flavors_name,
+       anon_1.flavors_memory_mb as anon_1_flavors_memory_mb,
+       anon_1.flavors_vcpus as anon_1_flavors_vcpus,
+       anon_1.flavors_root_gb as anon_1_flavors_root_gb,
+       anon_1.flavors_ephemeral_gb as anon_1_flavors_ephemeral_gb,
+       anon_1.flavors_flavorid as anon_1_flavors_flavorid,
+       anon_1.flavors_swap as anon_1_flavors_swap,
+       anon_1.flavors_rxtx_factor as anon_1_flavors_rxtx_factor,
+       anon_1.flavors_vcpu_weight as anon_1_flavors_vcpu_weight,
+       anon_1.flavors_disabled as anon_1_flavors_disabled,
+       anon_1.flavors_is_public as anon_1_flavors_is_public,
+       flavor_extra_specs_1.created_at as flavor_extra_specs_1_created_at,
+       flavor_extra_specs_1.updated_at as flavor_extra_specs_1_updated_at,
+       flavor_extra_specs_1.id as flavor_extra_specs_1_id,
+       flavor_extra_specs_1."key" as flavor_extra_specs_1_key,
+       flavor_extra_specs_1.value as flavor_extra_specs_1_value,
+       flavor_extra_specs_1.flavor_id as flavor_extra_specs_1_flavor_id
+from (select flavors.created_at as flavors_created_at,
+             flavors.updated_at as flavors_updated_at,
+             flavors.id as flavors_id,
+             flavors.name as flavors_name,
+             flavors.memory_mb as flavors_memory_mb,
+             flavors.vcpus as flavors_vcpus,
+             flavors.root_gb as flavors_root_gb,
+             flavors.ephemeral_gb as flavors_ephemeral_gb,
+             flavors.flavorid as flavors_flavorid,
+             flavors.swap as flavors_swap,
+             flavors.rxtx_factor as flavors_rxtx_factor,
+             flavors.vcpu_weight as flavors_vcpu_weight,
+             flavors.disabled as flavors_disabled,
+             flavors.is_public as flavors_is_public
+      from flavors
+      where (flavors.is_public = true
+             or (exists (select 1
+                         from flavor_projects
+                         where flavor_projects.flavor_id = flavors.id
+                               and flavor_projects.project_id = $1)))
+            and (flavors.flavorid > $2
+                 or flavors.flavorid = $3
+                    and flavors.id > $4)
+      order by flavors.flavorid asc, flavors.id asc
+      offset $5 rows
+      limit $6)
+     as anon_1
+     left join flavor_extra_specs as flavor_extra_specs_1
+     on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
+order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
+----
+sort
+ ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── key: (1,25)
+ ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+ ├── ordering: +7
+ └── right-join
+      ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:25(int) key:26(string) value:27(string) flavor_extra_specs.flavor_id:28(int) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+      ├── key: (1,25)
+      ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+      ├── scan flavor_extra_specs
+      │    ├── columns: flavor_extra_specs.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs.flavor_id:28(int!null) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+      │    ├── key: (25)
+      │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
+      ├── project
+      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    └── limit
+      │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         ├── key: (1)
+      │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         ├── offset
+      │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         │    ├── key: (1)
+      │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    ├── ordering: +7
+      │         │    ├── sort
+      │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         │    │    ├── key: (1)
+      │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    │    ├── ordering: +7
+      │         │    │    └── select
+      │         │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         │    │         ├── key: (1)
+      │         │    │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    │         ├── group-by
+      │         │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         │    │         │    ├── grouping columns: flavors.id:1(int!null)
+      │         │    │         │    ├── key: (1)
+      │         │    │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    │         │    ├── left-join (merge)
+      │         │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+      │         │    │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
+      │         │    │         │    │    ├── select
+      │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │         │    │         │    │    │    ├── key: (1)
+      │         │    │         │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    │         │    │    │    ├── ordering: +1
+      │         │    │         │    │    │    ├── scan flavors
+      │         │    │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │         │    │         │    │    │    │    ├── key: (1)
+      │         │    │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    │         │    │    │    │    └── ordering: +1
+      │         │    │         │    │    │    └── filters [type=bool, outer=(1,7)]
+      │         │    │         │    │    │         └── (flavors.flavorid > $2) OR ((flavors.flavorid = $3) AND (flavors.id > $4)) [type=bool, outer=(1,7)]
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+      │         │    │         │    │    │    ├── fd: ()-->(22)
+      │         │    │         │    │    │    ├── ordering: +17 opt(22)
+      │         │    │         │    │    │    ├── select
+      │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │         │    │         │    │    │    │    ├── key: (17,18)
+      │         │    │         │    │    │    │    ├── ordering: +17
+      │         │    │         │    │    │    │    ├── scan flavor_projects@secondary
+      │         │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │         │    │         │    │    │    │    │    ├── key: (17,18)
+      │         │    │         │    │    │    │    │    └── ordering: +17
+      │         │    │         │    │    │    │    └── filters [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+      │         │    │         │    │    │    │         └── flavor_projects.project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+      │         │    │         │    │    │    └── projections [outer=(17)]
+      │         │    │         │    │    │         └── true [type=bool]
+      │         │    │         │    │    └── merge-on
+      │         │    │         │    │         ├── left ordering: +1
+      │         │    │         │    │         ├── right ordering: +17
+      │         │    │         │    │         └── filters [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
+      │         │    │         │    │              └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ])]
+      │         │    │         │    └── aggregations [outer=(2-12,14,15,22)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(22)]
+      │         │    │         │         │    └── variable: true [type=bool, outer=(22)]
+      │         │    │         │         ├── any-not-null [type=string, outer=(2)]
+      │         │    │         │         │    └── variable: flavors.name [type=string, outer=(2)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(3)]
+      │         │    │         │         │    └── variable: flavors.memory_mb [type=int, outer=(3)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(4)]
+      │         │    │         │         │    └── variable: flavors.vcpus [type=int, outer=(4)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(5)]
+      │         │    │         │         │    └── variable: flavors.root_gb [type=int, outer=(5)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(6)]
+      │         │    │         │         │    └── variable: flavors.ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │         ├── any-not-null [type=string, outer=(7)]
+      │         │    │         │         │    └── variable: flavors.flavorid [type=string, outer=(7)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(8)]
+      │         │    │         │         │    └── variable: flavors.swap [type=int, outer=(8)]
+      │         │    │         │         ├── any-not-null [type=float, outer=(9)]
+      │         │    │         │         │    └── variable: flavors.rxtx_factor [type=float, outer=(9)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(10)]
+      │         │    │         │         │    └── variable: flavors.vcpu_weight [type=int, outer=(10)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(11)]
+      │         │    │         │         │    └── variable: flavors.disabled [type=bool, outer=(11)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(12)]
+      │         │    │         │         │    └── variable: flavors.is_public [type=bool, outer=(12)]
+      │         │    │         │         ├── any-not-null [type=timestamp, outer=(14)]
+      │         │    │         │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
+      │         │    │         │         └── any-not-null [type=timestamp, outer=(15)]
+      │         │    │         │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
+      │         │    │         └── filters [type=bool, outer=(12,23)]
+      │         │    │              └── (flavors.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,23)]
+      │         │    └── placeholder: $5 [type=int]
+      │         └── placeholder: $6 [type=int]
+      └── filters [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
+           └── flavor_extra_specs.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ])]
+
+opt
+select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
+       anon_1.instance_types_updated_at as anon_1_instance_types_updated_at,
+       anon_1.instance_types_deleted_at as anon_1_instance_types_deleted_at,
+       anon_1.instance_types_deleted as anon_1_instance_types_deleted,
+       anon_1.instance_types_id as anon_1_instance_types_id,
+       anon_1.instance_types_name as anon_1_instance_types_name,
+       anon_1.instance_types_memory_mb as anon_1_instance_types_memory_mb,
+       anon_1.instance_types_vcpus as anon_1_instance_types_vcpus,
+       anon_1.instance_types_root_gb as anon_1_instance_types_root_gb,
+       anon_1.instance_types_ephemeral_gb as anon_1_instance_types_ephemeral_gb,
+       anon_1.instance_types_flavorid as anon_1_instance_types_flavorid,
+       anon_1.instance_types_swap as anon_1_instance_types_swap,
+       anon_1.instance_types_rxtx_factor as anon_1_instance_types_rxtx_factor,
+       anon_1.instance_types_vcpu_weight as anon_1_instance_types_vcpu_weight,
+       anon_1.instance_types_disabled as anon_1_instance_types_disabled,
+       anon_1.instance_types_is_public as anon_1_instance_types_is_public,
+       instance_type_extra_specs_1.created_at as instance_type_extra_specs_1_created_at,
+       instance_type_extra_specs_1.updated_at as instance_type_extra_specs_1_updated_at,
+       instance_type_extra_specs_1.deleted_at as instance_type_extra_specs_1_deleted_at,
+       instance_type_extra_specs_1.deleted as instance_type_extra_specs_1_deleted,
+       instance_type_extra_specs_1.id as instance_type_extra_specs_1_id,
+       instance_type_extra_specs_1."key" as instance_type_extra_specs_1_key,
+       instance_type_extra_specs_1.value as instance_type_extra_specs_1_value,
+       instance_type_extra_specs_1.instance_type_id as instance_type_extra_specs_1_instance_type_id
+from (select instance_types.created_at as instance_types_created_at,
+             instance_types.updated_at as instance_types_updated_at,
+             instance_types.deleted_at as instance_types_deleted_at,
+             instance_types.deleted as instance_types_deleted,
+             instance_types.id as instance_types_id,
+             instance_types.name as instance_types_name,
+             instance_types.memory_mb as instance_types_memory_mb,
+             instance_types.vcpus as instance_types_vcpus,
+             instance_types.root_gb as instance_types_root_gb,
+             instance_types.ephemeral_gb as instance_types_ephemeral_gb,
+             instance_types.flavorid as instance_types_flavorid,
+             instance_types.swap as instance_types_swap,
+             instance_types.rxtx_factor as instance_types_rxtx_factor,
+             instance_types.vcpu_weight as instance_types_vcpu_weight,
+             instance_types.disabled as instance_types_disabled,
+             instance_types.is_public as instance_types_is_public
+      from instance_types
+      where instance_types.deleted = $1
+            and (instance_types.is_public = true
+                 or (exists (select 1
+                             from instance_type_projects
+                             where instance_type_projects.instance_type_id = instance_types.id
+                                   and instance_type_projects.deleted = $2
+                                   and instance_type_projects.project_id = $3)))
+      order by instance_types.flavorid asc, instance_types.id asc
+      offset $4 rows
+      limit $5)
+     as anon_1
+     left join instance_type_extra_specs as instance_type_extra_specs_1
+     on instance_type_extra_specs_1.instance_type_id = anon_1.instance_types_id
+        and instance_type_extra_specs_1.deleted = $6
+order by anon_1.instance_types_flavorid asc,
+         anon_1.instance_types_id asc
+----
+sort
+ ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
+ ├── key: (1,28)
+ ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ ├── ordering: +7,+1
+ └── right-join
+      ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      ├── key: (1,28)
+      ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      ├── select
+      │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool!null) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      │    ├── key: (28)
+      │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    ├── scan instance_type_extra_specs
+      │    │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      │    │    ├── key: (28)
+      │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    └── filters [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      │         └── instance_type_extra_specs.deleted = $6 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      ├── project
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    └── limit
+      │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         ├── key: (1)
+      │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         ├── offset
+      │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         │    ├── key: (1)
+      │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    ├── ordering: +7,+1
+      │         │    ├── sort
+      │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         │    │    ├── key: (1)
+      │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │    ├── ordering: +7,+1
+      │         │    │    └── select
+      │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         │    │         ├── key: (1)
+      │         │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         ├── group-by
+      │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+      │         │    │         │    ├── key: (1)
+      │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    ├── left-join (merge)
+      │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+      │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+      │         │    │         │    │    ├── select
+      │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │    ├── key: (1)
+      │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    │    │    ├── ordering: +1
+      │         │    │         │    │    │    ├── scan instance_types
+      │         │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │    │    ├── key: (1)
+      │         │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    │    │    │    └── ordering: +1
+      │         │    │         │    │    │    └── filters [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │         │    │         │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │         │    │         │    │    │    ├── fd: ()-->(25)
+      │         │    │         │    │    │    ├── ordering: +18 opt(25)
+      │         │    │         │    │    │    ├── select
+      │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+      │         │    │         │    │    │    │    ├── ordering: +18
+      │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
+      │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │         │    │         │    │    │    │    │    └── ordering: +18
+      │         │    │         │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │         │    │         │    │    │    │         └── instance_type_projects.project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │         │    │         │    │    │    └── projections [outer=(18)]
+      │         │    │         │    │    │         └── true [type=bool]
+      │         │    │         │    │    └── merge-on
+      │         │    │         │    │         ├── left ordering: +1
+      │         │    │         │    │         ├── right ordering: +18
+      │         │    │         │    │         └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+      │         │    │         │    │              └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+      │         │    │         │    └── aggregations [outer=(2-16,25)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(25)]
+      │         │    │         │         │    └── variable: true [type=bool, outer=(25)]
+      │         │    │         │         ├── any-not-null [type=string, outer=(2)]
+      │         │    │         │         │    └── variable: instance_types.name [type=string, outer=(2)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(3)]
+      │         │    │         │         │    └── variable: instance_types.memory_mb [type=int, outer=(3)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(4)]
+      │         │    │         │         │    └── variable: instance_types.vcpus [type=int, outer=(4)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(5)]
+      │         │    │         │         │    └── variable: instance_types.root_gb [type=int, outer=(5)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(6)]
+      │         │    │         │         │    └── variable: instance_types.ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │         ├── any-not-null [type=string, outer=(7)]
+      │         │    │         │         │    └── variable: instance_types.flavorid [type=string, outer=(7)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(8)]
+      │         │    │         │         │    └── variable: instance_types.swap [type=int, outer=(8)]
+      │         │    │         │         ├── any-not-null [type=float, outer=(9)]
+      │         │    │         │         │    └── variable: instance_types.rxtx_factor [type=float, outer=(9)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(10)]
+      │         │    │         │         │    └── variable: instance_types.vcpu_weight [type=int, outer=(10)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(11)]
+      │         │    │         │         │    └── variable: instance_types.disabled [type=bool, outer=(11)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(12)]
+      │         │    │         │         │    └── variable: instance_types.is_public [type=bool, outer=(12)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(13)]
+      │         │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+      │         │    │         │         ├── any-not-null [type=timestamp, outer=(14)]
+      │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+      │         │    │         │         ├── any-not-null [type=timestamp, outer=(15)]
+      │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+      │         │    │         │         └── any-not-null [type=timestamp, outer=(16)]
+      │         │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+      │         │    │         └── filters [type=bool, outer=(12,26)]
+      │         │    │              └── (instance_types.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,26)]
+      │         │    └── placeholder: $4 [type=int]
+      │         └── placeholder: $5 [type=int]
+      └── filters [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
+           └── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
+
+opt
+select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
+       anon_1.instance_types_updated_at as anon_1_instance_types_updated_at,
+       anon_1.instance_types_deleted_at as anon_1_instance_types_deleted_at,
+       anon_1.instance_types_deleted as anon_1_instance_types_deleted,
+       anon_1.instance_types_id as anon_1_instance_types_id,
+       anon_1.instance_types_name as anon_1_instance_types_name,
+       anon_1.instance_types_memory_mb as anon_1_instance_types_memory_mb,
+       anon_1.instance_types_vcpus as anon_1_instance_types_vcpus,
+       anon_1.instance_types_root_gb as anon_1_instance_types_root_gb,
+       anon_1.instance_types_ephemeral_gb as anon_1_instance_types_ephemeral_gb,
+       anon_1.instance_types_flavorid as anon_1_instance_types_flavorid,
+       anon_1.instance_types_swap as anon_1_instance_types_swap,
+       anon_1.instance_types_rxtx_factor as anon_1_instance_types_rxtx_factor,
+       anon_1.instance_types_vcpu_weight as anon_1_instance_types_vcpu_weight,
+       anon_1.instance_types_disabled as anon_1_instance_types_disabled,
+       anon_1.instance_types_is_public as anon_1_instance_types_is_public,
+       instance_type_extra_specs_1.created_at as instance_type_extra_specs_1_created_at,
+       instance_type_extra_specs_1.updated_at as instance_type_extra_specs_1_updated_at,
+       instance_type_extra_specs_1.deleted_at as instance_type_extra_specs_1_deleted_at,
+       instance_type_extra_specs_1.deleted as instance_type_extra_specs_1_deleted,
+       instance_type_extra_specs_1.id as instance_type_extra_specs_1_id,
+       instance_type_extra_specs_1."key" as instance_type_extra_specs_1_key,
+       instance_type_extra_specs_1.value as instance_type_extra_specs_1_value,
+       instance_type_extra_specs_1.instance_type_id as instance_type_extra_specs_1_instance_type_id
+from (select instance_types.created_at as instance_types_created_at,
+             instance_types.updated_at as instance_types_updated_at,
+             instance_types.deleted_at as instance_types_deleted_at,
+             instance_types.deleted as instance_types_deleted,
+             instance_types.id as instance_types_id,
+             instance_types.name as instance_types_name,
+             instance_types.memory_mb as instance_types_memory_mb,
+             instance_types.vcpus as instance_types_vcpus,
+             instance_types.root_gb as instance_types_root_gb,
+             instance_types.ephemeral_gb as instance_types_ephemeral_gb,
+             instance_types.flavorid as instance_types_flavorid,
+             instance_types.swap as instance_types_swap,
+             instance_types.rxtx_factor as instance_types_rxtx_factor,
+             instance_types.vcpu_weight as instance_types_vcpu_weight,
+             instance_types.disabled as instance_types_disabled,
+             instance_types.is_public as instance_types_is_public
+      from instance_types
+      where instance_types.deleted = $1
+            and (instance_types.is_public = true
+                 or (exists (select 1
+                             from instance_type_projects
+                             where instance_type_projects.instance_type_id = instance_types.id
+                                   and instance_type_projects.deleted = $2
+                                   and instance_type_projects.project_id = $3)))
+            and instance_types.flavorid = $4
+      offset $5 rows
+      limit $6)
+     as anon_1
+     left join instance_type_extra_specs as instance_type_extra_specs_1
+     on instance_type_extra_specs_1.instance_type_id = anon_1.instance_types_id
+        and instance_type_extra_specs_1.deleted = $7
+----
+right-join
+ ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
+ ├── key: (1,28)
+ ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ ├── select
+ │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool!null) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+ │    ├── key: (28)
+ │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ │    ├── scan instance_type_extra_specs
+ │    │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+ │    │    ├── key: (28)
+ │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ │    └── filters [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+ │         └── instance_type_extra_specs.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+ ├── project
+ │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │    └── limit
+ │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         ├── offset
+ │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+ │         │    ├── key: (1)
+ │         │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         │    ├── select
+ │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+ │         │    │    ├── key: (1)
+ │         │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         │    │    ├── group-by
+ │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+ │         │    │    │    ├── grouping columns: instance_types.id:1(int!null)
+ │         │    │    │    ├── key: (1)
+ │         │    │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         │    │    │    ├── left-join
+ │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+ │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+ │         │    │    │    │    ├── index-join instance_types
+ │         │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │         │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         │    │    │    │    │    └── select
+ │         │    │    │    │    │         ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool!null)
+ │         │    │    │    │    │         ├── key: (1)
+ │         │    │    │    │    │         ├── fd: (1)-->(7,13), (7,13)-->(1)
+ │         │    │    │    │    │         ├── scan instance_types@secondary
+ │         │    │    │    │    │         │    ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool)
+ │         │    │    │    │    │         │    ├── constraint: /7/13: (/NULL - ]
+ │         │    │    │    │    │         │    ├── key: (1)
+ │         │    │    │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
+ │         │    │    │    │    │         └── filters [type=bool, outer=(7,13), constraints=(/7: (/NULL - ]; /13: (/NULL - ])]
+ │         │    │    │    │    │              ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+ │         │    │    │    │    │              └── instance_types.flavorid = $4 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
+ │         │    │    │    │    ├── project
+ │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+ │         │    │    │    │    │    ├── fd: ()-->(25)
+ │         │    │    │    │    │    ├── select
+ │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+ │         │    │    │    │    │    │    ├── scan instance_type_projects@secondary
+ │         │    │    │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+ │         │    │    │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+ │         │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+ │         │    │    │    │    │    │         └── instance_type_projects.project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+ │         │    │    │    │    │    └── projections [outer=(18)]
+ │         │    │    │    │    │         └── true [type=bool]
+ │         │    │    │    │    └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+ │         │    │    │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+ │         │    │    │    └── aggregations [outer=(2-16,25)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(25)]
+ │         │    │    │         │    └── variable: true [type=bool, outer=(25)]
+ │         │    │    │         ├── any-not-null [type=string, outer=(2)]
+ │         │    │    │         │    └── variable: instance_types.name [type=string, outer=(2)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(3)]
+ │         │    │    │         │    └── variable: instance_types.memory_mb [type=int, outer=(3)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(4)]
+ │         │    │    │         │    └── variable: instance_types.vcpus [type=int, outer=(4)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(5)]
+ │         │    │    │         │    └── variable: instance_types.root_gb [type=int, outer=(5)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(6)]
+ │         │    │    │         │    └── variable: instance_types.ephemeral_gb [type=int, outer=(6)]
+ │         │    │    │         ├── any-not-null [type=string, outer=(7)]
+ │         │    │    │         │    └── variable: instance_types.flavorid [type=string, outer=(7)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(8)]
+ │         │    │    │         │    └── variable: instance_types.swap [type=int, outer=(8)]
+ │         │    │    │         ├── any-not-null [type=float, outer=(9)]
+ │         │    │    │         │    └── variable: instance_types.rxtx_factor [type=float, outer=(9)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(10)]
+ │         │    │    │         │    └── variable: instance_types.vcpu_weight [type=int, outer=(10)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(11)]
+ │         │    │    │         │    └── variable: instance_types.disabled [type=bool, outer=(11)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(12)]
+ │         │    │    │         │    └── variable: instance_types.is_public [type=bool, outer=(12)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(13)]
+ │         │    │    │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+ │         │    │    │         ├── any-not-null [type=timestamp, outer=(14)]
+ │         │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+ │         │    │    │         ├── any-not-null [type=timestamp, outer=(15)]
+ │         │    │    │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+ │         │    │    │         └── any-not-null [type=timestamp, outer=(16)]
+ │         │    │    │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+ │         │    │    └── filters [type=bool, outer=(12,26)]
+ │         │    │         └── (instance_types.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,26)]
+ │         │    └── placeholder: $5 [type=int]
+ │         └── placeholder: $6 [type=int]
+ └── filters [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
+      └── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
+
+opt
+select flavors.created_at as flavors_created_at,
+       flavors.updated_at as flavors_updated_at,
+       flavors.id as flavors_id,
+       flavors.name as flavors_name,
+       flavors.memory_mb as flavors_memory_mb,
+       flavors.vcpus as flavors_vcpus,
+       flavors.root_gb as flavors_root_gb,
+       flavors.ephemeral_gb as flavors_ephemeral_gb,
+       flavors.flavorid as flavors_flavorid,
+       flavors.swap as flavors_swap,
+       flavors.rxtx_factor as flavors_rxtx_factor,
+       flavors.vcpu_weight as flavors_vcpu_weight,
+       flavors.disabled as flavors_disabled,
+       flavors.is_public as flavors_is_public,
+       flavor_extra_specs_1.created_at as flavor_extra_specs_1_created_at,
+       flavor_extra_specs_1.updated_at as flavor_extra_specs_1_updated_at,
+       flavor_extra_specs_1.id as flavor_extra_specs_1_id,
+       flavor_extra_specs_1."key" as flavor_extra_specs_1_key,
+       flavor_extra_specs_1.value as flavor_extra_specs_1_value,
+       flavor_extra_specs_1.flavor_id as flavor_extra_specs_1_flavor_id
+from flavors
+     left join flavor_extra_specs as flavor_extra_specs_1
+     on flavor_extra_specs_1.flavor_id = flavors.id
+where flavors.is_public = true
+      or (exists (select 1
+                  from flavor_projects
+                  where flavor_projects.flavor_id = flavors.id
+                        and flavor_projects.project_id = $1))
+order by flavors.flavorid asc, flavors.id asc
+----
+sort
+ ├── columns: flavors_created_at:14(timestamp) flavors_updated_at:15(timestamp) flavors_id:1(int!null) flavors_name:2(string) flavors_memory_mb:3(int) flavors_vcpus:4(int) flavors_root_gb:5(int) flavors_ephemeral_gb:6(int) flavors_flavorid:7(string) flavors_swap:8(int) flavors_rxtx_factor:9(float) flavors_vcpu_weight:10(int) flavors_disabled:11(bool) flavors_is_public:12(bool) flavor_extra_specs_1_created_at:20(timestamp) flavor_extra_specs_1_updated_at:21(timestamp) flavor_extra_specs_1_id:16(int) flavor_extra_specs_1_key:17(string) flavor_extra_specs_1_value:18(string) flavor_extra_specs_1_flavor_id:19(int)
+ ├── key: (1,16)
+ ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (16)-->(17-21), (17,19)-->(16,18,20,21)
+ ├── ordering: +7
+ └── right-join
+      ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:16(int) key:17(string) value:18(string) flavor_extra_specs.flavor_id:19(int) flavor_extra_specs.created_at:20(timestamp) flavor_extra_specs.updated_at:21(timestamp)
+      ├── key: (1,16)
+      ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (16)-->(17-21), (17,19)-->(16,18,20,21)
+      ├── scan flavor_extra_specs
+      │    ├── columns: flavor_extra_specs.id:16(int!null) key:17(string!null) value:18(string) flavor_extra_specs.flavor_id:19(int!null) flavor_extra_specs.created_at:20(timestamp) flavor_extra_specs.updated_at:21(timestamp)
+      │    ├── key: (16)
+      │    └── fd: (16)-->(17-21), (17,19)-->(16,18,20,21)
+      ├── project
+      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    └── select
+      │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:29(bool)
+      │         ├── key: (1)
+      │         ├── fd: (1)-->(2-12,14,15,29), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         ├── group-by
+      │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:29(bool)
+      │         │    ├── grouping columns: flavors.id:1(int!null)
+      │         │    ├── key: (1)
+      │         │    ├── fd: (1)-->(2-12,14,15,29), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    ├── left-join (merge)
+      │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:23(int) true:28(bool)
+      │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(28)
+      │         │    │    ├── scan flavors
+      │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │         │    │    │    ├── key: (1)
+      │         │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    │    │    └── ordering: +1
+      │         │    │    ├── project
+      │         │    │    │    ├── columns: true:28(bool!null) flavor_projects.flavor_id:23(int!null)
+      │         │    │    │    ├── fd: ()-->(28)
+      │         │    │    │    ├── ordering: +23 opt(28)
+      │         │    │    │    ├── select
+      │         │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) project_id:24(string!null)
+      │         │    │    │    │    ├── key: (23,24)
+      │         │    │    │    │    ├── ordering: +23
+      │         │    │    │    │    ├── scan flavor_projects@secondary
+      │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) project_id:24(string!null)
+      │         │    │    │    │    │    ├── key: (23,24)
+      │         │    │    │    │    │    └── ordering: +23
+      │         │    │    │    │    └── filters [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
+      │         │    │    │    │         └── flavor_projects.project_id = $1 [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
+      │         │    │    │    └── projections [outer=(23)]
+      │         │    │    │         └── true [type=bool]
+      │         │    │    └── merge-on
+      │         │    │         ├── left ordering: +1
+      │         │    │         ├── right ordering: +23
+      │         │    │         └── filters [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ]), fd=(1)==(23), (23)==(1)]
+      │         │    │              └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ])]
+      │         │    └── aggregations [outer=(2-12,14,15,28)]
+      │         │         ├── any-not-null [type=bool, outer=(28)]
+      │         │         │    └── variable: true [type=bool, outer=(28)]
+      │         │         ├── any-not-null [type=string, outer=(2)]
+      │         │         │    └── variable: flavors.name [type=string, outer=(2)]
+      │         │         ├── any-not-null [type=int, outer=(3)]
+      │         │         │    └── variable: flavors.memory_mb [type=int, outer=(3)]
+      │         │         ├── any-not-null [type=int, outer=(4)]
+      │         │         │    └── variable: flavors.vcpus [type=int, outer=(4)]
+      │         │         ├── any-not-null [type=int, outer=(5)]
+      │         │         │    └── variable: flavors.root_gb [type=int, outer=(5)]
+      │         │         ├── any-not-null [type=int, outer=(6)]
+      │         │         │    └── variable: flavors.ephemeral_gb [type=int, outer=(6)]
+      │         │         ├── any-not-null [type=string, outer=(7)]
+      │         │         │    └── variable: flavors.flavorid [type=string, outer=(7)]
+      │         │         ├── any-not-null [type=int, outer=(8)]
+      │         │         │    └── variable: flavors.swap [type=int, outer=(8)]
+      │         │         ├── any-not-null [type=float, outer=(9)]
+      │         │         │    └── variable: flavors.rxtx_factor [type=float, outer=(9)]
+      │         │         ├── any-not-null [type=int, outer=(10)]
+      │         │         │    └── variable: flavors.vcpu_weight [type=int, outer=(10)]
+      │         │         ├── any-not-null [type=bool, outer=(11)]
+      │         │         │    └── variable: flavors.disabled [type=bool, outer=(11)]
+      │         │         ├── any-not-null [type=bool, outer=(12)]
+      │         │         │    └── variable: flavors.is_public [type=bool, outer=(12)]
+      │         │         ├── any-not-null [type=timestamp, outer=(14)]
+      │         │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
+      │         │         └── any-not-null [type=timestamp, outer=(15)]
+      │         │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
+      │         └── filters [type=bool, outer=(12,29)]
+      │              └── (flavors.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,29)]
+      └── filters [type=bool, outer=(1,19), constraints=(/1: (/NULL - ]; /19: (/NULL - ]), fd=(1)==(19), (19)==(1)]
+           └── flavor_extra_specs.flavor_id = flavors.id [type=bool, outer=(1,19), constraints=(/1: (/NULL - ]; /19: (/NULL - ])]
+
+opt
+select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
+       anon_1.instance_types_updated_at as anon_1_instance_types_updated_at,
+       anon_1.instance_types_deleted_at as anon_1_instance_types_deleted_at,
+       anon_1.instance_types_deleted as anon_1_instance_types_deleted,
+       anon_1.instance_types_id as anon_1_instance_types_id,
+       anon_1.instance_types_name as anon_1_instance_types_name,
+       anon_1.instance_types_memory_mb as anon_1_instance_types_memory_mb,
+       anon_1.instance_types_vcpus as anon_1_instance_types_vcpus,
+       anon_1.instance_types_root_gb as anon_1_instance_types_root_gb,
+       anon_1.instance_types_ephemeral_gb as anon_1_instance_types_ephemeral_gb,
+       anon_1.instance_types_flavorid as anon_1_instance_types_flavorid,
+       anon_1.instance_types_swap as anon_1_instance_types_swap,
+       anon_1.instance_types_rxtx_factor as anon_1_instance_types_rxtx_factor,
+       anon_1.instance_types_vcpu_weight as anon_1_instance_types_vcpu_weight,
+       anon_1.instance_types_disabled as anon_1_instance_types_disabled,
+       anon_1.instance_types_is_public as anon_1_instance_types_is_public,
+       instance_type_extra_specs_1.created_at as instance_type_extra_specs_1_created_at,
+       instance_type_extra_specs_1.updated_at as instance_type_extra_specs_1_updated_at,
+       instance_type_extra_specs_1.deleted_at as instance_type_extra_specs_1_deleted_at,
+       instance_type_extra_specs_1.deleted as instance_type_extra_specs_1_deleted,
+       instance_type_extra_specs_1.id as instance_type_extra_specs_1_id,
+       instance_type_extra_specs_1."key" as instance_type_extra_specs_1_key,
+       instance_type_extra_specs_1.value as instance_type_extra_specs_1_value,
+       instance_type_extra_specs_1.instance_type_id as instance_type_extra_specs_1_instance_type_id
+from (select instance_types.created_at as instance_types_created_at,
+             instance_types.updated_at as instance_types_updated_at,
+             instance_types.deleted_at as instance_types_deleted_at,
+             instance_types.deleted as instance_types_deleted,
+             instance_types.id as instance_types_id,
+             instance_types.name as instance_types_name,
+             instance_types.memory_mb as instance_types_memory_mb,
+             instance_types.vcpus as instance_types_vcpus,
+             instance_types.root_gb as instance_types_root_gb,
+             instance_types.ephemeral_gb as instance_types_ephemeral_gb,
+             instance_types.flavorid as instance_types_flavorid,
+             instance_types.swap as instance_types_swap,
+             instance_types.rxtx_factor as instance_types_rxtx_factor,
+             instance_types.vcpu_weight as instance_types_vcpu_weight,
+             instance_types.disabled as instance_types_disabled,
+             instance_types.is_public as instance_types_is_public
+      from instance_types
+      where instance_types.deleted = $1
+            and (instance_types.is_public = true
+                 or (exists (select 1
+                             from instance_type_projects
+                             where instance_type_projects.instance_type_id = instance_types.id
+                                   and instance_type_projects.deleted = $2
+                                   and instance_type_projects.project_id = $3)))
+            and (instance_types.flavorid > $4
+                 or instance_types.flavorid = $5
+                    and instance_types.id > $6)
+      order by instance_types.flavorid asc, instance_types.id asc
+      offset $7 rows
+      limit $8)
+     as anon_1
+     left join instance_type_extra_specs as instance_type_extra_specs_1
+     on instance_type_extra_specs_1.instance_type_id = anon_1.instance_types_id
+        and instance_type_extra_specs_1.deleted = $9
+order by anon_1.instance_types_flavorid asc,
+         anon_1.instance_types_id asc
+----
+sort
+ ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
+ ├── key: (1,28)
+ ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ ├── ordering: +7,+1
+ └── right-join
+      ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      ├── key: (1,28)
+      ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      ├── select
+      │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool!null) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      │    ├── key: (28)
+      │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    ├── scan instance_type_extra_specs
+      │    │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      │    │    ├── key: (28)
+      │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    └── filters [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      │         └── instance_type_extra_specs.deleted = $9 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      ├── project
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    └── limit
+      │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         ├── key: (1)
+      │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         ├── offset
+      │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         │    ├── key: (1)
+      │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    ├── ordering: +7,+1
+      │         │    ├── sort
+      │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         │    │    ├── key: (1)
+      │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │    ├── ordering: +7,+1
+      │         │    │    └── select
+      │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         │    │         ├── key: (1)
+      │         │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         ├── group-by
+      │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+      │         │    │         │    ├── key: (1)
+      │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    ├── left-join
+      │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+      │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+      │         │    │         │    │    ├── index-join instance_types
+      │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │    ├── key: (1)
+      │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    │    │    └── select
+      │         │    │         │    │    │         ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool!null)
+      │         │    │         │    │    │         ├── key: (1)
+      │         │    │         │    │    │         ├── fd: (1)-->(7,13), (7,13)-->(1)
+      │         │    │         │    │    │         ├── scan instance_types@secondary
+      │         │    │         │    │    │         │    ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool)
+      │         │    │         │    │    │         │    ├── constraint: /7/13: (/NULL - ]
+      │         │    │         │    │    │         │    ├── key: (1)
+      │         │    │         │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
+      │         │    │         │    │    │         └── filters [type=bool, outer=(1,7,13), constraints=(/13: (/NULL - ])]
+      │         │    │         │    │    │              ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │         │    │         │    │    │              └── (instance_types.flavorid > $4) OR ((instance_types.flavorid = $5) AND (instance_types.id > $6)) [type=bool, outer=(1,7)]
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │         │    │         │    │    │    ├── fd: ()-->(25)
+      │         │    │         │    │    │    ├── select
+      │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+      │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
+      │         │    │         │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │         │    │         │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │         │    │         │    │    │    │         └── instance_type_projects.project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │         │    │         │    │    │    └── projections [outer=(18)]
+      │         │    │         │    │    │         └── true [type=bool]
+      │         │    │         │    │    └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+      │         │    │         │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+      │         │    │         │    └── aggregations [outer=(2-16,25)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(25)]
+      │         │    │         │         │    └── variable: true [type=bool, outer=(25)]
+      │         │    │         │         ├── any-not-null [type=string, outer=(2)]
+      │         │    │         │         │    └── variable: instance_types.name [type=string, outer=(2)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(3)]
+      │         │    │         │         │    └── variable: instance_types.memory_mb [type=int, outer=(3)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(4)]
+      │         │    │         │         │    └── variable: instance_types.vcpus [type=int, outer=(4)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(5)]
+      │         │    │         │         │    └── variable: instance_types.root_gb [type=int, outer=(5)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(6)]
+      │         │    │         │         │    └── variable: instance_types.ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │         ├── any-not-null [type=string, outer=(7)]
+      │         │    │         │         │    └── variable: instance_types.flavorid [type=string, outer=(7)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(8)]
+      │         │    │         │         │    └── variable: instance_types.swap [type=int, outer=(8)]
+      │         │    │         │         ├── any-not-null [type=float, outer=(9)]
+      │         │    │         │         │    └── variable: instance_types.rxtx_factor [type=float, outer=(9)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(10)]
+      │         │    │         │         │    └── variable: instance_types.vcpu_weight [type=int, outer=(10)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(11)]
+      │         │    │         │         │    └── variable: instance_types.disabled [type=bool, outer=(11)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(12)]
+      │         │    │         │         │    └── variable: instance_types.is_public [type=bool, outer=(12)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(13)]
+      │         │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+      │         │    │         │         ├── any-not-null [type=timestamp, outer=(14)]
+      │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+      │         │    │         │         ├── any-not-null [type=timestamp, outer=(15)]
+      │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+      │         │    │         │         └── any-not-null [type=timestamp, outer=(16)]
+      │         │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+      │         │    │         └── filters [type=bool, outer=(12,26)]
+      │         │    │              └── (instance_types.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,26)]
+      │         │    └── placeholder: $7 [type=int]
+      │         └── placeholder: $8 [type=int]
+      └── filters [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
+           └── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
+
+opt
+select anon_1.flavors_created_at as anon_1_flavors_created_at,
+       anon_1.flavors_updated_at as anon_1_flavors_updated_at,
+       anon_1.flavors_id as anon_1_flavors_id,
+       anon_1.flavors_name as anon_1_flavors_name,
+       anon_1.flavors_memory_mb as anon_1_flavors_memory_mb,
+       anon_1.flavors_vcpus as anon_1_flavors_vcpus,
+       anon_1.flavors_root_gb as anon_1_flavors_root_gb,
+       anon_1.flavors_ephemeral_gb as anon_1_flavors_ephemeral_gb,
+       anon_1.flavors_flavorid as anon_1_flavors_flavorid,
+       anon_1.flavors_swap as anon_1_flavors_swap,
+       anon_1.flavors_rxtx_factor as anon_1_flavors_rxtx_factor,
+       anon_1.flavors_vcpu_weight as anon_1_flavors_vcpu_weight,
+       anon_1.flavors_disabled as anon_1_flavors_disabled,
+       anon_1.flavors_is_public as anon_1_flavors_is_public,
+       flavor_extra_specs_1.created_at as flavor_extra_specs_1_created_at,
+       flavor_extra_specs_1.updated_at as flavor_extra_specs_1_updated_at,
+       flavor_extra_specs_1.id as flavor_extra_specs_1_id,
+       flavor_extra_specs_1."key" as flavor_extra_specs_1_key,
+       flavor_extra_specs_1.value as flavor_extra_specs_1_value,
+       flavor_extra_specs_1.flavor_id as flavor_extra_specs_1_flavor_id
+from (select flavors.created_at as flavors_created_at,
+             flavors.updated_at as flavors_updated_at,
+             flavors.id as flavors_id,
+             flavors.name as flavors_name,
+             flavors.memory_mb as flavors_memory_mb,
+             flavors.vcpus as flavors_vcpus,
+             flavors.root_gb as flavors_root_gb,
+             flavors.ephemeral_gb as flavors_ephemeral_gb,
+             flavors.flavorid as flavors_flavorid,
+             flavors.swap as flavors_swap,
+             flavors.rxtx_factor as flavors_rxtx_factor,
+             flavors.vcpu_weight as flavors_vcpu_weight,
+             flavors.disabled as flavors_disabled,
+             flavors.is_public as flavors_is_public
+      from flavors
+      where flavors.is_public = true
+            or (exists (select 1
+                        from flavor_projects
+                        where flavor_projects.flavor_id = flavors.id
+                              and flavor_projects.project_id = $1))
+      order by flavors.flavorid asc, flavors.id asc
+      offset $2 rows
+      limit $3)
+     as anon_1
+     left join flavor_extra_specs as flavor_extra_specs_1
+     on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
+order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
+----
+sort
+ ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── key: (1,25)
+ ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+ ├── ordering: +7
+ └── right-join
+      ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:25(int) key:26(string) value:27(string) flavor_extra_specs.flavor_id:28(int) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+      ├── key: (1,25)
+      ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+      ├── scan flavor_extra_specs
+      │    ├── columns: flavor_extra_specs.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs.flavor_id:28(int!null) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+      │    ├── key: (25)
+      │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
+      ├── project
+      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    └── limit
+      │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         ├── key: (1)
+      │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         ├── offset
+      │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         │    ├── key: (1)
+      │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    ├── ordering: +7
+      │         │    ├── sort
+      │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         │    │    ├── key: (1)
+      │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    │    ├── ordering: +7
+      │         │    │    └── select
+      │         │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         │    │         ├── key: (1)
+      │         │    │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    │         ├── group-by
+      │         │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         │    │         │    ├── grouping columns: flavors.id:1(int!null)
+      │         │    │         │    ├── key: (1)
+      │         │    │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    │         │    ├── left-join (merge)
+      │         │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+      │         │    │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
+      │         │    │         │    │    ├── scan flavors
+      │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │         │    │         │    │    │    ├── key: (1)
+      │         │    │         │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    │         │    │    │    └── ordering: +1
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+      │         │    │         │    │    │    ├── fd: ()-->(22)
+      │         │    │         │    │    │    ├── ordering: +17 opt(22)
+      │         │    │         │    │    │    ├── select
+      │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │         │    │         │    │    │    │    ├── key: (17,18)
+      │         │    │         │    │    │    │    ├── ordering: +17
+      │         │    │         │    │    │    │    ├── scan flavor_projects@secondary
+      │         │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │         │    │         │    │    │    │    │    ├── key: (17,18)
+      │         │    │         │    │    │    │    │    └── ordering: +17
+      │         │    │         │    │    │    │    └── filters [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+      │         │    │         │    │    │    │         └── flavor_projects.project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+      │         │    │         │    │    │    └── projections [outer=(17)]
+      │         │    │         │    │    │         └── true [type=bool]
+      │         │    │         │    │    └── merge-on
+      │         │    │         │    │         ├── left ordering: +1
+      │         │    │         │    │         ├── right ordering: +17
+      │         │    │         │    │         └── filters [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
+      │         │    │         │    │              └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ])]
+      │         │    │         │    └── aggregations [outer=(2-12,14,15,22)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(22)]
+      │         │    │         │         │    └── variable: true [type=bool, outer=(22)]
+      │         │    │         │         ├── any-not-null [type=string, outer=(2)]
+      │         │    │         │         │    └── variable: flavors.name [type=string, outer=(2)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(3)]
+      │         │    │         │         │    └── variable: flavors.memory_mb [type=int, outer=(3)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(4)]
+      │         │    │         │         │    └── variable: flavors.vcpus [type=int, outer=(4)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(5)]
+      │         │    │         │         │    └── variable: flavors.root_gb [type=int, outer=(5)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(6)]
+      │         │    │         │         │    └── variable: flavors.ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │         ├── any-not-null [type=string, outer=(7)]
+      │         │    │         │         │    └── variable: flavors.flavorid [type=string, outer=(7)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(8)]
+      │         │    │         │         │    └── variable: flavors.swap [type=int, outer=(8)]
+      │         │    │         │         ├── any-not-null [type=float, outer=(9)]
+      │         │    │         │         │    └── variable: flavors.rxtx_factor [type=float, outer=(9)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(10)]
+      │         │    │         │         │    └── variable: flavors.vcpu_weight [type=int, outer=(10)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(11)]
+      │         │    │         │         │    └── variable: flavors.disabled [type=bool, outer=(11)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(12)]
+      │         │    │         │         │    └── variable: flavors.is_public [type=bool, outer=(12)]
+      │         │    │         │         ├── any-not-null [type=timestamp, outer=(14)]
+      │         │    │         │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
+      │         │    │         │         └── any-not-null [type=timestamp, outer=(15)]
+      │         │    │         │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
+      │         │    │         └── filters [type=bool, outer=(12,23)]
+      │         │    │              └── (flavors.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,23)]
+      │         │    └── placeholder: $2 [type=int]
+      │         └── placeholder: $3 [type=int]
+      └── filters [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
+           └── flavor_extra_specs.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ])]
+
+opt
+select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
+       anon_1.instance_types_updated_at as anon_1_instance_types_updated_at,
+       anon_1.instance_types_deleted_at as anon_1_instance_types_deleted_at,
+       anon_1.instance_types_deleted as anon_1_instance_types_deleted,
+       anon_1.instance_types_id as anon_1_instance_types_id,
+       anon_1.instance_types_name as anon_1_instance_types_name,
+       anon_1.instance_types_memory_mb as anon_1_instance_types_memory_mb,
+       anon_1.instance_types_vcpus as anon_1_instance_types_vcpus,
+       anon_1.instance_types_root_gb as anon_1_instance_types_root_gb,
+       anon_1.instance_types_ephemeral_gb as anon_1_instance_types_ephemeral_gb,
+       anon_1.instance_types_flavorid as anon_1_instance_types_flavorid,
+       anon_1.instance_types_swap as anon_1_instance_types_swap,
+       anon_1.instance_types_rxtx_factor as anon_1_instance_types_rxtx_factor,
+       anon_1.instance_types_vcpu_weight as anon_1_instance_types_vcpu_weight,
+       anon_1.instance_types_disabled as anon_1_instance_types_disabled,
+       anon_1.instance_types_is_public as anon_1_instance_types_is_public,
+       instance_type_extra_specs_1.created_at as instance_type_extra_specs_1_created_at,
+       instance_type_extra_specs_1.updated_at as instance_type_extra_specs_1_updated_at,
+       instance_type_extra_specs_1.deleted_at as instance_type_extra_specs_1_deleted_at,
+       instance_type_extra_specs_1.deleted as instance_type_extra_specs_1_deleted,
+       instance_type_extra_specs_1.id as instance_type_extra_specs_1_id,
+       instance_type_extra_specs_1."key" as instance_type_extra_specs_1_key,
+       instance_type_extra_specs_1.value as instance_type_extra_specs_1_value,
+       instance_type_extra_specs_1.instance_type_id as instance_type_extra_specs_1_instance_type_id
+from (select instance_types.created_at as instance_types_created_at,
+             instance_types.updated_at as instance_types_updated_at,
+             instance_types.deleted_at as instance_types_deleted_at,
+             instance_types.deleted as instance_types_deleted,
+             instance_types.id as instance_types_id,
+             instance_types.name as instance_types_name,
+             instance_types.memory_mb as instance_types_memory_mb,
+             instance_types.vcpus as instance_types_vcpus,
+             instance_types.root_gb as instance_types_root_gb,
+             instance_types.ephemeral_gb as instance_types_ephemeral_gb,
+             instance_types.flavorid as instance_types_flavorid,
+             instance_types.swap as instance_types_swap,
+             instance_types.rxtx_factor as instance_types_rxtx_factor,
+             instance_types.vcpu_weight as instance_types_vcpu_weight,
+             instance_types.disabled as instance_types_disabled,
+             instance_types.is_public as instance_types_is_public
+      from instance_types
+      where instance_types.deleted = $1
+            and (instance_types.is_public = true
+                 or (exists (select 1
+                             from instance_type_projects
+                             where instance_type_projects.instance_type_id = instance_types.id
+                                   and instance_type_projects.deleted = $2
+                                   and instance_type_projects.project_id = $3)))
+            and instance_types.disabled = false
+            and (instance_types.is_public = true
+                 or (exists (select 1
+                             from instance_type_projects
+                             where instance_type_projects.instance_type_id = instance_types.id
+                                   and instance_type_projects.deleted = $4
+                                   and instance_type_projects.deleted = $5
+                                   and instance_type_projects.project_id = $6)))
+      order by instance_types.flavorid asc, instance_types.id asc
+      offset $7 rows
+      limit $8)
+     as anon_1
+     left join instance_type_extra_specs as instance_type_extra_specs_1
+     on instance_type_extra_specs_1.instance_type_id = anon_1.instance_types_id
+        and instance_type_extra_specs_1.deleted = $9
+order by anon_1.instance_types_flavorid asc,
+         anon_1.instance_types_id asc
+----
+sort
+ ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:45(timestamp) instance_type_extra_specs_1_updated_at:46(timestamp) instance_type_extra_specs_1_deleted_at:44(timestamp) instance_type_extra_specs_1_deleted:43(bool) instance_type_extra_specs_1_id:39(int) instance_type_extra_specs_1_key:40(string) instance_type_extra_specs_1_value:41(string) instance_type_extra_specs_1_instance_type_id:42(int)
+ ├── key: (1,39)
+ ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
+ ├── ordering: +7,+1 opt(11)
+ └── right-join
+      ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:39(int) key:40(string) value:41(string) instance_type_extra_specs.instance_type_id:42(int) instance_type_extra_specs.deleted:43(bool) instance_type_extra_specs.deleted_at:44(timestamp) instance_type_extra_specs.created_at:45(timestamp) instance_type_extra_specs.updated_at:46(timestamp)
+      ├── key: (1,39)
+      ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
+      ├── select
+      │    ├── columns: instance_type_extra_specs.id:39(int!null) key:40(string) value:41(string) instance_type_extra_specs.instance_type_id:42(int!null) instance_type_extra_specs.deleted:43(bool!null) instance_type_extra_specs.deleted_at:44(timestamp) instance_type_extra_specs.created_at:45(timestamp) instance_type_extra_specs.updated_at:46(timestamp)
+      │    ├── key: (39)
+      │    ├── fd: (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
+      │    ├── scan instance_type_extra_specs
+      │    │    ├── columns: instance_type_extra_specs.id:39(int!null) key:40(string) value:41(string) instance_type_extra_specs.instance_type_id:42(int!null) instance_type_extra_specs.deleted:43(bool) instance_type_extra_specs.deleted_at:44(timestamp) instance_type_extra_specs.created_at:45(timestamp) instance_type_extra_specs.updated_at:46(timestamp)
+      │    │    ├── key: (39)
+      │    │    └── fd: (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
+      │    └── filters [type=bool, outer=(43), constraints=(/43: (/NULL - ])]
+      │         └── instance_type_extra_specs.deleted = $9 [type=bool, outer=(43), constraints=(/43: (/NULL - ])]
+      ├── project
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    ├── key: (1)
+      │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    └── limit
+      │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:37(bool)
+      │         ├── key: (1)
+      │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         ├── offset
+      │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:37(bool)
+      │         │    ├── key: (1)
+      │         │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         │    ├── ordering: +7,+1 opt(11)
+      │         │    ├── sort
+      │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:37(bool)
+      │         │    │    ├── key: (1)
+      │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         │    │    ├── ordering: +7,+1 opt(11)
+      │         │    │    └── select
+      │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:37(bool)
+      │         │    │         ├── key: (1)
+      │         │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         │    │         ├── group-by
+      │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:37(bool)
+      │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+      │         │    │         │    ├── key: (1)
+      │         │    │         │    ├── fd: ()-->(11), (1)-->(2-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         │    │         │    ├── left-join (merge)
+      │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:26(int) true:36(bool)
+      │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(36)
+      │         │    │         │    │    ├── sort
+      │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │    ├── key: (1)
+      │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         │    │         │    │    │    ├── ordering: +1 opt(11)
+      │         │    │         │    │    │    └── project
+      │         │    │         │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │         ├── key: (1)
+      │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         │    │         │    │    │         └── select
+      │         │    │         │    │    │              ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:34(bool)
+      │         │    │         │    │    │              ├── key: (1)
+      │         │    │         │    │    │              ├── fd: ()-->(11), (1)-->(2-10,12-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         │    │         │    │    │              ├── group-by
+      │         │    │         │    │    │              │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:34(bool)
+      │         │    │         │    │    │              │    ├── grouping columns: instance_types.id:1(int!null)
+      │         │    │         │    │    │              │    ├── key: (1)
+      │         │    │         │    │    │              │    ├── fd: ()-->(11), (1)-->(2-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         │    │         │    │    │              │    ├── left-join (merge)
+      │         │    │         │    │    │              │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:33(bool)
+      │         │    │         │    │    │              │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(33)
+      │         │    │         │    │    │              │    │    ├── select
+      │         │    │         │    │    │              │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │              │    │    │    ├── key: (1)
+      │         │    │         │    │    │              │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         │    │         │    │    │              │    │    │    ├── ordering: +1 opt(11)
+      │         │    │         │    │    │              │    │    │    ├── scan instance_types
+      │         │    │         │    │    │              │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │              │    │    │    │    ├── key: (1)
+      │         │    │         │    │    │              │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    │    │              │    │    │    │    └── ordering: +1 opt(11)
+      │         │    │         │    │    │              │    │    │    └── filters [type=bool, outer=(11,13), constraints=(/11: [/false - /false]; /13: (/NULL - ]), fd=()-->(11)]
+      │         │    │         │    │    │              │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │         │    │         │    │    │              │    │    │         └── instance_types.disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight)]
+      │         │    │         │    │    │              │    │    ├── project
+      │         │    │         │    │    │              │    │    │    ├── columns: true:33(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │         │    │         │    │    │              │    │    │    ├── fd: ()-->(33)
+      │         │    │         │    │    │              │    │    │    ├── ordering: +18 opt(33)
+      │         │    │         │    │    │              │    │    │    ├── select
+      │         │    │         │    │    │              │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) instance_type_projects.project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+      │         │    │         │    │    │              │    │    │    │    ├── ordering: +18
+      │         │    │         │    │    │              │    │    │    │    ├── scan instance_type_projects@secondary
+      │         │    │         │    │    │              │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) instance_type_projects.project_id:19(string) instance_type_projects.deleted:20(bool)
+      │         │    │         │    │    │              │    │    │    │    │    └── ordering: +18
+      │         │    │         │    │    │              │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+      │         │    │         │    │    │              │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │         │    │         │    │    │              │    │    │    │         └── instance_type_projects.project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │         │    │         │    │    │              │    │    │    └── projections [outer=(18)]
+      │         │    │         │    │    │              │    │    │         └── true [type=bool]
+      │         │    │         │    │    │              │    │    └── merge-on
+      │         │    │         │    │    │              │    │         ├── left ordering: +1
+      │         │    │         │    │    │              │    │         ├── right ordering: +18
+      │         │    │         │    │    │              │    │         └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+      │         │    │         │    │    │              │    │              └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+      │         │    │         │    │    │              │    └── aggregations [outer=(2-16,33)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=bool, outer=(33)]
+      │         │    │         │    │    │              │         │    └── variable: true [type=bool, outer=(33)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=string, outer=(2)]
+      │         │    │         │    │    │              │         │    └── variable: instance_types.name [type=string, outer=(2)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=int, outer=(3)]
+      │         │    │         │    │    │              │         │    └── variable: instance_types.memory_mb [type=int, outer=(3)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=int, outer=(4)]
+      │         │    │         │    │    │              │         │    └── variable: instance_types.vcpus [type=int, outer=(4)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=int, outer=(5)]
+      │         │    │         │    │    │              │         │    └── variable: instance_types.root_gb [type=int, outer=(5)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=int, outer=(6)]
+      │         │    │         │    │    │              │         │    └── variable: instance_types.ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=string, outer=(7)]
+      │         │    │         │    │    │              │         │    └── variable: instance_types.flavorid [type=string, outer=(7)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=int, outer=(8)]
+      │         │    │         │    │    │              │         │    └── variable: instance_types.swap [type=int, outer=(8)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=float, outer=(9)]
+      │         │    │         │    │    │              │         │    └── variable: instance_types.rxtx_factor [type=float, outer=(9)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=int, outer=(10)]
+      │         │    │         │    │    │              │         │    └── variable: instance_types.vcpu_weight [type=int, outer=(10)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=bool, outer=(11)]
+      │         │    │         │    │    │              │         │    └── variable: instance_types.disabled [type=bool, outer=(11)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=bool, outer=(12)]
+      │         │    │         │    │    │              │         │    └── variable: instance_types.is_public [type=bool, outer=(12)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=bool, outer=(13)]
+      │         │    │         │    │    │              │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=timestamp, outer=(14)]
+      │         │    │         │    │    │              │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+      │         │    │         │    │    │              │         ├── any-not-null [type=timestamp, outer=(15)]
+      │         │    │         │    │    │              │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+      │         │    │         │    │    │              │         └── any-not-null [type=timestamp, outer=(16)]
+      │         │    │         │    │    │              │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+      │         │    │         │    │    │              └── filters [type=bool, outer=(12,34)]
+      │         │    │         │    │    │                   └── (instance_types.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,34)]
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: true:36(bool!null) instance_type_projects.instance_type_id:26(int!null)
+      │         │    │         │    │    │    ├── fd: ()-->(36)
+      │         │    │         │    │    │    ├── ordering: +26 opt(36)
+      │         │    │         │    │    │    ├── select
+      │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) instance_type_projects.project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
+      │         │    │         │    │    │    │    ├── ordering: +26
+      │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
+      │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) instance_type_projects.project_id:27(string) instance_type_projects.deleted:28(bool)
+      │         │    │         │    │    │    │    │    └── ordering: +26
+      │         │    │         │    │    │    │    └── filters [type=bool, outer=(27,28), constraints=(/27: (/NULL - ]; /28: (/NULL - ])]
+      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $4 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
+      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $5 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
+      │         │    │         │    │    │    │         └── instance_type_projects.project_id = $6 [type=bool, outer=(27), constraints=(/27: (/NULL - ])]
+      │         │    │         │    │    │    └── projections [outer=(26)]
+      │         │    │         │    │    │         └── true [type=bool]
+      │         │    │         │    │    └── merge-on
+      │         │    │         │    │         ├── left ordering: +1
+      │         │    │         │    │         ├── right ordering: +26
+      │         │    │         │    │         └── filters [type=bool, outer=(1,26), constraints=(/1: (/NULL - ]; /26: (/NULL - ]), fd=(1)==(26), (26)==(1)]
+      │         │    │         │    │              └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,26), constraints=(/1: (/NULL - ]; /26: (/NULL - ])]
+      │         │    │         │    └── aggregations [outer=(2-16,36)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(36)]
+      │         │    │         │         │    └── variable: true [type=bool, outer=(36)]
+      │         │    │         │         ├── any-not-null [type=string, outer=(2)]
+      │         │    │         │         │    └── variable: instance_types.name [type=string, outer=(2)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(3)]
+      │         │    │         │         │    └── variable: instance_types.memory_mb [type=int, outer=(3)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(4)]
+      │         │    │         │         │    └── variable: instance_types.vcpus [type=int, outer=(4)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(5)]
+      │         │    │         │         │    └── variable: instance_types.root_gb [type=int, outer=(5)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(6)]
+      │         │    │         │         │    └── variable: instance_types.ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │         ├── any-not-null [type=string, outer=(7)]
+      │         │    │         │         │    └── variable: instance_types.flavorid [type=string, outer=(7)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(8)]
+      │         │    │         │         │    └── variable: instance_types.swap [type=int, outer=(8)]
+      │         │    │         │         ├── any-not-null [type=float, outer=(9)]
+      │         │    │         │         │    └── variable: instance_types.rxtx_factor [type=float, outer=(9)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(10)]
+      │         │    │         │         │    └── variable: instance_types.vcpu_weight [type=int, outer=(10)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(11)]
+      │         │    │         │         │    └── variable: instance_types.disabled [type=bool, outer=(11)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(12)]
+      │         │    │         │         │    └── variable: instance_types.is_public [type=bool, outer=(12)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(13)]
+      │         │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+      │         │    │         │         ├── any-not-null [type=timestamp, outer=(14)]
+      │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+      │         │    │         │         ├── any-not-null [type=timestamp, outer=(15)]
+      │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+      │         │    │         │         └── any-not-null [type=timestamp, outer=(16)]
+      │         │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+      │         │    │         └── filters [type=bool, outer=(12,37)]
+      │         │    │              └── (instance_types.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,37)]
+      │         │    └── placeholder: $7 [type=int]
+      │         └── placeholder: $8 [type=int]
+      └── filters [type=bool, outer=(1,42), constraints=(/1: (/NULL - ]; /42: (/NULL - ]), fd=(1)==(42), (42)==(1)]
+           └── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,42), constraints=(/1: (/NULL - ]; /42: (/NULL - ])]
+
+opt
+select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
+       anon_1.instance_types_updated_at as anon_1_instance_types_updated_at,
+       anon_1.instance_types_deleted_at as anon_1_instance_types_deleted_at,
+       anon_1.instance_types_deleted as anon_1_instance_types_deleted,
+       anon_1.instance_types_id as anon_1_instance_types_id,
+       anon_1.instance_types_name as anon_1_instance_types_name,
+       anon_1.instance_types_memory_mb as anon_1_instance_types_memory_mb,
+       anon_1.instance_types_vcpus as anon_1_instance_types_vcpus,
+       anon_1.instance_types_root_gb as anon_1_instance_types_root_gb,
+       anon_1.instance_types_ephemeral_gb as anon_1_instance_types_ephemeral_gb,
+       anon_1.instance_types_flavorid as anon_1_instance_types_flavorid,
+       anon_1.instance_types_swap as anon_1_instance_types_swap,
+       anon_1.instance_types_rxtx_factor as anon_1_instance_types_rxtx_factor,
+       anon_1.instance_types_vcpu_weight as anon_1_instance_types_vcpu_weight,
+       anon_1.instance_types_disabled as anon_1_instance_types_disabled,
+       anon_1.instance_types_is_public as anon_1_instance_types_is_public,
+       instance_type_extra_specs_1.created_at as instance_type_extra_specs_1_created_at,
+       instance_type_extra_specs_1.updated_at as instance_type_extra_specs_1_updated_at,
+       instance_type_extra_specs_1.deleted_at as instance_type_extra_specs_1_deleted_at,
+       instance_type_extra_specs_1.deleted as instance_type_extra_specs_1_deleted,
+       instance_type_extra_specs_1.id as instance_type_extra_specs_1_id,
+       instance_type_extra_specs_1."key" as instance_type_extra_specs_1_key,
+       instance_type_extra_specs_1.value as instance_type_extra_specs_1_value,
+       instance_type_extra_specs_1.instance_type_id as instance_type_extra_specs_1_instance_type_id
+from (select instance_types.created_at as instance_types_created_at,
+             instance_types.updated_at as instance_types_updated_at,
+             instance_types.deleted_at as instance_types_deleted_at,
+             instance_types.deleted as instance_types_deleted,
+             instance_types.id as instance_types_id,
+             instance_types.name as instance_types_name,
+             instance_types.memory_mb as instance_types_memory_mb,
+             instance_types.vcpus as instance_types_vcpus,
+             instance_types.root_gb as instance_types_root_gb,
+             instance_types.ephemeral_gb as instance_types_ephemeral_gb,
+             instance_types.flavorid as instance_types_flavorid,
+             instance_types.swap as instance_types_swap,
+             instance_types.rxtx_factor as instance_types_rxtx_factor,
+             instance_types.vcpu_weight as instance_types_vcpu_weight,
+             instance_types.disabled as instance_types_disabled,
+             instance_types.is_public as instance_types_is_public
+      from instance_types
+      where instance_types.deleted = $1
+            and (instance_types.is_public = true
+                 or (exists (select 1
+                             from instance_type_projects
+                             where instance_type_projects.instance_type_id = instance_types.id
+                                   and instance_type_projects.deleted = $2
+                                   and instance_type_projects.project_id = $3)))
+            and instance_types.flavorid = $4
+      order by instance_types.deleted asc, instance_types.id asc
+      offset $5 rows
+      limit $6)
+     as anon_1
+     left join instance_type_extra_specs as instance_type_extra_specs_1
+     on instance_type_extra_specs_1.instance_type_id = anon_1.instance_types_id
+        and instance_type_extra_specs_1.deleted = $7
+order by anon_1.instance_types_deleted asc,
+         anon_1.instance_types_id asc
+----
+sort
+ ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
+ ├── key: (1,28)
+ ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ ├── ordering: +13,+1
+ └── right-join
+      ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      ├── key: (1,28)
+      ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      ├── select
+      │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool!null) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      │    ├── key: (28)
+      │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    ├── scan instance_type_extra_specs
+      │    │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      │    │    ├── key: (28)
+      │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    └── filters [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      │         └── instance_type_extra_specs.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      ├── project
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    └── limit
+      │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         ├── key: (1)
+      │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         ├── offset
+      │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         │    ├── key: (1)
+      │         │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    ├── ordering: +13,+1
+      │         │    ├── sort
+      │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         │    │    ├── key: (1)
+      │         │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │    ├── ordering: +13,+1
+      │         │    │    └── select
+      │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         │    │         ├── key: (1)
+      │         │    │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         ├── group-by
+      │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) any_not_null:26(bool)
+      │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+      │         │    │         │    ├── key: (1)
+      │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    ├── left-join
+      │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+      │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+      │         │    │         │    │    ├── index-join instance_types
+      │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │    ├── key: (1)
+      │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    │    │    └── select
+      │         │    │         │    │    │         ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool!null)
+      │         │    │         │    │    │         ├── key: (1)
+      │         │    │         │    │    │         ├── fd: (1)-->(7,13), (7,13)-->(1)
+      │         │    │         │    │    │         ├── scan instance_types@secondary
+      │         │    │         │    │    │         │    ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool)
+      │         │    │         │    │    │         │    ├── constraint: /7/13: (/NULL - ]
+      │         │    │         │    │    │         │    ├── key: (1)
+      │         │    │         │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
+      │         │    │         │    │    │         └── filters [type=bool, outer=(7,13), constraints=(/7: (/NULL - ]; /13: (/NULL - ])]
+      │         │    │         │    │    │              ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │         │    │         │    │    │              └── instance_types.flavorid = $4 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │         │    │         │    │    │    ├── fd: ()-->(25)
+      │         │    │         │    │    │    ├── select
+      │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+      │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
+      │         │    │         │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │         │    │         │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │         │    │         │    │    │    │         └── instance_type_projects.project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │         │    │         │    │    │    └── projections [outer=(18)]
+      │         │    │         │    │    │         └── true [type=bool]
+      │         │    │         │    │    └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+      │         │    │         │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+      │         │    │         │    └── aggregations [outer=(2-16,25)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(25)]
+      │         │    │         │         │    └── variable: true [type=bool, outer=(25)]
+      │         │    │         │         ├── any-not-null [type=string, outer=(2)]
+      │         │    │         │         │    └── variable: instance_types.name [type=string, outer=(2)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(3)]
+      │         │    │         │         │    └── variable: instance_types.memory_mb [type=int, outer=(3)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(4)]
+      │         │    │         │         │    └── variable: instance_types.vcpus [type=int, outer=(4)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(5)]
+      │         │    │         │         │    └── variable: instance_types.root_gb [type=int, outer=(5)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(6)]
+      │         │    │         │         │    └── variable: instance_types.ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │         ├── any-not-null [type=string, outer=(7)]
+      │         │    │         │         │    └── variable: instance_types.flavorid [type=string, outer=(7)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(8)]
+      │         │    │         │         │    └── variable: instance_types.swap [type=int, outer=(8)]
+      │         │    │         │         ├── any-not-null [type=float, outer=(9)]
+      │         │    │         │         │    └── variable: instance_types.rxtx_factor [type=float, outer=(9)]
+      │         │    │         │         ├── any-not-null [type=int, outer=(10)]
+      │         │    │         │         │    └── variable: instance_types.vcpu_weight [type=int, outer=(10)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(11)]
+      │         │    │         │         │    └── variable: instance_types.disabled [type=bool, outer=(11)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(12)]
+      │         │    │         │         │    └── variable: instance_types.is_public [type=bool, outer=(12)]
+      │         │    │         │         ├── any-not-null [type=bool, outer=(13)]
+      │         │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+      │         │    │         │         ├── any-not-null [type=timestamp, outer=(14)]
+      │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+      │         │    │         │         ├── any-not-null [type=timestamp, outer=(15)]
+      │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+      │         │    │         │         └── any-not-null [type=timestamp, outer=(16)]
+      │         │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+      │         │    │         └── filters [type=bool, outer=(12,26)]
+      │         │    │              └── (instance_types.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,26)]
+      │         │    └── placeholder: $5 [type=int]
+      │         └── placeholder: $6 [type=int]
+      └── filters [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
+           └── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
+
+opt
+select anon_1.flavors_created_at as anon_1_flavors_created_at,
+       anon_1.flavors_updated_at as anon_1_flavors_updated_at,
+       anon_1.flavors_id as anon_1_flavors_id,
+       anon_1.flavors_name as anon_1_flavors_name,
+       anon_1.flavors_memory_mb as anon_1_flavors_memory_mb,
+       anon_1.flavors_vcpus as anon_1_flavors_vcpus,
+       anon_1.flavors_root_gb as anon_1_flavors_root_gb,
+       anon_1.flavors_ephemeral_gb as anon_1_flavors_ephemeral_gb,
+       anon_1.flavors_flavorid as anon_1_flavors_flavorid,
+       anon_1.flavors_swap as anon_1_flavors_swap,
+       anon_1.flavors_rxtx_factor as anon_1_flavors_rxtx_factor,
+       anon_1.flavors_vcpu_weight as anon_1_flavors_vcpu_weight,
+       anon_1.flavors_disabled as anon_1_flavors_disabled,
+       anon_1.flavors_is_public as anon_1_flavors_is_public,
+       flavor_extra_specs_1.created_at as flavor_extra_specs_1_created_at,
+       flavor_extra_specs_1.updated_at as flavor_extra_specs_1_updated_at,
+       flavor_extra_specs_1.id as flavor_extra_specs_1_id,
+       flavor_extra_specs_1."key" as flavor_extra_specs_1_key,
+       flavor_extra_specs_1.value as flavor_extra_specs_1_value,
+       flavor_extra_specs_1.flavor_id as flavor_extra_specs_1_flavor_id
+from (select flavors.created_at as flavors_created_at,
+             flavors.updated_at as flavors_updated_at,
+             flavors.id as flavors_id,
+             flavors.name as flavors_name,
+             flavors.memory_mb as flavors_memory_mb,
+             flavors.vcpus as flavors_vcpus,
+             flavors.root_gb as flavors_root_gb,
+             flavors.ephemeral_gb as flavors_ephemeral_gb,
+             flavors.flavorid as flavors_flavorid,
+             flavors.swap as flavors_swap,
+             flavors.rxtx_factor as flavors_rxtx_factor,
+             flavors.vcpu_weight as flavors_vcpu_weight,
+             flavors.disabled as flavors_disabled,
+             flavors.is_public as flavors_is_public
+      from flavors
+      where (flavors.is_public = true
+             or (exists (select 1
+                         from flavor_projects
+                         where flavor_projects.flavor_id = flavors.id
+                               and flavor_projects.project_id = $1)))
+            and flavors.id = $2
+      offset $3 rows
+      limit $4)
+     as anon_1
+     left join flavor_extra_specs as flavor_extra_specs_1
+     on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
+----
+right-join
+ ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── key: (1,25)
+ ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+ ├── scan flavor_extra_specs
+ │    ├── columns: flavor_extra_specs.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs.flavor_id:28(int!null) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+ │    ├── key: (25)
+ │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
+ ├── project
+ │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │    └── limit
+ │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         ├── offset
+ │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+ │         │    ├── key: (1)
+ │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    ├── select
+ │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+ │         │    │    ├── key: (1)
+ │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    │    ├── group-by
+ │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+ │         │    │    │    ├── grouping columns: flavors.id:1(int!null)
+ │         │    │    │    ├── key: (1)
+ │         │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    │    │    ├── left-join (merge)
+ │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+ │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
+ │         │    │    │    │    ├── select
+ │         │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │         │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    │    │    │    │    ├── ordering: +1
+ │         │    │    │    │    │    ├── scan flavors
+ │         │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │         │    │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    │    │    │    │    │    └── ordering: +1
+ │         │    │    │    │    │    └── filters [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+ │         │    │    │    │    │         └── flavors.id = $2 [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+ │         │    │    │    │    ├── project
+ │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+ │         │    │    │    │    │    ├── fd: ()-->(22)
+ │         │    │    │    │    │    ├── ordering: +17 opt(22)
+ │         │    │    │    │    │    ├── select
+ │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+ │         │    │    │    │    │    │    ├── key: (17,18)
+ │         │    │    │    │    │    │    ├── ordering: +17
+ │         │    │    │    │    │    │    ├── scan flavor_projects@secondary
+ │         │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+ │         │    │    │    │    │    │    │    ├── key: (17,18)
+ │         │    │    │    │    │    │    │    └── ordering: +17
+ │         │    │    │    │    │    │    └── filters [type=bool, outer=(17,18), constraints=(/17: (/NULL - ]; /18: (/NULL - ])]
+ │         │    │    │    │    │    │         ├── flavor_projects.project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+ │         │    │    │    │    │    │         └── flavor_projects.flavor_id = $2 [type=bool, outer=(17), constraints=(/17: (/NULL - ])]
+ │         │    │    │    │    │    └── projections [outer=(17)]
+ │         │    │    │    │    │         └── true [type=bool]
+ │         │    │    │    │    └── merge-on
+ │         │    │    │    │         ├── left ordering: +1
+ │         │    │    │    │         ├── right ordering: +17
+ │         │    │    │    │         └── filters [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
+ │         │    │    │    │              └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ])]
+ │         │    │    │    └── aggregations [outer=(2-12,14,15,22)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(22)]
+ │         │    │    │         │    └── variable: true [type=bool, outer=(22)]
+ │         │    │    │         ├── any-not-null [type=string, outer=(2)]
+ │         │    │    │         │    └── variable: flavors.name [type=string, outer=(2)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(3)]
+ │         │    │    │         │    └── variable: flavors.memory_mb [type=int, outer=(3)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(4)]
+ │         │    │    │         │    └── variable: flavors.vcpus [type=int, outer=(4)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(5)]
+ │         │    │    │         │    └── variable: flavors.root_gb [type=int, outer=(5)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(6)]
+ │         │    │    │         │    └── variable: flavors.ephemeral_gb [type=int, outer=(6)]
+ │         │    │    │         ├── any-not-null [type=string, outer=(7)]
+ │         │    │    │         │    └── variable: flavors.flavorid [type=string, outer=(7)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(8)]
+ │         │    │    │         │    └── variable: flavors.swap [type=int, outer=(8)]
+ │         │    │    │         ├── any-not-null [type=float, outer=(9)]
+ │         │    │    │         │    └── variable: flavors.rxtx_factor [type=float, outer=(9)]
+ │         │    │    │         ├── any-not-null [type=int, outer=(10)]
+ │         │    │    │         │    └── variable: flavors.vcpu_weight [type=int, outer=(10)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(11)]
+ │         │    │    │         │    └── variable: flavors.disabled [type=bool, outer=(11)]
+ │         │    │    │         ├── any-not-null [type=bool, outer=(12)]
+ │         │    │    │         │    └── variable: flavors.is_public [type=bool, outer=(12)]
+ │         │    │    │         ├── any-not-null [type=timestamp, outer=(14)]
+ │         │    │    │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
+ │         │    │    │         └── any-not-null [type=timestamp, outer=(15)]
+ │         │    │    │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
+ │         │    │    └── filters [type=bool, outer=(12,23)]
+ │         │    │         └── (flavors.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,23)]
+ │         │    └── placeholder: $3 [type=int]
+ │         └── placeholder: $4 [type=int]
+ └── filters [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
+      └── flavor_extra_specs.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ])]
+
+opt
+select anon_1.flavors_created_at as anon_1_flavors_created_at,
+       anon_1.flavors_updated_at as anon_1_flavors_updated_at,
+       anon_1.flavors_id as anon_1_flavors_id,
+       anon_1.flavors_name as anon_1_flavors_name,
+       anon_1.flavors_memory_mb as anon_1_flavors_memory_mb,
+       anon_1.flavors_vcpus as anon_1_flavors_vcpus,
+       anon_1.flavors_root_gb as anon_1_flavors_root_gb,
+       anon_1.flavors_ephemeral_gb as anon_1_flavors_ephemeral_gb,
+       anon_1.flavors_flavorid as anon_1_flavors_flavorid,
+       anon_1.flavors_swap as anon_1_flavors_swap,
+       anon_1.flavors_rxtx_factor as anon_1_flavors_rxtx_factor,
+       anon_1.flavors_vcpu_weight as anon_1_flavors_vcpu_weight,
+       anon_1.flavors_disabled as anon_1_flavors_disabled,
+       anon_1.flavors_is_public as anon_1_flavors_is_public,
+       anon_1.flavors_description as anon_1_flavors_description,
+       flavor_extra_specs_1.created_at as flavor_extra_specs_1_created_at,
+       flavor_extra_specs_1.updated_at as flavor_extra_specs_1_updated_at,
+       flavor_extra_specs_1.id as flavor_extra_specs_1_id,
+       flavor_extra_specs_1."key" as flavor_extra_specs_1_key,
+       flavor_extra_specs_1.value as flavor_extra_specs_1_value,
+       flavor_extra_specs_1.flavor_id as flavor_extra_specs_1_flavor_id
+from (select flavors.created_at as flavors_created_at,
+             flavors.updated_at as flavors_updated_at,
+             flavors.id as flavors_id,
+             flavors.name as flavors_name,
+             flavors.memory_mb as flavors_memory_mb,
+             flavors.vcpus as flavors_vcpus,
+             flavors.root_gb as flavors_root_gb,
+             flavors.ephemeral_gb as flavors_ephemeral_gb,
+             flavors.flavorid as flavors_flavorid,
+             flavors.swap as flavors_swap,
+             flavors.rxtx_factor as flavors_rxtx_factor,
+             flavors.vcpu_weight as flavors_vcpu_weight,
+             flavors.disabled as flavors_disabled,
+             flavors.is_public as flavors_is_public,
+             flavors.description as flavors_description
+      from flavors
+      where flavors.is_public = true
+            or (exists (select 1
+                        from flavor_projects
+                        where flavor_projects.flavor_id = flavors.id
+                              and flavor_projects.project_id = $1))
+      order by flavors.flavorid asc, flavors.id asc
+      limit $2)
+     as anon_1
+     left join flavor_extra_specs as flavor_extra_specs_1
+     on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
+order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
+----
+sort
+ ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) anon_1_flavors_description:13(string) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── key: (1,25)
+ ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+ ├── ordering: +7
+ └── right-join
+      ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:25(int) key:26(string) value:27(string) flavor_extra_specs.flavor_id:28(int) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+      ├── key: (1,25)
+      ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+      ├── scan flavor_extra_specs
+      │    ├── columns: flavor_extra_specs.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs.flavor_id:28(int!null) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+      │    ├── key: (25)
+      │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
+      ├── project
+      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15)
+      │    └── limit
+      │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         ├── key: (1)
+      │         ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)
+      │         ├── sort
+      │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         │    ├── key: (1)
+      │         │    ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)
+      │         │    ├── ordering: +7
+      │         │    └── select
+      │         │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         │         ├── key: (1)
+      │         │         ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)
+      │         │         ├── group-by
+      │         │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+      │         │         │    ├── grouping columns: flavors.id:1(int!null)
+      │         │         │    ├── key: (1)
+      │         │         │    ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)
+      │         │         │    ├── left-join (merge)
+      │         │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+      │         │         │    │    ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), ()~~>(22)
+      │         │         │    │    ├── scan flavors
+      │         │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │         │         │    │    │    ├── key: (1)
+      │         │         │    │    │    ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15)
+      │         │         │    │    │    └── ordering: +1
+      │         │         │    │    ├── project
+      │         │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+      │         │         │    │    │    ├── fd: ()-->(22)
+      │         │         │    │    │    ├── ordering: +17 opt(22)
+      │         │         │    │    │    ├── select
+      │         │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │         │         │    │    │    │    ├── key: (17,18)
+      │         │         │    │    │    │    ├── ordering: +17
+      │         │         │    │    │    │    ├── scan flavor_projects@secondary
+      │         │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │         │         │    │    │    │    │    ├── key: (17,18)
+      │         │         │    │    │    │    │    └── ordering: +17
+      │         │         │    │    │    │    └── filters [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+      │         │         │    │    │    │         └── flavor_projects.project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+      │         │         │    │    │    └── projections [outer=(17)]
+      │         │         │    │    │         └── true [type=bool]
+      │         │         │    │    └── merge-on
+      │         │         │    │         ├── left ordering: +1
+      │         │         │    │         ├── right ordering: +17
+      │         │         │    │         └── filters [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
+      │         │         │    │              └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ])]
+      │         │         │    └── aggregations [outer=(2-15,22)]
+      │         │         │         ├── any-not-null [type=bool, outer=(22)]
+      │         │         │         │    └── variable: true [type=bool, outer=(22)]
+      │         │         │         ├── any-not-null [type=string, outer=(2)]
+      │         │         │         │    └── variable: flavors.name [type=string, outer=(2)]
+      │         │         │         ├── any-not-null [type=int, outer=(3)]
+      │         │         │         │    └── variable: flavors.memory_mb [type=int, outer=(3)]
+      │         │         │         ├── any-not-null [type=int, outer=(4)]
+      │         │         │         │    └── variable: flavors.vcpus [type=int, outer=(4)]
+      │         │         │         ├── any-not-null [type=int, outer=(5)]
+      │         │         │         │    └── variable: flavors.root_gb [type=int, outer=(5)]
+      │         │         │         ├── any-not-null [type=int, outer=(6)]
+      │         │         │         │    └── variable: flavors.ephemeral_gb [type=int, outer=(6)]
+      │         │         │         ├── any-not-null [type=string, outer=(7)]
+      │         │         │         │    └── variable: flavors.flavorid [type=string, outer=(7)]
+      │         │         │         ├── any-not-null [type=int, outer=(8)]
+      │         │         │         │    └── variable: flavors.swap [type=int, outer=(8)]
+      │         │         │         ├── any-not-null [type=float, outer=(9)]
+      │         │         │         │    └── variable: flavors.rxtx_factor [type=float, outer=(9)]
+      │         │         │         ├── any-not-null [type=int, outer=(10)]
+      │         │         │         │    └── variable: flavors.vcpu_weight [type=int, outer=(10)]
+      │         │         │         ├── any-not-null [type=bool, outer=(11)]
+      │         │         │         │    └── variable: flavors.disabled [type=bool, outer=(11)]
+      │         │         │         ├── any-not-null [type=bool, outer=(12)]
+      │         │         │         │    └── variable: flavors.is_public [type=bool, outer=(12)]
+      │         │         │         ├── any-not-null [type=string, outer=(13)]
+      │         │         │         │    └── variable: flavors.description [type=string, outer=(13)]
+      │         │         │         ├── any-not-null [type=timestamp, outer=(14)]
+      │         │         │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
+      │         │         │         └── any-not-null [type=timestamp, outer=(15)]
+      │         │         │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
+      │         │         └── filters [type=bool, outer=(12,23)]
+      │         │              └── (flavors.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,23)]
+      │         └── placeholder: $2 [type=int]
+      └── filters [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
+           └── flavor_extra_specs.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ])]


### PR DESCRIPTION
Add additional Hibernate queries that have correlated subqueries that we
can't yet decorrelate.

Add correlated subquery cases derived from OpenStack Compute (nova) test
suite.

Release note: None