### PR TITLE
server: fix negative iops in progress

### DIFF
--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -551,8 +551,6 @@ func subtractDiskCounters(from *diskStats, sub diskStats) {
 	from.readCount -= sub.readCount
 	from.readTimeMs -= sub.readTimeMs
 	from.readBytes -= sub.readBytes
-
-	from.iopsInProgress -= sub.iopsInProgress
 }
 
 // sumNetworkCounters returns a new net.IOCountersStat whose values are the sum of the

--- a/pkg/server/status/runtime_test.go
+++ b/pkg/server/status/runtime_test.go
@@ -15,7 +15,6 @@
 package status
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -112,17 +111,18 @@ func TestSubtractDiskCounters(t *testing.T) {
 		writeCount:     1,
 	}
 	expected := diskStats{
-		readBytes:      2,
-		readTimeMs:     2,
-		readCount:      2,
-		writeBytes:     2,
-		writeTimeMs:    2,
-		writeCount:     2,
-		iopsInProgress: 2,
+		readBytes:   2,
+		readTimeMs:  2,
+		readCount:   2,
+		writeBytes:  2,
+		writeTimeMs: 2,
+		writeCount:  2,
+		// Don't touch iops in progress; it is a gauge, not a counter.
+		iopsInProgress: 3,
 	}
 	subtractDiskCounters(&from, sub)
 	if !reflect.DeepEqual(from, expected) {
-		fmt.Println()
+		t.Fatalf("expected %+v; got %+v", expected, from)
 	}
 }
 
@@ -149,6 +149,6 @@ func TestSubtractNetCounters(t *testing.T) {
 	}
 	subtractNetworkCounters(&from, sub)
 	if !reflect.DeepEqual(from, expected) {
-		fmt.Println()
+		t.Fatalf("expected %+v; got %+v", expected, from)
 	}
 }


### PR DESCRIPTION
We record most metrics as differences from their values at the beginning
of the cockroach process, so that IO before the process started and
between runs doesn't create large spikes when we take the metric's
derivative for charts. Iops was also being recorded as a difference
which was wrong because we always want to just record its current value.

Additionally, some of the unit tests weren't actually testing anything.

Fixes #27906

Release note: None