### PR TITLE
roachtest: skip the flaky cli/node-status test

### DIFF
--- a/pkg/cmd/roachtest/cli.go
+++ b/pkg/cmd/roachtest/cli.go
@@ -94,6 +94,7 @@ func registerCLI(r *registry) {
 	for _, tc := range testCases {
 		spec.SubTests = append(spec.SubTests, testSpec{
 			Name:   tc.name,
+			Skip:   "#28486: flaky",
 			Stable: true, // DO NOT COPY to new tests
 			Run:    tc.fn,
 		})


### PR DESCRIPTION
See #28486

Release note: None