### PR TITLE
release-2.0: Avoid OOMs when raft logs are very large

### DIFF
--- a/pkg/kv/leaseholder_cache_test.go
+++ b/pkg/kv/leaseholder_cache_test.go
@@ -31,7 +31,7 @@ func staticSize(size int64) func() int64 {
 func TestLeaseHolderCache(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.TODO()
-	cacheSize := 1 << 5
+	cacheSize := (1 << 4) * defaultShards
 	lc := NewLeaseHolderCache(staticSize(int64(cacheSize)))
 	if repStoreID, ok := lc.Lookup(ctx, 12); ok {
 		t.Errorf("lookup of missing key returned: %d", repStoreID)
@@ -70,7 +70,7 @@ func TestLeaseHolderCache(t *testing.T) {
 func BenchmarkLeaseHolderCacheParallel(b *testing.B) {
 	defer leaktest.AfterTest(b)()
 	ctx := context.TODO()
-	cacheSize := 1 << 6
+	cacheSize := (1 << 4) * defaultShards
 	lc := NewLeaseHolderCache(staticSize(int64(cacheSize)))
 	numRanges := 2 * len(lc.shards)
 	for i := 1; i <= numRanges; i++ {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -791,7 +791,7 @@ func (r *Replica) destroyDataRaftMuLocked(
 	// NB: this uses the local descriptor instead of the consistent one to match
 	// the data on disk.
 	desc := r.Desc()
-	if err := clearRangeData(ctx, desc, ms.KeyCount, r.store.Engine(), batch); err != nil {
+	if err := clearRangeData(ctx, desc, r.store.Engine(), batch); err != nil {
 		return err
 	}
 	clearTime := timeutil.Now()

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -440,6 +440,7 @@ type OutgoingSnapshot struct {
 	// sideloaded storage in the meantime.
 	WithSideloaded func(func(sideloadStorage) error) error
 	RaftEntryCache *raftEntryCache
+	snapType       string
 }
 
 // Close releases the resources associated with the snapshot.
@@ -534,6 +535,7 @@ func snapshot(
 				ConfState: cs,
 			},
 		},
+		snapType: snapType,
 	}, nil
 }
 

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -638,11 +638,7 @@ const (
 )
 
 func clearRangeData(
-	ctx context.Context,
-	desc *roachpb.RangeDescriptor,
-	keyCount int64,
-	eng engine.Engine,
-	batch engine.Batch,
+	ctx context.Context, desc *roachpb.RangeDescriptor, eng engine.Engine, batch engine.Batch,
 ) error {
 	iter := eng.NewIterator(false)
 	defer iter.Close()
@@ -655,12 +651,33 @@ func clearRangeData(
 	// perhaps we should fix RocksDB to handle large numbers of tombstones in an
 	// sstable better.
 	const clearRangeMinKeys = 64
-	const metadataRanges = 2
-	for i, keyRange := range rditer.MakeAllKeyRanges(desc) {
-		// Metadata ranges always have too few keys to justify ClearRange (see
-		// above), but the data range's key count needs to be explicitly checked.
+	keyRanges := rditer.MakeAllKeyRanges(desc)
+	for _, keyRange := range keyRanges {
+		// Peek into the range to see whether it's large enough to justify
+		// ClearRange. Note that the work done here is bounded by
+		// clearRangeMinKeys, so it will be fairly cheap even for large
+		// ranges.
+		//
+		// TODO(bdarnell): Move this into ClearIterRange so we don't have
+		// to do this scan twice.
+		count := 0
+		iter.Seek(keyRange.Start)
+		for {
+			valid, err := iter.Valid()
+			if err != nil {
+				return err
+			}
+			if !valid || !iter.Key().Less(keyRange.End) {
+				break
+			}
+			count++
+			if count > clearRangeMinKeys {
+				break
+			}
+			iter.Next()
+		}
 		var err error
-		if i >= metadataRanges && keyCount >= clearRangeMinKeys {
+		if count > clearRangeMinKeys {
 			err = batch.ClearRange(keyRange.Start, keyRange.End)
 		} else {
 			err = batch.ClearIterRange(iter, keyRange.Start, keyRange.End)
@@ -689,7 +706,6 @@ func (r *Replica) applySnapshot(
 
 	r.mu.RLock()
 	replicaID := r.mu.replicaID
-	keyCount := r.mu.state.Stats.KeyCount
 	r.mu.RUnlock()
 
 	snapType := inSnap.snapType
@@ -766,7 +782,7 @@ func (r *Replica) applySnapshot(
 	// Delete everything in the range and recreate it from the snapshot.
 	// We need to delete any old Raft log entries here because any log entries
 	// that predate the snapshot will be orphaned and never truncated or GC'd.
-	if err := clearRangeData(ctx, s.Desc, keyCount, r.store.Engine(), batch); err != nil {
+	if err := clearRangeData(ctx, s.Desc, r.store.Engine(), batch); err != nil {
 		return err
 	}
 	stats.clear = timeutil.Now()

--- a/pkg/storage/store_snapshot_test.go
+++ b/pkg/storage/store_snapshot_test.go
@@ -1,0 +1,105 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package storage
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/coreos/etcd/raft/raftpb"
+)
+
+func TestSnapshotRaftLogLimit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	store, _ := createTestStore(t, stopper)
+	store.SetRaftLogQueueActive(false)
+	repl, err := store.GetReplica(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var bytesWritten int64
+	blob := []byte(strings.Repeat("a", 1024*1024))
+	for i := 0; bytesWritten < 5*raftLogMaxSize; i++ {
+		pArgs := putArgs(roachpb.Key("a"), blob)
+		_, pErr := client.SendWrappedWith(ctx, store, roachpb.Header{RangeID: 1}, &pArgs)
+		if pErr != nil {
+			t.Fatal(pErr)
+		}
+		bytesWritten += int64(len(blob))
+	}
+
+	for _, snapType := range []string{snapTypePreemptive, snapTypeRaft} {
+		t.Run(snapType, func(t *testing.T) {
+			lastIndex, err := (*replicaRaftStorage)(repl).LastIndex()
+			if err != nil {
+				t.Fatal(err)
+			}
+			eng := store.Engine()
+			snap := eng.NewSnapshot()
+			defer snap.Close()
+
+			iter := rditer.NewReplicaDataIterator(repl.Desc(), snap, true /* replicatedOnly */)
+			defer iter.Close()
+			outSnap := &OutgoingSnapshot{
+				Iter:       iter,
+				EngineSnap: snap,
+				snapType:   snapType,
+				RaftSnap: raftpb.Snapshot{
+					Metadata: raftpb.SnapshotMetadata{
+						Index: lastIndex,
+					},
+				},
+			}
+
+			stream := fakeSnapshotStream{
+				nextResp: &SnapshotResponse{
+					Status: SnapshotResponse_ACCEPTED,
+				},
+			}
+			header := SnapshotRequest_Header{
+				State:    repl.State().ReplicaState,
+				Priority: SnapshotRequest_RECOVERY,
+			}
+
+			err = sendSnapshot(ctx, store.ClusterSettings(), stream, store.cfg.StorePool, header, outSnap,
+				eng.NewBatch, func() {})
+			if snapType == snapTypePreemptive {
+				if !testutils.IsError(err, "aborting snapshot because raft log is too large") {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else {
+				// HACK: the release-2.0 version of the snapshot code is not
+				// well-factored for testing, so we just guarantee that we
+				// make it through to the end and get an "expected EOF" error.
+				if !testutils.IsError(err, "expected EOF") {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Backports #28293 (and sneaks in a backport of #22915 because my new laptop has enough cores to make leaseholdercache_test.go fail).

There were some merge conflicts, mainly in the second commit. 