### PR TITLE
opt: make grouping columns optional in the GroupBy/DistinctOn orderings

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_distinct_on
@@ -92,7 +92,7 @@ SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz
 4 5 6
 4 1 6
 
-query III
+query III partialsort(1)
 SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz ORDER BY x
 ----
 1 1 NULL

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -184,11 +184,10 @@ distinct             ·            ·            (a, c)     weak-key(a)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) x FROM xyz ORDER BY x DESC
 ----
-distinct        ·            ·            (x)  weak-key(x); -x
- │              distinct on  x            ·    ·
- │              order key    x            ·    ·
- └── sort       ·            ·            (x)  -x
-      │         order        -x           ·    ·
+sort            ·            ·            (x)  weak-key(x); -x
+ │              order        -x           ·    ·
+ └── distinct   ·            ·            (x)  weak-key(x)
+      │         distinct on  x            ·    ·
       └── scan  ·            ·            (x)  ·
 ·               table        xyz@primary  ·    ·
 ·               spans        ALL          ·    ·
@@ -200,11 +199,10 @@ render               ·            ·            (y, z, x)  ·
  │                   render 0     y            ·          ·
  │                   render 1     z            ·          ·
  │                   render 2     x            ·          ·
- └── distinct        ·            ·            (x, y, z)  weak-key(x,z); +z
-      │              distinct on  x, z         ·          ·
-      │              order key    z            ·          ·
-      └── sort       ·            ·            (x, y, z)  +z
-           │         order        +z           ·          ·
+ └── sort            ·            ·            (x, y, z)  weak-key(x,z); +z
+      │              order        +z           ·          ·
+      └── distinct   ·            ·            (x, y, z)  weak-key(x,z)
+           │         distinct on  x, z         ·          ·
            └── scan  ·            ·            (x, y, z)  ·
 ·                    table        xyz@primary  ·          ·
 ·                    spans        ALL          ·          ·
@@ -381,11 +379,10 @@ EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) pk1 FROM xyz ORDER BY x
 ----
 render               ·            ·            (pk1)           ·
  │                   render 0     pk1          ·               ·
- └── distinct        ·            ·            (x, y, z, pk1)  weak-key(x,y,z); +x
-      │              distinct on  x, y, z      ·               ·
-      │              order key    x            ·               ·
-      └── sort       ·            ·            (x, y, z, pk1)  +x
-           │         order        +x           ·               ·
+ └── sort            ·            ·            (x, y, z, pk1)  weak-key(x,y,z); +x
+      │              order        +x           ·               ·
+      └── distinct   ·            ·            (x, y, z, pk1)  weak-key(x,y,z)
+           │         distinct on  x, y, z      ·               ·
            └── scan  ·            ·            (x, y, z, pk1)  ·
 ·                    table        xyz@primary  ·               ·
 ·                    spans        ALL          ·               ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
@@ -82,11 +82,10 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJyslE2LqzAUhvf3V1zedaAm2i
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz ORDER BY x
 ----
-distinct        ·            ·            (x, y, z)  weak-key(x,y,z); +x
- │              distinct on  x, y, z      ·          ·
- │              order key    x            ·          ·
- └── sort       ·            ·            (x, y, z)  +x
-      │         order        +x           ·          ·
+sort            ·            ·            (x, y, z)  weak-key(x,y,z); +x
+ │              order        +x           ·          ·
+ └── distinct   ·            ·            (x, y, z)  weak-key(x,y,z)
+      │         distinct on  x, y, z      ·          ·
       └── scan  ·            ·            (x, y, z)  ·
 ·               table        xyz@primary  ·          ·
 ·               spans        ALL          ·          ·
@@ -94,7 +93,7 @@ distinct        ·            ·            (x, y, z)  weak-key(x,y,z); +x
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz ORDER BY x]
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html#eJy0lb9u2zAQh_c-RXBrCdhH0o6tSUOXLE2Rdis8qOIhEOCIBkkBSQO_e6E_gCo3OsqyOkry777jdwf6HUpr6Gv2Qh6Sn4AgQIIABQI0CNjAQcDJ2Zy8t67-SRt4MK-QrAUU5akK9euDgNw6guQdQhGOBAn8yH4d6YkyQ261BgGGQlYcG8zJFS-Ze0tf336DgMcqJHepFKkSqYbDWYCtQl_Xh-yZIMGzmM7-bl0gt9oMsSl-Hi0vryn_pfChKPOwwvUlQTQHqU_lDDkyyV2Ko1A1Cu1Ztq3z0UnYzv45-1Wd6UFnOH3SuPSkI-xu0tu5k46U733igpOW033KpX1G2J3P-7k-I-V7n3JBn2q6T7W0zwi787mb6zNSvvepFvSpp_vUS_uMsDuf-7k-I-V7n_o_3ewfQJ_In2zpaUAcq7yur30yz9T-TXhbuZy-OZs3mPbxsck1Lwz50H7F9uGhbD_VDf4dRjYs-bBkw2oQxsuw4tve8mjNpjd8eMOGI-TtLYe-Z8M7nrxjw3s-vL-lbYzsWGzJ-C3DyJrhTXuGkUXTETi_aRhZNeR37bL3w_nTnwAAAP__eVbBtQ==
+https://cockroachdb.github.io/distsqlplan/decode.html#eJyslL-OozAQh_t7itO0N1KwDflDRXFNmsspu92KgsWjCCnByDZSshHvvgIkskSJIYLSNr_55sPWXCFXkv4lJzIQfgADBA4IAhB8QAggRii0SskYpetP2sBWniH0ELK8KG29HSOkShOEV7CZPRKE8J58HmlPiSS98ABBkk2yY4MpdHZK9CU6X74AYVfa8HfEMRIY-RBXCKq0t7rGJgeCkFU4nv03MzbLU7sI-uCIYQN6SuFPKbfiZa60JE2yVzuuXH0w78VGxCu6b0pb0gvG7iF_ntb3e_XZ-Ktkc1_lALv7hctJV8nHG_K5DQfYneFqkqEYbyjmNhxgd4brSYb-eEN_bsMBdme4mW3gPKDsyRQqN3Q3eB5X9uqBRPJA7fQyqtQp_dcqbTDtctfkmg1JxranrF1s8_aobvBnmDnDvBdm92HuDAs3Wbjb5u6070wH7nAwRXrpDK_c5NUU8toZ3rjJmylkNvDGhh7Za68srn59BwAA__88-9tq
 
 # Ensure that even with more ordering columns, ordering propagates past local
 # DISTINCT processors.

