### PR TITLE
sql: ceil no longer returns -0 for decimals

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -565,7 +565,7 @@ SELECT cbrt(-1.0::float), round(cbrt(27.0::float), 15), cbrt(19.3::decimal)
 query RRRRR
 SELECT ceil(-0.5::float), ceil(0.5::float), ceiling(0.5::float), ceil(0.1::decimal), ceiling(-0.9::decimal)
 ----
--0  1  1  1  -0
+-0  1  1  1  0
 
 query RR
 SELECT cos(-0.5), cos(0.5)
@@ -620,7 +620,7 @@ SELECT cbrt(-1.0::float), round(cbrt(27.0::float), 15), cbrt(19.3::decimal)
 query RRRRR
 SELECT ceil(-0.5::float), ceil(0.5::float), ceiling(0.5::float), ceil(0.1::decimal), ceiling(-0.9::decimal)
 ----
--0  1  1  1  -0
+-0  1  1  1  0
 
 query RR
 SELECT cos(-0.5), cos(0.5)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3009,6 +3009,9 @@ var ceilImpl = makeBuiltin(defProps(),
 	decimalOverload1(func(x *apd.Decimal) (tree.Datum, error) {
 		dd := &tree.DDecimal{}
 		_, err := tree.ExactCtx.Ceil(&dd.Decimal, x)
+		if dd.IsZero() {
+			dd.Negative = false
+		}
 		return dd, err
 	}, "Calculates the smallest integer greater than `val`."),
 )


### PR DESCRIPTION
This matches the postgres behavior (the float variant still returns -0
both here and in postgres).

Fixes #28363

Release note (sql change): The decimal variants of the ceil and ceiling
functions now return 0 where they would have returned -0 previously.