### PR TITLE
build:  install netbase in builder

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20180731-225910
+version=20180813-101406
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -191,6 +191,7 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key ad
 # ccache - speed up C and C++ compilation
 # lsof - roachprod monitor
 # netcat - roachprod monitor
+# netbase - /etc/services etc
 # nodejs - ui
 # openjdk-8-jre - railroad diagram generation
 # google-cloud-sdk - roachprod acceptance tests
@@ -201,6 +202,7 @@ RUN apt-get install -y --no-install-recommends \
     google-cloud-sdk \
     lsof \
     netcat \
+    netbase \
     nodejs \
     openjdk-8-jre \
     openssh-client \


### PR DESCRIPTION
Fixes #28504.

The builder needs /etc/services for some tests. Install `netbase` to
provide it.

