### PR TITLE
server: don't drain when decommissioning

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1539,44 +1539,15 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 
 	log.Event(ctx, "accepting connections")
 
-	// Begin the node liveness heartbeat. Add a callback which
-	// 1. records the local store "last up" timestamp for every store whenever the
-	//    liveness record is updated.
-	// 2. sets Draining if Decommissioning is set in the liveness record
-	decommissionSem := make(chan struct{}, 1)
+	// Begin the node liveness heartbeat. Add a callback which records the local
+	// store "last up" timestamp for every store whenever the liveness record is
+	// updated.
 	s.nodeLiveness.StartHeartbeat(ctx, s.stopper, func(ctx context.Context) {
 		now := s.clock.Now()
 		if err := s.node.stores.VisitStores(func(s *storage.Store) error {
 			return s.WriteLastUpTimestamp(ctx, now)
 		}); err != nil {
 			log.Warning(ctx, errors.Wrap(err, "writing last up timestamp"))
-		}
-
-		if liveness, err := s.nodeLiveness.Self(); err != nil && err != storage.ErrNoLivenessRecord {
-			log.Warning(ctx, errors.Wrap(err, "retrieving own liveness record"))
-		} else if liveness != nil && liveness.Decommissioning && !liveness.Draining {
-			select {
-			case decommissionSem <- struct{}{}:
-				s.stopper.RunWorker(ctx, func(context.Context) {
-					// Don't use the passed in ctx because there is an associated
-					// timeout meant to be used when heartbeating. Instead, tie the
-					// context to the stopper so that the drain attempt stops without
-					// blocking if the server starts shutting down.
-					ctx, done := s.stopper.WithCancelOnQuiesce(context.Background())
-					defer done()
-
-					defer func() {
-						<-decommissionSem
-					}()
-
-					if _, err := s.Drain(ctx, GracefulDrainModes); err != nil {
-						log.Warningf(ctx, "failed to set Draining when Decommissioning: %s", err)
-					}
-				})
-			default:
-				// Already have an active goroutine trying to drain; don't add a
-				// second one.
-			}
 		}
 	})
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -604,57 +604,6 @@ func TestListenerFileCreation(t *testing.T) {
 	}
 }
 
-func TestHeartbeatCallbackForDecommissioning(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(context.TODO())
-	ts := s.(*TestServer)
-	nodeLiveness := ts.nodeLiveness
-
-	for {
-		// Morally this loop only runs once. However, early in the boot
-		// sequence, the own liveness record may not yet exist. This
-		// has not been observed in this test, but was the root cause
-		// of #16656, so consider this part of its documentation.
-		liveness, err := nodeLiveness.Self()
-		if err != nil {
-			if errors.Cause(err) == storage.ErrNoLivenessRecord {
-				continue
-			}
-			t.Fatal(err)
-		}
-		if liveness.Decommissioning {
-			t.Fatal("Decommissioning set already")
-		}
-		if liveness.Draining {
-			t.Fatal("Draining set already")
-		}
-		break
-	}
-	ctx := context.Background()
-	log.Infof(ctx, "test starting decomissioning")
-	var err error
-	if _, err = nodeLiveness.SetDecommissioning(
-		ctx, ts.nodeIDContainer.Get(), true, /* decomission */
-	); err != nil {
-		t.Fatal(err)
-	}
-
-	// Node should realize it is decommissioning after next heartbeat update.
-	testutils.SucceedsSoon(t, func() error {
-		nodeLiveness.PauseHeartbeat(false /* pause */) // trigger immediate heartbeat
-		if liveness, err := nodeLiveness.Self(); err != nil {
-			// Record must exist at this point, so any error is fatal now.
-			t.Fatal(err)
-		} else if !liveness.Decommissioning {
-			return errors.Errorf("not decommissioning")
-		} else if !liveness.Draining {
-			return errors.Errorf("not draining")
-		}
-		return nil
-	})
-}
-
 func TestClusterIDMismatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 


### PR DESCRIPTION
Prior to this commit, a server which enters decommissioning would
automatically drain. This wasn't a great idea since it meant that
pointing the decommissioning command at a set of nodes required
for the cluster to work would brick that cluster, and would be
difficult to recover from (since the draining state is picked
up by the nodes when they start).

Instead, decouple draining from decommissioning. Decommissioning simply
tells the allocator to move data off that node; when the node gets shut
down cleanly (the operator's responsiblity), it will drain.

The resulting behavior when trying to decommission a too-large set of
nodes is now that the decommission command will simply not finish.
For example, starting a three node cluster and decommissioning all
nodes will simply hang (though the nodes will be marked as
decommissioning). Add three more nodes to the cluster and replicas
will move over to the newly added nodes, and the decommissioning
command will finish.

As a bonus, recommissioning a node now doesn't require the target
node to restart.

As a second bonus, the decommissioning acceptance test now takes
around 60% of the previous time (~45s down from 70+).

One remaining caveat is that users may forget that they attempted
to decommission nodes. We need to check that we prominently alert
in the UI when nodes are decommissioning. This isn't a new problem.

Fixes #27444.
Fixes #27025.

Release note (bug fix): decommissioning multiple nodes is now possible
without posing a risk to cluster health. Recommissioning a node does
no longer require a restart of the target nodes to take effect.