### PR TITLE
cherrypick-2.0: deps: bump go-libedit to avoid a panic

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -693,8 +693,8 @@
     "unix",
     "unix/sigtramp",
   ]
-  revision = "69b759d6ff84df6bbd39846dae3670625cc0361b"
-  version = "v1.7"
+  revision = "a197b52fb6d915176b1e3a1184369758c6adc7c8"
+  version = "v1.7.2"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
Picks #28233 and #28613.

cc @cockroachdb/release 