### PR TITLE
workload/tpcc: fix worker's interaction with context cancellation

### DIFF
--- a/pkg/workload/tpcc/new_order.go
+++ b/pkg/workload/tpcc/new_order.go
@@ -219,6 +219,9 @@ func (n newOrder) run(
 				iData := &iDatas[i]
 
 				if !rows.Next() {
+					if err := rows.Err(); err != nil {
+						return err
+					}
 					if rollback {
 						// 2.4.2.3: roll back when we're expecting a rollback due to
 						// simulated user error (invalid item id) and we actually
@@ -268,6 +271,9 @@ func (n newOrder) run(
 				item := &d.items[i]
 
 				if !rows.Next() {
+					if err := rows.Err(); err != nil {
+						return err
+					}
 					return errors.New("missing stock row")
 				}
 


### PR DESCRIPTION
This change fixes two issues that tpcc was running into with
context cancellation, which it now needs to deal with thanks
to #27344:

1. workers should still wait out their keying and think time
   when their context has been cancelled. If they don't, we
   risk all workers restarting at once when the ramp period
   finishes and overloading a cluster.
2. newOrder should correctly handle context cancellation errors
   that it previously mistook for missing item or stock rows.

Release note: None