### PR TITLE
monitoring: add expiration alerts for optional certificates.

### DIFF
--- a/monitoring/rules/alerts.rules.yml
+++ b/monitoring/rules/alerts.rules.yml
@@ -95,14 +95,41 @@ groups:
       frequency: daily
     annotations:
       summary: CA certificate for {{ $labels.instance }} expires in less than a year
+  - alert: ClientCACertificateExpiresSoon
+    expr: (security_certificate_expiration_client_ca{job="cockroachdb"} > 0) and (security_certificate_expiration_client_ca{job="cockroachdb"}
+      - time()) < 86400 * 366
+    labels:
+      frequency: daily
+    annotations:
+      summary: Client CA certificate for {{ $labels.instance }} expires in less than a year
+  - alert: UICACertificateExpiresSoon
+    expr: (security_certificate_expiration_ui_ca{job="cockroachdb"} > 0) and (security_certificate_expiration_ui_ca{job="cockroachdb"}
+      - time()) < 86400 * 366
+    labels:
+      frequency: daily
+    annotations:
+      summary: UI CA certificate for {{ $labels.instance }} expires in less than a year
   - alert: NodeCertificateExpiresSoon
     expr: (security_certificate_expiration_node{job="cockroachdb"} > 0) and (security_certificate_expiration_node{job="cockroachdb"}
       - time()) < 86400 * 183
     labels:
       frequency: daily
     annotations:
-      summary: Node certificate for {{ $labels.instance }} expires in less than six
-        months
+      summary: Node certificate for {{ $labels.instance }} expires in less than six months
+  - alert: NodeClientCertificateExpiresSoon
+    expr: (security_certificate_expiration_node_client{job="cockroachdb"} > 0) and (security_certificate_expiration_node_client{job="cockroachdb"}
+      - time()) < 86400 * 183
+    labels:
+      frequency: daily
+    annotations:
+      summary: Client certificate for {{ $labels.instance }} expires in less than six months
+  - alert: UICertificateExpiresSoon
+    expr: (security_certificate_expiration_ui{job="cockroachdb"} > 0) and (security_certificate_expiration_ui{job="cockroachdb"}
+      - time()) < 86400 * 30
+    labels:
+      frequency: daily
+    annotations:
+      summary: UI certificate for {{ $labels.instance }} expires in less than 30 days
   # Getting close to open file descriptor limit.
   - alert: HighOpenFDCount
     expr: sys_fd_open{job="cockroachdb"} / sys_fd_softlimit{job="cockroachdb"} > 0.8


### PR DESCRIPTION
We've recently added a number of optional certificates:
- client CA certificate
- client certificate for the node user
- UI CA certicate
- UI server certificate

Each has a corresponding certificate expiration metric. Add alerts for
all of them. The age threshold are somewhat arbitrary, with the UI
server certificate set fairly low for UI certificates as Let's Encrypt
is likely to be a common solution and has 90 day certificates.

Release note: None