### PR TITLE
opt: Add additional decorrelation rules

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/subquery_correlated
+++ b/pkg/sql/logictest/testdata/logic_test/subquery_correlated
@@ -682,6 +682,34 @@ GROUP BY c.c_id, o.ship;
 1  CA    3  1
 2  CA    1  3
 
+# Customers with their orders (even if no orders), plus max of bill and ship
+# states for that customer (alphabetically).
+query IIT
+SELECT
+    c.c_id,
+    o.o_id,
+    (
+        SELECT MAX(CASE WHEN c2.bill > o2.ship THEN c2.bill ELSE o2.ship END)
+        FROM c AS c2, o AS o2
+        WHERE c2.c_id=o2.c_id AND c2.c_id=c.c_id
+    )
+FROM c
+LEFT JOIN o
+ON c.c_id=o.c_id
+ORDER BY c.c_id, o.o_id
+----
+1  10    CA
+1  20    CA
+1  30    CA
+2  40    TX
+2  50    TX
+2  60    TX
+3  NULL  NULL
+4  70    WY
+4  80    WY
+5  NULL  NULL
+6  90    WA
+
 # ConcatAgg prevents decorrelation.
 statement error could not decorrelate subquery
 SELECT (SELECT concat_agg(ship || ' ') FROM o WHERE o.c_id=c.c_id)

--- a/pkg/sql/logictest/testdata/logic_test/subquery_correlated
+++ b/pkg/sql/logictest/testdata/logic_test/subquery_correlated
@@ -302,6 +302,35 @@ WHERE
 2  TX
 4  TX
 
+# Customers that have a bill state equal to the max ship state of all their
+# orders (alphabetically).
+query IT rowsort
+SELECT c_id, bill
+FROM c AS c2
+WHERE EXISTS
+(
+    SELECT * FROM c WHERE bill=(SELECT max(ship) FROM o WHERE c_id=c2.c_id AND c_id=c.c_id)
+)
+----
+1  CA
+2  TX
+
+# Customers that have at least one order shipped to their billing state (or if
+# the ship state is null).
+query IT rowsort
+SELECT c_id, bill
+FROM c AS c2
+WHERE EXISTS
+(
+    SELECT *
+    FROM (SELECT c_id, coalesce(ship, bill) AS state FROM o WHERE c_id=c2.c_id) AS o
+    WHERE state=bill
+)
+----
+1  CA
+2  TX
+4  TX
+
 # Max1Row prevents decorrelation.
 statement error could not decorrelate subquery
 SELECT *
@@ -689,7 +718,7 @@ SELECT
     c.c_id,
     o.o_id,
     (
-        SELECT MAX(CASE WHEN c2.bill > o2.ship THEN c2.bill ELSE o2.ship END)
+        SELECT max(CASE WHEN c2.bill > o2.ship THEN c2.bill ELSE o2.ship END)
         FROM c AS c2, o AS o2
         WHERE c2.c_id=o2.c_id AND c2.c_id=c.c_id
     )

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -219,10 +219,9 @@ func (c *CustomFuncs) HasZeroOrOneRow(group memo.GroupID) bool {
 	return c.f.mem.GroupProperties(group).Relational.Cardinality.IsZeroOrOne()
 }
 
-// HasOneOrMoreRows returns true if the given group will always return at least
-// one row.
-func (c *CustomFuncs) HasOneOrMoreRows(group memo.GroupID) bool {
-	return !c.f.mem.GroupProperties(group).Relational.Cardinality.CanBeZero()
+// CanHaveZeroRows returns true if the given group might return zero rows.
+func (c *CustomFuncs) CanHaveZeroRows(group memo.GroupID) bool {
+	return c.f.mem.GroupProperties(group).Relational.Cardinality.CanBeZero()
 }
 
 // HasCorrelatedSubquery returns true if the given scalar group contains a

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -90,7 +90,7 @@
 #
 # Citations: [3] (see identity #4)
 [TryDecorrelateProject, Normalize]
-(InnerJoin | InnerJoinApply | RightJoin | RightJoinApply
+(InnerJoin | InnerJoinApply
     $left:*
     $right:* &
         (HasOuterCols $right) &

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -110,21 +110,22 @@
     $on
 )
 
-# TryDecorrelateProjectSelect tries to decorrelate a Select operator that sits
-# below a LeftJoin/Project operator combo. The Project operator itself can't be
-# reordered above the LeftJoin like it can in the InnerJoin case. However, the
-# Select filter can be merged with the LeftJoin filter, which is enough to
-# decorrelate in several useful cases.
+# TryDecorrelateProjectSelect tries to decorrelate by hoisting a Select operator
+# that sits below a LeftJoin/Project operator combo. The Project operator itself
+# can't be reordered above the LeftJoin like it can in the InnerJoin case.
+# However, the Select filter can be merged with the LeftJoin filter, which is
+# enough to decorrelate in several useful cases.
 #
 # See the comment for TryDecorrelateSelect for an explanation of why the
 # DetectCycle and HighPriority tags are in use.
 [TryDecorrelateProjectSelect, Normalize, DetectCycle, HighPriority]
-(LeftJoin | LeftJoinApply
+(LeftJoinApply
     $left:*
     $right:(Project
-        $projectInput:* &
-            (HasOuterCols $projectInput) &
-            (Select $selectInput:* $filters:*)
+        (Select
+            $selectInput:*
+            $filters:* & ^(IsBoundBy $filters $selectInput)
+        )
         $projections:*
     )
     $on:*
@@ -138,6 +139,45 @@
             (ProjectColsFromBoth $projections $selectInput)
         )
         (ConcatFilters $on $filters)
+    )
+    (ProjectColsFromBoth $left $right)
+)
+
+# TryDecorrelateProjectInnerJoin tries to decorrelate by hoisting the filter of
+# an InnerJoin operator that sits below a LeftJoin/Project operator combo. The
+# Project operator itself can't be reordered above the LeftJoin like it can in
+# the InnerJoin case. However, the InnerJoin filter can be merged with the
+# LeftJoin filter, which is enough to decorrelate in several useful cases. This
+# rule works similarly to TryDecorrelateProjectSelect.
+#
+# See the comment for TryDecorrelateSelect for an explanation of why the
+# DetectCycle and HighPriority tags are in use.
+[TryDecorrelateProjectInnerJoin, Normalize, DetectCycle, HighPriority]
+(LeftJoinApply
+    $left:*
+    $right:(Project
+        $join:(InnerJoin | InnerJoinApply
+            $innerLeft:*
+            $innerRight:*
+            $innerOn:* & ^(IsBoundBy2 $innerOn $innerLeft $innerRight)
+        )
+        $projections:*
+    )
+    $on:*
+)
+=>
+(Project
+    ((OpName)
+        $left
+        (Project
+            ((OpName $join)
+                $innerLeft
+                $innerRight
+                (True)
+            )
+            (ProjectColsFromBoth $projections $join)
+        )
+        (ConcatFilters $on $innerOn)
     )
     (ProjectColsFromBoth $left $right)
 )

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -167,7 +167,7 @@
 )
 =>
 (Project
-    ((OpName)
+    (LeftJoinApply
         $left
         (Project
             ((OpName $join)
@@ -271,7 +271,7 @@
             $input
             (True)
         )
-        (AppendNonKeyCols $newLeft $aggregations)
+        (AppendAggregatedNonKeyCols $aggregations $newLeft)
         (GroupByUnionKey $newLeft $def)
     )
     $on
@@ -345,10 +345,36 @@
             $newRight:(EnsureNotNullIfCountRows $input $aggregations)
             (True)
         )
-        (AppendNonKeyCols $newLeft (TranslateCountRows $newRight $aggregations))
+        (AppendAggregatedNonKeyCols (TranslateCountRows $newRight $aggregations) $newLeft)
         (GroupByKey $newLeft)
     )
     $on
+)
+
+# TryDecorrelateSemiJoin maps a SemiJoin to an equivalent GroupBy/InnerJoin
+# complex in hopes of triggering further rules that will ultimately decorrelate
+# the query. Once this rule fires, a corresponding InnerJoin decorrelation rule
+# will match (i.e. TryDecorrelateGroupBy or TryDecorrelateProject).
+#
+# Citations: [5]
+[TryDecorrelateSemiJoin, Normalize]
+(SemiJoin | SemiJoinApply
+    $left:*
+    $right:* &
+        (HasOuterCols $right) &
+        (CanHaveZeroRows $right) & # Let EliminateExistsGroupBy match instead.
+        (GroupBy | Project)
+    $on:*
+)
+=>
+(GroupBy
+    (InnerJoinApply
+        $newLeft:(EnsureKey $left)
+        $right
+        $on
+    )
+    (AggregateNonKeyCols $newLeft)
+    (GroupByKey $newLeft)
 )
 
 # HoistSelectExists extracts existential subqueries from Select filters,

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -119,7 +119,7 @@
 # See the comment for TryDecorrelateSelect for an explanation of why the
 # DetectCycle and HighPriority tags are in use.
 [TryDecorrelateProjectSelect, Normalize, DetectCycle, HighPriority]
