### PR TITLE
distsql: keep track of whether a flow has started goroutines

### DIFF
--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -501,7 +501,7 @@ func (ds *ServerImpl) RunSyncFlow(stream DistSQL_RunSyncFlowServer) error {
 	if err := ds.Stopper.RunTask(ctx, "distsqlrun.ServerImpl: sync flow", func(ctx context.Context) {
 		ctx, ctxCancel := contextutil.WithCancel(ctx)
 		defer ctxCancel()
-		mbox.start(ctx, &f.waitGroup, ctxCancel)
+		f.startables = append(f.startables, mbox)
 		ds.Metrics.FlowStart()
 		if err := f.StartSync(ctx, func() {}); err != nil {
 			log.Fatalf(ctx, "unexpected error from syncFlow.Start(): %s "+


### PR DESCRIPTION
This enables callers of `Wait` to avoid the overhead of goroutine
creation + select when unnecessary. CPU profiling showed around 160ms of
CPU time was spent in `flow.Wait` during a run of `BenchmarkFlowSetup`.

Release note: None

cc @RaduBerinde 