### PR TITLE
cli: make --host/--{listen,advertise,http}-addr recognize port numbers

### DIFF
--- a/pkg/acceptance/cli_test.go
+++ b/pkg/acceptance/cli_test.go
@@ -117,9 +117,9 @@ function finish() {
 trap finish EXIT
 
 HOST=$(hostname -f)
-$bin start --logtostderr=INFO --background --insecure --listen-addr="${HOST}" --listen-port=12345 &> out
-$bin sql --insecure --host="${HOST}" --port=12345 -e "show databases"
-$bin quit --insecure --host="${HOST}" --port=12345
+$bin start --logtostderr=INFO --background --insecure --listen-addr="${HOST}":12345 &> out
+$bin sql --insecure --host="${HOST}":12345 -e "show databases"
+$bin quit --insecure --host="${HOST}":12345
 `
 	containerConfig.Cmd = []string{"/bin/bash", "-c", script}
 	if err := testDockerOneShot(ctx, t, "start_flags_test", containerConfig); err != nil {

--- a/pkg/acceptance/cluster/cluster.go
+++ b/pkg/acceptance/cluster/cluster.go
@@ -43,7 +43,7 @@ type Cluster interface {
 	// dismantle the cluster.
 	AssertAndStop(context.Context, testing.TB)
 	// ExecCLI runs `./cockroach <args>`, while filling in required flags such as
-	// --insecure, --certs-dir, --host or --port.
+	// --insecure, --certs-dir, --host.
 	//
 	// Returns stdout, stderr, and an error.
 	ExecCLI(ctx context.Context, i int, args []string) (string, string, error)

--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -541,7 +541,7 @@ func (l *DockerCluster) startNode(ctx context.Context, node *testNode) {
   pprof:     docker exec -it %[4]s pprof https+insecure://$(hostname):%[5]s/debug/pprof/heap
   cockroach: %[6]s
 
-  cli-env:   COCKROACH_INSECURE=false COCKROACH_CERTS_DIR=%[7]s COCKROACH_HOST=%s COCKROACH_PORT=%d`,
+  cli-env:   COCKROACH_INSECURE=false COCKROACH_CERTS_DIR=%[7]s COCKROACH_HOST=%s:%d`,
 		node.Name(), "https://"+httpAddr.String(), localLogDir, node.Container.id[:5],
 		base.DefaultHTTPPort, cmd, certsDir, httpAddr.IP, httpAddr.Port)
 }

--- a/pkg/acceptance/localcluster/localcluster.go
+++ b/pkg/acceptance/localcluster/localcluster.go
@@ -77,7 +77,7 @@ func (b *LocalCluster) AssertAndStop(ctx context.Context, t testing.TB) {
 // ExecCLI implements cluster.Cluster.
 func (b *LocalCluster) ExecCLI(ctx context.Context, i int, cmd []string) (string, string, error) {
 	cmd = append([]string{b.Cfg.Binary}, cmd...)
-	cmd = append(cmd, "--insecure", "--port", b.Port(ctx, i))
+	cmd = append(cmd, "--insecure", "--host", ":"+b.Port(ctx, i))
 	c := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
 	var o, e bytes.Buffer
 	c.Stdout, c.Stderr = &o, &e

--- a/pkg/ccl/cliccl/cli_test.go
+++ b/pkg/ccl/cliccl/cli_test.go
@@ -42,7 +42,7 @@ func newCLITest(args base.TestServerArgs) cliTest {
 	}
 	return cliTest{
 		TestServer: s.(*server.TestServer),
-		connArgs:   []string{"--insecure", "--host=" + host, "--port=" + port},
+		connArgs:   []string{"--insecure", "--host=" + host + ":" + port},
 	}
 }
 

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -290,8 +290,7 @@ func (c cliTest) RunWithArgs(origArgs []string) {
 				args = append(args, "--insecure=false")
 				args = append(args, fmt.Sprintf("--certs-dir=%s", c.certsDir))
 			}
-			args = append(args, fmt.Sprintf("--host=%s", h))
-			args = append(args, fmt.Sprintf("--port=%s", p))
+			args = append(args, fmt.Sprintf("--host=%s:%s", h, p))
 		}
 		args = append(args, origArgs[1:]...)
 

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -206,16 +206,22 @@ can also be specified (e.g. .25).`,
 	}
 
 	ClientHost = FlagInfo{
-		Name:        "host",
-		EnvVar:      "COCKROACH_HOST",
-		Description: `Database server host to connect to.`,
+		Name:   "host",
+		EnvVar: "COCKROACH_HOST",
+		Description: `
+CockroachDB node to connect to.
+This can be specified either as an address/hostname, or
+together with a port number as in -s myhost:26257.
+If the port number is left unspecified, it defaults to 26257.
+An IPv6 address can also be specified with the notation [...], for
+example [::1]:26257 or [fe80::f6f2:::]:26257.`,
 	}
 
 	ClientPort = FlagInfo{
 		Name:        "port",
 		Shorthand:   "p",
 		EnvVar:      "COCKROACH_PORT",
-		Description: `Database server port to connect to.`,
+		Description: `Deprecated. Use --host=<host>:<port>.`,
 	}
 
 	Database = FlagInfo{
@@ -267,8 +273,7 @@ sql_safe_updates = FALSE.`,
 	}
 
 	Set = FlagInfo{
-		Name:      "set",
-		Shorthand: "s",
+		Name: "set",
 		Description: `
 Set a client-side configuration parameter before running the SQL
 shell. This flag may be specified multiple times.`,
@@ -327,9 +332,12 @@ or both forms can be used together, for example:
 	ListenAddr = FlagInfo{
 		Name: "listen-addr",
 		Description: `
-The address or hostname to listen on. An IPv6 address can also be
-specified with the notation [...], for example [::1] or
-[fe80::f6f2:::].
+The address/hostname and port to listen on, for example
+--listen-addr=myhost:26257 or --listen-addr=:26257 (listen on all
+interfaces). If the port part is left unspecified, it defaults
+to 26257.
+An IPv6 address can also be specified with the notation [...], for
+example [::1]:26257 or [fe80::f6f2:::]:26257.
 If --advertise-addr is left unspecified, the node will also announce
 this address for use by other nodes. It is strongly recommended to use
 --advertise-addr in cloud and container deployments or any setup where
@@ -341,16 +349,6 @@ NAT is present between cluster nodes.`,
 		Description: `Alias for --listen-addr. Deprecated.`,
 	}
 
-	ListenPort = FlagInfo{
-		Name:      "listen-port",
-		Shorthand: "p",
-		Description: `
-The port to bind to.
-If --advertise-port is left unspecified, the node will also announce
-this port for use by other nodes. If a router implements NAT or N:M
-port forwarding, be sure to also use --advertise-port.`,
-	}
-
 	ServerPort = FlagInfo{
 		Name:        "port",
 		Description: `Alias for --listen-port. Deprecated.`,
@@ -359,10 +357,14 @@ port forwarding, be sure to also use --advertise-port.`,
 	AdvertiseAddr = FlagInfo{
 		Name: "advertise-addr",
 		Description: `
-The address or hostname to advertise to other CockroachDB nodes for intra-cluster
-communication; it must resolve and be routable from other nodes in the cluster.
+The address/hostname and port to advertise to other CockroachDB nodes
+for intra-cluster communication. It must resolve and be routable from
+other nodes in the cluster.
+If left unspecified, it defaults to the setting of --listen-addr.
 An IPv6 address can also be specified with the notation [...], for
-example [::1] or [fe80::f6f2:::].`,
+example [::1]:26257 or [fe80::f6f2:::]:26257.
+The port number should be the same as in --listen-addr unless port
+forwarding is set up on an intermediate firewall/router.`,
 	}
 
 	AdvertiseHost = FlagInfo{
@@ -371,16 +373,18 @@ example [::1] or [fe80::f6f2:::].`,
 	}
 
 	AdvertisePort = FlagInfo{
-		Name: "advertise-port",
-		Description: `
-The port to advertise to other CockroachDB nodes for intra-cluster
-communication. This should not be set differently from --listen-port
-unless port forwarding is set up on an intermediate firewall/router.`,
+		Name:        "advertise-port",
+		Description: `Deprecated. Use --advertise-addr=<host>:<port>.`,
 	}
 
 	ListenHTTPAddr = FlagInfo{
-		Name:        "http-addr",
-		Description: `The hostname or IP address to bind to for HTTP requests.`,
+		Name: "http-addr",
+		Description: `
+The hostname or IP address to bind to for HTTP requests.
+If left unspecified, the address part defaults to the setting of
+--listen-addr. The port number defaults to 8080.
+An IPv6 address can also be specified with the notation [...], for
+example [::1]:8080 or [fe80::f6f2:::]:8080.`,
 	}
 
 	ListenHTTPAddrAlias = FlagInfo{
@@ -390,7 +394,7 @@ unless port forwarding is set up on an intermediate firewall/router.`,
 
 	ListenHTTPPort = FlagInfo{
 		Name:        "http-port",
-		Description: `The port to bind to for HTTP requests.`,
+		Description: `Deprecated. Use --http-addr=<host>:<port>.`,
 	}
 
 	ListeningURLFile = FlagInfo{

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -164,44 +164,60 @@ func TestServerConnSettings(t *testing.T) {
 		{[]string{"start"}, ":" + base.DefaultPort, ":" + base.DefaultPort},
 		{[]string{"start", "--listen-addr", "127.0.0.1"}, "127.0.0.1:" + base.DefaultPort, "127.0.0.1:" + base.DefaultPort},
 		{[]string{"start", "--listen-addr", "192.168.0.111"}, "192.168.0.111:" + base.DefaultPort, "192.168.0.111:" + base.DefaultPort},
-		{[]string{"start", "--listen-port", "12345"}, ":12345", ":12345"},
-		{[]string{"start", "--listen-addr", "127.0.0.1", "--listen-port", "12345"}, "127.0.0.1:12345", "127.0.0.1:12345"},
+		{[]string{"start", "--listen-addr", ":12345"}, ":12345", ":12345"},
+		{[]string{"start", "--listen-addr", "127.0.0.1:12345"}, "127.0.0.1:12345", "127.0.0.1:12345"},
+		{[]string{"start", "--listen-addr", "127.0.0.1:12345", "--port", "55555"}, "127.0.0.1:55555", "127.0.0.1:55555"},
 		{[]string{"start", "--advertise-addr", "192.168.0.111"}, ":" + base.DefaultPort, "192.168.0.111:" + base.DefaultPort},
-		{[]string{"start", "--advertise-addr", "192.168.0.111", "--advertise-port", "12345"}, ":" + base.DefaultPort, "192.168.0.111:12345"},
+		{[]string{"start", "--advertise-addr", "192.168.0.111:12345"}, ":" + base.DefaultPort, "192.168.0.111:12345"},
 		{[]string{"start", "--listen-addr", "127.0.0.1", "--advertise-addr", "192.168.0.111"}, "127.0.0.1:" + base.DefaultPort, "192.168.0.111:" + base.DefaultPort},
-		{[]string{"start", "--listen-addr", "127.0.0.1", "--advertise-addr", "192.168.0.111", "--listen-port", "12345"}, "127.0.0.1:12345", "192.168.0.111:12345"},
-		{[]string{"start", "--listen-addr", "127.0.0.1", "--advertise-addr", "192.168.0.111", "--advertise-port", "12345"}, "127.0.0.1:" + base.DefaultPort, "192.168.0.111:12345"},
-		{[]string{"start", "--listen-addr", "127.0.0.1", "--advertise-addr", "192.168.0.111", "--listen-port", "54321", "--advertise-port", "12345"}, "127.0.0.1:54321", "192.168.0.111:12345"},
-		{[]string{"start", "--advertise-addr", "192.168.0.111", "--listen-port", "12345"}, ":12345", "192.168.0.111:12345"},
-		{[]string{"start", "--advertise-addr", "192.168.0.111", "--advertise-port", "12345"}, ":" + base.DefaultPort, "192.168.0.111:12345"},
-		{[]string{"start", "--advertise-addr", "192.168.0.111", "--listen-port", "54321", "--advertise-port", "12345"}, ":54321", "192.168.0.111:12345"},
+		{[]string{"start", "--listen-addr", "127.0.0.1:12345", "--advertise-addr", "192.168.0.111"}, "127.0.0.1:12345", "192.168.0.111:12345"},
+		{[]string{"start", "--listen-addr", "127.0.0.1", "--advertise-addr", "192.168.0.111:12345"}, "127.0.0.1:" + base.DefaultPort, "192.168.0.111:12345"},
+		{[]string{"start", "--listen-addr", "127.0.0.1:54321", "--advertise-addr", "192.168.0.111:12345"}, "127.0.0.1:54321", "192.168.0.111:12345"},
+		{[]string{"start", "--advertise-addr", "192.168.0.111", "--listen-addr", ":12345"}, ":12345", "192.168.0.111:12345"},
+		{[]string{"start", "--advertise-addr", "192.168.0.111:12345", "--listen-addr", ":54321"}, ":54321", "192.168.0.111:12345"},
 		// confirm hostnames will work
 		{[]string{"start", "--listen-addr", "my.host.name"}, "my.host.name:" + base.DefaultPort, "my.host.name:" + base.DefaultPort},
 		{[]string{"start", "--listen-addr", "myhostname"}, "myhostname:" + base.DefaultPort, "myhostname:" + base.DefaultPort},
 		// confirm IPv6 works too
-		{[]string{"start", "--listen-addr", "::1"}, "[::1]:" + base.DefaultPort, "[::1]:" + base.DefaultPort},
-		{[]string{"start", "--listen-addr", "2622:6221:e663:4922:fc2b:788b:fadd:7b48"}, "[2622:6221:e663:4922:fc2b:788b:fadd:7b48]:" + base.DefaultPort, "[2622:6221:e663:4922:fc2b:788b:fadd:7b48]:" + base.DefaultPort},
-		// Backward-compatibility flags
+		{[]string{"start", "--listen-addr", "[::1]"}, "[::1]:" + base.DefaultPort, "[::1]:" + base.DefaultPort},
+		{[]string{"start", "--listen-addr", "[2622:6221:e663:4922:fc2b:788b:fadd:7b48]"},
+			"[2622:6221:e663:4922:fc2b:788b:fadd:7b48]:" + base.DefaultPort, "[2622:6221:e663:4922:fc2b:788b:fadd:7b48]:" + base.DefaultPort},
+
+		// Backward-compatibility flag combinations.
 		{[]string{"start", "--host", "192.168.0.111"}, "192.168.0.111:" + base.DefaultPort, "192.168.0.111:" + base.DefaultPort},
 		{[]string{"start", "--port", "12345"}, ":12345", ":12345"},
 		{[]string{"start", "--advertise-host", "192.168.0.111"}, ":" + base.DefaultPort, "192.168.0.111:" + base.DefaultPort},
+		{[]string{"start", "--advertise-addr", "192.168.0.111", "--advertise-port", "12345"}, ":" + base.DefaultPort, "192.168.0.111:12345"},
+		{[]string{"start", "--listen-addr", "::1"}, "[::1]:" + base.DefaultPort, "[::1]:" + base.DefaultPort},
+		{[]string{"start", "--listen-addr", "2622:6221:e663:4922:fc2b:788b:fadd:7b48"},
+			"[2622:6221:e663:4922:fc2b:788b:fadd:7b48]:" + base.DefaultPort, "[2622:6221:e663:4922:fc2b:788b:fadd:7b48]:" + base.DefaultPort},
+		{[]string{"start", "--listen-addr", "127.0.0.1", "--port", "12345"}, "127.0.0.1:12345", "127.0.0.1:12345"},
+		{[]string{"start", "--listen-addr", "127.0.0.1", "--advertise-addr", "192.168.0.111", "--port", "12345"}, "127.0.0.1:12345", "192.168.0.111:12345"},
+		{[]string{"start", "--listen-addr", "127.0.0.1", "--advertise-addr", "192.168.0.111", "--port", "12345"}, "127.0.0.1:12345", "192.168.0.111:12345"},
+		{[]string{"start", "--listen-addr", "127.0.0.1", "--advertise-addr", "192.168.0.111", "--advertise-port", "12345"}, "127.0.0.1:" + base.DefaultPort, "192.168.0.111:12345"},
+		{[]string{"start", "--listen-addr", "127.0.0.1", "--advertise-addr", "192.168.0.111", "--port", "54321", "--advertise-port", "12345"}, "127.0.0.1:54321", "192.168.0.111:12345"},
+		{[]string{"start", "--advertise-addr", "192.168.0.111", "--port", "12345"}, ":12345", "192.168.0.111:12345"},
+		{[]string{"start", "--advertise-addr", "192.168.0.111", "--advertise-port", "12345"}, ":" + base.DefaultPort, "192.168.0.111:12345"},
+		{[]string{"start", "--advertise-addr", "192.168.0.111", "--port", "54321", "--advertise-port", "12345"}, ":54321", "192.168.0.111:12345"},
 	}
 
 	for i, td := range testData {
-		initCLIDefaults()
-		if err := f.Parse(td.args); err != nil {
-			t.Fatalf("Parse(%#v) got unexpected error: %v", td.args, err)
-		}
+		t.Run(strings.Join(td.args, " "), func(t *testing.T) {
+			initCLIDefaults()
+			if err := f.Parse(td.args); err != nil {
+				t.Fatalf("Parse(%#v) got unexpected error: %v", td.args, err)
+			}
 
-		extraServerFlagInit()
-		if td.expectedAddr != serverCfg.Addr {
-			t.Errorf("%d. serverCfg.Addr expected '%s', but got '%s'. td.args was '%#v'.",
-				i, td.expectedAddr, serverCfg.Addr, td.args)
-		}
-		if td.expectedAdvertiseAddr != serverCfg.AdvertiseAddr {
-			t.Errorf("%d. serverCfg.AdvertiseAddr expected '%s', but got '%s'. td.args was '%#v'.",
-				i, td.expectedAdvertiseAddr, serverCfg.AdvertiseAddr, td.args)
-		}
+			extraServerFlagInit()
+			if td.expectedAddr != serverCfg.Addr {
+				t.Errorf("%d. serverCfg.Addr expected '%s', but got '%s'. td.args was '%#v'.",
+					i, td.expectedAddr, serverCfg.Addr, td.args)
+			}
+			if td.expectedAdvertiseAddr != serverCfg.AdvertiseAddr {
+				t.Errorf("%d. serverCfg.AdvertiseAddr expected '%s', but got '%s'. td.args was '%#v'.",
+					i, td.expectedAdvertiseAddr, serverCfg.AdvertiseAddr, td.args)
+			}
+		})
 	}
 }
 
@@ -225,14 +241,22 @@ func TestClientConnSettings(t *testing.T) {
 		{[]string{"quit"}, ":" + base.DefaultPort},
 		{[]string{"quit", "--host", "127.0.0.1"}, "127.0.0.1:" + base.DefaultPort},
 		{[]string{"quit", "--host", "192.168.0.111"}, "192.168.0.111:" + base.DefaultPort},
-		{[]string{"quit", "--port", "12345"}, ":12345"},
-		{[]string{"quit", "--host", "127.0.0.1", "--port", "12345"}, "127.0.0.1:12345"},
+		{[]string{"quit", "--host", ":12345"}, ":12345"},
+		{[]string{"quit", "--host", "127.0.0.1:12345"}, "127.0.0.1:12345"},
 		// confirm hostnames will work
 		{[]string{"quit", "--host", "my.host.name"}, "my.host.name:" + base.DefaultPort},
 		{[]string{"quit", "--host", "myhostname"}, "myhostname:" + base.DefaultPort},
 		// confirm IPv6 works too
+		{[]string{"quit", "--host", "[::1]"}, "[::1]:" + base.DefaultPort},
+		{[]string{"quit", "--host", "[2622:6221:e663:4922:fc2b:788b:fadd:7b48]"},
+			"[2622:6221:e663:4922:fc2b:788b:fadd:7b48]:" + base.DefaultPort},
+
+		// Deprecated syntax.
+		{[]string{"quit", "--port", "12345"}, ":12345"},
+		{[]string{"quit", "--host", "127.0.0.1", "--port", "12345"}, "127.0.0.1:12345"},
 		{[]string{"quit", "--host", "::1"}, "[::1]:" + base.DefaultPort},
-		{[]string{"quit", "--host", "2622:6221:e663:4922:fc2b:788b:fadd:7b48"}, "[2622:6221:e663:4922:fc2b:788b:fadd:7b48]:" + base.DefaultPort},
+		{[]string{"quit", "--host", "2622:6221:e663:4922:fc2b:788b:fadd:7b48"},
+			"[2622:6221:e663:4922:fc2b:788b:fadd:7b48]:" + base.DefaultPort},
 	}
 
 	for i, td := range testData {

--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -46,9 +46,17 @@ interrupt
 eexpect ":/# "
 end_test
 
-start_test "Check that --port causes a deprecation warning."
+start_test "Check that server --port causes a deprecation warning."
 send "$argv start --insecure --port=26257\r"
-eexpect "port has been deprecated, use --listen-port/--advertise-port instead."
+eexpect "port has been deprecated, use --listen-addr instead."
+eexpect "node starting"
+interrupt
+eexpect ":/# "
+end_test
+
+start_test "Check that server --advertise-port causes a deprecation warning."
+send "$argv start --insecure --advertise-port=12345\r"
+eexpect "advertise-port has been deprecated, use --advertise-addr"
 eexpect "node starting"
 interrupt
 eexpect ":/# "
@@ -61,7 +69,6 @@ eexpect "node starting"
 interrupt
 eexpect ":/# "
 end_test
-
 
 start_test {Check that the "failed running SUBCOMMAND" message does not consider a flag the subcommand}
 send "$argv --verbosity 2 start --garbage\r"

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -534,9 +534,9 @@ func runStart(cmd *cobra.Command, args []string) error {
 				if le, ok := err.(server.ListenError); ok {
 					const errorPrefix = "consider changing the port via --"
 					if le.Addr == serverCfg.Addr {
-						err = errors.Wrap(err, errorPrefix+cliflags.ListenPort.Name)
+						err = errors.Wrap(err, errorPrefix+cliflags.ListenAddr.Name)
 					} else if le.Addr == serverCfg.HTTPAddr {
-						err = errors.Wrap(err, errorPrefix+cliflags.ListenHTTPPort.Name)
+						err = errors.Wrap(err, errorPrefix+cliflags.ListenHTTPAddr.Name)
 					}
 				}
 
@@ -815,9 +815,7 @@ func clientFlags() string {
 	flags := []string{os.Args[0]}
 	host, port, err := net.SplitHostPort(serverCfg.AdvertiseAddr)
 	if err == nil {
-		flags = append(flags,
-			"--host="+host,
-			"--port="+port)
+		flags = append(flags, "--host="+host+":"+port)
 	}
 	if startCtx.serverInsecure {
 		flags = append(flags, "--insecure")
@@ -1001,6 +999,9 @@ func addrWithDefaultHost(addr string) (string, error) {
 	}
 	if host == "" {
 		host = "localhost"
+	}
+	if strings.Contains(host, ":") {
+		host = "[" + host + "]"
 	}
 	return net.JoinHostPort(host, port), nil
 }

--- a/pkg/cmd/roachtest/debug.go
+++ b/pkg/cmd/roachtest/debug.go
@@ -33,7 +33,7 @@ func registerDebug(r *registry) {
 		// present.
 		debugExtractExist := func(node int, file string) error {
 			port := fmt.Sprintf("{pgport:%d}", node)
-			if err := c.RunE(ctx, c.Node(node), "./cockroach debug zip "+file+" --insecure --port "+port); err != nil {
+			if err := c.RunE(ctx, c.Node(node), "./cockroach debug zip "+file+" --insecure --host=:"+port); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -155,13 +155,13 @@ func runDecommission(t *test, c *cluster, nodes int, duration time.Duration) {
 		stop := func(node int) error {
 			port := fmt.Sprintf("{pgport:%d}", node)
 			defer time.Sleep(time.Second) // work around quit returning too early
-			return c.RunE(ctx, c.Node(node), "./cockroach quit --insecure --port "+port)
+			return c.RunE(ctx, c.Node(node), "./cockroach quit --insecure --host=:"+port)
 		}
 
 		decom := func(id string) error {
 			port := fmt.Sprintf("{pgport:%d}", nodes) // always use last node
 			t.Status("decommissioning node %s", id)
-			return c.RunE(ctx, c.Node(nodes), "./cockroach node decommission --insecure --wait=live --port "+port+" "+id)
+			return c.RunE(ctx, c.Node(nodes), "./cockroach node decommission --insecure --wait=live --host=:"+port+" "+id)
 		}
 
 		for tBegin, whileDown, node := timeutil.Now(), true, 1; timeutil.Since(tBegin) <= duration; whileDown, node = !whileDown, (node%numDecom)+1 {

--- a/pkg/cmd/roachtest/encryption.go
+++ b/pkg/cmd/roachtest/encryption.go
@@ -40,7 +40,7 @@ func registerEncryption(r *registry) {
 
 		stop := func(node int) error {
 			port := fmt.Sprintf("{pgport:%d}", node)
-			if err := c.RunE(ctx, c.Node(node), "./cockroach quit --insecure --port "+port); err != nil {
+			if err := c.RunE(ctx, c.Node(node), "./cockroach quit --insecure --host=:"+port); err != nil {
 				return err
 			}
 			c.Stop(ctx, c.Node(node))

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -153,7 +153,7 @@ func registerKVQuiescenceDead(r *registry) {
 				run(kv+" --seed 1 {pgurl:1}", true)
 			})
 			// Gracefully shut down third node (doesn't matter whether it's graceful or not).
-			c.Run(ctx, c.Node(nodes), "./cockroach quit --insecure --port {pgport:3}")
+			c.Run(ctx, c.Node(nodes), "./cockroach quit --insecure --host:{pgport:3}")
 			c.Stop(ctx, c.Node(nodes))
 			// Measure qps with node down (i.e. without quiescence).
 			qpsOneDown := qps(func() {

--- a/pkg/cmd/roachtest/upgrade.go
+++ b/pkg/cmd/roachtest/upgrade.go
@@ -86,7 +86,7 @@ func registerUpgrade(r *registry) {
 
 		stop := func(node int) error {
 			port := fmt.Sprintf("{pgport:%d}", node)
-			if err := c.RunE(ctx, c.Node(node), "./cockroach quit --insecure --port "+port); err != nil {
+			if err := c.RunE(ctx, c.Node(node), "./cockroach quit --insecure --host=:"+port); err != nil {
 				return err
 			}
 			c.Stop(ctx, c.Node(node))
@@ -95,7 +95,7 @@ func registerUpgrade(r *registry) {
 
 		decommissionAndStop := func(node int) error {
 			port := fmt.Sprintf("{pgport:%d}", node)
-			if err := c.RunE(ctx, c.Node(node), "./cockroach quit --decommission --insecure --port "+port); err != nil {
+			if err := c.RunE(ctx, c.Node(node), "./cockroach quit --decommission --insecure --host=:"+port); err != nil {
 				return err
 			}
 			c.Stop(ctx, c.Node(node))

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -166,7 +166,7 @@ func registerVersion(r *registry) {
 			stop := func(node int) error {
 				l.printf("stopping node %d\n", node)
 				port := fmt.Sprintf("{pgport:%d}", node)
-				if err := c.RunE(ctx, c.Node(node), "./cockroach quit --insecure --port "+port); err != nil {
+				if err := c.RunE(ctx, c.Node(node), "./cockroach quit --insecure --host=:"+port); err != nil {
 					return err
 				}
 				// NB: we still call Stop to make sure the process is dead when we try


### PR DESCRIPTION
cc @jseldess @Amruta-Ranade 
Fixes #23277.
Needed for #5816.

Prior to this patch, the various `cockroach` sub-commands would take
separate flags to specify an address/hostanme and to specify a port
number.

Meanwhile:

1. `--join` would recognize the syntax `host:port`.
2. the web UI, docs and other places often refer to a "server address"
   as the pair hostname:portnr.

For user convenience, it is thus important to make the interface more
straightforward/regular. This patch achieves this as follows:

- the flags
  `--listen-addr`/`--advertise-addr`/`--http-addr` (server-side) and
  `--host` (client-side) now recognize the syntax `host/addr:port`.
- the server-side `--port` flags are still recognized for backward
  compatibility but are marked as deprecated.
  The client-side `--port` is still recognized and not
  deprecated for now, but hidden from the contextual help.

As a side-effect of recognizing the port number inside the same flag,
the syntax with square brackets for IPv6 addresses now becomes
necessary when specifying also a port number. The syntax without
square brackets (and without port number) is temporarily still
recognized for backward compatibility, but is also marked as
deprecated.

Release note (cli change): the server-side command line flag
`--listen-addr`, which replaces the previous `--host` flag, is now
equipped to recognize both a hostname/address and port number. The
`--port` flag is deprecated as a result.

Release note (cli change): the server-side command line flag
`--http-addr`, which replaces the previous `--http-host` flag, is now
equipped to recognize both a hostname/address and port number. The
`--http-port` flag is deprecated as a result.

Release note (cli change): the server-side command line flag
`--advertise-addr`, which replaces the previous `--advertise-host`
flag, is now equipped to recognize both a hostname/address and
port number. The `--advertise-port` flag is deprecated as a result.

Release note (cli change): the client-side command line flag `--host`
is now equipped to recognize both a hostname/address and port
number. The client-side `--port` flag is still recognized,
but not documented any more; `--host` is now preferred.

Release note (cli change): the environment variable COCKROACH_PORT
that specifies the port number to use for client commands is now
deprecated. The port number can be placed in the COCKROACH_HOST
environment variable instead.

Release note (cli change): The syntax to specify IPv6 addresses with
the client-side command line flag `--host` is changed to use square
brackets, for example `--host=[::1]` instead of just `--host=::1`
previously. The previous syntax is still recognized for backward
compatibility but is deprecated.

Release note (cli change): the flag `--listen-port` which was
introduced in a recent change is now removed. (DOCS NOTE: remove both
this release note and the previous one that introduced --listen-port)