### PR TITLE
opt: add xform rules to push join through index join

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -226,134 +226,140 @@ Thomas H Cormen
 Thomas H Cormen
 Thomas H Cormen
 
-# TODO(radu): rework these tests once lookup join using non-covering index is
-# supported.
-#####################################
-##  LOOKUP JOIN ON SECONDARY INDEX  #
-#####################################
-#
-## Create a table with a secondary index which stores another column.
-#statement ok
-#CREATE TABLE multiples (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b), INDEX bc (b) STORING (c))
-#
-## Split into ten parts.
-#statement ok
-#ALTER TABLE multiples SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i)
-#
-## Relocate the ten parts to the five nodes.
-#statement ok
-#ALTER TABLE multiples EXPERIMENTAL_RELOCATE
-#  SELECT ARRAY[i%5+1], i FROM generate_series(0, 9) AS g(i)
-#
-## Generate 10 rows.
-#statement ok
-#INSERT INTO multiples SELECT x, 2*x, 3*x, 4*x FROM
-#  generate_series(1, 10) AS a(x)
-#
-## Lookup join on covering secondary index
-#query II rowsort
-#SELECT t1.a, t2.c FROM multiples t1 JOIN multiples@bc t2 ON t1.a = t2.b
-#----
-#2   3
-#4   6
-#6   9
-#8   12
-#10  15
-#
-## Lookup join on non-covering secondary index
-## The index join should be subsumed by joinreader, which takes care of the
-## primary index lookups.
-#query II rowsort
-#SELECT t1.a, t2.d FROM multiples t1 JOIN multiples@bc t2 ON t1.a = t2.b
-#----
-#2   4
-#4   8
-#6   12
-#8   16
-#10  20
+####################################
+#  LOOKUP JOIN ON SECONDARY INDEX  #
+####################################
 
-# TODO(radu): enable these tests.
-#############################
-##  LEFT OUTER LOOKUP JOIN  #
-#############################
-## Left join against primary index
-#query II rowsort
-#SELECT t1.b, t2.a FROM multiples t1 LEFT JOIN multiples t2 ON t1.b = t2.a
-#----
-#2 2
-#4 4
-#6 6
-#8 8
-#10 10
-#12 NULL
-#14 NULL
-#16 NULL
-#18 NULL
-#20 NULL
-#
-## Left join against covering secondary index
-#query II rowsort
-#SELECT t1.c, t2.c FROM multiples t1 LEFT JOIN multiples@bc t2 ON t1.c = t2.b
-#----
-#3   NULL
-#6   9
-#9   NULL
-#12  18
-#15  NULL
-#18  27
-#21  NULL
-#24  NULL
-#27  NULL
-#30  NULL
-#
-## Left join against non-covering secondary index
-#query II rowsort
-#SELECT t1.c, t2.d FROM multiples t1 LEFT JOIN multiples@bc t2 ON t1.c = t2.b
-#----
-#3   NULL
-#6   12
-#9   NULL
-#12  24
-#15  NULL
-#18  36
-#21  NULL
-#24  NULL
-#27  NULL
-#30  NULL
-#
-## Left join with ON filter on covering index
-#query II rowsort
-#SELECT t1.c, t2.c FROM multiples t1 LEFT JOIN multiples@bc t2 ON t1.c = t2.b AND t2.c < 20
-#----
-#3   NULL
-#6   9
-#9   NULL
-#12  18
-#15  NULL
-#18  NULL
-#21  NULL
-#24  NULL
-#27  NULL
-#30  NULL
-#
+statement ok
+CREATE TABLE small (a INT, b INT, c INT, d INT)
+
+statement ok
+CREATE TABLE large (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b), INDEX bc (b) STORING (c))
+
+# Generate 10 rows for both tables.
+statement ok
+INSERT INTO small SELECT x, 2*x, 3*x, 4*x FROM
+  generate_series(1, 10) AS a(x)
+
+statement ok
+INSERT INTO large SELECT x, 2*x, 3*x, 4*x FROM
+  generate_series(1, 10) AS a(x)
+
+statement ok
+ALTER TABLE small INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1,
+    "distinct_count": 1
+  }
+]'
+
+statement ok
+ALTER TABLE large INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10,
+    "distinct_count": 10
+  }
+]'
+
+# Lookup join on covering secondary index
+query II rowsort
+SELECT small.a, large.c FROM small JOIN large ON small.a = large.b
+----
+2   3
+4   6
+6   9
+8   12
+10  15
+
+# Lookup join on non-covering secondary index
+query II rowsort
+SELECT small.a, large.d FROM small JOIN large ON small.a = large.b
+----
+2   4
+4   8
+6   12
+8   16
+10  20
+
+############################
+#  LEFT OUTER LOOKUP JOIN  #
+############################
+
+# Left join against primary index
+query II rowsort
+SELECT small.b, large.a FROM small LEFT JOIN large ON small.b = large.a
+----
+2 2
+4 4
+6 6
+8 8
+10 10
+12 NULL
+14 NULL
+16 NULL
+18 NULL
+20 NULL
+
+# Left join against covering secondary index
+query II rowsort
+SELECT small.c, large.c FROM small LEFT JOIN large ON small.c = large.b
+----
+3   NULL
+6   9
+9   NULL
+12  18
+15  NULL
+18  27
+21  NULL
+24  NULL
+27  NULL
+30  NULL
+
+# Left join against non-covering secondary index
+query II rowsort
+SELECT small.c, large.d FROM small LEFT JOIN large ON small.c = large.b
+----
+3   NULL
+6   12
+9   NULL
+12  24
+15  NULL
+18  36
+21  NULL
+24  NULL
+27  NULL
+30  NULL
+
+# Left join with ON filter on covering index
+query II rowsort
+SELECT small.c, large.c FROM small LEFT JOIN large ON small.c = large.b AND large.c < 20
+----
+3   NULL
+6   9
+9   NULL
+12  18
+15  NULL
+18  NULL
+21  NULL
+24  NULL
+27  NULL
+30  NULL
+
 ## Left join with ON filter on non-covering index
-#query II rowsort
-#SELECT t1.c, t2.d FROM multiples t1 LEFT JOIN multiples@bc t2 ON t1.c = t2.b AND t2.d < 30
-#----
-#3   NULL
-#6   12
-#9   NULL
-#12  24
-#15  NULL
-#18  NULL
-#21  NULL
-#24  NULL
-#27  NULL
-#30  NULL
-#
-## Left join with ON filter and WHERE clause
-#query II rowsort
-#SELECT t1.c, t2.d FROM multiples t1 LEFT JOIN multiples@bc t2 ON t1.c = t2.b WHERE t2.d < 30
-#----
-#6   12
-#12  24
+query II rowsort
+SELECT small.c, large.d FROM small LEFT JOIN large ON small.c = large.b AND large.d < 30
+----
+3   NULL
+6   12
+9   NULL
+12  24
+15  NULL
+18  NULL
+21  NULL
+24  NULL
+27  NULL
+30  NULL

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -255,109 +255,157 @@ SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM authors INNER JOIN books2 ON bo
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkcFLwzAUxu_-FeGdNoisabdLYBDBy0Q6GbtJD1n7mHVdXklSUEb_d0kjuImresz33u99X_hOYKjCXB_RgXwGARwWUHBoLZXoHNkgx6VV9QYy4VCbtvNBLjiUZBHkCXztGwQJOd1SO0uBQ4Ve182w1nOgzn9Bzus9gsx6fnZYjB_e6l2DG9QV2llycR5aWx-1fVe68y8h7zU_8R-_B6rNp5342W5HdHDhp49Eh65lr1QbRkYyFcR1ziYqY0um0im7y-_ZRM3Zkgkp5SrfTsNG5yVTgquUq4yrOVeLq9HTi-i_dLBB15Jx-KcSkr7ggNUeY8-OOlvik6VysInP9cANQoXOx2kWHysTRyHgOSxG4XQcTkfh5Btc9DcfAQAA__9BRuUo
 
-# TODO(radu): rework these tests once lookup join using non-covering index is
-# supported.
-#####################################
-##  LOOKUP JOIN ON SECONDARY INDEX  #
-#####################################
-## Create a table with a secondary index which stores another column.
-#statement ok
-#CREATE TABLE multiples (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b), INDEX bc (b) STORING (c))
-#
-## Split into ten parts.
-#statement ok
-#ALTER TABLE multiples SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i)
-#
-## Relocate the ten parts to the five nodes.
-#statement ok
-#ALTER TABLE multiples EXPERIMENTAL_RELOCATE
-#  SELECT ARRAY[i%5+1], i FROM generate_series(0, 9) AS g(i)
-#
-## Lookup join on covering secondary index
-#query TTT colnames
-#EXPLAIN SELECT t1.a, t2.c FROM multiples t1 JOIN multiples@bc t2 ON t1.a = t2.b
-#----
-#Tree            Field           Description
-#render          ·               ·
-# └── join       ·               ·
-#      │         type            inner
-#      │         equality        (a) = (b)
-#      │         mergeJoinOrder  +"(a=b)"
-#      ├── scan  ·               ·
-#      │         table           multiples@primary
-#      │         spans           ALL
-#      └── scan  ·               ·
-#·               table           multiples@bc
-#·               spans           ALL
-#
-#query T
-#SELECT url FROM [EXPLAIN (DISTSQL) SELECT t1.a, t2.c FROM multiples t1 JOIN multiples@bc t2 ON t1.a = t2.b]
-#----
-#https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lM1qg0AUhfd9inDXU-Ko-XOVbUpJSuiuuDDOJdiauTIzQkvw3YtaGg3JKERczs-Z73DOcM8gSeA2OqGG4AM4MHCBgQcMfGAwg5BBpihGrUmVV2rBRnxD4DBIZJabcjtkEJNCCM5gEpMiBPAeHVLcYyRQTR1gINBESVphMpWcIvWzPuWpSbIUNTDY5SaYrDmEBQPKzeVdbaIjQsAL1p_9Qon8Q8_a6EPcor4SfeXZ5JMSOSFZGfi3wtb-XTfuXTcXE7kkJVChaDkIixt-t_RM2ZQ7Vzdvs70Wm_dvgQ_dQge70cJ8hBbc_km4QyfRwW4ksRghCa9_Et7QSXSwG0ksR0jC75-EP3QSHexGEquRZ9QNN3vUGUmNvSaQU84wFEesB56mXMX4piiuMPVyV-mqDYHa1Ke8XmxkfVQabIq5Vey2xPxa7NrJHWjPqvbtYv8R3zOreG4nzx8hL6zipZ28fIS8snfldHwT-ye7ZofF028AAAD__2gv7bk=
-#
-## Lookup join on non-covering secondary index
-## The index join should be subsumed by joinreader, which takes care of the
-## primary index lookups.
-#query TTT colnames
-#EXPLAIN SELECT t1.a, t2.d FROM multiples t1 JOIN multiples@bc t2 ON t1.a = t2.b
-#----
-#Tree                  Field           Description
-#render                ·               ·
-# └── join             ·               ·
-#      │               type            inner
-#      │               equality        (a) = (b)
-#      │               mergeJoinOrder  +"(a=b)"
-#      ├── scan        ·               ·
-#      │               table           multiples@primary
-#      │               spans           ALL
-#      └── index-join  ·               ·
-#           ├── scan   ·               ·
-#           │          table           multiples@bc
-#           │          spans           ALL
-#           └── scan   ·               ·
-#·                     table           multiples@primary
-#
-#query T
-#SELECT url FROM [EXPLAIN (DISTSQL) SELECT t1.a, t2.d FROM multiples t1 JOIN multiples@bc t2 ON t1.a = t2.b]
-#----
-#https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lM2LqzAUxffvryh3nUeNH_1w1W0fj3YosxtcWHMpzthcSSLMUPzfB3WYammjUHGZj5Pf4ZxwLyBJ4C4-o4bwDTgwcIGBBwx8YBBAxCBXlKDWpKorjWArPiF0GKQyL0y1HTFISCGEFzCpyRBCeI2PGR4wFqjmDjAQaOI0qzG5Ss-x-tqci8ykeYYaGOwLE842HKKSARXm-q428Qkh5CUbzv5HqfxBB130MelQ_xN9FPnsnVI5I1kb-LXCNsFDN-5DN1cThSQlUKHoOIjKO3539JfyOXdubt5nex02H94CH7uFHnarhcUELbjDk3DHTqKH3UpiOUES3vAkvLGT6GG3klhNkIQ_PAl_7CR62K0k1hPPqDtuDqhzkhoHTSCnmmEoTtgMPE2FSvBFUVJjmuW-1tUbArVpTnmz2MrmqDLYFnOr2O2I-a3YtZN70J5V7dvF_jO-A6t4YScvniEvreKVnbx6hry2d-X0fBP7J7tlR-Wf7wAAAP__gsjtvg==
+####################################
+#  LOOKUP JOIN ON SECONDARY INDEX  #
+####################################
 
