### PR TITLE
opt: [WIP] track distinct count changes

### DIFF
--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -383,6 +383,7 @@ func (ev ExprView) formatRelational(f *opt.ExprFmtCtx, tp treeprinter.Node) {
 	}
 
 	if !f.HasFlags(opt.ExprFmtHideStats) {
+		ev.formatStats(f, tp)
 		tp.Childf("stats: %s", &logProps.Relational.Stats)
 	}
 
@@ -424,6 +425,13 @@ func (ev ExprView) formatRelational(f *opt.ExprFmtCtx, tp treeprinter.Node) {
 
 	for i := 0; i < ev.ChildCount(); i++ {
 		ev.Child(i).format(f, tp)
+	}
+}
+
+func (ev ExprView) formatStats(f *opt.ExprFmtCtx, tp treeprinter.Node) {
+	logProps := ev.Logical()
+	for i := 0; i < logProps.Relational.Stats.ColStatCount(); i++ {
+		tp.Childf(logProps.Relational.Stats.ColStatString(i))
 	}
 }
 

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -92,12 +92,18 @@ project
  ├── fd: ()-->(1,2)
  └── select
       ├── columns: x:1(int!null) z:2(int!null) rowid:3(int!null)
-      ├── stats: [rows=8e-06, distinct(1)=8e-06, distinct(2)=8e-06, distinct(3)=8e-06]
+      ├── distinct(1)=8e-06[0-{2}-5000-{5}-5000-{3}-1-{7}-8e-06-{8}-8e-06]
+      ├── distinct(2)=8e-06[0-{2}-100-{5}-100-{3}-1-{7}-8e-06-{8}-8e-06]
+      ├── distinct(3)=8e-06[0-{2}-10000-{5}-10000-{3}-4-{7}-8e-06-{8}-8e-06]
+      ├── stats: [rows=8e-06]
       ├── key: (3)
       ├── fd: ()-->(1,2)
       ├── scan b
       │    ├── columns: x:1(int) z:2(int!null) rowid:3(int!null)
-      │    ├── stats: [rows=10000, distinct(1)=5000, distinct(2)=100, distinct(3)=10000]
+      │    ├── distinct(1)=5000[0-{2}-5000-{5}-5000]
+      │    ├── distinct(2)=100[0-{2}-100-{5}-100]
+      │    ├── distinct(3)=10000[0-{2}-10000-{5}-10000]
+      │    ├── stats: [rows=10000]
       │    ├── key: (3)
       │    └── fd: (3)-->(1,2)
       └── filters [type=bool, outer=(1-3), constraints=(/1: [/1 - /1]; /2: [/2 - /2]; /3: [/5 - /8]; tight), fd=()-->(1,2)]
@@ -141,12 +147,14 @@ SELECT * FROM a WHERE y = 5 AND x + y < 10
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null)
- ├── stats: [rows=3.33333333, distinct(2)=1]
+ ├── distinct(2)=1[0-{2}-400-{5}-400-{3}-1-{7}-1-{8}-1]
+ ├── stats: [rows=3.33333333]
  ├── key: (1)
  ├── fd: ()-->(2)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=4000, distinct(2)=400]
+ │    ├── distinct(2)=400[0-{2}-400-{5}-400]
+ │    ├── stats: [rows=4000]
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters [type=bool, outer=(1,2), constraints=(/2: [/5 - /5]), fd=()-->(2)]
@@ -191,15 +199,20 @@ project
  └── group-by
       ├── columns: z:2(int!null) sum:4(decimal)
       ├── grouping columns: z:2(int!null)
-      ├── stats: [rows=100, distinct(2)=100]
+      ├── distinct(2)=100[0-{2}-100-{5}-100-{5}-100-{8}-100]
+      ├── stats: [rows=100]
       ├── key: (2)
       ├── fd: (2)-->(4)
       ├── select
       │    ├── columns: x:1(int!null) z:2(int!null)
