### PR TITLE
opt: support testing only normalizations

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/ordinality
+++ b/pkg/sql/opt/memo/testdata/stats/ordinality
@@ -24,7 +24,7 @@ ALTER TABLE a INJECT STATISTICS '[
 ]'
 ----
 
-build
+norm
 SELECT * FROM (SELECT * FROM a WITH ORDINALITY) WHERE ordinality > 0 AND ordinality <= 10
 ----
 select
@@ -43,15 +43,14 @@ select
  │         ├── key: (1)
  │         └── fd: (1)-->(2)
  └── filters [type=bool, outer=(3), constraints=(/3: [/1 - /10]; tight)]
-      └── and [type=bool, outer=(3), constraints=(/3: [/1 - /10]; tight)]
-           ├── gt [type=bool, outer=(3), constraints=(/3: [/1 - ]; tight)]
-           │    ├── variable: ordinality [type=int, outer=(3)]
-           │    └── const: 0 [type=int]
-           └── le [type=bool, outer=(3), constraints=(/3: (/NULL - /10]; tight)]
-                ├── variable: ordinality [type=int, outer=(3)]
-                └── const: 10 [type=int]
+      ├── gt [type=bool, outer=(3), constraints=(/3: [/1 - ]; tight)]
+      │    ├── variable: ordinality [type=int, outer=(3)]
+      │    └── const: 0 [type=int]
+      └── le [type=bool, outer=(3), constraints=(/3: (/NULL - /10]; tight)]
+           ├── variable: ordinality [type=int, outer=(3)]
+           └── const: 10 [type=int]
 
-build
+norm
 SELECT * FROM (SELECT * FROM a WITH ORDINALITY) WHERE y > 0 AND y <= 10
 ----
 select
@@ -70,15 +69,14 @@ select
  │         ├── key: (1)
  │         └── fd: (1)-->(2)
  └── filters [type=bool, outer=(2), constraints=(/2: [/1 - /10]; tight)]
-      └── and [type=bool, outer=(2), constraints=(/2: [/1 - /10]; tight)]
-           ├── gt [type=bool, outer=(2), constraints=(/2: [/1 - ]; tight)]
-           │    ├── variable: a.y [type=int, outer=(2)]
-           │    └── const: 0 [type=int]
-           └── le [type=bool, outer=(2), constraints=(/2: (/NULL - /10]; tight)]
-                ├── variable: a.y [type=int, outer=(2)]
-                └── const: 10 [type=int]
+      ├── gt [type=bool, outer=(2), constraints=(/2: [/1 - ]; tight)]
+      │    ├── variable: a.y [type=int, outer=(2)]
+      │    └── const: 0 [type=int]
+      └── le [type=bool, outer=(2), constraints=(/2: (/NULL - /10]; tight)]
+           ├── variable: a.y [type=int, outer=(2)]
+           └── const: 10 [type=int]
 
-build
+norm
 SELECT 1 x FROM a WITH ORDINALITY
 ----
 project
@@ -86,19 +84,15 @@ project
  ├── stats: [rows=4000]
  ├── fd: ()-->(4)
  ├── row-number
- │    ├── columns: a.x:1(int!null) y:2(int) ordinality:3(int!null)
+ │    ├── columns: ordinality:3(int!null)
  │    ├── stats: [rows=4000]
- │    ├── key: (1)
- │    ├── fd: (1)-->(2,3), (3)-->(1,2)
+ │    ├── key: (3)
  │    └── scan a
- │         ├── columns: a.x:1(int!null) y:2(int)
- │         ├── stats: [rows=4000]
- │         ├── key: (1)
- │         └── fd: (1)-->(2)
+ │         └── stats: [rows=4000]
  └── projections
       └── const: 1 [type=int]
 
-build
+norm
 SELECT x FROM (SELECT * FROM a WITH ORDINALITY) WHERE ordinality > 0 AND ordinality <= 10
 ----
 project
@@ -106,31 +100,29 @@ project
  ├── stats: [rows=10]
  ├── key: (1)
  └── select
-      ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)
+      ├── columns: x:1(int!null) ordinality:3(int!null)
       ├── stats: [rows=10, distinct(3)=10]
       ├── key: (1)
-      ├── fd: (1)-->(2,3), (3)-->(1,2)
+      ├── fd: (1)-->(3), (3)-->(1)
       ├── row-number
