### PR TITLE
roachtest: graduate various unstable tests to stable

### DIFF
--- a/pkg/cmd/roachtest/disk_space.go
+++ b/pkg/cmd/roachtest/disk_space.go
@@ -311,6 +311,7 @@ func registerDiskUsage(r *registry) {
 				Name:       fmt.Sprintf("disk_space/tc=%s", testCase.name),
 				Nodes:      nodes(numNodes),
 				MinVersion: "2.1", // cockroach debug ballast
+				Stable:     true,  // DO NOT COPY to new tests
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					if local {
 						duration = 30 * time.Minute

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -154,6 +154,7 @@ gc:
 		Name:       fmt.Sprintf("drop/tpcc/w=%d,nodes=%d", warehouses, numNodes),
 		MinVersion: `v2.1.0`,
 		Nodes:      nodes(numNodes),
+		Stable:     true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			// NB: this is likely not going to work out in `-local` mode. Edit the
 			// numbers during iteration.

--- a/pkg/cmd/roachtest/election.go
+++ b/pkg/cmd/roachtest/election.go
@@ -26,7 +26,7 @@ func registerElectionAfterRestart(r *registry) {
 	r.Add(testSpec{
 		Name:   "election-after-restart",
 		Nodes:  nodes(3),
-		Stable: false, // Introduced 2018-06-06
+		Stable: true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			t.Status("starting up")
 			c.Put(ctx, cockroach, "./cockroach")

--- a/pkg/cmd/roachtest/encryption.go
+++ b/pkg/cmd/roachtest/encryption.go
@@ -92,6 +92,7 @@ func registerEncryption(r *registry) {
 			Name:       fmt.Sprintf("encryption/nodes=%d", n),
 			MinVersion: "v2.1.0",
 			Nodes:      nodes(n),
+			Stable:     true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runEncryption(ctx, t, c)
 			},

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -67,6 +67,7 @@ func registerKV(r *registry) {
 					Name:       fmt.Sprintf("kv%d/encrypt=%t/nodes=%d", p, e, n),
 					MinVersion: minVersion,
 					Nodes:      nodes(n+1, cpu(8)),
+					Stable:     true, // DO NOT COPY to new tests
 					Run: func(ctx context.Context, t *test, c *cluster) {
 						runKV(ctx, t, c, p, startArgs(fmt.Sprintf("--encrypt=%t", e)))
 					},

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -133,8 +133,9 @@ func registerTPCCBenchSpec(r *registry, b tpccBenchSpec) {
 	}
 
 	r.Add(testSpec{
-		Name:  name,
-		Nodes: nodeCount,
+		Name:   name,
+		Nodes:  nodeCount,
+		Stable: true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCCBench(ctx, t, c, b)
 		},


### PR DESCRIPTION
```
disk_space/tc=update_hot_key
disk_space/tc=update_hot_key_percent
disk_space/tc=update_mix
disk_space/tc=update_mix_hot_key
disk_space/tc=update_mix_hot_key_percent
disk_space/tc=update_mix_percent
drop/tpcc/w=100,nodes=9
election-after-restart
encryption/nodes=1
kv0/encrypt=false/nodes=1
kv0/encrypt=false/nodes=3
kv0/encrypt=true/nodes=1
kv0/encrypt=true/nodes=3
kv95/encrypt=false/nodes=1
kv95/encrypt=false/nodes=3
kv95/encrypt=true/nodes=1
kv95/encrypt=true/nodes=3
tpccbench/nodes=3/cpu=4
```

Release note: None