### PR TITLE
opt: Decorrelate Zip operator

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/subquery_correlated
+++ b/pkg/sql/logictest/testdata/logic_test/subquery_correlated
@@ -331,6 +331,20 @@ WHERE EXISTS
 2  TX
 4  TX
 
+# Customers with each of their orders numbered.
+query II rowsort
+SELECT c_id, generate_series(1, (SELECT count(*) FROM o WHERE o.c_id=c.c_id)) FROM c
+----
+1  1
+1  2
+1  3
+2  1
+2  2
+2  3
+4  1
+4  2
+6  1
+
 # Max1Row prevents decorrelation.
 statement error could not decorrelate subquery
 SELECT *

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -215,6 +215,36 @@
     (ConcatFilters $on $innerOn)
 )
 
+# TryDecorrelateInnerLeftJoin tries to decorrelate a LeftJoin operator nested
+# beneath an InnerJoin operator by using the associative identity to pull up the
+# left join to become the outer join. This may be enough to decorrelate the
+# outer join, or it may allow any outer column references to continue to journey
+# upwards.
+#
+# Citations: [1] (see identity #6)
+[TryDecorrelateInnerLeftJoin, Normalize]
+(InnerJoin | InnerJoinApply
+    $left:*
+    $right:* &
+        (HasOuterCols $right) &
+        (LeftJoin
+            $innerLeft:*
+            $innerRight:*
+            $innerOn:*
+        )
+    $on:* & (IsBoundBy $on (OutputCols2 $left $innerLeft))
+)
+=>
+(LeftJoinApply
+    ((OpName)
+        $left
+        $innerLeft
+        $on
+    )
+    $innerRight
+    $innerOn
+)
+
 # TryDecorrelateGroupBy "pushes down" a Join into a GroupBy operator, in an
 # attempt to keep "digging" down to find and eliminate unnecessary correlation.
 # The eventual hope is to trigger the DecorrelateJoin rule to turn a JoinApply
@@ -373,6 +403,40 @@
     (GroupByKey $newLeft)
 )
 
+# TryDecorrelateZip "pushes down" an outer InnerJoinApply operator into an inner
+# InnerJoinApply operator, in hopes of eliminating any correlation between the
+# Zip operator and the outer InnerJoinApply operator. Eventually, the hope is to
+# trigger the DecorrelateJoin pattern to turn JoinApply operators into non-apply
+# Join operators.
+#
+# This rule only matches Zip as $innerRight because other relational operators
+# can decorrelate by pushing parent joins down into an input operand. But Zip
+# does not have an input operand of its own, and so it uses InnerJoinApply as a
+# proxy for that, and pushes other operators down through that instead.
+#
+# TODO(andyk): Consider creating a single ProjectSet relational operator, rather
+#              than using InnerJoinApply + Zip, which seems fragile.
+[TryDecorrelateZip, Normalize]
+(InnerJoinApply
+    $left:*
+    (InnerJoinApply
+        $innerLeft:*
+        $innerRight:(Zip)
+        $innerOn:*
+    )
+    $on:*
+)
+=>
+(InnerJoinApply
+    (InnerJoinApply
+        $left
+        $innerLeft
+        (True)
+    )
+    $innerRight
+    (ConcatFilters $on $innerOn)
+)
+
 # HoistSelectExists extracts existential subqueries from Select filters,
 # turning them into semi-joins. This eliminates the subquery, which is often
 # expensive to execute and restricts the optimizer's plan choices.
@@ -484,6 +548,19 @@
 )
 =>
 (HoistValuesSubquery $rows $cols)
+
+# HoistZipSubquery extracts subqueries from zipped functions and joins them with
+# the Zip operator using an Apply join. This and other subquery hoisting
+# patterns create a single, top-level relational query with no nesting.
+#
+# This rule is marked as low priority for the same reason as HoistSelectExists.
+[HoistZipSubquery, Normalize, LowPriority]
+(Zip
+    $funcs:[ ... $item:* & (HasHoistableSubquery $item) ... ]
+    $cols:*
+)
+=>
+(HoistZipSubquery $funcs $cols)
 
 # NormalizeAnyFilter rewrites Any into Exists when it's a top-level conjunct in
 # a Select or Join filter. Any can be rewritten as Exists in this context

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1021,6 +1021,132 @@ semi-join-apply
  └── true [type=bool]
 
 # --------------------------------------------------