-      │    ├── stats: [rows=2000, distinct(1)=1000, distinct(2)=100]
+      │    ├── distinct(1)=1000[0-{2}-5000-{5}-5000-{3}-1000-{7}-1000-{8}-1000]
+      │    ├── distinct(2)=100[0-{2}-100-{5}-100-{5}-100]
+      │    ├── stats: [rows=2000]
       │    ├── scan b
       │    │    ├── columns: x:1(int) z:2(int!null)
-      │    │    └── stats: [rows=10000, distinct(1)=5000, distinct(2)=100]
+      │    │    ├── distinct(1)=5000[0-{2}-5000-{5}-5000]
+      │    │    ├── distinct(2)=100[0-{2}-100-{5}-100]
+      │    │    └── stats: [rows=10000]
       │    └── filters [type=bool, outer=(1), constraints=(/1: [/1001 - /2000]; tight)]
       │         ├── gt [type=bool, outer=(1), constraints=(/1: [/1001 - ]; tight)]
       │         │    ├── variable: b.x [type=int, outer=(1)]
@@ -494,12 +507,16 @@ SELECT * FROM district WHERE d_id = 1 AND d_name='bobs_burgers'
 ----
 select
  ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string!null)
- ├── stats: [rows=0.1, distinct(1)=0.1, distinct(3)=0.1]
+ ├── distinct(1)=0.1[0-{2}-10-{5}-10-{3}-1-{7}-0.1-{8}-0.1]
+ ├── distinct(3)=0.1[0-{2}-100-{5}-100-{3}-1-{7}-0.1-{8}-0.1]
+ ├── stats: [rows=0.1]
  ├── key: (2)
  ├── fd: ()-->(1,3)
  ├── scan district
  │    ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string)
- │    ├── stats: [rows=100, distinct(1)=10, distinct(3)=100]
+ │    ├── distinct(1)=10[0-{2}-10-{5}-10]
+ │    ├── distinct(3)=100[0-{2}-100-{5}-100]
+ │    ├── stats: [rows=100]
  │    ├── key: (1,2)
  │    └── fd: (1,2)-->(3)
  └── filters [type=bool, outer=(1,3), constraints=(/1: [/1 - /1]; /3: [/'bobs_burgers' - /'bobs_burgers']; tight), fd=()-->(1,3)]
@@ -518,12 +535,14 @@ SELECT * FROM district WHERE d_id = 1 and d_name LIKE 'bob'
 ----
 select
  ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string)
- ├── stats: [rows=3.33333333, distinct(1)=1]
+ ├── distinct(1)=1[0-{2}-10-{5}-10-{3}-1-{7}-1-{8}-1]
+ ├── stats: [rows=3.33333333]
  ├── key: (2)
  ├── fd: ()-->(1), (2)-->(3)
  ├── scan district
  │    ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string)
- │    ├── stats: [rows=100, distinct(1)=10]
+ │    ├── distinct(1)=10[0-{2}-10-{5}-10]
+ │    ├── stats: [rows=100]
  │    ├── key: (1,2)
  │    └── fd: (1,2)-->(3)
  └── filters [type=bool, outer=(1,3), constraints=(/1: [/1 - /1]), fd=()-->(1)]
@@ -544,12 +563,18 @@ SELECT * FROM district WHERE d_id > 1 AND d_id < 10 AND d_w_id=10 AND d_name='bo
 ----
 select
  ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string!null)
- ├── stats: [rows=0.08, distinct(1)=0.08, distinct(2)=0.08, distinct(3)=0.08]
+ ├── distinct(1)=0.08[0-{2}-10-{5}-10-{3}-8-{7}-0.08-{8}-0.08]
+ ├── distinct(2)=0.08[0-{2}-10-{5}-10-{3}-1-{7}-0.08-{8}-0.08]
+ ├── distinct(3)=0.08[0-{2}-100-{5}-100-{3}-1-{7}-0.08-{8}-0.08]
+ ├── stats: [rows=0.08]
  ├── key: (1)
  ├── fd: ()-->(2,3)
  ├── scan district
  │    ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string)
