### PR TITLE
client: fix assigning of anchor to first written key

### DIFF
--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -1035,7 +1035,7 @@ func (txn *Txn) Send(
 			if len(txn.mu.Proto.Key) == 0 {
 				txnAnchorKey := txn.mu.txnAnchorKey
 				if len(txnAnchorKey) == 0 {
-					txnAnchorKey = ba.Requests[0].GetInner().Header().Key
+					txnAnchorKey = ba.Requests[firstWriteIdx].GetInner().Header().Key
 				}
 				txn.mu.Proto.Key = txnAnchorKey
 			}


### PR DESCRIPTION
Before this patch, if the first write batch was starting with a read
request, the txn's anchor was erroneously set to the read's key.
I believe this broke a year ago in #13799

Release note: None