### PR TITLE
storage: hook closed timestamps into rangefeed

### DIFF
--- a/pkg/storage/closedts/closedts.go
+++ b/pkg/storage/closedts/closedts.go
@@ -126,6 +126,10 @@ type Producer interface {
 //    to its local storage, so that
 // 4. the CanServe method determines via the the underlying storage whether a
 //    given read can be satisfied via follower reads.
+// 5. the MaxClosed method determines via the underlying storage what the maximum
+//    closed timestamp is for the specified LAI.
+//    TODO(tschottdorf): This is already adding some cruft to this nice interface.
+//    CanServe and MaxClosed are almost identical.
 //
 // Note that a Provider has no duty to immediately persist the local closed
 // timestamps to the underlying storage.
@@ -134,6 +138,7 @@ type Provider interface {
 	Notifyee
 	Start()
 	CanServe(roachpb.NodeID, hlc.Timestamp, roachpb.RangeID, ctpb.Epoch, ctpb.LAI) bool
+	MaxClosed(roachpb.NodeID, roachpb.RangeID, ctpb.Epoch, ctpb.LAI) hlc.Timestamp
 }
 
 // A ClientRegistry is the client component of the follower reads subsystem. It

--- a/pkg/storage/closedts/container/noop.go
+++ b/pkg/storage/closedts/container/noop.go
@@ -78,6 +78,11 @@ func (noopEverything) CanServe(
 ) bool {
 	return false
 }
+func (noopEverything) MaxClosed(
+	roachpb.NodeID, roachpb.RangeID, ctpb.Epoch, ctpb.LAI,
+) hlc.Timestamp {
+	return hlc.Timestamp{}
+}
 func (noopEverything) Request(roachpb.NodeID, roachpb.RangeID) {}
 func (noopEverything) EnsureClient(roachpb.NodeID)             {}
 func (noopEverything) Dial(context.Context, roachpb.NodeID) (ctpb.Client, error) {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2869,11 +2869,11 @@ func (r *Replica) executeReadOnlyBatch(
 		if status, pErr = r.redirectOnOrAcquireLease(ctx); pErr != nil {
 			if lErr, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); ok &&
 				FollowerReadsEnabled.Get(&r.store.cfg.Settings.SV) &&
-				lErr.LeaseHolder != nil && lErr.Lease.Epoch != 0 {
+				lErr.LeaseHolder != nil && lErr.Lease.Type() == roachpb.LeaseEpoch {
 
-				r.mu.Lock()
+				r.mu.RLock()
 				lai := r.mu.state.LeaseAppliedIndex
-				r.mu.Unlock()
+				r.mu.RUnlock()
 				if !r.store.cfg.ClosedTimestamp.Provider.CanServe(
 					lErr.LeaseHolder.NodeID, ba.Timestamp, r.RangeID, ctpb.Epoch(lErr.Lease.Epoch), ctpb.LAI(lai),
 				) {

--- a/pkg/storage/replica_range_lease.go
+++ b/pkg/storage/replica_range_lease.go
@@ -494,11 +494,18 @@ func (r *Replica) leaseStatus(
 	return status
 }
 
-// requiresExpiringLeaseRLocked returns whether this range uses an
-// expiration-based lease; false if epoch-based. Ranges located before or
-// including the node liveness table must use expiration leases to avoid
-// circular dependencies on the node liveness table. The replica mutex must be
-// held.
+// requiresExpiringLease returns whether this range uses an expiration-based
+// lease; false if epoch-based. Ranges located before or including the node
+// liveness table must use expiration leases to avoid circular dependencies on
+// the node liveness table.
+func (r *Replica) requiresExpiringLease() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.requiresExpiringLeaseRLocked()
+}
+
+// requiresExpiringLeaseRLocked is like requiresExpiringLease, but requires that
+// the replica mutex be held.
 func (r *Replica) requiresExpiringLeaseRLocked() bool {
 	return r.store.cfg.NodeLiveness == nil || !r.store.cfg.EnableEpochRangeLeases ||
 		r.mu.state.Desc.StartKey.Less(roachpb.RKey(keys.NodeLivenessKeyMax))

--- a/pkg/storage/replica_rangefeed.go
+++ b/pkg/storage/replica_rangefeed.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
+	"github.com/cockroachdb/cockroach/pkg/storage/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/rangefeed"
@@ -202,6 +203,7 @@ func (r *Replica) maybeInitRangefeedRaftMuLocked() *rangefeed.Processor {
 		EventChanTimeout: 50 * time.Millisecond,
 	}
 	r.raftMu.rangefeed = rangefeed.NewProcessor(cfg)
+	r.store.addReplicaWithRangefeed(r.RangeID)
 
 	// Start it with an iterator to initialize the resolved timestamp.
 	rtsIter := r.Engine().NewIterator(engine.IterOptions{
@@ -216,10 +218,16 @@ func (r *Replica) maybeInitRangefeedRaftMuLocked() *rangefeed.Processor {
 	})
 	r.raftMu.rangefeed.Start(r.store.Stopper(), rtsIter)
 
-	// TODO(nvanbenschoten): forward the rangefeed's closed timestamp if the
-	// range has established a closed timestamp.
-	// r.raftMu.rangefeed.ForwardClosedTS(r.ClosedTimestamp)
+	// Check for an initial closed timestamp update immediately to help
+	// initialize the rangefeed's resolved timestamp as soon as possible.
+	r.handleClosedTimestampUpdateRaftMuLocked()
+
 	return r.raftMu.rangefeed
+}
+
+func (r *Replica) resetRangefeedRaftMuLocked() {
+	r.raftMu.rangefeed = nil
+	r.store.removeReplicaWithRangefeed(r.RangeID)
 }
 
 // maybeDestroyRangefeedRaftMuLocked tears down the provided Processor if it is
@@ -231,7 +239,7 @@ func (r *Replica) maybeDestroyRangefeedRaftMuLocked(p *rangefeed.Processor) {
 	}
 	if r.raftMu.rangefeed.Len() == 0 {
 		r.raftMu.rangefeed.Stop()
-		r.raftMu.rangefeed = nil
+		r.resetRangefeedRaftMuLocked()
 	}
 }
 
@@ -243,7 +251,7 @@ func (r *Replica) disconnectRangefeedWithErrRaftMuLocked(pErr *roachpb.Error) {
 		return
 	}
 	r.raftMu.rangefeed.StopWithErr(pErr)
-	r.raftMu.rangefeed = nil
+	r.resetRangefeedRaftMuLocked()
 }
 
 // disconnectRangefeedWithReasonRaftMuLocked broadcasts the provided rangefeed
@@ -328,6 +336,42 @@ func (r *Replica) handleLogicalOpLogRaftMuLocked(
 	// Pass the ops to the rangefeed processor.
 	if !r.raftMu.rangefeed.ConsumeLogicalOps(ops.Ops...) {
 		// Consumption failed and the rangefeed was stopped.
-		r.raftMu.rangefeed = nil
+		r.resetRangefeedRaftMuLocked()
+	}
+}
+
+// handleClosedTimestampUpdate determines the current maximum closed timestamp
+// for the replica and informs the rangefeed, if one is running. No-op if a
+// rangefeed is not active.
+func (r *Replica) handleClosedTimestampUpdate() {
+	r.raftMu.Lock()
+	defer r.raftMu.Unlock()
+	r.handleClosedTimestampUpdateRaftMuLocked()
+}
+
+// handleClosedTimestampUpdateRaftMuLocked is like handleClosedTimestampUpdate,
+// but it requires raftMu to be locked.
+func (r *Replica) handleClosedTimestampUpdateRaftMuLocked() {
+	if r.raftMu.rangefeed == nil {
+		return
+	}
+
+	r.mu.RLock()
+	lai := r.mu.state.LeaseAppliedIndex
+	lease := *r.mu.state.Lease
+	r.mu.RUnlock()
+
+	// Determine what the maximum closed timestamp is for this replica.
+	closedTS := r.store.cfg.ClosedTimestamp.Provider.MaxClosed(
+		lease.Replica.NodeID, r.RangeID, ctpb.Epoch(lease.Epoch), ctpb.LAI(lai),
+	)
+
+	// If the closed timestamp is not empty, inform the Processor.
+	if closedTS.IsEmpty() {
+		return
+	}
+	if !r.raftMu.rangefeed.ForwardClosedTS(closedTS) {
+		// Consumption failed and the rangefeed was stopped.
+		r.resetRangefeedRaftMuLocked()
 	}
 }


### PR DESCRIPTION
Closes #28912.

This change hooks up closed timestamps into rangefeed. It does
so by creating a new closed timestamp subscription and notifying
all ranges with active rangefeed when new closed timestamp entries
arrive. This triggers each rangefeed to check for the maximum closed
timestamp on its range and use this to attempt to move its resolved
timestamp forward.

Eventually this will need some testing tied in with the closedts
package. That will have to wait until the closedts package is set
up to be more easily used in tests from the storage package (right
now `NoopContainer`s are used in tests everywhere). For now, we can
wait for integration testing with cdc.

With this change and the changes it depends on, rangefeeds are sufficiently
feature-complete to be used for changefeeds. For instance, with a few small
tweaks, we pass 6 changefeed unit tests in `./pkg/ccl/changefeedccl` with
`kv.rangefeed.enabled` set to true.

Release note: None