### PR TITLE
sql: clean up planNode close; fix EXPLAIN ANALYZE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -1,0 +1,37 @@
+# LogicTest: local local-opt local-parallel-stmts fakedist fakedist-opt fakedist-metadata
+
+# Regression tests for weird explain analyze cases.
+
+statement ok
+EXPLAIN ANALYZE (DISTSQL) CREATE TABLE a (a INT PRIMARY KEY)
+
+statement ok
+EXPLAIN ANALYZE (DISTSQL) CREATE INDEX ON a(a)
+
+statement ok
+EXPLAIN ANALYZE (DISTSQL) INSERT INTO a VALUES (1)
+
+# Make sure failures are okay.
+statement error duplicate
+EXPLAIN ANALYZE (DISTSQL) INSERT INTO a VALUES (1)
+
+statement ok
+EXPLAIN ANALYZE (DISTSQL) INSERT INTO a SELECT a+1 FROM a
+
+statement ok
+EXPLAIN ANALYZE (DISTSQL) UPDATE a SET a = a*3
+
+statement ok
+EXPLAIN ANALYZE (DISTSQL) UPDATE a SET a = a*3 RETURNING a
+
+statement ok
+EXPLAIN ANALYZE (DISTSQL) UPSERT INTO a VALUES(10)
+
+statement ok
+EXPLAIN ANALYZE (DISTSQL) UPSERT INTO a VALUES(11) RETURNING NOTHING
+
+statement ok
+EXPLAIN ANALYZE (DISTSQL) DELETE FROM a
+
+statement ok
+EXPLAIN ANALYZE (DISTSQL) DROP TABLE a

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -174,7 +174,11 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 			p.applyLimit(n.sourcePlan, numRows, soft)
 		}
 	case *explainDistSQLNode:
-		p.setUnlimited(n.plan)
+		// EXPLAIN ANALYZE is special: it handles its own limit propagation, since
+		// it fully executes during startExec.
+		if !n.analyze {
+			p.setUnlimited(n.plan)
+		}
 	case *showTraceReplicaNode:
 		p.setUnlimited(n.plan)
 	case *explainPlanNode:


### PR DESCRIPTION
EXPLAIN ANALYZE had a bug that caused double closes of planNode trees
when those planNode trees had a startExec or Next method that could
cause the nodes to be closed themselves, like the mutation statements.

Release note: None