- │    ├── stats: [rows=100, distinct(1)=10, distinct(2)=10, distinct(3)=100]
+ │    ├── distinct(1)=10[0-{2}-10-{5}-10]
+ │    ├── distinct(2)=10[0-{2}-10-{5}-10]
+ │    ├── distinct(3)=100[0-{2}-100-{5}-100]
+ │    ├── stats: [rows=100]
  │    ├── key: (1,2)
  │    └── fd: (1,2)-->(3)
  └── filters [type=bool, outer=(1-3), constraints=(/1: [/2 - /9]; /2: [/10 - /10]; /3: [/'bobs_burgers' - /'bobs_burgers']; tight), fd=()-->(2,3)]
@@ -574,12 +599,18 @@ SELECT * FROM district WHERE d_id = 1 AND d_w_id=10 AND d_name='hello'
 select
  ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string!null)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=1, distinct(1)=1, distinct(2)=1, distinct(3)=1]
+ ├── distinct(1)=1[0-{2}-10-{5}-10-{3}-1-{7}-1-{8}-1]
+ ├── distinct(2)=1[0-{2}-10-{5}-10-{3}-1-{7}-1-{8}-1]
+ ├── distinct(3)=1[0-{2}-100-{5}-100-{3}-1-{7}-1-{8}-1]
+ ├── stats: [rows=1]
  ├── key: ()
  ├── fd: ()-->(1-3)
  ├── scan district
  │    ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string)
- │    ├── stats: [rows=100, distinct(1)=10, distinct(2)=10, distinct(3)=100]
+ │    ├── distinct(1)=10[0-{2}-10-{5}-10]
+ │    ├── distinct(2)=10[0-{2}-10-{5}-10]
+ │    ├── distinct(3)=100[0-{2}-100-{5}-100]
+ │    ├── stats: [rows=100]
  │    ├── key: (1,2)
  │    └── fd: (1,2)-->(3)
  └── filters [type=bool, outer=(1-3), constraints=(/1: [/1 - /1]; /2: [/10 - /10]; /3: [/'hello' - /'hello']; tight), fd=()-->(1-3)]
@@ -626,30 +657,41 @@ WHERE name='andy'
 ----
 select
  ├── columns: id:1(int!null) name:2(string!null) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int!null) year:7(int)
- ├── stats: [rows=2.31299908, distinct(2)=1]
+ ├── distinct(2)=1[0-{1}-432.339125-{3}-1-{7}-1-{8}-1]
+ ├── stats: [rows=2.31299908]
  ├── fd: ()-->(2), (1)-->(3), (1)==(6), (6)==(1)
  ├── project
  │    ├── columns: id:1(int!null) name:2(string) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int!null) year:7(int)
- │    ├── stats: [rows=1000, distinct(2)=432.339125]
+ │    ├── distinct(2)=432.339125[0-{1}-432.339125]
+ │    ├── stats: [rows=1000]
  │    ├── fd: (1)-->(2,3), (1)==(6), (6)==(1)
  │    └── select
  │         ├── columns: id:1(int!null) name:2(string) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int!null) year:7(int) rowid:8(int!null)
- │         ├── stats: [rows=1000, distinct(1)=700, distinct(2)=432.339125, distinct(6)=700]
+ │         ├── distinct(1)=700[0-{2}-10000-{5}-10000-{5}-10000-{4}-700-{7}-700-{8}-700]
+ │         ├── distinct(2)=432.339125[0-{2}-500-{5}-500-{5}-500-{5}-432.339125]
+ │         ├── distinct(6)=700[0-{1}-700-{5}-700-{5}-700-{4}-700-{7}-700-{8}-700]
+ │         ├── stats: [rows=1000]
  │         ├── key: (8)
  │         ├── fd: (1)-->(2,3), (8)-->(4-7), (1)==(6), (6)==(1)
  │         ├── inner-join
  │         │    ├── columns: id:1(int!null) name:2(string) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int) year:7(int) rowid:8(int!null)
