### PR TITLE
tpccbench: support multi-zone and partitioned benchmarking 

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -705,6 +705,12 @@ func startArgs(extraArgs ...string) option {
 // encryption enabled.
 var startArgsDontEncrypt = startArgs("--encrypt=false")
 
+// racks is an option which specifies the number of racks to partition the nodes
+// into.
+func racks(n int) option {
+	return startArgs(fmt.Sprintf("--racks=%d", n))
+}
+
 // stopArgs specifies extra arguments that are passed to `roachprod` during `c.Stop`.
 func stopArgs(extraArgs ...string) option {
 	return roachprodArgOption(extraArgs)


### PR DESCRIPTION
Before this change, tpccbench supported single-zone benchmarking and
multi-region benchmarking, but the latter was built as a special-case
of the former without particularly useful generality or orthogonality of
concepts. This change introduces mult-zone benchmarking. In doing so,
it generalizes tpccbench's handling of zone distribution and load
configuration so that they can be extended in the future.

The second commit demonstrates the added extensibility. It adds a
new load configuration for a single load gen with rack-aware partitioning.
This allows us to add a new 18 node, single DC, partitioned
bench spec.