### PR TITLE
sql/parser: report variants of CREATE TYPE as unimplemented

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -252,13 +252,13 @@ create_role_stmt ::=
 	| 'CREATE' 'ROLE' 'IF' 'NOT' 'EXISTS' string_or_placeholder
 
 create_ddl_stmt ::=
-	create_database_stmt
+	create_changefeed_stmt
+	| create_database_stmt
 	| create_index_stmt
 	| create_table_stmt
 	| create_table_as_stmt
 	| create_view_stmt
 	| create_sequence_stmt
-	| create_changefeed_stmt
 
 create_stats_stmt ::=
 	'CREATE' 'STATISTICS' statistics_name 'ON' name_list 'FROM' table_name
@@ -659,10 +659,12 @@ unreserved_keyword ::=
 	| 'DEALLOCATE'
 	| 'DELETE'
 	| 'DISCARD'
+	| 'DOMAIN'
 	| 'DOUBLE'
 	| 'DROP'
 	| 'EMIT'
 	| 'ENCODING'
+	| 'ENUM'
 	| 'ESCAPE'
 	| 'EXECUTE'
 	| 'EXPERIMENTAL'
@@ -866,6 +868,9 @@ opt_password ::=
 	opt_with 'PASSWORD' string_or_placeholder
 	| 
 
+create_changefeed_stmt ::=
+	'CREATE' 'CHANGEFEED' 'FOR' targets opt_changefeed_sink opt_with_options
+
 create_database_stmt ::=
 	'CREATE' 'DATABASE' database_name opt_with opt_template_clause opt_encoding_clause opt_lc_collate_clause opt_lc_ctype_clause
 	| 'CREATE' 'DATABASE' 'IF' 'NOT' 'EXISTS' database_name opt_with opt_template_clause opt_encoding_clause opt_lc_collate_clause opt_lc_ctype_clause
@@ -890,9 +895,6 @@ create_view_stmt ::=
 create_sequence_stmt ::=
 	'CREATE' 'SEQUENCE' sequence_name opt_sequence_option_list
 	| 'CREATE' 'SEQUENCE' 'IF' 'NOT' 'EXISTS' sequence_name opt_sequence_option_list
-
-create_changefeed_stmt ::=
-	'CREATE' 'CHANGEFEED' 'FOR' targets opt_changefeed_sink opt_with_options
 
 statistics_name ::=
 	name
@@ -1169,6 +1171,10 @@ opt_with ::=
 	'WITH'
 	| 
 
+opt_changefeed_sink ::=
+	'INTO' string_or_placeholder
+	| 
+
 opt_template_clause ::=
 	'TEMPLATE' opt_equal non_reserved_word_or_sconst
 	| 
@@ -1227,10 +1233,6 @@ sequence_name ::=
 
 opt_sequence_option_list ::=
 	sequence_option_list
-	| 
-
-opt_changefeed_sink ::=
-	'INTO' string_or_placeholder
 	| 
 
 cte_list ::=


### PR DESCRIPTION
Fixes #27759.

Prior to this patch CREATE TYPE was wholly unrecognized. This patch
makes basic syntax forms recognized and reports specific github issues
for them.

cc @awoods187 