### PR TITLE
ui: show sys+user combined cpu, normalized by # cores

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -12,28 +12,13 @@ export default function (props: GraphDashboardProps) {
 
   return [
     <LineGraph
-      title="User CPU Percent"
+      title="CPU Percent"
       sources={nodeSources}
     >
       <Axis units={AxisUnits.Percentage} label="CPU">
         {nodeIDs.map((nid) => (
           <Metric
-            name="cr.node.sys.cpu.user.percent"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={[nid]}
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="System CPU Percent"
-      sources={nodeSources}
-    >
-      <Axis units={AxisUnits.Percentage} label="CPU">
-        {nodeIDs.map((nid) => (
-          <Metric
-            name="cr.node.sys.cpu.sys.percent"
+            name="cr.node.sys.cpu.combined.percent-normalized"
             title={nodeDisplayName(nodesSummary, nid)}
             sources={[nid]}
           />


### PR DESCRIPTION
**Before**, system and user CPU percentages were separate graphs on the Hardware dashboard, reported as between 0 and (n*100)%, where n is the number of cores:

![image](https://user-images.githubusercontent.com/7341/44125412-6b2eef3c-a000-11e8-90fa-ee54f0417809.png)

**With this PR**, system and user CPU are combined and divided by the number of cores so that the number is always 0-100%:

![image](https://user-images.githubusercontent.com/7341/44125444-a5642c08-a000-11e8-973a-47520d2decd3.png)

(Scales on percentage graphs always seem to go up to 125%; not sure if it's possible to change this.)

Fixes #28154