### PR TITLE
opt: support DISTINCT for aggregates + simplification rules

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -174,21 +174,36 @@ group      ·            ·           (count int, sum decimal, max int)  ·
 ·          spans        ALL         ·                                  ·
 
 query TTTTT
+EXPLAIN (VERBOSE) SELECT count(v), count(DISTINCT v), sum(v), sum(DISTINCT v), min(v), min(DISTINCT v) FROM kv
+----
+group      ·            ·                  (count, count, sum, sum, min, min)  ·
+ │         aggregate 0  count(v)           ·                                   ·
+ │         aggregate 1  count(DISTINCT v)  ·                                   ·
+ │         aggregate 2  sum(v)             ·                                   ·
+ │         aggregate 3  sum(DISTINCT v)    ·                                   ·
+ │         aggregate 4  min(v)             ·                                   ·
+ │         aggregate 5  min(DISTINCT v)    ·                                   ·
+ │         scalar       ·                  ·                                   ·
+ └── scan  ·            ·                  (v)                                 ·
+·          table        kv@primary         ·                                   ·
+·          spans        ALL                ·                                   ·
+
+query TTTTT
 EXPLAIN (VERBOSE) SELECT count(DISTINCT a.*) FROM kv a, kv b
 ----
-group                ·            ·                                             (count)                                                       ·
- │                   aggregate 0  count(DISTINCT ((k, v, w, s) AS k, v, w, s))  ·                                                             ·
- │                   scalar       ·                                             ·                                                             ·
- └── render          ·            ·                                             ("((k, v, w, s) AS k, v, w, s)")                              ·
-      │              render 0     ((a.k, a.v, a.w, a.s) AS k, v, w, s)          ·                                                             ·
-      └── join       ·            ·                                             (k, v, w, s, k[omitted], v[omitted], w[omitted], s[omitted])  ·
-           │         type         cross                                         ·                                                             ·
-           ├── scan  ·            ·                                             (k, v, w, s)                                                  k!=NULL; key(k)
-           │         table        kv@primary                                    ·                                                             ·
-           │         spans        ALL                                           ·                                                             ·
-           └── scan  ·            ·                                             (k[omitted], v[omitted], w[omitted], s[omitted])              k!=NULL; key(k)
-·                    table        kv@primary                                    ·                                                             ·
-·                    spans        ALL                                           ·                                                             ·
+group                ·            ·                             (count)       ·
+ │                   aggregate 0  count(DISTINCT column9)       ·             ·
+ │                   scalar       ·                             ·             ·
+ └── render          ·            ·                             (column9)     ·
+      │              render 0     ((k, v, w, s) AS k, v, w, s)  ·             ·
+      └── join       ·            ·                             (k, v, w, s)  ·
+           │         type         cross                         ·             ·
+           ├── scan  ·            ·                             (k, v, w, s)  ·
+           │         table        kv@primary                    ·             ·
+           │         spans        ALL                           ·             ·
+           └── scan  ·            ·                             ()            ·
+·                    table        kv@primary                    ·             ·
+·                    spans        ALL                           ·             ·
 
 query TTT
 SELECT tree, field, description FROM [

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -182,7 +182,7 @@ group      ·            ·                  (count, count, sum, sum, min, min) 
  │         aggregate 2  sum(v)             ·                                   ·
  │         aggregate 3  sum(DISTINCT v)    ·                                   ·
  │         aggregate 4  min(v)             ·                                   ·
- │         aggregate 5  min(DISTINCT v)    ·                                   ·
+ │         aggregate 5  min(v)             ·                                   ·
  │         scalar       ·                  ·                                   ·
  └── scan  ·            ·                  (v)                                 ·
 ·          table        kv@primary         ·                                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -624,5 +624,6 @@ project
  └── projections
       └── const: 1 [type=int]
 
-statement error aggregates with DISTINCT are not supported yet
-EXPLAIN (OPT) SELECT sum(DISTINCT x) FROM (VALUES (1), (1), (2)) AS t(x)
+# Test with an unsupported statement.
+statement error window functions are not supported
+EXPLAIN (OPT) SELECT avg(x) OVER () FROM (VALUES (1)) AS t(x)

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -227,6 +227,7 @@ type ColumnOrdinalSet = util.FastIntSet
 type AggInfo struct {
 	FuncName   string
 	Builtin    *tree.Overload
+	Distinct   bool
 	ResultType types.T
 	ArgCols    []ColumnOrdinal
 }

--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -137,6 +137,9 @@ func init() {
 		opt.ConstAggOp:        typeAsFirstArg,
 		opt.ConstNotNullAggOp: typeAsFirstArg,
 		opt.FirstAggOp:        typeAsFirstArg,
+
+		// Modifiers for aggregations pass through their argument.
+		opt.AggDistinctOp: typeAsFirstArg,
 	}
 
 	for _, op := range opt.BooleanOperators {

--- a/pkg/sql/opt/norm/groupby.go
+++ b/pkg/sql/opt/norm/groupby.go
@@ -114,3 +114,15 @@ func (c *CustomFuncs) makeAggCols(
 		i++
 	}
 }
+
+// extractAggInputColumn returns the input ColumnID of an aggregate operator.
+func extractAggInputColumn(ev memo.ExprView) opt.ColumnID {
+	if !ev.IsAggregate() {
+		panic("not an Aggregate")
+	}
+	arg := ev.Child(0)
+	if arg.Operator() == opt.AggDistinctOp {
+		arg = arg.Child(0)
+	}
+	return arg.Private().(opt.ColumnID)
+}

--- a/pkg/sql/opt/norm/groupby.go
+++ b/pkg/sql/opt/norm/groupby.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 )
 
 // CanReduceGroupingCols is true if the given GroupBy operator has one or more