- │         │    ├── stats: [rows=10000000, distinct(1)=10000, distinct(2)=500, distinct(6)=700]
+ │         │    ├── distinct(1)=10000[0-{2}-10000-{5}-10000-{5}-10000]
+ │         │    ├── distinct(2)=500[0-{2}-500-{5}-500-{5}-500]
+ │         │    ├── distinct(6)=700[0-{1}-700-{5}-700-{5}-700]
+ │         │    ├── stats: [rows=10000000]
  │         │    ├── key: (1,8)
  │         │    ├── fd: (1)-->(2,3), (8)-->(4-7)
  │         │    ├── scan customers
  │         │    │    ├── columns: id:1(int!null) name:2(string) state:3(string)
- │         │    │    ├── stats: [rows=10000, distinct(1)=10000, distinct(2)=500]
+ │         │    │    ├── distinct(1)=10000[0-{2}-10000-{5}-10000]
+ │         │    │    ├── distinct(2)=500[0-{2}-500-{5}-500]
+ │         │    │    ├── stats: [rows=10000]
  │         │    │    ├── key: (1)
  │         │    │    └── fd: (1)-->(2,3)
  │         │    ├── scan order_history
  │         │    │    ├── columns: order_id:4(int) item_id:5(int) customer_id:6(int) year:7(int) rowid:8(int!null)
- │         │    │    ├── stats: [rows=1000, distinct(6)=700]
+ │         │    │    ├── distinct(6)=700[0-{1}-700-{5}-700]
+ │         │    │    ├── stats: [rows=1000]
  │         │    │    ├── key: (8)
  │         │    │    └── fd: (8)-->(4-7)
  │         │    └── true [type=bool]
@@ -678,30 +720,43 @@ WHERE id = 1 AND name='andy'
 ----
 select
  ├── columns: id:1(int!null) name:2(string!null) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int!null) year:7(int)
- ├── stats: [rows=1.42857143, distinct(1)=1, distinct(2)=1]
+ ├── distinct(1)=1[0-{1}-700-{3}-1-{7}-1-{8}-1]
+ ├── distinct(2)=1[0-{1}-432.339125-{3}-1-{7}-1-{8}-1]
+ ├── stats: [rows=1.42857143]
  ├── fd: ()-->(1-3,6), (1)==(6), (6)==(1)
  ├── project
  │    ├── columns: id:1(int!null) name:2(string) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int!null) year:7(int)
- │    ├── stats: [rows=1000, distinct(1)=700, distinct(2)=432.339125]
+ │    ├── distinct(1)=700[0-{1}-700]
+ │    ├── distinct(2)=432.339125[0-{1}-432.339125]
+ │    ├── stats: [rows=1000]
  │    ├── fd: (1)-->(2,3), (1)==(6), (6)==(1)
  │    └── select
  │         ├── columns: id:1(int!null) name:2(string) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int!null) year:7(int) rowid:8(int!null)
- │         ├── stats: [rows=1000, distinct(1)=700, distinct(2)=432.339125, distinct(6)=700]
+ │         ├── distinct(1)=700[0-{2}-10000-{5}-10000-{5}-10000-{4}-700-{7}-700-{8}-700]
+ │         ├── distinct(2)=432.339125[0-{2}-500-{5}-500-{5}-500-{5}-432.339125]
+ │         ├── distinct(6)=700[0-{1}-700-{5}-700-{5}-700-{4}-700-{7}-700-{8}-700]
+ │         ├── stats: [rows=1000]
  │         ├── key: (8)
  │         ├── fd: (1)-->(2,3), (8)-->(4-7), (1)==(6), (6)==(1)
  │         ├── inner-join
  │         │    ├── columns: id:1(int!null) name:2(string) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int) year:7(int) rowid:8(int!null)
- │         │    ├── stats: [rows=10000000, distinct(1)=10000, distinct(2)=500, distinct(6)=700]
+ │         │    ├── distinct(1)=10000[0-{2}-10000-{5}-10000-{5}-10000]
+ │         │    ├── distinct(2)=500[0-{2}-500-{5}-500-{5}-500]
+ │         │    ├── distinct(6)=700[0-{1}-700-{5}-700-{5}-700]
+ │         │    ├── stats: [rows=10000000]
  │         │    ├── key: (1,8)
  │         │    ├── fd: (1)-->(2,3), (8)-->(4-7)
  │         │    ├── scan customers
  │         │    │    ├── columns: id:1(int!null) name:2(string) state:3(string)
