### PR TITLE
 storage: enable merge queue by default

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -31,7 +31,7 @@
 <tr><td><code>kv.raft_log.synchronize</code></td><td>boolean</td><td><code>true</code></td><td>set to true to synchronize on Raft log writes to persistent storage ('false' risks data loss)</td></tr>
 <tr><td><code>kv.range.backpressure_range_size_multiplier</code></td><td>float</td><td><code>2</code></td><td>multiple of range_max_bytes that a range is allowed to grow to without splitting before writes to that range are blocked, or 0 to disable</td></tr>
 <tr><td><code>kv.range_descriptor_cache.size</code></td><td>integer</td><td><code>1000000</code></td><td>maximum number of entries in the range descriptor and leaseholder caches</td></tr>
-<tr><td><code>kv.range_merge.queue_enabled</code></td><td>boolean</td><td><code>false</code></td><td>whether the automatic merge queue is enabled</td></tr>
+<tr><td><code>kv.range_merge.queue_enabled</code></td><td>boolean</td><td><code>true</code></td><td>whether the automatic merge queue is enabled</td></tr>
 <tr><td><code>kv.rangefeed.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, rangefeed registration is enabled</td></tr>
 <tr><td><code>kv.snapshot_rebalance.max_rate</code></td><td>byte size</td><td><code>2.0 MiB</code></td><td>the rate limit (bytes/sec) to use for rebalance snapshots</td></tr>
 <tr><td><code>kv.snapshot_recovery.max_rate</code></td><td>byte size</td><td><code>8.0 MiB</code></td><td>the rate limit (bytes/sec) to use for recovery snapshots</td></tr>

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -31,6 +31,7 @@
 <tr><td><code>kv.raft_log.synchronize</code></td><td>boolean</td><td><code>true</code></td><td>set to true to synchronize on Raft log writes to persistent storage ('false' risks data loss)</td></tr>
 <tr><td><code>kv.range.backpressure_range_size_multiplier</code></td><td>float</td><td><code>2</code></td><td>multiple of range_max_bytes that a range is allowed to grow to without splitting before writes to that range are blocked, or 0 to disable</td></tr>
 <tr><td><code>kv.range_descriptor_cache.size</code></td><td>integer</td><td><code>1000000</code></td><td>maximum number of entries in the range descriptor and leaseholder caches</td></tr>
+<tr><td><code>kv.range_merge.queue_enabled</code></td><td>boolean</td><td><code>false</code></td><td>whether the automatic merge queue is enabled</td></tr>
 <tr><td><code>kv.rangefeed.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, rangefeed registration is enabled</td></tr>
 <tr><td><code>kv.snapshot_rebalance.max_rate</code></td><td>byte size</td><td><code>2.0 MiB</code></td><td>the rate limit (bytes/sec) to use for rebalance snapshots</td></tr>
 <tr><td><code>kv.snapshot_recovery.max_rate</code></td><td>byte size</td><td><code>8.0 MiB</code></td><td>the rate limit (bytes/sec) to use for recovery snapshots</td></tr>

