### PR TITLE
storage: deflake TestGossipRestartFirstNodeNeedsIncoming

### DIFF
--- a/pkg/acceptance/gossip_peerings_test.go
+++ b/pkg/acceptance/gossip_peerings_test.go
@@ -206,7 +206,6 @@ func testClusterConnectedAndFunctional(ctx context.Context, t *testing.T, c clus
 //
 // See https://github.com/cockroachdb/cockroach/issues/18027.
 func TestGossipRestartFirstNodeNeedsIncoming(t *testing.T) {
-	t.Skip("#28004")
 	s := log.Scope(t)
 	defer s.Close(t)
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1700,12 +1700,11 @@ func (s *Store) asyncGossipStore(ctx context.Context, reason string, useCached b
 
 // GossipStore broadcasts the store on the gossip network.
 func (s *Store) GossipStore(ctx context.Context, useCached bool) error {
-	// This should always return immediately and acts as a sanity check that we
-	// don't try to gossip before we're connected.
 	select {
 	case <-s.cfg.Gossip.Connected:
 	default:
-		log.Fatalf(ctx, "not connected to gossip")
+		// Nothing to do if gossip is not connected.
+		return nil
 	}
 
 	// Temporarily indicate that we're gossiping the store capacity to avoid


### PR DESCRIPTION
The compactor is started before gossip is connected, so be careful about
trying to gossip the store after a compactor cycle.

Fixes #28004

Release note: None