@@ -113,6 +114,86 @@ func (c *CustomFuncs) makeAggCols(
 		outColList[i] = opt.ColumnID(id)
 		i++
 	}
+}
+
+// CanRemoveAggDistinctForKeys returns true if the given aggregations contain an
+// aggregation with AggDistinct where the input column together with the
+// grouping columns form a key. In this case, the respective AggDistinct can be
+// removed.
+func (c *CustomFuncs) CanRemoveAggDistinctForKeys(
+	aggs memo.GroupID, def memo.PrivateID, input memo.GroupID,
+) bool {
+	inputFDs := &c.LookupLogical(input).Relational.FuncDeps
+	if _, hasKey := inputFDs.Key(); !hasKey {
+		// Fast-path for the case when the input has no keys.
+		return false
+	}
+
+	groupingCols := c.f.mem.LookupPrivate(def).(*memo.GroupByDef).GroupingCols
+	aggsExpr := c.f.mem.NormExpr(aggs).AsAggregations()
+	aggsElems := c.f.mem.LookupList(aggsExpr.Aggs())
+	for _, agg := range aggsElems {
+		if ok, _ := c.hasRemovableAggDistinct(agg, groupingCols, inputFDs); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// RemoveAggDistinctForKeys rewrites aggregations to remove AggDistinct when
+// the input column together with the grouping columns form a key. Returns the
+// new Aggregation expression.
+func (c *CustomFuncs) RemoveAggDistinctForKeys(
+	aggs memo.GroupID, def memo.PrivateID, input memo.GroupID,
+) memo.GroupID {
+	inputFDs := &c.LookupLogical(input).Relational.FuncDeps
+	groupingCols := c.f.mem.LookupPrivate(def).(*memo.GroupByDef).GroupingCols
+	aggsExpr := c.f.mem.NormExpr(aggs).AsAggregations()
+	aggsElems := c.f.mem.LookupList(aggsExpr.Aggs())
+
+	newAggElems := make([]memo.GroupID, len(aggsElems))
+	for i, agg := range aggsElems {
+		if ok, aggDistinctInput := c.hasRemovableAggDistinct(agg, groupingCols, inputFDs); ok {
+			// Remove AggDistinct. We rely on the fact that AggDistinct must be
+			// directly "under" the Aggregate.
+			// TODO(radu): this will need to be revisited when we add more modifiers.
+			aggExpr := c.f.mem.NormExpr(agg)
+			newAggElems[i] = c.f.DynamicConstruct(
+				aggExpr.Operator(),
+				memo.DynamicOperands{memo.DynamicID(aggDistinctInput)},
+			)
+		} else {
+			newAggElems[i] = agg
+		}
+	}
+
+	return c.f.ConstructAggregations(c.f.InternList(newAggElems), aggsExpr.Cols())
+}
+
+// hasRemovableAggDistinct is called with an aggregation element and returns
+// true if the aggregation has AggDistinct and the grouping columns along with
+// the aggregation input column form a key in the input (in which case
+// AggDistinct can be elided).
+// On success, the input group to AggDistinct is also returned.
+func (c *CustomFuncs) hasRemovableAggDistinct(
+	aggregation memo.GroupID, groupingCols opt.ColSet, inputFDs *props.FuncDepSet,
+) (ok bool, aggDistinctInput memo.GroupID) {
+	aggExpr := c.f.mem.NormExpr(aggregation)
+	if aggExpr.ChildCount() == 1 {
+		argExpr := c.f.mem.NormExpr(aggExpr.ChildGroup(c.f.mem, 0))
+		if argExpr.Operator() == opt.AggDistinctOp {
+			aggDistinctInput := argExpr.ChildGroup(c.f.mem, 0)
+			v := c.f.mem.NormExpr(aggDistinctInput)
+			if v.Operator() == opt.VariableOp {
+				cols := groupingCols.Copy()
+				cols.Add(int(v.Private(c.f.mem).(opt.ColumnID)))
+				if inputFDs.ColsAreStrictKey(cols) {
+					return true, aggDistinctInput
+				}
+			}
+		}
+	}
+	return false, 0
 }
 
 // extractAggInputColumn returns the input ColumnID of an aggregate operator.

--- a/pkg/sql/opt/norm/reject_nulls.go
+++ b/pkg/sql/opt/norm/reject_nulls.go
@@ -139,7 +139,7 @@ func deriveGroupByRejectNullCols(ev memo.ExprView) opt.ColSet {
 		}
 
 		// Get column ID of aggregate's Variable operator input.
-		inColID := agg.Child(0).Private().(opt.ColumnID)
+		inColID := extractAggInputColumn(agg)
 
 		// Criteria #3.
 		if savedInColID != 0 && savedInColID != inColID {

--- a/pkg/sql/opt/norm/rules/agg.opt
+++ b/pkg/sql/opt/norm/rules/agg.opt
@@ -1,0 +1,13 @@
+# =============================================================================
+# agg.opt contains normalization rules for aggregation operators (like Min,
+# Sum) and modifiers (like AggDistinct).
+# =============================================================================
+
+# EliminateAggDistinct removes AggDistinct for aggregations where DISTINCT
+# never modifies the result; for example: min(DISTINCT x).
+[EliminateAggDistinct, Normalize]
+(Min | Max | BoolAnd | BoolOr
+    (AggDistinct $in:*)
+)
+=>
+((OpName) $in)

--- a/pkg/sql/opt/norm/rules/groupby.opt
+++ b/pkg/sql/opt/norm/rules/groupby.opt
@@ -61,3 +61,18 @@ $input
     (AppendReducedGroupingCols $input $aggregations $def)
     (ReduceGroupingCols $input $def)
 )
+
+# EliminateAggDistinctForKeys eliminates unnecessary AggDistinct modifiers when
+# it is known that the aggregation argument is unique within each group.
+[EliminateAggDistinctForKeys, Normalize]
+(GroupBy | ScalarGroupBy
+    $input:*
+    $aggregations:*
+    $def:* & (CanRemoveAggDistinctForKeys $aggregations $def $input)
+)
+=>
+((OpName)
+    $input
+    (RemoveAggDistinctForKeys $aggregations $def $input)
+    $def
+)

--- a/pkg/sql/opt/norm/testdata/rules/agg
+++ b/pkg/sql/opt/norm/testdata/rules/agg
@@ -1,0 +1,94 @@
+exec-ddl
+CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON, arr int[])
+----
+TABLE a
+ ├── k int not null
+ ├── i int
+ ├── f float
+ ├── s string
+ ├── j jsonb
+ ├── arr int[]
+ └── INDEX primary
+      └── k int not null
+
+# --------------------------------------------------
+# EliminateAggDistinct
+# --------------------------------------------------
+
+opt
+SELECT min(DISTINCT i), max(DISTINCT i), bool_and(DISTINCT i>f), bool_or(DISTINCT i>f) FROM a
+----
+scalar-group-by
+ ├── columns: min:7(int) max:8(int) bool_and:10(bool) bool_or:11(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7,8,10,11)
+ ├── project
+ │    ├── columns: column9:9(bool) i:2(int)
+ │    ├── scan a
+ │    │    └── columns: i:2(int) f:3(float)
+ │    └── projections [outer=(2,3)]
+ │         └── a.i > a.f [type=bool, outer=(2,3)]
+ └── aggregations [outer=(2,9)]
+      ├── min [type=int, outer=(2)]
+      │    └── variable: a.i [type=int, outer=(2)]
+      ├── max [type=int, outer=(2)]
+      │    └── variable: a.i [type=int, outer=(2)]
+      ├── bool-and [type=bool, outer=(9)]
+      │    └── variable: column9 [type=bool, outer=(9)]
+      └── bool-or [type=bool, outer=(9)]
+           └── variable: column9 [type=bool, outer=(9)]
+
+# The rule should not apply to these aggregations.
+opt
+SELECT
+    count(DISTINCT i),
+    sum(DISTINCT i),
+    sum_int(DISTINCT i),
+    avg(DISTINCT i),
+    stddev(DISTINCT f),
+    variance(DISTINCT f),
+    xor_agg(DISTINCT s::BYTES),
+    array_agg(DISTINCT i),
+    json_agg(DISTINCT j)
+FROM a
+----
+scalar-group-by
+ ├── columns: count:7(int) sum:8(decimal) sum_int:9(int) avg:10(decimal) stddev:11(float) variance:12(float) xor_agg:14(bytes) array_agg:15(int[]) json_agg:16(jsonb)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7-12,14-16)
+ ├── project
+ │    ├── columns: column13:13(bytes) i:2(int) f:3(float) j:5(jsonb)
+ │    ├── scan a
+ │    │    └── columns: i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    └── projections [outer=(2-5)]
+ │         └── a.s::BYTES [type=bytes, outer=(4)]
+ └── aggregations [outer=(2,3,5,13)]
+      ├── count [type=int, outer=(2)]
+      │    └── agg-distinct [type=int, outer=(2)]
+      │         └── variable: a.i [type=int, outer=(2)]
+      ├── sum [type=decimal, outer=(2)]
+      │    └── agg-distinct [type=int, outer=(2)]
+      │         └── variable: a.i [type=int, outer=(2)]
+      ├── sum-int [type=int, outer=(2)]
+      │    └── agg-distinct [type=int, outer=(2)]
+      │         └── variable: a.i [type=int, outer=(2)]
+      ├── avg [type=decimal, outer=(2)]
+      │    └── agg-distinct [type=int, outer=(2)]
+      │         └── variable: a.i [type=int, outer=(2)]
+      ├── std-dev [type=float, outer=(3)]
+      │    └── agg-distinct [type=float, outer=(3)]
+      │         └── variable: a.f [type=float, outer=(3)]
+      ├── variance [type=float, outer=(3)]
+      │    └── agg-distinct [type=float, outer=(3)]
+      │         └── variable: a.f [type=float, outer=(3)]
+      ├── xor-agg [type=bytes, outer=(13)]
+      │    └── agg-distinct [type=bytes, outer=(13)]
+      │         └── variable: column13 [type=bytes, outer=(13)]
+      ├── array-agg [type=int[], outer=(2)]
+      │    └── agg-distinct [type=int, outer=(2)]
+      │         └── variable: a.i [type=int, outer=(2)]
+      └── json-agg [type=jsonb, outer=(5)]
+           └── agg-distinct [type=jsonb, outer=(5)]
+                └── variable: a.j [type=jsonb, outer=(5)]

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1224,6 +1224,74 @@ group-by
       └── const-agg [type=jsonb, outer=(5)]
            └── variable: a.j [type=jsonb, outer=(5)]
 
