### PR TITLE
opt: support AS OF SYSTEM TIME

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1800,6 +1800,7 @@ func (ex *connExecutor) resetPlanner(
 	p.semaCtx = tree.MakeSemaContext(ex.sessionData.User == security.RootUser)
 	p.semaCtx.Location = &ex.sessionData.Location
 	p.semaCtx.SearchPath = ex.sessionData.SearchPath
+	p.semaCtx.AsOfTimestamp = nil
 
 	p.extendedEvalCtx = ex.evalCtx(ctx, p, stmtTS)
 	p.extendedEvalCtx.ClusterID = ex.server.cfg.ClusterID()
@@ -1810,7 +1811,6 @@ func (ex *connExecutor) resetPlanner(
 	p.preparedStatements = ex.getPrepStmtsAccessor()
 	p.autoCommit = false
 	p.isPreparing = false
-	p.asOfSystemTime = false
 	p.avoidCachedDescriptors = false
 }
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -340,7 +340,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			return makeErrEvent(err)
 		}
 		if ts != nil {
-			p.asOfSystemTime = true
+			p.semaCtx.AsOfTimestamp = ts
 			p.avoidCachedDescriptors = true
 			ex.state.mu.txn.SetFixedTimestamp(ctx, *ts)
 		}
@@ -359,7 +359,7 @@ func (ex *connExecutor) execStmtInOpenState(
 					"Generally \"as of system time\" cannot be used inside a transaction.",
 					ex.state.mu.txn.OrigTimestamp()))
 			}
