### PR TITLE
opt: don't add empty interesting orderings for scans

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -25,12 +25,10 @@ select
  ├── columns: x:1(int!null) y:2(int)
  ├── stats: [rows=333.333333]
  ├── prune: (2)
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
       └── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
            ├── variable: x [type=int, outer=(1)]
@@ -43,12 +41,10 @@ select
  ├── columns: x:1(int!null) y:2(int)
  ├── stats: [rows=333.333333]
  ├── prune: (2)
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1), constraints=(/1: [/1 - ]; tight)]
       └── ge [type=bool, outer=(1), constraints=(/1: [/1 - ]; tight)]
            ├── variable: x [type=int, outer=(1)]
@@ -61,12 +57,10 @@ select
  ├── columns: x:1(int!null) y:2(int)
  ├── stats: [rows=333.333333]
  ├── prune: (2)
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1), constraints=(/1: (/NULL - /0]; tight)]
       └── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /0]; tight)]
            ├── variable: x [type=int, outer=(1)]
@@ -79,12 +73,10 @@ select
  ├── columns: x:1(int!null) y:2(int)
  ├── stats: [rows=333.333333]
  ├── prune: (2)
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1), constraints=(/1: (/NULL - /1]; tight)]
       └── le [type=bool, outer=(1), constraints=(/1: (/NULL - /1]; tight)]
            ├── variable: x [type=int, outer=(1)]
@@ -98,12 +90,10 @@ select
  ├── stats: [rows=1.42857143, distinct(1)=1]
  ├── fd: ()-->(1)
  ├── prune: (2)
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000, distinct(1)=700]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
       └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
            ├── variable: x [type=int, outer=(1)]
@@ -116,12 +106,10 @@ select
  ├── columns: x:1(int!null) y:2(int)
  ├── stats: [rows=4.28571429, distinct(1)=3]
  ├── prune: (2)
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000, distinct(1)=700]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1), constraints=(/1: [/2 - /4]; tight)]
       ├── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
       │    ├── variable: x [type=int, outer=(1)]
@@ -137,12 +125,10 @@ select
  ├── columns: x:1(int!null) y:2(int!null)
  ├── stats: [rows=0.00204081633, distinct(1)=0.00204081633, distinct(2)=0.00204081633]
  ├── fd: ()-->(1,2)
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000, distinct(1)=700, distinct(2)=700]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1: [/1 - /1]; /2: [/5 - /5]; tight), fd=()-->(1,2)]
       ├── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
       │    ├── variable: x [type=int, outer=(1)]
@@ -157,12 +143,10 @@ SELECT * FROM a WHERE x > 1 AND x < 5 AND y >= 7 AND y <= 9
 select
  ├── columns: x:1(int!null) y:2(int!null)
  ├── stats: [rows=0.0183673469, distinct(1)=0.0183673469, distinct(2)=0.0183673469]
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000, distinct(1)=700, distinct(2)=700]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1: [/2 - /4]; /2: [/7 - /9]; tight)]
       ├── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
       │    ├── variable: x [type=int, outer=(1)]
@@ -184,12 +168,10 @@ SELECT * FROM a WHERE x > 1 AND x < 5 AND x + y = 5
 select
  ├── columns: x:1(int!null) y:2(int)
  ├── stats: [rows=37.037037]
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1: [/2 - /4])]
       ├── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
       │    ├── variable: x [type=int, outer=(1)]
@@ -209,12 +191,10 @@ SELECT * FROM a WHERE x > 1 AND x + y >= 5 AND x + y <= 7
 select
  ├── columns: x:1(int!null) y:2(int)
  ├── stats: [rows=37.037037]
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1: [/2 - ])]
       ├── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
       │    ├── variable: x [type=int, outer=(1)]
@@ -238,12 +218,10 @@ select
  ├── columns: x:1(int) y:2(int)
  ├── stats: [rows=333.333333]
  ├── prune: (2)
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1)]
       └── gt [type=bool, outer=(1)]
            ├── variable: x [type=int, outer=(1)]