-      │    ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)
+      │    ├── columns: x:1(int!null) ordinality:3(int!null)
       │    ├── stats: [rows=4000, distinct(3)=4000]
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2,3), (3)-->(1,2)
+      │    ├── fd: (1)-->(3), (3)-->(1)
       │    └── scan a
-      │         ├── columns: x:1(int!null) y:2(int)
+      │         ├── columns: x:1(int!null)
       │         ├── stats: [rows=4000]
-      │         ├── key: (1)
-      │         └── fd: (1)-->(2)
+      │         └── key: (1)
       └── filters [type=bool, outer=(3), constraints=(/3: [/1 - /10]; tight)]
-           └── and [type=bool, outer=(3), constraints=(/3: [/1 - /10]; tight)]
-                ├── gt [type=bool, outer=(3), constraints=(/3: [/1 - ]; tight)]
-                │    ├── variable: ordinality [type=int, outer=(3)]
-                │    └── const: 0 [type=int]
-                └── le [type=bool, outer=(3), constraints=(/3: (/NULL - /10]; tight)]
-                     ├── variable: ordinality [type=int, outer=(3)]
-                     └── const: 10 [type=int]
+           ├── gt [type=bool, outer=(3), constraints=(/3: [/1 - ]; tight)]
+           │    ├── variable: ordinality [type=int, outer=(3)]
+           │    └── const: 0 [type=int]
+           └── le [type=bool, outer=(3), constraints=(/3: (/NULL - /10]; tight)]
+                ├── variable: ordinality [type=int, outer=(3)]
+                └── const: 10 [type=int]
 
 
-build
+norm
 SELECT * FROM (SELECT * FROM a WITH ORDINALITY) WHERE ordinality = 2
 ----
 select

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -58,7 +58,7 @@ ALTER TABLE b INJECT STATISTICS '[
 ----
 
 # Distinct values calculation with constraints.
-build
+norm
 SELECT * FROM b WHERE x = 1 AND z = 2 AND rowid >= 5 AND rowid <= 8
 ----
 project
@@ -76,24 +76,21 @@ project
       │    ├── key: (3)
       │    └── fd: (3)-->(1,2)
       └── filters [type=bool, outer=(1-3), constraints=(/1: [/1 - /1]; /2: [/2 - /2]; /3: [/5 - /8]; tight), fd=()-->(1,2)]
-           └── and [type=bool, outer=(1-3), constraints=(/1: [/1 - /1]; /2: [/2 - /2]; /3: [/5 - /8]; tight)]
-                ├── and [type=bool, outer=(1-3), constraints=(/1: [/1 - /1]; /2: [/2 - /2]; /3: [/5 - ]; tight)]
-                │    ├── and [type=bool, outer=(1,2), constraints=(/1: [/1 - /1]; /2: [/2 - /2]; tight)]
-                │    │    ├── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
-                │    │    │    ├── variable: b.x [type=int, outer=(1)]
-                │    │    │    └── const: 1 [type=int]
-                │    │    └── eq [type=bool, outer=(2), constraints=(/2: [/2 - /2]; tight)]
-                │    │         ├── variable: b.z [type=int, outer=(2)]
-                │    │         └── const: 2 [type=int]
-                │    └── ge [type=bool, outer=(3), constraints=(/3: [/5 - ]; tight)]
-                │         ├── variable: b.rowid [type=int, outer=(3)]
-                │         └── const: 5 [type=int]
-                └── le [type=bool, outer=(3), constraints=(/3: (/NULL - /8]; tight)]
-                     ├── variable: b.rowid [type=int, outer=(3)]
-                     └── const: 8 [type=int]
+           ├── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
+           │    ├── variable: b.x [type=int, outer=(1)]
+           │    └── const: 1 [type=int]
+           ├── eq [type=bool, outer=(2), constraints=(/2: [/2 - /2]; tight)]
+           │    ├── variable: b.z [type=int, outer=(2)]
+           │    └── const: 2 [type=int]
+           ├── ge [type=bool, outer=(3), constraints=(/3: [/5 - ]; tight)]
+           │    ├── variable: b.rowid [type=int, outer=(3)]
+           │    └── const: 5 [type=int]
+           └── le [type=bool, outer=(3), constraints=(/3: (/NULL - /8]; tight)]
+                ├── variable: b.rowid [type=int, outer=(3)]
+                └── const: 8 [type=int]
 
 # Can't determine stats from filter.
