### PR TITLE
distsql: disable EXPLAIN ANALYZE (DISTSQL) when distsql=off

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -1,4 +1,4 @@
-# LogicTest: local local-opt local-parallel-stmts fakedist fakedist-opt fakedist-metadata
+# LogicTest: 5node-dist
 
 # Regression tests for weird explain analyze cases.
 
@@ -35,3 +35,64 @@ EXPLAIN ANALYZE (DISTSQL) DELETE FROM a
 
 statement ok
 EXPLAIN ANALYZE (DISTSQL) DROP TABLE a
+
+# Create some dummy data for more EXPLAIN ANALYZE checks.
+statement ok
+CREATE TABLE kv (k INT PRIMARY KEY, v INT)
+
+statement ok
+INSERT INTO kv SELECT i, i FROM generate_series(1,5) AS g(i);
+
+statement ok
+CREATE TABLE kw (k INT PRIMARY KEY, w INT)
+
+statement ok
+INSERT INTO kw SELECT i, i FROM generate_series(1,5) AS g(i)
+
+# Split into 5 parts, each row from each table goes to one node.
+statement ok
+ALTER TABLE kv SPLIT AT SELECT i FROM generate_series(1,5) AS g(i)
+
+statement ok
+ALTER TABLE kw SPLIT AT SELECT i FROM generate_series(1,5) AS g(i)
+
+statement ok
+ALTER TABLE kv EXPERIMENTAL_RELOCATE SELECT ARRAY[i], i FROM generate_series(1, 5) as g(i)
+
+statement ok
+ALTER TABLE kw EXPERIMENTAL_RELOCATE SELECT ARRAY[i], i FROM generate_series(1, 5) as g(i)
+
+# Verify that EXPLAIN ANALYZE (DISTSQL) annotates plans with collected
+# statistics.
+
+# This query verifies stat collection for the tableReader, mergeJoiner, and
+# aggregator.
+query T
+SELECT url FROM [EXPLAIN ANALYZE (DISTSQL) SELECT kv.k, avg(kw.k) FROM kv JOIN kw ON kv.k=kw.k GROUP BY kv.k]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzcWMFu4zYUvPcrhHdKsSwsUrLjCCjgbU9pN3aRTQ5FYQRKxDrC2pZByd0NFvn3QpLb2FLCJ9o0yfgmy6LecPg4Gs53WGYJH8cLnkP0F1AgwIBAAARCINCHKYGVyB54nmeifKQecJl8g8gnkC5X66K8PSXwkAkO0Xco0mLOIYKb-H7Or3mccNHzgUDCizidV2VWIl3E4mn05R8gILKvuSd4nEReWT4v4vncK9IFjzw_BwKTdRF5IwrTZwLZutgUfKlz_-Q9xvnjboXq-Wn1thmHiD6T_YAP3gD-1RBw9ibwl_dkIuGCJ833fCgLd3rqFQ6uuJjx37J0yUWPNlZvzv8uzkb0w48_i3T2WF8CqW57DU6qey1iqmHNR-ubrWcX8TdvwReZePLWOU8ij_ne7-kvL_SSEWsw_MJeoLLsH2czwWdxkYke7bcWhcCkJrBaUgIfx3_ejSc3d-PbT5_ORrQk4PPt1dmIlVe_Tm7HN5trrEtaE6T1BA_pmvCwrpGTw_zDyPl8e3V3WdITHEIPgWu-TLioWsAbsd4oeLMN-h3oWC9fI-RVLsbZT9mqx_qNJ1-vPdipTbsrD3VKMhWAnzslmdSOZNK9JNPvLpm-gmT63l56iaz5tl4OjqKXfidBKGenTyyV-wURS3oksezOzf5KybpveuaUWikAHzqlVsyOWrETUCtkzbfV6vxk1Eq5XxC1Yu9YrYLumz5wSq0UgF84pVaBHbUK9lKrsLtahUaOo8iybwvW8CiCFdo5jip3DaJZwZE0S4me_WUr7L77Q6dkSwF43ynZCu3IVngCJgtZ823NujgZk6XcL4hghe_YZCEZ6jXPV9ky552iMb8kiiczXhObZ2vxwP8Q2UNVpv45qcZVx_KE50X9L6t_XC7_-ysv4urdGzaydcE3fLSnv7mZpPmX_29VW7x7_aHu-gTunwqeezlfFnvgoYFrgDoyRE0BYuYZogotzI7QwvL6Q931D-Sj0cIOAOrIkMYWRjrGPEOsCcjfBrSLx28ODqSzCXULRAu8vD71jQsCAqjvGCDmGkPMPEOhdAM08DQH96WD2WB3-xzhCzAwa6JQNuV4tJsqxfoWTBQCyLyJQjrGPEPnZk3UgXi0myrF-hZMFALIvIlCOsY8Q0PpZ-BCbqIudJgojZOR49FvqlQBmLcIckAWTBQCyDxDtHU0l7moLUDYe1VO2EYmqnLkdgCQfsejjMC8xcG6xkJQ1DpmWzY5CCAL0ZEckH7bo4zAQliEdI2FPK11fN_ReRrKrQ5tHbYtex0EkIUECUOk_duuisCC3cEQWfA78uBnf7_jWp6DALLgd5xLeDBE2v2PctdY4MS1UAcBZMHvOBfzYIi0-x_lrrHAiTzZoUi0Q13LdhBANvyOc2kPgqir_wkP2AfO5TvsSPkO05LvaDxyIYDM-x0EkAW_gyFyjiP9_qeNQEu-o7OPXct3EEAW_A6GyDmO9PufNgJ5vsOQfIe5lu8ggCz4HQyRhW-7c3kPhuj4GRjTle9Mn3_4NwAA__-RmWFi
+
+# This query verifies stats collection for the hashJoiner, distinct and sorter.
+query T
+SELECT url FROM [EXPLAIN ANALYZE (DISTSQL) SELECT DISTINCT(kw.w) FROM kv JOIN kw ON kv.k = kw.w ORDER BY kw.w]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzkWNGK4zYUfe9XmPvUUsFYsp3JGArD0oduC52y7VvJgydWJ2YTO0hKd8My_77ESfDGTnSlRCML9m1i-_oeXR-dozNfoG5K_mex4hLyf4ECAQYEEiCQAoEMZgTWoplzKRuxe2Rf8L78DHlMoKrXG7W7PCMwbwSH_AuoSi055PBP8bzkH3hRcnEXA4GSq6Jatm3WoloVYvv48X8gIJpPMhK8KPNo116qYrmMVLXieRRLIPC0UXn0SGH2SqDZqEPDrs_zNloUcnHaoX1-1r7thUNOX8l1wCcXgH8yBs5uAs4uAu_es6kbUXLBy5M3zXaV2CNnVv9bIRe_N1XNxR3tfbYl_0_9-Eh_-kVUL4v2LyDtxag3ivbaYB5tVf_R_cXBs1I1gpeRrEqeR-0zQGBVfI5WfNWIbbSRvMwjFkd_VO8Od8pKfjxcj6N3F-ffzTaxIcXfjVC7kWT9z_WzARMGwKkG-CW4qQ3cXyupqnqu7lg84BeBpz0Z2m11BXodysyAsOe42E7yLCG7pQxmr1tKdvNSJidLoeaiQYNSOwvg90GpHfWsdvQKtYvN1S42VLvd6y5R1YnSIYQ4Kt0EUbrYeIPdIHMI1k4bqI02mEM3kzlmvsVYUNpgAXwalDYwz9rAvhNtQAhx1Ib7ELQBwdppAxtTGxLzLZYEpQ0WwB-C0obEszYkV2hDaq4NaUgpCSHFUR-miD6knlISAreTiMRGIszQm0tEar7T0qAkwgJ4FpREpJ4lIv1Ojg8IIY7y8BDC8QHB2mlDOubxAfk_zwcu100teZ-xZ98c72jKyxe-p71sNmLO_xLNvG2z__nU1rXBq-RS7e-y_Y_39fGWVEX77sPKm43ih7UPl3rmG0G7p8z7T133J_C8VVxGktfqCjw0CQ2Q4YSoL0DM_4SoBYXZG1BY33_quv-N8-hROABAhhNySGGEMf4nxPqA4m8BneKJ-8WJtjjVF6fa4ux0M_eLM20xm5y2foOtN_HrXuh31ONx7maW_UdwLwSQf_dCGON_Qvd-3etGPM7dzLL_CO6FAPLvXghj_E9oqrWBB70BPWiLaayvpoPTqM6_vpkFdkKwOVR6OeTanDIDAOTea6wR-DcXjDUjZKPByXJke0EAjZCW9IDcG441ghHyEcKaESKkPuRQJOVQfcyhGVKuDzrXu0xo-QUBNILLBJdoMETOXceaNSPMJLQQgwAawWWCizUYIueuY82aEWaiTzIUiTJUn2UYkmXYG2UZ5iTLODxeIID8uwwCaASXwRAFNyP3rjNE4CTLuORxaFkGATSCy2CIgpuRe9cZItBnGYZkGabPMgzJMsxVlpm9_vA1AAD__9fTnRg=
+
+# Verify that EXPLAIN ANALYZE on an unsupported query doesn't return an error.
+statement ok
+EXPLAIN ANALYZE (DISTSQL) SHOW QUERIES;
+
+statement ok
+EXPLAIN ANALYZE (DISTSQL) EXPLAIN SELECT 1
+
+# This query verifies support for zeroNode in DistSQL.
+query B
+SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT sum(k) FROM kv WHERE FALSE]
+----
+true
+
+# This query verifies stat collection for the tableReader and windower.
+query T
+SELECT url FROM [EXPLAIN ANALYZE (DISTSQL) SELECT avg(k) OVER () FROM kv]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzEkz3L2zAUhff-CnGmFgSx_NFBU9qlhEJTQmmH4kGxLsHUtowkNwnB_71YHlIHp7jwJu-oj3POcy-cCxqj6YuqyUH-hABHDI4EHCk4MuQcrTUFOWfs8GUUbPQJMuIom7bzw3XOURhLkBf40lcEiW9qX9GOlCa7isChyauyCjGtLWtlz-tfv8FhzdExS0pLNsQ7r6qK-bImySIHjm3nJVsL5D2H6fw10Hl1IEjR8ztQV5auMVaTJT3hyPsZ7B9lo82R7CqbMn_4_untWrybAmdzwLU6sZpqY8-sc6QlSyP2ufx4d4B4MoBYvlXxtK3Gy6Hip0Ely6GSp0Gly6HSVynFDNSOXGsaRzflmHeOhtKQPtDYMGc6W9BXa4oQMx63QRcuNDk_vorxsGnCUwD8Wyz-KX4_EUe34vh_ksMoYSrsz54cc9R4yaJhmVPb5DG26WNssxeyzfs3fwIAAP__Jb_6rw==

