### PR TITLE
cli: support multi-line copy/paste

### DIFF
--- a/pkg/cli/interactive_tests/test_multiline_statements.tcl
+++ b/pkg/cli/interactive_tests/test_multiline_statements.tcl
@@ -4,6 +4,10 @@ source [file join [file dirname $argv0] common.tcl]
 
 start_server $argv
 
+# we force TERM to xterm, otherwise we can't
+# test bracketed paste below.
+set env(TERM) xterm
+
 spawn $argv sql
 eexpect root@
 
@@ -134,6 +138,19 @@ send "commit;\r"
 eexpect COMMIT
 eexpect root@
 end_test
+
+start_test "Test that a multi-line bracketed paste is handled properly."
+send "\033\[200~"
+send "\\set display_format csv\r\n"
+send "values (1,'a'), (2,'b'), (3,'c');\r\n"
+send "\033\[201~\r\n"
+eexpect "1,a"
+eexpect "2,b"
+eexpect "3,c"
+eexpect root@
+end_test
+
+
 
 interrupt
 eexpect eof


### PR DESCRIPTION
Fixes #24965.

The introduction of support for bracketed paste (#23116 /
cedff2372008ca2fd877c0e48652ad54552d4a13) has broken an invariant in
the SQL shell: that the readline function can return at most one line
of input. The shell was not organized to "peek" within that line and
detect that it needs different handling for different parts of the
pasted input, for example when pasting:

```
\set display_format csv
values (1,2), (3,4);
```

the `\set` must be executed client-side, and the `values`
server-side. This was not possible and the entire string was sent to
the server, and the server reported an error upon encountering `\set`.

To address this, this patch recognizes multi-line results of
Readline() and ensures the lines are processed one by one.

Release note (bug fix): `cockroach sql` and `cockroach demo` now again
properly handles copy-pasting a mixture of client-side
commands (e.g. `\set`) and SQL statements.