### PR TITLE
kv: avoid splitting txns requiring 1PC on retries

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -542,7 +542,7 @@ func (ds *DistSender) initAndVerifyBatch(
 var errNo1PCTxn = roachpb.NewErrorf("cannot send 1PC txn to multiple ranges")
 
 // splitBatchAndCheckForRefreshSpans splits the batch according to the
-// canSplitET parmeter and checks whether the final request is an
+// canSplitET parameter and checks whether the final request is an
 // EndTransaction. If so, the EndTransactionRequest.NoRefreshSpans
 // flag is reset to indicate whether earlier parts of the split may
 // result in refresh spans.
@@ -612,9 +612,15 @@ func (ds *DistSender) Send(
 
 	var rplChunks []*roachpb.BatchResponse
 	splitET := false
+	var require1PC bool
+	lastReq := ba.Requests[len(ba.Requests)-1].GetInner()
+	if et, ok := lastReq.(*roachpb.EndTransactionRequest); ok && et.Require1PC {
+		require1PC = true
+	}
 	// To ensure that we lay down intents to prevent starvation, always
 	// split the end transaction request into its own batch on retries.
-	if ba.Txn != nil && ba.Txn.Epoch > 0 {
+	// Txns requiring 1PC are an exception and should never be split.
+	if ba.Txn != nil && ba.Txn.Epoch > 0 && !require1PC {
 		splitET = true
 	}
 	parts := splitBatchAndCheckForRefreshSpans(ba, splitET)
@@ -647,6 +653,8 @@ func (ds *DistSender) Send(
 			// here and try again.
 			if len(parts) != 1 {
 				panic("EndTransaction not in last chunk of batch")
+			} else if require1PC {
+				log.Fatalf(ctx, "required 1PC transaction cannot be split: %s", ba)
 			}
 			parts = splitBatchAndCheckForRefreshSpans(ba, true /* split ET */)
 			// Restart transaction of the last chunk as multiple parts

--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -1859,9 +1859,25 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				if atomic.AddInt32(&count, 1) > 1 {
 					return nil
 				}
-				pErr := roachpb.NewReadWithinUncertaintyIntervalError(
+				err := roachpb.NewReadWithinUncertaintyIntervalError(
 					fArgs.Hdr.Timestamp, s.Clock().Now(), fArgs.Hdr.Txn)
-				return roachpb.NewErrorWithTxn(pErr, fArgs.Hdr.Txn)
+				return roachpb.NewErrorWithTxn(err, fArgs.Hdr.Txn)
+			}
+			return nil
+		}
+	}
+
+	newRetryFilter := func(
+		key roachpb.Key, reason roachpb.TransactionRetryReason,
+	) func(storagebase.FilterArgs) *roachpb.Error {
+		var count int32
+		return func(fArgs storagebase.FilterArgs) *roachpb.Error {
+			if fArgs.Req.Header().Key.Equal(key) {
+				if atomic.AddInt32(&count, 1) > 1 {
+					return nil
+				}
+				err := roachpb.NewTransactionRetryError(reason)
+				return roachpb.NewErrorWithTxn(err, fArgs.Hdr.Txn)
 			}
 			return nil
 		}
@@ -1990,6 +2006,36 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				return txn.CommitInBatch(ctx, b)
 			},
 			// No retries, 1pc commit.
+		},
+		{
+			name: "require1PC commit with injected possible replay error",
+			retryable: func(ctx context.Context, txn *client.Txn) error {
+				b := txn.NewBatch()
+				b.Put("a", "put")
+				b.AddRawRequest(&roachpb.EndTransactionRequest{
+					Commit:     true,
+					Require1PC: true,
+				})
+				return txn.Run(ctx, b)
+			},
+			filter: newRetryFilter(roachpb.Key([]byte("a")), roachpb.RETRY_POSSIBLE_REPLAY),
+			// Expect a client retry, which should succeed.
+			clientRetry: true,
+		},
+		{
+			name: "require1PC commit with injected serializable error",
+			retryable: func(ctx context.Context, txn *client.Txn) error {
+				b := txn.NewBatch()
+				b.Put("a", "put")
+				b.AddRawRequest(&roachpb.EndTransactionRequest{
+					Commit:     true,
+					Require1PC: true,
+				})
+				return txn.Run(ctx, b)
+			},
+			filter: newRetryFilter(roachpb.Key([]byte("a")), roachpb.RETRY_SERIALIZABLE),
+			// Expect a transaction coord retry, which should succeed.
+			txnCoordRetry: true,
 		},
 		{
 			// If there are suitable retry conditions but we've exhausted the limit

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -164,7 +164,7 @@ var _ client.TxnSender = &TxnCoordSender{}
 type lockedSender interface {
 	// SendLocked sends the batch request and receives a batch response. It
 	// requires that the TxnCoordSender lock be held when called, but this lock
-	// is not heldfor the entire duration of the call. Instead, the lock is
+	// is not held for the entire duration of the call. Instead, the lock is
 	// released immediately before the batch is sent to a lower-level Sender and
 	// is re-acquired when the response is returned.
 	// WARNING: because the lock is released when calling this method and


### PR DESCRIPTION
Previously, on a retry (e.g. possible replay errors) batches would be
split to move the `EndTransactionRequest` into a second part. If the
`Require1PC` flag is set, we now no longer split the batch, which would
simply result in a failure.

Release note: None