### PR TITLE
sql: mark DTime as having an ambiguous format

### DIFF
--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1609,7 +1609,7 @@ func (d *DTime) Min(_ *EvalContext) (Datum, bool) {
 }
 
 // AmbiguousFormat implements the Datum interface.
-func (*DTime) AmbiguousFormat() bool { return false }
+func (*DTime) AmbiguousFormat() bool { return true }
 
 // Format implements the NodeFormatter interface.
 func (d *DTime) Format(ctx *FmtCtx) {
@@ -1713,7 +1713,7 @@ func (d *DTimeTZ) Min(_ *EvalContext) (Datum, bool) {
 }
 
 // AmbiguousFormat implements the Datum interface.
-func (*DTimeTZ) AmbiguousFormat() bool { return false }
+func (*DTimeTZ) AmbiguousFormat() bool { return true }
 
 // Format implements the NodeFormatter interface.
 func (d *DTimeTZ) Format(ctx *FmtCtx) {

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -226,6 +226,8 @@ func TestFormatExpr(t *testing.T) {
 			`('Infinity':::DECIMAL + '-Infinity':::DECIMAL) + 'NaN':::DECIMAL`},
 		{`'+Inf':::FLOAT + '-Inf':::FLOAT + 'NaN':::FLOAT`, tree.FmtParsable,
 			`('+Inf':::FLOAT + '-Inf':::FLOAT) + 'NaN':::FLOAT`},
+		{`'12:00:00':::TIME`, tree.FmtParsable,
+			`'12:00:00':::TIME`},
 
 		{`(123:::INT, 123:::DECIMAL)`, tree.FmtCheckEquivalence,
 			`(123:::INT, 123:::DECIMAL)`},


### PR DESCRIPTION
Previously, DTime wasn't correctly marked as an AmbiguousFormat type.
This caused misformatting of time types in DistSQL.

Release note (bug fix): fix formatting of time datatypes in some
circumstances.