### PR TITLE
opt: add support for numeric references

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -226,6 +226,11 @@ func (p *planner) getTableScanByRef(
 		return planDataSource{}, errors.Wrapf(err, "%s", tree.ErrString(tref))
 	}
 
+	if tref.Columns != nil && len(tref.Columns) == 0 {
+		return planDataSource{}, pgerror.NewErrorf(pgerror.CodeSyntaxError,
+			"an explicit list of column IDs must include at least one column")
+	}
+
 	// Ideally, we'd like to populate DatabaseName here, however that
 	// would require a reverse-lookup from DB ID to database name, and
 	// we do not provide an API to do this without a KV lookup. The

--- a/pkg/sql/logictest/testdata/logic_test/drop_table
+++ b/pkg/sql/logictest/testdata/logic_test/drop_table
@@ -33,6 +33,9 @@ b
 statement error pgcode 42P01 relation "a" does not exist
 SELECT * FROM a
 
+statement error pq: \[53 AS a\]: table is being dropped
+SELECT * FROM [53 AS a]
+
 statement error pgcode 42P01 relation "a" does not exist
 DROP TABLE a
 

--- a/pkg/sql/logictest/testdata/logic_test/numeric_references
+++ b/pkg/sql/logictest/testdata/logic_test/numeric_references
@@ -1,0 +1,85 @@
+# LogicTest: local-opt
+# ------------------------------------------------------------------------------
+# Numeric References Tests.
+# These are put at the beginning of the file to ensure the numeric table
+# reference is 53 (the numeric reference of the first table).
+# If the numbering scheme in cockroach changes, this test will break.
+# TODO(madhavsuresh): get the numeric reference ID in a less brittle fashion
+# ------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE num_ref (a INT PRIMARY KEY, xx INT, b INT, c INT, INDEX bc (b,c))
+
+statement ok
+CREATE TABLE num_ref_hidden (a INT, b INT)
+
+
+statement ok
+ALTER TABLE num_ref RENAME COLUMN b TO d
+
+statement ok
+ALTER TABLE num_ref RENAME COLUMN a TO p
+
+statement ok
+ALTER TABLE num_ref DROP COLUMN xx
+
+statement ok
+INSERT INTO num_ref VALUES (1, 10, 101), (2, 20, 200), (3, 30, 300)
+
+statement ok
+INSERT INTO num_ref_hidden VALUES (1, 10), (2, 20), (3, 30)
+
+query III
+SELECT * FROM num_ref
+----
+1  10  101
+2  20  200
+3  30  300
+
+query III
+SELECT * FROM [53 as num_ref_alias]
+----
+1  10  101
+2  20  200
+3  30  300
+
+query III
+SELECT * FROM [53(4,3,1) AS num_ref_alias]
+----
+101  10  1
+200  20  2
+300  30  3
+
+query I
+SELECT * FROM [53(4) AS num_ref_alias]@[2]
+----
+101
+200
+300
+
+query I
+SELECT * FROM [53(1) AS num_ref_alias]@[1]
+----
+1
+2
+3
+
+query III colnames
+SELECT * FROM [53(1,3,4) AS num_ref_alias(col1,col2,col3)]
+----
+col1  col2  col3
+1     10    101
+2     20    200
+3     30    300
+
+query I
+SELECT * FROM [54(1,3) AS num_ref_hidden]
+----
+1
+2
+3
+
+query I
+SELECT count(rowid) FROM [54(3) AS num_ref_hidden]
+----
+3

--- a/pkg/sql/logictest/testdata/logic_test/privileges_table
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_table
@@ -12,6 +12,9 @@ statement ok
 CREATE TABLE t (k INT PRIMARY KEY, v int)
 
 statement ok
+SELECT * from [54 as num_ref]
+
+statement ok
 SHOW GRANTS ON t
 
 statement ok
@@ -65,6 +68,9 @@ SHOW COLUMNS FROM t
 
 statement error pq: user testuser does not have SELECT privilege on relation t
 SELECT r FROM t
+
+statement error pq: user testuser does not have SELECT privilege on relation t
+SELECT * from [56 as num_ref]
 
 statement error user testuser does not have GRANT privilege on relation t
 GRANT ALL ON t TO bar

