### PR TITLE
roachtest: fix upgrade test

### DIFF
--- a/pkg/cmd/roachtest/upgrade.go
+++ b/pkg/cmd/roachtest/upgrade.go
@@ -86,7 +86,10 @@ func registerUpgrade(r *registry) {
 
 		stop := func(node int) error {
 			port := fmt.Sprintf("{pgport:%d}", node)
-			if err := c.RunE(ctx, c.Node(node), "./cockroach quit --insecure --host=:"+port); err != nil {
+			// Note that the following command line needs to run against both v2.0
+			// and the current branch. Do not change it in a manner that is
+			// incompatible with 2.0.
+			if err := c.RunE(ctx, c.Node(node), "./cockroach quit --insecure --port="+port); err != nil {
 				return err
 			}
 			c.Stop(ctx, c.Node(node))
@@ -95,7 +98,10 @@ func registerUpgrade(r *registry) {
 
 		decommissionAndStop := func(node int) error {
 			port := fmt.Sprintf("{pgport:%d}", node)
-			if err := c.RunE(ctx, c.Node(node), "./cockroach quit --decommission --insecure --host=:"+port); err != nil {
+			// Note that the following command line needs to run against both v2.0
+			// and the current branch. Do not change it in a manner that is
+			// incompatible with 2.0.
+			if err := c.RunE(ctx, c.Node(node), "./cockroach quit --decommission --insecure --port="+port); err != nil {
 				return err
 			}
 			c.Stop(ctx, c.Node(node))


### PR DESCRIPTION
This is the same fix as #28472, but for a different test. Use a `quit`
command line that is compatible with 2.0. This was accidentally broken
in #28373.

Fixes #28452

Release note: None