### PR TITLE
opt: support numeric index references

### DIFF
--- a/pkg/sql/opt/catalog.go
+++ b/pkg/sql/opt/catalog.go
@@ -166,6 +166,10 @@ type Index interface {
 	// IdxName is the name of the index.
 	IdxName() string
 
+	// InternalID returns the internal identifier of the index. Only used
+	// when the query contains a numeric index reference.
+	InternalID() uint64
+
 	// IsInverted returns true if this is a JSON inverted index.
 	IsInverted() bool
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -110,56 +110,44 @@ scan  ·      ·           (p)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@[1]
 ----
-render     ·         ·                (p)                                        p!=NULL; key(p)
- │         render 0  num_ref_alias.p  ·                                          ·
- └── scan  ·         ·                (p, d[hidden,omitted], c[hidden,omitted])  p!=NULL; key(p)
-·          table     num_ref@primary  ·                                          ·
-·          spans     ALL              ·                                          ·
+scan  ·      ·                (p)  ·
+·     table  num_ref@primary  ·    ·
+·     spans  ALL              ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@[2]
 ----
-render     ·         ·                (p)                                        p!=NULL
- │         render 0  num_ref_alias.p  ·                                          ·
- └── scan  ·         ·                (p, d[hidden,omitted], c[hidden,omitted])  p!=NULL; weak-key(p,d,c)
-·          table     num_ref@bc       ·                                          ·
-·          spans     ALL              ·                                          ·
+scan  ·      ·           (p)  ·
+·     table  num_ref@bc  ·    ·
+·     spans  ALL         ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@[1]
 ----
-render     ·         ·                (d)                                        ·
- │         render 0  num_ref_alias.d  ·                                          ·
- └── scan  ·         ·                (d, p[hidden,omitted], c[hidden,omitted])  p!=NULL; key(p)
-·          table     num_ref@primary  ·                                          ·
-·          spans     ALL              ·                                          ·
+scan  ·      ·                (d)  ·
+·     table  num_ref@primary  ·    ·
+·     spans  ALL              ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@[2]
 ----
-render     ·         ·                (d)                                        ·
- │         render 0  num_ref_alias.d  ·                                          ·
- └── scan  ·         ·                (d, p[hidden,omitted], c[hidden,omitted])  p!=NULL; weak-key(d,p,c)
-·          table     num_ref@bc       ·                                          ·
-·          spans     ALL              ·                                          ·
+scan  ·      ·           (d)  ·
+·     table  num_ref@bc  ·    ·
+·     spans  ALL         ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@[1]
 ----
-render     ·         ·                (c)                                        ·
- │         render 0  num_ref_alias.c  ·                                          ·
- └── scan  ·         ·                (c, p[hidden,omitted], d[hidden,omitted])  p!=NULL; key(p)
-·          table     num_ref@primary  ·                                          ·
-·          spans     ALL              ·                                          ·
+scan  ·      ·                (c)  ·
+·     table  num_ref@primary  ·    ·
+·     spans  ALL              ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@[2]
 ----
-render     ·         ·                (c)                                        ·
- │         render 0  num_ref_alias.c  ·                                          ·
- └── scan  ·         ·                (c, p[hidden,omitted], d[hidden,omitted])  p!=NULL; weak-key(c,p,d)
-·          table     num_ref@bc       ·                                          ·
-·          spans     ALL              ·                                          ·
+scan  ·      ·           (c)  ·
+·     table  num_ref@bc  ·    ·
+·     spans  ALL         ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [54(1,3) AS num_ref_alias]

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -298,22 +298,26 @@ func (b *Builder) buildScan(
 
 		if indexFlags != nil {
 			def.Flags.NoIndexJoin = indexFlags.NoIndexJoin
-			if indexFlags.Index != "" {
+			if indexFlags.Index != "" || indexFlags.IndexID != 0 {
 				idx := -1
 				for i := 0; i < tab.IndexCount(); i++ {
-					if tab.Index(i).IdxName() == string(indexFlags.Index) {
+					if tab.Index(i).IdxName() == string(indexFlags.Index) ||
+						tab.Index(i).InternalID() == uint64(indexFlags.IndexID) {
 						idx = i
 						break
 					}
 				}
 				if idx == -1 {
-					panic(builderError{errors.Errorf("index %q not found", tree.ErrString(&indexFlags.Index))})
+					var err error
+					if indexFlags.Index != "" {
+						err = errors.Errorf("index %q not found", tree.ErrString(&indexFlags.Index))
+					} else {
+						err = errors.Errorf("index [%d] not found", indexFlags.IndexID)
+					}
+					panic(builderError{err})
 				}
 				def.Flags.ForceIndex = true
 				def.Flags.Index = idx
-			} else if indexFlags.IndexID != 0 {
-				// TODO(radu): support IndexIDs.
-				panic(unimplementedf("index IDs not supported in index flags"))
 			}
 		}
 

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -3,11 +3,11 @@
 # This statement must be first for the numeric references tests.
 # The numeric references test assume that this is the first table.
 exec-ddl
-CREATE TABLE numeric_references (a INT PRIMARY KEY, xx INT, b INT, c INT, INDEX bc (b,c))
+CREATE TABLE numeric_references (a INT PRIMARY KEY, y INT, b INT, c INT, INDEX bc (b,c))
 ----
 TABLE numeric_references
  ├── a int not null
- ├── xx int
+ ├── y int
  ├── b int
  ├── c int
  ├── INDEX primary
@@ -18,11 +18,11 @@ TABLE numeric_references
       └── a int not null
 
 exec-ddl
-CREATE TABLE num_ref_hidden (x INT , xx INT)
+CREATE TABLE num_ref_hidden (x INT, y INT)
 ----
 TABLE num_ref_hidden
  ├── x int
- ├── xx int
+ ├── y int
  ├── rowid int not null (hidden)
  └── INDEX primary
       └── rowid int not null (hidden)
@@ -1133,7 +1133,7 @@ project
       └── columns: x:1(int!null) y:2(float)
 
 
-# Numeric Reference Test (1/11)
+# Numeric Reference Tests
 # Cockroach numeric references start after 53 for user tables.
 # See opt/testutils/testcat/create_table.go:117 for more info on
 # 53 as a magic number.
@@ -1142,66 +1142,72 @@ build
 SELECT * FROM [53 AS t]
 ----
 scan numeric_references
- └── columns: a:1(int!null) xx:2(int) b:3(int) c:4(int)
+ └── columns: a:1(int!null) y:2(int) b:3(int) c:4(int)
 
-# Numeric Reference Test (2/11)
 build
 SELECT * FROM [53(1) AS t]
 ----
 scan numeric_references
  └── columns: a:1(int!null)
 
-# Numeric Reference Test (3/11)
 build
 SELECT * FROM [53(1,2) AS t]
 ----
 scan numeric_references
- └── columns: a:1(int!null) xx:2(int)
+ └── columns: a:1(int!null) y:2(int)
 
-# Numeric Reference Test (4/11)
 build
 SELECT * FROM [53(4) AS t]
 ----
 scan numeric_references
  └── columns: c:4(int)
 
-# Numeric Reference Test (5/11)
 build
 SELECT * FROM [53(5) AS t]
 ----
 error (42703): column [5] does not exist
 
-# Numeric Reference Test (6/11)
 build
 SELECT * FROM [53(2,4) AS t]
 ----
 scan numeric_references
- └── columns: xx:2(int) c:4(int)
+ └── columns: y:2(int) c:4(int)
 
-# Numeric Reference Test (7/11)
 build
 SELECT * FROM [53(2,3) AS t(col1,col2)]
 ----
 scan numeric_references
  └── columns: col1:2(int) col2:3(int)
 
-# Numeric Reference Test (8/11)
 build
 SELECT * FROM [53() AS t]
 ----
 error (42601): an explicit list of column IDs must include at least one column
 
-# Numeric Reference Test (9/11)
 # Test that hidden columns are not presented
 build
 SELECT * FROM [54 AS t]
 ----
 project
- ├── columns: x:1(int) xx:2(int)
+ ├── columns: x:1(int) y:2(int)
  └── scan num_ref_hidden
-      └── columns: x:1(int) xx:2(int) rowid:3(int!null)
+      └── columns: x:1(int) y:2(int) rowid:3(int!null)
 
-# Numeric Reference Test (10/11)
+# Verify that we force the given index.
+build
+SELECT * FROM [53 AS t]@[1]
+----
+scan numeric_references
+ ├── columns: a:1(int!null) y:2(int) b:3(int) c:4(int)
+ └── flags: force-index=primary
+
+build
+SELECT * FROM [53 AS t]@[2]
+----
+scan numeric_references
+ ├── columns: a:1(int!null) y:2(int) b:3(int) c:4(int)
+ └── flags: force-index=bc
+
 # Test that hidden columns are not presented
 build
 SELECT * FROM [54(1,3) AS t]
@@ -1211,7 +1217,6 @@ project
  └── scan num_ref_hidden
       └── columns: x:1(int) rowid:3(int!null)
 
-# Numeric Reference Test (11/11)
 build
 SELECT rowid FROM [54(3) as t]
 ----

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -163,6 +163,7 @@ func (tt *Table) addIndex(def *tree.IndexTableDef, typ indexType) {
 		if len(tt.Indexes) != 0 {
 			panic("primary index should always be 0th index")
 		}
+		idx.Ordinal = len(tt.Indexes)
 		tt.Indexes = append(tt.Indexes, idx)
 		return
 	}
@@ -215,6 +216,7 @@ func (tt *Table) addIndex(def *tree.IndexTableDef, typ indexType) {
 		}
 	}
 
+	idx.Ordinal = len(tt.Indexes)
 	tt.Indexes = append(tt.Indexes, idx)
 }
 

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -329,7 +329,9 @@ func (tt *Table) FindOrdinal(name string) int {
 
 // Index implements the opt.Index interface for testing purposes.
 type Index struct {
-	Name    string
+	Name string
+	// Ordinal is the ordinal of this index in the table.
+	Ordinal int
 	Columns []opt.IndexColumn
 
 	// KeyCount is the number of columns that make up the unique key for the
@@ -348,6 +350,11 @@ type Index struct {
 // IdxName is part of the opt.Index interface.
 func (ti *Index) IdxName() string {
 	return ti.Name
+}
+
+// InternalID is part of the opt.Index interface.
+func (ti *Index) InternalID() uint64 {
+	return 1 + uint64(ti.Ordinal)
 }
 
 // IsInverted is part of the opt.Index interface.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -456,6 +456,11 @@ func (oi *optIndex) IdxName() string {
 	return oi.desc.Name
 }
 
+// InternalID is part of the opt.Index interface.
+func (oi *optIndex) InternalID() uint64 {
+	return uint64(oi.desc.ID)
+}
+
 // IsInverted is part of the opt.Index interface.
 func (oi *optIndex) IsInverted() bool {
 	return oi.desc.Type == sqlbase.IndexDescriptor_INVERTED


### PR DESCRIPTION
Fixing up a TODO to support numeric index references in the index
flags.

Release note: None