--- a/pkg/sql/opt/catalog.go
+++ b/pkg/sql/opt/catalog.go
@@ -195,6 +195,11 @@ type Table interface {
 	// position within the table, where i < ColumnCount.
 	Column(i int) Column
 
+	// LookupColumnOrdinal returns the ordinal of the column with the given ID.
+	// Note that this takes the internal column ID, and has no relation to
+	// ColumnIDs in the optimizer.
+	LookupColumnOrdinal(colID uint32) (int, error)
+
 	// IndexCount returns the number of indexes defined on this table. This
 	// includes the primary index, so the count is always >= 1.
 	IndexCount() int
@@ -219,6 +224,10 @@ type Catalog interface {
 	// FindTable returns a Table interface for the database table matching the
 	// given table name.  Returns an error if the table does not exist.
 	FindTable(ctx context.Context, name *tree.TableName) (Table, error)
+
+	// FindTableByID returns a Table interface for the database table
+	// matching the given table ID. Returns an error if the table does not exist.
+	FindTableByID(ctx context.Context, tableID int64) (Table, error)
 }
 
 // FormatCatalogTable nicely formats a catalog table using a treeprinter for

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1,5 +1,211 @@
 # LogicTest: local-opt
 
+
+# ------------------------------------------------------------------------------
+# Numeric References Tests.
+# These are put at the beginning of the file to ensure the numeric table
+# reference is 53 (the numeric reference of the first table).
+# If the numbering scheme in cockroach changes, this test will break.
+# These tests replicate the tests at sql/table_ref_test.go. The reason
+# for duplication is to include tests within the opt testing framework
+# TODO(madhavsuresh): get the numeric reference ID in a less brittle fashion
+# ------------------------------------------------------------------------------
+statement ok
+CREATE TABLE num_ref (a INT PRIMARY KEY, xx INT, b INT, c INT, INDEX bc (b,c))
+
+statement ok
+CREATE TABLE num_ref_hidden (a INT, b INT)
+
+statement ok
+ALTER TABLE num_ref RENAME COLUMN b TO d
+
+statement ok
+ALTER TABLE num_ref RENAME COLUMN a TO p
+
+statement ok
+ALTER TABLE num_ref DROP COLUMN xx
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [53 AS num_ref_alias]
+----
+scan  ·      ·                (p, d, c)  ·
+·     table  num_ref@primary  ·          ·
+·     spans  ALL              ·          ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]
+----
+scan  ·      ·                (c)  ·
+·     table  num_ref@primary  ·    ·
+·     spans  ALL              ·    ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [53(1,4) AS num_ref_alias]
+----
+scan  ·      ·                (p, c)  ·
+·     table  num_ref@primary  ·       ·
+·     spans  ALL              ·       ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [53(1,3,4) AS num_ref_alias]
+----
+scan  ·      ·                (p, d, c)  ·
+·     table  num_ref@primary  ·          ·
+·     spans  ALL              ·          ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [53(4,3,1) AS num_ref_alias]
+----
+render     ·         ·                (c, d, p)  ·
+ │         render 0  c                ·          ·
+ │         render 1  d                ·          ·
+ │         render 2  p                ·          ·
+ └── scan  ·         ·                (p, d, c)  ·
+·          table     num_ref@primary  ·          ·
+·          spans     ALL              ·          ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [53(4,3,1) AS num_ref_alias(col1,col2,col3)]
+----
+render     ·         ·                (col1, col2, col3)  ·
+ │         render 0  c                ·                   ·
+ │         render 1  d                ·                   ·
+ │         render 2  p                ·                   ·
+ └── scan  ·         ·                (p, d, c)           ·
+·          table     num_ref@primary  ·                   ·
+·          spans     ALL              ·                   ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [53(4,3,1) AS num_ref_alias]@bc
+----
+scan  ·      ·           (c, d, p)  p!=NULL; weak-key(c,d,p)
+·     table  num_ref@bc  ·          ·
+·     spans  ALL         ·          ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@bc
+----
+render     ·         ·                (c)                                        ·
+ │         render 0  num_ref_alias.c  ·                                          ·
+ └── scan  ·         ·                (c, p[hidden,omitted], d[hidden,omitted])  p!=NULL; weak-key(c,p,d)
+·          table     num_ref@bc       ·                                          ·
+·          spans     ALL              ·                                          ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@bc
+----
+render     ·         ·                (d)                                        ·
+ │         render 0  num_ref_alias.d  ·                                          ·
+ └── scan  ·         ·                (d, p[hidden,omitted], c[hidden,omitted])  p!=NULL; weak-key(d,p,c)
+·          table     num_ref@bc       ·                                          ·
+·          spans     ALL              ·                                          ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@bc
+----
+render     ·         ·                (p)                                        p!=NULL
+ │         render 0  num_ref_alias.p  ·                                          ·
+ └── scan  ·         ·                (p, d[hidden,omitted], c[hidden,omitted])  p!=NULL; weak-key(p,d,c)
+·          table     num_ref@bc       ·                                          ·
+·          spans     ALL              ·                                          ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@[1]
+----
+render     ·         ·                (p)                                        p!=NULL; key(p)
+ │         render 0  num_ref_alias.p  ·                                          ·
+ └── scan  ·         ·                (p, d[hidden,omitted], c[hidden,omitted])  p!=NULL; key(p)
+·          table     num_ref@primary  ·                                          ·
+·          spans     ALL              ·                                          ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@[2]
+----
+render     ·         ·                (p)                                        p!=NULL
+ │         render 0  num_ref_alias.p  ·                                          ·
+ └── scan  ·         ·                (p, d[hidden,omitted], c[hidden,omitted])  p!=NULL; weak-key(p,d,c)
+·          table     num_ref@bc       ·                                          ·
+·          spans     ALL              ·                                          ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@[1]
+----
+render     ·         ·                (d)                                        ·
+ │         render 0  num_ref_alias.d  ·                                          ·
+ └── scan  ·         ·                (d, p[hidden,omitted], c[hidden,omitted])  p!=NULL; key(p)
+·          table     num_ref@primary  ·                                          ·
+·          spans     ALL              ·                                          ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@[2]
+----
+render     ·         ·                (d)                                        ·
+ │         render 0  num_ref_alias.d  ·                                          ·
+ └── scan  ·         ·                (d, p[hidden,omitted], c[hidden,omitted])  p!=NULL; weak-key(d,p,c)
+·          table     num_ref@bc       ·                                          ·
+·          spans     ALL              ·                                          ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@[1]
+----
+render     ·         ·                (c)                                        ·
+ │         render 0  num_ref_alias.c  ·                                          ·
+ └── scan  ·         ·                (c, p[hidden,omitted], d[hidden,omitted])  p!=NULL; key(p)
+·          table     num_ref@primary  ·                                          ·
+·          spans     ALL              ·                                          ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@[2]
+----
+render     ·         ·                (c)                                        ·
+ │         render 0  num_ref_alias.c  ·                                          ·
+ └── scan  ·         ·                (c, p[hidden,omitted], d[hidden,omitted])  p!=NULL; weak-key(c,p,d)
+·          table     num_ref@bc       ·                                          ·
+·          spans     ALL              ·                                          ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [54(1,3) AS num_ref_alias]
+----
+scan  ·      ·                       (a)  ·
+·     table  num_ref_hidden@primary  ·    ·
+·     spans  ALL                     ·    ·
+
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM [54(3) AS num_ref_alias]
+----
+scan  ·      ·                       ()  ·
+·     table  num_ref_hidden@primary  ·   ·
+·     spans  ALL                     ·   ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT rowid FROM [54(3) AS num_ref_alias]
+----
+scan  ·      ·                       (rowid[hidden])  ·
+·     table  num_ref_hidden@primary  ·                ·
+·     spans  ALL                     ·                ·
+
+query error pq: \[666\(1\) AS num_ref_alias\]: relation \"\[666\]\" does not exist
+EXPLAIN (VERBOSE) SELECT * FROM [666(1) AS num_ref_alias]
+
+query error pq: column \[666\] does not exist
+EXPLAIN (VERBOSE) SELECT * FROM [53(666) AS num_ref_alias]
+
+query error pq: column \[2\] does not exist
+EXPLAIN (VERBOSE) SELECT * FROM [53(2) AS num_ref_alias]
+
+query error pq: an explicit list of column IDs must include at least one column
+EXPLAIN (VERBOSE) SELECT * FROM [53() AS num_ref_alias]
+
+query error pq: an explicit list of column IDs must include at least one column
+EXPLAIN (VERBOSE) SELECT 1 FROM [53() as num_ref_alias]
+
+statement ok
+DROP TABLE num_ref
+
+query error pq: \[53\(1\) AS num_ref_alias\]: table is being dropped
+EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]
+
 # ------------------------------------------------------------------------------
 # Basic filter combinations.
 # ------------------------------------------------------------------------------

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1,5 +1,32 @@
 # tests adapted from logictest -- select
 
