### PR TITLE
build: clear go build cache in make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1338,7 +1338,7 @@ unsafe-clean-c-deps:
 clean: ## Remove build artifacts.
 clean: clean-c-deps
 	rm -rf bin/.go_protobuf_sources bin/.gw_protobuf_sources bin/.cpp_protobuf_sources build/defs.mk*
-	$(GO) clean $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -i github.com/cockroachdb/...
+	$(GO) clean $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -i -cache github.com/cockroachdb/cockroach...
 	$(FIND_RELEVANT) -type f \( -name 'zcgo_flags*.go' -o -name '*.test' \) -exec rm {} +
 	for f in cockroach*; do if [ -f "$$f" ]; then rm "$$f"; fi; done
 	rm -rf artifacts bin $(ARCHIVE) pkg/sql/parser/gen


### PR DESCRIPTION
This commit includes two fixes to `make clean`. It's possible
that either one of them is actually removing intended behavior.
- `make clean` now cleans the go build cache. This is important
  when switching back and forth between different compiler flags.
- `make clean` now only cleans the `cockroachdb/cockroach` repo,
  not the entire `github.com/cockroachdb` organization. I think
  this is why my `roachprod` and `loadgen` binaries would occasionally
  go missing. It's possible that this was intentional but only
  important back in the days before we vendored deps.

Release note: None