### PR TITLE
roachpb: specify HeartbeatRequest.Now

### DIFF
--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -467,6 +467,8 @@ func TestTxnCoordSenderHeartbeat(t *testing.T) {
 
 // getTxn fetches the requested key and returns the transaction info.
 func getTxn(ctx context.Context, txn *client.Txn) (*roachpb.Transaction, *roachpb.Error) {
+	// Note that this HeartbeatTxnRequest doesn't set the Now field, so it doesn't
+	// update the txn. It acts simply as an easy way to read the txn record.
 	hb := &roachpb.HeartbeatTxnRequest{
 		RequestHeader: roachpb.RequestHeader{
 			Key: txn.Proto().Key,

--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -1130,7 +1130,12 @@ func (*AdminChangeReplicasResponse) Descriptor() ([]byte, []int) { return fileDe
 // gossip protocol.
 type HeartbeatTxnRequest struct {
 	RequestHeader `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
-	Now           cockroach_util_hlc.Timestamp `protobuf:"bytes,2,opt,name=now" json:"now"`
+	// now is the client's timestamp. It will be recorded as the transaction's
+	// last active time.
+	// If not set, then the heartbeat doesn't update the transaction, and just
+	// returns the transaction record. This serves as a convenience for reading a
+	// transaction record used by some tests.
+	Now cockroach_util_hlc.Timestamp `protobuf:"bytes,2,opt,name=now" json:"now"`
 }
 
 func (m *HeartbeatTxnRequest) Reset()                    { *m = HeartbeatTxnRequest{} }

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -628,6 +628,11 @@ message HeartbeatTxnRequest {
   option (gogoproto.equal) = true;
 
   RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  // now is the client's timestamp. It will be recorded as the transaction's
+  // last active time.
+  // If not set, then the heartbeat doesn't update the transaction, and just
+  // returns the transaction record. This serves as a convenience for reading a
+  // transaction record used by some tests.
   util.hlc.Timestamp now = 2 [(gogoproto.nullable) = false];
 }
 


### PR DESCRIPTION
Make it clear that it can be missing.
I've spent a while looking at TestTxnCoordSenderHeartbeat and thinking
it fools itself by heartbeating a record when it wanted to check that
someone else is heartbeating itself, but in fact it was using the fact
that the Now field doesn't have to be set.

Release note: None