+opt
+SELECT *
+FROM a
+WHERE EXISTS
+(
+    SELECT * FROM xy INNER JOIN (SELECT count(DISTINCT uv.v) AS cnt, sum(v) FROM uv WHERE i=5 GROUP BY v) ON x=cnt
+)
+----
+group-by
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── grouping columns: k:1(int!null)
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(2-5)
+ ├── select
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) v:9(int) cnt:10(int!null)
+ │    ├── key: (1,6,9)
+ │    ├── fd: ()-->(2), (1)-->(3-5), (1,6,9)-->(3-5,10), (6)==(10), (10)==(6)
+ │    ├── group-by
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) v:9(int) cnt:10(int)
+ │    │    ├── grouping columns: k:1(int!null) x:6(int!null) v:9(int)
+ │    │    ├── key: (1,6,9)
+ │    │    ├── fd: ()-->(2), (1)-->(3-5), (1,6,9)-->(2-5,10)
+ │    │    ├── inner-join
+ │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) v:9(int)
+ │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
+ │    │    │    ├── inner-join
+ │    │    │    │    ├── columns: x:6(int!null) v:9(int)
+ │    │    │    │    ├── scan xy
+ │    │    │    │    │    ├── columns: x:6(int!null)
+ │    │    │    │    │    └── key: (6)
+ │    │    │    │    ├── scan uv
+ │    │    │    │    │    └── columns: v:9(int)
+ │    │    │    │    └── true [type=bool]
+ │    │    │    ├── select
+ │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
+ │    │    │    │    ├── scan a
+ │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    └── fd: (1)-->(2-5)
+ │    │    │    │    └── filters [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+ │    │    │    │         └── a.i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
+ │    │    │    └── true [type=bool]
+ │    │    └── aggregations [outer=(2-5,9)]
+ │    │         ├── count [type=int, outer=(9)]
+ │    │         │    └── agg-distinct [type=int, outer=(9)]
+ │    │         │         └── variable: uv.v [type=int, outer=(9)]
+ │    │         ├── const-agg [type=int, outer=(2)]
+ │    │         │    └── variable: a.i [type=int, outer=(2)]
+ │    │         ├── const-agg [type=float, outer=(3)]
+ │    │         │    └── variable: a.f [type=float, outer=(3)]
+ │    │         ├── const-agg [type=string, outer=(4)]
+ │    │         │    └── variable: a.s [type=string, outer=(4)]
+ │    │         └── const-agg [type=jsonb, outer=(5)]
+ │    │              └── variable: a.j [type=jsonb, outer=(5)]
+ │    └── filters [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
+ │         └── xy.x = cnt [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ])]
+ └── aggregations [outer=(2-5)]
+      ├── const-agg [type=int, outer=(2)]
+      │    └── variable: a.i [type=int, outer=(2)]
+      ├── const-agg [type=float, outer=(3)]
+      │    └── variable: a.f [type=float, outer=(3)]
+      ├── const-agg [type=string, outer=(4)]
+      │    └── variable: a.s [type=string, outer=(4)]
+      └── const-agg [type=jsonb, outer=(5)]
+           └── variable: a.j [type=jsonb, outer=(5)]
+
 # Indirectly decorrelate GROUP BY after decorrelating scalar GROUP BY.
 opt
 SELECT *

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -41,6 +41,53 @@ TABLE xy
  └── INDEX primary
       └── x int not null
 
