### PR TITLE
cli: format byte results like in SQL

### DIFF
--- a/pkg/cli/sql_util_test.go
+++ b/pkg/cli/sql_util_test.go
@@ -134,8 +134,8 @@ SET
 	}
 
 	expectedRows := [][]string{
-		{`parentID`, `INT`, `false`, `NULL`, ``, `{\"primary\"}`},
-		{`name`, `STRING`, `false`, `NULL`, ``, `{\"primary\"}`},
+		{`parentID`, `INT`, `false`, `NULL`, ``, `{"primary"}`},
+		{`name`, `STRING`, `false`, `NULL`, ``, `{"primary"}`},
 		{`id`, `INT`, `true`, `NULL`, ``, `{}`},
 	}
 	if !reflect.DeepEqual(expectedRows, rows) {


### PR DESCRIPTION
Fixes #20525.

This patch changes the formatting of byte array results to become
the same as converting a byte array to a string using a cast,
with `bytea_output` set to `escape`.

This is both a simplification of the code and a reduction of UX
surprise.

Release note (cli change): `cockroach` commands that print SQL
results containing byte array now print them as if they
were converted by a SQL cast to the `string` type.