### PR TITLE
rangefeed: add resolved timestamp initialization scan and registration catch-up scan

### DIFF
--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1109,3 +1109,12 @@ func (b *BulkOpSummary) Add(other BulkOpSummary) {
 	b.IndexEntries += other.IndexEntries
 	b.SystemRecords += other.SystemRecords
 }
+
+// MustSetValue is like SetValue, except it resets the enum and panics if the
+// provided value is not a valid variant type.
+func (e *RangeFeedEvent) MustSetValue(value interface{}) {
+	e.Reset()
+	if !e.SetValue(value) {
+		panic(fmt.Sprintf("%T excludes %T", e, value))
+	}
+}

--- a/pkg/storage/rangefeed/processor.go
+++ b/pkg/storage/rangefeed/processor.go
@@ -63,19 +63,21 @@ type Processor struct {
 	reg registry
 	rts resolvedTimestamp
 
-	regC    chan registration
-	lenReqC chan struct{}
-	lenResC chan int
-	eventC  chan event
-	stopC   chan *roachpb.Error
+	regC     chan registration
+	lenReqC  chan struct{}
+	lenResC  chan int
+	eventC   chan event
+	stopC    chan *roachpb.Error
+	stoppedC chan struct{}
 }
 
 // event is a union of different event types that the Processor goroutine needs
 // to be informed of. It is used so that all events can be sent over the same
 // channel, which is necessary to prevent reordering.
 type event struct {
-	ops []enginepb.MVCCLogicalOp
-	ct  hlc.Timestamp
+	ops   []enginepb.MVCCLogicalOp
+	ct    hlc.Timestamp
+	syncC chan struct{}
 }
 
 // NewProcessor creates a new rangefeed Processor. The corresponding goroutine
@@ -88,11 +90,12 @@ func NewProcessor(cfg Config) *Processor {
 		reg:    makeRegistry(),
 		rts:    makeResolvedTimestamp(),
 
-		regC:    make(chan registration),
-		lenReqC: make(chan struct{}),
-		lenResC: make(chan int),
-		eventC:  make(chan event, cfg.EventChanCap),
-		stopC:   make(chan *roachpb.Error),
+		regC:     make(chan registration),
+		lenReqC:  make(chan struct{}),
+		lenResC:  make(chan int),
+		eventC:   make(chan event, cfg.EventChanCap),
+		stopC:    make(chan *roachpb.Error),
+		stoppedC: make(chan struct{}),
 	}
 }
 