- │         │    │    ├── stats: [rows=10000, distinct(1)=10000, distinct(2)=500]
+ │         │    │    ├── distinct(1)=10000[0-{2}-10000-{5}-10000]
+ │         │    │    ├── distinct(2)=500[0-{2}-500-{5}-500]
+ │         │    │    ├── stats: [rows=10000]
  │         │    │    ├── key: (1)
  │         │    │    └── fd: (1)-->(2,3)
  │         │    ├── scan order_history
  │         │    │    ├── columns: order_id:4(int) item_id:5(int) customer_id:6(int) year:7(int) rowid:8(int!null)
- │         │    │    ├── stats: [rows=1000, distinct(6)=700]
+ │         │    │    ├── distinct(6)=700[0-{1}-700-{5}-700]
+ │         │    │    ├── stats: [rows=1000]
  │         │    │    ├── key: (8)
  │         │    │    └── fd: (8)-->(4-7)
  │         │    └── true [type=bool]
@@ -724,11 +779,17 @@ SELECT * FROM order_history WHERE item_id = order_id AND item_id = customer_id A
 ----
 select
  ├── columns: order_id:1(int!null) item_id:2(int!null) customer_id:3(int!null) year:4(int)
- ├── stats: [rows=0.00204081633, distinct(1)=0.00204081633, distinct(2)=0.00204081633, distinct(3)=0.00204081633]
+ ├── distinct(1)=0.00204081633[0-{1}-700-{5}-700-{4}-1-{7}-0.00204081633-{8}-0.00204081633]
+ ├── distinct(2)=0.00204081633[0-{1}-700-{5}-700-{4}-1-{7}-0.00204081633-{8}-0.00204081633]
+ ├── distinct(3)=0.00204081633[0-{1}-700-{5}-700-{3}-1-{4}-1-{7}-0.00204081633-{8}-0.00204081633]
+ ├── stats: [rows=0.00204081633]
  ├── fd: ()-->(1-3), (1)==(2,3), (2)==(1,3), (3)==(1,2)
  ├── scan order_history
  │    ├── columns: order_id:1(int) item_id:2(int) customer_id:3(int) year:4(int)
