### PR TITLE
sql: fix a number of bugs in schema change commit 

### DIFF
--- a/pkg/internal/client/sender.go
+++ b/pkg/internal/client/sender.go
@@ -151,6 +151,10 @@ type TxnSender interface {
 	// timestamp.
 	CommitTimestamp() hlc.Timestamp
 
+	// CommitTimestampFixed returns true if the commit timestamp has
+	// been fixed to the start timestamp and cannot be pushed forward.
+	CommitTimestampFixed() bool
+
 	// IsSerializablePushAndRefreshNotPossible returns true if the transaction is
 	// serializable, its timestamp has been pushed and there's no chance that
 	// refreshing the read spans will succeed later (thus allowing the transaction
@@ -270,6 +274,11 @@ func (m *MockTransactionalSender) OrigTimestamp() hlc.Timestamp {
 // CommitTimestamp is part of the TxnSender interface.
 func (m *MockTransactionalSender) CommitTimestamp() hlc.Timestamp {
 	return m.txn.OrigTimestamp
+}
+
+// CommitTimestampFixed is part of the TxnSender interface.
+func (m *MockTransactionalSender) CommitTimestampFixed() bool {
+	panic("unimplemented")
 }
 
 // SetFixedTimestamp is part of the TxnSender interface.

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -275,6 +275,12 @@ func (txn *Txn) CommitTimestamp() hlc.Timestamp {
 	return txn.mu.sender.CommitTimestamp()
 }
 
+// CommitTimestampFixed returns true if the commit timestamp has
+// been fixed to the start timestamp and cannot be pushed forward.
+func (txn *Txn) CommitTimestampFixed() bool {
+	return txn.mu.sender.CommitTimestampFixed()
+}
+
 // SetSystemConfigTrigger sets the system db trigger to true on this transaction.
 // This will impact the EndTransactionRequest.
 func (txn *Txn) SetSystemConfigTrigger() error {

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -957,6 +957,13 @@ func (tc *TxnCoordSender) CommitTimestamp() hlc.Timestamp {
 	return tc.mu.txn.OrigTimestamp
 }
 
+// CommitTimestampFixed is part of the client.TxnSender interface.
+func (tc *TxnCoordSender) CommitTimestampFixed() bool {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	return tc.mu.txn.OrigTimestampWasObserved
+}
+
 // SetFixedTimestamp is part of the client.TxnSender interface.
 func (tc *TxnCoordSender) SetFixedTimestamp(ctx context.Context, ts hlc.Timestamp) {
 	tc.mu.Lock()

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -252,11 +252,7 @@ func (sc *SchemaChanger) truncateIndexes(
 				}
 
 				tc := &TableCollection{leaseMgr: sc.leaseMgr}
-				defer func() {
-					if err := tc.releaseTables(ctx, dontBlockForDBCacheUpdate); err != nil {
-						log.Warningf(ctx, "error releasing tables: %s", err)
-					}
-				}()
+				defer tc.releaseTables(ctx)
 				tableDesc, err := sc.getTableVersion(ctx, txn, tc, version)
 				if err != nil {
 					return err
@@ -469,11 +465,7 @@ func (sc *SchemaChanger) distBackfill(
 
 			tc := &TableCollection{leaseMgr: sc.leaseMgr}
 			// Use a leased table descriptor for the backfill.
-			defer func() {
-				if err := tc.releaseTables(ctx, dontBlockForDBCacheUpdate); err != nil {
-					log.Warningf(ctx, "error releasing tables: %s", err)
-				}
-			}()
+			defer tc.releaseTables(ctx)
 			tableDesc, err := sc.getTableVersion(ctx, txn, tc, version)
 			if err != nil {
 				return err

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -479,6 +479,30 @@ func (ex *connExecutor) checkTableTwoVersionInvariant(ctx context.Context) error
 	if txn.IsCommitted() {
 		panic("transaction has already committed")
 	}
+
+	// Release leases here for two reasons:
+	// 1. If there are existing leases at version V-2 for a descriptor
+	// being modified to version V being held the wait loop below that
+	// waits on a cluster wide release of old version leases will hang
+	// until these leases expire.
+	// 2. Once this transaction commits, the schema changers run and
+	// increment the version of the modified descriptors. If one of the
+	// descriptors being modified has a lease being held the schema
+	// changers will stall until the leases expire.
+	//
+	// The above two cases can be satified by releasing leases for both
+	// cases explicitly, but we prefer to call it here and kill two birds
+	// with one stone.
+	//
+	// It is safe to release leases even though the transaction hasn't yet
+	// committed only because the transaction timestamp has been fixed using
+	// CommitTimestamp().
+	//
+	// releaseLeases can fail to release a lease if the server is shutting
+	// down. This is okay because it will result in the two cases mentioned
+	// above simply hanging until the expiration time for the leases.
+	ex.extraTxnState.tables.releaseLeases(ex.Ctx())
+
 	count, err := CountLeases(ctx, ex.server.cfg.InternalExecutor, tables, txn.OrigTimestamp())
 	if err != nil {
 		return err
@@ -509,10 +533,6 @@ func (ex *connExecutor) checkTableTwoVersionInvariant(ctx context.Context) error
 	// We cleanup the transaction and create a new transaction wait time
 	// might be extensive and so we'd better get rid of all the intents.
 	txn.CleanupOnError(ctx, retryErr)
-
-	// Release leases held by the current transaction before waiting
-	// on cluster wide releases of old version leases.
-	ex.extraTxnState.tables.releaseLeases(ex.Ctx())
 
 	// Wait until all older version leases have been released or expired.
 	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -479,6 +479,9 @@ func (ex *connExecutor) checkTableTwoVersionInvariant(ctx context.Context) error
 	if txn.IsCommitted() {
 		panic("transaction has already committed")
 	}
+	if !txn.CommitTimestampFixed() {
+		panic("commit timestamp was not fixed")
+	}
 
 	// Release leases here for two reasons:
 	// 1. If there are existing leases at version V-2 for a descriptor

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -203,7 +203,7 @@ func (ie *internalExecutorImpl) initConnEx(
 		// txn committed. But if there is a higher-level txn, they don't get
 		// released.
 		defer func() {
-			if err := ex.resetExtraTxnState(ctx, txnAborted, ex.server.dbCache); err != nil {
+			if err := ex.resetExtraTxnState(ctx, ex.server.dbCache); err != nil {
 				log.Warningf(ctx, "error while cleaning up connExecutor: %s", err)
 			}
 		}()

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -197,7 +197,7 @@ func (e errTableVersionMismatch) Error() string {
 // AcquireLease acquires a schema change lease on the table if
 // an unexpired lease doesn't exist. It returns the lease.
 func (sc *SchemaChanger) AcquireLease(
-	ctx context.Context, tables *TableCollection,
+	ctx context.Context,
 ) (sqlbase.TableDescriptor_SchemaChangeLease, error) {
 	var lease sqlbase.TableDescriptor_SchemaChangeLease
 	err := sc.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
@@ -224,13 +224,6 @@ func (sc *SchemaChanger) AcquireLease(
 		}
 		lease = sc.createSchemaChangeLease()
 		tableDesc.Lease = &lease
-		if tables != nil {
-			// tables is nil when running schema changes from the background schema change task.
-			// When running schema changes at the end of a SQL txn, tables is the
-			// table collection used as descriptor cache by queries. That must
-			// remain consistent with the KV state, so we must update it here.
-			tables.addUncommittedTable(*tableDesc)
-		}
 		return txn.Put(ctx, sqlbase.MakeDescMetadataKey(tableDesc.ID), sqlbase.WrapDescriptor(tableDesc))
 	})
 	return lease, err
@@ -255,7 +248,7 @@ func (sc *SchemaChanger) findTableWithLease(
 // ReleaseLease releases the table lease if it is the one registered with
 // the table descriptor.
 func (sc *SchemaChanger) ReleaseLease(
-	ctx context.Context, lease sqlbase.TableDescriptor_SchemaChangeLease, tables *TableCollection,
+	ctx context.Context, lease sqlbase.TableDescriptor_SchemaChangeLease,
 ) error {
 	return sc.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		tableDesc, err := sc.findTableWithLease(ctx, txn, lease)
@@ -265,13 +258,6 @@ func (sc *SchemaChanger) ReleaseLease(
 		tableDesc.Lease = nil
 		if err := txn.SetSystemConfigTrigger(); err != nil {
 			return err
-		}
-		if tables != nil {
-			// tables is nil when running schema changes from the background schema change task.
-			// When running schema changes at the end of a SQL txn, tables is the
-			// table collection used as descriptor cache by queries. That must
-			// remain consistent with the KV state, so we must update it here.
-			tables.addUncommittedTable(*tableDesc)
 		}
 		return txn.Put(ctx, sqlbase.MakeDescMetadataKey(tableDesc.ID), sqlbase.WrapDescriptor(tableDesc))
 	})
@@ -552,7 +538,7 @@ func (sc *SchemaChanger) exec(
 			sc.tableID, sc.mutationID)
 	}
 	// Acquire lease.
-	lease, err := sc.AcquireLease(ctx, evalCtx.Tables)
+	lease, err := sc.AcquireLease(ctx)
 	if err != nil {
 		return err
 	}
@@ -564,7 +550,7 @@ func (sc *SchemaChanger) exec(
 		if !needRelease {
 			return
 		}
-		if err := sc.ReleaseLease(ctx, lease, evalCtx.Tables); err != nil {
+		if err := sc.ReleaseLease(ctx, lease); err != nil {
 			log.Warning(ctx, err)
 		}
 	}()

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -93,7 +93,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	ctx := context.TODO()
 
 	// Acquire a lease.
-	lease, err := changer.AcquireLease(ctx, nil)
+	lease, err := changer.AcquireLease(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	}
 
 	// Acquiring another lease will fail.
-	if _, err := changer.AcquireLease(ctx, nil); !testutils.IsError(
+	if _, err := changer.AcquireLease(ctx); !testutils.IsError(
 		err, "an outstanding schema change lease exists",
 	) {
 		t.Fatal(err)
@@ -131,12 +131,12 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	}
 
 	// Releasing an old lease fails.
-	if err := changer.ReleaseLease(ctx, oldLease, nil); err == nil {
+	if err := changer.ReleaseLease(ctx, oldLease); err == nil {
 		t.Fatal("releasing a old lease succeeded")
 	}
 
 	// Release lease.
-	if err := changer.ReleaseLease(ctx, lease, nil); err != nil {
+	if err := changer.ReleaseLease(ctx, lease); err != nil {
 		t.Fatal(err)
 	}
 
@@ -146,7 +146,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	}
 
 	// acquiring the lease succeeds
-	lease, err = changer.AcquireLease(ctx, nil)
+	lease, err = changer.AcquireLease(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -480,7 +480,7 @@ func runSchemaChangeWithOperations(
 	// Grabbing a schema change lease on the table will fail, disallowing
 	// another schema change from being simultaneously executed.
 	sc := sql.NewSchemaChangerForTesting(tableDesc.ID, 0, 0, *kvDB, nil, jobRegistry, execCfg)
-	if l, err := sc.AcquireLease(ctx, nil); err == nil {
+	if l, err := sc.AcquireLease(ctx); err == nil {
 		t.Fatalf("schema change lease acquisition on table %d succeeded: %v", tableDesc.ID, l)
 	}
 


### PR DESCRIPTION
A schema change failure could result in a TableCollection
associated with a transaction not being reset properly. A
future transaction on the same session could see
uncommitted descriptors from a previous transaction.
Added TestSchemaUniqueColumnDropFailure
that fails before this change.

A schema change transaction abort/reset would always call
waitForCacheState() to check that dropped databases
were dropped from the cache. But a DROP DATABASE schema
change that fails will keep the database in the cache
resulting in the system locking up.

Consolidated call to resetLeases() to before a schema change
commit. The call is needed always after a schema change commit
and occasionally before a commit, so it is felt it's
better to always call it before commit. Also clarified
through comments why releaseLeases() will not deadlock.

Fixes #27847
Fixes #26961

Release notes (sql change): Fix node freeze after DROP DATABASE
when command aborts.
Release notes (sql change): Fix rare use of an older descriptor after
DROP INDEX.