-(LeftJoin | LeftJoinApply | FullJoin | FullJoinApply
+(LeftJoin | LeftJoinApply
     $left:*
     $right:(Project
         $projectInput:* &

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -216,7 +216,7 @@
 [SimplifyLeftJoin, Normalize]
 (LeftJoin | LeftJoinApply | FullJoin | FullJoinApply
     $left:*
-    $right:* & (HasOneOrMoreRows $right)
+    $right:* & ^(CanHaveZeroRows $right)
     $on:(True)
 )
 =>
@@ -234,7 +234,7 @@
 # present.
 [SimplifyRightJoin, Normalize]
 (RightJoin | RightJoinApply | FullJoin | FullJoinApply
-    $left:* & (HasOneOrMoreRows $left)
+    $left:* & ^(CanHaveZeroRows $left)
     $right:*
     $on:(True)
 )
@@ -251,7 +251,7 @@
 [EliminateSemiJoin, Normalize]
 (SemiJoin | SemiJoinApply
     $left:*
-    $right:* & (HasOneOrMoreRows $right)
+    $right:* & ^(CanHaveZeroRows $right)
     (True)
 )
 =>

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -544,7 +544,7 @@ opt
 SELECT k FROM a
 WHERE EXISTS
 (
-    SELECT * FROM xy RIGHT JOIN (SELECT u, u/1.1 AS div FROM uv WHERE i=5) ON x=div
+    SELECT * FROM xy INNER JOIN (SELECT u, u/1.1 AS div FROM uv WHERE i=5) ON x=div
 )
 ----
 project
@@ -563,26 +563,64 @@ project
       │    ├── outer: (2)
       │    ├── fd: (6)==(10), (10)==(6)
       │    ├── project
-      │    │    ├── columns: div:10(decimal) x:6(int)
+      │    │    ├── columns: div:10(decimal) x:6(int!null)
       │    │    ├── outer: (2)
-      │    │    ├── right-join
-      │    │    │    ├── columns: x:6(int) u:8(int!null)
+      │    │    ├── inner-join
+      │    │    │    ├── columns: x:6(int!null) u:8(int!null)
       │    │    │    ├── outer: (2)
       │    │    │    ├── key: (6,8)
       │    │    │    ├── scan xy
       │    │    │    │    ├── columns: x:6(int!null)
       │    │    │    │    └── key: (6)
-      │    │    │    ├── select
+      │    │    │    ├── scan uv
       │    │    │    │    ├── columns: u:8(int!null)
-      │    │    │    │    ├── outer: (2)
-      │    │    │    │    ├── key: (8)
-      │    │    │    │    ├── scan uv
-      │    │    │    │    │    ├── columns: u:8(int!null)
-      │    │    │    │    │    └── key: (8)
-      │    │    │    │    └── filters [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
-      │    │    │    │         └── a.i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
-      │    │    │    └── true [type=bool]
+      │    │    │    │    └── key: (8)
+      │    │    │    └── filters [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+      │    │    │         └── a.i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
       │    │    └── projections [outer=(6,8)]
+      │    │         └── uv.u / 1.1 [type=decimal, outer=(8)]
+      │    └── filters [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
+      │         └── xy.x = div [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ])]
+      └── true [type=bool]
+
+# Don't hoist Project operator in right join case.
+opt
+SELECT k FROM a
+WHERE EXISTS
+(
+    SELECT * FROM xy RIGHT JOIN (SELECT u, u/1.1 AS div FROM uv WHERE i=5) ON x=div
+)
+----
+project
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ └── semi-join-apply
+      ├── columns: k:1(int!null) i:2(int)
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── scan a
+      │    ├── columns: k:1(int!null) i:2(int)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      ├── right-join
+      │    ├── columns: x:6(int) div:10(decimal)
+      │    ├── outer: (2)
+      │    ├── scan xy
+      │    │    ├── columns: x:6(int!null)
+      │    │    └── key: (6)
+      │    ├── project
+      │    │    ├── columns: div:10(decimal)
+      │    │    ├── outer: (2)
+      │    │    ├── select
+      │    │    │    ├── columns: u:8(int!null)
+      │    │    │    ├── outer: (2)
+      │    │    │    ├── key: (8)
+      │    │    │    ├── scan uv
+      │    │    │    │    ├── columns: u:8(int!null)
+      │    │    │    │    └── key: (8)
+      │    │    │    └── filters [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+      │    │    │         └── a.i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
+      │    │    └── projections [outer=(8)]
       │    │         └── uv.u / 1.1 [type=decimal, outer=(8)]
       │    └── filters [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
       │         └── xy.x = div [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ])]
@@ -2286,24 +2324,24 @@ SELECT y FROM a RIGHT JOIN xy ON (SELECT k+1) = (SELECT x+1)
 ----
 project
  ├── columns: y:7(int)
- └── select
-      ├── columns: k:1(int) x:6(int!null) y:7(int)
-      ├── key: (1,6)
-      ├── fd: (6)-->(7)
-      ├── right-join
-      │    ├── columns: k:1(int) x:6(int!null) y:7(int)
-      │    ├── key: (1,6)
-      │    ├── fd: (6)-->(7)
-      │    ├── scan a
-      │    │    ├── columns: k:1(int!null)
-      │    │    └── key: (1)
+ └── right-join-apply
+      ├── columns: k:1(int) y:7(int) "?column?":8(int) "?column?":9(int)
+      ├── scan a
+      │    ├── columns: k:1(int!null)
+      │    └── key: (1)
+      ├── project
+      │    ├── columns: "?column?":9(int) "?column?":8(int) y:7(int)
+      │    ├── outer: (1)
+      │    ├── fd: ()-->(8)
       │    ├── scan xy
       │    │    ├── columns: x:6(int!null) y:7(int)
       │    │    ├── key: (6)
       │    │    └── fd: (6)-->(7)
-      │    └── true [type=bool]
-      └── filters [type=bool, outer=(1,6)]
-           └── (a.k + 1) = (xy.x + 1) [type=bool, outer=(1,6)]
+      │    └── projections [outer=(1,6,7)]
+      │         ├── xy.x + 1 [type=int, outer=(6)]
+      │         └── a.k + 1 [type=int, outer=(1)]
+      └── filters [type=bool, outer=(8,9), constraints=(/8: (/NULL - ]; /9: (/NULL - ]), fd=(8)==(9), (9)==(8)]
+           └── ?column? = ?column? [type=bool, outer=(8,9), constraints=(/8: (/NULL - ]; /9: (/NULL - ])]
 
 # Hoist Exists in join filter disjunction.
 opt

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -547,27 +547,21 @@ WHERE EXISTS
     SELECT * FROM xy INNER JOIN (SELECT u, u/1.1 AS div FROM uv WHERE i=5) ON x=div
 )
 ----
-project
+group-by
  ├── columns: k:1(int!null)
+ ├── grouping columns: k:1(int!null)
  ├── key: (1)
- └── semi-join-apply
-      ├── columns: k:1(int!null) i:2(int)
-      ├── key: (1)
-      ├── fd: (1)-->(2)
-      ├── scan a
-      │    ├── columns: k:1(int!null) i:2(int)
-      │    ├── key: (1)
-      │    └── fd: (1)-->(2)
-      ├── select
-      │    ├── columns: x:6(int!null) div:10(decimal!null)
-      │    ├── outer: (2)
-      │    ├── fd: (6)==(10), (10)==(6)
-      │    ├── project
-      │    │    ├── columns: div:10(decimal) x:6(int!null)
-      │    │    ├── outer: (2)
+ └── select
+      ├── columns: k:1(int!null) x:6(int!null) div:10(decimal!null)
+      ├── fd: (6)==(10), (10)==(6)
+      ├── project
+      │    ├── columns: div:10(decimal) k:1(int!null) x:6(int!null)
+      │    ├── inner-join
+      │    │    ├── columns: k:1(int!null) i:2(int!null) x:6(int!null) u:8(int!null)
+      │    │    ├── key: (1,6,8)
+      │    │    ├── fd: ()-->(2)
       │    │    ├── inner-join
       │    │    │    ├── columns: x:6(int!null) u:8(int!null)
-      │    │    │    ├── outer: (2)
       │    │    │    ├── key: (6,8)
       │    │    │    ├── scan xy
       │    │    │    │    ├── columns: x:6(int!null)
@@ -575,13 +569,22 @@ project
       │    │    │    ├── scan uv
       │    │    │    │    ├── columns: u:8(int!null)
       │    │    │    │    └── key: (8)
+      │    │    │    └── true [type=bool]
+      │    │    ├── select
+      │    │    │    ├── columns: k:1(int!null) i:2(int!null)
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: ()-->(2)
+      │    │    │    ├── scan a
+      │    │    │    │    ├── columns: k:1(int!null) i:2(int)
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    └── fd: (1)-->(2)
       │    │    │    └── filters [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
       │    │    │         └── a.i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
-      │    │    └── projections [outer=(6,8)]
-      │    │         └── uv.u / 1.1 [type=decimal, outer=(8)]
-      │    └── filters [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
-      │         └── xy.x = div [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ])]
-      └── true [type=bool]
+      │    │    └── true [type=bool]
+      │    └── projections [outer=(1,6,8)]
+      │         └── uv.u / 1.1 [type=decimal, outer=(8)]
+      └── filters [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
+           └── xy.x = div [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ])]
 
 # Don't hoist Project operator in right join case.
 opt
@@ -734,7 +737,7 @@ project
 # TryDecorrelateProjectInnerJoin
 # --------------------------------------------------
 opt
-SELECT (SELECT SUM(y + v) FROM xy, uv WHERE x=u AND x=k) FROM a
+SELECT (SELECT sum(y + v) FROM xy, uv WHERE x=u AND x=k) FROM a
 ----
 project
  ├── columns: sum:12(decimal)
@@ -1007,46 +1010,63 @@ WHERE EXISTS
     SELECT * FROM xy INNER JOIN (SELECT count(*) AS cnt, sum(v) FROM uv WHERE i=5 GROUP BY v) ON x=cnt
 )
 ----
-semi-join-apply
+group-by
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── grouping columns: k:1(int!null)
  ├── key: (1)
- ├── fd: (1)-->(2-5)
- ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
+ ├── fd: ()-->(2), (1)-->(2-5)
  ├── select
- │    ├── columns: x:6(int!null) y:7(int) v:9(int) cnt:10(int!null) sum:11(decimal)
- │    ├── outer: (2)
- │    ├── key: (6,9)
- │    ├── fd: (6)-->(7), (6,9)-->(7,10,11), (6)==(10), (10)==(6)
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) v:9(int) cnt:10(int!null)
+ │    ├── key: (1,6,9)
+ │    ├── fd: ()-->(2), (1)-->(3-5), (1,6,9)-->(3-5,10), (6)==(10), (10)==(6)
  │    ├── group-by