--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -324,11 +324,19 @@ func (ev ExprView) formatRelational(f *opt.ExprFmtCtx, tp treeprinter.Node) {
 
 	switch ev.Operator() {
 	// Special-case handling for GroupBy private; print grouping columns
-	// in addition to full set of columns.
+	// and internal ordering in addition to full set of columns.
 	case opt.GroupByOp, opt.ScalarGroupByOp, opt.DistinctOnOp:
 		def := ev.Private().(*GroupByDef)
 		if !def.GroupingCols.Empty() {
 			logProps.FormatColSet(f, tp, "grouping columns:", def.GroupingCols)
+		}
+		if !def.Ordering.Any() {
+			tp.Childf("internal-ordering: %s", def.Ordering)
+		}
+
+	case opt.LimitOp, opt.OffsetOp:
+		if ord := ev.Private().(*props.OrderingChoice); !ord.Any() {
+			tp.Childf("internal-ordering: %s", ord)
 		}
 
 	// Special-case handling for set operators to show the left and right

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -25,6 +25,7 @@ LIMIT 10
 ----
 limit
  ├── columns: y:2(int!null) x:3(string!null) c:5(int)
+ ├── internal-ordering: +2
  ├── cardinality: [0 - 10]
  ├── stats: [rows=10]
  ├── fd: (2)-->(5)
@@ -89,6 +90,7 @@ project
  ├── ordering: +2
  ├── limit
  │    ├── columns: a.x:1(int!null) y:2(int!null) b.x:3(string!null)
+ │    ├── internal-ordering: +2
  │    ├── cardinality: [0 - 10]
  │    ├── stats: [rows=10]
  │    ├── key: (1,3)

--- a/pkg/sql/opt/memo/testdata/stats/limit
+++ b/pkg/sql/opt/memo/testdata/stats/limit
@@ -121,6 +121,7 @@ select
  ├── fd: ()-->(3), (1)-->(2,4), (4)-->(1,2)
  ├── limit
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+ │    ├── internal-ordering: +3
  │    ├── cardinality: [0 - 5]
  │    ├── stats: [rows=5, distinct(3)=3.93848936]
  │    ├── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1775,6 +1775,7 @@ project
       │    ├── fd: ()-->(10)
       │    ├── scalar-group-by
       │    │    ├── columns: max:10(string)
+      │    │    ├── internal-ordering: +8 opt(9)
       │    │    ├── outer: (1)
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
@@ -2281,6 +2282,7 @@ project
       ├── distinct-on
       │    ├── columns: x:1(int!null) y:2(int) k:3(int)
       │    ├── grouping columns: x:1(int!null)
+      │    ├── internal-ordering: +5,+6 opt(4)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2,3)
       │    ├── sort

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -136,6 +136,7 @@ SELECT k, f*2.0 AS r FROM a ORDER BY r LIMIT 5
 ----
 limit
  ├── columns: k:1(int!null) r:6(float)
+ ├── internal-ordering: +6
  ├── cardinality: [0 - 5]
  ├── key: (1)
  ├── fd: (1)-->(6)
@@ -169,6 +170,7 @@ project
  ├── ordering: +3
  ├── limit
  │    ├── columns: i:2(int) f:3(float)
+ │    ├── internal-ordering: +3
  │    ├── cardinality: [0 - 5]
  │    ├── key: (2,3)
  │    ├── ordering: +3
@@ -248,6 +250,7 @@ project
  ├── ordering: +1
  ├── offset
  │    ├── columns: k:1(int!null) f:3(float)
+ │    ├── internal-ordering: +1
  │    ├── key: (1)
  │    ├── fd: (1)-->(3)
  │    ├── ordering: +1
@@ -267,6 +270,7 @@ SELECT k, f*2.0 AS r FROM a ORDER BY r OFFSET 5
 ----
 offset
  ├── columns: k:1(int!null) r:6(float)
+ ├── internal-ordering: +6
  ├── key: (1)
  ├── fd: (1)-->(6)
  ├── ordering: +6
@@ -297,6 +301,7 @@ project
  ├── ordering: +3
  ├── offset
  │    ├── columns: i:2(int) f:3(float)
+ │    ├── internal-ordering: +3
  │    ├── key: (2,3)
  │    ├── ordering: +3
  │    ├── sort
@@ -352,11 +357,13 @@ project
  ├── ordering: +3
  ├── limit
  │    ├── columns: i:2(int) f:3(float)
+ │    ├── internal-ordering: +3
  │    ├── cardinality: [0 - 10]
  │    ├── key: (2,3)
  │    ├── ordering: +3
  │    ├── offset
  │    │    ├── columns: i:2(int) f:3(float)
+ │    │    ├── internal-ordering: +3
  │    │    ├── key: (2,3)
  │    │    ├── ordering: +3
  │    │    ├── sort

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -30,6 +30,7 @@ SELECT d, e FROM (SELECT d, 1 AS one, e FROM abcde) ORDER BY d, one, e LIMIT 10
 ----
 limit
  ├── columns: d:4(int) e:5(int)
+ ├── internal-ordering: +4,+5
  ├── cardinality: [0 - 10]
  ├── ordering: +4,+5 opt(6)
  ├── sort
@@ -45,6 +46,7 @@ SELECT b, c FROM abcde WHERE d=1 AND e=2 ORDER BY b, c, d, e, a LIMIT 10
 ----
 limit
  ├── columns: b:2(int) c:3(int)
+ ├── internal-ordering: +2,+3,+1 opt(4,5)
  ├── cardinality: [0 - 10]
  ├── key: (1)
  ├── fd: ()-->(4,5), (1)-->(2,3), (2,3)~~>(1)
@@ -124,6 +126,7 @@ SELECT array_agg(b) FROM (SELECT * FROM abcde ORDER BY a, b, c)
 ----
 scalar-group-by
  ├── columns: array_agg:6(int[])
+ ├── internal-ordering: +1
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(6)
@@ -143,6 +146,7 @@ SELECT DISTINCT ON (b, c) a, b, c FROM abcde ORDER BY b, c, a, d, e
 distinct-on
  ├── columns: a:1(int) b:2(int) c:3(int)
  ├── grouping columns: b:2(int) c:3(int)
+ ├── internal-ordering: +1 opt(2,3)
  ├── key: (1)
  ├── fd: (1)-->(2,3), (2,3)-->(1)
  ├── ordering: +2,+3

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -326,6 +326,7 @@ project
  ├── key: (1)
  └── limit
       ├── columns: k:1(int!null) i:2(int)
+      ├── internal-ordering: +2
       ├── cardinality: [0 - 10]
       ├── key: (1)
       ├── fd: (1)-->(2)
@@ -349,6 +350,7 @@ project
  ├── cardinality: [0 - 10]
  └── limit
       ├── columns: k:1(int!null) i:2(int) s:4(string)
+      ├── internal-ordering: +2,+1
       ├── cardinality: [0 - 10]
       ├── key: (1)
       ├── fd: (1)-->(2,4)
@@ -374,6 +376,7 @@ project
  ├── fd: (1)-->(4)
  └── limit
       ├── columns: k:1(int!null) i:2(int) s:4(string)
+      ├── internal-ordering: +2,+1
       ├── cardinality: [0 - 10]
       ├── key: (1)
       ├── fd: (1)-->(2,4)
@@ -432,6 +435,7 @@ project
  ├── key: (1)
  └── offset
       ├── columns: k:1(int!null) i:2(int)
+      ├── internal-ordering: +2
       ├── key: (1)
       ├── fd: (1)-->(2)
       ├── sort
@@ -453,6 +457,7 @@ project
  ├── columns: s:4(string)
  └── offset
       ├── columns: k:1(int!null) i:2(int) s:4(string)
+      ├── internal-ordering: +2,+1
       ├── key: (1)
       ├── fd: (1)-->(2,4)
       ├── sort
@@ -476,6 +481,7 @@ project
  ├── fd: (1)-->(4)
  └── offset
       ├── columns: k:1(int!null) i:2(int) s:4(string)
+      ├── internal-ordering: +2,+1
       ├── key: (1)
       ├── fd: (1)-->(2,4)
       ├── sort
@@ -505,6 +511,7 @@ project
  ├── columns: tree:5(string) columns:10(string)
  └── offset
       ├── columns: tree:5(string) level:6(int) node_type:7(string) field:8(string) description:9(string) columns:10(string) ordering:11(string)
+      ├── internal-ordering: +5
       ├── sort
       │    ├── columns: tree:5(string) level:6(int) node_type:7(string) field:8(string) description:9(string) columns:10(string) ordering:11(string)
       │    ├── ordering: +5
@@ -529,11 +536,13 @@ project
  ├── key: (1)
  └── limit
       ├── columns: k:1(int!null) i:2(int)
+      ├── internal-ordering: +2
       ├── cardinality: [0 - 10]
       ├── key: (1)
       ├── fd: (1)-->(2)
       ├── offset
       │    ├── columns: k:1(int!null) i:2(int)
+      │    ├── internal-ordering: +2
       │    ├── key: (1)
       │    ├── fd: (1)-->(2)
       │    ├── ordering: +2
@@ -558,11 +567,13 @@ project
  ├── cardinality: [0 - 10]
  └── limit
       ├── columns: k:1(int!null) i:2(int) s:4(string)
+      ├── internal-ordering: +2,+1
       ├── cardinality: [0 - 10]
       ├── key: (1)
       ├── fd: (1)-->(2,4)
       ├── offset
       │    ├── columns: k:1(int!null) i:2(int) s:4(string)
+      │    ├── internal-ordering: +2,+1
       │    ├── key: (1)
       │    ├── fd: (1)-->(2,4)
       │    ├── ordering: +2,+1
@@ -589,11 +600,13 @@ project
  ├── fd: (1)-->(4)
  └── limit
       ├── columns: k:1(int!null) i:2(int) s:4(string)
+      ├── internal-ordering: +2,+1
       ├── cardinality: [0 - 10]
       ├── key: (1)
       ├── fd: (1)-->(2,4)
       ├── offset
       │    ├── columns: k:1(int!null) i:2(int) s:4(string)
+      │    ├── internal-ordering: +2,+1
       │    ├── key: (1)
       │    ├── fd: (1)-->(2,4)
       │    ├── ordering: +2,+1

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -217,6 +217,12 @@ define AntiJoinApply {
 # the GroupBy operator will also be empty. If the grouping columns are empty,
 # then all input rows form a single group. GroupBy is used for queries with
 # aggregate functions, HAVING clauses and/or GROUP BY expressions.
+#
+# The Def private contains an ordering; this ordering is used to determine
+# intra-group ordering and is only useful if there is an order-dependent
+# aggregation (like ARRAY_AGG). Grouping columns are inconsequential in this
+# ordering; we currently set all grouping columns as optional in this ordering
+# (but note that this is not required by the operator).
 [Relational]
 define GroupBy {
     Input        Expr

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -265,7 +265,12 @@ define ScalarGroupBy {
 # inconsequential - they can appear anywhere in the ordering and they won't
 # change the results (other than the result ordering).
 #
-# TODO(radu): actually set grouping columns as optional cols in Ordering.
+# Currently when we build DistinctOn, we set all grouping columns as optional
+# cols in Ordering (but this is not required by the operator).
+#
+# TODO(radu): in the future we may want an exploration transform to try out more
+# specific interesting orderings because execution is more efficient when we can
+# rely on an ordering on the grouping columns (or a subset of them).
 #
 # DistinctOn uses an Aggregations child and the GroupByDef private so that it's
 # polymorphic with GroupBy and can be used in the same rules (when appropriate).

--- a/pkg/sql/opt/optbuilder/distinct.go
+++ b/pkg/sql/opt/optbuilder/distinct.go
@@ -98,8 +98,11 @@ func (b *Builder) buildDistinctOn(distinctOnCols opt.ColSet, inScope *scope) (ou
 
 	def := memo.GroupByDef{
 		GroupingCols: distinctOnCols.Copy(),
-		Ordering:     inScope.makeOrderingChoice(),
 	}
+	// The ordering is used for intra-group ordering. Ordering with respect to the
+	// DISTINCT ON columns doesn't affect intra-group ordering, so we add these
+	// columns as optional.
+	def.Ordering.FromOrderingWithOptCols(inScope.ordering, distinctOnCols)
 
 	// Set up a new scope for the output of DISTINCT ON. This scope differs from
 	// the input scope in that it doesn't have "extra" ORDER BY columns, e.g.

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -146,8 +146,10 @@ func (b *Builder) constructGroupBy(
 		b.factory.InternColList(colList),
 	)
 	def := memo.GroupByDef{GroupingCols: groupingColSet}
-	// The ordering of the GROUP BY is inherited from the input.
-	def.Ordering.FromOrdering(ordering)
+	// The ordering of the GROUP BY is inherited from the input. This ordering is
+	// only useful for intra-group ordering (for order-sensitive aggregations like
+	// ARRAY_AGG). So we add the grouping columns as optional columns.
+	def.Ordering.FromOrderingWithOptCols(ordering, groupingColSet)
 	if groupingColSet.Empty() {
 		return b.factory.ConstructScalarGroupBy(input, aggs, b.factory.InternGroupByDef(&def))
 	}

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -921,6 +921,7 @@ SELECT array_agg(k), array_agg(s) FROM (SELECT k, s FROM kv ORDER BY k)
 ----
 scalar-group-by
  ├── columns: array_agg:5(int[]) array_agg:6(string[])
+ ├── internal-ordering: +1
  ├── project
  │    ├── columns: k:1(int!null) s:4(string)
  │    ├── ordering: +1
@@ -938,6 +939,7 @@ SELECT array_agg(k) FROM (SELECT k FROM kv ORDER BY s)
 ----
 scalar-group-by
  ├── columns: array_agg:5(int[])
+ ├── internal-ordering: +4
  ├── sort
  │    ├── columns: k:1(int!null) s:4(string)
  │    ├── ordering: +4
@@ -956,6 +958,7 @@ project
  ├── columns: "?column?":6(int[])
  ├── scalar-group-by
  │    ├── columns: column5:5(int[])
+ │    ├── internal-ordering: +4
  │    ├── sort
  │    │    ├── columns: k:1(int!null) s:4(string)
  │    │    ├── ordering: +4
@@ -1778,6 +1781,7 @@ SELECT concat_agg(s) FROM (SELECT s FROM kv ORDER BY k)
 ----
 scalar-group-by
  ├── columns: concat_agg:5(string)
+ ├── internal-ordering: +1
  ├── project
  │    ├── columns: k:1(int!null) s:4(string)
  │    ├── ordering: +1
@@ -1793,6 +1797,7 @@ SELECT json_agg(s) FROM (SELECT s FROM kv ORDER BY k)
 ----
 scalar-group-by
  ├── columns: json_agg:5(jsonb)
+ ├── internal-ordering: +1
  ├── project
  │    ├── columns: k:1(int!null) s:4(string)
  │    ├── ordering: +1
@@ -1808,6 +1813,7 @@ SELECT jsonb_agg(s) FROM (SELECT s FROM kv ORDER BY k)
 ----
 scalar-group-by
  ├── columns: jsonb_agg:5(jsonb)
+ ├── internal-ordering: +1
  ├── project
  │    ├── columns: k:1(int!null) s:4(string)
  │    ├── ordering: +1
@@ -2647,6 +2653,7 @@ SELECT array_agg(y) FROM (SELECT * FROM xyz ORDER BY x+y)
 ----
 scalar-group-by
  ├── columns: array_agg:5(int[])
+ ├── internal-ordering: +4
  ├── sort
  │    ├── columns: y:2(int) column4:4(int)
  │    ├── ordering: +4
@@ -2669,6 +2676,7 @@ SELECT array_agg(y) FROM (SELECT * FROM xyz ORDER BY x DESC)
 ----
 scalar-group-by
  ├── columns: array_agg:4(int[])
+ ├── internal-ordering: -1
  ├── sort
  │    ├── columns: x:1(int!null) y:2(int)
  │    ├── ordering: -1

--- a/pkg/sql/opt/optbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/optbuilder/testdata/distinct_on
@@ -86,13 +86,12 @@ distinct-on
 build
 SELECT DISTINCT ON (c, a, b) b FROM abc ORDER BY b
 ----
-distinct-on
+sort
  ├── columns: b:2(string!null)
- ├── grouping columns: a:1(string!null) b:2(string!null) c:3(string!null)
  ├── ordering: +2
- └── sort
+ └── distinct-on
       ├── columns: a:1(string!null) b:2(string!null) c:3(string!null)
-      ├── ordering: +2
+      ├── grouping columns: a:1(string!null) b:2(string!null) c:3(string!null)
       └── scan abc
            └── columns: a:1(string!null) b:2(string!null) c:3(string!null)
 
@@ -177,13 +176,12 @@ distinct-on
 build
 SELECT DISTINCT ON (x) x FROM xyz ORDER BY x DESC
 ----
-distinct-on
+sort
  ├── columns: x:1(int)
- ├── grouping columns: x:1(int)
  ├── ordering: -1
- └── sort
+ └── distinct-on
       ├── columns: x:1(int)
-      ├── ordering: -1
+      ├── grouping columns: x:1(int)
       └── project
            ├── columns: x:1(int)
            └── scan xyz
@@ -192,20 +190,19 @@ distinct-on
 build
 SELECT DISTINCT ON (x, z) y, z, x FROM xyz ORDER BY z
 ----
-distinct-on
+sort
  ├── columns: y:2(int) z:3(int) x:1(int)
- ├── grouping columns: x:1(int) z:3(int)
  ├── ordering: +3
- ├── sort
- │    ├── columns: x:1(int) y:2(int) z:3(int)
- │    ├── ordering: +3
- │    └── project
- │         ├── columns: x:1(int) y:2(int) z:3(int)
- │         └── scan xyz
- │              └── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
- └── aggregations
-      └── first-agg [type=int]
-           └── variable: xyz.y [type=int]
+ └── distinct-on
+      ├── columns: x:1(int) y:2(int) z:3(int)
+      ├── grouping columns: x:1(int) z:3(int)
+      ├── project
+      │    ├── columns: x:1(int) y:2(int) z:3(int)
+      │    └── scan xyz
+      │         └── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
+      └── aggregations
+           └── first-agg [type=int]
+                └── variable: xyz.y [type=int]
 
 build
 SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
@@ -415,33 +412,31 @@ distinct-on
 build
 SELECT DISTINCT ON(pk1, pk2, x, y) x, y, z FROM xyz ORDER BY x, y
 ----
-distinct-on
+sort
  ├── columns: x:1(int) y:2(int) z:3(int)
- ├── grouping columns: x:1(int) y:2(int) pk1:4(int!null) pk2:5(int!null)
  ├── ordering: +1,+2
- ├── sort
- │    ├── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
- │    ├── ordering: +1,+2
- │    └── scan xyz
- │         └── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
- └── aggregations
-      └── first-agg [type=int]
-           └── variable: xyz.z [type=int]
+ └── distinct-on
+      ├── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
+      ├── grouping columns: x:1(int) y:2(int) pk1:4(int!null) pk2:5(int!null)
+      ├── scan xyz
+      │    └── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
+      └── aggregations
+           └── first-agg [type=int]
+                └── variable: xyz.z [type=int]
 
 build
 SELECT DISTINCT ON (x, y, z) pk1 FROM xyz ORDER BY x
 ----
-distinct-on
+sort
  ├── columns: pk1:4(int)
- ├── grouping columns: x:1(int) y:2(int) z:3(int)
  ├── ordering: +1
- ├── sort
- │    ├── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null)
- │    ├── ordering: +1
- │    └── project
- │         ├── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null)
- │         └── scan xyz
- │              └── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
- └── aggregations
-      └── first-agg [type=int]
-           └── variable: xyz.pk1 [type=int]
+ └── distinct-on
+      ├── columns: x:1(int) y:2(int) z:3(int) pk1:4(int)
+      ├── grouping columns: x:1(int) y:2(int) z:3(int)
+      ├── project
+      │    ├── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null)
+      │    └── scan xyz
+      │         └── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
+      └── aggregations
+           └── first-agg [type=int]
+                └── variable: xyz.pk1 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/optbuilder/testdata/distinct_on
@@ -210,6 +210,7 @@ SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
 distinct-on
  ├── columns: y:2(int) z:3(int) x:1(int)
  ├── grouping columns: x:1(int)
+ ├── internal-ordering: -3,-2 opt(1)
  ├── ordering: +1
  ├── sort
  │    ├── columns: x:1(int) y:2(int) z:3(int)

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -997,6 +997,7 @@ SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twoc
 ----
 limit
  ├── columns: x:1(int!null) x:3(int!null) y:4(int) b:6(int!null) d:8(int!null) e:9(int)
+ ├── internal-ordering: +1
  ├── ordering: +1
  ├── sort
  │    ├── columns: onecolumn.x:1(int!null) twocolumn.x:3(int!null) twocolumn.y:4(int) onecolumn.x:6(int!null) twocolumn.x:8(int!null) twocolumn.y:9(int)
@@ -1114,6 +1115,7 @@ SELECT * FROM (twocolumn AS a JOIN twocolumn AS b USING(x) JOIN twocolumn AS c U
 ----
 limit
  ├── columns: x:1(int!null) y:2(int) y:5(int) y:8(int)
+ ├── internal-ordering: +1
  ├── ordering: +1
  ├── sort
  │    ├── columns: twocolumn.x:1(int!null) twocolumn.y:2(int) twocolumn.y:5(int) twocolumn.y:8(int)

--- a/pkg/sql/opt/optbuilder/testdata/limit
+++ b/pkg/sql/opt/optbuilder/testdata/limit
@@ -18,6 +18,7 @@ SELECT k, v FROM t ORDER BY k LIMIT 5
 ----
 limit
  ├── columns: k:1(int!null) v:2(int)
+ ├── internal-ordering: +1
  ├── ordering: +1
  ├── project
  │    ├── columns: k:1(int!null) v:2(int)
@@ -32,6 +33,7 @@ SELECT k, v FROM t ORDER BY v FETCH FIRST 5 ROWS ONLY
 ----
 limit
  ├── columns: k:1(int!null) v:2(int)
+ ├── internal-ordering: +2
  ├── ordering: +2
  ├── sort
  │    ├── columns: k:1(int!null) v:2(int)
@@ -58,6 +60,7 @@ SELECT k FROM t ORDER BY k FETCH FIRST ROW ONLY
 ----
 limit
  ├── columns: k:1(int!null)
+ ├── internal-ordering: +1
  ├── ordering: +1
  ├── project
  │    ├── columns: k:1(int!null)
@@ -72,9 +75,11 @@ SELECT k FROM t ORDER BY k OFFSET 3 ROWS FETCH NEXT ROW ONLY
 ----
 limit
  ├── columns: k:1(int!null)
+ ├── internal-ordering: +1
  ├── ordering: +1
  ├── offset
  │    ├── columns: k:1(int!null)
+ │    ├── internal-ordering: +1
  │    ├── ordering: +1
  │    ├── project
  │    │    ├── columns: k:1(int!null)
@@ -90,6 +95,7 @@ SELECT k, v FROM t ORDER BY k OFFSET 5
 ----
 offset
  ├── columns: k:1(int!null) v:2(int)
+ ├── internal-ordering: +1
  ├── ordering: +1
  ├── project
  │    ├── columns: k:1(int!null) v:2(int)
@@ -104,6 +110,7 @@ SELECT k FROM t ORDER BY k FETCH FIRST (1+1) ROWS ONLY
 ----
 limit
  ├── columns: k:1(int!null)
+ ├── internal-ordering: +1
  ├── ordering: +1
  ├── project
  │    ├── columns: k:1(int!null)
@@ -128,6 +135,7 @@ SELECT sum(w) FROM t GROUP BY k, v ORDER BY v DESC LIMIT 10
 ----
 limit
  ├── columns: sum:4(decimal)
+ ├── internal-ordering: -2
  ├── ordering: -2
  ├── sort
  │    ├── columns: v:2(int) sum:4(decimal)
@@ -149,6 +157,7 @@ SELECT DISTINCT v FROM T ORDER BY v LIMIT 10
 ----
 limit
  ├── columns: v:2(int)
+ ├── internal-ordering: +2
  ├── ordering: +2
  ├── sort
  │    ├── columns: v:2(int)
@@ -167,6 +176,7 @@ VALUES (1,1), (2,2) ORDER BY 1 LIMIT 1
 ----
 limit
  ├── columns: column1:1(int) column2:2(int)
+ ├── internal-ordering: +1
  ├── ordering: +1
  ├── sort
  │    ├── columns: column1:1(int) column2:2(int)
@@ -186,6 +196,7 @@ build
 ----
 limit
  ├── columns: column1:3(int)
+ ├── internal-ordering: -3
  ├── ordering: -3
  ├── sort
  │    ├── columns: column1:3(int)
@@ -222,6 +233,7 @@ VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1) ORDER BY 1 DESC LI
 ----
 limit
  ├── columns: column1:3(int)
+ ├── internal-ordering: -3
  ├── ordering: -3
  ├── sort
  │    ├── columns: column1:3(int)
@@ -259,6 +271,7 @@ project
  ├── columns: k:1(int!null)
  └── limit
       ├── columns: k:1(int!null) v:2(int)
+      ├── internal-ordering: +2
       ├── sort
       │    ├── columns: k:1(int!null) v:2(int)
       │    ├── ordering: +2
@@ -276,6 +289,7 @@ SELECT DISTINCT w FROM (SELECT w FROM t ORDER BY w LIMIT 100) ORDER BY w LIMIT 2
 ----
 limit
  ├── columns: w:3(int)
+ ├── internal-ordering: +3
  ├── ordering: +3
  ├── distinct-on
  │    ├── columns: w:3(int)
@@ -283,6 +297,7 @@ limit
  │    ├── ordering: +3
  │    └── limit
  │         ├── columns: w:3(int)
+ │         ├── internal-ordering: +3
  │         ├── ordering: +3
  │         ├── sort
  │         │    ├── columns: w:3(int)

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -63,6 +63,7 @@ SELECT a, b FROM t ORDER BY b DESC LIMIT 2
 ----
 limit
  ├── columns: a:1(int!null) b:2(int)
+ ├── internal-ordering: -2
  ├── ordering: -2
  ├── sort
  │    ├── columns: a:1(int!null) b:2(int)
@@ -117,6 +118,7 @@ SELECT a AS foo, (a) AS foo FROM t ORDER BY foo LIMIT 1
 ----
 limit
  ├── columns: foo:1(int!null) foo:1(int!null)
+ ├── internal-ordering: +1
  ├── ordering: +1
  ├── project
  │    ├── columns: a:1(int!null)
@@ -176,6 +178,7 @@ SELECT b FROM t ORDER BY a LIMIT 1
 ----
 limit
  ├── columns: b:2(int)
+ ├── internal-ordering: +1
  ├── ordering: +1
  ├── project
  │    ├── columns: a:1(int!null) b:2(int)
@@ -332,6 +335,7 @@ build
 ----
 limit
  ├── columns: a:1(int!null)
+ ├── internal-ordering: -1
  ├── ordering: -1
  ├── sort
  │    ├── columns: a:1(int!null)
@@ -347,6 +351,7 @@ build
 ----
 limit
  ├── columns: a:1(int!null)
+ ├── internal-ordering: -1
  ├── ordering: -1
  ├── sort
  │    ├── columns: a:1(int!null)
@@ -679,6 +684,7 @@ SELECT a FROM abc ORDER BY a DESC LIMIT 1
 ----
 limit
  ├── columns: a:1(int!null)
+ ├── internal-ordering: -1
  ├── ordering: -1
  ├── sort
  │    ├── columns: a:1(int!null)
@@ -694,6 +700,7 @@ SELECT a FROM abc ORDER BY a DESC OFFSET 1
 ----
 offset
  ├── columns: a:1(int!null)
+ ├── internal-ordering: -1
  ├── ordering: -1
  ├── sort
  │    ├── columns: a:1(int!null)
@@ -902,6 +909,7 @@ SELECT block_id,writer_id,block_num,block_id FROM blocks ORDER BY block_id, writ
 ----
 limit
  ├── columns: block_id:1(int!null) writer_id:2(string!null) block_num:3(int!null) block_id:1(int!null)
+ ├── internal-ordering: +1,+2,+3
  ├── ordering: +1,+2,+3
  ├── project
  │    ├── columns: block_id:1(int!null) writer_id:2(string!null) block_num:3(int!null)

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -826,6 +826,7 @@ project
            ├── subquery [type=int[]]
            │    └── scalar-group-by
            │         ├── columns: array_agg:3(int[])
+           │         ├── internal-ordering: +2
            │         ├── scan x
            │         │    ├── columns: a:2(int!null)
            │         │    └── ordering: +2
@@ -896,6 +897,7 @@ project
            ├── subquery [type=int[]]
            │    └── scalar-group-by
            │         ├── columns: array_agg:2(int[])
+           │         ├── internal-ordering: -1
            │         ├── sort
            │         │    ├── columns: column1:1(int)
            │         │    ├── ordering: -1

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -349,6 +349,7 @@ SELECT * FROM xyzw ORDER BY 1 LIMIT '1'
 ----
 limit
  ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ ├── internal-ordering: +1
  ├── ordering: +1
  ├── scan xyzw
  │    ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
@@ -385,6 +386,7 @@ SELECT * FROM xyzw ORDER BY x OFFSET 1 + 0.0
 ----
 offset
  ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ ├── internal-ordering: +1
  ├── ordering: +1
  ├── scan xyzw
  │    ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
@@ -417,6 +419,7 @@ SELECT * FROM xyzw ORDER BY x LIMIT 1
 ----
 limit
  ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ ├── internal-ordering: +1
  ├── ordering: +1
  ├── scan xyzw
  │    ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
@@ -428,9 +431,11 @@ SELECT * FROM xyzw ORDER BY x LIMIT 1 OFFSET 1
 ----
 limit
  ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ ├── internal-ordering: +1
  ├── ordering: +1
  ├── offset
  │    ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ │    ├── internal-ordering: +1
  │    ├── ordering: +1
  │    ├── scan xyzw
  │    │    ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
@@ -443,6 +448,7 @@ SELECT * FROM xyzw ORDER BY y OFFSET 1
 ----
 offset
  ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ ├── internal-ordering: +2
  ├── ordering: +2
  ├── sort
  │    ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
@@ -456,9 +462,11 @@ SELECT * FROM xyzw ORDER BY y OFFSET 1 LIMIT 1
 ----
 limit
  ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ ├── internal-ordering: +2
  ├── ordering: +2
  ├── offset
  │    ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ │    ├── internal-ordering: +2
  │    ├── ordering: +2
  │    ├── sort
  │    │    ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -1248,6 +1248,7 @@ SELECT x FROM xyz ORDER BY x OFFSET (SELECT x FROM xyz WHERE x = 1)
 ----
 offset
  ├── columns: x:1(int!null)
+ ├── internal-ordering: +1
  ├── ordering: +1
  ├── project
  │    ├── columns: xyz.x:1(int!null)
@@ -1891,6 +1892,7 @@ select
                           ├── columns: max:11(string)
                           └── limit
                                ├── columns: a.i:7(int) max:11(string)
+                               ├── internal-ordering: +7
                                ├── sort
                                │    ├── columns: a.i:7(int) max:11(string)
                                │    ├── ordering: +7

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -209,6 +209,7 @@ build
 ----
 limit
  ├── columns: column1:3(int)
+ ├── internal-ordering: -3
  ├── ordering: -3
  ├── sort
  │    ├── columns: column1:3(int)
@@ -245,6 +246,7 @@ VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1) ORDER BY 1 DESC LI
 ----
 limit
  ├── columns: column1:3(int)
+ ├── internal-ordering: -3
  ├── ordering: -3
  ├── sort
  │    ├── columns: column1:3(int)
@@ -551,6 +553,7 @@ build
 ----
 limit
  ├── columns: v:7(int)
+ ├── internal-ordering: -7
  ├── ordering: -7
  ├── sort
  │    ├── columns: v:7(int)
@@ -587,6 +590,7 @@ SELECT v FROM uniontest WHERE k = 1 UNION ALL SELECT v FROM uniontest WHERE k = 
 ----
 limit
  ├── columns: v:7(int)
+ ├── internal-ordering: -7
  ├── ordering: -7
  ├── sort
  │    ├── columns: v:7(int)

--- a/pkg/sql/opt/optbuilder/testdata/values
+++ b/pkg/sql/opt/optbuilder/testdata/values
@@ -32,6 +32,7 @@ VALUES (1), (1), (2), (3) ORDER BY 1 DESC LIMIT 3
 ----
 limit
  ├── columns: column1:1(int)
+ ├── internal-ordering: -1
  ├── ordering: -1
  ├── sort
  │    ├── columns: column1:1(int)

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -195,9 +195,10 @@ func (c *coster) computeVirtualScanCost(
 // rowSortCost is the CPU cost to sort one row, which depends on the number of
 // columns in the sort key.
 func (c *coster) rowSortCost(numKeyCols int) memo.Cost {
-	// We multiply by 2 to ensure that a sort is almost always
-	// more expensive than a reverse scan or an index scan.
-	return 2 * memo.Cost(numKeyCols) * cpuCostFactor
+	// There is a fixed "non-comparison" cost and a comparison cost proportional
+	// to the key columns. Note that the cost has to be high enough so that a
+	// sort is almost always more expensive than a reverse scan or an index scan.
+	return (1 + memo.Cost(numKeyCols)) * cpuCostFactor
 }
 
 // rowScanCost is the CPU cost to scan one row, which depends on the number of

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -334,6 +334,10 @@ func (c *coster) computeGroupByCost(candidate *memo.BestExpr, logical *props.Log
 	def := candidate.Private(c.mem).(*memo.GroupByDef)
 	groupingColCount := def.GroupingCols.Len()
 	cost += memo.Cost(inputRowCount) * memo.Cost(aggsCount+groupingColCount) * cpuCostFactor
+
+	// TODO(radu): take into account how many grouping columns we have an ordering
+	// on for DistinctOn.
+
 	return cost + c.computeChildrenCost(candidate)
 }
 

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -280,11 +280,13 @@ left-join (merge)
  │    ├── ordering: +1
  │    └── limit
  │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+ │         ├── internal-ordering: +1
  │         ├── key: (1)
  │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │         ├── ordering: +1
  │         ├── offset
  │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+ │         │    ├── internal-ordering: +1
  │         │    ├── key: (1)
  │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │         │    ├── ordering: +1
@@ -460,11 +462,13 @@ left-join (lookup flavor_extra_specs)
  │    │    ├── ordering: +7 opt(11)
  │    │    └── limit
  │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+ │    │         ├── internal-ordering: +7 opt(11)
  │    │         ├── key: (1)
  │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
  │    │         ├── ordering: +7 opt(11)
  │    │         ├── offset
  │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+ │    │         │    ├── internal-ordering: +7 opt(11)
  │    │         │    ├── key: (1)
  │    │         │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
  │    │         │    ├── ordering: +7 opt(11)
@@ -713,10 +717,12 @@ sort
       │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
       │    └── limit
       │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         ├── internal-ordering: +7,+1
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
       │         ├── offset
       │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    ├── internal-ordering: +7,+1
       │         │    ├── key: (1)
       │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
       │         │    ├── ordering: +7,+1
@@ -1656,10 +1662,12 @@ sort
       │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │    └── limit
       │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │         ├── internal-ordering: +7
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         ├── offset
       │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │         │    ├── internal-ordering: +7
       │         │    ├── key: (1)
       │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         │    ├── ordering: +7
@@ -1833,10 +1841,12 @@ sort
       │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
       │    └── limit
       │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         ├── internal-ordering: +7,+1
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
       │         ├── offset
       │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    ├── internal-ordering: +7,+1
       │         │    ├── key: (1)
       │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
       │         │    ├── ordering: +7,+1
@@ -2301,10 +2311,12 @@ sort
       │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
       │    └── limit
       │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         ├── internal-ordering: +7,+1
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
       │         ├── offset
       │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    ├── internal-ordering: +7,+1
       │         │    ├── key: (1)
       │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
       │         │    ├── ordering: +7,+1
@@ -2463,10 +2475,12 @@ sort
       │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │    └── limit
       │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │         ├── internal-ordering: +7
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         ├── offset
       │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │         │    ├── internal-ordering: +7
       │         │    ├── key: (1)
       │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         │    ├── ordering: +7
@@ -2635,11 +2649,13 @@ left-join (lookup instance_type_extra_specs)
  │    │    ├── ordering: +7,+1 opt(11)
  │    │    └── limit
  │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+ │    │         ├── internal-ordering: +7,+1 opt(11)
  │    │         ├── key: (1)
  │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
  │    │         ├── ordering: +7,+1 opt(11)
  │    │         ├── offset
  │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+ │    │         │    ├── internal-ordering: +7,+1 opt(11)
  │    │         │    ├── key: (1)
  │    │         │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
  │    │         │    ├── ordering: +7,+1 opt(11)
@@ -2897,10 +2913,12 @@ sort
       │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
       │    └── limit
       │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         ├── internal-ordering: +13,+1
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
       │         ├── offset
       │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    ├── internal-ordering: +13,+1
       │         │    ├── key: (1)
       │         │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
       │         │    ├── ordering: +13,+1
@@ -3210,6 +3228,7 @@ sort
       │    ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15)
       │    └── limit
       │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │         ├── internal-ordering: +7
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)
       │         ├── sort

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -1046,7 +1046,7 @@ ORDER BY no_w_id, no_d_id
 sort
  ├── columns: max:4(int)
  ├── stats: [rows=100, distinct(2,3)=100]
