### PR TITLE
ui: handle null lease timestamps on range report

### DIFF
--- a/pkg/ui/src/views/reports/containers/range/leaseTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/leaseTable.tsx
@@ -19,6 +19,10 @@ export default class LeaseTable extends React.Component<LeaseTableProps, {}> {
   }
 
   renderLeaseTimestampCell(timestamp: protos.cockroach.util.hlc.ITimestamp) {
+    if (_.isNil(timestamp)) {
+      return this.renderLeaseCell("<no value>");
+    }
+
     const value = Print.Timestamp(timestamp);
     return this.renderLeaseCell(value, `${value}\n${timestamp.wall_time.toString()}`);
   }


### PR DESCRIPTION
I don't know under what circumstances these lease timestamps would be null, but we can be defensive about it when displaying them.

Fixes: #28195
Release note: None

cc @BramGruneir, @tschottdorf 