### PR TITLE
importccl: count rows imported

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1112,7 +1112,7 @@ func TestImportCSVStmt(t *testing.T) {
 				&unused, &unused, &unused, &restored.rows, &restored.idx, &restored.sys, &restored.bytes,
 			); err != nil {
 				if !testutils.IsError(err, tc.err) {
-					t.Fatalf("%s: %v (%#v)", query, err, tc.args)
+					t.Fatalf("%s: %+v (%#v)", query, err, tc.args)
 				}
 				return
 			}
@@ -1135,9 +1135,6 @@ func TestImportCSVStmt(t *testing.T) {
 			isEmpty := len(tc.files) == 1 && tc.files[0] == empty[0]
 
 			if hasTransform {
-				if expected, actual := 0, restored.rows; expected != actual {
-					t.Fatalf("expected %d rows, got %d", expected, actual)
-				}
 				if err := sqlDB.DB.QueryRow(`SELECT count(*) FROM t`).Scan(&unused); !testutils.IsError(
 					err, "does not exist",
 				) {
@@ -1162,6 +1159,10 @@ func TestImportCSVStmt(t *testing.T) {
 					t.Fatalf("expected %d rows, got %d", expect, result)
 				}
 				return
+			}
+
+			if expected, actual := expectedRows, restored.rows; expected != actual {
+				t.Fatalf("expected %d rows, got %d", expected, actual)
 			}
 
 			// Verify correct number of rows via COUNT.

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -71,7 +71,7 @@ func MaxImportBatchSize(st *cluster.Settings) int64 {
 type sstBatcher struct {
 	maxSize int64
 	// rows written in the current batch.
-	rowCounter rowCounter
+	rowCounter RowCounter
 	totalRows  roachpb.BulkOpSummary
 
 	sstWriter     engine.RocksDBSstFileWriter
@@ -88,7 +88,7 @@ func (b *sstBatcher) add(key engine.MVCCKey, value []byte) error {
 	if len(b.batchEndKey) == 0 || bytes.Compare(key.Key, b.batchEndKey) > 0 {
 		b.batchEndKey = append(b.batchEndKey[:0], key.Key...)
 	}
-	if err := b.rowCounter.count(key.Key); err != nil {
+	if err := b.rowCounter.Count(key.Key); err != nil {
 		return err
 	}
 	return b.sstWriter.Add(engine.MVCCKeyValue{Key: key, Value: value})

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -381,12 +381,12 @@ func LoadCSV(
 		firstStageRouters[i] = pIdx
 	}
 
-	// The SST Writer returns 5 columns: name of the file, size of the file,
+	// The SST Writer returns 5 columns: name of the file, encoded BulkOpSummary,
 	// checksum, start key, end key.
 	p.planToStreamColMap = []int{0, 1, 2, 3, 4}
 	p.ResultTypes = []sqlbase.ColumnType{
 		{SemanticType: sqlbase.ColumnType_STRING},
-		{SemanticType: sqlbase.ColumnType_INT},
+		colTypeBytes,
 		colTypeBytes,
 		colTypeBytes,
 		colTypeBytes,


### PR DESCRIPTION
This plumbs the information about imported rows from the distributed
import process back to the gateway so it can be returned in the results,
similar to how it looked in original IMPORT via RESTORE.

Release note (sql change): fix imported row counts in IMPORT.