### PR TITLE
rsg: disallow REVOKE and GRANT

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -149,6 +149,9 @@ func TestRandomSyntaxGeneration(t *testing.T) {
 		if strings.Contains(s, "READ ONLY") || strings.Contains(s, "read_only") {
 			return errors.New("READ ONLY settings are unsupported")
 		}
+		if strings.Contains(s, "REVOKE") || strings.Contains(s, "GRANT") {
+			return errors.New("REVOKE and GRANT are unsupported")
+		}
 		// Recreate the database on every run in case it was dropped or renamed in
 		// a previous run. Should always succeed.
 		if err := db.exec(ctx, `CREATE DATABASE IF NOT EXISTS ident`); err != nil {


### PR DESCRIPTION
These timeout easily probably because they hit a bunch of descriptors
and are forcing each other to retry. Not worth dealing with now.

Release note: None