### PR TITLE
Revert "gossip: use RWMutex in gossip server"

### DIFF
--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -129,13 +129,13 @@ func (c *client) startLocked(
 		log.Infof(ctx, "started gossip client to %s", c.addr)
 		if err := c.gossip(ctx, g, stream, stopper, &wg); err != nil {
 			if !grpcutil.IsClosedConnection(err) {
-				g.mu.RLock()
+				g.mu.Lock()
 				if c.peerID != 0 {
 					log.Infof(ctx, "closing client to node %d (%s): %s", c.peerID, c.addr, err)
 				} else {
 					log.Infof(ctx, "closing client to %s: %s", c.addr, err)
 				}
-				g.mu.RUnlock()
+				g.mu.Unlock()
 			}
 		}
 	})
@@ -154,14 +154,14 @@ func (c *client) close() {
 // supplying a map of this node's knowledge of other nodes' high water
 // timestamps.
 func (c *client) requestGossip(g *Gossip, stream Gossip_GossipClient) error {
-	g.mu.RLock()
+	g.mu.Lock()
 	args := &Request{
 		NodeID:          g.NodeID.Get(),
 		Addr:            g.mu.is.NodeAddr,
 		HighWaterStamps: g.mu.is.getHighWaterStamps(),
 		ClusterID:       g.clusterID.Get(),
 	}
-	g.mu.RUnlock()
+	g.mu.Unlock()
 
 	bytesSent := int64(args.Size())
 	c.clientMetrics.BytesSent.Inc(bytesSent)
@@ -173,7 +173,7 @@ func (c *client) requestGossip(g *Gossip, stream Gossip_GossipClient) error {
 // sendGossip sends the latest gossip to the remote server, based on
 // the remote server's notion of other nodes' high water timestamps.
 func (c *client) sendGossip(g *Gossip, stream Gossip_GossipClient) error {
-	g.mu.RLock()
+	g.mu.Lock()
 	if delta := g.mu.is.delta(c.remoteHighWaterStamps); len(delta) > 0 {
 		args := Request{
 			NodeID:          g.NodeID.Get(),
@@ -199,10 +199,10 @@ func (c *client) sendGossip(g *Gossip, stream Gossip_GossipClient) error {
 			}
 		}
 
-		g.mu.RUnlock()
+		g.mu.Unlock()
 		return stream.Send(&args)
 	}
-	g.mu.RUnlock()
+	g.mu.Unlock()
 	return nil
 }
 

--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -313,8 +313,8 @@ func TestClientNodeID(t *testing.T) {
 }
 
 func verifyServerMaps(g *Gossip, expCount int) bool {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	return len(g.mu.nodeMap) == expCount
 }
 

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -477,42 +477,42 @@ func (g *Gossip) setResolvers(resolvers []resolver.Resolver) {
 
 // GetResolvers returns a copy of the resolvers slice.
 func (g *Gossip) GetResolvers() []resolver.Resolver {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	return append([]resolver.Resolver(nil), g.resolvers...)
 }
 
 // GetNodeIDAddress looks up the address of the node by ID.
 func (g *Gossip) GetNodeIDAddress(nodeID roachpb.NodeID) (*util.UnresolvedAddr, error) {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	return g.getNodeIDAddressLocked(nodeID)
 }
 
 // GetNodeIDForStoreID looks up the NodeID by StoreID.
 func (g *Gossip) GetNodeIDForStoreID(storeID roachpb.StoreID) (roachpb.NodeID, error) {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	return g.getNodeIDForStoreIDLocked(storeID)
 }
 
 // GetNodeDescriptor looks up the descriptor of the node by ID.
 func (g *Gossip) GetNodeDescriptor(nodeID roachpb.NodeID) (*roachpb.NodeDescriptor, error) {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	return g.getNodeDescriptorLocked(nodeID)
 }
 
 // LogStatus logs the current status of gossip such as the incoming and
 // outgoing connections.
 func (g *Gossip) LogStatus() {
-	g.mu.RLock()
+	g.mu.Lock()
 	n := len(g.nodeDescs)
 	status := "ok"
 	if g.mu.is.getInfo(KeySentinel) == nil {
 		status = "stalled"
 	}
-	g.mu.RUnlock()
+	g.mu.Unlock()
 
 	ctx := g.AnnotateCtx(context.TODO())
 	log.Infof(
@@ -524,8 +524,8 @@ func (g *Gossip) LogStatus() {
 func (g *Gossip) clientStatus() string {
 	var buf bytes.Buffer
 
-	g.mu.RLock()
-	defer g.mu.RUnlock()
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	g.clientsMu.Lock()
 	defer g.clientsMu.Unlock()
 
@@ -893,9 +893,9 @@ func (g *Gossip) AddInfoProto(key string, msg protoutil.Message, ttl time.Durati
 // GetInfo returns an info value by key or an KeyNotPresentError if specified
 // key does not exist or has expired.
 func (g *Gossip) GetInfo(key string) ([]byte, error) {
-	g.mu.RLock()
+	g.mu.Lock()
 	i := g.mu.is.getInfo(key)
-	g.mu.RUnlock()
+	g.mu.Unlock()
 
 	if i != nil {
 		if err := i.Value.Verify([]byte(key)); err != nil {
@@ -920,16 +920,16 @@ func (g *Gossip) GetInfoProto(key string, msg protoutil.Message) error {
 // originated on this node. This is useful for ensuring that the system config
 // is regossiped as soon as possible when its lease changes hands.
 func (g *Gossip) InfoOriginatedHere(key string) bool {
-	g.mu.RLock()
+	g.mu.Lock()
 	info := g.mu.is.getInfo(key)
-	g.mu.RUnlock()
+	g.mu.Unlock()
 	return info != nil && info.NodeID == g.NodeID.Get()
 }
 
 // GetInfoStatus returns the a copy of the contents of the infostore.
 func (g *Gossip) GetInfoStatus() InfoStatus {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	is := InfoStatus{
 		Infos: make(map[string]Info),
 	}
@@ -941,8 +941,8 @@ func (g *Gossip) GetInfoStatus() InfoStatus {
 
 // IterateInfos visits all infos matching the given prefix.
 func (g *Gossip) IterateInfos(prefix string, visit func(k string, info Info) error) error {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	for k, v := range g.mu.is.Infos {
 		if strings.HasPrefix(k, prefix+separator) {
 			if err := visit(k, *(protoutil.Clone(v).(*Info))); err != nil {
@@ -1038,8 +1038,8 @@ func (g *Gossip) updateSystemConfig(key string, content roachpb.Value) {
 // Incoming returns a slice of incoming gossip client connection
 // node IDs.
 func (g *Gossip) Incoming() []roachpb.NodeID {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	return g.mu.incoming.asSlice()
 }
 
@@ -1049,8 +1049,8 @@ func (g *Gossip) Incoming() []roachpb.NodeID {
 // of trying, or may already have failed, but haven't yet been
 // processed by the gossip instance.
 func (g *Gossip) Outgoing() []roachpb.NodeID {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	return g.outgoing.asSlice()
 }
 
@@ -1058,8 +1058,8 @@ func (g *Gossip) Outgoing() []roachpb.NodeID {
 // node in the system, according to the infos which have reached
 // this node via gossip network.
 func (g *Gossip) MaxHops() uint32 {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	_, maxHops := g.mu.is.mostDistant(func(_ roachpb.NodeID) bool { return false })
 	return maxHops
 }

--- a/pkg/gossip/server.go
+++ b/pkg/gossip/server.go
@@ -52,7 +52,7 @@ type server struct {
 	stopper *stop.Stopper
 
 	mu struct {
-		syncutil.RWMutex
+		syncutil.Mutex
 		is       *infoStore                         // The backing infostore
 		incoming nodeSet                            // Incoming client node IDs
 		nodeMap  map[util.UnresolvedAddr]serverInfo // Incoming client's local address -> serverInfo
@@ -379,8 +379,8 @@ func (s *server) start(addr net.Addr) {
 }
 
 func (s *server) status() string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "gossip server (%d/%d cur/max conns, %s)\n",
 		s.mu.incoming.gauge.Value(), s.mu.incoming.maxSize, s.serverMetrics)
@@ -400,7 +400,7 @@ func roundSecs(d time.Duration) time.Duration {
 
 // GetNodeAddr returns the node's address stored in the Infostore.
 func (s *server) GetNodeAddr() *util.UnresolvedAddr {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return &s.mu.is.NodeAddr
 }


### PR DESCRIPTION
This reverts commit edc4572027b7f37cc4664b8616045faf24564132.

See https://github.com/cockroachdb/cockroach/pull/28001#issuecomment-409109989 for a justification.