### PR TITLE
opt: support array flatten

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -86,6 +86,11 @@ SELECT ARRAY['foo', 'bar']
 # array construction from subqueries
 
 query T
+SELECT ARRAY(SELECT 3 WHERE false)
+----
+{}
+
+query T
 SELECT ARRAY(SELECT 3)
 ----
 {3}
@@ -95,10 +100,18 @@ SELECT ARRAY(VALUES (1),(2),(1))
 ----
 {1,2,1}
 
+statement error arrays cannot have arrays as element type
+SELECT ARRAY(VALUES (ARRAY[1]))
+
 query T
 SELECT ARRAY(VALUES ('a'),('b'),('c'))
 ----
 {"a","b","c"}
+
+query T
+SELECT ARRAY(SELECT (1,2))
+----
+{"(1,2)"}
 
 query error subquery must return only one column, found 2
 SELECT ARRAY(SELECT 1, 2)
@@ -279,6 +292,11 @@ query T
 SELECT (SELECT ARRAY['a', 'b', 'c'])[3]
 ----
 c
+
+query T
+SELECT ARRAY(SELECT generate_series(1,10) ORDER BY 1 DESC);
+----
+{10,9,8,7,6,5,4,3,2,1}
 
 # From a function call expression.
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -217,3 +217,21 @@ join       ·      ·            (x, z)  ·
 
 query error could not decorrelate subquery
 SELECT * FROM abc WHERE EXISTS(SELECT * FROM (VALUES (a), (b)) WHERE column1=a)
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT ARRAY(SELECT x FROM b)
+----
+root                 ·            ·                       ("array")  ·
+ ├── render          ·            ·                       ("array")  ·
+ │    │              render 0     COALESCE(@S1, ARRAY[])  ·          ·
+ │    └── emptyrow   ·            ·                       ()         ·
+ └── subquery        ·            ·                       ("array")  ·
+      │              id           @S1                     ·          ·
+      │              sql          <unknown>               ·          ·
+      │              exec mode    one row                 ·          ·
+      └── group      ·            ·                       (agg0)     ·
+           │         aggregate 0  array_agg(x)            ·          ·
+           │         scalar       ·                       ·          ·
+           └── scan  ·            ·                       (x)        ·
+·                    table        b@primary               ·          ·
+·                    spans        ALL                     ·          ·

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -842,6 +842,7 @@ func (s *scope) replaceSubquery(sub *tree.Subquery, multiRow bool, desiredColumn
 	return &subquery{
 		cols:     outScope.cols,
 		group:    outScope.group,
+		ordering: outScope.ordering,
 		multiRow: multiRow,
 		expr:     sub,
 	}

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -32,6 +32,11 @@ type subquery struct {
 	// group is the top level memo GroupID of the subquery.
 	group memo.GroupID
 
+	// ordering is the ordering requested by the subquery.
+	// It is only consulted in certain cases, however (such as the
+	// ArrayFlatten operation).
+	ordering opt.Ordering
+
 	// Is the subquery in a multi-row or single-row context?
 	multiRow bool
 

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -747,3 +747,169 @@ project
  └── projections
       └── unary-minus [type=int]
            └── const: -9223372036854775808 [type=int]
+
+# TODO(justin): modify build-scalar to handle subqueries
+# so this can use it.
+build
+SELECT ARRAY(SELECT 1)
+----
+project
+ ├── columns: array:3(tuple{int}[])
+ ├── values
+ │    └── tuple [type=tuple]
+ └── projections
+      └── coalesce [type=int[]]
+           ├── subquery [type=int[]]
+           │    └── scalar-group-by
+           │         ├── columns: array_agg:2(int[])
+           │         ├── project
+           │         │    ├── columns: "?column?":1(int!null)
+           │         │    ├── values
+           │         │    │    └── tuple [type=tuple]
+           │         │    └── projections
+           │         │         └── const: 1 [type=int]
+           │         └── aggregations
+           │              └── array-agg [type=int[]]
+           │                   └── variable: ?column? [type=int]
+           └── array: [type=int[]]
+
+exec-ddl
+CREATE TABLE x (a INT PRIMARY KEY)
+----
+TABLE x
+ ├── a int not null
+ └── INDEX primary
+      └── a int not null
+
+exec-ddl
+CREATE TABLE y (b INT PRIMARY KEY)
+----
+TABLE y
+ ├── b int not null
+ └── INDEX primary
+      └── b int not null
+
+build
+SELECT b, ARRAY(SELECT a FROM x WHERE x.a = y.b) FROM y
+----
+project
+ ├── columns: b:1(int!null) array:4(tuple{int}[])
+ ├── scan y
+ │    └── columns: b:1(int!null)
+ └── projections
+      └── coalesce [type=int[]]
+           ├── subquery [type=int[]]
+           │    └── scalar-group-by
+           │         ├── columns: array_agg:3(int[])
+           │         ├── select
+           │         │    ├── columns: a:2(int!null)
+           │         │    ├── scan x
+           │         │    │    └── columns: a:2(int!null)
+           │         │    └── filters [type=bool]
+           │         │         └── eq [type=bool]
+           │         │              ├── variable: x.a [type=int]
+           │         │              └── variable: y.b [type=int]
+           │         └── aggregations
+           │              └── array-agg [type=int[]]
+           │                   └── variable: x.a [type=int]
+           └── array: [type=int[]]
+
+build
+SELECT b, ARRAY(SELECT a FROM x ORDER BY a) FROM y
+----
+project
+ ├── columns: b:1(int!null) array:4(tuple{int}[])
+ ├── scan y
+ │    └── columns: b:1(int!null)
+ └── projections
+      └── coalesce [type=int[]]
+           ├── subquery [type=int[]]
+           │    └── scalar-group-by
+           │         ├── columns: array_agg:3(int[])
+           │         ├── scan x
+           │         │    ├── columns: a:2(int!null)
+           │         │    └── ordering: +2
+           │         └── aggregations
+           │              └── array-agg [type=int[]]
+           │                   └── variable: x.a [type=int]
+           └── array: [type=int[]]
+
+build
+SELECT ARRAY(VALUES ('foo'), ('bar'), ('baz'))
+----
+project
+ ├── columns: array:3(tuple{string}[])
+ ├── values
+ │    └── tuple [type=tuple]
+ └── projections
+      └── coalesce [type=string[]]
+           ├── subquery [type=string[]]
+           │    └── scalar-group-by
+           │         ├── columns: array_agg:2(string[])
+           │         ├── values
+           │         │    ├── columns: column1:1(string)
+           │         │    ├── tuple [type=tuple{string}]
+           │         │    │    └── const: 'foo' [type=string]
+           │         │    ├── tuple [type=tuple{string}]
+           │         │    │    └── const: 'bar' [type=string]
+           │         │    └── tuple [type=tuple{string}]
+           │         │         └── const: 'baz' [type=string]
+           │         └── aggregations
+           │              └── array-agg [type=string[]]
+           │                   └── variable: column1 [type=string]
+           └── array: [type=string[]]
+
+build
+SELECT ARRAY(VALUES (ARRAY[1]))
+----
+error (0A000): can't build ARRAY(int[])
+
+build
+SELECT ARRAY(SELECT (1, 2))
+----
+error (0A000): can't build ARRAY(tuple{int, int})
+
+build
+SELECT ARRAY(VALUES ((1, 2)))
+----
+error (0A000): can't build ARRAY(tuple{int, int})
+
+build
+SELECT ARRAY(VALUES ('{}'::JSONB))
+----
+error (0A000): arrays of jsonb not allowed
+
+build
+SELECT ARRAY(SELECT 1, 2)
+----
+error (42601): subquery must return only one column, found 2
+
+build
+SELECT ARRAY(SELECT generate_series(1,100) ORDER BY 1 DESC);
+----
+project
+ ├── columns: array:3(tuple{int}[])
+ ├── values
+ │    └── tuple [type=tuple]
+ └── projections
+      └── coalesce [type=int[]]
+           ├── subquery [type=int[]]
+           │    └── scalar-group-by
+           │         ├── columns: array_agg:2(int[])
+           │         ├── sort
+           │         │    ├── columns: column1:1(int)
+           │         │    ├── ordering: -1
+           │         │    └── inner-join-apply
+           │         │         ├── columns: column1:1(int)
+           │         │         ├── values
+           │         │         │    └── tuple [type=tuple]
+           │         │         ├── zip
+           │         │         │    ├── columns: column1:1(int)
+           │         │         │    └── function: generate_series [type=int]
+           │         │         │         ├── const: 1 [type=int]
+           │         │         │         └── const: 100 [type=int]
+           │         │         └── true [type=bool]
+           │         └── aggregations
+           │              └── array-agg [type=int[]]
+           │                   └── variable: column1 [type=int]
+           └── array: [type=int[]]


### PR DESCRIPTION
This commit introduces optbuilder support for array flatten. It doesn't
include the associated required decorrelation to execute correlated
subqueries involving the array flatten operator.

Release note: None