### PR TITLE
sql,  opt: support SRFs in the SELECT list

### DIFF
--- a/pkg/cmd/docgen/funcs.go
+++ b/pkg/cmd/docgen/funcs.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 func init() {
@@ -196,12 +195,6 @@ func generateFunctions(from []string, categorize bool) []byte {
 			args := fn.Types.String()
 
 			retType := fn.FixedReturnType()
-			if t, ok := retType.(types.TTuple); ok &&
-				props.Class == tree.GeneratorClass && len(t.Types) == 1 {
-				// Set-generating functions with just one tuple element are
-				// simplified to return just a scalar.
-				retType = t.Types[0]
-			}
 			ret := retType.String()
 
 			cat := props.Category

--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -91,12 +91,6 @@ query I rowsort
 SELECT job_id FROM crdb_internal.jobs
 ----
 
-query I rowsort
-SELECT generate_series(1, 2)
-----
-1
-2
-
 statement ok
 SET EXPERIMENTAL_OPT = ALWAYS
 
@@ -109,9 +103,6 @@ SELECT count(*) FILTER (WHERE v>10) FROM t
 
 query error pq: views and sequences are not supported
 SELECT * FROM tview
-
-query error pq: generator functions are not supported
-SELECT generate_series(1, 2)
 
 statement ok
 SET EXPERIMENTAL_OPT = LOCAL

--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -943,3 +943,29 @@ subtest liquibase_example_query
 #          index_name,
 #          ordinal_position
 # ----
+
+subtest unnest_with_tuple_types
+
+query T colnames
+SELECT unnest(ARRAY[(1,2),(3,4)])
+----
+unnest
+(1,2)
+(3,4)
+
+query error pq: type tuple{int, int} is not composite
+SELECT (unnest(ARRAY[(1,2),(3,4)])).*
+
+query T colnames
+SELECT * FROM unnest(ARRAY[(1,2),(3,4)])
+----
+unnest
+(1,2)
+(3,4)
+
+query T colnames
+SELECT t.* FROM unnest(ARRAY[(1,2),(3,4)]) AS t
+----
+t
+(1,2)
+(3,4)

--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -223,7 +223,7 @@ ascii
 subtest nested_SRF
 # See #20511
 
-query error pq: unimplemented: nested set-returning functions
+query error unimplemented: nested set-returning functions
 SELECT generate_series(generate_series(1, 3), 3)
 
 query I
@@ -708,7 +708,7 @@ generate_subscripts
 
 subtest srf_errors
 
-query error generator functions are not yet supported in ORDER BY
+query error generator functions are not allowed in ORDER BY
 SELECT * FROM t ORDER BY generate_series(1, 3)
 
 query error generator functions are not allowed in WHERE

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -140,6 +140,10 @@ func (b *Builder) buildRelational(ev memo.ExprView) (execPlan, error) {
 			break
 		}
 		if ev.IsJoinApply() {
+			if ev.Child(1).Operator() == opt.ZipOp {
+				ep, err = b.buildProjectSet(ev)
+				break
+			}
 			return execPlan{}, errors.Errorf("could not decorrelate subquery")
 		}
 		return execPlan{}, errors.Errorf("unsupported relational op %s", ev.Operator())
@@ -763,16 +767,20 @@ func (b *Builder) buildLookupJoin(ev memo.ExprView) (execPlan, error) {
 	return res, nil
 }
 
-func (b *Builder) buildZip(ev memo.ExprView) (execPlan, error) {
+// initZipBuild builds the expressions in a Zip operation and initializes the
+// data structures needed to build a projectSetNode.
+// Note: this function modifies outputCols.
+func (b *Builder) initZipBuild(
+	ev memo.ExprView, outputCols opt.ColMap, scalarCtx buildScalarCtx,
+) (tree.TypedExprs, sqlbase.ResultColumns, []int, opt.ColMap, error) {
 	exprs := make(tree.TypedExprs, ev.ChildCount())
 	numColsPerGen := make([]int, len(exprs))
 	var err error
-	scalarCtx := buildScalarCtx{}
 	for i := range exprs {
 		child := ev.Child(i)
 		exprs[i], err = b.buildScalar(&scalarCtx, child)
 		if err != nil {
-			return execPlan{}, err
+			return nil, nil, nil, opt.ColMap{}, err
 		}
 
 		props := child.Private().(*memo.FuncOpDef).Properties
@@ -791,12 +799,24 @@ func (b *Builder) buildZip(ev memo.ExprView) (execPlan, error) {
 		resultCols[i].Typ = md.ColumnType(col)
 	}
 
-	// TODO(rytaft): We currently construct a ProjectSet with an empty Values
-	// node as input, which is correct when the SRFs and/or scalar functions in
-	// this Zip expression were originally in the FROM clause. Once we support
-	// SRFs in the SELECT list, the Zip may be on the right hand side of an
-	// InnerJoinApply operator. In this case, we will need to pass the left hand
-	// side of the join as input to ConstructProjectSet.
+	numInputCols := outputCols.Len()
+	zipCols := ev.Private().(opt.ColList)
+	for i, col := range zipCols {
+		outputCols.Set(int(col), i+numInputCols)
+	}
+
+	return exprs, resultCols, numColsPerGen, outputCols, nil
+}
+
+func (b *Builder) buildZip(ev memo.ExprView) (execPlan, error) {
+	exprs, resultCols, numColsPerGen, outputCols, err := b.initZipBuild(
+		ev, opt.ColMap{}, buildScalarCtx{},
+	)
+	if err != nil {
+		return execPlan{}, err
+	}
+
+	// This is an uncorrelated Zip, so the input to the ProjectSet node is empty.
 	input, err := b.factory.ConstructValues([][]tree.TypedExpr{{}}, nil)
 	if err != nil {
 		return execPlan{}, err
@@ -808,10 +828,31 @@ func (b *Builder) buildZip(ev memo.ExprView) (execPlan, error) {
 	}
 
 	ep := execPlan{root: node}
-	for i, col := range cols {
-		ep.outputCols.Set(int(col), i)
+	ep.outputCols = outputCols
+	return ep, nil
+}
+
+func (b *Builder) buildProjectSet(ev memo.ExprView) (execPlan, error) {
+	input, err := b.buildRelational(ev.Child(0))
+	if err != nil {
+		return execPlan{}, err
 	}
 
+	ctx := input.makeBuildScalarCtx()
+	exprs, resultCols, numColsPerGen, outputCols, err := b.initZipBuild(
+		ev.Child(1), input.outputCols, ctx,
+	)
+	if err != nil {
+		return execPlan{}, err
+	}
+
+	node, err := b.factory.ConstructProjectSet(input.root, exprs, resultCols, numColsPerGen)
+	if err != nil {
+		return execPlan{}, err
+	}
+
+	ep := execPlan{root: node}
+	ep.outputCols = outputCols
 	return ep, nil
 }
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -24,52 +24,161 @@ EXPLAIN SELECT * FROM ROWS FROM (cos(1))
 project set    ·  ·
  └── emptyrow  ·  ·
 
+query TTT
+EXPLAIN SELECT generate_series(1, 3)
+----
+project set    ·  ·
+ └── emptyrow  ·  ·
 
-# TODO(radu): enable once SRF's are supported in the Select list.
-#
-#query TTT
-#EXPLAIN SELECT generate_series(1, 3)
-#----
-#generator  ·  ·
-#
-#subtest multiple_SRFs
-## See #20511
-#
-## query TTT
-## EXPLAIN SELECT generate_series(1, 2), generate_series(1, 2)
-## ----
-## join            ·     ·
-## │              type  cross
-## ├── generator  ·     ·
-## └── generator  ·     ·
-#
-#statement ok
-#CREATE TABLE t (a string)
-#
-#statement ok
-#CREATE TABLE u (b string)
-#
-## query TTT
-## EXPLAIN(EXPRS) SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
-## ----
-## render                    ·         ·
-## │                        render 0  a
-## │                        render 1  b
-## │                        render 2  generate_series
-## │                        render 3  generate_series
-## └── join                 ·         ·
-##      │                   type      cross
-##      ├── join            ·         ·
-##      │    │              type      cross
-##      │    ├── join       ·         ·
-##      │    │    │         type      cross
-##      │    │    ├── scan  ·         ·
-##      │    │    │         table     t@primary
-##      │    │    │         spans     ALL
-##      │    │    └── scan  ·         ·
-##      │    │              table     u@primary
-##      │    │              spans     ALL
-##      │    └── generator  ·         ·
-##      │                   expr      generate_series(1, 2)
-##      └── generator       ·         ·
-##·                         expr      generate_series(3, 4)
+subtest multiple_SRFs
+# See #20511
+
+query TTT
+EXPLAIN SELECT generate_series(1, 2), generate_series(1, 2)
+----
+project set    ·  ·
+ └── emptyrow  ·  ·
+
+statement ok
+CREATE TABLE t (a string)
+
+statement ok
+CREATE TABLE u (b string)
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
+----
+join                ·         ·                      (a, b, generate_series, generate_series)  ·
+ │                  type      cross                  ·                                         ·
+ ├── join           ·         ·                      (a, b)                                    ·
+ │    │             type      cross                  ·                                         ·
+ │    ├── scan      ·         ·                      (a)                                       ·
+ │    │             table     t@primary              ·                                         ·
+ │    │             spans     ALL                    ·                                         ·
+ │    └── scan      ·         ·                      (b)                                       ·
+ │                  table     u@primary              ·                                         ·
+ │                  spans     ALL                    ·                                         ·
+ └── project set    ·         ·                      (column5, column6)                        ·
+      │             render 0  generate_series(1, 2)  ·                                         ·
+      │             render 1  generate_series(3, 4)  ·                                         ·
+      └── emptyrow  ·         ·                      ()                                        ·
+
+subtest correlated_SRFs
+
+statement ok
+CREATE TABLE data (a INT PRIMARY KEY)
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT a, generate_series(a, a + 1) FROM data ORDER BY 1, 2
+----
+sort              ·         ·                            (a, generate_series)  +a,+generate_series
+ │                order     +a,+generate_series          ·                     ·
+ └── project set  ·         ·                            (a, generate_series)  ·
+      │           render 0  generate_series(@1, @1 + 1)  ·                     ·
+      └── scan    ·         ·                            (a)                   ·
+·                 table     data@primary                 ·                     ·
+·                 spans     ALL                          ·                     ·
+
+statement ok
+CREATE TABLE xy (x INT PRIMARY KEY, y INT)
+
+statement ok
+CREATE TABLE xz (x INT PRIMARY KEY, z INT)
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT x, y, z, information_schema._pg_expandarray(ARRAY[x, y, z])
+  FROM xy NATURAL JOIN xz WHERE y < z ORDER BY 1, 2, 3
+----
+render                         ·               ·                                                      (x, y, z, "information_schema._pg_expandarray")                 ·
+ │                             render 0        "xy.x"                                                 ·                                                               ·
+ │                             render 1        "xy.y"                                                 ·                                                               ·
+ │                             render 2        "xz.z"                                                 ·                                                               ·
+ │                             render 3        "information_schema._pg_expandarray"                   ·                                                               ·
+ └── sort                      ·               ·                                                      ("information_schema._pg_expandarray", "xy.x", "xy.y", "xz.z")  +"xy.x"
+      │                        order           +"xy.x"                                                ·                                                               ·
+      └── render               ·               ·                                                      ("information_schema._pg_expandarray", "xy.x", "xy.y", "xz.z")  ·
+           │                   render 0        ((x, n) AS x, n)                                       ·                                                               ·
+           │                   render 1        x                                                      ·                                                               ·
+           │                   render 2        y                                                      ·                                                               ·
+           │                   render 3        z                                                      ·                                                               ·
+           └── project set     ·               ·                                                      (x, y, x, z, x, n)                                              ·
+                │              render 0        information_schema._pg_expandarray(ARRAY[@1, @2, @4])  ·                                                               ·
+                └── join       ·               ·                                                      (x, y, x, z)                                                    ·
+                     │         type            inner                                                  ·                                                               ·
+                     │         equality        (x) = (x)                                              ·                                                               ·
+                     │         mergeJoinOrder  +"(x=x)"                                               ·                                                               ·
+                     │         pred            (x = x) AND (y < z)                                    ·                                                               ·
+                     ├── scan  ·               ·                                                      (x, y)                                                          +x
+                     │         table           xy@primary                                             ·                                                               ·
+                     │         spans           ALL                                                    ·                                                               ·
+                     └── scan  ·               ·                                                      (x, z)                                                          +x
+·                              table           xz@primary                                             ·                                                               ·
+·                              spans           ALL                                                    ·                                                               ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT generate_series(x, z) FROM xz WHERE z < ANY(SELECT generate_series(x, y) FROM xy)
+----
+render                      ·         ·                        (generate_series)  ·
+ │                          render 0  column6                  ·                  ·
+ └── project set            ·         ·                        (x, z, column6)    ·
+      │                     render 0  generate_series(@1, @2)  ·                  ·
+      └── join              ·         ·                        (x, z)             ·
+           │                type      semi                     ·                  ·
+           │                pred      z < column5              ·                  ·
+           ├── scan         ·         ·                        (x, z)             ·
+           │                table     xz@primary               ·                  ·
+           │                spans     ALL                      ·                  ·
+           └── project set  ·         ·                        (x, y, column5)    ·
+                │           render 0  generate_series(@1, @2)  ·                  ·
+                └── scan    ·         ·                        (x, y)             ·
+·                           table     xy@primary               ·                  ·
+·                           spans     ALL                      ·                  ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT generate_subscripts(ARRAY[0, x, 1, 2]), generate_series(x, y), unnest(ARRAY[0, x, y, z]), y, z
+  FROM xy NATURAL LEFT OUTER JOIN xz
+----
+render               ·               ·                                        (generate_subscripts, generate_series, unnest, y, z)  ·
+ │                   render 0        column5                                  ·                                                     ·
+ │                   render 1        column6                                  ·                                                     ·
+ │                   render 2        column7                                  ·                                                     ·
+ │                   render 3        y                                        ·                                                     ·
+ │                   render 4        z                                        ·                                                     ·
+ └── project set     ·               ·                                        (x, y, x, z, column5, column6, column7)               ·
+      │              render 0        generate_subscripts(ARRAY[0, @1, 1, 2])  ·                                                     ·
+      │              render 1        generate_series(@1, @2)                  ·                                                     ·
+      │              render 2        unnest(ARRAY[0, @1, @2, @4])             ·                                                     ·
+      └── join       ·               ·                                        (x, y, x, z)                                          ·
+           │         type            left outer                               ·                                                     ·
+           │         equality        (x) = (x)                                ·                                                     ·
+           │         mergeJoinOrder  +"(x=x)"                                 ·                                                     ·
+           │         pred            x = x                                    ·                                                     ·
+           ├── scan  ·               ·                                        (x, y)                                                +x
+           │         table           xy@primary                               ·                                                     ·
+           │         spans           ALL                                      ·                                                     ·
+           └── scan  ·               ·                                        (x, z)                                                +x
+·                    table           xz@primary                               ·                                                     ·
+·                    spans           ALL                                      ·                                                     ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT generate_series((SELECT unnest(ARRAY[x, y]) FROM xy), z) FROM xz
+----
+root                        ·          ·                         (generate_series)  ·
+ ├── render                 ·          ·                         (generate_series)  ·
+ │    │                     render 0   column6                   ·                  ·
+ │    └── project set       ·          ·                         (z, column6)       ·
+ │         │                render 0   generate_series(@S1, @1)  ·                  ·
+ │         └── scan         ·          ·                         (z)                ·
+ │                          table      xz@primary                ·                  ·
+ │                          spans      ALL                       ·                  ·
+ └── subquery               ·          ·                         (generate_series)  ·
+      │                     id         @S1                       ·                  ·
+      │                     sql        <unknown>                 ·                  ·
+      │                     exec mode  one row                   ·                  ·
+      └── render            ·          ·                         (column5)          ·
+           │                render 0   column5                   ·                  ·
+           └── project set  ·          ·                         (x, y, column5)    ·
+                │           render 0   unnest(ARRAY[@1, @2])     ·                  ·
+                └── scan    ·          ·                         (x, y)             ·
+·                           table      xy@primary                ·                  ·
+·                           spans      ALL                       ·                  ·

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -161,7 +161,9 @@ type Factory interface {
 	// ConstructProjectSet returns a node that performs a lateral cross join
 	// between the output of the given node and the functional zip of the given
 	// expressions.
-	ConstructProjectSet(n Node, exprs tree.TypedExprs, cols sqlbase.ResultColumns) (Node, error)
+	ConstructProjectSet(
+		n Node, exprs tree.TypedExprs, cols sqlbase.ResultColumns, numColsPerGen []int,
+	) (Node, error)
 
 	// RenameColumns modifies the column names of a node.
 	RenameColumns(input Node, colNames []string) (Node, error)

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -162,7 +162,7 @@ type Factory interface {
 	// between the output of the given node and the functional zip of the given
 	// expressions.
 	ConstructProjectSet(
-		n Node, exprs tree.TypedExprs, cols sqlbase.ResultColumns, numColsPerGen []int,
+		n Node, exprs tree.TypedExprs, zipCols sqlbase.ResultColumns, numColsPerGen []int,
 	) (Node, error)
 
 	// RenameColumns modifies the column names of a node.

--- a/pkg/sql/opt/memo/testdata/stats/srfs
+++ b/pkg/sql/opt/memo/testdata/stats/srfs
@@ -14,7 +14,7 @@ inner-join
  │    │    ├── stats: [rows=1000]
  │    │    ├── function: upper [type=string]
  │    │    │    └── const: 'def' [type=string]
- │    │    ├── function: generate_series [type=tuple{int AS generate_series}]
+ │    │    ├── function: generate_series [type=int]
  │    │    │    ├── const: 1 [type=int]
  │    │    │    └── const: 3 [type=int]
  │    │    └── function: upper [type=string]
@@ -28,7 +28,7 @@ inner-join
  ├── zip
  │    ├── columns: generate_series:5(int)
  │    ├── stats: [rows=1000]
- │    └── function: generate_series [type=tuple{int AS generate_series}]
+ │    └── function: generate_series [type=int]
  │         ├── const: 1 [type=int]
  │         └── const: 4 [type=int]
  └── true [type=bool]
@@ -47,7 +47,7 @@ group-by
       ├── zip
       │    ├── columns: generate_series:2(int)
       │    ├── stats: [rows=1000, distinct(2)=700]
-      │    └── function: generate_series [type=tuple{int AS generate_series}]
+      │    └── function: generate_series [type=int]
       │         ├── const: 1 [type=int]
       │         └── const: 2 [type=int]
       ├── zip

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -42,6 +42,12 @@ func (b *Builder) buildOrderBy(orderBy tree.OrderBy, inScope, projectionsScope *
 		return
 	}
 
+	// We need to save and restore the previous value of the field in
+	// semaCtx in case we are recursively called within a subquery
+	// context.
+	defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
+	b.semaCtx.Properties.Require("ORDER BY", tree.RejectGenerators)
+
 	orderByScope := inScope.push()
 	orderByScope.physicalProps.Ordering.Columns = make([]props.OrderingColumnChoice, 0, len(orderBy))
 

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -406,7 +406,8 @@ func (b *Builder) buildFunction(
 	)
 
 	if isGenerator(def) {
-		return b.finishBuildGeneratorFunction(f, out, inScope, outScope)
+		columns := len(def.ReturnLabels)
+		return b.finishBuildGeneratorFunction(f, out, columns, label, inScope, outScope)
 	}
 
 	return b.finishBuildScalar(f, out, label, inScope, outScope)

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -303,6 +303,16 @@ func (b *Builder) buildScalarHelper(
 		to := b.buildScalarHelper(t.TypedTo(), "", inScope, nil)
 		out = b.buildRangeCond(t.Not, t.Symmetric, input, from, to)
 
+	case *srf:
+		if len(t.cols) == 1 {
+			return b.finishBuildScalarRef(&t.cols[0], label, inScope, outScope)
+		}
+		list := make([]memo.GroupID, len(t.cols))
+		for i := range t.cols {
+			list[i] = b.buildScalarHelper(&t.cols[i], "", inScope, nil)
+		}
+		out = b.factory.ConstructTuple(b.factory.InternList(list), b.factory.InternType(t.ResolvedType()))
+
 	case *subquery:
 		out, _ = b.buildSingleRowSubquery(t, inScope)
 

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -17,9 +17,50 @@ package optbuilder
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
+
+// srf represents an srf expression in an expression tree
+// after it has been type-checked and added to the memo.
+type srf struct {
+	// The resolved function expression.
+	*tree.FuncExpr
+
+	// cols contains the output columns of the srf.
+	cols []scopeColumn
+
+	// group is the top level memo GroupID of the srf.
+	group memo.GroupID
+}
+
+// Walk is part of the tree.Expr interface.
+func (s *srf) Walk(v tree.Visitor) tree.Expr {
+	return s
+}
+
+// TypeCheck is part of the tree.Expr interface.
+func (s *srf) TypeCheck(ctx *tree.SemaContext, desired types.T) (tree.TypedExpr, error) {
+	if ctx.Properties.Derived.SeenGenerator {
+		// This error happens if this srf struct is nested inside a raw srf that
+		// has not yet been replaced. This is possible since scope.replaceSRF first
+		// calls f.Walk(s) on the external raw srf, which replaces any internal
+		// raw srfs with srf structs. The next call to TypeCheck on the external
+		// raw srf triggers this error.
+		return nil, pgerror.UnimplementedWithIssueErrorf(26234, "nested set-returning functions")
+	}
+
+	return s, nil
+}
+
+// Eval is part of the tree.TypedExpr interface.
+func (s *srf) Eval(_ *tree.EvalContext) (tree.Datum, error) {
+	panic("srf must be replaced before evaluation")
+}
+
+var _ tree.Expr = &srf{}
+var _ tree.TypedExpr = &srf{}
 
 // buildZip builds a set of memo groups which represent a functional zip over
 // the given expressions.
@@ -33,11 +74,16 @@ import (
 func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 	outScope = inScope.push()
 
+	// We need to save and restore the previous value of the field in
+	// semaCtx in case we are recursively called within a subquery
+	// context.
+	defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
+	b.semaCtx.Properties.Require("FROM",
+		tree.RejectAggregates|tree.RejectWindowApplications|tree.RejectNestedGenerators)
+
 	// Build each of the provided expressions.
 	elems := make([]memo.GroupID, len(exprs))
 	for i, expr := range exprs {
-		b.assertNoAggregationOrWindowing(expr, "FROM")
-
 		// Output column names should exactly match the original expression, so we
 		// have to determine the output column name before we perform type
 		// checking.
@@ -45,13 +91,6 @@ func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 		if err != nil {
 			panic(builderError{err})
 		}
-
-		// Set the flag to allow generator functions. It needs to be reset for each
-		// expression since it is set to false once an SRF is seen to disallow
-		// nested SRFs.
-		// TODO(rytaft): This is a temporary solution and will need to change once
-		// we support SRFs in the SELECT list.
-		inScope.allowGeneratorFunc = true
 
 		texpr := inScope.resolveType(expr, types.Any)
 		elems[i] = b.buildScalarHelper(texpr, label, inScope, outScope)
@@ -91,4 +130,38 @@ func (b *Builder) finishBuildGeneratorFunction(
 	}
 
 	return group
+}
+
+// constructProjectSet constructs a lateral cross join between the given input
+// group and a Zip operation constructed from the given srfs.
+//
+// This function is called at most once per SELECT clause, and it is only
+// called if at least one SRF was discovered in the SELECT list. The apply join
+// is necessary in case some of the SRFs depend on the input. For example,
+// consider this query:
+//
+//   SELECT generate_series(t.a, t.a + 1) FROM t
+//
+// In this case, the inputs to generate_series depend on table t, so during
+// execution, generate_series will be called once for each row of t (hence the
+// apply join).
+//
+// If the SRFs do not depend on the input, then the optimizer will replace the
+// apply join with a regular inner join during optimization.
+func (b *Builder) constructProjectSet(in memo.GroupID, srfs []*srf) memo.GroupID {
+	// Get the output columns and GroupIDs of the Zip operation.
+	colList := make(opt.ColList, 0, len(srfs))
+	elems := make([]memo.GroupID, len(srfs))
+	for i, srf := range srfs {
+		for _, col := range srf.cols {
+			colList = append(colList, col.id)
+		}
+		elems[i] = srf.group
+	}
+
+	zip := b.factory.ConstructZip(
+		b.factory.InternList(elems), b.factory.InternColList(colList),
+	)
+
+	return b.factory.ConstructInnerJoinApply(in, zip, b.factory.ConstructTrue())
 }

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -308,12 +308,12 @@ group-by
 build
 SELECT * FROM kv GROUP BY v, count(w)
 ----
-error (42803): aggregate functions are not allowed in GROUP BY
+error: count(): aggregate functions are not allowed in GROUP BY
 
 build
 SELECT count(w) FROM kv GROUP BY 1
 ----
-error (42803): aggregate functions are not allowed in GROUP BY
+error: count(): aggregate functions are not allowed in GROUP BY
 
 build
 SELECT sum(v) FROM kv GROUP BY k LIMIT sum(v)
@@ -328,7 +328,7 @@ error (42803): aggregate functions are not allowed in OFFSET
 build
 VALUES (99, count(1))
 ----
-error (42803): aggregate functions are not allowed in VALUES
+error: count(): aggregate functions are not allowed in VALUES
 
 build
 SELECT count(*), k FROM kv GROUP BY 5
@@ -563,7 +563,7 @@ error (42803): column "v" must appear in the GROUP BY clause or be used in an ag
 build
 SELECT k FROM kv WHERE avg(k) > 1
 ----
-error (42803): aggregate functions are not allowed in WHERE
+error: avg(): aggregate functions are not allowed in WHERE
 
 build
 SELECT max(avg(k)) FROM kv

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -427,7 +427,7 @@ sort
       ├── columns: array:2(int[]) generate_series:1(int)
       ├── zip
       │    ├── columns: generate_series:1(int)
-      │    └── function: generate_series [type=tuple{int AS generate_series}]
+      │    └── function: generate_series [type=int]
       │         ├── const: 1 [type=int]
       │         └── const: 1 [type=int]
       └── projections
@@ -444,7 +444,7 @@ sort
       ├── columns: array:2(int[]) generate_series:1(int)
       ├── zip
       │    ├── columns: generate_series:1(int)
-      │    └── function: generate_series [type=tuple{int AS generate_series}]
+      │    └── function: generate_series [type=int]
       │         ├── const: 1 [type=int]
       │         └── const: 1 [type=int]
       └── projections
@@ -461,7 +461,7 @@ sort
       ├── columns: array:2(int[]) column3:3(int) generate_series:1(int)
       ├── zip
       │    ├── columns: generate_series:1(int)
-      │    └── function: generate_series [type=tuple{int AS generate_series}]
+      │    └── function: generate_series [type=int]
       │         ├── const: 1 [type=int]
       │         └── const: 1 [type=int]
       └── projections

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -7,7 +7,7 @@ SELECT * FROM generate_series(1, 3)
 ----
 zip
  ├── columns: generate_series:1(int)
- └── function: generate_series [type=tuple{int AS generate_series}]
+ └── function: generate_series [type=int]
       ├── const: 1 [type=int]
       └── const: 3 [type=int]
 
@@ -18,12 +18,12 @@ inner-join
  ├── columns: generate_series:1(int) generate_series:2(int)
  ├── zip
  │    ├── columns: generate_series:1(int)
- │    └── function: generate_series [type=tuple{int AS generate_series}]
+ │    └── function: generate_series [type=int]
  │         ├── const: 1 [type=int]
  │         └── const: 2 [type=int]
  ├── zip
  │    ├── columns: generate_series:2(int)
- │    └── function: generate_series [type=tuple{int AS generate_series}]
+ │    └── function: generate_series [type=int]
  │         ├── const: 1 [type=int]
  │         └── const: 2 [type=int]
  └── true [type=bool]
@@ -33,7 +33,7 @@ SELECT * FROM pg_catalog.generate_series(1, 3)
 ----
 zip
  ├── columns: generate_series:1(int)
- └── function: generate_series [type=tuple{int AS generate_series}]
+ └── function: generate_series [type=int]
       ├── const: 1 [type=int]
       └── const: 3 [type=int]
 
@@ -42,7 +42,7 @@ SELECT * FROM generate_series(1, 1) AS c(x)
 ----
 zip
  ├── columns: x:1(int)
- └── function: generate_series [type=tuple{int AS generate_series}]
+ └── function: generate_series [type=int]
       ├── const: 1 [type=int]
       └── const: 1 [type=int]
 
@@ -53,7 +53,7 @@ row-number
  ├── columns: x:1(int) y:2(int!null)
  └── zip
       ├── columns: generate_series:1(int)
-      └── function: generate_series [type=tuple{int AS generate_series}]
+      └── function: generate_series [type=int]
            ├── const: 1 [type=int]
            └── const: 1 [type=int]
 
@@ -105,13 +105,13 @@ project
       │    │    └── true [type=bool]
       │    ├── zip
       │    │    ├── columns: generate_series:5(int)
-      │    │    └── function: generate_series [type=tuple{int AS generate_series}]
+      │    │    └── function: generate_series [type=int]
       │    │         ├── const: 1 [type=int]
       │    │         └── const: 2 [type=int]
       │    └── true [type=bool]
       ├── zip
       │    ├── columns: generate_series:6(int)
-      │    └── function: generate_series [type=tuple{int AS generate_series}]
+      │    └── function: generate_series [type=int]
       │         ├── const: 3 [type=int]
       │         └── const: 4 [type=int]
       └── true [type=bool]
@@ -123,7 +123,7 @@ project
  ├── columns: "?column?":2(int)
  ├── zip
  │    ├── columns: generate_series:1(int)
- │    └── function: generate_series [type=tuple{int AS generate_series}]
+ │    └── function: generate_series [type=int]
  │         ├── const: 1 [type=int]
  │         └── const: 2 [type=int]
  └── projections
@@ -143,7 +143,7 @@ SELECT * from unnest(ARRAY[1,2])
 ----
 zip
  ├── columns: unnest:1(int)
- └── function: unnest [type=tuple{int AS unnest}]
+ └── function: unnest [type=int]
       └── array: [type=int[]]
            ├── const: 1 [type=int]
            └── const: 2 [type=int]
@@ -194,14 +194,14 @@ SELECT * from generate_series(1, (select * from generate_series(1, 0)))
 ----
 zip
  ├── columns: generate_series:2(int)
- └── function: generate_series [type=tuple{int AS generate_series}]
+ └── function: generate_series [type=int]
       ├── const: 1 [type=int]
       └── subquery [type=int]
            └── max1-row
                 ├── columns: generate_series:1(int)
                 └── zip
                      ├── columns: generate_series:1(int)
-                     └── function: generate_series [type=tuple{int AS generate_series}]
+                     └── function: generate_series [type=int]
                           ├── const: 1 [type=int]
                           └── const: 0 [type=int]
 
@@ -248,12 +248,12 @@ limit
  │    │    ├── columns: generate_series:1(int) unnest:2(int)
  │    │    ├── zip
  │    │    │    ├── columns: generate_series:1(int)
- │    │    │    └── function: generate_series [type=tuple{int AS generate_series}]
+ │    │    │    └── function: generate_series [type=int]
  │    │    │         ├── const: 1 [type=int]
  │    │    │         └── const: 1 [type=int]
  │    │    ├── zip
  │    │    │    ├── columns: unnest:2(int)
- │    │    │    └── function: unnest [type=tuple{int AS unnest}]
+ │    │    │    └── function: unnest [type=int]
  │    │    │         └── array: [type=int[]]
  │    │    │              └── const: 1 [type=int]
  │    │    └── true [type=bool]
@@ -394,7 +394,7 @@ SELECT * FROM generate_subscripts(ARRAY[3,2,1])
 ----
 zip
  ├── columns: generate_subscripts:1(int)
- └── function: generate_subscripts [type=tuple{int AS generate_subscripts}]
+ └── function: generate_subscripts [type=int]
       └── array: [type=int[]]
            ├── const: 3 [type=int]
            ├── const: 2 [type=int]
@@ -407,14 +407,14 @@ ROWS FROM (generate_series(0, 1), generate_series(1, 3), pg_get_keywords(), unne
 ----
 zip
  ├── columns: generate_series:1(int) generate_series:2(int) word:3(string) catcode:4(string) catdesc:5(string) unnest:6(string)
- ├── function: generate_series [type=tuple{int AS generate_series}]
+ ├── function: generate_series [type=int]
  │    ├── const: 0 [type=int]
  │    └── const: 1 [type=int]
- ├── function: generate_series [type=tuple{int AS generate_series}]
+ ├── function: generate_series [type=int]
  │    ├── const: 1 [type=int]
  │    └── const: 3 [type=int]
  ├── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
- └── function: unnest [type=tuple{string AS unnest}]
+ └── function: unnest [type=string]
       └── array: [type=string[]]
            ├── const: 'a' [type=string]
            ├── const: 'b' [type=string]
@@ -438,14 +438,14 @@ inner-join
  │    │    ├── columns: upper:2(string) generate_series:3(int)
  │    │    ├── function: upper [type=string]
  │    │    │    └── const: 'def' [type=string]
- │    │    └── function: generate_series [type=tuple{int AS generate_series}]
+ │    │    └── function: generate_series [type=int]
  │    │         ├── const: 1 [type=int]
  │    │         └── const: 3 [type=int]
  │    └── filters [type=bool]
  │         └── true [type=bool]
  ├── zip
  │    ├── columns: generate_series:4(int)
- │    └── function: generate_series [type=tuple{int AS generate_series}]
+ │    └── function: generate_series [type=int]
  │         ├── const: 1 [type=int]
  │         └── const: 4 [type=int]
  └── filters [type=bool]

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -60,14 +60,26 @@ row-number
 build
 SELECT * FROM (VALUES (1)) LIMIT generate_series(1, 3)
 ----
-error (0A000): generator functions are not supported
+error: generate_series(): generator functions are not allowed in LIMIT
 
 # multiple_SRFs
 
 build
 SELECT generate_series(1, 2), generate_series(3, 4)
 ----
-error (0A000): generator functions are not supported
+inner-join-apply
+ ├── columns: generate_series:1(int) generate_series:2(int)
+ ├── values
+ │    └── tuple [type=tuple]
+ ├── zip
+ │    ├── columns: column1:1(int) column2:2(int)
+ │    ├── function: generate_series [type=int]
+ │    │    ├── const: 1 [type=int]
+ │    │    └── const: 2 [type=int]
+ │    └── function: generate_series [type=int]
+ │         ├── const: 3 [type=int]
+ │         └── const: 4 [type=int]
+ └── true [type=bool]
 
 exec-ddl
 CREATE TABLE t (a string)
@@ -134,7 +146,24 @@ project
 build
 SELECT 3 + (3 * generate_series(1,3))
 ----
-error (0A000): generator functions are not supported
+project
+ ├── columns: "?column?":2(int)
+ ├── inner-join-apply
+ │    ├── columns: column1:1(int)
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    ├── zip
+ │    │    ├── columns: column1:1(int)
+ │    │    └── function: generate_series [type=int]
+ │    │         ├── const: 1 [type=int]
+ │    │         └── const: 3 [type=int]
+ │    └── true [type=bool]
+ └── projections
+      └── plus [type=int]
+           ├── const: 3 [type=int]
+           └── mult [type=int]
+                ├── const: 3 [type=int]
+                └── variable: column1 [type=int]
 
 # unnest
 
@@ -151,22 +180,90 @@ zip
 build
 SELECT unnest(ARRAY[1,2]), unnest(ARRAY['a', 'b'])
 ----
-error (0A000): generator functions are not supported
+inner-join-apply
+ ├── columns: unnest:1(int) unnest:2(string)
+ ├── values
+ │    └── tuple [type=tuple]
+ ├── zip
+ │    ├── columns: column1:1(int) column2:2(string)
+ │    ├── function: unnest [type=int]
+ │    │    └── array: [type=int[]]
+ │    │         ├── const: 1 [type=int]
+ │    │         └── const: 2 [type=int]
+ │    └── function: unnest [type=int]
+ │         └── array: [type=string[]]
+ │              ├── const: 'a' [type=string]
+ │              └── const: 'b' [type=string]
+ └── true [type=bool]
 
 build
 SELECT unnest(ARRAY[3,4]) - 2
 ----
-error (0A000): generator functions are not supported
+project
+ ├── columns: "?column?":2(int)
+ ├── inner-join-apply
+ │    ├── columns: column1:1(int)
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    ├── zip
+ │    │    ├── columns: column1:1(int)
+ │    │    └── function: unnest [type=int]
+ │    │         └── array: [type=int[]]
+ │    │              ├── const: 3 [type=int]
+ │    │              └── const: 4 [type=int]
+ │    └── true [type=bool]
+ └── projections
+      └── minus [type=int]
+           ├── variable: column1 [type=int]
+           └── const: 2 [type=int]
 
 build
 SELECT 1 + generate_series(0, 1), unnest(ARRAY[2, 4]) - 1
 ----
-error (0A000): generator functions are not supported
+project
+ ├── columns: "?column?":2(int) "?column?":4(int)
+ ├── inner-join-apply
+ │    ├── columns: column1:1(int) column3:3(int)
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    ├── zip
+ │    │    ├── columns: column1:1(int) column3:3(int)
+ │    │    ├── function: generate_series [type=int]
+ │    │    │    ├── const: 0 [type=int]
+ │    │    │    └── const: 1 [type=int]
+ │    │    └── function: unnest [type=int]
+ │    │         └── array: [type=int[]]
+ │    │              ├── const: 2 [type=int]
+ │    │              └── const: 4 [type=int]
+ │    └── true [type=bool]
+ └── projections
+      ├── plus [type=int]
+      │    ├── const: 1 [type=int]
+      │    └── variable: column1 [type=int]
+      └── minus [type=int]
+           ├── variable: column3 [type=int]
+           └── const: 1 [type=int]
 
 build
 SELECT ascii(unnest(ARRAY['a', 'b', 'c']));
 ----
-error (0A000): generator functions are not supported
+project
+ ├── columns: ascii:2(int)
+ ├── inner-join-apply
+ │    ├── columns: column1:1(string)
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    ├── zip
+ │    │    ├── columns: column1:1(string)
+ │    │    └── function: unnest [type=string]
+ │    │         └── array: [type=string[]]
+ │    │              ├── const: 'a' [type=string]
+ │    │              ├── const: 'b' [type=string]
+ │    │              └── const: 'c' [type=string]
+ │    └── true [type=bool]
+ └── projections
+      └── function: ascii [type=int]
+           └── variable: column1 [type=string]
 
 # nested_SRF
 # See #20511
@@ -174,12 +271,30 @@ error (0A000): generator functions are not supported
 build
 SELECT generate_series(generate_series(1, 3), 3)
 ----
-error (0A000): generator functions are not supported
+error: generate_series(): unimplemented: nested set-returning functions
 
 build
 SELECT generate_series(1, 3) + generate_series(1, 3)
 ----
-error (0A000): generator functions are not supported
+project
+ ├── columns: "?column?":3(int)
+ ├── inner-join-apply
+ │    ├── columns: column1:1(int) column2:2(int)
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    ├── zip
+ │    │    ├── columns: column1:1(int) column2:2(int)
+ │    │    ├── function: generate_series [type=int]
+ │    │    │    ├── const: 1 [type=int]
+ │    │    │    └── const: 3 [type=int]
+ │    │    └── function: generate_series [type=int]
+ │    │         ├── const: 1 [type=int]
+ │    │         └── const: 3 [type=int]
+ │    └── true [type=bool]
+ └── projections
+      └── plus [type=int]
+           ├── variable: column1 [type=int]
+           └── variable: column2 [type=int]
 
 build
 SELECT generate_series(1, 3) FROM t WHERE generate_series > 3
@@ -210,7 +325,55 @@ zip
 build
 SELECT unnest((SELECT current_schemas((SELECT isnan((SELECT round(3.4, (SELECT generate_series(1, 0)))))))));
 ----
-error (0A000): generator functions are not supported
+inner-join-apply
+ ├── columns: unnest:5(string)
+ ├── values
+ │    └── tuple [type=tuple]
+ ├── zip
+ │    ├── columns: column5:5(string)
+ │    └── function: unnest [type=string]
+ │         └── subquery [type=string[]]
+ │              └── max1-row
+ │                   ├── columns: current_schemas:4(string[])
+ │                   └── project
+ │                        ├── columns: current_schemas:4(string[])
+ │                        ├── values
+ │                        │    └── tuple [type=tuple]
+ │                        └── projections
+ │                             └── function: current_schemas [type=string[]]
+ │                                  └── subquery [type=bool]
+ │                                       └── max1-row
+ │                                            ├── columns: isnan:3(bool)
+ │                                            └── project
+ │                                                 ├── columns: isnan:3(bool)
+ │                                                 ├── values
+ │                                                 │    └── tuple [type=tuple]
+ │                                                 └── projections
+ │                                                      └── function: isnan [type=bool]
+ │                                                           └── subquery [type=decimal]
+ │                                                                └── max1-row
+ │                                                                     ├── columns: round:2(decimal)
+ │                                                                     └── project
+ │                                                                          ├── columns: round:2(decimal)
+ │                                                                          ├── values
+ │                                                                          │    └── tuple [type=tuple]
+ │                                                                          └── projections
+ │                                                                               └── function: round [type=decimal]
+ │                                                                                    ├── const: 3.4 [type=decimal]
+ │                                                                                    └── subquery [type=int]
+ │                                                                                         └── max1-row
+ │                                                                                              ├── columns: column1:1(int)
+ │                                                                                              └── inner-join-apply
+ │                                                                                                   ├── columns: column1:1(int)
+ │                                                                                                   ├── values
+ │                                                                                                   │    └── tuple [type=tuple]
+ │                                                                                                   ├── zip
+ │                                                                                                   │    ├── columns: column1:1(int)
+ │                                                                                                   │    └── function: generate_series [type=int]
+ │                                                                                                   │         ├── const: 1 [type=int]
+ │                                                                                                   │         └── const: 0 [type=int]
+ │                                                                                                   └── true [type=bool]
+ └── true [type=bool]
 
 # pg_get_keywords
 
@@ -267,19 +430,71 @@ limit
 build
 SELECT 'a', pg_get_keywords(), 'c' LIMIT 1
 ----
-error (0A000): generator functions are not supported
+limit
+ ├── columns: "?column?":1(string!null) pg_get_keywords:5(tuple{string AS word, string AS catcode, string AS catdesc}) "?column?":6(string!null)
+ ├── project
+ │    ├── columns: "?column?":1(string!null) pg_get_keywords:5(tuple{string AS word, string AS catcode, string AS catdesc}) "?column?":6(string!null)
+ │    ├── inner-join-apply
+ │    │    ├── columns: word:2(string) catcode:3(string) catdesc:4(string)
+ │    │    ├── values
+ │    │    │    └── tuple [type=tuple]
+ │    │    ├── zip
+ │    │    │    ├── columns: word:2(string) catcode:3(string) catdesc:4(string)
+ │    │    │    └── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
+ │    │    └── true [type=bool]
+ │    └── projections
+ │         ├── const: 'a' [type=string]
+ │         ├── tuple [type=tuple{string AS word, string AS catcode, string AS catdesc}]
+ │         │    ├── variable: word [type=string]
+ │         │    ├── variable: catcode [type=string]
+ │         │    └── variable: catdesc [type=string]
+ │         └── const: 'c' [type=string]
+ └── const: 1 [type=int]
 
 build
 SELECT 'a', pg_get_keywords() b, 'c' LIMIT 1
 ----
-error (0A000): generator functions are not supported
+limit
+ ├── columns: "?column?":1(string!null) b:5(tuple{string AS word, string AS catcode, string AS catdesc}) "?column?":6(string!null)
+ ├── project
+ │    ├── columns: "?column?":1(string!null) b:5(tuple{string AS word, string AS catcode, string AS catdesc}) "?column?":6(string!null)
+ │    ├── inner-join-apply
+ │    │    ├── columns: word:2(string) catcode:3(string) catdesc:4(string)
+ │    │    ├── values
+ │    │    │    └── tuple [type=tuple]
+ │    │    ├── zip
+ │    │    │    ├── columns: word:2(string) catcode:3(string) catdesc:4(string)
+ │    │    │    └── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
+ │    │    └── true [type=bool]
+ │    └── projections
+ │         ├── const: 'a' [type=string]
+ │         ├── tuple [type=tuple{string AS word, string AS catcode, string AS catdesc}]
+ │         │    ├── variable: word [type=string]
+ │         │    ├── variable: catcode [type=string]
+ │         │    └── variable: catdesc [type=string]
+ │         └── const: 'c' [type=string]
+ └── const: 1 [type=int]
 
 # unary_table
 
 build
 SELECT 'a', crdb_internal.unary_table() b, 'c' LIMIT 1
 ----
-error (0A000): generator functions are not supported
+limit
+ ├── columns: "?column?":1(string!null) b:2(tuple) "?column?":3(string!null)
+ ├── project
+ │    ├── columns: "?column?":1(string!null) b:2(tuple) "?column?":3(string!null)
+ │    ├── inner-join-apply
+ │    │    ├── values
+ │    │    │    └── tuple [type=tuple]
+ │    │    ├── zip
+ │    │    │    └── function: crdb_internal.unary_table [type=tuple]
+ │    │    └── true [type=bool]
+ │    └── projections
+ │         ├── const: 'a' [type=string]
+ │         ├── tuple [type=tuple]
+ │         └── const: 'c' [type=string]
+ └── const: 1 [type=int]
 
 # upper
 
@@ -308,7 +523,23 @@ row-number
 build
 SELECT information_schema._pg_expandarray(ARRAY['b', 'a'])
 ----
-error (0A000): generator functions are not supported
+project
+ ├── columns: _pg_expandarray:3(tuple{string AS x, int AS n})
+ ├── inner-join-apply
+ │    ├── columns: x:1(string) n:2(int)
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    ├── zip
+ │    │    ├── columns: x:1(string) n:2(int)
+ │    │    └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
+ │    │         └── array: [type=string[]]
+ │    │              ├── const: 'b' [type=string]
+ │    │              └── const: 'a' [type=string]
+ │    └── true [type=bool]
+ └── projections
+      └── tuple [type=tuple{string AS x, int AS n}]
+           ├── variable: x [type=string]
+           └── variable: n [type=int]
 
 build
 SELECT * FROM information_schema._pg_expandarray(ARRAY['b', 'a'])
@@ -335,22 +566,62 @@ error (42809): type string is not composite
 build
 SELECT (unnest(ARRAY[]:::INT[])).*
 ----
-error (0A000): generator functions are not supported
+error (42809): type int is not composite
 
 build
 SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).*
 ----
-error (0A000): generator functions are not supported
+project
+ ├── columns: x:3(string) n:4(int)
+ ├── inner-join-apply
+ │    ├── columns: x:1(string) n:2(int)
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    ├── zip
+ │    │    ├── columns: x:1(string) n:2(int)
+ │    │    └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
+ │    │         └── array: [type=string[]]
+ │    │              ├── const: 'c' [type=string]
+ │    │              ├── const: 'b' [type=string]
+ │    │              └── const: 'a' [type=string]
+ │    └── true [type=bool]
+ └── projections
+      ├── column-access: 0 [type=string]
+      │    └── tuple [type=tuple{string AS x, int AS n}]
+      │         ├── variable: x [type=string]
+      │         └── variable: n [type=int]
+      └── column-access: 1 [type=int]
+           └── tuple [type=tuple{string AS x, int AS n}]
+                ├── variable: x [type=string]
+                └── variable: n [type=int]
 
 build
 SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).x
 ----
-error (0A000): generator functions are not supported
+project
+ ├── columns: x:3(string)
+ ├── inner-join-apply
+ │    ├── columns: x:1(string) n:2(int)
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    ├── zip
+ │    │    ├── columns: x:1(string) n:2(int)
+ │    │    └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
+ │    │         └── array: [type=string[]]
+ │    │              ├── const: 'c' [type=string]
+ │    │              ├── const: 'b' [type=string]
+ │    │              └── const: 'a' [type=string]
+ │    └── true [type=bool]
+ └── projections
+      └── column-access: 0 [type=string]
+           └── tuple [type=tuple{string AS x, int AS n}]
+                ├── variable: x [type=string]
+                └── variable: n [type=int]
 
 build
 SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).other
 ----
-error (0A000): generator functions are not supported
+error (42804): could not identify column "other" in tuple{string AS x, int AS n}
 
 build
 SELECT temp.n from information_schema._pg_expandarray(ARRAY['c','b','a']) AS temp;
@@ -454,9 +725,186 @@ inner-join
 build
 SELECT * FROM ROWS FROM (generate_series(generate_series(1,2),3))
 ----
-error (0A000): generator functions are not supported
+error: generate_series(): generate_series(): set-returning functions must appear at the top level of FROM
+
+# SRFs not allowed in HAVING, unless they are part of a subquery.
+build
+SELECT max(a) FROM t HAVING max(a::int) > generate_series(0, a::int)
+----
+error: generate_series(): generator functions are not allowed in HAVING
 
 build
-SELECT * FROM ROWS FROM (generate_series((generate_series(1,2)).generate_series,3))
+SELECT max(a) FROM t HAVING max(a::int) > (SELECT generate_series(0, b::int) FROM u limit 1)
 ----
-error (0A000): generator functions are not supported
+project
+ ├── columns: max:8(string)
+ └── select
+      ├── columns: column7:7(int!null) max:8(string)
+      ├── scalar-group-by
+      │    ├── columns: column7:7(int) max:8(string)
+      │    ├── project
+      │    │    ├── columns: column6:6(int) a:1(string)
+      │    │    ├── scan t
+      │    │    │    └── columns: a:1(string) t.rowid:2(int!null)
+      │    │    └── projections
+      │    │         └── cast: INT [type=int]
+      │    │              └── variable: t.a [type=string]
+      │    └── aggregations
+      │         ├── max [type=int]
+      │         │    └── variable: column6 [type=int]
+      │         └── max [type=string]
+      │              └── variable: t.a [type=string]
+      └── filters [type=bool]
+           └── gt [type=bool]
+                ├── variable: column7 [type=int]
+                └── subquery [type=int]
+                     └── max1-row
+                          ├── columns: column5:5(int)
+                          └── limit
+                               ├── columns: column5:5(int)
+                               ├── project
+                               │    ├── columns: column5:5(int)
+                               │    └── inner-join-apply
+                               │         ├── columns: b:3(string) u.rowid:4(int!null) column5:5(int)
+                               │         ├── scan u
+                               │         │    └── columns: b:3(string) u.rowid:4(int!null)
+                               │         ├── zip
+                               │         │    ├── columns: column5:5(int)
+                               │         │    └── function: generate_series [type=int]
+                               │         │         ├── const: 0 [type=int]
+                               │         │         └── cast: INT [type=int]
+                               │         │              └── variable: u.b [type=string]
+                               │         └── true [type=bool]
+                               └── const: 1 [type=int]
+
+build
+SELECT generate_series((SELECT generate_subscripts(ARRAY[a, a||b]) FROM t, u), 100) FROM t
+----
+project
+ ├── columns: generate_series:8(int)
+ └── inner-join-apply
+      ├── columns: t.a:1(string) t.rowid:2(int!null) column8:8(int)
+      ├── scan t
+      │    └── columns: t.a:1(string) t.rowid:2(int!null)
+      ├── zip
+      │    ├── columns: column8:8(int)
+      │    └── function: generate_series [type=int]
+      │         ├── subquery [type=int]
+      │         │    └── max1-row
+      │         │         ├── columns: column7:7(int)
+      │         │         └── project
+      │         │              ├── columns: column7:7(int)
+      │         │              └── inner-join-apply
+      │         │                   ├── columns: t.a:3(string) t.rowid:4(int!null) b:5(string) u.rowid:6(int!null) column7:7(int)
+      │         │                   ├── inner-join
+      │         │                   │    ├── columns: t.a:3(string) t.rowid:4(int!null) b:5(string) u.rowid:6(int!null)
+      │         │                   │    ├── scan t
+      │         │                   │    │    └── columns: t.a:3(string) t.rowid:4(int!null)
+      │         │                   │    ├── scan u
+      │         │                   │    │    └── columns: b:5(string) u.rowid:6(int!null)
+      │         │                   │    └── true [type=bool]
+      │         │                   ├── zip
+      │         │                   │    ├── columns: column7:7(int)
+      │         │                   │    └── function: generate_subscripts [type=int]
+      │         │                   │         └── array: [type=string[]]
+      │         │                   │              ├── variable: t.a [type=string]
+      │         │                   │              └── concat [type=string]
+      │         │                   │                   ├── variable: t.a [type=string]
+      │         │                   │                   └── variable: u.b [type=string]
+      │         │                   └── true [type=bool]
+      │         └── const: 100 [type=int]
+      └── true [type=bool]
+
+exec-ddl
+CREATE TABLE a (x INT PRIMARY KEY, j JSON, k JSON, m JSON, n JSON)
+----
+TABLE a
+ ├── x int not null
+ ├── j jsonb
+ ├── k jsonb
+ ├── m jsonb
+ ├── n jsonb
+ └── INDEX primary
+      └── x int not null
+
+build
+SELECT
+  json_array_elements(j),
+  (SELECT jsonb_each(k)),
+  (SELECT jsonb_object_keys(m) FROM a),
+  (SELECT generate_series((SELECT generate_series(x, 100) FROM jsonb_array_elements_text(n)), 1000))
+FROM a
+----
+project
+ ├── columns: json_array_elements:6(jsonb) jsonb_each:10(tuple{string AS key, jsonb AS value}) jsonb_object_keys:17(string) generate_series:21(int)
+ ├── inner-join-apply
+ │    ├── columns: a.x:1(int!null) a.j:2(jsonb) a.k:3(jsonb) a.m:4(jsonb) a.n:5(jsonb) column6:6(jsonb)
+ │    ├── scan a
+ │    │    └── columns: a.x:1(int!null) a.j:2(jsonb) a.k:3(jsonb) a.m:4(jsonb) a.n:5(jsonb)
+ │    ├── zip
+ │    │    ├── columns: column6:6(jsonb)
+ │    │    └── function: json_array_elements [type=jsonb]
+ │    │         └── variable: a.j [type=jsonb]
+ │    └── true [type=bool]
+ └── projections
+      ├── subquery [type=tuple{string AS key, jsonb AS value}]
+      │    └── max1-row
+      │         ├── columns: jsonb_each:9(tuple{string AS key, jsonb AS value})
+      │         └── project
+      │              ├── columns: jsonb_each:9(tuple{string AS key, jsonb AS value})
+      │              ├── inner-join-apply
+      │              │    ├── columns: key:7(string) value:8(jsonb)
+      │              │    ├── values
+      │              │    │    └── tuple [type=tuple]
+      │              │    ├── zip
+      │              │    │    ├── columns: key:7(string) value:8(jsonb)
+      │              │    │    └── function: jsonb_each [type=tuple{string AS key, jsonb AS value}]
+      │              │    │         └── variable: a.k [type=jsonb]
+      │              │    └── true [type=bool]
+      │              └── projections
+      │                   └── tuple [type=tuple{string AS key, jsonb AS value}]
+      │                        ├── variable: key [type=string]
+      │                        └── variable: value [type=jsonb]
+      ├── subquery [type=string]
+      │    └── max1-row
+      │         ├── columns: column16:16(string)
+      │         └── project
+      │              ├── columns: column16:16(string)
+      │              └── inner-join-apply
+      │                   ├── columns: a.x:11(int!null) a.j:12(jsonb) a.k:13(jsonb) a.m:14(jsonb) a.n:15(jsonb) column16:16(string)
+      │                   ├── scan a
+      │                   │    └── columns: a.x:11(int!null) a.j:12(jsonb) a.k:13(jsonb) a.m:14(jsonb) a.n:15(jsonb)
+      │                   ├── zip
+      │                   │    ├── columns: column16:16(string)
+      │                   │    └── function: jsonb_object_keys [type=string]
+      │                   │         └── variable: a.m [type=jsonb]
+      │                   └── true [type=bool]
+      └── subquery [type=int]
+           └── max1-row
+                ├── columns: column20:20(int)
+                └── inner-join-apply
+                     ├── columns: column20:20(int)
+                     ├── values
+                     │    └── tuple [type=tuple]
+                     ├── zip
+                     │    ├── columns: column20:20(int)
+                     │    └── function: generate_series [type=int]
+                     │         ├── subquery [type=int]
+                     │         │    └── max1-row
+                     │         │         ├── columns: column19:19(int)
+                     │         │         └── project
+                     │         │              ├── columns: column19:19(int)
+                     │         │              └── inner-join-apply
+                     │         │                   ├── columns: jsonb_array_elements_text:18(string) column19:19(int)
+                     │         │                   ├── zip
+                     │         │                   │    ├── columns: jsonb_array_elements_text:18(string)
+                     │         │                   │    └── function: jsonb_array_elements_text [type=string]
+                     │         │                   │         └── variable: a.n [type=jsonb]
+                     │         │                   ├── zip
+                     │         │                   │    ├── columns: column19:19(int)
+                     │         │                   │    └── function: generate_series [type=int]
+                     │         │                   │         ├── variable: a.x [type=int]
+                     │         │                   │         └── const: 100 [type=int]
+                     │         │                   └── true [type=bool]
+                     │         └── const: 1000 [type=int]
+                     └── true [type=bool]

--- a/pkg/sql/opt/optbuilder/testdata/window
+++ b/pkg/sql/opt/optbuilder/testdata/window
@@ -27,4 +27,4 @@ error (42803): aggregate function calls cannot contain window function calls
 build
 SELECT * FROM kv GROUP BY v, count(w) OVER ()
 ----
-error (42P20): window functions are not allowed in GROUP BY
+error: count(): window functions are not allowed in GROUP BY

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -557,9 +557,10 @@ func (ef *execFactory) ConstructLimit(
 
 // ConstructProjectSet is part of the exec.Factory interface.
 func (ef *execFactory) ConstructProjectSet(
-	n exec.Node, exprs tree.TypedExprs, cols sqlbase.ResultColumns, numColsPerGen []int,
+	n exec.Node, exprs tree.TypedExprs, zipCols sqlbase.ResultColumns, numColsPerGen []int,
 ) (exec.Node, error) {
 	src := asDataSource(n)
+	cols := append(src.info.SourceColumns, zipCols...)
 	p := &projectSetNode{
 		source:          src.plan,
 		sourceInfo:      src.info,

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -557,7 +557,7 @@ func (ef *execFactory) ConstructLimit(
 
 // ConstructProjectSet is part of the exec.Factory interface.
 func (ef *execFactory) ConstructProjectSet(
-	n exec.Node, exprs tree.TypedExprs, cols sqlbase.ResultColumns,
+	n exec.Node, exprs tree.TypedExprs, cols sqlbase.ResultColumns, numColsPerGen []int,
 ) (exec.Node, error) {
 	src := asDataSource(n)
 	p := &projectSetNode{
@@ -567,7 +567,7 @@ func (ef *execFactory) ConstructProjectSet(
 		numColsInSource: len(src.info.SourceColumns),
 		exprs:           exprs,
 		funcs:           make([]*tree.FuncExpr, len(exprs)),
-		numColsPerGen:   make([]int, len(exprs)),
+		numColsPerGen:   numColsPerGen,
 		run: projectSetRun{
 			gens:      make([]tree.ValueGenerator, len(exprs)),
 			done:      make([]bool, len(exprs)),
@@ -578,12 +578,7 @@ func (ef *execFactory) ConstructProjectSet(
 	for i, expr := range exprs {
 		if tFunc, ok := expr.(*tree.FuncExpr); ok && tFunc.IsGeneratorApplication() {
 			// Set-generating functions: generate_series() etc.
-			tType := expr.ResolvedType().(types.TTuple)
 			p.funcs[i] = tFunc
-			p.numColsPerGen[i] = len(tType.Types)
-		} else {
-			// A simple non-generator expression.
-			p.numColsPerGen[i] = 1
 		}
 	}
 

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -103,11 +103,7 @@ var generators = map[string]builtinDefinition{
 				if len(args) == 0 {
 					return tree.UnknownReturnType
 				}
-				t := types.UnwrapType(args[0].ResolvedType()).(types.TArray).Typ
-				return types.TTuple{
-					Types:  []types.T{t},
-					Labels: arrayValueGeneratorLabels,
-				}
+				return types.UnwrapType(args[0].ResolvedType()).(types.TArray).Typ
 			},
 			makeArrayGenerator,
 			"Returns the input array as a set of rows",
@@ -178,7 +174,7 @@ var generators = map[string]builtinDefinition{
 }
 
 func makeGeneratorOverload(
-	in tree.ArgTypes, ret types.TTuple, g tree.GeneratorFactory, info string,
+	in tree.ArgTypes, ret types.T, g tree.GeneratorFactory, info string,
 ) tree.Overload {
 	return makeGeneratorOverloadWithReturnType(in, tree.FixedReturnType(ret), g, info)
 }
@@ -215,7 +211,7 @@ func makeKeywordsGenerator(_ *tree.EvalContext, _ tree.Datums) (tree.ValueGenera
 }
 
 // ResolvedType implements the tree.ValueGenerator interface.
-func (*keywordsValueGenerator) ResolvedType() types.TTuple { return keywordsValueGeneratorType }
+func (*keywordsValueGenerator) ResolvedType() types.T { return keywordsValueGeneratorType }
 
 // Close implements the tree.ValueGenerator interface.
 func (*keywordsValueGenerator) Close() {}
@@ -262,22 +258,16 @@ var keywordNames = func() []string {
 type seriesValueGenerator struct {
 	origStart, value, start, stop, step interface{}
 	nextOK                              bool
-	genType                             types.TTuple
+	genType                             types.T
 	next                                func(*seriesValueGenerator) (bool, error)
 	genValue                            func(*seriesValueGenerator) tree.Datums
 }
 
 var seriesValueGeneratorLabels = []string{"generate_series"}
 
-var seriesValueGeneratorType = types.TTuple{
-	Types:  []types.T{types.Int},
-	Labels: seriesValueGeneratorLabels,
-}
+var seriesValueGeneratorType = types.Int
 
-var seriesTSValueGeneratorType = types.TTuple{
-	Types:  []types.T{types.Timestamp},
-	Labels: seriesValueGeneratorLabels,
-}
+var seriesTSValueGeneratorType = types.Timestamp
 
 var errStepCannotBeZero = pgerror.NewError(pgerror.CodeInvalidParameterValueError, "step cannot be 0")
 
@@ -369,7 +359,7 @@ func makeTSSeriesGenerator(_ *tree.EvalContext, args tree.Datums) (tree.ValueGen
 }
 
 // ResolvedType implements the tree.ValueGenerator interface.
-func (s *seriesValueGenerator) ResolvedType() types.TTuple {
+func (s *seriesValueGenerator) ResolvedType() types.T {
 	return s.genType
 }
 
@@ -409,11 +399,8 @@ type arrayValueGenerator struct {
 var arrayValueGeneratorLabels = []string{"unnest"}
 
 // ResolvedType implements the tree.ValueGenerator interface.
-func (s *arrayValueGenerator) ResolvedType() types.TTuple {
-	return types.TTuple{
-		Types:  []types.T{s.array.ParamTyp},
-		Labels: arrayValueGeneratorLabels,
-	}
+func (s *arrayValueGenerator) ResolvedType() types.T {
+	return s.array.ParamTyp
 }
 
 // Start implements the tree.ValueGenerator interface.
@@ -458,7 +445,7 @@ type expandArrayValueGenerator struct {
 var expandArrayValueGeneratorLabels = []string{"x", "n"}
 
 // ResolvedType implements the tree.ValueGenerator interface.
-func (s *expandArrayValueGenerator) ResolvedType() types.TTuple {
+func (s *expandArrayValueGenerator) ResolvedType() types.T {
 	return types.TTuple{
 		Types:  []types.T{s.avg.array.ParamTyp, types.Int},
 		Labels: expandArrayValueGeneratorLabels,
@@ -524,13 +511,10 @@ type subscriptsValueGenerator struct {
 
 var subscriptsValueGeneratorLabels = []string{"generate_subscripts"}
 
-var subscriptsValueGeneratorType = types.TTuple{
-	Types:  []types.T{types.Int},
-	Labels: subscriptsValueGeneratorLabels,
-}
+var subscriptsValueGeneratorType = types.Int
 
 // ResolvedType implements the tree.ValueGenerator interface.
-func (s *subscriptsValueGenerator) ResolvedType() types.TTuple {
+func (s *subscriptsValueGenerator) ResolvedType() types.T {
 	return subscriptsValueGeneratorType
 }
 
@@ -582,7 +566,7 @@ func makeUnaryGenerator(_ *tree.EvalContext, args tree.Datums) (tree.ValueGenera
 }
 
 // ResolvedType implements the tree.ValueGenerator interface.
-func (*unaryValueGenerator) ResolvedType() types.TTuple { return unaryValueGeneratorType }
+func (*unaryValueGenerator) ResolvedType() types.T { return unaryValueGeneratorType }
 
 // Start implements the tree.ValueGenerator interface.
 func (s *unaryValueGenerator) Start() error {
@@ -641,15 +625,9 @@ var jsonArrayElementsTextImpl = makeGeneratorOverload(
 
 var jsonArrayGeneratorLabels = []string{"value"}
 
-var jsonArrayGeneratorType = types.TTuple{
-	Types:  []types.T{types.JSON},
-	Labels: jsonArrayGeneratorLabels,
-}
+var jsonArrayGeneratorType = types.JSON
 
-var jsonArrayTextGeneratorType = types.TTuple{
-	Types:  []types.T{types.String},
-	Labels: jsonArrayGeneratorLabels,
-}
+var jsonArrayTextGeneratorType = types.String
 
 type jsonArrayGenerator struct {
 	json      tree.DJSON
@@ -685,7 +663,7 @@ func makeJSONArrayGenerator(args tree.Datums, asText bool) (tree.ValueGenerator,
 }
 
 // ResolvedType implements the tree.ValueGenerator interface.
-func (g *jsonArrayGenerator) ResolvedType() types.TTuple {
+func (g *jsonArrayGenerator) ResolvedType() types.T {
 	if g.asText {
 		return jsonArrayTextGeneratorType
 	}
@@ -735,10 +713,7 @@ var jsonObjectKeysImpl = makeGeneratorOverload(
 
 var jsonObjectKeysGeneratorLabels = []string{"json_object_keys"}
 
-var jsonObjectKeysGeneratorType = types.TTuple{
-	Types:  []types.T{types.String},
-	Labels: jsonObjectKeysGeneratorLabels,
-}
+var jsonObjectKeysGeneratorType = types.String
 
 type jsonObjectKeysGenerator struct {
 	iter *json.ObjectIterator
@@ -766,7 +741,7 @@ func makeJSONObjectKeysGenerator(
 }
 
 // ResolvedType implements the tree.ValueGenerator interface.
-func (g *jsonObjectKeysGenerator) ResolvedType() types.TTuple {
+func (g *jsonObjectKeysGenerator) ResolvedType() types.T {
 	return jsonObjectKeysGeneratorType
 }
 
@@ -842,7 +817,7 @@ func makeJSONEachGenerator(args tree.Datums, asText bool) (tree.ValueGenerator, 
 }
 
 // ResolvedType implements the tree.ValueGenerator interface.
-func (g *jsonEachGenerator) ResolvedType() types.TTuple {
+func (g *jsonEachGenerator) ResolvedType() types.T {
 	if g.asText {
 		return jsonEachTextGeneratorType
 	}

--- a/pkg/sql/sem/tree/generators.go
+++ b/pkg/sql/sem/tree/generators.go
@@ -41,7 +41,7 @@ import (
 // iterators or generators in Python).
 type ValueGenerator interface {
 	// ResolvedType returns the type signature of this value generator.
-	ResolvedType() types.TTuple
+	ResolvedType() types.T
 
 	// Start initializes the generator. Must be called once before
 	// Next() and Values(). It can be called again to restart

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -145,8 +145,14 @@ func TestTypeCheck(t *testing.T) {
 		{`((('1', 2) AS a, b)).a`, `'1':::STRING`},
 		{`((('1', 2) AS a, b)).b`, `2:::INT`},
 		{`(pg_get_keywords()).word`, `(pg_get_keywords()).word`},
-		{`(generate_series(1,3)).generate_series`, `(generate_series(1:::INT, 3:::INT)).generate_series`},
-		{`(generate_series(1,3)).*`, `generate_series(1:::INT, 3:::INT)`},
+		{
+			`(information_schema._pg_expandarray(ARRAY[1,3])).x`,
+			`(information_schema._pg_expandarray(ARRAY[1:::INT, 3:::INT])).x`,
+		},
+		{
+			`(information_schema._pg_expandarray(ARRAY[1:::INT, 3:::INT])).*`,
+			`information_schema._pg_expandarray(ARRAY[1:::INT, 3:::INT])`,
+		},
 		{`((ROW (1) AS a)).*`, `(ROW(1:::INT) AS a)`},
 		{`((('1'||'', 1+1) AS a, b)).*`, `(('1':::STRING, 2:::INT) AS a, b)`},
 

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -205,7 +205,7 @@ func (p *planner) orderBy(
 	}
 
 	if p.semaCtx.Properties.Derived.SeenGenerator {
-		return nil, pgerror.Unimplemented("srf in order by", "generator functions are not yet supported in ORDER BY")
+		return nil, tree.NewInvalidFunctionUsageError(tree.GeneratorClass, "ORDER BY")
 	}
 
 	if ordering == nil {


### PR DESCRIPTION
This PR contains two commits:

1. Change the return type of single-column generator functions to be the type of the column rather than tuple{column type}. This matches Postgres behavior and is necessary to support SRFs in the optbuilder.
2. Add full support for SRFs in the optimizer. 

See the commit messages for more details.