### PR TITLE
sql: implement the column `numeric_precision_radix`

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -248,6 +248,7 @@ CREATE TABLE information_schema.columns (
 	CHARACTER_MAXIMUM_LENGTH INT,
 	CHARACTER_OCTET_LENGTH   INT,
 	NUMERIC_PRECISION        INT,
+	NUMERIC_PRECISION_RADIX  INT,
 	NUMERIC_SCALE            INT,
 	DATETIME_PRECISION       INT,
 	CHARACTER_SET_CATALOG    STRING,
@@ -276,6 +277,7 @@ CREATE TABLE information_schema.columns (
 					characterMaximumLength(column.Type),      // character_maximum_length
 					characterOctetLength(column.Type),        // character_octet_length
 					numericPrecision(column.Type),            // numeric_precision
+					numericPrecisionRadix(column.Type),       // numeric_precision_radix
 					numericScale(column.Type),                // numeric_scale
 					datetimePrecision(column.Type),           // datetime_precision
 					tree.DNull,                               // character_set_catalog
@@ -332,6 +334,10 @@ func characterOctetLength(colType sqlbase.ColumnType) tree.Datum {
 
 func numericPrecision(colType sqlbase.ColumnType) tree.Datum {
 	return dIntFnOrNull(colType.NumericPrecision)
+}
+
+func numericPrecisionRadix(colType sqlbase.ColumnType) tree.Datum {
+	return dIntFnOrNull(colType.NumericPrecisionRadix)
 }
 
 func numericScale(colType sqlbase.ColumnType) tree.Datum {

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -863,19 +863,19 @@ DROP TABLE char_len
 statement ok
 CREATE TABLE num_prec (a INT, b FLOAT, c FLOAT(23), d DECIMAL, e DECIMAL(12), f DECIMAL(12, 6), g BOOLEAN)
 
-query TTIII colnames
-SELECT table_name, column_name, numeric_precision, numeric_scale, datetime_precision
+query TTIIII colnames
+SELECT table_name, column_name, numeric_precision, numeric_precision_radix, numeric_scale, datetime_precision
 FROM information_schema.columns
 WHERE table_schema = 'public' AND table_name = 'num_prec'
 ----
-table_name  column_name  numeric_precision  numeric_scale  datetime_precision
-num_prec    a            64                 0              NULL
-num_prec    b            53                 NULL           NULL
-num_prec    c            23                 NULL           NULL
-num_prec    d            NULL               NULL           NULL
-num_prec    e            12                 0              NULL
-num_prec    f            12                 6              NULL
-num_prec    g            NULL               NULL           NULL
+table_name  column_name  numeric_precision  numeric_precision_radix  numeric_scale  datetime_precision
+num_prec    a            64                 2                        0              NULL
+num_prec    b            53                 2                        NULL           NULL
+num_prec    c            23                 2                        NULL           NULL
+num_prec    d            NULL               10                       NULL           NULL
+num_prec    e            12                 10                       0              NULL
+num_prec    f            12                 10                       6              NULL
+num_prec    g            NULL               NULL                     NULL           NULL
 
 statement ok
 DROP TABLE num_prec

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -223,7 +223,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         17 columns, 906 rows
+                     │                     size         18 columns, 907 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -216,7 +216,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         17 columns, 906 rows
+                     │                     size         18 columns, 907 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2230,6 +2230,20 @@ func (c *ColumnType) NumericPrecision() (int32, bool) {
 	return 0, false
 }
 
+// NumericPrecisionRadix returns implicit precision radix of numeric
+// data types. Returns false if the data type is not numeric.
+func (c *ColumnType) NumericPrecisionRadix() (int32, bool) {
+	switch c.SemanticType {
+	case ColumnType_INT:
+		return 2, true
+	case ColumnType_FLOAT:
+		return 2, true
+	case ColumnType_DECIMAL:
+		return 10, true
+	}
+	return 0, false
+}
+
 // NumericScale returns the declared or implicit precision of exact numeric
 // data types. Returns false if the data type is not an exact numeric, or if the
 // scale of the exact numeric type is not bounded.


### PR DESCRIPTION
in `information_schema.columns`

As documented here:
https://www.postgresql.org/docs/10/static/infoschema-columns.html

> If data_type identifies a numeric type, this column indicates in
> which base the values in the columns numeric_precision and
> numeric_scale are expressed. The value is either 2 or 10. For all
> other data types, this column is null.

Fixes #24846.

Release note (sql change):
`numeric_precision_radix` was added to `information_schema.columns`