### PR TITLE
cli: ensure the exit status is set for unknown sub-commands

### DIFF
--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -308,9 +308,7 @@ var certCmds = []*cobra.Command{
 var certCmd = &cobra.Command{
 	Use:   "cert",
 	Short: "create ca, node, and client certs",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cmd.Usage()
-	},
+	RunE:  usageAndErr,
 }
 
 func init() {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -185,3 +185,13 @@ func Run(args []string) error {
 	cockroachCmd.SetArgs(args)
 	return cockroachCmd.Execute()
 }
+
+// usageAndErr informs the user about the usage of the command
+// and returns an error. This ensures that the top-level command
+// has a suitable exit status.
+func usageAndErr(cmd *cobra.Command, args []string) error {
+	if err := cmd.Usage(); err != nil {
+		return err
+	}
+	return fmt.Errorf("unknown sub-command: %s", strings.Join(args, " "))
+}

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1408,7 +1408,5 @@ var debugCmd = &cobra.Command{
 These commands are useful for extracting data from the data files of a
 process that has failed and cannot restart.
 `,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cmd.Usage()
-	},
+	RunE: usageAndErr,
 }

--- a/pkg/cli/gen.go
+++ b/pkg/cli/gen.go
@@ -219,9 +219,7 @@ var genCmd = &cobra.Command{
 	Use:   "gen [command]",
 	Short: "generate auxiliary files",
 	Long:  "Generate manpages, example shell settings, example databases, etc.",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cmd.Usage()
-	},
+	RunE:  usageAndErr,
 }
 
 var genCmds = []*cobra.Command{

--- a/pkg/cli/interactive_tests/test_error_handling.tcl
+++ b/pkg/cli/interactive_tests/test_error_handling.tcl
@@ -44,6 +44,14 @@ send "echo \$?\r"
 eexpect "1\r\n:/# "
 end_test
 
+start_test "Check that unknown sub-commands report a non-zero exit status."
+send "$argv node wowowo\r"
+eexpect "Error: unknown sub-command"
+eexpect ":/# "
+send "echo \$?\r"
+eexpect "1\r\n:/# "
+end_test
+
 send "exit 0\r"
 eexpect eof
 

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -455,9 +455,7 @@ var nodeCmd = &cobra.Command{
 	Use:   "node [command]",
 	Short: "list, inspect or remove nodes",
 	Long:  "List, inspect or remove nodes.",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cmd.Usage()
-	},
+	RunE:  usageAndErr,
 }
 
 func init() {

--- a/pkg/cli/user.go
+++ b/pkg/cli/user.go
@@ -173,9 +173,7 @@ var userCmds = []*cobra.Command{
 var userCmd = &cobra.Command{
 	Use:   "user",
 	Short: "get, set, list and remove users",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cmd.Usage()
-	},
+	RunE:  usageAndErr,
 }
 
 func init() {

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -301,9 +301,7 @@ var zoneCmds = []*cobra.Command{
 var zoneCmd = &cobra.Command{
 	Use:   "zone",
 	Short: "get, set, list and remove zones",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cmd.Usage()
-	},
+	RunE:  usageAndErr,
 }
 
 func init() {


### PR DESCRIPTION
Fixes #25298.

Prior to this patch, an unknown sub-command would cause an error
message but a success (0) exit status. This patch changes it to
properly report an error status instead.

Release note (cli change): `cockroach` will now report a non-zero exit
status if an attempt is made to use a non-existent sub-command.