### PR TITLE
opt: add rulestats test directive

### DIFF
--- a/pkg/sql/opt/testutils/opt_tester.go
+++ b/pkg/sql/opt/testutils/opt_tester.go
@@ -17,8 +17,10 @@ package testutils
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
+	"text/tabwriter"
 
 	"github.com/pmezard/go-difflib/difflib"
 
@@ -140,6 +142,11 @@ func NewOptTester(catalog opt.Catalog, sql string) *OptTester {
 //    Builds an expression tree from a SQL query, fully optimizes it using the
 //    memo, and then outputs the memo containing the forest of trees.
 //
+//  - rulestats [flags]
+//
+//    Performs the optimization and outputs statistics about applied rules.
+//
+//
 // Supported flags:
 //
 //  - format: controls the formatting of expressions for build, opt, and
@@ -213,6 +220,13 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 		}
 		fillInLazyProps(ev)
 		return ev.FormatString(ot.Flags.ExprFormat)
+
+	case "rulestats":
+		result, err := ot.RuleStats()
+		if err != nil {
+			d.Fatalf(tb, "%v", err)
+		}
+		return result
 
 	case "optsteps":
 		result, err := ot.OptSteps()
@@ -339,6 +353,95 @@ func (ot *OptTester) Memo() (string, error) {
 	}
 	o.Optimize(root, required)
 	return o.Memo().FormatString(ot.Flags.MemoFormat), nil
+}
+
+// RuleStats performs the optimization and returns statistics about how many
+// rules were applied.
+func (ot *OptTester) RuleStats() (string, error) {
+	type ruleStats struct {
+		rule       opt.RuleName
+		numApplied int
+		numAdded   int
+	}
+	stats := make([]ruleStats, opt.NumRuleNames)
+	for i := range stats {
+		stats[i].rule = opt.RuleName(i)
+	}
+
+	o := xform.NewOptimizer(&ot.evalCtx)
+
+	o.NotifyOnAppliedRule(
+		func(ruleName opt.RuleName, group memo.GroupID, expr memo.ExprOrdinal, added int) {
+			stats[ruleName].numApplied++
+			stats[ruleName].numAdded += added
+		},
+	)
+	root, required, err := ot.buildExpr(o.Factory())
+	if err != nil {
+		return "", err
+	}
+	o.Optimize(root, required)
+
+	// Split the rules.
+	var norm, explore []ruleStats
+	var allNorm, allExplore ruleStats
+	for i := range stats {
+		if stats[i].numApplied > 0 {
+			if stats[i].rule.IsNormalize() {
+				allNorm.numApplied += stats[i].numApplied
+				norm = append(norm, stats[i])
+			} else {
+				allExplore.numApplied += stats[i].numApplied
+				allExplore.numAdded += stats[i].numAdded
+				explore = append(explore, stats[i])
+			}
+		}
+	}
+	// Sort with most applied rules first.
+	sort.SliceStable(norm, func(i, j int) bool {
+		return norm[i].numApplied > norm[j].numApplied
+	})
+	sort.SliceStable(explore, func(i, j int) bool {
+		return explore[i].numApplied > explore[j].numApplied
+	})
+
+	// Only show the top 5 rules.
+	const topK = 5
+	if len(norm) > topK {
+		norm = norm[:topK]
+	}
+	if len(explore) > topK {
+		explore = explore[:topK]
+	}
+
+	// Ready to report.
+	var res strings.Builder
+	fmt.Fprintf(&res, "Normalization rules applied %d times.\n", allNorm.numApplied)
+	if len(norm) > 0 {
+		fmt.Fprintf(&res, "Top normalization rules:\n")
+		tw := tabwriter.NewWriter(&res, 1 /* minwidth */, 1 /* tabwidth */, 1 /* padding */, ' ', 0)
+		for _, s := range norm {
+			fmt.Fprintf(tw, "  %s\tapplied\t%d\ttimes.\n", s.rule, s.numApplied)
+		}
+		_ = tw.Flush()
+	}
+
+	fmt.Fprintf(
+		&res, "Exploration rules applied %d times, added %d expressions.\n",
+		allExplore.numApplied, allExplore.numAdded,
+	)
+
+	if len(explore) > 0 {
+		fmt.Fprintf(&res, "Top exploration rules:\n")
+		tw := tabwriter.NewWriter(&res, 1 /* minwidth */, 1 /* tabwidth */, 1 /* padding */, ' ', 0)
+		for _, s := range explore {
+			fmt.Fprintf(
+				tw, "  %s\tapplied\t%d\ttimes, added\t%d\texpressions.\n", s.rule, s.numApplied, s.numAdded,
+			)
+		}
+		_ = tw.Flush()
+	}
+	return res.String(), nil
 }
 
 // OptSteps steps through the transformations performed by the optimizer on the

--- a/pkg/sql/opt/xform/testdata/rules/stats
+++ b/pkg/sql/opt/xform/testdata/rules/stats
@@ -1,0 +1,44 @@
+exec-ddl
+CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX b(b), UNIQUE INDEX c(c))
+----
+TABLE abc
+ ├── a int not null
+ ├── b int
+ ├── c int
+ ├── INDEX primary
+ │    └── a int not null
+ ├── INDEX b
+ │    ├── b int
+ │    └── a int not null
+ └── INDEX c
+      ├── c int
+      └── a int not null (storing)
+
+exec-ddl
+CREATE TABLE xyz (x INT PRIMARY KEY, y INT, z INT, INDEX y(y), UNIQUE INDEX z(z))
+----
+TABLE xyz
+ ├── x int not null
+ ├── y int
+ ├── z int
+ ├── INDEX primary
+ │    └── x int not null
+ ├── INDEX y
+ │    ├── y int
+ │    └── x int not null
+ └── INDEX z
+      ├── z int
+      └── x int not null (storing)
+
+# TODO(radu): fix the runaway exploration on this query.
+rulestats
+SELECT * FROM abc JOIN xyz ON a=x
+----
+Normalization rules applied 0 times.
+Exploration rules applied 56 times, added 49 expressions.
+Top exploration rules:
+  CommuteJoin              applied 18 times, added 9  expressions.
+  GenerateMergeJoins       applied 18 times, added 18 expressions.
+  PushJoinThroughIndexJoin applied 12 times, added 12 expressions.
+  GenerateLookupJoin       applied 6  times, added 6  expressions.
+  GenerateIndexScans       applied 2  times, added 4  expressions.


### PR DESCRIPTION
Add a testing mode which just prints out statistics about how many
rules were ran. This is useful to keep an eye on how various changes
affect the number of rules that are applied.

Example:

```
rulestats
SELECT * FROM abc WHERE 1 < a
----
Normalization rules applied 1 times.
Top normalization rules:
  CommuteVarInequality applied   1 times.
Exploration rules applied 4 times, added 5 expressions.
Top exploration rules:
  PushFilterIntoIndexJoinNoRemainder applied   2 times, added   2 expressions.
  GenerateIndexScans                 applied   1 times, added   2 expressions.
  ConstrainScan                      applied   1 times, added   1 expressions.
```

Release note: None