### PR TITLE
sql: don't allocate initial cap of 10000 rows for returning DML stmts

### DIFF
--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -217,8 +217,7 @@ func (d *deleteNode) startExec(params runParams) error {
 	if d.run.rowsNeeded {
 		d.run.rows = sqlbase.NewRowContainer(
 			params.EvalContext().Mon.MakeBoundAccount(),
-			sqlbase.ColTypeInfoFromResCols(d.columns),
-			maxDeleteBatchSize)
+			sqlbase.ColTypeInfoFromResCols(d.columns), 0)
 	}
 	return d.run.td.init(params.p.txn, params.EvalContext())
 }

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -354,8 +354,7 @@ func (n *insertNode) startExec(params runParams) error {
 	if n.run.rowsNeeded {
 		n.run.rows = sqlbase.NewRowContainer(
 			params.EvalContext().Mon.MakeBoundAccount(),
-			sqlbase.ColTypeInfoFromResCols(n.columns),
-			maxInsertBatchSize)
+			sqlbase.ColTypeInfoFromResCols(n.columns), 0)
 
 		// In some cases (e.g. `INSERT INTO t (a) ...`) the data source
 		// does not provide all the table columns. However we do need to

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -459,8 +459,7 @@ func (u *updateNode) startExec(params runParams) error {
 	if u.run.rowsNeeded {
 		u.run.rows = sqlbase.NewRowContainer(
 			params.EvalContext().Mon.MakeBoundAccount(),
-			sqlbase.ColTypeInfoFromResCols(u.columns),
-			maxUpdateBatchSize)
+			sqlbase.ColTypeInfoFromResCols(u.columns), 0)
 	}
 	return u.run.tu.init(params.p.txn, params.EvalContext())
 }


### PR DESCRIPTION
Before this change we would initialize RowContainers with an
initial capacity of `10000` rows for DML statements that had
a `RETURNING` clause. This was absolutely insane because most
`DML` statements that return rows return only a few. This change
fixes this mistake so that the RowContainers are now initialized
without an initial capacity (which means that a single "chunk" is
allocated to begin).

I initially saw this pop up in a CPU profile of `adriatic`, which
was running TPC-C. In the profile I saw that `updateNode's` use
of `RowContainer.AddRow` was accounting for **1.59%** of system-wide
CPU utilization.

After making this change I tested it out against TPC-C, which is
a good generator to experiment with for this change because it uses
DML statements with RETURNING clauses in 3 of its 5 txn types.
On my laptop this change improved throughput by **13.8%** and
reduced average latency by **12.3%**.

Release note (performance improvement): Avoid allocating large row
buffer for DML statements with RETURNING clauses.