### PR TITLE
opt: Tighten up ExprView and its usage

### DIFF
--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -679,7 +679,7 @@ func (c *indexConstraintCtx) makeSpansForAnd(
 	// a map could help here.
 	c.makeSpansForExpr(offset, ev.Child(0), out)
 	var exprConstraint constraint.Constraint
-	for i := 1; i < ev.ChildCount(); i++ {
+	for i, n := 1, ev.ChildCount(); i < n; i++ {
 		c.makeSpansForExpr(offset, ev.Child(i), &exprConstraint)
 		out.IntersectWith(c.evalCtx, &exprConstraint)
 	}
@@ -716,7 +716,7 @@ func (c *indexConstraintCtx) makeSpansForAnd(
 		}
 
 		c.makeSpansForExpr(offset+delta, ev.Child(0), &ofsC)
-		for j := 1; j < ev.ChildCount(); j++ {
+		for j, n := 1, ev.ChildCount(); j < n; j++ {
 			c.makeSpansForExpr(offset+delta, ev.Child(j), &exprConstraint)
 			ofsC.IntersectWith(c.evalCtx, &exprConstraint)
 		}

--- a/pkg/sql/opt/memo/constraint_builder.go
+++ b/pkg/sql/opt/memo/constraint_builder.go
@@ -410,7 +410,7 @@ func (cb *constraintsBuilder) buildConstraints(ev ExprView) (_ *constraint.Set, 
 		// (e.g. when using optsteps).
 		if ev.ChildCount() > 0 {
 			c, tight := cb.getConstraints(ev.Child(0))
-			for i := 1; i < ev.ChildCount(); i++ {
+			for i, n := 1, ev.ChildCount(); i < n; i++ {
 				ci, tighti := cb.getConstraints(ev.Child(i))
 				c = c.Intersect(cb.evalCtx, ci)
 				tight = tight && tighti

--- a/pkg/sql/opt/memo/expr_view_format.go
+++ b/pkg/sql/opt/memo/expr_view_format.go
@@ -286,7 +286,7 @@ func (ev ExprView) formatRelational(f *ExprFmtCtx, tp treeprinter.Node) {
 		}
 	}
 
-	for i := 0; i < ev.ChildCount(); i++ {
+	for i, n := 0, ev.ChildCount(); i < n; i++ {
 		ev.Child(i).format(f, tp)
 	}
 }
@@ -310,7 +310,7 @@ func (ev ExprView) formatScalar(f *ExprFmtCtx, tp treeprinter.Node) {
 		ev.FormatScalarProps(f)
 		tp = tp.Child(f.Buffer.String())
 	}
-	for i := 0; i < ev.ChildCount(); i++ {
+	for i, n := 0, ev.ChildCount(); i < n; i++ {
 		child := ev.Child(i)
 		child.format(f, tp)
 	}

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -113,7 +113,7 @@ func (b *logicalPropsBuilder) buildRelationalProps(ev ExprView) props.Logical {
 	}
 
 	// If CanHaveSideEffects is true for any child, it's true for the expression.
-	for i, end := 0, ev.ChildCount(); i < end; i++ {
+	for i, n := 0, ev.ChildCount(); i < n; i++ {
 		if ev.childGroup(i).logical.CanHaveSideEffects() {
 			logical.Relational.CanHaveSideEffects = true
 			break
@@ -301,7 +301,7 @@ func (b *logicalPropsBuilder) buildProjectProps(ev ExprView) props.Logical {
 
 	// Also add any column that projects a constant value, since the optimizer
 	// sometimes constructs these in order to guarantee a not-null column.
-	for i := 0; i < projections.ChildCount(); i++ {
+	for i, n := 0, projections.ChildCount(); i < n; i++ {
 		child := projections.Child(i)
 		if child.IsConstValue() {
 			if ExtractConstDatum(child) != tree.DNull {
@@ -713,7 +713,7 @@ func (b *logicalPropsBuilder) buildValuesProps(ev ExprView) props.Logical {
 	// Outer Columns
 	// -------------
 	// Union outer columns from all row expressions.
-	for i := 0; i < ev.ChildCount(); i++ {
+	for i, n := 0, ev.ChildCount(); i < n; i++ {
 		relational.OuterCols.UnionWith(ev.childGroup(i).logical.Scalar.OuterCols)
 	}
 
@@ -1026,7 +1026,7 @@ func (b *logicalPropsBuilder) buildZipProps(ev ExprView) props.Logical {
 	// Outer Columns
 	// -------------
 	// Union outer columns from all input expressions.
-	for i := 0; i < ev.ChildCount(); i++ {
+	for i, n := 0, ev.ChildCount(); i < n; i++ {
 		relational.OuterCols.UnionWith(ev.childGroup(i).logical.OuterCols())
 	}
 
@@ -1061,7 +1061,7 @@ func (b *logicalPropsBuilder) buildScalarProps(ev ExprView) props.Logical {
 
 	// By default, derive OuterCols and CanHaveSideEffects from all children, both
 	// relational and scalar.
-	for i, end := 0, ev.ChildCount(); i < end; i++ {
+	for i, n := 0, ev.ChildCount(); i < n; i++ {
 		childLogical := &ev.childGroup(i).logical
 
 		scalar.OuterCols.UnionWith(childLogical.OuterCols())
@@ -1097,7 +1097,7 @@ func (b *logicalPropsBuilder) buildScalarProps(ev ExprView) props.Logical {
 		}
 
 		// Check for filter conjuncts of the form: x = y.
-		for i := 0; i < ev.ChildCount(); i++ {
+		for i, n := 0, ev.ChildCount(); i < n; i++ {
 			child := ev.Child(i)
 			if child.Operator() == opt.EqOp {
 				left := child.Child(0)

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -1002,9 +1002,9 @@ func (sb *statisticsBuilder) colStatValues(colSet opt.ColSet, ev ExprView) *prop
 	// map to find the exact count of distinct values for the columns in colSet.
 	distinct := make(map[string]struct{}, ev.Child(0).ChildCount())
 	groups := make([]GroupID, 0, colSet.Len())
-	for i := 0; i < ev.ChildCount(); i++ {
+	for i, in := 0, ev.ChildCount(); i < in; i++ {
 		groups = groups[:0]
-		for j := 0; j < ev.Child(i).ChildCount(); j++ {
+		for j, jn := 0, ev.Child(i).ChildCount(); j < jn; j++ {
 			if colSet.Contains(int(colList[j])) {
 				groups = append(groups, ev.Child(i).ChildGroup(j))
 			}
@@ -1173,7 +1173,7 @@ func (sb *statisticsBuilder) buildZip(ev ExprView, relProps *props.Relational) {
 
 	// The row count of a zip operation is equal to the maximum row count of its
 	// children.
-	for i := 0; i < ev.ChildCount(); i++ {
+	for i, n := 0, ev.ChildCount(); i < n; i++ {
 		child := ev.Child(i)
 		if child.Operator() == opt.FunctionOp {
 			def := child.Private().(*FuncOpDef)
@@ -1417,7 +1417,7 @@ func (sb *statisticsBuilder) applyFilter(
 		// conjunct.
 		applyConjunct(filter, constraintSet, tight)
 	} else {
-		for i := 0; i < filter.ChildCount(); i++ {
+		for i, n := 0, filter.ChildCount(); i < n; i++ {
 			child := filter.Child(i)
 			constraintSet = child.Logical().Scalar.Constraints
 			tight = child.Logical().Scalar.TightConstraints

--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -86,7 +86,7 @@ func FindAggregateOverload(ev ExprView) (name string, overload *tree.Overload) {
 	for o := range overloads {
 		overload = &overloads[o]
 		matches := true
-		for i := 0; i < ev.ChildCount(); i++ {
+		for i, n := 0, ev.ChildCount(); i < n; i++ {
 			typ := ev.Child(i).Logical().Scalar.Type
 			if !overload.Types.MatchAt(typ, i) {
 				matches = false
@@ -247,7 +247,7 @@ func typeAsAny(_ ExprView) types.T {
 // typeCoalesce returns the type of a coalesce expression, which is equal to
 // the type of its first non-null child.
 func typeCoalesce(ev ExprView) types.T {
-	for i := 0; i < ev.ChildCount(); i++ {
+	for i, n := 0, ev.ChildCount(); i < n; i++ {
 		childType := ev.Child(i).Logical().Scalar.Type
 		if childType != types.Unknown {
 			return childType
@@ -267,7 +267,7 @@ func typeCoalesce(ev ExprView) types.T {
 // the type of the ELSE <expr> value if all the previous types are unknown.
 func typeCase(ev ExprView) types.T {
 	// Skip over the first child since that corresponds to the input <cond>.
-	for i := 1; i < ev.ChildCount(); i++ {
+	for i, n := 1, ev.ChildCount(); i < n; i++ {
 		childType := ev.Child(i).Logical().Scalar.Type
 		if childType != types.Unknown {
 			return childType

--- a/pkg/sql/opt/norm/check_expr.go
+++ b/pkg/sql/opt/norm/check_expr.go
@@ -68,7 +68,7 @@ func (f *Factory) checkExpr(ev memo.ExprView) {
 	case opt.DistinctOnOp:
 		// Aggregates can be only FirstAgg or ConstAgg.
 		agg := ev.Child(1)
-		for i := 0; i < agg.ChildCount(); i++ {
+		for i, n := 0, agg.ChildCount(); i < n; i++ {
 			if childOp := agg.Child(i).Operator(); childOp != opt.FirstAggOp && childOp != opt.ConstAggOp {
 				panic(fmt.Sprintf("distinct-on contains %s", childOp))
 			}
@@ -77,7 +77,7 @@ func (f *Factory) checkExpr(ev memo.ExprView) {
 	case opt.GroupByOp, opt.ScalarGroupByOp:
 		// Aggregates cannot be FirstAgg.
 		agg := ev.Child(1)
-		for i := 0; i < agg.ChildCount(); i++ {
+		for i, n := 0, agg.ChildCount(); i < n; i++ {
 			if childOp := agg.Child(i).Operator(); childOp == opt.FirstAggOp {
 				panic(fmt.Sprintf("group-by contains %s", childOp))
 			}

--- a/pkg/sql/opt/norm/decorrelate.go
+++ b/pkg/sql/opt/norm/decorrelate.go
@@ -47,7 +47,7 @@ func (c *CustomFuncs) HasHoistableSubquery(group memo.GroupID) bool {
 	// effects. These can only be executed if the branch test evaluates to true,
 	// and so it's not possible to hoist out subqueries, since they would then be
 	// evaluated when they shouldn't be.
-	for i, end := 0, ev.ChildCount(); i < end; i++ {
+	for i, n := 0, ev.ChildCount(); i < n; i++ {
 		child := ev.Child(i)
 		if c.HasHoistableSubquery(child.Group()) {
 			scalar.Rule.HasHoistableSubquery = true

--- a/pkg/sql/opt/norm/reject_nulls.go
+++ b/pkg/sql/opt/norm/reject_nulls.go
@@ -124,7 +124,7 @@ func deriveGroupByRejectNullCols(ev memo.ExprView) opt.ColSet {
 
 	var rejectNullCols opt.ColSet
 	var savedInColID opt.ColumnID
-	for i, end := 0, aggs.ChildCount(); i < end; i++ {
+	for i, n := 0, aggs.ChildCount(); i < n; i++ {
 		agg := aggs.Child(i)
 		aggOp := agg.Operator()
 

--- a/pkg/sql/opt/testutils/format.go
+++ b/pkg/sql/opt/testutils/format.go
@@ -72,7 +72,7 @@ func onlyScalars(ev memo.ExprView) bool {
 	if !ev.IsScalar() {
 		return false
 	}
-	for i := 0; i < ev.ChildCount(); i++ {
+	for i, n := 0, ev.ChildCount(); i < n; i++ {
 		if !onlyScalars(ev.Child(i)) {
 			return false
 		}

--- a/pkg/sql/opt/testutils/opt_tester.go
+++ b/pkg/sql/opt/testutils/opt_tester.go
@@ -283,7 +283,7 @@ func fillInLazyProps(ev memo.ExprView) {
 		xform.DeriveInterestingOrderings(ev)
 	}
 
-	for i := 0; i < ev.ChildCount(); i++ {
+	for i, n := 0, ev.ChildCount(); i < n; i++ {
 		fillInLazyProps(ev.Child(i))
 	}
 }

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -524,7 +524,7 @@ func harvestEqualityColumns(
 	if on.Operator() != opt.FiltersOp {
 		return nil, nil
 	}
-	for i := 0; i < on.ChildCount(); i++ {
+	for i, n := 0, on.ChildCount(); i < n; i++ {
 		e := on.Child(i)
 		ok, left, right := isJoinEquality(leftCols, rightCols, e)
 		if !ok {


### PR DESCRIPTION
1. When iterating over ExprView children, always use this pattern:

     for i, n := 1, ev.ChildCount(); i < n; i++ {

   It's important to cache ChildCount rather than recompute it each
   time through the loop.

2. Update MakeNormExprView to inline code from MakeExprView.

3. Update Child to inline code from ChildGroup.

Release note: None