### PR TITLE
cli: hint client flags in the output of `cockroach start`

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -566,6 +566,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(tw, "build:\t%s %s @ %s (%s)\n", info.Distribution, info.Tag, info.Time, info.GoVersion)
 			fmt.Fprintf(tw, "webui:\t%s\n", serverCfg.AdminURL())
 			fmt.Fprintf(tw, "sql:\t%s\n", pgURL)
+			fmt.Fprintf(tw, "client flags:\t%s\n", clientFlags())
 			if len(serverCfg.SocketFile) != 0 {
 				fmt.Fprintf(tw, "socket:\t%s\n", serverCfg.SocketFile)
 			}
@@ -785,6 +786,22 @@ func runStart(cmd *cobra.Command, args []string) error {
 	}
 
 	return returnErr
+}
+
+func clientFlags() string {
+	flags := []string{os.Args[0]}
+	host, port, err := net.SplitHostPort(serverCfg.AdvertiseAddr)
+	if err == nil {
+		flags = append(flags,
+			"--host="+host,
+			"--port="+port)
+	}
+	if startCtx.serverInsecure {
+		flags = append(flags, "--insecure")
+	} else {
+		flags = append(flags, "--certs-dir="+startCtx.serverSSLCertsDir)
+	}
+	return strings.Join(flags, " ")
 }
 
 func reportConfiguration(ctx context.Context) {


### PR DESCRIPTION
Fixes #14325.
Requested by @sploiselle.

When one starts a node with the --host/--advertise flag, all future
clients commands require the same value in --host. However, there is
no in-app messaging that communicates this requirement, nor is there a
command that you can run to find out what the --host flag was set to.

Ditto for --certs-dir.

This patch enhances the situation by announcing the command prefix to
use for client commands in the output of `cockroach start`. For
example:

```
% ./cockroach start --certs-dir=certs --host=localhost
CockroachDB node starting [...]
...
client flags:        ./cockroach --host=localhost --port=26257 --certs-dir=certs
...
```

```
% ./cockroach start --certs-dir=certs --host=localhost --advertise-host=kenax
CockroachDB node starting [...]
...
client flags:        ./cockroach --host=kenax --port=26257 --certs-dir=certs
...
```

Release note (cli change): `cockroach start` now informs the user of
which command-line flags to use to access the newly started node in
client commands (e.g. `cockroach quit` etc.).