### PR TITLE
pgwire: bump maxBytes out in TestSQLNetworkMetrics

### DIFF
--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -1602,7 +1602,7 @@ func TestSQLNetworkMetrics(t *testing.T) {
 	defer cleanupFn()
 
 	const minbytes = 20
-	const maxbytes = 770
+	const maxbytes = 2 * 1024
 
 	// Make sure we're starting at 0.
 	if _, _, err := checkSQLNetworkMetrics(s, 0, 0, 0, 0); err != nil {


### PR DESCRIPTION
A recent change (2b45482349e0dc990a83e88173503c663430e615) introduced an
`IntervalStyle` server status parameter that increased the number of
bytes sent out on a pgwire connection but did not go over the limit.
However, if any changes were made, the build version string would result
in exceeding this limit due to some extra info for dirty builds resulting
in a test failure. The maximum threshold that TestSQLNetworkMetrics uses
does not need to be exact, we just need to make sure we do not blow up
the connection. Therefore, the limit has been increased to 2KiB.

The statusReportParams map has been changed to a slice for deterministic
ordering properties since it was not actually used as a map.

Release note: None