### PR TITLE
storageccl: don't skip row after deleted row

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1731,7 +1731,7 @@ func TestBackupAsOfSystemTime(t *testing.T) {
 	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&beforeTs)
 
 	err := crdb.ExecuteTx(ctx, sqlDB.DB, nil /* txopts */, func(tx *gosql.Tx) error {
-		_, err := sqlDB.DB.Exec(`DELETE FROM data.bank`)
+		_, err := sqlDB.DB.Exec(`DELETE FROM data.bank WHERE id % 4 = 1`)
 		if err != nil {
 			return err
 		}
@@ -1742,7 +1742,7 @@ func TestBackupAsOfSystemTime(t *testing.T) {
 	}
 
 	sqlDB.QueryRow(t, `SELECT count(*) FROM data.bank`).Scan(&rowCount)
-	if expected := 0; rowCount != expected {
+	if expected := numAccounts * 3 / 4; rowCount != expected {
 		t.Fatalf("expected %d rows but found %d", expected, rowCount)
 	}
 
@@ -1761,7 +1761,7 @@ func TestBackupAsOfSystemTime(t *testing.T) {
 	sqlDB.Exec(t, `DROP TABLE data.bank`)
 	sqlDB.Exec(t, `RESTORE data.* FROM $1`, equalDir)
 	sqlDB.QueryRow(t, `SELECT count(*) FROM data.bank`).Scan(&rowCount)
-	if expected := 0; rowCount != expected {
+	if expected := numAccounts * 3 / 4; rowCount != expected {
 		t.Fatalf("expected %d rows but found %d", expected, rowCount)
 	}
 }

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -175,12 +175,6 @@ func evalExport(
 		// Skip tombstone (len=0) records when startTime is zero
 		// (non-incremental) and we're not exporting all versions.
 		if skipTombstones && args.StartTime.IsEmpty() && len(iter.UnsafeValue()) == 0 {
-			iter.NextKey()
-			if ok, err := iter.Valid(); err != nil {
-				return result.Result{}, err
-			} else if !ok {
-				break
-			}
 			continue
 		}
 


### PR DESCRIPTION
We don't need to manually advance the iterator before calling `continue`
since the for loop advances it as well, and doing so means the row
_following_ a deleted row is also skipped.

Fixes #28171.

Release note (bug fix): Fix bug that could skip the row following a deleted row during BACKUP.