### PR TITLE
distsql: account for aggregate func memory usage

### DIFF
--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -908,9 +908,11 @@ func (ag *aggregatorBase) createAggregateFuncs() (aggregateFuncs, error) {
 	}
 	bucket := make(aggregateFuncs, len(ag.funcs))
 	for i, f := range ag.funcs {
-		// TODO(radu): we should account for the size of impl (this needs to be done
-		// in each aggregate constructor).
-		bucket[i] = f.create(ag.flowCtx.EvalCtx, f.arguments)
+		agg := f.create(ag.flowCtx.EvalCtx, f.arguments)
+		if err := ag.bucketsAcc.Grow(ag.Ctx, agg.Size()); err != nil {
+			return nil, err
+		}
+		bucket[i] = agg
 	}
 	return bucket, nil
 }

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -429,7 +429,7 @@ const sizeOfBoolAndAggregate = int64(unsafe.Sizeof(boolAndAggregate{}))
 const sizeOfBoolOrAggregate = int64(unsafe.Sizeof(boolOrAggregate{}))
 const sizeOfBytesXorAggregate = int64(unsafe.Sizeof(bytesXorAggregate{}))
 const sizeOfIntXorAggregate = int64(unsafe.Sizeof(intXorAggregate{}))
-const sizeOfJsonAggregate = int64(unsafe.Sizeof(jsonAggregate{}))
+const sizeOfJSONAggregate = int64(unsafe.Sizeof(jsonAggregate{}))
 
 // See NewAnyNotNullAggregate.
 type anyNotNullAggregate struct {
@@ -577,7 +577,9 @@ func (a *avgAggregate) Result() (tree.Datum, error) {
 }
 
 // Close is part of the tree.AggregateFunc interface.
-func (a *avgAggregate) Close(context.Context) {}
+func (a *avgAggregate) Close(ctx context.Context) {
+	a.agg.Close(ctx)
+}
 
 // Size is part of the tree.AggregateFunc interface.
 func (a *avgAggregate) Size() int64 {
@@ -818,14 +820,32 @@ func (a *countRowsAggregate) Size() int64 {
 type MaxAggregate struct {
 	max     tree.Datum
 	evalCtx *tree.EvalContext
+
+	acc               mon.BoundAccount
+	datumSize         uintptr
+	variableDatumSize bool
 }
 
-func newMaxAggregate(_ []types.T, evalCtx *tree.EvalContext, _ tree.Datums) tree.AggregateFunc {
-	return &MaxAggregate{evalCtx: evalCtx}
+func newMaxAggregate(
+	params []types.T, evalCtx *tree.EvalContext, _ tree.Datums,
+) tree.AggregateFunc {
+	sz, variable := tree.DatumTypeSize(params[0])
+	// If the datum type has a fixed size, it will be included in the size
+	// reported by Size(). Otherwise it will be accounted for in Add(). This
+	// avoids doing unnecessary memory accounting work for fixed-size datums.
+	if variable {
+		sz = 0
+	}
+	return &MaxAggregate{
+		evalCtx:           evalCtx,
+		acc:               evalCtx.Mon.MakeBoundAccount(),
+		datumSize:         sz,
+		variableDatumSize: variable,
+	}
 }
 
 // Add sets the max to the larger of the current max or the passed datum.
-func (a *MaxAggregate) Add(_ context.Context, datum tree.Datum, _ ...tree.Datum) error {
+func (a *MaxAggregate) Add(ctx context.Context, datum tree.Datum, _ ...tree.Datum) error {
 	if datum == tree.DNull {
 		return nil
 	}
@@ -836,6 +856,11 @@ func (a *MaxAggregate) Add(_ context.Context, datum tree.Datum, _ ...tree.Datum)
 	c := a.max.Compare(a.evalCtx, datum)
 	if c < 0 {
 		a.max = datum
+		if a.variableDatumSize {
+			if err := a.acc.ResizeTo(ctx, int64(datum.Size())); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }
@@ -849,25 +874,46 @@ func (a *MaxAggregate) Result() (tree.Datum, error) {
 }
 
 // Close is part of the tree.AggregateFunc interface.
-func (a *MaxAggregate) Close(context.Context) {}
+func (a *MaxAggregate) Close(ctx context.Context) {
+	a.acc.Close(ctx)
+}
 
 // Size is part of the tree.AggregateFunc interface.
 func (a *MaxAggregate) Size() int64 {
-	return sizeOfMaxAggregate
+	return sizeOfMaxAggregate + int64(a.datumSize)
 }
 
 // MinAggregate keeps track of the smallest value passed to Add.
 type MinAggregate struct {
 	min     tree.Datum
 	evalCtx *tree.EvalContext
+
+	acc               mon.BoundAccount
+	datumSize         uintptr
+	variableDatumSize bool
 }
 
-func newMinAggregate(_ []types.T, evalCtx *tree.EvalContext, _ tree.Datums) tree.AggregateFunc {
-	return &MinAggregate{evalCtx: evalCtx}
+func newMinAggregate(
+	params []types.T, evalCtx *tree.EvalContext, _ tree.Datums,
+) tree.AggregateFunc {
+	sz, variable := tree.DatumTypeSize(params[0])
+	// If the datum type has a fixed size, it will be included in the size
+	// reported by Size(). Otherwise it will be accounted for in Add(). This
+	// avoids doing unnecessary memory accounting work for fixed-size datums.
+	if variable {
+		// Datum size will be accounted for in the Add method.
+		sz = 0
+	}
+	return &MinAggregate{
+		evalCtx:           evalCtx,
+		acc:               evalCtx.Mon.MakeBoundAccount(),
+		datumSize:         sz,
+		variableDatumSize: variable,
+	}
 }
 
 // Add sets the min to the smaller of the current min or the passed datum.
-func (a *MinAggregate) Add(_ context.Context, datum tree.Datum, _ ...tree.Datum) error {
+func (a *MinAggregate) Add(ctx context.Context, datum tree.Datum, _ ...tree.Datum) error {
 	if datum == tree.DNull {
 		return nil
 	}
@@ -878,6 +924,11 @@ func (a *MinAggregate) Add(_ context.Context, datum tree.Datum, _ ...tree.Datum)
 	c := a.min.Compare(a.evalCtx, datum)
 	if c > 0 {
 		a.min = datum
+		if a.variableDatumSize {
+			if err := a.acc.ResizeTo(ctx, int64(datum.Size())); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }
@@ -891,11 +942,13 @@ func (a *MinAggregate) Result() (tree.Datum, error) {
 }
 
 // Close is part of the tree.AggregateFunc interface.
-func (a *MinAggregate) Close(context.Context) {}
+func (a *MinAggregate) Close(ctx context.Context) {
+	a.acc.Close(ctx)
+}
 
 // Size is part of the tree.AggregateFunc interface.
 func (a *MinAggregate) Size() int64 {
-	return sizeOfMinAggregate
+	return sizeOfMinAggregate + int64(a.datumSize)
 }
 
 type smallIntSumAggregate struct {
@@ -939,18 +992,19 @@ type intSumAggregate struct {
 	// result. Which one is used is determined by the `large` field
 	// below.
 	intSum      int64
-	decSum      tree.DDecimal
+	decSum      apd.Decimal
 	tmpDec      apd.Decimal
 	large       bool
 	seenNonNull bool
+	acc         mon.BoundAccount
 }
 
-func newIntSumAggregate(_ []types.T, _ *tree.EvalContext, _ tree.Datums) tree.AggregateFunc {
-	return &intSumAggregate{}
+func newIntSumAggregate(_ []types.T, evalCtx *tree.EvalContext, _ tree.Datums) tree.AggregateFunc {
+	return &intSumAggregate{acc: evalCtx.Mon.MakeBoundAccount()}
 }
 
 // Add adds the value of the passed datum to the sum.
-func (a *intSumAggregate) Add(_ context.Context, datum tree.Datum, _ ...tree.Datum) error {
+func (a *intSumAggregate) Add(ctx context.Context, datum tree.Datum, _ ...tree.Datum) error {
 	if datum == tree.DNull {
 		return nil
 	}
@@ -975,8 +1029,11 @@ func (a *intSumAggregate) Add(_ context.Context, datum tree.Datum, _ ...tree.Dat
 
 		if a.large {
 			a.tmpDec.SetCoefficient(t)
-			_, err := tree.ExactCtx.Add(&a.decSum.Decimal, &a.decSum.Decimal, &a.tmpDec)
+			_, err := tree.ExactCtx.Add(&a.decSum, &a.decSum, &a.tmpDec)
 			if err != nil {
+				return err
+			}
+			if err := a.acc.ResizeTo(ctx, int64(tree.SizeOfDecimal(a.decSum))); err != nil {
 				return err
 			}
 		}
@@ -992,7 +1049,7 @@ func (a *intSumAggregate) Result() (tree.Datum, error) {
 	}
 	dd := &tree.DDecimal{}
 	if a.large {
-		dd.Set(&a.decSum.Decimal)
+		dd.Set(&a.decSum)
 	} else {
 		dd.SetCoefficient(a.intSum)
 	}
@@ -1000,7 +1057,9 @@ func (a *intSumAggregate) Result() (tree.Datum, error) {
 }
 
 // Close is part of the tree.AggregateFunc interface.
-func (a *intSumAggregate) Close(context.Context) {}
+func (a *intSumAggregate) Close(ctx context.Context) {
+	a.acc.Close(ctx)
+}
 
 // Size is part of the tree.AggregateFunc interface.
 func (a *intSumAggregate) Size() int64 {
@@ -1010,14 +1069,17 @@ func (a *intSumAggregate) Size() int64 {
 type decimalSumAggregate struct {
 	sum        apd.Decimal
 	sawNonNull bool
+	acc        mon.BoundAccount
 }
 
-func newDecimalSumAggregate(_ []types.T, _ *tree.EvalContext, _ tree.Datums) tree.AggregateFunc {
-	return &decimalSumAggregate{}
+func newDecimalSumAggregate(
+	_ []types.T, evalCtx *tree.EvalContext, _ tree.Datums,
+) tree.AggregateFunc {
+	return &decimalSumAggregate{acc: evalCtx.Mon.MakeBoundAccount()}
 }
 
 // Add adds the value of the passed datum to the sum.
-func (a *decimalSumAggregate) Add(_ context.Context, datum tree.Datum, _ ...tree.Datum) error {
+func (a *decimalSumAggregate) Add(ctx context.Context, datum tree.Datum, _ ...tree.Datum) error {
 	if datum == tree.DNull {
 		return nil
 	}
@@ -1026,6 +1088,11 @@ func (a *decimalSumAggregate) Add(_ context.Context, datum tree.Datum, _ ...tree
 	if err != nil {
 		return err
 	}
+
+	if err := a.acc.ResizeTo(ctx, int64(tree.SizeOfDecimal(a.sum))); err != nil {
+		return err
+	}
+
 	a.sawNonNull = true
 	return nil
 }
@@ -1041,7 +1108,9 @@ func (a *decimalSumAggregate) Result() (tree.Datum, error) {
 }
 
 // Close is part of the tree.AggregateFunc interface.
-func (a *decimalSumAggregate) Close(context.Context) {}
+func (a *decimalSumAggregate) Close(ctx context.Context) {
+	a.acc.Close(ctx)
+}
 
 // Size is part of the tree.AggregateFunc interface.
 func (a *decimalSumAggregate) Size() int64 {
@@ -1132,12 +1201,14 @@ type intSqrDiffAggregate struct {
 	tmpDec tree.DDecimal
 }
 
-func newIntSqrDiff() decimalSqrDiff {
-	return &intSqrDiffAggregate{agg: newDecimalSqrDiff()}
+func newIntSqrDiff(evalCtx *tree.EvalContext) decimalSqrDiff {
+	return &intSqrDiffAggregate{agg: newDecimalSqrDiff(evalCtx)}
 }
 
-func newIntSqrDiffAggregate(_ []types.T, _ *tree.EvalContext, _ tree.Datums) tree.AggregateFunc {
-	return newIntSqrDiff()
+func newIntSqrDiffAggregate(
+	_ []types.T, evalCtx *tree.EvalContext, _ tree.Datums,
+) tree.AggregateFunc {
+	return newIntSqrDiff(evalCtx)
 }
 
 // Count is part of the decimalSqrDiff interface.
@@ -1164,7 +1235,9 @@ func (a *intSqrDiffAggregate) Result() (tree.Datum, error) {
 }
 
 // Close is part of the tree.AggregateFunc interface.
-func (a *intSqrDiffAggregate) Close(context.Context) {}
+func (a *intSqrDiffAggregate) Close(ctx context.Context) {
+	a.agg.Close(ctx)
+}
 
 // Size is part of the tree.AggregateFunc interface.
 func (a *intSqrDiffAggregate) Size() int64 {
@@ -1238,17 +1311,22 @@ type decimalSqrDiffAggregate struct {
 	// Variables used as scratch space within iterations.
 	delta apd.Decimal
 	tmp   apd.Decimal
+
+	acc mon.BoundAccount
 }
 
-func newDecimalSqrDiff() decimalSqrDiff {
+func newDecimalSqrDiff(evalCtx *tree.EvalContext) decimalSqrDiff {
 	ed := apd.MakeErrDecimal(tree.IntermediateCtx)
-	return &decimalSqrDiffAggregate{ed: &ed}
+	return &decimalSqrDiffAggregate{
+		ed:  &ed,
+		acc: evalCtx.Mon.MakeBoundAccount(),
+	}
 }
 
 func newDecimalSqrDiffAggregate(
-	_ []types.T, _ *tree.EvalContext, _ tree.Datums,
+	_ []types.T, evalCtx *tree.EvalContext, _ tree.Datums,
 ) tree.AggregateFunc {
-	return newDecimalSqrDiff()
+	return newDecimalSqrDiff(evalCtx)
 }
 
 // Count is part of the decimalSqrDiff interface.
@@ -1261,7 +1339,9 @@ func (a *decimalSqrDiffAggregate) Tmp() *apd.Decimal {
 	return &a.tmp
 }
 
-func (a *decimalSqrDiffAggregate) Add(_ context.Context, datum tree.Datum, _ ...tree.Datum) error {
+func (a *decimalSqrDiffAggregate) Add(
+	ctx context.Context, datum tree.Datum, _ ...tree.Datum,
+) error {
 	if datum == tree.DNull {
 		return nil
 	}
@@ -1277,6 +1357,15 @@ func (a *decimalSqrDiffAggregate) Add(_ context.Context, datum tree.Datum, _ ...
 	a.ed.Add(&a.mean, &a.mean, &a.tmp)
 	a.ed.Sub(&a.tmp, d, &a.mean)
 	a.ed.Add(&a.sqrDiff, &a.sqrDiff, a.ed.Mul(&a.delta, &a.delta, &a.tmp))
+
+	size := tree.SizeOfDecimal(a.count) +
+		tree.SizeOfDecimal(a.mean) +
+		tree.SizeOfDecimal(a.sqrDiff) +
+		tree.SizeOfDecimal(a.delta) +
+		tree.SizeOfDecimal(a.tmp)
+	if err := a.acc.ResizeTo(ctx, int64(size)); err != nil {
+		return err
+	}
 
 	return a.ed.Err()
 }
@@ -1294,7 +1383,9 @@ func (a *decimalSqrDiffAggregate) Result() (tree.Datum, error) {
 }
 
 // Close is part of the tree.AggregateFunc interface.
-func (a *decimalSqrDiffAggregate) Close(context.Context) {}
+func (a *decimalSqrDiffAggregate) Close(ctx context.Context) {
+	a.acc.Close(ctx)
+}
 
 // Size is part of the tree.AggregateFunc interface.
 func (a *decimalSqrDiffAggregate) Size() int64 {
@@ -1383,11 +1474,16 @@ type decimalSumSqrDiffsAggregate struct {
 	tmpMean  apd.Decimal
 	delta    apd.Decimal
 	tmp      apd.Decimal
+
+	acc mon.BoundAccount
 }
 
-func newDecimalSumSqrDiffs() decimalSqrDiff {
+func newDecimalSumSqrDiffs(evalCtx *tree.EvalContext) decimalSqrDiff {
 	ed := apd.MakeErrDecimal(tree.IntermediateCtx)
-	return &decimalSumSqrDiffsAggregate{ed: &ed}
+	return &decimalSumSqrDiffsAggregate{
+		ed:  &ed,
+		acc: evalCtx.Mon.MakeBoundAccount(),
+	}
 }
 
 // Count is part of the decimalSqrDiff interface.
@@ -1401,7 +1497,7 @@ func (a *decimalSumSqrDiffsAggregate) Tmp() *apd.Decimal {
 }
 
 func (a *decimalSumSqrDiffsAggregate) Add(
-	_ context.Context, sqrDiffD tree.Datum, otherArgs ...tree.Datum,
+	ctx context.Context, sqrDiffD tree.Datum, otherArgs ...tree.Datum,
 ) error {
 	sumD := otherArgs[0]
 	countD := otherArgs[1]
@@ -1445,6 +1541,17 @@ func (a *decimalSumSqrDiffsAggregate) Add(
 	// Update running mean.
 	a.ed.Add(&a.mean, &a.mean, &a.tmp)
 
+	size := tree.SizeOfDecimal(a.count) +
+		tree.SizeOfDecimal(a.mean) +
+		tree.SizeOfDecimal(a.sqrDiff) +
+		tree.SizeOfDecimal(a.tmpCount) +
+		tree.SizeOfDecimal(a.tmpMean) +
+		tree.SizeOfDecimal(a.delta) +
+		tree.SizeOfDecimal(a.tmp)
+	if err := a.acc.ResizeTo(ctx, int64(size)); err != nil {
+		return err
+	}
+
 	return a.ed.Err()
 }
 
@@ -1457,7 +1564,9 @@ func (a *decimalSumSqrDiffsAggregate) Result() (tree.Datum, error) {
 }
 
 // Close is part of the tree.AggregateFunc interface.
-func (a *decimalSumSqrDiffsAggregate) Close(context.Context) {}
+func (a *decimalSumSqrDiffsAggregate) Close(ctx context.Context) {
+	a.acc.Close(ctx)
+}
 
 // Size is part of the tree.AggregateFunc interface.
 func (a *decimalSumSqrDiffsAggregate) Size() int64 {
@@ -1492,7 +1601,7 @@ type decimalVarianceAggregate struct {
 func newIntVarianceAggregate(
 	params []types.T, evalCtx *tree.EvalContext, _ tree.Datums,
 ) tree.AggregateFunc {
-	return &decimalVarianceAggregate{agg: newIntSqrDiff()}
+	return &decimalVarianceAggregate{agg: newIntSqrDiff(evalCtx)}
 }
 
 func newFloatVarianceAggregate(_ []types.T, _ *tree.EvalContext, _ tree.Datums) tree.AggregateFunc {
@@ -1500,9 +1609,9 @@ func newFloatVarianceAggregate(_ []types.T, _ *tree.EvalContext, _ tree.Datums) 
 }
 
 func newDecimalVarianceAggregate(
-	_ []types.T, _ *tree.EvalContext, _ tree.Datums,
+	_ []types.T, evalCtx *tree.EvalContext, _ tree.Datums,
 ) tree.AggregateFunc {
-	return &decimalVarianceAggregate{agg: newDecimalSqrDiff()}
+	return &decimalVarianceAggregate{agg: newDecimalSqrDiff(evalCtx)}
 }
 
 func newFloatFinalVarianceAggregate(
@@ -1512,9 +1621,9 @@ func newFloatFinalVarianceAggregate(
 }
 
 func newDecimalFinalVarianceAggregate(
-	_ []types.T, _ *tree.EvalContext, _ tree.Datums,
+	_ []types.T, evalCtx *tree.EvalContext, _ tree.Datums,
 ) tree.AggregateFunc {
-	return &decimalVarianceAggregate{agg: newDecimalSumSqrDiffs()}
+	return &decimalVarianceAggregate{agg: newDecimalSumSqrDiffs(evalCtx)}
 }
 
 // Add is part of the tree.AggregateFunc interface.
@@ -1572,7 +1681,9 @@ func (a *decimalVarianceAggregate) Result() (tree.Datum, error) {
 }
 
 // Close is part of the tree.AggregateFunc interface.
-func (a *floatVarianceAggregate) Close(context.Context) {}
+func (a *floatVarianceAggregate) Close(ctx context.Context) {
+	a.agg.Close(ctx)
+}
 
 // Size is part of the tree.AggregateFunc interface.
 func (a *floatVarianceAggregate) Size() int64 {
@@ -1580,7 +1691,9 @@ func (a *floatVarianceAggregate) Size() int64 {
 }
 
 // Close is part of the tree.AggregateFunc interface.
-func (a *decimalVarianceAggregate) Close(context.Context) {}
+func (a *decimalVarianceAggregate) Close(ctx context.Context) {
+	a.agg.Close(ctx)
+}
 
 // Size is part of the tree.AggregateFunc interface.
 func (a *decimalVarianceAggregate) Size() int64 {
@@ -1684,7 +1797,9 @@ func (a *decimalStdDevAggregate) Result() (tree.Datum, error) {
 }
 
 // Close is part of the tree.AggregateFunc interface.
-func (a *floatStdDevAggregate) Close(context.Context) {}
+func (a *floatStdDevAggregate) Close(ctx context.Context) {
+	a.agg.Close(ctx)
+}
 
 // Size is part of the tree.AggregateFunc interface.
 func (a *floatStdDevAggregate) Size() int64 {
@@ -1692,7 +1807,9 @@ func (a *floatStdDevAggregate) Size() int64 {
 }
 
 // Close is part of the tree.AggregateFunc interface.
-func (a *decimalStdDevAggregate) Close(context.Context) {}
+func (a *decimalStdDevAggregate) Close(ctx context.Context) {
+	a.agg.Close(ctx)
+}
 
 // Size is part of the tree.AggregateFunc interface.
 func (a *decimalStdDevAggregate) Size() int64 {
@@ -1826,5 +1943,5 @@ func (a *jsonAggregate) Close(ctx context.Context) {
 
 // Size is part of the tree.AggregateFunc interface.
 func (a *jsonAggregate) Size() int64 {
-	return sizeOfJsonAggregate
+	return sizeOfJSONAggregate
 }

--- a/pkg/sql/sem/tree/aggregate_funcs.go
+++ b/pkg/sql/sem/tree/aggregate_funcs.go
@@ -36,4 +36,8 @@ type AggregateFunc interface {
 	// requested during aggregation, and must be called upon completion of the
 	// aggregation.
 	Close(context.Context)
+
+	// Size returns the size of the AggregateFunc implementation in bytes. It does
+	// not account for additional memory used during accumulation.
+	Size() int64
 }

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -835,10 +835,14 @@ func (d *DDecimal) Format(ctx *FmtCtx) {
 	}
 }
 
+// SizeOfDecimal returns the size in bytes of an apd.Decimal.
+func SizeOfDecimal(d apd.Decimal) uintptr {
+	return uintptr(cap(d.Coeff.Bits())) * unsafe.Sizeof(big.Word(0))
+}
+
 // Size implements the Datum interface.
 func (d *DDecimal) Size() uintptr {
-	intVal := d.Decimal.Coeff
-	return unsafe.Sizeof(*d) + uintptr(cap(intVal.Bits()))*unsafe.Sizeof(big.Word(0))
+	return unsafe.Sizeof(*d) + SizeOfDecimal(d.Decimal)
 }
 
 var (

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -525,6 +525,10 @@ func (b *BoundAccount) Resize(ctx context.Context, oldSz, newSz int64) error {
 
 // ResizeTo resizes (grows or shrinks) the account to a specified size.
 func (b *BoundAccount) ResizeTo(ctx context.Context, newSz int64) error {
+	if newSz == b.used {
+		// Performance optimization to avoid an unnecessary dispatch.
+		return nil
+	}
 	return b.Resize(ctx, b.used, newSz)
 }
 


### PR DESCRIPTION
The size of AggregateFunc implementations was previously not taken into
account by the Aggregator processor's memory monitoring.

Also, some aggregate builtins were not accounting for additional memory
usage during accumulation, particularly those which relied on Decimals, which
can grow arbitrarily large. I added more monitoring where appropriate.

The original issue warns against calling `Grow()` for every row. I'm calling
`ResizeTo()`, which is a no-op when the size hasn't actually changed. That
seems to be the case the vast majority of the time here, so I don't think it's
a bottleneck. There is still some overhead from the method dispatch, which
could be avoided by keeping track of the previous size on the AggregatorFunc
side and only calling `ResizeTo` when it changes. Not sure it's enough of a
performance hit to warrant that though. (We're talking about single digit
nanoseconds per row.) I can add that logic if reviewers feel it's worth it.

```
name                                   old time/op  new time/op  delta
AvgAggregateInt/count=1000-4           92.1µs ± 8%  96.8µs ± 5%     ~     (p=0.151 n=5+5)
AvgAggregateSmallInt/count=1000-4      27.1µs ± 3%  28.1µs ± 3%   +3.92%  (p=0.032 n=5+5)
AvgAggregateFloat/count=1000-4         7.35µs ± 1%  7.55µs ± 2%   +2.86%  (p=0.008 n=5+5)
AvgAggregateDecimal/count=1000-4        152µs ± 3%   162µs ± 2%   +6.15%  (p=0.008 n=5+5)
CountAggregate/count=1000-4            3.50µs ± 1%  3.49µs ± 1%     ~     (p=0.841 n=5+5)
SumIntAggregateInt/count=1000-4        14.8µs ± 2%  14.7µs ± 1%     ~     (p=0.310 n=5+5)
SumAggregateInt/count=1000-4           78.0µs ± 1%  83.4µs ± 1%   +6.92%  (p=0.008 n=5+5)
SumAggregateSmallInt/count=1000-4      21.1µs ± 2%  21.5µs ± 1%   +1.90%  (p=0.032 n=5+5)
SumAggregateFloat/count=1000-4         3.90µs ± 1%  3.99µs ± 1%   +2.32%  (p=0.008 n=5+5)
SumAggregateDecimal/count=1000-4        142µs ± 2%   150µs ± 2%   +5.26%  (p=0.008 n=5+5)
MaxAggregateInt/count=1000-4           8.72µs ± 2%  9.25µs ± 1%   +6.10%  (p=0.008 n=5+5)
MaxAggregateFloat/count=1000-4         8.75µs ± 2%  9.23µs ± 1%   +5.48%  (p=0.008 n=5+5)
MaxAggregateDecimal/count=1000-4       61.3µs ±10%  68.2µs ±27%     ~     (p=0.841 n=5+5)
MinAggregateInt/count=1000-4           8.66µs ± 2%  9.60µs ± 2%  +10.81%  (p=0.008 n=5+5)
MinAggregateFloat/count=1000-4         8.63µs ± 2%  9.38µs ± 2%   +8.67%  (p=0.008 n=5+5)
MinAggregateDecimal/count=1000-4       37.7µs ± 6%  42.8µs ±16%     ~     (p=0.056 n=5+5)
VarianceAggregateInt/count=1000-4      9.18ms ± 2%  9.71ms ± 5%   +5.70%  (p=0.032 n=5+5)
VarianceAggregateFloat/count=1000-4    9.31µs ± 1%  9.26µs ± 2%     ~     (p=0.548 n=5+5)
VarianceAggregateDecimal/count=1000-4  9.22ms ± 1%  9.27ms ± 2%     ~     (p=0.548 n=5+5)
StdDevAggregateInt/count=1000-4        9.20ms ± 1%  9.47ms ± 4%     ~     (p=0.056 n=5+5)
StdDevAggregateFloat/count=1000-4      13.1µs ± 1%  13.8µs ± 3%   +5.77%  (p=0.008 n=5+5)
StdDevAggregateDecimal/count=1000-4    9.33ms ± 2%  9.32ms ± 3%     ~     (p=1.000 n=5+5)
```