### PR TITLE
opt/sql: support ORDER BY INDEX, change behaviour

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -375,6 +375,18 @@ statement error ORDER BY INDEX in window definition is not supported
 SELECT avg(k) OVER (ORDER BY PRIMARY KEY kv) FROM kv
 
 statement ok
+INSERT INTO kv VALUES (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)
+
+query I
+SELECT k FROM kv ORDER BY INDEX kv@foo
+----
+1
+2
+3
+4
+5
+
+statement ok
 CREATE TABLE abc2 (
   a INT,
   b INT,
@@ -428,3 +440,9 @@ SELECT a, b, c FROM abc2 ORDER BY INDEX abc2@ba DESC
 3  30  300
 2  30  400
 1  30  500
+
+statement error relation \"x\" does not exist
+SELECT a, b, c FROM abc2 AS x ORDER BY INDEX x@bc
+
+statement error no data source matches prefix: test.public.abc2
+SELECT a, b, c FROM abc2 AS x ORDER BY INDEX abc2@bc

--- a/pkg/sql/logictest/testdata/planner_test/order_by
+++ b/pkg/sql/logictest/testdata/planner_test/order_by
@@ -713,8 +713,8 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo
 ----
 nosort     ·      ·       (k)     k!=NULL
- │         order  -v      ·       ·
- └── scan  ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v
+ │         order  -v,+k   ·       ·
+ └── scan  ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v,+k
 ·          table  kv@foo  ·       ·
 ·          spans  ALL     ·       ·
 
@@ -722,8 +722,8 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo ASC
 ----
 nosort     ·      ·       (k)     k!=NULL
- │         order  -v      ·       ·
- └── scan  ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v
+ │         order  -v,+k   ·       ·
+ └── scan  ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v,+k
 ·          table  kv@foo  ·       ·
 ·          spans  ALL     ·       ·
 
@@ -731,8 +731,8 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo DESC
 ----
 nosort        ·      ·       (k)     k!=NULL
- │            order  +v      ·       ·
- └── revscan  ·      ·       (k, v)  k!=NULL; weak-key(k,v); +v
+ │            order  +v,-k   ·       ·
+ └── revscan  ·      ·       (k, v)  k!=NULL; weak-key(k,v); +v,-k
 ·             table  kv@foo  ·       ·
 ·             spans  ALL     ·       ·
 
@@ -755,7 +755,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv JOIN (VALUES (1,2)) AS z(a,b) ON kv.k = z.a ORDER BY INDEX kv@foo
 ----
 sort                   ·              ·                 (k)                             ·
- │                     order          -v                ·                               ·
+ │                     order          -v,+k             ·                               ·
  └── render            ·              ·                 (k, v)                          ·
       │                render 0       test.public.kv.k  ·                               ·
       │                render 1       test.public.kv.v  ·                               ·
@@ -772,38 +772,40 @@ sort                   ·              ·                 (k)                   
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
 ----
-sort                 ·               ·                 (k)                             k!=NULL; key(k)
- │                   order           -v                ·                               ·
- └── render          ·               ·                 (k, v)                          k!=NULL; v!=NULL; key(k)
-      │              render 0        a.k               ·                               ·
-      │              render 1        test.public.kv.v  ·                               ·
-      └── join       ·               ·                 (k, v[omitted], k[omitted], v)  k=k; v=v; k!=NULL; v!=NULL; key(k)
-           │         type            inner             ·                               ·
-           │         equality        (k, v) = (k, v)   ·                               ·
-           │         mergeJoinOrder  +"(k=k)"          ·                               ·
-           ├── scan  ·               ·                 (k, v)                          k!=NULL; key(k); +k
-           │         table           kv@primary        ·                               ·
-           │         spans           ALL               ·                               ·
-           └── scan  ·               ·                 (k, v)                          k!=NULL; key(k); +k
-·                    table           kv@primary        ·                               ·
-·                    spans           ALL               ·                               ·
+sort                 ·               ·                 (k)                    k!=NULL; key(k)
+ │                   order           -v,+k             ·                      ·
+ └── render          ·               ·                 (k, v, k)              k=k; k!=NULL; v!=NULL; key(k)
+      │              render 0        a.k               ·                      ·
+      │              render 1        test.public.kv.v  ·                      ·
+      │              render 2        test.public.kv.k  ·                      ·
+      └── join       ·               ·                 (k, v[omitted], k, v)  k=k; v=v; k!=NULL; v!=NULL; key(k)
+           │         type            inner             ·                      ·
+           │         equality        (k, v) = (k, v)   ·                      ·
+           │         mergeJoinOrder  +"(k=k)"          ·                      ·
+           ├── scan  ·               ·                 (k, v)                 k!=NULL; key(k); +k
+           │         table           kv@primary        ·                      ·
+           │         spans           ALL               ·                      ·
+           └── scan  ·               ·                 (k, v)                 k!=NULL; key(k); +k
+·                    table           kv@primary        ·                      ·
+·                    spans           ALL               ·                      ·
 
 # The underlying index can be forced manually, of course.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv@foo a NATURAL JOIN kv@foo ORDER BY INDEX kv@foo
 ----
-nosort               ·               ·                  (k)                             k!=NULL
- │                   order           -v                 ·                               ·
- └── render          ·               ·                  (k, v)                          k!=NULL; v!=NULL; -v
-      │              render 0        a.k                ·                               ·
-      │              render 1        test.public.kv.v   ·                               ·
-      └── join       ·               ·                  (k, v[omitted], k[omitted], v)  k=k; v=v; k!=NULL; v!=NULL; -v
-           │         type            inner              ·                               ·
-           │         equality        (k, v) = (k, v)    ·                               ·
-           │         mergeJoinOrder  -"(v=v)",+"(k=k)"  ·                               ·
-           ├── scan  ·               ·                  (k, v)                          k!=NULL; weak-key(k,v); -v,+k
-           │         table           kv@foo             ·                               ·
-           │         spans           ALL                ·                               ·
-           └── scan  ·               ·                  (k, v)                          k!=NULL; weak-key(k,v); -v,+k
-·                    table           kv@foo             ·                               ·
-·                    spans           ALL                ·                               ·
+nosort               ·               ·                  (k)                    k!=NULL
+ │                   order           -v,+k              ·                      ·
+ └── render          ·               ·                  (k, v, k)              k=k; k!=NULL; v!=NULL; -v,+k
+      │              render 0        a.k                ·                      ·
+      │              render 1        test.public.kv.v   ·                      ·
+      │              render 2        test.public.kv.k   ·                      ·
+      └── join       ·               ·                  (k, v[omitted], k, v)  k=k; v=v; k!=NULL; v!=NULL; -v,+k
+           │         type            inner              ·                      ·
+           │         equality        (k, v) = (k, v)    ·                      ·
+           │         mergeJoinOrder  -"(v=v)",+"(k=k)"  ·                      ·
+           ├── scan  ·               ·                  (k, v)                 k!=NULL; weak-key(k,v); -v,+k
+           │         table           kv@foo             ·                      ·
+           │         spans           ALL                ·                      ·
+           └── scan  ·               ·                  (k, v)                 k!=NULL; weak-key(k,v); -v,+k
+·                    table           kv@foo             ·                      ·
+·                    spans           ALL                ·                      ·

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -15,6 +15,9 @@
 package optbuilder
 
 import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -45,14 +48,86 @@ func (b *Builder) buildOrderBy(orderBy tree.OrderBy, inScope, projectionsScope *
 	orderByScope := inScope.push()
 	orderByScope.physicalProps.Ordering.Columns = make([]props.OrderingColumnChoice, 0, len(orderBy))
 
-	// TODO(rytaft): rewrite ORDER BY if it uses ORDER BY INDEX tbl@idx or
-	// ORDER BY PRIMARY KEY syntax.
-
 	for i := range orderBy {
 		b.buildOrdering(orderBy[i], inScope, projectionsScope, orderByScope)
 	}
 
 	b.buildOrderByProject(projectionsScope, orderByScope)
+}
+
+// findIndexByName returns an index in the table with the given name. If the
+// name is empty the primary index is returned.
+func (b *Builder) findIndexByName(table opt.Table, name tree.UnrestrictedName) (opt.Index, error) {
+	if name == "" {
+		return table.Index(0), nil
+	}
+
+	for i, n := 0, table.IndexCount(); i < n; i++ {
+		idx := table.Index(i)
+		if string(name) == idx.IdxName() {
+			return idx, nil
+		}
+	}
+
+	return nil, fmt.Errorf(`index %q not found`, name)
+}
+
+// addOrderingColumn adds expr as an ordering column to orderByScope, if it is
+// already projected in projectionsScope then that projection is re-used.
+func (b *Builder) addOrderingColumn(
+	expr tree.TypedExpr, inScope, projectionsScope, orderByScope *scope,
+) {
+	// Use an existing projection if possible. Otherwise, build a new
+	// projection.
+	if col := projectionsScope.findExistingCol(expr); col != nil {
+		orderByScope.cols = append(orderByScope.cols, *col)
+	} else {
+		b.buildScalarProjection(expr, "", inScope, orderByScope)
+	}
+}
+
+// buildOrderByIndex appends to the ordering a column for each indexed column
+// in the specified index, including the implicit primary key columns.
+func (b *Builder) buildOrderByIndex(
+	order *tree.Order, inScope, projectionsScope, orderByScope *scope,
+) {
+	tn, err := order.Table.Normalize()
+	if err != nil {
+		panic(builderError{err})
+	}
+
+	tab := b.resolveTable(tn)
+
+	index, err := b.findIndexByName(tab, order.Index)
+	if err != nil {
+		panic(builderError{err})
+	}
+
+	start := len(orderByScope.cols)
+	// Append each key column from the index (including the implicit primary key
+	// columns) to the ordering scope.
+	for i, n := 0, index.KeyColumnCount(); i < n; i++ {
+		// Columns which are indexable are always orderable.
+		col := index.Column(i)
+		if err != nil {
+			panic(err)
+		}
+
+		expr := inScope.resolveType(tree.NewColumnItem(tab.TabName(), tree.Name(col.Column.ColName())), types.Any)
+		b.addOrderingColumn(expr, inScope, projectionsScope, orderByScope)
+	}
+
+	// Add the new columns to the ordering.
+	for i := start; i < len(orderByScope.cols); i++ {
+		desc := index.Column(i - start).Descending
+
+		// DESC inverts the order of the index.
+		if order.Direction == tree.Descending {
+			desc = !desc
+		}
+
+		orderByScope.physicalProps.Ordering.AppendCol(orderByScope.cols[i].id, desc)
+	}
 }
 
 // buildOrdering sets up the projection(s) of a single ORDER BY argument.
@@ -61,7 +136,8 @@ func (b *Builder) buildOrderBy(orderBy tree.OrderBy, inScope, projectionsScope *
 // The projection columns are added to the orderByScope.
 func (b *Builder) buildOrdering(order *tree.Order, inScope, projectionsScope, orderByScope *scope) {
 	if order.OrderType == tree.OrderByIndex {
-		panic(unimplementedf("ORDER BY index not supported"))
+		b.buildOrderByIndex(order, inScope, projectionsScope, orderByScope)
+		return
 	}
 
 	// Unwrap parenthesized expressions like "((a))" to "a".
@@ -127,14 +203,7 @@ func (b *Builder) buildOrdering(order *tree.Order, inScope, projectionsScope, or
 	for _, e := range exprs {
 		// Ensure we can order on the given column.
 		ensureColumnOrderable(e)
-
-		// Use an existing projection if possible. Otherwise, build a new
-		// projection.
-		if col := projectionsScope.findExistingCol(e); col != nil {
-			orderByScope.cols = append(orderByScope.cols, *col)
-		} else {
-			b.buildScalarProjection(e, "", inScope, orderByScope)
-		}
+		b.addOrderingColumn(e, inScope, projectionsScope, orderByScope)
 	}
 
 	// Add the new columns to the ordering.

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -61,16 +61,8 @@ func (b *Builder) buildTable(texpr tree.TableExpr, inScope *scope) (outScope *sc
 		if err != nil {
 			panic(builderError{err})
 		}
-		tab, err := b.catalog.FindTable(b.ctx, tn)
-		if err != nil {
-			pgerr, ok := err.(*pgerror.Error)
-			if ok && pgerr.Code == pgerror.CodeWrongObjectTypeError {
-				// Remap wrong object error to unimplemented error.
-				panic(unimplementedf("views and sequences are not supported"))
-			}
 
-			panic(builderError{err})
-		}
+		tab := b.resolveTable(tn)
 		return b.buildScan(tab, tn, inScope)
 
 	case *tree.ParenTableExpr:

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -762,12 +762,18 @@ sort
 build
 SELECT a FROM abc ORDER BY INDEX abc@bc
 ----
-error (0A000): ORDER BY index not supported
+sort
+ ├── columns: a:1(int!null)
+ ├── ordering: +2,+3
+ └── project
+      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      └── scan abc
+           └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
 
 build
 SELECT a FROM abc ORDER BY PRIMARY KEY a
 ----
-error (0A000): ORDER BY index not supported
+error: table "a" not found
 
 exec-ddl
 CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
@@ -796,7 +802,8 @@ CREATE TABLE abcd (
   b INT,
   c INT,
   d INT,
-  INDEX abc (a, b, c)
+  INDEX abc (a, b, c),
+  INDEX bcd (b, c DESC, d)
 )
 ----
 TABLE abcd
@@ -806,10 +813,15 @@ TABLE abcd
  ├── d int
  ├── INDEX primary
  │    └── a int not null
- └── INDEX abc
-      ├── a int not null
+ ├── INDEX abc
+ │    ├── a int not null
+ │    ├── b int
+ │    └── c int
+ └── INDEX bcd
       ├── b int
-      └── c int
+      ├── c int desc
+      ├── d int
+      └── a int not null
 
 # Verify that projections after ORDER BY perform correctly (i.e., the outer
 # expression does not guarantee it will apply the ORDER BY).
@@ -898,6 +910,115 @@ limit
  │         ├── columns: block_id:1(int!null) writer_id:2(string!null) block_num:3(int!null) raw_bytes:4(bytes)
  │         └── ordering: +1,+2,+3
  └── const: 1 [type=int]
+
+build
+SELECT a FROM abcd ORDER BY PRIMARY KEY abcd
+----
+project
+ ├── columns: a:1(int!null)
+ ├── ordering: +1
+ └── scan abcd
+      ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+      └── ordering: +1
+
+build
+SELECT a FROM abcd ORDER BY b, PRIMARY KEY abcd
+----
+sort
+ ├── columns: a:1(int!null)
+ ├── ordering: +2,+1
+ └── project
+      ├── columns: a:1(int!null) b:2(int)
+      └── scan abcd
+           └── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+
+build
+SELECT a FROM abcd ORDER BY INDEX abcd@abc
+----
+sort
+ ├── columns: a:1(int!null)
+ ├── ordering: +1,+2,+3
+ └── project
+      ├── columns: a:1(int!null) b:2(int) c:3(int)
+      └── scan abcd
+           └── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+
+build
+SELECT a FROM abcd ORDER BY INDEX abcd@abc DESC
+----
+sort
+ ├── columns: a:1(int!null)
+ ├── ordering: -1,-2,-3
+ └── project
+      ├── columns: a:1(int!null) b:2(int) c:3(int)
+      └── scan abcd
+           └── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+
+build
+SELECT a FROM abcd AS foo ORDER BY INDEX abcd@abc DESC
+----
+error (42P01): no data source matches prefix: t.public.abcd
+
+build
+SELECT a FROM abcd AS foo ORDER BY INDEX foo@abc DESC
+----
+error: table "foo" not found
+
+build
+SELECT a FROM abcd ORDER BY INDEX abcd@bcd
+----
+sort
+ ├── columns: a:1(int!null)
+ ├── ordering: +2,-3,+4,+1
+ └── scan abcd
+      └── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+
+build
+SELECT a FROM abcd ORDER BY INDEX abcd@bcd DESC
+----
+sort
+ ├── columns: a:1(int!null)
+ ├── ordering: -2,+3,-4,-1
+ └── scan abcd
+      └── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+
+
+build
+SELECT a FROM abcd ORDER BY INDEX abcd@nonexistent
+----
+error: index "nonexistent" not found
+
+build
+SELECT a FROM t.public.abcd ORDER BY INDEX t.public.abcd@bcd
+----
+sort
+ ├── columns: a:1(int!null)
+ ├── ordering: +2,-3,+4,+1
+ └── scan abcd
+      └── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+
+build
+SELECT a FROM t.abcd ORDER BY INDEX t.abcd@bcd
+----
+sort
+ ├── columns: a:1(int!null)
+ ├── ordering: +2,-3,+4,+1
+ └── scan abcd
+      └── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+
+build
+SELECT a FROM public.abcd ORDER BY INDEX public.abcd@bcd
+----
+sort
+ ├── columns: a:1(int!null)
+ ├── ordering: +2,-3,+4,+1
+ └── scan abcd
+      └── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+
+build
+SELECT a FROM (SELECT a FROM abcd) ORDER BY INDEX abcd@bcd
+----
+error (42P01): no data source matches prefix: t.public.abcd
 
 # Drop previous table with same name, but different schema.
 exec-ddl

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -341,3 +341,18 @@ func (b *Builder) assertNoAggregationOrWindowing(expr tree.Expr, op string) {
 		})
 	}
 }
+
+// resolveTable returns the table in the catalog with the given name.
+func (b *Builder) resolveTable(tn *tree.TableName) opt.Table {
+	tab, err := b.catalog.FindTable(b.ctx, tn)
+	if err != nil {
+		pgerr, ok := err.(*pgerror.Error)
+		if ok && pgerr.Code == pgerror.CodeWrongObjectTypeError {
+			// Remap wrong object error to unimplemented error.
+			panic(unimplementedf("views and sequences are not supported"))
+		}
+
+		panic(builderError{err})
+	}
+	return tab
+}

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -139,8 +139,13 @@ func (tc *Catalog) ExecuteDDL(sql string) (string, error) {
 // qualifyTableName updates the given table name to include catalog and schema
 // if not already included.
 func (tc *Catalog) qualifyTableName(name *tree.TableName) {
-	if name.ExplicitSchema {
-		if name.ExplicitCatalog {
+	hadExplicitSchema := name.ExplicitSchema
+	hadExplicitCatalog := name.ExplicitCatalog
+	name.ExplicitSchema = true
+	name.ExplicitCatalog = true
+
+	if hadExplicitSchema {
+		if hadExplicitCatalog {
 			// Already 3 parts: nothing to do.
 			return
 		}
@@ -154,7 +159,6 @@ func (tc *Catalog) qualifyTableName(name *tree.TableName) {
 		// Compatibility with CockroachDB v1.1: use D.public.T.
 		name.CatalogName = name.SchemaName
 		name.SchemaName = tree.PublicSchemaName
-		name.ExplicitCatalog = true
 		return
 	}
 

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -105,6 +105,11 @@ func newOptTable(
 	name *tree.TableName, statsCache *stats.TableStatisticsCache, desc *sqlbase.TableDescriptor,
 ) *optTable {
 	ot := &optTable{name: *name}
+
+	// The opt.Table interface requires that table names be fully qualified.
+	ot.name.ExplicitSchema = true
+	ot.name.ExplicitCatalog = true
+
 	ot.init(statsCache, desc)
 	return ot
 }

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -438,6 +438,19 @@ func (p *planner) rewriteIndexOrderings(
 				})
 			}
 
+			for _, id := range idxDesc.ExtraColumnIDs {
+				col, err := desc.FindColumnByID(id)
+				if err != nil {
+					return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "column with ID %d not found", id)
+				}
+
+				newOrderBy = append(newOrderBy, &tree.Order{
+					OrderType: tree.OrderByColumn,
+					Expr:      tree.NewColumnItem(tn, tree.Name(col.Name)),
+					Direction: chooseDirection(o.Direction == tree.Descending, sqlbase.IndexDescriptor_ASC),
+				})
+			}
+
 		default:
 			return nil, errors.Errorf("unknown ORDER BY specification: %s", tree.ErrString(&orderBy))
 		}


### PR DESCRIPTION
This commit introduces support for ORDER BY INDEX into the optimizer. It
also slightly changes the behaviour of ORDER BY INDEX in the heuristic
planner.

Previously, ORDER BY INDEX would imply an ordering only by the columns
explicitly specified in the definition of the index. Now, we add the
implicitly added primary key columns as well.

It's not clear if the previous behaviour was more desirable (and I don't
have a strong opinion) but it has a handful of desirable properties:
* It doesn't require extending any of the interfaces in the opt package
  (namely, otherwise we would need to extend opt.Index with something like
  `ExplicitColumns`),
* it now meets the stated goal of guaranteeing an ordering (because
  every such ordering now contains a key),
* it's a strengthening of the previous behaviour, the semantics
  guaranteed before are still guaranteed.

However, I can see some downsides:
* It requires fetching more columns in some cases,
* it is a stronger guarantee,
* it leaks the way we order indexes internally.

Release note (sql change): ORDER BY INDEX now implies an ordering by the
implicit primary key columns appended to indexes.