### PR TITLE
server: fix startup race with DistSQLPlanner

### DIFF
--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -170,7 +170,8 @@ func createAndStartTestNode(
 		t.Fatal(err)
 	}
 	if err := node.start(context.Background(), addr, bootstrappedEngines, newEngines,
-		roachpb.Attributes{}, locality, cv); err != nil {
+		roachpb.Attributes{}, locality, cv, nil, /*nodeDescriptorCallback */
+	); err != nil {
 		t.Fatal(err)
 	}
 	if err := WaitForInitialSplits(node.storeCfg.DB); err != nil {
@@ -412,6 +413,7 @@ func TestCorruptedClusterID(t *testing.T) {
 	if err := node.start(
 		context.Background(), serverAddr, bootstrappedEngines, newEngines,
 		roachpb.Attributes{}, roachpb.Locality{}, cv,
+		nil, /* nodeDescriptorCallback */
 	); !testutils.IsError(err, "unidentified store") {
 		t.Errorf("unexpected error %v", err)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1438,6 +1438,7 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 		s.cfg.NodeAttributes,
 		s.cfg.Locality,
 		cv,
+		s.execCfg.DistSQLPlanner.SetNodeDesc,
 	); err != nil {
 		return err
 	}
@@ -1449,8 +1450,6 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 		},
 		time.NewTicker,
 	)
-
-	s.execCfg.DistSQLPlanner.SetNodeDesc(s.node.Descriptor)
 
 	// Cluster ID should have been determined by this point.
 	if s.rpcContext.ClusterID.Get() == uuid.Nil {


### PR DESCRIPTION
The DistSQL merge introduced a potential race during server startup,
because the DistSQLPlanner is now required to be initialized before
running SQL queries via the internalExecutor.

The problem is that some of the replica scanners use internalExecutor to
do their job, and the replica scanners are started from `Store.Start`
which is started by `node.Start`. `node.Start` also has another
responsibility: to assign the node's `NodeDescriptor`. But the
`DistSQLPlanner` also needs a `NodeDescriptor`, so there's a circular
dependency: the scanners need `DistSQLPlanner`, but `DistSQLPlanner`
isn't ready until after the scanners start.

This commit solves the problem by introducing a `NodeDescriptor`
callback that's passed to `node.Start`, that is called as soon as the
`NodeDescriptor` is ready.

Closes #28463.
Closes #28446.
Closes #28445.
Closes #28444.
Closes #28443.
Closes #28442.
Closes #28441.
Closes #28440.
Closes #28439.
Closes #28438.
Closes #28437.
Closes #28436.
Closes #28434.
Closes #28433.
Closes #28432.
Closes #28431.
Closes #28430.
Closes #28429.
Closes #28428.
Closes #28427.
Closes #28426.
Closes #28425.
Closes #28422.

Release note: None