### PR TITLE
ui: change disk capacity graph on HW dashboard to available per node

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -3,8 +3,7 @@ import React from "react";
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
-import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
-import * as docsURL from "oss/src/util/docs";
+import {GraphDashboardProps, nodeDisplayName, storeIDsForNode} from "./dashboardUtils";
 
 // TODO(vilterp): tooltips
 
@@ -142,39 +141,17 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Disk Capacity"
+      title="Available Disk Capacity"
       sources={storeSources}
-      tooltip={(
-        <div>
-          <dl>
-            <dt>Capacity</dt>
-            <dd>
-              Total disk space available {tooltipSelection} to CockroachDB.
-              {" "}
-              <em>
-                Control this value per node with the
-                {" "}
-                <code>
-                  <a href={docsURL.startFlags} target="_blank">
-                    --store
-                  </a>
-                </code>
-                {" "}
-                flag.
-              </em>
-            </dd>
-            <dt>Available</dt>
-            <dd>Free disk space available {tooltipSelection} to CockroachDB.</dd>
-            <dt>Used</dt>
-            <dd>Disk space used {tooltipSelection} by CockroachDB.</dd>
-          </dl>
-        </div>
-      )}
     >
       <Axis units={AxisUnits.Bytes} label="capacity">
-        <Metric name="cr.store.capacity" title="Capacity" />
-        <Metric name="cr.store.capacity.available" title="Available" />
-        <Metric name="cr.store.capacity.used" title="Used" />
+        {nodeIDs.map((nid) => (
+          <Metric
+            name="cr.store.capacity.available"
+            sources={storeIDsForNode(nodesSummary, nid)}
+            title={nodeDisplayName(nodesSummary, nid)}
+          />
+        ))}
       </Axis>
     </LineGraph>,
 


### PR DESCRIPTION
Instead of showing aggregated available, used, and total across all nodes.

This is in keeping with the Hardware dashboard's focus on allowing the operator to see imbalances between nodes, and makes it easier to see when a node is about to fill up. The cluster-wide capacity graph is still available on the overview dashboard.

![image](https://user-images.githubusercontent.com/7341/43556524-1c79d82a-95ce-11e8-8336-9642e4aee76d.png)


Release note: None