### PR TITLE
sql: fix the reporting of types in information_schema.columns

### DIFF
--- a/pkg/sql/coltypes/aliases.go
+++ b/pkg/sql/coltypes/aliases.go
@@ -15,6 +15,10 @@
 package coltypes
 
 import (
+	"strings"
+
+	"github.com/lib/pq/oid"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
@@ -149,8 +153,8 @@ var typNameLiterals map[string]T
 
 func init() {
 	typNameLiterals = make(map[string]T)
-	for _, t := range types.OidToType {
-		name := types.PGDisplayName(t)
+	for o, t := range types.OidToType {
+		name := strings.ToLower(oid.TypeName[o])
 		if _, ok := typNameLiterals[name]; !ok {
 			colTyp, err := DatumTypeToColumnType(t)
 			if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -826,20 +826,20 @@ DROP TABLE nullability
 statement ok
 CREATE TABLE data_types (a INT, b FLOAT, c DECIMAL, d STRING, e BYTES, f TIMESTAMP, g TIMESTAMPTZ)
 
-query TTT colnames
-SELECT table_name, column_name, data_type
+query TTTT colnames
+SELECT table_name, column_name, data_type, crdb_sql_type
 FROM information_schema.columns
 WHERE table_schema = 'public' AND table_name = 'data_types'
 ----
-table_name  column_name  data_type
-data_types  a            INT
-data_types  b            FLOAT8
-data_types  c            DECIMAL
-data_types  d            STRING
-data_types  e            BYTES
-data_types  f            TIMESTAMP
-data_types  g            TIMESTAMP WITH TIME ZONE
-data_types  rowid        INT
+table_name  column_name  data_type                 crdb_sql_type
+data_types  a            integer                   INT
+data_types  b            double precision          FLOAT8
+data_types  c            numeric                   DECIMAL
+data_types  d            text                      STRING
+data_types  e            bytea                     BYTES
+data_types  f            timestamp                 TIMESTAMP
+data_types  g            timestamp with time zone  TIMESTAMP WITH TIME ZONE
+data_types  rowid        integer                   INT
 
 statement ok
 DROP TABLE data_types
@@ -1598,8 +1598,8 @@ query TTTTIIITTTTT colnames
 SELECT * FROM information_schema.sequences
 ----
 sequence_catalog  sequence_schema  sequence_name  data_type  numeric_precision  numeric_precision_radix  numeric_scale  start_value  minimum_value  maximum_value        increment  cycle_option
-test              public           test_seq       INT        64                 2                        0              1            1              9223372036854775807  1          NO
-test              public           test_seq_2     INT        64                 2                        0              15           5              1000                 -1         NO
+test              public           test_seq       integer    64                 2                        0              1            1              9223372036854775807  1          NO
+test              public           test_seq_2     integer    64                 2                        0              15           5              1000                 -1         NO
 
 statement ok
 CREATE DATABASE other_db

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -209,7 +209,7 @@ sort                                       ·            ·
  └── render                                ·            ·
       └── group                            ·            ·
            │                               aggregate 0  column_name
-           │                               aggregate 1  data_type
+           │                               aggregate 1  crdb_sql_type
            │                               aggregate 2  is_nullable
            │                               aggregate 3  column_default
            │                               aggregate 4  generation_expression
@@ -224,7 +224,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         19 columns, 910 rows
+                     │                     size         20 columns, 911 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -202,7 +202,7 @@ sort                                       ·            ·
  └── render                                ·            ·
       └── group                            ·            ·
            │                               aggregate 0  column_name
-           │                               aggregate 1  data_type
+           │                               aggregate 1  crdb_sql_type
            │                               aggregate 2  is_nullable
            │                               aggregate 3  column_default
            │                               aggregate 4  generation_expression
@@ -217,7 +217,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         19 columns, 910 rows
+                     │                     size         20 columns, 911 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·

--- a/pkg/sql/sem/types/oid.go
+++ b/pkg/sql/sem/types/oid.go
@@ -119,62 +119,6 @@ var OidToType = map[oid.Oid]T{
 	oid.T_record: FamTuple,
 }
 
-// AliasedOidToName maps Postgres object IDs to type names for those OIDs that map to
-// Cockroach types that have more than one associated OID, like Int. The name
-// for these OIDs will override the type name of the corresponding type when
-// looking up the display name for an OID.
-var aliasedOidToName = map[oid.Oid]string{
-	// TODO(justin): find a better solution to this than mapping every array type.
-	oid.T_anyarray:     "anyarray",
-	oid.T_bit:          "bit",
-	oid.T__bit:         "_bit",
-	oid.T_bpchar:       "bpchar",
-	oid.T__bpchar:      "_bpchar",
-	oid.T_bool:         "bool",
-	oid.T__bool:        "_bool",
-	oid.T_bytea:        "bytea",
-	oid.T__bytea:       "_bytea",
-	oid.T_char:         "char",
-	oid.T__char:        "_char",
-	oid.T_date:         "date",
-	oid.T__date:        "_date",
-	oid.T_float4:       "float4",
-	oid.T__float4:      "_float4",
-	oid.T_float8:       "float8",
-	oid.T__float8:      "_float8",
-	oid.T_inet:         "inet",
-	oid.T__inet:        "_inet",
-	oid.T_int2:         "int2",
-	oid.T__int2:        "_int2",
-	oid.T_int4:         "int4",
-	oid.T__int4:        "_int4",
-	oid.T_int8:         "int8",
-	oid.T__int8:        "_int8",
-	oid.T_interval:     "interval",
-	oid.T__interval:    "_interval",
-	oid.T_name:         "name",
-	oid.T__name:        "_name",
-	oid.T_numeric:      "numeric",
-	oid.T__numeric:     "_numeric",
-	oid.T_oid:          "oid",
-	oid.T__oid:         "_oid",
-	oid.T_text:         "text",
-	oid.T__text:        "_text",
-	oid.T_time:         "time",
-	oid.T__time:        "_time",
-	oid.T_timestamp:    "timestamp",
-	oid.T__timestamp:   "_timestamp",
-	oid.T_timestamptz:  "timestamptz",
-	oid.T__timestamptz: "_timestamptz",
-	oid.T_uuid:         "uuid",
-	oid.T__uuid:        "_uuid",
-	oid.T_varchar:      "varchar",
-	oid.T__varchar:     "_varchar",
-	oid.T_oidvector:    "oidvector",
-	oid.T_record:       "record",
-	oid.T_int2vector:   "int2vector",
-}
-
 // oidToArrayOid maps scalar type Oids to their corresponding array type Oid.
 var oidToArrayOid = map[oid.Oid]oid.Oid{
 	oid.T_anyelement:  oid.T_anyarray,
@@ -200,14 +144,6 @@ var oidToArrayOid = map[oid.Oid]oid.Oid{
 	oid.T_timestamptz: oid.T__timestamptz,
 	oid.T_varchar:     oid.T__varchar,
 	oid.T_uuid:        oid.T__uuid,
-}
-
-// PGDisplayName returns the Postgres display name for a given type.
-func PGDisplayName(typ T) string {
-	if typname, ok := aliasedOidToName[typ.Oid()]; ok {
-		return typname
-	}
-	return typ.String()
 }
 
 // TOid represents an alias to the Int type with a different Postgres OID.

--- a/pkg/sql/show_columns.go
+++ b/pkg/sql/show_columns.go
@@ -28,17 +28,17 @@ func (p *planner) ShowColumns(ctx context.Context, n *tree.ShowColumns) (planNod
 	const getColumnsQuery = `
 SELECT
   column_name AS column_name,
-  data_type AS data_type,
+  crdb_sql_type AS data_type,
   is_nullable::BOOL,
   column_default,
   generation_expression,
   IF(inames[1] IS NULL, ARRAY[]:::STRING[], inames) AS indices,
   is_hidden::BOOL
 FROM
-  (SELECT column_name, data_type, is_nullable, column_default, generation_expression, ordinal_position, is_hidden,
+  (SELECT column_name, crdb_sql_type, is_nullable, column_default, generation_expression, ordinal_position, is_hidden,
           array_agg(index_name) AS inames
      FROM
-         (SELECT column_name, data_type, is_nullable, column_default, generation_expression, ordinal_position, is_hidden
+         (SELECT column_name, crdb_sql_type, is_nullable, column_default, generation_expression, ordinal_position, is_hidden
             FROM %[4]s.information_schema.columns
            WHERE (length(%[1]s)=0 OR table_catalog=%[1]s) AND table_schema=%[5]s AND table_name=%[2]s)
          LEFT OUTER JOIN
@@ -46,7 +46,7 @@ FROM
             FROM %[4]s.information_schema.statistics
            WHERE (length(%[1]s)=0 OR table_catalog=%[1]s) AND table_schema=%[5]s AND table_name=%[2]s)
          USING(column_name)
-    GROUP BY column_name, data_type, is_nullable, column_default, generation_expression, ordinal_position, is_hidden
+    GROUP BY column_name, crdb_sql_type, is_nullable, column_default, generation_expression, ordinal_position, is_hidden
    )
 ORDER BY ordinal_position`
 	return p.showTableDetails(ctx, "SHOW COLUMNS", n.Table, getColumnsQuery)

--- a/pkg/sql/sqlbase/structured.pb.go
+++ b/pkg/sql/sqlbase/structured.pb.go
@@ -51,8 +51,13 @@ func (x *ConstraintValidity) UnmarshalJSON(data []byte) error {
 }
 func (ConstraintValidity) EnumDescriptor() ([]byte, []int) { return fileDescriptorStructured, []int{0} }
 
-// These mirror the types supported by the sql/parser. See
-// sql/parser/col_types.go.
+// These mirror the types supported by sql/coltypes.
+//
+// Note: when adding constants to this list or renaming constants,
+// verify with PostgreSQL what the type name should be in
+// information_schema.columns.data_type, and modify
+// (*ColumnType).InformationSchemaVisibleType() accordingly.
+//
 type ColumnType_SemanticType int32
 
 const (

--- a/pkg/sql/sqlbase/structured.proto
+++ b/pkg/sql/sqlbase/structured.proto
@@ -100,8 +100,13 @@ import "gogoproto/gogo.proto";
 message ColumnType {
   option (gogoproto.equal) = true;
 
-  // These mirror the types supported by the sql/parser. See
-  // sql/parser/col_types.go.
+  // These mirror the types supported by sql/coltypes.
+  //
+  // Note: when adding constants to this list or renaming constants,
+  // verify with PostgreSQL what the type name should be in
+  // information_schema.columns.data_type, and modify
+  // (*ColumnType).InformationSchemaVisibleType() accordingly.
+  //
   enum SemanticType {
     BOOL = 0;
     INT = 1;        // INT(width)


### PR DESCRIPTION
First commits from #28944 and priors.
Forked off #28690.
Fixes #27601.
Largely addresses the concerns that led to issue #26925.

Prior to this patch, CockroachDB incorrectly placed the "input syntax"
of each SQL type in the column `data_type` of
`information_schema.columns`.

The input syntax is the one reported in SHOW COLUMNS, SHOW CREATE
TABLE and other places, and is suitable to reproduce the exact type of
at able.

In contrast, `information_schema.columns.data_type` is constrained by
compatibility with third party tools and PostgreSQL clients.  It must
report the name of the type like PostgreSQL does, which in turn is
constrained by the SQL standard. A text column must be reported as
"text" not "string"; a decimal column as "numeric" not "decimal", a
float8 column as "double precision" not "float8", and so on.

By reporting the wrong string in that column CockroachDB is confusing
ORMs, which subsequently decide that the current on-disk type is not
the one expected by the app and then initiate a schema change (ALTER
COLUMN SET TYPE).

This patch corrects this incompatibility by introducing logic that
produces the proper information schema names for column types. This is
expected to reduce ORM complaints about insufficient support for ALTER
COLUMN SET TYPE (but will be tested/evaluated separately).

Release note (bug fix): CockroachDB now populates the `data_type`
column of `information_schema.columns` like PostgreSQL for
compatibility with 3rd party tools and ORMs.