### PR TITLE
distsql: avoid generating ids for and registering local flows

### DIFF
--- a/pkg/sql/distsqlrun/flow_registry.go
+++ b/pkg/sql/distsqlrun/flow_registry.go
@@ -174,13 +174,6 @@ func (fr *flowRegistry) RegisterFlow(
 ) (retErr error) {
 	fr.Lock()
 	defer fr.Unlock()
-	if fr.draining {
-		return errors.Errorf(
-			"could not register flowID %d on node %d because the registry is draining",
-			id,
-			fr.nodeID,
-		)
-	}
 	defer func() {
 		if retErr != nil {
 			for _, stream := range inboundStreams {
@@ -188,6 +181,13 @@ func (fr *flowRegistry) RegisterFlow(
 			}
 		}
 	}()
+	if fr.draining {
+		return errors.Errorf(
+			"could not register flowID %d on node %d because the registry is draining",
+			id,
+			fr.nodeID,
+		)
+	}
 	entry := fr.getEntryLocked(id)
 	if entry.flow != nil {
 		return errors.Errorf(
@@ -304,6 +304,11 @@ func (fr *flowRegistry) waitForFlowLocked(
 // the time window have a reasonable amount of time to connect to their
 // consumers, thus unblocking them.
 // The flowRegistry rejects any new flows once it has finished draining.
+//
+// Note that since local flows are not added to the registry, they are not
+// waited for. However, this is fine since there should be no local flows
+// running when the flowRegistry drains as the draining logic starts with
+// draining all client connections to a node.
 func (fr *flowRegistry) Drain(flowDrainWait time.Duration, minFlowDrainWait time.Duration) {
 	allFlowsDone := make(chan struct{}, 1)
 	start := timeutil.Now()

--- a/pkg/sql/distsqlrun/flow_registry_test.go
+++ b/pkg/sql/distsqlrun/flow_registry_test.go
@@ -532,13 +532,26 @@ func TestSyncFlowAfterDrain(t *testing.T) {
 	// We create some flow; it doesn't matter what.
 	req := SetupFlowRequest{Version: Version}
 	req.Flow = FlowSpec{
-		Processors: []ProcessorSpec{{
-			Core: ProcessorCoreUnion{Values: &ValuesCoreSpec{}},
-			Output: []OutputRouterSpec{{
-				Type:    OutputRouterSpec_PASS_THROUGH,
-				Streams: []StreamEndpointSpec{{Type: StreamEndpointSpec_SYNC_RESPONSE}},
-			}},
-		}},
+		Processors: []ProcessorSpec{
+			{
+				Core: ProcessorCoreUnion{Values: &ValuesCoreSpec{}},
+				Output: []OutputRouterSpec{{
+					Type:    OutputRouterSpec_PASS_THROUGH,
+					Streams: []StreamEndpointSpec{{StreamID: 1, Type: StreamEndpointSpec_REMOTE}},
+				}},
+			},
+			{
+				Input: []InputSyncSpec{{
+					Type:    InputSyncSpec_UNORDERED,
+					Streams: []StreamEndpointSpec{{StreamID: 1, Type: StreamEndpointSpec_REMOTE}},
+				}},
+				Core: ProcessorCoreUnion{Noop: &NoopCoreSpec{}},
+				Output: []OutputRouterSpec{{
+					Type:    OutputRouterSpec_PASS_THROUGH,
+					Streams: []StreamEndpointSpec{{Type: StreamEndpointSpec_SYNC_RESPONSE}},
+				}},
+			},
+		},
 	}
 
 	types := make([]sqlbase.ColumnType, 0)


### PR DESCRIPTION
Results on a kv --read-percent=100 workload indicate a ~7.5% throughput
improvement.

Before:
```
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
   60.0s        0         860707        14345.6      1.1      0.9
   2.6      4.5     50.3
```

After:
```
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
   60.0s        0         924902        15415.3      1.0      0.9
   2.4      3.8     28.3
```

Release note: None