### PR TITLE
storage: truncate log only between first index and truncate index

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -71,11 +71,15 @@ var (
 	// been down without needing to retrieve liveness records from the cluster.
 	localStoreLastUpSuffix = []byte("uptm")
 	// localHLCUpperBoundSuffix stores an upper bound to the wall time used by
-	// the HLC
+	// the HLC.
 	localHLCUpperBoundSuffix = []byte("hlcu")
 	// localStoreSuggestedCompactionSuffix stores suggested compactions to
 	// be aggregated and processed on the store.
 	localStoreSuggestedCompactionSuffix = []byte("comp")
+	// localRemovedLeakedRaftEntriesSuffix marks that a store has completed
+	// its migration to remove all possibly-leaked Raft entries.
+	// TODO(nvanbenschoten): This can be removed in 2.2.
+	localRemovedLeakedRaftEntriesSuffix = []byte("dlre")
 
 	// LocalStoreSuggestedCompactionsMin is the start of the span of
 	// possible suggested compaction keys for a store.

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -75,8 +75,8 @@ func StoreLastUpKey() roachpb.Key {
 	return MakeStoreKey(localStoreLastUpSuffix, nil)
 }
 
-// StoreHLCUpperBoundKey returns the key for storing an upper bound to the
-// wall time used by HLC
+// StoreHLCUpperBoundKey returns the store-local key for storing an upper bound
+// to the wall time used by HLC.
 func StoreHLCUpperBoundKey() roachpb.Key {
 	return MakeStoreKey(localHLCUpperBoundSuffix, nil)
 }
@@ -113,6 +113,13 @@ func DecodeStoreSuggestedCompactionKey(key roachpb.Key) (start, end roachpb.Key,
 		return nil, nil, errors.Errorf("invalid key has trailing garbage: %q", detail)
 	}
 	return start, end, nil
+}
+
+// StoreRemovedLeakedRaftEntriesKey returns a store-local key that marks
+// when a store has completed its migration to remove all possibly-leaked
+// Raft entries on all replicas.
+func StoreRemovedLeakedRaftEntriesKey() roachpb.Key {
+	return MakeStoreKey(localRemovedLeakedRaftEntriesSuffix, nil)
 }
 
 // NodeLivenessKey returns the key for the node liveness record.

