### PR TITLE
sql/tree,sql/parser: remove UnaryPlus and keep negative constants

### DIFF
--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -46,9 +46,6 @@
 <table><thead>
 <tr><td><code>+</code></td><td>Return</td></tr>
 </thead><tbody>
-<tr><td><code>+</code><a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
-<tr><td><code>+</code><a href="float.html">float</a></td><td><a href="float.html">float</a></td></tr>
-<tr><td><code>+</code><a href="int.html">int</a></td><td><a href="int.html">int</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>+</code> <a href="int.html">int</a></td><td><a href="date.html">date</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>+</code> <a href="interval.html">interval</a></td><td><a href="timestamp.html">timestamptz</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>+</code> <a href="time.html">time</a></td><td><a href="timestamp.html">timestamp</a></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -116,7 +116,7 @@ INSERT INTO test VALUES (_, _, __more1__), (__more1__)            -
 SELECT (_, _, __more3__) FROM test WHERE _                        ·
 SELECT key FROM test.crdb_internal.node_statement_statistics      ·
 SELECT sin(_)                                                     ·
-SELECT sqrt(-_)                                                   !
+SELECT sqrt(_)                                                    !
 SELECT x FROM (VALUES (_, _, __more1__), (__more1__)) AS t (x)    ·
 SELECT x FROM test WHERE y = (_ / z)                              !+
 SELECT x FROM test WHERE y IN (_, _, _ + x, _, _)                 ·
@@ -142,7 +142,7 @@ INSERT INTO _ VALUES (_, _, __more1__), (__more1__)
 SELECT (_, _, __more3__) FROM _ WHERE _
 SELECT _ FROM _.crdb_internal.node_statement_statistics
 SELECT sin(_)
