### PR TITLE
storage: log when slow operations terminate

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1489,10 +1489,11 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) (LeaseStatus, *r
 		}
 
 		// Wait for the range lease to finish, or the context to expire.
-		pErr = func() *roachpb.Error {
+		pErr = func() (pErr *roachpb.Error) {
 			slowTimer := timeutil.NewTimer()
 			defer slowTimer.Stop()
 			slowTimer.Reset(base.SlowRequestThreshold)
+			tBegin := timeutil.Now()
 			for {
 				select {
 				case pErr = <-llHandle.C():
@@ -1537,7 +1538,10 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) (LeaseStatus, *r
 					log.Warningf(ctx, "have been waiting %s attempting to acquire lease",
 						base.SlowRequestThreshold)
 					r.store.metrics.SlowLeaseRequests.Inc(1)
-					defer r.store.metrics.SlowLeaseRequests.Dec(1)
+					defer func() {
+						r.store.metrics.SlowLeaseRequests.Dec(1)
+						log.Infof(ctx, "slow lease acquisition finished after %s with error %v", timeutil.Since(tBegin), pErr)
+					}()
 				case <-ctx.Done():
 					llHandle.Cancel()
 					log.VErrEventf(ctx, 2, "lease acquisition failed: %s", ctx.Err())


### PR DESCRIPTION
Log when a slow proposal, lease acquisition, or quota pool acquisition terminates.
Previously, we'd only log once when a timer had expired.

This is helpful to correlate the end times with other events across the cluster.
For example, if a slow command blocks the command queue, knowing approximately
when it leaves the command queue can help reason about other commands queued
behind it.
Similar, for slow lease proposals it's interesting when exactly they unwedge, and
whether that correlates with any other activity on the range such as snapshots.

Prompted specifically by #28179, where we see that leases for r1 are getting stuck,
but we don't even really know when they get unstuck.

Release note: None