-build
+norm
 SELECT * FROM a WHERE x + y < 10
 ----
 select
@@ -114,12 +111,12 @@ select
            └── const: 10 [type=int]
 
 # Remaining filter.
-build
+norm
 SELECT * FROM a WHERE y = 5 AND x + y < 10
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null)
- ├── stats: [rows=10, distinct(2)=1]
+ ├── stats: [rows=3.33333333, distinct(2)=1]
  ├── key: (1)
  ├── fd: ()-->(2)
  ├── scan a
@@ -128,18 +125,17 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters [type=bool, outer=(1,2), constraints=(/2: [/5 - /5]), fd=()-->(2)]
-      └── and [type=bool, outer=(1,2), constraints=(/2: [/5 - /5])]
-           ├── eq [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
-           │    ├── variable: a.y [type=int, outer=(2)]
-           │    └── const: 5 [type=int]
-           └── lt [type=bool, outer=(1,2)]
-                ├── plus [type=int, outer=(1,2)]
-                │    ├── variable: a.x [type=int, outer=(1)]
-                │    └── variable: a.y [type=int, outer=(2)]
-                └── const: 10 [type=int]
+      ├── eq [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
+      │    ├── variable: a.y [type=int, outer=(2)]
+      │    └── const: 5 [type=int]
+      └── lt [type=bool, outer=(1,2)]
+           ├── plus [type=int, outer=(1,2)]
+           │    ├── variable: a.x [type=int, outer=(1)]
+           │    └── variable: a.y [type=int, outer=(2)]
+           └── const: 10 [type=int]
 
 # Contradiction.
-build
+norm
 SELECT * FROM a WHERE x > 5 AND x < 0
 ----
 select
@@ -153,15 +149,14 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters [type=bool, outer=(1), constraints=(contradiction; tight)]
-      └── and [type=bool, outer=(1), constraints=(contradiction; tight)]
-           ├── gt [type=bool, outer=(1), constraints=(/1: [/6 - ]; tight)]
-           │    ├── variable: a.x [type=int, outer=(1)]
-           │    └── const: 5 [type=int]
-           └── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /-1]; tight)]
-                ├── variable: a.x [type=int, outer=(1)]
-                └── const: 0 [type=int]
+      ├── gt [type=bool, outer=(1), constraints=(/1: [/6 - ]; tight)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── const: 5 [type=int]
+      └── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /-1]; tight)]
+           ├── variable: a.x [type=int, outer=(1)]
+           └── const: 0 [type=int]
 
-build
+norm
 SELECT sum(x) FROM b WHERE x > 1000 AND x <= 2000 GROUP BY z
 ----
 project
@@ -173,27 +168,19 @@ project
       ├── stats: [rows=100, distinct(2)=100]
       ├── key: (2)
       ├── fd: (2)-->(4)
-      ├── project
+      ├── select
       │    ├── columns: x:1(int!null) z:2(int!null)
-      │    ├── stats: [rows=2000, distinct(2)=100]
-      │    └── select
-      │         ├── columns: x:1(int!null) z:2(int!null) rowid:3(int!null)
-      │         ├── stats: [rows=2000, distinct(1)=1000, distinct(2)=100]
-      │         ├── key: (3)
-      │         ├── fd: (3)-->(1,2)
-      │         ├── scan b
-      │         │    ├── columns: x:1(int) z:2(int!null) rowid:3(int!null)
-      │         │    ├── stats: [rows=10000, distinct(1)=5000, distinct(2)=100]
-      │         │    ├── key: (3)
-      │         │    └── fd: (3)-->(1,2)
-      │         └── filters [type=bool, outer=(1), constraints=(/1: [/1001 - /2000]; tight)]
-      │              └── and [type=bool, outer=(1), constraints=(/1: [/1001 - /2000]; tight)]
-      │                   ├── gt [type=bool, outer=(1), constraints=(/1: [/1001 - ]; tight)]
-      │                   │    ├── variable: b.x [type=int, outer=(1)]
-      │                   │    └── const: 1000 [type=int]
-      │                   └── le [type=bool, outer=(1), constraints=(/1: (/NULL - /2000]; tight)]
-      │                        ├── variable: b.x [type=int, outer=(1)]
-      │                        └── const: 2000 [type=int]
+      │    ├── stats: [rows=2000, distinct(1)=1000, distinct(2)=100]
+      │    ├── scan b
+      │    │    ├── columns: x:1(int) z:2(int!null)
+      │    │    └── stats: [rows=10000, distinct(1)=5000, distinct(2)=100]
+      │    └── filters [type=bool, outer=(1), constraints=(/1: [/1001 - /2000]; tight)]
+      │         ├── gt [type=bool, outer=(1), constraints=(/1: [/1001 - ]; tight)]
+      │         │    ├── variable: b.x [type=int, outer=(1)]
+      │         │    └── const: 1000 [type=int]
+      │         └── le [type=bool, outer=(1), constraints=(/1: (/NULL - /2000]; tight)]
+      │              ├── variable: b.x [type=int, outer=(1)]
+      │              └── const: 2000 [type=int]
       └── aggregations [outer=(1)]
            └── sum [type=decimal, outer=(1)]
                 └── variable: b.x [type=int, outer=(1)]

