### PR TITLE
 sql: epoch based table descriptor leases

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -88,6 +88,11 @@ const (
 	// DefaultTableDescriptorLeaseRenewalTimeout is the default time
 	// before a lease expires when acquisition to renew the lease begins.
 	DefaultTableDescriptorLeaseRenewalTimeout = time.Minute
+
+	// DefaultTableDescriptorLeaseEpochRefreshInterval is the default
+	// periodicity at which an attempt is made to refresh the LeaseManager
+	// local epoch.
+	DefaultTableDescriptorLeaseEpochRefreshInterval = 10 * time.Second
 )
 
 var defaultRaftElectionTimeoutTicks = envutil.EnvOrDefaultInt(
@@ -548,16 +553,21 @@ type LeaseManagerConfig struct {
 	// the lease renewal timeout.
 	TableDescriptorLeaseJitterFraction float64
 
-	// DefaultTableDescriptorLeaseRenewalTimeout is the default time
+	// TableDescriptorLeaseRenewalTimeout is the default time
 	// before a lease expires when acquisition to renew the lease begins.
 	TableDescriptorLeaseRenewalTimeout time.Duration
+
+	// TableDescriptorLeaseEpochRefreshInterval is the default periodicity
+	// at which an attempt is made to refresh the LeaseManager local epoch.
+	TableDescriptorLeaseEpochRefreshInterval time.Duration
 }
 
 // NewLeaseManagerConfig initializes a LeaseManagerConfig with default values.
 func NewLeaseManagerConfig() *LeaseManagerConfig {
 	return &LeaseManagerConfig{
-		TableDescriptorLeaseDuration:       DefaultTableDescriptorLeaseDuration,
-		TableDescriptorLeaseJitterFraction: DefaultTableDescriptorLeaseJitterFraction,
-		TableDescriptorLeaseRenewalTimeout: DefaultTableDescriptorLeaseRenewalTimeout,
+		TableDescriptorLeaseDuration:             DefaultTableDescriptorLeaseDuration,
+		TableDescriptorLeaseJitterFraction:       DefaultTableDescriptorLeaseJitterFraction,
+		TableDescriptorLeaseRenewalTimeout:       DefaultTableDescriptorLeaseRenewalTimeout,
+		TableDescriptorLeaseEpochRefreshInterval: DefaultTableDescriptorLeaseEpochRefreshInterval,
 	}
 }

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -93,6 +93,11 @@ const (
 	// periodicity at which an attempt is made to refresh the LeaseManager
 	// local epoch.
 	DefaultTableDescriptorLeaseEpochRefreshInterval = 10 * time.Second
+
+	// DefaultTableDescriptorLeasePurgeOldLeasesInterval is the default
+	// periodicity at which an attempt is made to purge old epoch leases
+	// originating from other nodes.
+	DefaultTableDescriptorLeasePurgeOldLeasesInterval = 1 * time.Minute
 )
 
 var defaultRaftElectionTimeoutTicks = envutil.EnvOrDefaultInt(
@@ -560,14 +565,19 @@ type LeaseManagerConfig struct {
 	// TableDescriptorLeaseEpochRefreshInterval is the default periodicity
 	// at which an attempt is made to refresh the LeaseManager local epoch.
 	TableDescriptorLeaseEpochRefreshInterval time.Duration
+
+	// TableDescriptorLeasePurgeOldLeasesInterval is the periodicity
+	// at which an attempt is made to refresh the LeaseManager local epoch.
+	TableDescriptorLeasePurgeOldLeasesInterval time.Duration
 }
 
 // NewLeaseManagerConfig initializes a LeaseManagerConfig with default values.
 func NewLeaseManagerConfig() *LeaseManagerConfig {
 	return &LeaseManagerConfig{
-		TableDescriptorLeaseDuration:             DefaultTableDescriptorLeaseDuration,
-		TableDescriptorLeaseJitterFraction:       DefaultTableDescriptorLeaseJitterFraction,
-		TableDescriptorLeaseRenewalTimeout:       DefaultTableDescriptorLeaseRenewalTimeout,
-		TableDescriptorLeaseEpochRefreshInterval: DefaultTableDescriptorLeaseEpochRefreshInterval,
+		TableDescriptorLeaseDuration:               DefaultTableDescriptorLeaseDuration,
+		TableDescriptorLeaseJitterFraction:         DefaultTableDescriptorLeaseJitterFraction,
+		TableDescriptorLeaseRenewalTimeout:         DefaultTableDescriptorLeaseRenewalTimeout,
+		TableDescriptorLeaseEpochRefreshInterval:   DefaultTableDescriptorLeaseEpochRefreshInterval,
+		TableDescriptorLeasePurgeOldLeasesInterval: DefaultTableDescriptorLeasePurgeOldLeasesInterval,
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -653,9 +653,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	s.execCfg = &execCfg
 
-	s.leaseMgr.SetExecCfg(&execCfg)
-	s.leaseMgr.RefreshLeases(s.stopper, s.db, s.gossip)
-
 	s.node.InitLogger(&execCfg)
 
 	return s, nil
@@ -1578,6 +1575,8 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 			return err
 		}
 	}
+
+	s.leaseMgr.Start(s.execCfg, s.nodeLiveness)
 
 	// Before serving SQL requests, we have to make sure the database is
 	// in an acceptable form for this version of the software.

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -448,7 +448,7 @@ func TestReportUsage(t *testing.T) {
 		"diagnostics.reporting.send_crash_reports": "false",
 		"server.time_until_store_dead":             "1m30s",
 		"trace.debug.enable":                       "false",
-		"version":                                  "2.0-11",
+		"version":                                  "2.0-12",
 		"cluster.secret":                           "<redacted>",
 	} {
 		if got, ok := r.last.AlteredSettings[key]; !ok {

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -68,6 +68,7 @@ const (
 	VersionAsyncConsensus
 	VersionBatchResponse
 	VersionCreateChangefeed
+	VersionWriteEpochBasedTableLeases
 
 	// Add new versions here (step one of two).
 
@@ -264,6 +265,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionCreateChangefeed is https://github.com/cockroachdb/cockroach/pull/27962.
 		Key:     VersionCreateChangefeed,
 		Version: roachpb.Version{Major: 2, Minor: 0, Unstable: 11},
+	},
+	{
+		// VersionCreateChangefeed is https://github.com/cockroachdb/cockroach/pull/28508.
+		Key:     VersionWriteEpochBasedTableLeases,
+		Version: roachpb.Version{Major: 2, Minor: 0, Unstable: 12},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -360,7 +360,7 @@ CREATE TABLE crdb_internal.leases (
 					if !leased {
 						continue
 					}
-					expCopy := state.leaseExpiration()
+					expCopy := state.storedExpiration()
 					if err := addRow(
 						nodeID,
 						tableID,

--- a/pkg/sql/lease_internal_test.go
+++ b/pkg/sql/lease_internal_test.go
@@ -207,9 +207,12 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	ts.mu.Lock()
 	correctLease := ts.mu.active.data[0].TableDescriptor.ID == tables[5].ID &&
 		ts.mu.active.data[0].TableDescriptor.Version == tables[5].Version
-	correctExpiration := ts.mu.active.data[0].expiration == expiration
-	correctEpoch := ts.mu.active.data[0].epoch == 1
+	epoch := ts.mu.active.data[0].epoch
+	correctEpoch := epoch == 1
 	ts.mu.Unlock()
+	leaseManager.mu.Lock()
+	correctExpiration := leaseManager.mu.expiration[epoch] == expiration
+	leaseManager.mu.Unlock()
 	if !correctLease {
 		t.Fatalf("wrong lease survived purge")
 	}

--- a/pkg/sql/lease_internal_test.go
+++ b/pkg/sql/lease_internal_test.go
@@ -197,7 +197,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 		t.Fatalf("found %d versions instead of 2", numLeases)
 	}
 	if err := purgeOldVersions(
-		context.TODO(), kvDB, tableDesc.ID, false, 2 /* minVersion */, leaseManager); err != nil {
+		context.TODO(), tableDesc.ID, false, 2 /* minVersion */, leaseManager); err != nil {
 		t.Fatal(err)
 	}
 
@@ -208,12 +208,16 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	correctLease := ts.mu.active.data[0].TableDescriptor.ID == tables[5].ID &&
 		ts.mu.active.data[0].TableDescriptor.Version == tables[5].Version
 	correctExpiration := ts.mu.active.data[0].expiration == expiration
+	correctEpoch := ts.mu.active.data[0].epoch == 1
 	ts.mu.Unlock()
 	if !correctLease {
 		t.Fatalf("wrong lease survived purge")
 	}
 	if !correctExpiration {
 		t.Fatalf("wrong lease expiration survived purge")
+	}
+	if !correctEpoch {
+		t.Fatalf("wrong lease epoch survived purge")
 	}
 
 	// Test that purgeOldVersions correctly removes a table version
@@ -229,7 +233,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 		t.Fatalf("found %d versions instead of 2", numLeases)
 	}
 	if err := purgeOldVersions(
-		context.TODO(), kvDB, tableDesc.ID, false, 2 /* minVersion */, leaseManager); err != nil {
+		context.TODO(), tableDesc.ID, false, 2 /* minVersion */, leaseManager); err != nil {
 		t.Fatal(err)
 	}
 	if numLeases := getNumVersions(ts); numLeases != 1 {

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -1083,15 +1083,174 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 
 type mockNodeLiveness struct {
 	epoch int64
+	mu    struct {
+		syncutil.Mutex
+		livenesses []storage.Liveness
+	}
 }
 
 func (m *mockNodeLiveness) Self() (*storage.Liveness, error) {
 	return &storage.Liveness{Epoch: atomic.LoadInt64(&m.epoch)}, nil
 }
 
+func (m *mockNodeLiveness) GetLivenesses() []storage.Liveness {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.mu.livenesses
+}
+
+func (m *mockNodeLiveness) setLivenesses(livenesses []storage.Liveness) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.mu.livenesses = livenesses
+}
+
 // This test makes sure leases get renewed automatically when the node
 // liveness epoch changes.
 func TestLeaseRenewedWithEpochChange(testingT *testing.T) {
+	defer leaktest.AfterTest(testingT)()
+
+	var testAcquiredCount int32
+	var testAcquisitionBlockCount int32
+	var testAcquisitionFreshestCount int32
+	var nl mockNodeLiveness
+	atomic.AddInt64(&nl.epoch, 1)
+
+	params, _ := tests.CreateTestServerParams()
+	params.Knobs = base.TestingKnobs{
+		SQLLeaseManager: &sql.LeaseManagerTestingKnobs{
+			MockNodeLiveness: &nl,
+			LeaseStoreTestingKnobs: sql.LeaseStoreTestingKnobs{
+				// We want to track when leases get acquired and when they are renewed.
+				// We also want to know when acquiring blocks to test lease renewal.
+				LeaseAcquiredEvent: func(table sqlbase.TableDescriptor, _ error) {
+					if table.ID > keys.MaxReservedDescID {
+						atomic.AddInt32(&testAcquiredCount, 1)
+					}
+				},
+				LeaseAcquireResultBlockEvent: func(eventType sql.LeaseAcquireBlockType) {
+					switch eventType {
+					case sql.LeaseAcquireBlock:
+						atomic.AddInt32(&testAcquisitionBlockCount, 1)
+
+					case sql.LeaseAcquireFreshestBlock:
+						atomic.AddInt32(&testAcquisitionFreshestCount, 1)
+					}
+				},
+			},
+		},
+	}
+	params.LeaseManagerConfig = base.NewLeaseManagerConfig()
+	// The lease jitter is set to ensure newer leases have higher
+	// expiration timestamps.
+	params.LeaseManagerConfig.TableDescriptorLeaseJitterFraction = 0.0
+	// Speed up epoch refresh.
+	params.LeaseManagerConfig.TableDescriptorLeaseEpochRefreshInterval = 100 * time.Millisecond
+
+	ctx := context.Background()
+	t := newLeaseTest(testingT, params)
+	defer t.cleanup()
+
+	if _, err := t.db.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test1 (k CHAR PRIMARY KEY, v CHAR);
+CREATE TABLE t.test2 ();
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	test2Desc := sqlbase.GetTableDescriptor(t.kvDB, "t", "test2")
+	dbID := test2Desc.ParentID
+
+	// Acquire a lease on test1 by name.
+	ts1, eo1, err := t.node(1).AcquireByName(ctx, t.server.Clock().Now(), dbID, "test1")
+	if err != nil {
+		t.Fatal(err)
+	} else if err := t.release(1, ts1); err != nil {
+		t.Fatal(err)
+	} else if count := atomic.LoadInt32(&testAcquiredCount); count != 1 {
+		t.Fatalf("expected 1 lease to be acquired, but acquired %d times",
+			count)
+	}
+
+	// Acquire a lease on test2 by ID.
+	ts2, eo2, err := t.node(1).Acquire(ctx, t.server.Clock().Now(), test2Desc.ID)
+	if err != nil {
+		t.Fatal(err)
+	} else if err := t.release(1, ts2); err != nil {
+		t.Fatal(err)
+	} else if count := atomic.LoadInt32(&testAcquiredCount); count != 2 {
+		t.Fatalf("expected 2 leases to be acquired, but acquired %d times",
+			count)
+	}
+
+	// Reset testAcquisitionBlockCount as the first acqusition will always block.
+	atomic.StoreInt32(&testAcquisitionBlockCount, 0)
+
+	// Increment the epoch.
+	atomic.AddInt64(&nl.epoch, 1)
+
+	testutils.SucceedsSoon(t, func() error {
+		// Acquire another lease by name on test1. At first this will be the
+		// same lease, but eventually we will see a renewed lease.
+		ts1, en1, err := t.node(1).AcquireByName(ctx, t.server.Clock().Now(), dbID, "test1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := t.release(1, ts1); err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		// We check for the new expiry time because if our past acquire triggered
+		// the background renewal, the next lease we get will be the result of the
+		// background renewal.
+		if en1.WallTime <= eo1.WallTime {
+			return errors.Errorf("expected new lease expiration (%s) to be after old lease expiration (%s)",
+				en1, eo1)
+		} else if count := atomic.LoadInt32(&testAcquiredCount); count < 2 {
+			return errors.Errorf("expected at least 2 leases to be acquired, but acquired %d times",
+				count)
+		} else if blockCount := atomic.LoadInt32(&testAcquisitionBlockCount); blockCount > 0 {
+			t.Fatalf("expected repeated lease acquisition to not block, but blockCount is: %d", blockCount)
+		}
+
+		// Acquire another lease by ID on test2. At first this will be the same
+		// lease, but eventually we will asynchronously renew a lease and our
+		// acquire will get a newer lease.
+		ts2, en2, err := t.node(1).Acquire(ctx, t.server.Clock().Now(), test2Desc.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := t.release(1, ts2); err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		// We check for the new expiry time because if our past acquire triggered
+		// the background renewal, the next lease we get will be the result of the
+		// background renewal.
+		if en2.WallTime <= eo2.WallTime {
+			return errors.Errorf("expected new lease expiration (%s) to be after old lease expiration (%s)",
+				en2, eo2)
+		} else if count := atomic.LoadInt32(&testAcquiredCount); count < 3 {
+			return errors.Errorf("expected at least 3 leases to be acquired, but acquired %d times",
+				count)
+		} else if blockCount := atomic.LoadInt32(&testAcquisitionBlockCount); blockCount > 0 {
+			t.Fatalf("expected repeated lease acquisition to not block, but blockCount is: %d", blockCount)
+		}
+
+		return nil
+	})
+
+	if count := atomic.LoadInt32(&testAcquisitionFreshestCount); count != 2 {
+		t.Fatalf("freshest lease acquisition count is: %d", count)
+	}
+}
+
+func TestLeasePurgeWithEpochChange(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
 
 	var testAcquiredCount int32
@@ -1530,4 +1689,93 @@ CREATE TABLE t.test0 (k CHAR PRIMARY KEY, v CHAR);
 	}()
 
 	wg.Wait()
+}
+
+func TestReleaseOldEpochs(testingT *testing.T) {
+	defer leaktest.AfterTest(testingT)()
+	params, _ := tests.CreateTestServerParams()
+	var numReleases int32
+	var nl mockNodeLiveness
+	atomic.StoreInt64(&nl.epoch, 2)
+	nodeLivenesses := []storage.Liveness{
+		{NodeID: 1, Epoch: 3},
+		{NodeID: 2, Epoch: 9},
+		{NodeID: 3, Epoch: 7},
+	}
+	// Copy of node livenesses for the mock node livenesses.
+	var copy []storage.Liveness
+	for _, n := range nodeLivenesses {
+		copy = append(copy, n)
+	}
+	nl.setLivenesses(copy)
+	params.Knobs = base.TestingKnobs{
+		SQLLeaseManager: &sql.LeaseManagerTestingKnobs{
+			MockNodeLiveness: &nl,
+			LeaseStoreTestingKnobs: sql.LeaseStoreTestingKnobs{
+				ReleaseOldEpochLeases: func(nodeID roachpb.NodeID, epoch int64, count int) {
+					atomic.AddInt32(&numReleases, 1)
+					match := false
+					for _, n := range nodeLivenesses {
+						if n.NodeID == nodeID && n.Epoch == epoch+1 {
+							match = true
+							break
+						}
+					}
+					if !match {
+						testingT.Errorf("unexpected epoch = %d", epoch)
+					}
+					if count != 0 && count != 1 {
+						testingT.Errorf("unexpected count = %d", count)
+					}
+				},
+			},
+		},
+	}
+	params.LeaseManagerConfig = base.NewLeaseManagerConfig()
+	// The lease jitter is set to ensure newer leases have higher
+	// expiration timestamps.
+	params.LeaseManagerConfig.TableDescriptorLeaseJitterFraction = 0.0
+	// epoch leases expire quickly.
+	params.LeaseManagerConfig.TableDescriptorLeaseDuration = 100 * time.Millisecond
+	// Speed up purge process.
+	params.LeaseManagerConfig.TableDescriptorLeasePurgeOldLeasesInterval = 40 * time.Millisecond
+
+	t := newLeaseTest(testingT, params)
+	defer t.cleanup()
+
+	for i, _ := range nodeLivenesses {
+		_ = t.node(uint32(i + 1))
+	}
+
+	numNodes := len(nodeLivenesses)
+	expectedReleases := numNodes * (numNodes - 1)
+	testutils.SucceedsSoon(t, func() error {
+		if n := atomic.LoadInt32(&numReleases); int(n) != expectedReleases {
+			return errors.Errorf("num releases: %d", n)
+		}
+		return nil
+	})
+
+	// Add a new node and increment the epoch on one node.
+	nodeLivenesses = []storage.Liveness{
+		{NodeID: 1, Epoch: 3},
+		{NodeID: 2, Epoch: 10},
+		{NodeID: 3, Epoch: 7},
+		{NodeID: 4, Epoch: 7},
+	}
+	// Copy of node livenesses for the mock node livenesses.
+	copy = nil
+	for _, n := range nodeLivenesses {
+		copy = append(copy, n)
+	}
+	nl.setLivenesses(copy)
+
+	// 2 for the node whose epoch has increased and 3 for the new node.
+	expectedReleases += 2 + 3
+	testutils.SucceedsSoon(t, func() error {
+		if n := atomic.LoadInt32(&numReleases); int(n) != expectedReleases {
+			return errors.Errorf("num releases: %d", n)
+		}
+		return nil
+	})
 }

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -207,6 +208,9 @@ func (t *leaseTest) node(nodeID uint32) *sql.LeaseManager {
 			t.server.Stopper(),
 			t.cfg,
 		)
+		if mockLiveness := t.leaseManagerTestingKnobs.MockNodeLiveness; mockLiveness != nil {
+			mgr.SetLiveness(mockLiveness)
+		}
 		t.nodes[nodeID] = mgr
 	}
 	return mgr
@@ -1248,6 +1252,159 @@ CREATE TABLE t.test2 ();
 
 		return nil
 	})
+}
+
+type mockNodeLiveness struct {
+	epoch int64
+}
+
+func (m *mockNodeLiveness) Self() (*storage.Liveness, error) {
+	return &storage.Liveness{Epoch: atomic.LoadInt64(&m.epoch)}, nil
+}
+
+// This test makes sure leases get renewed automatically when the node
+// liveness epoch changes.
+func TestLeaseRenewedWithEpochChange(testingT *testing.T) {
+	defer leaktest.AfterTest(testingT)()
+
+	var testAcquiredCount int32
+	var testAcquisitionBlockCount int32
+	var testAcquisitionFreshestCount int32
+	var nl mockNodeLiveness
+	atomic.AddInt64(&nl.epoch, 1)
+
+	params, _ := tests.CreateTestServerParams()
+	params.Knobs = base.TestingKnobs{
+		SQLLeaseManager: &sql.LeaseManagerTestingKnobs{
+			MockNodeLiveness: &nl,
+			LeaseStoreTestingKnobs: sql.LeaseStoreTestingKnobs{
+				// We want to track when leases get acquired and when they are renewed.
+				// We also want to know when acquiring blocks to test lease renewal.
+				LeaseAcquiredEvent: func(table sqlbase.TableDescriptor, _ error) {
+					if table.ID > keys.MaxReservedDescID {
+						atomic.AddInt32(&testAcquiredCount, 1)
+					}
+				},
+				LeaseAcquireResultBlockEvent: func(eventType sql.LeaseAcquireBlockType) {
+					switch eventType {
+					case sql.LeaseAcquireBlock:
+						atomic.AddInt32(&testAcquisitionBlockCount, 1)
+
+					case sql.LeaseAcquireFreshestBlock:
+						atomic.AddInt32(&testAcquisitionFreshestCount, 1)
+					}
+				},
+			},
+		},
+	}
+	params.LeaseManagerConfig = base.NewLeaseManagerConfig()
+	// The lease jitter is set to ensure newer leases have higher
+	// expiration timestamps.
+	params.LeaseManagerConfig.TableDescriptorLeaseJitterFraction = 0.0
+	// Speed up epoch refresh.
+	params.LeaseManagerConfig.TableDescriptorLeaseEpochRefreshInterval = 100 * time.Millisecond
+
+	ctx := context.Background()
+	t := newLeaseTest(testingT, params)
+	defer t.cleanup()
+
+	if _, err := t.db.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test1 (k CHAR PRIMARY KEY, v CHAR);
+CREATE TABLE t.test2 ();
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	test2Desc := sqlbase.GetTableDescriptor(t.kvDB, "t", "test2")
+	dbID := test2Desc.ParentID
+
+	// Acquire a lease on test1 by name.
+	ts1, eo1, err := t.node(1).AcquireByName(ctx, t.server.Clock().Now(), dbID, "test1")
+	if err != nil {
+		t.Fatal(err)
+	} else if err := t.release(1, ts1); err != nil {
+		t.Fatal(err)
+	} else if count := atomic.LoadInt32(&testAcquiredCount); count != 1 {
+		t.Fatalf("expected 1 lease to be acquired, but acquired %d times",
+			count)
+	}
+
+	// Acquire a lease on test2 by ID.
+	ts2, eo2, err := t.node(1).Acquire(ctx, t.server.Clock().Now(), test2Desc.ID)
+	if err != nil {
+		t.Fatal(err)
+	} else if err := t.release(1, ts2); err != nil {
+		t.Fatal(err)
+	} else if count := atomic.LoadInt32(&testAcquiredCount); count != 2 {
+		t.Fatalf("expected 2 leases to be acquired, but acquired %d times",
+			count)
+	}
+
+	// Reset testAcquisitionBlockCount as the first acqusition will always block.
+	atomic.StoreInt32(&testAcquisitionBlockCount, 0)
+
+	// Increment the epoch.
+	atomic.AddInt64(&nl.epoch, 1)
+
+	testutils.SucceedsSoon(t, func() error {
+		// Acquire another lease by name on test1. At first this will be the
+		// same lease, but eventually we will see a renewed lease.
+		ts1, en1, err := t.node(1).AcquireByName(ctx, t.server.Clock().Now(), dbID, "test1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := t.release(1, ts1); err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		// We check for the new expiry time because if our past acquire triggered
+		// the background renewal, the next lease we get will be the result of the
+		// background renewal.
+		if en1.WallTime <= eo1.WallTime {
+			return errors.Errorf("expected new lease expiration (%s) to be after old lease expiration (%s)",
+				en1, eo1)
+		} else if count := atomic.LoadInt32(&testAcquiredCount); count < 2 {
+			return errors.Errorf("expected at least 2 leases to be acquired, but acquired %d times",
+				count)
+		} else if blockCount := atomic.LoadInt32(&testAcquisitionBlockCount); blockCount > 0 {
+			t.Fatalf("expected repeated lease acquisition to not block, but blockCount is: %d", blockCount)
+		}
+
+		// Acquire another lease by ID on test2. At first this will be the same
+		// lease, but eventually we will asynchronously renew a lease and our
+		// acquire will get a newer lease.
+		ts2, en2, err := t.node(1).Acquire(ctx, t.server.Clock().Now(), test2Desc.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := t.release(1, ts2); err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		// We check for the new expiry time because if our past acquire triggered
+		// the background renewal, the next lease we get will be the result of the
+		// background renewal.
+		if en2.WallTime <= eo2.WallTime {
+			return errors.Errorf("expected new lease expiration (%s) to be after old lease expiration (%s)",
+				en2, eo2)
+		} else if count := atomic.LoadInt32(&testAcquiredCount); count < 3 {
+			return errors.Errorf("expected at least 3 leases to be acquired, but acquired %d times",
+				count)
+		} else if blockCount := atomic.LoadInt32(&testAcquisitionBlockCount); blockCount > 0 {
+			t.Fatalf("expected repeated lease acquisition to not block, but blockCount is: %d", blockCount)
+		}
+
+		return nil
+	})
+
+	if count := atomic.LoadInt32(&testAcquisitionFreshestCount); count != 2 {
+		t.Fatalf("freshest lease acquisition count is: %d", count)
+	}
 }
 
 // Check that the table version is incremented with every schema change.

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -244,7 +244,7 @@ select crdb_internal.set_vmodule('')
 query T
 select crdb_internal.node_executable_version()
 ----
-2.0-11
+2.0-12
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -341,4 +341,4 @@ select * from crdb_internal.gossip_alerts
 query T
 select crdb_internal.node_executable_version()
 ----
-2.0-11
+2.0-12

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -734,6 +734,7 @@ system         public        jobs              payload         4
 system         public        jobs              progress        5
 system         public        jobs              status          2
 system         public        lease             descID          1
+system         public        lease             epoch           5
 system         public        lease             expiration      4
 system         public        lease             nodeID          3
 system         public        lease             version         2

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -279,7 +279,7 @@ dist sender send  querying next range at /Table/2/1/53/"kv2"/3/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
 dist sender send  querying next range at /Table/3/1/55/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  r1: sending batch 1 EndTxn, 1 QueryIntent to (n1,s1):1
+dist sender send  r1: sending batch 1 EndTxn, 2 QueryIntent to (n1,s1):1
 sql txn           Scan /Table/55/{1-2}
 dist sender send  querying next range at /Table/55/1
 dist sender send  r1: sending batch 1 Scan to (n1,s1):1

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -110,6 +110,7 @@ descID      INT        false  NULL  ·  {"primary"}
 version     INT        false  NULL  ·  {"primary"}
 nodeID      INT        false  NULL  ·  {"primary"}
 expiration  TIMESTAMP  false  NULL  ·  {"primary"}
+epoch       INT        true   NULL  ·  {}
 
 query TTBTTT
 SHOW COLUMNS FROM system.eventlog

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -77,6 +77,7 @@ CREATE TABLE system.lease (
   version    INT,
   "nodeID"   INT,
   expiration TIMESTAMP,
+  epoch      INT,
   PRIMARY KEY ("descID", version, expiration, "nodeID")
 );`
 
@@ -408,10 +409,12 @@ var (
 			{Name: "version", ID: 2, Type: colTypeInt},
 			{Name: "nodeID", ID: 3, Type: colTypeInt},
 			{Name: "expiration", ID: 4, Type: colTypeTimestamp},
+			{Name: "epoch", ID: 5, Type: colTypeInt, Nullable: true},
 		},
-		NextColumnID: 5,
+		NextColumnID: 6,
 		Families: []ColumnFamilyDescriptor{
 			{Name: "primary", ID: 0, ColumnNames: []string{"descID", "version", "nodeID", "expiration"}, ColumnIDs: []ColumnID{1, 2, 3, 4}},
+			{Name: "fam_5_epoch", ID: 5, ColumnNames: []string{"epoch"}, ColumnIDs: []ColumnID{5}, DefaultColumnID: 5},
 		},
 		PrimaryIndex: IndexDescriptor{
 			Name:             "primary",
@@ -421,7 +424,7 @@ var (
 			ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC, IndexDescriptor_ASC, IndexDescriptor_ASC, IndexDescriptor_ASC},
 			ColumnIDs:        []ColumnID{1, 2, 4, 3},
 		},
-		NextFamilyID:   1,
+		NextFamilyID:   6,
 		NextIndexID:    2,
 		Privileges:     NewCustomSuperuserPrivilegeDescriptor(SystemAllowedPrivileges[keys.LeaseTableID]),
 		FormatVersion:  InterleavedFormatVersion,

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -1363,6 +1363,9 @@ func TestReacquireLeaseOnRestart(t *testing.T) {
 	params, _ := tests.CreateTestServerParams()
 	params.Knobs.Store = storeTestingKnobs
 	params.Knobs.KVClient = clientTestingKnobs
+	params.LeaseManagerConfig = base.NewLeaseManagerConfig()
+	// Speed up epoch refresh.
+	params.LeaseManagerConfig.TableDescriptorLeaseEpochRefreshInterval = 100 * time.Millisecond
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 


### PR DESCRIPTION
The first two commits can be review separately and are a part of a different PR.