### PR TITLE
opt: Add support for views

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/numeric_references
+++ b/pkg/sql/logictest/testdata/logic_test/numeric_references
@@ -83,3 +83,9 @@ query I
 SELECT count(rowid) FROM [54(3) AS num_ref_hidden]
 ----
 3
+
+# Ensure that privileges are checked when using numeric references.
+user testuser
+
+statement error pq: user testuser does not have SELECT privilege on relation num_ref
+SELECT * FROM [53 AS t]

--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -92,6 +92,9 @@ SELECT job_id FROM crdb_internal.jobs
 ----
 
 statement ok
+CREATE SEQUENCE seq
+
+statement ok
 SET EXPERIMENTAL_OPT = ALWAYS
 
 query error pq: unsupported statement: \*tree\.Insert
@@ -101,8 +104,8 @@ INSERT INTO test (k, v) VALUES (5, 50)
 query error pq: aggregates with FILTER are not supported yet
 SELECT count(*) FILTER (WHERE v>10) FROM t
 
-query error pq: views and sequences are not supported
-SELECT * FROM tview
+query error pq: sequences are not supported
+SELECT * FROM seq
 
 statement ok
 SET EXPERIMENTAL_OPT = LOCAL

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1,5 +1,8 @@
 # LogicTest: local local-opt local-parallel-stmts fakedist fakedist-opt fakedist-metadata
 
+# NOTE: Keep this table at the beginning of the file to ensure that its numeric
+#       reference is 53 (the numeric reference of the first table). If the
+#       numbering scheme in cockroach changes, this test will break.
 statement ok
 CREATE TABLE t (a INT PRIMARY KEY, b INT)
 
@@ -273,6 +276,27 @@ SELECT * FROM v6
 3 97
 
 user root
+
+# Ensure that views work over tables identified by numeric reference.
+statement ok
+CREATE VIEW num_ref_view AS SELECT a, b FROM [53 AS t]
+
+statement ok
+GRANT SELECT ON num_ref_view TO testuser
+
+user testuser
+
+query II rowsort
+SELECT * FROM num_ref_view
+----
+1 99
+2 98
+3 97
+
+user root
+
+statement ok
+DROP VIEW num_ref_view
 
 statement error pgcode 42809 "v1" is not a table
 DROP TABLE v1

