### PR TITLE
server: fix crash when getting disk stats on mac

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -772,6 +772,12 @@
   version = "v0.15.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/lufia/iostat"
+  packages = ["."]
+  revision = "9f7362b77ad333b26c01c99de52a11bdb650ded2"
+
+[[projects]]
   name = "github.com/marstr/guid"
   packages = ["."]
   revision = "8bd9a64bf37eb297b492a4101fb28e80ac0b290f"
@@ -1318,6 +1324,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7356b2f481042b2b79a78bd5541e8c7d40e8073cbb5d6c6f0854c9dcfd9455b0"
+  inputs-digest = "24f1631a158f62585d7805d142405d71312f2609b00cb7a3d268b18b9f5f7f32"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/server/status/disk_counters.go
+++ b/pkg/server/status/disk_counters.go
@@ -1,0 +1,47 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build !darwin
+
+package status
+
+import (
+	"context"
+
+	"github.com/shirou/gopsutil/disk"
+)
+
+func getDiskCounters(ctx context.Context) ([]diskStats, error) {
+	driveStats, err := disk.IOCountersWithContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	output := make([]diskStats, len(driveStats))
+	i := 0
+	for _, counters := range driveStats {
+		output[i] = diskStats{
+			readBytes:      int64(counters.ReadBytes),
+			readTimeMs:     int64(counters.ReadTime),
+			readCount:      int64(counters.ReadCount),
+			writeBytes:     int64(counters.WriteBytes),
+			writeTimeMs:    int64(counters.WriteTime),
+			writeCount:     int64(counters.WriteCount),
+			iopsInProgress: int64(counters.IopsInProgress),
+		}
+		i++
+	}
+
+	return output, nil
+}

--- a/pkg/server/status/disk_counters_darwin.go
+++ b/pkg/server/status/disk_counters_darwin.go
@@ -1,0 +1,45 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build darwin
+
+package status
+
+import (
+	"context"
+
+	"github.com/lufia/iostat"
+)
+
+func getDiskCounters(context.Context) ([]diskStats, error) {
+	driveStats, err := iostat.ReadDriveStats()
+	if err != nil {
+		return nil, err
+	}
+
+	output := make([]diskStats, len(driveStats))
+	for i, counters := range driveStats {
+		output[i] = diskStats{
+			readBytes:      counters.BytesRead,
+			readCount:      counters.NumRead,
+			readTimeMs:     int64(counters.TotalReadTime),
+			writeBytes:     counters.BytesWritten,
+			writeCount:     counters.NumWrite,
+			writeTimeMs:    int64(counters.TotalWriteTime),
+			iopsInProgress: 0, // Not reported by this library. (#27927)
+		}
+	}
+
+	return output, nil
+}

--- a/pkg/server/status/runtime_test.go
+++ b/pkg/server/status/runtime_test.go
@@ -15,48 +15,46 @@
 package status
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/shirou/gopsutil/disk"
 	"github.com/shirou/gopsutil/net"
 )
 
 func TestSumDiskCounters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	counters := map[string]disk.IOCountersStat{
-		"disk0": {
-			ReadBytes:      1,
-			ReadTime:       1,
-			ReadCount:      1,
-			IopsInProgress: 1,
-			WriteBytes:     1,
-			WriteTime:      1,
-			WriteCount:     1,
+	counters := []diskStats{
+		{
+			readBytes:      1,
+			readTimeMs:     1,
+			readCount:      1,
+			iopsInProgress: 1,
+			writeBytes:     1,
+			writeTimeMs:    1,
+			writeCount:     1,
 		},
-		"disk1": {
-			ReadBytes:      1,
-			ReadTime:       1,
-			ReadCount:      1,
-			IopsInProgress: 1,
-			WriteBytes:     1,
-			WriteTime:      1,
-			WriteCount:     1,
+		{
+			readBytes:      1,
+			readTimeMs:     1,
+			readCount:      1,
+			iopsInProgress: 1,
+			writeBytes:     1,
+			writeTimeMs:    1,
+			writeCount:     1,
 		},
 	}
 	summed := sumDiskCounters(counters)
-	expected := disk.IOCountersStat{
-		ReadBytes:      2,
-		ReadTime:       2,
-		ReadCount:      2,
-		WriteBytes:     2,
-		WriteTime:      2,
-		WriteCount:     2,
-		IopsInProgress: 2,
+	expected := diskStats{
+		readBytes:      2,
+		readTimeMs:     2,
+		readCount:      2,
+		writeBytes:     2,
+		writeTimeMs:    2,
+		writeCount:     2,
+		iopsInProgress: 2,
 	}
 	if !reflect.DeepEqual(summed, expected) {
 		t.Fatalf("expected %+v; got %+v", expected, summed)
@@ -95,32 +93,32 @@ func TestSumNetCounters(t *testing.T) {
 func TestSubtractDiskCounters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	from := disk.IOCountersStat{
-		ReadBytes:      3,
-		ReadTime:       3,
-		ReadCount:      3,
-		WriteBytes:     3,
-		WriteTime:      3,
-		WriteCount:     3,
-		IopsInProgress: 3,
+	from := diskStats{
+		readBytes:      3,
+		readTimeMs:     3,
+		readCount:      3,
+		writeBytes:     3,
+		writeTimeMs:    3,
+		writeCount:     3,
+		iopsInProgress: 3,
 	}
-	sub := disk.IOCountersStat{
-		ReadBytes:      1,
-		ReadTime:       1,
-		ReadCount:      1,
-		IopsInProgress: 1,
-		WriteBytes:     1,
-		WriteTime:      1,
-		WriteCount:     1,
+	sub := diskStats{
+		readBytes:      1,
+		readTimeMs:     1,
+		readCount:      1,
+		iopsInProgress: 1,
+		writeBytes:     1,
+		writeTimeMs:    1,
+		writeCount:     1,
 	}
-	expected := disk.IOCountersStat{
-		ReadBytes:      2,
-		ReadTime:       2,
-		ReadCount:      2,
-		WriteBytes:     2,
-		WriteTime:      2,
-		WriteCount:     2,
-		IopsInProgress: 2,
+	expected := diskStats{
+		readBytes:      2,
+		readTimeMs:     2,
+		readCount:      2,
+		writeBytes:     2,
+		writeTimeMs:    2,
+		writeCount:     2,
+		iopsInProgress: 2,
 	}
 	subtractDiskCounters(&from, sub)
 	if !reflect.DeepEqual(from, expected) {


### PR DESCRIPTION
The hardware stats library, gopsutil, uses unguarded shared mutable state on darwin while gathering disk stats. Thus, it crashes during the tests, which use many servers concurrently. This change uses a different library to gather these stats on darwin.

Fixes #27867

Release note: None