+# This statement must be first for the numeric references tests.
+# The numeric references test assume that this is the first table.
+exec-ddl
+CREATE TABLE numeric_references (a INT PRIMARY KEY, xx INT, b INT, c INT, INDEX bc (b,c))
+----
+TABLE numeric_references
+ ├── a int not null
+ ├── xx int
+ ├── b int
+ ├── c int
+ ├── INDEX primary
+ │    └── a int not null
+ └── INDEX bc
+      ├── b int
+      ├── c int
+      └── a int not null
+
+exec-ddl
+CREATE TABLE num_ref_hidden (x INT , xx INT)
+----
+TABLE num_ref_hidden
+ ├── x int
+ ├── xx int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
 # SELECT with no table.
 
 build
@@ -1094,3 +1121,90 @@ project
  ├── columns: x:1(int!null)
  └── scan a
       └── columns: x:1(int!null) y:2(float)
+
+
+# Numeric Reference Test (1/11)
+# Cockroach numeric references start after 53 for user tables.
+# See opt/testutils/testcat/create_table.go:117 for more info on
+# 53 as a magic number.
+
+build
+SELECT * FROM [53 AS t]
+----
+scan numeric_references
+ └── columns: a:1(int!null) xx:2(int) b:3(int) c:4(int)
+
+# Numeric Reference Test (2/11)
+build
+SELECT * FROM [53(1) AS t]
+----
+scan numeric_references
+ └── columns: a:1(int!null)
+
+# Numeric Reference Test (3/11)
+build
+SELECT * FROM [53(1,2) AS t]
+----
+scan numeric_references
+ └── columns: a:1(int!null) xx:2(int)
+
+# Numeric Reference Test (4/11)
+build
+SELECT * FROM [53(4) AS t]
+----
+scan numeric_references
+ └── columns: c:4(int)
+
+# Numeric Reference Test (5/11)
+build
+SELECT * FROM [53(5) AS t]
+----
+error (42703): column [5] does not exist
+
+# Numeric Reference Test (6/11)
+build
+SELECT * FROM [53(2,4) AS t]
+----
+scan numeric_references
+ └── columns: xx:2(int) c:4(int)
+
+# Numeric Reference Test (7/11)
+build
+SELECT * FROM [53(2,3) AS t(col1,col2)]
+----
+scan numeric_references
+ └── columns: col1:2(int) col2:3(int)
+
+# Numeric Reference Test (8/11)
+build
+SELECT * FROM [53() AS t]
+----
+error (42601): an explicit list of column IDs must include at least one column
+
+# Numeric Reference Test (9/11)
+# Test that hidden columns are not presented
+build
+SELECT * FROM [54 AS t]
+----
+project
+ ├── columns: x:1(int) xx:2(int)
+ └── scan num_ref_hidden
+      └── columns: x:1(int) xx:2(int) rowid:3(int!null)
+
+# Numeric Reference Test (10/11)
+# Test that hidden columns are not presented
+build
+SELECT * FROM [54(1,3) AS t]
+----
+project
+ ├── columns: x:1(int)
+ └── scan num_ref_hidden
+      └── columns: x:1(int) rowid:3(int!null)
+
+
+# Numeric Reference Test (11/11)
+build
+SELECT rowid FROM [54(3) as t]
+----
+scan num_ref_hidden
+ └── columns: rowid:3(int!null)

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
@@ -105,11 +106,16 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 		case *tree.IndexTableDef:
 			tab.addIndex(def, nonUniqueIndex)
 		}
