### PR TITLE
opt: fix bug in GenerateMergeJoins

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -743,45 +743,19 @@ render            ·              ·                (k)           ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
 ----
-render                    ·         ·                (k)           ·
- │                        render 0  k                ·             ·
- └── sort                 ·         ·                (k, k, v)     -v,+k
-      │                   order     -v,+k            ·             ·
-      └── render          ·         ·                (k, k, v)     ·
-           │              render 0  k                ·             ·
-           │              render 1  k                ·             ·
-           │              render 2  v                ·             ·
-           └── join       ·         ·                (k, v, k, v)  ·
-                │         type      inner            ·             ·
-                │         equality  (k, v) = (k, v)  ·             ·
-                ├── scan  ·         ·                (k, v)        ·
-                │         table     kv@primary       ·             ·
-                │         spans     ALL              ·             ·
-                └── scan  ·         ·                (k, v)        ·
-·                         table     kv@primary       ·             ·
-·                         spans     ALL              ·             ·
-
-# The underlying index can be forced manually, of course.
-query TTTTT
-EXPLAIN (VERBOSE) SELECT k FROM kv@foo a NATURAL JOIN kv@foo ORDER BY INDEX kv@foo
-----
-render                    ·         ·                (k)           ·
- │                        render 0  k                ·             ·
- └── sort                 ·         ·                (k, k, v)     -v,+k
-      │                   order     -v,+k            ·             ·
-      └── render          ·         ·                (k, k, v)     ·
-           │              render 0  k                ·             ·
-           │              render 1  k                ·             ·
-           │              render 2  v                ·             ·
-           └── join       ·         ·                (k, v, k, v)  ·
-                │         type      inner            ·             ·
-                │         equality  (k, v) = (k, v)  ·             ·
-                ├── scan  ·         ·                (k, v)        ·
-                │         table     kv@foo           ·             ·
-                │         spans     ALL              ·             ·
-                └── scan  ·         ·                (k, v)        ·
-·                         table     kv@foo           ·             ·
-·                         spans     ALL              ·             ·
+render          ·               ·                    (k)           ·
+ │              render 0        k                    ·             ·
+ └── join       ·               ·                    (k, v, k, v)  -v,+k
+      │         type            inner                ·             ·
+      │         equality        (v, k) = (v, k)      ·             ·
+      │         mergeJoinOrder  -"(v=v)",+"(k=k)"    ·             ·
+      │         pred            (k = k) AND (v = v)  ·             ·
+      ├── scan  ·               ·                    (k, v)        -v,+k
+      │         table           kv@foo               ·             ·
+      │         spans           ALL                  ·             ·
+      └── scan  ·               ·                    (k, v)        -v,+k
+·               table           kv@foo               ·             ·
+·               spans           ALL                  ·             ·
 
 statement ok
 CREATE TABLE xyz (x INT, y INT, z INT, INDEX(z,y))

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -485,7 +485,7 @@ func (c *CustomFuncs) ConstructMergeJoins(
 			// should augment it with the other columns (in arbitrary order) in the
 			// hope that we can get the full ordering cheaply using a "streaming"
 			// sort. This would not useful now since we don't support streaming sorts.
-			break
+			continue
 		}
 		def := memo.MergeOnDef{JoinType: originalOp}
 		def.LeftEq = make(opt.Ordering, n)


### PR DESCRIPTION
The intention was to skip orderings that don't cover all equality
columns but we were breaking out of the loop.

Release note: None