### PR TITLE
 opt: pass through merge join ordering

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -401,8 +401,9 @@ func (b *Builder) buildMergeJoin(ev memo.ExprView) (execPlan, error) {
 	leftOrd := b.makeSQLOrdering(left, def.LeftEq)
 	rightOrd := b.makeSQLOrdering(right, def.RightEq)
 	ep := execPlan{outputCols: outputCols}
+	reqOrd := b.makeSQLOrderingFromChoice(ep, &ev.Physical().Ordering)
 	ep.root, err = b.factory.ConstructMergeJoin(
-		joinType, left.root, right.root, onExpr, leftOrd, rightOrd,
+		joinType, left.root, right.root, onExpr, leftOrd, rightOrd, reqOrd,
 	)
 	if err != nil {
 		return execPlan{}, err

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
@@ -178,301 +178,278 @@ NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
 /36/#/55/1/76               /38/#/56/1/78/38/#/58/1/38  10        {4}       4
 /38/#/56/1/78/38/#/58/1/38  NULL                        20        {5}       5
 
-# TODO(radu): enable these tests when we plan merge joins.
-# statement ok
-# SET CLUSTER SETTING sql.distsql.interleaved_joins.enabled = true;
-# 
-# #####################
-# # Interleaved joins #
-# #####################
-# 
-# # Select over two ranges for parent/child with split at children key.
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJzMkkFr6zAQhO_vVzzm9B7dEstpL4aCryklKbkWH4S1SQSOZFZyaSn570VWoU5oQ9tTb5ZmZscf2hc4b3ip9xxQPUCBUIIwR0PoxbccgpckZePCPKEqCNb1Q8zX0caOUWFwXgwLGxAMR227pDeHhtB6YVTv1qW_9P2sPDES_BDfxjaEEPWWUZUHmlSrSfUHgxcusnSsH3nN2rDceutYZsVRE-54E5Hw7F7Lc91rYRcT-dpud1Ol3dnOJCHPAaHjTfxXq4v_N5K84ycIqyFWf2tFdUn1FdXX-IxGHdGUP6JRv5SmOE-z5tB7F_hLr16ktWGz5bxjwQ_S8r34dqzJx9WYGy8Mh5jVeT4sXJbSD07D6my4OAqr03D5rXBz-PMaAAD__y7yGHk=
-# 
-# # Swap parent1 and child1 tables.
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM child1 JOIN parent1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJzMklFL-zAUxd__n-LPeVK8sqbDl4LQ14lsslfpQ2jutkCXlJtUFNl3lzSC3dChPvnW5JxzT3_kvsJ5w0u954DqEQqEEoQ5GkIvvuUQvCQpGxfmGVVBsK4fYr6ONnaMCoPzYljYgGA4atslvTk0hNYLo_qwLv2172fliZHgh_g-tiGEqLeMqjzQpFpNqj8ZvHCRpWP9xGvWhuXOW8cyK46acM-biIRn91pe6nZnO5PA13a7mwq9FnYxKXkOCB1v4kWtri5vJZnHTxBWQ6z-14rqkuo51Tf4ikYd0ZS_olF_lKY4T7Pm0HsX-FuvXqS1YbPlvGPBD9Lyg_h2rMnH1ZgbLwyHmNV5PixcltIPTsPqbLg4CqvTcPmjcHP49xYAAP__IiwYdw==
-# 
-# # Select over two ranges for parent/child with split at grandchild key.
-# # Also, rows with pid1 <= 30 should have 4 rows whereas pid1 > 30 should
-# # have 3 rows.
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 ON parent1.pid1 = child1.pid1 WHERE parent1.pid1 >= 29 AND parent1.pid1 <= 31 ORDER BY parent1.pid1]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJzUUcFq6zAQvL-veOypJSqxnOZiKOiaUpKSa_FBWBtH4EhmtS4twf9eJB0Sl6S0vfVm7czs7IyP4LzBtT5ggOoFJAhYQi2gJ99gCJ7iOJNW5g2qQoB1_cBxXAtoPCFUR2DLHUIFK8dIHepX3KI2SI_eOqR5XGuQte2SyxPuGKKHPWh6V70mdBw5W9vuz5FmbzsTgbwHBHS44xslZ7cPFLnpEwRsBq7-KylUKdRCqHuhllCPAvzAp2MD6xahkqO4EuiUw5NBQjM9W8kZ1OOF1Gt_5_t5OWFfcy8n7vJXdRZ_o84LgbYYeu8CfquqInaNpsX8b4IfqMFn8k2yyc9N0qWBwcAZlfmxcglKB56L5ZfixURcfBaXP3Kux38fAQAA__8x_hkU
-# 
-# # Parent-child where pid1 <= 15 have one joined row and pid1 > 15 have no
-# # joined rows (since child2 only has 15 rows up to pid1 = 15).
-# # Note this spans all 5 nodes, which makes sense since we want to read all
-# # parent rows even if child rows are non-existent (so we can support OUTER
-# # joins).
-# # TODO(richardwu): we can remove nodes reading from just one table for INNER
-# # joins or LEFT/RIGHT joins.
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 >= 12 ORDER BY pid1]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJzMlD1rwzAQhvf-ivJOLbkSyx8ZDAWtKSUpWYsHY10Sg2MZSS4twf-92B4Sl6YfzuLN0t3j9x6BdESpFa_SA1vErxAg-CAEIIQgREgIldEZW6tN29IDS_WO2CPkZVW7djshZNow4iNc7gpGjGXp2BScvvGGU8XmSeclm7kHgmKX5kWX-MxbhzYjP6TmQ1ap4dK1Y2zy3f68ku3zQrWz9f8BoeCtu5Nidv9o2t7uE4R17eJbKUj6JEOSEckFkoaga3ca1rp0x4hFQxeETh7aKDashmNLMUPSfGO90g-6mkeD7kvp_iBdjDpOMd3j9EcJ-dMVCkYJBdMVCkcJhdMV-uVJ2rCtdGn5T7fTa683qx33z4HVtcn4xeisi-mX647rNhRb11dFv1iWXakb8BwWP8KLAex9hf1rkoNr4PAaOPoXnDQ3nwEAAP__9wcgdA==
-# 
-# # These rows are all on the same node 1 (gateway).
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 IN (1, 11, 21, 31) ORDER BY pid1]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJyMUE1LxDAUvPsrZE6KD9ws6iEg5LoirvQqPYTmbTfQTcrLqyhL_7u0OagHwVvmIzOZnJFy4Bd_4gL7BoOWMEruuJQsC1UNu_ABuyHENE660C2hy8KwZ2jUgWGxS8oysH_nhn1gecoxsdxuQAisPg5rwzMfFEtHPHn5dKMXTmpAaGJ__Kl0xziELQg1B4SBD3rlzM31oyze9QjCflJ76Qy5Lbk7cvfkHtDOhDzp92OL-p5hzUz_H9RwGXMq_GvAX8mbuSVw6Ll-WsmTdPwquVtrKtyv91YicNGqmgp2qUpzO198BQAA___Vk4P-
-# 
-# # Parent-grandchild.
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL)
-#   SELECT * FROM parent1 JOIN grandchild2 USING(pid1) WHERE
-#     pid1 >= 11 AND pid1 <= 13
-#     OR pid1 >= 19 AND pid1 <= 21
-#     OR pid1 >= 31 AND pid1 <= 33
-# ]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJzslE9r3DAQxe_9FGJOu3RKLDlpqWBBhVJwKd5iemt9ENbEETiSkeTSEvzdi-0u8Yb0Xwohh71ZevPjDX6juQHnDZX6miLIz8ABQQDCBdQIffANxejDJC2FhfkGMkOwrh_SdF0jND4QyBtINnUEEgqXKHSkv1JF2lB4762jcJYBgqGkbTc7faDLBJOHvdbhu-p1IJcm-0lg72yXKEi22SjOvgxZljc7xnMpZVF-2rJ9tVJox_jrg_KmfMvWjOA_le1CraD8IAFCZdurdTtt0M40V7Yz4qA-ek_LfwOEji7TRvHn212YGpk_AWE_JMkURyVQnaO6QPUS1SuoRwQ_pNt8YtItgeQj_iLD2-gG54OhQOYoq3q8J-XSv_D9WX6n8H5rcWTNHzQ-_DQ-T2h8xIMyFKcMn1CGf1jjFcXeu0h_9cKzaUWQaWnZJ9EPoaGPwTezzXLcz9x8YSimReXLoXCzNDe4hvlv4fMjOLsLi_9xzv8JrsdnPwIAAP__gf0kvQ==
-# 
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL)
-#   SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
-#     pid1 >= 11 AND pid1 <= 13
-#     OR pid1 >= 19 AND pid1 <= 21
-#     OR pid1 >= 31 AND pid1 <= 33
-# ]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJzslE-L2zAQxe_9FGJOCZ2ylr1LqSCgQim4FKeY3lofhDXrFXglI8mlZfF3L7Yb4oT0Xwolh9wsvfnxBr_RPIF1mgr1SAHEJ-CAkALCHVQInXc1heD8KM2Fuf4KIkEwtuvjeF0h1M4TiCeIJrYEAnIbybekvlBJSpN_54wlf5MAgqaoTDs5vaf7CKOHeVT-m2y8srp-MK0e7UeRvTVtJC_YaiU5-9wnSVZvGM-EEHnxcc225UKhDeOvdsrr4g1bMin_oaxnagFlOwkQStM8LFvqlCcb-U757_3M_w0QWrqPK8mfrzd-bGT6BIRtHwWTHGWKMkN5i_IO5UuoBgTXx30-IaqGQPABf5LhPrreOq_Jkz7IqhpOpFy4F667yY4KT1unB9b8rPHh1_G5oPFJz8owvWZ4QRn-Zo2XFDpnA_3RC0_GFUG6oXmfBNf7mj54V08283E7cdOFphBnlc-H3E7S1OAS5r-Ebw_g5BhO_8U5-yu4Gp59DwAA__8zXSS0
-# 
-# query TTT
-# EXPLAIN SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
-#   pid1 >= 11 AND pid1 <= 13
-#   OR pid1 >= 19 AND pid1 <= 21
-#   OR pid1 >= 31 AND pid1 <= 33
-# ----
-# render          ·               ·
-#  └── join       ·               ·
-#       │         type            inner
-#       │         equality        (pid1) = (pid1)
-#       │         mergeJoinOrder  +"(pid1=pid1)"
-#       ├── scan  ·               ·
-#       │         table           grandchild2@primary
-#       │         spans           /11/#/56/1-/13/#/56/2 /19/#/56/1-/21/#/56/2 /31/#/56/1-/33/#/56/2
-#       └── scan  ·               ·
-# ·               table           parent1@primary
-# ·               spans           /11-/13/# /19-/21/# /31-/33/#
-# 
-# # Join on multiple interleaved columns with an overarching ancestor (parent1).
-# # Note there are 5 nodes because the filter cid2 >= 12 AND cid2 <= 14
-# # creates a giant parent span which requires reading from all rows.
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL)
-#   SELECT * FROM child2 JOIN grandchild2 ON
-#     child2.pid1=grandchild2.pid1
-#     AND child2.cid2=grandchild2.cid2
-#     AND child2.cid3=grandchild2.cid3
-#   WHERE
-#     child2.pid1 >= 5 AND child2.pid1 <= 7
-#     OR child2.cid2 >= 12 AND child2.cid2 <= 14
-#     OR gcid2 >= 49 AND gcid2 <= 51
-# ]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJzslUFr2zAUx-_7FOKdHPJGLVluV0FAgzHIGMkIu20-GOs1NbhWkOSxUfLdh-3FrUs21gRy8tH668df8k_wHqG2hlb5A3lQ34ADggCEBBAkIKSQIeycLch769otPbA0P0HFCGW9a0K7nCEU1hGoRwhlqAgULOtArqL8B20oN-Q-2bImdxUDgqGQl1XX-JnuArQd5UPufunivqxMe4JNub1_HmxdXptxyj6WVSCnWBRFmrPvTRwntGCpUmq5-jpj71cf2BAUC3bzJ5ix9YZFkRYDwsWYEQPD5QE6UHKg5O2YkgOV8gMFCP29AaGiuxBpPkct5qiT-Wzh2muMlgBh3QTFNEctUCeoJeoU9TXqG9TvUN9CtkewTXj68T7kWwLF9_gXOU9Omto6Q47MSEK2P6JvZd_a3VX6YuPxajGq5ie9Cz69i0u8C3GSHDHJuYSc5CQ5ySTnEnLkSXLkJOfS4-6InA35na09_dc0i9txSGZL_ez0tnEFfXG26Gr6z3XHdQuGfOhT3n8s6y7qDvgc5v-Er0dw_BIW5zQn58DyHDh9FZzt3_wOAAD__-mfE2o=
-# 
-# query TTT
-# EXPLAIN
-#   SELECT * FROM child2 JOIN grandchild2 ON
-#     child2.pid1=grandchild2.pid1
-#     AND child2.cid2=grandchild2.cid2
-#     AND child2.cid3=grandchild2.cid3
-#   WHERE
-#     child2.pid1 >= 5 AND child2.pid1 <= 7
-#     OR child2.cid2 >= 12 AND child2.cid2 <= 14
-#     OR gcid2 >= 49 AND gcid2 <= 51
-# ----
-# join       ·               ·
-#  │         type            inner
-#  │         equality        (pid1, cid2, cid3) = (pid1, cid2, cid3)
-#  │         mergeJoinOrder  +"(pid1=pid1)",+"(cid2=cid2)",+"(cid3=cid3)"
-#  ├── scan  ·               ·
-#  │         table           child2@primary
-#  │         spans           ALL
-#  └── scan  ·               ·
-# ·          table           grandchild2@primary
-# ·          spans           ALL
-# 
-# # Aggregation over parent and child keys.
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL)
-#   SELECT sum(parent1.pid1), sum(child1.cid1) FROM parent1 JOIN child1 USING(pid1) WHERE
-#     pid1 >= 10 AND pid1 <= 39
-# ]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJzUlVGrmzAUx9_3KS7n6V4WuEZtbysM3GPHto6OPQ0fgjm1gk0kiWOj-N1HlLVa2jisL74lOefv75z_CeYEQnL8yo6oIfoJFAj4QCAAAiEQWEBCoFQyRa2lsimtYMN_Q-QRyEVZGXucEEilQohOYHJTIESwEQZVgewX7pBxVJ9kLlC9WgRHw_KiIX7GvQHLyI9M_YlLplAYm2MDT9vKRE-x3e7y7NBNTA95wc-Bf4kkttW3JCBQ4N48x_T9ywdls5olEDgnB5DUBGRlLl1owzKEiNbk_zv9mGUKM2akel32u_v-48tzTC2zWfkvd4H-XeCFUwmpOCrkPUhSu0ui3tiagl5NdNS4_RmOe6DTjrdv04zbH2VtMENrBzrtWLuaxtpglLXhDK0d6LRj7Xoaa8NR1noztHag0461i-n__zeAO9SlFBqv3oHbX_bs-4A8w_Yx0bJSKX5TMm0w7Xbb6JoDjtq0UdpuNqIN2QK7YuoU-z0xvRb7bvIAOnCqQ7c4fKTuhVO8dJOXj5DfnOKVm7x6hLx2z8obuCbuS3bNTup3fwMAAP__hy1jzg==
-# 
-# ###############
-# # Outer joins #
-# ###############
-# 
-# # The schema/values for each table are as follows:
-# # Table:        pkey:                     pkey values (same):   values:
-# # outer_p1      (pid1)                    {1, 2, 3, ... 20}     100 + pkey
-# # outer_c1      (pid1, cid1, cid2)        {2, 4, 6, ... 28}     200 + pkey
-# # outer_gc1     (pid1, cid1, cid2, gcid1) {4, 8, 12, ... 36}    300 + pkey
-# 
-# # Split between 4 nodes based on pkey value (p):
-# # node 1:       p - 1 mod 20 ∈ [1...5)
-# # node 2:       p - 1 mod 20 ∈ [5...10)
-# # node 3:       p - 1 mod 20 ∈ [10...15)
-# # node 4:       p - 1 mod 20 ∈ [15...20)
-# 
-# statement ok
-# CREATE TABLE outer_p1 (
-#   pid1 INT PRIMARY KEY,
-#   pa1 INT
-# )
-# 
-# statement ok
-# CREATE TABLE outer_c1 (
-#   pid1 INT,
-#   cid1 INT,
-#   cid2 INT,
-#   ca1 INT,
-#   PRIMARY KEY (pid1, cid1, cid2)
-# ) INTERLEAVE IN PARENT outer_p1 (pid1)
-# 
-# statement ok
-# CREATE TABLE outer_gc1 (
-#   pid1 INT,
-#   cid1 INT,
-#   cid2 INT,
-#   gcid1 INT,
-#   gca1 INT,
-#   PRIMARY KEY (pid1, cid1, cid2, gcid1)
-# ) INTERLEAVE IN PARENT outer_c1 (pid1, cid1, cid2)
-# 
-# statement ok
-# ALTER TABLE outer_p1 SPLIT AT
-#   SELECT i FROM generate_series(0, 40, 5) AS g(i)
-# 
-# statement ok
-# ALTER TABLE outer_p1 EXPERIMENTAL_RELOCATE
-#   SELECT ARRAY[(((i-3)/5)%4)::INT + 1], i FROM generate_series(3, 40, 5) AS g(i)
-# 
-# query TTITI colnames
-# SHOW EXPERIMENTAL_RANGES FROM TABLE outer_p1
-# ----
-# Start Key  End Key  Range ID  Replicas  Lease Holder
-# NULL       /0       20        {5}       5
-# /0         /5       31        {1}       1
-# /5         /10      32        {2}       2
-# /10        /15      33        {3}       3
-# /15        /20      34        {4}       4
-# /20        /25      35        {1}       1
-# /25        /30      36        {2}       2
-# /30        /35      37        {3}       3
-# /35        /40      38        {4}       4
-# /40        NULL     39        {5}       5
-# 
-# ### Begin OUTER queries
-# 
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_p1 FULL OUTER JOIN outer_c1 USING (pid1)]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJzclE2L2zAQhu_9FWJOu3TK-nMPhoIuDTgYp5jkVEwx1iQ1OJKR5NIQ_N-L7EOaNP1Y5-abpdEzr585zBmkEpRXRzKQfAEfEAJACAEhAoQYSoROq5qMUdo9mYBU_IDEQ2hk11t3XSLUShMkZ7CNbQkSSKUl3VL1nQqqBOm1aiTpFxchyFZNOyZmtLfgMppjpU9c9Zb01849KprDt99LtStNrQBhe-ooYatdlrHNbvupYOtNmgNCS3v7xP33zx-16zJ-upYkBemEpat8l2VP3EcePiPjATIeIeMxMv4K5YCgensxM7Y6ECT-gH-wv0j3UmlBmsSVZTncmU-uPqjuJb55eD86uIr2Zw0-WMjgg1n24ULsw1n20ULso1n23kLs_7FwCzKdkob-a6N4biWRONC0v4zqdU2ftarHmOm4GbnxQpCxU9WfDqkcS-MP_gr7f4Vfr2DvFg4eSQ4fgaNH4PhNcDm8-xkAAP__5oReVw==
-# 
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_gc1 FULL OUTER JOIN outer_c1 USING (pid1, cid1, cid2)]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJzklU2LnEAQhu_5FVKnHabC-rlJhEBfsuAiTpCdU5Agdq0R3G7pbkOWwf8eWiEzTiYf6xw9Vlc9_crTUB5ASE5Z-Uwa4i_gAYIPCAEghIAQQYHQKVmR1lLZkQlI-A-IXYRGdL2xxwVCJRVBfADTmJYghkQYUi2V3ymnkpN6kI0gdWsjOJmyacfElJ4M2IzmuVQvTPaG1Ne6slN5U3_7vTe2prsA4fGlo9i536eps9s_fsqdh12SAUJLT-aGeVtk_hZZsN18VPa22ZGNIMFJxU5yn-3T9IZ5yO42-Kv0kb07KQNk7zfosBAdFqHDPkAxIMjeHCVoU9YEsTfgH0Qd_fRCKk6K-ExIMVxQmcm3sruNzgYvR_uzaG_RG_nreyN_kahgfaKCRaLC9YkKF4ly1yfqH_-RnHQnhab_2n6uXZ_Ea5p2rZa9quizktUYM5W7kRsPOGkzdb2pSMTYGj_wFPb-Ct_NYPcc9q9JDq6Bw2vg6FVwMbz5GQAA__8alY8h
-# 
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_c1 LEFT OUTER JOIN outer_p1 USING (pid1) WHERE pid1 >= 0 AND pid1 < 40]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJzUlE-Lo0AQxe_7KeSddtlaYqu7B2HBSwYMIQ6SOQ0yiF3JCMaW7naYEPzug3rIJJP5l5xys_v1q1e_gnKHWkle5Bs2CO8hQPBA8EEIkBEarQo2RuleHh_H8hmhSyjrprX9dUYolGaEO9jSVowQcW1ZV5w_ccq5ZD1TZc164oIg2eZlNaTNeWXRZ5SbXG8j1VrWD0XfQ1quH99KTS-NpUBYbhsOnfn0Zukkd8tp6sySeAFCxSv7MxK_f_3XfZXhE4SktaETCYo8inyKAor-IesIqrV7DmPzNSMUHb3Dukdsa6Ula5YHTFl3YhoL9Uc1k-Do4elo7yBanDVmcZVj9s5i9a6S1T-L1b9K1k9-FSmbRtWGv7Qdbr9eLNc87qJRrS74VqtiiBmPyeAbLiQbO6piPMT1IA0NvjaLD81_D8zusdm7JNm_xBx8y5x1P14CAAD___ca6HA=
-# 
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_p1 RIGHT OUTER JOIN outer_gc1 USING (pid1) WHERE pid1 >= 1 AND pid1 <= 20]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJzUlE9r20AQxe_9FOKdWjrF-ucWBIW9lFamWEW4pyCC0I4VgawVu6sQY_Tdg6SDY8f5Z5980-7bN29-A6MdGiV5mW_YILqBB4IPQgBCiIzQalWwMUoP8vQ4lg-IXELVtJ0drjNCoTQj2sFWtmZEiBvLuub8nlPOJeuFqhrWMxcEyTav6jHtL68thoxqk-utUJ1lfdsOPaRVefdcKotBm2qBsNq2HDlp_PvPykn-r36lziKJlyDUvLafhff1y0891Bk_QUg6GzkiIOGTCEnMSXwn8QNZT1Cd3cMYm5eMyOvpBeA9Z9coLVmzPADL-hMjWapvqp2FRw9PR_sH0d5Zs_aud9b-WcD-9QIHZwEH1wv8xu8jZdOqxvC7lsUdto1lydNqGtXpgv9pVYwx0zEZfeOFZGMn1ZsOcTNKY4NPzd6r5vmB2T02-5ckB5eYww-Zs_7TYwAAAP__Vjbt9A==
-# 
-# ########################
-# # Non-interleaved joins #
-# ########################
-# 
-# # Join on siblings uses merge joiner.
-# # TODO(richardwu): Update this once sibling joins are implemented.
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM child1 JOIN child2 USING(pid1)]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJzElsFq20AQhu99ijCnlmyxdyXZsaCgawpNSuit-KBYU1vgaM1Kgobgdy-yCq5ldUabwfLNsvbbnZ35QP8bFDbDh_QFS4h_ggYFBhQEoCAEBREsFeycXWFZWtcsaYH77DfEUwV5saur5u-lgpV1CPEbVHm1RYjhR_q8xSdMM3STKSjIsErz7eGYnctfUvearDb5NtOw3CuwdfV3q-MOz683m7TcnLJJs36poKzSNUKs9-p9JUVESUZUkvlvScd9rMvQYdbd57Y5eNCqntt9Q7fGrzYv0E10p-Nb_FV9TPTtpy8uX2_an6Dgsa7im0SrxKgkUEmkkplK5p3bH28WDLhZXfRV3Vvwg_1sdxMddVb2nx2enK2HD1qP5J5HSbOR3NPXcU9f3j0zvNlmpPl7lDQfaf7mOvM3l59_MLzZwUjz9yjpbqT5B9eZf3D5-YfDmx2ONH-PkhYjzT-8zvzDcbNHTzlPWO5sUeKgZDFtLoTZGts2lbZ2K_zu7OpwTPv4eOAOX9QMy6p9a9qH-6J91RQ4HJ5J4IUE1qK6dUTT2qNlxg-eSeCFBNaiujstO6NNl57-Swd0vwMS1qc9m3bpUCI4DTOC0zAjOA1zgjM0I3gkEZyGGcFpmBGchjnBGZoRfCYRfC5RlIYZRWmYUZSGOUUZmlH0TqIoDTOK0jCjKA1zijI0o-hCoqgW5QSGZiRlaMZShuY05XAuK8jCgiwtyOKCMC_IAoMWJQZ9Fhm8bKVpzlaa5myladZWBuds9QlL5zPzSUu-NGerV17yxjlbz8IDaety_-FPAAAA__-7ahyi
-# 
-# # Join on non-interleaved tables (with key) uses merge joiner.
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN parent2 ON pid1=pid2]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lVFr2zAQx9_3Kco9bVQjluykqWHg1w7WjrK34Qc1uiWG1DKSDCsl333YLmQxic5GRG9xrJ_u_r8D3zvUWuGjfEUL-W_gwEAAgxQYZMBgCSWDxugNWqtNd2QAHtRfyBMGVd20rvu7ZLDRBiF_B1e5PUIOv-TLHp9RKjSLBBgodLLa92UaU71K81Y00mDtOJQHBrp1H3cdr3h5u9lJuzuFi-58ycA6uUXI-YFd6Ol4jzYKDarxPbdd4eOptj53rq81zvYDzRa_66pGs1idXrvHP-5zwW-_fDPVdjf8BAZPrctvCs4KwYqUFdko8zFPOiHPjE4f9VfdLDgfnTxfOzupzafPl8eaL48_37trzldMdyxiORbxHa-v6Tid7jiN5TiN7_j-mo6z6Y6zWI5n9LT09SSCehIXe4o0d57EWlBnGnlG2-ja4qT1k3RRUG1xsGN1azb40-hNX2Z4fOq5fhEotG54-_HwUA-vuganw1kIvAqB1yEwJ0LzMZ38Tws_LLwwP6WTMZ2GDMsPE8Pyw8Sw_DAxLCIzEToLGdYyRLcfJnT7YUK3HyZ0E5mJ0KsQ3Xchuv0wodsPE7r9MKGbyEyEXofovg_R7YcJ3X6Y0O2HCd1EZurLP2dZipl0FkSvguh1EM2p4PM2Znn49C8AAP__9ASy7Q==
-# 
-# # Join on non-interleaved column uses hash joiner.
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 ON pa1 = ca1]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJy8llFr2zwUhu-_X1HOVQv6SCTZaWMY-HLdRTvK7oYv3PgsMaSWkRVYKfnvI_Egi-PpWDtEl2nySK_OeaDvBzSmwqfyDTvIvoMEAQoEaBCQgIAUCgGtNSvsOmMPP-mBx-onZHMBddPu3OHPhYCVsQjZB7jabREy-Fa-bvEFywrtbA4CKnRlvT1e09r6rbTveVtabJyEYi_A7Nzvs05HvL7fbMpucw7nCop9IaBz5Rohk3vxb5nS8UyrTb2tQiPps0jqr5FO5-waYyu0WJ2dVBxI6icj7_pcdpsvpm7QzuRg1lv84W5zdffJ1uuNu831HQh43rnsJpciVyLXIk9Eng5efHqNZrxmJOqT-d-0M5kO3z16d3J2t5y-XBlLuIBMi0jCycjCyasKp6YPWMVaekCm-0hLV5GXrq66dD19wDrW0gMyPURauo68dH3VpSfTB5zEWnpApmWkpSeRl55E6xMjQV6wa03T4aS2MD88Bas19qPpzM6u8Ks1q-M1_cfnI3f8J1lh5_pvVf_hsem_OgScDi848JIDS1ZumfppGTAyFQYvOPCSA0tW7sHILmg1pOd_0to_b-2F5fnM5kM64QjuhwnB_TAhuB-mBCdoQvCUI7gfJgT3w4TgfpgSnKAJwRccwe85ivphQlE_TCjqhylFCZpQ9IGjqB8mFPXDhKJ-mFKUoAlFlxxFJasnEDQhKUETlhI0pSmFU12BVxZ4bYFXF5h9gVcYJKsxyIvKEGSrn6Zs9dOUrX6atJXAKVtDytLlzkLaUihN2RrUl4JxytaL8uC1tdj_9ysAAP__U3kYdA==
-# 
-# # Prefix join on interleaved columns uses merge joiner.
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM child2 JOIN grandchild2 USING(pid1, cid2)]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJzEll1r2zAUhu_3K8q52qhGItn5Mgx828HaUXY3cuFGZ47BtYxsw0rJfx-2C1kcT8eainzp2I_06uiBvK9QKIn3yTNWEP0EDgwEMAiAQQgMVrBnUGp1wKpSuv2kB-7kb4iWDLKibOr25z2Dg9II0SvUWZ0jRPAjecrxEROJerEEBhLrJMu7bUqdPSf6JT4cs1wK2J8YqKZ-W-q8wtPLzTGpjpdszFncInsGVZ2kCBE_sf9LtRpPleqkkO8TTfwz2nkppSVqlMOlblksbtv9J385ctpvqFP8qrIC9YIPLiHHX_XHN_rTF52lx_MjMHho6uimOxGLAxaHLN6weMvi3WAm58MGEw7bFGOHGM1-rz6rcsFXgy_H9w4v9ubTHeD-zLRItfZsJp_XTO7VTDH9HoQ_OyxSbTzbIea1Q3i1I5h-D4E_OyxSbT3bEcxrR-DVjnD6PYT-7LBItfNsRzivHeFsnWck2SNWpSoqnNRolu3ZUKbYT65SjT7gd60O3Tb940PHdX_fEqu6fyv6h7uif9UGnA6vXeCdC8ydcvOVmeYWIxN28NoF3rnA3Cn3YGRXtBjSy7_pwDzvwAjzy5kth3ToIrgZJgQ3w4TgZpgSnKAJwVcugpthQnAzTAhuhinBCZoQfO0i-MZFUTNMKGqGCUXNMKUoQROKbl0UNcOEomaYUNQMU4oSNKHozkVR7tQTCJqQlKAJSwma0pTCqa7gVhbc2oJbXXDsC26FgTs1Bn5VGaxsNdOUrWaastVMk7YSOGWrTVm6vjObtmRLU7Za9SVrnLL1qjwYbd2fPvwJAAD__4eyQAE=
-# 
-# # Subset join on interleaved columns uses hash joiner.
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM child2 JOIN grandchild2 USING(pid1, cid3)]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJzElsGK2zAQhu99imVOLagkkp1sYij42O1htyy9FR-80TQxZK0gOdBlybsX2y1pHFdjdYp6VOxP-jX-IP8r1EbjffmMDrKvIEGAAgEJCEhBwAIKAQdrNuicse0rPXCnv0M2F1DVh2PT_lwI2BiLkL1CUzV7hAy-lE97fMRSo53NQYDGpqz23TEHWz2X9iXf7Kq9VlCcBJhj83Or8w5PLze70u0u2VyKPIHiVAhwTblFyORJ_F2qxXiqrS1r_W-iqT9GO291rI3VaFFfbFa0JPXKyP0-lm73yVQ12pkcTH2P35q3XcZ3H2y13f1agICHY5PddCuRK5GnIl-KfCXy9WAA55sljJuNxL43781hJhfDGYyenV6cLad_cBlPw4BUy8gaysgaymgaqulDV_FUCEh1G1kFFVkFFU2FZPrQk3gqBKRaRVYhiaxCEk2FdPrQ03gqBKRaR1YhjaxC-l96ykioR3QHUzuc1ELm7bVQb7EfkzNHu8HP1my6Y_rlQ8d1f7kaXdM_Vf3iru4ftQGnw0sOvObAkpVbLvy0DBiZCoOXHHjNgSUr92BkV7Qa0vPf6cQ_78QLy8uZzYd0yhHcDxOC-2FCcD9MCU7QhOALjuB-mBDcDxOC-2FKcIImBF9yBL_lKOqHCUX9MKGoH6YUJWhC0RVHUT9MKOqHCUX9MKUoQROKrjmKSlZPIGhCUoImLCVoSlMKp7oCryzw2gKvLjD7Aq8wSFZjkFeVIchWP03Z6qcpW_00aSuBU7aGlKXrbxbSlkJpytagvhSMU7ZelQevrcXpzY8AAAD__5b5Mtw=
-# 
-# # Sort node in between join and child nodes produces hash joiner.
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN (SELECT * FROM child1 ORDER BY cid1) USING(pid1)]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lk9vm0wQxu_vp4jm9FbdKuyC_yFV4tj0kFRpbxUHYrYxksOiBUuNonz3ClMrApx9mGK41bV_zOzsb_LwQrlJ9W3ypEsKf5IkQYoE-SQoIEELigUV1mx1WRpb_6QBbtLfFHqCsrw4VPV_x4K2xmoKX6jKqr2mkH4kD3t9r5NU22uPBKW6SrL9sUxhs6fEPkdFYnVeSYpfBZlD9fdZb494eL7aJeWuDUf172NBZZU8agrlq_i3nhbne9rusn3abemtnOKU-25spe217Bw_Uh9HHdl_t4e35xxyY1Ntddp6UlyT6CdnDvIlKXdfTZbXh-nMba9_Vf9H8sNnmz3ujv8iQXeHKryKpIiUiAIRLd4dZzDiKGf6vDWfTHGtvO6hz9ZetGrL4ebIuWxm9LS8gM2g3MlmOaXNcmabl9PZrIbfnprLKEZPqwsYBcqdjFJTGqVmNmo1nVH-8Nvz5zKK0dP6AkaBciej_CmN8mc2aj2dUcHw2wvmMorR0-YCRoFyJ6OCKY0KZjZqM8873Jku7nVZmLzUg97QvPocOn3UzVxKc7Bb_c2a7bFM8_HuyB1fHFJdVs23fvPhJm--qhscDq_HwFKNopdjaOW5admlvRbdgr0urBgDVzx4PQbuDJxLL8fQnYH3aN858MB9W4H7tqT7uhZj9sMNg_1ww2g_AA32w02j_Vg6J75yD3w1Zj_cMNgPN4z2A9BgP9w02o_1mP3YjDHcDQPD3TAyHNDAcDcNE6AXIK2JS_BHRfYShCM5oIHlgEaaIxx4DnAkuuzlCMd02csRjuqABq4DGsmOcGA7wKHu7gyVC6A7J0T7d85JUS4NdWflKBeHuruTFOnOiVIujXRnhSkbR7qz4rSPu_NUboDunETt3zknUrk01J0Vqlwc6a7cqdrVPX79708AAAD__3t4GdI=
-# 
-# query TTT
-# EXPLAIN SELECT * FROM parent1 JOIN (SELECT * FROM child1 ORDER BY cid1) USING (pid1)
-# ----
-# render               ·         ·
-#  └── join            ·         ·
-#       │              type      inner
-#       │              equality  (pid1) = (pid1)
-#       ├── scan       ·         ·
-#       │              table     parent1@primary
-#       │              spans     ALL
-#       └── sort       ·         ·
-#            │         order     +cid1
-#            └── scan  ·         ·
-# ·                    table     child1@primary
-# ·                    spans     ALL
-# 
-# # Multi-table staggered join uses interleaved joiner on the bottom join
-# # and a merge joiner.
-# query T
-# SELECT url FROM[EXPLAIN (DISTSQL)
-#   SELECT * FROM grandchild1
-#   JOIN child1 USING (pid1, cid1)
-#   JOIN parent1 USING (pid1)
-# ORDER BY pid1
-# ]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJzcls9u2kAQh-99imhOrbIV7NpAsFTJV6o2qVBvlQ8OnoAlx4vWS9Uo4t0rYxLMn-xgRhiJo7377c7OfIffK-Q6wfv4GQsI_oAEAQoEeCDABwE9iATMjZ5gUWhTbqmAUfIPgq6ANJ8vbPk7EjDRBiF4BZvaDCGAUW7RZBj_xTHGCZrvOs3RdLogIEEbp9nqxh_4ZKG8I32OzUs4NXGeTGZplpSljNPprL76vlCdBQIyfLKfQ3krQnX75Zsp979_goCHhQ1uQilCJUJPhL4IBxAtBeiFXRe-qffx5WYWF7Pt8kIJ0TISUNh4ihDIpTi-Ab_jx2z99k5v-9i3B81jg7mVrJrUhzVtztEmQYPJ7jm35cVH7TrwvJ9oprgeqtyZ6ttYaiM5PI7e_kQ2L_N4LztQ873-qucduT2Nj673t66XJ9kur8d2ogF12_tt2S4vY7s8v-3qJN3U9ehGNKCu26At3dRldFPn1807STfvenQjGlDX7a4t3bzL6OadXzf_JN3869GNaEBdt2FbuvmX0c1vNzoeKGeMxVznBR6VCrvlgzCZYtWmQi_MBH8ZPVldU30-rLhVPEmwsNWqqj5GebVUFng83OfAQw4sWXXLnpuWDVqmmsF9DjzkwJJV907L9mi1S3frtOfut-eE5XbPuru0zxHcDROCu2FCcDdMCU7QhOA9juBumBDcDROCu2FKcIImBO9zBB9wFHXDhKJumFDUDVOKEjSh6B1HUTdMKOqGCUXdMKUoQROKDjmKSlZOIGhCUoImLCVoSlMKp7ICLyzw0gIvLjDzAi8wSFZikHuRoZGtbpqy1U1Ttrpp0lYCp2xtEpb2Z9YkLTWlKVsb5aXGOGXrXnhw2hotP_0PAAD__9pnwiY=
-# 
-# # Multi-table join with parent1 and child1 at the bottom uses interleaved
-# # joiner but induces a hash joiner on the higher join.
-# query T
-# SELECT url FROM [EXPLAIN (DISTSQL)
-#   SELECT * FROM parent1
-#   JOIN child1 USING (pid1)
-#   JOIN grandchild1 USING (pid1, cid1)
-# ]
-# ----
-# https://cockroachdb.github.io/distsqlplan/decode.html#eJzUls-K2zAQh-99imVOLVXZSLbzx1DwsSllt4Teig_aeDYxeK0gK6XLkncvjrPEdlJNHIEgtzjSJ81ovsPvDUqV4YN8wQri38CBgQAGATAIgUEEKYONVkusKqXrLQ0wz_5CPGKQl5utqf9OGSyVRojfwOSmQIhhXhrUBco_uECZof6u8hL1_QgYZGhkXuxv_IHPBuo78hepX5ON1FiauoxFvlq3V5brvMjqheYcYFDgs_mY8M-fvup67_4nMHjcmvgu4SwRLAlZEkG6Y6C25lDpscCn17u1rNbdemowgHSXMqiMXCHEfMcub_qXfCoO_d5H3ZPfG1lpWWaHbgaXJjqlif-WdjxqWyqdocasc1hak9SWM_19k9X6MEjem-RhHCwJjgNhieiMJHifyoQl0173x7YCh7bO1PygvqjNPY_6D3D27rBzN79KcX7bihNNtxUfe1ace1ac-1FcXKWZuG3NiKbbmk08ayY8ayb8aBZcpVlw25oRTbc1m3rWLPCsWeBHs_AqzcLb1oxouq3ZzLNmoWfNQv-58ExFC6w2qqzwotQ3qnvCbIXNG1Vqq5f4U6vl_prm83HP7TNIhpVpVkXzMS-bpbrAy-GxCzxzgblT3Tyy03zAk4lh8NgFnrnA3Knu3pOd0KJPj9p0YH_vwArz7puN-nToIrgdJgS3w4TgdpgSnKAJwSMXwe0wIbgdJgS3w5TgBE0IPnYRfOKiqB0mFLXDhKJ2mFKUoAlFpy6K2mFCUTtMKGqHKUUJmlB05qIod8oJBE1IStCEpQRNaUrhVFZwCwtuacEtLjjmBbfAwJ0SAz-JDINstdOUrXaastVOk7YSOGXrkLB0OrMhaWkoTdk6KC8NxilbT8KD1dZ09-FfAAAA___T9r_v
+statement ok
+SET CLUSTER SETTING sql.distsql.interleaved_joins.enabled = true;
+
+#####################
+# Interleaved joins #
+#####################
+
+# Select over two ranges for parent/child with split at children key.
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzUkkFr6zAQhO_vV5g5vcfbEstpL4aAriklKbkWH4S1SQSOZCS5tJT89yKrUCe0oe2tN69mZscf7Aus07xSBw6oHyBAqECYoyH03rUcgvNJysalfkJdEozth5ifo4kdo8ZgndfsWYOgOSrTJb05NoTWeUb9bl25K9fPqjMjwQ3xbW1DCFHtGHV1pEm1mFR_sHhpI_uO1SNvWGn2t85Y9rPypAl3vI1IeOag_LPslWcbE_nG7PZTpd2bTich7wGh4238K8X_fwufvOMnCOtVIUWxKOQ8DUOsCylIViSvSd7gMzRxglb9CE38BrTyMtqGQ-9s4C_dQ5kOivWO8_UFN_iW771rx5o8rsfc-KA5xKzO87C0WUo_OA2Li-HyJCzOw9W3ws3xz2sAAAD__y3KHZU=
+
+# Swap parent1 and child1 tables.
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM child1 JOIN parent1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzUkkFr6zAQhO_vV5g5vcfbEstpL4aAriklKbkWH4S1SQSOZCS5tJT89yKrUCe0oe2tN69mZscf7Aus07xSBw6oHyBAqECYoyH03rUcgvNJysalfkJdEozth5ifo4kdo8ZgndfsWYOgOSrTJb05NoTWeUb9bl25K9fPqjMjwQ3xbW1DCFHtGHV1pEm1mFR_sHhpI_uO1SNvWGn2t85Y9rPypAl3vI1IeOag_LNs96bTCXxjdvup0CvPNiYl7wGh4238K8X_fwufzOMnCOtVIUWxKOR1GoZYF1KQrEjOSd7gMzRxglb9CE38BrTyMtqGQ-9s4C_dQ5kOivWO8_UFN_iW771rx5o8rsfc-KA5xKzO87C0WUo_OA2Li-HyJCzOw9W3ws3xz2sAAAD__yRsHZU=
+
+# Select over two ranges for parent/child with split at grandchild key.
+# Also, rows with pid1 <= 30 should have 4 rows whereas pid1 > 30 should
+# have 3 rows.
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 ON parent1.pid1 = child1.pid1 WHERE parent1.pid1 >= 29 AND parent1.pid1 <= 31 ORDER BY parent1.pid1]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzUUcFq6zAQvL-vMHt6JSqxnOZiCOiaUpKSa_FBWBtH4EhmtS4twf9eJB8Sl6S0vfXm3ZnR7IxP4LzBjT5igPIFJAhYQiWgI19jCJ7ieiStzRuUuQDrup7juhJQe0IoT8CWW4QS1o6RWtSvuENtkB69dUjz-KxB1rZNLk-4Z4ge9qjpXXWa0HHk7GxzuETqg21NBMZ3QECLe_6v5OxuRZGbPkHAdpMpma0ytYhDz2WmpFCFUAuhHoRaQjUI8D2fLw-sG4RSDuJGunMoTwYJzTSDkjOohisVbPy97-bFhH3LvZi4y191m__Bbq-k22HovAv4rd7yWDyaBscfFXxPNT6Tr5PNOG6TLi0MBh5ROQ5rl6B04KVYfileTMT5Z3HxI-dq-PcRAAD__3DaHjA=
+
+# Parent-child where pid1 <= 15 have one joined row and pid1 > 15 have no
+# joined rows (since child2 only has 15 rows up to pid1 = 15).
+# Note this spans all 5 nodes, which makes sense since we want to read all
+# parent rows even if child rows are non-existent (so we can support OUTER
+# joins).
+# TODO(richardwu): we can remove nodes reading from just one table for INNER
+# joins or LEFT/RIGHT joins.
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 >= 12 ORDER BY pid1]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzUlM_K2zAQxO99CjOnlmyJ5T85GAK6ppSk5Fp8MNYmMTiWkeTSEvzuRfYhcWna73NOvlnaHc_8FrQ3NFrxvriyRfYdAoQIhBiEBIQUOaE1umRrtfEto2CnfiILCVXTds5f54RSG0Z2g6tczciwaxybmosffORCsfmiq4bNOgRBsSuqenD8yicH71FdC_NLtoXhxvkYx-p8eayUl6pWPtv4HxBqPrmPUqw-bY3vHT5BOOwDKYJtID3EoXNZIAXJiGRCMiW5Qd4TdOfuya0rzoxM9PSE7g6ljWLDasogxQp5_5cR7PVn3a7TSfcz92jiLmbNVixkttEsumghdPEsunghdMksumQhdP_ZaUe2rW4sv-lFh34lsDrzuEKs7kzJ34wuB5vxeBh0w4Vi68aqGA-7ZigNAR_F4p_izUQc_imOXnGOXxEnr4jTd4nz_sPvAAAA__9VWS06
+
+# These rows are all on the same node 1 (gateway).
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 IN (1, 11, 21, 31) ORDER BY pid1]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJyMUE1LxDAUvPsrypwUH7hZPw6BhVwrsiu9Sg-hedsNdJOSvIqy9L9Lm4N6ELxlPjKTyQUhOt7bM2foNyi0hDHFjnOOaaGKoXYf0BuCD-MkC90SupgY-gLxMjA06iCcBrbv3LB1nJ6jD5zuNiA4FuuHteGFj4Klw59t-jSjTRxEgdD4_vRT6U5-cFsQSg4IAx_l2qjbm11avOsRhMO-MqraVeZ-AZPoyigyWzIPZB7JPKGdCXGS75dnsT1Dq5n-v67hPMaQ-deav5I3c0tg13P5wRyn1PFrit1aU-BhvbcSjrMUVRVQhyLN7Xz1FQAA__9AfoaM
+
+# Parent-grandchild.
+query T
+SELECT url FROM [EXPLAIN (DISTSQL)
+  SELECT * FROM parent1 JOIN grandchild2 USING(pid1) WHERE
+    pid1 >= 11 AND pid1 <= 13
+    OR pid1 >= 19 AND pid1 <= 21
+    OR pid1 >= 31 AND pid1 <= 33
+]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzslE9r3DAQxe_9FGJOu3RKLDlpqWBBhVLYUrxl6a31QVgTR-BIRpJLS_B3L7K7xBvSfymEHPbm0dOPN_iN5gacN1Tpa4ogPwMHBAEIF1Aj9ME3FKMPWZovbs03kAWCdf2Q8nGN0PhAIG8g2dQRSNi6RKEj_ZX2pA2F9946CmcFIBhK2naT0we6TJA97LUO31WvA7mU7bPA3tkuUZBstVKcfRmKomw2jJdSym31ac12-4VCG8ZfH5Q31Vu2ZAT_qaxnagGVBwkQ9ra9WrbTBu1Mc2U7Iw7qo_c0_zdA6OgyrRR_vt6E3Mj0CQi7iinONkyVuRiSZIqjEqjOUV2geonqFdQjgh_SbVgx6ZZA8hF_EehtjoPzwVAgcxRcPd4TeeVf-P6svHPxfmtxZM0fNEv8NEtPdZbEgwIVp0CfaqB_2PZ7ir13kf7q7Rd5eZBpad400Q-hoY_BN5PNXO4mbjowFNOs8rnYukmaGlzC_Lfw-RFc3IXF_ziX_wTX47MfAQAA__8YYyxn
+
+query T
+SELECT url FROM [EXPLAIN (DISTSQL)
+  SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
+    pid1 >= 11 AND pid1 <= 13
+    OR pid1 >= 19 AND pid1 <= 21
+    OR pid1 >= 31 AND pid1 <= 33
+]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzslE9r3DAQxe_9FGJOu3RKLDtpqWBBhVJwKd5iemt9ENbEETiSkeTSEvzdi-wu8Yb0Xwohh7159PTjDX6juQHrNFXqmgKIz8ABIQeEC2gQBu9aCsH5JC0XS_0NRIZg7DDGdNwgtM4TiBuIJvYEAkobyfekvlJNSpN_74wlf5YBgqaoTD87faDLCMnDXCv_XXZeWd1emV4n-ySyd6aP5AXbbCRnX8YsK9od44UQoqw-bdm-Xim0Y_z1QXlTvWVrJuc_le1CraDiIAFCbbqrdUuD8mQjPyiP3s_y3wChp8u4kfz5dudTI_MnIOwrJjnbMfkyFWMUTHKUOcoC5TnKC5SvoJkQ3BhvwwpRdQSCT_iLQG9zHK3zmjzpo-Ca6Z7IK_fCDWfFnYv3W-dH1vxBs8RPs_RUZyl_UKD5KdCnGugftn1NYXA20F-9_SwtD9IdLZsmuNG39NG7drZZyv3MzQeaQlxUvhSlnaW5wTXMfwufH8HZXTj_H-fin-BmevYjAAD__-kZLGc=
+
+query TTT
+EXPLAIN SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
+  pid1 >= 11 AND pid1 <= 13
+  OR pid1 >= 19 AND pid1 <= 21
+  OR pid1 >= 31 AND pid1 <= 33
+----
+render          ·               ·
+ └── join       ·               ·
+      │         type            inner
+      │         equality        (pid1) = (pid1)
+      │         mergeJoinOrder  +"(pid1=pid1)"
+      ├── scan  ·               ·
+      │         table           grandchild2@primary
+      │         spans           /11/#/56/1-/13/#/56/2 /19/#/56/1-/21/#/56/2 /31/#/56/1-/33/#/56/2
+      └── scan  ·               ·
+·               table           parent1@primary
+·               spans           /11-/13/# /19-/21/# /31-/33/#
+
+# Join on multiple interleaved columns with an overarching ancestor (parent1).
+# Note there are 5 nodes because the filter cid2 >= 12 AND cid2 <= 14
+# creates a giant parent span which requires reading from all rows.
+query T
+SELECT url FROM [EXPLAIN (DISTSQL)
+  SELECT * FROM child2 JOIN grandchild2 ON
+    child2.pid1=grandchild2.pid1
+    AND child2.cid2=grandchild2.cid2
+    AND child2.cid3=grandchild2.cid3
+  WHERE
+    child2.pid1 >= 5 AND child2.pid1 <= 7
+    OR child2.cid2 >= 12 AND child2.cid2 <= 14
+    OR gcid2 >= 49 AND gcid2 <= 51
+]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzsls-K2zAQh-99CjEnh0xZS5aTrsCgQimkFKeE3lofjDWbNXitIMulZcm7F9uNs162_5JLDjmORh8_iU8weoTaGkrzB2pAfQEOCAIQIkCQgBBDhrBztqCmsa7bMgAr8x1UiFDWu9Z3yxlCYR2BegRf-opAwar25CrKv9GGckPugy1rcjchIBjyeVn1iR_pzkOXUT7k7ocu7svKdCfYlNv7p42ty2sz7bL3ZeXJKRYEgebsaxuGESUsVkqt0s8z9jZ9x8ZGkbDlr8aMrTcsCLQYES6mjBgZLg_QgZIjJW-nlBypmB8oQBjuDQgV3flA8zlqMUcdzWeJ664xWQKEdcr6-yRMx8cDJUwvZocy6splv7n1immOWqCOUEvUMeoF6iXqN6hvIdsj2NYfLTU-3xIovsffmDwKbGvrDDkyE2PZ_gXXqX1tdzfxs40vR4tJND_pEfHrI7q4RyROMimuJi_OZHSSyehq8uJMypNMyqvJizP5l8_WhpqdrRv6pwkcdiOczJaGed_Y1hX0ydmijxnKdc_1C4YaP3T5UKzqvtUf8CnM_wgvJnD4HBbnJEfnwPIcOP4vONu_-hkAAP__KSY_SA==
+
+query TTT
+EXPLAIN
+  SELECT * FROM child2 JOIN grandchild2 ON
+    child2.pid1=grandchild2.pid1
+    AND child2.cid2=grandchild2.cid2
+    AND child2.cid3=grandchild2.cid3
+  WHERE
+    child2.pid1 >= 5 AND child2.pid1 <= 7
+    OR child2.cid2 >= 12 AND child2.cid2 <= 14
+    OR gcid2 >= 49 AND gcid2 <= 51
+----
+join       ·               ·
+ │         type            inner
+ │         equality        (pid1, cid2, cid3) = (pid1, cid2, cid3)
+ │         mergeJoinOrder  +"(pid1=pid1)",+"(cid2=cid2)",+"(cid3=cid3)"
+ ├── scan  ·               ·
+ │         table           child2@primary
+ │         spans           ALL
+ └── scan  ·               ·
+·          table           grandchild2@primary
+·          spans           ALL
+
+# Aggregation over parent and child keys.
+query T
+SELECT url FROM [EXPLAIN (DISTSQL)
+  SELECT sum(parent1.pid1), sum(child1.cid1) FROM parent1 JOIN child1 USING(pid1) WHERE
+    pid1 >= 10 AND pid1 <= 39
+]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzclcGLm0AUxu_9K-SddunAOmqyWWHBHlPaTUnpqXgYnLeuYGZkZiwtwf-9jNJGQzIuxpM3x3mfv-99T3hHEJLjCzughvgnUCAQAIEQCERAYAUpgUrJDLWWypZ0gi3_DbFPoBBVbezrlEAmFUJ8BFOYEiGGrTCoSmS_cI-Mo_osC4HqwSI4GlaULfELvhqwjOLA1J-kYgqFsTX2wtvVJvYSe9wX-Vu_MHsrSv7_4l8hSaz7jgQESnw1dwn9eP-sbFX7CAR2L15CvWevLT4pSRJC2hCQtTl1pQ3LEWLakPd3_inPFebMSPWwHnb7_cfXu4RaD-1TeH8VGFwFnji1kIqjQj6ApI3bEvWdnoLrnsKBJzpp_MECxj_SeS_rx3nGH0yKOlxA1COd96LezBN1OCnqaAFRj3Tei_ppnqijSVH7C4h6pPNe1Kv598cF4B51JYXGsz1y-cu-3S_Ic-yWkZa1yvCbklmL6Y67Vte-4KhNd0u7w1Z0V9ZgX0yd4mAgpufiwE0eQYdOdeQWR7f4XjnFazd5fQv50SneuMmbW8hP7ln5I7-J-yc7Z6fNh78BAAD___NTc6o=
+
+###############
+# Outer joins #
+###############
+
+# The schema/values for each table are as follows:
+# Table:        pkey:                     pkey values (same):   values:
+# outer_p1      (pid1)                    {1, 2, 3, ... 20}     100 + pkey
+# outer_c1      (pid1, cid1, cid2)        {2, 4, 6, ... 28}     200 + pkey
+# outer_gc1     (pid1, cid1, cid2, gcid1) {4, 8, 12, ... 36}    300 + pkey
+
+# Split between 4 nodes based on pkey value (p):
+# node 1:       p - 1 mod 20 ∈ [1...5)
+# node 2:       p - 1 mod 20 ∈ [5...10)
+# node 3:       p - 1 mod 20 ∈ [10...15)
+# node 4:       p - 1 mod 20 ∈ [15...20)
+
+statement ok
+CREATE TABLE outer_p1 (
+  pid1 INT PRIMARY KEY,
+  pa1 INT
+)
+
+statement ok
+CREATE TABLE outer_c1 (
+  pid1 INT,
+  cid1 INT,
+  cid2 INT,
+  ca1 INT,
+  PRIMARY KEY (pid1, cid1, cid2)
+) INTERLEAVE IN PARENT outer_p1 (pid1)
+
+statement ok
+CREATE TABLE outer_gc1 (
+  pid1 INT,
+  cid1 INT,
+  cid2 INT,
+  gcid1 INT,
+  gca1 INT,
+  PRIMARY KEY (pid1, cid1, cid2, gcid1)
+) INTERLEAVE IN PARENT outer_c1 (pid1, cid1, cid2)
+
+statement ok
+ALTER TABLE outer_p1 SPLIT AT
+  SELECT i FROM generate_series(0, 40, 5) AS g(i)
+
+statement ok
+ALTER TABLE outer_p1 EXPERIMENTAL_RELOCATE
+  SELECT ARRAY[(((i-3)/5)%4)::INT + 1], i FROM generate_series(3, 40, 5) AS g(i)
+
+query TTITI colnames
+SHOW EXPERIMENTAL_RANGES FROM TABLE outer_p1
+----
+start_key  end_key  range_id  replicas  lease_holder
+NULL       /0       20        {5}       5
+/0         /5       31        {1}       1
+/5         /10      32        {2}       2
+/10        /15      33        {3}       3
+/15        /20      34        {4}       4
+/20        /25      35        {1}       1
+/25        /30      36        {2}       2
+/30        /35      37        {3}       3
+/35        /40      38        {4}       4
+/40        NULL     39        {5}       5
+
+### Begin OUTER queries
+
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_p1 FULL OUTER JOIN outer_c1 USING (pid1)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzclE1r3DAQhu_9FWJOCZ0Syx85GAIqYQsOxi5uciqmGGuyNTiSkeTSEPzfi-xDutvtl_fmm6XRo9fzCOYFlJZUNE9kIf0MHBBCQIgAIQaEBGqEweiWrNXGH1mATH6HNEDo1DA6v10jtNoQpC_gOtcTpJApR6an5htV1Egyd7pTZK58hCTXdP2cmNOjA5_RPTXmWejRkfky-ENVt__6a6n1peUqQLh_HihlHx7ynJUP97uK3ZVZAQg9PboLwd9e3hh_y_wJCGXBBGc3TPj-KlKSTMpuy_f57tPt7kJwFNElMhEiEzEykSAT11BPCHp0r41a1-wJUj7hb2S8OhiVNpIMyYOm6-mErkK_08NVcnTwdHR4EM1XvUO4zXcIV8mItikjWiUj3qaMeJWMYJsy_jK7K7KDVpb-aRoFfpyR3NMy-6weTUsfjW7nmGVZzty8Icm6pcqXRabm0vyDP8P8j_D1ARwcw-E5ydE5cHwOnPwXXE9vfgQAAP__bK5tZg==
+
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_gc1 FULL OUTER JOIN outer_c1 USING (pid1, cid1, cid2)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzsldFr2zAQxt_3V4h7ssmNxrKTdoaCSpdBSrCH1z4NM4x1zQypZCR5rJT870M2o3WXlTR5zeN9d58-8TuQnkBpSVn1QBbS7xABAgeEGBASQJhBidAaXZO12viRwbCUvyGdIjSq7ZyXS4RaG4L0CVzjNgQpLJUjs6HqFxVUSTI3ulFkznyEJFc1mz5xRfcOfEbzUJlHoTtH5se69lNFs_75b69vDWcBwu1jSyn7crdasfzudlGwm3yZAcKG7l0gogkKPkERT8JL408bSYCQZywIRMQumZiH7Cr7zALBfXUe_i1jX1744YKUJJOy6_xqtfh2vQhEhGIe4guBozgfCTGKixCZSJCJGTLxCcotgu7cMzfrqjVBGm3xP2yfkXZKG0mG5Ihhud1BP9MfdXs2ezW4O5qPoqOD1spPa91jrfwgtvGJ7R5s44PYJie2e7BNDmI7PbF951O_g21BttXK0l4v-dR_BSTXNPwbVnempq9G133MUOa9rxckWTd0o6FYqr7VX_ClOXrTPB-Zp6_N_Jjk-Bhzcox59i5zuf3wJwAA___QpMHp
+
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_c1 LEFT OUTER JOIN outer_p1 USING (pid1) WHERE pid1 >= 0 AND pid1 < 40]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzUlE9rg0AQxe_9FDKnlk6Jq6YHIbCXFAxBi6SnIkXcSSoYV3bX0hD87mX1kCZN_yWn3Jx9-_bNb2DcQi0FxfmaNITPwADBAwQfEALIEBolC9JaKisPlyPxDqGLUNZNa-xxhlBIRRBuwZSmIgghqg2pivI3SikXpGayrEmNXEAQZPKy6tPmtDRgM8p1rjZctobUS2F7SMvV61epsdLwFCAsNg2Fznz6sHCSp8U0dWZJFANCRUtzzdntzUTZV_pPQEhihzNn4vCxLVoTOpwh95D7yAPk95B1CLI1Oyht8hVByDr8BnzH29ZSCVIk9gCz7shoYnknm1FwcPF4tLcXzU6aObv8mXsngXuXD-6fBO5fPvgvv5eUdCNrTX9aItduIYkVDSurZasKelSy6GOGMul9_YEgbQaVDUVU91Lf4Gcz-9E83jO7h2bvnGT_HHPwL3PWXX0EAAD__3y68rA=
+
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_p1 RIGHT OUTER JOIN outer_gc1 USING (pid1) WHERE pid1 >= 1 AND pid1 <= 20]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzclE9rs0AQxu_vp5A5vS_vlLhqWhACeymtoWiR9FSkiDuxgnFldy0Nwe9eVg9p0vRfcsvN3WefeeY3MG6gkYLifEUawkdggOABgg8IAWQIrZIFaS2VlcfHkXiF0EWomrYz9jpDKKQiCDdgKlMThBA1hlRN-QullAtSc1k1pCYuIAgyeVUPaXe0NGAzqlWu1lx2htRTa3tIq_L5o1QWVhtrAcJi3VLopNHN7cJJHhbXqTNPohgQalqav5z9_zdTts7wCQhJ7HDmzBxu6ZLOhA73kXvIA-RT5JfIryDrEWRntmTa5CVByHr8hH4L3TVSCVIkdiiz_sB8Ynkh20mw9_BwtLcTzY4aPDuTwXtH0XtnQu8fRe-fCf03v5yUdCsbTT_aKdcuJYmSxg3WslMF3StZDDHjMRl8w4UgbUaVjYeoGaShwfdm9qV5umN2983eKcn-KebgV-as__MWAAD__72G-Cw=
+
+########################
+# Non-interleaved joins #
+########################
+
+# Join on siblings uses merge joiner.
+# TODO(richardwu): Update this once sibling joins are implemented.
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM child1 JOIN child2 USING(pid1)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzElkFr2zAUx-_7FOGdNqrRSLaTxlDQtYMlo-w2cnDjt8SQWkF2YKXkuw_HgyyOp2ftgXyra_2kv55_kP87lCbHZfaKFaQ_QIIABQIiEBCDgATWAg7WbLCqjG2WtMBT_gvSqYCiPBzr5t9rARtjEdJ3qIt6j5DC9-xlj8-Y5WjvpyAgxzor9udjDrZ4zeyb3uyKfS5hfRJgjvWfrS47vLxNdlm1u2Z1s34toKqzLUIqT-L_IiWOSIoVSf0z0mUfY3O0mHf3uWsOHrSq53Zf0W7xiylKtPeyM_E9_qw_ann36dEW2137JwhYLSdaTh4nuvnYq2OdTrQUWgkdCZ0IPRN63hnF5ZrRgGsey74r9KZfms_mcC-Tzsr-s-Ors-Xwry4DiegRaRZIRDmOiDKwiGr45FUgGTwizQPJoMaRQQWWIRo--SiQDB6RHgLJEI0jQxRYhnj45ONAMnhEWgSSIR5HhnjEvtKT7RmrgykrHNRGps3tMN9iO7PKHO0Gv1mzOR_TPq7O3PlXOMeqbt-q9uGpbF81AYfDMw684MCSlVsmblp6jEz5wTMOvODAkpW7M7IbWnXp6d905J535ITl9cymXTrmCO6GCcHdMCG4G6YEJ2hC8IQjuBsmBHfDhOBumBKcoAnBZxzB5xxF3TChqBsmFHXDlKIETSj6wFHUDROKumFCUTdMKUrQhKILjqKS1RMImpCUoAlLCZrSlMKprsArC7y2wKsLzL7AKwyS1RjkTWXwstVNU7a6acpWN03aSuCUrT5l6fab-bQlX5qy1asveeOUrTflwWnr-vThdwAAAP__Z2kpbQ==
+
+# Join on non-interleaved tables (with key) uses merge joiner.
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN parent2 ON pid1=pid2]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzElVFr2zAQx9_3Kcw9bVQjluykqaGg1w6WjLK34Qc3viWG1DKSDCsl333YLmQxic5GoL3FsX66-_8u5N6hViVuilc0kP0CDgwEMEiAQQoMlpAzaLTaoTFKd0cG4Kn8A1nMoKqb1nZf5wx2SiNk72Are0TI4GfxcsRnLErUixgYlGiL6tiXaXT1Wug32RQaa8shPzFQrf2463zFy1t0KMzhEpbd-ZyBscUeIeMndqOn8z1Kl6ixHN9z1xU-n2rra-f6WuNs31Hv8ZuqatSL1eW1R_xtP0t-9-VRV_vD8BEYbDeR5NFjJDu129ZmkeRMCiYTJtORgHO4ZEK4GW1v1FfVLDgfnbxeO72ozacPm4caNg8_7PtgwxbThYtQwkV44etgwpPpwpNQwpPwwh-CCU-nC09DCZ_R09LVk_DqSdzsKdCPgMf_Zald6eoZTaNqg5NWVtzlwnKPgyqjWr3DH1rt-jLD47bn-uVRorHD24-Hp3p41TU4HU594JUPvPaBORGaj-n4X1q4YeGE-SUdj-nEZ1humBiWGyaG5YaJYRGZidCpz7CWPrrdMKHbDRO63TChm8hMhF756L730e2GCd1umNDthgndRGYi9NpH94OPbjdM6HbDhG43TOgmMlP__HOWpZhJp170yotee9GcCj5vY-anT38DAAD__zUYv7M=
+
+# Join on non-interleaved column uses hash joiner.
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 ON pa1 = ca1]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJy8llFr2zwUhu-_X1HOVQv6SCTZaWMY-HLdRTvK7oYv3PgsMaSWkRVYKfnvI_Egi-PpWDtEl2nySK_OeaDvBzSmwqfyDTvIvoMEAQoEaBCQgIAUCgGtNSvsOmMPP-mBx-onZHMBddPu3OHPhYCVsQjZB7jabREy-Fa-bvEFywrtbA4CKnRlvT1e09r6rbTveVtabJyEYi_A7Nzvs05HvL7fbMpucw7nCop9IaBz5Rohk3vxb5nS8UyrTb2tQiPps0jqr5FO5-waYyu0WJ2dVBxI6icj7_pcdpsvpm7QzuRg1lv84W5zdffJ1uuNu831HQh43rnsJpciVyLXIk9Eng5efHqNZrxmJOqT-d-0M5kO3z16d3J2t5y-XBlLuIBMi0jCycjCyasKp6YPWMVaekCm-0hLV5GXrq66dD19wDrW0gMyPURauo68dH3VpSfTB5zEWnpApmWkpSeRl55E6xMjQV6wa03T4aS2MD88Bas19qPpzM6u8Ks1q-M1_cfnI3f8J1lh5_pvVf_hsem_OgScDi848JIDS1ZumfppGTAyFQYvOPCSA0tW7sHILmg1pOd_0to_b-2F5fnM5kM64QjuhwnB_TAhuB-mBCdoQvCUI7gfJgT3w4TgfpgSnKAJwRccwe85ivphQlE_TCjqhylFCZpQ9IGjqB8mFPXDhKJ-mFKUoAlFlxxFJasnEDQhKUETlhI0pSmFU12BVxZ4bYFXF5h9gVcYJKsxyIvKEGSrn6Zs9dOUrX6atJXAKVtDytLlzkLaUihN2RrUl4JxytaL8uC1tdj_9ysAAP__U3kYdA==
+
+# Prefix join on interleaved columns uses merge joiner.
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM child2 JOIN grandchild2 USING(pid1, cid2)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzMls9r2zAUx-_7K8w7tVQjkWznh6GgwS4dLB1lt5GDG70lhtQKsgMrJf_7sF3I4nh61jScHGXrIz299zl83yDXChfpCxaQ_AAODAQwCIFBBAxiWDLYGb3CotCm2tIAD-oXJGMGWb7bl9XnJYOVNgjJG5RZuUVI4Hv6vMUnTBWa0RgYKCzTbFtfszPZS2pe5WqTbZWA5YGB3pfvRx1PeH4NNmmxOWUlZ7JClgyKMl0jJPzA_q2quLuqtUlz9X9KE38t7XiUNgoNqvZRd0yKu-r-3js7XvsVzRq_6CxHM-KtIWzxZ3nzTt_em2y9OS6BweMiuJE8uA9kfBt8WnwObqSoVpP6575Mgvq5TIZMRkxOmZwxOW817NiJsEcn9nnXCzsfttAf9W7E49bO7rujk7t5f0H4cNo6VDUZWFt-WW359Wgr-g9JDKeOQ1XTgdURl1VHXI86Yf8hhcOp41DVbGB1wsuqE16POlH_IUXDqeNQ1XxgdaLLqhNdjzpEGH7CYqfzAnulqHH1cFRrbNpa6L1Z4TejV_U1zfKx5urIoLAom7-iWTzkza-qwP7wxAee-8Dcq24e22nu0DLhBk984LkPzL3qbrXsjBZtevwnHdr7HVphftqzcZuOfAS3w4TgdpgQ3A5TghM0IXjsI7gdJgS3w4TgdpgSnKAJwSc-gk99FLXDhKJ2mFDUDlOKEjSh6MxHUTtMKGqHCUXtMKUoQROKzn0U5V45gaAJSQmasJSgKU0pnMoKfmHBLy34xQXPvOAXGLhXYuBnkcHJVjtN2WqnKVvtNGkrgVO2uoSl85m5pCVXmrLVKS8545StZ-HBauvy8OF3AAAA___ImVxT
+
+# Subset join on interleaved columns uses hash joiner.
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM child2 JOIN grandchild2 USING(pid1, cid3)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzElsGK2zAQhu99imVOLagkkp1sYij42O1htyy9FR-80TQxZK0gOdBlybsX2y1pHFdjdYp6VOxP-jX-IP8r1EbjffmMDrKvIEGAAgEJCEhBwAIKAQdrNuicse0rPXCnv0M2F1DVh2PT_lwI2BiLkL1CUzV7hAy-lE97fMRSo53NQYDGpqz23TEHWz2X9iXf7Kq9VlCcBJhj83Or8w5PLze70u0u2VyKPIHiVAhwTblFyORJ_F2qxXiqrS1r_W-iqT9GO291rI3VaFFfbFa0JPXKyP0-lm73yVQ12pkcTH2P35q3XcZ3H2y13f1agICHY5PddCuRK5GnIl-KfCXy9WAA55sljJuNxL43781hJhfDGYyenV6cLad_cBlPw4BUy8gaysgaymgaqulDV_FUCEh1G1kFFVkFFU2FZPrQk3gqBKRaRVYhiaxCEk2FdPrQ03gqBKRaR1YhjaxC-l96ykioR3QHUzuc1ELm7bVQb7EfkzNHu8HP1my6Y_rlQ8d1f7kaXdM_Vf3iru4ftQGnw0sOvObAkpVbLvy0DBiZCoOXHHjNgSUr92BkV7Qa0vPf6cQ_78QLy8uZzYd0yhHcDxOC-2FCcD9MCU7QhOALjuB-mBDcDxOC-2FKcIImBF9yBL_lKOqHCUX9MKGoH6YUJWhC0RVHUT9MKOqHCUX9MKUoQROKrjmKSlZPIGhCUoImLCVoSlMKp7oCryzw2gKvLjD7Aq8wSFZjkFeVIchWP03Z6qcpW_00aSuBU7aGlKXrbxbSlkJpytagvhSMU7ZelQevrcXpzY8AAAD__5b5Mtw=
+
+# Multi-table staggered join uses interleaved joiner on the bottom join
+# and a merge joiner.
+query T
+SELECT url FROM[EXPLAIN (DISTSQL)
+  SELECT * FROM grandchild1
+  JOIN child1 USING (pid1, cid1)
+  JOIN parent1 USING (pid1)
+ORDER BY pid1
+]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzklkFr4zwQhu_frzBzaqk-GsmO0xgKWthLl910KXtbfHDjaWJwrSAry5aS_744TlvHSTVxBM4hR0d5JM3MI3hfoVApTpJnLCH6DRwYCGDgA4MAGAwhZrDQaoplqXT1lxq4S_9CNGCQFYulqX6OGUyVRohewWQmR4jgrjCoc0z-4AMmKepvKitQXw-AQYomyfL1id_xyUB1Rvac6Bc500mRTudZnlZXechm8-bq-0K9FzDI8clcSH7FpLi6vNXV_98_gcH9xLuQ3Lv15PDS-zL56l1IUX2F68WliTzJmRRM-kwGTA6ZDJkcQbxioJZmU9tHSY8v3jwp59sVSA7xKmZQmmSGEPEVO7xHv5LHfNOe6-H2tm81LxKNheFOdxKf3uljH6VT1Ji297mqDj7oX3vK-4F6hpu589bg3ybXmNpmYvXAbvZOaMTkuNWKjzJ9tzL3FDBR_6vFNd8ezWfHB1vH86NeBz-r10H0qPk6wr5eBz_N6-A9vw5xlJ7irPQketTUc9SXnuI0eoqe9fSP0tM_Kz2JHjX1vOlLT_80evo96xkcpWdwVnoSPWrqOe5Lz-A0egYnjL577vaA5UIVJR6UagdVdZjOsO5ZqZZ6ij-1mq6PqT_v19w6O6VYmnpV1B93Rb1UXfBwOHSBxy4wd7o3H9pp3qFlohscusBjF5g73bvVsh1atOlBk_bt_fatMN_u2aBNBy6C22FCcDtMCG6HKcEJmhB86CK4HSYEt8OE4HaYEpygCcFDF8FHLoraYUJRO0woaocpRQmaUPTGRVE7TChqhwlF7TClKEETio5dFOVOOYGgCUkJmrCUoClNKZzKCm5hwS0tuMUFx7zgFhi4U2LgO5Ghk612mrLVTlO22mnSVgKnbO0SlnZn1iUtdaUpWzvlpc44ZetOeLDaGq_--xcAAP__p93xug==
+
+# Multi-table join with parent1 and child1 at the bottom uses interleaved
+# joiner but induces a hash joiner on the higher join.
+query T
+SELECT url FROM [EXPLAIN (DISTSQL)
+  SELECT * FROM parent1
+  JOIN child1 USING (pid1)
+  JOIN grandchild1 USING (pid1, cid1)
+]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzclk9r2z4Yx--_VxGe069Mo5Fsp42hoOM6RjvCbsMHN36aGFwryMpYKXnvw3ZGbCfTE0egQ25N5Y_0_Pkcvh9Qqgyf0jesIP4JHBgIYBAAgxAYRJAw2Gi1xKpSuv6kBR6z3xBPGeTlZmvqfycMlkojxB9gclMgxPBYGtQFpr9wgWmG-qvKS9S3U2CQoUnzonnxG74aqN_I31L9LjepxtLUZSzy1bp7slznRVYftPcAgwJfzf-Sf7p50PW3zZ_A4PlpIvnkYSLrJp63Jp5IzqRgMmAyZDKCZMdAbc2-8kPBL--TdVqt-_XVbAjJLmFQmXSFEPMdO38IP9KXYt__bdS_-W9jK52W2b670aWJXmnin6UdrtqWSmeoMetdltQk9cmJ_r6k1Xq_WD7Y7H49TIaHBTEpbrpbCZvFREzeMzkfdH9oK3Bo60TNT-qz2tzyaDiAk2-Hvbf5Rcrz61KeGEJX-Zln5bln5bkf5cVF2onr0o4YQle7O8_aCc_aCT_aBRdpF1yXdsQQutrde9Yu8Kxd4Ee78CLtwuvSjhhCV7u5Z-1Cz9qF_nPliYoWWG1UWeFZqXFa94TZCtsZVWqrl_hdq2XzTPvzueGazJJhZdpT0f54LNujusDz4ZkLPHeBuVPdPLLTfMTIxDh45gLPXWDuVPdgZEe0GNLTLh3Y5x1YYd6f2XRIhy6C22FCcDtMCG6HKcEJmhA8chHcDhOC22FCcDtMCU7QhOAzF8HvXBS1w4SidphQ1A5TihI0oei9i6J2mFDUDhOK2mFKUYImFJ27KMqdcgJBE5ISNGEpQVOaUjiVFdzCgltacIsLjnnBLTBwp8TAjyLDKFvtNGWrnaZstdOkrQRO2TomLB3vbExaGktTto7KS6Nxytaj8GC1Ndn99ycAAP__c9_P7g==

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -104,6 +104,7 @@ type Factory interface {
 		left, right Node,
 		onCond tree.TypedExpr,
 		leftOrdering, rightOrdering sqlbase.ColumnOrdering,
+		reqOrdering sqlbase.ColumnOrdering,
 	) (Node, error)
 
 	// ConstructGroupBy returns a node that runs an aggregation. A set of

