### PR TITLE
storage: disable proposal refreshes in flaky lease tests

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1006,12 +1006,18 @@ func TestRefreshPendingCommands(t *testing.T) {
 	// possible for node 3 to propose the RequestLease command and have that
 	// command executed by the other nodes but to never see the execution locally
 	// because it is caught up by applying a snapshot.
-	testCases := []storage.StoreTestingKnobs{
-		{DisableRefreshReasonNewLeader: true, DisableRefreshReasonTicks: true},
-		{DisableRefreshReasonNewLeader: true, DisableRefreshReasonSnapshotApplied: true},
+	testCases := map[string]storage.StoreTestingKnobs{
+		"reasonSnapshotApplied": {
+			DisableRefreshReasonNewLeader: true,
+			DisableRefreshReasonTicks:     true,
+		},
+		"reasonTicks": {
+			DisableRefreshReasonNewLeader:       true,
+			DisableRefreshReasonSnapshotApplied: true,
+		},
 	}
-	for _, c := range testCases {
-		t.Run("", func(t *testing.T) {
+	for name, c := range testCases {
+		t.Run(name, func(t *testing.T) {
 			sc := storage.TestStoreConfig(nil)
 			sc.TestingKnobs = c
 			// Disable periodic gossip tasks which can move the range 1 lease

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4196,7 +4196,9 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 			if len(e.Data) == 0 {
 				// Overwrite unconditionally since this is the most aggressive
 				// reproposal mode.
-				refreshReason = reasonNewLeaderOrConfigChange
+				if !r.store.TestingKnobs().DisableRefreshReasonNewLeaderOrConfigChange {
+					refreshReason = reasonNewLeaderOrConfigChange
+				}
 				commandID = "" // special-cased value, command isn't used
 			} else {
 				var encodedCommand []byte

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -773,9 +773,13 @@ type StoreTestingKnobs struct {
 	// DisableLeaderFollowsLeaseholder disables attempts to transfer raft
 	// leadership when it diverges from the range's leaseholder.
 	DisableLeaderFollowsLeaseholder bool
-	// DisableRefreshReasonTicks disables refreshing pending commands when a new
+	// DisableRefreshReasonNewLeader disables refreshing pending commands when a new
 	// leader is discovered.
 	DisableRefreshReasonNewLeader bool
+	// DisableRefreshReasonNewLeaderOrConfigChange disables refreshing pending
+	// commands when a new leader is discovered or when a config change is
+	// dropped.
+	DisableRefreshReasonNewLeaderOrConfigChange bool
 	// DisableRefreshReasonTicks disables refreshing pending commands when a
 	// snapshot is applied.
 	DisableRefreshReasonSnapshotApplied bool


### PR DESCRIPTION
Fixes #28086.
Fixes #28026.
Fixes #28230.
Fixes #28277.
Fixes #28334.
Fixes #28421.
Fixes #28479.
Fixes #28546.
Fixes #28547.

This commit adjusts `TestLeaseConcurrent` and `TestReplicaLeaseCounters`
to ignore `reasonNewLeaderOrConfigChange` proposal refreshes, which allows
them to avoid the flake discussed in #28086.