### PR TITLE
libroach: make DBSstFileWriter output work with time bound iterator

### DIFF
--- a/c-deps/libroach/CMakeLists.txt
+++ b/c-deps/libroach/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(roach
   mvcc.cc
   options.cc
   snapshot.cc
+  timebound.cc
   utils.cc
   protos/roachpb/data.pb.cc
   protos/roachpb/internal.pb.cc

--- a/c-deps/libroach/timebound.h
+++ b/c-deps/libroach/timebound.h
@@ -1,0 +1,26 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+
+#pragma once
+
+#include <rocksdb/table_properties.h>
+
+namespace cockroach {
+
+// DBMakeTimeBoundCollector returns a TablePropertiesCollector hook to store the
+// min and max MVCC timestamps present in each sstable in the metadata for that
+// sstable. Used by the time bounded iterator optimization.
+rocksdb::TablePropertiesCollectorFactory* DBMakeTimeBoundCollector();
+
+}  // namespace cockroach

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -41,20 +41,12 @@ func registerCDC(r *registry) {
 
 		c.Put(ctx, cockroach, "./cockroach", crdbNodes)
 		c.Put(ctx, workload, "./workload", workloadNode)
-		// Force encryption off as we do not have a good way to detect whether it is enabled
-		// for the `debug compact` call below.
-		c.Start(ctx, crdbNodes, startArgsDontEncrypt)
+		c.Start(ctx, crdbNodes)
 
 		t.Status("loading initial data")
 		c.Run(ctx, workloadNode, fmt.Sprintf(
 			`./workload fixtures load tpcc --warehouses=%d --checks=false {pgurl:1}`, warehouses,
 		))
-
-		// Run compactions on the data so TimeBoundIterator works. This can be
-		// fixed. See #26870
-		c.Stop(ctx, crdbNodes)
-		c.Run(ctx, crdbNodes, `./cockroach debug compact /mnt/data1/cockroach/`)
-		c.Start(ctx, crdbNodes, startArgsDontEncrypt)
 
 		t.Status("installing kafka")
 		c.Run(ctx, kafkaNode, `curl https://packages.confluent.io/archive/4.0/confluent-oss-4.0.0-2.11.tar.gz | tar -xzv`)


### PR DESCRIPTION
The time bounded iterator optimization looks for sstable metadata that
indicates the min and max mvcc timestamp included. The iterator (which
is configured with a min and max bounds) can use this to skip tables
that don't have relevant data. When the bounds aren't set, it has to
fall back to checking the table.

The TimeBoundTblPropCollectorFactory already sets the metadata on
sstable creation, but it wasn't hooked up to DBSstFileWriter. This meant
that IMPORT and RESTORE (both of which use DBSstFileWriter via the
Import command) would create and ingest sstables that hit the no bounds
fall back.

This commit adds TimeBoundTblPropCollectorFactory to DBSstFileWriter
which means data ingested via RESTORE and IMPORT now work with time
bounded iterators just like any other sstables.

Closes #26870

Release note (performance improvement): data ingested with RESTORE and
IMPORT is now eligible for a performance optimization used in
incremental BACKUP and CHANGEFEEDs