-			p.asOfSystemTime = true
+			p.semaCtx.AsOfTimestamp = ts
 			p.avoidCachedDescriptors = true
 		}
 	}

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -193,7 +193,7 @@ func (ex *connExecutor) prepare(
 			return err
 		}
 		if protoTS != nil {
-			p.asOfSystemTime = true
+			p.semaCtx.AsOfTimestamp = protoTS
 			// We can't use cached descriptors anywhere in this query, because
 			// we want the descriptors at the timestamp given, not the latest
 			// known to the cache.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"reflect"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -616,112 +615,16 @@ func checkResultType(typ types.T) error {
 func (p *planner) EvalAsOfTimestamp(
 	asOf tree.AsOfClause, max hlc.Timestamp,
 ) (hlc.Timestamp, error) {
-	// We need to save and restore the previous value of the field in
-	// semaCtx in case we are recursively called within a subquery
-	// context.
-	scalarProps := &p.semaCtx.Properties
-	defer scalarProps.Restore(*scalarProps)
-	scalarProps.Require("AS OF SYSTEM TIME", tree.RejectSpecial|tree.RejectSubqueries)
-
-	te, err := asOf.Expr.TypeCheck(&p.semaCtx, types.String)
-	if err != nil {
-		return hlc.Timestamp{}, err
-	}
-	evalCtx := p.EvalContext()
-	if !tree.IsConst(evalCtx, te) {
-		return hlc.Timestamp{}, errors.Errorf("AS OF SYSTEM TIME: only constant expressions are allowed")
-	}
-	d, err := te.Eval(evalCtx)
-	if err != nil {
-		return hlc.Timestamp{}, err
-	}
-
-	var ts hlc.Timestamp
-	var convErr error
-
-	switch d := d.(type) {
-	case *tree.DString:
-		s := string(*d)
-		// Allow nanosecond precision because the timestamp is only used by the
-		// system and won't be returned to the user over pgwire.
-		if dt, err := tree.ParseDTimestamp(s, time.Nanosecond); err == nil {
-			ts.WallTime = dt.Time.UnixNano()
-			break
-		}
-		// Attempt to parse as a decimal.
-		if dec, _, err := apd.NewFromString(s); err == nil {
-			ts, convErr = decimalToHLC(dec)
-			break
-		}
-		// Attempt to parse as an interval.
-		if iv, err := tree.ParseDInterval(s); err == nil {
-			ts.WallTime = duration.Add(evalCtx.GetStmtTimestamp(), iv.Duration).UnixNano()
-			break
-		}
-		convErr = errors.Errorf("AS OF SYSTEM TIME: value is neither timestamp, decimal, nor interval")
-	case *tree.DInt:
-		ts.WallTime = int64(*d)
-	case *tree.DDecimal:
-		ts, convErr = decimalToHLC(&d.Decimal)
-	case *tree.DInterval:
-		ts.WallTime = duration.Add(evalCtx.GetStmtTimestamp(), d.Duration).UnixNano()
-	default:
-		convErr = errors.Errorf("AS OF SYSTEM TIME: expected timestamp, decimal, or interval, got %s (%T)", d.ResolvedType(), d)
-	}
-	if convErr != nil {
-		return ts, convErr
-	}
-
-	var zero hlc.Timestamp
-	if ts == zero {
-		return ts, errors.Errorf("AS OF SYSTEM TIME: zero timestamp is invalid")
-	} else if max.Less(ts) {
-		return ts, errors.Errorf("AS OF SYSTEM TIME: cannot specify timestamp in the future")
-	}
-	return ts, nil
+	return tree.EvalAsOfTimestamp(asOf, max, &p.semaCtx, p.EvalContext())
 }
 
-// ParseHLC parses the string representation of an `hlc.Timestamp` that is
-// accepted by `AS OF SYSTEM TIME`.
+// ParseHLC parses a string representation of an `hlc.Timestamp`.
 func ParseHLC(s string) (hlc.Timestamp, error) {
 	dec, _, err := apd.NewFromString(s)
 	if err != nil {
 		return hlc.Timestamp{}, err
 	}
-	return decimalToHLC(dec)
-}
-
-func decimalToHLC(d *apd.Decimal) (hlc.Timestamp, error) {
-	// Format the decimal into a string and split on `.` to extract the nanosecond
-	// walltime and logical tick parts.
-	// TODO(mjibson): use d.Modf() instead of converting to a string.
-	s := d.Text('f')
-	parts := strings.SplitN(s, ".", 2)
-	nanos, err := strconv.ParseInt(parts[0], 10, 64)
-	if err != nil {
-		return hlc.Timestamp{}, errors.Wrap(err, "AS OF SYSTEM TIME: parsing argument")
-	}
-	var logical int64
-	if len(parts) > 1 {
-		// logicalLength is the number of decimal digits expected in the
-		// logical part to the right of the decimal. See the implementation of
-		// cluster_logical_timestamp().
-		const logicalLength = 10
-		p := parts[1]
-		if lp := len(p); lp > logicalLength {
-			return hlc.Timestamp{}, errors.Errorf("AS OF SYSTEM TIME: logical part has too many digits")
-		} else if lp < logicalLength {
-			p += strings.Repeat("0", logicalLength-lp)
-		}
-		logical, err = strconv.ParseInt(p, 10, 32)
-		if err != nil {
-			return hlc.Timestamp{}, errors.Wrap(err, "AS OF SYSTEM TIME: parsing argument")
-		}
-	}
-	return hlc.Timestamp{
-		WallTime: nanos,
-		Logical:  int32(logical),
-	}, nil
+	return tree.DecimalToHLC(dec)
 }
 
 // isAsOf analyzes a statement to bypass the logic in newPlan(), since

--- a/pkg/sql/logictest/testdata/logic_test/subquery_correlated
+++ b/pkg/sql/logictest/testdata/logic_test/subquery_correlated
@@ -733,7 +733,7 @@ FROM c
 INNER JOIN o
 ON c.c_id=o.c_id AND o.ship = (SELECT o.ship FROM o WHERE o.c_id=c.c_id);
 
-statement error HINT: some correlated subqueries are not supported yet
+statement error AS OF SYSTEM TIME must be provided on a top-level statement
 SELECT (SELECT c_id FROM o AS OF SYSTEM TIME '-0ns')
 FROM c
 WHERE EXISTS(SELECT * FROM o WHERE o.c_id=c.c_id)

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -22,6 +22,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/pkg/errors"
 )
 
 // buildTable builds a set of memo groups that represent the given table
@@ -314,8 +316,12 @@ func (b *Builder) buildSelectClause(
 // See Builder.buildStmt for a description of the remaining input and
 // return values.
 func (b *Builder) buildFrom(from *tree.From, where *tree.Where, inScope *scope) (outScope *scope) {
+	// The root AS OF clause is recognized and handled by the executor. The only
+	// thing that must be done at this point is to ensure that if any timestamps
+	// are specified, the root SELECT was an AS OF SYSTEM TIME and that the time
+	// specified matches the one found at the root.
 	if from.AsOf.Expr != nil {
-		panic(unimplementedf("AS OF clause not supported"))
+		b.validateAsOf(from.AsOf)
 	}
 
 	var joinTables map[string]struct{}
@@ -375,4 +381,21 @@ func (b *Builder) buildFrom(from *tree.From, where *tree.Where, inScope *scope) 
 	}
 
 	return outScope
+}
+
+// validateAsOf ensures that any AS OF SYSTEM TIME timestamp is consistent with
+// that of the root statement.
+func (b *Builder) validateAsOf(asOf tree.AsOfClause) {
+	ts, err := tree.EvalAsOfTimestamp(asOf, hlc.MaxTimestamp, b.semaCtx, b.evalCtx)
+	if err != nil {
+		panic(builderError{err})
+	}
+
+	if b.semaCtx.AsOfTimestamp == nil {
+		panic(builderError{errors.Errorf("AS OF SYSTEM TIME must be provided on a top-level statement")})
+	}
+
+	if *b.semaCtx.AsOfTimestamp != ts {
+		panic(builderError{errors.Errorf("cannot specify AS OF SYSTEM TIME with different timestamps")})
+	}
 }

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1050,10 +1050,12 @@ select
            ├── variable: a.x [type=int]
            └── placeholder: $1 [type=int]
 
