### PR TITLE
storage: misc logging improvements

### DIFF
--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -853,7 +853,6 @@ func (bq *baseQueue) addToPurgatoryLocked(
 					for _, id := range ranges {
 						repl, err := bq.store.GetReplica(id)
 						if err != nil {
-							log.Errorf(ctx, "range %s no longer exists on store: %s", id, err)
 							continue
 						}
 						annotatedCtx := repl.AnnotateCtx(ctx)

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1047,6 +1047,7 @@ func RelocateRange(
 		return false
 	}
 
+	every := log.Every(time.Minute)
 	for len(addTargets) > 0 {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -1060,7 +1061,9 @@ func RelocateRange(
 			if !canRetry(err) {
 				return returnErr
 			}
-			log.Warning(ctx, returnErr)
+			if every.ShouldLog() {
+				log.Warning(ctx, returnErr)
+			}
 			continue
 		}
 		addTargets = addTargets[1:]

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -460,6 +460,10 @@ type OutgoingSnapshot struct {
 	snapType       string
 }
 
+func (s *OutgoingSnapshot) String() string {
+	return fmt.Sprintf("%s snapshot %s at applied index %d", s.snapType, s.SnapUUID.Short(), s.State.RaftAppliedIndex)
+}
+
 // Close releases the resources associated with the snapshot.
 func (s *OutgoingSnapshot) Close() {
 	s.Iter.Close()
@@ -535,8 +539,6 @@ func snapshot(
 	iter := rditer.NewReplicaDataIterator(&desc, snap, true /* replicatedOnly */)
 	snapUUID := uuid.MakeV4()
 
-	log.Infof(ctx, "generated %s snapshot %s at index %d",
-		snapType, snapUUID.Short(), appliedIndex)
 	return OutgoingSnapshot{
 		RaftEntryCache: eCache,
 		WithSideloaded: withSideloaded,

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -595,22 +595,24 @@ func sendSnapshot(
 			if len(resp.Message) > 0 {
 				declinedMsg = resp.Message
 			}
-			return errors.Errorf("%s: remote declined snapshot: %s", to, declinedMsg)
+			return errors.Errorf("%s: remote declined %s: %s", to, snap, declinedMsg)
 		}
 		storePool.throttle(throttleFailed, to.StoreID)
-		return errors.Errorf("%s: programming error: remote declined required snapshot: %s",
-			to, resp.Message)
+		return errors.Errorf("%s: programming error: remote declined required %s: %s",
+			to, snap, resp.Message)
 	case SnapshotResponse_ERROR:
 		storePool.throttle(throttleFailed, to.StoreID)
-		return errors.Errorf("%s: remote couldn't accept snapshot with error: %s",
-			to, resp.Message)
+		return errors.Errorf("%s: remote couldn't accept %s with error: %s",
+			to, snap, resp.Message)
 	case SnapshotResponse_ACCEPTED:
 	// This is the response we're expecting. Continue with snapshot sending.
 	default:
 		storePool.throttle(throttleFailed, to.StoreID)
-		return errors.Errorf("%s: server sent an invalid status during negotiation: %s",
-			to, resp.Status)
+		return errors.Errorf("%s: server sent an invalid status while negotiating %s: %s",
+			to, snap, resp.Status)
 	}
+
+	log.Infof(ctx, "sending %s", snap)
 
 	// The size of batches to send. This is the granularity of rate limiting.
 	const batchSize = 256 << 10 // 256 KB


### PR DESCRIPTION
Got confused by this message in #28995. Prior to this
commit on a merge it looks like the subsuming range is
removing itself, but it's actually the subsumee.

Release note: None