### PR TITLE
[wip] ui: add tooltip showing error for failed jobs

### DIFF
--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -71,12 +71,19 @@ const formatDuration = (d: moment.Duration) =>
     .join(":");
 
 class JobStatusCell extends React.Component<{ job: Job }, {}> {
-  is(...statuses: string[]) {
+  statusIsOneOf(...statuses: string[]) {
     return statuses.indexOf(this.props.job.status) !== -1;
   }
 
   renderProgress() {
-    if (this.is("succeeded", "failed", "canceled")) {
+    if (this.statusIsOneOf("failed")) {
+      return (
+        <ToolTipWrapper text={<pre>{this.props.job.error}</pre>}>
+          Failed
+        </ToolTipWrapper>
+      );
+    }
+    if (this.statusIsOneOf("succeeded", "canceled")) {
       return <div className="jobs-table__status">{this.props.job.status}</div>;
     }
     const percent = this.props.job.fraction_completed * 100;
@@ -90,16 +97,16 @@ class JobStatusCell extends React.Component<{ job: Job }, {}> {
     const started = TimestampToMoment(this.props.job.started);
     const finished = TimestampToMoment(this.props.job.finished);
     const modified = TimestampToMoment(this.props.job.modified);
-    if (this.is("pending", "paused")) {
+    if (this.statusIsOneOf("pending", "paused")) {
       return _.capitalize(this.props.job.status);
-    } else if (this.is("running")) {
+    } else if (this.statusIsOneOf("running")) {
       const fractionCompleted = this.props.job.fraction_completed;
       if (fractionCompleted > 0) {
         const duration = modified.diff(started);
         const remaining = duration / fractionCompleted - duration;
         return formatDuration(moment.duration(remaining)) + " remaining";
       }
-    } else if (this.is("succeeded")) {
+    } else if (this.statusIsOneOf("succeeded")) {
       return "Duration: " + formatDuration(moment.duration(finished.diff(started)));
     }
   }


### PR DESCRIPTION
Attempts to fix #20990: currently, there's no way to see the error message for failed jobs.

A tooltip is probably the easiest way to address this, if it can be styled properly. The CSS needs some work; it currently looks like this:
![image](https://user-images.githubusercontent.com/7341/44276855-d2896500-a216-11e8-8569-bfe7d49e335f.png)

Also, the content should be copy-pastable.

I'm going on vacation for a week; maybe @j-low you have bandwidth to take this over?

A job detail page may be a better solution in the long run, but I don't want the perfect to be the enemy of the good here… cc @josueeee 