- ├── cost: 98128.5754
+ ├── cost: 98121.9316
  ├── key: (2,3)
  ├── fd: (2,3)-->(4)
  ├── ordering: +3,+2
@@ -1079,7 +1079,7 @@ ORDER BY o_w_id, o_d_id
 sort
  ├── columns: max:9(int)
  ├── stats: [rows=100, distinct(2,3)=100]
- ├── cost: 330028.575
+ ├── cost: 330021.932
  ├── key: (2,3)
  ├── fd: (2,3)-->(9)
  ├── ordering: +3,+2
@@ -1170,7 +1170,7 @@ ORDER BY o_w_id, o_d_id
 sort
  ├── columns: sum:9(decimal)
  ├── stats: [rows=100, distinct(2,3)=100]
- ├── cost: 342028.575
+ ├── cost: 342021.932
  ├── key: (2,3)
  ├── fd: (2,3)-->(9)
  ├── ordering: +3,+2
@@ -1202,7 +1202,7 @@ ORDER BY ol_w_id, ol_d_id
 sort
  ├── columns: count:11(int)
  ├── stats: [rows=100, distinct(2,3)=100]
- ├── cost: 1100028.58
+ ├── cost: 1100021.93
  ├── key: (2,3)
  ├── fd: (2,3)-->(11)
  ├── ordering: +3,+2

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -851,7 +851,7 @@ ORDER BY no_w_id, no_d_id
 sort
  ├── columns: max:4(int)
  ├── stats: [rows=1000, distinct(2,3)=1000]
