### PR TITLE
release-2.0: cli/sql: avoid a panic when reading '?' while non-interactive

### DIFF
--- a/pkg/cli/interactive_tests/test_contextual_help.tcl
+++ b/pkg/cli/interactive_tests/test_contextual_help.tcl
@@ -137,4 +137,16 @@ end_test
 interrupt
 eexpect eof
 
+start_test "Check that the hint for a single ? is also printed in non-interactive sessions."
+spawn /bin/bash
+
+send "echo '?' | $argv sql\r"
+eexpect "Note:"
+eexpect JSON
+eexpect "use '??'"
+
+send "exit\r"
+eexpect eof
+end_test
+
 stop_server $argv

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -916,7 +916,11 @@ func (c *cliState) doPrepareStatementLine(
 
 	if !endOfStmt {
 		if lastTok == '?' {
-			fmt.Fprintf(c.ins.Stdout(),
+			stdout := os.Stdout
+			if c.hasEditor() {
+				stdout = c.ins.Stdout()
+			}
+			fmt.Fprintf(stdout,
 				"Note: a single '?' is a JSON operator. If you want contextual help, use '??'.\n")
 		}
 		return contState


### PR DESCRIPTION
Backport 1/1 commits from #28324.

/cc @cockroachdb/release

---

Fixes  #28239.

Release note (bug fix): `cockroach sql` and `cockroach demo` now
properly print a warning when a `?` character is mistakenly used to
receive contextual help in a non-interactive session, instead of
crashing.
