### PR TITLE
sql: improve handling of decimal zeroes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -223,8 +223,8 @@
 [[projects]]
   name = "github.com/cockroachdb/apd"
   packages = ["."]
-  revision = "b1ce49cb2a474f4416531e7395373eaafaa4fbe2"
-  version = "v1.0.0"
+  revision = "9c2ab8efc9ac66bf4bb79ab6bed4dcd0c709d1b9"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
@@ -1324,6 +1324,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c2d233664857e819b8ff29b49491bd8ecebb24377fb2f152274e86401c220b56"
+  inputs-digest = "24f1631a158f62585d7805d142405d71312f2609b00cb7a3d268b18b9f5f7f32"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/sql/logictest/testdata/logic_test/decimal
+++ b/pkg/sql/logictest/testdata/logic_test/decimal
@@ -67,14 +67,15 @@ statement ok
 CREATE TABLE t (d decimal, v decimal(3, 1))
 
 statement ok
-INSERT INTO t VALUES (1.00::decimal, 1.00::decimal), (2.0::decimal, 2.0::decimal), (3::decimal, 3::decimal)
+INSERT INTO t VALUES (0.000::decimal, 0.00::decimal), (1.00::decimal, 1.00::decimal), (2.0::decimal, 2.0::decimal), (3::decimal, 3::decimal)
 
 query RR
 SELECT * FROM t ORDER BY d
 ----
-1.00 1.0
-2.0  2.0
-3    3.0
+0.000  0.0
+1.00   1.0
+2.0    2.0
+3      3.0
 
 # Ensure trailing zeros are kept in an index.
 
@@ -96,7 +97,7 @@ SELECT * FROM t2 ORDER BY d
 ----
 NaN        NaN
 -Infinity  -Infinity
--0.0000    -0.0
+0.0000     0.0
 1.00       1.0
 2.0        2.0
 3          3.0
@@ -160,11 +161,11 @@ query R rowsort
 SELECT * FROM s WHERE d = 0
 ----
 0
--0
--0.0
--0.00
--0.000
--0.0000
+0
+0.0
+0.00
+0.000
+0.0000
 
 query R
 SELECT * FROM s WHERE d IS NAN
@@ -183,29 +184,12 @@ SELECT * FROM s WHERE d = 'NaN'
 NaN
 NaN
 
-# Check the ordering of decimal values.
-# The various zero values do not sort well currently
-# (see issue #28061) so we need to exclude them to get a stable sort.
-#
-# TODO(knz/mjibson): this WHERE clause can be removed/improved
-# once #27978 / #28061 are resolved.
-query R
-SELECT d FROM s WHERE d != 0 ORDER BY d
-----
-NaN
-NaN
--Infinity
--1
-1
-Infinity
+# In the following tests, the various zero values all compare equal to
+# each other so we must use two ORDER BY clauses to obtain a stable result.
 
-# We can check the relative ordering of zeros and other values by
-# doing some conversion to float and some arithmetic.
-#
-# TODO(knz/mjibson) This test can be deleted when the WHERE clause can
-# be removed from the previous test.
+# Check the ordering of decimal values.
 query R
-SELECT floor(d::FLOAT+0.1)::DECIMAL FROM s ORDER BY d
+SELECT d FROM s ORDER BY d, d::TEXT
 ----
 NULL
 NaN
@@ -214,81 +198,74 @@ NaN
 -1
 0
 0
-0
-0
-0
-0
+0.0
+0.00
+0.000
+0.0000
 1
 Infinity
 
-# In the following tests, the various zero values all compare equal to
-# each other so we cannot use ORDER BY to obtain a stable result so we
-# have to use `rowsort`. The test above has already controlled the
-# ordering.
-# These tests are only about testing the NaN-ness of the values, so
-# ordering is really inconsequential.
-
 # Just test the NaN-ness of the values.
-query RBBB rowsort
-SELECT d, d IS NaN, d = 'NaN', isnan(d) FROM s@{FORCE_INDEX=primary}
+query RBBB
+SELECT d, d IS NaN, d = 'NaN', isnan(d) FROM s@{FORCE_INDEX=primary} ORDER BY d, d::TEXT
 ----
 NULL       NULL   NULL   NULL
 NaN        true   true   true
 NaN        true   true   true
 -Infinity  false  false  false
 -1         false  false  false