- ├── cost: 1508.63137
+ ├── cost: 1408.97353
  ├── key: (2,3)
  ├── fd: (2,3)-->(4)
  ├── ordering: +3,+2
@@ -884,7 +884,7 @@ ORDER BY o_w_id, o_d_id
 sort
  ├── columns: max:9(int)
  ├── stats: [rows=1000, distinct(2,3)=1000]
- ├── cost: 1518.63137
+ ├── cost: 1418.97353
  ├── key: (2,3)
  ├── fd: (2,3)-->(9)
  ├── ordering: +3,+2
@@ -975,7 +975,7 @@ ORDER BY o_w_id, o_d_id
 sort
  ├── columns: sum:9(decimal)
  ├── stats: [rows=1000, distinct(2,3)=1000]
- ├── cost: 1558.63137
+ ├── cost: 1458.97353
  ├── key: (2,3)
  ├── fd: (2,3)-->(9)
  ├── ordering: +3,+2
@@ -1007,7 +1007,7 @@ ORDER BY ol_w_id, ol_d_id
 sort
  ├── columns: count:11(int)
  ├── stats: [rows=1000, distinct(2,3)=1000]
- ├── cost: 1518.63137
+ ├── cost: 1418.97353
  ├── key: (2,3)
  ├── fd: (2,3)-->(11)
  ├── ordering: +3,+2

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -354,6 +354,7 @@ project
  ├── ordering: -15,+23,+11,+1
  └── limit
       ├── columns: p_partkey:1(int) p_mfgr:3(string) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_nationkey:13(int!null) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string) nation.n_nationkey:22(int!null) nation.n_name:23(string) nation.n_regionkey:24(int!null) region.r_regionkey:26(int!null) region.r_name:27(string!null)
