### PR TITLE
release-2.0: storageccl: don't skip row after deleted row

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1813,7 +1813,7 @@ func TestBackupAsOfSystemTime(t *testing.T) {
 	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&beforeTs)
 
 	err := crdb.ExecuteTx(ctx, sqlDB.DB, nil /* txopts */, func(tx *gosql.Tx) error {
-		_, err := sqlDB.DB.Exec(`DELETE FROM data.bank`)
+		_, err := sqlDB.DB.Exec(`DELETE FROM data.bank WHERE id % 4 = 1`)
 		if err != nil {
 			return err
 		}
@@ -1823,8 +1823,8 @@ func TestBackupAsOfSystemTime(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sqlDB.QueryRow(t, `SELECT COUNT(*) FROM data.bank`).Scan(&rowCount)
-	if expected := 0; rowCount != expected {
+	sqlDB.QueryRow(t, `SELECT count(*) FROM data.bank`).Scan(&rowCount)
+	if expected := numAccounts * 3 / 4; rowCount != expected {
 		t.Fatalf("expected %d rows but found %d", expected, rowCount)
 	}
 
@@ -1842,8 +1842,8 @@ func TestBackupAsOfSystemTime(t *testing.T) {
 
 	sqlDB.Exec(t, `DROP TABLE data.bank`)
 	sqlDB.Exec(t, `RESTORE data.* FROM $1`, equalDir)
-	sqlDB.QueryRow(t, `SELECT COUNT(*) FROM data.bank`).Scan(&rowCount)
-	if expected := 0; rowCount != expected {
+	sqlDB.QueryRow(t, `SELECT count(*) FROM data.bank`).Scan(&rowCount)
+	if expected := numAccounts * 3 / 4; rowCount != expected {
 		t.Fatalf("expected %d rows but found %d", expected, rowCount)
 	}
 }

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -175,7 +175,6 @@ func evalExport(
 		// Skip tombstone (len=0) records when startTime is zero
 		// (non-incremental) and we're not exporting all versions.
 		if skipTombstones && args.StartTime.IsEmpty() && len(iter.UnsafeValue()) == 0 {
-			iter.NextKey()
 			continue
 		}
 


### PR DESCRIPTION
Backport 1/1 commits from #28172.

/cc @cockroachdb/release

---

We don't need to manually advance the iterator before calling `continue`
since the for loop advances it as well, and doing so means the row
_following_ a deleted row is also skipped.

Fixes #28171.

Release note (bug fix): Fix bug that could skip the row following a deleted row during BACKUP.
