### PR TITLE
server: set up and plumb a closedts.Container

### DIFF
--- a/pkg/storage/closedts/container/noop.go
+++ b/pkg/storage/closedts/container/noop.go
@@ -1,0 +1,85 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package container
+
+import (
+	"context"
+	"errors"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/closedts/ctpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+)
+
+type noopEverything struct{}
+
+// NoopContainer returns a Container for which all parts of the subsystem are
+// mocked out. This is for usage in testing where there just needs to be a
+// structure that stays out of the way.
+//
+// The returned container will behave correctly. It will never allow any time-
+// stamps to be closed out, so it never makes any promises; it doesn't use any
+// locking and it does not consume any (nontrivial) resources.
+func NoopContainer() *Container {
+	return &Container{
+		Config: Config{
+			Settings: cluster.MakeTestingClusterSettings(),
+			Stopper:  stop.NewStopper(),
+			Clock: func(roachpb.NodeID) (hlc.Timestamp, ctpb.Epoch, error) {
+				return hlc.Timestamp{}, 0, errors.New("closed timestamps disabled for testing")
+			},
+			Refresh: func(...roachpb.RangeID) {},
+			Dialer:  noopEverything{},
+		},
+		Tracker:  noopEverything{},
+		Storage:  noopEverything{},
+		Provider: noopEverything{},
+		Server:   noopEverything{},
+		Clients:  noopEverything{},
+	}
+}
+
+func (noopEverything) Get(client ctpb.InboundClient) error {
+	return errors.New("closed timestamps disabled")
+}
+func (noopEverything) Close(next hlc.Timestamp) (hlc.Timestamp, map[roachpb.RangeID]ctpb.LAI) {
+	return hlc.Timestamp{}, nil
+}
+func (noopEverything) Track(
+	ctx context.Context,
+) (hlc.Timestamp, func(context.Context, roachpb.RangeID, ctpb.LAI)) {
+	return hlc.Timestamp{}, func(context.Context, roachpb.RangeID, ctpb.LAI) {}
+}
+func (noopEverything) VisitAscending(roachpb.NodeID, func(ctpb.Entry) (done bool))  {}
+func (noopEverything) VisitDescending(roachpb.NodeID, func(ctpb.Entry) (done bool)) {}
+func (noopEverything) Add(roachpb.NodeID, ctpb.Entry)                               {}
+func (noopEverything) Notify(roachpb.NodeID) chan<- ctpb.Entry {
+	return nil // will explode when used, but nobody would use this
+}
+func (noopEverything) Subscribe(context.Context, chan<- ctpb.Entry) {}
+func (noopEverything) Start()                                       {}
+func (noopEverything) CanServe(
+	roachpb.NodeID, hlc.Timestamp, roachpb.RangeID, ctpb.Epoch, ctpb.LAI,
+) bool {
+	return false
+}
+func (noopEverything) Request(roachpb.NodeID, roachpb.RangeID) {}
+func (noopEverything) EnsureClient(roachpb.NodeID)             {}
+func (noopEverything) Dial(context.Context, roachpb.NodeID) (ctpb.Client, error) {
+	return nil, errors.New("closed timestamps disabled")
+}
+func (noopEverything) Ready(roachpb.NodeID) bool { return false }

