### PR TITLE
sql: quantize the statement counts reported to the reg server

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -833,7 +833,7 @@ func importPlanHook(
 			tableDetails = append(tableDetails, jobspb.ImportDetails_Table{Name: name})
 		}
 
-		telemetry.CountBucketed("import.files", len(files))
+		telemetry.CountBucketed("import.files", int64(len(files)))
 
 		_, errCh, err := p.ExecCfg().JobRegistry.StartJob(ctx, resultsCh, jobs.Record{
 			Description: jobDesc,
@@ -1136,9 +1136,9 @@ func (r *importResumer) OnTerminal(
 	}
 
 	if status == jobs.StatusSucceeded {
-		telemetry.CountBucketed("import.rows", int(r.res.Rows))
+		telemetry.CountBucketed("import.rows", r.res.Rows)
 		const mb = 1 << 20
-		telemetry.CountBucketed("import.size-mb", int(r.res.DataSize/mb))
+		telemetry.CountBucketed("import.size-mb", r.res.DataSize/mb)
 
 		resultsCh <- tree.Datums{
 			tree.NewDInt(tree.DInt(*job.ID())),

--- a/pkg/roachpb/app_stats.pb.go
+++ b/pkg/roachpb/app_stats.pb.go
@@ -19,6 +19,8 @@ var _ = math.Inf
 type StatementStatistics struct {
 	// Count is the total number of times this statement was executed
 	// since the begin of the reporting period.
+	// When transmitted to the reporting server, this value gets
+	// quantized into buckets (few <10, dozens 10+, 100 or more).
 	Count int64 `protobuf:"varint,1,opt,name=count" json:"count"`
 	// FirstAttemptCount collects the total number of times a first
 	// attempt was executed (either the one time in explicitly committed
@@ -28,9 +30,15 @@ type StatementStatistics struct {
 	// can be computed as FirstAttemptCount / Count.
 	// The cumulative number of retries can be computed with
 	// Count - FirstAttemptCount.
+	//
+	// When transmitted to the reporting server, this value gets
+	// simplified so that the proportion of statements that could be
+	// executed without retry remains as FirstAttemptCount / Count.
 	FirstAttemptCount int64 `protobuf:"varint,2,opt,name=first_attempt_count,json=firstAttemptCount" json:"first_attempt_count"`
 	// MaxRetries collects the maximum observed number of automatic
 	// retries in the reporting period.
+	// When transmitted to the reporting server, this value gets
+	// quantized into buckets (few <10, dozens 10+, 100 or more).
 	MaxRetries int64 `protobuf:"varint,3,opt,name=max_retries,json=maxRetries" json:"max_retries"`
 	// LastErr collects the last error encountered.
 	LastErr string `protobuf:"bytes,4,opt,name=last_err,json=lastErr" json:"last_err"`

--- a/pkg/roachpb/app_stats.proto
+++ b/pkg/roachpb/app_stats.proto
@@ -21,6 +21,8 @@ import "gogoproto/gogo.proto";
 message StatementStatistics {
   // Count is the total number of times this statement was executed
   // since the begin of the reporting period.
+  // When transmitted to the reporting server, this value gets
+  // quantized into buckets (few <10, dozens 10+, 100 or more).
   optional int64 count = 1 [(gogoproto.nullable) = false];
 
   // FirstAttemptCount collects the total number of times a first
@@ -31,10 +33,16 @@ message StatementStatistics {
   // can be computed as FirstAttemptCount / Count.
   // The cumulative number of retries can be computed with
   // Count - FirstAttemptCount.
+  //
+  // When transmitted to the reporting server, this value gets
+  // simplified so that the proportion of statements that could be
+  // executed without retry remains as FirstAttemptCount / Count.
   optional int64 first_attempt_count = 2 [(gogoproto.nullable) = false];
 
   // MaxRetries collects the maximum observed number of automatic
   // retries in the reporting period.
+  // When transmitted to the reporting server, this value gets
+  // quantized into buckets (few <10, dozens 10+, 100 or more).
   optional int64 max_retries = 3 [(gogoproto.nullable) = false];
 
   // LastErr collects the last error encountered.
@@ -64,6 +72,8 @@ message StatementStatistics {
   // We store it separately (as opposed to computing it post-hoc) because the combined
   // variance for the overhead cannot be derived from the variance of the separate latencies.
   optional NumericStat overhead_lat = 10 [(gogoproto.nullable) = false];
+
+  // Note: be sure to update `sql/app_stats.go` when adding/removing fields here!
 }
 
 message NumericStat {


### PR DESCRIPTION
Fixes #25114.

This preserves every count smaller than 10, then for larger values
bucket into buckets that are powers of 10.

Release note (sql change): CockroachDB now hides more information from
the statement statistics reported to Cockroach Labs.