### PR TITLE
[wip] ui: hardware dashboard: memory as percentage, not absolute value

### DIFF
--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -22,12 +22,12 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/elastic/gosigar"
+	"github.com/shirou/gopsutil/net"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
-	"github.com/shirou/gopsutil/net"
 )
 
 var (

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -50,10 +50,10 @@ export default function (props: GraphDashboardProps) {
         </div>
       )}
     >
-      <Axis units={AxisUnits.Bytes} label="memory usage">
+      <Axis units={AxisUnits.Percentage} label="memory usage">
         {nodeIDs.map((nid) => (
           <Metric
-            name="cr.node.sys.rss"
+            name="cr.node.sys.rss.percent"
             title={nodeDisplayName(nodesSummary, nid)}
             sources={[nid]}
           />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7341/44126537-ea95693a-a006-11e8-9ee4-116bf2fe203a.png)

Percentage makes it easier to see how close you are to being full. The node list now shows the value and the percentage. Maybe we should have both on the dashboard, but it's already getting big.