### PR TITLE
opt: remove tuple lables from subquery output

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -139,16 +139,16 @@ select
  │    └── interesting orderings: (+1)
  └── filters [type=bool, outer=(1,2)]
       └── eq [type=bool, outer=(1,2)]
-           ├── subquery [type=tuple{int AS x, int AS u}, outer=(1,2)]
+           ├── subquery [type=tuple{int, int}, outer=(1,2)]
            │    └── max1-row
-           │         ├── columns: column13:13(tuple{int AS x, int AS u})
+           │         ├── columns: column13:13(tuple{int, int})
            │         ├── outer: (1,2)
            │         ├── cardinality: [0 - 1]
            │         ├── stats: [rows=1]
            │         ├── key: ()
            │         ├── fd: ()-->(13)
            │         └── project
-           │              ├── columns: column13:13(tuple{int AS x, int AS u})
+           │              ├── columns: column13:13(tuple{int, int})
            │              ├── outer: (1,2)
            │              ├── stats: [rows=1400]
            │              ├── prune: (13)
@@ -190,7 +190,7 @@ select
            │              │         └── projections [outer=(2,8)]
            │              │              └── variable: xy.y [type=int, outer=(2)]
            │              └── projections [outer=(11,12)]
-           │                   └── tuple [type=tuple{int AS x, int AS u}, outer=(11,12)]
+           │                   └── tuple [type=tuple{int, int}, outer=(11,12)]
            │                        ├── variable: x [type=int, outer=(11)]
            │                        └── variable: u [type=int, outer=(12)]
            └── tuple [type=tuple{int, int}]

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -189,12 +189,10 @@ func (b *Builder) buildSubqueryProjection(
 		cols := make(tree.Exprs, len(s.cols))
 		colGroups := make([]memo.GroupID, len(s.cols))
 		typ := types.TTuple{
-			Types:  make([]types.T, len(s.cols)),
-			Labels: make([]string, len(s.cols)),
+			Types: make([]types.T, len(s.cols)),
 		}
 		for i := range s.cols {
 			cols[i] = &s.cols[i]
-			typ.Labels[i] = string(s.cols[i].name)
 			typ.Types[i] = s.cols[i].ResolvedType()
 			colGroups[i] = b.factory.ConstructVariable(b.factory.InternColumnID(s.cols[i].id))
 		}

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -664,14 +664,14 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column3:3(tuple{int AS a, int AS b})
+           │    ├── columns: column3:3(tuple{int, int})
            │    ├── values
            │    │    ├── columns: column1:1(int) column2:2(int)
            │    │    └── tuple [type=tuple{int, int}]
            │    │         ├── const: 1 [type=int]
            │    │         └── const: 1 [type=int]
            │    └── projections
-           │         └── tuple [type=tuple{int AS a, int AS b}]
+           │         └── tuple [type=tuple{int, int}]
            │              ├── variable: column1 [type=int]
            │              └── variable: column2 [type=int]
            └── tuple [type=tuple{int, int}]
@@ -707,14 +707,14 @@ project
       └── not [type=bool]
            └── any: eq [type=bool]
                 ├── project
-                │    ├── columns: column3:3(tuple{int AS a, int AS b})
+                │    ├── columns: column3:3(tuple{int, int})
                 │    ├── values
                 │    │    ├── columns: column1:1(int) column2:2(int)
                 │    │    └── tuple [type=tuple{int, int}]
                 │    │         ├── const: 1 [type=int]
                 │    │         └── const: 1 [type=int]
                 │    └── projections
-                │         └── tuple [type=tuple{int AS a, int AS b}]
+                │         └── tuple [type=tuple{int, int}]
                 │              ├── variable: column1 [type=int]
                 │              └── variable: column2 [type=int]
                 └── tuple [type=tuple{int, int}]
@@ -755,7 +755,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column3:3(tuple{int AS a, int AS b})
+           │    ├── columns: column3:3(tuple{int, int})
            │    ├── select
            │    │    ├── columns: column1:1(int!null) column2:2(int)
            │    │    ├── values
@@ -768,7 +768,7 @@ project
            │    │              ├── variable: column1 [type=int]
            │    │              └── const: 1 [type=int]
            │    └── projections
-           │         └── tuple [type=tuple{int AS a, int AS b}]
+           │         └── tuple [type=tuple{int, int}]
            │              ├── variable: column1 [type=int]
            │              └── variable: column2 [type=int]
            └── tuple [type=tuple{int, int}]
@@ -810,7 +810,7 @@ project
       └── not [type=bool]
            └── any: eq [type=bool]
                 ├── project
-                │    ├── columns: column3:3(tuple{int AS a, int AS b})
+                │    ├── columns: column3:3(tuple{int, int})
                 │    ├── select
                 │    │    ├── columns: column1:1(int!null) column2:2(int)
                 │    │    ├── values
@@ -823,7 +823,7 @@ project
                 │    │              ├── variable: column1 [type=int]
                 │    │              └── const: 1 [type=int]
                 │    └── projections
-                │         └── tuple [type=tuple{int AS a, int AS b}]
+                │         └── tuple [type=tuple{int, int}]
                 │              ├── variable: column1 [type=int]
                 │              └── variable: column2 [type=int]
                 └── tuple [type=tuple{int, int}]
@@ -865,7 +865,7 @@ project
       └── not [type=bool]
            └── any: eq [type=bool]
                 ├── project
-                │    ├── columns: column3:3(tuple{int AS a, int AS b})
+                │    ├── columns: column3:3(tuple{int, int})
                 │    ├── select
                 │    │    ├── columns: column1:1(int!null) column2:2(int)
                 │    │    ├── values
@@ -878,7 +878,7 @@ project
                 │    │              ├── variable: column1 [type=int]
                 │    │              └── const: 1 [type=int]
                 │    └── projections
-                │         └── tuple [type=tuple{int AS a, int AS b}]
+                │         └── tuple [type=tuple{int, int}]
                 │              ├── variable: column1 [type=int]
                 │              └── variable: column2 [type=int]
                 └── tuple [type=tuple{int, int}]
@@ -920,7 +920,7 @@ project
       └── not [type=bool]
            └── any: eq [type=bool]
                 ├── project
-                │    ├── columns: column3:3(tuple{int AS a, int AS b})
+                │    ├── columns: column3:3(tuple{int, int})
                 │    ├── select
                 │    │    ├── columns: column1:1(int!null) column2:2(int)
                 │    │    ├── values
@@ -933,7 +933,7 @@ project
                 │    │              ├── variable: column1 [type=int]
                 │    │              └── const: 1 [type=int]
                 │    └── projections
-                │         └── tuple [type=tuple{int AS a, int AS b}]
+                │         └── tuple [type=tuple{int, int}]
                 │              ├── variable: column1 [type=int]
                 │              └── variable: column2 [type=int]
                 └── tuple [type=tuple{int, int}]

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -94,7 +94,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column4:4(tuple{int AS a, int AS b, int AS c})
+           │    ├── columns: column4:4(tuple{int, int, int})
            │    ├── project
            │    │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
            │    │    ├── values
@@ -104,7 +104,7 @@ project
            │    │         ├── const: 2 [type=int]
            │    │         └── const: 3 [type=int]
            │    └── projections
-           │         └── tuple [type=tuple{int AS a, int AS b, int AS c}]
+           │         └── tuple [type=tuple{int, int, int}]
            │              ├── variable: a [type=int]
            │              ├── variable: b [type=int]
            │              └── variable: c [type=int]
@@ -126,11 +126,11 @@ project
            │    ├── const: 1 [type=int]
            │    ├── const: 2 [type=int]
            │    └── const: 3 [type=int]
-           └── subquery [type=tuple{int AS a, int AS b, int AS c}]
+           └── subquery [type=tuple{int, int, int}]
                 └── max1-row
-                     ├── columns: column4:4(tuple{int AS a, int AS b, int AS c})
+                     ├── columns: column4:4(tuple{int, int, int})
                      └── project
-                          ├── columns: column4:4(tuple{int AS a, int AS b, int AS c})
+                          ├── columns: column4:4(tuple{int, int, int})
                           ├── project
                           │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
                           │    ├── values
@@ -140,7 +140,7 @@ project
                           │         ├── const: 2 [type=int]
                           │         └── const: 3 [type=int]
                           └── projections
-                               └── tuple [type=tuple{int AS a, int AS b, int AS c}]
+                               └── tuple [type=tuple{int, int, int}]
                                     ├── variable: a [type=int]
                                     ├── variable: b [type=int]
                                     └── variable: c [type=int]
@@ -158,11 +158,11 @@ project
            │    ├── const: 1 [type=int]
            │    ├── const: 2 [type=int]
            │    └── const: 3 [type=int]
-           └── subquery [type=tuple{int AS a, int AS b, int AS c}]
+           └── subquery [type=tuple{int, int, int}]
                 └── max1-row
-                     ├── columns: column4:4(tuple{int AS a, int AS b, int AS c})
+                     ├── columns: column4:4(tuple{int, int, int})
                      └── project
-                          ├── columns: column4:4(tuple{int AS a, int AS b, int AS c})
+                          ├── columns: column4:4(tuple{int, int, int})
                           ├── project
                           │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
                           │    ├── values
@@ -172,7 +172,7 @@ project
                           │         ├── const: 2 [type=int]
                           │         └── const: 3 [type=int]
                           └── projections
-                               └── tuple [type=tuple{int AS a, int AS b, int AS c}]
+                               └── tuple [type=tuple{int, int, int}]
                                     ├── variable: a [type=int]
                                     ├── variable: b [type=int]
                                     └── variable: c [type=int]
@@ -186,11 +186,11 @@ project
  │    └── tuple [type=tuple]
  └── projections
       └── eq [type=bool]
-           ├── subquery [type=tuple{int AS x, int AS y, int AS z}]
+           ├── subquery [type=tuple{int, int, int}]
            │    └── max1-row
-           │         ├── columns: column7:7(tuple{int AS x, int AS y, int AS z})
+           │         ├── columns: column7:7(tuple{int, int, int})
            │         └── project
-           │              ├── columns: column7:7(tuple{int AS x, int AS y, int AS z})
+           │              ├── columns: column7:7(tuple{int, int, int})
            │              ├── project
            │              │    ├── columns: x:1(int!null) y:2(int!null) z:3(int!null)
            │              │    ├── values
@@ -200,15 +200,15 @@ project
            │              │         ├── const: 2 [type=int]
            │              │         └── const: 3 [type=int]
            │              └── projections
-           │                   └── tuple [type=tuple{int AS x, int AS y, int AS z}]
+           │                   └── tuple [type=tuple{int, int, int}]
            │                        ├── variable: x [type=int]
            │                        ├── variable: y [type=int]
            │                        └── variable: z [type=int]
-           └── subquery [type=tuple{int AS a, int AS b, int AS c}]
+           └── subquery [type=tuple{int, int, int}]
                 └── max1-row
-                     ├── columns: column8:8(tuple{int AS a, int AS b, int AS c})
+                     ├── columns: column8:8(tuple{int, int, int})
                      └── project
-                          ├── columns: column8:8(tuple{int AS a, int AS b, int AS c})
+                          ├── columns: column8:8(tuple{int, int, int})
                           ├── project
                           │    ├── columns: a:4(int!null) b:5(int!null) c:6(int!null)
                           │    ├── values
@@ -218,7 +218,7 @@ project
                           │         ├── const: 2 [type=int]
                           │         └── const: 3 [type=int]
                           └── projections
-                               └── tuple [type=tuple{int AS a, int AS b, int AS c}]
+                               └── tuple [type=tuple{int, int, int}]
                                     ├── variable: a [type=int]
                                     ├── variable: b [type=int]
                                     └── variable: c [type=int]
@@ -289,7 +289,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column5:5(tuple{int AS c, int AS d})
+           │    ├── columns: column5:5(tuple{int, int})
            │    ├── project
            │    │    ├── columns: c:1(int!null) d:2(int!null)
            │    │    ├── values
@@ -298,14 +298,14 @@ project
            │    │         ├── const: 1 [type=int]
            │    │         └── const: 2 [type=int]
            │    └── projections
-           │         └── tuple [type=tuple{int AS c, int AS d}]
+           │         └── tuple [type=tuple{int, int}]
            │              ├── variable: c [type=int]
            │              └── variable: d [type=int]
-           └── subquery [type=tuple{int AS a, int AS b}]
+           └── subquery [type=tuple{int, int}]
                 └── max1-row
-                     ├── columns: column6:6(tuple{int AS a, int AS b})
+                     ├── columns: column6:6(tuple{int, int})
                      └── project
-                          ├── columns: column6:6(tuple{int AS a, int AS b})
+                          ├── columns: column6:6(tuple{int, int})
                           ├── project
                           │    ├── columns: a:3(int!null) b:4(int!null)
                           │    ├── values
@@ -314,7 +314,7 @@ project
                           │         ├── const: 1 [type=int]
                           │         └── const: 2 [type=int]
                           └── projections
-                               └── tuple [type=tuple{int AS a, int AS b}]
+                               └── tuple [type=tuple{int, int}]
                                     ├── variable: a [type=int]
                                     └── variable: b [type=int]
 
@@ -331,11 +331,11 @@ project
  │    └── tuple [type=tuple]
  └── projections
       └── in [type=bool]
-           ├── subquery [type=tuple{int AS a, int AS b}]
+           ├── subquery [type=tuple{int, int}]
            │    └── max1-row
-           │         ├── columns: column3:3(tuple{int AS a, int AS b})
+           │         ├── columns: column3:3(tuple{int, int})
            │         └── project
-           │              ├── columns: column3:3(tuple{int AS a, int AS b})
+           │              ├── columns: column3:3(tuple{int, int})
            │              ├── project
            │              │    ├── columns: a:1(int!null) b:2(int!null)
            │              │    ├── values
@@ -344,7 +344,7 @@ project
            │              │         ├── const: 1 [type=int]
            │              │         └── const: 2 [type=int]
            │              └── projections
-           │                   └── tuple [type=tuple{int AS a, int AS b}]
+           │                   └── tuple [type=tuple{int, int}]
            │                        ├── variable: a [type=int]
            │                        └── variable: b [type=int]
            └── tuple [type=tuple{tuple{int AS a, int AS b}}]
@@ -366,7 +366,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column4:4(tuple{int AS b, int AS c})
+           │    ├── columns: column4:4(tuple{int, int})
            │    ├── project
            │    │    ├── columns: b:1(int!null) c:2(int!null)
            │    │    ├── values
@@ -375,7 +375,7 @@ project
            │    │         ├── const: 1 [type=int]
            │    │         └── const: 2 [type=int]
            │    └── projections
-           │         └── tuple [type=tuple{int AS b, int AS c}]
+           │         └── tuple [type=tuple{int, int}]
            │              ├── variable: b [type=int]
            │              └── variable: c [type=int]
            └── subquery [type=tuple{int, int}]
@@ -436,11 +436,11 @@ project
            │         └── tuple [type=tuple{int, int}]
            │              ├── const: 1 [type=int]
            │              └── const: 2 [type=int]
-           └── subquery [type=tuple{int AS a, int AS b}]
+           └── subquery [type=tuple{int, int}]
                 └── max1-row
-                     ├── columns: column4:4(tuple{int AS a, int AS b})
+                     ├── columns: column4:4(tuple{int, int})
                      └── project
-                          ├── columns: column4:4(tuple{int AS a, int AS b})
+                          ├── columns: column4:4(tuple{int, int})
                           ├── project
                           │    ├── columns: a:2(int!null) b:3(int!null)
                           │    ├── values
@@ -449,7 +449,7 @@ project
                           │         ├── const: 1 [type=int]
                           │         └── const: 2 [type=int]
                           └── projections
-                               └── tuple [type=tuple{int AS a, int AS b}]
+                               └── tuple [type=tuple{int, int}]
                                     ├── variable: a [type=int]
                                     └── variable: b [type=int]
 
@@ -509,7 +509,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column3:3(tuple{int AS a, int AS b})
+           │    ├── columns: column3:3(tuple{int, int})
            │    ├── project
            │    │    ├── columns: a:1(int!null) b:2(int!null)
            │    │    ├── values
@@ -518,7 +518,7 @@ project
            │    │         ├── const: 1 [type=int]
            │    │         └── const: 2 [type=int]
            │    └── projections
-           │         └── tuple [type=tuple{int AS a, int AS b}]
+           │         └── tuple [type=tuple{int, int}]
            │              ├── variable: a [type=int]
            │              └── variable: b [type=int]
            └── tuple [type=tuple{int, int}]
@@ -552,7 +552,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column3:3(tuple{int AS a, int AS b})
+           │    ├── columns: column3:3(tuple{int, int})
            │    ├── project
            │    │    ├── columns: a:1(int!null) b:2(int!null)
            │    │    ├── values
@@ -561,7 +561,7 @@ project
            │    │         ├── const: 1 [type=int]
            │    │         └── const: 2 [type=int]
            │    └── projections
-           │         └── tuple [type=tuple{int AS a, int AS b}]
+           │         └── tuple [type=tuple{int, int}]
            │              ├── variable: a [type=int]
            │              └── variable: b [type=int]
            └── tuple [type=tuple{int, int}]
@@ -597,7 +597,7 @@ project
       └── not [type=bool]
            └── any: ne [type=bool]
                 ├── project
-                │    ├── columns: column3:3(tuple{int AS a, int AS b})
+                │    ├── columns: column3:3(tuple{int, int})
                 │    ├── project
                 │    │    ├── columns: a:1(int!null) b:2(int!null)
                 │    │    ├── values
@@ -606,7 +606,7 @@ project
                 │    │         ├── const: 1 [type=int]
                 │    │         └── const: 2 [type=int]
                 │    └── projections
-                │         └── tuple [type=tuple{int AS a, int AS b}]
+                │         └── tuple [type=tuple{int, int}]
                 │              ├── variable: a [type=int]
                 │              └── variable: b [type=int]
                 └── tuple [type=tuple{int, int}]
@@ -653,13 +653,13 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column4:4(tuple{int AS a, int AS b})
+           │    ├── columns: column4:4(tuple{int, int})
            │    ├── project
            │    │    ├── columns: a:1(int!null) b:2(int)
            │    │    └── scan abc
            │    │         └── columns: a:1(int!null) b:2(int) c:3(int)
            │    └── projections
-           │         └── tuple [type=tuple{int AS a, int AS b}]
+           │         └── tuple [type=tuple{int, int}]
            │              ├── variable: abc.a [type=int]
            │              └── variable: abc.b [type=int]
            └── tuple [type=tuple{int, int}]
@@ -676,7 +676,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column4:4(tuple{int AS a, int AS b})
+           │    ├── columns: column4:4(tuple{int, int})
            │    ├── project
            │    │    ├── columns: a:1(int!null) b:2(int)
            │    │    └── select
@@ -686,7 +686,7 @@ project
            │    │         └── filters [type=bool]
            │    │              └── false [type=bool]
            │    └── projections
-           │         └── tuple [type=tuple{int AS a, int AS b}]
+           │         └── tuple [type=tuple{int, int}]
            │              ├── variable: abc.a [type=int]
            │              └── variable: abc.b [type=int]
            └── tuple [type=tuple{int, int}]
@@ -1969,3 +1969,34 @@ project
            │    └── scan u
            │         └── columns: b:3(string) u.rowid:4(int!null)
            └── variable: column5 [type=string]
+
+# Regression test for #28240. Make sure that the tuple labels are stripped from
+# the subquery.
+build
+SELECT (1, 2, 3) IN (SELECT 1, 2, 3)
+----
+project
+ ├── columns: "?column?":5(bool)
+ ├── values
+ │    └── tuple [type=tuple]
+ └── projections
+      └── any: eq [type=bool]
+           ├── project
+           │    ├── columns: column4:4(tuple{int, int, int})
+           │    ├── project
+           │    │    ├── columns: "?column?":1(int!null) "?column?":2(int!null) "?column?":3(int!null)
+           │    │    ├── values
+           │    │    │    └── tuple [type=tuple]
+           │    │    └── projections
+           │    │         ├── const: 1 [type=int]
+           │    │         ├── const: 2 [type=int]
+           │    │         └── const: 3 [type=int]
+           │    └── projections
+           │         └── tuple [type=tuple{int, int, int}]
+           │              ├── variable: ?column? [type=int]
+           │              ├── variable: ?column? [type=int]
+           │              └── variable: ?column? [type=int]
+           └── tuple [type=tuple{int, int, int}]
+                ├── const: 1 [type=int]
+                ├── const: 2 [type=int]
+                └── const: 3 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/where
+++ b/pkg/sql/opt/optbuilder/testdata/where
@@ -76,11 +76,11 @@ select
  └── filters [type=bool]
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column5:5(tuple{int AS k, int AS v})
+           │    ├── columns: column5:5(tuple{int, int})
            │    ├── scan kv
            │    │    └── columns: kv.k:3(int!null) kv.v:4(int)
            │    └── projections
-           │         └── tuple [type=tuple{int AS k, int AS v}]
+           │         └── tuple [type=tuple{int, int}]
            │              ├── variable: kv.k [type=int]
            │              └── variable: kv.v [type=int]
            └── tuple [type=tuple{int, int}]


### PR DESCRIPTION
Tuple types include an optional label for each column in the
tuple. Previously, the optimizer was populating these labels for
the output of subqueries. However, this was causing a problem in
the execution engine for queries such as:
```
SELECT (1, 2, 3) IN (SELECT 1, 2, 3)
```
This query causes an error:
```
ANY (((1, 2, 3) AS "?column?", "?column?", "?column?"),): found
duplicate tuple label: "?column?"
```
This commit removes the labels from the type.

Fixes #28240

cc @jordanlewis 

Release note: None