### PR TITLE
sql: fix the rewrite for logic tests

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1881,7 +1881,7 @@ func (t *logicTest) execQuery(query logicQuery) error {
 				}
 			} else {
 				// Emit the actual results.
-				for _, line := range t.formatValues(actualResults, query.valsPerLine) {
+				for _, line := range t.formatValues(actualResultsRaw, query.valsPerLine) {
 					t.emit(line)
 				}
 			}


### PR DESCRIPTION
Reverts #27970.
Fixes #28025.

The change was incorrect with regards to queries where the amount of
whitespace per column is sensitive, for example the output of EXPLAIN.

Release note: None