### PR TITLE
builder: shave some yaks

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20180715-164923
+version=20180731-225910
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"
@@ -59,21 +59,12 @@ cockroach_toplevel=$(dirname "$(cd "$(dirname "${0}")"; pwd)")
 mkdir -p "${cockroach_toplevel}"/artifacts
 export TMPDIR=$cockroach_toplevel/artifacts
 
-# Make a fake passwd file for the invoking user.
-#
-# This setup is so that files created from inside the container in a mounted
-# volume end up being owned by the invoking user and not by root.
-# We'll mount a fresh directory owned by the invoking user as /root inside the
-# container because the container needs a $HOME (without one the default is /)
-# and because various utilities (e.g. bash writing to .bash_history) need to be
-# able to write to there.
-container_home=/root
+# We'll mount a fresh directory owned by the invoking user as the container
+# user's home directory because various utilities (e.g. bash writing to
+# .bash_history) need to be able to write to there.
+container_home=/home/roach
 host_home=${cockroach_toplevel}/build/builder_home
-passwd_file=${host_home}/passwd
-username=$(id -un)
-uid_gid=$(id -u):$(id -g)
 mkdir -p "${host_home}"
-echo "${username}:x:${uid_gid}::${container_home}:/bin/bash" > "${passwd_file}"
 
 # Since we're mounting both /root and its subdirectories in our container,
 # Docker will create the subdirectories on the host side under the directory
@@ -122,7 +113,6 @@ vols=
 # build static binaries in the container and then run them on the host).
 #
 # vols="${vols} --volume=/var/run/docker.sock:/var/run/docker.sock"
-vols="${vols} --volume=${passwd_file}:/etc/passwd${cached_volume_mode}"
 vols="${vols} --volume=${host_home}:${container_home}${cached_volume_mode}"
 
 mkdir -p "${HOME}"/.yarn-cache
@@ -166,7 +156,7 @@ vols="${vols} --volume=${gocache}/docker/pkg:/go/pkg${delegated_volume_mode}"
 
 # shellcheck disable=SC2086
 docker run --privileged -i ${tty-} --rm \
-  -u "${uid_gid}" \
+  -u "$(id -u):$(id -g)" \
   ${vols} \
   --workdir="/go/src/github.com/cockroachdb/cockroach" \
   --env="TMPDIR=/go/src/github.com/cockroachdb/cockroach/artifacts" \

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -61,6 +61,16 @@ RUN mkdir src \
  && mkdir build && (cd build && DEFCONFIG=../aarch64-unknown-linux-gnueabi.defconfig /usr/local/ct-ng/bin/ct-ng defconfig && /usr/local/ct-ng/bin/ct-ng build) && rm -rf build \
  && rm -rf src
 
+RUN mkdir -p /usr/local/lib/ccache \
+ && ln -s /usr/bin/ccache /usr/local/lib/ccache/x86_64-unknown-linux-gnu-cc \
+ && ln -s /usr/bin/ccache /usr/local/lib/ccache/x86_64-unknown-linux-gnu-c++ \
+ && ln -s /usr/bin/ccache /usr/local/lib/ccache/x86_64-unknown-linux-musl-cc \
+ && ln -s /usr/bin/ccache /usr/local/lib/ccache/x86_64-unknown-linux-musl-c++ \
+ && ln -s /usr/bin/ccache /usr/local/lib/ccache/x86_64-w64-mingw32-cc \
+ && ln -s /usr/bin/ccache /usr/local/lib/ccache/x86_64-w64-mingw32-c++ \
+ && ln -s /usr/bin/ccache /usr/local/lib/ccache/aarch64-unknown-linux-gnueabi-cc \
+ && ln -s /usr/bin/ccache /usr/local/lib/ccache/aarch64-unknown-linux-gnueabi-c++
+
 ENV PATH $PATH:/x-tools/x86_64-unknown-linux-gnu/bin:/x-tools/x86_64-unknown-linux-musl/bin:/x-tools/x86_64-w64-mingw32/bin:/x-tools/aarch64-unknown-linux-gnueabi/bin
 
 # Build & install the terminfo lib (incl. in ncurses) for the linux targets (x86 and arm).
@@ -138,6 +148,9 @@ RUN git clone --depth 1 https://github.com/tpoechtrager/osxcross.git \
  && mv osxcross/target /x-tools/x86_64-apple-darwin13 \
  && rm -rf osxcross
 
+RUN ln -s /usr/bin/ccache /usr/local/lib/ccache/x86_64-apple-darwin13-cc \
+ && ln -s /usr/bin/ccache /usr/local/lib/ccache/x86_64-apple-darwin13-c++
+
 ENV PATH $PATH:/x-tools/x86_64-apple-darwin13/bin
 
 # Compile Go from source so that CC defaults to clang instead of gcc. This
@@ -194,11 +207,6 @@ RUN apt-get install -y --no-install-recommends \
     yarn \
     google-chrome-stable
 
-# Without CCACHE_CPP2=1, ccache can generate spurious warnings. See the manpage
-# for details. This option is enabled by default in ccache v3.3+, but our
-# version of Ubuntu ships v3.2.4.
-ENV CCACHE_CPP2=1
-
 ENV PATH /opt/backtrace/bin:$PATH
 
 RUN apt-get purge -y \
@@ -218,3 +226,7 @@ RUN apt-get purge -y \
 RUN rm -rf /tmp/* /var/lib/apt/lists/*
 
 RUN ln -s /go/src/github.com/cockroachdb/cockroach/build/builder/mkrelease.sh /usr/local/bin/mkrelease
+
+COPY entrypoint.sh /usr/local/bin
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -227,6 +227,9 @@ RUN rm -rf /tmp/* /var/lib/apt/lists/*
 
 RUN ln -s /go/src/github.com/cockroachdb/cockroach/build/builder/mkrelease.sh /usr/local/bin/mkrelease
 
+RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.1.0/autouseradd-1.1.0-amd64.tar.gz \
+    | tar xz -C /usr --strip-components 1
+
 COPY entrypoint.sh /usr/local/bin
 
-ENTRYPOINT ["entrypoint.sh"]
+ENTRYPOINT ["autouseradd", "--user", "roach", "--no-create-home", "--", "entrypoint.sh"]

--- a/build/builder/entrypoint.sh
+++ b/build/builder/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -n "${COCKROACH_BUILDER_CCACHE-}" ]]; then
+  PATH=/usr/lib/ccache:/usr/local/lib/ccache:$PATH
+  export CCACHE_DIR=/go/native/ccache
+  export CCACHE_MAXSIZE=${COCKROACH_BUILDER_CCACHE_MAXSIZE-10G}
+  # Without CCACHE_CPP2=1, ccache can generate spurious warnings. See the manpage
+  # for details. This option is enabled by default in ccache v3.3+, but our
+  # version Ubuntu 16.04 ships v3.2.4.
+  # TODO(benesch): Remove when we upgrade to Ubuntu 18.04 or newer.
+  export CCACHE_CPP2=1
+fi
+
+exec "${@-$SHELL}"


### PR DESCRIPTION
Teach the builder to ccache release builds. I think there's a good chance that this speeds up acceptance test runs by a few minutes when the cache is warm. While I'm here, shave an /etc/passwd yak that I've been meaning to fix for a while.