--- a/pkg/storage/batcheval/cmd_truncate_log.go
+++ b/pkg/storage/batcheval/cmd_truncate_log.go
@@ -54,7 +54,8 @@ func TruncateLog(
 	// After a merge, it's possible that this request was sent to the wrong
 	// range based on the start key. This will cancel the request if this is not
 	// the range specified in the request body.
-	if cArgs.EvalCtx.GetRangeID() != args.RangeID {
+	rangeID := cArgs.EvalCtx.GetRangeID()
+	if rangeID != args.RangeID {
 		log.Infof(ctx, "attempting to truncate raft logs for another range: r%d. Normally this is due to a merge and can be ignored.",
 			args.RangeID)
 		return result.Result{}, nil
@@ -83,16 +84,14 @@ func TruncateLog(
 	// We start at index zero because it's always possible that a previous
 	// truncation did not clean up entries made obsolete by the previous
 	// truncation.
-	start := engine.MakeMVCCMetadataKey(keys.RaftLogKey(cArgs.EvalCtx.GetRangeID(), 0))
-	end := engine.MakeMVCCMetadataKey(keys.RaftLogKey(cArgs.EvalCtx.GetRangeID(), args.Index))
+	start := engine.MakeMVCCMetadataKey(keys.RaftLogKey(rangeID, 0))
+	end := engine.MakeMVCCMetadataKey(keys.RaftLogKey(rangeID, args.Index).PrefixEnd())
 
 	var ms enginepb.MVCCStats
 	if cArgs.EvalCtx.ClusterSettings().Version.IsActive(cluster.VersionRaftLogTruncationBelowRaft) {
 		// Compute the stats delta that were to occur should the log entries be
 		// purged. We do this as a side effect of seeing a new TruncatedState,
-		// downstream of Raft. A follower may not run the side effect in the event
-		// of an ill-timed crash, but that's OK since the next truncation will get
-		// everything.
+		// downstream of Raft.
 		//
 		// Note that any sideloaded payloads that may be removed by this truncation
 		// don't matter; they're not tracked in the raft log delta.

--- a/pkg/storage/batcheval/cmd_truncate_log.go
+++ b/pkg/storage/batcheval/cmd_truncate_log.go
@@ -81,10 +81,7 @@ func TruncateLog(
 		return result.Result{}, err
 	}
 
-	// We start at index zero because it's always possible that a previous
-	// truncation did not clean up entries made obsolete by the previous
-	// truncation.
-	start := engine.MakeMVCCMetadataKey(keys.RaftLogKey(rangeID, 0))
+	start := engine.MakeMVCCMetadataKey(keys.RaftLogKey(rangeID, firstIndex))
 	end := engine.MakeMVCCMetadataKey(keys.RaftLogKey(rangeID, args.Index).PrefixEnd())
 
 	var ms enginepb.MVCCStats

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5714,22 +5714,22 @@ func (r *Replica) applyRaftCommand(
 			// TruncatedState index is always consistent with the state of the
 			// Raft log itself. We can use the distinct writer because we know
 			// all writes will be to distinct keys.
-			start := engine.MakeMVCCMetadataKey(
-				keys.RaftLogKey(r.RangeID, oldTruncatedState.Index+1),
-			)
-			end := engine.MakeMVCCMetadataKey(
-				keys.RaftLogKey(r.RangeID, newTruncatedState.Index).PrefixEnd(),
-			)
-			// Clear the log entries. Intentionally don't use range deletion
-			// tombstones (ClearRange()) due to performance concerns connected
-			// to having many range deletion tombstones. There is a chance that
-			// ClearRange will perform well here because the tombstones could be
-			// "collapsed", but it is hardly worth the risk at this point.
-			iter := r.store.Engine().NewIterator(engine.IterOptions{UpperBound: end.Key})
-			if err := writer.ClearIterRange(iter, start, end); err != nil {
-				log.Errorf(ctx, "unable to clear truncated Raft entries for %+v: %s", rResult.State.TruncatedState, err)
+			//
+			// Intentionally don't use range deletion tombstones (ClearRange())
+			// due to performance concerns connected to having many range
+			// deletion tombstones. There is a chance that ClearRange will
+			// perform well here because the tombstones could be "collapsed",
+			// but it is hardly worth the risk at this point.
+			prefixBuf := &r.raftMu.stateLoader.RangeIDPrefixBuf
+			for idx := oldTruncatedState.Index + 1; idx <= newTruncatedState.Index; idx++ {
+				// NB: RangeIDPrefixBufs have sufficient capacity (32 bytes) to
+				// avoid allocating when constructing Raft log keys (16 bytes).
+				unsafeKey := prefixBuf.RaftLogKey(idx)
+				if err := writer.Clear(engine.MakeMVCCMetadataKey(unsafeKey)); err != nil {
+					err = errors.Wrapf(err, "unable to clear truncated Raft entries for %+v", newTruncatedState)
+					return enginepb.MVCCStats{}, err
+				}
 			}
-			iter.Close()
 		}
 	}
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5615,6 +5615,7 @@ func (r *Replica) applyRaftCommand(
 	usingAppliedStateKey := r.mu.state.UsingAppliedStateKey
 	oldRaftAppliedIndex := r.mu.state.RaftAppliedIndex
 	oldLeaseAppliedIndex := r.mu.state.LeaseAppliedIndex
+	oldTruncatedState := r.mu.state.TruncatedState
 
 	// Exploit the fact that a split will result in a full stats
 	// recomputation to reset the ContainsEstimates flag.
@@ -5700,6 +5701,35 @@ func (r *Replica) applyRaftCommand(
 		ms.Add(deltaStats)
 		if err := r.raftMu.stateLoader.SetMVCCStats(ctx, writer, &ms); err != nil {
 			return enginepb.MVCCStats{}, errors.Wrap(err, "unable to update MVCCStats")
+		}
+	}
+
+	if rResult.State != nil && rResult.State.TruncatedState != nil {
+		newTruncatedState := rResult.State.TruncatedState
+
+		if r.store.cfg.Settings.Version.IsActive(cluster.VersionRaftLogTruncationBelowRaft) {
+			// Truncate the Raft log from the entry after the previous
+			// truncation index to the new truncation index. This is performed
+			// atomically with the raft command application so that the
+			// TruncatedState index is always consistent with the state of the
+			// Raft log itself. We can use the distinct writer because we know
+			// all writes will be to distinct keys.
+			start := engine.MakeMVCCMetadataKey(
+				keys.RaftLogKey(r.RangeID, oldTruncatedState.Index+1),
+			)
+			end := engine.MakeMVCCMetadataKey(
+				keys.RaftLogKey(r.RangeID, newTruncatedState.Index).PrefixEnd(),
+			)
+			// Clear the log entries. Intentionally don't use range deletion
+			// tombstones (ClearRange()) due to performance concerns connected
+			// to having many range deletion tombstones. There is a chance that
+			// ClearRange will perform well here because the tombstones could be
+			// "collapsed", but it is hardly worth the risk at this point.
+			iter := r.store.Engine().NewIterator(engine.IterOptions{UpperBound: end.Key})
+			if err := writer.ClearIterRange(iter, start, end); err != nil {
+				log.Errorf(ctx, "unable to clear truncated Raft entries for %+v: %s", rResult.State.TruncatedState, err)
+			}
+			iter.Close()
 		}
 	}
 

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -323,6 +323,15 @@ func (r *Replica) raftTruncatedStateLocked(
 	return ts, nil
 }
 
+// raftTruncatedState returns metadata about the log that preceded the first
+// current entry. This includes both entries that have been compacted away and
+// the dummy entries that make up the starting point of an empty log.
+func (r *Replica) raftTruncatedState(ctx context.Context) (roachpb.RaftTruncatedState, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.raftTruncatedStateLocked(ctx)
+}
+
 // FirstIndex implements the raft.Storage interface.
 func (r *replicaRaftStorage) FirstIndex() (uint64, error) {
 	ctx := r.AnnotateCtx(context.TODO())

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -271,17 +272,22 @@ func (e *NotBootstrappedError) Error() string {
 }
 
 // A storeReplicaVisitor calls a visitor function for each of a store's
-// initialized Replicas (in unspecified order).
+// initialized Replicas (in unspecified order). It provides an option
+// to visit replicas in increasing RangeID order.
 type storeReplicaVisitor struct {
 	store   *Store
-	repls   []*Replica // Replicas to be visited.
+	repls   []*Replica // Replicas to be visited
+	ordered bool       // Option to visit replicas in sorted order
 	visited int        // Number of visited ranges, -1 before first call to Visit()
 }
 
-// Len implements shuffle.Interface.
+// Len implements sort.Interface.
 func (rs storeReplicaVisitor) Len() int { return len(rs.repls) }
 
-// Swap implements shuffle.Interface.
+// Less implements sort.Interface.
+func (rs storeReplicaVisitor) Less(i, j int) bool { return rs.repls[i].RangeID < rs.repls[j].RangeID }
+
+// Swap implements sort.Interface.
 func (rs storeReplicaVisitor) Swap(i, j int) { rs.repls[i], rs.repls[j] = rs.repls[j], rs.repls[i] }
 
 // newStoreReplicaVisitor constructs a storeReplicaVisitor.
@@ -290,6 +296,12 @@ func newStoreReplicaVisitor(store *Store) *storeReplicaVisitor {
 		store:   store,
 		visited: -1,
 	}
+}
+
+// InOrder tells the visitor to visit replicas in increasing RangeID order.
+func (rs *storeReplicaVisitor) InOrder() *storeReplicaVisitor {
+	rs.ordered = true
+	return rs
 }
 
 // Visit calls the visitor with each Replica until false is returned.
@@ -303,15 +315,20 @@ func (rs *storeReplicaVisitor) Visit(visitor func(*Replica) bool) {
 		return true
 	})
 
-	// The Replicas are already in "unspecified order" due to map iteration,
-	// but we want to make sure it's completely random to prevent issues in
-	// tests where stores are scanning replicas in lock-step and one store is
-	// winning the race and getting a first crack at processing the replicas on
-	// its queues.
-	//
-	// TODO(peter): Re-evaluate whether this is necessary after we allow
-	// rebalancing away from the leaseholder. See TestRebalance_3To5Small.
-	shuffle.Shuffle(rs)
+	if rs.ordered {
+		// If the replicas were requested in sorted order, perform the sort.
+		sort.Sort(rs)
+	} else {
+		// The Replicas are already in "unspecified order" due to map iteration,
+		// but we want to make sure it's completely random to prevent issues in
+		// tests where stores are scanning replicas in lock-step and one store is
+		// winning the race and getting a first crack at processing the replicas on
+		// its queues.
+		//
+		// TODO(peter): Re-evaluate whether this is necessary after we allow
+		// rebalancing away from the leaseholder. See TestRebalance_3To5Small.
+		shuffle.Shuffle(rs)
+	}
 
 	rs.visited = 0
 	for _, repl := range rs.repls {
@@ -1452,6 +1469,15 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		})
 	if err != nil {
 		return err
+	}
+
+	// Ensure that no Raft entries were abandoned by previous versions of Cockroach
+	// that did not delete Raft entries atomically with applying log truncation
+	// Raft commands. This will only be performed once, after which this call will
+	// see a migration marker and quickly no-op.
+	err = removeLeakedRaftEntries(ctx, s.Clock(), s.engine, newStoreReplicaVisitor(s))
+	if err != nil {
+		return errors.Wrapf(err, "checking for leaked raft entries for %v", s.engine)
 	}
 
 	// Start Raft processing goroutines.


### PR DESCRIPTION
### Question

Raft log truncations currently perform two steps (there may be
others, but for the sake of this discussion, let's consider only
these two):
1. above raft, they compute the stats of all raft log entries up
   to the truncation entry.
2. beneath raft, they use ClearIterRange to clear all raft log
   entries up to the truncation entry.

In both steps, operations are performed on all entries up to the
truncation entry, and in both steps these operations start from
entry 0. A comment added in #16993 gives some idea as to why:

> // We start at index zero because it's always possible that a previous
> // truncation did not clean up entries made obsolete by the previous
> // truncation.

My current understanding is that this case where a Raft log has
been truncated but its entries not cleaned up is only possible if
a node crashes between `applyRaftCommand` and `handleEvalResultRaftMuLocked`.
This brings up the question: why don't we truncate raft entries
downstream of raft in `applyRaftCommand`? That way, the entries
could be deleted atomically with the update to the `RaftTruncatedStateKey`
and we wouldn't have to worry about them ever diverging or Raft entries
being leaked. That seems like a trivial change, and if that was the
case, would the approach here be safe? I don't see a reason why
not.

### Motivation

For motivation on why we should explore this, I've found that when
running `sysbench oltp_insert` on a fresh cluster without pre-splits to
measure single range write through, raft log truncation accounts for
about **20%** of CPU utilization.

<img width="1272" alt="truncate" src="https://user-images.githubusercontent.com/5438456/43502846-bb7a98d2-952a-11e8-9ba0-0b886d3e3ad9.png">

If we switch the ClearIterRange to a ClearRange downstream of raft,
we improve throughput by **13%** and reduce the amount of CPU that raft
log truncation uses to about **5%**. It's obvious why this speeds up the
actual truncation itself downstream of raft. The reason why it speeds
up the stats computation is less clear, but it may be allowing a RocksDB
iterator to more easily skip over the deleted entry keys.

If we make the change proposed here, we improve throughput by **28%** and
reduce the amount of CPU that raft log truncation uses to a negligible
amount (**< 1%**, hard to tell exactly). The reason this speeds both the
truncation and the stats computation is because it avoids iterating
over RocksDB tombstones for all Raft entries that have ever existed
on the range.

The throughput improvements are of course exaggerated because we are
isolating the throughput of a single range, but they're significant
enough to warrant exploration about whether we can make this approach
work.

### Extension

Finally, the outsized impact of this small change naturally justifies
further exploration. If we could make the change here safe (i.e. if we
could depend on replica.FirstIndex() to always be a lower bound on raft
log entry keys), could we make similar changes elsewhere? Are there
other places where we iterate over an entire raft log keyspace and
inadvertently run into all of the deletion tombstones when we could
simply skip to the `replica.FirstIndex()`? At a minimum, I believe
that `clearRangeData` fits this description, so there may be room to
speed up snapshots and replica GC.

cc. @tschottdorf @petermattis @benesch