### PR TITLE
storage: avoid repetitive, redundant calls to EnsureClient

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3767,13 +3767,6 @@ func (s *Store) processTick(ctx context.Context, rangeID roachpb.RangeID) bool {
 	}
 	livenessMap, _ := s.livenessMap.Load().(map[roachpb.NodeID]bool)
 
-	// Make sure we ask all live nodes for closed timestamp updates.
-	for nodeID, live := range livenessMap {
-		if live {
-			s.cfg.ClosedTimestamp.Clients.EnsureClient(nodeID)
-		}
-	}
-
 	start := timeutil.Now()
 	r := (*Replica)(value)
 	exists, err := r.tick(livenessMap)
@@ -3838,6 +3831,8 @@ func (s *Store) raftTickLoop(ctx context.Context) {
 				nextMap := s.cfg.NodeLiveness.GetIsLiveMap()
 				for nodeID, isLive := range nextMap {
 					if isLive {
+						// Make sure we ask all live nodes for closed timestamp updates.
+						s.cfg.ClosedTimestamp.Clients.EnsureClient(nodeID)
 						continue
 					}
 					// Liveness claims that this node is down, but ConnHealth gets the last say


### PR DESCRIPTION
Putting `EnsureClient` in the `processTick` loop is very expensive.
If there are 10 nodes and 1000 unquiesced ranges, it would be called
50,000 times per second.

It appears to only be necessary to call this once per node. By moving
`EnsureClient` to the `IsNodeLiveCallback` method, we can accomplish
what we want.

Release note: None