### PR TITLE
server: capture info about hardware and OS in diagnostics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1026,9 +1026,14 @@
 [[projects]]
   name = "github.com/shirou/gopsutil"
   packages = [
+    "cpu",
     "disk",
+    "host",
     "internal/common",
+    "load",
+    "mem",
     "net",
+    "process",
   ]
   revision = "4a180b209f5f494e5923cfce81ea30ba23915877"
   version = "v2.18.06"
@@ -1324,6 +1329,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5a796ea9a2f90290a876f3422b30b8a3fe68fdeb5217309b737e060740b4f070"
+  inputs-digest = "6c2af648541ee9e4639f3a0b6225895ed070f7af98337b8c7e9ace5d44a18c86"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/server/diagnosticspb/diagnostics.pb.go
+++ b/pkg/server/diagnosticspb/diagnostics.pb.go
@@ -11,6 +11,10 @@
 		DiagnosticReport
 		NodeInfo
 		StoreInfo
+		CPUInfo
+		HardwareInfo
+		OSInfo
+		MemInfo
 */
 package diagnosticspb
 
@@ -25,6 +29,7 @@ import cockroach_roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
 import github_com_cockroachdb_cockroach_pkg_roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
 
 import sortkeys "github.com/gogo/protobuf/sortkeys"
+import binary "encoding/binary"
 
 import io "io"
 
@@ -62,6 +67,8 @@ type NodeInfo struct {
 	KeyCount   int64                                               `protobuf:"varint,3,opt,name=key_count,json=keyCount,proto3" json:"key_count,omitempty"`
 	RangeCount int64                                               `protobuf:"varint,4,opt,name=range_count,json=rangeCount,proto3" json:"range_count,omitempty"`
 	Locality   cockroach_roachpb.Locality                          `protobuf:"bytes,5,opt,name=locality" json:"locality"`
+	Hardware   HardwareInfo                                        `protobuf:"bytes,6,opt,name=hardware" json:"hardware"`
+	Os         OSInfo                                              `protobuf:"bytes,7,opt,name=os" json:"os"`
 }
 
 func (m *NodeInfo) Reset()                    { *m = NodeInfo{} }
@@ -75,6 +82,9 @@ type StoreInfo struct {
 	Bytes      int64                                                `protobuf:"varint,3,opt,name=bytes,proto3" json:"bytes,omitempty"`
 	KeyCount   int64                                                `protobuf:"varint,4,opt,name=key_count,json=keyCount,proto3" json:"key_count,omitempty"`
 	RangeCount int64                                                `protobuf:"varint,5,opt,name=range_count,json=rangeCount,proto3" json:"range_count,omitempty"`
+	Capacity   int64                                                `protobuf:"varint,6,opt,name=capacity,proto3" json:"capacity,omitempty"`
+	Available  int64                                                `protobuf:"varint,7,opt,name=available,proto3" json:"available,omitempty"`
+	Used       int64                                                `protobuf:"varint,8,opt,name=used,proto3" json:"used,omitempty"`
 }
 
 func (m *StoreInfo) Reset()                    { *m = StoreInfo{} }
