### PR TITLE
ui: remove "DistSQL Reads" series from QPS graphs

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -20,8 +20,7 @@ export default function (props: GraphDashboardProps) {
       }
     >
       <Axis label="queries">
-        <Metric name="cr.node.sql.select.count" title="Total Reads" nonNegativeRate />
-        <Metric name="cr.node.sql.distsql.select.count" title="DistSQL Reads" nonNegativeRate />
+        <Metric name="cr.node.sql.select.count" title="Selects" nonNegativeRate />
         <Metric name="cr.node.sql.update.count" title="Updates" nonNegativeRate />
         <Metric name="cr.node.sql.insert.count" title="Inserts" nonNegativeRate />
         <Metric name="cr.node.sql.delete.count" title="Deletes" nonNegativeRate />

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -42,8 +42,7 @@ export default function (props: GraphDashboardProps) {
       }
     >
       <Axis label="queries">
-        <Metric name="cr.node.sql.select.count" title="Total Reads" nonNegativeRate />
-        <Metric name="cr.node.sql.distsql.select.count" title="DistSQL Reads" nonNegativeRate />
+        <Metric name="cr.node.sql.select.count" title="Selects" nonNegativeRate />
         <Metric name="cr.node.sql.update.count" title="Updates" nonNegativeRate />
         <Metric name="cr.node.sql.insert.count" title="Inserts" nonNegativeRate />
         <Metric name="cr.node.sql.delete.count" title="Deletes" nonNegativeRate />


### PR DESCRIPTION
...and rename "total reads" to "selects" to match the other graphs,
which are labeled "inserts", "updates", and "deletes".

DistSQL vs non-DistSQL is too much of an implementation detail to show
here, and the two engines are about to be merged anyway.

Fixes #23847

Now: ("Before" image in issue)
![image](https://user-images.githubusercontent.com/7341/43797317-02a143b2-9a55-11e8-8075-3235c39a6ef8.png)

Release note (admin ui change): remove "distsql reads" time series from
chart on the SQL dashboard, since execution engines are being merged.