### PR TITLE
cli: inform the user about the "webui" URL, not "admin" url

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -564,7 +564,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 			tw := tabwriter.NewWriter(&buf, 2, 1, 2, ' ', 0)
 			fmt.Fprintf(tw, "CockroachDB node starting at %s (took %0.1fs)\n", timeutil.Now(), timeutil.Since(tBegin).Seconds())
 			fmt.Fprintf(tw, "build:\t%s %s @ %s (%s)\n", info.Distribution, info.Tag, info.Time, info.GoVersion)
-			fmt.Fprintf(tw, "admin:\t%s\n", serverCfg.AdminURL())
+			fmt.Fprintf(tw, "webui:\t%s\n", serverCfg.AdminURL())
 			fmt.Fprintf(tw, "sql:\t%s\n", pgURL)
 			if len(serverCfg.SocketFile) != 0 {
 				fmt.Fprintf(tw, "socket:\t%s\n", serverCfg.SocketFile)


### PR DESCRIPTION
Fixes #27982.

Before:

```
build:               CCL v2.1.0-alpha.20180702-927-ga149437eec-dirty @ 2018/07/28 08:56:38 (go1.10.3)
admin:               http://kenax:8080
sql:                 postgresql://root@kenax:26257?sslmode=disable
```

After:

```
build:               CCL v2.1.0-alpha.20180702-961-gc16689112e-dirty @ 2018/07/30 15:53:55 (go1.10.3)
webui:               http://kenax:8080
sql:                 postgresql://root@kenax:26257?sslmode=disable
```

Release note (cli change): `cockroach start` now reports the URL of
the web UI with the prefix "`webui:`", not `admin:` as previously.