### PR TITLE
backport-2.0: sql: mark expired schema change lease as a temporary error

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -138,6 +138,7 @@ func isPermanentSchemaChangeError(err error) bool {
 		context.Canceled,
 		context.DeadlineExceeded,
 		errExistingSchemaChangeLease,
+		errExpiredSchemaChangeLease,
 		errNotHitGCTTLDeadline,
 		errSchemaChangeDuringDrain,
 		errSchemaChangeNotFirstInLine:
@@ -161,6 +162,7 @@ func isPermanentSchemaChangeError(err error) bool {
 
 var (
 	errExistingSchemaChangeLease  = errors.New("an outstanding schema change lease exists")
+	errExpiredSchemaChangeLease   = errors.New("the schema change lease has expired")
 	errSchemaChangeNotFirstInLine = errors.New("schema change not first in line")
 	errNotHitGCTTLDeadline        = errors.New("not hit gc ttl deadline")
 	errSchemaChangeDuringDrain    = errors.New("a schema change ran during the drain phase, re-increment")
@@ -241,7 +243,8 @@ func (sc *SchemaChanger) findTableWithLease(
 		return nil, errors.Errorf("no lease present for tableID: %d", sc.tableID)
 	}
 	if *tableDesc.Lease != lease {
-		return nil, errors.Errorf("table: %d has lease: %v, expected: %v", sc.tableID, tableDesc.Lease, lease)
+		log.Errorf(ctx, "table: %d has lease: %v, expected: %v", sc.tableID, tableDesc.Lease, lease)
+		return nil, errExpiredSchemaChangeLease
 	}
 	return tableDesc, nil
 }

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -121,7 +121,8 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	}
 
 	// Extending an old lease fails.
-	if err := changer.ExtendLease(ctx, &oldLease); !testutils.IsError(err, "table: .* has lease") {
+	if err := changer.ExtendLease(ctx, &oldLease); !testutils.IsError(
+		err, "the schema change lease has expired") {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #28762.

/cc @cockroachdb/release

---

An expired schema change lease is no reason to rollback
a schema change. The schema change mechanism uses transactions
and doesn't need a guarantee that it only run by a single lease
holder. An expired lease should simply mean: stop and allow the
lease holder to proceed.

related to #27273
related to #27958
related to #27760

Release note: None
