### PR TITLE
sql: support casting arrays and tuples to strings

### DIFF
--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3068,6 +3068,10 @@ func PerformCast(ctx *EvalContext, d Datum, t coltypes.CastTargetType) (Datum, e
 			s = d.String()
 		case *DTimestamp, *DTimestampTZ, *DDate, *DTime, *DTimeTZ:
 			s = AsStringWithFlags(d, FmtBareStrings)
+		case *DTuple:
+			s = AsStringWithFlags(d, FmtPgwireText)
+		case *DArray:
+			s = AsStringWithFlags(d, FmtPgwireText)
 		case *DInterval:
 			// When converting an interval to string, we need a string representation
 			// of the duration (e.g. "5s") and not of the interval itself (e.g.

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -1410,6 +1410,16 @@ func TestEval(t *testing.T) {
 		{`convert_to('abå', 'latin1')`, `'\x6162e5'`},
 		{`convert_to('abå', 'utf8')`, `'\x6162c3a5'`},
 		{`convert_to('ab漢', 'utf8')`, `'\x6162e6bca2'`},
+		{`(1,2,3)::string`, `'(1,2,3)'`},
+		{`(1,NULL,3)::string`, `'(1,,3)'`},
+		{`(1,'a"b',3)::string`, `'(1,"a""b",3)'`},
+		{`(1,(2,3))::string`, `'(1,"(2,3)")'`},
+		{`(1,(2,'a"b'))::string`, `'(1,"(2,""a""""b"")")'`},
+		{`(1,array['a','b"c'])::string`, `e'(1,"{""a"",""b\\\\""c""}")'`},
+		{`ARRAY[1,2,3]::string`, `'{1,2,3}'`},
+		{`ARRAY[1,NULL,3]::string`, `'{1,NULL,3}'`},
+		{`ARRAY['a b','c"d']::string`, `e'{"a b","c\\"d"}'`},
+		{`ARRAY[(1,'a b'),(2,'c"d')]::string`, `e'{"(1,\\"a b\\")","(2,\\"c\\"\\"d\\")"}'`},
 	}
 	ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	// We have to manually close this account because we're doing the evaluations

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1400,6 +1400,7 @@ var (
 	decimalCastTypes = []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
 		types.Timestamp, types.TimestampTZ, types.Date, types.Interval}
 	stringCastTypes = []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
+		types.FamArray, types.FamTuple,
 		types.Bytes, types.Timestamp, types.TimestampTZ, types.Interval, types.UUID, types.Date, types.Time, types.TimeTZ, types.Oid, types.INet, types.JSON}
 	bytesCastTypes     = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Bytes, types.UUID}
 	dateCastTypes      = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Date, types.Timestamp, types.TimestampTZ, types.Int}


### PR DESCRIPTION
Fixes #24746.
Forked off #28143.

The previous patch to fix pgwire text encoding for tuples/arrays
really defines a different conversion algorithm from array/tuples to
strings.

This incidentally is the general-purpose algorithm used in PostgreSQL
to convert arrays and tuples to strings, not just for pgwire.

This patch utilizes this observation to define the new
(and now correct) casts from array and tuple types to strings
based on the new algorithm, like PostgreSQL does.

Release note (sql change): CockroachDB now supports converting arrays
and tuples to strings for compatibility with PostgreSQL.