### PR TITLE
changefeedccl: use sarama's Close instead of AsyncClose

### DIFF
--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -28,11 +28,12 @@ type asyncProducerMock struct {
 func (p asyncProducerMock) Input() chan<- *sarama.ProducerMessage     { return p.inputCh }
 func (p asyncProducerMock) Successes() <-chan *sarama.ProducerMessage { return p.successesCh }
 func (p asyncProducerMock) Errors() <-chan *sarama.ProducerError      { return p.errorsCh }
-func (p asyncProducerMock) Close() error                              { panic(`unimplemented`) }
-func (p asyncProducerMock) AsyncClose() {
+func (p asyncProducerMock) AsyncClose()                               { panic(`unimplemented`) }
+func (p asyncProducerMock) Close() error {
 	close(p.inputCh)
 	close(p.successesCh)
 	close(p.errorsCh)
+	return nil
 }
 
 func TestKafkaSink(t *testing.T) {


### PR DESCRIPTION
I thought AsyncClose and manually draining the successes and errors
channels was preferred, but I can't seem to find where I got this
impression from (and the sarama implementation of Close does exactly
this). Bonus: this fixes our `(kafkaSink).Close` hang (though I can't
figure out how to write a unit test for it).

Closes #27849

Release note: None