### PR TITLE
opt: remove some unnecessary projections

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -866,34 +866,28 @@ CREATE TABLE foo(a INT, b CHAR)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1
 ----
-render               ·            ·            (m)              ·
- │                   render 0     agg0         ·                ·
- └── group           ·            ·            (column4, agg0)  ·
-      │              aggregate 0  column4      ·                ·
-      │              aggregate 1  min(a)       ·                ·
-      │              group by     @1           ·                ·
-      └── render     ·            ·            (column4, a)     ·
-           │         render 0     a            ·                ·
-           │         render 1     a            ·                ·
-           └── scan  ·            ·            (a)              ·
-·                    table        foo@primary  ·                ·
-·                    spans        ALL          ·                ·
+render          ·            ·            (m)        ·
+ │              render 0     agg0         ·          ·
+ └── group      ·            ·            (a, agg0)  ·
+      │         aggregate 0  a            ·          ·
+      │         aggregate 1  min(a)       ·          ·
+      │         group by     @1           ·          ·
+      └── scan  ·            ·            (a)        ·
+·               table        foo@primary  ·          ·
+·               spans        ALL          ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2
 ----
-render               ·            ·            (m)              ·
- │                   render 0     agg0         ·                ·
- └── group           ·            ·            (column4, agg0)  ·
-      │              aggregate 0  column4      ·                ·
-      │              aggregate 1  min(a)       ·                ·
-      │              group by     @1           ·                ·
-      └── render     ·            ·            (column4, a)     ·
-           │         render 0     b            ·                ·
-           │         render 1     a            ·                ·
-           └── scan  ·            ·            (a, b)           ·
-·                    table        foo@primary  ·                ·
-·                    spans        ALL          ·                ·
+render          ·            ·            (m)        ·
+ │              render 0     agg0         ·          ·
+ └── group      ·            ·            (b, agg0)  ·
+      │         aggregate 0  b            ·          ·
+      │         aggregate 1  min(a)       ·          ·
+      │         group by     @2           ·          ·
+      └── scan  ·            ·            (a, b)     ·
+·               table        foo@primary  ·          ·
+·               spans        ALL          ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT array_agg(v) FROM (SELECT * FROM kv ORDER BY v)

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -581,34 +581,26 @@ CREATE TABLE foo(a INT, b CHAR)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b, a FROM foo ORDER BY @1
 ----
-render               ·         ·            (b, a)           ·
- │                   render 0  b            ·                ·
- │                   render 1  a            ·                ·
- └── sort            ·         ·            (column4, a, b)  +column4
-      │              order     +column4     ·                ·
-      └── render     ·         ·            (column4, a, b)  ·
-           │         render 0  a            ·                ·
-           │         render 1  a            ·                ·
-           │         render 2  b            ·                ·
-           └── scan  ·         ·            (a, b)           ·
-·                    table     foo@primary  ·                ·
-·                    spans     ALL          ·                ·
+render          ·         ·            (b, a)  ·
+ │              render 0  b            ·       ·
+ │              render 1  a            ·       ·
+ └── sort       ·         ·            (a, b)  +a
+      │         order     +a           ·       ·
+      └── scan  ·         ·            (a, b)  ·
+·               table     foo@primary  ·       ·
+·               spans     ALL          ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b, a FROM foo ORDER BY @2
 ----
-render               ·         ·            (b, a)           ·
- │                   render 0  b            ·                ·
- │                   render 1  a            ·                ·
- └── sort            ·         ·            (column4, a, b)  +column4
-      │              order     +column4     ·                ·
-      └── render     ·         ·            (column4, a, b)  ·
-           │         render 0  b            ·                ·
-           │         render 1  a            ·                ·
-           │         render 2  b            ·                ·
-           └── scan  ·         ·            (a, b)           ·
-·                    table     foo@primary  ·                ·
-·                    spans     ALL          ·                ·
+render          ·         ·            (b, a)  ·
+ │              render 0  b            ·       ·
+ │              render 1  a            ·       ·
+ └── sort       ·         ·            (a, b)  +b
+      │         order     +b           ·       ·
+      └── scan  ·         ·            (a, b)  ·
+·               table     foo@primary  ·       ·
+·               spans     ALL          ·       ·
 
 # ------------------------------------------------------------------------------
 # Check star expansion in ORDER BY.

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -578,32 +578,20 @@ select
 opt
 SELECT b OR b FROM c
 ----
