### PR TITLE
cli: fix Example_demo

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -669,6 +669,7 @@ func Example_demo() {
 	// Ensure that CLI error messages and anything meant for the
 	// original stderr is redirected to stdout, where it can be
 	// captured.
+	defer func() { stderr = log.OrigStderr }()
 	stderr = os.Stdout
 
 	for _, cmd := range testData {


### PR DESCRIPTION
Wasn't restoring `stderr` properly.

Release note: None