### PR TITLE
storage: avoid double lock in tryGetOrCreateReplica

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2032,10 +2032,10 @@ func (r *Replica) sendWithRangeID(
 // declared in the SpanSet; this is OK because it can never change the
 // evaluation of a batch, only allow or disallow it.
 func (r *Replica) requestCanProceed(rspan roachpb.RSpan, ts hlc.Timestamp) error {
-	r.mu.Lock()
+	r.mu.RLock()
 	desc := r.mu.state.Desc
 	threshold := r.mu.state.GCThreshold
-	r.mu.Unlock()
+	r.mu.RUnlock()
 	if !threshold.Less(ts) {
 		return &roachpb.BatchTimestampBeforeGCError{
 			Timestamp: ts,


### PR DESCRIPTION
Before this change, `tryGetOrCreateReplica` was RLocking, checking
an uncommon condition, then Locking. This was unnecessary and made
the code look strange. It also resulted in an extra RLock in the
exceptionally common case where the Replica was not destroyed.

This change fixes this by collapsing the destroyStatus check into
the main critical section. There's no real expected performance
improvement here, this is mostly just for cleaner code.

Release note: None