### PR TITLE
cli: enhance errors reported upon conn failures

### DIFF
--- a/pkg/cli/interactive_tests/netcat.py
+++ b/pkg/cli/interactive_tests/netcat.py
@@ -1,0 +1,15 @@
+import socket
+import sys
+
+server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+server.bind(("0.0.0.0", 26257))
+server.listen(1)
+print "ready"
+client_socket, addr = server.accept()
+print "connected"
+
+while True:
+    c = client_socket.recv(1)
+    sys.stdout.write("%c" % c)
+    sys.stdout.flush()

--- a/pkg/cli/interactive_tests/test_error_hints.tcl
+++ b/pkg/cli/interactive_tests/test_error_hints.tcl
@@ -1,0 +1,156 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+set fakeserv [file join [file dirname $argv0] netcat.py]
+
+# We'll override security defaults below.
+set certs_dir "/certs"
+set ::env(COCKROACH_INSECURE) "false"
+
+spawn /bin/bash
+set shell_spawn_id $spawn_id
+
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+# Check what happens when attempting to connect and the server does not exist.
+
+start_test "Connecting a RPC client to a non-started server"
+send "$argv quit\r"
+eexpect "Error: cannot load certificates.\r\nCheck your certificate settings"
+eexpect "or use --insecure"
+eexpect ":/# "
+
+send "$argv quit --certs-dir=$certs_dir\r"
+eexpect "Error: cannot dial server.\r\nIs the server running?"
+eexpect "connection refused"
+eexpect ":/# "
+end_test
+
+start_test "Connecting a SQL client to a non-started server"
+send "$argv sql -e 'select 1'\r"
+eexpect "Error: cannot load certificates.\r\nCheck your certificate settings"
+eexpect "or use --insecure"
+eexpect ":/# "
+
+send "$argv sql -e 'select 1' --certs-dir=$certs_dir\r"
+eexpect "Error: cannot dial server.\r\nIs the server running?"
+eexpect "connection refused"
+eexpect ":/# "
+end_test
+
+# Check what happens when attempting to connect securely to an
+# insecure server.
+
+send "$argv start --insecure\r"
+eexpect "initialized new cluster"
+
+spawn /bin/bash
+set client_spawn_id $spawn_id
+
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+start_test "Connecting a secure RPC client to an insecure server"
+send "$argv quit --certs-dir=$certs_dir\r"
+eexpect "Error: cannot establish secure connection to insecure server."
+eexpect "Maybe use --insecure?"
+eexpect ":/# "
+end_test
+
+start_test "Connecting a secure SQL client to an insecure server"
+send "$argv sql -e 'select 1' --certs-dir=$certs_dir\r"
+eexpect "Error: cannot establish secure connection to insecure server."
+eexpect ":/# "
+end_test
+
+# Check what happens when attempting to connect insecurely to a secure
+# server.
+
+set spawn_id $shell_spawn_id
+interrupt
+interrupt
+eexpect ":/# "
+
+send "$argv start --certs-dir=$certs_dir\r"
+eexpect "restarted pre-existing node"
+
+set spawn_id $client_spawn_id
+
+start_test "Connecting an insecure RPC client to a secure server"
+send "$argv quit --insecure\r"
+eexpect "Error: server closed the connection."
+eexpect "remove --insecure"
+eexpect ":/# "
+end_test
+
+start_test "Connecting an insecure SQL client to a secure server"
+send "$argv sql -e 'select 1' --insecure\r"
+eexpect "Error: SSL authentication error while connecting."
+eexpect "remove --insecure"
+eexpect ":/# "
+end_test
+
+# Check what happens when attempting to connect to something
+# that is not a CockroachDB server.
+set spawn_id $shell_spawn_id
+interrupt
+interrupt
+eexpect ":/# "
+
+start_test "Connecting an insecure RPC client to a non-CockroachDB server"
+# In one shell, start a bogus server
+send "python2 $fakeserv\r"
+eexpect "ready"
+# In the other shell, try to run cockroach quit
+set spawn_id $client_spawn_id
+send "$argv quit --insecure\r"
+eexpect "insecure\r\n"
+# In the first shell, stop the server.
+set spawn_id $shell_spawn_id
+eexpect "connected"
+eexpect ":26257"
+interrupt
+eexpect ":/# "
+# Check that cockroach quit becomes suitably confused.
+set spawn_id $client_spawn_id
+eexpect "Error: server closed the connection."
+eexpect "Is this a CockroachDB node?"
+eexpect ":/# "
+set spawn_id $shell_spawn_id
+end_test
+
+start_test "Connecting an insecure SQL client to a non-CockroachDB server"
+# In one shell, start a bogus server
+send "python2 $fakeserv\r"
+eexpect "ready"
+# In the other shell, try to run cockroach sql
+set spawn_id $client_spawn_id
+send "$argv sql -e 'select 1' --insecure\r"
+eexpect "insecure\r\n"
+# In the first shell, wait for netcat to receive garbage,
+# then kill it
+set spawn_id $shell_spawn_id
+eexpect "connected"
+eexpect "cockroach sql"
+interrupt
+eexpect ":/# "
+# Check that cockroach sql becomes suitably confused.
+set spawn_id $client_spawn_id
+eexpect "Error: server closed the connection."
+eexpect "Is this a CockroachDB node?"
+eexpect "EOF"
+eexpect ":/# "
+set spawn_id $shell_spawn_id
+end_test
+
+
+# clean up the background processes
+set spawn_id $shell_spawn_id
+send "exit\r"
+eexpect eof
+
+set spawn_id $client_spawn_id
+send "exit\r"
+eexpect eof

