### PR TITLE
sql: a few performance optimizations

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -187,8 +187,8 @@ func MakeSimpleTableDescriptor(
 
 	semaCtx := tree.SemaContext{}
 	evalCtx := tree.EvalContext{
-		CtxProvider: ctxProvider{ctx},
-		Sequence:    &importSequenceOperators{},
+		Context:  ctx,
+		Sequence: &importSequenceOperators{},
 	}
 	affected := make(map[sqlbase.ID]*sqlbase.TableDescriptor)
 	tableDesc, err := sql.MakeTableDesc(

--- a/pkg/ccl/importccl/read_import_proc.go
+++ b/pkg/ccl/importccl/read_import_proc.go
@@ -38,14 +38,6 @@ import (
 
 type readFileFunc func(context.Context, io.Reader, int32, string, progressFn) error
 
-type ctxProvider struct {
-	context.Context
-}
-
-func (c ctxProvider) Ctx() context.Context {
-	return c
-}
-
 // readInputFile reads each of the passed dataFiles using the passed func. The
 // key part of dataFiles is the unique index of the data file among all files in
 // the IMPORT. progressFn, if not nil, is periodically invoked with a percentage

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1054,8 +1054,10 @@ func (ex *connExecutor) run(ctx context.Context, cancel context.CancelFunc) erro
 			}
 			return err
 		}
-		ex.sessionEventf(ex.Ctx(), "[%s pos:%d] executing %s",
-			ex.machine.CurState(), pos, cmd)
+		if log.ExpensiveLogEnabled(ex.Ctx(), 2) || ex.eventLog != nil {
+			ex.sessionEventf(ex.Ctx(), "[%s pos:%d] executing %s",
+				ex.machine.CurState(), pos, cmd)
+		}
 
 		var ev fsm.Event
 		var payload fsm.EventPayload
@@ -1097,7 +1099,9 @@ func (ex *connExecutor) run(ctx context.Context, cancel context.CancelFunc) erro
 				res = ex.clientComm.CreateErrorResult(pos)
 				break
 			}
