### PR TITLE
opt: audit TODOs and clean up easy ones

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -410,21 +410,17 @@ limit                ·         ·
 statement ok
 CREATE TABLE tc (a INT, b INT, INDEX c(a))
 
-#TODO(justin): we can't execbuild index joins yet.
-#query TTTTT
-#EXPLAIN (VERBOSE) SELECT * FROM tc WHERE a = 10 ORDER BY b
-#----
-#sort                  ·         ·                 (a, b)                                   a=CONST; +b
-# │                    order     +b                ·                                        ·
-# └── render           ·         ·                 (a, b)                                   a=CONST
-#      │               render 0  test.public.tc.a  ·                                        ·
-#      │               render 1  test.public.tc.b  ·                                        ·
-#      └── index-join  ·         ·                 (a, b, rowid[hidden,omitted])            a=CONST; rowid!=NULL; key(rowid)
-#           ├── scan   ·         ·                 (a[omitted], b[omitted], rowid[hidden])  a=CONST; rowid!=NULL; key(rowid)
-#           │          table     tc@c              ·                                        ·
-#           │          spans     /10-/11           ·                                        ·
-#           └── scan   ·         ·                 (a, b, rowid[hidden,omitted])            ·
-#·                     table     tc@primary        ·                                        ·
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM tc WHERE a = 10 ORDER BY b
+----
+sort             ·      ·           (a, b)              +b
+ │               order  +b          ·                   ·
+ └── index-join  ·      ·           (a, b)              ·
+      ├── scan   ·      ·           (a, rowid[hidden])  ·
+      │          table  tc@c        ·                   ·
+      │          spans  /10-/11     ·                   ·
+      └── scan   ·      ·           (a, b)              ·
+·                table  tc@primary  ·                   ·
 
 query TTTTT colnames
 EXPLAIN (TYPES) INSERT INTO t VALUES (1, 2)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -1,8 +1,5 @@
 # LogicTest: local-opt
 
-# TODO(justin): presently these all fall back to the heuristic planner. Update
-# them when we support inverted index queries in the optimizer.
-
 statement ok
 CREATE TABLE d (
   a INT PRIMARY KEY,

--- a/pkg/sql/opt/memo/memo_format.go
+++ b/pkg/sql/opt/memo/memo_format.go
@@ -232,10 +232,8 @@ func (f *memoFormatter) sortGroups(root GroupID) (groups []GroupID) {
 	// If there remains any group with nonzero indegree, we had a cycle.
 	for i := range indegrees {
 		if indegrees[i] != 0 {
-			// TODO(justin): we should handle this case, but there's no good way to
-			// test it yet. Cross this bridge when we come to it (use raw-memo to
-			// bypass this sorting procedure if this is causing you trouble).
-			panic("memo had a cycle, use raw-memo")
+			// The memo should never have a cycle.
+			panic("memo had a cycle, use raw-memo to print")
 		}
 	}
 

--- a/pkg/sql/opt/memo/testdata/typing
+++ b/pkg/sql/opt/memo/testdata/typing
@@ -209,24 +209,23 @@ project
       ├── a.x << 3 [type=int]
       └── a.y >> 2 [type=int]
 
-# TODO(justin): re-enable when we support inverted index queries.
 # FetchVal, FetchText, FetchValPath, FetchTextPath
-# build
-# SELECT '[1, 2]'->1 AS r,
-#        '[1, 2]'->>1 AS s,
-#        '{"a": 5}'#>ARRAY['a'] AS t,
-#        '{"a": 5}'#>>ARRAY['a'] AS u
-#   FROM a
-# ----
-# project
-#  ├── columns: r:3(jsonb) s:4(string) t:5(jsonb) u:6(string)
-#  ├── scan a
-#  │    └── columns: x:1(int!null) y:2(int)
-#  └── projections
-#       ├── '[1, 2]'->1 [type=jsonb]
-#       ├── '[1, 2]'->>1 [type=string]
-#       ├── '{"a": 5}'#>ARRAY['a'] [type=jsonb]
-#       └── '{"a": 5}'#>>ARRAY['a'] [type=string]
+build
+SELECT '[1, 2]'->1 AS r,
+       '[1, 2]'->>1 AS s,
+       '{"a": 5}'#>ARRAY['a'] AS t,
+       '{"a": 5}'#>>ARRAY['a'] AS u
+  FROM a
+----
+project
+ ├── columns: r:3(jsonb) s:4(string) t:5(jsonb) u:6(string)
+ ├── scan a
+ │    └── columns: x:1(int!null) y:2(int)
+ └── projections
+      ├── '[1, 2]'->1 [type=jsonb]
+      ├── '[1, 2]'->>1 [type=string]
+      ├── '{"a": 5}'#>ARRAY['a'] [type=jsonb]
+      └── '{"a": 5}'#>>ARRAY['a'] [type=string]
 
 # Concat
 build

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1999,37 +1999,29 @@ project
       ├── group-by
       │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) max:10(string)
       │    ├── grouping columns: k:1(int!null)
-      │    ├── internal-ordering: +8 opt(9)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-5,10)
-      │    ├── sort
-      │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) y:7(int!null) column8:8(int) column9:9(string!null)
+      │    ├── inner-join
+      │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) y:7(int!null) column9:9(string!null)
       │    │    ├── fd: (1)-->(2-5), (7)-->(9), (1)==(7), (7)==(1)