+# TryDecorrelateInnerLeftJoin
+# --------------------------------------------------
+opt
+SELECT *
+FROM (VALUES (1), (2)) AS v(v1)
+WHERE EXISTS(
+    SELECT k
+    FROM a
+    WHERE
+    (
+        SELECT y FROM xy LEFT JOIN (SELECT v1 FROM uv LIMIT 1) ON x=v1 WHERE x=k
+    )=i
+)
+----
+semi-join-apply
+ ├── columns: v1:1(int)
+ ├── cardinality: [0 - 2]
+ ├── values
+ │    ├── columns: column1:1(int)
+ │    ├── cardinality: [2 - 2]
+ │    ├── (1,) [type=tuple{int}]
+ │    └── (2,) [type=tuple{int}]
+ ├── left-join
+ │    ├── columns: k:2(int!null) i:3(int!null) x:7(int!null) y:8(int!null) v1:11(int)
+ │    ├── outer: (1)
+ │    ├── key: (7)
+ │    ├── fd: (2)-->(3), (7)-->(8,11), (2)==(7), (7)==(2), (3)==(8), (8)==(3), ()~~>(11)
+ │    ├── inner-join
+ │    │    ├── columns: k:2(int!null) i:3(int!null) x:7(int!null) y:8(int!null)
+ │    │    ├── key: (7)
+ │    │    ├── fd: (2)-->(3), (7)-->(8), (2)==(7), (7)==(2), (3)==(8), (8)==(3)
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:2(int!null) i:3(int)
+ │    │    │    ├── key: (2)
+ │    │    │    └── fd: (2)-->(3)
+ │    │    ├── scan xy
+ │    │    │    ├── columns: x:7(int!null) y:8(int)
+ │    │    │    ├── key: (7)
+ │    │    │    └── fd: (7)-->(8)
+ │    │    └── filters [type=bool, outer=(2,3,7,8), constraints=(/2: (/NULL - ]; /3: (/NULL - ]; /7: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(7), (7)==(2), (3)==(8), (8)==(3)]
+ │    │         ├── xy.x = a.k [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
+ │    │         └── a.i = xy.y [type=bool, outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ])]
+ │    ├── project
+ │    │    ├── columns: v1:11(int)
+ │    │    ├── outer: (1)
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(11)
+ │    │    ├── scan uv
+ │    │    │    ├── limit: 1
+ │    │    │    └── key: ()
+ │    │    └── projections [outer=(1)]
+ │    │         └── variable: column1 [type=int, outer=(1)]
+ │    └── filters [type=bool, outer=(7,11), constraints=(/7: (/NULL - ]; /11: (/NULL - ]), fd=(7)==(11), (11)==(7)]
+ │         └── xy.x = v1 [type=bool, outer=(7,11), constraints=(/7: (/NULL - ]; /11: (/NULL - ])]
+ └── true [type=bool]
+
+opt
+SELECT *
+FROM xy, uv
+WHERE (SELECT i FROM a WHERE k=x) IS DISTINCT FROM u
+----
+project
+ ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
+ ├── fd: (1)-->(2), (3)-->(4)
+ └── select
+      ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) k:5(int) i:6(int)
+      ├── key: (1,3,5)
+      ├── fd: (1)-->(2), (3)-->(4), (5)-->(6)
+      ├── left-join
+      │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) k:5(int) i:6(int)
+      │    ├── key: (1,3,5)
+      │    ├── fd: (1)-->(2), (3)-->(4), (5)-->(6)
+      │    ├── inner-join
+      │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
+      │    │    ├── key: (1,3)
+      │    │    ├── fd: (1)-->(2), (3)-->(4)
+      │    │    ├── scan xy
+      │    │    │    ├── columns: x:1(int!null) y:2(int)
+      │    │    │    ├── key: (1)
+      │    │    │    └── fd: (1)-->(2)
+      │    │    ├── scan uv
+      │    │    │    ├── columns: u:3(int!null) v:4(int)
+      │    │    │    ├── key: (3)
+      │    │    │    └── fd: (3)-->(4)
+      │    │    └── true [type=bool]
+      │    ├── scan a
+      │    │    ├── columns: k:5(int!null) i:6(int)
+      │    │    ├── key: (5)
+      │    │    └── fd: (5)-->(6)
+      │    └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+      │         └── a.k = xy.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+      └── filters [type=bool, outer=(3,6)]
+           └── uv.u IS DISTINCT FROM a.i [type=bool, outer=(3,6)]
+
+opt
+SELECT generate_series(1, (SELECT u FROM uv WHERE u=x))
+FROM xy
+----
+project
+ ├── columns: generate_series:5(int)
+ └── inner-join-apply
+      ├── columns: x:1(int!null) u:3(int) column5:5(int)
+      ├── left-join (merge)
+      │    ├── columns: x:1(int!null) u:3(int)
+      │    ├── key: (1,3)
+      │    ├── scan xy
+      │    │    ├── columns: x:1(int!null)
+      │    │    ├── key: (1)
+      │    │    └── ordering: +1
+      │    ├── scan uv
+      │    │    ├── columns: u:3(int!null)
+      │    │    ├── key: (3)
+      │    │    └── ordering: +3
+      │    └── merge-on
+      │         ├── left ordering: +1
+      │         ├── right ordering: +3
+      │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+      │              └── uv.u = xy.x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+      ├── zip
+      │    ├── columns: column5:5(int)
+      │    ├── outer: (3)
+      │    └── generate_series(1, uv.u) [type=int, outer=(3)]
+      └── true [type=bool]
+
+# --------------------------------------------------
 # TryDecorrelateGroupBy
 # --------------------------------------------------
 opt
@@ -1108,36 +1234,51 @@ project
       │    ├── grouping columns: u:3(int!null)
       │    ├── key: (3)
       │    ├── fd: (1)-->(2), (3)-->(1,2,4,10), (1)==(4), (4)==(1)
-      │    ├── inner-join
+      │    ├── inner-join (merge)
       │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null) k:5(int!null) i:6(int!null)
       │    │    ├── key: (3)
-      │    │    ├── fd: (1)-->(2), (3)-->(4), (5)-->(6), (1)==(4,5), (4)==(1,5), (5)==(1,4)
-      │    │    ├── inner-join
-      │    │    │    ├── columns: u:3(int!null) v:4(int) k:5(int!null) i:6(int!null)
-      │    │    │    ├── key: (3,5)
-      │    │    │    ├── fd: (3)-->(4), (5)-->(6)
-      │    │    │    ├── scan uv
+      │    │    ├── fd: (1)-->(2), (3)-->(4), (1)==(4,5), (4)==(1,5), (5)-->(6), (5)==(1,4)
+      │    │    ├── inner-join (merge)
+      │    │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null)
+      │    │    │    ├── key: (3)
+      │    │    │    ├── fd: (1)-->(2), (3)-->(4), (1)==(4), (4)==(1)
+      │    │    │    ├── ordering: +(1|4)
+      │    │    │    ├── scan xy
+      │    │    │    │    ├── columns: x:1(int!null) y:2(int)
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    ├── fd: (1)-->(2)
+      │    │    │    │    └── ordering: +1
+      │    │    │    ├── sort
       │    │    │    │    ├── columns: u:3(int!null) v:4(int)
       │    │    │    │    ├── key: (3)
-      │    │    │    │    └── fd: (3)-->(4)
-      │    │    │    ├── select
-      │    │    │    │    ├── columns: k:5(int!null) i:6(int!null)
+      │    │    │    │    ├── fd: (3)-->(4)
+      │    │    │    │    ├── ordering: +4
+      │    │    │    │    └── scan uv
+      │    │    │    │         ├── columns: u:3(int!null) v:4(int)
+      │    │    │    │         ├── key: (3)
+      │    │    │    │         └── fd: (3)-->(4)
+      │    │    │    └── merge-on
+      │    │    │         ├── left ordering: +1
+      │    │    │         ├── right ordering: +4
+      │    │    │         └── filters [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+      │    │    │              └── xy.x = uv.v [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ])]
+      │    │    ├── select
+      │    │    │    ├── columns: k:5(int!null) i:6(int!null)
+      │    │    │    ├── key: (5)
+      │    │    │    ├── fd: (5)-->(6)
+      │    │    │    ├── ordering: +5
+      │    │    │    ├── scan a
+      │    │    │    │    ├── columns: k:5(int!null) i:6(int)
       │    │    │    │    ├── key: (5)
       │    │    │    │    ├── fd: (5)-->(6)
-      │    │    │    │    ├── scan a
-      │    │    │    │    │    ├── columns: k:5(int!null) i:6(int)
-      │    │    │    │    │    ├── key: (5)
-      │    │    │    │    │    └── fd: (5)-->(6)
-      │    │    │    │    └── filters [type=bool, outer=(6), constraints=(/6: (/NULL - ]; tight)]
-      │    │    │    │         └── a.i IS NOT NULL [type=bool, outer=(6), constraints=(/6: (/NULL - ]; tight)]
-      │    │    │    └── true [type=bool]
-      │    │    ├── scan xy
-      │    │    │    ├── columns: x:1(int!null) y:2(int)
-      │    │    │    ├── key: (1)
-      │    │    │    └── fd: (1)-->(2)
-      │    │    └── filters [type=bool, outer=(1,4,5), constraints=(/1: (/NULL - ]; /4: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(4,5), (4)==(1,5), (5)==(1,4)]
-      │    │         ├── xy.x = uv.v [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ])]
-      │    │         └── a.k = xy.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+      │    │    │    │    └── ordering: +5
+      │    │    │    └── filters [type=bool, outer=(6), constraints=(/6: (/NULL - ]; tight)]
+      │    │    │         └── a.i IS NOT NULL [type=bool, outer=(6), constraints=(/6: (/NULL - ]; tight)]
+      │    │    └── merge-on
+      │    │         ├── left ordering: +1
+      │    │         ├── right ordering: +5
+      │    │         └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+      │    │              └── a.k = xy.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
       │    └── aggregations [outer=(1,2,4,6)]
       │         ├── max [type=int, outer=(6)]
       │         │    └── variable: a.i [type=int, outer=(6)]
