### PR TITLE
kv,storage: disable pipelining in merge transaction

### DIFF
--- a/pkg/internal/client/sender.go
+++ b/pkg/internal/client/sender.go
@@ -78,6 +78,11 @@ type TxnSender interface {
 	// if this method is invoked multiple times, the most recent callback
 	// is the only one which will be invoked.
 	OnFinish(func(error))
+	// DisablePipelining instructs the TxnSender not to pipeline requests. It
+	// should rarely be necessary to call this method. It is only recommended for
+	// transactions that need extremely precise control over the request ordering,
+	// like the transaction that merges ranges together.
+	DisablePipelining()
 }
 
 // TxnSenderFactory is the interface used to create new instances
@@ -128,6 +133,9 @@ func (f TxnSenderFunc) AugmentMeta(context.Context, roachpb.TxnCoordMeta) { pani
 
 // OnFinish is part of the TxnSender interface.
 func (f TxnSenderFunc) OnFinish(_ func(error)) { panic("unimplemented") }
+
+// DisablePipelining is part of the TxnSender interface.
+func (f TxnSenderFunc) DisablePipelining() { panic("unimplemented") }
 
 // TxnSenderFactoryFunc is an adapter to allow the use of ordinary functions
 // as TxnSenderFactories. This is a helper mechanism to facilitate testing.

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -369,6 +369,23 @@ func (txn *Txn) SetSystemConfigTrigger() error {
 	return nil
 }
 
+// DisablePipelining instructs the transaction not to pipeline requests. It
+// should rarely be necessary to call this method. It is only recommended for
+// transactions that need extremely precise control over the request ordering,
+// like the transaction that merges ranges together.
+//
+// DisablePipelining must be called before any operations are performed on the
+// transaction.
+func (txn *Txn) DisablePipelining() error {
+	txn.mu.Lock()
+	defer txn.mu.Unlock()
+	if txn.mu.active {
+		return errors.Errorf("cannot disable pipelining on a running transaction")
+	}
+	txn.mu.sender.DisablePipelining()
+	return nil
+}
+
 // Proto returns the transactions underlying protocol buffer. It is not thread-safe,
 // only use if you know that no requests are executing concurrently.
 //

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -496,6 +496,11 @@ func (tc *TxnCoordSender) OnFinish(onFinishFn func(error)) {
 	tc.mu.onFinishFn = onFinishFn
 }
 
+// DisablePipelining is part of the client.TxnSender interface.
+func (tc *TxnCoordSender) DisablePipelining() {
+	tc.interceptorAlloc.txnPipeliner.disabled = true
+}
+
 // Send implements the batch.Sender interface.
 //
 // Read/write mutating requests have their key or key range added to the

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
@@ -1722,5 +1723,72 @@ func TestIntentTrackingBeforeBeginTransaction(t *testing.T) {
 
 	if numSpans := len(tcs.GetMeta().Intents); numSpans != 1 {
 		t.Fatalf("expected 1 intent span, got: %d", numSpans)
+	}
+}
+
+// TestTxnCoordSenderPipelining verifies that transactional pipelining of writes
+// is enabled by default in a transaction and is disabled after
+// DisablePipelining is called. It also verifies that DisablePipelining returns
+// an error if the transaction has already performed an operation.
+func TestTxnCoordSenderPipelining(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	s := createTestDB(t)
+	defer s.Stop()
+	distSender := s.DB.GetFactory().(*TxnCoordSenderFactory).NonTransactionalSender()
+
+	var calls []roachpb.Method
+	var senderFn client.SenderFunc = func(
+		ctx context.Context, ba roachpb.BatchRequest,
+	) (*roachpb.BatchResponse, *roachpb.Error) {
+		calls = append(calls, ba.Methods()...)
+		return distSender.Send(ctx, ba)
+	}
+
+	ambientCtx := log.AmbientContext{Tracer: tracing.NewTracer()}
+	tsf := NewTxnCoordSenderFactory(TxnCoordSenderFactoryConfig{
+		AmbientCtx: ambientCtx,
+		Settings:   s.Cfg.Settings,
+		Clock:      s.Clock,
+		Stopper:    s.Stopper,
+	}, senderFn)
+	db := client.NewDB(ambientCtx, tsf, s.Clock)
+
+	err := db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		return txn.Put(ctx, "key", "val")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		if err := txn.DisablePipelining(); err != nil {
+			return err
+		}
+		return txn.Put(ctx, "key", "val")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, []roachpb.Method{
+		roachpb.BeginTransaction, roachpb.Put, roachpb.QueryIntent, roachpb.EndTransaction,
+		roachpb.BeginTransaction, roachpb.Put, roachpb.EndTransaction,
+	}, calls)
+
+	for _, action := range []func(ctx context.Context, txn *client.Txn) error{
+		func(ctx context.Context, txn *client.Txn) error { return txn.Put(ctx, "key", "val") },
+		func(ctx context.Context, txn *client.Txn) error { _, err := txn.Get(ctx, "key"); return err },
+	} {
+		err = db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+			if err := action(ctx, txn); err != nil {
+				t.Fatal(err)
+			}
+			return txn.DisablePipelining()
+		})
+		if exp := "cannot disable pipelining on a running transaction"; !testutils.IsError(err, exp) {
+			t.Fatalf("expected %q error, but got %v", exp, err)
+		}
 	}
 }

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -894,10 +894,14 @@ func TestStoreRangeMergeConcurrentRequests(t *testing.T) {
 	storeCfg.TestingKnobs.DisableReplicateQueue = true
 
 	var mtc *multiTestContext
-	storeCfg.TestingKnobs.TestingRequestFilter = func(ba roachpb.BatchRequest) *roachpb.Error {
-		if ba.IsSingleGetSnapshotForMergeRequest() && rand.Int()%4 == 0 {
-			// Before every few GetSnapshotForMerge requests, expire all range leases.
-			// This makes the following sequence of events quite likely:
+	storeCfg.TestingKnobs.TestingResponseFilter = func(
+		ba roachpb.BatchRequest, _ *roachpb.BatchResponse,
+	) *roachpb.Error {
+		del := ba.Requests[0].GetDelete()
+		if del != nil && bytes.HasSuffix(del.Key, keys.LocalRangeDescriptorSuffix) && rand.Int()%4 == 0 {
+			// After every few deletions of the local range descriptor, expire all
+			// range leases. This makes the following sequence of events quite
+			// likely:
 			//
 			//     1. The merge transaction begins and lays down deletion intents for
 			//        the meta2 and local copies of the RHS range descriptor.
@@ -909,7 +913,10 @@ func TestStoreRangeMergeConcurrentRequests(t *testing.T) {
 			//        channel.
 			//     4. The Get request blocks on the newly installed mergeComplete
 			//        channel.
-			//     5. The GetSnapshotForMerge request arrives.
+			//     5. The GetSnapshotForMerge request arrives. (Or, if the merge
+			//        transaction is incorrectly pipelined, the QueryIntent request
+			//        for the RHS range descriptor key that precedes the
+			//        GetSnapshotForMerge request arrives.)
 			//
 			// This scenario previously caused deadlock. The merge was not able to
 			// complete until the GetSnapshotForMerge request completed, but the

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -114,6 +114,8 @@ func (db *testSender) AugmentMeta(context.Context, roachpb.TxnCoordMeta) { panic
 
 func (db *testSender) OnFinish(func(error)) { panic("unimplemented") }
 
+func (db *testSender) DisablePipelining() { panic("unimplemented") }
+
 // Send forwards the call to the single store. This is a poor man's
 // version of kv.TxnCoordSender, but it serves the purposes of
 // supporting tests in this package. Transactions are not supported.


### PR DESCRIPTION
It turns out that pipelining is fundamentally incompatible with merge
transactions. The extra QueryIntent requests generated by pipelining can
get routed to a RHS that is currently blocked for merging and wedge the
merge. Consider the following sequence of events:

  1. The merge transaction begins and lays down intents on the meta2 and
     local copy of the RHS range descriptor using asynchronous commits.

  2. The RHS loses its lease.

  3. The merge transaction sends a GetSnapshotForMergeRequest. The
     pipeliner injects two QueryIntent requests, one to the meta2 range
     descriptor and one to the local range descriptor on the RHS, as
     non-transactional requests always flush the pipeline.

  4. The QueryIntent request hits the RHS and triggers a lease
     acquisition. The lease acquisition notices that the local range
     descriptor has a deletion intent, infers that a merge is in
     progress, and blocks all traffic, except for GetSnapshotForMerge
     requests.

GetSnapshotForMerge requests are allowed to proceed even when the range
is blocked for merging but QueryIntent requests are not. We can't, in
general, allow QueryIntent requests through, as we might return stale
data if the merge has already committed and the LHS is processing
new writes. We could, I think, allow QueryIntents for the local range
descriptor to proceed, but that's a very-specific corner case and hard
to reason about.

Just disable pipelining in the merge transaction to sidestep the issue.

One other option: we could allow the RHS to serve reads up until the
commit timestamp of the merge transaction. That would allow the
GetSnapshotForMerge and QueryIntent requests from the merge transaction
through, as well as any other read traffic executing beneath the merge
transaction's timestamp. The downside is that the new leaseholder would
have to wait out the full clock offset after the merge txn committed to
serve any writes. (Just like the lease stasis period.) It was decided
that this option was too disruptive and complex to pursue for the time
being.

Fix #27820.