### PR TITLE
roachtest: mark cdc test as v2.1+ only

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -183,17 +183,19 @@ func registerCDC(r *registry) {
 	}
 
 	r.Add(testSpec{
-		Name:   "cdc/w=1000/nodes=3/init=false",
-		Nodes:  nodes(4, cpu(16)),
-		Stable: false,
+		Name:       "cdc/w=1000/nodes=3/init=false",
+		MinVersion: "2.1.0",
+		Nodes:      nodes(4, cpu(16)),
+		Stable:     false,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCDC(ctx, t, c, 1000, false /* initialScan */)
 		},
 	})
 	r.Add(testSpec{
-		Name:   "cdc/w=100/nodes=3/init=true",
-		Nodes:  nodes(4, cpu(16)),
-		Stable: false,
+		Name:       "cdc/w=100/nodes=3/init=true",
+		MinVersion: "2.1.0",
+		Nodes:      nodes(4, cpu(16)),
+		Stable:     false,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCDC(ctx, t, c, 100, true /* initialScan */)
 		},


### PR DESCRIPTION
CDC was introduced in the v2.1 cycle, so don't run the test against
v2.0.

Fixes #27146.

Release note: None