--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -167,6 +167,8 @@ func TestExportCmd(t *testing.T) {
 
 	var res5 ExportAndSlurpResult
 	t.Run("ts5", func(t *testing.T) {
+		// Prevent the merge queue from immediately discarding our splits.
+		sqlDB.Exec(t, `SET CLUSTER SETTING kv.range_merge.queue_enabled = false`)
 		sqlDB.Exec(t, `ALTER TABLE mvcclatest.export SPLIT AT VALUES (2)`)
 		res5 = exportAndSlurp(t, hlc.Timestamp{})
 		expect(t, res5, 2, 2, 2, 7)

--- a/pkg/cmd/roachtest/election.go
+++ b/pkg/cmd/roachtest/election.go
@@ -36,6 +36,8 @@ func registerElectionAfterRestart(r *registry) {
 			c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
         CREATE DATABASE IF NOT EXISTS test;
         CREATE TABLE test.kv (k INT PRIMARY KEY, v INT);
+        -- Prevent the merge queue from immediately discarding our splits.
+        SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
         ALTER TABLE test.kv SPLIT AT SELECT generate_series(0, 10000, 100)"`)
 
 			start := timeutil.Now()

--- a/pkg/sql/distsqlrun/cluster_test.go
+++ b/pkg/sql/distsqlrun/cluster_test.go
@@ -563,6 +563,8 @@ func TestDistSQLReadsFillGatewayID(t *testing.T) {
 		sqlutils.ToRowFn(sqlutils.RowIdxFn))
 
 	if _, err := db.Exec(`
+-- Prevent the merge queue from immediately discarding our splits.
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
 ALTER TABLE t SPLIT AT VALUES (1), (2), (3);
 ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[3], 3);
 `); err != nil {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1565,6 +1565,10 @@ func (m *sessionDataMutator) SetLookupJoinEnabled(val bool) {
 	m.data.LookupJoinEnabled = val
 }
 
+func (m *sessionDataMutator) SetForceSplitAt(val bool) {
+	m.data.ForceSplitAt = val
+}
+
 func (m *sessionDataMutator) SetZigzagJoinEnabled(val bool) {
 	m.data.ZigzagJoinEnabled = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -3,6 +3,10 @@
 statement ok
 CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c, d))
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split into ten parts.
 statement ok
 ALTER TABLE data SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i)

--- a/pkg/sql/logictest/testdata/logic_test/distsql_distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_distinct_on
@@ -34,6 +34,10 @@ INSERT INTO abc VALUES
   ('2', '3', '4'),
   ('3', '4', '5')
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 statement ok
 ALTER TABLE xyz SPLIT AT VALUES (2), (4), (6), (7)
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_interleaved_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_interleaved_join
@@ -168,6 +168,10 @@ FROM
 # Split our ranges #
 ####################
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split at parent1 key into five parts.
 statement ok
 ALTER TABLE parent1 SPLIT AT SELECT i FROM generate_series(8, 32, 8) AS g(i)

--- a/pkg/sql/logictest/testdata/logic_test/distsql_lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_lookup_join
@@ -9,6 +9,10 @@ SET experimental_force_lookup_join = true;
 statement ok
 CREATE TABLE data (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b, c, d))
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split into ten parts.
 statement ok
 ALTER TABLE data SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i)
@@ -226,6 +230,10 @@ true
 # Create a table with a secondary index which stores another column.
 statement ok
 CREATE TABLE multiples (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b), INDEX bc (b) STORING (c))
+
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
 
 # Split into ten parts.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -13,6 +13,10 @@ INSERT INTO NumToSquare SELECT i, i*i FROM generate_series(1, 100) AS g(i)
 statement ok
 CREATE TABLE NumToStr (y INT PRIMARY KEY, str STRING)
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split into five parts.
 statement ok
 ALTER TABLE NumToStr SPLIT AT SELECT (i * 100 * 100 / 5)::int FROM generate_series(1, 4) AS g(i)

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -3,6 +3,10 @@
 statement ok
 CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c, d))
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split into ten parts.
 statement ok
 ALTER TABLE data SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i)

--- a/pkg/sql/logictest/testdata/logic_test/distsql_tighten_spans
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_tighten_spans
@@ -99,6 +99,10 @@ INSERT INTO decimal_t VALUES
 # Also split at the beginning of each index (0 for ASC, 100 for DESC) to
 # prevent interfering with previous indexes/tables.
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # p1 table (interleaved index)
 statement ok
 ALTER TABLE p1 SPLIT AT VALUES(2)

--- a/pkg/sql/logictest/testdata/logic_test/distsql_union
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_union
@@ -16,6 +16,10 @@ INSERT INTO xyz VALUES
   (4, 2, 'b'),
   (5, 2, 'c')
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 statement ok
 ALTER TABLE xyz SPLIT AT VALUES (2), (3), (4), (5)
 

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -49,6 +49,10 @@ CREATE TABLE kw (k INT PRIMARY KEY, w INT)
 statement ok
 INSERT INTO kw SELECT i, i FROM generate_series(1,5) AS g(i)
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split into 5 parts, each row from each table goes to one node.
 statement ok
 ALTER TABLE kv SPLIT AT SELECT i FROM generate_series(1,5) AS g(i)

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1310,6 +1310,7 @@ default_transaction_isolation      serializable  NULL      NULL        NULL     
 default_transaction_read_only      off           NULL      NULL        NULL        string
 distsql                            off           NULL      NULL        NULL        string
 experimental_force_lookup_join     off           NULL      NULL        NULL        string
