### PR TITLE
sql: empty ArrayFlattens can now roundtrip

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -90,6 +90,9 @@ SELECT ARRAY(SELECT 3 WHERE false)
 ----
 {}
 
+statement ok
+SELECT ARRAY(SELECT 3 WHERE false) FROM k
+
 query T
 SELECT ARRAY(SELECT 3)
 ----

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -837,6 +837,16 @@ type ArrayFlatten struct {
 func (node *ArrayFlatten) Format(ctx *FmtCtx) {
 	ctx.WriteString("ARRAY ")
 	exprFmtWithParen(ctx, node.Subquery)
+	if ctx.HasFlags(FmtParsable) {
+		if t, ok := node.Subquery.(*DTuple); ok {
+			if len(t.D) == 0 {
+				if colTyp, err := coltypes.DatumTypeToColumnType(node.typ); err == nil {
+					ctx.WriteString(":::")
+					colTyp.Format(ctx.Buffer, ctx.flags.EncodeFlags())
+				}
+			}
+		}
+	}
 }
 
 // Exprs represents a list of value expressions. It's not a valid expression


### PR DESCRIPTION
Previously, ArrayFlatten expressions that had no results couldn't
roundtrip in DistSQL, since empty arrays need to be type annotated to be
type checked. Correct this problem.

Release note (bug fix): certain queries that use empty arrays
constructed from subqueries no longer spuriously fail when executed via
the distributed query engine.