--- a/pkg/sql/logictest/testdata/planner_test/distsql_auto_mode
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_auto_mode
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: fakedist
 
 #
 # Tests that verify DistSQL support and auto mode determination.
@@ -128,44 +128,3 @@ query BT
 EXPLAIN (DISTSQL) SELECT 246::REGTYPE FROM abc
 ----
 false  https://cockroachdb.github.io/distsqlplan/decode.html#eJyMjzFLBDEQhXt_hbw64K6IxVQ2h1yjx3KNSIpc8jgW9pJlkgXlyH-X3RRiIVz53pv53swVMQW-uQsz5BM9rMGsyTPnpKvVBvbhC9IZjHFeympbA5-UkCvKWCZCcHSniQNdoD50MAgsbpw27Kzjxen3izt5GAyMgSr3j0_PIjLsXo8fhx1sNUhL-eXn4s6E9NXcfsPAPKeY-af-P3JXrQHDme3PnBb1PGjyW02T79veZgTm0tK-iX1sUbX17icAAP__JLhsAQ==
-
-# Verify that EXPLAIN ANALYZE (DISTSQL) annotates plans with collected
-# statistics.
-
-statement ok
-INSERT INTO kv VALUES (1,1);
-
-statement ok
-INSERT INTO kw VALUES (1,1);
-
-# This query verifies stat collection for the tableReader, mergeJoiner, and
-# aggregator.
-query T
-SELECT url FROM [EXPLAIN ANALYZE (DISTSQL) SELECT kv.k, avg(kw.k) FROM kv JOIN kw ON kv.k=kw.k GROUP BY kv.k]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html#eJysk0Fv1DAQhe_8CmtOW2FpY29PlpCyXFChbFBVkBCKKhMPwSKJo7FDW1X731Hsw5Jss7CIW_w8n_3ejPMEnTO40y16UF9AQMmhJ1eh945GKRVcmQdQGQfb9UMY5ZJD5QhBPUGwoUFQcKu_NniD2iCtM-BgMGjbxGN7sq2mx_zHT-BA7t4zQm0UE8DBB900LNgWFcs8cCiGoFguoNxzcEM4XOiDrhGU2PN_MyUWTN3_B1Ny0dTBy9A5MkhoJj7KkfxTyTPJ3iPV-NbZDmktp8ka_BZWuXh58Yps_T19Ao8ymwWN2lHaiM1Lk3hU2-oH1mLr6JENHo1iMmPv7OtDz3guF9u2OWeW27omrHVwtN5MA-ejvyJ1Lo6Jw3b3-W5X3N7tPl5fr3Ix5t9-erPK5cVfTPsok0iZlmJcnhPjBn3vOo_zV_Dsydk4ejQ1pqfk3UAVfiBXxWvSsohcFAz6kHZlWlx1cSv-M7_D4gxYzmF5Et5M4GwOb07ClzO43L_4FQAA__-EfYCR
-
-# This query verifies stats collection for the hashJoiner, distinct and sorter.
-query T
-SELECT url FROM [EXPLAIN ANALYZE (DISTSQL) SELECT DISTINCT(kw.w) FROM kv JOIN kw ON kv.k = kw.w ORDER BY kw.w]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html#eJyck8FunDAQhu99CmtOrWppMZCLpUoo6qFppaZKe6s4uHi6sQIYzZgmUbTvXmEipbCBLnuD3_PBN_b4CVpv8atpkEH_BAWlhI58hcyehmgsuLIPoBMJru36MMSlhMoTgn6C4EKNoOGH-VXjDRqLtEtAgsVgXB0_25FrDD0Wd39AAvl7FoTGaqFAAgdT1yK4BrVIGCRc90GLQkF5kOD78PJDDmaPoNVBnielFqTuT5ZKF6XSRakXl771ZJHQTjzKgfxfySudfTJ8-9m7FmmXThur8Xd4W6h3H8jtb-MTyBiKWZcxO2o1UvPSMTyq5eAJrWBnUYtYAxIa8yAabDw9ip7RapEm4ou7fF6xju-e80RcnrC12Zbz_u4pIO2y6Y4U6v0JZ3zkrVa8l2zzLbYfHQfXVmGXz32HfRknId6FM-TXJC-2SN4gd75lnE_tq19OhlFFu8dx9Nn3VOE38lX8zfh6HbkYWOQwrqbjy1Ubl-Id_xdWG-B0DqercDaBkzmcrcL5OpyvwhczuDy8-RsAAP__mE7PKQ==
-
-# Verify that EXPLAIN ANALYZE on an unsupported query doesn't return an error.
-statement ok
-EXPLAIN ANALYZE (DISTSQL) SHOW QUERIES;
-
-statement ok
-EXPLAIN ANALYZE (DISTSQL) EXPLAIN SELECT 1
-
-# This query verifies support for zeroNode in DistSQL.
-query B
-SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT sum(k) FROM kv WHERE FALSE]
-----
-true
-
-# This query verifies stat collection for the tableReader and windower.
-query T
-SELECT url FROM [EXPLAIN ANALYZE (DISTSQL) SELECT avg(k) OVER () FROM kv]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkUFLMzEQhu_frwjv6RMC3RRPOVUvUgQrRfQge4iboQQ3m2Uma1vK_nfp5qAVKvU47-SZ94Ec0CVPDy6SwL7CoNboOTUkkvgYlQdLv4OtNELXD_kY1xpNYoI9IIfcEiye3FtLa3KeeFZBw1N2oZ3O9hyi4_3i_QManLaimJy3ykBDsmtblUMkqyqBxmrIVi0M6lEjDfmrULLbEKwZ9eVSL6HzaUs8M6dGN893_xfm6gKd6HYqUky8V4OQt-q6Uvfh9qze_C96a5I-dUIncucuV2OtQX5D5V8kDdzQI6dmqinjauKmwJPksjVlWHZldRT8Dptf4fkPuB7_fQYAAP__QWu4Ow==


### PR DESCRIPTION
This makes sense since queries should not be executed through distsql if
distsql=off.

Release note: None