### PR TITLE
storage: cancel liveness update context on Stopper cancellation

### DIFF
--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -697,7 +697,7 @@ func (txn *Txn) rollback(ctx context.Context) *roachpb.Error {
 	}
 
 	stopper := txn.db.ctx.Stopper
-	ctx = stopper.WithCancel(txn.db.AnnotateCtx(context.Background()))
+	ctx = stopper.WithCancelOnQuiesce(txn.db.AnnotateCtx(context.Background()))
 	if err := stopper.RunAsyncTask(ctx, "async-rollback", func(ctx context.Context) {
 		if err := txn.sendEndTxnReq(ctx, false /* commit */, nil); err != nil {
 			log.Infof(ctx, "async rollback failed: %s", err)

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -697,12 +697,14 @@ func (txn *Txn) rollback(ctx context.Context) *roachpb.Error {
 	}
 
 	stopper := txn.db.ctx.Stopper
-	ctx = stopper.WithCancelOnQuiesce(txn.db.AnnotateCtx(context.Background()))
+	ctx, cancel := stopper.WithCancelOnQuiesce(txn.db.AnnotateCtx(context.Background()))
 	if err := stopper.RunAsyncTask(ctx, "async-rollback", func(ctx context.Context) {
+		defer cancel()
 		if err := txn.sendEndTxnReq(ctx, false /* commit */, nil); err != nil {
 			log.Infof(ctx, "async rollback failed: %s", err)
 		}
 	}); err != nil {
+		cancel()
 		return roachpb.NewError(err)
 	}
 	return nil

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -807,7 +807,8 @@ func TestGRPCKeepaliveFailureFailsInflightRPCs(t *testing.T) {
 
 			stopper := stop.NewStopper()
 			defer stopper.Stop(context.TODO())
-			ctx := stopper.WithCancelOnQuiesce(context.TODO())
+			ctx, cancel := stopper.WithCancelOnQuiesce(context.TODO())
+			defer cancel()
 
 			// Construct server with server-side keepalive.
 			clock := hlc.NewClock(timeutil.Unix(0, 20).UnixNano, time.Nanosecond)

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -807,7 +807,7 @@ func TestGRPCKeepaliveFailureFailsInflightRPCs(t *testing.T) {
 
 			stopper := stop.NewStopper()
 			defer stopper.Stop(context.TODO())
-			ctx := stopper.WithCancel(context.TODO())
+			ctx := stopper.WithCancelOnQuiesce(context.TODO())
 
 			// Construct server with server-side keepalive.
 			clock := hlc.NewClock(timeutil.Unix(0, 20).UnixNano, time.Nanosecond)

--- a/pkg/server/server_update.go
+++ b/pkg/server/server_update.go
@@ -38,7 +38,8 @@ func (*UpgradeTestingKnobs) ModuleTestingKnobs() {}
 
 // startAttemptUpgrade attempts to upgrade cluster version.
 func (s *Server) startAttemptUpgrade(ctx context.Context) {
-	if err := s.stopper.RunAsyncTask(s.stopper.WithCancel(ctx), "auto-upgrade", func(ctx context.Context) {
+	ctx = s.stopper.WithCancelOnQuiesce(ctx)
+	if err := s.stopper.RunAsyncTask(ctx, "auto-upgrade", func(ctx context.Context) {
 		retryOpts := retry.Options{
 			InitialBackoff: time.Second,
 			MaxBackoff:     30 * time.Second,

--- a/pkg/server/server_update.go
+++ b/pkg/server/server_update.go
@@ -38,8 +38,9 @@ func (*UpgradeTestingKnobs) ModuleTestingKnobs() {}
 
 // startAttemptUpgrade attempts to upgrade cluster version.
 func (s *Server) startAttemptUpgrade(ctx context.Context) {
-	ctx = s.stopper.WithCancelOnQuiesce(ctx)
+	ctx, cancel := s.stopper.WithCancelOnQuiesce(ctx)
 	if err := s.stopper.RunAsyncTask(ctx, "auto-upgrade", func(ctx context.Context) {
+		defer cancel()
 		retryOpts := retry.Options{
 			InitialBackoff: time.Second,
 			MaxBackoff:     30 * time.Second,
@@ -89,6 +90,7 @@ func (s *Server) startAttemptUpgrade(ctx context.Context) {
 			}
 		}
 	}); err != nil {
+		cancel()
 		log.Infof(ctx, "failed attempt to upgrade cluster version, error: %s", err)
 	}
 }

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1578,7 +1578,7 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 
 	// Make a context tied to the Stopper. The test works without, but this
 	// is cleaner since we won't properly terminate the transaction below.
-	ctx = tc.Server(0).Stopper().WithCancel(ctx)
+	ctx = tc.Server(0).Stopper().WithCancelOnQuiesce(ctx)
 
 	// This transaction will try to write "under" a served read.
 	txnOld := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1578,7 +1578,8 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 
 	// Make a context tied to the Stopper. The test works without, but this
 	// is cleaner since we won't properly terminate the transaction below.
-	ctx = tc.Server(0).Stopper().WithCancelOnQuiesce(ctx)
+	ctx, cancel := tc.Server(0).Stopper().WithCancelOnQuiesce(ctx)
+	defer cancel()
 
 	// This transaction will try to write "under" a served read.
 	txnOld := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -456,22 +456,24 @@ func (nl *NodeLiveness) StartHeartbeat(
 	stopper.RunWorker(ctx, func(context.Context) {
 		ambient := nl.ambientCtx
 		ambient.AddLogTag("hb", nil)
+		ctx := stopper.WithCancelOnStop(context.Background())
+		ctx, sp := ambient.AnnotateCtxWithSpan(ctx, "liveness heartbeat loop")
+		defer sp.Finish()
+
+		incrementEpoch := true
 		ticker := time.NewTicker(nl.heartbeatInterval)
 		defer ticker.Stop()
-		incrementEpoch := true
 		for {
 			select {
 			case <-nl.heartbeatToken:
 			case <-stopper.ShouldStop():
 				return
 			}
-			func() {
+			func(ctx context.Context) {
 				// Give the context a timeout approximately as long as the time we
 				// have left before our liveness entry expires.
-				ctx, cancel := context.WithTimeout(context.Background(), nl.livenessThreshold-nl.heartbeatInterval)
-				ctx, sp := ambient.AnnotateCtxWithSpan(ctx, "liveness heartbeat loop")
+				ctx, cancel := context.WithTimeout(ctx, nl.livenessThreshold-nl.heartbeatInterval)
 				defer cancel()
-				defer sp.Finish()
 
 				// Retry heartbeat in the event the conditional put fails.
 				for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
@@ -490,7 +492,7 @@ func (nl *NodeLiveness) StartHeartbeat(
 					}
 					break
 				}
-			}()
+			}(ctx)
 			nl.heartbeatToken <- struct{}{}
 			select {
 			case <-ticker.C:

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -456,7 +456,8 @@ func (nl *NodeLiveness) StartHeartbeat(
 	stopper.RunWorker(ctx, func(context.Context) {
 		ambient := nl.ambientCtx
 		ambient.AddLogTag("hb", nil)
-		ctx := stopper.WithCancelOnStop(context.Background())
+		ctx, cancel := stopper.WithCancelOnStop(context.Background())
+		defer cancel()
 		ctx, sp := ambient.AnnotateCtxWithSpan(ctx, "liveness heartbeat loop")
 		defer sp.Finish()
 

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -350,8 +350,39 @@ func TestStopperWithCancel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := stop.NewStopper()
 	ctx := context.Background()
-	ctx1 := s.WithCancelOnQuiesce(ctx)
-	ctx2 := s.WithCancelOnStop(ctx)
+	ctx1, _ := s.WithCancelOnQuiesce(ctx)
+	ctx2, _ := s.WithCancelOnStop(ctx)
+	ctx3, cancel3 := s.WithCancelOnQuiesce(ctx)
+	ctx4, cancel4 := s.WithCancelOnStop(ctx)
+
+	if err := ctx1.Err(); err != nil {
+		t.Fatalf("should not be canceled: %v", err)
+	}
+	if err := ctx2.Err(); err != nil {
+		t.Fatalf("should not be canceled: %v", err)
+	}
+	if err := ctx3.Err(); err != nil {
+		t.Fatalf("should not be canceled: %v", err)
+	}
+	if err := ctx4.Err(); err != nil {
+		t.Fatalf("should not be canceled: %v", err)
+	}
+
+	cancel3()
+	cancel4()
+	if err := ctx1.Err(); err != nil {
+		t.Fatalf("should not be canceled: %v", err)
+	}
+	if err := ctx2.Err(); err != nil {
+		t.Fatalf("should not be canceled: %v", err)
+	}
+	if err := ctx3.Err(); err != context.Canceled {
+		t.Fatalf("should be canceled: %v", err)
+	}
+	if err := ctx4.Err(); err != context.Canceled {
+		t.Fatalf("should be canceled: %v", err)
+	}
+
 	s.Quiesce(ctx)
 	if err := ctx1.Err(); err != context.Canceled {
 		t.Fatalf("should be canceled: %v", err)
@@ -359,10 +390,8 @@ func TestStopperWithCancel(t *testing.T) {
 	if err := ctx2.Err(); err != nil {
 		t.Fatalf("should not be canceled: %v", err)
 	}
+
 	s.Stop(ctx)
-	if err := ctx1.Err(); err != context.Canceled {
-		t.Fatalf("should be canceled: %v", err)
-	}
 	if err := ctx2.Err(); err != context.Canceled {
 		t.Fatalf("should be canceled: %v", err)
 	}

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -349,10 +349,22 @@ func TestStopperRunTaskPanic(t *testing.T) {
 func TestStopperWithCancel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := stop.NewStopper()
-	ctx := s.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx1 := s.WithCancelOnQuiesce(ctx)
+	ctx2 := s.WithCancelOnStop(ctx)
+	s.Quiesce(ctx)
+	if err := ctx1.Err(); err != context.Canceled {
+		t.Fatalf("should be canceled: %v", err)
+	}
+	if err := ctx2.Err(); err != nil {
+		t.Fatalf("should not be canceled: %v", err)
+	}
 	s.Stop(ctx)
-	if err := ctx.Err(); err != context.Canceled {
-		t.Fatal(err)
+	if err := ctx1.Err(); err != context.Canceled {
+		t.Fatalf("should be canceled: %v", err)
+	}
+	if err := ctx2.Err(); err != context.Canceled {
+		t.Fatalf("should be canceled: %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #27878.

The test was flaky because a NodeLiveness update was getting stuck when
killing a majority of nodes in a Range. The fix was to tie NodeLiveness'
update context to its stopper so that liveness updates are canceled when
their node begins to shut down.

This was a real issue that I suspect would occasionally make nodes hang on
shutdown when their liveness range was becoming unavailable. There are
probably other issues in the same class of bugs, but stressing
`TestLogGrowthWhenRefreshingPendingCommands` isn't showing anything else.

In doing so, the change needed to extend `stopper.WithCancel` into
`stopper.WithCancelOnQuiesce` and `stopper.WithCancelOnStop`.

Release note: None