- │    │    ├── columns: x:6(int!null) y:7(int) v:9(int) cnt:10(int) sum:11(decimal)
- │    │    ├── grouping columns: x:6(int!null) v:9(int)
- │    │    ├── outer: (2)
- │    │    ├── key: (6,9)
- │    │    ├── fd: (6)-->(7), (6,9)-->(7,10,11)
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) v:9(int) cnt:10(int)
+ │    │    ├── grouping columns: k:1(int!null) x:6(int!null) v:9(int)
+ │    │    ├── key: (1,6,9)
+ │    │    ├── fd: ()-->(2), (1)-->(3-5), (1,6,9)-->(2-5,10)
  │    │    ├── inner-join
- │    │    │    ├── columns: x:6(int!null) y:7(int) v:9(int)
- │    │    │    ├── outer: (2)
- │    │    │    ├── fd: (6)-->(7)
- │    │    │    ├── scan xy
- │    │    │    │    ├── columns: x:6(int!null) y:7(int)
- │    │    │    │    ├── key: (6)
- │    │    │    │    └── fd: (6)-->(7)
- │    │    │    ├── scan uv
- │    │    │    │    └── columns: v:9(int)
- │    │    │    └── filters [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
- │    │    │         └── a.i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
- │    │    └── aggregations [outer=(7,9)]
+ │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) v:9(int)
+ │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
+ │    │    │    ├── inner-join
+ │    │    │    │    ├── columns: x:6(int!null) v:9(int)
+ │    │    │    │    ├── scan xy
+ │    │    │    │    │    ├── columns: x:6(int!null)
+ │    │    │    │    │    └── key: (6)
+ │    │    │    │    ├── scan uv
+ │    │    │    │    │    └── columns: v:9(int)
+ │    │    │    │    └── true [type=bool]
+ │    │    │    ├── select
+ │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
+ │    │    │    │    ├── scan a
+ │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    └── fd: (1)-->(2-5)
+ │    │    │    │    └── filters [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+ │    │    │    │         └── a.i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
+ │    │    │    └── true [type=bool]
+ │    │    └── aggregations [outer=(2-5)]
  │    │         ├── count-rows [type=int]
- │    │         ├── sum [type=decimal, outer=(9)]
- │    │         │    └── variable: uv.v [type=int, outer=(9)]
- │    │         └── any-not-null [type=int, outer=(7)]
- │    │              └── variable: xy.y [type=int, outer=(7)]
+ │    │         ├── any-not-null [type=int, outer=(2)]
+ │    │         │    └── variable: a.i [type=int, outer=(2)]
+ │    │         ├── any-not-null [type=float, outer=(3)]
+ │    │         │    └── variable: a.f [type=float, outer=(3)]
+ │    │         ├── any-not-null [type=string, outer=(4)]
+ │    │         │    └── variable: a.s [type=string, outer=(4)]
+ │    │         └── any-not-null [type=jsonb, outer=(5)]
+ │    │              └── variable: a.j [type=jsonb, outer=(5)]
  │    └── filters [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
  │         └── xy.x = cnt [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ])]
- └── true [type=bool]
+ └── aggregations [outer=(2-5)]
+      ├── any-not-null [type=int, outer=(2)]
+      │    └── variable: a.i [type=int, outer=(2)]
+      ├── any-not-null [type=float, outer=(3)]
+      │    └── variable: a.f [type=float, outer=(3)]
+      ├── any-not-null [type=string, outer=(4)]
+      │    └── variable: a.s [type=string, outer=(4)]
+      └── any-not-null [type=jsonb, outer=(5)]
+           └── variable: a.j [type=jsonb, outer=(5)]
 
 # Indirectly decorrelate GROUP BY after decorrelating scalar GROUP BY.
 opt
@@ -1223,52 +1243,65 @@ WHERE EXISTS
     SELECT * FROM xy INNER JOIN (SELECT sum(v), count(*) AS cnt FROM uv WHERE i=5) ON x=cnt
 )
 ----
-semi-join-apply
+group-by
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── grouping columns: k:1(int!null)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
  ├── select
- │    ├── columns: x:6(int!null) y:7(int) sum:10(decimal) cnt:11(int!null)
- │    ├── outer: (2)
- │    ├── key: (6)
- │    ├── fd: (6)-->(7,10), (6)==(11), (11)==(6)
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) cnt:11(int!null)
+ │    ├── key: (1,6)
+ │    ├── fd: (1)-->(2-5), (1,6)-->(2-5,11), (6)==(11), (11)==(6)
  │    ├── group-by