-			log.VEventf(ex.Ctx(), 2, "portal resolved to: %s", portal.Stmt.Str)
+			if log.ExpensiveLogEnabled(ex.Ctx(), 2) {
+				log.VEventf(ex.Ctx(), 2, "portal resolved to: %s", portal.Stmt.Str)
+			}
 			ex.curStmt = portal.Stmt.Statement
 
 			*pinfo = tree.PlaceholderInfo{
@@ -2005,7 +2009,9 @@ func (ex *connExecutor) getPrepStmtsAccessor() preparedStatementsAccessor {
 
 // sessionEventf logs a message to the session event log (if any).
 func (ex *connExecutor) sessionEventf(ctx context.Context, format string, args ...interface{}) {
-	log.VEventfDepth(ex.Ctx(), 1 /* depth */, 2 /* level */, format, args...)
+	if log.ExpensiveLogEnabled(ex.Ctx(), 2) {
+		log.VEventfDepth(ex.Ctx(), 1 /* depth */, 2 /* level */, format, args...)
+	}
 	if ex.eventLog != nil {
 		ex.eventLog.Printf(format, args...)
 	}

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1732,7 +1732,7 @@ func (ex *connExecutor) evalCtx(
 			TxnReadOnly:      ex.state.readOnly,
 			TxnImplicit:      ex.implicitTxn(),
 			Settings:         ex.server.cfg.Settings,
-			CtxProvider:      ex,
+			Context:          ex.Ctx(),
 			Mon:              ex.state.mon,
 			TestingKnobs:     ex.server.cfg.EvalContextTestingKnobs,
 			TxnTimestamp:     ex.state.sqlTimestamp,

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1038,6 +1038,8 @@ func (ex *connExecutor) run(ctx context.Context, cancel context.CancelFunc) erro
 	ex.server.cfg.SessionRegistry.register(ex.sessionID, ex)
 	defer ex.server.cfg.SessionRegistry.deregister(ex.sessionID)
 
+	pinfo := &tree.PlaceholderInfo{}
+
 	var draining bool
 	for {
 		ex.curStmt = nil
@@ -1098,7 +1100,7 @@ func (ex *connExecutor) run(ctx context.Context, cancel context.CancelFunc) erro
 			log.VEventf(ex.Ctx(), 2, "portal resolved to: %s", portal.Stmt.Str)
 			ex.curStmt = portal.Stmt.Statement
 
-			pinfo := &tree.PlaceholderInfo{
+			*pinfo = tree.PlaceholderInfo{
 				TypeHints: portal.Stmt.TypeHints,
 				Types:     portal.Stmt.Types,
 				Values:    portal.Qargs,

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -16,7 +16,6 @@ package distsqlrun
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -431,7 +430,6 @@ func (h *ProcOutputHelper) consumerClosed() {
 //   func (p *concatProcessor) Start(ctx context.Context) context.Context {
 //     p.l.Start(ctx)
 //     p.r.Start(ctx)
-//     // Don't forget to declare a name for the proc and add it to procNameToLogTag.
 //     return p.StartInternal(ctx, concatProcName)
 //   }
 //
@@ -743,29 +741,6 @@ func (pb *ProcessorBase) Run(ctx context.Context, wg *sync.WaitGroup) {
 	}
 }
 
-var procNameToLogTag = map[string]string{
-	distinctProcName:                "distinct",
-	hashAggregatorProcName:          "hashAgg",
-	hashJoinerProcName:              "hashJoiner",
-	indexJoinerProcName:             "indexJoiner",
-	interleavedReaderJoinerProcName: "interleaveReaderJoiner",
-	joinReaderProcName:              "joinReader",
-	mergeJoinerProcName:             "mergeJoiner",
-	metadataTestReceiverProcName:    "metaReceiver",
-	metadataTestSenderProcName:      "metaSender",
-	noopProcName:                    "noop",
-	orderedAggregatorProcName:       "orderedAgg",
-	samplerProcName:                 "sampler",
-	scrubTableReaderProcName:        "scrub",
-	sortAllProcName:                 "sortAll",
-	sortTopKProcName:                "sortTopK",
-	sortedDistinctProcName:          "sortedDistinct",
-	sortChunksProcName:              "sortChunks",
-	tableReaderProcName:             "tableReader",
-	valuesProcName:                  "values",
-	zigzagJoinerProcName:            "zigzagJoiner",
-}
-
 // ProcStateOpts contains fields used by the ProcessorBase's family of functions
 // that deal with draining and trailing metadata: the ProcessorBase implements
 // generic useful functionality that needs to call back into the Processor.
@@ -803,9 +778,7 @@ func (pb *ProcessorBase) Init(
 // StartInternal prepares the ProcessorBase for execution. It returns the
 // annotated context that's also stored in pb.ctx.
 func (pb *ProcessorBase) StartInternal(ctx context.Context, name string) context.Context {
-	pb.Ctx = log.WithLogTag(
-		ctx, fmt.Sprintf("%s/%d", procNameToLogTag[name], pb.processorID), nil,
-	)
+	pb.Ctx = ctx
 
 	pb.origCtx = pb.Ctx
 	pb.Ctx, pb.span = processorSpan(pb.Ctx, name)

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -812,7 +812,7 @@ func (pb *ProcessorBase) StartInternal(ctx context.Context, name string) context
 	if pb.span != nil {
 		pb.span.SetTag(tracing.TagPrefix+"processorid", pb.processorID)
 	}
-	pb.evalCtx.CtxProvider = tree.FixedCtxProvider{Context: pb.Ctx}
+	pb.evalCtx.Context = pb.Ctx
 	return pb.Ctx
 }
 

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -265,15 +265,6 @@ func FlowVerIsCompatible(flowVer, minAcceptedVersion, serverVersion DistSQLVersi
 	return flowVer >= minAcceptedVersion && flowVer <= serverVersion
 }
 
-// simpleCtxProvider always returns the context that it holds.
-type simpleCtxProvider struct {
-	ctx context.Context
-}
-
-func (s simpleCtxProvider) Ctx() context.Context {
-	return s.ctx
-}
-
 // Note: unless an error is returned, the returned context contains a span that
 // must be finished through Flow.Cleanup.
 func (ds *ServerImpl) setupFlow(
@@ -391,7 +382,7 @@ func (ds *ServerImpl) setupFlow(
 			ActiveMemAcc: &acc,
 			// TODO(andrei): This is wrong. Each processor should override Ctx with its
 			// own context.
-			CtxProvider:      simpleCtxProvider{ctx: ctx},
+			Context:          ctx,
 			Txn:              txn,
 			Planner:          evalPlanner,
 			Sequence:         sequence,

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -334,7 +334,7 @@ func TestLimitScans(t *testing.T) {
 	sp := tracer.StartSpan("root", tracing.Recordable)
 	tracing.StartRecording(sp, tracing.SnowballRecording)
 	ctx := opentracing.ContextWithSpan(context.Background(), sp)
-	flowCtx.EvalCtx.CtxProvider = tree.FixedCtxProvider{Context: ctx}
+	flowCtx.EvalCtx.Context = ctx
 
 	tr, err := newTableReader(&flowCtx, 0 /* processorID */, &spec, &post, nil /* output */)
 	if err != nil {

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -296,7 +296,7 @@ func internalExtendedEvalCtx(
 			TxnReadOnly:   *dataMutator.curTxnReadOnly,
 			TxnImplicit:   true,
 			Settings:      execCfg.Settings,
-			CtxProvider:   tree.FixedCtxProvider{Context: ctx},
+			Context:       ctx,
 			Mon:           plannerMon,
 			TestingKnobs:  evalContextTestingKnobs,
 			StmtTimestamp: stmtTimestamp,

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2384,31 +2384,6 @@ type SequenceOperators interface {
 	SetSequenceValue(ctx context.Context, seqName *TableName, newVal int64, isCalled bool) error
 }
 
-// CtxProvider is anything that can return a Context.
-//
-// TODO(andrei): I think this whole CtxProvider business might not be needed any
-// more. I think it was needed back in the day to indirect dereferencing a
-// context to a session, whose context used to change willy-nilly when entering
-// and exiting a transaction. More recently, the points where that context
-// changes are clear; uses of an EvalContext don't straddle context changes, so
-// we should bind EvalCtx.Ctx to a context.Context directly.
-type CtxProvider interface {
-	// Ctx returns this provider's context.
-	Ctx() context.Context
-}
-
-// FixedCtxProvider returns a given Context.
-type FixedCtxProvider struct {
-	context.Context
-}
-
-// Ctx implements CtxProvider.
-func (s FixedCtxProvider) Ctx() context.Context {
-	return s.Context
-}
-
-var _ CtxProvider = FixedCtxProvider{}
-
 // EvalContextTestingKnobs contains test knobs.
 type EvalContextTestingKnobs struct {
 	// AssertFuncExprReturnTypes indicates whether FuncExpr evaluations
@@ -2480,14 +2455,8 @@ type EvalContext struct {
 	// need to restore once we finish evaluating it.
 	iVarContainerStack []IndexedVarContainer
 
-	// CtxProvider holds the context in which the expression is evaluated. This
-	// will point to the session, which is itself a provider of contexts.
-	// NOTE: seems a bit lazy to hold a pointer to the session's context here,
-	// instead of making sure the right context is explicitly set before the
-	// EvalContext is used. But there's already precedent with the Location field,
-	// and also at the time of writing, EvalContexts are initialized with the
-	// planner and not mutated.
-	CtxProvider CtxProvider
+	// Context holds the context in which the expression is evaluated.
+	Context context.Context
 
 	// InternalExecutor gives access to an executor to be used for running
 	// "internal" statements. It may seem bizarre that "expression evaluation" may
@@ -2552,7 +2521,7 @@ func MakeTestingEvalContextWithMon(st *cluster.Settings, monitor *mon.BytesMonit
 	}
 	monitor.Start(context.Background(), nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
 	ctx.Mon = monitor
-	ctx.CtxProvider = FixedCtxProvider{context.TODO()}
+	ctx.Context = context.TODO()
 	acc := monitor.MakeBoundAccount()
 	ctx.ActiveMemAcc = &acc
 	now := timeutil.Now()
@@ -2687,7 +2656,7 @@ func (ctx *EvalContext) GetLocation() *time.Location {
 
 // Ctx returns the session's context.
 func (ctx *EvalContext) Ctx() context.Context {
-	return ctx.CtxProvider.Ctx()
+	return ctx.Context
 }
 
 func (ctx *EvalContext) getTmpDec() *apd.Decimal {


### PR DESCRIPTION
The only visible change in this PR is to remove the processor-specific tags from logs. These haven't proven useful and they're expensive, so I think they're fine to delete.

- sql: remove pointless map creations
- distsqlrun: don't add processor id to log tags
- sql: hide common + expensive logs behind a gate
- sql: remove a common allocation
- distsqlrun: get rid of ContextProvider