+experimental_force_split_at        off           NULL      NULL        NULL        string
 experimental_force_zigzag_join     off           NULL      NULL        NULL        string
 experimental_serial_normalization  rowid         NULL      NULL        NULL        string
 extra_float_digits                 0             NULL      NULL        NULL        string
@@ -1346,6 +1347,7 @@ default_transaction_isolation      serializable  NULL  user     NULL      serial
 default_transaction_read_only      off           NULL  user     NULL      off           off
 distsql                            off           NULL  user     NULL      off           off
 experimental_force_lookup_join     off           NULL  user     NULL      off           off
+experimental_force_split_at        off           NULL  user     NULL      off           off
 experimental_force_zigzag_join     off           NULL  user     NULL      off           off
 experimental_serial_normalization  rowid         NULL  user     NULL      rowid         rowid
 extra_float_digits                 0             NULL  user     NULL      0             0
@@ -1382,6 +1384,7 @@ default_transaction_isolation      NULL    NULL     NULL     NULL        NULL
 default_transaction_read_only      NULL    NULL     NULL     NULL        NULL
 distsql                            NULL    NULL     NULL     NULL        NULL
 experimental_force_lookup_join     NULL    NULL     NULL     NULL        NULL
+experimental_force_split_at        NULL    NULL     NULL     NULL        NULL
 experimental_force_zigzag_join     NULL    NULL     NULL     NULL        NULL
 experimental_opt                   NULL    NULL     NULL     NULL        NULL
 experimental_serial_normalization  NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -9,6 +9,10 @@ SHOW EXPERIMENTAL_RANGES FROM TABLE t
 start_key  end_key  range_id  replicas  lease_holder
 NULL       NULL     1         {1}       1
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 statement ok
 ALTER TABLE t SPLIT AT VALUES (1), (10)
 

--- a/pkg/sql/logictest/testdata/logic_test/select_index_span_ranges
+++ b/pkg/sql/logictest/testdata/logic_test/select_index_span_ranges
@@ -35,6 +35,10 @@ INSERT INTO t VALUES
 (12, 0, 88, 0),
 (13, 0, 13, 0)
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split the table across multiple ranges.
 statement ok
 ALTER TABLE t SPLIT AT VALUES (2)

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -34,6 +34,7 @@ default_transaction_isolation      serializable
 default_transaction_read_only      off
 distsql                            off
 experimental_force_lookup_join     off
+experimental_force_split_at        off
 experimental_force_zigzag_join     off
 experimental_serial_normalization  rowid
 extra_float_digits                 0

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -157,6 +157,10 @@ CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
 statement ok
 INSERT INTO abc VALUES (1, 2, 3), (4, 5, 6)
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 statement ok
 ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))
 

--- a/pkg/sql/logictest/testdata/planner_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_agg
@@ -3,6 +3,10 @@
 statement ok
 CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c, d))
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split into ten parts.
 statement ok
 ALTER TABLE data SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i)

--- a/pkg/sql/logictest/testdata/planner_test/distsql_distinct_on
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_distinct_on
@@ -16,6 +16,10 @@ CREATE TABLE abc (
   PRIMARY KEY (a, b, c)
 )
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 statement ok
 ALTER TABLE xyz SPLIT AT VALUES (2), (4), (6), (7)
 

--- a/pkg/sql/logictest/testdata/planner_test/distsql_indexjoin
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_indexjoin
@@ -3,6 +3,10 @@
 statement ok
 CREATE TABLE t (k INT PRIMARY KEY, v INT, w INT, INDEX v(v))
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split the index into 5 parts, as if numbers were in the range 1 to 100.
 statement ok
 ALTER INDEX t@v SPLIT AT SELECT (i * 10)::int FROM generate_series(1, 4) AS g(i)