- │    │    ├── columns: x:6(int!null) y:7(int) sum:10(decimal) cnt:11(int)
- │    │    ├── grouping columns: x:6(int!null)
- │    │    ├── outer: (2)
- │    │    ├── key: (6)
- │    │    ├── fd: (6)-->(7,10,11)
- │    │    ├── left-join
- │    │    │    ├── columns: x:6(int!null) y:7(int) v:9(int) notnull:12(bool)
- │    │    │    ├── outer: (2)
- │    │    │    ├── fd: (6)-->(7), ()~~>(12)
- │    │    │    ├── scan xy
- │    │    │    │    ├── columns: x:6(int!null) y:7(int)
- │    │    │    │    ├── key: (6)
- │    │    │    │    └── fd: (6)-->(7)
- │    │    │    ├── project
- │    │    │    │    ├── columns: notnull:12(bool!null) v:9(int)
- │    │    │    │    ├── fd: ()-->(12)
- │    │    │    │    ├── scan uv
- │    │    │    │    │    └── columns: v:9(int)
- │    │    │    │    └── projections [outer=(9)]
- │    │    │    │         └── true [type=bool]
- │    │    │    └── filters [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
- │    │    │         └── a.i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
- │    │    └── aggregations [outer=(7,9,12)]
- │    │         ├── sum [type=decimal, outer=(9)]
- │    │         │    └── variable: uv.v [type=int, outer=(9)]
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) cnt:11(int)
+ │    │    ├── grouping columns: k:1(int!null) x:6(int!null)
+ │    │    ├── key: (1,6)
+ │    │    ├── fd: (1)-->(2-5), (1,6)-->(2-5,11)
+ │    │    ├── inner-join-apply
+ │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) notnull:12(bool)
+ │    │    │    ├── fd: (1)-->(2-5)
+ │    │    │    ├── scan a
+ │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    └── fd: (1)-->(2-5)
+ │    │    │    ├── left-join
+ │    │    │    │    ├── columns: x:6(int!null) notnull:12(bool)
+ │    │    │    │    ├── outer: (2)
+ │    │    │    │    ├── fd: ()~~>(12)
+ │    │    │    │    ├── scan xy
+ │    │    │    │    │    ├── columns: x:6(int!null)
+ │    │    │    │    │    └── key: (6)
+ │    │    │    │    ├── project
+ │    │    │    │    │    ├── columns: notnull:12(bool!null)
+ │    │    │    │    │    ├── fd: ()-->(12)
+ │    │    │    │    │    ├── scan uv
+ │    │    │    │    │    └── projections
+ │    │    │    │    │         └── true [type=bool]
+ │    │    │    │    └── filters [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+ │    │    │    │         └── a.i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
+ │    │    │    └── true [type=bool]
+ │    │    └── aggregations [outer=(2-5,12)]
  │    │         ├── count [type=int, outer=(12)]
  │    │         │    └── variable: notnull [type=bool, outer=(12)]
- │    │         └── any-not-null [type=int, outer=(7)]
- │    │              └── variable: xy.y [type=int, outer=(7)]
+ │    │         ├── any-not-null [type=int, outer=(2)]
+ │    │         │    └── variable: a.i [type=int, outer=(2)]
+ │    │         ├── any-not-null [type=float, outer=(3)]
+ │    │         │    └── variable: a.f [type=float, outer=(3)]
+ │    │         ├── any-not-null [type=string, outer=(4)]
+ │    │         │    └── variable: a.s [type=string, outer=(4)]
+ │    │         └── any-not-null [type=jsonb, outer=(5)]
+ │    │              └── variable: a.j [type=jsonb, outer=(5)]
  │    └── filters [type=bool, outer=(6,11), constraints=(/6: (/NULL - ]; /11: (/NULL - ]), fd=(6)==(11), (11)==(6)]
  │         └── xy.x = cnt [type=bool, outer=(6,11), constraints=(/6: (/NULL - ]; /11: (/NULL - ])]
- └── true [type=bool]
+ └── aggregations [outer=(2-5)]
+      ├── any-not-null [type=int, outer=(2)]
+      │    └── variable: a.i [type=int, outer=(2)]
+      ├── any-not-null [type=float, outer=(3)]
+      │    └── variable: a.f [type=float, outer=(3)]
+      ├── any-not-null [type=string, outer=(4)]
+      │    └── variable: a.s [type=string, outer=(4)]
+      └── any-not-null [type=jsonb, outer=(5)]
+           └── variable: a.j [type=jsonb, outer=(5)]
 
 # Synthesize key when one is not present.
 opt
@@ -1531,6 +1564,112 @@ project
       │         └── max = 'foo' [type=bool, outer=(10), constraints=(/10: [/'foo' - /'foo']; tight)]
       └── true [type=bool]
 
+# --------------------------------------------------
+# TryDecorrelateSemiJoin
+# --------------------------------------------------
+
+# Right input of SemiJoin is GroupBy.
+opt
+SELECT *
+FROM xy
+WHERE EXISTS
+(
+    SELECT * FROM a WHERE i=(SELECT max(i) FROM a WHERE f=y::float)
+)
+----
+group-by
+ ├── columns: x:1(int!null) y:2(int)
+ ├── grouping columns: x:1(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── select
+ │    ├── columns: x:1(int!null) y:2(int) a.k:3(int!null) a.i:4(int!null) max:13(int!null)
+ │    ├── key: (1,3)
+ │    ├── fd: (1)-->(2), (3)-->(4), (1,3)-->(2,4,13), (4)==(13), (13)==(4)
+ │    ├── group-by
+ │    │    ├── columns: x:1(int!null) y:2(int) a.k:3(int!null) a.i:4(int) max:13(int)
+ │    │    ├── grouping columns: x:1(int!null) a.k:3(int!null)
+ │    │    ├── key: (1,3)
+ │    │    ├── fd: (1)-->(2), (3)-->(4), (1,3)-->(2,4,13)
+ │    │    ├── inner-join
+ │    │    │    ├── columns: x:1(int!null) y:2(int) a.k:3(int!null) a.i:4(int) a.i:9(int!null) a.f:10(float!null)
+ │    │    │    ├── fd: (1)-->(2), (3)-->(4)
+ │    │    │    ├── inner-join
+ │    │    │    │    ├── columns: a.k:3(int!null) a.i:4(int) a.i:9(int!null) a.f:10(float)
+ │    │    │    │    ├── fd: (3)-->(4)
+ │    │    │    │    ├── scan a
+ │    │    │    │    │    ├── columns: a.k:3(int!null) a.i:4(int)
+ │    │    │    │    │    ├── key: (3)
+ │    │    │    │    │    └── fd: (3)-->(4)
+ │    │    │    │    ├── select
+ │    │    │    │    │    ├── columns: a.i:9(int!null) a.f:10(float)
+ │    │    │    │    │    ├── scan a
+ │    │    │    │    │    │    └── columns: a.i:9(int) a.f:10(float)
+ │    │    │    │    │    └── filters [type=bool, outer=(9), constraints=(/9: (/NULL - ]; tight)]
+ │    │    │    │    │         └── a.i IS NOT NULL [type=bool, outer=(9), constraints=(/9: (/NULL - ]; tight)]
+ │    │    │    │    └── true [type=bool]
+ │    │    │    ├── scan xy
+ │    │    │    │    ├── columns: x:1(int!null) y:2(int)
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    └── fd: (1)-->(2)
+ │    │    │    └── filters [type=bool, outer=(2,10), constraints=(/10: (/NULL - ])]
+ │    │    │         └── a.f = xy.y::FLOAT [type=bool, outer=(2,10), constraints=(/10: (/NULL - ])]
+ │    │    └── aggregations [outer=(2,4,9)]
+ │    │         ├── max [type=int, outer=(9)]
+ │    │         │    └── variable: a.i [type=int, outer=(9)]
+ │    │         ├── any-not-null [type=int, outer=(4)]
+ │    │         │    └── variable: a.i [type=int, outer=(4)]
+ │    │         └── any-not-null [type=int, outer=(2)]
+ │    │              └── variable: xy.y [type=int, outer=(2)]
+ │    └── filters [type=bool, outer=(4,13), constraints=(/4: (/NULL - ]; /13: (/NULL - ]), fd=(4)==(13), (13)==(4)]
+ │         └── a.i = max [type=bool, outer=(4,13), constraints=(/4: (/NULL - ]; /13: (/NULL - ])]
+ └── aggregations [outer=(2)]
+      └── any-not-null [type=int, outer=(2)]
+           └── variable: xy.y [type=int, outer=(2)]
+
+# Right input of SemiJoin is Project.
+opt
+SELECT k FROM a
+WHERE EXISTS
+(
+    SELECT * FROM xy INNER JOIN (SELECT coalesce(u, 10) AS computed FROM uv WHERE u=i) ON x=computed
+)
+----
+project
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ └── select
+      ├── columns: k:1(int!null) x:6(int!null) computed:10(int!null)
+      ├── key: (1)
+      ├── fd: (1)-->(10), (6)==(10), (10)==(6)
+      ├── project
+      │    ├── columns: computed:10(int) k:1(int!null) x:6(int!null)
+      │    ├── key: (1,6)
+      │    ├── fd: (1)-->(10)
+      │    ├── inner-join
+      │    │    ├── columns: k:1(int!null) i:2(int!null) x:6(int!null) u:8(int!null)
+      │    │    ├── key: (1,6)
+      │    │    ├── fd: (1)-->(2), (2)==(8), (8)==(2)
+      │    │    ├── inner-join
+      │    │    │    ├── columns: x:6(int!null) u:8(int!null)
+      │    │    │    ├── key: (6,8)
+      │    │    │    ├── scan xy
+      │    │    │    │    ├── columns: x:6(int!null)
+      │    │    │    │    └── key: (6)
+      │    │    │    ├── scan uv
+      │    │    │    │    ├── columns: u:8(int!null)
+      │    │    │    │    └── key: (8)
+      │    │    │    └── true [type=bool]
+      │    │    ├── scan a
+      │    │    │    ├── columns: k:1(int!null) i:2(int)
+      │    │    │    ├── key: (1)
+      │    │    │    └── fd: (1)-->(2)
+      │    │    └── filters [type=bool, outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+      │    │         └── uv.u = a.i [type=bool, outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ])]
+      │    └── projections [outer=(1,6,8)]
+      │         └── COALESCE(uv.u, 10) [type=int, outer=(8)]
+      └── filters [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
+           └── xy.x = computed [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ])]
 
 # --------------------------------------------------
 # HoistSelectExists

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -647,22 +647,36 @@ project
       │    ├── columns: k:1(int!null) i:2(int)
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
-      ├── left-join
+      ├── left-join (merge)
       │    ├── columns: x:6(int!null) plus:10(int)
       │    ├── outer: (2)
       │    ├── scan xy
       │    │    ├── columns: x:6(int!null)
-      │    │    └── key: (6)
-      │    ├── project
+      │    │    ├── key: (6)
+      │    │    └── ordering: +6
+      │    ├── sort
       │    │    ├── columns: plus:10(int)
-      │    │    ├── scan uv
-      │    │    │    ├── columns: u:8(int!null)
-      │    │    │    └── key: (8)
-      │    │    └── projections [outer=(8)]
-      │    │         └── uv.u + 1 [type=int, outer=(8)]
-      │    └── filters [type=bool, outer=(2,6,10), constraints=(/2: [/5 - /5]; /6: (/NULL - ]; /10: (/NULL - ]), fd=()-->(2), (6)==(10), (10)==(6)]
-      │         ├── xy.x = plus [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ])]
-      │         └── a.i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
+      │    │    ├── outer: (2)
+      │    │    ├── ordering: +10
+      │    │    └── project
+      │    │         ├── columns: plus:10(int)
+      │    │         ├── outer: (2)
+      │    │         ├── select
+      │    │         │    ├── columns: u:8(int!null)
+      │    │         │    ├── outer: (2)
+      │    │         │    ├── key: (8)
+      │    │         │    ├── scan uv
+      │    │         │    │    ├── columns: u:8(int!null)
+      │    │         │    │    └── key: (8)
+      │    │         │    └── filters [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+      │    │         │         └── a.i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
+      │    │         └── projections [outer=(8)]
+      │    │              └── uv.u + 1 [type=int, outer=(8)]
+      │    └── merge-on
+      │         ├── left ordering: +6
+      │         ├── right ordering: +10
+      │         └── filters [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
+      │              └── xy.x = plus [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ])]
       └── true [type=bool]
 
 # Don't decorrelate FULL JOIN case.
@@ -715,6 +729,59 @@ project
       │         └── filters [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
       │              └── xy.x = plus [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ])]
       └── true [type=bool]
+
+# --------------------------------------------------
+# TryDecorrelateProjectInnerJoin
+# --------------------------------------------------
+opt
+SELECT (SELECT SUM(y + v) FROM xy, uv WHERE x=u AND x=k) FROM a
+----
+project
+ ├── columns: sum:12(decimal)
+ ├── group-by
+ │    ├── columns: k:1(int!null) sum:11(decimal)
+ │    ├── grouping columns: k:1(int!null)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(11)
+ │    ├── right-join
+ │    │    ├── columns: k:1(int!null) x:6(int) column10:10(int)
+ │    │    ├── key: (1,6)
+ │    │    ├── fd: (6)-->(10)
+ │    │    ├── project
+ │    │    │    ├── columns: column10:10(int) x:6(int!null)
+ │    │    │    ├── key: (6)
+ │    │    │    ├── fd: (6)-->(10)
+ │    │    │    ├── inner-join (merge)
+ │    │    │    │    ├── columns: x:6(int!null) y:7(int) u:8(int!null) v:9(int)
+ │    │    │    │    ├── key: (8)
+ │    │    │    │    ├── fd: (6)-->(7), (8)-->(9), (6)==(8), (8)==(6)
+ │    │    │    │    ├── scan xy
+ │    │    │    │    │    ├── columns: x:6(int!null) y:7(int)
+ │    │    │    │    │    ├── key: (6)
+ │    │    │    │    │    ├── fd: (6)-->(7)
+ │    │    │    │    │    └── ordering: +6
+ │    │    │    │    ├── scan uv
+ │    │    │    │    │    ├── columns: u:8(int!null) v:9(int)
+ │    │    │    │    │    ├── key: (8)
+ │    │    │    │    │    ├── fd: (8)-->(9)
+ │    │    │    │    │    └── ordering: +8
+ │    │    │    │    └── merge-on
+ │    │    │    │         ├── left ordering: +6
+ │    │    │    │         ├── right ordering: +8
+ │    │    │    │         └── filters [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
+ │    │    │    │              └── xy.x = uv.u [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ])]
+ │    │    │    └── projections [outer=(6,7,9)]
+ │    │    │         └── xy.y + uv.v [type=int, outer=(7,9)]
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1(int!null)
+ │    │    │    └── key: (1)
+ │    │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │         └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+ │    └── aggregations [outer=(10)]
+ │         └── sum [type=decimal, outer=(10)]
+ │              └── variable: column10 [type=int, outer=(10)]
+ └── projections [outer=(11)]
+      └── variable: sum [type=decimal, outer=(11)]
 
 # --------------------------------------------------
 # TryDecorrelateInnerJoin

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -595,7 +595,7 @@ opt
 SELECT k FROM a
 WHERE EXISTS
 (
-    SELECT * FROM xy FULL JOIN (SELECT u, u+1 AS plus FROM uv WHERE i=5) ON x=plus
+    SELECT * FROM xy LEFT JOIN (SELECT u, u+1 AS plus FROM uv WHERE i=5) ON x=plus
 )
 ----
 project
