### PR TITLE
sql: recognize ARRAY(...) in addition to ARRAY[...]

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1303,9 +1303,10 @@ d_expr ::=
 	| '(' a_expr ')'
 	| func_expr
 	| select_with_parens
-	| 'ARRAY' select_with_parens
-	| 'ARRAY' array_expr
 	| labeled_row
+	| 'ARRAY' select_with_parens
+	| 'ARRAY' row
+	| 'ARRAY' array_expr
 
 array_subscripts ::=
 	( array_subscript ) ( ( array_subscript ) )*
@@ -1611,13 +1612,17 @@ func_expr ::=
 	func_application filter_clause over_clause
 	| func_expr_common_subexpr
 
-array_expr ::=
-	'[' opt_expr_list ']'
-	| '[' array_expr_list ']'
-
 labeled_row ::=
 	row
 	| '(' row 'AS' name_list ')'
+
+row ::=
+	'ROW' '(' opt_expr_list ')'
+	| expr_tuple_unambiguous
+
+array_expr ::=
+	'[' opt_expr_list ']'
+	| '[' array_expr_list ']'
 
 array_subscript ::=
 	'[' a_expr ']'
@@ -1870,12 +1875,12 @@ opt_expr_list ::=
 	expr_list
 	| 
 
+expr_tuple_unambiguous ::=
+	'(' ')'
+	| '(' tuple1_unambiguous_values ')'
+
 array_expr_list ::=
 	( array_expr ) ( ( ',' array_expr ) )*
-
-row ::=
-	'ROW' '(' opt_expr_list ')'
-	| expr_tuple_unambiguous
 
 opt_slice_bound ::=
 	a_expr
@@ -2039,9 +2044,9 @@ special_function ::=
 	| 'GREATEST' '(' expr_list ')'
 	| 'LEAST' '(' expr_list ')'
 
-expr_tuple_unambiguous ::=
-	'(' ')'
-	| '(' tuple1_unambiguous_values ')'
+tuple1_unambiguous_values ::=
+	a_expr ','
+	| a_expr ',' expr_list
 
 window_definition ::=
 	window_name 'AS' window_specification
@@ -2122,10 +2127,6 @@ trim_list ::=
 	a_expr 'FROM' expr_list
 	| 'FROM' expr_list
 	| expr_list
-
-tuple1_unambiguous_values ::=
-	a_expr ','
-	| a_expr ',' expr_list
 
 index_hints_param ::=
 	'FORCE_INDEX' '=' index_name

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1251,6 +1251,8 @@ func TestParse2(t *testing.T) {
 		{`SELECT '\abc\' NOT SIMILAR TO '-\___-\' ESCAPE '-'`, `SELECT not_similar_to_escape(e'\\abc\\', e'-\\___-\\', '-')`},
 		{`SELECT 'a' NOT SIMILAR TO '\a' ESCAPE ''`, `SELECT not_similar_to_escape('a', e'\\a', '')`},
 
+		{`SELECT (ARRAY (1, 2))[1]`, `SELECT (ARRAY[1, 2])[1]`},
+
 		// Pretty printing the FAMILY INET function is not normal due to the grammar
 		// definition of FAMILY.
 		{`SELECT FAMILY(x)`, // lint: uppercase function OK

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6891,17 +6891,21 @@ d_expr:
   {
     $$.val = &tree.Subquery{Select: $1.selectStmt()}
   }
-| ARRAY select_with_parens
+| labeled_row
+  {
+    $$.val = $1.tuple()
+  }
+| ARRAY select_with_parens %prec UMINUS
   {
     $$.val = &tree.ArrayFlatten{Subquery: &tree.Subquery{Select: $2.selectStmt()}}
+  }
+| ARRAY row
+  {
+    $$.val = &tree.Array{Exprs: $2.tuple().Exprs}
   }
 | ARRAY array_expr
   {
     $$.val = $2.expr()
-  }
-| labeled_row
-  {
-    $$.val = $1.tuple()
   }
 
 // TODO(pmattis): Support this notation?

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -959,6 +959,7 @@ func TestEval(t *testing.T) {
 		{`ARRAY['a', 'b', 'c']`, `ARRAY['a','b','c']`},
 		{`ARRAY[ARRAY[1, 2], ARRAY[2, 3]]`, `ARRAY[ARRAY[1,2],ARRAY[2,3]]`},
 		{`ARRAY[1, NULL]`, `ARRAY[1,NULL]`},
+		{`ARRAY(1, 2)`, `ARRAY[1,2]`},
 		// Array sizes.
 		{`array_length(ARRAY[1, 2, 3], 1)`, `3`},
 		{`array_length(ARRAY[1, 2, 3], 2)`, `NULL`},


### PR DESCRIPTION
This patch adds grammar support to construct arrays using the keyword
`ARRAY` followed by a tuple between parentheses. Previously, the
syntax with parentheses was limited to only recognize subqueries.

This extension is needed for distSQL physical planning.

Release note (sql change): CockroachDB now supports constructing array
values using parentheses, for example `ARRAY(1,2,3,4)`. This is a
CockroachDB extension; the standard PostgreSQL syntax `ARRAY[1,2,3,4]`
remains supported.