### PR TITLE
cli: new command 'start-single-node'

### DIFF
--- a/build/verify-archive.sh
+++ b/build/verify-archive.sh
@@ -15,7 +15,7 @@ workdir=$(mktemp -d)
 tar xzf cockroach.src.tgz -C "$workdir"
 (cd "$workdir"/cockroach-* && make clean && make install)
 
-cockroach start --insecure --store type=mem,size=1GiB --background
+cockroach start-single-node --insecure --store type=mem,size=1GiB --background
 cockroach sql --insecure <<EOF
   CREATE DATABASE bank;
   CREATE TABLE bank.accounts (id INT PRIMARY KEY, balance DECIMAL);

--- a/pkg/ccl/cliccl/start.go
+++ b/pkg/ccl/cliccl/start.go
@@ -21,12 +21,14 @@ import (
 var storeEncryptionSpecs baseccl.StoreEncryptionSpecList
 
 func init() {
-	cli.VarFlag(cli.StartCmd.Flags(), &storeEncryptionSpecs, cliflagsccl.EnterpriseEncryption)
+	for _, cmd := range cli.StartCmds {
+		cli.VarFlag(cmd.Flags(), &storeEncryptionSpecs, cliflagsccl.EnterpriseEncryption)
 
-	// Add a new pre-run command to match encryption specs to store specs.
-	cli.AddPersistentPreRunE(cli.StartCmd, func(cmd *cobra.Command, _ []string) error {
-		return populateStoreSpecsEncryption()
-	})
+		// Add a new pre-run command to match encryption specs to store specs.
+		cli.AddPersistentPreRunE(cmd, func(cmd *cobra.Command, _ []string) error {
+			return populateStoreSpecsEncryption()
+		})
+	}
 }
 
 // populateStoreSpecsEncryption is a PreRun hook that matches store encryption specs with the

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -185,7 +185,8 @@ func init() {
 	})
 
 	cockroachCmd.AddCommand(
-		StartCmd,
+		startCmd,
+		startSingleNodeCmd,
 		initCmd,
 		certCmd,
 		quitCmd,

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1518,24 +1518,25 @@ func TestFlagUsage(t *testing.T) {
   cockroach [command]
 
 Available Commands:
-  start       start a node
-  init        initialize a cluster
-  cert        create ca, node, and client certs
-  quit        drain and shutdown node
+  start             start a node in a multi-node cluster
+  start-single-node start a single-node cluster
+  init              initialize a cluster
+  cert              create ca, node, and client certs
+  quit              drain and shutdown node
 
-  sql         open a sql shell
-  user        get, set, list and remove users
-  node        list, inspect or remove nodes
-  dump        dump sql tables
+  sql               open a sql shell
+  user              get, set, list and remove users
+  node              list, inspect or remove nodes
+  dump              dump sql tables
 
-  demo        open a demo sql shell
-  gen         generate auxiliary files
-  version     output version information
-  debug       debugging commands
-  sqlfmt      format SQL statements
-  workload    [experimental] generators for data and query loads
-  systembench Run systembench
-  help        Help about any command
+  demo              open a demo sql shell
+  gen               generate auxiliary files
+  version           output version information
+  debug             debugging commands
+  sqlfmt            format SQL statements
+  workload          [experimental] generators for data and query loads
+  systembench       Run systembench
+  help              Help about any command
 
 Flags:
   -h, --help                             help for cockroach

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -107,6 +108,8 @@ func initCLIDefaults() {
 	serverCfg.DelayedBootstrapFn = nil
 	serverCfg.SocketFile = ""
 	serverCfg.JoinList = nil
+	serverCfg.DefaultZoneConfig = config.DefaultZoneConfig()
+	serverCfg.DefaultSystemZoneConfig = config.DefaultSystemZoneConfig()
 
 	startCtx.serverInsecure = baseCfg.Insecure
 	startCtx.serverSSLCertsDir = base.DefaultCertsDirectory
@@ -286,8 +289,7 @@ var startCtx struct {
 	pidFile string
 
 	// logging settings specific to file logging.
-	logDir     log.DirName
-	logDirFlag *pflag.Flag
+	logDir log.DirName
 }
 
 // quitCtx captures the command-line parameters of the `quit` command.

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -75,7 +76,7 @@ func setupTransientServers(
 
 	// Set up logging. For demo/transient server we use non-standard
 	// behavior where we avoid file creation if possible.
-	df := startCtx.logDirFlag
+	df := cmd.Flags().Lookup(cliflags.LogDir.Name)
 	sf := cmd.Flags().Lookup(logflags.LogToStderrName)
 	if !df.Changed && !sf.Changed {
 		// User did not request logging flags; shut down logging under
@@ -87,7 +88,7 @@ func setupTransientServers(
 		_ = sf.Value.Set(log.Severity_ERROR.String())
 		sf.Changed = true
 	}
-	stopper, err := setupAndInitializeLoggingAndProfiling(ctx)
+	stopper, err := setupAndInitializeLoggingAndProfiling(ctx, cmd)
 	if err != nil {
 		return connURL, adminURL, cleanup, err
 	}

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
+	"github.com/gogo/protobuf/proto"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -187,15 +188,25 @@ func init() {
 	initCLIDefaults()
 
 	// Every command but start will inherit the following setting.
-	cockroachCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
+	AddPersistentPreRunE(cockroachCmd, func(cmd *cobra.Command, _ []string) error {
 		extraClientFlagInit()
 		return setDefaultStderrVerbosity(cmd, log.Severity_WARNING)
+	})
+
+	// Add a pre-run command for `start` and `start-single-node`.
+	for _, cmd := range StartCmds {
+		AddPersistentPreRunE(cmd, func(cmd *cobra.Command, _ []string) error {
+			// Finalize the configuration of network and logging settings.
+			extraServerFlagInit()
+			return setDefaultStderrVerbosity(cmd, log.Severity_INFO)
+		})
 	}
 
-	// Add a pre-run command for `start`.
-	AddPersistentPreRunE(StartCmd, func(cmd *cobra.Command, _ []string) error {
-		extraServerFlagInit()
-		return setDefaultStderrVerbosity(cmd, log.Severity_INFO)
+	// start-single-node starts with default replication of 1.
+	AddPersistentPreRunE(startSingleNodeCmd, func(cmd *cobra.Command, _ []string) error {
+		serverCfg.DefaultSystemZoneConfig.NumReplicas = proto.Int32(1)
+		serverCfg.DefaultZoneConfig.NumReplicas = proto.Int32(1)
+		return nil
 	})
 
 	// Map any flags registered in the standard "flag" package into the
@@ -253,8 +264,8 @@ func init() {
 	// avoid printing some messages to standard output in that case.
 	_, startCtx.inBackground = envutil.EnvString(backgroundEnvVar, 1)
 
-	{
-		f := StartCmd.Flags()
+	for _, cmd := range StartCmds {
+		f := cmd.Flags()
 
 		// Server flags.
 		VarFlag(f, addrSetter{&startCtx.serverListenAddr, &serverListenPort}, cliflags.ListenAddr)
@@ -312,8 +323,15 @@ func init() {
 		// variables, but share the same default.
 		StringFlag(f, &startCtx.serverSSLCertsDir, cliflags.ServerCertsDir, startCtx.serverSSLCertsDir)
 
-		// Cluster joining flags.
+		// Cluster joining flags. We need to enable this both for 'start'
+		// and 'start-single-node' although the latter does not support
+		// --join, because it delegates its logic to that of 'start', and
+		// 'start' will check that the flag is properly defined.
 		VarFlag(f, &serverCfg.JoinList, cliflags.Join)
+		// We also hide it from help for 'start-single-node'.
+		if cmd == startSingleNodeCmd {
+			_ = f.MarkHidden(cliflags.Join.Name)
+		}
 
 		// Engine flags.
 		VarFlag(f, cacheSizeValue, cliflags.Cache)
@@ -329,10 +347,11 @@ func init() {
 	}
 
 	// Log flags.
-	for _, cmd := range []*cobra.Command{demoCmd, StartCmd} {
+	logCmds := append(StartCmds, demoCmd)
+	logCmds = append(logCmds, demoCmd.Commands()...)
+	for _, cmd := range logCmds {
 		f := cmd.Flags()
 		VarFlag(f, &startCtx.logDir, cliflags.LogDir)
-		startCtx.logDirFlag = f.Lookup(cliflags.LogDir.Name)
 		VarFlag(f,
 			pflag.PFlagFromGoFlag(flag.Lookup(logflags.LogFilesCombinedMaxSizeName)).Value,
 			cliflags.LogDirMaxSize)
@@ -383,7 +402,7 @@ func init() {
 		genHAProxyCmd,
 		quitCmd,
 		sqlShellCmd,
-		/* StartCmd is covered above */
+		/* StartCmds are covered above */
 	}
 	clientCmds = append(clientCmds, userCmds...)
 	clientCmds = append(clientCmds, zoneCmds...)
@@ -475,6 +494,7 @@ func init() {
 	sqlCmds := []*cobra.Command{sqlShellCmd, dumpCmd, demoCmd}
 	sqlCmds = append(sqlCmds, zoneCmds...)
 	sqlCmds = append(sqlCmds, userCmds...)
+	sqlCmds = append(sqlCmds, demoCmd.Commands()...)
 	for _, cmd := range sqlCmds {
 		f := cmd.Flags()
 		BoolFlag(f, &sqlCtx.echo, cliflags.EchoSQL, sqlCtx.echo)
@@ -500,7 +520,8 @@ func init() {
 	}
 
 	// Commands that print tables.
-	tableOutputCommands := append([]*cobra.Command{sqlShellCmd, genSettingsListCmd, demoCmd},
+	tableOutputCommands := append(
+		[]*cobra.Command{sqlShellCmd, genSettingsListCmd, demoCmd},
 		demoCmd.Commands()...)
 	tableOutputCommands = append(tableOutputCommands, userCmds...)
 	tableOutputCommands = append(tableOutputCommands, nodeCmds...)

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -80,7 +80,7 @@ func TestCacheFlagValue(t *testing.T) {
 	// Avoid leaking configuration changes after the test ends.
 	defer initCLIDefaults()
 
-	f := StartCmd.Flags()
+	f := startCmd.Flags()
 	args := []string{"--cache", "100MB"}
 	if err := f.Parse(args); err != nil {
 		t.Fatal(err)
@@ -98,7 +98,7 @@ func TestSQLMemoryPoolFlagValue(t *testing.T) {
 	// Avoid leaking configuration changes after the test ends.
 	defer initCLIDefaults()
 
-	f := StartCmd.Flags()
+	f := startCmd.Flags()
 
 	// Check absolute values.
 	testCases := []struct {
@@ -145,7 +145,7 @@ func TestClockOffsetFlagValue(t *testing.T) {
 	// Avoid leaking configuration changes after the tests end.
 	defer initCLIDefaults()
 
-	f := StartCmd.Flags()
+	f := startCmd.Flags()
 	testData := []struct {
 		args     []string
 		expected time.Duration
@@ -366,7 +366,7 @@ func TestServerConnSettings(t *testing.T) {
 	// Avoid leaking configuration changes after the tests end.
 	defer initCLIDefaults()
 
-	f := StartCmd.Flags()
+	f := startCmd.Flags()
 	testData := []struct {
 		args                     []string
 		expectedAddr             string
@@ -458,7 +458,7 @@ func TestServerJoinSettings(t *testing.T) {
 	// Avoid leaking configuration changes after the tests end.
 	defer initCLIDefaults()
 
-	f := StartCmd.Flags()
+	f := startCmd.Flags()
 	testData := []struct {
 		args         []string
 		expectedJoin []string
@@ -559,7 +559,7 @@ func TestHttpHostFlagValue(t *testing.T) {
 	// Avoid leaking configuration changes after the tests end.
 	defer initCLIDefaults()
 
-	f := StartCmd.Flags()
+	f := startCmd.Flags()
 	testData := []struct {
 		args     []string
 		expected string

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -89,7 +89,7 @@ proc send_eof {} {
 proc start_server {argv} {
     report "BEGIN START SERVER"
     system "mkfifo url_fifo || true;
-            $argv start --insecure --pid-file=server_pid --listening-url-file=url_fifo --background -s=path=logs/db >>logs/expect-cmd.log 2>&1 &
+            $argv start-single-node --insecure --pid-file=server_pid --listening-url-file=url_fifo --background -s=path=logs/db >>logs/expect-cmd.log 2>&1 &
             cat url_fifo > server_url"
     report "START SERVER DONE"
 }

--- a/pkg/cli/interactive_tests/test_audit_log.tcl
+++ b/pkg/cli/interactive_tests/test_audit_log.tcl
@@ -62,7 +62,7 @@ stop_server $argv
 
 start_test "Check that audit logging works even with a custom directory"
 # Start a server with a custom log
-system "$argv start --insecure --pid-file=server_pid --listening-url-file=url_fifo --background -s=path=logs/db --sql-audit-dir=logs/db/audit-new >>logs/expect-cmd.log 2>&1 & cat url_fifo > server_url"
+system "$argv start-single-node --insecure --pid-file=server_pid --listening-url-file=url_fifo --background -s=path=logs/db --sql-audit-dir=logs/db/audit-new >>logs/expect-cmd.log 2>&1 & cat url_fifo > server_url"
 
 set logfile logs/db/audit-new/cockroach-sql-audit.log
 

--- a/pkg/cli/interactive_tests/test_cert_advisory_validation.tcl
+++ b/pkg/cli/interactive_tests/test_cert_advisory_validation.tcl
@@ -21,7 +21,7 @@ send "$argv cert create-node localhost --certs-dir=$certs_dir --ca-key=$certs_di
 eexpect $prompt
 
 start_test "Check that the server reports a warning if attempting to advertise an IP address not in cert."
-send "$argv start --certs-dir=$certs_dir --advertise-addr=127.0.0.1\r"
+send "$argv start-single-node --certs-dir=$certs_dir --advertise-addr=127.0.0.1\r"
 eexpect "advertise address"
 eexpect "127.0.0.1"
 eexpect "not in node certificate"
@@ -32,7 +32,7 @@ eexpect $prompt
 end_test
 
 start_test "Check that the server reports no warning if the avertise addr is in th cert."
-send "$argv start --certs-dir=$certs_dir --advertise-addr=localhost\r"
+send "$argv start-single-node --certs-dir=$certs_dir --advertise-addr=localhost\r"
 expect {
   "not in node certificate" {
      report "unexpected warning"

--- a/pkg/cli/interactive_tests/test_encryption.tcl
+++ b/pkg/cli/interactive_tests/test_encryption.tcl
@@ -35,7 +35,7 @@ file_has_size "$keydir/aes-256.key" "64"
 end_test
 
 start_test "Start normal node."
-send "$argv start --insecure --store=$storedir\r"
+send "$argv start-single-node --insecure --store=$storedir\r"
 eexpect "node starting"
 interrupt
 eexpect "shutdown completed"
@@ -44,47 +44,47 @@ eexpect ""
 end_test
 
 start_test "Restart with plaintext."
-send "$argv start --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=plain,old-key=plain\r"
+send "$argv start-single-node --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=plain,old-key=plain\r"
 eexpect "node starting"
 interrupt
 eexpect "shutdown completed"
 send "$argv debug encryption-status $storedir --enterprise-encryption=path=$storedir,key=plain,old-key=plain\r"
 eexpect "    \"Active\": true,\r\n    \"Type\": \"Plaintext\","
 # Try starting without the encryption flag.
-send "$argv start --insecure --store=$storedir\r"
+send "$argv start-single-node --insecure --store=$storedir\r"
 eexpect "encryption was used on this store before, but no encryption flags specified."
 end_test
 
 start_test "Restart with AES-128."
-send "$argv start --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-128.key,old-key=plain\r"
+send "$argv start-single-node --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-128.key,old-key=plain\r"
 eexpect "node starting"
 interrupt
 eexpect "shutdown completed"
 send "$argv debug encryption-status $storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-128.key,old-key=plain\r"
 eexpect "    \"Active\": true,\r\n    \"Type\": \"AES128_CTR\","
 # Try starting without the encryption flag.
-send "$argv start --insecure --store=$storedir\r"
+send "$argv start-single-node --insecure --store=$storedir\r"
 eexpect "encryption was used on this store before, but no encryption flags specified."
 # Try with the wrong key.
-send "$argv start --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-192.key,old-key=plain\r"
+send "$argv start-single-node --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-192.key,old-key=plain\r"
 eexpect "key_manager does not have a key with ID"
 end_test
 
 start_test "Restart with AES-256."
-send "$argv start --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-256.key,old-key=$keydir/aes-128.key\r"
+send "$argv start-single-node --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-256.key,old-key=$keydir/aes-128.key\r"
 eexpect "node starting"
 interrupt
 eexpect "shutdown completed"
 send "$argv debug encryption-status $storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-256.key,old-key=plain\r"
 eexpect "    \"Active\": true,\r\n    \"Type\": \"AES256_CTR\","
 # Startup again, but don't specify the old key, it's no longer in use.
-send "$argv start --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-256.key,old-key=plain\r"
+send "$argv start-single-node --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-256.key,old-key=plain\r"
 eexpect "node starting"
 interrupt
 # Try starting without the encryption flag.
-send "$argv start --insecure --store=$storedir\r"
+send "$argv start-single-node --insecure --store=$storedir\r"
 eexpect "encryption was used on this store before, but no encryption flags specified."
 # Try with the wrong key.
-send "$argv start --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-192.key,old-key=plain\r"
+send "$argv start-single-node --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-192.key,old-key=plain\r"
 eexpect "key_manager does not have a key with ID"
 end_test

--- a/pkg/cli/interactive_tests/test_error_hints.tcl
+++ b/pkg/cli/interactive_tests/test_error_hints.tcl
@@ -43,7 +43,7 @@ end_test
 # Check what happens when attempting to connect securely to an
 # insecure server.
 
-send "$argv start --insecure\r"
+send "$argv start-single-node --insecure\r"
 eexpect "initialized new cluster"
 
 spawn /bin/bash
@@ -73,7 +73,7 @@ interrupt
 interrupt
 eexpect ":/# "
 
-send "$argv start --certs-dir=$certs_dir\r"
+send "$argv start-single-node --listen-addr=localhost --certs-dir=$certs_dir\r"
 eexpect "restarted pre-existing node"
 
 set spawn_id $client_spawn_id

--- a/pkg/cli/interactive_tests/test_extern_dir.tcl
+++ b/pkg/cli/interactive_tests/test_extern_dir.tcl
@@ -11,14 +11,14 @@ eexpect ":/# "
 
 start_test "Check that non-absolute external-io-dir rejected"
 
-send "$argv start --insecure --store=$storedir --external-io-dir=blah\r"
+send "$argv start-single-node --insecure --store=$storedir --external-io-dir=blah\r"
 eexpect "external-io-dir path must be absolute"
 
 end_test
 
 start_test "Check disabling external IO explicitly"
 
-send "$argv start --insecure --store=$storedir --external-io-dir=disabled\r"
+send "$argv start-single-node --insecure --store=$storedir --external-io-dir=disabled\r"
 eexpect "external I/O path:   <disabled>"
 interrupt
 eexpect "shutdown completed"
@@ -27,7 +27,7 @@ end_test
 
 start_test "Check setting external IO explicitly"
 
-send "$argv start --insecure --store=$storedir --external-io-dir=$externdir\r"
+send "$argv start-single-node --insecure --store=$storedir --external-io-dir=$externdir\r"
 eexpect "external I/O path:   $externdir"
 interrupt
 eexpect "shutdown completed"
@@ -36,7 +36,7 @@ end_test
 
 start_test "Check implicit external I/O dir under store dir"
 
-send "$argv start --insecure --store=$storedir\r"
+send "$argv start-single-node --insecure --store=$storedir\r"
 eexpect "external I/O path:   $env(HOME)/$storedir/extern"
 interrupt
 eexpect "shutdown completed"

--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -7,28 +7,28 @@ send "PS1=':''/# '\r"
 eexpect ":/# "
 
 start_test "Check that --max-disk-temp-storage works."
-send "$argv start --insecure --store=path=mystore --max-disk-temp-storage=10GiB\r"
+send "$argv start-single-node --insecure --store=path=mystore --max-disk-temp-storage=10GiB\r"
 eexpect "node starting"
 interrupt
 eexpect ":/# "
 end_test
 
 start_test "Check that --max-disk-temp-storage can be expressed as a percentage."
-send "$argv start --insecure --store=path=mystore --max-disk-temp-storage=10%\r"
+send "$argv start-single-node --insecure --store=path=mystore --max-disk-temp-storage=10%\r"
 eexpect "node starting"
 interrupt
 eexpect ":/# "
 end_test
 
 start_test "Check that --max-disk-temp-storage percentage works when the store is in-memory."
-send "$argv start --insecure --store=type=mem,size=1GB --max-disk-temp-storage=10%\r"
+send "$argv start-single-node --insecure --store=type=mem,size=1GB --max-disk-temp-storage=10%\r"
 eexpect "node starting"
 interrupt
 eexpect ":/# "
 end_test
 
 start_test "Check that memory max flags do not exceed available RAM."
-send "$argv start --insecure --cache=.40 --max-sql-memory=.40\r"
+send "$argv start-single-node --insecure --cache=.40 --max-sql-memory=.40\r"
 eexpect "WARNING: the sum of --max-sql-memory"
 eexpect "is larger than"
 eexpect "of total RAM"
@@ -39,7 +39,7 @@ eexpect ":/# "
 end_test
 
 start_test "Check that not using --host nor --advertise causes a user warning."
-send "$argv start --insecure\r"
+send "$argv start-single-node --insecure\r"
 eexpect "WARNING: neither --listen-addr nor --advertise-addr was specified"
 eexpect "node starting"
 interrupt
@@ -47,7 +47,7 @@ eexpect ":/# "
 end_test
 
 start_test "Check that --listening-url-file gets created with the right data"
-send "$argv start --insecure --listening-url-file=foourl\r"
+send "$argv start-single-node --insecure --listening-url-file=foourl\r"
 eexpect "node starting"
 system "grep -q 'postgresql://.*@.*:\[0-9\]\[0-9\]*' foourl"
 interrupt
@@ -57,16 +57,36 @@ end_test
 start_test {Check that the "failed running SUBCOMMAND" message does not consider a flag the subcommand}
 send "$argv --vmodule=*=2 start --garbage\r"
 eexpect {Failed running "start"}
+eexpect ":/# "
 end_test
 
 start_test {Check that the "failed running SUBCOMMAND" message handles nested subcommands}
 send "$argv --vmodule=*=2 debug zip --garbage\r"
 eexpect {Failed running "debug zip"}
+eexpect ":/# "
 end_test
 
 start_test {Check that the "failed running SUBCOMMAND" message handles missing subcommands}
 send "$argv --vmodule=*=2 --garbage\r"
 eexpect {Failed running "cockroach"}
+eexpect ":/# "
+end_test
+
+start_test "Check that start without --join reports a deprecation warning"
+send "$argv start --insecure\r"
+eexpect "running 'cockroach start' without --join is deprecated."
+eexpect "node starting"
+interrupt
+eexpect ":/# "
+end_test
+
+start_test "Check that start-single-node disables replication properly"
+system "rm -rf logs/db"
+start_server $argv
+send "$argv sql -e 'show zone configuration for range default'\r"
+eexpect "num_replicas = 1"
+eexpect ":/# "
+stop_server $argv
 end_test
 
 send "exit 0\r"

--- a/pkg/cli/interactive_tests/test_high_verbosity.tcl
+++ b/pkg/cli/interactive_tests/test_high_verbosity.tcl
@@ -2,7 +2,7 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
-system "mkfifo url_fifo || true; $argv start --insecure --vmodule=*=3 --pid-file=server_pid --listening-url-file=url_fifo -s=path=logs/db & cat url_fifo > server_url"
+system "mkfifo url_fifo || true; $argv start-single-node --insecure --vmodule=*=3 --pid-file=server_pid --listening-url-file=url_fifo -s=path=logs/db & cat url_fifo > server_url"
 
 spawn /bin/bash
 send "PS1=':''/# '\r"

--- a/pkg/cli/interactive_tests/test_log_config_msg.tcl
+++ b/pkg/cli/interactive_tests/test_log_config_msg.tcl
@@ -14,7 +14,7 @@ end_test
 
 
 # Make a server with a tiny log buffer so as to force frequent log rotation.
-system "mkfifo url_fifo || true; $argv start --insecure --pid-file=server_pid --listening-url-file=url_fifo --background -s=path=logs/db --log-file-max-size=2k >>logs/expect-cmd.log 2>&1 & cat url_fifo > server_url"
+system "mkfifo url_fifo || true; $argv start-single-node --insecure --pid-file=server_pid --listening-url-file=url_fifo --background -s=path=logs/db --log-file-max-size=2k >>logs/expect-cmd.log 2>&1 & cat url_fifo > server_url"
 stop_server $argv
 
 start_test "Check that the cluster ID is reported at the start of new log files."

--- a/pkg/cli/interactive_tests/test_log_flags.tcl
+++ b/pkg/cli/interactive_tests/test_log_flags.tcl
@@ -13,7 +13,7 @@ eexpect ":/# "
 # to exit entirely (it has errorHandling set to ExitOnError).
 
 start_test "Check that log files are created by default in the store directory."
-send "$argv start --insecure --store=path=logs/mystore\r"
+send "$argv start-single-node --insecure --store=path=logs/mystore\r"
 eexpect "node starting"
 interrupt
 eexpect ":/# "
@@ -23,7 +23,7 @@ eexpect ":/# "
 end_test
 
 start_test "Check that an empty -log-dir disables file logging."
-send "$argv start --insecure --store=path=logs/mystore2 --log-dir=\r"
+send "$argv start-single-node --insecure --store=path=logs/mystore2 --log-dir=\r"
 eexpect "node starting"
 interrupt
 eexpect ":/# "
@@ -33,32 +33,32 @@ eexpect ":/# "
 end_test
 
 start_test "Check that leading tildes are properly rejected."
-send "$argv start --insecure -s=path=logs/db --log-dir=\~/blah\r"
+send "$argv start-single-node --insecure -s=path=logs/db --log-dir=\~/blah\r"
 eexpect "log directory cannot start with '~'"
 eexpect ":/# "
 end_test
 
 start_test "Check that the user can override."
-send "$argv start --insecure -s=path=logs/db --log-dir=logs/blah/\~/blah\r"
+send "$argv start-single-node --insecure -s=path=logs/db --log-dir=logs/blah/\~/blah\r"
 eexpect "logs: *blah/~/blah"
 interrupt
 eexpect ":/# "
 end_test
 
 start_test "Check that TRUE and FALSE are valid values for the severity flags."
-send "$argv start --insecure -s=path=logs/db --logtostderr=false\r"
+send "$argv start-single-node --insecure -s=path=logs/db --logtostderr=false\r"
 eexpect "node starting"
 interrupt
 eexpect ":/# "
-send "$argv start --insecure -s=path=logs/db --logtostderr=true\r"
+send "$argv start-single-node --insecure -s=path=logs/db --logtostderr=true\r"
 eexpect "node starting"
 interrupt
 eexpect ":/# "
-send "$argv start --insecure -s=path=logs/db --logtostderr=2\r"
+send "$argv start-single-node --insecure -s=path=logs/db --logtostderr=2\r"
 eexpect "node starting"
 interrupt
 eexpect ":/# "
-send "$argv start --insecure -s=path=logs/db --logtostderr=cantparse\r"
+send "$argv start-single-node --insecure -s=path=logs/db --logtostderr=cantparse\r"
 eexpect "parsing \"cantparse\": invalid syntax"
 eexpect ":/# "
 end_test

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -7,7 +7,7 @@ send "PS1=':''/# '\r"
 eexpect ":/# "
 
 start_test "Check that a server encountering a fatal error when not logging to stderr shows the fatal error."
-send "$argv start -s=path=logs/db --insecure\r"
+send "$argv start-single-node -s=path=logs/db --insecure\r"
 eexpect "CockroachDB node starting"
 system "$argv sql --insecure -e \"select crdb_internal.force_log_fatal('helloworld')\" || true"
 eexpect "\r\nF"
@@ -19,7 +19,7 @@ eexpect ":/# "
 end_test
 
 start_test "Check that a broken stderr prints a message to the log files."
-send "$argv start -s=path=logs/db --insecure --logtostderr --vmodule=*=1 2>&1 | cat\r"
+send "$argv start-single-node -s=path=logs/db --insecure --logtostderr --vmodule=*=1 2>&1 | cat\r"
 eexpect "CockroachDB node starting"
 system "killall cat"
 eexpect ":/# "
@@ -30,13 +30,13 @@ start_test "Check that a broken log file prints a message to stderr."
 # The path that we pass to the --log-dir will already exist as a file.
 system "mkdir -p logs"
 system "touch logs/broken"
-send "$argv start -s=path=logs/db --log-dir=logs/broken --insecure --logtostderr\r"
+send "$argv start-single-node -s=path=logs/db --log-dir=logs/broken --insecure --logtostderr\r"
 eexpect "unable to create log directory"
 eexpect ":/# "
 end_test
 
 start_test "Check that a server started with only in-memory stores and no --log-dir automatically logs to stderr."
-send "$argv start --insecure --store=type=mem,size=1GiB\r"
+send "$argv start-single-node --insecure --store=type=mem,size=1GiB\r"
 eexpect "CockroachDB node starting"
 end_test
 
@@ -52,7 +52,7 @@ eexpect ":/# "
 stop_server $argv
 
 start_test "Check that a server started with --logtostderr logs even info messages to stderr."
-send "$argv start -s=path=logs/db --insecure --logtostderr\r"
+send "$argv start-single-node -s=path=logs/db --insecure --logtostderr\r"
 eexpect "CockroachDB node starting"
 end_test
 
@@ -61,7 +61,7 @@ interrupt
 eexpect ":/# "
 
 start_test "Check that --logtostderr can override the threshold but no error is printed on startup"
-send "echo marker; $argv start -s=path=logs/db --insecure --logtostderr=ERROR 2>&1 | grep -v '^\\*'\r"
+send "echo marker; $argv start-single-node -s=path=logs/db --insecure --logtostderr=ERROR 2>&1 | grep -v '^\\*'\r"
 eexpect "marker\r\nCockroachDB node starting"
 end_test
 
@@ -70,7 +70,7 @@ interrupt
 eexpect ":/# "
 
 start_test "Check that panic reports are printed to the log even when --logtostderr is specified"
-send "$argv start -s=path=logs/db --insecure --logtostderr\r"
+send "$argv start-single-node -s=path=logs/db --insecure --logtostderr\r"
 eexpect "CockroachDB node starting"
 
 system "$argv sql --insecure -e \"select crdb_internal.force_panic('helloworld')\" || true"

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -4,6 +4,7 @@ source [file join [file dirname $argv0] common.tcl]
 
 set certs_dir "/certs"
 set ::env(COCKROACH_INSECURE) "false"
+set ::env(COCKROACH_HOST) "localhost"
 
 spawn /bin/bash
 send "PS1=':''/# '\r"
@@ -12,7 +13,7 @@ set prompt ":/# "
 eexpect $prompt
 
 start_test "Check that --insecure reports that the server is really insecure"
-send "$argv start --insecure\r"
+send "$argv start-single-node --insecure\r"
 eexpect "WARNING: RUNNING IN INSECURE MODE"
 eexpect "node starting"
 interrupt
@@ -22,7 +23,7 @@ end_test
 
 proc start_secure_server {argv certs_dir} {
     report "BEGIN START SECURE SERVER"
-    system "mkfifo url_fifo || true; $argv start --certs-dir=$certs_dir --pid-file=server_pid --listening-url-file=url_fifo -s=path=logs/db >>expect-cmd.log 2>&1 & cat url_fifo > server_url"
+    system "mkfifo url_fifo || true; $argv start-single-node --certs-dir=$certs_dir --pid-file=server_pid --listening-url-file=url_fifo -s=path=logs/db >>expect-cmd.log 2>&1 & cat url_fifo > server_url"
     report "END START SECURE SERVER"
 }
 

--- a/pkg/cli/interactive_tests/test_server_sig.tcl
+++ b/pkg/cli/interactive_tests/test_server_sig.tcl
@@ -9,7 +9,7 @@ send "PS1='\\h:''/# '\r"
 eexpect ":/# "
 
 start_test "Check that the server shuts down upon receiving SIGTERM"
-send "$argv start --insecure --pid-file=server_pid --log-dir=logs \r"
+send "$argv start-single-node --insecure --pid-file=server_pid --log-dir=logs \r"
 eexpect "initialized"
 
 system "kill `cat server_pid`"
@@ -25,7 +25,7 @@ eexpect ":/# "
 end_test
 
 start_test "Check that the server shuts down upon receiving Ctrl+C."
-send "$argv start --insecure --pid-file=server_pid --log-dir=logs \r"
+send "$argv start-single-node --insecure --pid-file=server_pid --log-dir=logs \r"
 eexpect "restarted"
 
 interrupt
@@ -43,7 +43,7 @@ end_test
 start_test "Check that the server shuts down fast upon receiving Ctrl+C twice."
 
 # Start a server via the shell
-send "$argv start --insecure --pid-file=server_pid --log-dir=logs \r"
+send "$argv start-single-node --insecure --pid-file=server_pid --log-dir=logs \r"
 eexpect "restarted"
 
 # Make a client open a connection and keep using it with an open txn.

--- a/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
+++ b/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
@@ -44,7 +44,7 @@ send "ulimit -v [ expr {3*$vmem/2} ]\r"
 eexpect ":/# "
 
 # Start a server with this limit set. The server will now run in the foreground.
-send "$argv start --insecure --max-sql-memory=25% --no-redirect-stderr -s=path=logs/db \r"
+send "$argv start-single-node --insecure --max-sql-memory=25% --no-redirect-stderr -s=path=logs/db \r"
 eexpect "restarted pre-existing node"
 sleep 1
 
@@ -91,7 +91,7 @@ end_test
 start_test "Ensure that memory monitoring prevents crashes"
 # Re-launch a server with relatively lower limit for SQL memory
 set spawn_id $shell_spawn_id
-send "$argv start --insecure --max-sql-memory=1000K --no-redirect-stderr -s=path=logs/db \r"
+send "$argv start-single-node --insecure --max-sql-memory=1000K --no-redirect-stderr -s=path=logs/db \r"
 eexpect "restarted pre-existing node"
 sleep 2
 

--- a/pkg/cli/interactive_tests/test_temp_dir.tcl
+++ b/pkg/cli/interactive_tests/test_temp_dir.tcl
@@ -50,7 +50,7 @@ eexpect ":/# "
 
 start_test "Check that on node startup a temporary subdirectory is created under --temp-dir and recorded to a record file, and on node shutdown the directory is removed."
 send "mkdir -p $tempdir\r"
-send "$argv start --insecure --store=$storedir --temp-dir=$tempdir\r"
+send "$argv start-single-node --insecure --store=$storedir --temp-dir=$tempdir\r"
 eexpect "node starting"
 eexpect "temp dir:*$tempdir/$tempprefix"
 # Verify the temp directory under first store is created.
@@ -75,7 +75,7 @@ end_test
 
 start_test "Check that on node startup a temporary subdirectory is created under --temp-dir even if store is in-memory and removed on shutdown."
 send "mkdir -p $tempdir\r"
-send "$argv start --insecure --store=type=mem,size=1GB --temp-dir=$tempdir\r"
+send "$argv start-single-node --insecure --store=type=mem,size=1GB --temp-dir=$tempdir\r"
 eexpect "node starting"
 eexpect "temp dir:*$tempdir/$tempprefix"
 # Verify the temp directory under first store is created.
@@ -91,7 +91,7 @@ send "mkdir -p $tempdir $storedir/temp1 $storedir/temp2\r"
 send "echo foobartext >  $storedir/temp1/foo.txt\r"
 # We add the temp directories to the record file.
 send "cat > $storedir/$recordfile <<EOF\r$cwd/$storedir/temp1\r$cwd/$storedir/temp2\rEOF\r"
-send "$argv start --insecure --store=$storedir --temp-dir=$tempdir\r"
+send "$argv start-single-node --insecure --store=$storedir --temp-dir=$tempdir\r"
 eexpect "node starting"
 eexpect "temp dir:*$cwd/$tempdir/$tempprefix"
 # Verify temp1 and temp2 are removed shortly after startup.
@@ -106,7 +106,7 @@ file_exists $storedir
 end_test
 
 start_test "Check that if --temp-dir is unspecified, a temporary directory is created under --store"
-send "$argv start --insecure --store=$storedir\r"
+send "$argv start-single-node --insecure --store=$storedir\r"
 eexpect "node starting"
 eexpect "temp dir:*$cwd/$storedir/$tempprefix"
 # Verify the temp directory under first store is created.
@@ -120,16 +120,16 @@ file_exists $storedir
 end_test
 
 start_test "Check that temp directory does not get wiped upon subsequent failed cockroach start attempt and that a cockroach instance can be subsequently started up after a shutdown"
-send "$argv start --insecure --store=$storedir --background\r"
+send "$argv start-single-node --insecure --store=$storedir --background\r"
 eexpect ":/# "
 # Try to start up a second cockroach instance with the same store path.
-send "$argv start --insecure --store=$storedir\r"
+send "$argv start-single-node --insecure --store=$storedir\r"
 eexpect "ERROR: could not cleanup temporary directories from record file: could not lock temporary directory $cwd/$storedir/$tempprefix*"
 # Verify the temp directory still exists.
 glob_exists "$storedir/$tempprefix*"
 send "pkill -9 cockroach\r"
 # We should be able to start the cockroach instance again.
-send "$argv start --insecure --store=$storedir\r"
+send "$argv start-single-node --insecure --store=$storedir\r"
 eexpect "node starting"
 interrupt
 eexpect "shutdown completed"

--- a/pkg/cli/start_test.go
+++ b/pkg/cli/start_test.go
@@ -31,7 +31,7 @@ func TestInitInsecure(t *testing.T) {
 	// Avoid leaking configuration changes after the tests end.
 	defer initCLIDefaults()
 
-	f := StartCmd.Flags()
+	f := startCmd.Flags()
 
 	testCases := []struct {
 		args     []string
@@ -83,7 +83,7 @@ func TestStartArgChecking(t *testing.T) {
 	defer func(save server.Config) { serverCfg = save }(serverCfg)
 	defer initCLIDefaults()
 
-	f := StartCmd.Flags()
+	f := startCmd.Flags()
 
 	testCases := []struct {
 		args     []string

--- a/pkg/cli/start_unix.go
+++ b/pkg/cli/start_unix.go
@@ -58,7 +58,9 @@ func handleSignalDuringShutdown(sig os.Signal) {
 var startBackground bool
 
 func init() {
-	BoolFlag(StartCmd.Flags(), &startBackground, cliflags.Background, false)
+	for _, cmd := range StartCmds {
+		BoolFlag(cmd.Flags(), &startBackground, cliflags.Background, false)
+	}
 }
 
 func maybeRerunBackground() (bool, error) {


### PR DESCRIPTION
Fixes #24118.
Fixes #21429.

Suggested/requested by @bdarnell:

> There are currently two ways to initialize a cluster: Starting the
  first node without a --join flag, or starting all nodes with --join
  flags and running a separate cockroach init command. This redundancy
  is confusing (our docs use both methods without explaining the
  difference) and it's easy to accidentally initialize a new cluster
  by restarting your first node with the wrong flags. (This could have
  catastrophic consequences in 1.1 because data from the two clusters
  could get mixed. We've added safeguards against this in 2.0 but it's
  still an easy way to break things.)
> I think that we should deprecate this implicit initialization mode
  and make the --join flag mandatory when starting a node (and
  therefore the init command would be mandatory too). To avoid adding
  too much complexity to single-node clusters, I propose a new
  `cockroach start-single-node` command to perform the start and init
  combination that is today implicit in the absence of a --join flag.
> This would have a side benefit that we would know when the user
  intends to keep the cluster as a single node instead of adding more
  later. The `start-single-node` command could therefore set the
  replication factor to 1 to disable the "underreplicated ranges"
  warning.

This patch implements the new `start-single-node` command as follows:

- the new command does not accept `--join`.
- it attempts to set the replication factor to 1 upon starting up.

Meanwhile `cockroach start` is changed to produce a deprecation
warning if `--join` is not specified.

Release note (cli change): a new command `cockroach start-single-node`
is introduced to start single-node clusters with replication disabled.

Release note (cli change): using `cockroach start` without `--join` is
now deprecated and this mode of execution will be removed in a later
version of CockroachDB. Consider using `cockroach start-single-node`
instead or combine `cockroach start` with `cockroach init`.