### PR TITLE
ui: update copy on connection lost alert

### DIFF
--- a/pkg/ui/src/redux/alerts.spec.ts
+++ b/pkg/ui/src/redux/alerts.spec.ts
@@ -308,7 +308,7 @@ describe("alerts", function() {
         const alert = disconnectedAlertSelector(state());
         assert.isObject(alert);
         assert.equal(alert.level, AlertLevel.CRITICAL);
-        assert.equal(alert.title, "Connection to CockroachDB node lost.");
+        assert.equal(alert.title, "We're currently having some trouble fetching updated data. If this persists, it might be a good idea to check your network connection to the CockroachDB cluster.");
       });
 
       it("does not display if dismissed locally", function () {

--- a/pkg/ui/src/redux/alerts.ts
+++ b/pkg/ui/src/redux/alerts.ts
@@ -239,7 +239,7 @@ export const disconnectedAlertSelector = createSelector(
 
     return {
       level: AlertLevel.CRITICAL,
-      title: "Connection to CockroachDB node lost.",
+      title: "We're currently having some trouble fetching updated data. If this persists, it might be a good idea to check your network connection to the CockroachDB cluster.",
       dismiss: (dispatch) => {
         dispatch(disconnectedDismissedLocalSetting.set(moment()));
         return Promise.resolve();


### PR DESCRIPTION
Fixes #20510
Release note (admin ui change): Update the alert text on the web UI
connection lost alert banner.  This has been a longstanding source
of confusion for users, particularly since the alert is a bit too
pessimistic sometimes (see #20499).

Before: 
<img width="1229" alt="screen shot 2018-08-20 at 12 12 20 pm" src="https://user-images.githubusercontent.com/793969/44352426-4f644b00-a472-11e8-82c3-a5a8e191542c.png">


After:
<img width="1245" alt="screen shot 2018-08-20 at 12 08 35 pm" src="https://user-images.githubusercontent.com/793969/44352417-47a4a680-a472-11e8-8b85-289e53cd2386.png">
