### PR TITLE
distsql: make planningCtx's spanIter instantiation lazy

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -548,7 +548,12 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 ) {
 	evalCtx := p.ExtendedEvalContext()
 	txn := p.txn
-	planCtx := dsp.NewPlanningCtx(ctx, evalCtx, txn)
+	var planCtx PlanningCtx
+	if distribute {
+		planCtx = dsp.NewPlanningCtx(ctx, evalCtx, txn)
+	} else {
+		planCtx = dsp.newLocalPlanningCtx(ctx, evalCtx)
+	}
 	planCtx.isLocal = !distribute
 	planCtx.planner = p
 	planCtx.stmtType = recv.stmtType


### PR DESCRIPTION
Release note: None

Some good improvements here, will check the throughput improvement (hopefully there's some) out as well.

```
name                          old time/op    new time/op    delta
FlowSetup/distribute=true-8     44.1µs ± 3%    46.8µs ± 9%   +6.12%  (p=0.022 n=9+10)
FlowSetup/distribute=false-8    68.2µs ±12%    40.2µs ± 5%  -41.04%  (p=0.000 n=10+10)

name                          old alloc/op   new alloc/op   delta
FlowSetup/distribute=true-8     38.2kB ± 0%    38.2kB ± 0%     ~     (p=0.560 n=9+9)
FlowSetup/distribute=false-8     126kB ± 0%      32kB ± 0%  -74.60%  (p=0.000 n=8+10)

name                          old allocs/op  new allocs/op  delta
FlowSetup/distribute=true-8        366 ± 0%       367 ± 0%     ~     (p=1.000 n=10+10)
FlowSetup/distribute=false-8       321 ± 0%       317 ± 0%   -1.25%  (p=0.002 n=8+10)
Switched to branch 'txncoord'
```