### PR TITLE
release-2.1: opt: do not inline expressions in correlated subquery

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1059,15 +1059,20 @@ func (b *logicalPropsBuilder) buildScalarProps(ev ExprView) props.Logical {
 		return logical
 	}
 
-	// By default, derive OuterCols and CanHaveSideEffects from all children, both
-	// relational and scalar.
-	for i, end := 0, ev.ChildCount(); i < end; i++ {
+	// By default, derive OuterCols and CanHaveSideEffects from all children,
+	// both relational and scalar. Derive HasCorrelatedSubquery from scalar
+	// children.
+	for i, n := 0, ev.ChildCount(); i < n; i++ {
 		childLogical := &ev.childGroup(i).logical
 
 		scalar.OuterCols.UnionWith(childLogical.OuterCols())
 
 		if childLogical.CanHaveSideEffects() {
 			scalar.CanHaveSideEffects = true
+		}
+
+		if childLogical.Scalar != nil && childLogical.Scalar.HasCorrelatedSubquery {
+			scalar.HasCorrelatedSubquery = true
 		}
 	}
 
@@ -1114,12 +1119,17 @@ func (b *logicalPropsBuilder) buildScalarProps(ev ExprView) props.Logical {
 		funcOpDef := ev.Private().(*FuncOpDef)
 		if funcOpDef.Properties.Impure {
 			// Impure functions can return different value on each call.
-			logical.Scalar.CanHaveSideEffects = true
+			scalar.CanHaveSideEffects = true
 		}
 
 	case opt.DivOp:
 		// Division by zero error is possible.
-		logical.Scalar.CanHaveSideEffects = true
+		scalar.CanHaveSideEffects = true
+
+	case opt.SubqueryOp, opt.ExistsOp, opt.AnyOp:
+		if !scalar.OuterCols.Empty() {
+			scalar.HasCorrelatedSubquery = true
+		}
 	}
 
 	return logical

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -346,6 +346,12 @@ func (c *CustomFuncs) CanHaveZeroRows(group memo.GroupID) bool {
 	return c.mem.GroupProperties(group).Relational.Cardinality.CanBeZero()
 }
 
+// HasCorrelatedSubquery returns true if the given scalar group contains a
+// subquery within its subtree that has at least one outer column.
+func (c *CustomFuncs) HasCorrelatedSubquery(group memo.GroupID) bool {
+	return c.LookupScalar(group).HasCorrelatedSubquery
+}
+
 // ----------------------------------------------------------------------
 //
 // Private extraction functions

--- a/pkg/sql/opt/norm/decorrelate.go
+++ b/pkg/sql/opt/norm/decorrelate.go
@@ -28,8 +28,14 @@ import (
 // subquery needs to be hoisted up into its parent query as part of query
 // decorrelation.
 func (c *CustomFuncs) HasHoistableSubquery(group memo.GroupID) bool {
-	// Lazily calculate and store the HasHoistableSubquery value.
+	// Don't bother traversing the expression tree if there is no correlated
+	// subquery.
 	scalar := c.LookupScalar(group)
+	if !scalar.HasCorrelatedSubquery {
+		return false
+	}
+
+	// Lazily calculate and store the HasHoistableSubquery value.
 	if scalar.IsAvailable(props.HasHoistableSubquery) {
 		return scalar.Rule.HasHoistableSubquery
 	}

--- a/pkg/sql/opt/norm/inline.go
+++ b/pkg/sql/opt/norm/inline.go
@@ -25,13 +25,20 @@ import (
 //
 //   SELECT x+1, x+2, y FROM a
 //
-// hasDuplicateRefs would be true for the Projections expression, since the x
+// HasDuplicateRefs would be true for the Projections expression, since the x
 // column is referenced twice.
 //
 // Correlated subqueries are disallowed since it introduces additional
 // complexity for a case that's not important for inlining (correlated
 // subqueries are hoisted to a higher context anyway).
 func (c *CustomFuncs) HasDuplicateRefs(target memo.GroupID) bool {
+	// Don't bother traversing the expression tree if there is a correlated
+	// subquery.
+	scalar := c.LookupScalar(target)
+	if scalar.HasCorrelatedSubquery {
+		return true
+	}
+
 	var refs opt.ColSet
 
 	// When a column reference is found, add it to the refs set. If the set
@@ -41,9 +48,10 @@ func (c *CustomFuncs) HasDuplicateRefs(target memo.GroupID) bool {
 	findDupRefs = func(group memo.GroupID) bool {
 		expr := c.f.mem.NormExpr(group)
 		if !expr.IsScalar() {
-			// Don't try to count references within correlated subqueries.
+			// We know that this is not a correlated subquery since
+			// scalar.HasCorrelatedSubquery was already checked above.
 			// Uncorrelated subqueries never have references.
-			return !c.OuterCols(group).Empty()
+			return false
 		}
 
 		switch expr.Operator() {
@@ -116,7 +124,7 @@ func (c *CustomFuncs) InlineProjections(target, projections memo.GroupID) memo.G
 		expr := c.f.mem.NormExpr(child)
 		if !expr.IsScalar() {
 			if !c.OuterCols(child).Empty() {
-				// Should have prevented this in hasDuplicateRefs/canInline.
+				// Should have prevented this in HasDuplicateRefs/HasCorrelatedSubquery.
 				panic("cannot inline references within correlated subqueries")
 			}
 			return child

--- a/pkg/sql/opt/norm/rules/inline.opt
+++ b/pkg/sql/opt/norm/rules/inline.opt
@@ -35,7 +35,7 @@
         $input:*
         $projections:* & (CanInline $projections)
     )
-    $filter:*
+    $filter:* & ^(HasCorrelatedSubquery $filter)
 )
 =>
 (Project

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -118,6 +118,118 @@ semi-join
  └── filters [type=bool, outer=(2,6)]
       └── (x - i) > (i * i) [type=bool, outer=(2,6)]
 
+exec-ddl
+CREATE TABLE crdb_internal.zones (
+    zone_id INT NOT NULL,
+    cli_specifier STRING NULL,
+    config_yaml BYTES NOT NULL,
+    config_protobuf BYTES NOT NULL
+)
+----
+TABLE zones
+ ├── zone_id int not null
+ ├── cli_specifier string
+ ├── config_yaml bytes not null
+ ├── config_protobuf bytes not null
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+# Regression test for #28827. Ensure that inlining is not applied when there
+# is a correlated subquery in the filter.
+norm
+SELECT
+  subq_0.c0 AS c0
+FROM (SELECT 1 AS c0, 2 as c1) AS subq_0
+WHERE
+  1
+  >= CASE
+    WHEN subq_0.c1 IS NOT NULL
+    THEN pg_catalog.extract(
+      CAST(
+        CASE
+        WHEN
+        (
+            EXISTS(
+              SELECT
+                ref_1.config_yaml AS c0,
+                ref_1.config_yaml AS c1,
+                subq_0.c0 AS c2,
+                ref_1.config_yaml AS c3
+              FROM
+                crdb_internal.zones AS ref_1
+              WHERE
+                subq_0.c0 IS NOT NULL
+              LIMIT
+                52
+            )
+          )
+        THEN pg_catalog.version()
+        ELSE pg_catalog.version()
+        END
+          AS TEXT
+      ),
+      CAST(pg_catalog.current_date() AS DATE)
+    )
+    ELSE 1
+    END
+LIMIT
+  107
+----
+project
+ ├── columns: c0:1(int!null)
+ ├── cardinality: [0 - 1]
+ ├── side-effects
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── select
+      ├── columns: c0:1(int!null) c1:2(int!null)
+      ├── cardinality: [0 - 1]
+      ├── side-effects
+      ├── key: ()
+      ├── fd: ()-->(1,2)
+      ├── project
+      │    ├── columns: c0:1(int!null) c1:2(int!null)
+      │    ├── cardinality: [1 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(1,2)
+      │    ├── values
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── key: ()
+      │    │    └── tuple [type=tuple]
+      │    └── projections
+      │         ├── const: 1 [type=int]
+      │         └── const: 2 [type=int]
+      └── filters [type=bool, outer=(1,2), side-effects]
+           └── le [type=bool, outer=(1,2), side-effects]
+                ├── case [type=int, outer=(1,2), side-effects]
+                │    ├── true [type=bool]
+                │    ├── when [type=int, outer=(1,2), side-effects]
+                │    │    ├── c1 IS NOT NULL [type=bool, outer=(2)]
+                │    │    └── function: extract [type=int, outer=(1), side-effects]
+                │    │         ├── cast: TEXT [type=string, outer=(1)]
+                │    │         │    └── case [type=string, outer=(1)]
+                │    │         │         ├── true [type=bool]
+                │    │         │         ├── when [type=string, outer=(1)]
+                │    │         │         │    ├── exists [type=bool, outer=(1)]
+                │    │         │         │    │    └── limit
+                │    │         │         │    │         ├── columns: config_yaml:5(bytes!null)
+                │    │         │         │    │         ├── outer: (1)
+                │    │         │         │    │         ├── cardinality: [0 - 52]
+                │    │         │         │    │         ├── select
+                │    │         │         │    │         │    ├── columns: config_yaml:5(bytes!null)
+                │    │         │         │    │         │    ├── outer: (1)
+                │    │         │         │    │         │    ├── scan zones
+                │    │         │         │    │         │    │    └── columns: config_yaml:5(bytes!null)
+                │    │         │         │    │         │    └── filters [type=bool, outer=(1), constraints=(/1: (/NULL - ]; tight)]
+                │    │         │         │    │         │         └── c0 IS NOT NULL [type=bool, outer=(1), constraints=(/1: (/NULL - ]; tight)]
+                │    │         │         │    │         └── const: 52 [type=int]
+                │    │         │         │    └── function: version [type=string]
+                │    │         │         └── function: version [type=string]
+                │    │         └── function: current_date [type=date, side-effects]
+                │    └── const: 1 [type=int]
+                └── const: 1 [type=int]
+
 # --------------------------------------------------
 # InlineProjectInProject
 # --------------------------------------------------

--- a/pkg/sql/opt/props/logical.go
+++ b/pkg/sql/opt/props/logical.go
@@ -262,6 +262,14 @@ type Scalar struct {
 	// comment for Logical.CanHaveSideEffects.
 	CanHaveSideEffects bool
 
+	// HasCorrelatedSubquery is true if the scalar expression tree contains a
+	// subquery having one or more outer columns. The subquery can be a Subquery,
+	// Exists, or Any operator. These operators need to be hoisted out of scalar
+	// expression trees and turned into top-level apply joins. This property makes
+	// detection fast and easy so that the hoister doesn't waste time searching
+	// subtrees that don't contain subqueries.
+	HasCorrelatedSubquery bool
+
 	// Constraints is the set of constraints deduced from a boolean expression.
 	// For the expression to be true, all constraints in the set must be
 	// satisfied.


### PR DESCRIPTION
Backport 1/1 commits from #28861.

/cc @cockroachdb/release

---

This commit fixes a bug in which expressions could be inlined
in a correlated subquery, causing a panic. Now there is an
explicit check for correlated subqueries in the rule
`PushSelectIntoInlinableProject`.

Fixes #28827

Release note: None
