### PR TITLE
storage: use RWMutex in raftEntryCache, create freelist of Entries

### DIFF
--- a/pkg/storage/entry_cache.go
+++ b/pkg/storage/entry_cache.go
@@ -47,6 +47,54 @@ func (a *entryCacheKey) Compare(b llrb.Comparable) int {
 	}
 }
 
+const defaultEntryCacheFreeListSize = 16
+
+// entryCacheFreeList represents a free list of raftEntryCache cache.Entry
+// objects. The free list is initially empty and is populated as entries are
+// freed.
+//
+// A freelist is used here instead of a sync.Pool because all access to the
+// freelist is protected by the raftEntryCache lock so it doesn't need its
+// own locking. This allows us to avoid the added synchronization cost of
+// a sync.Pool.
+type entryCacheFreeList []*cache.Entry
+
+func makeEntryCacheFreeList(size int) entryCacheFreeList {
+	return make(entryCacheFreeList, 0, size)
+}
+
+func (f *entryCacheFreeList) newEntry(key entryCacheKey, value raftpb.Entry) *cache.Entry {
+	i := len(*f) - 1
+	if i < 0 {
+		alloc := struct {
+			key   entryCacheKey
+			value raftpb.Entry
+			entry cache.Entry
+		}{
+			key:   key,
+			value: value,
+		}
+		alloc.entry.Key = &alloc.key
+		alloc.entry.Value = &alloc.value
+		return &alloc.entry
+	}
+	e := (*f)[i]
+	(*f)[i] = nil
+	(*f) = (*f)[:i]
+
+	*e.Key.(*entryCacheKey) = key
+	*e.Value.(*raftpb.Entry) = value
+	return e
+}
+
+func (f *entryCacheFreeList) freeEntry(e *cache.Entry) {
+	if len(*f) < cap(*f) {
+		*e.Key.(*entryCacheKey) = entryCacheKey{}
+		*e.Value.(*raftpb.Entry) = raftpb.Entry{}
+		*f = append(*f, e)
+	}
+}
+
 // A raftEntryCache maintains a global cache of Raft group log entries. The
 // cache mostly prevents unnecessary reads from disk of recently-written log
 // entries between log append and application to the FSM.
