### PR TITLE
opt: stop using OrderingChoice in optbuilder

### DIFF
--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -124,9 +124,8 @@ func (b *Builder) Build() (root memo.GroupID, required *props.Physical, err erro
 	}()
 
 	outScope := b.buildStmt(b.stmt, &scope{builder: b})
-	root = outScope.group
-	outScope.setPresentation()
-	return root, &outScope.physicalProps, nil
+	physicalProps := outScope.makePhysicalProps()
+	return outScope.group, &physicalProps, nil
 }
 
 // builderError is used for semantic errors that occur during the build process

--- a/pkg/sql/opt/optbuilder/explain.go
+++ b/pkg/sql/opt/optbuilder/explain.go
@@ -31,9 +31,6 @@ func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope 
 	// We don't allow the statement under Explain to reference outer columns, so we
 	// pass a "blank" scope rather than inScope.
 	stmtScope := b.buildStmt(explain.Statement, &scope{builder: b})
-	// Calculate the presentation, since we will store it in the Explain op.
-	stmtScope.setPresentation()
-
 	outScope = inScope.push()
 
 	var cols sqlbase.ResultColumns
@@ -59,7 +56,7 @@ func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope 
 	def := memo.ExplainOpDef{
 		Options: opts,
 		ColList: colsToColList(outScope.cols),
-		Props:   stmtScope.physicalProps,
+		Props:   stmtScope.makePhysicalProps(),
 	}
 	outScope.group = b.factory.ConstructExplain(stmtScope.group, b.factory.InternExplainOpDef(&def))
 	return outScope

--- a/pkg/sql/opt/optbuilder/limit.go
+++ b/pkg/sql/opt/optbuilder/limit.go
@@ -26,8 +26,8 @@ import (
 //   SELECT k FROM kv LIMIT k
 // are not valid.
 func (b *Builder) buildLimit(limit *tree.Limit, parentScope, inScope *scope) {
-	ordering := &inScope.physicalProps.Ordering
-	orderingPrivID := b.factory.InternOrderingChoice(ordering)
+	ordering := inScope.makeOrderingChoice()
+	orderingPrivID := b.factory.InternOrderingChoice(&ordering)
 
 	// We need to save and restore the previous value of the field in
 	// semaCtx in case we are recursively called within a subquery

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -193,7 +193,7 @@ func (b *Builder) buildWithOrdinality(colName string, inScope *scope) (outScope 
 	inScope.group = b.factory.ConstructRowNumber(
 		inScope.group,
 		b.factory.InternRowNumberDef(&memo.RowNumberDef{
-			Ordering: inScope.physicalProps.Ordering,
+			Ordering: inScope.makeOrderingChoice(),
 			ColID:    col.id,
 		}),
 	)
@@ -251,7 +251,7 @@ func (b *Builder) buildSelect(stmt *tree.Select, inScope *scope) (outScope *scop
 		panic(fmt.Errorf("unknown select statement: %T", stmt.Select))
 	}
 
-	if outScope.physicalProps.Ordering.Any() && orderBy != nil {
+	if outScope.ordering.Empty() && orderBy != nil {
 		projectionsScope := outScope.replace()
 		projectionsScope.cols = make([]scopeColumn, 0, len(outScope.cols))
 		for i := range outScope.cols {

--- a/pkg/sql/opt/props/ordering_choice_test.go
+++ b/pkg/sql/opt/props/ordering_choice_test.go
@@ -22,7 +22,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
-func TestOrderingChoice_Ordering(t *testing.T) {
+func TestOrderingChoice_FromOrdering(t *testing.T) {
+	var oc props.OrderingChoice
+	oc.FromOrdering(opt.Ordering{1, -2, 3})
+	if exp, actual := "+1,-2,+3", oc.String(); exp != actual {
+		t.Errorf("expected %s, got %s", exp, actual)
+	}
+}
+
+func TestOrderingChoice_ToOrdering(t *testing.T) {
 	testcases := []struct {
 		s string
 		o opt.Ordering
@@ -35,7 +43,7 @@ func TestOrderingChoice_Ordering(t *testing.T) {
 
 	for _, tc := range testcases {
 		choice := props.ParseOrderingChoice(tc.s)
-		ordering := choice.Ordering()
+		ordering := choice.ToOrdering()
 		if len(ordering) != len(tc.o) {
 			t.Errorf("%s: expected %s, actual: %s", tc.s, tc.o, ordering)
 		} else {

--- a/pkg/sql/opt/xform/interesting_orderings.go
+++ b/pkg/sql/opt/xform/interesting_orderings.go
@@ -102,7 +102,7 @@ func interestingOrderingsForGroupBy(ev memo.ExprView) opt.OrderingSet {
 
 	res := DeriveInterestingOrderings(ev.Child(0)).Copy()
 	if !def.Ordering.Any() {
-		ordering := def.Ordering.Ordering()
+		ordering := def.Ordering.ToOrdering()
 		res.RestrictToPrefix(ordering)
 		if len(res) == 0 {
 			res.Add(ordering)
@@ -116,7 +116,7 @@ func interestingOrderingsForGroupBy(ev memo.ExprView) opt.OrderingSet {
 
 func interestingOrderingsForLimit(ev memo.ExprView) opt.OrderingSet {
 	res := DeriveInterestingOrderings(ev.Child(0))
-	ord := ev.Private().(*props.OrderingChoice).Ordering()
+	ord := ev.Private().(*props.OrderingChoice).ToOrdering()
 	if ord.Empty() {
 		return res
 	}


### PR DESCRIPTION
The optbuilder uses `OrderingChoice` which leads to difficulty
handling the column groups. Using `opt.Ordering` is more appropriate
since we don't apply any FDs in the builder.

A few associated improvements:

 - we no longer store physical props in the scope; instead we only
   store an `opt.Ordering`. The physical props are generated only when
   they are needed (once per query, except for explain).

 - we don't need `orderByCols` anymore.

Release note: None