### PR TITLE
opt: Improve performance of IndexJoin planning

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -103,8 +103,8 @@ func init() {
 }
 
 var profileTime = flag.Duration("profile-time", 10*time.Second, "duration of profiling run")
-var profileType = flag.String("profile-type", "ExecOpt", "Parse, OptBuild, Normalize, Explore, ExecPlan, ExecOpt")
-var profileQuery = flag.String("profile-query", "kv-test", "name of query to run")
+var profileType = flag.String("profile-type", "Explore", "Parse, OptBuild, Normalize, Explore, ExecPlan, ExecOpt")
+var profileQuery = flag.String("profile-query", "kv-read", "name of query to run")
 
 // TestCPUProfile executes the configured profileQuery in a loop in order to
 // profile its CPU usage. Rather than allow the Go testing infrastructure to

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -302,24 +302,22 @@ render            ·         ·              (a, c)     ·
 ·                 table     large@bc       ·          ·
 
 # Lookup join on non-covering secondary index
+# TODO(radu): index-join fixup needed
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.a, large.d FROM small JOIN large ON small.a = large.b
 ----
-render                 ·         ·              (a, d)        ·
- │                     render 0  a              ·             ·
- │                     render 1  d              ·             ·
- └── lookup-join       ·         ·              (a, a, b, d)  ·
-      │                type      inner          ·             ·
-      ├── lookup-join  ·         ·              (a, a, b)     ·
-      │    │           type      inner          ·             ·
-      │    │           pred      @1 = @3        ·             ·
-      │    ├── scan    ·         ·              (a)           ·
-      │    │           table     small@primary  ·             ·
-      │    │           spans     ALL            ·             ·
-      │    └── scan    ·         ·              (a, b)        ·
-      │                table     large@bc       ·             ·
-      └── scan         ·         ·              (d)           ·
-·                      table     large@primary  ·             ·
+render          ·         ·              (a, d)     ·
+ │              render 0  a              ·          ·
+ │              render 1  d              ·          ·
+ └── join       ·         ·              (b, d, a)  ·
+      │         type      inner          ·          ·
+      │         equality  (b) = (a)      ·          ·
+      ├── scan  ·         ·              (b, d)     ·
+      │         table     large@primary  ·          ·
+      │         spans     ALL            ·          ·
+      └── scan  ·         ·              (a)        ·
+·               table     small@primary  ·          ·
+·               spans     ALL            ·          ·
 
 ############################
 #  LEFT OUTER LOOKUP JOIN  #
@@ -355,24 +353,22 @@ render            ·         ·              (c, c)     ·
 ·                 table     large@bc       ·          ·
 
 # Left join against non-covering secondary index
+# TODO(radu): index-join fixup needed
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.c, large.d FROM small LEFT JOIN large ON small.c = large.b
 ----
-render                 ·         ·              (c, d)        ·
- │                     render 0  c              ·             ·
- │                     render 1  d              ·             ·
- └── lookup-join       ·         ·              (c, a, b, d)  ·
-      │                type      left outer     ·             ·
-      ├── lookup-join  ·         ·              (c, a, b)     ·
-      │    │           type      left outer     ·             ·
-      │    │           pred      @1 = @3        ·             ·
-      │    ├── scan    ·         ·              (c)           ·
-      │    │           table     small@primary  ·             ·
-      │    │           spans     ALL            ·             ·
-      │    └── scan    ·         ·              (a, b)        ·
-      │                table     large@bc       ·             ·
-      └── scan         ·         ·              (d)           ·
-·                      table     large@primary  ·             ·
+render          ·         ·              (c, d)     ·
+ │              render 0  c              ·          ·
+ │              render 1  d              ·          ·
+ └── join       ·         ·              (b, d, c)  ·
+      │         type      right outer    ·          ·
+      │         equality  (b) = (c)      ·          ·
+      ├── scan  ·         ·              (b, d)     ·
+      │         table     large@primary  ·          ·
+      │         spans     ALL            ·          ·
+      └── scan  ·         ·              (c)        ·
+·               table     small@primary  ·          ·
+·               spans     ALL            ·          ·
 
 # Left join with ON filter on covering index
 query TTTTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -769,6 +769,6 @@ filter           ·       ·                (x, y, z)              ·
  └── index-join  ·       ·                (x, y, z)              +x
       ├── scan   ·       ·                (y, z, rowid[hidden])  +y
       │          table   xyz@xyz_z_y_idx  ·                      ·
-      │          spans   /1-/2            ·                      ·
+      │          spans   /1/!NULL-/2      ·                      ·
       └── scan   ·       ·                (x, y, z)              ·
 ·                table   xyz@primary      ·                      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -133,10 +133,6 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION]
 fetched: /t/dc/'bar'/22/2/'two' -> NULL
 output row: [2 'two' 22 'bar']
 
-# The where-clause does not contain columns matching a prefix of any index.
-# Note that the index "bc" is chosen because the condition is estimated to be
-# very selective and the main cost is the scan (this index contains fewer
-# columns and this is deemed to offset the cost of the index join).
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE c = 22; SET tracing = off
 
@@ -144,13 +140,16 @@ query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
 ----
-fetched: /t/bc/'one'/11/1 -> NULL
-fetched: /t/bc/'three'/33/3 -> NULL
-fetched: /t/bc/'two'/22/2 -> NULL
+fetched: /t/primary/1/'one' -> NULL
+fetched: /t/primary/1/'one'/c -> 11
+fetched: /t/primary/1/'one'/d -> 'foo'
 fetched: /t/primary/2/'two' -> NULL
 fetched: /t/primary/2/'two'/c -> 22
 fetched: /t/primary/2/'two'/d -> 'bar'
 output row: [2 'two' 22 'bar']
+fetched: /t/primary/3/'three' -> NULL
+fetched: /t/primary/3/'three'/c -> 33
+fetched: /t/primary/3/'three'/d -> 'blah'
 
 # Use the descending index
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
@@ -34,24 +34,26 @@ scan  ·      ·
 query TTT
 EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
-index-join  ·      ·
- ├── scan   ·      ·
- │          table  abcd@b
- │          spans  ALL
- └── scan   ·      ·
-·           table  abcd@primary
+filter           ·      ·
+ └── index-join  ·      ·
+      ├── scan   ·      ·
+      │          table  abcd@b
+      │          spans  ALL
+      └── scan   ·      ·
+·                table  abcd@primary
 
 # Force index cd
 
 query TTT
 EXPLAIN SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 ----
-index-join  ·      ·
- ├── scan   ·      ·
- │          table  abcd@cd
- │          spans  ALL
- └── scan   ·      ·
-·           table  abcd@primary
+filter           ·      ·
+ └── index-join  ·      ·
+      ├── scan   ·      ·
+      │          table  abcd@cd
+      │          spans  ALL
+      └── scan   ·      ·
+·                table  abcd@primary
 
 # Force index bcd
 
@@ -120,12 +122,13 @@ filter           ·      ·
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b} WHERE a >= 20 AND a <= 30
 ----