--- a/pkg/sql/opt/memo/testdata/stats/values
+++ b/pkg/sql/opt/memo/testdata/stats/values
@@ -1,4 +1,4 @@
-build
+norm
 SELECT * FROM (VALUES (1, 2), (1, 2), (1, 3), (2, 3)) AS q(x, y) WHERE x = 5 AND y = 3
 ----
 select
@@ -23,15 +23,14 @@ select
  │         ├── const: 2 [type=int]
  │         └── const: 3 [type=int]
  └── filters [type=bool, outer=(1,2), constraints=(/1: [/5 - /5]; /2: [/3 - /3]; tight), fd=()-->(1,2)]
-      └── and [type=bool, outer=(1,2), constraints=(/1: [/5 - /5]; /2: [/3 - /3]; tight)]
-           ├── eq [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight)]
-           │    ├── variable: column1 [type=int, outer=(1)]
-           │    └── const: 5 [type=int]
-           └── eq [type=bool, outer=(2), constraints=(/2: [/3 - /3]; tight)]
-                ├── variable: column2 [type=int, outer=(2)]
-                └── const: 3 [type=int]
+      ├── eq [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight)]
+      │    ├── variable: column1 [type=int, outer=(1)]
+      │    └── const: 5 [type=int]
+      └── eq [type=bool, outer=(2), constraints=(/2: [/3 - /3]; tight)]
+           ├── variable: column2 [type=int, outer=(2)]
+           └── const: 3 [type=int]
 
-build
+norm
 SELECT x, y FROM (VALUES (1, 2), (1, 2), (1, 3), (2, 3)) AS q(x, y) GROUP BY x, y
 ----
 group-by
@@ -57,7 +56,7 @@ group-by
            ├── const: 2 [type=int]
            └── const: 3 [type=int]
 
-build
+norm
 SELECT * FROM (VALUES (1), (1), (1), (2))
 ----
 values
@@ -73,7 +72,7 @@ values
  └── tuple [type=tuple{int}]
       └── const: 2 [type=int]
 
-build
+norm
 SELECT * FROM (VALUES (1), (1), (1), (2)) AS q(x) WHERE x = 1
 ----
 select

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -110,6 +110,13 @@ func (o *Optimizer) DisableOptimizations() {
 	o.NotifyOnMatchedRule(func(opt.RuleName) bool { return false })
 }
 
+// DisableExplorations disables all explore rules. The normalized expression
+// tree becomes the output expression tree (because no explore transforms are
+// applied).
+func (o *Optimizer) DisableExplorations() {
+	o.NotifyOnMatchedRule(func(ruleName opt.RuleName) bool { return ruleName.IsNormalize() })
+}
+
 // NotifyOnMatchedRule sets a callback function which is invoked each time an
 // optimization rule (Normalize or Explore) has been matched by the optimizer.
 // If matchedRule is nil, then no notifications are sent, and all rules are


### PR DESCRIPTION
This commit adds a new test directive, "norm", to the opt tester.
"norm" can be used to enable normalization transformations only,
excluding exploration transformations. This test directive is useful
for testing statistics, since the selectivity code relies on the
filter being normalized for Select and Join operations.

Release note: None