+      ├── internal-ordering: -15,+23,+11,+1 opt(27)
       ├── cardinality: [0 - 100]
       ├── fd: ()-->(27), (1)-->(3), (22)-->(23,24), (13)==(22), (22)==(13), (24)==(26), (26)==(24)
       ├── ordering: -15,+23,+11,+1 opt(27)
@@ -546,6 +547,7 @@ LIMIT 10;
 ----
 limit
  ├── columns: l_orderkey:18(int!null) revenue:35(float) o_orderdate:13(date) o_shippriority:16(int)
+ ├── internal-ordering: -35,+13
  ├── cardinality: [0 - 10]
  ├── key: (18)
  ├── fd: (18)-->(13,16,35)
@@ -1340,6 +1342,7 @@ LIMIT 20;
 ----
 limit
  ├── columns: c_custkey:1(int!null) c_name:2(string) revenue:39(float) c_acctbal:6(float) n_name:35(string) c_address:3(string) c_phone:5(string) c_comment:8(string)
+ ├── internal-ordering: -39
  ├── cardinality: [0 - 20]
  ├── key: (1)
  ├── fd: (1)-->(2,3,5,6,8,35,39)
@@ -2236,6 +2239,7 @@ LIMIT 100;
 ----
 limit
  ├── columns: c_name:2(string) c_custkey:1(int) o_orderkey:9(int!null) o_orderdate:13(date) o_totalprice:12(float) sum:51(float)