@@ -609,8 +609,8 @@ project
       │    ├── columns: k:1(int!null) i:2(int)
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
-      ├── full-join
-      │    ├── columns: x:6(int) plus:10(int)
+      ├── left-join
+      │    ├── columns: x:6(int!null) plus:10(int)
       │    ├── outer: (2)
       │    ├── scan xy
       │    │    ├── columns: x:6(int!null)
@@ -625,6 +625,57 @@ project
       │    └── filters [type=bool, outer=(2,6,10), constraints=(/2: [/5 - /5]; /6: (/NULL - ]; /10: (/NULL - ]), fd=()-->(2), (6)==(10), (10)==(6)]
       │         ├── xy.x = plus [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ])]
       │         └── a.i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
+      └── true [type=bool]
+
+# Don't decorrelate FULL JOIN case.
+opt
+SELECT k FROM a
+WHERE EXISTS
+(
+    SELECT * FROM xy FULL JOIN (SELECT u, u+1 AS plus FROM uv WHERE i=5) ON x=plus
+)
+----
+project
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ └── semi-join-apply
+      ├── columns: k:1(int!null) i:2(int)
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── scan a
+      │    ├── columns: k:1(int!null) i:2(int)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      ├── full-join (merge)
+      │    ├── columns: x:6(int) plus:10(int)
+      │    ├── outer: (2)
+      │    ├── scan xy
+      │    │    ├── columns: x:6(int!null)
+      │    │    ├── key: (6)
+      │    │    └── ordering: +6
+      │    ├── sort
+      │    │    ├── columns: plus:10(int)
+      │    │    ├── outer: (2)
+      │    │    ├── ordering: +10
+      │    │    └── project
+      │    │         ├── columns: plus:10(int)
+      │    │         ├── outer: (2)
+      │    │         ├── select
+      │    │         │    ├── columns: u:8(int!null)
+      │    │         │    ├── outer: (2)
+      │    │         │    ├── key: (8)
+      │    │         │    ├── scan uv
+      │    │         │    │    ├── columns: u:8(int!null)
+      │    │         │    │    └── key: (8)
+      │    │         │    └── filters [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+      │    │         │         └── a.i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
+      │    │         └── projections [outer=(8)]
+      │    │              └── uv.u + 1 [type=int, outer=(8)]
+      │    └── merge-on
+      │         ├── left ordering: +6
+      │         ├── right ordering: +10
+      │         └── filters [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
+      │              └── xy.x = plus [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ])]
       └── true [type=bool]
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/external/activerecord
+++ b/pkg/sql/opt/xform/testdata/external/activerecord
@@ -181,7 +181,6 @@ TABLE pg_type
       ├── typnamespace oid not null
       └── oid oid not null (storing)
 
-# TODO(andyk): Need to decorrelate LeftJoin -> Project complex.
 opt
 SELECT a.attname,
   format_type(a.atttypid, a.atttypmod),
@@ -208,10 +207,24 @@ sort
  └── project
       ├── columns: format_type:27(string) pg_get_expr:28(string) collname:67(string) comment:68(string) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null)
       ├── fd: (3,9)-->(27)
-      ├── left-join-apply
-      │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null) adrelid:23(oid) adnum:24(int) adbin:25(string) pg_collation.collname:30(string)
-      │    ├── key: (1,6,23,24)
-      │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18), (23,24)-->(25), (1,6,23,24)-->(30)
+      ├── right-join
+      │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null) adrelid:23(oid) adnum:24(int) adbin:25(string) pg_collation.oid:29(oid) pg_collation.collname:30(string) pg_type.oid:36(oid) typcollation:63(oid)
+      │    ├── key: (1,6,23,24,29,36)
+      │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18), (23,24)-->(25), (29)-->(30), (36)-->(63)
+      │    ├── inner-join
+      │    │    ├── columns: pg_collation.oid:29(oid!null) pg_collation.collname:30(string!null) pg_type.oid:36(oid!null) typcollation:63(oid!null)
+      │    │    ├── key: (29,36)
+      │    │    ├── fd: (29)-->(30), (36)-->(63)
+      │    │    ├── scan pg_collation@pg_collation_name_enc_nsp_index
+      │    │    │    ├── columns: pg_collation.oid:29(oid!null) pg_collation.collname:30(string!null)
+      │    │    │    ├── key: (29)
+      │    │    │    └── fd: (29)-->(30)
+      │    │    ├── scan pg_type
+      │    │    │    ├── columns: pg_type.oid:36(oid!null) typcollation:63(oid!null)
+      │    │    │    ├── key: (36)
+      │    │    │    └── fd: (36)-->(63)
+      │    │    └── filters [type=bool, outer=(29,63), constraints=(/29: (/NULL - ]; /63: (/NULL - ])]
+      │    │         └── pg_collation.oid != pg_type.typcollation [type=bool, outer=(29,63), constraints=(/29: (/NULL - ]; /63: (/NULL - ])]
       │    ├── right-join
       │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null) adrelid:23(oid) adnum:24(int) adbin:25(string)
       │    │    ├── key: (1,6,23,24)
@@ -242,31 +255,9 @@ sort
       │    │    └── filters [type=bool, outer=(1,6,23,24), constraints=(/1: (/NULL - ]; /6: (/NULL - ]; /23: (/NULL - ]; /24: (/NULL - ]), fd=(1)==(23), (23)==(1), (6)==(24), (24)==(6)]
       │    │         ├── pg_attribute.attrelid = pg_attrdef.adrelid [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ])]
       │    │         └── pg_attribute.attnum = pg_attrdef.adnum [type=bool, outer=(6,24), constraints=(/6: (/NULL - ]; /24: (/NULL - ])]
-      │    ├── project
-      │    │    ├── columns: pg_collation.collname:30(string!null)
-      │    │    ├── outer: (3,18)
-      │    │    ├── cardinality: [0 - 1]
-      │    │    ├── key: ()
-      │    │    ├── fd: ()-->(30)
-      │    │    └── inner-join
-      │    │         ├── columns: pg_collation.oid:29(oid!null) pg_collation.collname:30(string!null) pg_type.oid:36(oid!null) typcollation:63(oid!null)
-      │    │         ├── outer: (3,18)
-      │    │         ├── cardinality: [0 - 1]
-      │    │         ├── key: ()
-      │    │         ├── fd: ()-->(29,30,36,63)
-      │    │         ├── scan pg_collation@pg_collation_name_enc_nsp_index
-      │    │         │    ├── columns: pg_collation.oid:29(oid!null) pg_collation.collname:30(string!null)
-      │    │         │    ├── key: (29)
-      │    │         │    └── fd: (29)-->(30)
-      │    │         ├── scan pg_type
-      │    │         │    ├── columns: pg_type.oid:36(oid!null) typcollation:63(oid!null)
-      │    │         │    ├── key: (36)
-      │    │         │    └── fd: (36)-->(63)
-      │    │         └── filters [type=bool, outer=(3,18,29,36,63), constraints=(/3: (/NULL - ]; /18: (/NULL - ]; /29: (/NULL - ]; /36: (/NULL - ]; /63: (/NULL - ]), fd=(18)==(29), (29)==(18), (3)==(36), (36)==(3)]
-      │    │              ├── pg_collation.oid = pg_attribute.attcollation [type=bool, outer=(18,29), constraints=(/18: (/NULL - ]; /29: (/NULL - ])]
-      │    │              ├── pg_type.oid = pg_attribute.atttypid [type=bool, outer=(3,36), constraints=(/3: (/NULL - ]; /36: (/NULL - ])]
-      │    │              └── pg_attribute.attcollation != pg_type.typcollation [type=bool, outer=(18,63), constraints=(/18: (/NULL - ]; /63: (/NULL - ])]
-      │    └── true [type=bool]
+      │    └── filters [type=bool, outer=(3,18,29,36), constraints=(/3: (/NULL - ]; /18: (/NULL - ]; /29: (/NULL - ]; /36: (/NULL - ]), fd=(18)==(29), (29)==(18), (3)==(36), (36)==(3)]
+      │         ├── pg_collation.oid = pg_attribute.attcollation [type=bool, outer=(18,29), constraints=(/18: (/NULL - ]; /29: (/NULL - ])]
+      │         └── pg_type.oid = pg_attribute.atttypid [type=bool, outer=(3,36), constraints=(/3: (/NULL - ]; /36: (/NULL - ])]
       └── projections [outer=(1-3,6,9,13,23,25,30)]
            ├── format_type(pg_attribute.atttypid, pg_attribute.atttypmod) [type=string, outer=(3,9)]
            ├── pg_get_expr(pg_attrdef.adbin, pg_attrdef.adrelid) [type=string, outer=(23,25)]

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -2118,7 +2118,6 @@ drop table TAuction2, TBid2;
 # ------------------------------------------------------------------------------
 # Query #11
 #   org.hibernate.test.cid.CompositeIdTest
-#   TODO(andyk): Need to decorrelate LeftJoin -> Project complex.
 # ------------------------------------------------------------------------------
 exec-ddl
 CREATE TABLE customer (
@@ -2228,9 +2227,27 @@ project
  │    ├── grouping columns: lineitem.productid:6(string)
  │    ├── key: (6)
  │    ├── fd: ()-->(1-3), (6)-->(1-5,7,17), ()~~>(4,5)
- │    ├── left-join-apply
- │    │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date!null) lineitem.customerid:4(string) lineitem.ordernumber:5(int) lineitem.productid:6(string) lineitem.quantity:7(int) column16:16(decimal)
+ │    ├── right-join
+ │    │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date!null) lineitem.customerid:4(string) lineitem.ordernumber:5(int) lineitem.productid:6(string) lineitem.quantity:7(int) lineitem.customerid:8(string) lineitem.ordernumber:9(int) column16:16(decimal)
  │    │    ├── fd: ()-->(1-3), (6)-->(4,5,7), ()~~>(4,5)
