### PR TITLE
[dnm] opt: close left node if right node fails to build

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -424,6 +426,7 @@ func (b *Builder) initJoinBuild(
 	}
 	rightPlan, err = b.buildRelational(rightChild)
 	if err != nil {
+		leftPlan.root.Close(context.Background())
 		return execPlan{}, execPlan{}, nil, opt.ColMap{}, err
 	}
 

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -15,6 +15,8 @@
 package exec
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -25,7 +27,9 @@ import (
 
 // Node represents a node in the execution tree
 // (currently maps to sql.planNode).
-type Node interface{}
+type Node interface {
+	Close(ctx context.Context)
+}
 
 // Plan represents the plan for a query (currently maps to sql.planTop).
 // For simple queries, the plan is associated with a single Node tree.


### PR DESCRIPTION
This is an incomplete proof of concept of a patch that cleans up
exec.Nodes if the build process fails. This is now important because of
the virtual scan infrastructure, since valuesNodes track their memory
and need to be cleaned up with Close at some point, and not just
abandoned to the heap.

Release note: None