--- a/pkg/security/certificate_loader.go
+++ b/pkg/security/certificate_loader.go
@@ -255,11 +255,11 @@ func (cl *CertificateLoader) MaybeCreateCertsDir() error {
 	}
 
 	if !os.IsNotExist(err) {
-		return errors.Wrapf(err, "could not stat certs directory %s", cl.certsDir)
+		return makeErrorf(err, "could not stat certs directory %s", cl.certsDir)
 	}
 
 	if err := os.Mkdir(cl.certsDir, defaultCertsDirPerm); err != nil {
-		return errors.Wrapf(err, "could not create certs directory %s", cl.certsDir)
+		return makeErrorf(err, "could not create certs directory %s", cl.certsDir)
 	}
 	return nil
 }
@@ -390,7 +390,7 @@ func (cl *CertificateLoader) findKey(ci *CertInfo) error {
 // The Error field must be nil
 func parseCertificate(ci *CertInfo) error {
 	if ci.Error != nil {
-		return errors.Wrapf(ci.Error, "parseCertificate called on bad CertInfo object: %s", ci.Filename)
+		return makeErrorf(ci.Error, "parseCertificate called on bad CertInfo object: %s", ci.Filename)
 	}
 
 	if len(ci.FileContents) == 0 {
@@ -400,7 +400,7 @@ func parseCertificate(ci *CertInfo) error {
 	// PEM-decode the file.
 	derCerts, err := PEMToCertificates(ci.FileContents)
 	if err != nil {
-		return errors.Wrapf(err, "failed to parse certificate file %s as PEM", ci.Filename)
+		return makeErrorf(err, "failed to parse certificate file %s as PEM", ci.Filename)
 	}
 
 	// Make sure we get at least one certificate.
@@ -413,11 +413,11 @@ func parseCertificate(ci *CertInfo) error {
 	for i, c := range derCerts {
 		x509Cert, err := x509.ParseCertificate(c.Bytes)
 		if err != nil {
-			return errors.Wrapf(err, "failed to parse certificate %d in file %s", i, ci.Filename)
+			return makeErrorf(err, "failed to parse certificate %d in file %s", i, ci.Filename)
 		}
 
 		if err := validateCockroachCertificate(ci, x509Cert); err != nil {
-			return errors.Wrapf(err, "failed to validate certificate %d in file %s", i, ci.Filename)
+			return makeErrorf(err, "failed to validate certificate %d in file %s", i, ci.Filename)
 		}
 		if x509Cert.NotAfter.After(latest) {
 			latest = x509Cert.NotAfter


### PR DESCRIPTION
Fixes #24788.

Prior to this patch, the various CLI commands were making
a halfhearted attempt at decorating the underlying error with some
troubleshooting instructions.

Unfortunately, this was mixing up situations where the TCP connection
failed outright, those where the security settings were incorrect, and
connections dropped later, after the initial handshake was
successful.

In practice, we've noticed that the troubleshooting steps are rather
different for both kinds of situations. So this patch enhances the
code to clarify what is going on. It attempts to distinguish:

- TCP connection problem ("check --host vs --advertise-host").
- secure conn to insecure server ("use --insecure?")
- invalid TLS settings / TLS auth error ("check credentials").
- timeouts.
- connection lost (e.g. conn closed by server).

Release note (cli change): The various `cockroach` client comments
now better attempt to inform the user about why a connection is failing.