### PR TITLE
sql: fix the pg text representation of tuples/arrays

### DIFF
--- a/pkg/sql/lex/encode.go
+++ b/pkg/sql/lex/encode.go
@@ -28,7 +28,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"unicode"
 	"unicode/utf8"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -128,24 +127,6 @@ func EncodeSQLStringWithFlags(buf *bytes.Buffer, in string, flags EncodeFlags) {
 	if escapedString || quote {
 		buf.WriteByte('\'')
 	}
-}
-
-// EncodeSQLStringInsideArray writes a string literal to buf using the "string
-// within array" formatting.
-func EncodeSQLStringInsideArray(buf *bytes.Buffer, in string) {
-	buf.WriteByte('"')
-	// Loop through each unicode code point.
-	for i, r := range in {
-		ch := byte(r)
-		if unicode.IsPrint(r) && !stringencoding.NeedEscape(ch) && ch != '"' {
-			// Character is printable doesn't need escaping - just print it out.
-			buf.WriteRune(r)
-		} else {
-			stringencoding.EncodeEscapedChar(buf, in, r, ch, i, '"')
-		}
-	}
-
-	buf.WriteByte('"')
 }
 
 // EncodeUnrestrictedSQLIdent writes the identifier in s to buf.

--- a/pkg/sql/lex/encode_test.go
+++ b/pkg/sql/lex/encode_test.go
@@ -86,16 +86,9 @@ func testEncodeString(t *testing.T, input []byte, encode func(*bytes.Buffer, str
 
 func BenchmarkEncodeSQLString(b *testing.B) {
 	str := strings.Repeat("foo", 10000)
-	b.Run("old version", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			lex.EncodeSQLStringWithFlags(bytes.NewBuffer(nil), str, lex.EncBareStrings)
-		}
-	})
-	b.Run("new version", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			lex.EncodeSQLStringInsideArray(bytes.NewBuffer(nil), str)
-		}
-	})
+	for i := 0; i < b.N; i++ {
+		lex.EncodeSQLStringWithFlags(bytes.NewBuffer(nil), str, lex.EncBareStrings)
+	}
 }
 
 func TestEncodeRestrictedSQLIdent(t *testing.T) {

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -76,7 +76,7 @@ SELECT ARRAY['one', 'two', 'fünf']
 query T
 SELECT ARRAY[e'\n', e'g\x10h']
 ----
-{"\n","g\x10h"}
+{"\x0a","g\x10h"}
 
 query T
 SELECT ARRAY['foo', 'bar']
@@ -582,10 +582,10 @@ query T rowsort
 SELECT b FROM a
 ----
 {}
-{true}
-{false}
-{true,true}
-{false,true}
+{t}
+{f}
+{t,t}
+{f,t}
 
 statement ok
 DROP TABLE a

--- a/pkg/sql/logictest/testdata/logic_test/orms
+++ b/pkg/sql/logictest/testdata/logic_test/orms
@@ -68,9 +68,9 @@ GROUP BY i.relname,
          ix.indkey
 ORDER BY i.relname
 ----
-name              primary  unique  indkey  column_indexes  column_names   definition
-customers_id_idx  false    false   2       {1,2}           {"name","id"}  CREATE INDEX customers_id_idx ON test.public.customers (id ASC)
-primary           true     true    1       {1,2}           {"name","id"}  CREATE UNIQUE INDEX "primary" ON test.public.customers (name ASC)
+name              primary  unique  indkey  column_indexes  column_names  definition
+customers_id_idx  false    false   2       {1,2}           {name,id}     CREATE INDEX customers_id_idx ON test.public.customers (id ASC)
+primary           true     true    1       {1,2}           {name,id}     CREATE UNIQUE INDEX "primary" ON test.public.customers (name ASC)
 
 
 query TT colnames

--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -284,13 +284,13 @@ query TTT colnames
 SELECT 'a' AS a, pg_get_keywords(), 'c' AS c LIMIT 1
 ----
 a  pg_get_keywords             c
-a  ('abort','U','unreserved')  c
+a  ("abort","U","unreserved")  c
 
 query TTT colnames
 SELECT 'a' AS a, pg_get_keywords() AS b, 'c' AS c LIMIT 1
 ----
 a  b                           c
-a  ('abort','U','unreserved')  c
+a  ("abort","U","unreserved")  c
 
 subtest unary_table
 
@@ -387,7 +387,7 @@ query T colnames
 SELECT information_schema._pg_expandarray(ARRAY['a'])
 ----
 information_schema._pg_expandarray
-('a',1)
+("a",1)
 
 query TI colnames
 SELECT * FROM information_schema._pg_expandarray(ARRAY['a'])
@@ -399,8 +399,8 @@ query T colnames
 SELECT information_schema._pg_expandarray(ARRAY['b', 'a'])
 ----
 information_schema._pg_expandarray
-('b',1)
-('a',2)
+("b",1)
+("a",2)
 
 query TI colnames
 SELECT * FROM information_schema._pg_expandarray(ARRAY['b', 'a'])
@@ -413,9 +413,9 @@ query T colnames
 SELECT information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])
 ----
 information_schema._pg_expandarray