@@ -304,12 +282,10 @@ select
  ├── columns: x:1(int!null) y:2(int)
  ├── stats: [rows=4.28571429, distinct(1)=3]
  ├── prune: (2)
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000, distinct(1)=700]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1), constraints=(/1: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
       └── in [type=bool, outer=(1), constraints=(/1: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
            ├── variable: x [type=int, outer=(1)]
@@ -348,12 +324,10 @@ select
  ├── columns: x:1(int!null) y:2(int)
  ├── stats: [rows=2.85714286, distinct(1)=2]
  ├── prune: (2)
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000, distinct(1)=700]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1), constraints=(/1: [/7 - /7] [/9 - /9]; tight)]
       ├── in [type=bool, outer=(1), constraints=(/1: [/1 - /1] [/3 - /3] [/5 - /5] [/7 - /7] [/9 - /9]; tight)]
       │    ├── variable: x [type=int, outer=(1)]
@@ -374,12 +348,10 @@ SELECT * FROM a WHERE x IN (1, 3) AND y > 4
 select
  ├── columns: x:1(int!null) y:2(int!null)
  ├── stats: [rows=0.952380952, distinct(1)=0.952380952]
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000, distinct(1)=700]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1: [/1 - /1] [/3 - /3]; /2: [/5 - ]; tight)]
       ├── in [type=bool, outer=(1), constraints=(/1: [/1 - /1] [/3 - /3]; tight)]
       │    ├── variable: x [type=int, outer=(1)]
@@ -397,12 +369,10 @@ SELECT * FROM a WHERE (x, y) > (1, 2)
 select
  ├── columns: x:1(int!null) y:2(int)
  ├── stats: [rows=333.333333]
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1/2: [/1/3 - ]; tight)]
       └── gt [type=bool, outer=(1,2), constraints=(/1/2: [/1/3 - ]; tight)]
            ├── tuple [type=tuple{int, int}, outer=(1,2)]
@@ -418,12 +388,10 @@ SELECT * FROM a WHERE (x, y) >= (1, 2)
 select
  ├── columns: x:1(int!null) y:2(int)
  ├── stats: [rows=333.333333]
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1/2: [/1/2 - ]; tight)]
       └── ge [type=bool, outer=(1,2), constraints=(/1/2: [/1/2 - ]; tight)]
            ├── tuple [type=tuple{int, int}, outer=(1,2)]
@@ -439,12 +407,10 @@ SELECT * FROM a WHERE (x, y) < (1, 2)
 select
  ├── columns: x:1(int!null) y:2(int)
  ├── stats: [rows=333.333333]
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1/2: (/NULL - /1/1]; tight)]
       └── lt [type=bool, outer=(1,2), constraints=(/1/2: (/NULL - /1/1]; tight)]
            ├── tuple [type=tuple{int, int}, outer=(1,2)]
@@ -460,12 +426,10 @@ SELECT * FROM a WHERE (x, y) <= (1, 2)
 select
  ├── columns: x:1(int!null) y:2(int)
  ├── stats: [rows=333.333333]
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1/2: (/NULL - /1/2]; tight)]
       └── le [type=bool, outer=(1,2), constraints=(/1/2: (/NULL - /1/2]; tight)]
            ├── tuple [type=tuple{int, int}, outer=(1,2)]
@@ -482,12 +446,10 @@ SELECT * FROM a WHERE (x, y) >= (1, 2.5)
 select
  ├── columns: x:1(int) y:2(int)
  ├── stats: [rows=333.333333]
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2)]
       └── ge [type=bool, outer=(1,2)]
            ├── tuple [type=tuple{int, int}, outer=(1,2)]
@@ -504,12 +466,10 @@ SELECT * FROM a WHERE (x, y) >= (1, NULL)
 select
  ├── columns: x:1(int) y:2(int)
  ├── stats: [rows=333.333333]
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2)]
       └── ge [type=bool, outer=(1,2)]
            ├── tuple [type=tuple{int, int}, outer=(1,2)]
@@ -528,12 +488,10 @@ select
  ├── columns: x:1(int) y:2(int)
  ├── stats: [rows=333.333333]
  ├── prune: (2)
- ├── interesting orderings: ()
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1)]
       └── ge [type=bool, outer=(1)]
            ├── tuple [type=tuple{int, int}, outer=(1)]
@@ -561,12 +519,10 @@ select
  ├── columns: a:1(int!null) b:2(bool) c:3(string)
  ├── stats: [rows=333.333333]
  ├── prune: (2,3)
- ├── interesting orderings: ()
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1-3)
- │    └── interesting orderings: ()
+ │    └── prune: (1-3)
  └── filters [type=bool, outer=(1), constraints=(/1: (/NULL - /4] [/6 - ]; tight)]
       └── ne [type=bool, outer=(1), constraints=(/1: (/NULL - /4] [/6 - ]; tight)]
            ├── variable: a [type=int, outer=(1)]
