### PR TITLE
opt: Use FDs to improve SELECT selectivity 

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -408,14 +408,19 @@ func (sb *statisticsBuilder) buildSelect(filter ExprView, inputStats *props.Stat
 	//     TODO(rytaft): we may be able to get a more precise estimate than
 	//     1/3 for certain types of filters. For example, the selectivity of
 	//     x=y can be estimated as 1/(max(distinct(x), distinct(y)).
+
 	sb.s.Selectivity = 1
+	numUnappliedConstraints := 0
 	sel := func(constraintSet *constraint.Set, tight bool) {
 		if constraintSet != nil {
-			childSelectivity := sb.applyConstraintSet(constraintSet, &inputStatsBuilder)
-			if !tight && childSelectivity > unknownFilterSelectivity {
-				childSelectivity = unknownFilterSelectivity
+			n, isContradiction := sb.applyConstraintSet(constraintSet, &inputStatsBuilder)
+			numUnappliedConstraints += n
+			if !tight && n == 0 {
+				numUnappliedConstraints++
 			}
-			sb.s.Selectivity *= childSelectivity
+			if isContradiction {
+				sb.s.Selectivity *= 0
+			}
 		} else {
 			sb.s.Selectivity *= unknownFilterSelectivity
 		}
@@ -435,6 +440,9 @@ func (sb *statisticsBuilder) buildSelect(filter ExprView, inputStats *props.Stat
 			sel(constraintSet, tight)
 		}
 	}
+
+	sb.s.Selectivity *= sb.selectivityFromDistinctCounts(&inputStatsBuilder)
+	sb.s.Selectivity *= sb.selectivityFromUnappliedConstraints(numUnappliedConstraints)
 
 	sb.applySelectivity(inputStats.RowCount)
 }
@@ -1106,30 +1114,30 @@ func (sb *statisticsBuilder) applyConstraint(
 
 func (sb *statisticsBuilder) applyConstraintSet(
 	cs *constraint.Set, inputStatsBuilder *statisticsBuilder,
-) (selectivity float64) {
+) (numUnappliedConstraints int, isContradiction bool) {
 	if cs.IsUnconstrained() {
-		return 1 /* selectivity */
+		return 0, false /* numUnappliedConstraints, contradiction */
 	}
 
 	if cs == constraint.Contradiction {
 		// A contradiction results in 0 rows.
-		return 0 /* selectivity */
+		return 0, true /* numUnappliedConstraints, contradiction */
 	}
 
-	adjustedSelectivity := 1.0
+	numUnappliedConstraints = 0
 	for i := 0; i < cs.Length(); i++ {
 		applied := sb.updateDistinctCountsFromConstraint(cs.Constraint(i), inputStatsBuilder)
 		if !applied {
-			// If a constraint cannot be applied, it probably represents an
+			// If a constraint cannot be applied, it may represent an
 			// inequality like x < 1. As a result, distinctCounts does not fully
-			// represent the selectivity of the constraint set. Adjust the
-			// selectivity to account for this constraint.
-			adjustedSelectivity *= unknownFilterSelectivity
+			// represent the selectivity of the constraint set.
+			// We return the number of unapplied constraints to the caller
+			// function to be used for selectivity calculation.
+			numUnappliedConstraints++
 		}
 	}
 
-	selectivity = sb.selectivityFromDistinctCounts(inputStatsBuilder)
-	return selectivity * adjustedSelectivity
+	return numUnappliedConstraints, false
 }
 
 // updateDistinctCountsFromConstraint updates the distinct count for each
@@ -1241,8 +1249,8 @@ func (sb *statisticsBuilder) updateDistinctCountsFromConstraint(
 }
 
 // selectivityFromDistinctCounts calculates the selectivity of a filter by
-// taking the product of selectivities of each constrained column. This can be
-// represented by the formula:
+// taking the product of selectivities of each constrained column. In the general case,
+// this can be represented by the formula:
 //
 //                  ┬-┬ ⎛ new distinct(i) ⎞
 //   selectivity =  │ │ ⎜ --------------- ⎟
@@ -1254,15 +1262,26 @@ func (sb *statisticsBuilder) updateDistinctCountsFromConstraint(
 // This selectivity will be used later to update the row count and the
 // distinct count for the unconstrained columns in applySelectivityToColStat.
 //
-// TODO(rytaft): This formula assumes that the columns are completely
-// independent. Improve this estimate to take functional dependencies and/or
-// column correlations into account.
+// In the general case this algorithm assumes the columns are completely
+// independent. It considers one case where correlations are implied
+// by functional dependencies.
+// Briefly, if the distinct count of all determinant columns in the columnStatistics
+// is one, then we should ignore the selectivities of the dependent columns since the
+// columns are fully correlated with the determinant columns.
+// See statisticsBuilder.selectivityFromReducedCols for a more detailed
+// explanation.
+//
 func (sb *statisticsBuilder) selectivityFromDistinctCounts(
 	inputStatsBuilder *statisticsBuilder,
 ) (selectivity float64) {
+
+	var allConstant bool
+	if selectivity, allConstant = sb.selectivityFromReducedCols(inputStatsBuilder); allConstant {
+		return selectivity
+	}
 	selectivity = 1.0
-	for col, colStat := range sb.s.ColStats {
-		inputStat := inputStatsBuilder.colStat(util.MakeFastIntSet(int(col)))
+	for _, colStat := range sb.s.ColStats {
+		inputStat := inputStatsBuilder.colStat(colStat.Cols)
 		if inputStat.DistinctCount != 0 && colStat.DistinctCount < inputStat.DistinctCount {
 			selectivity *= colStat.DistinctCount / inputStat.DistinctCount
 		}
@@ -1322,4 +1341,60 @@ func (sb *statisticsBuilder) updateStatsFromContradiction() {
 	for i := range sb.s.MultiColStats {
 		sb.s.MultiColStats[i].DistinctCount = 0
 	}
+}
+
+func (sb *statisticsBuilder) selectivityFromUnappliedConstraints(
+	numUnappliedConstraints int,
+) (selectivity float64) {
+	return math.Pow(unknownFilterSelectivity, float64(numUnappliedConstraints))
+}
+
+// selectivityFromReducedCols is used for selectivity calculation.
+// When columns in the colStats are functionally determined by other columns,
+// and the determinant columns each have distinctCount = 1, we should consider
+// the implied correlations for selectivity calculation. Consider the query:
+//
+//   SELECT * FROM customer WHERE id = 123 and name = 'John Smith'
+//
+// If id is the primary key of customer, then name is functionally determined by id. We
+// only need to consider the selectivity of id, not name, since id and name
+// are fully correlated. To determine if we have a case such as this one,
+// we functionally reduce the set of columns which have column statistics,
+// eliminating columns that can be functionally determined by other columns.
+// If the distinct count on all of these reduced columns is one, then we apply
+// only the selectivities implied by this reduced column set.
+//
+func (sb *statisticsBuilder) selectivityFromReducedCols(
+	inputStatsBuilder *statisticsBuilder,
+) (selectivity float64, allConstant bool) {
+	var cols opt.ColSet
+
+	// We consider only single column stats for now
+	// in our selectivity calculations.
+	for col := range sb.s.ColStats {
+		cols.Add(int(col))
+	}
+
+	reducedCols := inputStatsBuilder.props.FuncDeps.ReduceCols(cols)
+	if reducedCols.Len() == 0 {
+		// We return selectivity of 1 since the selectivity hasn't changed.
+		// There are no reduced columns and so allConstant is vacuously false.
+		return 1, false
+	}
+
+	allConstant = true
+	selectivity = 1.0
+	for i, ok := reducedCols.Next(0); ok; i, ok = reducedCols.Next(i + 1) {
+		colStat := sb.s.ColStats[opt.ColumnID(i)]
+		if colStat.DistinctCount != 1 {
+			allConstant = false
+			break
+		}
+		inputStat := inputStatsBuilder.colStat(colStat.Cols)
+		if inputStat.DistinctCount != 0 && colStat.DistinctCount < inputStat.DistinctCount {
+			selectivity *= colStat.DistinctCount / inputStat.DistinctCount
+		}
+	}
+
+	return selectivity, allConstant
 }

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -754,7 +754,7 @@ SELECT * FROM c WHERE (v, u) IN ((1, 2), (3, 50), (5, NULL))
 scan c@v
  ├── columns: k:1(int!null) u:2(int!null) v:3(int!null)
  ├── constraint: /3/2/1: [/1/2 - /1/2] [/3/50 - /3/50]
- ├── stats: [rows=0.00816326531, distinct(2)=0.00816326531, distinct(3)=0.00816326531]
+ ├── stats: [rows=0.00272108844, distinct(2)=0.00272108844, distinct(3)=0.00272108844]
  ├── key: (1)
  └── fd: (1)-->(2,3)
 
@@ -765,7 +765,7 @@ SELECT * FROM c WHERE (v, 2) IN ((1, 2), (3, 50), (5, 100))
 ----
 select
  ├── columns: k:1(int!null) u:2(int) v:3(int!null)
- ├── stats: [rows=4.28571429, distinct(3)=3]
+ ├── stats: [rows=1.42857143, distinct(3)=1.42857143]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── scan c@v
@@ -798,7 +798,7 @@ SELECT * FROM c WHERE (v, u + v) IN ((1, 2), (3, 50), (5, 100))
 ----
 select
  ├── columns: k:1(int!null) u:2(int) v:3(int!null)
- ├── stats: [rows=4.28571429, distinct(3)=3]
+ ├── stats: [rows=1.42857143, distinct(3)=1.42857143]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── scan c@v
@@ -830,7 +830,7 @@ SELECT * FROM c WHERE (v, u) IN ((1, 2), (k, 50), (5, 100))
 ----
 select
  ├── columns: k:1(int!null) u:2(int!null) v:3(int)
- ├── stats: [rows=4.28571429, distinct(2)=3]
+ ├── stats: [rows=1.42857143, distinct(2)=1.42857143]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── scan c

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -390,3 +390,298 @@ project
                 │    ├── variable: tab0.col0 [type=int, outer=(2)]
                 │    └── const: 1 [type=int]
                 └── variable: case [type=bool, outer=(27)]
+
+
+exec-ddl
+CREATE TABLE customers (id INT PRIMARY KEY, name STRING, state STRING)
+----
+TABLE customers
+ ├── id int not null
+ ├── name string
+ ├── state string
+ └── INDEX primary
+      └── id int not null
+
+exec-ddl
+CREATE TABLE order_history (order_id INT, item_id INT, customer_id INT, year INT)
+----
+TABLE order_history
+ ├── order_id int
+ ├── item_id int
+ ├── customer_id int
+ ├── year int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+exec-ddl
+CREATE TABLE district (d_id INT, d_w_id INT, d_name STRING, PRIMARY KEY(d_id, d_w_id))
+----
+TABLE district
+ ├── d_id int not null
+ ├── d_w_id int not null
+ ├── d_name string
+ └── INDEX primary
+      ├── d_id int not null
+      └── d_w_id int not null
+
+exec-ddl
+ALTER TABLE district INJECT STATISTICS '[
+{
+  "columns": ["d_id"],
+  "created_at": "2018-01-01 1:00:00.00000+00:00",
+  "row_count": 100,
+  "distinct_count": 10
+},
+{
+  "columns": ["d_w_id"],
+  "created_at": "2018-01-01 1:30:00.00000+00:00",
+  "row_count": 100,
+  "distinct_count": 10
+},
+{
+  "columns": ["d_name"],
+  "created_at": "2018-01-01 1:30:00.00000+00:00",
+  "row_count": 100,
+  "distinct_count": 100
+}
+]'
+----
+
+# This tests selectivityFromReducedCols.
+# Since the reduced column set is (d_id, d_name), and
+# both columns have distinct count 1, we expect this
+# to calculate selectivity through selectivityFromReducedCols.
+# The output is the same as the naive approach.
+norm
+SELECT * FROM district WHERE d_id = 1 AND d_name='bobs_burgers'
+----
+select
+ ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string!null)
+ ├── stats: [rows=0.1, distinct(1)=0.1, distinct(3)=0.1]
+ ├── key: (2)
+ ├── fd: ()-->(1,3)
+ ├── scan district
+ │    ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string)
+ │    ├── stats: [rows=100, distinct(1)=10, distinct(3)=100]
+ │    ├── key: (1,2)
+ │    └── fd: (1,2)-->(3)
+ └── filters [type=bool, outer=(1,3), constraints=(/1: [/1 - /1]; /3: [/'bobs_burgers' - /'bobs_burgers']; tight), fd=()-->(1,3)]
+      ├── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
+      │    ├── variable: district.d_id [type=int, outer=(1)]
+      │    └── const: 1 [type=int]
+      └── eq [type=bool, outer=(3), constraints=(/3: [/'bobs_burgers' - /'bobs_burgers']; tight)]
+           ├── variable: district.d_name [type=string, outer=(3)]
+           └── const: 'bobs_burgers' [type=string]
+
+# In this case we expect to use unknownFilterSelectivity
+# to estimate the selectivity on d_name, and use
+# the ratio of current/input distinct counts for d_id
+norm
+SELECT * FROM district WHERE d_id = 1 and d_name LIKE 'bob'
+----
+select
+ ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string)
+ ├── stats: [rows=3.33333333, distinct(1)=1]
+ ├── key: (2)
+ ├── fd: ()-->(1), (2)-->(3)
+ ├── scan district
+ │    ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string)
+ │    ├── stats: [rows=100, distinct(1)=10]
+ │    ├── key: (1,2)
+ │    └── fd: (1,2)-->(3)
+ └── filters [type=bool, outer=(1,3), constraints=(/1: [/1 - /1]), fd=()-->(1)]
+      ├── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
+      │    ├── variable: district.d_id [type=int, outer=(1)]
+      │    └── const: 1 [type=int]
+      └── like [type=bool, outer=(3)]
+           ├── variable: district.d_name [type=string, outer=(3)]
+           └── const: 'bob' [type=string]
+
+# This tests selectivityFromReducedCols.
+# Since (1,2)-->(3) in order to use selectivityFromReducedCols,
+# both (1,2) must have distinct=1 after applying the filter. Since
+# d_id is a range constraint, this fails, and we fall back to the
+# naive estimation for selectivity.
+norm
+SELECT * FROM district WHERE d_id > 1 AND d_id < 10 AND d_w_id=10 AND d_name='bobs_burgers'
+----
+select
+ ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string!null)
+ ├── stats: [rows=0.08, distinct(1)=0.08, distinct(2)=0.08, distinct(3)=0.08]
+ ├── key: (1)
+ ├── fd: ()-->(2,3)
+ ├── scan district
+ │    ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string)
+ │    ├── stats: [rows=100, distinct(1)=10, distinct(2)=10, distinct(3)=100]
+ │    ├── key: (1,2)
+ │    └── fd: (1,2)-->(3)
+ └── filters [type=bool, outer=(1-3), constraints=(/1: [/2 - /9]; /2: [/10 - /10]; /3: [/'bobs_burgers' - /'bobs_burgers']; tight), fd=()-->(2,3)]
+      ├── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
+      │    ├── variable: district.d_id [type=int, outer=(1)]
+      │    └── const: 1 [type=int]
+      ├── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /9]; tight)]
+      │    ├── variable: district.d_id [type=int, outer=(1)]
+      │    └── const: 10 [type=int]
+      ├── eq [type=bool, outer=(2), constraints=(/2: [/10 - /10]; tight)]
+      │    ├── variable: district.d_w_id [type=int, outer=(2)]
+      │    └── const: 10 [type=int]
+      └── eq [type=bool, outer=(3), constraints=(/3: [/'bobs_burgers' - /'bobs_burgers']; tight)]
+           ├── variable: district.d_name [type=string, outer=(3)]
+           └── const: 'bobs_burgers' [type=string]
+
+# This tests selectivityFromReducedCols
+# We don't apply the selectivity on d_name since (1,2)-->3.
+norm
+SELECT * FROM district WHERE d_id = 1 AND d_w_id=10 AND d_name='hello'
+----
+select
+ ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string!null)
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1, distinct(1)=1, distinct(2)=1, distinct(3)=1]
+ ├── key: ()
+ ├── fd: ()-->(1-3)
+ ├── scan district
+ │    ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string)
+ │    ├── stats: [rows=100, distinct(1)=10, distinct(2)=10, distinct(3)=100]
+ │    ├── key: (1,2)
+ │    └── fd: (1,2)-->(3)
+ └── filters [type=bool, outer=(1-3), constraints=(/1: [/1 - /1]; /2: [/10 - /10]; /3: [/'hello' - /'hello']; tight), fd=()-->(1-3)]
+      ├── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
+      │    ├── variable: district.d_id [type=int, outer=(1)]
+      │    └── const: 1 [type=int]
+      ├── eq [type=bool, outer=(2), constraints=(/2: [/10 - /10]; tight)]
+      │    ├── variable: district.d_w_id [type=int, outer=(2)]
+      │    └── const: 10 [type=int]
+      └── eq [type=bool, outer=(3), constraints=(/3: [/'hello' - /'hello']; tight)]
+           ├── variable: district.d_name [type=string, outer=(3)]
+           └── const: 'hello' [type=string]
+
+exec-ddl
+ALTER TABLE customers INJECT STATISTICS '[
+{
+  "columns": ["name"],
+  "created_at": "2018-01-01 1:00:00.00000+00:00",
+  "row_count": 10000,
+  "distinct_count": 500
+},
+{
+  "columns": ["id"],
+  "created_at": "2018-01-01 1:30:00.00000+00:00",
+  "row_count": 10000,
+  "distinct_count": 10000
+}
+]'
+----
+
+# This tests selectivityFromReducedCols
+# The following two tests cases are paired together. The first has
+# one constraint, one on single non-key column. The second  query has two
+# constraints on columns which form a determinant, dependent FD pair.
+# The dependent column in this FD pair is from the first test case.
+# This series of tests demonstrates that the selectivity
+# contribution for a pair of (determinant, dependent) FDs is the
+# selectivity of the determinant.
+# After the join we expect cardinality 1111111,
+# then we expect selectivity 1/400 on the filter.
+# 1/2 join-subquery-selectivityFromReducedCols tests
+
+build
+SELECT * FROM (SELECT * FROM customers, order_history WHERE id = customer_id)
+WHERE name='andy'
+----
+select
+ ├── columns: id:1(int!null) name:2(string!null) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int!null) year:7(int)
+ ├── stats: [rows=2222.22222, distinct(2)=1]
+ ├── fd: ()-->(2), (1)-->(3), (1)==(6), (6)==(1)
+ ├── project
+ │    ├── columns: id:1(int!null) name:2(string) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int!null) year:7(int)
+ │    ├── stats: [rows=1111111.11, distinct(2)=500]
+ │    ├── fd: (1)-->(2,3), (1)==(6), (6)==(1)
+ │    └── select
+ │         ├── columns: id:1(int!null) name:2(string) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int!null) year:7(int) rowid:8(int!null)
+ │         ├── stats: [rows=1111111.11, distinct(2)=500]
+ │         ├── key: (8)
+ │         ├── fd: (1)-->(2,3), (8)-->(4-7), (1)==(6), (6)==(1)
+ │         ├── inner-join
+ │         │    ├── columns: id:1(int!null) name:2(string) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int) year:7(int) rowid:8(int!null)
+ │         │    ├── stats: [rows=10000000, distinct(2)=500]
+ │         │    ├── key: (1,8)
+ │         │    ├── fd: (1)-->(2,3), (8)-->(4-7)
+ │         │    ├── scan customers
+ │         │    │    ├── columns: id:1(int!null) name:2(string) state:3(string)
+ │         │    │    ├── stats: [rows=10000, distinct(2)=500]
+ │         │    │    ├── key: (1)
+ │         │    │    └── fd: (1)-->(2,3)
+ │         │    ├── scan order_history
+ │         │    │    ├── columns: order_id:4(int) item_id:5(int) customer_id:6(int) year:7(int) rowid:8(int!null)
+ │         │    │    ├── stats: [rows=1000]
+ │         │    │    ├── key: (8)
+ │         │    │    └── fd: (8)-->(4-7)
+ │         │    └── true [type=bool]
+ │         └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │              └── eq [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+ │                   ├── variable: customers.id [type=int, outer=(1)]
+ │                   └── variable: order_history.customer_id [type=int, outer=(6)]
+ └── filters [type=bool, outer=(2), constraints=(/2: [/'andy' - /'andy']; tight), fd=()-->(2)]
+      └── eq [type=bool, outer=(2), constraints=(/2: [/'andy' - /'andy']; tight)]
+           ├── variable: customers.name [type=string, outer=(2)]
+           └── const: 'andy' [type=string]
+
+# This tests selectivityFromReducedCols
+# The previous tests case and the following are paired together. The first has
+# one constraint, one on single non-key column. The second  query has two
+# constraints on columns which form a determinant, dependent FD pair.
+# The dependent column in this FD pair is from the first test case.
+# This series of tests demonstrates that the selectivity
+# contribution for a pair of (determinant, dependent) FDs is the
+# selectivity of the determinant.
+# After the join we expect cardinality 1111111,
+# then we expect selectivity 1/600 on the filter.
+# 2/2 join-subquery-selectivityFromReducedCols tests
+
+build
+SELECT * FROM (SELECT * FROM customers, order_history WHERE id = customer_id)
+WHERE id = 1 AND name='andy'
+----
+select
+ ├── columns: id:1(int!null) name:2(string!null) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int!null) year:7(int)
+ ├── stats: [rows=111.111111, distinct(1)=1, distinct(2)=1]
+ ├── fd: ()-->(1-3,6), (1)==(6), (6)==(1)
+ ├── project
+ │    ├── columns: id:1(int!null) name:2(string) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int!null) year:7(int)
+ │    ├── stats: [rows=1111111.11, distinct(1)=10000, distinct(2)=500]
+ │    ├── fd: (1)-->(2,3), (1)==(6), (6)==(1)
+ │    └── select
+ │         ├── columns: id:1(int!null) name:2(string) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int!null) year:7(int) rowid:8(int!null)
+ │         ├── stats: [rows=1111111.11, distinct(1)=10000, distinct(2)=500]
+ │         ├── key: (8)
+ │         ├── fd: (1)-->(2,3), (8)-->(4-7), (1)==(6), (6)==(1)
+ │         ├── inner-join
+ │         │    ├── columns: id:1(int!null) name:2(string) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int) year:7(int) rowid:8(int!null)
+ │         │    ├── stats: [rows=10000000, distinct(1)=10000, distinct(2)=500]
+ │         │    ├── key: (1,8)
+ │         │    ├── fd: (1)-->(2,3), (8)-->(4-7)
+ │         │    ├── scan customers
+ │         │    │    ├── columns: id:1(int!null) name:2(string) state:3(string)
+ │         │    │    ├── stats: [rows=10000, distinct(1)=10000, distinct(2)=500]
+ │         │    │    ├── key: (1)
+ │         │    │    └── fd: (1)-->(2,3)
+ │         │    ├── scan order_history
+ │         │    │    ├── columns: order_id:4(int) item_id:5(int) customer_id:6(int) year:7(int) rowid:8(int!null)
+ │         │    │    ├── stats: [rows=1000]
+ │         │    │    ├── key: (8)
+ │         │    │    └── fd: (8)-->(4-7)
+ │         │    └── true [type=bool]
+ │         └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │              └── eq [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+ │                   ├── variable: customers.id [type=int, outer=(1)]
+ │                   └── variable: order_history.customer_id [type=int, outer=(6)]
+ └── filters [type=bool, outer=(1,2), constraints=(/1: [/1 - /1]; /2: [/'andy' - /'andy']; tight), fd=()-->(1,2)]
+      └── and [type=bool, outer=(1,2), constraints=(/1: [/1 - /1]; /2: [/'andy' - /'andy']; tight)]
+           ├── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
+           │    ├── variable: customers.id [type=int, outer=(1)]
+           │    └── const: 1 [type=int]
+           └── eq [type=bool, outer=(2), constraints=(/2: [/'andy' - /'andy']; tight)]
+                ├── variable: customers.name [type=string, outer=(2)]
+                └── const: 'andy' [type=string]

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -139,11 +139,11 @@ memo (optimized)
  ├── G1: (project G2 G3)
  │    └── "[presentation: k:1]"
  │         ├── best: (project G2 G3)
- │         └── cost: 0.00
+ │         └── cost: 1.05
  ├── G2: (select G4 G5) (select G6 G8) (select G7 G8) (scan a@u,cols=(1,2),constrained) (scan a@u,rev,cols=(1,2),constrained)
  │    └── ""
  │         ├── best: (scan a@u,cols=(1,2),constrained)
- │         └── cost: 0.00
+ │         └── cost: 1.05
  ├── G3: (projections a.k)
  ├── G4: (scan a,cols=(1,2)) (scan a,rev,cols=(1,2)) (scan a@u,cols=(1,2)) (scan a@u,rev,cols=(1,2)) (scan a@v,cols=(1,2)) (scan a@v,rev,cols=(1,2))
  │    └── ""


### PR DESCRIPTION
This PR considers the case where applying the
selectivity from a set of constraints would be
redudant given a set of functional dependencies.

Before this PR, the selectivity of a filter
was defined as a product of all the selectivities of
each constraint applied to each column.
This PR makes two changes:

1) The selectivity should be determined after
all constraints have been applied.

2) If there are columns which are functionally
dependent in the input to the filter, and the
distinct count of the determinant is 1,
then the selectivity of only the determinant should
be applied.

This commit was inspired by the ideas found in the postgres link below.

https://github.com/postgres/postgres/blob/372728b0d49552641f0ea83d9d2e08817de038fa/src/backend/statistics/README.dependencies