-# TODO(radu): enable these tests.
-#############################
-##  LEFT OUTER LOOKUP JOIN  #
-#############################
-## Left join against primary index
-#query T
-#SELECT url FROM [EXPLAIN (DISTSQL) SELECT t1.b, t2.a FROM multiples t1 LEFT JOIN multiples t2 ON t1.b = t2.a]
-#----
-#https://cockroachdb.github.io/distsqlplan/decode.html#eJzElF-Lm0AUxd_7KeQ-T1lHTTY7T3nZQpYlKSF9Kj5Y57LYmrnDzAhdFr97UUujIR2FCD7On-PveM5wP0CRxH12RgviO3BgEAGDGBgkwGAFKQNtKEdryTRXOsFO_gYRMiiUrlyznTLIySCID3CFKxEEnLIfJR4xk2geQmAg0WVF2WK0Kc6Zed-eq9IVukQLDA6VE8E2grRmQJW7fNe67A1B8JpNZ79Qof6iV0P06V2jCF6fv5yCw7fT8zF4Oez2wG5aeiX6VengJxUqICWCLf_nkzOP1ei_Vi8OK0VGokE5sJfWN35mT59JP_Dw6uZtdjxg8-kV8bkrGmH3KlovXVE0PaZo7phG2L2YHpeOKZ4eUzx3TCPsXkybpWNKpseUzB3TCLsX09PSMY2M8CNaTcripKkXNnMT5Rt2Q9ZSZXL8aihvMd3y0OraDYnWdae8W-xUd9QY7Iu5VxwNxPxaHPnJI-jYq0784uQe3yuveO0nr-8hP3rFGz95cw_5yd9VOPJM_I_smp3Wn_4EAAD__6ZdGew=
-#
-## Left join against covering secondary index
-#query T
-#SELECT url FROM [EXPLAIN (DISTSQL) SELECT t1.c, t2.c FROM multiples t1 LEFT JOIN multiples@bc t2 ON t1.c = t2.b]
-#----
-#https://cockroachdb.github.io/distsqlplan/decode.html#eJzMlF9r2zAUxd_3Kcx91qhlO2mqp7x0kFKSEbKn4QfXuhRvjq6QZFgp_u7D9ljtkMiGGNJH_Tn-HZ8j7jsokrjNjmhB_AQODCJgEAODBBgsIGWgDeVoLZnmSifYyD8gQgaF0pVrtlMGORkE8Q6ucCWCgEP2UuIeM4nmLgQGEl1WlC1Gm-KYmbf1sSpdoUu0wGBXORGsY0hrBlS5j-9al70iCF6z6ewnKtQ_9GKIPrxpFMHz47dDsPtxeNwHT7vNFhi85AM3z0S_Kx38okIFpESw5v8tcrZOLrqMLrr8MFcpMhINyoGztD7zH1v6SvqOhyc3z7PjAZtPb4fP3c4Iu9fO8obtRNMTiuZOaITdS-j-hgnF0xOK505ohN1LaHXDhJLpCSVzJzTC7iX08Elm4BmXe7SalMVJEy5sZiTKV-wGqqXK5PjdUN5iuuWu1bUbEq3rTnm32KjuqDHYF3OvOBqI-ak48pNH0LFXnfjFyTW-F17x0k9eXkO-94pXfvLqGvKDv6tw5Jn4H9kpO62__A0AAP__DxgOwA==
-#
-## Left join against non-covering secondary index
-#query T
-#SELECT url FROM [EXPLAIN (DISTSQL) SELECT t1.c, t2.d FROM multiples t1 LEFT JOIN multiples@bc t2 ON t1.c = t2.b]
-#----
-#https://cockroachdb.github.io/distsqlplan/decode.html#eJzMlF9r2zAUxd_3Kcx91qhlO2mqp7x0kFKSEbKn4QfXuhRvjq6QZFgp_u7D9ljtkMiGGNJH_Tn-HZ8j7jsokrjNjmhB_AQODCJgEAODBBgsIGWgDeVoLZnmSifYyD8gQgaF0pVrtlMGORkE8Q6ucCWCgEP2UuIeM4nmLgQGEl1WlC1Gm-KYmbf1sSpdoUu0wGBXORGsY0hrBlS5j-9al70iCF6z6ewnKtQ_9GKIPrxpFMHz47dDsPtxeNwHT7vNFhi85AM3z0S_Kx38okIFpESw5v8tcrZeXHQZXXT5Ya5SZCQalANnaX3mP7b0lfQdD09unmfHAzaf3g6fu50Rdq-d5Q3biaYnFM2d0Ai7l9D9DROKpycUz53QCLuX0OqGCSXTE0rmTmiE3Uvo4ZPMwDMu92g1KYuTJlzYzEiUr9gNVEuVyfG7obzFdMtdq2s3JFrXnfJusVHdUWOwL-ZecTQQ81Nx5CePoGOvOvGLk2t8L7zipZ-8vIZ87xWv_OTVNeQHf1fhyDPxP7JTdlp_-RsAAP__KqEOxQ==
-#
-## Left join with ON filter on covering index
-#query T
-#SELECT url FROM [EXPLAIN (DISTSQL) SELECT t1.c, t2.c FROM multiples t1 LEFT JOIN multiples@bc t2 ON t1.c = t2.b AND t2.c < 20]
-#----
-#https://cockroachdb.github.io/distsqlplan/decode.html#eJzUlc9r2zAUx-_7K8Q7baBR_0qa6pRLCy4lGcE7bT641iPT5ugZSYaGkv99OB6rHVrZkFxytK2vP-99npBeQZPEVbFDC-IHhMAhAg4xcEiAwwxyDrWhEq0l0y7pAql8ARFwULpuXPs651CSQRCv4JSrEARkxXOFGywkmpsAOEh0haqOmNqoXWH2y11TOVVXaIHDunGCLWPIDxyocW__ta7YIojwwKezH0npf-jZEJ3taxTs6f4hY-vv2f2GPa7TFXB4LgfVPBH9aWr2m5RmpAVbtmZSLfHlQVUOTVsq-9kEQVyyKBBCpKuMfTZq-8sxqyQy0tX-y_-2Qr5MPuws-rCzt4YaTUaiQTnoJj-80_uKvlJ9EwYnK99nxwN2OH2i4aUnOsLuTXR-ZRONpluNLm11hN2zentlVuPpVuNLWx1h96wursxqMt1qcmmrI-ye1bsrszpyW23Q1qQtTjqxg_bMR7nF7oKw1JgSvxkqj5jucX3MHV9ItK77GnYPqe4-tQX2w6E3HA3C4Wk48pNH0LE3nfjDyTl1z7zhuZ88P4d86w0v_OTFOeQ7_6yCkW3i32Sn7Pzw6W8AAAD__16RXd8=
-#
-## Left join with ON filter on non-covering index
-#query T
-#SELECT url FROM [EXPLAIN (DISTSQL) SELECT t1.c, t2.d FROM multiples t1 LEFT JOIN multiples@bc t2 ON t1.c = t2.b AND t2.d < 30]
-#----
-#https://cockroachdb.github.io/distsqlplan/decode.html#eJzUlUFvmzAUx-_7FNY7bZKnYiBp6hOXVqKqkilip40DxU-ZN2Ij20iNqnz3iTCtELUGKblwxPafn9_vWfYrKC1wXezRAv8BDCiEQCECCjFQWEBOoTa6RGu1aZd0gVS8AA8oSFU3rh3OKZTaIPBXcNJVCByy4rnCLRYCzU0AFAS6QlYnTG3kvjCHZN9UTtYVWqCwaRwnSQT5kYJu3Nt_rSt2CJwd6XT2o5bqH3oxRGeHGjl5un_IyOZ7dr8lj5t0DRSey8FunrT-09Tkt5aKaMVJ0ppJlcCXB1k5NJwkMfnZBEFUkijgnKfrjHw2cvfLESsFEq2qw5f_ZTGaLD6sLPywsreCGqWNQINiUE1-fKf2tf6q6xsWnK18nx0N2Gx6R9m1OzrC7nV0ObOOhtOthte2OsLuWb2dmdVoutXo2lZH2D2rq5lZjadbja9tdYTds3o3M6sjr9UWba2VxUk3dtDe-Sh22D0QVjemxG9GlydM97k55U4DAq3rZln3kapuqt1gP8y84XAQZufh0E8eQUfedOwPx5fse-ENL_3k5SXkW2945SevLiHf-XsVjBwT_yE7Z-fHT38DAAD__7jtXe4=
-#
-## Left join with ON filter and WHERE clause
-#query T
-#SELECT url FROM [EXPLAIN (DISTSQL) SELECT t1.c, t2.d FROM multiples t1 LEFT JOIN multiples@bc t2 ON t1.c = t2.b WHERE t2.d < 30]
-#----
-#https://cockroachdb.github.io/distsqlplan/decode.html#eJzMlUtr20AQx-_9FMuct0Srh-PsSZcEHIJdjHpqdVCkIaiVNcs-oCH4uxdZpZFMshLYBx338ddv9jfL6g1aqnBbHNCA_AECOITAIQIOMXBIIOegNJVoDOluSx_YVH9ABhzqVjnbTeccStII8g1sbRsECVnx3OAeiwr1TQAcKrRF3ZwwSteHQr-mB9fYWjVogMPOWcnSCPIjB3L2_bvGFi8IUhz5fPYj1e0_dDJGZ68KJXu6f8jY7nt2v2ePu80WODyXo2qeiH47xX5R3TJqJUs7Mw91Y1FLlibspwuCqGRRIKXcbLP_9QueJp8eIfz0CO-Vu5Z0hRqrUdn58YNDbukrqRsRnO38mB2N2GJ-68S1WzfBHrRutdTWhfP1hdfWN8Ee6Ltdqr5ovr7o2vom2AN966Xqi-fri6-tb4I90He3VH0Tv449GkWtwVmvatC9y1i9YP-IG3K6xG-ayhOmH-5OudNEhcb2q6IfbNp-qStwGBbecDgKi_Nw6CdPoCNvOvaH40vqTrzhlZ-8uoR86w2v_eT1JeQ7f6-CiWviv2Tn7Pz45W8AAAD__4bONQ0=
+statement ok
+CREATE TABLE small (a INT, b INT, c INT, d INT)
+
+statement ok
+CREATE TABLE large (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b), INDEX bc (b) STORING (c))
+
+statement ok
+ALTER TABLE small INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1,
+    "distinct_count": 1
+  }
+]'
+
+statement ok
+ALTER TABLE large INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10,
+    "distinct_count": 10
+  }
+]'
+
+# Lookup join on covering secondary index
+query TTTTT
+EXPLAIN (VERBOSE) SELECT small.a, large.c FROM small JOIN large ON small.a = large.b
+----
+render            ·         ·              (a, c)     ·
+ │                render 0  a              ·          ·
+ │                render 1  c              ·          ·
+ └── lookup-join  ·         ·              (a, b, c)  ·
+      │           type      inner          ·          ·
+      │           pred      @1 = @2        ·          ·
+      ├── scan    ·         ·              (a)        ·
+      │           table     small@primary  ·          ·
+      │           spans     ALL            ·          ·
+      └── scan    ·         ·              (b, c)     ·
+·                 table     large@bc       ·          ·
+
+# Lookup join on non-covering secondary index
+query TTTTT
+EXPLAIN (VERBOSE) SELECT small.a, large.d FROM small JOIN large ON small.a = large.b
+----
+render                 ·         ·              (a, d)        ·
+ │                     render 0  a              ·             ·
+ │                     render 1  d              ·             ·
+ └── lookup-join       ·         ·              (a, a, b, d)  ·
+      │                type      inner          ·             ·
+      ├── lookup-join  ·         ·              (a, a, b)     ·
+      │    │           type      inner          ·             ·
+      │    │           pred      @1 = @3        ·             ·
+      │    ├── scan    ·         ·              (a)           ·
+      │    │           table     small@primary  ·             ·
+      │    │           spans     ALL            ·             ·
+      │    └── scan    ·         ·              (a, b)        ·
+      │                table     large@bc       ·             ·
+      └── scan         ·         ·              (d)           ·
+·                      table     large@primary  ·             ·
+
+############################
+#  LEFT OUTER LOOKUP JOIN  #
+############################
+
+# Left join against primary index
+query TTTTT
+EXPLAIN (VERBOSE) SELECT small.b, large.a FROM small LEFT JOIN large ON small.b = large.a
+----
+lookup-join  ·      ·              (b, a)  ·
+ │           type   left outer     ·       ·
+ │           pred   @1 = @2        ·       ·
+ ├── scan    ·      ·              (b)     ·
+ │           table  small@primary  ·       ·
+ │           spans  ALL            ·       ·
+ └── scan    ·      ·              (a)     ·
+·            table  large@primary  ·       ·
+
+# Left join against covering secondary index
+query TTTTT
+EXPLAIN (VERBOSE) SELECT small.c, large.c FROM small LEFT JOIN large ON small.c = large.b
+----
+render            ·         ·              (c, c)     ·
+ │                render 0  c              ·          ·
+ │                render 1  c              ·          ·
+ └── lookup-join  ·         ·              (c, b, c)  ·
+      │           type      left outer     ·          ·
+      │           pred      @1 = @2        ·          ·
+      ├── scan    ·         ·              (c)        ·
+      │           table     small@primary  ·          ·
+      │           spans     ALL            ·          ·
+      └── scan    ·         ·              (b, c)     ·
+·                 table     large@bc       ·          ·
+
+# Left join against non-covering secondary index
+query TTTTT
+EXPLAIN (VERBOSE) SELECT small.c, large.d FROM small LEFT JOIN large ON small.c = large.b
+----
+render                 ·         ·              (c, d)        ·
+ │                     render 0  c              ·             ·
+ │                     render 1  d              ·             ·
+ └── lookup-join       ·         ·              (c, a, b, d)  ·
+      │                type      left outer     ·             ·
+      ├── lookup-join  ·         ·              (c, a, b)     ·
+      │    │           type      left outer     ·             ·
+      │    │           pred      @1 = @3        ·             ·
+      │    ├── scan    ·         ·              (c)           ·
+      │    │           table     small@primary  ·             ·
+      │    │           spans     ALL            ·             ·
+      │    └── scan    ·         ·              (a, b)        ·
+      │                table     large@bc       ·             ·
+      └── scan         ·         ·              (d)           ·
+·                      table     large@primary  ·             ·
+
+# Left join with ON filter on covering index
+query TTTTT
+EXPLAIN (VERBOSE) SELECT small.c, large.c FROM small LEFT JOIN large ON small.c = large.b AND large.c < 20
+----
+render            ·         ·                        (c, c)     ·
+ │                render 0  c                        ·          ·
+ │                render 1  c                        ·          ·
+ └── lookup-join  ·         ·                        (c, b, c)  ·
+      │           type      left outer               ·          ·
+      │           pred      (@1 = @2) AND (@3 < 20)  ·          ·
+      ├── scan    ·         ·                        (c)        ·
+      │           table     small@primary            ·          ·
+      │           spans     ALL                      ·          ·
+      └── scan    ·         ·                        (b, c)     ·
+·                 table     large@bc                 ·          ·
+
+# Left join with ON filter on non-covering index
+# TODO(radu): this doesn't use lookup join yet, the current rules don't cover
+# left join with ON condition on columns that are not covered by the index.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT small.c, large.d FROM small LEFT JOIN large ON small.c = large.b AND large.d < 30
+----
+render          ·         ·              (c, d)     ·
+ │              render 0  c              ·          ·
+ │              render 1  d              ·          ·
+ └── join       ·         ·              (b, d, c)  ·
+      │         type      right outer    ·          ·
+      │         equality  (b) = (c)      ·          ·
+      ├── scan  ·         ·              (b, d)     ·
+      │         table     large@primary  ·          ·
+      │         spans     ALL            ·          ·
+      │         filter    d < 30         ·          ·
+      └── scan  ·         ·              (c)        ·
+·               table     small@primary  ·          ·
+·               spans     ALL            ·          ·

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -56,7 +56,7 @@
 # has a Select->Scan combination as its right input. The filter can get merged
 # with the ON condition (this is correct for both inner and left join).
 [GenerateLookupJoinWithFilter, Explore]
