### PR TITLE
sql: propagate errors directly through wrapped plans

### DIFF
--- a/pkg/sql/row_source_to_plan_node.go
+++ b/pkg/sql/row_source_to_plan_node.go
@@ -68,12 +68,12 @@ func (r *rowSourceToPlanNode) Next(params runParams) (bool, error) {
 		r.row, p = r.source.Next()
 
 		if p != nil {
+			if p.Err != nil {
+				return false, p.Err
+			}
 			if r.forwarder != nil {
 				r.forwarder.forwardMetadata(p)
 				continue
-			}
-			if p.Err != nil {
-				return false, p.Err
 			}
 			if p.TraceData != nil {
 				// We drop trace metadata since we have no reasonable way to propagate


### PR DESCRIPTION
Previously, errors created by the bottom part of a partially wrapped
planNode tree would be bubbled up through metadata, even though
planNodes can do the bubbling up of errors directly via their Next
method.

For an unknown (as of yet) reason, these errors don't get propagated
properly via metadata if they occur during the Start method of
rowSourceToPlanNode.

Correct this problem by returning errors directly through the wrapped
planNode tree, not via metadata.

Release note: None