### PR TITLE
hlc: Prevent false positives in forward clock jump monitoring

### DIFF
--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -191,6 +191,12 @@ func (c *Clock) StartMonitoringForwardClockJumps(
 				if forwardClockJumpEnabled {
 					// Forward jump check is enabled. Start the ticker
 					ticker = tickerFn(refreshPhysicalNowItvl)
+
+					// Fetch the clock once before we start enforcing forward
+					// jumps. Otherwise the gap between the previous call to
+					// Now() and the time of the first tick would look like a
+					// forward jump.
+					c.PhysicalNow()
 				}
 				c.setForwardJumpCheckEnabled(forwardClockJumpEnabled)
 			case <-ticker.C:

--- a/pkg/util/hlc/hlc_test.go
+++ b/pkg/util/hlc/hlc_test.go
@@ -536,3 +536,32 @@ func TestResetAndRefreshHLCUpperBound(t *testing.T) {
 		})
 	}
 }
+
+func TestLateStartForwardClockJump(t *testing.T) {
+	// Regression test for https://github.com/cockroachdb/cockroach/issues/28367
+	//
+	// Previously, if the clock offset monitor were started a long time
+	// after the last call to hlc.Clock.Now, that time would register as
+	// a forward clock jump (because the background goroutine to keep
+	// the HLC clock fresh was not yet running).
+	m := NewManualClock(1)
+	c := NewClock(m.UnixNano, 500*time.Millisecond)
+	c.Now()
+	m.Increment(int64(time.Second))
+
+	// Control channels for the clock monitor: active it immediately,
+	// then wait for the first tick. We use a real ticker because the
+	// interfaces involved are not very mock-friendly.
+	activeCh := make(chan bool, 1)
+	activeCh <- true
+	tickedCh := make(chan struct{}, 1)
+	ticked := func() {
+		tickedCh <- struct{}{}
+	}
+	if err := c.StartMonitoringForwardClockJumps(activeCh, time.NewTicker, ticked); err != nil {
+		t.Fatal(err)
+	}
+	<-tickedCh
+	c.Now()
+
+}


### PR DESCRIPTION
A recent change to the ordering of various startup events has led to a
gap between calls to hlc.Clock.Now, which looks like a forward clock
jump to first iteration of the monitoring goroutine.

Fixes #28367

Release note: None