### PR TITLE
sqlbase: avoid using SERIAL in system tables

### DIFF
--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -128,7 +128,7 @@ CREATE TABLE system.jobs (
 	// Design outlined in /docs/RFCS/web_session_login.rfc
 	WebSessionsTableSchema = `
 CREATE TABLE system.web_sessions (
-	id             SERIAL     PRIMARY KEY,
+	id             INT        NOT NULL DEFAULT unique_rowid() PRIMARY KEY,
 	"hashedSecret" BYTES      NOT NULL,
 	username       STRING     NOT NULL,
 	"createdAt"    TIMESTAMP  NOT NULL DEFAULT now(),


### PR DESCRIPTION
Needed for  #28575.

We'll soon want special behavior for SERIAL. We can't afford the
definition of system tables to be subject to a discussion about what
SERIAL means. So this patch ensures system tables don't use SERIAL.

Release note: None