--- a/pkg/sql/logictest/testdata/planner_test/distsql_interleaved_join
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_interleaved_join
@@ -83,6 +83,10 @@ INTERLEAVE IN PARENT child2 (pid1, cid2, cid3)
 # Split our ranges #
 ####################
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split at parent1 key into five parts.
 statement ok
 ALTER TABLE parent1 SPLIT AT SELECT i FROM generate_series(8, 32, 8) AS g(i)

--- a/pkg/sql/logictest/testdata/planner_test/distsql_join
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_join
@@ -3,6 +3,10 @@
 statement ok
 CREATE TABLE data (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b, c, d))
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split into ten parts.
 statement ok
 ALTER TABLE data SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i)

--- a/pkg/sql/logictest/testdata/planner_test/distsql_lookup_join
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_lookup_join
@@ -9,6 +9,10 @@ SET experimental_force_lookup_join = true;
 statement ok
 CREATE TABLE data (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b, c, d))
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split into ten parts.
 statement ok
 ALTER TABLE data SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i)

--- a/pkg/sql/logictest/testdata/planner_test/distsql_misc
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_misc
@@ -57,6 +57,10 @@ subtest stats
 statement ok
 CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c, d))
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split into ten parts.
 statement ok
 ALTER TABLE data SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i)

--- a/pkg/sql/logictest/testdata/planner_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_numtables
@@ -13,6 +13,10 @@ INSERT INTO NumToSquare SELECT i, i*i FROM generate_series(1, 100) AS g(i)
 statement ok
 CREATE TABLE NumToStr (y INT PRIMARY KEY, str STRING)
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split into five parts.
 statement ok
 ALTER TABLE NumToStr SPLIT AT SELECT (i * 100 * 100 / 5)::int FROM generate_series(1, 4) AS g(i)

--- a/pkg/sql/logictest/testdata/planner_test/distsql_sort
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_sort
@@ -3,6 +3,10 @@
 statement ok
 CREATE TABLE data (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b, c, d))
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split into ten parts.
 statement ok
 ALTER TABLE data SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i)

--- a/pkg/sql/logictest/testdata/planner_test/distsql_srfs
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_srfs
@@ -3,6 +3,10 @@
 statement ok
 CREATE TABLE data (a INT PRIMARY KEY)
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split into ten parts.
 statement ok
 ALTER TABLE data SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i)

--- a/pkg/sql/logictest/testdata/planner_test/distsql_tighten_spans
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_tighten_spans
@@ -47,6 +47,10 @@ CREATE TABLE decimal_t (a DECIMAL PRIMARY KEY)
 # Also split at the beginning of each index (0 for ASC, 100 for DESC) to
 # prevent interfering with previous indexes/tables.
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # p1 table (interleaved index)
 statement ok
 ALTER TABLE p1 SPLIT AT VALUES(2)

--- a/pkg/sql/logictest/testdata/planner_test/distsql_union
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_union
@@ -7,6 +7,10 @@ CREATE TABLE xyz (
   z TEXT
 )
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 statement ok
 ALTER TABLE xyz SPLIT AT VALUES (2), (3), (4), (5)
 

--- a/pkg/sql/logictest/testdata/planner_test/distsql_window
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_window
@@ -3,6 +3,10 @@
 statement ok
 CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c, d))
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split into ten parts.
 statement ok
 ALTER TABLE data SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i)

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -167,7 +167,7 @@ EXPLAIN SHOW DATABASE
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 32 rows
+·                 size  2 columns, 33 rows
 
 query TTT
 EXPLAIN SHOW TIME ZONE
@@ -175,7 +175,7 @@ EXPLAIN SHOW TIME ZONE
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 32 rows
+·                 size  2 columns, 33 rows
 
 query TTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -183,7 +183,7 @@ EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 32 rows
+·                 size  2 columns, 33 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -191,7 +191,7 @@ EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 32 rows
+·                 size  2 columns, 33 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -199,7 +199,7 @@ EXPLAIN SHOW TRANSACTION PRIORITY
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 32 rows
+·                 size  2 columns, 33 rows
 
 query TTT
 EXPLAIN SHOW COLUMNS FROM foo

