### PR TITLE
cli: add option to also write client key in PKCS#8 format.

### DIFF
--- a/pkg/acceptance/cluster/certs.go
+++ b/pkg/acceptance/cluster/certs.go
@@ -42,19 +42,11 @@ func GenerateCerts(ctx context.Context) func() {
 
 	maybePanic(security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, 48*time.Hour, false, security.RootUser))
+		512, 48*time.Hour, false, security.RootUser, true /* generate pk8 key */))
 
 	maybePanic(security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, 48*time.Hour, false, "testuser"))
-
-	// Store a copy of the client private key in PKCS#8 format, which is
-	// the only format understood by PgJDBC (Java).
-	{
-		execCmd("openssl", "pkcs8", "-topk8", "-outform", "DER", "-nocrypt",
-			"-in", filepath.Join(certsDir, "client.root.key"),
-			"-out", filepath.Join(certsDir, "client.root.pk8"))
-	}
+		512, 48*time.Hour, false, "testuser", true /* generate pk8 key */))
 
 	// Store a copy of the client certificate and private key in a PKCS#12
 	// bundle, which is the only format understood by Npgsql (.NET).

--- a/pkg/acceptance/testdata/java/src/main/java/CockroachDBTest.java
+++ b/pkg/acceptance/testdata/java/src/main/java/CockroachDBTest.java
@@ -33,7 +33,7 @@ public abstract class CockroachDBTest {
         if (System.getenv("PGSSLCERT") != null) {
             DBUrl += "?ssl=true";
             DBUrl += "&sslcert=" + System.getenv("PGSSLCERT");
-            DBUrl += "&sslkey=/certs/client.root.pk8";
+            DBUrl += "&sslkey=/certs/client.root.key.pk8";
             DBUrl += "&sslrootcert=/certs/ca.crt";
             DBUrl += "&sslfactory=org.postgresql.ssl.jdbc4.LibPQFactory";
         } else {

--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -38,6 +38,7 @@ var caCertificateLifetime time.Duration
 var certificateLifetime time.Duration
 var allowCAKeyReuse bool
 var overwriteFiles bool
+var generatePKCS8Key bool
 
 // A createCACert command generates a CA certificate and stores it
 // in the cert directory.
@@ -187,7 +188,8 @@ func runCreateClientCert(cmd *cobra.Command, args []string) error {
 			keySize,
 			certificateLifetime,
 			overwriteFiles,
-			username),
+			username,
+			generatePKCS8Key),
 		"failed to generate client certificate and key")
 }
 

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -471,6 +471,11 @@ a public network without combining it with --listen-addr.`,
 		Description: `Certificate and key files are overwritten if they exist.`,
 	}
 
+	GeneratePKCS8Key = FlagInfo{
+		Name:        "also-generate-pkcs8-key",
+		Description: `Also write the key in pkcs8 format to <certs-dir>/client.<username>.key.pk8.`,
+	}
+
 	Password = FlagInfo{
 		Name:        "password",
 		Description: `Prompt for the new user's password.`,

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -346,6 +346,8 @@ func init() {
 		IntFlag(f, &keySize, cliflags.KeySize, defaultKeySize)
 		BoolFlag(f, &overwriteFiles, cliflags.OverwriteFiles, false)
 	}
+	// PKCS8 key format is only available for the client cert command.
+	BoolFlag(createClientCertCmd.Flags(), &generatePKCS8Key, cliflags.GeneratePKCS8Key, false)
 
 	BoolFlag(setUserCmd.Flags(), &password, cliflags.Password, false)
 

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -170,7 +170,7 @@ func generateBaseCerts(certsDir string) error {
 
 	if err := security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, time.Hour*48, true, security.RootUser,
+		512, time.Hour*48, true, security.RootUser, false,
 	); err != nil {
 		return errors.Errorf("could not generate Client pair: %v", err)
 	}
@@ -208,14 +208,14 @@ func generateSplitCACerts(certsDir string) error {
 
 	if err := security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedClientCAKey),
-		512, time.Hour*48, true, security.NodeUser,
+		512, time.Hour*48, true, security.NodeUser, false,
 	); err != nil {
 		return errors.Errorf("could not generate Client pair: %v", err)
 	}
 
 	if err := security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedClientCAKey),
-		512, time.Hour*48, true, security.RootUser,
+		512, time.Hour*48, true, security.RootUser, false,
 	); err != nil {
 		return errors.Errorf("could not generate Client pair: %v", err)
 	}

--- a/pkg/security/pem.go
+++ b/pkg/security/pem.go
@@ -20,6 +20,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"io"
 	"os"
 	"strings"
 
@@ -30,7 +31,7 @@ import (
 // The file "path" is created with "mode" and WRONLY|CREATE.
 // If overwrite is true, the file will be overwritten if it exists.
 func WritePEMToFile(path string, mode os.FileMode, overwrite bool, blocks ...*pem.Block) error {
-	flags := os.O_WRONLY | os.O_CREATE
+	flags := os.O_WRONLY | os.O_CREATE | os.O_TRUNC
 	if !overwrite {
 		flags |= os.O_EXCL
 	}
@@ -48,6 +49,29 @@ func WritePEMToFile(path string, mode os.FileMode, overwrite bool, blocks ...*pe
 	return f.Close()
 }
 
+// SafeWriteToFile writes the passed-in bytes to a file.
+// The file "path" is created with "mode" and WRONLY|CREATE.
+// If overwrite is true, the file will be overwritten if it exists.
+func SafeWriteToFile(path string, mode os.FileMode, overwrite bool, contents []byte) error {
+	flags := os.O_WRONLY | os.O_CREATE | os.O_TRUNC
+	if !overwrite {
+		flags |= os.O_EXCL
+	}
+	f, err := os.OpenFile(path, flags, mode)
+	if err != nil {
+		return err
+	}
+
+	n, err := f.Write(contents)
+	if err == nil && n < len(contents) {
+		err = io.ErrShortWrite
+	}
+	if err1 := f.Close(); err == nil {
+		err = err1
+	}
+	return err
+}
+
 // PrivateKeyToPEM generates a PEM block from a private key.
 func PrivateKeyToPEM(key crypto.PrivateKey) (*pem.Block, error) {
 	switch k := key.(type) {
@@ -62,6 +86,11 @@ func PrivateKeyToPEM(key crypto.PrivateKey) (*pem.Block, error) {
 	default:
 		return nil, errors.Errorf("unknown key type: %v", k)
 	}
+}
+
+// PrivateKeyToPKCS8 encodes a private key into PKCS#8.
+func PrivateKeyToPKCS8(key crypto.PrivateKey) ([]byte, error) {
+	return x509.MarshalPKCS8PrivateKey(key)
 }
 
 // PEMToCertificates parses multiple certificate PEM blocks and returns them.


### PR DESCRIPTION
This is useful for java which does not understand PKCS#1 in PEM format.
This does not change the format of the `client.<username>.key` file but
writes an additional file named `client.<username>.key.pk8`.

Removed `openssl` command to convert key to PKCS#8 in java acceptance
test.

Release note (cli change): add option to write client key in PKCS#8
format.