+ ├── internal-ordering: -12,+13
  ├── cardinality: [0 - 100]
  ├── key: (9)
  ├── fd: (1)-->(2), (9)-->(1,2,12,13,51)
@@ -2574,6 +2578,7 @@ LIMIT 100;
 ----
 limit
  ├── columns: s_name:2(string) numwait:69(int)
+ ├── internal-ordering: -69,+2
  ├── cardinality: [0 - 100]
  ├── key: (2)
  ├── fd: (2)-->(69)

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -251,6 +251,7 @@ SELECT array_agg(z) FROM (SELECT * FROM a ORDER BY y)
 ----
 scalar-group-by
  ├── columns: array_agg:5(decimal[])
+ ├── internal-ordering: +2
  ├── sort
  │    ├── columns: y:2(float!null) z:3(decimal)
  │    ├── ordering: +2
@@ -265,6 +266,7 @@ SELECT array_agg(x) FROM (SELECT * FROM a ORDER BY x, y DESC)
 ----
 scalar-group-by
  ├── columns: array_agg:5(int[])
+ ├── internal-ordering: +1,-2
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(float!null)
  │    └── ordering: +1,-2
@@ -655,6 +657,7 @@ SELECT * FROM abc WHERE a+b>c ORDER BY a, b LIMIT 10
 ----
 limit
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── internal-ordering: +1,+2
  ├── ordering: +1,+2
  ├── select
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
@@ -671,6 +674,7 @@ SELECT * FROM abc ORDER BY a, b OFFSET 10
 ----
 offset
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── internal-ordering: +1,+2
  ├── ordering: +1,+2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
