### PR TITLE
sql: always close planNode trees

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -756,6 +756,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		err = planner.makePlan(ctx, stmt)
 		enhanceErrWithCorrelation(err, isCorrelated)
 	}
+	defer planner.curPlan.close(ctx)
 
 	defer func() { planner.maybeLogStatement(ctx, "exec", res.RowsAffected(), res.Err()) }()
 
@@ -806,7 +807,6 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		ex.sessionTracing.TraceExecStart(ctx, "distributed")
 		err = ex.execWithDistSQLEngine(ctx, planner, stmt.AST.StatementType(), res, distributePlan)
 	} else {
-		defer planner.curPlan.close(ctx)
 		ex.sessionTracing.TraceExecStart(ctx, "local")
 		err = ex.execWithLocalEngine(ctx, planner, stmt.AST.StatementType(), res)
 	}

--- a/pkg/sql/distinct.go
+++ b/pkg/sql/distinct.go
@@ -229,7 +229,7 @@ func (n *distinctNode) startExec(params runParams) error {
 		return err
 	}
 
-	n.run = makeRowSourceToPlanNode(proc, nil /* forwarder */, planColumns(n))
+	n.run = makeRowSourceToPlanNode(proc, nil /* forwarder */, planColumns(n), nil /* originalPlanNode */)
 
 	n.run.source.Start(params.ctx)
 
@@ -247,11 +247,8 @@ func (n *distinctNode) Values() tree.Datums {
 func (n *distinctNode) Close(ctx context.Context) {
 	if n.run != nil {
 		n.run.Close(ctx)
-	} else {
-		// If we haven't gotten around to initializing n.run yet, then we still
-		// need to propagate the close message to our inputs - do so directly.
-		n.plan.Close(ctx)
 	}
+	n.plan.Close(ctx)
 }
 
 // projectChildPropsToOnExprs takes the physical props (e.g. ordering info,

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -480,9 +480,14 @@ type PlanningCtx struct {
 	NodeAddresses map[roachpb.NodeID]string
 
 	// isLocal is set to true if we're planning this query on a single node.
-	isLocal  bool
-	planner  *planner
-	stmtType tree.StatementType
+	isLocal bool
+	planner *planner
+	// ignoreClose, when set to true, will prevent the closing of the planner's
+	// current plan. The top-level query needs to close it, but everything else
+	// (like subqueries or EXPLAIN ANALYZE) should set this to true to avoid
+	// double closes of the planNode tree.
+	ignoreClose bool
+	stmtType    tree.StatementType
 	// planDepth is set to the current depth of the planNode tree. It's used to
 	// keep track of whether it's valid to run a root node in a special fast path
 	// mode.

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -63,6 +63,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 
 	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p.txn)
 	planCtx.isLocal = !shouldDistributeGivenRecAndMode(recommendation, params.SessionData().DistSQLMode)
+	planCtx.ignoreClose = true
 	planCtx.planner = params.p
 	planCtx.stmtType = n.stmtType
 	planCtx.validExtendedEvalCtx = true
@@ -154,10 +155,5 @@ func (n *explainDistSQLNode) Next(runParams) (bool, error) {
 
 func (n *explainDistSQLNode) Values() tree.Datums { return n.run.values }
 func (n *explainDistSQLNode) Close(ctx context.Context) {
-	// If we managed to execute and we were in ANALYZE mode, our child planNode
-	// tree will already have been closed - so don't do anything to avoid a double
-	// close of that tree.
-	if !n.run.executedStatement {
-		n.plan.Close(ctx)
-	}
+	n.plan.Close(ctx)
 }


### PR DESCRIPTION
The distsql merge introduced some confusing, incorrect contracts around
planNode tree closure. This commit restores order: planNode trees are
now unconditionally closed after a flow is finished, and when a flow is
closed it releases all of its resources that aren't managed by embedded
planNode trees if it has any.

Closes #28829.

Release note: None