### PR TITLE
opt: remove TODOs that no longer apply

### DIFF
--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -718,8 +718,6 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 			break
 		}
 
-		// TODO(peter): the ARRAY flatten operator requires a single column from
-		// the subquery.
 		if sub, ok := t.Subquery.(*tree.Subquery); ok {
 			// Copy the ArrayFlatten expression so that the tree isn't mutated.
 			copy := *t

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -34,7 +34,6 @@ import (
 // scanOp operator. Joins will result in the construction of several groups,
 // including two for the left and right table scans, at least one for the join
 // condition, and one for the join itself.
-// TODO(rytaft): Add support for function and join table expressions.
 //
 // See Builder.buildStmt for a description of the remaining input and
 // return values.
@@ -500,8 +499,6 @@ func (b *Builder) buildFrom(from *tree.From, where *tree.Where, inScope *scope) 
 	}
 
 	if outScope == nil {
-		// TODO(peter): This should be a table with 1 row and 0 columns to match
-		// current cockroach behavior.
 		rows := []memo.GroupID{b.factory.ConstructTuple(
 			b.factory.InternList(nil), b.factory.InternType(memo.EmptyTupleType),
 		)}

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -542,8 +542,6 @@ project
            ├── variable: kv.k [type=int]
            └── variable: kv.v [type=int]
 
-# TODO(rytaft): don't qualify the column name in the error message differently
-# than it was qualified in the query.
 build
 SELECT count(*), k+v FROM kv GROUP BY k
 ----

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -141,10 +141,10 @@ SELECT DISTINCT y + z FROM xyz ORDER BY y + z
 ----
 error (22023): unsupported binary operator: <int> + <float>
 
-# TODO(rytaft): This query causes an error in Postgres, but it is supported by
-# CockroachDB with the semantics:
+# This query causes an error in Postgres, and the optimizer has followed
+# that lead. However, it is supported by the heuristic planner in CockroachDB
+# with the semantics:
 #   SELECT y AS w FROM t GROUP BY y ORDER BY min(z);
-# We may decide to support this later, but for now this should cause an error.
 build
 SELECT DISTINCT y AS w FROM xyz ORDER by z
 ----

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -143,7 +143,6 @@ sort
 
 # Check that ORDER BY chokes on ambiguity if no table less columns
 # were introduced by USING. (#12239)
-# TODO(rytaft): This is a bug. This query is invalid.
 build
 SELECT * FROM onecolumn AS a, onecolumn AS b ORDER BY x
 ----

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -84,10 +84,10 @@ project
       ├── columns: a:1(int!null) b:2(int) c:3(bool)
       └── ordering: -1
 
-# TODO(rytaft): This query causes an error in Postgres, but it is supported by
-# CockroachDB with the semantics:
+# This query causes an error in Postgres, and the optimizer has followed
+# that lead. However, it is supported by the heuristic planner in CockroachDB
+# with the semantics:
 #   SELECT c FROM t GROUP BY c ORDER BY max(b) DESC;
-# We may decide to support this later, but for now this should cause an error.
 build
 SELECT DISTINCT c FROM t ORDER BY b DESC
 ----
@@ -741,8 +741,6 @@ sort
                      ├── variable: abc.b [type=int]
                      └── const: 2 [type=int]
 
-# Verify that the ordering of the primary index is still used for the outer sort.
-# TODO(rytaft): Verify that the sort node is removed before execution.
 build
 SELECT * FROM (SELECT b, c FROM abc WHERE a=1 ORDER BY a,b) ORDER BY b,c
 ----

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -352,15 +352,11 @@ TABLE xyzw
       ├── y int
       └── x int not null
 
-# TODO(rytaft): Fix error message:
-# error: name "x" is not defined
 build
 SELECT * FROM xyzw LIMIT x
 ----
 error (42703): column "x" does not exist
 
-# TODO(rytaft): Fix error message:
-# error: name "y" is not defined
 build
 SELECT * FROM xyzw OFFSET 1 + y
 ----

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -735,7 +735,6 @@ SELECT 1 EXCEPT SELECT '3'
 ----
 error (42804): EXCEPT types int and string cannot be matched
 
-# TODO(rytaft): Error message should be `pgcode 42703 column "z" does not exist`
 build
 SELECT 1 UNION SELECT 3 ORDER BY z
 ----

--- a/pkg/sql/opt/optbuilder/testdata/values
+++ b/pkg/sql/opt/optbuilder/testdata/values
@@ -49,7 +49,6 @@ limit
  │              └── const: 3 [type=int]
  └── const: 3 [type=int]
 
-# TODO(rytaft): Error message should be `pgcode 42703 column "z" does not exist`
 build
 VALUES (1), (1), (2), (3) ORDER BY z
 ----

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -107,9 +107,8 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 			tab.addIndex(def, nonUniqueIndex)
 		}
 
-		// TODO(rytaft): In the future we will likely want to check for unique
-		// constraints, indexes, and foreign key constraints to determine
-		// nullability, uniqueness, etc.
+		// TODO(rytaft): In the future we will likely want to check for foreign key
+		// constraints.
 	}
 
 	// We need to keep track of the tableID from numeric references. 53 is a magic


### PR DESCRIPTION
This commit removes several TODOs from throughout
opt that are no longer applicable.

Release note: None