--0         false  false  false
--0.0       false  false  false
--0.00      false  false  false
--0.000     false  false  false
--0.0000    false  false  false
 0          false  false  false
+0          false  false  false
+0.0        false  false  false
+0.00       false  false  false
+0.000      false  false  false
+0.0000     false  false  false
 1          false  false  false
 Infinity   false  false  false
 
 # Just test the NaN-ness of the values in secondary index
-query RBBB rowsort
-SELECT d, d IS NaN, d = 'NaN', isnan(d) FROM s@{FORCE_INDEX=s_d_idx}
+query RBBB
+SELECT d, d IS NaN, d = 'NaN', isnan(d) FROM s@{FORCE_INDEX=s_d_idx} ORDER BY d, d::TEXT
 ----
 NULL       NULL   NULL   NULL
 NaN        true   true   true
 NaN        true   true   true
 -Infinity  false  false  false
 -1         false  false  false
--0         false  false  false
--0.0       false  false  false
--0.00      false  false  false
--0.000     false  false  false
--0.0000    false  false  false
 0          false  false  false
+0          false  false  false
+0.0        false  false  false
+0.00       false  false  false
+0.000      false  false  false
+0.0000     false  false  false
 1          false  false  false
 Infinity   false  false  false
 
-query RB rowsort
-select d, d > 'NaN' from s@{FORCE_INDEX=primary} where d > 'NaN'
+query RB
+select d, d > 'NaN' from s@{FORCE_INDEX=primary} where d > 'NaN' ORDER BY d, d::TEXT
 ----
 -Infinity  true
 -1         true
--0         true
--0.0       true
--0.00      true
--0.000     true
--0.0000    true
 0          true
+0          true
+0.0        true
+0.00       true
+0.000      true
+0.0000     true
 1          true
 Infinity   true
 
-query RB rowsort
-select d, d > 'NaN' from s@{FORCE_INDEX=s_d_idx} where d > 'NaN'
+query RB
+select d, d > 'NaN' from s@{FORCE_INDEX=s_d_idx} where d > 'NaN' ORDER BY d, d::TEXT
 ----
 -Infinity  true
 -1         true
--0         true
--0.0       true
--0.00      true
--0.000     true
--0.0000    true
 0          true
+0          true
+0.0        true
+0.00       true
+0.000      true
+0.0000     true
 1          true
 Infinity   true
 
@@ -300,11 +277,11 @@ query R rowsort
 SELECT * FROM s@idx WHERE d = 0
 ----
 0
--0
--0.0
--0.00
--0.000
--0.0000
+0
+0.0
+0.00
+0.000
+0.0000
 
 statement ok
 INSERT INTO s VALUES

