### PR TITLE
roachtest: Fix kv/quiescence/nodes=3 use of --host

### DIFF
--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -153,7 +153,7 @@ func registerKVQuiescenceDead(r *registry) {
 				run(kv+" --seed 1 {pgurl:1}", true)
 			})
 			// Gracefully shut down third node (doesn't matter whether it's graceful or not).
-			c.Run(ctx, c.Node(nodes), "./cockroach quit --insecure --host:{pgport:3}")
+			c.Run(ctx, c.Node(nodes), "./cockroach quit --insecure --host=:{pgport:3}")
 			c.Stop(ctx, c.Node(nodes))
 			// Measure qps with node down (i.e. without quiescence).
 			qpsOneDown := qps(func() {


### PR DESCRIPTION
This was broken by #28373.

Release note: None