+ │    │    ├── project
+ │    │    │    ├── columns: column16:16(decimal) lineitem.customerid:8(string!null) lineitem.ordernumber:9(int!null)
+ │    │    │    ├── inner-join
+ │    │    │    │    ├── columns: lineitem.customerid:8(string!null) lineitem.ordernumber:9(int!null) lineitem.productid:10(string!null) lineitem.quantity:11(int) product.productid:12(string!null) cost:14(decimal)
+ │    │    │    │    ├── key: (8,9,12)
+ │    │    │    │    ├── fd: (8-10)-->(11), (12)-->(14), (10)==(12), (12)==(10)
+ │    │    │    │    ├── scan lineitem
+ │    │    │    │    │    ├── columns: lineitem.customerid:8(string!null) lineitem.ordernumber:9(int!null) lineitem.productid:10(string!null) lineitem.quantity:11(int)
+ │    │    │    │    │    ├── key: (8-10)
+ │    │    │    │    │    └── fd: (8-10)-->(11)
+ │    │    │    │    ├── scan product
+ │    │    │    │    │    ├── columns: product.productid:12(string!null) cost:14(decimal)
+ │    │    │    │    │    ├── key: (12)
+ │    │    │    │    │    └── fd: (12)-->(14)
+ │    │    │    │    └── filters [type=bool, outer=(10,12), constraints=(/10: (/NULL - ]; /12: (/NULL - ]), fd=(10)==(12), (12)==(10)]
+ │    │    │    │         └── lineitem.productid = product.productid [type=bool, outer=(10,12), constraints=(/10: (/NULL - ]; /12: (/NULL - ])]
+ │    │    │    └── projections [outer=(8,9,11,14)]
+ │    │    │         └── lineitem.quantity * product.cost [type=decimal, outer=(11,14)]
  │    │    ├── left-join (merge)
  │    │    │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date!null) lineitem.customerid:4(string) lineitem.ordernumber:5(int) lineitem.productid:6(string) lineitem.quantity:7(int)
  │    │    │    ├── key: (6)
@@ -2252,29 +2269,9 @@ project
  │    │    │         └── filters [type=bool, outer=(1,2,4,5), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /4: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(4), (4)==(1), (2)==(5), (5)==(2)]
  │    │    │              ├── customerorder.customerid = lineitem.customerid [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ])]
  │    │    │              └── customerorder.ordernumber = lineitem.ordernumber [type=bool, outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ])]
- │    │    ├── project
- │    │    │    ├── columns: column16:16(decimal)
- │    │    │    ├── outer: (1,2)
- │    │    │    ├── inner-join
- │    │    │    │    ├── columns: lineitem.customerid:8(string!null) lineitem.ordernumber:9(int!null) lineitem.productid:10(string!null) lineitem.quantity:11(int) product.productid:12(string!null) cost:14(decimal)
- │    │    │    │    ├── outer: (1,2)
- │    │    │    │    ├── key: (12)
- │    │    │    │    ├── fd: ()-->(8,9), (10)-->(11), (12)-->(14), (10)==(12), (12)==(10)
- │    │    │    │    ├── scan lineitem
- │    │    │    │    │    ├── columns: lineitem.customerid:8(string!null) lineitem.ordernumber:9(int!null) lineitem.productid:10(string!null) lineitem.quantity:11(int)
- │    │    │    │    │    ├── key: (8-10)
- │    │    │    │    │    └── fd: (8-10)-->(11)
- │    │    │    │    ├── scan product
- │    │    │    │    │    ├── columns: product.productid:12(string!null) cost:14(decimal)
- │    │    │    │    │    ├── key: (12)
- │    │    │    │    │    └── fd: (12)-->(14)
- │    │    │    │    └── filters [type=bool, outer=(1,2,8-10,12), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /8: (/NULL - ]; /9: (/NULL - ]; /10: (/NULL - ]; /12: (/NULL - ]), fd=(10)==(12), (12)==(10), (1)==(8), (8)==(1), (2)==(9), (9)==(2)]
- │    │    │    │         ├── lineitem.productid = product.productid [type=bool, outer=(10,12), constraints=(/10: (/NULL - ]; /12: (/NULL - ])]
- │    │    │    │         ├── lineitem.customerid = customerorder.customerid [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
- │    │    │    │         └── lineitem.ordernumber = customerorder.ordernumber [type=bool, outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ])]
- │    │    │    └── projections [outer=(11,14)]
- │    │    │         └── lineitem.quantity * product.cost [type=decimal, outer=(11,14)]
- │    │    └── true [type=bool]
+ │    │    └── filters [type=bool, outer=(1,2,8,9), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /8: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(8), (8)==(1), (2)==(9), (9)==(2)]
+ │    │         ├── lineitem.customerid = customerorder.customerid [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
+ │    │         └── lineitem.ordernumber = customerorder.ordernumber [type=bool, outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ])]
  │    └── aggregations [outer=(1-5,7,16)]
  │         ├── sum [type=decimal, outer=(16)]
  │         │    └── variable: column16 [type=decimal, outer=(16)]
@@ -2362,8 +2359,8 @@ project
  │    │    │    ├── grouping columns: customer.customerid:1(string!null) customerorder.customerid:4(string) customerorder.ordernumber:5(int) lineitem.customerid:7(string) lineitem.ordernumber:8(int) lineitem.productid:9(string) product.productid:11(string)
  │    │    │    ├── key: (1,4,5,7-9,11)
  │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9,11)-->(2,3,6,10,12-14,24)
- │    │    │    ├── left-join-apply
- │    │    │    │    ├── columns: customer.customerid:1(string!null) name:2(string!null) address:3(string!null) customerorder.customerid:4(string) customerorder.ordernumber:5(int) orderdate:6(date) lineitem.customerid:7(string) lineitem.ordernumber:8(int) lineitem.productid:9(string) lineitem.quantity:10(int) product.productid:11(string) product.description:12(string) product.cost:13(decimal) product.numberavailable:14(int) column23:23(decimal)
+ │    │    │    ├── left-join
+ │    │    │    │    ├── columns: customer.customerid:1(string!null) name:2(string!null) address:3(string!null) customerorder.customerid:4(string) customerorder.ordernumber:5(int) orderdate:6(date) lineitem.customerid:7(string) lineitem.ordernumber:8(int) lineitem.productid:9(string) lineitem.quantity:10(int) product.productid:11(string) product.description:12(string) product.cost:13(decimal) product.numberavailable:14(int) lineitem.customerid:15(string) lineitem.ordernumber:16(int) column23:23(decimal)
  │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14)
  │    │    │    │    ├── left-join
  │    │    │    │    │    ├── columns: customer.customerid:1(string!null) name:2(string!null) address:3(string!null) customerorder.customerid:4(string) customerorder.ordernumber:5(int) orderdate:6(date) lineitem.customerid:7(string) lineitem.ordernumber:8(int) lineitem.productid:9(string) lineitem.quantity:10(int) product.productid:11(string) product.description:12(string) product.cost:13(decimal) product.numberavailable:14(int)
@@ -2406,13 +2403,11 @@ project
  │    │    │    │    │    └── filters [type=bool, outer=(9,11), constraints=(/9: (/NULL - ]; /11: (/NULL - ]), fd=(9)==(11), (11)==(9)]
  │    │    │    │    │         └── lineitem.productid = product.productid [type=bool, outer=(9,11), constraints=(/9: (/NULL - ]; /11: (/NULL - ])]
  │    │    │    │    ├── project
- │    │    │    │    │    ├── columns: column23:23(decimal)
- │    │    │    │    │    ├── outer: (4,5)
+ │    │    │    │    │    ├── columns: column23:23(decimal) lineitem.customerid:15(string!null) lineitem.ordernumber:16(int!null)
  │    │    │    │    │    ├── inner-join
  │    │    │    │    │    │    ├── columns: lineitem.customerid:15(string!null) lineitem.ordernumber:16(int!null) lineitem.productid:17(string!null) lineitem.quantity:18(int) product.productid:19(string!null) product.cost:21(decimal)
- │    │    │    │    │    │    ├── outer: (4,5)
- │    │    │    │    │    │    ├── key: (19)
- │    │    │    │    │    │    ├── fd: ()-->(15,16), (17)-->(18), (19)-->(21), (17)==(19), (19)==(17)
+ │    │    │    │    │    │    ├── key: (15,16,19)
+ │    │    │    │    │    │    ├── fd: (15-17)-->(18), (19)-->(21), (17)==(19), (19)==(17)
  │    │    │    │    │    │    ├── scan lineitem
  │    │    │    │    │    │    │    ├── columns: lineitem.customerid:15(string!null) lineitem.ordernumber:16(int!null) lineitem.productid:17(string!null) lineitem.quantity:18(int)
  │    │    │    │    │    │    │    ├── key: (15-17)
@@ -2421,13 +2416,13 @@ project
  │    │    │    │    │    │    │    ├── columns: product.productid:19(string!null) product.cost:21(decimal)
  │    │    │    │    │    │    │    ├── key: (19)
  │    │    │    │    │    │    │    └── fd: (19)-->(21)
