### PR TITLE
opt/exec: Fix panic for correlated subqueries

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -70,3 +70,7 @@ func (b *Builder) BuildScalar(ivh *tree.IndexedVarHelper) (tree.TypedExpr, error
 	}
 	return b.buildScalar(&ctx, b.ev)
 }
+
+func (b *Builder) decorrelationError() error {
+	return errors.Errorf("could not decorrelate subquery")
+}

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -144,7 +144,7 @@ func (b *Builder) buildRelational(ev memo.ExprView) (execPlan, error) {
 				ep, err = b.buildProjectSet(ev)
 				break
 			}
-			return execPlan{}, errors.Errorf("could not decorrelate subquery")
+			return execPlan{}, b.decorrelationError()
 		}
 		return execPlan{}, errors.Errorf("unsupported relational op %s", ev.Operator())
 	}

--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -377,6 +377,11 @@ func (b *Builder) buildSubquery(ctx *buildScalarCtx, ev memo.ExprView) (tree.Typ
 		return nil, errors.Errorf("subquery input with multiple columns")
 	}
 
+	// We cannot execute correlated subqueries.
+	if !input.Logical().Relational.OuterCols.Empty() {
+		return nil, b.decorrelationError()
+	}
+
 	// Build the execution plan for the subquery. Note that the subquery could
 	// have subqueries of its own which are added to b.subqueries.
 	root, err := b.build(input)

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -182,3 +182,18 @@ root                        ·          ·                         (generate_ser
                 └── scan    ·          ·                         (x, y)             ·
 ·                           table      xy@primary                ·                  ·
 ·                           spans      ALL                       ·                  ·
+
+# Regression test for #24676.
+statement ok
+CREATE TABLE groups(
+  id SERIAL,
+  data jsonb,
+  primary key (id)
+)
+
+query error could not decorrelate subquery
+EXPLAIN (VERBOSE) SELECT
+  g.data->>'name' AS group_name,
+  jsonb_array_elements( (SELECT gg.data->'members' FROM groups gg WHERE gg.data->>'name' = g.data->>'name') )
+FROM
+  groups g


### PR DESCRIPTION
Previously, the execbuilder was throwing a panic if it encountered
a correlated subquery. This commit changes the panic to the error:
"could not decorrelate subquery".

Release note: None