### PR TITLE
server, ui: fix disk time units on mac; add to Hardware dashboard

### DIFF
--- a/pkg/server/status/disk_counters.go
+++ b/pkg/server/status/disk_counters.go
@@ -18,6 +18,7 @@ package status
 
 import (
 	"context"
+	"time"
 
 	"github.com/shirou/gopsutil/disk"
 )
@@ -33,10 +34,10 @@ func getDiskCounters(ctx context.Context) ([]diskStats, error) {
 	for _, counters := range driveStats {
 		output[i] = diskStats{
 			readBytes:      int64(counters.ReadBytes),
-			readTimeMs:     int64(counters.ReadTime),
+			readTime:       time.Duration(counters.ReadTime * 1e6),
 			readCount:      int64(counters.ReadCount),
 			writeBytes:     int64(counters.WriteBytes),
-			writeTimeMs:    int64(counters.WriteTime),
+			writeTime:      time.Duration(counters.WriteTime * 1e6),
 			writeCount:     int64(counters.WriteCount),
 			iopsInProgress: int64(counters.IopsInProgress),
 		}

--- a/pkg/server/status/disk_counters_darwin.go
+++ b/pkg/server/status/disk_counters_darwin.go
@@ -33,10 +33,10 @@ func getDiskCounters(context.Context) ([]diskStats, error) {
 		output[i] = diskStats{
 			readBytes:      counters.BytesRead,
 			readCount:      counters.NumRead,
-			readTimeMs:     int64(counters.TotalReadTime),
+			readTime:       counters.TotalReadTime,
 			writeBytes:     counters.BytesWritten,
 			writeCount:     counters.NumWrite,
-			writeTimeMs:    int64(counters.TotalWriteTime),
+			writeTime:      counters.TotalWriteTime,
 			iopsInProgress: 0, // Not reported by this library. (#27927)
 		}
 	}

--- a/pkg/server/status/runtime_test.go
+++ b/pkg/server/status/runtime_test.go
@@ -28,30 +28,30 @@ func TestSumDiskCounters(t *testing.T) {
 	counters := []diskStats{
 		{
 			readBytes:      1,
-			readTimeMs:     1,
+			readTime:       1,
 			readCount:      1,
 			iopsInProgress: 1,
 			writeBytes:     1,
-			writeTimeMs:    1,
+			writeTime:      1,
 			writeCount:     1,
 		},
 		{
 			readBytes:      1,
-			readTimeMs:     1,
+			readTime:       1,
 			readCount:      1,
 			iopsInProgress: 1,
 			writeBytes:     1,
-			writeTimeMs:    1,
+			writeTime:      1,
 			writeCount:     1,
 		},
 	}
 	summed := sumDiskCounters(counters)
 	expected := diskStats{
 		readBytes:      2,
-		readTimeMs:     2,
+		readTime:       2,
 		readCount:      2,
 		writeBytes:     2,
-		writeTimeMs:    2,
+		writeTime:      2,
 		writeCount:     2,
 		iopsInProgress: 2,
 	}
@@ -94,29 +94,29 @@ func TestSubtractDiskCounters(t *testing.T) {
 
 	from := diskStats{
 		readBytes:      3,
-		readTimeMs:     3,
+		readTime:       3,
 		readCount:      3,
 		writeBytes:     3,
-		writeTimeMs:    3,
+		writeTime:      3,
 		writeCount:     3,
 		iopsInProgress: 3,
 	}
 	sub := diskStats{
 		readBytes:      1,
-		readTimeMs:     1,
+		readTime:       1,
 		readCount:      1,
 		iopsInProgress: 1,
 		writeBytes:     1,
-		writeTimeMs:    1,
+		writeTime:      1,
 		writeCount:     1,
 	}
 	expected := diskStats{
-		readBytes:   2,
-		readTimeMs:  2,
-		readCount:   2,
-		writeBytes:  2,
-		writeTimeMs: 2,
-		writeCount:  2,
+		readBytes:  2,
+		readTime:   2,
+		readCount:  2,
+		writeBytes: 2,
+		writeTime:  2,
+		writeCount: 2,
 		// Don't touch iops in progress; it is a gauge, not a counter.
 		iopsInProgress: 3,
 	}

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -110,6 +110,38 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="Disk Read Time"
+      sources={nodeSources}
+    >
+      <Axis units={AxisUnits.Duration} label="Read Time">
+        {nodeIDs.map((nid) => (
+          <Metric
+            name="cr.node.sys.host.disk.read.time"
+            title={nodeDisplayName(nodesSummary, nid)}
+            sources={[nid]}
+            nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Disk Write Time"
+      sources={nodeSources}
+    >
+      <Axis units={AxisUnits.Duration} label="Write Time">
+        {nodeIDs.map((nid) => (
+          <Metric
+            name="cr.node.sys.host.disk.write.time"
+            title={nodeDisplayName(nodesSummary, nid)}
+            sources={[nid]}
+            nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Disk Capacity"
       sources={storeSources}
       tooltip={(


### PR DESCRIPTION
- The disk read and write time metrics are stored in nanoseconds. Gopsutil reports them in milliseconds, so they were being multiplied by 1e6. However, #27930 introduced a new library for mac only, which reported the numbers already in nanoseconds. They were then still multiplied by 1e6, thus storing numbers which were much too high. This change corrects that conversion.
- The second commit adds disk read and write time charts to the Hardware dashboard.

![image](https://user-images.githubusercontent.com/7341/43295585-e76d4090-9113-11e8-9055-c4d5c0b80857.png)

Going forward, hopefully a fix to https://github.com/shirou/gopsutil/issues/560 (which I may contribute) will allow us to use only one library which uses time units consistently, avoiding bugs like this.