--- a/pkg/storage/closedts/provider/provider.go
+++ b/pkg/storage/closedts/provider/provider.go
@@ -110,6 +110,10 @@ func (p *Provider) runCloser(ctx context.Context) {
 	// extra work to help the subscribers terminate.
 	defer p.drain()
 
+	if p.cfg.NodeID == 0 {
+		// This Provider is likely misconfigured.
+		panic("can't use NodeID zero")
+	}
 	ch := p.Notify(p.cfg.NodeID)
 	defer close(ch)
 
@@ -130,7 +134,7 @@ func (p *Provider) runCloser(ctx context.Context) {
 			t.Read = true
 		}
 
-		next, epoch, err := p.cfg.Clock()
+		next, epoch, err := p.cfg.Clock(p.cfg.NodeID)
 
 		next.WallTime -= int64(targetDuration)
 		if err != nil {

--- a/pkg/storage/closedts/provider/provider_test.go
+++ b/pkg/storage/closedts/provider/provider_test.go
@@ -59,7 +59,7 @@ func TestProviderSubscribeNotify(t *testing.T) {
 		Settings: st,
 		Stopper:  stopper,
 		Storage:  storage,
-		Clock: func() (hlc.Timestamp, ctpb.Epoch, error) {
+		Clock: func(roachpb.NodeID) (hlc.Timestamp, ctpb.Epoch, error) {
 			select {
 			case <-stopper.ShouldQuiesce():
 			case <-unblockClockCh:

--- a/pkg/storage/closedts/provider/testutils/clock.go
+++ b/pkg/storage/closedts/provider/testutils/clock.go
@@ -17,6 +17,7 @@ package testutils
 import (
 	"errors"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -52,7 +53,7 @@ func (c *TestClock) Tick(liveNow hlc.Timestamp, liveEpoch ctpb.Epoch, err error)
 }
 
 // LiveNow implements closedts.LiveClockFn.
-func (c *TestClock) LiveNow() (liveNow hlc.Timestamp, liveEpoch ctpb.Epoch, _ error) {
+func (c *TestClock) LiveNow(roachpb.NodeID) (liveNow hlc.Timestamp, liveEpoch ctpb.Epoch, _ error) {
 	select {
 	case r := <-c.ch:
 		return r.liveNow, r.liveEpoch, r.err

--- a/pkg/storage/closedts/transport/clients.go
+++ b/pkg/storage/closedts/transport/clients.go
@@ -109,6 +109,9 @@ func (pr *Clients) getOrCreateClient(nodeID roachpb.NodeID) *client {
 
 		c, err := pr.cfg.Dialer.Dial(ctx, nodeID)
 		if err != nil {
+			if log.V(1) {
+				log.Warningf(ctx, "error opening closed timestamp stream to n%d: %s", nodeID, err)
+			}
 			return
 		}
 		defer func() {

--- a/pkg/storage/closedts/transport/server.go
+++ b/pkg/storage/closedts/transport/server.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/storage/closedts"
 	"github.com/cockroachdb/cockroach/pkg/storage/closedts/ctpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -53,6 +54,10 @@ func (s *Server) Get(client ctpb.InboundClient) error {
 	// This problem has likely been solved somewhere in our codebase.
 	ctx := client.Context()
 	ch := make(chan ctpb.Entry, 10)
+
+	if log.V(1) {
+		log.Infof(ctx, "closed timestamp server serving new inbound client connection")
+	}
 
 	// TODO(tschottdorf): make this, say, 2*closedts.CloseFraction*closedts.TargetInterval.
 	const closedTimestampNoUpdateWarnThreshold = 10 * time.Second

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -3064,6 +3064,14 @@ func (r *Replica) tryExecuteWriteBatch(
 	}
 	r.limitTxnMaxTimestamp(ctx, &ba, status)
 
+	// TODO(tschottdorf): hook up the closed timestamp subsystem. For now, this
+	// block serves as an easily enabled canary that verifies whether the system
+	// is set up where it's needed.
+	if false {
+		_, untrack := r.store.cfg.ClosedTimestamp.Tracker.Track(ctx)
+		untrack(ctx, r.RangeID, 0)
+	}
+
 	// Examine the read and write timestamp caches for preceding
 	// commands which require this command to move its timestamp
 	// forward. Or, in the case of a transactional write, the txn

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -25,9 +25,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
-	"github.com/cockroachdb/cockroach/pkg/util/limit"
-
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/google/btree"
@@ -42,10 +39,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
+	"github.com/cockroachdb/cockroach/pkg/storage/closedts/container"
 	"github.com/cockroachdb/cockroach/pkg/storage/compactor"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
@@ -58,6 +57,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/limit"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -144,6 +144,7 @@ func TestStoreConfig(clock *hlc.Clock) StoreConfig {
 		TimestampCachePageSize:      tscache.TestSklPageSize,
 		HistogramWindowInterval:     metric.TestSampleInterval,
 		EnableEpochRangeLeases:      true,
+		ClosedTimestamp:             container.NoopContainer(),
 	}
 
 	// Tests should never send unsequenced transactional writes,
@@ -574,6 +575,8 @@ type StoreConfig struct {
 	Transport    *RaftTransport
 	NodeDialer   *nodedialer.Dialer
 	RPCContext   *rpc.Context
+
+	ClosedTimestamp *container.Container
 
 	// SQLExecutor is used by the store to execute SQL statements.
 	SQLExecutor sqlutil.InternalExecutor


### PR DESCRIPTION
The container is only set up and plumbed but not used. Unfortunately,
since the NodeID is known only late but servers have to be registered
early, the initialization process has become a little more complicated,
tough not overly so.

Release note: None