### PR TITLE
distsql: reduce allocations in tableReader

### DIFF
--- a/pkg/sql/distsqlrun/scrub_tablereader.go
+++ b/pkg/sql/distsqlrun/scrub_tablereader.go
@@ -45,6 +45,7 @@ var ScrubTypes = []sqlbase.ColumnType{
 
 type scrubTableReader struct {
 	tableReader
+	tableDesc sqlbase.TableDescriptor
 	// fetcherResultToColIdx maps RowFetcher results to the column index in
 	// the TableDescriptor. This is only initialized and used during scrub
 	// physical checks.

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -34,7 +34,6 @@ import (
 type tableReader struct {
 	processorBase
 
-	tableDesc sqlbase.TableDescriptor
 	spans     roachpb.Spans
 	limitHint int64
 
@@ -63,9 +62,7 @@ func newTableReader(
 		return nil, errors.Errorf("attempting to create a tableReader with uninitialized NodeID")
 	}
 
-	tr := &tableReader{
-		tableDesc: spec.Table,
-	}
+	tr := &tableReader{}
 
 	tr.limitHint = limitHint(spec.LimitHint, post)
 
@@ -96,7 +93,7 @@ func newTableReader(
 	neededColumns := tr.out.neededColumns()
 
 	if _, _, err := initRowFetcher(
-		&tr.fetcher, &tr.tableDesc, int(spec.IndexIdx), tr.tableDesc.ColumnIdxMap(), spec.Reverse,
+		&tr.fetcher, &spec.Table, int(spec.IndexIdx), spec.Table.ColumnIdxMap(), spec.Reverse,
 		neededColumns, spec.IsCheck, &tr.alloc,
 	); err != nil {
 		return nil, err


### PR DESCRIPTION
The tableReader had an unused tableDesc field that was resulting in
allocating more than necessary. BenchmarkFlowSetup shows a reduction
of flat allocations from 23.73MB to 15.82MB for a run of the benchmark.

Release note: None