-index-join  ·      ·
- ├── scan   ·      ·
- │          table  abcd@b
- │          spans  ALL
- └── scan   ·      ·
-·           table  abcd@primary
+filter           ·      ·
+ └── index-join  ·      ·
+      ├── scan   ·      ·
+      │          table  abcd@b
+      │          spans  ALL
+      └── scan   ·      ·
+·                table  abcd@primary
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -943,9 +943,9 @@ func (c *indexConstraintCtx) simplifyFilter(
 ) memo.GroupID {
 	// Special handling for AND and OR.
 	if ev.Operator() == opt.OrOp || ev.Operator() == opt.AndOp || ev.Operator() == opt.FiltersOp {
-		newChildren := make([]memo.GroupID, ev.ChildCount())
-		for i := range newChildren {
-			newChildren[i] = c.simplifyFilter(ev.Child(i), final, maxSimplifyPrefix)
+		lb := norm.MakeListBuilder(c.factory.CustomFuncs())
+		for i, cnt := 0, ev.ChildCount(); i < cnt; i++ {
+			lb.AddItem(c.simplifyFilter(ev.Child(i), final, maxSimplifyPrefix))
 		}
 
 		// Note: if nothing changed, the factory will detect that it's the same
@@ -953,11 +953,11 @@ func (c *indexConstraintCtx) simplifyFilter(
 		// the node (e.g. if children have been simplified to True).
 		switch ev.Operator() {
 		case opt.AndOp:
-			return c.factory.ConstructAnd(c.factory.InternList(newChildren))
+			return c.factory.ConstructAnd(lb.BuildList())
 		case opt.FiltersOp:
-			return c.factory.ConstructFilters(c.factory.InternList(newChildren))
+			return c.factory.ConstructFilters(lb.BuildList())
 		case opt.OrOp:
-			return c.factory.ConstructOr(c.factory.InternList(newChildren))
+			return c.factory.ConstructOr(lb.BuildList())
 		}
 	}
 

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -252,6 +252,12 @@ func (m *Memo) NormExpr(group GroupID) *Expr {
 	return m.groups[group].expr(normExprOrdinal)
 }
 
+// NormOp returns the operator type of NormExpr. See that method's comment for
+// more details.
+func (m *Memo) NormOp(group GroupID) opt.Operator {
+	return m.groups[group].expr(normExprOrdinal).op
+}
+
 // MemoizeNormExpr enters a normalized expression into the memo. This requires
 // the creation of a new memo group with the normalized expression as its first
 // expression. If the expression is already part of an existing memo group, then

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -148,7 +148,7 @@ func New() *Memo {
 	// for lists are all reserved.
 	m := &Memo{
 		exprMap: make(map[Fingerprint]GroupID),
-		groups:  make([]group, 1, 8),
+		groups:  make([]group, 1, 12),
 	}
 
 	m.privateStorage.init()

--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -89,6 +89,20 @@ scan a
  ├── prune: (3)
  └── interesting orderings: (+1) (-3)
 
+# Test limited scan with 1 row.
+opt
+SELECT s, x FROM a WHERE x > 1 LIMIT 1
+----
+scan a
+ ├── columns: s:3(string) x:1(int!null)
+ ├── constraint: /1: [/2 - ]
+ ├── limit: 1
+ ├── stats: [rows=1]
+ ├── key: ()
+ ├── fd: ()-->(1,3)
+ ├── prune: (3)
+ └── interesting orderings: (+1) (-3)
+
 # Test case where there are no weak keys available.
 opt
 SELECT d FROM a

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -73,7 +73,7 @@ func (c *CustomFuncs) ListOnlyHasNulls(list memo.ListID) bool {
 	}
 
 	for _, item := range c.mem.LookupList(list) {
-		if c.mem.NormExpr(item).Operator() != opt.NullOp {
+		if c.mem.NormOp(item) != opt.NullOp {
 			return false
 		}
 	}
@@ -224,7 +224,7 @@ func (c *CustomFuncs) CanConstructBinary(op opt.Operator, left, right memo.Group
 
 // Operator returns the type of the given group's normalized expression.
 func (c *CustomFuncs) Operator(group memo.GroupID) opt.Operator {
-	return c.mem.NormExpr(group).Operator()
+	return c.mem.NormOp(group)
 }
 
 // LookupLogical returns the given group's logical properties.
@@ -566,7 +566,7 @@ func (c *CustomFuncs) ConcatFilters(left, right memo.GroupID) memo.GroupID {
 // IsContradiction returns true if the given operation is False or a Filter with
 // a contradiction constraint.
 func (c *CustomFuncs) IsContradiction(filter memo.GroupID) bool {
-	if c.mem.NormExpr(filter).Operator() == opt.FalseOp {
+	if c.mem.NormOp(filter) == opt.FalseOp {
 		return true
 	}
 	return c.LookupLogical(filter).Scalar.Constraints == constraint.Contradiction

--- a/pkg/sql/opt/norm/decorrelate.go
+++ b/pkg/sql/opt/norm/decorrelate.go
@@ -360,7 +360,7 @@ func (c *CustomFuncs) EnsureCanaryCol(in, aggs memo.GroupID) opt.ColumnID {
 	aggsElems := c.f.mem.LookupList(aggsExpr.Aggs())
 
 	for _, elem := range aggsElems {
-		if !opt.AggregateIgnoresNulls(c.f.mem.NormExpr(elem).Operator()) {
+		if !opt.AggregateIgnoresNulls(c.f.mem.NormOp(elem)) {
 			// Look for an existing not null column that is not projected by a
 			// passthrough aggregate like ConstAgg.
 			id, ok := c.LookupLogical(in).Relational.NotNullCols.Next(0)

--- a/pkg/sql/opt/norm/join.go
+++ b/pkg/sql/opt/norm/join.go
@@ -382,7 +382,7 @@ func (c *CustomFuncs) deriveUnfilteredCols(group memo.GroupID) opt.ColSet {
 		on := expr.ChildGroup(c.f.mem, 2)
 
 		// Cross join always preserves left/right rows.
-		isCrossJoin := c.f.mem.NormExpr(on).Operator() == opt.TrueOp
+		isCrossJoin := c.f.mem.NormOp(on) == opt.TrueOp
 
 		// Inner joins may preserve left/right rows, according to
 		// JoinFiltersMatchAllLeftRows conditions.

--- a/pkg/sql/opt/norm/list_builder.go
+++ b/pkg/sql/opt/norm/list_builder.go
@@ -80,10 +80,15 @@ func (b *ListBuilder) ensureItems() {
 	// Try to reuse scratch list stored in factory.
 	if b.items == nil {
 		b.items = b.cf.scratchItems
-		b.items = b.items[:0]
+		if b.items == nil {
+			// Start with 8 slots to prevent unnecessary resizing.
+			b.items = make([]memo.GroupID, 0, 8)
+		} else {
+			b.items = b.items[:0]
 
-		// Set the factory scratch list to nil so that recursive calls won't try
-		// to use it when it's already in use.
-		b.cf.scratchItems = nil
+			// Set the factory scratch list to nil so that recursive calls won't try
+			// to use it when it's already in use.
+			b.cf.scratchItems = nil
+		}
 	}
 }

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -280,35 +280,11 @@ PruneJoinRightCols
          └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
               └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 --------------------------------------------------------------------------------
-GenerateIndexScans (higher cost)
+GenerateIndexScans (no changes)
 --------------------------------------------------------------------------------
-   project
-    ├── columns: s:4(string)
-    └── inner-join
-         ├── columns: k:1(int!null) i:2(int!null) s:4(string) x:6(int!null)
-         ├── key: (6)
-         ├── fd: (1)-->(2,4), (1)==(6), (6)==(1)
-         ├── select
-         │    ├── columns: k:1(int!null) i:2(int!null) s:4(string)
-         │    ├── key: (1)
-         │    ├── fd: (1)-->(2,4)
-  -      │    ├── scan a
-  +      │    ├── index-join a
-         │    │    ├── columns: k:1(int!null) i:2(int) s:4(string)
-         │    │    ├── key: (1)
-  -      │    │    └── fd: (1)-->(2,4)
-  +      │    │    ├── fd: (1)-->(2,4)
-  +      │    │    └── scan a@secondary
-  +      │    │         ├── columns: k:1(int!null) s:4(string)
-  +      │    │         ├── key: (1)
-  +      │    │         └── fd: (1)-->(4)
-         │    └── filters [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
-         │         └── i = (10 - 1) [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
-         ├── scan xy
-         │    ├── columns: x:6(int!null)
-         │    └── key: (6)
-         └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-              └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+--------------------------------------------------------------------------------
+GenerateConstrainedScans (no changes)
+--------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 GenerateIndexScans (no changes)
 --------------------------------------------------------------------------------
@@ -573,7 +549,7 @@ GenerateIndexScans
               ├── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
               └── f > 100.0 [type=bool, outer=(3), constraints=(/3: [/100.00000000000001 - ]; tight)]
 ================================================================================
-ConstrainScan
+GenerateConstrainedScans
   Cost: 1.55
 ================================================================================
    project
@@ -826,28 +802,8 @@ EliminateSelect
   + └── filters [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
   +      └── y = i [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
 --------------------------------------------------------------------------------
-GenerateIndexScans (higher cost)
+GenerateIndexScans (no changes)
 --------------------------------------------------------------------------------
-   semi-join
-    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
-    ├── key: (1)
-    ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
-  - ├── scan a
-  + ├── index-join a
-    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
-    │    ├── key: (1)
-  - │    └── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
-  + │    ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
-  + │    └── scan a@secondary
-  + │         ├── columns: k:1(int!null) f:3(float) s:4(string) j:5(jsonb)
-  + │         ├── key: (1)
-  + │         └── fd: (1)-->(3-5), (3,4)~~>(1,5)
-    ├── scan xy
-    │    ├── columns: x:6(int!null) y:7(int)
-    │    ├── key: (6)
-    │    └── fd: (6)-->(7)
-    └── filters [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
-         └── y = i [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
 --------------------------------------------------------------------------------
 GenerateIndexScans (no changes)
 --------------------------------------------------------------------------------

--- a/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
@@ -809,7 +809,7 @@ func (g *ruleGen) genConstruct(construct *lang.FuncExpr) {
 		// Construct expression based on dynamic type of referenced op.
 		ref := t.Args[0].(*lang.RefExpr)
 		g.w.nest("%s.DynamicConstruct(\n", g.factoryVar)
-		g.w.writeIndent("%s.mem.NormExpr(%s).Operator(),\n", g.thisVar, ref.Label)
+		g.w.writeIndent("%s.mem.NormOp(%s),\n", g.thisVar, ref.Label)
 		g.w.nestIndent("memo.DynamicOperands{\n")
 		for _, arg := range construct.Args {
 			g.w.writeIndent("memo.DynamicID(")

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
@@ -631,7 +631,7 @@ func (_f *Factory) ConstructSelect(
 					u := _expr2.ChildGroup(_f.mem, 1)
 					if _f.matchedRule == nil || _f.matchedRule(opt.Test) {
 						_group = _f.DynamicConstruct(
-							_f.mem.NormExpr(item).Operator(),
+							_f.mem.NormOp(item),
 							memo.DynamicOperands{
 								memo.DynamicID(_f.ConstructSelect(
 									t,
@@ -844,7 +844,7 @@ func (_f *Factory) ConstructSelect(
 			if _f.funcs.True() {
 				if _f.matchedRule == nil || _f.matchedRule(opt.Test) {
 					_group = _f.DynamicConstruct(
-						_f.mem.NormExpr(input).Operator(),
+						_f.mem.NormOp(input),
 						memo.DynamicOperands{
 							memo.DynamicID(expr1),
 							memo.DynamicID(expr2),

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -16,6 +16,7 @@ package xform
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/idxconstraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
@@ -46,181 +47,70 @@ func (c *CustomFuncs) Init(e *explorer) {
 //
 // ----------------------------------------------------------------------
 
-// CanGenerateIndexScans returns true if new index Scan operators can be
-// generated, based on the given ScanOpDef. Index scans should only be generated
-// from the original unaltered primary index Scan operator (i.e. unconstrained
-// and not limited).
-func (c *CustomFuncs) CanGenerateIndexScans(def memo.PrivateID) bool {
+// IsCanonicalScan returns true if the given ScanOpDef is an original unaltered
+// primary index Scan operator (i.e. unconstrained and not limited).
+func (c *CustomFuncs) IsCanonicalScan(def memo.PrivateID) bool {
 	scanOpDef := c.e.mem.LookupPrivate(def).(*memo.ScanOpDef)
 	return scanOpDef.Index == opt.PrimaryIndex &&
 		scanOpDef.Constraint == nil &&
 		scanOpDef.HardLimit == 0
 }
 
-// CanGenerateInvertedIndexScans returns true if new index Scan operators can
-// be generated on inverted indexes. Same as CanGenerateIndexScans, but with
-// the additional check that we have at least one inverted index on the table.
-func (c *CustomFuncs) CanGenerateInvertedIndexScans(def memo.PrivateID) bool {
-	if !c.CanGenerateIndexScans(def) {
-		return false
-	}
-
-	// Don't bother matching unless there's an inverted index.
-	scanOpDef := c.e.mem.LookupPrivate(def).(*memo.ScanOpDef)
-	md := c.e.mem.Metadata()
-	tab := md.Table(scanOpDef.Table)
-	// Index 0 is the primary index and is never inverted.
-	for i, n := 1, tab.IndexCount(); i < n; i++ {
-		if tab.Index(i).IsInverted() {
-			return true
-		}
-	}
-	return false
-}
-
-// GenerateIndexScans enumerates all indexes on the scan operator's table and
-// generates an alternate scan operator for each index that includes the set of
-// needed columns.
+// GenerateIndexScans enumerates all secondary indexes on the given Scan
+// operator's table and generates an alternate Scan operator for each index that
+// includes the set of needed columns specified in the ScanOpDef.
+//
+// NOTE: This does not generate index joins for non-covering indexes (except in
+//       case of ForceIndex). Index joins are usually only introduced "one level
+//       up", when the Scan operator is wrapped by an operator that constrains
+//       or limits scan output in some way (e.g. Select, Limit, InnerJoin).
+//       Index joins are only lower cost when their input does not include all
+//       rows from the table. See ConstrainScans and LimitScans for cases where
+//       index joins are introduced into the memo.
 func (c *CustomFuncs) GenerateIndexScans(def memo.PrivateID) []memo.Expr {
 	c.e.exprs = c.e.exprs[:0]
 	scanOpDef := c.e.mem.LookupPrivate(def).(*memo.ScanOpDef)
-	md := c.e.mem.Metadata()
-	tab := md.Table(scanOpDef.Table)
 
-	// Iterate over all secondary indexes (index 0 is the primary index).
-	var pkCols opt.ColList
-	for i := 1; i < tab.IndexCount(); i++ {
-		if tab.Index(i).IsInverted() {
-			// Ignore inverted indexes.
-			continue
-		}
-		if scanOpDef.Flags.ForceIndex && scanOpDef.Flags.Index != i {
-			// If we are forcing a specific index, don't bother with the others.
+	// Iterate over all secondary indexes.
+	var iter scanIndexIter
+	iter.init(c.e.mem, scanOpDef)
+	for iter.next() {
+		// Skip primary index.
+		if iter.index == opt.PrimaryIndex {
 			continue
 		}
 
-		indexCols := md.IndexColumns(scanOpDef.Table, i)
-
-		// If the alternate index includes the set of needed columns (def.Cols),
-		// then construct a new Scan operator using that index.
-		if scanOpDef.Cols.SubsetOf(indexCols) {
+		// If the secondary index includes the set of needed columns, then construct
+		// a new Scan operator using that index.
+		if iter.isCovering() {
 			newDef := *scanOpDef
-			newDef.Index = i
+			newDef.Index = iter.index
 			indexScan := memo.MakeScanExpr(c.e.mem.InternScanOpDef(&newDef))
 			c.e.exprs = append(c.e.exprs, memo.Expr(indexScan))
-		} else if !scanOpDef.Flags.NoIndexJoin {
-			// The alternate index was missing columns, so in order to satisfy the
-			// requirements, we need to perform an index join with the primary index.
-			if pkCols == nil {
-				primaryIndex := md.Table(scanOpDef.Table).Index(opt.PrimaryIndex)
-				pkCols = make(opt.ColList, primaryIndex.KeyColumnCount())
-				for i := range pkCols {
-					pkCols[i] = scanOpDef.Table.ColumnID(primaryIndex.Column(i).Ordinal)
-				}
-			}
-
-			// We scan whatever columns we need which are available from the index,
-			// plus the PK columns. The main reason is to allow pushing of filters as
-			// much as possible.
-			scanCols := indexCols.Intersection(scanOpDef.Cols)
-			for _, c := range pkCols {
-				scanCols.Add(int(c))
-			}
-
-			indexScanOpDef := memo.ScanOpDef{
-				Table: scanOpDef.Table,
-				Index: i,
-				Cols:  scanCols,
-				Flags: scanOpDef.Flags,
-			}
-
-			input := c.e.f.ConstructScan(c.e.mem.InternScanOpDef(&indexScanOpDef))
-
-			def := memo.IndexJoinDef{
-				Table: scanOpDef.Table,
-				Cols:  scanOpDef.Cols,
-			}
-
-			private := c.e.mem.InternIndexJoinDef(&def)
-			indexJoin := memo.MakeIndexJoinExpr(input, private)
-			c.e.exprs = append(c.e.exprs, memo.Expr(indexJoin))
-		}
-	}
-
-	return c.e.exprs
-}
-
-// GenerateInvertedIndexScans enumerates all inverted indexes on the scan
-// operator's table and generates a scan for each inverted index that can
-// service the query.
-// The resulting scan operator is pre-constrained and may come with an index join.
-// The reason it's pre-constrained is that we cannot treat an inverted index in
-// the same way as a regular index, since it does not actually contain the
-// indexed column.
-func (c *CustomFuncs) GenerateInvertedIndexScans(
-	def memo.PrivateID, filter memo.GroupID,
-) []memo.Expr {
-	c.e.exprs = c.e.exprs[:0]
-	scanOpDef := c.e.mem.LookupPrivate(def).(*memo.ScanOpDef)
-	md := c.e.mem.Metadata()
-	tab := md.Table(scanOpDef.Table)
-
-	primaryIndex := md.Table(scanOpDef.Table).Index(opt.PrimaryIndex)
-	var pkColSet opt.ColSet
-	for i := 0; i < primaryIndex.KeyColumnCount(); i++ {
-		pkColSet.Add(int(scanOpDef.Table.ColumnID(primaryIndex.Column(i).Ordinal)))
-	}
-
-	// Iterate over all inverted indexes (index 0 is the primary index and is
-	// never inverted).
-	for i := 1; i < tab.IndexCount(); i++ {
-		if !tab.Index(i).IsInverted() {
-			continue
-		}
-		if scanOpDef.Flags.ForceIndex && scanOpDef.Flags.Index != i {
-			// If we are forcing a specific index, ignore the others.
 			continue
 		}
 
-		preDef := &memo.ScanOpDef{
-			Table: scanOpDef.Table,
-			Index: i,
-			// Though the index is marked as containing the JSONB column being
-			// indexed, it doesn't actually, and it's only valid to extract the
-			// primary key columns from it.
-			Cols:  pkColSet,
-			Flags: scanOpDef.Flags,
-		}
-
-		constrainedScan, remainingFilter, ok := c.constrainedScanOpDef(filter, c.e.mem.InternScanOpDef(preDef), true /* isInverted */)
-		if !ok {
+		// Otherwise, if the index must be forced, then construct an IndexJoin
+		// operator that provides the columns missing from the index. Note that
+		// if ForceIndex=true, scanIndexIter only returns the one index that is
+		// being forced, so no need to check that here.
+		if !scanOpDef.Flags.ForceIndex {
 			continue
 		}
 
-		// TODO(justin): We might not need to do an index join in order to get the
-		// correct columns, but it's difficult to tell at this point.
-		def := c.e.mem.InternIndexJoinDef(&memo.IndexJoinDef{
-			Table: scanOpDef.Table,
-			Cols:  scanOpDef.Cols,
-		})
-		scan := c.e.f.ConstructScan(c.e.mem.InternScanOpDef(&constrainedScan))
+		var sb indexScanBuilder
+		sb.init(c, scanOpDef.Table)
 
-		if c.e.mem.NormOp(remainingFilter) == opt.TrueOp {
-			c.e.exprs = append(
-				c.e.exprs,
-				memo.Expr(memo.MakeIndexJoinExpr(scan, def)),
-			)
-		} else {
-			c.e.exprs = append(
-				c.e.exprs,
-				memo.Expr(
-					memo.MakeSelectExpr(
-						c.e.f.ConstructIndexJoin(scan, def),
-						remainingFilter,
-					),
-				),
-			)
-		}
+		// Scan whatever columns we need which are available from the index, plus
+		// the PK columns.
+		newDef := *scanOpDef
+		newDef.Index = iter.index
+		newDef.Cols = iter.indexCols().Intersection(scanOpDef.Cols)
+		newDef.Cols.UnionWith(sb.primaryKeyCols())
+		sb.setScan(c.e.f.InternScanOpDef(&newDef))
+
+		sb.addIndexJoin(scanOpDef.Cols)
+		c.e.exprs = append(c.e.exprs, sb.build())
 	}
 
 	return c.e.exprs
@@ -233,26 +123,265 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 //
 // ----------------------------------------------------------------------
 
-// CanConstrainScan returns true if the scan could potentially have a constraint
-// applied to it from the given filter. This is only allowed when the scan
-//  - does not already have constraints, and
-//  - does not have a limit (which applies pre-filter).
-// The function also makes some fast checks on the filter and returns false if
-// it detects that the filter will not result in any index constraints.
-func (c *CustomFuncs) CanConstrainScan(def memo.PrivateID, filter memo.GroupID) bool {
-	scanOpDef := c.e.mem.LookupPrivate(def).(*memo.ScanOpDef)
-	if scanOpDef.Constraint != nil || scanOpDef.HardLimit != 0 {
-		return false
+// GenerateConstrainedScans enumerates all secondary indexes on the Scan
+// operator's table and tries to push the given Select filter into new
+// constrained Scan operators using those indexes. Since this only needs to be
+// done once per table, GenerateConstrainedScans should only be called on the
+// original unaltered primary index Scan operator (i.e. not constrained or
+// limited).
+//
+// For each secondary index that "covers" the columns needed by the scan, there
+// are three cases:
+//
+//  - a filter that can be completely converted to a constraint over that index
+//    generates a single constrained Scan operator (to be added to the same
+//    group as the original Select operator):
+//
+//      (Scan $scanDef)
+//
+//  - a filter that can be partially converted to a constraint over that index
+//    generates a constrained Scan operator in a new memo group, wrapped in a
+//    Select operator having the remaining filter (to be added to the same group
+//    as the original Select operator):
+//
+//      (Select (Scan $scanDef) $filter)
+//
+//  - a filter that cannot be converted to a constraint generates nothing
+//
+// And for a secondary index that does not cover the needed columns:
+//
+//  - a filter that can be completely converted to a constraint over that index
+//    generates a single constrained Scan operator in a new memo group, wrapped
+//    in an IndexJoin operator that looks up the remaining needed columns (and
+//    is added to the same group as the original Select operator)
+//
+//      (IndexJoin (Scan $scanDef) $indexJoinDef)
+//
+//  - a filter that can be partially converted to a constraint over that index
+//    generates a constrained Scan operator in a new memo group, wrapped in an
+//    IndexJoin operator that looks up the remaining needed columns; the
+//    remaining filter is distributed above and/or below the IndexJoin,
+//    depending on which columns it references:
+//
+//      (IndexJoin
+//        (Select (Scan $scanDef) $filter)
+//        $indexJoinDef
+//      )
+//
+//      (Select
+//        (IndexJoin (Scan $scanDef) $indexJoinDef)
+//        $filter
+//      )
+//
+//      (Select
+//        (IndexJoin
+//          (Select (Scan $scanDef) $innerFilter)
+//          $indexJoinDef
+//        )
+//        $outerFilter
+//      )
+//
+func (c *CustomFuncs) GenerateConstrainedScans(
+	scanDef memo.PrivateID, filter memo.GroupID,
+) []memo.Expr {
+	c.e.exprs = c.e.exprs[:0]
+	scanOpDef := c.e.mem.LookupPrivate(scanDef).(*memo.ScanOpDef)
+
+	var sb indexScanBuilder
+	sb.init(c, scanOpDef.Table)
+
+	// Iterate over all indexes.
+	var iter scanIndexIter
+	iter.init(c.e.mem, scanOpDef)
+	for iter.next() {
+		// Check whether the filter can constrain the index.
+		constraint, remaining, ok := c.tryConstrainIndex(
+			filter, scanOpDef.Table, iter.index, false /* isInverted */)
+		if !ok {
+			continue
+		}
+
+		// Construct new constrained ScanOpDef.
+		newDef := *scanOpDef
+		newDef.Index = iter.index
+		newDef.Constraint = constraint
+
+		// If the alternate index includes the set of needed columns, then construct
+		// a new Scan operator using that index.
+		if iter.isCovering() {
+			sb.setScan(c.e.f.InternScanOpDef(&newDef))
+
+			// If there is a remaining filter, then the constrained Scan operator
+			// will be created in a new group, and a Select operator will be added
+			// to the same group as the original operator.
+			sb.addSelect(remaining)
+			c.e.exprs = append(c.e.exprs, sb.build())
+			continue
+		}
+
+		// Otherwise, construct an IndexJoin operator that provides the columns
+		// missing from the index.
+		if scanOpDef.Flags.NoIndexJoin {
+			continue
+		}
+
+		// Scan whatever columns we need which are available from the index, plus
+		// the PK columns.
+		newDef.Cols = iter.indexCols().Intersection(scanOpDef.Cols)
+		newDef.Cols.UnionWith(sb.primaryKeyCols())
+		sb.setScan(c.e.f.InternScanOpDef(&newDef))
+
+		// If remaining filter exists, split it into one part that can be pushed
+		// below the IndexJoin, and one part that needs to stay above.
+		remaining = sb.addSelectAfterSplit(remaining, newDef.Cols)
+		sb.addIndexJoin(scanOpDef.Cols)
+		sb.addSelect(remaining)
+
+		c.e.exprs = append(c.e.exprs, sb.build())
 	}
+
+	return c.e.exprs
+}
+
+// HasInvertedIndexes returns true if at least one inverted index is defined on
+// the Scan operator's table.
+func (c *CustomFuncs) HasInvertedIndexes(def memo.PrivateID) bool {
+	// Don't bother matching unless there's an inverted index.
+	scanOpDef := c.e.mem.LookupPrivate(def).(*memo.ScanOpDef)
+	var iter scanIndexIter
+	iter.init(c.e.mem, scanOpDef)
+	return iter.nextInverted()
+}
+
+// GenerateInvertedIndexScans enumerates all inverted indexes on the Scan
+// operator's table and generates an alternate Scan operator for each inverted
+// index that can service the query.
+//
+// The resulting Scan operator is pre-constrained and requires an IndexJoin to
+// project columns other than the primary key columns. The reason it's pre-
+// constrained is that we cannot treat an inverted index in the same way as a
+// regular index, since it does not actually contain the indexed column.
+func (c *CustomFuncs) GenerateInvertedIndexScans(
+	def memo.PrivateID, filter memo.GroupID,
+) []memo.Expr {
+	c.e.exprs = c.e.exprs[:0]
+	scanOpDef := c.e.mem.LookupPrivate(def).(*memo.ScanOpDef)
+
+	var sb indexScanBuilder
+	sb.init(c, scanOpDef.Table)
+
+	// Iterate over all inverted indexes.
+	var iter scanIndexIter
+	iter.init(c.e.mem, scanOpDef)
+	for iter.nextInverted() {
+		// Check whether the filter can constrain the index.
+		constraint, remaining, ok := c.tryConstrainIndex(
+			filter, scanOpDef.Table, iter.index, true /* isInverted */)
+		if !ok {
+			continue
+		}
+
+		// Construct new ScanOpDef with the new index and constraint.
+		newDef := *scanOpDef
+		newDef.Index = iter.index
+		newDef.Constraint = constraint
+
+		// Though the index is marked as containing the JSONB column being
+		// indexed, it doesn't actually, and it's only valid to extract the
+		// primary key columns from it.
+		newDef.Cols = sb.primaryKeyCols()
+
+		// The Scan operator always goes in a new group, since it's always nested
+		// underneath the IndexJoin. The IndexJoin may also go into its own group,
+		// if there's a remaining filter above it.
+		// TODO(justin): We might not need to do an index join in order to get the
+		// correct columns, but it's difficult to tell at this point.
+		sb.setScan(c.e.mem.InternScanOpDef(&newDef))
+
+		// If remaining filter exists, split it into one part that can be pushed
+		// below the IndexJoin, and one part that needs to stay above.
+		remaining = sb.addSelectAfterSplit(remaining, newDef.Cols)
+		sb.addIndexJoin(scanOpDef.Cols)
+		sb.addSelect(remaining)
+
+		c.e.exprs = append(c.e.exprs, sb.build())
+	}
+
+	return c.e.exprs
+}
+
+// tryConstrainIndex tries to derive a constraint for the given index from the
+// specified filter. If a constraint is derived, it is returned along with any
+// filter remaining after extracting the constraint. If no constraint can be
+// derived, then tryConstrainIndex returns ok = false.
+func (c *CustomFuncs) tryConstrainIndex(
+	filter memo.GroupID, tabID opt.TableID, indexOrd int, isInverted bool,
+) (constraint *constraint.Constraint, remainingFilter memo.GroupID, ok bool) {
+	// Start with fast check to rule out indexes that cannot be constrained.
+	if !isInverted && !c.canMaybeConstrainIndex(filter, tabID, indexOrd) {
+		return nil, 0, false
+	}
+
+	// Fill out data structures needed to initialize the idxconstraint library.
+	// Use LaxKeyColumnCount, since all columns <= LaxKeyColumnCount are
+	// guaranteed to be part of each row's key (i.e. not stored in row's value,
+	// which does not take part in an index scan). Note that the OrderingColumn
+	// slice cannot be reused, as Instance.Init can use it in the constraint.
 	md := c.e.mem.Metadata()
-	index := md.Table(scanOpDef.Table).Index(scanOpDef.Index)
-	firstIndexCol := scanOpDef.Table.ColumnID(index.Column(0).Ordinal)
+	index := md.Table(tabID).Index(indexOrd)
+	columns := make([]opt.OrderingColumn, index.LaxKeyColumnCount())
+	var notNullCols opt.ColSet
+	for i := range columns {
+		col := index.Column(i)
+		colID := tabID.ColumnID(col.Ordinal)
+		columns[i] = opt.MakeOrderingColumn(colID, col.Descending)
+		if !col.Column.IsNullable() {
+			notNullCols.Add(int(colID))
+		}
+	}
+
+	// Generate index constraints.
+	var ic idxconstraint.Instance
+	ev := memo.MakeNormExprView(c.e.mem, filter)
+	ic.Init(ev, columns, notNullCols, isInverted, c.e.evalCtx, c.e.f)
+	constraint = ic.Constraint()
+	if constraint.IsUnconstrained() {
+		return nil, 0, false
+	}
+
+	// Return 0 if no remaining filter.
+	remaining := ic.RemainingFilter()
+	if c.e.mem.NormOp(remaining) == opt.TrueOp {
+		remaining = 0
+	}
+
+	// Make copy of constraint so that idxconstraint instance is not referenced.
+	copy := *constraint
+	return &copy, remaining, true
+}
+
+// canMaybeConstrainIndex performs two checks that can quickly rule out the
+// possibility that the given index can be constrained by the specified filter:
+//
+//   1. If the filter does not reference the first index column, then no
+//      constraint can be generated.
+//   2. If none of the filter's constraints start with the first index column,
+//      then no constraint can be generated.
+//
+func (c *CustomFuncs) canMaybeConstrainIndex(
+	filter memo.GroupID, tabID opt.TableID, indexOrd int,
+) bool {
+	md := c.e.mem.Metadata()
+	index := md.Table(tabID).Index(indexOrd)
+
 	// If the filter does not involve the first index column, we won't be able to
 	// generate a constraint.
+	firstIndexCol := tabID.ColumnID(index.Column(0).Ordinal)
 	filterProps := c.LookupLogical(filter).Scalar
 	if !filterProps.OuterCols.Contains(int(firstIndexCol)) {
 		return false
 	}
+
 	// If the constraints are tight, check if there is a constraint that starts
 	// with the first index column. If the constraints are not tight, it's
 	// possible that index constraints can still be generated (that code currently
@@ -271,130 +400,6 @@ func (c *CustomFuncs) CanConstrainScan(def memo.PrivateID, filter memo.GroupID) 
 	return true
 }
 
-// constrainedScanOpDef tries to push a filter into a scanOpDef as a
-// constraint. If it cannot push the filter down (i.e. the resulting constraint
-// is unconstrained), then it returns ok = false in the third return value.
-func (c *CustomFuncs) constrainedScanOpDef(
-	filterGroup memo.GroupID, scanDef memo.PrivateID, isInverted bool,
-) (newDef memo.ScanOpDef, remainingFilter memo.GroupID, ok bool) {
-	scanOpDef := c.e.mem.LookupPrivate(scanDef).(*memo.ScanOpDef)
-
-	// Fill out data structures needed to initialize the idxconstraint library.
-	// Use LaxKeyColumnCount, since all columns <= LaxKeyColumnCount are
-	// guaranteed to be part of each row's key (i.e. not stored in row's value,
-	// which does not take part in an index scan).
-	md := c.e.mem.Metadata()
-	index := md.Table(scanOpDef.Table).Index(scanOpDef.Index)
-	columns := make([]opt.OrderingColumn, index.LaxKeyColumnCount())
-	var notNullCols opt.ColSet
-	for i := range columns {
-		col := index.Column(i)
-		colID := scanOpDef.Table.ColumnID(col.Ordinal)
-		columns[i] = opt.MakeOrderingColumn(colID, col.Descending)
-		if !col.Column.IsNullable() {
-			notNullCols.Add(int(colID))
-		}
-	}
-
-	// Generate index constraints.
-	var ic idxconstraint.Instance
-	filter := memo.MakeNormExprView(c.e.mem, filterGroup)
-	ic.Init(filter, columns, notNullCols, isInverted, c.e.evalCtx, c.e.f)
-	constraint := ic.Constraint()
-	if constraint.IsUnconstrained() {
-		return memo.ScanOpDef{}, 0, false
-	}
-	newDef = *scanOpDef
-	newDef.Constraint = constraint
-
-	remainingFilter = ic.RemainingFilter()
-	return newDef, remainingFilter, true
-}
-
-// ConstrainScan tries to push filters into Scan operations as constraints. It
-// is applied on a Select -> Scan pattern. The scan operation is assumed to have
-// no constraints.
-//
-// There are three cases:
-//
-//  - if the filter can be completely converted to constraints, we return a
-//    constrained scan expression (to be added to the same group as the select
-//    operator).
-//
-//  - if the filter can be partially converted to constraints, we construct the
-//    constrained scan and we return a select expression with the remaining
-//    filter (to be added to the same group as the select operator).
-//
-//  - if the filter cannot be converted to constraints, does and returns
-//    nothing.
-//
-func (c *CustomFuncs) ConstrainScan(filterGroup memo.GroupID, scanDef memo.PrivateID) []memo.Expr {
-	c.e.exprs = c.e.exprs[:0]
-
-	newDef, remainingFilter, ok := c.constrainedScanOpDef(filterGroup, scanDef, false /* isInverted */)
-	if !ok {
-		return nil
-	}
-
-	if c.e.mem.NormOp(remainingFilter) == opt.TrueOp {
-		// No remaining filter. Add the constrained scan node to select's group.
-		constrainedScan := memo.MakeScanExpr(c.e.mem.InternScanOpDef(&newDef))
-		c.e.exprs = append(c.e.exprs, memo.Expr(constrainedScan))
-	} else {
-		// We have a remaining filter. We create the constrained scan in a new group
-		// and create a select node in the same group with the original select.
-		constrainedScan := c.e.f.ConstructScan(c.e.mem.InternScanOpDef(&newDef))
-		newSelect := memo.MakeSelectExpr(constrainedScan, remainingFilter)
-		c.e.exprs = append(c.e.exprs, memo.Expr(newSelect))
-	}
-	return c.e.exprs
-}
-
-// ConstrainIndexJoinScan tries to push filters into Index Join index
-// scan operations as constraints. It is applied on a Select -> IndexJoin ->
-// Scan pattern. The scan operation is assumed to have no constraints.
-//
-// There are three cases, similar to ConstrainScan:
-//
-//  - if the filter can be completely converted to constraints, we return a
-//    constrained scan expression wrapped in a lookup join (to be added to the
-//    same group as the select operator).
-//
-//  - if the filter can be partially converted to constraints, we construct the
-//    constrained scan wrapped in a lookup join, and we return a select
-//    expression with the remaining filter (to be added to the same group as
-//    the select operator).
-//
-//  - if the filter cannot be converted to constraints, does and returns
-//    nothing.
-//
-func (c *CustomFuncs) ConstrainIndexJoinScan(
-	filterGroup memo.GroupID, scanDef, indexJoinDef memo.PrivateID,
-) []memo.Expr {
-	c.e.exprs = c.e.exprs[:0]
-
-	newDef, remainingFilter, ok := c.constrainedScanOpDef(filterGroup, scanDef, false /* isInverted */)
-	if !ok {
-		return nil
-	}
-	constrainedScan := c.e.f.ConstructScan(c.e.mem.InternScanOpDef(&newDef))
-
-	if c.e.mem.NormOp(remainingFilter) == opt.TrueOp {
-		// No remaining filter. Add the constrained lookup join index scan node to
-		// select's group.
-		lookupJoin := memo.MakeIndexJoinExpr(constrainedScan, indexJoinDef)
-		c.e.exprs = append(c.e.exprs, memo.Expr(lookupJoin))
-	} else {
-		// We have a remaining filter. We create the constrained lookup join index
-		// scan in a new group and create a select node in the same group with the
-		// original select.
-		lookupJoin := c.e.f.ConstructIndexJoin(constrainedScan, indexJoinDef)
-		newSelect := memo.MakeSelectExpr(lookupJoin, remainingFilter)
-		c.e.exprs = append(c.e.exprs, memo.Expr(newSelect))
-	}
-	return c.e.exprs
-}
-
 // ----------------------------------------------------------------------
 //
 // Limit Rules
@@ -402,28 +407,10 @@ func (c *CustomFuncs) ConstrainIndexJoinScan(
 //
 // ----------------------------------------------------------------------
 
-// CanLimitScan returns true if the given expression can have its output row
-// count limited. This is only possible when there is no existing limit and
-// when the required ordering of the rows to be limited can be satisfied by the
-// scan operator.
-func (c *CustomFuncs) CanLimitScan(def, limit, ordering memo.PrivateID) bool {
+// IsPositiveLimit is true if the given limit value is greater than zero.
+func (c *CustomFuncs) IsPositiveLimit(limit memo.PrivateID) bool {
 	limitVal := int64(*c.e.mem.LookupPrivate(limit).(*tree.DInt))
-	if limitVal <= 0 {
-		// Can't push limit into scan if it's zero or negative.
-		return false
-	}
-
-	scanOpDef := c.e.mem.LookupPrivate(def).(*memo.ScanOpDef)
-	if scanOpDef.HardLimit != 0 {
-		// Don't push limit into scan if scan is already limited. This should
-		// only happen when normalizations haven't run, as otherwise redundant
-		// Limit operators would be discarded.
-		return false
-	}
-
-	required := c.e.mem.LookupPrivate(ordering).(*props.OrderingChoice)
-	ok, _ := scanOpDef.CanProvideOrdering(c.e.mem.Metadata(), required)
-	return ok
+	return limitVal > 0
 }
 
 // LimitScanDef constructs a new ScanOpDef private value that is based on the
@@ -439,6 +426,97 @@ func (c *CustomFuncs) LimitScanDef(def, limit, ordering memo.PrivateID) memo.Pri
 	defCopy := *scanOpDef
 	defCopy.HardLimit = memo.MakeScanLimit(int64(*c.e.mem.LookupPrivate(limit).(*tree.DInt)), reverse)
 	return c.e.mem.InternScanOpDef(&defCopy)
+}
+
+// CanLimitConstrainedScan returns true if the given scan has already been
+// constrained and can have a row count limit installed as well. This is only
+// possible when the required ordering of the rows to be limited can be
+// satisfied by the Scan operator.
+//
+// NOTE: Limiting unconstrained scans is done by the PushLimitIntoScan rule,
+//       since that can require IndexJoin operators to be generated.
+func (c *CustomFuncs) CanLimitConstrainedScan(def, ordering memo.PrivateID) bool {
+	scanOpDef := c.e.mem.LookupPrivate(def).(*memo.ScanOpDef)
+	if scanOpDef.HardLimit != 0 {
+		// Don't push limit into scan if scan is already limited. This would
+		// usually only happen when normalizations haven't run, as otherwise
+		// redundant Limit operators would be discarded.
+		return false
+	}
+
+	if scanOpDef.Constraint == nil {
+		// This is not a constrained scan, so skip it. The PushLimitIntoScan rule
+		// is responsible for limited unconstrained scans.
+		return false
+	}
+
+	required := c.e.mem.LookupPrivate(ordering).(*props.OrderingChoice)
+	ok, _ := scanOpDef.CanProvideOrdering(c.e.mem.Metadata(), required)
+	return ok
+}
+
+// GenerateLimitedScans enumerates all secondary indexes on the Scan operator's
+// table and tries to create new limited Scan operators from them. Since this
+// only needs to be done once per table, GenerateLimitedScans should only be
+// called on the original unaltered primary index Scan operator (i.e. not
+// constrained or limited).
+//
+// For a secondary index that "covers" the columns needed by the scan, a single
+// limited Scan operator is created. For a non-covering index, an IndexJoin is
+// constructed to add missing columns to the limited Scan.
+func (c *CustomFuncs) GenerateLimitedScans(def, limit, ordering memo.PrivateID) []memo.Expr {
+	c.e.exprs = c.e.exprs[:0]
+	scanOpDef := c.e.mem.LookupPrivate(def).(*memo.ScanOpDef)
+	required := c.e.mem.LookupPrivate(ordering).(*props.OrderingChoice)
+	limitVal := int64(*c.e.mem.LookupPrivate(limit).(*tree.DInt))
+
+	var sb indexScanBuilder
+	sb.init(c, scanOpDef.Table)
+
+	// Iterate over all indexes, looking for those that can be limited.
+	var iter scanIndexIter
+	iter.init(c.e.mem, scanOpDef)
+	for iter.next() {
+		newDef := *scanOpDef
+		newDef.Index = iter.index
+
+		// If the alternate index does not conform to the ordering, then skip it.
+		// If reverse=true, then the scan needs to be in reverse order to match
+		// the required ordering.
+		ok, reverse := newDef.CanProvideOrdering(c.e.mem.Metadata(), required)
+		if !ok {
+			continue
+		}
+		newDef.HardLimit = memo.MakeScanLimit(limitVal, reverse)
+
+		// If the alternate index includes the set of needed columns, then construct
+		// a new Scan operator using that index.
+		if iter.isCovering() {
+			sb.setScan(c.e.f.InternScanOpDef(&newDef))
+			c.e.exprs = append(c.e.exprs, sb.build())
+			continue
+		}
+
+		// Otherwise, try to construct an IndexJoin operator that provides the
+		// columns missing from the index.
+		if scanOpDef.Flags.NoIndexJoin {
+			continue
+		}
+
+		// Scan whatever columns we need which are available from the index, plus
+		// the PK columns.
+		newDef.Cols = iter.indexCols().Intersection(scanOpDef.Cols)
+		newDef.Cols.UnionWith(sb.primaryKeyCols())
+		sb.setScan(c.e.f.InternScanOpDef(&newDef))
+
+		// The Scan operator will go into its own group (because it projects a
+		// different set of columns), and the IndexJoin operator will be added to
+		// the same group as the original Limit operator.
+		sb.addIndexJoin(scanOpDef.Cols)
+		c.e.exprs = append(c.e.exprs, sb.build())
+	}
+
+	return c.e.exprs
 }
 
 // ----------------------------------------------------------------------
@@ -732,4 +810,90 @@ func (c *CustomFuncs) MakeOrderingChoiceFromColumn(
 		oc.AppendCol(c.ExtractColID(col), true /* descending */)
 	}
 	return c.e.f.InternOrderingChoice(&oc)
+}
+
+// scanIndexIter is a helper struct that supports iteration over the indexes
+// of a Scan operator table. For example:
+//
+//   var iter scanIndexIter
+//   iter.init(mem, scanOpDef)
+//   for iter.next() {
+//     doSomething(iter.index)
+//   }
+//
+type scanIndexIter struct {
+	mem       *memo.Memo
+	scanOpDef *memo.ScanOpDef
+	tab       opt.Table
+	index     int
+	cols      opt.ColSet
+}
+
+func (it *scanIndexIter) init(mem *memo.Memo, scanOpDef *memo.ScanOpDef) {
+	it.mem = mem
+	it.scanOpDef = scanOpDef
+	it.tab = mem.Metadata().Table(scanOpDef.Table)
+	it.index = -1
+}
+
+// next advances iteration to the next index of the Scan operator's table. This
+// is the primary index if it's the first time next is called, or a secondary
+// index thereafter. Inverted index are skipped. If the ForceIndex flag is set,
+// then all indexes except the forced index are skipped. When there are no more
+// indexes to enumerate, next returns false. The current index is accessible via
+// the iterator's "index" field.
+func (it *scanIndexIter) next() bool {
+	for {
+		it.index++
+		if it.index >= it.tab.IndexCount() {
+			return false
+		}
+
+		if it.tab.Index(it.index).IsInverted() {
+			continue
+		}
+		if it.scanOpDef.Flags.ForceIndex && it.scanOpDef.Flags.Index != it.index {
+			// If we are forcing a specific index, ignore the others.
+			continue
+		}
+		it.cols = opt.ColSet{}
+		return true
+	}
+}
+
+// nextInverted advances iteration to the next inverted index of the Scan
+// operator's table. It returns false when there are no more inverted indexes to
+// enumerate (or if there were none to begin with). The current index is
+// accessible via the iterator's "index" field.
+func (it *scanIndexIter) nextInverted() bool {
+	for {
+		it.index++
+		if it.index >= it.tab.IndexCount() {
+			return false
+		}
+
+		if !it.tab.Index(it.index).IsInverted() {
+			continue
+		}
+		if it.scanOpDef.Flags.ForceIndex && it.scanOpDef.Flags.Index != it.index {
+			// If we are forcing a specific index, ignore the others.
+			continue
+		}
+		it.cols = opt.ColSet{}
+		return true
+	}
+}
+
+// indexCols returns the set of columns contained in the current index.
+func (it *scanIndexIter) indexCols() opt.ColSet {
+	if it.cols.Empty() {
+		it.cols = it.mem.Metadata().IndexColumns(it.scanOpDef.Table, it.index)
+	}
+	return it.cols
+}
+
+// isCovering returns true if the current index contains all columns projected
+// by the Scan operator.
+func (it *scanIndexIter) isCovering() bool {
+	return it.scanOpDef.Cols.SubsetOf(it.indexCols())
 }

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -205,7 +205,7 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 		})
 		scan := c.e.f.ConstructScan(c.e.mem.InternScanOpDef(&constrainedScan))
 
-		if c.e.mem.NormExpr(remainingFilter).Operator() == opt.TrueOp {
+		if c.e.mem.NormOp(remainingFilter) == opt.TrueOp {
 			c.e.exprs = append(
 				c.e.exprs,
 				memo.Expr(memo.MakeIndexJoinExpr(scan, def)),
@@ -336,7 +336,7 @@ func (c *CustomFuncs) ConstrainScan(filterGroup memo.GroupID, scanDef memo.Priva
 		return nil
 	}
 
-	if c.e.mem.NormExpr(remainingFilter).Operator() == opt.TrueOp {
+	if c.e.mem.NormOp(remainingFilter) == opt.TrueOp {
 		// No remaining filter. Add the constrained scan node to select's group.
 		constrainedScan := memo.MakeScanExpr(c.e.mem.InternScanOpDef(&newDef))
 		c.e.exprs = append(c.e.exprs, memo.Expr(constrainedScan))
@@ -379,7 +379,7 @@ func (c *CustomFuncs) ConstrainIndexJoinScan(
 	}
 	constrainedScan := c.e.f.ConstructScan(c.e.mem.InternScanOpDef(&newDef))
 
-	if c.e.mem.NormExpr(remainingFilter).Operator() == opt.TrueOp {
+	if c.e.mem.NormOp(remainingFilter) == opt.TrueOp {
 		// No remaining filter. Add the constrained lookup join index scan node to
 		// select's group.
 		lookupJoin := memo.MakeIndexJoinExpr(constrainedScan, indexJoinDef)

--- a/pkg/sql/opt/xform/index_scan_builder.go
+++ b/pkg/sql/opt/xform/index_scan_builder.go
@@ -1,0 +1,181 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package xform
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
+)
+
+// indexScanBuilder composes a constrained, limited scan over a table index.
+// Any filters are created as close to the scan as possible, and index joins can
+// be used to scan a non-covering index. For example, in order to construct:
+//
+//   (IndexJoin
+//     (Select (Scan $scanDef) $filter)
+//     $indexJoinDef
+//   )
+//
+// make the following calls:
+//
+//   var sb indexScanBuilder
+//   sb.init(c, tabID)
+//   sb.setScan(scanDef)
+//   sb.addSelect(filter)
+//   sb.addIndexJoin(cols)
+//   expr := sb.build()
+//
+type indexScanBuilder struct {
+	c            *CustomFuncs
+	f            *norm.Factory
+	mem          *memo.Memo
+	tabID        opt.TableID
+	pkCols       opt.ColSet
+	scanDef      memo.PrivateID
+	innerFilter  memo.GroupID
+	outerFilter  memo.GroupID
+	indexJoinDef memo.PrivateID
+}
+
+func (b *indexScanBuilder) init(c *CustomFuncs, tabID opt.TableID) {
+	b.c = c
+	b.f = c.e.f
+	b.mem = c.e.mem
+	b.tabID = tabID
+}
+
+// primaryKeyCols returns the columns from the scanned table's primary index.
+func (b *indexScanBuilder) primaryKeyCols() opt.ColSet {
+	// Ensure that pkCols set is initialized with the primary index columns.
+	if b.pkCols.Empty() {
+		primaryIndex := b.c.e.mem.Metadata().Table(b.tabID).Index(opt.PrimaryIndex)
+		for i, cnt := 0, primaryIndex.KeyColumnCount(); i < cnt; i++ {
+			b.pkCols.Add(int(b.tabID.ColumnID(primaryIndex.Column(i).Ordinal)))
+		}
+	}
+	return b.pkCols
+}
+
+// setScan constructs a standalone Scan expression. As a side effect, it clears
+// any expressions added during previous invocations of the builder.
+func (b *indexScanBuilder) setScan(def memo.PrivateID) {
+	b.scanDef = def
+	b.innerFilter = 0
+	b.outerFilter = 0
+	b.indexJoinDef = 0
+}
+
+// addSelect wraps the input expression with a Select expression having the
+// given filter.
+func (b *indexScanBuilder) addSelect(filter memo.GroupID) {
+	if filter != 0 {
+		if b.indexJoinDef == 0 {
+			if b.innerFilter != 0 {
+				panic("cannot call addSelect methods twice before index join is added")
+			}
+			b.innerFilter = filter
+		} else {
+			if b.outerFilter != 0 {
+				panic("cannot call addSelect methods twice after index join is added")
+			}
+			b.outerFilter = filter
+		}
+	}
+}
+
+// addSelectAfterSplit first splits the given filter into two parts: a filter
+// that only involves columns in the given set, and a remaining filter that
+// includes everything else. The filter that is bound by the columns becomes a
+// Select expression that wraps the input expression, and the remaining filter
+// is returned (or 0 if there is no remaining filter).
+func (b *indexScanBuilder) addSelectAfterSplit(
+	filter memo.GroupID, cols opt.ColSet,
+) (remainingFilter memo.GroupID) {
+	if filter == 0 {
+		return 0
+	}
+
+	filterCols := b.c.OuterCols(filter)
+	if filterCols.SubsetOf(cols) {
+		// Filter is fully bound by the cols, so add entire filter.
+		b.addSelect(filter)
+		return 0
+	}
+
+	// Try to split filter.
+	conditions := b.mem.NormExpr(filter).AsFilters().Conditions()
+	boundConditions := b.c.ExtractBoundConditions(conditions, cols)
+	if boundConditions.Length == 0 {
+		// None of the filter conjuncts can be bound by the cols, so no expression
+		// can be added.
+		return filter
+	}
+
+	// Add conditions which are fully bound by the cols and return the rest.
+	b.addSelect(b.f.ConstructFilters(boundConditions))
+	return b.f.ConstructFilters(b.c.ExtractUnboundConditions(conditions, cols))
+}
+
+// addIndexJoin wraps the input expression with an IndexJoin expression that
+// produces the given set of columns by lookup in the primary index.
+func (b *indexScanBuilder) addIndexJoin(cols opt.ColSet) {
+	if b.indexJoinDef != 0 {
+		panic("cannot call addIndexJoin twice")
+	}
+	if b.outerFilter != 0 {
+		panic("cannot add index join after an outer filter has been added")
+	}
+	b.indexJoinDef = b.mem.InternIndexJoinDef(&memo.IndexJoinDef{
+		Table: b.tabID,
+		Cols:  cols,
+	})
+}
+
+// build constructs the final memo expression by composing together the various
+// expressions that were specified by previous calls to various add methods.
+func (b *indexScanBuilder) build() memo.Expr {
+	// 1. Only scan.
+	if b.innerFilter == 0 && b.indexJoinDef == 0 {
+		return memo.Expr(memo.MakeScanExpr(b.scanDef))
+	}
+
+	// 2. Wrap scan in inner filter if it was added.
+	input := b.f.ConstructScan(b.scanDef)
+	if b.innerFilter != 0 {
+		if b.indexJoinDef == 0 {
+			return memo.Expr(memo.MakeSelectExpr(input, b.innerFilter))
+		}
+
+		input = b.f.ConstructSelect(input, b.innerFilter)
+	}
+
+	// 3. Wrap input in index join if it was added.
+	if b.indexJoinDef != 0 {
+		if b.outerFilter == 0 {
+			return memo.Expr(memo.MakeIndexJoinExpr(input, b.indexJoinDef))
+		}
+
+		input = b.f.ConstructIndexJoin(input, b.indexJoinDef)
+	}
+
+	// 4. Wrap input in outer filter (which must exist at this point).
+	if b.outerFilter == 0 {
+		// indexJoinDef == 0: outerFilter == 0 handled by #1 and #2 above.
+		// indexJoinDef != 0: outerFilter == 0 handled by #3 above.
+		panic("outer filter cannot be 0 at this point")
+	}
+	return memo.Expr(memo.MakeSelectExpr(input, b.outerFilter))
+}

--- a/pkg/sql/opt/xform/rules/limit.opt
+++ b/pkg/sql/opt/xform/rules/limit.opt
@@ -3,34 +3,50 @@
 # =============================================================================
 
 
-# PushLimitIntoScan constructs a new Scan operator that limits the number of
-# returned rows. This can substantially reduce the cost of execution, as rows
+# GenerateLimitedScans generates a set of limited Scan operators, one for each
+# matching index on the scanned table. If the secondary index cannot provide all
+# the output columns, an IndexJoin is introduced to supply them. Pushing a limit
+# into Scan operators can substantially reduce the cost of execution, as rows
 # are never fetched to begin with, rather than fetched only to be discarded by
 # a Limit operator.
-[PushLimitIntoScan, Explore]
+[GenerateLimitedScans, Explore]
 (Limit
-    (Scan $def:*)
-    (Const $limit:*)
-    $ordering:* & (CanLimitScan $def $limit $ordering)
+    (Scan $def:* & (IsCanonicalScan $def))
+    (Const $limit:* & (IsPositiveLimit $limit))
+    $ordering:*
 )
 =>
-(Scan
-    (LimitScanDef $def $limit $ordering)
-)
+(GenerateLimitedScans $def $limit $ordering)
 
-# PushLimitIntoIndexJoin pushes a limit through an index join.
+# PushLimitIntoConstrainedScan constructs a new Scan operator that adds a hard
+# row limit to an existing Scan operator that already has a constraint
+# associated with it (added by the ConstrainScans rule). The Scan operator
+# always applies the limit after any constraint.
+[PushLimitIntoConstrainedScan, Explore]
+(Limit
+    (Scan $def:*)
+    (Const $limit:* & (IsPositiveLimit $limit))
+    $ordering:* & (CanLimitConstrainedScan $def $ordering)
+)
+=>
+(Scan (LimitScanDef $def $limit $ordering))
+
+# PushLimitIntoIndexJoin pushes a limit through an index join and constructs a
+# new Scan operator that incorporates it. Since index lookup can be expensive,
+# it's always better to discard rows beforehand.
+#
 # TODO(radu): we can similarly push Offset too.
 [PushLimitIntoIndexJoin, Explore]
 (Limit
     (IndexJoin
-      $input:*
-      $def:*
+      (Scan $scanDef:*)
+      $indexJoinDef:*
     )
-    $limit:*
-    $ordering:* & (HasColsInOrdering $input $ordering)
+    (Const $limit:* & (IsPositiveLimit $limit))
+    $ordering:* & (CanLimitConstrainedScan $scanDef $ordering)
 )
 =>
 (IndexJoin
-  (Limit $input $limit $ordering)
-  $def
+  (Scan (LimitScanDef $scanDef $limit $ordering))
+  $indexJoinDef
 )

--- a/pkg/sql/opt/xform/rules/scan.opt
+++ b/pkg/sql/opt/xform/rules/scan.opt
@@ -6,4 +6,4 @@
 # GenerateIndexScans creates alternate Scan expressions for each secondary index
 # on the scanned table.
 [GenerateIndexScans, Explore]
-(Scan $def:* & (CanGenerateIndexScans $def)) => (GenerateIndexScans $def)
+(Scan $def:* & (IsCanonicalScan $def)) => (GenerateIndexScans $def)

--- a/pkg/sql/opt/xform/rules/select.opt
+++ b/pkg/sql/opt/xform/rules/select.opt
@@ -2,120 +2,27 @@
 # select.opt contains exploration rules for the Select operator.
 # =============================================================================
 
-# ConstrainScan matches a Select over an unconstrained Scan and tries to push
-# down the filter (or part of it) as index constraints. The result is either
-# a constrained Scan or a Select (with a remaining filter) on top of a
-# constrained Scan.
-[ConstrainScan, Explore]
+
+# GenerateConstrainedScans generates a set of constrained Scan expressions, one
+# for each matching index on the scanned table. The expressions consist of
+# either a standalone Scan operator (if no remaining filter), or else a Scan
+# wrapped by a Select (with a remaining filter). Or, if a secondary index cannot
+# provide all the output columns, an IndexJoin is introduced to supply them. See
+# the comment for the GenerateConstrainedScans custom method for more details
+# and examples.
+[GenerateConstrainedScans, Explore]
 (Select
-  (Scan $def:*)
-  $filter:* & (CanConstrainScan $def $filter)
+  (Scan $def:* & (IsCanonicalScan $def))
+  $filter:*
 )
 =>
-(ConstrainScan $filter $def)
-
-# PushFilterIntoIndexJoinNoRemainder matches a Select over an index join in
-# which the Select filter condition is fully bound by the input to the index
-# join. If this rule matches, it pushes the Select fully below the index join.
-#
-# Note that the below rule, PushFilterIntoIndexJoin, would cover this case if
-# its Filter match condition ^(IsBoundBy $filter $input) were removed. But the
-# problem is that PushFilterIntoIndexJoin would construct a Select with filter
-# condition True, which would not get normalized away (since exploration rules
-# don't re-construct the root node). We need two rules in order to avoid
-# constructing no-op Select operators.
-#
-# In addition, PushFilterIntoIndexJoinNoRemainder serves as an optimization:
-# if the filter is fully bound by the index join input, it is not necessary to
-# check each condition. In order to avoid checking each condition,
-# PushFilterIntoIndexJoin must be ordered after this rule.
-[PushFilterIntoIndexJoinNoRemainder, Explore]
-(Select
-  (IndexJoin
-    $input:*
-    $def:*
-  )
-  $filter:* & (IsBoundBy $filter (OutputCols $input))
-)
-=>
-(IndexJoin
-  (Select $input $filter)
-  $def
-)
-
-
-# PushFilterIntoIndexJoin matches a Select over a index join in which some of
-# the Select filter conditions are bound by the input to the index join, and
-# some are not. If this rule matches, it pushes the bound conditions below the
-# index join.
-[PushFilterIntoIndexJoin, Explore]
-(Select
-  (IndexJoin
-    $input:*
-    $def:*
-  )
-  $filter:(Filters $list:[
-      ...
-      $condition:* & (IsBoundBy $condition $inputCols:(OutputCols $input))
-      ...
-  ]) & ^(IsBoundBy $filter $inputCols)
-)
-=>
-(Select
-  (IndexJoin
-    (Select
-      $input
-      (Filters (ExtractBoundConditions $list $inputCols))
-    )
-    $def
-  )
-  (Filters (ExtractUnboundConditions $list $inputCols))
-)
-
-# ConstrainIndexJoinScan matches a Select over a index join with an
-# unconstrained Scan and tries to push down the filter (or part of it) as index
-# constraints. The result is either a index join with a constrained index Scan
-# or a Select (with a remaining filter) on top of a index join with a
-# constrained index Scan.
-#
-# This rule is needed in addition to the above two rules for the cases where
-# an index constraint can be inferred, but there is no conjunct in the filter
-# that is fully bound by the index scan. For example, consider the query:
-#
-#   SELECT * FROM abc WHERE (a, b, c) > (1, 2, 3) AND (a, b, c) < (8, 9, 10)
-#
-# in which there is a secondary index on (a, b). The best plan is an index join
-# using a constrained scan of the secondary index, with the constraint
-# (a, b) >= (1, 2) AND (a, b) <= (8, 9) pushed down to the scan, and the
-# original filter preserved above the index join:
-#
-#   (Select
-#     (IndexJoin abc
-#       (Scan abc@secondary, constraint: /a/b/rowid: [/1/2 - /8/9])
-#     )
-#     (Filter (a, b, c) > (1, 2, 3) AND (a, b, c) < (8, 9, 10))
-#   )
-#
-# Neither of the above two rules would find this plan.
-#
-# TODO(rytaft): try to find a mechanism for pushdown that is more powerful than
-# finding conjuncts that are fully bound.
-[ConstrainIndexJoinScan, Explore]
-(Select
-  (IndexJoin
-    (Scan $scanDef:*)
-    $indexJoinDef:*
-  )
-  $filter:* & (CanConstrainScan $scanDef $filter)
-)
-=>
-(ConstrainIndexJoinScan $filter $scanDef $indexJoinDef)
+(GenerateConstrainedScans $def $filter)
 
 # GenerateInvertedIndexScans creates alternate expressions for filters that can
 # be serviced by an inverted index.
 [GenerateInvertedIndexScans, Explore]
 (Select
-  (Scan $def:* & (CanGenerateInvertedIndexScans $def))
+  (Scan $def:* & (IsCanonicalScan $def) & (HasInvertedIndexes $def))
   $filter:*
 )
 =>

--- a/pkg/sql/opt/xform/testdata/external/activerecord
+++ b/pkg/sql/opt/xform/testdata/external/activerecord
@@ -212,7 +212,7 @@ sort
       │    ├── key: (1,6,23,24,29,36)
       │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18), (23,24)-->(25), (29)-->(30), (36)-->(63)
       │    ├── inner-join
-      │    │    ├── columns: pg_collation.oid:29(oid!null) pg_collation.collname:30(string!null) pg_type.oid:36(oid!null) typcollation:63(oid!null)
+      │    │    ├── columns: adrelid:23(oid) adnum:24(int) adbin:25(string) pg_collation.oid:29(oid!null) pg_collation.collname:30(string!null) pg_type.oid:36(oid!null) typcollation:63(oid!null)
       │    │    ├── key: (29,36)
       │    │    ├── fd: (29)-->(30), (36)-->(63)
       │    │    ├── scan pg_collation@pg_collation_name_enc_nsp_index
@@ -225,34 +225,36 @@ sort
       │    │    │    └── fd: (36)-->(63)
       │    │    └── filters [type=bool, outer=(29,63), constraints=(/29: (/NULL - ]; /63: (/NULL - ])]
       │    │         └── pg_collation.oid != typcollation [type=bool, outer=(29,63), constraints=(/29: (/NULL - ]; /63: (/NULL - ])]
-      │    ├── left-join (lookup pg_attrdef)
+      │    ├── right-join
       │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null) adrelid:23(oid) adnum:24(int) adbin:25(string)
-      │    │    ├── key columns: [22] = [22]
       │    │    ├── key: (1,6,23,24)
       │    │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18), (23,24)-->(25)
-      │    │    ├── left-join (lookup pg_attrdef@pg_attrdef_adrelid_adnum_index)
-      │    │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null) pg_attrdef.oid:22(oid) adrelid:23(oid) adnum:24(int)
-      │    │    │    ├── key columns: [1 6] = [23 24]
-      │    │    │    ├── key: (1,6,22)
-      │    │    │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18), (22)-->(23,24), (23,24)-->(22)
-      │    │    │    ├── select
-      │    │    │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null)
-      │    │    │    │    ├── key: (1,6)
-      │    │    │    │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18)
-      │    │    │    │    ├── scan pg_attribute
-      │    │    │    │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null)
-      │    │    │    │    │    ├── key: (1,6)
-      │    │    │    │    │    └── fd: (1,6)-->(2,3,9,13,15,18), (1,2)-->(3,6,9,13,15,18)
-      │    │    │    │    └── filters [type=bool, outer=(1,6,15), constraints=(/1: (/NULL - ]; /6: [/1 - ]; /15: [/false - /false]), fd=()-->(15)]
-      │    │    │    │         ├── attrelid = '"numbers"'::REGCLASS [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
-      │    │    │    │         ├── attnum > 0 [type=bool, outer=(6), constraints=(/6: [/1 - ]; tight)]
-      │    │    │    │         └── NOT attisdropped [type=bool, outer=(15), constraints=(/15: [/false - /false]; tight)]
-      │    │    │    └── filters [type=bool, outer=(1,6,23,24), constraints=(/1: (/NULL - ]; /6: (/NULL - ]; /23: (/NULL - ]; /24: [/1 - ]), fd=(1)==(23), (23)==(1), (6)==(24), (24)==(6)]
-      │    │    │         ├── attrelid = adrelid [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ])]
-      │    │    │         ├── attnum = adnum [type=bool, outer=(6,24), constraints=(/6: (/NULL - ]; /24: (/NULL - ])]
+      │    │    ├── select
+      │    │    │    ├── columns: adrelid:23(oid!null) adnum:24(int!null) adbin:25(string)
+      │    │    │    ├── key: (23,24)
+      │    │    │    ├── fd: (23,24)-->(25)
+      │    │    │    ├── scan pg_attrdef
+      │    │    │    │    ├── columns: adrelid:23(oid!null) adnum:24(int!null) adbin:25(string)
+      │    │    │    │    ├── key: (23,24)
+      │    │    │    │    └── fd: (23,24)-->(25)
+      │    │    │    └── filters [type=bool, outer=(23,24), constraints=(/23: (/NULL - ]; /24: [/1 - ])]
       │    │    │         ├── adrelid = '"numbers"'::REGCLASS [type=bool, outer=(23), constraints=(/23: (/NULL - ])]
       │    │    │         └── adnum > 0 [type=bool, outer=(24), constraints=(/24: [/1 - ]; tight)]
-      │    │    └── true [type=bool]
+      │    │    ├── select
+      │    │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null)
+      │    │    │    ├── key: (1,6)
+      │    │    │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18)
+      │    │    │    ├── scan pg_attribute
+      │    │    │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null)
+      │    │    │    │    ├── key: (1,6)
+      │    │    │    │    └── fd: (1,6)-->(2,3,9,13,15,18), (1,2)-->(3,6,9,13,15,18)
+      │    │    │    └── filters [type=bool, outer=(1,6,15), constraints=(/1: (/NULL - ]; /6: [/1 - ]; /15: [/false - /false]), fd=()-->(15)]
+      │    │    │         ├── attrelid = '"numbers"'::REGCLASS [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+      │    │    │         ├── attnum > 0 [type=bool, outer=(6), constraints=(/6: [/1 - ]; tight)]
+      │    │    │         └── NOT attisdropped [type=bool, outer=(15), constraints=(/15: [/false - /false]; tight)]
+      │    │    └── filters [type=bool, outer=(1,6,23,24), constraints=(/1: (/NULL - ]; /6: (/NULL - ]; /23: (/NULL - ]; /24: (/NULL - ]), fd=(1)==(23), (23)==(1), (6)==(24), (24)==(6)]
+      │    │         ├── attrelid = adrelid [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ])]
+      │    │         └── attnum = adnum [type=bool, outer=(6,24), constraints=(/6: (/NULL - ]; /24: (/NULL - ])]
       │    └── filters [type=bool, outer=(3,18,29,36), constraints=(/3: (/NULL - ]; /18: (/NULL - ]; /29: (/NULL - ]; /36: (/NULL - ]), fd=(18)==(29), (29)==(18), (3)==(36), (36)==(3)]
       │         ├── pg_collation.oid = attcollation [type=bool, outer=(18,29), constraints=(/18: (/NULL - ]; /29: (/NULL - ])]
       │         └── pg_type.oid = atttypid [type=bool, outer=(3,36), constraints=(/3: (/NULL - ]; /36: (/NULL - ])]

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -437,183 +437,181 @@ from (select flavors.created_at as flavors_created_at,
      on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
 order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
-left-join (lookup flavor_extra_specs)
+sort
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:38(timestamp) flavor_extra_specs_1_updated_at:39(timestamp) flavor_extra_specs_1_id:34(int) flavor_extra_specs_1_key:35(string) flavor_extra_specs_1_value:36(string) flavor_extra_specs_1_flavor_id:37(int)
- ├── key columns: [34] = [34]
  ├── key: (1,34)
  ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35-39), (35,37)-->(34,36,38,39)
  ├── ordering: +7 opt(11)
- ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx)
- │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:34(int) key:35(string) flavor_extra_specs.flavor_id:37(int)
- │    ├── key columns: [1] = [37]
- │    ├── key: (1,34)
- │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35,37), (35,37)-->(34)
- │    ├── ordering: +7 opt(11)
- │    ├── project
- │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
- │    │    ├── key: (1)
- │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
- │    │    ├── ordering: +7 opt(11)
- │    │    └── limit
- │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
- │    │         ├── internal-ordering: +7 opt(11)
- │    │         ├── key: (1)
- │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
- │    │         ├── ordering: +7 opt(11)
- │    │         ├── offset
- │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
- │    │         │    ├── internal-ordering: +7 opt(11)
- │    │         │    ├── key: (1)
- │    │         │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
- │    │         │    ├── ordering: +7 opt(11)
- │    │         │    ├── sort
- │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
- │    │         │    │    ├── key: (1)
- │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
- │    │         │    │    ├── ordering: +7 opt(11)
- │    │         │    │    └── select
- │    │         │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
- │    │         │    │         ├── key: (1)
- │    │         │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
- │    │         │    │         ├── group-by
- │    │         │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
- │    │         │    │         │    ├── grouping columns: flavors.id:1(int!null)
- │    │         │    │         │    ├── key: (1)
- │    │         │    │         │    ├── fd: ()-->(11), (1)-->(2-12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
- │    │         │    │         │    ├── right-join
- │    │         │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:23(int) true:31(bool)
- │    │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(31)
- │    │         │    │         │    │    ├── project
- │    │         │    │         │    │    │    ├── columns: true:31(bool!null) flavor_projects.flavor_id:23(int!null)
- │    │         │    │         │    │    │    ├── fd: ()-->(31)
- │    │         │    │         │    │    │    ├── select
- │    │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) flavor_projects.project_id:24(string!null)
- │    │         │    │         │    │    │    │    ├── key: (23,24)
- │    │         │    │         │    │    │    │    ├── scan flavor_projects@secondary
- │    │         │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) flavor_projects.project_id:24(string!null)
- │    │         │    │         │    │    │    │    │    └── key: (23,24)
- │    │         │    │         │    │    │    │    └── filters [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
- │    │         │    │         │    │    │    │         └── flavor_projects.project_id = $2 [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
- │    │         │    │         │    │    │    └── projections [outer=(23)]
- │    │         │    │         │    │    │         └── true [type=bool]
- │    │         │    │         │    │    ├── project
- │    │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
- │    │         │    │         │    │    │    ├── key: (1)
- │    │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
- │    │         │    │         │    │    │    └── select
- │    │         │    │         │    │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
- │    │         │    │         │    │    │         ├── key: (1)
- │    │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
- │    │         │    │         │    │    │         ├── group-by
- │    │         │    │         │    │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
- │    │         │    │         │    │    │         │    ├── grouping columns: flavors.id:1(int!null)
- │    │         │    │         │    │    │         │    ├── key: (1)
- │    │         │    │         │    │    │         │    ├── fd: ()-->(11), (1)-->(2-12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
- │    │         │    │         │    │    │         │    ├── left-join (merge)
- │    │         │    │         │    │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:28(bool)
- │    │         │    │         │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(28)
- │    │         │    │         │    │    │         │    │    ├── select
- │    │         │    │         │    │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
- │    │         │    │         │    │    │         │    │    │    ├── key: (1)
- │    │         │    │         │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
- │    │         │    │         │    │    │         │    │    │    ├── ordering: +1 opt(11)
- │    │         │    │         │    │    │         │    │    │    ├── scan flavors
- │    │         │    │         │    │    │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
- │    │         │    │         │    │    │         │    │    │    │    ├── key: (1)
- │    │         │    │         │    │    │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │    │         │    │         │    │    │         │    │    │    │    └── ordering: +1 opt(11)
- │    │         │    │         │    │    │         │    │    │    └── filters [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
- │    │         │    │         │    │    │         │    │    │         └── disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight)]
- │    │         │    │         │    │    │         │    │    ├── project
- │    │         │    │         │    │    │         │    │    │    ├── columns: true:28(bool!null) flavor_projects.flavor_id:17(int!null)
- │    │         │    │         │    │    │         │    │    │    ├── fd: ()-->(28)
- │    │         │    │         │    │    │         │    │    │    ├── ordering: +17 opt(28)
- │    │         │    │         │    │    │         │    │    │    ├── select
- │    │         │    │         │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) flavor_projects.project_id:18(string!null)
- │    │         │    │         │    │    │         │    │    │    │    ├── key: (17,18)
- │    │         │    │         │    │    │         │    │    │    │    ├── ordering: +17
- │    │         │    │         │    │    │         │    │    │    │    ├── scan flavor_projects@secondary
- │    │         │    │         │    │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) flavor_projects.project_id:18(string!null)
- │    │         │    │         │    │    │         │    │    │    │    │    ├── key: (17,18)
- │    │         │    │         │    │    │         │    │    │    │    │    └── ordering: +17
- │    │         │    │         │    │    │         │    │    │    │    └── filters [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
- │    │         │    │         │    │    │         │    │    │    │         └── flavor_projects.project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
- │    │         │    │         │    │    │         │    │    │    └── projections [outer=(17)]
- │    │         │    │         │    │    │         │    │    │         └── true [type=bool]
- │    │         │    │         │    │    │         │    │    └── merge-on
- │    │         │    │         │    │    │         │    │         ├── left ordering: +1
- │    │         │    │         │    │    │         │    │         ├── right ordering: +17
- │    │         │    │         │    │    │         │    │         └── filters [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
- │    │         │    │         │    │    │         │    │              └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ])]
- │    │         │    │         │    │    │         │    └── aggregations [outer=(2-12,14,15,28)]
- │    │         │    │         │    │    │         │         ├── const-not-null-agg [type=bool, outer=(28)]
- │    │         │    │         │    │    │         │         │    └── variable: true [type=bool, outer=(28)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=string, outer=(2)]
- │    │         │    │         │    │    │         │         │    └── variable: name [type=string, outer=(2)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(3)]
- │    │         │    │         │    │    │         │         │    └── variable: memory_mb [type=int, outer=(3)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(4)]
- │    │         │    │         │    │    │         │         │    └── variable: vcpus [type=int, outer=(4)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(5)]
- │    │         │    │         │    │    │         │         │    └── variable: root_gb [type=int, outer=(5)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(6)]
- │    │         │    │         │    │    │         │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=string, outer=(7)]
- │    │         │    │         │    │    │         │         │    └── variable: flavorid [type=string, outer=(7)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(8)]
- │    │         │    │         │    │    │         │         │    └── variable: swap [type=int, outer=(8)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=float, outer=(9)]
- │    │         │    │         │    │    │         │         │    └── variable: rxtx_factor [type=float, outer=(9)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(10)]
- │    │         │    │         │    │    │         │         │    └── variable: vcpu_weight [type=int, outer=(10)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=bool, outer=(11)]
- │    │         │    │         │    │    │         │         │    └── variable: disabled [type=bool, outer=(11)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=bool, outer=(12)]
- │    │         │    │         │    │    │         │         │    └── variable: is_public [type=bool, outer=(12)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=timestamp, outer=(14)]
- │    │         │    │         │    │    │         │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
- │    │         │    │         │    │    │         │         └── const-agg [type=timestamp, outer=(15)]
- │    │         │    │         │    │    │         │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
- │    │         │    │         │    │    │         └── filters [type=bool, outer=(12,29)]
- │    │         │    │         │    │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,29)]
- │    │         │    │         │    │    └── filters [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ]), fd=(1)==(23), (23)==(1)]
- │    │         │    │         │    │         └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ])]
- │    │         │    │         │    └── aggregations [outer=(2-12,14,15,31)]
- │    │         │    │         │         ├── const-not-null-agg [type=bool, outer=(31)]
- │    │         │    │         │         │    └── variable: true [type=bool, outer=(31)]
- │    │         │    │         │         ├── const-agg [type=string, outer=(2)]
- │    │         │    │         │         │    └── variable: name [type=string, outer=(2)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(3)]
- │    │         │    │         │         │    └── variable: memory_mb [type=int, outer=(3)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(4)]
- │    │         │    │         │         │    └── variable: vcpus [type=int, outer=(4)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(5)]
- │    │         │    │         │         │    └── variable: root_gb [type=int, outer=(5)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(6)]
- │    │         │    │         │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
- │    │         │    │         │         ├── const-agg [type=string, outer=(7)]
- │    │         │    │         │         │    └── variable: flavorid [type=string, outer=(7)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(8)]
- │    │         │    │         │         │    └── variable: swap [type=int, outer=(8)]
- │    │         │    │         │         ├── const-agg [type=float, outer=(9)]
- │    │         │    │         │         │    └── variable: rxtx_factor [type=float, outer=(9)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(10)]
- │    │         │    │         │         │    └── variable: vcpu_weight [type=int, outer=(10)]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(11)]
- │    │         │    │         │         │    └── variable: disabled [type=bool, outer=(11)]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(12)]
- │    │         │    │         │         │    └── variable: is_public [type=bool, outer=(12)]
- │    │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
- │    │         │    │         │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
- │    │         │    │         │         └── const-agg [type=timestamp, outer=(15)]
- │    │         │    │         │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
- │    │         │    │         └── filters [type=bool, outer=(12,32)]
- │    │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,32)]
- │    │         │    └── placeholder: $3 [type=int]
- │    │         └── placeholder: $4 [type=int]
- │    └── filters [type=bool, outer=(1,37), constraints=(/1: (/NULL - ]; /37: (/NULL - ]), fd=(1)==(37), (37)==(1)]
- │         └── flavor_extra_specs.flavor_id = flavors.id [type=bool, outer=(1,37), constraints=(/1: (/NULL - ]; /37: (/NULL - ])]
- └── true [type=bool]
+ └── right-join
+      ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:34(int) key:35(string) value:36(string) flavor_extra_specs.flavor_id:37(int) flavor_extra_specs.created_at:38(timestamp) flavor_extra_specs.updated_at:39(timestamp)
+      ├── key: (1,34)
+      ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35-39), (35,37)-->(34,36,38,39)
+      ├── scan flavor_extra_specs
+      │    ├── columns: flavor_extra_specs.id:34(int!null) key:35(string!null) value:36(string) flavor_extra_specs.flavor_id:37(int!null) flavor_extra_specs.created_at:38(timestamp) flavor_extra_specs.updated_at:39(timestamp)
+      │    ├── key: (34)
+      │    └── fd: (34)-->(35-39), (35,37)-->(34,36,38,39)
+      ├── project
+      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    ├── key: (1)
+      │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │    └── limit
+      │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+      │         ├── internal-ordering: +7 opt(11)
+      │         ├── key: (1)
+      │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         ├── offset
+      │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+      │         │    ├── internal-ordering: +7 opt(11)
+      │         │    ├── key: (1)
+      │         │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    ├── ordering: +7 opt(11)
+      │         │    ├── sort
+      │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+      │         │    │    ├── key: (1)
+      │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    │    ├── ordering: +7 opt(11)
+      │         │    │    └── select
+      │         │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+      │         │    │         ├── key: (1)
+      │         │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    │         ├── group-by
+      │         │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+      │         │    │         │    ├── grouping columns: flavors.id:1(int!null)
+      │         │    │         │    ├── key: (1)
+      │         │    │         │    ├── fd: ()-->(11), (1)-->(2-12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    │         │    ├── right-join
+      │         │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:23(int) true:31(bool)
+      │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(31)
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: true:31(bool!null) flavor_projects.flavor_id:23(int!null)
+      │         │    │         │    │    │    ├── fd: ()-->(31)
+      │         │    │         │    │    │    ├── select
+      │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) flavor_projects.project_id:24(string!null)
+      │         │    │         │    │    │    │    ├── key: (23,24)
+      │         │    │         │    │    │    │    ├── scan flavor_projects@secondary
+      │         │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) flavor_projects.project_id:24(string!null)
+      │         │    │         │    │    │    │    │    └── key: (23,24)
+      │         │    │         │    │    │    │    └── filters [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
+      │         │    │         │    │    │    │         └── flavor_projects.project_id = $2 [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
+      │         │    │         │    │    │    └── projections [outer=(23)]
+      │         │    │         │    │    │         └── true [type=bool]
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │         │    │         │    │    │    ├── key: (1)
+      │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    │         │    │    │    └── select
+      │         │    │         │    │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
+      │         │    │         │    │    │         ├── key: (1)
+      │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    │         │    │    │         ├── group-by
+      │         │    │         │    │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
+      │         │    │         │    │    │         │    ├── grouping columns: flavors.id:1(int!null)
+      │         │    │         │    │    │         │    ├── key: (1)
+      │         │    │         │    │    │         │    ├── fd: ()-->(11), (1)-->(2-12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    │         │    │    │         │    ├── left-join (merge)
+      │         │    │         │    │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:28(bool)
+      │         │    │         │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(28)
+      │         │    │         │    │    │         │    │    ├── select
+      │         │    │         │    │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │         │    │         │    │    │         │    │    │    ├── key: (1)
+      │         │    │         │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    │         │    │    │         │    │    │    ├── ordering: +1 opt(11)
+      │         │    │         │    │    │         │    │    │    ├── scan flavors
+      │         │    │         │    │    │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │         │    │         │    │    │         │    │    │    │    ├── key: (1)
+      │         │    │         │    │    │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │         │    │         │    │    │         │    │    │    │    └── ordering: +1 opt(11)
+      │         │    │         │    │    │         │    │    │    └── filters [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
+      │         │    │         │    │    │         │    │    │         └── disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight)]
+      │         │    │         │    │    │         │    │    ├── project
+      │         │    │         │    │    │         │    │    │    ├── columns: true:28(bool!null) flavor_projects.flavor_id:17(int!null)
+      │         │    │         │    │    │         │    │    │    ├── fd: ()-->(28)
+      │         │    │         │    │    │         │    │    │    ├── ordering: +17 opt(28)
+      │         │    │         │    │    │         │    │    │    ├── select
+      │         │    │         │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) flavor_projects.project_id:18(string!null)
+      │         │    │         │    │    │         │    │    │    │    ├── key: (17,18)
+      │         │    │         │    │    │         │    │    │    │    ├── ordering: +17
+      │         │    │         │    │    │         │    │    │    │    ├── scan flavor_projects@secondary
+      │         │    │         │    │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) flavor_projects.project_id:18(string!null)
+      │         │    │         │    │    │         │    │    │    │    │    ├── key: (17,18)
+      │         │    │         │    │    │         │    │    │    │    │    └── ordering: +17
+      │         │    │         │    │    │         │    │    │    │    └── filters [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+      │         │    │         │    │    │         │    │    │    │         └── flavor_projects.project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+      │         │    │         │    │    │         │    │    │    └── projections [outer=(17)]
+      │         │    │         │    │    │         │    │    │         └── true [type=bool]
+      │         │    │         │    │    │         │    │    └── merge-on
+      │         │    │         │    │    │         │    │         ├── left ordering: +1
+      │         │    │         │    │    │         │    │         ├── right ordering: +17
+      │         │    │         │    │    │         │    │         └── filters [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
+      │         │    │         │    │    │         │    │              └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ])]
+      │         │    │         │    │    │         │    └── aggregations [outer=(2-12,14,15,28)]
+      │         │    │         │    │    │         │         ├── const-not-null-agg [type=bool, outer=(28)]
+      │         │    │         │    │    │         │         │    └── variable: true [type=bool, outer=(28)]
+      │         │    │         │    │    │         │         ├── const-agg [type=string, outer=(2)]
+      │         │    │         │    │    │         │         │    └── variable: name [type=string, outer=(2)]
+      │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(3)]
+      │         │    │         │    │    │         │         │    └── variable: memory_mb [type=int, outer=(3)]
+      │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(4)]
+      │         │    │         │    │    │         │         │    └── variable: vcpus [type=int, outer=(4)]
+      │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(5)]
+      │         │    │         │    │    │         │         │    └── variable: root_gb [type=int, outer=(5)]
+      │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(6)]
+      │         │    │         │    │    │         │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │    │    │         │         ├── const-agg [type=string, outer=(7)]
+      │         │    │         │    │    │         │         │    └── variable: flavorid [type=string, outer=(7)]
+      │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(8)]
+      │         │    │         │    │    │         │         │    └── variable: swap [type=int, outer=(8)]
+      │         │    │         │    │    │         │         ├── const-agg [type=float, outer=(9)]
+      │         │    │         │    │    │         │         │    └── variable: rxtx_factor [type=float, outer=(9)]
+      │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(10)]
+      │         │    │         │    │    │         │         │    └── variable: vcpu_weight [type=int, outer=(10)]
+      │         │    │         │    │    │         │         ├── const-agg [type=bool, outer=(11)]
+      │         │    │         │    │    │         │         │    └── variable: disabled [type=bool, outer=(11)]
+      │         │    │         │    │    │         │         ├── const-agg [type=bool, outer=(12)]
+      │         │    │         │    │    │         │         │    └── variable: is_public [type=bool, outer=(12)]
+      │         │    │         │    │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+      │         │    │         │    │    │         │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
+      │         │    │         │    │    │         │         └── const-agg [type=timestamp, outer=(15)]
+      │         │    │         │    │    │         │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
+      │         │    │         │    │    │         └── filters [type=bool, outer=(12,29)]
+      │         │    │         │    │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,29)]
+      │         │    │         │    │    └── filters [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ]), fd=(1)==(23), (23)==(1)]
+      │         │    │         │    │         └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ])]
+      │         │    │         │    └── aggregations [outer=(2-12,14,15,31)]
+      │         │    │         │         ├── const-not-null-agg [type=bool, outer=(31)]
+      │         │    │         │         │    └── variable: true [type=bool, outer=(31)]
+      │         │    │         │         ├── const-agg [type=string, outer=(2)]
+      │         │    │         │         │    └── variable: name [type=string, outer=(2)]
+      │         │    │         │         ├── const-agg [type=int, outer=(3)]
+      │         │    │         │         │    └── variable: memory_mb [type=int, outer=(3)]
+      │         │    │         │         ├── const-agg [type=int, outer=(4)]
+      │         │    │         │         │    └── variable: vcpus [type=int, outer=(4)]
+      │         │    │         │         ├── const-agg [type=int, outer=(5)]
+      │         │    │         │         │    └── variable: root_gb [type=int, outer=(5)]
+      │         │    │         │         ├── const-agg [type=int, outer=(6)]
+      │         │    │         │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │         ├── const-agg [type=string, outer=(7)]
+      │         │    │         │         │    └── variable: flavorid [type=string, outer=(7)]
+      │         │    │         │         ├── const-agg [type=int, outer=(8)]
+      │         │    │         │         │    └── variable: swap [type=int, outer=(8)]
+      │         │    │         │         ├── const-agg [type=float, outer=(9)]
+      │         │    │         │         │    └── variable: rxtx_factor [type=float, outer=(9)]
+      │         │    │         │         ├── const-agg [type=int, outer=(10)]
+      │         │    │         │         │    └── variable: vcpu_weight [type=int, outer=(10)]
+      │         │    │         │         ├── const-agg [type=bool, outer=(11)]
+      │         │    │         │         │    └── variable: disabled [type=bool, outer=(11)]
+      │         │    │         │         ├── const-agg [type=bool, outer=(12)]
+      │         │    │         │         │    └── variable: is_public [type=bool, outer=(12)]
+      │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+      │         │    │         │         │    └── variable: flavors.created_at [type=timestamp, outer=(14)]
+      │         │    │         │         └── const-agg [type=timestamp, outer=(15)]
+      │         │    │         │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
+      │         │    │         └── filters [type=bool, outer=(12,32)]
+      │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,32)]
+      │         │    └── placeholder: $3 [type=int]
+      │         └── placeholder: $4 [type=int]
+      └── filters [type=bool, outer=(1,37), constraints=(/1: (/NULL - ]; /37: (/NULL - ]), fd=(1)==(37), (37)==(1)]
+           └── flavor_extra_specs.flavor_id = flavors.id [type=bool, outer=(1,37), constraints=(/1: (/NULL - ]; /37: (/NULL - ])]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -675,126 +673,129 @@ from (select instance_types.created_at as instance_types_created_at,
 order by anon_1.instance_types_flavorid asc,
          anon_1.instance_types_id asc
 ----
-left-join (lookup instance_type_extra_specs)
+sort
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
- ├── key columns: [28] = [28]
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── ordering: +7,+1
- ├── left-join (lookup instance_type_extra_specs@secondary)
- │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
- │    ├── key columns: [1] = [31]
- │    ├── key: (1,28)
- │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
- │    ├── ordering: +7,+1
- │    ├── project
- │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │    ├── ordering: +7,+1
- │    │    └── limit
- │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         ├── internal-ordering: +7,+1
- │    │         ├── key: (1)
- │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         ├── ordering: +7,+1
- │    │         ├── offset
- │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    ├── internal-ordering: +7,+1
- │    │         │    ├── key: (1)
- │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    ├── ordering: +7,+1
- │    │         │    ├── sort
- │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │    ├── key: (1)
- │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    ├── ordering: +7,+1
- │    │         │    │    └── select
- │    │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │         ├── key: (1)
- │    │         │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         ├── group-by
- │    │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
- │    │         │    │         │    ├── key: (1)
- │    │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    ├── left-join (merge)
- │    │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
- │    │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
- │    │         │    │         │    │    ├── select
- │    │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │         │    │    │    ├── key: (1)
- │    │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    │    │    ├── ordering: +1
- │    │         │    │         │    │    │    ├── scan instance_types
- │    │         │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │         │    │    │    │    ├── key: (1)
- │    │         │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    │    │    │    └── ordering: +1
- │    │         │    │         │    │    │    └── filters [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
- │    │         │    │         │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
- │    │         │    │         │    │    ├── project
- │    │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
- │    │         │    │         │    │    │    ├── fd: ()-->(25)
- │    │         │    │         │    │    │    ├── ordering: +18 opt(25)
- │    │         │    │         │    │    │    ├── select
- │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
- │    │         │    │         │    │    │    │    ├── ordering: +18
- │    │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
- │    │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
- │    │         │    │         │    │    │    │    │    └── ordering: +18
- │    │         │    │         │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
- │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
- │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $3 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
- │    │         │    │         │    │    │    │         └── project_id = $4 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
- │    │         │    │         │    │    │    └── projections [outer=(18)]
- │    │         │    │         │    │    │         └── true [type=bool]
- │    │         │    │         │    │    └── merge-on
- │    │         │    │         │    │         ├── left ordering: +1
- │    │         │    │         │    │         ├── right ordering: +18
- │    │         │    │         │    │         └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
- │    │         │    │         │    │              └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
- │    │         │    │         │    └── aggregations [outer=(2-16,25)]
- │    │         │    │         │         ├── const-not-null-agg [type=bool, outer=(25)]
- │    │         │    │         │         │    └── variable: true [type=bool, outer=(25)]
- │    │         │    │         │         ├── const-agg [type=string, outer=(2)]
- │    │         │    │         │         │    └── variable: name [type=string, outer=(2)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(3)]
- │    │         │    │         │         │    └── variable: memory_mb [type=int, outer=(3)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(4)]
- │    │         │    │         │         │    └── variable: vcpus [type=int, outer=(4)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(5)]
- │    │         │    │         │         │    └── variable: root_gb [type=int, outer=(5)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(6)]
- │    │         │    │         │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
- │    │         │    │         │         ├── const-agg [type=string, outer=(7)]
- │    │         │    │         │         │    └── variable: flavorid [type=string, outer=(7)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(8)]
- │    │         │    │         │         │    └── variable: swap [type=int, outer=(8)]
- │    │         │    │         │         ├── const-agg [type=float, outer=(9)]
- │    │         │    │         │         │    └── variable: rxtx_factor [type=float, outer=(9)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(10)]
- │    │         │    │         │         │    └── variable: vcpu_weight [type=int, outer=(10)]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(11)]
- │    │         │    │         │         │    └── variable: disabled [type=bool, outer=(11)]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(12)]
- │    │         │    │         │         │    └── variable: is_public [type=bool, outer=(12)]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(13)]
- │    │         │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
- │    │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
- │    │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
- │    │         │    │         │         ├── const-agg [type=timestamp, outer=(15)]
- │    │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
- │    │         │    │         │         └── const-agg [type=timestamp, outer=(16)]
- │    │         │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
- │    │         │    │         └── filters [type=bool, outer=(12,26)]
- │    │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
- │    │         │    └── placeholder: $5 [type=int]
- │    │         └── placeholder: $6 [type=int]
- │    └── filters [type=bool, outer=(1,31,32), constraints=(/1: (/NULL - ]; /31: (/NULL - ]; /32: (/NULL - ]), fd=(1)==(31), (31)==(1)]
- │         ├── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
- │         └── instance_type_extra_specs.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
- └── true [type=bool]
+ └── right-join
+      ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      ├── key: (1,28)
+      ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      ├── select
+      │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool!null) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      │    ├── key: (28)
+      │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    ├── scan instance_type_extra_specs
+      │    │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      │    │    ├── key: (28)
+      │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    └── filters [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      │         └── instance_type_extra_specs.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      ├── project
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    └── limit
+      │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         ├── internal-ordering: +7,+1
+      │         ├── key: (1)
+      │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         ├── offset
+      │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    ├── internal-ordering: +7,+1
+      │         │    ├── key: (1)
+      │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    ├── ordering: +7,+1
+      │         │    ├── sort
+      │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    │    ├── key: (1)
+      │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │    ├── ordering: +7,+1
+      │         │    │    └── select
+      │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    │         ├── key: (1)
+      │         │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         ├── group-by
+      │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+      │         │    │         │    ├── key: (1)
+      │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    ├── left-join (merge)
+      │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+      │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+      │         │    │         │    │    ├── select
+      │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │    ├── key: (1)
+      │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    │    │    ├── ordering: +1
+      │         │    │         │    │    │    ├── scan instance_types
+      │         │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │    │    ├── key: (1)
+      │         │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    │    │    │    └── ordering: +1
+      │         │    │         │    │    │    └── filters [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │         │    │         │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │         │    │         │    │    │    ├── fd: ()-->(25)
+      │         │    │         │    │    │    ├── ordering: +18 opt(25)
+      │         │    │         │    │    │    ├── select
+      │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+      │         │    │         │    │    │    │    ├── ordering: +18
+      │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
+      │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │         │    │         │    │    │    │    │    └── ordering: +18
+      │         │    │         │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $3 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │         │    │         │    │    │    │         └── project_id = $4 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │         │    │         │    │    │    └── projections [outer=(18)]
+      │         │    │         │    │    │         └── true [type=bool]
+      │         │    │         │    │    └── merge-on
+      │         │    │         │    │         ├── left ordering: +1
+      │         │    │         │    │         ├── right ordering: +18
+      │         │    │         │    │         └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+      │         │    │         │    │              └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+      │         │    │         │    └── aggregations [outer=(2-16,25)]
+      │         │    │         │         ├── const-not-null-agg [type=bool, outer=(25)]
+      │         │    │         │         │    └── variable: true [type=bool, outer=(25)]
+      │         │    │         │         ├── const-agg [type=string, outer=(2)]
+      │         │    │         │         │    └── variable: name [type=string, outer=(2)]
+      │         │    │         │         ├── const-agg [type=int, outer=(3)]
+      │         │    │         │         │    └── variable: memory_mb [type=int, outer=(3)]
+      │         │    │         │         ├── const-agg [type=int, outer=(4)]
+      │         │    │         │         │    └── variable: vcpus [type=int, outer=(4)]
+      │         │    │         │         ├── const-agg [type=int, outer=(5)]
+      │         │    │         │         │    └── variable: root_gb [type=int, outer=(5)]
+      │         │    │         │         ├── const-agg [type=int, outer=(6)]
+      │         │    │         │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │         ├── const-agg [type=string, outer=(7)]
+      │         │    │         │         │    └── variable: flavorid [type=string, outer=(7)]
+      │         │    │         │         ├── const-agg [type=int, outer=(8)]
+      │         │    │         │         │    └── variable: swap [type=int, outer=(8)]
+      │         │    │         │         ├── const-agg [type=float, outer=(9)]
+      │         │    │         │         │    └── variable: rxtx_factor [type=float, outer=(9)]
+      │         │    │         │         ├── const-agg [type=int, outer=(10)]
+      │         │    │         │         │    └── variable: vcpu_weight [type=int, outer=(10)]
+      │         │    │         │         ├── const-agg [type=bool, outer=(11)]
+      │         │    │         │         │    └── variable: disabled [type=bool, outer=(11)]
+      │         │    │         │         ├── const-agg [type=bool, outer=(12)]
+      │         │    │         │         │    └── variable: is_public [type=bool, outer=(12)]
+      │         │    │         │         ├── const-agg [type=bool, outer=(13)]
+      │         │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+      │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+      │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+      │         │    │         │         ├── const-agg [type=timestamp, outer=(15)]
+      │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+      │         │    │         │         └── const-agg [type=timestamp, outer=(16)]
+      │         │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+      │         │    │         └── filters [type=bool, outer=(12,26)]
+      │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
+      │         │    └── placeholder: $5 [type=int]
+      │         └── placeholder: $6 [type=int]
+      └── filters [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
+           └── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
 
 opt
 select instance_types.created_at as instance_types_created_at,
@@ -996,111 +997,113 @@ from (select instance_types.created_at as instance_types_created_at,
      on instance_type_extra_specs_1.instance_type_id = anon_1.instance_types_id
         and instance_type_extra_specs_1.deleted = $7
 ----
-left-join (lookup instance_type_extra_specs)
+right-join
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
- ├── key columns: [28] = [28]
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
- ├── left-join (lookup instance_type_extra_specs@secondary)
- │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
- │    ├── key columns: [1] = [31]
- │    ├── key: (1,28)
- │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
- │    ├── project
- │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
- │    │    └── limit
- │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         ├── key: (1)
- │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
- │    │         ├── offset
- │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    ├── key: (1)
- │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
- │    │         │    ├── select
- │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │    ├── key: (1)
- │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
- │    │         │    │    ├── group-by
- │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │    │    ├── grouping columns: instance_types.id:1(int!null)
- │    │         │    │    │    ├── key: (1)
- │    │         │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
- │    │         │    │    │    ├── left-join
- │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
- │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), ()~~>(25)
- │    │         │    │    │    │    ├── index-join instance_types
- │    │         │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │    │    │    │    ├── key: (1)
- │    │         │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
- │    │         │    │    │    │    │    └── select
- │    │         │    │    │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string!null) instance_types.deleted:13(bool!null)
- │    │         │    │    │    │    │         ├── key: (1)
- │    │         │    │    │    │    │         ├── fd: (1)-->(2,13), (2,13)-->(1)
- │    │         │    │    │    │    │         ├── scan instance_types@secondary
- │    │         │    │    │    │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string!null) instance_types.deleted:13(bool)
- │    │         │    │    │    │    │         │    ├── constraint: /2/13: (/NULL - ]
- │    │         │    │    │    │    │         │    ├── key: (1)
- │    │         │    │    │    │    │         │    └── fd: (1)-->(2,13), (2,13)~~>(1)
- │    │         │    │    │    │    │         └── filters [type=bool, outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ])]
- │    │         │    │    │    │    │              ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
- │    │         │    │    │    │    │              └── name = $4 [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
- │    │         │    │    │    │    ├── project
- │    │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
- │    │         │    │    │    │    │    ├── fd: ()-->(25)
- │    │         │    │    │    │    │    ├── select
- │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
- │    │         │    │    │    │    │    │    ├── scan instance_type_projects@secondary
- │    │         │    │    │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
- │    │         │    │    │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
- │    │         │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
- │    │         │    │    │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
- │    │         │    │    │    │    │    └── projections [outer=(18)]
- │    │         │    │    │    │    │         └── true [type=bool]
- │    │         │    │    │    │    └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
- │    │         │    │    │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
- │    │         │    │    │    └── aggregations [outer=(2-16,25)]
- │    │         │    │    │         ├── const-not-null-agg [type=bool, outer=(25)]
- │    │         │    │    │         │    └── variable: true [type=bool, outer=(25)]
- │    │         │    │    │         ├── const-agg [type=string, outer=(2)]
- │    │         │    │    │         │    └── variable: name [type=string, outer=(2)]
- │    │         │    │    │         ├── const-agg [type=int, outer=(3)]
- │    │         │    │    │         │    └── variable: memory_mb [type=int, outer=(3)]
- │    │         │    │    │         ├── const-agg [type=int, outer=(4)]
- │    │         │    │    │         │    └── variable: vcpus [type=int, outer=(4)]
- │    │         │    │    │         ├── const-agg [type=int, outer=(5)]
- │    │         │    │    │         │    └── variable: root_gb [type=int, outer=(5)]
- │    │         │    │    │         ├── const-agg [type=int, outer=(6)]
- │    │         │    │    │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
- │    │         │    │    │         ├── const-agg [type=string, outer=(7)]
- │    │         │    │    │         │    └── variable: flavorid [type=string, outer=(7)]
- │    │         │    │    │         ├── const-agg [type=int, outer=(8)]
- │    │         │    │    │         │    └── variable: swap [type=int, outer=(8)]
- │    │         │    │    │         ├── const-agg [type=float, outer=(9)]
- │    │         │    │    │         │    └── variable: rxtx_factor [type=float, outer=(9)]
- │    │         │    │    │         ├── const-agg [type=int, outer=(10)]
- │    │         │    │    │         │    └── variable: vcpu_weight [type=int, outer=(10)]
- │    │         │    │    │         ├── const-agg [type=bool, outer=(11)]
- │    │         │    │    │         │    └── variable: disabled [type=bool, outer=(11)]
- │    │         │    │    │         ├── const-agg [type=bool, outer=(12)]
- │    │         │    │    │         │    └── variable: is_public [type=bool, outer=(12)]
- │    │         │    │    │         ├── const-agg [type=bool, outer=(13)]
- │    │         │    │    │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
- │    │         │    │    │         ├── const-agg [type=timestamp, outer=(14)]
- │    │         │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
- │    │         │    │    │         ├── const-agg [type=timestamp, outer=(15)]
- │    │         │    │    │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
- │    │         │    │    │         └── const-agg [type=timestamp, outer=(16)]
- │    │         │    │    │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
- │    │         │    │    └── filters [type=bool, outer=(12,26)]
- │    │         │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
- │    │         │    └── placeholder: $5 [type=int]
- │    │         └── placeholder: $6 [type=int]
- │    └── filters [type=bool, outer=(1,31,32), constraints=(/1: (/NULL - ]; /31: (/NULL - ]; /32: (/NULL - ]), fd=(1)==(31), (31)==(1)]
- │         ├── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
+ ├── select
+ │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool!null) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+ │    ├── key: (28)
+ │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ │    ├── scan instance_type_extra_specs
+ │    │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+ │    │    ├── key: (28)
+ │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ │    └── filters [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
  │         └── instance_type_extra_specs.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
- └── true [type=bool]
+ ├── project
+ │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+ │    └── limit
+ │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+ │         ├── offset
+ │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │         │    ├── key: (1)
+ │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+ │         │    ├── select
+ │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │         │    │    ├── key: (1)
+ │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+ │         │    │    ├── group-by
+ │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │         │    │    │    ├── grouping columns: instance_types.id:1(int!null)
+ │         │    │    │    ├── key: (1)
+ │         │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+ │         │    │    │    ├── left-join
+ │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+ │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), ()~~>(25)
+ │         │    │    │    │    ├── index-join instance_types
+ │         │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │         │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+ │         │    │    │    │    │    └── select
+ │         │    │    │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string!null) instance_types.deleted:13(bool!null)
+ │         │    │    │    │    │         ├── key: (1)
+ │         │    │    │    │    │         ├── fd: (1)-->(2,13), (2,13)-->(1)
+ │         │    │    │    │    │         ├── scan instance_types@secondary
+ │         │    │    │    │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string!null) instance_types.deleted:13(bool)
+ │         │    │    │    │    │         │    ├── constraint: /2/13: (/NULL - ]
+ │         │    │    │    │    │         │    ├── key: (1)
+ │         │    │    │    │    │         │    └── fd: (1)-->(2,13), (2,13)~~>(1)
+ │         │    │    │    │    │         └── filters [type=bool, outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ])]
+ │         │    │    │    │    │              ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+ │         │    │    │    │    │              └── name = $4 [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
+ │         │    │    │    │    ├── project
+ │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+ │         │    │    │    │    │    ├── fd: ()-->(25)
+ │         │    │    │    │    │    ├── select
+ │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+ │         │    │    │    │    │    │    ├── scan instance_type_projects@secondary
+ │         │    │    │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+ │         │    │    │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+ │         │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+ │         │    │    │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+ │         │    │    │    │    │    └── projections [outer=(18)]
+ │         │    │    │    │    │         └── true [type=bool]
+ │         │    │    │    │    └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+ │         │    │    │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+ │         │    │    │    └── aggregations [outer=(2-16,25)]
+ │         │    │    │         ├── const-not-null-agg [type=bool, outer=(25)]
+ │         │    │    │         │    └── variable: true [type=bool, outer=(25)]
+ │         │    │    │         ├── const-agg [type=string, outer=(2)]
+ │         │    │    │         │    └── variable: name [type=string, outer=(2)]
+ │         │    │    │         ├── const-agg [type=int, outer=(3)]
+ │         │    │    │         │    └── variable: memory_mb [type=int, outer=(3)]
+ │         │    │    │         ├── const-agg [type=int, outer=(4)]
+ │         │    │    │         │    └── variable: vcpus [type=int, outer=(4)]
+ │         │    │    │         ├── const-agg [type=int, outer=(5)]
+ │         │    │    │         │    └── variable: root_gb [type=int, outer=(5)]
+ │         │    │    │         ├── const-agg [type=int, outer=(6)]
+ │         │    │    │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
+ │         │    │    │         ├── const-agg [type=string, outer=(7)]
+ │         │    │    │         │    └── variable: flavorid [type=string, outer=(7)]
+ │         │    │    │         ├── const-agg [type=int, outer=(8)]
+ │         │    │    │         │    └── variable: swap [type=int, outer=(8)]
+ │         │    │    │         ├── const-agg [type=float, outer=(9)]
+ │         │    │    │         │    └── variable: rxtx_factor [type=float, outer=(9)]
+ │         │    │    │         ├── const-agg [type=int, outer=(10)]
+ │         │    │    │         │    └── variable: vcpu_weight [type=int, outer=(10)]
+ │         │    │    │         ├── const-agg [type=bool, outer=(11)]
+ │         │    │    │         │    └── variable: disabled [type=bool, outer=(11)]
+ │         │    │    │         ├── const-agg [type=bool, outer=(12)]
+ │         │    │    │         │    └── variable: is_public [type=bool, outer=(12)]
+ │         │    │    │         ├── const-agg [type=bool, outer=(13)]
+ │         │    │    │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+ │         │    │    │         ├── const-agg [type=timestamp, outer=(14)]
+ │         │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+ │         │    │    │         ├── const-agg [type=timestamp, outer=(15)]
+ │         │    │    │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+ │         │    │    │         └── const-agg [type=timestamp, outer=(16)]
+ │         │    │    │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+ │         │    │    └── filters [type=bool, outer=(12,26)]
+ │         │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
+ │         │    └── placeholder: $5 [type=int]
+ │         └── placeholder: $6 [type=int]
+ └── filters [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
+      └── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -1159,115 +1162,117 @@ from (select instance_types.created_at as instance_types_created_at,
      on instance_type_extra_specs_1.instance_type_id = anon_1.instance_types_id
         and instance_type_extra_specs_1.deleted = $7
 ----
-left-join (lookup instance_type_extra_specs)
+right-join
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
- ├── key columns: [28] = [28]
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
- ├── left-join (lookup instance_type_extra_specs@secondary)
- │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
- │    ├── key columns: [1] = [31]
- │    ├── key: (1,28)
- │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
- │    ├── project
- │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │    └── limit
- │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         ├── key: (1)
- │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         ├── offset
- │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    ├── key: (1)
- │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    ├── select
- │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │    ├── key: (1)
- │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    ├── group-by
- │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │    │    ├── grouping columns: instance_types.id:1(int!null)
- │    │         │    │    │    ├── key: (1)
- │    │         │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    │    ├── left-join (merge)
- │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
- │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
- │    │         │    │    │    │    ├── select
- │    │         │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │    │    │    │    ├── key: (1)
- │    │         │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    │    │    │    ├── ordering: +1
- │    │         │    │    │    │    │    ├── scan instance_types
- │    │         │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │    │    │    │    │    ├── key: (1)
- │    │         │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    │    │    │    │    └── ordering: +1
- │    │         │    │    │    │    │    └── filters [type=bool, outer=(1,13), constraints=(/1: (/NULL - ]; /13: (/NULL - ])]
- │    │         │    │    │    │    │         ├── instance_types.id = $4 [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
- │    │         │    │    │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
- │    │         │    │    │    │    ├── project
- │    │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
- │    │         │    │    │    │    │    ├── fd: ()-->(25)
- │    │         │    │    │    │    │    ├── ordering: +18 opt(25)
- │    │         │    │    │    │    │    ├── select
- │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
- │    │         │    │    │    │    │    │    ├── ordering: +18
- │    │         │    │    │    │    │    │    ├── scan instance_type_projects@secondary
- │    │         │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
- │    │         │    │    │    │    │    │    │    └── ordering: +18
- │    │         │    │    │    │    │    │    └── filters [type=bool, outer=(18-20), constraints=(/18: (/NULL - ]; /19: (/NULL - ]; /20: (/NULL - ])]
- │    │         │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
- │    │         │    │    │    │    │    │         ├── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
- │    │         │    │    │    │    │    │         └── instance_type_projects.instance_type_id = $4 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
- │    │         │    │    │    │    │    └── projections [outer=(18)]
- │    │         │    │    │    │    │         └── true [type=bool]
- │    │         │    │    │    │    └── merge-on
- │    │         │    │    │    │         ├── left ordering: +1
- │    │         │    │    │    │         ├── right ordering: +18
- │    │         │    │    │    │         └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
- │    │         │    │    │    │              └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
- │    │         │    │    │    └── aggregations [outer=(2-16,25)]
- │    │         │    │    │         ├── const-not-null-agg [type=bool, outer=(25)]
- │    │         │    │    │         │    └── variable: true [type=bool, outer=(25)]
- │    │         │    │    │         ├── const-agg [type=string, outer=(2)]
- │    │         │    │    │         │    └── variable: name [type=string, outer=(2)]
- │    │         │    │    │         ├── const-agg [type=int, outer=(3)]
- │    │         │    │    │         │    └── variable: memory_mb [type=int, outer=(3)]
- │    │         │    │    │         ├── const-agg [type=int, outer=(4)]
- │    │         │    │    │         │    └── variable: vcpus [type=int, outer=(4)]
- │    │         │    │    │         ├── const-agg [type=int, outer=(5)]
- │    │         │    │    │         │    └── variable: root_gb [type=int, outer=(5)]
- │    │         │    │    │         ├── const-agg [type=int, outer=(6)]
- │    │         │    │    │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
- │    │         │    │    │         ├── const-agg [type=string, outer=(7)]
- │    │         │    │    │         │    └── variable: flavorid [type=string, outer=(7)]
- │    │         │    │    │         ├── const-agg [type=int, outer=(8)]
- │    │         │    │    │         │    └── variable: swap [type=int, outer=(8)]
- │    │         │    │    │         ├── const-agg [type=float, outer=(9)]
- │    │         │    │    │         │    └── variable: rxtx_factor [type=float, outer=(9)]
- │    │         │    │    │         ├── const-agg [type=int, outer=(10)]
- │    │         │    │    │         │    └── variable: vcpu_weight [type=int, outer=(10)]
- │    │         │    │    │         ├── const-agg [type=bool, outer=(11)]
- │    │         │    │    │         │    └── variable: disabled [type=bool, outer=(11)]
- │    │         │    │    │         ├── const-agg [type=bool, outer=(12)]
- │    │         │    │    │         │    └── variable: is_public [type=bool, outer=(12)]
- │    │         │    │    │         ├── const-agg [type=bool, outer=(13)]
- │    │         │    │    │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
- │    │         │    │    │         ├── const-agg [type=timestamp, outer=(14)]
- │    │         │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
- │    │         │    │    │         ├── const-agg [type=timestamp, outer=(15)]
- │    │         │    │    │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
- │    │         │    │    │         └── const-agg [type=timestamp, outer=(16)]
- │    │         │    │    │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
- │    │         │    │    └── filters [type=bool, outer=(12,26)]
- │    │         │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
- │    │         │    └── placeholder: $5 [type=int]
- │    │         └── placeholder: $6 [type=int]
- │    └── filters [type=bool, outer=(1,31,32), constraints=(/1: (/NULL - ]; /31: (/NULL - ]; /32: (/NULL - ]), fd=(1)==(31), (31)==(1)]
- │         ├── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
+ ├── select
+ │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool!null) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+ │    ├── key: (28)
+ │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ │    ├── scan instance_type_extra_specs
+ │    │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+ │    │    ├── key: (28)
+ │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ │    └── filters [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
  │         └── instance_type_extra_specs.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
- └── true [type=bool]
+ ├── project
+ │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │    └── limit
+ │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         ├── offset
+ │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │         │    ├── key: (1)
+ │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         │    ├── select
+ │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │         │    │    ├── key: (1)
+ │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         │    │    ├── group-by
+ │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │         │    │    │    ├── grouping columns: instance_types.id:1(int!null)
+ │         │    │    │    ├── key: (1)
+ │         │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         │    │    │    ├── left-join (merge)
+ │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+ │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+ │         │    │    │    │    ├── select
+ │         │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │         │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         │    │    │    │    │    ├── ordering: +1
+ │         │    │    │    │    │    ├── scan instance_types
+ │         │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │         │    │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         │    │    │    │    │    │    └── ordering: +1
+ │         │    │    │    │    │    └── filters [type=bool, outer=(1,13), constraints=(/1: (/NULL - ]; /13: (/NULL - ])]
+ │         │    │    │    │    │         ├── instance_types.id = $4 [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+ │         │    │    │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+ │         │    │    │    │    ├── project
+ │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+ │         │    │    │    │    │    ├── fd: ()-->(25)
+ │         │    │    │    │    │    ├── ordering: +18 opt(25)
+ │         │    │    │    │    │    ├── select
+ │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+ │         │    │    │    │    │    │    ├── ordering: +18
+ │         │    │    │    │    │    │    ├── scan instance_type_projects@secondary
+ │         │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+ │         │    │    │    │    │    │    │    └── ordering: +18
+ │         │    │    │    │    │    │    └── filters [type=bool, outer=(18-20), constraints=(/18: (/NULL - ]; /19: (/NULL - ]; /20: (/NULL - ])]
+ │         │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+ │         │    │    │    │    │    │         ├── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+ │         │    │    │    │    │    │         └── instance_type_projects.instance_type_id = $4 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+ │         │    │    │    │    │    └── projections [outer=(18)]
+ │         │    │    │    │    │         └── true [type=bool]
+ │         │    │    │    │    └── merge-on
+ │         │    │    │    │         ├── left ordering: +1
+ │         │    │    │    │         ├── right ordering: +18
+ │         │    │    │    │         └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+ │         │    │    │    │              └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+ │         │    │    │    └── aggregations [outer=(2-16,25)]
+ │         │    │    │         ├── const-not-null-agg [type=bool, outer=(25)]
+ │         │    │    │         │    └── variable: true [type=bool, outer=(25)]
+ │         │    │    │         ├── const-agg [type=string, outer=(2)]
+ │         │    │    │         │    └── variable: name [type=string, outer=(2)]
+ │         │    │    │         ├── const-agg [type=int, outer=(3)]
+ │         │    │    │         │    └── variable: memory_mb [type=int, outer=(3)]
+ │         │    │    │         ├── const-agg [type=int, outer=(4)]
+ │         │    │    │         │    └── variable: vcpus [type=int, outer=(4)]
+ │         │    │    │         ├── const-agg [type=int, outer=(5)]
+ │         │    │    │         │    └── variable: root_gb [type=int, outer=(5)]
+ │         │    │    │         ├── const-agg [type=int, outer=(6)]
+ │         │    │    │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
+ │         │    │    │         ├── const-agg [type=string, outer=(7)]
+ │         │    │    │         │    └── variable: flavorid [type=string, outer=(7)]
+ │         │    │    │         ├── const-agg [type=int, outer=(8)]
+ │         │    │    │         │    └── variable: swap [type=int, outer=(8)]
+ │         │    │    │         ├── const-agg [type=float, outer=(9)]
+ │         │    │    │         │    └── variable: rxtx_factor [type=float, outer=(9)]
+ │         │    │    │         ├── const-agg [type=int, outer=(10)]
+ │         │    │    │         │    └── variable: vcpu_weight [type=int, outer=(10)]
+ │         │    │    │         ├── const-agg [type=bool, outer=(11)]
+ │         │    │    │         │    └── variable: disabled [type=bool, outer=(11)]
+ │         │    │    │         ├── const-agg [type=bool, outer=(12)]
+ │         │    │    │         │    └── variable: is_public [type=bool, outer=(12)]
+ │         │    │    │         ├── const-agg [type=bool, outer=(13)]
+ │         │    │    │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+ │         │    │    │         ├── const-agg [type=timestamp, outer=(14)]
+ │         │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+ │         │    │    │         ├── const-agg [type=timestamp, outer=(15)]
+ │         │    │    │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+ │         │    │    │         └── const-agg [type=timestamp, outer=(16)]
+ │         │    │    │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+ │         │    │    └── filters [type=bool, outer=(12,26)]
+ │         │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
+ │         │    └── placeholder: $5 [type=int]
+ │         └── placeholder: $6 [type=int]
+ └── filters [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
+      └── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -1792,125 +1797,128 @@ from (select instance_types.created_at as instance_types_created_at,
 order by anon_1.instance_types_flavorid asc,
          anon_1.instance_types_id asc
 ----
-left-join (lookup instance_type_extra_specs)
+sort
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
- ├── key columns: [28] = [28]
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── ordering: +7,+1
- ├── left-join (lookup instance_type_extra_specs@secondary)
- │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
- │    ├── key columns: [1] = [31]
- │    ├── key: (1,28)
- │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
- │    ├── ordering: +7,+1
- │    ├── project
- │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │    ├── ordering: +7,+1
- │    │    └── limit
- │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         ├── internal-ordering: +7,+1
- │    │         ├── key: (1)
- │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         ├── ordering: +7,+1
- │    │         ├── offset
- │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    ├── internal-ordering: +7,+1
- │    │         │    ├── key: (1)
- │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    ├── ordering: +7,+1
- │    │         │    ├── sort
- │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │    ├── key: (1)
- │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    ├── ordering: +7,+1
- │    │         │    │    └── select
- │    │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │         ├── key: (1)
- │    │         │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         ├── group-by
- │    │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
- │    │         │    │         │    ├── key: (1)
- │    │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    ├── left-join (merge)
- │    │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
- │    │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
- │    │         │    │         │    │    ├── select
- │    │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │         │    │    │    ├── key: (1)
- │    │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    │    │    ├── ordering: +1
- │    │         │    │         │    │    │    ├── scan instance_types
- │    │         │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │         │    │    │    │    ├── key: (1)
- │    │         │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    │    │    │    └── ordering: +1
- │    │         │    │         │    │    │    └── filters [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
- │    │         │    │         │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
- │    │         │    │         │    │    ├── project
- │    │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
- │    │         │    │         │    │    │    ├── fd: ()-->(25)
- │    │         │    │         │    │    │    ├── ordering: +18 opt(25)
- │    │         │    │         │    │    │    ├── select
- │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
- │    │         │    │         │    │    │    │    ├── ordering: +18
- │    │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
- │    │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
- │    │         │    │         │    │    │    │    │    └── ordering: +18
- │    │         │    │         │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
- │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
- │    │         │    │         │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
- │    │         │    │         │    │    │    └── projections [outer=(18)]
- │    │         │    │         │    │    │         └── true [type=bool]
- │    │         │    │         │    │    └── merge-on
- │    │         │    │         │    │         ├── left ordering: +1
- │    │         │    │         │    │         ├── right ordering: +18
- │    │         │    │         │    │         └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
- │    │         │    │         │    │              └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
- │    │         │    │         │    └── aggregations [outer=(2-16,25)]
- │    │         │    │         │         ├── const-not-null-agg [type=bool, outer=(25)]
- │    │         │    │         │         │    └── variable: true [type=bool, outer=(25)]
- │    │         │    │         │         ├── const-agg [type=string, outer=(2)]
- │    │         │    │         │         │    └── variable: name [type=string, outer=(2)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(3)]
- │    │         │    │         │         │    └── variable: memory_mb [type=int, outer=(3)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(4)]
- │    │         │    │         │         │    └── variable: vcpus [type=int, outer=(4)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(5)]
- │    │         │    │         │         │    └── variable: root_gb [type=int, outer=(5)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(6)]
- │    │         │    │         │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
- │    │         │    │         │         ├── const-agg [type=string, outer=(7)]
- │    │         │    │         │         │    └── variable: flavorid [type=string, outer=(7)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(8)]
- │    │         │    │         │         │    └── variable: swap [type=int, outer=(8)]
- │    │         │    │         │         ├── const-agg [type=float, outer=(9)]
- │    │         │    │         │         │    └── variable: rxtx_factor [type=float, outer=(9)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(10)]
- │    │         │    │         │         │    └── variable: vcpu_weight [type=int, outer=(10)]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(11)]
- │    │         │    │         │         │    └── variable: disabled [type=bool, outer=(11)]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(12)]
- │    │         │    │         │         │    └── variable: is_public [type=bool, outer=(12)]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(13)]
- │    │         │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
- │    │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
- │    │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
- │    │         │    │         │         ├── const-agg [type=timestamp, outer=(15)]
- │    │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
- │    │         │    │         │         └── const-agg [type=timestamp, outer=(16)]
- │    │         │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
- │    │         │    │         └── filters [type=bool, outer=(12,26)]
- │    │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
- │    │         │    └── placeholder: $4 [type=int]
- │    │         └── placeholder: $5 [type=int]
- │    └── filters [type=bool, outer=(1,31,32), constraints=(/1: (/NULL - ]; /31: (/NULL - ]; /32: (/NULL - ]), fd=(1)==(31), (31)==(1)]
- │         ├── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
- │         └── instance_type_extra_specs.deleted = $6 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
- └── true [type=bool]
+ └── right-join
+      ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      ├── key: (1,28)
+      ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      ├── select
+      │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool!null) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      │    ├── key: (28)
+      │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    ├── scan instance_type_extra_specs
+      │    │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      │    │    ├── key: (28)
+      │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    └── filters [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      │         └── instance_type_extra_specs.deleted = $6 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      ├── project
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    └── limit
+      │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         ├── internal-ordering: +7,+1
+      │         ├── key: (1)
+      │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         ├── offset
+      │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    ├── internal-ordering: +7,+1
+      │         │    ├── key: (1)
+      │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    ├── ordering: +7,+1
+      │         │    ├── sort
+      │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    │    ├── key: (1)
+      │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │    ├── ordering: +7,+1
+      │         │    │    └── select
+      │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    │         ├── key: (1)
+      │         │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         ├── group-by
+      │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+      │         │    │         │    ├── key: (1)
+      │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    ├── left-join (merge)
+      │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+      │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+      │         │    │         │    │    ├── select
+      │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │    ├── key: (1)
+      │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    │    │    ├── ordering: +1
+      │         │    │         │    │    │    ├── scan instance_types
+      │         │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │    │    ├── key: (1)
+      │         │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    │    │    │    └── ordering: +1
+      │         │    │         │    │    │    └── filters [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │         │    │         │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │         │    │         │    │    │    ├── fd: ()-->(25)
+      │         │    │         │    │    │    ├── ordering: +18 opt(25)
+      │         │    │         │    │    │    ├── select
+      │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+      │         │    │         │    │    │    │    ├── ordering: +18
+      │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
+      │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │         │    │         │    │    │    │    │    └── ordering: +18
+      │         │    │         │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │         │    │         │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │         │    │         │    │    │    └── projections [outer=(18)]
+      │         │    │         │    │    │         └── true [type=bool]
+      │         │    │         │    │    └── merge-on
+      │         │    │         │    │         ├── left ordering: +1
+      │         │    │         │    │         ├── right ordering: +18
+      │         │    │         │    │         └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+      │         │    │         │    │              └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+      │         │    │         │    └── aggregations [outer=(2-16,25)]
+      │         │    │         │         ├── const-not-null-agg [type=bool, outer=(25)]
+      │         │    │         │         │    └── variable: true [type=bool, outer=(25)]
+      │         │    │         │         ├── const-agg [type=string, outer=(2)]
+      │         │    │         │         │    └── variable: name [type=string, outer=(2)]
+      │         │    │         │         ├── const-agg [type=int, outer=(3)]
+      │         │    │         │         │    └── variable: memory_mb [type=int, outer=(3)]
+      │         │    │         │         ├── const-agg [type=int, outer=(4)]
+      │         │    │         │         │    └── variable: vcpus [type=int, outer=(4)]
+      │         │    │         │         ├── const-agg [type=int, outer=(5)]
+      │         │    │         │         │    └── variable: root_gb [type=int, outer=(5)]
+      │         │    │         │         ├── const-agg [type=int, outer=(6)]
+      │         │    │         │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │         ├── const-agg [type=string, outer=(7)]
+      │         │    │         │         │    └── variable: flavorid [type=string, outer=(7)]
+      │         │    │         │         ├── const-agg [type=int, outer=(8)]
+      │         │    │         │         │    └── variable: swap [type=int, outer=(8)]
+      │         │    │         │         ├── const-agg [type=float, outer=(9)]
+      │         │    │         │         │    └── variable: rxtx_factor [type=float, outer=(9)]
+      │         │    │         │         ├── const-agg [type=int, outer=(10)]
+      │         │    │         │         │    └── variable: vcpu_weight [type=int, outer=(10)]
+      │         │    │         │         ├── const-agg [type=bool, outer=(11)]
+      │         │    │         │         │    └── variable: disabled [type=bool, outer=(11)]
+      │         │    │         │         ├── const-agg [type=bool, outer=(12)]
+      │         │    │         │         │    └── variable: is_public [type=bool, outer=(12)]
+      │         │    │         │         ├── const-agg [type=bool, outer=(13)]
+      │         │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+      │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+      │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+      │         │    │         │         ├── const-agg [type=timestamp, outer=(15)]
+      │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+      │         │    │         │         └── const-agg [type=timestamp, outer=(16)]
+      │         │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+      │         │    │         └── filters [type=bool, outer=(12,26)]
+      │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
+      │         │    └── placeholder: $4 [type=int]
+      │         └── placeholder: $5 [type=int]
+      └── filters [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
+           └── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -1969,111 +1977,113 @@ from (select instance_types.created_at as instance_types_created_at,
      on instance_type_extra_specs_1.instance_type_id = anon_1.instance_types_id
         and instance_type_extra_specs_1.deleted = $7
 ----
-left-join (lookup instance_type_extra_specs)
+right-join
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
- ├── key columns: [28] = [28]
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
- ├── left-join (lookup instance_type_extra_specs@secondary)
- │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
- │    ├── key columns: [1] = [31]
- │    ├── key: (1,28)
- │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
- │    ├── project
- │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │    └── limit
- │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         ├── key: (1)
- │    │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         ├── offset
- │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    ├── key: (1)
- │    │         │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    ├── select
- │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │    ├── key: (1)
- │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    ├── group-by
- │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │    │    ├── grouping columns: instance_types.id:1(int!null)
- │    │         │    │    │    ├── key: (1)
- │    │         │    │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    │    ├── left-join
- │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
- │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
- │    │         │    │    │    │    ├── index-join instance_types
- │    │         │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │    │    │    │    ├── key: (1)
- │    │         │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    │    │    │    └── select
- │    │         │    │    │    │    │         ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool!null)
- │    │         │    │    │    │    │         ├── key: (1)
- │    │         │    │    │    │    │         ├── fd: (1)-->(7,13), (7,13)-->(1)
- │    │         │    │    │    │    │         ├── scan instance_types@secondary
- │    │         │    │    │    │    │         │    ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool)
- │    │         │    │    │    │    │         │    ├── constraint: /7/13: (/NULL - ]
- │    │         │    │    │    │    │         │    ├── key: (1)
- │    │         │    │    │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
- │    │         │    │    │    │    │         └── filters [type=bool, outer=(7,13), constraints=(/7: (/NULL - ]; /13: (/NULL - ])]
- │    │         │    │    │    │    │              ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
- │    │         │    │    │    │    │              └── flavorid = $4 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
- │    │         │    │    │    │    ├── project
- │    │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
- │    │         │    │    │    │    │    ├── fd: ()-->(25)
- │    │         │    │    │    │    │    ├── select
- │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
- │    │         │    │    │    │    │    │    ├── scan instance_type_projects@secondary
- │    │         │    │    │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
- │    │         │    │    │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
- │    │         │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
- │    │         │    │    │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
- │    │         │    │    │    │    │    └── projections [outer=(18)]
- │    │         │    │    │    │    │         └── true [type=bool]
- │    │         │    │    │    │    └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
- │    │         │    │    │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
- │    │         │    │    │    └── aggregations [outer=(2-16,25)]
- │    │         │    │    │         ├── const-not-null-agg [type=bool, outer=(25)]
- │    │         │    │    │         │    └── variable: true [type=bool, outer=(25)]
- │    │         │    │    │         ├── const-agg [type=string, outer=(2)]
- │    │         │    │    │         │    └── variable: name [type=string, outer=(2)]
- │    │         │    │    │         ├── const-agg [type=int, outer=(3)]
- │    │         │    │    │         │    └── variable: memory_mb [type=int, outer=(3)]
- │    │         │    │    │         ├── const-agg [type=int, outer=(4)]
- │    │         │    │    │         │    └── variable: vcpus [type=int, outer=(4)]
- │    │         │    │    │         ├── const-agg [type=int, outer=(5)]
- │    │         │    │    │         │    └── variable: root_gb [type=int, outer=(5)]
- │    │         │    │    │         ├── const-agg [type=int, outer=(6)]
- │    │         │    │    │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
- │    │         │    │    │         ├── const-agg [type=string, outer=(7)]
- │    │         │    │    │         │    └── variable: flavorid [type=string, outer=(7)]
- │    │         │    │    │         ├── const-agg [type=int, outer=(8)]
- │    │         │    │    │         │    └── variable: swap [type=int, outer=(8)]
- │    │         │    │    │         ├── const-agg [type=float, outer=(9)]
- │    │         │    │    │         │    └── variable: rxtx_factor [type=float, outer=(9)]
- │    │         │    │    │         ├── const-agg [type=int, outer=(10)]
- │    │         │    │    │         │    └── variable: vcpu_weight [type=int, outer=(10)]
- │    │         │    │    │         ├── const-agg [type=bool, outer=(11)]
- │    │         │    │    │         │    └── variable: disabled [type=bool, outer=(11)]
- │    │         │    │    │         ├── const-agg [type=bool, outer=(12)]
- │    │         │    │    │         │    └── variable: is_public [type=bool, outer=(12)]
- │    │         │    │    │         ├── const-agg [type=bool, outer=(13)]
- │    │         │    │    │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
- │    │         │    │    │         ├── const-agg [type=timestamp, outer=(14)]
- │    │         │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
- │    │         │    │    │         ├── const-agg [type=timestamp, outer=(15)]
- │    │         │    │    │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
- │    │         │    │    │         └── const-agg [type=timestamp, outer=(16)]
- │    │         │    │    │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
- │    │         │    │    └── filters [type=bool, outer=(12,26)]
- │    │         │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
- │    │         │    └── placeholder: $5 [type=int]
- │    │         └── placeholder: $6 [type=int]
- │    └── filters [type=bool, outer=(1,31,32), constraints=(/1: (/NULL - ]; /31: (/NULL - ]; /32: (/NULL - ]), fd=(1)==(31), (31)==(1)]
- │         ├── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
+ ├── select
+ │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool!null) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+ │    ├── key: (28)
+ │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ │    ├── scan instance_type_extra_specs
+ │    │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+ │    │    ├── key: (28)
+ │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+ │    └── filters [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
  │         └── instance_type_extra_specs.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
- └── true [type=bool]
+ ├── project
+ │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │    └── limit
+ │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         ├── offset
+ │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │         │    ├── key: (1)
+ │         │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         │    ├── select
+ │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │         │    │    ├── key: (1)
+ │         │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         │    │    ├── group-by
+ │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │         │    │    │    ├── grouping columns: instance_types.id:1(int!null)
+ │         │    │    │    ├── key: (1)
+ │         │    │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         │    │    │    ├── left-join
+ │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+ │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+ │         │    │    │    │    ├── index-join instance_types
+ │         │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │         │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+ │         │    │    │    │    │    └── select
+ │         │    │    │    │    │         ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool!null)
+ │         │    │    │    │    │         ├── key: (1)
+ │         │    │    │    │    │         ├── fd: (1)-->(7,13), (7,13)-->(1)
+ │         │    │    │    │    │         ├── scan instance_types@secondary
+ │         │    │    │    │    │         │    ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool)
+ │         │    │    │    │    │         │    ├── constraint: /7/13: (/NULL - ]
+ │         │    │    │    │    │         │    ├── key: (1)
+ │         │    │    │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
+ │         │    │    │    │    │         └── filters [type=bool, outer=(7,13), constraints=(/7: (/NULL - ]; /13: (/NULL - ])]
+ │         │    │    │    │    │              ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+ │         │    │    │    │    │              └── flavorid = $4 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
+ │         │    │    │    │    ├── project
+ │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+ │         │    │    │    │    │    ├── fd: ()-->(25)
+ │         │    │    │    │    │    ├── select
+ │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+ │         │    │    │    │    │    │    ├── scan instance_type_projects@secondary
+ │         │    │    │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+ │         │    │    │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+ │         │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+ │         │    │    │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+ │         │    │    │    │    │    └── projections [outer=(18)]
+ │         │    │    │    │    │         └── true [type=bool]
+ │         │    │    │    │    └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+ │         │    │    │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+ │         │    │    │    └── aggregations [outer=(2-16,25)]
+ │         │    │    │         ├── const-not-null-agg [type=bool, outer=(25)]
+ │         │    │    │         │    └── variable: true [type=bool, outer=(25)]
+ │         │    │    │         ├── const-agg [type=string, outer=(2)]
+ │         │    │    │         │    └── variable: name [type=string, outer=(2)]
+ │         │    │    │         ├── const-agg [type=int, outer=(3)]
+ │         │    │    │         │    └── variable: memory_mb [type=int, outer=(3)]
+ │         │    │    │         ├── const-agg [type=int, outer=(4)]
+ │         │    │    │         │    └── variable: vcpus [type=int, outer=(4)]
+ │         │    │    │         ├── const-agg [type=int, outer=(5)]
+ │         │    │    │         │    └── variable: root_gb [type=int, outer=(5)]
+ │         │    │    │         ├── const-agg [type=int, outer=(6)]
+ │         │    │    │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
+ │         │    │    │         ├── const-agg [type=string, outer=(7)]
+ │         │    │    │         │    └── variable: flavorid [type=string, outer=(7)]
+ │         │    │    │         ├── const-agg [type=int, outer=(8)]
+ │         │    │    │         │    └── variable: swap [type=int, outer=(8)]
+ │         │    │    │         ├── const-agg [type=float, outer=(9)]
+ │         │    │    │         │    └── variable: rxtx_factor [type=float, outer=(9)]
+ │         │    │    │         ├── const-agg [type=int, outer=(10)]
+ │         │    │    │         │    └── variable: vcpu_weight [type=int, outer=(10)]
+ │         │    │    │         ├── const-agg [type=bool, outer=(11)]
+ │         │    │    │         │    └── variable: disabled [type=bool, outer=(11)]
+ │         │    │    │         ├── const-agg [type=bool, outer=(12)]
+ │         │    │    │         │    └── variable: is_public [type=bool, outer=(12)]
+ │         │    │    │         ├── const-agg [type=bool, outer=(13)]
+ │         │    │    │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+ │         │    │    │         ├── const-agg [type=timestamp, outer=(14)]
+ │         │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+ │         │    │    │         ├── const-agg [type=timestamp, outer=(15)]
+ │         │    │    │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+ │         │    │    │         └── const-agg [type=timestamp, outer=(16)]
+ │         │    │    │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+ │         │    │    └── filters [type=bool, outer=(12,26)]
+ │         │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
+ │         │    └── placeholder: $5 [type=int]
+ │         └── placeholder: $6 [type=int]
+ └── filters [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
+      └── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
 
 opt
 select flavors.created_at as flavors_created_at,
@@ -2257,123 +2267,126 @@ from (select instance_types.created_at as instance_types_created_at,
 order by anon_1.instance_types_flavorid asc,
          anon_1.instance_types_id asc
 ----
-left-join (lookup instance_type_extra_specs)
+sort
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
- ├── key columns: [28] = [28]
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── ordering: +7,+1
- ├── left-join (lookup instance_type_extra_specs@secondary)
- │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
- │    ├── key columns: [1] = [31]
- │    ├── key: (1,28)
- │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
- │    ├── ordering: +7,+1
- │    ├── project
- │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │    ├── ordering: +7,+1
- │    │    └── limit
- │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         ├── internal-ordering: +7,+1
- │    │         ├── key: (1)
- │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         ├── ordering: +7,+1
- │    │         ├── offset
- │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    ├── internal-ordering: +7,+1
- │    │         │    ├── key: (1)
- │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    ├── ordering: +7,+1
- │    │         │    ├── sort
- │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │    ├── key: (1)
- │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    ├── ordering: +7,+1
- │    │         │    │    └── select
- │    │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │         ├── key: (1)
- │    │         │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         ├── group-by
- │    │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
- │    │         │    │         │    ├── key: (1)
- │    │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    ├── left-join
- │    │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
- │    │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
- │    │         │    │         │    │    ├── index-join instance_types
- │    │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │         │    │    │    ├── key: (1)
- │    │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    │    │    └── select
- │    │         │    │         │    │    │         ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool!null)
- │    │         │    │         │    │    │         ├── key: (1)
- │    │         │    │         │    │    │         ├── fd: (1)-->(7,13), (7,13)-->(1)
- │    │         │    │         │    │    │         ├── scan instance_types@secondary
- │    │         │    │         │    │    │         │    ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool)
- │    │         │    │         │    │    │         │    ├── constraint: /7/13: (/NULL - ]
- │    │         │    │         │    │    │         │    ├── key: (1)
- │    │         │    │         │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
- │    │         │    │         │    │    │         └── filters [type=bool, outer=(1,7,13), constraints=(/13: (/NULL - ])]
- │    │         │    │         │    │    │              ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
- │    │         │    │         │    │    │              └── (flavorid > $4) OR ((flavorid = $5) AND (instance_types.id > $6)) [type=bool, outer=(1,7)]
- │    │         │    │         │    │    ├── project
- │    │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
- │    │         │    │         │    │    │    ├── fd: ()-->(25)
- │    │         │    │         │    │    │    ├── select
- │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
- │    │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
- │    │         │    │         │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
- │    │         │    │         │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
- │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
- │    │         │    │         │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
- │    │         │    │         │    │    │    └── projections [outer=(18)]
- │    │         │    │         │    │    │         └── true [type=bool]
- │    │         │    │         │    │    └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
- │    │         │    │         │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
- │    │         │    │         │    └── aggregations [outer=(2-16,25)]
- │    │         │    │         │         ├── const-not-null-agg [type=bool, outer=(25)]
- │    │         │    │         │         │    └── variable: true [type=bool, outer=(25)]
- │    │         │    │         │         ├── const-agg [type=string, outer=(2)]
- │    │         │    │         │         │    └── variable: name [type=string, outer=(2)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(3)]
- │    │         │    │         │         │    └── variable: memory_mb [type=int, outer=(3)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(4)]
- │    │         │    │         │         │    └── variable: vcpus [type=int, outer=(4)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(5)]
- │    │         │    │         │         │    └── variable: root_gb [type=int, outer=(5)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(6)]
- │    │         │    │         │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
- │    │         │    │         │         ├── const-agg [type=string, outer=(7)]
- │    │         │    │         │         │    └── variable: flavorid [type=string, outer=(7)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(8)]
- │    │         │    │         │         │    └── variable: swap [type=int, outer=(8)]
- │    │         │    │         │         ├── const-agg [type=float, outer=(9)]
- │    │         │    │         │         │    └── variable: rxtx_factor [type=float, outer=(9)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(10)]
- │    │         │    │         │         │    └── variable: vcpu_weight [type=int, outer=(10)]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(11)]
- │    │         │    │         │         │    └── variable: disabled [type=bool, outer=(11)]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(12)]
- │    │         │    │         │         │    └── variable: is_public [type=bool, outer=(12)]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(13)]
- │    │         │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
- │    │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
- │    │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
- │    │         │    │         │         ├── const-agg [type=timestamp, outer=(15)]
- │    │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
- │    │         │    │         │         └── const-agg [type=timestamp, outer=(16)]
- │    │         │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
- │    │         │    │         └── filters [type=bool, outer=(12,26)]
- │    │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
- │    │         │    └── placeholder: $7 [type=int]
- │    │         └── placeholder: $8 [type=int]
- │    └── filters [type=bool, outer=(1,31,32), constraints=(/1: (/NULL - ]; /31: (/NULL - ]; /32: (/NULL - ]), fd=(1)==(31), (31)==(1)]
- │         ├── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
- │         └── instance_type_extra_specs.deleted = $9 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
- └── true [type=bool]
+ └── right-join
+      ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      ├── key: (1,28)
+      ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      ├── select
+      │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool!null) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      │    ├── key: (28)
+      │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    ├── scan instance_type_extra_specs
+      │    │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      │    │    ├── key: (28)
+      │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    └── filters [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      │         └── instance_type_extra_specs.deleted = $9 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      ├── project
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    └── limit
+      │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         ├── internal-ordering: +7,+1
+      │         ├── key: (1)
+      │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         ├── offset
+      │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    ├── internal-ordering: +7,+1
+      │         │    ├── key: (1)
+      │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    ├── ordering: +7,+1
+      │         │    ├── sort
+      │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    │    ├── key: (1)
+      │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │    ├── ordering: +7,+1
+      │         │    │    └── select
+      │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    │         ├── key: (1)
+      │         │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         ├── group-by
+      │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+      │         │    │         │    ├── key: (1)
+      │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    ├── left-join
+      │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+      │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+      │         │    │         │    │    ├── index-join instance_types
+      │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │    ├── key: (1)
+      │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    │    │    └── select
+      │         │    │         │    │    │         ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool!null)
+      │         │    │         │    │    │         ├── key: (1)
+      │         │    │         │    │    │         ├── fd: (1)-->(7,13), (7,13)-->(1)
+      │         │    │         │    │    │         ├── scan instance_types@secondary
+      │         │    │         │    │    │         │    ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool)
+      │         │    │         │    │    │         │    ├── constraint: /7/13: (/NULL - ]
+      │         │    │         │    │    │         │    ├── key: (1)
+      │         │    │         │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
+      │         │    │         │    │    │         └── filters [type=bool, outer=(1,7,13), constraints=(/13: (/NULL - ])]
+      │         │    │         │    │    │              ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │         │    │         │    │    │              └── (flavorid > $4) OR ((flavorid = $5) AND (instance_types.id > $6)) [type=bool, outer=(1,7)]
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │         │    │         │    │    │    ├── fd: ()-->(25)
+      │         │    │         │    │    │    ├── select
+      │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+      │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
+      │         │    │         │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │         │    │         │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │         │    │         │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │         │    │         │    │    │    └── projections [outer=(18)]
+      │         │    │         │    │    │         └── true [type=bool]
+      │         │    │         │    │    └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+      │         │    │         │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+      │         │    │         │    └── aggregations [outer=(2-16,25)]
+      │         │    │         │         ├── const-not-null-agg [type=bool, outer=(25)]
+      │         │    │         │         │    └── variable: true [type=bool, outer=(25)]
+      │         │    │         │         ├── const-agg [type=string, outer=(2)]
+      │         │    │         │         │    └── variable: name [type=string, outer=(2)]
+      │         │    │         │         ├── const-agg [type=int, outer=(3)]
+      │         │    │         │         │    └── variable: memory_mb [type=int, outer=(3)]
+      │         │    │         │         ├── const-agg [type=int, outer=(4)]
+      │         │    │         │         │    └── variable: vcpus [type=int, outer=(4)]
+      │         │    │         │         ├── const-agg [type=int, outer=(5)]
+      │         │    │         │         │    └── variable: root_gb [type=int, outer=(5)]
+      │         │    │         │         ├── const-agg [type=int, outer=(6)]
+      │         │    │         │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │         ├── const-agg [type=string, outer=(7)]
+      │         │    │         │         │    └── variable: flavorid [type=string, outer=(7)]
+      │         │    │         │         ├── const-agg [type=int, outer=(8)]
+      │         │    │         │         │    └── variable: swap [type=int, outer=(8)]
+      │         │    │         │         ├── const-agg [type=float, outer=(9)]
+      │         │    │         │         │    └── variable: rxtx_factor [type=float, outer=(9)]
+      │         │    │         │         ├── const-agg [type=int, outer=(10)]
+      │         │    │         │         │    └── variable: vcpu_weight [type=int, outer=(10)]
+      │         │    │         │         ├── const-agg [type=bool, outer=(11)]
+      │         │    │         │         │    └── variable: disabled [type=bool, outer=(11)]
+      │         │    │         │         ├── const-agg [type=bool, outer=(12)]
+      │         │    │         │         │    └── variable: is_public [type=bool, outer=(12)]
+      │         │    │         │         ├── const-agg [type=bool, outer=(13)]
+      │         │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+      │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+      │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+      │         │    │         │         ├── const-agg [type=timestamp, outer=(15)]
+      │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+      │         │    │         │         └── const-agg [type=timestamp, outer=(16)]
+      │         │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+      │         │    │         └── filters [type=bool, outer=(12,26)]
+      │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
+      │         │    └── placeholder: $7 [type=int]
+      │         └── placeholder: $8 [type=int]
+      └── filters [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
+           └── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -2598,192 +2611,195 @@ from (select instance_types.created_at as instance_types_created_at,
 order by anon_1.instance_types_flavorid asc,
          anon_1.instance_types_id asc
 ----
-left-join (lookup instance_type_extra_specs)
+sort
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:45(timestamp) instance_type_extra_specs_1_updated_at:46(timestamp) instance_type_extra_specs_1_deleted_at:44(timestamp) instance_type_extra_specs_1_deleted:43(bool) instance_type_extra_specs_1_id:39(int) instance_type_extra_specs_1_key:40(string) instance_type_extra_specs_1_value:41(string) instance_type_extra_specs_1_instance_type_id:42(int)
- ├── key columns: [39] = [39]
  ├── key: (1,39)
  ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
  ├── ordering: +7,+1 opt(11)
- ├── left-join (lookup instance_type_extra_specs@secondary)
- │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:39(int) key:40(string) instance_type_extra_specs.instance_type_id:42(int) instance_type_extra_specs.deleted:43(bool)
- │    ├── key columns: [1] = [42]
- │    ├── key: (1,39)
- │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40,42,43), (40,42,43)~~>(39)
- │    ├── ordering: +7,+1 opt(11)
- │    ├── project
- │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │    ├── key: (1)
- │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │    ├── ordering: +7,+1 opt(11)
- │    │    └── limit
- │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
- │    │         ├── internal-ordering: +7,+1 opt(11)
- │    │         ├── key: (1)
- │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         ├── ordering: +7,+1 opt(11)
- │    │         ├── offset
- │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
- │    │         │    ├── internal-ordering: +7,+1 opt(11)
- │    │         │    ├── key: (1)
- │    │         │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    ├── ordering: +7,+1 opt(11)
- │    │         │    ├── sort
- │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
- │    │         │    │    ├── key: (1)
- │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │    ├── ordering: +7,+1 opt(11)
- │    │         │    │    └── select
- │    │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
- │    │         │    │         ├── key: (1)
- │    │         │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         ├── group-by
- │    │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
- │    │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
- │    │         │    │         │    ├── key: (1)
- │    │         │    │         │    ├── fd: ()-->(11), (1)-->(2-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    ├── left-join
- │    │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:26(int) true:36(bool)
- │    │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(36)
- │    │         │    │         │    │    ├── project
- │    │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │         │    │    │    ├── key: (1)
- │    │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    │    │    └── select
- │    │         │    │         │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
- │    │         │    │         │    │    │         ├── key: (1)
- │    │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    │    │         ├── group-by
- │    │         │    │         │    │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
- │    │         │    │         │    │    │         │    ├── grouping columns: instance_types.id:1(int!null)
- │    │         │    │         │    │    │         │    ├── key: (1)
- │    │         │    │         │    │    │         │    ├── fd: ()-->(11), (1)-->(2-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    │    │         │    ├── left-join (merge)
- │    │         │    │         │    │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:33(bool)
- │    │         │    │         │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(33)
- │    │         │    │         │    │    │         │    │    ├── select
- │    │         │    │         │    │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │         │    │    │         │    │    │    ├── key: (1)
- │    │         │    │         │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    │    │         │    │    │    ├── ordering: +1 opt(11)
- │    │         │    │         │    │    │         │    │    │    ├── scan instance_types
- │    │         │    │         │    │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │         │    │    │         │    │    │    │    ├── key: (1)
- │    │         │    │         │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    │    │         │    │    │    │    └── ordering: +1 opt(11)
- │    │         │    │         │    │    │         │    │    │    └── filters [type=bool, outer=(11,13), constraints=(/11: [/false - /false]; /13: (/NULL - ]), fd=()-->(11)]
- │    │         │    │         │    │    │         │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
- │    │         │    │         │    │    │         │    │    │         └── disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight)]
- │    │         │    │         │    │    │         │    │    ├── project
- │    │         │    │         │    │    │         │    │    │    ├── columns: true:33(bool!null) instance_type_projects.instance_type_id:18(int!null)
- │    │         │    │         │    │    │         │    │    │    ├── fd: ()-->(33)
- │    │         │    │         │    │    │         │    │    │    ├── ordering: +18 opt(33)
- │    │         │    │         │    │    │         │    │    │    ├── select
- │    │         │    │         │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) instance_type_projects.project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
- │    │         │    │         │    │    │         │    │    │    │    ├── ordering: +18
- │    │         │    │         │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
- │    │         │    │         │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) instance_type_projects.project_id:19(string) instance_type_projects.deleted:20(bool)
- │    │         │    │         │    │    │         │    │    │    │    │    └── ordering: +18
- │    │         │    │         │    │    │         │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
- │    │         │    │         │    │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
- │    │         │    │         │    │    │         │    │    │    │         └── instance_type_projects.project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
- │    │         │    │         │    │    │         │    │    │    └── projections [outer=(18)]
- │    │         │    │         │    │    │         │    │    │         └── true [type=bool]
- │    │         │    │         │    │    │         │    │    └── merge-on
- │    │         │    │         │    │    │         │    │         ├── left ordering: +1
- │    │         │    │         │    │    │         │    │         ├── right ordering: +18
- │    │         │    │         │    │    │         │    │         └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
- │    │         │    │         │    │    │         │    │              └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
- │    │         │    │         │    │    │         │    └── aggregations [outer=(2-16,33)]
- │    │         │    │         │    │    │         │         ├── const-not-null-agg [type=bool, outer=(33)]
- │    │         │    │         │    │    │         │         │    └── variable: true [type=bool, outer=(33)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=string, outer=(2)]
- │    │         │    │         │    │    │         │         │    └── variable: name [type=string, outer=(2)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(3)]
- │    │         │    │         │    │    │         │         │    └── variable: memory_mb [type=int, outer=(3)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(4)]
- │    │         │    │         │    │    │         │         │    └── variable: vcpus [type=int, outer=(4)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(5)]
- │    │         │    │         │    │    │         │         │    └── variable: root_gb [type=int, outer=(5)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(6)]
- │    │         │    │         │    │    │         │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=string, outer=(7)]
- │    │         │    │         │    │    │         │         │    └── variable: flavorid [type=string, outer=(7)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(8)]
- │    │         │    │         │    │    │         │         │    └── variable: swap [type=int, outer=(8)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=float, outer=(9)]
- │    │         │    │         │    │    │         │         │    └── variable: rxtx_factor [type=float, outer=(9)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(10)]
- │    │         │    │         │    │    │         │         │    └── variable: vcpu_weight [type=int, outer=(10)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=bool, outer=(11)]
- │    │         │    │         │    │    │         │         │    └── variable: disabled [type=bool, outer=(11)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=bool, outer=(12)]
- │    │         │    │         │    │    │         │         │    └── variable: is_public [type=bool, outer=(12)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=bool, outer=(13)]
- │    │         │    │         │    │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=timestamp, outer=(14)]
- │    │         │    │         │    │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
- │    │         │    │         │    │    │         │         ├── const-agg [type=timestamp, outer=(15)]
- │    │         │    │         │    │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
- │    │         │    │         │    │    │         │         └── const-agg [type=timestamp, outer=(16)]
- │    │         │    │         │    │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
- │    │         │    │         │    │    │         └── filters [type=bool, outer=(12,34)]
- │    │         │    │         │    │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,34)]
- │    │         │    │         │    │    ├── project
- │    │         │    │         │    │    │    ├── columns: true:36(bool!null) instance_type_projects.instance_type_id:26(int!null)
- │    │         │    │         │    │    │    ├── fd: ()-->(36)
- │    │         │    │         │    │    │    ├── select
- │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) instance_type_projects.project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
- │    │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
- │    │         │    │         │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:26(int!null) instance_type_projects.project_id:27(string) instance_type_projects.deleted:28(bool)
- │    │         │    │         │    │    │    │    └── filters [type=bool, outer=(27,28), constraints=(/27: (/NULL - ]; /28: (/NULL - ])]
- │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $4 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
- │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $5 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
- │    │         │    │         │    │    │    │         └── instance_type_projects.project_id = $6 [type=bool, outer=(27), constraints=(/27: (/NULL - ])]
- │    │         │    │         │    │    │    └── projections [outer=(26)]
- │    │         │    │         │    │    │         └── true [type=bool]
- │    │         │    │         │    │    └── filters [type=bool, outer=(1,26), constraints=(/1: (/NULL - ]; /26: (/NULL - ]), fd=(1)==(26), (26)==(1)]
- │    │         │    │         │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,26), constraints=(/1: (/NULL - ]; /26: (/NULL - ])]
- │    │         │    │         │    └── aggregations [outer=(2-16,36)]
- │    │         │    │         │         ├── const-not-null-agg [type=bool, outer=(36)]
- │    │         │    │         │         │    └── variable: true [type=bool, outer=(36)]
- │    │         │    │         │         ├── const-agg [type=string, outer=(2)]
- │    │         │    │         │         │    └── variable: name [type=string, outer=(2)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(3)]
- │    │         │    │         │         │    └── variable: memory_mb [type=int, outer=(3)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(4)]
- │    │         │    │         │         │    └── variable: vcpus [type=int, outer=(4)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(5)]
- │    │         │    │         │         │    └── variable: root_gb [type=int, outer=(5)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(6)]
- │    │         │    │         │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
- │    │         │    │         │         ├── const-agg [type=string, outer=(7)]
- │    │         │    │         │         │    └── variable: flavorid [type=string, outer=(7)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(8)]
- │    │         │    │         │         │    └── variable: swap [type=int, outer=(8)]
- │    │         │    │         │         ├── const-agg [type=float, outer=(9)]
- │    │         │    │         │         │    └── variable: rxtx_factor [type=float, outer=(9)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(10)]
- │    │         │    │         │         │    └── variable: vcpu_weight [type=int, outer=(10)]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(11)]
- │    │         │    │         │         │    └── variable: disabled [type=bool, outer=(11)]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(12)]
- │    │         │    │         │         │    └── variable: is_public [type=bool, outer=(12)]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(13)]
- │    │         │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
- │    │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
- │    │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
- │    │         │    │         │         ├── const-agg [type=timestamp, outer=(15)]
- │    │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
- │    │         │    │         │         └── const-agg [type=timestamp, outer=(16)]
- │    │         │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
- │    │         │    │         └── filters [type=bool, outer=(12,37)]
- │    │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,37)]
- │    │         │    └── placeholder: $7 [type=int]
- │    │         └── placeholder: $8 [type=int]
- │    └── filters [type=bool, outer=(1,42,43), constraints=(/1: (/NULL - ]; /42: (/NULL - ]; /43: (/NULL - ]), fd=(1)==(42), (42)==(1)]
- │         ├── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,42), constraints=(/1: (/NULL - ]; /42: (/NULL - ])]
- │         └── instance_type_extra_specs.deleted = $9 [type=bool, outer=(43), constraints=(/43: (/NULL - ])]
- └── true [type=bool]
+ └── right-join
+      ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:39(int) key:40(string) value:41(string) instance_type_extra_specs.instance_type_id:42(int) instance_type_extra_specs.deleted:43(bool) instance_type_extra_specs.deleted_at:44(timestamp) instance_type_extra_specs.created_at:45(timestamp) instance_type_extra_specs.updated_at:46(timestamp)
+      ├── key: (1,39)
+      ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
+      ├── select
+      │    ├── columns: instance_type_extra_specs.id:39(int!null) key:40(string) value:41(string) instance_type_extra_specs.instance_type_id:42(int!null) instance_type_extra_specs.deleted:43(bool!null) instance_type_extra_specs.deleted_at:44(timestamp) instance_type_extra_specs.created_at:45(timestamp) instance_type_extra_specs.updated_at:46(timestamp)
+      │    ├── key: (39)
+      │    ├── fd: (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
+      │    ├── scan instance_type_extra_specs
+      │    │    ├── columns: instance_type_extra_specs.id:39(int!null) key:40(string) value:41(string) instance_type_extra_specs.instance_type_id:42(int!null) instance_type_extra_specs.deleted:43(bool) instance_type_extra_specs.deleted_at:44(timestamp) instance_type_extra_specs.created_at:45(timestamp) instance_type_extra_specs.updated_at:46(timestamp)
+      │    │    ├── key: (39)
+      │    │    └── fd: (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
+      │    └── filters [type=bool, outer=(43), constraints=(/43: (/NULL - ])]
+      │         └── instance_type_extra_specs.deleted = $9 [type=bool, outer=(43), constraints=(/43: (/NULL - ])]
+      ├── project
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    ├── key: (1)
+      │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    └── limit
+      │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+      │         ├── internal-ordering: +7,+1 opt(11)
+      │         ├── key: (1)
+      │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         ├── offset
+      │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+      │         │    ├── internal-ordering: +7,+1 opt(11)
+      │         │    ├── key: (1)
+      │         │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         │    ├── ordering: +7,+1 opt(11)
+      │         │    ├── sort
+      │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+      │         │    │    ├── key: (1)
+      │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         │    │    ├── ordering: +7,+1 opt(11)
+      │         │    │    └── select
+      │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+      │         │    │         ├── key: (1)
+      │         │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         │    │         ├── group-by
+      │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+      │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+      │         │    │         │    ├── key: (1)
+      │         │    │         │    ├── fd: ()-->(11), (1)-->(2-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         │    │         │    ├── left-join
+      │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:26(int) true:36(bool)
+      │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(36)
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │    ├── key: (1)
+      │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         │    │         │    │    │    └── select
+      │         │    │         │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
+      │         │    │         │    │    │         ├── key: (1)
+      │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         │    │         │    │    │         ├── group-by
+      │         │    │         │    │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
+      │         │    │         │    │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+      │         │    │         │    │    │         │    ├── key: (1)
+      │         │    │         │    │    │         │    ├── fd: ()-->(11), (1)-->(2-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         │    │         │    │    │         │    ├── left-join (merge)
+      │         │    │         │    │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:33(bool)
+      │         │    │         │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(33)
+      │         │    │         │    │    │         │    │    ├── select
+      │         │    │         │    │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │         │    │    │    ├── key: (1)
+      │         │    │         │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │         │    │         │    │    │         │    │    │    ├── ordering: +1 opt(11)
+      │         │    │         │    │    │         │    │    │    ├── scan instance_types
+      │         │    │         │    │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │         │    │    │    │    ├── key: (1)
+      │         │    │         │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    │    │         │    │    │    │    └── ordering: +1 opt(11)
+      │         │    │         │    │    │         │    │    │    └── filters [type=bool, outer=(11,13), constraints=(/11: [/false - /false]; /13: (/NULL - ]), fd=()-->(11)]
+      │         │    │         │    │    │         │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │         │    │         │    │    │         │    │    │         └── disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight)]
+      │         │    │         │    │    │         │    │    ├── project
+      │         │    │         │    │    │         │    │    │    ├── columns: true:33(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │         │    │         │    │    │         │    │    │    ├── fd: ()-->(33)
+      │         │    │         │    │    │         │    │    │    ├── ordering: +18 opt(33)
+      │         │    │         │    │    │         │    │    │    ├── select
+      │         │    │         │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) instance_type_projects.project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+      │         │    │         │    │    │         │    │    │    │    ├── ordering: +18
+      │         │    │         │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
+      │         │    │         │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) instance_type_projects.project_id:19(string) instance_type_projects.deleted:20(bool)
+      │         │    │         │    │    │         │    │    │    │    │    └── ordering: +18
+      │         │    │         │    │    │         │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+      │         │    │         │    │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │         │    │         │    │    │         │    │    │    │         └── instance_type_projects.project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │         │    │         │    │    │         │    │    │    └── projections [outer=(18)]
+      │         │    │         │    │    │         │    │    │         └── true [type=bool]
+      │         │    │         │    │    │         │    │    └── merge-on
+      │         │    │         │    │    │         │    │         ├── left ordering: +1
+      │         │    │         │    │    │         │    │         ├── right ordering: +18
+      │         │    │         │    │    │         │    │         └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+      │         │    │         │    │    │         │    │              └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+      │         │    │         │    │    │         │    └── aggregations [outer=(2-16,33)]
+      │         │    │         │    │    │         │         ├── const-not-null-agg [type=bool, outer=(33)]
+      │         │    │         │    │    │         │         │    └── variable: true [type=bool, outer=(33)]
+      │         │    │         │    │    │         │         ├── const-agg [type=string, outer=(2)]
+      │         │    │         │    │    │         │         │    └── variable: name [type=string, outer=(2)]
+      │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(3)]
+      │         │    │         │    │    │         │         │    └── variable: memory_mb [type=int, outer=(3)]
+      │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(4)]
+      │         │    │         │    │    │         │         │    └── variable: vcpus [type=int, outer=(4)]
+      │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(5)]
+      │         │    │         │    │    │         │         │    └── variable: root_gb [type=int, outer=(5)]
+      │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(6)]
+      │         │    │         │    │    │         │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │    │    │         │         ├── const-agg [type=string, outer=(7)]
+      │         │    │         │    │    │         │         │    └── variable: flavorid [type=string, outer=(7)]
+      │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(8)]
+      │         │    │         │    │    │         │         │    └── variable: swap [type=int, outer=(8)]
+      │         │    │         │    │    │         │         ├── const-agg [type=float, outer=(9)]
+      │         │    │         │    │    │         │         │    └── variable: rxtx_factor [type=float, outer=(9)]
+      │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(10)]
+      │         │    │         │    │    │         │         │    └── variable: vcpu_weight [type=int, outer=(10)]
+      │         │    │         │    │    │         │         ├── const-agg [type=bool, outer=(11)]
+      │         │    │         │    │    │         │         │    └── variable: disabled [type=bool, outer=(11)]
+      │         │    │         │    │    │         │         ├── const-agg [type=bool, outer=(12)]
+      │         │    │         │    │    │         │         │    └── variable: is_public [type=bool, outer=(12)]
+      │         │    │         │    │    │         │         ├── const-agg [type=bool, outer=(13)]
+      │         │    │         │    │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+      │         │    │         │    │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+      │         │    │         │    │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+      │         │    │         │    │    │         │         ├── const-agg [type=timestamp, outer=(15)]
+      │         │    │         │    │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+      │         │    │         │    │    │         │         └── const-agg [type=timestamp, outer=(16)]
+      │         │    │         │    │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+      │         │    │         │    │    │         └── filters [type=bool, outer=(12,34)]
+      │         │    │         │    │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,34)]
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: true:36(bool!null) instance_type_projects.instance_type_id:26(int!null)
+      │         │    │         │    │    │    ├── fd: ()-->(36)
+      │         │    │         │    │    │    ├── select
+      │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) instance_type_projects.project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
+      │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
+      │         │    │         │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:26(int!null) instance_type_projects.project_id:27(string) instance_type_projects.deleted:28(bool)
+      │         │    │         │    │    │    │    └── filters [type=bool, outer=(27,28), constraints=(/27: (/NULL - ]; /28: (/NULL - ])]
+      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $4 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
+      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $5 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
+      │         │    │         │    │    │    │         └── instance_type_projects.project_id = $6 [type=bool, outer=(27), constraints=(/27: (/NULL - ])]
+      │         │    │         │    │    │    └── projections [outer=(26)]
+      │         │    │         │    │    │         └── true [type=bool]
+      │         │    │         │    │    └── filters [type=bool, outer=(1,26), constraints=(/1: (/NULL - ]; /26: (/NULL - ]), fd=(1)==(26), (26)==(1)]
+      │         │    │         │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,26), constraints=(/1: (/NULL - ]; /26: (/NULL - ])]
+      │         │    │         │    └── aggregations [outer=(2-16,36)]
+      │         │    │         │         ├── const-not-null-agg [type=bool, outer=(36)]
+      │         │    │         │         │    └── variable: true [type=bool, outer=(36)]
+      │         │    │         │         ├── const-agg [type=string, outer=(2)]
+      │         │    │         │         │    └── variable: name [type=string, outer=(2)]
+      │         │    │         │         ├── const-agg [type=int, outer=(3)]
+      │         │    │         │         │    └── variable: memory_mb [type=int, outer=(3)]
+      │         │    │         │         ├── const-agg [type=int, outer=(4)]
+      │         │    │         │         │    └── variable: vcpus [type=int, outer=(4)]
+      │         │    │         │         ├── const-agg [type=int, outer=(5)]
+      │         │    │         │         │    └── variable: root_gb [type=int, outer=(5)]
+      │         │    │         │         ├── const-agg [type=int, outer=(6)]
+      │         │    │         │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │         ├── const-agg [type=string, outer=(7)]
+      │         │    │         │         │    └── variable: flavorid [type=string, outer=(7)]
+      │         │    │         │         ├── const-agg [type=int, outer=(8)]
+      │         │    │         │         │    └── variable: swap [type=int, outer=(8)]
+      │         │    │         │         ├── const-agg [type=float, outer=(9)]
+      │         │    │         │         │    └── variable: rxtx_factor [type=float, outer=(9)]
+      │         │    │         │         ├── const-agg [type=int, outer=(10)]
+      │         │    │         │         │    └── variable: vcpu_weight [type=int, outer=(10)]
+      │         │    │         │         ├── const-agg [type=bool, outer=(11)]
+      │         │    │         │         │    └── variable: disabled [type=bool, outer=(11)]
+      │         │    │         │         ├── const-agg [type=bool, outer=(12)]
+      │         │    │         │         │    └── variable: is_public [type=bool, outer=(12)]
+      │         │    │         │         ├── const-agg [type=bool, outer=(13)]
+      │         │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+      │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+      │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+      │         │    │         │         ├── const-agg [type=timestamp, outer=(15)]
+      │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+      │         │    │         │         └── const-agg [type=timestamp, outer=(16)]
+      │         │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+      │         │    │         └── filters [type=bool, outer=(12,37)]
+      │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,37)]
+      │         │    └── placeholder: $7 [type=int]
+      │         └── placeholder: $8 [type=int]
+      └── filters [type=bool, outer=(1,42), constraints=(/1: (/NULL - ]; /42: (/NULL - ]), fd=(1)==(42), (42)==(1)]
+           └── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,42), constraints=(/1: (/NULL - ]; /42: (/NULL - ])]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -2845,123 +2861,126 @@ from (select instance_types.created_at as instance_types_created_at,
 order by anon_1.instance_types_deleted asc,
          anon_1.instance_types_id asc
 ----
-left-join (lookup instance_type_extra_specs)
+sort
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
- ├── key columns: [28] = [28]
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── ordering: +13,+1
- ├── left-join (lookup instance_type_extra_specs@secondary)
- │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
- │    ├── key columns: [1] = [31]
- │    ├── key: (1,28)
- │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
- │    ├── ordering: +13,+1
- │    ├── project
- │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │    ├── ordering: +13,+1
- │    │    └── limit
- │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         ├── internal-ordering: +13,+1
- │    │         ├── key: (1)
- │    │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         ├── ordering: +13,+1
- │    │         ├── offset
- │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    ├── internal-ordering: +13,+1
- │    │         │    ├── key: (1)
- │    │         │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    ├── ordering: +13,+1
- │    │         │    ├── sort
- │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │    ├── key: (1)
- │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    ├── ordering: +13,+1
- │    │         │    │    └── select
- │    │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │         ├── key: (1)
- │    │         │    │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         ├── group-by
- │    │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
- │    │         │    │         │    ├── key: (1)
- │    │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    ├── left-join
- │    │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
- │    │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
- │    │         │    │         │    │    ├── index-join instance_types
- │    │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │         │    │    │    ├── key: (1)
- │    │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    │    │    └── select
- │    │         │    │         │    │    │         ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool!null)
- │    │         │    │         │    │    │         ├── key: (1)
- │    │         │    │         │    │    │         ├── fd: (1)-->(7,13), (7,13)-->(1)
- │    │         │    │         │    │    │         ├── scan instance_types@secondary
- │    │         │    │         │    │    │         │    ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool)
- │    │         │    │         │    │    │         │    ├── constraint: /7/13: (/NULL - ]
- │    │         │    │         │    │    │         │    ├── key: (1)
- │    │         │    │         │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
- │    │         │    │         │    │    │         └── filters [type=bool, outer=(7,13), constraints=(/7: (/NULL - ]; /13: (/NULL - ])]
- │    │         │    │         │    │    │              ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
- │    │         │    │         │    │    │              └── flavorid = $4 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
- │    │         │    │         │    │    ├── project
- │    │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
- │    │         │    │         │    │    │    ├── fd: ()-->(25)
- │    │         │    │         │    │    │    ├── select
- │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
- │    │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
- │    │         │    │         │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
- │    │         │    │         │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
- │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
- │    │         │    │         │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
- │    │         │    │         │    │    │    └── projections [outer=(18)]
- │    │         │    │         │    │    │         └── true [type=bool]
- │    │         │    │         │    │    └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
- │    │         │    │         │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
- │    │         │    │         │    └── aggregations [outer=(2-16,25)]
- │    │         │    │         │         ├── const-not-null-agg [type=bool, outer=(25)]
- │    │         │    │         │         │    └── variable: true [type=bool, outer=(25)]
- │    │         │    │         │         ├── const-agg [type=string, outer=(2)]
- │    │         │    │         │         │    └── variable: name [type=string, outer=(2)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(3)]
- │    │         │    │         │         │    └── variable: memory_mb [type=int, outer=(3)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(4)]
- │    │         │    │         │         │    └── variable: vcpus [type=int, outer=(4)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(5)]
- │    │         │    │         │         │    └── variable: root_gb [type=int, outer=(5)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(6)]
- │    │         │    │         │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
- │    │         │    │         │         ├── const-agg [type=string, outer=(7)]
- │    │         │    │         │         │    └── variable: flavorid [type=string, outer=(7)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(8)]
- │    │         │    │         │         │    └── variable: swap [type=int, outer=(8)]
- │    │         │    │         │         ├── const-agg [type=float, outer=(9)]
- │    │         │    │         │         │    └── variable: rxtx_factor [type=float, outer=(9)]
- │    │         │    │         │         ├── const-agg [type=int, outer=(10)]
- │    │         │    │         │         │    └── variable: vcpu_weight [type=int, outer=(10)]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(11)]
- │    │         │    │         │         │    └── variable: disabled [type=bool, outer=(11)]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(12)]
- │    │         │    │         │         │    └── variable: is_public [type=bool, outer=(12)]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(13)]
- │    │         │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
- │    │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
- │    │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
- │    │         │    │         │         ├── const-agg [type=timestamp, outer=(15)]
- │    │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
- │    │         │    │         │         └── const-agg [type=timestamp, outer=(16)]
- │    │         │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
- │    │         │    │         └── filters [type=bool, outer=(12,26)]
- │    │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
- │    │         │    └── placeholder: $5 [type=int]
- │    │         └── placeholder: $6 [type=int]
- │    └── filters [type=bool, outer=(1,31,32), constraints=(/1: (/NULL - ]; /31: (/NULL - ]; /32: (/NULL - ]), fd=(1)==(31), (31)==(1)]
- │         ├── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
- │         └── instance_type_extra_specs.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
- └── true [type=bool]
+ └── right-join
+      ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      ├── key: (1,28)
+      ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      ├── select
+      │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool!null) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      │    ├── key: (28)
+      │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    ├── scan instance_type_extra_specs
+      │    │    ├── columns: instance_type_extra_specs.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int!null) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      │    │    ├── key: (28)
+      │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    └── filters [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      │         └── instance_type_extra_specs.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      ├── project
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    └── limit
+      │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         ├── internal-ordering: +13,+1
+      │         ├── key: (1)
+      │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         ├── offset
+      │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    ├── internal-ordering: +13,+1
+      │         │    ├── key: (1)
+      │         │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    ├── ordering: +13,+1
+      │         │    ├── sort
+      │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    │    ├── key: (1)
+      │         │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │    ├── ordering: +13,+1
+      │         │    │    └── select
+      │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    │         ├── key: (1)
+      │         │    │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         ├── group-by
+      │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+      │         │    │         │    ├── key: (1)
+      │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    ├── left-join
+      │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+      │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+      │         │    │         │    │    ├── index-join instance_types
+      │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │         │    │         │    │    │    ├── key: (1)
+      │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │         │    │         │    │    │    └── select
+      │         │    │         │    │    │         ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool!null)
+      │         │    │         │    │    │         ├── key: (1)
+      │         │    │         │    │    │         ├── fd: (1)-->(7,13), (7,13)-->(1)
+      │         │    │         │    │    │         ├── scan instance_types@secondary
+      │         │    │         │    │    │         │    ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool)
+      │         │    │         │    │    │         │    ├── constraint: /7/13: (/NULL - ]
+      │         │    │         │    │    │         │    ├── key: (1)
+      │         │    │         │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
+      │         │    │         │    │    │         └── filters [type=bool, outer=(7,13), constraints=(/7: (/NULL - ]; /13: (/NULL - ])]
+      │         │    │         │    │    │              ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │         │    │         │    │    │              └── flavorid = $4 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │         │    │         │    │    │    ├── fd: ()-->(25)
+      │         │    │         │    │    │    ├── select
+      │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+      │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
+      │         │    │         │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │         │    │         │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │         │    │         │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │         │    │         │    │    │    └── projections [outer=(18)]
+      │         │    │         │    │    │         └── true [type=bool]
+      │         │    │         │    │    └── filters [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+      │         │    │         │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ])]
+      │         │    │         │    └── aggregations [outer=(2-16,25)]
+      │         │    │         │         ├── const-not-null-agg [type=bool, outer=(25)]
+      │         │    │         │         │    └── variable: true [type=bool, outer=(25)]
+      │         │    │         │         ├── const-agg [type=string, outer=(2)]
+      │         │    │         │         │    └── variable: name [type=string, outer=(2)]
+      │         │    │         │         ├── const-agg [type=int, outer=(3)]
+      │         │    │         │         │    └── variable: memory_mb [type=int, outer=(3)]
+      │         │    │         │         ├── const-agg [type=int, outer=(4)]
+      │         │    │         │         │    └── variable: vcpus [type=int, outer=(4)]
+      │         │    │         │         ├── const-agg [type=int, outer=(5)]
+      │         │    │         │         │    └── variable: root_gb [type=int, outer=(5)]
+      │         │    │         │         ├── const-agg [type=int, outer=(6)]
+      │         │    │         │         │    └── variable: ephemeral_gb [type=int, outer=(6)]
+      │         │    │         │         ├── const-agg [type=string, outer=(7)]
+      │         │    │         │         │    └── variable: flavorid [type=string, outer=(7)]
+      │         │    │         │         ├── const-agg [type=int, outer=(8)]
+      │         │    │         │         │    └── variable: swap [type=int, outer=(8)]
+      │         │    │         │         ├── const-agg [type=float, outer=(9)]
+      │         │    │         │         │    └── variable: rxtx_factor [type=float, outer=(9)]
+      │         │    │         │         ├── const-agg [type=int, outer=(10)]
+      │         │    │         │         │    └── variable: vcpu_weight [type=int, outer=(10)]
+      │         │    │         │         ├── const-agg [type=bool, outer=(11)]
+      │         │    │         │         │    └── variable: disabled [type=bool, outer=(11)]
+      │         │    │         │         ├── const-agg [type=bool, outer=(12)]
+      │         │    │         │         │    └── variable: is_public [type=bool, outer=(12)]
+      │         │    │         │         ├── const-agg [type=bool, outer=(13)]
+      │         │    │         │         │    └── variable: instance_types.deleted [type=bool, outer=(13)]
+      │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+      │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp, outer=(14)]
+      │         │    │         │         ├── const-agg [type=timestamp, outer=(15)]
+      │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp, outer=(15)]
+      │         │    │         │         └── const-agg [type=timestamp, outer=(16)]
+      │         │    │         │              └── variable: instance_types.updated_at [type=timestamp, outer=(16)]
+      │         │    │         └── filters [type=bool, outer=(12,26)]
+      │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
+      │         │    └── placeholder: $5 [type=int]
+      │         └── placeholder: $6 [type=int]
+      └── filters [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
+           └── instance_type_extra_specs.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ])]
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -755,7 +755,7 @@ project
            ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null)
            ├── constraint: /3/2/4/1: [/10/100/50 - /10/100/50]
            ├── limit: 1(rev)
