### PR TITLE
sql/distsqlrun: nodedialer: removing "connection established" log spam

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -239,7 +239,7 @@ func NewDistSender(cfg DistSenderConfig, g *gossip.Gossip) *DistSender {
 			ds.rpcRetryOptions.Closer = ds.rpcContext.Stopper.ShouldQuiesce()
 		}
 	}
-	ds.nodeDialer = nodedialer.New(ds.rpcContext, gossip.AddressResolver(g))
+	ds.nodeDialer = cfg.NodeDialer
 	ds.asyncSenderSem = make(chan struct{}, defaultSenderConcurrency)
 
 	if g != nil {

--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -88,6 +88,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 			AmbientCtx: ambient,
 			Clock:      s.Clock(),
 			RPCContext: s.RPCContext(),
+			NodeDialer: nodedialer.New(s.RPCContext(), gossip.AddressResolver(s.(*server.TestServer).Gossip())),
 		},
 		s.(*server.TestServer).Gossip(),
 	)
@@ -1001,6 +1002,7 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 					kv.DistSenderConfig{
 						AmbientCtx: log.AmbientContext{Tracer: s.ClusterSettings().Tracer},
 						Clock:      clock, RPCContext: s.RPCContext(),
+						NodeDialer: nodedialer.New(s.RPCContext(), gossip.AddressResolver(s.(*server.TestServer).Gossip())),
 					},
 					s.(*server.TestServer).Gossip(),
 				)

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -331,6 +331,7 @@ func TestSendRPCOrder(t *testing.T) {
 			TransportFactory: adaptSimpleTransport(testFn),
 		},
 		RangeDescriptorDB: mockRangeDescriptorDBForDescs(descriptor),
+		NodeDialer:        nodedialer.New(nil, gossip.AddressResolver(g)),
 	}
 
 	ds := NewDistSender(cfg, g)
@@ -494,6 +495,7 @@ func TestImmutableBatchArgs(t *testing.T) {
 			TransportFactory: adaptSimpleTransport(testFn),
 		},
 		RangeDescriptorDB: defaultMockRangeDescriptorDB,
+		NodeDialer:        nodedialer.New(nil, gossip.AddressResolver(g)),
 	}
 
 	ds := NewDistSender(cfg, g)
@@ -557,6 +559,7 @@ func TestRetryOnNotLeaseHolderError(t *testing.T) {
 			TransportFactory: adaptSimpleTransport(testFn),
 		},
 		RangeDescriptorDB: defaultMockRangeDescriptorDB,
+		NodeDialer:        nodedialer.New(nil, gossip.AddressResolver(g)),
 	}
 	ds := NewDistSender(cfg, g)
 	v := roachpb.MakeValueFromString("value")
@@ -638,6 +641,7 @@ func TestDistSenderDownNodeEvictLeaseholder(t *testing.T) {
 					},
 				},
 			}),
+		NodeDialer: nodedialer.New(nil, gossip.AddressResolver(g)),
 	}
 
 	ds := NewDistSender(cfg, g)
@@ -693,6 +697,7 @@ func TestRetryOnDescriptorLookupError(t *testing.T) {
 			errs = errs[1:]
 			return []roachpb.RangeDescriptor{testUserRangeDescriptor}, nil, err
 		}),
+		NodeDialer: nodedialer.New(nil, gossip.AddressResolver(g)),
 	}
 	ds := NewDistSender(cfg, g)
 	put := roachpb.NewPut(roachpb.Key("a"), roachpb.MakeValueFromString("value"))
@@ -780,6 +785,7 @@ func TestEvictOnFirstRangeGossip(t *testing.T) {
 			),
 		},
 		RangeDescriptorDB: rDB,
+		NodeDialer:        nodedialer.New(nil, gossip.AddressResolver(g)),
 	}
 
 	ds := NewDistSender(cfg, g).withMetaRecursion()
@@ -893,6 +899,7 @@ func TestEvictCacheOnError(t *testing.T) {
 				TransportFactory: adaptSimpleTransport(testFn),
 			},
 			RangeDescriptorDB: defaultMockRangeDescriptorDB,
