### PR TITLE
roachtest: update store dump creation comments

### DIFF
--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -29,7 +29,7 @@ func registerBackup(r *registry) {
 
 			t.Status(`downloading store dumps`)
 			// Created via:
-			// roachtest --cockroach cockroach-v2.0.1 store-gen --stores=10 bank \
+			// roachtest --cockroach cockroach-v2.0.4-fb6939 store-gen --stores=10 bank \
 			//           --payload-bytes=10240 --ranges=0 --rows=65104166
 			location := `gs://cockroach-fixtures/workload/bank/version=1.0.0,payload-bytes=10240,ranges=0,rows=65104166,seed=1`
 			storeDirsPath := storeDirURL(location, nodes, "2.0")

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -30,7 +30,7 @@ func registerClearRange(r *registry) {
 		Stable:     true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			// Created via:
-			// roachtest --cockroach cockroach-v2.0.1 store-gen --stores=10 bank \
+			// roachtest --cockroach cockroach-v2.0-8 store-gen --stores=10 bank \
 			//           --payload-bytes=10240 --ranges=0 --rows=65104166
 			if err := c.RunE(ctx, c.Node(1), "test -d /mnt/data1/.zfs/snapshot/pristine"); err != nil {
 				// TODO(peter): install zfs with 'roachprod reformat zfs'.


### PR DESCRIPTION
I recreated the `backup` fixture. The other one had a wrong version in
the comment to begin with.

Release note: None