### PR TITLE
sql: crdb_internal.cluster_id() works in distsql

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -479,6 +479,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		RPCContext:     s.rpcContext,
 		Stopper:        s.stopper,
 		NodeID:         &s.nodeIDContainer,
+		ClusterID:      &s.rpcContext.ClusterID,
 
 		TempStorage: tempEngine,
 		DiskMonitor: s.cfg.TempStorageConfig.Mon,

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -43,7 +43,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 // DistSQLVersion identifies DistSQL engine versions.
@@ -146,7 +145,7 @@ type ServerConfig struct {
 
 	// NodeID is the id of the node on which this Server is running.
 	NodeID    *base.NodeIDContainer
-	ClusterID uuid.UUID
+	ClusterID *base.ClusterIDContainer
 
 	// JobRegistry manages jobs being used by this Server.
 	JobRegistry *jobs.Registry
@@ -367,7 +366,7 @@ func (ds *ServerImpl) setupFlow(
 	evalCtx := tree.EvalContext{
 		Settings:     ds.ServerConfig.Settings,
 		SessionData:  sd,
-		ClusterID:    ds.ServerConfig.ClusterID,
+		ClusterID:    ds.ServerConfig.ClusterID.Get(),
 		NodeID:       nodeID,
 		ReCache:      ds.regexpCache,
 		Mon:          &monitor,

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -289,6 +289,15 @@ FROM crdb_internal.kv_store_status WHERE node_id = 1
 node_id  store_id  attrs  used
 1        1         []     0
 
+statement ok
+CREATE TABLE foo (a INT PRIMARY KEY); INSERT INTO foo VALUES(1)
+
+# Make sure that the cluster id isn't unset.
+query B
+select crdb_internal.cluster_id() != '00000000-0000-0000-0000-000000000000' FROM foo
+----
+true
+
 # Check that privileged builtins are only allowed for 'root'
 user testuser
 


### PR DESCRIPTION
Previously, the cluster id was not properly propagated to distsql,
preventing use of crdb_internal.cluster_id().

Release note (bug fix): properly permit use of
crdb_internal.cluster_id() in distsql queries.