### PR TITLE
kv: teach DistSender about RangeFeeds, use for changefeeds

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -1051,6 +1051,8 @@ func (ds *DistSender) sendPartialBatch(
 			} else {
 				descKey = rs.Key
 			}
+			// TODO(nvanbenschoten): shouldn't we be passing an eviction token
+			// here from the previous iteration? See #28967.
 			desc, evictToken, err = ds.getDescriptor(ctx, descKey, nil, isReverse)
 			if err != nil {
 				log.VErrEventf(ctx, 1, "range descriptor re-lookup failed: %s", err)

--- a/pkg/kv/dist_sender_rangefeed.go
+++ b/pkg/kv/dist_sender_rangefeed.go
@@ -1,0 +1,224 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package kv
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+)
+
+// RangeFeed divides a RangeFeed request on range boundaries and establishes a
+// RangeFeed to each of the individual ranges. It streams back results on the
+// provided channel.
+func (ds *DistSender) RangeFeed(
+	ctx context.Context, args *roachpb.RangeFeedRequest, eventCh chan<- *roachpb.RangeFeedEvent,
+) *roachpb.Error {
+	ctx = ds.AnnotateCtx(ctx)
+	ctx, cleanup := tracing.EnsureChildSpan(ctx, ds.AmbientContext.Tracer, "dist sender")
+	defer cleanup()
+
+	startRKey, err := keys.Addr(args.Span.Key)
+	if err != nil {
+		return roachpb.NewError(err)
+	}
+	endRKey, err := keys.Addr(args.Span.EndKey)
+	if err != nil {
+		return roachpb.NewError(err)
+	}
+	rs := roachpb.RSpan{Key: startRKey, EndKey: endRKey}
+
+	g := ctxgroup.WithContext(ctx)
+	g.GoCtx(func(ctx context.Context) error {
+		return ds.divideAndSendRangeFeedToRanges(ctx, &g, args, rs, eventCh)
+	})
+	return roachpb.NewError(g.Wait())
+}
+
+func (ds *DistSender) divideAndSendRangeFeedToRanges(
+	ctx context.Context,
+	g *ctxgroup.Group,
+	args *roachpb.RangeFeedRequest,
+	rs roachpb.RSpan,
+	eventCh chan<- *roachpb.RangeFeedEvent,
+) error {
+	ri := NewRangeIterator(ds)
+	for ri.Seek(ctx, rs.Key, Ascending); ri.Valid(); ri.Next(ctx) {
+		desc := ri.Desc()
+		partialRS, err := rs.Intersect(desc)
+		if err != nil {
+			return err
+		}
+
+		ds.partialRangeFeed(g, *args, partialRS, desc, ri.Token(), eventCh)
+		if !ri.NeedAnother(rs) {
+			break
+		}
+	}
+	return ri.Error().GoError()
+}
+
+// partialRangeFeed establishes a RangeFeed to the range specified by desc. It
+// manages lifecycle events of the range in order to maintain the RangeFeed
+// connection.
+func (ds *DistSender) partialRangeFeed(
+	g *ctxgroup.Group,
+	argsCopy roachpb.RangeFeedRequest,
+	rs roachpb.RSpan,
+	desc *roachpb.RangeDescriptor,
+	evictToken *EvictionToken,
+	eventCh chan<- *roachpb.RangeFeedEvent,
+) {
+	g.GoCtx(func(ctx context.Context) error {
+		// Start a retry loop for sending the batch to the range.
+		for r := retry.StartWithCtx(ctx, ds.rpcRetryOptions); r.Next(); {
+			// If we've cleared the descriptor on a send failure, re-lookup.
+			if desc == nil {
+				var err error
+				desc, evictToken, err = ds.getDescriptor(ctx, rs.Key, nil, false)
+				if err != nil {
+					log.VErrEventf(ctx, 1, "range descriptor re-lookup failed: %s", err)
+					continue
+				}
+			}
+
+			// Establish a RangeFeed for a single Range.
+			maxTS, pErr := ds.singleRangeFeed(ctx, argsCopy, desc, eventCh)
+
+			// Forward the timestamp of the request in case we end up sending it
+			// again.
+			argsCopy.Timestamp.Forward(maxTS)
+
+			if pErr != nil {
+				switch t := pErr.GetDetail().(type) {
+				case *roachpb.SendError, *roachpb.RangeNotFoundError:
+					// Evict the decriptor from the cache and reload on next attempt.
+					if err := evictToken.Evict(ctx); err != nil {
+						return err
+					}
+					desc = nil
+					continue
+				case *roachpb.RangeKeyMismatchError:
+					// Evict the decriptor from the cache.
+					if err := evictToken.Evict(ctx); err != nil {
+						return err
+					}
+					return ds.divideAndSendRangeFeedToRanges(ctx, g, &argsCopy, rs, eventCh)
+				case *roachpb.RangeFeedRetryError:
+					switch t.Reason {
+					case roachpb.RangeFeedRetryError_REASON_REPLICA_REMOVED,
+						roachpb.RangeFeedRetryError_REASON_RAFT_SNAPSHOT,
+						roachpb.RangeFeedRetryError_REASON_LOGICAL_OPS_MISSING:
+						// Try again with same descriptor. These are transient
+						// errors that should not show up again.
+						continue
+					case roachpb.RangeFeedRetryError_REASON_RANGE_SPLIT,
+						roachpb.RangeFeedRetryError_REASON_RANGE_MERGED:
+						// Evict the decriptor from the cache.
+						if err := evictToken.Evict(ctx); err != nil {
+							return err
+						}
+						return ds.divideAndSendRangeFeedToRanges(ctx, g, &argsCopy, rs, eventCh)
+					default:
+						log.Fatalf(ctx, "unexpected RangeFeedRetryError reason %v", t.Reason)
+					}
+				default:
+					return t
+				}
+			}
+			break
+		}
+		return nil
+	})
+}
+
+// singleRangeFeed gathers and rearranges the replicas, and makes a RangeFeed
+// RPC call. Results will be send on the provided channel. Returns the timestamp
+// of the maximum rangefeed checkpoint seen, which can be used to re-establish
+// the rangefeed with a larger starting timestamp, reflecting the fact that all
+// values up to the last checkpoint have already been observed. Returns the
+// request's timestamp if not checkpoints are seen.
+func (ds *DistSender) singleRangeFeed(
+	ctx context.Context,
+	argsCopy roachpb.RangeFeedRequest,
+	desc *roachpb.RangeDescriptor,
+	eventCh chan<- *roachpb.RangeFeedEvent,
+) (hlc.Timestamp, *roachpb.Error) {
+	argsCopy.RangeID = desc.RangeID
+	argsCopy.Span = desc.RSpan().AsRawSpanWithNoLocals()
+
+	var latencyFn LatencyFunc
+	if ds.rpcContext != nil {
+		latencyFn = ds.rpcContext.RemoteClocks.Latency
+	}
+	replicas := NewReplicaSlice(ds.gossip, desc)
+	replicas.OptimizeReplicaOrder(ds.getNodeDescriptor(), latencyFn)
+
+	transport, err := ds.transportFactory(SendOptions{}, ds.nodeDialer, replicas)
+	if err != nil {
+		return argsCopy.Timestamp, roachpb.NewError(err)
+	}
+
+	for {
+		if transport.IsExhausted() {
+			return argsCopy.Timestamp, roachpb.NewError(roachpb.NewSendError(
+				fmt.Sprintf("sending to all %d replicas failed", len(replicas)),
+			))
+		}
+
+		argsCopy.Replica = transport.NextReplica()
+		clientCtx, client, err := transport.NextInternalClient(ctx)
+		if err != nil {
+			log.VErrEventf(ctx, 2, "RPC error: %s", err)
+			continue
+		}
+
+		stream, err := client.RangeFeed(clientCtx, &argsCopy)
+		if err != nil {
+			log.VErrEventf(ctx, 2, "RPC error: %s", err)
+			continue
+		}
+		for {
+			event, err := stream.Recv()
+			if err == io.EOF {
+				return argsCopy.Timestamp, nil
+			}
+			if err != nil {
+				return argsCopy.Timestamp, roachpb.NewError(err)
+			}
+			switch t := event.GetValue().(type) {
+			case *roachpb.RangeFeedCheckpoint:
+				if t.Span.Contains(argsCopy.Span) {
+					argsCopy.Timestamp.Forward(t.ResolvedTS)
+				}
+			case *roachpb.RangeFeedError:
+				return argsCopy.Timestamp, &t.Error
+			}
+			select {
+			case eventCh <- event:
+			case <-ctx.Done():
+				return argsCopy.Timestamp, roachpb.NewError(ctx.Err())
+			}
+		}
+	}
+}

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -156,6 +156,12 @@ func (l *simpleTransportAdapter) SendNext(
 	return l.fn(ctx, l.opts, l.replicas, ba)
 }
 
