### PR TITLE
sql: nicer test failures for TraceTest

### DIFF
--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -326,8 +326,7 @@ func TestTrace(t *testing.T) {
 								if r >= len(test.expSpans) {
 									t.Errorf("extra span: %s", op)
 									remainingErr = true
-								}
-								if op != test.expSpans[r] {
+								} else if op != test.expSpans[r] {
 									t.Errorf("expected span: %q, got: %q", test.expSpans[r], op)
 									remainingErr = true
 								}


### PR DESCRIPTION
Before this patch, if the test got an unexpected span, it'd crash trying
to index into the expected spans.

Release note: None