### PR TITLE
sql: fix planning of ProjectSet with projections

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_srfs
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_srfs
@@ -52,3 +52,14 @@ SELECT a, generate_series(1, 2), generate_series(1, 4) FROM data WHERE a < 2 ORD
 1  NULL  4
 1  1     1
 1  2     2
+
+statement ok
+CREATE TABLE groups(
+  id SERIAL,
+  data jsonb,
+  primary key (id)
+)
+
+query TT
+SELECT g.data->>'name' AS group_name, jsonb_array_elements(g.data->'members') FROM groups g;
+----


### PR DESCRIPTION
Previously, the ProjectSet DistSQL processor was incorrectly planned
when upstream columns were projected away.

Release note (bug fix): prevent spurious query errors when planning
some complex correlated SRFs through the distributed execution engine.