### PR TITLE
storage: gate merges behind a cluster setting 

### DIFF
--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -155,6 +155,10 @@ message ChangeReplicasTrigger {
 
   option (gogoproto.goproto_stringer) = false;
 
+  // TODO(benesch): this trigger should just specify the updated descriptor,
+  // like the split and merge triggers, so that the receiver doesn't need to
+  // reconstruct the range descriptor update.
+
   ReplicaChangeType change_type = 1;
   // The replica being modified.
   ReplicaDescriptor replica = 2 [(gogoproto.nullable) = false];

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -474,7 +474,7 @@ func TestReportUsage(t *testing.T) {
 		"diagnostics.reporting.send_crash_reports": "false",
 		"server.time_until_store_dead":             "1m30s",
 		"trace.debug.enable":                       "false",
-		"version":                                  "2.0-11",
+		"version":                                  "2.0-12",
 		"cluster.secret":                           "<redacted>",
 	} {
 		if got, ok := r.last.AlteredSettings[key]; !ok {

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -68,6 +68,7 @@ const (
 	VersionAsyncConsensus
 	VersionBatchResponse
 	VersionCreateChangefeed
+	VersionRangeMerges
 
 	// Add new versions here (step one of two).
 
@@ -264,6 +265,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionCreateChangefeed is https://github.com/cockroachdb/cockroach/pull/27962.
 		Key:     VersionCreateChangefeed,
 		Version: roachpb.Version{Major: 2, Minor: 0, Unstable: 11},
+	},
+	{
+		// VersionRangeMerges is https://github.com/cockroachdb/cockroach/pull/28865.
+		Key:     VersionRangeMerges,
+		Version: roachpb.Version{Major: 2, Minor: 0, Unstable: 12},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -244,7 +244,7 @@ select crdb_internal.set_vmodule('')
 query T
 select crdb_internal.node_executable_version()
 ----
-2.0-11
+2.0-12
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -341,4 +341,4 @@ select * from crdb_internal.gossip_alerts
 query T
 select crdb_internal.node_executable_version()
 ----
-2.0-11
+2.0-12

--- a/pkg/storage/merge_queue.go
+++ b/pkg/storage/merge_queue.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -139,7 +140,8 @@ func newMergeQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *mergeQue
 }
 
 func (mq *mergeQueue) enabled() bool {
-	return MergeQueueEnabled.Get(&mq.store.ClusterSettings().SV)
+	st := mq.store.ClusterSettings()
+	return st.Version.IsMinSupported(cluster.VersionRangeMerges) && MergeQueueEnabled.Get(&st.SV)
 }
 
 func (mq *mergeQueue) shouldQueue(

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -826,6 +826,9 @@ func (r *Replica) changeReplicas(
 		b.AddRawRequest(&roachpb.EndTransactionRequest{
 			Commit: true,
 			InternalCommitTrigger: &roachpb.InternalCommitTrigger{
+				// TODO(benesch): this trigger should just specify the updated
+				// descriptor, like the split and merge triggers, so that the receiver
+				// doesn't need to reconstruct the range descriptor update.
 				ChangeReplicasTrigger: &roachpb.ChangeReplicasTrigger{
 					ChangeType:      changeType,
 					Replica:         repDesc,
@@ -961,9 +964,6 @@ func replicaSetsEqual(a, b []roachpb.ReplicaDescriptor) bool {
 // Note that in addition to using this method to update the on-disk range
 // descriptor, a CommitTrigger must be used to update the in-memory
 // descriptor; it will not automatically be copied from newDesc.
-// TODO(bdarnell): store the entire RangeDescriptor in the CommitTrigger
-// and load it automatically instead of reconstructing individual
-// changes.
 func updateRangeDescriptor(
 	b *client.Batch,
 	descKey roachpb.Key,

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -646,9 +646,7 @@ func (r *Replica) handleReplicatedEvalResult(
 	}
 
 	if rResult.Merge != nil {
-		if err := r.store.MergeRange(ctx, r, rResult.Merge.LeftDesc.EndKey,
-			rResult.Merge.RightDesc,
-		); err != nil {
+		if err := r.store.MergeRange(ctx, r, rResult.Merge.LeftDesc, rResult.Merge.RightDesc); err != nil {
 			// Our in-memory state has diverged from the on-disk state.
 			log.Fatalf(ctx, "failed to update store after merging range: %s", err)
 		}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2334,42 +2334,42 @@ func splitPostApply(
 //
 // This is only called from the split trigger in the context of the execution
 // of a Raft command.
-func (s *Store) SplitRange(ctx context.Context, origRng, newRng *Replica) error {
-	origDesc := origRng.Desc()
-	newDesc := newRng.Desc()
+func (s *Store) SplitRange(ctx context.Context, leftRepl, rightRepl *Replica) error {
+	leftDesc := leftRepl.Desc()
+	rightDesc := rightRepl.Desc()
 
-	if !bytes.Equal(origDesc.EndKey, newDesc.EndKey) ||
-		bytes.Compare(origDesc.StartKey, newDesc.StartKey) >= 0 {
-		return errors.Errorf("orig range is not splittable by new range: %+v, %+v", origDesc, newDesc)
+	if !bytes.Equal(leftDesc.EndKey, rightDesc.EndKey) ||
+		bytes.Compare(leftDesc.StartKey, rightDesc.StartKey) >= 0 {
+		return errors.Errorf("orig range is not splittable by new range: %+v, %+v", leftDesc, rightDesc)
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if exRng, ok := s.mu.uninitReplicas[newDesc.RangeID]; ok {
+	if exRng, ok := s.mu.uninitReplicas[rightDesc.RangeID]; ok {
 		// If we have an uninitialized replica of the new range we require pointer
-		// equivalence with newRng. See Store.splitTriggerPostApply().
-		if exRng != newRng {
-			log.Fatalf(ctx, "found unexpected uninitialized replica: %s vs %s", exRng, newRng)
+		// equivalence with rightRepl. See Store.splitTriggerPostApply().
+		if exRng != rightRepl {
+			log.Fatalf(ctx, "found unexpected uninitialized replica: %s vs %s", exRng, rightRepl)
 		}
-		s.unlinkReplicaByRangeIDLocked(newDesc.RangeID)
+		s.unlinkReplicaByRangeIDLocked(rightDesc.RangeID)
 	}
 
 	// Replace the end key of the original range with the start key of
 	// the new range. Reinsert the range since the btree is keyed by range end keys.
-	if kr := s.mu.replicasByKey.Delete(origRng); kr != origRng {
-		return errors.Errorf("replicasByKey unexpectedly contains %v instead of replica %s", kr, origRng)
+	if kr := s.mu.replicasByKey.Delete(leftRepl); kr != leftRepl {
+		return errors.Errorf("replicasByKey unexpectedly contains %v instead of replica %s", kr, leftRepl)
 	}
 
-	copyDesc := *origDesc
+	copyDesc := *leftDesc
 	copyDesc.IncrementGeneration()
-	copyDesc.EndKey = append([]byte(nil), newDesc.StartKey...)
-	origRng.setDescWithoutProcessUpdate(&copyDesc)
+	copyDesc.EndKey = append([]byte(nil), rightDesc.StartKey...)
+	leftRepl.setDescWithoutProcessUpdate(&copyDesc)
 
 	// Clear the LHS txn wait queue, to redirect to the RHS if
 	// appropriate. We do this after setDescWithoutProcessUpdate
 	// to ensure that no pre-split commands are inserted into the
 	// txnWaitQueue after we clear it.
-	origRng.txnWaitQueue.Clear(false /* disable */)
+	leftRepl.txnWaitQueue.Clear(false /* disable */)
 
 	// The rangefeed processor will no longer be provided logical ops for
 	// its entire range, so it needs to be shut down and all registrations
@@ -2377,28 +2377,28 @@ func (s *Store) SplitRange(ctx context.Context, origRng, newRng *Replica) error 
 	// TODO(nvanbenschoten): It should be possible to only reject registrations
 	// that overlap with the new range of the split and keep registrations that
 	// are only interested in keys that are still on the original range running.
-	origRng.disconnectRangefeedWithReasonRaftMuLocked(
+	leftRepl.disconnectRangefeedWithReasonRaftMuLocked(
 		roachpb.RangeFeedRetryError_REASON_RANGE_SPLIT,
 	)
 
 	// Clear the original range's request stats, since they include requests for
 	// spans that are now owned by the new range.
-	origRng.leaseholderStats.resetRequestCounts()
-	origRng.writeStats.splitRequestCounts(newRng.writeStats)
+	leftRepl.leaseholderStats.resetRequestCounts()
+	leftRepl.writeStats.splitRequestCounts(rightRepl.writeStats)
 
-	if kr := s.mu.replicasByKey.ReplaceOrInsert(origRng); kr != nil {
-		return errors.Errorf("replicasByKey unexpectedly contains %s when inserting replica %s", kr, origRng)
+	if kr := s.mu.replicasByKey.ReplaceOrInsert(leftRepl); kr != nil {
+		return errors.Errorf("replicasByKey unexpectedly contains %s when inserting replica %s", kr, leftRepl)
 	}
 
-	if err := s.addReplicaInternalLocked(newRng); err != nil {
-		return errors.Errorf("couldn't insert range %v in replicasByKey btree: %s", newRng, err)
+	if err := s.addReplicaInternalLocked(rightRepl); err != nil {
+		return errors.Errorf("couldn't insert range %v in replicasByKey btree: %s", rightRepl, err)
 	}
 
 	// Update the max bytes and other information of the new range.
 	// This may not happen if the system config has not yet been loaded.
 	// Since this is done under the store lock, system config update will
 	// properly set these fields.
-	if err := newRng.updateRangeInfo(newRng.Desc()); err != nil {
+	if err := rightRepl.updateRangeInfo(rightRepl.Desc()); err != nil {
 		return err
 	}
 
@@ -2406,7 +2406,7 @@ func (s *Store) SplitRange(ctx context.Context, origRng, newRng *Replica) error 
 	s.metrics.ReplicaCount.Inc(1)
 	s.maybeGossipOnCapacityChange(ctx, rangeAddEvent)
 
-	return s.processRangeDescriptorUpdateLocked(ctx, origRng)
+	return s.processRangeDescriptorUpdateLocked(ctx, leftRepl)
 }
 
 // MergeRange expands the left-hand replica, leftRepl, to absorb the right-hand

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -1357,7 +1357,9 @@ func splitTestRange(store *Store, key, splitKey roachpb.RKey, t *testing.T) *Rep
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = store.SplitRange(repl.AnnotateCtx(context.TODO()), repl, newRng); err != nil {
+	newLeftDesc := *repl.Desc()
+	newLeftDesc.EndKey = splitKey
+	if err = store.SplitRange(repl.AnnotateCtx(context.TODO()), repl, newRng, newLeftDesc); err != nil {
 		t.Fatal(err)
 	}
 	return newRng


### PR DESCRIPTION
The big commit:

> storage: gate merges behind a cluster setting 
>
> Merges will explode if used in a mixed-version cluster. Gate them behind
> a cluster setting.
>
> For extra safety, also gate increments of the new generation counter in
> the range descriptor behind the same cluster setting. It's not clear
> exactly what would go wrong, if anything, if mixed-version clusters
> incremented the generation counter, but better to be extra cautious.

The early commits are cleanup to make the last commit less painful.