### PR TITLE
backport-2.1: workload/tpcc: Fix index-out-of-range panic

### DIFF
--- a/pkg/workload/tpcc/order_status.go
+++ b/pkg/workload/tpcc/order_status.go
@@ -109,12 +109,13 @@ func (o orderStatus) run(
 				if config.usePostgres {
 					indexStr = ""
 				}
-				rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+				queryStr := fmt.Sprintf(`
 					SELECT c_id, c_balance, c_first, c_middle
 					FROM customer%[1]s
 					WHERE c_w_id = %[2]d AND c_d_id = %[3]d AND c_last = '%[4]s'
-					ORDER BY c_first ASC`, indexStr,
-					wID, d.dID, d.cLast))
+					ORDER BY c_first ASC`,
+					indexStr, wID, d.dID, d.cLast)
+				rows, err := tx.QueryContext(ctx, queryStr)
 				if err != nil {
 					return errors.Wrap(err, "select by last name fail")
 				}
@@ -132,6 +133,9 @@ func (o orderStatus) run(
 					return err
 				}
 				rows.Close()
+				if len(customers) == 0 {
+					return fmt.Errorf("found no customers matching query: %s", queryStr)
+				}
 				cIdx := len(customers) / 2
 				if len(customers)%2 == 0 {
 					cIdx--


### PR DESCRIPTION
Backport 1/1 commits from #28989.

/cc @cockroachdb/release

---

I'm not sure whether this suggests something is broken with our tpc-c
implementation, our test fixtures, or cockroach itself, but I've seen
panics caused by the customers slice being empty a couple times now.
How unexpected is this?

Release note: None

---

Given that tpcc is now being shipped as part of the cockroach binary (https://github.com/cockroachdb/cockroach/pull/28978), fixing a crash in it seems backport-worthy.