### PR TITLE
testutils: make no inbound stream connection a retryable error

### DIFF
--- a/pkg/sql/create_test.go
+++ b/pkg/sql/create_test.go
@@ -194,7 +194,10 @@ func createTestTable(
 
 	for {
 		if _, err := db.Exec(tableSQL); err != nil {
-			if testutils.IsSQLRetryableError(err) {
+			// Scenario where an ambiguous commit error happens is described in more
+			// detail in
+			// https://reviewable.io/reviews/cockroachdb/cockroach/10251#-KVGGLbjhbPdlR6EFlfL
+			if testutils.IsError(err, "result is ambiguous") {
 				continue
 			}
 			t.Errorf("table %d: could not be created: %s", id, err)

--- a/pkg/testutils/error.go
+++ b/pkg/testutils/error.go
@@ -71,7 +71,7 @@ func IsPError(pErr *roachpb.Error, re string) bool {
 func IsSQLRetryableError(err error) bool {
 	// Don't forget to update the corresponding test when making adjustments
 	// here.
-	return IsError(err, "(connection reset by peer|connection refused|failed to send RPC|rpc error: code = Unavailable|EOF|result is ambiguous)")
+	return IsError(err, "(no inbound stream connection|connection reset by peer|connection refused|failed to send RPC|rpc error: code = Unavailable|EOF|result is ambiguous)")
 }
 
 // Caller returns filename and line number info for the specified stack


### PR DESCRIPTION
This error indicates that a connection could not be established between
nodes during the execution of a SQL query, so any query failure due to
this indicates that this query could succeed if retried.

Fixes #27845

Release note: None

cc @tschottdorf 