### PR TITLE
distsql: fix NULL handling in left lookup joins

### DIFF
--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -228,6 +228,21 @@ func TestJoinReader(t *testing.T) {
 			outputTypes: oneIntCol,
 			expected:    "[]",
 		},
+		{
+			description: "Test left outer lookup join on secondary index with NULL lookup value",
+			indexIdx:    1,
+			post: PostProcessSpec{
+				Projection:    true,
+				OutputColumns: []uint32{0, 2},
+			},
+			input: [][]tree.Datum{
+				{tree.NewDInt(0), tree.DNull},
+			},
+			lookupCols:  []uint32{0, 1},
+			joinType:    sqlbase.LeftOuterJoin,
+			outputTypes: twoIntCols,
+			expected:    "[[0 NULL]]",
+		},
 	}
 	for _, td := range []*sqlbase.TableDescriptor{tdSecondary, tdFamily} {
 		for _, c := range testCases {

--- a/pkg/sql/logictest/testdata/logic_test/distsql_lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_lookup_join
@@ -126,6 +126,20 @@ query I
 SELECT h FROM distsql_lookup_test_1 JOIN distsql_lookup_test_3@g_idx ON b = g
 ----
 
+# Test left lookup join on NULL column.
+query II rowsort
+SELECT b, h FROM distsql_lookup_test_1 LEFT JOIN distsql_lookup_test_3@g_idx ON b = g;
+----
+1     NULL
+1     NULL
+NULL  NULL
+
+# Test left lookup join where all input rows are NULL.
+query II
+SELECT b, h FROM distsql_lookup_test_1 LEFT JOIN distsql_lookup_test_3@g_idx ON b = g WHERE b IS NULL
+----
+NULL  NULL
+
 # Ensure join performs properly on input that has more than 100 rows.
 query I
 SELECT count(*) FROM data as d1 NATURAL JOIN data as d2


### PR DESCRIPTION
In left outer lookup joins, input rows with null lookup columns were
being improperly omitted from the result set. The fix was to skip these
rows when performing the index lookup rather than filtering them out
entirely.

Fixes #27032

Release note: None