### PR TITLE
sql: properly mark UUID as having ambiguous format

### DIFF
--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1248,7 +1248,7 @@ func (*DUuid) Max(_ *EvalContext) (Datum, bool) {
 }
 
 // AmbiguousFormat implements the Datum interface.
-func (*DUuid) AmbiguousFormat() bool { return false }
+func (*DUuid) AmbiguousFormat() bool { return true }
 
 // Format implements the NodeFormatter interface.
 func (d *DUuid) Format(ctx *FmtCtx) {

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -228,6 +228,8 @@ func TestFormatExpr(t *testing.T) {
 			`('+Inf':::FLOAT + '-Inf':::FLOAT) + 'NaN':::FLOAT`},
 		{`'12:00:00':::TIME`, tree.FmtParsable,
 			`'12:00:00':::TIME`},
+		{`'63616665-6630-3064-6465-616462656562':::UUID`, tree.FmtParsable,
+			`'63616665-6630-3064-6465-616462656562':::UUID`},
 
 		{`(123:::INT, 123:::DECIMAL)`, tree.FmtCheckEquivalence,
 			`(123:::INT, 123:::DECIMAL)`},


### PR DESCRIPTION
Since a UUID enclosed in a string is indistinguishable from an ordinary
string.

Release note: None