### PR TITLE
sql: mark expired schema change lease as a temporary error

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -132,7 +132,8 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	}
 
 	// Extending an old lease fails.
-	if err := changer.ExtendLease(ctx, &oldLease); !testutils.IsError(err, "table: .* has lease") {
+	if err := changer.ExtendLease(ctx, &oldLease); !testutils.IsError(
+		err, "the schema change lease has expired") {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
An expired schema change lease is no reason to rollback
a schema change. The schema change mechanism uses transactions
and doesn't need a guarantee that it only run by a single lease
holder. An expired lease should simply mean: stop and allow the
lease holder to proceed.

related to #27273
related to #27958
related to #27760

Release note: None