+exec-ddl
+CREATE TABLE abc
+(
+    a INT,
+    b INT,
+    c INT,
+    PRIMARY KEY (a,b,c)
+)
+----
+TABLE abc
+ ├── a int not null
+ ├── b int not null
+ ├── c int not null
+ └── INDEX primary
+      ├── a int not null
+      ├── b int not null
+      └── c int not null
+
+exec-ddl
+CREATE TABLE uvwz
+(
+    u INT NOT NULL,
+    v INT NOT NULL,
+    w INT NOT NULL,
+    z INT NOT NULL,
+
+    UNIQUE INDEX (u,v),
+    UNIQUE INDEX (v,w)
+)
+----
+TABLE uvwz
+ ├── u int not null
+ ├── v int not null
+ ├── w int not null
+ ├── z int not null
+ ├── rowid int not null (hidden)
+ ├── INDEX primary
+ │    └── rowid int not null (hidden)
+ ├── INDEX secondary
+ │    ├── u int not null
+ │    ├── v int not null
+ │    └── rowid int not null (hidden) (storing)
+ └── INDEX secondary
+      ├── v int not null
+      ├── w int not null
+      └── rowid int not null (hidden) (storing)
+
 # --------------------------------------------------
 # ConvertGroupByToDistinct
 # --------------------------------------------------
@@ -255,17 +302,22 @@ group-by
            └── variable: a.s [type=string, outer=(4)]
 
 opt
-SELECT k, sum(DISTINCT i), f, s FROM a GROUP BY s, f, k
+SELECT k, sum(DISTINCT i), f, s FROM a, xy GROUP BY s, f, k
 ----
 group-by
- ├── columns: k:1(int!null) sum:6(decimal) f:3(float) s:4(string)
+ ├── columns: k:1(int!null) sum:8(decimal) f:3(float) s:4(string)
  ├── grouping columns: k:1(int!null)
  ├── key: (1)
- ├── fd: (1)-->(3,4,6)
- ├── scan a
+ ├── fd: (1)-->(3,4,8)
+ ├── inner-join
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null)
- │    ├── key: (1)
- │    └── fd: (1)-->(2-4), (2,4)-->(1,3), (2,3)~~>(1,4)
+ │    ├── fd: (1)-->(2-4), (2,4)-->(1,3), (2,3)~~>(1,4)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-4), (2,4)-->(1,3), (2,3)~~>(1,4)
+ │    ├── scan xy
+ │    └── true [type=bool]
  └── aggregations [outer=(2-4)]
       ├── sum [type=decimal, outer=(2)]
       │    └── agg-distinct [type=int, outer=(2)]