@@ -579,12 +535,10 @@ select
  ├── columns: a:1(int) b:2(bool) c:3(string)
  ├── stats: [rows=333.333333]
  ├── prune: (2,3)
- ├── interesting orderings: ()
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1-3)
- │    └── interesting orderings: ()
+ │    └── prune: (1-3)
  └── filters [type=bool, outer=(1), constraints=(/1: [ - /4] [/6 - ]; tight)]
       └── is-not [type=bool, outer=(1), constraints=(/1: [ - /4] [/6 - ]; tight)]
            ├── variable: a [type=int, outer=(1)]
@@ -597,12 +551,10 @@ select
  ├── columns: a:1(int) b:2(bool!null) c:3(string)
  ├── stats: [rows=333.333333]
  ├── prune: (1,3)
- ├── interesting orderings: ()
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1-3)
- │    └── interesting orderings: ()
+ │    └── prune: (1-3)
  └── filters [type=bool, outer=(2), constraints=(/2: (/NULL - /false]; tight)]
       └── ne [type=bool, outer=(2), constraints=(/2: (/NULL - /false]; tight)]
            ├── variable: b [type=bool, outer=(2)]
@@ -615,12 +567,10 @@ select
  ├── columns: a:1(int) b:2(bool!null) c:3(string)
  ├── stats: [rows=333.333333]
  ├── prune: (1,3)
- ├── interesting orderings: ()
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1-3)
- │    └── interesting orderings: ()
+ │    └── prune: (1-3)
  └── filters [type=bool, outer=(2), constraints=(/2: [/true - ]; tight)]
       └── ne [type=bool, outer=(2), constraints=(/2: [/true - ]; tight)]
            ├── variable: b [type=bool, outer=(2)]
@@ -633,12 +583,10 @@ select
  ├── columns: a:1(int) b:2(bool) c:3(string)
  ├── stats: [rows=333.333333]
  ├── prune: (1,3)
- ├── interesting orderings: ()
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1-3)
- │    └── interesting orderings: ()
+ │    └── prune: (1-3)
  └── filters [type=bool, outer=(2), constraints=(/2: [ - /false]; tight)]
       └── is-not [type=bool, outer=(2), constraints=(/2: [ - /false]; tight)]
            ├── variable: b [type=bool, outer=(2)]
@@ -651,12 +599,10 @@ select
  ├── columns: a:1(int) b:2(bool) c:3(string)
  ├── stats: [rows=333.333333]
  ├── prune: (1,3)
- ├── interesting orderings: ()
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1-3)
- │    └── interesting orderings: ()
+ │    └── prune: (1-3)
  └── filters [type=bool, outer=(2), constraints=(/2: [ - /false) [/true - ]; tight)]
       └── is-not [type=bool, outer=(2), constraints=(/2: [ - /false) [/true - ]; tight)]
            ├── variable: b [type=bool, outer=(2)]
@@ -670,12 +616,10 @@ select
  ├── stats: [rows=500, distinct(2)=1]
  ├── fd: ()-->(2)
  ├── prune: (1,3)
- ├── interesting orderings: ()
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    ├── stats: [rows=1000, distinct(2)=2]
- │    ├── prune: (1-3)
- │    └── interesting orderings: ()
+ │    └── prune: (1-3)
  └── filters [type=bool, outer=(2), constraints=(/2: [/true - /true]; tight), fd=()-->(2)]
       └── variable: b [type=bool, outer=(2), constraints=(/2: [/true - /true]; tight)]
 
@@ -687,12 +631,10 @@ select
  ├── stats: [rows=500, distinct(2)=1]
  ├── fd: ()-->(2)
  ├── prune: (1,3)
- ├── interesting orderings: ()
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    ├── stats: [rows=1000, distinct(2)=2]
- │    ├── prune: (1-3)
- │    └── interesting orderings: ()
+ │    └── prune: (1-3)
  └── filters [type=bool, outer=(2), constraints=(/2: [/false - /false]; tight), fd=()-->(2)]
       └── not [type=bool, outer=(2), constraints=(/2: [/false - /false]; tight)]
            └── variable: b [type=bool, outer=(2)]
@@ -705,12 +647,10 @@ select
  ├── stats: [rows=166.666667, distinct(2)=1]
  ├── fd: ()-->(2)
  ├── prune: (3)
