### PR TITLE
sql: format tuple expressions with ROW prefix

### DIFF
--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -2491,6 +2491,8 @@ type DTuple struct {
 	// the tuple type auto-computed when ResolvedType() is called the
 	// first time.
 	typ types.TTuple
+
+	row bool
 }
 
 // NewDTuple creates a *DTuple with the provided datums. When creating a new
@@ -2671,9 +2673,12 @@ func (*DTuple) AmbiguousFormat() bool { return false }
 // TODO(bram): We don't format tuples in the same way as postgres. See #25522.
 // TODO(knz): this is broken if the tuple is labeled. See #26624.
 func (d *DTuple) Format(ctx *FmtCtx) {
-	if ctx.HasFlags(FmtParsable) && (len(d.D) == 0) {
-		ctx.WriteString("ROW()")
-		return
+	if ctx.HasFlags(FmtParsable) {
+		ctx.WriteString("ROW")
+		if len(d.D) == 0 {
+			ctx.WriteString("()")
+			return
+		}
 	}
 	ctx.FormatNode(&d.D)
 }

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3784,6 +3784,7 @@ func (t *Tuple) Eval(ctx *EvalContext) (Datum, error) {
 		}
 		tuple.D[i] = d
 	}
+	tuple.row = t.Row
 	return tuple, nil
 }
 

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -415,7 +415,17 @@ func (node *ComparisonExpr) Format(ctx *FmtCtx) {
 	if node.Operator.hasSubOperator() {
 		binExprFmtWithParenAndSubOp(ctx, node.Left, node.SubOperator.String(), opStr, node.Right)
 	} else {
-		binExprFmtWithParen(ctx, node.Left, opStr, node.Right, true)
+		if t, ok := node.Right.(*Tuple); ok {
+			exprFmtWithParen(ctx, node.Left)
+			ctx.WriteByte(' ')
+			ctx.WriteString(opStr)
+			ctx.WriteByte(' ')
+			ctx.WriteByte('(')
+			ctx.FormatNode(&t.Exprs)
+			ctx.WriteByte(')')
+		} else {
+			binExprFmtWithParen(ctx, node.Left, opStr, node.Right, true)
+		}
 	}
 }
 
@@ -756,7 +766,7 @@ func (node *Tuple) Format(ctx *FmtCtx) {
 	if len(node.Labels) > 0 {
 		ctx.WriteByte('(')
 	}
-	if node.Row {
+	if ctx.HasFlags(FmtParsable) {
 		ctx.WriteString("ROW")
 	}
 	ctx.WriteByte('(')


### PR DESCRIPTION
Unconditionally format tuple expressions (e.g. (1,2,3) as
ROW(1,2,3). This disambiguates singleton tuples (e.g. (1)) so that
they are correctly interpreted as tuples upon deserialization, rather
than parenthesized base types.

Currently failing logic tests that require rewriting.