### PR TITLE
engine: use Txn.Timestamp instead of OrigTimestamp for LogLogicalOp

### DIFF
--- a/pkg/storage/engine/mvcc_logical_ops_test.go
+++ b/pkg/storage/engine/mvcc_logical_ops_test.go
@@ -64,7 +64,10 @@ func TestMVCCOpLogWriter(t *testing.T) {
 	if err := MVCCPut(ctx, olDist, nil, localKey, hlc.Timestamp{Logical: 3}, value2, &txn1Seq); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, olDist, nil, testKey2, hlc.Timestamp{Logical: 3}, value3, txn1); err != nil {
+	// Set the txn timestamp to a larger value than the intent.
+	txn1LargerTS := *txn1
+	txn1LargerTS.Timestamp = hlc.Timestamp{Logical: 4}
+	if err := MVCCPut(ctx, olDist, nil, testKey2, hlc.Timestamp{Logical: 3}, value3, &txn1LargerTS); err != nil {
 		t.Fatal(err)
 	}
 	olDist.Close()
@@ -133,7 +136,7 @@ func TestMVCCOpLogWriter(t *testing.T) {
 		makeOp(&enginepb.MVCCWriteIntentOp{
 			TxnID:     txn1.ID,
 			TxnKey:    txn1.Key,
-			Timestamp: hlc.Timestamp{Logical: 3},
+			Timestamp: hlc.Timestamp{Logical: 4},
 		}),
 		makeOp(&enginepb.MVCCCommitIntentOp{
 			TxnID:     txn1.ID,


### PR DESCRIPTION
The `OrigTimestamp` was being used to give a timestamp to the
txn in the logical op log because that is the timestamp the
intent is written at. However, the intent can't actually
commit until its `Timestamp`. This was causing issues with
closed timestamps, which forwards the `Txn.Timestamp` but don't
affect the `OrigTimestamp`. Without this change we were hitting
an assertion in the rangefeed package where a new intent looked
like it was below the resolved timestamp.

Release note: None