### PR TITLE
ui: fix statements page crash

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/index.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/index.tsx
@@ -81,9 +81,8 @@ class ClusterVisualization extends React.Component<ClusterVisualizationProps & R
           loading={!this.props.licenseDataExists}
           className="loading-image loading-image__spinner-left"
           image={spinner}
-        >
-          <NodeCanvasContent tiers={tiers} />
-        </Loading>
+          render={() => <NodeCanvasContent tiers={tiers} />}
+        />
       </div>
     );
   }

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeCanvasContainer.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeCanvasContainer.tsx
@@ -75,15 +75,16 @@ class NodeCanvasContainer extends React.Component<NodeCanvasContainerProps & Nod
         loading={!this.props.dataExists}
         className="loading-image loading-image__spinner-left"
         image={spinner}
-      >
-        <NodeCanvas
-          localityTree={currentLocality}
-          locationTree={this.props.locationTree}
-          tiers={this.props.tiers}
-          livenessStatuses={this.props.livenessStatuses}
-          livenesses={this.props.livenesses}
-        />
-      </Loading>
+        render={() => (
+          <NodeCanvas
+            localityTree={currentLocality}
+            locationTree={this.props.locationTree}
+            tiers={this.props.tiers}
+            livenessStatuses={this.props.livenessStatuses}
+            livenesses={this.props.livenesses}
+          />
+        )}
+      />
     );
   }
 }

--- a/pkg/ui/src/views/cluster/containers/dataDistribution/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/dataDistribution/index.tsx
@@ -147,13 +147,14 @@ class DataDistributionPage extends React.Component<DataDistributionPageProps> {
             className="loading-image loading-image__spinner-left"
             loading={!this.props.dataDistribution || !this.props.localityTree}
             image={spinner}
-          >
-            <DataDistribution
-              localityTree={this.props.localityTree}
-              dataDistribution={this.props.dataDistribution}
-              sortedZoneConfigs={this.props.sortedZoneConfigs}
-            />
-          </Loading>
+            render={() => (
+              <DataDistribution
+                localityTree={this.props.localityTree}
+                dataDistribution={this.props.dataDistribution}
+                sortedZoneConfigs={this.props.sortedZoneConfigs}
+              />
+            )}
+          />
         </section>
       </div>
     );

--- a/pkg/ui/src/views/cluster/containers/nodeLogs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeLogs/index.tsx
@@ -110,9 +110,8 @@ class Logs extends React.Component<LogProps & RouterState, {}> {
             loading={ !this.props.logs.data }
             className="loading-image loading-image__spinner-left"
             image={ spinner }
-          >
-            { content }
-          </Loading>
+            render={() => content}
+          />
         </section>
       </div>
     );

--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -199,7 +199,8 @@ class JobsTable extends React.Component<JobsTableProps, {}> {
     this.props.setShow(selected.value);
   }
 
