### PR TITLE
backport-2.0: storage: proactively renew expiration-based leases

### DIFF
--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -259,17 +259,28 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease) {
 	// by the previous lease holder.
 	r.mu.Lock()
 	r.mu.state.Lease = &newLease
+	expirationBasedLease := r.requiresExpiringLeaseRLocked()
 	r.mu.Unlock()
 
+	// Gossip the first range whenever its lease is acquired. We check to make
+	// sure the lease is active so that a trailing replica won't process an old
+	// lease request and attempt to gossip the first range.
 	if leaseChangingHands && iAmTheLeaseHolder && r.IsFirstRange() && r.IsLeaseValid(newLease, r.store.Clock().Now()) {
-		// Gossip the first range whenever its lease is acquired. We check to
-		// make sure the lease is active so that a trailing replica won't process
-		// an old lease request and attempt to gossip the first range.
 		r.gossipFirstRange(ctx)
+	}
 
-		// Notify the lease renewer worker that we want it to renew the first
-		// range's expiration-based lease.
-		r.store.expirationBasedLeaseChan <- r
+	// Whenever we first acquire an expiration-based lease, notify the lease
+	// renewer worker that we want it to keep proactively renewing the lease
+	// before it expires.
+	if leaseChangingHands && iAmTheLeaseHolder && expirationBasedLease && r.IsLeaseValid(newLease, r.store.Clock().Now()) {
+		// It's not worth blocking on a full channel here since the worst that can
+		// happen is the lease times out and has to be reacquired when needed, but
+		// log an error since it's pretty unexpected.
+		select {
+		case r.store.expirationBasedLeaseChan <- r:
+		default:
+			log.Warningf(ctx, "unable to kick off proactive lease renewal; channel full")
+		}
 	}
 
 	if leaseChangingHands && !iAmTheLeaseHolder {

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unsafe"
 
 	"github.com/coreos/etcd/raft"
 	"github.com/kr/pretty"
@@ -273,13 +274,10 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease) {
 	// renewer worker that we want it to keep proactively renewing the lease
 	// before it expires.
 	if leaseChangingHands && iAmTheLeaseHolder && expirationBasedLease && r.IsLeaseValid(newLease, r.store.Clock().Now()) {
-		// It's not worth blocking on a full channel here since the worst that can
-		// happen is the lease times out and has to be reacquired when needed, but
-		// log an error since it's pretty unexpected.
+		r.store.renewableLeases.Store(int64(r.RangeID), unsafe.Pointer(r))
 		select {
-		case r.store.expirationBasedLeaseChan <- r:
+		case r.store.renewableLeasesSignal <- struct{}{}:
 		default:
-			log.Warningf(ctx, "unable to kick off proactive lease renewal; channel full")
 		}
 	}
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -406,6 +406,10 @@ type Store struct {
 	// data destruction.
 	snapshotApplySem chan struct{}
 
+	// Channel of newly-acquired expiration-based leases that we want to
+	// proactively renew.
+	expirationBasedLeaseChan chan *Replica
+
 	// draining holds a bool which indicates whether this store is draining. See
 	// SetDraining() for a more detailed explanation of behavior changes.
 	//
@@ -889,6 +893,7 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 	s.metrics.registry.AddMetricStruct(s.compactor.Metrics)
 
 	s.snapshotApplySem = make(chan struct{}, cfg.concurrentSnapshotApplyLimit)
+	s.expirationBasedLeaseChan = make(chan *Replica, 1)
 
 	s.bulkIOWriteLimiter = rate.NewLimiter(rate.Limit(bulkIOWriteLimit.Get(&cfg.Settings.SV)), bulkIOWriteBurst)
 	bulkIOWriteLimit.SetOnChange(&cfg.Settings.SV, func() {
@@ -1373,6 +1378,8 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		log.Event(ctx, "computed initial metrics")
 	}
 
+	s.startLeaseRenewer(ctx)
+
 	// Start the storage engine compactor.
 	if envutil.EnvOrDefaultBool("COCKROACH_ENABLE_COMPACTOR", true) {
 		s.compactor.Start(s.AnnotateCtx(context.Background()), s.stopper)
@@ -1480,6 +1487,61 @@ func (s *Store) startGossip() {
 			}
 		})
 	}
+}
+
+// startLeaseRenewer runs an infinite loop in a goroutine which regularly
+// checks whether the store has any expiration-based leases that should be
+// proactively renewed and attempts to continue renewing them.
+//
+// This reduces user-visible latency when range lookups are needed to serve a
+// request and reduces ping-ponging of r1's lease to different replicas as
+// maybeGossipFirstRange is called on each (e.g.  #24753).
+//
+// NOTE: Currently the only lease that we proactively renew is r1, but this
+// could easily be expanded to renew all the meta2 ranges as well. If we do so,
+// the length of expirationBasedLeaseChan should be increased.
+func (s *Store) startLeaseRenewer(ctx context.Context) {
+	// Start a goroutine that watches and proactively renews certain
+	// expiration-based leases.
+	s.stopper.RunWorker(ctx, func(context.Context) {
+		repls := make(map[*Replica]struct{})
+		timer := timeutil.NewTimer()
+		defer timer.Stop()
+
+		// Determine how frequently to attempt to ensure that we have each lease.
+		// The divisor used here is somewhat arbitrary, but needs to be large
+		// enough to ensure we'll attempt to renew the lease reasonably early
+		// within the RangeLeaseRenewalDuration time window. This means we'll wake
+		// up more often that strictly necessary, but it's more maintainable than
+		// attempting to accurately determine exactly when each iteration of a
+		// lease expires and when we should attempt to renew it as a result.
+		renewalDuration := s.cfg.RangeLeaseActiveDuration() / 5
+		for {
+			for repl := range repls {
+				annotatedCtx := repl.AnnotateCtx(ctx)
+				_, pErr := repl.redirectOnOrAcquireLease(annotatedCtx)
+				if pErr != nil {
+					if _, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); !ok {
+						log.Warningf(annotatedCtx, "failed to proactively renew lease: %s", pErr)
+					}
+					delete(repls, repl)
+					continue
+				}
+			}
+
+			if len(repls) > 0 {
+				timer.Reset(renewalDuration)
+			}
+			select {
+			case repl := <-s.expirationBasedLeaseChan:
+				repls[repl] = struct{}{}
+			case <-timer.C:
+				timer.Read = true
+			case <-s.stopper.ShouldStop():
+				return
+			}
+		}
+	})
 }
 
 // systemGossipUpdate is a callback for gossip updates to

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -406,9 +406,11 @@ type Store struct {
 	// data destruction.
 	snapshotApplySem chan struct{}
 
-	// Channel of newly-acquired expiration-based leases that we want to
-	// proactively renew.
-	expirationBasedLeaseChan chan *Replica
+	// Track newly-acquired expiration-based leases that we want to proactively
+	// renew. An object is sent on the signal whenever a new entry is added to
+	// the map.
+	renewableLeases       syncutil.IntMap // map[roachpb.RangeID]*Replica
+	renewableLeasesSignal chan struct{}
 
 	// draining holds a bool which indicates whether this store is draining. See
 	// SetDraining() for a more detailed explanation of behavior changes.
@@ -894,10 +896,7 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 
 	s.snapshotApplySem = make(chan struct{}, cfg.concurrentSnapshotApplyLimit)
 
-	// The channel size here is arbitrary. We don't want it to fill up, but it
-	// isn't a disaster if it does and it shouldn't unless a huge number of meta2
-	// range leases are acquired at once.
-	s.expirationBasedLeaseChan = make(chan *Replica, 64)
+	s.renewableLeasesSignal = make(chan struct{})
 
 	s.bulkIOWriteLimiter = rate.NewLimiter(rate.Limit(bulkIOWriteLimit.Get(&cfg.Settings.SV)), bulkIOWriteBurst)
 	bulkIOWriteLimit.SetOnChange(&cfg.Settings.SV, func() {
@@ -1517,36 +1516,23 @@ func (s *Store) startLeaseRenewer(ctx context.Context) {
 		// lease expires and when we should attempt to renew it as a result.
 		renewalDuration := s.cfg.RangeLeaseActiveDuration() / 5
 		for {
-			for repl := range repls {
+			s.renewableLeases.Range(func(k int64, v unsafe.Pointer) bool {
+				repl := (*Replica)(v)
 				annotatedCtx := repl.AnnotateCtx(ctx)
-				_, pErr := repl.redirectOnOrAcquireLease(annotatedCtx)
-				if pErr != nil {
+				if _, pErr := repl.redirectOnOrAcquireLease(annotatedCtx); pErr != nil {
 					if _, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); !ok {
 						log.Warningf(annotatedCtx, "failed to proactively renew lease: %s", pErr)
 					}
-					delete(repls, repl)
-					continue
+					s.renewableLeases.Delete(k)
 				}
-			}
+				return true
+			})
 
 			if len(repls) > 0 {
 				timer.Reset(renewalDuration)
 			}
 			select {
-			case repl := <-s.expirationBasedLeaseChan:
-				repls[repl] = struct{}{}
-				// If we got one entry off the channel, there may be more (e.g. a node
-				// holding a bunch of meta2 ranges just failed), so keep pulling until
-				// we can't get any more.
-			continuepulling:
-				for {
-					select {
-					case repl := <-s.expirationBasedLeaseChan:
-						repls[repl] = struct{}{}
-					default:
-						break continuepulling
-					}
-				}
+			case <-s.renewableLeasesSignal:
 			case <-timer.C:
 				timer.Read = true
 			case <-s.stopper.ShouldStop():


### PR DESCRIPTION
Backport 2/2 commits from #25322.

/cc @cockroachdb/release

---

This mechanism won't scale incredibly well to proactively renewing all
expiration-based leases since it'd require a goroutine per lease. It
should be fine if we only auto-renew r1's lease, though.

Fixes #24753

Release note: None

----------------

To fix https://github.com/cockroachdb/cockroach/issues/27731 in v2.0.