--- a/pkg/sql/logictest/testdata/planner_test/subquery
+++ b/pkg/sql/logictest/testdata/planner_test/subquery
@@ -5,6 +5,10 @@
 statement ok
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 query TTT
 EXPLAIN ALTER TABLE abc SPLIT AT VALUES ((SELECT 42))
 ----

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
@@ -3,6 +3,10 @@
 statement ok
 CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c, d))
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split into ten parts.
 statement ok
 ALTER TABLE data SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
@@ -16,6 +16,10 @@ CREATE TABLE abc (
   PRIMARY KEY (a, b, c)
 )
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 statement ok
 ALTER TABLE xyz SPLIT AT VALUES (2), (4), (6), (7)
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_indexjoin
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_indexjoin
@@ -3,6 +3,10 @@
 statement ok
 CREATE TABLE t (k INT PRIMARY KEY, v INT, w INT, INDEX v(v))
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split the index into 5 parts, as if numbers were in the range 1 to 100.
 statement ok
 ALTER INDEX t@v SPLIT AT SELECT (i * 10)::int FROM generate_series(1, 4) AS g(i)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
@@ -83,6 +83,10 @@ INTERLEAVE IN PARENT child2 (pid1, cid2, cid3)
 # Split our ranges #
 ####################
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split at parent1 key into five parts.
 statement ok
 ALTER TABLE parent1 SPLIT AT SELECT i FROM generate_series(8, 32, 8) AS g(i)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
@@ -3,6 +3,10 @@
 statement ok
 CREATE TABLE data (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b, c, d))
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split into ten parts.
 statement ok
 ALTER TABLE data SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
@@ -60,6 +60,10 @@ subtest stats
 statement ok
 CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c, d))
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split into ten parts.
 statement ok
 ALTER TABLE data SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -13,6 +13,10 @@ INSERT INTO NumToSquare SELECT i, i*i FROM generate_series(1, 100) AS g(i)
 statement ok
 CREATE TABLE NumToStr (y INT PRIMARY KEY, str STRING)
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split into five parts.
 statement ok
 ALTER TABLE NumToStr SPLIT AT SELECT (i * 100 * 100 / 5)::int FROM generate_series(1, 4) AS g(i)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
@@ -47,6 +47,10 @@ CREATE TABLE decimal_t (a DECIMAL PRIMARY KEY)
 # Also split at the beginning of each index (0 for ASC, 100 for DESC) to
 # prevent interfering with previous indexes/tables.
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # p1 table (interleaved index)
 statement ok
 ALTER TABLE p1 SPLIT AT VALUES(2)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_union
@@ -7,6 +7,10 @@ CREATE TABLE xyz (
   z TEXT
 )
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 statement ok
 ALTER TABLE xyz SPLIT AT VALUES (2), (3), (4), (5)
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -160,7 +160,7 @@ EXPLAIN SHOW DATABASE
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 32 rows
+·                 size  2 columns, 33 rows
 
 query TTT
 EXPLAIN SHOW TIME ZONE
@@ -168,7 +168,7 @@ EXPLAIN SHOW TIME ZONE
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 32 rows
+·                 size  2 columns, 33 rows
 
 query TTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -176,7 +176,7 @@ EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 32 rows
+·                 size  2 columns, 33 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -184,7 +184,7 @@ EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 32 rows
+·                 size  2 columns, 33 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -192,7 +192,7 @@ EXPLAIN SHOW TRANSACTION PRIORITY
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 32 rows
+·                 size  2 columns, 33 rows
 
 query TTT
 EXPLAIN SHOW COLUMNS FROM foo

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -97,6 +97,10 @@ lookup-join  ·      ·                         (a, b, c, d, e, f)  ·
 statement ok
 CREATE TABLE data (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b, c, d))
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 # Split into ten parts.
 statement ok
 ALTER TABLE data SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i)

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -6,6 +6,10 @@
 statement ok
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
 
+# Prevent the merge queue from immediately discarding our splits.
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 query TTT
 EXPLAIN ALTER TABLE abc SPLIT AT VALUES ((SELECT 42))
 ----

