### PR TITLE
sql: don't capture context in CommitTrigger

### DIFF
--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -49,7 +49,7 @@ type Txn struct {
 	// They should be set before operating on the transaction.
 
 	// commitTriggers are run upon successful commit.
-	commitTriggers []func()
+	commitTriggers []func(ctx context.Context)
 	// systemConfigTrigger is set to true when modifying keys from the SystemConfig
 	// span. This sets the SystemConfigTrigger on EndTransactionRequest.
 	systemConfigTrigger bool
@@ -573,7 +573,7 @@ func (txn *Txn) commit(ctx context.Context) error {
 	pErr := txn.sendEndTxnReq(ctx, true /* commit */, txn.deadline())
 	if pErr == nil {
 		for _, t := range txn.commitTriggers {
-			t()
+			t(ctx)
 		}
 	}
 	return pErr.GoError()
@@ -710,7 +710,7 @@ func (txn *Txn) rollback(ctx context.Context) *roachpb.Error {
 
 // AddCommitTrigger adds a closure to be executed on successful commit
 // of the transaction.
-func (txn *Txn) AddCommitTrigger(trigger func()) {
+func (txn *Txn) AddCommitTrigger(trigger func(ctx context.Context)) {
 	txn.commitTriggers = append(txn.commitTriggers, trigger)
 }
 

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -122,7 +122,7 @@ func (ev EventLogger) InsertEventRecord(
 	info interface{},
 ) error {
 	// Record event record insertion in local log output.
-	txn.AddCommitTrigger(func() {
+	txn.AddCommitTrigger(func(ctx context.Context) {
 		log.Infof(
 			ctx, "Event: %q, target: %d, info: %+v",
 			eventType,


### PR DESCRIPTION
Previously, callers to CommitTrigger would pass in the context they had
at call-time to be used at commit-trigger time for various purposes,
including logging to traces. This could lead to use-after-free errors
on those traces.

Now, instead of capturing the context, the commiter passes its context
into the commit triggers at commit time.

Release note: None