### PR TITLE
storage: print trace for slow lease requests

### DIFF
--- a/pkg/storage/quota_pool.go
+++ b/pkg/storage/quota_pool.go
@@ -29,8 +29,10 @@ package storage
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -96,13 +98,22 @@ func (qp *quotaPool) add(v int64) {
 	qp.Unlock()
 }
 
+func logSlowQuota(ctx context.Context, v int64, start time.Time) func() {
+	log.Warningf(ctx, "have been waiting %s attempting to acquire %s of proposal quota",
+		humanizeutil.IBytes(v),
+		timeutil.Since(start))
+	return func() {
+		log.Infof(ctx, "acquiring %v of proposal quota after %s resulted in %v", v, humanizeutil.IBytes(v), timeutil.Since(start))
+	}
+}
+
 // acquire acquires the specified amount of quota from the pool. On success,
 // nil is returned and the caller must call add(v) or otherwise arrange for the
 // quota to be returned to the pool. If 'v' is greater than the total capacity
 // of the pool, we instead try to acquire quota equal to the maximum capacity.
 //
 // Safe for concurrent use.
-func (qp *quotaPool) acquire(ctx context.Context, v int64) error {
+func (qp *quotaPool) acquire(ctx context.Context, v int64) (err error) {
 	if v > qp.max {
 		v = qp.max
 	}
@@ -124,10 +135,9 @@ func (qp *quotaPool) acquire(ctx context.Context, v int64) error {
 	slowTimer.Reset(base.SlowRequestThreshold)
 	for {
 		select {
-		case now := <-slowTimer.C:
+		case <-slowTimer.C:
 			slowTimer.Read = true
-			log.Warningf(ctx, "have been waiting %s attempting to acquire quota",
-				now.Sub(start))
+			defer logSlowQuota(ctx, v, start)()
 			continue
 		case <-ctx.Done():
 			qp.Lock()
@@ -168,13 +178,11 @@ func (qp *quotaPool) acquire(ctx context.Context, v int64) error {
 	// next in line (if any).
 
 	var acquired int64
-	slowTimer.Reset(base.SlowRequestThreshold)
 	for acquired < v {
 		select {
-		case now := <-slowTimer.C:
+		case <-slowTimer.C:
 			slowTimer.Read = true
-			log.Warningf(ctx, "have been waiting %s attempting to acquire quota",
-				now.Sub(start))
+			defer logSlowQuota(ctx, v, start)()
 		case <-ctx.Done():
 			if acquired > 0 {
 				qp.add(acquired)

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1477,10 +1477,11 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) (LeaseStatus, *r
 		}
 
 		// Wait for the range lease to finish, or the context to expire.
-		pErr = func() *roachpb.Error {
+		pErr = func() (pErr *roachpb.Error) {
 			slowTimer := timeutil.NewTimer()
 			defer slowTimer.Stop()
 			slowTimer.Reset(base.SlowRequestThreshold)
+			tBegin := timeutil.Now()
 			for {
 				select {
 				case pErr = <-llHandle.C():
@@ -1525,7 +1526,10 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) (LeaseStatus, *r
 					log.Warningf(ctx, "have been waiting %s attempting to acquire lease",
 						base.SlowRequestThreshold)
 					r.store.metrics.SlowLeaseRequests.Inc(1)
-					defer r.store.metrics.SlowLeaseRequests.Dec(1)
+					defer func() {
+						r.store.metrics.SlowLeaseRequests.Dec(1)
+						log.Infof(ctx, "slow lease acquisition finished after %s with error %v", timeutil.Since(tBegin), pErr)
+					}()
 				case <-ctx.Done():
 					llHandle.Cancel()
 					log.VErrEventf(ctx, 2, "lease acquisition failed: %s", ctx.Err())

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1528,7 +1528,7 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) (LeaseStatus, *r
 					r.store.metrics.SlowLeaseRequests.Inc(1)
 					defer func() {
 						r.store.metrics.SlowLeaseRequests.Dec(1)
-						log.Infof(ctx, "slow lease acquisition finished after %s with error %v", timeutil.Since(tBegin), pErr)
+						log.Infof(ctx, "slow lease acquisition finished after %s with error %v after %d attempts", timeutil.Since(tBegin), pErr, attempt)
 					}()
 				case <-ctx.Done():
 					llHandle.Cancel()
@@ -3100,6 +3100,8 @@ func (r *Replica) tryExecuteWriteBatch(
 	slowTimer := timeutil.NewTimer()
 	defer slowTimer.Stop()
 	slowTimer.Reset(base.SlowRequestThreshold)
+	tBegin := timeutil.Now()
+
 	for {
 		select {
 		case propResult := <-ch:
@@ -3128,7 +3130,14 @@ func (r *Replica) tryExecuteWriteBatch(
 			log.Warningf(ctx, "have been waiting %s for proposing command %s",
 				base.SlowRequestThreshold, ba)
 			r.store.metrics.SlowRaftRequests.Inc(1)
-			defer r.store.metrics.SlowRaftRequests.Dec(1)
+			defer func() {
+				r.store.metrics.SlowRaftRequests.Dec(1)
+				contextStr := ""
+				if err := ctx.Err(); err != nil {
+					contextStr = " with context cancellation"
+				}
+				log.Infof(ctx, "slow command %s finished after %s%s", ba, timeutil.Since(tBegin), contextStr)
+			}()
 
 		case <-ctxDone:
 			// If our context was canceled, return an AmbiguousResultError


### PR DESCRIPTION
This experiments with the idea floated in #28282 (the discussion there is
about liveness, but it applies equally to lease requests)

The first three commits are #28519, please don't review them here.

Release note: None