### PR TITLE
opt: simplify distinct build code

### DIFF
--- a/pkg/sql/opt/optbuilder/distinct.go
+++ b/pkg/sql/opt/optbuilder/distinct.go
@@ -15,44 +15,27 @@
 package optbuilder
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
-// buildDistinct builds a set of memo groups that represent a DISTINCT
-// expression if distinct is true. If distinct is false, we just return
-// `inScope`. If distinctOn is not empty, then this is a DISTINCT ON expression
-// that performs the distinct operation on a subset of columns.
-//
-// See Builder.buildStmt for a description of the remaining input and
-// return values.
-func (b *Builder) buildDistinct(distinctOn tree.DistinctOn, inScope *scope) (outScope *scope) {
-	if len(distinctOn) > 0 {
-		panic(unimplementedf("DISTINCT ON is not supported"))
-	}
-
-	outScope = inScope.replace()
-	outScope.copyPhysicalProps(inScope)
-
-	// Distinct is equivalent to group by without any aggregations.
-	var groupCols opt.ColSet
+// constructDistinct wraps inScope.group in a DistinctOn operator corresponding
+// to a SELECT DISTINCT statement.
+func (b *Builder) constructDistinct(inScope *scope) memo.GroupID {
+	// We are doing a distinct along all the projected columns.
+	var def memo.GroupByDef
 	for i := range inScope.cols {
 		if !inScope.cols[i].hidden {
-			groupCols.Add(int(inScope.cols[i].id))
-			outScope.cols = append(outScope.cols, inScope.cols[i])
+			def.GroupingCols.Add(int(inScope.cols[i].id))
 		}
 	}
 
-	// Check that the ordering can be provided by the projected columns.
+	// Check that the ordering only refers to projected columns.
 	// This will cause an error for queries like:
 	//   SELECT DISTINCT a FROM t ORDER BY b
-	// TODO(rytaft): This is not valid syntax in Postgres, but it works in
-	// CockroachDB, so we may need to support it eventually.
-	for _, col := range outScope.physicalProps.Ordering.Columns {
-		id, _ := col.Group.Next(0)
-		if !outScope.hasColumn(opt.ColumnID(id)) {
+	// Note: this behavior is consistent with PostgreSQL.
+	for _, col := range inScope.physicalProps.Ordering.Columns {
+		if !col.Group.Intersects(def.GroupingCols) {
 			panic(builderError{pgerror.NewErrorf(
 				pgerror.CodeInvalidColumnReferenceError,
 				"for SELECT DISTINCT, ORDER BY expressions must appear in select list",
@@ -60,14 +43,13 @@ func (b *Builder) buildDistinct(distinctOn tree.DistinctOn, inScope *scope) (out
 		}
 	}
 
-	// Because the ordering can only refer to the projected columns, it doesn't
-	// affect the results; we don't need to set def.Ordering.
-	def := memo.GroupByDef{GroupingCols: groupCols}
+	// We don't set def.Ordering. Because the ordering can only refer to projected
+	// columns, it does not affect the results; it doesn't need to be required of
+	// the DistinctOn input.
 
-	outScope.group = b.factory.ConstructDistinctOn(
+	return b.factory.ConstructDistinctOn(
 		inScope.group,
 		b.factory.ConstructAggregations(memo.EmptyList, b.factory.InternColList(nil)),
 		b.factory.InternGroupByDef(&def),
 	)
-	return outScope
 }

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -173,12 +173,6 @@ func (s *scope) copyOrdering(src *scope) {
 	}
 }
 
-// copyPhysicalProps copies the physicalProps from the src scope to this scope.
-func (s *scope) copyPhysicalProps(src *scope) {
-	s.physicalProps.Presentation = src.physicalProps.Presentation
-	s.copyOrdering(src)
-}
-
 // getColumn returns the scopeColumn with the given id (either in cols or
 // extraCols).
 func (s *scope) getColumn(col opt.ColumnID) *scopeColumn {
@@ -277,24 +271,6 @@ func (s *scope) isOuterColumn(id opt.ColumnID) bool {
 	}
 
 	return true
-}
-
-// hasColumn returns true if the given column id is found within this scope.
-func (s *scope) hasColumn(id opt.ColumnID) bool {
-	// We only allow hidden columns in the current scope. Hidden columns
-	// in parent scopes are not accessible.
-	allowHidden := true
-
-	for curr := s; curr != nil; curr, allowHidden = curr.parent, false {
-		for i := range curr.cols {
-			col := &curr.cols[i]
-			if col.id == id && (allowHidden || !col.hidden) {
-				return true
-			}
-		}
-	}
-
-	return false
 }
 
 // colSet returns a ColSet of all the columns in this scope,

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -302,8 +302,11 @@ func (b *Builder) buildSelectClause(
 	outScope = projectionsScope
 
 	// Wrap with distinct operator if it exists.
-	if sel.Distinct || len(sel.DistinctOn) > 0 {
-		outScope = b.buildDistinct(sel.DistinctOn, outScope)
+	if sel.Distinct {
+		if len(sel.DistinctOn) > 0 {
+			panic(unimplementedf("DISTINCT ON is not supported"))
+		}
+		outScope.group = b.constructDistinct(outScope)
 	}
 	return outScope
 }


### PR DESCRIPTION
I've been trying to share build code between DISTINCT and DISTINCT ON but the cases are different enough that it's actually messier than handling them separately. Extracting out some simplifications I noticed on the DISTINCT path.


This change simplifies the code that handles building (the distinct
part of) SELECT DISTINCT:

 - we were setting up a new scope that was the same with the original
   scope; instead, we now just update `outScope.group` (similar to
   `constructProjectSet`).

 - when verifying the ordering columns, we use the grouping columns
   instead of looking through the scope columns. The original code was
   accepting hidden columns, or columns from parent scopes which
   doesn't seem correct.

Release note: None