@@ -1158,50 +1299,65 @@ FROM xy, uv
 WHERE x=v AND (SELECT max(i) FROM a WHERE k=x) IS DISTINCT FROM u
 ----
 project
- ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
- ├── key: (1,3)
- ├── fd: (1)-->(2), (1,3)-->(2,4), (1)==(4), (4)==(1)
+ ├── columns: x:1(int) y:2(int) u:3(int!null) v:4(int)
+ ├── key: (3)
+ ├── fd: (1)-->(2), (3)-->(1,2,4), (1)==(4), (4)==(1)
  └── select
-      ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) max:10(int)
-      ├── key: (1,3)
-      ├── fd: (1)-->(2), (1,3)-->(2,4,10), (1)==(4), (4)==(1)
+      ├── columns: x:1(int) y:2(int) u:3(int!null) v:4(int) max:10(int)
+      ├── key: (3)
+      ├── fd: (1)-->(2), (3)-->(1,2,4,10), (1)==(4), (4)==(1)
       ├── group-by
-      │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) max:10(int)
-      │    ├── grouping columns: x:1(int!null) u:3(int!null)
-      │    ├── key: (1,3)
-      │    ├── fd: (1)-->(2), (1,3)-->(2,4,10), (1)==(4), (4)==(1)
-      │    ├── inner-join-apply
-      │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) k:5(int) i:6(int)
-      │    │    ├── key: (1,3,5)
-      │    │    ├── fd: (1)-->(2), (1,3)-->(4), (1,5)-->(6), (1)==(4), (4)==(1)
-      │    │    ├── scan xy
-      │    │    │    ├── columns: x:1(int!null) y:2(int)
-      │    │    │    ├── key: (1)
-      │    │    │    └── fd: (1)-->(2)
-      │    │    ├── left-join
-      │    │    │    ├── columns: u:3(int!null) v:4(int) k:5(int) i:6(int)
-      │    │    │    ├── outer: (1)
-      │    │    │    ├── key: (3,5)
-      │    │    │    ├── fd: (3)-->(4), (5)-->(6)
-      │    │    │    ├── scan uv
+      │    ├── columns: x:1(int) y:2(int) u:3(int!null) v:4(int) max:10(int)
+      │    ├── grouping columns: u:3(int!null)
+      │    ├── key: (3)
+      │    ├── fd: (1)-->(2), (3)-->(1,2,4,10), (1)==(4), (4)==(1)
+      │    ├── left-join (merge)
+      │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null) k:5(int) i:6(int)
+      │    │    ├── key: (3,5)
+      │    │    ├── fd: (1)-->(2), (3)-->(4), (1)==(4), (4)==(1), (5)-->(6)
+      │    │    ├── inner-join (merge)
+      │    │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null)
+      │    │    │    ├── key: (3)
+      │    │    │    ├── fd: (1)-->(2), (3)-->(4), (1)==(4), (4)==(1)
+      │    │    │    ├── ordering: +(1|4)
+      │    │    │    ├── scan xy
+      │    │    │    │    ├── columns: x:1(int!null) y:2(int)
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    ├── fd: (1)-->(2)
+      │    │    │    │    └── ordering: +1
+      │    │    │    ├── sort
       │    │    │    │    ├── columns: u:3(int!null) v:4(int)
       │    │    │    │    ├── key: (3)
-      │    │    │    │    └── fd: (3)-->(4)
-      │    │    │    ├── scan a
-      │    │    │    │    ├── columns: k:5(int!null) i:6(int)
-      │    │    │    │    ├── key: (5)
-      │    │    │    │    └── fd: (5)-->(6)
-      │    │    │    └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
-      │    │    │         └── a.k = xy.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
-      │    │    └── filters [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
-      │    │         └── xy.x = uv.v [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ])]
-      │    └── aggregations [outer=(2,4,6)]
+      │    │    │    │    ├── fd: (3)-->(4)
+      │    │    │    │    ├── ordering: +4
+      │    │    │    │    └── scan uv
+      │    │    │    │         ├── columns: u:3(int!null) v:4(int)
+      │    │    │    │         ├── key: (3)
+      │    │    │    │         └── fd: (3)-->(4)
+      │    │    │    └── merge-on
+      │    │    │         ├── left ordering: +1
+      │    │    │         ├── right ordering: +4
+      │    │    │         └── filters [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+      │    │    │              └── xy.x = uv.v [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ])]
+      │    │    ├── scan a
+      │    │    │    ├── columns: k:5(int!null) i:6(int)
+      │    │    │    ├── key: (5)
+      │    │    │    ├── fd: (5)-->(6)
+      │    │    │    └── ordering: +5
+      │    │    └── merge-on
+      │    │         ├── left ordering: +1
+      │    │         ├── right ordering: +5
+      │    │         └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+      │    │              └── a.k = xy.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+      │    └── aggregations [outer=(1,2,4,6)]
       │         ├── max [type=int, outer=(6)]
       │         │    └── variable: a.i [type=int, outer=(6)]
       │         ├── const-agg [type=int, outer=(4)]
       │         │    └── variable: uv.v [type=int, outer=(4)]
-      │         └── const-agg [type=int, outer=(2)]
-      │              └── variable: xy.y [type=int, outer=(2)]
+      │         ├── const-agg [type=int, outer=(2)]
+      │         │    └── variable: xy.y [type=int, outer=(2)]
+      │         └── const-agg [type=int, outer=(1)]
+      │              └── variable: xy.x [type=int, outer=(1)]
       └── filters [type=bool, outer=(3,10)]
            └── uv.u IS DISTINCT FROM max [type=bool, outer=(3,10)]
 
@@ -1278,29 +1434,29 @@ group-by
  │    │    ├── grouping columns: k:1(int!null) x:6(int!null)
  │    │    ├── key: (1,6)
  │    │    ├── fd: (1)-->(2-5), (1,6)-->(2-5,11)
- │    │    ├── inner-join-apply
+ │    │    ├── left-join
  │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) notnull:12(bool)
- │    │    │    ├── fd: (1)-->(2-5)
- │    │    │    ├── scan a
- │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    │    │    │    ├── key: (1)
- │    │    │    │    └── fd: (1)-->(2-5)
- │    │    │    ├── left-join
- │    │    │    │    ├── columns: x:6(int!null) notnull:12(bool)
- │    │    │    │    ├── outer: (2)
- │    │    │    │    ├── fd: ()~~>(12)
+ │    │    │    ├── fd: (1)-->(2-5), ()~~>(12)
+ │    │    │    ├── inner-join
+ │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null)
+ │    │    │    │    ├── key: (1,6)
+ │    │    │    │    ├── fd: (1)-->(2-5)
+ │    │    │    │    ├── scan a
+ │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    └── fd: (1)-->(2-5)
  │    │    │    │    ├── scan xy
  │    │    │    │    │    ├── columns: x:6(int!null)
  │    │    │    │    │    └── key: (6)