- │    │    │    │    │    │    └── filters [type=bool, outer=(4,5,15-17,19), constraints=(/4: (/NULL - ]; /5: (/NULL - ]; /15: (/NULL - ]; /16: (/NULL - ]; /17: (/NULL - ]; /19: (/NULL - ]), fd=(17)==(19), (19)==(17), (4)==(15), (15)==(4), (5)==(16), (16)==(5)]
- │    │    │    │    │    │         ├── lineitem.productid = product.productid [type=bool, outer=(17,19), constraints=(/17: (/NULL - ]; /19: (/NULL - ])]
- │    │    │    │    │    │         ├── lineitem.customerid = customerorder.customerid [type=bool, outer=(4,15), constraints=(/4: (/NULL - ]; /15: (/NULL - ])]
- │    │    │    │    │    │         └── lineitem.ordernumber = customerorder.ordernumber [type=bool, outer=(5,16), constraints=(/5: (/NULL - ]; /16: (/NULL - ])]
- │    │    │    │    │    └── projections [outer=(18,21)]
+ │    │    │    │    │    │    └── filters [type=bool, outer=(17,19), constraints=(/17: (/NULL - ]; /19: (/NULL - ]), fd=(17)==(19), (19)==(17)]
+ │    │    │    │    │    │         └── lineitem.productid = product.productid [type=bool, outer=(17,19), constraints=(/17: (/NULL - ]; /19: (/NULL - ])]
+ │    │    │    │    │    └── projections [outer=(15,16,18,21)]
  │    │    │    │    │         └── lineitem.quantity * product.cost [type=decimal, outer=(18,21)]
- │    │    │    │    └── true [type=bool]
+ │    │    │    │    └── filters [type=bool, outer=(4,5,15,16), constraints=(/4: (/NULL - ]; /5: (/NULL - ]; /15: (/NULL - ]; /16: (/NULL - ]), fd=(4)==(15), (15)==(4), (5)==(16), (16)==(5)]
+ │    │    │    │         ├── lineitem.customerid = customerorder.customerid [type=bool, outer=(4,15), constraints=(/4: (/NULL - ]; /15: (/NULL - ])]
+ │    │    │    │         └── lineitem.ordernumber = customerorder.ordernumber [type=bool, outer=(5,16), constraints=(/5: (/NULL - ]; /16: (/NULL - ])]
  │    │    │    └── aggregations [outer=(2,3,6,10,12-14,23)]
  │    │    │         ├── sum [type=decimal, outer=(23)]
  │    │    │         │    └── variable: column23 [type=decimal, outer=(23)]
@@ -2513,9 +2508,27 @@ project
  │    ├── grouping columns: lineitem.productid:6(string)
  │    ├── key: (6)
  │    ├── fd: ()-->(1-3), (6)-->(1-5,7,17), ()~~>(4,5)
- │    ├── left-join-apply
- │    │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date!null) lineitem.customerid:4(string) lineitem.ordernumber:5(int) lineitem.productid:6(string) lineitem.quantity:7(int) column16:16(decimal)
+ │    ├── right-join
+ │    │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date!null) lineitem.customerid:4(string) lineitem.ordernumber:5(int) lineitem.productid:6(string) lineitem.quantity:7(int) lineitem.customerid:8(string) lineitem.ordernumber:9(int) column16:16(decimal)
  │    │    ├── fd: ()-->(1-3), (6)-->(4,5,7), ()~~>(4,5)
+ │    │    ├── project
+ │    │    │    ├── columns: column16:16(decimal) lineitem.customerid:8(string!null) lineitem.ordernumber:9(int!null)
+ │    │    │    ├── inner-join
+ │    │    │    │    ├── columns: lineitem.customerid:8(string!null) lineitem.ordernumber:9(int!null) lineitem.productid:10(string!null) lineitem.quantity:11(int) product.productid:12(string!null) cost:14(decimal)
+ │    │    │    │    ├── key: (8,9,12)
+ │    │    │    │    ├── fd: (8-10)-->(11), (12)-->(14), (10)==(12), (12)==(10)
+ │    │    │    │    ├── scan lineitem
+ │    │    │    │    │    ├── columns: lineitem.customerid:8(string!null) lineitem.ordernumber:9(int!null) lineitem.productid:10(string!null) lineitem.quantity:11(int)
+ │    │    │    │    │    ├── key: (8-10)
+ │    │    │    │    │    └── fd: (8-10)-->(11)
+ │    │    │    │    ├── scan product
+ │    │    │    │    │    ├── columns: product.productid:12(string!null) cost:14(decimal)
+ │    │    │    │    │    ├── key: (12)
+ │    │    │    │    │    └── fd: (12)-->(14)
+ │    │    │    │    └── filters [type=bool, outer=(10,12), constraints=(/10: (/NULL - ]; /12: (/NULL - ]), fd=(10)==(12), (12)==(10)]
+ │    │    │    │         └── lineitem.productid = product.productid [type=bool, outer=(10,12), constraints=(/10: (/NULL - ]; /12: (/NULL - ])]
+ │    │    │    └── projections [outer=(8,9,11,14)]
+ │    │    │         └── lineitem.quantity * product.cost [type=decimal, outer=(11,14)]
  │    │    ├── left-join (merge)
  │    │    │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date!null) lineitem.customerid:4(string) lineitem.ordernumber:5(int) lineitem.productid:6(string) lineitem.quantity:7(int)
  │    │    │    ├── key: (6)
@@ -2537,29 +2550,9 @@ project
  │    │    │         └── filters [type=bool, outer=(1,2,4,5), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /4: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(4), (4)==(1), (2)==(5), (5)==(2)]
  │    │    │              ├── customerorder.customerid = lineitem.customerid [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ])]
  │    │    │              └── customerorder.ordernumber = lineitem.ordernumber [type=bool, outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ])]
- │    │    ├── project
- │    │    │    ├── columns: column16:16(decimal)
- │    │    │    ├── outer: (1,2)
- │    │    │    ├── inner-join
- │    │    │    │    ├── columns: lineitem.customerid:8(string!null) lineitem.ordernumber:9(int!null) lineitem.productid:10(string!null) lineitem.quantity:11(int) product.productid:12(string!null) cost:14(decimal)
- │    │    │    │    ├── outer: (1,2)
- │    │    │    │    ├── key: (12)
- │    │    │    │    ├── fd: ()-->(8,9), (10)-->(11), (12)-->(14), (10)==(12), (12)==(10)
- │    │    │    │    ├── scan lineitem
- │    │    │    │    │    ├── columns: lineitem.customerid:8(string!null) lineitem.ordernumber:9(int!null) lineitem.productid:10(string!null) lineitem.quantity:11(int)
- │    │    │    │    │    ├── key: (8-10)
- │    │    │    │    │    └── fd: (8-10)-->(11)
- │    │    │    │    ├── scan product
- │    │    │    │    │    ├── columns: product.productid:12(string!null) cost:14(decimal)
- │    │    │    │    │    ├── key: (12)
- │    │    │    │    │    └── fd: (12)-->(14)
- │    │    │    │    └── filters [type=bool, outer=(1,2,8-10,12), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /8: (/NULL - ]; /9: (/NULL - ]; /10: (/NULL - ]; /12: (/NULL - ]), fd=(10)==(12), (12)==(10), (1)==(8), (8)==(1), (2)==(9), (9)==(2)]
- │    │    │    │         ├── lineitem.productid = product.productid [type=bool, outer=(10,12), constraints=(/10: (/NULL - ]; /12: (/NULL - ])]
- │    │    │    │         ├── lineitem.customerid = customerorder.customerid [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
- │    │    │    │         └── lineitem.ordernumber = customerorder.ordernumber [type=bool, outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ])]
- │    │    │    └── projections [outer=(11,14)]
- │    │    │         └── lineitem.quantity * product.cost [type=decimal, outer=(11,14)]
- │    │    └── true [type=bool]
+ │    │    └── filters [type=bool, outer=(1,2,8,9), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /8: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(8), (8)==(1), (2)==(9), (9)==(2)]
+ │    │         ├── lineitem.customerid = customerorder.customerid [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
+ │    │         └── lineitem.ordernumber = customerorder.ordernumber [type=bool, outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ])]
  │    └── aggregations [outer=(1-5,7,16)]
  │         ├── sum [type=decimal, outer=(16)]
  │         │    └── variable: column16 [type=decimal, outer=(16)]
@@ -2606,21 +2599,15 @@ project
  │    ├── grouping columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null)
  │    ├── key: (1,2)
  │    ├── fd: (1,2)-->(3,13)
- │    ├── left-join-apply
- │    │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date!null) column12:12(decimal)
+ │    ├── right-join
+ │    │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date!null) lineitem.customerid:4(string) lineitem.ordernumber:5(int) column12:12(decimal)
  │    │    ├── fd: (1,2)-->(3)
- │    │    ├── scan customerorder
- │    │    │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date!null)
- │    │    │    ├── key: (1,2)
- │    │    │    └── fd: (1,2)-->(3)
  │    │    ├── project
- │    │    │    ├── columns: column12:12(decimal)
- │    │    │    ├── outer: (1,2)
+ │    │    │    ├── columns: column12:12(decimal) lineitem.customerid:4(string!null) lineitem.ordernumber:5(int!null)
  │    │    │    ├── inner-join
  │    │    │    │    ├── columns: lineitem.customerid:4(string!null) lineitem.ordernumber:5(int!null) lineitem.productid:6(string!null) quantity:7(int) product.productid:8(string!null) cost:10(decimal)
- │    │    │    │    ├── outer: (1,2)
- │    │    │    │    ├── key: (8)
- │    │    │    │    ├── fd: ()-->(4,5), (6)-->(7), (8)-->(10), (6)==(8), (8)==(6)
+ │    │    │    │    ├── key: (4,5,8)
+ │    │    │    │    ├── fd: (4-6)-->(7), (8)-->(10), (6)==(8), (8)==(6)
  │    │    │    │    ├── scan lineitem
  │    │    │    │    │    ├── columns: lineitem.customerid:4(string!null) lineitem.ordernumber:5(int!null) lineitem.productid:6(string!null) quantity:7(int)
  │    │    │    │    │    ├── key: (4-6)
@@ -2629,13 +2616,17 @@ project
  │    │    │    │    │    ├── columns: product.productid:8(string!null) cost:10(decimal)
  │    │    │    │    │    ├── key: (8)
  │    │    │    │    │    └── fd: (8)-->(10)
