### PR TITLE
roachpb: introduce an API to clone RangeDescriptors

### DIFF
--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/pkg/errors"
 )
 
@@ -137,6 +138,11 @@ func (r RangeDescriptor) GetReplicaDescriptorByID(replicaID ReplicaID) (ReplicaD
 // TODO(bdarnell): unify this with Validate().
 func (r RangeDescriptor) IsInitialized() bool {
 	return len(r.EndKey) != 0
+}
+
+// Clone makes a deep copy of this RangeDescriptor.
+func (r *RangeDescriptor) Clone() RangeDescriptor {
+	return *protoutil.Clone(r).(*RangeDescriptor)
 }
 
 // Validate performs some basic validation of the contents of a range descriptor.

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -273,7 +273,7 @@ func (r *Replica) adminSplitWithDescriptor(
 	}
 
 	// Init updated version of existing range descriptor.
-	leftDesc := *desc
+	leftDesc := desc.Clone()
 	leftDesc.EndKey = splitKey
 
 	log.Infof(ctx, "initiating a split of this range at key %s [r%d]",
@@ -386,7 +386,7 @@ func (r *Replica) AdminMerge(
 		return reply, roachpb.NewErrorf("cannot merge final range")
 	}
 
-	updatedLeftDesc := *origLeftDesc
+	updatedLeftDesc := origLeftDesc.Clone()
 	rightDescKey := keys.RangeDescriptorKey(origLeftDesc.EndKey)
 
 	// Lookup right hand side range (subsumed). This really belongs

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2333,7 +2333,7 @@ func (s *Store) SplitRange(ctx context.Context, origRng, newRng *Replica) error 
 		return errors.Errorf("replicasByKey unexpectedly contains %v instead of replica %s", kr, origRng)
 	}
 
-	copyDesc := *origDesc
+	copyDesc := origDesc.Clone()
 	copyDesc.EndKey = append([]byte(nil), newDesc.StartKey...)
 	origRng.setDescWithoutProcessUpdate(&copyDesc)
 
@@ -2427,7 +2427,7 @@ func (s *Store) MergeRange(
 	// TODO(benesch): bump the timestamp cache of the LHS.
 
 	// Update the end key of the subsuming range.
-	copy := *leftDesc
+	copy := leftDesc.Clone()
 	copy.EndKey = updatedEndKey
 	return leftRepl.setDesc(&copy)
 }


### PR DESCRIPTION
Various code paths would previously create shallow copies of
RangeDescriptors using the assignment operator. This worked well enough,
as all the fields are currently either value types, like NextReplicaID,
or treated as immutable, like StartKey and EndKey.

A future commit, however, will add a Generation counter of type *uint64
to the message. This field must not be shallowly copied; if two
RangeDescriptors shared a generation counter, the results would be
disastrous. For backwards-compatibility reasons, it also won't be
possible for the field to be a value type (i.e., of type uint64).

So, this commit introduces a Clone method that makes a deep copy of a
RangeDescriptor, and uses it in place of the shallow copies mentioned
previously.

Release note: None
