### PR TITLE
sql: rename AddSingleGroupStage to AddSingleProcessorStage

### DIFF
--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -551,7 +551,7 @@ func (dsp *DistSQLPlanner) loadCSVSamplingPlan(
 		OutputOrdering: kvOrdering,
 	}
 
-	p.AddSingleGroupStage(thisNode,
+	p.AddSingleProcessorStage(thisNode,
 		distsqlrun.ProcessorCoreUnion{Sorter: &sorterSpec},
 		distsqlrun.PostProcessSpec{},
 		[]sqlbase.ColumnType{colTypeBytes, colTypeBytes},

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -146,7 +146,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 	if len(p.ResultRouters) == 1 {
 		node = p.Processors[p.ResultRouters[0]].Node
 	}
-	p.AddSingleGroupStage(
+	p.AddSingleProcessorStage(
 		node,
 		distsqlrun.ProcessorCoreUnion{SampleAggregator: agg},
 		distsqlrun.PostProcessSpec{},

--- a/pkg/sql/distsqlplan/physical_plan.go
+++ b/pkg/sql/distsqlplan/physical_plan.go
@@ -220,10 +220,10 @@ func (p *PhysicalPlan) MergeResultStreams(
 	}
 }
 
-// AddSingleGroupStage adds a "single group" stage (one that cannot be
-// parallelized) which consists of a single processor on the specified node. The
-// previous stage (ResultRouters) are all connected to this processor.
-func (p *PhysicalPlan) AddSingleGroupStage(
+// AddSingleProcessorStage adds a stage consisting of a single processor on the
+// specified node. The previous stage (ResultRouters) are all connected to this
+// processor.
+func (p *PhysicalPlan) AddSingleProcessorStage(
 	nodeID roachpb.NodeID,
 	core distsqlrun.ProcessorCoreUnion,
 	post distsqlrun.PostProcessSpec,
@@ -686,7 +686,7 @@ func (p *PhysicalPlan) AddLimit(count int64, offset int64, node roachpb.NodeID) 
 	if count != math.MaxInt64 {
 		post.Limit = uint64(count)
 	}
-	p.AddSingleGroupStage(
+	p.AddSingleProcessorStage(
 		node,
 		distsqlrun.ProcessorCoreUnion{Noop: &distsqlrun.NoopCoreSpec{}},
 		post,


### PR DESCRIPTION
Renames AddSingleGroupStage to AddSingleProcessorStage
to better encapsulate meaning of the method.

It seems like the method was introduced for handling aggregation
and subsequently reused in different places. I might be missing
something though.

Release note: None