### PR TITLE
 opt: rework reverse scans 

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -288,13 +288,16 @@ func (b *Builder) buildScan(ev memo.ExprView) (execPlan, error) {
 
 	reqOrder := b.makeSQLOrderingFromChoice(res, &ev.Physical().Ordering)
 
+	_, reverse := def.CanProvideOrdering(md, &ev.Physical().Ordering)
+
 	root, err := b.factory.ConstructScan(
 		tab,
 		tab.Index(def.Index),
 		needed,
 		def.Constraint,
-		def.HardLimit,
-		def.Reverse,
+		def.HardLimit.RowCount(),
+		// def.HardLimit.Reverse() was taken into account by CanProvideOrdering.
+		reverse,
 		reqOrder,
 	)
 	if err != nil {

--- a/pkg/sql/opt/memo/memo_format.go
+++ b/pkg/sql/opt/memo/memo_format.go
@@ -123,7 +123,7 @@ func (f *memoFormatter) formatExpr(e *Expr) {
 	for i := 0; i < e.ChildCount(); i++ {
 		fmt.Fprintf(f.buf, " G%d", f.numbering[e.ChildGroup(f.mem, i)])
 	}
-	f.formatPrivate(e.Private(f.mem), formatMemo)
+	f.formatPrivate(e.Private(f.mem), &props.Physical{}, formatMemo)
 	f.buf.WriteString(")")
 }
 
@@ -190,7 +190,7 @@ func (f *memoFormatter) formatBestExpr(be *BestExpr) {
 		}
 	}
 
-	f.formatPrivate(be.Private(f.mem), formatMemo)
+	f.formatPrivate(be.Private(f.mem), f.mem.LookupPhysicalProps(be.Required()), formatMemo)
 	f.buf.WriteString(")")
 }
 
@@ -264,7 +264,9 @@ func (f *memoFormatter) computeIndegrees(id GroupID, reachable []bool, indegrees
 	})
 }
 
