### PR TITLE
storage: place replicas in purgatory when the range is below quorum

### DIFF
--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -86,6 +86,25 @@ var (
 	}
 )
 
+// quorumError indicates a retryable error condition which sends replicas being
+// processed through the replicate queue into purgatory so that they can be
+// retried quickly as soon as nodes come online.
+type quorumError struct {
+	msg string
+}
+
+func newQuorumError(f string, args ...interface{}) *quorumError {
+	return &quorumError{
+		msg: fmt.Sprintf(f, args...),
+	}
+}
+
+func (e *quorumError) Error() string {
+	return e.msg
+}
+
+func (*quorumError) purgatoryErrorMarker() {}
+
 // ReplicateQueueMetrics is the set of metrics for the replicate queue.
 type ReplicateQueueMetrics struct {
 	AddReplicaCount        *metric.Counter
@@ -267,7 +286,7 @@ func (rq *replicateQueue) processOneChange(
 	{
 		quorum := computeQuorum(len(desc.Replicas))
 		if lr := len(liveReplicas); lr < quorum {
-			return false, errors.Errorf(
+			return false, newQuorumError(
 				"range requires a replication change, but lacks a quorum of live replicas (%d/%d)", lr, quorum)
 		}
 	}


### PR DESCRIPTION
When the replicate queue cannot process a replica because the range is
below quorum, place the replica in purgatory so that it will be
processed quickly upon a change in liveness. Failure to do this was
causing rare slowness to up-replicate a new cluster if a replica was
processed before liveness had marked a node as live. Previously this
failure was masked by the scanner rapidly re-scanning replicas on test
clusters, but this was changed in #27441 so that the scanner has a
min-idle-time between scanning replicas to avoid burning cpu.

Also fixes test flakiness that was a side effect of the slow
up-replication. The "had X ranges at startup, expected 22" seems to be
caused by splits taking longer than expected on an overly stressed
machine (note that up-replication in the failed test is not a factor
because the error here occurs when there is only a single node in the
test cluster). When test clusters up-replicate quicker there is less stress on
the system when running tests concurrently.

Fixes #28395
Fixes #28746

Release note: None