### PR TITLE
sql: remove noPeers peerGroupChecker

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -2178,3 +2178,64 @@ SELECT avg(price) OVER w1, avg(price) OVER w2, avg(price) OVER w1 FROM products 
 425.00                 750.00   425.00
 350.00                 425.00   350.00
 175.00                 175.00   175.00
+
+# In the following 4 tests, since ORDER BY is omitted, all rows are peers, so frame includes all the rows for every row.
+query TTRR
+SELECT group_name, product_name, price, sum(price) OVER (RANGE CURRENT ROW) FROM products ORDER BY group_id
+----
+Smartphone  Microsoft Lumia  200.00   6450.00
+Smartphone  HTC One          400.00   6450.00
+Smartphone  Nexus            500.00   6450.00
+Smartphone  iPhone           900.00   6450.00
+Laptop      HP Elite         1200.00  6450.00
+Laptop      Lenovo Thinkpad  700.00   6450.00
+Laptop      Sony VAIO        700.00   6450.00
+Laptop      Dell             800.00   6450.00
+Tablet      iPad             700.00   6450.00
+Tablet      Kindle Fire      150.00   6450.00
+Tablet      Samsung          200.00   6450.00
+
+query TTRR
+SELECT group_name, product_name, price, sum(price) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM products ORDER BY group_id
+----
+Smartphone  Microsoft Lumia  200.00   6450.00
+Smartphone  HTC One          400.00   6450.00
+Smartphone  Nexus            500.00   6450.00
+Smartphone  iPhone           900.00   6450.00
+Laptop      HP Elite         1200.00  6450.00
+Laptop      Lenovo Thinkpad  700.00   6450.00
+Laptop      Sony VAIO        700.00   6450.00
+Laptop      Dell             800.00   6450.00
+Tablet      iPad             700.00   6450.00
+Tablet      Kindle Fire      150.00   6450.00
+Tablet      Samsung          200.00   6450.00
+
+query TTRR
+SELECT group_name, product_name, price, sum(price) OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW) FROM products ORDER BY group_id
+----
+Smartphone  Microsoft Lumia  200.00   6450.00
+Smartphone  HTC One          400.00   6450.00
+Smartphone  Nexus            500.00   6450.00
+Smartphone  iPhone           900.00   6450.00
+Laptop      HP Elite         1200.00  6450.00
+Laptop      Lenovo Thinkpad  700.00   6450.00
+Laptop      Sony VAIO        700.00   6450.00
+Laptop      Dell             800.00   6450.00
+Tablet      iPad             700.00   6450.00
+Tablet      Kindle Fire      150.00   6450.00
+Tablet      Samsung          200.00   6450.00
+
+query TTRR
+SELECT group_name, product_name, price, sum(price) OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) FROM products ORDER BY group_id
+----
+Smartphone  Microsoft Lumia  200.00   6450.00
+Smartphone  HTC One          400.00   6450.00
+Smartphone  Nexus            500.00   6450.00
+Smartphone  iPhone           900.00   6450.00
+Laptop      HP Elite         1200.00  6450.00
+Laptop      Lenovo Thinkpad  700.00   6450.00
+Laptop      Sony VAIO        700.00   6450.00
+Laptop      Dell             800.00   6450.00
+Tablet      iPad             700.00   6450.00
+Tablet      Kindle Fire      150.00   6450.00
+Tablet      Samsung          200.00   6450.00

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -608,11 +608,6 @@ type allPeers struct{}
 // allPeers implements the peerGroupChecker interface.
 func (allPeers) InSameGroup(i, j int) bool { return true }
 
-type noPeers struct{}
-
-// noPeers implements the peerGroupChecker interface.
-func (noPeers) InSameGroup(i, j int) bool { return false }
-
 // peerGroupChecker can check if a pair of row indexes within a partition are
 // in the same peer group.
 type peerGroupChecker interface {
@@ -787,13 +782,8 @@ func (n *windowNode) computeWindows(ctx context.Context, evalCtx *tree.EvalConte
 				// for functions with syntactically equivalent PARTITION BY and ORDER BY clauses.
 				sort.Sort(sorter)
 				peerGrouper = sorter
-			} else if frameRun.Frame != nil && frameRun.Frame.Mode == tree.ROWS {
-				// If ORDER BY clause is not provided and Frame is specified with ROWS mode,
-				// any row has no peers.
-				peerGrouper = noPeers{}
 			} else {
-				// If ORDER BY clause is not provided and either no Frame is provided or Frame is
-				// specified with RANGE mode, all rows are peers.
+				// If ORDER BY clause is not provided, all rows are peers.
 				peerGrouper = allPeers{}
 			}
 


### PR DESCRIPTION
There is actually no such notion as "no peers."
For some reason, I couldn't match behavior of PG
on some logic tests while working on #26666, so I
thought PG had "no peers" in RANGE mode.

I don't know whether I had a bug at some point and
fixed it later or this problem was resolved with
making all tests produce deterministic results
(see #27635).

Release note: None