- │    └── stats: [rows=1000, distinct(1)=700, distinct(2)=700, distinct(3)=700]
+ │    ├── distinct(1)=700[0-{1}-700-{5}-700]
+ │    ├── distinct(2)=700[0-{1}-700-{5}-700]
+ │    ├── distinct(3)=700[0-{1}-700-{5}-700]
+ │    └── stats: [rows=1000]
  └── filters [type=bool, outer=(1-3), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /3: [/5 - /5]), fd=()-->(1-3), (1)==(2,3), (2)==(1,3), (3)==(1,2)]
       ├── eq [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
       │    ├── variable: order_history.item_id [type=int, outer=(2)]
@@ -746,11 +807,15 @@ SELECT * FROM order_history WHERE item_id = order_id AND item_id < 5 AND item_id
 ----
 select
  ├── columns: order_id:1(int!null) item_id:2(int!null) customer_id:3(int) year:4(int)
- ├── stats: [rows=0.158730159, distinct(1)=0.158730159, distinct(2)=0.158730159]
+ ├── distinct(1)=0.158730159[0-{1}-700-{5}-700-{4}-700-{7}-0.158730159-{8}-0.158730159]
+ ├── distinct(2)=0.158730159[0-{1}-700-{5}-700-{4}-700-{7}-0.158730159-{8}-0.158730159]
+ ├── stats: [rows=0.158730159]
  ├── fd: (1)==(2), (2)==(1)
  ├── scan order_history
  │    ├── columns: order_id:1(int) item_id:2(int) customer_id:3(int) year:4(int)
- │    └── stats: [rows=1000, distinct(1)=700, distinct(2)=700]
+ │    ├── distinct(1)=700[0-{1}-700-{5}-700]
+ │    ├── distinct(2)=700[0-{1}-700-{5}-700]
+ │    └── stats: [rows=1000]
  └── filters [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: [/1 - /4]), fd=(1)==(2), (2)==(1)]
       ├── eq [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
       │    ├── variable: order_history.item_id [type=int, outer=(2)]
@@ -768,11 +833,15 @@ SELECT * FROM order_history WHERE item_id = order_id AND customer_id < 5 AND cus
 ----
 select
  ├── columns: order_id:1(int!null) item_id:2(int!null) customer_id:3(int!null) year:4(int)
- ├── stats: [rows=0.158730159, distinct(1)=0.158730159, distinct(2)=0.158730159]
+ ├── distinct(1)=0.158730159[0-{1}-700-{5}-700-{4}-700-{7}-0.158730159-{8}-0.158730159]
+ ├── distinct(2)=0.158730159[0-{1}-700-{5}-700-{4}-700-{7}-0.158730159-{8}-0.158730159]
+ ├── stats: [rows=0.158730159]
  ├── fd: (1)==(2), (2)==(1)
  ├── scan order_history
  │    ├── columns: order_id:1(int) item_id:2(int) customer_id:3(int) year:4(int)
- │    └── stats: [rows=1000, distinct(1)=700, distinct(2)=700]
+ │    ├── distinct(1)=700[0-{1}-700-{5}-700]
+ │    ├── distinct(2)=700[0-{1}-700-{5}-700]
+ │    └── stats: [rows=1000]
  └── filters [type=bool, outer=(1-3), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /3: [/1 - /4]), fd=(1)==(2), (2)==(1)]
       ├── eq [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
       │    ├── variable: order_history.item_id [type=int, outer=(2)]
@@ -790,11 +859,15 @@ SELECT * FROM order_history WHERE item_id = order_id AND customer_id % 2 = 0
 ----
 select
  ├── columns: order_id:1(int!null) item_id:2(int!null) customer_id:3(int) year:4(int)
- ├── stats: [rows=0.476190476, distinct(1)=0.476190476, distinct(2)=0.476190476]
+ ├── distinct(1)=0.476190476[0-{1}-700-{5}-700-{4}-700-{7}-0.476190476-{8}-0.476190476]
+ ├── distinct(2)=0.476190476[0-{1}-700-{5}-700-{4}-700-{7}-0.476190476-{8}-0.476190476]
+ ├── stats: [rows=0.476190476]
  ├── fd: (1)==(2), (2)==(1)
  ├── scan order_history
  │    ├── columns: order_id:1(int) item_id:2(int) customer_id:3(int) year:4(int)
- │    └── stats: [rows=1000, distinct(1)=700, distinct(2)=700]
+ │    ├── distinct(1)=700[0-{1}-700-{5}-700]
+ │    ├── distinct(2)=700[0-{1}-700-{5}-700]
+ │    └── stats: [rows=1000]
  └── filters [type=bool, outer=(1-3), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
       ├── eq [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
       │    ├── variable: order_history.item_id [type=int, outer=(2)]


### PR DESCRIPTION
This demonstrates stats tracking. 

Notes: 
- Some transformations don't change, how do we skip these? 
     - As the stats code evolves, transformations may become more expensive
- stats evolution is printed as  `before-{transform}-after`
- Transforms are currently hacked with this const array: 
```
const (
	DistinctUpdateUnannotated DistinctUpdateCtx = iota
	DistinctUpdateDontTrack
	DistinctUpdateFromTableStats
	DistinctUpdateFromConstraints
	DistinctUpdateFromEquivalency
	DistinctUpdateFromSelectivityRadu
	DistinctUpdateZeroSelectivity
	DistinctUpdateFromSelectivity
	DistinctCountMinRowCount
	DistinctUpdateLaxRowCount
	DistinctUpdateBooleanType
)
```

TODO: 
- benchmark to ensure there is no significant overhead incurred
- use bench/bench_test.go 
- make sure strings only allocated 
- set tracking as a debug flag (make sure adding this is lightweight) 
  - formatting flag to hide verbose stats
  - make sure no allocations happen
- row count tracking
- reorganize code to be able to print out profiling information per transformation
  - "costing" each transformation
- pretty print transforms