@@ -82,10 +92,61 @@ func (m *StoreInfo) String() string            { return proto.CompactTextString(
 func (*StoreInfo) ProtoMessage()               {}
 func (*StoreInfo) Descriptor() ([]byte, []int) { return fileDescriptorDiagnostics, []int{2} }
 
+type CPUInfo struct {
+	Numcpu   int32    `protobuf:"varint,1,opt,name=numcpu,proto3" json:"numcpu,omitempty"`
+	Sockets  int32    `protobuf:"varint,2,opt,name=sockets,proto3" json:"sockets,omitempty"`
+	Cores    int32    `protobuf:"varint,3,opt,name=cores,proto3" json:"cores,omitempty"`
+	Model    string   `protobuf:"bytes,4,opt,name=model,proto3" json:"model,omitempty"`
+	Mhz      float32  `protobuf:"fixed32,5,opt,name=mhz,proto3" json:"mhz,omitempty"`
+	Features []string `protobuf:"bytes,6,rep,name=features" json:"features,omitempty"`
+}
+
+func (m *CPUInfo) Reset()                    { *m = CPUInfo{} }
+func (m *CPUInfo) String() string            { return proto.CompactTextString(m) }
+func (*CPUInfo) ProtoMessage()               {}
+func (*CPUInfo) Descriptor() ([]byte, []int) { return fileDescriptorDiagnostics, []int{3} }
+
+type HardwareInfo struct {
+	Virtualization string  `protobuf:"bytes,1,opt,name=virtualization,proto3" json:"virtualization,omitempty"`
+	Cpu            CPUInfo `protobuf:"bytes,2,opt,name=cpu" json:"cpu"`
+	Mem            MemInfo `protobuf:"bytes,3,opt,name=mem" json:"mem"`
+	Loadavg15      float32 `protobuf:"fixed32,4,opt,name=loadavg15,proto3" json:"loadavg15,omitempty"`
+}
+
+func (m *HardwareInfo) Reset()                    { *m = HardwareInfo{} }
+func (m *HardwareInfo) String() string            { return proto.CompactTextString(m) }
+func (*HardwareInfo) ProtoMessage()               {}
+func (*HardwareInfo) Descriptor() ([]byte, []int) { return fileDescriptorDiagnostics, []int{4} }
+
+type OSInfo struct {
+	Family   string `protobuf:"bytes,1,opt,name=family,proto3" json:"family,omitempty"`
+	Platform string `protobuf:"bytes,2,opt,name=platform,proto3" json:"platform,omitempty"`
+	Version  string `protobuf:"bytes,3,opt,name=version,proto3" json:"version,omitempty"`
+}
+
+func (m *OSInfo) Reset()                    { *m = OSInfo{} }
+func (m *OSInfo) String() string            { return proto.CompactTextString(m) }
+func (*OSInfo) ProtoMessage()               {}
+func (*OSInfo) Descriptor() ([]byte, []int) { return fileDescriptorDiagnostics, []int{5} }
+
+type MemInfo struct {
+	Total     uint64 `protobuf:"varint,1,opt,name=total,proto3" json:"total,omitempty"`
+	Available uint64 `protobuf:"varint,2,opt,name=available,proto3" json:"available,omitempty"`
+}
+
+func (m *MemInfo) Reset()                    { *m = MemInfo{} }
+func (m *MemInfo) String() string            { return proto.CompactTextString(m) }
+func (*MemInfo) ProtoMessage()               {}
+func (*MemInfo) Descriptor() ([]byte, []int) { return fileDescriptorDiagnostics, []int{6} }
+
 func init() {
 	proto.RegisterType((*DiagnosticReport)(nil), "cockroach.server.diagnosticspb.DiagnosticReport")
 	proto.RegisterType((*NodeInfo)(nil), "cockroach.server.diagnosticspb.NodeInfo")
 	proto.RegisterType((*StoreInfo)(nil), "cockroach.server.diagnosticspb.StoreInfo")
+	proto.RegisterType((*CPUInfo)(nil), "cockroach.server.diagnosticspb.CPUInfo")
+	proto.RegisterType((*HardwareInfo)(nil), "cockroach.server.diagnosticspb.HardwareInfo")
+	proto.RegisterType((*OSInfo)(nil), "cockroach.server.diagnosticspb.OSInfo")
+	proto.RegisterType((*MemInfo)(nil), "cockroach.server.diagnosticspb.MemInfo")
 }
 func (m *DiagnosticReport) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
@@ -307,6 +368,22 @@ func (m *NodeInfo) MarshalTo(dAtA []byte) (int, error) {
 		return 0, err
 	}
 	i += n3
+	dAtA[i] = 0x32
+	i++
+	i = encodeVarintDiagnostics(dAtA, i, uint64(m.Hardware.Size()))
+	n4, err := m.Hardware.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n4
+	dAtA[i] = 0x3a
+	i++
+	i = encodeVarintDiagnostics(dAtA, i, uint64(m.Os.Size()))
+	n5, err := m.Os.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n5
 	return i, nil
 }
 
@@ -349,6 +426,191 @@ func (m *StoreInfo) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x28
 		i++
 		i = encodeVarintDiagnostics(dAtA, i, uint64(m.RangeCount))
+	}
+	if m.Capacity != 0 {
+		dAtA[i] = 0x30
+		i++
+		i = encodeVarintDiagnostics(dAtA, i, uint64(m.Capacity))
+	}
+	if m.Available != 0 {
+		dAtA[i] = 0x38
+		i++
+		i = encodeVarintDiagnostics(dAtA, i, uint64(m.Available))
+	}
+	if m.Used != 0 {
+		dAtA[i] = 0x40
+		i++
+		i = encodeVarintDiagnostics(dAtA, i, uint64(m.Used))
+	}
+	return i, nil
+}
+
+func (m *CPUInfo) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *CPUInfo) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Numcpu != 0 {
+		dAtA[i] = 0x8
+		i++
+		i = encodeVarintDiagnostics(dAtA, i, uint64(m.Numcpu))
+	}
+	if m.Sockets != 0 {
+		dAtA[i] = 0x10
+		i++
+		i = encodeVarintDiagnostics(dAtA, i, uint64(m.Sockets))
+	}
+	if m.Cores != 0 {
+		dAtA[i] = 0x18
+		i++
+		i = encodeVarintDiagnostics(dAtA, i, uint64(m.Cores))
+	}
+	if len(m.Model) > 0 {
+		dAtA[i] = 0x22
+		i++
+		i = encodeVarintDiagnostics(dAtA, i, uint64(len(m.Model)))
+		i += copy(dAtA[i:], m.Model)
+	}
+	if m.Mhz != 0 {
+		dAtA[i] = 0x2d
+		i++
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(m.Mhz))))
+		i += 4
+	}
+	if len(m.Features) > 0 {
+		for _, s := range m.Features {
+			dAtA[i] = 0x32
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			dAtA[i] = uint8(l)
+			i++
+			i += copy(dAtA[i:], s)
+		}
+	}
+	return i, nil
+}
+
+func (m *HardwareInfo) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *HardwareInfo) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Virtualization) > 0 {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintDiagnostics(dAtA, i, uint64(len(m.Virtualization)))
+		i += copy(dAtA[i:], m.Virtualization)
+	}
+	dAtA[i] = 0x12
+	i++
+	i = encodeVarintDiagnostics(dAtA, i, uint64(m.Cpu.Size()))
+	n6, err := m.Cpu.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n6
+	dAtA[i] = 0x1a
+	i++
+	i = encodeVarintDiagnostics(dAtA, i, uint64(m.Mem.Size()))
+	n7, err := m.Mem.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n7
+	if m.Loadavg15 != 0 {
+		dAtA[i] = 0x25
+		i++
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(m.Loadavg15))))
+		i += 4
+	}
+	return i, nil
+}
+
+func (m *OSInfo) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OSInfo) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Family) > 0 {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintDiagnostics(dAtA, i, uint64(len(m.Family)))
+		i += copy(dAtA[i:], m.Family)
+	}
+	if len(m.Platform) > 0 {
+		dAtA[i] = 0x12
+		i++
+		i = encodeVarintDiagnostics(dAtA, i, uint64(len(m.Platform)))
+		i += copy(dAtA[i:], m.Platform)
+	}
+	if len(m.Version) > 0 {
+		dAtA[i] = 0x1a
+		i++
+		i = encodeVarintDiagnostics(dAtA, i, uint64(len(m.Version)))
+		i += copy(dAtA[i:], m.Version)
+	}
+	return i, nil
+}
+
+func (m *MemInfo) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MemInfo) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Total != 0 {
+		dAtA[i] = 0x8
+		i++
+		i = encodeVarintDiagnostics(dAtA, i, uint64(m.Total))
+	}
+	if m.Available != 0 {
+		dAtA[i] = 0x10
+		i++
+		i = encodeVarintDiagnostics(dAtA, i, uint64(m.Available))
 	}
 	return i, nil
 }
