### PR TITLE
distsql: add remaining seq fns to blacklist

### DIFF
--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -384,6 +384,7 @@ func (ds *ServerImpl) setupFlow(
 	var haveSequences bool
 	for _, seq := range req.EvalContext.SeqState.Seqs {
 		evalCtx.SessionData.SequenceState.RecordValue(seq.SeqID, seq.LatestVal)
+		haveSequences = true
 	}
 	if haveSequences {
 		evalCtx.SessionData.SequenceState.SetLastSequenceIncremented(

--- a/pkg/sql/logictest/testdata/logic_test/sequences_distsql
+++ b/pkg/sql/logictest/testdata/logic_test/sequences_distsql
@@ -31,8 +31,7 @@ SELECT c, lastval() FROM t
 ----
 1 10
 
-# Restore this query when #24130 is fixed:
-# query II
-# SELECT c, currval('distsql_test') FROM t
-# ----
-# 1, 1
+query II
+SELECT c, currval('distsql_test') FROM t
+----
+1 10

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1433,8 +1433,9 @@ CockroachDB supports the following flags:
 
 	"nextval": makeBuiltin(
 		tree.FunctionProperties{
-			Category: categorySequences,
-			Impure:   true,
+			Category:         categorySequences,
+			DistsqlBlacklist: true,
+			Impure:           true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"sequence_name", types.String}},
@@ -1457,8 +1458,9 @@ CockroachDB supports the following flags:
 
 	"currval": makeBuiltin(
 		tree.FunctionProperties{
-			Category: categorySequences,
-			Impure:   true,
+			Category:         categorySequences,
+			DistsqlBlacklist: true,
+			Impure:           true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"sequence_name", types.String}},
@@ -1502,8 +1504,9 @@ CockroachDB supports the following flags:
 	// See https://github.com/cockroachdb/cockroach/issues/21564
 	"setval": makeBuiltin(
 		tree.FunctionProperties{
-			Category: categorySequences,
-			Impure:   true,
+			Category:         categorySequences,
+			DistsqlBlacklist: true,
+			Impure:           true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"sequence_name", types.String}, {"value", types.Int}},


### PR DESCRIPTION
There were still a couple of sequence functions that weren't properly
blacklisted from running in DistSQL.

Release note (bug fix): prevent some sequence builtins from incorrectly
running in distributed flows.