### PR TITLE
storage: remove store.LookupReplica support for range lookups

### DIFF
--- a/pkg/storage/client_lease_test.go
+++ b/pkg/storage/client_lease_test.go
@@ -57,7 +57,7 @@ func TestStoreRangeLease(t *testing.T) {
 			}
 		}
 
-		rLeft := mtc.stores[0].LookupReplica(roachpb.RKeyMin, nil)
+		rLeft := mtc.stores[0].LookupReplica(roachpb.RKeyMin)
 		lease, _ := rLeft.GetLease()
 		if lt := lease.Type(); lt != roachpb.LeaseExpiration {
 			t.Fatalf("expected lease type expiration; got %d", lt)
@@ -65,7 +65,7 @@ func TestStoreRangeLease(t *testing.T) {
 
 		// After the split, expect an expiration lease for other ranges.
 		for _, key := range splitKeys {
-			repl := mtc.stores[0].LookupReplica(roachpb.RKey(key), nil)
+			repl := mtc.stores[0].LookupReplica(roachpb.RKey(key))
 			lease, _ = repl.GetLease()
 			if lt := lease.Type(); lt != roachpb.LeaseExpiration {
 				t.Fatalf("%s: expected lease type epoch; got %d", key, lt)
@@ -84,7 +84,7 @@ func TestStoreRangeLease(t *testing.T) {
 		// After the expiration, expect an epoch lease for the RHS if
 		// we've enabled epoch based range leases.
 		for _, key := range splitKeys {
-			repl := mtc.stores[0].LookupReplica(roachpb.RKey(key), nil)
+			repl := mtc.stores[0].LookupReplica(roachpb.RKey(key))
 			lease, _ = repl.GetLease()
 			if enableEpoch {
 				if lt := lease.Type(); lt != roachpb.LeaseEpoch {
@@ -123,7 +123,7 @@ func TestStoreRangeLeaseSwitcheroo(t *testing.T) {
 	}
 
 	// We started with epoch ranges enabled, so verify we have an epoch lease.
-	repl := mtc.stores[0].LookupReplica(roachpb.RKey(splitKey), nil)
+	repl := mtc.stores[0].LookupReplica(roachpb.RKey(splitKey))
 	lease, _ := repl.GetLease()
 	if lt := lease.Type(); lt != roachpb.LeaseEpoch {
 		t.Fatalf("expected lease type epoch; got %d", lt)
@@ -140,7 +140,7 @@ func TestStoreRangeLeaseSwitcheroo(t *testing.T) {
 	}
 
 	// Verify we end up with an expiration lease on restart.
-	repl = mtc.stores[0].LookupReplica(roachpb.RKey(splitKey), nil)
+	repl = mtc.stores[0].LookupReplica(roachpb.RKey(splitKey))
 	lease, _ = repl.GetLease()
 	if lt := lease.Type(); lt != roachpb.LeaseExpiration {
 		t.Fatalf("expected lease type expiration; got %d", lt)
@@ -157,7 +157,7 @@ func TestStoreRangeLeaseSwitcheroo(t *testing.T) {
 	}
 
 	// Verify we end up with an epoch lease on restart.
-	repl = mtc.stores[0].LookupReplica(roachpb.RKey(splitKey), nil)
+	repl = mtc.stores[0].LookupReplica(roachpb.RKey(splitKey))
 	lease, _ = repl.GetLease()
 	if lt := lease.Type(); lt != roachpb.LeaseEpoch {
 		t.Fatalf("expected lease type epoch; got %d", lt)
@@ -245,7 +245,7 @@ func TestGossipSystemConfigOnLeaseChange(t *testing.T) {
 	const numStores = 3
 	mtc.Start(t, numStores)
 
-	rangeID := mtc.stores[0].LookupReplica(roachpb.RKey(keys.SystemConfigSpan.Key), nil).RangeID
+	rangeID := mtc.stores[0].LookupReplica(roachpb.RKey(keys.SystemConfigSpan.Key)).RangeID
 	mtc.replicateRange(rangeID, 1, 2)
 
 	initialStoreIdx := -1

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -69,8 +69,8 @@ func createSplitRanges(
 		return nil, nil, err.GoError()
 	}
 
-	lhsDesc := store.LookupReplica(roachpb.RKey("a"), nil).Desc()
-	rhsDesc := store.LookupReplica(roachpb.RKey("c"), nil).Desc()
+	lhsDesc := store.LookupReplica(roachpb.RKey("a")).Desc()
+	rhsDesc := store.LookupReplica(roachpb.RKey("c")).Desc()
 
 	if bytes.Equal(lhsDesc.StartKey, rhsDesc.StartKey) {
 		return nil, nil, fmt.Errorf("split ranges have the same start key: %q = %q",
@@ -104,8 +104,8 @@ func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 	}
 
 	// Verify the merge by looking up keys from both ranges.
-	lhsRepl := store.LookupReplica(roachpb.RKey("a"), nil)
-	rhsRepl := store.LookupReplica(roachpb.RKey("c"), nil)
+	lhsRepl := store.LookupReplica(roachpb.RKey("a"))
+	rhsRepl := store.LookupReplica(roachpb.RKey("c"))
 
 	if !reflect.DeepEqual(lhsRepl, rhsRepl) {
 		t.Fatalf("ranges were not merged: %s != %s", lhsRepl, rhsRepl)
@@ -303,8 +303,8 @@ func mergeWithData(t *testing.T, retries int64) {
 	}
 
 	// Verify the merge by looking up keys from both ranges.
-	lhsRepl := store1.LookupReplica(roachpb.RKey("a"), nil)
-	rhsRepl := store1.LookupReplica(roachpb.RKey("c"), nil)
+	lhsRepl := store1.LookupReplica(roachpb.RKey("a"))
+	rhsRepl := store1.LookupReplica(roachpb.RKey("c"))
 
 	if lhsRepl != rhsRepl {
 		t.Fatalf("ranges were not merged %+v=%+v", lhsRepl.Desc(), rhsRepl.Desc())
@@ -566,7 +566,7 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	if _, err := client.SendWrapped(ctx, store.TestSender(), args); err != nil {
 		t.Fatal(err)
 	}
-	replMerged := store.LookupReplica(lhsDesc.StartKey, nil)
+	replMerged := store.LookupReplica(lhsDesc.StartKey)
 
 	// Get the range stats for the merged range and verify.
 	snap = store.Engine().NewSnapshot()
@@ -1400,7 +1400,7 @@ func TestStoreRangeMergeAbandonedFollowers(t *testing.T) {
 	testutils.SucceedsSoon(t, func() error {
 		repls = nil
 		for _, key := range keys {
-			repl := store2.LookupReplica(key, nil /* end */)
+			repl := store2.LookupReplica(key) /* end */
 			if repl == nil || !repl.Desc().StartKey.Equal(key) {
 				return fmt.Errorf("replica for key %q is missing or has wrong start key: %s", key, repl)
 			}
@@ -1560,8 +1560,8 @@ func TestMergeQueue(t *testing.T) {
 	split(t, roachpb.Key("a"))
 	split(t, roachpb.Key("b"))
 	split(t, roachpb.Key("c"))
-	lhs := func() *storage.Replica { return store.LookupReplica(roachpb.RKey("a"), nil) }
-	rhs := func() *storage.Replica { return store.LookupReplica(roachpb.RKey("b"), nil) }
+	lhs := func() *storage.Replica { return store.LookupReplica(roachpb.RKey("a")) }
+	rhs := func() *storage.Replica { return store.LookupReplica(roachpb.RKey("b")) }
 	lhsDesc := lhs().Desc()
 	rhsDesc := rhs().Desc()
 
@@ -1591,7 +1591,7 @@ func TestMergeQueue(t *testing.T) {
 
 	verifyMerged := func(t *testing.T) {
 		t.Helper()
-		repl := store.LookupReplica(rhsDesc.StartKey, nil)
+		repl := store.LookupReplica(rhsDesc.StartKey)
 		if !repl.Desc().StartKey.Equal(lhsDesc.StartKey) {
 			t.Fatalf("ranges unexpectedly unmerged")
 		}
@@ -1599,7 +1599,7 @@ func TestMergeQueue(t *testing.T) {
 
 	verifyUnmerged := func(t *testing.T) {
 		t.Helper()
-		repl := store.LookupReplica(rhsDesc.StartKey, nil)
+		repl := store.LookupReplica(rhsDesc.StartKey)
 		if repl.Desc().StartKey.Equal(lhsDesc.StartKey) {
 			t.Fatalf("ranges unexpectedly merged")
 		}

--- a/pkg/storage/client_metrics_test.go
+++ b/pkg/storage/client_metrics_test.go
@@ -187,7 +187,7 @@ func TestStoreMetrics(t *testing.T) {
 	verifyStats(t, mtc, 0)
 
 	// Replicate the "right" range to the other stores.
-	replica := mtc.stores[0].LookupReplica(roachpb.RKey("z"), nil)
+	replica := mtc.stores[0].LookupReplica(roachpb.RKey("z"))
 	mtc.replicateRange(replica.RangeID, 1, 2)
 
 	// Verify stats on store1 after replication.

--- a/pkg/storage/client_raft_log_queue_test.go
+++ b/pkg/storage/client_raft_log_queue_test.go
@@ -58,7 +58,7 @@ func TestRaftLogQueue(t *testing.T) {
 	}
 
 	// Get the raft leader (and ensure one exists).
-	rangeID := mtc.stores[0].LookupReplica([]byte("a"), nil).RangeID
+	rangeID := mtc.stores[0].LookupReplica([]byte("a")).RangeID
 	raftLeaderRepl := mtc.getRaftLeader(rangeID)
 	if raftLeaderRepl == nil {
 		t.Fatalf("could not find raft leader replica for range %d", rangeID)

--- a/pkg/storage/client_status_test.go
+++ b/pkg/storage/client_status_test.go
@@ -36,7 +36,7 @@ func TestComputeStatsForKeySpan(t *testing.T) {
 	splitKeys := []string{"a", "c", "e", "g", "i"}
 	for _, k := range splitKeys {
 		key := roachpb.Key(k)
-		repl := mtc.stores[0].LookupReplica(roachpb.RKey(key), roachpb.RKeyMin)
+		repl := mtc.stores[0].LookupReplica(roachpb.RKey(key))
 		args := adminSplitArgs(key)
 		header := roachpb.Header{
 			RangeID: repl.RangeID,
@@ -48,7 +48,7 @@ func TestComputeStatsForKeySpan(t *testing.T) {
 
 	// Wait for splits to finish.
 	testutils.SucceedsSoon(t, func() error {
-		repl := mtc.stores[0].LookupReplica(roachpb.RKey("z"), nil)
+		repl := mtc.stores[0].LookupReplica(roachpb.RKey("z"))
 		if actualRSpan := repl.Desc().RSpan(); !actualRSpan.Key.Equal(roachpb.RKey("i")) {
 			return errors.Errorf("expected range %s to begin at key 'i'", repl)
 		}

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -167,7 +167,7 @@ func createTestStoreWithEngine(
 		t.Fatal(err)
 	}
 	// Wait for the store's single range to have quorum before proceeding.
-	repl := store.LookupReplica(roachpb.RKeyMin, nil)
+	repl := store.LookupReplica(roachpb.RKeyMin)
 	testutils.SucceedsSoon(t, func() error {
 		if !repl.HasQuorum() {
 			return errors.New("first range has not reached quorum")
@@ -595,7 +595,7 @@ func (m *multiTestContext) FirstRange() (*roachpb.RangeDescriptor, error) {
 		// querying all stores; it may not be present on all stores, but the
 		// current version is guaranteed to be present on one of them.
 		if err := str.VisitStores(func(s *storage.Store) error {
-			firstRng := s.LookupReplica(roachpb.RKeyMin, nil)
+			firstRng := s.LookupReplica(roachpb.RKeyMin)
 			if firstRng != nil {
 				descs = append(descs, firstRng.Desc())
 			}

--- a/pkg/storage/consistency_queue_test.go
+++ b/pkg/storage/consistency_queue_test.go
@@ -49,7 +49,7 @@ func TestConsistencyQueueRequiresLive(t *testing.T) {
 	mtc.Start(t, 3)
 
 	// Replicate the range to three nodes.
-	repl := mtc.stores[0].LookupReplica(roachpb.RKeyMin, nil)
+	repl := mtc.stores[0].LookupReplica(roachpb.RKeyMin)
 	rangeID := repl.RangeID
 	mtc.replicateRange(rangeID, 1, 2)
 

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -444,7 +444,7 @@ func MakeSSTable(key, value string, ts hlc.Timestamp) ([]byte, engine.MVCCKeyVal
 
 func ProposeAddSSTable(ctx context.Context, key, val string, ts hlc.Timestamp, store *Store) error {
 	var ba roachpb.BatchRequest
-	ba.RangeID = store.LookupReplica(roachpb.RKey(key), nil).RangeID
+	ba.RangeID = store.LookupReplica(roachpb.RKey(key)).RangeID
 
 	var addReq roachpb.AddSSTableRequest
 	addReq.Data, _ = MakeSSTable(key, val, ts)

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2051,7 +2051,7 @@ func (r *Replica) requestCanProceed(rspan roachpb.RSpan, ts hlc.Timestamp) error
 	// Try to suggest the correct range on a key mismatch error where
 	// even the start key of the request went to the wrong range.
 	if !desc.ContainsKey(rspan.Key) {
-		if repl := r.store.LookupReplica(rspan.Key, nil); repl != nil {
+		if repl := r.store.LookupReplica(rspan.Key); repl != nil {
 			// Only return the correct range descriptor as a hint
 			// if we know the current lease holder for that range, which
 			// indicates that our knowledge is not stale.

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -783,7 +783,7 @@ func TestReplicaRangeBoundsChecking(t *testing.T) {
 	tc.Start(t, stopper)
 
 	key := roachpb.RKey("a")
-	firstRepl := tc.store.LookupReplica(key, nil)
+	firstRepl := tc.store.LookupReplica(key)
 	newRepl := splitTestRange(tc.store, key, key, t)
 	if _, pErr := newRepl.redirectOnOrAcquireLease(context.Background()); pErr != nil {
 		t.Fatal(pErr)
@@ -6502,7 +6502,7 @@ func TestReplicaCorruption(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r := tc.store.LookupReplica(rkey, rkey)
+	r := tc.store.LookupReplica(rkey)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.mu.destroyStatus.err.Error() != pErr.GetDetail().Error() {
@@ -6961,7 +6961,7 @@ func TestReplicaLoadSystemConfigSpanIntent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	repl := tc.store.LookupReplica(scStartSddr, nil)
+	repl := tc.store.LookupReplica(scStartSddr)
 	if repl == nil {
 		t.Fatalf("no replica contains the SystemConfig span")
 	}
@@ -9345,7 +9345,7 @@ func TestErrorInRaftApplicationClearsIntents(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	repl := store.LookupReplica(rkey, nil /* end */)
+	repl := store.LookupReplica(rkey) /* end */
 	if repl == nil {
 		t.Fatalf("replica for key %s not found", rkey)
 	}
@@ -9683,7 +9683,7 @@ func TestReplicaRecomputeStats(t *testing.T) {
 	tc.Start(t, stopper)
 
 	key := roachpb.RKey("a")
-	repl := tc.store.LookupReplica(key, nil)
+	repl := tc.store.LookupReplica(key)
 	desc := repl.Desc()
 	sKey := desc.StartKey.AsRawKey()
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1591,7 +1591,7 @@ func (s *Store) startGossip() {
 				retryOptions := base.DefaultRetryOptions()
 				retryOptions.Closer = s.stopper.ShouldStop()
 				for r := retry.Start(retryOptions); r.Next(); {
-					if repl := s.LookupReplica(roachpb.RKey(gossipFn.key), nil); repl != nil {
+					if repl := s.LookupReplica(roachpb.RKey(gossipFn.key)); repl != nil {
 						annotatedCtx := repl.AnnotateCtx(ctx)
 						if err := gossipFn.fn(annotatedCtx, repl); err != nil {
 							log.Warningf(annotatedCtx, "could not gossip %s: %s", gossipFn.description, err)
@@ -1999,21 +1999,21 @@ func (s *Store) GetReplica(rangeID roachpb.RangeID) (*Replica, error) {
 	return nil, roachpb.NewRangeNotFoundError(rangeID)
 }
 
-// LookupReplica looks up a replica via binary search over the
-// "replicasByKey" btree. Returns nil if no replica is found for
-// specified key range. Note that the specified keys are transformed
-// using Key.Address() to ensure we lookup replicas correctly for local
-// keys. When end is nil, a replica that contains start is looked up.
-func (s *Store) LookupReplica(start, end roachpb.RKey) *Replica {
+// LookupReplica looks up the replica that contains the specified key. It
+// returns nil if no such replica exists.
+func (s *Store) LookupReplica(key roachpb.RKey) *Replica {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-
 	var repl *Replica
-	s.visitReplicasLocked(start, roachpb.RKeyMax, func(replIter *Replica) bool {
-		repl = replIter
+	// Simulate AscendGreater by calling key.Next. We want to skip the replica
+	// whose end key equals key, as end keys are exclusive.
+	s.mu.replicasByKey.AscendGreaterOrEqual(rangeBTreeKey(key.Next()), func(item btree.Item) bool {
+		repl, _ = item.(*Replica)
+		// Stop iterating immediately. The first item we see is the only one that
+		// can possibly contain key.
 		return false
 	})
-	if repl == nil || !repl.Desc().ContainsKeyRange(start, end) {
+	if repl == nil || !repl.Desc().ContainsKey(key) {
 		return nil
 	}
 	return repl
@@ -2054,37 +2054,6 @@ func (s *Store) getOverlappingKeyRangeLocked(rngDesc *roachpb.RangeDescriptor) K
 	}
 
 	return nil
-}
-
-// visitReplicasLocked will call iterator for every replica on the store which
-// contains any keys in the span between startKey and endKey. Iteration will be
-// in ascending order. Iteration can be stopped early by returning false from
-// iterator.
-func (s *Store) visitReplicasLocked(startKey, endKey roachpb.RKey, iterator func(r *Replica) bool) {
-	// Iterate over replicasByKey to visit all ranges containing keys in the
-	// specified range. We use startKey.Next() because btree's Ascend methods
-	// are inclusive of the start bound and exclusive of the end bound, but
-	// ranges are stored in the BTree by EndKey; in cockroach, end keys have the
-	// opposite behavior (a range's EndKey is contained by the subsequent
-	// range). We want visitReplicasLocked to match cockroach's behavior; using
-	// startKey.Next(), will ignore a range which has EndKey exactly equal to
-	// the supplied startKey. Iteration ends when all ranges are exhausted, or
-	// the next range contains no keys in the supplied span.
-	s.mu.replicasByKey.AscendGreaterOrEqual(rangeBTreeKey(startKey.Next()),
-		func(item btree.Item) bool {
-			kr := item.(KeyRange)
-			if !kr.Desc().StartKey.Less(endKey) {
-				// This properly checks if this range contains any keys in the supplied span.
-				return false
-			}
-
-			switch rep := item.(type) {
-			case *Replica:
-				return iterator(rep)
-			default:
-				return true
-			}
-		})
 }
 
 // RaftStatus returns the current raft status of the local replica of

--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -113,7 +113,7 @@ func TestTimeSeriesMaintenanceQueue(t *testing.T) {
 	// Generate several splits.
 	splitKeys := []roachpb.Key{roachpb.Key("c"), roachpb.Key("b"), roachpb.Key("a")}
 	for _, k := range splitKeys {
-		repl := store.LookupReplica(roachpb.RKey(k), nil)
+		repl := store.LookupReplica(roachpb.RKey(k))
 		args := adminSplitArgs(k)
 		if _, pErr := client.SendWrappedWith(context.Background(), store, roachpb.Header{
 			RangeID: repl.RangeID,
@@ -177,7 +177,7 @@ func TestTimeSeriesMaintenanceQueue(t *testing.T) {
 			keys = append(keys, roachpb.RKey(k))
 		}
 		for _, key := range keys {
-			repl := store.LookupReplica(key, nil)
+			repl := store.LookupReplica(key)
 			ts, err := repl.GetQueueLastProcessed(context.TODO(), "timeSeriesMaintenance")
 			if err != nil {
 				return err

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -364,7 +364,7 @@ func (tc *TestCluster) AddReplicas(
 				log.Errorf(context.TODO(), "unexpected error: %s", err)
 				return err
 			}
-			repl := store.LookupReplica(rKey, nil)
+			repl := store.LookupReplica(rKey)
 			if repl == nil {
 				return errors.Errorf("range not found on store %d", target)
 			}


### PR DESCRIPTION
All but one caller of Store.LookupReplica either a) passed nil for the
second parameter (the end key), or b) could easily pass nil for the
second parameter. Remove the second parameter entirely. In effect, this
means that Store.LookupReplica now only supports point lookups, not
range lookups. This makes calls to store.LookupReplica much less
confusing to read.

The one caller who legitimately used range lookup support is taught to
perform a range bound check after calling LookupReplica.

This commit also simplifies the LookupReplica logic by inlining the
visitReplicasLocked helper, of which LookupReplica was the only caller.

Release note: None