### PR TITLE
sql: speed up two schema change tests by a bit

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1338,7 +1338,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	}
 
 	// Bulk insert.
-	const maxValue = 5000
+	const maxValue = 2000
 	if err := bulkInsertIntoTable(sqlDB, maxValue); err != nil {
 		t.Fatal(err)
 	}
@@ -1437,7 +1437,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	}
 
 	// Bulk insert.
-	maxValue := 5000
+	maxValue := 2000
 	if err := bulkInsertIntoTable(sqlDB, maxValue); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
speed up TestSchemaChangeRetry and
TestSchemaChangeRetryOnVersionChange by
reducing the data used in these tests.

Release note: None