### PR TITLE
storage: don't allow Raft requests to be handled synchronously

### DIFF
--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -2014,19 +2014,18 @@ func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 			// side in the split trigger was racing with the uninitialized
 			// version for the same group, resulting in clobbered HardState).
 			for term := uint64(1); ; term++ {
-				if err := mtc.stores[0].HandleRaftRequest(context.Background(),
-					&storage.RaftMessageRequest{
-						RangeID:     trigger.RightDesc.RangeID,
-						ToReplica:   replicas[0],
-						FromReplica: replicas[1],
-						Message: raftpb.Message{
-							Type: raftpb.MsgVote,
-							To:   uint64(replicas[0].ReplicaID),
-							From: uint64(replicas[1].ReplicaID),
-							Term: term,
-						},
-					}, nil); err != nil {
-					t.Error(err)
+				if sent := mtc.transport.SendAsync(&storage.RaftMessageRequest{
+					RangeID:     trigger.RightDesc.RangeID,
+					ToReplica:   replicas[0],
+					FromReplica: replicas[1],
+					Message: raftpb.Message{
+						Type: raftpb.MsgVote,
+						To:   uint64(replicas[0].ReplicaID),
+						From: uint64(replicas[1].ReplicaID),
+						Term: term,
+					},
+				}); !sent {
+					t.Error("transport failed to send vote request")
 				}
 				select {
 				case <-splitDone:

--- a/pkg/storage/raft_transport.go
+++ b/pkg/storage/raft_transport.go
@@ -90,11 +90,10 @@ type SnapshotResponseStream interface {
 // RaftMessageHandler is the interface that must be implemented by
 // arguments to RaftTransport.Listen.
 type RaftMessageHandler interface {
-	// HandleRaftRequest is called for each incoming Raft message. If it returns
-	// an error it will be streamed back to the sender of the message as a
-	// RaftMessageResponse. If the stream parameter is nil the request should be
-	// processed synchronously. If the stream is non-nil the request can be
-	// processed asynchronously and any error should be sent on the stream.
+	// HandleRaftRequest is called for each incoming Raft message. The request is
+	// always processed asynchronously and the response is sent over respStream.
+	// If an error is encountered during asynchronous processing, it will be
+	// streamed back to the sender of the message as a RaftMessageResponse.
 	HandleRaftRequest(ctx context.Context, req *RaftMessageRequest,
 		respStream RaftMessageResponseStream) *roachpb.Error
 


### PR DESCRIPTION
Raft requests are always handled asynchronously, except that one test,
TestStoreRangeSplitRaceUninitializedRHS, had a special-case synchronous
path. That test works just as well without the synchronous path, so port
the test to the asynchronous path and remove the weird synchronous
special case.

This makes the Raft subsystem that much easier for newcomers to reason
about.

Release note: None