### PR TITLE
client: delete stale comment

### DIFF
--- a/pkg/internal/client/client_test.go
+++ b/pkg/internal/client/client_test.go
@@ -879,9 +879,6 @@ func TestReadOnlyTxnObeysDeadline(t *testing.T) {
 	}
 	if err := txn.Commit(ctx); !testutils.IsError(
 		err, "deadline exceeded before transaction finalization") {
-		// We test for TransactionAbortedError. If this was not a read-only txn,
-		// the error returned by the server would have been different - a
-		// TransactionStatusError. This inconsistency is unfortunate.
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
There used to be a discrepancy between deadline exceeded errors detected
on the server side and those detected on the client side for elided
EndTransaction requests. No longer since #21140.

Release note: None