### PR TITLE
storage: serve reads based on closed timestamps

### DIFF
--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -110,11 +110,7 @@ func createTestNode(
 		cfg.Settings,
 		cfg.HistogramWindowInterval,
 	)
-	cfg.ClosedTimestamp = container.NewContainer(container.Config{
-		Settings: st,
-		Stopper:  stopper,
-		Clock:    cfg.NodeLiveness.AsLiveClock(),
-	})
+	cfg.ClosedTimestamp = container.NoopContainer()
 
 	storage.TimeUntilStoreDead.Override(&cfg.Settings.SV, 10*time.Millisecond)
 	cfg.StorePool = storage.NewStorePool(

--- a/pkg/storage/closed_timestamp_test.go
+++ b/pkg/storage/closed_timestamp_test.go
@@ -1,0 +1,198 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package storage_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func TestClosedTimestampCanServe(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	const numNodes = 3
+
+	tc := serverutils.StartTestCluster(t, numNodes, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	db0 := tc.ServerConn(0)
+	// Every 0.01s=10ms, try close out a timestamp ~300ms in the past.
+	// We don't want to be more aggressive than that since it's also
+	// a limit on how long transactions can run.
+	if _, err := db0.Exec(`
+SET CLUSTER SETTING kv.closed_timestamp.target_duration = '300ms';
+SET CLUSTER SETTING kv.closed_timestamp.close_fraction = 0.01/0.3;
+SET CLUSTER SETTING kv.closed_timestamp.follower_reads_enabled = true;
+CREATE DATABASE cttest;
+CREATE TABLE cttest.kv (id INT PRIMARY KEY, value STRING);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	var rangeID roachpb.RangeID
+	var startKey roachpb.Key
+	var numReplicas int
+	testutils.SucceedsSoon(t, func() error {
+		if err := db0.QueryRow(
+			`SELECT range_id, start_key, array_length(replicas, 1) FROM crdb_internal.ranges WHERE "table" = 'kv' AND "database" = 'cttest'`,
+		).Scan(&rangeID, &startKey, &numReplicas); err != nil {
+			return err
+		}
+		if numReplicas != 3 {
+			return errors.New("not fully replicated yet")
+		}
+		return nil
+	})
+
+	desc, err := tc.LookupRange(startKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First, we perform an arbitrary lease transfer because that will turn the
+	// lease into an epoch based one (the initial lease is likely expiration based
+	// since the range just split off from the very first range which is expiration
+	// based).
+	var lh roachpb.ReplicationTarget
+	testutils.SucceedsSoon(t, func() error {
+		var err error
+		lh, err = tc.FindRangeLeaseHolder(desc, nil)
+		return err
+	})
+
+	for i := 0; i < numNodes; i++ {
+		target := tc.Target(i)
+		if target != lh {
+			if err := tc.TransferRangeLease(desc, target); err != nil {
+				t.Fatal(err)
+			}
+			break
+		}
+	}
+
+	var repls []*storage.Replica
+	testutils.SucceedsSoon(t, func() error {
+		repls = nil
+		for i := 0; i < numNodes; i++ {
+			repl, err := tc.Server(i).GetStores().(*storage.Stores).GetReplicaForRangeID(desc.RangeID)
+			if err != nil {
+				return err
+			}
+			if repl != nil {
+				repls = append(repls, repl)
+			}
+		}
+		return nil
+	})
+
+	require.Equal(t, numReplicas, len(repls))
+
+	// Wait until we see an epoch based lease on our chosen range. This should
+	// happen fairly quickly since we just transferred a lease (as a means to make
+	// it epoch based). If the lease transfer fails, we'll be sitting out the lease
+	// expiration, which is on the order of seconds. Not great, but good enough since
+	// the transfer basically always works.
+	for ok := false; !ok; time.Sleep(10 * time.Millisecond) {
+		for _, repl := range repls {
+			lease, _ := repl.GetLease()
+			if lease.Epoch != 0 {
+				ok = true
+				break
+			}
+		}
+	}
+
+	if _, err := db0.Exec(`INSERT INTO cttest.kv VALUES(1, $1)`, "foo"); err != nil {
+		t.Fatal(err)
+	}
+
+	var baRead roachpb.BatchRequest
+	baRead.Header.RangeID = desc.RangeID
+	r := &roachpb.ScanRequest{}
+	r.Key = desc.StartKey.AsRawKey()
+	r.EndKey = desc.EndKey.AsRawKey()
+	baRead.Add(r)
+	baRead.Timestamp = hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+
+	// The read should succeed once enough time (~300ms, but it's difficult to
+	// assert on that) has passed - on all replicas!
+	testutils.SucceedsSoon(t, func() error {
+		for _, repl := range repls {
+			resp, pErr := repl.Send(ctx, baRead)
+			if pErr != nil {
+				switch tErr := pErr.GetDetail().(type) {
+				case *roachpb.NotLeaseHolderError:
+					return tErr
+				case *roachpb.RangeNotFoundError:
+					// Can happen during upreplication.
+					return tErr
+				default:
+					t.Fatal(errors.Wrapf(pErr.GoError(), "on %s", repl))
+				}
+			}
+			rows := resp.Responses[0].GetInner().(*roachpb.ScanResponse).Rows
+			// Should see the write.
+			if len(rows) != 1 {
+				t.Fatalf("expected one row, but got %d", len(rows))
+			}
+		}
+		return nil
+	})
+
+	// We just served a follower read. As a sanity check, make sure that we can't write at
+	// that same timestamp.
+	{
+		var baWrite roachpb.BatchRequest
+		r := &roachpb.DeleteRequest{}
+		r.Key = desc.StartKey.AsRawKey()
+		txn := roachpb.MakeTransaction("testwrite", r.Key, roachpb.NormalUserPriority, enginepb.SERIALIZABLE, baRead.Timestamp, 100)
+		baWrite.Txn = &txn
+		baWrite.Add(r)
+		baWrite.RangeID = repls[0].RangeID
+
+		var found bool
+		for _, repl := range repls {
+			resp, pErr := repl.Send(ctx, baWrite)
+			if _, ok := pErr.GoError().(*roachpb.NotLeaseHolderError); ok {
+				continue
+			} else if pErr != nil {
+				t.Fatal(pErr)
+			}
+			found = true
+			if !baRead.Timestamp.Less(resp.Txn.Timestamp) || resp.Txn.OrigTimestamp == resp.Txn.Timestamp {
+				t.Fatal("timestamp did not get bumped")
+			}
+			break
+		}
+		if !found {
+			t.Fatal("unable to send to any replica")
+		}
+	}
+}

--- a/pkg/storage/closedts/container/noop.go
+++ b/pkg/storage/closedts/container/noop.go
@@ -50,6 +50,7 @@ func NoopContainer() *Container {
 		Provider: noopEverything{},
 		Server:   noopEverything{},
 		Clients:  noopEverything{},
+		noop:     true,
 	}
 }
 

--- a/pkg/storage/closedts/setting.go
+++ b/pkg/storage/closedts/setting.go
@@ -23,7 +23,7 @@ import (
 
 // TargetDuration is the follower reads closed timestamp update target duration.
 var TargetDuration = settings.RegisterNonNegativeDurationSetting(
-	"server.closed_timestamp.target_duration",
+	"kv.closed_timestamp.target_duration",
 	"if nonzero, attempt to provide closed timestamp notifications for timestamps trailing cluster time by approximately this duration",
 	5*time.Second,
 )
@@ -31,8 +31,8 @@ var TargetDuration = settings.RegisterNonNegativeDurationSetting(
 // CloseFraction is the fraction of TargetDuration determining how often closed
 // timestamp updates are to be attempted.
 var CloseFraction = settings.RegisterValidatedFloatSetting(
-	"server.closed_timestamp.close_fraction",
-	"desc",
+	"kv.closed_timestamp.close_fraction",
+	"fraction of closed timestamp target duration specifying how frequently the closed timestamp is advanced",
 	0.2,
 	func(v float64) error {
 		if v <= 0 || v > 1 {

--- a/pkg/storage/closedts/transport/transport_test.go
+++ b/pkg/storage/closedts/transport/transport_test.go
@@ -48,6 +48,7 @@ func NewTestContainer() *TestContainer {
 	s := transport.NewServer(stopper, p, refreshed.Add)
 	dialer := transporttestutils.NewChanDialer(stopper, s)
 	c := transport.NewClients(transport.Config{
+		NodeID:   roachpb.NodeID(12345),
 		Settings: st,
 		Stopper:  stopper,
 		Dialer:   dialer,

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -345,6 +345,11 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease) {
 		}
 		// Make sure the push transaction queue is enabled.
 		r.txnWaitQueue.Enable()
+
+		// Emit an MLAI on the leaseholder replica, as follower will be looking
+		// for one and if we went on to quiesce, they wouldn't necessarily get
+		// one otherwise (unless they ask for it, which adds latency).
+		r.EmitMLAI()
 	}
 
 	// Mark the new lease in the replica's lease history.

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -468,7 +468,7 @@ func sendLeaseRequest(r *Replica, l *roachpb.Lease) error {
 	ba.Timestamp = r.store.Clock().Now()
 	ba.Add(&roachpb.RequestLeaseRequest{Lease: *l})
 	exLease, _ := r.GetLease()
-	ch, _, pErr := r.propose(context.TODO(), exLease, ba, nil, &allSpans)
+	ch, _, _, pErr := r.propose(context.TODO(), exLease, ba, nil, &allSpans)
 	if pErr == nil {
 		// Next if the command was committed, wait for the range to apply it.
 		// TODO(bdarnell): refactor this to a more conventional error-handling pattern.
@@ -1237,7 +1237,7 @@ func TestReplicaLeaseRejectUnknownRaftNodeID(t *testing.T) {
 	ba := roachpb.BatchRequest{}
 	ba.Timestamp = tc.repl.store.Clock().Now()
 	ba.Add(&roachpb.RequestLeaseRequest{Lease: *lease})
-	ch, _, pErr := tc.repl.propose(context.Background(), exLease, ba, nil, &allSpans)
+	ch, _, _, pErr := tc.repl.propose(context.Background(), exLease, ba, nil, &allSpans)
 	if pErr == nil {
 		// Next if the command was committed, wait for the range to apply it.
 		// TODO(bdarnell): refactor to a more conventional error-handling pattern.
@@ -4536,7 +4536,7 @@ func TestRaftRetryProtectionInTxn(t *testing.T) {
 		// also avoid updating the timestamp cache.
 		ba.Timestamp = txn.OrigTimestamp
 		lease, _ := tc.repl.GetLease()
-		ch, _, err := tc.repl.propose(context.Background(), lease, ba, nil, &allSpans)
+		ch, _, _, err := tc.repl.propose(context.Background(), lease, ba, nil, &allSpans)
 		if err != nil {
 			t.Fatalf("%d: unexpected error: %s", i, err)
 		}
@@ -7800,7 +7800,7 @@ func TestReplicaIDChangePending(t *testing.T) {
 		},
 		Value: roachpb.MakeValueFromBytes([]byte("val")),
 	})
-	_, _, err := repl.propose(context.Background(), lease, ba, nil, &allSpans)
+	_, _, _, err := repl.propose(context.Background(), lease, ba, nil, &allSpans)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -9351,7 +9351,7 @@ func TestErrorInRaftApplicationClearsIntents(t *testing.T) {
 	}
 
 	exLease, _ := repl.GetLease()
-	ch, _, pErr := repl.propose(
+	ch, _, _, pErr := repl.propose(
 		context.Background(), exLease, ba, nil /* endCmds */, &allSpans,
 	)
 	if pErr != nil {
@@ -9398,7 +9398,7 @@ func TestProposeWithAsyncConsensus(t *testing.T) {
 
 	atomic.StoreInt32(&filterActive, 1)
 	exLease, _ := repl.GetLease()
-	ch, _, pErr := repl.propose(
+	ch, _, _, pErr := repl.propose(
 		context.Background(), exLease, ba, nil /* endCmds */, &allSpans,
 	)
 	if pErr != nil {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3797,6 +3797,13 @@ func (s *Store) processTick(ctx context.Context, rangeID roachpb.RangeID) bool {
 	}
 	livenessMap, _ := s.livenessMap.Load().(map[roachpb.NodeID]bool)
 
+	// Make sure we ask all live nodes for closed timestamp updates.
+	for nodeID, live := range livenessMap {
+		if live {
+			s.cfg.ClosedTimestamp.Clients.EnsureClient(nodeID)
+		}
+	}
+
 	start := timeutil.Now()
 	r := (*Replica)(value)
 	exists, err := r.tick(livenessMap)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -730,7 +730,7 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 		t.Fatal("replica was not marked as destroyed")
 	}
 
-	if _, _, pErr := repl1.propose(
+	if _, _, _, pErr := repl1.propose(
 		context.Background(), lease, roachpb.BatchRequest{}, nil, &allSpans,
 	); !pErr.Equal(expErr) {
 		t.Fatalf("expected error %s, but got %v", expErr, pErr)


### PR DESCRIPTION
This "finishes" hooking up the storage side of closed timestamps. After
checking their lease and deciding that the lease does not allow serving
a read, replicas now check whether they can serve the batch as a
follower read. This requires that the range is epoch based, that
appropriate information is stored in the closed timestamp subsystem, and
finally that the cluster setting to enable this is set.

Added a test that verifies that a test server will serve follower reads
(directly from the replicas, without routing through DistSender).

Introducing machinery at the distributed sender to actually consider
routing reads to follower replicas is the next step.

TODO: take perf numbers before/after this change to verify that there
isn't a noticeable regression.

Touches #16593.

Release note: None