- │    │    │    │    ├── project
- │    │    │    │    │    ├── columns: notnull:12(bool!null)
- │    │    │    │    │    ├── fd: ()-->(12)
- │    │    │    │    │    ├── scan uv
- │    │    │    │    │    └── projections
- │    │    │    │    │         └── true [type=bool]
- │    │    │    │    └── filters [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
- │    │    │    │         └── a.i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
- │    │    │    └── true [type=bool]
+ │    │    │    │    └── true [type=bool]
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: notnull:12(bool!null)
+ │    │    │    │    ├── fd: ()-->(12)
+ │    │    │    │    ├── scan uv
+ │    │    │    │    └── projections
+ │    │    │    │         └── true [type=bool]
+ │    │    │    └── filters [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+ │    │    │         └── a.i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
  │    │    └── aggregations [outer=(2-5,12)]
  │    │         ├── count [type=int, outer=(12)]
  │    │         │    └── variable: notnull [type=bool, outer=(12)]
@@ -2897,6 +3053,186 @@ project
  │    └── true [type=bool]
  └── projections [outer=(8)]
       └── variable: column1 [type=bool, outer=(8)]
+
+# --------------------------------------------------
+# HoistZipSubquery and TryDecorrelateZip
+# --------------------------------------------------
+opt
+SELECT generate_series(1, (SELECT v FROM uv WHERE u=x)) FROM xy
+----
+project
+ ├── columns: generate_series:5(int)
+ └── inner-join-apply
+      ├── columns: v:4(int) column5:5(int)
+      ├── project
+      │    ├── columns: v:4(int)
+      │    └── left-join (merge)
+      │         ├── columns: x:1(int!null) u:3(int) v:4(int)
+      │         ├── key: (1,3)
+      │         ├── fd: (3)-->(4)
+      │         ├── scan xy
+      │         │    ├── columns: x:1(int!null)
+      │         │    ├── key: (1)
+      │         │    └── ordering: +1
+      │         ├── scan uv
+      │         │    ├── columns: u:3(int!null) v:4(int)
+      │         │    ├── key: (3)
+      │         │    ├── fd: (3)-->(4)
+      │         │    └── ordering: +3
+      │         └── merge-on
+      │              ├── left ordering: +1
+      │              ├── right ordering: +3
+      │              └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+      │                   └── uv.u = xy.x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+      ├── zip
+      │    ├── columns: column5:5(int)
+      │    ├── outer: (4)
+      │    └── generate_series(1, uv.v) [type=int, outer=(4)]
+      └── true [type=bool]
+
+# Zip correlation within EXISTS.
+opt
+SELECT * FROM xy WHERE EXISTS(SELECT * FROM generate_series(1, (SELECT v FROM uv WHERE u=x)))
+----
+semi-join-apply
+ ├── columns: x:1(int!null) y:2(int)
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── scan xy
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ ├── inner-join-apply
+ │    ├── columns: v:4(int) generate_series:5(int)
+ │    ├── outer: (1)
+ │    ├── project
+ │    │    ├── columns: v:4(int)
+ │    │    ├── outer: (1)
+ │    │    └── right-join
+ │    │         ├── columns: u:3(int) v:4(int)
+ │    │         ├── outer: (1)
+ │    │         ├── key: (3)
+ │    │         ├── fd: (3)-->(4)
+ │    │         ├── scan uv
+ │    │         │    ├── columns: u:3(int!null) v:4(int)
+ │    │         │    ├── key: (3)
+ │    │         │    └── fd: (3)-->(4)
+ │    │         ├── values
+ │    │         │    ├── cardinality: [1 - 1]
+ │    │         │    ├── key: ()
+ │    │         │    └── tuple [type=tuple]
+ │    │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+ │    │              └── uv.u = xy.x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+ │    ├── zip
+ │    │    ├── columns: generate_series:5(int)
+ │    │    ├── outer: (4)
+ │    │    └── generate_series(1, uv.v) [type=int, outer=(4)]
+ │    └── true [type=bool]
+ └── true [type=bool]
+
+# Function contains multiple subqueries in arguments.
+opt
+SELECT generate_series((select y FROM xy WHERE x=k), (SELECT v FROM uv WHERE u=k)) FROM a
+----
+project
+ ├── columns: generate_series:10(int)
+ └── inner-join-apply
+      ├── columns: y:7(int) v:9(int) column10:10(int)
+      ├── project
+      │    ├── columns: y:7(int) v:9(int)
+      │    └── left-join (merge)
+      │         ├── columns: k:1(int!null) y:7(int) u:8(int) v:9(int)
+      │         ├── fd: (8)-->(9)
+      │         ├── project
+      │         │    ├── columns: k:1(int!null) y:7(int)
+      │         │    ├── ordering: +1
+      │         │    └── left-join (merge)
+      │         │         ├── columns: k:1(int!null) x:6(int) y:7(int)
+      │         │         ├── key: (1,6)
+      │         │         ├── fd: (6)-->(7)
+      │         │         ├── ordering: +1
+      │         │         ├── scan a
+      │         │         │    ├── columns: k:1(int!null)
+      │         │         │    ├── key: (1)
+      │         │         │    └── ordering: +1
+      │         │         ├── scan xy
+      │         │         │    ├── columns: x:6(int!null) y:7(int)
+      │         │         │    ├── key: (6)
+      │         │         │    ├── fd: (6)-->(7)
+      │         │         │    └── ordering: +6
+      │         │         └── merge-on
+      │         │              ├── left ordering: +1
+      │         │              ├── right ordering: +6
+      │         │              └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+      │         │                   └── xy.x = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+      │         ├── scan uv
+      │         │    ├── columns: u:8(int!null) v:9(int)
+      │         │    ├── key: (8)
+      │         │    ├── fd: (8)-->(9)
+      │         │    └── ordering: +8
+      │         └── merge-on
+      │              ├── left ordering: +1
+      │              ├── right ordering: +8
+      │              └── filters [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+      │                   └── uv.u = a.k [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
+      ├── zip
+      │    ├── columns: column10:10(int)
+      │    ├── outer: (7,9)
+      │    └── generate_series(xy.y, uv.v) [type=int, outer=(7,9)]
+      └── true [type=bool]
+
+# Multiple functions.
+opt
+SELECT
+    generate_series(1, (SELECT v FROM uv WHERE u=k)),
+    information_schema._pg_expandarray(ARRAY[(SELECT x FROM xy WHERE x=k)])
+FROM a
+----
+project
+ ├── columns: generate_series:8(int) _pg_expandarray:13(tuple{int AS x, int AS n})
+ ├── inner-join-apply
+ │    ├── columns: k:1(int!null) v:7(int) column8:8(int) xy.x:9(int) x:11(int) n:12(int)
+ │    ├── left-join (merge)
+ │    │    ├── columns: k:1(int!null) v:7(int) xy.x:9(int)
+ │    │    ├── project
+ │    │    │    ├── columns: k:1(int!null) v:7(int)
+ │    │    │    ├── ordering: +1
+ │    │    │    └── left-join (merge)
+ │    │    │         ├── columns: k:1(int!null) u:6(int) v:7(int)
+ │    │    │         ├── key: (1,6)
+ │    │    │         ├── fd: (6)-->(7)
+ │    │    │         ├── ordering: +1
+ │    │    │         ├── scan a
+ │    │    │         │    ├── columns: k:1(int!null)
+ │    │    │         │    ├── key: (1)
+ │    │    │         │    └── ordering: +1
+ │    │    │         ├── scan uv
+ │    │    │         │    ├── columns: u:6(int!null) v:7(int)
+ │    │    │         │    ├── key: (6)
+ │    │    │         │    ├── fd: (6)-->(7)
+ │    │    │         │    └── ordering: +6
+ │    │    │         └── merge-on
+ │    │    │              ├── left ordering: +1
+ │    │    │              ├── right ordering: +6
+ │    │    │              └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │    │                   └── uv.u = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+ │    │    ├── scan xy
+ │    │    │    ├── columns: xy.x:9(int!null)
+ │    │    │    ├── key: (9)
+ │    │    │    └── ordering: +9
+ │    │    └── merge-on
+ │    │         ├── left ordering: +1
+ │    │         ├── right ordering: +9
+ │    │         └── filters [type=bool, outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+ │    │              └── xy.x = a.k [type=bool, outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ])]
+ │    ├── zip
+ │    │    ├── columns: column8:8(int) x:11(int) n:12(int)
+ │    │    ├── outer: (7,9)
+ │    │    ├── generate_series(1, uv.v) [type=int, outer=(7)]
+ │    │    └── information_schema._pg_expandarray(ARRAY[xy.x]) [type=tuple{int AS x, int AS n}, outer=(9)]
+ │    └── true [type=bool]
+ └── projections [outer=(8,11,12)]
+      └── ((x, n) AS x, n) [type=tuple{int AS x, int AS n}, outer=(11,12)]
 
 # --------------------------------------------------
 # NormalizeAnyFilter

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -794,31 +794,36 @@ project
       │    ├── grouping columns: b.x:6(int!null)
       │    ├── key: (6)
       │    ├── fd: (1)-->(2-5), (6)-->(1-5,7,11), (1)==(6), (6)==(1)
-      │    ├── inner-join-apply
+      │    ├── left-join-apply
       │    │    ├── columns: a.k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) b.x:6(int!null) b.y:7(int) k:10(int)
-      │    │    ├── fd: (1)-->(2-5), (1,6)-->(7), (1)==(6), (6)==(1)
-      │    │    ├── scan a
-      │    │    │    ├── columns: a.k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
-      │    │    │    ├── key: (1)
-      │    │    │    └── fd: (1)-->(2-5)
-      │    │    ├── left-join
-      │    │    │    ├── columns: b.x:6(int!null) b.y:7(int) k:10(int)
-      │    │    │    ├── outer: (1)
-      │    │    │    ├── fd: (6)-->(7), ()~~>(10)
+      │    │    ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
+      │    │    ├── inner-join (merge)
+      │    │    │    ├── columns: a.k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) b.x:6(int!null) b.y:7(int)
+      │    │    │    ├── key: (6)
+      │    │    │    ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
+      │    │    │    ├── scan a
+      │    │    │    │    ├── columns: a.k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    ├── fd: (1)-->(2-5)
+      │    │    │    │    └── ordering: +1
       │    │    │    ├── scan b
       │    │    │    │    ├── columns: b.x:6(int!null) b.y:7(int)
       │    │    │    │    ├── key: (6)
-      │    │    │    │    └── fd: (6)-->(7)
-      │    │    │    ├── project
-      │    │    │    │    ├── columns: k:10(int)
-      │    │    │    │    ├── outer: (1)
-      │    │    │    │    ├── fd: ()-->(10)
-      │    │    │    │    ├── scan b
-      │    │    │    │    └── projections [outer=(1)]
-      │    │    │    │         └── variable: a.k [type=int, outer=(1)]
-      │    │    │    └── true [type=bool]
-      │    │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-      │    │         └── a.k = b.x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+      │    │    │    │    ├── fd: (6)-->(7)
+      │    │    │    │    └── ordering: +6
+      │    │    │    └── merge-on
+      │    │    │         ├── left ordering: +1
+      │    │    │         ├── right ordering: +6
+      │    │    │         └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+      │    │    │              └── a.k = b.x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+      │    │    ├── project
+      │    │    │    ├── columns: k:10(int)
+      │    │    │    ├── outer: (1)
+      │    │    │    ├── fd: ()-->(10)
+      │    │    │    ├── scan b
+      │    │    │    └── projections [outer=(1)]
+      │    │    │         └── variable: a.k [type=int, outer=(1)]
+      │    │    └── true [type=bool]
       │    └── aggregations [outer=(1-5,7,10)]
       │         ├── min [type=int, outer=(10)]
       │         │    └── variable: k [type=int, outer=(10)]

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -1297,19 +1297,17 @@ project
       │    ├── inner-join
       │    │    ├── columns: person.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null) phone.id:7(int!null) phone.phone_type:9(string!null) phone.person_id:10(int!null) phone.order_id:11(int) phone.person_id:15(int!null) phone.order_id:16(int!null)
       │    │    ├── fd: ()-->(9), (1)-->(2-6), (7)-->(10,11), (1)==(10,15), (10)==(1,15), (15)==(1,10)
