### PR TITLE
distsql: fix crash where plan was not closed on error in EXPLAIN ANALYZE

### DIFF
--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -138,9 +138,5 @@ func (n *explainDistSQLNode) Next(runParams) (bool, error) {
 
 func (n *explainDistSQLNode) Values() tree.Datums { return n.run.values }
 func (n *explainDistSQLNode) Close(ctx context.Context) {
-	// If we analyzed the statement, we relinquished ownership of the plan to a
-	// distSQLWrapper.
-	if !n.analyze {
-		n.plan.Close(ctx)
-	}
+	n.plan.Close(ctx)
 }

--- a/pkg/sql/logictest/testdata/planner_test/distsql_auto_mode
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_auto_mode
@@ -147,6 +147,10 @@ SELECT url FROM [EXPLAIN ANALYZE (DISTSQL) SELECT DISTINCT(kw.w) FROM kv JOIN kw
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJyck8FunDAQhu99CmtOrWppMZCLpUoo6qFppaZKe6s4uHi6sQIYzZgmUbTvXmEipbCBLnuD3_PBN_b4CVpv8atpkEH_BAWlhI58hcyehmgsuLIPoBMJru36MMSlhMoTgn6C4EKNoOGH-VXjDRqLtEtAgsVgXB0_25FrDD0Wd39AAvl7FoTGaqFAAgdT1yK4BrVIGCRc90GLQkF5kOD78PJDDmaPoNVBnielFqTuT5ZKF6XSRakXl771ZJHQTjzKgfxfySudfTJ8-9m7FmmXThur8Xd4W6h3H8jtb-MTyBiKWZcxO2o1UvPSMTyq5eAJrWBnUYtYAxIa8yAabDw9ip7RapEm4ou7fF6xju-e80RcnrC12Zbz_u4pIO2y6Y4U6v0JZ3zkrVa8l2zzLbYfHQfXVmGXz32HfRknId6FM-TXJC-2SN4gd75lnE_tq19OhlFFu8dx9Nn3VOE38lX8zfh6HbkYWOQwrqbjy1Ubl-Id_xdWG-B0DqercDaBkzmcrcL5OpyvwhczuDy8-RsAAP__mE7PKQ==
 
+# Verify that EXPLAIN ANALYZE on an unsupported query returns an error.
+query error unsupported node
+EXPLAIN ANALYZE (DISTSQL) SHOW QUERIES;
+
 # This query verifies support for zeroNode in DistSQL.
 query B
 SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT sum(k) FROM kv WHERE FALSE]


### PR DESCRIPTION
The plans that EXPLAIN ANALYZE ran were incorrectly not being closed.
If an error ocurred before the query was analyzed, Close() would be a
noop and the server would crash with a memory error.

Fixes #28285

Release note: None