### PR TITLE
libroach: rotate data encryption keys while running.

### DIFF
--- a/c-deps/libroach/ccl/ctr_stream.cc
+++ b/c-deps/libroach/ccl/ctr_stream.cc
@@ -47,8 +47,7 @@ rocksdb::Status CTRCipherStreamCreator::InitSettingsAndCreateCipherStream(
     memcpy(&counter, random_bytes.data() + 12, 4);
     enc_settings.set_counter(counter);
 
-    result->reset(
-        new CTRCipherStream(std::move(key), enc_settings.nonce(), enc_settings.counter()));
+    result->reset(new CTRCipherStream(key, enc_settings.nonce(), enc_settings.counter()));
   }
 
   // Serialize enc_settings directly into the passed settings pointer. This will be ignored
@@ -81,15 +80,15 @@ rocksdb::Status CTRCipherStreamCreator::CreateCipherStreamFromSettings(
         "key_manager does not have a key with ID %s", enc_settings.key_id().c_str()));
   }
 
-  result->reset(new CTRCipherStream(std::move(key), enc_settings.nonce(), enc_settings.counter()));
+  result->reset(new CTRCipherStream(key, enc_settings.nonce(), enc_settings.counter()));
   return rocksdb::Status::OK();
 }
 
 enginepb::EnvType CTRCipherStreamCreator::GetEnvType() { return env_type_; }
 
-CTRCipherStream::CTRCipherStream(std::unique_ptr<enginepbccl::SecretKey> key,
+CTRCipherStream::CTRCipherStream(std::shared_ptr<enginepbccl::SecretKey> key,
                                  const std::string& nonce, uint32_t counter)
-    : key_(std::move(key)), nonce_(nonce), counter_(counter) {}
+    : key_(key), nonce_(nonce), counter_(counter) {}
 
 CTRCipherStream::~CTRCipherStream() {}
 

--- a/c-deps/libroach/ccl/ctr_stream.h
+++ b/c-deps/libroach/ccl/ctr_stream.h
@@ -46,7 +46,7 @@ class CTRCipherStream final : public rocksdb_utils::BlockAccessCipherStream {
   // - a block cipher (takes ownership)
   // - nonce of size 'cipher.BlockSize - sizeof(counter)' (eg: 16-4 = 12 bytes for AES)
   // - counter
-  CTRCipherStream(std::unique_ptr<enginepbccl::SecretKey> key, const std::string& nonce,
+  CTRCipherStream(std::shared_ptr<enginepbccl::SecretKey> key, const std::string& nonce,
                   uint32_t counter);
   virtual ~CTRCipherStream();
 
@@ -67,7 +67,7 @@ class CTRCipherStream final : public rocksdb_utils::BlockAccessCipherStream {
                                        char* data, char* scratch) const override;
 
  private:
-  const std::unique_ptr<enginepbccl::SecretKey> key_;
+  const std::shared_ptr<enginepbccl::SecretKey> key_;
   const std::string nonce_;
   const uint32_t counter_;
 };

--- a/c-deps/libroach/ccl/db_test.cc
+++ b/c-deps/libroach/ccl/db_test.cc
@@ -227,6 +227,7 @@ TEST_F(CCLTest, EncryptionStats) {
 
     cockroach::ccl::baseccl::EncryptionOptions enc_opts;
     enc_opts.set_key_source(cockroach::ccl::baseccl::KeyFiles);
+    enc_opts.set_data_key_rotation_period(3600);
     enc_opts.mutable_key_files()->set_current_key(dir.Path("aes-128.key"));
     enc_opts.mutable_key_files()->set_old_key("plain");
 

--- a/c-deps/libroach/ccl/testutils.cc
+++ b/c-deps/libroach/ccl/testutils.cc
@@ -47,16 +47,16 @@ rocksdb::Status WriteAES128KeyFile(rocksdb::Env* env, const std::string& filenam
 
 MemKeyManager::~MemKeyManager() {}
 
-std::unique_ptr<enginepbccl::SecretKey> MemKeyManager::CurrentKey() {
+std::shared_ptr<enginepbccl::SecretKey> MemKeyManager::CurrentKey() {
   if (key_ != nullptr) {
-    return std::unique_ptr<enginepbccl::SecretKey>(new enginepbccl::SecretKey(*key_.get()));
+    return std::shared_ptr<enginepbccl::SecretKey>(new enginepbccl::SecretKey(*key_.get()));
   }
   return nullptr;
 }
 
-std::unique_ptr<enginepbccl::SecretKey> MemKeyManager::GetKey(const std::string& id) {
+std::shared_ptr<enginepbccl::SecretKey> MemKeyManager::GetKey(const std::string& id) {
   if (key_ != nullptr && key_->info().key_id() == id) {
-    return std::unique_ptr<enginepbccl::SecretKey>(new enginepbccl::SecretKey(*key_.get()));
+    return std::shared_ptr<enginepbccl::SecretKey>(new enginepbccl::SecretKey(*key_.get()));
   }
   return nullptr;
 }

--- a/c-deps/libroach/ccl/testutils.h
+++ b/c-deps/libroach/ccl/testutils.h
@@ -36,8 +36,8 @@ class MemKeyManager : public KeyManager {
   explicit MemKeyManager(enginepbccl::SecretKey* key) : key_(key) {}
   virtual ~MemKeyManager();
 
-  virtual std::unique_ptr<enginepbccl::SecretKey> CurrentKey() override;
-  virtual std::unique_ptr<enginepbccl::SecretKey> GetKey(const std::string& id) override;
+  virtual std::shared_ptr<enginepbccl::SecretKey> CurrentKey() override;
+  virtual std::shared_ptr<enginepbccl::SecretKey> GetKey(const std::string& id) override;
 
   // Replace the key with the passed-in one. Takes ownership.
   void set_key(enginepbccl::SecretKey* key);

--- a/c-deps/libroach/testutils.h
+++ b/c-deps/libroach/testutils.h
@@ -47,6 +47,7 @@ class FakeTimeEnv : public rocksdb::EnvWrapper {
   }
 
   void SetCurrentTime(int64_t t) { fake_time_ = t; };
+  void IncCurrentTime(int64_t t) { fake_time_ += t; };
 
  private:
   int64_t fake_time_;


### PR DESCRIPTION
* use shared_ptr for keys in key manager
* keep active date key as member
* regenerate data key if needed when asked for

Release note (enterprise change): rotate encryption keys while running