### PR TITLE
server: enable web login by default; allow disabling with env var

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -316,7 +316,7 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 		panic(err)
 	}
 
-	requireWebLogin := envutil.EnvOrDefaultBool("COCKROACH_EXPERIMENTAL_REQUIRE_WEB_LOGIN", false)
+	disableWebLogin := envutil.EnvOrDefaultBool("COCKROACH_DISABLE_WEB_LOGIN", false)
 
 	cfg := Config{
 		Config:                         new(base.Config),
@@ -329,7 +329,7 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 		ScanMinIdleTime:                defaultScanMinIdleTime,
 		ScanMaxIdleTime:                defaultScanMaxIdleTime,
 		EventLogEnabled:                defaultEventLogEnabled,
-		EnableWebSessionAuthentication: requireWebLogin,
+		EnableWebSessionAuthentication: !disableWebLogin,
 		Stores: base.StoreSpecList{
 			Specs: []base.StoreSpec{storeSpec},
 		},


### PR DESCRIPTION
Customers should have login on by default for secure clusters, but may
need to turn it off if there is some bug with login that we don't know
about.

This commit provides a way of turning it off, in a way that does not
encourage the customer to use it: it's not very discoverable, and
requires a restart to take effect.

Release note (admin ui change): require login by default on secure
clusters