### PR TITLE
base,server: better UX for server addrs and cert mis-configurations

### DIFF
--- a/pkg/base/addr_validation.go
+++ b/pkg/base/addr_validation.go
@@ -1,0 +1,235 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package base
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/pkg/errors"
+)
+
+// ValidateAddrs controls the address fields in the Config object
+// and "fills in" the blanks:
+// - the host part of Addr and HTTPAddr is resolved to an IP address
+//   if specified (it stays blank if blank to mean "all addresses").
+// - the host part of AdvertiseAddr is filled in if blank, either
+//   from Addr if non-empty or os.Hostname(). It is also checked
+//   for resolvability.
+// - non-numeric port numbers are resolved to numeric.
+//
+// The addresses fields must be guaranteed by the caller to either be
+// completely empty, or have both a host part and a port part
+// separated by a colon. In the latter case either can be empty to
+// indicate it's left unspecified.
+func (cfg *Config) ValidateAddrs(ctx context.Context) error {
+	// Validate the advertise address.
+	advHost, advPort, err := validateAdvertiseAddr(ctx,
+		cfg.AdvertiseAddr, "--listen-addr", cfg.Addr, "")
+	if err != nil {
+		return errors.Wrapf(err, "invalid --advertise-addr")
+	}
+	cfg.AdvertiseAddr = net.JoinHostPort(advHost, advPort)
+
+	// Validate the listen address.
+	listenHost, listenPort, err := validateListenAddr(ctx, cfg.Addr, "")
+	if err != nil {
+		return errors.Wrapf(err, "invalid --listen-addr")
+	}
+	cfg.Addr = net.JoinHostPort(listenHost, listenPort)
+
+	// Validate the HTTP advertise address.
+	advHTTPHost, advHTTPPort, err := validateAdvertiseAddr(ctx,
+		cfg.HTTPAdvertiseAddr, "--http-addr", cfg.HTTPAddr, advHost)
+	if err != nil {
+		return errors.Wrapf(err, "cannot compute public HTTP address")
+	}
+	cfg.HTTPAdvertiseAddr = net.JoinHostPort(advHTTPHost, advHTTPPort)
+
+	// Validate the HTTP address -- use the resolved listen addr
+	// as default.
+	httpHost, httpPort, err := validateListenAddr(ctx, cfg.HTTPAddr, listenHost)
+	if err != nil {
+		return errors.Wrapf(err, "invalid --http-addr")
+	}
+	cfg.HTTPAddr = net.JoinHostPort(httpHost, httpPort)
+	return nil
+}
+
+// UpdateAddrs updates the listen and advertise port numbers with
+// those found during the call to net.Listen().
+//
+// After ValidateAddr() the actual listen addr should be equal to the
+// one requested; only the port number can change because of
+// auto-allocation. We do check this equality here and report a
+// warning if any discrepancy is found.
+func UpdateAddrs(ctx context.Context, addr, advAddr *string, ln net.Addr) error {
+	desiredHost, _, err := net.SplitHostPort(*addr)
+	if err != nil {
+		return err
+	}
+
+	// Update the listen port number and check the actual listen addr is
+	// the one requested.
+	lnAddr := ln.String()
+	lnHost, lnPort, err := net.SplitHostPort(lnAddr)
+	if err != nil {
+		return err
+	}
+	requestedAll := (desiredHost == "" || desiredHost == "0.0.0.0" || desiredHost == "::")
+	listenedAll := (lnHost == "" || lnHost == "0.0.0.0" || lnHost == "::")
+	if (requestedAll && !listenedAll) || (!requestedAll && desiredHost != lnHost) {
+		log.Warningf(ctx, "requested to listen on %q, actually listening on %q", desiredHost, lnHost)
+	}
+	*addr = net.JoinHostPort(lnHost, lnPort)
+
+	// Update the advertised port number if it wasn't set to start
+	// with. We don't touch the advertised host, as this may have
+	// nothing to do with the listen address.
+	advHost, advPort, err := net.SplitHostPort(*advAddr)
+	if err != nil {
+		return err
+	}
+	if advPort == "" || advPort == "0" {
+		advPort = lnPort
+	}
+	*advAddr = net.JoinHostPort(advHost, advPort)
+	return nil
+}
+
+// validateAdvertiseAddr validates an normalizes an address suitable
+// for use in gossiping - for use by other nodes. This ensures
+// that if the "host" part is empty, it gets filled in with
+// the configured listen address if any, or the canonical host name.
+func validateAdvertiseAddr(
+	ctx context.Context, advAddr, flag, listenAddr, defaultHost string,
+) (string, string, error) {
+	listenHost, listenPort, err := getListenAddr(listenAddr, defaultHost)
+	if err != nil {
+		return "", "", errors.Wrapf(err, "invalid %s", flag)
+	}
+
+	advHost, advPort := "", ""
+	if advAddr != "" {
+		var err error
+		advHost, advPort, err = net.SplitHostPort(advAddr)
+		if err != nil {
+			return "", "", err
+		}
+	}
+	// If there was no port number, reuse the one from the listen
+	// address.
+	if advPort == "" || advPort == "0" {
+		advPort = listenPort
+	}
+	// Resolve non-numeric to numeric.
+	portNumber, err := net.DefaultResolver.LookupPort(ctx, "tcp", advPort)
+	if err != nil {
+		return "", "", err
+	}
+	advPort = strconv.Itoa(portNumber)
+
+	// If the advertise host is empty, then we have two cases.
+	if advHost == "" {
+		if listenHost != "" {
+			// If the listen address was non-empty (ie. explicit, not
+			// "listen on all addresses"), use that.
+			advHost = listenHost
+		} else {
+			// No specific listen address, use the canonical host name.
+			var err error
+			advHost, err = os.Hostname()
+			if err != nil {
+				return "", "", err
+			}
+
+			// As a sanity check, verify that the canonical host name
+			// properly resolves. It's not the full story (it could resolve
+			// locally but not elsewhere) but at least it prevents typos.
+			_, err = net.DefaultResolver.LookupIPAddr(ctx, advHost)
+			if err != nil {
+				return "", "", err
+			}
+		}
+	}
+	return advHost, advPort, nil
+}
+
+// validateListenAddr validates and normalizes an address suitable for
+// use with net.Listen(). This accepts an empty "host" part as "listen
+// on all interfaces" and resolves host names to IP addresses.
+func validateListenAddr(ctx context.Context, addr, defaultHost string) (string, string, error) {
+	host, port, err := getListenAddr(addr, defaultHost)
+	if err != nil {
+		return "", "", err
+	}
+	return resolveAddr(ctx, host, port)
+}
+
+func getListenAddr(addr, defaultHost string) (string, string, error) {
+	host, port := "", ""
+	if addr != "" {
+		var err error
+		host, port, err = net.SplitHostPort(addr)
+		if err != nil {
+			return "", "", err
+		}
+	}
+	if host == "" {
+		host = defaultHost
+	}
+	if port == "" {
+		port = "0"
+	}
+	return host, port, nil
+}
+
+// resolveAddr resolves non-numeric references to numeric references.
+func resolveAddr(ctx context.Context, host, port string) (string, string, error) {
+	resolver := net.DefaultResolver
+
+	// Resolve the port number. This may translate service names
+	// e.g. "postgresql" to a numeric value.
+	portNumber, err := resolver.LookupPort(ctx, "tcp", port)
+	if err != nil {
+		return "", "", err
+	}
+	port = strconv.Itoa(portNumber)
+
+	// Resolve the address.
+	if host == "" {
+		// Keep empty. This means "listen on all addresses".
+		return host, port, nil
+	}
+
+	// Resolve the IP address or hostname to an IP address.
+	addrs, err := resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return "", "", err
+	}
+	if len(addrs) == 0 {
+		return "", "", fmt.Errorf("cannot resolve %q to an address", host)
+	}
+
+	// TODO(knz): this function can be changed to return all resolved
+	// addresses once the server is taught to listen on multiple
+	// interfaces. #5816
+	return addrs[0].String(), port, nil
+}

