### PR TITLE
opt: support ANY/ALL/SOME with arrays

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -341,6 +341,18 @@ SELECT k FROM t WHERE k = ANY ARRAY[2,4]
 2
 4
 
+query I rowsort
+SELECT k FROM t WHERE k > ANY ARRAY[2,4]
+----
+3
+4
+5
+
+query I
+SELECT k FROM t WHERE k < ALL ARRAY[2,4]
+----
+1
+
 # Undocumented - bounds should be allowed, as in Postgres
 statement ok
 CREATE TABLE boundedtable (b INT[10], c INT ARRAY[10])

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -506,3 +506,30 @@ render     ·         ·                   ("array")  ·
  └── scan  ·         ·                   (a)        ·
 ·          table     t@primary           ·          ·
 ·          spans     ALL                 ·          ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT 1 > ANY ARRAY[a + 1, 2, 3] FROM t
+----
+render     ·         ·                           ("?column?")  ·
+ │         render 0  1 > ANY ARRAY[a + 1, 2, 3]  ·             ·
+ └── scan  ·         ·                           (a)           ·
+·          table     t@primary                   ·             ·
+·          spans     ALL                         ·             ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT 1 = ANY (1, 2, 3) FROM t
+----
+render     ·         ·                  ("?column?")  ·
+ │         render 0  1 = ANY (1, 2, 3)  ·             ·
+ └── scan  ·         ·                  ()            ·
+·          table     t@primary          ·             ·
+·          spans     ALL                ·             ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT 1 = ANY () FROM t
+----
+render     ·         ·           ("?column?")  ·
+ │         render 0  1 = ANY ()  ·             ·
+ └── scan  ·         ·           ()            ·
+·          table     t@primary   ·             ·
+·          spans     ALL         ·             ·

--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -127,6 +127,7 @@ func init() {
 		opt.SubqueryOp:        typeSubquery,
 		opt.ArrayOp:           typeAsPrivate,
 		opt.ColumnAccessOp:    typeColumnAccess,
+		opt.AnyScalarOp:       typeAsBool,
 
 		// Override default typeAsAggregate behavior for aggregate functions with
 		// a large number of possible overloads or where ReturnType depends on

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -348,6 +348,13 @@ define JsonSomeExists {
    Right Expr
 }
 
+[Scalar]
+define AnyScalar {
+   Left  Expr
+   Right Expr
+   Cmp   Operator
+}
+
 [Scalar, Binary]
 define Bitand {
    Left  Expr

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -886,7 +886,7 @@ SELECT ARRAY(SELECT 1, 2)
 error (42601): subquery must return only one column, found 2
 
 build
-SELECT ARRAY(SELECT generate_series(1,100) ORDER BY 1 DESC);
+SELECT ARRAY(SELECT generate_series(1,100) ORDER BY 1 DESC)
 ----
 project
  ├── columns: array:3(tuple{int}[])
@@ -915,3 +915,78 @@ project
            │              └── array-agg [type=int[]]
            │                   └── variable: column1 [type=int]
            └── array: [type=int[]]
+
+build-scalar
+1 = ANY ARRAY[1, 2, 3]
+----
+any-scalar: eq [type=bool]
+ ├── const: 1 [type=int]
+ └── array: [type=int[]]
+      ├── const: 1 [type=int]
+      ├── const: 2 [type=int]
+      └── const: 3 [type=int]
+
+build-scalar
+1 > ANY ARRAY[1, 2, 3]
+----
+any-scalar: gt [type=bool]
+ ├── const: 1 [type=int]
+ └── array: [type=int[]]
+      ├── const: 1 [type=int]
+      ├── const: 2 [type=int]
+      └── const: 3 [type=int]
+
+build-scalar
+1 = ALL ARRAY[1, 2, 3]
+----
+not [type=bool]
+ └── any-scalar: ne [type=bool]
+      ├── const: 1 [type=int]
+      └── array: [type=int[]]
+           ├── const: 1 [type=int]
+           ├── const: 2 [type=int]
+           └── const: 3 [type=int]
+
+build-scalar
+1 > ALL ARRAY[1, 2, 3]
+----
+not [type=bool]
+ └── any-scalar: le [type=bool]
+      ├── const: 1 [type=int]
+      └── array: [type=int[]]
+           ├── const: 1 [type=int]
+           ├── const: 2 [type=int]
+           └── const: 3 [type=int]
+
+build-scalar
+1 = ANY (1, 2, 3)
+----
+any-scalar: eq [type=bool]
+ ├── const: 1 [type=int]
+ └── tuple [type=tuple{int, int, int}]
+      ├── const: 1 [type=int]
+      ├── const: 2 [type=int]
+      └── const: 3 [type=int]
+
+build-scalar
+'foo' = ANY ('foo', 'bar', 'baz')
+----
+any-scalar: eq [type=bool]
+ ├── const: 'foo' [type=string]
+ └── tuple [type=tuple{string, string, string}]
+      ├── const: 'foo' [type=string]
+      ├── const: 'bar' [type=string]
+      └── const: 'baz' [type=string]
+
+
+build-scalar
+1 = ANY ()
+----
+any-scalar: eq [type=bool]
+ ├── const: 1 [type=int]
+ └── tuple [type=tuple{}]
+
+build
+SELECT 1 > ALL ARRAY['foo']
+----
+error (22023): unsupported comparison operator: 1 > ALL ARRAY['foo']: could not parse "foo" as type int: strconv.ParseInt: parsing "foo": invalid syntax

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -445,7 +445,7 @@ func (node *ComparisonExpr) memoizeFn() {
 		// Array operators memoize the SubOperator's CmpOp.
 		fOp, _, _, _, _ = foldComparisonExpr(node.SubOperator, nil, nil)
 		// The right operand is either an array or a tuple/subquery.
-		switch t := rightRet.(type) {
+		switch t := types.UnwrapType(rightRet).(type) {
 		case types.TArray:
 			// For example:
 			//   x = ANY(ARRAY[1,2])
@@ -454,7 +454,11 @@ func (node *ComparisonExpr) memoizeFn() {
 			// For example:
 			//   x = ANY(SELECT y FROM t)
 			//   x = ANY(1,2)
-			rightRet = t.Types[0]
+			if len(t.Types) > 0 {
+				rightRet = t.Types[0]
+			} else {
+				rightRet = leftRet
+			}
 		}
 	}
 


### PR DESCRIPTION
This commit supports scalar expressions of the form

```
a <op> (ANY|SOME|ALL) <array expr>
```

To keep the internal opt representation simpler, like with subqueries,
ALL is implemented via DeMorgan's law:

```
a <op> ALL x
=>
NOT (a <negated op> ANY x)
```

Release note: None