### PR TITLE
ui: require web login for secure clusters

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -316,8 +316,6 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 		panic(err)
 	}
 
-	requireWebLogin := envutil.EnvOrDefaultBool("COCKROACH_EXPERIMENTAL_REQUIRE_WEB_LOGIN", false)
-
 	cfg := Config{
 		Config:                         new(base.Config),
 		MaxOffset:                      MaxOffsetType(base.DefaultMaxClockOffset),
@@ -329,7 +327,7 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 		ScanMinIdleTime:                defaultScanMinIdleTime,
 		ScanMaxIdleTime:                defaultScanMaxIdleTime,
 		EventLogEnabled:                defaultEventLogEnabled,
-		EnableWebSessionAuthentication: requireWebLogin,
+		EnableWebSessionAuthentication: true,
 		Stores: base.StoreSpecList{
 			Specs: []base.StoreSpec{storeSpec},
 		},

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -316,6 +316,8 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 		panic(err)
 	}
 
+	disableWebLogin := envutil.EnvOrDefaultBool("COCKROACH_DISABLE_WEB_LOGIN", false)
+
 	cfg := Config{
 		Config:                         new(base.Config),
 		MaxOffset:                      MaxOffsetType(base.DefaultMaxClockOffset),
@@ -327,7 +329,7 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 		ScanMinIdleTime:                defaultScanMinIdleTime,
 		ScanMaxIdleTime:                defaultScanMaxIdleTime,
 		EventLogEnabled:                defaultEventLogEnabled,
-		EnableWebSessionAuthentication: true,
+		EnableWebSessionAuthentication: !disableWebLogin,
 		Stores: base.StoreSpecList{
 			Specs: []base.StoreSpec{storeSpec},
 		},


### PR DESCRIPTION
Closes: #6307
Closes: #18206
Closes: #26518
Release note (admin ui change): Login is now required for secure clusters.
Users log in with a regular database username, so that user must already have a
password set.  Insecure clusters do not require login, and have a visual
indicator showing that they are insecure.