### PR TITLE
server: skip flaky TestStatusAPIStatements for now

### DIFF
--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -885,6 +885,8 @@ func TestRemoteDebugModeSetting(t *testing.T) {
 func TestStatusAPIStatements(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	t.Skip("https://github.com/cockroachdb/cockroach/issues/27272")
+
 	testCluster := serverutils.StartTestCluster(t, 3, base.TestClusterArgs{})
 	defer testCluster.Stopper().Stop(context.Background())
 


### PR DESCRIPTION
While I work to identify the root cause, this will stop the
flaky test from breaking the build.

The issue is tracked on #27272.

Release note: None