### PR TITLE
distsql: run last processor from main goroutine

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -226,8 +226,9 @@ func (dsp *DistSQLPlanner) Run(
 		recv.SetError(err)
 		return
 	}
+
 	// TODO(radu): this should go through the flow scheduler.
-	if err := flow.Start(ctx, func() {}); err != nil {
+	if err := flow.StartSync(ctx, func() {}); err != nil {
 		log.Fatalf(ctx, "unexpected error from syncFlow.Start(): %s "+
 			"The error should have gone to the consumer.", err)
 	}

--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -74,7 +74,7 @@ func runTestFlow(
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := flow.Start(ctx, func() {}); err != nil {
+	if err := flow.StartAsync(ctx, func() {}); err != nil {
 		t.Fatal(err)
 	}
 	flow.Wait()

--- a/pkg/sql/distsqlrun/flow_registry_test.go
+++ b/pkg/sql/distsqlrun/flow_registry_test.go
@@ -547,7 +547,7 @@ func TestSyncFlowAfterDrain(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := flow.Start(ctx, func() {}); err != nil {
+	if err := flow.StartAsync(ctx, func() {}); err != nil {
 		t.Fatal(err)
 	}
 	flow.Wait()

--- a/pkg/sql/distsqlrun/flow_scheduler.go
+++ b/pkg/sql/distsqlrun/flow_scheduler.go
@@ -97,7 +97,7 @@ func (fs *flowScheduler) runFlowNow(ctx context.Context, f *Flow) error {
 	)
 	fs.mu.numRunning++
 	fs.metrics.FlowStart()
-	if err := f.Start(ctx, func() { fs.flowDoneCh <- f }); err != nil {
+	if err := f.StartAsync(ctx, func() { fs.flowDoneCh <- f }); err != nil {
 		return err
 	}
 	// TODO(radu): we could replace the WaitGroup with a structure that keeps a

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -444,7 +444,7 @@ func (ds *ServerImpl) RunSyncFlow(stream DistSQL_RunSyncFlowServer) error {
 		defer ctxCancel()
 		mbox.start(ctx, &f.waitGroup, ctxCancel)
 		ds.Metrics.FlowStart()
-		if err := f.Start(ctx, func() {}); err != nil {
+		if err := f.StartSync(ctx, func() {}); err != nil {
 			log.Fatalf(ctx, "unexpected error from syncFlow.Start(): %s "+
 				"The error should have gone to the consumer.", err)
 		}


### PR DESCRIPTION
Closes #27734

This change improves distsql throughput for short-running queries by
removing some synchronization overhead. On a kv --read-percent=100
workload, this change resulted in a 25% throughput improvement (however note that these numbers vary a fair amount).

Release note (performance improvement): Improve fixed cost of running
distributed sql queries.

```
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
   60.0s        0         690447        11507.2      1.4      1.1      3.3      5.8    130.0
```

```
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
   60.0s        0         865636        14427.7      1.1      0.9      2.6      4.2     39.8
```