### PR TITLE
storage: consider quiescing when owning expired lease

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4411,9 +4411,6 @@ func (r *Replica) maybeTransferRaftLeader(
 	ctx context.Context, status *raft.Status, now hlc.Timestamp,
 ) {
 	l := *r.mu.state.Lease
-	if !r.isLeaseValidRLocked(l, now) {
-		return
-	}
 	if r.store.TestingKnobs().DisableLeaderFollowsLeaseholder {
 		return
 	}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -9515,7 +9515,7 @@ func (q *testQuiescer) hasRaftReadyRLocked() bool {
 	return q.raftReady
 }
 
-func (q *testQuiescer) ownsValidLeaseRLocked(ts hlc.Timestamp) bool {
+func (q *testQuiescer) ownsMostRecentLeaseRLocked() bool {
 	return q.ownsValidLease
 }
 


### PR DESCRIPTION
Consider a dormant range whose lease expired peacefully before the Raft
group had a chance to quiesce. Prior to this commit, no replica would ever
quiesce this range, as this required both Raft and an active Range
leadership at one location. However, there isn't a mechanism to "poke"
inactive Range leadership (i.e. trigger a lease renewal), and so a Range in
that state would just "sit around" forever, consuming CPU on ticks. It is
suspected that this explains severe instability on one of our production
clusters, where a large table was dropped, and its replicas seemingly never
quiesce, hogging resources.

Release note (bug fix): Fixed a situation (common after dropping a table) in
which empty ranges continued to remain active (thus consuming more CPU than
necessary).