### PR TITLE
opt: add two new external queries for testing

### DIFF
--- a/pkg/sql/opt/xform/testdata/external/pgadmin
+++ b/pkg/sql/opt/xform/testdata/external/pgadmin
@@ -1,0 +1,156 @@
+# Correlated subqueries.
+
+# For testing, create the schema for the builtin tables.
+exec-ddl
+CREATE TABLE pg_stat_activity (
+    datid OID NULL,
+    datname NAME NULL,
+    pid INTEGER NULL,
+    usesysid OID NULL,
+    username NAME NULL,
+    application_name STRING NULL,
+    client_addr INET NULL,
+    client_hostname STRING NULL,
+    client_port INTEGER NULL,
+    backend_start TIMESTAMP WITH TIME ZONE NULL,
+    xact_start TIMESTAMP WITH TIME ZONE NULL,
+    query_start TIMESTAMP WITH TIME ZONE NULL,
+    state_change TIMESTAMP WITH TIME ZONE NULL,
+    wait_event_type STRING NULL,
+    wait_event STRING NULL,
+    state STRING NULL,
+    backend_xid INTEGER NULL,
+    backend_xmin INTEGER NULL,
+    query STRING NULL
+)
+----
+TABLE pg_stat_activity
+ ├── datid oid
+ ├── datname name
+ ├── pid int
+ ├── usesysid oid
+ ├── username name
+ ├── application_name string
+ ├── client_addr inet
+ ├── client_hostname string
+ ├── client_port int
+ ├── backend_start timestamptz
+ ├── xact_start timestamptz
+ ├── query_start timestamptz
+ ├── state_change timestamptz
+ ├── wait_event_type string
+ ├── wait_event string
+ ├── state string
+ ├── backend_xid int
+ ├── backend_xmin int
+ ├── query string
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+exec-ddl
+CREATE TABLE pg_roles (
+    oid OID NULL,
+    rolname NAME NULL,
+    rolsuper BOOL NULL,
+    rolinherit BOOL NULL,
+    rolcreaterole BOOL NULL,
+    rolcreatedb BOOL NULL,
+    rolcatupdate BOOL NULL,
+    rolcanlogin BOOL NULL,
+    rolreplication BOOL NULL,
+    rolconnlimit INT NULL,
+    rolpassword STRING NULL,
+    rolvaliduntil TIMESTAMP WITH TIME ZONE NULL,
+    rolbypassrls BOOL NULL,
+    rolconfig STRING[] NULL
+)
+----
+TABLE pg_roles
+ ├── oid oid
+ ├── rolname name
+ ├── rolsuper bool
+ ├── rolinherit bool
+ ├── rolcreaterole bool
+ ├── rolcreatedb bool
+ ├── rolcatupdate bool
+ ├── rolcanlogin bool
+ ├── rolreplication bool
+ ├── rolconnlimit int
+ ├── rolpassword string
+ ├── rolvaliduntil timestamptz
+ ├── rolbypassrls bool
+ ├── rolconfig string[]
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+opt
+SELECT
+    pid AS "PID",
+    username AS "User",
+    datname AS "Database",
+    backend_start AS "Backend start",
+    CASE
+    WHEN client_hostname IS NOT NULL
+    AND client_hostname != ''
+    THEN client_hostname::STRING
+    || ':'
+    || client_port::STRING
+    WHEN client_addr IS NOT NULL
+    AND client_addr::STRING != ''
+    THEN client_addr::STRING || ':' || client_port::STRING
+    WHEN client_port = -1 THEN 'local pipe'
+    ELSE 'localhost:' || client_port::STRING
+    END
+        AS "Client",
+    application_name AS "Application",
+    query AS "Query",
+    query_start AS "Query start",
+    xact_start AS "Xact start"
+FROM
+    pg_stat_activity AS sa
+WHERE
+    (
+        SELECT
+            r.rolsuper OR r.oid = sa.usesysid
+        FROM
+            pg_roles AS r
+        WHERE
+            r.rolname = current_user()
+    )
+----
+project
+ ├── columns: PID:3(int) User:5(name) Database:2(name) "Backend start":10(timestamptz) Client:37(string) Application:6(string) Query:19(string) "Query start":12(timestamptz) "Xact start":11(timestamptz)
+ ├── inner-join-apply
+ │    ├── columns: datname:2(name) pid:3(int) usesysid:4(oid) username:5(name) application_name:6(string) client_addr:7(inet) client_hostname:8(string) client_port:9(int) backend_start:10(timestamptz) xact_start:11(timestamptz) query_start:12(timestamptz) query:19(string) "?column?":36(bool!null)
+ │    ├── scan pg_stat_activity
+ │    │    └── columns: datname:2(name) pid:3(int) usesysid:4(oid) username:5(name) application_name:6(string) client_addr:7(inet) client_hostname:8(string) client_port:9(int) backend_start:10(timestamptz) xact_start:11(timestamptz) query_start:12(timestamptz) query:19(string)
+ │    ├── select
+ │    │    ├── columns: "?column?":36(bool!null)
+ │    │    ├── outer: (4)
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(36)
+ │    │    ├── max1-row
+ │    │    │    ├── columns: "?column?":36(bool)
+ │    │    │    ├── outer: (4)
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(36)
+ │    │    │    └── project
+ │    │    │         ├── columns: "?column?":36(bool)
+ │    │    │         ├── outer: (4)
+ │    │    │         ├── select
+ │    │    │         │    ├── columns: oid:21(oid) rolname:22(name!null) rolsuper:23(bool)
+ │    │    │         │    ├── scan pg_roles
+ │    │    │         │    │    └── columns: oid:21(oid) rolname:22(name) rolsuper:23(bool)
+ │    │    │         │    └── filters [type=bool, outer=(22), constraints=(/22: (/NULL - ])]
+ │    │    │         │         └── pg_roles.rolname = current_user() [type=bool, outer=(22), constraints=(/22: (/NULL - ])]
+ │    │    │         └── projections [outer=(4,21,23)]
+ │    │    │              └── pg_roles.rolsuper OR (pg_roles.oid = pg_stat_activity.usesysid) [type=bool, outer=(4,21,23)]
+ │    │    └── filters [type=bool, outer=(36), constraints=(/36: [/true - /true]; tight), fd=()-->(36)]
+ │    │         └── variable: ?column? [type=bool, outer=(36), constraints=(/36: [/true - /true]; tight)]
+ │    └── true [type=bool]
+ └── projections [outer=(2,3,5-12,19)]
+      └── CASE WHEN (pg_stat_activity.client_hostname IS NOT NULL) AND (pg_stat_activity.client_hostname != '') THEN (pg_stat_activity.client_hostname || ':') || pg_stat_activity.client_port::STRING WHEN (pg_stat_activity.client_addr IS NOT NULL) AND (pg_stat_activity.client_addr::STRING != '') THEN (pg_stat_activity.client_addr::STRING || ':') || pg_stat_activity.client_port::STRING WHEN pg_stat_activity.client_port = -1 THEN 'local pipe' ELSE 'localhost:' || pg_stat_activity.client_port::STRING END [type=string, outer=(7-9)]

