### PR TITLE
sql: pass Statement by reference, not by value

### DIFF
--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -96,7 +96,7 @@ func (s stmtKey) flags() string {
 }
 
 func (a *appStats) recordStatement(
-	stmt Statement,
+	stmt *Statement,
 	distSQLUsed bool,
 	optUsed bool,
 	automaticRetryCount int,
@@ -162,7 +162,7 @@ func (a *appStats) getStatsForStmt(key stmtKey) *stmtStats {
 	return s
 }
 
-func anonymizeStmt(stmt Statement) string {
+func anonymizeStmt(stmt *Statement) string {
 	return tree.AsStringWithFlags(stmt.AST, tree.FmtHideConstants)
 }
 

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1078,7 +1078,7 @@ func (ex *connExecutor) run(ctx context.Context, cancel context.CancelFunc) erro
 			ex.phaseTimes[sessionEndParse] = tcmd.ParseEnd
 
 			ctx := withStatement(ex.Ctx(), ex.curStmt)
-			ev, payload, err = ex.execStmt(ctx, curStmt, stmtRes, nil /* pinfo */, pos)
+			ev, payload, err = ex.execStmt(ctx, &curStmt, stmtRes, nil /* pinfo */, pos)
 			if err != nil {
 				return err
 			}
@@ -1132,7 +1132,7 @@ func (ex *connExecutor) run(ctx context.Context, cancel context.CancelFunc) erro
 				AnonymizedStr: portal.Stmt.AnonymizedStr,
 			}
 			ctx := withStatement(ex.Ctx(), ex.curStmt)
-			ev, payload, err = ex.execStmt(ctx, curStmt, stmtRes, pinfo, pos)
+			ev, payload, err = ex.execStmt(ctx, &curStmt, stmtRes, pinfo, pos)
 			if err != nil {
 				return err
 			}
@@ -1886,7 +1886,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 //
 // If an error is returned, it is to be considered a query execution error.
 func (ex *connExecutor) initStatementResult(
-	ctx context.Context, res RestrictedCommandResult, stmt Statement, cols sqlbase.ResultColumns,
+	ctx context.Context, res RestrictedCommandResult, stmt *Statement, cols sqlbase.ResultColumns,
 ) error {
 	for _, c := range cols {
 		if err := checkResultType(c.Typ); err != nil {

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -53,7 +53,7 @@ func (ex *connExecutor) execPrepare(
 	}
 
 	ps, err := ex.addPreparedStmt(
-		ctx, parseCmd.Name, Statement{AST: parseCmd.Stmt}, parseCmd.TypeHints,
+		ctx, parseCmd.Name, &Statement{AST: parseCmd.Stmt}, parseCmd.TypeHints,
 	)
 	if err != nil {
 		return retErr(err)
@@ -112,7 +112,7 @@ func (ex *connExecutor) execPrepare(
 //
 // placeholderHints are used to assist in inferring placeholder types.
 func (ex *connExecutor) addPreparedStmt(
-	ctx context.Context, name string, stmt Statement, placeholderHints tree.PlaceholderTypes,
+	ctx context.Context, name string, stmt *Statement, placeholderHints tree.PlaceholderTypes,
 ) (*PreparedStatement, error) {
 	if _, ok := ex.prepStmtsNamespace.prepStmts[name]; ok {
 		panic(fmt.Sprintf("prepared statement already exists: %q", name))
@@ -142,7 +142,7 @@ func (ex *connExecutor) addPreparedStmt(
 // The PreparedStatement is returned (or nil if there are no results). The
 // returned PreparedStatement needs to be close()d once its no longer in use.
 func (ex *connExecutor) prepare(
-	ctx context.Context, stmt Statement, placeholderHints tree.PlaceholderTypes,
+	ctx context.Context, stmt *Statement, placeholderHints tree.PlaceholderTypes,
 ) (*PreparedStatement, error) {
 	if placeholderHints == nil {
 		placeholderHints = make(tree.PlaceholderTypes)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1627,7 +1627,7 @@ func (s *sqlStatsCollectorImpl) PhaseTimes() *phaseTimes {
 
 // RecordStatement is part of the sqlStatsCollector interface.
 func (s *sqlStatsCollectorImpl) RecordStatement(
-	stmt Statement,
+	stmt *Statement,
 	distSQLUsed bool,
 	optUsed bool,
 	automaticRetryCount int,

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -93,7 +93,7 @@ func (EngineMetrics) MetricStruct() {}
 // - err is the error encountered, if any.
 func (ex *connExecutor) recordStatementSummary(
 	planner *planner,
-	stmt Statement,
+	stmt *Statement,
 	distSQLUsed bool,
 	optUsed bool,
 	automaticRetryCount int,

--- a/pkg/sql/parallel_stmts.go
+++ b/pkg/sql/parallel_stmts.go
@@ -365,7 +365,7 @@ func rangeGroupFromSpans(spans roachpb.Spans) interval.RangeGroup {
 // parallelized. This means that its results should be mocked out, and that
 // it should be run asynchronously and in parallel with other statements that
 // are independent.
-func IsStmtParallelized(stmt Statement) bool {
+func IsStmtParallelized(stmt *Statement) bool {
 	parallelizedRetClause := func(ret tree.ReturningClause) bool {
 		_, ok := ret.(*tree.ReturningNothing)
 		return ok

--- a/pkg/sql/parallel_stmts_test.go
+++ b/pkg/sql/parallel_stmts_test.go
@@ -333,7 +333,7 @@ func planQuery(t *testing.T, s serverutils.TestServerInterface, sql string) (*pl
 		t.Fatalf("expected to parse 1 statement, got: %d", len(stmts))
 	}
 	stmt := stmts[0]
-	if err := p.makePlan(context.TODO(), Statement{AST: stmt}); err != nil {
+	if err := p.makePlan(context.TODO(), &Statement{AST: stmt}); err != nil {
 		t.Fatal(err)
 	}
 	return p, func() {

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -58,7 +58,7 @@ type planMaker interface {
 	// iterating using curPlan.plan.Next() and curPlan.plan.Values() in
 	// order to retrieve matching rows. Finally, the plan must be closed
 	// with curPlan.close().
-	makePlan(ctx context.Context, stmt Statement) error
+	makePlan(ctx context.Context, stmt *Statement) error
 
 	// prepare does the same checks as makePlan but skips building some
 	// data structures necessary for execution, based on the assumption
@@ -294,7 +294,7 @@ type planTop struct {
 //
 // After makePlan(), the caller should be careful to also call
 // p.curPlan.Close().
-func (p *planner) makePlan(ctx context.Context, stmt Statement) error {
+func (p *planner) makePlan(ctx context.Context, stmt *Statement) error {
 	// Reinitialize.
 	p.curPlan = planTop{AST: stmt.AST}
 
@@ -356,7 +356,7 @@ func (p *planner) makePlan(ctx context.Context, stmt Statement) error {
 
 // makeOptimizerPlan is an alternative to makePlan which uses the (experimental)
 // optimizer.
-func (p *planner) makeOptimizerPlan(ctx context.Context, stmt Statement) error {
+func (p *planner) makeOptimizerPlan(ctx context.Context, stmt *Statement) error {
 	// Ensure that p.curPlan is populated in case an error occurs early,
 	// so that maybeLogStatement in the error case does not find an empty AST.
 	p.curPlan = planTop{AST: stmt.AST}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -516,7 +516,7 @@ func (p *planner) prepareForDistSQLSupportCheck() {
 // optimizerMode setting. If it is run, it will return true. If it returns false
 // and no error is returned, it is safe to fallback to a non-optimizer plan.
 func (p *planner) optionallyUseOptimizer(
-	ctx context.Context, sd sessiondata.SessionData, stmt Statement,
+	ctx context.Context, sd sessiondata.SessionData, stmt *Statement,
 ) (bool, error) {
 	if sd.OptimizerMode == sessiondata.OptimizerOff {
 		log.VEvent(ctx, 1, "optimizer disabled")
@@ -554,7 +554,7 @@ type sqlStatsCollector interface {
 
 	// RecordStatement record stats for one statement.
 	RecordStatement(
-		stmt Statement,
+		stmt *Statement,
 		distSQLUsed bool,
 		optUsed bool,
 		automaticRetryCount int,

--- a/pkg/sql/subquery_test.go
+++ b/pkg/sql/subquery_test.go
@@ -36,7 +36,7 @@ func TestStartSubqueriesReturnsError(t *testing.T) {
 		t.Fatalf("expected to parse 1 statement, got: %d", len(stmts))
 	}
 	stmt := stmts[0]
-	if err := p.makePlan(context.TODO(), Statement{AST: stmt}); err != nil {
+	if err := p.makePlan(context.TODO(), &Statement{AST: stmt}); err != nil {
 		t.Fatal(err)
 	}
 	params := runParams{ctx: context.TODO(), p: p, extendedEvalCtx: &p.extendedEvalCtx}

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -99,7 +99,7 @@ func (dsp *DistSQLPlanner) Exec(ctx context.Context, localPlanner interface{}, s
 		return err
 	}
 	p := localPlanner.(*planner)
-	if err := p.makePlan(ctx, Statement{AST: stmt}); err != nil {
+	if err := p.makePlan(ctx, &Statement{AST: stmt}); err != nil {
 		return err
 	}
 	rw := newCallbackResultWriter(func(ctx context.Context, row tree.Datums) error {


### PR DESCRIPTION
A Statement is 72 bytes. Andy Kimball noticed that we pass them by value
all over the place, down long chains of method calls. Pass them by
reference instead.

Release note: None