--- a/pkg/base/addr_validation.go
+++ b/pkg/base/addr_validation.go
@@ -16,6 +16,7 @@ package base
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"os"
@@ -232,4 +233,104 @@ func resolveAddr(ctx context.Context, host, port string) (string, string, error)
 	// addresses once the server is taught to listen on multiple
 	// interfaces. #5816
 	return addrs[0].String(), port, nil
+}
+
+// CheckCertificateAddrs validates the addresses inside the configured
+// certificates to be compatible with the configured listen and
+// advertise addresses.
+func (cfg *Config) CheckCertificateAddrs(ctx context.Context) {
+	if cfg.Insecure {
+		return
+	}
+
+	// By now the certificate manager must be initialized.
+	cm, _ := cfg.GetCertificateManager()
+
+	// Verify that the listen and advertise addresses are compatible
+	// with the provided certificate.
+	certInfo := cm.NodeCert()
+	if certInfo.Error != nil {
+		log.Shout(ctx, log.Severity_ERROR,
+			"invalid node certificate: %v", certInfo.Error)
+	} else {
+		cert := certInfo.ParsedCertificates[0]
+		addrInfo := certAddrs(cert)
+
+		// Log the certificate details in any case. This will aid during troubleshooting.
+		log.Infof(ctx, "server certificate addresses: %s", addrInfo)
+
+		// Verify the compatibility. This requires that ValidateAddr() has
+		// been called already.
+		var buf strings.Builder
+		notifyFunc := func(msg, host string) {
+			if buf.Len() > 0 {
+				buf.WriteString(" and ")
+			}
+			fmt.Fprintf(&buf, "%s address %q", msg, host)
+		}
+		checkCertAddr(ctx, cfg.Addr, "listen", notifyFunc, cert)
+		checkCertAddr(ctx, cfg.AdvertiseAddr, "advertise", notifyFunc, cert)
+		if buf.Len() > 0 {
+			log.Shout(ctx, log.Severity_WARNING,
+				fmt.Sprintf("%s not in node certificate (%s)\n"+
+					"Secure node-node and SQL connections are likely to fail.\n"+
+					"Consider extending the node certificate or tweak --listen-addr/--advertise-addr.",
+					buf.String(), addrInfo))
+		}
+	}
+
+	// Verify that the http listen and advertise addresses are
+	// compatible with the provided certificate.
+	certInfo = cm.UICert()
+	if certInfo == nil {
+		// A nil UI cert means use the node cert instead;
+		// see details in (*CertificateManager) getEmbeddedUIServerTLSConfig()
+		// and (*CertificateManager) getUICertLocked().
+		certInfo = cm.NodeCert()
+	}
+	if certInfo.Error != nil {
+		log.Shout(ctx, log.Severity_ERROR,
+			"invalid UI certificate: %v", certInfo.Error)
+	} else {
+		cert := certInfo.ParsedCertificates[0]
+		addrInfo := certAddrs(cert)
+
+		// Log the certificate details in any case. This will aid during
+		// troubleshooting.
+		log.Infof(ctx, "web UI certificate addresses: %s", addrInfo)
+	}
+}
+
+// checkCertAddr verifies that the given address in addr is compatible
+// with the provided certificate.
+func checkCertAddr(
+	ctx context.Context, addr, msg string, notifyFunc func(msg, host string), cert *x509.Certificate,
+) {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		panic(fmt.Sprintf("programming error: %s address not normalized: %v", msg, err))
+	}
+	if err := cert.VerifyHostname(host); err != nil {
+		notifyFunc(msg, host)
+	}
+}
+
+// certAddrs formats the list of addresses included in a certificate for
+// printing in an error message.
+func certAddrs(cert *x509.Certificate) string {
+	// If an IP address was specified as listen/adv address, the
+	// hostname validation will only use the IPAddresses field. So this
+	// needs to be printed in all cases.
+	addrs := make([]string, len(cert.IPAddresses))
+	for i, ip := range cert.IPAddresses {
+		addrs[i] = ip.String()
+	}
+	// For names, the hostname validation will use DNSNames if
+	// the Subject Alt Name is present in the cert, otherwise
+	// it will use the common name. We can't parse the
+	// extensions here so we print both.
+	return fmt.Sprintf("IP=%s; DNS=%s; CN=%s",
+		strings.Join(addrs, ","),
+		strings.Join(cert.DNSNames, ","),
+		cert.Subject.CommonName)
 }