--- a/pkg/sql/opt/norm/testdata/props/prune_cols
+++ b/pkg/sql/opt/norm/testdata/props/prune_cols
@@ -204,16 +204,16 @@ WHERE
 project
  ├── columns: i:2(int)
  ├── prune: (2)
- └── semi-join
+ └── semi-join (merge)
       ├── columns: k:1(int!null) i:2(int)
       ├── key: (1)
       ├── fd: (1)-->(2)
       ├── prune: (2)
-      ├── interesting orderings: (+1)
       ├── semi-join (merge)
       │    ├── columns: k:1(int!null) i:2(int)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2)
+      │    ├── ordering: +1
       │    ├── prune: (2)
       │    ├── interesting orderings: (+1)
       │    ├── scan a
@@ -238,10 +238,14 @@ project
       ├── scan xy
       │    ├── columns: xy.x:5(int!null)
       │    ├── key: (5)
+      │    ├── ordering: +5
       │    ├── prune: (5)
       │    └── interesting orderings: (+5)
-      └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
-           └── a.k = xy.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+      └── merge-on
+           ├── left ordering: +1
+           ├── right ordering: +5
+           └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+                └── a.k = xy.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
 
 # AntiJoin operator.
 opt
@@ -254,16 +258,16 @@ WHERE
 project
  ├── columns: i:2(int)
  ├── prune: (2)