-      │    │    ├── scan person
-      │    │    │    ├── columns: person.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null)
-      │    │    │    ├── key: (1)
-      │    │    │    └── fd: (1)-->(2-6)
-      │    │    ├── inner-join
-      │    │    │    ├── columns: phone.id:7(int!null) phone.phone_type:9(string!null) phone.person_id:10(int) phone.order_id:11(int) phone.person_id:15(int) phone.order_id:16(int!null)
-      │    │    │    ├── fd: ()-->(9), (7)-->(10,11)
-      │    │    │    ├── select
-      │    │    │    │    ├── columns: phone.person_id:15(int) phone.order_id:16(int!null)
-      │    │    │    │    ├── scan phone
-      │    │    │    │    │    └── columns: phone.person_id:15(int) phone.order_id:16(int)
-      │    │    │    │    └── filters [type=bool, outer=(16), constraints=(/16: (/NULL - ]; tight)]
-      │    │    │    │         └── phone.order_id IS NOT NULL [type=bool, outer=(16), constraints=(/16: (/NULL - ]; tight)]
+      │    │    ├── select
+      │    │    │    ├── columns: phone.person_id:15(int) phone.order_id:16(int!null)
+      │    │    │    ├── scan phone
+      │    │    │    │    └── columns: phone.person_id:15(int) phone.order_id:16(int)
+      │    │    │    └── filters [type=bool, outer=(16), constraints=(/16: (/NULL - ]; tight)]
+      │    │    │         └── phone.order_id IS NOT NULL [type=bool, outer=(16), constraints=(/16: (/NULL - ]; tight)]
+      │    │    ├── inner-join (lookup person)
+      │    │    │    ├── columns: person.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null) phone.id:7(int!null) phone.phone_type:9(string!null) phone.person_id:10(int!null) phone.order_id:11(int)
+      │    │    │    ├── key columns: [10] = [1]
+      │    │    │    ├── key: (7)
+      │    │    │    ├── fd: ()-->(9), (1)-->(2-6), (7)-->(10,11), (1)==(10), (10)==(1)
       │    │    │    ├── select
       │    │    │    │    ├── columns: phone.id:7(int!null) phone.phone_type:9(string!null) phone.person_id:10(int) phone.order_id:11(int)
       │    │    │    │    ├── key: (7)
