### PR TITLE
rocksdb: Link in sst_dump as a debug command

### DIFF
--- a/c-deps/libroach/CMakeLists.txt
+++ b/c-deps/libroach/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(roach
   mvcc.cc
   options.cc
   snapshot.cc
+  sst_dump.cc
   timebound.cc
   utils.cc
   protos/roachpb/data.pb.cc

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -399,6 +399,7 @@ DBStatus DBSstFileWriterFinish(DBSstFileWriter* fw, DBString* data);
 void DBSstFileWriterClose(DBSstFileWriter* fw);
 
 void DBRunLDB(int argc, char** argv);
+void DBRunSSTDump(int argc, char** argv);
 
 // DBEnvWriteFile writes the given data as a new "file" in the given engine.
 DBStatus DBEnvWriteFile(DBEngine* db, DBSlice path, DBSlice contents);

--- a/c-deps/libroach/sst_dump.cc
+++ b/c-deps/libroach/sst_dump.cc
@@ -1,0 +1,21 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+
+#include <rocksdb/sst_dump_tool.h>
+#include <libroach.h>
+
+void DBRunSSTDump(int argc, char** argv) {
+  rocksdb::SSTDumpTool tool;
+  tool.Run(argc, argv);
+}

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -917,6 +917,20 @@ https://github.com/facebook/rocksdb/wiki/Administration-and-Data-Access-Tool#ldb
 	},
 }
 
+var debugSSTDumpCmd = &cobra.Command{
+	Use:   "sst_dump",
+	Short: "run the RocksDB 'sst_dump' tool",
+	Long: `
+Runs the RocksDB 'sst_dump' tool
+`,
+	// sst_dump does its own flag parsing.
+	// TODO(mberhault): support encrypted stores.
+	DisableFlagParsing: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		engine.RunSSTDump(args)
+	},
+}
+
 var debugEnvCmd = &cobra.Command{
 	Use:   "env",
 	Short: "output environment settings",
@@ -1392,6 +1406,7 @@ var debugCmds = append(DebugCmdsForRocksDB,
 	debugBallastCmd,
 	debugDecodeKeyCmd,
 	debugRocksDBCmd,
+	debugSSTDumpCmd,
 	debugGossipValuesCmd,
 	debugTimeSeriesDumpCmd,
 	debugSyncTestCmd,

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2697,6 +2697,24 @@ func RunLDB(args []string) {
 	C.DBRunLDB(C.int(len(argv)), &argv[0])
 }
 
+// RunSSTDump runs RocksDB's sst_dump command-line tool. The passed
+// command-line arguments should not include argv[0].
+func RunSSTDump(args []string) {
+	// Prepend "sst_dump" as argv[0].
+	args = append([]string{"sst_dump"}, args...)
+	argv := make([]*C.char, len(args))
+	for i := range args {
+		argv[i] = C.CString(args[i])
+	}
+	defer func() {
+		for i := range argv {
+			C.free(unsafe.Pointer(argv[i]))
+		}
+	}()
+
+	C.DBRunSSTDump(C.int(len(argv)), &argv[0])
+}
+
 // GetAuxiliaryDir returns the auxiliary storage path for this engine.
 func (r *RocksDB) GetAuxiliaryDir() string {
 	return r.auxDir


### PR DESCRIPTION
There's less reason to build this in than ldb, since it can't make use
of our custom comparator or pretty-printer, but it's nontrivial to
build this tool from upstream with snappy support.

Release note: None