### PR TITLE
storage: Cap the size of raft logs included in preemptive snapshots

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -794,7 +794,7 @@ func (r *Replica) destroyRaftMuLocked(
 	ms := r.GetMVCCStats()
 
 	desc := r.Desc()
-	err := clearRangeData(ctx, desc, ms.KeyCount, r.store.Engine(), batch, destroyData)
+	err := clearRangeData(ctx, desc, r.store.Engine(), batch, destroyData)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -440,6 +440,7 @@ type OutgoingSnapshot struct {
 	// sideloaded storage in the meantime.
 	WithSideloaded func(func(sideloadStorage) error) error
 	RaftEntryCache *raftEntryCache
+	snapType       string
 }
 
 // Close releases the resources associated with the snapshot.
@@ -534,6 +535,7 @@ func snapshot(
 				ConfState: cs,
 			},
 		},
+		snapType: snapType,
 	}, nil
 }
 

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -640,7 +640,6 @@ const (
 func clearRangeData(
 	ctx context.Context,
 	desc *roachpb.RangeDescriptor,
-	keyCount int64,
 	eng engine.Engine,
 	batch engine.Batch,
 	destroyData bool,
@@ -656,18 +655,39 @@ func clearRangeData(
 	// perhaps we should fix RocksDB to handle large numbers of tombstones in an
 	// sstable better.
 	const clearRangeMinKeys = 64
-	const metadataRanges = 2
 	keyRanges := rditer.MakeAllKeyRanges(desc)
 	if !destroyData {
-		// TODO(benesch): The fact that we hardcode the number of metadata ranges,
-		// here and above, suggests that rditer.MakeAllKeyRanges has the wrong API.
+		// TODO(benesch): The fact that we hardcode the number of
+		// "metadata" ranges (i.e. non-user-keyspace) suggests that
+		// rditer.MakeAllKeyRanges has the wrong API.
 		keyRanges = keyRanges[:1]
 	}
-	for i, keyRange := range keyRanges {
-		// Metadata ranges always have too few keys to justify ClearRange (see
-		// above), but the data range's key count needs to be explicitly checked.
+	for _, keyRange := range keyRanges {
+		// Peek into the range to see whether it's large enough to justify
+		// ClearRange. Note that the work done here is bounded by
+		// clearRangeMinKeys, so it will be fairly cheap even for large
+		// ranges.
+		//
+		// TODO(bdarnell): Move this into ClearIterRange so we don't have
+		// to do this scan twice.
+		count := 0
+		iter.Seek(keyRange.Start)
+		for {
+			valid, err := iter.Valid()
+			if err != nil {
+				return err
+			}
+			if !valid || !iter.Key().Less(keyRange.End) {
+				break
+			}
+			count++
+			if count > clearRangeMinKeys {
+				break
+			}
+			iter.Next()
+		}
 		var err error
-		if i >= metadataRanges && keyCount >= clearRangeMinKeys {
+		if count > clearRangeMinKeys {
 			err = batch.ClearRange(keyRange.Start, keyRange.End)
 		} else {
 			err = batch.ClearIterRange(iter, keyRange.Start, keyRange.End)
@@ -694,7 +714,6 @@ func (r *Replica) applySnapshot(
 
 	r.mu.RLock()
 	replicaID := r.mu.replicaID
-	keyCount := r.mu.state.Stats.KeyCount
 	r.mu.RUnlock()
 
 	snapType := inSnap.snapType
@@ -758,7 +777,7 @@ func (r *Replica) applySnapshot(
 	// Delete everything in the range and recreate it from the snapshot.
 	// We need to delete any old Raft log entries here because any log entries
 	// that predate the snapshot will be orphaned and never truncated or GC'd.
-	if err := clearRangeData(ctx, s.Desc, keyCount, r.store.Engine(), batch, true /* destroyData */); err != nil {
+	if err := clearRangeData(ctx, s.Desc, r.store.Engine(), batch, true /* destroyData */); err != nil {
 		return err
 	}
 	stats.clear = timeutil.Now()

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -210,12 +210,41 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 	// together.
 	firstIndex := header.State.TruncatedState.Index + 1
 	endIndex := snap.RaftSnap.Metadata.Index + 1
-	logEntries := make([][]byte, 0, endIndex-firstIndex)
+	preallocSize := endIndex - firstIndex
+	const maxPreallocSize = 1000
+	if preallocSize > maxPreallocSize {
+		// It's possible for the raft log to become enormous in certain
+		// sustained failure conditions. We may bail out of the snapshot
+		// process early in scanFunc, but in the worst case this
+		// preallocation is enough to run the server out of memory. Limit
+		// the size of the buffer we will preallocate.
+		preallocSize = maxPreallocSize
+	}
+	logEntries := make([][]byte, 0, preallocSize)
 
+	var raftLogBytes int64
 	scanFunc := func(kv roachpb.KeyValue) (bool, error) {
 		bytes, err := kv.Value.GetBytes()
 		if err == nil {
 			logEntries = append(logEntries, bytes)
+			raftLogBytes += int64(len(bytes))
+			if snap.snapType == snapTypePreemptive && raftLogBytes > 4*raftLogMaxSize {
+				// If the raft log is too large, abort the snapshot instead of
+				// potentially running out of memory. However, if this is a
+				// raft-initiated snapshot (instead of a preemptive one), we
+				// have a dilemma. It may be impossible to truncate the raft
+				// log until we have caught up a peer with a snapshot. Since
+				// we don't know the exact size at which we will run out of
+				// memory, we err on the size of allowing the snapshot if it
+				// is raft-initiated, while aborting preemptive snapshots at a
+				// reasonable threshold. (Empirically, this is good enough:
+				// the situations that result in large raft logs have not been
+				// observed to result in raft-initiated snapshots).
+				return false, errors.Errorf(
+					"aborting snapshot because raft log is too large "+
+						"(%d bytes after processing %d of %d entries)",
+					raftLogBytes, len(logEntries), endIndex-firstIndex)
+			}
 		}
 		return false, err
 	}

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -240,6 +240,13 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 				// reasonable threshold. (Empirically, this is good enough:
 				// the situations that result in large raft logs have not been
 				// observed to result in raft-initiated snapshots).
+				//
+				// By aborting preemptive snapshots here, we disallow replica
+				// changes until the current replicas have caught up and
+				// truncated the log (either the range is available, in which
+				// case this will eventually happen, or it's not,in which case
+				// the preemptive snapshot would be wasted anyway because the
+				// change replicas transaction would be unable to commit).
 				return false, errors.Errorf(
 					"aborting snapshot because raft log is too large "+
 						"(%d bytes after processing %d of %d entries)",

--- a/pkg/storage/store_snapshot_test.go
+++ b/pkg/storage/store_snapshot_test.go
@@ -1,0 +1,101 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package storage
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/coreos/etcd/raft/raftpb"
+	"golang.org/x/time/rate"
+)
+
+func TestSnapshotRaftLogLimit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	store, _ := createTestStore(t, stopper)
+	store.SetRaftLogQueueActive(false)
+	repl, err := store.GetReplica(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var bytesWritten int64
+	blob := []byte(strings.Repeat("a", 1024*1024))
+	for i := 0; bytesWritten < 5*raftLogMaxSize; i++ {
+		pArgs := putArgs(roachpb.Key("a"), blob)
+		_, pErr := client.SendWrappedWith(ctx, store, roachpb.Header{RangeID: 1}, &pArgs)
+		if pErr != nil {
+			t.Fatal(pErr)
+		}
+		bytesWritten += int64(len(blob))
+	}
+
+	for _, snapType := range []string{snapTypePreemptive, snapTypeRaft} {
+		t.Run(snapType, func(t *testing.T) {
+			lastIndex, err := (*replicaRaftStorage)(repl).LastIndex()
+			if err != nil {
+				t.Fatal(err)
+			}
+			eng := store.Engine()
+			snap := eng.NewSnapshot()
+			defer snap.Close()
+
+			ss := kvBatchSnapshotStrategy{
+				limiter:  rate.NewLimiter(1<<10, 1),
+				newBatch: eng.NewBatch,
+			}
+			iter := rditer.NewReplicaDataIterator(repl.Desc(), snap, true /* replicatedOnly */)
+			defer iter.Close()
+			outSnap := &OutgoingSnapshot{
+				Iter:       iter,
+				EngineSnap: snap,
+				snapType:   snapType,
+				RaftSnap: raftpb.Snapshot{
+					Metadata: raftpb.SnapshotMetadata{
+						Index: lastIndex,
+					},
+				},
+			}
+
+			var stream fakeSnapshotStream
+			header := SnapshotRequest_Header{
+				State: repl.State().ReplicaState,
+			}
+
+			err = ss.Send(ctx, stream, header, outSnap)
+			if snapType == snapTypePreemptive {
+				if !testutils.IsError(err, "aborting snapshot because raft log is too large") {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
The first of three PRs related to OOMs caused by large raft logs. 

Release note (bug fix): Fix out-of-memory errors caused by very large
raft logs.