@@ -699,6 +703,7 @@ sort
  ├── ordering: +2
  └── limit
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      ├── internal-ordering: +1,+2
       ├── select
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
       │    ├── ordering: +1,+2
@@ -717,6 +722,7 @@ sort
  ├── ordering: +2
  └── offset
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      ├── internal-ordering: +1,+2
       ├── scan abc
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
       │    └── ordering: +1,+2
@@ -739,6 +745,7 @@ SELECT * FROM (SELECT * FROM abc WHERE a+b>c ORDER BY a, b LIMIT 10) ORDER BY a
 ----
 limit
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── internal-ordering: +1,+2
  ├── ordering: +1
  ├── select
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
@@ -755,6 +762,7 @@ SELECT * FROM (SELECT * FROM abc ORDER BY a, b OFFSET 10) ORDER BY a
 ----
 offset
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── internal-ordering: +1,+2
  ├── ordering: +1
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
@@ -777,6 +785,7 @@ SELECT * FROM (SELECT * FROM abc WHERE a+b>c ORDER BY a, b LIMIT 10) ORDER BY a,
 ----
 limit
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── internal-ordering: +1,+2
  ├── ordering: +1,+2,+3
  ├── select
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
@@ -793,6 +802,7 @@ SELECT * FROM (SELECT * FROM abc ORDER BY a, b OFFSET 10) ORDER BY a, b, c
 ----
 offset
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── internal-ordering: +1,+2
  ├── ordering: +1,+2,+3
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
@@ -852,6 +862,7 @@ sort
  └── distinct-on
       ├── columns: a:1(int) b:2(int!null) c:3(int!null)
       ├── grouping columns: b:2(int!null) c:3(int!null)
+      ├── internal-ordering: +1 opt(2,3)
       ├── scan abc
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
       │    └── ordering: +1 opt(2,3)
@@ -865,6 +876,7 @@ SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
 distinct-on
  ├── columns: a:1(int!null) c:3(int)
  ├── grouping columns: a:1(int!null)
+ ├── internal-ordering: -3,+2 opt(1)
  ├── ordering: +1
  ├── sort
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
@@ -926,6 +938,7 @@ SELECT * FROM (SELECT DISTINCT ON (b, c) a, b, c FROM abc ORDER BY c, b, a) ORDE
 distinct-on
  ├── columns: a:1(int) b:2(int!null) c:3(int!null)
  ├── grouping columns: b:2(int!null) c:3(int!null)
+ ├── internal-ordering: +1 opt(2,3)
  ├── ordering: +1
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
@@ -945,6 +958,7 @@ sort
  └── distinct-on
       ├── columns: a:1(int) b:2(int!null) c:3(int)
       ├── grouping columns: b:2(int!null)
+      ├── internal-ordering: +3 opt(2)
       ├── sort
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
       │    ├── ordering: +3 opt(2)
@@ -966,6 +980,7 @@ sort
  └── distinct-on
       ├── columns: a:1(int!null) b:2(int) c:3(int)
       ├── grouping columns: a:1(int!null)
+      ├── internal-ordering: +2 opt(1)
       ├── scan abc
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
       │    └── ordering: +2 opt(1)

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -818,7 +818,7 @@ sort
       └── scan abc
            └── columns: b:2(int!null) c:3(int!null)
 
-# In this case the ordeirng is passed through.
+# In this case the ordering is passed through.
 opt
 SELECT DISTINCT a, b, c FROM abc ORDER BY a, b
 ----
@@ -831,36 +831,51 @@ scan abc
 opt
 SELECT DISTINCT ON (b, c) a, b, c FROM abc ORDER BY b
 ----
-distinct-on
+sort
  ├── columns: a:1(int) b:2(int!null) c:3(int!null)
- ├── grouping columns: b:2(int!null) c:3(int!null)
  ├── ordering: +2
- ├── sort
- │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
- │    ├── ordering: +2
- │    └── scan abc
- │         └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
- └── aggregations
-      └── first-agg [type=int]
-           └── variable: abc.a [type=int]
+ └── distinct-on
+      ├── columns: a:1(int) b:2(int!null) c:3(int!null)
+      ├── grouping columns: b:2(int!null) c:3(int!null)
+      ├── scan abc
+      │    └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      └── aggregations
+           └── first-agg [type=int]
+                └── variable: abc.a [type=int]
 
 opt
 SELECT DISTINCT ON (b, c) a, b, c FROM abc ORDER BY b, c, a
 ----
-distinct-on
+sort
  ├── columns: a:1(int) b:2(int!null) c:3(int!null)
- ├── grouping columns: b:2(int!null) c:3(int!null)
  ├── ordering: +2,+3
+ └── distinct-on
+      ├── columns: a:1(int) b:2(int!null) c:3(int!null)
+      ├── grouping columns: b:2(int!null) c:3(int!null)
+      ├── scan abc
+      │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    └── ordering: +1 opt(2,3)
+      └── aggregations
+           └── first-agg [type=int]
+                └── variable: abc.a [type=int]
+
+opt
+SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
+----
+distinct-on
+ ├── columns: a:1(int!null) c:3(int)
+ ├── grouping columns: a:1(int!null)
+ ├── ordering: +1
  ├── sort
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
- │    ├── ordering: +2,+3,+1
+ │    ├── ordering: +1,-3,+2
  │    └── scan abc
  │         └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  └── aggregations
       └── first-agg [type=int]
-           └── variable: abc.a [type=int]
+           └── variable: abc.c [type=int]
 
-# Pass through a stronger ordering from above.
+# Pass through the ordering from above.
 opt
 SELECT * FROM (SELECT DISTINCT ON (a, b) a, b, c FROM abc) ORDER BY a
 ----
@@ -875,6 +890,7 @@ distinct-on
       └── first-agg [type=int]
            └── variable: abc.c [type=int]
 
+# Internal orderings that refer just to ON columns can be ignored.
 opt
 SELECT * FROM (SELECT DISTINCT ON (a, b) a, b, c FROM abc ORDER BY a) ORDER BY a, b
 ----
@@ -889,7 +905,6 @@ distinct-on
       └── first-agg [type=int]
            └── variable: abc.c [type=int]
 
-# Pass down the internal ordering if it is stronger.
 opt
 SELECT * FROM (SELECT DISTINCT ON (a, b) a, b, c FROM abc ORDER BY a, b) ORDER BY a
 ----
@@ -899,26 +914,63 @@ distinct-on
  ├── ordering: +1
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
- │    └── ordering: +1,+2
+ │    └── ordering: +1
  └── aggregations
       └── first-agg [type=int]
            └── variable: abc.c [type=int]
 
-# Can't pass down incompatible ordering.
+# The c,b part of the inner ordering can be ignored.
 opt
-SELECT * FROM (SELECT DISTINCT ON(b, c) a, b, c FROM abc ORDER BY b, c) ORDER BY c
+SELECT * FROM (SELECT DISTINCT ON (b, c) a, b, c FROM abc ORDER BY c, b, a) ORDER BY a
+----
+distinct-on
+ ├── columns: a:1(int) b:2(int!null) c:3(int!null)
+ ├── grouping columns: b:2(int!null) c:3(int!null)
+ ├── ordering: +1
+ ├── scan abc
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    └── ordering: +1
+ └── aggregations
+      └── first-agg [type=int]
+           └── variable: abc.a [type=int]
+
+# There is no ordering that satisfies both the intra-group ordering of c+ and the
+# inter-group ordering of a+; we have to sort twice.
+opt
+SELECT * FROM (SELECT DISTINCT ON (b) a, b, c FROM abc ORDER BY b, c) ORDER BY a
 ----
 sort
- ├── columns: a:1(int) b:2(int!null) c:3(int!null)
- ├── ordering: +3
+ ├── columns: a:1(int) b:2(int!null) c:3(int)
+ ├── ordering: +1
  └── distinct-on
