### PR TITLE
opt: refactor PushSelectIntoGroupBy rule

### DIFF
--- a/pkg/sql/opt/norm/join.go
+++ b/pkg/sql/opt/norm/join.go
@@ -92,7 +92,7 @@ func (c *CustomFuncs) ConstructNonRightJoin(
 // If src has a correlated subquery, CanMap returns false.
 func (c *CustomFuncs) CanMap(filters, src, dst memo.GroupID) bool {
 	// Fast path if src is already bound by dst.
-	if c.IsBoundBy(src, dst) {
+	if c.IsBoundBy(src, c.OutputCols(dst)) {
 		return true
 	}
 
@@ -135,7 +135,7 @@ func (c *CustomFuncs) CanMap(filters, src, dst memo.GroupID) bool {
 // a.x = b.x, because it would just return the tautology b.x = b.x.
 func (c *CustomFuncs) Map(filters, src, dst memo.GroupID) memo.GroupID {
 	// Fast path if src is already bound by dst.
-	if c.IsBoundBy(src, dst) {
+	if c.IsBoundBy(src, c.OutputCols(dst)) {
 		return src
 	}
 

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -124,7 +124,7 @@
     $right:(Project
         (Select
             $selectInput:*
-            $filters:* & ^(IsBoundBy $filters $selectInput)
+            $filters:* & ^(IsBoundBy $filters (OutputCols $selectInput))
         )
         $projections:*
     )
@@ -159,7 +159,7 @@
         $join:(InnerJoin | InnerJoinApply
             $innerLeft:*
             $innerRight:*
-            $innerOn:* & ^(IsBoundBy2 $innerOn $innerLeft $innerRight)
+            $innerOn:* & ^(IsBoundBy $innerOn (OutputCols2 $innerLeft $innerRight))
         )
         $projections:*
     )

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -108,7 +108,7 @@
             ...
             $condition:* &
                 ^(Eq (Variable) (Variable)) &
-                ^(IsBoundBy $condition $left) &
+                ^(IsBoundBy $condition (OutputCols $left)) &
                 (CanMap $filters $condition $left)
             ...
         ]
@@ -134,7 +134,7 @@
             ...
             $condition:* &
                 ^(Eq (Variable) (Variable)) &
-                ^(IsBoundBy $condition $right) &
+                ^(IsBoundBy $condition (OutputCols $right)) &
                 (CanMap $filters $condition $right)
             ...
         ]
@@ -173,16 +173,20 @@
 (InnerJoin | InnerJoinApply | RightJoin | RightJoinApply | SemiJoin | SemiJoinApply
     $left:*
     $right:*
-    $on:(Filters $list:[ ... $condition:* & (IsBoundBy $condition $left) ... ])
+    $on:(Filters $list:[
+        ...
+        $condition:* & (IsBoundBy $condition $leftCols:(OutputCols $left))
+        ...
+    ])
 )
 =>
 ((OpName)
     (Select
         $left
-        (Filters (ExtractBoundConditions $list $left))
+        (Filters (ExtractBoundConditions $list $leftCols))
     )
     $right
-    (Filters (ExtractUnboundConditions $list $left))
+    (Filters (ExtractUnboundConditions $list $leftCols))
 )
 
 # PushFilterIntoJoinRight is symmetric with PushFilterIntoJoinLeft. It pushes
@@ -196,16 +200,20 @@
  SemiJoin | SemiJoinApply | AntiJoin | AntiJoinApply
     $left:*
     $right:*
-    $on:(Filters $list:[ ... $condition:* & (IsBoundBy $condition $right) ... ])
+    $on:(Filters $list:[
+        ...
+        $condition:* & (IsBoundBy $condition $rightCols:(OutputCols $right))
+        ...
+    ])
 )
 =>
 ((OpName)
     $left
     (Select
         $right
-        (Filters (ExtractBoundConditions $list $right))
+        (Filters (ExtractBoundConditions $list $rightCols))
     )
-    (Filters (ExtractUnboundConditions $list $right))
+    (Filters (ExtractUnboundConditions $list $rightCols))
 )
 
 # SimplifyLeftJoinWithoutFilters reduces a LeftJoin operator to an InnerJoin

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -67,7 +67,11 @@
         $projections:*
     )
     (Filters
-        $list:[ ... $condition:* & (IsBoundBy $condition $input) ... ]
+        $list:[
+            ...
+            $condition:* & (IsBoundBy $condition $inputCols:(OutputCols $input))
+            ...
+        ]
     )
 )
 =>