- └── anti-join
+ └── anti-join (merge)
       ├── columns: k:1(int!null) i:2(int)
       ├── key: (1)
       ├── fd: (1)-->(2)
       ├── prune: (2)
-      ├── interesting orderings: (+1)
       ├── anti-join (merge)
       │    ├── columns: k:1(int!null) i:2(int)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2)
+      │    ├── ordering: +1
       │    ├── prune: (2)
       │    ├── interesting orderings: (+1)
       │    ├── scan a
@@ -288,10 +292,14 @@ project
       ├── scan xy
       │    ├── columns: xy.x:5(int!null)
       │    ├── key: (5)
+      │    ├── ordering: +5
       │    ├── prune: (5)
       │    └── interesting orderings: (+5)
-      └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
-           └── a.k = xy.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+      └── merge-on
+           ├── left ordering: +1
+           ├── right ordering: +5
+           └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+                └── a.k = xy.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
 
 # GroupBy operator.
 opt

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -746,18 +746,24 @@ project
  │    ├── grouping columns: k:1(int!null)
  │    ├── key: (1)
  │    ├── fd: (1)-->(11)
- │    ├── right-join
+ │    ├── left-join (merge)
  │    │    ├── columns: k:1(int!null) x:6(int) column10:10(int)
  │    │    ├── key: (1,6)
  │    │    ├── fd: (6)-->(10)
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1(int!null)
+ │    │    │    ├── key: (1)
+ │    │    │    └── ordering: +1
  │    │    ├── project
  │    │    │    ├── columns: column10:10(int) x:6(int!null)
  │    │    │    ├── key: (6)
  │    │    │    ├── fd: (6)-->(10)
