### PR TITLE
opt: pass stronger ordering requirement through limit/offset

### DIFF
--- a/pkg/sql/opt/memo/private_defs.go
+++ b/pkg/sql/opt/memo/private_defs.go
@@ -131,7 +131,7 @@ func (s *ScanOpDef) CanProvideOrdering(md *opt.Metadata, required *props.Orderin
 			ordering.AppendCol(colID, indexCol.Descending)
 		}
 	}
-	return ordering.SubsetOf(required)
+	return ordering.Implies(required)
 }
 
 // GroupByDef defines the value of the Def private field of the GroupBy and
@@ -270,10 +270,10 @@ func (w *RowNumberDef) CanProvideOrdering(required *props.OrderingChoice) bool {
 	if prefix < len(required.Columns) {
 		truncated := required.Copy()
 		truncated.Truncate(prefix)
-		return w.Ordering.SubsetOf(&truncated)
+		return w.Ordering.Implies(&truncated)
 	}
 
-	return w.Ordering.SubsetOf(required)
+	return w.Ordering.Implies(required)
 }
 
 // SetOpColMap defines the value of the ColMap private field of the set
@@ -339,13 +339,13 @@ func (m *MergeOnDef) CanProvideOrdering(required *props.OrderingChoice) bool {
 	// ordering is preserved when multiple rows match on the equality columns.
 	switch m.JoinType {
 	case opt.InnerJoinOp:
-		return m.LeftOrdering.SubsetOf(required) || m.RightOrdering.SubsetOf(required)
+		return m.LeftOrdering.Implies(required) || m.RightOrdering.Implies(required)
 
 	case opt.LeftJoinOp, opt.SemiJoinOp, opt.AntiJoinOp:
-		return m.LeftOrdering.SubsetOf(required)
+		return m.LeftOrdering.Implies(required)
 
 	case opt.RightJoinOp:
-		return m.RightOrdering.SubsetOf(required)
+		return m.RightOrdering.Implies(required)
 
 	default:
 		return false

--- a/pkg/sql/opt/props/ordering_choice.go
+++ b/pkg/sql/opt/props/ordering_choice.go
@@ -209,34 +209,37 @@ func (oc *OrderingChoice) ColSet() opt.ColSet {
 	return cs
 }
 
-// SubsetOf returns true if every ordering in this set is allowed by the given
-// set. In other words, is this set of ordering choices at least as restrictive
-// as the input set? Here are some examples:
+// Implies returns true if any ordering allowed by <oc> is also allowed by <other>.
 //
-//   <empty>           matches <empty>
-//   +1                matches <empty>        (given set is prefix)
-//   +1                matches +1
-//   +1,-2             matches +1             (given set is prefix)
-//   +1,-2             matches +1,-2
-//   +1                matches +1 opt(2)      (unused optional col is ignored)
-//   -2,+1             matches +1 opt(2)      (optional col is ignored)
-//   +1                matches +(1|2)         (subset of choice)
-//   +(1|2)            matches +(1|2|3)       (subset of choice)
-//   +(1|2),-4         matches +(1|2|3),-(4|5)
-//   +(1|2) opt(4)     matches +(1|2|3) opt(4)
+// In the case of no optional or equivalent columns, Implies returns true when
+// the given ordering is a prefix of this ordering.
 //
-//   <empty>           !matches +1
-//   +1                !matches -1            (direction mismatch)
-//   +1                !matches +1,-2         (prefix matching not commutative)
-//   +1 opt(2)         !matches +1            (extra optional cols not allowed)
-//   +1 opt(2)         !matches +1 opt(3)
-//   +(1|2)            !matches -(1|2)        (direction mismatch)
-//   +(1|2)            !matches +(3|4)        (no intersection)
-//   +(1|2)            !matches +(2|3)        (intersects, but not subset)
-//   +(1|2|3)          !matches +(1|2)        (subset of choice not commutative)
-//   +(1|2)            !matches +1 opt(2)
+// Examples:
 //
-func (oc *OrderingChoice) SubsetOf(other *OrderingChoice) bool {
+//   <empty>           implies <empty>
+//   +1                implies <empty>        (given set is prefix)
+//   +1                implies +1
+//   +1,-2             implies +1             (given set is prefix)
+//   +1,-2             implies +1,-2
+//   +1                implies +1 opt(2)      (unused optional col is ignored)
+//   -2,+1             implies +1 opt(2)      (optional col is ignored)
+//   +1                implies +(1|2)         (subset of choice)
+//   +(1|2)            implies +(1|2|3)       (subset of choice)
+//   +(1|2),-4         implies +(1|2|3),-(4|5)
+//   +(1|2) opt(4)     implies +(1|2|3) opt(4)
+//
+//   <empty>           !implies +1
+//   +1                !implies -1            (direction mismatch)
+//   +1                !implies +1,-2         (prefix matching not commutative)
+//   +1 opt(2)         !implies +1            (extra optional cols not allowed)
+//   +1 opt(2)         !implies +1 opt(3)
+//   +(1|2)            !implies -(1|2)        (direction mismatch)
+//   +(1|2)            !implies +(3|4)        (no intersection)
+//   +(1|2)            !implies +(2|3)        (intersects, but not subset)
+//   +(1|2|3)          !implies +(1|2)        (subset of choice not commutative)
+//   +(1|2)            !implies +1 opt(2)
+//
+func (oc *OrderingChoice) Implies(other *OrderingChoice) bool {
 	if !oc.Optional.SubsetOf(other.Optional) {
 		return false
 	}

--- a/pkg/sql/opt/props/ordering_choice_test.go
+++ b/pkg/sql/opt/props/ordering_choice_test.go
@@ -68,7 +68,7 @@ func TestOrderingChoice_ColSet(t *testing.T) {
 	}
 }
 
-func TestOrderingChoice_SubsetOf(t *testing.T) {
+func TestOrderingChoice_Implies(t *testing.T) {
 	testcases := []struct {
 		left     string
 		right    string
@@ -102,7 +102,7 @@ func TestOrderingChoice_SubsetOf(t *testing.T) {
 	for _, tc := range testcases {
 		left := props.ParseOrderingChoice(tc.left)
 		right := props.ParseOrderingChoice(tc.right)
-		if left.SubsetOf(&right) != tc.expected {
+		if left.Implies(&right) != tc.expected {
 			if tc.expected {
 				t.Errorf("expected %s to be subset of %s", tc.left, tc.right)
 			} else {

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -777,30 +777,26 @@ scan abc
 opt
 SELECT * FROM (SELECT * FROM abc WHERE a+b>c ORDER BY a, b LIMIT 10) ORDER BY a, b, c
 ----
-sort
+limit
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── ordering: +1,+2,+3
- └── limit
-      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
-      ├── select
-      │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
-      │    ├── ordering: +1,+2
-      │    ├── scan abc
-      │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
-      │    │    └── ordering: +1,+2
-      │    └── filters [type=bool]
-      │         └── abc.c < (abc.a + abc.b) [type=bool]
-      └── const: 10 [type=int]
+ ├── select
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── ordering: +1,+2,+3
+ │    ├── scan abc
+ │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    │    └── ordering: +1,+2,+3
+ │    └── filters [type=bool]
+ │         └── abc.c < (abc.a + abc.b) [type=bool]
+ └── const: 10 [type=int]
 
 opt
 SELECT * FROM (SELECT * FROM abc ORDER BY a, b OFFSET 10) ORDER BY a, b, c
 ----
-sort
+offset
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── ordering: +1,+2,+3
- └── offset
-      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
-      ├── scan abc
-      │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
-      │    └── ordering: +1,+2
-      └── const: 10 [type=int]
+ ├── scan abc
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    └── ordering: +1,+2,+3
+ └── const: 10 [type=int]

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -636,3 +636,171 @@ inner-join (merge)
       └── filters [type=bool]
            ├── abc.a = xyz.x [type=bool]
            └── abc.b = xyz.y [type=bool]
+
+# --------------------------------------------------
+# Limit / Offset
+# --------------------------------------------------
+
+# Basic cases.
+
+opt
+SELECT * FROM abc ORDER BY a, b LIMIT 10
+----
+scan abc
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── limit: 10
+ └── ordering: +1,+2
+
+# The filter prevents pushing of the limit into the scan.
+opt
+SELECT * FROM abc WHERE a+b>c ORDER BY a, b LIMIT 10
+----
+limit
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── ordering: +1,+2
+ ├── select
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── ordering: +1,+2
+ │    ├── scan abc
+ │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    │    └── ordering: +1,+2
+ │    └── filters [type=bool]
+ │         └── abc.c < (abc.a + abc.b) [type=bool]
+ └── const: 10 [type=int]
+
+opt
+SELECT * FROM abc ORDER BY a, b OFFSET 10 
+----
+offset
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── ordering: +1,+2
+ ├── scan abc
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    └── ordering: +1,+2
+ └── const: 10 [type=int]
+
+
+# Cases where the requirement on Limit/Offset is incompatible with the
+# internal requirement.
+
+opt
+SELECT * FROM (SELECT * FROM abc ORDER BY a, b LIMIT 10) ORDER BY b
+----
+sort
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── ordering: +2
+ └── scan abc
+      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      └── limit: 10
+
+opt
+SELECT * FROM (SELECT * FROM abc WHERE a+b>c ORDER BY a, b LIMIT 10) ORDER BY b
+----
+sort
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── ordering: +2
+ └── limit
+      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      ├── select
+      │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    ├── ordering: +1,+2
+      │    ├── scan abc
+      │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    │    └── ordering: +1,+2
+      │    └── filters [type=bool]
+      │         └── abc.c < (abc.a + abc.b) [type=bool]
+      └── const: 10 [type=int]
+
+opt
+SELECT * FROM (SELECT * FROM abc ORDER BY a, b OFFSET 10) ORDER BY b
+----
+sort
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── ordering: +2
+ └── offset
+      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      ├── scan abc
+      │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    └── ordering: +1,+2
+      └── const: 10 [type=int]
+
+
+# Cases where the requirement on Limit/Offset is weaker than the
+# internal requirement.
+
+opt
+SELECT * FROM (SELECT * FROM abc ORDER BY a, b LIMIT 10) ORDER BY a
+----
+scan abc
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── limit: 10
+ └── ordering: +1
+
+opt
+SELECT * FROM (SELECT * FROM abc WHERE a+b>c ORDER BY a, b LIMIT 10) ORDER BY a
+----
+limit
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── ordering: +1
+ ├── select
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── ordering: +1,+2
+ │    ├── scan abc
+ │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    │    └── ordering: +1,+2
+ │    └── filters [type=bool]
+ │         └── abc.c < (abc.a + abc.b) [type=bool]
+ └── const: 10 [type=int]
+
+opt
+SELECT * FROM (SELECT * FROM abc ORDER BY a, b OFFSET 10) ORDER BY a
+----
+offset
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── ordering: +1
+ ├── scan abc
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    └── ordering: +1,+2
+ └── const: 10 [type=int]
+
+# Cases where the requirement on Limit/Offset is stronger than the
+# internal requirement.
+
+opt
+SELECT * FROM (SELECT * FROM abc ORDER BY a, b LIMIT 10) ORDER BY a, b, c
+----
+scan abc
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── limit: 10
+ └── ordering: +1,+2,+3
+
+opt
+SELECT * FROM (SELECT * FROM abc WHERE a+b>c ORDER BY a, b LIMIT 10) ORDER BY a, b, c
+----
+sort
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── ordering: +1,+2,+3
+ └── limit
+      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      ├── select
+      │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    ├── ordering: +1,+2
+      │    ├── scan abc
+      │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    │    └── ordering: +1,+2
+      │    └── filters [type=bool]
+      │         └── abc.c < (abc.a + abc.b) [type=bool]
+      └── const: 10 [type=int]
+
+opt
+SELECT * FROM (SELECT * FROM abc ORDER BY a, b OFFSET 10) ORDER BY a, b, c
+----
+sort
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── ordering: +1,+2,+3
+ └── offset
+      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      ├── scan abc
+      │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    └── ordering: +1,+2
+      └── const: 10 [type=int]


### PR DESCRIPTION
#### opt: add ordering property tests for limit/offset

Release note: None

#### opt: pass stronger ordering requirement through limit/offset

Limit and Offset currently only provide the ordering that they require
of their input. This change improves them to pass through stronger
orderings. For example, if the internal ordering is `a+,b+` and the
requirement on limit/offset is `a+,b+,c+`, the latter can be passed
through.

Release note: None