-project
- ├── columns: "?column?":7(bool)
- ├── scan c
- │    └── columns: b:2(bool)
- └── projections [outer=(2)]
-      └── variable: b [type=bool, outer=(2)]
+scan c
+ └── columns: "?column?":2(bool)
 
 opt
 SELECT a OR (a AND b) OR (a AND c) FROM c
 ----
-project
- ├── columns: "?column?":7(bool)
- ├── scan c
- │    └── columns: a:1(bool)
- └── projections [outer=(1)]
-      └── variable: a [type=bool, outer=(1)]
+scan c
+ └── columns: "?column?":1(bool)
 
 opt
 SELECT (a AND b) OR a OR (a AND c) FROM c
 ----
-project
- ├── columns: "?column?":7(bool)
- ├── scan c
- │    └── columns: a:1(bool)
- └── projections [outer=(1)]
-      └── variable: a [type=bool, outer=(1)]
+scan c
+ └── columns: "?column?":1(bool)
 
 opt
 SELECT (a AND b) OR (b AND a) FROM c

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -522,3 +522,42 @@ project
            └── avg [type=decimal, outer=(4)]
                 └── agg-distinct [type=int, outer=(4)]
                      └── variable: z [type=int, outer=(4)]
+
+# Aggregate where we might try to collapse projections into passthrough cols.
+norm
+SELECT avg(1::int)::float, avg(2::float)::float, avg(3::decimal)::float
+----
+project
+ ├── columns: avg:3(float) avg:6(float) avg:9(float)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(3,6,9)
+ ├── scalar-group-by
+ │    ├── columns: column2:2(decimal) column5:5(float) column8:8(decimal)
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(2,5,8)
+ │    ├── project
+ │    │    ├── columns: column1:1(int!null) column4:4(float!null) column7:7(decimal!null)
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,4,7)
+ │    │    ├── values
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    └── tuple [type=tuple]
+ │    │    └── projections
+ │    │         ├── const: 1 [type=int]
+ │    │         ├── const: 2.0 [type=float]
+ │    │         └── const: 3 [type=decimal]
+ │    └── aggregations [outer=(1,4,7)]
+ │         ├── avg [type=decimal, outer=(1)]
+ │         │    └── variable: column1 [type=int, outer=(1)]
+ │         ├── avg [type=float, outer=(4)]
+ │         │    └── variable: column4 [type=float, outer=(4)]
+ │         └── avg [type=decimal, outer=(7)]
+ │              └── variable: column7 [type=decimal, outer=(7)]
+ └── projections [outer=(2,5,8)]
+      ├── column2::FLOAT8 [type=float, outer=(2)]
+      ├── variable: column5 [type=float, outer=(5)]
+      └── column8::FLOAT8 [type=float, outer=(8)]

--- a/pkg/sql/opt/norm/testdata/rules/numeric
+++ b/pkg/sql/opt/norm/testdata/rules/numeric
@@ -90,14 +90,8 @@ SELECT
     a.d / 1 AS t
 FROM a
 ----
-project
- ├── columns: r:6(decimal) s:7(float) t:8(decimal)
- ├── scan a
- │    └── columns: i:2(int) f:3(float) d:4(decimal)
- └── projections [outer=(2-4)]
-      ├── variable: i [type=int, outer=(2)]
-      ├── variable: f [type=float, outer=(3)]
-      └── variable: d [type=decimal, outer=(4)]
+scan a
+ └── columns: r:2(int) s:3(float) t:4(decimal)
 
 # --------------------------------------------------
 # InvertMinus
@@ -124,12 +118,8 @@ project
 opt
 SELECT -(-a.i::int) AS r FROM a
 ----
