### PR TITLE
debug: add encryption-status command.

### DIFF
--- a/c-deps/libroach/batch.cc
+++ b/c-deps/libroach/batch.cc
@@ -532,6 +532,10 @@ DBString DBBatch::GetCompactionStats() { return ToDBString("unsupported"); }
 
 DBStatus DBBatch::GetEnvStats(DBEnvStatsResult* stats) { return FmtStatus("unsupported"); }
 
+DBStatus DBBatch::GetEncryptionRegistries(DBEncryptionRegistries* result) {
+  return FmtStatus("unsupported");
+}
+
 DBStatus DBBatch::EnvWriteFile(DBSlice path, DBSlice contents) { return FmtStatus("unsupported"); }
 
 DBStatus DBBatch::EnvOpenFile(DBSlice path, rocksdb::WritableFile** file) {
@@ -611,15 +615,17 @@ DBStatus DBWriteOnlyBatch::ApplyBatchRepr(DBSlice repr, bool sync) {
 
 DBSlice DBWriteOnlyBatch::BatchRepr() { return ToDBSlice(batch.GetWriteBatch()->Data()); }
 
-DBIterator* DBWriteOnlyBatch::NewIter(DBIterOptions) {
-  return NULL;
-}
+DBIterator* DBWriteOnlyBatch::NewIter(DBIterOptions) { return NULL; }
 
 DBStatus DBWriteOnlyBatch::GetStats(DBStatsResult* stats) { return FmtStatus("unsupported"); }
 
 DBString DBWriteOnlyBatch::GetCompactionStats() { return ToDBString("unsupported"); }
 
 DBStatus DBWriteOnlyBatch::GetEnvStats(DBEnvStatsResult* stats) { return FmtStatus("unsupported"); }
+
+DBStatus DBWriteOnlyBatch::GetEncryptionRegistries(DBEncryptionRegistries* result) {
+  return FmtStatus("unsupported");
+}
 
 DBStatus DBWriteOnlyBatch::EnvWriteFile(DBSlice path, DBSlice contents) {
   return FmtStatus("unsupported");
@@ -649,7 +655,9 @@ DBStatus DBWriteOnlyBatch::EnvDeleteFile(DBSlice path) { return FmtStatus("unsup
 
 DBStatus DBWriteOnlyBatch::EnvDeleteDirAndFiles(DBSlice dir) { return FmtStatus("unsupported"); }
 
-DBStatus DBWriteOnlyBatch::EnvLinkFile(DBSlice oldname, DBSlice newname) { return FmtStatus("unsupported"); }
+DBStatus DBWriteOnlyBatch::EnvLinkFile(DBSlice oldname, DBSlice newname) {
+  return FmtStatus("unsupported");
+}
 
 rocksdb::WriteBatch::Handler* GetDBBatchInserter(::rocksdb::WriteBatchBase* batch) {
   return new DBBatchInserter(batch);

--- a/c-deps/libroach/batch.h
+++ b/c-deps/libroach/batch.h
@@ -41,6 +41,7 @@ struct DBBatch : public DBEngine {
   virtual DBStatus GetStats(DBStatsResult* stats);
   virtual DBString GetCompactionStats();
   virtual DBStatus GetEnvStats(DBEnvStatsResult* stats);
+  virtual DBStatus GetEncryptionRegistries(DBEncryptionRegistries* result);
   virtual DBStatus EnvWriteFile(DBSlice path, DBSlice contents);
   virtual DBStatus EnvOpenFile(DBSlice path, rocksdb::WritableFile** file);
   virtual DBStatus EnvReadFile(DBSlice path, DBSlice* contents);
@@ -71,6 +72,7 @@ struct DBWriteOnlyBatch : public DBEngine {
   virtual DBStatus GetStats(DBStatsResult* stats);
   virtual DBString GetCompactionStats();
   virtual DBString GetEnvStats(DBEnvStatsResult* stats);
+  virtual DBStatus GetEncryptionRegistries(DBEncryptionRegistries* result);
   virtual DBStatus EnvWriteFile(DBSlice path, DBSlice contents);
   virtual DBStatus EnvOpenFile(DBSlice path, rocksdb::WritableFile** file);
   virtual DBStatus EnvReadFile(DBSlice path, DBSlice* contents);

--- a/c-deps/libroach/ccl/db.cc
+++ b/c-deps/libroach/ccl/db.cc
@@ -58,6 +58,23 @@ class CCLEnvStatsHandler : public EnvStatsHandler {
     return rocksdb::Status::OK();
   }
 
+  virtual rocksdb::Status GetEncryptionRegistry(std::string* serialized_registry) override {
+    if (data_key_manager_ == nullptr) {
+      return rocksdb::Status::OK();
+    }
+
+    auto key_registry = data_key_manager_->GetScrubbedRegistry();
+    if (key_registry == nullptr) {
+      return rocksdb::Status::OK();
+    }
+
+    if (!key_registry->SerializeToString(serialized_registry)) {
+      return rocksdb::Status::InvalidArgument("failed to serialize data keys registry");
+    }
+
+    return rocksdb::Status::OK();
+  }
+
   virtual std::string GetActiveDataKeyID() override {
     // Look up the current data key.
     if (data_key_manager_ == nullptr) {

--- a/c-deps/libroach/ccl/key_manager.cc
+++ b/c-deps/libroach/ccl/key_manager.cc
@@ -173,7 +173,7 @@ std::string StoreKeyInfoSummary(const enginepbccl::KeyInfo& info) {
   if (info.encryption_type() == enginepbccl::Plaintext) {
     return "plain";
   }
-  return fmt::StringPrintf("ID: %s, Type: %s, Source: %s", info.key_id().substr(0, 8).c_str(),
+  return fmt::StringPrintf("ID: %s, Type: %s, Source: %s", info.key_id().c_str(),
                            AlgorithmEnumToString(info.encryption_type()).c_str(),
                            info.source().c_str());
 }
@@ -182,10 +182,9 @@ std::string DataKeyInfoSummary(const enginepbccl::KeyInfo& info) {
   if (info.encryption_type() == enginepbccl::Plaintext) {
     return "plain";
   }
-  return fmt::StringPrintf("ID: %s, Type: %s, Parent Key ID: %s",
-                           info.key_id().substr(0, 8).c_str(),
+  return fmt::StringPrintf("ID: %s, Type: %s, Parent Key ID: %s", info.key_id().c_str(),
                            AlgorithmEnumToString(info.encryption_type()).c_str(),
-                           info.parent_key_id().substr(0, 8).c_str());
+                           info.parent_key_id().c_str());
 }
 
 };  // namespace KeyManagerUtils
@@ -349,6 +348,22 @@ std::unique_ptr<enginepbccl::KeyInfo> DataKeyManager::GetActiveStoreKeyInfo() {
   // Any modification of the registry should have called Validate.
   assert(iter != registry_->store_keys().cend());
   return std::unique_ptr<enginepbccl::KeyInfo>(new enginepbccl::KeyInfo(iter->second));
+}
+
+std::unique_ptr<enginepbccl::DataKeysRegistry> DataKeyManager::GetScrubbedRegistry() const {
+  std::unique_lock<std::mutex> l(mu_);
+  if (registry_ == nullptr) {
+    return nullptr;
+  }
+
+  auto new_registry =
+      std::unique_ptr<enginepbccl::DataKeysRegistry>(new enginepbccl::DataKeysRegistry(*registry_));
+  auto keys = new_registry->mutable_data_keys();
+  for (auto key_iter = keys->begin(); key_iter != keys->end(); ++key_iter) {
+    key_iter->second.clear_key();
+  }
+
+  return new_registry;
 }
 
 rocksdb::Status DataKeyManager::MaybeRotateKeyLocked() {

--- a/c-deps/libroach/ccl/key_manager.h
+++ b/c-deps/libroach/ccl/key_manager.h
@@ -132,6 +132,9 @@ class DataKeyManager : public KeyManager {
   // be accurate here.
   std::unique_ptr<enginepbccl::KeyInfo> GetActiveStoreKeyInfo();
 
+  // GetScrubbedRegistry returns a copy of the key registry with key contents scrubbed.
+  std::unique_ptr<enginepbccl::DataKeysRegistry> GetScrubbedRegistry() const;
+
   virtual std::shared_ptr<enginepbccl::SecretKey> CurrentKey() override;
   virtual std::shared_ptr<enginepbccl::SecretKey> GetKey(const std::string& id) override;
 
@@ -157,7 +160,7 @@ class DataKeyManager : public KeyManager {
   // current_key_ is the active data key (or nullptr if none present yet) and is updated every time
   // registry_ is modified.
   // TODO(mberhault): use a shared_mutex for multiple read-only holders.
-  std::mutex mu_;
+  mutable std::mutex mu_;
   std::unique_ptr<enginepbccl::DataKeysRegistry> registry_;
   std::shared_ptr<enginepbccl::SecretKey> current_key_;
 };

--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -639,6 +639,10 @@ DBString DBGetCompactionStats(DBEngine* db) { return db->GetCompactionStats(); }
 
 DBStatus DBGetEnvStats(DBEngine* db, DBEnvStatsResult* stats) { return db->GetEnvStats(stats); }
 
+DBStatus DBGetEncryptionRegistries(DBEngine* db, DBEncryptionRegistries* result) {
+  return db->GetEncryptionRegistries(result);
+}
+
 DBSSTable* DBGetSSTables(DBEngine* db, int* n) { return db->GetSSTables(n); }
 
 DBString DBGetUserProperties(DBEngine* db) { return db->GetUserProperties(); }

--- a/c-deps/libroach/db_test.cc
+++ b/c-deps/libroach/db_test.cc
@@ -46,6 +46,12 @@ TEST(Libroach, DBOpen) {
   EXPECT_EQ(stats.active_key_files, 0);
   EXPECT_EQ(stats.active_key_bytes, 0);
 
+  // Fetch registries, parse, and check that they're empty.
+  DBEncryptionRegistries result;
+  EXPECT_STREQ(DBGetEncryptionRegistries(db, &result).data, NULL);
+  EXPECT_STREQ(result.key_registry.data, NULL);
+  EXPECT_STREQ(result.file_registry.data, NULL);
+
   DBClose(db);
 }
 

--- a/c-deps/libroach/engine.h
+++ b/c-deps/libroach/engine.h
@@ -42,6 +42,7 @@ struct DBEngine {
   virtual DBStatus GetStats(DBStatsResult* stats) = 0;
   virtual DBString GetCompactionStats() = 0;
   virtual DBString GetEnvStats(DBEnvStatsResult* stats) = 0;
+  virtual DBStatus GetEncryptionRegistries(DBEncryptionRegistries* result) = 0;
   virtual DBStatus EnvWriteFile(DBSlice path, DBSlice contents) = 0;
   virtual DBStatus EnvOpenFile(DBSlice path, rocksdb::WritableFile** file) = 0;
   virtual DBStatus EnvReadFile(DBSlice path, DBSlice* contents) = 0;
@@ -87,6 +88,7 @@ struct DBImpl : public DBEngine {
   virtual DBStatus GetStats(DBStatsResult* stats);
   virtual DBString GetCompactionStats();
   virtual DBStatus GetEnvStats(DBEnvStatsResult* stats);
+  virtual DBStatus GetEncryptionRegistries(DBEncryptionRegistries* result);
   virtual DBStatus EnvWriteFile(DBSlice path, DBSlice contents);
   virtual DBStatus EnvOpenFile(DBSlice path, rocksdb::WritableFile** file);
   virtual DBStatus EnvReadFile(DBSlice path, DBSlice* contents);

--- a/c-deps/libroach/env_manager.h
+++ b/c-deps/libroach/env_manager.h
@@ -25,7 +25,10 @@ class EnvStatsHandler {
  public:
   virtual ~EnvStatsHandler() {}
 
+  // Get serialized encryption stats.
   virtual rocksdb::Status GetEncryptionStats(std::string* stats) = 0;
+  // Get a serialized encryption registry (scrubbed of key contents).
+  virtual rocksdb::Status GetEncryptionRegistry(std::string* registry) = 0;
   // Get the ID of the active data key, or "plain" if none.
   virtual std::string GetActiveDataKeyID() = 0;
   // Get the key ID in use by this file, or "plain" if none.

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -346,9 +346,18 @@ typedef struct {
   DBString encryption_status;
 } DBEnvStatsResult;
 
+// DBEncryptionRegistries contains file and key registries.
+typedef struct {
+  // File registry.
+  DBString file_registry;
+  // Key registry (with actual keys scrubbed).
+  DBString key_registry;
+} DBEncryptionRegistries;
+
 DBStatus DBGetStats(DBEngine* db, DBStatsResult* stats);
 DBString DBGetCompactionStats(DBEngine* db);
 DBStatus DBGetEnvStats(DBEngine* db, DBEnvStatsResult* stats);
+DBStatus DBGetEncryptionRegistries(DBEngine* db, DBEncryptionRegistries* result);
 
 typedef struct {
   int level;

--- a/c-deps/libroach/snapshot.cc
+++ b/c-deps/libroach/snapshot.cc
@@ -13,10 +13,10 @@
 // permissions and limitations under the License.
 
 #include "snapshot.h"
+#include "encoding.h"
 #include "getter.h"
 #include "iterator.h"
 #include "status.h"
-#include "encoding.h"
 
 namespace cockroach {
 
@@ -56,6 +56,10 @@ DBString DBSnapshot::GetCompactionStats() { return ToDBString("unsupported"); }
 
 DBStatus DBSnapshot::GetEnvStats(DBEnvStatsResult* stats) { return FmtStatus("unsupported"); }
 
+DBStatus DBSnapshot::GetEncryptionRegistries(DBEncryptionRegistries* result) {
+  return FmtStatus("unsupported");
+}
+
 DBStatus DBSnapshot::EnvWriteFile(DBSlice path, DBSlice contents) {
   return FmtStatus("unsupported");
 }
@@ -80,6 +84,8 @@ DBStatus DBSnapshot::EnvDeleteFile(DBSlice path) { return FmtStatus("unsupported
 
 DBStatus DBSnapshot::EnvDeleteDirAndFiles(DBSlice dir) { return FmtStatus("unsupported"); }
 
-DBStatus DBSnapshot::EnvLinkFile(DBSlice oldname, DBSlice newname) { return FmtStatus("unsupported"); }
+DBStatus DBSnapshot::EnvLinkFile(DBSlice oldname, DBSlice newname) {
+  return FmtStatus("unsupported");
+}
 
 }  // namespace cockroach

--- a/c-deps/libroach/snapshot.h
+++ b/c-deps/libroach/snapshot.h
@@ -38,6 +38,7 @@ struct DBSnapshot : public DBEngine {
   virtual DBStatus GetStats(DBStatsResult* stats);
   virtual DBString GetCompactionStats();
   virtual DBStatus GetEnvStats(DBEnvStatsResult* stats);
+  virtual DBStatus GetEncryptionRegistries(DBEncryptionRegistries* result);
   virtual DBStatus EnvWriteFile(DBSlice path, DBSlice contents);
   virtual DBStatus EnvOpenFile(DBSlice path, rocksdb::WritableFile** file);
   virtual DBStatus EnvReadFile(DBSlice path, DBSlice* contents);

--- a/pkg/ccl/cliccl/debug.go
+++ b/pkg/ccl/cliccl/debug.go
@@ -9,16 +9,60 @@
 package cliccl
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
 	"github.com/cockroachdb/cockroach/pkg/ccl/baseccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/cliccl/cliflagsccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl/enginepbccl"
 	"github.com/cockroachdb/cockroach/pkg/cli"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/spf13/cobra"
 )
 
-// This does not define new commands, only adds the encryption flag to debug commands in
-// `pkg/cli/debug.go` and registers a callback to generate encryption options.
+// Defines CCL-specific debug commands, adds the encryption flag to debug commands in
+// `pkg/cli/debug.go`, and registers a callback to generate encryption options.
+
+var encryptionStatusOpts struct {
+	activeStoreIDOnly bool
+}
 
 func init() {
+	encryptionStatusCmd := &cobra.Command{
+		Use:   "encryption-status <directory>",
+		Short: "show encryption status of a store",
+		Long: `
+Shows encryption status of the store located in 'directory'.
+Encryption keys must be specified in the '--enterprise-encryption' flag.
+
+Displays all store and data keys as well as files encrypted with each.
+Specifying --active-store-key-id-only prints the key ID of the active store key
+and exits.
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: cli.MaybeDecorateGRPCError(runEncryptionStatus),
+	}
+
+	// Add it to the root debug command. We can't add it to the lists of commands (eg: DebugCmdsForRocksDB)
+	// as cli init() is called before us.
+	cli.DebugCmd.AddCommand(encryptionStatusCmd)
+
+	// Add the encryption flag.
+	f := encryptionStatusCmd.Flags()
+	cli.VarFlag(f, &storeEncryptionSpecs, cliflagsccl.EnterpriseEncryption)
+	// And other flags.
+	f.BoolVar(&encryptionStatusOpts.activeStoreIDOnly, "active-store-key-id-only", false,
+		"print active store key ID and exit")
+
+	// Add encryption flag to all OSS debug commands that want it.
 	for _, cmd := range cli.DebugCmdsForRocksDB {
 		// storeEncryptionSpecs is in start.go.
 		cli.VarFlag(cmd.Flags(), &storeEncryptionSpecs, cliflagsccl.EnterpriseEncryption)
@@ -39,5 +83,169 @@ func fillEncryptionOptionsForStore(cfg *engine.RocksDBConfig) error {
 		cfg.ExtraOptions = opts
 		cfg.UseFileRegistry = true
 	}
+	return nil
+}
+
+type keyInfoByAge []*enginepbccl.KeyInfo
+
+func (ki keyInfoByAge) Len() int           { return len(ki) }
+func (ki keyInfoByAge) Swap(i, j int)      { ki[i], ki[j] = ki[j], ki[i] }
+func (ki keyInfoByAge) Less(i, j int) bool { return ki[i].CreationTime < ki[j].CreationTime }
+
+// JSONTime is a json-marshalable time.Time.
+type JSONTime time.Time
+
+// MarshalJSON marshals time.Time into json.
+func (t JSONTime) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"%s\"", time.Time(t).String())), nil
+}
+
+// PrettyDataKey is the final json-exportable struct for a data key.
+type PrettyDataKey struct {
+	ID      string
+	Active  bool `json:",omitempty"`
+	Exposed bool `json:",omitempty"`
+	Created JSONTime
+	Files   []string `json:",omitempty"`
+}
+
+// PrettyStoreKey is the final json-exportable struct for a store key.
+type PrettyStoreKey struct {
+	ID       string
+	Active   bool `json:",omitempty"`
+	Type     string
+	Created  JSONTime
+	Source   string
+	Files    []string        `json:",omitempty"`
+	DataKeys []PrettyDataKey `json:",omitempty"`
+}
+
+func runEncryptionStatus(cmd *cobra.Command, args []string) error {
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	dir := args[0]
+
+	db, err := cli.OpenExistingStore(dir, stopper, true /* readOnly */)
+	if err != nil {
+		return err
+	}
+
+	registries, err := db.GetEncryptionRegistries()
+	if err != nil {
+		return err
+	}
+
+	if len(registries.FileRegistry) == 0 || len(registries.KeyRegistry) == 0 {
+		return nil
+	}
+
+	var fileRegistry enginepb.FileRegistry
+	if err := protoutil.Unmarshal(registries.FileRegistry, &fileRegistry); err != nil {
+		return err
+	}
+
+	var keyRegistry enginepbccl.DataKeysRegistry
+	if err := protoutil.Unmarshal(registries.KeyRegistry, &keyRegistry); err != nil {
+		return err
+	}
+
+	if encryptionStatusOpts.activeStoreIDOnly {
+		fmt.Println(keyRegistry.ActiveStoreKeyId)
+		return nil
+	}
+
+	// Build a map of 'key ID' -> list of files
+	fileKeyMap := make(map[string][]string)
+
+	for name, entry := range fileRegistry.Files {
+		keyID := "plain"
+
+		if entry.EnvType != enginepb.EnvType_Plaintext && len(entry.EncryptionSettings) > 0 {
+			var setting enginepbccl.EncryptionSettings
+			if err := protoutil.Unmarshal(entry.EncryptionSettings, &setting); err != nil {
+				fmt.Fprintf(os.Stderr, "could not unmarshal encryption settings for file %s: %v", name, err)
+				continue
+			}
+			keyID = setting.KeyId
+		}
+
+		fileKeyMap[keyID] = append(fileKeyMap[keyID], name)
+	}
+
+	// Build a map of 'store key ID' -> list of child data key info
+	childKeyMap := make(map[string]keyInfoByAge)
+
+	for _, dataKey := range keyRegistry.DataKeys {
+		info := dataKey.Info
+		parentKey := "plain"
+		if len(info.ParentKeyId) > 0 {
+			parentKey = info.ParentKeyId
+		}
+		childKeyMap[parentKey] = append(childKeyMap[parentKey], info)
+	}
+
+	// Make a sortable slice of store key infos.
+	storeKeyList := make(keyInfoByAge, 0)
+	for _, ki := range keyRegistry.StoreKeys {
+		storeKeyList = append(storeKeyList, ki)
+	}
+
+	storeKeys := make([]PrettyStoreKey, 0, len(storeKeyList))
+	sort.Sort(storeKeyList)
+	for _, storeKey := range storeKeyList {
+		storeNode := PrettyStoreKey{
+			ID:      storeKey.KeyId,
+			Active:  (storeKey.KeyId == keyRegistry.ActiveStoreKeyId),
+			Type:    storeKey.EncryptionType.String(),
+			Created: JSONTime(timeutil.Unix(storeKey.CreationTime, 0)),
+			Source:  storeKey.Source,
+		}
+
+		// Files encrypted by the store key. This should only be the data key registry.
+		if files, ok := fileKeyMap[storeKey.KeyId]; ok {
+			sort.Strings(files)
+			storeNode.Files = files
+			delete(fileKeyMap, storeKey.KeyId)
+		}
+
+		// Child keys.
+		if children, ok := childKeyMap[storeKey.KeyId]; ok {
+			storeNode.DataKeys = make([]PrettyDataKey, 0, len(children))
+
+			sort.Sort(children)
+			for _, c := range children {
+				dataNode := PrettyDataKey{
+					ID:      c.KeyId,
+					Active:  (c.KeyId == keyRegistry.ActiveDataKeyId),
+					Exposed: c.WasExposed,
+					Created: JSONTime(timeutil.Unix(c.CreationTime, 0)),
+				}
+				files, ok := fileKeyMap[c.KeyId]
+				if ok {
+					sort.Strings(files)
+					dataNode.Files = files
+					delete(fileKeyMap, c.KeyId)
+				}
+				storeNode.DataKeys = append(storeNode.DataKeys, dataNode)
+			}
+			delete(childKeyMap, storeKey.KeyId)
+		}
+		storeKeys = append(storeKeys, storeNode)
+	}
+
+	j, err := json.MarshalIndent(storeKeys, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", j)
+
+	if len(fileKeyMap) > 0 {
+		fmt.Fprintf(os.Stderr, "WARNING: could not find key info for some files: %+v\n", fileKeyMap)
+	}
+	if len(childKeyMap) > 0 {
+		fmt.Fprintf(os.Stderr, "WARNING: could not find parent key info for some data keys: %+v\n", childKeyMap)
+	}
+
 	return nil
 }

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -170,7 +170,7 @@ func init() {
 		demoCmd,
 		genCmd,
 		versionCmd,
-		debugCmd,
+		DebugCmd,
 		sqlfmtCmd,
 	)
 }

--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -78,7 +78,7 @@ func TestOpenExistingStore(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("dir=%s", test.dir), func(t *testing.T) {
-			_, err := openExistingStore(test.dir, stopper, false /* readOnly */)
+			_, err := OpenExistingStore(test.dir, stopper, false /* readOnly */)
 			if !testutils.IsError(err, test.expErr) {
 				t.Errorf("wanted %s but got %v", test.expErr, err)
 			}
@@ -111,7 +111,7 @@ func TestOpenReadOnlyStore(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("readOnly=%t", test.readOnly), func(t *testing.T) {
-			db, err := openExistingStore(storePath, stopper, test.readOnly)
+			db, err := OpenExistingStore(storePath, stopper, test.readOnly)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -194,7 +194,7 @@ func TestRemoveDeadReplicas(t *testing.T) {
 		stopper := stop.NewStopper()
 		defer stopper.Stop(ctx)
 
-		db, err := openExistingStore(storePath, stopper, false /* readOnly */)
+		db, err := OpenExistingStore(storePath, stopper, false /* readOnly */)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -384,6 +384,17 @@ type EnvStats struct {
 	EncryptionStatus []byte
 }
 
+// EncryptionRegistries contains the encryption-related registries:
+// Both are serialized protobufs.
+type EncryptionRegistries struct {
+	// FileRegistry is the list of files with encryption status.
+	// serialized storage/engine/enginepb/file_registry.proto::FileRegistry
+	FileRegistry []byte
+	// KeyRegistry is the list of keys, scrubbed of actual key data.
+	// serialized ccl/storageccl/engineccl/enginepbccl/key_registry.proto::DataKeysRegistry
+	KeyRegistry []byte
+}
+
 // PutProto sets the given key to the protobuf-serialized byte string
 // of msg and the provided timestamp. Returns the length in bytes of
 // key and the value.

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1160,6 +1160,20 @@ func (r *RocksDB) GetEnvStats() (*EnvStats, error) {
 	}, nil
 }
 
+// GetEncryptionRegistries returns the file and key registries when encryption is enabled
+// on the store.
+func (r *RocksDB) GetEncryptionRegistries() (*EncryptionRegistries, error) {
+	var s C.DBEncryptionRegistries
+	if err := statusToError(C.DBGetEncryptionRegistries(r.rdb, &s)); err != nil {
+		return nil, err
+	}
+
+	return &EncryptionRegistries{
+		FileRegistry: cStringToGoBytes(s.file_registry),
+		KeyRegistry:  cStringToGoBytes(s.key_registry),
+	}, nil
+}
+
 type rocksDBSnapshot struct {
 	parent *RocksDB
 	handle *C.DBEngine


### PR DESCRIPTION
When encryption is enabled, this outputs full key details and associated
files.

Shows the hierarchy of store keys, data keys, and files.

We do not currently show encryption progress as it requires opening
rocksdb in read/write mode. This will eventually be added.

For example, this is the output on a store that has had two different
store keys and multiple data keys:

```
$ ./cockroach debug encryption-status --enterprise-encryption=path=cockroach-data,key=keys/aes-192.key,old-key=keys/aes-128.key cockroach-data
[
  {
    "ID": "222430e9b9e6bdb54b66dcb4124778da6c284a9d47e6a1637e0b26d059e61a80",
    "Type": "AES128_CTR",
    "Created": "2018-06-19 09:59:38 -0400 EDT",
    "Source": "/store/cockroach/src/github.com/cockroachdb/cockroach/keys/aes-128.key",
    "DataKeys": [
      {
        "ID": "1cfd71ab16fdc332aea838ae70b7952f28bfd247fd9da8ebef03d9576f8b7d30",
        "Created": "2018-06-19 09:59:38 -0400 EDT",
        "Files": [
          "IDENTITY"
        ]
      }
    ]
  },
  {
    "ID": "dc8a5767b73746f69c9245fe01688c0f9b934adb2b592d2d199c4a85f6d72d93",
    "Active": true,
    "Type": "AES192_CTR",
    "Created": "2018-06-19 14:04:04 -0400 EDT",
    "Source": "/store/cockroach/src/github.com/cockroachdb/cockroach/keys/aes-192.key",
    "Files": [
      "COCKROACHDB_DATA_KEYS"
    ],
    "DataKeys": [
      {
        "ID": "72b1a1162dbcc934f3d6c275ca845c1bfb74e81c24d9779132017ad5defcb7de",
        "Created": "2018-06-19 14:04:04 -0400 EDT"
      },
      {
        "ID": "99f26acfaf9004ebcfc8f7fad8d06e54ab101d5b3c77a0b7f912f5b270884564",
        "Created": "2018-07-09 11:59:11 -0400 EDT"
      },
      {
        "ID": "123df81c7ad822168bf2e84502691c68a07bba5af52e66b7b33751306c4ac9a8",
        "Active": true,
        "Created": "2018-08-08 07:16:27 -0400 EDT",
        "Files": [
          "000166.log",
          "000169.sst",
          "CURRENT",
          "MANIFEST-000165",
          "OPTIONS-000165",
          "OPTIONS-000168"
        ]
      }
    ]
  }
]
```

And on a store running with just plaintext (still with encryption flag
passed):
```
$ ./cockroach debug encryption-status --enterprise-encryption=path=cockroach-data2,key=plain,old-key=plain cockroach-data2
[
  {
    "ID": "plain",
    "Active": true,
    "Type": "Plaintext",
    "Created": "2018-06-19 14:24:31 -0400 EDT",
    "Source": "plain",
    "Files": [
      "000109.log",
      "000112.sst",
      "CURRENT",
      "MANIFEST-000108",
      "OPTIONS-000108",
      "OPTIONS-000111"
    ],
    "DataKeys": [
      {
        "ID": "plain",
        "Active": true,
        "Exposed": true,
        "Created": "2018-06-19 14:24:31 -0400 EDT"
      }
    ]
  }
]
```

A store that does not even use the file registry will not output
anything (eg: a store without the `--enterprise-encryption` flag).

Release note (enterprise change): add encryption-status debug command to
display encryption key information.