### PR TITLE
distsql: fix up version history

### DIFF
--- a/pkg/sql/distsqlrun/version_history.txt
+++ b/pkg/sql/distsqlrun/version_history.txt
@@ -62,10 +62,10 @@
     - Enhancements to lookup joins. They now support joining against secondary
       indexes as well as left outer joins. Left join support required two
       additional fields on JoinReaderSpec: index_filter_expr and type.
-- Version: 15 (MinAcceptedVersion: 6)
     - Add support for processing queries with tuples in DistSQL. Old versions
-      would not recognize the new tuple field in the proto.
-- Version: 16 (MinAcceptedVersion: 6)
+      would not recognize the new tuple field in the proto. (This change was
+      introduced without bumping the version.)
+- Version: 15 (MinAcceptedVersion: 6)
     - Add SRF support via a new ProjectSet processor. The new processor spec
       would not be recognized by old versions.
 - Version: 17 (MinAcceptedVersion: 6)


### PR DESCRIPTION
The distsql version history was slightly inaccurate since there was a
commit which updated the history but not the actual version number. I
fixed it up to avoid future confusion. Note there is not actually a
version 16; we jumped from 15 to 17.

Release note: None