### PR TITLE
roachtest: add backup TPCC test

### DIFF
--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -17,6 +17,12 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/pkg/errors"
 )
 
 func registerBackup(r *registry) {
@@ -44,6 +50,199 @@ func registerBackup(r *registry) {
 				t.Status(`running backup`)
 				c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
 				BACKUP bank.bank TO 'gs://cockroachdb-backup-testing/`+c.name+`'"`)
+				return nil
+			})
+			m.Wait()
+		},
+	})
+
+	// backupTPCC continuously runs TPCC, takes a full backup after some time,
+	// and incremental after more time. It then restores the two backups and
+	// verifies them with a fingerprint.
+	r.Add(testSpec{
+		Name:    `backupTPCC`,
+		Nodes:   nodes(3),
+		Stable:  false,
+		Timeout: 1 * time.Hour,
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			c.Put(ctx, cockroach, "./cockroach")
+			c.Put(ctx, workload, "./workload")
+			c.Start(ctx)
+			conn := c.Conn(ctx, 1)
+
+			duration := 5 * time.Minute
+			if local {
+				duration = 5 * time.Second
+			}
+			warehouses := 1
+			backupDir := "gs://cockroachdb-backup-testing/" + c.name
+			fullDir := backupDir + "/full"
+			incDir := backupDir + "/inc"
+
+			t.Status(`workload initialization`)
+			cmd := fmt.Sprintf(
+				"./workload init tpcc --warehouses=%d {pgurl:1-%d}",
+				warehouses, c.nodes,
+			)
+			c.Run(ctx, c.Node(1), cmd)
+
+			m := newMonitor(ctx, c)
+			m.Go(func(ctx context.Context) error {
+				_, err := conn.ExecContext(ctx, `
+					CREATE DATABASE restore_full;
+					CREATE DATABASE restore_inc;
+				`)
+				return err
+			})
+			m.Wait()
+
+			t.Status(`run tpcc`)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			cmdDone := make(chan error)
+			go func() {
+				cmd := fmt.Sprintf(
+					"./workload run tpcc --warehouses=%d {pgurl:1-%d}",
+					warehouses, c.nodes,
+				)
+
+				cmdDone <- c.RunE(ctx, c.Node(1), cmd)
+			}()
+
+			select {
+			case <-time.After(duration):
+			case <-ctx.Done():
+				return
+			}
+
+			t.Status(`full backup`)
+			tFull := fmt.Sprint(timeutil.Now().UnixNano())
+			m = newMonitor(ctx, c)
+			m.Go(func(ctx context.Context) error {
+				_, err := conn.ExecContext(ctx,
+					`BACKUP tpcc.* TO $1 AS OF SYSTEM TIME `+tFull,
+					fullDir,
+				)
+				return err
+			})
+			m.Wait()
+
+			t.Status(`continue tpcc`)
+			select {
+			case <-time.After(duration):
+			case <-ctx.Done():
+				return
+			}
+
+			t.Status(`incremental backup`)
+			tInc := fmt.Sprint(timeutil.Now().UnixNano())
+			m = newMonitor(ctx, c)
+			m.Go(func(ctx context.Context) error {
+				_, err := conn.ExecContext(ctx,
+					`BACKUP tpcc.* TO $1 AS OF SYSTEM TIME `+tInc+` INCREMENTAL FROM $2`,
+					incDir,
+					fullDir,
+				)
+				if err != nil {
+					return err
+				}
+
+				// Backups are done, make sure workload is still running.
+				select {
+				case err := <-cmdDone:
+					// Workload exited before it should have.
+					return err
+				default:
+					return nil
+				}
+			})
+			m.Wait()
+
+			m = newMonitor(ctx, c)
+			m.Go(func(ctx context.Context) error {
+				t.Status(`restore full`)
+				if _, err := conn.ExecContext(ctx,
+					`RESTORE tpcc.* FROM $1 WITH into_db='restore_full'`,
+					fullDir,
+				); err != nil {
+					return err
+				}
+
+				t.Status(`restore incremental`)
+				if _, err := conn.ExecContext(ctx,
+					`RESTORE tpcc.* FROM $1, $2 WITH into_db='restore_inc'`,
+					fullDir,
+					incDir,
+				); err != nil {
+					return err
+				}
+
+				t.Status(`fingerprint`)
+				fingerprint := func(db string, asof string) (string, error) {
+					var b strings.Builder
+
+					var tables []string
+					rows, err := conn.QueryContext(ctx, fmt.Sprintf("SHOW TABLES FROM %s", db))
+					if err != nil {
+						return "", err
+					}
+					defer rows.Close()
+					for rows.Next() {
+						var name string
+						if err := rows.Scan(&name); err != nil {
+							return "", err
+						}
+						tables = append(tables, name)
+					}
+
+					for _, table := range tables {
+						fmt.Fprintf(&b, "table %s\n", table)
+						query := fmt.Sprintf("SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE %s.%s", db, table)
+						if asof != "" {
+							query = fmt.Sprintf("SELECT * FROM [%s] AS OF SYSTEM TIME %s", query, asof)
+						}
+						rows, err = conn.QueryContext(ctx, query)
+						if err != nil {
+							return "", err
+						}
+						defer rows.Close()
+						for rows.Next() {
+							var name, fp string
+							if err := rows.Scan(&name, &fp); err != nil {
+								return "", err
+							}
+							fmt.Fprintf(&b, "%s: %s\n", name, fp)
+						}
+					}
+
+					return b.String(), rows.Err()
+				}
+
+				tpccFull, err := fingerprint("tpcc", tFull)
+				if err != nil {
+					return err
+				}
+				tpccInc, err := fingerprint("tpcc", tInc)
+				if err != nil {
+					return err
+				}
+				restoreFull, err := fingerprint("restore_full", "")
+				if err != nil {
+					return err
+				}
+				restoreInc, err := fingerprint("restore_inc", "")
+				if err != nil {
+					return err
+				}
+
+				if tpccFull != restoreFull {
+					return errors.Errorf("got %s, expected %s", restoreFull, tpccFull)
+				}
+				if tpccInc != restoreInc {
+					return errors.Errorf("got %s, expected %s", restoreInc, tpccInc)
+				}
+
 				return nil
 			})
 			m.Wait()


### PR DESCRIPTION
Add a small nightly test for BACKUP and RESTORE (both with INCREMENTAL)
during a TPCC workload. This is to test BACKUP and RESTORE on more real
workloads than we've previously tested.

Release note: None