### PR TITLE
sql: disallow specifying both FORCE_INDEX and NO_INDEX_JOIN

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1710,7 +1710,7 @@ distinct_on_clause ::=
 	'DISTINCT' 'ON' '(' expr_list ')'
 
 table_ref ::=
-	relation_expr opt_index_hints opt_ordinality opt_alias_clause
+	relation_expr opt_index_flags opt_ordinality opt_alias_clause
 	| select_with_parens opt_ordinality opt_alias_clause
 	| joined_table
 	| '(' joined_table ')' opt_ordinality alias_clause
@@ -1915,10 +1915,10 @@ from_list ::=
 window_definition_list ::=
 	( window_definition ) ( ( ',' window_definition ) )*
 
-opt_index_hints ::=
+opt_index_flags ::=
 	'@' index_name
 	| '@' '[' iconst64 ']'
-	| '@' '{' index_hints_param_list '}'
+	| '@' '{' index_flags_param_list '}'
 	| 
 
 opt_ordinality ::=
@@ -2058,8 +2058,8 @@ tuple1_unambiguous_values ::=
 window_definition ::=
 	window_name 'AS' window_specification
 
-index_hints_param_list ::=
-	( index_hints_param ) ( ( ',' index_hints_param ) )*
+index_flags_param_list ::=
+	( index_flags_param ) ( ( ',' index_flags_param ) )*
 
 join_type ::=
 	'FULL' join_outer
@@ -2135,7 +2135,7 @@ trim_list ::=
 	| 'FROM' expr_list
 	| expr_list
 
-index_hints_param ::=
+index_flags_param ::=
 	'FORCE_INDEX' '=' index_name
 	| 'NO_INDEX_JOIN'
 

--- a/docs/generated/sql/bnf/table_ref.bnf
+++ b/docs/generated/sql/bnf/table_ref.bnf
@@ -1,5 +1,5 @@
 table_ref ::=
