### PR TITLE
sql: fix schema change reverse mutation and rollback job setup

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -471,7 +471,7 @@ func TestBackupRestoreSystemJobs(t *testing.T) {
 	sqlDB.Exec(t, `SET DATABASE = data`)
 
 	sqlDB.Exec(t, `BACKUP TABLE bank TO $1 INCREMENTAL FROM $2`, incDir, fullDir)
-	if err := jobutils.VerifySystemJob(t, sqlDB, baseNumJobs+1, jobspb.TypeBackup, jobs.Record{
+	if err := jobutils.VerifySystemJob(t, sqlDB, baseNumJobs+1, jobspb.TypeBackup, jobs.StatusSucceeded, jobs.Record{
 		Username: security.RootUser,
 		Description: fmt.Sprintf(
 			`BACKUP TABLE bank TO '%s' INCREMENTAL FROM '%s'`,
@@ -486,7 +486,7 @@ func TestBackupRestoreSystemJobs(t *testing.T) {
 	}
 
 	sqlDB.Exec(t, `RESTORE TABLE bank FROM $1, $2 WITH OPTIONS ('into_db'='restoredb')`, fullDir, incDir)
-	if err := jobutils.VerifySystemJob(t, sqlDB, baseNumJobs+2, jobspb.TypeRestore, jobs.Record{
+	if err := jobutils.VerifySystemJob(t, sqlDB, baseNumJobs+2, jobspb.TypeRestore, jobs.StatusSucceeded, jobs.Record{
 		Username: security.RootUser,
 		Description: fmt.Sprintf(
 			`RESTORE TABLE bank FROM '%s', '%s' WITH into_db = 'restoredb'`,

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1098,7 +1098,7 @@ func TestImportCSVStmt(t *testing.T) {
 			}
 			jobPrefix += `t (a INT PRIMARY KEY, b STRING, INDEX (b), INDEX (a, b)) CSV DATA (%s)`
 
-			if err := jobutils.VerifySystemJob(t, sqlDB, baseNumJobs+testNum, jobspb.TypeImport, jobs.Record{
+			if err := jobutils.VerifySystemJob(t, sqlDB, baseNumJobs+testNum, jobspb.TypeImport, jobs.StatusSucceeded, jobs.Record{
 				Username:    security.RootUser,
 				Description: fmt.Sprintf(jobPrefix+tc.jobOpts, strings.Join(tc.files, ", ")),
 			}); err != nil {

--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -131,7 +131,12 @@ func GetSystemJobsCount(t testing.TB, db *sqlutils.SQLRunner) int {
 
 // VerifySystemJob checks that that job records are created as expected.
 func VerifySystemJob(
-	t testing.TB, db *sqlutils.SQLRunner, offset int, expectedType jobspb.Type, expected jobs.Record,
+	t testing.TB,
+	db *sqlutils.SQLRunner,
+	offset int,
+	expectedType jobspb.Type,
+	expectedStatus jobs.Status,
+	expected jobs.Record,
 ) error {
 	var actual jobs.Record
 	var rawDescriptorIDs pq.Int64Array
@@ -160,7 +165,7 @@ func VerifySystemJob(
 			offset, strings.Join(pretty.Diff(e, a), "\n"))
 	}
 
-	if e, a := jobs.StatusSucceeded, jobs.Status(statusString); e != a {
+	if e, a := expectedStatus, jobs.Status(statusString); e != a {
 		return errors.Errorf("job %d: expected status %v, got %v", offset, e, a)
 	}
 	if e, a := expectedType.String(), actualType; e != a {


### PR DESCRIPTION
This change fixes a number of problems related to the rollback
of a schema change.
1. During a rollback the reversal of a mutation would
reverse an incomplete list of mutations dependent on the reversed
mutation. It didn't pick all the mutations representing
the mutation-id being reversed, and didn't do a graph traversal
beyond a depth of 1 while picking out the mutations needing reversal.
2. The jobs associated with the schema changes reversed through the
graph traversal would be left in the pending state rather than
marked failed.
2. A job associated with a schema change would be marked failed
outside of the transaction rolling back the schema change. the
system could land up in a situation where the job was marked failed
but the schema change had not been rolled back. Or a rolled-back
schema change could be marked failed even though it could not
be marked failed.
3. The rollback job associated with the reversed schema change
was created outside of the schema change reversal transaction.
This could result in a situation where a rollback job was
created for a rollback job. A reversal of a reversal
of a schema change is not permitted and the double reversal would
fail, but the new ROLL BACK of a ROLL BACK job would still exist
because it was created outside the transaction.

fixes #27760
related to #27273
related to #27402