### PR TITLE
server: remove initNodeID

### DIFF
--- a/pkg/storage/stores_server.go
+++ b/pkg/storage/stores_server.go
@@ -18,30 +18,23 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/pkg/errors"
-
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // Server implements ConsistencyServer.
 type Server struct {
-	descriptor *roachpb.NodeDescriptor
-	stores     *Stores
+	stores *Stores
 }
 
 var _ ConsistencyServer = Server{}
 
 // MakeServer returns a new instance of Server.
 func MakeServer(descriptor *roachpb.NodeDescriptor, stores *Stores) Server {
-	return Server{descriptor, stores}
+	return Server{stores}
 }
 
 func (is Server) execStoreCommand(h StoreRequestHeader, f func(*Store) error) error {
-	if h.NodeID != is.descriptor.NodeID {
-		return errors.Errorf("request for NodeID %d cannot be served by NodeID %d",
-			h.NodeID, is.descriptor.NodeID)
-	}
 	store, err := is.stores.GetStore(h.StoreID)
 	if err != nil {
 		return err


### PR DESCRIPTION
Initialize a full descriptor right at the top of
(*Node).start(), before any stores have been started.

There's a lot more refactoring that could (should) be done here, but I'm mostly
interested in being able to set up a closed timestamp subsystem before starting
any nodes, and that can be accomplished as of this PR.

Release note: None