@@ -344,3 +396,129 @@ distinct-on
       │    └── variable: xy.x [type=int, outer=(6)]
       └── const-agg [type=float, outer=(3)]
            └── variable: a.f [type=float, outer=(3)]
+
+# --------------------------------------------------
+# EliminateAggDistinctForKeys
+# --------------------------------------------------
+
+# ScalarGroupBy with key argument. Only the first aggregation can be
+# simplified.
+opt
+SELECT sum(DISTINCT k), sum(DISTINCT i) FROM a
+----
+scalar-group-by
+ ├── columns: sum:6(decimal) sum:7(decimal)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(6,7)
+ ├── scan a@fi_idx
+ │    ├── columns: k:1(int!null) i:2(int!null)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── aggregations [outer=(1,2)]
+      ├── sum [type=decimal, outer=(1)]
+      │    └── variable: a.k [type=int, outer=(1)]
+      └── sum [type=decimal, outer=(2)]
+           └── agg-distinct [type=int, outer=(2)]
+                └── variable: a.i [type=int, outer=(2)]
+
+# GroupBy with key argument.
+opt
+SELECT sum(DISTINCT k) FROM a GROUP BY i
+----
+project
+ ├── columns: sum:6(decimal)
+ └── group-by
+      ├── columns: i:2(int!null) sum:6(decimal)
+      ├── grouping columns: i:2(int!null)
+      ├── key: (2)
+      ├── fd: (2)-->(6)
+      ├── scan a@fi_idx
+      │    ├── columns: k:1(int!null) i:2(int!null)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── aggregations [outer=(1)]
+           └── sum [type=decimal, outer=(1)]
+                └── variable: a.k [type=int, outer=(1)]
+
+# GroupBy with no key.
+opt
+SELECT sum(DISTINCT a) FROM abc GROUP BY b
+----
+project
+ ├── columns: sum:4(decimal)
+ └── group-by
+      ├── columns: b:2(int!null) sum:4(decimal)
+      ├── grouping columns: b:2(int!null)
+      ├── key: (2)
+      ├── fd: (2)-->(4)
+      ├── scan abc
+      │    └── columns: a:1(int!null) b:2(int!null)
+      └── aggregations [outer=(1)]
+           └── sum [type=decimal, outer=(1)]
+                └── agg-distinct [type=int, outer=(1)]
+                     └── variable: abc.a [type=int, outer=(1)]
+
+# GroupBy with composite key formed by argument plus grouping columns.
+opt
+SELECT sum(DISTINCT a) FROM abc GROUP BY b, c
+----
+project
+ ├── columns: sum:4(decimal)
+ └── group-by
+      ├── columns: b:2(int!null) c:3(int!null) sum:4(decimal)
+      ├── grouping columns: b:2(int!null) c:3(int!null)
+      ├── key: (2,3)
+      ├── fd: (2,3)-->(4)
+      ├── scan abc
+      │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      │    └── key: (1-3)
+      └── aggregations [outer=(1)]
+           └── sum [type=decimal, outer=(1)]
+                └── variable: abc.a [type=int, outer=(1)]
+
+# GroupBy with multiple aggregations simplified.
+opt
+SELECT sum(DISTINCT i), avg(DISTINCT f) FROM a GROUP BY k
+----
+project
+ ├── columns: sum:6(decimal) avg:7(float)
+ └── group-by
+      ├── columns: k:1(int!null) sum:6(decimal) avg:7(float)
+      ├── grouping columns: k:1(int!null)
+      ├── key: (1)
+      ├── fd: (1)-->(6,7)
+      ├── scan a@fi_idx
+      │    ├── columns: k:1(int!null) i:2(int!null) f:3(float)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2,3), (2,3)~~>(1)
+      └── aggregations [outer=(2,3)]
+           ├── sum [type=decimal, outer=(2)]
+           │    └── variable: a.i [type=int, outer=(2)]
+           └── avg [type=float, outer=(3)]
+                └── variable: a.f [type=float, outer=(3)]
+
+# GroupBy where only some aggregations are simplified (the table has
+# keys u,v and v,w).
+opt
+SELECT sum(DISTINCT u), stddev(DISTINCT w), avg(DISTINCT z) FROM uvwz GROUP BY v
+----
+project
+ ├── columns: sum:6(decimal) stddev:7(decimal) avg:8(decimal)
+ └── group-by
+      ├── columns: v:2(int!null) sum:6(decimal) stddev:7(decimal) avg:8(decimal)
+      ├── grouping columns: v:2(int!null)
+      ├── key: (2)
+      ├── fd: (2)-->(6-8)
+      ├── scan uvwz
+      │    ├── columns: u:1(int!null) v:2(int!null) w:3(int!null) z:4(int!null)
+      │    ├── key: (2,3)
+      │    └── fd: (1,2)-->(3,4), (2,3)-->(1,4)
+      └── aggregations [outer=(1,3,4)]
+           ├── sum [type=decimal, outer=(1)]
+           │    └── variable: uvwz.u [type=int, outer=(1)]
+           ├── std-dev [type=decimal, outer=(3)]
+           │    └── variable: uvwz.w [type=int, outer=(3)]
+           └── avg [type=decimal, outer=(4)]
+                └── agg-distinct [type=int, outer=(4)]
+                     └── variable: uvwz.z [type=int, outer=(4)]

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -254,6 +254,27 @@ group-by
       └── const-agg [type=string, outer=(4)]
            └── variable: a.s [type=string, outer=(4)]
 
