### PR TITLE
cli: fix flake in test_error_hints.tcl

### DIFF
--- a/pkg/cli/error.go
+++ b/pkg/cli/error.go
@@ -59,7 +59,7 @@ var reGRPCAuthFailure = regexp.MustCompile(`authentication handshake failed: x50
 // provide one (i.e. the client was started with --insecure).
 // Note however in that case it's not certain what the problem is,
 // as the same error could be raised for other reasons.
-var reGRPCConnFailed = regexp.MustCompile(`desc = transport is closing`)
+var reGRPCConnFailed = regexp.MustCompile(`desc = (transport is closing|all SubConns are in TransientFailure)`)
 
 // MaybeDecorateGRPCError catches grpc errors and provides a more helpful error
 // message to the user.


### PR DESCRIPTION
Fixes #28525.

It's possible for a RPC client to connects to a server during server
initialization after the socket has been set up but before the TLS
context has been fully initialized. In that case the connection will
simply abort with no error, with a recommendation for the client to
retry (TransientFailure).

This patch extends the "error hinting" logic of CLI commands to
recognize this case too.

Release note: None