+ │    │    │    ├── ordering: +6
  │    │    │    ├── inner-join (merge)
  │    │    │    │    ├── columns: x:6(int!null) y:7(int) u:8(int!null) v:9(int)
  │    │    │    │    ├── key: (8)
  │    │    │    │    ├── fd: (6)-->(7), (8)-->(9), (6)==(8), (8)==(6)
+ │    │    │    │    ├── ordering: +(6|8)
  │    │    │    │    ├── scan xy
  │    │    │    │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    │    │    │    ├── key: (6)
@@ -775,11 +781,11 @@ project
  │    │    │    │              └── xy.x = uv.u [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ])]
  │    │    │    └── projections [outer=(6,7,9)]
  │    │    │         └── xy.y + uv.v [type=int, outer=(7,9)]
- │    │    ├── scan a
- │    │    │    ├── columns: k:1(int!null)
- │    │    │    └── key: (1)
- │    │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
- │    │         └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+ │    │    └── merge-on
+ │    │         ├── left ordering: +1
+ │    │         ├── right ordering: +6
+ │    │         └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │              └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
  │    └── aggregations [outer=(10)]
  │         └── sum [type=decimal, outer=(10)]
  │              └── variable: column10 [type=int, outer=(10)]
@@ -797,16 +803,18 @@ WHERE EXISTS
     SELECT * FROM xy INNER JOIN uv ON x=u AND x=k
 )
 ----
