### PR TITLE
distsql: run local flows in root txn

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -221,7 +221,15 @@ func (dsp *DistSQLPlanner) Run(
 	// Set up the flow on this node.
 	localReq := setupReq
 	localReq.Flow = flows[thisNodeID]
-	ctx, flow, err := dsp.distSQLSrv.SetupSyncFlow(ctx, evalCtx.Mon, &localReq, recv)
+	var flow *distsqlrun.Flow
+	var err error
+	if len(flows) > 1 {
+		ctx, flow, err = dsp.distSQLSrv.SetupSyncFlow(ctx, evalCtx.Mon, &localReq, recv)
+	} else {
+		// If we are only running this local flow, we can setup the flow with
+		// the root txn.
+		ctx, flow, err = dsp.distSQLSrv.SetupLocalSyncFlow(ctx, evalCtx.Mon, &localReq, recv, txn)
+	}
 	if err != nil {
 		recv.SetError(err)
 		return


### PR DESCRIPTION
Previously, all flows would create a leaf txn to avoid each distributed
Txn heartbeating the transaction. This is unnecessary for local
flows, so setupFlow has been extended with an optional txn parameter to
provide a txn to set up the flow with. The DistSQLPlanner sets up flows
using the root txn in these cases.

Before:
```
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
   30.0s        0         454367        15145.8      1.1      0.9
   2.4      3.9     58.7
```

After:
```
 _elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
    30.0s        0         478906        15963.9      1.0      0.9
    2.2      3.8     22.0
```

Release note: None