### PR TITLE
sql: Avoid two allocations in the object resolution path

### DIFF
--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -154,6 +154,7 @@ type planner struct {
 	subqueryVisitor       subqueryVisitor
 	nameResolutionVisitor sqlbase.NameResolutionVisitor
 	srfExtractionVisitor  srfExtractionVisitor
+	tableName             tree.TableName
 
 	// Use a common datum allocator across all the plan nodes. This separates the
 	// plan lifetime from the lifetime of returned results allowing plan nodes to

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -202,9 +202,8 @@ func (p *planner) LookupObject(
 	ctx context.Context, dbName, scName, tbName string,
 ) (found bool, objMeta tree.NameResolutionResult, err error) {
 	sc := p.LogicalSchemaAccessor()
-	// TODO(knz): elide this allocation of TableName.
-	tn := tree.MakeTableNameWithSchema(tree.Name(dbName), tree.Name(scName), tree.Name(tbName))
-	objDesc, _, err := sc.GetObjectDesc(&tn, p.ObjectLookupFlags(ctx, false /*required*/))
+	p.tableName = tree.MakeTableNameWithSchema(tree.Name(dbName), tree.Name(scName), tree.Name(tbName))
+	objDesc, _, err := sc.GetObjectDesc(&p.tableName, p.ObjectLookupFlags(ctx, false /*required*/))
 	return objDesc != nil, objDesc, err
 }
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2641,7 +2641,7 @@ may increase either contention or retry errors, or both.`,
 				ctx := evalCtx.Ctx()
 				curDb := evalCtx.SessionData.Database
 				iter := evalCtx.SessionData.SearchPath.IterWithoutImplicitPGCatalog()
-				for scName, ok := iter(); ok; scName, ok = iter() {
+				for scName, ok := iter.Next(); ok; scName, ok = iter.Next() {
 					if found, _, err := evalCtx.Planner.LookupSchema(ctx, curDb, scName); found || err != nil {
 						if err != nil {
 							return nil, err
@@ -2676,13 +2676,13 @@ may increase either contention or retry errors, or both.`,
 				curDb := evalCtx.SessionData.Database
 				includePgCatalog := *(args[0].(*tree.DBool))
 				schemas := tree.NewDArray(types.String)
-				var iter func() (string, bool)
+				var iter sessiondata.SearchPathIter
 				if includePgCatalog {
 					iter = evalCtx.SessionData.SearchPath.Iter()
 				} else {
 					iter = evalCtx.SessionData.SearchPath.IterWithoutImplicitPGCatalog()
 				}
-				for scName, ok := iter(); ok; scName, ok = iter() {
+				for scName, ok := iter.Next(); ok; scName, ok = iter.Next() {
 					if found, _, err := evalCtx.Planner.LookupSchema(ctx, curDb, scName); found || err != nil {
 						if err != nil {
 							return nil, err

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -321,7 +321,7 @@ func (t *TableName) ResolveExisting(
 
 	// This is a naked table name. Use the search path.
 	iter := searchPath.Iter()
-	for next, ok := iter(); ok; next, ok = iter() {
+	for next, ok := iter.Next(); ok; next, ok = iter.Next() {
 		if found, objMeta, err := r.LookupObject(ctx, curDb, next, t.Table()); found || err != nil {
 			if err == nil {
 				t.CatalogName = Name(curDb)
@@ -367,7 +367,7 @@ func (t *TableName) ResolveTarget(
 	// This is a naked table name. Use the current schema = the first
 	// valid item in the search path.
 	iter := searchPath.IterWithoutImplicitPGCatalog()
-	for scName, ok := iter(); ok; scName, ok = iter() {
+	for scName, ok := iter.Next(); ok; scName, ok = iter.Next() {
 		if found, scMeta, err = r.LookupSchema(ctx, curDb, scName); found || err != nil {
 			if err == nil {
 				t.CatalogName = Name(curDb)
@@ -413,7 +413,7 @@ func (tp *TableNamePrefix) Resolve(
 	// This is a naked table name. Use the current schema = the first
 	// valid item in the search path.
 	iter := searchPath.IterWithoutImplicitPGCatalog()
-	for scName, ok := iter(); ok; scName, ok = iter() {
+	for scName, ok := iter.Next(); ok; scName, ok = iter.Next() {
 		if found, scMeta, err = r.LookupSchema(ctx, curDb, scName); found || err != nil {
 			if err == nil {
 				tp.CatalogName = Name(curDb)
@@ -477,7 +477,7 @@ func (n *UnresolvedName) ResolveFunction(
 			// The function wasn't qualified, so we must search for it via
 			// the search path first.
 			iter := searchPath.Iter()
-			for alt, ok := iter(); ok; alt, ok = iter() {
+			for alt, ok := iter.Next(); ok; alt, ok = iter.Next() {
 				fullName = alt + "." + function
 				if def, ok = FunDefs[fullName]; ok {
 					found = true

--- a/pkg/sql/sessiondata/search_path_test.go
+++ b/pkg/sql/sessiondata/search_path_test.go
@@ -37,7 +37,7 @@ func TestImpliedSearchPath(t *testing.T) {
 			searchPath := MakeSearchPath(tc.explicitSearchPath)
 			actualSearchPath := make([]string, 0)
 			iter := searchPath.Iter()
-			for p, ok := iter(); ok; p, ok = iter() {
+			for p, ok := iter.Next(); ok; p, ok = iter.Next() {
 				actualSearchPath = append(actualSearchPath, p)
 			}
 			if !reflect.DeepEqual(tc.expectedSearchPath, actualSearchPath) {
@@ -49,7 +49,7 @@ func TestImpliedSearchPath(t *testing.T) {
 			searchPath := MakeSearchPath(tc.explicitSearchPath)
 			actualSearchPath := make([]string, 0)
 			iter := searchPath.IterWithoutImplicitPGCatalog()
-			for p, ok := iter(); ok; p, ok = iter() {
+			for p, ok := iter.Next(); ok; p, ok = iter.Next() {
 				actualSearchPath = append(actualSearchPath, p)
 			}
 			if !reflect.DeepEqual(tc.expectedSearchPathWithoutImplicitPgCatalog, actualSearchPath) {


### PR DESCRIPTION
As part of optimizing very simple SELECT queries (like KV), I'm
looking for ways to avoid allocations. This PR changes the object
resolution code path to avoid two allocations:

1. Escaping of table name to heap when calling GetObjectDesc.
   The change is to add a "scratch" tableName field to the planner,
   so that a pointer to that can be passed to GetObjectDesc.
2. Use stack iterator instead of function closure for iterating
   over the search path. This avoids creating an object for
   iteration (i.e. the function was allocated on the heap).

Release note: None