### PR TITLE
libroach: report "first seen" timestamp for store key.

### DIFF
--- a/c-deps/libroach/ccl/db.cc
+++ b/c-deps/libroach/ccl/db.cc
@@ -33,31 +33,24 @@ namespace cockroach {
 
 class CCLEnvStatsHandler : public EnvStatsHandler {
  public:
-  explicit CCLEnvStatsHandler(KeyManager* store_key_manager, KeyManager* data_key_manager)
-      : store_key_manager_(store_key_manager), data_key_manager_(data_key_manager) {}
+  explicit CCLEnvStatsHandler(DataKeyManager* data_key_manager)
+      : data_key_manager_(data_key_manager) {}
   virtual ~CCLEnvStatsHandler() {}
 
   virtual rocksdb::Status GetEncryptionStats(std::string* serialized_stats) override {
-    enginepbccl::EncryptionStatus enc_status;
-
-    bool has_stats = false;
-    if (store_key_manager_ != nullptr) {
-      has_stats = true;
-      // CurrentKeyInfo returns a unique_ptr containing a copy. Transfer ownership from the
-      // unique_ptr to the proto. set_allocated_active_store deletes the existing field, if any.
-      enc_status.set_allocated_active_store_key(store_key_manager_->CurrentKeyInfo().release());
-    }
-
-    if (data_key_manager_ != nullptr) {
-      has_stats = true;
-      // CurrentKeyInfo returns a unique_ptr containing a copy. Transfer ownership from the
-      // unique_ptr to the proto. set_allocated_active_store deletes the existing field, if any.
-      enc_status.set_allocated_active_data_key(data_key_manager_->CurrentKeyInfo().release());
-    }
-
-    if (!has_stats) {
+    if (data_key_manager_ == nullptr) {
       return rocksdb::Status::OK();
     }
+
+    enginepbccl::EncryptionStatus enc_status;
+
+    // GetActiveStoreKeyInfo returns a unique_ptr containing a copy. Transfer ownership from the
+    // unique_ptr to the proto. set_allocated_active_store deletes the existing field, if any.
+    enc_status.set_allocated_active_store_key(data_key_manager_->GetActiveStoreKeyInfo().release());
+
+    // CurrentKeyInfo returns a unique_ptr containing a copy. Transfer ownership from the
+    // unique_ptr to the proto. set_allocated_active_store deletes the existing field, if any.
+    enc_status.set_allocated_active_data_key(data_key_manager_->CurrentKeyInfo().release());
 
     if (!enc_status.SerializeToString(serialized_stats)) {
       return rocksdb::Status::InvalidArgument("failed to serialize encryption status");
@@ -103,9 +96,8 @@ class CCLEnvStatsHandler : public EnvStatsHandler {
   }
 
  private:
-  // KeyManagers are needed to get key information but are not owned by the StatsHandler.
-  KeyManager* store_key_manager_;
-  KeyManager* data_key_manager_;
+  // The DataKeyManager is needed to get key information but is not owned by the StatsHandler.
+  DataKeyManager* data_key_manager_;
 };
 
 // DBOpenHookCCL parses the extra_options field of DBOptions and initializes
@@ -201,14 +193,14 @@ rocksdb::Status DBOpenHookCCL(std::shared_ptr<rocksdb::Logger> info_log, const s
   if (!db_opts.read_only) {
     // Generate a new data key if needed by giving the active store key info to the data key
     // manager.
-    status = data_key_manager->SetActiveStoreKey(std::move(store_key));
+    status = data_key_manager->SetActiveStoreKeyInfo(std::move(store_key));
     if (!status.ok()) {
       return status;
     }
   }
 
   // Everything's ok: initialize a stats handler.
-  env_mgr->SetStatsHandler(new CCLEnvStatsHandler(store_key_manager, data_key_manager));
+  env_mgr->SetStatsHandler(new CCLEnvStatsHandler(data_key_manager));
 
   return rocksdb::Status::OK();
 }

--- a/c-deps/libroach/ccl/key_manager.cc
+++ b/c-deps/libroach/ccl/key_manager.cc
@@ -329,12 +329,27 @@ std::unique_ptr<enginepbccl::SecretKey> DataKeyManager::GetKey(const std::string
   return std::unique_ptr<enginepbccl::SecretKey>(new enginepbccl::SecretKey(key->second));
 }
 
+std::unique_ptr<enginepbccl::KeyInfo> DataKeyManager::GetActiveStoreKeyInfo() {
+  std::unique_lock<std::mutex> l(mu_);
+
+  assert(registry_ != nullptr);
+  if (registry_->active_store_key_id() == "") {
+    return nullptr;
+  }
+
+  auto iter = registry_->store_keys().find(registry_->active_store_key_id());
+
+  // Any modification of the registry should have called Validate.
+  assert(iter != registry_->store_keys().cend());
+  return std::unique_ptr<enginepbccl::KeyInfo>(new enginepbccl::KeyInfo(iter->second));
+}
+
 rocksdb::Status DataKeyManager::MaybeRotateKeyLocked() {
   assert(registry_ != nullptr);
 
   if (registry_->active_store_key_id() == "" || registry_->active_data_key_id() == "") {
     return rocksdb::Status::InvalidArgument(
-        "MaybeRotateKey called before SetActiveStoreKey: there is no key to rotate");
+        "MaybeRotateKey called before SetActiveStoreKeyInfo: there is no key to rotate");
   }
 
   auto active_key = CurrentKeyLocked();
@@ -379,7 +394,7 @@ rocksdb::Status DataKeyManager::MaybeRotateKeyLocked() {
 }
 
 rocksdb::Status
-DataKeyManager::SetActiveStoreKey(std::unique_ptr<enginepbccl::KeyInfo> store_info) {
+DataKeyManager::SetActiveStoreKeyInfo(std::unique_ptr<enginepbccl::KeyInfo> store_info) {
   std::unique_lock<std::mutex> l(mu_);
 
   assert(registry_ != nullptr);

--- a/c-deps/libroach/ccl/key_manager.h
+++ b/c-deps/libroach/ccl/key_manager.h
@@ -112,7 +112,7 @@ class DataKeyManager : public KeyManager {
   // `env` is owned by the caller and should be an encrypted Env.
   // `db_dir` is the rocksdb directory.
   // If read-only is true, the DataKeyManager can be used to lookup keys but cannot
-  // change any keys (eg: SetActiveStoreKey will fail).
+  // change any keys (eg: SetActiveStoreKeyInfo will fail).
   explicit DataKeyManager(rocksdb::Env* env, std::shared_ptr<rocksdb::Logger> logger,
                           const std::string& db_dir, int64_t rotation_period, bool read_only);
 
@@ -122,9 +122,15 @@ class DataKeyManager : public KeyManager {
   // On error, existing keys held by the object are not overwritten.
   rocksdb::Status LoadKeys();
 
-  // SetActiveStoreKey takes the KeyInfo of the active store key
+  // SetActiveStoreKeyInfo takes the KeyInfo of the active store key
   // and adds it to the registry. A new data key is generated if needed.
-  rocksdb::Status SetActiveStoreKey(std::unique_ptr<enginepbccl::KeyInfo> store_key);
+  rocksdb::Status SetActiveStoreKeyInfo(std::unique_ptr<enginepbccl::KeyInfo> store_key);
+
+  // GetActiveStoreKeyInfo returns the KeyInfo for the active store key.
+  // The data key registry keeps the active store key information (but not the key) from
+  // the first time the active key was seen. Fields like creation_time will only
+  // be accurate here.
+  std::unique_ptr<enginepbccl::KeyInfo> GetActiveStoreKeyInfo();
 
   virtual std::unique_ptr<enginepbccl::SecretKey> CurrentKey() override;
   virtual std::unique_ptr<enginepbccl::SecretKey> GetKey(const std::string& id) override;

--- a/c-deps/libroach/ccl/key_manager_test.cc
+++ b/c-deps/libroach/ccl/key_manager_test.cc
@@ -502,7 +502,7 @@ TEST(DataKeyManager, SetStoreKey) {
     // Set new active store key.
     auto store_info = std::unique_ptr<enginepbccl::KeyInfo>(
         new enginepbccl::KeyInfo(keyInfoFromTestKey(t.store_info)));
-    auto status = dkm.SetActiveStoreKey(std::move(store_info));
+    auto status = dkm.SetActiveStoreKeyInfo(std::move(store_info));
     EXPECT_ERR(status, t.error);
     if (status.ok()) {
       // New key generated. Check active data key.
@@ -559,7 +559,7 @@ TEST(DataKeyManager, RotateKey) {
 
   struct TestCase {
     testKey store_info;    // Active store key info.
-    int64_t current_time;  // We update the fake env time before the call to SetActiveStoreKey.
+    int64_t current_time;  // We update the fake env time before the call to SetActiveStoreKeyInfo.
     testKey active_key;    // We call compareNonRandomKeyInfo against the active data key.
   };
 
@@ -611,7 +611,7 @@ TEST(DataKeyManager, RotateKey) {
     // Set new active store key.
     auto store_info = std::unique_ptr<enginepbccl::KeyInfo>(
         new enginepbccl::KeyInfo(keyInfoFromTestKey(t.store_info)));
-    auto status = dkm.SetActiveStoreKey(std::move(store_info));
+    auto status = dkm.SetActiveStoreKeyInfo(std::move(store_info));
     ASSERT_OK(status);
 
     auto active_info = dkm.CurrentKey();
@@ -633,7 +633,7 @@ TEST(DataKeyManager, RotateKey) {
     env->SetCurrentTime(tc.current_time + 100);
     auto store_info = std::unique_ptr<enginepbccl::KeyInfo>(
         new enginepbccl::KeyInfo(keyInfoFromTestKey(tc.store_info)));
-    EXPECT_ERR(ro_dkm.SetActiveStoreKey(std::move(store_info)),
+    EXPECT_ERR(ro_dkm.SetActiveStoreKeyInfo(std::move(store_info)),
                "key manager is read-only, keys cannot be rotated");
     active_info = ro_dkm.CurrentKey();
     ASSERT_NE(active_info, nullptr);


### PR DESCRIPTION
The store key manager doesn't have any state so it only knows about the
time it loaded the key. Instead, use the `KeyInfo` from the key registry
which persists the "first seen" time as the `creation_time`.

Release note: None