### PR TITLE
sql: add support for server_encoding

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1292,6 +1292,7 @@ intervalstyle                   postgres      NULL      NULL        NULL        
 max_index_keys                  32            NULL      NULL        NULL        string
 node_id                         1             NULL      NULL        NULL        string
 search_path                     public        NULL      NULL        NULL        string
+server_encoding                 UTF8          NULL      NULL        NULL        string
 server_version                  9.5.0         NULL      NULL        NULL        string
 server_version_num              90500         NULL      NULL        NULL        string
 session_user                    root          NULL      NULL        NULL        string
@@ -1325,6 +1326,7 @@ intervalstyle                   postgres      NULL  user     NULL      postgres 
 max_index_keys                  32            NULL  user     NULL      32            32
 node_id                         1             NULL  user     NULL      1             1
 search_path                     public        NULL  user     NULL      public        public
+server_encoding                 UTF8          NULL  user     NULL      UTF8          UTF8
 server_version                  9.5.0         NULL  user     NULL      9.5.0         9.5.0
 server_version_num              90500         NULL  user     NULL      90500         90500
 session_user                    root          NULL  user     NULL      root          root
@@ -1359,6 +1361,7 @@ intervalstyle                   NULL    NULL     NULL     NULL        NULL
 max_index_keys                  NULL    NULL     NULL     NULL        NULL
 node_id                         NULL    NULL     NULL     NULL        NULL
 search_path                     NULL    NULL     NULL     NULL        NULL
+server_encoding                 NULL    NULL     NULL     NULL        NULL
 server_version                  NULL    NULL     NULL     NULL        NULL
 server_version_num              NULL    NULL     NULL     NULL        NULL
 session_user                    NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -130,6 +130,15 @@ statement error non-UTF8 encoding other not supported
 SET client_encoding = 'other'
 
 statement ok
+SET server_encoding = 'UTF8'
+
+statement ok
+SET server_encoding = 'unicode'
+
+statement error non-UTF8 encoding other not supported
+SET server_encoding = 'other'
+
+statement ok
 SET datestyle = 'ISO'
 
 statement error non-ISO date style other not supported

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -40,6 +40,7 @@ intervalstyle                   postgres
 max_index_keys                  32
 node_id                         1
 search_path                     public
+server_encoding                 UTF8
 server_version                  9.5.0
 server_version_num              90500
 session_user                    root

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -167,7 +167,7 @@ EXPLAIN SHOW DATABASE
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 29 rows
+·                 size  2 columns, 30 rows
 
 query TTT
 EXPLAIN SHOW TIME ZONE
@@ -175,7 +175,7 @@ EXPLAIN SHOW TIME ZONE
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 29 rows
+·                 size  2 columns, 30 rows
 
 query TTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -183,7 +183,7 @@ EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 29 rows
+·                 size  2 columns, 30 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -191,7 +191,7 @@ EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 29 rows
+·                 size  2 columns, 30 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -199,7 +199,7 @@ EXPLAIN SHOW TRANSACTION PRIORITY
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 29 rows
+·                 size  2 columns, 30 rows
 
 query TTT
 EXPLAIN SHOW COLUMNS FROM foo

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -160,7 +160,7 @@ EXPLAIN SHOW DATABASE
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 29 rows
+·                 size  2 columns, 30 rows
 
 query TTT
 EXPLAIN SHOW TIME ZONE
@@ -168,7 +168,7 @@ EXPLAIN SHOW TIME ZONE
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 29 rows
+·                 size  2 columns, 30 rows
 
 query TTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -176,7 +176,7 @@ EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 29 rows
+·                 size  2 columns, 30 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -184,7 +184,7 @@ EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 29 rows
+·                 size  2 columns, 30 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -192,7 +192,7 @@ EXPLAIN SHOW TRANSACTION PRIORITY
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 29 rows
+·                 size  2 columns, 30 rows
 
 query TTT
 EXPLAIN SHOW COLUMNS FROM foo

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1304,6 +1304,7 @@ func (c *conn) sendAuthPasswordRequest() (string, error) {
 // during connection initialization.
 var statusReportParams = map[string]string{
 	"client_encoding": "UTF8",
+	"server_encoding": "UTF8",
 	"DateStyle":       "ISO",
 	// All datetime binary formats expect 64-bit integer microsecond values.
 	// This param needs to be provided to clients or some may provide 64-bit


### PR DESCRIPTION
Fixes #26948.

Release note (sql change): The session variable and protocol status
parameter `server_encoding` is now defined and has the constant value
UTF8, for compatibility with PostgreSQL. It is not possible to change
its value.