### PR TITLE
ui: enable click trigger on entirety of dropdown area

### DIFF
--- a/pkg/ui/src/views/shared/components/dropdown/dropdown.styl
+++ b/pkg/ui/src/views/shared/components/dropdown/dropdown.styl
@@ -15,6 +15,7 @@ $dropdown-hover-color = darken($background-color, 2.5%)
   white-space nowrap
   padding-right 10px
   color $body-color
+  cursor pointer
 
   &:hover
     background-color $dropdown-hover-color
@@ -22,10 +23,15 @@ $dropdown-hover-color = darken($background-color, 2.5%)
   &__title
     vertical-align middle
     display inline-block
+    -webkit-user-select none
+    -moz-user-select none
+
 
   &__select
     display inline-block
     vertical-align middle
+    -webkit-user-select none
+    -moz-user-select none
 
     &:hover
       background-color $dropdown-hover-color
@@ -35,6 +41,8 @@ $dropdown-hover-color = darken($background-color, 2.5%)
     display none
     color $link-color
     cursor pointer
+    -webkit-user-select none
+    -moz-user-select none
 
     &:first-child
       border-right 1px solid $button-border-color

--- a/pkg/ui/src/views/shared/components/dropdown/index.tsx
+++ b/pkg/ui/src/views/shared/components/dropdown/index.tsx
@@ -7,6 +7,7 @@ import "./dropdown.styl";
 
 import {leftArrow, rightArrow} from "src/views/shared/components/icons";
 import { trustIcon } from "src/util/trust";
+import ReactSelectClass from "react-select";
 
 export interface DropdownOption {
   value: string;
@@ -33,6 +34,26 @@ interface DropdownOwnProps {
  * Dropdown component that uses the URL query string for state.
  */
 export default class Dropdown extends React.Component<DropdownOwnProps, {}> {
+  dropdownRef: React.RefObject<HTMLDivElement> = React.createRef();
+  titleRef: React.RefObject<HTMLDivElement> = React.createRef();
+  selectRef: React.RefObject<ReactSelectClass> = React.createRef();
+
+  constructor(props: DropdownOwnProps) {
+    super(props);
+
+    this.triggerSelectClick = this.triggerSelectClick.bind(this);
+  }
+
+  triggerSelectClick(e: any) {
+    const dropdownNode: any = this.dropdownRef.current as Node;
+    const titleNode: any = this.titleRef.current as Node;
+    const selectNode: any = this.selectRef.current;
+
+    if (e.target === dropdownNode || e.target === titleNode || e.target.className.indexOf("dropdown__select") > -1) {
+      selectNode.handleMouseDownOnMenu(e);
+    }
+  }
+
   render() {
     const {selected, options, onChange, onArrowClick, disabledArrows} = this.props;
 
@@ -49,15 +70,27 @@ export default class Dropdown extends React.Component<DropdownOwnProps, {}> {
       { "dropdown__side-arrow--disabled": _.includes(disabledArrows, ArrowDirection.RIGHT) },
     );
 
-    return <div className={className}>
+    return <div className={className} onClick={this.triggerSelectClick} ref={this.dropdownRef}>
       {/* TODO (maxlang): consider moving arrows outside the dropdown component */}
       <span
         className={leftClassName}
         dangerouslySetInnerHTML={trustIcon(leftArrow)}
         onClick={() => this.props.onArrowClick(ArrowDirection.LEFT)}>
       </span>
-      <span className="dropdown__title">{this.props.title}{this.props.title ? ":" : ""}</span>
-      <Select className="dropdown__select" clearable={false} searchable={false} options={options} value={selected} onChange={onChange} />
+      <span
+        className="dropdown__title"
+        ref={this.titleRef}>
+          {this.props.title}{this.props.title ? ":" : ""}
+      </span>
+      <Select
+        className="dropdown__select"
+        clearable={false}
+        searchable={false}
+        options={options}
+        value={selected}
+        onChange={onChange}
+        ref={this.selectRef}
+      />
       <span
         className={rightClassName}
         dangerouslySetInnerHTML={trustIcon(rightArrow)}

--- a/pkg/ui/styl/shame.styl
+++ b/pkg/ui/styl/shame.styl
@@ -53,6 +53,7 @@
 
 .Select-value-label
   display block !important
+  cursor pointer
 
 .Select-arrow
   border-top-color $link-color !important


### PR DESCRIPTION
__[description]__
* fixes: [#20818](https://github.com/cockroachdb/cockroach/issues/20818)
* work overlaps: [#20853](https://github.com/cockroachdb/cockroach/pull/20853)
* (from #20853) "Previously, the darken-on-hover area was not the same as the clickable area. Now the whole area is clickable."
* menu persists when clicking on surrounding container of the `Select` component which is different than when clicking the `Select` component itself or outside of the surrounding container and this seems difficult to avoid; I'm not sure if this is an issue.