### PR TITLE
server: refactor node boot sequence (step 1)

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -587,7 +587,6 @@ func (n *Node) startStores(
 	if _, err := n.stores.SynthesizeClusterVersion(ctx); err != nil {
 		return err
 	}
-	// Also populate bootstrap list
 
 	// Connect gossip before starting bootstrap. For new nodes, connecting
 	// to the gossip network is necessary to get the cluster ID.

--- a/pkg/storage/consistency_queue_test.go
+++ b/pkg/storage/consistency_queue_test.go
@@ -115,7 +115,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 	notifyReportDiff := make(chan struct{}, 1)
 	sc.TestingKnobs.BadChecksumReportDiff =
 		func(s roachpb.StoreIdent, diff []storage.ReplicaSnapshotDiff) {
-			if s != mtc.Store(0).Ident {
+			if s != *mtc.Store(0).Ident {
 				t.Errorf("BadChecksumReportDiff called from follower (StoreIdent = %s)", s)
 				return
 			}
@@ -131,7 +131,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 	// Store 0 will panic.
 	notifyPanic := make(chan struct{}, 1)
 	sc.TestingKnobs.BadChecksumPanic = func(s roachpb.StoreIdent) {
-		if s != mtc.Store(0).Ident {
+		if s != *mtc.Store(0).Ident {
 			t.Errorf("BadChecksumPanic called from follower (StoreIdent = %s)", s)
 			return
 		}

--- a/pkg/storage/replica_consistency.go
+++ b/pkg/storage/replica_consistency.go
@@ -98,7 +98,7 @@ func (r *Replica) CheckConsistency(
 		if expResponse.Snapshot != nil && result.Response.Snapshot != nil {
 			diff := diffRange(expResponse.Snapshot, result.Response.Snapshot)
 			if report := r.store.cfg.TestingKnobs.BadChecksumReportDiff; report != nil {
-				report(r.store.Ident, diff)
+				report(*r.store.Ident, diff)
 			}
 			buf.WriteByte('\n')
 			_, _ = diff.WriteTo(&buf)
@@ -144,7 +144,7 @@ func (r *Replica) CheckConsistency(
 		if !args.WithDiff {
 			// We'll call this recursively with WithDiff==true; let's let that call
 			// be the one to trigger the handler.
-			p(r.store.Ident)
+			p(*r.store.Ident)
 		}
 		logFunc = log.Errorf
 	}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -188,14 +188,14 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, stopper *stop.Stopper,
 		// store will be passed to the sender after it is created and bootstrapped.
 		factory := &testSenderFactory{}
 		cfg.DB = client.NewDB(cfg.AmbientCtx, factory, cfg.Clock)
-		tc.store = NewStore(cfg, tc.engine, &roachpb.NodeDescriptor{NodeID: 1})
-		if err := tc.store.Bootstrap(ctx, roachpb.StoreIdent{
+		if err := Bootstrap(ctx, tc.engine, roachpb.StoreIdent{
 			ClusterID: uuid.MakeV4(),
 			NodeID:    1,
 			StoreID:   1,
 		}, cfg.Settings.Version.BootstrapVersion()); err != nil {
 			t.Fatal(err)
 		}
+		tc.store = NewStore(cfg, tc.engine, &roachpb.NodeDescriptor{NodeID: 1})
 		// Now that we have our actual store, monkey patch the factory used in cfg.DB.
 		factory.setStore(tc.store)
 		// We created the store without a real KV client, so it can't perform splits.

--- a/pkg/storage/store_pool_test.go
+++ b/pkg/storage/store_pool_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 var uniqueStore = []*roachpb.StoreDescriptor{
@@ -549,6 +550,13 @@ func TestStorePoolUpdateLocalStoreBeforeGossip(t *testing.T) {
 	cfg := TestStoreConfig(clock)
 	cfg.Transport = NewDummyRaftTransport(cfg.Settings)
 	store := NewStore(cfg, eng, &node)
+	// Fake an ident because this test doesn't want to start the store
+	// but without an Ident there will be NPEs.
+	store.Ident = &roachpb.StoreIdent{
+		ClusterID: uuid.Nil,
+		StoreID:   1,
+		NodeID:    1,
+	}
 
 	// Create replica.
 	rg := roachpb.RangeDescriptor{

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -185,8 +185,8 @@ func createTestStoreWithoutStart(t testing.TB, stopper *stop.Stopper, cfg *Store
 	cfg.DB = client.NewDB(cfg.AmbientCtx, factory, cfg.Clock)
 	store := NewStore(*cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 	factory.setStore(store)
-	if err := store.Bootstrap(
-		context.TODO(), roachpb.StoreIdent{NodeID: 1, StoreID: 1}, cfg.Settings.Version.BootstrapVersion(),
+	if err := Bootstrap(
+		context.TODO(), eng, roachpb.StoreIdent{NodeID: 1, StoreID: 1}, cfg.Settings.Version.BootstrapVersion(),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -372,7 +372,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 		}
 
 		// Bootstrap with a fake ident.
-		if err := store.Bootstrap(ctx, testIdent, cfg.Settings.Version.BootstrapVersion()); err != nil {
+		if err := Bootstrap(ctx, eng, testIdent, cfg.Settings.Version.BootstrapVersion()); err != nil {
 			t.Errorf("error bootstrapping store: %s", err)
 		}
 
@@ -511,7 +511,7 @@ func TestBootstrapOfNonEmptyStore(t *testing.T) {
 	}
 
 	// Bootstrap should fail on non-empty engine.
-	switch err := errors.Cause(store.Bootstrap(ctx, testIdent, cfg.Settings.Version.BootstrapVersion())); err.(type) {
+	switch err := errors.Cause(Bootstrap(ctx, eng, testIdent, cfg.Settings.Version.BootstrapVersion())); err.(type) {
 	case *NotBootstrappedError:
 	default:
 		t.Errorf("unexpected error bootstrapping non-empty store: %v", err)

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -151,20 +151,20 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	)
 	cfg.Transport = transport
 	cfg.TimestampCachePageSize = tscache.TestSklPageSize
-	ltc.Store = storage.NewStore(cfg, ltc.Eng, nodeDesc)
 	ctx := context.TODO()
 
-	if err := ltc.Store.Bootstrap(ctx, roachpb.StoreIdent{NodeID: nodeID, StoreID: 1}, cfg.Settings.Version.BootstrapVersion()); err != nil {
+	if err := storage.Bootstrap(ctx, ltc.Eng, roachpb.StoreIdent{NodeID: nodeID, StoreID: 1}, cfg.Settings.Version.BootstrapVersion()); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}
-
-	ltc.Stores.AddStore(ltc.Store)
+	ltc.Store = storage.NewStore(cfg, ltc.Eng, nodeDesc)
 	if err := ltc.Store.BootstrapRange(nil, cfg.Settings.Version.ServerVersion); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}
 	if err := ltc.Store.Start(ctx, ltc.Stopper); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}
+
+	ltc.Stores.AddStore(ltc.Store)
 	nc.Set(ctx, nodeDesc.NodeID)
 	if err := ltc.Gossip.SetNodeDescriptor(nodeDesc); err != nil {
 		t.Fatalf("unable to set node descriptor: %s", err)


### PR DESCRIPTION
The node startup sequence has been a source of confusion on my part numerous times.
We initialize a bunch of stores with an empty NodeDescriptor, then magically mutate
it in a few locations depending on whether this is an existing or newly bootstrapped
node, and generally do things in a Rube Goldberg type of manner.

To properly plumb follower reads (and to increase general sanity in this part of the
code), my ultimate goal here is to have the StoreConfig fully initialized before
any stores are created. This in particular means that the NodeID must be known at
that point.

This is possible because a) either we have bootstrapped stores, so they have the
NodeID on their engine and we can grab it from there, or b) we need to allocate
a new NodeID via Gossip, and that doesn't need anything.

Unfortunately, draining this swamp will take a bit of elbow grease, and while I'm
already knee deep in the next cycle, this part can already be reviewed.

Release note: None