-           ├── stats: [rows=6.80272109e-07]
+           ├── stats: [rows=6.80272109e-07, distinct(2)=6.80272109e-07, distinct(3)=6.80272109e-07, distinct(4)=6.80272109e-07]
            ├── cost: 7.34693878e-07
            ├── key: ()
            ├── fd: ()-->(1-4)

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -560,7 +560,7 @@ project
            ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null)
            ├── constraint: /3/2/4/1: [/10/100/50 - /10/100/50]
            ├── limit: 1(rev)
-           ├── stats: [rows=2.9154519e-06]
+           ├── stats: [rows=2.9154519e-06, distinct(2)=2.9154519e-06, distinct(3)=2.9154519e-06, distinct(4)=2.9154519e-06]
            ├── cost: 3.14868805e-06
            ├── key: ()
            ├── fd: ()-->(1-4)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1211,45 +1211,11 @@ TABLE uvw
       ├── v int
       └── u int not null
 
+# TODO(radu): index-join fixup needed
 exploretrace rule=PushJoinThroughIndexJoin
 SELECT * FROM abc JOIN uvw ON a=u
 ----
-----
-================================================================================
-PushJoinThroughIndexJoin
-================================================================================
-Source expression:
-  inner-join
-   ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int) w:7(int)
-   ├── fd: (5)-->(6,7), (1)==(5), (5)==(1)
-   ├── scan abc
-   │    └── columns: a:1(int) b:2(int) c:3(int)
-   ├── scan uvw
-   │    ├── columns: u:5(int!null) v:6(int) w:7(int)
-   │    ├── key: (5)
-   │    └── fd: (5)-->(6,7)
-   └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
-        └── a = u [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
 
-New expression 1 of 1:
-  inner-join (lookup uvw)
-   ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int) w:7(int)
-   ├── key columns: [5] = [5]
-   ├── fd: (5)-->(6,7), (1)==(5), (5)==(1)
-   ├── inner-join
-   │    ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int)
-   │    ├── fd: (5)-->(6), (1)==(5), (5)==(1)
-   │    ├── scan abc
-   │    │    └── columns: a:1(int) b:2(int) c:3(int)
-   │    ├── scan uvw@v
-   │    │    ├── columns: u:5(int!null) v:6(int)
-   │    │    ├── key: (5)
-   │    │    └── fd: (5)-->(6)
-   │    └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
-   │         └── a = u [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
-   └── true [type=bool]
-----
-----
 
 exec-ddl
 ALTER TABLE abc INJECT STATISTICS '[
@@ -1273,55 +1239,52 @@ ALTER TABLE uvw INJECT STATISTICS '[
 ]'
 ----
 
