### PR TITLE
sql: fix fmt of CastExprs with collated types

### DIFF
--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -735,3 +735,11 @@ render              ·         ·                                           (x i
 
 statement error EXPLAIN \(OPT\) only supported with the cost-based optimizer
 EXPLAIN (OPT) SELECT 1
+
+# Make sure that casts of null values to collated strings roundtrip correctly.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT NULL COLLATE en
+----
+render         ·         ·                                ("?column?")  "?column?"=CONST
+ │             render 0  CAST(NULL AS STRING) COLLATE en  ·             ·
+ └── emptyrow  ·         ·                                ()            ·

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1362,8 +1362,17 @@ func (node *CastExpr) Format(ctx *FmtCtx) {
 		ctx.WriteString("CAST(")
 		ctx.FormatNode(node.Expr)
 		ctx.WriteString(" AS ")
-		node.Type.Format(buf, ctx.flags.EncodeFlags())
+		t, isCollatedString := node.Type.(*coltypes.TCollatedString)
+		typ := node.Type
+		if isCollatedString {
+			typ = coltypes.String
+		}
+		typ.Format(buf, ctx.flags.EncodeFlags())
 		ctx.WriteByte(')')
+		if isCollatedString {
+			ctx.WriteString(" COLLATE ")
+			lex.EncodeUnrestrictedSQLIdent(ctx.Buffer, t.Locale, lex.EncNoFlags)
+		}
 	}
 }
 

--- a/pkg/sql/sem/tree/normalize_test.go
+++ b/pkg/sql/sem/tree/normalize_test.go
@@ -213,6 +213,7 @@ func TestNormalizeExpr(t *testing.T) {
 		// #15454: ensure that operators are pretty-printed correctly after normalization.
 		{`(random() + 1.0)::INT`, `(random() + 1.0)::INT`},
 		{`('a' || left('b', random()::INT)) COLLATE en`, `('a' || left('b', random()::INT)) COLLATE en`},
+		{`NULL COLLATE en`, `CAST(NULL AS STRING) COLLATE en`},
 		{`(1.0 + random()) IS OF (INT)`, `(1.0 + random()) IS OF (INT)`},
 		// #14687: ensure that negative divisors flip the inequality when rotating.
 		{`1 < a / -2`, `a < -2`},

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -848,7 +848,11 @@ func (node *CastExpr) doc(p *PrettyCfg) pretty.Doc {
 			typ,
 		)
 	default:
-		return pretty.Fold(pretty.Concat,
+		t, isCollatedString := node.Type.(*coltypes.TCollatedString)
+		if isCollatedString {
+			typ = pretty.Text(coltypes.String.String())
+		}
+		ret := pretty.Fold(pretty.Concat,
 			pretty.Text("CAST"),
 			pretty.Bracket(
 				"(",
@@ -862,6 +866,14 @@ func (node *CastExpr) doc(p *PrettyCfg) pretty.Doc {
 				")",
 			),
 		)
+
+		if isCollatedString {
+			ret = pretty.Fold(pretty.ConcatSpace,
+				ret,
+				pretty.Text("COLLATE"),
+				pretty.Text(t.Locale))
+		}
+		return ret
 	}
 }
 

--- a/pkg/sql/sem/tree/pretty_test.go
+++ b/pkg/sql/sem/tree/pretty_test.go
@@ -26,6 +26,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -178,6 +179,22 @@ func BenchmarkPrettyData(b *testing.B) {
 			for _, w := range []int{1, 30, 80} {
 				pretty.Pretty(doc, w, true /*useTabs*/, 4 /*tabWidth*/)
 			}
+		}
+	}
+}
+
+func TestPrettyExprs(t *testing.T) {
+	tests := map[tree.Expr]string{
+		&tree.CastExpr{
+			Expr: tree.NewDString("foo"),
+			Type: &coltypes.TCollatedString{Locale: "en"},
+		}: `CAST('foo':::STRING AS STRING) COLLATE en`,
+	}
+
+	for expr, pretty := range tests {
+		got := tree.Pretty(expr)
+		if pretty != got {
+			t.Fatalf("got: %s\nexpected: %s", got, pretty)
 		}
 	}
 }


### PR DESCRIPTION
Previously, formatting a CastExpr of a value to a collated string type
would produce an unparseable representation, due to the fact that
collated string types aren't ordinary types in our parser.

Before, CastExpr(3, collated string (en)) would be formatted as
`CAST(3 AS STRING COLLATE en)` which is invalid syntax. Now, it's
formatted as `CAST(3 as STRING) COLLATE en` which is valid.

Release note (bug fix): fix roundtripping of cast expression formatting
in the presence of collated strings.