### PR TITLE
opt: minor optimizations and tests for stats

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -632,3 +632,107 @@ project
       │              └── const: 5 [type=int]
       └── aggregations
            └── count-rows [type=int]
+
+exec-ddl
+CREATE TABLE abc (a INT, b INT, c INT, PRIMARY KEY (a, c))
+----
+TABLE abc
+ ├── a int not null
+ ├── b int
+ ├── c int not null
+ └── INDEX primary
+      ├── a int not null
+      └── c int not null
+
+exec-ddl
+CREATE TABLE def (d INT, e INT, f INT, PRIMARY KEY (f, e), INDEX e_idx (e) STORING (d))
+----
+TABLE def
+ ├── d int
+ ├── e int not null
+ ├── f int not null
+ ├── INDEX primary
+ │    ├── f int not null
+ │    └── e int not null
+ └── INDEX e_idx
+      ├── e int not null
+      ├── f int not null
+      └── d int (storing)
+
+# Set up the statistics as if the first table is much smaller than the second.
+exec-ddl
+ALTER TABLE abc INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 100,
+    "distinct_count": 100
+  }
+]'
+----
+
+exec-ddl
+ALTER TABLE def INJECT STATISTICS '[
+  {
+    "columns": ["e"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 100
+  },
+  {
+    "columns": ["f"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000
+  }
+]'
+----
+
+# The filter a=f is selective, so we expect a lookup join.
+opt
+SELECT * FROM abc JOIN def ON a = f
+----
+inner-join (lookup def)
+ ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) e:5(int!null) f:6(int!null)
+ ├── key columns: [1] = [6]
+ ├── stats: [rows=100, distinct(1)=100, distinct(6)=100]
+ ├── key: (3,5,6)
+ ├── fd: (1,3)-->(2), (5,6)-->(4), (1)==(6), (6)==(1)
+ ├── scan abc
+ │    ├── columns: a:1(int!null) b:2(int) c:3(int!null)
+ │    ├── stats: [rows=100, distinct(1)=100]
+ │    ├── key: (1,3)
+ │    └── fd: (1,3)-->(2)
+ └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+      └── eq [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+           ├── variable: abc.a [type=int, outer=(1)]
+           └── variable: def.f [type=int, outer=(6)]
+
+# The filter a=e is not very selective, so we do not expect a lookup join.
+opt
+SELECT * FROM abc JOIN def ON a = e
+----
+inner-join (merge)
+ ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) e:5(int!null) f:6(int!null)
+ ├── stats: [rows=10000, distinct(1)=100, distinct(5)=100]
+ ├── key: (3,5,6)
+ ├── fd: (1,3)-->(2), (5,6)-->(4), (1)==(5), (5)==(1)
+ ├── scan abc
+ │    ├── columns: a:1(int!null) b:2(int) c:3(int!null)
+ │    ├── stats: [rows=100, distinct(1)=100]
+ │    ├── key: (1,3)
+ │    ├── fd: (1,3)-->(2)
+ │    └── ordering: +1
+ ├── scan def@e_idx
+ │    ├── columns: d:4(int) e:5(int!null) f:6(int!null)
+ │    ├── stats: [rows=10000, distinct(5)=100]
+ │    ├── key: (5,6)
+ │    ├── fd: (5,6)-->(4)
+ │    └── ordering: +5
+ └── merge-on
+      ├── left ordering: +1
+      ├── right ordering: +5
+      └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+           └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+                ├── variable: abc.a [type=int, outer=(1)]
+                └── variable: def.e [type=int, outer=(5)]

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -642,3 +642,37 @@ select
            │    ├── variable: order_history.customer_id [type=int, outer=(3)]
            │    └── const: 2 [type=int]
            └── const: 0 [type=int]
+
+exec-ddl
+CREATE TABLE c (x INT, z INT NOT NULL, UNIQUE INDEX x_idx (x))
+----
+TABLE c
+ ├── x int
+ ├── z int not null
+ ├── rowid int not null (hidden)
+ ├── INDEX primary
+ │    └── rowid int not null (hidden)
+ └── INDEX x_idx
+      ├── x int
+      └── rowid int not null (hidden) (storing)
+
+# Test that the distinct count for x is estimated correctly (since it's a weak
+# key).
+norm
+SELECT * FROM c WHERE x >= 0 AND x < 100
+----
+select
+ ├── columns: x:1(int!null) z:2(int!null)
+ ├── stats: [rows=100, distinct(1)=100]
+ ├── fd: (1)-->(2)
+ ├── scan c
+ │    ├── columns: x:1(int) z:2(int!null)
+ │    ├── stats: [rows=1000, distinct(1)=1000]
+ │    └── fd: (1)~~>(2)
+ └── filters [type=bool, outer=(1), constraints=(/1: [/0 - /99]; tight)]
+      ├── ge [type=bool, outer=(1), constraints=(/1: [/0 - ]; tight)]
+      │    ├── variable: c.x [type=int, outer=(1)]
+      │    └── const: 0 [type=int]
+      └── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /99]; tight)]
+           ├── variable: c.x [type=int, outer=(1)]
+           └── const: 100 [type=int]


### PR DESCRIPTION
This commit is a minor update to the larger stats PR #28315.

1. It adds an optimization to the `colStatFromChild`
function in statisticsBuilder: if the caller already knows
which child should contain the requested stats, the caller
can pass in the child index.

2. It adds a test case to show that injecting statistics
allows control over whether or not a lookup join is chosen
instead of a hash/merge join.

3. It adds a test case to ensure that the distinct count for
weak keys is estimated correctly.

Release note: None