### PR TITLE
backport-2.0: storage: prevent unbounded raft log growth without quorum

### DIFF
--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -786,7 +786,8 @@ func TestGRPCKeepaliveFailureFailsInflightRPCs(t *testing.T) {
 
 			stopper := stop.NewStopper()
 			defer stopper.Stop(context.TODO())
-			ctx := stopper.WithCancelOnQuiesce(context.TODO())
+			ctx, cancel := stopper.WithCancelOnQuiesce(context.TODO())
+			defer cancel()
 
 			// Construct server with server-side keepalive.
 			clock := hlc.NewClock(timeutil.Unix(0, 20).UnixNano, time.Nanosecond)

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -786,7 +786,7 @@ func TestGRPCKeepaliveFailureFailsInflightRPCs(t *testing.T) {
 
 			stopper := stop.NewStopper()
 			defer stopper.Stop(context.TODO())
-			ctx := stopper.WithCancel(context.TODO())
+			ctx := stopper.WithCancelOnQuiesce(context.TODO())
 
 			// Construct server with server-side keepalive.
 			clock := hlc.NewClock(timeutil.Unix(0, 20).UnixNano, time.Nanosecond)

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1540,7 +1540,7 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 
 	// Make a context tied to the Stopper. The test works without, but this
 	// is cleaner since we won't properly terminate the transaction below.
-	ctx = tc.Server(0).Stopper().WithCancel(ctx)
+	ctx = tc.Server(0).Stopper().WithCancelOnQuiesce(ctx)
 
 	// This transaction will try to write "under" a served read.
 	txnOld := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1540,7 +1540,8 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 
 	// Make a context tied to the Stopper. The test works without, but this
 	// is cleaner since we won't properly terminate the transaction below.
-	ctx = tc.Server(0).Stopper().WithCancelOnQuiesce(ctx)
+	ctx, cancel := tc.Server(0).Stopper().WithCancelOnQuiesce(ctx)
+	defer cancel()
 
 	// This transaction will try to write "under" a served read.
 	txnOld := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -411,7 +411,8 @@ func (nl *NodeLiveness) StartHeartbeat(
 	stopper.RunWorker(ctx, func(context.Context) {
 		ambient := nl.ambientCtx
 		ambient.AddLogTag("hb", nil)
-		ctx := stopper.WithCancelOnStop(context.Background())
+		ctx, cancel := stopper.WithCancelOnStop(context.Background())
+		defer cancel()
 		ctx, sp := ambient.AnnotateCtxWithSpan(ctx, "liveness heartbeat loop")
 		defer sp.Finish()
 

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -411,18 +411,20 @@ func (nl *NodeLiveness) StartHeartbeat(
 	stopper.RunWorker(ctx, func(context.Context) {
 		ambient := nl.ambientCtx
 		ambient.AddLogTag("hb", nil)
+		ctx := stopper.WithCancelOnStop(context.Background())
+		ctx, sp := ambient.AnnotateCtxWithSpan(ctx, "liveness heartbeat loop")
+		defer sp.Finish()
+
+		incrementEpoch := true
 		ticker := time.NewTicker(nl.heartbeatInterval)
 		defer ticker.Stop()
-		incrementEpoch := true
 		for {
 			if !nl.pauseHeartbeat.Load().(bool) {
-				func() {
+				func(ctx context.Context) {
 					// Give the context a timeout approximately as long as the time we
 					// have left before our liveness entry expires.
-					ctx, cancel := context.WithTimeout(context.Background(), nl.livenessThreshold-nl.heartbeatInterval)
-					ctx, sp := ambient.AnnotateCtxWithSpan(ctx, "liveness heartbeat loop")
+					ctx, cancel = context.WithTimeout(ctx, nl.livenessThreshold-nl.heartbeatInterval)
 					defer cancel()
-					defer sp.Finish()
 
 					// Retry heartbeat in the event the conditional put fails.
 					for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
@@ -441,7 +443,7 @@ func (nl *NodeLiveness) StartHeartbeat(
 						}
 						break
 					}
-				}()
+				}(ctx)
 			}
 			select {
 			case <-ticker.C:

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -392,7 +392,12 @@ type Replica struct {
 		// map must only be referenced while Replica.mu is held, except if the
 		// element is removed from the map first. The notable exception is the
 		// contained RaftCommand, which we treat as immutable.
-		proposals         map[storagebase.CmdIDKey]*ProposalData
+		proposals map[storagebase.CmdIDKey]*ProposalData
+		// remoteProposals is maintained by Raft leaders and stores in-flight
+		// commands that were forwarded to the leader during its current term.
+		// The set allows leaders to detect duplicate forwarded commands and
+		// avoid re-proposing the same forwarded command multiple times.
+		remoteProposals   map[storagebase.CmdIDKey]struct{}
 		internalRaftGroup *raft.RawNode
 		// The ID of the replica within the Raft group. May be 0 if the replica has
 		// been created from a preemptive snapshot (i.e. before being added to the
@@ -852,6 +857,7 @@ func (r *Replica) cancelPendingCommandsLocked() {
 		p.finishRaftApplication(resp)
 	}
 	r.mu.proposals = map[storagebase.CmdIDKey]*ProposalData{}
+	r.mu.remoteProposals = nil
 }
 
 // setTombstoneKey writes a tombstone to disk to ensure that replica IDs never
@@ -3333,6 +3339,39 @@ func (r *Replica) stepRaftGroup(req *RaftMessageRequest) error {
 		// other replica is not quiesced, so we don't need to wake the leader.
 		r.unquiesceLocked()
 		r.refreshLastUpdateTimeForReplicaLocked(req.FromReplica.ReplicaID)
+		if req.Message.Type == raftpb.MsgProp {
+			// A proposal was forwarded to this replica.
+			if r.mu.replicaID == r.mu.leaderID {
+				// This replica is the leader. Record that the proposal
+				// was seen and drop the proposal if it was already seen.
+				// This prevents duplicate forwarded proposals from each
+				// being appended to a leader's raft log.
+				allSeen := true
+				for _, e := range req.Message.Entries {
+					switch e.Type {
+					case raftpb.EntryNormal:
+						cmdID, _ := DecodeRaftCommand(e.Data)
+						if r.mu.remoteProposals == nil {
+							r.mu.remoteProposals = map[storagebase.CmdIDKey]struct{}{}
+						}
+						if _, ok := r.mu.remoteProposals[cmdID]; !ok {
+							r.mu.remoteProposals[cmdID] = struct{}{}
+							allSeen = false
+						}
+					case raftpb.EntryConfChange:
+						// We could peek into the EntryConfChange to find the
+						// command ID, but we don't expect follower-initiated
+						// conf changes.
+						allSeen = false
+					default:
+						log.Fatalf(context.TODO(), "unexpected Raft entry: %v", e)
+					}
+				}
+				if allSeen {
+					return false /* unquiesceAndWakeLeader */, nil
+				}
+			}
+		}
 		err := raftGroup.Step(req.Message)
 		if err == raft.ErrProposalDropped {
 			// A proposal was forwarded to this replica but we couldn't propose it.
@@ -3441,6 +3480,9 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		if !r.store.TestingKnobs().DisableRefreshReasonNewLeader {
 			refreshReason = reasonNewLeader
 		}
+		// Clear the remote proposal set. Would have been nil already if not
+		// previously the leader.
+		r.mu.remoteProposals = nil
 		leaderID = roachpb.ReplicaID(rd.SoftState.Lead)
 	}
 
@@ -3831,17 +3873,28 @@ func (r *Replica) tick() (bool, error) {
 
 	r.mu.ticks++
 	r.mu.internalRaftGroup.Tick()
+
+	refreshAtDelta := r.store.cfg.RaftElectionTimeoutTicks
+	if knob := r.store.TestingKnobs().RefreshReasonTicksPeriod; knob > 0 {
+		refreshAtDelta = knob
+	}
 	if !r.store.TestingKnobs().DisableRefreshReasonTicks &&
-		r.mu.ticks%r.store.cfg.RaftElectionTimeoutTicks == 0 {
+		r.mu.replicaID != r.mu.leaderID &&
+		r.mu.ticks%refreshAtDelta == 0 {
 		// RaftElectionTimeoutTicks is a reasonable approximation of how long we
 		// should wait before deciding that our previous proposal didn't go
 		// through. Note that the combination of the above condition and passing
 		// RaftElectionTimeoutTicks to refreshProposalsLocked means that commands
 		// will be refreshed when they have been pending for 1 to 2 election
 		// cycles.
-		r.refreshProposalsLocked(
-			r.store.cfg.RaftElectionTimeoutTicks, reasonTicks,
-		)
+		//
+		// However, we don't refresh proposals if we are the leader because
+		// doing so would be useless. The commands tracked by a leader replica
+		// were either all proposed when the replica was a leader or were
+		// re-proposed when the replica became a leader. Either way, they are
+		// guaranteed to be in the leader's Raft log so re-proposing won't do
+		// anything.
+		r.refreshProposalsLocked(refreshAtDelta, reasonTicks)
 	}
 	return true, nil
 }
@@ -3946,6 +3999,9 @@ func (r *Replica) maybeTransferRaftLeader(
 ) {
 	l := *r.mu.state.Lease
 	if !r.isLeaseValidRLocked(l, now) {
+		return
+	}
+	if r.store.TestingKnobs().DisableLeaderFollowsLeaseholder {
 		return
 	}
 	if pr, ok := status.Progress[uint64(l.Replica.ReplicaID)]; ok && pr.Match >= status.Commit {
@@ -4608,6 +4664,9 @@ func (r *Replica) processRaftCommand(
 		proposal.ctx = nil // avoid confusion
 		delete(r.mu.proposals, idKey)
 	}
+
+	// Delete the entry for a forwarded proposal set.
+	delete(r.mu.remoteProposals, idKey)
 
 	leaseIndex, proposalRetry, forcedErr := r.checkForcedErrLocked(ctx, idKey, raftCmd, proposal, proposedLocally)
 

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -274,7 +274,8 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease) {
 		r.txnWaitQueue.Clear(true /* disable */)
 	}
 
-	if !iAmTheLeaseHolder && r.IsLeaseValid(newLease, r.store.Clock().Now()) {
+	if !iAmTheLeaseHolder && r.IsLeaseValid(newLease, r.store.Clock().Now()) &&
+		!r.store.TestingKnobs().DisableLeaderFollowsLeaseholder {
 		// If this replica is the raft leader but it is not the new lease holder,
 		// then try to transfer the raft leadership to match the lease. We like it
 		// when leases and raft leadership are collocated because that facilitates

--- a/pkg/storage/replica_sideload.go
+++ b/pkg/storage/replica_sideload.go
@@ -70,7 +70,7 @@ func (r *Replica) maybeSideloadEntriesRaftMuLocked(
 	maybeRaftCommand := func(cmdID storagebase.CmdIDKey) (storagebase.RaftCommand, bool) {
 		r.mu.Lock()
 		defer r.mu.Unlock()
-		cmd, ok := r.mu.proposals[cmdID]
+		cmd, ok := r.mu.localProposals[cmdID]
 		if ok {
 			return cmd.command, true
 		}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1909,7 +1909,7 @@ func TestLeaseConcurrent(t *testing.T) {
 					// When we complete the command, we have to remove it from the map;
 					// otherwise its context (and tracing span) may be used after the
 					// client cleaned up.
-					delete(tc.repl.mu.proposals, proposal.idKey)
+					delete(tc.repl.mu.localProposals, proposal.idKey)
 					proposal.finishRaftApplication(proposalResult{Err: roachpb.NewErrorf(origMsg)})
 					return
 				}
@@ -7250,7 +7250,7 @@ func TestReplicaTryAbandon(t *testing.T) {
 	func() {
 		tc.repl.mu.Lock()
 		defer tc.repl.mu.Unlock()
-		if len(tc.repl.mu.proposals) == 0 {
+		if len(tc.repl.mu.localProposals) == 0 {
 			t.Fatal("expected non-empty proposals map")
 		}
 	}()
@@ -7695,7 +7695,7 @@ func TestReplicaCancelRaftCommandProgress(t *testing.T) {
 			// client abandoning it.
 			if rand.Intn(2) == 0 {
 				log.Infof(context.Background(), "abandoning command %d", i)
-				delete(repl.mu.proposals, proposal.idKey)
+				delete(repl.mu.localProposals, proposal.idKey)
 			} else if err := repl.submitProposalLocked(proposal); err != nil {
 				t.Error(err)
 			} else {
@@ -7773,7 +7773,7 @@ func TestReplicaBurstPendingCommandsAndRepropose(t *testing.T) {
 		}
 
 		tc.repl.mu.Lock()
-		for _, p := range tc.repl.mu.proposals {
+		for _, p := range tc.repl.mu.localProposals {
 			if v := p.ctx.Value(magicKey{}); v != nil {
 				origIndexes = append(origIndexes, int(p.command.MaxLeaseIndex))
 			}
@@ -7805,13 +7805,13 @@ func TestReplicaBurstPendingCommandsAndRepropose(t *testing.T) {
 
 	tc.repl.mu.Lock()
 	defer tc.repl.mu.Unlock()
-	nonePending := len(tc.repl.mu.proposals) == 0
+	nonePending := len(tc.repl.mu.localProposals) == 0
 	c := int(tc.repl.mu.lastAssignedLeaseIndex) - int(tc.repl.mu.state.LeaseAppliedIndex)
 	if nonePending && c > 0 {
 		t.Errorf("no pending cmds, but have required index offset %d", c)
 	}
 	if !nonePending {
-		t.Fatalf("still pending commands: %+v", tc.repl.mu.proposals)
+		t.Fatalf("still pending commands: %+v", tc.repl.mu.localProposals)
 	}
 }
 
@@ -7900,7 +7900,7 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		}
 		// Build the map of expected reproposals at this stage.
 		m := map[storagebase.CmdIDKey]int{}
-		for id, p := range r.mu.proposals {
+		for id, p := range r.mu.localProposals {
 			m[id] = p.proposedAtTicks
 		}
 		r.mu.Unlock()

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -7835,8 +7835,14 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	electionTicks := tc.store.cfg.RaftElectionTimeoutTicks
+	// Only followers refresh pending commands during tick events. Change the
+	// replica that the range thinks is the leader so that the replica thinks
+	// it's a follower.
+	r.mu.Lock()
+	r.mu.leaderID = 2
+	r.mu.Unlock()
 
+	electionTicks := tc.store.cfg.RaftElectionTimeoutTicks
 	{
 		// The verifications of the reproposal counts below rely on r.mu.ticks
 		// starting with a value of 0 (modulo electionTicks). Move the replica into

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -733,6 +733,9 @@ type StoreTestingKnobs struct {
 	DisableScanner bool
 	// DisablePeriodicGossips disables periodic gossiping.
 	DisablePeriodicGossips bool
+	// DisableLeaderFollowsLeaseholder disables attempts to transfer raft
+	// leadership when it diverges from the range's leaseholder.
+	DisableLeaderFollowsLeaseholder bool
 	// DisableRefreshReasonTicks disables refreshing pending commands when a new
 	// leader is discovered.
 	DisableRefreshReasonNewLeader bool
@@ -742,6 +745,10 @@ type StoreTestingKnobs struct {
 	// DisableRefreshReasonTicks disables refreshing pending commands
 	// periodically.
 	DisableRefreshReasonTicks bool
+	// RefreshReasonTicksPeriod overrides the default period over which
+	// pending commands are refreshed. The period is specified as a multiple
+	// of Raft group ticks.
+	RefreshReasonTicksPeriod int
 	// DisableProcessRaft disables the process raft loop.
 	DisableProcessRaft bool
 	// DisableLastProcessedCheck disables checking on replica queue last processed times.

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -118,7 +118,8 @@ type Stopper struct {
 		numTasks  int        // number of outstanding tasks
 		tasks     TaskMap
 		closers   []Closer
-		cancels   []func()
+		qCancels  []func()
+		sCancels  []func()
 	}
 }
 
@@ -413,6 +414,9 @@ func (s *Stopper) Stop(ctx context.Context) {
 	}
 
 	s.Quiesce(ctx)
+	for _, cancel := range s.mu.sCancels {
+		cancel()
+	}
 	close(s.stopper)
 	s.stop.Wait()
 	s.mu.Lock()
@@ -459,7 +463,7 @@ func (s *Stopper) Quiesce(ctx context.Context) {
 	defer s.Recover(ctx)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for _, cancel := range s.mu.cancels {
+	for _, cancel := range s.mu.qCancels {
 		cancel()
 	}
 	if !s.mu.quiescing {
@@ -473,13 +477,23 @@ func (s *Stopper) Quiesce(ctx context.Context) {
 	}
 }
 
-// WithCancel returns a child context which is canceled when the Stopper
-// begins to quiesce.
-func (s *Stopper) WithCancel(ctx context.Context) context.Context {
+// WithCancelOnQuiesce returns a child context which is canceled when the
+// Stopper begins to quiesce.
+func (s *Stopper) WithCancelOnQuiesce(ctx context.Context) context.Context {
+	return s.withCancel(ctx, &s.mu.qCancels)
+}
+
+// WithCancelOnStop returns a child context which is canceled when the Stopper
+// begins to stop.
+func (s *Stopper) WithCancelOnStop(ctx context.Context) context.Context {
+	return s.withCancel(ctx, &s.mu.sCancels)
+}
+
+func (s *Stopper) withCancel(ctx context.Context, cancels *[]func()) context.Context {
 	var cancel func()
 	ctx, cancel = context.WithCancel(ctx)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.mu.cancels = append(s.mu.cancels, cancel)
+	*cancels = append(*cancels, cancel)
 	return ctx
 }

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -204,7 +204,13 @@ func (s *Stopper) RunWorker(ctx context.Context, f func(context.Context)) {
 func (s *Stopper) AddCloser(c Closer) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.mu.closers = append(s.mu.closers, c)
+	select {
+	case <-s.stopper:
+		// Close immediately.
+		c.Close()
+	default:
+		s.mu.closers = append(s.mu.closers, c)
+	}
 }
 
 // WithCancelOnQuiesce returns a child context which is canceled when the
@@ -214,7 +220,7 @@ func (s *Stopper) AddCloser(c Closer) {
 // Canceling this context releases resources associated with it, so code should
 // call cancel as soon as the operations running in this Context complete.
 func (s *Stopper) WithCancelOnQuiesce(ctx context.Context) (context.Context, func()) {
-	return s.withCancel(ctx, s.mu.qCancels)
+	return s.withCancel(ctx, s.mu.qCancels, s.quiescer)
 }
 
 // WithCancelOnStop returns a child context which is canceled when the
@@ -224,24 +230,31 @@ func (s *Stopper) WithCancelOnQuiesce(ctx context.Context) (context.Context, fun
 // Canceling this context releases resources associated with it, so code should
 // call cancel as soon as the operations running in this Context complete.
 func (s *Stopper) WithCancelOnStop(ctx context.Context) (context.Context, func()) {
-	return s.withCancel(ctx, s.mu.sCancels)
+	return s.withCancel(ctx, s.mu.sCancels, s.stopper)
 }
 
 func (s *Stopper) withCancel(
-	ctx context.Context, cancels map[int]func(),
+	ctx context.Context, cancels map[int]func(), cancelCh chan struct{},
 ) (context.Context, func()) {
 	var cancel func()
 	ctx, cancel = context.WithCancel(ctx)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	id := s.mu.idAlloc
-	s.mu.idAlloc++
-	cancels[id] = cancel
-	return ctx, func() {
+	select {
+	case <-cancelCh:
+		// Cancel immediately.
 		cancel()
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		delete(cancels, id)
+		return ctx, func() {}
+	default:
+		id := s.mu.idAlloc
+		s.mu.idAlloc++
+		cancels[id] = cancel
+		return ctx, func() {
+			cancel()
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			delete(cancels, id)
+		}
 	}
 }
 

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -458,10 +458,13 @@ func (s *Stopper) Stop(ctx context.Context) {
 	}
 
 	s.Quiesce(ctx)
+	s.mu.Lock()
 	for _, cancel := range s.mu.sCancels {
 		cancel()
 	}
 	close(s.stopper)
+	s.mu.Unlock()
+
 	s.stop.Wait()
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -118,8 +118,9 @@ type Stopper struct {
 		numTasks  int        // number of outstanding tasks
 		tasks     TaskMap
 		closers   []Closer
-		qCancels  []func()
-		sCancels  []func()
+		idAlloc   int
+		qCancels  map[int]func()
+		sCancels  map[int]func()
 	}
 }
 
@@ -152,6 +153,8 @@ func NewStopper(options ...Option) *Stopper {
 	}
 
 	s.mu.tasks = TaskMap{}
+	s.mu.qCancels = map[int]func(){}
+	s.mu.sCancels = map[int]func(){}
 
 	for _, opt := range options {
 		opt.apply(s)
@@ -195,10 +198,51 @@ func (s *Stopper) RunWorker(ctx context.Context, f func(context.Context)) {
 }
 
 // AddCloser adds an object to close after the stopper has been stopped.
+//
+// WARNING: memory resources acquired by this method will stay around for
+// the lifetime of the Stopper. Use with care to avoid leaking memory.
 func (s *Stopper) AddCloser(c Closer) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.mu.closers = append(s.mu.closers, c)
+}
+
+// WithCancelOnQuiesce returns a child context which is canceled when the
+// returned cancel function is called or when the Stopper begins to quiesce,
+// whichever happens first.
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete.
+func (s *Stopper) WithCancelOnQuiesce(ctx context.Context) (context.Context, func()) {
+	return s.withCancel(ctx, s.mu.qCancels)
+}
+
+// WithCancelOnStop returns a child context which is canceled when the
+// returned cancel function is called or when the Stopper begins to stop,
+// whichever happens first.
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete.
+func (s *Stopper) WithCancelOnStop(ctx context.Context) (context.Context, func()) {
+	return s.withCancel(ctx, s.mu.sCancels)
+}
+
+func (s *Stopper) withCancel(
+	ctx context.Context, cancels map[int]func(),
+) (context.Context, func()) {
+	var cancel func()
+	ctx, cancel = context.WithCancel(ctx)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := s.mu.idAlloc
+	s.mu.idAlloc++
+	cancels[id] = cancel
+	return ctx, func() {
+		cancel()
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		delete(cancels, id)
+	}
 }
 
 // RunTask adds one to the count of tasks left to quiesce in the system.
@@ -475,25 +519,4 @@ func (s *Stopper) Quiesce(ctx context.Context) {
 		// Unlock s.mu, wait for the signal, and lock s.mu.
 		s.mu.quiesce.Wait()
 	}
-}
-
-// WithCancelOnQuiesce returns a child context which is canceled when the
-// Stopper begins to quiesce.
-func (s *Stopper) WithCancelOnQuiesce(ctx context.Context) context.Context {
-	return s.withCancel(ctx, &s.mu.qCancels)
-}
-
-// WithCancelOnStop returns a child context which is canceled when the Stopper
-// begins to stop.
-func (s *Stopper) WithCancelOnStop(ctx context.Context) context.Context {
-	return s.withCancel(ctx, &s.mu.sCancels)
-}
-
-func (s *Stopper) withCancel(ctx context.Context, cancels *[]func()) context.Context {
-	var cancel func()
-	ctx, cancel = context.WithCancel(ctx)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	*cancels = append(*cancels, cancel)
-	return ctx
 }

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -17,6 +17,7 @@ package stop_test
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -253,6 +254,35 @@ func TestStopperClosers(t *testing.T) {
 	}
 }
 
+func TestStopperCloserConcurrent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	const trials = 10
+	for i := 0; i < trials; i++ {
+		s := stop.NewStopper()
+		var tc1 testCloser
+
+		// Add Closer and Stop concurrently. There should be
+		// no circumstance where the Closer is not called.
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			runtime.Gosched()
+			s.AddCloser(&tc1)
+		}()
+		go func() {
+			defer wg.Done()
+			runtime.Gosched()
+			s.Stop(context.Background())
+		}()
+		wg.Wait()
+
+		if !tc1 {
+			t.Errorf("expected true; got %t", tc1)
+		}
+	}
+}
+
 func TestStopperNumTasks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := stop.NewStopper()
@@ -394,6 +424,44 @@ func TestStopperWithCancel(t *testing.T) {
 	s.Stop(ctx)
 	if err := ctx2.Err(); err != context.Canceled {
 		t.Fatalf("should be canceled: %v", err)
+	}
+}
+
+func TestStopperWithCancelConcurrent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	const trials = 10
+	for i := 0; i < trials; i++ {
+		s := stop.NewStopper()
+		ctx := context.Background()
+		var ctx1, ctx2 context.Context
+
+		// Tie two contexts to the Stopper and Stop concurrently. There should
+		// be no circumstance where either Context is not canceled.
+		var wg sync.WaitGroup
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			runtime.Gosched()
+			ctx1, _ = s.WithCancelOnQuiesce(ctx)
+		}()
+		go func() {
+			defer wg.Done()
+			runtime.Gosched()
+			ctx2, _ = s.WithCancelOnStop(ctx)
+		}()
+		go func() {
+			defer wg.Done()
+			runtime.Gosched()
+			s.Stop(ctx)
+		}()
+		wg.Wait()
+
+		if err := ctx1.Err(); err != context.Canceled {
+			t.Errorf("should be canceled: %v", err)
+		}
+		if err := ctx2.Err(); err != context.Canceled {
+			t.Errorf("should be canceled: %v", err)
+		}
 	}
 }
 

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -350,8 +350,39 @@ func TestStopperWithCancel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := stop.NewStopper()
 	ctx := context.Background()
-	ctx1 := s.WithCancelOnQuiesce(ctx)
-	ctx2 := s.WithCancelOnStop(ctx)
+	ctx1, _ := s.WithCancelOnQuiesce(ctx)
+	ctx2, _ := s.WithCancelOnStop(ctx)
+	ctx3, cancel3 := s.WithCancelOnQuiesce(ctx)
+	ctx4, cancel4 := s.WithCancelOnStop(ctx)
+
+	if err := ctx1.Err(); err != nil {
+		t.Fatalf("should not be canceled: %v", err)
+	}
+	if err := ctx2.Err(); err != nil {
+		t.Fatalf("should not be canceled: %v", err)
+	}
+	if err := ctx3.Err(); err != nil {
+		t.Fatalf("should not be canceled: %v", err)
+	}
+	if err := ctx4.Err(); err != nil {
+		t.Fatalf("should not be canceled: %v", err)
+	}
+
+	cancel3()
+	cancel4()
+	if err := ctx1.Err(); err != nil {
+		t.Fatalf("should not be canceled: %v", err)
+	}
+	if err := ctx2.Err(); err != nil {
+		t.Fatalf("should not be canceled: %v", err)
+	}
+	if err := ctx3.Err(); err != context.Canceled {
+		t.Fatalf("should be canceled: %v", err)
+	}
+	if err := ctx4.Err(); err != context.Canceled {
+		t.Fatalf("should be canceled: %v", err)
+	}
+
 	s.Quiesce(ctx)
 	if err := ctx1.Err(); err != context.Canceled {
 		t.Fatalf("should be canceled: %v", err)
@@ -359,10 +390,8 @@ func TestStopperWithCancel(t *testing.T) {
 	if err := ctx2.Err(); err != nil {
 		t.Fatalf("should not be canceled: %v", err)
 	}
+
 	s.Stop(ctx)
-	if err := ctx1.Err(); err != context.Canceled {
-		t.Fatalf("should be canceled: %v", err)
-	}
 	if err := ctx2.Err(); err != context.Canceled {
 		t.Fatalf("should be canceled: %v", err)
 	}

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -349,10 +349,22 @@ func TestStopperRunTaskPanic(t *testing.T) {
 func TestStopperWithCancel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := stop.NewStopper()
-	ctx := s.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx1 := s.WithCancelOnQuiesce(ctx)
+	ctx2 := s.WithCancelOnStop(ctx)
+	s.Quiesce(ctx)
+	if err := ctx1.Err(); err != context.Canceled {
+		t.Fatalf("should be canceled: %v", err)
+	}
+	if err := ctx2.Err(); err != nil {
+		t.Fatalf("should not be canceled: %v", err)
+	}
 	s.Stop(ctx)
-	if err := ctx.Err(); err != context.Canceled {
-		t.Fatal(err)
+	if err := ctx1.Err(); err != context.Canceled {
+		t.Fatalf("should be canceled: %v", err)
+	}
+	if err := ctx2.Err(); err != context.Canceled {
+		t.Fatalf("should be canceled: %v", err)
 	}
 }
 


### PR DESCRIPTION
Backport 2/2 commits from #27774.

/cc @cockroachdb/release

---

Fixes #27772.

This change adds safeguards to prevent cases where a raft log
would grow without bound during loss of quorum scenarios. It
also adds a new test that demonstrates that the raft log does
not grow without bound in these cases.

There are two cases that need to be handled to prevent the
unbounded raft log growth observed in #27772.
1. When the leader proposes a command and cannot establish a
   quorum. In this case, we know the leader has the entry in
   its log, so there's no need to refresh it with `reasonTicks`.
   To avoid this, we no longer use `refreshTicks` as a leader.
2. When a follower proposes a command that is forwarded to the
   leader who cannot establish a quorum. In this case, the
   follower can't be sure (currently) that the leader got the
   proposal, so it needs to refresh using `reasonTicks`. However,
   the leader now detects duplicate forwarded proposals and
   avoids appending redundant entries to its log. It does so
   by maintaining a set of in-flight forwarded proposals that
   it has received during its term as leader. This set is reset
   after every leadership change.

Both of these cases are tested against in the new
TestLogGrowthWhenRefreshingPendingCommands. Without both of
the safeguards introduced in this commit, the test fails.

Release note (bug fix): Prevent loss of quorum situations from
allowing unbounded growth of a Range's Raft log.
