### PR TITLE
roachtest: add ycsb roachtests for workloads A, B, C, and F

### DIFF
--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -50,6 +50,7 @@ func registerTests(r *registry) {
 	registerTPCC(r)
 	registerUpgrade(r)
 	registerVersion(r)
+	registerYCSB(r)
 }
 
 func registerBenchmarks(r *registry) {

--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -1,0 +1,63 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+func registerYCSB(r *registry) {
+	runYCSB := func(ctx context.Context, t *test, c *cluster, wl string) {
+		nodes := c.nodes - 1
+
+		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+		c.Start(ctx, c.Range(1, nodes))
+
+		t.Status("running workload")
+		m := newMonitor(ctx, c, c.Range(1, nodes))
+		m.Go(func(ctx context.Context) error {
+			ramp := " --ramp=" + ifLocal("0s", "1m")
+			duration := " --duration=" + ifLocal("10s", "10m")
+			cmd := fmt.Sprintf(
+				"./workload run ycsb --init --initial-rows=1000000 --splits=100"+
+					" --workload=%s --concurrency=64 --histograms=logs/stats.json"+
+					ramp+duration+" {pgurl:1-%d}",
+				wl, nodes)
+			c.Run(ctx, c.Node(nodes+1), cmd)
+			return nil
+		})
+		m.Wait()
+	}
+
+	for _, wl := range []string{"A", "B", "C", "D", "E", "F"} {
+		if wl == "D" || wl == "E" {
+			// These workloads are currently unsupported by workload.
+			// See TODOs in workload/ycsb/ycsb.go.
+			continue
+		}
+
+		wl := wl
+		r.Add(testSpec{
+			Name:  fmt.Sprintf("ycsb/%s/nodes=3", wl),
+			Nodes: nodes(4),
+			Run: func(ctx context.Context, t *test, c *cluster) {
+				runYCSB(ctx, t, c, wl)
+			},
+		})
+	}
+}

--- a/pkg/workload/ycsb/ycsb.go
+++ b/pkg/workload/ycsb/ycsb.go
@@ -158,7 +158,7 @@ func (g *ycsb) Tables() []workload.Table {
 			func(splitIdx int) []interface{} {
 				w := ycsbWorker{config: g, hashFunc: fnv.New64()}
 				return []interface{}{
-					w.hashKey(uint64(splitIdx)),
+					w.buildKeyName(uint64(splitIdx)),
 				}
 			},
 		),

--- a/pkg/workload/ycsb/ycsb.go
+++ b/pkg/workload/ycsb/ycsb.go
@@ -130,6 +130,8 @@ func (g *ycsb) Hooks() workload.Hooks {
 				return errors.New("Workload E (scans) not implemented yet")
 			case "F", "f":
 				g.insertFreq = 1.0
+			default:
+				return errors.Errorf("Unknown workload: %q", g.workload)
 			}
 			return nil
 		},


### PR DESCRIPTION
This change adds the following four roachtests:
```
ycsb/A/nodes=3
ycsb/B/nodes=3
ycsb/C/nodes=3
ycsb/F/nodes=3
```

These tests are hooked up to output a histogram so that their
stats can be ingested into roachperf. The initialization of the
dataset is quick (~20 seconds), so we can just use `--init`
instead of worrying about importing a fixture.

Workloads D and E are not yet supported by workload, so their
corresponding roachtests are disabled for now.