### PR TITLE
storage: don't return status error on rollbacks

### DIFF
--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -1398,7 +1398,7 @@ func (txn *Txn) GenerateForcedRetryableError(msg string) error {
 		txn.ID(),
 		roachpb.MakeTransaction(
 			txn.DebugName(),
-			nil, // aseKey
+			nil, // baseKey
 			txn.UserPriority(),
 			txn.Isolation(),
 			txn.db.clock.Now(),

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -705,10 +705,10 @@ DELETE FROM t.test3;
 								// client sends an async EndTransaction. However, with
 								// concurrent uses of the txn, it's possible for that cleanup to
 								// race with the BeginTransaction. If the cleanup wins the race,
-								// it gets a "transaction not found" error, and then the
-								// BeginTransaction succeeds and nobody cleans it up. Again, if
-								// the txn had actually been aborted, the transaction record
-								// would already be in place.
+								// it succeeds (even though it doesn't find the txn record), and
+								// then the BeginTransaction also succeeds and nobody cleans it
+								// up. Again, if the txn had actually been aborted, the
+								// transaction record would already be in place.
 								if _, ok := err.(*roachpb.TransactionAbortedError); ok {
 									// We use a WaitGroup to make sure this async abort cleans up
 									// before the subtest.


### PR DESCRIPTION
Before this patch, EndTransaction(commit=false) would return
TransactionStatusError if the txn record was not found (just like a
commit). This patch makes it return success (and an unmodified txn proto
in the response).
The motivation is that the client is routinely sending rollbacks in
situations where it's unclear whether the txn record has previously been
written successfully. We currently mostly swallow those errors on the
client, but that code is ugly and incomplete - the client sometimes turn
commits into rollbacks if all writes have been performed at an old
epoch. In that case we have a problem because, if the rollback encouters
the error, we might not have the responses for other requests in its
batch. So, I will take the client out of the business of massaging
these errors.

Release note: none