- │    │    │    │    └── filters [type=bool, outer=(1,2,4-6,8), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /4: (/NULL - ]; /5: (/NULL - ]; /6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6), (1)==(4), (4)==(1), (2)==(5), (5)==(2)]
- │    │    │    │         ├── lineitem.productid = product.productid [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ])]
- │    │    │    │         ├── lineitem.customerid = customerorder.customerid [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ])]
- │    │    │    │         └── lineitem.ordernumber = customerorder.ordernumber [type=bool, outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ])]
- │    │    │    └── projections [outer=(7,10)]
+ │    │    │    │    └── filters [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
+ │    │    │    │         └── lineitem.productid = product.productid [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ])]
+ │    │    │    └── projections [outer=(4,5,7,10)]
  │    │    │         └── lineitem.quantity * product.cost [type=decimal, outer=(7,10)]
- │    │    └── true [type=bool]
+ │    │    ├── scan customerorder
+ │    │    │    ├── columns: customerorder.customerid:1(string!null) customerorder.ordernumber:2(int!null) orderdate:3(date!null)
+ │    │    │    ├── key: (1,2)
+ │    │    │    └── fd: (1,2)-->(3)
+ │    │    └── filters [type=bool, outer=(1,2,4,5), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /4: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(4), (4)==(1), (2)==(5), (5)==(2)]
+ │    │         ├── lineitem.customerid = customerorder.customerid [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ])]
+ │    │         └── lineitem.ordernumber = customerorder.ordernumber [type=bool, outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ])]
  │    └── aggregations [outer=(3,12)]
  │         ├── sum [type=decimal, outer=(12)]
  │         │    └── variable: column12 [type=decimal, outer=(12)]

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -2642,7 +2642,6 @@ drop table customer, customerorder, lineitem, product
 # ------------------------------------------------------------------------------
 # Query #12
 #   org.hibernate.test.criteria.CriteriaQueryTest
-#   TODO(andyk): Need to map SemiJoinApply to InnerJoinApply for decorrelation.
 # ------------------------------------------------------------------------------
 exec-ddl
 CREATE TABLE student (
@@ -2708,45 +2707,63 @@ WHERE
         )
   );
 ----
-semi-join-apply
- ├── columns: studenti1_26_0_:1(int!null) name2_26_0_:2(string!null) address_3_26_0_:3(string) address_4_26_0_:4(string) preferre5_26_0_:5(string)
+group-by
+ ├── columns: studenti1_26_0_:1(int!null) name2_26_0_:2(string) address_3_26_0_:3(string) address_4_26_0_:4(string) preferre5_26_0_:5(string)
+ ├── grouping columns: student.studentid:1(int!null)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- ├── scan student
- │    ├── columns: student.studentid:1(int!null) name:2(string!null) address_city:3(string) address_state:4(string) preferredcoursecode:5(string)
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
  ├── select
- │    ├── columns: enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null) enrolment.year:9(int!null) y0_:14(int!null)
- │    ├── outer: (5)
- │    ├── key: (6,7)
- │    ├── fd: (6,7)-->(9,14), (9)==(14), (14)==(9)
+ │    ├── columns: student.studentid:1(int!null) name:2(string) address_city:3(string) address_state:4(string) preferredcoursecode:5(string) enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null) enrolment.year:9(int!null) y0_:14(int!null)
+ │    ├── key: (1,6,7)
+ │    ├── fd: (1)-->(2-5), (6,7)-->(9), (1,6,7)-->(2-5,9,14), (9)==(14), (14)==(9)
  │    ├── group-by
- │    │    ├── columns: enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null) enrolment.year:9(int) y0_:14(int)
- │    │    ├── grouping columns: enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null)
- │    │    ├── outer: (5)
- │    │    ├── key: (6,7)
- │    │    ├── fd: (6,7)-->(9,14)
+ │    │    ├── columns: student.studentid:1(int!null) name:2(string) address_city:3(string) address_state:4(string) preferredcoursecode:5(string) enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null) enrolment.year:9(int) y0_:14(int)
+ │    │    ├── grouping columns: student.studentid:1(int!null) enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null)
+ │    │    ├── key: (1,6,7)
+ │    │    ├── fd: (1)-->(2-5), (6,7)-->(9), (1,6,7)-->(2-5,9,14)
  │    │    ├── inner-join
- │    │    │    ├── columns: enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null) enrolment.year:9(int!null) enrolment.coursecode:11(string!null) enrolment.year:13(int!null)
- │    │    │    ├── outer: (5)
- │    │    │    ├── fd: ()-->(11), (6,7)-->(9)
- │    │    │    ├── scan enrolment
- │    │    │    │    ├── columns: enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null) enrolment.year:9(int!null)
- │    │    │    │    ├── key: (6,7)
- │    │    │    │    └── fd: (6,7)-->(9)
- │    │    │    ├── scan enrolment
- │    │    │    │    └── columns: enrolment.coursecode:11(string!null) enrolment.year:13(int!null)
+ │    │    │    ├── columns: student.studentid:1(int!null) name:2(string!null) address_city:3(string) address_state:4(string) preferredcoursecode:5(string!null) enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null) enrolment.year:9(int!null) enrolment.coursecode:11(string!null) enrolment.year:13(int!null)
+ │    │    │    ├── fd: (1)-->(2-5), (6,7)-->(9), (5)==(11), (11)==(5)
+ │    │    │    ├── inner-join
+ │    │    │    │    ├── columns: enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null) enrolment.year:9(int!null) enrolment.coursecode:11(string!null) enrolment.year:13(int!null)
+ │    │    │    │    ├── fd: (6,7)-->(9)
+ │    │    │    │    ├── scan enrolment
+ │    │    │    │    │    ├── columns: enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null) enrolment.year:9(int!null)
+ │    │    │    │    │    ├── key: (6,7)
+ │    │    │    │    │    └── fd: (6,7)-->(9)
+ │    │    │    │    ├── scan enrolment
+ │    │    │    │    │    └── columns: enrolment.coursecode:11(string!null) enrolment.year:13(int!null)
+ │    │    │    │    └── true [type=bool]
+ │    │    │    ├── scan student
+ │    │    │    │    ├── columns: student.studentid:1(int!null) name:2(string!null) address_city:3(string) address_state:4(string) preferredcoursecode:5(string)
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    └── fd: (1)-->(2-5)
  │    │    │    └── filters [type=bool, outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ]), fd=(5)==(11), (11)==(5)]
  │    │    │         └── student.preferredcoursecode = enrolment.coursecode [type=bool, outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ])]
- │    │    └── aggregations [outer=(9,13)]
+ │    │    └── aggregations [outer=(2-5,9,13)]
  │    │         ├── max [type=int, outer=(13)]
  │    │         │    └── variable: enrolment.year [type=int, outer=(13)]
- │    │         └── any-not-null [type=int, outer=(9)]
- │    │              └── variable: enrolment.year [type=int, outer=(9)]
+ │    │         ├── any-not-null [type=int, outer=(9)]
+ │    │         │    └── variable: enrolment.year [type=int, outer=(9)]
+ │    │         ├── any-not-null [type=string, outer=(2)]
+ │    │         │    └── variable: student.name [type=string, outer=(2)]
+ │    │         ├── any-not-null [type=string, outer=(3)]
+ │    │         │    └── variable: student.address_city [type=string, outer=(3)]
+ │    │         ├── any-not-null [type=string, outer=(4)]
+ │    │         │    └── variable: student.address_state [type=string, outer=(4)]
+ │    │         └── any-not-null [type=string, outer=(5)]
+ │    │              └── variable: student.preferredcoursecode [type=string, outer=(5)]
  │    └── filters [type=bool, outer=(9,14), constraints=(/9: (/NULL - ]; /14: (/NULL - ]), fd=(9)==(14), (14)==(9)]
  │         └── enrolment.year = y0_ [type=bool, outer=(9,14), constraints=(/9: (/NULL - ]; /14: (/NULL - ])]
- └── true [type=bool]
+ └── aggregations [outer=(2-5)]
+      ├── any-not-null [type=string, outer=(2)]
+      │    └── variable: student.name [type=string, outer=(2)]
+      ├── any-not-null [type=string, outer=(3)]
+      │    └── variable: student.address_city [type=string, outer=(3)]
+      ├── any-not-null [type=string, outer=(4)]
+      │    └── variable: student.address_state [type=string, outer=(4)]
+      └── any-not-null [type=string, outer=(5)]
+           └── variable: student.preferredcoursecode [type=string, outer=(5)]
 
 exec-ddl
 drop table student, enrolment

--- a/pkg/sql/opt/xfunc/custom_funcs.go
+++ b/pkg/sql/opt/xfunc/custom_funcs.go
@@ -120,6 +120,13 @@ func (c *CustomFuncs) IsBoundBy(src, dst memo.GroupID) bool {
 	return c.OuterCols(src).SubsetOf(c.OutputCols(dst))
 }
 
+// IsBoundBy2 returns true if all outer references in the source expression are
+// bound by one of the two destination expressions. This is a variation on the
+// IsBoundBy method.
+func (c *CustomFuncs) IsBoundBy2(src, dst1, dst2 memo.GroupID) bool {
+	return c.OuterCols(src).SubsetOf(c.OutputCols(dst1).Union(c.OutputCols(dst2)))
+}
+
 // ExtractBoundConditions returns a new list containing only those expressions
 // from the given list that are fully bound by the given expression (i.e. all
 // outer references are satisfied by it). For example:


### PR DESCRIPTION
Add more decorrelation rules needed for the Hibernate test suite:

- TryDecorrelateSemiJoin maps a SemiJoin to an equivalent GroupBy/
    InnerJoin complex in hopes of triggering further rules that will
    ultimately decorrelate the query.

- TryDecorrelateProjectInnerJoin tries to decorrelate by hoisting the
    filter of an InnerJoin operator that sits below a LeftJoin/Project
    operator combo.

Also fix a couple bugs with existing decorrelation rules.