@@ -446,6 +708,10 @@ func (m *NodeInfo) Size() (n int) {
 	}
 	l = m.Locality.Size()
 	n += 1 + l + sovDiagnostics(uint64(l))
+	l = m.Hardware.Size()
+	n += 1 + l + sovDiagnostics(uint64(l))
+	l = m.Os.Size()
+	n += 1 + l + sovDiagnostics(uint64(l))
 	return n
 }
 
@@ -466,6 +732,90 @@ func (m *StoreInfo) Size() (n int) {
 	}
 	if m.RangeCount != 0 {
 		n += 1 + sovDiagnostics(uint64(m.RangeCount))
+	}
+	if m.Capacity != 0 {
+		n += 1 + sovDiagnostics(uint64(m.Capacity))
+	}
+	if m.Available != 0 {
+		n += 1 + sovDiagnostics(uint64(m.Available))
+	}
+	if m.Used != 0 {
+		n += 1 + sovDiagnostics(uint64(m.Used))
+	}
+	return n
+}
+
+func (m *CPUInfo) Size() (n int) {
+	var l int
+	_ = l
+	if m.Numcpu != 0 {
+		n += 1 + sovDiagnostics(uint64(m.Numcpu))
+	}
+	if m.Sockets != 0 {
+		n += 1 + sovDiagnostics(uint64(m.Sockets))
+	}
+	if m.Cores != 0 {
+		n += 1 + sovDiagnostics(uint64(m.Cores))
+	}
+	l = len(m.Model)
+	if l > 0 {
+		n += 1 + l + sovDiagnostics(uint64(l))
+	}
+	if m.Mhz != 0 {
+		n += 5
+	}
+	if len(m.Features) > 0 {
+		for _, s := range m.Features {
+			l = len(s)
+			n += 1 + l + sovDiagnostics(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *HardwareInfo) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.Virtualization)
+	if l > 0 {
+		n += 1 + l + sovDiagnostics(uint64(l))
+	}
+	l = m.Cpu.Size()
+	n += 1 + l + sovDiagnostics(uint64(l))
+	l = m.Mem.Size()
+	n += 1 + l + sovDiagnostics(uint64(l))
+	if m.Loadavg15 != 0 {
+		n += 5
+	}
+	return n
+}
+
+func (m *OSInfo) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.Family)
+	if l > 0 {
+		n += 1 + l + sovDiagnostics(uint64(l))
+	}
+	l = len(m.Platform)
+	if l > 0 {
+		n += 1 + l + sovDiagnostics(uint64(l))
+	}
+	l = len(m.Version)
+	if l > 0 {
+		n += 1 + l + sovDiagnostics(uint64(l))
+	}
+	return n
+}
+
+func (m *MemInfo) Size() (n int) {
+	var l int
+	_ = l
+	if m.Total != 0 {
+		n += 1 + sovDiagnostics(uint64(m.Total))
+	}
+	if m.Available != 0 {
+		n += 1 + sovDiagnostics(uint64(m.Available))
 	}
 	return n
 }