-SELECT sqrt(-_)
+SELECT sqrt(_)
 SELECT _ FROM (VALUES (_, _, __more1__), (__more1__)) AS _ (_)
 SELECT _ FROM _ WHERE _ = (_ / _)
 SELECT _ FROM _ WHERE _ IN (_, _, _ + _, _, _)

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -396,11 +396,7 @@ func (b *Builder) buildScalarHelper(
 
 	case *tree.UnaryExpr:
 		out = b.buildScalarHelper(t.TypedInnerExpr(), "", inScope, nil)
-
-		// Discard do-nothing unary plus operator.
-		if t.Operator != tree.UnaryPlus {
-			out = unaryOpMap[t.Operator](b.factory, out)
-		}
+		out = unaryOpMap[t.Operator](b.factory, out)
 
 	// NB: this is the exception to the sorting of the case statements. The
 	// tree.Datum case needs to occur after *tree.Placeholder which implements

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -2450,27 +2450,41 @@ build
 SELECT +k * (-w) AS r FROM kv GROUP BY +k, -w
 ----
 project
- ├── columns: r:7(int)
+ ├── columns: r:6(int)
  ├── group-by
- │    ├── columns: column5:5(int) column6:6(int)
- │    ├── grouping columns: column5:5(int) column6:6(int)
+ │    ├── columns: k:1(int!null) column5:5(int)
+ │    ├── grouping columns: k:1(int!null) column5:5(int)
  │    └── project
- │         ├── columns: column5:5(int) column6:6(int)
+ │         ├── columns: column5:5(int) k:1(int!null)
  │         ├── scan kv
  │         │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
  │         └── projections
- │              ├── variable: kv.k [type=int]
  │              └── unary-minus [type=int]
  │                   └── variable: kv.w [type=int]
  └── projections
       └── mult [type=int]
-           ├── variable: column5 [type=int]
-           └── variable: column6 [type=int]
+           ├── variable: kv.k [type=int]
+           └── variable: column5 [type=int]
 
 build
 SELECT k * (-w) FROM kv GROUP BY +k, -w
 ----
-error (42803): column "k" must appear in the GROUP BY clause or be used in an aggregate function
+project
+ ├── columns: "?column?":6(int)
+ ├── group-by
+ │    ├── columns: k:1(int!null) column5:5(int)
+ │    ├── grouping columns: k:1(int!null) column5:5(int)
+ │    └── project
+ │         ├── columns: column5:5(int) k:1(int!null)
+ │         ├── scan kv
+ │         │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │         └── projections
+ │              └── unary-minus [type=int]
+ │                   └── variable: kv.w [type=int]
+ └── projections
+      └── mult [type=int]
+           ├── variable: kv.k [type=int]
+           └── variable: column5 [type=int]
 
 build
 SELECT +k * (-w) AS r FROM kv GROUP BY k, w

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -317,8 +317,7 @@ case [type=int]
  │    │    ├── variable: @1 [type=int]
  │    │    └── const: 5 [type=int]
  │    └── const: 1 [type=int]
- └── unary-minus [type=int]
-      └── const: 1 [type=int]
+ └── const: -1 [type=int]
 
 build-scalar vars=(int)
 CASE WHEN @1 > 5 THEN 1 WHEN @1 < 0 THEN 2 ELSE -1 END
@@ -335,8 +334,7 @@ case [type=int]
  │    │    ├── variable: @1 [type=int]
  │    │    └── const: 0 [type=int]
  │    └── const: 2 [type=int]
- └── unary-minus [type=int]
-      └── const: 1 [type=int]
+ └── const: -1 [type=int]
 
 build-scalar vars=(int)
 CASE @1 WHEN 5 THEN 1 ELSE -1 END
@@ -346,8 +344,7 @@ case [type=int]
  ├── when [type=int]
  │    ├── const: 5 [type=int]
  │    └── const: 1 [type=int]
- └── unary-minus [type=int]
-      └── const: 1 [type=int]
+ └── const: -1 [type=int]
 
 build-scalar vars=(int, int)
 CASE @1 + 3 WHEN 5 * @2 THEN 1 % @2 WHEN 6 THEN 2 ELSE -1 END
@@ -366,8 +363,7 @@ case [type=int]
  ├── when [type=int]
  │    ├── const: 6 [type=int]
  │    └── const: 2 [type=int]
- └── unary-minus [type=int]
-      └── const: 1 [type=int]
+ └── const: -1 [type=int]
 
 # Tests for CASE with no ELSE statement
 build-scalar vars=(int)

--- a/pkg/sql/parser/scan.go
+++ b/pkg/sql/parser/scan.go
@@ -678,7 +678,7 @@ func (s *Scanner) scanNumber(lval *sqlSymType, ch int) {
 
 	for {
 		ch := s.peek()
-		if isHex && lex.IsHexDigit(ch) || lex.IsDigit(ch) {
+		if (isHex && lex.IsHexDigit(ch)) || lex.IsDigit(ch) {
 			s.pos++
 			continue
 		}

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6324,11 +6324,12 @@ a_expr:
   // b_expr and to the math_op list below.
 | '+' a_expr %prec UMINUS
   {
-    $$.val = &tree.UnaryExpr{Operator: tree.UnaryPlus, Expr: $2.expr()}
+    // Unary plus is a no-op. Desugar immediately.
+    $$.val = $2.expr()
   }
 | '-' a_expr %prec UMINUS
   {
-    $$.val = &tree.UnaryExpr{Operator: tree.UnaryMinus, Expr: $2.expr()}
+    $$.val = unaryNegation($2.expr())
   }
 | '~' a_expr %prec UMINUS
   {
@@ -6681,11 +6682,11 @@ b_expr:
   }
 | '+' b_expr %prec UMINUS
   {
-    $$.val = &tree.UnaryExpr{Operator: tree.UnaryPlus, Expr: $2.expr()}
+    $$.val = $2.expr()
   }
 | '-' b_expr %prec UMINUS
   {
-    $$.val = &tree.UnaryExpr{Operator: tree.UnaryMinus, Expr: $2.expr()}
+    $$.val = unaryNegation($2.expr())
   }
 | '~' b_expr %prec UMINUS
   {

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -496,7 +496,6 @@ func (constantFolderVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 }
 
 var unaryOpToToken = map[UnaryOperator]token.Token{
-	UnaryPlus:  token.ADD,
 	UnaryMinus: token.SUB,
 }
 var unaryOpToTokenIntOnly = map[UnaryOperator]token.Token{

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -103,30 +103,6 @@ type unaryOpOverload []overloadImpl
 
 // UnaryOps contains the unary operations indexed by operation type.
 var UnaryOps = map[UnaryOperator]unaryOpOverload{
-	UnaryPlus: {
-		UnaryOp{
-			Typ:        types.Int,
-			ReturnType: types.Int,
-			Fn: func(_ *EvalContext, d Datum) (Datum, error) {
-				return d, nil
-			},
-		},
-		UnaryOp{
-			Typ:        types.Float,
-			ReturnType: types.Float,
-			Fn: func(_ *EvalContext, d Datum) (Datum, error) {
-				return d, nil
-			},
-		},
-		UnaryOp{
-			Typ:        types.Decimal,
-			ReturnType: types.Decimal,
-			Fn: func(_ *EvalContext, d Datum) (Datum, error) {
-				return d, nil
-			},
-		},
-	},
-
 	UnaryMinus: {
 		UnaryOp{
 			Typ:        types.Int,

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1081,15 +1081,13 @@ func (UnaryOperator) operator() {}
 
 // UnaryExpr.Operator
 const (
-	UnaryPlus UnaryOperator = iota
-	UnaryMinus
+	UnaryMinus UnaryOperator = iota
 	UnaryComplement
 
 	NumUnaryOperators
 )
 
 var unaryOpName = [...]string{
-	UnaryPlus:       "+",
 	UnaryMinus:      "-",
 	UnaryComplement: "~",
 }
@@ -1115,7 +1113,17 @@ func (*UnaryExpr) operatorExpr() {}
 // Format implements the NodeFormatter interface.
 func (node *UnaryExpr) Format(ctx *FmtCtx) {
 	ctx.WriteString(node.Operator.String())
-	exprFmtWithParen(ctx, node.Expr)
+	e := node.Expr
+	_, isOp := e.(operatorExpr)
+	_, isDatum := e.(Datum)
+	_, isConstant := e.(Constant)
+	if isOp || (node.Operator == UnaryMinus && (isDatum || isConstant)) {
+		ctx.WriteByte('(')
+		ctx.FormatNode(e)
+		ctx.WriteByte(')')
+	} else {
+		ctx.FormatNode(e)
+	}
 }
 
 // TypedInnerExpr returns the UnaryExpr's inner expression as a TypedExpr.

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -59,6 +59,10 @@ func TestFormatStatement(t *testing.T) {
 		{`GRANT SELECT ON bar TO foo`, tree.FmtAnonymize,
 			`GRANT SELECT ON TABLE _ TO _`},
 
+		{`INSERT INTO a VALUES (-2, +3)`,
+			tree.FmtHideConstants,
+			`INSERT INTO a VALUES (_, _)`},
+
 		{`INSERT INTO a VALUES (0), (0), (0), (0), (0), (0)`,
 			tree.FmtHideConstants,
 			`INSERT INTO a VALUES (_), (__more5__)`},

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -90,9 +90,6 @@ func (expr *UnaryExpr) normalize(v *NormalizeVisitor) TypedExpr {
 	}
 
 	switch expr.Operator {
-	case UnaryPlus:
-		// +a -> a
-		return val
 	case UnaryMinus:
 		// -0 -> 0 (except for float which has negative zero)
 		if val.ResolvedType() != types.Float && v.isNumericZero(val) {


### PR DESCRIPTION
Fixes #28418.

This patch achieves the following:

- it completely removes the AST nodes for the unary plus operator. It
  had no semantic value whatsoever. Instead the syntax is fully
  desugared during parsing.
- it ensures that negation applied to a numeric literal is kept
  "inside" the numeric literals.
- it also disambiguates the negation unary expression from negative
  literals by adding that special case to `(*UnaryExpr).Format()`.

The net result (and the result that motivated this change in the first
place) is that negative/positive numbers are now keyed as a single
`_` in statement stats.

Prior to this patch, `INSERT ... VALUES (-1, +3)` would key
differently from `INSERT ... VALUES (+1, -3)`. This is silly and
inconvenient. With this patch, they now key in the same bucket as
expected.

Release note: None