### PR TITLE
cli: ensure user set --password can also modify the password

### DIFF
--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -50,13 +50,19 @@ eexpect "empty passwords are not permitted"
 eexpect $prompt
 end_test
 
+start_test "Make the user without password."
+send "$argv user set carl --certs-dir=$certs_dir\r"
+eexpect "CREATE USER"
+eexpect $prompt
+end_test
+
 start_test "Check a password can be changed."
 send "$argv user set carl --password --certs-dir=$certs_dir\r"
 eexpect "Enter password:"
 send "woof\r"
 eexpect "Confirm password:"
 send "woof\r"
-eexpect "CREATE USER"
+eexpect "ALTER USER"
 eexpect $prompt
 end_test
 


### PR DESCRIPTION
Fixes  #27882.

Until now the flag `--password` could only set the password if the
user did not exist previously (ie. during user creation). This patch
fixes the feature so that `--password` can be used to change an
existing user's password.

Release note (bug fix): `cockroach user set --password` can now change
the password of existing users.