### PR TITLE
acceptanceccl: unskip CDC acceptance test

### DIFF
--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -200,6 +200,11 @@ func CreateDocker(
 	}
 }
 
+// Client returns the underlying docker client.
+func (l *DockerCluster) Client() client.APIClient {
+	return l.client
+}
+
 func (l *DockerCluster) expectEvent(c *Container, msgs ...string) {
 	for index, ctr := range l.Nodes {
 		if c.id != ctr.id {


### PR DESCRIPTION
I stressed this for half an hour with no repros, so I suspect the
original failure is something with teamcity (it was happening relatively
frequently on CI). This unskips the test and adds some additional
debugging in case it happens again.

Release note: None