@@ -1320,9 +1318,9 @@ project
       │    │    │    │    │    └── fd: (7)-->(9-11)
       │    │    │    │    └── filters [type=bool, outer=(9), constraints=(/9: [/'LAND_LINE' - /'LAND_LINE']; tight), fd=()-->(9)]
       │    │    │    │         └── phone.phone_type = 'LAND_LINE' [type=bool, outer=(9), constraints=(/9: [/'LAND_LINE' - /'LAND_LINE']; tight)]
-      │    │    │    └── true [type=bool]
-      │    │    └── filters [type=bool, outer=(1,10,15), constraints=(/1: (/NULL - ]; /10: (/NULL - ]; /15: (/NULL - ]), fd=(1)==(10,15), (10)==(1,15), (15)==(1,10)]
-      │    │         ├── person.id = phone.person_id [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ])]
+      │    │    │    └── filters [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+      │    │    │         └── person.id = phone.person_id [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ])]
+      │    │    └── filters [type=bool, outer=(1,15), constraints=(/1: (/NULL - ]; /15: (/NULL - ]), fd=(1)==(15), (15)==(1)]
       │    │         └── person.id = phone.person_id [type=bool, outer=(1,15), constraints=(/1: (/NULL - ]; /15: (/NULL - ])]
       │    └── aggregations [outer=(1-6,11,16)]
       │         ├── max [type=int, outer=(16)]

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -386,85 +386,85 @@ project
       │         │    │         │    ├── inner-join
       │         │    │         │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string) p_type:5(string) p_size:6(int!null) supplier.s_suppkey:10(int!null) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_nationkey:13(int!null) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string) partsupp.ps_partkey:17(int!null) partsupp.ps_suppkey:18(int!null) partsupp.ps_supplycost:20(float) partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float!null) supplier.s_suppkey:34(int!null) supplier.s_nationkey:37(int!null) nation.n_nationkey:41(int!null) nation.n_regionkey:43(int!null) region.r_regionkey:45(int!null) region.r_name:46(string!null)
       │         │    │         │    │    ├── key: (18,29,34)
-      │         │    │         │    │    ├── fd: ()-->(6,46), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (29,30)-->(32), (34)-->(37), (30)==(34), (34)==(30), (41)-->(43), (37)==(41), (41)==(37), (43)==(45), (45)==(43), (1)==(17,29), (17)==(1,29), (29)==(1,17), (10)==(18), (18)==(10)
+      │         │    │         │    │    ├── fd: ()-->(6,46), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (1)==(17,29), (17)==(1,29), (10)==(18), (18)==(10), (29,30)-->(32), (34)-->(37), (30)==(34), (34)==(30), (41)-->(43), (37)==(41), (41)==(37), (43)==(45), (45)==(43), (29)==(1,17)
       │         │    │         │    │    ├── inner-join
-      │         │    │         │    │    │    ├── columns: partsupp.ps_partkey:17(int!null) partsupp.ps_suppkey:18(int!null) partsupp.ps_supplycost:20(float) partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float!null) supplier.s_suppkey:34(int!null) supplier.s_nationkey:37(int!null) nation.n_nationkey:41(int!null) nation.n_regionkey:43(int!null) region.r_regionkey:45(int!null) region.r_name:46(string!null)
-      │         │    │         │    │    │    ├── key: (17,18,29,34)
-      │         │    │         │    │    │    ├── fd: ()-->(46), (17,18)-->(20), (29,30)-->(32), (34)-->(37), (30)==(34), (34)==(30), (41)-->(43), (37)==(41), (41)==(37), (43)==(45), (45)==(43)
+      │         │    │         │    │    │    ├── columns: partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float!null) supplier.s_suppkey:34(int!null) supplier.s_nationkey:37(int!null) nation.n_nationkey:41(int!null) nation.n_regionkey:43(int!null) region.r_regionkey:45(int!null) region.r_name:46(string!null)
+      │         │    │         │    │    │    ├── key: (29,34)
+      │         │    │         │    │    │    ├── fd: ()-->(46), (29,30)-->(32), (34)-->(37), (30)==(34), (34)==(30), (41)-->(43), (37)==(41), (41)==(37), (43)==(45), (45)==(43)
       │         │    │         │    │    │    ├── inner-join
-      │         │    │         │    │    │    │    ├── columns: partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float!null) supplier.s_suppkey:34(int!null) supplier.s_nationkey:37(int!null) nation.n_nationkey:41(int!null) nation.n_regionkey:43(int!null) region.r_regionkey:45(int!null) region.r_name:46(string!null)
+      │         │    │         │    │    │    │    ├── columns: partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float!null) supplier.s_suppkey:34(int!null) supplier.s_nationkey:37(int!null) nation.n_nationkey:41(int!null) nation.n_regionkey:43(int!null)
       │         │    │         │    │    │    │    ├── key: (29,34)
-      │         │    │         │    │    │    │    ├── fd: ()-->(46), (29,30)-->(32), (34)-->(37), (30)==(34), (34)==(30), (41)-->(43), (37)==(41), (41)==(37), (43)==(45), (45)==(43)
+      │         │    │         │    │    │    │    ├── fd: (29,30)-->(32), (34)-->(37), (30)==(34), (34)==(30), (41)-->(43), (37)==(41), (41)==(37)
       │         │    │         │    │    │    │    ├── inner-join
-      │         │    │         │    │    │    │    │    ├── columns: partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float!null) supplier.s_suppkey:34(int!null) supplier.s_nationkey:37(int!null) nation.n_nationkey:41(int!null) nation.n_regionkey:43(int!null)
+      │         │    │         │    │    │    │    │    ├── columns: partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float!null) supplier.s_suppkey:34(int!null) supplier.s_nationkey:37(int!null)
       │         │    │         │    │    │    │    │    ├── key: (29,34)
