### PR TITLE
cli: control the sum of --cache + --max-sql-memory

### DIFF
--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -27,6 +27,17 @@ interrupt
 eexpect ":/# "
 end_test
 
+start_test "Check that memory max flags do not exceed available RAM."
+send "$argv start --insecure --cache=.40 --max-sql-memory=.40\r"
+eexpect "WARNING: the sum of --max-sql-memory"
+eexpect "is larger than"
+eexpect "of total RAM"
+eexpect "increased risk"
+eexpect "node starting"
+interrupt
+eexpect ":/# "
+end_test
+
 start_test {Check that the "failed running SUBCOMMAND" message does not consider a flag the subcommand}
 send "$argv --verbosity 2 start --garbage\r"
 eexpect {Failed running "start"}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -827,6 +827,17 @@ func maybeWarnMemorySizes(ctx context.Context) {
 		}
 		log.Warning(ctx, buf.String())
 	}
+
+	// Check that the total suggested "max" memory is well below the available memory.
+	if maxMemory, err := server.GetTotalMemory(ctx); err == nil {
+		requestedMem := serverCfg.CacheSize + serverCfg.SQLMemoryPoolSize
+		maxRecommendedMem := int64(.75 * float64(maxMemory))
+		if requestedMem > maxRecommendedMem {
+			log.Shout(ctx, log.Severity_WARNING, fmt.Sprintf(
+				"the sum of --max-sql-memory (%s) and --cache (%s) is larger than 75%% of total RAM (%s).\nThis server is running at increased risk of memory-related failures.",
+				sqlSizeValue, cacheSizeValue, humanizeutil.IBytes(maxRecommendedMem)))
+		}
+	}
 }
 
 func logOutputDirectory() string {


### PR DESCRIPTION
Fixes #24396

Release note (cli change): `cockroach start` now reports a waraning if
more than 75% of available RAM is reserved by `--cache` and
`--max-sql-memory`.