-      ├── columns: a:1(int) b:2(int!null) c:3(int!null)
-      ├── grouping columns: b:2(int!null) c:3(int!null)
+      ├── columns: a:1(int) b:2(int!null) c:3(int)
+      ├── grouping columns: b:2(int!null)
       ├── sort
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
-      │    ├── ordering: +2,+3
+      │    ├── ordering: +3 opt(2)
       │    └── scan abc
       │         └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
       └── aggregations
+           ├── first-agg [type=int]
+           │    └── variable: abc.a [type=int]
            └── first-agg [type=int]
-                └── variable: abc.a [type=int]
+                └── variable: abc.c [type=int]
+
+# Same as above, except we can use the index ordering for the distinct input.
+opt
+SELECT * FROM (SELECT DISTINCT ON (a) a, b, c FROM abc ORDER BY a, b) ORDER BY c
+----
+sort
+ ├── columns: a:1(int!null) b:2(int) c:3(int)
+ ├── ordering: +3
+ └── distinct-on
+      ├── columns: a:1(int!null) b:2(int) c:3(int)
+      ├── grouping columns: a:1(int!null)
+      ├── scan abc
+      │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    └── ordering: +2 opt(1)
+      └── aggregations
+           ├── first-agg [type=int]
+           │    └── variable: abc.b [type=int]
+           └── first-agg [type=int]
+                └── variable: abc.c [type=int]

--- a/pkg/sql/opt/xform/testdata/ruleprops/orderings
+++ b/pkg/sql/opt/xform/testdata/ruleprops/orderings
@@ -126,11 +126,10 @@ group-by
  ├── key: (2,3)
  ├── fd: (3)~~>(2), (2,3)-->(5)
  ├── prune: (5)
- ├── interesting orderings: (+2)
  ├── sort
  │    ├── columns: a:1(int) b:2(int) c:3(int)
  │    ├── fd: (3)~~>(1,2)
- │    ├── ordering: +2,+1
+ │    ├── ordering: +1 opt(2,3)
  │    ├── prune: (1-3)
  │    └── scan abc
  │         ├── columns: a:1(int) b:2(int) c:3(int)

--- a/pkg/sql/opt/xform/testdata/ruleprops/orderings
+++ b/pkg/sql/opt/xform/testdata/ruleprops/orderings
@@ -123,6 +123,7 @@ SELECT array_agg(a), b, c FROM (SELECT * FROM abc ORDER BY b, a) GROUP BY b, c
 group-by
  ├── columns: array_agg:5(int[]) b:2(int) c:3(int)
  ├── grouping columns: b:2(int) c:3(int)
+ ├── internal-ordering: +1 opt(2,3)
  ├── key: (2,3)
  ├── fd: (3)~~>(2), (2,3)-->(5)
  ├── prune: (5)
@@ -204,6 +205,7 @@ SELECT * FROM abc ORDER BY b LIMIT 10
 ----
 limit
  ├── columns: a:1(int) b:2(int) c:3(int)
+ ├── internal-ordering: +2
  ├── cardinality: [0 - 10]
  ├── fd: (3)~~>(1,2)
  ├── ordering: +2
@@ -225,6 +227,7 @@ SELECT * FROM abc ORDER BY a OFFSET 10
 ----
 offset
  ├── columns: a:1(int) b:2(int) c:3(int)
+ ├── internal-ordering: +1
  ├── fd: (3)~~>(1,2)
  ├── ordering: +1
  ├── prune: (2,3)

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -69,6 +69,7 @@ SELECT s FROM (SELECT s, i FROM a ORDER BY s LIMIT 10) a ORDER BY s, i LIMIT 1
 ----
 limit
  ├── columns: s:4(string)
+ ├── internal-ordering: +4,+2
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(2,4)
@@ -87,6 +88,7 @@ SELECT s FROM a ORDER BY f LIMIT 1
 ----
 limit
  ├── columns: s:4(string)
+ ├── internal-ordering: +3
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(3,4)
@@ -174,6 +176,7 @@ SELECT * FROM kuv WHERE u > 1 AND u < 10 ORDER BY u, v LIMIT 5
 ----
 limit
  ├── columns: k:1(int!null) u:2(int!null) v:3(int)
+ ├── internal-ordering: +2,+3
  ├── cardinality: [0 - 5]
  ├── key: (1)
  ├── fd: (1)-->(2,3)

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -44,6 +44,7 @@ SELECT k,f FROM a ORDER BY f DESC, k ASC LIMIT 10
 ----
 limit
  ├── columns: k:1(int!null) f:3(float)
+ ├── internal-ordering: -3,+1
  ├── cardinality: [0 - 10]
  ├── key: (1)
  ├── fd: (1)-->(3)

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -230,14 +230,14 @@ memo (optimized)
  │    │    └── cost: 1070.00
  │    └── "[ordering: +4,+1]"
  │         ├── best: (sort G2)
- │         └── cost: 1478.63
+ │         └── cost: 1378.97
  └── G3: (scan a@si_idx,rev,cols=(1,2,4))
       ├── ""
       │    ├── best: (scan a@si_idx,rev,cols=(1,2,4))
       │    └── cost: 1169.66
       └── "[ordering: +4,+1]"
            ├── best: (sort G3)
-           └── cost: 1578.29
+           └── cost: 1478.63
 
 exploretrace rule=GenerateIndexScans
 SELECT s, i, f FROM a ORDER BY s, k, i
@@ -345,7 +345,7 @@ memo (optimized)
  ├── G1: (scan a,cols=(2-4)) (scan a,rev,cols=(2-4)) (scan a@s_idx,cols=(2-4)) (scan a@s_idx,rev,cols=(2-4)) (index-join G2 a,cols=(2-4)) (index-join G3 a,cols=(2-4))
  │    ├── "[presentation: s:4,i:2,f:3] [ordering: -4,+2]"
  │    │    ├── best: (sort G1)
- │    │    └── cost: 1478.63
+ │    │    └── cost: 1378.97
  │    └── ""
  │         ├── best: (scan a@s_idx,cols=(2-4))
  │         └── cost: 1070.00
@@ -355,14 +355,14 @@ memo (optimized)
  │    │    └── cost: 1070.00
  │    └── "[ordering: -4,+2]"
  │         ├── best: (sort G2)
- │         └── cost: 1478.63
+ │         └── cost: 1378.97
  └── G3: (scan a@si_idx,rev,cols=(1,2,4))
       ├── ""
       │    ├── best: (scan a@si_idx,rev,cols=(1,2,4))
       │    └── cost: 1169.66
       └── "[ordering: -4,+2]"
            ├── best: (sort G3)
-           └── cost: 1578.29
+           └── cost: 1478.63
 
 exec-ddl
 CREATE TABLE abc (
@@ -567,7 +567,7 @@ memo (optimized)
  └── G1: (scan a,cols=(1,2,4)) (scan a,rev,cols=(1,2,4)) (scan a@s_idx,cols=(1,2,4)) (scan a@s_idx,rev,cols=(1,2,4)) (scan a@si_idx,cols=(1,2,4)) (scan a@si_idx,rev,cols=(1,2,4))
       ├── "[presentation: i:2,k:1] [ordering: -4,+2,+1]"
       │    ├── best: (sort G1)
-      │    └── cost: 1677.95
+      │    └── cost: 1478.63
       └── ""
            ├── best: (scan a@s_idx,cols=(1,2,4))
            └── cost: 1070.00


### PR DESCRIPTION
#### opt: adjust cost of sort

The cost of sort is proportional to the amount of columns we are
sorting on. A single sort on three columns has the same cost as two
sorts (one on a single column and one on two columns), even though
it's clearly preferable to sort once.

This change adjusts the formula so it has a term that accounts for the
non-comparison cost.

A follow-up commit adds testcases with DISTINCT ON which would have
two sorts without this change.

Release note: None

#### opt: make DISTINCT ON columns optional in the internal ordering

The purpose of the DistinctOn internal ordering is to determine the
intra-group ordering; this change makes all the grouping columns be
optional columns in the ordering.

Release note: None

#### opt: add grouping columns as optional columns to GroupBy ordering

Similar to DistinctOn, the internal ordering in GroupBy is used for
intra-group ordering. We add the grouping columns as optional.

Release note: None

#### opt: output internal-ordering field in expressions

Now that the internal ordering is not always identical to the required
ordering on the input, display the internal ordering for Limit,
Offset, and GroupBy variations.

Release note: None