### PR TITLE
batcheval: Add warning to GetMVCCStats

### DIFF
--- a/pkg/storage/batcheval/eval_context.go
+++ b/pkg/storage/batcheval/eval_context.go
@@ -67,7 +67,13 @@ type EvalContext interface {
 	Desc() *roachpb.RangeDescriptor
 	ContainsKey(key roachpb.Key) bool
 
+	// GetMVCCStats returns a snapshot of the MVCC stats for the range.
+	// If called from a command that declares a read/write span on the
+	// entire range, the stats will be consistent with the data that is
+	// visible to the batch. Otherwise, it may return inconsistent
+	// results due to concurrent writes.
 	GetMVCCStats() enginepb.MVCCStats
+
 	GetGCThreshold() hlc.Timestamp
 	GetTxnSpanGCThreshold() hlc.Timestamp
 	GetLastReplicaGCTimestamp(context.Context) (hlc.Timestamp, error)

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1774,6 +1774,8 @@ func (r *Replica) setLastReplicaDescriptors(req *RaftMessageRequest) {
 }
 
 // GetMVCCStats returns a copy of the MVCC stats object for this range.
+// This accessor is thread-safe, but provides no guarantees about its
+// synchronization with any concurrent writes.
 func (r *Replica) GetMVCCStats() enginepb.MVCCStats {
 	r.mu.RLock()
 	defer r.mu.RUnlock()


### PR DESCRIPTION
This method is only really well-defined when called from a command
that gets a write lock on the entire range. Warn against other uses.

Fixes #21509

Release note: None