### PR TITLE
sql: put rendered setting value in event log entry

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -329,19 +329,26 @@ SET CLUSTER SETTING kv.allocator.load_based_lease_rebalancing.enabled = false
 statement ok
 SET CLUSTER SETTING kv.allocator.load_based_lease_rebalancing.enabled = DEFAULT
 
+statement ok
+PREPARE set_setting AS SET CLUSTER SETTING cluster.organization = $1
+
+statement ok
+EXECUTE set_setting('some string')
+
 # verify setting changes are logged
 ##################
 query IIT
 SELECT "targetID", "reportingID", "info"
 FROM system.eventlog
-WHERE "eventType" = 'set_cluster_setting' AND info NOT LIKE '%version%' AND info NOT LIKE '%sql.defaults.distsql%'
+WHERE "eventType" = 'set_cluster_setting'
+AND info NOT LIKE '%version%' AND info NOT LIKE '%sql.defaults.distsql%' AND info NOT LIKE '%cluster.secret%'
 ORDER BY "timestamp"
 ----
 0  1  {"SettingName":"diagnostics.reporting.enabled","Value":"true","User":"root"}
 0  1  {"SettingName":"trace.debug.enable","Value":"false","User":"root"}
-0  1  {"SettingName":"cluster.secret","Value":"gen_random_uuid()::STRING","User":"root"}
 0  1  {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"false","User":"root"}
 0  1  {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"DEFAULT","User":"root"}
+0  1  {"SettingName":"cluster.organization","Value":"'some string'","User":"root"}
 
 # Set and unset zone configs
 ##################


### PR DESCRIPTION
previously we'd include the pre-rendered expression, which is particularly useless with placeholders.

Fixes #28992.

Release note: none.