--- a/pkg/sql/logictest/testdata/logic_test/zero
+++ b/pkg/sql/logictest/testdata/logic_test/zero
@@ -1,0 +1,167 @@
+# LogicTest: local local-opt local-parallel-stmts fakedist fakedist-opt fakedist-metadata fakedist-disk
+
+# This tests zeros and numbers with trailing zeros.
+
+# ints
+
+statement ok
+CREATE TABLE i (i int, v int)
+
+statement ok
+INSERT INTO i VALUES
+  (1, 0),
+  (2, -0),
+  (3, 0::int),
+  (4, -0::int),
+  (5, '0'::int),
+  (6, '-0'::int)
+
+query II
+select * FROM i ORDER BY i
+----
+1 0
+2 0
+3 0
+4 0
+5 0
+6 0
+
+query IIIIII
+SELECT 0, -0, 0::int, -0::int, '0'::int, '-0'::int
+----
+0 0 0 0 0 0
+
+# floats
+
+statement ok
+CREATE TABLE f (i int, v float)
+
+statement ok
+INSERT INTO f VALUES
+  (1, 0.0),
+  (2, -0.0),
+  (3, 0.00::float),
+  (4, -0.00::float),
+  (5, (-0.000)::float),
+  (6, 0::float),
+  (7, -0::float),
+  (8, '0.0000'::float),
+  (9, '-0.0000'::float),
+  (10, 0),
+  (11, -0)
+
+query IR
+select * FROM f ORDER BY i
+----
+1 0
+2 0
+3 0
+4 -0
+5 0
+6 0
+7 -0
+8 0
+9 -0
+10 0
+11 0
+
+query RRRRRIIRRRR
+SELECT 0.0::float, -0.0::float, 0.00::float, -0.00::float, (-0.000)::float, 0, -0, 0::float, -0::float, '0.0000'::float, '-0.0000'::float
+----
+0 -0 0 -0 0 0 0 0 -0 0 -0
+
+# decimals
+
+query RRRRRRRRR
+SELECT 0.0::decimal, -0.0::decimal, 0.00::decimal, -0.00::decimal, (-0.000)::decimal, 0::decimal, -0::decimal, '0.0000'::decimal, '-0.0000'::decimal
+----
+0.0 0.0 0.00 0.00 0.000 0 0 0.0000 0.0000
+
+statement ok
+CREATE TABLE d (i INT, v DECIMAL)
+
+statement ok
+INSERT INTO d VALUES
+  (1, 0.0),
+  (2, -0.0),
+  (3, 0.00::decimal),
+  (4, -0.00::decimal),
+  (5, (-0.000)::decimal),
+  (6, 0::decimal),
+  (7, -0::decimal),
+  (8, '0.0000'::decimal),
+  (9, '-0.0000'::decimal),
+  (10, 0),
+  (11, -0)
+
+query IR
+select * FROM d ORDER BY i
+----
+1 0.0
+2 0.0
+3 0.00
+4 0.00
+5 0.000
+6 0
+7 0
+8 0.0000
+9 0.0000
+10 0
+11 0
+
+statement ok
+CREATE TABLE didx (i INT, v DECIMAL, INDEX vidx (v))
+
+statement ok
+INSERT INTO didx VALUES
+  (1, 0.0),
+  (2, -0.0),
+  (3, 0.00::decimal),
+  (4, -0.00::decimal),
+  (5, (-0.000)::decimal),
+  (6, 0::decimal),
+  (7, -0::decimal),
+  (8, '0.0000'::decimal),
+  (9, '-0.0000'::decimal),
+  (10, 0),
+  (11, -0)
+
+query R
+SELECT v FROM didx ORDER BY INDEX didx@vidx
+----
+0.0
+0.0
+0.00
+0.00
+0.000
+0
+0
+0.0000
+0.0000
+0
+0
+
+query RRRR
+SELECT - -0.00::decimal, - - -0.00::decimal, - - -0.00, - -0.00
+----
+0.00 0.00 0.00 0.00
+
+# TODO(mjibson): 
+#
+#query RRRR
+#SELECT -+-0.010::decimal, 0.020, 0.030::decimal, -0.0400000000000000000000000000
+#----
+#0.010 0.020 0.030 -0.0400000000000000000000000000
+#
+#query RR
+#SELECT -0.040 + 0, 0.040::decimal + 0
+#----
+#-0.040 0.040
+
+query R
+SELECT * FROM (VALUES (-0.0::DECIMAL), (-0::DECIMAL), (0::DECIMAL), (-0.00::DECIMAL)) ORDER BY 1
+----
+0.0
+0
+0
+0.00

--- a/pkg/sql/sem/tree/parse_string_test.go
+++ b/pkg/sql/sem/tree/parse_string_test.go
@@ -44,7 +44,6 @@ func TestParseDatumStringAs(t *testing.T) {
 		},
 		types.Decimal: {
 			"0.0",
-			"-0.0",
 			"1.0",
 			"-1.0",
 			strconv.FormatFloat(math.MaxFloat64, 'G', -1, 64),

--- a/pkg/util/encoding/decimal_test.go
+++ b/pkg/util/encoding/decimal_test.go
@@ -439,6 +439,43 @@ func TestNonsortingEncodeDecimalRand(t *testing.T) {
 	}
 }
 
