### PR TITLE
sql: remove unnecessary limit propagation

### DIFF
--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -49,13 +49,6 @@ type explainDistSQLRun struct {
 }
 
 func (n *explainDistSQLNode) startExec(params runParams) error {
-	// Check for subqueries and trigger limit propagation.
-	if _, err := params.p.prepareForDistSQLSupportCheck(
-		params.ctx, true, /* returnError */
-	); err != nil {
-		return err
-	}
-
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
 	auto, err := distSQLPlanner.CheckSupport(n.plan)
 	if err != nil {

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -505,19 +505,6 @@ func (p *planner) SessionData() *sessiondata.SessionData {
 	return p.EvalContext().SessionData
 }
 
-// prepareForDistSQLSupportCheck prepares p.curPlan.plan for a distSQL support
-// check and does additional verification of the planner state. It returns
-// whether the caller should go ahead and check for plan support through
-// shouldUseDistSQL. If returnError is set and false is returned, an error
-// explaining the failure will be returned.
-func (p *planner) prepareForDistSQLSupportCheck(
-	ctx context.Context, returnError bool,
-) (bool, error) {
-	// Trigger limit propagation.
-	p.setUnlimited(p.curPlan.plan)
-	return true, nil
-}
-
 // optionallyUseOptimizer will attempt to make an optimizer plan based on the
 // optimizerMode setting. If it is run, it will return true. If it returns false
 // and no error is returned, it is safe to fallback to a non-optimizer plan.


### PR DESCRIPTION
When queries are planned via the optimizer, we don't need to trigger
limit propagation.

Release note: None