-func (f exprFormatter) formatPrivate(private interface{}, mode formatMode) {
+func (f exprFormatter) formatPrivate(
+	private interface{}, physProps *props.Physical, mode formatMode,
+) {
 	if private == nil {
 		return
 	}
@@ -277,8 +279,8 @@ func (f exprFormatter) formatPrivate(private interface{}, mode formatMode) {
 		} else {
 			fmt.Fprintf(f.buf, " %s@%s", tab.TabName().TableName, tab.Index(t.Index).IdxName())
 		}
-		if t.Reverse {
-			fmt.Fprintf(f.buf, ",rev")
+		if _, reverse := t.CanProvideOrdering(f.mem.metadata, &physProps.Ordering); reverse {
+			f.buf.WriteString(",rev")
 		}
 		if mode == formatMemo {
 			if tab.ColumnCount() != t.Cols.Len() {
@@ -287,8 +289,8 @@ func (f exprFormatter) formatPrivate(private interface{}, mode formatMode) {
 			if t.Constraint != nil {
 				fmt.Fprintf(f.buf, ",constrained")
 			}
-			if t.HardLimit > 0 {
-				fmt.Fprintf(f.buf, ",lim=%d", t.HardLimit)
+			if t.HardLimit.IsSet() {
+				fmt.Fprintf(f.buf, ",lim=%s", t.HardLimit)
 			}
 		}
 

--- a/pkg/sql/opt/memo/private_defs.go
+++ b/pkg/sql/opt/memo/private_defs.go
@@ -15,6 +15,8 @@
 package memo
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
@@ -83,9 +85,6 @@ type ScanOpDef struct {
 	// opt.Index metadata.
 	Index int
 
-	// Reverse indicates if the Scan is a reverse scan.
-	Reverse bool
-
 	// Cols specifies the set of columns that the scan operator projects. This
 	// may be a subset of the columns that the table/index contains.
 	Cols opt.ColSet
@@ -95,13 +94,52 @@ type ScanOpDef struct {
 	Constraint *constraint.Constraint
 
 	// HardLimit specifies the maximum number of rows that the scan can return
-	// (after applying any constraint). This is a "hard" limit, meaning that
-	// the scan operator must never return more than this number of rows, even
-	// if more are available. If its value is zero, then the limit is
-	// unknown, and the scan should return all available rows.
-	HardLimit int64
+	// (after applying any constraint), as well as the required scan direction.
+	// This is a "hard" limit, meaning that the scan operator must never return
+	// more than this number of rows, even if more are available. If its value is
+	// zero, then the limit is unknown, and the scan should return all available
+	// rows.
+	HardLimit ScanLimit
 
 	Flags ScanFlags
+}
+
+// ScanLimit is used for a limited table or index scan and stores the limit as
+// well as the desired scan direction. A value of 0 means that there is no
+// limit.
+type ScanLimit int64
+
+// MakeScanLimit initializes a ScanLimit with a number of rows and a direction.
+func MakeScanLimit(rowCount int64, reverse bool) ScanLimit {
+	if reverse {
+		return ScanLimit(-rowCount)
+	}
+	return ScanLimit(rowCount)
+}
+
+// IsSet returns true if there is a limit.
+func (sl ScanLimit) IsSet() bool {
+	return sl != 0
+}
+
+// RowCount returns the number of rows in the limit.
+func (sl ScanLimit) RowCount() int64 {
+	if sl.Reverse() {
+		return int64(-sl)
+	}
+	return int64(sl)
+}
+
+// Reverse returns true if the limit requires a reverse scan.
+func (sl ScanLimit) Reverse() bool {
+	return sl < 0
+}
+
+func (sl ScanLimit) String() string {
+	if sl.Reverse() {
+		return fmt.Sprintf("%d(rev)", -sl)
+	}
+	return fmt.Sprintf("%d", sl)
 }
 
 // ScanFlags stores any flags for the scan specified in the query (see
@@ -138,21 +176,68 @@ type VirtualScanOpDef struct {
 }
 
 // CanProvideOrdering returns true if the scan operator returns rows that
-// satisfy the given required ordering.
-func (s *ScanOpDef) CanProvideOrdering(md *opt.Metadata, required *props.OrderingChoice) bool {
-	// Scan naturally orders according to scanned index's key columns.
-	var ordering props.OrderingChoice
-	index := md.Table(s.Table).Index(s.Index)
-	for i := 0; i < index.KeyColumnCount(); i++ {
-		indexCol := index.Column(i)
-		colID := s.Table.ColumnID(indexCol.Ordinal)
-		if s.Reverse {
-			ordering.AppendCol(colID, !indexCol.Descending)
-		} else {
-			ordering.AppendCol(colID, indexCol.Descending)
+// satisfy the given required ordering; it also returns whether the scan needs
+// to be in reverse order to match the required ordering.
+func (s *ScanOpDef) CanProvideOrdering(
+	md *opt.Metadata, required *props.OrderingChoice,
+) (ok bool, reverse bool) {
+	// Scan naturally orders according to scanned index's key columns. A scan can
+	// be executed either as a forward or as a reverse scan (unless it has a row
+	// limit, in which case the direction is fixed).
+	//
+	// The code below follows the structure of OrderingChoice.Implies. We go
+	// through the columns and determine if the ordering matches with either scan
+	// direction.
+
+	// We start off as accepting either a forward or a reverse scan. Until then,
+	// the reverse variable is unset. Once the direction is known, reverseSet is
+	// true and reverse indicates whether we need to do a reverse scan.
+	const (
+		either = 0
+		fwd    = 1
+		rev    = 2
+	)
+	direction := either
+	if s.HardLimit.IsSet() {
+		// When we have a limit, the limit forces a certain scan direction (because
+		// it affects the results, not just their ordering).
+		direction = fwd
+		if s.HardLimit.Reverse() {
+			direction = rev
 		}
 	}
-	return ordering.Implies(required)
+	index := md.Table(s.Table).Index(s.Index)
+	for left, right := 0, 0; right < len(required.Columns); {
+		if left >= index.KeyColumnCount() {
+			return false, false
+		}
+		indexCol := index.Column(left)
+		indexColID := s.Table.ColumnID(indexCol.Ordinal)
+		if required.Optional.Contains(int(indexColID)) {
+			left++
+			continue
+		}
+		reqCol := &required.Columns[right]
+		if !reqCol.Group.Contains(int(indexColID)) {
+			return false, false
+		}
+		// The directions of the index column and the required column impose either
+		// a forward or a reverse scan.
+		required := fwd
+		if indexCol.Descending != reqCol.Descending {
+			required = rev
+		}
+		if direction == either {
+			direction = required
+		} else if direction != required {
+			// We already determined the direction, and according to it, this column
+			// has the wrong direction.
+			return false, false
+		}
+		left, right = left+1, right+1
+	}
+	// If direction is either, we prefer forward scan.
+	return true, direction == rev
 }
 
 // GroupByDef defines the value of the Def private field of the GroupBy and

--- a/pkg/sql/opt/memo/private_defs_test.go
+++ b/pkg/sql/opt/memo/private_defs_test.go
@@ -51,25 +51,39 @@ func TestScanCanProvideOrdering(t *testing.T) {
 	testcases := []struct {
 		index    int
 		ordering string
-		expected bool
+		expected string // "no", "fwd", or "rev".
 	}{
-		{index: primary, ordering: "", expected: true},
-		{index: primary, ordering: "+1", expected: true},
-		{index: primary, ordering: "+1,+2", expected: false},
-		{index: altIndex1, ordering: "", expected: true},
-		{index: altIndex1, ordering: "+1 opt(2)", expected: true},
-		{index: altIndex1, ordering: "-2,+1", expected: false},
-		{index: altIndex2, ordering: "", expected: true},
-		{index: altIndex2, ordering: "-3,+(4|1)", expected: true},
-		{index: altIndex2, ordering: "-3,+4,+1", expected: true},
+		{index: primary, ordering: "", expected: "fwd"},
+		{index: primary, ordering: "+1", expected: "fwd"},
+		{index: primary, ordering: "-1", expected: "rev"},
+		{index: primary, ordering: "+1,+2", expected: "no"},
+		{index: primary, ordering: "-1,-2", expected: "no"},
+		{index: altIndex1, ordering: "", expected: "fwd"},
+		{index: altIndex1, ordering: "+1 opt(2)", expected: "fwd"},
+		{index: altIndex1, ordering: "-1 opt(2)", expected: "rev"},
+		{index: altIndex1, ordering: "-2,+1", expected: "no"},
+		{index: altIndex2, ordering: "", expected: "fwd"},
+		{index: altIndex2, ordering: "-3,+(4|1)", expected: "fwd"},
+		{index: altIndex2, ordering: "-3,+4,+1", expected: "fwd"},
+		{index: altIndex2, ordering: "+3,-4,-1", expected: "rev"},
+		{index: altIndex2, ordering: "+3,+4,+1", expected: "no"},
 	}
 
 	for _, tc := range testcases {
 		def := &memo.ScanOpDef{Table: a, Index: tc.index}
 		required := props.ParseOrderingChoice(tc.ordering)
-		actual := def.CanProvideOrdering(md, &required)
-		if actual != tc.expected {
-			t.Errorf("index: %d, required: %s, expected %v", tc.index, tc.ordering, tc.expected)
+		ok, reverse := def.CanProvideOrdering(md, &required)
+		res := "no"
+		if ok {
+			if reverse {
+				res = "rev"
+			} else {
+				res = "fwd"
+			}
+		}
+
+		if res != tc.expected {
+			t.Errorf("index: %d, required: %s, expected %v, got %v", tc.index, tc.ordering, tc.expected, res)
 		}
 	}
 }

--- a/pkg/sql/opt/memo/private_storage.go
+++ b/pkg/sql/opt/memo/private_storage.go
@@ -226,11 +226,6 @@ func (ps *privateStorage) internScanOpDef(def *ScanOpDef) PrivateID {
 	// The below code is carefully constructed to not allocate in the case where
 	// the value is already in the map. Be careful when modifying.
 	ps.keyBuf.Reset()
-	if def.Reverse {
-		ps.keyBuf.WriteByte(1)
-	} else {
-		ps.keyBuf.WriteByte(0)
-	}
 	ps.keyBuf.writeUvarint(uint64(def.Table))
 	ps.keyBuf.writeUvarint(uint64(def.Index))
 
@@ -238,7 +233,7 @@ func (ps *privateStorage) internScanOpDef(def *ScanOpDef) PrivateID {
 	// It's unclear if we have cases where we expect the same constraints to be
 	// generated multiple times.
 	ps.keyBuf.writeUvarint(uint64(uintptr(unsafe.Pointer(def.Constraint))))
-	ps.keyBuf.writeVarint(def.HardLimit)
+	ps.keyBuf.writeVarint(int64(def.HardLimit))
 	ps.keyBuf.writeColSet(def.Cols)
 
 	flags := 0

--- a/pkg/sql/opt/memo/private_storage_test.go
+++ b/pkg/sql/opt/memo/private_storage_test.go
@@ -138,9 +138,9 @@ func TestInternScanOpDef(t *testing.T) {
 	test(scanDef3, scanDef4, false)
 	scanDef5 := &ScanOpDef{Table: 1, Index: 2, Cols: util.MakeFastIntSet(1, 2)}
 	test(scanDef3, scanDef5, false)
-	scanDef6 := &ScanOpDef{Table: 1, Index: 2, Cols: util.MakeFastIntSet(1, 2), Reverse: true}
+	scanDef6 := &ScanOpDef{Table: 1, Index: 2, Cols: util.MakeFastIntSet(1, 2), HardLimit: 10}
 	test(scanDef5, scanDef6, false)
-	scanDef7 := &ScanOpDef{Table: 1, Index: 2, Cols: util.MakeFastIntSet(1, 2), HardLimit: 10}
+	scanDef7 := &ScanOpDef{Table: 1, Index: 2, Cols: util.MakeFastIntSet(1, 2), HardLimit: -10}
 	test(scanDef5, scanDef7, false)
 	scanDef8 := &ScanOpDef{Table: 1, Index: 2, Cols: util.MakeFastIntSet(1, 2), Flags: ScanFlags{NoIndexJoin: true}}
 	test(scanDef5, scanDef8, false)

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -389,8 +389,10 @@ func (sb *statisticsBuilder) colStatScan(colSet opt.ColSet, ev ExprView) *props.
 	sb.applySelectivityToColStat(colStat, s.Selectivity, inputStats.RowCount)
 
 	// Cap distinct count at limit, if it exists.
-	if def.HardLimit > 0 && float64(def.HardLimit) < s.RowCount {
-		colStat.DistinctCount = min(colStat.DistinctCount, float64(def.HardLimit))
+	if def.HardLimit.IsSet() {
+		if limit := float64(def.HardLimit.RowCount()); limit < s.RowCount {
+			colStat.DistinctCount = min(colStat.DistinctCount, limit)
+		}
 	}
 
 	return colStat

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -168,7 +168,7 @@ memo (optimized)
  │         └── cost: 41568.65
  ├── G5: (const 10)
  ├── G6: (plus G16 G17)
- ├── G7: (scan b,cols=(3)) (scan b,rev,cols=(3))
+ ├── G7: (scan b,cols=(3))
  │    └── ""
  │         ├── best: (scan b,cols=(3))
  │         └── cost: 1030.00
@@ -177,7 +177,7 @@ memo (optimized)
  │         ├── best: (select G10 G11)
  │         └── cost: 1050.00
  ├── G9: (filters G12)
- ├── G10: (scan a) (scan a,rev)
+ ├── G10: (scan a)
  │    └── ""
  │         ├── best: (scan a)
  │         └── cost: 1040.00
@@ -206,7 +206,7 @@ memo (optimized)
  │         ├── best: (select G4 G5)
  │         └── cost: 1050.00
  ├── G3: (projections G6 G7 G8 G9)
- ├── G4: (scan b) (scan b,rev)
+ ├── G4: (scan b)
  │    └── ""
  │         ├── best: (scan b)
  │         └── cost: 1040.00
@@ -234,38 +234,34 @@ memo (optimized)
  │    └── "[presentation: x:1]"
  │         ├── best: (project G2 G3)
  │         └── cost: 1.05
- ├── G2: (select G4 G5) (select G6 G8) (select G7 G8)
+ ├── G2: (select G4 G5) (select G6 G7)
  │    └── ""
- │         ├── best: (select G6 G8)
+ │         ├── best: (select G6 G7)
  │         └── cost: 1.05
  ├── G3: (projections a.x)
- ├── G4: (scan a) (scan a,rev)
+ ├── G4: (scan a)
  │    └── ""
  │         ├── best: (scan a)
  │         └── cost: 1040.00
- ├── G5: (filters G9 G10)
+ ├── G5: (filters G8 G9)
  ├── G6: (scan a,constrained)
  │    └── ""
  │         ├── best: (scan a,constrained)
  │         └── cost: 1.04
- ├── G7: (scan a,rev,constrained)
- │    └── ""
- │         ├── best: (scan a,rev,constrained)
- │         └── cost: 1.04
- ├── G8: (filters G10)
- ├── G9: (eq G13 G12)
- ├── G10: (eq G11 G12)
- ├── G11: (plus G13 G14)
- ├── G12: (const 1)
- ├── G13: (variable a.x)
- └── G14: (variable a.y)
+ ├── G7: (filters G9)
+ ├── G8: (eq G12 G11)
+ ├── G9: (eq G10 G11)
+ ├── G10: (plus G12 G13)
+ ├── G11: (const 1)
+ ├── G12: (variable a.x)
+ └── G13: (variable a.y)
 
 memo raw-memo
 SELECT x FROM a WHERE x = 1 AND x+y = 1
 ----
 root: G12, [presentation: x:1]
 memo (optimized)
- ├── G1: (scan a) (scan a,rev)
+ ├── G1: (scan a)
  │    └── ""
  │         ├── best: (scan a)
  │         └── cost: 1040.00
@@ -277,7 +273,7 @@ memo (optimized)
  ├── G7: (eq G6 G3)
  ├── G8: (and G4 G7)
  ├── G9: (filters G4 G7)
- ├── G10: (select G1 G9) (select G15 G14) (select G16 G14)
+ ├── G10: (select G1 G9) (select G15 G14)
  │    └── ""
  │         ├── best: (select G15 G14)
  │         └── cost: 1.05
@@ -288,13 +284,9 @@ memo (optimized)
  │         └── cost: 1.05
  ├── G13: (true)
  ├── G14: (filters G7)
- ├── G15: (scan a,constrained)
- │    └── ""
- │         ├── best: (scan a,constrained)
- │         └── cost: 1.04
- └── G16: (scan a,rev,constrained)
+ └── G15: (scan a,constrained)
       └── ""
-           ├── best: (scan a,rev,constrained)
+           ├── best: (scan a,constrained)
            └── cost: 1.04
 
 memo 
@@ -305,7 +297,7 @@ memo (optimized)
  │    └── "[presentation: x:7,y:8]"
  │         ├── best: (union G2 G3)
  │         └── cost: 2150.00
- ├── G2: (scan a) (scan a,rev)
+ ├── G2: (scan a)
  │    └── ""
  │         ├── best: (scan a)
  │         └── cost: 1040.00
@@ -313,7 +305,7 @@ memo (optimized)
  │    └── ""
  │         ├── best: (project G4 G5)
  │         └── cost: 1070.00
- ├── G4: (scan a) (scan a,rev)
+ ├── G4: (scan a)
  │    └── ""
  │         ├── best: (scan a)
  │         └── cost: 1040.00
@@ -332,7 +324,7 @@ memo (optimized)
  │    └── "[presentation: array_agg:3]"
  │         ├── best: (scalar-group-by G2 G3 cols=())
  │         └── cost: 1040.01
- ├── G2: (scan a,cols=(1)) (scan a,rev,cols=(1))
+ ├── G2: (scan a,cols=(1))
  │    └── ""
  │         ├── best: (scan a,cols=(1))
  │         └── cost: 1030.00
@@ -353,7 +345,7 @@ memo (optimized)
  │         ├── best: (group-by G4 G5 cols=(2))
  │         └── cost: 1067.00
  ├── G3: (projections array_agg)
- ├── G4: (scan a) (scan a,rev)
+ ├── G4: (scan a)
  │    └── ""
  │         ├── best: (scan a)
  │         └── cost: 1040.00
@@ -369,7 +361,7 @@ memo (optimized)
  │    └── "[presentation: array_agg:3]"
  │         ├── best: (scalar-group-by G2="[ordering: +2]" G3 cols=(),ordering=+2)
  │         └── cost: 1259.33
- ├── G2: (scan a) (scan a,rev)
+ ├── G2: (scan a)
  │    ├── ""
  │    │    ├── best: (scan a)
  │    │    └── cost: 1040.00

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -293,10 +293,15 @@ GenerateIndexScans (higher cost)
          │    ├── key: (1)
          │    ├── fd: (1)-->(2,4)
   -      │    ├── scan a
-  +      │    ├── scan a,rev
+  +      │    ├── index-join a
          │    │    ├── columns: k:1(int!null) i:2(int) s:4(string)
          │    │    ├── key: (1)
-         │    │    └── fd: (1)-->(2,4)
+  -      │    │    └── fd: (1)-->(2,4)
+  +      │    │    ├── fd: (1)-->(2,4)
+  +      │    │    └── scan a@secondary
+  +      │    │         ├── columns: k:1(int!null) s:4(string)
+  +      │    │         ├── key: (1)
+  +      │    │         └── fd: (1)-->(4)
          │    └── filters [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
          │         └── a.i = (10 - 1) [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
          ├── scan xy
@@ -308,39 +313,11 @@ GenerateIndexScans (higher cost)
 ConstrainScan (no changes)
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
-ConstrainScan (no changes)
---------------------------------------------------------------------------------
---------------------------------------------------------------------------------
 ConstrainIndexJoinScan (no changes)
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
-ConstrainIndexJoinScan (no changes)
+GenerateIndexScans (no changes)
 --------------------------------------------------------------------------------
---------------------------------------------------------------------------------
-GenerateIndexScans (higher cost)
---------------------------------------------------------------------------------
-   project
-    ├── columns: s:4(string)
-    └── inner-join
-         ├── columns: k:1(int!null) i:2(int!null) s:4(string) x:6(int!null)
-         ├── key: (6)
-         ├── fd: (1)-->(2,4), (1)==(6), (6)==(1)
-         ├── select
-         │    ├── columns: k:1(int!null) i:2(int!null) s:4(string)
-         │    ├── key: (1)
-         │    ├── fd: (1)-->(2,4)
-         │    ├── scan a
-         │    │    ├── columns: k:1(int!null) i:2(int) s:4(string)
-         │    │    ├── key: (1)
-         │    │    └── fd: (1)-->(2,4)
-         │    └── filters [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
-         │         └── a.i = (10 - 1) [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
-  -      ├── scan xy
-  +      ├── scan xy,rev
-         │    ├── columns: x:6(int!null)
-         │    └── key: (6)
-         └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-              └── a.k = xy.x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 ================================================================================
 CommuteJoin
   Cost: 2145.00
@@ -604,9 +581,6 @@ GenerateIndexScans
 --------------------------------------------------------------------------------
 ConstrainScan (no changes)
 --------------------------------------------------------------------------------
---------------------------------------------------------------------------------
-ConstrainScan (no changes)
---------------------------------------------------------------------------------
 ================================================================================
 ConstrainScan
   Cost: 1.55
@@ -655,19 +629,6 @@ SimplifyFilters
   -           ├── true [type=bool]
   -           └── true [type=bool]
   +      └── fd: ()-->(4), (1)-->(3), (3)-->(1)
---------------------------------------------------------------------------------
-ConstrainScan (higher cost)
---------------------------------------------------------------------------------
-   project
-    ├── columns: s:4(string!null) k:1(int!null)
-    ├── key: (1)
-    ├── fd: ()-->(4)
-  - └── scan a@secondary
-  + └── scan a@secondary,rev
-         ├── columns: k:1(int!null) f:3(float!null) s:4(string!null)
-         ├── constraint: /-4/3: [/'foo'/100.00000000000001 - /'foo']
-         ├── key: (1)
-         └── fd: ()-->(4), (1)-->(3), (3)-->(1)
 ================================================================================
 Final best expression
   Cost: 0.51
@@ -881,10 +842,15 @@ GenerateIndexScans (higher cost)
     ├── key: (1)
     ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
   - ├── scan a
-  + ├── scan a,rev
+  + ├── index-join a
     │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
     │    ├── key: (1)
-    │    └── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
+  - │    └── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
+  + │    ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
+  + │    └── scan a@secondary
+  + │         ├── columns: k:1(int!null) f:3(float) s:4(string) j:5(jsonb)
+  + │         ├── key: (1)
+  + │         └── fd: (1)-->(3-5), (3,4)~~>(1,5)
     ├── scan xy
     │    ├── columns: x:6(int!null) y:7(int)
     │    ├── key: (6)
@@ -892,24 +858,8 @@ GenerateIndexScans (higher cost)
     └── filters [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
          └── xy.y = a.i [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
 --------------------------------------------------------------------------------
-GenerateIndexScans (higher cost)
+GenerateIndexScans (no changes)
 --------------------------------------------------------------------------------
-   semi-join
-    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
-    ├── key: (1)
-    ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
-  - ├── scan a,rev
-  + ├── scan a
-    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
-    │    ├── key: (1)
-    │    └── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
-  - ├── scan xy
-  + ├── scan xy,rev
-    │    ├── columns: x:6(int!null) y:7(int)
-    │    ├── key: (6)
-    │    └── fd: (6)-->(7)
-    └── filters [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
-         └── xy.y = a.i [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
 --------------------------------------------------------------------------------
 GenerateMergeJoins (no changes)
 --------------------------------------------------------------------------------
@@ -1720,39 +1670,8 @@ InlineProjectInProject
   + └── projections [outer=(1,10)]
   +      └── CASE WHEN bool_or AND (xy.x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(1,10)]
 --------------------------------------------------------------------------------
-GenerateIndexScans (higher cost)
+GenerateIndexScans (no changes)
 --------------------------------------------------------------------------------
-   project
-    ├── columns: r:8(bool)
-    ├── group-by
-    │    ├── columns: x:1(int!null) bool_or:10(bool)
-    │    ├── grouping columns: x:1(int!null)
-    │    ├── key: (1)
-    │    ├── fd: (1)-->(10)
-    │    ├── left-join
-    │    │    ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
-    │    │    ├── key: (1,3)
-    │    │    ├── fd: (3)-->(9)
-  - │    │    ├── scan xy
-  + │    │    ├── scan xy,rev
-    │    │    │    ├── columns: x:1(int!null)
-    │    │    │    └── key: (1)
-    │    │    ├── project
-    │    │    │    ├── columns: notnull:9(bool) k:3(int!null)
-    │    │    │    ├── key: (3)
-    │    │    │    ├── fd: (3)-->(9)
-    │    │    │    ├── scan a
-    │    │    │    │    ├── columns: k:3(int!null)
-    │    │    │    │    └── key: (3)
-    │    │    │    └── projections [outer=(3)]
-    │    │    │         └── a.k IS NOT NULL [type=bool, outer=(3)]
-    │    │    └── filters [type=bool, outer=(1,3)]
-    │    │         └── (xy.x = a.k) IS NOT false [type=bool, outer=(1,3)]
-    │    └── aggregations [outer=(9)]
-    │         └── bool-or [type=bool, outer=(9)]
-    │              └── variable: notnull [type=bool, outer=(9)]
-    └── projections [outer=(1,10)]
-         └── CASE WHEN bool_or AND (xy.x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(1,10)]
 ================================================================================
 GenerateIndexScans
   Cost: 12160.00

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -25,6 +25,10 @@
 # the table's indexes according to its ordering. The private Def field is an
 # *opt.ScanOpDef that identifies the table and index to scan, as well as the
 # subset of columns to project from it.
+#
+# The scan can be constrained and/or have an internal row limit. A scan can be
+# executed either as a forward or as a reverse scan (except when it has a limit,
+# in which case the direction is fixed).
 [Relational]
 define Scan {
     Def ScanOpDef

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -2815,13 +2815,12 @@ SELECT array_agg(y) FROM (SELECT * FROM xyz ORDER BY x DESC)
 scalar-group-by
  ├── columns: array_agg:4(int[])
  ├── internal-ordering: -1
- ├── sort
+ ├── project
  │    ├── columns: x:1(int!null) y:2(int)
  │    ├── ordering: -1
- │    └── project
- │         ├── columns: x:1(int!null) y:2(int)
- │         └── scan xyz
- │              └── columns: x:1(int!null) y:2(int) z:3(float)
+ │    └── scan xyz,rev
+ │         ├── columns: x:1(int!null) y:2(int) z:3(float)
+ │         └── ordering: -1
  └── aggregations
       └── array-agg [type=int[]]
            └── variable: xyz.y [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -77,13 +77,12 @@ limit
 build
 SELECT a FROM t ORDER BY 1 DESC
 ----
-sort
+project
  ├── columns: a:1(int!null)
  ├── ordering: -1
- └── project
-      ├── columns: a:1(int!null)
-      └── scan t
-           └── columns: a:1(int!null) b:2(int) c:3(bool)
+ └── scan t,rev
+      ├── columns: a:1(int!null) b:2(int) c:3(bool)
+      └── ordering: -1
 
 # TODO(rytaft): This query causes an error in Postgres, but it is supported by
 # CockroachDB with the semantics:
@@ -97,13 +96,12 @@ error (42P10): for SELECT DISTINCT, ORDER BY expressions must appear in select l
 build
 SELECT a AS foo, b FROM t ORDER BY foo DESC
 ----
-sort
+project
  ├── columns: foo:1(int!null) b:2(int)
  ├── ordering: -1
- └── project
-      ├── columns: a:1(int!null) b:2(int)
-      └── scan t
-           └── columns: a:1(int!null) b:2(int) c:3(bool)
+ └── scan t,rev
+      ├── columns: a:1(int!null) b:2(int) c:3(bool)
+      └── ordering: -1
 
 # Check that ambiguous references to renders are properly reported.
 build
@@ -143,35 +141,32 @@ project
 build
 SELECT a AS "foo.bar", b FROM t ORDER BY "foo.bar" DESC
 ----
-sort
+project
  ├── columns: bar:1(int!null) b:2(int)
  ├── ordering: -1
- └── project
-      ├── columns: a:1(int!null) b:2(int)
-      └── scan t
-           └── columns: a:1(int!null) b:2(int) c:3(bool)
+ └── scan t,rev
+      ├── columns: a:1(int!null) b:2(int) c:3(bool)
+      └── ordering: -1
 
 build
 SELECT a AS foo, b FROM t ORDER BY a DESC
 ----
-sort
+project
  ├── columns: foo:1(int!null) b:2(int)
  ├── ordering: -1
- └── project
-      ├── columns: a:1(int!null) b:2(int)
-      └── scan t
-           └── columns: a:1(int!null) b:2(int) c:3(bool)
+ └── scan t,rev
+      ├── columns: a:1(int!null) b:2(int) c:3(bool)
+      └── ordering: -1
 
 build
 SELECT b FROM t ORDER BY a DESC
 ----
-sort
+project
  ├── columns: b:2(int)
  ├── ordering: -1
- └── project
-      ├── columns: a:1(int!null) b:2(int)
-      └── scan t
-           └── columns: a:1(int!null) b:2(int) c:3(bool)
+ └── scan t,rev
+      ├── columns: a:1(int!null) b:2(int) c:3(bool)
+      └── ordering: -1
 
 build
 SELECT b FROM t ORDER BY a LIMIT 1
@@ -337,13 +332,12 @@ limit
  ├── columns: a:1(int!null)
  ├── internal-ordering: -1
  ├── ordering: -1
- ├── sort
+ ├── project
  │    ├── columns: a:1(int!null)
  │    ├── ordering: -1
- │    └── project
- │         ├── columns: a:1(int!null)
- │         └── scan t
- │              └── columns: a:1(int!null) b:2(int) c:3(bool)
+ │    └── scan t,rev
+ │         ├── columns: a:1(int!null) b:2(int) c:3(bool)
+ │         └── ordering: -1
  └── const: 4 [type=int]
 
 build
@@ -353,13 +347,12 @@ limit
  ├── columns: a:1(int!null)
  ├── internal-ordering: -1
  ├── ordering: -1
- ├── sort
+ ├── project
  │    ├── columns: a:1(int!null)
  │    ├── ordering: -1
- │    └── project
- │         ├── columns: a:1(int!null)
- │         └── scan t
- │              └── columns: a:1(int!null) b:2(int) c:3(bool)
+ │    └── scan t,rev
+ │         ├── columns: a:1(int!null) b:2(int) c:3(bool)
+ │         └── ordering: -1
  └── const: 4 [type=int]
 
 build
@@ -671,13 +664,12 @@ sort
 build
 SELECT a FROM abc ORDER BY a DESC
 ----
-sort
+project
  ├── columns: a:1(int!null)
  ├── ordering: -1
- └── project
-      ├── columns: a:1(int!null)
-      └── scan abc
-           └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+ └── scan abc,rev
+      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+      └── ordering: -1
 
 build
 SELECT a FROM abc ORDER BY a DESC LIMIT 1
@@ -686,13 +678,12 @@ limit
  ├── columns: a:1(int!null)
  ├── internal-ordering: -1
  ├── ordering: -1
- ├── sort
+ ├── project
  │    ├── columns: a:1(int!null)
  │    ├── ordering: -1
- │    └── project
- │         ├── columns: a:1(int!null)
- │         └── scan abc
- │              └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+ │    └── scan abc,rev
+ │         ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+ │         └── ordering: -1
  └── const: 1 [type=int]
 
 build
@@ -702,13 +693,12 @@ offset
  ├── columns: a:1(int!null)
  ├── internal-ordering: -1
  ├── ordering: -1
- ├── sort
+ ├── project
  │    ├── columns: a:1(int!null)
  │    ├── ordering: -1
- │    └── project
- │         ├── columns: a:1(int!null)
- │         └── scan abc
- │              └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+ │    └── scan abc,rev
+ │         ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+ │         └── ordering: -1
  └── const: 1 [type=int]
 
 build

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -179,7 +179,9 @@ func (c *coster) computeScanCost(candidate *memo.BestExpr, logical *props.Logica
 	}
 	rowCount := logical.Relational.Stats.RowCount
 	perRowCost := c.rowScanCost(def.Table, def.Index, def.Cols.Len())
-	if def.Reverse {
+
+	props := c.mem.LookupPhysicalProps(candidate.Required())
+	if _, reverse := def.CanProvideOrdering(c.mem.Metadata(), &props.Ordering); reverse {
 		if rowCount > 1 {
 			// Need to do binary search to seek to the previous row.
 			perRowCost += memo.Cost(math.Log2(rowCount)) * cpuCostFactor

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -92,7 +92,8 @@ func (o *Optimizer) canProvideOrdering(eid memo.ExprID, required *props.Ordering
 	case opt.ScanOp:
 		// Scan naturally orders according to the order of the scanned index.
 		def := mexpr.Private(o.mem).(*memo.ScanOpDef)
-		return def.CanProvideOrdering(o.mem.Metadata(), required)
+		ok, _ := def.CanProvideOrdering(o.mem.Metadata(), required)
+		return ok
 
 	case opt.RowNumberOp:
 		def := mexpr.Private(o.mem).(*memo.RowNumberDef)

--- a/pkg/sql/opt/xform/rules/limit.opt
+++ b/pkg/sql/opt/xform/rules/limit.opt
@@ -15,7 +15,7 @@
 )
 =>
 (Scan
-    (LimitScanDef $def $limit)
+    (LimitScanDef $def $limit $ordering)
 )
 
 # PushLimitIntoIndexJoin pushes a limit through an index join.

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -754,7 +754,7 @@ project
       └── scan order@secondary,rev
            ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_c_id:4(int!null)
            ├── constraint: /3/2/4/1: [/10/100/50 - /10/100/50]
-           ├── limit: 1
+           ├── limit: 1(rev)
            ├── stats: [rows=6.80272109e-07]
            ├── cost: 7.34693878e-07
            ├── key: ()
@@ -816,7 +816,7 @@ project
  └── scan new_order,rev
       ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
       ├── constraint: /3/2/-1: [/10/100 - /10/100]
-      ├── limit: 1
+      ├── limit: 1(rev)
       ├── stats: [rows=0.142857143]
       ├── cost: 0.151428571
       ├── key: ()

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -559,7 +559,7 @@ project
       └── scan order@secondary,rev
            ├── columns: "order".o_id:1(int!null) "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) "order".o_c_id:4(int!null)
            ├── constraint: /3/2/4/1: [/10/100/50 - /10/100/50]
-           ├── limit: 1
+           ├── limit: 1(rev)
            ├── stats: [rows=2.9154519e-06]
            ├── cost: 3.14868805e-06
            ├── key: ()
@@ -621,7 +621,7 @@ project
  └── scan new_order,rev
       ├── columns: new_order.no_o_id:1(int!null) new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
       ├── constraint: /3/2/-1: [/10/100 - /10/100]
-      ├── limit: 1
+      ├── limit: 1(rev)
       ├── stats: [rows=0.00204081633]
       ├── cost: 0.00216326531
       ├── key: ()

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -182,7 +182,7 @@ memo (optimized)
  │         ├── best: (select G4="[ordering: +1,-2]" G5)
  │         └── cost: 1070.00
  ├── G3: (projections G6 a.x a.y)
- ├── G4: (scan a,cols=(1,2)) (scan a,rev,cols=(1,2))
+ ├── G4: (scan a,cols=(1,2))
  │    ├── ""
  │    │    ├── best: (scan a,cols=(1,2))
  │    │    └── cost: 1060.00
@@ -231,7 +231,7 @@ memo (optimized)
  │         ├── best: (sort G2)
  │         └── cost: 1096.21
  ├── G3: (projections a.y a.z)
- ├── G4: (scan a,cols=(1-3)) (scan a,rev,cols=(1-3))
+ ├── G4: (scan a,cols=(1-3))
  │    ├── ""
  │    │    ├── best: (scan a,cols=(1-3))
  │    │    └── cost: 1070.00
@@ -296,7 +296,7 @@ memo (optimized)
  │    └── "[presentation: tree:5,field:8,description:9,columns:10,ordering:11]"
  │         ├── best: (explain G2="[presentation: x:1,y:2,z:3,s:4] [ordering: +2]" [presentation: x:1,y:2,z:3,s:4] [ordering: +2])
  │         └── cost: 1289.32
- └── G2: (scan a) (scan a,rev)
+ └── G2: (scan a)
       ├── ""
       │    ├── best: (scan a)
       │    └── cost: 1080.00
@@ -319,7 +319,7 @@ memo (optimized)
  │    └── ""
  │         ├── best: (row-number G2)
  │         └── cost: 1060.00
- └── G2: (scan a,cols=(2)) (scan a,rev,cols=(2))
+ └── G2: (scan a,cols=(2))
       └── ""
            ├── best: (scan a,cols=(2))
            └── cost: 1050.00
@@ -340,7 +340,7 @@ memo (optimized)
  │         ├── best: (row-number G4)
  │         └── cost: 1060.00
  ├── G3: (projections G5 a.y)
- ├── G4: (scan a,cols=(2)) (scan a,rev,cols=(2))
+ ├── G4: (scan a,cols=(2))
  │    └── ""
  │         ├── best: (scan a,cols=(2))
  │         └── cost: 1050.00
@@ -358,7 +358,7 @@ memo (optimized)
  │    └── ""
  │         ├── best: (row-number G2)
  │         └── cost: 1060.00
- └── G2: (scan a,cols=(2)) (scan a,rev,cols=(2))
+ └── G2: (scan a,cols=(2))
       └── ""
            ├── best: (scan a,cols=(2))
            └── cost: 1050.00
@@ -374,7 +374,7 @@ memo (optimized)
  │    └── ""
  │         ├── best: (row-number G2="[ordering: +2]" ordering=+2)
  │         └── cost: 1269.32
- └── G2: (scan a,cols=(2)) (scan a,rev,cols=(2))
+ └── G2: (scan a,cols=(2))
       ├── ""
       │    ├── best: (scan a,cols=(2))
       │    └── cost: 1050.00
@@ -393,7 +393,7 @@ memo (optimized)
  │    └── ""
  │         ├── best: (row-number G2="[ordering: +2]" ordering=+2)
  │         └── cost: 1269.32
- └── G2: (scan a,cols=(2)) (scan a,rev,cols=(2))
+ └── G2: (scan a,cols=(2))
       ├── ""
       │    ├── best: (scan a,cols=(2))
       │    └── cost: 1050.00
@@ -412,7 +412,7 @@ memo (optimized)
  │    └── ""
  │         ├── best: (row-number G2)
  │         └── cost: 1060.00
- └── G2: (scan a,cols=(2)) (scan a,rev,cols=(2))
+ └── G2: (scan a,cols=(2))
       └── ""
            ├── best: (scan a,cols=(2))
            └── cost: 1050.00

--- a/pkg/sql/opt/xform/testdata/rules/combo
+++ b/pkg/sql/opt/xform/testdata/rules/combo
@@ -64,35 +64,11 @@ Source expression:
         ├── abc.a = xyz.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
         └── abc.b = xyz.y [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
 
-New expression 1 of 3:
-  inner-join
-   ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
-   ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
-   ├── scan abc,rev
-   │    └── columns: a:1(int) b:2(int) c:3(int)
-   ├── scan xyz
-   │    └── columns: x:5(int) y:6(int) z:7(int)
-   └── filters [type=bool, outer=(1,2,5,6), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /5: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(5), (5)==(1), (2)==(6), (6)==(2)]
-        ├── abc.a = xyz.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
-        └── abc.b = xyz.y [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
-
-New expression 2 of 3:
+New expression 1 of 1:
   inner-join
    ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
    ├── scan abc@ab
-   │    └── columns: a:1(int) b:2(int) c:3(int)
-   ├── scan xyz
-   │    └── columns: x:5(int) y:6(int) z:7(int)
-   └── filters [type=bool, outer=(1,2,5,6), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /5: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(5), (5)==(1), (2)==(6), (6)==(2)]
-        ├── abc.a = xyz.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
-        └── abc.b = xyz.y [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
-
-New expression 3 of 3:
-  inner-join
-   ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
-   ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
-   ├── scan abc@ab,rev
    │    └── columns: a:1(int) b:2(int) c:3(int)
    ├── scan xyz
    │    └── columns: x:5(int) y:6(int) z:7(int)
@@ -115,37 +91,13 @@ Source expression:
         ├── abc.a = xyz.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
         └── abc.b = xyz.y [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
 
-New expression 1 of 3:
-  inner-join
-   ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
-   ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
-   ├── scan abc
-   │    └── columns: a:1(int) b:2(int) c:3(int)
-   ├── scan xyz,rev
-   │    └── columns: x:5(int) y:6(int) z:7(int)
-   └── filters [type=bool, outer=(1,2,5,6), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /5: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(5), (5)==(1), (2)==(6), (6)==(2)]
-        ├── abc.a = xyz.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
-        └── abc.b = xyz.y [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
-
-New expression 2 of 3:
+New expression 1 of 1:
   inner-join
    ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
    ├── scan abc
    │    └── columns: a:1(int) b:2(int) c:3(int)
    ├── scan xyz@xy
-   │    └── columns: x:5(int) y:6(int) z:7(int)
-   └── filters [type=bool, outer=(1,2,5,6), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /5: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(5), (5)==(1), (2)==(6), (6)==(2)]
-        ├── abc.a = xyz.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
-        └── abc.b = xyz.y [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
-
-New expression 3 of 3:
-  inner-join
-   ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
-   ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
-   ├── scan abc
-   │    └── columns: a:1(int) b:2(int) c:3(int)
-   ├── scan xyz@xy,rev
    │    └── columns: x:5(int) y:6(int) z:7(int)
    └── filters [type=bool, outer=(1,2,5,6), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /5: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(5), (5)==(1), (2)==(6), (6)==(2)]
         ├── abc.a = xyz.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -128,7 +128,7 @@ scalar-group-by
  ├── scan xyz@zyx,rev
  │    ├── columns: y:2(int!null) z:3(float!null)
  │    ├── constraint: /3/2/1: (/7.0/NULL - /7.0]
- │    ├── limit: 1
+ │    ├── limit: 1(rev)
  │    ├── key: ()
  │    └── fd: ()-->(2,3)
  └── aggregations [outer=(2)]
@@ -185,7 +185,7 @@ scalar-group-by
  ├── fd: ()-->(4)
  ├── scan xyz@xy,rev
  │    ├── columns: x:1(int!null)
- │    ├── limit: 1
+ │    ├── limit: 1(rev)
  │    ├── key: ()
  │    └── fd: ()-->(1)
  └── aggregations [outer=(1)]
@@ -238,7 +238,7 @@ scalar-group-by
  ├── scan xyz@xy,rev
  │    ├── columns: x:1(int!null)
  │    ├── constraint: /1/2: [/0 - /0] [/4 - /4] [/7 - /7]
- │    ├── limit: 1
+ │    ├── limit: 1(rev)
  │    ├── key: ()
  │    └── fd: ()-->(1)
  └── aggregations [outer=(1)]
@@ -473,7 +473,7 @@ memo (optimized)
  │         └── cost: 1.05
  ├── G4: (aggregations G8)
  ├── G5: (min G9)
- ├── G6: (scan abc,cols=(1)) (scan abc,rev,cols=(1))
+ ├── G6: (scan abc,cols=(1))
  │    ├── ""
  │    │    ├── best: (scan abc,cols=(1))
  │    │    └── cost: 1050.00
@@ -508,7 +508,7 @@ memo (optimized)
  │         └── cost: 1119.21
  ├── G7: (const 1)
  ├── G8: (const-agg G12)
- ├── G9: (scan abc,cols=(2)) (scan abc,rev,cols=(2))
+ ├── G9: (scan abc,cols=(2))
  │    ├── ""
  │    │    ├── best: (scan abc,cols=(2))
  │    │    └── cost: 1050.00
@@ -529,13 +529,13 @@ memo (optimized)
  │         ├── best: (scalar-group-by G3 G4 cols=())
  │         └── cost: 1.07
  ├── G2: (aggregations G5)
- ├── G3: (limit G6 G7 ordering=-1) (scan abc,rev,cols=(1),lim=1)
+ ├── G3: (limit G6 G7 ordering=-1) (scan abc,rev,cols=(1),lim=1(rev))
  │    └── ""
- │         ├── best: (scan abc,rev,cols=(1),lim=1)
+ │         ├── best: (scan abc,rev,cols=(1),lim=1(rev))
  │         └── cost: 1.05
  ├── G4: (aggregations G8)
  ├── G5: (max G9)
- ├── G6: (scan abc,cols=(1)) (scan abc,rev,cols=(1))
+ ├── G6: (scan abc,cols=(1))
  │    ├── ""
  │    │    ├── best: (scan abc,cols=(1))
  │    │    └── cost: 1050.00
@@ -570,7 +570,7 @@ memo (optimized)
  │         └── cost: 1119.21
  ├── G7: (const 1)
  ├── G8: (const-agg G12)
- ├── G9: (scan abc,cols=(2)) (scan abc,rev,cols=(2))
+ ├── G9: (scan abc,cols=(2))
  │    ├── ""
  │    │    ├── best: (scan abc,cols=(2))
  │    │    └── cost: 1050.00
@@ -596,7 +596,7 @@ scalar-group-by
  ├── fd: ()-->(5)
  ├── scan abc,rev
  │    ├── columns: a:1(string!null)
- │    ├── limit: 1
+ │    ├── limit: 1(rev)
  │    ├── key: ()
  │    └── fd: ()-->(1)
  └── aggregations [outer=(1)]
@@ -614,7 +614,7 @@ scalar-group-by
  ├── fd: ()-->(5)
  ├── scan abc,rev
  │    ├── columns: a:1(string!null)
- │    ├── limit: 1
+ │    ├── limit: 1(rev)
  │    ├── key: ()
  │    └── fd: ()-->(1)
  └── aggregations [outer=(1)]
@@ -659,7 +659,7 @@ memo (optimized)
  │         └── cost: 1119.21
  ├── G7: (const 1)
  ├── G8: (const-agg G12)
- ├── G9: (scan abc,cols=(2)) (scan abc,rev,cols=(2))
+ ├── G9: (scan abc,cols=(2))
  │    ├── ""
  │    │    ├── best: (scan abc,cols=(2))
  │    │    └── cost: 1050.00

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -91,7 +91,7 @@ memo (optimized)
  │    └── "[presentation: a:1,b:2,c:3,x:5,y:6,z:7]"
  │         ├── best: (inner-join G2 G4 G5)
  │         └── cost: 2184.29
- ├── G2: (scan abc,cols=(1-3)) (scan abc,rev,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@ab,rev,cols=(1-3)) (scan abc@bc,cols=(1-3)) (scan abc@bc,rev,cols=(1-3))
+ ├── G2: (scan abc,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@bc,cols=(1-3))
  │    ├── ""
  │    │    ├── best: (scan abc,cols=(1-3))
  │    │    └── cost: 1070.00
@@ -99,7 +99,7 @@ memo (optimized)
  │         ├── best: (scan abc@ab,cols=(1-3))
  │         └── cost: 1070.00
  ├── G3: (merge-on G5 inner-join,+1,+7)
- ├── G4: (scan xyz,cols=(5-7)) (scan xyz,rev,cols=(5-7)) (scan xyz@xy,cols=(5-7)) (scan xyz@xy,rev,cols=(5-7)) (scan xyz@yz,cols=(5-7)) (scan xyz@yz,rev,cols=(5-7))
+ ├── G4: (scan xyz,cols=(5-7)) (scan xyz@xy,cols=(5-7)) (scan xyz@yz,cols=(5-7))
  │    ├── ""
  │    │    ├── best: (scan xyz,cols=(5-7))
  │    │    └── cost: 1070.00
@@ -119,14 +119,14 @@ memo (optimized)
  │    └── "[presentation: a:1,b:2,c:3,x:5,y:6,z:7]"
  │         ├── best: (full-join G2 G3 G5)
  │         └── cost: 2184.29
- ├── G2: (scan abc,cols=(1-3)) (scan abc,rev,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@ab,rev,cols=(1-3)) (scan abc@bc,cols=(1-3)) (scan abc@bc,rev,cols=(1-3))
+ ├── G2: (scan abc,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@bc,cols=(1-3))
  │    ├── ""
  │    │    ├── best: (scan abc,cols=(1-3))
  │    │    └── cost: 1070.00
  │    └── "[ordering: +1]"
  │         ├── best: (scan abc@ab,cols=(1-3))
  │         └── cost: 1070.00
- ├── G3: (scan xyz,cols=(5-7)) (scan xyz,rev,cols=(5-7)) (scan xyz@xy,cols=(5-7)) (scan xyz@xy,rev,cols=(5-7)) (scan xyz@yz,cols=(5-7)) (scan xyz@yz,rev,cols=(5-7))
+ ├── G3: (scan xyz,cols=(5-7)) (scan xyz@xy,cols=(5-7)) (scan xyz@yz,cols=(5-7))
  │    ├── ""
  │    │    ├── best: (scan xyz,cols=(5-7))
  │    │    └── cost: 1070.00
@@ -186,14 +186,14 @@ memo (optimized)
  │    └── "[presentation: a:1,b:2,c:3,x:5,y:6,z:7]"
  │         ├── best: (left-join G2 G3 G5)
  │         └── cost: 2184.29
- ├── G2: (scan abc,cols=(1-3)) (scan abc,rev,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@ab,rev,cols=(1-3)) (scan abc@bc,cols=(1-3)) (scan abc@bc,rev,cols=(1-3))
+ ├── G2: (scan abc,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@bc,cols=(1-3))
  │    ├── ""
  │    │    ├── best: (scan abc,cols=(1-3))
  │    │    └── cost: 1070.00
  │    └── "[ordering: +1]"
  │         ├── best: (scan abc@ab,cols=(1-3))
  │         └── cost: 1070.00
- ├── G3: (scan xyz,cols=(5-7)) (scan xyz,rev,cols=(5-7)) (scan xyz@xy,cols=(5-7)) (scan xyz@xy,rev,cols=(5-7)) (scan xyz@yz,cols=(5-7)) (scan xyz@yz,rev,cols=(5-7))
+ ├── G3: (scan xyz,cols=(5-7)) (scan xyz@xy,cols=(5-7)) (scan xyz@yz,cols=(5-7))
  │    ├── ""
  │    │    ├── best: (scan xyz,cols=(5-7))
  │    │    └── cost: 1070.00
@@ -233,7 +233,7 @@ memo (optimized)
  │    └── "[presentation: a:1,b:2,c:3,x:5,y:6,z:7]"
  │         ├── best: (right-join G2 G4 G5)
  │         └── cost: 2184.29
- ├── G2: (scan abc,cols=(1-3)) (scan abc,rev,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@ab,rev,cols=(1-3)) (scan abc@bc,cols=(1-3)) (scan abc@bc,rev,cols=(1-3))
+ ├── G2: (scan abc,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@bc,cols=(1-3))
  │    ├── ""
  │    │    ├── best: (scan abc,cols=(1-3))
  │    │    └── cost: 1070.00
@@ -241,7 +241,7 @@ memo (optimized)
  │         ├── best: (scan abc@ab,cols=(1-3))
  │         └── cost: 1070.00
  ├── G3: (merge-on G5 right-join,+1,+7)
- ├── G4: (scan xyz,cols=(5-7)) (scan xyz,rev,cols=(5-7)) (scan xyz@xy,cols=(5-7)) (scan xyz@xy,rev,cols=(5-7)) (scan xyz@yz,cols=(5-7)) (scan xyz@yz,rev,cols=(5-7))
+ ├── G4: (scan xyz,cols=(5-7)) (scan xyz@xy,cols=(5-7)) (scan xyz@yz,cols=(5-7))
  │    ├── ""
  │    │    ├── best: (scan xyz,cols=(5-7))
  │    │    └── cost: 1070.00
@@ -299,7 +299,7 @@ memo (optimized)
  │         ├── best: (merge-join G3="[ordering: +1]" G5="[ordering: +5]" G2)
  │         └── cost: 2174.29
  ├── G2: (merge-on G6 inner-join,+1,+5)
- ├── G3: (scan abc,cols=(1-3)) (scan abc,rev,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@ab,rev,cols=(1-3)) (scan abc@bc,cols=(1-3)) (scan abc@bc,rev,cols=(1-3))
+ ├── G3: (scan abc,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@bc,cols=(1-3))
  │    ├── ""
  │    │    ├── best: (scan abc,cols=(1-3))
  │    │    └── cost: 1070.00
@@ -307,7 +307,7 @@ memo (optimized)
  │         ├── best: (scan abc@ab,cols=(1-3))
  │         └── cost: 1070.00
  ├── G4: (merge-on G6 inner-join,+5,+1)
- ├── G5: (scan xyz,cols=(5-7)) (scan xyz,rev,cols=(5-7)) (scan xyz@xy,cols=(5-7)) (scan xyz@xy,rev,cols=(5-7)) (scan xyz@yz,cols=(5-7)) (scan xyz@yz,rev,cols=(5-7))
+ ├── G5: (scan xyz,cols=(5-7)) (scan xyz@xy,cols=(5-7)) (scan xyz@yz,cols=(5-7))
  │    ├── ""
  │    │    ├── best: (scan xyz,cols=(5-7))
  │    │    └── cost: 1070.00
@@ -389,7 +389,7 @@ memo (optimized)
  ├── G2: (merge-on G8 inner-join,+1,+2,+3,+4,+5,+6)
  ├── G3: (merge-on G8 inner-join,+3,+2,+1,+6,+5,+4)
  ├── G4: (merge-on G8 inner-join,+4,+5,+6,+1,+2,+3)
- ├── G5: (scan stu) (scan stu,rev) (scan stu@uts) (scan stu@uts,rev)
+ ├── G5: (scan stu) (scan stu@uts)
  │    ├── ""
  │    │    ├── best: (scan stu)
  │    │    └── cost: 1060.00
@@ -400,7 +400,7 @@ memo (optimized)
  │         ├── best: (scan stu@uts)
  │         └── cost: 1060.00
  ├── G6: (merge-on G8 inner-join,+6,+5,+4,+3,+2,+1)
- ├── G7: (scan stu) (scan stu,rev) (scan stu@uts) (scan stu@uts,rev)
+ ├── G7: (scan stu) (scan stu@uts)
  │    ├── ""
  │    │    ├── best: (scan stu)
  │    │    └── cost: 1060.00
@@ -616,16 +616,16 @@ memo (optimized)
  │    └── "[presentation: a:1,b:2,c:3,x:5,y:6,z:7]"
  │         ├── best: (inner-join G2 G3 G4)
  │         └── cost: 1456.81
- ├── G2: (scan xyz,cols=(5-7)) (scan xyz,rev,cols=(5-7)) (scan xyz@xy,cols=(5-7)) (scan xyz@xy,rev,cols=(5-7)) (scan xyz@yz,cols=(5-7)) (scan xyz@yz,rev,cols=(5-7))
+ ├── G2: (scan xyz,cols=(5-7)) (scan xyz@xy,cols=(5-7)) (scan xyz@yz,cols=(5-7))
  │    └── ""
  │         ├── best: (scan xyz,cols=(5-7))
  │         └── cost: 1070.00
- ├── G3: (select G5 G10) (select G6 G10) (select G7 G10) (select G8 G10) (select G9 G10)
+ ├── G3: (select G5 G8) (select G6 G8) (select G7 G8)
  │    └── ""
- │         ├── best: (select G6 G10)
+ │         ├── best: (select G6 G8)
  │         └── cost: 360.00
  ├── G4: (true)
- ├── G5: (scan abc,cols=(1-3)) (scan abc,rev,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@ab,rev,cols=(1-3)) (scan abc@bc,cols=(1-3)) (scan abc@bc,rev,cols=(1-3))
+ ├── G5: (scan abc,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@bc,cols=(1-3))
  │    └── ""
  │         ├── best: (scan abc,cols=(1-3))
  │         └── cost: 1070.00
@@ -633,22 +633,14 @@ memo (optimized)
  │    └── ""
  │         ├── best: (scan abc@ab,cols=(1-3),constrained)
  │         └── cost: 356.67
- ├── G7: (scan abc@ab,rev,cols=(1-3),constrained)
- │    └── ""
- │         ├── best: (scan abc@ab,rev,cols=(1-3),constrained)
- │         └── cost: 384.60
- ├── G8: (scan abc@bc,cols=(1-3),constrained)
+ ├── G7: (scan abc@bc,cols=(1-3),constrained)
  │    └── ""
  │         ├── best: (scan abc@bc,cols=(1-3),constrained)
  │         └── cost: 356.67
- ├── G9: (scan abc@bc,rev,cols=(1-3),constrained)
- │    └── ""
- │         ├── best: (scan abc@bc,rev,cols=(1-3),constrained)
- │         └── cost: 384.60
- ├── G10: (filters G11)
- ├── G11: (eq G12 G13)
- ├── G12: (variable abc.a)
- └── G13: (variable abc.b)
+ ├── G8: (filters G9)
+ ├── G9: (eq G10 G11)
+ ├── G10: (variable abc.a)
+ └── G11: (variable abc.b)
 
 exec-ddl
 CREATE TABLE kfloat (k FLOAT PRIMARY KEY)
@@ -666,11 +658,11 @@ memo (optimized)
  │    └── "[presentation: a:1,b:2,c:3,k:5]"
  │         ├── best: (inner-join G3 G2 G4)
  │         └── cost: 2130.00
- ├── G2: (scan kfloat) (scan kfloat,rev)
+ ├── G2: (scan kfloat)
  │    └── ""
  │         ├── best: (scan kfloat)
  │         └── cost: 1020.00
- ├── G3: (scan abc,cols=(1-3)) (scan abc,rev,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@ab,rev,cols=(1-3)) (scan abc@bc,cols=(1-3)) (scan abc@bc,rev,cols=(1-3))
+ ├── G3: (scan abc,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@bc,cols=(1-3))
  │    └── ""
  │         ├── best: (scan abc,cols=(1-3))
  │         └── cost: 1070.00
@@ -1250,40 +1242,6 @@ New expression 1 of 1:
    │    ├── scan abc
    │    │    └── columns: a:1(int) b:2(int) c:3(int)
    │    ├── scan uvw@v
-   │    │    ├── columns: u:5(int!null) v:6(int)
-   │    │    ├── key: (5)
-   │    │    └── fd: (5)-->(6)
-   │    └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
-   │         └── abc.a = uvw.u [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
-   └── true [type=bool]
-
-================================================================================
-PushJoinThroughIndexJoin
-================================================================================
-Source expression:
-  inner-join
-   ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int) w:7(int)
-   ├── fd: (5)-->(6,7), (1)==(5), (5)==(1)
-   ├── scan abc
-   │    └── columns: a:1(int) b:2(int) c:3(int)
-   ├── scan uvw
-   │    ├── columns: u:5(int!null) v:6(int) w:7(int)
-   │    ├── key: (5)
-   │    └── fd: (5)-->(6,7)
-   └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
-        └── abc.a = uvw.u [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
-
-New expression 1 of 1:
-  inner-join (lookup uvw)
-   ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int) w:7(int)
-   ├── key columns: [5] = [5]
-   ├── fd: (5)-->(6,7), (1)==(5), (5)==(1)
-   ├── inner-join
-   │    ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int)
-   │    ├── fd: (5)-->(6), (1)==(5), (5)==(1)
-   │    ├── scan abc
-   │    │    └── columns: a:1(int) b:2(int) c:3(int)
-   │    ├── scan uvw@v,rev
    │    │    ├── columns: u:5(int!null) v:6(int)
    │    │    ├── key: (5)
    │    │    └── fd: (5)-->(6)

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -118,16 +118,16 @@ memo
 SELECT s FROM a WHERE s='foo' LIMIT 1
 ----
 memo (optimized)
- ├── G1: (limit G2 G3) (scan a@s_idx,cols=(4),constrained,lim=1) (scan a@s_idx,rev,cols=(4),constrained,lim=1) (scan a@si_idx,cols=(4),constrained,lim=1) (scan a@si_idx,rev,cols=(4),constrained,lim=1)
+ ├── G1: (limit G2 G3) (scan a@s_idx,cols=(4),constrained,lim=1) (scan a@si_idx,cols=(4),constrained,lim=1)
  │    └── "[presentation: s:4]"
  │         ├── best: (scan a@s_idx,cols=(4),constrained,lim=1)
  │         └── cost: 1.05
- ├── G2: (select G4 G5) (scan a@s_idx,cols=(4),constrained) (scan a@s_idx,rev,cols=(4),constrained) (scan a@si_idx,cols=(4),constrained) (scan a@si_idx,rev,cols=(4),constrained)
+ ├── G2: (select G4 G5) (scan a@s_idx,cols=(4),constrained) (scan a@si_idx,cols=(4),constrained)
  │    └── ""
  │         ├── best: (scan a@s_idx,cols=(4),constrained)
  │         └── cost: 1.50
  ├── G3: (const 1)
- ├── G4: (scan a,cols=(4)) (scan a,rev,cols=(4)) (scan a@s_idx,cols=(4)) (scan a@s_idx,rev,cols=(4)) (scan a@si_idx,cols=(4)) (scan a@si_idx,rev,cols=(4))
+ ├── G4: (scan a,cols=(4)) (scan a@s_idx,cols=(4)) (scan a@si_idx,cols=(4))
  │    └── ""
  │         ├── best: (scan a@s_idx,cols=(4))
  │         └── cost: 1050.00

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -65,7 +65,7 @@ SELECT k,f from a ORDER BY k DESC LIMIT 10
 ----
 scan a,rev
  ├── columns: k:1(int!null) f:3(float)
- ├── limit: 10
+ ├── limit: 10(rev)
  ├── key: (1)
  ├── fd: (1)-->(3)
  └── ordering: -1
@@ -74,49 +74,35 @@ memo
 SELECT k,f FROM a ORDER BY k DESC LIMIT 10
 ----
 memo (optimized)
- ├── G1: (limit G2 G7 ordering=-1) (scan a,rev,cols=(1,3),lim=10) (index-join G3 a,cols=(1,3)) (index-join G4 a,cols=(1,3))
+ ├── G1: (limit G2 G5 ordering=-1) (scan a,rev,cols=(1,3),lim=10(rev)) (index-join G3 a,cols=(1,3))
  │    ├── "[presentation: k:1,f:3] [ordering: -1]"
- │    │    ├── best: (scan a,rev,cols=(1,3),lim=10)
+ │    │    ├── best: (scan a,rev,cols=(1,3),lim=10(rev))
  │    │    └── cost: 11.03
  │    └── ""
- │         ├── best: (scan a,rev,cols=(1,3),lim=10)
+ │         ├── best: (scan a,rev,cols=(1,3),lim=10(rev))
  │         └── cost: 11.03
- ├── G2: (scan a,cols=(1,3)) (scan a,rev,cols=(1,3)) (scan a@s_idx,cols=(1,3)) (scan a@s_idx,rev,cols=(1,3)) (index-join G5 a,cols=(1,3)) (index-join G6 a,cols=(1,3))
+ ├── G2: (scan a,cols=(1,3)) (scan a@s_idx,cols=(1,3)) (index-join G4 a,cols=(1,3))
  │    ├── ""
  │    │    ├── best: (scan a@s_idx,cols=(1,3))
  │    │    └── cost: 1060.00
  │    └── "[ordering: -1]"
  │         ├── best: (scan a,rev,cols=(1,3))
  │         └── cost: 1169.66
- ├── G3: (limit G5 G7 ordering=-1)
+ ├── G3: (limit G4 G5 ordering=-1)
  │    ├── ""
- │    │    ├── best: (limit G5="[ordering: -1]" G7 ordering=-1)
+ │    │    ├── best: (limit G4="[ordering: -1]" G5 ordering=-1)
  │    │    └── cost: 1259.42
  │    └── "[ordering: -1]"
- │         ├── best: (limit G5="[ordering: -1]" G7 ordering=-1)
+ │         ├── best: (limit G4="[ordering: -1]" G5 ordering=-1)
  │         └── cost: 1259.42
- ├── G4: (limit G6 G7 ordering=-1)
- │    ├── ""
- │    │    ├── best: (limit G6="[ordering: -1]" G7 ordering=-1)
- │    │    └── cost: 1359.07
- │    └── "[ordering: -1]"
- │         ├── best: (limit G6="[ordering: -1]" G7 ordering=-1)
- │         └── cost: 1359.07
- ├── G5: (scan a@si_idx,cols=(1))
+ ├── G4: (scan a@si_idx,cols=(1))
  │    ├── ""
  │    │    ├── best: (scan a@si_idx,cols=(1))
  │    │    └── cost: 1050.00
  │    └── "[ordering: -1]"
- │         ├── best: (sort G5)
+ │         ├── best: (sort G4)
  │         └── cost: 1259.32
- ├── G6: (scan a@si_idx,rev,cols=(1))
- │    ├── ""
- │    │    ├── best: (scan a@si_idx,rev,cols=(1))
- │    │    └── cost: 1149.66
- │    └── "[ordering: -1]"
- │         ├── best: (sort G6)
- │         └── cost: 1358.97
- └── G7: (const 10)
+ └── G5: (const 10)
 
 
 opt
@@ -196,7 +182,7 @@ memo
 SELECT k FROM a ORDER BY k ASC
 ----
 memo (optimized)
- └── G1: (scan a,cols=(1)) (scan a,rev,cols=(1)) (scan a@s_idx,cols=(1)) (scan a@s_idx,rev,cols=(1)) (scan a@si_idx,cols=(1)) (scan a@si_idx,rev,cols=(1))
+ └── G1: (scan a,cols=(1)) (scan a@s_idx,cols=(1)) (scan a@si_idx,cols=(1))
       ├── "[presentation: k:1] [ordering: +1]"
       │    ├── best: (scan a,cols=(1))
       │    └── cost: 1060.00
@@ -218,27 +204,20 @@ memo
 SELECT s, i, f FROM a ORDER BY s, k, i
 ----
 memo (optimized)
- ├── G1: (scan a,cols=(1-4)) (scan a,rev,cols=(1-4)) (scan a@s_idx,cols=(1-4)) (scan a@s_idx,rev,cols=(1-4)) (index-join G2 a,cols=(1-4)) (index-join G3 a,cols=(1-4))
+ ├── G1: (scan a,cols=(1-4)) (scan a@s_idx,cols=(1-4)) (index-join G2 a,cols=(1-4))
  │    ├── "[presentation: s:4,i:2,f:3] [ordering: +4,+1]"
  │    │    ├── best: (scan a@s_idx,cols=(1-4))
  │    │    └── cost: 1080.00
  │    └── ""
  │         ├── best: (scan a@s_idx,cols=(1-4))
  │         └── cost: 1080.00
- ├── G2: (scan a@si_idx,cols=(1,2,4))
- │    ├── ""
- │    │    ├── best: (scan a@si_idx,cols=(1,2,4))
- │    │    └── cost: 1070.00
- │    └── "[ordering: +4,+1]"
- │         ├── best: (sort G2)
- │         └── cost: 1378.97
- └── G3: (scan a@si_idx,rev,cols=(1,2,4))
+ └── G2: (scan a@si_idx,cols=(1,2,4))
       ├── ""
-      │    ├── best: (scan a@si_idx,rev,cols=(1,2,4))
-      │    └── cost: 1169.66
+      │    ├── best: (scan a@si_idx,cols=(1,2,4))
+      │    └── cost: 1070.00
       └── "[ordering: +4,+1]"
-           ├── best: (sort G3)
-           └── cost: 1478.63
+           ├── best: (sort G2)
+           └── cost: 1378.97
 
 exploretrace rule=GenerateIndexScans
 SELECT s, i, f FROM a ORDER BY s, k, i
@@ -258,36 +237,14 @@ Source expression:
         ├── key: (1)
         └── fd: (1)-->(2-4)
 
-New expression 1 of 5:
-  sort
-   ├── columns: s:4(string) i:2(int) f:3(float)
-   ├── key: (1)
-   ├── fd: (1)-->(2-4)
-   ├── ordering: +4,+1
-   └── scan a,rev
-        ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
-        ├── key: (1)
-        └── fd: (1)-->(2-4)
-
-New expression 2 of 5:
+New expression 1 of 2:
   scan a@s_idx
    ├── columns: s:4(string) i:2(int) f:3(float)
    ├── key: (1)
    ├── fd: (1)-->(2-4)
    └── ordering: +4,+1
 
-New expression 3 of 5:
-  sort
-   ├── columns: s:4(string) i:2(int) f:3(float)
-   ├── key: (1)
-   ├── fd: (1)-->(2-4)
-   ├── ordering: +4,+1
-   └── scan a@s_idx,rev
-        ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
-        ├── key: (1)
-        └── fd: (1)-->(2-4)
-
-New expression 4 of 5:
+New expression 2 of 2:
   sort
    ├── columns: s:4(string) i:2(int) f:3(float)
    ├── key: (1)
@@ -301,21 +258,6 @@ New expression 4 of 5:
              ├── columns: k:1(int!null) i:2(int) s:4(string)
              ├── key: (1)
              └── fd: (1)-->(2,4)
-
-New expression 5 of 5:
-  sort
-   ├── columns: s:4(string) i:2(int) f:3(float)
-   ├── key: (1)
-   ├── fd: (1)-->(2-4)
-   ├── ordering: +4,+1
-   └── index-join a
-        ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
-        ├── key: (1)
-        ├── fd: (1)-->(2-4)
-        └── scan a@si_idx,rev
-             ├── columns: k:1(int!null) i:2(int) s:4(string)
-             ├── key: (1)
-             └── fd: (1)-->(2,4)
 ----
 ----
 
@@ -323,47 +265,36 @@ memo
 SELECT s, i, f FROM a ORDER BY f
 ----
 memo (optimized)
- ├── G1: (scan a,cols=(2-4)) (scan a,rev,cols=(2-4)) (scan a@s_idx,cols=(2-4)) (scan a@s_idx,rev,cols=(2-4)) (index-join G2 a,cols=(2-4)) (index-join G3 a,cols=(2-4))
+ ├── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4)) (index-join G2 a,cols=(2-4))
  │    ├── "[presentation: s:4,i:2,f:3] [ordering: +3]"
  │    │    ├── best: (sort G1)
  │    │    └── cost: 1279.32
  │    └── ""
  │         ├── best: (scan a@s_idx,cols=(2-4))
  │         └── cost: 1070.00
- ├── G2: (scan a@si_idx,cols=(1,2,4))
- │    └── ""
- │         ├── best: (scan a@si_idx,cols=(1,2,4))
- │         └── cost: 1070.00
- └── G3: (scan a@si_idx,rev,cols=(1,2,4))
+ └── G2: (scan a@si_idx,cols=(1,2,4))
       └── ""
-           ├── best: (scan a@si_idx,rev,cols=(1,2,4))
-           └── cost: 1169.66
+           ├── best: (scan a@si_idx,cols=(1,2,4))
+           └── cost: 1070.00
 
 memo
 SELECT s, i, f FROM a ORDER BY s DESC, i
 ----
 memo (optimized)
- ├── G1: (scan a,cols=(2-4)) (scan a,rev,cols=(2-4)) (scan a@s_idx,cols=(2-4)) (scan a@s_idx,rev,cols=(2-4)) (index-join G2 a,cols=(2-4)) (index-join G3 a,cols=(2-4))
+ ├── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4)) (index-join G2 a,cols=(2-4))
  │    ├── "[presentation: s:4,i:2,f:3] [ordering: -4,+2]"
  │    │    ├── best: (sort G1)
  │    │    └── cost: 1378.97
  │    └── ""
  │         ├── best: (scan a@s_idx,cols=(2-4))
  │         └── cost: 1070.00
- ├── G2: (scan a@si_idx,cols=(1,2,4))
- │    ├── ""
- │    │    ├── best: (scan a@si_idx,cols=(1,2,4))
- │    │    └── cost: 1070.00
- │    └── "[ordering: -4,+2]"
- │         ├── best: (sort G2)
- │         └── cost: 1378.97
- └── G3: (scan a@si_idx,rev,cols=(1,2,4))
+ └── G2: (scan a@si_idx,cols=(1,2,4))
       ├── ""
-      │    ├── best: (scan a@si_idx,rev,cols=(1,2,4))
-      │    └── cost: 1169.66
+      │    ├── best: (scan a@si_idx,cols=(1,2,4))
+      │    └── cost: 1070.00
       └── "[ordering: -4,+2]"
-           ├── best: (sort G3)
-           └── cost: 1478.63
+           ├── best: (sort G2)
+           └── cost: 1378.97
 
 exec-ddl
 CREATE TABLE abc (
@@ -407,29 +338,21 @@ memo (optimized)
  │    └── ""
  │         ├── best: (project G2 G3)
  │         └── cost: 1070.00
- ├── G2: (scan abc,cols=(4)) (scan abc,rev,cols=(4)) (index-join G4 abc,cols=(4)) (index-join G5 abc,cols=(4)) (index-join G6 abc,cols=(4)) (index-join G7 abc,cols=(4))
+ ├── G2: (scan abc,cols=(4)) (index-join G4 abc,cols=(4)) (index-join G5 abc,cols=(4))
  │    └── ""
  │         ├── best: (scan abc,cols=(4))
  │         └── cost: 1050.00
- ├── G3: (projections G8 abc.d)
+ ├── G3: (projections G6 abc.d)
  ├── G4: (scan abc@bc,cols=(1-3))
  │    └── ""
  │         ├── best: (scan abc@bc,cols=(1-3))
  │         └── cost: 1060.00
- ├── G5: (scan abc@bc,rev,cols=(1-3))
- │    └── ""
- │         ├── best: (scan abc@bc,rev,cols=(1-3))
- │         └── cost: 1159.66
- ├── G6: (scan abc@ba,cols=(1-3))
+ ├── G5: (scan abc@ba,cols=(1-3))
  │    └── ""
  │         ├── best: (scan abc@ba,cols=(1-3))
  │         └── cost: 1060.00
- ├── G7: (scan abc@ba,rev,cols=(1-3))
- │    └── ""
- │         ├── best: (scan abc@ba,rev,cols=(1-3))
- │         └── cost: 1159.66
- ├── G8: (function G9 lower)
- └── G9: (variable abc.d)
+ ├── G6: (function G7 lower)
+ └── G7: (variable abc.d)
 
 memo
 SELECT j FROM a WHERE s = 'foo'
@@ -439,43 +362,31 @@ memo (optimized)
  │    └── "[presentation: j:5]"
  │         ├── best: (project G2 G3)
  │         └── cost: 1.53
- ├── G2: (select G4 G11) (scan a@si_idx,cols=(4,5),constrained) (scan a@si_idx,rev,cols=(4,5),constrained) (index-join G5 a,cols=(4,5)) (index-join G6 a,cols=(4,5)) (index-join G7 a,cols=(4,5)) (index-join G8 a,cols=(4,5))
+ ├── G2: (select G4 G8) (scan a@si_idx,cols=(4,5),constrained) (index-join G5 a,cols=(4,5)) (index-join G6 a,cols=(4,5))
  │    └── ""
  │         ├── best: (scan a@si_idx,cols=(4,5),constrained)
  │         └── cost: 1.51
  ├── G3: (projections a.j)
- ├── G4: (scan a,cols=(4,5)) (scan a,rev,cols=(4,5)) (index-join G9 a,cols=(4,5)) (index-join G10 a,cols=(4,5)) (scan a@si_idx,cols=(4,5)) (scan a@si_idx,rev,cols=(4,5))
+ ├── G4: (scan a,cols=(4,5)) (index-join G7 a,cols=(4,5)) (scan a@si_idx,cols=(4,5))
  │    └── ""
  │         ├── best: (scan a@si_idx,cols=(4,5))
  │         └── cost: 1060.00
- ├── G5: (select G9 G11) (scan a@s_idx,cols=(1,4),constrained)
+ ├── G5: (select G7 G8) (scan a@s_idx,cols=(1,4),constrained)
  │    └── ""
  │         ├── best: (scan a@s_idx,cols=(1,4),constrained)
  │         └── cost: 1.51
- ├── G6: (select G10 G11) (scan a@s_idx,rev,cols=(1,4),constrained)
- │    └── ""
- │         ├── best: (scan a@s_idx,rev,cols=(1,4),constrained)
- │         └── cost: 1.52
- ├── G7: (scan a@s_idx,cols=(1,4),constrained)
+ ├── G6: (scan a@s_idx,cols=(1,4),constrained)
  │    └── ""
  │         ├── best: (scan a@s_idx,cols=(1,4),constrained)
  │         └── cost: 1.51
- ├── G8: (scan a@s_idx,rev,cols=(1,4),constrained)
- │    └── ""
- │         ├── best: (scan a@s_idx,rev,cols=(1,4),constrained)
- │         └── cost: 1.52
- ├── G9: (scan a@s_idx,cols=(1,4))
+ ├── G7: (scan a@s_idx,cols=(1,4))
  │    └── ""
  │         ├── best: (scan a@s_idx,cols=(1,4))
  │         └── cost: 1060.00
- ├── G10: (scan a@s_idx,rev,cols=(1,4))
- │    └── ""
- │         ├── best: (scan a@s_idx,rev,cols=(1,4))
- │         └── cost: 1159.66
- ├── G11: (filters G12)
- ├── G12: (eq G13 G14)
- ├── G13: (variable a.s)
- └── G14: (const 'foo')
+ ├── G8: (filters G9)
+ ├── G9: (eq G10 G11)
+ ├── G10: (variable a.s)
+ └── G11: (const 'foo')
 
 # Scan of primary index is lowest cost.
 opt
@@ -491,27 +402,20 @@ memo
 SELECT s, i, f FROM a ORDER BY k, i, s
 ----
 memo (optimized)
- ├── G1: (scan a,cols=(1-4)) (scan a,rev,cols=(1-4)) (scan a@s_idx,cols=(1-4)) (scan a@s_idx,rev,cols=(1-4)) (index-join G2 a,cols=(1-4)) (index-join G3 a,cols=(1-4))
+ ├── G1: (scan a,cols=(1-4)) (scan a@s_idx,cols=(1-4)) (index-join G2 a,cols=(1-4))
  │    ├── "[presentation: s:4,i:2,f:3] [ordering: +1]"
  │    │    ├── best: (scan a,cols=(1-4))
  │    │    └── cost: 1090.00
  │    └── ""
  │         ├── best: (scan a@s_idx,cols=(1-4))
  │         └── cost: 1080.00
- ├── G2: (scan a@si_idx,cols=(1,2,4))
- │    ├── ""
- │    │    ├── best: (scan a@si_idx,cols=(1,2,4))
- │    │    └── cost: 1070.00
- │    └── "[ordering: +1]"
- │         ├── best: (sort G2)
- │         └── cost: 1279.32
- └── G3: (scan a@si_idx,rev,cols=(1,2,4))
+ └── G2: (scan a@si_idx,cols=(1,2,4))
       ├── ""
-      │    ├── best: (scan a@si_idx,rev,cols=(1,2,4))
-      │    └── cost: 1169.66
+      │    ├── best: (scan a@si_idx,cols=(1,2,4))
+      │    └── cost: 1070.00
       └── "[ordering: +1]"
-           ├── best: (sort G3)
-           └── cost: 1378.97
+           ├── best: (sort G2)
+           └── cost: 1279.32
 
 # Secondary index has right order
 opt
@@ -525,27 +429,20 @@ memo
 SELECT s, j FROM a ORDER BY s
 ----
 memo (optimized)
- ├── G1: (scan a,cols=(4,5)) (scan a,rev,cols=(4,5)) (index-join G2 a,cols=(4,5)) (index-join G3 a,cols=(4,5)) (scan a@si_idx,cols=(4,5)) (scan a@si_idx,rev,cols=(4,5))
+ ├── G1: (scan a,cols=(4,5)) (index-join G2 a,cols=(4,5)) (scan a@si_idx,cols=(4,5))
  │    ├── "[presentation: s:4,j:5] [ordering: +4]"
  │    │    ├── best: (scan a@si_idx,rev,cols=(4,5))
  │    │    └── cost: 1159.66
  │    └── ""
  │         ├── best: (scan a@si_idx,cols=(4,5))
  │         └── cost: 1060.00
- ├── G2: (scan a@s_idx,cols=(1,4))
- │    ├── ""
- │    │    ├── best: (scan a@s_idx,cols=(1,4))
- │    │    └── cost: 1060.00
- │    └── "[ordering: +4]"
- │         ├── best: (scan a@s_idx,cols=(1,4))
- │         └── cost: 1060.00
- └── G3: (scan a@s_idx,rev,cols=(1,4))
+ └── G2: (scan a@s_idx,cols=(1,4))
       ├── ""
-      │    ├── best: (scan a@s_idx,rev,cols=(1,4))
-      │    └── cost: 1159.66
+      │    ├── best: (scan a@s_idx,cols=(1,4))
+      │    └── cost: 1060.00
       └── "[ordering: +4]"
-           ├── best: (sort G3)
-           └── cost: 1368.97
+           ├── best: (scan a@s_idx,cols=(1,4))
+           └── cost: 1060.00
 
 # Consider three different indexes, and pick index with multiple keys.
 opt
@@ -565,7 +462,7 @@ memo
 SELECT i, k FROM a ORDER BY s DESC, i, k
 ----
 memo (optimized)
- └── G1: (scan a,cols=(1,2,4)) (scan a,rev,cols=(1,2,4)) (scan a@s_idx,cols=(1,2,4)) (scan a@s_idx,rev,cols=(1,2,4)) (scan a@si_idx,cols=(1,2,4)) (scan a@si_idx,rev,cols=(1,2,4))
+ └── G1: (scan a,cols=(1,2,4)) (scan a@s_idx,cols=(1,2,4)) (scan a@si_idx,cols=(1,2,4))
       ├── "[presentation: i:2,k:1] [ordering: -4,+2,+1]"
       │    ├── best: (sort G1)
       │    └── cost: 1478.63
@@ -581,12 +478,12 @@ memo (optimized)
  │    └── "[presentation: i:2,k:1]"
  │         ├── best: (project G2 G3)
  │         └── cost: 360.00
- ├── G2: (select G4 G5) (scan a@s_idx,cols=(1,2,4),constrained) (scan a@s_idx,rev,cols=(1,2,4),constrained) (scan a@si_idx,cols=(1,2,4),constrained) (scan a@si_idx,rev,cols=(1,2,4),constrained)
+ ├── G2: (select G4 G5) (scan a@s_idx,cols=(1,2,4),constrained) (scan a@si_idx,cols=(1,2,4),constrained)
  │    └── ""
  │         ├── best: (scan a@s_idx,cols=(1,2,4),constrained)
  │         └── cost: 356.67
  ├── G3: (projections a.k a.i)
- ├── G4: (scan a,cols=(1,2,4)) (scan a,rev,cols=(1,2,4)) (scan a@s_idx,cols=(1,2,4)) (scan a@s_idx,rev,cols=(1,2,4)) (scan a@si_idx,cols=(1,2,4)) (scan a@si_idx,rev,cols=(1,2,4))
+ ├── G4: (scan a,cols=(1,2,4)) (scan a@s_idx,cols=(1,2,4)) (scan a@si_idx,cols=(1,2,4))
  │    └── ""
  │         ├── best: (scan a@s_idx,cols=(1,2,4))
  │         └── cost: 1070.00

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -70,11 +70,11 @@ memo
 SELECT k FROM a WHERE k = 1
 ----
 memo (optimized)
- ├── G1: (select G2 G3) (scan a,cols=(1),constrained) (scan a,rev,cols=(1),constrained)
+ ├── G1: (select G2 G3) (scan a,cols=(1),constrained)
  │    └── "[presentation: k:1]"
  │         ├── best: (scan a,cols=(1),constrained)
  │         └── cost: 1.04
- ├── G2: (scan a,cols=(1)) (scan a,rev,cols=(1)) (scan a@u,cols=(1)) (scan a@u,rev,cols=(1)) (scan a@v,cols=(1)) (scan a@v,rev,cols=(1))
+ ├── G2: (scan a,cols=(1)) (scan a@u,cols=(1)) (scan a@v,cols=(1))
  │    └── ""
  │         ├── best: (scan a,cols=(1))
  │         └── cost: 1040.00
@@ -103,12 +103,12 @@ memo (optimized)
  │    └── "[presentation: k:1]"
  │         ├── best: (project G2 G3)
  │         └── cost: 353.33
- ├── G2: (select G4 G5) (scan a@v,cols=(1,3),constrained) (scan a@v,rev,cols=(1,3),constrained)
+ ├── G2: (select G4 G5) (scan a@v,cols=(1,3),constrained)
  │    └── ""
  │         ├── best: (scan a@v,cols=(1,3),constrained)
  │         └── cost: 350.00
  ├── G3: (projections a.k)
- ├── G4: (scan a,cols=(1,3)) (scan a,rev,cols=(1,3)) (scan a@u,cols=(1,3)) (scan a@u,rev,cols=(1,3)) (scan a@v,cols=(1,3)) (scan a@v,rev,cols=(1,3))
+ ├── G4: (scan a,cols=(1,3)) (scan a@u,cols=(1,3)) (scan a@v,cols=(1,3))
  │    └── ""
  │         ├── best: (scan a,cols=(1,3))
  │         └── cost: 1050.00
@@ -140,31 +140,27 @@ memo (optimized)
  │    └── "[presentation: k:1]"
  │         ├── best: (project G2 G3)
  │         └── cost: 1.06
- ├── G2: (select G4 G5) (select G6 G8) (select G7 G8) (scan a@u,cols=(1,2),constrained) (scan a@u,rev,cols=(1,2),constrained)
+ ├── G2: (select G4 G5) (select G6 G7) (scan a@u,cols=(1,2),constrained)
  │    └── ""
  │         ├── best: (scan a@u,cols=(1,2),constrained)
  │         └── cost: 1.05
  ├── G3: (projections a.k)
- ├── G4: (scan a,cols=(1,2)) (scan a,rev,cols=(1,2)) (scan a@u,cols=(1,2)) (scan a@u,rev,cols=(1,2)) (scan a@v,cols=(1,2)) (scan a@v,rev,cols=(1,2))
+ ├── G4: (scan a,cols=(1,2)) (scan a@u,cols=(1,2)) (scan a@v,cols=(1,2))
  │    └── ""
  │         ├── best: (scan a,cols=(1,2))
  │         └── cost: 1050.00
- ├── G5: (filters G10 G9)
+ ├── G5: (filters G9 G8)
  ├── G6: (scan a,cols=(1,2),constrained)
  │    └── ""
  │         ├── best: (scan a,cols=(1,2),constrained)
  │         └── cost: 1.05
- ├── G7: (scan a,rev,cols=(1,2),constrained)
- │    └── ""
- │         ├── best: (scan a,rev,cols=(1,2),constrained)
- │         └── cost: 1.05
- ├── G8: (filters G10)
- ├── G9: (eq G11 G12)
- ├── G10: (eq G13 G14)
- ├── G11: (variable a.k)
- ├── G12: (const 5)
- ├── G13: (variable a.u)
- └── G14: (const 1)
+ ├── G7: (filters G9)
+ ├── G8: (eq G10 G11)
+ ├── G9: (eq G12 G13)
+ ├── G10: (variable a.k)
+ ├── G11: (const 5)
+ ├── G12: (variable a.u)
+ └── G13: (const 1)
 
 # Constraint + remaining filter.
 opt
@@ -193,31 +189,27 @@ memo (optimized)
  │    └── "[presentation: k:1]"
  │         ├── best: (project G2 G3)
  │         └── cost: 1.52
- ├── G2: (select G4 G5) (select G6 G8) (select G7 G8)
+ ├── G2: (select G4 G5) (select G6 G7)
  │    └── ""
- │         ├── best: (select G6 G8)
+ │         ├── best: (select G6 G7)
  │         └── cost: 1.51
  ├── G3: (projections a.k)
- ├── G4: (scan a,cols=(1,2)) (scan a,rev,cols=(1,2)) (scan a@u,cols=(1,2)) (scan a@u,rev,cols=(1,2)) (scan a@v,cols=(1,2)) (scan a@v,rev,cols=(1,2))
+ ├── G4: (scan a,cols=(1,2)) (scan a@u,cols=(1,2)) (scan a@v,cols=(1,2))
  │    └── ""
  │         ├── best: (scan a,cols=(1,2))
  │         └── cost: 1050.00
- ├── G5: (filters G9 G10)
+ ├── G5: (filters G8 G9)
  ├── G6: (scan a@u,cols=(1,2),constrained)
  │    └── ""
  │         ├── best: (scan a@u,cols=(1,2),constrained)
  │         └── cost: 1.50
- ├── G7: (scan a@u,rev,cols=(1,2),constrained)
- │    └── ""
- │         ├── best: (scan a@u,rev,cols=(1,2),constrained)
- │         └── cost: 1.51
- ├── G8: (filters G10)
- ├── G9: (eq G14 G12)
- ├── G10: (eq G11 G12)
- ├── G11: (plus G13 G14)
- ├── G12: (const 1)
- ├── G13: (variable a.k)
- └── G14: (variable a.u)
+ ├── G7: (filters G9)
+ ├── G8: (eq G13 G11)
+ ├── G9: (eq G10 G11)
+ ├── G10: (plus G12 G13)
+ ├── G11: (const 1)
+ ├── G12: (variable a.k)
+ └── G13: (variable a.u)
 
 opt
 SELECT k FROM a WHERE u = 1 AND v = 5
@@ -249,40 +241,32 @@ memo (optimized)
  │    └── "[presentation: k:1]"
  │         ├── best: (project G2 G3)
  │         └── cost: 1.07
- ├── G2: (select G4 G5) (select G6 G8) (select G7 G8) (select G9 G11) (select G10 G11)
+ ├── G2: (select G4 G5) (select G6 G7) (select G8 G9)
  │    └── ""
- │         ├── best: (select G9 G11)
+ │         ├── best: (select G8 G9)
  │         └── cost: 1.07
  ├── G3: (projections a.k)
- ├── G4: (scan a) (scan a,rev) (scan a@u) (scan a@u,rev) (scan a@v) (scan a@v,rev)
+ ├── G4: (scan a) (scan a@u) (scan a@v)
  │    └── ""
  │         ├── best: (scan a)
  │         └── cost: 1060.00
- ├── G5: (filters G13 G12)
+ ├── G5: (filters G11 G10)
  ├── G6: (scan a@u,constrained)
  │    └── ""
  │         ├── best: (scan a@u,constrained)
  │         └── cost: 1.51
- ├── G7: (scan a@u,rev,constrained)
- │    └── ""
- │         ├── best: (scan a@u,rev,constrained)
- │         └── cost: 1.52
- ├── G8: (filters G12)
- ├── G9: (scan a@v,constrained)
+ ├── G7: (filters G10)
+ ├── G8: (scan a@v,constrained)
  │    └── ""
  │         ├── best: (scan a@v,constrained)
  │         └── cost: 1.06
- ├── G10: (scan a@v,rev,constrained)
- │    └── ""
- │         ├── best: (scan a@v,rev,constrained)
- │         └── cost: 1.06
- ├── G11: (filters G13)
- ├── G12: (eq G14 G15)
- ├── G13: (eq G16 G17)
- ├── G14: (variable a.v)
- ├── G15: (const 5)
- ├── G16: (variable a.u)
- └── G17: (const 1)
+ ├── G9: (filters G11)
+ ├── G10: (eq G12 G13)
+ ├── G11: (eq G14 G15)
+ ├── G12: (variable a.v)
+ ├── G13: (const 5)
+ ├── G14: (variable a.u)
+ └── G15: (const 1)
 
 # Only not-null constraint is pushed down.
 opt
@@ -346,52 +330,36 @@ memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10
 ----
 memo (optimized)
- ├── G1: (select G2 G11) (index-join G3 b,cols=(1-4)) (index-join G4 b,cols=(1-4)) (index-join G5 b,cols=(1-4)) (index-join G6 b,cols=(1-4))
+ ├── G1: (select G2 G7) (index-join G3 b,cols=(1-4)) (index-join G4 b,cols=(1-4))
  │    └── "[presentation: k:1,u:2,v:3,j:4]"
  │         ├── best: (index-join G3 b,cols=(1-4))
  │         └── cost: 51.30
- ├── G2: (scan b) (scan b,rev) (index-join G7 b,cols=(1-4)) (index-join G8 b,cols=(1-4)) (index-join G9 b,cols=(1-4)) (index-join G10 b,cols=(1-4))
+ ├── G2: (scan b) (index-join G5 b,cols=(1-4)) (index-join G6 b,cols=(1-4))
  │    └── ""
  │         ├── best: (scan b)
  │         └── cost: 1080.00
- ├── G3: (select G9 G11) (scan b@v,cols=(1,3),constrained)
+ ├── G3: (select G6 G7) (scan b@v,cols=(1,3),constrained)
  │    └── ""
  │         ├── best: (scan b@v,cols=(1,3),constrained)
  │         └── cost: 10.40
- ├── G4: (select G10 G11) (scan b@v,rev,cols=(1,3),constrained)
- │    └── ""
- │         ├── best: (scan b@v,rev,cols=(1,3),constrained)
- │         └── cost: 10.73
- ├── G5: (scan b@v,cols=(1,3),constrained)
+ ├── G4: (scan b@v,cols=(1,3),constrained)
  │    └── ""
  │         ├── best: (scan b@v,cols=(1,3),constrained)
  │         └── cost: 10.40
- ├── G6: (scan b@v,rev,cols=(1,3),constrained)
- │    └── ""
- │         ├── best: (scan b@v,rev,cols=(1,3),constrained)
- │         └── cost: 10.73
- ├── G7: (scan b@u,cols=(1,2))
+ ├── G5: (scan b@u,cols=(1,2))
  │    └── ""
  │         ├── best: (scan b@u,cols=(1,2))
  │         └── cost: 1040.00
- ├── G8: (scan b@u,rev,cols=(1,2))
- │    └── ""
- │         ├── best: (scan b@u,rev,cols=(1,2))
- │         └── cost: 1139.66
- ├── G9: (scan b@v,cols=(1,3))
+ ├── G6: (scan b@v,cols=(1,3))
  │    └── ""
  │         ├── best: (scan b@v,cols=(1,3))
  │         └── cost: 1040.00
- ├── G10: (scan b@v,rev,cols=(1,3))
- │    └── ""
- │         ├── best: (scan b@v,rev,cols=(1,3))
- │         └── cost: 1139.66
- ├── G11: (filters G12 G13)
- ├── G12: (ge G15 G14)
- ├── G13: (le G15 G16)
- ├── G14: (const 1)
- ├── G15: (variable b.v)
- └── G16: (const 10)
+ ├── G7: (filters G8 G9)
+ ├── G8: (ge G11 G10)
+ ├── G9: (le G11 G12)
+ ├── G10: (const 1)
+ ├── G11: (variable b.v)
+ └── G12: (const 10)
 
 # Don't choose lookup join if it's not beneficial.
 opt
@@ -431,11 +399,11 @@ memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k > 5
 ----
 memo (optimized)
- ├── G1: (select G2 G17) (select G3 G9) (select G4 G9) (index-join G5 b,cols=(1-4)) (index-join G6 b,cols=(1-4)) (select G7 G9) (select G8 G9) (select G10 G27) (select G11 G27) (index-join G12 b,cols=(1-4)) (index-join G13 b,cols=(1-4))
+ ├── G1: (select G2 G10) (select G3 G6) (index-join G4 b,cols=(1-4)) (select G5 G6) (select G7 G17) (index-join G8 b,cols=(1-4))
  │    └── "[presentation: k:1,u:2,v:3,j:4]"
- │         ├── best: (index-join G5 b,cols=(1-4))
+ │         ├── best: (index-join G4 b,cols=(1-4))
  │         └── cost: 24.13
- ├── G2: (scan b) (scan b,rev) (index-join G25 b,cols=(1-4)) (index-join G26 b,cols=(1-4)) (index-join G14 b,cols=(1-4)) (index-join G16 b,cols=(1-4))
+ ├── G2: (scan b) (index-join G16 b,cols=(1-4)) (index-join G9 b,cols=(1-4))
  │    └── ""
  │         ├── best: (scan b)
  │         └── cost: 1080.00
@@ -443,93 +411,53 @@ memo (optimized)
  │    └── ""
  │         ├── best: (scan b,constrained)
  │         └── cost: 360.00
- ├── G4: (scan b,rev,constrained)
+ ├── G4: (select G9 G10) (select G11 G17)
  │    └── ""
- │         ├── best: (scan b,rev,constrained)
- │         └── cost: 387.94
- ├── G5: (select G14 G17) (select G15 G27)
- │    └── ""
- │         ├── best: (select G15 G27)
+ │         ├── best: (select G11 G17)
  │         └── cost: 10.50
- ├── G6: (select G16 G17) (select G18 G27)
+ ├── G5: (index-join G12 b,cols=(1-4))
  │    └── ""
- │         ├── best: (select G18 G27)
- │         └── cost: 10.83
- ├── G7: (index-join G19 b,cols=(1-4))
- │    └── ""
- │         ├── best: (index-join G19 b,cols=(1-4))
+ │         ├── best: (index-join G12 b,cols=(1-4))
  │         └── cost: 2413.33
- ├── G8: (index-join G20 b,cols=(1-4))
+ ├── G6: (filters G14 G15)
+ ├── G7: (index-join G13 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G20 b,cols=(1-4))
- │         └── cost: 2512.99
- ├── G9: (filters G23 G24)
- ├── G10: (index-join G21 b,cols=(1-4))
- │    └── ""
- │         ├── best: (index-join G21 b,cols=(1-4))
+ │         ├── best: (index-join G13 b,cols=(1-4))
  │         └── cost: 51.30
- ├── G11: (index-join G22 b,cols=(1-4))
+ ├── G8: (select G13 G17)
  │    └── ""
- │         ├── best: (index-join G22 b,cols=(1-4))
- │         └── cost: 51.63
- ├── G12: (select G21 G27)
- │    └── ""
- │         ├── best: (select G21 G27)
+ │         ├── best: (select G13 G17)
  │         └── cost: 10.50
- ├── G13: (select G22 G27)
- │    └── ""
- │         ├── best: (select G22 G27)
- │         └── cost: 10.83
- ├── G14: (scan b@v,cols=(1,3))
+ ├── G9: (scan b@v,cols=(1,3))
  │    └── ""
  │         ├── best: (scan b@v,cols=(1,3))
  │         └── cost: 1040.00
- ├── G15: (scan b@v,cols=(1,3),constrained)
+ ├── G10: (filters G14 G15 G21)
+ ├── G11: (scan b@v,cols=(1,3),constrained)
  │    └── ""
  │         ├── best: (scan b@v,cols=(1,3),constrained)
  │         └── cost: 10.40
- ├── G16: (scan b@v,rev,cols=(1,3))
+ ├── G12: (select G16 G17)
  │    └── ""
- │         ├── best: (scan b@v,rev,cols=(1,3))
- │         └── cost: 1139.66
- ├── G17: (filters G23 G24 G31)
- ├── G18: (scan b@v,rev,cols=(1,3),constrained)
- │    └── ""
- │         ├── best: (scan b@v,rev,cols=(1,3),constrained)
- │         └── cost: 10.73
- ├── G19: (select G25 G27)
- │    └── ""
- │         ├── best: (select G25 G27)
+ │         ├── best: (select G16 G17)
  │         └── cost: 1050.00
- ├── G20: (select G26 G27)
- │    └── ""
- │         ├── best: (select G26 G27)
- │         └── cost: 1149.66
- ├── G21: (scan b@v,cols=(1,3),constrained)
+ ├── G13: (scan b@v,cols=(1,3),constrained)
  │    └── ""
  │         ├── best: (scan b@v,cols=(1,3),constrained)
  │         └── cost: 10.40
- ├── G22: (scan b@v,rev,cols=(1,3),constrained)
- │    └── ""
- │         ├── best: (scan b@v,rev,cols=(1,3),constrained)
- │         └── cost: 10.73
- ├── G23: (ge G29 G28)
- ├── G24: (le G29 G30)
- ├── G25: (scan b@u,cols=(1,2))
+ ├── G14: (ge G19 G18)
+ ├── G15: (le G19 G20)
+ ├── G16: (scan b@u,cols=(1,2))
  │    └── ""
  │         ├── best: (scan b@u,cols=(1,2))
  │         └── cost: 1040.00
- ├── G26: (scan b@u,rev,cols=(1,2))
- │    └── ""
- │         ├── best: (scan b@u,rev,cols=(1,2))
- │         └── cost: 1139.66
- ├── G27: (filters G31)
- ├── G28: (const 1)
- ├── G29: (variable b.v)
- ├── G30: (const 10)
- ├── G31: (gt G32 G33)
- ├── G32: (variable b.k)
- └── G33: (const 5)
+ ├── G17: (filters G21)
+ ├── G18: (const 1)
+ ├── G19: (variable b.v)
+ ├── G20: (const 10)
+ ├── G21: (gt G22 G23)
+ ├── G22: (variable b.k)
+ └── G23: (const 5)
 
 
 # --------------------------------------------------
@@ -560,90 +488,58 @@ memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1
 ----
 memo (optimized)
- ├── G1: (select G2 G3) (select G4 G21) (select G5 G21) (select G6 G18) (select G7 G18) (select G8 G18) (select G9 G18)
+ ├── G1: (select G2 G3) (select G4 G13) (select G5 G11) (select G6 G11)
  │    └── "[presentation: k:1,u:2,v:3,j:4]"
- │         ├── best: (select G6 G18)
+ │         ├── best: (select G5 G11)
  │         └── cost: 51.40
- ├── G2: (scan b) (scan b,rev) (index-join G16 b,cols=(1-4)) (index-join G17 b,cols=(1-4)) (index-join G19 b,cols=(1-4)) (index-join G20 b,cols=(1-4))
+ ├── G2: (scan b) (index-join G10 b,cols=(1-4)) (index-join G12 b,cols=(1-4))
  │    └── ""
  │         ├── best: (scan b)
  │         └── cost: 1080.00
- ├── G3: (filters G23 G24 G22)
- ├── G4: (index-join G10 b,cols=(1-4))
+ ├── G3: (filters G15 G16 G14)
+ ├── G4: (index-join G7 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G10 b,cols=(1-4))
+ │         ├── best: (index-join G7 b,cols=(1-4))
  │         └── cost: 2413.33
- ├── G5: (index-join G11 b,cols=(1-4))
+ ├── G5: (index-join G8 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G11 b,cols=(1-4))
- │         └── cost: 2512.99
- ├── G6: (index-join G12 b,cols=(1-4))
- │    └── ""
- │         ├── best: (index-join G12 b,cols=(1-4))
+ │         ├── best: (index-join G8 b,cols=(1-4))
  │         └── cost: 51.30
- ├── G7: (index-join G13 b,cols=(1-4))
+ ├── G6: (index-join G9 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G13 b,cols=(1-4))
- │         └── cost: 51.63
- ├── G8: (index-join G14 b,cols=(1-4))
- │    └── ""
- │         ├── best: (index-join G14 b,cols=(1-4))
+ │         ├── best: (index-join G9 b,cols=(1-4))
  │         └── cost: 51.30
- ├── G9: (index-join G15 b,cols=(1-4))
+ ├── G7: (select G10 G11)
  │    └── ""
- │         ├── best: (index-join G15 b,cols=(1-4))
- │         └── cost: 51.63
- ├── G10: (select G16 G18)
- │    └── ""
- │         ├── best: (select G16 G18)
+ │         ├── best: (select G10 G11)
  │         └── cost: 1050.00
- ├── G11: (select G17 G18)
- │    └── ""
- │         ├── best: (select G17 G18)
- │         └── cost: 1149.66
- ├── G12: (select G19 G21) (scan b@v,cols=(1,3),constrained)
+ ├── G8: (select G12 G13) (scan b@v,cols=(1,3),constrained)
  │    └── ""
  │         ├── best: (scan b@v,cols=(1,3),constrained)
  │         └── cost: 10.40
- ├── G13: (select G20 G21) (scan b@v,rev,cols=(1,3),constrained)
- │    └── ""
- │         ├── best: (scan b@v,rev,cols=(1,3),constrained)
- │         └── cost: 10.73
- ├── G14: (scan b@v,cols=(1,3),constrained)
+ ├── G9: (scan b@v,cols=(1,3),constrained)
  │    └── ""
  │         ├── best: (scan b@v,cols=(1,3),constrained)
  │         └── cost: 10.40
- ├── G15: (scan b@v,rev,cols=(1,3),constrained)
- │    └── ""
- │         ├── best: (scan b@v,rev,cols=(1,3),constrained)
- │         └── cost: 10.73
- ├── G16: (scan b@u,cols=(1,2))
+ ├── G10: (scan b@u,cols=(1,2))
  │    └── ""
  │         ├── best: (scan b@u,cols=(1,2))
  │         └── cost: 1040.00
- ├── G17: (scan b@u,rev,cols=(1,2))
- │    └── ""
- │         ├── best: (scan b@u,rev,cols=(1,2))
- │         └── cost: 1139.66
- ├── G18: (filters G22)
- ├── G19: (scan b@v,cols=(1,3))
+ ├── G11: (filters G14)
+ ├── G12: (scan b@v,cols=(1,3))
  │    └── ""
  │         ├── best: (scan b@v,cols=(1,3))
  │         └── cost: 1040.00
- ├── G20: (scan b@v,rev,cols=(1,3))
- │    └── ""
- │         ├── best: (scan b@v,rev,cols=(1,3))
- │         └── cost: 1139.66
- ├── G21: (filters G23 G24)
- ├── G22: (eq G25 G26)
- ├── G23: (ge G27 G26)
- ├── G24: (le G27 G28)
- ├── G25: (plus G29 G30)
- ├── G26: (const 1)
- ├── G27: (variable b.v)
- ├── G28: (const 10)
- ├── G29: (variable b.k)
- └── G30: (variable b.u)
+ ├── G13: (filters G15 G16)
+ ├── G14: (eq G17 G18)
+ ├── G15: (ge G19 G18)
+ ├── G16: (le G19 G20)
+ ├── G17: (plus G21 G22)
+ ├── G18: (const 1)
+ ├── G19: (variable b.v)
+ ├── G20: (const 10)
+ ├── G21: (variable b.k)
+ └── G22: (variable b.u)
 
 opt
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1 AND k > 5
@@ -674,128 +570,80 @@ memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1 AND k > 5
 ----
 memo (optimized)
- ├── G1: (select G2 G3) (select G4 G6) (select G5 G6) (select G7 G9) (select G8 G9) (select G10 G16) (select G11 G16) (select G12 G25) (select G13 G25) (select G14 G16) (select G15 G16)
+ ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G11) (select G9 G16) (select G10 G11)
  │    └── "[presentation: k:1,u:2,v:3,j:4]"
- │         ├── best: (select G10 G16)
+ │         ├── best: (select G8 G11)
  │         └── cost: 24.17
- ├── G2: (scan b) (scan b,rev) (index-join G23 b,cols=(1-4)) (index-join G24 b,cols=(1-4)) (index-join G26 b,cols=(1-4)) (index-join G28 b,cols=(1-4))
+ ├── G2: (scan b) (index-join G15 b,cols=(1-4)) (index-join G17 b,cols=(1-4))
  │    └── ""
  │         ├── best: (scan b)
  │         └── cost: 1080.00
- ├── G3: (filters G35 G36 G34 G37)
+ ├── G3: (filters G23 G24 G22 G25)
  ├── G4: (scan b,constrained)
  │    └── ""
  │         ├── best: (scan b,constrained)
  │         └── cost: 360.00
- ├── G5: (scan b,rev,constrained)
+ ├── G5: (filters G23 G24 G22)
+ ├── G6: (index-join G12 b,cols=(1-4))
  │    └── ""
- │         ├── best: (scan b,rev,constrained)
- │         └── cost: 387.94
- ├── G6: (filters G35 G36 G34)
- ├── G7: (index-join G17 b,cols=(1-4))
- │    └── ""
- │         ├── best: (index-join G17 b,cols=(1-4))
+ │         ├── best: (index-join G12 b,cols=(1-4))
  │         └── cost: 1504.44
- ├── G8: (index-join G18 b,cols=(1-4))
+ ├── G7: (filters G23 G24)
+ ├── G8: (index-join G13 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G18 b,cols=(1-4))
- │         └── cost: 1604.10
- ├── G9: (filters G35 G36)
- ├── G10: (index-join G19 b,cols=(1-4))
- │    └── ""
- │         ├── best: (index-join G19 b,cols=(1-4))
+ │         ├── best: (index-join G13 b,cols=(1-4))
  │         └── cost: 24.13
- ├── G11: (index-join G20 b,cols=(1-4))
+ ├── G9: (index-join G20 b,cols=(1-4))
  │    └── ""
  │         ├── best: (index-join G20 b,cols=(1-4))
- │         └── cost: 24.47
- ├── G12: (index-join G31 b,cols=(1-4))
- │    └── ""
- │         ├── best: (index-join G31 b,cols=(1-4))
  │         └── cost: 51.30
- ├── G13: (index-join G32 b,cols=(1-4))
+ ├── G10: (index-join G14 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G32 b,cols=(1-4))
- │         └── cost: 51.63
- ├── G14: (index-join G21 b,cols=(1-4))
- │    └── ""
- │         ├── best: (index-join G21 b,cols=(1-4))
+ │         ├── best: (index-join G14 b,cols=(1-4))
  │         └── cost: 24.13
- ├── G15: (index-join G22 b,cols=(1-4))
+ ├── G11: (filters G22)
+ ├── G12: (select G15 G16)
  │    └── ""
- │         ├── best: (index-join G22 b,cols=(1-4))
- │         └── cost: 24.47
- ├── G16: (filters G34)
- ├── G17: (select G23 G25)
- │    └── ""
- │         ├── best: (select G23 G25)
+ │         ├── best: (select G15 G16)
  │         └── cost: 1050.00
- ├── G18: (select G24 G25)
+ ├── G13: (select G17 G18) (select G19 G21)
  │    └── ""
- │         ├── best: (select G24 G25)
- │         └── cost: 1149.66
- ├── G19: (select G26 G29) (select G27 G33)
- │    └── ""
- │         ├── best: (select G27 G33)
+ │         ├── best: (select G19 G21)
  │         └── cost: 10.50
- ├── G20: (select G28 G29) (select G30 G33)
+ ├── G14: (select G20 G21)
  │    └── ""
- │         ├── best: (select G30 G33)
- │         └── cost: 10.83
- ├── G21: (select G31 G33)
- │    └── ""
- │         ├── best: (select G31 G33)
+ │         ├── best: (select G20 G21)
  │         └── cost: 10.50
- ├── G22: (select G32 G33)
- │    └── ""
- │         ├── best: (select G32 G33)
- │         └── cost: 10.83
- ├── G23: (scan b@u,cols=(1,2))
+ ├── G15: (scan b@u,cols=(1,2))
  │    └── ""
  │         ├── best: (scan b@u,cols=(1,2))
  │         └── cost: 1040.00
- ├── G24: (scan b@u,rev,cols=(1,2))
- │    └── ""
- │         ├── best: (scan b@u,rev,cols=(1,2))
- │         └── cost: 1139.66
- ├── G25: (filters G34 G37)
- ├── G26: (scan b@v,cols=(1,3))
+ ├── G16: (filters G22 G25)
+ ├── G17: (scan b@v,cols=(1,3))
  │    └── ""
  │         ├── best: (scan b@v,cols=(1,3))
  │         └── cost: 1040.00
- ├── G27: (scan b@v,cols=(1,3),constrained)
+ ├── G18: (filters G23 G24 G25)
+ ├── G19: (scan b@v,cols=(1,3),constrained)
  │    └── ""
  │         ├── best: (scan b@v,cols=(1,3),constrained)
  │         └── cost: 10.40
- ├── G28: (scan b@v,rev,cols=(1,3))
- │    └── ""
- │         ├── best: (scan b@v,rev,cols=(1,3))
- │         └── cost: 1139.66
- ├── G29: (filters G35 G36 G37)
- ├── G30: (scan b@v,rev,cols=(1,3),constrained)
- │    └── ""
- │         ├── best: (scan b@v,rev,cols=(1,3),constrained)
- │         └── cost: 10.73
- ├── G31: (scan b@v,cols=(1,3),constrained)
+ ├── G20: (scan b@v,cols=(1,3),constrained)
  │    └── ""
  │         ├── best: (scan b@v,cols=(1,3),constrained)
  │         └── cost: 10.40
- ├── G32: (scan b@v,rev,cols=(1,3),constrained)
- │    └── ""
- │         ├── best: (scan b@v,rev,cols=(1,3),constrained)
- │         └── cost: 10.73
- ├── G33: (filters G37)
- ├── G34: (eq G38 G39)
- ├── G35: (ge G40 G39)
- ├── G36: (le G40 G41)
- ├── G37: (gt G43 G42)
- ├── G38: (plus G43 G44)
- ├── G39: (const 1)
- ├── G40: (variable b.v)
- ├── G41: (const 10)
- ├── G42: (const 5)
- ├── G43: (variable b.k)
- └── G44: (variable b.u)
+ ├── G21: (filters G25)
+ ├── G22: (eq G26 G27)
+ ├── G23: (ge G28 G27)
+ ├── G24: (le G28 G29)
+ ├── G25: (gt G31 G30)
+ ├── G26: (plus G31 G32)
+ ├── G27: (const 1)
+ ├── G28: (variable b.v)
+ ├── G29: (const 10)
+ ├── G30: (const 5)
+ ├── G31: (variable b.k)
+ └── G32: (variable b.u)
 
 # --------------------------------------------------
 # ConstrainLookupJoinIndexScan
@@ -825,61 +673,45 @@ memo
 SELECT * FROM b WHERE (u, k, v) > (1, 2, 3) AND (u, k, v) < (8, 9, 10)
 ----
 memo (optimized)
- ├── G1: (select G2 G5) (select G3 G5) (select G4 G5)
+ ├── G1: (select G2 G4) (select G3 G4)
  │    └── "[presentation: k:1,u:2,v:3,j:4]"
- │         ├── best: (select G3 G5)
+ │         ├── best: (select G3 G4)
  │         └── cost: 58.74
- ├── G2: (scan b) (scan b,rev) (index-join G6 b,cols=(1-4)) (index-join G7 b,cols=(1-4)) (index-join G8 b,cols=(1-4)) (index-join G9 b,cols=(1-4))
+ ├── G2: (scan b) (index-join G5 b,cols=(1-4)) (index-join G6 b,cols=(1-4))
  │    └── ""
  │         ├── best: (scan b)
  │         └── cost: 1080.00
- ├── G3: (index-join G10 b,cols=(1-4))
+ ├── G3: (index-join G7 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G10 b,cols=(1-4))
+ │         ├── best: (index-join G7 b,cols=(1-4))
  │         └── cost: 58.63
- ├── G4: (index-join G11 b,cols=(1-4))
- │    └── ""
- │         ├── best: (index-join G11 b,cols=(1-4))
- │         └── cost: 59.03
- ├── G5: (filters G12 G13)
- ├── G6: (scan b@u,cols=(1,2))
+ ├── G4: (filters G8 G9)
+ ├── G5: (scan b@u,cols=(1,2))
  │    └── ""
  │         ├── best: (scan b@u,cols=(1,2))
  │         └── cost: 1040.00
- ├── G7: (scan b@u,rev,cols=(1,2))
- │    └── ""
- │         ├── best: (scan b@u,rev,cols=(1,2))
- │         └── cost: 1139.66
- ├── G8: (scan b@v,cols=(1,3))
+ ├── G6: (scan b@v,cols=(1,3))
  │    └── ""
  │         ├── best: (scan b@v,cols=(1,3))
  │         └── cost: 1040.00
- ├── G9: (scan b@v,rev,cols=(1,3))
- │    └── ""
- │         ├── best: (scan b@v,rev,cols=(1,3))
- │         └── cost: 1139.66
- ├── G10: (scan b@u,cols=(1,2),constrained)
+ ├── G7: (scan b@u,cols=(1,2),constrained)
  │    └── ""
  │         ├── best: (scan b@u,cols=(1,2),constrained)
  │         └── cost: 11.89
- ├── G11: (scan b@u,rev,cols=(1,2),constrained)
- │    └── ""
- │         ├── best: (scan b@u,rev,cols=(1,2),constrained)
- │         └── cost: 12.29
- ├── G12: (gt G15 G14)
- ├── G13: (lt G15 G16)
- ├── G14: (tuple G17 G18 G19)
- ├── G15: (tuple G20 G21 G22)
- ├── G16: (tuple G23 G24 G25)
- ├── G17: (const 1)
- ├── G18: (const 2)
- ├── G19: (const 3)
- ├── G20: (variable b.u)
- ├── G21: (variable b.k)
- ├── G22: (variable b.v)
- ├── G23: (const 8)
- ├── G24: (const 9)
- └── G25: (const 10)
+ ├── G8: (gt G11 G10)
+ ├── G9: (lt G11 G12)
+ ├── G10: (tuple G13 G14 G15)
+ ├── G11: (tuple G16 G17 G18)
+ ├── G12: (tuple G19 G20 G21)
+ ├── G13: (const 1)
+ ├── G14: (const 2)
+ ├── G15: (const 3)
+ ├── G16: (variable b.u)
+ ├── G17: (variable b.k)
+ ├── G18: (variable b.v)
+ ├── G19: (const 8)
+ ├── G20: (const 9)
+ └── G21: (const 10)
 
 # --------------------------------------------------
 # GenerateInvertedIndexScans


### PR DESCRIPTION
Instead of creating separate expressions for reverse scans, a Scan now
can be executed in either direction, depending on the required
ordering. The cost can still differ (it can depend on the required
properties).

The only wrinkle is that in the HardLimit case, the direction must be
fixed. This is handled using a reverse flag only for that case.

In addition to being a general performance improvement, this also
fixes a more significant inefficiency - in the index join case, we
were creating separate groups for the forward and the reverse scan
expressions. This lead to other rules (like PushJoinThroughIndexJoin)
generating many more combinations of expressions than necessary.

Release note: None