### PR TITLE
storage: make subsumption atomic with merge commit application

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -792,47 +792,73 @@ func (r *Replica) String() string {
 	return fmt.Sprintf("[n%d,s%d,r%s]", r.store.Ident.NodeID, r.store.Ident.StoreID, &r.rangeStr)
 }
 
-// destroyRaftMuLocked deletes data associated with a replica, leaving a
-// tombstone. If `destroyData` is true, data in all of the range's keyspaces
-// will be deleted. Otherwise, only data in the range-ID local keyspace will be
-// deleted. Requires that Replica.raftMu is held.
-func (r *Replica) destroyRaftMuLocked(
-	ctx context.Context, nextReplicaID roachpb.ReplicaID, destroyData bool,
+func (r *Replica) preDestroyRaftMuLocked(
+	ctx context.Context,
+	reader engine.Reader,
+	batch engine.Batch,
+	nextReplicaID roachpb.ReplicaID,
+	destroyData bool,
 ) error {
-	startTime := timeutil.Now()
-
-	// Use a more efficient write-only batch because we don't need to do any
-	// reads from the batch.
-	batch := r.store.Engine().NewWriteOnlyBatch()
-	defer batch.Close()
-
-	ms := r.GetMVCCStats()
-
 	desc := r.Desc()
-	err := clearRangeData(ctx, desc, r.store.Engine(), batch, destroyData)
+	err := clearRangeData(ctx, desc, reader, batch, destroyData)
 	if err != nil {
 		return err
 	}
-	clearTime := timeutil.Now()
-
-	// Suggest the cleared range to the compactor queue.
-	r.store.compactor.Suggest(ctx, storagebase.SuggestedCompaction{
-		StartKey: roachpb.Key(desc.StartKey),
-		EndKey:   roachpb.Key(desc.EndKey),
-		Compaction: storagebase.Compaction{
-			Bytes:            ms.Total(),
-			SuggestedAtNanos: clearTime.UnixNano(),
-		},
-	})
 
 	// Save a tombstone to ensure that replica IDs never get reused.
 	//
 	// NB: Legacy tombstones (which are in the replicated key space) are wiped
 	// in clearRangeData, but that's OK since we're writing a new one in the same
 	// batch (and in particular, sequenced *after* the wipe).
-	if err := r.setTombstoneKey(ctx, batch, nextReplicaID); err != nil {
+	return r.setTombstoneKey(ctx, batch, nextReplicaID)
+}
+
+func (r *Replica) postDestroyRaftMuLocked(ctx context.Context, ms enginepb.MVCCStats) error {
+	// Suggest the cleared range to the compactor queue.
+	//
+	// TODO(benesch): we would ideally atomically suggest the compaction with
+	// the deletion of the data itself.
+	desc := r.Desc()
+	r.store.compactor.Suggest(ctx, storagebase.SuggestedCompaction{
+		StartKey: roachpb.Key(desc.StartKey),
+		EndKey:   roachpb.Key(desc.EndKey),
+		Compaction: storagebase.Compaction{
+			Bytes:            ms.Total(),
+			SuggestedAtNanos: timeutil.Now().UnixNano(),
+		},
+	})
+
+	// NB: we need the nil check below because it's possible that we're GC'ing a
+	// Replica without a replicaID, in which case it does not have a sideloaded
+	// storage.
+	//
+	// TODO(tschottdorf): at node startup, we should remove all on-disk
+	// directories belonging to replicas which aren't present. A crash before a
+	// call to postDestroyRaftMuLocked will currently leave the files around
+	// forever.
+	if r.raftMu.sideloaded != nil {
+		return r.raftMu.sideloaded.Clear(ctx)
+	}
+	return nil
+}
+
+// destroyRaftMuLocked deletes data associated with a replica, leaving a
+// tombstone. If `destroyData` is true, data in all of the range's keyspaces
+// will be deleted. Otherwise, only data in the range-ID local keyspace will be
+// deleted. Requires that Replica.raftMu is held.
+func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb.ReplicaID) error {
+	startTime := timeutil.Now()
+
+	ms := r.GetMVCCStats()
+
+	const destroyData = true
+	batch := r.Engine().NewWriteOnlyBatch()
+	defer batch.Close()
+	if err := r.preDestroyRaftMuLocked(ctx, r.Engine(), batch, nextReplicaID, destroyData); err != nil {
 		return err
 	}
+	preTime := timeutil.Now()
+
 	// We need to sync here because we are potentially deleting sideloaded
 	// proposals from the file system next. We could write the tombstone only in
 	// a synchronous batch first and then delete the data alternatively, but
@@ -843,24 +869,15 @@ func (r *Replica) destroyRaftMuLocked(
 	}
 	commitTime := timeutil.Now()
 
-	// NB: we need the nil check below because it's possible that we're
-	// GC'ing a Replica without a replicaID, in which case it does not
-	// have a sideloaded storage.
-	//
-	// TODO(tschottdorf): at node startup, we should remove all on-disk
-	// directories belonging to replicas which aren't present. A crash
-	// here will currently leave the files around forever.
-	if r.raftMu.sideloaded != nil {
-		if err := r.raftMu.sideloaded.Clear(ctx); err != nil {
-			return err
-		}
+	if err := r.postDestroyRaftMuLocked(ctx, ms); err != nil {
+		return err
 	}
 
 	log.Infof(ctx, "removed %d (%d+%d) keys in %0.0fms [clear=%0.0fms commit=%0.0fms]",
 		ms.KeyCount+ms.SysCount, ms.KeyCount, ms.SysCount,
 		commitTime.Sub(startTime).Seconds()*1000,
-		clearTime.Sub(startTime).Seconds()*1000,
-		commitTime.Sub(clearTime).Seconds()*1000)
+		preTime.Sub(startTime).Seconds()*1000,
+		commitTime.Sub(preTime).Seconds()*1000)
 	return nil
 }
 
@@ -5329,6 +5346,29 @@ func (r *Replica) processRaftCommand(
 				log.Fatal(ctx, err)
 			}
 			splitPreApply(ctx, r.store.cfg.Settings, tmpBatch, raftCmd.ReplicatedEvalResult.Split.SplitTrigger)
+			writeBatch.Data = tmpBatch.Repr()
+			tmpBatch.Close()
+		}
+
+		if merge := raftCmd.ReplicatedEvalResult.Merge; merge != nil {
+			// Merges require the subsumed range to be atomically deleted when the
+			// merge transaction commits.
+			//
+			// This is not the most efficient, but it only happens on merges,
+			// which are relatively infrequent and don't write much data.
+			tmpBatch := r.store.engine.NewBatch()
+			if err := tmpBatch.ApplyBatchRepr(writeBatch.Data, false); err != nil {
+				log.Fatal(ctx, err)
+			}
+			rhsRepl, err := r.store.GetReplica(merge.RightDesc.RangeID)
+			if err != nil {
+				log.Fatal(ctx, err)
+			}
+			const destroyData = false
+			err = rhsRepl.preDestroyRaftMuLocked(ctx, tmpBatch, tmpBatch, merge.RightDesc.NextReplicaID, destroyData)
+			if err != nil {
+				log.Fatal(ctx, err)
+			}
 			writeBatch.Data = tmpBatch.Repr()
 			tmpBatch.Close()
 		}

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -647,7 +647,7 @@ const (
 func clearRangeData(
 	ctx context.Context,
 	desc *roachpb.RangeDescriptor,
-	eng engine.Engine,
+	eng engine.Reader,
 	batch engine.Batch,
 	destroyData bool,
 ) error {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2395,20 +2395,17 @@ func (s *Store) MergeRange(
 	leftRepl.raftMu.AssertHeld()
 	rightRepl.raftMu.AssertHeld()
 
-	if rightRepl.IsInitialized() {
-		// Note that we were called (indirectly) from raft processing so we must
-		// call removeReplicaImpl directly to avoid deadlocking on the right-hand
-		// replica's raftMu.
-		if err := s.removeReplicaImpl(ctx, rightRepl, rightDesc.NextReplicaID, RemoveOptions{
-			DestroyData: false,
-		}); err != nil {
-			return errors.Errorf("cannot remove range: %s", err)
-		}
-	} else {
-		s.mu.Lock()
-		s.unlinkReplicaByRangeIDLocked(rightRepl.RangeID)
-		_ = s.removePlaceholderLocked(ctx, rightRepl.RangeID)
-		s.mu.Unlock()
+	if err := rightRepl.postDestroyRaftMuLocked(ctx, rightRepl.GetMVCCStats()); err != nil {
+		return err
+	}
+
+	// Note that we were called (indirectly) from raft processing so we must
+	// call removeReplicaImpl directly to avoid deadlocking on the right-hand
+	// replica's raftMu.
+	if err := s.removeReplicaImpl(ctx, rightRepl, rightDesc.NextReplicaID, RemoveOptions{
+		DestroyData: false, // the replica was destroyed when the merge commit applied
+	}); err != nil {
+		return errors.Errorf("cannot remove range: %s", err)
 	}
 
 	if leftRepl.leaseholderStats != nil {
@@ -2539,9 +2536,7 @@ type RemoveOptions struct {
 // removal decision is passed in. Removal is aborted if the replica ID has
 // advanced to or beyond the NextReplicaID since the removal decision was made.
 //
-// If opts.DestroyData is true, data in all of the range's keyspaces is deleted.
-// Otherwise, only data in the range-ID local keyspace is deleted. In either
-// case a tombstone record is written.
+// If opts.DestroyReplica is false, replica.destroyRaftMuLocked is not called.
 func (s *Store) RemoveReplica(
 	ctx context.Context, rep *Replica, nextReplicaID roachpb.ReplicaID, opts RemoveOptions,
 ) error {
@@ -2607,8 +2602,10 @@ func (s *Store) removeReplicaImpl(
 	rep.mu.Unlock()
 	rep.readOnlyCmdMu.Unlock()
 
-	if err := rep.destroyRaftMuLocked(ctx, nextReplicaID, opts.DestroyData); err != nil {
-		return err
+	if opts.DestroyData {
+		if err := rep.destroyRaftMuLocked(ctx, nextReplicaID); err != nil {
+			return err
+		}
 	}
 
 	s.mu.Lock()


### PR DESCRIPTION
~Please review the first commit separately in #28661.~

During a merge, the subsumed range logically ceases to exist at the
moment that the merge transaction commit applies. It's important that we
remove the subsumed range from disk in the same batch as the merge
commit to protect against an ill-timed crash. Tease apart
Replica.destroyRaftMuLocked to make this possible.

Release note: None