-(InnerJoin | LeftJoin 
+(InnerJoin | LeftJoin
     $left:*
     (Select
         (Scan $scanDef:*)
@@ -66,3 +66,73 @@
 )
 =>
 (ConstructLookupJoin (OpName) $left $scanDef (ConcatFilters $on $filter))
+
+# PushJoinThroughIndexJoin takes an expression which does an index join followed
+# by a join and produces an expression which first does the join and then joins
+# with the index. This can be advantageous when the join has fewer results than
+# the right input; in particular, the new join can be converted to a lookup join
+# by other rules.
+#
+#     Join                            LookupJoin
+#     /   \                               |
+#    /     \              ->            Join
+#  Left  IndexJoin                      /   \
+#           |                          /     \
+#         Right                      Left  Right
+#
+# Note that the IndexJoin becomes a more general LookupJoin because an IndexJoin
+# can only output columns from one table, whereas we also need to output columns
+# produced by Left.
+#
+# The rule can only be applied when the ON condition doesn't depend on columns
+# added by the index join.
+[PushJoinThroughIndexJoin, Explore]
+(InnerJoin | LeftJoin
+    $left:*
+    (IndexJoin $right:* $indexJoinDef:*)
+    $on:* & (IsBoundBy2 $on $left $right)
+)
+=>
+(LookupJoin
+   $newJoin:((OpName) $left $right $on)
+   (True)
+   (HoistIndexJoinDef $indexJoinDef $newJoin (OpName))
+)
+
+# PushJoinThroughIndexJoinWithExtraFilter is a specialization of the previous
+# rule for the case of an inner join where only part of the ON condition can be
+# evaluated before the index join.
+#
+# This case is particularly important because any filters on the results of an
+# inner join get pushed into the ON condition; so simply adding a WHERE clause
+# can stop the previous rule from running.
+#
+# TODO(radu): this rule doesn't cover left join because of a technicality: if a
+# left row has matches in newJoin but has no matches in the lookup join, only
+# the looked up columns get NULL-extended (whereas some of the table columns are
+# coming from newJoin and those would need to be NULLed out too). The fix would
+# be to lookup all columns and discard those from newJoin. This requires a
+# top-level projection, as well as an inner projection to avoid having the same
+# ColumnID on both sides of the lookup join.
+[PushJoinThroughIndexJoinWithExtraFilter, Explore]
+(InnerJoin
+    $left:*
+    (IndexJoin $right:* $indexJoinDef:*)
+    $on:* & ^(IsBoundBy2 $on $left $right) & (Filters
+        $onList: [
+            ...
+            $condition:* & (IsBoundBy2 $condition $left $right)
+            ...
+        ]
+    )
+)
+=>
+(LookupJoin
+    $newJoin:(InnerJoin
+        $left
+        $right
+        (Filters (ExtractBoundConditions2 $onList $left $right))
+    )
+    (Filters (ExtractUnboundConditions $onList $newJoin))
+    (HoistIndexJoinDef $indexJoinDef $newJoin (OpName))
+)

--- a/pkg/sql/opt/xform/testdata/external/activerecord
+++ b/pkg/sql/opt/xform/testdata/external/activerecord
@@ -225,36 +225,34 @@ sort
       │    │    │    └── fd: (36)-->(63)
       │    │    └── filters [type=bool, outer=(29,63), constraints=(/29: (/NULL - ]; /63: (/NULL - ])]
       │    │         └── pg_collation.oid != pg_type.typcollation [type=bool, outer=(29,63), constraints=(/29: (/NULL - ]; /63: (/NULL - ])]
-      │    ├── right-join
+      │    ├── left-join (lookup pg_attrdef)
       │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null) adrelid:23(oid) adnum:24(int) adbin:25(string)
+      │    │    ├── key columns: [22] = [22]
       │    │    ├── key: (1,6,23,24)
       │    │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18), (23,24)-->(25)
-      │    │    ├── select
-      │    │    │    ├── columns: adrelid:23(oid!null) adnum:24(int!null) adbin:25(string)
-      │    │    │    ├── key: (23,24)
-      │    │    │    ├── fd: (23,24)-->(25)
-      │    │    │    ├── scan pg_attrdef
-      │    │    │    │    ├── columns: adrelid:23(oid!null) adnum:24(int!null) adbin:25(string)
-      │    │    │    │    ├── key: (23,24)
-      │    │    │    │    └── fd: (23,24)-->(25)
-      │    │    │    └── filters [type=bool, outer=(23,24), constraints=(/23: (/NULL - ]; /24: [/1 - ])]
-      │    │    │         ├── pg_attrdef.adrelid = '"numbers"'::REGCLASS [type=bool, outer=(23), constraints=(/23: (/NULL - ])]
-      │    │    │         └── pg_attrdef.adnum > 0 [type=bool, outer=(24), constraints=(/24: [/1 - ]; tight)]
-      │    │    ├── select
-      │    │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null)
-      │    │    │    ├── key: (1,6)
-      │    │    │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18)
-      │    │    │    ├── scan pg_attribute
+      │    │    ├── left-join (lookup pg_attrdef@pg_attrdef_adrelid_adnum_index)
+      │    │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null) pg_attrdef.oid:22(oid) adrelid:23(oid) adnum:24(int)
+      │    │    │    ├── key columns: [1 6] = [23 24]
+      │    │    │    ├── key: (1,6,22)
+      │    │    │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18), (22)-->(23,24), (23,24)-->(22)
+      │    │    │    ├── select
       │    │    │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null)
       │    │    │    │    ├── key: (1,6)
