### PR TITLE
cli/sql: support prompt customization

### DIFF
--- a/pkg/cli/interactive_tests/test_txn_prompt.tcl
+++ b/pkg/cli/interactive_tests/test_txn_prompt.tcl
@@ -8,35 +8,58 @@ spawn /bin/bash
 send "PS1='\\h:''/# '\r"
 eexpect ":/# "
 
-send "$argv sql\r"
+send "$argv sql --host=localhost\r"
 eexpect root@
+
+###START tests prompt customization
+
+start_test "Check that invalid prompt patterns cause an error."
+send "\\set prompt1 %?\r"
+eexpect "unrecognized format code in prompt"
+
+# Reset to default.
+send "\\unset prompt1\r"
+eexpect root@
+end_test
+
+start_test "Check that one can use % signs in the prompt."
+send "\\set prompt1 abc%%def\r"
+eexpect "abc%def"
+
+send "\\set prompt1 abc%Mdef\r"
+eexpect abclocalhost:26257def
+
+send "\\set prompt1 abc%mdef\r"
+eexpect abclocalhostdef
+
+send "\\set prompt1 abc%>def\r"
+eexpect abc26257def
+
+send "\\set prompt1 abc%ndef\r"
+eexpect abcrootdef
+
+send "\\set prompt1 abc%/def\r"
+eexpect abcdefaultdbdef
+
+# Check promptw with no formatting code.
+send "\\set prompt1 woo \r"
+eexpect woo
+
+send "SET database \r"
+eexpect "\r\n -> "
+send "defaultdb;\r"
+eexpect woo
+
+# Reset to default.
+send "\\unset prompt1\r"
+eexpect root@
+end_test
 
 start_test "Check option to echo statements"
 send "\\set echo\r"
 send "select 1;\r"
 eexpect "\n> select 1;\r\n"
 eexpect root@
-end_test
-
-start_test "Check prompt update statements are disabled when smart_prompt is not set"
-send "\r"
-eexpect "> SHOW TRANSACTION STATUS"
-eexpect root@
-send "\\unset smart_prompt\r"
-send "set application_name=test;\r"
-eexpect "> set application_name=test;"
-eexpect "SET"
-expect {
-    "SHOW" {
-	report "unexpected SHOW"
-	exit 1
-    }
-    root@ {}
-}
-
-# reset settings for later tests
-send "\\unset echo\r"
-send "\\set smart_prompt\r"
 end_test
 
 start_test "Check database prompt."
@@ -128,4 +151,3 @@ eexpect ":/# "
 
 send "exit\r"
 eexpect eof
-


### PR DESCRIPTION
Supersedes #27437.

Fixes #24494.

This patch introduces a new client-side option `prompt1` with a
similar behavior as `PROMPT1` in `psql`: it can contain %-codes to
produce a custom prompt.

Release note (cli change): the interactive prompt can now be
customized with the client-side option `prompt1`.

