### PR TITLE
importccl: support Cockroach Dump in IMPORT PGDUMP

### DIFF
--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -350,6 +350,8 @@ func readPostgresCreateTable(
 						def.DefaultExpr.Expr = cmd.Default
 						create.Defs[i] = def
 					}
+				case *tree.AlterTableValidateConstraint:
+					// ignore
 				default:
 					return nil, errors.Errorf("unsupported statement: %s", stmt)
 				}

--- a/pkg/ccl/importccl/testdata/cockroachdump/dump.sql
+++ b/pkg/ccl/importccl/testdata/cockroachdump/dump.sql
@@ -1,0 +1,25 @@
+CREATE TABLE t (
+	i INT NOT NULL,
+	t STRING NULL,
+	CONSTRAINT "primary" PRIMARY KEY (i ASC),
+	INDEX t_t_idx (t ASC),
+	FAMILY "primary" (i, t)
+);
+
+CREATE TABLE a (
+	i INT NOT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (i ASC),
+	FAMILY "primary" (i)
+);
+
+INSERT INTO t (i, t) VALUES
+	(1, 'test'),
+	(2, 'other');
+
+INSERT INTO a (i) VALUES
+	(2);
+
+ALTER TABLE a ADD CONSTRAINT fk_i_ref_t FOREIGN KEY (i) REFERENCES t (i);
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+ALTER TABLE a VALIDATE CONSTRAINT fk_i_ref_t;


### PR DESCRIPTION
This requires ignoring VALIDATE CONSTRAINT statements, which is ok since
they are being added in the invalid state and we don't validate them.

Fixes #28008

Release note (sql change): Support CockroachDB dumps in IMPORT PGDUMP.