### PR TITLE
sql: do not scrub internal app names

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -757,7 +757,7 @@ func Example_demo() {
 	// defaultdb
 	// demo -e show application_name
 	// application_name
-	// cockroach demo
+	// $ cockroach demo
 	// demo --format=table -e show database
 	//   database
 	// +-----------+
@@ -825,7 +825,7 @@ func Example_sql() {
 	// Output:
 	// sql -e show application_name
 	// application_name
-	// cockroach sql
+	// $ cockroach sql
 	// sql -e create database t; create table t.f (x int, y int); insert into t.f values (42, 69)
 	// INSERT 1
 	// sql -e select 3 as "3" -e select * from t.f

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 
 	// Force at least the example workloads to exist
@@ -91,7 +92,7 @@ func setupTransientServer(
 
 	options := url.Values{}
 	options.Add("sslmode", "disable")
-	options.Add("application_name", "cockroach demo")
+	options.Add("application_name", sql.InternalAppNamePrefix+"cockroach demo")
 	url := url.URL{
 		Scheme:   "postgres",
 		User:     url.User(security.RootUser),

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -515,7 +516,7 @@ var sqlConnTimeout = envutil.EnvOrDefaultString("COCKROACH_CONNECT_TIMEOUT", "5"
 //
 // The appName given as argument is added to the URL even if --url is
 // specified, but only if the URL didn't already specify
-// application_name.
+// application_name. It is prefixed with '$ ' to mark it as internal.
 func makeSQLClient(appName string) (*sqlConn, error) {
 	var baseURL *url.URL
 	var options url.Values
@@ -608,7 +609,7 @@ func makeSQLClient(appName string) (*sqlConn, error) {
 	// Load the application name. It's not a command-line flag, so
 	// anything already in the URL should take priority.
 	if options.Get("application_name") == "" && appName != "" {
-		options.Set("application_name", appName)
+		options.Set("application_name", sql.InternalAppNamePrefix+appName)
 	}
 
 	// Set a connection timeout if none is provided already. This

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -390,7 +390,7 @@ func (ie *internalExecutorImpl) execInternal(
 	qargs ...interface{},
 ) (retRes result, retErr error) {
 	if sargs != nil && sargs.ApplicationName == "" {
-		sargs.ApplicationName = "internal-" + opName
+		sargs.ApplicationName = InternalAppNamePrefix + "internal-" + opName
 	}
 
 	defer func() {


### PR DESCRIPTION
When reporting statement statistics, we currently scrub the application
name unconditionally. This commit exempts application names with the
"internal-" prefix from scrubbing.

Release note: None