### PR TITLE
sql: permit comparison with empty; mixed-type tuples

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/suboperators
+++ b/pkg/sql/logictest/testdata/logic_test/suboperators
@@ -140,12 +140,17 @@ SELECT 1 = ANY(SELECT * FROM unnest(ARRAY[1.0, 1.1]))
 true
 
 query B
-SELECT 1 < ANY(SELECT * FROM unnest(ARRAY[1.0, 1.1]))
+SELECT 1 = ANY(SELECT * FROM unnest(ARRAY[1.0, 1.1]))
 ----
 true
 
 query B
-SELECT 1 = ANY(SELECT * FROM unnest(ARRAY[1.0001, 2]))
+SELECT 1.0 < ANY(SELECT * FROM unnest(ARRAY[1.0, 1.1]))
+----
+true
+
+query B
+SELECT 1.0 = ANY(SELECT * FROM unnest(ARRAY[1.0001, 2]))
 ----
 false
 
@@ -362,6 +367,9 @@ SELECT 1 = ANY (1, 2, 3)
 ----
 true
 
+query error could not parse "foo" as type int
+SELECT 1 = ANY (1, 2, 3.3, 'foo')
+
 query B
 SELECT 1 = ANY (((1, 2, 3)))
 ----
@@ -377,19 +385,25 @@ SELECT 1 = ANY (((2, 3, 4)))
 ----
 false
 
-query error incompatible tuple element type: decimal
+query B
 SELECT 1 = ANY (1, 1.1)
+----
+true
 
 query B
 SELECT 1::decimal = ANY (1, 1.1)
 ----
 true
 
-query error incompatible tuple element type: decimal
+query B
 SELECT 1 = ANY (1.0, 1.1)
+----
+true
 
-query error incompatible tuple element type: decimal
+query B
 SELECT 1 = ANY (((1.0, 1.1)))
+----
+true
 
 query B
 SELECT 1::decimal = ANY (1.0, 1.1)
@@ -404,5 +418,7 @@ true
 query error could not parse \"hello\" as type int
 SELECT 1 = ANY (1, 'hello', 3)
 
-query error unsupported comparison operator: <int> = ANY <tuple{}>
+query B
 SELECT 1 = ANY ROW()
+----
+false

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -15,6 +15,11 @@ SELECT 1 IN ()
 ----
 false
 
+query B
+SELECT 1 = ANY ()
+----
+false
+
 subtest unlabeled_tuple
 
 # TODO(bram): We don't pretty print tuples the same way as postgres. See #25522.

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1354,26 +1354,20 @@ func (d *DOidWrapper) TypeCheck(_ *SemaContext, _ types.T) (TypedExpr, error) { 
 // identity function for Datum.
 func (d dNull) TypeCheck(_ *SemaContext, desired types.T) (TypedExpr, error) { return d, nil }
 
-// typeCheckAndRequireTupleElems asserts that all elements in the Tuple
-// can be typed as required and are equivalent to required. Note that one would invoke
-// with the required element type and NOT types.TTuple (as opposed to how Tuple.TypeCheck operates).
-// For example, (1, 2.5) with required types.Decimal would raise a sane error whereas (1.0, 2.5)
-// with required types.Decimal would pass.
-//
-// It is only valid to pass in a Tuple expression
+// typeCheckAndRequireTupleElems asserts that all elements in the Tuple are
+// comparable to the input Expr given the input comparison operator.
 func typeCheckAndRequireTupleElems(
-	ctx *SemaContext, expr Expr, required types.T,
+	ctx *SemaContext, expr TypedExpr, tuple *Tuple, op ComparisonOperator,
 ) (TypedExpr, error) {
-	tuple := expr.(*Tuple)
 	tuple.typ = types.TTuple{Types: make([]types.T, len(tuple.Exprs))}
 	for i, subExpr := range tuple.Exprs {
-		// Require that the sub expression is equivalent (or may be inferred) to the required type.
-		typedExpr, err := typeCheckAndRequire(ctx, subExpr, required, "tuple element")
+		// Require that the sub expression is comparable to the required type.
+		_, rightTyped, _, _, err := typeCheckComparisonOp(ctx, op, expr, subExpr)
 		if err != nil {
 			return nil, err
 		}
-		tuple.Exprs[i] = typedExpr
-		tuple.typ.Types[i] = typedExpr.ResolvedType()
+		tuple.Exprs[i] = rightTyped
+		tuple.typ.Types[i] = rightTyped.ResolvedType()
 	}
 	return tuple, nil
 }
@@ -1469,7 +1463,7 @@ func typeCheckComparisonOpWithSubOperator(
 		if tuple, ok := right.(*Tuple); ok {
 			// If right expression is a tuple, we require that all elements' inferred
 			// type is equivalent to the left's type.
-			rightTyped, err = typeCheckAndRequireTupleElems(ctx, tuple, cmpTypeLeft)
+			rightTyped, err = typeCheckAndRequireTupleElems(ctx, leftTyped, tuple, subOp)
 			if err != nil {
 				return nil, nil, CmpOp{}, false, err
 			}
@@ -1494,15 +1488,17 @@ func typeCheckComparisonOpWithSubOperator(
 			cmpTypeRight = rightUnwrapped.Typ
 		case types.TTuple:
 			if len(rightUnwrapped.Types) == 0 {
-				// Literal tuple contains no elements (subquery tuples always contain
-				// one and only one element since subqueries are asserted to return
-				// one column of results in analyzeExpr in analyze.go).
-				return nil, nil, CmpOp{}, false, subOpCompError(cmpTypeLeft, rightReturn, subOp, op)
+				// Literal tuple contains no elements, or subquery tuple returns 0 rows.
+				cmpTypeRight = cmpTypeLeft
+			} else {
+				// Literal tuples and subqueries were type checked such that all
+				// elements have comparable types with the left. Once that's true, we
+				// can safely grab the first element's type as the right type for the
+				// purposes of computing the correct comparison function below, since
+				// if two datum types are comparable, it's legal to call .Compare on
+				// one with the other.
+				cmpTypeRight = rightUnwrapped.Types[0]
 			}
-			// Literal tuples were type checked such that all elements have equivalent types.
-			// Subqueries only contain one element from analyzeExpr in analyze.go.
-			// Therefore, we can take the first element's type as the right type.
-			cmpTypeRight = rightUnwrapped.Types[0]
 		default:
 			sigWithErr := fmt.Sprintf(compExprsWithSubOpFmt, left, subOp, op, right,
 				fmt.Sprintf("op %s <right> requires array, tuple or subquery on right side", op))


### PR DESCRIPTION
The expression `foo = ANY()` is now allowed. Previously, it would fail
to type-check. This change permits queries with subqueries that return
no results to properly execute via the distributed sql engine.

Also, tuple comparisons where the left expression type is comparable but
not equal to all of the tuple's inner expression types are now
permitted.

Release note (sql change): ANY/ALL/SOME comparisons with empty tuples
are now allowed. ANY/ALL/SOME comparisons are now more permissive about
the types of their input expressions.