### PR TITLE
server: record all quartiles of histograms

### DIFF
--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -69,6 +69,8 @@ var recordHistogramQuantiles = []quantile{
 	{"-p90", 90},
 	{"-p75", 75},
 	{"-p50", 50},
+	{"-p25", 25},
+	{"-min", 0},
 }
 
 // storeMetrics is the minimum interface of the storage.Store object needed by


### PR DESCRIPTION
To support showing the full five-number summary of a metric.

Contributes to #27934.
Release note: None.