### PR TITLE
changefeedccl: fix race

### DIFF
--- a/pkg/ccl/changefeedccl/poller.go
+++ b/pkg/ccl/changefeedccl/poller.go
@@ -109,6 +109,8 @@ func equalSpanSets(a, b roachpb.Spans) bool {
 	if len(a) != len(b) {
 		return false
 	}
+	a = append(roachpb.Spans(nil), a...)
+	b = append(roachpb.Spans(nil), b...)
 	sort.Sort(a)
 	sort.Sort(b)
 	for i := range a {


### PR DESCRIPTION
equalSpanSets was sorting its inputs without copying them.

Fixes #28685

Release note: None