-semi-join
+semi-join (merge)
  ├── columns: k:1(int!null)
  ├── key: (1)
  ├── scan a
  │    ├── columns: k:1(int!null)
- │    └── key: (1)
+ │    ├── key: (1)
+ │    └── ordering: +1
  ├── inner-join (merge)
  │    ├── columns: x:6(int!null) y:7(int) u:8(int!null) v:9(int)
  │    ├── key: (8)
  │    ├── fd: (6)-->(7), (8)-->(9), (6)==(8), (8)==(6)
+ │    ├── ordering: +(6|8)
  │    ├── scan xy
  │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    ├── key: (6)
@@ -822,8 +830,11 @@ semi-join
  │         ├── right ordering: +8
  │         └── filters [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
  │              └── xy.x = uv.u [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ])]
- └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-      └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+ └── merge-on
+      ├── left ordering: +1
+      ├── right ordering: +6
+      └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+           └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Anti-join as outer.
 opt
@@ -833,16 +844,18 @@ WHERE NOT EXISTS
     SELECT * FROM xy INNER JOIN uv ON x=u AND x=k
 )
 ----
-anti-join
+anti-join (merge)
  ├── columns: k:1(int!null)
  ├── key: (1)
  ├── scan a
  │    ├── columns: k:1(int!null)
- │    └── key: (1)
+ │    ├── key: (1)
+ │    └── ordering: +1
  ├── inner-join (merge)
  │    ├── columns: x:6(int!null) y:7(int) u:8(int!null) v:9(int)
  │    ├── key: (8)
  │    ├── fd: (6)-->(7), (8)-->(9), (6)==(8), (8)==(6)
+ │    ├── ordering: +(6|8)
  │    ├── scan xy
  │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    ├── key: (6)
@@ -858,8 +871,11 @@ anti-join
  │         ├── right ordering: +8
  │         └── filters [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
  │              └── xy.x = uv.u [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ])]
- └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-      └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+ └── merge-on
+      ├── left ordering: +1
+      ├── right ordering: +6
+      └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+           └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Right-join as outer.
 opt
@@ -884,14 +900,19 @@ project
       │    ├── grouping columns: k:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(10)
-      │    ├── right-join
+      │    ├── left-join (merge)
       │    │    ├── columns: k:1(int!null) x:6(int) u:8(int)
       │    │    ├── key: (1,8)
       │    │    ├── fd: (6)==(8), (8)==(6)
+      │    │    ├── scan a
+      │    │    │    ├── columns: k:1(int!null)
+      │    │    │    ├── key: (1)
+      │    │    │    └── ordering: +1
       │    │    ├── inner-join (merge)
       │    │    │    ├── columns: x:6(int!null) u:8(int!null)
       │    │    │    ├── key: (8)
       │    │    │    ├── fd: (6)==(8), (8)==(6)
+      │    │    │    ├── ordering: +(6|8)
       │    │    │    ├── scan xy
       │    │    │    │    ├── columns: x:6(int!null)
       │    │    │    │    ├── key: (6)
@@ -905,11 +926,11 @@ project
       │    │    │         ├── right ordering: +8
       │    │    │         └── filters [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
       │    │    │              └── xy.x = uv.u [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ])]
-      │    │    ├── scan a
-      │    │    │    ├── columns: k:1(int!null)
-      │    │    │    └── key: (1)
-      │    │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-      │    │         └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+      │    │    └── merge-on
+      │    │         ├── left ordering: +1
+      │    │         ├── right ordering: +6
+      │    │         └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+      │    │              └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
       │    └── aggregations [outer=(6)]
       │         └── count [type=int, outer=(6)]
       │              └── variable: xy.x [type=int, outer=(6)]
@@ -1781,18 +1802,20 @@ select
 opt
 SELECT * FROM a WHERE EXISTS(SELECT * FROM xy WHERE EXISTS (SELECT * FROM uv WHERE x=u) AND x=k)
 ----
-semi-join
+semi-join (merge)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
+ │    ├── fd: (1)-->(2-5)
+ │    └── ordering: +1
  ├── semi-join (merge)
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
+ │    ├── ordering: +6
  │    ├── scan xy
  │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    ├── key: (6)
@@ -1808,8 +1831,11 @@ semi-join
  │         ├── right ordering: +8
  │         └── filters [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
  │              └── xy.x = uv.u [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ])]
- └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-      └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+ └── merge-on
+      ├── left ordering: +1
+      ├── right ordering: +6
+      └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+           └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # --------------------------------------------------
 # HoistSelectNotExists
@@ -2344,11 +2370,12 @@ project
  │    ├── grouping columns: k:1(int!null) xy.x:7(int)
  │    ├── key: (1,7)
  │    ├── fd: (1,7)-->(21)
- │    ├── left-join
+ │    ├── left-join (merge)
  │    │    ├── columns: k:1(int!null) xy.x:7(int) xy.y:20(int)
  │    │    ├── left-join (merge)
  │    │    │    ├── columns: k:1(int!null) xy.x:7(int)
  │    │    │    ├── key: (1,7)
+ │    │    │    ├── ordering: +1
  │    │    │    ├── scan a
  │    │    │    │    ├── columns: k:1(int!null)
  │    │    │    │    ├── key: (1)
@@ -2362,10 +2389,16 @@ project
  │    │    │         ├── right ordering: +7
  │    │    │         └── filters [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
  │    │    │              └── xy.x = a.k [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ])]
- │    │    ├── scan xy
- │    │    │    └── columns: xy.y:20(int)
- │    │    └── filters [type=bool, outer=(1,20), constraints=(/1: (/NULL - ]; /20: (/NULL - ]), fd=(1)==(20), (20)==(1)]
- │    │         └── xy.y = a.k [type=bool, outer=(1,20), constraints=(/1: (/NULL - ]; /20: (/NULL - ])]
+ │    │    ├── sort
+ │    │    │    ├── columns: xy.y:20(int)
+ │    │    │    ├── ordering: +20
+ │    │    │    └── scan xy
+ │    │    │         └── columns: xy.y:20(int)
+ │    │    └── merge-on
+ │    │         ├── left ordering: +1
+ │    │         ├── right ordering: +20
+ │    │         └── filters [type=bool, outer=(1,20), constraints=(/1: (/NULL - ]; /20: (/NULL - ]), fd=(1)==(20), (20)==(1)]
+ │    │              └── xy.y = a.k [type=bool, outer=(1,20), constraints=(/1: (/NULL - ]; /20: (/NULL - ])]
  │    └── aggregations [outer=(20)]
  │         └── count [type=int, outer=(20)]
  │              └── variable: xy.y [type=int, outer=(20)]

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -95,7 +95,12 @@ func (o *Optimizer) canProvideOrdering(eid memo.ExprID, required *props.Ordering
 		return def.CanProvideOrdering(o.mem.Metadata(), required)
 
 	case opt.RowNumberOp:
-		def := o.mem.LookupPrivate(mexpr.AsRowNumber().Def()).(*memo.RowNumberDef)
+		def := mexpr.Private(o.mem).(*memo.RowNumberDef)
+		return def.CanProvideOrdering(required)
+
+	case opt.MergeJoinOp:
+		mergeOn := o.mem.NormExpr(mexpr.ChildGroup(o.mem, 2))
+		def := mergeOn.Private(o.mem).(*memo.MergeOnDef)
 		return def.CanProvideOrdering(required)
 
 	case opt.LimitOp:

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -243,40 +243,54 @@ where
             phone0_.id=calls3_.phone_id
     )
 ----
-inner-join
+inner-join (merge)
  ├── columns: id1_6_0_:1(int!null) id1_4_1_:6(int!null) phone_nu2_6_0_:2(string) person_i4_6_0_:4(int!null) phone_ty3_6_0_:3(string) person_i1_5_0__:12(int!null) addresse2_5_0__:13(string) addresse3_0__:14(string!null) address2_4_1_:7(string) createdo3_4_1_:8(timestamp) name4_4_1_:9(string) nickname5_4_1_:10(string) version6_4_1_:11(int!null) person_i1_5_0__:12(int!null) addresse2_5_0__:13(string) addresse3_0__:14(string!null)
  ├── key: (1,14)
  ├── fd: (1)-->(2-4), (6)-->(7-11), (4)==(6,12), (6)==(4,12), (12,14)-->(13), (12)==(4,6)
- ├── inner-join
+ ├── inner-join (merge)
  │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int!null) person.id:6(int!null) address:7(string) createdon:8(timestamp) name:9(string) nickname:10(string) version:11(int!null)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (6)-->(7-11), (4)==(6), (6)==(4)
- │    ├── semi-join
- │    │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int)
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-4)
- │    │    ├── scan phone
- │    │    │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int)
- │    │    │    ├── key: (1)
- │    │    │    └── fd: (1)-->(2-4)
- │    │    ├── scan phone_call
- │    │    │    ├── columns: phone_call.id:15(int!null) phone_id:18(int)
- │    │    │    ├── key: (15)
- │    │    │    └── fd: (15)-->(18)
- │    │    └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
- │    │         └── phone.id = phone_call.phone_id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+ │    ├── ordering: +(4|6)
  │    ├── scan person
  │    │    ├── columns: person.id:6(int!null) address:7(string) createdon:8(timestamp) name:9(string) nickname:10(string) version:11(int!null)
  │    │    ├── key: (6)
- │    │    └── fd: (6)-->(7-11)
- │    └── filters [type=bool, outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ]), fd=(4)==(6), (6)==(4)]
- │         └── phone.person_id = person.id [type=bool, outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ])]
+ │    │    ├── fd: (6)-->(7-11)
+ │    │    └── ordering: +6
+ │    ├── sort
+ │    │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-4)
+ │    │    ├── ordering: +4
+ │    │    └── semi-join
+ │    │         ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int)
+ │    │         ├── key: (1)
+ │    │         ├── fd: (1)-->(2-4)
+ │    │         ├── scan phone
+ │    │         │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int)
+ │    │         │    ├── key: (1)
+ │    │         │    └── fd: (1)-->(2-4)
+ │    │         ├── scan phone_call
+ │    │         │    ├── columns: phone_call.id:15(int!null) phone_id:18(int)
+ │    │         │    ├── key: (15)
+ │    │         │    └── fd: (15)-->(18)
+ │    │         └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+ │    │              └── phone.id = phone_call.phone_id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+ │    └── merge-on
+ │         ├── left ordering: +6
+ │         ├── right ordering: +4
+ │         └── filters [type=bool, outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ]), fd=(4)==(6), (6)==(4)]
+ │              └── phone.person_id = person.id [type=bool, outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ])]
  ├── scan person_addresses
  │    ├── columns: person_addresses.person_id:12(int!null) addresses:13(string) addresses_key:14(string!null)
  │    ├── key: (12,14)
- │    └── fd: (12,14)-->(13)
- └── filters [type=bool, outer=(6,12), constraints=(/6: (/NULL - ]; /12: (/NULL - ]), fd=(6)==(12), (12)==(6)]
-      └── person.id = person_addresses.person_id [type=bool, outer=(6,12), constraints=(/6: (/NULL - ]; /12: (/NULL - ])]
+ │    ├── fd: (12,14)-->(13)
+ │    └── ordering: +12
+ └── merge-on
+      ├── left ordering: +6
+      ├── right ordering: +12
+      └── filters [type=bool, outer=(6,12), constraints=(/6: (/NULL - ]; /12: (/NULL - ]), fd=(6)==(12), (12)==(6)]
+           └── person.id = person_addresses.person_id [type=bool, outer=(6,12), constraints=(/6: (/NULL - ]; /12: (/NULL - ])]
 
 opt
 select
@@ -305,36 +319,50 @@ where
 project
  ├── columns: id1_6_:1(int!null) phone_nu2_6_:2(string) person_i4_6_:4(int!null) phone_ty3_6_:3(string)
  ├── fd: (1)-->(2-4)
- └── inner-join
+ └── inner-join (merge)
       ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int!null) person.id:6(int!null) person_addresses.person_id:12(int!null)
       ├── fd: (1)-->(2-4), (4)==(6,12), (6)==(4,12), (12)==(4,6)
-      ├── inner-join
+      ├── inner-join (merge)
       │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int!null) person.id:6(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-4), (4)==(6), (6)==(4)
-      │    ├── semi-join
+      │    ├── ordering: +(4|6)
+      │    ├── scan person
+      │    │    ├── columns: person.id:6(int!null)
+      │    │    ├── key: (6)
+      │    │    └── ordering: +6
+      │    ├── sort
       │    │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int)
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(2-4)
-      │    │    ├── scan phone
-      │    │    │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int)
-      │    │    │    ├── key: (1)
-      │    │    │    └── fd: (1)-->(2-4)
-      │    │    ├── scan phone_call
-      │    │    │    ├── columns: phone_call.id:15(int!null) phone_id:18(int)
-      │    │    │    ├── key: (15)
-      │    │    │    └── fd: (15)-->(18)
-      │    │    └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
-      │    │         └── phone.id = phone_call.phone_id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
-      │    ├── scan person
-      │    │    ├── columns: person.id:6(int!null)
-      │    │    └── key: (6)
-      │    └── filters [type=bool, outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ]), fd=(4)==(6), (6)==(4)]
-      │         └── phone.person_id = person.id [type=bool, outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ])]
+      │    │    ├── ordering: +4
+      │    │    └── semi-join
+      │    │         ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int)
+      │    │         ├── key: (1)
+      │    │         ├── fd: (1)-->(2-4)
+      │    │         ├── scan phone
+      │    │         │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int)
+      │    │         │    ├── key: (1)
+      │    │         │    └── fd: (1)-->(2-4)
+      │    │         ├── scan phone_call
+      │    │         │    ├── columns: phone_call.id:15(int!null) phone_id:18(int)
+      │    │         │    ├── key: (15)
+      │    │         │    └── fd: (15)-->(18)
+      │    │         └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+      │    │              └── phone.id = phone_call.phone_id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+      │    └── merge-on
+      │         ├── left ordering: +6
+      │         ├── right ordering: +4
+      │         └── filters [type=bool, outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ]), fd=(4)==(6), (6)==(4)]
+      │              └── phone.person_id = person.id [type=bool, outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ])]
       ├── scan person_addresses
-      │    └── columns: person_addresses.person_id:12(int!null)
-      └── filters [type=bool, outer=(6,12), constraints=(/6: (/NULL - ]; /12: (/NULL - ]), fd=(6)==(12), (12)==(6)]
-           └── person.id = person_addresses.person_id [type=bool, outer=(6,12), constraints=(/6: (/NULL - ]; /12: (/NULL - ])]
+      │    ├── columns: person_addresses.person_id:12(int!null)
+      │    └── ordering: +12
+      └── merge-on
+           ├── left ordering: +6
+           ├── right ordering: +12
+           └── filters [type=bool, outer=(6,12), constraints=(/6: (/NULL - ]; /12: (/NULL - ]), fd=(6)==(12), (12)==(6)]
+                └── person.id = person_addresses.person_id [type=bool, outer=(6,12), constraints=(/6: (/NULL - ]; /12: (/NULL - ])]
 
 opt
 select
@@ -1950,22 +1978,36 @@ WHERE ref0_.generationuser_id = 1;
 project
  ├── columns: generati1_2_0_:1(int!null) ref_id2_2_0_:2(int!null) formula131_0_:11(string) formula132_0_:16(string) formula133_0_:21(string) id1_0_1_:3(int!null) age2_0_1_:4(string) culture3_0_1_:5(string) descript4_0_1_:6(string)
  ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2)
- ├── left-join
+ ├── right-join (merge)
  │    ├── columns: generationuser_id:1(int!null) ref_id:2(int!null) generationgroup.id:3(int!null) generationgroup.age:4(string) generationgroup.culture:5(string) generationgroup.description:6(string) generationgroup.age:8(string) generationgroup.culture:14(string) generationgroup.id:17(int) generationgroup.description:20(string)
  │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2), (17)-->(20)
+ │    ├── scan generationgroup
+ │    │    ├── columns: generationgroup.id:17(int!null) generationgroup.description:20(string)
+ │    │    ├── key: (17)
+ │    │    ├── fd: (17)-->(20)
+ │    │    └── ordering: +17
  │    ├── project
  │    │    ├── columns: generationuser_id:1(int!null) ref_id:2(int!null) generationgroup.id:3(int!null) generationgroup.age:4(string) generationgroup.culture:5(string) generationgroup.description:6(string) generationgroup.age:8(string) generationgroup.culture:14(string)
  │    │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2)
- │    │    └── left-join
+ │    │    ├── ordering: +(2|3) opt(1)
+ │    │    └── right-join (merge)
  │    │         ├── columns: generationuser_id:1(int!null) ref_id:2(int!null) generationgroup.id:3(int!null) generationgroup.age:4(string) generationgroup.culture:5(string) generationgroup.description:6(string) generationgroup.age:8(string) generationgroup.id:12(int) generationgroup.culture:14(string)
  │    │         ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2), (12)-->(14)
+ │    │         ├── ordering: +(2|3) opt(1)
+ │    │         ├── scan generationgroup
+ │    │         │    ├── columns: generationgroup.id:12(int!null) generationgroup.culture:14(string)
+ │    │         │    ├── key: (12)
+ │    │         │    ├── fd: (12)-->(14)
+ │    │         │    └── ordering: +12
  │    │         ├── project
  │    │         │    ├── columns: generationuser_id:1(int!null) ref_id:2(int!null) generationgroup.id:3(int!null) generationgroup.age:4(string) generationgroup.culture:5(string) generationgroup.description:6(string) generationgroup.age:8(string)
  │    │         │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2)
+ │    │         │    ├── ordering: +(2|3) opt(1)
  │    │         │    └── right-join (merge)
  │    │         │         ├── columns: generationuser_id:1(int!null) ref_id:2(int!null) generationgroup.id:3(int!null) generationgroup.age:4(string) generationgroup.culture:5(string) generationgroup.description:6(string) generationgroup.id:7(int) generationgroup.age:8(string)
  │    │         │         ├── key: (3,7)
  │    │         │         ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2), (7)-->(8)
+ │    │         │         ├── ordering: +(2|3) opt(1)
  │    │         │         ├── scan generationgroup
  │    │         │         │    ├── columns: generationgroup.id:7(int!null) generationgroup.age:8(string)
  │    │         │         │    ├── key: (7)
