### PR TITLE
security: fix rotation test flakiness.

### DIFF
--- a/pkg/security/certs_rotation_test.go
+++ b/pkg/security/certs_rotation_test.go
@@ -228,17 +228,15 @@ func TestRotateCerts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Wait until client3 succeeds.
+	// Wait until client3 succeeds (both http and sql).
 	testutils.SucceedsSoon(t,
 		func() error {
 			if err := clientTest(thirdClient); err != nil {
-				return errors.Errorf("third client failed: %v", err)
+				return errors.Errorf("third HTTP client failed: %v", err)
+			}
+			if _, err := thirdSQLClient.Exec("SELECT 1"); err != nil {
+				return errors.Errorf("third SQL client failed: %v", err)
 			}
 			return nil
 		})
-
-	// SQL client 3 should also succeed.
-	if _, err := thirdSQLClient.Exec("SELECT 1"); err != nil {
-		t.Fatal(err)
-	}
 }


### PR DESCRIPTION
Fixes #28125

Move the sql client test success condition into the "SucceedsSoon" loop,
this was failing occasionally on stress tests. We're relying on the go
sql package trying the connection again after a failure, it doesn't seem
to be as guaranteed as expected.

Release note: None