### PR TITLE
cli: Add unsafe-remove-dead-replicas command

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -16,6 +16,7 @@
 package cli
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/hex"
@@ -1143,6 +1144,152 @@ func runDebugSyncTest(cmd *cobra.Command, args []string) error {
 	return synctest.Run(syncTestOpts)
 }
 
+var debugUnsafeRemoveDeadReplicasCmd = &cobra.Command{
+	Use:   "unsafe-remove-dead-replicas --dead-store-ids=[store ID,...] [path]",
+	Short: "Unsafely remove all other replicas from the given range",
+	Long: `
+
+This command is UNSAFE and should only be used with the supervision of
+a Cockroach Labs engineer. It is a last-resort option to recover data
+after multiple node failures. The recovered data is not guaranteed to
+be consistent.
+
+The --dead-store-ids flag takes a comma-separated list of dead store
+IDs and scans this store for any ranges whose only live replica is on
+this store. These range descriptors will be edited to forcibly remove
+the dead stores, allowing the range to recover from this single
+replica.
+
+Must only be used when the dead stores are lost and unrecoverable. If
+the dead stores were to rejoin the cluster after this command was
+used, data may be corrupted.
+
+This comand will prompt for confirmation before committing its changes.
+
+Limitations: Can only recover from a single replica. If a range with
+four replicas has experienced two failures, or a range with five
+replicas experiences three failures, this tool cannot (yet) be used to
+recover from the two remaining replicas.
+
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: MaybeDecorateGRPCError(runDebugUnsafeRemoveDeadReplicas),
+}
+
+var removeDeadReplicasOpts struct {
+	deadStoreIDs []int
+}
+
+func runDebugUnsafeRemoveDeadReplicas(cmd *cobra.Command, args []string) error {
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	db, err := openExistingStore(args[0], stopper, false /* readOnly */)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	deadStoreIDs := map[roachpb.StoreID]struct{}{}
+	for _, id := range removeDeadReplicasOpts.deadStoreIDs {
+		deadStoreIDs[roachpb.StoreID(id)] = struct{}{}
+	}
+	batch, err := removeDeadReplicas(db, deadStoreIDs)
+	if err != nil {
+		return err
+	} else if batch == nil {
+		fmt.Printf("Nothing to do\n")
+		return nil
+	}
+	defer batch.Close()
+
+	fmt.Printf("Proceed with the above rewrites? [y/N] ")
+
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return err
+	}
+	fmt.Printf("\n")
+	if line[0] == 'y' || line[0] == 'Y' {
+		fmt.Printf("Committing\n")
+		if err := batch.Commit(true); err != nil {
+			return err
+		}
+	} else {
+		fmt.Printf("Aborting\n")
+	}
+	return nil
+}
+
+func removeDeadReplicas(db engine.Engine, deadStoreIDs map[roachpb.StoreID]struct{}) (engine.Batch, error) {
+	clock := hlc.NewClock(hlc.UnixNano, 0)
+
+	ctx := context.Background()
+
+	storeIdent, err := storage.ReadStoreIdent(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("Scanning replicas on store %s for dead peers %v\n", storeIdent,
+		removeDeadReplicasOpts.deadStoreIDs)
+
+	if _, ok := deadStoreIDs[storeIdent.StoreID]; ok {
+		return nil, errors.Errorf("This store's ID (%s) marked as dead, aborting", storeIdent.StoreID)
+	}
+
+	var newDescs []roachpb.RangeDescriptor
+
+	err = storage.IterateRangeDescriptors(ctx, db, func(desc roachpb.RangeDescriptor) (bool, error) {
+		hasSelf := false
+		numDeadPeers := 0
+		numReplicas := len(desc.Replicas)
+		for _, rep := range desc.Replicas {
+			if rep.StoreID == storeIdent.StoreID {
+				hasSelf = true
+			}
+			if _, ok := deadStoreIDs[rep.StoreID]; ok {
+				numDeadPeers++
+			}
+		}
+		if hasSelf && numDeadPeers > 0 && numDeadPeers == numReplicas-1 {
+			newDesc := desc
+			// Rewrite the replicas list. Bump the replica ID as an extra
+			// defense against one of the old replicas returning from the
+			// dead.
+			newDesc.Replicas = []roachpb.ReplicaDescriptor{{
+				NodeID:    storeIdent.NodeID,
+				StoreID:   storeIdent.StoreID,
+				ReplicaID: desc.NextReplicaID,
+			}}
+			newDesc.NextReplicaID++
+			fmt.Printf("Replica %s -> %s\n", desc, newDesc)
+			newDescs = append(newDescs, newDesc)
+		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(newDescs) == 0 {
+		return nil, nil
+	}
+
+	batch := db.NewBatch()
+	for _, desc := range newDescs {
+		var ms enginepb.MVCCStats
+		err := engine.MVCCPutProto(ctx, batch, &ms, keys.RangeDescriptorKey(desc.StartKey),
+			clock.Now(), nil /* txn */, &desc)
+		if err != nil {
+			batch.Close()
+			return nil, err
+		}
+	}
+
+	return batch, nil
+}
+
 func init() {
 	debugCmd.AddCommand(debugCmds...)
 
@@ -1153,6 +1300,10 @@ func init() {
 		"duration to run the test for")
 	f.BoolVarP(&syncTestOpts.LogOnly, "log-only", "l", syncTestOpts.LogOnly,
 		"only write to the WAL, not to sstables")
+
+	f = debugUnsafeRemoveDeadReplicasCmd.Flags()
+	f.IntSliceVar(&removeDeadReplicasOpts.deadStoreIDs, "dead-store-ids", nil,
+		"list of dead store IDs")
 }
 
 // DebugCmdsForRocksDB lists debug commands that access rocksdb.
@@ -1174,6 +1325,7 @@ var debugCmds = append(DebugCmdsForRocksDB,
 	debugRocksDBCmd,
 	debugGossipValuesCmd,
 	debugSyncTestCmd,
+	debugUnsafeRemoveDeadReplicasCmd,
 	debugEnvCmd,
 	debugZipCmd,
 )

--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
@@ -145,8 +147,47 @@ func TestRemoveDeadReplicas(t *testing.T) {
 	// Start the cluster, let it replicate, then stop it. Since two
 	// nodes use in-memory stores, this automatically causes the cluster
 	// to lose its quorum.
-	tc := testcluster.StartTestCluster(t, 3, clusterArgs)
-	tc.Stopper().Stop(ctx)
+	//
+	// While it's running, start a transaction and write an intent to
+	// one of the range descriptors (without committing or aborting the
+	// transaction). This exercises a special case in removeDeadReplicas.
+	func() {
+		tc := testcluster.StartTestCluster(t, 3, clusterArgs)
+		defer tc.Stopper().Stop(ctx)
+
+		// Perform a write, to ensure that pre-crash data is preserved.
+		// Creating a table causes extra friction in the test harness when
+		// we restart the cluster, so just write a setting.
+		s := sqlutils.MakeSQLRunner(tc.Conns[0])
+		s.Exec(t, "set cluster setting cluster.organization='remove dead replicas test'")
+
+		txn := client.NewTxn(tc.Servers[0].DB(), 1, client.RootTxn)
+		var desc roachpb.RangeDescriptor
+		// Pick one of the predefined split points.
+		rdKey := keys.RangeDescriptorKey(roachpb.RKey(keys.TimeseriesPrefix))
+		if err := txn.GetProto(ctx, rdKey, &desc); err != nil {
+			t.Fatal(err)
+		}
+		desc.NextReplicaID++
+		if err := txn.Put(ctx, rdKey, &desc); err != nil {
+			t.Fatal(err)
+		}
+
+		// At this point the intent has been written to rocksdb but this
+		// write was not synced (only the raft log append was synced). We
+		// need to force another sync, but we're far from the storage
+		// layer here so the easiest thing to do is simply perform a
+		// second write. This will force the first write to be persisted
+		// to disk (the second write may or may not make it to disk due to
+		// timing).
+		desc.NextReplicaID++
+		if err := txn.Put(ctx, rdKey, &desc); err != nil {
+			t.Fatal(err)
+		}
+
+		// We deliberately do not close this transaction so the intent is
+		// left behind.
+	}()
 
 	// Open the store directly to repair it.
 	func() {
@@ -160,8 +201,8 @@ func TestRemoveDeadReplicas(t *testing.T) {
 		defer db.Close()
 
 		batch, err := removeDeadReplicas(db, map[roachpb.StoreID]struct{}{
-			2: struct{}{},
-			3: struct{}{},
+			2: {},
+			3: {},
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -176,13 +217,14 @@ func TestRemoveDeadReplicas(t *testing.T) {
 
 		// The repair process is idempotent and should give a nil batch the second time.
 		batch, err = removeDeadReplicas(db, map[roachpb.StoreID]struct{}{
-			2: struct{}{},
-			3: struct{}{},
+			2: {},
+			3: {},
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
 		if batch != nil {
+			batch.Close()
 			t.Fatalf("expected nil batch on second attempt")
 		}
 	}()
@@ -191,7 +233,7 @@ func TestRemoveDeadReplicas(t *testing.T) {
 	// nodes with the in-memory stores will be assigned new node IDs 4
 	// and 5. StartTestCluster will even wait for all the ranges to be
 	// replicated to the new nodes.
-	tc = testcluster.StartTestCluster(t, 3, clusterArgs)
+	tc := testcluster.StartTestCluster(t, 3, clusterArgs)
 	defer tc.Stopper().Stop(ctx)
 	s := sqlutils.MakeSQLRunner(tc.Conns[0])
 	row := s.QueryRow(t, "select replicas from [show experimental_ranges from table system.namespace] limit 1")
@@ -199,5 +241,12 @@ func TestRemoveDeadReplicas(t *testing.T) {
 	row.Scan(&replicaStr)
 	if replicaStr != "{1,4,5}" {
 		t.Fatalf("expected replicas on {1,4,5} but got %s", replicaStr)
+	}
+
+	row = s.QueryRow(t, "show cluster setting cluster.organization")
+	var org string
+	row.Scan(&org)
+	if org != "remove dead replicas test" {
+		t.Fatalf("expected old setting to be present, got %s instead", org)
 	}
 }

--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -20,11 +20,15 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
@@ -117,5 +121,83 @@ func TestOpenReadOnlyStore(t *testing.T) {
 				t.Fatalf("wanted %s but got %v", test.expErr, err)
 			}
 		})
+	}
+}
+
+func TestRemoveDeadReplicas(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	baseDir, dirCleanupFn := testutils.TempDir(t)
+	defer dirCleanupFn()
+
+	// The first node gets a real store, others are just in memory.
+	storePath := filepath.Join(baseDir, "store")
+
+	clusterArgs := base.TestClusterArgs{
+		ServerArgsPerNode: map[int]base.TestServerArgs{
+			0: {
+				StoreSpecs:      []base.StoreSpec{{Path: storePath}},
+				ScanMaxIdleTime: time.Millisecond,
+			},
+		},
+	}
+	// Start the cluster, let it replicate, then stop it. Since two
+	// nodes use in-memory stores, this automatically causes the cluster
+	// to lose its quorum.
+	tc := testcluster.StartTestCluster(t, 3, clusterArgs)
+	tc.Stopper().Stop(ctx)
+
+	// Open the store directly to repair it.
+	func() {
+		stopper := stop.NewStopper()
+		defer stopper.Stop(ctx)
+
+		db, err := openExistingStore(storePath, stopper, false /* readOnly */)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		batch, err := removeDeadReplicas(db, map[roachpb.StoreID]struct{}{
+			2: struct{}{},
+			3: struct{}{},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if batch == nil {
+			t.Fatal("expected non-nil batch")
+		}
+		if err := batch.Commit(true); err != nil {
+			t.Fatal(err)
+		}
+		batch.Close()
+
+		// The repair process is idempotent and should give a nil batch the second time.
+		batch, err = removeDeadReplicas(db, map[roachpb.StoreID]struct{}{
+			2: struct{}{},
+			3: struct{}{},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if batch != nil {
+			t.Fatalf("expected nil batch on second attempt")
+		}
+	}()
+
+	// Now that the data is salvaged, we can restart the cluster. The
+	// nodes with the in-memory stores will be assigned new node IDs 4
+	// and 5. StartTestCluster will even wait for all the ranges to be
+	// replicated to the new nodes.
+	tc = testcluster.StartTestCluster(t, 3, clusterArgs)
+	defer tc.Stopper().Stop(ctx)
+	s := sqlutils.MakeSQLRunner(tc.Conns[0])
+	row := s.QueryRow(t, "select replicas from [show experimental_ranges from table system.namespace] limit 1")
+	var replicaStr string
+	row.Scan(&replicaStr)
+	if replicaStr != "{1,4,5}" {
+		t.Fatalf("expected replicas on {1,4,5} but got %s", replicaStr)
 	}
 }

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1375,7 +1375,7 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) (LeaseStatus, *r
 						// This would be the situation in which the lease holder gets removed when
 						// holding the lease, or in which a lease request erroneously gets accepted
 						// for a replica that is not in the replica set. Neither of the two can
-						// happen since appropriate mechanisms have been added:
+						// happen in normal usage since appropriate mechanisms have been added:
 						//
 						// 1. Only the lease holder (at the time) schedules removal of a replica,
 						// but the lease can change hands and so the situation in which a follower
@@ -1401,7 +1401,12 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) (LeaseStatus, *r
 						// ProposerLease. Hence, an extra check is in order: processRaftCommand
 						// makes sure that lease requests for a replica not in the descriptor are
 						// bounced.
-						log.Fatalf(ctx, "lease %s owned by replica %+v that no longer exists",
+						//
+						// However, this is possible if the `cockroach debug
+						// unsafe-remove-dead-replicas` command has been used, so
+						// this is just a logged error instead of a fatal
+						// assertion.
+						log.Errorf(ctx, "lease %s owned by replica %+v that no longer exists",
 							status.Lease, status.Lease.Replica)
 					}
 					// Otherwise, if the lease is currently held by another replica, redirect


### PR DESCRIPTION
This command can be used to (inconsistently) salvage a single replica
from a cluster that has lost multiple nodes.

Release note: None