### PR TITLE
sql: Skip TestScatterRandomizeLeases when running stressrace

### DIFF
--- a/pkg/sql/scatter_test.go
+++ b/pkg/sql/scatter_test.go
@@ -24,13 +24,19 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func TestScatterRandomizeLeases(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	if testutils.NightlyStress() && util.RaceEnabled {
+		t.Skip("uses too many resources for stressrace")
+	}
 
 	const numHosts = 3
 	tc := serverutils.StartTestCluster(t, numHosts, base.TestClusterArgs{})


### PR DESCRIPTION
The test appears to use too many resources when run under race for
multiple invocations of it to be ok. On a gceworker with 32GB of memory,
running `make stress` without race is fine, and running `make stress
GOFLAGS=-race 'STRESSFLAGS=-p 1'` is fine, but running `make stress
GOFLAGS=-race` without the parallel runs limit of 1 causes the OOM
killer to kill the tests within a couple minutes.

Fixes #27686 

Release note: None

----------------

cc @dt as current teamcity rotation engineer. More details in my last few comments on the issue, starting from https://github.com/cockroachdb/cockroach/issues/27686#issuecomment-408994475. The teamcity logs combined with the OOMs on the 32GB gceworker make me suspicious of swap being enabled on the teamcity VMs, but I thought we had fixed that in the past.