### PR TITLE
distsqlrun: start indexjoiner's row fetcher input

### DIFF
--- a/pkg/sql/distsqlrun/indexjoiner.go
+++ b/pkg/sql/distsqlrun/indexjoiner.go
@@ -125,6 +125,7 @@ func newIndexJoiner(
 // Start is part of the RowSource interface.
 func (ij *indexJoiner) Start(ctx context.Context) context.Context {
 	ij.input.Start(ctx)
+	ij.fetcherInput.Start(ctx)
 	return ij.startInternal(ctx, indexJoinerProcName)
 }
 


### PR DESCRIPTION
Fixes #27914.

Previously, indexjoiner failed to start its input RowFetcherWrapper.
This caused a potential panic with logging and kv tracing, and is
corrected by this patch.

Release note (bug fix): fix a panic caused by kv tracing a plan that
uses an index joiner