### PR TITLE
sql: clarify ordered columns for distinctNode

### DIFF
--- a/pkg/sql/distinct.go
+++ b/pkg/sql/distinct.go
@@ -28,9 +28,6 @@ import (
 // distinctNode de-duplicates rows returned by a wrapped planNode.
 type distinctNode struct {
 	plan planNode
-	// All the columns that are part of the Sort. Set to nil if no-sort, or
-	// sort used an expression that was not part of the requested column set.
-	columnsInOrder []bool
 
 	// distinctOnColIdxs are the column indices of the child planNode and
 	// is what defines the distinct key.
@@ -40,6 +37,10 @@ type distinctNode struct {
 	// planNode's column indices indicating which columns are specified in
 	// the DISTINCT ON (<exprs>) clause.
 	distinctOnColIdxs util.FastIntSet
+
+	// Subset of distinctOnColIdxs on which the input guarantees an ordering.
+	// All rows that are equal on these columns appear contiguously in the input.
+	columnsInOrder util.FastIntSet
 
 	run *rowSourceToPlanNode
 }

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2360,8 +2360,9 @@ func (dsp *DistSQLPlanner) createPlanForZero(
 
 func createDistinctSpec(n *distinctNode, cols []int) *distsqlrun.DistinctSpec {
 	var orderedColumns []uint32
-	for i, o := range n.columnsInOrder {
-		if o {
+	if !n.columnsInOrder.Empty() {
+		orderedColumns = make([]uint32, 0, n.columnsInOrder.Len())
+		for i, ok := n.columnsInOrder.Next(0); ok; i, ok = n.columnsInOrder.Next(i + 1) {
 			orderedColumns = append(orderedColumns, uint32(cols[i]))
 		}
 	}

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -88,6 +88,9 @@ func NewDistinct(
 		}
 		distinctCols.Add(int(col))
 	}
+	if !orderedCols.SubsetOf(distinctCols) {
+		return nil, errors.New("ordered cols must be a subset of distinct cols")
+	}
 
 	ctx := flowCtx.EvalCtx.Ctx()
 	memMonitor := newMonitor(ctx, flowCtx.EvalCtx.Mon, "distinct-mem")

--- a/pkg/sql/distsqlrun/processors.pb.go
+++ b/pkg/sql/distsqlrun/processors.pb.go
@@ -518,7 +518,8 @@ type DistinctSpec struct {
 	// The ordered columns in the input stream can be optionally specified for
 	// possible optimizations. The specific ordering (ascending/descending) of
 	// the column itself is not important nor is the order in which the columns
-	// are specified.
+	// are specified. The ordered columns must be a subset of the distinct
+	// columns.
 	OrderedColumns []uint32 `protobuf:"varint,1,rep,name=ordered_columns,json=orderedColumns" json:"ordered_columns,omitempty"`
 	// The distinct columns in the input stream are those columns on which we
 	// check for distinct rows. If A,B,C are in distinct_columns and there is a

--- a/pkg/sql/distsqlrun/processors.proto
+++ b/pkg/sql/distsqlrun/processors.proto
@@ -282,7 +282,8 @@ message DistinctSpec {
   // The ordered columns in the input stream can be optionally specified for
   // possible optimizations. The specific ordering (ascending/descending) of
   // the column itself is not important nor is the order in which the columns
-  // are specified.
+  // are specified. The ordered columns must be a subset of the distinct
+  // columns.
   repeated uint32 ordered_columns = 1;
   // The distinct columns in the input stream are those columns on which we
   // check for distinct rows. If A,B,C are in distinct_columns and there is a

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -460,16 +460,16 @@ func expandDistinctNode(
 		// column values again. We can thus clear out our bookkeeping.
 		// This needs to be planColumns(n.plan) and not planColumns(n) since
 		// distinctNode is "distinctifying" on the child plan's output rows.
-		d.columnsInOrder = make([]bool, len(planColumns(d.plan)))
-		for i := range d.columnsInOrder {
+		d.columnsInOrder = util.FastIntSet{}
+		for i, numCols := 0, len(planColumns(d.plan)); i < numCols; i++ {
 			group := distinctOnPp.eqGroups.Find(i)
 			if distinctOnPp.constantCols.Contains(group) {
-				d.columnsInOrder[i] = true
+				d.columnsInOrder.Add(i)
 				continue
 			}
 			for _, g := range distinctOnPp.ordering {
 				if g.ColIdx == group {
-					d.columnsInOrder[i] = true
+					d.columnsInOrder.Add(i)
 					break
 				}
 			}

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -239,16 +239,14 @@ func (v *planVisitor) visit(plan planNode) {
 			v.observer.attr(name, "distinct on", buf.String())
 		}
 
-		if n.columnsInOrder != nil {
+		if !n.columnsInOrder.Empty() {
 			var buf bytes.Buffer
 			prefix := ""
 			columns := planColumns(n.plan)
-			for i, key := range n.columnsInOrder {
-				if key {
-					buf.WriteString(prefix)
-					buf.WriteString(columns[i].Name)
-					prefix = ", "
-				}
+			for i, ok := n.columnsInOrder.Next(0); ok; i, ok = n.columnsInOrder.Next(i + 1) {
+				buf.WriteString(prefix)
+				buf.WriteString(columns[i].Name)
+				prefix = ", "
 			}
 			v.observer.attr(name, "order key", buf.String())
 		}


### PR DESCRIPTION
The distinctNode keeps track of the ordered columns that can be
utilized by the distinct processor. It is not clear from the code that
only the distinct columns can be marked as ordered; otherwise we would
end up with incorrect results.

This change clarifies that `DistinctSpec.OrderedColumns` must be a
subset of `DistinctColumns` and makes it an error if this is not the
case. The corresponding field in `distinctNode` is converted to a
`FastIntSet` and the semantics are clarified.

Release note: None