### PR TITLE
opt: fix bug in lookup join local path

### DIFF
--- a/pkg/sql/lookup_join.go
+++ b/pkg/sql/lookup_join.go
@@ -143,7 +143,8 @@ func (lj *lookupJoinNode) Next(params runParams) (bool, error) {
 }
 
 func (lj *lookupJoinNode) Values() tree.Datums {
-	return lj.run.n.Values()
+	// Chop off any values we may have tacked onto the table scanNode.
+	return lj.run.n.Values()[:len(lj.columns)]
 }
 
 func (lj *lookupJoinNode) Close(ctx context.Context) {


### PR DESCRIPTION
We are sometimes adding columns to the table scanNode so the joinNode
can return more columns than the lookup join node; we need to chop
them off before returning them, or other nodes can get confused.

This fixes a bigtest failure.

Release note: None