### PR TITLE
teamcity-publish-artifacts: use updated name for cockroach release binaries

### DIFF
--- a/build/teamcity-publish-artifacts.sh
+++ b/build/teamcity-publish-artifacts.sh
@@ -20,13 +20,13 @@ if [ "$TEAMCITY_BUILDCONF_NAME" == 'Publish Releases' ]; then
     image=docker.io/cockroachdb/cockroach
   fi
 
-  cp cockroach-linux-2.6.32-gnu-amd64 build/deploy/cockroach
+  cp cockroach.linux-2.6.32-gnu-amd64 build/deploy/cockroach
   docker build --no-cache --tag=$image:{latest,"$TC_BUILD_BRANCH"} build/deploy
 
   TYPE=$(go env GOOS)
 
   # For the acceptance tests that run without Docker.
-  ln -s cockroach-linux-2.6.32-gnu-amd64 cockroach
+  ln -s cockroach.linux-2.6.32-gnu-amd64 cockroach
   build/builder.sh mkrelease $TYPE testbuild TAGS=acceptance PKG=./pkg/acceptance
   (cd pkg/acceptance && ./acceptance.test -l ./artifacts -i $image -b /cockroach/cockroach -nodes 4 -test.v -test.timeout -5m) &> ./artifacts/publish-acceptance.log
 


### PR DESCRIPTION
This was necessary to get the release builds for v2.1-alpha.20180730 to generate properly.

Release note: None