--- a/pkg/sql/opt/memo/memo_format.go
+++ b/pkg/sql/opt/memo/memo_format.go
@@ -273,9 +273,9 @@ func (f exprFormatter) formatPrivate(private interface{}, mode formatMode) {
 		// Don't output name of index if it's the primary index.
 		tab := f.mem.metadata.Table(t.Table)
 		if t.Index == opt.PrimaryIndex {
-			fmt.Fprintf(f.buf, " %s", tab.TabName().TableName)
+			fmt.Fprintf(f.buf, " %s", tab.Name().TableName)
 		} else {
-			fmt.Fprintf(f.buf, " %s@%s", tab.TabName().TableName, tab.Index(t.Index).IdxName())
+			fmt.Fprintf(f.buf, " %s@%s", tab.Name().TableName, tab.Index(t.Index).IdxName())
 		}
 		if t.Reverse {
 			fmt.Fprintf(f.buf, ",rev")
@@ -294,7 +294,7 @@ func (f exprFormatter) formatPrivate(private interface{}, mode formatMode) {
 
 	case *VirtualScanOpDef:
 		tab := f.mem.metadata.Table(t.Table)
-		fmt.Fprintf(f.buf, " %s", tab.TabName())
+		fmt.Fprintf(f.buf, " %s", tab.Name())
 
 	case *RowNumberDef:
 		if !t.Ordering.Any() {
@@ -312,7 +312,7 @@ func (f exprFormatter) formatPrivate(private interface{}, mode formatMode) {
 
 	case *IndexJoinDef:
 		tab := f.mem.metadata.Table(t.Table)
-		fmt.Fprintf(f.buf, " %s", tab.TabName().TableName)
+		fmt.Fprintf(f.buf, " %s", tab.Name().TableName)
 		if mode == formatMemo {
 			fmt.Fprintf(f.buf, ",cols=%s", t.Cols)
 		}
@@ -320,9 +320,9 @@ func (f exprFormatter) formatPrivate(private interface{}, mode formatMode) {
 	case *LookupJoinDef:
 		tab := f.mem.metadata.Table(t.Table)
 		if t.Index == opt.PrimaryIndex {
-			fmt.Fprintf(f.buf, " %s", tab.TabName().TableName)
+			fmt.Fprintf(f.buf, " %s", tab.Name().TableName)
 		} else {
-			fmt.Fprintf(f.buf, " %s@%s", tab.TabName().TableName, tab.Index(t.Index).IdxName())
+			fmt.Fprintf(f.buf, " %s@%s", tab.Name().TableName, tab.Index(t.Index).IdxName())
 		}
 		if mode == formatMemo {
 			fmt.Fprintf(f.buf, ",keyCols=%v,lookupCols=%s", t.KeyCols, t.LookupCols)

--- a/pkg/sql/opt/memo/private_defs_test.go
+++ b/pkg/sql/opt/memo/private_defs_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 func TestScanCanProvideOrdering(t *testing.T) {
@@ -39,7 +40,7 @@ func TestScanCanProvideOrdering(t *testing.T) {
 	}
 
 	md := opt.NewMetadata()
-	a := md.AddTable(cat.Table("a"))
+	a := md.AddTable(cat.Table(tree.NewUnqualifiedTableName("a")))
 
 	// PRIMARY KEY (k)
 	primary := 0

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -92,8 +92,8 @@ func TestGetStatsFromConstraint(t *testing.T) {
 	}
 
 	mem := New()
-	tab := catalog.Table("sel")
-	tabID := mem.metadata.AddTableWithName(tab, tab.TabName().String())
+	tab := catalog.Table(tree.NewUnqualifiedTableName("sel"))
+	tabID := mem.metadata.AddTableWithName(tab, tab.Name().String())
 
 	// Test that applyConstraintSet correctly updates the statistics from
 	// constraint set cs, and selectivity is calculated correctly.

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -222,7 +222,7 @@ func (md *Metadata) ColumnOrdinal(id ColumnID) int {
 // references to the same table are assigned different table ids (e.g. in a
 // self-join query).
 func (md *Metadata) AddTable(tab Table) TableID {
-	return md.AddTableWithName(tab, string(tab.TabName().TableName))
+	return md.AddTableWithName(tab, string(tab.Name().TableName))
 }
 
 // AddTableWithName indexes a new reference to a table within the query.

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -73,7 +73,7 @@ func TestMetadataTables(t *testing.T) {
 
 	// Add a table reference to the metadata.
 	a := &testcat.Table{}
-	a.Name = tree.MakeUnqualifiedTableName(tree.Name("a"))
+	a.TabName = tree.MakeUnqualifiedTableName(tree.Name("a"))
 	x := &testcat.Column{Name: "x"}
 	y := &testcat.Column{Name: "y"}
 	a.Columns = append(a.Columns, x, y)
@@ -100,7 +100,7 @@ func TestMetadataTables(t *testing.T) {
 
 	// Add a table reference without a name to the metadata.
 	b := &testcat.Table{}
-	b.Name = tree.MakeUnqualifiedTableName(tree.Name("b"))
+	b.TabName = tree.MakeUnqualifiedTableName(tree.Name("b"))
 	b.Columns = append(b.Columns, &testcat.Column{Name: "x"})
 
 	otherTabID := md.AddTable(b)
@@ -130,7 +130,7 @@ func TestIndexColumns(t *testing.T) {
 	}
 
 	md := opt.NewMetadata()
-	a := md.AddTable(cat.Table("a"))
+	a := md.AddTable(cat.Table(tree.NewUnqualifiedTableName("a")))
 
 	k := int(a.ColumnID(0))
 	i := int(a.ColumnID(1))

--- a/pkg/sql/opt/norm/factory_test.go
+++ b/pkg/sql/opt/norm/factory_test.go
@@ -35,12 +35,12 @@ func TestFactoryProjectColsFromBoth(t *testing.T) {
 	pb := projectionsBuilder{f: f}
 
 	cat := createFiltersCatalog(t)
-	a := f.Metadata().AddTable(cat.Table("a"))
+	a := f.Metadata().AddTable(cat.Table(tree.NewTableName("t", "a")))
 	ax := a.ColumnID(0)
 	ay := a.ColumnID(1)
 	aCols := util.MakeFastIntSet(int(ax), int(ay))
 
-	a2 := f.Metadata().AddTable(cat.Table("a"))
+	a2 := f.Metadata().AddTable(cat.Table(tree.NewTableName("t", "a")))
 	a2x := a2.ColumnID(0)
 	a2y := a2.ColumnID(1)
 	a2Cols := util.MakeFastIntSet(int(a2x), int(a2y))
@@ -121,7 +121,7 @@ func TestSimplifyFilters(t *testing.T) {
 	f := NewFactory(&evalCtx)
 
 	cat := createFiltersCatalog(t)
-	a := f.Metadata().AddTable(cat.Table("a"))
+	a := f.Metadata().AddTable(cat.Table(tree.NewTableName("t", "a")))
 	ax := a.ColumnID(0)
 
 	variable := f.ConstructVariable(f.InternColumnID(ax))

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -73,6 +73,16 @@ type Builder struct {
 	semaCtx *tree.SemaContext
 	evalCtx *tree.EvalContext
 	catalog opt.Catalog
+
+	// If set, the planner will skip checking for the SELECT privilege when
+	// resolving data sources (tables, views, etc). This is used when compiling
+	// views and the view SELECT privilege has already been checked. This should
+	// be used with care.
+	skipSelectPrivilegeChecks bool
+
+	// views contains a cache of views that have already been parsed, in case they
+	// are referenced multiple times in the same query.
+	views map[opt.View]*tree.Select
 }
 
 // New creates a new Builder structure initialized with the given

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -31,8 +31,8 @@ import (
 // See Builder.buildStmt for a description of the remaining input and
 // return values.
 func (b *Builder) buildJoin(join *tree.JoinTableExpr, inScope *scope) (outScope *scope) {
-	leftScope := b.buildTable(join.Left, nil /* indexFlags */, inScope)
-	rightScope := b.buildTable(join.Right, nil /* indexFlags */, inScope)
+	leftScope := b.buildDataSource(join.Left, nil /* indexFlags */, inScope)
+	rightScope := b.buildDataSource(join.Right, nil /* indexFlags */, inScope)
 
 	// Check that the same table name is not used on both sides.
 	leftTables := make(map[string]struct{})

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -614,6 +614,12 @@ TABLE abc
       ├── a int not null
       └── c int not null
 
+exec-ddl
+CREATE VIEW abcview AS SELECT * FROM abc
+----
+VIEW abcview
+ └── SELECT * FROM abc
+
 build
 SELECT d FROM abc ORDER BY lower(d)
 ----
@@ -780,7 +786,12 @@ sort
 build
 SELECT a FROM abc ORDER BY PRIMARY KEY a
 ----
-error: table "a" not found
+error: no data source matches prefix: "a"
+
+build
+SELECT a FROM abcview ORDER BY INDEX abcview@bc
+----
+error (42809): "abcview" is not a table
 
 exec-ddl
 CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
@@ -970,7 +981,7 @@ error (42P01): no data source matches prefix: t.public.abcd
 build
 SELECT a FROM abcd AS foo ORDER BY INDEX foo@abc DESC
 ----
-error: table "foo" not found
+error: no data source matches prefix: "foo"
 
 build
 SELECT a FROM abcd ORDER BY INDEX abcd@bcd

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1211,7 +1211,6 @@ project
  └── scan num_ref_hidden
       └── columns: x:1(int) rowid:3(int!null)
 
-
 # Numeric Reference Test (11/11)
 build
 SELECT rowid FROM [54(3) as t]

--- a/pkg/sql/opt/optbuilder/testdata/view
+++ b/pkg/sql/opt/optbuilder/testdata/view
@@ -1,0 +1,109 @@
+exec-ddl
+CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
+----
+TABLE a
+ ├── k int not null
+ ├── i int
+ ├── f float
+ ├── s string
+ ├── j jsonb
+ └── INDEX primary
+      └── k int not null
+
+exec-ddl
+CREATE VIEW av AS SELECT k, i, s FROM a
+----
+VIEW av
+ └── SELECT k, i, s FROM a
+
+build
+SELECT * FROM av
+----
+project
+ ├── columns: k:1(int!null) i:2(int) s:4(string)
+ └── scan a
+      └── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+
+build
+SELECT av.i, s, t.public.av.s AS s2 FROM t.av
+----
+project
+ ├── columns: i:2(int) s:4(string) s2:4(string)
+ └── project
+      ├── columns: k:1(int!null) i:2(int) s:4(string)
+      └── scan a
+           └── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+
+# Self view join (multiple references to view).
+build
+SELECT av.k, av2.s FROM av, av AS av2 WHERE av.k=av2.k
+----
+project
+ ├── columns: k:1(int!null) s:9(string)
+ └── select
+      ├── columns: a.k:1(int!null) a.i:2(int) a.s:4(string) a.k:6(int!null) a.i:7(int) a.s:9(string)
+      ├── inner-join
+      │    ├── columns: a.k:1(int!null) a.i:2(int) a.s:4(string) a.k:6(int!null) a.i:7(int) a.s:9(string)
+      │    ├── project
+      │    │    ├── columns: a.k:1(int!null) a.i:2(int) a.s:4(string)
+      │    │    └── scan a
+      │    │         └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+      │    ├── project
+      │    │    ├── columns: a.k:6(int!null) a.i:7(int) a.s:9(string)
+      │    │    └── scan a
+      │    │         └── columns: a.k:6(int!null) a.i:7(int) a.f:8(float) a.s:9(string) a.j:10(jsonb)
+      │    └── true [type=bool]
+      └── filters [type=bool]
+           └── eq [type=bool]
+                ├── variable: a.k [type=int]
+                └── variable: a.k [type=int]
+
+# View with aliased column names, filter, and ORDER BY.
+exec-ddl
+CREATE VIEW av2 (x, y) AS SELECT k, f FROM a WHERE i=10 ORDER BY s
+----
+VIEW av2 (x, y)
+ └── SELECT k, f FROM a WHERE i = 10 ORDER BY s
+
+# Result is not ordered.
+build
+SELECT * FROM av2
+----
+project
+ ├── columns: x:1(int!null) y:3(float)
+ └── project
+      ├── columns: k:1(int!null) f:3(float) s:4(string)
+      └── select
+           ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+           ├── scan a
+           │    └── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+           └── filters [type=bool]
+                └── eq [type=bool]
+                     ├── variable: a.i [type=int]
+                     └── const: 10 [type=int]
+
+# Sort used by group by because of presence of ARRAY_AGG.
+build
+SELECT array_agg(y) FROM av2
+----
+scalar-group-by
+ ├── columns: array_agg:6(float[])
+ ├── internal-ordering: +4
+ ├── sort
+ │    ├── columns: f:3(float) s:4(string)
+ │    ├── ordering: +4
+ │    └── project
+ │         ├── columns: f:3(float) s:4(string)
+ │         └── project
+ │              ├── columns: k:1(int!null) f:3(float) s:4(string)
+ │              └── select
+ │                   ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ │                   ├── scan a
+ │                   │    └── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │                   └── filters [type=bool]
+ │                        └── eq [type=bool]
+ │                             ├── variable: a.i [type=int]
+ │                             └── const: 10 [type=int]
+ └── aggregations
+      └── array-agg [type=float[]]
+           └── variable: a.f [type=float]

--- a/pkg/sql/opt/testutils/testcat/alter_table.go
+++ b/pkg/sql/opt/testutils/testcat/alter_table.go
@@ -38,16 +38,12 @@ func (tc *Catalog) AlterTable(stmt *tree.AlterTable) {
 
 	// Update the table name to include catalog and schema if not provided.
 	tc.qualifyTableName(tn)
-
-	table, ok := tc.tables[tn.FQString()]
-	if !ok {
-		panic(fmt.Sprintf("cannot find table %q", tree.ErrString(tn)))
-	}
+	tab := tc.Table(tn)
 
 	for _, cmd := range stmt.Cmds {
 		switch t := cmd.(type) {
 		case *tree.AlterTableInjectStats:
-			injectTableStats(table, t.Stats)
+			injectTableStats(tab, t.Stats)
 
 		default:
 			panic(fmt.Sprintf("unsupported ALTER TABLE command %T", t))

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -56,7 +56,7 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 	// Update the table name to include catalog and schema if not provided.
 	tc.qualifyTableName(tn)
 
-	tab := &Table{Name: *tn}
+	tab := &Table{TabName: *tn}
 
 	// Assume that every table in the "system" catalog is a virtual table. This
 	// is a simplified assumption for testing purposes.
@@ -115,7 +115,7 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 	// We need to keep track of the tableID from numeric references. 53 is a magic
 	// number derived from how CRDB internally stores tables. The first user table
 	// is 53. This magic number is used to have tests look consistent.
-	tab.tableID = sqlbase.ID(len(tc.tables) + 53)
+	tab.tableID = sqlbase.ID(len(tc.dataSources) + 53)
 	// Add the new table to the catalog.
 	tc.AddTable(tab)
 

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -881,77 +881,56 @@ project
       ├── prune: (1,2,11)
       └── interesting orderings: (+2,+1)
 
-# TODO(andyk): re-enable when we support COUNT DISTINCT.
-#opt format=show-all
-#SELECT count(DISTINCT s_i_id)
-#FROM order_line
-#JOIN stock
-#ON s_i_id=ol_i_id AND s_w_id=ol_w_id
-#WHERE ol_w_id = 10
-#    AND ol_d_id = 100
-#    AND ol_o_id BETWEEN 1000 - 20 AND 1000 - 1
-#    AND s_quantity < 15
-#----
-
-# Rewrite the query so that it is supported.
 opt format=show-all
-SELECT count(*)
-FROM
-(
-  SELECT DISTINCT s_i_id
-  FROM order_line
-  JOIN stock
-  ON s_i_id=ol_i_id AND s_w_id=ol_w_id
-  WHERE ol_w_id = 10
+SELECT count(DISTINCT s_i_id)
+FROM order_line
+JOIN stock
+ON s_i_id=ol_i_id AND s_w_id=ol_w_id
+WHERE ol_w_id = 10
     AND ol_d_id = 100
     AND ol_o_id BETWEEN 1000 - 20 AND 1000 - 1
     AND s_quantity < 15
-)
 ----
 scalar-group-by
  ├── columns: count:28(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 0.0100267868
+ ├── cost: 0.0100267051
  ├── key: ()
  ├── fd: ()-->(28)
  ├── prune: (28)
- ├── distinct-on
- │    ├── columns: stock.s_i_id:11(int!null)
- │    ├── grouping columns: stock.s_i_id:11(int!null)
- │    ├── stats: [rows=4.0816376e-06, distinct(11)=4.0816376e-06]
- │    ├── cost: 2.67459551e-05
- │    ├── key: (11)
- │    └── inner-join (lookup stock)
- │         ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) order_line.ol_i_id:5(int!null) stock.s_i_id:11(int!null) stock.s_w_id:12(int!null) stock.s_quantity:13(int!null)
- │         ├── key columns: [3 5] = [12 11]
- │         ├── stats: [rows=4.73185689e-06, distinct(3)=4.08163265e-06, distinct(5)=4.0816376e-06, distinct(11)=4.0816376e-06, distinct(12)=4.08163265e-06]
- │         ├── cost: 2.66578201e-05
- │         ├── fd: ()-->(2,3,12), (11)-->(13), (5)==(11), (11)==(5), (3)==(12), (12)==(3)
- │         ├── interesting orderings: (+3,+2,-1)
- │         ├── scan order_line
- │         │    ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) order_line.ol_i_id:5(int!null)
- │         │    ├── constraint: /3/2/-1/4: [/10/100/999 - /10/100/980]
- │         │    ├── stats: [rows=4.08163265e-06, distinct(1)=4.08163265e-06, distinct(2)=4.08163265e-06, distinct(3)=4.08163265e-06, distinct(5)=4.0816376e-06]
- │         │    ├── cost: 4.65306122e-06
- │         │    ├── fd: ()-->(2,3)
- │         │    ├── prune: (5)
- │         │    └── interesting orderings: (+3,+2,-1)
- │         └── filters [type=bool, outer=(3,5,11-13), constraints=(/3: (/NULL - ]; /5: (/NULL - ]; /11: (/NULL - ]; /12: [/10 - /10]; /13: (/NULL - /14]), fd=()-->(3,12), (5)==(11), (11)==(5), (3)==(12), (12)==(3)]
- │              ├── eq [type=bool, outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ])]
- │              │    ├── variable: stock.s_i_id [type=int, outer=(11)]
- │              │    └── variable: order_line.ol_i_id [type=int, outer=(5)]
- │              ├── eq [type=bool, outer=(3,12), constraints=(/3: (/NULL - ]; /12: (/NULL - ])]
- │              │    ├── variable: stock.s_w_id [type=int, outer=(12)]
- │              │    └── variable: order_line.ol_w_id [type=int, outer=(3)]
- │              ├── eq [type=bool, outer=(12), constraints=(/12: [/10 - /10]; tight)]
- │              │    ├── variable: stock.s_w_id [type=int, outer=(12)]
- │              │    └── const: 10 [type=int]
- │              └── lt [type=bool, outer=(13), constraints=(/13: (/NULL - /14]; tight)]
- │                   ├── variable: stock.s_quantity [type=int, outer=(13)]
- │                   └── const: 15 [type=int]
- └── aggregations
-      └── count-rows [type=int]
+ ├── inner-join (lookup stock)
+ │    ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) order_line.ol_i_id:5(int!null) stock.s_i_id:11(int!null) stock.s_w_id:12(int!null) stock.s_quantity:13(int!null)
+ │    ├── key columns: [3 5] = [12 11]
+ │    ├── stats: [rows=4.73185689e-06, distinct(3)=4.08163265e-06, distinct(5)=4.0816376e-06, distinct(11)=4.0816376e-06, distinct(12)=4.08163265e-06]
+ │    ├── cost: 2.66578201e-05
+ │    ├── fd: ()-->(2,3,12), (11)-->(13), (5)==(11), (11)==(5), (3)==(12), (12)==(3)
+ │    ├── interesting orderings: (+3,+2,-1)
+ │    ├── scan order_line
+ │    │    ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) order_line.ol_i_id:5(int!null)
+ │    │    ├── constraint: /3/2/-1/4: [/10/100/999 - /10/100/980]
+ │    │    ├── stats: [rows=4.08163265e-06, distinct(1)=4.08163265e-06, distinct(2)=4.08163265e-06, distinct(3)=4.08163265e-06, distinct(5)=4.0816376e-06]
+ │    │    ├── cost: 4.65306122e-06
+ │    │    ├── fd: ()-->(2,3)
+ │    │    ├── prune: (5)
+ │    │    └── interesting orderings: (+3,+2,-1)
+ │    └── filters [type=bool, outer=(3,5,11-13), constraints=(/3: (/NULL - ]; /5: (/NULL - ]; /11: (/NULL - ]; /12: [/10 - /10]; /13: (/NULL - /14]), fd=()-->(3,12), (5)==(11), (11)==(5), (3)==(12), (12)==(3)]
+ │         ├── eq [type=bool, outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ])]
+ │         │    ├── variable: stock.s_i_id [type=int, outer=(11)]
+ │         │    └── variable: order_line.ol_i_id [type=int, outer=(5)]
+ │         ├── eq [type=bool, outer=(3,12), constraints=(/3: (/NULL - ]; /12: (/NULL - ])]
+ │         │    ├── variable: stock.s_w_id [type=int, outer=(12)]
+ │         │    └── variable: order_line.ol_w_id [type=int, outer=(3)]
+ │         ├── eq [type=bool, outer=(12), constraints=(/12: [/10 - /10]; tight)]
+ │         │    ├── variable: stock.s_w_id [type=int, outer=(12)]
+ │         │    └── const: 10 [type=int]
+ │         └── lt [type=bool, outer=(13), constraints=(/13: (/NULL - /14]; tight)]
+ │              ├── variable: stock.s_quantity [type=int, outer=(13)]
+ │              └── const: 15 [type=int]
+ └── aggregations [outer=(11)]
+      └── count [type=int, outer=(11)]
+           └── agg-distinct [type=int, outer=(11)]
+                └── variable: stock.s_i_id [type=int, outer=(11)]
 
 # --------------------------------------------------
 # Consistency Queries

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -686,77 +686,56 @@ project
       ├── prune: (1,2,11)
       └── interesting orderings: (+2,+1)
 
-# TODO(andyk): re-enable when we support COUNT DISTINCT.
-#opt format=show-all
-#SELECT count(DISTINCT s_i_id)
-#FROM order_line
-#JOIN stock
-#ON s_i_id=ol_i_id AND s_w_id=ol_w_id
-#WHERE ol_w_id = 10
-#    AND ol_d_id = 100
-#    AND ol_o_id BETWEEN 1000 - 20 AND 1000 - 1
-#    AND s_quantity < 15
-#----
-
-# Rewrite the query so that it is supported.
 opt format=show-all
-SELECT count(*)
-FROM
-(
-  SELECT DISTINCT s_i_id
-  FROM order_line
-  JOIN stock
-  ON s_i_id=ol_i_id AND s_w_id=ol_w_id
-  WHERE ol_w_id = 10
+SELECT count(DISTINCT s_i_id)
+FROM order_line
+JOIN stock
+ON s_i_id=ol_i_id AND s_w_id=ol_w_id
+WHERE ol_w_id = 10
     AND ol_d_id = 100
     AND ol_o_id BETWEEN 1000 - 20 AND 1000 - 1
     AND s_quantity < 15
-)
 ----
 scalar-group-by
  ├── columns: count:28(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 0.0103338609
+ ├── cost: 0.0103333056
  ├── key: ()
  ├── fd: ()-->(28)
  ├── prune: (28)
- ├── distinct-on
- │    ├── columns: stock.s_i_id:11(int!null)
- │    ├── grouping columns: stock.s_i_id:11(int!null)
- │    ├── stats: [rows=2.77662085e-05, distinct(11)=2.77662085e-05]
- │    ├── cost: 0.000333583229
- │    ├── key: (11)
- │    └── inner-join (lookup stock)
- │         ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) order_line.ol_i_id:5(int!null) stock.s_i_id:11(int!null) stock.s_w_id:12(int!null) stock.s_quantity:13(int!null)
- │         ├── key columns: [3 5] = [12 11]
- │         ├── stats: [rows=2.77662085e-05, distinct(3)=2.77662085e-05, distinct(5)=2.77662085e-05, distinct(11)=2.77662085e-05, distinct(12)=2.77662085e-05]
- │         ├── cost: 0.000333027905
- │         ├── fd: ()-->(2,3,12), (11)-->(13), (5)==(11), (11)==(5), (3)==(12), (12)==(3)
- │         ├── interesting orderings: (+3,+2,-1)
- │         ├── scan order_line
- │         │    ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) order_line.ol_i_id:5(int!null)
- │         │    ├── constraint: /3/2/-1/4: [/10/100/999 - /10/100/980]
- │         │    ├── stats: [rows=5.83090379e-05, distinct(1)=5.83090379e-05, distinct(2)=5.83090379e-05, distinct(3)=5.83090379e-05, distinct(5)=5.83090372e-05]
- │         │    ├── cost: 6.64723032e-05
- │         │    ├── fd: ()-->(2,3)
- │         │    ├── prune: (5)
- │         │    └── interesting orderings: (+3,+2,-1)
- │         └── filters [type=bool, outer=(3,5,11-13), constraints=(/3: (/NULL - ]; /5: (/NULL - ]; /11: (/NULL - ]; /12: [/10 - /10]; /13: (/NULL - /14]), fd=()-->(3,12), (5)==(11), (11)==(5), (3)==(12), (12)==(3)]
- │              ├── eq [type=bool, outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ])]
- │              │    ├── variable: stock.s_i_id [type=int, outer=(11)]
- │              │    └── variable: order_line.ol_i_id [type=int, outer=(5)]
- │              ├── eq [type=bool, outer=(3,12), constraints=(/3: (/NULL - ]; /12: (/NULL - ])]
- │              │    ├── variable: stock.s_w_id [type=int, outer=(12)]
- │              │    └── variable: order_line.ol_w_id [type=int, outer=(3)]
- │              ├── eq [type=bool, outer=(12), constraints=(/12: [/10 - /10]; tight)]
- │              │    ├── variable: stock.s_w_id [type=int, outer=(12)]
- │              │    └── const: 10 [type=int]
- │              └── lt [type=bool, outer=(13), constraints=(/13: (/NULL - /14]; tight)]
- │                   ├── variable: stock.s_quantity [type=int, outer=(13)]
- │                   └── const: 15 [type=int]
- └── aggregations
-      └── count-rows [type=int]
+ ├── inner-join (lookup stock)
+ │    ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) order_line.ol_i_id:5(int!null) stock.s_i_id:11(int!null) stock.s_w_id:12(int!null) stock.s_quantity:13(int!null)
+ │    ├── key columns: [3 5] = [12 11]
+ │    ├── stats: [rows=2.77662085e-05, distinct(3)=2.77662085e-05, distinct(5)=2.77662085e-05, distinct(11)=2.77662085e-05, distinct(12)=2.77662085e-05]
+ │    ├── cost: 0.000333027905
+ │    ├── fd: ()-->(2,3,12), (11)-->(13), (5)==(11), (11)==(5), (3)==(12), (12)==(3)
+ │    ├── interesting orderings: (+3,+2,-1)
+ │    ├── scan order_line
+ │    │    ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) order_line.ol_i_id:5(int!null)
+ │    │    ├── constraint: /3/2/-1/4: [/10/100/999 - /10/100/980]
+ │    │    ├── stats: [rows=5.83090379e-05, distinct(1)=5.83090379e-05, distinct(2)=5.83090379e-05, distinct(3)=5.83090379e-05, distinct(5)=5.83090372e-05]
+ │    │    ├── cost: 6.64723032e-05
+ │    │    ├── fd: ()-->(2,3)
+ │    │    ├── prune: (5)
+ │    │    └── interesting orderings: (+3,+2,-1)
+ │    └── filters [type=bool, outer=(3,5,11-13), constraints=(/3: (/NULL - ]; /5: (/NULL - ]; /11: (/NULL - ]; /12: [/10 - /10]; /13: (/NULL - /14]), fd=()-->(3,12), (5)==(11), (11)==(5), (3)==(12), (12)==(3)]
+ │         ├── eq [type=bool, outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ])]
+ │         │    ├── variable: stock.s_i_id [type=int, outer=(11)]
+ │         │    └── variable: order_line.ol_i_id [type=int, outer=(5)]
+ │         ├── eq [type=bool, outer=(3,12), constraints=(/3: (/NULL - ]; /12: (/NULL - ])]
+ │         │    ├── variable: stock.s_w_id [type=int, outer=(12)]
+ │         │    └── variable: order_line.ol_w_id [type=int, outer=(3)]
+ │         ├── eq [type=bool, outer=(12), constraints=(/12: [/10 - /10]; tight)]
+ │         │    ├── variable: stock.s_w_id [type=int, outer=(12)]
+ │         │    └── const: 10 [type=int]
+ │         └── lt [type=bool, outer=(13), constraints=(/13: (/NULL - /14]; tight)]
+ │              ├── variable: stock.s_quantity [type=int, outer=(13)]
+ │              └── const: 15 [type=int]
+ └── aggregations [outer=(11)]
+      └── count [type=int, outer=(11)]
+           └── agg-distinct [type=int, outer=(11)]
+                └── variable: stock.s_i_id [type=int, outer=(11)]
 
 # --------------------------------------------------
 # Consistency Queries

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -504,9 +504,6 @@ project
 # among those that had not been shipped as of a given date. Orders are listed in
 # decreasing order of revenue. If more than 10 unshipped orders exist, only the
 # 10 orders with the largest revenue are listed.
-#
-# TODO:
-#   1. Discard non-primary key columns from grouping columns
 # --------------------------------------------------
 opt
 SELECT
@@ -1237,9 +1234,6 @@ sort
 # revenue lost. The customers are listed in descending order of lost revenue.
 # Revenue lost is defined as sum(l_extendedprice*(1-l_discount)) for all
 # qualifying lineitems.
-#
-# TODO:
-#   1. Discard non-primary key columns from grouping columns
 # --------------------------------------------------
 opt
 SELECT
@@ -1711,45 +1705,22 @@ project
 # shipped during a given quarter of a given year. In case of a tie, the query
 # lists all suppliers whose contribution was equal to the maximum, presented in
 # supplier number order.
-#
-# TODO:
-#   1. Support views
 # --------------------------------------------------
-#opt
-#CREATE VIEW revenue0 (supplier_no, total_revenue) AS
-#    SELECT
-#        l_suppkey,
-#        sum(l_extendedprice * (1 - l_discount))
-#    FROM
-#        lineitem
-#    WHERE
-#        l_shipdate >= DATE '1996-01-01'
-#        AND l_shipdate < DATE '1996-01-01' + INTERVAL '3' MONTH
-#    GROUP BY
-#        l_suppkey;
-#
-#SELECT
-#    s_suppkey,
-#    s_name,
-#    s_address,
-#    s_phone,
-#    total_revenue
-#FROM
-#    supplier,
-#    revenue0
-#WHERE
-#    s_suppkey = supplier_no
-#    AND total_revenue = (
-#        SELECT
-#            max(total_revenue)
-#        FROM
-#            revenue0
-#    )
-#ORDER BY
-#    s_suppkey;
-#
-#DROP VIEW revenue0;
-#----
+exec-ddl
+CREATE VIEW revenue0 (supplier_no, total_revenue) AS
+    SELECT
+        l_suppkey,
+        sum(l_extendedprice * (1 - l_discount))
+    FROM
+        lineitem
+    WHERE
+        l_shipdate >= DATE '1996-01-01'
+        AND l_shipdate < DATE '1996-01-01' + INTERVAL '3' MONTH
+    GROUP BY
+        l_suppkey;
+----
+VIEW revenue0 (supplier_no, total_revenue)
+ └── SELECT l_suppkey, sum(l_extendedprice * (1 - l_discount)) FROM lineitem WHERE (l_shipdate >= DATE '1996-01-01') AND (l_shipdate < (DATE '1996-01-01' + '3mon':::INTERVAL)) GROUP BY l_suppkey
 
 opt
 SELECT
@@ -1760,35 +1731,14 @@ SELECT
     total_revenue
 FROM
     supplier,
-    (
-        SELECT
-            l_suppkey AS supplier_no,
-            sum(l_extendedprice * (1 - l_discount)) AS total_revenue
-        FROM
-            lineitem
-        WHERE
-            l_shipdate >= DATE '1996-01-01'
-            AND l_shipdate < DATE '1996-01-01' + INTERVAL '3' MONTH
-        GROUP BY
-            l_suppkey
-    )
+    revenue0
 WHERE
     s_suppkey = supplier_no
     AND total_revenue = (
         SELECT
             max(total_revenue)
-        FROM (
-            SELECT
-                l_suppkey AS supplier_no,
-                sum(l_extendedprice * (1 - l_discount)) AS total_revenue
-            FROM
-                lineitem
-            WHERE
-                l_shipdate >= DATE '1996-01-01'
-                AND l_shipdate < DATE '1996-01-01' + INTERVAL '3' MONTH
-            GROUP BY
-                l_suppkey
-        )
+        FROM
+            revenue0
     )
 ORDER BY
     s_suppkey;
@@ -1799,20 +1749,20 @@ sort
  ├── fd: (1)-->(2,3,5,25)
  ├── ordering: +1
  └── project
-      ├── columns: s_suppkey:1(int!null) s_name:2(string) s_address:3(string) s_phone:5(string) total_revenue:25(float!null)
+      ├── columns: s_suppkey:1(int!null) s_name:2(string) s_address:3(string) s_phone:5(string) sum:25(float!null)
       ├── key: (1)
       ├── fd: (1)-->(2,3,5,25)
       └── inner-join (lookup supplier)
-           ├── columns: s_suppkey:1(int!null) s_name:2(string) s_address:3(string) s_phone:5(string) lineitem.l_suppkey:10(int!null) total_revenue:25(float!null)
+           ├── columns: s_suppkey:1(int!null) s_name:2(string) s_address:3(string) s_phone:5(string) lineitem.l_suppkey:10(int!null) sum:25(float!null)
            ├── key columns: [10] = [1]
            ├── key: (10)
            ├── fd: (1)-->(2,3,5), (10)-->(25), (1)==(10), (10)==(1)
            ├── select
-           │    ├── columns: lineitem.l_suppkey:10(int!null) total_revenue:25(float!null)
+           │    ├── columns: lineitem.l_suppkey:10(int!null) sum:25(float!null)
            │    ├── key: (10)
            │    ├── fd: (10)-->(25)
            │    ├── group-by
-           │    │    ├── columns: lineitem.l_suppkey:10(int!null) total_revenue:25(float)
+           │    │    ├── columns: lineitem.l_suppkey:10(int!null) sum:25(float)
            │    │    ├── grouping columns: lineitem.l_suppkey:10(int!null)
            │    │    ├── key: (10)
            │    │    ├── fd: (10)-->(25)
@@ -1832,7 +1782,7 @@ sort
            │    │              └── variable: column24 [type=float, outer=(24)]
            │    └── filters [type=bool, outer=(25), constraints=(/25: (/NULL - ])]
            │         └── eq [type=bool, outer=(25), constraints=(/25: (/NULL - ])]
-           │              ├── variable: total_revenue [type=float, outer=(25)]
+           │              ├── variable: sum [type=float, outer=(25)]
            │              └── subquery [type=float]
            │                   └── scalar-group-by
            │                        ├── columns: max:44(float)
@@ -1840,7 +1790,7 @@ sort
            │                        ├── key: ()
            │                        ├── fd: ()-->(44)
            │                        ├── group-by
-           │                        │    ├── columns: lineitem.l_suppkey:28(int!null) total_revenue:43(float)
+           │                        │    ├── columns: lineitem.l_suppkey:28(int!null) sum:43(float)
            │                        │    ├── grouping columns: lineitem.l_suppkey:28(int!null)
            │                        │    ├── key: (28)
            │                        │    ├── fd: (28)-->(43)
@@ -1860,7 +1810,7 @@ sort
            │                        │              └── variable: column42 [type=float, outer=(42)]
            │                        └── aggregations [outer=(43)]
            │                             └── max [type=float, outer=(43)]
-           │                                  └── variable: total_revenue [type=float, outer=(43)]
+           │                                  └── variable: sum [type=float, outer=(43)]
            └── filters [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
                 └── supplier.s_suppkey = lineitem.l_suppkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ])]
 
@@ -1877,71 +1827,28 @@ sort
 # and not from a supplier who has had complaints registered at the Better
 # Business Bureau. Results must be presented in descending count and ascending
 # brand, type, and size.
-#
-# TODO:
-#   1. Support DISTINCT in aggregate function
 # --------------------------------------------------
-#opt
-#SELECT
-#    p_brand,
-#    p_type,
-#    p_size,
-#    count(DISTINCT ps_suppkey) AS supplier_cnt
-#FROM
-#    partsupp,
-#    part
-#WHERE
-#    p_partkey = ps_partkey
-#    AND p_brand <> 'Brand#45'
-#    AND p_type NOT LIKE 'MEDIUM POLISHED %'
-#    AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9)
-#    AND ps_suppkey NOT IN (
-#        SELECT
-#            s_suppkey
-#        FROM
-#            supplier
-#        WHERE
-#            s_comment LIKE '%Customer%Complaints%'
-#    )
-#GROUP BY
-#    p_brand,
-#    p_type,
-#    p_size
-#ORDER BY
-#    supplier_cnt DESC,
-#    p_brand,
-#    p_type,
-#    p_size;
-#----
-
 opt
 SELECT
     p_brand,
     p_type,
     p_size,
-    count(ps_suppkey) AS supplier_cnt
-FROM (
-    SELECT DISTINCT
-        p_brand,
-        p_type,
-        p_size,
-        ps_suppkey
-    FROM
-        partsupp,
-        part
-    WHERE
-        p_partkey = ps_partkey
-        AND p_brand <> 'Brand#45'
-        AND p_type NOT LIKE 'MEDIUM POLISHED %'
-        AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9)
-        AND ps_suppkey NOT IN (
-            SELECT
-                s_suppkey
-            FROM
-                supplier
-            WHERE
-                s_comment LIKE '%Customer%Complaints%'
-        )
+    count(DISTINCT ps_suppkey) AS supplier_cnt
+FROM
+    partsupp,
+    part
+WHERE
+    p_partkey = ps_partkey
+    AND p_brand <> 'Brand#45'
+    AND p_type NOT LIKE 'MEDIUM POLISHED %'
+    AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9)
+    AND ps_suppkey NOT IN (
+        SELECT
+            s_suppkey
+        FROM
+            supplier
+        WHERE
+            s_comment LIKE '%Customer%Complaints%'
     )
 GROUP BY
     p_brand,
@@ -1963,49 +1870,46 @@ sort
       ├── grouping columns: p_brand:9(string!null) p_type:10(string) p_size:11(int!null)
       ├── key: (9-11)
       ├── fd: (9-11)-->(22)
-      ├── distinct-on
-      │    ├── columns: ps_suppkey:2(int!null) p_brand:9(string!null) p_type:10(string) p_size:11(int!null)
-      │    ├── grouping columns: ps_suppkey:2(int!null) p_brand:9(string!null) p_type:10(string) p_size:11(int!null)
-      │    ├── key: (2,9-11)
-      │    └── inner-join
-      │         ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) p_partkey:6(int!null) p_brand:9(string!null) p_type:10(string) p_size:11(int!null)
-      │         ├── key: (2,6)
-      │         ├── fd: (6)-->(9-11), (1)==(6), (6)==(1)
-      │         ├── anti-join
-      │         │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null)
-      │         │    ├── key: (1,2)
-      │         │    ├── scan partsupp
-      │         │    │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null)
-      │         │    │    └── key: (1,2)
-      │         │    ├── select
-      │         │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(string)
-      │         │    │    ├── key: (15)
-      │         │    │    ├── fd: (15)-->(21)
-      │         │    │    ├── scan supplier
-      │         │    │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(string)
-      │         │    │    │    ├── key: (15)
-      │         │    │    │    └── fd: (15)-->(21)
-      │         │    │    └── filters [type=bool, outer=(21)]
-      │         │    │         └── supplier.s_comment LIKE '%Customer%Complaints%' [type=bool, outer=(21)]
-      │         │    └── filters [type=bool, outer=(2,15)]
-      │         │         └── (partsupp.ps_suppkey = supplier.s_suppkey) IS NOT false [type=bool, outer=(2,15)]
-      │         ├── select
-      │         │    ├── columns: p_partkey:6(int!null) p_brand:9(string!null) p_type:10(string) p_size:11(int!null)
-      │         │    ├── key: (6)
-      │         │    ├── fd: (6)-->(9-11)
-      │         │    ├── scan part
-      │         │    │    ├── columns: p_partkey:6(int!null) p_brand:9(string) p_type:10(string) p_size:11(int)
-      │         │    │    ├── key: (6)
-      │         │    │    └── fd: (6)-->(9-11)
-      │         │    └── filters [type=bool, outer=(9-11), constraints=(/9: (/NULL - /'Brand#45') [/e'Brand#45\x00' - ]; /11: [/3 - /3] [/9 - /9] [/14 - /14] [/19 - /19] [/23 - /23] [/36 - /36] [/45 - /45] [/49 - /49])]
-      │         │         ├── part.p_brand != 'Brand#45' [type=bool, outer=(9), constraints=(/9: (/NULL - /'Brand#45') [/e'Brand#45\x00' - ]; tight)]
-      │         │         ├── part.p_type NOT LIKE 'MEDIUM POLISHED %' [type=bool, outer=(10)]
-      │         │         └── part.p_size IN (3, 9, 14, 19, 23, 36, 45, 49) [type=bool, outer=(11), constraints=(/11: [/3 - /3] [/9 - /9] [/14 - /14] [/19 - /19] [/23 - /23] [/36 - /36] [/45 - /45] [/49 - /49]; tight)]
-      │         └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-      │              └── part.p_partkey = partsupp.ps_partkey [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+      ├── inner-join
+      │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) p_partkey:6(int!null) p_brand:9(string!null) p_type:10(string) p_size:11(int!null)
+      │    ├── key: (2,6)
+      │    ├── fd: (6)-->(9-11), (1)==(6), (6)==(1)
+      │    ├── anti-join
+      │    │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null)
+      │    │    ├── key: (1,2)
+      │    │    ├── scan partsupp
+      │    │    │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null)
+      │    │    │    └── key: (1,2)
+      │    │    ├── select
+      │    │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(string)
+      │    │    │    ├── key: (15)
+      │    │    │    ├── fd: (15)-->(21)
+      │    │    │    ├── scan supplier
+      │    │    │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(string)
+      │    │    │    │    ├── key: (15)
+      │    │    │    │    └── fd: (15)-->(21)
+      │    │    │    └── filters [type=bool, outer=(21)]
+      │    │    │         └── supplier.s_comment LIKE '%Customer%Complaints%' [type=bool, outer=(21)]
+      │    │    └── filters [type=bool, outer=(2,15)]
+      │    │         └── (partsupp.ps_suppkey = supplier.s_suppkey) IS NOT false [type=bool, outer=(2,15)]
+      │    ├── select
+      │    │    ├── columns: p_partkey:6(int!null) p_brand:9(string!null) p_type:10(string) p_size:11(int!null)
+      │    │    ├── key: (6)
+      │    │    ├── fd: (6)-->(9-11)
+      │    │    ├── scan part
+      │    │    │    ├── columns: p_partkey:6(int!null) p_brand:9(string) p_type:10(string) p_size:11(int)
+      │    │    │    ├── key: (6)
+      │    │    │    └── fd: (6)-->(9-11)
+      │    │    └── filters [type=bool, outer=(9-11), constraints=(/9: (/NULL - /'Brand#45') [/e'Brand#45\x00' - ]; /11: [/3 - /3] [/9 - /9] [/14 - /14] [/19 - /19] [/23 - /23] [/36 - /36] [/45 - /45] [/49 - /49])]
+      │    │         ├── part.p_brand != 'Brand#45' [type=bool, outer=(9), constraints=(/9: (/NULL - /'Brand#45') [/e'Brand#45\x00' - ]; tight)]
+      │    │         ├── part.p_type NOT LIKE 'MEDIUM POLISHED %' [type=bool, outer=(10)]
+      │    │         └── part.p_size IN (3, 9, 14, 19, 23, 36, 45, 49) [type=bool, outer=(11), constraints=(/11: [/3 - /3] [/9 - /9] [/14 - /14] [/19 - /19] [/23 - /23] [/36 - /36] [/45 - /45] [/49 - /49]; tight)]
+      │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+      │         └── part.p_partkey = partsupp.ps_partkey [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
       └── aggregations [outer=(2)]
            └── count [type=int, outer=(2)]
-                └── variable: partsupp.ps_suppkey [type=int, outer=(2)]
+                └── agg-distinct [type=int, outer=(2)]
+                     └── variable: partsupp.ps_suppkey [type=int, outer=(2)]
 
 # --------------------------------------------------
 # Q17
@@ -2021,8 +1925,7 @@ sort
 # of less than 20% of this average were no longer taken?
 #
 # TODO:
-#   1. Discard non-primary key columns from grouping columns
-#   2. Allow Select to be pushed below RowNumber used to add key column
+#   1. Allow Select to be pushed below RowNumber used to add key column
 # --------------------------------------------------
 opt
 SELECT
@@ -2110,9 +2013,6 @@ project
 # Finds a list of the top 100 customers who have ever placed large quantity
 # orders. The query lists the customer name, customer key, the order key, date
 # and total price and the quantity for the order.
-#
-# TODO:
-#   1. Discard non-primary key columns from grouping columns
 # --------------------------------------------------
 opt
 SELECT


### PR DESCRIPTION
Allow views to be used as a data source in addition to tables. Generalize
Catalog interface to resolve data sources rather than just tables. Separate
out privilege checking so that it can be better controlled by optbuilder.
If selecting from a view, we want to check SELECT privilege on the view,
and not on the underlying table(s).

Release note: None