### PR TITLE
sqlbase: preserve HasNulls during array decoding

### DIFF
--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1558,6 +1558,7 @@ func decodeArray(a *DatumAlloc, elementType types.T, b []byte) (tree.Datum, []by
 	for i := uint64(0); i < header.length; i++ {
 		if header.isNull(i) {
 			result.Array[i] = tree.DNull
+			result.HasNulls = true
 		} else {
 			val, b, err = decodeUntaggedDatum(a, elementType, b)
 			if err != nil {

--- a/pkg/sql/sqlbase/table_test.go
+++ b/pkg/sql/sqlbase/table_test.go
@@ -361,6 +361,10 @@ func TestArrayEncoding(t *testing.T) {
 			enc = append(enc, byte(len(test.encoding)))
 			enc = append(enc, test.encoding...)
 			d, _, err := decodeArray(&DatumAlloc{}, test.datum.ParamTyp, enc)
+			hasNulls := d.(*tree.DArray).HasNulls
+			if test.datum.HasNulls != hasNulls {
+				t.Fatalf("expected %v to have HasNulls=%t, got %t", enc, test.datum.HasNulls, hasNulls)
+			}
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Previously, decoding an array with nulls would produce a DArray without
its HasNulls bit set. Correct that issue.

Release note: None