### PR TITLE
sql: return a copy of array in arrayAggregate

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -2781,3 +2781,33 @@ Sony VAIO        1h2m3s        700.00   620.00
 Samsung          1h2m3s        200.00   620.00
 iPhone           1m2s          900.00   620.00
 Dell             1m2s          800.00   620.00
+
+query TRTT
+SELECT group_name, price, product_name, array_agg(product_name) OVER (PARTITION BY group_name ORDER BY price, group_id) FROM products ORDER BY group_id
+----
+Smartphone  200.00   Microsoft Lumia  {"Microsoft Lumia"}
+Smartphone  400.00   HTC One          {"Microsoft Lumia","HTC One"}
+Smartphone  500.00   Nexus            {"Microsoft Lumia","HTC One","Nexus"}
+Smartphone  900.00   iPhone           {"Microsoft Lumia","HTC One","Nexus","iPhone"}
+Laptop      1200.00  HP Elite         {"Lenovo Thinkpad","Sony VAIO","Dell","HP Elite"}
+Laptop      700.00   Lenovo Thinkpad  {"Lenovo Thinkpad"}
+Laptop      700.00   Sony VAIO        {"Lenovo Thinkpad","Sony VAIO"}
+Laptop      800.00   Dell             {"Lenovo Thinkpad","Sony VAIO","Dell"}
+Tablet      700.00   iPad             {"Kindle Fire","Samsung","iPad"}
+Tablet      150.00   Kindle Fire      {"Kindle Fire"}
+Tablet      200.00   Samsung          {"Kindle Fire","Samsung"}
+
+query TT
+SELECT product_name, array_agg(product_name) OVER (ORDER BY group_id) FROM products ORDER BY group_id
+----
+Microsoft Lumia  {"Microsoft Lumia"}
+HTC One          {"Microsoft Lumia","HTC One"}
+Nexus            {"Microsoft Lumia","HTC One","Nexus"}
+iPhone           {"Microsoft Lumia","HTC One","Nexus","iPhone"}
+HP Elite         {"Microsoft Lumia","HTC One","Nexus","iPhone","HP Elite"}
+Lenovo Thinkpad  {"Microsoft Lumia","HTC One","Nexus","iPhone","HP Elite","Lenovo Thinkpad"}
+Sony VAIO        {"Microsoft Lumia","HTC One","Nexus","iPhone","HP Elite","Lenovo Thinkpad","Sony VAIO"}
+Dell             {"Microsoft Lumia","HTC One","Nexus","iPhone","HP Elite","Lenovo Thinkpad","Sony VAIO","Dell"}
+iPad             {"Microsoft Lumia","HTC One","Nexus","iPhone","HP Elite","Lenovo Thinkpad","Sony VAIO","Dell","iPad"}
+Kindle Fire      {"Microsoft Lumia","HTC One","Nexus","iPhone","HP Elite","Lenovo Thinkpad","Sony VAIO","Dell","iPad","Kindle Fire"}
+Samsung          {"Microsoft Lumia","HTC One","Nexus","iPhone","HP Elite","Lenovo Thinkpad","Sony VAIO","Dell","iPad","Kindle Fire","Samsung"}

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -503,10 +503,11 @@ func (a *arrayAggregate) Add(ctx context.Context, datum tree.Datum, _ ...tree.Da
 	return a.arr.Append(datum)
 }
 
-// Result returns an array of all datums passed to Add.
+// Result returns a copy of the array of all datums passed to Add.
 func (a *arrayAggregate) Result() (tree.Datum, error) {
 	if len(a.arr.Array) > 0 {
-		return a.arr, nil
+		arrCopy := *a.arr
+		return &arrCopy, nil
 	}
 	return tree.DNull, nil
 }


### PR DESCRIPTION
Makes arrayAggregate follow its contract by returning
a copy of accumulated array with every call to Result().

Fixes: #28287.

Release note (bug fix): CockroachDB now correctly
handles computation of `array_agg` when used as
a window function.