-      │    │    │    │    └── fd: (1,6)-->(2,3,9,13,15,18), (1,2)-->(3,6,9,13,15,18)
-      │    │    │    └── filters [type=bool, outer=(1,6,15), constraints=(/1: (/NULL - ]; /6: [/1 - ]; /15: [/false - /false]), fd=()-->(15)]
-      │    │    │         ├── pg_attribute.attrelid = '"numbers"'::REGCLASS [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
-      │    │    │         ├── pg_attribute.attnum > 0 [type=bool, outer=(6), constraints=(/6: [/1 - ]; tight)]
-      │    │    │         └── NOT pg_attribute.attisdropped [type=bool, outer=(15), constraints=(/15: [/false - /false]; tight)]
-      │    │    └── filters [type=bool, outer=(1,6,23,24), constraints=(/1: (/NULL - ]; /6: (/NULL - ]; /23: (/NULL - ]; /24: (/NULL - ]), fd=(1)==(23), (23)==(1), (6)==(24), (24)==(6)]
-      │    │         ├── pg_attribute.attrelid = pg_attrdef.adrelid [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ])]
-      │    │         └── pg_attribute.attnum = pg_attrdef.adnum [type=bool, outer=(6,24), constraints=(/6: (/NULL - ]; /24: (/NULL - ])]
+      │    │    │    │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18)
+      │    │    │    │    ├── scan pg_attribute
+      │    │    │    │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null)
+      │    │    │    │    │    ├── key: (1,6)
+      │    │    │    │    │    └── fd: (1,6)-->(2,3,9,13,15,18), (1,2)-->(3,6,9,13,15,18)
+      │    │    │    │    └── filters [type=bool, outer=(1,6,15), constraints=(/1: (/NULL - ]; /6: [/1 - ]; /15: [/false - /false]), fd=()-->(15)]
+      │    │    │    │         ├── pg_attribute.attrelid = '"numbers"'::REGCLASS [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+      │    │    │    │         ├── pg_attribute.attnum > 0 [type=bool, outer=(6), constraints=(/6: [/1 - ]; tight)]
+      │    │    │    │         └── NOT pg_attribute.attisdropped [type=bool, outer=(15), constraints=(/15: [/false - /false]; tight)]
+      │    │    │    └── filters [type=bool, outer=(1,6,23,24), constraints=(/1: (/NULL - ]; /6: (/NULL - ]; /23: (/NULL - ]; /24: [/1 - ]), fd=(1)==(23), (23)==(1), (6)==(24), (24)==(6)]
+      │    │    │         ├── pg_attribute.attrelid = pg_attrdef.adrelid [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ])]
+      │    │    │         ├── pg_attribute.attnum = pg_attrdef.adnum [type=bool, outer=(6,24), constraints=(/6: (/NULL - ]; /24: (/NULL - ])]
+      │    │    │         ├── pg_attrdef.adrelid = '"numbers"'::REGCLASS [type=bool, outer=(23), constraints=(/23: (/NULL - ])]
+      │    │    │         └── pg_attrdef.adnum > 0 [type=bool, outer=(24), constraints=(/24: [/1 - ]; tight)]
+      │    │    └── true [type=bool]
       │    └── filters [type=bool, outer=(3,18,29,36), constraints=(/3: (/NULL - ]; /18: (/NULL - ]; /29: (/NULL - ]; /36: (/NULL - ]), fd=(18)==(29), (29)==(18), (3)==(36), (36)==(3)]
       │         ├── pg_collation.oid = pg_attribute.attcollation [type=bool, outer=(18,29), constraints=(/18: (/NULL - ]; /29: (/NULL - ])]
       │         └── pg_type.oid = pg_attribute.atttypid [type=bool, outer=(3,36), constraints=(/3: (/NULL - ]; /36: (/NULL - ])]

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -441,190 +441,192 @@ from (select flavors.created_at as flavors_created_at,
      on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
 order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
-sort
+left-join (lookup flavor_extra_specs)
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:38(timestamp) flavor_extra_specs_1_updated_at:39(timestamp) flavor_extra_specs_1_id:34(int) flavor_extra_specs_1_key:35(string) flavor_extra_specs_1_value:36(string) flavor_extra_specs_1_flavor_id:37(int)
+ ├── key columns: [34] = [34]
  ├── key: (1,34)
  ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35-39), (35,37)-->(34,36,38,39)
  ├── ordering: +7 opt(11)