--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -233,6 +233,11 @@ func TestCancelDistSQLQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Prevent the merge queue from immediately discarding our splits.
+	if _, err := conn1.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false"); err != nil {
+		t.Fatal(err)
+	}
+
 	if _, err := conn1.Exec("ALTER TABLE nums SPLIT AT VALUES (50)"); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/scatter_test.go
+++ b/pkg/sql/scatter_test.go
@@ -51,6 +51,9 @@ func TestScatterRandomizeLeases(t *testing.T) {
 
 	r := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
+	// Prevent the merge queue from immediately discarding our splits.
+	r.Exec(t, "SET CLUSTER SETTING kv.range_merge.queue_enabled = false")
+
 	// Introduce 99 splits to get 100 ranges.
 	r.Exec(t, "ALTER TABLE test.t SPLIT AT (SELECT i*10 FROM generate_series(1, 99) AS g(i))")
 
@@ -122,6 +125,8 @@ func TestScatterResponse(t *testing.T) {
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "test", "t")
 
 	r := sqlutils.MakeSQLRunner(sqlDB)
+	// Prevent the merge queue from immediately discarding our splits.
+	r.Exec(t, "SET CLUSTER SETTING kv.range_merge.queue_enabled = false")
 	r.Exec(t, "ALTER TABLE test.t SPLIT AT (SELECT i*10 FROM generate_series(1, 99) AS g(i))")
 	rows := r.Query(t, "ALTER TABLE test.t SCATTER")
 

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -46,6 +46,9 @@ type SessionData struct {
 	// lookup join where the left side is scanned and index lookups are done on
 	// the right side. Will emit a warning if a lookup join can't be planned.
 	LookupJoinEnabled bool
+	// ForceSplitAt indicates whether checks to prevent incorrect usage of ALTER
+	// TABLE ... SPLIT AT should be skipped.
+	ForceSplitAt bool
 	// OptimizerMode indicates whether to use the experimental optimizer for
 	// query planning.
 	OptimizerMode OptimizerMode

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -235,6 +235,9 @@ func TestTrace(t *testing.T) {
 	if _, err := clusterDB.Exec(`
 		CREATE DATABASE test;
 
+		-- Prevent the merge queue from immediately discarding our splits.
+		SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
+
 		--- test.foo is a single range table.
 		CREATE TABLE test.foo (id INT PRIMARY KEY);
 
@@ -520,6 +523,8 @@ func TestKVTraceDistSQL(t *testing.T) {
 	r.Exec(t, "CREATE DATABASE test")
 	r.Exec(t, "CREATE TABLE test.a (a INT PRIMARY KEY, b INT)")
 	r.Exec(t, "INSERT INTO test.a VALUES (1,1), (2,2)")
+	// Prevent the merge queue from immediately discarding our splits.
+	r.Exec(t, "SET CLUSTER SETTING kv.range_merge.queue_enabled = false")
 	r.Exec(t, "ALTER TABLE a SPLIT AT VALUES(1)")
 	r.Exec(t, "SET tracing = on,kv; SELECT count(*) FROM test.a; SET tracing = off")
 

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -1535,6 +1535,8 @@ func TestDistSQLRetryableError(t *testing.T) {
 
 	// We're going to split one of the tables, but node 4 is unaware of this.
 	_, err := db.Exec(fmt.Sprintf(`
+	-- Prevent the merge queue from immediately discarding our splits.
+	SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
 	ALTER TABLE "t" SPLIT AT VALUES (1), (2), (3);
 	ALTER TABLE "t" EXPERIMENTAL_RELOCATE VALUES (ARRAY[%d], 1), (ARRAY[%d], 2), (ARRAY[%d], 3);
 	`,

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -279,6 +279,28 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`experimental_force_split_at`: {
+		Set: func(
+			_ context.Context, m *sessionDataMutator,
+			evalCtx *extendedEvalContext, values []tree.TypedExpr,
+		) error {
+			s, err := getSingleBool("experimental_force_split_at", evalCtx, values)
+			if err != nil {
+				return err
+			}
+			m.SetForceSplitAt(bool(*s))
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.ForceSplitAt)
+		},
+		Reset: func(m *sessionDataMutator) error {
+			m.SetForceSplitAt(false)
+			return nil
+		},
+	},
+
+	// CockroachDB extension.
 	`experimental_force_zigzag_join`: {
 		Set: func(
 			_ context.Context, m *sessionDataMutator,

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -2153,29 +2153,10 @@ func TestMergeQueue(t *testing.T) {
 		verifyMerged(t)
 	})
 
-	t.Run("rhs-setting-threshold", func(t *testing.T) {
-		reset(t)
-
-		if err := store.DB().Put(ctx, "b-key", "val"); err != nil {
-			t.Fatal(err)
-		}
-		store.ForceMergeScanAndProcess()
-		verifyUnmerged(t)
-
-		storage.MergeMaxRHSSize.Override(sv, 100)
-		defer storage.MergeMaxRHSSize.Override(sv, storage.MergeMaxRHSSize.Default())
-		store.ForceMergeScanAndProcess()
-		verifyMerged(t)
-	})
-
 	rng, _ := randutil.NewPseudoRand()
 
 	t.Run("rhs-replica-threshold", func(t *testing.T) {
 		reset(t)
-
-		// Make the RHS cluster setting threshold irrelevant.
-		storage.MergeMaxRHSSize.Override(sv, 1<<32)
-		defer storage.MergeMaxRHSSize.Override(sv, storage.MergeMaxRHSSize.Default())
 
 		bytes := randutil.RandBytes(rng, int(defaultZone.RangeMinBytes))
 		if err := store.DB().Put(ctx, "b-key", bytes); err != nil {
@@ -2206,9 +2187,6 @@ func TestMergeQueue(t *testing.T) {
 
 	t.Run("combined-threshold", func(t *testing.T) {
 		reset(t)
-
-		storage.MergeMaxRHSSize.Override(sv, 1<<32)
-		defer storage.MergeMaxRHSSize.Override(sv, storage.MergeMaxRHSSize.Default())
 
 		// The ranges are individually beneath the minimum size threshold, but
 		// together they'll exceed the maximum size threshold.

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -2085,6 +2085,7 @@ func TestMergeQueue(t *testing.T) {
 	storeCfg.TestingKnobs.DisableScanner = true
 	sv := &storeCfg.Settings.SV
 	storage.MergeQueueEnabled.Override(sv, true)
+	storage.MergeQueueInterval.Override(sv, 0) // process greedily
 	var mtc multiTestContext
 	mtc.storeConfig = &storeCfg
 	mtc.Start(t, 2)

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -2091,6 +2091,7 @@ func TestMergeQueue(t *testing.T) {
 	mtc.Start(t, 2)
 	defer mtc.Stop()
 	store := mtc.Store(0)
+	store.SetMergeQueueActive(true)
 
 	split := func(t *testing.T, key roachpb.Key) {
 		t.Helper()

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -627,6 +627,7 @@ func (m *multiTestContext) makeStoreConfig(i int) storage.StoreConfig {
 	cfg.NodeDialer = m.nodeDialer
 	cfg.Transport = m.transport
 	cfg.Gossip = m.gossips[i]
+	cfg.TestingKnobs.DisableMergeQueue = true
 	cfg.TestingKnobs.DisableSplitQueue = true
 	cfg.TestingKnobs.ReplicateQueueAcceptsUnsplit = true
 	return cfg

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -184,6 +184,11 @@ func (s *Store) SetSplitQueueActive(active bool) {
 	s.setSplitQueueActive(active)
 }
 
+// SetMergeQueueActive enables or disables the split queue.
+func (s *Store) SetMergeQueueActive(active bool) {
+	s.setMergeQueueActive(active)
+}
+
 // SetRaftSnapshotQueueActive enables or disables the raft snapshot queue.
 func (s *Store) SetRaftSnapshotQueueActive(active bool) {
 	s.setRaftSnapshotQueueActive(active)

--- a/pkg/storage/merge_queue.go
+++ b/pkg/storage/merge_queue.go
@@ -49,7 +49,7 @@ const (
 var MergeQueueEnabled = settings.RegisterBoolSetting(
 	"kv.range_merge.queue_enabled",
 	"whether the automatic merge queue is enabled",
-	false,
+	true,
 )
 
 // MergeQueueInterval is a setting that controls how often the merge queue waits

--- a/pkg/storage/merge_queue.go
+++ b/pkg/storage/merge_queue.go
@@ -46,15 +46,11 @@ const (
 
 // MergeQueueEnabled is a setting that controls whether the merge queue is
 // enabled.
-var MergeQueueEnabled = func() *settings.BoolSetting {
-	s := settings.RegisterBoolSetting(
-		"kv.range_merge.queue_enabled",
-		"whether the automatic merge queue is enabled",
-		false,
-	)
-	s.Hide()
-	return s
-}()
+var MergeQueueEnabled = settings.RegisterBoolSetting(
+	"kv.range_merge.queue_enabled",
+	"whether the automatic merge queue is enabled",
+	false,
+)
 
 // MergeQueueInterval is a setting that controls how often the merge queue waits
 // between processing replicas.

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -198,8 +198,10 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, stopper *stop.Stopper,
 		tc.store = NewStore(cfg, tc.engine, &roachpb.NodeDescriptor{NodeID: 1})
 		// Now that we have our actual store, monkey patch the factory used in cfg.DB.
 		factory.setStore(tc.store)
-		// We created the store without a real KV client, so it can't perform splits.
+		// We created the store without a real KV client, so it can't perform splits
+		// or merges.
 		tc.store.splitQueue.SetDisabled(true)
+		tc.store.mergeQueue.SetDisabled(true)
 
 		if tc.repl == nil && tc.bootstrapMode == bootstrapRangeWithMetadata {
 			if err := tc.store.BootstrapRange(nil, cfg.Settings.Version.ServerVersion); err != nil {

--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -183,6 +183,12 @@ func TestReplicateQueueDownReplicate(t *testing.T) {
 			ServerArgs: base.TestServerArgs{
 				ScanMinIdleTime: time.Millisecond,
 				ScanMaxIdleTime: time.Millisecond,
+				Knobs: base.TestingKnobs{
+					Store: &storage.StoreTestingKnobs{
+						// Prevent the merge queue from immediately discarding our splits.
+						DisableMergeQueue: true,
+					},
+				},
 			},
 		},
 	)

--- a/pkg/workload/tpcc/ddls.go
+++ b/pkg/workload/tpcc/ddls.go
@@ -163,6 +163,11 @@ const (
 // NB: Since we always split at the same points (specific warehouse IDs and
 // item IDs), splitting is idempotent.
 func splitTables(db *gosql.DB, warehouses int) {
+	// Prevent the merge queue from immediately discarding our splits.
+	if _, err := db.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false"); err != nil {
+		panic(err)
+	}
+
 	var g errgroup.Group
 	const concurrency = 64
 	sem := make(chan struct{}, concurrency)

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -362,6 +362,11 @@ func Setup(
 
 // Split creates the range splits defined by the given table.
 func Split(ctx context.Context, db *gosql.DB, table Table, concurrency int) error {
+	// Prevent the merge queue from immediately discarding our splits.
+	if _, err := db.Exec(`SET CLUSTER SETTING kv.range_merge.queue_enabled = false`); err != nil {
+		return err
+	}
+
 	if table.Splits.NumBatches <= 0 {
 		return nil
 	}


### PR DESCRIPTION
Flip the bit; burn the boats. (We're not really burning the boats; the last commit here won't get backported unless we're comfortable with merges.)

Release note (sql change): ALTER TABLE ... SPLIT AT now produces an
error if executed while the merge queue is enabled, as the merge queue
is likely to immediately discard any splits created by the statement.

Docs team: the above has implications for the documentation of `ALTER TABLE ... SPLIT AT`. Users are now prevented from splitting a table unless they disable the merge queue with `SET CLUSTER SETTING kv.range_merge.queue_enabled = false`. This is so that users are not confused when their manual splits are immediately merged away by the merge queue. (We're planning to come up with a more user friendly solution to this in v2.2.) They can turn the merge queue back on once they've ensured that their newly split ranges exceed the minimum range size (1MB), guaranteeing that they won't be merged away.