- ├── interesting orderings: ()
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    ├── stats: [rows=1000, distinct(2)=2]
- │    ├── prune: (1-3)
- │    └── interesting orderings: ()
+ │    └── prune: (1-3)
  └── filters [type=bool, outer=(1,2), constraints=(/1: [/6 - ]; /2: [/true - /true]; tight), fd=()-->(2)]
       ├── gt [type=bool, outer=(1), constraints=(/1: [/6 - ]; tight)]
       │    ├── variable: a [type=int, outer=(1)]
@@ -724,12 +664,10 @@ select
  ├── columns: a:1(int) b:2(bool) c:3(string!null)
  ├── stats: [rows=333.333333]
  ├── prune: (1,2)
- ├── interesting orderings: ()
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1-3)
- │    └── interesting orderings: ()
+ │    └── prune: (1-3)
  └── filters [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo') [/e'foo\x00' - ]; tight)]
       └── ne [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo') [/e'foo\x00' - ]; tight)]
            ├── variable: c [type=string, outer=(3)]
@@ -742,12 +680,10 @@ select
  ├── columns: a:1(int) b:2(bool) c:3(string)
  ├── stats: [rows=333.333333]
  ├── prune: (1,2)
- ├── interesting orderings: ()
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1-3)
- │    └── interesting orderings: ()
+ │    └── prune: (1-3)
  └── filters [type=bool, outer=(3), constraints=(/3: [ - /'foo') [/e'foo\x00' - ]; tight)]
       └── is-not [type=bool, outer=(3), constraints=(/3: [ - /'foo') [/e'foo\x00' - ]; tight)]
            ├── variable: c [type=string, outer=(3)]
@@ -766,8 +702,7 @@ select
  │    ├── scan a
  │    │    ├── columns: x:1(int) y:2(int)
  │    │    ├── stats: [rows=1000]
- │    │    ├── prune: (1,2)
- │    │    └── interesting orderings: ()
+ │    │    └── prune: (1,2)
  │    └── projections [outer=(1,2)]
  │         └── tuple [type=tuple{int, int}, outer=(1,2)]
  │              ├── variable: x [type=int, outer=(1)]

--- a/pkg/sql/opt/memo/testdata/logprops/constraints-null
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints-null
@@ -39,12 +39,10 @@ select
  ├── stats: [rows=1.42857143, distinct(1)=1]
  ├── fd: ()-->(1)
  ├── prune: (2,3)
- ├── interesting orderings: ()
  ├── scan t
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    ├── stats: [rows=1000, distinct(1)=700]
- │    ├── prune: (1-3)
- │    └── interesting orderings: ()
+ │    └── prune: (1-3)
  └── filters [type=bool, outer=(1), constraints=(/1: [/NULL - /NULL]; tight), fd=()-->(1)]
       └── is [type=bool, outer=(1), constraints=(/1: [/NULL - /NULL]; tight)]
            ├── variable: a [type=int, outer=(1)]
@@ -57,12 +55,10 @@ select
  ├── columns: a:1(int!null) b:2(bool) c:3(string)
  ├── stats: [rows=333.333333]
  ├── prune: (2,3)
- ├── interesting orderings: ()
  ├── scan t
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1-3)
- │    └── interesting orderings: ()
+ │    └── prune: (1-3)
  └── filters [type=bool, outer=(1), constraints=(/1: (/NULL - ]; tight)]
       └── is-not [type=bool, outer=(1), constraints=(/1: (/NULL - ]; tight)]
            ├── variable: a [type=int, outer=(1)]
@@ -76,12 +72,10 @@ select
  ├── stats: [rows=0.714285714, distinct(2)=0.714285714, distinct(3)=0.714285714]
  ├── fd: ()-->(2,3)
  ├── prune: (1)
- ├── interesting orderings: ()
  ├── scan t
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    ├── stats: [rows=1000, distinct(2)=2, distinct(3)=700]
- │    ├── prune: (1-3)
- │    └── interesting orderings: ()
+ │    └── prune: (1-3)
  └── filters [type=bool, outer=(2,3), constraints=(/2: [/NULL - /NULL]; /3: [/NULL - /NULL]; tight), fd=()-->(2,3)]
       ├── is [type=bool, outer=(2), constraints=(/2: [/NULL - /NULL]; tight)]
       │    ├── variable: b [type=bool, outer=(2)]
