### PR TITLE
sql/sem/tree: fix the pretty-printing for IMPORT

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1018,6 +1018,7 @@ func TestParse(t *testing.T) {
 		{`IMPORT TABLE foo CREATE USING 'nodelocal:///some/file' MYSQLOUTFILE DATA ('path/to/some/file', $1)`},
 		{`IMPORT TABLE foo (id INT PRIMARY KEY, email STRING, age INT) CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
 		{`IMPORT TABLE foo (id INT, email STRING, age INT) CSV DATA ('path/to/some/file', $1) WITH comma = ',', "nullif" = 'n/a', temp = $2`},
+		{`IMPORT TABLE foo FROM PGDUMPCREATE ('nodelocal:///some/file') WITH temp = 'path/to/temp'`},
 		{`EXPORT INTO CSV 'a' FROM TABLE a`},
 		{`EXPORT INTO CSV 'a' FROM SELECT * FROM a`},
 		{`EXPORT INTO CSV 's3://my/path/%part%.csv' WITH delimiter = '|' FROM TABLE a`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1632,6 +1632,10 @@ import_format:
 // %Help: IMPORT - load data from file in a distributed manner
 // %Category: CCL
 // %Text:
+// IMPORT [ TABLE <tablename> FROM ]
+//        <format> ( <datafile> )
+//        [ WITH <option> [= <value>] [, ...] ]
+//
 // IMPORT TABLE <tablename>
 //        { ( <elements> ) | CREATE USING <schemafile> }
 //        <format>

--- a/pkg/sql/sem/tree/import.go
+++ b/pkg/sql/sem/tree/import.go
@@ -33,6 +33,7 @@ func (node *Import) Format(ctx *FmtCtx) {
 
 	if node.Bundle {
 		if node.Table.TableNameReference != nil {
+			ctx.WriteString("TABLE ")
 			ctx.FormatNode(&node.Table)
 			ctx.WriteString(" FROM ")
 		}


### PR DESCRIPTION
Fixes #28562.

The IMPORT statement didn't roundtrip properly. This patch fixes it.

Also the contextual help is extended to include the new IMPORT syntax.

Release note: None