### PR TITLE
sql: fix a bug in the planning of subqueries

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -466,3 +466,14 @@ CREATE TABLE test2(b INT PRIMARY KEY)
 query I
 SELECT * FROM test2 WHERE 0 = CASE WHEN true THEN (SELECT a FROM test LIMIT 1) ELSE 10 END
 ----
+
+# Regression test for #28335.
+query I
+SELECT (SELECT ARRAY(SELECT 1))[1]
+----
+1
+
+query B
+SELECT (SELECT 123 IN (VALUES (1), (2)))
+----
+false

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -286,6 +286,11 @@ func (v *subqueryVisitor) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.E
 	switch t := expr.(type) {
 	case *tree.ArrayFlatten:
 		if sub, ok := t.Subquery.(*tree.Subquery); ok {
+			if v.subqueryAlreadyAnalyzed(sub) {
+				// Subquery was already processed. Nothing to do.
+				return false, expr
+			}
+
 			result, err := v.extractSubquery(sub, true /* multi-row */, 1 /* desired-columns */)
 			if err != nil {
 				v.err = err
@@ -325,6 +330,11 @@ func (v *subqueryVisitor) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.E
 		switch t.Operator {
 		case tree.In, tree.NotIn, tree.Any, tree.Some, tree.All:
 			if sub, ok := t.Right.(*tree.Subquery); ok {
+				if v.subqueryAlreadyAnalyzed(sub) {
+					// Subquery was already processed. Nothing to do.
+					return false, expr
+				}
+
 				result, err := v.extractSubquery(sub, true /* multi-row */, -1 /* desired-columns */)
 				if err != nil {
 					v.err = err


### PR DESCRIPTION
Fixes #28335.

The heuristic planner would recurse twice into the operand of the
array flatten and ComparisonExpr operators, and cause an invalid plan
to be generated as a result. This patch fixes it.

Release note (sql change): CockroachDB now supports the `ARRAY()`
operator and comparisons with sub-queries on the right side of the
comparison, when they appear themselves in sub-queries.