### PR TITLE
acceptanceccl: speed up the CDC bank test

### DIFF
--- a/pkg/ccl/acceptanceccl/cdc_kafka_test.go
+++ b/pkg/ccl/acceptanceccl/cdc_kafka_test.go
@@ -172,7 +172,11 @@ func testBank(ctx context.Context, t *testing.T, c *cluster.DockerCluster, k *do
 		partitions[i] = strconv.Itoa(int(p))
 	}
 
-	const requestedResolved = 100
+	// TODO(dan): This should be higher (it was 100 initially) but a change that
+	// tuned the kafka producer config raised the running time of this test to
+	// tens of minutes. While I'm figuring out the right tunings, lower this to
+	// speed the test up.
+	const requestedResolved = 5
 	var numResolved, rowsSinceResolved int
 	v := changefeedccl.Validators{
 		changefeedccl.NewOrderValidator(`Bank_bank`),


### PR DESCRIPTION
PR #27754 retuned the kafka producer configs and drastically raised the
running time of this test. While I'm looking into the tunings, unblock
everyone's acceptance build times.

Release note: None