### PR TITLE
cdc: Add highwater timestamp to crdb_internal.jobs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -103,10 +103,10 @@ Channel
 
 
 # The validity of the rows in this table are tested elsewhere; we merely assert the columns.
-query ITTTTTTTTTRTI colnames
+query ITTTTTTTTTRTTI colnames
 SELECT * FROM crdb_internal.jobs WHERE false
 ----
-job_id  job_type  description  user_name  descriptor_ids  status  created  started  finished  modified  fraction_completed  error  coordinator_id
+job_id  job_type  description  user_name  descriptor_ids  status  created  started  finished  modified  fraction_completed  high_water_timestamp  error  coordinator_id
 
 query IITTITTT colnames
 SELECT * FROM crdb_internal.schema_changes WHERE table_id < 0

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -112,7 +112,7 @@ EXPLAIN SHOW JOBS
 ----
 render       ·     ·
  └── values  ·     ·
-·            size  13 columns, 0 rows
+·            size  14 columns, 0 rows
 
 statement ok
 CREATE INDEX a ON foo(x)
@@ -223,7 +223,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         18 columns, 907 rows
+                     │                     size         18 columns, 908 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -105,7 +105,7 @@ EXPLAIN SHOW JOBS
 ----
 render       ·     ·
  └── values  ·     ·
-·            size  13 columns, 0 rows
+·            size  14 columns, 0 rows
 
 statement ok
 CREATE INDEX a ON foo(x)
@@ -216,7 +216,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         18 columns, 907 rows
+                     │                     size         18 columns, 908 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·


### PR DESCRIPTION
Adds column high_water_timestamp to the crdb_internal.jobs table, and
thus also to the output of SHOW JOBS. This column is stored internally
as a HLC timestamp, but is output to the user as a DECIMAL in the same
fashion as the `cluster_logical_timestamp()` built-in. This column will
be nil for existing jobs, which use fraction_completed to represent
their progress.

Release note: Added an additional column to crdb_internal.jobs and SHOW
JOBS to represent the "high water timestamp" of Changefeed jobs. This is
used to represent the progress of changefeeds, as an alternative to the
fraction_completed column which is used by existing jobs.