### PR TITLE
Further simplifying template for filers

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,6 +9,8 @@ If not, or you're not sure, please file an issue on our forum instead: https://f
 
 Please describe the issue you observed, and any steps we can take to reproduce it:
 
+- Which version of CockroachDB are you using? 
+
 - What did you do?
 
 - What did you expect to see?

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,14 +1,21 @@
-Is this a bug report or a feature request? Prefer live chat? Message our engineers on our Gitter channel at https://gitter.im/cockroachdb/cockroach.
+Is this a bug report or a feature request? 
+
+If so, please fill out the template below and we'll be happy to help.
+
+If not, or you're not sure, please file an issue on our forum instead: https://forum.cockroachlabs.com/. You'll get a faster response there for troubleshooting and general questions, and it's likely that someone else has encountered the same issue.
+
 
 **BUG REPORT**
 
-Please describe the issue you observed:
+Please describe the issue you observed, and any steps we can take to reproduce it:
 
 - What did you do?
 
 - What did you expect to see?
 
 - What did you see instead?
+
+- What is the impact?
 
 **FEATURE REQUEST**
 


### PR DESCRIPTION
1) Clarify intent for github issues (github = engineering & product system for bugs & feature enhancements, forum = support system for questions, troubleshooting, and triage).
2) Ask for impact of bugs so we can prioritize appropriately.
3) Remove reference to Gitter so we can more effectively prioritize work and capture knowledge.

@bdarnell @couchand @vivekmenezes @nstewart - given recent contributions, let me know if you have any input or questions. The intent here is not to reject anything that comes through github or gitter, but to encourage a different path for questions & general help.