### PR TITLE
storage: improve EndTransaction's AbortSpan declaration

### DIFF
--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -59,7 +59,13 @@ func declareKeysEndTransaction(
 	}
 	if header.Txn != nil {
 		header.Txn.AssertInitialized(context.TODO())
-		spans.Add(spanset.SpanReadWrite, roachpb.Span{Key: keys.AbortSpanKey(header.RangeID, header.Txn.ID)})
+		abortSpanAccess := spanset.SpanReadOnly
+		if !et.Commit && et.Poison {
+			abortSpanAccess = spanset.SpanReadWrite
+		}
+		spans.Add(abortSpanAccess, roachpb.Span{
+			Key: keys.AbortSpanKey(header.RangeID, header.Txn.ID),
+		})
 	}
 
 	// All transactions depend on the range descriptor because they need


### PR DESCRIPTION
Fixes #24285.

We no longer declare a write on the abort span key if the
EndTransaction is not trying to abort the transaction with
poison=true.

Release note: None