-      │         │    │         │    │    │    │    │    ├── fd: (29,30)-->(32), (34)-->(37), (30)==(34), (34)==(30), (41)-->(43), (37)==(41), (41)==(37)
-      │         │    │         │    │    │    │    │    ├── inner-join
-      │         │    │         │    │    │    │    │    │    ├── columns: partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float!null) supplier.s_suppkey:34(int!null) supplier.s_nationkey:37(int!null)
-      │         │    │         │    │    │    │    │    │    ├── key: (29,34)
-      │         │    │         │    │    │    │    │    │    ├── fd: (29,30)-->(32), (34)-->(37), (30)==(34), (34)==(30)
-      │         │    │         │    │    │    │    │    │    ├── scan supplier
-      │         │    │         │    │    │    │    │    │    │    ├── columns: supplier.s_suppkey:34(int!null) supplier.s_nationkey:37(int!null)
-      │         │    │         │    │    │    │    │    │    │    ├── key: (34)
-      │         │    │         │    │    │    │    │    │    │    └── fd: (34)-->(37)
-      │         │    │         │    │    │    │    │    │    ├── select
-      │         │    │         │    │    │    │    │    │    │    ├── columns: partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float!null)
+      │         │    │         │    │    │    │    │    ├── fd: (29,30)-->(32), (34)-->(37), (30)==(34), (34)==(30)
+      │         │    │         │    │    │    │    │    ├── scan supplier
+      │         │    │         │    │    │    │    │    │    ├── columns: supplier.s_suppkey:34(int!null) supplier.s_nationkey:37(int!null)
+      │         │    │         │    │    │    │    │    │    ├── key: (34)
+      │         │    │         │    │    │    │    │    │    └── fd: (34)-->(37)
+      │         │    │         │    │    │    │    │    ├── select
+      │         │    │         │    │    │    │    │    │    ├── columns: partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float!null)
+      │         │    │         │    │    │    │    │    │    ├── key: (29,30)
+      │         │    │         │    │    │    │    │    │    ├── fd: (29,30)-->(32)
+      │         │    │         │    │    │    │    │    │    ├── scan partsupp
+      │         │    │         │    │    │    │    │    │    │    ├── columns: partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float)
       │         │    │         │    │    │    │    │    │    │    ├── key: (29,30)
-      │         │    │         │    │    │    │    │    │    │    ├── fd: (29,30)-->(32)
-      │         │    │         │    │    │    │    │    │    │    ├── scan partsupp
-      │         │    │         │    │    │    │    │    │    │    │    ├── columns: partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float)
-      │         │    │         │    │    │    │    │    │    │    │    ├── key: (29,30)
-      │         │    │         │    │    │    │    │    │    │    │    └── fd: (29,30)-->(32)
-      │         │    │         │    │    │    │    │    │    │    └── filters [type=bool, outer=(32), constraints=(/32: (/NULL - ]; tight)]
-      │         │    │         │    │    │    │    │    │    │         └── partsupp.ps_supplycost IS NOT NULL [type=bool, outer=(32), constraints=(/32: (/NULL - ]; tight)]
-      │         │    │         │    │    │    │    │    │    └── filters [type=bool, outer=(30,34), constraints=(/30: (/NULL - ]; /34: (/NULL - ]), fd=(30)==(34), (34)==(30)]
-      │         │    │         │    │    │    │    │    │         └── supplier.s_suppkey = partsupp.ps_suppkey [type=bool, outer=(30,34), constraints=(/30: (/NULL - ]; /34: (/NULL - ])]
-      │         │    │         │    │    │    │    │    ├── scan nation
-      │         │    │         │    │    │    │    │    │    ├── columns: nation.n_nationkey:41(int!null) nation.n_regionkey:43(int!null)
-      │         │    │         │    │    │    │    │    │    ├── key: (41)
-      │         │    │         │    │    │    │    │    │    └── fd: (41)-->(43)
-      │         │    │         │    │    │    │    │    └── filters [type=bool, outer=(37,41), constraints=(/37: (/NULL - ]; /41: (/NULL - ]), fd=(37)==(41), (41)==(37)]
-      │         │    │         │    │    │    │    │         └── supplier.s_nationkey = nation.n_nationkey [type=bool, outer=(37,41), constraints=(/37: (/NULL - ]; /41: (/NULL - ])]
-      │         │    │         │    │    │    │    ├── select
-      │         │    │         │    │    │    │    │    ├── columns: region.r_regionkey:45(int!null) region.r_name:46(string!null)
+      │         │    │         │    │    │    │    │    │    │    └── fd: (29,30)-->(32)
+      │         │    │         │    │    │    │    │    │    └── filters [type=bool, outer=(32), constraints=(/32: (/NULL - ]; tight)]
+      │         │    │         │    │    │    │    │    │         └── partsupp.ps_supplycost IS NOT NULL [type=bool, outer=(32), constraints=(/32: (/NULL - ]; tight)]
+      │         │    │         │    │    │    │    │    └── filters [type=bool, outer=(30,34), constraints=(/30: (/NULL - ]; /34: (/NULL - ]), fd=(30)==(34), (34)==(30)]
+      │         │    │         │    │    │    │    │         └── supplier.s_suppkey = partsupp.ps_suppkey [type=bool, outer=(30,34), constraints=(/30: (/NULL - ]; /34: (/NULL - ])]
+      │         │    │         │    │    │    │    ├── scan nation
+      │         │    │         │    │    │    │    │    ├── columns: nation.n_nationkey:41(int!null) nation.n_regionkey:43(int!null)
+      │         │    │         │    │    │    │    │    ├── key: (41)
+      │         │    │         │    │    │    │    │    └── fd: (41)-->(43)
+      │         │    │         │    │    │    │    └── filters [type=bool, outer=(37,41), constraints=(/37: (/NULL - ]; /41: (/NULL - ]), fd=(37)==(41), (41)==(37)]
+      │         │    │         │    │    │    │         └── supplier.s_nationkey = nation.n_nationkey [type=bool, outer=(37,41), constraints=(/37: (/NULL - ]; /41: (/NULL - ])]
+      │         │    │         │    │    │    ├── select
+      │         │    │         │    │    │    │    ├── columns: region.r_regionkey:45(int!null) region.r_name:46(string!null)
+      │         │    │         │    │    │    │    ├── key: (45)
+      │         │    │         │    │    │    │    ├── fd: ()-->(46)
+      │         │    │         │    │    │    │    ├── scan region
+      │         │    │         │    │    │    │    │    ├── columns: region.r_regionkey:45(int!null) region.r_name:46(string)
       │         │    │         │    │    │    │    │    ├── key: (45)
-      │         │    │         │    │    │    │    │    ├── fd: ()-->(46)
-      │         │    │         │    │    │    │    │    ├── scan region
-      │         │    │         │    │    │    │    │    │    ├── columns: region.r_regionkey:45(int!null) region.r_name:46(string)
-      │         │    │         │    │    │    │    │    │    ├── key: (45)
-      │         │    │         │    │    │    │    │    │    └── fd: (45)-->(46)
-      │         │    │         │    │    │    │    │    └── filters [type=bool, outer=(46), constraints=(/46: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(46)]
-      │         │    │         │    │    │    │    │         └── region.r_name = 'EUROPE' [type=bool, outer=(46), constraints=(/46: [/'EUROPE' - /'EUROPE']; tight)]
-      │         │    │         │    │    │    │    └── filters [type=bool, outer=(43,45), constraints=(/43: (/NULL - ]; /45: (/NULL - ]), fd=(43)==(45), (45)==(43)]
-      │         │    │         │    │    │    │         └── nation.n_regionkey = region.r_regionkey [type=bool, outer=(43,45), constraints=(/43: (/NULL - ]; /45: (/NULL - ])]
+      │         │    │         │    │    │    │    │    └── fd: (45)-->(46)
+      │         │    │         │    │    │    │    └── filters [type=bool, outer=(46), constraints=(/46: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(46)]
+      │         │    │         │    │    │    │         └── region.r_name = 'EUROPE' [type=bool, outer=(46), constraints=(/46: [/'EUROPE' - /'EUROPE']; tight)]
+      │         │    │         │    │    │    └── filters [type=bool, outer=(43,45), constraints=(/43: (/NULL - ]; /45: (/NULL - ]), fd=(43)==(45), (45)==(43)]
+      │         │    │         │    │    │         └── nation.n_regionkey = region.r_regionkey [type=bool, outer=(43,45), constraints=(/43: (/NULL - ]; /45: (/NULL - ])]
+      │         │    │         │    │    ├── inner-join
+      │         │    │         │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string) p_type:5(string) p_size:6(int!null) supplier.s_suppkey:10(int!null) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_nationkey:13(int!null) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string) partsupp.ps_partkey:17(int!null) partsupp.ps_suppkey:18(int!null) partsupp.ps_supplycost:20(float)
+      │         │    │         │    │    │    ├── key: (17,18)
+      │         │    │         │    │    │    ├── fd: ()-->(6), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (1)==(17), (17)==(1), (10)==(18), (18)==(10)
       │         │    │         │    │    │    ├── scan partsupp
       │         │    │         │    │    │    │    ├── columns: partsupp.ps_partkey:17(int!null) partsupp.ps_suppkey:18(int!null) partsupp.ps_supplycost:20(float)
       │         │    │         │    │    │    │    ├── key: (17,18)
       │         │    │         │    │    │    │    └── fd: (17,18)-->(20)