-	table_name ( '@' scan_parameters | ) ( 'WITH' 'ORDINALITY' |  ) ( ( 'AS' table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) | table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) ) |  )
+	table_name opt_index_flags ( 'WITH' 'ORDINALITY' |  ) ( ( 'AS' table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) | table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) ) |  )
 	| '(' select_stmt ')' ( 'WITH' 'ORDINALITY' |  ) ( ( 'AS' table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) | table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) ) |  )
 	| joined_table
 	| '(' joined_table ')' ( 'WITH' 'ORDINALITY' |  ) ( ( 'AS' table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) | table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) ) |  )

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -100,7 +100,10 @@ func (p *planner) getVirtualDataSource(
 // getDataSource builds a planDataSource from a single data source clause
 // (TableExpr) in a SelectClause.
 func (p *planner) getDataSource(
-	ctx context.Context, src tree.TableExpr, hints *tree.IndexHints, scanVisibility scanVisibility,
+	ctx context.Context,
+	src tree.TableExpr,
+	indexFlags *tree.IndexFlags,
+	scanVisibility scanVisibility,
 ) (planDataSource, error) {
 	switch t := src.(type) {
 	case *tree.NormalizableTableName:
@@ -124,7 +127,7 @@ func (p *planner) getDataSource(
 		}
 
 		colCfg := scanColumnsConfig{visibility: scanVisibility}
-		return p.getPlanForDesc(ctx, desc, tn, hints, colCfg)
+		return p.getPlanForDesc(ctx, desc, tn, indexFlags, colCfg)
 
 	case *tree.RowsFromExpr:
 		return p.getPlanForRowsFrom(ctx, t.Items...)
@@ -160,19 +163,19 @@ func (p *planner) getDataSource(
 		}, nil
 
 	case *tree.ParenTableExpr:
-		return p.getDataSource(ctx, t.Expr, hints, scanVisibility)
+		return p.getDataSource(ctx, t.Expr, indexFlags, scanVisibility)
 
 	case *tree.TableRef:
-		return p.getTableScanByRef(ctx, t, hints, scanVisibility)
+		return p.getTableScanByRef(ctx, t, indexFlags, scanVisibility)
 
 	case *tree.AliasedTableExpr:
 		// Alias clause: source AS alias(cols...)
 
-		if t.Hints != nil {
-			hints = t.Hints
+		if t.IndexFlags != nil {
+			indexFlags = t.IndexFlags
 		}
 
-		src, err := p.getDataSource(ctx, t.Expr, hints, scanVisibility)
+		src, err := p.getDataSource(ctx, t.Expr, indexFlags, scanVisibility)
 		if err != nil {
 			return src, err
 		}
@@ -219,7 +222,10 @@ func (p *planner) getTableDescByID(
 }
 
 func (p *planner) getTableScanByRef(
-	ctx context.Context, tref *tree.TableRef, hints *tree.IndexHints, scanVisibility scanVisibility,
+	ctx context.Context,
+	tref *tree.TableRef,
+	indexFlags *tree.IndexFlags,
+	scanVisibility scanVisibility,
 ) (planDataSource, error) {
 	desc, err := p.getTableDescByID(ctx, sqlbase.ID(tref.TableID))
 	if err != nil {
@@ -241,7 +247,7 @@ func (p *planner) getTableScanByRef(
 		addUnwantedAsHidden: true,
 		visibility:          scanVisibility,
 	}
-	src, err := p.getPlanForDesc(ctx, desc, &tn, hints, colCfg)
+	src, err := p.getPlanForDesc(ctx, desc, &tn, indexFlags, colCfg)
 	if err != nil {
 		return src, err
 	}
@@ -311,7 +317,7 @@ func (p *planner) getPlanForDesc(
 	ctx context.Context,
 	desc *sqlbase.TableDescriptor,
 	tn *tree.TableName,
-	hints *tree.IndexHints,
+	indexFlags *tree.IndexFlags,
 	colCfg scanColumnsConfig,
 ) (planDataSource, error) {
 	if desc.IsView() {
@@ -331,7 +337,7 @@ func (p *planner) getPlanForDesc(
 
 	// This name designates a real table.
 	scan := p.Scan()
-	if err := scan.initTable(ctx, p, desc, hints, colCfg); err != nil {
+	if err := scan.initTable(ctx, p, desc, indexFlags, colCfg); err != nil {
 		return planDataSource{}, err
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/select_index_hints
+++ b/pkg/sql/logictest/testdata/logic_test/select_index_hints
@@ -98,6 +98,3 @@ SELECT * FROM abcd@badidx
 
 query error index \"badidx\" not found
 SELECT * FROM abcd@{FORCE_INDEX=badidx}
-
-query error index \"cd\" is not covering and NO_INDEX_JOIN was specified
-SELECT b, c, d FROM abcd@{FORCE_INDEX=cd,NO_INDEX_JOIN} WHERE c = 10

--- a/pkg/sql/logictest/testdata/planner_test/distsql_misc
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_misc
@@ -11,9 +11,9 @@ query T
 SELECT url FROM [EXPLAIN (DISTSQL)
     SELECT leftside.v, leftside.k, leftside.data, rightside.v, rightside.k, rightside.data
     FROM
-      (SELECT v,k,data FROM test@{FORCE_INDEX=[1],NO_INDEX_JOIN} ORDER BY v,k,data) AS leftside
+      (SELECT v,k,data FROM test@{FORCE_INDEX=[1]} ORDER BY v,k,data) AS leftside
     FULL OUTER JOIN
-      (SELECT v,k,data FROM test@{FORCE_INDEX=[2],NO_INDEX_JOIN} ORDER BY v,k,data) AS rightside
+      (SELECT v,k,data FROM test@{FORCE_INDEX=[2]} ORDER BY v,k,data) AS rightside
       ON leftside.v = rightside.v AND leftside.k = rightside.k AND leftside.data = rightside.data
     WHERE (leftside.k IS NULL) OR
           (rightside.k IS NULL)
@@ -44,7 +44,7 @@ SELECT url FROM [EXPLAIN (DISTSQL)
     FROM
       (SELECT child_id, id, id2 FROM child@{NO_INDEX_JOIN} ORDER BY id, id2) AS p
     FULL OUTER JOIN
-      (SELECT id, id2 FROM parent@{FORCE_INDEX=[2],NO_INDEX_JOIN} ORDER BY id, id2) AS c
+      (SELECT id, id2 FROM parent@{FORCE_INDEX=[2]} ORDER BY id, id2) AS c
       ON p.id = c.id AND p.id2 = c.id2
     WHERE (p.id IS NOT NULL OR p.id2 IS NOT NULL) AND
           c.id IS NULL AND c.id2 IS NULL

--- a/pkg/sql/logictest/testdata/planner_test/planning_errors
+++ b/pkg/sql/logictest/testdata/planner_test/planning_errors
@@ -3,10 +3,5 @@
 # Check that plans that fail during expansion/optimization do not cause
 # memory leaks. #17274
 
-statement error index "aa" is not covering
-CREATE TABLE kv(k INT, v INT);
- CREATE INDEX aa ON kv(v);
- SELECT k FROM [SHOW JOBS], kv@{FORCE_INDEX=aa,NO_INDEX_JOIN};
-
 statement error pgcode 42P01 relation "nonexistent" does not exist
 SELECT * FROM [SHOW JOBS], [SHOW CREATE TABLE nonexistent];

--- a/pkg/sql/logictest/testdata/planner_test/select_index_hints
+++ b/pkg/sql/logictest/testdata/planner_test/select_index_hints
@@ -149,19 +149,17 @@ render     ·      ·
 ·          spans  ALL
 
 query TTT
-EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=bcd,NO_INDEX_JOIN} WHERE c = 10
+EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=bcd} WHERE c = 10
 ----
 render     ·      ·
  └── scan  ·      ·
 ·          table  abcd@bcd
-·          hint   no index join
 ·          spans  ALL
 
 query TTT
-EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=primary,NO_INDEX_JOIN} WHERE c = 10
+EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=primary} WHERE c = 10
 ----
 render     ·      ·
  └── scan  ·      ·
 ·          table  abcd@primary
-·          hint   no index join
 ·          spans  ALL

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
@@ -13,9 +13,9 @@ subtest scrub
 # SELECT url FROM [EXPLAIN (DISTSQL)
 #     SELECT leftside.v, leftside.k, leftside.data, rightside.v, rightside.k, rightside.data
 #     FROM
-#       (SELECT v,k,data FROM test@{FORCE_INDEX=[1],NO_INDEX_JOIN} ORDER BY v,k,data) AS leftside
+#       (SELECT v,k,data FROM test@{FORCE_INDEX=[1]} ORDER BY v,k,data) AS leftside
 #     FULL OUTER JOIN
-#       (SELECT v,k,data FROM test@{FORCE_INDEX=[2],NO_INDEX_JOIN} ORDER BY v,k,data) AS rightside
+#       (SELECT v,k,data FROM test@{FORCE_INDEX=[2]} ORDER BY v,k,data) AS rightside
 #       ON leftside.v = rightside.v AND leftside.k = rightside.k AND leftside.data = rightside.data
 #     WHERE (leftside.k IS NULL) OR
 #           (rightside.k IS NULL)
@@ -46,7 +46,7 @@ subtest scrub
 #     FROM
 #       (SELECT child_id, id, id2 FROM child@{NO_INDEX_JOIN} ORDER BY id, id2) AS p
 #     FULL OUTER JOIN
-#       (SELECT id, id2 FROM parent@{FORCE_INDEX=[2],NO_INDEX_JOIN} ORDER BY id, id2) AS c
+#       (SELECT id, id2 FROM parent@{FORCE_INDEX=[2]} ORDER BY id, id2) AS c
 #       ON p.id = c.id AND p.id2 = c.id2
 #     WHERE (p.id IS NOT NULL OR p.id2 IS NOT NULL) AND
 #           c.id IS NULL AND c.id2 IS NULL

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_hints
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_hints
@@ -147,19 +147,17 @@ render     ·      ·
 ·          spans  ALL
 
 query TTT
-EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=bcd,NO_INDEX_JOIN} WHERE c = 10
+EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=bcd} WHERE c = 10
 ----
 render     ·      ·
  └── scan  ·      ·
 ·          table  abcd@bcd
-·          hint   no index join
 ·          spans  ALL
 
 query TTT
-EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=primary,NO_INDEX_JOIN} WHERE c = 10
+EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=primary} WHERE c = 10
 ----
 render     ·      ·
  └── scan  ·      ·
 ·          table  abcd@primary
-·          hint   no index join
 ·          spans  ALL

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -40,8 +40,8 @@ func (b *Builder) buildTable(texpr tree.TableExpr, inScope *scope) (outScope *sc
 	// NB: The case statements are sorted lexicographically.
 	switch source := texpr.(type) {
 	case *tree.AliasedTableExpr:
-		if source.Hints != nil {
-			panic(unimplementedf("index hints are not supported"))
+		if source.IndexFlags != nil {
+			panic(unimplementedf("index flags are not supported"))
 		}
 
 		outScope = b.buildTable(source.Expr, inScope)

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -530,7 +530,7 @@ offset
 build
 SELECT * FROM xyzw@foo
 ----
-error (0A000): index hints are not supported
+error (0A000): index flags are not supported
 
 exec-ddl
 CREATE TABLE boolean_table (

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -582,7 +582,6 @@ func TestParse(t *testing.T) {
 		{`SELECT 'a' FROM t@primary`},
 		{`SELECT 'a' FROM t@like`},
 		{`SELECT 'a' FROM t@{NO_INDEX_JOIN}`},
-		{`SELECT 'a' FROM t@{FORCE_INDEX=bar,NO_INDEX_JOIN}`},
 		{`SELECT * FROM t AS "of" AS OF SYSTEM TIME '2016-01-01'`},
 
 		{`SELECT BOOL 'foo'`},
@@ -854,9 +853,7 @@ func TestParse(t *testing.T) {
 		{`SELECT * FROM [123(1, 2, 3) AS t]`},
 		{`SELECT * FROM [123() AS t]`},
 		{`SELECT * FROM t@[123]`},
-		{`SELECT * FROM t@{FORCE_INDEX=[123],NO_INDEX_JOIN}`},
 		{`SELECT * FROM [123 AS t]@[456]`},
-		{`SELECT * FROM [123 AS t]@{FORCE_INDEX=[456],NO_INDEX_JOIN}`},
 
 		{`SELECT (1 + 2).*`},
 		{`SELECT (1 + 2).col`},
@@ -1084,8 +1081,6 @@ func TestParse2(t *testing.T) {
 		{`SELECT CAST(1 AS "_int8")`, `SELECT CAST(1 AS INT[])`},
 
 		{`SELECT 'a' FROM t@{FORCE_INDEX=bar}`, `SELECT 'a' FROM t@bar`},
-		{`SELECT 'a' FROM t@{NO_INDEX_JOIN,FORCE_INDEX=bar}`,
-			`SELECT 'a' FROM t@{FORCE_INDEX=bar,NO_INDEX_JOIN}`},
 
 		{`SELECT 'a' FROM t@{FORCE_INDEX=[123]}`, `SELECT 'a' FROM t@[123]`},
 		{`SELECT 'a' FROM [123 AS t]@{FORCE_INDEX=[456]}`, `SELECT 'a' FROM [123 AS t]@[456]`},
@@ -1857,10 +1852,10 @@ SELECT a FROM foo@{FORCE_INDEX=bar,FORCE_INDEX=baz}
 `,
 		},
 		{
-			`SELECT a FROM foo@{FORCE_INDEX=bar,NO_INDEX_JOIN,FORCE_INDEX=baz}`,
-			`FORCE_INDEX specified multiple times at or near "baz"
-SELECT a FROM foo@{FORCE_INDEX=bar,NO_INDEX_JOIN,FORCE_INDEX=baz}
-                                                             ^
+			`SELECT a FROM foo@{FORCE_INDEX=bar,NO_INDEX_JOIN}`,
+			`FORCE_INDEX cannot be specified in conjunction with NO_INDEX_JOIN at or near "no_index_join"
+SELECT a FROM foo@{FORCE_INDEX=bar,NO_INDEX_JOIN}
+                                   ^
 `,
 		},
 		{
@@ -1868,13 +1863,6 @@ SELECT a FROM foo@{FORCE_INDEX=bar,NO_INDEX_JOIN,FORCE_INDEX=baz}
 			`NO_INDEX_JOIN specified multiple times at or near "no_index_join"
 SELECT a FROM foo@{NO_INDEX_JOIN,NO_INDEX_JOIN}
                                  ^
-`,
-		},
-		{
-			`SELECT a FROM foo@{NO_INDEX_JOIN,FORCE_INDEX=baz,NO_INDEX_JOIN}`,
-			`NO_INDEX_JOIN specified multiple times at or near "no_index_join"
-SELECT a FROM foo@{NO_INDEX_JOIN,FORCE_INDEX=baz,NO_INDEX_JOIN}
-                                                 ^
 `,
 		},
 		{

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -5466,21 +5466,10 @@ index_hints_param_list:
   {
     a := $1.indexHints()
     b := $3.indexHints()
-    if a.NoIndexJoin && b.NoIndexJoin {
-       sqllex.Error("NO_INDEX_JOIN specified multiple times")
-       return 1
+    if err := a.CombineWith(b); err != nil {
+      sqllex.Error(err.Error())
+      return 1
     }
-    if (a.Index != "" || a.IndexID != 0) && (b.Index != "" || b.IndexID != 0) {
-       sqllex.Error("FORCE_INDEX specified multiple times")
-       return 1
-    }
-    // At this point either a or b contains "no information"
-    // (the empty string for Index and the value 0 for IndexID).
-    // Using the addition operator automatically selects the non-zero
-    // value, avoiding a conditional branch.
-    a.Index = a.Index + b.Index
-    a.IndexID = a.IndexID + b.IndexID
-    a.NoIndexJoin = a.NoIndexJoin || b.NoIndexJoin
     $$.val = a
   }
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -144,8 +144,8 @@ func (u *sqlSymUnion) tablePatterns() tree.TablePatterns {
 func (u *sqlSymUnion) normalizableTableNames() tree.NormalizableTableNames {
     return u.val.(tree.NormalizableTableNames)
 }
-func (u *sqlSymUnion) indexHints() *tree.IndexHints {
-    return u.val.(*tree.IndexHints)
+func (u *sqlSymUnion) indexFlags() *tree.IndexFlags {
+    return u.val.(*tree.IndexFlags)
 }
 func (u *sqlSymUnion) arraySubscript() *tree.ArraySubscript {
     return u.val.(*tree.ArraySubscript)
@@ -853,9 +853,9 @@ func newNameFromStr(s string) *tree.Name {
 %type <tree.Expr> where_clause
 %type <*tree.ArraySubscript> array_subscript
 %type <tree.Expr> opt_slice_bound
-%type <*tree.IndexHints> opt_index_hints
-%type <*tree.IndexHints> index_hints_param
-%type <*tree.IndexHints> index_hints_param_list
+%type <*tree.IndexFlags> opt_index_flags
+%type <*tree.IndexFlags> index_flags_param
+%type <*tree.IndexFlags> index_flags_param_list
 %type <tree.Expr> a_expr b_expr c_expr d_expr
 %type <tree.Expr> substr_from substr_for
 %type <tree.Expr> in_expr
@@ -5440,32 +5440,32 @@ from_list:
     $$.val = append($1.tblExprs(), $3.tblExpr())
   }
 
-index_hints_param:
+index_flags_param:
   FORCE_INDEX '=' index_name
   {
-     $$.val = &tree.IndexHints{Index: tree.UnrestrictedName($3)}
+     $$.val = &tree.IndexFlags{Index: tree.UnrestrictedName($3)}
   }
 | FORCE_INDEX '=' '[' iconst64 ']'
   {
     /* SKIP DOC */
-    $$.val = &tree.IndexHints{IndexID: tree.IndexID($4.int64())}
+    $$.val = &tree.IndexFlags{IndexID: tree.IndexID($4.int64())}
   }
 |
   NO_INDEX_JOIN
   {
-     $$.val = &tree.IndexHints{NoIndexJoin: true}
+     $$.val = &tree.IndexFlags{NoIndexJoin: true}
   }
 
-index_hints_param_list:
-  index_hints_param
+index_flags_param_list:
+  index_flags_param
   {
-    $$.val = $1.indexHints()
+    $$.val = $1.indexFlags()
   }
 |
-  index_hints_param_list ',' index_hints_param
+  index_flags_param_list ',' index_flags_param
   {
-    a := $1.indexHints()
-    b := $3.indexHints()
+    a := $1.indexFlags()
+    b := $3.indexFlags()
     if err := a.CombineWith(b); err != nil {
       sqllex.Error(err.Error())
       return 1
@@ -5473,22 +5473,22 @@ index_hints_param_list:
     $$.val = a
   }
 
-opt_index_hints:
+opt_index_flags:
   '@' index_name
   {
-    $$.val = &tree.IndexHints{Index: tree.UnrestrictedName($2)}
+    $$.val = &tree.IndexFlags{Index: tree.UnrestrictedName($2)}
   }
 | '@' '[' iconst64 ']'
   {
-    $$.val = &tree.IndexHints{IndexID: tree.IndexID($3.int64())}
+    $$.val = &tree.IndexFlags{IndexID: tree.IndexID($3.int64())}
   }
-| '@' '{' index_hints_param_list '}'
+| '@' '{' index_flags_param_list '}'
   {
-    $$.val = $3.indexHints()
+    $$.val = $3.indexFlags()
   }
 | /* EMPTY */
   {
-    $$.val = (*tree.IndexHints)(nil)
+    $$.val = (*tree.IndexFlags)(nil)
   }
 
 // %Help: <SOURCE> - define a data source for SELECT
@@ -5507,33 +5507,42 @@ opt_index_hints:
 //   '[' EXPLAIN ... ']'
 //   '[' SHOW ... ']'
 //
-// Index hints:
+// Index flags:
 //   '{' FORCE_INDEX = <idxname> [, ...] '}'
 //   '{' NO_INDEX_JOIN [, ...] '}'
 //
 // %SeeAlso: WEBDOCS/table-expressions.html
 table_ref:
-  '[' iconst64 opt_tableref_col_list alias_clause ']' opt_index_hints opt_ordinality opt_alias_clause
+  '[' iconst64 opt_tableref_col_list alias_clause ']' opt_index_flags opt_ordinality opt_alias_clause
   {
     /* SKIP DOC */
     $$.val = &tree.AliasedTableExpr{
-                 Expr: &tree.TableRef{
-                    TableID: $2.int64(),
-                    Columns: $3.tableRefCols(),
-                    As: $4.aliasClause(),
-                 },
-                 Hints: $6.indexHints(),
-                 Ordinality: $7.bool(),
-                 As: $8.aliasClause(),
-             }
+        Expr: &tree.TableRef{
+           TableID: $2.int64(),
+           Columns: $3.tableRefCols(),
+           As:      $4.aliasClause(),
+        },
+        IndexFlags: $6.indexFlags(),
+        Ordinality: $7.bool(),
+        As:         $8.aliasClause(),
+    }
   }
-| relation_expr opt_index_hints opt_ordinality opt_alias_clause
+| relation_expr opt_index_flags opt_ordinality opt_alias_clause
   {
-    $$.val = &tree.AliasedTableExpr{Expr: $1.newNormalizableTableNameFromUnresolvedName(), Hints: $2.indexHints(), Ordinality: $3.bool(), As: $4.aliasClause() }
+    $$.val = &tree.AliasedTableExpr{
+      Expr:       $1.newNormalizableTableNameFromUnresolvedName(),
+      IndexFlags: $2.indexFlags(),
+      Ordinality: $3.bool(),
+      As:         $4.aliasClause(),
+    }
   }
 | select_with_parens opt_ordinality opt_alias_clause
   {
-    $$.val = &tree.AliasedTableExpr{Expr: &tree.Subquery{Select: $1.selectStmt()}, Ordinality: $2.bool(), As: $3.aliasClause() }
+    $$.val = &tree.AliasedTableExpr{
+      Expr:       &tree.Subquery{Select: $1.selectStmt()},
+      Ordinality: $2.bool(),
+      As:         $3.aliasClause(),
+    }
   }
 | LATERAL select_with_parens opt_ordinality opt_alias_clause { return unimplementedWithIssue(sqllex, 24560) }
 | joined_table

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -279,7 +279,7 @@ func (n *scanNode) initTable(
 	ctx context.Context,
 	p *planner,
 	desc *sqlbase.TableDescriptor,
-	indexHints *tree.IndexHints,
+	indexFlags *tree.IndexFlags,
 	colCfg scanColumnsConfig,
 ) error {
 	n.desc = desc
@@ -290,20 +290,20 @@ func (n *scanNode) initTable(
 		}
 	}
 
-	if indexHints != nil {
-		if err := n.lookupSpecifiedIndex(indexHints); err != nil {
+	if indexFlags != nil {
+		if err := n.lookupSpecifiedIndex(indexFlags); err != nil {
 			return err
 		}
 	}
 
-	n.noIndexJoin = (indexHints != nil && indexHints.NoIndexJoin)
+	n.noIndexJoin = (indexFlags != nil && indexFlags.NoIndexJoin)
 	return n.initDescDefaults(p.curPlan.deps, colCfg)
 }
 
-func (n *scanNode) lookupSpecifiedIndex(indexHints *tree.IndexHints) error {
-	if indexHints.Index != "" {
+func (n *scanNode) lookupSpecifiedIndex(indexFlags *tree.IndexFlags) error {
+	if indexFlags.Index != "" {
 		// Search index by name.
-		indexName := string(indexHints.Index)
+		indexName := string(indexFlags.Index)
 		if indexName == n.desc.PrimaryIndex.Name {
 			n.specifiedIndex = &n.desc.PrimaryIndex
 		} else {
@@ -315,22 +315,22 @@ func (n *scanNode) lookupSpecifiedIndex(indexHints *tree.IndexHints) error {
 			}
 		}
 		if n.specifiedIndex == nil {
-			return errors.Errorf("index %q not found", tree.ErrString(&indexHints.Index))
+			return errors.Errorf("index %q not found", tree.ErrString(&indexFlags.Index))
 		}
-	} else if indexHints.IndexID != 0 {
+	} else if indexFlags.IndexID != 0 {
 		// Search index by ID.
-		if n.desc.PrimaryIndex.ID == sqlbase.IndexID(indexHints.IndexID) {
+		if n.desc.PrimaryIndex.ID == sqlbase.IndexID(indexFlags.IndexID) {
 			n.specifiedIndex = &n.desc.PrimaryIndex
 		} else {
 			for i := range n.desc.Indexes {
-				if n.desc.Indexes[i].ID == sqlbase.IndexID(indexHints.IndexID) {
+				if n.desc.Indexes[i].ID == sqlbase.IndexID(indexFlags.IndexID) {
 					n.specifiedIndex = &n.desc.Indexes[i]
 					break
 				}
 			}
 		}
 		if n.specifiedIndex == nil {
-			return errors.Errorf("index [%d] not found", indexHints.IndexID)
+			return errors.Errorf("index [%d] not found", indexFlags.IndexID)
 		}
 	}
 	return nil

--- a/pkg/sql/scrub_fk.go
+++ b/pkg/sql/scrub_fk.go
@@ -233,9 +233,9 @@ func (o *sqlForeignKeyCheckOperation) Close(ctx context.Context) {
 //
 //   SELECT p.id, p.dept_id
 //   FROM
-//     (SELECT id, dept_id FROM child@{FORCE_INDEX=[..],NO_INDEX_JOIN} ORDER BY dept_id) AS p
+//     (SELECT id, dept_id FROM child@{FORCE_INDEX=[..]} ORDER BY dept_id) AS p
 //   LEFT OUTER JOIN
-//     (SELECT dept_id FROM parent@{FORCE_INDEX=dept_idx,NO_INDEX_JOIN} ORDER BY dept_id) AS c
+//     (SELECT dept_id FROM parent@{FORCE_INDEX=dept_idx} ORDER BY dept_id) AS c
 //   ON
 //      p.dept_id = c.dept_id
 //   WHERE p.dept_id IS NOT NULL AND c.dept_id IS NULL
@@ -273,7 +273,7 @@ func createFKCheckQuery(
 				FROM
 					(SELECT %[9]s FROM %[2]s.%[3]s@{NO_INDEX_JOIN} %[12]s ORDER BY %[10]s) AS p
 				FULL OUTER JOIN
-					(SELECT %[11]s FROM %[2]s.%[4]s@{FORCE_INDEX=[%[5]d],NO_INDEX_JOIN} %[12]s ORDER BY %[11]s) AS c
+					(SELECT %[11]s FROM %[2]s.%[4]s@{FORCE_INDEX=[%[5]d]} %[12]s ORDER BY %[11]s) AS c
 					ON %[6]s
         WHERE (%[7]s) AND %[8]s`
 

--- a/pkg/sql/scrub_index.go
+++ b/pkg/sql/scrub_index.go
@@ -260,7 +260,7 @@ func (o *indexCheckOperation) Close(ctx context.Context) {
 //   FROM
 //     (SELECT * FROM test@{NO_INDEX_JOIN} AS left ORDER BY k, s, v)
 //   FULL OUTER JOIN
-//     (SELECT * FROM test@{FORCE_INDEX=v_idx,NO_INDEX_JOIN} AS right ORDER BY k, s, v)
+//     (SELECT * FROM test@{FORCE_INDEX=v_idx} AS right ORDER BY k, s, v)
 //   ON
 //      left.k = right.k AND
 //      left.s = right.s AND
@@ -309,9 +309,9 @@ func createIndexCheckQuery(
 	const checkIndexQuery = `
 				SELECT %[1]s, %[2]s
 				FROM
-					(SELECT %[9]s FROM %[3]s@{FORCE_INDEX=[1],NO_INDEX_JOIN} %[10]s ORDER BY %[5]s) AS leftside
+					(SELECT %[9]s FROM %[3]s@{FORCE_INDEX=[1]} %[10]s ORDER BY %[5]s) AS leftside
 				FULL OUTER JOIN
-					(SELECT %[9]s FROM %[3]s@{FORCE_INDEX=[%[4]d],NO_INDEX_JOIN} %[10]s ORDER BY %[5]s) AS rightside
+					(SELECT %[9]s FROM %[3]s@{FORCE_INDEX=[%[4]d]} %[10]s ORDER BY %[5]s) AS rightside
 					ON %[6]s
 				WHERE (%[7]s) OR
 							(%[8]s)`

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -103,14 +103,14 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 		return err
 	}
 
-	indexHints := &tree.IndexHints{
+	indexFlags := &tree.IndexFlags{
 		IndexID:     tree.IndexID(o.indexDesc.ID),
 		NoIndexJoin: true,
 	}
 	scan := params.p.Scan()
 	scan.run.isCheck = true
 	colCfg := scanColumnsConfig{wantedColumns: columnIDs, addUnwantedAsHidden: true}
-	if err := scan.initTable(ctx, params.p, o.tableDesc, indexHints, colCfg); err != nil {
+	if err := scan.initTable(ctx, params.p, o.tableDesc, indexFlags, colCfg); err != nil {
 		return err
 	}
 	plan := planNode(scan)

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -587,10 +587,10 @@ func (node *Subquery) doc(p *PrettyCfg) pretty.Doc {
 
 func (node *AliasedTableExpr) doc(p *PrettyCfg) pretty.Doc {
 	d := p.Doc(node.Expr)
-	if node.Hints != nil {
+	if node.IndexFlags != nil {
 		d = pretty.Concat(
 			d,
-			p.Doc(node.Hints),
+			p.Doc(node.IndexFlags),
 		)
 	}
 	if node.Ordinality {

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -260,12 +260,12 @@ func (node *StatementSource) Format(ctx *FmtCtx) {
 // IndexID is a custom type for IndexDescriptor IDs.
 type IndexID uint32
 
-// IndexHints represents "@<index_name|index_id>" or "@{param[,param]}" where
+// IndexFlags represents "@<index_name|index_id>" or "@{param[,param]}" where
 // param is one of:
 //  - FORCE_INDEX=<index_name|index_id>
 //  - NO_INDEX_JOIN
 // It is used optionally after a table name in SELECT statements.
-type IndexHints struct {
+type IndexFlags struct {
 	Index   UnrestrictedName
 	IndexID IndexID
 	// NoIndexJoin cannot be specified together with an index.
@@ -274,13 +274,13 @@ type IndexHints struct {
 
 // ForceIndex returns true if a forced index was specified, either using a name
 // or an IndexID.
-func (ih *IndexHints) ForceIndex() bool {
+func (ih *IndexFlags) ForceIndex() bool {
 	return ih.Index != "" || ih.IndexID != 0
 }
 
-// CombineWith combines two IndexHints structures, returning an error if they
+// CombineWith combines two IndexFlags structures, returning an error if they
 // conflict with one another.
-func (ih *IndexHints) CombineWith(other *IndexHints) error {
+func (ih *IndexFlags) CombineWith(other *IndexFlags) error {
 	if ih.NoIndexJoin && other.NoIndexJoin {
 		return errors.New("NO_INDEX_JOIN specified multiple times")
 	}
@@ -303,7 +303,7 @@ func (ih *IndexHints) CombineWith(other *IndexHints) error {
 }
 
 // Format implements the NodeFormatter interface.
-func (ih *IndexHints) Format(ctx *FmtCtx) {
+func (ih *IndexFlags) Format(ctx *FmtCtx) {
 	if !ih.NoIndexJoin {
 		ctx.WriteByte('@')
 		if ih.Index != "" {
@@ -330,7 +330,7 @@ func (ih *IndexHints) Format(ctx *FmtCtx) {
 // alias.
 type AliasedTableExpr struct {
 	Expr       TableExpr
-	Hints      *IndexHints
+	IndexFlags *IndexFlags
 	Ordinality bool
 	As         AliasClause
 }
@@ -338,8 +338,8 @@ type AliasedTableExpr struct {
 // Format implements the NodeFormatter interface.
 func (node *AliasedTableExpr) Format(ctx *FmtCtx) {
 	ctx.FormatNode(node.Expr)
-	if node.Hints != nil {
-		ctx.FormatNode(node.Hints)
+	if node.IndexFlags != nil {
+		ctx.FormatNode(node.IndexFlags)
 	}
 	if node.Ordinality {
 		ctx.WriteString(" WITH ORDINALITY")

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -24,6 +24,7 @@
 package tree
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -259,35 +260,66 @@ func (node *StatementSource) Format(ctx *FmtCtx) {
 // IndexID is a custom type for IndexDescriptor IDs.
 type IndexID uint32
 
-// IndexHints represents "@<index_name>" or "@{param[,param]}" where param is
-// one of:
-//  - FORCE_INDEX=<index_name>
+// IndexHints represents "@<index_name|index_id>" or "@{param[,param]}" where
+// param is one of:
+//  - FORCE_INDEX=<index_name|index_id>
 //  - NO_INDEX_JOIN
 // It is used optionally after a table name in SELECT statements.
 type IndexHints struct {
-	Index       UnrestrictedName
-	IndexID     IndexID
+	Index   UnrestrictedName
+	IndexID IndexID
+	// NoIndexJoin cannot be specified together with an index.
 	NoIndexJoin bool
 }
 
+// ForceIndex returns true if a forced index was specified, either using a name
+// or an IndexID.
+func (ih *IndexHints) ForceIndex() bool {
+	return ih.Index != "" || ih.IndexID != 0
+}
+
+// CombineWith combines two IndexHints structures, returning an error if they
+// conflict with one another.
+func (ih *IndexHints) CombineWith(other *IndexHints) error {
+	if ih.NoIndexJoin && other.NoIndexJoin {
+		return errors.New("NO_INDEX_JOIN specified multiple times")
+	}
+	noIndexJoin := ih.NoIndexJoin || other.NoIndexJoin
+
+	if noIndexJoin && (ih.ForceIndex() || other.ForceIndex()) {
+		return errors.New("FORCE_INDEX cannot be specified in conjunction with NO_INDEX_JOIN")
+	}
+
+	if other.ForceIndex() {
+		if ih.ForceIndex() {
+			return errors.New("FORCE_INDEX specified multiple times")
+		}
+		ih.Index = other.Index
+		ih.IndexID = other.IndexID
+	}
+
+	ih.NoIndexJoin = noIndexJoin
+	return nil
+}
+
 // Format implements the NodeFormatter interface.
-func (n *IndexHints) Format(ctx *FmtCtx) {
-	if !n.NoIndexJoin {
+func (ih *IndexHints) Format(ctx *FmtCtx) {
+	if !ih.NoIndexJoin {
 		ctx.WriteByte('@')
-		if n.Index != "" {
-			ctx.FormatNode(&n.Index)
+		if ih.Index != "" {
+			ctx.FormatNode(&ih.Index)
 		} else {
-			ctx.Printf("[%d]", n.IndexID)
+			ctx.Printf("[%d]", ih.IndexID)
 		}
 	} else {
-		if n.Index == "" && n.IndexID == 0 {
+		if ih.Index == "" && ih.IndexID == 0 {
 			ctx.WriteString("@{NO_INDEX_JOIN}")
 		} else {
 			ctx.WriteString("@{FORCE_INDEX=")
-			if n.Index != "" {
-				ctx.FormatNode(&n.Index)
+			if ih.Index != "" {
+				ctx.FormatNode(&ih.Index)
 			} else {
-				ctx.Printf("[%d]", n.IndexID)
+				ctx.Printf("[%d]", ih.IndexID)
 			}
 			ctx.WriteString(",NO_INDEX_JOIN}")
 		}

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -148,7 +148,7 @@ func (n *showFingerprintsNode) Next(params runParams) (bool, error) {
 	// exposed to users, consider adding a version to the fingerprint output.
 	sql := fmt.Sprintf(`SELECT
 	  xor_agg(fnv64(%s))::string AS fingerprint
-	  FROM [%d AS t]@{FORCE_INDEX=[%d],NO_INDEX_JOIN}
+	  FROM [%d AS t]@{FORCE_INDEX=[%d]}
 	`, strings.Join(cols, `,`), n.tableDesc.ID, index.ID)
 	// If were'in in an AOST context, propagate it to the inner statement so that
 	// the inner statement gets planned with planner.avoidCachedDescriptors set,


### PR DESCRIPTION
The current code allows both `FORCE_INDEX` and `NO_INDEX_JOIN`
"hints", and the query fails if the index we force requires
index-join.

This semantic would be tricky to support with the optimizer (it would
be a "no-plans" condition during exploration).

This commit changes the behavior to disallow setting both hints at the
same time. The code to combine and validate `IndexHints` is moved in a
method; the code is kept general even though with this change it's
never valid to have more than one parameter.

Release note (sql change): It is now an error to specify both
FORCE_INDEX and NO_INDEX_JOIN hints at the same time.