### PR TITLE
acceptance: skip TestGossipRestartFirNodeNeedsIncoming

### DIFF
--- a/pkg/acceptance/gossip_peerings_test.go
+++ b/pkg/acceptance/gossip_peerings_test.go
@@ -206,6 +206,7 @@ func testClusterConnectedAndFunctional(ctx context.Context, t *testing.T, c clus
 //
 // See https://github.com/cockroachdb/cockroach/issues/18027.
 func TestGossipRestartFirstNodeNeedsIncoming(t *testing.T) {
+	t.Skip("#28004")
 	s := log.Scope(t)
 	defer s.Close(t)
 


### PR DESCRIPTION
This test became flaky recently. Trying to bisect the origin of the
flakiness, but worthwhile to skip for now.

See #28004

Release note: None