+			NodeDialer:        nodedialer.New(nil, gossip.AddressResolver(g)),
 		}
 		ds := NewDistSender(cfg, g)
 		ds.leaseHolderCache.Update(context.TODO(), 1, leaseHolder.StoreID)
@@ -961,6 +968,7 @@ func TestEvictCacheOnUnknownLeaseHolder(t *testing.T) {
 			TransportFactory: adaptSimpleTransport(testFn),
 		},
 		RangeDescriptorDB: threeReplicaMockRangeDescriptorDB,
+		NodeDialer:        nodedialer.New(nil, gossip.AddressResolver(g)),
 	}
 	ds := NewDistSender(cfg, g)
 	key := roachpb.Key("a")
@@ -1057,6 +1065,7 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 		TestingKnobs: ClientTestingKnobs{
 			TransportFactory: adaptSimpleTransport(testFn),
 		},
+		NodeDialer: nodedialer.New(nil, gossip.AddressResolver(g)),
 	}
 	ds := NewDistSender(cfg, g)
 	scan := roachpb.NewScan(roachpb.Key("a"), roachpb.Key("d"))
@@ -1148,6 +1157,7 @@ func TestRetryOnWrongReplicaErrorWithSuggestion(t *testing.T) {
 		TestingKnobs: ClientTestingKnobs{
 			TransportFactory: adaptSimpleTransport(testFn),
 		},
+		NodeDialer: nodedialer.New(nil, gossip.AddressResolver(g)),
 	}
 	ds := NewDistSender(cfg, g)
 	scan := roachpb.NewScan(roachpb.Key("a"), roachpb.Key("d"))
@@ -1169,6 +1179,7 @@ func TestGetFirstRangeDescriptor(t *testing.T) {
 	n.Start()
 	ds := NewDistSender(DistSenderConfig{
 		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
+		NodeDialer: nodedialer.New(nil, gossip.AddressResolver(n.Nodes[0].Gossip)),
 	}, n.Nodes[0].Gossip)
 	if _, err := ds.FirstRange(); err == nil {
 		t.Errorf("expected not to find first range descriptor")
@@ -1527,6 +1538,7 @@ func TestClockUpdateOnResponse(t *testing.T) {
 		AmbientCtx:        log.AmbientContext{Tracer: tracing.NewTracer()},
 		Clock:             clock,
 		RangeDescriptorDB: defaultMockRangeDescriptorDB,
+		NodeDialer:        nodedialer.New(nil, gossip.AddressResolver(g)),
 	}
 	ds := NewDistSender(cfg, g)
 

--- a/pkg/kv/local_test_cluster_util.go
+++ b/pkg/kv/local_test_cluster_util.go
@@ -77,7 +77,7 @@ func NewDistSenderForLocalTestCluster(
 	latency time.Duration,
 	stores client.Sender,
 	stopper *stop.Stopper,
-	gossip *gossip.Gossip,
+	g *gossip.Gossip,
 ) *DistSender {
 	retryOpts := base.DefaultRetryOptions()
 	retryOpts.Closer = stopper.ShouldQuiesce()
@@ -88,6 +88,7 @@ func NewDistSenderForLocalTestCluster(
 		Clock:           clock,
 		RPCRetryOptions: &retryOpts,
 		nodeDescriptor:  nodeDesc,
+		NodeDialer:      nodedialer.New(nil, gossip.AddressResolver(g)),
 		TestingKnobs: ClientTestingKnobs{
 			TransportFactory: func(
 				opts SendOptions,
@@ -102,5 +103,5 @@ func NewDistSenderForLocalTestCluster(
 				return &localTestClusterTransport{transport, latency}, nil
 			},
 		},
-	}, gossip)
+	}, g)
 }

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -85,6 +86,7 @@ func createTestNode(
 		Clock:           cfg.Clock,
 		RPCContext:      nodeRPCContext,
 		RPCRetryOptions: &retryOpts,
+		NodeDialer:      nodedialer.New(nodeRPCContext, gossip.AddressResolver(cfg.Gossip)),
 	}, cfg.Gossip)
 	tsf := kv.NewTxnCoordSenderFactory(
 		kv.TxnCoordSenderFactoryConfig{


### PR DESCRIPTION
Before we spun up multiple instances of a node dialer which led to
spammy logs.

Now we create one instance per node.

closes #28165

Release note: None