@@ -75,11 +79,11 @@
     (Project
         (Select
             $input
-            (Filters (ExtractBoundConditions $list $input))
+            (Filters (ExtractBoundConditions $list $inputCols))
         )
         $projections
     )
-    (Filters (ExtractUnboundConditions $list $input))
+    (Filters (ExtractUnboundConditions $list $inputCols))
 )
 
 # MergeSelectInnerJoin merges a Select operator with an InnerJoin input by
@@ -140,7 +144,7 @@
         $list:[
             ...
             $condition:* &
-                (IsBoundBy $condition $left) &
+                (IsBoundBy $condition (OutputCols $left)) &
                 (CanMap $on $condition $right)
             ...
         ]
@@ -180,7 +184,7 @@
         $list:[
             ...
             $condition:* &
-                (IsBoundBy $condition $right) &
+                (IsBoundBy $condition (OutputCols $right)) &
                 (CanMap $on $condition $left)
             ...
         ]
@@ -224,19 +228,23 @@
         $right:*
         $on:*
     )
-    $filter:(Filters $list:[ ... $condition:* & (IsBoundBy $condition $left) ... ])
+    $filter:(Filters $list:[
+        ...
+        $condition:* & (IsBoundBy $condition $leftCols:(OutputCols $left))
+        ...
+    ])
 )
 =>
 (Select
     ((OpName $input)
         (Select
             $left
-            (Filters (ExtractBoundConditions $list $left))
+            (Filters (ExtractBoundConditions $list $leftCols))
         )
         $right
         $on
     )
-    (Filters (ExtractUnboundConditions $list $left))
+    (Filters (ExtractUnboundConditions $list $leftCols))
 )
 
 # PushSelectIntoJoinRight is symmetric with PushSelectIntoJoinLeft. It pushes
@@ -249,7 +257,11 @@
         $right:*
         $on:*
     )
-    $filter:(Filters $list:[ ... $condition:* & (IsBoundBy $condition $right) ... ])
+    $filter:(Filters $list:[
+        ...
+        $condition:* & (IsBoundBy $condition $rightCols:(OutputCols $right))
+        ...
+    ])
 )
 =>
 (Select
@@ -257,11 +269,11 @@
         $left
         (Select
             $right
-            (Filters (ExtractBoundConditions $list $right))
+            (Filters (ExtractBoundConditions $list $rightCols))
         )
         $on
     )
-    (Filters (ExtractUnboundConditions $list $right))
+    (Filters (ExtractUnboundConditions $list $rightCols))
 )
 
 # PushSelectIntoGroupBy pushes a Select condition below a GroupBy in the case
@@ -283,19 +295,23 @@
         $aggregations:*
         $def:*
     )
-    (Filters $list:[ ... $condition:* & (IsBoundBy $condition $input) ... ])
+    (Filters $list:[
+        ...
+        $condition:* & (IsBoundBy $condition $inputCols:(OutputCols $input))
+        ...
+    ])
 )
 =>
 (Select
     (GroupBy
         (Select
             $input
-            (Filters (ExtractBoundConditions $list $input))
+            (Filters (ExtractBoundConditions $list $inputCols))
         )
         $aggregations
         $def
     )
-    (Filters (ExtractUnboundConditions $list $input))
+    (Filters (ExtractUnboundConditions $list $inputCols))
 )
 
 # RemoveNotNullCondition removes a filter with an IS NOT NULL condition

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -277,9 +277,10 @@
 )
 
 # PushSelectIntoGroupBy pushes a Select condition below a GroupBy in the case
-# where it does not reference any of the aggregation columns. This only works
-# if this is not an instance of the "scalar" GroupBy, which returns only one
-# row, and which exhibits different behavior if the input is empty:
+# where it only references grouping columns or ConstAgg columns.
+#
+# This rule doesn't work on ScalarGroupBy which exhibits different behavior if
+# the input is empty:
 #   SELECT MAX(y) FROM a
 #
 # If "a" is empty, this returns a single row containing a null value. This is
