### PR TITLE
opt: minor orderByCols cleanup in optbuilder

### DIFF
--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -58,7 +58,7 @@ func (b *Builder) buildOrderBy(orderBy tree.OrderBy, inScope, projectionsScope *
 		b.buildOrdering(orderBy[i], inScope, projectionsScope, orderByScope)
 	}
 
-	b.buildOrderByProject(projectionsScope, orderByScope)
+	projectionsScope.setOrdering(orderByScope.cols, &orderByScope.physicalProps.Ordering)
 }
 
 // findIndexByName returns an index in the table with the given name. If the
@@ -217,16 +217,6 @@ func (b *Builder) buildOrdering(order *tree.Order, inScope, projectionsScope, or
 		desc := order.Direction == tree.Descending
 		orderByScope.physicalProps.Ordering.AppendCol(orderByScope.cols[i].id, desc)
 	}
-}
-
-// buildOrderByProject adds columns from orderByScope to the orderByCols slice
-// of projectionsScope. buildOrderByProject also sets the ordering and
-// presentation properties on the projectionsScope. These properties later
-// become part of the required physical properties returned by Build.
-func (b *Builder) buildOrderByProject(projectionsScope, orderByScope *scope) {
-	projectionsScope.orderByCols = append(projectionsScope.orderByCols, orderByScope.cols...)
-	projectionsScope.physicalProps.Ordering = orderByScope.physicalProps.Ordering
-	projectionsScope.setPresentation()
 }
 
 func ensureColumnOrderable(e tree.TypedExpr) {

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -31,7 +31,7 @@ func (b *Builder) constructProjectForScope(inScope, projectionsScope *scope) {
 		projectionsScope.group = inScope.group
 	} else {
 		projectionsScope.group = b.constructProject(
-			inScope.group, append(projectionsScope.cols, projectionsScope.orderByCols...),
+			inScope.group, append(projectionsScope.cols, projectionsScope.extraCols...),
 		)
 	}
 }

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -282,7 +282,6 @@ func (b *Builder) buildSelectClause(
 	sel *tree.SelectClause, orderBy tree.OrderBy, inScope *scope,
 ) (outScope *scope) {
 	fromScope := b.buildFrom(sel.From, sel.Where, inScope)
-	outScope = fromScope
 
 	var projectionsScope *scope
 	if b.needsAggregation(sel, orderBy) {
@@ -290,7 +289,8 @@ func (b *Builder) buildSelectClause(
 	} else {
 		projectionsScope = fromScope.replace()
 		b.buildProjectionList(sel.Exprs, fromScope, projectionsScope)
-		b.buildOrderBy(orderBy, outScope, projectionsScope)
+		b.buildOrderBy(orderBy, fromScope, projectionsScope)
+		outScope = fromScope
 	}
 
 	if len(fromScope.srfs) > 0 {


### PR DESCRIPTION
The projections in DISTINCT ON will need treatment similar to the
ORDER BY projections. We refactor things a bit so that the existing
infrastructure can be reused: `orderByCols` is renamed to `extraCols`
and is now de-duplicated against `cols`; for convenience when copying
an ordering, we remember the ordering cols as a ColSet.

Release note: None