-('c',1)
-('b',2)
-('a',3)
+("c",1)
+("b",2)
+("a",3)
 
 query TI colnames
 SELECT * FROM information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])
@@ -540,9 +540,9 @@ x  n
 query T
 SELECT ((i.keys).*, 123) FROM (SELECT information_schema._pg_expandarray(ARRAY[3,2,1]) AS keys) AS i
 ----
-((3, 1),123)
-((2, 2),123)
-((1, 3),123)
+("(3,1)",123)
+("(2,2)",123)
+("(1,3)",123)
 
 subtest generate_subscripts
 

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -7,7 +7,7 @@ query TT colnames
 SELECT (1, 2, 'hello', NULL, NULL) AS t, (true, NULL, (false, 6.6, false)) AS u
 ----
 t                u
-(1,2,'hello',,)  (true,,(false, 6.6, false))
+(1,2,"hello",,)  (t,,"(f,6.6,f)")
 
 query BBBBBBBBB colnames
 SELECT
@@ -634,7 +634,7 @@ SELECT ((1, 2, 'hello', NULL, NULL) AS a1, b2, c3, d4, e5) AS r,
        ((true, NULL, (false, 6.6, false)) AS a1, b2, c3) AS s
 ----
 r                s
-(1,2,'hello',,)  (true,,(false, 6.6, false))
+(1,2,"hello",,)  (t,,"(f,6.6,f)")
 
 # Comparing tuples
 query BBB colnames
@@ -709,7 +709,7 @@ query T colnames
 SELECT ((((((1, '2', 3) AS a, b, c), ((4,'5') AS a, b), (ROW(6) AS a)) AS a, b, c), ((7, 8) AS a, b), (ROW('9') AS a)) AS a, b, c) AS r
 ----
 r
-(((1, '2', 3), (4, '5'), (6)),(7, 8),('9'))
+("(""(1,""""2"""",3)"",""(4,""""5"""")"",""(6)"")","(7,8)","(""9"")")
 
 subtest labeled_tuple_column_access
 
@@ -767,7 +767,7 @@ a  b  c
 query T
 SELECT (((ROW(1,'2',true) AS a,b,c)).*, 456)
 ----
-((1, '2', true),456)
+("(1,""2"",t)",456)
 
 query I colnames
 SELECT ((ROW(1) AS a)).*

