### PR TITLE
 cli,sql: add another crutch to the handling of column types in `dump`

### DIFF
--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -198,7 +198,10 @@ func TestDumpRandom(t *testing.T) {
 		CREATE TABLE d.t (
 			rowid int,
 			i int,
+			si smallint,
+			bi bigint,
 			f float,
+			fr real,
 			d date,
 			m timestamp,
 			n interval,
@@ -209,7 +212,7 @@ func TestDumpRandom(t *testing.T) {
 			u uuid,
 			ip inet,
 			j json,
-			PRIMARY KEY (rowid, i, f, d, m, n, o, e, s, b, u, ip)
+			PRIMARY KEY (rowid, i, si, bi, f, fr, d, m, n, o, e, s, b, u, ip)
 		);
 		SET extra_float_digits = 3;
 	`, nil); err != nil {
@@ -278,7 +281,10 @@ func TestDumpRandom(t *testing.T) {
 			vals := []driver.Value{
 				_i,
 				i,
+				i & 0x7fff, // si
+				i,          // bi
 				f,
+				f, // fr
 				d,
 				m,
 				[]byte(n), // intervals come out as `[]byte`s
@@ -290,14 +296,14 @@ func TestDumpRandom(t *testing.T) {
 				[]byte(ip.String()),
 				[]byte(j.String()),
 			}
-			if err := conn.Exec("INSERT INTO d.t VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)", vals); err != nil {
+			if err := conn.Exec("INSERT INTO d.t VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)", vals); err != nil {
 				t.Fatal(err)
 			}
 			generatedRows = append(generatedRows, vals[1:])
 		}
 
 		check := func(table string) {
-			q := fmt.Sprintf("SELECT i, f, d, m, n, o, e, s, b, u, ip, j FROM %s ORDER BY rowid", table)
+			q := fmt.Sprintf("SELECT i, si, bi, f, fr, d, m, n, o, e, s, b, u, ip, j FROM %s ORDER BY rowid", table)
 			nrows, err := conn.Query(q, nil)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/sql/sem/tree/parse_array.go
+++ b/pkg/sql/sem/tree/parse_array.go
@@ -145,46 +145,6 @@ func (p *parseState) parseElement() error {
 	return p.result.Append(d)
 }
 
-// ArrayElementTypeStringToColType returns a column type given a
-// string representation of the type. Used by dump. It only
-// supports those type names that can appear immediately before `[]`.
-func ArrayElementTypeStringToColType(s string) (coltypes.T, error) {
-	switch s {
-	case "BOOL":
-		return coltypes.Bool, nil
-	case "INT":
-		return coltypes.Int, nil
-	case "FLOAT", "FLOAT8", "DOUBLE PRECISION":
-		return coltypes.Float8, nil
-	case "REAL", "FLOAT4":
-		return coltypes.Float4, nil
-	case "DECIMAL":
-		return coltypes.Decimal, nil
-	case "TIMESTAMP":
-		return coltypes.Timestamp, nil
-	case "TIMESTAMPTZ", "TIMESTAMP WITH TIME ZONE":
-		return coltypes.TimestampWithTZ, nil
-	case "INTERVAL":
-		return coltypes.Interval, nil
-	case "UUID":
-		return coltypes.UUID, nil
-	case "INET":
-		return coltypes.INet, nil
-	case "DATE":
-		return coltypes.Date, nil
-	case "TIME":
-		return coltypes.Time, nil
-	case "STRING":
-		return coltypes.String, nil
-	case "NAME":
-		return coltypes.Name, nil
-	case "BYTES":
-		return coltypes.Bytes, nil
-	default:
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unexpected column type %s", s)
-	}
-}
-
 // ParseDArrayFromString parses the string-form of constructing arrays, handling
 // cases such as `'{1,2,3}'::INT[]`.
 func ParseDArrayFromString(evalCtx *EvalContext, s string, t coltypes.T) (*DArray, error) {


### PR DESCRIPTION
All commits but the last part of #28945 and priors.
PR forked from #28690.

There are major problems in `cockroach dump` described separately in
#28948. Part of this is `cockroach dump` trying to reverse-engineer a datum
type from the announced column type in `information_schema.columns`,
by parsing the type name. Prior to this patch, this parsing was
incomplete (it went out of sync with the SQL parser over time,
naturally as it was bound to do).

This entire approach is flawed, but this is no time to redesign
`cockroach dump`. Instead, this patch re-syncs the dump-specific type
parser with the general SQL parser. It also ensures this parser is
still able to parse pre-2.1 type name aliases.

Release note (bug fix): `cockroach dump` is now again better able to
operate across multiple CockroachDB versions.