### PR TITLE
sql: periodically refresh table leases

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -671,6 +671,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	s.leaseMgr.SetExecCfg(&execCfg)
 	s.leaseMgr.RefreshLeases(s.stopper, s.db, s.gossip)
+	s.leaseMgr.PeriodicallyRefreshSomeLeases()
 
 	s.node.InitLogger(&execCfg)
 


### PR DESCRIPTION
This change periodically refreshes some of the table leases.
The current limit is 50 tables and can be configured using
sql.tablecache.lease.refresh_limit

This change will eventually be replaced by epoch based
table leases

related to #23510

Release note (sql change): Fix problem with needing to run
a periodic sql query on the outside to get good initial
latency on a dormant cluster.