@@ -1990,18 +2032,16 @@ project
  │    │         │              ├── right ordering: +2
  │    │         │              └── filters [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
  │    │         │                   └── generationgroup.id = generationuser_generationgroup.ref_id [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
- │    │         ├── scan generationgroup
- │    │         │    ├── columns: generationgroup.id:12(int!null) generationgroup.culture:14(string)
- │    │         │    ├── key: (12)
- │    │         │    └── fd: (12)-->(14)
- │    │         └── filters [type=bool, outer=(2,12), constraints=(/2: (/NULL - ]; /12: (/NULL - ]), fd=(2)==(12), (12)==(2)]
- │    │              └── generationgroup.id = generationuser_generationgroup.ref_id [type=bool, outer=(2,12), constraints=(/2: (/NULL - ]; /12: (/NULL - ])]
- │    ├── scan generationgroup
- │    │    ├── columns: generationgroup.id:17(int!null) generationgroup.description:20(string)
- │    │    ├── key: (17)
- │    │    └── fd: (17)-->(20)
- │    └── filters [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ]), fd=(2)==(17), (17)==(2)]
- │         └── generationgroup.id = generationuser_generationgroup.ref_id [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ])]
+ │    │         └── merge-on
+ │    │              ├── left ordering: +12
+ │    │              ├── right ordering: +2
+ │    │              └── filters [type=bool, outer=(2,12), constraints=(/2: (/NULL - ]; /12: (/NULL - ]), fd=(2)==(12), (12)==(2)]
+ │    │                   └── generationgroup.id = generationuser_generationgroup.ref_id [type=bool, outer=(2,12), constraints=(/2: (/NULL - ]; /12: (/NULL - ])]
+ │    └── merge-on
+ │         ├── left ordering: +17
+ │         ├── right ordering: +2
+ │         └── filters [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ]), fd=(2)==(17), (17)==(2)]
+ │              └── generationgroup.id = generationuser_generationgroup.ref_id [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ])]
  └── projections [outer=(1-6,8,14,20)]
       ├── variable: generationgroup.age [type=string, outer=(8)]
       ├── variable: generationgroup.culture [type=string, outer=(14)]

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -300,78 +300,99 @@ project
  │    │    │         │    ├── left-join
  │    │    │         │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) pg_class.oid:91(oid) pg_class.relname:92(string)
  │    │    │         │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79), (91)-->(92)
- │    │    │         │    │    ├── left-join
+ │    │    │         │    │    ├── left-join (merge)
  │    │    │         │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool)
  │    │    │         │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79)
- │    │    │         │    │    │    ├── right-join
+ │    │    │         │    │    │    ├── left-join (merge)
  │    │    │         │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string)
  │    │    │         │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68)
- │    │    │         │    │    │    │    ├── left-join
- │    │    │         │    │    │    │    │    ├── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null) pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string)
- │    │    │         │    │    │    │    │    ├── fd: (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)-->(69), (69)-->(68)
- │    │    │         │    │    │    │    │    ├── inner-join
- │    │    │         │    │    │    │    │    │    ├── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null) pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null)
- │    │    │         │    │    │    │    │    │    ├── fd: (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39)
- │    │    │         │    │    │    │    │    │    ├── scan pg_inherits
- │    │    │         │    │    │    │    │    │    │    └── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null)
- │    │    │         │    │    │    │    │    │    ├── scan pg_class@pg_class_relname_nsp_index
- │    │    │         │    │    │    │    │    │    │    ├── columns: pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null)
- │    │    │         │    │    │    │    │    │    │    ├── key: (41)
- │    │    │         │    │    │    │    │    │    │    └── fd: (41)-->(42,43), (42,43)-->(41)
- │    │    │         │    │    │    │    │    │    └── filters [type=bool, outer=(39,41), constraints=(/39: (/NULL - ]; /41: (/NULL - ]), fd=(39)==(41), (41)==(39)]
- │    │    │         │    │    │    │    │    │         └── pg_inherits.inhparent = pg_class.oid [type=bool, outer=(39,41), constraints=(/39: (/NULL - ]; /41: (/NULL - ])]
- │    │    │         │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index
- │    │    │         │    │    │    │    │    │    ├── columns: pg_namespace.oid:68(oid!null) pg_namespace.nspname:69(string!null)
- │    │    │         │    │    │    │    │    │    ├── key: (68)
- │    │    │         │    │    │    │    │    │    └── fd: (68)-->(69), (69)-->(68)
- │    │    │         │    │    │    │    │    └── filters [type=bool, outer=(43,68), constraints=(/43: (/NULL - ]; /68: (/NULL - ]), fd=(43)==(68), (68)==(43)]
- │    │    │         │    │    │    │    │         └── pg_namespace.oid = pg_class.relnamespace [type=bool, outer=(43,68), constraints=(/43: (/NULL - ]; /68: (/NULL - ])]
- │    │    │         │    │    │    │    ├── right-join
+ │    │    │         │    │    │    │    ├── ordering: +1 opt(3,28,29)
+ │    │    │         │    │    │    │    ├── sort
  │    │    │         │    │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string)
  │    │    │         │    │    │    │    │    ├── key: (1,32)
  │    │    │         │    │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32)
- │    │    │         │    │    │    │    │    ├── scan pg_tablespace@pg_tablespace_spcname_index
- │    │    │         │    │    │    │    │    │    ├── columns: pg_tablespace.oid:32(oid!null) spcname:33(string!null)
- │    │    │         │    │    │    │    │    │    ├── key: (32)
- │    │    │         │    │    │    │    │    │    └── fd: (32)-->(33), (33)-->(32)
- │    │    │         │    │    │    │    │    ├── inner-join
- │    │    │         │    │    │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null)
- │    │    │         │    │    │    │    │    │    ├── key: (1)
- │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3)
- │    │    │         │    │    │    │    │    │    ├── select
- │    │    │         │    │    │    │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[])
- │    │    │         │    │    │    │    │    │    │    ├── key: (1)
- │    │    │         │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
- │    │    │         │    │    │    │    │    │    │    ├── scan pg_class
- │    │    │         │    │    │    │    │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[])
- │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
- │    │    │         │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
- │    │    │         │    │    │    │    │    │    │    └── filters [type=bool, outer=(17)]
- │    │    │         │    │    │    │    │    │    │         └── (pg_class.relkind = 'r'::CHAR) OR (pg_class.relkind = 'f'::CHAR) [type=bool, outer=(17)]
- │    │    │         │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index
- │    │    │         │    │    │    │    │    │    │    ├── columns: pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null)
- │    │    │         │    │    │    │    │    │    │    ├── constraint: /29: [/'public' - /'public']
- │    │    │         │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │         │    │    │    │    │    │    │    ├── key: ()
- │    │    │         │    │    │    │    │    │    │    └── fd: ()-->(28,29)
- │    │    │         │    │    │    │    │    │    └── filters [type=bool, outer=(3,28), constraints=(/3: (/NULL - ]; /28: (/NULL - ]), fd=(3)==(28), (28)==(3)]
- │    │    │         │    │    │    │    │    │         └── pg_namespace.oid = pg_class.relnamespace [type=bool, outer=(3,28), constraints=(/3: (/NULL - ]; /28: (/NULL - ])]
- │    │    │         │    │    │    │    │    └── filters [type=bool, outer=(8,32), constraints=(/8: (/NULL - ]; /32: (/NULL - ]), fd=(8)==(32), (32)==(8)]
- │    │    │         │    │    │    │    │         └── pg_tablespace.oid = pg_class.reltablespace [type=bool, outer=(8,32), constraints=(/8: (/NULL - ]; /32: (/NULL - ])]
- │    │    │         │    │    │    │    └── filters [type=bool, outer=(1,38), constraints=(/1: (/NULL - ]; /38: (/NULL - ]), fd=(1)==(38), (38)==(1)]
- │    │    │         │    │    │    │         └── pg_inherits.inhrelid = pg_class.oid [type=bool, outer=(1,38), constraints=(/1: (/NULL - ]; /38: (/NULL - ])]
- │    │    │         │    │    │    ├── select
+ │    │    │         │    │    │    │    │    ├── ordering: +1 opt(3,28,29)
+ │    │    │         │    │    │    │    │    └── right-join
+ │    │    │         │    │    │    │    │         ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string)
+ │    │    │         │    │    │    │    │         ├── key: (1,32)
+ │    │    │         │    │    │    │    │         ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32)
+ │    │    │         │    │    │    │    │         ├── scan pg_tablespace@pg_tablespace_spcname_index
+ │    │    │         │    │    │    │    │         │    ├── columns: pg_tablespace.oid:32(oid!null) spcname:33(string!null)
+ │    │    │         │    │    │    │    │         │    ├── key: (32)
+ │    │    │         │    │    │    │    │         │    └── fd: (32)-->(33), (33)-->(32)
+ │    │    │         │    │    │    │    │         ├── inner-join
+ │    │    │         │    │    │    │    │         │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null)
+ │    │    │         │    │    │    │    │         │    ├── key: (1)
+ │    │    │         │    │    │    │    │         │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3)
+ │    │    │         │    │    │    │    │         │    ├── select
+ │    │    │         │    │    │    │    │         │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[])
+ │    │    │         │    │    │    │    │         │    │    ├── key: (1)
+ │    │    │         │    │    │    │    │         │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+ │    │    │         │    │    │    │    │         │    │    ├── scan pg_class
+ │    │    │         │    │    │    │    │         │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[])
+ │    │    │         │    │    │    │    │         │    │    │    ├── key: (1)
+ │    │    │         │    │    │    │    │         │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+ │    │    │         │    │    │    │    │         │    │    └── filters [type=bool, outer=(17)]
+ │    │    │         │    │    │    │    │         │    │         └── (pg_class.relkind = 'r'::CHAR) OR (pg_class.relkind = 'f'::CHAR) [type=bool, outer=(17)]
+ │    │    │         │    │    │    │    │         │    ├── scan pg_namespace@pg_namespace_nspname_index
+ │    │    │         │    │    │    │    │         │    │    ├── columns: pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null)
+ │    │    │         │    │    │    │    │         │    │    ├── constraint: /29: [/'public' - /'public']
+ │    │    │         │    │    │    │    │         │    │    ├── cardinality: [0 - 1]
+ │    │    │         │    │    │    │    │         │    │    ├── key: ()
+ │    │    │         │    │    │    │    │         │    │    └── fd: ()-->(28,29)
+ │    │    │         │    │    │    │    │         │    └── filters [type=bool, outer=(3,28), constraints=(/3: (/NULL - ]; /28: (/NULL - ]), fd=(3)==(28), (28)==(3)]
+ │    │    │         │    │    │    │    │         │         └── pg_namespace.oid = pg_class.relnamespace [type=bool, outer=(3,28), constraints=(/3: (/NULL - ]; /28: (/NULL - ])]
+ │    │    │         │    │    │    │    │         └── filters [type=bool, outer=(8,32), constraints=(/8: (/NULL - ]; /32: (/NULL - ]), fd=(8)==(32), (32)==(8)]
+ │    │    │         │    │    │    │    │              └── pg_tablespace.oid = pg_class.reltablespace [type=bool, outer=(8,32), constraints=(/8: (/NULL - ]; /32: (/NULL - ])]
+ │    │    │         │    │    │    │    ├── sort
+ │    │    │         │    │    │    │    │    ├── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null) pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string)
+ │    │    │         │    │    │    │    │    ├── fd: (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)-->(69), (69)-->(68)
+ │    │    │         │    │    │    │    │    ├── ordering: +38
+ │    │    │         │    │    │    │    │    └── left-join
+ │    │    │         │    │    │    │    │         ├── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null) pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string)
+ │    │    │         │    │    │    │    │         ├── fd: (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)-->(69), (69)-->(68)
+ │    │    │         │    │    │    │    │         ├── inner-join
+ │    │    │         │    │    │    │    │         │    ├── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null) pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null)
+ │    │    │         │    │    │    │    │         │    ├── fd: (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39)
+ │    │    │         │    │    │    │    │         │    ├── scan pg_inherits
+ │    │    │         │    │    │    │    │         │    │    └── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null)
+ │    │    │         │    │    │    │    │         │    ├── scan pg_class@pg_class_relname_nsp_index
+ │    │    │         │    │    │    │    │         │    │    ├── columns: pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null)
+ │    │    │         │    │    │    │    │         │    │    ├── key: (41)
+ │    │    │         │    │    │    │    │         │    │    └── fd: (41)-->(42,43), (42,43)-->(41)
+ │    │    │         │    │    │    │    │         │    └── filters [type=bool, outer=(39,41), constraints=(/39: (/NULL - ]; /41: (/NULL - ]), fd=(39)==(41), (41)==(39)]
+ │    │    │         │    │    │    │    │         │         └── pg_inherits.inhparent = pg_class.oid [type=bool, outer=(39,41), constraints=(/39: (/NULL - ]; /41: (/NULL - ])]
+ │    │    │         │    │    │    │    │         ├── scan pg_namespace@pg_namespace_nspname_index
+ │    │    │         │    │    │    │    │         │    ├── columns: pg_namespace.oid:68(oid!null) pg_namespace.nspname:69(string!null)
+ │    │    │         │    │    │    │    │         │    ├── key: (68)
+ │    │    │         │    │    │    │    │         │    └── fd: (68)-->(69), (69)-->(68)
+ │    │    │         │    │    │    │    │         └── filters [type=bool, outer=(43,68), constraints=(/43: (/NULL - ]; /68: (/NULL - ]), fd=(43)==(68), (68)==(43)]
+ │    │    │         │    │    │    │    │              └── pg_namespace.oid = pg_class.relnamespace [type=bool, outer=(43,68), constraints=(/43: (/NULL - ]; /68: (/NULL - ])]
+ │    │    │         │    │    │    │    └── merge-on
+ │    │    │         │    │    │    │         ├── left ordering: +1
+ │    │    │         │    │    │    │         ├── right ordering: +38
+ │    │    │         │    │    │    │         └── filters [type=bool, outer=(1,38), constraints=(/1: (/NULL - ]; /38: (/NULL - ]), fd=(1)==(38), (38)==(1)]
+ │    │    │         │    │    │    │              └── pg_inherits.inhrelid = pg_class.oid [type=bool, outer=(1,38), constraints=(/1: (/NULL - ]; /38: (/NULL - ])]
+ │    │    │         │    │    │    ├── sort
  │    │    │         │    │    │    │    ├── columns: indexrelid:72(oid!null) indrelid:73(oid!null) indisclustered:79(bool!null)
  │    │    │         │    │    │    │    ├── key: (72)
  │    │    │         │    │    │    │    ├── fd: ()-->(79), (72)-->(73)
- │    │    │         │    │    │    │    ├── scan pg_index
- │    │    │         │    │    │    │    │    ├── columns: indexrelid:72(oid!null) indrelid:73(oid!null) indisclustered:79(bool!null)
- │    │    │         │    │    │    │    │    ├── key: (72)
- │    │    │         │    │    │    │    │    └── fd: (72)-->(73,79)
- │    │    │         │    │    │    │    └── filters [type=bool, outer=(79), constraints=(/79: [/true - /true]; tight), fd=()-->(79)]
- │    │    │         │    │    │    │         └── pg_index.indisclustered = true [type=bool, outer=(79), constraints=(/79: [/true - /true]; tight)]
- │    │    │         │    │    │    └── filters [type=bool, outer=(1,73), constraints=(/1: (/NULL - ]; /73: (/NULL - ]), fd=(1)==(73), (73)==(1)]
- │    │    │         │    │    │         └── pg_index.indrelid = pg_class.oid [type=bool, outer=(1,73), constraints=(/1: (/NULL - ]; /73: (/NULL - ])]
+ │    │    │         │    │    │    │    ├── ordering: +73 opt(73,79)
+ │    │    │         │    │    │    │    └── select
+ │    │    │         │    │    │    │         ├── columns: indexrelid:72(oid!null) indrelid:73(oid!null) indisclustered:79(bool!null)
+ │    │    │         │    │    │    │         ├── key: (72)
+ │    │    │         │    │    │    │         ├── fd: ()-->(79), (72)-->(73)
+ │    │    │         │    │    │    │         ├── scan pg_index
+ │    │    │         │    │    │    │         │    ├── columns: indexrelid:72(oid!null) indrelid:73(oid!null) indisclustered:79(bool!null)
+ │    │    │         │    │    │    │         │    ├── key: (72)
+ │    │    │         │    │    │    │         │    └── fd: (72)-->(73,79)
+ │    │    │         │    │    │    │         └── filters [type=bool, outer=(79), constraints=(/79: [/true - /true]; tight), fd=()-->(79)]
+ │    │    │         │    │    │    │              └── pg_index.indisclustered = true [type=bool, outer=(79), constraints=(/79: [/true - /true]; tight)]
+ │    │    │         │    │    │    └── merge-on
+ │    │    │         │    │    │         ├── left ordering: +1
+ │    │    │         │    │    │         ├── right ordering: +73
+ │    │    │         │    │    │         └── filters [type=bool, outer=(1,73), constraints=(/1: (/NULL - ]; /73: (/NULL - ]), fd=(1)==(73), (73)==(1)]
+ │    │    │         │    │    │              └── pg_index.indrelid = pg_class.oid [type=bool, outer=(1,73), constraints=(/1: (/NULL - ]; /73: (/NULL - ])]
  │    │    │         │    │    ├── scan pg_class@pg_class_relname_nsp_index
  │    │    │         │    │    │    ├── columns: pg_class.oid:91(oid!null) pg_class.relname:92(string!null)
  │    │    │         │    │    │    ├── key: (91)

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -300,78 +300,99 @@ project
  │    │    │         │    ├── left-join
  │    │    │         │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) pg_class.oid:91(oid) pg_class.relname:92(string)
  │    │    │         │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79), (91)-->(92)
- │    │    │         │    │    ├── left-join
+ │    │    │         │    │    ├── left-join (merge)
  │    │    │         │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool)
  │    │    │         │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79)
- │    │    │         │    │    │    ├── right-join
+ │    │    │         │    │    │    ├── left-join (merge)
  │    │    │         │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string) pg_inherits.inhrelid:38(oid) pg_inherits.inhparent:39(oid) pg_class.oid:41(oid) pg_class.relname:42(string) pg_class.relnamespace:43(oid) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string)
  │    │    │         │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68)
- │    │    │         │    │    │    │    ├── left-join
- │    │    │         │    │    │    │    │    ├── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null) pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string)
- │    │    │         │    │    │    │    │    ├── fd: (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)-->(69), (69)-->(68)
- │    │    │         │    │    │    │    │    ├── inner-join
- │    │    │         │    │    │    │    │    │    ├── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null) pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null)
- │    │    │         │    │    │    │    │    │    ├── fd: (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39)
- │    │    │         │    │    │    │    │    │    ├── scan pg_inherits
- │    │    │         │    │    │    │    │    │    │    └── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null)
- │    │    │         │    │    │    │    │    │    ├── scan pg_class@pg_class_relname_nsp_index
- │    │    │         │    │    │    │    │    │    │    ├── columns: pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null)
- │    │    │         │    │    │    │    │    │    │    ├── key: (41)
- │    │    │         │    │    │    │    │    │    │    └── fd: (41)-->(42,43), (42,43)-->(41)
- │    │    │         │    │    │    │    │    │    └── filters [type=bool, outer=(39,41), constraints=(/39: (/NULL - ]; /41: (/NULL - ]), fd=(39)==(41), (41)==(39)]
- │    │    │         │    │    │    │    │    │         └── pg_inherits.inhparent = pg_class.oid [type=bool, outer=(39,41), constraints=(/39: (/NULL - ]; /41: (/NULL - ])]
- │    │    │         │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index
- │    │    │         │    │    │    │    │    │    ├── columns: pg_namespace.oid:68(oid!null) pg_namespace.nspname:69(string!null)
- │    │    │         │    │    │    │    │    │    ├── key: (68)
- │    │    │         │    │    │    │    │    │    └── fd: (68)-->(69), (69)-->(68)
- │    │    │         │    │    │    │    │    └── filters [type=bool, outer=(43,68), constraints=(/43: (/NULL - ]; /68: (/NULL - ]), fd=(43)==(68), (68)==(43)]
- │    │    │         │    │    │    │    │         └── pg_namespace.oid = pg_class.relnamespace [type=bool, outer=(43,68), constraints=(/43: (/NULL - ]; /68: (/NULL - ])]
- │    │    │         │    │    │    │    ├── right-join
+ │    │    │         │    │    │    │    ├── ordering: +1 opt(3,28,29)
+ │    │    │         │    │    │    │    ├── sort
  │    │    │         │    │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string)
  │    │    │         │    │    │    │    │    ├── key: (1,32)
  │    │    │         │    │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32)
