### PR TITLE
cli: support loading initial datasets in `cockroach demo`

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -358,7 +358,7 @@ func init() {
 	StringFlag(zf, &zoneCtx.zoneConfig, cliflags.ZoneConfig, zoneCtx.zoneConfig)
 	BoolFlag(zf, &zoneCtx.zoneDisableReplication, cliflags.ZoneDisableReplication, zoneCtx.zoneDisableReplication)
 
-	for _, cmd := range []*cobra.Command{sqlShellCmd, demoCmd} {
+	for _, cmd := range append([]*cobra.Command{sqlShellCmd, demoCmd}, demoCmd.Commands()...) {
 		f := cmd.Flags()
 		VarFlag(f, &sqlCtx.setStmts, cliflags.Set)
 		VarFlag(f, &sqlCtx.execStmts, cliflags.Execute)


### PR DESCRIPTION
Any registered workloads are automatically added as subcommands.
`cockroach demo` demo keeps the old behavior, but `cockroach demo
startrek` will load the startrek dataset into the `startrek` database
and alter the connection it starts to start in that database.

    $ ./cockroach demo startrek
    #
    # Welcome to the CockroachDB demo database!
    #
    # You are connected to a temporary, in-memory CockroachDB
    # instance. Your changes will not be saved!
    #
    # Web UI: http://127.0.0.1:63932
    #
    # Server version: CockroachDB CCL v2.1.0-alpha.20180702-1271-g3fe24ce-dirty (x86_64-apple-darwin17.7.0, built 2018/08/08 16:30:52, go1.10) (same version as client)
    # Cluster ID: 7d0a580b-ecb2-4f5a-ae0f-bae298dbaf9b
    #
    # Enter \? for a brief introduction.
    #
    root@127.0.0.1:63931/startrek> select * from episodes limit 1;
    +----+--------+-----+--------------+----------+
    | id | season | num |    title     | stardate |
    +----+--------+-----+--------------+----------+
    |  1 |      1 |   1 | The Man Trap |   1531.1 |
    +----+--------+-----+--------------+----------+
    (1 row)

Still TODO is faster loading than Setup for large workloads, like tpcc.

Release note (cli change): `cockroach demo` now supports starting with
one of various datasets loaded