### PR TITLE
opt: don't set up FDs for synthesized columns on composite types

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -331,3 +331,43 @@ project
                                          └── eq [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
                                               ├── variable: xysd.x [type=int, outer=(8)]
                                               └── variable: kuv.k [type=int, outer=(1)]
+
+# We have the FD: y --> y::TEXT.
+build
+SELECT y, y::TEXT FROM xysd
+----
+project
+ ├── columns: y:2(int) y:5(string)
+ ├── stats: [rows=1000]
+ ├── fd: (2)-->(5)
+ ├── prune: (2,5)
+ ├── scan xysd
+ │    ├── columns: x:1(int!null) xysd.y:2(int) s:3(string) d:4(decimal!null)
+ │    ├── stats: [rows=1000]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ │    ├── prune: (1-4)
+ │    └── interesting orderings: (+1) (-3,+4,+1)
+ └── projections [outer=(2)]
+      └── cast: TEXT [type=string, outer=(2)]
+           └── variable: xysd.y [type=int, outer=(2)]
+
+# We don't have the FD: d --> d::TEXT because d is a composite type.
+# For example, d=1 is equal to d=1.0 but d::TEXT differs.
+build
+SELECT d, d::TEXT FROM xysd
+----
+project
+ ├── columns: d:4(decimal!null) d:5(string)
+ ├── stats: [rows=1000]
+ ├── prune: (4,5)
+ ├── scan xysd
+ │    ├── columns: x:1(int!null) y:2(int) s:3(string) xysd.d:4(decimal!null)
+ │    ├── stats: [rows=1000]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ │    ├── prune: (1-4)
+ │    └── interesting orderings: (+1) (-3,+4,+1)
+ └── projections [outer=(4)]
+      └── cast: TEXT [type=string, outer=(4)]
+           └── variable: xysd.d [type=decimal, outer=(4)]

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -165,7 +165,6 @@ SELECT f, f+1.1 AS r FROM (SELECT f, i FROM a GROUP BY f, i) a ORDER BY f LIMIT 
 project
  ├── columns: f:3(float) r:6(float)
  ├── cardinality: [0 - 5]
- ├── fd: (3)-->(6)
  ├── ordering: +3
  ├── limit
  │    ├── columns: i:2(int) f:3(float)
@@ -293,7 +292,6 @@ SELECT f, f+1.1 AS r FROM (SELECT f, i FROM a GROUP BY f, i) a ORDER BY f OFFSET
 ----
 project
  ├── columns: f:3(float) r:6(float)
- ├── fd: (3)-->(6)
  ├── ordering: +3
  ├── offset
  │    ├── columns: i:2(int) f:3(float)
@@ -348,7 +346,6 @@ SELECT f, f+1.1 AS r FROM (SELECT f, i FROM a GROUP BY f, i) a ORDER BY f OFFSET
 project
  ├── columns: f:3(float) r:6(float)
  ├── cardinality: [0 - 10]
- ├── fd: (3)-->(6)
  ├── ordering: +3
  ├── limit
  │    ├── columns: i:2(int) f:3(float)

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -279,7 +279,6 @@ SELECT f, f+1.1 AS r FROM (SELECT f, k FROM a GROUP BY f, k HAVING sum(k)=100) a
 ----
 project
  ├── columns: f:3(float) r:6(float)
- ├── fd: (3)-->(6)
  ├── select
  │    ├── columns: k:1(int!null) f:3(float) column5:5(decimal!null)
  │    ├── key: (1)
@@ -396,7 +395,6 @@ SELECT f, f*2.0 AS r FROM (SELECT f, s FROM a GROUP BY f, s LIMIT 5) a
 project
  ├── columns: f:3(float) r:5(float)
  ├── cardinality: [0 - 5]
- ├── fd: (3)-->(5)
  ├── limit
  │    ├── columns: f:3(float) s:4(string)
  │    ├── cardinality: [0 - 5]
@@ -616,7 +614,6 @@ SELECT f, f*2.0 AS r FROM (SELECT f, s FROM a GROUP BY f, s OFFSET 5 LIMIT 5) a
 project
  ├── columns: f:3(float) r:5(float)
  ├── cardinality: [0 - 5]
- ├── fd: (3)-->(5)
  ├── limit
  │    ├── columns: f:3(float) s:4(string)
  │    ├── cardinality: [0 - 5]

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -235,7 +235,6 @@ SELECT f, f+1.1 AS r FROM (SELECT f, i FROM a GROUP BY f, i HAVING sum(f)=10.0) 
 ----
 project
  ├── columns: f:3(float) r:7(float)
- ├── fd: (3)-->(7)
  ├── select
  │    ├── columns: i:2(int) f:3(float) column6:6(float!null)
  │    ├── key: (2,3)

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -254,7 +254,6 @@ sort
       ├── fd: (9,10)-->(17,18,20,22-26)
       ├── project
       │    ├── columns: column19:19(float) column21:21(float) l_quantity:5(float) l_extendedprice:6(float) l_discount:7(float) l_returnflag:9(string) l_linestatus:10(string)
-      │    ├── fd: (6,7)-->(19)
       │    ├── select
       │    │    ├── columns: l_quantity:5(float) l_extendedprice:6(float) l_discount:7(float) l_tax:8(float) l_returnflag:9(string) l_linestatus:10(string) l_shipdate:11(date!null)
       │    │    ├── scan lineitem


### PR DESCRIPTION
"Composite" types are those where two values can be equal and yet not
be identical, like collated strings or decimals (1 vs 1.0). We can't
set up an FD for arbitrary expressions involving these types; for
example, `d --> d::TEXT` is not correct because `d=1` and `d=1.0` are
equal but `d::TEXT` differs.

This change checks for composite types before adding FDs. This is a
pretty big hammer; in the future, we should add a whitelist of
operators that won't cause problems (e.g. arithmetic).

Fixes #28352.

Release note: None