- │    │    │         │    │    │    │    │    ├── scan pg_tablespace@pg_tablespace_spcname_index
- │    │    │         │    │    │    │    │    │    ├── columns: pg_tablespace.oid:32(oid!null) spcname:33(string!null)
- │    │    │         │    │    │    │    │    │    ├── key: (32)
- │    │    │         │    │    │    │    │    │    └── fd: (32)-->(33), (33)-->(32)
- │    │    │         │    │    │    │    │    ├── inner-join
- │    │    │         │    │    │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null)
- │    │    │         │    │    │    │    │    │    ├── key: (1)
- │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3)
- │    │    │         │    │    │    │    │    │    ├── select
- │    │    │         │    │    │    │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[])
- │    │    │         │    │    │    │    │    │    │    ├── key: (1)
- │    │    │         │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
- │    │    │         │    │    │    │    │    │    │    ├── scan pg_class
- │    │    │         │    │    │    │    │    │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[])
- │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
- │    │    │         │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
- │    │    │         │    │    │    │    │    │    │    └── filters [type=bool, outer=(17)]
- │    │    │         │    │    │    │    │    │    │         └── (pg_class.relkind = 'r'::CHAR) OR (pg_class.relkind = 'f'::CHAR) [type=bool, outer=(17)]
- │    │    │         │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index
- │    │    │         │    │    │    │    │    │    │    ├── columns: pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null)
- │    │    │         │    │    │    │    │    │    │    ├── constraint: /29: [/'public' - /'public']
- │    │    │         │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │         │    │    │    │    │    │    │    ├── key: ()
- │    │    │         │    │    │    │    │    │    │    └── fd: ()-->(28,29)
- │    │    │         │    │    │    │    │    │    └── filters [type=bool, outer=(3,28), constraints=(/3: (/NULL - ]; /28: (/NULL - ]), fd=(3)==(28), (28)==(3)]
- │    │    │         │    │    │    │    │    │         └── pg_namespace.oid = pg_class.relnamespace [type=bool, outer=(3,28), constraints=(/3: (/NULL - ]; /28: (/NULL - ])]
- │    │    │         │    │    │    │    │    └── filters [type=bool, outer=(8,32), constraints=(/8: (/NULL - ]; /32: (/NULL - ]), fd=(8)==(32), (32)==(8)]
- │    │    │         │    │    │    │    │         └── pg_tablespace.oid = pg_class.reltablespace [type=bool, outer=(8,32), constraints=(/8: (/NULL - ]; /32: (/NULL - ])]
- │    │    │         │    │    │    │    └── filters [type=bool, outer=(1,38), constraints=(/1: (/NULL - ]; /38: (/NULL - ]), fd=(1)==(38), (38)==(1)]
- │    │    │         │    │    │    │         └── pg_inherits.inhrelid = pg_class.oid [type=bool, outer=(1,38), constraints=(/1: (/NULL - ]; /38: (/NULL - ])]
- │    │    │         │    │    │    ├── select
+ │    │    │         │    │    │    │    │    ├── ordering: +1 opt(3,28,29)
+ │    │    │         │    │    │    │    │    └── right-join
+ │    │    │         │    │    │    │    │         ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null) pg_tablespace.oid:32(oid) spcname:33(string)
+ │    │    │         │    │    │    │    │         ├── key: (1,32)
+ │    │    │         │    │    │    │    │         ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32)
+ │    │    │         │    │    │    │    │         ├── scan pg_tablespace@pg_tablespace_spcname_index
+ │    │    │         │    │    │    │    │         │    ├── columns: pg_tablespace.oid:32(oid!null) spcname:33(string!null)
+ │    │    │         │    │    │    │    │         │    ├── key: (32)
+ │    │    │         │    │    │    │    │         │    └── fd: (32)-->(33), (33)-->(32)
+ │    │    │         │    │    │    │    │         ├── inner-join
+ │    │    │         │    │    │    │    │         │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null)
+ │    │    │         │    │    │    │    │         │    ├── key: (1)
+ │    │    │         │    │    │    │    │         │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3)
+ │    │    │         │    │    │    │    │         │    ├── select
+ │    │    │         │    │    │    │    │         │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[])
+ │    │    │         │    │    │    │    │         │    │    ├── key: (1)
+ │    │    │         │    │    │    │    │         │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+ │    │    │         │    │    │    │    │         │    │    ├── scan pg_class
+ │    │    │         │    │    │    │    │         │    │    │    ├── columns: pg_class.oid:1(oid!null) pg_class.relname:2(string!null) pg_class.relnamespace:3(oid!null) pg_class.relowner:5(oid!null) pg_class.reltablespace:8(oid!null) pg_class.reltuples:10(float!null) pg_class.relhasindex:13(bool!null) pg_class.relpersistence:15(string!null) pg_class.relkind:17(string!null) pg_class.relhasoids:20(bool!null) pg_class.relhasrules:22(bool!null) pg_class.relhastriggers:23(bool!null) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[])
+ │    │    │         │    │    │    │    │         │    │    │    ├── key: (1)
+ │    │    │         │    │    │    │    │         │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+ │    │    │         │    │    │    │    │         │    │    └── filters [type=bool, outer=(17)]
+ │    │    │         │    │    │    │    │         │    │         └── (pg_class.relkind = 'r'::CHAR) OR (pg_class.relkind = 'f'::CHAR) [type=bool, outer=(17)]
+ │    │    │         │    │    │    │    │         │    ├── scan pg_namespace@pg_namespace_nspname_index
+ │    │    │         │    │    │    │    │         │    │    ├── columns: pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null)
+ │    │    │         │    │    │    │    │         │    │    ├── constraint: /29: [/'public' - /'public']
+ │    │    │         │    │    │    │    │         │    │    ├── cardinality: [0 - 1]
+ │    │    │         │    │    │    │    │         │    │    ├── key: ()
+ │    │    │         │    │    │    │    │         │    │    └── fd: ()-->(28,29)
+ │    │    │         │    │    │    │    │         │    └── filters [type=bool, outer=(3,28), constraints=(/3: (/NULL - ]; /28: (/NULL - ]), fd=(3)==(28), (28)==(3)]
+ │    │    │         │    │    │    │    │         │         └── pg_namespace.oid = pg_class.relnamespace [type=bool, outer=(3,28), constraints=(/3: (/NULL - ]; /28: (/NULL - ])]
+ │    │    │         │    │    │    │    │         └── filters [type=bool, outer=(8,32), constraints=(/8: (/NULL - ]; /32: (/NULL - ]), fd=(8)==(32), (32)==(8)]
+ │    │    │         │    │    │    │    │              └── pg_tablespace.oid = pg_class.reltablespace [type=bool, outer=(8,32), constraints=(/8: (/NULL - ]; /32: (/NULL - ])]
+ │    │    │         │    │    │    │    ├── sort
+ │    │    │         │    │    │    │    │    ├── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null) pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string)
+ │    │    │         │    │    │    │    │    ├── fd: (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)-->(69), (69)-->(68)
+ │    │    │         │    │    │    │    │    ├── ordering: +38
+ │    │    │         │    │    │    │    │    └── left-join
+ │    │    │         │    │    │    │    │         ├── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null) pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null) pg_namespace.oid:68(oid) pg_namespace.nspname:69(string)
+ │    │    │         │    │    │    │    │         ├── fd: (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)-->(69), (69)-->(68)
+ │    │    │         │    │    │    │    │         ├── inner-join
+ │    │    │         │    │    │    │    │         │    ├── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null) pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null)
+ │    │    │         │    │    │    │    │         │    ├── fd: (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39)
+ │    │    │         │    │    │    │    │         │    ├── scan pg_inherits
+ │    │    │         │    │    │    │    │         │    │    └── columns: pg_inherits.inhrelid:38(oid!null) pg_inherits.inhparent:39(oid!null)
+ │    │    │         │    │    │    │    │         │    ├── scan pg_class@pg_class_relname_nsp_index
+ │    │    │         │    │    │    │    │         │    │    ├── columns: pg_class.oid:41(oid!null) pg_class.relname:42(string!null) pg_class.relnamespace:43(oid!null)
+ │    │    │         │    │    │    │    │         │    │    ├── key: (41)
+ │    │    │         │    │    │    │    │         │    │    └── fd: (41)-->(42,43), (42,43)-->(41)
+ │    │    │         │    │    │    │    │         │    └── filters [type=bool, outer=(39,41), constraints=(/39: (/NULL - ]; /41: (/NULL - ]), fd=(39)==(41), (41)==(39)]
+ │    │    │         │    │    │    │    │         │         └── pg_inherits.inhparent = pg_class.oid [type=bool, outer=(39,41), constraints=(/39: (/NULL - ]; /41: (/NULL - ])]
+ │    │    │         │    │    │    │    │         ├── scan pg_namespace@pg_namespace_nspname_index
+ │    │    │         │    │    │    │    │         │    ├── columns: pg_namespace.oid:68(oid!null) pg_namespace.nspname:69(string!null)
+ │    │    │         │    │    │    │    │         │    ├── key: (68)
+ │    │    │         │    │    │    │    │         │    └── fd: (68)-->(69), (69)-->(68)
+ │    │    │         │    │    │    │    │         └── filters [type=bool, outer=(43,68), constraints=(/43: (/NULL - ]; /68: (/NULL - ]), fd=(43)==(68), (68)==(43)]
+ │    │    │         │    │    │    │    │              └── pg_namespace.oid = pg_class.relnamespace [type=bool, outer=(43,68), constraints=(/43: (/NULL - ]; /68: (/NULL - ])]
+ │    │    │         │    │    │    │    └── merge-on
+ │    │    │         │    │    │    │         ├── left ordering: +1
+ │    │    │         │    │    │    │         ├── right ordering: +38
+ │    │    │         │    │    │    │         └── filters [type=bool, outer=(1,38), constraints=(/1: (/NULL - ]; /38: (/NULL - ]), fd=(1)==(38), (38)==(1)]
+ │    │    │         │    │    │    │              └── pg_inherits.inhrelid = pg_class.oid [type=bool, outer=(1,38), constraints=(/1: (/NULL - ]; /38: (/NULL - ])]
+ │    │    │         │    │    │    ├── sort
  │    │    │         │    │    │    │    ├── columns: indexrelid:72(oid!null) indrelid:73(oid!null) indisclustered:79(bool!null)
  │    │    │         │    │    │    │    ├── key: (72)
  │    │    │         │    │    │    │    ├── fd: ()-->(79), (72)-->(73)
- │    │    │         │    │    │    │    ├── scan pg_index
- │    │    │         │    │    │    │    │    ├── columns: indexrelid:72(oid!null) indrelid:73(oid!null) indisclustered:79(bool!null)
- │    │    │         │    │    │    │    │    ├── key: (72)
- │    │    │         │    │    │    │    │    └── fd: (72)-->(73,79)
- │    │    │         │    │    │    │    └── filters [type=bool, outer=(79), constraints=(/79: [/true - /true]; tight), fd=()-->(79)]
- │    │    │         │    │    │    │         └── pg_index.indisclustered = true [type=bool, outer=(79), constraints=(/79: [/true - /true]; tight)]
- │    │    │         │    │    │    └── filters [type=bool, outer=(1,73), constraints=(/1: (/NULL - ]; /73: (/NULL - ]), fd=(1)==(73), (73)==(1)]
- │    │    │         │    │    │         └── pg_index.indrelid = pg_class.oid [type=bool, outer=(1,73), constraints=(/1: (/NULL - ]; /73: (/NULL - ])]
+ │    │    │         │    │    │    │    ├── ordering: +73 opt(73,79)
+ │    │    │         │    │    │    │    └── select
+ │    │    │         │    │    │    │         ├── columns: indexrelid:72(oid!null) indrelid:73(oid!null) indisclustered:79(bool!null)
+ │    │    │         │    │    │    │         ├── key: (72)
+ │    │    │         │    │    │    │         ├── fd: ()-->(79), (72)-->(73)
+ │    │    │         │    │    │    │         ├── scan pg_index
+ │    │    │         │    │    │    │         │    ├── columns: indexrelid:72(oid!null) indrelid:73(oid!null) indisclustered:79(bool!null)
+ │    │    │         │    │    │    │         │    ├── key: (72)
+ │    │    │         │    │    │    │         │    └── fd: (72)-->(73,79)
+ │    │    │         │    │    │    │         └── filters [type=bool, outer=(79), constraints=(/79: [/true - /true]; tight), fd=()-->(79)]
+ │    │    │         │    │    │    │              └── pg_index.indisclustered = true [type=bool, outer=(79), constraints=(/79: [/true - /true]; tight)]
+ │    │    │         │    │    │    └── merge-on
+ │    │    │         │    │    │         ├── left ordering: +1
+ │    │    │         │    │    │         ├── right ordering: +73
+ │    │    │         │    │    │         └── filters [type=bool, outer=(1,73), constraints=(/1: (/NULL - ]; /73: (/NULL - ]), fd=(1)==(73), (73)==(1)]
+ │    │    │         │    │    │              └── pg_index.indrelid = pg_class.oid [type=bool, outer=(1,73), constraints=(/1: (/NULL - ]; /73: (/NULL - ])]
  │    │    │         │    │    ├── scan pg_class@pg_class_relname_nsp_index
  │    │    │         │    │    │    ├── columns: pg_class.oid:91(oid!null) pg_class.relname:92(string!null)
  │    │    │         │    │    │    ├── key: (91)

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -268,115 +268,121 @@ from (select flavors.created_at as flavors_created_at,
      on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
 order by anon_1.flavors_id asc
 ----
-sort
+left-join (merge)
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── ordering: +1
- └── right-join
-      ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:25(int) key:26(string) value:27(string) flavor_extra_specs.flavor_id:28(int) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
-      ├── key: (1,25)
-      ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
-      ├── scan flavor_extra_specs
-      │    ├── columns: flavor_extra_specs.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs.flavor_id:28(int!null) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
-      │    ├── key: (25)
-      │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
-      ├── project
-      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    └── limit
-      │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
-      │         ├── key: (1)
-      │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         ├── offset
-      │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
-      │         │    ├── key: (1)
-      │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    ├── ordering: +1
-      │         │    ├── sort
-      │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
-      │         │    │    ├── key: (1)
-      │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │    ├── ordering: +1
-      │         │    │    └── select
-      │         │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
-      │         │    │         ├── key: (1)
-      │         │    │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │         ├── group-by
-      │         │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
-      │         │    │         │    ├── grouping columns: flavors.id:1(int!null)
-      │         │    │         │    ├── key: (1)
-      │         │    │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │         │    ├── left-join (merge)
-      │         │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
-      │         │    │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
-      │         │    │         │    │    ├── select
-      │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │         │    │         │    │    │    ├── key: (1)
-      │         │    │         │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │         │    │    │    ├── ordering: +1
-      │         │    │         │    │    │    ├── scan flavors
-      │         │    │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │         │    │         │    │    │    │    ├── key: (1)
-      │         │    │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │         │    │    │    │    └── ordering: +1
-      │         │    │         │    │    │    └── filters [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
-      │         │    │         │    │    │         └── flavors.flavorid = $2 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
-      │         │    │         │    │    ├── project
-      │         │    │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
-      │         │    │         │    │    │    ├── fd: ()-->(22)
-      │         │    │         │    │    │    ├── ordering: +17 opt(22)
-      │         │    │         │    │    │    ├── select
-      │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
-      │         │    │         │    │    │    │    ├── key: (17,18)
-      │         │    │         │    │    │    │    ├── ordering: +17
-      │         │    │         │    │    │    │    ├── scan flavor_projects@secondary
-      │         │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
-      │         │    │         │    │    │    │    │    ├── key: (17,18)
-      │         │    │         │    │    │    │    │    └── ordering: +17
-      │         │    │         │    │    │    │    └── filters [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
-      │         │    │         │    │    │    │         └── flavor_projects.project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
-      │         │    │         │    │    │    └── projections [outer=(17)]
-      │         │    │         │    │    │         └── true [type=bool]
-      │         │    │         │    │    └── merge-on
-      │         │    │         │    │         ├── left ordering: +1
-      │         │    │         │    │         ├── right ordering: +17
-      │         │    │         │    │         └── filters [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
-      │         │    │         │    │              └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ])]
-      │         │    │         │    └── aggregations [outer=(2-12,14,15,22)]
-      │         │    │         │         ├── any-not-null [type=bool, outer=(22)]
-      │         │    │         │         │    └── variable: true [type=bool, outer=(22)]
-      │         │    │         │         ├── any-not-null [type=string, outer=(2)]
-      │         │    │         │         │    └── variable: flavors.name [type=string, outer=(2)]
-      │         │    │         │         ├── any-not-null [type=int, outer=(3)]
-      │         │    │         │         │    └── variable: flavors.memory_mb [type=int, outer=(3)]
-      │         │    │         │         ├── any-not-null [type=int, outer=(4)]
-      │         │    │         │         │    └── variable: flavors.vcpus [type=int, outer=(4)]
-      │         │    │         │         ├── any-not-null [type=int, outer=(5)]
-      │         │    │         │         │    └── variable: flavors.root_gb [type=int, outer=(5)]
-      │         │    │         │         ├── any-not-null [type=int, outer=(6)]
-      │         │    │         │         │    └── variable: flavors.ephemeral_gb [type=int, outer=(6)]
-      │         │    │         │         ├── any-not-null [type=string, outer=(7)]
-      │         │    │         │         │    └── variable: flavors.flavorid [type=string, outer=(7)]
-      │         │    │         │         ├── any-not-null [type=int, outer=(8)]
-      │         │    │         │         │    └── variable: flavors.swap [type=int, outer=(8)]
-      │         │    │         │         ├── any-not-null [type=float, outer=(9)]
-      │         │    │         │         │    └── variable: flavors.rxtx_factor [type=float, outer=(9)]
-      │         │    │         │         ├── any-not-null [type=int, outer=(10)]
-      │         │    │         │         │    └── variable: flavors.vcpu_weight [type=int, outer=(10)]
-      │         │    │         │         ├── any-not-null [type=bool, outer=(11)]
-      │         │    │         │         │    └── variable: flavors.disabled [type=bool, outer=(11)]
-      │         │    │         │         ├── any-not-null [type=bool, outer=(12)]
-      │         │    │         │         │    └── variable: flavors.is_public [type=bool, outer=(12)]
-      │         │    │         │         ├── any-not-null [type=timestamp, outer=(14)]
-      │         │    │         │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
-      │         │    │         │         └── any-not-null [type=timestamp, outer=(15)]
-      │         │    │         │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
-      │         │    │         └── filters [type=bool, outer=(12,23)]
-      │         │    │              └── (flavors.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,23)]
-      │         │    └── placeholder: $3 [type=int]
-      │         └── placeholder: $4 [type=int]
+ ├── project
+ │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │    ├── ordering: +1
+ │    └── limit
+ │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         ├── ordering: +1
+ │         ├── offset
+ │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+ │         │    ├── key: (1)
+ │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    ├── ordering: +1
+ │         │    ├── sort
+ │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+ │         │    │    ├── key: (1)
+ │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    │    ├── ordering: +1
+ │         │    │    └── select
+ │         │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+ │         │    │         ├── key: (1)
+ │         │    │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    │         ├── group-by
+ │         │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) any_not_null:23(bool)
+ │         │    │         │    ├── grouping columns: flavors.id:1(int!null)
+ │         │    │         │    ├── key: (1)
+ │         │    │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    │         │    ├── left-join (merge)
+ │         │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+ │         │    │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
+ │         │    │         │    │    ├── select
+ │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │         │    │         │    │    │    ├── key: (1)
+ │         │    │         │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    │         │    │    │    ├── ordering: +1
+ │         │    │         │    │    │    ├── scan flavors
+ │         │    │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │         │    │         │    │    │    │    ├── key: (1)
+ │         │    │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │         │    │         │    │    │    │    └── ordering: +1
+ │         │    │         │    │    │    └── filters [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
+ │         │    │         │    │    │         └── flavors.flavorid = $2 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
+ │         │    │         │    │    ├── project
+ │         │    │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+ │         │    │         │    │    │    ├── fd: ()-->(22)
+ │         │    │         │    │    │    ├── ordering: +17 opt(22)
+ │         │    │         │    │    │    ├── select
+ │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+ │         │    │         │    │    │    │    ├── key: (17,18)
+ │         │    │         │    │    │    │    ├── ordering: +17
+ │         │    │         │    │    │    │    ├── scan flavor_projects@secondary
+ │         │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+ │         │    │         │    │    │    │    │    ├── key: (17,18)
+ │         │    │         │    │    │    │    │    └── ordering: +17
+ │         │    │         │    │    │    │    └── filters [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+ │         │    │         │    │    │    │         └── flavor_projects.project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+ │         │    │         │    │    │    └── projections [outer=(17)]
+ │         │    │         │    │    │         └── true [type=bool]
+ │         │    │         │    │    └── merge-on
+ │         │    │         │    │         ├── left ordering: +1
+ │         │    │         │    │         ├── right ordering: +17
+ │         │    │         │    │         └── filters [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
+ │         │    │         │    │              └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ])]
+ │         │    │         │    └── aggregations [outer=(2-12,14,15,22)]
+ │         │    │         │         ├── any-not-null [type=bool, outer=(22)]
+ │         │    │         │         │    └── variable: true [type=bool, outer=(22)]
+ │         │    │         │         ├── any-not-null [type=string, outer=(2)]
+ │         │    │         │         │    └── variable: flavors.name [type=string, outer=(2)]
+ │         │    │         │         ├── any-not-null [type=int, outer=(3)]
+ │         │    │         │         │    └── variable: flavors.memory_mb [type=int, outer=(3)]
+ │         │    │         │         ├── any-not-null [type=int, outer=(4)]
+ │         │    │         │         │    └── variable: flavors.vcpus [type=int, outer=(4)]
+ │         │    │         │         ├── any-not-null [type=int, outer=(5)]
+ │         │    │         │         │    └── variable: flavors.root_gb [type=int, outer=(5)]
+ │         │    │         │         ├── any-not-null [type=int, outer=(6)]
+ │         │    │         │         │    └── variable: flavors.ephemeral_gb [type=int, outer=(6)]
+ │         │    │         │         ├── any-not-null [type=string, outer=(7)]
+ │         │    │         │         │    └── variable: flavors.flavorid [type=string, outer=(7)]
+ │         │    │         │         ├── any-not-null [type=int, outer=(8)]
+ │         │    │         │         │    └── variable: flavors.swap [type=int, outer=(8)]
+ │         │    │         │         ├── any-not-null [type=float, outer=(9)]
+ │         │    │         │         │    └── variable: flavors.rxtx_factor [type=float, outer=(9)]
+ │         │    │         │         ├── any-not-null [type=int, outer=(10)]
+ │         │    │         │         │    └── variable: flavors.vcpu_weight [type=int, outer=(10)]
+ │         │    │         │         ├── any-not-null [type=bool, outer=(11)]
+ │         │    │         │         │    └── variable: flavors.disabled [type=bool, outer=(11)]
+ │         │    │         │         ├── any-not-null [type=bool, outer=(12)]
+ │         │    │         │         │    └── variable: flavors.is_public [type=bool, outer=(12)]
+ │         │    │         │         ├── any-not-null [type=timestamp, outer=(14)]
+ │         │    │         │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
+ │         │    │         │         └── any-not-null [type=timestamp, outer=(15)]
+ │         │    │         │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
+ │         │    │         └── filters [type=bool, outer=(12,23)]
+ │         │    │              └── (flavors.is_public = true) OR (any_not_null IS NOT NULL) [type=bool, outer=(12,23)]
+ │         │    └── placeholder: $3 [type=int]
+ │         └── placeholder: $4 [type=int]
+ ├── sort
+ │    ├── columns: flavor_extra_specs.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs.flavor_id:28(int!null) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+ │    ├── key: (25)
+ │    ├── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
+ │    ├── ordering: +28
+ │    └── scan flavor_extra_specs
+ │         ├── columns: flavor_extra_specs.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs.flavor_id:28(int!null) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+ │         ├── key: (25)
+ │         └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
+ └── merge-on
+      ├── left ordering: +1
+      ├── right ordering: +28
       └── filters [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
            └── flavor_extra_specs.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ])]
 

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -2378,10 +2378,11 @@ limit
  │         │    │    ├── inner-join
  │         │    │    │    ├── columns: s_suppkey:1(int!null) s_name:2(string) s_nationkey:4(int!null) lineitem.l_orderkey:8(int!null) lineitem.l_suppkey:10(int!null) lineitem.l_commitdate:19(date!null) lineitem.l_receiptdate:20(date!null)
  │         │    │    │    ├── fd: (1)-->(2,4), (1)==(10), (10)==(1)
