### PR TITLE
storage: discard a unworthwhile merge TODO

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2784,9 +2784,6 @@ func (r *Replica) limitTxnMaxTimestamp(
 // maybeWatchForMerge checks whether a merge of this replica into its left
 // neighbor is in its critical phase and, if so, arranges to block all requests
 // until the merge completes.
-//
-// TODO(benesch): now that merges require collocation, it might be cleaner to
-// fold this function into store.MergeRange.
 func (r *Replica) maybeWatchForMerge(ctx context.Context) error {
 	desc := r.Desc()
 	descKey := keys.RangeDescriptorKey(desc.StartKey)


### PR DESCRIPTION
This TODO suggested removing maybeWatchForMerge by teaching the LHS
replica to reach into the RHS replica after a merge committed to unblock
requests. It failed to consider that we'd need to do the same if the
merge aborted. We don't presently have an abort trigger, so this is
excessively difficult. Simply discard the TODO; the status quo is fine.

Release note: None