### PR TITLE
client,kv: add comments to the Sender

### DIFF
--- a/pkg/kv/transport_race.go
+++ b/pkg/kv/transport_race.go
@@ -50,8 +50,11 @@ func jitter(avgInterval time.Duration) time.Duration {
 }
 
 // GRPCTransportFactory during race builds wraps the implementation and
-// intercepts all BatchRequests, reading them in a tight loop. This allows the
-// race detector to catch any mutations of a batch passed to the transport.
+// intercepts all BatchRequests, reading them asynchronously in a tight loop.
+// This allows the race detector to catch any mutations of a batch passed to the
+// transport. The dealio is that batches passed to the transport are immutable -
+// neither the client nor the server are allowed to mutate anything and this
+// transport makes sure they don't. See client.Sender() for more.
 func GRPCTransportFactory(
 	opts SendOptions, nodeDialer *nodedialer.Dialer, replicas ReplicaSlice, args roachpb.BatchRequest,
 ) (Transport, error) {

--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -4646,7 +4646,18 @@ func (*BatchResponse) ProtoMessage()               {}
 func (*BatchResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{89} }
 
 type BatchResponse_Header struct {
-	// error is non-nil if an error occurred.
+	// error communicates a structured error (i.e. one originating from a Node)
+	// while the BatchResponse is sent over the network. If the code were
+	// written today, the RPC endpoint would return a message containing both a
+	// BatchResponse and an Error, and this embedding would go away. However, it
+	// returns only a BatchResponse, and so the Error needs to be tucked away
+	// somewhere (the structured error cannot be communicated via an RPC-level
+	// error).
+	//
+	// Outside of the RPC boundaries, this field is nil and must neither be
+	// checked nor populated (it is reset by the DistSender, which extracts this
+	// error and returns it separately). In effect, nearly no usage of
+	// BatchResponse needs to care about this field.
 	Error *Error `protobuf:"bytes,1,opt,name=error" json:"error,omitempty"`
 	// timestamp is set only for non-transactional responses and denotes the
 	// timestamp at which the batch executed. The timestamp cache is updated

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1498,7 +1498,18 @@ message BatchResponse {
 
   message Header {
     reserved 4;
-    // error is non-nil if an error occurred.
+    // error communicates a structured error (i.e. one originating from a Node)
+    // while the BatchResponse is sent over the network. If the code were
+    // written today, the RPC endpoint would return a message containing both a
+    // BatchResponse and an Error, and this embedding would go away. However, it
+    // returns only a BatchResponse, and so the Error needs to be tucked away
+    // somewhere (the structured error cannot be communicated via an RPC-level
+    // error).
+    //
+    // Outside of the RPC boundaries, this field is nil and must neither be
+    // checked nor populated (it is reset by the DistSender, which extracts this
+    // error and returns it separately). In effect, nearly no usage of
+    // BatchResponse needs to care about this field.
     Error error = 1;
     // timestamp is set only for non-transactional responses and denotes the
     // timestamp at which the batch executed. The timestamp cache is updated


### PR DESCRIPTION
This patch attempts to document, to the best of my ability, some quirks
of the sender interface. It also attempts to add some helpful words to
the mind-bending "race transport".

Fixes #27976

Release note: None