### PR TITLE
roachpb: fix RangeDescriptor generation counter printing

### DIFF
--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -199,7 +199,7 @@ func (r RangeDescriptor) String() string {
 	} else {
 		buf.WriteString("<no replicas>")
 	}
-	fmt.Fprintf(&buf, ", next=%d, gen=%d]", r.NextReplicaID, r.Generation)
+	fmt.Fprintf(&buf, ", next=%d, gen=%d]", r.NextReplicaID, r.GetGeneration())
 
 	return buf.String()
 }


### PR DESCRIPTION
The code was printing a `*int64` via `%d` which gives you the
address.

Release note: None