### PR TITLE
distsqlrun: report correct privs to SemaContext

### DIFF
--- a/pkg/sql/distsqlrun/expr_test.go
+++ b/pkg/sql/distsqlrun/expr_test.go
@@ -43,7 +43,8 @@ func TestProcessExpression(t *testing.T) {
 
 	e := Expression{Expr: "@1 * (@2 + @3) + @1"}
 	h := tree.MakeIndexedVarHelper(testVarContainer{}, 4)
-	expr, err := processExpression(e, &h)
+	semaCtx := tree.MakeSemaContext(false)
+	expr, err := processExpression(e, &semaCtx, &h)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2014,3 +2014,7 @@ query T
 SELECT pg_catalog.pg_client_encoding()
 ----
 UTF8
+
+# Ensure that privileged builtins work from DistSQL.
+statement ok
+SELECT crdb_internal.set_vmodule('foo=2') FROM foo


### PR DESCRIPTION
Previously, privileged builtins weren't runnable via DistSQL.

Release note (bug fix): correct erroneous failures of privileged
builtins in queries run through distsql.