-      │         │    │         │    │    │    └── true [type=bool]
-      │         │    │         │    │    ├── inner-join
-      │         │    │         │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string) p_type:5(string) p_size:6(int!null) supplier.s_suppkey:10(int!null) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_nationkey:13(int!null) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string)
-      │         │    │         │    │    │    ├── key: (1,10)
-      │         │    │         │    │    │    ├── fd: ()-->(6), (1)-->(3,5), (10)-->(11-16)
-      │         │    │         │    │    │    ├── scan supplier
-      │         │    │         │    │    │    │    ├── columns: supplier.s_suppkey:10(int!null) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_nationkey:13(int!null) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string)
-      │         │    │         │    │    │    │    ├── key: (10)
-      │         │    │         │    │    │    │    └── fd: (10)-->(11-16)
-      │         │    │         │    │    │    ├── select
-      │         │    │         │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string) p_type:5(string) p_size:6(int!null)
-      │         │    │         │    │    │    │    ├── key: (1)
-      │         │    │         │    │    │    │    ├── fd: ()-->(6), (1)-->(3,5)
-      │         │    │         │    │    │    │    ├── scan part
-      │         │    │         │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string) p_type:5(string) p_size:6(int)
+      │         │    │         │    │    │    ├── inner-join
+      │         │    │         │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string) p_type:5(string) p_size:6(int!null) supplier.s_suppkey:10(int!null) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_nationkey:13(int!null) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string)
+      │         │    │         │    │    │    │    ├── key: (1,10)
+      │         │    │         │    │    │    │    ├── fd: ()-->(6), (1)-->(3,5), (10)-->(11-16)
+      │         │    │         │    │    │    │    ├── scan supplier
+      │         │    │         │    │    │    │    │    ├── columns: supplier.s_suppkey:10(int!null) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_nationkey:13(int!null) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string)
+      │         │    │         │    │    │    │    │    ├── key: (10)
+      │         │    │         │    │    │    │    │    └── fd: (10)-->(11-16)
+      │         │    │         │    │    │    │    ├── select
+      │         │    │         │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string) p_type:5(string) p_size:6(int!null)
       │         │    │         │    │    │    │    │    ├── key: (1)
-      │         │    │         │    │    │    │    │    └── fd: (1)-->(3,5,6)
-      │         │    │         │    │    │    │    └── filters [type=bool, outer=(5,6), constraints=(/6: [/15 - /15]), fd=()-->(6)]
-      │         │    │         │    │    │    │         ├── part.p_size = 15 [type=bool, outer=(6), constraints=(/6: [/15 - /15]; tight)]
-      │         │    │         │    │    │    │         └── part.p_type LIKE '%BRASS' [type=bool, outer=(5)]
-      │         │    │         │    │    │    └── true [type=bool]
-      │         │    │         │    │    └── filters [type=bool, outer=(1,10,17,18,29), constraints=(/1: (/NULL - ]; /10: (/NULL - ]; /17: (/NULL - ]; /18: (/NULL - ]; /29: (/NULL - ]), fd=(1)==(17,29), (17)==(1,29), (10)==(18), (18)==(10), (29)==(1,17)]
-      │         │    │         │    │         ├── part.p_partkey = partsupp.ps_partkey [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ])]
-      │         │    │         │    │         ├── supplier.s_suppkey = partsupp.ps_suppkey [type=bool, outer=(10,18), constraints=(/10: (/NULL - ]; /18: (/NULL - ])]
+      │         │    │         │    │    │    │    │    ├── fd: ()-->(6), (1)-->(3,5)
+      │         │    │         │    │    │    │    │    ├── scan part
+      │         │    │         │    │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string) p_type:5(string) p_size:6(int)
+      │         │    │         │    │    │    │    │    │    ├── key: (1)
+      │         │    │         │    │    │    │    │    │    └── fd: (1)-->(3,5,6)
+      │         │    │         │    │    │    │    │    └── filters [type=bool, outer=(5,6), constraints=(/6: [/15 - /15]), fd=()-->(6)]
+      │         │    │         │    │    │    │    │         ├── part.p_size = 15 [type=bool, outer=(6), constraints=(/6: [/15 - /15]; tight)]
+      │         │    │         │    │    │    │    │         └── part.p_type LIKE '%BRASS' [type=bool, outer=(5)]
+      │         │    │         │    │    │    │    └── true [type=bool]
+      │         │    │         │    │    │    └── filters [type=bool, outer=(1,10,17,18), constraints=(/1: (/NULL - ]; /10: (/NULL - ]; /17: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(17), (17)==(1), (10)==(18), (18)==(10)]
+      │         │    │         │    │    │         ├── part.p_partkey = partsupp.ps_partkey [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ])]
+      │         │    │         │    │    │         └── supplier.s_suppkey = partsupp.ps_suppkey [type=bool, outer=(10,18), constraints=(/10: (/NULL - ]; /18: (/NULL - ])]
+      │         │    │         │    │    └── filters [type=bool, outer=(1,29), constraints=(/1: (/NULL - ]; /29: (/NULL - ]), fd=(1)==(29), (29)==(1)]
       │         │    │         │    │         └── part.p_partkey = partsupp.ps_partkey [type=bool, outer=(1,29), constraints=(/1: (/NULL - ]; /29: (/NULL - ])]
       │         │    │         │    └── aggregations [outer=(1,3,11-16,20,32)]
       │         │    │         │         ├── min [type=float, outer=(32)]


### PR DESCRIPTION
Decorrelate subqueries appearing in Zip operator functions, like this:

  SELECT generate_series(1, (SELECT v FROM uv WHERE u=x)) FROM xy

This requires hoisting the subquery out of the Zip operator, and "pushing down"
InnerJoinApply operators into InnerJoinApply/LeftJoin expressions that contain
correlated Zip operators.

Release note: None