### PR TITLE
opt: Make improvements to planning time for small queries

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -103,7 +103,7 @@ func BenchmarkPhases(b *testing.B) {
 type benchmark struct {
 }
 
-func newBenchmark(b *testing.B) *benchmark {
+func newBenchmark(_ *testing.B) *benchmark {
 	return &benchmark{}
 }
 

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -16,16 +16,19 @@ package bench
 
 import (
 	"context"
-	gosql "database/sql"
 	"fmt"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
@@ -40,35 +43,17 @@ const (
 
 	// optbuild + normalizations enabled, but with no exploration patterns,
 	// enforcers, or costing.
-	prepare
+	normalize
 
-	// prepare + exploration patterns, enforcers, and costing.
-	search
-
-	// search + build the execution nodes.
-	execbuild
-
-	// execbuild + execute using minimal test execution harness.
-	execute
-
-	// Executes the query end-to-end using the v2.0 planner (but with empty
-	// tables).
-	v20
-
-	// Executes the query end-to-end using the new optimizer (but with empty
-	// tables).
-	v21
+	// normalize + exploration patterns, enforcers, and costing.
+	explore
 )
 
 var benchmarkTypeStrings = [...]string{
 	parse:     "Parse",
 	optbuild:  "OptBuild",
-	prepare:   "Prepare",
-	search:    "Search",
-	execbuild: "ExecBuild",
-	execute:   "Execute",
-	v20:       "V20",
-	v21:       "V21",
+	normalize: "Normalize",
+	explore:   "Explore",
 }
 
 type benchQuery struct {
@@ -77,33 +62,13 @@ type benchQuery struct {
 }
 
 var queries = [...]benchQuery{
-	// Taken from BenchmarkSelectXXX in pkg/sql/bench/bench_test.go.
-	{"Select1", `SELECT 1`},
-	{"Select2", `SELECT a, b, c, a+b, a+1, (a+2)*(b+3)*(c+4) FROM bench.select WHERE (a = 1) OR ((a = 2) and (b = c)) OR (a + b = 3) OR (2*a + 4*b = 4*c)`},
-	{"Select3", `SELECT a/b, b/c, c != 3.3 + 1.0, a = 2.0, c * 9.0 FROM bench.select WHERE a > 1 AND b < 4.5`},
-
-	// Taken from BenchmarkCount in pkg/sql/bench/bench_test.go.
-	{"Count", `SELECT count(*) FROM bench.count`},
-
-	// Taken from BenchmarkScan in pkg/sql/bench/bench_test.go.
-	{"Scan", `SELECT * FROM scan LIMIT 10`},
-
-	// Taken from BenchmarkPlanning in pkg/sql/bench/bench_test.go.
-	{"Planning1", `SELECT * FROM abc`},
-	{"Planning2", `SELECT * FROM abc WHERE a > 5 ORDER BY a`},
-	{"Planning3", `SELECT * FROM abc WHERE b = 5`},
-	{"Planning4", `SELECT * FROM abc WHERE b = 5 ORDER BY a`},
-	{"Planning5", `SELECT * FROM abc WHERE c = 5`},
-	{"Planning6", `SELECT * FROM abc JOIN abc AS abc2 ON abc.a = abc2.a`},
-
-	// Taken from BenchmarkScanFilter in pkg/sql/bench/bench_test.go.
-	{"ScanFilter", `SELECT * FROM scan2 WHERE a IN (1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 20, 21, 23) AND b < 10*a`},
-
-	// Taken from BenchmarkWideTableIgnoreColumns in pkg/sql/bench/bench_test.go.
-	{"WideTableIgnoreColumns", `SELECT count(*) FROM widetable WHERE f4 < 10`},
-
-	// Taken from BenchmarkIndexJoin in pkg/sql/bench_test.go.
-	{"IndexJoin", `SELECT * from tidx WHERE v < 1000`},
+	{"kv-read", `SELECT k, v FROM kv WHERE k IN ($1)`},
+	{"planning1", `SELECT * FROM abc`},
+	{"planning2", `SELECT * FROM abc WHERE a > 5 ORDER BY a`},
+	{"planning3", `SELECT * FROM abc WHERE b = 5`},
+	{"planning4", `SELECT * FROM abc WHERE b = 5 ORDER BY a`},
+	{"planning5", `SELECT * FROM abc WHERE c = 5`},
+	{"planning6", `SELECT * FROM abc JOIN abc AS abc2 ON abc.a = abc2.a`},
 }
 
 func init() {
@@ -130,68 +95,72 @@ func BenchmarkPhases(b *testing.B) {
 	for _, query := range queries {
 		bm.run(b, parse, query)
 		bm.run(b, optbuild, query)
-		bm.run(b, prepare, query)
-		bm.run(b, search, query)
-		bm.run(b, execbuild, query)
-		bm.run(b, execute, query)
-
-		// Uncomment to see performance of v2.0 planner vs. new v2.1 optimizer
-		// (but executes the queries over empty tables).
-		// bm.run(b, v20, query)
-		// bm.run(b, v21, query)
+		bm.run(b, normalize, query)
+		bm.run(b, explore, query)
 	}
 }
 
 type benchmark struct {
-	s  serverutils.TestServerInterface
-	db *gosql.DB
-	sr *sqlutils.SQLRunner
 }
 
 func newBenchmark(b *testing.B) *benchmark {
-	bm := &benchmark{}
-	bm.s, bm.db, _ = serverutils.StartServer(b, base.TestServerArgs{UseDatabase: "bench"})
-
-	bm.sr = sqlutils.MakeSQLRunner(bm.db)
-	bm.sr.Exec(b, `CREATE DATABASE bench`)
-	bm.sr.Exec(b, `CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)`)
-	bm.sr.Exec(b, `CREATE TABLE bench.scan (k INT PRIMARY KEY)`)
-	bm.sr.Exec(b, `CREATE TABLE bench.select (k INT PRIMARY KEY, a INT, b INT, c INT, d INT)`)
-	bm.sr.Exec(b, `CREATE TABLE bench.count (k INT PRIMARY KEY, v TEXT)`)
-	bm.sr.Exec(b, `CREATE TABLE scan2 (a INT, b INT, PRIMARY KEY (a, b))`)
-	bm.sr.Exec(b, `CREATE TABLE widetable (
-		f1 INT, f2 INT, f3 INT, f4 INT, f5 INT, f6 INT, f7 INT, f8 INT, f9 INT, f10 INT,
-		f11 TEXT, f12 TEXT, f13 TEXT, f14 TEXT, f15 TEXT, f16 TEXT, f17 TEXT, f18 TEXT, f19 TEXT,
-		f20 TEXT,
-		PRIMARY KEY (f1, f2, f3))`)
-	bm.sr.Exec(b, `CREATE TABLE tidx (
-		k INT NOT NULL,
-		v INT NULL,
-		extra STRING NULL,
-		CONSTRAINT "primary" PRIMARY KEY (k ASC),
-		INDEX idx (v ASC),
-		FAMILY "primary" (k, v, extra))`)
-
-	return bm
+	return &benchmark{}
 }
 
 func (bm *benchmark) close() {
-	bm.s.Stopper().Stop(context.TODO())
 }
 
 func (bm *benchmark) run(b *testing.B, bmType benchmarkType, query benchQuery) {
 	b.Run(fmt.Sprintf("%s/%s", query.name, benchmarkTypeStrings[bmType]), func(b *testing.B) {
-		if bmType == v20 {
-			// TODO(radu): remove this once the optimizer plays nice with distsql.
-			bm.sr.Exec(b, `SET DISTSQL=OFF`)
-			bm.sr.Exec(b, `SET EXPERIMENTAL_OPT=OFF`)
-		} else {
-			bm.sr.Exec(b, `SET EXPERIMENTAL_OPT=ON`)
+		bm.runUsingAPI(b, bmType, query.query)
+	})
+}
+
+func (bm *benchmark) runUsingAPI(b *testing.B, bmType benchmarkType, query string) {
+	ctx := context.Background()
+	semaCtx := tree.MakeSemaContext(false /* privileged */)
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+
+	cat := testcat.New()
+	bm.executeDDL(b, cat, `CREATE TABLE kv (k BIGINT NOT NULL PRIMARY KEY, v BYTES NOT NULL)`)
+	bm.executeDDL(b, cat, `CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX(b), UNIQUE INDEX(c))`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		stmt, err := parser.ParseOne(query)
+		if err != nil {
+			b.Fatalf("%v", err)
 		}
 
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			bm.sr.Exec(b, query.query)
+		if bmType == parse {
+			continue
 		}
-	})
+
+		opt := xform.NewOptimizer(&evalCtx)
+		if bmType == optbuild {
+			opt.DisableOptimizations()
+		}
+		bld := optbuilder.New(ctx, &semaCtx, &evalCtx, cat, opt.Factory(), stmt)
+		root, props, err := bld.Build()
+		if err != nil {
+			b.Fatalf("%v", err)
+		}
+
+		if bmType == optbuild || bmType == normalize {
+			continue
+		}
+
+		opt.Optimize(root, props)
+
+		if bmType == explore {
+			continue
+		}
+	}
+}
+
+func (bm *benchmark) executeDDL(b *testing.B, cat *testcat.Catalog, sql string) {
+	_, err := cat.ExecuteDDL(sql)
+	if err != nil {
+		b.Fatalf("%v", err)
+	}
 }

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -219,7 +219,7 @@ func (*Builder) getColumns(
 	columnCount := md.Table(tableID).ColumnCount()
 	n := 0
 	for i := 0; i < columnCount; i++ {
-		colID := md.TableColumn(tableID, i)
+		colID := tableID.ColumnID(i)
 		if cols.Contains(int(colID)) {
 			needed.Add(i)
 			output.Set(int(colID), n)

--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -362,7 +362,7 @@ func (ev ExprView) formatRelational(f *opt.ExprFmtCtx, tp treeprinter.Node) {
 		idxCols := make(opt.ColList, len(def.KeyCols))
 		idx := ev.mem.metadata.Table(def.Table).Index(def.Index)
 		for i := range idxCols {
-			idxCols[i] = ev.mem.metadata.TableColumn(def.Table, idx.Column(i).Ordinal)
+			idxCols[i] = def.Table.ColumnID(idx.Column(i).Ordinal)
 		}
 		tp.Childf("key columns: %v = %v", def.KeyCols, idxCols)
 	}

--- a/pkg/sql/opt/memo/list_storage_test.go
+++ b/pkg/sql/opt/memo/list_storage_test.go
@@ -21,7 +21,6 @@ import (
 
 func TestListStorage(t *testing.T) {
 	var ls listStorage
-	ls.init()
 
 	catID := ls.intern(stringToGroups("cat"))
 	if catID != (ListID{Offset: 1, Length: 3}) {

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1132,7 +1132,7 @@ func (b *logicalPropsBuilder) makeTableFuncDep(
 	var allCols opt.ColSet
 	tab := md.Table(tabID)
 	for i := 0; i < tab.ColumnCount(); i++ {
-		allCols.Add(int(md.TableColumn(tabID, i)))
+		allCols.Add(int(tabID.ColumnID(i)))
 	}
 
 	fd = &props.FuncDepSet{}
@@ -1148,8 +1148,7 @@ func (b *logicalPropsBuilder) makeTableFuncDep(
 		// strict key. See the comment for opt.Index.LaxKeyColumnCount.
 		for col := 0; col < index.LaxKeyColumnCount(); col++ {
 			ord := index.Column(col).Ordinal
-			colID := md.TableColumn(tabID, ord)
-			keyCols.Add(int(colID))
+			keyCols.Add(int(tabID.ColumnID(ord)))
 		}
 		if index.LaxKeyColumnCount() < index.KeyColumnCount() {
 			// This case only occurs for a UNIQUE index having a NULL-able column.
@@ -1229,8 +1228,7 @@ func (b *logicalPropsBuilder) tableNotNullCols(md *opt.Metadata, tabID opt.Table
 	tab := md.Table(tabID)
 	for i := 0; i < tab.ColumnCount(); i++ {
 		if !tab.Column(i).IsNullable() {
-			colID := md.TableColumn(tabID, i)
-			cs.Add(int(colID))
+			cs.Add(int(tabID.ColumnID(i)))
 		}
 	}
 	return cs

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -119,11 +119,6 @@ type Memo struct {
 	// expression to indicate that it did not originate from the memo.
 	groups []group
 
-	// Intern the set of unique physical properties used by expressions in the
-	// memo, since there are so many duplicates.
-	physPropsMap map[string]PhysicalPropsID
-	physProps    []props.Physical
-
 	// Some memoExprs have a variable number of children. The Expr stores
 	// the list as a ListID struct, which is a slice of an array maintained by
 	// listStorage. Note that ListID 0 is invalid in order to indicate an
@@ -146,17 +141,10 @@ func New() *Memo {
 	// index 0 for private data, index 0 for physical properties, and index 0
 	// for lists are all reserved.
 	m := &Memo{
-		metadata:     opt.NewMetadata(),
-		exprMap:      make(map[Fingerprint]GroupID),
-		groups:       make([]group, 1),
-		physPropsMap: make(map[string]PhysicalPropsID),
-		physProps:    make([]props.Physical, 1, 2),
+		metadata: opt.NewMetadata(),
+		exprMap:  make(map[Fingerprint]GroupID),
+		groups:   make([]group, 1),
 	}
-
-	// Intern physical properties that require nothing of operator.
-	physProps := props.Physical{}
-	m.physProps = append(m.physProps, physProps)
-	m.physPropsMap[physProps.Fingerprint()] = MinPhysPropsID
 
 	m.listStorage.init()
 	m.privateStorage.init()
@@ -353,20 +341,20 @@ func (m *Memo) LookupList(id ListID) []GroupID {
 // If the same list was added previously, then this method is a no-op and
 // returns the same ID as did the previous call.
 func (m *Memo) InternPhysicalProps(physical *props.Physical) PhysicalPropsID {
-	fingerprint := physical.Fingerprint()
-	id, ok := m.physPropsMap[fingerprint]
-	if !ok {
-		id = PhysicalPropsID(len(m.physProps))
-		m.physProps = append(m.physProps, *physical)
-		m.physPropsMap[fingerprint] = id
+	// Special case physical properties that require nothing of operator.
+	if !physical.Defined() {
+		return MinPhysPropsID
 	}
-	return id
+	return PhysicalPropsID(m.privateStorage.internPhysProps(physical))
 }
 
 // LookupPhysicalProps returns the set of physical props that was earlier
 // interned in the memo by a call to InternPhysicalProps.
 func (m *Memo) LookupPhysicalProps(id PhysicalPropsID) *props.Physical {
-	return &m.physProps[id]
+	if id == MinPhysPropsID {
+		return &props.MinPhysProps
+	}
+	return m.privateStorage.lookup(PrivateID(id)).(*props.Physical)
 }
 
 // LookupPrivate returns a private value that was earlier interned in the memo

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -146,7 +146,6 @@ func New() *Memo {
 		groups:   make([]group, 1),
 	}
 
-	m.listStorage.init()
 	m.privateStorage.init()
 	return m
 }

--- a/pkg/sql/opt/memo/private_defs.go
+++ b/pkg/sql/opt/memo/private_defs.go
@@ -124,7 +124,7 @@ func (s *ScanOpDef) CanProvideOrdering(md *opt.Metadata, required *props.Orderin
 	index := md.Table(s.Table).Index(s.Index)
 	for i := 0; i < index.KeyColumnCount(); i++ {
 		indexCol := index.Column(i)
-		colID := md.TableColumn(s.Table, indexCol.Ordinal)
+		colID := s.Table.ColumnID(indexCol.Ordinal)
 		if s.Reverse {
 			ordering.AppendCol(colID, !indexCol.Descending)
 		} else {

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -1014,9 +1014,8 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 func (sb *statisticsBuilder) colSetFromTableStatistic(
 	stat opt.TableStatistic, tableID opt.TableID,
 ) (cols opt.ColSet) {
-	md := sb.ev.Metadata()
 	for i := 0; i < stat.ColumnCount(); i++ {
-		cols.Add(int(md.TableColumn(tableID, stat.ColumnOrdinal(i))))
+		cols.Add(int(tableID.ColumnID(stat.ColumnOrdinal(i))))
 	}
 	return cols
 }

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -79,7 +79,7 @@ func TestMetadataTables(t *testing.T) {
 	a.Columns = append(a.Columns, x, y)
 
 	tabID := md.AddTable(a)
-	if tabID != 1 {
+	if tabID == 0 {
 		t.Fatalf("unexpected table id: %d", tabID)
 	}
 
@@ -88,8 +88,8 @@ func TestMetadataTables(t *testing.T) {
 		t.Fatal("table didn't match table added to metadata")
 	}
 
-	colID := md.TableColumn(tabID, 0)
-	if colID != 1 {
+	colID := tabID.ColumnID(0)
+	if colID == 0 {
 		t.Fatalf("unexpected column id: %d", colID)
 	}
 
@@ -100,15 +100,16 @@ func TestMetadataTables(t *testing.T) {
 
 	// Add a table reference without a name to the metadata.
 	b := &testcat.Table{}
+	b.Name = tree.MakeUnqualifiedTableName(tree.Name("b"))
 	b.Columns = append(b.Columns, &testcat.Column{Name: "x"})
 
-	tabID = md.AddTable(b)
-	if tabID != 3 {
+	otherTabID := md.AddTable(b)
+	if otherTabID == tabID {
 		t.Fatalf("unexpected table id: %d", tabID)
 	}
 
-	label = md.ColumnLabel(md.TableColumn(tabID, 0))
-	if label != "x" {
+	label = md.ColumnLabel(otherTabID.ColumnID(0))
+	if label != "b.x" {
 		t.Fatalf("unexpected column label: %s", label)
 	}
 }
@@ -131,10 +132,10 @@ func TestIndexColumns(t *testing.T) {
 	md := opt.NewMetadata()
 	a := md.AddTable(cat.Table("a"))
 
-	k := int(md.TableColumn(a, 0))
-	i := int(md.TableColumn(a, 1))
-	s := int(md.TableColumn(a, 2))
-	f := int(md.TableColumn(a, 3))
+	k := int(a.ColumnID(0))
+	i := int(a.ColumnID(1))
+	s := int(a.ColumnID(2))
+	f := int(a.ColumnID(3))
 
 	testCases := []struct {
 		index        int

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -163,13 +163,12 @@ func (f *Factory) InternList(items []memo.GroupID) memo.ListID {
 // so that any custom manual pattern matching/replacement code can be run.
 func (f *Factory) onConstruct(e memo.Expr) memo.GroupID {
 	group := f.mem.MemoizeNormExpr(f.evalCtx, e)
-	ev := memo.MakeNormExprView(f.mem, group)
 
 	// RaceEnabled ensures that checks are run on every change (as part of make
 	// testrace) while keeping the check code out of non-test builds.
 	// TODO(radu): replace this with a flag that is true for all tests.
 	if util.RaceEnabled {
-		f.checkExpr(ev)
+		f.checkExpr(memo.MakeNormExprView(f.mem, group))
 	}
 	return group
 }

--- a/pkg/sql/opt/norm/factory_test.go
+++ b/pkg/sql/opt/norm/factory_test.go
@@ -36,13 +36,13 @@ func TestFactoryProjectColsFromBoth(t *testing.T) {
 
 	cat := createFiltersCatalog(t)
 	a := f.Metadata().AddTable(cat.Table("a"))
-	ax := f.Metadata().TableColumn(a, 0)
-	ay := f.Metadata().TableColumn(a, 1)
+	ax := a.ColumnID(0)
+	ay := a.ColumnID(1)
 	aCols := util.MakeFastIntSet(int(ax), int(ay))
 
 	a2 := f.Metadata().AddTable(cat.Table("a"))
-	a2x := f.Metadata().TableColumn(a2, 0)
-	a2y := f.Metadata().TableColumn(a2, 1)
+	a2x := a2.ColumnID(0)
+	a2y := a2.ColumnID(1)
 	a2Cols := util.MakeFastIntSet(int(a2x), int(a2y))
 
 	scan := f.ConstructScan(f.InternScanOpDef(&memo.ScanOpDef{Table: a, Cols: aCols}))
@@ -122,7 +122,7 @@ func TestSimplifyFilters(t *testing.T) {
 
 	cat := createFiltersCatalog(t)
 	a := f.Metadata().AddTable(cat.Table("a"))
-	ax := f.Metadata().TableColumn(a, 0)
+	ax := a.ColumnID(0)
 
 	variable := f.ConstructVariable(f.InternColumnID(ax))
 	constant := f.ConstructConst(f.InternDatum(tree.NewDInt(1)))

--- a/pkg/sql/opt/norm/prune_cols.go
+++ b/pkg/sql/opt/norm/prune_cols.go
@@ -94,7 +94,7 @@ func (c *CustomFuncs) CanPruneCols(target memo.GroupID, neededCols opt.ColSet) b
 		pruneCols = DerivePruneCols(ev)
 	}
 
-	return !pruneCols.Difference(neededCols).Empty()
+	return !pruneCols.SubsetOf(neededCols)
 }
 
 // PruneCols creates an expression that discards any outputs columns of the

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -73,9 +73,6 @@ type Builder struct {
 	semaCtx *tree.SemaContext
 	evalCtx *tree.EvalContext
 	catalog opt.Catalog
-
-	// Skip index 0 in order to reserve it to indicate the "unknown" column.
-	colMap []scopeColumn
 }
 
 // New creates a new Builder structure initialized with the given
@@ -91,7 +88,6 @@ func New(
 	return &Builder{
 		factory: factory,
 		stmt:    stmt,
-		colMap:  make([]scopeColumn, 1),
 		ctx:     ctx,
 		semaCtx: semaCtx,
 		evalCtx: evalCtx,

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -550,7 +550,6 @@ func NewScalar(
 	sb := &ScalarBuilder{
 		Builder: Builder{
 			factory: factory,
-			colMap:  make([]scopeColumn, 1, 1+md.NumColumns()),
 			ctx:     ctx,
 			semaCtx: semaCtx,
 			evalCtx: evalCtx,
@@ -562,14 +561,12 @@ func NewScalar(
 	sb.scope.cols = make([]scopeColumn, 0, md.NumColumns())
 	for colID := opt.ColumnID(1); int(colID) <= md.NumColumns(); colID++ {
 		name := tree.Name(md.ColumnLabel(colID))
-		col := scopeColumn{
+		sb.scope.cols = append(sb.scope.cols, scopeColumn{
 			origName: name,
 			name:     name,
 			typ:      md.ColumnType(colID),
 			id:       colID,
-		}
-		sb.colMap = append(sb.colMap, col)
-		sb.scope.cols = append(sb.scope.cols, col)
+		})
 	}
 
 	return sb

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -65,7 +65,7 @@ func (b *Builder) buildTable(texpr tree.TableExpr, inScope *scope) (outScope *sc
 		}
 
 		tab := b.resolveTable(tn)
-		return b.buildScan(tab, tn, inScope)
+		return b.buildScan(tab, tn, nil, inScope)
 
 	case *tree.ParenTableExpr:
 		return b.buildTable(source.Expr, inScope)
@@ -90,7 +90,7 @@ func (b *Builder) buildTable(texpr tree.TableExpr, inScope *scope) (outScope *sc
 
 	case *tree.TableRef:
 		tab := b.resolveTableRef(source)
-		outScope = b.buildScanWithTableRef(tab, tab.TabName(), inScope, source)
+		outScope = b.buildScanFromTableRef(tab, source, inScope)
 		b.renameSource(source.As, outScope)
 		return outScope
 
@@ -145,104 +145,91 @@ func (b *Builder) renameSource(as tree.AliasClause, scope *scope) {
 	}
 }
 
-// buildScanWithTableRef adds support for numeric references in queries.
+// buildScanFromTableRef adds support for numeric references in queries.
 // For example:
 // SELECT * FROM [53 as t]; (table reference)
 // SELECT * FROM [53(1) as t]; (+columnar reference)
 // SELECT * FROM [53(1) as t]@1; (+index reference)
 // Note, the query SELECT * FROM [53() as t] is unsupported. Column lists must
 // be non-empty
-func (b *Builder) buildScanWithTableRef(
-	tab opt.Table, tn *tree.TableName, inScope *scope, ref *tree.TableRef,
+func (b *Builder) buildScanFromTableRef(
+	tab opt.Table, ref *tree.TableRef, inScope *scope,
 ) (outScope *scope) {
 
 	if ref.Columns != nil && len(ref.Columns) == 0 {
 		panic(builderError{pgerror.NewErrorf(pgerror.CodeSyntaxError,
 			"an explicit list of column IDs must include at least one column")})
 	}
-	tabName := tree.AsStringWithFlags(tn, b.FmtFlags)
-	tabID := b.factory.Metadata().AddTableWithName(tab, tabName)
 
-	var colsToAdd []int
 	// See tree.TableRef: "Note that a nil [Columns] array means 'unspecified'
 	// (all columns). whereas an array of length 0 means 'zero columns'.
 	// Lists of zero columns are not supported and will throw an error."
 	// The error for lists of zero columns is thrown in the caller function
 	// for buildScanWithTableRef.
-	if ref.Columns == nil {
-		for i := 0; i < tab.ColumnCount(); i++ {
-			colsToAdd = append(colsToAdd, i)
-		}
-	} else {
-		for _, c := range ref.Columns {
-			ordinalCol, err := tab.LookupColumnOrdinal(uint32(c))
+	// for buildScanFromTableRef.
+	var ordinals []int
+	if ref.Columns != nil {
+		ordinals = make([]int, len(ref.Columns))
+		for i, c := range ref.Columns {
+			ord, err := tab.LookupColumnOrdinal(uint32(c))
 			if err != nil {
 				panic(builderError{err})
 			}
-			colsToAdd = append(colsToAdd, ordinalCol)
+			ordinals[i] = ord
 		}
 	}
-	var tabCols opt.ColSet
-	outScope = inScope.push()
-	for _, i := range colsToAdd {
-		col := tab.Column(i)
-		colID := b.factory.Metadata().TableColumn(tabID, i)
-		name := tree.Name(col.ColName())
-		colProps := scopeColumn{
-			id:       colID,
-			origName: name,
-			name:     name,
-			table:    *tn,
-			typ:      col.DatumType(),
-			hidden:   col.IsHidden(),
-		}
-		tabCols.Add(int(colID))
-		b.colMap = append(b.colMap, colProps)
-		outScope.cols = append(outScope.cols, colProps)
-	}
-	if tab.IsVirtualTable() {
-		def := memo.VirtualScanOpDef{Table: tabID, Cols: tabCols}
-		outScope.group = b.factory.ConstructVirtualScan(b.factory.InternVirtualScanOpDef(&def))
-	} else {
-		def := memo.ScanOpDef{Table: tabID, Cols: tabCols}
-		outScope.group = b.factory.ConstructScan(b.factory.InternScanOpDef(&def))
-	}
-	return outScope
+	return b.buildScan(tab, tab.TabName(), ordinals, inScope)
 }
 
 // buildScan builds a memo group for a ScanOp or VirtualScanOp expression on the
-// given table with the given table name.
+// given table with the given table name. If the ordinals slice is not nil, then
+// only columns with ordinals in that list are projected by the scan. Otherwise,
+// all columns from the table are projected.
 //
 // See Builder.buildStmt for a description of the remaining input and
 // return values.
-func (b *Builder) buildScan(tab opt.Table, tn *tree.TableName, inScope *scope) (outScope *scope) {
-	tabName := tree.AsStringWithFlags(tn, b.FmtFlags)
-	tabID := b.factory.Metadata().AddTableWithName(tab, tabName)
+func (b *Builder) buildScan(
+	tab opt.Table, tn *tree.TableName, ordinals []int, inScope *scope,
+) (outScope *scope) {
+	md := b.factory.Metadata()
 
-	var tabCols opt.ColSet
+	var tabName string
+	tabName = tree.AsStringWithFlags(tn, b.FmtFlags)
+	tabID := md.AddTableWithName(tab, tabName)
+
+	colCount := len(ordinals)
+	if colCount == 0 {
+		colCount = tab.ColumnCount()
+	}
+
+	var tabColIDs opt.ColSet
 	outScope = inScope.push()
-	for i := 0; i < tab.ColumnCount(); i++ {
-		col := tab.Column(i)
-		colID := b.factory.Metadata().TableColumn(tabID, i)
+	outScope.cols = make([]scopeColumn, 0, colCount)
+	for i := 0; i < colCount; i++ {
+		ord := i
+		if ordinals != nil {
+			ord = ordinals[i]
+		}
+
+		col := tab.Column(ord)
+		colID := b.factory.Metadata().TableColumn(tabID, ord)
+		tabColIDs.Add(int(colID))
 		name := tree.Name(col.ColName())
-		colProps := scopeColumn{
+		outScope.cols = append(outScope.cols, scopeColumn{
 			id:       colID,
 			origName: name,
 			name:     name,
 			table:    *tn,
 			typ:      col.DatumType(),
 			hidden:   col.IsHidden(),
-		}
-		tabCols.Add(int(colID))
-		b.colMap = append(b.colMap, colProps)
-		outScope.cols = append(outScope.cols, colProps)
+		})
 	}
 
 	if tab.IsVirtualTable() {
-		def := memo.VirtualScanOpDef{Table: tabID, Cols: tabCols}
+		def := memo.VirtualScanOpDef{Table: tabID, Cols: tabColIDs}
 		outScope.group = b.factory.ConstructVirtualScan(b.factory.InternVirtualScanOpDef(&def))
 	} else {
-		def := memo.ScanOpDef{Table: tabID, Cols: tabCols}
+		def := memo.ScanOpDef{Table: tabID, Cols: tabColIDs}
 		outScope.group = b.factory.ConstructScan(b.factory.InternScanOpDef(&def))
 	}
 	return outScope

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -65,7 +65,7 @@ func (b *Builder) buildTable(texpr tree.TableExpr, inScope *scope) (outScope *sc
 		}
 
 		tab := b.resolveTable(tn)
-		return b.buildScan(tab, tn, nil, inScope)
+		return b.buildScan(tab, tn, nil /* ordinals */, inScope)
 
 	case *tree.ParenTableExpr:
 		return b.buildTable(source.Expr, inScope)
@@ -191,8 +191,7 @@ func (b *Builder) buildScan(
 ) (outScope *scope) {
 	md := b.factory.Metadata()
 
-	var tabName string
-	tabName = tree.AsStringWithFlags(tn, b.FmtFlags)
+	tabName := tree.AsStringWithFlags(tn, b.FmtFlags)
 	tabID := md.AddTableWithName(tab, tabName)
 
 	colCount := len(ordinals)

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -155,7 +155,6 @@ func (b *Builder) renameSource(as tree.AliasClause, scope *scope) {
 func (b *Builder) buildScanFromTableRef(
 	tab opt.Table, ref *tree.TableRef, inScope *scope,
 ) (outScope *scope) {
-
 	if ref.Columns != nil && len(ref.Columns) == 0 {
 		panic(builderError{pgerror.NewErrorf(pgerror.CodeSyntaxError,
 			"an explicit list of column IDs must include at least one column")})
@@ -165,7 +164,6 @@ func (b *Builder) buildScanFromTableRef(
 	// (all columns). whereas an array of length 0 means 'zero columns'.
 	// Lists of zero columns are not supported and will throw an error."
 	// The error for lists of zero columns is thrown in the caller function
-	// for buildScanWithTableRef.
 	// for buildScanFromTableRef.
 	var ordinals []int
 	if ref.Columns != nil {
@@ -212,7 +210,7 @@ func (b *Builder) buildScan(
 		}
 
 		col := tab.Column(ord)
-		colID := b.factory.Metadata().TableColumn(tabID, ord)
+		colID := tabID.ColumnID(ord)
 		tabColIDs.Add(int(colID))
 		name := tree.Name(col.ColName())
 		outScope.cols = append(outScope.cols, scopeColumn{

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -157,21 +157,19 @@ func (b *Builder) synthesizeColumn(
 	scope *scope, label string, typ types.T, expr tree.TypedExpr, group memo.GroupID,
 ) *scopeColumn {
 	if label == "" {
-		label = fmt.Sprintf("column%d", len(b.colMap))
+		label = fmt.Sprintf("column%d", b.factory.Metadata().NumColumns()+1)
 	}
 
 	name := tree.Name(label)
 	colID := b.factory.Metadata().AddColumn(label, typ)
-	col := scopeColumn{
+	scope.cols = append(scope.cols, scopeColumn{
 		origName: name,
 		name:     name,
 		typ:      typ,
 		id:       colID,
 		expr:     expr,
 		group:    group,
-	}
-	b.colMap = append(b.colMap, col)
-	scope.cols = append(scope.cols, col)
+	})
 	return &scope.cols[len(scope.cols)-1]
 }
 

--- a/pkg/sql/opt/props/physical.go
+++ b/pkg/sql/opt/props/physical.go
@@ -50,8 +50,12 @@ type Physical struct {
 	Ordering OrderingChoice
 }
 
-// Defined returns true if any physical property is defined. If none is
-// defined, then this is an instance of MinPhysProps.
+// MinPhysProps are the default physical properties that require nothing and
+// provide nothing.
+var MinPhysProps Physical
+
+// Defined is true if any physical property is defined. If none is defined, then
+// this is an instance of MinPhysProps.
 func (p *Physical) Defined() bool {
 	return !p.Presentation.Any() || !p.Ordering.Any()
 }
@@ -65,8 +69,7 @@ func (p *Physical) ColSet() opt.ColSet {
 	return colSet
 }
 
-// FormatString writes physical properties to a human-readable format.
-func (p *Physical) FormatString(verbose bool) string {
+func (p *Physical) String() string {
 	hasProjection := !p.Presentation.Any()
 	hasOrdering := !p.Ordering.Any()
 
@@ -78,14 +81,9 @@ func (p *Physical) FormatString(verbose bool) string {
 	var buf bytes.Buffer
 
 	if hasProjection {
-		if verbose {
-			buf.WriteString("[presentation: ")
-			p.Presentation.format(&buf)
-			buf.WriteByte(']')
-		} else {
-			buf.WriteString("p:")
-			p.Presentation.format(&buf)
-		}
+		buf.WriteString("[presentation: ")
+		p.Presentation.format(&buf)
+		buf.WriteByte(']')
 
 		if hasOrdering {
 			buf.WriteString(" ")
@@ -93,27 +91,12 @@ func (p *Physical) FormatString(verbose bool) string {
 	}
 
 	if hasOrdering {
-		if verbose {
-			buf.WriteString("[ordering: ")
-			p.Ordering.Format(&buf)
-			buf.WriteByte(']')
-		} else {
-			buf.WriteString("o:")
-			p.Ordering.Format(&buf)
-		}
+		buf.WriteString("[ordering: ")
+		p.Ordering.Format(&buf)
+		buf.WriteByte(']')
 	}
 
 	return buf.String()
-}
-
-// Fingerprint returns a string that uniquely describes this set of physical
-// properties. It is suitable for use as a hash key in a map.
-func (p *Physical) Fingerprint() string {
-	return p.FormatString(false /* verbose */)
-}
-
-func (p *Physical) String() string {
-	return p.FormatString(true /* verbose */)
 }
 
 // Equals returns true if the two physical properties are identical.

--- a/pkg/sql/opt/props/physical_test.go
+++ b/pkg/sql/opt/props/physical_test.go
@@ -36,7 +36,7 @@ func TestPhysicalProps(t *testing.T) {
 		opt.LabeledColumn{Label: "b", ID: 2},
 	}
 	phys = &props.Physical{Presentation: presentation}
-	testPhysicalProps(t, phys, "p:a:1,b:2")
+	testPhysicalProps(t, phys, "[presentation: a:1,b:2]")
 
 	if presentation.Any() {
 		t.Error("presentation should not be empty")
@@ -53,12 +53,12 @@ func TestPhysicalProps(t *testing.T) {
 	// Add ordering props.
 	ordering := props.ParseOrderingChoice("+1,+5")
 	phys.Ordering = ordering
-	testPhysicalProps(t, phys, "p:a:1,b:2 o:+1,+5")
+	testPhysicalProps(t, phys, "[presentation: a:1,b:2] [ordering: +1,+5]")
 }
 
 func testPhysicalProps(t *testing.T, physProps *props.Physical, expected string) {
 	t.Helper()
-	actual := physProps.Fingerprint()
+	actual := physProps.String()
 	if actual != expected {
 		t.Errorf("\nexpected: %s\nactual: %s", expected, actual)
 	}

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -50,10 +50,6 @@ type coster struct {
 	mem *memo.Memo
 }
 
-func newCoster(mem *memo.Memo) *coster {
-	return &coster{mem: mem}
-}
-
 const (
 	// These costs have been copied from the Postgres optimizer:
 	// https://github.com/postgres/postgres/blob/master/src/include/optimizer/cost.h

--- a/pkg/sql/opt/xform/interesting_orderings.go
+++ b/pkg/sql/opt/xform/interesting_orderings.go
@@ -74,7 +74,7 @@ func interestingOrderingsForScan(ev memo.ExprView) opt.OrderingSet {
 		o := make(opt.Ordering, 0, numIndexCols)
 		for j := 0; j < numIndexCols; j++ {
 			indexCol := index.Column(j)
-			colID := md.TableColumn(def.Table, indexCol.Ordinal)
+			colID := def.Table.ColumnID(indexCol.Ordinal)
 			if !def.Cols.Contains(int(colID)) {
 				break
 			}

--- a/pkg/sql/opt/xfunc/custom_funcs.go
+++ b/pkg/sql/opt/xfunc/custom_funcs.go
@@ -57,7 +57,7 @@ func MakeCustomFuncs(mem *memo.Memo, evalCtx *tree.EvalContext) CustomFuncs {
 // duplicates. See the comment for listSorter.compare for comparison rule
 // details.
 func (c *CustomFuncs) IsSortedUniqueList(list memo.ListID) bool {
-	if list.Length == 0 {
+	if list.Length <= 1 {
 		return true
 	}
 	ls := listSorter{cf: c, list: c.mem.LookupList(list)}


### PR DESCRIPTION
This PR contains a number of small improvements to planning performance
for small queries like `SELECT k, v FROM kv WHERE k IN ($1)`. Together,
the changes improve optimization performance on that query by ~15%.
```
                                                             before         after
BenchmarkPhases/kv-read/Parse-8         	  200000	      8136 ns/op    8052 ns/op
BenchmarkPhases/kv-read/OptBuild-8      	   50000	     27826 ns/op    23860 ns/op
BenchmarkPhases/kv-read/Normalize-8     	   50000	     28081 ns/op    23662 ns/op
BenchmarkPhases/kv-read/Explore-8       	   50000	     36305 ns/op    31146 ns/op
```
Note that this is a micro-benchmark, so this won't translate to similar gains
in an overall workload. However, most of the fixes are applicable to a wide
variety of queries, so the net effect should be positive.