### PR TITLE
encoding/csv: update license file paths

### DIFF
--- a/pkg/util/encoding/csv/example_test.go
+++ b/pkg/util/encoding/csv/example_test.go
@@ -1,17 +1,17 @@
 // Copyright 2015 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// license that can be found in licenses/BSD-golang.txt.
 
 package csv_test
 
 import (
 	"context"
-	"encoding/csv"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/util/encoding/csv"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 

--- a/pkg/util/encoding/csv/reader.go
+++ b/pkg/util/encoding/csv/reader.go
@@ -1,6 +1,6 @@
 // Copyright 2011 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// license that can be found in licenses/BSD-golang.txt.
 
 // Package csv reads and writes comma-separated values (CSV) files.
 // There are many kinds of CSV files; this package supports the format

--- a/pkg/util/encoding/csv/reader_test.go
+++ b/pkg/util/encoding/csv/reader_test.go
@@ -1,6 +1,6 @@
 // Copyright 2011 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// license that can be found in licenses/BSD-golang.txt.
 
 package csv
 

--- a/pkg/util/encoding/csv/writer.go
+++ b/pkg/util/encoding/csv/writer.go
@@ -1,6 +1,6 @@
 // Copyright 2011 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// license that can be found in licenses/BSD-golang.txt.
 
 package csv
 

--- a/pkg/util/encoding/csv/writer_test.go
+++ b/pkg/util/encoding/csv/writer_test.go
@@ -1,6 +1,6 @@
 // Copyright 2011 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// license that can be found in licenses/BSD-golang.txt.
 
 package csv
 


### PR DESCRIPTION
Forgot to update these when vendoring the stdlib package.
Also switch the Example_ tests to test this package instead of stdlib.

Release note: none.