### PR TITLE
distsqlrun: un-blacklist current_schemas

### DIFF
--- a/pkg/sql/distsqlrun/api.go
+++ b/pkg/sql/distsqlrun/api.go
@@ -45,7 +45,7 @@ func MakeEvalContext(evalCtx tree.EvalContext) EvalContext {
 	}
 
 	// Populate the search path.
-	iter := evalCtx.SessionData.SearchPath.Iter()
+	iter := evalCtx.SessionData.SearchPath.IterWithoutImplicitPGCatalog()
 	for s, ok := iter(); ok; s, ok = iter() {
 		res.SearchPath = append(res.SearchPath, s)
 	}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2652,8 +2652,7 @@ may increase either contention or retry errors, or both.`,
 	// SQL client against a pg server.
 	"current_schema": makeBuiltin(
 		tree.FunctionProperties{
-			Category:         categorySystemInfo,
-			DistsqlBlacklist: true,
+			Category: categorySystemInfo,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{},
@@ -2686,8 +2685,7 @@ may increase either contention or retry errors, or both.`,
 	// server.
 	"current_schemas": makeBuiltin(
 		tree.FunctionProperties{
-			Category:         categorySystemInfo,
-			DistsqlBlacklist: true,
+			Category: categorySystemInfo,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"include_pg_catalog", types.Bool}},


### PR DESCRIPTION
Previously, the remote search path for new distsql flows always included
the implicit pg_catalog entry. This is incorrect, because it causes a
difference in a few builtin functions. This incorrectness was the reason
for needing to blacklist current_schemas.

Release note: None