### PR TITLE
roachtest: fix version/* tests

### DIFF
--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -166,7 +166,10 @@ func registerVersion(r *registry) {
 			stop := func(node int) error {
 				l.printf("stopping node %d\n", node)
 				port := fmt.Sprintf("{pgport:%d}", node)
-				if err := c.RunE(ctx, c.Node(node), "./cockroach quit --insecure --host=:"+port); err != nil {
+				// Note that the following command line needs to run against both v2.0
+				// and the current branch. Do not change it in a manner that is
+				// incompatible with 2.0.
+				if err := c.RunE(ctx, c.Node(node), "./cockroach quit --insecure --port="+port); err != nil {
 					return err
 				}
 				// NB: we still call Stop to make sure the process is dead when we try


### PR DESCRIPTION
Use a `quit` command line that is compatible with 2.0. This was
accidentally broken in #28373.

Fixes #28453
Fixes #28454

Release note: None