--- a/pkg/base/addr_validation_test.go
+++ b/pkg/base/addr_validation_test.go
@@ -1,0 +1,156 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package base_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+type addrs struct{ listen, adv, http, advhttp string }
+
+func (a *addrs) String() string {
+	return fmt.Sprintf("--listen-addr=%s --advertise-addr=%s --http-addr=%s (http adv: %s)",
+		a.listen, a.adv, a.http, a.advhttp)
+}
+
+func TestValidateAddrs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Prepare some reference strings that will be checked in the
+	// test below.
+	hostname, err := os.Hostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostAddrs, err := net.DefaultResolver.LookupIPAddr(context.Background(), hostname)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostAddr := hostAddrs[0].String()
+	if strings.Contains(hostAddr, ":") {
+		hostAddr = "[" + hostAddr + "]"
+	}
+	localAddrs, err := net.DefaultResolver.LookupIPAddr(context.Background(), "localhost")
+	if err != nil {
+		t.Fatal(err)
+	}
+	localAddr := localAddrs[0].String()
+	if strings.Contains(localAddr, ":") {
+		localAddr = "[" + localAddr + "]"
+	}
+
+	// The test cases.
+	testData := []struct {
+		in          addrs
+		expectedErr string
+		expected    addrs
+	}{
+		// Common case: no server flags, all defaults.
+		{addrs{":26257", "", ":8080", ""}, "",
+			addrs{":26257", hostname + ":26257", ":8080", hostname + ":8080"}},
+
+		// Another common case: --listen-addr=<somehost>
+		{addrs{hostname + ":26257", "", ":8080", ""}, "",
+			addrs{hostAddr + ":26257", hostname + ":26257", hostAddr + ":8080", hostname + ":8080"}},
+
+		// Another common case: --listen-addr=localhost
+		{addrs{"localhost:26257", "", ":8080", ""}, "",
+			addrs{localAddr + ":26257", "localhost:26257", localAddr + ":8080", "localhost:8080"}},
+
+		// Correct use: --listen-addr=<someaddr> --advertise-host=<somehost>
+		{addrs{hostAddr + ":26257", hostname + ":", ":8080", ""}, "",
+			addrs{hostAddr + ":26257", hostname + ":26257", hostAddr + ":8080", hostname + ":8080"}},
+
+		// Explicit port number in advertise addr.
+		{addrs{hostAddr + ":26257", hostname + ":12345", ":8080", ""}, "",
+			addrs{hostAddr + ":26257", hostname + ":12345", hostAddr + ":8080", hostname + ":8080"}},
+
+		// Use a non-numeric port number.
+		{addrs{":postgresql", "", ":http", ""}, "",
+			addrs{":5432", hostname + ":5432", ":80", hostname + ":80"}},
+
+		// Make HTTP local only.
+		{addrs{":26257", "", "localhost:8080", ""}, "",
+			addrs{":26257", hostname + ":26257", localAddr + ":8080", "localhost:8080"}},
+
+		// Local server but public HTTP.
+		{addrs{"localhost:26257", "", hostname + ":8080", ""}, "",
+			addrs{localAddr + ":26257", "localhost:26257", hostAddr + ":8080", hostname + ":8080"}},
+
+		// Not-unreasonable case: addresses set empty. Means using port 0.
+		{addrs{"", "", "", ""}, "",
+			addrs{":0", hostname + ":0", ":0", hostname + ":0"}},
+		{addrs{":", "", "", ""}, "",
+			addrs{":0", hostname + ":0", ":0", hostname + ":0"}},
+		{addrs{"", ":", "", ""}, "",
+			addrs{":0", hostname + ":0", ":0", hostname + ":0"}},
+		{addrs{"", "", ":", ""}, "",
+			addrs{":0", hostname + ":0", ":0", hostname + ":0"}},
+
+		// Advertise port 0 means reuse listen port. We don't
+		// auto-allocate ports for advertised addresses.
+		{addrs{":12345", ":0", "", ""}, "",
+			addrs{":12345", hostname + ":12345", ":0", hostname + ":0"}},
+
+		// Expected errors.
+
+		// Missing port number.
+		{addrs{"localhost", "", "", ""}, "invalid --listen-addr.*missing port in address", addrs{}},
+		{addrs{":26257", "", "localhost", ""}, "invalid --http-addr.*missing port in address", addrs{}},
+		// Invalid port number.
+		{addrs{"localhost:-1231", "", "", ""}, "invalid port", addrs{}},
+		{addrs{"localhost:nonexistent", "", "", ""}, "unknown port", addrs{}},
+		// Invalid address.
+		{addrs{"nonexistent.example.com:26257", "", "", ""}, "no such host", addrs{}},
+		{addrs{"333.333.333.333:26257", "", "", ""}, "no such host", addrs{}},
+	}
+
+	for _, test := range testData {
+		t.Run(test.in.String(), func(t *testing.T) {
+			cfg := base.Config{
+				Addr:          test.in.listen,
+				AdvertiseAddr: test.in.adv,
+				HTTPAddr:      test.in.http,
+			}
+
+			if err := cfg.ValidateAddrs(context.Background()); err != nil {
+				if !testutils.IsError(err, test.expectedErr) {
+					t.Fatalf("expected error %q, got %v", test.expectedErr, err)
+				}
+				return
+			}
+			if test.expectedErr != "" {
+				t.Fatalf("expected error %q, got success", test.expectedErr)
+			}
+
+			got := addrs{cfg.Addr, cfg.AdvertiseAddr, cfg.HTTPAddr, cfg.HTTPAdvertiseAddr}
+			gotStr := got.String()
+			expStr := test.expected.String()
+
+			if gotStr != expStr {
+				t.Fatalf("expected %q,\ngot %q", expStr, gotStr)
+			}
+		})
+	}
+}

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -129,13 +129,17 @@ type Config struct {
 	// route to an interface that Addr is listening on.
 	AdvertiseAddr string
 
-	// HTTPAddr is server's public HTTP address.
+	// HTTPAddr is the configured HTTP listen address.
 	//
 	// This is temporary, and will be removed when grpc.(*Server).ServeHTTP
 	// performance problems are addressed upstream.
 	//
 	// See https://github.com/grpc/grpc-go/issues/586.
 	HTTPAddr string
+
+	// HTTPAdvertiseAddr is the advertised HTTP address.
+	// This is computed from HTTPAddr if specified otherwise Addr.
+	HTTPAdvertiseAddr string
 
 	// The certificate manager. Must be accessed through GetCertificateManager.
 	certificateManager lazyCertificateManager
@@ -184,7 +188,7 @@ func (cfg *Config) HTTPRequestScheme() string {
 func (cfg *Config) AdminURL() *url.URL {
 	return &url.URL{
 		Scheme: cfg.HTTPRequestScheme(),
-		Host:   cfg.HTTPAddr,
+		Host:   cfg.HTTPAdvertiseAddr,
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -29,7 +29,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -173,8 +172,8 @@ type Server struct {
 
 // NewServer creates a Server from a server.Config.
 func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
-	if _, err := net.ResolveTCPAddr("tcp", cfg.AdvertiseAddr); err != nil {
-		return nil, errors.Errorf("unable to resolve RPC address %q: %v", cfg.AdvertiseAddr, err)
+	if err := cfg.ValidateAddrs(context.Background()); err != nil {
+		return nil, err
 	}
 
 	st := cfg.Settings
@@ -1067,22 +1066,12 @@ func (s *Server) Start(ctx context.Context) error {
 
 	ln, err := net.Listen("tcp", s.cfg.Addr)
 	if err != nil {
-		return ListenError{
-			error: err,
-			Addr:  s.cfg.Addr,
-		}
+		return ListenError{error: err, Addr: s.cfg.Addr}
+	}
+	if err := base.UpdateAddrs(ctx, &s.cfg.Addr, &s.cfg.AdvertiseAddr, ln.Addr()); err != nil {
+		return errors.Wrapf(err, "internal error: cannot parse listen address")
 	}
 	log.Eventf(ctx, "listening on port %s", s.cfg.Addr)
-	unresolvedListenAddr, err := officialAddr(ctx, s.cfg.Addr, ln.Addr(), os.Hostname)
-	if err != nil {
-		return err
-	}
-	s.cfg.Addr = unresolvedListenAddr.String()
-	unresolvedAdvertAddr, err := officialAddr(ctx, s.cfg.AdvertiseAddr, ln.Addr(), os.Hostname)
-	if err != nil {
-		return err
-	}
-	s.cfg.AdvertiseAddr = unresolvedAdvertAddr.String()
 
 	s.rpcContext.SetLocalInternalServer(s.node)
 
@@ -1105,11 +1094,9 @@ func (s *Server) Start(ctx context.Context) error {
 			Addr:  s.cfg.HTTPAddr,
 		}
 	}
-	unresolvedHTTPAddr, err := officialAddr(ctx, s.cfg.HTTPAddr, httpLn.Addr(), os.Hostname)
-	if err != nil {
-		return err
+	if err := base.UpdateAddrs(ctx, &s.cfg.HTTPAddr, &s.cfg.HTTPAdvertiseAddr, httpLn.Addr()); err != nil {
+		return errors.Wrapf(err, "internal error: cannot parse http listen address")
 	}
-	s.cfg.HTTPAddr = unresolvedHTTPAddr.String()
 
 	workersCtx := s.AnnotateCtx(context.Background())
 
@@ -1308,9 +1295,9 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// Write listener info files early in the startup sequence. `listenerInfo` has a comment.
 	listenerFiles := listenerInfo{
-		advertise: unresolvedAdvertAddr.String(),
-		http:      unresolvedHTTPAddr.String(),
-		listen:    unresolvedListenAddr.String(),
+		advertise: s.cfg.AdvertiseAddr,
+		http:      s.cfg.HTTPAdvertiseAddr,
+		listen:    s.cfg.Addr,
 	}.Iter()
 
 	for _, storeSpec := range s.cfg.Stores.Specs {
@@ -1346,8 +1333,10 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// Filter the gossip bootstrap resolvers based on the listen and
 	// advertise addresses.
-	filtered := s.cfg.FilterGossipBootstrapResolvers(ctx, unresolvedListenAddr, unresolvedAdvertAddr)
-	s.gossip.Start(unresolvedAdvertAddr, filtered)
+	listenAddrU := util.NewUnresolvedAddr("tcp", s.cfg.Addr)
+	advAddrU := util.NewUnresolvedAddr("tcp", s.cfg.AdvertiseAddr)
+	filtered := s.cfg.FilterGossipBootstrapResolvers(ctx, listenAddrU, advAddrU)
+	s.gossip.Start(advAddrU, filtered)
 	log.Event(ctx, "started gossip")
 
 	defer time.AfterFunc(30*time.Second, func() {
@@ -1445,7 +1434,7 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 	// we're joining an existing cluster for the first time.
 	if err := s.node.start(
 		ctx,
-		unresolvedAdvertAddr,
+		advAddrU,
 		bootstrappedEngines, emptyEngines,
 		s.cfg.NodeAttributes,
 		s.cfg.Locality,
@@ -1477,7 +1466,7 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 	})
 
 	// We can now add the node registry.
-	s.recorder.AddNode(s.registry, s.node.Descriptor, s.node.startedAt, s.cfg.AdvertiseAddr, s.cfg.HTTPAddr)
+	s.recorder.AddNode(s.registry, s.node.Descriptor, s.node.startedAt, s.cfg.AdvertiseAddr, s.cfg.HTTPAdvertiseAddr)
 
 	// Begin recording runtime statistics.
 	s.startSampleEnvironment(DefaultMetricsSampleInterval)
@@ -1532,9 +1521,9 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 	s.mux.Handle(statusVars, http.HandlerFunc(s.status.handleVars))
 	log.Event(ctx, "added http endpoints")
 
-	log.Infof(ctx, "starting %s server at %s", s.cfg.HTTPRequestScheme(), unresolvedHTTPAddr)
-	log.Infof(ctx, "starting grpc/postgres server at %s", unresolvedListenAddr)
-	log.Infof(ctx, "advertising CockroachDB node at %s", unresolvedAdvertAddr)
+	log.Infof(ctx, "starting %s server at %s", s.cfg.HTTPRequestScheme(), s.cfg.HTTPAdvertiseAddr)
+	log.Infof(ctx, "starting grpc/postgres server at %s", s.cfg.Addr)
+	log.Infof(ctx, "advertising CockroachDB node at %s", s.cfg.AdvertiseAddr)
 
 	log.Event(ctx, "accepting connections")
 
@@ -1941,45 +1930,6 @@ func (w *gzipResponseWriter) Close() error {
 	w.Reset(nil) // release ResponseWriter reference.
 	gzipResponseWriterPool.Put(w)
 	return err
-}
-
-func officialAddr(
-	ctx context.Context, cfgAddr string, lnAddr net.Addr, osHostname func() (string, error),
-) (*util.UnresolvedAddr, error) {
-	cfgHost, cfgPort, err := net.SplitHostPort(cfgAddr)
-	if err != nil {
-		return nil, err
-	}
-
-	lnHost, lnPort, err := net.SplitHostPort(lnAddr.String())
-	if err != nil {
-		return nil, err
-	}
-
-	host := cfgHost
-	if len(host) == 0 {
-		// A host was not provided. Ask the system.
-		name, err := osHostname()
-		if err != nil {
-			return nil, errors.Wrap(err, "unable to get hostname")
-		}
-		host = name
-	}
-	addrs, err := net.DefaultResolver.LookupHost(ctx, host)
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to lookup hostname %q", host)
-	}
-	if len(addrs) == 0 {
-		return nil, errors.Errorf("hostname %q did not resolve to any addresses; listener address: %s", host, lnHost)
-	}
-
-	// cfgPort may need to be used if --advertise-port was set on the command line.
-	port := lnPort
-	if i, err := strconv.Atoi(cfgPort); err == nil && i > 0 {
-		port = cfgPort
-	}
-
-	return util.NewUnresolvedAddr(lnAddr.Network(), net.JoinHostPort(host, port)), nil
 }
 
 func serveUIAssets(fileServer http.Handler, cfg Config) http.Handler {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1098,6 +1098,12 @@ func (s *Server) Start(ctx context.Context) error {
 		return errors.Wrapf(err, "internal error: cannot parse http listen address")
 	}
 
+	// Check the compatibility between the configured addresses and that
+	// provided in certificates. This also logs the certificate
+	// addresses in all cases to aid troubleshooting.
+	// This must be called after both calls to UpdateAddrs() above.
+	s.cfg.CheckCertificateAddrs(ctx)
+
 	workersCtx := s.AnnotateCtx(context.Background())
 
 	s.stopper.RunWorker(workersCtx, func(workersCtx context.Context) {
@@ -1521,7 +1527,8 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 	s.mux.Handle(statusVars, http.HandlerFunc(s.status.handleVars))
 	log.Event(ctx, "added http endpoints")
 
-	log.Infof(ctx, "starting %s server at %s", s.cfg.HTTPRequestScheme(), s.cfg.HTTPAdvertiseAddr)
+	log.Infof(ctx, "starting %s server at %s (use: %s)",
+		s.cfg.HTTPRequestScheme(), s.cfg.HTTPAddr, s.cfg.HTTPAdvertiseAddr)
 	log.Infof(ctx, "starting grpc/postgres server at %s", s.cfg.Addr)
 	log.Infof(ctx, "advertising CockroachDB node at %s", s.cfg.AdvertiseAddr)
 


### PR DESCRIPTION
Fixes #28500.

###  base,server: perform address validation and normalization upfront

Prior to this patch, the listen and advertise addresses were resolved
late in the server initialization, down to the point where the
`net.Listen()` call was made. 

This patch extracts address normalization earlier into a separate
method `(*Config).ValidateAddrs()` and removes this responsibility
from the `Server` code. The only thing that remains to be done
after `net.Listen()` is to update the port numbers if they were
automatically allocated.

This patch also adds proper support and validation for named ports.

Release note (cli change): CockroachDB now supports configuring port
numbers with `--listen-addr`/`--http-addr`/`--advertise-addr` using
service names in addition to numeric values.

### server,base: verify upfront that the addresses are listed in certs

Prior to this patch, CockroachDB made no attempt upfront at
verifying/validating that the addresses configured with
`--listen`/`--advertise` were present in the provided certificate
files. Instead, the validation was delayed upon the first received
client connection, which could occur much later than start-up and
would only be reported in the log file.

This led to poor UX, where an invalid certificate configuration
would *appear* to work (`cockroach start` reporting no error) but
client connections would fail (with more or less clear x509 errors).

To improve UX, this patch validates the configured addresses upfront
while the connections are being set up. If a discrepancy is detected,
it is logged immediately with a `log.Shout` so that it is more likely
to be seen by the human operator.

Also in any case the configured addresses inside the certificates are
logged, to aid troubleshooting.

For example:

```
$ cockroach cert create-node --certs-dir=certs localhost

$ ./cockroach start --certs-dir=certs --listen-addr=kenax
*
* WARNING: [n?] listen address "192.168.2.10" and advertise address "kenax" not in node certificate (dnsNames: localhost; commonName: node)
* Secure node-node and SQL connections are likely to fail.
* Consider extending the node certificate or use different server flags.
*
```

Release note (cli change): CockroachDB now attempts to inform the
operator if the names and IP addresses listed in the configured
certificates do not match the server configuration.