@@ -297,7 +298,10 @@
     )
     (Filters $list:[
         ...
-        $condition:* & (IsBoundBy $condition $inputCols:(OutputCols $input))
+        $condition:* & (IsBoundBy
+            $condition
+            $passthroughCols:(GroupingAndConstCols $def $aggregations)
+        )
         ...
     ])
 )
@@ -306,12 +310,12 @@
     (GroupBy
         (Select
             $input
-            (Filters (ExtractBoundConditions $list $inputCols))
+            (Filters (ExtractBoundConditions $list $passthroughCols))
         )
         $aggregations
         $def
     )
-    (Filters (ExtractUnboundConditions $list $inputCols))
+    (Filters (ExtractUnboundConditions $list $passthroughCols))
 )
 
 # RemoveNotNullCondition removes a filter with an IS NOT NULL condition

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -90,7 +90,7 @@
 (InnerJoin | LeftJoin
     $left:*
     (IndexJoin $right:* $indexJoinDef:*)
-    $on:* & (IsBoundBy2 $on $left $right)
+    $on:* & (IsBoundBy $on (OutputCols2 $left $right))
 )
 =>
 (LookupJoin
@@ -118,10 +118,10 @@
 (InnerJoin
     $left:*
     (IndexJoin $right:* $indexJoinDef:*)
-    $on:* & ^(IsBoundBy2 $on $left $right) & (Filters
+    $on:* & ^(IsBoundBy $on $innerCols:(OutputCols2 $left $right)) & (Filters
         $onList: [
             ...
-            $condition:* & (IsBoundBy2 $condition $left $right)
+            $condition:* & (IsBoundBy $condition $innerCols)
             ...
         ]
     )
@@ -131,8 +131,8 @@
     $newJoin:(InnerJoin
         $left
         $right
-        (Filters (ExtractBoundConditions2 $onList $left $right))
+        (Filters (ExtractBoundConditions $onList $innerCols))
     )
-    (Filters (ExtractUnboundConditions $onList $newJoin))
+    (Filters (ExtractUnboundConditions $onList $innerCols))
     (HoistIndexJoinDef $indexJoinDef $newJoin (OpName))
 )

--- a/pkg/sql/opt/xform/rules/select.opt
+++ b/pkg/sql/opt/xform/rules/select.opt
@@ -35,14 +35,11 @@
     $input:*
     $def:*
   )
-  $filter:* & (IsBoundBy $filter $input)
+  $filter:* & (IsBoundBy $filter (OutputCols $input))
 )
 =>
 (IndexJoin
-  (Select
-    $input
-    $filter
-  )
+  (Select $input $filter)
   $def
 )
 
@@ -57,18 +54,22 @@
     $input:*
     $def:*
   )
-  $filter:(Filters $list:[ ... $condition:* & (IsBoundBy $condition $input) ... ]) & ^(IsBoundBy $filter $input)
+  $filter:(Filters $list:[
+      ...
+      $condition:* & (IsBoundBy $condition $inputCols:(OutputCols $input))
+      ...
+  ]) & ^(IsBoundBy $filter $inputCols)
 )
 =>
 (Select
   (IndexJoin
     (Select
       $input
-      (Filters (ExtractBoundConditions $list $input))
+      (Filters (ExtractBoundConditions $list $inputCols))
     )
     $def
   )
-  (Filters (ExtractUnboundConditions $list $input))
+  (Filters (ExtractUnboundConditions $list $inputCols))
 )
 
 # ConstrainIndexJoinScan matches a Select over a index join with an


### PR DESCRIPTION
#### opt: change IsBoundBy to operate on ColSets

We change functions `IsBoundBy`,  `ExtractBoundConditions`,
`ExtractUnboundConditions` to take a list of columns instead of a
group. This is more flexible and it allows reuse of the column sets
within a rule; we also don't need the `IsBoundBy2` and
`ExtractBoundConditions2` variants (we instead provide an
`OutputCols2` variant).

Release note: None

#### opt: refactor PushSelectIntoGroupBy rule

This rule uses the fact that filters on column IDs which match with
the input can be passed through. This will not be the case with
DistinctOn. We refactor the rule so it more accurately calculates the
set of "passthrough" columns: these are the grouping columns plus any
`ConstAgg` columns.

Release note: None
