### PR TITLE
importccl: pre-read schemas in mysqldump import

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -687,6 +687,8 @@ func importPlanHook(
 			fks := fkHandler{skip: skipFKs, allowed: true, resolver: make(fkResolver)}
 			switch format.Format {
 			case roachpb.IOFileFormat_Mysqldump:
+				evalCtx := &p.ExtendedEvalContext().EvalContext
+				tableDescs, err = readMysqlCreateTable(reader, evalCtx, parentID, match)
 			case roachpb.IOFileFormat_PgDump:
 				evalCtx := &p.ExtendedEvalContext().EvalContext
 				tableDescs, err = readPostgresCreateTable(reader, evalCtx, p.ExecCfg().Settings, match, parentID, walltime, fks, int(format.PgDump.MaxRowSize))

--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -17,8 +17,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
-
 	"github.com/pkg/errors"
 	mysqltypes "vitess.io/vitess/go/sqltypes"
 	mysql "vitess.io/vitess/go/vt/sqlparser"
@@ -41,11 +39,9 @@ import (
 // tables with names that appear in the `tables` map is converted to Cockroach
 // KVs using the mapped converter and sent to kvCh.
 type mysqldumpReader struct {
-	evalCtx   *tree.EvalContext
-	tables    map[string]*rowConverter
-	importAll bool // import any table encountered.
-	kvCh      chan kvBatch
-
+	evalCtx  *tree.EvalContext
+	tables   map[string]*rowConverter
+	kvCh     chan kvBatch
 	debugRow func(tree.Datums)
 }
 
@@ -54,7 +50,7 @@ var _ inputConverter = &mysqldumpReader{}
 func newMysqldumpReader(
 	kvCh chan kvBatch, tables map[string]*sqlbase.TableDescriptor, evalCtx *tree.EvalContext,
 ) (*mysqldumpReader, error) {
-	res := &mysqldumpReader{evalCtx: evalCtx, kvCh: kvCh, importAll: len(tables) == 0}
+	res := &mysqldumpReader{evalCtx: evalCtx, kvCh: kvCh}
 
 	converters := make(map[string]*rowConverter, len(tables))
 	for name, table := range tables {
@@ -69,7 +65,6 @@ func newMysqldumpReader(
 		converters[name] = conv
 	}
 	res.tables = converters
-
 	return res, nil
 }
 
@@ -83,7 +78,6 @@ func (m *mysqldumpReader) inputFinished(ctx context.Context) {
 func (m *mysqldumpReader) readFile(
 	ctx context.Context, input io.Reader, inputIdx int32, inputName string, progressFn progressFn,
 ) error {
-	var generatedIDs sqlbase.ID
 	var inserts, count int64
 	r := bufio.NewReaderSize(input, 1024*64)
 	tokens := mysql.NewTokenizer(r)
@@ -100,43 +94,6 @@ func (m *mysqldumpReader) readFile(
 			return errors.Wrap(err, "mysql parse error")
 		}
 		switch i := stmt.(type) {
-		case *mysql.DDL:
-			if i.Action == mysql.DropStr {
-				continue
-			}
-			if i.Action != mysql.CreateStr {
-				return errors.Errorf("unsupported %q statement in mysqldump", i.Action)
-			}
-			name := i.NewName.Name.String()
-			conv, ok := m.tables[name]
-			// If we already have this schema, skip it.
-			if conv != nil {
-				continue
-			}
-			// If we're only importing the named tables and this is not one, skip it.
-			if !m.importAll && !ok {
-				continue
-			}
-
-			generatedIDs++
-			id := defaultCSVTableID + generatedIDs
-			tbl, err := mysqlTableToCockroach(m.evalCtx, defaultCSVParentID, id, name, i.TableSpec)
-			if err != nil {
-				return err
-			}
-			conv, err = newRowConverter(tbl, m.evalCtx, m.kvCh)
-			if err != nil {
-				return err
-			}
-			kv := roachpb.KeyValue{Key: sqlbase.MakeDescMetadataKey(id)}
-			if err := kv.Value.SetProto(tbl); err != nil {
-				return err
-			}
-			kv.Value.InitChecksum(kv.Key)
-			conv.kvBatch = append(conv.kvBatch, kv)
-
-			m.tables[name] = conv
-
 		case *mysql.Insert:
 			name := i.Table.Name.String()
 			conv, ok := m.tables[name]


### PR DESCRIPTION
This switches mysqldump import to use read schemas from during setup on
the gateway, rather than during sampling, similar to how pgdump operates
(i.e. in three passes over the input rather than two).

This simplifies handling foreign keys, which can sometimes appear in
a table definition before the table they reference — making them hard to
correctly resolve immediately. Reading though the whole file to capture
all the schemas before evaluating them should make that a bit easier.

In the future, a return to 2-pass could be possible either if it turns
out that KVs can be produced correctly even if the schema is later
changed by a foreign key, or by oversampling raw rows of the input
*without* converting during the read extracting the schemas, then using
those schemas to convert the sampled rows to KVs from which the splits
can be sampled.

Release note: none.