- └── right-join
-      ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:34(int) key:35(string) value:36(string) flavor_extra_specs.flavor_id:37(int) flavor_extra_specs.created_at:38(timestamp) flavor_extra_specs.updated_at:39(timestamp)
-      ├── key: (1,34)
-      ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35-39), (35,37)-->(34,36,38,39)
-      ├── scan flavor_extra_specs
-      │    ├── columns: flavor_extra_specs.id:34(int!null) key:35(string!null) value:36(string) flavor_extra_specs.flavor_id:37(int!null) flavor_extra_specs.created_at:38(timestamp) flavor_extra_specs.updated_at:39(timestamp)
-      │    ├── key: (34)
-      │    └── fd: (34)-->(35-39), (35,37)-->(34,36,38,39)
-      ├── project
-      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │    ├── key: (1)
-      │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │    └── limit
-      │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
-      │         ├── key: (1)
-      │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         ├── offset
-      │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
-      │         │    ├── key: (1)
-      │         │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    ├── ordering: +7 opt(11)
-      │         │    ├── sort
-      │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
-      │         │    │    ├── key: (1)
-      │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │    ├── ordering: +7 opt(11)
-      │         │    │    └── select
-      │         │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
-      │         │    │         ├── key: (1)
-      │         │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         ├── group-by
-      │         │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
-      │         │    │         │    ├── grouping columns: flavors.id:1(int!null)
-      │         │    │         │    ├── key: (1)
-      │         │    │         │    ├── fd: ()-->(11), (1)-->(2-12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    ├── left-join (merge)
-      │         │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:23(int) true:31(bool)
-      │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(31)
-      │         │    │         │    │    ├── sort
-      │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │         │    │         │    │    │    ├── key: (1)
-      │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    │    │    ├── ordering: +1 opt(11)
-      │         │    │         │    │    │    └── project
-      │         │    │         │    │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │         │    │         │    │    │         ├── key: (1)
-      │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    │    │         └── select
-      │         │    │         │    │    │              ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
-      │         │    │         │    │    │              ├── key: (1)
-      │         │    │         │    │    │              ├── fd: ()-->(11), (1)-->(2-10,12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    │    │              ├── group-by
-      │         │    │         │    │    │              │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
-      │         │    │         │    │    │              │    ├── grouping columns: flavors.id:1(int!null)
-      │         │    │         │    │    │              │    ├── key: (1)
-      │         │    │         │    │    │              │    ├── fd: ()-->(11), (1)-->(2-12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    │    │              │    ├── left-join (merge)
-      │         │    │         │    │    │              │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:28(bool)
-      │         │    │         │    │    │              │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(28)
-      │         │    │         │    │    │              │    │    ├── select
-      │         │    │         │    │    │              │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │         │    │         │    │    │              │    │    │    ├── key: (1)
-      │         │    │         │    │    │              │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    │    │              │    │    │    ├── ordering: +1 opt(11)
-      │         │    │         │    │    │              │    │    │    ├── scan flavors
-      │         │    │         │    │    │              │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │         │    │         │    │    │              │    │    │    │    ├── key: (1)
-      │         │    │         │    │    │              │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │         │    │    │              │    │    │    │    └── ordering: +1 opt(11)
-      │         │    │         │    │    │              │    │    │    └── filters [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
-      │         │    │         │    │    │              │    │    │         └── flavors.disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight)]
-      │         │    │         │    │    │              │    │    ├── project
-      │         │    │         │    │    │              │    │    │    ├── columns: true:28(bool!null) flavor_projects.flavor_id:17(int!null)
-      │         │    │         │    │    │              │    │    │    ├── fd: ()-->(28)
-      │         │    │         │    │    │              │    │    │    ├── ordering: +17 opt(28)
-      │         │    │         │    │    │              │    │    │    ├── select
-      │         │    │         │    │    │              │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) flavor_projects.project_id:18(string!null)
-      │         │    │         │    │    │              │    │    │    │    ├── key: (17,18)
-      │         │    │         │    │    │              │    │    │    │    ├── ordering: +17
-      │         │    │         │    │    │              │    │    │    │    ├── scan flavor_projects@secondary
-      │         │    │         │    │    │              │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) flavor_projects.project_id:18(string!null)
-      │         │    │         │    │    │              │    │    │    │    │    ├── key: (17,18)
-      │         │    │         │    │    │              │    │    │    │    │    └── ordering: +17
-      │         │    │         │    │    │              │    │    │    │    └── filters [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
-      │         │    │         │    │    │              │    │    │    │         └── flavor_projects.project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
-      │         │    │         │    │    │              │    │    │    └── projections [outer=(17)]
-      │         │    │         │    │    │              │    │    │         └── true [type=bool]
-      │         │    │         │    │    │              │    │    └── merge-on
-      │         │    │         │    │    │              │    │         ├── left ordering: +1
-      │         │    │         │    │    │              │    │         ├── right ordering: +17
-      │         │    │         │    │    │              │    │         └── filters [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
-      │         │    │         │    │    │              │    │              └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ])]
-      │         │    │         │    │    │              │    └── aggregations [outer=(2-12,14,15,28)]
-      │         │    │         │    │    │              │         ├── const-not-null-agg [type=bool, outer=(28)]
-      │         │    │         │    │    │              │         │    └── variable: true [type=bool, outer=(28)]
-      │         │    │         │    │    │              │         ├── const-agg [type=string, outer=(2)]
-      │         │    │         │    │    │              │         │    └── variable: flavors.name [type=string, outer=(2)]
-      │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(3)]
-      │         │    │         │    │    │              │         │    └── variable: flavors.memory_mb [type=int, outer=(3)]
-      │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(4)]
-      │         │    │         │    │    │              │         │    └── variable: flavors.vcpus [type=int, outer=(4)]
-      │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(5)]
-      │         │    │         │    │    │              │         │    └── variable: flavors.root_gb [type=int, outer=(5)]
-      │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(6)]
-      │         │    │         │    │    │              │         │    └── variable: flavors.ephemeral_gb [type=int, outer=(6)]
-      │         │    │         │    │    │              │         ├── const-agg [type=string, outer=(7)]
-      │         │    │         │    │    │              │         │    └── variable: flavors.flavorid [type=string, outer=(7)]
-      │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(8)]
-      │         │    │         │    │    │              │         │    └── variable: flavors.swap [type=int, outer=(8)]
-      │         │    │         │    │    │              │         ├── const-agg [type=float, outer=(9)]
-      │         │    │         │    │    │              │         │    └── variable: flavors.rxtx_factor [type=float, outer=(9)]
-      │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(10)]
-      │         │    │         │    │    │              │         │    └── variable: flavors.vcpu_weight [type=int, outer=(10)]
-      │         │    │         │    │    │              │         ├── const-agg [type=bool, outer=(11)]
-      │         │    │         │    │    │              │         │    └── variable: flavors.disabled [type=bool, outer=(11)]
-      │         │    │         │    │    │              │         ├── const-agg [type=bool, outer=(12)]
-      │         │    │         │    │    │              │         │    └── variable: flavors.is_public [type=bool, outer=(12)]
-      │         │    │         │    │    │              │         ├── const-agg [type=timestamp, outer=(14)]
-      │         │    │         │    │    │              │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
-      │         │    │         │    │    │              │         └── const-agg [type=timestamp, outer=(15)]
-      │         │    │         │    │    │              │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
-      │         │    │         │    │    │              └── filters [type=bool, outer=(12,29)]
-      │         │    │         │    │    │                   └── (flavors.is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,29)]
-      │         │    │         │    │    ├── project
-      │         │    │         │    │    │    ├── columns: true:31(bool!null) flavor_projects.flavor_id:23(int!null)
-      │         │    │         │    │    │    ├── fd: ()-->(31)
-      │         │    │         │    │    │    ├── ordering: +23 opt(31)
-      │         │    │         │    │    │    ├── select
-      │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) flavor_projects.project_id:24(string!null)
-      │         │    │         │    │    │    │    ├── key: (23,24)
-      │         │    │         │    │    │    │    ├── ordering: +23
-      │         │    │         │    │    │    │    ├── scan flavor_projects@secondary
-      │         │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) flavor_projects.project_id:24(string!null)
-      │         │    │         │    │    │    │    │    ├── key: (23,24)
-      │         │    │         │    │    │    │    │    └── ordering: +23
-      │         │    │         │    │    │    │    └── filters [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
-      │         │    │         │    │    │    │         └── flavor_projects.project_id = $2 [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
-      │         │    │         │    │    │    └── projections [outer=(23)]
-      │         │    │         │    │    │         └── true [type=bool]
-      │         │    │         │    │    └── merge-on
-      │         │    │         │    │         ├── left ordering: +1
-      │         │    │         │    │         ├── right ordering: +23
-      │         │    │         │    │         └── filters [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ]), fd=(1)==(23), (23)==(1)]
-      │         │    │         │    │              └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ])]
-      │         │    │         │    └── aggregations [outer=(2-12,14,15,31)]
-      │         │    │         │         ├── const-not-null-agg [type=bool, outer=(31)]
-      │         │    │         │         │    └── variable: true [type=bool, outer=(31)]
-      │         │    │         │         ├── const-agg [type=string, outer=(2)]
-      │         │    │         │         │    └── variable: flavors.name [type=string, outer=(2)]
-      │         │    │         │         ├── const-agg [type=int, outer=(3)]
-      │         │    │         │         │    └── variable: flavors.memory_mb [type=int, outer=(3)]
-      │         │    │         │         ├── const-agg [type=int, outer=(4)]
-      │         │    │         │         │    └── variable: flavors.vcpus [type=int, outer=(4)]
-      │         │    │         │         ├── const-agg [type=int, outer=(5)]
-      │         │    │         │         │    └── variable: flavors.root_gb [type=int, outer=(5)]
-      │         │    │         │         ├── const-agg [type=int, outer=(6)]
-      │         │    │         │         │    └── variable: flavors.ephemeral_gb [type=int, outer=(6)]
-      │         │    │         │         ├── const-agg [type=string, outer=(7)]
-      │         │    │         │         │    └── variable: flavors.flavorid [type=string, outer=(7)]
-      │         │    │         │         ├── const-agg [type=int, outer=(8)]
-      │         │    │         │         │    └── variable: flavors.swap [type=int, outer=(8)]
-      │         │    │         │         ├── const-agg [type=float, outer=(9)]
-      │         │    │         │         │    └── variable: flavors.rxtx_factor [type=float, outer=(9)]
-      │         │    │         │         ├── const-agg [type=int, outer=(10)]
-      │         │    │         │         │    └── variable: flavors.vcpu_weight [type=int, outer=(10)]
-      │         │    │         │         ├── const-agg [type=bool, outer=(11)]
-      │         │    │         │         │    └── variable: flavors.disabled [type=bool, outer=(11)]
-      │         │    │         │         ├── const-agg [type=bool, outer=(12)]
-      │         │    │         │         │    └── variable: flavors.is_public [type=bool, outer=(12)]
-      │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
-      │         │    │         │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
-      │         │    │         │         └── const-agg [type=timestamp, outer=(15)]
-      │         │    │         │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
-      │         │    │         └── filters [type=bool, outer=(12,32)]
-      │         │    │              └── (flavors.is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,32)]
-      │         │    └── placeholder: $3 [type=int]
-      │         └── placeholder: $4 [type=int]
-      └── filters [type=bool, outer=(1,37), constraints=(/1: (/NULL - ]; /37: (/NULL - ]), fd=(1)==(37), (37)==(1)]
-           └── flavor_extra_specs.flavor_id = flavors.id [type=bool, outer=(1,37), constraints=(/1: (/NULL - ]; /37: (/NULL - ])]
+ ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx)
+ │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:34(int) key:35(string) flavor_extra_specs.flavor_id:37(int)
+ │    ├── key columns: [1] = [37]
+ │    ├── key: (1,34)
+ │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35,37), (35,37)-->(34)
+ │    ├── ordering: +7 opt(11)
+ │    ├── project
+ │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │    │    ├── key: (1)
+ │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+ │    │    ├── ordering: +7 opt(11)
+ │    │    └── limit
+ │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+ │    │         ├── key: (1)
+ │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+ │    │         ├── ordering: +7 opt(11)
+ │    │         ├── offset
+ │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+ │    │         │    ├── key: (1)
+ │    │         │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+ │    │         │    ├── ordering: +7 opt(11)
+ │    │         │    ├── sort
+ │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+ │    │         │    │    ├── key: (1)
+ │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+ │    │         │    │    ├── ordering: +7 opt(11)
+ │    │         │    │    └── select
+ │    │         │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+ │    │         │    │         ├── key: (1)
+ │    │         │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+ │    │         │    │         ├── group-by
+ │    │         │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+ │    │         │    │         │    ├── grouping columns: flavors.id:1(int!null)
+ │    │         │    │         │    ├── key: (1)
+ │    │         │    │         │    ├── fd: ()-->(11), (1)-->(2-12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+ │    │         │    │         │    ├── left-join (merge)
+ │    │         │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:23(int) true:31(bool)
+ │    │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(31)
+ │    │         │    │         │    │    ├── sort
+ │    │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │    │         │    │         │    │    │    ├── key: (1)
+ │    │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+ │    │         │    │         │    │    │    ├── ordering: +1 opt(11)
+ │    │         │    │         │    │    │    └── project
+ │    │         │    │         │    │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │    │         │    │         │    │    │         ├── key: (1)
+ │    │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+ │    │         │    │         │    │    │         └── select
+ │    │         │    │         │    │    │              ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
+ │    │         │    │         │    │    │              ├── key: (1)
+ │    │         │    │         │    │    │              ├── fd: ()-->(11), (1)-->(2-10,12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+ │    │         │    │         │    │    │              ├── group-by
+ │    │         │    │         │    │    │              │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
+ │    │         │    │         │    │    │              │    ├── grouping columns: flavors.id:1(int!null)
+ │    │         │    │         │    │    │              │    ├── key: (1)
+ │    │         │    │         │    │    │              │    ├── fd: ()-->(11), (1)-->(2-12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+ │    │         │    │         │    │    │              │    ├── left-join (merge)
+ │    │         │    │         │    │    │              │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:28(bool)
+ │    │         │    │         │    │    │              │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(28)
+ │    │         │    │         │    │    │              │    │    ├── select
+ │    │         │    │         │    │    │              │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │    │         │    │         │    │    │              │    │    │    ├── key: (1)
+ │    │         │    │         │    │    │              │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+ │    │         │    │         │    │    │              │    │    │    ├── ordering: +1 opt(11)
+ │    │         │    │         │    │    │              │    │    │    ├── scan flavors
+ │    │         │    │         │    │    │              │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │    │         │    │         │    │    │              │    │    │    │    ├── key: (1)
+ │    │         │    │         │    │    │              │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+ │    │         │    │         │    │    │              │    │    │    │    └── ordering: +1 opt(11)
+ │    │         │    │         │    │    │              │    │    │    └── filters [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
+ │    │         │    │         │    │    │              │    │    │         └── flavors.disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight)]
+ │    │         │    │         │    │    │              │    │    ├── project
+ │    │         │    │         │    │    │              │    │    │    ├── columns: true:28(bool!null) flavor_projects.flavor_id:17(int!null)
+ │    │         │    │         │    │    │              │    │    │    ├── fd: ()-->(28)
+ │    │         │    │         │    │    │              │    │    │    ├── ordering: +17 opt(28)
+ │    │         │    │         │    │    │              │    │    │    ├── select
+ │    │         │    │         │    │    │              │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) flavor_projects.project_id:18(string!null)
+ │    │         │    │         │    │    │              │    │    │    │    ├── key: (17,18)
+ │    │         │    │         │    │    │              │    │    │    │    ├── ordering: +17
+ │    │         │    │         │    │    │              │    │    │    │    ├── scan flavor_projects@secondary
+ │    │         │    │         │    │    │              │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) flavor_projects.project_id:18(string!null)
+ │    │         │    │         │    │    │              │    │    │    │    │    ├── key: (17,18)
+ │    │         │    │         │    │    │              │    │    │    │    │    └── ordering: +17
+ │    │         │    │         │    │    │              │    │    │    │    └── filters [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+ │    │         │    │         │    │    │              │    │    │    │         └── flavor_projects.project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+ │    │         │    │         │    │    │              │    │    │    └── projections [outer=(17)]
+ │    │         │    │         │    │    │              │    │    │         └── true [type=bool]
+ │    │         │    │         │    │    │              │    │    └── merge-on
+ │    │         │    │         │    │    │              │    │         ├── left ordering: +1
+ │    │         │    │         │    │    │              │    │         ├── right ordering: +17
+ │    │         │    │         │    │    │              │    │         └── filters [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
+ │    │         │    │         │    │    │              │    │              └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ])]
+ │    │         │    │         │    │    │              │    └── aggregations [outer=(2-12,14,15,28)]
+ │    │         │    │         │    │    │              │         ├── const-not-null-agg [type=bool, outer=(28)]
+ │    │         │    │         │    │    │              │         │    └── variable: true [type=bool, outer=(28)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=string, outer=(2)]
+ │    │         │    │         │    │    │              │         │    └── variable: flavors.name [type=string, outer=(2)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(3)]
+ │    │         │    │         │    │    │              │         │    └── variable: flavors.memory_mb [type=int, outer=(3)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(4)]
+ │    │         │    │         │    │    │              │         │    └── variable: flavors.vcpus [type=int, outer=(4)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(5)]
+ │    │         │    │         │    │    │              │         │    └── variable: flavors.root_gb [type=int, outer=(5)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(6)]
+ │    │         │    │         │    │    │              │         │    └── variable: flavors.ephemeral_gb [type=int, outer=(6)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=string, outer=(7)]
+ │    │         │    │         │    │    │              │         │    └── variable: flavors.flavorid [type=string, outer=(7)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(8)]
+ │    │         │    │         │    │    │              │         │    └── variable: flavors.swap [type=int, outer=(8)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=float, outer=(9)]
+ │    │         │    │         │    │    │              │         │    └── variable: flavors.rxtx_factor [type=float, outer=(9)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(10)]
+ │    │         │    │         │    │    │              │         │    └── variable: flavors.vcpu_weight [type=int, outer=(10)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=bool, outer=(11)]
+ │    │         │    │         │    │    │              │         │    └── variable: flavors.disabled [type=bool, outer=(11)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=bool, outer=(12)]
+ │    │         │    │         │    │    │              │         │    └── variable: flavors.is_public [type=bool, outer=(12)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=timestamp, outer=(14)]
+ │    │         │    │         │    │    │              │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
+ │    │         │    │         │    │    │              │         └── const-agg [type=timestamp, outer=(15)]
+ │    │         │    │         │    │    │              │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
+ │    │         │    │         │    │    │              └── filters [type=bool, outer=(12,29)]
+ │    │         │    │         │    │    │                   └── (flavors.is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,29)]
+ │    │         │    │         │    │    ├── project
+ │    │         │    │         │    │    │    ├── columns: true:31(bool!null) flavor_projects.flavor_id:23(int!null)
+ │    │         │    │         │    │    │    ├── fd: ()-->(31)
+ │    │         │    │         │    │    │    ├── ordering: +23 opt(31)
+ │    │         │    │         │    │    │    ├── select
+ │    │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) flavor_projects.project_id:24(string!null)
+ │    │         │    │         │    │    │    │    ├── key: (23,24)
+ │    │         │    │         │    │    │    │    ├── ordering: +23
+ │    │         │    │         │    │    │    │    ├── scan flavor_projects@secondary
+ │    │         │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) flavor_projects.project_id:24(string!null)
+ │    │         │    │         │    │    │    │    │    ├── key: (23,24)
+ │    │         │    │         │    │    │    │    │    └── ordering: +23
+ │    │         │    │         │    │    │    │    └── filters [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
+ │    │         │    │         │    │    │    │         └── flavor_projects.project_id = $2 [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
+ │    │         │    │         │    │    │    └── projections [outer=(23)]
+ │    │         │    │         │    │    │         └── true [type=bool]
+ │    │         │    │         │    │    └── merge-on
+ │    │         │    │         │    │         ├── left ordering: +1
+ │    │         │    │         │    │         ├── right ordering: +23
+ │    │         │    │         │    │         └── filters [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ]), fd=(1)==(23), (23)==(1)]
+ │    │         │    │         │    │              └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ])]
+ │    │         │    │         │    └── aggregations [outer=(2-12,14,15,31)]
+ │    │         │    │         │         ├── const-not-null-agg [type=bool, outer=(31)]
+ │    │         │    │         │         │    └── variable: true [type=bool, outer=(31)]
+ │    │         │    │         │         ├── const-agg [type=string, outer=(2)]
+ │    │         │    │         │         │    └── variable: flavors.name [type=string, outer=(2)]
+ │    │         │    │         │         ├── const-agg [type=int, outer=(3)]
+ │    │         │    │         │         │    └── variable: flavors.memory_mb [type=int, outer=(3)]
+ │    │         │    │         │         ├── const-agg [type=int, outer=(4)]
+ │    │         │    │         │         │    └── variable: flavors.vcpus [type=int, outer=(4)]
+ │    │         │    │         │         ├── const-agg [type=int, outer=(5)]
+ │    │         │    │         │         │    └── variable: flavors.root_gb [type=int, outer=(5)]
+ │    │         │    │         │         ├── const-agg [type=int, outer=(6)]
+ │    │         │    │         │         │    └── variable: flavors.ephemeral_gb [type=int, outer=(6)]
+ │    │         │    │         │         ├── const-agg [type=string, outer=(7)]
+ │    │         │    │         │         │    └── variable: flavors.flavorid [type=string, outer=(7)]
+ │    │         │    │         │         ├── const-agg [type=int, outer=(8)]
+ │    │         │    │         │         │    └── variable: flavors.swap [type=int, outer=(8)]
+ │    │         │    │         │         ├── const-agg [type=float, outer=(9)]
+ │    │         │    │         │         │    └── variable: flavors.rxtx_factor [type=float, outer=(9)]
+ │    │         │    │         │         ├── const-agg [type=int, outer=(10)]
+ │    │         │    │         │         │    └── variable: flavors.vcpu_weight [type=int, outer=(10)]
+ │    │         │    │         │         ├── const-agg [type=bool, outer=(11)]
+ │    │         │    │         │         │    └── variable: flavors.disabled [type=bool, outer=(11)]
+ │    │         │    │         │         ├── const-agg [type=bool, outer=(12)]
+ │    │         │    │         │         │    └── variable: flavors.is_public [type=bool, outer=(12)]
+ │    │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+ │    │         │    │         │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
+ │    │         │    │         │         └── const-agg [type=timestamp, outer=(15)]
+ │    │         │    │         │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
+ │    │         │    │         └── filters [type=bool, outer=(12,32)]
+ │    │         │    │              └── (flavors.is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,32)]
+ │    │         │    └── placeholder: $3 [type=int]
+ │    │         └── placeholder: $4 [type=int]
+ │    └── filters [type=bool, outer=(1,37), constraints=(/1: (/NULL - ]; /37: (/NULL - ]), fd=(1)==(37), (37)==(1)]
+ │         └── flavor_extra_specs.flavor_id = flavors.id [type=bool, outer=(1,37), constraints=(/1: (/NULL - ]; /37: (/NULL - ])]
+ └── true [type=bool]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -2614,204 +2616,201 @@ from (select instance_types.created_at as instance_types_created_at,
 order by anon_1.instance_types_flavorid asc,
          anon_1.instance_types_id asc
 ----
-sort
+left-join (lookup instance_type_extra_specs)
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:45(timestamp) instance_type_extra_specs_1_updated_at:46(timestamp) instance_type_extra_specs_1_deleted_at:44(timestamp) instance_type_extra_specs_1_deleted:43(bool) instance_type_extra_specs_1_id:39(int) instance_type_extra_specs_1_key:40(string) instance_type_extra_specs_1_value:41(string) instance_type_extra_specs_1_instance_type_id:42(int)
+ ├── key columns: [39] = [39]
  ├── key: (1,39)
  ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
  ├── ordering: +7,+1 opt(11)
- └── right-join
-      ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:39(int) key:40(string) value:41(string) instance_type_extra_specs.instance_type_id:42(int) instance_type_extra_specs.deleted:43(bool) instance_type_extra_specs.deleted_at:44(timestamp) instance_type_extra_specs.created_at:45(timestamp) instance_type_extra_specs.updated_at:46(timestamp)
-      ├── key: (1,39)
-      ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
-      ├── select
-      │    ├── columns: instance_type_extra_specs.id:39(int!null) key:40(string) value:41(string) instance_type_extra_specs.instance_type_id:42(int!null) instance_type_extra_specs.deleted:43(bool!null) instance_type_extra_specs.deleted_at:44(timestamp) instance_type_extra_specs.created_at:45(timestamp) instance_type_extra_specs.updated_at:46(timestamp)
-      │    ├── key: (39)
-      │    ├── fd: (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
-      │    ├── scan instance_type_extra_specs
-      │    │    ├── columns: instance_type_extra_specs.id:39(int!null) key:40(string) value:41(string) instance_type_extra_specs.instance_type_id:42(int!null) instance_type_extra_specs.deleted:43(bool) instance_type_extra_specs.deleted_at:44(timestamp) instance_type_extra_specs.created_at:45(timestamp) instance_type_extra_specs.updated_at:46(timestamp)
-      │    │    ├── key: (39)
-      │    │    └── fd: (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
-      │    └── filters [type=bool, outer=(43), constraints=(/43: (/NULL - ])]
-      │         └── instance_type_extra_specs.deleted = $9 [type=bool, outer=(43), constraints=(/43: (/NULL - ])]
-      ├── project
-      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │    ├── key: (1)
-      │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    └── limit
-      │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
-      │         ├── key: (1)
-      │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │         ├── offset
-      │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
-      │         │    ├── key: (1)
-      │         │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │         │    ├── ordering: +7,+1 opt(11)
-      │         │    ├── sort
-      │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
-      │         │    │    ├── key: (1)
-      │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │         │    │    ├── ordering: +7,+1 opt(11)
-      │         │    │    └── select
-      │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
-      │         │    │         ├── key: (1)
-      │         │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │         │    │         ├── group-by
-      │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
-      │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
-      │         │    │         │    ├── key: (1)
-      │         │    │         │    ├── fd: ()-->(11), (1)-->(2-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │         │    │         │    ├── left-join (merge)
-      │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:26(int) true:36(bool)
-      │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(36)
-      │         │    │         │    │    ├── sort
-      │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │         │    │         │    │    │    ├── key: (1)
-      │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │         │    │         │    │    │    ├── ordering: +1 opt(11)
-      │         │    │         │    │    │    └── project
-      │         │    │         │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │         │    │         │    │    │         ├── key: (1)
-      │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │         │    │         │    │    │         └── select
-      │         │    │         │    │    │              ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
-      │         │    │         │    │    │              ├── key: (1)
-      │         │    │         │    │    │              ├── fd: ()-->(11), (1)-->(2-10,12-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │         │    │         │    │    │              ├── group-by
-      │         │    │         │    │    │              │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
-      │         │    │         │    │    │              │    ├── grouping columns: instance_types.id:1(int!null)
-      │         │    │         │    │    │              │    ├── key: (1)
-      │         │    │         │    │    │              │    ├── fd: ()-->(11), (1)-->(2-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │         │    │         │    │    │              │    ├── left-join (merge)
-      │         │    │         │    │    │              │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:33(bool)
-      │         │    │         │    │    │              │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(33)
-      │         │    │         │    │    │              │    │    ├── select
-      │         │    │         │    │    │              │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │         │    │         │    │    │              │    │    │    ├── key: (1)
-      │         │    │         │    │    │              │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │         │    │         │    │    │              │    │    │    ├── ordering: +1 opt(11)
-      │         │    │         │    │    │              │    │    │    ├── scan instance_types
-      │         │    │         │    │    │              │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │         │    │         │    │    │              │    │    │    │    ├── key: (1)
-      │         │    │         │    │    │              │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         │    │         │    │    │              │    │    │    │    └── ordering: +1 opt(11)
-      │         │    │         │    │    │              │    │    │    └── filters [type=bool, outer=(11,13), constraints=(/11: [/false - /false]; /13: (/NULL - ]), fd=()-->(11)]
-      │         │    │         │    │    │              │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
-      │         │    │         │    │    │              │    │    │         └── instance_types.disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight)]
-      │         │    │         │    │    │              │    │    ├── project
-      │         │    │         │    │    │              │    │    │    ├── columns: true:33(bool!null) instance_type_projects.instance_type_id:18(int!null)
-      │         │    │         │    │    │              │    │    │    ├── fd: ()-->(33)
-      │         │    │         │    │    │              │    │    │    ├── ordering: +18 opt(33)
-      │         │    │         │    │    │              │    │    │    ├── select
-      │         │    │         │    │    │              │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) instance_type_projects.project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
-      │         │    │         │    │    │              │    │    │    │    ├── ordering: +18
-      │         │    │         │    │    │              │    │    │    │    ├── scan instance_type_projects@secondary
-      │         │    │         │    │    │              │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) instance_type_projects.project_id:19(string) instance_type_projects.deleted:20(bool)
-      │         │    │         │    │    │              │    │    │    │    │    └── ordering: +18
-      │         │    │         │    │    │              │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
-      │         │    │         │    │    │              │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
-      │         │    │         │    │    │              │    │    │    │         └── instance_type_projects.project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
-      │         │    │         │    │    │              │    │    │    └── projections [outer=(18)]
-      │         │    │         │    │    │              │    │    │         └── true [type=bool]
-      │         │    │         │    │    │              │    │    └── merge-on
-      │         │    │         │    │    │              │    │         ├── left ordering: +1
-      │         │    │         │    │    │              │    │         ├── right ordering: +18
-      │         │    │         │    │    │              │    │         └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
-      │         │    │         │    │    │              │    │              └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
-      │         │    │         │    │    │              │    └── aggregations [outer=(2-16,33)]
-      │         │    │         │    │    │              │         ├── const-not-null-agg [type=bool, outer=(33)]
-      │         │    │         │    │    │              │         │    └── variable: true [type=bool, outer=(33)]
-      │         │    │         │    │    │              │         ├── const-agg [type=string, outer=(2)]
-      │         │    │         │    │    │              │         │    └── variable: instance_types.name [type=string, outer=(2)]
-      │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(3)]
-      │         │    │         │    │    │              │         │    └── variable: instance_types.memory_mb [type=int, outer=(3)]
-      │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(4)]
-      │         │    │         │    │    │              │         │    └── variable: instance_types.vcpus [type=int, outer=(4)]
-      │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(5)]
-      │         │    │         │    │    │              │         │    └── variable: instance_types.root_gb [type=int, outer=(5)]
-      │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(6)]
-      │         │    │         │    │    │              │         │    └── variable: instance_types.ephemeral_gb [type=int, outer=(6)]
-      │         │    │         │    │    │              │         ├── const-agg [type=string, outer=(7)]
-      │         │    │         │    │    │              │         │    └── variable: instance_types.flavorid [type=string, outer=(7)]
-      │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(8)]
-      │         │    │         │    │    │              │         │    └── variable: instance_types.swap [type=int, outer=(8)]
-      │         │    │         │    │    │              │         ├── const-agg [type=float, outer=(9)]
-      │         │    │         │    │    │              │         │    └── variable: instance_types.rxtx_factor [type=float, outer=(9)]
-      │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(10)]
-      │         │    │         │    │    │              │         │    └── variable: instance_types.vcpu_weight [type=int, outer=(10)]
-      │         │    │         │    │    │              │         ├── const-agg [type=bool, outer=(11)]
-      │         │    │         │    │    │              │         │    └── variable: instance_types.disabled [type=bool, outer=(11)]
-      │         │    │         │    │    │              │         ├── const-agg [type=bool, outer=(12)]
-      │         │    │         │    │    │              │         │    └── variable: instance_types.is_public [type=bool, outer=(12)]
-      │         │    │         │    │    │              │         ├── const-agg [type=bool, outer=(13)]
-      │         │    │         │    │    │              │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
-      │         │    │         │    │    │              │         ├── const-agg [type=timestamp, outer=(14)]
-      │         │    │         │    │    │              │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
-      │         │    │         │    │    │              │         ├── const-agg [type=timestamp, outer=(15)]
-      │         │    │         │    │    │              │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
-      │         │    │         │    │    │              │         └── const-agg [type=timestamp, outer=(16)]
-      │         │    │         │    │    │              │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
-      │         │    │         │    │    │              └── filters [type=bool, outer=(12,34)]
-      │         │    │         │    │    │                   └── (instance_types.is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,34)]
-      │         │    │         │    │    ├── project
-      │         │    │         │    │    │    ├── columns: true:36(bool!null) instance_type_projects.instance_type_id:26(int!null)
-      │         │    │         │    │    │    ├── fd: ()-->(36)
-      │         │    │         │    │    │    ├── ordering: +26 opt(36)
-      │         │    │         │    │    │    ├── select
-      │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) instance_type_projects.project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
-      │         │    │         │    │    │    │    ├── ordering: +26
-      │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
-      │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) instance_type_projects.project_id:27(string) instance_type_projects.deleted:28(bool)
-      │         │    │         │    │    │    │    │    └── ordering: +26
-      │         │    │         │    │    │    │    └── filters [type=bool, outer=(27,28), constraints=(/27: (/NULL - ]; /28: (/NULL - ])]
-      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $4 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
-      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $5 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
-      │         │    │         │    │    │    │         └── instance_type_projects.project_id = $6 [type=bool, outer=(27), constraints=(/27: (/NULL - ])]
-      │         │    │         │    │    │    └── projections [outer=(26)]
-      │         │    │         │    │    │         └── true [type=bool]
-      │         │    │         │    │    └── merge-on
-      │         │    │         │    │         ├── left ordering: +1
-      │         │    │         │    │         ├── right ordering: +26
-      │         │    │         │    │         └── filters [type=bool, outer=(1,26), constraints=(/1: (/NULL - ]; /26: (/NULL - ]), fd=(1)==(26), (26)==(1)]
-      │         │    │         │    │              └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,26), constraints=(/1: (/NULL - ]; /26: (/NULL - ])]
-      │         │    │         │    └── aggregations [outer=(2-16,36)]
-      │         │    │         │         ├── const-not-null-agg [type=bool, outer=(36)]
-      │         │    │         │         │    └── variable: true [type=bool, outer=(36)]
-      │         │    │         │         ├── const-agg [type=string, outer=(2)]
-      │         │    │         │         │    └── variable: instance_types.name [type=string, outer=(2)]
-      │         │    │         │         ├── const-agg [type=int, outer=(3)]
-      │         │    │         │         │    └── variable: instance_types.memory_mb [type=int, outer=(3)]
-      │         │    │         │         ├── const-agg [type=int, outer=(4)]
-      │         │    │         │         │    └── variable: instance_types.vcpus [type=int, outer=(4)]
-      │         │    │         │         ├── const-agg [type=int, outer=(5)]
-      │         │    │         │         │    └── variable: instance_types.root_gb [type=int, outer=(5)]
-      │         │    │         │         ├── const-agg [type=int, outer=(6)]
-      │         │    │         │         │    └── variable: instance_types.ephemeral_gb [type=int, outer=(6)]
-      │         │    │         │         ├── const-agg [type=string, outer=(7)]
-      │         │    │         │         │    └── variable: instance_types.flavorid [type=string, outer=(7)]
-      │         │    │         │         ├── const-agg [type=int, outer=(8)]
-      │         │    │         │         │    └── variable: instance_types.swap [type=int, outer=(8)]
-      │         │    │         │         ├── const-agg [type=float, outer=(9)]
-      │         │    │         │         │    └── variable: instance_types.rxtx_factor [type=float, outer=(9)]
-      │         │    │         │         ├── const-agg [type=int, outer=(10)]
-      │         │    │         │         │    └── variable: instance_types.vcpu_weight [type=int, outer=(10)]
-      │         │    │         │         ├── const-agg [type=bool, outer=(11)]
-      │         │    │         │         │    └── variable: instance_types.disabled [type=bool, outer=(11)]
-      │         │    │         │         ├── const-agg [type=bool, outer=(12)]
-      │         │    │         │         │    └── variable: instance_types.is_public [type=bool, outer=(12)]
-      │         │    │         │         ├── const-agg [type=bool, outer=(13)]
-      │         │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
-      │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
-      │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
-      │         │    │         │         ├── const-agg [type=timestamp, outer=(15)]
-      │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
-      │         │    │         │         └── const-agg [type=timestamp, outer=(16)]
-      │         │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
-      │         │    │         └── filters [type=bool, outer=(12,37)]
-      │         │    │              └── (instance_types.is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,37)]
-      │         │    └── placeholder: $7 [type=int]
-      │         └── placeholder: $8 [type=int]
-      └── filters [type=bool, outer=(1,42), constraints=(/1: (/NULL - ]; /42: (/NULL - ]), fd=(1)==(42), (42)==(1)]
-           └── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,42), constraints=(/1: (/NULL - ]; /42: (/NULL - ])]
+ ├── left-join (lookup instance_type_extra_specs@secondary)
+ │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:39(int) key:40(string) instance_type_extra_specs.instance_type_id:42(int) instance_type_extra_specs.deleted:43(bool)
+ │    ├── key columns: [1] = [42]
+ │    ├── key: (1,39)
+ │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40,42,43), (40,42,43)~~>(39)
+ │    ├── ordering: +7,+1 opt(11)
+ │    ├── project
+ │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │    ├── key: (1)
+ │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+ │    │    ├── ordering: +7,+1 opt(11)
+ │    │    └── limit
+ │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+ │    │         ├── key: (1)
+ │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+ │    │         ├── ordering: +7,+1 opt(11)
+ │    │         ├── offset
+ │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+ │    │         │    ├── key: (1)
+ │    │         │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+ │    │         │    ├── ordering: +7,+1 opt(11)
+ │    │         │    ├── sort
+ │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+ │    │         │    │    ├── key: (1)
+ │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+ │    │         │    │    ├── ordering: +7,+1 opt(11)
+ │    │         │    │    └── select
+ │    │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+ │    │         │    │         ├── key: (1)
+ │    │         │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+ │    │         │    │         ├── group-by
+ │    │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+ │    │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+ │    │         │    │         │    ├── key: (1)
+ │    │         │    │         │    ├── fd: ()-->(11), (1)-->(2-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+ │    │         │    │         │    ├── left-join (merge)
+ │    │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:26(int) true:36(bool)
+ │    │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(36)
+ │    │         │    │         │    │    ├── sort
+ │    │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │         │    │         │    │    │    ├── key: (1)
+ │    │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+ │    │         │    │         │    │    │    ├── ordering: +1 opt(11)
+ │    │         │    │         │    │    │    └── project
+ │    │         │    │         │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │         │    │         │    │    │         ├── key: (1)
+ │    │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+ │    │         │    │         │    │    │         └── select
+ │    │         │    │         │    │    │              ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
+ │    │         │    │         │    │    │              ├── key: (1)
+ │    │         │    │         │    │    │              ├── fd: ()-->(11), (1)-->(2-10,12-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+ │    │         │    │         │    │    │              ├── group-by
+ │    │         │    │         │    │    │              │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
+ │    │         │    │         │    │    │              │    ├── grouping columns: instance_types.id:1(int!null)
+ │    │         │    │         │    │    │              │    ├── key: (1)
+ │    │         │    │         │    │    │              │    ├── fd: ()-->(11), (1)-->(2-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+ │    │         │    │         │    │    │              │    ├── left-join (merge)
+ │    │         │    │         │    │    │              │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:33(bool)
+ │    │         │    │         │    │    │              │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(33)
+ │    │         │    │         │    │    │              │    │    ├── select
+ │    │         │    │         │    │    │              │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │         │    │         │    │    │              │    │    │    ├── key: (1)
+ │    │         │    │         │    │    │              │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+ │    │         │    │         │    │    │              │    │    │    ├── ordering: +1 opt(11)
+ │    │         │    │         │    │    │              │    │    │    ├── scan instance_types
+ │    │         │    │         │    │    │              │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │         │    │         │    │    │              │    │    │    │    ├── key: (1)
+ │    │         │    │         │    │    │              │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │    │         │    │         │    │    │              │    │    │    │    └── ordering: +1 opt(11)
+ │    │         │    │         │    │    │              │    │    │    └── filters [type=bool, outer=(11,13), constraints=(/11: [/false - /false]; /13: (/NULL - ]), fd=()-->(11)]
+ │    │         │    │         │    │    │              │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+ │    │         │    │         │    │    │              │    │    │         └── instance_types.disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight)]
+ │    │         │    │         │    │    │              │    │    ├── project
+ │    │         │    │         │    │    │              │    │    │    ├── columns: true:33(bool!null) instance_type_projects.instance_type_id:18(int!null)
+ │    │         │    │         │    │    │              │    │    │    ├── fd: ()-->(33)
+ │    │         │    │         │    │    │              │    │    │    ├── ordering: +18 opt(33)
+ │    │         │    │         │    │    │              │    │    │    ├── select
+ │    │         │    │         │    │    │              │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) instance_type_projects.project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+ │    │         │    │         │    │    │              │    │    │    │    ├── ordering: +18
+ │    │         │    │         │    │    │              │    │    │    │    ├── scan instance_type_projects@secondary
+ │    │         │    │         │    │    │              │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) instance_type_projects.project_id:19(string) instance_type_projects.deleted:20(bool)
+ │    │         │    │         │    │    │              │    │    │    │    │    └── ordering: +18
+ │    │         │    │         │    │    │              │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+ │    │         │    │         │    │    │              │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+ │    │         │    │         │    │    │              │    │    │    │         └── instance_type_projects.project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+ │    │         │    │         │    │    │              │    │    │    └── projections [outer=(18)]
+ │    │         │    │         │    │    │              │    │    │         └── true [type=bool]
+ │    │         │    │         │    │    │              │    │    └── merge-on
+ │    │         │    │         │    │    │              │    │         ├── left ordering: +1
+ │    │         │    │         │    │    │              │    │         ├── right ordering: +18
+ │    │         │    │         │    │    │              │    │         └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+ │    │         │    │         │    │    │              │    │              └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+ │    │         │    │         │    │    │              │    └── aggregations [outer=(2-16,33)]
+ │    │         │    │         │    │    │              │         ├── const-not-null-agg [type=bool, outer=(33)]
+ │    │         │    │         │    │    │              │         │    └── variable: true [type=bool, outer=(33)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=string, outer=(2)]
+ │    │         │    │         │    │    │              │         │    └── variable: instance_types.name [type=string, outer=(2)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(3)]
+ │    │         │    │         │    │    │              │         │    └── variable: instance_types.memory_mb [type=int, outer=(3)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(4)]
+ │    │         │    │         │    │    │              │         │    └── variable: instance_types.vcpus [type=int, outer=(4)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(5)]
+ │    │         │    │         │    │    │              │         │    └── variable: instance_types.root_gb [type=int, outer=(5)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(6)]
+ │    │         │    │         │    │    │              │         │    └── variable: instance_types.ephemeral_gb [type=int, outer=(6)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=string, outer=(7)]
+ │    │         │    │         │    │    │              │         │    └── variable: instance_types.flavorid [type=string, outer=(7)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(8)]
+ │    │         │    │         │    │    │              │         │    └── variable: instance_types.swap [type=int, outer=(8)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=float, outer=(9)]
+ │    │         │    │         │    │    │              │         │    └── variable: instance_types.rxtx_factor [type=float, outer=(9)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=int, outer=(10)]
+ │    │         │    │         │    │    │              │         │    └── variable: instance_types.vcpu_weight [type=int, outer=(10)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=bool, outer=(11)]
+ │    │         │    │         │    │    │              │         │    └── variable: instance_types.disabled [type=bool, outer=(11)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=bool, outer=(12)]
+ │    │         │    │         │    │    │              │         │    └── variable: instance_types.is_public [type=bool, outer=(12)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=bool, outer=(13)]
+ │    │         │    │         │    │    │              │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=timestamp, outer=(14)]
+ │    │         │    │         │    │    │              │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+ │    │         │    │         │    │    │              │         ├── const-agg [type=timestamp, outer=(15)]
+ │    │         │    │         │    │    │              │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+ │    │         │    │         │    │    │              │         └── const-agg [type=timestamp, outer=(16)]
+ │    │         │    │         │    │    │              │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+ │    │         │    │         │    │    │              └── filters [type=bool, outer=(12,34)]
+ │    │         │    │         │    │    │                   └── (instance_types.is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,34)]
+ │    │         │    │         │    │    ├── project
+ │    │         │    │         │    │    │    ├── columns: true:36(bool!null) instance_type_projects.instance_type_id:26(int!null)
+ │    │         │    │         │    │    │    ├── fd: ()-->(36)
+ │    │         │    │         │    │    │    ├── ordering: +26 opt(36)
+ │    │         │    │         │    │    │    ├── select
+ │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) instance_type_projects.project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
+ │    │         │    │         │    │    │    │    ├── ordering: +26
+ │    │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
+ │    │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) instance_type_projects.project_id:27(string) instance_type_projects.deleted:28(bool)
+ │    │         │    │         │    │    │    │    │    └── ordering: +26
+ │    │         │    │         │    │    │    │    └── filters [type=bool, outer=(27,28), constraints=(/27: (/NULL - ]; /28: (/NULL - ])]
+ │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $4 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
+ │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $5 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
+ │    │         │    │         │    │    │    │         └── instance_type_projects.project_id = $6 [type=bool, outer=(27), constraints=(/27: (/NULL - ])]
+ │    │         │    │         │    │    │    └── projections [outer=(26)]
+ │    │         │    │         │    │    │         └── true [type=bool]
+ │    │         │    │         │    │    └── merge-on
+ │    │         │    │         │    │         ├── left ordering: +1
+ │    │         │    │         │    │         ├── right ordering: +26
+ │    │         │    │         │    │         └── filters [type=bool, outer=(1,26), constraints=(/1: (/NULL - ]; /26: (/NULL - ]), fd=(1)==(26), (26)==(1)]
+ │    │         │    │         │    │              └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,26), constraints=(/1: (/NULL - ]; /26: (/NULL - ])]
+ │    │         │    │         │    └── aggregations [outer=(2-16,36)]
+ │    │         │    │         │         ├── const-not-null-agg [type=bool, outer=(36)]
+ │    │         │    │         │         │    └── variable: true [type=bool, outer=(36)]
+ │    │         │    │         │         ├── const-agg [type=string, outer=(2)]
+ │    │         │    │         │         │    └── variable: instance_types.name [type=string, outer=(2)]
+ │    │         │    │         │         ├── const-agg [type=int, outer=(3)]
+ │    │         │    │         │         │    └── variable: instance_types.memory_mb [type=int, outer=(3)]
+ │    │         │    │         │         ├── const-agg [type=int, outer=(4)]
+ │    │         │    │         │         │    └── variable: instance_types.vcpus [type=int, outer=(4)]
+ │    │         │    │         │         ├── const-agg [type=int, outer=(5)]
+ │    │         │    │         │         │    └── variable: instance_types.root_gb [type=int, outer=(5)]
+ │    │         │    │         │         ├── const-agg [type=int, outer=(6)]
+ │    │         │    │         │         │    └── variable: instance_types.ephemeral_gb [type=int, outer=(6)]
+ │    │         │    │         │         ├── const-agg [type=string, outer=(7)]
+ │    │         │    │         │         │    └── variable: instance_types.flavorid [type=string, outer=(7)]
+ │    │         │    │         │         ├── const-agg [type=int, outer=(8)]
+ │    │         │    │         │         │    └── variable: instance_types.swap [type=int, outer=(8)]
+ │    │         │    │         │         ├── const-agg [type=float, outer=(9)]
+ │    │         │    │         │         │    └── variable: instance_types.rxtx_factor [type=float, outer=(9)]
+ │    │         │    │         │         ├── const-agg [type=int, outer=(10)]
+ │    │         │    │         │         │    └── variable: instance_types.vcpu_weight [type=int, outer=(10)]
+ │    │         │    │         │         ├── const-agg [type=bool, outer=(11)]
+ │    │         │    │         │         │    └── variable: instance_types.disabled [type=bool, outer=(11)]
+ │    │         │    │         │         ├── const-agg [type=bool, outer=(12)]
+ │    │         │    │         │         │    └── variable: instance_types.is_public [type=bool, outer=(12)]
+ │    │         │    │         │         ├── const-agg [type=bool, outer=(13)]
+ │    │         │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+ │    │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+ │    │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+ │    │         │    │         │         ├── const-agg [type=timestamp, outer=(15)]
+ │    │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+ │    │         │    │         │         └── const-agg [type=timestamp, outer=(16)]
+ │    │         │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+ │    │         │    │         └── filters [type=bool, outer=(12,37)]
+ │    │         │    │              └── (instance_types.is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,37)]
+ │    │         │    └── placeholder: $7 [type=int]
+ │    │         └── placeholder: $8 [type=int]
+ │    └── filters [type=bool, outer=(1,42,43), constraints=(/1: (/NULL - ]; /42: (/NULL - ]; /43: (/NULL - ]), fd=(1)==(42), (42)==(1)]
+ │         ├── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,42), constraints=(/1: (/NULL - ]; /42: (/NULL - ])]
+ │         └── instance_type_extra_specs.deleted = $9 [type=bool, outer=(43), constraints=(/43: (/NULL - ])]
+ └── true [type=bool]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1197,3 +1197,175 @@ New expression 1 of 1:
         └── abc.a > 1 [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
 ----
 ----
+
+# --------------------------------------------------
+# PushJoinThroughIndexJoin
+# --------------------------------------------------
+
+exec-ddl
+CREATE TABLE uvw
+(
+    u INT PRIMARY KEY,
+    v INT,
+    w INT,
+    INDEX v (v)
+)
+----
+TABLE uvw
+ ├── u int not null
+ ├── v int
+ ├── w int
+ ├── INDEX primary
+ │    └── u int not null
+ └── INDEX v
+      ├── v int
+      └── u int not null
+
+exploretrace rule=PushJoinThroughIndexJoin
+SELECT * FROM abc JOIN uvw ON a=u
+----
+----
+================================================================================
+PushJoinThroughIndexJoin
+================================================================================
+Source expression:
+  inner-join
+   ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int) w:7(int)
+   ├── fd: (5)-->(6,7), (1)==(5), (5)==(1)
+   ├── scan abc
+   │    └── columns: a:1(int) b:2(int) c:3(int)
+   ├── scan uvw
+   │    ├── columns: u:5(int!null) v:6(int) w:7(int)
+   │    ├── key: (5)
+   │    └── fd: (5)-->(6,7)
+   └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+        └── abc.a = uvw.u [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+
+New expression 1 of 1:
+  inner-join (lookup uvw)
+   ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int) w:7(int)
+   ├── key columns: [5] = [5]
+   ├── fd: (5)-->(6,7), (1)==(5), (5)==(1)
+   ├── inner-join
+   │    ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int)
+   │    ├── fd: (5)-->(6), (1)==(5), (5)==(1)
+   │    ├── scan abc
+   │    │    └── columns: a:1(int) b:2(int) c:3(int)
+   │    ├── scan uvw@v
+   │    │    ├── columns: u:5(int!null) v:6(int)
+   │    │    ├── key: (5)
+   │    │    └── fd: (5)-->(6)
+   │    └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+   │         └── abc.a = uvw.u [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+   └── true [type=bool]
+
+================================================================================
+PushJoinThroughIndexJoin
+================================================================================
+Source expression:
+  inner-join
+   ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int) w:7(int)
+   ├── fd: (5)-->(6,7), (1)==(5), (5)==(1)
+   ├── scan abc
+   │    └── columns: a:1(int) b:2(int) c:3(int)
+   ├── scan uvw
+   │    ├── columns: u:5(int!null) v:6(int) w:7(int)
+   │    ├── key: (5)
+   │    └── fd: (5)-->(6,7)
+   └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+        └── abc.a = uvw.u [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+
+New expression 1 of 1:
+  inner-join (lookup uvw)
+   ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int) w:7(int)
+   ├── key columns: [5] = [5]
+   ├── fd: (5)-->(6,7), (1)==(5), (5)==(1)
+   ├── inner-join
+   │    ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int)
+   │    ├── fd: (5)-->(6), (1)==(5), (5)==(1)
+   │    ├── scan abc
+   │    │    └── columns: a:1(int) b:2(int) c:3(int)
+   │    ├── scan uvw@v,rev
+   │    │    ├── columns: u:5(int!null) v:6(int)
+   │    │    ├── key: (5)
+   │    │    └── fd: (5)-->(6)
+   │    └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+   │         └── abc.a = uvw.u [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+   └── true [type=bool]
+----
+----
+
+exec-ddl
+ALTER TABLE abc INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 1,
+    "distinct_count": 1
+  }
+]'
+----
+
+exec-ddl
+ALTER TABLE uvw INJECT STATISTICS '[
+  {
+    "columns": ["u"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 10,
+    "distinct_count": 10
+  }
+]'
+----
+
+opt
+SELECT * FROM abc JOIN uvw ON a=v
+----
+inner-join (lookup uvw)
+ ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int!null) w:7(int)
+ ├── key columns: [5] = [5]
+ ├── fd: (5)-->(6,7), (1)==(6), (6)==(1)
+ ├── inner-join (lookup uvw@v)
+ │    ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int!null)
+ │    ├── key columns: [1] = [6]
+ │    ├── fd: (5)-->(6), (1)==(6), (6)==(1)
+ │    ├── scan abc
+ │    │    └── columns: a:1(int) b:2(int) c:3(int)
+ │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │         └── abc.a = uvw.v [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+ └── true [type=bool]
+
+opt
+SELECT * FROM abc JOIN uvw ON a=v AND b+u>1
+----
+inner-join (lookup uvw)
+ ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int!null) w:7(int)
+ ├── key columns: [5] = [5]
+ ├── fd: (5)-->(6,7), (1)==(6), (6)==(1)
+ ├── inner-join (lookup uvw@v)
+ │    ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int!null)
+ │    ├── key columns: [1] = [6]
+ │    ├── fd: (5)-->(6), (1)==(6), (6)==(1)
+ │    ├── scan abc
+ │    │    └── columns: a:1(int) b:2(int) c:3(int)
+ │    └── filters [type=bool, outer=(1,2,5,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │         ├── abc.a = uvw.v [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+ │         └── (abc.b + uvw.u) > 1 [type=bool, outer=(2,5)]
+ └── true [type=bool]
+
+opt
+SELECT * FROM abc JOIN uvw ON a=v WHERE b+w>1
+----
+inner-join (lookup uvw)
+ ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int!null) w:7(int)
+ ├── key columns: [5] = [5]
+ ├── fd: (5)-->(6,7), (1)==(6), (6)==(1)
+ ├── inner-join (lookup uvw@v)
+ │    ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int!null)
+ │    ├── key columns: [1] = [6]
+ │    ├── fd: (5)-->(6), (1)==(6), (6)==(1)
+ │    ├── scan abc
+ │    │    └── columns: a:1(int) b:2(int) c:3(int)
+ │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │         └── abc.a = uvw.v [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+ └── filters [type=bool, outer=(2,7)]
+      └── (abc.b + uvw.w) > 1 [type=bool, outer=(2,7)]

--- a/pkg/sql/opt/xfunc/custom_funcs.go
+++ b/pkg/sql/opt/xfunc/custom_funcs.go
@@ -153,7 +153,22 @@ func (c *CustomFuncs) ExtractBoundConditions(list memo.ListID, group memo.GroupI
 	return lb.BuildList()
 }
 
-// ExtractUnboundConditions is the inverse of extractBoundConditions. Instead of
+// ExtractBoundConditions2 is a variant of ExtractBoundConditions which extracts
+// conditions that are fully bound by the union of columns produced by two
+// expressions.
+func (c *CustomFuncs) ExtractBoundConditions2(
+	list memo.ListID, group1, group2 memo.GroupID,
+) memo.ListID {
+	lb := MakeListBuilder(c)
+	for _, item := range c.mem.LookupList(list) {
+		if c.IsBoundBy2(item, group1, group2) {
+			lb.AddItem(item)
+		}
+	}
+	return lb.BuildList()
+}
+
+// ExtractUnboundConditions is the inverse of ExtractBoundConditions. Instead of
 // extracting expressions that are bound by the given expression, it extracts
 // list expressions that have at least one outer reference that is *not* bound
 // by the given expression (i.e. it has a "free" variable).


### PR DESCRIPTION
When there is a join on top of an index join and the ON condition only
refers to columns that are available before the index join, we can do
the join first and then join with the primary index.

The main goal is to be able to do lookup joins that use non-covering
indexes; this requires the lookup join to happen before ("under") the
index join. The new rules in conjunction with the existing lookup join
rules achieve this.

Release note: None

As is the PR is light on tests; I am working on reenabling the relevant lookup join tests.