### PR TITLE
opt,sql: do not allow special functions in ON clause

### DIFF
--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -96,6 +96,9 @@ func (p *planner) makeJoinPredicate(
 		}
 		switch t := cond.(type) {
 		case *tree.OnJoinCond:
+			// Do not allow special functions in the ON clause.
+			p.semaCtx.Properties.Require("ON", tree.RejectSpecial)
+
 			// Determine the on condition expression. Note that the predicate can't
 			// already have onCond set (we haven't passed any usingColumns).
 			pred.onCond, err = p.analyzeExpr(

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -1071,3 +1071,10 @@ FROM
 ----
 1     2
 NULL  NULL
+
+# Regression test for #28817. Do not allow special functions in ON clause.
+query error generator functions are not allowed in ON
+SELECT * FROM foo JOIN bar ON generate_series(0, 1) < 2
+
+query error aggregate functions are not allowed in ON
+SELECT * FROM foo JOIN bar ON max(foo.c) < 2

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -64,6 +64,8 @@ func (b *Builder) buildJoin(join *tree.JoinTableExpr, inScope *scope) (outScope 
 
 		var filter memo.GroupID
 		if on, ok := cond.(*tree.OnJoinCond); ok {
+			// Do not allow special functions in the ON clause.
+			b.semaCtx.Properties.Require("ON", tree.RejectSpecial)
 			filter = b.buildScalar(outScope.resolveAndRequireType(on.Expr, types.Bool, "ON"), outScope)
 		} else {
 			filter = b.factory.ConstructTrue()

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -3197,3 +3197,14 @@ build
 SELECT * FROM foo JOIN bar ON foo.c
 ----
 error (42804): argument of ON must be type bool, not type float
+
+# Regression test for #28817. Do not allow special functions in ON clause.
+build
+SELECT * FROM foo JOIN bar ON generate_series(0, 1) < 2
+----
+error: generate_series(): generator functions are not allowed in ON
+
+build
+SELECT * FROM foo JOIN bar ON max(foo.c) < 2
+----
+error: max(): aggregate functions are not allowed in ON


### PR DESCRIPTION
Previously, both the heuristic planner and the optimizer were
erroneously allowing ON clauses to have special functions such
as generator functions or aggregates. This commit ensures that
any queries containing special functions in the ON clause now
throw an error.

Fixes #28817

Release note (sql change): Previously, CockroachDB was
erroneously allowing generator functions, aggregates, and window
functions in the ON clause of joins. These functions are no longer
allowed in join conditions, and will cause an error if used.