### PR TITLE
sql: correct null handling by generator builtins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -2,6 +2,10 @@
 
 subtest generate_series
 
+query I
+SELECT * FROM generate_series(1, NULL)
+----
+
 query I colnames
 SELECT * FROM generate_series(1, 3)
 ----
@@ -178,6 +182,11 @@ x  generate_series
 1  3
 
 subtest unnest
+
+query I
+SELECT * FROM unnest(NULL)
+----
+
 
 query I colnames
 SELECT * from unnest(ARRAY[1,2])

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -103,6 +103,9 @@ var generators = map[string]builtinDefinition{
 				if len(args) == 0 {
 					return tree.UnknownReturnType
 				}
+				if args[0].ResolvedType() == types.Unknown {
+					return types.Unknown
+				}
 				return types.UnwrapType(args[0].ResolvedType()).(types.TArray).Typ
 			},
 			makeArrayGenerator,

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -758,8 +758,9 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, e
 	}
 
 	// Return NULL if at least one overload is possible, no overload accepts
-	// NULL arguments, and NULL is given as an argument.
-	if !def.NullableArgs {
+	// NULL arguments, the function isn't a generator builtin, and NULL is given
+	// as an argument.
+	if !def.NullableArgs && def.FunctionProperties.Class != GeneratorClass {
 		for _, expr := range typedSubExprs {
 			if expr.ResolvedType() == types.Unknown {
 				return DNull, nil


### PR DESCRIPTION
Previously, generator builtins returned NULL when given a NULL argument.
This was incorrect behavior - generator builtins are supposed to return
no rows when given a NULL argument.

Fixes #28237.

Release note (bug fix): generator builtins now correctly return no rows
instead of NULL when given NULL arguments.