### PR TITLE
 WIP: sql: use node liveness epochs for table leases

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -653,9 +653,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	s.execCfg = &execCfg
 
-	s.leaseMgr.SetExecCfg(&execCfg)
-	s.leaseMgr.RefreshLeases(s.stopper, s.db, s.gossip)
-
 	s.node.InitLogger(&execCfg)
 
 	return s, nil
@@ -1579,6 +1576,15 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 			return err
 		}
 	}
+
+	{
+		var regLiveness jobs.NodeLiveness = s.nodeLiveness
+	s.leaseMgr.Start(
+			regLiveness,
+			s.execCfg,
+			s.db,
+			s.gossip)
+		}
 
 	// Before serving SQL requests, we have to make sure the database is
 	// in an acceptable form for this version of the software.

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -252,11 +252,7 @@ func (sc *SchemaChanger) truncateIndexes(
 				}
 
 				tc := &TableCollection{leaseMgr: sc.leaseMgr}
-				defer func() {
-					if err := tc.releaseTables(ctx, dontBlockForDBCacheUpdate); err != nil {
-						log.Warningf(ctx, "error releasing tables: %s", err)
-					}
-				}()
+				defer tc.releaseTables(ctx)
 				tableDesc, err := sc.getTableVersion(ctx, txn, tc, version)
 				if err != nil {
 					return err
@@ -469,11 +465,7 @@ func (sc *SchemaChanger) distBackfill(
 
 			tc := &TableCollection{leaseMgr: sc.leaseMgr}
 			// Use a leased table descriptor for the backfill.
-			defer func() {
-				if err := tc.releaseTables(ctx, dontBlockForDBCacheUpdate); err != nil {
-					log.Warningf(ctx, "error releasing tables: %s", err)
-				}
-			}()
+			defer tc.releaseTables(ctx)
 			tableDesc, err := sc.getTableVersion(ctx, txn, tc, version)
 			if err != nil {
 				return err

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -479,6 +479,30 @@ func (ex *connExecutor) checkTableTwoVersionInvariant(ctx context.Context) error
 	if txn.IsCommitted() {
 		panic("transaction has already committed")
 	}
+
+	// Release leases here for two reasons:
+	// 1. If there are existing leases at version V-2 for a descriptor
+	// being modified to version V being held the wait loop below that
+	// waits on a cluster wide release of old version leases will hang
+	// until these leases expire.
+	// 2. Once this transaction commits, the schema changers run and
+	// increment the version of the modified descriptors. If one of the
+	// descriptors being modified has a lease being held the schema
+	// changers will stall until the leases expire.
+	//
+	// The above two cases can be satified by releasing leases for both
+	// cases explicitly, but we prefer to call it here and kill two birds
+	// with one stone.
+	//
+	// It is safe to release leases even though the transaction hasn't yet
+	// committed only because the transaction timestamp has been fixed using
+	// CommitTimestamp().
+	//
+	// releaseLeases can fail to release a lease if the server is shutting
+	// down. This is okay because it will result in the two cases mentioned
+	// above simply hanging until the expiration time for the leases.
+	ex.extraTxnState.tables.releaseLeases(ex.Ctx())
+
 	count, err := CountLeases(ctx, ex.server.cfg.InternalExecutor, tables, txn.OrigTimestamp())
 	if err != nil {
 		return err
@@ -509,10 +533,6 @@ func (ex *connExecutor) checkTableTwoVersionInvariant(ctx context.Context) error
 	// We cleanup the transaction and create a new transaction wait time
 	// might be extensive and so we'd better get rid of all the intents.
 	txn.CleanupOnError(ctx, retryErr)
-
-	// Release leases held by the current transaction before waiting
-	// on cluster wide releases of old version leases.
-	ex.extraTxnState.tables.releaseLeases(ex.Ctx())
 
 	// Wait until all older version leases have been released or expired.
 	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {

--- a/pkg/sql/helpers_test.go
+++ b/pkg/sql/helpers_test.go
@@ -119,9 +119,9 @@ func (m *LeaseManager) AcquireAndAssertMinVersion(
 	if err := ensureVersion(ctx, tableID, minVersion, m); err != nil {
 		return nil, hlc.Timestamp{}, err
 	}
-	table, _, err := t.findForTimestamp(ctx, timestamp)
+	table, err := t.findForTimestamp(ctx, timestamp)
 	if err != nil {
 		return nil, hlc.Timestamp{}, err
 	}
-	return &table.TableDescriptor, table.expiration, nil
+	return &table.TableDescriptor, m.txnDeadline(table, timestamp), nil
 }

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -203,7 +203,7 @@ func (ie *internalExecutorImpl) initConnEx(
 		// txn committed. But if there is a higher-level txn, they don't get
 		// released.
 		defer func() {
-			if err := ex.resetExtraTxnState(ctx, txnAborted, ex.server.dbCache); err != nil {
+			if err := ex.resetExtraTxnState(ctx, ex.server.dbCache); err != nil {
 				log.Warningf(ctx, "error while cleaning up connExecutor: %s", err)
 			}
 		}()

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -213,7 +213,10 @@ func (s LeaseStore) acquire(ctx context.Context, tableID sqlbase.ID) (*tableVers
 	return table, err
 }
 
-// Release a previously acquired table descriptor.
+// Release a previously acquired table descriptor. Never let this method
+// read a table descriptor because it can be called while modifying a
+// descriptor through a schema change before the schema change has committed
+// that can result in a deadlock.
 func (s LeaseStore) release(ctx context.Context, stopper *stop.Stopper, table *tableVersionState) {
 	retryOptions := base.DefaultRetryOptions()
 	retryOptions.Closer = stopper.ShouldQuiesce()
@@ -318,6 +321,10 @@ func incrementVersion(
 	// the mvcc timestamp of the descriptor. This requires moving the
 	// schema change lease out of the descriptor making the
 	// descriptor truly immutable at a version.
+	// Also recognize that the leases are released before the transaction
+	// is committed through a call to TableCollection.releaseLeases(),
+	// so updating this policy will also need to consider not doing
+	// that.
 	modTime := txn.CommitTimestamp()
 	tableDesc.ModificationTime = modTime
 	log.Infof(ctx, "publish: descID=%d (%s) version=%d mtime=%s",
@@ -978,7 +985,7 @@ func (t *tableState) release(
 	return nil, nil
 }
 
-// release the lease associated with the table version.
+// releaseLease associated with the table version.
 func releaseLease(table *tableVersionState, m *LeaseManager) {
 	m.tableNames.remove(table)
 

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -24,6 +24,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -67,6 +69,8 @@ type tableVersionState struct {
 	// ModificationTime of the next version when the table version
 	// isn't associated with a lease.
 	expiration hlc.Timestamp
+
+	epoch int64
 
 	mu struct {
 		syncutil.Mutex
@@ -121,7 +125,8 @@ func (s *tableVersionState) leaseExpiration() tree.DTimestamp {
 // LeaseStore implements the operations for acquiring and releasing leases and
 // publishing a new version of a descriptor. Exported only for testing.
 type LeaseStore struct {
-	execCfg *ExecutorConfig
+	execCfg      *ExecutorConfig
+	nodeLiveness jobs.NodeLiveness
 
 	// group is used for all calls made to acquireNodeLease to prevent
 	// concurrent lease acquisitions from the store.
@@ -144,6 +149,14 @@ type LeaseStore struct {
 	testingKnobs LeaseStoreTestingKnobs
 }
 
+// The deadline a txn using this table version should use.
+func (s LeaseStore) txnDeadline(tvs *tableVersionState, timestamp hlc.Timestamp) hlc.Timestamp {
+	if tvs.expiration == hlc.MaxTimestamp {
+		timestamp.Add(int64(s.leaseDuration), 0)
+	}
+	return tvs.expiration
+}
+
 // jitteredLeaseDuration returns a randomly jittered duration from the interval
 // [(1-leaseJitterFraction) * leaseDuration, (1+leaseJitterFraction) * leaseDuration].
 func (s LeaseStore) jitteredLeaseDuration() time.Duration {
@@ -154,12 +167,9 @@ func (s LeaseStore) jitteredLeaseDuration() time.Duration {
 // acquire a lease on the most recent version of a table descriptor.
 // If the lease cannot be obtained because the descriptor is in the process of
 // being dropped, the error will be errTableDropped.
-func (s LeaseStore) acquire(ctx context.Context, tableID sqlbase.ID) (*tableVersionState, error) {
+func (s LeaseStore) acquire(ctx context.Context, epoch int64, tableID sqlbase.ID) (*tableVersionState, error) {
 	var table *tableVersionState
 	err := s.execCfg.DB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		expiration := txn.OrigTimestamp()
-		expiration.WallTime += int64(s.jitteredLeaseDuration())
-
 		tableDesc, err := sqlbase.GetTableDescFromID(ctx, txn, tableID)
 		if err != nil {
 			return err
@@ -172,7 +182,8 @@ func (s LeaseStore) acquire(ctx context.Context, tableID sqlbase.ID) (*tableVers
 		// to not modify it.
 		table = &tableVersionState{
 			TableDescriptor: *tableDesc,
-			expiration:      expiration,
+			expiration:      hlc.MaxTimestamp,
+			epoch:           epoch,
 		}
 		table.mu.leased = true
 
@@ -195,8 +206,8 @@ func (s LeaseStore) acquire(ctx context.Context, tableID sqlbase.ID) (*tableVers
 		// read from the database for the special descriptor of a system table
 		// (#23937).
 		insertLease := fmt.Sprintf(
-			`INSERT INTO system.lease ("descID", version, "nodeID", expiration) VALUES (%d, %d, %d, %s)`,
-			table.ID, int(table.Version), nodeID, &leaseExpiration,
+			`INSERT INTO system.lease ("descID", version, "nodeID", expiration, epoch) VALUES (%d, %d, %d, %s, %d)`,
+			table.ID, int(table.Version), nodeID, &leaseExpiration, epoch,
 		)
 		count, err := s.execCfg.InternalExecutor.Exec(ctx, "lease-insert", txn, insertLease)
 		if err != nil {
@@ -230,14 +241,14 @@ func (s LeaseStore) release(ctx context.Context, stopper *stop.Stopper, table *t
 			panic("zero nodeID")
 		}
 		const deleteLease = `DELETE FROM system.lease ` +
-			`WHERE ("descID", version, "nodeID", expiration) = ($1, $2, $3, $4)`
+			`WHERE ("descID", version, "nodeID", expiration, epoch) = ($1, $2, $3, $4, $5)`
 		leaseExpiration := table.leaseExpiration()
 		count, err := s.execCfg.InternalExecutor.Exec(
 			ctx,
 			"lease-release",
 			nil, /* txn */
 			deleteLease,
-			table.ID, int(table.Version), nodeID, &leaseExpiration,
+			table.ID, int(table.Version), nodeID, &leaseExpiration, table.epoch,
 		)
 		if err != nil {
 			log.Warningf(ctx, "error releasing lease %q: %s", table, err)
@@ -252,6 +263,37 @@ func (s LeaseStore) release(ctx context.Context, stopper *stop.Stopper, table *t
 
 		if s.testingKnobs.LeaseReleasedEvent != nil {
 			s.testingKnobs.LeaseReleasedEvent(table.TableDescriptor, err)
+		}
+		break
+	}
+}
+
+func (s LeaseStore) releaseOldLeases(
+	ctx context.Context, stopper *stop.Stopper, nodeID roachpb.NodeID, currentEpoch int64,
+) {
+	retryOptions := base.DefaultRetryOptions()
+	retryOptions.Closer = stopper.ShouldQuiesce()
+	// This transaction is idempotent; the retry was put in place because of
+	// NodeUnavailableErrors.
+	for r := retry.Start(retryOptions); r.Next(); {
+		log.VEventf(ctx, 2, "LeaseStore releasing old leases < (%d:%d)", nodeID, currentEpoch)
+		const deleteLeases = `DELETE FROM system.lease ` +
+			`WHERE ("nodeID", expiration) = ($1, $2) AND epoch < $3`
+		tvs := tableVersionState{expiration: hlc.MaxTimestamp}
+		leaseExpiration := tvs.leaseExpiration()
+		count, err := s.execCfg.InternalExecutor.Exec(
+			ctx,
+			"lease-release",
+			nil, /* txn */
+			deleteLeases,
+			nodeID, &leaseExpiration, currentEpoch,
+		)
+		if err != nil {
+			log.Warningf(ctx, "error releasing old leases < (%d:%d), err = %s", nodeID, currentEpoch, err)
+			continue
+		}
+		if count > 1 {
+			log.VEventf(ctx, 2, "LeaseStore released %d old leases < (%d:%d)", count, nodeID, currentEpoch)
 		}
 		break
 	}
@@ -652,7 +694,8 @@ type tableState struct {
 func ensureVersion(
 	ctx context.Context, tableID sqlbase.ID, minVersion sqlbase.DescriptorVersion, m *LeaseManager,
 ) error {
-	if s := m.findNewest(tableID); s != nil && minVersion <= s.Version {
+	epoch := m.getEpoch()
+	if s := m.findNewest(tableID); s != nil && minVersion <= s.Version && epoch <= s.epoch {
 		return nil
 	}
 
@@ -684,40 +727,37 @@ func ensureVersion(
 // before calling.
 //
 // The refcount for the returned tableVersionState is incremented.
-// It returns true if the descriptor returned is the known latest version
-// of the descriptor.
 func (t *tableState) findForTimestamp(
 	ctx context.Context, timestamp hlc.Timestamp,
-) (*tableVersionState, bool, error) {
+) (*tableVersionState, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	// Acquire a lease if no table descriptor exists in the cache.
 	if len(t.mu.active.data) == 0 {
-		return nil, false, errRenewLease
+		return nil, errRenewLease
 	}
 
 	// Walk back the versions to find one that is valid for the timestamp.
 	for i := len(t.mu.active.data) - 1; i >= 0; i-- {
 		// Check to see if the ModificationTime is valid.
 		if table := t.mu.active.data[i]; !timestamp.Less(table.ModificationTime) {
-			latest := i+1 == len(t.mu.active.data)
 			if !table.hasExpired(timestamp) {
 				// Existing valid table version.
 				table.incRefcount()
-				return table, latest, nil
+				return table, nil
 			}
 
-			if latest {
+			if latest := i+1 == len(t.mu.active.data); latest {
 				// Renew the lease if the lease has expired
 				// The latest descriptor always has a lease.
-				return nil, false, errRenewLease
+				return nil, errRenewLease
 			}
 			break
 		}
 	}
 
-	return nil, false, errReadOlderTableVersion
+	return nil, errReadOlderTableVersion
 }
 
 // Read an older table descriptor version for the particular timestamp
@@ -914,10 +954,13 @@ func (t *tableState) removeInactiveVersions() []*tableVersionState {
 func acquireNodeLease(ctx context.Context, m *LeaseManager, id sqlbase.ID) (bool, error) {
 	var toRelease *tableVersionState
 	resultChan, didAcquire := m.group.DoChan(fmt.Sprintf("acquire%d", id), func() (interface{}, error) {
+		if m.nodeLiveness == nil {
+			return nil, errors.New("cannot acquire leases without node liveness information")
+		}
 		if m.isDraining() {
 			return nil, errors.New("cannot acquire lease when draining")
 		}
-		table, err := m.LeaseStore.acquire(ctx, id)
+		table, err := m.LeaseStore.acquire(ctx, m.getEpoch(), id)
 		if err != nil {
 			return nil, err
 		}
@@ -1015,7 +1058,6 @@ func releaseLease(table *tableVersionState, m *LeaseManager) {
 // If t has no active leases, nothing is done.
 func purgeOldVersions(
 	ctx context.Context,
-	db *client.DB,
 	id sqlbase.ID,
 	dropped bool,
 	minVersion sqlbase.DescriptorVersion,
@@ -1056,7 +1098,7 @@ func purgeOldVersions(
 	// Acquire a refcount on the table on the latest version to maintain an
 	// active lease, so that it doesn't get released when removeInactives()
 	// is called below. Release this lease after calling removeInactives().
-	table, _, err := t.findForTimestamp(ctx, m.execCfg.Clock.Now())
+	table, err := t.findForTimestamp(ctx, m.execCfg.Clock.Now())
 	if dropped := err == errTableDropped; dropped || err == nil {
 		removeInactives(dropped)
 		if table != nil {
@@ -1227,12 +1269,10 @@ func (c *tableNameCache) insert(table *tableVersionState) {
 		c.tables[key] = table
 		return
 	}
-	// If we already have a lease in the cache for this name, see if this one is
-	// better (higher version or later expiration).
-	if table.Version > existing.Version ||
-		(table.Version == existing.Version && (existing.expiration.Less(table.expiration))) {
-		// Overwrite the old table. The new one is better. From now on, we want
-		// clients to use the new one.
+	// If we already have a lease in the cache for this name, see if this one
+	// has a higher version.
+	if table.Version > existing.Version {
+		// From now on, we want clients to use the new one.
 		c.tables[key] = table
 	}
 }
@@ -1278,6 +1318,7 @@ type LeaseManager struct {
 	mu struct {
 		syncutil.Mutex
 		tables map[sqlbase.ID]*tableState
+		epoch  int64
 	}
 
 	draining atomic.Value
@@ -1328,9 +1369,17 @@ func NewLeaseManager(
 	return lm
 }
 
-// SetExecCfg has to be called if a nil execCfg was passed to NewLeaseManager.
-func (m *LeaseManager) SetExecCfg(execCfg *ExecutorConfig) {
+// Start the lease manager
+func (m *LeaseManager) Start(
+	nodeLiveness jobs.NodeLiveness,
+	execCfg *ExecutorConfig,
+	db *client.DB,
+	g *gossip.Gossip,
+) {
+	m.nodeLiveness = nodeLiveness
 	m.execCfg = execCfg
+	m.refreshLeases(m.stopper, db, g)
+	m.periodicallyPurgeOldLeases()
 }
 
 func nameMatchesTable(table *sqlbase.TableDescriptor, dbID sqlbase.ID, tableName string) bool {
@@ -1359,17 +1408,7 @@ func (m *LeaseManager) AcquireByName(
 	tableVersion := m.tableNames.get(dbID, tableName, timestamp)
 	if tableVersion != nil {
 		if !timestamp.Less(tableVersion.ModificationTime) {
-			// If this lease is nearly expired, ensure a renewal is queued.
-			durationUntilExpiry := time.Duration(tableVersion.expiration.WallTime - timestamp.WallTime)
-			if durationUntilExpiry < m.LeaseStore.leaseRenewalTimeout {
-				if t := m.findTableState(tableVersion.ID, false /* create */); t != nil {
-					if err := t.maybeQueueLeaseRenewal(
-						ctx, m, tableVersion.ID, tableName); err != nil {
-						return nil, hlc.Timestamp{}, err
-					}
-				}
-			}
-			return &tableVersion.TableDescriptor, tableVersion.expiration, nil
+			return &tableVersion.TableDescriptor, m.txnDeadline(tableVersion, timestamp), nil
 		}
 		if err := m.Release(&tableVersion.TableDescriptor); err != nil {
 			return nil, hlc.Timestamp{}, err
@@ -1490,18 +1529,9 @@ func (m *LeaseManager) Acquire(
 ) (*sqlbase.TableDescriptor, hlc.Timestamp, error) {
 	for {
 		t := m.findTableState(tableID, true /*create*/)
-		table, latest, err := t.findForTimestamp(ctx, timestamp)
+		table, err := t.findForTimestamp(ctx, timestamp)
 		if err == nil {
-			// If the latest lease is nearly expired, ensure a renewal is queued.
-			if latest {
-				durationUntilExpiry := time.Duration(table.expiration.WallTime - timestamp.WallTime)
-				if durationUntilExpiry < m.LeaseStore.leaseRenewalTimeout {
-					if err := t.maybeQueueLeaseRenewal(ctx, m, tableID, table.Name); err != nil {
-						return nil, hlc.Timestamp{}, err
-					}
-				}
-			}
-			return &table.TableDescriptor, table.expiration, nil
+			return &table.TableDescriptor, m.txnDeadline(table, timestamp), nil
 		}
 		switch err {
 		case errRenewLease:
@@ -1594,9 +1624,131 @@ func (m *LeaseManager) findTableState(tableID sqlbase.ID, create bool) *tableSta
 	return t
 }
 
-// RefreshLeases starts a goroutine that refreshes the lease manager
+// setEpoch returns true if the epoch was updated.
+func (m *LeaseManager) setEpoch(epoch int64) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if epoch < m.mu.epoch {
+		log.Errorf(context.TODO(), "new epoch: %d < current epoch: %d", epoch, m.mu.epoch)
+	} else if epoch > m.mu.epoch {
+		m.mu.epoch = epoch
+		return true
+	}
+	return false
+}
+
+func (m *LeaseManager) getEpoch() int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.mu.epoch
+}
+
+func (m *LeaseManager) initEpoch() {
+	for {
+		liveness := m.nodeLiveness.GetLivenesses()
+		nodeID := m.execCfg.NodeID.Get()
+		for _, nl := range liveness {
+			if nl.NodeID == nodeID {
+				m.setEpoch(nl.Epoch)
+				return
+			}
+		}
+	}
+}
+
+func (m *LeaseManager) getLatestIDVersions() []IDVersion {
+	var idVersions []IDVersion
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for id, table := range m.mu.tables {
+		if table.mu.dropped {
+			continue
+		}
+		if s := table.mu.active.findNewest(); s != nil {
+			idVersions = append(idVersions, IDVersion{id: id, version: s.Version})
+		}
+	}
+	return idVersions
+}
+
+// periodicallyPurgeOldLeases created from other nodes in the cluster.
+// Also keep node epoch up to date.
+func (m *LeaseManager) periodicallyPurgeOldLeases() {
+	m.initEpoch()
+	m.stopper.RunWorker(context.Background(), func(ctx context.Context) {
+		tickDuration := time.Minute
+		ticker := time.NewTicker(tickDuration)
+		tickChan := ticker.C
+		defer ticker.Stop()
+		type epochStability struct {
+			latestEpoch    int64
+			stabilityEpoch int64
+			duration       time.Duration
+			released       bool
+		}
+		epochs := make(map[roachpb.NodeID]epochStability)
+		for {
+			select {
+			case <-m.stopper.ShouldQuiesce():
+				return
+
+			case <-tickChan:
+				// Update epoch stability information.
+				nodeLiveness := m.nodeLiveness.GetLivenesses()
+				nodeID := m.execCfg.NodeID.Get()
+				for _, nl := range nodeLiveness {
+					if nl.NodeID == nodeID {
+						// Reset epoch of node for future leases.
+						if m.setEpoch(nl.Epoch) {
+							tables := m.getLatestIDVersions()
+							for _, table := range tables {
+								// This upgrades all the leases due to an epoch change.
+								// For updates to leases because of a table version change
+								// we depend on gossip. This is not something we can depend on
+								// especially given that the expiration time for a lease is infinite.
+								if err := purgeOldVersions(ctx, table.id, false /*drop*/, table.version, m); err != nil {
+									log.Errorf(ctx, "err = %s", err)
+								}
+							}
+						}
+						continue
+					}
+					es, ok := epochs[nl.NodeID]
+					if !ok {
+						es = epochStability{stabilityEpoch: nl.Epoch}
+					} else {
+						// Tick stability epoch.
+						es.duration += tickDuration
+					}
+					es.latestEpoch = nl.Epoch
+					epochs[nl.NodeID] = es
+				}
+
+				for nodeID, es := range epochs {
+					if !es.released && es.duration > 2*m.leaseDuration {
+						// Release stability epoch. This is a rather aggressive strategy
+						// given that it's being sent from all nodes and usually nodes
+						// that gracefully shutdown delete their leases.
+						m.releaseOldLeases(ctx, m.stopper, nodeID, es.stabilityEpoch)
+						es.released = true
+						epochs[nodeID] = es
+					}
+					if es.released && es.latestEpoch != es.stabilityEpoch {
+						// Reset stability epoch to latest epoch and start ticking.
+						epochs[nodeID] = epochStability{
+							latestEpoch:    es.latestEpoch,
+							stabilityEpoch: es.latestEpoch,
+						}
+					}
+				}
+			}
+		}
+	})
+}
+
+// refreshLeases starts a goroutine that refreshes the lease manager
 // leases for tables received in the latest system configuration via gossip.
-func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, g *gossip.Gossip) {
+func (m *LeaseManager) refreshLeases(s *stop.Stopper, db *client.DB, g *gossip.Gossip) {
 	ctx := context.TODO()
 	s.RunWorker(ctx, func(ctx context.Context) {
 		descKeyPrefix := keys.MakeTablePrefix(uint32(sqlbase.DescriptorTable.ID))
@@ -1637,7 +1789,7 @@ func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, g *gossip.G
 						}
 						// Try to refresh the table lease to one >= this version.
 						if err := purgeOldVersions(
-							ctx, db, table.ID, table.Dropped(), table.Version, m); err != nil {
+							ctx, table.ID, table.Dropped(), table.Version, m); err != nil {
 							log.Warningf(ctx, "error purging leases for table %d(%s): %s",
 								table.ID, table.Name, err)
 						}

--- a/pkg/sql/lease_internal_test.go
+++ b/pkg/sql/lease_internal_test.go
@@ -197,7 +197,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 		t.Fatalf("found %d versions instead of 2", numLeases)
 	}
 	if err := purgeOldVersions(
-		context.TODO(), kvDB, tableDesc.ID, false, 2 /* minVersion */, leaseManager); err != nil {
+		context.TODO(), tableDesc.ID, false, 2 /* minVersion */, leaseManager); err != nil {
 		t.Fatal(err)
 	}
 
@@ -229,7 +229,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 		t.Fatalf("found %d versions instead of 2", numLeases)
 	}
 	if err := purgeOldVersions(
-		context.TODO(), kvDB, tableDesc.ID, false, 2 /* minVersion */, leaseManager); err != nil {
+		context.TODO(), tableDesc.ID, false, 2 /* minVersion */, leaseManager); err != nil {
 		t.Fatal(err)
 	}
 	if numLeases := getNumVersions(ts); numLeases != 1 {

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -197,7 +197,7 @@ func (e errTableVersionMismatch) Error() string {
 // AcquireLease acquires a schema change lease on the table if
 // an unexpired lease doesn't exist. It returns the lease.
 func (sc *SchemaChanger) AcquireLease(
-	ctx context.Context, tables *TableCollection,
+	ctx context.Context,
 ) (sqlbase.TableDescriptor_SchemaChangeLease, error) {
 	var lease sqlbase.TableDescriptor_SchemaChangeLease
 	err := sc.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
@@ -224,13 +224,6 @@ func (sc *SchemaChanger) AcquireLease(
 		}
 		lease = sc.createSchemaChangeLease()
 		tableDesc.Lease = &lease
-		if tables != nil {
-			// tables is nil when running schema changes from the background schema change task.
-			// When running schema changes at the end of a SQL txn, tables is the
-			// table collection used as descriptor cache by queries. That must
-			// remain consistent with the KV state, so we must update it here.
-			tables.addUncommittedTable(*tableDesc)
-		}
 		return txn.Put(ctx, sqlbase.MakeDescMetadataKey(tableDesc.ID), sqlbase.WrapDescriptor(tableDesc))
 	})
 	return lease, err
@@ -255,7 +248,7 @@ func (sc *SchemaChanger) findTableWithLease(
 // ReleaseLease releases the table lease if it is the one registered with
 // the table descriptor.
 func (sc *SchemaChanger) ReleaseLease(
-	ctx context.Context, lease sqlbase.TableDescriptor_SchemaChangeLease, tables *TableCollection,
+	ctx context.Context, lease sqlbase.TableDescriptor_SchemaChangeLease,
 ) error {
 	return sc.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		tableDesc, err := sc.findTableWithLease(ctx, txn, lease)
@@ -265,13 +258,6 @@ func (sc *SchemaChanger) ReleaseLease(
 		tableDesc.Lease = nil
 		if err := txn.SetSystemConfigTrigger(); err != nil {
 			return err
-		}
-		if tables != nil {
-			// tables is nil when running schema changes from the background schema change task.
-			// When running schema changes at the end of a SQL txn, tables is the
-			// table collection used as descriptor cache by queries. That must
-			// remain consistent with the KV state, so we must update it here.
-			tables.addUncommittedTable(*tableDesc)
 		}
 		return txn.Put(ctx, sqlbase.MakeDescMetadataKey(tableDesc.ID), sqlbase.WrapDescriptor(tableDesc))
 	})
@@ -552,7 +538,7 @@ func (sc *SchemaChanger) exec(
 			sc.tableID, sc.mutationID)
 	}
 	// Acquire lease.
-	lease, err := sc.AcquireLease(ctx, evalCtx.Tables)
+	lease, err := sc.AcquireLease(ctx)
 	if err != nil {
 		return err
 	}
@@ -564,7 +550,7 @@ func (sc *SchemaChanger) exec(
 		if !needRelease {
 			return
 		}
-		if err := sc.ReleaseLease(ctx, lease, evalCtx.Tables); err != nil {
+		if err := sc.ReleaseLease(ctx, lease); err != nil {
 			log.Warning(ctx, err)
 		}
 	}()

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -93,7 +93,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	ctx := context.TODO()
 
 	// Acquire a lease.
-	lease, err := changer.AcquireLease(ctx, nil)
+	lease, err := changer.AcquireLease(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	}
 
 	// Acquiring another lease will fail.
-	if _, err := changer.AcquireLease(ctx, nil); !testutils.IsError(
+	if _, err := changer.AcquireLease(ctx); !testutils.IsError(
 		err, "an outstanding schema change lease exists",
 	) {
 		t.Fatal(err)
@@ -131,12 +131,12 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	}
 
 	// Releasing an old lease fails.
-	if err := changer.ReleaseLease(ctx, oldLease, nil); err == nil {
+	if err := changer.ReleaseLease(ctx, oldLease); err == nil {
 		t.Fatal("releasing a old lease succeeded")
 	}
 
 	// Release lease.
-	if err := changer.ReleaseLease(ctx, lease, nil); err != nil {
+	if err := changer.ReleaseLease(ctx, lease); err != nil {
 		t.Fatal(err)
 	}
 
@@ -146,7 +146,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	}
 
 	// acquiring the lease succeeds
-	lease, err = changer.AcquireLease(ctx, nil)
+	lease, err = changer.AcquireLease(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -480,7 +480,7 @@ func runSchemaChangeWithOperations(
 	// Grabbing a schema change lease on the table will fail, disallowing
 	// another schema change from being simultaneously executed.
 	sc := sql.NewSchemaChangerForTesting(tableDesc.ID, 0, 0, *kvDB, nil, jobRegistry, execCfg)
-	if l, err := sc.AcquireLease(ctx, nil); err == nil {
+	if l, err := sc.AcquireLease(ctx); err == nil {
 		t.Fatalf("schema change lease acquisition on table %d succeeded: %v", tableDesc.ID, l)
 	}
 

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -77,6 +77,7 @@ CREATE TABLE system.lease (
   version    INT,
   "nodeID"   INT,
   expiration TIMESTAMP,
+  epoch      INT,
   PRIMARY KEY ("descID", version, expiration, "nodeID")
 );`
 
@@ -408,10 +409,11 @@ var (
 			{Name: "version", ID: 2, Type: colTypeInt},
 			{Name: "nodeID", ID: 3, Type: colTypeInt},
 			{Name: "expiration", ID: 4, Type: colTypeTimestamp},
+			{Name: "epoch", ID: 5, Type: colTypeInt, Nullable: true},
 		},
-		NextColumnID: 5,
+		NextColumnID: 6,
 		Families: []ColumnFamilyDescriptor{
-			{Name: "primary", ID: 0, ColumnNames: []string{"descID", "version", "nodeID", "expiration"}, ColumnIDs: []ColumnID{1, 2, 3, 4}},
+			{Name: "primary", ID: 0, ColumnNames: []string{"descID", "version", "nodeID", "expiration", "epoch"}, ColumnIDs: []ColumnID{1, 2, 3, 4, 5}},
 		},
 		PrimaryIndex: IndexDescriptor{
 			Name:             "primary",

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -165,8 +165,6 @@ type TableCollection struct {
 
 	// dbCacheSubscriber is used to block until the node's database cache has been
 	// updated when releaseTables is called.
-	// Can be nil if releaseTables() is only called with the
-	// dontBlockForDBCacheUpdate option.
 	dbCacheSubscriber dbCacheSubscriber
 
 	// Same as uncommittedTables applying to databases modified within
@@ -185,7 +183,7 @@ type dbCacheSubscriber interface {
 	// waitForCacheState takes a callback depending on the cache state and blocks
 	// until the callback declares success. The callback is repeatedly called as
 	// the cache is updated.
-	waitForCacheState(cond func(*databaseCache) (bool, error)) error
+	waitForCacheState(cond func(*databaseCache) bool)
 }
 
 // getTableVersion returns a table descriptor with a version suitable for
@@ -370,16 +368,6 @@ func (tc *TableCollection) getTableVersionByID(
 // releaseOpt specifies options for tc.releaseTables().
 type releaseOpt bool
 
-const (
-	// blockForDBCacheUpdate makes releaseTables() block until the node's database
-	// cache has been updated to reflect the dropped or renamed databases. If used
-	// within a SQL session, this ensures that future queries on that session
-	// behave correctly when trying to use the names of the recently
-	// dropped/renamed databases.
-	blockForDBCacheUpdate     releaseOpt = true
-	dontBlockForDBCacheUpdate releaseOpt = false
-)
-
 func (tc *TableCollection) releaseLeases(ctx context.Context) {
 	if len(tc.leasedTables) > 0 {
 		log.VEventf(ctx, 2, "releasing %d tables", len(tc.leasedTables))
@@ -393,52 +381,42 @@ func (tc *TableCollection) releaseLeases(ctx context.Context) {
 }
 
 // releaseTables releases all tables currently held by the TableCollection.
-func (tc *TableCollection) releaseTables(ctx context.Context, opt releaseOpt) error {
-	if len(tc.leasedTables) > 0 {
-		log.VEventf(ctx, 2, "releasing %d tables", len(tc.leasedTables))
-		for _, table := range tc.leasedTables {
-			if err := tc.leaseMgr.Release(table); err != nil {
-				log.Warning(ctx, err)
-			}
-		}
-		tc.leasedTables = tc.leasedTables[:0]
-	}
+func (tc *TableCollection) releaseTables(ctx context.Context) {
+	tc.releaseLeases(ctx)
 	tc.uncommittedTables = nil
 	tc.createdTables = nil
-
-	if opt == blockForDBCacheUpdate {
-		for _, uc := range tc.uncommittedDatabases {
-			if !uc.dropped {
-				continue
-			}
-			// Wait until the database cache has been updated to properly
-			// reflect a dropped database, so that future commands on the
-			// same gateway node observe the dropped database.
-			err := tc.dbCacheSubscriber.waitForCacheState(
-				func(dc *databaseCache) (bool, error) {
-					// Resolve the database name from the database cache.
-					dbID, err := dc.getDatabaseID(ctx,
-						tc.leaseMgr.execCfg.DB.Txn, uc.name, false /*required*/)
-					if err != nil || dbID == 0 {
-						// dbID can still be 0 if required is false and
-						// the database is not found.
-						return true, err
-					}
-
-					// If the database name still exists but it now references another
-					// db with a more recent id, we're good - it means that the database
-					// name has been reused.
-					return dbID > uc.id, nil
-				})
-			if err != nil {
-				return err
-			}
-		}
-	}
-
 	tc.uncommittedDatabases = nil
 	tc.releaseAllDescriptors()
-	return nil
+}
+
+// Wait until the database cache has been updated to properly
+// reflect all dropped databases, so that future commands on the
+// same gateway node observe the dropped databases.
+func (tc *TableCollection) waitForCacheToDropDatabases(ctx context.Context) {
+	for _, uc := range tc.uncommittedDatabases {
+		if !uc.dropped {
+			continue
+		}
+		// Wait until the database cache has been updated to properly
+		// reflect a dropped database, so that future commands on the
+		// same gateway node observe the dropped database.
+		tc.dbCacheSubscriber.waitForCacheState(
+			func(dc *databaseCache) bool {
+				// Resolve the database name from the database cache.
+				dbID, err := dc.getDatabaseID(ctx,
+					tc.leaseMgr.execCfg.DB.Txn, uc.name, false /*required*/)
+				if err != nil || dbID == 0 {
+					// dbID can still be 0 if required is false and
+					// the database is not found.
+					return true
+				}
+
+				// If the database name still exists but it now references another
+				// db with a more recent id, we're good - it means that the database
+				// name has been reused.
+				return dbID > uc.id
+			})
+	}
 }
 
 func (tc *TableCollection) addUncommittedTable(desc sqlbase.TableDescriptor) {


### PR DESCRIPTION
ignore the first two commits

This is only a prototype to prompt discussion and feedback

The basic idea is:
1. Start creating leases with the liveness epoch of the node.
2. Set the expiration time of such leases to infinity for backwards
compatibility reasons. Older nodes can see the infinite expiration
time and will assume the lease is legit.
3. whenever the epoch changes, refresh all the leases, and purge
old leases.
4. Keep track of liveness epoches of all other nodes in the cluster
and purge infinite time leases at older epoches after a set timeout.

The only remaining part here is to to create a reliabe way to be notified
of changes to system config (this uses gossip) to be reliably notified
of changes in table versios so that leases can be renewed.

My plan is to split this into a few PR:
1. Introduce node liveness epoch into the lease table and add a migration
to ALTER TABLE ADD COLUMN epoch. Start writing leases with epoch but retain
the expiration time.
2. When the epoch changes or table versions change refresh all leases.
3. Set the expiration time to infinity only after the cluster upgrade has
been accepted by the user, start following node liveness and delete old
leases from other nodes.