-  renderTable(jobs: Job[]) {
+  renderTable = () => {
+    const jobs = this.props.jobs && this.props.jobs.length > 0 && this.props.jobs;
     if (_.isEmpty(jobs)) {
       return <div className="no-results"><h2>No Results</h2></div>;
     }
@@ -218,7 +219,6 @@ class JobsTable extends React.Component<JobsTableProps, {}> {
   }
 
   render() {
-    const data = this.props.jobs && this.props.jobs.length > 0 && this.props.jobs;
     return <div className="jobs-page">
       <Helmet>
         <title>Jobs</title>
@@ -263,9 +263,12 @@ class JobsTable extends React.Component<JobsTableProps, {}> {
           </PageConfigItem>
         </PageConfig>
       </div>
-      <Loading loading={_.isNil(this.props.jobs)} className="loading-image loading-image__spinner" image={spinner}>
-          { this.renderTable(data) }
-      </Loading>
+      <Loading
+        loading={_.isNil(this.props.jobs)}
+        className="loading-image loading-image__spinner"
+        image={spinner}
+        render={this.renderTable}
+      />
     </div>;
   }
 }

--- a/pkg/ui/src/views/reports/containers/commandQueue/index.tsx
+++ b/pkg/ui/src/views/reports/containers/commandQueue/index.tsx
@@ -110,9 +110,8 @@ class CommandQueue extends React.Component<CommandQueueProps, {}> {
           loading={!this.props.commandQueue || this.props.commandQueue.inFlight}
           className="loading-image loading-image__spinner-left"
           image={spinner}
-        >
-          {this.renderReportBody()}
-        </Loading>
+          render={this.renderReportBody}
+        />
       </div>
     );
   }

--- a/pkg/ui/src/views/reports/containers/localities/index.tsx
+++ b/pkg/ui/src/views/reports/containers/localities/index.tsx
@@ -100,22 +100,23 @@ class Localities extends React.Component<LocalitiesProps, {}> {
           loading={ !this.props.localityStatus.data || !this.props.locationStatus.data }
           className="loading-image loading-image__spinner-left"
           image={ spinner }
-        >
-          <section className="section">
-            <table className="locality-table">
-              <thead>
-                <tr>
-                  <th>Localities</th>
-                  <th>Nodes</th>
-                  <th>Location</th>
-                </tr>
-              </thead>
-              <tbody>
-                { renderLocalityTree(this.props.locationTree, this.props.localityTree) }
-              </tbody>
-            </table>
-          </section>
-        </Loading>
+          render={() => (
+            <section className="section">
+              <table className="locality-table">
+                <thead>
+                  <tr>
+                    <th>Localities</th>
+                    <th>Nodes</th>
+                    <th>Location</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  { renderLocalityTree(this.props.locationTree, this.props.localityTree) }
+                </tbody>
+              </table>
+            </section>
+          )}
+        />
       </div>
     );
   }

--- a/pkg/ui/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/index.tsx
@@ -446,12 +446,13 @@ class Network extends React.Component<NetworkProps, {}> {
           loading={!contentAvailable(nodesSummary)}
           className="loading-image loading-image__spinner-left loading-image__spinner-left__padded"
           image={spinner}
-        >
-          <div>
-            <NodeFilterList nodeIDs={filters.nodeIDs} localityRegex={filters.localityRegex} />
-            {this.renderContent(nodesSummary, filters)}
-          </div>
-        </Loading>
+          render={() => (
+            <div>
+              <NodeFilterList nodeIDs={filters.nodeIDs} localityRegex={filters.localityRegex} />
+              {this.renderContent(nodesSummary, filters)}
+            </div>
+          )}
+        />
       </div>
     );
   }

--- a/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
+++ b/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
@@ -188,12 +188,13 @@ class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
           loading={isLoading(this.props.problemRanges)}
           className="loading-image loading-image__spinner-left loading-image__spinner-left__padded"
           image={spinner}
-        >
-          <div>
-            {this.renderReportBody()}
-            <ConnectionsTable problemRanges={this.props.problemRanges} />
-          </div>
-        </Loading>
+          render={() => (
+            <div>
+              {this.renderReportBody()}
+              <ConnectionsTable problemRanges={this.props.problemRanges} />
+            </div>
+          )}
+        />
       </div>
     );
   }

--- a/pkg/ui/src/views/reports/containers/range/allocator.tsx
+++ b/pkg/ui/src/views/reports/containers/range/allocator.tsx
@@ -59,24 +59,25 @@ export default class AllocatorOutput extends React.Component<AllocatorOutputProp
           loading={!allocator || allocator.inFlight}
           className="loading-image loading-image__spinner-left"
           image={spinner}
