### PR TITLE
storage: fix a nasty merge/replica GC race

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2381,7 +2381,7 @@ func TestReplicaRemovalCampaign(t *testing.T) {
 
 			if td.remove {
 				// Simulate second replica being transferred by removing it.
-				if err := store0.RemoveReplica(context.Background(), replica2, *replica2.Desc(), storage.RemoveOptions{
+				if err := store0.RemoveReplica(context.Background(), replica2, replica2.Desc().NextReplicaID, storage.RemoveOptions{
 					DestroyData: true,
 				}); err != nil {
 					t.Fatal(err)

--- a/pkg/storage/queue_test.go
+++ b/pkg/storage/queue_test.go
@@ -101,7 +101,7 @@ func createReplicas(t *testing.T, tc *testContext, num int) []*Replica {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := tc.store.RemoveReplica(context.Background(), repl1, *repl1.Desc(), RemoveOptions{
+	if err := tc.store.RemoveReplica(context.Background(), repl1, repl1.Desc().NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); err != nil {
 		t.Fatal(err)
@@ -537,7 +537,7 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if err := s.RemoveReplica(context.Background(), repl1, *repl1.Desc(), RemoveOptions{
+	if err := s.RemoveReplica(context.Background(), repl1, repl1.Desc().NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); err != nil {
 		t.Error(err)

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -779,7 +779,7 @@ func (r *Replica) String() string {
 // will be deleted. Otherwise, only data in the range-ID local keyspace will be
 // deleted. Requires that Replica.raftMu is held.
 func (r *Replica) destroyRaftMuLocked(
-	ctx context.Context, consistentDesc roachpb.RangeDescriptor, destroyData bool,
+	ctx context.Context, nextReplicaID roachpb.ReplicaID, destroyData bool,
 ) error {
 	startTime := timeutil.Now()
 
@@ -790,8 +790,6 @@ func (r *Replica) destroyRaftMuLocked(
 
 	ms := r.GetMVCCStats()
 
-	// NB: this uses the local descriptor instead of the consistent one to match
-	// the data on disk.
 	desc := r.Desc()
 	err := clearRangeData(ctx, desc, ms.KeyCount, r.store.Engine(), batch, destroyData)
 	if err != nil {
@@ -814,7 +812,7 @@ func (r *Replica) destroyRaftMuLocked(
 	// NB: Legacy tombstones (which are in the replicated key space) are wiped
 	// in clearRangeData, but that's OK since we're writing a new one in the same
 	// batch (and in particular, sequenced *after* the wipe).
-	if err := r.setTombstoneKey(ctx, batch, &consistentDesc); err != nil {
+	if err := r.setTombstoneKey(ctx, batch, nextReplicaID); err != nil {
 		return err
 	}
 	// We need to sync here because we are potentially deleting sideloaded
@@ -881,42 +879,30 @@ func (r *Replica) cleanupFailedProposalLocked(p *ProposalData) {
 
 // setTombstoneKey writes a tombstone to disk to ensure that replica IDs never
 // get reused. It determines what the minimum next replica ID can be using
-// the provided RangeDescriptor and the Replica's own ID.
+// the provided nextReplicaID and the Replica's own ID.
 //
 // We have to be careful to set the right key, since a replica can be using an
 // ID that it hasn't yet received a RangeDescriptor for if it receives raft
 // requests for that replica ID (as seen in #14231).
 func (r *Replica) setTombstoneKey(
-	ctx context.Context, eng engine.ReadWriter, desc *roachpb.RangeDescriptor,
+	ctx context.Context, eng engine.ReadWriter, externalNextReplicaID roachpb.ReplicaID,
 ) error {
 	r.mu.Lock()
-	nextReplicaID := r.nextReplicaIDLocked(desc)
-	r.mu.minReplicaID = nextReplicaID
+	nextReplicaID := r.mu.state.Desc.NextReplicaID
+	if nextReplicaID < externalNextReplicaID {
+		nextReplicaID = externalNextReplicaID
+	}
+	if nextReplicaID > r.mu.minReplicaID {
+		r.mu.minReplicaID = nextReplicaID
+	}
 	r.mu.Unlock()
 
-	tombstoneKey := keys.RaftTombstoneKey(desc.RangeID)
+	tombstoneKey := keys.RaftTombstoneKey(r.RangeID)
 	tombstone := &roachpb.RaftTombstone{
 		NextReplicaID: nextReplicaID,
 	}
 	return engine.MVCCPutProto(ctx, eng, nil, tombstoneKey,
 		hlc.Timestamp{}, nil, tombstone)
-}
-
-// nextReplicaIDLocked returns the minimum ID that a new replica can be created
-// with for this replica's range. We have to be very careful to ensure that
-// replica IDs never get re-used because that can cause panics.
-//
-// The externalDesc parameter is an optional way to provide an additional
-// descriptor for the range that was looked up outside the replica code.
-func (r *Replica) nextReplicaIDLocked(externalDesc *roachpb.RangeDescriptor) roachpb.ReplicaID {
-	result := r.mu.state.Desc.NextReplicaID
-	if externalDesc != nil && result < externalDesc.NextReplicaID {
-		result = externalDesc.NextReplicaID
-	}
-	if result < r.mu.minReplicaID {
-		result = r.mu.minReplicaID
-	}
-	return result
 }
 
 func (r *Replica) setReplicaID(replicaID roachpb.ReplicaID) error {
@@ -2797,7 +2783,7 @@ func (r *Replica) maybeWatchForMerge(ctx context.Context) error {
 		replyDesc := rs[0]
 		if replyDesc.RangeID != desc.RangeID {
 			// Merge successful. Remove the replica.
-			err := r.store.RemoveReplica(ctx, r, *desc, RemoveOptions{DestroyData: true})
+			err := r.store.RemoveReplica(ctx, r, desc.NextReplicaID, RemoveOptions{DestroyData: true})
 			// It's not a problem if the replica is already gone. It may have been
 			// cleaned up when the merge transaction committed if it was collocated
 			// with a replica of the left-hand side of the merge.

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -7040,14 +7040,14 @@ func TestReplicaDestroy(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectedErr := "replica descriptor's ID has changed"
-	if err := tc.store.removeReplicaImpl(context.Background(), tc.repl, *origDesc, RemoveOptions{
+	if err := tc.store.removeReplicaImpl(context.Background(), tc.repl, origDesc.NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); !testutils.IsError(err, expectedErr) {
 		t.Fatalf("expected error %q but got %v", expectedErr, err)
 	}
 
 	// Now try a fresh descriptor and succeed.
-	if err := tc.store.removeReplicaImpl(context.Background(), tc.repl, *repl.Desc(), RemoveOptions{
+	if err := tc.store.removeReplicaImpl(context.Background(), tc.repl, repl.Desc().NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); err != nil {
 		t.Fatal(err)
@@ -7091,7 +7091,7 @@ func TestQuotaPoolAccessOnDestroyedReplica(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tc.store.removeReplicaImpl(context.TODO(), repl, *repl.Desc(), RemoveOptions{
+	if err := tc.store.removeReplicaImpl(context.TODO(), repl, repl.Desc().NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); err != nil {
 		t.Fatal(err)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2398,7 +2398,7 @@ func (s *Store) MergeRange(
 		// Note that we were called (indirectly) from raft processing so we must
 		// call removeReplicaImpl directly to avoid deadlocking on the right-hand
 		// replica's raftMu.
-		if err := s.removeReplicaImpl(ctx, rightRepl, rightDesc, RemoveOptions{
+		if err := s.removeReplicaImpl(ctx, rightRepl, rightDesc.NextReplicaID, RemoveOptions{
 			DestroyData: false,
 		}); err != nil {
 			return errors.Errorf("cannot remove range: %s", err)
@@ -2528,28 +2528,29 @@ type RemoveOptions struct {
 	DestroyData bool
 }
 
-// RemoveReplica removes the replica from the store's replica map and
-// from the sorted replicasByKey btree. The version of the replica
-// descriptor that was used to make the removal decision is passed in,
-// and the removal is aborted if the replica ID has changed since
-// then.
+// RemoveReplica removes the replica from the store's replica map and from the
+// sorted replicasByKey btree.
 //
-// If opts.DestroyData is true, data in all of the range's keyspaces
-// is deleted. Otherwise, only data in the range-ID local keyspace is
-// deleted. In either case a tombstone record is written.
+// The NextReplicaID from the replica descriptor that was used to make the
+// removal decision is passed in. Removal is aborted if the replica ID has
+// advanced to or beyond the NextReplicaID since the removal decision was made.
+//
+// If opts.DestroyData is true, data in all of the range's keyspaces is deleted.
+// Otherwise, only data in the range-ID local keyspace is deleted. In either
+// case a tombstone record is written.
 func (s *Store) RemoveReplica(
-	ctx context.Context, rep *Replica, consistentDesc roachpb.RangeDescriptor, opts RemoveOptions,
+	ctx context.Context, rep *Replica, nextReplicaID roachpb.ReplicaID, opts RemoveOptions,
 ) error {
 	rep.raftMu.Lock()
 	defer rep.raftMu.Unlock()
-	return s.removeReplicaImpl(ctx, rep, consistentDesc, opts)
+	return s.removeReplicaImpl(ctx, rep, nextReplicaID, opts)
 }
 
 // removeReplicaImpl is the implementation of RemoveReplica, which is sometimes
 // called directly when the necessary lock is already held. It requires that
 // Replica.raftMu is held and that s.mu is not held.
 func (s *Store) removeReplicaImpl(
-	ctx context.Context, rep *Replica, consistentDesc roachpb.RangeDescriptor, opts RemoveOptions,
+	ctx context.Context, rep *Replica, nextReplicaID roachpb.ReplicaID, opts RemoveOptions,
 ) error {
 	log.Infof(ctx, "removing replica")
 
@@ -2557,16 +2558,16 @@ func (s *Store) removeReplicaImpl(
 	// they can differ in cases when a replica's ID is increased due to an
 	// incoming raft message (see #14231 for background).
 	rep.mu.Lock()
-	if rep.mu.replicaID >= consistentDesc.NextReplicaID {
+	if rep.mu.replicaID >= nextReplicaID {
 		rep.mu.Unlock()
 		return errors.Errorf("cannot remove replica %s; replica ID has changed (%s >= %s)",
-			rep, rep.mu.replicaID, consistentDesc.NextReplicaID)
+			rep, rep.mu.replicaID, nextReplicaID)
 	}
 	desc := rep.mu.state.Desc
-	if repDesc, ok := desc.GetReplicaDescriptor(s.StoreID()); ok && repDesc.ReplicaID >= consistentDesc.NextReplicaID {
+	if repDesc, ok := desc.GetReplicaDescriptor(s.StoreID()); ok && repDesc.ReplicaID >= nextReplicaID {
 		rep.mu.Unlock()
 		return errors.Errorf("cannot remove replica %s; replica descriptor's ID has changed (%s >= %s)",
-			rep, repDesc.ReplicaID, consistentDesc.NextReplicaID)
+			rep, repDesc.ReplicaID, nextReplicaID)
 	}
 	rep.mu.Unlock()
 
@@ -2602,7 +2603,7 @@ func (s *Store) removeReplicaImpl(
 	rep.mu.Unlock()
 	rep.readOnlyCmdMu.Unlock()
 
-	if err := rep.destroyRaftMuLocked(ctx, consistentDesc, opts.DestroyData); err != nil {
+	if err := rep.destroyRaftMuLocked(ctx, nextReplicaID, opts.DestroyData); err != nil {
 		return err
 	}
 
@@ -3549,7 +3550,9 @@ func (s *Store) processRaftSnapshotRequest(
 				// Raft has decided the snapshot shouldn't be applied we would be
 				// writing the tombstone key incorrectly.
 				r.mu.Lock()
-				r.mu.minReplicaID = r.nextReplicaIDLocked(nil)
+				if r.mu.state.Desc.NextReplicaID > r.mu.minReplicaID {
+					r.mu.minReplicaID = r.mu.state.Desc.NextReplicaID
+				}
 				r.mu.Unlock()
 			}
 

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -556,7 +556,7 @@ func TestStoreAddRemoveRanges(t *testing.T) {
 		t.Error(err)
 	}
 	// Remove range 1.
-	if err := store.RemoveReplica(context.Background(), repl1, *repl1.Desc(), RemoveOptions{
+	if err := store.RemoveReplica(context.Background(), repl1, repl1.Desc().NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); err != nil {
 		t.Error(err)
@@ -572,7 +572,7 @@ func TestStoreAddRemoveRanges(t *testing.T) {
 		t.Fatal("expected error re-adding same range")
 	}
 	// Try to remove range 1 again.
-	if err := store.RemoveReplica(context.Background(), repl1, *repl1.Desc(), RemoveOptions{
+	if err := store.RemoveReplica(context.Background(), repl1, repl1.Desc().NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); err == nil {
 		t.Fatal("expected error re-removing same range")
@@ -685,14 +685,14 @@ func TestStoreRemoveReplicaOldDescriptor(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectedErr := "replica descriptor's ID has changed"
-	if err := store.RemoveReplica(context.Background(), rep, *origDesc, RemoveOptions{
+	if err := store.RemoveReplica(context.Background(), rep, origDesc.NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); !testutils.IsError(err, expectedErr) {
 		t.Fatalf("expected error %q but got %v", expectedErr, err)
 	}
 
 	// Now try a fresh descriptor and succeed.
-	if err := store.RemoveReplica(context.Background(), rep, *rep.Desc(), RemoveOptions{
+	if err := store.RemoveReplica(context.Background(), rep, rep.Desc().NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); err != nil {
 		t.Fatal(err)
@@ -709,7 +709,7 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := store.RemoveReplica(context.Background(), repl1, *repl1.Desc(), RemoveOptions{
+	if err := store.RemoveReplica(context.Background(), repl1, repl1.Desc().NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); err != nil {
 		t.Fatal(err)
@@ -750,7 +750,7 @@ func TestStoreReplicaVisitor(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if err := store.RemoveReplica(context.Background(), repl1, *repl1.Desc(), RemoveOptions{
+	if err := store.RemoveReplica(context.Background(), repl1, repl1.Desc().NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); err != nil {
 		t.Error(err)
@@ -817,7 +817,7 @@ func TestHasOverlappingReplica(t *testing.T) {
 		t.Error(err)
 	}
 	// Remove range 1.
-	if err := store.RemoveReplica(context.Background(), repl1, *repl1.Desc(), RemoveOptions{
+	if err := store.RemoveReplica(context.Background(), repl1, repl1.Desc().NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); err != nil {
 		t.Error(err)
@@ -874,7 +874,7 @@ func TestProcessRangeDescriptorUpdate(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if err := store.RemoveReplica(context.Background(), repl1, *repl1.Desc(), RemoveOptions{
+	if err := store.RemoveReplica(context.Background(), repl1, repl1.Desc().NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); err != nil {
 		t.Error(err)
@@ -2471,7 +2471,7 @@ func TestMaybeRemove(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if err := store.RemoveReplica(context.Background(), repl, *repl.Desc(), RemoveOptions{
+	if err := store.RemoveReplica(context.Background(), repl, repl.Desc().NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); err != nil {
 		t.Error(err)
@@ -2555,7 +2555,7 @@ func TestStoreRangePlaceholders(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if err := s.RemoveReplica(ctx, repl1, *repl1.Desc(), RemoveOptions{
+	if err := s.RemoveReplica(ctx, repl1, repl1.Desc().NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); err != nil {
 		t.Error(err)
@@ -2649,7 +2649,7 @@ func TestStoreRemovePlaceholderOnError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.RemoveReplica(context.Background(), repl1, *repl1.Desc(), RemoveOptions{
+	if err := s.RemoveReplica(context.Background(), repl1, repl1.Desc().NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); err != nil {
 		t.Fatal(err)
@@ -2724,7 +2724,7 @@ func TestStoreRemovePlaceholderOnRaftIgnored(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.RemoveReplica(context.Background(), repl1, *repl1.Desc(), RemoveOptions{
+	if err := s.RemoveReplica(context.Background(), repl1, repl1.Desc().NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); err != nil {
 		t.Fatal(err)
@@ -2866,11 +2866,7 @@ func TestRemovedReplicaTombstone(t *testing.T) {
 				defer repl1.mu.Unlock()
 
 				go func() {
-					desc := roachpb.RangeDescriptor{
-						RangeID:       rangeID,
-						NextReplicaID: c.descNextReplicaID,
-					}
-					errChan <- s.RemoveReplica(ctx, repl1, desc, RemoveOptions{DestroyData: true})
+					errChan <- s.RemoveReplica(ctx, repl1, c.descNextReplicaID, RemoveOptions{DestroyData: true})
 				}()
 
 				time.Sleep(1 * time.Millisecond)


### PR DESCRIPTION
Fix a particularly nasty merge/replica GC race. In short, the replica GC
queue was writing a tombstone for the wrong range when the replica it
was considering was a) no longer a member of its range, and b) its range
had since been subsumed by its left-hand neighbor.