### PR TITLE
sql: avoid using Tuple in RangePartition

### DIFF
--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -186,12 +186,12 @@ func createPartitioningImpl(
 		}
 		var err error
 		p.FromInclusive, err = valueEncodePartitionTuple(
-			tree.PartitionByRange, evalCtx, r.From, cols)
+			tree.PartitionByRange, evalCtx, &tree.Tuple{Exprs: r.From}, cols)
 		if err != nil {
 			return partDesc, errors.Wrapf(err, "PARTITION %s", p.Name)
 		}
 		p.ToExclusive, err = valueEncodePartitionTuple(
-			tree.PartitionByRange, evalCtx, r.To, cols)
+			tree.PartitionByRange, evalCtx, &tree.Tuple{Exprs: r.To}, cols)
 		if err != nil {
 			return partDesc, errors.Wrapf(err, "PARTITION %s", p.Name)
 		}

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3721,8 +3721,8 @@ range_partition:
   {
     $$.val = tree.RangePartition{
       Name: tree.UnrestrictedName($1),
-      From: &tree.Tuple{Exprs: $5.exprs()},
-      To: &tree.Tuple{Exprs: $9.exprs()},
+      From: $5.exprs(),
+      To: $9.exprs(),
       Subpartition: $11.partitionBy(),
     }
   }

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -816,8 +816,8 @@ func (node *ListPartition) Format(ctx *FmtCtx) {
 // RangePartition represents a PARTITION definition within a PARTITION BY RANGE.
 type RangePartition struct {
 	Name         UnrestrictedName
-	From         Expr
-	To           Expr
+	From         Exprs
+	To           Exprs
 	Subpartition *PartitionBy
 }
 
@@ -825,10 +825,11 @@ type RangePartition struct {
 func (node *RangePartition) Format(ctx *FmtCtx) {
 	ctx.WriteString(`PARTITION `)
 	ctx.FormatNode(&node.Name)
-	ctx.WriteString(` VALUES FROM `)
-	ctx.FormatNode(node.From)
-	ctx.WriteString(` TO `)
-	ctx.FormatNode(node.To)
+	ctx.WriteString(` VALUES FROM (`)
+	ctx.FormatNode(&node.From)
+	ctx.WriteString(`) TO (`)
+	ctx.FormatNode(&node.To)
+	ctx.WriteByte(')')
 	if node.Subpartition != nil {
 		ctx.FormatNode(node.Subpartition)
 	}


### PR DESCRIPTION
Forked off  #28143, needed for #25522 / #26624.

The `Tuple` AST node is really for scalar tuples. RangePartition is
not using a scalar tuple. So split them.

Release note: None