-        >
-          <table className="allocator-table">
-            <tbody>
-              <tr className="allocator-table__row allocator-table__row--header">
-                <th className="allocator-table__cell allocator-table__cell--header">Timestamp</th>
-                <th className="allocator-table__cell allocator-table__cell--header">Message</th>
-              </tr>
-              {
-                _.map(allocator.data.dry_run.events, (event, key) => (
-                  <tr key={key} className="allocator-table__row">
-                    <td className="allocator-table__cell allocator-table__cell--date">{Print.Timestamp(event.time)}</td>
-                    <td className="allocator-table__cell">{event.message}</td>
-                  </tr>
-                ))
-              }
-            </tbody>
-          </table>
-        </Loading>
+          render={() => (
+            <table className="allocator-table">
+              <tbody>
+                <tr className="allocator-table__row allocator-table__row--header">
+                  <th className="allocator-table__cell allocator-table__cell--header">Timestamp</th>
+                  <th className="allocator-table__cell allocator-table__cell--header">Message</th>
+                </tr>
+                {
+                  _.map(allocator.data.dry_run.events, (event, key) => (
+                    <tr key={key} className="allocator-table__row">
+                      <td className="allocator-table__cell allocator-table__cell--date">{Print.Timestamp(event.time)}</td>
+                      <td className="allocator-table__cell">{event.message}</td>
+                    </tr>
+                  ))
+                }
+              </tbody>
+            </table>
+          )}
+        />
       </div>
     );
   }

--- a/pkg/ui/src/views/reports/containers/range/connectionsTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/connectionsTable.tsx
@@ -31,37 +31,38 @@ export default function ConnectionsTable(props: ConnectionsTableProps) {
         loading={!range || range.inFlight}
         className="loading-image loading-image__spinner-left"
         image={spinner}
-      >
-        <table className="connections-table">
-          <tbody>
-            <tr className="connections-table__row connections-table__row--header">
-              <th className="connections-table__cell connections-table__cell--header">Node</th>
-              <th className="connections-table__cell connections-table__cell--header">Valid</th>
-              <th className="connections-table__cell connections-table__cell--header">Replicas</th>
-              <th className="connections-table__cell connections-table__cell--header">Error</th>
-            </tr>
-            {
-              _.map(ids, id => {
-                const resp = range.data.responses_by_node_id[id];
-                const rowClassName = classNames(
-                  "connections-table__row",
-                  { "connections-table__row--warning": !resp.response || !_.isEmpty(resp.error_message) },
-                );
-                return (
-                  <tr key={id} className={rowClassName}>
-                    <td className="connections-table__cell">n{id}</td>
-                    <td className="connections-table__cell">
-                      {resp.response ? "ok" : "error"}
-                    </td>
-                    <td className="connections-table__cell">{resp.infos.length}</td>
-                    <td className="connections-table__cell">{resp.error_message}</td>
-                  </tr>
-                );
-              })
-            }
-          </tbody>
-        </table>
-      </Loading>
+        render={() => (
+          <table className="connections-table">
+            <tbody>
+              <tr className="connections-table__row connections-table__row--header">
+                <th className="connections-table__cell connections-table__cell--header">Node</th>
+                <th className="connections-table__cell connections-table__cell--header">Valid</th>
+                <th className="connections-table__cell connections-table__cell--header">Replicas</th>
+                <th className="connections-table__cell connections-table__cell--header">Error</th>
+              </tr>
+              {
+                _.map(ids, id => {
+                  const resp = range.data.responses_by_node_id[id];
+                  const rowClassName = classNames(
+                    "connections-table__row",
+                    { "connections-table__row--warning": !resp.response || !_.isEmpty(resp.error_message) },
+                  );
+                  return (
+                    <tr key={id} className={rowClassName}>
+                      <td className="connections-table__cell">n{id}</td>
+                      <td className="connections-table__cell">
+                        {resp.response ? "ok" : "error"}
+                      </td>
+                      <td className="connections-table__cell">{resp.infos.length}</td>
+                      <td className="connections-table__cell">{resp.error_message}</td>
+                    </tr>
+                  );
+                })
+              }
+            </tbody>
+          </table>
+        )}
+      />
     </div>
   );
 }