+opt
+SELECT k, sum(DISTINCT i), f, s FROM a GROUP BY s, f, k
+----
+group-by
+ ├── columns: k:1(int!null) sum:6(decimal) f:3(float) s:4(string)
+ ├── grouping columns: k:1(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(3,4,6)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4), (2,4)-->(1,3), (2,3)~~>(1,4)
+ └── aggregations [outer=(2-4)]
+      ├── sum [type=decimal, outer=(2)]
+      │    └── agg-distinct [type=int, outer=(2)]
+      │         └── variable: a.i [type=int, outer=(2)]
+      ├── const-agg [type=float, outer=(3)]
+      │    └── variable: a.f [type=float, outer=(3)]
+      └── const-agg [type=string, outer=(4)]
+           └── variable: a.s [type=string, outer=(4)]
+
 # Eliminated columns are not part of projection.
 opt
 SELECT min(f) FROM a GROUP BY i, s, k

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -212,11 +212,15 @@ define AntiJoinApply {
 # GroupBy computes aggregate functions over groups of input rows. Input rows
 # that are equal on the grouping columns are grouped together. The set of
 # computed aggregate functions is described by the Aggregations field (which is
-# always an Aggregations operator). The arguments of the aggregate functions are
-# columns from the input. If the set of input rows is empty, then the output of
-# the GroupBy operator will also be empty. If the grouping columns are empty,
-# then all input rows form a single group. GroupBy is used for queries with
-# aggregate functions, HAVING clauses and/or GROUP BY expressions.
+# always an Aggregations operator).
+#
+# The arguments of the aggregate functions are columns from the input
+# (i.e. Variables), possibly wrapped in aggregate modifiers like AggDistinct.
+#
+# If the set of input rows is empty, then the output of the GroupBy operator
+# will also be empty. If the grouping columns are empty, then all input rows
+# form a single group. GroupBy is used for queries with aggregate functions,
+# HAVING clauses and/or GROUP BY expressions.
 #
 # The Def private contains an ordering; this ordering is used to determine
 # intra-group ordering and is only useful if there is an order-dependent

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -134,8 +134,13 @@ define Projections {
 
 # Aggregations is a set of aggregate expressions that will become output columns
 # for a containing GroupBy operator. The expressions can only consist of
-# aggregate functions and variable references. More complex expressions must be
-# formulated using a Project operator as input to the GroupBy operator.
+# aggregate functions, variable references, and modifiers like AggDistinct.
+# Examples of valid expressions:
+#   (Min (Variable 1))
+#   (Count (AggDistinct (Variable 1)))
+#
+# More complex arguments must be formulated using a Project operator as input to
+# the GroupBy operator.
 #
 # The private Cols field contains the list of column indexes returned by the
 # expression, as an opt.ColList. It is legal for Cols to be empty.
@@ -653,5 +658,13 @@ define ConstNotNullAgg {
 # FirstAggs in a DistinctOn.
 [Scalar, Aggregate]
 define FirstAgg {
+    Input Expr
+}
+
+# AggDistinct is used as a modifier that wraps the input of an aggregate
+# function. It causes the respective aggregation to only process each distinct
+# value once.
+[Scalar]
+define AggDistinct {
     Input Expr
 }

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -376,7 +376,7 @@ func (s *scope) findAggregate(agg aggregateInfo) *scopeColumn {
 	for i, a := range s.groupby.aggs {
 		// Find an existing aggregate that has the same function and the same
 		// arguments.
-		if a.def == agg.def && len(a.args) == len(agg.args) {
+		if a.def == agg.def && a.distinct == agg.distinct && len(a.args) == len(agg.args) {
 			match := true
 			for j, arg := range a.args {
 				if arg != agg.args[j] {

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -791,6 +791,113 @@ scalar-group-by
            └── variable: column5 [type=tuple{int AS k, int AS v, int AS w, string AS s}]
 
 build
+SELECT count(DISTINCT k), count(DISTINCT v), count(DISTINCT (v)) FROM kv
+----
+scalar-group-by
+ ├── columns: count:5(int) count:6(int) count:6(int)
+ ├── project
+ │    ├── columns: k:1(int!null) v:2(int)
+ │    └── scan kv
+ │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ └── aggregations
+      ├── count [type=int]
+      │    └── agg-distinct [type=int]
+      │         └── variable: kv.k [type=int]
+      └── count [type=int]
+           └── agg-distinct [type=int]
+                └── variable: kv.v [type=int]
+
+build
+SELECT upper(s), count(DISTINCT k), count(DISTINCT v), count(DISTINCT (v)) FROM kv GROUP BY upper(s)
+----
+group-by
+ ├── columns: upper:5(string) count:6(int) count:7(int) count:7(int)
+ ├── grouping columns: column5:5(string)
+ ├── project
+ │    ├── columns: column5:5(string) k:1(int!null) v:2(int)
+ │    ├── scan kv
+ │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    └── projections
+ │         └── function: upper [type=string]
+ │              └── variable: kv.s [type=string]
+ └── aggregations
+      ├── count [type=int]
+      │    └── agg-distinct [type=int]
+      │         └── variable: kv.k [type=int]
+      └── count [type=int]
+           └── agg-distinct [type=int]
+                └── variable: kv.v [type=int]
+
+build
+SELECT count((k, v)) FROM kv
+----
+scalar-group-by
+ ├── columns: count:6(int)
+ ├── project
+ │    ├── columns: column5:5(tuple{int, int})
+ │    ├── scan kv
+ │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    └── projections
+ │         └── tuple [type=tuple{int, int}]
+ │              ├── variable: kv.k [type=int]
+ │              └── variable: kv.v [type=int]
+ └── aggregations
+      └── count [type=int]
+           └── variable: column5 [type=tuple{int, int}]
+
+build
+SELECT count(DISTINCT (k, v)) FROM kv
+----
+scalar-group-by
+ ├── columns: count:6(int)
+ ├── project
+ │    ├── columns: column5:5(tuple{int, int})
+ │    ├── scan kv
+ │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    └── projections
+ │         └── tuple [type=tuple{int, int}]
+ │              ├── variable: kv.k [type=int]
+ │              └── variable: kv.v [type=int]
+ └── aggregations
+      └── count [type=int]
+           └── agg-distinct [type=tuple{int, int}]
+                └── variable: column5 [type=tuple{int, int}]
+
+build
+SELECT count(DISTINCT (k, (v))) FROM kv
+----
+scalar-group-by
+ ├── columns: count:6(int)
+ ├── project
+ │    ├── columns: column5:5(tuple{int, int})
+ │    ├── scan kv
+ │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    └── projections
+ │         └── tuple [type=tuple{int, int}]
+ │              ├── variable: kv.k [type=int]
+ │              └── variable: kv.v [type=int]
+ └── aggregations
+      └── count [type=int]
+           └── agg-distinct [type=tuple{int, int}]
+                └── variable: column5 [type=tuple{int, int}]
+
+build
+SELECT count(*) FROM kv a, kv b
+----
+scalar-group-by
+ ├── columns: count:9(int)
+ ├── project
+ │    └── inner-join
+ │         ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string) kv.k:5(int!null) kv.v:6(int) kv.w:7(int) kv.s:8(string)
+ │         ├── scan kv
+ │         │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+ │         ├── scan kv
+ │         │    └── columns: kv.k:5(int!null) kv.v:6(int) kv.w:7(int) kv.s:8(string)
+ │         └── true [type=bool]
+ └── aggregations
+      └── count-rows [type=int]
+
+build
 SELECT count((k, v)) FROM kv LIMIT 1
 ----
 limit
@@ -1035,6 +1142,29 @@ scalar-group-by
       │    └── variable: column5 [type=decimal]
       └── sum [type=decimal]
            └── variable: column7 [type=decimal]
+
+build
+SELECT avg(DISTINCT k), avg(DISTINCT v), sum(DISTINCT k), sum(DISTINCT v) FROM kv
+----
+scalar-group-by
+ ├── columns: avg:5(decimal) avg:6(decimal) sum:7(decimal) sum:8(decimal)
+ ├── project
+ │    ├── columns: k:1(int!null) v:2(int)
+ │    └── scan kv
+ │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ └── aggregations
+      ├── avg [type=decimal]
+      │    └── agg-distinct [type=int]
+      │         └── variable: kv.k [type=int]
+      ├── avg [type=decimal]
+      │    └── agg-distinct [type=int]
+      │         └── variable: kv.v [type=int]
+      ├── sum [type=decimal]
+      │    └── agg-distinct [type=int]
+      │         └── variable: kv.k [type=int]
+      └── sum [type=decimal]
+           └── agg-distinct [type=int]
+                └── variable: kv.v [type=int]
 
 build
 SELECT avg(k) * 2.0 + max(v)::DECIMAL AS r FROM kv
@@ -2448,7 +2578,16 @@ project
 build
 SELECT sum(DISTINCT abc.d) FROM abc
 ----
-error (0A000): aggregates with DISTINCT are not supported yet
+scalar-group-by
+ ├── columns: sum:5(decimal)
+ ├── project
+ │    ├── columns: d:4(decimal)
+ │    └── scan abc
+ │         └── columns: a:1(string!null) b:2(float) c:3(bool) d:4(decimal)
+ └── aggregations
+      └── sum [type=decimal]
+           └── agg-distinct [type=decimal]
+                └── variable: abc.d [type=decimal]
 
 build
 SELECT sum(abc.d) FILTER (WHERE abc.d > 0) FROM abc

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -14,15 +14,19 @@ TABLE abc
  └── INDEX primary
       └── a string not null
 
+# --------------------------------------------------
+# ReplaceMinWithLimit
+# --------------------------------------------------
+
 opt
-select max(a) FROM abc
+SELECT min(a) FROM abc
 ----
 scalar-group-by
- ├── columns: max:5(string)
+ ├── columns: min:5(string)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(5)
- ├── scan abc,rev
+ ├── scan abc
  │    ├── columns: a:1(string!null)
  │    ├── limit: 1
  │    ├── key: ()
@@ -31,58 +35,9 @@ scalar-group-by
       └── const-agg [type=string, outer=(1)]
            └── variable: abc.a [type=string, outer=(1)]
 
+# Verify the rule still fires even if DISTINCT is used.
 opt
-select max(b) FROM abc
-----
-scalar-group-by
- ├── columns: max:5(float)
- ├── cardinality: [1 - 1]
- ├── key: ()
- ├── fd: ()-->(5)
- ├── scan abc
- │    └── columns: b:2(float)
- └── aggregations [outer=(2)]
-      └── max [type=float, outer=(2)]
-           └── variable: abc.b [type=float, outer=(2)]
-
-memo
-select max(b) from abc
-----
-memo (optimized)
- ├── G1: (scalar-group-by G9 G2 cols=()) (scalar-group-by G3 G4 cols=())
- │    └── "[presentation: max:5]"
- │         ├── best: (scalar-group-by G9 G2 cols=())
- │         └── cost: 1060.01
- ├── G2: (aggregations G5)
- ├── G3: (limit G6 G7 ordering=-2)
- │    └── ""
- │         ├── best: (limit G6="[ordering: -2]" G7 ordering=-2)
- │         └── cost: 1119.22
- ├── G4: (aggregations G8)
- ├── G5: (max G12)
- ├── G6: (select G9 G10)
- │    ├── ""
- │    │    ├── best: (select G9 G10)
- │    │    └── cost: 1060.00
- │    └── "[ordering: -2]"
- │         ├── best: (sort G6)
- │         └── cost: 1119.21
- ├── G7: (const 1)
- ├── G8: (const-agg G12)
- ├── G9: (scan abc,cols=(2)) (scan abc,rev,cols=(2))
- │    ├── ""
- │    │    ├── best: (scan abc,cols=(2))
- │    │    └── cost: 1050.00
- │    └── "[ordering: -2]"
- │         ├── best: (sort G9)
- │         └── cost: 1259.32
- ├── G10: (filters G11)
- ├── G11: (is-not G12 G13)
- ├── G12: (variable abc.b)
- └── G13: (null)
-
-opt
-SELECT min(a) FROM abc
+SELECT min(DISTINCT a) FROM abc
 ----
 scalar-group-by
  ├── columns: min:5(string)
@@ -626,3 +581,93 @@ memo (optimized)
  ├── G11: (is-not G12 G13)
  ├── G12: (variable abc.b)
  └── G13: (null)
+
+# --------------------------------------------------
+# ReplaceMaxWithLimit
+# --------------------------------------------------
+
+opt
+select max(a) FROM abc
+----
+scalar-group-by
+ ├── columns: max:5(string)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(5)
+ ├── scan abc,rev
+ │    ├── columns: a:1(string!null)
+ │    ├── limit: 1
+ │    ├── key: ()
+ │    └── fd: ()-->(1)
+ └── aggregations [outer=(1)]
+      └── const-agg [type=string, outer=(1)]
+           └── variable: abc.a [type=string, outer=(1)]
+
+# Verify the rule still fires even if DISTINCT is used.
+opt
+select max(DISTINCT a) FROM abc
+----
+scalar-group-by
+ ├── columns: max:5(string)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(5)
+ ├── scan abc,rev
+ │    ├── columns: a:1(string!null)
+ │    ├── limit: 1
+ │    ├── key: ()
+ │    └── fd: ()-->(1)
+ └── aggregations [outer=(1)]
+      └── const-agg [type=string, outer=(1)]
+           └── variable: abc.a [type=string, outer=(1)]
+
+opt
+select max(b) FROM abc
+----
+scalar-group-by
+ ├── columns: max:5(float)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(5)
+ ├── scan abc
+ │    └── columns: b:2(float)
+ └── aggregations [outer=(2)]
+      └── max [type=float, outer=(2)]
+           └── variable: abc.b [type=float, outer=(2)]
+
+memo
+select max(b) from abc
+----
+memo (optimized)
+ ├── G1: (scalar-group-by G9 G2 cols=()) (scalar-group-by G3 G4 cols=())
+ │    └── "[presentation: max:5]"
+ │         ├── best: (scalar-group-by G9 G2 cols=())
+ │         └── cost: 1060.01
+ ├── G2: (aggregations G5)
+ ├── G3: (limit G6 G7 ordering=-2)
+ │    └── ""
+ │         ├── best: (limit G6="[ordering: -2]" G7 ordering=-2)
+ │         └── cost: 1119.22
+ ├── G4: (aggregations G8)
+ ├── G5: (max G12)
+ ├── G6: (select G9 G10)
+ │    ├── ""
+ │    │    ├── best: (select G9 G10)
+ │    │    └── cost: 1060.00
+ │    └── "[ordering: -2]"
+ │         ├── best: (sort G6)
+ │         └── cost: 1119.21
+ ├── G7: (const 1)
+ ├── G8: (const-agg G12)
+ ├── G9: (scan abc,cols=(2)) (scan abc,rev,cols=(2))
+ │    ├── ""
+ │    │    ├── best: (scan abc,cols=(2))
+ │    │    └── cost: 1050.00
+ │    └── "[ordering: -2]"
+ │         ├── best: (sort G9)
+ │         └── cost: 1259.32
+ ├── G10: (filters G11)
+ ├── G11: (is-not G12 G13)
+ ├── G12: (variable abc.b)
+ └── G13: (null)
+

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -383,6 +383,9 @@ func (ef *execFactory) constructGroupBy(
 			aggFn,
 			ef.planner.EvalContext().Mon.MakeBoundAccount(),
 		)
+		if agg.Distinct {
+			f.setDistinct()
+		}
 		n.funcs = append(n.funcs, f)
 		n.columns = append(n.columns, sqlbase.ResultColumn{
 			Name: fmt.Sprintf("agg%d", i),


### PR DESCRIPTION
#### opt: support DISTINCT for aggregates

Adding optbuilder and execbuilder support for DISTINCT aggregate
arguments. We use a new `AggDistinct` operator which acts as a
modifier that wraps the Variable argument.

Note that DISTINCT does not affect any existing normalization rules;
e.g. it does not change whether an aggregation ignores nulls. The
existing rules should work just the same; added a few testcases.

Release note: None

#### opt: remove DISTINCT from aggregations for which it makes no difference

Some aggregations, like `min`, are unaffected by `DISTINCT`. Add
normalization rule to remove `AggDistinct` in these cases.

Release note: None

#### opt: remove DISTINCT when argument is unique within group

This change introduces a rule that removes `AggDistinct` if we can
prove that there are no duplicate input values within a group (i.e.
the input column plus the grouping columns form a key).

Release note: None