-      │    │    ├── ordering: +8 opt(9)
-      │    │    └── inner-join
-      │    │         ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) y:7(int!null) column8:8(int) column9:9(string!null)
-      │    │         ├── fd: (1)-->(2-5), (7)-->(9), (1)==(7), (7)==(1)
-      │    │         ├── scan a
-      │    │         │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
-      │    │         │    ├── key: (1)
-      │    │         │    └── fd: (1)-->(2-5)
-      │    │         ├── select
-      │    │         │    ├── columns: y:7(int) column8:8(int) column9:9(string!null)
-      │    │         │    ├── fd: (7)-->(9)
-      │    │         │    ├── project
-      │    │         │    │    ├── columns: column9:9(string) column8:8(int) y:7(int)
-      │    │         │    │    ├── fd: (7)-->(9)
-      │    │         │    │    ├── scan xy
-      │    │         │    │    │    ├── columns: x:6(int!null) y:7(int)
-      │    │         │    │    │    ├── key: (6)
-      │    │         │    │    │    └── fd: (6)-->(7)
-      │    │         │    │    └── projections [outer=(6,7)]
-      │    │         │    │         ├── xy.y::STRING [type=string, outer=(7)]
-      │    │         │    │         └── xy.x + xy.y [type=int, outer=(6,7)]
-      │    │         │    └── filters [type=bool, outer=(9), constraints=(/9: (/NULL - ]; tight)]
-      │    │         │         └── column9 IS NOT NULL [type=bool, outer=(9), constraints=(/9: (/NULL - ]; tight)]
-      │    │         └── filters [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
-      │    │              └── xy.y = a.k [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ])]
+      │    │    ├── scan a
+      │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+      │    │    │    ├── key: (1)
+      │    │    │    └── fd: (1)-->(2-5)
+      │    │    ├── select
+      │    │    │    ├── columns: y:7(int) column9:9(string!null)
+      │    │    │    ├── fd: (7)-->(9)
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: column9:9(string) y:7(int)
+      │    │    │    │    ├── fd: (7)-->(9)
+      │    │    │    │    ├── scan xy
+      │    │    │    │    │    └── columns: y:7(int)
+      │    │    │    │    └── projections [outer=(7)]
+      │    │    │    │         └── xy.y::STRING [type=string, outer=(7)]
+      │    │    │    └── filters [type=bool, outer=(9), constraints=(/9: (/NULL - ]; tight)]
+      │    │    │         └── column9 IS NOT NULL [type=bool, outer=(9), constraints=(/9: (/NULL - ]; tight)]
+      │    │    └── filters [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+      │    │         └── xy.y = a.k [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ])]
       │    └── aggregations [outer=(2-5,9)]
       │         ├── max [type=string, outer=(9)]
       │         │    └── variable: column9 [type=string, outer=(9)]

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -166,6 +166,17 @@ func BoolOperatorRequiresNotNullArgs(op Operator) bool {
 	return false
 }
 
+// AggregateIsOrderingSensitive returns true if the given aggregate operator is
+// non-commutative. That is, it can give different results based on the order
+// values are fed to it.
+func AggregateIsOrderingSensitive(op Operator) bool {
+	switch op {
+	case ArrayAggOp, ConcatAggOp, JsonAggOp, JsonbAggOp:
+		return true
+	}
+	return false
+}
+
 // AggregateIgnoresNulls returns true if the given aggregate operator has a
 // single input, and if it always evaluates to the same result regardless of
 // how many NULL values are included in that input, in any order.

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -226,18 +226,8 @@ func (b *Builder) buildAggregation(
 
 	aggInfos := aggOutScope.groupby.aggs
 
-	// Copy the ordering from fromScope to aggInScope if needed.
-	// TODO(justin): we should have a whitelist somewhere of ordering-sensitive
-	// aggregations and only propagate the ordering if we have one here.
-	if len(aggOutScope.getAggregateCols()) > 0 {
-		aggInScope.copyOrdering(fromScope)
-	}
-
-	// Construct the pre-projection, which renders the grouping columns and the
-	// aggregate arguments, as well as any additional order by columns.
-	b.constructProjectForScope(fromScope, aggInScope)
-
 	// Construct the aggregation operators.
+	haveOrderingSensitiveAgg := false
 	aggCols := aggOutScope.getAggregateCols()
 	argCols := aggInScope.cols[len(groupings):]
 	for i, agg := range aggInfos {
@@ -251,8 +241,20 @@ func (b *Builder) buildAggregation(
 				argList[j] = b.factory.ConstructAggDistinct(argList[j])
 			}
 		}
-		aggCols[i].group = constructAggLookup[agg.def.Name](b.factory, argList)
+		aggOp := aggOpLookup[agg.def.Name]
+		if opt.AggregateIsOrderingSensitive(aggOp) {
+			haveOrderingSensitiveAgg = true
+		}
+		aggCols[i].group = constructAggLookup[aggOp](b.factory, argList)
 	}
