### PR TITLE
 sql: avoid using Tuple in ValuesClause

### DIFF
--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -290,9 +290,9 @@ func insertStmtToKVs(
 		Mapping: ri.InsertColIDtoRowIndex,
 		Cols:    tableDesc.Columns,
 	}
-	for _, tuple := range values.Tuples {
-		row := make([]tree.Datum, len(tuple.Exprs))
-		for i, expr := range tuple.Exprs {
+	for _, tuple := range values.Rows {
+		row := make([]tree.Datum, len(tuple))
+		for i, expr := range tuple {
 			if expr == tree.DNull {
 				row[i] = tree.DNull
 				continue

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -459,12 +459,12 @@ func (m *pgDumpReader) readFile(
 			}
 			inserts++
 			startingCount := count
-			for _, tuple := range values.Tuples {
+			for _, tuple := range values.Rows {
 				count++
-				if expected, got := len(conv.visibleCols), len(tuple.Exprs); expected != got {
+				if expected, got := len(conv.visibleCols), len(tuple); expected != got {
 					return errors.Errorf("expected %d values, got %d: %v", expected, got, tuple)
 				}
-				for i, expr := range tuple.Exprs {
+				for i, expr := range tuple {
 					typed, err := expr.TypeCheck(semaCtx, conv.visibleColTypes[i])
 					if err != nil {
 						return errors.Wrapf(err, "reading row %d (%d in insert statement %d)",

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1791,7 +1791,7 @@ cancel_jobs_stmt:
   {
     $$.val = &tree.ControlJobs{
       Jobs: &tree.Select{
-        Select: &tree.ValuesClause{Tuples: []*tree.Tuple{{Exprs: tree.Exprs{$3.expr()}}}},
+        Select: &tree.ValuesClause{Rows: []tree.Exprs{tree.Exprs{$3.expr()}}},
       },
       Command: tree.CancelJob,
     }
@@ -1814,7 +1814,7 @@ cancel_queries_stmt:
   {
     $$.val = &tree.CancelQueries{
       Queries: &tree.Select{
-        Select: &tree.ValuesClause{Tuples: []*tree.Tuple{{Exprs: tree.Exprs{$3.expr()}}}},
+        Select: &tree.ValuesClause{Rows: []tree.Exprs{tree.Exprs{$3.expr()}}},
       },
       IfExists: false,
     }
@@ -1823,7 +1823,7 @@ cancel_queries_stmt:
   {
     $$.val = &tree.CancelQueries{
       Queries: &tree.Select{
-        Select: &tree.ValuesClause{Tuples: []*tree.Tuple{{Exprs: tree.Exprs{$5.expr()}}}},
+        Select: &tree.ValuesClause{Rows: []tree.Exprs{tree.Exprs{$5.expr()}}},
       },
       IfExists: true,
     }
@@ -1850,7 +1850,7 @@ cancel_sessions_stmt:
   {
    $$.val = &tree.CancelSessions{
       Sessions: &tree.Select{
-        Select: &tree.ValuesClause{Tuples: []*tree.Tuple{{Exprs: tree.Exprs{$3.expr()}}}},
+        Select: &tree.ValuesClause{Rows: []tree.Exprs{tree.Exprs{$3.expr()}}},
       },
       IfExists: false,
     }
@@ -1859,7 +1859,7 @@ cancel_sessions_stmt:
   {
    $$.val = &tree.CancelSessions{
       Sessions: &tree.Select{
-        Select: &tree.ValuesClause{Tuples: []*tree.Tuple{{Exprs: tree.Exprs{$5.expr()}}}},
+	    Select: &tree.ValuesClause{Rows: []tree.Exprs{tree.Exprs{$5.expr()}}},
       },
       IfExists: true,
     }
@@ -3493,7 +3493,7 @@ pause_stmt:
   {
     $$.val = &tree.ControlJobs{
       Jobs: &tree.Select{
-        Select: &tree.ValuesClause{Tuples: []*tree.Tuple{{Exprs: tree.Exprs{$3.expr()}}}},
+        Select: &tree.ValuesClause{Rows: []tree.Exprs{tree.Exprs{$3.expr()}}},
       },
       Command: tree.PauseJob,
     }
@@ -4420,7 +4420,7 @@ resume_stmt:
   {
     $$.val = &tree.ControlJobs{
       Jobs: &tree.Select{
-        Select: &tree.ValuesClause{Tuples: []*tree.Tuple{{Exprs: tree.Exprs{$3.expr()}}}},
+        Select: &tree.ValuesClause{Rows: []tree.Exprs{tree.Exprs{$3.expr()}}},
       },
       Command: tree.ResumeJob,
     }
@@ -5383,13 +5383,13 @@ having_clause:
 values_clause:
   VALUES '(' expr_list ')' %prec UMINUS
   {
-    $$.val = &tree.ValuesClause{Tuples: []*tree.Tuple{{Exprs: $3.exprs()}}}
+    $$.val = &tree.ValuesClause{Rows: []tree.Exprs{$3.exprs()}}
   }
 | VALUES error // SHOW HELP: VALUES
 | values_clause ',' '(' expr_list ')'
   {
     valNode := $1.selectStmt().(*tree.ValuesClause)
-    valNode.Tuples = append(valNode.Tuples, &tree.Tuple{Exprs: $4.exprs()})
+    valNode.Rows = append(valNode.Rows, $4.exprs())
     $$.val = valNode
   }
 

--- a/pkg/sql/sem/tree/col_name.go
+++ b/pkg/sql/sem/tree/col_name.go
@@ -186,7 +186,7 @@ func computeColNameInternalSubquery(
 	case *ParenSelect:
 		return computeColNameInternalSubquery(sp, e.Select.Select)
 	case *ValuesClause:
-		if len(e.Tuples) > 0 && len(e.Tuples[0].Exprs) == 1 {
+		if len(e.Rows) > 0 && len(e.Rows[0]) == 1 {
 			return 2, "column1", nil
 		}
 	case *SelectClause:

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -882,9 +882,9 @@ func (node *ValuesClause) doc(p *PrettyCfg) pretty.Doc {
 }
 
 func (node *ValuesClause) docTable(p *PrettyCfg) []pretty.RLTableRow {
-	d := make([]pretty.Doc, len(node.Tuples))
-	for i, n := range node.Tuples {
-		d[i] = p.Doc(n)
+	d := make([]pretty.Doc, len(node.Rows))
+	for i := range node.Rows {
+		d[i] = pretty.Bracket("(", p.Doc(&node.Rows[i]), ")")
 	}
 	return []pretty.RLTableRow{p.row("VALUES", pretty.Join(",", d...))}
 }

--- a/pkg/sql/sem/tree/type_check_internal_test.go
+++ b/pkg/sql/sem/tree/type_check_internal_test.go
@@ -499,7 +499,7 @@ func TestProcessPlaceholderAnnotations(t *testing.T) {
 	}
 	for i, d := range testData {
 		args := d.initArgs
-		stmt := &tree.ValuesClause{Tuples: []*tree.Tuple{{Exprs: d.stmtExprs}}}
+		stmt := &tree.ValuesClause{Rows: []tree.Exprs{d.stmtExprs}}
 		if err := args.ProcessPlaceholderAnnotations(stmt); err != nil {
 			t.Errorf("%d: unexpected error returned from ProcessPlaceholderAnnotations: %v", i, err)
 		} else if !reflect.DeepEqual(args, d.desired) {
@@ -569,7 +569,7 @@ func TestProcessPlaceholderAnnotationsError(t *testing.T) {
 	}
 	for i, d := range testData {
 		args := d.initArgs
-		stmt := &tree.ValuesClause{Tuples: []*tree.Tuple{{Exprs: d.stmtExprs}}}
+		stmt := &tree.ValuesClause{Rows: []tree.Exprs{d.stmtExprs}}
 		if err := args.ProcessPlaceholderAnnotations(stmt); !testutils.IsError(err, d.expected) {
 			t.Errorf("%d: expected %s, but found %v", i, d.expected, err)
 		}

--- a/pkg/sql/sem/tree/values.go
+++ b/pkg/sql/sem/tree/values.go
@@ -25,16 +25,18 @@ package tree
 
 // ValuesClause represents a VALUES clause.
 type ValuesClause struct {
-	Tuples []*Tuple
+	Rows []Exprs
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ValuesClause) Format(ctx *FmtCtx) {
 	ctx.WriteString("VALUES ")
-	for i, n := range node.Tuples {
-		if i > 0 {
-			ctx.WriteString(", ")
-		}
-		ctx.FormatNode(n)
+	comma := ""
+	for i := range node.Rows {
+		ctx.WriteString(comma)
+		ctx.WriteByte('(')
+		ctx.FormatNode(&node.Rows[i])
+		ctx.WriteByte(')')
+		comma = ", "
 	}
 }

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -1296,13 +1296,13 @@ func (stmt *Update) walkStmt(v Visitor) Statement {
 // walkStmt is part of the walkableStmt interface.
 func (stmt *ValuesClause) walkStmt(v Visitor) Statement {
 	ret := stmt
-	for i, tuple := range stmt.Tuples {
-		t, changed := WalkExpr(v, tuple)
+	for i, tuple := range stmt.Rows {
+		exprs, changed := walkExprSlice(v, tuple)
 		if changed {
 			if ret == stmt {
-				ret = &ValuesClause{append([]*Tuple(nil), stmt.Tuples...)}
+				ret = &ValuesClause{append([]Exprs(nil), stmt.Rows...)}
 			}
-			ret.Tuples[i] = t.(*Tuple)
+			ret.Rows[i] = exprs
 		}
 	}
 	return ret

--- a/pkg/sql/tests/planhook.go
+++ b/pkg/sql/tests/planhook.go
@@ -37,8 +37,8 @@ func init() {
 		header := sqlbase.ResultColumns{
 			{Name: "value", Typ: types.String},
 		}
-		rows := &tree.Tuple{Exprs: tree.Exprs{tree.NewStrVal(show.Name)}}
-		sel := &tree.Select{Select: &tree.ValuesClause{Tuples: []*tree.Tuple{rows}}}
+		rows := tree.Exprs{tree.NewStrVal(show.Name)}
+		sel := &tree.Select{Select: &tree.ValuesClause{Rows: []tree.Exprs{rows}}}
 		subPlan, err := state.Select(ctx, sel, nil)
 
 		return func(_ context.Context, subPlans []sql.PlanNode, resultsCh chan<- tree.Datums) error {

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -51,14 +51,14 @@ func (p *planner) Values(
 		specifiedInQuery: true,
 		isConst:          true,
 	}
-	if len(n.Tuples) == 0 {
+	if len(n.Rows) == 0 {
 		return v, nil
 	}
 
-	numCols := len(n.Tuples[0].Exprs)
+	numCols := len(n.Rows[0])
 
-	v.tuples = make([][]tree.TypedExpr, 0, len(n.Tuples))
-	tupleBuf := make([]tree.TypedExpr, len(n.Tuples)*numCols)
+	v.tuples = make([][]tree.TypedExpr, 0, len(n.Rows))
+	tupleBuf := make([]tree.TypedExpr, len(n.Rows)*numCols)
 
 	v.columns = make(sqlbase.ResultColumns, 0, numCols)
 
@@ -72,8 +72,8 @@ func (p *planner) Values(
 	// Ensure there are no special functions in the clause.
 	p.semaCtx.Properties.Require("VALUES", tree.RejectSpecial)
 
-	for num, tuple := range n.Tuples {
-		if a, e := len(tuple.Exprs), numCols; a != e {
+	for num, tuple := range n.Rows {
+		if a, e := len(tuple), numCols; a != e {
 			return nil, newValuesListLenErr(e, a)
 		}
 
@@ -81,7 +81,7 @@ func (p *planner) Values(
 		tupleRow := tupleBuf[:numCols:numCols]
 		tupleBuf = tupleBuf[numCols:]
 
-		for i, expr := range tuple.Exprs {
+		for i, expr := range tuple {
 			desired := types.Any
 			if len(desiredTypes) > i {
 				desired = desiredTypes[i]

--- a/pkg/sql/values_test.go
+++ b/pkg/sql/values_test.go
@@ -83,11 +83,11 @@ func TestValues(t *testing.T) {
 		return []tree.Datums{datums}
 	}
 
-	makeValues := func(tuples ...*tree.Tuple) *tree.ValuesClause {
-		return &tree.ValuesClause{Tuples: tuples}
+	makeValues := func(tuples ...tree.Exprs) *tree.ValuesClause {
+		return &tree.ValuesClause{Rows: tuples}
 	}
-	makeTuple := func(exprs ...tree.Expr) *tree.Tuple {
-		return &tree.Tuple{Exprs: exprs}
+	makeTuple := func(exprs ...tree.Expr) tree.Exprs {
+		return tree.Exprs(exprs)
 	}
 
 	testCases := []struct {


### PR DESCRIPTION
Forked off from #28143.
Needed for #26624.

The `Tuple` AST node is really about scalar tuples. The `VALUES`
clause operands are not really scalar tuples. So instead use
`Exprs` for `ValuesClause`.

This will simplify later patch to fix the handling of scalar tuples.

Release note: None