+# TODO(radu): index-join fixup needed
 opt
 SELECT * FROM abc JOIN uvw ON a=v
 ----
-inner-join (lookup uvw)
+inner-join
  ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int!null) w:7(int)
- ├── key columns: [5] = [5]
  ├── fd: (5)-->(6,7), (1)==(6), (6)==(1)
- ├── inner-join (lookup uvw@v)
- │    ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int!null)
- │    ├── key columns: [1] = [6]
- │    ├── fd: (5)-->(6), (1)==(6), (6)==(1)
- │    ├── scan abc
- │    │    └── columns: a:1(int) b:2(int) c:3(int)
- │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
- │         └── a = v [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
- └── true [type=bool]
+ ├── scan uvw
+ │    ├── columns: u:5(int!null) v:6(int) w:7(int)
+ │    ├── key: (5)
+ │    └── fd: (5)-->(6,7)
+ ├── scan abc
+ │    └── columns: a:1(int) b:2(int) c:3(int)
+ └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+      └── a = v [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
+# TODO(radu): index-join fixup needed
 opt
 SELECT * FROM abc JOIN uvw ON a=v AND b+u>1
 ----
-inner-join (lookup uvw)
+inner-join
  ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int!null) w:7(int)
- ├── key columns: [5] = [5]
  ├── fd: (5)-->(6,7), (1)==(6), (6)==(1)
- ├── inner-join (lookup uvw@v)
- │    ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int!null)
- │    ├── key columns: [1] = [6]
- │    ├── fd: (5)-->(6), (1)==(6), (6)==(1)
- │    ├── scan abc
- │    │    └── columns: a:1(int) b:2(int) c:3(int)
- │    └── filters [type=bool, outer=(1,2,5,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
- │         ├── a = v [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
- │         └── (b + u) > 1 [type=bool, outer=(2,5)]
- └── true [type=bool]
+ ├── scan uvw
+ │    ├── columns: u:5(int!null) v:6(int) w:7(int)
+ │    ├── key: (5)
+ │    └── fd: (5)-->(6,7)
+ ├── scan abc
+ │    └── columns: a:1(int) b:2(int) c:3(int)
+ └── filters [type=bool, outer=(1,2,5,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+      ├── a = v [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+      └── (b + u) > 1 [type=bool, outer=(2,5)]
 
+# TODO(radu): index-join fixup needed
 opt
 SELECT * FROM abc JOIN uvw ON a=v WHERE b+w>1
 ----
-inner-join (lookup uvw)
+inner-join
  ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int!null) w:7(int)
- ├── key columns: [5] = [5]
  ├── fd: (5)-->(6,7), (1)==(6), (6)==(1)
- ├── inner-join (lookup uvw@v)
- │    ├── columns: a:1(int!null) b:2(int) c:3(int) u:5(int!null) v:6(int!null)
- │    ├── key columns: [1] = [6]
- │    ├── fd: (5)-->(6), (1)==(6), (6)==(1)
- │    ├── scan abc
- │    │    └── columns: a:1(int) b:2(int) c:3(int)
- │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
- │         └── a = v [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
- └── filters [type=bool, outer=(2,7)]
+ ├── scan uvw
+ │    ├── columns: u:5(int!null) v:6(int) w:7(int)
+ │    ├── key: (5)
+ │    └── fd: (5)-->(6,7)
+ ├── scan abc
+ │    └── columns: a:1(int) b:2(int) c:3(int)
+ └── filters [type=bool, outer=(1,2,6,7), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+      ├── a = v [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
       └── (b + w) > 1 [type=bool, outer=(2,7)]

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -74,35 +74,21 @@ memo
 SELECT k,f FROM a ORDER BY k DESC LIMIT 10
 ----
 memo (optimized)
- ├── G1: (limit G2 G5 ordering=-1) (scan a,rev,cols=(1,3),lim=10(rev)) (index-join G3 a,cols=(1,3))
+ ├── G1: (limit G2 G3 ordering=-1) (scan a,rev,cols=(1,3),lim=10(rev))
  │    ├── "[presentation: k:1,f:3] [ordering: -1]"
  │    │    ├── best: (scan a,rev,cols=(1,3),lim=10(rev))
  │    │    └── cost: 11.03
  │    └── ""
  │         ├── best: (scan a,rev,cols=(1,3),lim=10(rev))
  │         └── cost: 11.03
- ├── G2: (scan a,cols=(1,3)) (scan a@s_idx,cols=(1,3)) (index-join G4 a,cols=(1,3))
+ ├── G2: (scan a,cols=(1,3)) (scan a@s_idx,cols=(1,3))
  │    ├── ""
  │    │    ├── best: (scan a@s_idx,cols=(1,3))
  │    │    └── cost: 1060.00
  │    └── "[ordering: -1]"
  │         ├── best: (scan a,rev,cols=(1,3))
  │         └── cost: 1169.66
- ├── G3: (limit G4 G5 ordering=-1)
- │    ├── ""
- │    │    ├── best: (limit G4="[ordering: -1]" G5 ordering=-1)
- │    │    └── cost: 1259.42
- │    └── "[ordering: -1]"
- │         ├── best: (limit G4="[ordering: -1]" G5 ordering=-1)
- │         └── cost: 1259.42
- ├── G4: (scan a@si_idx,cols=(1))
- │    ├── ""
- │    │    ├── best: (scan a@si_idx,cols=(1))
- │    │    └── cost: 1050.00
- │    └── "[ordering: -1]"
- │         ├── best: (sort G4)
- │         └── cost: 1259.32
- └── G5: (const 10)
+ └── G3: (const 10)
 
 
 opt
@@ -204,21 +190,15 @@ memo
 SELECT s, i, f FROM a ORDER BY s, k, i
 ----
 memo (optimized)
- ├── G1: (scan a,cols=(1-4)) (scan a@s_idx,cols=(1-4)) (index-join G2 a,cols=(1-4))
- │    ├── "[presentation: s:4,i:2,f:3] [ordering: +4,+1]"
- │    │    ├── best: (scan a@s_idx,cols=(1-4))
- │    │    └── cost: 1080.00
- │    └── ""
- │         ├── best: (scan a@s_idx,cols=(1-4))
- │         └── cost: 1080.00
- └── G2: (scan a@si_idx,cols=(1,2,4))
-      ├── ""
-      │    ├── best: (scan a@si_idx,cols=(1,2,4))
-      │    └── cost: 1070.00
-      └── "[ordering: +4,+1]"
-           ├── best: (sort G2)
-           └── cost: 1378.97
+ └── G1: (scan a,cols=(1-4)) (scan a@s_idx,cols=(1-4))
+      ├── "[presentation: s:4,i:2,f:3] [ordering: +4,+1]"
+      │    ├── best: (scan a@s_idx,cols=(1-4))
+      │    └── cost: 1080.00
+      └── ""
+           ├── best: (scan a@s_idx,cols=(1-4))
+           └── cost: 1080.00
 
+# No index-join should be generated for a@si_idx, since it is not constrained.
 exploretrace rule=GenerateIndexScans
 SELECT s, i, f FROM a ORDER BY s, k, i
 ----
@@ -237,27 +217,64 @@ Source expression:
         ├── key: (1)
         └── fd: (1)-->(2-4)
 
-New expression 1 of 2:
+New expression 1 of 1:
   scan a@s_idx
    ├── columns: s:4(string) i:2(int) f:3(float)
    ├── key: (1)
    ├── fd: (1)-->(2-4)
    └── ordering: +4,+1
+----
+----
+
+# --------------------------------------------------
+# GenerateConstrainedScans
+# --------------------------------------------------
+
+# Constrain the a@si_idx so that an index join is generated.
+exploretrace rule=GenerateConstrainedScans
+SELECT s, i, f FROM a WHERE s='foo' ORDER BY s, k, i
+----
+----
+================================================================================
+GenerateConstrainedScans
+================================================================================
+Source expression:
+  select
+   ├── columns: s:4(string!null) i:2(int) f:3(float)
+   ├── key: (1)
+   ├── fd: ()-->(4), (1)-->(2,3)
+   ├── ordering: +1 opt(4)
+   ├── scan a@s_idx
+   │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
+   │    ├── key: (1)
+   │    ├── fd: (1)-->(2-4)
+   │    └── ordering: +1 opt(4)
+   └── filters [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+        └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
+
+New expression 1 of 2:
+  scan a@s_idx
+   ├── columns: s:4(string!null) i:2(int) f:3(float)
+   ├── constraint: /4/1: [/'foo' - /'foo']
+   ├── key: (1)
+   ├── fd: ()-->(4), (1)-->(2,3)
+   └── ordering: +1 opt(4)
 
 New expression 2 of 2:
   sort
-   ├── columns: s:4(string) i:2(int) f:3(float)
+   ├── columns: s:4(string!null) i:2(int) f:3(float)
    ├── key: (1)
-   ├── fd: (1)-->(2-4)
-   ├── ordering: +4,+1
+   ├── fd: ()-->(4), (1)-->(2,3)
+   ├── ordering: +1 opt(4)
    └── index-join a
-        ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
+        ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string!null)
         ├── key: (1)
-        ├── fd: (1)-->(2-4)
+        ├── fd: ()-->(4), (1)-->(2,3)
         └── scan a@si_idx
-             ├── columns: k:1(int!null) i:2(int) s:4(string)
+             ├── columns: k:1(int!null) i:2(int) s:4(string!null)
+             ├── constraint: /-4/-2/1: [/'foo' - /'foo']
              ├── key: (1)
-             └── fd: (1)-->(2,4)
+             └── fd: ()-->(4), (1)-->(2)
 ----
 ----
 
@@ -265,36 +282,69 @@ memo
 SELECT s, i, f FROM a ORDER BY f
 ----
 memo (optimized)
- ├── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4)) (index-join G2 a,cols=(2-4))
- │    ├── "[presentation: s:4,i:2,f:3] [ordering: +3]"
- │    │    ├── best: (sort G1)
- │    │    └── cost: 1279.32
- │    └── ""
- │         ├── best: (scan a@s_idx,cols=(2-4))
- │         └── cost: 1070.00
- └── G2: (scan a@si_idx,cols=(1,2,4))
+ └── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4))
+      ├── "[presentation: s:4,i:2,f:3] [ordering: +3]"
+      │    ├── best: (sort G1)
+      │    └── cost: 1279.32
       └── ""
-           ├── best: (scan a@si_idx,cols=(1,2,4))
+           ├── best: (scan a@s_idx,cols=(2-4))
            └── cost: 1070.00
 
 memo
 SELECT s, i, f FROM a ORDER BY s DESC, i
 ----
 memo (optimized)
- ├── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4)) (index-join G2 a,cols=(2-4))
- │    ├── "[presentation: s:4,i:2,f:3] [ordering: -4,+2]"
+ └── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4))
+      ├── "[presentation: s:4,i:2,f:3] [ordering: -4,+2]"
+      │    ├── best: (sort G1)
+      │    └── cost: 1378.97
+      └── ""
+           ├── best: (scan a@s_idx,cols=(2-4))
+           └── cost: 1070.00
+
+memo
+SELECT s, i, f FROM a WHERE s='foo' ORDER BY s DESC, i
+----
+memo (optimized)
+ ├── G1: (select G2 G3) (scan a@s_idx,cols=(2-4),constrained) (index-join G4 a,cols=(2-4))
+ │    ├── "[presentation: s:4,i:2,f:3] [ordering: +2 opt(4)]"
  │    │    ├── best: (sort G1)
