### PR TITLE
Makefile: new targets `testoptlogic`/`testplannerlogic`

### DIFF
--- a/build/variables.mk
+++ b/build/variables.mk
@@ -122,6 +122,7 @@ define VALID_VARS
   TARGET
   TARGET_TRIPLE
   TAR_XFORM_FLAG
+  TESTCONFIG
   TESTFLAGS
   TESTS
   TESTTIMEOUT
@@ -163,8 +164,10 @@ define VALID_VARS
   is-cross-compile
   langgen-package
   libroach-inputs
+  logic-test-selector
   logictest-package
   logictestccl-package
+  logictestopt-package
   macos-version
   native-tag
   optgen-defs


### PR DESCRIPTION
This splits the test `TestPlannerLogic` into a separate make target
`testplannerlogic`, but keeps it as a dependency of `testlogic`.

It also introduces `testoptlogic` to run the exec builder logic tests,
and also adds it as a dependency of `testlogic`.

This way, now `testlogic` does "the right thing" by running all core
logic tests.

Finally, this patch also introduces the new config var TESTCONFIG to
specify a logic test execution environment.

Release note: None