### PR TITLE
sql: rename window frame bounds

### DIFF
--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -1113,11 +1113,11 @@ func (spec *WindowerSpec_Frame_BoundType) initFromAST(bt tree.WindowFrameBoundTy
 	switch bt {
 	case tree.UnboundedPreceding:
 		*spec = WindowerSpec_Frame_UNBOUNDED_PRECEDING
-	case tree.ValuePreceding:
+	case tree.OffsetPreceding:
 		*spec = WindowerSpec_Frame_OFFSET_PRECEDING
 	case tree.CurrentRow:
 		*spec = WindowerSpec_Frame_CURRENT_ROW
-	case tree.ValueFollowing:
+	case tree.OffsetFollowing:
 		*spec = WindowerSpec_Frame_OFFSET_FOLLOWING
 	case tree.UnboundedFollowing:
 		*spec = WindowerSpec_Frame_UNBOUNDED_FOLLOWING
@@ -1198,11 +1198,11 @@ func (spec WindowerSpec_Frame_BoundType) convertToAST() tree.WindowFrameBoundTyp
 	case WindowerSpec_Frame_UNBOUNDED_PRECEDING:
 		return tree.UnboundedPreceding
 	case WindowerSpec_Frame_OFFSET_PRECEDING:
-		return tree.ValuePreceding
+		return tree.OffsetPreceding
 	case WindowerSpec_Frame_CURRENT_ROW:
 		return tree.CurrentRow
 	case WindowerSpec_Frame_OFFSET_FOLLOWING:
-		return tree.ValueFollowing
+		return tree.OffsetFollowing
 	case WindowerSpec_Frame_UNBOUNDED_FOLLOWING:
 		return tree.UnboundedFollowing
 	default:

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -7256,16 +7256,16 @@ opt_frame_clause:
     startBound := bounds.StartBound
     endBound := bounds.EndBound
     switch {
-    case startBound.BoundType == tree.ValuePreceding:
+    case startBound.BoundType == tree.OffsetPreceding:
       sqllex.Error("RANGE PRECEDING is only supported with UNBOUNDED")
       return 1
-    case startBound.BoundType == tree.ValueFollowing:
+    case startBound.BoundType == tree.OffsetFollowing:
       sqllex.Error("RANGE FOLLOWING is only supported with UNBOUNDED")
       return 1
-    case endBound != nil && endBound.BoundType == tree.ValuePreceding:
+    case endBound != nil && endBound.BoundType == tree.OffsetPreceding:
       sqllex.Error("RANGE PRECEDING is only supported with UNBOUNDED")
       return 1
-    case endBound != nil && endBound.BoundType == tree.ValueFollowing:
+    case endBound != nil && endBound.BoundType == tree.OffsetFollowing:
       sqllex.Error("RANGE FOLLOWING is only supported with UNBOUNDED")
       return 1
     }
@@ -7294,7 +7294,7 @@ frame_extent:
     case startBound.BoundType == tree.UnboundedFollowing:
       sqllex.Error("frame start cannot be UNBOUNDED FOLLOWING")
       return 1
-    case startBound.BoundType == tree.ValueFollowing:
+    case startBound.BoundType == tree.OffsetFollowing:
       sqllex.Error("frame starting from following row cannot end with current row")
       return 1
     }
@@ -7311,13 +7311,13 @@ frame_extent:
     case endBound.BoundType == tree.UnboundedPreceding:
       sqllex.Error("frame end cannot be UNBOUNDED PRECEDING")
       return 1
-    case startBound.BoundType == tree.CurrentRow && endBound.BoundType == tree.ValuePreceding:
+    case startBound.BoundType == tree.CurrentRow && endBound.BoundType == tree.OffsetPreceding:
       sqllex.Error("frame starting from current row cannot have preceding rows")
       return 1
-    case startBound.BoundType == tree.ValueFollowing && endBound.BoundType == tree.ValuePreceding:
+    case startBound.BoundType == tree.OffsetFollowing && endBound.BoundType == tree.OffsetPreceding:
       sqllex.Error("frame starting from following row cannot have preceding rows")
       return 1
-    case startBound.BoundType == tree.ValueFollowing && endBound.BoundType == tree.CurrentRow:
+    case startBound.BoundType == tree.OffsetFollowing && endBound.BoundType == tree.CurrentRow:
       sqllex.Error("frame starting from following row cannot have preceding rows")
       return 1
     }
