### PR TITLE
sql: further fix the columns in pg_index

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -556,8 +556,8 @@ FROM pg_catalog.pg_index
 WHERE indnatts = 2
 ----
 indexrelid  indrelid    indislive  indisreplident  indkey  indcollation  indclass  indoption  indexprs  indpred
-586319999   4183203597  true       false           3 4     {0,0}         {0,0}     {0,0}      NULL      NULL
-4084598994  226054345   true       false           1 2     {0,0}         {0,0}     {0,0}      NULL      NULL
+586319999   4183203597  true       false           3 4     0 0           0 0       0 0        NULL      NULL
+4084598994  226054345   true       false           1 2     0 0           0 0       0 0        NULL      NULL
 
 statement ok
 SET DATABASE = system
@@ -567,26 +567,26 @@ SELECT *
 FROM pg_catalog.pg_index
 ORDER BY indexrelid
 ----
-indexrelid  indrelid    indnatts  indisunique  indisprimary  indisexclusion  indimmediate  indisclustered  indisvalid  indcheckxmin  indisready  indislive  indisreplident  indkey   indcollation             indclass  indoption  indexprs  indpred
-27122201    2904033927  2         true         true          false           true          false           true        false         false       true       false           1 6      {0,0}                    {0,0}      {0,0}      NULL      NULL
-235043584   971623778   2         true         true          false           true          false           true        false         false       true       false           1 2      {1661428263,1661428263}  {0,0}      {0,0}      NULL      NULL
-235043586   971623778   1         false        false         false           false         false           true        false         false       true       false           2        {1661428263}             {0}        {0}        NULL      NULL
-235043587   971623778   1         false        false         false           false         false           true        false         false       true       false           1        {1661428263}             {0}        {0}        NULL      NULL
-553144061   2568924675  2         true         true          false           true          false           true        false         false       true       false           1 2      {0,0}                    {0,0}      {0,0}      NULL      NULL
-633004884   1455563232  1         false        false         false           false         false           true        false         false       true       false           4        {0}                      {0}        {0}        NULL      NULL
-633004885   1455563232  1         false        false         false           false         false           true        false         false       true       false           5        {0}                      {0}        {0}        NULL      NULL
-633004886   1455563232  1         true         true          false           true          false           true        false         false       true       false           1        {0}                      {0}        {0}        NULL      NULL
-961325075   2492394317  1         true         true          false           true          false           true        false         false       true       false           1        {0}                      {0}        {0}        NULL      NULL
-1168848597  1038690067  2         true         true          false           true          false           true        false         false       true       false           1 7      {0,0}                    {0,0}      {0,0}      NULL      NULL
-1849259112  3649853378  1         true         true          false           true          false           true        false         false       true       false           1        {0}                      {0}        {0}        NULL      NULL
-1849259115  3649853378  2         false        false         false           false         false           true        false         false       true       false           2 3      {1661428263,0}           {0,0}      {0,0}      NULL      NULL
-2151986803  504491171   1         true         true          false           true          false           true        false         false       true       false           1        {1661428263}             {0}        {0}        NULL      NULL
-2490277766  936526412   1         true         true          false           true          false           true        false         false       true       false           1        {1661428263}             {0}        {0}        NULL      NULL
-2516644345  13912245    1         true         true          false           true          false           true        false         false       true       false           1        {0}                      {0}        {0}        NULL      NULL
-2795406519  4084372773  1         true         true          false           true          false           true        false         false       true       false           1        {1661428263}             {0}        {0}        NULL      NULL
-2916809960  3412769920  2         true         true          false           true          false           true        false         false       true       false           1 2      {0,1661428263}           {0,0}      {0,0}      NULL      NULL
-3042779560  1692823172  2         true         true          false           true          false           true        false         false       true       false           1 2      {1661428263,1661428263}  {0,0}      {0,0}      NULL      NULL
-4083294912  4199044472  4         true         true          false           true          false           true        false         false       true       false           1 2 4 3  {0,0,0,0}                {0,0,0,0}  {0,0,0,0}  NULL      NULL
+indexrelid  indrelid    indnatts  indisunique  indisprimary  indisexclusion  indimmediate  indisclustered  indisvalid  indcheckxmin  indisready  indislive  indisreplident  indkey   indcollation           indclass  indoption  indexprs  indpred
+27122201    2904033927  2         true         true          false           true          false           true        false         false       true       false           1 6      0 0                    0 0       0 0        NULL      NULL
+235043584   971623778   2         true         true          false           true          false           true        false         false       true       false           1 2      1661428263 1661428263  0 0       0 0        NULL      NULL
+235043586   971623778   1         false        false         false           false         false           true        false         false       true       false           2        1661428263             0         0          NULL      NULL
+235043587   971623778   1         false        false         false           false         false           true        false         false       true       false           1        1661428263             0         0          NULL      NULL
+553144061   2568924675  2         true         true          false           true          false           true        false         false       true       false           1 2      0 0                    0 0       0 0        NULL      NULL
+633004884   1455563232  1         false        false         false           false         false           true        false         false       true       false           4        0                      0         0          NULL      NULL
+633004885   1455563232  1         false        false         false           false         false           true        false         false       true       false           5        0                      0         0          NULL      NULL
+633004886   1455563232  1         true         true          false           true          false           true        false         false       true       false           1        0                      0         0          NULL      NULL
+961325075   2492394317  1         true         true          false           true          false           true        false         false       true       false           1        0                      0         0          NULL      NULL
+1168848597  1038690067  2         true         true          false           true          false           true        false         false       true       false           1 7      0 0                    0 0       0 0        NULL      NULL
+1849259112  3649853378  1         true         true          false           true          false           true        false         false       true       false           1        0                      0         0          NULL      NULL
+1849259115  3649853378  2         false        false         false           false         false           true        false         false       true       false           2 3      1661428263 0           0 0       0 0        NULL      NULL
+2151986803  504491171   1         true         true          false           true          false           true        false         false       true       false           1        1661428263             0         0          NULL      NULL
+2490277766  936526412   1         true         true          false           true          false           true        false         false       true       false           1        1661428263             0         0          NULL      NULL
+2516644345  13912245    1         true         true          false           true          false           true        false         false       true       false           1        0                      0         0          NULL      NULL
+2795406519  4084372773  1         true         true          false           true          false           true        false         false       true       false           1        1661428263             0         0          NULL      NULL
+2916809960  3412769920  2         true         true          false           true          false           true        false         false       true       false           1 2      0 1661428263           0 0       0 0        NULL      NULL
+3042779560  1692823172  2         true         true          false           true          false           true        false         false       true       false           1 2      1661428263 1661428263  0 0       0 0        NULL      NULL
+4083294912  4199044472  4         true         true          false           true          false           true        false         false       true       false           1 2 4 3  0 0 0 0                0 0 0 0   0 0 0 0    NULL      NULL
 
 # From #26504
 query OOI colnames

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -912,23 +912,23 @@ CREATE TABLE pg_catalog.pg_foreign_table (
 }
 
 func makeZeroedOidVector(size int) (tree.Datum, error) {
-	oidVector := tree.NewDArray(types.Oid)
+	oidArray := tree.NewDArray(types.Oid)
 	for i := 0; i < size; i++ {
-		if err := oidVector.Append(oidZero); err != nil {
+		if err := oidArray.Append(oidZero); err != nil {
 			return nil, err
 		}
 	}
-	return oidVector, nil
+	return tree.NewDOidVectorFromDArray(oidArray), nil
 }
 
-func makeZeroedIntArray(size int) (tree.Datum, error) {
+func makeZeroedIntVector(size int) (tree.Datum, error) {
 	intArray := tree.NewDArray(types.Int)
 	for i := 0; i < size; i++ {
 		if err := intArray.Append(zeroVal); err != nil {
 			return nil, err
 		}
 	}
-	return intArray, nil
+	return tree.NewDIntVectorFromDArray(intArray), nil
 }
 
 // See: https://www.postgresql.org/docs/9.6/static/catalog-pg-index.html.
@@ -981,13 +981,14 @@ CREATE TABLE pg_catalog.pg_index (
 							return err
 						}
 					}
+					collationOidVector := tree.NewDOidVectorFromDArray(collationOids)
 					// TODO(bram): #27763 indclass still needs to be populated but it
 					// requires pg_catalog.pg_opclass first.
 					indclass, err := makeZeroedOidVector(len(index.ColumnIDs))
 					if err != nil {
 						return err
 					}
-					indoption, err := makeZeroedIntArray(len(index.ColumnIDs))
+					indoption, err := makeZeroedIntVector(len(index.ColumnIDs))
 					if err != nil {
 						return err
 					}
@@ -1006,7 +1007,7 @@ CREATE TABLE pg_catalog.pg_index (
 						tree.DBoolTrue,                           // indislive
 						tree.DBoolFalse,                          // indisreplident
 						indkey,                                   // indkey
-						collationOids,                            // indcollation
+						collationOidVector,                       // indcollation
 						indclass,                                 // indclass
 						indoption,                                // indoption
 						tree.DNull,                               // indexprs


### PR DESCRIPTION
Previously, some columns in pg_index were marked as oidvector and
int2vector, but the actual generated values for those columns were plain
arrays. This was subtly incorrect and caused incorrect formatting and
potential client incompatibility.

Release note (sql change): correct the oids and formatting of some
columns in the pg_catalog.pg_index table.