### PR TITLE
libroach: ensure encryption flags are passed if previously used.

### DIFF
--- a/c-deps/libroach/file_registry.h
+++ b/c-deps/libroach/file_registry.h
@@ -55,6 +55,7 @@ class FileRegistry {
 
   // Load the file registry. Errors on file reading/parsing issues.
   // OK if the file does not exist or is empty.
+  // This does **not** create a file registry.
   rocksdb::Status Load();
 
   // Returns a hash-set of all used env types.

--- a/pkg/cli/interactive_tests/test_encryption.tcl
+++ b/pkg/cli/interactive_tests/test_encryption.tcl
@@ -1,0 +1,90 @@
+#! /usr/bin/env expect -f
+#
+source [file join [file dirname $argv0] common.tcl]
+
+set storedir "encryption_store"
+set keydir "$storedir/keys"
+
+spawn /bin/bash
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+proc file_has_size {filepath size} {
+  if {! [file exist $filepath]} {
+    report "MISSING EXPECTED FILE: $filepath"
+    exit 1
+  }
+  set fsize [file size $filepath]
+  if { $fsize != $size } {
+		report "WRONG FILE SIZE FOR: $filepath. EXPECTED $size, GOT $fsize"
+		exit 1
+	}
+}
+
+start_test "Generate encryption keys."
+send "mkdir -p $keydir\n"
+send "$argv gen encryption-key -s 128 $keydir/aes-128.key\r"
+eexpect "successfully created AES-128 key: $keydir/aes-128.key"
+send "$argv gen encryption-key -s 192 $keydir/aes-192.key\r"
+eexpect "successfully created AES-192 key: $keydir/aes-192.key"
+send "$argv gen encryption-key -s 256 $keydir/aes-256.key\r"
+eexpect "successfully created AES-256 key: $keydir/aes-256.key"
+file_has_size "$keydir/aes-128.key" "48"
+file_has_size "$keydir/aes-192.key" "56"
+file_has_size "$keydir/aes-256.key" "64"
+end_test
+
+start_test "Start normal node."
+send "$argv start --insecure --store=$storedir\r"
+eexpect "node starting"
+interrupt
+eexpect "shutdown completed"
+send "$argv debug encryption-status $storedir\r"
+eexpect ""
+end_test
+
+start_test "Restart with plaintext."
+send "$argv start --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=plain,old-key=plain\r"
+eexpect "node starting"
+interrupt
+eexpect "shutdown completed"
+send "$argv debug encryption-status $storedir --enterprise-encryption=path=$storedir,key=plain,old-key=plain\r"
+eexpect "    \"Active\": true,\r\n    \"Type\": \"Plaintext\","
+# Try starting without the encryption flag.
+send "$argv start --insecure --store=$storedir\r"
+eexpect "encryption was used on this store before, but no encryption flags specified."
+end_test
+
+start_test "Restart with AES-128."
+send "$argv start --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-128.key,old-key=plain\r"
+eexpect "node starting"
+interrupt
+eexpect "shutdown completed"
+send "$argv debug encryption-status $storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-128.key,old-key=plain\r"
+eexpect "    \"Active\": true,\r\n    \"Type\": \"AES128_CTR\","
+# Try starting without the encryption flag.
+send "$argv start --insecure --store=$storedir\r"
+eexpect "encryption was used on this store before, but no encryption flags specified."
+# Try with the wrong key.
+send "$argv start --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-192.key,old-key=plain\r"
+eexpect "key_manager does not have a key with ID"
+end_test
+
+start_test "Restart with AES-256."
+send "$argv start --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-256.key,old-key=$keydir/aes-128.key\r"
+eexpect "node starting"
+interrupt
+eexpect "shutdown completed"
+send "$argv debug encryption-status $storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-256.key,old-key=plain\r"
+eexpect "    \"Active\": true,\r\n    \"Type\": \"AES256_CTR\","
+# Startup again, but don't specify the old key, it's no longer in use.
+send "$argv start --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-256.key,old-key=plain\r"
+eexpect "node starting"
+interrupt
+# Try starting without the encryption flag.
+send "$argv start --insecure --store=$storedir\r"
+eexpect "encryption was used on this store before, but no encryption flags specified."
+# Try with the wrong key.
+send "$argv start --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-192.key,old-key=plain\r"
+eexpect "key_manager does not have a key with ID"
+end_test


### PR DESCRIPTION
Add some safeguards around the encryption flag.
When we have a `COCKROACH_REGISTRY` file, we absolutely must keep using
it to keep track of all files.

It gets created the first time a file is created when using the
file_registry which currently only happens when
`--enterprise-encryption` is specified.

This means that if we have a registry file, we MUST have encryption
options (and be using a CCL build).

Also add a simple interactive test to check encryption transition and
handling of some bad args (wrong keys, no encryption flag)

Release note: None