### PR TITLE
sql: do not use `rowsort` for queries that use ORDER BY

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/decimal
+++ b/pkg/sql/logictest/testdata/logic_test/decimal
@@ -183,65 +183,112 @@ SELECT * FROM s WHERE d = 'NaN'
 NaN
 NaN
 
+# Check the ordering of decimal values.
+# The various zero values do not sort well currently
+# (see issue #28061) so we need to exclude them to get a stable sort.
+#
+# TODO(knz/mjibson): this WHERE clause can be removed/improved
+# once #27978 / #28061 are resolved.
+query R
+SELECT d FROM s WHERE d != 0 ORDER BY d
+----
+NaN
+NaN
+-Infinity
+-1
+1
+Infinity
+
+# We can check the relative ordering of zeros and other values by
+# doing some conversion to float and some arithmetic.
+#
+# TODO(knz/mjibson) This test can be deleted when the WHERE clause can
+# be removed from the previous test.
+query R
+SELECT floor(d::FLOAT+0.1)::DECIMAL FROM s ORDER BY d
+----
+NULL
+NaN
+NaN
+-Infinity
+-1
+0
+0
+0
+0
+0
+0
+1
+Infinity
+
+# In the following tests, the various zero values all compare equal to
+# each other so we cannot use ORDER BY to obtain a stable result so we
+# have to use `rowsort`. The test above has already controlled the
+# ordering.
+# These tests are only about testing the NaN-ness of the values, so
+# ordering is really inconsequential.
+
+# Just test the NaN-ness of the values.
 query RBBB rowsort
-SELECT d, d IS NaN, d = 'NaN', isnan(d) FROM s@{FORCE_INDEX=primary} ORDER BY 1
+SELECT d, d IS NaN, d = 'NaN', isnan(d) FROM s@{FORCE_INDEX=primary}
 ----
 NULL       NULL   NULL   NULL
 NaN        true   true   true
 NaN        true   true   true
 -Infinity  false  false  false
 -1         false  false  false
-0          false  false  false
 -0         false  false  false
 -0.0       false  false  false
 -0.00      false  false  false
 -0.000     false  false  false
 -0.0000    false  false  false
+0          false  false  false
 1          false  false  false
 Infinity   false  false  false
 
+# Just test the NaN-ness of the values in secondary index
 query RBBB rowsort
-SELECT d, d IS NaN, d = 'NaN', isnan(d) FROM s@{FORCE_INDEX=s_d_idx} ORDER BY 1
+SELECT d, d IS NaN, d = 'NaN', isnan(d) FROM s@{FORCE_INDEX=s_d_idx}
 ----
 NULL       NULL   NULL   NULL
 NaN        true   true   true
 NaN        true   true   true
 -Infinity  false  false  false
 -1         false  false  false
-0          false  false  false
 -0         false  false  false
 -0.0       false  false  false
 -0.00      false  false  false
 -0.000     false  false  false
 -0.0000    false  false  false
+0          false  false  false
 1          false  false  false
 Infinity   false  false  false
 
 query RB rowsort
-select d, d > 'NaN' from s@{FORCE_INDEX=primary} where d > 'NaN' ORDER BY d
+select d, d > 'NaN' from s@{FORCE_INDEX=primary} where d > 'NaN'
 ----
 -Infinity  true
 -1         true
-0          true
 -0         true
 -0.0       true
 -0.00      true
 -0.000     true
 -0.0000    true
+0          true
 1          true
 Infinity   true
 
 query RB rowsort
-select d, d > 'NaN' from s@{FORCE_INDEX=s_d_idx} where d > 'NaN' ORDER BY d
+select d, d > 'NaN' from s@{FORCE_INDEX=s_d_idx} where d > 'NaN'
 ----
 -Infinity  true
 -1         true
-0          true
 -0         true
 -0.0       true
 -0.00      true
 -0.000     true
 -0.0000    true
+0          true
 1          true
 Infinity   true
 

--- a/pkg/sql/logictest/testdata/logic_test/distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distinct_on
@@ -84,6 +84,7 @@ SELECT DISTINCT ON (b, c, a) a FROM abc
 1
 1
 
+# We need to rowsort this since the ORDER BY isn't on the entire SELECT columns.
 query T rowsort
 SELECT DISTINCT ON (c, a, b) b FROM abc ORDER BY b
 ----
@@ -121,14 +122,14 @@ SELECT DISTINCT ON (x, y) y FROM xyz
 5
 1
 
-query TT rowsort
+query TT
 SELECT DISTINCT ON (a, c) a, b FROM abc ORDER BY a, c, b
 ----
 1 1
 1 1
 
 # We wrap this with an ORDER BY otherwise this would be non-deterministic.
-query TTT rowsort
+query TTT
 SELECT DISTINCT ON (c, a) b, c, a FROM abc ORDER BY c, a, b DESC
 ----
 1 1 1
@@ -157,7 +158,7 @@ SELECT DISTINCT ON (b) b FROM abc
 2
 
 # We wrap this with an ORDER BY otherwise this would be non-deterministic.
-query TTT rowsort
+query TTT
 SELECT DISTINCT ON (a) a, b, c FROM abc ORDER BY a, b, c
 ----
 1 1 1

--- a/pkg/sql/logictest/testdata/logic_test/float
+++ b/pkg/sql/logictest/testdata/logic_test/float
@@ -40,7 +40,7 @@ NaN   true   true   true
 1     false  false  false
 +Inf  false  false  false
 
-query RB rowsort
+query RB
 select f, f > 'NaN' from p@{FORCE_INDEX=primary} where f > 'NaN' ORDER BY f
 ----
 -Inf  true
@@ -49,7 +49,7 @@ select f, f > 'NaN' from p@{FORCE_INDEX=primary} where f > 'NaN' ORDER BY f
 1     true
 +Inf  true
 
-query RB rowsort
+query RB
 select f, f > 'NaN' from p@{FORCE_INDEX=p_f_key} where f > 'NaN' ORDER BY f
 ----
 -Inf  true
@@ -134,4 +134,3 @@ DROP TABLE vals
 
 statement ok
 RESET extra_float_digits
-

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -206,7 +206,7 @@ Ronald Rivest
 Clifford Stein
 
 # Ensure lookup join preserves ordering from the left side.
-query T rowsort
+query T
 SELECT a.name FROM authors AS a JOIN books2 AS b2 ON a.book = b2.title ORDER BY a.name
 ----
 Charles E Leiserson

--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -27,7 +27,7 @@ query II rowsort
 3  30
 
 # Select
-query II rowsort
+query II
 SELECT * FROM test.t ORDER BY 1-t.k
 ----
 3  30

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -299,7 +299,7 @@ CREATE TABLE ef (e INT, f INT, INDEX(f))
 statement ok
 INSERT INTO ef VALUES (NULL, 1), (1, 1)
 
-query I rowsort
+query I
 SELECT e FROM ef WHERE f > 0 AND f < 2 ORDER BY f
 ----
 NULL


### PR DESCRIPTION
If a query uses ORDER BY, the test's expected output should be
stable, and the test should exercise that it is indeed stable and the
one expected given the ORDER BY constraint.

By improperly adding `rowsort` to a test that otherwises uses ORDER
BY, the value of the test is reduced as the quality of ORDER BY is not
tested any more.

This patch corrects this by removing `rowsort` from tests that also
use ORDER BY.

(There are a few tests that control the behavior of `rowsort` itself,
and these are left unchanged here.)

Release note: None