### PR TITLE
vendor: Update etcd

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -275,7 +275,7 @@
     "raft",
     "raft/raftpb",
   ]
-  revision = "90a2fbe50ebdb8f6e3cef987558dd73b9101d483"
+  revision = "3a037744dee9a7df42d3469917e3b34c02ae0bb3"
 
 [[projects]]
   name = "github.com/cpuguy83/go-md2man"


### PR DESCRIPTION
Picks up coreos/etcd#9982 and coreos/etcd#9985 (and no other changes
to packages we use).

Fixes #27983
Fixes #27804

Release note (bug fix): Additional fixes for out-of-memory errors
caused by very large raft logs.

Release note (performance improvement): Greatly improved performance
when catching up followers that are behind when raft logs are large.