### PR TITLE
ui: add disk ops per second graph to hardware dashboard

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -141,6 +141,38 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="Disk Read Ops"
+      sources={nodeSources}
+    >
+      <Axis units={AxisUnits.Count} label="Read Ops">
+        {nodeIDs.map((nid) => (
+          <Metric
+            name="cr.node.sys.host.disk.read.count"
+            title={nodeDisplayName(nodesSummary, nid)}
+            sources={[nid]}
+            nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Disk Write Ops"
+      sources={nodeSources}
+    >
+      <Axis units={AxisUnits.Count} label="Write Ops">
+        {nodeIDs.map((nid) => (
+          <Metric
+            name="cr.node.sys.host.disk.write.count"
+            title={nodeDisplayName(nodesSummary, nid)}
+            sources={[nid]}
+            nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Available Disk Capacity"
       sources={storeSources}
     >

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -94,21 +94,6 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Disk IOPS In Progress"
-      sources={nodeSources}
-    >
-      <Axis units={AxisUnits.Count} label="IOPS">
-        {nodeIDs.map((nid) => (
-          <Metric
-            name="cr.node.sys.host.disk.iopsinprogress"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={[nid]}
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
       title="Disk Read Time"
       sources={nodeSources}
     >
@@ -167,6 +152,21 @@ export default function (props: GraphDashboardProps) {
             title={nodeDisplayName(nodesSummary, nid)}
             sources={[nid]}
             nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Disk IOPS In Progress"
+      sources={nodeSources}
+    >
+      <Axis units={AxisUnits.Count} label="IOPS">
+        {nodeIDs.map((nid) => (
+          <Metric
+            name="cr.node.sys.host.disk.iopsinprogress"
+            title={nodeDisplayName(nodesSummary, nid)}
+            sources={[nid]}
           />
         ))}
       </Axis>


### PR DESCRIPTION
The middle two graphs are new:
![image](https://user-images.githubusercontent.com/7341/44124100-7a365648-9ff9-11e8-96b8-c9253ba4e05d.png)

Fixes #28552