### PR TITLE
teamcity: increase stress test timeout to 40m

### DIFF
--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -22,7 +22,7 @@ env=(
 build/builder.sh env "${env[@]}" bash <<'EOF'
 set -euxo pipefail
 go install ./pkg/cmd/github-post
-make stress PKG="$PKG" TESTTIMEOUT=30m GOFLAGS="$GOFLAGS" TAGS="$TAGS" STRESSFLAGS='-maxruns 100 -maxfails 1 -stderr' \
+make stress PKG="$PKG" TESTTIMEOUT=40m GOFLAGS="$GOFLAGS" TAGS="$TAGS" STRESSFLAGS='-maxruns 100 -maxfails 1 -stderr' \
   | tee artifacts/stress.log \
   || { go tool test2json < artifacts/stress.log | github-post; exit 1; }
 EOF


### PR DESCRIPTION
increase this temporarily while we work on reducing the
run time of tests. There is no point to tests failing
because of a timeout.

Release note: None