+// TestNonsortingEncodeDecimalRoundtrip tests that decimals can round trip
+// through EncodeNonsortingDecimal and DecodeNonsortingDecimal with an expected
+// coefficient and exponent.
+func TestNonsortingEncodeDecimalRoundtrip(t *testing.T) {
+	tests := map[string]string{
+		"0":         "0E+0",
+		"0.0":       "0E-1",
+		"0.00":      "0E-2",
+		"0e-10":     "0E-10",
+		"0.00e-10":  "0E-12",
+		"00":        "0E+0",
+		"-0":        "-0E+0",
+		"-0.0":      "-0E-1",
+		"-0.00":     "-0E-2",
+		"-0e-10":    "-0E-10",
+		"-0.00e-10": "-0E-12",
+		"-00":       "-0E+0",
+	}
+	for tc, expect := range tests {
+		t.Run(tc, func(t *testing.T) {
+			d, _, err := apd.NewFromString(tc)
+			if err != nil {
+				t.Fatal(err)
+			}
+			enc := EncodeNonsortingDecimal(nil, d)
+			res, err := DecodeNonsortingDecimal(enc, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			s := res.Text('E')
+			if expect != s {
+				t.Fatalf("expected %s, got %s", expect, s)
+			}
+		})
+	}
+}
+
 func TestUpperBoundNonsortingDecimalUnscaledSize(t *testing.T) {
 	x := make([]byte, 100)
 	d := new(apd.Decimal)

--- a/pkg/util/json/encode_test.go
+++ b/pkg/util/json/encode_test.go
@@ -165,6 +165,7 @@ func TestJSONEncodeRoundTrip(t *testing.T) {
 		`-1`,
 		`1000000000000000`,
 		`100000000000000000000000000000000000`,
+		`0e1`,
 		`[]`,
 		`["hello"]`,
 		`[1]`,
@@ -210,6 +211,7 @@ func TestJSONEncodeStrictRoundTrip(t *testing.T) {
 		`1.1231231230`,
 		`1.1231231230000`,
 		`1.1231231230000000`,
+		`0E+1`,
 	}
 
 	for _, tc := range cases {
@@ -231,40 +233,6 @@ func TestJSONEncodeStrictRoundTrip(t *testing.T) {
 		if newStr != tc {
 			t.Fatalf("expected %s, got %s", tc, newStr)
 		}
-	}
-}
-
-func TestJSONEncodeNonRoundTrip(t *testing.T) {
-	cases := []struct {
-		input    string
-		expected string
-	}{
-		// Due to the encoding used by the DECIMAL encoder, these values do not round trip perfectly.
-		{`0e+1`, `0`},
-		{`0e1`, `0`},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.input, func(t *testing.T) {
-			j, err := ParseJSON(tc.input)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			encoded, err := EncodeJSON(nil, j)
-			if err != nil {
-				t.Fatal(err)
-			}
-			_, decoded, err := DecodeJSON(encoded)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			newStr := decoded.String()
-			if newStr != tc.expected {
-				t.Fatalf("expected %s, got %s", tc.expected, newStr)
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
Previously we had inconsistent handling of decimal zeroes. Various forms
(-0, -0.00, +0.00) were correctly handled from a "what is this equal to"
perspective, but we were not consistent in keeping the digits after the
decimal point. Furthermore, postgres always removes negatives when making
-0 for ints and decimals (not floats).

This behavior (removing the negative from -0 automatically) existed in the
higher level apd tests but we were subverting it by using apd.Decimal.Neg
directly. apd has been updated to do this for Decimals now.

Our constant evaluation has also caused us some problems. We use the
go/constant package, but it evaluates numbers as floats. When we applied
the + operator our NumVal type would remove its OrigString representation
and thus use only the constant's Value, which, as a float, didn't contain
the trailing digits after the decimal (in cases like +0.000). Now the +
operator is a pass through.

The - operator remains the same, but has special logic to detect -0 and
leave the original string

The added logic tests have been compared to postgres and now we match
them exactly for many more things.

Of note is that, in postgres, `SELECT -0::float` returns -0 (in opposition
to the decimal behavior). This is why the test in TestParseDatumStringAs
removed only the -0 test for decimals and not floats.

Release note (sql change): More correct handling of decimal
0s. Specifically, -0 is coerced to 0 and values like 0.00 retain the
digits after the decimal point.