### PR TITLE
opt: unskip C# test

### DIFF
--- a/pkg/acceptance/adapter_test.go
+++ b/pkg/acceptance/adapter_test.go
@@ -42,8 +42,6 @@ func TestDockerC(t *testing.T) {
 }
 
 func TestDockerCSharp(t *testing.T) {
-	// TODO(justin): figure out what's going on here.
-	t.Skip()
 	s := log.Scope(t)
 	defer s.Close(t)
 


### PR DESCRIPTION
I'm not sure what fixed this since the acceptance test framework is
making it quite difficult to bisect, but regardless, it seems to pass now.

@andy-kimball this is that int4-oid-cast elision that we talked about.

Release note: None