### PR TITLE
cli: warn when many rows are buffered in RAM during formatting

### DIFF
--- a/pkg/cli/interactive_tests/test_pretty.tcl
+++ b/pkg/cli/interactive_tests/test_pretty.tcl
@@ -53,9 +53,10 @@ eexpect "1 row"
 eexpect root@
 end_test
 
-start_test "Check that tables are not pretty-printed when output is a terminal and --format=tsv is specified."
 send "\\q\r"
 eexpect ":/# "
+
+start_test "Check that tables are not pretty-printed when output is a terminal and --format=tsv is specified."
 send "$argv sql --format=tsv\r"
 eexpect root@
 send "select 42 as woo; select 1 as woo;\r"
@@ -63,9 +64,17 @@ eexpect "woo\r\n42\r\n"
 eexpect "woo\r\n1\r\n"
 eexpect root@
 send "\\q\r"
+eexpect ":/# "
 end_test
 
+start_test "Check that a warning is printed if the pretty-printer is buffering many rows."
+send "$argv sql --format=table -e 'select * from generate_series(1,20000)' >/dev/null\r"
+eexpect "warning: buffering more than"
+eexpect "RAM usage growing"
+eexpect "consider another formatter"
 eexpect ":/# "
+end_test
+
 send "exit\r"
 eexpect eof
 


### PR DESCRIPTION
Fixes #18329.

When outputting to a terminal the default formatter is `table` and
that buffers rows in RAM to determine the width of each column for the
rendering.

When there are many rows (e.g. TPCC tables) this buffering can cause
RAM usage to explode and the client to die with an OOM error.

This constitutes poor UX, insofar that the user will receive no
feedback after entering a SQL query about what is going on and simply
sees the process die without an explanation.

It is not so clear we want to remove this buffering (or limit it, e.g.
stop adjusting column width after a certain number of rows) as this
would greatly increase the complexity of the rendering algorithm.

Meanwhile, `psql` also has the same behavior, as well as other
command-line SQL shells I have experimented with.

So in order to improve the UX, the patch instead simply issues a
warning (on standard error) to inform the user when more than 10000
rows are being buffered in RAM. For example:

```
> select * from generate_series(1,100000000);
warning: buffering more than 10000 result rows in client - RAM usage growing, consider another formatter instead
```

The user is then free to decide to either wait (and accept the
potentially high RAM usage) or terminate the query and try again with
a different formatter.

For context, `table` is now the only formatter that buffers the result
rows. All the other formatters are "safe" in this regard.

Release note (sql change): the `cockroach` sub-commands that print out
SQL results now issue a warning if more than 10000 result rows are
buffered in the `table` formatter.