### PR TITLE
opt: add colstats flag to opttester

### DIFF
--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -234,6 +234,14 @@ func (ev ExprView) FormatString(flags ExprFmtFlags) string {
 	return tp.String()
 }
 
+// RequestColStat causes a column statistic to be calculated on the expression.
+// This is used for testing.
+func (ev ExprView) RequestColStat(evalCtx *tree.EvalContext, cols opt.ColSet) {
+	var sb statisticsBuilder
+	sb.init(evalCtx, &keyBuffer{})
+	sb.colStat(cols, ev)
+}
+
 // HasOnlyConstChildren returns true if all children of ev are constant values
 // (tuples of constant values are considered constant values).
 func HasOnlyConstChildren(ev ExprView) bool {
@@ -254,7 +262,3 @@ func HasOnlyConstChildren(ev ExprView) bool {
 func MatchesTupleOfConstants(ev ExprView) bool {
 	return ev.Operator() == opt.TupleOp && HasOnlyConstChildren(ev)
 }
-
-// ExprFmtInterceptor is a callback that can be set to a custom formatting
-// function. If the function returns true, the normal formatting code is bypassed.
-var ExprFmtInterceptor func(f *ExprFmtCtx, tp treeprinter.Node, ev ExprView) bool

--- a/pkg/sql/opt/memo/expr_view_format.go
+++ b/pkg/sql/opt/memo/expr_view_format.go
@@ -25,6 +25,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
 
+// ExprFmtInterceptor is a callback that can be set to a custom formatting
+// function. If the function returns true, the normal formatting code is bypassed.
+var ExprFmtInterceptor func(f *ExprFmtCtx, tp treeprinter.Node, ev ExprView) bool
+
 // ExprFmtFlags controls which properties of the expression are shown in
 // formatted output.
 type ExprFmtFlags int

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -80,6 +80,23 @@ inner-join
  │    └── stats: [rows=10000]
  └── true [type=bool]
 
+norm colstat=1 colstat=2 colstat=3 colstat=4 colstat=5 colstat=6 colstat=(2,5,6)
+SELECT * FROM a JOIN b ON true
+----
+inner-join
+ ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) x:5(int) z:6(int!null)
+ ├── stats: [rows=50000000, distinct(1)=5000, distinct(2)=400, distinct(3)=3500, distinct(4)=3500, distinct(5)=500, distinct(6)=100, distinct(2,5,6)=4000000]
+ ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ ├── scan a
+ │    ├── columns: a.x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+ │    ├── stats: [rows=5000, distinct(1)=5000, distinct(2)=400, distinct(3)=3500, distinct(4)=3500]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ ├── scan b
+ │    ├── columns: b.x:5(int) z:6(int!null)
+ │    └── stats: [rows=10000, distinct(5)=500, distinct(6)=100, distinct(5,6)=10000]
+ └── true [type=bool]
+
 norm
 SELECT * FROM a JOIN b ON false
 ----


### PR DESCRIPTION
Adding a flag that triggers the calculation of a column statistic for
the root expression. This is useful for testing statistics that
otherwise aren't calculated; in particular, we have code for
multi-column stats but they are not used yet.

Release note: None