### PR TITLE
opt: fix select_index flaky test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -299,7 +299,7 @@ CREATE TABLE ef (e INT, f INT, INDEX(f))
 statement ok
 INSERT INTO ef VALUES (NULL, 1), (1, 1)
 
-query I
+query I rowsort
 SELECT e FROM ef WHERE f > 0 AND f < 2 ORDER BY f
 ----
 NULL


### PR DESCRIPTION
This test had its `rowsort` removed erroneously. The two results have
the same value for `f`.

Release note: None