+func (l *simpleTransportAdapter) NextInternalClient(
+	ctx context.Context,
+) (context.Context, roachpb.InternalClient, error) {
+	panic("unimplemented")
+}
+
 func (l *simpleTransportAdapter) NextReplica() roachpb.ReplicaDescriptor {
 	if !l.IsExhausted() {
 		return l.replicas[l.nextReplica].ReplicaDescriptor

--- a/pkg/kv/send_test.go
+++ b/pkg/kv/send_test.go
@@ -108,6 +108,12 @@ func (f *firstNErrorTransport) SendNext(
 	return &roachpb.BatchResponse{}, err
 }
 
+func (f *firstNErrorTransport) NextInternalClient(
+	ctx context.Context,
+) (context.Context, roachpb.InternalClient, error) {
+	panic("unimplemented")
+}
+
 func (f *firstNErrorTransport) NextReplica() roachpb.ReplicaDescriptor {
 	return roachpb.ReplicaDescriptor{}
 }

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -17,6 +17,7 @@ package rpc
 import (
 	"context"
 	"fmt"
+	"io"
 	"math"
 	"net"
 	"sync"
@@ -30,6 +31,7 @@ import (
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -373,10 +375,79 @@ func (a internalClientAdapter) Batch(
 	return a.InternalServer.Batch(ctx, ba)
 }
 
+type rangeFeedClientAdapter struct {
+	ctx    context.Context
+	eventC chan *roachpb.RangeFeedEvent
+	errC   chan error
+}
+
+// roachpb.Internal_RangeFeedServer methods.
+func (a rangeFeedClientAdapter) Recv() (*roachpb.RangeFeedEvent, error) {
+	// Prioritize eventC. Both channels are buffered and the only guarantee we
+	// have is that once an error is sent on errC no other events will be sent
+	// on eventC again.
+	select {
+	case e := <-a.eventC:
+		return e, nil
+	case err := <-a.errC:
+		select {
+		case e := <-a.eventC:
+			a.errC <- err
+			return e, nil
+		default:
+			return nil, err
+		}
+	}
+}
+
+// roachpb.Internal_RangeFeedServer methods.
+func (a rangeFeedClientAdapter) Send(e *roachpb.RangeFeedEvent) error {
+	select {
+	case a.eventC <- e:
+		return nil
+	case <-a.ctx.Done():
+		return a.ctx.Err()
+	}
+}
+
+// grpc.ClientStream methods.
+func (rangeFeedClientAdapter) Header() (metadata.MD, error) { panic("unimplemented") }
+func (rangeFeedClientAdapter) Trailer() metadata.MD         { panic("unimplemented") }
+func (rangeFeedClientAdapter) CloseSend() error             { panic("unimplemented") }
+
+// grpc.ServerStream methods.
+func (rangeFeedClientAdapter) SetHeader(metadata.MD) error  { panic("unimplemented") }
+func (rangeFeedClientAdapter) SendHeader(metadata.MD) error { panic("unimplemented") }
+func (rangeFeedClientAdapter) SetTrailer(metadata.MD)       { panic("unimplemented") }
+
+// grpc.Stream methods.
+func (a rangeFeedClientAdapter) Context() context.Context  { return a.ctx }
+func (rangeFeedClientAdapter) SendMsg(m interface{}) error { panic("unimplemented") }
+func (rangeFeedClientAdapter) RecvMsg(m interface{}) error { panic("unimplemented") }
+
+var _ roachpb.Internal_RangeFeedClient = rangeFeedClientAdapter{}
+var _ roachpb.Internal_RangeFeedServer = rangeFeedClientAdapter{}
+
 func (a internalClientAdapter) RangeFeed(
 	ctx context.Context, args *roachpb.RangeFeedRequest, _ ...grpc.CallOption,
 ) (roachpb.Internal_RangeFeedClient, error) {
-	panic("unimplemented")
+	ctx, cancel := context.WithCancel(ctx)
+	rfAdapter := rangeFeedClientAdapter{
+		ctx:    ctx,
+		eventC: make(chan *roachpb.RangeFeedEvent, 128),
+		errC:   make(chan error, 1),
+	}
+
+	go func() {
+		defer cancel()
+		err := a.InternalServer.RangeFeed(args, rfAdapter)
+		if err == nil {
+			err = io.EOF
+		}
+		rfAdapter.errC <- err
+	}()
+
+	return rfAdapter, nil
 }
 
 var _ roachpb.InternalClient = internalClientAdapter{}

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -522,6 +522,12 @@ func (t *multiTestContextKVTransport) SendNext(
 	return br, nil
 }
 
+func (t *multiTestContextKVTransport) NextInternalClient(
+	ctx context.Context,
+) (context.Context, roachpb.InternalClient, error) {
+	panic("unimplemented")
+}
+
 func (t *multiTestContextKVTransport) NextReplica() roachpb.ReplicaDescriptor {
 	if t.IsExhausted() {
 		return roachpb.ReplicaDescriptor{}

--- a/pkg/storage/rangefeed/registry.go
+++ b/pkg/storage/rangefeed/registry.go
@@ -31,8 +31,6 @@ type Stream interface {
 	// Context returns the context for this stream.
 	Context() context.Context
 	// Send blocks until it sends m, the stream is done, or the stream breaks.
-	// The provided RangeFeedEvent is not guaranteed to be safe for use after
-	// Send returns, so a copy should be made before returning if necessary.
 	// Send must be safe to call on the same stream in different goroutines.
 	Send(*roachpb.RangeFeedEvent) error
 }

--- a/pkg/storage/rangefeed/registry_test.go
+++ b/pkg/storage/rangefeed/registry_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
@@ -68,21 +67,7 @@ func (s *testStream) Send(e *roachpb.RangeFeedEvent) error {
 	if s.mu.sendErr != nil {
 		return s.mu.sendErr
 	}
-	// Send's contract does not promise that its provided events are safe for
-	// use after it has returned. To work around this, make a clone.
-	var eClone roachpb.RangeFeedEvent
-	{
-		b, err := protoutil.Marshal(e)
-		if err != nil {
-			panic(err)
-		}
-		err = protoutil.Unmarshal(b, &eClone)
-		if err != nil {
-			panic(err)
-		}
-	}
-
-	s.mu.events = append(s.mu.events, &eClone)
+	s.mu.events = append(s.mu.events, e)
 	return nil
 }
 

--- a/pkg/storage/rangefeed/task_test.go
+++ b/pkg/storage/rangefeed/task_test.go
@@ -71,10 +71,6 @@ type testIterator struct {
 	kvs []engine.MVCCKeyValue
 	cur int
 
-	// Simulate unsafe buffers.
-	unsafeKeyBuf []byte
-	unsafeValBuf []byte
-
 	closed bool
 	err    error
 	block  chan struct{}
@@ -152,28 +148,15 @@ func (s *testIterator) NextKey() {
 }
 
 func (s *testIterator) UnsafeKey() engine.MVCCKey {
-	curKey := s.curKV().Key
-	curKey.Key = copyToUnsafeBuf(&s.unsafeKeyBuf, curKey.Key)
-	return curKey
+	return s.curKV().Key
 }
 
 func (s *testIterator) UnsafeValue() []byte {
-	curVal := s.curKV().Value
-	return copyToUnsafeBuf(&s.unsafeValBuf, curVal)
+	return s.curKV().Value
 }
 
 func (s *testIterator) curKV() engine.MVCCKeyValue {
 	return s.kvs[s.cur]
-}
-
-func copyToUnsafeBuf(buf *[]byte, src []byte) []byte {
-	if cap(*buf) < len(src) {
-		*buf = append([]byte(nil), src...)
-	} else {
-		*buf = (*buf)[:len(src)]
-		copy(*buf, src)
-	}
-	return *buf
 }
 
 func TestInitResolvedTSScan(t *testing.T) {


### PR DESCRIPTION
This change adds a RangeFeed method to DistSender and teaches it how
to split rangefeeds across ranges and how to manage their individual
lifecycle events. It then adjusts the changefeed poller to use RangeFeed
requests when the corresponding cluster setting is enabled.