### PR TITLE
storage/engine: mark some non-MVCC functions as deprecated

### DIFF
--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -431,6 +431,7 @@ func verifyCleanup(key roachpb.Key, eng engine.Engine, t *testing.T, coords ...*
 			}
 		}
 		meta := &enginepb.MVCCMetadata{}
+		//lint:ignore SA1019 historical usage of deprecated eng.GetProto is OK
 		ok, _, _, err := eng.GetProto(engine.MakeMVCCMetadataKey(key), meta)
 		if err != nil {
 			return fmt.Errorf("error getting MVCC metadata: %s", err)

--- a/pkg/storage/batch_spanset_test.go
+++ b/pkg/storage/batch_spanset_test.go
@@ -93,6 +93,7 @@ func TestSpanSetBatch(t *testing.T) {
 	}
 
 	// Reads inside the range work.
+	//lint:ignore SA1019 historical usage of deprecated batch.Get is OK
 	if value, err := batch.Get(insideKey); err != nil {
 		t.Errorf("failed to read inside the range: %s", err)
 	} else if !bytes.Equal(value, []byte("value")) {
@@ -103,9 +104,11 @@ func TestSpanSetBatch(t *testing.T) {
 	isReadSpanErr := func(err error) bool {
 		return testutils.IsError(err, "cannot read undeclared span")
 	}
+	//lint:ignore SA1019 historical usage of deprecated batch.Get is OK
 	if _, err := batch.Get(outsideKey); !isReadSpanErr(err) {
 		t.Errorf("Get: unexpected error %v", err)
 	}
+	//lint:ignore SA1019 historical usage of deprecated batch.GetProto is OK
 	if _, _, _, err := batch.GetProto(outsideKey, nil); !isReadSpanErr(err) {
 		t.Errorf("GetProto: unexpected error %v", err)
 	}

--- a/pkg/storage/compactor/compactor.go
+++ b/pkg/storage/compactor/compactor.go
@@ -492,6 +492,7 @@ func (c *Compactor) Suggest(ctx context.Context, sc storagebase.SuggestedCompact
 	// Check whether a suggested compaction already exists for this key span.
 	key := keys.StoreSuggestedCompactionKey(sc.StartKey, sc.EndKey)
 	var existing storagebase.Compaction
+	//lint:ignore SA1019 historical usage of deprecated c.eng.GetProto is OK
 	ok, _, _, err := c.eng.GetProto(engine.MVCCKey{Key: key}, &existing)
 	if err != nil {
 		log.VErrEventf(ctx, 2, "unable to record suggested compaction: %s", err)
@@ -508,6 +509,7 @@ func (c *Compactor) Suggest(ctx context.Context, sc storagebase.SuggestedCompact
 	}
 
 	// Store the new compaction.
+	//lint:ignore SA1019 historical usage of deprecated engine.PutProto is OK
 	if _, _, err = engine.PutProto(c.eng, engine.MVCCKey{Key: key}, &sc.Compaction); err != nil {
 		log.Warningf(ctx, "unable to record suggested compaction: %s", err)
 	}

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -167,11 +167,15 @@ type Reader interface {
 	// engine; exported to enable wrappers to exist in other packages.
 	Closed() bool
 	// Get returns the value for the given key, nil otherwise.
+	//
+	// Deprecated: use MVCCGet instead.
 	Get(key MVCCKey) ([]byte, error)
 	// GetProto fetches the value at the specified key and unmarshals it
 	// using a protobuf decoder. Returns true on success or false if the
 	// key was not found. On success, returns the length in bytes of the
 	// key and the value.
+	//
+	// Deprecated: use Iterator.ValueProto instead.
 	GetProto(key MVCCKey, msg protoutil.Message) (ok bool, keyBytes, valBytes int64, err error)
 	// Iterate scans from start to end keys, visiting at most max
 	// key/value pairs. On each key value pair, the function f is
@@ -379,6 +383,8 @@ type EnvStats struct {
 // PutProto sets the given key to the protobuf-serialized byte string
 // of msg and the provided timestamp. Returns the length in bytes of
 // key and the value.
+//
+// Deprecated: use MVCCPutProto instead.
 func PutProto(
 	engine Writer, key MVCCKey, msg protoutil.Message,
 ) (keyBytes, valBytes int64, err error) {

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -217,6 +217,7 @@ func (s spanSetReader) Get(key engine.MVCCKey) ([]byte, error) {
 	if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: key.Key}); err != nil {
 		return nil, err
 	}
+	//lint:ignore SA1019 implementing deprecated interface function (Get) is OK
 	return s.r.Get(key)
 }
 
@@ -226,6 +227,7 @@ func (s spanSetReader) GetProto(
 	if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: key.Key}); err != nil {
 		return false, 0, 0, err
 	}
+	//lint:ignore SA1019 implementing deprecated interface function (GetProto) is OK
 	return s.r.GetProto(key, msg)
 }
 


### PR DESCRIPTION
Using an engine without the MVCC wrapper is almost always wrong. Mark
the functions that do so as deprecated so they don't continue to get
used in new code. (The compactor, for example, uses PutProto where it
should have used MVCCPutProto.)

Release note: None