### PR TITLE
[dnm] cache Optimizer in planner

### DIFF
--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -150,6 +150,14 @@ func New() *Memo {
 	return m
 }
 
+func (m *Memo) Reset() {
+	m.metadata.Reset()
+	m.exprMap = make(map[Fingerprint]GroupID)
+	m.groups = m.groups[:1]
+	m.groups[0] = group{}
+	m.privateStorage.reset()
+}
+
 // Metadata returns the metadata instance associated with the memo.
 func (m *Memo) Metadata() *opt.Metadata {
 	return m.metadata

--- a/pkg/sql/opt/memo/private_storage.go
+++ b/pkg/sql/opt/memo/private_storage.go
@@ -78,6 +78,12 @@ func (ps *privateStorage) init() {
 	ps.privates = make([]interface{}, 1)
 }
 
+func (ps *privateStorage) reset() {
+	ps.privatesMap = make(map[privateKey]PrivateID)
+	ps.privates = ps.privates[:1]
+	ps.privates[0] = nil
+}
+
 // lookup returns a private value previously interned by privateStorage.
 func (ps *privateStorage) lookup(id PrivateID) interface{} {
 	return ps.privates[id]

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -158,6 +158,11 @@ func NewMetadata() *Metadata {
 	return &Metadata{}
 }
 
+func (md *Metadata) Reset() {
+	md.cols = md.cols[:0]
+	md.tables = md.tables[:0]
+}
+
 // AddColumn assigns a new unique id to a column within the query and records
 // its label and type.
 func (md *Metadata) AddColumn(label string, typ types.T) ColumnID {

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -113,6 +113,12 @@ func NewFactory(evalCtx *tree.EvalContext) *Factory {
 	return f
 }
 
+func (f *Factory) Reset(evalCtx *tree.EvalContext) {
+	f.mem.Reset()
+	f.evalCtx = evalCtx
+	f.ruleCycles = make(map[memo.Fingerprint]bool)
+}
+
 // DisableOptimizations disables all transformation rules. The unaltered input
 // expression tree becomes the output expression tree (because no transforms
 // are applied).

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -90,6 +90,13 @@ func NewOptimizer(evalCtx *tree.EvalContext) *Optimizer {
 	return o
 }
 
+func (o *Optimizer) Reset(evalCtx *tree.EvalContext) {
+	o.f.Reset(evalCtx)
+	o.stateMap = make(map[optStateKey]*optState)
+	o.evalCtx = evalCtx
+	o.explorer.init(o)
+}
+
 // Factory returns a factory interface that the caller uses to construct an
 // input expression tree. The root of the resulting tree can be passed to the
 // Optimize method in order to find the lowest cost plan.

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -153,6 +154,8 @@ type planner struct {
 	subqueryVisitor       subqueryVisitor
 	nameResolutionVisitor sqlbase.NameResolutionVisitor
 	srfExtractionVisitor  srfExtractionVisitor
+
+	opt *xform.Optimizer
 
 	// Use a common datum allocator across all the plan nodes. This separates the
 	// plan lifetime from the lifetime of returned results allowing plan nodes to


### PR DESCRIPTION
No doubt this is incomplete and/or broken, but I think a strategy like this could
be a nice to have. Pushing it as a proof of concept.

Instead of constructing a new optimizer, memo, memo group storage, etc
each query, reuse the memory by adding Reset methods to many of these
common structures.

Release note: None