+
 		// TODO(rytaft): In the future we will likely want to check for unique
 		// constraints, indexes, and foreign key constraints to determine
 		// nullability, uniqueness, etc.
 	}
 
+	// We need to keep track of the tableID from numeric references. 53 is a magic
+	// number derived from how CRDB internally stores tables. The first user table
+	// is 53. This magic number is used to have tests look consistent.
+	tab.tableID = sqlbase.ID(len(tc.tables) + 53)
 	// Add the new table to the catalog.
 	tc.AddTable(tab)
 

--- a/pkg/sql/sem/tree/table_ref.go
+++ b/pkg/sql/sem/tree/table_ref.go
@@ -29,6 +29,7 @@ type TableRef struct {
 	// ColumnIDs is the list of column IDs requested in the table.
 	// Note that a nil array here means "unspecified" (all columns)
 	// whereas an array of length 0 means "zero columns".
+	// Lists of zero columns are not supported and will throw an error.
 	Columns []ColumnID
 
 	// As determines the names that can be used in the surrounding query


### PR DESCRIPTION
This commit adds support in the optimizer for the following
type of query:

`SELECT * FROM [53 as t]`

Release note:
- Numeric references in opt/ do not use the table descriptor
  cache. This diverges from how numeric references were resolved in the
  heuristic planner.
- This PR changes the semantics of SELECT * FROM [53() as t].
  Previously, and empty column list to a table reference query
  was accepted, and an zero column row was returned. With this
  change, an empty column list is no longer accepted. Empty column
  lists now returns the error: "An explicit list of column IDs must
  include at least one column"

Relevant comment by @knz on this change:

 "I am not 100% sure how to solve this but I would be comfortable to
 'solve' this by rejecting the notation NN() during planning and say with
 an error "an explicit list of column IDs must include at least one
 column".
 Even in the envisioned case for numeric references to handle view
 descriptors, this would be adequate (a numeric reference inside a view
 descriptor will always include at least the PK columns, even if only
 hidden)"