### PR TITLE
opt: compute null rejections with scalar group by

### DIFF
--- a/pkg/sql/opt/norm/reject_nulls.go
+++ b/pkg/sql/opt/norm/reject_nulls.go
@@ -93,7 +93,7 @@ func DeriveRejectNullCols(ev memo.ExprView) opt.ColSet {
 		// Request null-rejection on all output columns.
 		relational.Rule.RejectNullCols = relational.OutputCols
 
-	case opt.GroupByOp, opt.DistinctOnOp:
+	case opt.GroupByOp, opt.ScalarGroupByOp:
 		relational.Rule.RejectNullCols = deriveGroupByRejectNullCols(ev)
 	}
 

--- a/pkg/sql/opt/norm/rules/reject_nulls.opt
+++ b/pkg/sql/opt/norm/rules/reject_nulls.opt
@@ -117,7 +117,7 @@
 # an InnerJoin operator.
 #
 # This rule is not useful for DistinctOn: it can only fire if there are no
-# FIrstAgg aggregates, but in that case the filter would have gotten pushed
+# FirstAgg aggregates, but in that case the filter would have gotten pushed
 # through DistinctOn.
 #
 # This rule is marked as low priority so that it runs after Select filter
@@ -125,7 +125,7 @@
 # preferable to synthesizing a new "col IS NOT NULL" filter.
 [RejectNullsGroupBy, Normalize, LowPriority]
 (Select
-    $input:(GroupBy
+    $input:(GroupBy | ScalarGroupBy
         $innerInput:*
         $aggregations:*
         $def:*

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -267,6 +267,37 @@ project
       └── filters [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
            └── column7 = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight)]
 
+# Single max aggregate function without grouping columns.
+opt
+SELECT max(x)
+FROM (SELECT k FROM a)
+LEFT JOIN (SELECT x FROM xy)
+ON True
+HAVING max(x)=1
+----
+select
+ ├── columns: max:7(int!null)
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7)
+ ├── scalar-group-by
+ │    ├── columns: column7:7(int)
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(7)
+ │    ├── inner-join
+ │    │    ├── columns: x:5(int!null)
+ │    │    ├── scan a
+ │    │    ├── scan xy
+ │    │    │    ├── columns: x:5(int!null)
+ │    │    │    └── key: (5)
+ │    │    └── true [type=bool]
+ │    └── aggregations [outer=(5)]
+ │         └── max [type=int, outer=(5)]
+ │              └── variable: x [type=int, outer=(5)]
+ └── filters [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+      └── column7 = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight)]
+
 # Multiple aggregate functions on same column.
 opt
 SELECT min(x), max(x)


### PR DESCRIPTION
Previously this was only checking GroupBy, but ScalarGroupBy can perform
the same null rejection. We also had DistinctOn in the switch here,
but null rejection for DistinctOn was removed in an earlier PR for
reasons described in the comment above the rule.

Closes #24453.

Release note: None