### PR TITLE
sql: remove a wasteful sprintf

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2007,10 +2007,9 @@ func (ex *connExecutor) getPrepStmtsAccessor() preparedStatementsAccessor {
 
 // sessionEventf logs a message to the session event log (if any).
 func (ex *connExecutor) sessionEventf(ctx context.Context, format string, args ...interface{}) {
-	str := fmt.Sprintf(format, args...)
-	log.VEventfDepth(ex.Ctx(), 1 /* depth */, 2 /* level */, str)
+	log.VEventfDepth(ex.Ctx(), 1 /* depth */, 2 /* level */, format, args...)
 	if ex.eventLog != nil {
-		ex.eventLog.Printf("%s", str)
+		ex.eventLog.Printf(format, args...)
 	}
 }
 


### PR DESCRIPTION
Previously, sessionEventf would unconditionally sprintf its arguments,
even if not necessary for logs.

Release note: None