### PR TITLE
partitionccl: Skip flaky partitioning tests

### DIFF
--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1135,6 +1135,9 @@ func setupPartitioningTestCluster(ctx context.Context, t testing.TB) (*sqlutils.
 
 func TestInitialPartitioning(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	t.Skip("#28789")
+
 	rng, _ := randutil.NewPseudoRand()
 	testCases := allPartitioningTests(rng)
 
@@ -1235,6 +1238,8 @@ func TestSelectPartitionExprs(t *testing.T) {
 
 func TestRepartitioning(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	t.Skip("#28786")
 
 	rng, _ := randutil.NewPseudoRand()
 	testCases, err := allRepartitioningTests(allPartitioningTests(rng))


### PR DESCRIPTION
cc #28789 and #28786

Release note: None

These have been failing like crazy the last few days. We should of course fix them, but I'm tired of seeing new issues filed about them every few hours.