### PR TITLE
opt: Fix memory budget bug with virtual tables

### DIFF
--- a/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
+++ b/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
@@ -90,7 +90,7 @@ end_test
 start_test "Ensure that memory monitoring prevents crashes"
 # Re-launch a server with relatively lower limit for SQL memory
 set spawn_id $shell_spawn_id
-send "$argv start --insecure --max-sql-memory=150K --no-redirect-stderr -s=path=logs/db \r"
+send "$argv start --insecure --max-sql-memory=1000K --no-redirect-stderr -s=path=logs/db \r"
 eexpect "restarted pre-existing node"
 sleep 2
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/information_schema
+++ b/pkg/sql/opt/exec/execbuilder/testdata/information_schema
@@ -3,12 +3,12 @@
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM system.information_schema.schemata
 ----
-values  ·     ·                  (catalog_name, schema_name, default_character_set_name, sql_path)  ·
-·       size  4 columns, 4 rows  ·                                                                  ·
+virtual table  ·       ·  (catalog_name, schema_name, default_character_set_name, sql_path)  ·
+·              source  ·  ·                                                                  ·
 
 query TTT
 EXPLAIN SELECT * FROM system.information_schema.tables WHERE table_name='foo'
 ----
-filter       ·     ·
- └── values  ·     ·
-·            size  6 columns, 102 rows
+filter              ·       ·
+ └── virtual table  ·       ·
+·                   source  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -32,12 +32,12 @@ append     ·      ·
 query TTT
 EXPLAIN SELECT node_id FROM crdb_internal.node_build_info UNION VALUES(123)
 ----
-union             ·     ·
- ├── values       ·     ·
- │                size  1 column, 1 row
- └── render       ·     ·
-      └── values  ·     ·
-·                 size  3 columns, 6 rows
+union                    ·       ·
+ ├── values              ·       ·
+ │                       size    1 column, 1 row
+ └── render              ·       ·
+      └── virtual table  ·       ·
+·                        source  ·
 
 statement ok
 CREATE TABLE abc (a INT, b INT, c INT)

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -401,7 +401,7 @@ func (p *planner) makeOptimizerPlan(ctx context.Context, stmt Statement) error {
 
 	ev := o.Optimize(root, props)
 
-	factory := makeExecFactory(ctx, p)
+	factory := makeExecFactory(p)
 	plan, err := execbuilder.New(&factory, ev).Build()
 	if err != nil {
 		return err


### PR DESCRIPTION
The execbuilder immediately triggers construction of virtual table rows. This
causes a valuesNode to be created to hold the rows, which in turn triggers
memory budgeting. However, when the budget is exceeded, the resulting error
path never calls Close() on the valuesNode, and the server panics when it
detects the failure to clean up.

The fix is to delay construction of the virtual table rows by using a
delayedNode. A new startExec() method on delayedNode will invoke its
constructor to create the wrapped valuesNode. This happens during execution,
after the plan tree has been fully constructed, and so the execution engine
cleans up any used memory in the error case.

Release note: None