### PR TITLE
roachtest: skip tpcc checks in cdc test

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -47,7 +47,7 @@ func registerCDC(r *registry) {
 
 		t.Status("loading initial data")
 		c.Run(ctx, workloadNode, fmt.Sprintf(
-			`./workload fixtures load tpcc --warehouses=%d {pgurl:1}`, warehouses,
+			`./workload fixtures load tpcc --warehouses=%d --checks=false {pgurl:1}`, warehouses,
 		))
 
 		// Run compactions on the data so TimeBoundIterator works. This can be


### PR DESCRIPTION
It's running out of memory budget on warehouses=1000. Plus I keep
forgetting to add this during local testing and then having to wait for
it.

Closes #27877

Release note: None