@@ -1342,6 +1692,66 @@ func (m *NodeInfo) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Hardware", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDiagnostics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthDiagnostics
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Hardware.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Os", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDiagnostics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthDiagnostics
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Os.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipDiagnostics(dAtA[iNdEx:])
@@ -1487,6 +1897,614 @@ func (m *StoreInfo) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Capacity", wireType)
+			}
+			m.Capacity = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDiagnostics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Capacity |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 7:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Available", wireType)
+			}
+			m.Available = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDiagnostics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Available |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 8:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Used", wireType)
+			}
+			m.Used = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDiagnostics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Used |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipDiagnostics(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthDiagnostics
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CPUInfo) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowDiagnostics
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CPUInfo: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CPUInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Numcpu", wireType)
+			}
+			m.Numcpu = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDiagnostics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Numcpu |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Sockets", wireType)
+			}
+			m.Sockets = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDiagnostics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Sockets |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Cores", wireType)
+			}
+			m.Cores = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDiagnostics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Cores |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Model", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDiagnostics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthDiagnostics
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Model = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 5 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Mhz", wireType)
+			}
+			var v uint32
+			if (iNdEx + 4) > l {
+				return io.ErrUnexpectedEOF
+			}
+			v = uint32(binary.LittleEndian.Uint32(dAtA[iNdEx:]))
+			iNdEx += 4
+			m.Mhz = float32(math.Float32frombits(v))
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Features", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDiagnostics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthDiagnostics
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Features = append(m.Features, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipDiagnostics(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthDiagnostics
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *HardwareInfo) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowDiagnostics
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: HardwareInfo: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: HardwareInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Virtualization", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDiagnostics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthDiagnostics
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Virtualization = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Cpu", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDiagnostics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthDiagnostics
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Cpu.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Mem", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDiagnostics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthDiagnostics
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Mem.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 5 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Loadavg15", wireType)
+			}
+			var v uint32
+			if (iNdEx + 4) > l {
+				return io.ErrUnexpectedEOF
+			}
+			v = uint32(binary.LittleEndian.Uint32(dAtA[iNdEx:]))
+			iNdEx += 4
+			m.Loadavg15 = float32(math.Float32frombits(v))
+		default:
+			iNdEx = preIndex
+			skippy, err := skipDiagnostics(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthDiagnostics
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *OSInfo) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowDiagnostics
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: OSInfo: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: OSInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Family", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDiagnostics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthDiagnostics
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Family = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Platform", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDiagnostics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthDiagnostics
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Platform = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Version", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDiagnostics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthDiagnostics
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Version = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipDiagnostics(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthDiagnostics
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MemInfo) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowDiagnostics
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MemInfo: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MemInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Total", wireType)
+			}
+			m.Total = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDiagnostics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Total |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Available", wireType)
+			}
+			m.Available = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDiagnostics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Available |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipDiagnostics(dAtA[iNdEx:])
@@ -1616,54 +2634,72 @@ var (
 func init() { proto.RegisterFile("server/diagnosticspb/diagnostics.proto", fileDescriptorDiagnostics) }
 
 var fileDescriptorDiagnostics = []byte{
-	// 782 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x95, 0xcf, 0x6b, 0xdb, 0x48,
-	0x14, 0xc7, 0x23, 0xff, 0xf6, 0x38, 0x61, 0x1d, 0xad, 0xd9, 0x15, 0x4e, 0xb0, 0x43, 0x0e, 0x59,
-	0x2f, 0x0b, 0x12, 0x38, 0x7b, 0x28, 0x85, 0xb6, 0xc4, 0x76, 0x52, 0x02, 0x25, 0x07, 0xa7, 0xb9,
-	0x84, 0x52, 0x33, 0x92, 0xc6, 0x8a, 0x6a, 0x59, 0x23, 0xcf, 0x8c, 0x02, 0x0e, 0xfd, 0x23, 0x7a,
-	0xef, 0x3f, 0x94, 0x63, 0x7b, 0xeb, 0xc9, 0xb4, 0xee, 0x5f, 0xd1, 0x9e, 0x8a, 0xde, 0xc8, 0x8e,
-	0xe2, 0x34, 0x31, 0x2e, 0xf4, 0x36, 0x9a, 0x37, 0xef, 0xf3, 0x7d, 0xf3, 0x7d, 0xcc, 0x13, 0xda,
-	0xe3, 0x84, 0x5d, 0x12, 0x66, 0xd8, 0x2e, 0x76, 0x7c, 0xca, 0x85, 0x6b, 0xf1, 0xc0, 0x4c, 0x7e,
-	0xe9, 0x01, 0xa3, 0x82, 0xaa, 0x35, 0x8b, 0x5a, 0x03, 0x46, 0xb1, 0x75, 0xa1, 0xcb, 0x0c, 0xfd,
-	0x56, 0x46, 0x75, 0xd3, 0xa2, 0x7e, 0xdf, 0x75, 0x8c, 0x2b, 0xea, 0x13, 0x99, 0x52, 0xad, 0x38,
-	0xd4, 0xa1, 0xb0, 0x34, 0xa2, 0x55, 0xbc, 0xfb, 0x37, 0x40, 0x02, 0xd3, 0xc0, 0x41, 0xd0, 0xe3,
-	0x02, 0x8b, 0x58, 0xa1, 0xba, 0xcd, 0x47, 0x9e, 0xc1, 0x47, 0x9e, 0x89, 0x39, 0x31, 0xb8, 0x60,
-	0xa1, 0x25, 0x42, 0x46, 0xec, 0x38, 0xfa, 0xd7, 0x2c, 0x6d, 0x48, 0x04, 0xb6, 0xb1, 0xc0, 0x72,
-	0x7f, 0xf7, 0x63, 0x11, 0x95, 0x3b, 0xf3, 0x4a, 0xba, 0x24, 0xa0, 0x4c, 0xa8, 0x2d, 0x94, 0xf1,
-	0xa9, 0x4d, 0x34, 0x65, 0x47, 0x69, 0x94, 0x9a, 0x0d, 0xfd, 0xe1, 0xda, 0xf5, 0x13, 0x6a, 0x93,
-	0x63, 0xbf, 0x4f, 0x5b, 0x99, 0xeb, 0x49, 0x7d, 0xad, 0x0b, 0xb9, 0xea, 0x73, 0x94, 0xe3, 0x82,
-	0x32, 0xc2, 0xb5, 0xd4, 0x4e, 0xba, 0x51, 0x6a, 0xfe, 0xbb, 0x8c, 0x72, 0x1a, 0x9d, 0x4e, 0x60,
-	0xe2, 0x74, 0xb5, 0x83, 0x72, 0xdc, 0xba, 0x20, 0x43, 0xac, 0xa5, 0x01, 0xb4, 0x97, 0x04, 0x8d,
-	0x3c, 0x3d, 0xbe, 0xb2, 0xfe, 0x12, 0x9b, 0x1e, 0xe9, 0x10, 0x6e, 0x31, 0x37, 0x10, 0x94, 0xcd,
-	0x29, 0x90, 0xab, 0x9e, 0xa0, 0x22, 0x1f, 0x79, 0xd2, 0x30, 0x2d, 0x03, 0xa0, 0xff, 0x16, 0x40,
-	0x6d, 0xea, 0x79, 0xc4, 0x12, 0xc4, 0x3e, 0x15, 0x58, 0x90, 0x21, 0xf1, 0x45, 0xb4, 0x70, 0xa1,
-	0xbe, 0x98, 0x56, 0xe0, 0x23, 0x2f, 0xda, 0xe4, 0xea, 0x5b, 0x54, 0x09, 0x7d, 0x77, 0x18, 0x78,
-	0x70, 0x90, 0xd8, 0x3d, 0xc2, 0x18, 0x65, 0x5c, 0xcb, 0x02, 0xfa, 0x78, 0xd9, 0x65, 0x17, 0x2d,
-	0xd7, 0xcf, 0x92, 0xb0, 0x43, 0x60, 0x1d, 0xfa, 0x82, 0x8d, 0xbb, 0x7f, 0x86, 0x77, 0x23, 0x6a,
-	0x80, 0xca, 0xd8, 0x13, 0x84, 0x11, 0xbb, 0xc7, 0x89, 0x10, 0xae, 0xef, 0x70, 0x2d, 0x07, 0xca,
-	0x87, 0x2b, 0x2b, 0x1f, 0x48, 0xd0, 0x69, 0xcc, 0x91, 0xaa, 0x7f, 0xe0, 0xdb, 0xbb, 0xaa, 0x8d,
-	0xd6, 0xe1, 0x86, 0x3d, 0x8b, 0x86, 0xbe, 0xe0, 0x5a, 0x1e, 0xd4, 0x0e, 0x56, 0x56, 0x83, 0x0b,
-	0xb4, 0x81, 0x21, 0x95, 0x4a, 0xe4, 0x66, 0x47, 0x7d, 0x83, 0xd6, 0xa3, 0x07, 0xd0, 0x93, 0x8f,
-	0x81, 0x6b, 0x85, 0x5f, 0x54, 0x39, 0xa7, 0x3e, 0x69, 0x4b, 0x06, 0xa8, 0xc4, 0xed, 0x2b, 0x5d,
-	0xdd, 0xec, 0xab, 0x43, 0xb4, 0xd1, 0x27, 0x38, 0x7a, 0x23, 0xbd, 0x90, 0x63, 0x87, 0x68, 0x45,
-	0x10, 0x6b, 0xad, 0x2c, 0x76, 0x24, 0x29, 0x67, 0x11, 0x24, 0xa9, 0xb6, 0xde, 0x4f, 0x04, 0xaa,
-	0x47, 0x48, 0xbb, 0xaf, 0xc7, 0x6a, 0x19, 0xa5, 0x07, 0x64, 0x0c, 0xcf, 0xad, 0xd8, 0x8d, 0x96,
-	0x6a, 0x05, 0x65, 0x2f, 0xb1, 0x17, 0x12, 0x2d, 0xb5, 0xa3, 0x34, 0xd2, 0x5d, 0xf9, 0xf1, 0x38,
-	0xf5, 0x48, 0xa9, 0xb6, 0x50, 0xe5, 0x67, 0x1d, 0x5b, 0xc6, 0x28, 0x26, 0x19, 0x4f, 0x51, 0x79,
-	0xb1, 0x0f, 0x2b, 0xd5, 0xf0, 0x0a, 0x95, 0x17, 0x1d, 0x4e, 0xe6, 0xa7, 0x65, 0x7e, 0x33, 0x99,
-	0x5f, 0x6a, 0x6e, 0x27, 0x8c, 0x95, 0xfd, 0x4d, 0xb4, 0x29, 0x49, 0x7f, 0x86, 0x36, 0xef, 0x58,
-	0xba, 0xac, 0xbc, 0x6c, 0x02, 0xb0, 0xfb, 0x4d, 0x41, 0x85, 0xd9, 0x4c, 0x52, 0xcf, 0x51, 0x3e,
-	0x9a, 0x47, 0x3d, 0xd7, 0x86, 0xe4, 0x6c, 0xeb, 0x60, 0x3a, 0xa9, 0xe7, 0x20, 0xdc, 0xf9, 0x3e,
-	0xa9, 0xef, 0x3b, 0xae, 0xb8, 0x08, 0x4d, 0xdd, 0xa2, 0x43, 0x63, 0x5e, 0x9f, 0x6d, 0xde, 0xac,
-	0x8d, 0x60, 0xe0, 0x18, 0xf1, 0xf0, 0x94, 0x93, 0xae, 0xd3, 0xcd, 0x45, 0xc4, 0x63, 0x3b, 0x2a,
-	0xc1, 0x1c, 0x0b, 0x18, 0x71, 0xe0, 0x10, 0x7c, 0xa8, 0x5b, 0xa8, 0x38, 0x20, 0x63, 0xf9, 0x50,
-	0xb4, 0x34, 0x44, 0x0a, 0x03, 0x32, 0x06, 0xb3, 0xd5, 0x3a, 0x2a, 0x31, 0xec, 0x3b, 0x24, 0x0e,
-	0x67, 0x20, 0x8c, 0x60, 0x4b, 0x1e, 0x78, 0x82, 0x0a, 0x1e, 0xb5, 0xb0, 0xe7, 0x8a, 0xb1, 0x96,
-	0x05, 0xe3, 0xb6, 0x12, 0xc6, 0xcd, 0x0a, 0x79, 0x11, 0x1f, 0x99, 0xcd, 0xa5, 0x59, 0xca, 0xee,
-	0xfb, 0x14, 0x2a, 0xce, 0x27, 0xe9, 0x6f, 0xbd, 0xfc, 0x6b, 0x54, 0x80, 0x09, 0x1d, 0xc1, 0xa1,
-	0x05, 0xad, 0xf6, 0x74, 0x52, 0xcf, 0x4b, 0xf1, 0x88, 0xfe, 0xff, 0x4a, 0xf4, 0x38, 0xaf, 0x9b,
-	0x07, 0x68, 0xd2, 0xdc, 0xf4, 0xbd, 0xe6, 0x66, 0x1e, 0x36, 0x37, 0xbb, 0x68, 0x6e, 0xeb, 0x9f,
-	0xeb, 0x2f, 0xb5, 0xb5, 0xeb, 0x69, 0x4d, 0xf9, 0x30, 0xad, 0x29, 0x9f, 0xa6, 0x35, 0xe5, 0xf3,
-	0xb4, 0xa6, 0xbc, 0xfb, 0x5a, 0x5b, 0x3b, 0xdf, 0xb8, 0xf5, 0xc8, 0xcd, 0x1c, 0xfc, 0x1d, 0xf7,
-	0x7f, 0x04, 0x00, 0x00, 0xff, 0xff, 0x32, 0xf4, 0x4e, 0xc3, 0xdf, 0x07, 0x00, 0x00,
+	// 1071 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x56, 0x4f, 0x6f, 0xe3, 0x44,
+	0x14, 0xaf, 0xe3, 0xfc, 0x9d, 0x74, 0xa1, 0x3b, 0x54, 0x8b, 0x95, 0xad, 0xd2, 0x2a, 0x87, 0x6e,
+	0x11, 0x28, 0x11, 0x5d, 0x90, 0x10, 0x62, 0x59, 0x35, 0x6d, 0x17, 0x2a, 0x41, 0x41, 0x2e, 0xe5,
+	0x50, 0x21, 0xa2, 0x89, 0x3d, 0x71, 0x4d, 0x6c, 0x8f, 0x3b, 0x33, 0x0e, 0x4a, 0xc5, 0x9d, 0x2b,
+	0x17, 0xbe, 0x53, 0x8f, 0x70, 0x41, 0x9c, 0x2a, 0x08, 0x27, 0xbe, 0x02, 0x27, 0x34, 0x6f, 0x26,
+	0x89, 0x9b, 0xee, 0x6e, 0x28, 0xd2, 0xde, 0xe6, 0xbd, 0x37, 0xef, 0xf7, 0xde, 0xfb, 0xbd, 0x79,
+	0xcf, 0x46, 0xdb, 0x82, 0xf2, 0x11, 0xe5, 0x1d, 0x3f, 0x24, 0x41, 0xc2, 0x84, 0x0c, 0x3d, 0x91,
+	0xf6, 0xf3, 0x52, 0x3b, 0xe5, 0x4c, 0x32, 0xdc, 0xf4, 0x98, 0x37, 0xe4, 0x8c, 0x78, 0xe7, 0x6d,
+	0xed, 0xd1, 0xbe, 0xe1, 0xd1, 0xb8, 0xef, 0xb1, 0x64, 0x10, 0x06, 0x9d, 0x4b, 0x96, 0x50, 0xed,
+	0xd2, 0x58, 0x0f, 0x58, 0xc0, 0xe0, 0xd8, 0x51, 0x27, 0xa3, 0x7d, 0x13, 0x40, 0xd2, 0x7e, 0x87,
+	0xa4, 0x69, 0x4f, 0x48, 0x22, 0x4d, 0x84, 0xc6, 0x86, 0xb8, 0x88, 0x3a, 0xe2, 0x22, 0xea, 0x13,
+	0x41, 0x3b, 0x42, 0xf2, 0xcc, 0x93, 0x19, 0xa7, 0xbe, 0xb1, 0x3e, 0x98, 0xba, 0xc5, 0x54, 0x12,
+	0x9f, 0x48, 0xa2, 0xf5, 0xad, 0x5f, 0x6b, 0x68, 0xed, 0x60, 0x96, 0x89, 0x4b, 0x53, 0xc6, 0x25,
+	0xee, 0xa2, 0x62, 0xc2, 0x7c, 0xea, 0x58, 0x5b, 0xd6, 0x4e, 0x7d, 0x77, 0xa7, 0xfd, 0xf2, 0xdc,
+	0xdb, 0xc7, 0xcc, 0xa7, 0x47, 0xc9, 0x80, 0x75, 0x8b, 0x57, 0xd7, 0x9b, 0x2b, 0x2e, 0xf8, 0xe2,
+	0x4f, 0x50, 0x59, 0x48, 0xc6, 0xa9, 0x70, 0x0a, 0x5b, 0xf6, 0x4e, 0x7d, 0xf7, 0xad, 0x65, 0x28,
+	0x27, 0xea, 0x76, 0x0e, 0xc6, 0xb8, 0xe3, 0x03, 0x54, 0x16, 0xde, 0x39, 0x8d, 0x89, 0x63, 0x03,
+	0xd0, 0x76, 0x1e, 0xe8, 0x22, 0x6a, 0x9b, 0x92, 0xdb, 0x5f, 0x91, 0x7e, 0x44, 0x0f, 0xa8, 0xf0,
+	0x78, 0x98, 0x4a, 0xc6, 0x67, 0x28, 0xe0, 0x8b, 0x8f, 0x51, 0x4d, 0x5c, 0x44, 0x9a, 0x30, 0xa7,
+	0x08, 0x40, 0x6f, 0x2f, 0x00, 0xed, 0xb3, 0x28, 0xa2, 0x9e, 0xa4, 0xfe, 0x89, 0x24, 0x92, 0xc6,
+	0x34, 0x91, 0xea, 0x10, 0x42, 0x7e, 0x06, 0xad, 0x2a, 0x2e, 0x22, 0xa5, 0x14, 0xf8, 0x07, 0xb4,
+	0x9e, 0x25, 0x61, 0x9c, 0x46, 0x70, 0x91, 0xfa, 0x3d, 0xca, 0x39, 0xe3, 0xc2, 0x29, 0x01, 0xf4,
+	0xd1, 0xb2, 0x62, 0x17, 0x29, 0x6f, 0x9f, 0xe6, 0xc1, 0x0e, 0x01, 0xeb, 0x30, 0x91, 0x7c, 0xec,
+	0xbe, 0x91, 0xdd, 0xb6, 0xe0, 0x14, 0xad, 0x91, 0x48, 0x52, 0x4e, 0xfd, 0x9e, 0xa0, 0x52, 0x86,
+	0x49, 0x20, 0x9c, 0x32, 0x44, 0x3e, 0xbc, 0x73, 0xe4, 0x3d, 0x0d, 0x74, 0x62, 0x70, 0x74, 0xd4,
+	0xd7, 0xc9, 0x4d, 0x2d, 0xf6, 0xd1, 0x2a, 0x54, 0xd8, 0xf3, 0x58, 0x96, 0x48, 0xe1, 0x54, 0x20,
+	0xda, 0xde, 0x9d, 0xa3, 0x41, 0x01, 0xfb, 0x80, 0xa1, 0x23, 0xd5, 0xe9, 0x5c, 0x83, 0xbf, 0x43,
+	0xab, 0x6a, 0x00, 0x7a, 0x7a, 0x18, 0x84, 0x53, 0xfd, 0x9f, 0x51, 0xce, 0x58, 0x42, 0xf7, 0x35,
+	0x06, 0x44, 0x31, 0xed, 0xab, 0x5f, 0xce, 0xf5, 0x38, 0x46, 0xf7, 0x06, 0x94, 0xa8, 0x19, 0xe9,
+	0x65, 0x82, 0x04, 0xd4, 0xa9, 0x41, 0xb0, 0xee, 0x9d, 0x83, 0x3d, 0xd3, 0x28, 0xa7, 0x0a, 0x24,
+	0x1f, 0x6d, 0x75, 0x90, 0x33, 0x34, 0x9e, 0x21, 0xe7, 0x45, 0x3d, 0xc6, 0x6b, 0xc8, 0x1e, 0xd2,
+	0x31, 0x8c, 0x5b, 0xcd, 0x55, 0x47, 0xbc, 0x8e, 0x4a, 0x23, 0x12, 0x65, 0xd4, 0x29, 0x6c, 0x59,
+	0x3b, 0xb6, 0xab, 0x85, 0x0f, 0x0b, 0x1f, 0x58, 0x8d, 0x2e, 0x5a, 0x7f, 0x5e, 0xc7, 0x96, 0x61,
+	0xd4, 0xf2, 0x18, 0x1f, 0xa3, 0xb5, 0xc5, 0x3e, 0xdc, 0x29, 0x87, 0x6f, 0xd0, 0xda, 0x22, 0xc3,
+	0x79, 0x7f, 0x5b, 0xfb, 0xef, 0xe6, 0xfd, 0xeb, 0xbb, 0x1b, 0x39, 0x62, 0x75, 0x7f, 0x73, 0x6d,
+	0xca, 0xa3, 0x3f, 0x45, 0xf7, 0x6f, 0x51, 0xba, 0x2c, 0xbd, 0x52, 0x0e, 0xa0, 0xf5, 0xa3, 0x8d,
+	0xaa, 0xd3, 0x9d, 0x84, 0xcf, 0x50, 0x45, 0xed, 0xa3, 0x5e, 0xe8, 0x83, 0x73, 0xa9, 0xbb, 0x37,
+	0xb9, 0xde, 0x2c, 0x83, 0xf9, 0xe0, 0x9f, 0xeb, 0xcd, 0xc7, 0x41, 0x28, 0xcf, 0xb3, 0x7e, 0xdb,
+	0x63, 0x71, 0x67, 0x96, 0x9f, 0xdf, 0x9f, 0x9f, 0x3b, 0xe9, 0x30, 0xe8, 0x98, 0xe5, 0xa9, 0x37,
+	0xdd, 0x81, 0x5b, 0x56, 0x88, 0x47, 0xbe, 0x4a, 0xa1, 0x3f, 0x96, 0xb0, 0xe2, 0x80, 0x21, 0x10,
+	0xf0, 0x43, 0x54, 0x1b, 0xd2, 0xb1, 0x1e, 0x14, 0xc7, 0x06, 0x4b, 0x75, 0x48, 0xc7, 0x40, 0x36,
+	0xde, 0x44, 0x75, 0x4e, 0x92, 0x80, 0x1a, 0x73, 0x11, 0xcc, 0x08, 0x54, 0xfa, 0xc2, 0x13, 0x54,
+	0x8d, 0x98, 0x47, 0xa2, 0x50, 0x8e, 0x9d, 0x12, 0x10, 0xf7, 0x30, 0x47, 0xdc, 0x34, 0x91, 0xcf,
+	0xcc, 0x95, 0xe9, 0x5e, 0x9a, 0xba, 0xe0, 0x63, 0x54, 0x3d, 0x27, 0xdc, 0xff, 0x9e, 0x70, 0xea,
+	0x94, 0xc1, 0xfd, 0x9d, 0x65, 0x0f, 0xfa, 0x53, 0x73, 0x3f, 0xb7, 0x7b, 0x67, 0x18, 0xf8, 0x23,
+	0x54, 0x60, 0x6a, 0xda, 0xad, 0xc5, 0xcd, 0xfb, 0x3c, 0xa4, 0x2f, 0x4e, 0x72, 0x18, 0x05, 0x26,
+	0x5a, 0x7f, 0x17, 0x50, 0x6d, 0xb6, 0xd7, 0x5f, 0x69, 0x2b, 0xbe, 0x45, 0x55, 0xf8, 0x5e, 0x28,
+	0x70, 0x78, 0x10, 0xdd, 0xfd, 0xc9, 0xf5, 0x66, 0x45, 0x07, 0x57, 0xe8, 0xef, 0xdd, 0x09, 0xdd,
+	0xf8, 0xb9, 0x15, 0x00, 0xcd, 0xb7, 0xda, 0x7e, 0x61, 0xab, 0x8b, 0x2f, 0x6f, 0x75, 0xe9, 0x56,
+	0xab, 0x1b, 0xa8, 0xea, 0x91, 0x94, 0x78, 0xaa, 0xd5, 0x65, 0xed, 0x3c, 0x95, 0xf1, 0x06, 0xaa,
+	0x91, 0x11, 0x09, 0x23, 0xf5, 0x51, 0x03, 0xfa, 0x6d, 0x77, 0xae, 0xc0, 0x18, 0x15, 0x33, 0x41,
+	0x7d, 0xa7, 0x0a, 0x06, 0x38, 0xb7, 0x7e, 0xb6, 0x50, 0x65, 0xff, 0xcb, 0x53, 0x60, 0xfa, 0x01,
+	0x2a, 0x27, 0x59, 0xec, 0xa5, 0x99, 0x26, 0xda, 0x35, 0x12, 0x76, 0x50, 0x45, 0x30, 0x6f, 0x48,
+	0xa5, 0x30, 0x53, 0x33, 0x15, 0x55, 0x7d, 0x1e, 0x7c, 0xad, 0x6d, 0x3d, 0x4d, 0x20, 0x28, 0x6d,
+	0xcc, 0x7c, 0x1a, 0x41, 0x6d, 0x35, 0x57, 0x0b, 0x6a, 0x16, 0xe3, 0xf3, 0x4b, 0x28, 0xa8, 0xe0,
+	0xaa, 0xa3, 0xaa, 0xc4, 0x2c, 0x3b, 0xfd, 0x1d, 0xaa, 0xb9, 0x33, 0xb9, 0xf5, 0x9b, 0x85, 0x56,
+	0xf3, 0x4f, 0x0c, 0x6f, 0xa3, 0xd7, 0x46, 0x21, 0x97, 0x19, 0x89, 0xc2, 0x4b, 0x22, 0x43, 0x96,
+	0x98, 0xa9, 0x5e, 0xd0, 0xe2, 0xa7, 0xc8, 0x56, 0x15, 0xe8, 0xed, 0xf1, 0x68, 0xd9, 0xdb, 0x33,
+	0xa5, 0x9b, 0xc7, 0xa7, 0x3c, 0x15, 0x40, 0x4c, 0x63, 0xa8, 0xe8, 0x3f, 0x00, 0x7c, 0x4e, 0xe3,
+	0x3c, 0x40, 0x4c, 0x63, 0xd5, 0x84, 0x88, 0x11, 0x9f, 0x8c, 0x82, 0x77, 0xdf, 0x07, 0x0a, 0x0a,
+	0xee, 0x5c, 0xd1, 0xfa, 0x1a, 0x95, 0xf5, 0x83, 0x57, 0x74, 0x0f, 0x48, 0x1c, 0x46, 0xd3, 0xfd,
+	0x64, 0x24, 0x45, 0x4b, 0x1a, 0x11, 0x39, 0x60, 0x3c, 0x36, 0x4b, 0x78, 0x26, 0xab, 0x56, 0x8c,
+	0x28, 0x17, 0xaa, 0x7c, 0x1b, 0x4c, 0x53, 0xb1, 0xf5, 0x04, 0x55, 0x4c, 0x2e, 0x8a, 0x7f, 0xc9,
+	0x24, 0x89, 0x00, 0xb7, 0xe8, 0x6a, 0xe1, 0xe6, 0xdb, 0x28, 0x80, 0x65, 0xae, 0xe8, 0x3e, 0xba,
+	0xfa, 0xb3, 0xb9, 0x72, 0x35, 0x69, 0x5a, 0xbf, 0x4c, 0x9a, 0xd6, 0xef, 0x93, 0xa6, 0xf5, 0xc7,
+	0xa4, 0x69, 0xfd, 0xf4, 0x57, 0x73, 0xe5, 0xec, 0xde, 0x8d, 0x82, 0xfb, 0x65, 0xf8, 0x03, 0x7c,
+	0xfc, 0x6f, 0x00, 0x00, 0x00, 0xff, 0xff, 0x6d, 0x77, 0x69, 0x93, 0xc3, 0x0a, 0x00, 0x00,
 }

--- a/pkg/server/diagnosticspb/diagnostics.proto
+++ b/pkg/server/diagnosticspb/diagnostics.proto
@@ -40,6 +40,9 @@ message NodeInfo {
   int64 key_count = 3;
   int64 range_count = 4;
   roachpb.Locality locality = 5 [(gogoproto.nullable) = false];
+
+  HardwareInfo hardware = 6 [(gogoproto.nullable) = false];
+  OSInfo os = 7 [(gogoproto.nullable) = false];
 }
 
 message StoreInfo {
@@ -48,5 +51,39 @@ message StoreInfo {
   int64 bytes = 3;
   int64 key_count = 4;
   int64 range_count = 5;
+
+  int64 capacity  = 6;
+  int64 available = 7;
+  int64 used = 8;
+
+  // Want: sync times, observed read/write speeds
+}
+
+message CPUInfo {
+  int32 numcpu = 1; // go's reported runtime.NUMCPU()
+  int32 sockets = 2; // number of cpus reported
+  int32 cores = 3;  // gopsutil's reported cores for first cpu
+  string model = 4; // reported model name e.g. `Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz`
+  float mhz = 5;  // speed of first cpu e.g. 3100
+  repeated string features = 6; // cpu feature flags for first cpu
+}
+
+message HardwareInfo {
+  string virtualization = 1;
+  CPUInfo cpu = 2 [(gogoproto.nullable) = false];
+  MemInfo mem = 3 [(gogoproto.nullable) = false];
+  float loadavg15 = 4;
+  // TODO(dt, bram): Cloud-specific info like instance class.
+}
+
+message OSInfo {
+  string family = 1;
+  string platform = 2;
+  string version = 3;
+}
+
+message MemInfo {
+  uint64 total = 1;
+  uint64 available = 2;
 }
 

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -322,6 +323,26 @@ func TestReportUsage(t *testing.T) {
 		if expected, actual := ts.node.Descriptor.NodeID, r.last.Node.NodeID; expected != actual {
 			return errors.Errorf("expected node id %v got %v", expected, actual)
 		}
+
+		if r.last.Node.Hardware.Mem.Total == 0 {
+			return errors.Errorf("expected non-zero total mem")
+		}
+		if r.last.Node.Hardware.Mem.Available == 0 {
+			return errors.Errorf("expected non-zero available mem")
+		}
+		if actual, expected := r.last.Node.Hardware.Cpu.Numcpu, runtime.NumCPU(); int(actual) != expected {
+			return errors.Errorf("expected %d num cpu, got %d", expected, actual)
+		}
+		if r.last.Node.Hardware.Cpu.Sockets == 0 {
+			return errors.Errorf("expected non-zero sockets")
+		}
+		if r.last.Node.Hardware.Cpu.Mhz == 0.0 {
+			return errors.Errorf("expected non-zero speed")
+		}
+		if r.last.Node.Os.Platform == "" {
+			return errors.Errorf("expected non-empty OS")
+		}
+
 		if minExpected, actual := totalKeys, r.last.Node.KeyCount; minExpected > actual {
 			return errors.Errorf("expected node keys at least %v got %v", minExpected, actual)
 		}


### PR DESCRIPTION
Information about cores and memory commonly used to run Cockroach can help us size caches, tune recommendations, etc.

First draft of what we discussed. Will need to think about testing a bit though.