--- a/pkg/sql/opt/xform/testdata/external/pgjdbc
+++ b/pkg/sql/opt/xform/testdata/external/pgjdbc
@@ -1,0 +1,169 @@
+# Reconstructed from:
+# https://github.com/jordanlewis/pgjdbc/blob/462d505f01ec6180b30eaffabe51839dd126b90c/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java#L2391-L2408
+
+# For testing, create the schema for the builtin tables.
+exec-ddl
+CREATE TABLE pg_type (
+    oid OID NULL,
+    typname NAME NOT NULL,
+    typnamespace OID NULL,
+    typowner OID NULL,
+    typlen INT NULL,
+    typbyval BOOL NULL,
+    typtype STRING NULL,
+    typcategory STRING NULL,
+    typispreferred BOOL NULL,
+    typisdefined BOOL NULL,
+    typdelim STRING NULL,
+    typrelid OID NULL,
+    typelem OID NULL,
+    typarray OID NULL,
+    typinput OID NULL,
+    typoutput OID NULL,
+    typreceive OID NULL,
+    typsend OID NULL,
+    typmodin OID NULL,
+    typmodout OID NULL,
+    typanalyze OID NULL,
+    typalign STRING NULL,
+    typstorage STRING NULL,
+    typnotnull BOOL NULL,
+    typbasetype OID NULL,
+    typtypmod INT NULL,
+    typndims INT NULL,
+    typcollation OID NULL,
+    typdefaultbin STRING NULL,
+    typdefault STRING NULL,
+    typacl STRING[] NULL
+)
+----
+TABLE pg_type
+ ├── oid oid
+ ├── typname name not null
+ ├── typnamespace oid
+ ├── typowner oid
+ ├── typlen int
+ ├── typbyval bool
+ ├── typtype string
+ ├── typcategory string
+ ├── typispreferred bool
+ ├── typisdefined bool
+ ├── typdelim string
+ ├── typrelid oid
+ ├── typelem oid
+ ├── typarray oid
+ ├── typinput oid
+ ├── typoutput oid
+ ├── typreceive oid
+ ├── typsend oid
+ ├── typmodin oid
+ ├── typmodout oid
+ ├── typanalyze oid
+ ├── typalign string
+ ├── typstorage string
+ ├── typnotnull bool
+ ├── typbasetype oid
+ ├── typtypmod int
+ ├── typndims int
+ ├── typcollation oid
+ ├── typdefaultbin string
+ ├── typdefault string
+ ├── typacl string[]
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+exec-ddl
+CREATE TABLE pg_namespace (
+    oid OID NULL,
+    nspname NAME NOT NULL,
+    nspowner OID NULL,
+    nspacl STRING[] NULL
+)
+----
+TABLE pg_namespace
+ ├── oid oid
+ ├── nspname name not null
+ ├── nspowner oid
+ ├── nspacl string[]
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+opt
+SELECT
+    NULL AS type_cat,
+    n.nspname AS type_schem,
+    t.typname AS type_name,
+    NULL AS class_name,
+    CASE
+    WHEN t.typtype = 'c' THEN 'STRUCT'
+    ELSE 'DISTINCT'
+    END
+        AS data_type,
+    pg_catalog.obj_description(t.oid, 'pg_type') AS remarks,
+    CASE
+    WHEN t.typtype = 'd'
+    THEN (
+        SELECT
+            CASE
+            WHEN typname = 'pgType' THEN 'sqlType'
+            ELSE 'OTHER'
+            END
+        FROM
+            pg_type
+        WHERE
+            oid = t.typbasetype
+    )
+    ELSE NULL
+    END
+        AS base_type
+FROM
+    pg_type AS t, pg_namespace AS n
+WHERE
+    t.typnamespace = n.oid AND n.nspname != 'pg_catalog';
+----
+project
+ ├── columns: type_cat:38(unknown) type_schem:34(name!null) type_name:2(name!null) class_name:38(unknown) data_type:39(string) remarks:40(string) base_type:74(string)
+ ├── fd: ()-->(38)
+ ├── left-join-apply
+ │    ├── columns: pg_type.oid:1(oid) pg_type.typname:2(name!null) pg_type.typnamespace:3(oid!null) pg_type.typtype:7(string) pg_type.typbasetype:25(oid) pg_namespace.oid:33(oid!null) nspname:34(name!null) case:73(string)
+ │    ├── fd: (3)==(33), (33)==(3)
+ │    ├── inner-join
+ │    │    ├── columns: pg_type.oid:1(oid) pg_type.typname:2(name!null) pg_type.typnamespace:3(oid!null) pg_type.typtype:7(string) pg_type.typbasetype:25(oid) pg_namespace.oid:33(oid!null) nspname:34(name!null)
+ │    │    ├── fd: (3)==(33), (33)==(3)
+ │    │    ├── scan pg_type
+ │    │    │    └── columns: pg_type.oid:1(oid) pg_type.typname:2(name!null) pg_type.typnamespace:3(oid) pg_type.typtype:7(string) pg_type.typbasetype:25(oid)
+ │    │    ├── select
+ │    │    │    ├── columns: pg_namespace.oid:33(oid) nspname:34(name!null)
+ │    │    │    ├── scan pg_namespace
+ │    │    │    │    └── columns: pg_namespace.oid:33(oid) nspname:34(name!null)
+ │    │    │    └── filters [type=bool, outer=(34), constraints=(/34: (/NULL - /'pg_catalog') [/e'pg_catalog\x00' - ]; tight)]
+ │    │    │         └── pg_namespace.nspname != 'pg_catalog' [type=bool, outer=(34), constraints=(/34: (/NULL - /'pg_catalog') [/e'pg_catalog\x00' - ]; tight)]
+ │    │    └── filters [type=bool, outer=(3,33), constraints=(/3: (/NULL - ]; /33: (/NULL - ]), fd=(3)==(33), (33)==(3)]
+ │    │         └── pg_type.typnamespace = pg_namespace.oid [type=bool, outer=(3,33), constraints=(/3: (/NULL - ]; /33: (/NULL - ])]
+ │    ├── max1-row
+ │    │    ├── columns: case:73(string)
+ │    │    ├── outer: (25)
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(73)
+ │    │    └── project
+ │    │         ├── columns: case:73(string)
+ │    │         ├── outer: (25)
+ │    │         ├── select
+ │    │         │    ├── columns: pg_type.oid:41(oid!null) pg_type.typname:42(name!null)
+ │    │         │    ├── outer: (25)
+ │    │         │    ├── fd: ()-->(41)
+ │    │         │    ├── scan pg_type
+ │    │         │    │    └── columns: pg_type.oid:41(oid) pg_type.typname:42(name!null)
+ │    │         │    └── filters [type=bool, outer=(25,41), constraints=(/25: (/NULL - ]; /41: (/NULL - ]), fd=(25)==(41), (41)==(25)]
+ │    │         │         └── pg_type.oid = pg_type.typbasetype [type=bool, outer=(25,41), constraints=(/25: (/NULL - ]; /41: (/NULL - ])]
+ │    │         └── projections [outer=(42)]
+ │    │              └── CASE WHEN pg_type.typname = 'pgType' THEN 'sqlType' ELSE 'OTHER' END [type=string, outer=(42)]
+ │    └── true [type=bool]
+ └── projections [outer=(1,2,7,34,73)]
+      ├── null [type=unknown]
+      ├── CASE WHEN pg_type.typtype = 'c' THEN 'STRUCT' ELSE 'DISTINCT' END [type=string, outer=(7)]
+      ├── obj_description(pg_type.oid, 'pg_type') [type=string, outer=(1)]
+      └── CASE WHEN pg_type.typtype = 'd' THEN case END [type=string, outer=(7,73)]


### PR DESCRIPTION
This commit adds two queries from external sources - one from
pgAdmin and one from PGJDBC. These two queries are not currently
decorrelated successfully by the optimizer.

Release note: None