-project
- ├── columns: r:6(int)
- ├── scan a
- │    └── columns: i:2(int)
- └── projections [outer=(2)]
-      └── variable: i [type=int, outer=(2)]
+scan a
+ └── columns: r:2(int)
 
 # --------------------------------------------------
 # FoldUnaryMinus

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -88,12 +88,8 @@ project
 opt
 SELECT COALESCE(i) FROM a
 ----
-project
- ├── columns: coalesce:7(int)
- ├── scan a
- │    └── columns: i:2(int)
- └── projections [outer=(2)]
-      └── variable: i [type=int, outer=(2)]
+scan a
+ └── columns: coalesce:2(int)
 
 # --------------------------------------------------
 # SimplifyCoalesce
@@ -148,16 +144,13 @@ SELECT
 FROM a
 ----
 project
- ├── columns: i:7(int) arr:8(int[]) json:9(jsonb) int:10(int) s:11(string)
- ├── fd: ()-->(9,10)
+ ├── columns: i:2(int) arr:6(int[]) json:7(jsonb) int:8(int) s:4(string)
+ ├── fd: ()-->(7,8)
  ├── scan a
- │    └── columns: a.i:2(int) a.s:4(string) a.arr:6(int[])
+ │    └── columns: i:2(int) s:4(string) arr:6(int[])
  └── projections [outer=(2,4,6)]
-      ├── variable: a.i [type=int, outer=(2)]
-      ├── variable: a.arr [type=int[], outer=(6)]
       ├── '[1, 2]'::JSONB [type=jsonb]
-      ├── null [type=int]
-      └── variable: a.s [type=string, outer=(4)]
+      └── null [type=int]
 
 # Shouldn't eliminate these casts.
 opt

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -410,6 +410,20 @@ func (b *Builder) buildScalarHelper(
 		}
 	}
 
+	// In case we ended up normalizing to a raw variable expression within a
+	// projection, attempt to make that expression a passthrough column rather
+	// than a synthesized column.
+	if !inGroupingContext && outScope != nil {
+		if v := b.factory.Memo().NormExpr(out).AsVariable(); v != nil {
+			return b.finishBuildScalarRef(
+				inScope.getColumn(b.factory.Memo().LookupPrivate(v.Col()).(opt.ColumnID)),
+				label,
+				inScope,
+				outScope,
+			)
+		}
+	}
+
 	return b.finishBuildScalar(scalar, out, label, inScope, outScope)
 }
 

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -563,13 +563,11 @@ SELECT b, c FROM t ORDER BY @2
 ----
 sort
  ├── columns: b:2(int) c:3(bool)
- ├── ordering: +4
+ ├── ordering: +2
  └── project
-      ├── columns: column4:4(int) b:2(int) c:3(bool)
-      ├── scan t
-      │    └── columns: a:1(int!null) b:2(int) c:3(bool)
-      └── projections
-           └── variable: b [type=int]
+      ├── columns: b:2(int) c:3(bool)
+      └── scan t
+           └── columns: a:1(int!null) b:2(int) c:3(bool)
 
 build
 SELECT b, c FROM t ORDER BY @4

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1045,13 +1045,8 @@ scan a
 build
 SELECT @1 AS r, @2 AS s FROM a
 ----
-project
- ├── columns: r:3(int) s:4(float)
- ├── scan a
- │    └── columns: x:1(int!null) y:2(float)
- └── projections
-      ├── variable: x [type=int]
-      └── variable: y [type=float]
+scan a
+ └── columns: r:1(int!null) s:2(float)
 
 build
 SELECT * FROM a WHERE (x > 10)::bool


### PR DESCRIPTION
In some cases, we would generate a projection despite actually having a
passthrough column. This would occur when we had an expression which
itself was not explicitly a passthrough projection, but would normalize
to one (such as `SELECT x + 0 FROM a`).

This commit modifies the optbuilder to hit the passthrough codepath when
we end up normalizing to a variable expr. I'm not sure if there's a
better way - this breaks the rule that @andy-kimball gave me once of not
inspecting what you've built, but this seems ok to me as it's
semantically equivalent and effectively an optimization.

This can't be a normalization rule on Projections because by
normalization-time we've already constructed the new column ids for the
projection, so it's too late by then to do a passthrough.

Release note: None