@@ -54,19 +102,21 @@ func (a *entryCacheKey) Compare(b llrb.Comparable) int {
 // This cache stores entries with sideloaded proposals inlined (i.e. ready to
 // be sent to followers).
 type raftEntryCache struct {
-	syncutil.RWMutex                     // protects Cache for concurrent access.
+	syncutil.RWMutex                     // protects Cache for concurrent access
 	bytes            uint64              // total size of the cache in bytes
 	cache            *cache.OrderedCache // LRU cache of log entries, keyed by rangeID / log index
+	freeList         entryCacheFreeList  // used to avoid allocations on insertion
 }
 
 // newRaftEntryCache returns a new RaftEntryCache with the given
 // maximum size in bytes.
 func newRaftEntryCache(maxBytes uint64) *raftEntryCache {
 	rec := &raftEntryCache{
-		cache: cache.NewOrderedCache(cache.Config{Policy: cache.CacheLRU}),
+		cache:    cache.NewOrderedCache(cache.Config{Policy: cache.CacheLRU}),
+		freeList: makeEntryCacheFreeList(defaultEntryCacheFreeListSize),
 	}
 	// The raft entry cache mutex will be held when the ShouldEvict
-	// and OnEvicted callbacks are invoked.
+	// and OnEvictedEntry callbacks are invoked.
 	//
 	// On ShouldEvict, compare the total size of the cache in bytes to the
 	// configured maxBytes. We also insist that at least one entry remains
@@ -75,26 +125,13 @@ func newRaftEntryCache(maxBytes uint64) *raftEntryCache {
 	rec.cache.Config.ShouldEvict = func(n int, k, v interface{}) bool {
 		return rec.bytes > maxBytes && n >= 1
 	}
-	rec.cache.Config.OnEvicted = func(k, v interface{}) {
-		ent := v.(*raftpb.Entry)
+	rec.cache.Config.OnEvictedEntry = func(e *cache.Entry) {
+		ent := e.Value.(*raftpb.Entry)
 		rec.bytes -= uint64(ent.Size())
+		rec.freeList.freeEntry(e)
 	}
 
 	return rec
-}
-
-func (rec *raftEntryCache) makeCacheEntry(key entryCacheKey, value raftpb.Entry) *cache.Entry {
-	alloc := struct {
-		key   entryCacheKey
-		value raftpb.Entry
-		entry cache.Entry
-	}{
-		key:   key,
-		value: value,
-	}
-	alloc.entry.Key = &alloc.key
-	alloc.entry.Value = &alloc.value
-	return &alloc.entry
 }
 
 // addEntries adds the slice of raft entries, using the range ID and the
@@ -107,9 +144,10 @@ func (rec *raftEntryCache) addEntries(rangeID roachpb.RangeID, ents []raftpb.Ent
 	defer rec.Unlock()
 
 	for _, e := range ents {
-		rec.bytes += uint64(e.Size())
-		entry := rec.makeCacheEntry(entryCacheKey{RangeID: rangeID, Index: e.Index}, e)
+		key := entryCacheKey{RangeID: rangeID, Index: e.Index}
+		entry := rec.freeList.newEntry(key, e)
 		rec.cache.AddEntry(entry)
+		rec.bytes += uint64(e.Size())
 	}
 }
 

--- a/pkg/util/cache/cache.go
+++ b/pkg/util/cache/cache.go
@@ -63,6 +63,10 @@ type Config struct {
 	// OnEvicted optionally specifies a callback function to be
 	// executed when an entry is purged from the cache.
 	OnEvicted func(key, value interface{})
+
+	// OnEvictedEntry optionally specifies a callback function to
+	// be executed when an entry is purged from the cache.
+	OnEvictedEntry func(entry *Entry)
 }
 
 // Entry holds the key and value and a pointer to the linked list
@@ -259,9 +263,14 @@ func (bc *baseCache) DelEntry(entry *Entry) {
 
 // Clear clears all entries from the cache.
 func (bc *baseCache) Clear() {
-	if bc.OnEvicted != nil {
+	if bc.OnEvicted != nil || bc.OnEvictedEntry != nil {
 		for e := bc.ll.back(); e != &bc.ll.root; e = e.prev {
-			bc.OnEvicted(e.Key, e.Value)
+			if bc.OnEvicted != nil {
+				bc.OnEvicted(e.Key, e.Value)
+			}
+			if bc.OnEvictedEntry != nil {
+				bc.OnEvictedEntry(e)
+			}
 		}
 	}
 	bc.ll.init()
@@ -284,6 +293,9 @@ func (bc *baseCache) removeElement(e *Entry) {
 	bc.store.del(e)
 	if bc.OnEvicted != nil {
 		bc.OnEvicted(e.Key, e.Value)
+	}
+	if bc.OnEvictedEntry != nil {
+		bc.OnEvictedEntry(e)
 	}
 }
 


### PR DESCRIPTION
This PR contains two separate perf improvements to the raftEntryCache.

### Use RWMutex, avoid contention on reads

raftEntryCache is shared across all Replicas on a Store, so it needs
its own locking on top of Replica.raftMu. This also means that multiple
Replicas may read their entries at the same time, either through `getTerm`
or `getEntries`.

During a TPC-C 10k run with 16 core machines I noticed that the locking
in these two methods was accounting for 1.2% of total CPU utilization
and the locking in `addEntries` was accounting for .2%. This implies
that reads of the cache are at least 6x more frequent than writes.
This indicates that we would get a win out of allowing concurrent
reads by switching to a RWMutex.

The first commit makes the change on switching to a RWMutex in
raftEntryCache. Measurements after this change show that the RLock
calls now account for only 0.15% of CPU usage.

There is one downside to this change and that is that it requires us
to remove the optimization to avoid `entryCacheKey` allocations in
lookup methods. This is unfortunate, but not a huge deal. That's
especailly true because all of the `OrderedCache` lookup functions
allocate `Entry` objects anyway. I had a second change that used
unsafe.Pointers and atomic swaps to optimistically avoid these new
allocations in the cases where pre-allocated `*entryCacheKey` objects
were not already "reserved" concurrently. This made things a little
more complicated though and I wasn't able to experimentally prove that
it was worth it. I'm curious what reveiwers think.

### Add new freelist, recycle Entries

The second commit creates a freelist structure that a raftEntryCache
holds on to which avoids allocations in the steady-state where
the cache is full. The freelist is populated when `cache.Entry`
objects are removed from the `OrderedCache`, either manually through
its `delEntries` method or when evicted due to size constraints.
The freelist is then used to avoid allocations during cache insertion.