### PR TITLE
importccl: fix setting oversample option

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -653,7 +653,7 @@ func importPlanHook(
 			if err != nil {
 				return err
 			}
-			sstSize = os
+			oversample = os
 		}
 
 		var skipFKs bool


### PR DESCRIPTION
Looks like a typo where we were ending up (re) setting the sstSize
to the oversample option value.
Release note: None