### PR TITLE
opt: some stats code refactoring, cleanup, fixes

### DIFF
--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -238,7 +238,7 @@ func (ev ExprView) FormatString(flags ExprFmtFlags) string {
 // This is used for testing.
 func (ev ExprView) RequestColStat(evalCtx *tree.EvalContext, cols opt.ColSet) {
 	var sb statisticsBuilder
-	sb.init(evalCtx, &keyBuffer{})
+	sb.init(evalCtx, ev.Metadata(), &keyBuffer{})
 	sb.colStat(cols, ev)
 }
 

--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -234,6 +234,14 @@ func (ev ExprView) FormatString(flags ExprFmtFlags) string {
 	return tp.String()
 }
 
+// RequestColStat causes a column statistic to be calculated on the expression.
+// This is used for testing.
+func (ev ExprView) RequestColStat(evalCtx *tree.EvalContext, cols opt.ColSet) {
+	var sb statisticsBuilder
+	sb.init(evalCtx, &keyBuffer{})
+	sb.colStat(cols, ev)
+}
+
 // HasOnlyConstChildren returns true if all children of ev are constant values
 // (tuples of constant values are considered constant values).
 func HasOnlyConstChildren(ev ExprView) bool {
@@ -254,7 +262,3 @@ func HasOnlyConstChildren(ev ExprView) bool {
 func MatchesTupleOfConstants(ev ExprView) bool {
 	return ev.Operator() == opt.TupleOp && HasOnlyConstChildren(ev)
 }
-
-// ExprFmtInterceptor is a callback that can be set to a custom formatting
-// function. If the function returns true, the normal formatting code is bypassed.
-var ExprFmtInterceptor func(f *ExprFmtCtx, tp treeprinter.Node, ev ExprView) bool

--- a/pkg/sql/opt/memo/expr_view_format.go
+++ b/pkg/sql/opt/memo/expr_view_format.go
@@ -25,6 +25,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
 
+// ExprFmtInterceptor is a callback that can be set to a custom formatting
+// function. If the function returns true, the normal formatting code is bypassed.
+var ExprFmtInterceptor func(f *ExprFmtCtx, tp treeprinter.Node, ev ExprView) bool
+
 // ExprFmtFlags controls which properties of the expression are shown in
 // formatted output.
 type ExprFmtFlags int

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -153,7 +153,7 @@ func (b *logicalPropsBuilder) buildScanProps(ev ExprView) props.Logical {
 	// Initialize key FD's from the table schema, including constant columns from
 	// the constraint, minus any columns that are not projected by the Scan
 	// operator.
-	relational.FuncDeps.CopyFrom(b.makeTableFuncDep(md, def.Table))
+	relational.FuncDeps.CopyFrom(makeTableFuncDep(md, def.Table))
 	if def.Constraint != nil {
 		relational.FuncDeps.AddConstants(def.Constraint.ExtractConstCols(b.evalCtx))
 	}
@@ -557,7 +557,7 @@ func (b *logicalPropsBuilder) buildIndexJoinProps(ev ExprView) props.Logical {
 	// -----------------------
 	// Start with the input FD set, and join that with the table's FD.
 	relational.FuncDeps.CopyFrom(&inputProps.FuncDeps)
-	relational.FuncDeps.AddFrom(b.makeTableFuncDep(md, def.Table))
+	relational.FuncDeps.AddFrom(makeTableFuncDep(md, def.Table))
 	relational.FuncDeps.MakeNotNull(relational.NotNullCols)
 	relational.FuncDeps.ProjectCols(relational.OutputCols)
 
@@ -1129,9 +1129,7 @@ func (b *logicalPropsBuilder) buildScalarProps(ev ExprView) props.Logical {
 // given base table. The set is derived lazily and is cached in the metadata,
 // since it may be accessed multiple times during query optimization. For more
 // details, see Relational.FuncDepSet.
-func (b *logicalPropsBuilder) makeTableFuncDep(
-	md *opt.Metadata, tabID opt.TableID,
-) *props.FuncDepSet {
+func makeTableFuncDep(md *opt.Metadata, tabID opt.TableID) *props.FuncDepSet {
 	fd, ok := md.TableAnnotation(tabID, fdAnnID).(*props.FuncDepSet)
 	if ok {
 		// Already made.

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -174,7 +174,7 @@ func (b *logicalPropsBuilder) buildScanProps(ev ExprView) props.Logical {
 
 	// Statistics
 	// ----------
-	b.sb.init(b.evalCtx, &b.kb)
+	b.sb.init(b.evalCtx, md, &b.kb)
 	b.sb.buildScan(ev, relational)
 
 	return logical
@@ -210,7 +210,7 @@ func (b *logicalPropsBuilder) buildVirtualScanProps(ev ExprView) props.Logical {
 
 	// Statistics
 	// ----------
-	b.sb.init(b.evalCtx, &b.kb)
+	b.sb.init(b.evalCtx, ev.Metadata(), &b.kb)
 	b.sb.buildVirtualScan(ev, relational)
 
 	return logical
@@ -272,7 +272,7 @@ func (b *logicalPropsBuilder) buildSelectProps(ev ExprView) props.Logical {
 
 	// Statistics
 	// ----------
-	b.sb.init(b.evalCtx, &b.kb)
+	b.sb.init(b.evalCtx, ev.Metadata(), &b.kb)
 	b.sb.buildSelect(ev, relational)
 
 	return logical
@@ -362,7 +362,7 @@ func (b *logicalPropsBuilder) buildProjectProps(ev ExprView) props.Logical {
 
 	// Statistics
 	// ----------
-	b.sb.init(b.evalCtx, &b.kb)
+	b.sb.init(b.evalCtx, ev.Metadata(), &b.kb)
 	b.sb.buildProject(ev, relational)
 
 	return logical
@@ -523,7 +523,7 @@ func (b *logicalPropsBuilder) buildJoinProps(ev ExprView) props.Logical {
 
 	// Statistics
 	// ----------
-	b.sb.init(b.evalCtx, &b.kb)
+	b.sb.init(b.evalCtx, ev.Metadata(), &b.kb)
 	b.sb.buildJoin(ev, relational)
 
 	return logical
@@ -568,7 +568,7 @@ func (b *logicalPropsBuilder) buildIndexJoinProps(ev ExprView) props.Logical {
 
 	// Statistics
 	// ----------
-	b.sb.init(b.evalCtx, &b.kb)
+	b.sb.init(b.evalCtx, md, &b.kb)
 	b.sb.buildIndexJoin(ev, relational)
 
 	return logical
@@ -631,7 +631,7 @@ func (b *logicalPropsBuilder) buildGroupByProps(ev ExprView) props.Logical {
 
 	// Statistics
 	// ----------
-	b.sb.init(b.evalCtx, &b.kb)
+	b.sb.init(b.evalCtx, ev.Metadata(), &b.kb)
 	b.sb.buildGroupBy(ev, relational)
 
 	return logical
@@ -689,7 +689,7 @@ func (b *logicalPropsBuilder) buildSetProps(ev ExprView) props.Logical {
 
 	// Statistics
 	// ----------
-	b.sb.init(b.evalCtx, &b.kb)
+	b.sb.init(b.evalCtx, ev.Metadata(), &b.kb)
 	b.sb.buildSetOp(ev, relational)
 
 	return logical
@@ -730,7 +730,7 @@ func (b *logicalPropsBuilder) buildValuesProps(ev ExprView) props.Logical {
 
 	// Statistics
 	// ----------
-	b.sb.init(b.evalCtx, &b.kb)
+	b.sb.init(b.evalCtx, ev.Metadata(), &b.kb)
 	b.sb.buildValues(ev, relational)
 
 	return logical
@@ -861,7 +861,7 @@ func (b *logicalPropsBuilder) buildLimitProps(ev ExprView) props.Logical {
 
 	// Statistics
 	// ----------
-	b.sb.init(b.evalCtx, &b.kb)
+	b.sb.init(b.evalCtx, ev.Metadata(), &b.kb)
 	b.sb.buildLimit(ev, relational)
 
 	return logical
@@ -916,7 +916,7 @@ func (b *logicalPropsBuilder) buildOffsetProps(ev ExprView) props.Logical {
 
 	// Statistics
 	// ----------
-	b.sb.init(b.evalCtx, &b.kb)
+	b.sb.init(b.evalCtx, ev.Metadata(), &b.kb)
 	b.sb.buildOffset(ev, relational)
 
 	return logical
@@ -955,7 +955,7 @@ func (b *logicalPropsBuilder) buildMax1RowProps(ev ExprView) props.Logical {
 
 	// Statistics
 	// ----------
-	b.sb.init(b.evalCtx, &b.kb)
+	b.sb.init(b.evalCtx, ev.Metadata(), &b.kb)
 	b.sb.buildMax1Row(ev, relational)
 
 	return logical
@@ -1004,7 +1004,7 @@ func (b *logicalPropsBuilder) buildRowNumberProps(ev ExprView) props.Logical {
 
 	// Statistics
 	// ----------
-	b.sb.init(b.evalCtx, &b.kb)
+	b.sb.init(b.evalCtx, ev.Metadata(), &b.kb)
 	b.sb.buildRowNumber(ev, relational)
 
 	return logical
@@ -1041,7 +1041,7 @@ func (b *logicalPropsBuilder) buildZipProps(ev ExprView) props.Logical {
 
 	// Statistics
 	// ----------
-	b.sb.init(b.evalCtx, &b.kb)
+	b.sb.init(b.evalCtx, ev.Metadata(), &b.kb)
 	b.sb.buildZip(ev, relational)
 
 	return logical

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -106,7 +106,7 @@ func TestGetStatsFromConstraint(t *testing.T) {
 		}
 
 		sb := &statisticsBuilder{}
-		sb.init(&evalCtx, &keyBuffer{})
+		sb.init(&evalCtx, mem.Metadata(), &keyBuffer{})
 
 		// Make the scan.
 		def := &ScanOpDef{Table: tabID, Cols: cols}

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -80,6 +80,23 @@ inner-join
  │    └── stats: [rows=10000]
  └── true [type=bool]
 
+norm colstat=1 colstat=2 colstat=3 colstat=4 colstat=5 colstat=6 colstat=(2,5,6)
+SELECT * FROM a JOIN b ON true
+----
+inner-join
+ ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) x:5(int) z:6(int!null)
+ ├── stats: [rows=50000000, distinct(1)=5000, distinct(2)=400, distinct(3)=3500, distinct(4)=3500, distinct(5)=500, distinct(6)=100, distinct(2,5,6)=4000000]
+ ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ ├── scan a
+ │    ├── columns: a.x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+ │    ├── stats: [rows=5000, distinct(1)=5000, distinct(2)=400, distinct(3)=3500, distinct(4)=3500]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ ├── scan b
+ │    ├── columns: b.x:5(int) z:6(int!null)
+ │    └── stats: [rows=10000, distinct(5)=500, distinct(6)=100, distinct(5,6)=10000]
+ └── true [type=bool]
+
 norm
 SELECT * FROM a JOIN b ON false
 ----


### PR DESCRIPTION
First commit is #28737.

#### opt: misc stats code cleanup

 - embed `*opt.Metadata` in `statisticsBuilder` to avoid having to
   pass `ev.Metadata()` around;

 - rename `colStatMetadata` to `colStatLeaf`; the "metadata" part is
   confusing, as the function itself has no relation to where the
   given Statistic is coming from;

 - change `ColSet.Len() == 0` checks with `Empty()` which is more
   efficient.

Release note: None

#### opt: clean up colStat path for scans

Currently we pass the parent's relProps to colStatFromChild which is
strange to begin with, and it is only used in the case of the scan,
for `relProps.FuncDeps`. This is not really correct - we are using the
scan's FDs (which reflect constraints/limit) to calculate a stat which
gets stored in the table statistics.

This change fixes this issue by using the table FDs and cleans up the
code somewhat. colStatScan now doesn't rely on colStatFromChild but on
a separate colStatTable function.

A subsequent commit will further clean up colStatFromChild.

Release note: None

#### opt: clean up colStatFromChild

Splitting up colStatsFromChild into two variants with very different
semantics:
 - `colStatsFromChild` is used when we want the stats from a specific
   child. This version no longer needs to implement a fake child for
   scans.

 - `colStatsFromInput` is used when we want stats for selectivity
   estimation. This is only used with a few operators (Scan, Select,
   Join), and it is handled on an operator-by-operator basis. This
   will allow clean handling of LookupJoin, where the right "input" is
   the table itself and not a child of the expression (similar to the
   Scan "input").

Also simplifying `copyColStatsFromChild` to receive the `Statistics`
directly instead of `relProps`.

Release note: None

