### PR TITLE
 sql/tree: improve the anonymization of long node lists

### DIFF
--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -57,11 +57,11 @@ select * from crdb_internal.node_runtime_info;
 
 	const (
 		expMessage = "panic while testing 2 statements: INSERT INTO _(_, _) VALUES " +
-			"(_, _, _, _); SELECT * FROM _._; caused by i'm not safe"
+			"(_, _, __more2__); SELECT * FROM _._; caused by i'm not safe"
 		expSafeRedactedMessage = "?:0: panic while testing 2 statements: INSERT INTO _(_, _) VALUES " +
-			"(_, _, _, _); SELECT * FROM _._: caused by <redacted>"
+			"(_, _, __more2__); SELECT * FROM _._: caused by <redacted>"
 		expSafeSafeMessage = "?:0: panic while testing 2 statements: INSERT INTO _(_, _) VALUES " +
-			"(_, _, _, _); SELECT * FROM _._: caused by something safe"
+			"(_, _, __more2__); SELECT * FROM _._: caused by something safe"
 	)
 
 	actMessage := safeErr.Error()

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -107,17 +107,17 @@ SELECT key,flags
  WHERE application_name = 'valuetest' ORDER BY key, flags
 ----
 key                                                               flags
-INSERT INTO test VALUES (_, _, _)                                 ·
-SELECT ROW(_, _, _, _, _) FROM test WHERE _                       ·
+INSERT INTO test VALUES (_, _, __more1__), (__more1__)            ·
+SELECT ROW(_, _, __more3__) FROM test WHERE _                     ·
 SELECT key FROM test.crdb_internal.node_statement_statistics      ·
 SELECT sin(_)                                                     ·
 SELECT sqrt(-_)                                                   !
-SELECT x FROM (VALUES (_, _, _)) AS t (x)                         ·
+SELECT x FROM (VALUES (_, _, __more1__), (__more1__)) AS t (x)    ·
 SELECT x FROM test WHERE y = (_ / z)                              !+
-SELECT x FROM test WHERE y IN (_, _)                              ·
-SELECT x FROM test WHERE y IN (_, _)                              +
 SELECT x FROM test WHERE y IN (_, _, _ + x, _, _)                 ·
-SELECT x FROM test WHERE y NOT IN (_, _)                          ·
+SELECT x FROM test WHERE y IN (_, _, __more3__)                   ·
+SELECT x FROM test WHERE y IN (_, _, __more3__)                   +
+SELECT x FROM test WHERE y NOT IN (_, _, __more3__)               ·
 SET CLUSTER SETTING "debug.panic_on_failed_assertions" = DEFAULT  ·
 SET CLUSTER SETTING "debug.panic_on_failed_assertions" = _        ·
 SET application_name = _                                          ·
@@ -131,17 +131,17 @@ SELECT anonymized
   FROM test.crdb_internal.node_statement_statistics
  WHERE application_name = 'valuetest' ORDER BY key
 ----
-INSERT INTO _ VALUES (_, _, _)
-SELECT ROW(_, _, _, _, _) FROM _ WHERE _
+INSERT INTO _ VALUES (_, _, __more1__), (__more1__)
+SELECT ROW(_, _, __more3__) FROM _ WHERE _
 SELECT _ FROM _.crdb_internal.node_statement_statistics
 SELECT sin(_)
 SELECT sqrt(-_)
-SELECT _ FROM (VALUES (_, _, _)) AS _ (_)
+SELECT _ FROM (VALUES (_, _, __more1__), (__more1__)) AS _ (_)
 SELECT _ FROM _ WHERE _ = (_ / _)
-SELECT _ FROM _ WHERE _ IN (_, _)
-SELECT _ FROM _ WHERE _ IN (_, _)
 SELECT _ FROM _ WHERE _ IN (_, _, _ + _, _, _)
-SELECT _ FROM _ WHERE _ NOT IN (_, _)
+SELECT _ FROM _ WHERE _ IN (_, _, __more3__)
+SELECT _ FROM _ WHERE _ IN (_, _, __more3__)
+SELECT _ FROM _ WHERE _ NOT IN (_, _, __more3__)
 SET CLUSTER SETTING "debug.panic_on_failed_assertions" = DEFAULT
 SET CLUSTER SETTING "debug.panic_on_failed_assertions" = _
 SET application_name = _

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -57,7 +57,8 @@ const (
 	FmtShowTypes
 
 	// FmtHideConstants instructs the pretty-printer to produce a
-	// representation that does not disclose query-specific data.
+	// representation that does not disclose query-specific data. It
+	// also shorten long lists in tuples, VALUES and array expressions.
 	FmtHideConstants
 
 	// FmtAnonymize instructs the pretty-printer to remove

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -58,6 +58,21 @@ func TestFormatStatement(t *testing.T) {
 		{`GRANT SELECT ON bar TO foo`, tree.FmtAnonymize,
 			`GRANT SELECT ON TABLE _ TO _`},
 
+		{`INSERT INTO a VALUES (0), (0), (0), (0), (0), (0)`,
+			tree.FmtHideConstants,
+			`INSERT INTO a VALUES (_), (__more5__)`},
+		{`INSERT INTO a VALUES (0, 0, 0, 0, 0, 0)`,
+			tree.FmtHideConstants,
+			`INSERT INTO a VALUES (_, _, __more4__)`},
+		{`INSERT INTO a VALUES (ARRAY[0, 0, 0, 0, 0, 0, 0])`,
+			tree.FmtHideConstants,
+			`INSERT INTO a VALUES (ARRAY[_, _, __more5__])`},
+		{`INSERT INTO a VALUES (ARRAY[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ` +
+			`0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ` +
+			`0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])`,
+			tree.FmtHideConstants,
+			`INSERT INTO a VALUES (ARRAY[_, _, __more30__])`},
+
 		{`SELECT 1+COALESCE(NULL, 'a', x)-ARRAY[3.14]`, tree.FmtHideConstants,
 			`SELECT (_ + COALESCE(_, _, x)) - ARRAY[_]`},
 

--- a/pkg/sql/sem/tree/name_part.go
+++ b/pkg/sql/sem/tree/name_part.go
@@ -33,7 +33,7 @@ type Name string
 // Format implements the NodeFormatter interface.
 func (n *Name) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	if f.HasFlags(FmtAnonymize) {
+	if f.HasFlags(FmtAnonymize) && !isArityIndicatorString(string(*n)) {
 		ctx.WriteByte('_')
 	} else {
 		lex.EncodeRestrictedSQLIdent(ctx.Buffer, string(*n), f.EncodeFlags())


### PR DESCRIPTION
First commit from #27646.

Fixes #21803.

The format flag FmtHideConstants is meant to shorten long horizontal
lists of AST nodes (e.g. VALUES tuples) so that statements that are
alike except for the specific arity of these lists are collapsed in
reported statistics.

This is meant to achieve two goals:

- to reduce the amount of data reported;
- in per-node statistics, to bucket similar statements together.

Prior to this patch, this logic was incomplete/incorrect.

1. it did not shorten the argument list of `ARRAY[...]`. In practice
   we have seen clients with large array expressions, so they deserve
   to be shortened as well.

2. the shortening was performed by simple truncation. This was
   incorrect for the second goal outlined above: although the
   particular values in each tuple are unlikely to participate in the
   performance, the *arity* of the tuples is a distinguishing factor.
   This patch corrects the previous situation by appending a
   pseudo-identifier that indicates the number of items
   truncated. Truncated arities are rounded to the closest multiple of
   a power of ten (31 -> 30, 210 -> 200, 42023 -> 40000, etc).

Release note: None