### PR TITLE
importccl: unskip MysqlOutfile test

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1952,8 +1952,6 @@ func TestImportMysql(t *testing.T) {
 func TestImportMysqlOutfile(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("#25835")
-
 	const (
 		nodes = 3
 	)


### PR DESCRIPTION
It was skipped as part of the commit in #25835, but I'm not sure why it
was added there. In any case it seems to pass now.

Release note: None