### PR TITLE
cli: Add rangelog info to debug zip

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -2230,6 +2230,7 @@ func TestZip(t *testing.T) {
 	const expected = `debug zip ` + os.DevNull + `
 writing ` + os.DevNull + `
   debug/events
+  debug/rangelog
   debug/liveness
   debug/settings
   debug/gossip/liveness

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -103,9 +103,10 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 		eventsName    = base + "/events"
 		gossipLName   = base + "/gossip/liveness"
 		gossipNName   = base + "/gossip/nodes"
-		metricsName   = base + "/metrics"
 		livenessName  = base + "/liveness"
+		metricsName   = base + "/metrics"
 		nodesPrefix   = base + "/nodes"
+		rangelogName  = base + "/rangelog"
 		reportsPrefix = base + "/reports"
 		schemaPrefix  = base + "/schema"
 		settingsName  = base + "/settings"
@@ -156,6 +157,20 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 			}
 		} else {
 			if err := z.createJSON(eventsName, events); err != nil {
+				return err
+			}
+		}
+	}
+
+	{
+		ctx, cancel := timeoutCtx(baseCtx)
+		defer cancel()
+		if rangelog, err := admin.RangeLog(ctx, &serverpb.RangeLogRequest{}); err != nil {
+			if err := z.createError(rangelogName, err); err != nil {
+				return err
+			}
+		} else {
+			if err := z.createJSON(rangelogName, rangelog); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Using the rangelog admin server endpoint, which currently grabs the
entire rangelog without an ORDER BY or LIMIT clause due to the
performance reasons outlined in #18159.

Release note (cli change): The file generated by running debug zip
now contains the contents of the system.rangelog table, which is a
record of range splits and rebalances in the cluster.