### PR TITLE
opt: fix panic caused by select from table with no columns

### DIFF
--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -201,14 +201,16 @@ func (s *scope) makeOrderingChoice() props.OrderingChoice {
 func (s *scope) makePhysicalProps() props.Physical {
 	p := props.Physical{}
 
-	p.Presentation = make(props.Presentation, 0, len(s.cols))
-	for i := range s.cols {
-		col := &s.cols[i]
-		if !col.hidden {
-			p.Presentation = append(p.Presentation, opt.LabeledColumn{
-				Label: string(col.name),
-				ID:    col.id,
-			})
+	if len(s.cols) > 0 {
+		p.Presentation = make(props.Presentation, 0, len(s.cols))
+		for i := range s.cols {
+			col := &s.cols[i]
+			if !col.hidden {
+				p.Presentation = append(p.Presentation, opt.LabeledColumn{
+					Label: string(col.name),
+					ID:    col.id,
+				})
+			}
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1217,3 +1217,27 @@ SELECT rowid FROM [54(3) as t]
 ----
 scan num_ref_hidden
  └── columns: rowid:3(int!null)
+
+# Regression test for #28388. Ensure that selecting from a table with no
+# columns does not cause a panic.
+exec-ddl
+CREATE TABLE no_cols_table ()
+----
+TABLE no_cols_table
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+build
+SELECT * FROM no_cols_table
+----
+project
+ └── scan no_cols_table
+      └── columns: rowid:1(int!null)
+
+build
+SELECT * FROM [54(3) as t]
+----
+project
+ └── scan num_ref_hidden
+      └── columns: rowid:3(int!null)


### PR DESCRIPTION
This commit fixes a panic caused by running `SELECT *` from a table
with no visible columns (e.g., a table with only the hidden rowid
column). The bug was caused by the `optbuilder` creating a `Presentation`
slice even when there are no columns to present. Ensuring that
the slice is nil in this case fixes the bug.

Fixes #28388

Release note: None