### PR TITLE
ui: enhance the label for distributed execution in the stmt screen

### DIFF
--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -294,7 +294,7 @@ class StatementDetails extends React.Component<StatementDetailsProps, StatementD
                 </td>
               </tr>
               <tr className="numeric-stats-table__row--body">
-                <th className="numeric-stats-table__cell" style={{ textAlign: "left" }}>Used DistSQL?</th>
+                <th className="numeric-stats-table__cell" style={{ textAlign: "left" }}>Distributed execution?</th>
                 <td className="numeric-stats-table__cell" style={{ textAlign: "right" }}>{ renderBools(distSQL) }</td>
               </tr>
               <tr className="numeric-stats-table__row--body">


### PR DESCRIPTION
Fixes #28118.

The notion advertised to users is called "distributed query
execution", not "distsql". This patch changes the label accordingly.

Release note: None