### PR TITLE
sql: Introduce fast path delete for cascading interleaved tables

### DIFF
--- a/pkg/sql/delete_test.go
+++ b/pkg/sql/delete_test.go
@@ -1,0 +1,217 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestInterleavedFastPathDeleteCheck(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+
+	tables := map[string]string{
+		`parent`: `
+CREATE TABLE IF NOT EXISTS parent(
+  id INT PRIMARY KEY
+)`,
+		`child`: `
+CREATE TABLE IF NOT EXISTS child(
+  pid INT,
+  id INT,
+  PRIMARY KEY (pid, id),
+  FOREIGN KEY(pid) REFERENCES parent(id) ON UPDATE CASCADE ON DELETE CASCADE
+) INTERLEAVE IN PARENT parent(pid)
+`,
+		`sibling`: `
+CREATE TABLE IF NOT EXISTS sibling(
+  pid INT,
+  id INT,
+  PRIMARY KEY (pid, id),
+  FOREIGN KEY(pid) REFERENCES parent(id) ON UPDATE CASCADE ON DELETE CASCADE
+) INTERLEAVE IN PARENT parent(pid)
+`,
+		`grandchild`: `
+CREATE TABLE IF NOT EXISTS grandchild(
+    gid INT,
+    pid INT,
+    id INT,
+    FOREIGN KEY (gid, pid) REFERENCES child(pid, id) ON UPDATE CASCADE ON DELETE CASCADE,
+    PRIMARY KEY(gid, pid, id)
+) INTERLEAVE IN PARENT child(gid, pid)
+`,
+		`external_ref`: `
+CREATE TABLE IF NOT EXISTS external_ref(
+	id INT,
+	parent_id INT,
+	child_id INT,
+	FOREIGN KEY (parent_id, child_id) REFERENCES child(pid, id) ON DELETE CASCADE
+)
+`,
+		`child_with_index`: `
+CREATE TABLE IF NOT EXISTS child_with_index(
+	pid INT,
+	child_id INT,
+	other_field STRING,
+	PRIMARY KEY (pid, child_id),
+	FOREIGN KEY (pid) REFERENCES parent(id),
+	UNIQUE (other_field)
+) INTERLEAVE IN PARENT parent(pid); CREATE INDEX ON child_with_index (other_field) STORING (child_id)
+`,
+	}
+
+	drop := func(tables ...string) {
+		for _, table := range tables {
+			if _, err := db.Exec(fmt.Sprintf(`DROP TABLE IF EXISTS %s CASCADE`, table)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// setup is called at the beginning of every sub-test
+	setup := func(tablesNeeded ...string) {
+		drop(tablesNeeded...)
+		for _, table := range tablesNeeded {
+			if _, ok := tables[table]; !ok {
+				t.Fatal(errors.New("invalid table name for setup"))
+			}
+			if _, err := db.Exec(tables[table]); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	testCheck := func(expected bool, tableNames ...string) func(*testing.T) {
+		return func(t *testing.T) {
+			setup(tableNames...)
+			defer drop(tableNames...)
+
+			tablesByID := make(map[sqlbase.ID]*TableDescriptor)
+			pd := sqlbase.GetTableDescriptor(kvDB, "defaultdb", "parent")
+			tablesByID[pd.ID] = pd
+
+			for _, tableName := range tableNames {
+				if tableName != "parent" {
+					cd := sqlbase.GetTableDescriptor(kvDB, "defaultdb", tableName)
+					tablesByID[cd.ID] = cd
+				}
+			}
+
+			lookup := func(ctx context.Context, tableID sqlbase.ID) (sqlbase.TableLookup, error) {
+				table, exists := tablesByID[tableID]
+				if !exists {
+					return sqlbase.TableLookup{}, errors.Errorf("Could not lookup table:%d", tableID)
+				}
+				return sqlbase.TableLookup{Table: table}, nil
+			}
+
+			fkTables, err := sqlbase.TablesNeededForFKs(
+				context.TODO(),
+				*pd,
+				sqlbase.CheckDeletes,
+				lookup,
+				sqlbase.NoCheckPrivilege,
+				nil, /* AnalyzeExprFunction */
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if canDeleteFastInterleaved(*pd, fkTables) != expected {
+				t.Fatalf("canDeleteFastInterleaved returned %t, expected %t", !expected, expected)
+			}
+		}
+	}
+
+	t.Run("canDeleteFastInterleaved, one child", testCheck(true, "parent", "child"))
+	t.Run("canDeleteFastInterleaved, two children", testCheck(true, "parent", "child", "sibling"))
+	t.Run("canDeleteFastInterleaved, two children", testCheck(true, "parent", "child", "sibling", "grandchild"))
+	t.Run("canDeleteFastInterleaved, two children", testCheck(true, "parent", "child", "grandchild"))
+	t.Run("canDeleteFastInterleaved, one child, external ref", testCheck(false, "parent", "child", "external_ref"))
+	t.Run("canDeleteFastInterleaved, one child with a secondary index", testCheck(false, "parent", "child_with_index"))
+}
+
+func TestInterleavedFastDeleteRestorable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+	parentStmt := `
+CREATE TABLE IF NOT EXISTS parent(
+  id INT PRIMARY KEY
+)`
+	childStmt := `
+CREATE TABLE IF NOT EXISTS child(
+  pid INT,
+  id INT,
+  PRIMARY KEY (pid, id),
+  FOREIGN KEY(pid) REFERENCES parent(id) ON UPDATE CASCADE ON DELETE CASCADE
+) INTERLEAVE IN PARENT parent(pid)`
+
+	if _, err := sqlDB.Exec(parentStmt); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(childStmt); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`INSERT INTO parent SELECT generate_series(1,10)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`INSERT INTO child(pid, id) SELECT parent.id, 1 from parent`); err != nil {
+		t.Fatal(err)
+	}
+	var timestamp string
+	if err := sqlDB.QueryRow("SELECT cluster_logical_timestamp()").Scan(&timestamp); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`DELETE FROM parent WHERE id <= 5`); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := sqlDB.Query(fmt.Sprintf(`SELECT * FROM parent AS OF SYSTEM TIME '%s'`, timestamp))
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for rows.Next() {
+		count++
+	}
+
+	if count != 10 {
+		t.Fatal(fmt.Sprintf("Expected 10 rows from AS OF SYSTEM TIME query, got %d", count))
+	}
+
+	rows, err = sqlDB.Query(fmt.Sprintf(`SELECT * FROM child AS OF SYSTEM TIME '%s'`, timestamp))
+	if err != nil {
+		t.Fatal(err)
+	}
+	count = 0
+	for rows.Next() {
+		count++
+	}
+
+	if count != 10 {
+		t.Fatal(fmt.Sprintf("Expected 10 rows from AS OF SYSTEM TIME query, got %d", count))
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -366,7 +366,6 @@ INSERT INTO c20067 VALUES (1, 1, 'John Doe')
 # constraint on a non-interleaved column.
 
 subtest interleaved_join_on_other_columns
-
 statement ok
 CREATE TABLE users (id INT PRIMARY KEY)
 
@@ -383,3 +382,381 @@ query I
 SELECT count(*) FROM users JOIN documents ON users.id=documents.user_id WHERE documents.id=0
 ----
 1
+
+subtest InterleavedDeleteFastPath
+statement ok
+CREATE TABLE a (
+    a_id INT PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE b(
+    b_id INT,
+    a_id INT,
+    FOREIGN KEY (a_id) REFERENCES a(a_id) ON UPDATE CASCADE ON DELETE CASCADE,
+    PRIMARY KEY(a_id, b_id)
+) INTERLEAVE IN PARENT a(a_id)
+
+statement ok
+CREATE TABLE c(
+    c_id INT,
+    a_id INT,
+    b_id INT,
+    FOREIGN KEY (a_id, b_id) REFERENCES b(a_id, b_id) ON UPDATE CASCADE ON DELETE CASCADE,
+    PRIMARY KEY(a_id, b_id, c_id)
+) INTERLEAVE IN PARENT b(a_id, b_id)
+
+statement ok
+INSERT INTO a SELECT generate_series(1,10);
+INSERT INTO b(a_id, b_id) SELECT generate_series(1,10), 1
+
+statement ok
+DELETE FROM a WHERE a_id <= 2
+
+query I
+SELECT count(*) from a
+----
+8
+
+query I
+SELECT count(*) from b
+----
+8
+
+query I colnames
+SELECT * from a order by a_id
+----
+a_id
+3
+4
+5
+6
+7
+8
+9
+10
+
+query II colnames
+SELECT * from b order by a_id, b_id
+----
+b_id  a_id
+1     3
+1     4
+1     5
+1     6
+1     7
+1     8
+1     9
+1     10
+
+statement ok
+INSERT INTO b(a_id, b_id) select a.a_id, 2 from a;
+INSERT INTO c(a_id, b_id, c_id) select a.a_id, b.b_id, 1 from a, b where a.a_id = b.a_id
+
+query III colnames
+SELECT * from c order by a_id, b_id, c_id
+----
+c_id  a_id  b_id
+1     3     1
+1     3     2
+1     4     1
+1     4     2
+1     5     1
+1     5     2
+1     6     1
+1     6     2
+1     7     1
+1     7     2
+1     8     1
+1     8     2
+1     9     1
+1     9     2
+1     10    1
+1     10    2
+
+statement ok
+SET TRACING = on,kv,results; DELETE FROM a where a_id <= 7 and a_id >= 5; SET tracing = off
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION]
+----
+Scan /Table/79/1/{5-7/#}
+querying next range at /Table/79/1/5
+r1: sending batch 1 Scan to (n1,s1):1
+DelRange /Table/79/1/5 - /Table/79/1/7/NULL
+querying next range at /Table/79/1/5
+r1: sending batch 1 DelRng, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+fast path completed
+rows affected: 3
+
+query II colnames
+select * from b order by a_id, b_id
+----
+b_id  a_id
+1     3
+2     3
+1     4
+2     4
+1     8
+2     8
+1     9
+2     9
+1     10
+2     10
+
+query III colnames
+select * from c order by a_id, b_id, c_id
+----
+c_id  a_id  b_id
+1     3     1
+1     3     2
+1     4     1
+1     4     2
+1     8     1
+1     8     2
+1     9     1
+1     9     2
+1     10    1
+1     10    2
+
+statement ok
+SET TRACING = on,kv,results; DELETE FROM a; SET tracing = off
+
+query T
+select message FROM [SHOW KV TRACE FOR SESSION]
+----
+Scan /Table/79/{1-2}
+querying next range at /Table/79/1
+r1: sending batch 1 Scan to (n1,s1):1
+DelRange /Table/79/1 - /Table/79/3
+querying next range at /Table/79/1
+r1: sending batch 1 DelRng, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+fast path completed
+rows affected: 5
+
+query II colnames
+select * from b order by a_id, b_id
+----
+b_id  a_id
+
+query III colnames
+select * from c order by a_id, b_id, c_id
+----
+c_id  a_id  b_id
+
+statement ok
+INSERT INTO a SELECT generate_series(1,10);
+INSERT INTO b(a_id, b_id) SELECT generate_series(1,10), 1
+
+statement ok
+SET TRACING = on,kv,results; 
+
+query I
+delete from a returning *
+----
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+
+statement ok
+SET TRACING=off;
+
+query T
+select message FROM [SHOW KV TRACE FOR SESSION];
+----
+Scan /Table/79/{1-2}
+querying next range at /Table/79/1
+r1: sending batch 1 Scan to (n1,s1):1
+fetched: /a/primary/1 -> NULL
+Del /Table/79/1/1/0
+cascading delete into table: 80 using index: 1
+querying next range at /Table/79/1/1/#/80/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/1/#/80/1/1
+r1: sending batch 1 Scan to (n1,s1):1
+Del /Table/79/1/1/#/80/1/1/0
+querying next range at /Table/79/1/1/#/80/1/1/0
+r1: sending batch 1 Del, 1 BeginTxn to (n1,s1):1
+cascading delete into table: 81 using index: 1
+querying next range at /Table/79/1/1/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/1/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/1/#/80/1
+r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+fetched: /a/primary/2 -> NULL
+Del /Table/79/1/2/0
+cascading delete into table: 80 using index: 1
+querying next range at /Table/79/1/2/#/80/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/2/#/80/1/1
+r1: sending batch 1 Scan to (n1,s1):1
+Del /Table/79/1/2/#/80/1/1/0
+querying next range at /Table/79/1/2/#/80/1/1/0
+r1: sending batch 1 Del to (n1,s1):1
+cascading delete into table: 81 using index: 1
+querying next range at /Table/79/1/2/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/2/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/2/#/80/1
+r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+fetched: /a/primary/3 -> NULL
+Del /Table/79/1/3/0
+cascading delete into table: 80 using index: 1
+querying next range at /Table/79/1/3/#/80/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/3/#/80/1/1
+r1: sending batch 1 Scan to (n1,s1):1
+Del /Table/79/1/3/#/80/1/1/0
+querying next range at /Table/79/1/3/#/80/1/1/0
+r1: sending batch 1 Del to (n1,s1):1
+cascading delete into table: 81 using index: 1
+querying next range at /Table/79/1/3/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/3/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/3/#/80/1
+r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+fetched: /a/primary/4 -> NULL
+Del /Table/79/1/4/0
+cascading delete into table: 80 using index: 1
+querying next range at /Table/79/1/4/#/80/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/4/#/80/1/1
+r1: sending batch 1 Scan to (n1,s1):1
+Del /Table/79/1/4/#/80/1/1/0
+querying next range at /Table/79/1/4/#/80/1/1/0
+r1: sending batch 1 Del to (n1,s1):1
+cascading delete into table: 81 using index: 1
+querying next range at /Table/79/1/4/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/4/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/4/#/80/1
+r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+fetched: /a/primary/5 -> NULL
+Del /Table/79/1/5/0
+cascading delete into table: 80 using index: 1
+querying next range at /Table/79/1/5/#/80/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/5/#/80/1/1
+r1: sending batch 1 Scan to (n1,s1):1
+Del /Table/79/1/5/#/80/1/1/0
+querying next range at /Table/79/1/5/#/80/1/1/0
+r1: sending batch 1 Del to (n1,s1):1
+cascading delete into table: 81 using index: 1
+querying next range at /Table/79/1/5/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/5/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/5/#/80/1
+r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+fetched: /a/primary/6 -> NULL
+Del /Table/79/1/6/0
+cascading delete into table: 80 using index: 1
+querying next range at /Table/79/1/6/#/80/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/6/#/80/1/1
+r1: sending batch 1 Scan to (n1,s1):1
+Del /Table/79/1/6/#/80/1/1/0
+querying next range at /Table/79/1/6/#/80/1/1/0
+r1: sending batch 1 Del to (n1,s1):1
+cascading delete into table: 81 using index: 1
+querying next range at /Table/79/1/6/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/6/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/6/#/80/1
+r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+fetched: /a/primary/7 -> NULL
+Del /Table/79/1/7/0
+cascading delete into table: 80 using index: 1
+querying next range at /Table/79/1/7/#/80/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/7/#/80/1/1
+r1: sending batch 1 Scan to (n1,s1):1
+Del /Table/79/1/7/#/80/1/1/0
+querying next range at /Table/79/1/7/#/80/1/1/0
+r1: sending batch 1 Del to (n1,s1):1
+cascading delete into table: 81 using index: 1
+querying next range at /Table/79/1/7/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/7/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/7/#/80/1
+r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+fetched: /a/primary/8 -> NULL
+Del /Table/79/1/8/0
+cascading delete into table: 80 using index: 1
+querying next range at /Table/79/1/8/#/80/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/8/#/80/1/1
+r1: sending batch 1 Scan to (n1,s1):1
+Del /Table/79/1/8/#/80/1/1/0
+querying next range at /Table/79/1/8/#/80/1/1/0
+r1: sending batch 1 Del to (n1,s1):1
+cascading delete into table: 81 using index: 1
+querying next range at /Table/79/1/8/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/8/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/8/#/80/1
+r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+fetched: /a/primary/9 -> NULL
+Del /Table/79/1/9/0
+cascading delete into table: 80 using index: 1
+querying next range at /Table/79/1/9/#/80/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/9/#/80/1/1
+r1: sending batch 1 Scan to (n1,s1):1
+Del /Table/79/1/9/#/80/1/1/0
+querying next range at /Table/79/1/9/#/80/1/1/0
+r1: sending batch 1 Del to (n1,s1):1
+cascading delete into table: 81 using index: 1
+querying next range at /Table/79/1/9/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/9/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/9/#/80/1
+r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+fetched: /a/primary/10 -> NULL
+Del /Table/79/1/10/0
+cascading delete into table: 80 using index: 1
+querying next range at /Table/79/1/10/#/80/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/10/#/80/1/1
+r1: sending batch 1 Scan to (n1,s1):1
+Del /Table/79/1/10/#/80/1/1/0
+querying next range at /Table/79/1/10/#/80/1/1/0
+r1: sending batch 1 Del to (n1,s1):1
+cascading delete into table: 81 using index: 1
+querying next range at /Table/79/1/10/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/10/#/80/1/1/#/81/1
+r1: sending batch 1 Scan to (n1,s1):1
+querying next range at /Table/79/1/10/#/80/1
+r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+querying next range at /Table/79/1/1/0
+r1: sending batch 10 Del, 1 EndTxn to (n1,s1):1
+output row: [1]
+output row: [2]
+output row: [3]
+output row: [4]
+output row: [5]
+output row: [6]
+output row: [7]
+output row: [8]
+output row: [9]
+output row: [10]
+rows affected: 10
+
+statement ok
+DROP TABLE c; DROP TABLE b; DROP TABLE a

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -97,7 +97,6 @@ func (td *tableDeleter) fastPathAvailable(ctx context.Context) bool {
 func (td *tableDeleter) fastDelete(
 	ctx context.Context, scan *scanNode, autoCommit autoCommitOpt, traceKV bool,
 ) (rowCount int, err error) {
-
 	for _, span := range scan.spans {
 		log.VEvent(ctx, 2, "fast delete: skipping scan")
 		if traceKV {


### PR DESCRIPTION
This patch introduces fast deletes for interleaved tables with ON DELETE
CASCADE. Deleting from a table with other tables interleaved in it will
now simply call KV DelRanges instead of going through all of the
foreign key checks and cascades for the interleaved tables.

This fast path is *not* activated when:
* The table or any of its interleaved tables have any secondary indices
* The table or any of its interleaved tables are referenced by any other
table outside of them by foreign key
* Any of the interleaved relationships are not ON DELETE CASCADE

Release note: None

closes #27990 