### PR TITLE
cli: move initialization of the --logtostderr default

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"math/rand"
 	"os"
@@ -28,6 +29,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
@@ -40,6 +42,12 @@ func Main() {
 
 	if len(os.Args) == 1 {
 		os.Args = append(os.Args, "help")
+	}
+
+	// Change the logging defaults for the main cockroach binary.
+	// The value is overridden after command-line parsing.
+	if err := flag.Lookup(logflags.LogToStderrName).Value.Set("NONE"); err != nil {
+		panic(err)
 	}
 
 	cmdName := commandName(os.Args[1:])

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -134,12 +134,6 @@ func VarFlag(f *pflag.FlagSet, value pflag.Value, flagInfo cliflags.FlagInfo) {
 func init() {
 	initCLIDefaults()
 
-	// Change the logging defaults for the main cockroach binary.
-	// The value is overridden after command-line parsing.
-	if err := flag.Lookup(logflags.LogToStderrName).Value.Set("false"); err != nil {
-		panic(err)
-	}
-
 	// Every command but start will inherit the following setting.
 	cockroachCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
 		extraClientFlagInit()
@@ -164,6 +158,13 @@ func init() {
 			flag.Hidden = true
 		} else if flag.Name == logflags.ShowLogsName {
 			flag.Hidden = true
+		} else if flag.Name == logflags.LogToStderrName {
+			// The actual default value for --logtostderr is overridden in
+			// cli.Main. We don't override it here as doing so would affect all of
+			// the cli tests and any package which depends on cli. The following line
+			// is only overriding the default value for the pflag package (and what
+			// is visible in help text), not the stdlib flag value.
+			flag.DefValue = "NONE"
 		}
 		pf.AddFlag(flag)
 	})


### PR DESCRIPTION
`cli.init()` was overriding the default value of --logtostderr and
setting it to `NONE` which was super confusing for tests in the `cli`
package and any package that depends on `cli`. Move this initialization
to `cli.Main` so that only the `cockroach` binary is affected.

Fixes #28259

Release note: None