### PR TITLE
storage: retry failed liveness heartbeats in tests

### DIFF
--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -1207,7 +1207,13 @@ func (m *multiTestContext) heartbeatLiveness(ctx context.Context, store int) err
 	if err != nil {
 		return err
 	}
-	return nl.Heartbeat(ctx, l)
+
+	for r := retry.StartWithCtx(ctx, retry.Options{MaxRetries: 5}); r.Next(); {
+		if err = nl.Heartbeat(ctx, l); err != storage.ErrEpochIncremented {
+			break
+		}
+	}
+	return err
 }
 
 // advanceClock advances the mtc's manual clock such that all


### PR DESCRIPTION
Teach multiTestContext.heartbeatLiveness to retry heartbeats that fail
due to ErrEpochIncremented. This error is expected when the heartbeat
races with an epoch increment from another store.

Fix #27835.

Release note: None

---

@nvanbenschoten you mind taking this one? Should be real quick.