### PR TITLE
ui: remove remote_debugging checks

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/server/debug"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -825,8 +824,6 @@ func (s *adminServer) RangeLog(
 		limit = defaultAPIEventLimit
 	}
 
-	includeRawKeys := debug.GatewayRemoteAllowed(ctx, s.server.ClusterSettings())
-
 	// Execute the query.
 	q := makeSQLQuery()
 	q.Append(`SELECT timestamp, "rangeID", "storeID", "eventType", "otherRangeID", info `)
@@ -901,17 +898,9 @@ func (s *adminServer) RangeLog(
 				return nil, errors.Wrap(err, fmt.Sprintf("info didn't parse correctly: %s", info))
 			}
 			if event.Info.NewDesc != nil {
-				if !includeRawKeys {
-					event.Info.NewDesc.StartKey = nil
-					event.Info.NewDesc.EndKey = nil
-				}
 				prettyInfo.NewDesc = event.Info.NewDesc.String()
 			}
 			if event.Info.UpdatedDesc != nil {
-				if !includeRawKeys {
-					event.Info.UpdatedDesc.StartKey = nil
-					event.Info.UpdatedDesc.EndKey = nil
-				}
 				prettyInfo.UpdatedDesc = event.Info.UpdatedDesc.String()
 			}
 			if event.Info.AddedReplica != nil {

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -15,7 +15,6 @@
 package debug
 
 import (
-	"context"
 	"expvar"
 	"fmt"
 	"net"
@@ -27,7 +26,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/server/debug/pprofui"
 	"golang.org/x/net/trace"
-	"google.golang.org/grpc/metadata"
 
 	"github.com/pkg/errors"
 	"github.com/rcrowley/go-metrics"
@@ -178,25 +176,6 @@ func isLocalhost(remoteAddr string) bool {
 	default:
 		return false
 	}
-}
-
-// GatewayRemoteAllowed returns whether a request that has been passed through
-// the grpc gateway should be allowed accessed to privileged debugging
-// information. Because this function assumes the presence of a context field
-// populated by the grpc gateway, it's not applicable for other uses.
-func GatewayRemoteAllowed(ctx context.Context, st *cluster.Settings) bool {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		// This should only happen for direct grpc connections, which are allowed.
-		return true
-	}
-	peerAddr, ok := md["x-forwarded-for"]
-	if !ok || len(peerAddr) == 0 {
-		// This should only happen for direct grpc connections, which are allowed.
-		return true
-	}
-
-	return authRequest(peerAddr[0], st)
 }
 
 func handleLanding(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/statements.go
+++ b/pkg/server/statements.go
@@ -29,7 +29,6 @@ import (
 func (s *statusServer) Statements(
 	ctx context.Context, req *serverpb.StatementsRequest,
 ) (*serverpb.StatementsResponse, error) {
-	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 
 	response := &serverpb.StatementsResponse{


### PR DESCRIPTION
Once #28207 lands, all of these endpoints will be protected by login already,
so we can skip the check for the setting remote_debugging.mode.

Closes: #24992
Release note (admin ui change): The cluster setting remote_debugging.mode no
longer controls access to any web ui API endpoints, since they are already
protected behind user login.