@@ -7344,14 +7344,14 @@ frame_bound:
   {
     $$.val = &tree.WindowFrameBound{
       OffsetExpr: $1.expr(),
-      BoundType: tree.ValuePreceding,
+      BoundType: tree.OffsetPreceding,
     }
   }
 | a_expr FOLLOWING
   {
     $$.val = &tree.WindowFrameBound{
       OffsetExpr: $1.expr(),
-      BoundType: tree.ValueFollowing,
+      BoundType: tree.OffsetFollowing,
     }
   }
 

--- a/pkg/sql/sem/builtins/window_frame_builtins_test.go
+++ b/pkg/sql/sem/builtins/window_frame_builtins_test.go
@@ -65,8 +65,8 @@ func testSlidingWindow(t *testing.T, count int) {
 	wfr.Frame = &tree.WindowFrame{
 		Mode: tree.ROWS,
 		Bounds: tree.WindowFrameBounds{
-			StartBound: &tree.WindowFrameBound{BoundType: tree.ValuePreceding},
-			EndBound:   &tree.WindowFrameBound{BoundType: tree.ValueFollowing},
+			StartBound: &tree.WindowFrameBound{BoundType: tree.OffsetPreceding},
+			EndBound:   &tree.WindowFrameBound{BoundType: tree.OffsetFollowing},
 		},
 	}
 	testMin(t, evalCtx, wfr)

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -689,11 +689,11 @@ func (node *WindowFrameBound) doc(p *PrettyCfg) pretty.Doc {
 	switch node.BoundType {
 	case UnboundedPreceding:
 		return pretty.Text("UNBOUNDED PRECEDING")
-	case ValuePreceding:
+	case OffsetPreceding:
 		return pretty.ConcatSpace(p.Doc(node.OffsetExpr), pretty.Text("PRECEDING"))
 	case CurrentRow:
 		return pretty.Text("CURRENT ROW")
-	case ValueFollowing:
+	case OffsetFollowing:
 		return pretty.ConcatSpace(p.Doc(node.OffsetExpr), pretty.Text("FOLLOWING"))
 	case UnboundedFollowing:
 		return pretty.Text("UNBOUNDED FOLLOWING")

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -655,12 +655,12 @@ type WindowFrameBoundType int
 const (
 	// UnboundedPreceding represents UNBOUNDED PRECEDING type of boundary.
 	UnboundedPreceding WindowFrameBoundType = iota
-	// ValuePreceding represents 'value' PRECEDING type of boundary.
-	ValuePreceding
+	// OffsetPreceding represents 'value' PRECEDING type of boundary.
+	OffsetPreceding
 	// CurrentRow represents CURRENT ROW type of boundary.
 	CurrentRow
-	// ValueFollowing represents 'value' FOLLOWING type of boundary.
-	ValueFollowing
+	// OffsetFollowing represents 'value' FOLLOWING type of boundary.
+	OffsetFollowing
 	// UnboundedFollowing represents UNBOUNDED FOLLOWING type of boundary.
 	UnboundedFollowing
 )
@@ -689,12 +689,12 @@ func (node *WindowFrameBound) Format(ctx *FmtCtx) {
 	switch node.BoundType {
 	case UnboundedPreceding:
 		ctx.WriteString("UNBOUNDED PRECEDING")
-	case ValuePreceding:
+	case OffsetPreceding:
 		ctx.FormatNode(node.OffsetExpr)
 		ctx.WriteString(" PRECEDING")
 	case CurrentRow:
 		ctx.WriteString("CURRENT ROW")
-	case ValueFollowing:
+	case OffsetFollowing:
 		ctx.FormatNode(node.OffsetExpr)
 		ctx.WriteString(" FOLLOWING")
 	case UnboundedFollowing:

--- a/pkg/sql/sem/tree/window_funcs.go
+++ b/pkg/sql/sem/tree/window_funcs.go
@@ -59,13 +59,13 @@ func (wfr WindowFrameRun) FrameStartIdx() int {
 		switch wfr.Frame.Bounds.StartBound.BoundType {
 		case UnboundedPreceding:
 			return 0
-		case ValuePreceding:
+		case OffsetPreceding:
 			// TODO(yuzefovich): Currently, it is not supported, and this case should not be reached.
 			panic("unsupported WindowFrameBoundType in RANGE mode")
 		case CurrentRow:
 			// Spec: in RANGE mode CURRENT ROW means that the frame starts with the current row's first peer.
 			return wfr.FirstPeerIdx
-		case ValueFollowing:
+		case OffsetFollowing:
 			// TODO(yuzefovich): Currently, it is not supported, and this case should not be reached.
 			panic("unsupported WindowFrameBoundType in RANGE mode")
 		default:
@@ -75,7 +75,7 @@ func (wfr WindowFrameRun) FrameStartIdx() int {
 		switch wfr.Frame.Bounds.StartBound.BoundType {
 		case UnboundedPreceding:
 			return 0
-		case ValuePreceding:
+		case OffsetPreceding:
 			offset := MustBeDInt(wfr.StartBoundOffset)
 			idx := wfr.RowIdx - int(offset)
 			if idx < 0 {
@@ -84,7 +84,7 @@ func (wfr WindowFrameRun) FrameStartIdx() int {
 			return idx
 		case CurrentRow:
 			return wfr.RowIdx
-		case ValueFollowing:
+		case OffsetFollowing:
 			offset := MustBeDInt(wfr.StartBoundOffset)
 			idx := wfr.RowIdx + int(offset)
 			if idx >= wfr.PartitionSize() {
@@ -124,12 +124,12 @@ func (wfr WindowFrameRun) FrameEndIdx() int {
 			return wfr.DefaultFrameSize()
 		}
 		switch wfr.Frame.Bounds.EndBound.BoundType {
-		case ValuePreceding:
+		case OffsetPreceding:
 			// TODO(yuzefovich): Currently, it is not supported, and this case should not be reached.
 			panic("unsupported WindowFrameBoundType in RANGE mode")
 		case CurrentRow:
 			return wfr.DefaultFrameSize()
-		case ValueFollowing:
+		case OffsetFollowing:
 			// TODO(yuzefovich): Currently, it is not supported, and this case should not be reached.
 			panic("unsupported WindowFrameBoundType in RANGE mode")
 		case UnboundedFollowing:
@@ -143,7 +143,7 @@ func (wfr WindowFrameRun) FrameEndIdx() int {
 			return wfr.RowIdx + 1
 		}
 		switch wfr.Frame.Bounds.EndBound.BoundType {
-		case ValuePreceding:
+		case OffsetPreceding:
 			offset := MustBeDInt(wfr.EndBoundOffset)
 			idx := wfr.RowIdx - int(offset) + 1
 			if idx < 0 {
@@ -152,7 +152,7 @@ func (wfr WindowFrameRun) FrameEndIdx() int {
 			return idx
 		case CurrentRow:
 			return wfr.RowIdx + 1
-		case ValueFollowing:
+		case OffsetFollowing:
 			offset := MustBeDInt(wfr.EndBoundOffset)
 			idx := wfr.RowIdx + int(offset) + 1
 			if idx >= wfr.PartitionSize() {


### PR DESCRIPTION
Renames ValuePreceding and ValueFollowing types of
window frame bounds to OffsetPreceding and OffsetFollowing,
respectively, to better convey the meaning. PG also uses
"OFFSET_*" in their code.

Release note: None