+# This is slightly funky, because the AS OF SYSTEM TIME timestamp only gets
+# interpreted by the executor, which obviously is not at play in these tests.
 build
 SELECT * FROM a AS OF SYSTEM TIME '10ns'
 ----
-error (0A000): AS OF clause not supported
+error: AS OF SYSTEM TIME must be provided on a top-level statement
 
 build
 SELECT * FROM a AS t(a, b, c)

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -108,16 +108,6 @@ type planner struct {
 	// statsCollector is used to collect statistics about SQL statement execution.
 	statsCollector sqlStatsCollector
 
-	// asOfSystemTime indicates whether the transaction timestamp was
-	// forced to a specific value (in which case that value is stored in
-	// txn.mu.Proto.OrigTimestamp). If set, avoidCachedDescriptors below
-	// must also be set.
-	// TODO(anyone): we may want to support table readers at arbitrary
-	// timestamps, so that each FROM clause can have its own
-	// timestamp. In that case, the timestamp would not be set
-	// globally for the entire txn and this field would not be needed.
-	asOfSystemTime bool
-
 	// avoidCachedDescriptors, when true, instructs all code that
 	// accesses table/view descriptors to force reading the descriptors
 	// within the transaction. This is necessary to:

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -472,7 +472,7 @@ func (p *planner) getTimestamp(asOf tree.AsOfClause) (hlc.Timestamp, bool, error
 		// table readers at arbitrary timestamps, and each FROM clause
 		// can have its own timestamp. In that case, the timestamp
 		// would not be set globally for the entire txn.
-		if !p.asOfSystemTime {
+		if p.semaCtx.AsOfTimestamp == nil {
 			return hlc.MaxTimestamp, false,
 				fmt.Errorf("AS OF SYSTEM TIME must be provided on a top-level statement")
 		}
@@ -485,7 +485,7 @@ func (p *planner) getTimestamp(asOf tree.AsOfClause) (hlc.Timestamp, bool, error
 		if err != nil {
 			return hlc.MaxTimestamp, false, err
 		}
-		if ts != p.txn.OrigTimestamp() {
+		if ts != *p.semaCtx.AsOfTimestamp {
 			return hlc.MaxTimestamp, false,
 				fmt.Errorf("cannot specify AS OF SYSTEM TIME with different timestamps")
 		}

--- a/pkg/sql/sem/tree/as_of.go
+++ b/pkg/sql/sem/tree/as_of.go
@@ -1,0 +1,130 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tree
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/pkg/errors"
+)
+
+// EvalAsOfTimestamp evaluates the timestamp argument to an AS OF SYSTEM TIME query.
+func EvalAsOfTimestamp(
+	asOf AsOfClause, max hlc.Timestamp, semaCtx *SemaContext, evalCtx *EvalContext,
+) (hlc.Timestamp, error) {
+	// We need to save and restore the previous value of the field in
+	// semaCtx in case we are recursively called within a subquery
+	// context.
+	scalarProps := &semaCtx.Properties
+	defer scalarProps.Restore(*scalarProps)
+	scalarProps.Require("AS OF SYSTEM TIME", RejectSpecial|RejectSubqueries)
+
+	te, err := asOf.Expr.TypeCheck(semaCtx, types.String)
+	if err != nil {
+		return hlc.Timestamp{}, err
+	}
+	if !IsConst(evalCtx, te) {
+		return hlc.Timestamp{}, errors.Errorf("AS OF SYSTEM TIME: only constant expressions are allowed")
+	}
+	d, err := te.Eval(evalCtx)
+	if err != nil {
+		return hlc.Timestamp{}, err
+	}
+
+	var ts hlc.Timestamp
+	var convErr error
+
+	switch d := d.(type) {
+	case *DString:
+		s := string(*d)
+		// Allow nanosecond precision because the timestamp is only used by the
+		// system and won't be returned to the user over pgwire.
+		if dt, err := ParseDTimestamp(s, time.Nanosecond); err == nil {
+			ts.WallTime = dt.Time.UnixNano()
+			break
+		}
+		// Attempt to parse as a decimal.
+		if dec, _, err := apd.NewFromString(s); err == nil {
+			ts, convErr = DecimalToHLC(dec)
+			break
+		}
+		// Attempt to parse as an interval.
+		if iv, err := ParseDInterval(s); err == nil {
+			ts.WallTime = duration.Add(evalCtx.GetStmtTimestamp(), iv.Duration).UnixNano()
+			break
+		}
+		convErr = errors.Errorf("AS OF SYSTEM TIME: value is neither timestamp, decimal, nor interval")
+	case *DInt:
+		ts.WallTime = int64(*d)
+	case *DDecimal:
+		ts, convErr = DecimalToHLC(&d.Decimal)
+	case *DInterval:
+		ts.WallTime = duration.Add(evalCtx.GetStmtTimestamp(), d.Duration).UnixNano()
+	default:
+		convErr = errors.Errorf("AS OF SYSTEM TIME: expected timestamp, decimal, or interval, got %s (%T)", d.ResolvedType(), d)
+	}
+	if convErr != nil {
+		return ts, convErr
+	}
+
+	var zero hlc.Timestamp
+	if ts == zero {
+		return ts, errors.Errorf("AS OF SYSTEM TIME: zero timestamp is invalid")
+	} else if max.Less(ts) {
+		return ts, errors.Errorf("AS OF SYSTEM TIME: cannot specify timestamp in the future")
+	}
+	return ts, nil
+}
+
+// DecimalToHLC performs the conversion from an inputted DECIMAL datum for an
+// AS OF SYSTEM TIME query to an HLC timestamp.
+func DecimalToHLC(d *apd.Decimal) (hlc.Timestamp, error) {
+	// Format the decimal into a string and split on `.` to extract the nanosecond
+	// walltime and logical tick parts.
+	// TODO(mjibson): use d.Modf() instead of converting to a string.
+	s := d.Text('f')
+	parts := strings.SplitN(s, ".", 2)
+	nanos, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return hlc.Timestamp{}, errors.Wrap(err, "AS OF SYSTEM TIME: parsing argument")
+	}
+	var logical int64
+	if len(parts) > 1 {
+		// logicalLength is the number of decimal digits expected in the
+		// logical part to the right of the decimal. See the implementation of
+		// cluster_logical_timestamp().
+		const logicalLength = 10
+		p := parts[1]
+		if lp := len(p); lp > logicalLength {
+			return hlc.Timestamp{}, errors.Errorf("AS OF SYSTEM TIME: logical part has too many digits")
+		} else if lp < logicalLength {
+			p += strings.Repeat("0", logicalLength-lp)
+		}
+		logical, err = strconv.ParseInt(p, 10, 32)
+		if err != nil {
+			return hlc.Timestamp{}, errors.Wrap(err, "AS OF SYSTEM TIME: parsing argument")
+		}
+	}
+	return hlc.Timestamp{
+		WallTime: nanos,
+		Logical:  int32(logical),
+	}, nil
+}

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
 // SemaContext defines the context in which to perform semantic analysis on an
@@ -51,6 +52,15 @@ type SemaContext struct {
 	// the root user.
 	// TODO(knz): this attribute can be moved to EvalContext pending #15363.
 	privileged bool
+
+	// AsOfTimestamp denotes the explicit AS OF SYSTEM TIME timestamp for the
+	// query, if any. If the query is not an AS OF SYSTEM TIME query,
+	// AsOfTimestamp is nil.
+	// TODO(knz): we may want to support table readers at arbitrary
+	// timestamps, so that each FROM clause can have its own
+	// timestamp. In that case, the timestamp would not be set
+	// globally for the entire txn and this field would not be needed.
+	AsOfTimestamp *hlc.Timestamp
 
 	Properties SemaProperties
 }

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -153,7 +153,7 @@ func (n *showFingerprintsNode) Next(params runParams) (bool, error) {
 	// If were'in in an AOST context, propagate it to the inner statement so that
 	// the inner statement gets planned with planner.avoidCachedDescriptors set,
 	// like the outter one.
-	if params.p.asOfSystemTime {
+	if params.p.semaCtx.AsOfTimestamp != nil {
 		ts := params.p.txn.OrigTimestamp()
 		sql = sql + " AS OF SYSTEM TIME " + ts.AsOfSystemTime()
 	}


### PR DESCRIPTION
This change supports AS OF SYSTEM TIME in the optimizer. The bulk of
this functionality is provided by the executor, the only task that falls
on the opt package is guaranteeing that any timestamps specified for a
subquery are consistent with that of the root query.

To this end, this commit removes the `asOfSystemTime` flag on `planner`
and replaces it with a timestamp field in the SemaContext struct, as the
timestamp does dictate the semantic validity of the query.

It also migrates the functionality of interpreting the timestamp from
the sql package to the tree package in order to be able to use it in
opt.

Release note: None