@@ -97,12 +91,10 @@ select
  ├── columns: a:1(int) b:2(bool!null) c:3(string!null)
  ├── stats: [rows=111.111111]
  ├── prune: (1)
- ├── interesting orderings: ()
  ├── scan t
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1-3)
- │    └── interesting orderings: ()
+ │    └── prune: (1-3)
  └── filters [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]; tight)]
       ├── is-not [type=bool, outer=(2), constraints=(/2: (/NULL - ]; tight)]
       │    ├── variable: b [type=bool, outer=(2)]
@@ -131,12 +123,10 @@ SELECT * FROM xy WHERE x > abs(y)
 select
  ├── columns: x:1(int!null) y:2(int)
  ├── stats: [rows=333.333333]
- ├── interesting orderings: ()
  ├── scan xy
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1: (/NULL - ])]
       └── gt [type=bool, outer=(1,2), constraints=(/1: (/NULL - ])]
            ├── variable: x [type=int, outer=(1)]
@@ -151,12 +141,10 @@ select
  ├── columns: x:1(int!null) y:2(int)
  ├── stats: [rows=333.333333]
  ├── prune: (2)
- ├── interesting orderings: ()
  ├── scan xy
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
       └── gt [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
            ├── variable: x [type=int, outer=(1)]
@@ -172,12 +160,10 @@ SELECT * FROM xy WHERE x > y
 select
  ├── columns: x:1(int!null) y:2(int!null)
  ├── stats: [rows=111.111111]
- ├── interesting orderings: ()
  ├── scan xy
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
       └── gt [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
            ├── variable: x [type=int, outer=(1)]
@@ -191,12 +177,10 @@ select
  ├── columns: x:1(int!null) y:2(int!null)
  ├── stats: [rows=1.42857143, distinct(1)=1.42857143, distinct(2)=1.42857143]
  ├── fd: (1)==(2), (2)==(1)
- ├── interesting orderings: ()
  ├── scan xy
  │    ├── columns: x:1(int) y:2(int)
  │    ├── stats: [rows=1000, distinct(1)=700, distinct(2)=700]
- │    ├── prune: (1,2)
- │    └── interesting orderings: ()
+ │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
       └── eq [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
            ├── variable: x [type=int, outer=(1)]

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -150,12 +150,10 @@ project
       │              ├── outer: (1)
       │              ├── stats: [rows=1000, distinct(1)=1, distinct(9)=1]
       │              ├── fd: ()-->(9)
-      │              ├── interesting orderings: ()
       │              ├── scan uv
       │              │    ├── columns: v:6(int!null)
       │              │    ├── stats: [rows=1000]
-      │              │    ├── prune: (6)
-      │              │    └── interesting orderings: ()
+      │              │    └── prune: (6)
       │              ├── max1-row
       │              │    ├── columns: n:9(int!null)
       │              │    ├── outer: (6)
@@ -233,12 +231,11 @@ project
       │              ├── stats: [rows=1000, distinct(1)=1, distinct(2)=1, distinct(8)=1]
       │              ├── fd: ()-->(8)
       │              ├── prune: (6)
-      │              ├── interesting orderings: () (+8)
+      │              ├── interesting orderings: (+8)
       │              ├── scan uv
       │              │    ├── columns: v:6(int!null)
       │              │    ├── stats: [rows=1000]
-      │              │    ├── prune: (6)
-      │              │    └── interesting orderings: ()
+      │              │    └── prune: (6)
       │              ├── scan mn
       │              │    ├── columns: m:8(int!null)
       │              │    ├── stats: [rows=1000, distinct(8)=1000]
@@ -333,12 +330,10 @@ project
       │    │         ├── outer: (1)
       │    │         ├── stats: [rows=1.42857143, distinct(1)=1, distinct(5)=1]
       │    │         ├── fd: ()-->(5)
-      │    │         ├── interesting orderings: ()
       │    │         ├── scan uv
       │    │         │    ├── columns: u:5(int)
       │    │         │    ├── stats: [rows=1000, distinct(5)=700]
-      │    │         │    ├── prune: (5)
-      │    │         │    └── interesting orderings: ()
+      │    │         │    └── prune: (5)
       │    │         └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
       │    │              └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
       │    │                   ├── variable: u [type=int, outer=(5)]
@@ -390,7 +385,7 @@ right-join
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-6)
  ├── reject-nulls: (1-4)
- ├── interesting orderings: (+1) (-3,+4,+1) ()
+ ├── interesting orderings: (+1) (-3,+4,+1)
  ├── project
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── stats: [rows=1000]
@@ -432,18 +427,15 @@ right-join
  │         │    │         ├── outer: (1)
  │         │    │         ├── stats: [rows=0.428571429]
  │         │    │         ├── fd: ()-->(8)
- │         │    │         ├── interesting orderings: ()
  │         │    │         ├── select
  │         │    │         │    ├── columns: uv.u:8(int!null)
  │         │    │         │    ├── outer: (1)
  │         │    │         │    ├── stats: [rows=1.42857143, distinct(1)=1, distinct(8)=1]
  │         │    │         │    ├── fd: ()-->(8)
- │         │    │         │    ├── interesting orderings: ()
  │         │    │         │    ├── scan uv
  │         │    │         │    │    ├── columns: uv.u:8(int)
  │         │    │         │    │    ├── stats: [rows=1000, distinct(8)=700]
- │         │    │         │    │    ├── prune: (8)
- │         │    │         │    │    └── interesting orderings: ()
+ │         │    │         │    │    └── prune: (8)
  │         │    │         │    └── filters [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
  │         │    │         │         └── eq [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
  │         │    │         │              ├── variable: uv.u [type=int, outer=(8)]
@@ -457,8 +449,7 @@ right-join
  ├── scan uv
  │    ├── columns: uv.u:5(int) uv.v:6(int!null)
  │    ├── stats: [rows=1000]
- │    ├── prune: (5,6)
- │    └── interesting orderings: ()
+ │    └── prune: (5,6)
  └── true [type=bool]
 
 # Full-join.
@@ -508,7 +499,7 @@ project
       ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
       ├── prune: (2-6)
       ├── reject-nulls: (1-6,8)
-      ├── interesting orderings: (+1) (-3,+4,+1) ()
+      ├── interesting orderings: (+1) (-3,+4,+1)
       ├── scan xysd
       │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
       │    ├── stats: [rows=1000]
@@ -523,12 +514,10 @@ project
       │    ├── fd: ()~~>(8)
       │    ├── prune: (5,6)
       │    ├── reject-nulls: (8)
-      │    ├── interesting orderings: ()
       │    ├── scan uv
       │    │    ├── columns: uv.u:5(int) uv.v:6(int!null)
       │    │    ├── stats: [rows=1000]
-      │    │    ├── prune: (5,6)
-      │    │    └── interesting orderings: ()
+      │    │    └── prune: (5,6)
       │    ├── max1-row
       │    │    ├── columns: uv.u:8(int!null)
       │    │    ├── outer: (1)
@@ -541,18 +530,15 @@ project
       │    │         ├── outer: (1)
       │    │         ├── stats: [rows=0.428571429]
       │    │         ├── fd: ()-->(8)
-      │    │         ├── interesting orderings: ()
       │    │         ├── select
       │    │         │    ├── columns: uv.u:8(int!null)
       │    │         │    ├── outer: (1)
       │    │         │    ├── stats: [rows=1.42857143, distinct(1)=1, distinct(8)=1]
       │    │         │    ├── fd: ()-->(8)
-      │    │         │    ├── interesting orderings: ()
       │    │         │    ├── scan uv
       │    │         │    │    ├── columns: uv.u:8(int)
       │    │         │    │    ├── stats: [rows=1000, distinct(8)=700]
-      │    │         │    │    ├── prune: (8)
-      │    │         │    │    └── interesting orderings: ()
+      │    │         │    │    └── prune: (8)
       │    │         │    └── filters [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
       │    │         │         └── eq [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
       │    │         │              ├── variable: uv.u [type=int, outer=(8)]
@@ -585,8 +571,7 @@ semi-join
  ├── scan uv
  │    ├── columns: u:5(int) v:6(int!null)
  │    ├── stats: [rows=1000, distinct(5)=700]
- │    ├── prune: (5,6)
- │    └── interesting orderings: ()
+ │    └── prune: (5,6)
  └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
       └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
            ├── variable: x [type=int, outer=(1)]
@@ -602,7 +587,7 @@ semi-join-apply
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (2-4)
- ├── interesting orderings: (+1) (-3,+4,+1) ()
+ ├── interesting orderings: (+1) (-3,+4,+1)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── stats: [rows=1000]
@@ -616,19 +601,16 @@ semi-join-apply
  │    ├── stats: [rows=0.428571429]
  │    ├── fd: ()-->(6)
  │    ├── prune: (5)
- │    ├── interesting orderings: ()
  │    ├── select
  │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    ├── outer: (1)
  │    │    ├── stats: [rows=1.42857143, distinct(1)=1, distinct(6)=1]
  │    │    ├── fd: ()-->(6)
  │    │    ├── prune: (5)
- │    │    ├── interesting orderings: ()
  │    │    ├── scan uv
  │    │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    │    ├── stats: [rows=1000, distinct(6)=700]
- │    │    │    ├── prune: (5,6)
- │    │    │    └── interesting orderings: ()
+ │    │    │    └── prune: (5,6)
  │    │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         └── eq [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
  │    │              ├── variable: v [type=int, outer=(6)]
@@ -646,7 +628,7 @@ semi-join-apply
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (2-4)
- ├── interesting orderings: (+1) (-3,+4,+1) ()
+ ├── interesting orderings: (+1) (-3,+4,+1)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── stats: [rows=1000]
@@ -660,12 +642,10 @@ semi-join-apply
  │    ├── stats: [rows=1000]
  │    ├── fd: ()-->(6)
  │    ├── prune: (5)
- │    ├── interesting orderings: ()
  │    ├── scan uv
  │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    ├── stats: [rows=1000]
- │    │    ├── prune: (5,6)
- │    │    └── interesting orderings: ()
+ │    │    └── prune: (5,6)
  │    ├── scan mn
  │    │    ├── columns: m:8(int!null) n:9(int)
  │    │    ├── stats: [rows=1000, distinct(8)=1000]
@@ -703,8 +683,7 @@ anti-join
  ├── scan uv
  │    ├── columns: u:5(int) v:6(int!null)
  │    ├── stats: [rows=1000, distinct(5)=700]
- │    ├── prune: (5,6)
- │    └── interesting orderings: ()
+ │    └── prune: (5,6)
  └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
       └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
            ├── variable: x [type=int, outer=(1)]
@@ -720,7 +699,7 @@ anti-join-apply
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (2-4)
- ├── interesting orderings: (+1) (-3,+4,+1) ()
+ ├── interesting orderings: (+1) (-3,+4,+1)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── stats: [rows=1000]
@@ -734,19 +713,16 @@ anti-join-apply
  │    ├── stats: [rows=0.428571429]
  │    ├── fd: ()-->(6)
  │    ├── prune: (5)
- │    ├── interesting orderings: ()
  │    ├── select
  │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    ├── outer: (1)
  │    │    ├── stats: [rows=1.42857143, distinct(1)=1, distinct(6)=1]
  │    │    ├── fd: ()-->(6)
  │    │    ├── prune: (5)
- │    │    ├── interesting orderings: ()
  │    │    ├── scan uv
  │    │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    │    ├── stats: [rows=1000, distinct(6)=700]
- │    │    │    ├── prune: (5,6)
- │    │    │    └── interesting orderings: ()
+ │    │    │    └── prune: (5,6)
  │    │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         └── eq [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
  │    │              ├── variable: v [type=int, outer=(6)]
@@ -902,8 +878,7 @@ semi-join
  │    │    ├── fd: ()-->(5)
  │    │    ├── prune: (5)
  │    │    ├── scan xysd@secondary
- │    │    │    ├── stats: [rows=1000]
- │    │    │    └── interesting orderings: ()
+ │    │    │    └── stats: [rows=1000]
  │    │    └── aggregations
  │    │         └── count-rows [type=int]
  │    └── filters [type=bool, outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
@@ -913,8 +888,7 @@ semi-join
  ├── scan uv
  │    ├── columns: u:6(int) v:7(int!null)
  │    ├── stats: [rows=1000]
- │    ├── prune: (6,7)
- │    └── interesting orderings: ()
+ │    └── prune: (6,7)
  └── true [type=bool]
 
 # Calculate semi-join-apply cardinality.
@@ -928,7 +902,7 @@ semi-join-apply
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (2-4)
- ├── interesting orderings: (+1) (-3,+4,+1) ()
+ ├── interesting orderings: (+1) (-3,+4,+1)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── limit: 10
@@ -944,19 +918,16 @@ semi-join-apply
  │    ├── stats: [rows=1.42857143]
  │    ├── fd: ()-->(5)
  │    ├── prune: (6)
- │    ├── interesting orderings: ()
  │    ├── select
  │    │    ├── columns: u:5(int!null) v:6(int!null)
  │    │    ├── outer: (1)
  │    │    ├── stats: [rows=1.42857143, distinct(1)=1, distinct(5)=1]
  │    │    ├── fd: ()-->(5)
  │    │    ├── prune: (6)
- │    │    ├── interesting orderings: ()
  │    │    ├── scan uv
  │    │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    │    ├── stats: [rows=1000, distinct(5)=700]
- │    │    │    ├── prune: (5,6)
- │    │    │    └── interesting orderings: ()
+ │    │    │    └── prune: (5,6)
  │    │    └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
  │    │         └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
  │    │              ├── variable: x [type=int, outer=(1)]
@@ -986,8 +957,7 @@ anti-join
  ├── scan uv
  │    ├── columns: u:2(int) v:3(int!null)
  │    ├── stats: [rows=1000, distinct(2)=700]
- │    ├── prune: (2,3)
- │    └── interesting orderings: ()
+ │    └── prune: (2,3)
  └── filters [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
       └── eq [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
            ├── variable: u [type=int, outer=(2)]
@@ -1004,7 +974,7 @@ anti-join-apply
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (2-4)
- ├── interesting orderings: (+1) (-3,+4,+1) ()
+ ├── interesting orderings: (+1) (-3,+4,+1)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── limit: 10
@@ -1020,19 +990,16 @@ anti-join-apply
  │    ├── stats: [rows=1.42857143]
  │    ├── fd: ()-->(5)
  │    ├── prune: (6)
- │    ├── interesting orderings: ()
  │    ├── select
  │    │    ├── columns: u:5(int!null) v:6(int!null)
  │    │    ├── outer: (1)
  │    │    ├── stats: [rows=1.42857143, distinct(1)=1, distinct(5)=1]
  │    │    ├── fd: ()-->(5)
  │    │    ├── prune: (6)
- │    │    ├── interesting orderings: ()
  │    │    ├── scan uv
  │    │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    │    ├── stats: [rows=1000, distinct(5)=700]
- │    │    │    ├── prune: (5,6)
- │    │    │    └── interesting orderings: ()
+ │    │    │    └── prune: (5,6)
  │    │    └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
  │    │         └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
  │    │              ├── variable: x [type=int, outer=(1)]

--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -207,8 +207,7 @@ project
  ├── fd: ()-->(5)
  ├── prune: (5)
  ├── scan xysd@secondary
- │    ├── stats: [rows=1000]
- │    └── interesting orderings: ()
+ │    └── stats: [rows=1000]
  └── projections
       └── const: 1 [type=int]
 

--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -96,8 +96,7 @@ SELECT d FROM a
 scan a@secondary
  ├── columns: d:4(decimal!null)
  ├── stats: [rows=1000]
- ├── prune: (4)
- └── interesting orderings: ()
+ └── prune: (4)
 
 exec-ddl
 CREATE TABLE t (

--- a/pkg/sql/opt/ordering.go
+++ b/pkg/sql/opt/ordering.go
@@ -162,6 +162,9 @@ func (os OrderingSet) Copy() OrderingSet {
 // Add an ordering to the list, checking whether it is a prefix of another
 // ordering (or vice-versa).
 func (os *OrderingSet) Add(o Ordering) {
+	if len(o) == 0 {
+		panic("empty ordering")
+	}
 	for i := range *os {
 		prefix := (*os)[i].CommonPrefix(o)
 		if len(prefix) == len(o) {

--- a/pkg/sql/opt/xform/interesting_orderings.go
+++ b/pkg/sql/opt/xform/interesting_orderings.go
@@ -71,16 +71,21 @@ func interestingOrderingsForScan(ev memo.ExprView) opt.OrderingSet {
 			continue
 		}
 		numIndexCols := index.KeyColumnCount()
-		o := make(opt.Ordering, 0, numIndexCols)
+		var o opt.Ordering
 		for j := 0; j < numIndexCols; j++ {
 			indexCol := index.Column(j)
 			colID := def.Table.ColumnID(indexCol.Ordinal)
 			if !def.Cols.Contains(int(colID)) {
 				break
 			}
+			if o == nil {
+				o = make(opt.Ordering, 0, numIndexCols)
+			}
 			o = append(o, opt.MakeOrderingColumn(colID, indexCol.Descending))
 		}
-		ord.Add(o)
+		if o != nil {
+			ord.Add(o)
+		}
 	}
 	return ord
 }


### PR DESCRIPTION
Fixing a case where we were adding empty interesting orderings.

Release note: None