### PR TITLE
opt: reorganize selectivity calculations

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -128,13 +128,10 @@ func TestGetStatsFromConstraint(t *testing.T) {
 		// Calculate distinct counts.
 		numUnappliedConstraints := sb.applyConstraintSet(cs, ev, relProps)
 
-		// Calculate selectivity.
-		s.Selectivity *= sb.selectivityFromDistinctCounts(cols, ev, relProps)
-		s.Selectivity *= sb.selectivityFromUnappliedConstraints(numUnappliedConstraints)
-
-		// Calculate row count.
-		inputRows := mem.GroupProperties(scanGroup).Relational.Stats.RowCount
-		sb.applySelectivity(inputRows, s)
+		// Calculate row count and selectivity.
+		s.RowCount = mem.GroupProperties(scanGroup).Relational.Stats.RowCount
+		s.ApplySelectivity(sb.selectivityFromDistinctCounts(cols, ev, s))
+		s.ApplySelectivity(sb.selectivityFromUnappliedConstraints(numUnappliedConstraints))
 
 		// Check if the statistics match the expected value.
 		testStats(t, s, expectedStats, expectedSelectivity)

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -716,8 +716,6 @@ TABLE xyz
 # In the first case, x=10 is pushed down; in the second case it is part of the
 # ON condition. The latter formulation happens in practice when we convert to
 # lookup join (we incorporate the filter back into the ON condition).
-# TODO(radu): the second case has orders of magnitude smaller row count; fix
-# this.
 
 norm disable=(PushFilterIntoJoinLeftAndRight,PushFilterIntoJoinLeft,PushFilterIntoJoinRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
 SELECT * FROM (SELECT * FROM uvw WHERE w=1) JOIN (SELECT * FROM xyz WHERE x=10) ON u=x
@@ -752,7 +750,7 @@ SELECT * FROM (SELECT * FROM uvw WHERE w=1) JOIN xyz ON u=x AND x=10
 ----
 inner-join
  ├── columns: u:1(int!null) v:2(int) w:3(int!null) x:5(int!null) y:6(int) z:7(int)
- ├── stats: [rows=0.0029154519, distinct(1)=0.0029154519, distinct(5)=0.0029154519]
+ ├── stats: [rows=1.429009, distinct(1)=1, distinct(5)=1]
  ├── fd: ()-->(1,3,5), (1)==(5), (5)==(1)
  ├── select
  │    ├── columns: u:1(int) v:2(int) w:3(int!null)

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -689,3 +689,83 @@ inner-join (merge)
       ├── right ordering: +5
       └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
            └── a = e [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+
+exec-ddl
+CREATE TABLE uvw (u INT, v INT, w INT)
+----
+TABLE uvw
+ ├── u int
+ ├── v int
+ ├── w int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+exec-ddl
+CREATE TABLE xyz (x INT, y INT, z INT)
+----
+TABLE xyz
+ ├── x int
+ ├── y int
+ ├── z int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+# Verify that two equivalent formulations of a join lead to similar statistics.
+# In the first case, x=10 is pushed down; in the second case it is part of the
+# ON condition. The latter formulation happens in practice when we convert to
+# lookup join (we incorporate the filter back into the ON condition).
+# TODO(radu): the second case has orders of magnitude smaller row count; fix
+# this.
+
+norm disable=(PushFilterIntoJoinLeftAndRight,PushFilterIntoJoinLeft,PushFilterIntoJoinRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
+SELECT * FROM (SELECT * FROM uvw WHERE w=1) JOIN (SELECT * FROM xyz WHERE x=10) ON u=x
+----
+inner-join
+ ├── columns: u:1(int!null) v:2(int) w:3(int!null) x:5(int!null) y:6(int) z:7(int)
+ ├── stats: [rows=1.429009, distinct(1)=1, distinct(5)=1]
+ ├── fd: ()-->(1,3,5), (1)==(5), (5)==(1)
+ ├── select
+ │    ├── columns: u:1(int) v:2(int) w:3(int!null)
+ │    ├── stats: [rows=1.42857143, distinct(1)=1.42813399, distinct(3)=1]
+ │    ├── fd: ()-->(3)
+ │    ├── scan uvw
+ │    │    ├── columns: u:1(int) v:2(int) w:3(int)
+ │    │    └── stats: [rows=1000, distinct(1)=700, distinct(3)=700]
+ │    └── filters [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
+ │         └── w = 1 [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight)]
+ ├── select
+ │    ├── columns: x:5(int!null) y:6(int) z:7(int)
+ │    ├── stats: [rows=1.42857143, distinct(5)=1]
+ │    ├── fd: ()-->(5)
+ │    ├── scan xyz
+ │    │    ├── columns: x:5(int) y:6(int) z:7(int)
+ │    │    └── stats: [rows=1000, distinct(5)=700]
+ │    └── filters [type=bool, outer=(5), constraints=(/5: [/10 - /10]; tight), fd=()-->(5)]
+ │         └── x = 10 [type=bool, outer=(5), constraints=(/5: [/10 - /10]; tight)]
+ └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+      └── u = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+
+norm disable=(PushFilterIntoJoinLeftAndRight,PushFilterIntoJoinLeft,PushFilterIntoJoinRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
+SELECT * FROM (SELECT * FROM uvw WHERE w=1) JOIN xyz ON u=x AND x=10
+----
+inner-join
+ ├── columns: u:1(int!null) v:2(int) w:3(int!null) x:5(int!null) y:6(int) z:7(int)
+ ├── stats: [rows=0.0029154519, distinct(1)=0.0029154519, distinct(5)=0.0029154519]
+ ├── fd: ()-->(1,3,5), (1)==(5), (5)==(1)
+ ├── select
+ │    ├── columns: u:1(int) v:2(int) w:3(int!null)
+ │    ├── stats: [rows=1.42857143, distinct(1)=1.42813399, distinct(3)=1]
+ │    ├── fd: ()-->(3)
+ │    ├── scan uvw
+ │    │    ├── columns: u:1(int) v:2(int) w:3(int)
+ │    │    └── stats: [rows=1000, distinct(1)=700, distinct(3)=700]
+ │    └── filters [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
+ │         └── w = 1 [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight)]
+ ├── scan xyz
+ │    ├── columns: x:5(int) y:6(int) z:7(int)
+ │    └── stats: [rows=1000, distinct(5)=700]
+ └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: [/10 - /10]), fd=()-->(1,5), (1)==(5), (5)==(1)]
+      ├── u = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+      └── x = 10 [type=bool, outer=(5), constraints=(/5: [/10 - /10]; tight)]

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -502,7 +502,7 @@ SELECT * FROM order_history WHERE item_id = order_id AND item_id = customer_id A
 ----
 select
  ├── columns: order_id:1(int!null) item_id:2(int!null) customer_id:3(int!null) year:4(int)
- ├── stats: [rows=0.00204081633, distinct(1)=0.00204081633, distinct(2)=0.00204081633, distinct(3)=0.00204081633]
+ ├── stats: [rows=1, distinct(1)=1, distinct(2)=1, distinct(3)=1]
  ├── fd: ()-->(1-3), (1)==(2,3), (2)==(1,3), (3)==(1,2)
  ├── scan order_history
  │    ├── columns: order_id:1(int) item_id:2(int) customer_id:3(int) year:4(int)
@@ -602,14 +602,12 @@ TABLE uvw
 
 # Test selectivity calculations by applying the two constraints in different
 # orders.
-# TODO(radu): applying both constraints at the same time results in much lower
-# estimates.
 norm
 SELECT * FROM uvw WHERE u=v AND u=10
 ----
 select
  ├── columns: u:1(int!null) v:2(int!null) w:3(int)
- ├── stats: [rows=0.00204081633, distinct(1)=0.00204081633, distinct(2)=0.00204081633]
+ ├── stats: [rows=1, distinct(1)=1, distinct(2)=1]
  ├── fd: ()-->(1,2), (1)==(2), (2)==(1)
  ├── scan uvw
  │    ├── columns: u:1(int) v:2(int) w:3(int)

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -588,3 +588,70 @@ select
  └── filters [type=bool, outer=(1), constraints=(/1: [/0 - /99]; tight)]
       ├── x >= 0 [type=bool, outer=(1), constraints=(/1: [/0 - ]; tight)]
       └── x < 100 [type=bool, outer=(1), constraints=(/1: (/NULL - /99]; tight)]
+
+exec-ddl
+CREATE TABLE uvw (u INT, v INT, w INT)
+----
+TABLE uvw
+ ├── u int
+ ├── v int
+ ├── w int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+# Test selectivity calculations by applying the two constraints in different
+# orders.
+# TODO(radu): applying both constraints at the same time results in much lower
+# estimates.
+norm
+SELECT * FROM uvw WHERE u=v AND u=10
+----
+select
+ ├── columns: u:1(int!null) v:2(int!null) w:3(int)
+ ├── stats: [rows=0.00204081633, distinct(1)=0.00204081633, distinct(2)=0.00204081633]
+ ├── fd: ()-->(1,2), (1)==(2), (2)==(1)
+ ├── scan uvw
+ │    ├── columns: u:1(int) v:2(int) w:3(int)
+ │    └── stats: [rows=1000, distinct(1)=700, distinct(2)=700]
+ └── filters [type=bool, outer=(1,2), constraints=(/1: [/10 - /10]; /2: (/NULL - ]), fd=()-->(1,2), (1)==(2), (2)==(1)]
+      ├── u = v [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
+      └── u = 10 [type=bool, outer=(1), constraints=(/1: [/10 - /10]; tight)]
+
+norm disable=MergeSelects
+SELECT * FROM (SELECT * FROM uvw WHERE u=10) WHERE u=v
+----
+select
+ ├── columns: u:1(int!null) v:2(int!null) w:3(int)
+ ├── stats: [rows=1.0003063, distinct(1)=1, distinct(2)=1]
+ ├── fd: ()-->(1,2), (1)==(2), (2)==(1)
+ ├── select
+ │    ├── columns: u:1(int!null) v:2(int) w:3(int)
+ │    ├── stats: [rows=1.42857143, distinct(1)=1, distinct(2)=1.42813399]
+ │    ├── fd: ()-->(1)
+ │    ├── scan uvw
+ │    │    ├── columns: u:1(int) v:2(int) w:3(int)
+ │    │    └── stats: [rows=1000, distinct(1)=700, distinct(2)=700]
+ │    └── filters [type=bool, outer=(1), constraints=(/1: [/10 - /10]; tight), fd=()-->(1)]
+ │         └── u = 10 [type=bool, outer=(1), constraints=(/1: [/10 - /10]; tight)]
+ └── filters [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
+      └── u = v [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
+
+norm disable=MergeSelects
+SELECT * FROM (SELECT * FROM uvw WHERE u=v) WHERE u=10
+----
+select
+ ├── columns: u:1(int!null) v:2(int!null) w:3(int)
+ ├── stats: [rows=1, distinct(1)=1]
+ ├── fd: ()-->(1,2), (1)==(2), (2)==(1)
+ ├── select
+ │    ├── columns: u:1(int!null) v:2(int!null) w:3(int)
+ │    ├── stats: [rows=1.42857143, distinct(1)=1.42857143, distinct(2)=1.42857143]
+ │    ├── fd: (1)==(2), (2)==(1)
+ │    ├── scan uvw
+ │    │    ├── columns: u:1(int) v:2(int) w:3(int)
+ │    │    └── stats: [rows=1000, distinct(1)=700, distinct(2)=700]
+ │    └── filters [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
+ │         └── u = v [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
+ └── filters [type=bool, outer=(1), constraints=(/1: [/10 - /10]; tight), fd=()-->(1)]
+      └── u = 10 [type=bool, outer=(1), constraints=(/1: [/10 - /10]; tight)]

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -130,13 +130,6 @@ func (o *Optimizer) DisableOptimizations() {
 	o.NotifyOnMatchedRule(func(opt.RuleName) bool { return false })
 }
 
-// DisableExplorations disables all explore rules. The normalized expression
-// tree becomes the output expression tree (because no explore transforms are
-// applied).
-func (o *Optimizer) DisableExplorations() {
-	o.NotifyOnMatchedRule(func(ruleName opt.RuleName) bool { return ruleName.IsNormalize() })
-}
-
 // NotifyOnMatchedRule sets a callback function which is invoked each time an
 // optimization rule (Normalize or Explore) has been matched by the optimizer.
 // If matchedRule is nil, then no notifications are sent, and all rules are

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -895,15 +895,15 @@ scalar-group-by
  ├── columns: count:28(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 0.0100267051
+ ├── cost: 0.17464683
  ├── key: ()
  ├── fd: ()-->(28)
  ├── prune: (28)
  ├── inner-join (lookup stock)
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) s_i_id:11(int!null) s_w_id:12(int!null) s_quantity:13(int!null)
  │    ├── key columns: [3 5] = [12 11]
- │    ├── stats: [rows=4.73185689e-06, distinct(3)=4.08163265e-06, distinct(5)=4.0816376e-06, distinct(11)=4.0816376e-06, distinct(12)=4.08163265e-06]
- │    ├── cost: 2.66578201e-05
+ │    ├── stats: [rows=0.136054422, distinct(3)=4.08163265e-06, distinct(5)=4.0816376e-06, distinct(11)=4.0816376e-06, distinct(12)=4.08163265e-06]
+ │    ├── cost: 0.163286286
  │    ├── fd: ()-->(2,3,12), (11)-->(13), (5)==(11), (11)==(5), (3)==(12), (12)==(3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    ├── scan order_line


### PR DESCRIPTION
#### opt: add disable flag to opttester

Add a flag to norm/opt that disables specific rules.

Release note: None

#### opt: add testcases showing stats problem

Release note: None

#### opt: reorganize selectivity calculations

Fixing a few issues with selectivity calculations, related to the
handling of constraints in conjunction with equivalencies. In
principle, applying the filter `a=10 AND a=b` should result in similar
stats with applying `a=10` and then applying `a=b` but this was not
the case.

Changes:
 - We were updating the distinct counts to take into account the
   equivalencies before we estimated selectivity. This can lead to the
   selectivity of some constraints effectively being applied twice.
   The call to applyEquivalencies is moved after the selectivity
   calculations.

 - When calculating selectivity from distinct counts we were taking
   into account equivalencies, even though we later apply the
   selectivity of equivalencies separately. The fix is to only look at
   the distinct count of each column, rather than taking the minimum
   across the equivalency group.

 - When calculating selectivity for equivalency, we were looking
   at the "input" distinct counts. But if some distinct counts were
   updated by a constraint, we want to use the updated values; so the
   code now checks `ColStats` first. An example with some intuition
   for this: when applying a filter `a=10 AND a=b`, the behavior
   should be the same with first applying filter `a=10` and then
   applying `a=b`. So the "input" to the equivalency calculation needs
   to reflect `a=10`.

 - Finally, another difference when handling a conjunction is that we
   only calculate RowCount and bound the distinct counts at the end.
   We now update the RowCount "in step" with Selectivity; in addition,
   RowCount is used as an upper bound when consulting "input" stats.

Release note: None
