### PR TITLE
build: fix C dependencies for bin/{workload,roachtest}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1391,6 +1391,7 @@ logictestopt-package = ./pkg/sql/opt/exec/execbuilder
 
 # Additional dependencies for binaries that depend on generated code.
 bin/workload bin/docgen bin/roachtest: $(SQLPARSER_TARGETS) $(PROTOBUF_TARGETS)
+bin/workload bin/roachtest: $(C_LIBS_CCL) $(CGO_FLAGS_FILES)
 bin/roachtest: $(OPTGEN_TARGETS)
 
 $(bins): bin/%: bin/%.d | bin/prereqs bin/.submodules-initialized


### PR DESCRIPTION
`bin/{workload,roachtest}` recently acquired dependencies on
`storage/engine` which requires ths C libraries to be built. Failure to
build these dependencies was causing the nightly roachtest build to fail
when make was from a clean repo with `make bin/workload bin/roachtest`.

Release note: None