### PR TITLE
changefeedccl: add production monitoring metrics

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -55,6 +55,7 @@ func createBenchmarkChangefeed(
 		Targets: map[sqlbase.ID]string{tableDesc.ID: tableDesc.Name},
 	}
 	progress := jobspb.Progress{}
+	metrics := MakeMetrics().(*Metrics)
 
 	ctx, cancel := context.WithCancel(ctx)
 	errCh := make(chan error, 1)
@@ -62,7 +63,7 @@ func createBenchmarkChangefeed(
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		errCh <- runChangefeedFlow(ctx, execCfg, details, progress, resultsCh, nil)
+		errCh <- runChangefeedFlow(ctx, execCfg, details, progress, metrics, resultsCh, nil)
 	}()
 	return func() error {
 		select {

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -16,10 +16,14 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/pkg/errors"
 )
 
@@ -371,4 +375,126 @@ func (s *channelSink) Close() error {
 	// don't work.
 	s.resultsCh = nil
 	return nil
+}
+
+type metricsSink struct {
+	metrics *Metrics
+	wrapped Sink
+}
+
+func makeMetricsSink(metrics *Metrics, s Sink) *metricsSink {
+	m := &metricsSink{
+		metrics: metrics,
+		wrapped: s,
+	}
+	return m
+}
+
+func (s *metricsSink) EmitRow(ctx context.Context, topic string, key, value []byte) error {
+	err := s.wrapped.EmitRow(ctx, topic, key, value)
+	if err == nil {
+		s.metrics.EmittedMessages.Inc(1)
+		s.metrics.EmittedBytes.Inc(int64(len(key) + len(value)))
+	}
+	return err
+}
+
+func (s *metricsSink) EmitResolvedTimestamp(ctx context.Context, payload []byte) error {
+	err := s.wrapped.EmitResolvedTimestamp(ctx, payload)
+	if err == nil {
+		s.metrics.EmittedMessages.Inc(1)
+		s.metrics.EmittedBytes.Inc(int64(len(payload)))
+	}
+	return err
+}
+func (s *metricsSink) Flush(ctx context.Context) error {
+	start := timeutil.Now()
+	err := s.wrapped.Flush(ctx)
+	if err == nil {
+		s.metrics.FlushNanos.Inc(timeutil.Since(start).Nanoseconds())
+	}
+	return err
+}
+func (s *metricsSink) Close() error {
+	return s.wrapped.Close()
+}
+
+var (
+	metaChangefeedEmittedMessages = metric.Metadata{
+		Name:        "changefeed.emitted_messages",
+		Help:        "Messages emitted by all feeds",
+		Measurement: "Messages",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaChangefeedEmittedBytes = metric.Metadata{
+		Name:        "changefeed.emitted_bytes",
+		Help:        "Bytes emitted by all feeds",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_BYTES,
+	}
+	// This is more naturally a histogram but that creates a lot of timeseries
+	// and it's not clear that the additional fidelity is worth it. Revisit if
+	// evidence suggests otherwise.
+	metaChangefeedFlushNanos = metric.Metadata{
+		Name:        "changefeed.flush_nanos",
+		Help:        "Total time spent flushing all feeds",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+
+	// TODO(dan): This was intended to be a measure of the minimum distance of
+	// any changefeed ahead of its gc ttl threshold, but keeping that correct in
+	// the face of changing zone configs is much harder, so this will have to do
+	// for now.
+	metaChangefeedMinHighWater = metric.Metadata{
+		Name:        "changefeed.min_high_water",
+		Help:        "Latest high_water timestamp of most behind feed",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_TIMESTAMP_NS,
+	}
+)
+
+const noMinHighWaterSentinel = int64(-1)
+
+// Metrics are for production monitoring of changefeeds.
+type Metrics struct {
+	EmittedMessages *metric.Counter
+	EmittedBytes    *metric.Counter
+	FlushNanos      *metric.Counter
+
+	mu struct {
+		syncutil.Mutex
+		id       int
+		resolved map[int]hlc.Timestamp
+	}
+	MinHighWater *metric.Gauge
+}
+
+// MetricStruct implements the metric.Struct interface.
+func (*Metrics) MetricStruct() {}
+
+// MakeMetrics makes the metrics for changefeed monitoring.
+func MakeMetrics() metric.Struct {
+	m := &Metrics{
+		EmittedMessages: metric.NewCounter(metaChangefeedEmittedMessages),
+		EmittedBytes:    metric.NewCounter(metaChangefeedEmittedBytes),
+		FlushNanos:      metric.NewCounter(metaChangefeedFlushNanos),
+	}
+	m.mu.resolved = make(map[int]hlc.Timestamp)
+	m.MinHighWater = metric.NewFunctionalGauge(metaChangefeedMinHighWater, func() int64 {
+		minHighWater := noMinHighWaterSentinel
+		m.mu.Lock()
+		for _, resolved := range m.mu.resolved {
+			if minHighWater == noMinHighWaterSentinel || resolved.WallTime < minHighWater {
+				minHighWater = resolved.WallTime
+			}
+		}
+		m.mu.Unlock()
+		return minHighWater
+	})
+	return m
+}
+
+func init() {
+	jobs.MakeChangefeedMetricsHook = MakeMetrics
 }

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -389,6 +389,13 @@ func (j *Job) Details() jobspb.Details {
 	return j.mu.payload.UnwrapDetails()
 }
 
+// RegistryMetrics returns the metrics for production monitoring of each job
+// type. They're all stored as the `metric.Struct` interface because of
+// dependency cycles.
+func (j *Job) RegistryMetrics() *Metrics {
+	return &j.registry.metrics
+}
+
 // FractionCompleted returns completion according to the in-memory job state.
 func (j *Job) FractionCompleted() float32 {
 	progress := j.Progress()

--- a/pkg/jobs/metrics.go
+++ b/pkg/jobs/metrics.go
@@ -1,0 +1,36 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package jobs
+
+import "github.com/cockroachdb/cockroach/pkg/util/metric"
+
+// Metrics are for production monitoring of each job type.
+type Metrics struct {
+	Changefeed metric.Struct
+}
+
+// MetricStruct implements the metric.Struct interface.
+func (Metrics) MetricStruct() {}
+
+// InitHooks initializes the metrics for job monitoring.
+func (m *Metrics) InitHooks() {
+	if MakeChangefeedMetricsHook != nil {
+		m.Changefeed = MakeChangefeedMetricsHook()
+	}
+}
+
+// MakeChangefeedMetricsHook allows for registration of changefeed metrics from
+// ccl code.
+var MakeChangefeedMetricsHook func() metric.Struct

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -91,6 +91,7 @@ type Registry struct {
 	nodeID   *base.NodeIDContainer
 	settings *cluster.Settings
 	planFn   planHookMaker
+	metrics  Metrics
 
 	mu struct {
 		syncutil.Mutex
@@ -147,7 +148,15 @@ func MakeRegistry(
 	}
 	r.mu.epoch = 1
 	r.mu.jobs = make(map[int64]context.CancelFunc)
+	r.metrics.InitHooks()
 	return r
+}
+
+// MetricsStruct returns the metrics for production monitoring of each job type.
+// They're all stored as the `metric.Struct` interface because of dependency
+// cycles.
+func (r *Registry) MetricsStruct() *Metrics {
+	return &r.metrics
 }
 
 // lenientNow returns the timestamp after which we should attempt

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -478,6 +478,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			return sql.NewInternalPlanner(opName, nil, user, &sql.MemoryMetrics{}, &execCfg)
 		},
 	)
+	s.registry.AddMetricStruct(s.jobRegistry.MetricsStruct())
 
 	distSQLMetrics := distsqlrun.MakeDistSQLMetrics(cfg.HistogramWindowInterval())
 	s.registry.AddMetricStruct(distSQLMetrics)

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -550,8 +550,14 @@ func (ts *TestServer) MustGetSQLCounter(name string) int64 {
 
 	ts.registry.Each(func(n string, v interface{}) {
 		if name == n {
-			c = v.(*metric.Counter).Count()
-			found = true
+			switch t := v.(type) {
+			case *metric.Counter:
+				c = t.Count()
+				found = true
+			case *metric.Gauge:
+				c = t.Value()
+				found = true
+			}
 		}
 	})
 	if !found {


### PR DESCRIPTION
The following are added and registered via a ccl hook:

    changefeed.emitted_messages
    changefeed.emitted_bytes
    changefeed.flush_nanos
    changefeed.min_high_water

Release note (enterprise change): CHANGEFEEDS now export metrics for
production monitoring