--- a/pkg/sql/pgwire/write_buffer.go
+++ b/pkg/sql/pgwire/write_buffer.go
@@ -41,10 +41,9 @@ type writeBuffer struct {
 	// We keep both of these because there are operations that are only possible to
 	// perform (efficiently) with one or the other, such as strconv.AppendInt with
 	// putbuf or Datum.Format with variablePutbuf.
-	putbuf          [64]byte
-	variablePutbuf  bytes.Buffer
-	simpleFormatter tree.FmtCtx
-	arrayFormatter  tree.FmtCtx
+	putbuf         [64]byte
+	variablePutbuf bytes.Buffer
+	textFormatter  tree.FmtCtx
 
 	// bytecount counts the number of bytes written across all pgwire connections, not just this
 	// buffer. This is passed in so that finishMsg can track all messages we've sent to a network
@@ -56,8 +55,7 @@ func newWriteBuffer(bytecount *metric.Counter) *writeBuffer {
 	b := &writeBuffer{
 		bytecount: bytecount,
 	}
-	b.simpleFormatter = tree.MakeFmtCtx(&b.variablePutbuf, tree.FmtSimple)
-	b.arrayFormatter = tree.MakeFmtCtx(&b.variablePutbuf, tree.FmtArrays)
+	b.textFormatter = tree.MakeFmtCtx(&b.variablePutbuf, tree.FmtPgwireText)
 	return b
 }
 

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -82,9 +82,10 @@ const (
 	// using numeric notation (@S123).
 	FmtSymbolicSubqueries
 
-	// If set, strings will be formatted for being contents of ARRAYs.
-	// Used internally in combination with FmtArrays defined below.
-	fmtWithinArray
+	// If set, strings will be formatted using the postgres datum-to-text
+	// conversion. See comments in pgwire_encode.go.
+	// Used internally in combination with FmtPgwireText defined below.
+	fmtPgwireFormat
 
 	// If set, datums and placeholders will have type annotations (like
 	// :::interval) as necessary to disambiguate between possible type
@@ -113,9 +114,10 @@ const (
 	// identifiers without wrapping quotes in any case.
 	FmtBareIdentifiers FmtFlags = FmtFlags(lex.EncBareIdentifiers)
 
-	// FmtArrays instructs the pretty-printer to print strings without
-	// wrapping quotes, if the string contains no special characters.
-	FmtArrays FmtFlags = fmtWithinArray | FmtFlags(lex.EncBareStrings)
+	// FmtPgwireText instructs the pretty-printer to use
+	// a pg-compatible conversion to strings. See comments
+	// in pgwire_encode.go.
+	FmtPgwireText FmtFlags = fmtPgwireFormat | FmtFlags(lex.EncBareStrings)
 
 	// FmtParsable instructs the pretty-printer to produce a representation that
 	// can be parsed into an equivalent expression (useful for serialization of

--- a/pkg/sql/sem/tree/pgwire_encode.go
+++ b/pkg/sql/sem/tree/pgwire_encode.go
@@ -1,0 +1,128 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tree
+
+import (
+	"bytes"
+	"unicode"
+
+	"github.com/cockroachdb/cockroach/pkg/util/stringencoding"
+)
+
+func (d *DTuple) pgwireFormat(ctx *FmtCtx) {
+	// When converting a tuple to text in "postgres mode" there is
+	// special behavior: values are printed in "postgres mode" then the
+	// result string itself is rendered in "postgres mode".
+	// Immediate NULL tuple elements are printed as the empty string.
+	//
+	// In this last conversion, for *tuples* the special double quote
+	// and backslash characters are *doubled* (not escaped).  Other
+	// special characters from C like \t \n etc are not escaped and
+	// instead printed as-is. Only non-valid characters get escaped to
+	// hex. So we delegate this formatting to a tuple-specific
+	// string printer called pgwireFormatStringInTuple().
+	ctx.WriteByte('(')
+	comma := ""
+	for _, v := range d.D {
+		ctx.WriteString(comma)
+		switch dv := v.(type) {
+		case *DTuple, *DArray:
+			s := AsStringWithFlags(v, ctx.flags)
+			pgwireFormatStringInTuple(ctx.Buffer, s)
+		case *DString:
+			pgwireFormatStringInTuple(ctx.Buffer, string(*dv))
+		case *DCollatedString:
+			pgwireFormatStringInTuple(ctx.Buffer, dv.Contents)
+		default:
+			ctx.FormatNode(v)
+		}
+		comma = ","
+	}
+	ctx.WriteByte(')')
+}
+
+func pgwireFormatStringInTuple(buf *bytes.Buffer, in string) {
+	// TODO(knz): to be fully pg-compliant, this function should avoid
+	// enclosing the string in double quotes if there is no special
+	// character inside.
+	buf.WriteByte('"')
+	// Loop through each unicode code point.
+	for i, r := range in {
+		if r == '"' || r == '\\' {
+			// Strings in tuples double " and \.
+			buf.WriteByte(byte(r))
+			buf.WriteByte(byte(r))
+		} else if unicode.IsGraphic(r) {
+			buf.WriteRune(r)
+		} else {
+			stringencoding.EncodeChar(buf, in, r, i)
+		}
+	}
+	buf.WriteByte('"')
+}
+
+func (d *DArray) pgwireFormat(ctx *FmtCtx) {
+	// When converting an array to text in "postgres mode" there is
+	// special behavior: values are printed in "postgres mode" then the
+	// result string itself is rendered in "postgres mode".
+	// Immediate NULL array elements are printed as "NULL".
+	//
+	// In this last conversion, for *arrays* the special double quote
+	// and backslash characters are *escaped* (not doubled).  Other
+	// special characters from C like \t \n etc are not escaped and
+	// instead printed as-is. Only non-valid characters get escaped to
+	// hex. So we delegate this formatting to a tuple-specific
+	// string printer called pgwireFormatStringInArray().
+	ctx.WriteByte('{')
+	comma := ""
+	for _, v := range d.Array {
+		ctx.WriteString(comma)
+		switch dv := v.(type) {
+		case dNull:
+			ctx.WriteString("NULL")
+		case *DTuple, *DArray:
+			s := AsStringWithFlags(v, ctx.flags)
+			pgwireFormatStringInArray(ctx.Buffer, s)
+		case *DString:
+			pgwireFormatStringInArray(ctx.Buffer, string(*dv))
+		case *DCollatedString:
+			pgwireFormatStringInArray(ctx.Buffer, dv.Contents)
+		default:
+			ctx.FormatNode(v)
+		}
+		comma = ","
+	}
+	ctx.WriteByte('}')
+}
+
+func pgwireFormatStringInArray(buf *bytes.Buffer, in string) {
+	// TODO(knz): to be fully pg-compliant, this function should avoid
+	// enclosing the string in double quotes if there is no special
+	// character inside.
+	buf.WriteByte('"')
+	// Loop through each unicode code point.
+	for i, r := range in {
+		if r == '"' || r == '\\' {
+			// Strings in arrays escape " and \.
+			buf.WriteByte('\\')
+			buf.WriteByte(byte(r))
+		} else if unicode.IsGraphic(r) {
+			buf.WriteRune(r)
+		} else {
+			stringencoding.EncodeChar(buf, in, r, i)
+		}
+	}
+	buf.WriteByte('"')
+}


### PR DESCRIPTION
Forked off #28143.
Fixes #25522.

This patch fixes the conversion of arrays and tuples to text for the
purpose of emitting the arrays/tuples back to a client through pgwire.
This now properly supports nested arrays, arrays containing tuples,
tuples containing arrays, etc. Labels in tuples are never emitted
through pgwire.

Release note (bug fix): CockroachDB supports a wider range of tuple
and array values in query results.