+
+	if haveOrderingSensitiveAgg {
+		aggInScope.copyOrdering(fromScope)
+	}
+
+	// Construct the pre-projection, which renders the grouping columns and the
+	// aggregate arguments, as well as any additional order by columns.
+	b.constructProjectForScope(fromScope, aggInScope)
 
 	var groupingColSet opt.ColSet
 	for i := range groupings {
@@ -439,56 +441,76 @@ func isGenerator(def *tree.FunctionDefinition) bool {
 	return def.Class == tree.GeneratorClass
 }
 
-var constructAggLookup = map[string]func(f *norm.Factory, argList []memo.GroupID) memo.GroupID{
-	"array_agg": func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
+var aggOpLookup = map[string]opt.Operator{
+	"array_agg":  opt.ArrayAggOp,
+	"avg":        opt.AvgOp,
+	"bool_and":   opt.BoolAndOp,
+	"bool_or":    opt.BoolOrOp,
+	"concat_agg": opt.ConcatAggOp,
+	"count":      opt.CountOp,
+	"count_rows": opt.CountRowsOp,
+	"max":        opt.MaxOp,
+	"min":        opt.MinOp,
+	"sum_int":    opt.SumIntOp,
+	"sum":        opt.SumOp,
+	"sqrdiff":    opt.SqrDiffOp,
+	"variance":   opt.VarianceOp,
+	"stddev":     opt.StdDevOp,
+	"xor_agg":    opt.XorAggOp,
+	"json_agg":   opt.JsonAggOp,
+	"jsonb_agg":  opt.JsonbAggOp,
+}
+
+var constructAggLookup = map[opt.Operator]func(f *norm.Factory, argList []memo.GroupID) memo.GroupID{
+	opt.ArrayAggOp: func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
 		return f.ConstructArrayAgg(argList[0])
 	},
-	"avg": func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
+	opt.AvgOp: func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
 		return f.ConstructAvg(argList[0])
 	},
-	"bool_and": func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
+	opt.BoolAndOp: func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
 		return f.ConstructBoolAnd(argList[0])
 	},
-	"bool_or": func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
+	opt.BoolOrOp: func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
 		return f.ConstructBoolOr(argList[0])
 	},
-	"concat_agg": func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
+	opt.ConcatAggOp: func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
 		return f.ConstructConcatAgg(argList[0])
 	},
-	"count": func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
+	opt.CountOp: func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
 		return f.ConstructCount(argList[0])
 	},
-	"count_rows": func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
+	opt.CountRowsOp: func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
 		return f.ConstructCountRows()
 	},
-	"max": func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
+	opt.MaxOp: func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
 		return f.ConstructMax(argList[0])
 	},
-	"min": func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
+	opt.MinOp: func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
 		return f.ConstructMin(argList[0])
 	},
-	"sum_int": func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
+	opt.SumIntOp: func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
 		return f.ConstructSumInt(argList[0])
 	},
-	"sum": func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
+	opt.SumOp: func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
 		return f.ConstructSum(argList[0])
 	},
-	"sqrdiff": func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
+	opt.SqrDiffOp: func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
 		return f.ConstructSqrDiff(argList[0])
 	},
-	"variance": func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
+	opt.VarianceOp: func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
 		return f.ConstructVariance(argList[0])
 	},
-	"stddev": func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
+	opt.StdDevOp: func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
 		return f.ConstructStdDev(argList[0])
 	},
-	"xor_agg": func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
+	opt.XorAggOp: func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
 		return f.ConstructXorAgg(argList[0])
 	},
-	"json_agg": func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
+	opt.JsonAggOp: func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
 		return f.ConstructJsonAgg(argList[0])
 	},
-	"jsonb_agg": func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
+	opt.JsonbAggOp: func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
 		return f.ConstructJsonbAgg(argList[0])
 	},
 }

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -1058,6 +1058,22 @@ scalar-group-by
            └── variable: kv.k [type=int]
 
 build
+SELECT max(k) FROM (SELECT k FROM kv ORDER BY s)
+----
+scalar-group-by
+ ├── columns: max:5(int)
+ ├── project
+ │    ├── columns: k:1(int!null)
+ │    └── project
+ │         ├── columns: k:1(int!null) s:4(string)
+ │         └── scan kv
+ │              └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ └── aggregations
+      └── max [type=int]
+           └── variable: kv.k [type=int]
+
+
+build
 SELECT array_agg(k) || 1 FROM (SELECT k FROM kv ORDER BY s)
 ----
 project


### PR DESCRIPTION
There's two commits here:

* the first just deletes some TODOs that weren't relevant anymore,
* the second modifies the optbuilder for groupby to only pass through ordering when there's an aggregate that needs it.