--- a/pkg/ui/src/views/reports/containers/range/logTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/logTable.tsx
@@ -103,32 +103,33 @@ export default class LogTable extends React.Component<LogTableProps, {}> {
           loading={!log || log.inFlight}
           className="loading-image loading-image__spinner-left"
           image={spinner}
-        >
-          <table className="log-table">
-            <tbody>
-              <tr className="log-table__row log-table__row--header">
-                <th className="log-table__cell log-table__cell--header">Timestamp</th>
-                <th className="log-table__cell log-table__cell--header">Store</th>
-                <th className="log-table__cell log-table__cell--header">Event Type</th>
-                <th className="log-table__cell log-table__cell--header">Range</th>
-                <th className="log-table__cell log-table__cell--header">Other Range</th>
-                <th className="log-table__cell log-table__cell--header">Info</th>
-              </tr>
-              {_.map(events, (event, key) => (
-                <tr key={key} className="log-table__row">
-                  <td className="log-table__cell log-table__cell--date">
-                    {Print.Timestamp(event.event.timestamp)}
-                  </td>
-                  <td className="log-table__cell">s{event.event.store_id}</td>
-                  <td className="log-table__cell">{printLogEventType(event.event.event_type)}</td>
-                  <td className="log-table__cell">{this.renderRangeID(event.event.range_id)}</td>
-                  <td className="log-table__cell">{this.renderRangeID(event.event.other_range_id)}</td>
-                  <td className="log-table__cell">{this.renderLogInfo(event.pretty_info)}</td>
+          render={() => (
+            <table className="log-table">
+              <tbody>
+                <tr className="log-table__row log-table__row--header">
+                  <th className="log-table__cell log-table__cell--header">Timestamp</th>
+                  <th className="log-table__cell log-table__cell--header">Store</th>
+                  <th className="log-table__cell log-table__cell--header">Event Type</th>
+                  <th className="log-table__cell log-table__cell--header">Range</th>
+                  <th className="log-table__cell log-table__cell--header">Other Range</th>
+                  <th className="log-table__cell log-table__cell--header">Info</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </Loading>
+                {_.map(events, (event, key) => (
+                  <tr key={key} className="log-table__row">
+                    <td className="log-table__cell log-table__cell--date">
+                      {Print.Timestamp(event.event.timestamp)}
+                    </td>
+                    <td className="log-table__cell">s{event.event.store_id}</td>
+                    <td className="log-table__cell">{printLogEventType(event.event.event_type)}</td>
+                    <td className="log-table__cell">{this.renderRangeID(event.event.range_id)}</td>
+                    <td className="log-table__cell">{this.renderRangeID(event.event.other_range_id)}</td>
+                    <td className="log-table__cell">{this.renderLogInfo(event.pretty_info)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        />
       </div>
     );
   }

--- a/pkg/ui/src/views/reports/containers/settings/index.tsx
+++ b/pkg/ui/src/views/reports/containers/settings/index.tsx
@@ -87,12 +87,13 @@ class Settings extends React.Component<SettingsProps, {}> {
           loading={!this.props.settings.data}
           className="loading-image loading-image__spinner-left loading-image__spinner-left__padded"
           image={spinner}
-        >
-          <div>
-            <p>Note that some settings have been redacted for security purposes.</p>
-            {this.renderTable()}
-          </div>
-        </Loading>
+          render={() => (
+            <div>
+              <p>Note that some settings have been redacted for security purposes.</p>
+              {this.renderTable()}
+            </div>
+          )}
+        />
       </div>
     );
   }

--- a/pkg/ui/src/views/shared/components/loading/index.tsx
+++ b/pkg/ui/src/views/shared/components/loading/index.tsx
@@ -4,6 +4,10 @@ interface LoadingProps {
   loading: boolean;
   className: string;
   image: string;
+  // The render function should probably be the only API, but currently
+  // it will be used if it is there, and fall back to children if it is not.
+  // TODO(vilterp): migrate all usages of Loading to use render prop.
+  render?: () => JSX.Element;
   children?: React.ReactNode;
 }
 
@@ -17,6 +21,9 @@ export default function Loading(props: LoadingProps) {
   };
   if (props.loading) {
     return <div className={props.className} style={image} />;
+  }
+  if (props.render) {
+    return props.render();
   }
 
   // This throws an error if more than one child is passed.

--- a/pkg/ui/src/views/shared/components/loading/index.tsx
+++ b/pkg/ui/src/views/shared/components/loading/index.tsx
@@ -4,11 +4,7 @@ interface LoadingProps {
   loading: boolean;
   className: string;
   image: string;
-  // The render function should probably be the only API, but currently
-  // it will be used if it is there, and fall back to children if it is not.
-  // TODO(vilterp): migrate all usages of Loading to use render prop.
-  render?: () => JSX.Element;
-  children?: React.ReactNode;
+  render: () => React.ReactNode;
 }
 
 // *
@@ -22,15 +18,9 @@ export default function Loading(props: LoadingProps) {
   if (props.loading) {
     return <div className={props.className} style={image} />;
   }
-  if (props.render) {
-    return props.render();
-  }
-
-  // This throws an error if more than one child is passed.
-  // Unfortunately the error seems to get eaten by some try/catch
-  // above this, but leaving it here to at least signal intent.
-  // Also unfortunately it's unclear how to enforce this invariant
-  // with the type system, since the `children` argument matches
-  // both one node and multiple nodes.
-  return React.Children.only(props.children);
+  return (
+    <React.Fragment>
+      { props.render() }
+    </React.Fragment>
+  );
 }

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -145,15 +145,14 @@ class StatementDetails extends React.Component<StatementDetailsProps, StatementD
             loading={_.isNil(this.props.statement)}
             className="loading-image loading-image__spinner"
             image={spinner}
-          >
-            { this.renderContent() }
-          </Loading>
+            render={this.renderContent}
+          />
         </section>
       </div>
     );
   }
 
-  renderContent() {
+  renderContent = () => {
     if (!this.props.statement) {
       return null;
     }

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -30,7 +30,6 @@ type ICollectedStatementStatistics = protos.cockroach.server.serverpb.Statements
 type RouteProps = RouteComponentProps<any, any>;
 
 interface StatementsPageProps {
-  valid: boolean;
   statements: AggregateStatistics[];
   apps: string[];
   totalFingerprints: number;
@@ -72,12 +71,7 @@ class StatementsPage extends React.Component<StatementsPageProps & RouteProps, S
     this.props.refreshStatements();
   }
 
-  renderStatements() {
-    if (!this.props.valid) {
-      // This should really be handled by a loader component.
-      return null;
-    }
-
+  renderStatements = () => {
     const selectedApp = this.props.params[appAttr] || "";
     const appOptions = [{ value: "", label: "All" }];
     this.props.apps.forEach(app => appOptions.push({ value: app, label: app }));
@@ -143,9 +137,8 @@ class StatementsPage extends React.Component<StatementsPageProps & RouteProps, S
           loading={_.isNil(this.props.statements)}
           className="loading-image loading-image__spinner"
           image={spinner}
-        >
-          {this.renderStatements()}
-        </Loading>
+          render={this.renderStatements}
+        />
       </section>
     );
   }
@@ -248,7 +241,6 @@ const StatementsPageConnected = connect(
     apps: selectApps(state),
     totalFingerprints: selectTotalFingerprints(state),
     lastReset: selectLastReset(state),
-    valid: state.cachedData.statements.valid,
   }),
   {
     refreshStatements,


### PR DESCRIPTION
Release note (admin ui change): fix bug in which statements page blanks out after it reloads itself after a few minutes.

Includes introduction of `render` prop to `Loading` component. I don't have time for a major discussion and refactor right now, but I also can't stomach yet another stupid bug caused by `Loading` being the way it is right now.