### PR TITLE
client: rename txn.OnFinish

### DIFF
--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -732,9 +732,14 @@ func (txn *Txn) AddCommitTrigger(trigger func(ctx context.Context)) {
 	txn.commitTriggers = append(txn.commitTriggers, trigger)
 }
 
-// OnFinish adds a closure to be executed when the transaction sender
-// moves from state "ready" to "done" or "aborted".
-func (txn *Txn) OnFinish(onFinishFn func(error)) {
+// OnCurrentIncarnationFinish adds a closure to be executed when the transaction
+// sender moves from state "ready" to "done" or "aborted".
+// Note that, as the name suggests, this callback is not persistent across
+// different underlying KV transactions. In other words, once a
+// TransactionAbortedError happens, the callback is called, but then it won't be
+// called again after the client restarts. This is not intended to be used by
+// layers above the retries.
+func (txn *Txn) OnCurrentIncarnationFinish(onFinishFn func(error)) {
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
 	txn.mu.sender.OnFinish(onFinishFn)

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -376,7 +376,7 @@ func makeDistSQLReceiver(
 	// monitoring to connExecutor and have it cancel the SQL txn's context? Or for
 	// that matter, should the TxnCoordSender cancel the context itself?
 	if r.txn != nil {
-		r.txn.OnFinish(func(err error) {
+		r.txn.OnCurrentIncarnationFinish(func(err error) {
 			r.txnAbortedErr.Store(errWrap{err: err})
 		})
 	}
@@ -493,7 +493,7 @@ func (r *distSQLReceiver) Push(
 // ProducerDone is part of the RowReceiver interface.
 func (r *distSQLReceiver) ProducerDone() {
 	if r.txn != nil {
-		r.txn.OnFinish(nil)
+		r.txn.OnCurrentIncarnationFinish(nil)
 	}
 	if r.closed {
 		panic("double close")


### PR DESCRIPTION
... to OnCurrentIncarnationFinish. Make the narrow-mindedness of the API
abundently clear.

Release note: None