@@ -101,6 +104,8 @@ func NewProcessor(cfg Config) *Processor {
 func (p *Processor) Start(stopper *stop.Stopper) {
 	ctx := p.AnnotateCtx(context.Background())
 	stopper.RunWorker(ctx, func(ctx context.Context) {
+		defer close(p.stoppedC)
+
 		// intentPushTicker periodically pushes all unresolved intents that are
 		// above a certain age, helping to ensure that the resolved timestamp
 		// continues to make progress.
@@ -177,15 +182,6 @@ func (p *Processor) Start(stopper *stop.Stopper) {
 
 			// Close registrations and exit when signaled.
 			case pErr := <-p.stopC:
-				// Process any events still in the event channel.
-				for loop := true; loop; {
-					select {
-					case e := <-p.eventC:
-						p.consumeEvent(ctx, e)
-					default:
-						loop = false
-					}
-				}
 				p.reg.DisconnectWithErr(all, pErr)
 				return
 
@@ -205,11 +201,16 @@ func (p *Processor) Start(stopper *stop.Stopper) {
 func (p *Processor) Register(
 	span roachpb.RSpan, startTS hlc.Timestamp, stream Stream, errC chan<- *roachpb.Error,
 ) {
-	p.regC <- registration{
+	r := registration{
 		span:    span.AsRawSpanWithNoLocals(),
 		startTS: startTS,
 		stream:  stream,
 		errC:    errC,
+	}
+	select {
+	case p.regC <- r:
+	case <-p.stoppedC:
+		errC <- roachpb.NewErrorf("rangefeed processor closed")
 	}
 }
 
@@ -218,9 +219,15 @@ func (p *Processor) Len() int {
 	if p == nil {
 		return 0
 	}
+
 	// Ask the processor goroutine.
-	p.lenReqC <- struct{}{}
-	return <-p.lenResC
+	select {
+	case p.lenReqC <- struct{}{}:
+		// Wait for response.
+		return <-p.lenResC
+	case <-p.stoppedC:
+		return 0
+	}
 }
 
 // Stop shuts down the processor and closes all registrations. Safe to call on
@@ -237,11 +244,17 @@ func (p *Processor) StopWithErr(pErr *roachpb.Error) {
 	if p == nil {
 		return
 	}
+	// Flush any remaining events before stopping.
+	p.syncEventC()
 	// Send on the channel instead of closing it. This ensures synchronous
 	// communication so that when this method returns the caller can be sure
 	// that the Processor goroutine is canceling all registrations and shutting
 	// down.
-	p.stopC <- pErr
+	select {
+	case p.stopC <- pErr:
+	case <-p.stoppedC:
+		// Already stopped. Do nothing.
+	}
 }
 
 // ConsumeLogicalOps informs the rangefeed processor of the set of logical
@@ -254,7 +267,11 @@ func (p *Processor) ConsumeLogicalOps(ops []enginepb.MVCCLogicalOp) {
 		return
 	}
 	// TODO(nvanbenschoten): backpressure or disconnect on blocking call.
-	p.eventC <- event{ops: ops}
+	select {
+	case p.eventC <- event{ops: ops}:
+	case <-p.stoppedC:
+		// Already stopped. Do nothing.
+	}
 }
 
 // ForwardClosedTS indicates that the closed timestamp that serves as the basis
@@ -267,7 +284,29 @@ func (p *Processor) ForwardClosedTS(closedTS hlc.Timestamp) {
 	if closedTS == (hlc.Timestamp{}) {
 		return
 	}
-	p.eventC <- event{ct: closedTS}
+	select {
+	case p.eventC <- event{ct: closedTS}:
+	case <-p.stoppedC:
+		// Already stopped. Do nothing.
+	}
+}
+
+// syncEventC synchronizes access to the Processor goroutine, allowing the
+// caller to establish causality with actions taken by the Processor goroutine.
+// It does so by flushing the event pipeline.
+func (p *Processor) syncEventC() {
+	syncC := make(chan struct{})
+	select {
+	case p.eventC <- event{syncC: syncC}:
+		select {
+		case <-syncC:
+		// Synchronized.
+		case <-p.stoppedC:
+			// Already stopped. Do nothing.
+		}
+	case <-p.stoppedC:
+		// Already stopped. Do nothing.
+	}
 }
 
 func (p *Processor) consumeEvent(ctx context.Context, e event) {
@@ -276,6 +315,8 @@ func (p *Processor) consumeEvent(ctx context.Context, e event) {
 		p.consumeLogicalOps(ctx, e.ops)
 	case e.ct != hlc.Timestamp{}:
 		p.forwardClosedTS(ctx, e.ct)
+	case e.syncC != nil:
+		close(e.syncC)
 	default:
 		panic("missing event variant")
 	}

--- a/pkg/storage/rangefeed/processor.go
+++ b/pkg/storage/rangefeed/processor.go
@@ -75,9 +75,10 @@ type Processor struct {
 // to be informed of. It is used so that all events can be sent over the same
 // channel, which is necessary to prevent reordering.
 type event struct {
-	ops   []enginepb.MVCCLogicalOp
-	ct    hlc.Timestamp
-	syncC chan struct{}
+	ops     []enginepb.MVCCLogicalOp
+	ct      hlc.Timestamp
+	initRTS bool
+	syncC   chan struct{}
 }
 
 // NewProcessor creates a new rangefeed Processor. The corresponding goroutine
@@ -100,11 +101,30 @@ func NewProcessor(cfg Config) *Processor {
 }
 
 // Start launches a goroutine to process rangefeed events and send them to
-// registrations. The provided stopper is used to finish processing.
-func (p *Processor) Start(stopper *stop.Stopper) {
+// registrations.
+//
+// The provided Snapshot is used to initialize the rangefeed's resolved
+// timestamp. It must obey the contract of a Snapshot used for an
+// initResolvedTSScan. The Processor promises to clean up the Snapshot by
+// calling its Close method when it is finished. If the Snapshot is nil then
+// no initialization scan will be performed and the resolved timestamp will
+// immediately be considered initialized.
+func (p *Processor) Start(stopper *stop.Stopper, rtsSnap Snapshot) {
 	ctx := p.AnnotateCtx(context.Background())
 	stopper.RunWorker(ctx, func(ctx context.Context) {
 		defer close(p.stoppedC)
+
+		// Launch an async task to scan over the resolved timestamp snapshot and
+		// initialize the unresolvedIntentQueue. Ignore error if quiescing.
+		if rtsSnap != nil {
+			initScan := makeInitResolvedTSScan(p, rtsSnap)
+			err := stopper.RunAsyncTask(ctx, "rangefeed: init resolved ts", initScan.Run)
+			if err != nil {
+				initScan.Cancel() // clean up
+			}
+		} else {
+			p.initResolvedTS(ctx)
+		}
 
 		// intentPushTicker periodically pushes all unresolved intents that are
 		// above a certain age, helping to ensure that the resolved timestamp
@@ -301,6 +321,16 @@ func (p *Processor) ForwardClosedTS(closedTS hlc.Timestamp) {
 	}
 }
 
+// setResolvedTSInitialized informs the Processor that its resolved timestamp has
+// all the information it needs to be considered initialized.
+func (p *Processor) setResolvedTSInitialized() {
+	select {
+	case p.eventC <- event{initRTS: true}:
+	case <-p.stoppedC:
+		// Already stopped. Do nothing.
+	}
+}
+
 // syncEventC synchronizes access to the Processor goroutine, allowing the
 // caller to establish causality with actions taken by the Processor goroutine.
 // It does so by flushing the event pipeline.
@@ -325,6 +355,8 @@ func (p *Processor) consumeEvent(ctx context.Context, e event) {
 		p.consumeLogicalOps(ctx, e.ops)
 	case e.ct != hlc.Timestamp{}:
 		p.forwardClosedTS(ctx, e.ct)
+	case e.initRTS:
+		p.initResolvedTS(ctx)
 	case e.syncC != nil:
 		close(e.syncC)
 	default:
@@ -338,8 +370,7 @@ func (p *Processor) consumeLogicalOps(ctx context.Context, ops []enginepb.MVCCLo
 		switch t := op.GetValue().(type) {
 		case *enginepb.MVCCWriteValueOp:
 			// Publish the new value directly.
-			val := roachpb.Value{RawBytes: t.Value, Timestamp: t.Timestamp}
-			p.publishValue(ctx, t.Key, val)
+			p.publishValue(ctx, t.Key, t.Timestamp, t.Value)
 
 		case *enginepb.MVCCWriteIntentOp:
 			// No updates to publish.
@@ -349,8 +380,7 @@ func (p *Processor) consumeLogicalOps(ctx context.Context, ops []enginepb.MVCCLo
 
 		case *enginepb.MVCCCommitIntentOp:
 			// Publish the newly committed value.
-			val := roachpb.Value{RawBytes: t.Value, Timestamp: t.Timestamp}
-			p.publishValue(ctx, t.Key, val)
+			p.publishValue(ctx, t.Key, t.Timestamp, t.Value)
 
 		case *enginepb.MVCCAbortIntentOp:
 			// No updates to publish.
@@ -373,7 +403,15 @@ func (p *Processor) forwardClosedTS(ctx context.Context, newClosedTS hlc.Timesta
 	}
 }
 
-func (p *Processor) publishValue(ctx context.Context, key roachpb.Key, value roachpb.Value) {
+func (p *Processor) initResolvedTS(ctx context.Context) {
+	if p.rts.Init() {
+		p.publishCheckpoint(ctx)
+	}
+}
+
+func (p *Processor) publishValue(
+	ctx context.Context, key roachpb.Key, timestamp hlc.Timestamp, value []byte,
+) {
 	if !p.Span.ContainsKey(roachpb.RKey(key)) {
 		log.Fatalf(ctx, "key %v not in Processor's key range %v", key, p.Span)
 	}
@@ -381,8 +419,11 @@ func (p *Processor) publishValue(ctx context.Context, key roachpb.Key, value roa
 	span := roachpb.Span{Key: key}
 	var event roachpb.RangeFeedEvent
 	event.SetValue(&roachpb.RangeFeedValue{
-		Key:   key,
-		Value: value,
+		Key: key,
+		Value: roachpb.Value{
+			RawBytes:  value,
+			Timestamp: timestamp,
+		},
 	})
 	p.reg.PublishToOverlapping(span, &event)
 }

--- a/pkg/storage/rangefeed/processor.go
+++ b/pkg/storage/rangefeed/processor.go
@@ -483,7 +483,7 @@ func (p *Processor) publishValue(
 
 	span := roachpb.Span{Key: key}
 	var event roachpb.RangeFeedEvent
-	event.SetValue(&roachpb.RangeFeedValue{
+	event.MustSetValue(&roachpb.RangeFeedValue{
 		Key: key,
 		Value: roachpb.Value{
 			RawBytes:  value,
@@ -503,7 +503,7 @@ func (p *Processor) publishCheckpoint(ctx context.Context) {
 
 func (p *Processor) newCheckpointEvent() *roachpb.RangeFeedEvent {
 	var event roachpb.RangeFeedEvent
-	event.SetValue(&roachpb.RangeFeedCheckpoint{
+	event.MustSetValue(&roachpb.RangeFeedCheckpoint{
 		Span:       p.Span.AsRawSpanWithNoLocals(),
 		ResolvedTS: p.rts.Get(),
 	})

--- a/pkg/storage/rangefeed/processor.go
+++ b/pkg/storage/rangefeed/processor.go
@@ -128,7 +128,7 @@ func (p *Processor) Start(stopper *stop.Stopper) {
 			// Handle new registrations.
 			case r := <-p.regC:
 				if !p.Span.AsRawSpanWithNoLocals().Contains(r.span) {
-					log.Fatalf(ctx, "registration %+v not contained in processor span %v", r, p.Span)
+					log.Fatalf(ctx, "registration %s not in Processor's key range %v", r, p.Span)
 				}
 
 				// TODO(nvanbenschoten): catch up scan.

--- a/pkg/storage/rangefeed/processor.go
+++ b/pkg/storage/rangefeed/processor.go
@@ -222,12 +222,20 @@ func (p *Processor) StopWithErr(pErr *roachpb.Error) {
 	}
 }
 
-// Register registers the stream over the specified span of keys. The channel
-// will be provided an error when the registration closes. NOT safe to call on
-// nil Processor.
+// Register registers the stream over the specified span of keys. The
+// registration will not observe any events that were consumed before this
+// method was called. It is undefined whether the registration will observe
+// events that are consumed concurrently with this call. The channel will be
+// provided an error when the registration closes. NOT safe to call on nil
+// Processor.
 func (p *Processor) Register(
 	span roachpb.RSpan, startTS hlc.Timestamp, stream Stream, errC chan<- *roachpb.Error,
 ) {
+	// Synchronize the event channel so that this registration doesn't see any
+	// events that were consumed before this registration was called. Instead,
+	// it should see these events during its catch up scan.
+	p.syncEventC()
+
 	r := registration{
 		span:    span.AsRawSpanWithNoLocals(),
 		startTS: startTS,

--- a/pkg/storage/rangefeed/processor.go
+++ b/pkg/storage/rangefeed/processor.go
@@ -131,8 +131,10 @@ func (p *Processor) Start(stopper *stop.Stopper) {
 					log.Fatalf(ctx, "registration %s not in Processor's key range %v", r, p.Span)
 				}
 
+				p.reg.Register(&r)
+
 				// TODO(nvanbenschoten): catch up scan.
-				p.reg.Register(r)
+				r.SetCaughtUp()
 
 			// Respond to answers about the processor goroutine state.
 			case <-p.lenReqC:

--- a/pkg/storage/rangefeed/processor.go
+++ b/pkg/storage/rangefeed/processor.go
@@ -259,7 +259,7 @@ func (p *Processor) StopWithErr(pErr *roachpb.Error) {
 
 // ConsumeLogicalOps informs the rangefeed processor of the set of logical
 // operations. Safe to call on nil Processor.
-func (p *Processor) ConsumeLogicalOps(ops []enginepb.MVCCLogicalOp) {
+func (p *Processor) ConsumeLogicalOps(ops ...enginepb.MVCCLogicalOp) {
 	if p == nil {
 		return
 	}

--- a/pkg/storage/rangefeed/processor_test.go
+++ b/pkg/storage/rangefeed/processor_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -162,10 +163,18 @@ func TestProcessor(t *testing.T) {
 	p.Register(
 		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 		hlc.Timestamp{WallTime: 1},
+		nil, /* catchUpSnap */
 		r1Stream,
 		r1ErrC,
 	)
 	require.Equal(t, 1, p.Len())
+	require.Equal(t,
+		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
+			roachpb.Span{Key: roachpb.KeyMin, EndKey: roachpb.KeyMax},
+			hlc.Timestamp{WallTime: 1},
+		)},
+		r1Stream.Events(),
+	)
 
 	// Test checkpoint with one registration.
 	p.ForwardClosedTS(hlc.Timestamp{WallTime: 5})
@@ -267,10 +276,18 @@ func TestProcessor(t *testing.T) {
 	p.Register(
 		roachpb.RSpan{Key: roachpb.RKey("c"), EndKey: roachpb.RKey("z")},
 		hlc.Timestamp{WallTime: 1},
+		nil, /* catchUpSnap */
 		r2Stream,
 		r2ErrC,
 	)
 	require.Equal(t, 2, p.Len())
+	require.Equal(t,
+		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
+			roachpb.Span{Key: roachpb.KeyMin, EndKey: roachpb.KeyMax},
+			hlc.Timestamp{WallTime: 15},
+		)},
+		r2Stream.Events(),
+	)
 
 	// Both registrations should see checkpoint.
 	p.ForwardClosedTS(hlc.Timestamp{WallTime: 20})
@@ -338,7 +355,7 @@ func TestNilProcessor(t *testing.T) {
 	// The following should panic because they are not safe
 	// to call on a nil Processor.
 	require.Panics(t, func() { p.Start(stop.NewStopper(), nil) })
-	require.Panics(t, func() { p.Register(roachpb.RSpan{}, hlc.Timestamp{}, nil, nil) })
+	require.Panics(t, func() { p.Register(roachpb.RSpan{}, hlc.Timestamp{}, nil, nil, nil) })
 }
 
 // TestProcessorInitializeResolvedTimestamp tests that when a Processor is given
@@ -381,6 +398,7 @@ func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 	p.Register(
 		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 		hlc.Timestamp{WallTime: 1},
+		nil, /* catchUpSnap */
 		r1Stream,
 		make(chan *roachpb.Error, 1),
 	)
@@ -418,6 +436,148 @@ func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 	require.Equal(t, chEvent, r1Stream.Events())
 }
 
+func TestProcessorCatchUpScan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	p, stopper := newTestProcessor(nil /* rtsSnap */)
+	defer stopper.Stop(context.Background())
+
+	// The resolved timestamp should be initialized.
+	p.syncEventC()
+	require.True(t, p.rts.IsInit())
+	require.Equal(t, hlc.Timestamp{}, p.rts.Get())
+
+	txn1, txn2 := uuid.MakeV4(), uuid.MakeV4()
+	catchUpSnap := newTestSnapshot([]engine.MVCCKeyValue{
+		makeKV("a", "val1", 10),
+		makeInline("b", "val2"),
+		makeIntent("c", txn1, "txnKey1", 15),
+		makeKV("c", "val3", 11),
+		makeKV("c", "val4", 9),
+		makeIntent("d", txn2, "txnKey2", 21),
+		makeKV("d", "val5", 20),
+		makeKV("d", "val6", 19),
+		makeInline("g", "val7"),
+		makeKV("m", "val8", 1),
+		makeIntent("n", txn1, "txnKey1", 12),
+		makeIntent("r", txn1, "txnKey1", 19),
+		makeKV("r", "val9", 4),
+		makeIntent("w", txn1, "txnKey1", 3),
+		makeInline("x", "val10"),
+		makeIntent("z", txn2, "txnKey2", 21),
+		makeKV("z", "val11", 4),
+	})
+	catchUpSnap.block = make(chan struct{})
+
+	// Add a registration with the catch-up snapshot.
+	r1Stream := newTestStream()
+	p.Register(
+		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("w")},
+		hlc.Timestamp{WallTime: 2}, // too large to see key @ m
+		catchUpSnap,
+		r1Stream,
+		make(chan *roachpb.Error, 1),
+	)
+	require.Equal(t, 1, p.Len())
+
+	// The registration should not have gotten an initial checkpoint.
+	require.Nil(t, r1Stream.Events())
+
+	// Forward the closed timestamp. The resolved timestamp should be
+	// initialized and should move forward, but the registration should
+	// still not get a checkpoint.
+	p.ForwardClosedTS(hlc.Timestamp{WallTime: 20})
+	p.syncEventC()
+	require.True(t, p.rts.IsInit())
+	require.Equal(t, hlc.Timestamp{WallTime: 20}, p.rts.Get())
+	require.Nil(t, r1Stream.Events())
+
+	// Let the scan proceed.
+	close(catchUpSnap.block)
+	<-catchUpSnap.done
+	require.True(t, catchUpSnap.closed)
+
+	// Synchronize the event channel then verify that the registration's stream
+	// was sent all values in its range and the resolved timestamp once the
+	// catch-up scan was complete.
+	p.syncEventC()
+	expEvents := []*roachpb.RangeFeedEvent{
+		rangeFeedValue(
+			roachpb.Key("a"),
+			roachpb.Value{RawBytes: []byte("val1"), Timestamp: hlc.Timestamp{WallTime: 10}},
+		),
+		rangeFeedValue(
+			roachpb.Key("b"),
+			roachpb.Value{RawBytes: []byte("val2"), Timestamp: hlc.Timestamp{WallTime: 0}},
+		),
+		rangeFeedValue(
+			roachpb.Key("c"),
+			roachpb.Value{RawBytes: []byte("val3"), Timestamp: hlc.Timestamp{WallTime: 11}},
+		),
+		rangeFeedValue(
+			roachpb.Key("c"),
+			roachpb.Value{RawBytes: []byte("val4"), Timestamp: hlc.Timestamp{WallTime: 9}},
+		),
+		rangeFeedValue(
+			roachpb.Key("d"),
+			roachpb.Value{RawBytes: []byte("val5"), Timestamp: hlc.Timestamp{WallTime: 20}},
+		),
+		rangeFeedValue(
+			roachpb.Key("d"),
+			roachpb.Value{RawBytes: []byte("val6"), Timestamp: hlc.Timestamp{WallTime: 19}},
+		),
+		rangeFeedValue(
+			roachpb.Key("g"),
+			roachpb.Value{RawBytes: []byte("val7"), Timestamp: hlc.Timestamp{WallTime: 0}},
+		),
+		rangeFeedValue(
+			roachpb.Key("r"),
+			roachpb.Value{RawBytes: []byte("val9"), Timestamp: hlc.Timestamp{WallTime: 4}},
+		),
+		rangeFeedCheckpoint(
+			roachpb.Span{Key: roachpb.KeyMin, EndKey: roachpb.KeyMax},
+			hlc.Timestamp{WallTime: 20},
+		),
+	}
+	require.Equal(t, expEvents, r1Stream.Events())
+
+	// Forward the closed timestamp. The registration should get a checkpoint
+	// this time.
+	p.ForwardClosedTS(hlc.Timestamp{WallTime: 25})
+	p.syncEventC()
+	require.True(t, p.rts.IsInit())
+	require.Equal(t, hlc.Timestamp{WallTime: 25}, p.rts.Get())
+	require.Equal(t,
+		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
+			roachpb.Span{Key: roachpb.KeyMin, EndKey: roachpb.KeyMax},
+			hlc.Timestamp{WallTime: 25},
+		)},
+		r1Stream.Events(),
+	)
+
+	// Add a second registration, this time with a snapshot that will throw an
+	// error.
+	r2Stream := newTestStream()
+	r2ErrC := make(chan *roachpb.Error, 1)
+	errCatchUpSnap := newErrorSnapshot(errors.New("iteration error"))
+	p.Register(
+		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
+		hlc.Timestamp{WallTime: 1},
+		errCatchUpSnap,
+		r2Stream,
+		r2ErrC,
+	)
+	require.Equal(t, 2, p.Len())
+
+	// Wait for the scan to hit the error and finish.
+	<-errCatchUpSnap.done
+	require.True(t, errCatchUpSnap.closed)
+
+	// The registration should throw an error and be unregistered.
+	require.NotNil(t, <-r2ErrC)
+	p.syncEventC()
+	require.Equal(t, 1, p.Len())
+}
+
 // TestProcessorConcurrentStop tests that all methods in Processor's API
 // correctly handle the processor concurrently shutting down. If they did
 // not then it would be possible for them to deadlock.
@@ -434,7 +594,7 @@ func TestProcessorConcurrentStop(t *testing.T) {
 			runtime.Gosched()
 			s := newTestStream()
 			errC := make(chan<- *roachpb.Error, 1)
-			p.Register(p.Span, hlc.Timestamp{}, s, errC)
+			p.Register(p.Span, hlc.Timestamp{}, nil, s, errC)
 		}()
 		go func() {
 			defer wg.Done()
@@ -502,7 +662,8 @@ func TestProcessorRegistrationObservesOnlyNewEvents(t *testing.T) {
 			// operation is should see is firstIdx.
 			s := newTestStream()
 			regs[s] = firstIdx
-			p.Register(p.Span, hlc.Timestamp{}, s, make(chan *roachpb.Error, 1))
+			errC := make(chan *roachpb.Error, 1)
+			p.Register(p.Span, hlc.Timestamp{}, nil, s, errC)
 			regDone <- struct{}{}
 		}
 	}()
@@ -512,8 +673,11 @@ func TestProcessorRegistrationObservesOnlyNewEvents(t *testing.T) {
 	// from before they registered.
 	for s, expFirstIdx := range regs {
 		events := s.Events()
-		firstEvent := events[0].GetValue().(*roachpb.RangeFeedValue)
-		firstIdx := firstEvent.Value.Timestamp.WallTime
+		require.IsType(t, &roachpb.RangeFeedCheckpoint{}, events[0].GetValue())
+		require.IsType(t, &roachpb.RangeFeedValue{}, events[1].GetValue())
+
+		firstVal := events[1].GetValue().(*roachpb.RangeFeedValue)
+		firstIdx := firstVal.Value.Timestamp.WallTime
 		require.Equal(t, expFirstIdx, firstIdx)
 	}
 }

--- a/pkg/storage/rangefeed/processor_test.go
+++ b/pkg/storage/rangefeed/processor_test.go
@@ -98,9 +98,7 @@ func abortIntentOp(txnID uuid.UUID) enginepb.MVCCLogicalOp {
 
 func makeRangeFeedEvent(val interface{}) *roachpb.RangeFeedEvent {
 	var event roachpb.RangeFeedEvent
-	if !event.SetValue(val) {
-		panic(fmt.Sprintf("unknown rangefeed event: %v", val))
-	}
+	event.MustSetValue(val)
 	return &event
 }
 

--- a/pkg/storage/rangefeed/processor_test.go
+++ b/pkg/storage/rangefeed/processor_test.go
@@ -383,3 +383,54 @@ func TestProcessorConcurrentStop(t *testing.T) {
 		wg.Wait()
 	}
 }
+
+// TestProcessorRegistrationObservesOnlyNewEvents tests that a registration
+// observes only operations that are consumed after it has registered.
+func TestProcessorRegistrationObservesOnlyNewEvents(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	p, stopper := newTestProcessor()
+	defer stopper.Stop(context.Background())
+
+	firstC := make(chan int64)
+	regDone := make(chan struct{})
+	regs := make(map[*testStream]int64)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := int64(1); i < 250; i++ {
+			// Add a new registration every 10 ops.
+			if i%10 == 0 {
+				firstC <- i
+				<-regDone
+			}
+
+			// Consume the logical op. Encode the index in the timestamp.
+			p.ConsumeLogicalOps(writeValueOp(hlc.Timestamp{WallTime: i}))
+		}
+		p.syncEventC()
+		close(firstC)
+	}()
+	go func() {
+		defer wg.Done()
+		for firstIdx := range firstC {
+			// For each index, create a new registration. The first
+			// operation is should see is firstIdx.
+			s := newTestStream()
+			regs[s] = firstIdx
+			p.Register(p.Span, hlc.Timestamp{}, s, make(chan *roachpb.Error, 1))
+			regDone <- struct{}{}
+		}
+	}()
+	wg.Wait()
+
+	// Verify that no registrations were given operations
+	// from before they registered.
+	for s, expFirstIdx := range regs {
+		events := s.Events()
+		firstEvent := events[0].GetValue().(*roachpb.RangeFeedValue)
+		firstIdx := firstEvent.Value.Timestamp.WallTime
+		require.Equal(t, expFirstIdx, firstIdx)
+	}
+}

--- a/pkg/storage/rangefeed/registry.go
+++ b/pkg/storage/rangefeed/registry.go
@@ -16,6 +16,7 @@ package rangefeed
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 
@@ -59,6 +60,10 @@ func (r *registration) ID() uintptr {
 // Range implements interval.Interface.
 func (r *registration) Range() interval.Range {
 	return r.keys
+}
+
+func (r registration) String() string {
+	return fmt.Sprintf("[%s @ %s+]", r.span, r.startTS)
 }
 
 // registry holds a set of registrations and manages their lifecycle.

--- a/pkg/storage/rangefeed/registry.go
+++ b/pkg/storage/rangefeed/registry.go
@@ -27,7 +27,10 @@ import (
 
 // Stream is a object capable of transmitting RangeFeedEvents.
 type Stream interface {
+	// Context returns the context for this stream.
 	Context() context.Context
+	// Send blocks until it sends m, the stream is done or the stream breaks.
+	// Send must be safe to call on the same stream in different goroutines.
 	Send(*roachpb.RangeFeedEvent) error
 }
 
@@ -52,7 +55,8 @@ type registration struct {
 	startTS hlc.Timestamp
 
 	// Catch-up state.
-	caughtUp bool
+	catchUpSnap Snapshot
+	caughtUp    bool
 
 	// Output.
 	stream Stream

--- a/pkg/storage/rangefeed/registry_test.go
+++ b/pkg/storage/rangefeed/registry_test.go
@@ -96,10 +96,9 @@ func newTestRegistration(span roachpb.Span) *testRegistration {
 	errC := make(chan *roachpb.Error, 1)
 	return &testRegistration{
 		registration: registration{
-			span:     span,
-			caughtUp: true,
-			stream:   s,
-			errC:     errC,
+			span:   span,
+			stream: s,
+			errC:   errC,
 		},
 		stream: s,
 		errC:   errC,

--- a/pkg/storage/rangefeed/registry_test.go
+++ b/pkg/storage/rangefeed/registry_test.go
@@ -224,6 +224,25 @@ func TestRegistry(t *testing.T) {
 	reg.Disconnect(spAC)
 	require.Equal(t, 0, reg.Len())
 	require.Nil(t, rAB.Err())
+
+	// Register first 2 registrations again.
+	reg.Register(&rAB.registration)
+	require.Equal(t, 1, reg.Len())
+	reg.Register(&rBC.registration)
+	require.Equal(t, 2, reg.Len())
+
+	// Publish event to only rAB.
+	reg.PublishToReg(&rAB.registration, ev1)
+	require.Equal(t, []*roachpb.RangeFeedEvent{ev1}, rAB.Events())
+	require.Nil(t, rAB.Err())
+	require.Nil(t, rBC.Events())
+	require.Nil(t, rBC.Err())
+
+	// Disconnect only rBC.
+	reg.DisconnectRegWithError(&rBC.registration, err1)
+	require.Equal(t, 1, reg.Len())
+	require.Nil(t, rAB.Err())
+	require.Equal(t, err1, rBC.Err())
 }
 
 func TestRegistryPublishBeneathStartTimestamp(t *testing.T) {

--- a/pkg/storage/rangefeed/registry_test.go
+++ b/pkg/storage/rangefeed/registry_test.go
@@ -139,10 +139,10 @@ func TestRegistry(t *testing.T) {
 	val := roachpb.Value{Timestamp: hlc.Timestamp{WallTime: 1}}
 	ev1, ev2 := new(roachpb.RangeFeedEvent), new(roachpb.RangeFeedEvent)
 	ev3, ev4 := new(roachpb.RangeFeedEvent), new(roachpb.RangeFeedEvent)
-	ev1.SetValue(&roachpb.RangeFeedValue{Value: val})
-	ev2.SetValue(&roachpb.RangeFeedValue{Value: val})
-	ev3.SetValue(&roachpb.RangeFeedValue{Value: val})
-	ev4.SetValue(&roachpb.RangeFeedValue{Value: val})
+	ev1.MustSetValue(&roachpb.RangeFeedValue{Value: val})
+	ev2.MustSetValue(&roachpb.RangeFeedValue{Value: val})
+	ev3.MustSetValue(&roachpb.RangeFeedValue{Value: val})
+	ev4.MustSetValue(&roachpb.RangeFeedValue{Value: val})
 	err1 := roachpb.NewErrorf("error1")
 
 	reg := makeRegistry()
@@ -272,7 +272,7 @@ func TestRegistryPublishBeneathStartTimestamp(t *testing.T) {
 	// Publish a value with a timestamp beneath the registration's start
 	// timestamp. Should be ignored.
 	ev := new(roachpb.RangeFeedEvent)
-	ev.SetValue(&roachpb.RangeFeedValue{
+	ev.MustSetValue(&roachpb.RangeFeedValue{
 		Value: roachpb.Value{Timestamp: hlc.Timestamp{WallTime: 5}},
 	})
 	reg.PublishToOverlapping(spAB, ev)
@@ -280,7 +280,7 @@ func TestRegistryPublishBeneathStartTimestamp(t *testing.T) {
 
 	// Publish a value with a timestamp equal to the registration's start
 	// timestamp. Should be ignored.
-	ev.SetValue(&roachpb.RangeFeedValue{
+	ev.MustSetValue(&roachpb.RangeFeedValue{
 		Value: roachpb.Value{Timestamp: hlc.Timestamp{WallTime: 10}},
 	})
 	reg.PublishToOverlapping(spAB, ev)
@@ -288,8 +288,7 @@ func TestRegistryPublishBeneathStartTimestamp(t *testing.T) {
 
 	// Publish a checkpoint with a timestamp beneath the registration's. Should
 	// be delivered.
-	ev.Reset() // TODO(nvanbenschoten): Fix SetValue.
-	ev.SetValue(&roachpb.RangeFeedCheckpoint{
+	ev.MustSetValue(&roachpb.RangeFeedCheckpoint{
 		ResolvedTS: hlc.Timestamp{WallTime: 5},
 	})
 	reg.PublishToOverlapping(spAB, ev)
@@ -306,7 +305,7 @@ func TestRegistryPublishCheckpointNotCaughtUp(t *testing.T) {
 
 	// Publish a checkpoint before registration caught up. Should be ignored.
 	ev := new(roachpb.RangeFeedEvent)
-	ev.SetValue(&roachpb.RangeFeedCheckpoint{
+	ev.MustSetValue(&roachpb.RangeFeedCheckpoint{
 		ResolvedTS: hlc.Timestamp{WallTime: 5},
 	})
 	reg.PublishToOverlapping(spAB, ev)

--- a/pkg/storage/rangefeed/scan.go
+++ b/pkg/storage/rangefeed/scan.go
@@ -1,0 +1,108 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package rangefeed
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+)
+
+// A Snapshot is an atomic view of all MVCCKeys within a key range.
+type Snapshot interface {
+	// Iterate scans from the start key to the end key, invoking the function f
+	// on each key value pair at or above the specified timestamp. If f returns
+	// an error or if the scan itself encounters an error, the iteration will
+	// stop and return the error. If the first result of f is true, the
+	// iteration stops and returns a nil error.
+	Iterate(start, end roachpb.Key, f func(engine.MVCCKeyValue) (bool, error)) error
+	// Close closes the snapshot, freeing up any outstanding resources.
+	Close()
+}
+
+// A runnable can be run as an async task.
+type runnable interface {
+	// Run executes the runnable. Cannot be called multiple times.
+	Run(context.Context)
+	// Must be called if runnable is not Run.
+	Cancel()
+}
+
+// initResolvedTSScan scans over all keys in the provided Snapshot and informs
+// the rangefeed Processor of any intents. This allows the Processor to backfill
+// its unresolvedIntentQueue with any intents that were written before the
+// Processor was started and hooked up to a stream of logical operations. The
+// Processor can initialize its resolvedTimestamp once the scan completes
+// because it knows it is now tracking all intents in its key range.
+//
+// Snapshot Contract:
+//   The provided Snapshot must observe all intents in the Processor's keyspan.
+//   An important implication of this is that if the Snapshot uses a
+//   TimeBoundIterator, its MinTimestamp cannot be above the keyspan's largest
+//   known resolved timestamp, if one has ever been recorded.
+//
+type initResolvedTSScan struct {
+	p    *Processor
+	snap Snapshot
+}
+
+func makeInitResolvedTSScan(p *Processor, snap Snapshot) runnable {
+	return &initResolvedTSScan{p: p, snap: snap}
+}
+
+func (s *initResolvedTSScan) Run(ctx context.Context) {
+	defer s.snap.Close()
+
+	var meta enginepb.MVCCMetadata
+	sp := s.p.Span.AsRawSpanWithNoLocals()
+	err := s.snap.Iterate(sp.Key, sp.EndKey, func(kv engine.MVCCKeyValue) (bool, error) {
+		if !kv.Key.IsValue() {
+			// Found a metadata key. Inform the Processor if it's an intent.
+			if err := protoutil.Unmarshal(kv.Value, &meta); err != nil {
+				return false, errors.Wrapf(err, "unmarshaling mvcc meta: %v", kv)
+			}
+
+			if meta.Txn != nil {
+				var op enginepb.MVCCLogicalOp
+				op.SetValue(&enginepb.MVCCWriteIntentOp{
+					TxnID:     meta.Txn.ID,
+					TxnKey:    meta.Txn.Key,
+					Timestamp: meta.Txn.Timestamp,
+				})
+				s.p.ConsumeLogicalOps(op)
+			}
+		}
+		return false, nil
+	})
+
+	if err != nil {
+		err = errors.Wrap(err, "initial resolved timestamp scan failed")
+		log.Error(ctx, err)
+		s.p.StopWithErr(roachpb.NewError(err))
+	} else {
+		// Inform the processor that its resolved timestamp can be initialized.
+		s.p.setResolvedTSInitialized()
+	}
+}
+
+func (s *initResolvedTSScan) Cancel() {
+	s.snap.Close()
+}

--- a/pkg/storage/rangefeed/scan.go
+++ b/pkg/storage/rangefeed/scan.go
@@ -180,8 +180,9 @@ func (s *catchUpScan) iterateAndSend(ctx context.Context) error {
 			// filter on the registration's starting timestamp. Instead, we
 			// return all inline writes.
 			unsafeVal = meta.RawBytes
-		} else if unsafeKey.Timestamp.Less(s.r.startTS) {
-			// Before the registration's starting timestamp. Ignore.
+		} else if !s.r.startTS.Less(unsafeKey.Timestamp) {
+			// At or before the registration's exclusive starting timestamp.
+			// Ignore.
 			continue
 		}
 

--- a/pkg/storage/rangefeed/scan.go
+++ b/pkg/storage/rangefeed/scan.go
@@ -187,7 +187,7 @@ func (s *catchUpScan) iterateAndSend(ctx context.Context) error {
 		}
 
 		var event roachpb.RangeFeedEvent
-		event.SetValue(&roachpb.RangeFeedValue{
+		event.MustSetValue(&roachpb.RangeFeedValue{
 			Key: unsafeKey.Key,
 			Value: roachpb.Value{
 				RawBytes:  unsafeVal,

--- a/pkg/storage/rangefeed/scan_test.go
+++ b/pkg/storage/rangefeed/scan_test.go
@@ -288,10 +288,6 @@ func TestCatchUpScan(t *testing.T) {
 			roachpb.Key("g"),
 			roachpb.Value{RawBytes: []byte("val7"), Timestamp: hlc.Timestamp{WallTime: 0}},
 		),
-		rangeFeedValue(
-			roachpb.Key("r"),
-			roachpb.Value{RawBytes: []byte("val9"), Timestamp: hlc.Timestamp{WallTime: 4}},
-		),
 	}
 	require.Equal(t, expEvents, r.Events())
 	require.Equal(t, 1, len(p.catchUpC))

--- a/pkg/storage/rangefeed/scan_test.go
+++ b/pkg/storage/rangefeed/scan_test.go
@@ -70,6 +70,7 @@ func makeIntent(key string, txnID uuid.UUID, txnKey string, txnTS int64) engine.
 type testSnapshot struct {
 	kvs    []engine.MVCCKeyValue
 	closed bool
+	err    error
 	block  chan struct{}
 	done   chan struct{}
 }
@@ -86,6 +87,13 @@ func newTestSnapshot(kvs []engine.MVCCKeyValue) *testSnapshot {
 	}
 }
 
+func newErrorSnapshot(err error) *testSnapshot {
+	return &testSnapshot{
+		err:  err,
+		done: make(chan struct{}),
+	}
+}
+
 func (s *testSnapshot) Iterate(
 	start, end roachpb.Key, f func(engine.MVCCKeyValue) (bool, error),
 ) error {
@@ -94,6 +102,9 @@ func (s *testSnapshot) Iterate(
 	}
 	if s.block != nil {
 		<-s.block
+	}
+	if s.err != nil {
+		return s.err
 	}
 	for _, kv := range s.kvs {
 		if kv.Key.Key.Compare(start) < 0 || kv.Key.Key.Compare(end) >= 0 {
@@ -170,4 +181,67 @@ func TestInitResolvedTSScan(t *testing.T) {
 	for _, expEvent := range expEvents {
 		require.Equal(t, expEvent, <-p.eventC)
 	}
+}
+
+func TestCatchUpScan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Mock processor. We just needs its catchUpC.
+	p := Processor{catchUpC: make(chan catchUpResult, 1)}
+
+	// Run a catch-up scan for a registration over a test
+	// snapshot with the following keys.
+	txn1, txn2 := uuid.MakeV4(), uuid.MakeV4()
+	snap := newTestSnapshot([]engine.MVCCKeyValue{
+		makeKV("a", "val1", 10),
+		makeInline("b", "val2"),
+		makeIntent("c", txn1, "txnKey1", 15),
+		makeKV("c", "val3", 11),
+		makeKV("c", "val4", 9),
+		makeIntent("d", txn2, "txnKey2", 21),
+		makeKV("d", "val5", 20),
+		makeKV("d", "val6", 19),
+		makeInline("g", "val7"),
+		makeKV("m", "val8", 1),
+		makeIntent("n", txn1, "txnKey1", 12),
+		makeIntent("r", txn1, "txnKey1", 19),
+		makeKV("r", "val9", 4),
+		makeIntent("w", txn1, "txnKey1", 3),
+		makeInline("x", "val10"),
+		makeIntent("z", txn2, "txnKey2", 21),
+		makeKV("z", "val11", 4),
+	})
+	r := newTestRegistration(roachpb.Span{
+		Key:    roachpb.Key("d"),
+		EndKey: roachpb.Key("w"),
+	})
+	r.catchUpSnap = snap
+	r.startTS = hlc.Timestamp{WallTime: 4}
+
+	catchUpScan := makeCatchUpScan(&p, &r.registration)
+	catchUpScan.Run(context.Background())
+	require.True(t, snap.closed)
+
+	// Compare the events sent on the registration's Stream to the expected events.
+	expEvents := []*roachpb.RangeFeedEvent{
+		rangeFeedValue(
+			roachpb.Key("d"),
+			roachpb.Value{RawBytes: []byte("val5"), Timestamp: hlc.Timestamp{WallTime: 20}},
+		),
+		rangeFeedValue(
+			roachpb.Key("d"),
+			roachpb.Value{RawBytes: []byte("val6"), Timestamp: hlc.Timestamp{WallTime: 19}},
+		),
+		rangeFeedValue(
+			roachpb.Key("g"),
+			roachpb.Value{RawBytes: []byte("val7"), Timestamp: hlc.Timestamp{WallTime: 0}},
+		),
+		rangeFeedValue(
+			roachpb.Key("r"),
+			roachpb.Value{RawBytes: []byte("val9"), Timestamp: hlc.Timestamp{WallTime: 4}},
+		),
+	}
+	require.Equal(t, expEvents, r.Events())
+	require.Equal(t, 1, len(p.catchUpC))
+	require.Equal(t, catchUpResult{r: &r.registration}, <-p.catchUpC)
 }

--- a/pkg/storage/rangefeed/scan_test.go
+++ b/pkg/storage/rangefeed/scan_test.go
@@ -1,0 +1,173 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package rangefeed
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+func makeKV(key, val string, ts int64) engine.MVCCKeyValue {
+	return engine.MVCCKeyValue{
+		Key: engine.MVCCKey{
+			Key:       roachpb.Key(key),
+			Timestamp: hlc.Timestamp{WallTime: ts},
+		},
+		Value: []byte(val),
+	}
+}
+
+func makeMetaKV(key string, meta enginepb.MVCCMetadata) engine.MVCCKeyValue {
+	b, err := protoutil.Marshal(&meta)
+	if err != nil {
+		panic(err)
+	}
+	return engine.MVCCKeyValue{
+		Key: engine.MVCCKey{
+			Key: roachpb.Key(key),
+		},
+		Value: b,
+	}
+}
+
+func makeInline(key, val string) engine.MVCCKeyValue {
+	return makeMetaKV(key, enginepb.MVCCMetadata{
+		RawBytes: []byte(val),
+	})
+}
+
+func makeIntent(key string, txnID uuid.UUID, txnKey string, txnTS int64) engine.MVCCKeyValue {
+	return makeMetaKV(key, enginepb.MVCCMetadata{Txn: &enginepb.TxnMeta{
+		ID:        txnID,
+		Key:       []byte(txnKey),
+		Timestamp: hlc.Timestamp{WallTime: txnTS},
+	}})
+}
+
+type testSnapshot struct {
+	kvs    []engine.MVCCKeyValue
+	closed bool
+	block  chan struct{}
+	done   chan struct{}
+}
+
+func newTestSnapshot(kvs []engine.MVCCKeyValue) *testSnapshot {
+	if !sort.SliceIsSorted(kvs, func(i, j int) bool {
+		return kvs[i].Key.Less(kvs[j].Key)
+	}) {
+		panic("unsorted kvs")
+	}
+	return &testSnapshot{
+		kvs:  kvs,
+		done: make(chan struct{}),
+	}
+}
+
+func (s *testSnapshot) Iterate(
+	start, end roachpb.Key, f func(engine.MVCCKeyValue) (bool, error),
+) error {
+	if s.closed {
+		panic("testSnapshot closed")
+	}
+	if s.block != nil {
+		<-s.block
+	}
+	for _, kv := range s.kvs {
+		if kv.Key.Key.Compare(start) < 0 || kv.Key.Key.Compare(end) >= 0 {
+			continue
+		}
+		if stop, err := f(kv); err != nil {
+			return err
+		} else if stop {
+			break
+		}
+	}
+	return nil
+}
+
+func (s *testSnapshot) Close() {
+	s.closed = true
+	close(s.done)
+}
+
+func TestInitResolvedTSScan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Mock processor. We just needs its eventC.
+	p := Processor{
+		Config: Config{
+			Span: roachpb.RSpan{
+				Key:    roachpb.RKey("d"),
+				EndKey: roachpb.RKey("w"),
+			},
+		},
+		eventC: make(chan event, 100),
+	}
+
+	// Run an init rts scan over a test snapshot with the following keys.
+	txn1, txn2 := uuid.MakeV4(), uuid.MakeV4()
+	snap := newTestSnapshot([]engine.MVCCKeyValue{
+		makeKV("a", "val1", 10),
+		makeInline("b", "val2"),
+		makeIntent("c", txn1, "txnKey1", 15),
+		makeKV("c", "val3", 11),
+		makeKV("c", "val4", 9),
+		makeIntent("d", txn2, "txnKey2", 21),
+		makeKV("d", "val5", 20),
+		makeKV("d", "val6", 19),
+		makeInline("g", "val7"),
+		makeKV("m", "val8", 1),
+		makeIntent("n", txn1, "txnKey1", 12),
+		makeIntent("r", txn1, "txnKey1", 19),
+		makeKV("r", "val9", 4),
+		makeIntent("w", txn1, "txnKey1", 3),
+		makeInline("x", "val10"),
+		makeIntent("z", txn2, "txnKey2", 21),
+		makeKV("z", "val11", 4),
+	})
+
+	initScan := makeInitResolvedTSScan(&p, snap)
+	initScan.Run(context.Background())
+	require.True(t, snap.closed)
+
+	// Compare the event channel to the expected events.
+	expEvents := []event{
+		{ops: []enginepb.MVCCLogicalOp{
+			writeIntentOpWithKey(txn2, []byte("txnKey2"), hlc.Timestamp{WallTime: 21}),
+		}},
+		{ops: []enginepb.MVCCLogicalOp{
+			writeIntentOpWithKey(txn1, []byte("txnKey1"), hlc.Timestamp{WallTime: 12}),
+		}},
+		{ops: []enginepb.MVCCLogicalOp{
+			writeIntentOpWithKey(txn1, []byte("txnKey1"), hlc.Timestamp{WallTime: 19}),
+		}},
+		{initRTS: true},
+	}
+	require.Equal(t, len(expEvents), len(p.eventC))
+	for _, expEvent := range expEvents {
+		require.Equal(t, expEvent, <-p.eventC)
+	}
+}


### PR DESCRIPTION
This PR includes a number of small improvements to the `rangefeed` package, culminating in the introduction of two scans that a rangefeed will need to perform. The first is a scan over the entire key range from the previously known resolved timestamp onward to learn about all existing unresolved intents. The second is a scan over a new registration's key range to backfill in all values from before it was registered but after its starting timestamp. Both of these scans will be able to take advantage of TimeBound iterators. However, the way they're represented in the `rangefeed` package is pretty abstract, which made testing pretty easy.

The first commit and the last two are substantial, but the rest are just small logical changes so I hope this is easy to review.

@benesch thanks for offering to take a look at this while @tschottdorf is out! There's only been one PR merged so far so it shouldn't take much to catch up to speed: https://github.com/cockroachdb/cockroach/pull/28072.