### PR TITLE
roachtest: use 8-cpu machines for the ycsb tests

### DIFF
--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -22,6 +22,10 @@ import (
 
 func registerYCSB(r *registry) {
 	runYCSB := func(ctx context.Context, t *test, c *cluster, wl string) {
+		if !c.isLocal() {
+			c.RemountNoBarrier(ctx)
+		}
+
 		nodes := c.nodes - 1
 
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
@@ -54,7 +58,7 @@ func registerYCSB(r *registry) {
 		wl := wl
 		r.Add(testSpec{
 			Name:  fmt.Sprintf("ycsb/%s/nodes=3", wl),
-			Nodes: nodes(4),
+			Nodes: nodes(4, cpu(8)),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runYCSB(ctx, t, c, wl)
 			},


### PR DESCRIPTION
This makes the numbers more easily comparable vs the `kv{0,95}` tests
which use 8-cpu machines.

Similarly, remount the disks with `nobarrier` which is also the
configuration used by `kv{0,95}`.

Release note: None