### PR TITLE
release-2.1: changefeedccl,roachtest: more changefeed introspection for debugging

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -464,6 +464,12 @@ func TestChangefeedMonitoring(t *testing.T) {
 	if c := s.MustGetSQLCounter(`changefeed.emitted_bytes`); c != 0 {
 		t.Errorf(`expected 0 got %d`, c)
 	}
+	if c := s.MustGetSQLCounter(`changefeed.emit_nanos`); c != 0 {
+		t.Errorf(`expected 0 got %d`, c)
+	}
+	if c := s.MustGetSQLCounter(`changefeed.flushes`); c != 0 {
+		t.Errorf(`expected 0 got %d`, c)
+	}
 	if c := s.MustGetSQLCounter(`changefeed.flush_nanos`); c != 0 {
 		t.Errorf(`expected 0 got %d`, c)
 	}
@@ -481,6 +487,12 @@ func TestChangefeedMonitoring(t *testing.T) {
 		if c := s.MustGetSQLCounter(`changefeed.emitted_bytes`); c != 11 {
 			return errors.Errorf(`expected 11 got %d`, c)
 		}
+		if c := s.MustGetSQLCounter(`changefeed.emit_nanos`); c <= 0 {
+			return errors.Errorf(`expected > 0 got %d`, c)
+		}
+		if c := s.MustGetSQLCounter(`changefeed.flushes`); c <= 0 {
+			return errors.Errorf(`expected > 0 got %d`, c)
+		}
 		if c := s.MustGetSQLCounter(`changefeed.flush_nanos`); c <= 0 {
 			return errors.Errorf(`expected > 0 got %d`, c)
 		}
@@ -497,10 +509,10 @@ func TestChangefeedMonitoring(t *testing.T) {
 	fooCopy.Next()
 	testutils.SucceedsSoon(t, func() error {
 		if c := s.MustGetSQLCounter(`changefeed.emitted_messages`); c != 4 {
-			return errors.Errorf(`expected 1 got %d`, c)
+			return errors.Errorf(`expected 4 got %d`, c)
 		}
 		if c := s.MustGetSQLCounter(`changefeed.emitted_bytes`); c != 44 {
-			return errors.Errorf(`expected 11 got %d`, c)
+			return errors.Errorf(`expected 44 got %d`, c)
 		}
 		return nil
 	})

--- a/pkg/ccl/changefeedccl/poller.go
+++ b/pkg/ccl/changefeedccl/poller.go
@@ -233,11 +233,12 @@ func (p *poller) Run(ctx context.Context) error {
 				if req.StartTime == (hlc.Timestamp{}) {
 					req.MVCCFilter = roachpb.MVCCFilter_Latest
 				}
+				startTime := timeutil.Now()
 				res, pErr := client.SendWrappedWith(ctx, sender, header, req)
 				finished := atomic.AddInt64(&atomicFinished, 1)
 				if log.V(2) {
-					log.Infof(ctx, `finished ExportRequest [%s,%s) %d of %d`,
-						span.Key, span.EndKey, finished, len(requests))
+					log.Infof(ctx, `finished ExportRequest [%s,%s) %d of %d took %s`,
+						span.Key, span.EndKey, finished, len(requests), timeutil.Since(startTime))
 				}
 				if pErr != nil {
 					return errors.Wrapf(


### PR DESCRIPTION
Backport 1/1 commits from #28853.

/cc @cockroachdb/release

Closes #28922.

---

Fix up the roachtests to use the high-water timestamp in
crdb_internal.jobs, now that it exists. Also length the roachtest to get
a better sense of how variable the latencies are over a longer period.

Add a couple more metrics (changefeed.emit_nanos and changefeed.flushes)
that are helpful in debugging performance problems with the sink.
Timeseries storage is expensive, is this too many metrics?

Release note (enterprise change): Added additional monitoring metrics
for changefeeds.
