### PR TITLE
ts: Add Cluster Settings for Rollup

### DIFF
--- a/pkg/ts/db.go
+++ b/pkg/ts/db.go
@@ -30,14 +30,14 @@ import (
 
 var (
 	resolution1nsDefaultRollupThreshold = time.Second
-	// The prune threshold for the 10s resolution was created before time series
-	// rollups were enabled. It is still used in the transition period during
-	// an upgrade before the cluster version is finalized. After the version
-	// upgrade, the rollup threshold is used instead.
-	resolution10sDefaultPruneThreshold  = 30 * 24 * time.Hour
-	resolution10sDefaultRollupThreshold = 7 * 24 * time.Hour
-	resolution30mDefaultPruneThreshold  = 365 * 24 * time.Hour
-	resolution50nsDefaultPruneThreshold = 1 * time.Millisecond
+	// The deprecated prune threshold for the 10s resolution was created before
+	// time series rollups were enabled. It is still used in the transition period
+	// during an upgrade before the cluster version is finalized. After the
+	// version upgrade, the rollup threshold is used instead.
+	deprecatedResolution10sDefaultPruneThreshold = 30 * 24 * time.Hour
+	resolution10sDefaultRollupThreshold          = 10 * 24 * time.Hour
+	resolution30mDefaultPruneThreshold           = 90 * 24 * time.Hour
+	resolution50nsDefaultPruneThreshold          = 1 * time.Millisecond
 )
 
 // TimeseriesStorageEnabled controls whether to store timeseries data to disk.
@@ -48,11 +48,35 @@ var TimeseriesStorageEnabled = settings.RegisterBoolSetting(
 	true,
 )
 
-// Resolution10StoreDuration defines the amount of time to store internal metrics
-var Resolution10StoreDuration = settings.RegisterDurationSetting(
+// DeprecatedResolution10StoreDuration is a deprecated setting that previously configured
+// how long time series data was retained; it has been replaced with
+// Resolution10sStorageTTL. We retain this setting for backwards compatibility
+// during a version upgrade.
+var DeprecatedResolution10StoreDuration = settings.RegisterDurationSetting(
 	"timeseries.resolution_10s.storage_duration",
-	"the amount of time to store timeseries data",
-	resolution10sDefaultPruneThreshold,
+	"deprecated setting: the amount of time to store timeseries data. "+
+		"Replaced by timeseries.storage.10s_resolution_ttl.",
+	deprecatedResolution10sDefaultPruneThreshold,
+)
+
+// Resolution10sStorageTTL defines the maximum age of data that will be retained
+// at he 10 second resolution. Data older than this is subject to being "rolled
+// up" into the 30 minute resolution and then deleted.
+var Resolution10sStorageTTL = settings.RegisterDurationSetting(
+	"timeseries.storage.10s_resolution_ttl",
+	"the maximum age of time series data stored at the 10 second resolution. Data older than this "+
+		"is subject to rollup and deletion.",
+	resolution10sDefaultRollupThreshold,
+)
+
+// Resolution30mStorageTTL defines the maximum age of data that will be
+// retained at he 30 minute resolution. Data older than this is subject to
+// deletion.
+var Resolution30mStorageTTL = settings.RegisterDurationSetting(
+	"timeseries.storage.30m_resolution_ttl",
+	"the maximum age of time series data stored at the 30 minute resolution. Data older than this "+
+		"is subject to deletion.",
+	resolution30mDefaultPruneThreshold,
 )
 
 // DB provides Cockroach's Time Series API.
@@ -77,11 +101,11 @@ func NewDB(db *client.DB, settings *cluster.Settings) *DB {
 	pruneThresholdByResolution := map[Resolution]func() int64{
 		Resolution10s: func() int64 {
 			if settings.Version.IsMinSupported(cluster.VersionColumnarTimeSeries) {
-				return resolution10sDefaultRollupThreshold.Nanoseconds()
+				return Resolution10sStorageTTL.Get(&settings.SV).Nanoseconds()
 			}
-			return Resolution10StoreDuration.Get(&settings.SV).Nanoseconds()
+			return DeprecatedResolution10StoreDuration.Get(&settings.SV).Nanoseconds()
 		},
-		Resolution30m:  func() int64 { return resolution30mDefaultPruneThreshold.Nanoseconds() },
+		Resolution30m:  func() int64 { return Resolution30mStorageTTL.Get(&settings.SV).Nanoseconds() },
 		resolution1ns:  func() int64 { return resolution1nsDefaultRollupThreshold.Nanoseconds() },
 		resolution50ns: func() int64 { return resolution50nsDefaultPruneThreshold.Nanoseconds() },
 	}

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -860,7 +860,7 @@ func TestPruneThreshold(t *testing.T) {
 		if db.WriteRollups() {
 			expected = resolution10sDefaultRollupThreshold.Nanoseconds()
 		} else {
-			expected = resolution10sDefaultPruneThreshold.Nanoseconds()
+			expected = deprecatedResolution10sDefaultPruneThreshold.Nanoseconds()
 		}
 		result := db.PruneThreshold(Resolution10s)
 		if expected != result {


### PR DESCRIPTION
Add new cluster settings for configuring the rollup and deletion
thresholds for time series data.

Previous to this commit, there was a single setting
`timeseries.resolution_10s.storage_duration`. There are now two settings
for the two resolutions in use: `timeseries.storage.10s_resolution_ttl`
  and `timeseries.storage.30m_resolution_ttl`. The first setting
  controls how long 10 second resolution data is retained before being
  converted to 30 minute resolution; the second controls how long the 30
  minute resolution data is further retained before deletion.

The existing `timeseries.resolution_10s.storage_duration` remains for
backwards-compatibility reasons (it must be present before the cluster
version is upgraded), but should be considered deprecated.

Also adjusted the default values for these two new settings: 10 days for
the 10s TTL, and 90 days for the 30 minute TTL.

Release note (cli change): Added two new cluster settings for
controlling how long time series data is retained on the cluster; the
new settings work with the recently added "roll-ups" to allow longer
retention of time series data while consuming considerably less disk
space.