- │    │    └── cost: 1378.97
+ │    │    └── cost: 1.56
  │    └── ""
- │         ├── best: (scan a@s_idx,cols=(2-4))
- │         └── cost: 1070.00
- └── G2: (scan a@si_idx,cols=(1,2,4))
-      ├── ""
-      │    ├── best: (scan a@si_idx,cols=(1,2,4))
-      │    └── cost: 1070.00
-      └── "[ordering: -4,+2]"
-           ├── best: (sort G2)
-           └── cost: 1378.97
+ │         ├── best: (scan a@s_idx,cols=(2-4),constrained)
+ │         └── cost: 1.53
+ ├── G2: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4))
+ │    ├── ""
+ │    │    ├── best: (scan a@s_idx,cols=(2-4))
+ │    │    └── cost: 1070.00
+ │    └── "[ordering: +2 opt(4)]"
+ │         ├── best: (sort G2)
+ │         └── cost: 1279.32
+ ├── G3: (filters G5)
+ ├── G4: (scan a@si_idx,cols=(1,2,4),constrained)
+ │    ├── ""
+ │    │    ├── best: (scan a@si_idx,cols=(1,2,4),constrained)
+ │    │    └── cost: 1.53
+ │    └── "[ordering: +2 opt(4)]"
+ │         ├── best: (scan a@si_idx,rev,cols=(1,2,4),constrained)
+ │         └── cost: 1.54
+ ├── G5: (eq G6 G7)
+ ├── G6: (variable s)
+ └── G7: (const 'foo')
+
+# Force an index in order to ensure that an index join is created.
+opt
+SELECT * FROM a@si_idx
+----
+index-join a
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ └── scan a@si_idx
+      ├── columns: k:1(int!null) i:2(int) s:4(string) j:5(jsonb)
+      ├── flags: force-index=si_idx
+      ├── key: (1)
+      └── fd: (1)-->(2,4,5)
 
 exec-ddl
 CREATE TABLE abc (
@@ -338,21 +388,13 @@ memo (optimized)
  │    └── ""
  │         ├── best: (project G2 G3)
  │         └── cost: 1070.00
- ├── G2: (scan abc,cols=(4)) (index-join G4 abc,cols=(4)) (index-join G5 abc,cols=(4))
+ ├── G2: (scan abc,cols=(4))
  │    └── ""
  │         ├── best: (scan abc,cols=(4))
  │         └── cost: 1050.00
- ├── G3: (projections G6 d)
- ├── G4: (scan abc@bc,cols=(1-3))
- │    └── ""
- │         ├── best: (scan abc@bc,cols=(1-3))
- │         └── cost: 1060.00
- ├── G5: (scan abc@ba,cols=(1-3))
- │    └── ""
- │         ├── best: (scan abc@ba,cols=(1-3))
- │         └── cost: 1060.00
- ├── G6: (function G7 lower)
- └── G7: (variable d)
+ ├── G3: (projections G4 d)
+ ├── G4: (function G5 lower)
+ └── G5: (variable d)
 
 memo
 SELECT j FROM a WHERE s = 'foo'
@@ -362,31 +404,23 @@ memo (optimized)
  │    └── "[presentation: j:5]"
  │         ├── best: (project G2 G3)
  │         └── cost: 1.53
- ├── G2: (select G4 G8) (scan a@si_idx,cols=(4,5),constrained) (index-join G5 a,cols=(4,5)) (index-join G6 a,cols=(4,5))
+ ├── G2: (select G4 G5) (index-join G6 a,cols=(4,5)) (scan a@si_idx,cols=(4,5),constrained)
  │    └── ""
  │         ├── best: (scan a@si_idx,cols=(4,5),constrained)
  │         └── cost: 1.51
  ├── G3: (projections j)
- ├── G4: (scan a,cols=(4,5)) (index-join G7 a,cols=(4,5)) (scan a@si_idx,cols=(4,5))
+ ├── G4: (scan a,cols=(4,5)) (scan a@si_idx,cols=(4,5))
  │    └── ""
  │         ├── best: (scan a@si_idx,cols=(4,5))
  │         └── cost: 1060.00
- ├── G5: (select G7 G8) (scan a@s_idx,cols=(1,4),constrained)
- │    └── ""
- │         ├── best: (scan a@s_idx,cols=(1,4),constrained)
- │         └── cost: 1.51
+ ├── G5: (filters G7)
  ├── G6: (scan a@s_idx,cols=(1,4),constrained)
  │    └── ""
  │         ├── best: (scan a@s_idx,cols=(1,4),constrained)
  │         └── cost: 1.51
- ├── G7: (scan a@s_idx,cols=(1,4))
- │    └── ""
- │         ├── best: (scan a@s_idx,cols=(1,4))
- │         └── cost: 1060.00
- ├── G8: (filters G9)
- ├── G9: (eq G10 G11)
- ├── G10: (variable s)
- └── G11: (const 'foo')
+ ├── G7: (eq G8 G9)
+ ├── G8: (variable s)
+ └── G9: (const 'foo')
 
 # Scan of primary index is lowest cost.
 opt
@@ -402,20 +436,13 @@ memo
 SELECT s, i, f FROM a ORDER BY k, i, s
 ----
 memo (optimized)
- ├── G1: (scan a,cols=(1-4)) (scan a@s_idx,cols=(1-4)) (index-join G2 a,cols=(1-4))
- │    ├── "[presentation: s:4,i:2,f:3] [ordering: +1]"
- │    │    ├── best: (scan a,cols=(1-4))
- │    │    └── cost: 1090.00
- │    └── ""
- │         ├── best: (scan a@s_idx,cols=(1-4))
- │         └── cost: 1080.00
- └── G2: (scan a@si_idx,cols=(1,2,4))
-      ├── ""
-      │    ├── best: (scan a@si_idx,cols=(1,2,4))
-      │    └── cost: 1070.00
-      └── "[ordering: +1]"
-           ├── best: (sort G2)
-           └── cost: 1279.32
+ └── G1: (scan a,cols=(1-4)) (scan a@s_idx,cols=(1-4))
+      ├── "[presentation: s:4,i:2,f:3] [ordering: +1]"
+      │    ├── best: (scan a,cols=(1-4))
+      │    └── cost: 1090.00
+      └── ""
+           ├── best: (scan a@s_idx,cols=(1-4))
+           └── cost: 1080.00
 
 # Secondary index has right order
 opt
@@ -429,19 +456,12 @@ memo
 SELECT s, j FROM a ORDER BY s
 ----
 memo (optimized)
- ├── G1: (scan a,cols=(4,5)) (index-join G2 a,cols=(4,5)) (scan a@si_idx,cols=(4,5))
- │    ├── "[presentation: s:4,j:5] [ordering: +4]"
- │    │    ├── best: (scan a@si_idx,rev,cols=(4,5))
- │    │    └── cost: 1159.66
- │    └── ""
- │         ├── best: (scan a@si_idx,cols=(4,5))
- │         └── cost: 1060.00
- └── G2: (scan a@s_idx,cols=(1,4))
-      ├── ""
-      │    ├── best: (scan a@s_idx,cols=(1,4))
-      │    └── cost: 1060.00
-      └── "[ordering: +4]"
-           ├── best: (scan a@s_idx,cols=(1,4))
+ └── G1: (scan a,cols=(4,5)) (scan a@si_idx,cols=(4,5))
+      ├── "[presentation: s:4,j:5] [ordering: +4]"
+      │    ├── best: (scan a@si_idx,rev,cols=(4,5))
+      │    └── cost: 1159.66
+      └── ""
+           ├── best: (scan a@si_idx,cols=(4,5))
            └── cost: 1060.00
 
 # Consider three different indexes, and pick index with multiple keys.

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -53,7 +53,7 @@ TABLE b
       └── k int not null
 
 # --------------------------------------------------
-# ConstrainScan
+# GenerateConstrainedScans
 # --------------------------------------------------
 
 opt
@@ -309,10 +309,7 @@ project
       └── filters [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
            └── k = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
 
-# --------------------------------------------------
-# PushFilterIntoLookupJoinNoRemainder
-# --------------------------------------------------
-
+# Constraint + index-join, with no remainder filter.
 opt
 SELECT * FROM b WHERE v >= 1 AND v <= 10
 ----
@@ -330,36 +327,24 @@ memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10
 ----
 memo (optimized)
- ├── G1: (select G2 G7) (index-join G3 b,cols=(1-4)) (index-join G4 b,cols=(1-4))
+ ├── G1: (select G2 G3) (index-join G4 b,cols=(1-4))
  │    └── "[presentation: k:1,u:2,v:3,j:4]"
- │         ├── best: (index-join G3 b,cols=(1-4))
+ │         ├── best: (index-join G4 b,cols=(1-4))
  │         └── cost: 51.30
- ├── G2: (scan b) (index-join G5 b,cols=(1-4)) (index-join G6 b,cols=(1-4))
+ ├── G2: (scan b)
  │    └── ""
  │         ├── best: (scan b)
  │         └── cost: 1080.00
- ├── G3: (select G6 G7) (scan b@v,cols=(1,3),constrained)
- │    └── ""
- │         ├── best: (scan b@v,cols=(1,3),constrained)
- │         └── cost: 10.40
+ ├── G3: (filters G5 G6)
  ├── G4: (scan b@v,cols=(1,3),constrained)
  │    └── ""
  │         ├── best: (scan b@v,cols=(1,3),constrained)
  │         └── cost: 10.40
- ├── G5: (scan b@u,cols=(1,2))
- │    └── ""
- │         ├── best: (scan b@u,cols=(1,2))
- │         └── cost: 1040.00
- ├── G6: (scan b@v,cols=(1,3))
- │    └── ""
- │         ├── best: (scan b@v,cols=(1,3))
- │         └── cost: 1040.00
- ├── G7: (filters G8 G9)
- ├── G8: (ge G11 G10)
- ├── G9: (le G11 G12)
- ├── G10: (const 1)
- ├── G11: (variable v)
- └── G12: (const 10)
+ ├── G5: (ge G8 G7)
+ ├── G6: (le G8 G9)
+ ├── G7: (const 1)
+ ├── G8: (variable v)
+ └── G9: (const 10)
 
 # Don't choose lookup join if it's not beneficial.
 opt
@@ -399,74 +384,46 @@ memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k > 5
 ----
 memo (optimized)
- ├── G1: (select G2 G10) (select G3 G6) (index-join G4 b,cols=(1-4)) (select G5 G6) (select G7 G17) (index-join G8 b,cols=(1-4))
+ ├── G1: (select G2 G3) (select G4 G5) (index-join G6 b,cols=(1-4))
  │    └── "[presentation: k:1,u:2,v:3,j:4]"
- │         ├── best: (index-join G4 b,cols=(1-4))
+ │         ├── best: (index-join G6 b,cols=(1-4))
  │         └── cost: 24.13
- ├── G2: (scan b) (index-join G16 b,cols=(1-4)) (index-join G9 b,cols=(1-4))
+ ├── G2: (scan b)
  │    └── ""
  │         ├── best: (scan b)
  │         └── cost: 1080.00
- ├── G3: (scan b,constrained)
+ ├── G3: (filters G7 G8 G14)
+ ├── G4: (scan b,constrained)
  │    └── ""
  │         ├── best: (scan b,constrained)
  │         └── cost: 360.00
- ├── G4: (select G9 G10) (select G11 G17)
+ ├── G5: (filters G7 G8)
+ ├── G6: (select G9 G10)
  │    └── ""
- │         ├── best: (select G11 G17)
+ │         ├── best: (select G9 G10)
  │         └── cost: 10.50
- ├── G5: (index-join G12 b,cols=(1-4))
- │    └── ""
- │         ├── best: (index-join G12 b,cols=(1-4))
- │         └── cost: 2413.33
- ├── G6: (filters G14 G15)
- ├── G7: (index-join G13 b,cols=(1-4))
- │    └── ""
- │         ├── best: (index-join G13 b,cols=(1-4))
- │         └── cost: 51.30
- ├── G8: (select G13 G17)
- │    └── ""
- │         ├── best: (select G13 G17)
- │         └── cost: 10.50
- ├── G9: (scan b@v,cols=(1,3))
- │    └── ""
- │         ├── best: (scan b@v,cols=(1,3))
- │         └── cost: 1040.00
- ├── G10: (filters G14 G15 G21)
- ├── G11: (scan b@v,cols=(1,3),constrained)
+ ├── G7: (ge G12 G11)
+ ├── G8: (le G12 G13)
+ ├── G9: (scan b@v,cols=(1,3),constrained)
  │    └── ""
  │         ├── best: (scan b@v,cols=(1,3),constrained)
  │         └── cost: 10.40
- ├── G12: (select G16 G17)
- │    └── ""
- │         ├── best: (select G16 G17)
- │         └── cost: 1050.00
- ├── G13: (scan b@v,cols=(1,3),constrained)
- │    └── ""
- │         ├── best: (scan b@v,cols=(1,3),constrained)
- │         └── cost: 10.40
- ├── G14: (ge G19 G18)
- ├── G15: (le G19 G20)
- ├── G16: (scan b@u,cols=(1,2))
- │    └── ""
- │         ├── best: (scan b@u,cols=(1,2))
- │         └── cost: 1040.00
- ├── G17: (filters G21)
- ├── G18: (const 1)
- ├── G19: (variable v)
- ├── G20: (const 10)
- ├── G21: (gt G22 G23)
- ├── G22: (variable k)
- └── G23: (const 5)
+ ├── G10: (filters G14)
+ ├── G11: (const 1)
+ ├── G12: (variable v)
+ ├── G13: (const 10)
+ ├── G14: (gt G15 G16)
+ ├── G15: (variable k)
+ └── G16: (const 5)
 
 # Ensure the rule doesn't match at all when the first column of the index is
-# not in the filter.
-exploretrace rule=ConstrainScan
+# not in the filter (i.e. the @v index is not matched by ConstrainScans).
+exploretrace rule=GenerateConstrainedScans
 SELECT k FROM a WHERE u = 1
 ----
 ----
 ================================================================================
-ConstrainScan
+GenerateConstrainedScans
 ================================================================================
 Source expression:
   project
@@ -495,11 +452,7 @@ New expression 1 of 1:
 ----
 ----
 
-# --------------------------------------------------
-# PushFilterIntoLookupJoin
-# --------------------------------------------------
-
-# Constraint + remaining filter.
+# Constraint + index join + remaining filter.
 opt
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1
 ----
@@ -523,58 +476,33 @@ memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1
 ----
 memo (optimized)
- ├── G1: (select G2 G3) (select G4 G13) (select G5 G11) (select G6 G11)
+ ├── G1: (select G2 G3) (select G4 G5)
  │    └── "[presentation: k:1,u:2,v:3,j:4]"
- │         ├── best: (select G5 G11)
+ │         ├── best: (select G4 G5)
  │         └── cost: 51.40
- ├── G2: (scan b) (index-join G10 b,cols=(1-4)) (index-join G12 b,cols=(1-4))
+ ├── G2: (scan b)
  │    └── ""
  │         ├── best: (scan b)
  │         └── cost: 1080.00
- ├── G3: (filters G15 G16 G14)
- ├── G4: (index-join G7 b,cols=(1-4))
- │    └── ""
- │         ├── best: (index-join G7 b,cols=(1-4))
- │         └── cost: 2413.33
- ├── G5: (index-join G8 b,cols=(1-4))
+ ├── G3: (filters G6 G7 G9)
+ ├── G4: (index-join G8 b,cols=(1-4))
  │    └── ""
  │         ├── best: (index-join G8 b,cols=(1-4))
  │         └── cost: 51.30
- ├── G6: (index-join G9 b,cols=(1-4))
- │    └── ""
- │         ├── best: (index-join G9 b,cols=(1-4))
- │         └── cost: 51.30
- ├── G7: (select G10 G11)
- │    └── ""
- │         ├── best: (select G10 G11)
- │         └── cost: 1050.00
- ├── G8: (select G12 G13) (scan b@v,cols=(1,3),constrained)
+ ├── G5: (filters G9)
+ ├── G6: (ge G10 G13)
+ ├── G7: (le G10 G11)
+ ├── G8: (scan b@v,cols=(1,3),constrained)
  │    └── ""
  │         ├── best: (scan b@v,cols=(1,3),constrained)
  │         └── cost: 10.40
- ├── G9: (scan b@v,cols=(1,3),constrained)
- │    └── ""
- │         ├── best: (scan b@v,cols=(1,3),constrained)
- │         └── cost: 10.40
- ├── G10: (scan b@u,cols=(1,2))
- │    └── ""
- │         ├── best: (scan b@u,cols=(1,2))
- │         └── cost: 1040.00
- ├── G11: (filters G14)
- ├── G12: (scan b@v,cols=(1,3))
- │    └── ""
- │         ├── best: (scan b@v,cols=(1,3))
- │         └── cost: 1040.00
- ├── G13: (filters G15 G16)
- ├── G14: (eq G17 G18)
- ├── G15: (ge G19 G18)
- ├── G16: (le G19 G20)
- ├── G17: (plus G21 G22)
- ├── G18: (const 1)
- ├── G19: (variable v)
- ├── G20: (const 10)
- ├── G21: (variable k)
- └── G22: (variable u)
+ ├── G9: (eq G12 G13)
+ ├── G10: (variable v)
+ ├── G11: (const 10)
+ ├── G12: (plus G14 G15)
+ ├── G13: (const 1)
+ ├── G14: (variable k)
+ └── G15: (variable u)
 
 opt
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1 AND k > 5
@@ -605,85 +533,47 @@ memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1 AND k > 5
 ----
 memo (optimized)
- ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G11) (select G9 G16) (select G10 G11)
+ ├── G1: (select G2 G3) (select G4 G5) (select G6 G7)
  │    └── "[presentation: k:1,u:2,v:3,j:4]"
- │         ├── best: (select G8 G11)
+ │         ├── best: (select G6 G7)
  │         └── cost: 24.17
- ├── G2: (scan b) (index-join G15 b,cols=(1-4)) (index-join G17 b,cols=(1-4))
+ ├── G2: (scan b)
  │    └── ""
  │         ├── best: (scan b)
  │         └── cost: 1080.00
- ├── G3: (filters G23 G24 G22 G25)
+ ├── G3: (filters G8 G9 G11 G18)
  ├── G4: (scan b,constrained)
  │    └── ""
  │         ├── best: (scan b,constrained)
  │         └── cost: 360.00
- ├── G5: (filters G23 G24 G22)
- ├── G6: (index-join G12 b,cols=(1-4))
+ ├── G5: (filters G8 G9 G11)
+ ├── G6: (index-join G10 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G12 b,cols=(1-4))
- │         └── cost: 1504.44
- ├── G7: (filters G23 G24)
- ├── G8: (index-join G13 b,cols=(1-4))
- │    └── ""
- │         ├── best: (index-join G13 b,cols=(1-4))
+ │         ├── best: (index-join G10 b,cols=(1-4))
  │         └── cost: 24.13
- ├── G9: (index-join G20 b,cols=(1-4))
+ ├── G7: (filters G11)
+ ├── G8: (ge G12 G17)
+ ├── G9: (le G12 G13)
+ ├── G10: (select G14 G15)
  │    └── ""
- │         ├── best: (index-join G20 b,cols=(1-4))
- │         └── cost: 51.30
- ├── G10: (index-join G14 b,cols=(1-4))
- │    └── ""
- │         ├── best: (index-join G14 b,cols=(1-4))
- │         └── cost: 24.13
- ├── G11: (filters G22)
- ├── G12: (select G15 G16)
- │    └── ""
- │         ├── best: (select G15 G16)
- │         └── cost: 1050.00
- ├── G13: (select G17 G18) (select G19 G21)
- │    └── ""
- │         ├── best: (select G19 G21)
+ │         ├── best: (select G14 G15)
  │         └── cost: 10.50
- ├── G14: (select G20 G21)
- │    └── ""
- │         ├── best: (select G20 G21)
- │         └── cost: 10.50
- ├── G15: (scan b@u,cols=(1,2))
- │    └── ""
- │         ├── best: (scan b@u,cols=(1,2))
- │         └── cost: 1040.00
- ├── G16: (filters G22 G25)
- ├── G17: (scan b@v,cols=(1,3))
- │    └── ""
- │         ├── best: (scan b@v,cols=(1,3))
- │         └── cost: 1040.00
- ├── G18: (filters G23 G24 G25)
- ├── G19: (scan b@v,cols=(1,3),constrained)
+ ├── G11: (eq G16 G17)
+ ├── G12: (variable v)
+ ├── G13: (const 10)
+ ├── G14: (scan b@v,cols=(1,3),constrained)
  │    └── ""
  │         ├── best: (scan b@v,cols=(1,3),constrained)
  │         └── cost: 10.40
- ├── G20: (scan b@v,cols=(1,3),constrained)
- │    └── ""
- │         ├── best: (scan b@v,cols=(1,3),constrained)
- │         └── cost: 10.40
- ├── G21: (filters G25)
- ├── G22: (eq G26 G27)
- ├── G23: (ge G28 G27)
- ├── G24: (le G28 G29)
- ├── G25: (gt G31 G30)
- ├── G26: (plus G31 G32)
- ├── G27: (const 1)
- ├── G28: (variable v)
- ├── G29: (const 10)
- ├── G30: (const 5)
- ├── G31: (variable k)
- └── G32: (variable u)
+ ├── G15: (filters G18)
+ ├── G16: (plus G20 G19)
+ ├── G17: (const 1)
+ ├── G18: (gt G20 G21)
+ ├── G19: (variable u)
+ ├── G20: (variable k)
+ └── G21: (const 5)
 
-# --------------------------------------------------
-# ConstrainLookupJoinIndexScan
-# --------------------------------------------------
-
+# Constraint + index-join.
 opt
 SELECT * FROM b WHERE (u, k, v) > (1, 2, 3) AND (u, k, v) < (8, 9, 10)
 ----
@@ -712,41 +602,33 @@ memo (optimized)
  │    └── "[presentation: k:1,u:2,v:3,j:4]"
  │         ├── best: (select G3 G4)
  │         └── cost: 58.74
- ├── G2: (scan b) (index-join G5 b,cols=(1-4)) (index-join G6 b,cols=(1-4))
+ ├── G2: (scan b)
  │    └── ""
  │         ├── best: (scan b)
  │         └── cost: 1080.00
- ├── G3: (index-join G7 b,cols=(1-4))
+ ├── G3: (index-join G5 b,cols=(1-4))
  │    └── ""
- │         ├── best: (index-join G7 b,cols=(1-4))
+ │         ├── best: (index-join G5 b,cols=(1-4))
  │         └── cost: 58.63
- ├── G4: (filters G8 G9)
- ├── G5: (scan b@u,cols=(1,2))
- │    └── ""
- │         ├── best: (scan b@u,cols=(1,2))
- │         └── cost: 1040.00
- ├── G6: (scan b@v,cols=(1,3))
- │    └── ""
- │         ├── best: (scan b@v,cols=(1,3))
- │         └── cost: 1040.00
- ├── G7: (scan b@u,cols=(1,2),constrained)
+ ├── G4: (filters G6 G7)
+ ├── G5: (scan b@u,cols=(1,2),constrained)
  │    └── ""
  │         ├── best: (scan b@u,cols=(1,2),constrained)
  │         └── cost: 11.89
- ├── G8: (gt G11 G10)
- ├── G9: (lt G11 G12)
- ├── G10: (tuple G13 G14 G15)
- ├── G11: (tuple G16 G17 G18)
- ├── G12: (tuple G19 G20 G21)
- ├── G13: (const 1)
- ├── G14: (const 2)
- ├── G15: (const 3)
- ├── G16: (variable u)
- ├── G17: (variable k)
- ├── G18: (variable v)
- ├── G19: (const 8)
- ├── G20: (const 9)
- └── G21: (const 10)
+ ├── G6: (gt G9 G8)
+ ├── G7: (lt G9 G10)
+ ├── G8: (tuple G11 G12 G13)
+ ├── G9: (tuple G14 G15 G16)
+ ├── G10: (tuple G17 G18 G19)
+ ├── G11: (const 1)
+ ├── G12: (const 2)
+ ├── G13: (const 3)
+ ├── G14: (variable u)
+ ├── G15: (variable k)
+ ├── G16: (variable v)
+ ├── G17: (const 8)
+ ├── G18: (const 9)
+ └── G19: (const 10)
 
 # --------------------------------------------------
 # GenerateInvertedIndexScans

--- a/pkg/sql/opt/xform/testdata/rules/stats
+++ b/pkg/sql/opt/xform/testdata/rules/stats
@@ -35,10 +35,9 @@ rulestats
 SELECT * FROM abc JOIN xyz ON a=x
 ----
 Normalization rules applied 0 times.
-Exploration rules applied 56 times, added 49 expressions.
+Exploration rules applied 8 times, added 5 expressions.
 Top exploration rules:
-  CommuteJoin              applied 18 times, added 9  expressions.
-  GenerateMergeJoins       applied 18 times, added 18 expressions.
-  PushJoinThroughIndexJoin applied 12 times, added 12 expressions.
-  GenerateLookupJoin       applied 6  times, added 6  expressions.
-  GenerateIndexScans       applied 2  times, added 4  expressions.
+  CommuteJoin        applied 2 times, added 1 expressions.
+  GenerateMergeJoins applied 2 times, added 2 expressions.
+  GenerateLookupJoin applied 2 times, added 2 expressions.
+  GenerateIndexScans applied 2 times, added 0 expressions.


### PR DESCRIPTION
Previously, we were generating an IndexJoin+Scan expression for every
secondary index on a table. However, unless the Scan is constrained or
limited, the IndexJoin has almost no chance of being the best plan. And
yet we were paying a sizeable perf penalty for generating the IndexJoins
and then not using them.

The change is to generate IndexJoins "one level up", only when a Scan is
wrapped in a Select or Limit. At this point, they become viable plans that
have a reasonable chance of being selected.

There are significant planning-time improvements from this change. Here are
single CPU numbers showing the effects on optbuild + normalization + exploration
times:
```
  name                      old time/op  new time/op  delta
  Phases/kv-read/Explore    30.1µs ± 2%  27.7µs ± 3%   -8.12%  (p=0.008 n=5+5)
  Phases/planning1/Explore  15.4µs ± 1%  10.6µs ± 1%  -30.90%  (p=0.008 n=5+5)
  Phases/planning2/Explore  56.8µs ± 2%  31.7µs ± 3%  -44.13%  (p=0.008 n=5+5)
  Phases/planning3/Explore  54.2µs ± 3%  36.7µs ± 3%  -32.21%  (p=0.008 n=5+5)
  Phases/planning4/Explore  67.8µs ± 1%  44.4µs ± 3%  -34.45%  (p=0.008 n=5+5)
  Phases/planning5/Explore  54.0µs ± 3%  35.5µs ± 1%  -34.37%  (p=0.008 n=5+5)
  Phases/planning6/Explore   218µs ± 1%    64µs ± 2%  -70.41%  (p=0.008 n=5+5)
```