### PR TITLE
sql: make IndexedRow an interface

### DIFF
--- a/pkg/sql/sem/builtins/window_builtins.go
+++ b/pkg/sql/sem/builtins/window_builtins.go
@@ -476,7 +476,7 @@ func newFirstValueWindow([]types.T, *tree.EvalContext) tree.WindowFunc {
 func (firstValueWindow) Compute(
 	_ context.Context, _ *tree.EvalContext, wfr *tree.WindowFrameRun,
 ) (tree.Datum, error) {
-	return wfr.Rows[wfr.FrameStartIdx()].Row[wfr.ArgIdxStart], nil
+	return wfr.Rows.GetRow(wfr.FrameStartIdx()).GetDatum(wfr.ArgIdxStart), nil
 }
 
 func (firstValueWindow) Close(context.Context, *tree.EvalContext) {}
@@ -491,7 +491,7 @@ func newLastValueWindow([]types.T, *tree.EvalContext) tree.WindowFunc {
 func (lastValueWindow) Compute(
 	_ context.Context, _ *tree.EvalContext, wfr *tree.WindowFrameRun,
 ) (tree.Datum, error) {
-	return wfr.Rows[wfr.FrameEndIdx()-1].Row[wfr.ArgIdxStart], nil
+	return wfr.Rows.GetRow(wfr.FrameEndIdx() - 1).GetDatum(wfr.ArgIdxStart), nil
 }
 
 func (lastValueWindow) Close(context.Context, *tree.EvalContext) {}
@@ -523,7 +523,7 @@ func (nthValueWindow) Compute(
 	if nth > wfr.FrameSize() {
 		return tree.DNull, nil
 	}
-	return wfr.Rows[wfr.FrameStartIdx()+nth-1].Row[wfr.ArgIdxStart], nil
+	return wfr.Rows.GetRow(wfr.FrameStartIdx() + nth - 1).GetDatum(wfr.ArgIdxStart), nil
 }
 
 func (nthValueWindow) Close(context.Context, *tree.EvalContext) {}


### PR DESCRIPTION
Adds IndexedRows and IndexedRow interfaces so that we can implement them directly using EncDatum's of EncDatumRows instead of having to populate tree.Datums.

The reasoning behind this change is that in DistSQL we operate with `EncDatumRow`s, and we can (with this change) use the same encoded rows as underlying "storage" of `tree.Datum` of columns instead of having to create many `tree.Datums` only to match what `WindowFrameRun` expects. With this change, we simply make sure that `EncDatum`s are decoded.

I've done a few benchmarks after switching to this strategy (along with few other refactorings), and I see a significant improvement. For example, on TPCH dataset, on query `SELECT count(*) OVER (PARTITION BY o_orderdate) FROM orders ORDER BY o_orderkey LIMIT 10;` I had 20% improvement over local execution, with new approach it is 40%.

Related to: #27140.

Release note: None