### PR TITLE
sql: remove dead code

### DIFF
--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1508,34 +1508,6 @@ func (desc *TableDescriptor) validatePartitioning() error {
 // current heuristic will assign to a family.
 const FamilyHeuristicTargetBytes = 256
 
-// upperBoundColumnValueEncodedSize returns the maximum encoded size of the
-// given column using the "value" encoding. If the size is unbounded, false is returned.
-func upperBoundColumnValueEncodedSize(col ColumnDescriptor) (int, bool) {
-	var typ encoding.Type
-	var size int
-	switch col.Type.SemanticType {
-	case ColumnType_BOOL:
-		typ = encoding.True
-	case ColumnType_INT, ColumnType_DATE, ColumnType_TIME,
-		ColumnType_TIMESTAMP,
-		ColumnType_TIMESTAMPTZ, ColumnType_OID:
-		typ, size = encoding.Int, int(col.Type.Width)
-	case ColumnType_FLOAT:
-		typ = encoding.Float
-	case ColumnType_INTERVAL:
-		typ = encoding.Duration
-	case ColumnType_STRING, ColumnType_BYTES, ColumnType_COLLATEDSTRING, ColumnType_NAME, ColumnType_UUID, ColumnType_INET:
-		// STRINGs are counted as runes, so this isn't totally correct, but this
-		// seems better than always assuming the maximum rune width.
-		typ, size = encoding.Bytes, int(col.Type.Width)
-	case ColumnType_DECIMAL:
-		typ, size = encoding.Decimal, int(col.Type.Precision)
-	default:
-		panic(errors.Errorf("unknown column type: %s", col.Type.SemanticType))
-	}
-	return encoding.UpperBoundValueEncodingSize(uint32(col.ID), typ, size)
-}
-
 // fitColumnToFamily attempts to fit a new column into the existing column
 // families. If the heuristics find a fit, true is returned along with the
 // index of the selected family. Otherwise, false is returned and the column

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -1100,50 +1100,8 @@ func TestColumnTypeSQLString(t *testing.T) {
 	}
 }
 
