### PR TITLE
cli: provide `auto_trace` as replacement to SHOW TRACE FOR <stmt>

### DIFF
--- a/pkg/cli/interactive_tests/test_auto_trace.tcl
+++ b/pkg/cli/interactive_tests/test_auto_trace.tcl
@@ -1,0 +1,85 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+spawn $argv sql
+eexpect root@
+
+start_test "Check traces over simple statements"
+send "\\set auto_trace\r"
+eexpect root@
+send "select 1;\r"
+# main result
+eexpect "1 row"
+# trace result
+eexpect "session recording"
+eexpect "executing: SELECT 1"
+eexpect "rows affected: 1"
+eexpect root@
+end_test
+
+start_test "Check traces over simple statements with errors"
+send "select woo;\r"
+# main result
+eexpect "column \"woo\" does not exist"
+# trace result
+eexpect "session recording"
+eexpect "executing: SELECT woo"
+eexpect "does not exist"
+eexpect root@
+end_test
+
+start_test "Check results in simple traces"
+send "\\reset auto_trace\r"
+eexpect root@
+send "create table t(x int); insert into t values (1),(2);\r"
+eexpect root@
+send "\\set auto_trace=results\r"
+eexpect root@
+send "select * from t;\r"
+# main result
+eexpect "2 rows"
+# trace result
+eexpect "session recording"
+eexpect "executing: SELECT \* FROM t"
+eexpect "output row:"
+eexpect "output row:"
+eexpect "rows affected: 2"
+eexpect root@
+end_test
+
+start_test "Check KV traces"
+send "\\set auto_trace=kv\r"
+eexpect root@
+send "select * from t;\r"
+# main result
+eexpect "2 rows"
+# trace result
+eexpect "querying next range"
+eexpect "Scan"
+eexpect "rows affected: 2"
+eexpect root@
+end_test
+
+start_test "Check results in KV traces"
+send "\\set auto_trace=kv,results\r"
+eexpect root@
+send "select * from t;\r"
+# main result
+eexpect "2 rows"
+# trace result
+eexpect "querying next range"
+eexpect "Scan"
+eexpect "output row:"
+eexpect "output row:"
+eexpect "rows affected: 2"
+eexpect root@
+end_test
+
+# Terminate.
+send "\\q\r"
+eexpect eof
+
+stop_server $argv


### PR DESCRIPTION
The SHOW TRACE FOR <stmt> syntax form was removed from CockroachDB SQL
because it was hard to implement correctly server-side.

However this does not mean that the need for it did not exist. Folk
were moderately unhappy to lose a feature that was exploited
productively during performance analysis and general troubleshooting.

To respond to the need, this patch instead provides a feature in
`cockroach sql` that replaces the previous SHOW TRACE FOR <stmt>
syntax. For example:

```
> \set auto_trace on
> SELECT 1
+----------+
| ?column? |
+----------+
|        1 |
+----------+
(1 row)

Time: 327.38µs

+----------------------------------+------------+------------------------------------------------------------------+---------------------------------------+----------+-------------------+------+
|            timestamp             |    age     |                             message                              |                  tag                  | location |     operation     | span |
+----------------------------------+------------+------------------------------------------------------------------+---------------------------------------+----------+-------------------+------+
| 2018-07-20 15:25:29.09039+00:00  | 0s         | === SPAN START: session recording ===                            |                                       |          | session recording |    0 |
| 2018-07-20 15:25:29.09041+00:00  | 19µs997ns  | [NoTxn pos:22] executing Sync                                    | [n1,client=127.0.0.1:16847,user=root] |          | session recording |    0 |
| 2018-07-20 15:25:29.09048+00:00  | 89µs917ns  | [NoTxn pos:23] executing ExecStmt: SELECT 1                      | [n1,client=127.0.0.1:16847,user=root] |          | session recording |    0 |
[...]
+----------------------------------+------------+------------------------------------------------------------------+---------------------------------------+----------+-------------------+------+
(22 rows)

Time: 1.836533ms
```

That is, for every statement executed, the shell also produces the
trace for that statement in a separate result below.

A trace is also produced in case the statement produces a SQL error.

It works as follows:

- a new client-side option `auto_trace` is provided (configurable with
  `\set`).
- when set to non-off, it causes every subsequent statement to be
  enclosed in:
  - `SET tracing = off; SET tracing = on, <options...>` at the
	 beginning where `<options...>` is the content of the variable
	 `auto_trace`.
  - `SET tracing = off; SHOW <option> TRACE FOR SESSION` at the end,
	where `<option>` is either empty or `kv` if `auto_trace` contains
	`kv`.

Release note (cli change): A new client-side option `auto_trace` is
provided to facilitate usage of session tracing.