- │         │    │    │    ├── semi-join
+ │         │    │    │    ├── semi-join (merge)
  │         │    │    │    │    ├── columns: lineitem.l_orderkey:8(int!null) lineitem.l_suppkey:10(int!null) lineitem.l_commitdate:19(date!null) lineitem.l_receiptdate:20(date!null)
  │         │    │    │    │    ├── anti-join (merge)
  │         │    │    │    │    │    ├── columns: lineitem.l_orderkey:8(int!null) lineitem.l_suppkey:10(int!null) lineitem.l_commitdate:19(date!null) lineitem.l_receiptdate:20(date!null)
+ │         │    │    │    │    │    ├── ordering: +8
  │         │    │    │    │    │    ├── select
  │         │    │    │    │    │    │    ├── columns: lineitem.l_orderkey:8(int!null) lineitem.l_suppkey:10(int!null) lineitem.l_commitdate:19(date!null) lineitem.l_receiptdate:20(date!null)
  │         │    │    │    │    │    │    ├── ordering: +8
@@ -2411,10 +2412,14 @@ limit
  │         │    │    │    │    ├── scan lineitem
  │         │    │    │    │    │    ├── columns: lineitem.l_orderkey:37(int!null) lineitem.l_partkey:38(int!null) lineitem.l_suppkey:39(int!null) lineitem.l_linenumber:40(int!null) lineitem.l_quantity:41(float) lineitem.l_extendedprice:42(float) lineitem.l_discount:43(float) lineitem.l_tax:44(float) lineitem.l_returnflag:45(string) lineitem.l_linestatus:46(string) lineitem.l_shipdate:47(date) lineitem.l_commitdate:48(date) lineitem.l_receiptdate:49(date) lineitem.l_shipinstruct:50(string) lineitem.l_shipmode:51(string) lineitem.l_comment:52(string)
  │         │    │    │    │    │    ├── key: (37,40)
- │         │    │    │    │    │    └── fd: (37,40)-->(38,39,41-52)
- │         │    │    │    │    └── filters [type=bool, outer=(8,10,37,39), constraints=(/8: (/NULL - ]; /10: (/NULL - ]; /37: (/NULL - ]; /39: (/NULL - ]), fd=(8)==(37), (37)==(8)]
- │         │    │    │    │         ├── lineitem.l_orderkey = lineitem.l_orderkey [type=bool, outer=(8,37), constraints=(/8: (/NULL - ]; /37: (/NULL - ])]
- │         │    │    │    │         └── lineitem.l_suppkey != lineitem.l_suppkey [type=bool, outer=(10,39), constraints=(/10: (/NULL - ]; /39: (/NULL - ])]
+ │         │    │    │    │    │    ├── fd: (37,40)-->(38,39,41-52)
+ │         │    │    │    │    │    └── ordering: +37
+ │         │    │    │    │    └── merge-on
+ │         │    │    │    │         ├── left ordering: +8
+ │         │    │    │    │         ├── right ordering: +37
+ │         │    │    │    │         └── filters [type=bool, outer=(8,10,37,39), constraints=(/8: (/NULL - ]; /10: (/NULL - ]; /37: (/NULL - ]; /39: (/NULL - ]), fd=(8)==(37), (37)==(8)]
+ │         │    │    │    │              ├── lineitem.l_orderkey = lineitem.l_orderkey [type=bool, outer=(8,37), constraints=(/8: (/NULL - ]; /37: (/NULL - ])]
+ │         │    │    │    │              └── lineitem.l_suppkey != lineitem.l_suppkey [type=bool, outer=(10,39), constraints=(/10: (/NULL - ]; /39: (/NULL - ])]
  │         │    │    │    ├── scan supplier
  │         │    │    │    │    ├── columns: s_suppkey:1(int!null) s_name:2(string) s_nationkey:4(int!null)
  │         │    │    │    │    ├── key: (1)

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -416,3 +416,223 @@ memo (optimized)
       └── ""
            ├── best: (scan a,cols=(2))
            └── cost: 1050.00
+
+# --------------------------------------------------
+# Merge Join
+# --------------------------------------------------
+
+exec-ddl
+CREATE TABLE abc (a INT, b INT, c INT, PRIMARY KEY (a, b, c))
+----
+TABLE abc
+ ├── a int not null
+ ├── b int not null
+ ├── c int not null
+ └── INDEX primary
+      ├── a int not null
+      ├── b int not null
+      └── c int not null
+
+exec-ddl
+CREATE TABLE xyz (x INT, y INT, z INT, PRIMARY KEY (x, y, z))
+----
+TABLE xyz
+ ├── x int not null
+ ├── y int not null
+ ├── z int not null
+ └── INDEX primary
+      ├── x int not null
+      ├── y int not null
+      └── z int not null
+
+opt
+SELECT * FROM abc JOIN xyz ON a=x ORDER BY a
+----
+inner-join (merge)
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
+ ├── ordering: +(1|4)
+ ├── scan abc
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    └── ordering: +1
+ ├── scan xyz
+ │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    └── ordering: +4
+ └── merge-on
+      ├── left ordering: +1
+      ├── right ordering: +4
+      └── filters [type=bool]
+           └── abc.a = xyz.x [type=bool]
+
+opt
+SELECT * FROM abc JOIN xyz ON a=x ORDER BY x
+----
+inner-join (merge)
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
+ ├── ordering: +(1|4)
+ ├── scan abc
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    └── ordering: +1
+ ├── scan xyz
+ │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    └── ordering: +4
+ └── merge-on
+      ├── left ordering: +1
+      ├── right ordering: +4
+      └── filters [type=bool]
+           └── abc.a = xyz.x [type=bool]
+
+# A left join guarantees an ordering on the left side.
+opt
+SELECT * FROM abc LEFT JOIN xyz ON a=x ORDER BY a
+----
+left-join (merge)
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int) y:5(int) z:6(int)
+ ├── ordering: +1
+ ├── scan abc
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    └── ordering: +1
+ ├── scan xyz
+ │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    └── ordering: +4
+ └── merge-on
+      ├── left ordering: +1
+      ├── right ordering: +4
+      └── filters [type=bool]
+           └── abc.a = xyz.x [type=bool]
+
+# A left join doesn't guarantee an ordering on x (some rows will have NULLs).
+opt
+SELECT * FROM abc LEFT JOIN xyz ON a=x ORDER BY x
+----
+sort
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int) y:5(int) z:6(int)
+ ├── ordering: +4
+ └── left-join (merge)
+      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int) y:5(int) z:6(int)
+      ├── scan abc
+      │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    └── ordering: +1
+      ├── scan xyz
+      │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      │    └── ordering: +4
+      └── merge-on
+           ├── left ordering: +1
+           ├── right ordering: +4
+           └── filters [type=bool]
+                └── abc.a = xyz.x [type=bool]
+
+# A right join doesn't guarantee an ordering on a (some rows will have NULLs).
+opt
+SELECT * FROM abc RIGHT JOIN xyz ON a=x ORDER BY a
+----
+sort
+ ├── columns: a:1(int) b:2(int) c:3(int) x:4(int!null) y:5(int!null) z:6(int!null)
+ ├── ordering: +1
+ └── right-join (merge)
+      ├── columns: a:1(int) b:2(int) c:3(int) x:4(int!null) y:5(int!null) z:6(int!null)
+      ├── scan abc
+      │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    └── ordering: +1
+      ├── scan xyz
+      │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      │    └── ordering: +4
+      └── merge-on
+           ├── left ordering: +1
+           ├── right ordering: +4
+           └── filters [type=bool]
+                └── abc.a = xyz.x [type=bool]
+
+opt
+SELECT * FROM abc RIGHT JOIN xyz ON a=x ORDER BY x
+----
+right-join (merge)
+ ├── columns: a:1(int) b:2(int) c:3(int) x:4(int!null) y:5(int!null) z:6(int!null)
+ ├── ordering: +4
+ ├── scan abc
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    └── ordering: +1
+ ├── scan xyz
+ │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    └── ordering: +4
+ └── merge-on
+      ├── left ordering: +1
+      ├── right ordering: +4
+      └── filters [type=bool]
+           └── abc.a = xyz.x [type=bool]
+
+opt
+SELECT * FROM abc FULL OUTER JOIN xyz ON a=x ORDER BY a
+----
+sort
+ ├── columns: a:1(int) b:2(int) c:3(int) x:4(int) y:5(int) z:6(int)
+ ├── ordering: +1
+ └── full-join (merge)
+      ├── columns: a:1(int) b:2(int) c:3(int) x:4(int) y:5(int) z:6(int)
+      ├── scan abc
+      │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    └── ordering: +1
+      ├── scan xyz
+      │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+      │    └── ordering: +4
+      └── merge-on
+           ├── left ordering: +1
+           ├── right ordering: +4
+           └── filters [type=bool]
+                └── abc.a = xyz.x [type=bool]
+
+opt
+SELECT * FROM abc JOIN xyz ON a=x AND b=y ORDER BY a
+----
+inner-join (merge)
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
+ ├── ordering: +(1|4)
+ ├── scan abc
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    └── ordering: +1,+2
+ ├── scan xyz
+ │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    └── ordering: +4,+5
+ └── merge-on
+      ├── left ordering: +1,+2
+      ├── right ordering: +4,+5
+      └── filters [type=bool]
+           ├── abc.a = xyz.x [type=bool]
+           └── abc.b = xyz.y [type=bool]
+
+opt
+SELECT * FROM abc JOIN xyz ON a=x AND b=y ORDER BY a, b
+----
+inner-join (merge)
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
+ ├── ordering: +(1|4),+(2|5)
+ ├── scan abc
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    └── ordering: +1,+2
+ ├── scan xyz
+ │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    └── ordering: +4,+5
+ └── merge-on
+      ├── left ordering: +1,+2
+      ├── right ordering: +4,+5
+      └── filters [type=bool]
+           ├── abc.a = xyz.x [type=bool]
+           └── abc.b = xyz.y [type=bool]
+
+opt
+SELECT * FROM abc JOIN xyz ON a=x AND b=y ORDER BY a, y
+----
+inner-join (merge)
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
+ ├── ordering: +(1|4),+(2|5)
+ ├── scan abc
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    └── ordering: +1,+2
+ ├── scan xyz
+ │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    └── ordering: +4,+5
+ └── merge-on
+      ├── left ordering: +1,+2
+      ├── right ordering: +4,+5
+      └── filters [type=bool]
+           ├── abc.a = xyz.x [type=bool]
+           └── abc.b = xyz.y [type=bool]

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -737,6 +737,72 @@ inner-join (merge)
            ├── stu.u = xyz.x [type=bool, outer=(3,4), constraints=(/3: (/NULL - ]; /4: (/NULL - ])]
            └── stu.t = xyz.z [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
 
+# Verify multiple merge-joins can be chained.
+opt
+SELECT * FROM abc JOIN xyz ON a=x AND b=y JOIN stu ON a=s
+----
+inner-join (merge)
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int) s:9(int!null) t:10(int!null) u:11(int!null)
+ ├── fd: (1)==(5,9), (5)==(1,9), (2)==(6), (6)==(2), (9)==(1,5)
+ ├── inner-join (merge)
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
+ │    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
+ │    ├── ordering: +(1|5)
+ │    ├── scan abc@ab
+ │    │    ├── columns: a:1(int) b:2(int) c:3(int)
+ │    │    └── ordering: +1,+2
+ │    ├── scan xyz@xy
+ │    │    ├── columns: x:5(int) y:6(int) z:7(int)
+ │    │    └── ordering: +5,+6
+ │    └── merge-on
+ │         ├── left ordering: +1,+2
+ │         ├── right ordering: +5,+6
+ │         └── filters [type=bool, outer=(1,2,5,6), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /5: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(5), (5)==(1), (2)==(6), (6)==(2)]
+ │              ├── abc.a = xyz.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+ │              └── abc.b = xyz.y [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
+ ├── scan stu
+ │    ├── columns: s:9(int!null) t:10(int!null) u:11(int!null)
+ │    ├── key: (9-11)
+ │    └── ordering: +9
+ └── merge-on
+      ├── left ordering: +1
+      ├── right ordering: +9
+      └── filters [type=bool, outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+           └── abc.a = stu.s [type=bool, outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ])]
+
+opt
+SELECT * FROM abc JOIN xyz ON a=x AND b=y JOIN stu ON a=u AND y=t
+----
+inner-join (merge)
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int) s:9(int!null) t:10(int!null) u:11(int!null)
+ ├── fd: (1)==(5,11), (5)==(1,11), (2)==(6,10), (6)==(2,10), (11)==(1,5), (10)==(2,6)
+ ├── scan stu@uts
+ │    ├── columns: s:9(int!null) t:10(int!null) u:11(int!null)
+ │    ├── key: (9-11)
+ │    └── ordering: +11,+10
+ ├── inner-join (merge)
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
+ │    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
+ │    ├── ordering: +(1|5),+(2|6)
+ │    ├── scan abc@ab
+ │    │    ├── columns: a:1(int) b:2(int) c:3(int)
+ │    │    └── ordering: +1,+2
+ │    ├── scan xyz@xy
+ │    │    ├── columns: x:5(int) y:6(int) z:7(int)
+ │    │    └── ordering: +5,+6
+ │    └── merge-on
+ │         ├── left ordering: +1,+2
+ │         ├── right ordering: +5,+6
+ │         └── filters [type=bool, outer=(1,2,5,6), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /5: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(5), (5)==(1), (2)==(6), (6)==(2)]
+ │              ├── abc.a = xyz.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+ │              └── abc.b = xyz.y [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
+ └── merge-on
+      ├── left ordering: +11,+10
+      ├── right ordering: +1,+6
+      └── filters [type=bool, outer=(1,6,10,11), constraints=(/1: (/NULL - ]; /6: (/NULL - ]; /10: (/NULL - ]; /11: (/NULL - ]), fd=(1)==(11), (11)==(1), (6)==(10), (10)==(6)]
+           ├── abc.a = stu.u [type=bool, outer=(1,11), constraints=(/1: (/NULL - ]; /11: (/NULL - ])]
+           └── xyz.y = stu.t [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ])]
+
 # --------------------------------------------------
 # GenerateLookupJoin
 # --------------------------------------------------

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -259,6 +259,7 @@ func (ef *execFactory) ConstructMergeJoin(
 	left, right exec.Node,
 	onCond tree.TypedExpr,
 	leftOrdering, rightOrdering sqlbase.ColumnOrdering,
+	reqOrdering sqlbase.ColumnOrdering,
 ) (exec.Node, error) {
 	p := ef.planner
 	leftSrc := asDataSource(left)
@@ -298,6 +299,11 @@ func (ef *execFactory) ConstructMergeJoin(
 		node.mergeJoinOrdering[i].ColIdx = i
 		node.mergeJoinOrdering[i].Direction = leftOrdering[i].Direction
 	}
+
+	// Set up node.props, which tells the distsql planner to maintain the
+	// resulting ordering (if needed).
+	node.props.ordering = reqOrdering
+
 	return node, nil
 }
 


### PR DESCRIPTION
A MergeJoin can provide the ordering on the equality columns. This
helps cases where we can "chain" multiple merge joins.

Release note: None