-func TestColumnValueEncodedSize(t *testing.T) {
-	tests := []struct {
-		colType ColumnType
-		size    int // -1 means unbounded
-	}{
-		{ColumnType{SemanticType: ColumnType_BOOL}, 1},
-		{ColumnType{SemanticType: ColumnType_INT}, 10},
-		{ColumnType{SemanticType: ColumnType_INT, Width: 2}, 10},
-		{ColumnType{SemanticType: ColumnType_FLOAT}, 9},
-		{ColumnType{SemanticType: ColumnType_FLOAT, Precision: 100}, 9},
-		{ColumnType{SemanticType: ColumnType_DECIMAL}, -1},
-		{ColumnType{SemanticType: ColumnType_DECIMAL, Precision: 100}, 69},
-		{ColumnType{SemanticType: ColumnType_DECIMAL, Precision: 100, Width: 100}, 69},
-		{ColumnType{SemanticType: ColumnType_DATE}, 10},
-		{ColumnType{SemanticType: ColumnType_TIMESTAMP}, 10},
-		{ColumnType{SemanticType: ColumnType_INTERVAL}, 28},
-		{ColumnType{SemanticType: ColumnType_STRING}, -1},
-		{ColumnType{SemanticType: ColumnType_STRING, Width: 100}, 110},
-		{ColumnType{SemanticType: ColumnType_BYTES}, -1},
-	}
-	for i, test := range tests {
-		testIsBounded := test.size != -1
-		size, isBounded := upperBoundColumnValueEncodedSize(ColumnDescriptor{
-			Type: test.colType,
-		})
-		if isBounded != testIsBounded {
-			if isBounded {
-				t.Errorf("%d: expected unbounded but got bounded", i)
-			} else {
-				t.Errorf("%d: expected bounded but got unbounded", i)
-			}
-			continue
-		}
-		if isBounded && size != test.size {
-			t.Errorf("%d: got size %d but expected %d", i, size, test.size)
-		}
-	}
-}
-
 func TestFitColumnToFamily(t *testing.T) {
-	intEncodedSize, _ := upperBoundColumnValueEncodedSize(ColumnDescriptor{
-		ID:   8,
-		Type: ColumnType{SemanticType: ColumnType_INT},
-	})
+	intEncodedSize := 10 // 1 byte tag + 9 bytes max varint encoded size
 
 	makeTestTableDescriptor := func(familyTypes [][]ColumnType) TableDescriptor {
 		nextColumnID := ColumnID(8)

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -213,8 +213,7 @@ func DecodeUint64Descending(b []byte) ([]byte, uint64, error) {
 }
 
 const (
-	maxVarintSize        = 9
-	maxBinaryUvarintSize = binary.MaxVarintLen64
+	maxVarintSize = 9
 )
 
 // EncodeVarintAscending encodes the int64 value using a variable length
@@ -2012,38 +2011,6 @@ func PeekValueLengthWithOffsetsAndType(b []byte, dataOffset int, typ Type) (leng
 		return 0, errors.Errorf("got invalid INET IP family: %d", family)
 	default:
 		return 0, errors.Errorf("unknown type %s", typ)
-	}
-}
-
-// UpperBoundValueEncodingSize returns the maximum encoded size of the given
-// datum type using the "value" encoding, including the tag. If the size is
-// unbounded, false is returned.
-func UpperBoundValueEncodingSize(colID uint32, typ Type, size int) (int, bool) {
-	encodedTag := EncodeValueTag(nil, colID, typ)
-	switch typ {
-	case Null, True, False:
-		// The data is encoded in the type.
-		return len(encodedTag), true
-	case Int:
-		return len(encodedTag) + maxVarintSize, true
-	case Float:
-		return len(encodedTag) + uint64AscendingEncodedLength, true
-	case Bytes:
-		if size > 0 {
-			return len(encodedTag) + maxVarintSize + size, true
-		}
-		return 0, false
-	case Decimal:
-		if size > 0 {
-			return len(encodedTag) + maxBinaryUvarintSize + upperBoundNonsortingDecimalUnscaledSize(size), true
-		}
-		return 0, false
-	case Time:
-		return len(encodedTag) + 2*maxVarintSize, true
-	case Duration:
-		return len(encodedTag) + 3*maxVarintSize, true
-	default:
-		panic(fmt.Errorf("unknown type: %s", typ))
 	}
 }
 

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -1791,45 +1791,6 @@ func TestValueEncodingRand(t *testing.T) {
 	}
 }
 
-func TestUpperBoundValueEncodingSize(t *testing.T) {
-	tests := []struct {
-		colID uint32
-		typ   Type
-		width int
-		size  int // -1 means unbounded
-	}{
-		{colID: 0, typ: Null, size: 1},
-		{colID: 0, typ: True, size: 1},
-		{colID: 0, typ: False, size: 1},
-		{colID: 0, typ: Int, size: 10},
-		{colID: 0, typ: Int, width: 100, size: 10},
-		{colID: 0, typ: Float, size: 9},
-		{colID: 0, typ: Decimal, size: -1},
-		{colID: 0, typ: Decimal, width: 100, size: 69},
-		{colID: 0, typ: Time, size: 19},
-		{colID: 0, typ: Duration, size: 28},
-		{colID: 0, typ: Bytes, size: -1},
-		{colID: 0, typ: Bytes, width: 100, size: 110},
-
-		{colID: 8, typ: True, size: 2},
-	}
-	for i, test := range tests {
-		testIsBounded := test.size != -1
-		size, isBounded := UpperBoundValueEncodingSize(test.colID, test.typ, test.width)
-		if isBounded != testIsBounded {
-			if isBounded {
-				t.Errorf("%d: expected unbounded but got bounded", i)
-			} else {
-				t.Errorf("%d: expected bounded but got unbounded", i)
-			}
-			continue
-		}
-		if isBounded && size != test.size {
-			t.Errorf("%d: got size %d but expected %d", i, size, test.size)
-		}
-	}
-}
-
 func TestPrettyPrintValueEncoded(t *testing.T) {
 	uuidStr := "63616665-6630-3064-6465-616462656562"
 	u, err := uuid.FromString(uuidStr)


### PR DESCRIPTION
The functions to retrieve the sizes of value encodings have not been
used in a long time. Remove them.

Release note: None