### PR TITLE
sql: reduce number of places where skipCache is set

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -519,7 +519,7 @@ func importPlanHook(
 		} else {
 			// No target table means we're importing whatever we find into the session
 			// database, so it must exist.
-			dbDesc, err := sql.ResolveDatabase(ctx, p, p.SessionData().Database, true /*required*/)
+			dbDesc, err := p.ResolveUncachedDatabaseByName(ctx, p.SessionData().Database, true /*required*/)
 			if err != nil {
 				return errors.Wrap(err, "could not resolve current database")
 			}

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -34,12 +34,7 @@ func (p *planner) AlterSequence(ctx context.Context, n *tree.AlterSequence) (pla
 		return nil, err
 	}
 
-	var seqDesc *TableDescriptor
-	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
-	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		seqDesc, err = ResolveExistingObject(ctx, p, tn, !n.IfExists, requireSequenceDesc)
-	})
+	seqDesc, err := p.ResolveMutableTableDescriptor(ctx, tn, !n.IfExists, requireSequenceDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -265,7 +265,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				}
 				descriptorChanged = true
 				for _, updated := range affected {
-					if err := params.p.saveNonmutationAndNotify(params.ctx, updated); err != nil {
+					if err := params.p.writeSchemaChange(params.ctx, updated, sqlbase.InvalidMutationID); err != nil {
 						return err
 					}
 				}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -129,12 +129,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			// If the new column has a DEFAULT expression that uses a sequence, add references between
 			// its descriptor and this column descriptor.
 			if d.HasDefaultExpr() {
-				var changedSeqDescs []*TableDescriptor
-				// DDL statements use uncached descriptors, and can view newly added things.
-				// TODO(vivek): check if the cache can be used.
-				params.p.runWithOptions(resolveFlags{skipCache: true}, func() {
-					changedSeqDescs, err = maybeAddSequenceDependencies(params.p, n.tableDesc, col, expr, params.EvalContext())
-				})
+				changedSeqDescs, err := maybeAddSequenceDependencies(params.p, n.tableDesc, col, expr, params.EvalContext())
 				if err != nil {
 					return err
 				}
@@ -742,13 +737,7 @@ func applyColumnMutation(
 			col.DefaultExpr = &s
 
 			// Add references to the sequence descriptors this column is now using.
-
-			// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
-			// TODO(vivek): check if the cache can be used.
-			var changedSeqDescs []*TableDescriptor
-			params.p.runWithOptions(resolveFlags{skipCache: true}, func() {
-				changedSeqDescs, err = maybeAddSequenceDependencies(params.p, tableDesc, col, expr, params.EvalContext())
-			})
+			changedSeqDescs, err := maybeAddSequenceDependencies(params.p, tableDesc, col, expr, params.EvalContext())
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -54,12 +54,7 @@ func (p *planner) AlterTable(ctx context.Context, n *tree.AlterTable) (planNode,
 		return nil, err
 	}
 
-	var tableDesc *TableDescriptor
-	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
-	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		tableDesc, err = ResolveExistingObject(ctx, p, tn, !n.IfExists, requireTableDesc)
-	})
+	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, tn, !n.IfExists, requireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -206,7 +206,8 @@ func (sc *SchemaChanger) runBackfill(
 func (sc *SchemaChanger) getTableVersion(
 	ctx context.Context, txn *client.Txn, tc *TableCollection, version sqlbase.DescriptorVersion,
 ) (*sqlbase.TableDescriptor, error) {
-	tableDesc, err := tc.getTableVersionByID(ctx, txn, sc.tableID)
+	flags := ObjectLookupFlags{CommonLookupFlags{txn: txn}}
+	tableDesc, err := tc.getTableVersionByID(ctx, sc.tableID, flags)
 	if err != nil {
 		return nil, err
 	}
@@ -485,8 +486,10 @@ func (sc *SchemaChanger) distBackfill(
 				if err != nil {
 					return err
 				}
+
+				flags := ObjectLookupFlags{CommonLookupFlags{txn: txn}}
 				for k := range fkTables {
-					table, err := tc.getTableVersionByID(ctx, txn, k)
+					table, err := tc.getTableVersionByID(ctx, k, flags)
 					if err != nil {
 						return err
 					}

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -39,12 +39,7 @@ func (p *planner) CreateIndex(ctx context.Context, n *tree.CreateIndex) (planNod
 		return nil, err
 	}
 
-	var tableDesc *TableDescriptor
-	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
-	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		tableDesc, err = ResolveExistingObject(ctx, p, tn, true /*required*/, requireTableDesc)
-	})
+	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, tn, true /*required*/, requireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -37,10 +37,7 @@ func (p *planner) CreateSequence(ctx context.Context, n *tree.CreateSequence) (p
 		return nil, err
 	}
 
-	var dbDesc *DatabaseDescriptor
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		dbDesc, err = ResolveTargetObject(ctx, p, name)
-	})
+	dbDesc, err := p.ResolveUncachedDatabase(ctx, name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -53,10 +53,7 @@ func (p *planner) CreateTable(ctx context.Context, n *tree.CreateTable) (planNod
 		return nil, err
 	}
 
-	var dbDesc *DatabaseDescriptor
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		dbDesc, err = ResolveTargetObject(ctx, p, tn)
-	})
+	dbDesc, err := p.ResolveUncachedDatabase(ctx, tn)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -165,7 +165,7 @@ func (n *createViewNode) startExec(params runParams) error {
 			dep.ID = desc.ID
 			backrefDesc.DependedOnBy = append(backrefDesc.DependedOnBy, dep)
 		}
-		if err := params.p.saveNonmutationAndNotify(params.ctx, &backrefDesc); err != nil {
+		if err := params.p.writeSchemaChange(params.ctx, &backrefDesc, sqlbase.InvalidMutationID); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -87,7 +87,14 @@ func (p *planner) CreateView(ctx context.Context, n *tree.CreateView) (planNode,
 		return nil, fmtErr
 	}
 
-	planDeps, sourceColumns, err := p.analyzeViewQuery(ctx, n.AsSource)
+	var planDeps planDependencies
+	var sourceColumns sqlbase.ResultColumns
+	// To avoid races with ongoing schema changes to tables that the view
+	// depends on, make sure we use the most recent versions of table
+	// descriptors rather than the copies in the lease cache.
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
+		planDeps, sourceColumns, err = p.analyzeViewQuery(ctx, n.AsSource)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -48,10 +48,7 @@ func (p *planner) CreateView(ctx context.Context, n *tree.CreateView) (planNode,
 		return nil, err
 	}
 
-	var dbDesc *DatabaseDescriptor
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		dbDesc, err = ResolveTargetObject(ctx, p, name)
-	})
+	dbDesc, err := p.ResolveUncachedDatabase(ctx, name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -52,11 +52,7 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 	}
 
 	// Check that the database exists.
-	var dbDesc *DatabaseDescriptor
-	var err error
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		dbDesc, err = ResolveDatabase(ctx, p, string(n.Name), !n.IfExists)
-	})
+	dbDesc, err := p.ResolveUncachedDatabaseByName(ctx, string(n.Name), !n.IfExists)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -39,14 +39,7 @@ func (p *planner) DropIndex(ctx context.Context, n *tree.DropIndex) (planNode, e
 	// don't exist and continue execution.
 	idxNames := make([]fullIndexName, 0, len(n.IndexList))
 	for _, index := range n.IndexList {
-		var tn *tree.TableName
-		var tableDesc *TableDescriptor
-		var err error
-		// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
-		// TODO(vivek): check if the cache can be used.
-		p.runWithOptions(resolveFlags{skipCache: true}, func() {
-			tn, tableDesc, err = expandIndexName(ctx, p, index, !n.IfExists /* requireTable */)
-		})
+		tn, tableDesc, err := expandMutableIndexName(ctx, p, index, !n.IfExists /* requireTable */)
 		if err != nil {
 			// Error or table did not exist.
 			return nil, err

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -72,12 +72,8 @@ func (n *dropIndexNode) startExec(params runParams) error {
 		// the list: when two or more index names refer to the same table,
 		// the mutation list and new version number created by the first
 		// drop need to be visible to the second drop.
-		var tableDesc *TableDescriptor
-		var err error
-		params.p.runWithOptions(resolveFlags{skipCache: true}, func() {
-			tableDesc, err = ResolveExistingObject(
-				ctx, params.p, index.tn, true /*required*/, requireTableDesc)
-		})
+		tableDesc, err := params.p.ResolveMutableTableDescriptor(
+			ctx, index.tn, true /*required*/, requireTableDesc)
 		if err != nil {
 			// Somehow the descriptor we had during newPlan() is not there
 			// any more.

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -152,12 +152,8 @@ func (*dropTableNode) Close(context.Context)        {}
 // If the table does not exist, this function returns a nil descriptor.
 func (p *planner) prepareDrop(
 	ctx context.Context, name *tree.TableName, required bool, requiredType requiredType,
-) (tableDesc *sqlbase.TableDescriptor, err error) {
-	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
-	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		tableDesc, err = ResolveExistingObject(ctx, p, name, required, requiredType)
-	})
+) (*MutableTableDescriptor, error) {
+	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, name, required, requiredType)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -222,7 +222,7 @@ func (p *planner) removeFK(
 		return err
 	}
 	idx.ForeignKey = sqlbase.ForeignKeyReference{}
-	return p.saveNonmutationAndNotify(ctx, table)
+	return p.writeSchemaChange(ctx, table, sqlbase.InvalidMutationID)
 }
 
 func (p *planner) removeInterleave(ctx context.Context, ref sqlbase.ForeignKeyReference) error {
@@ -239,7 +239,7 @@ func (p *planner) removeInterleave(ctx context.Context, ref sqlbase.ForeignKeyRe
 		return err
 	}
 	idx.Interleave.Ancestors = nil
-	return p.saveNonmutationAndNotify(ctx, table)
+	return p.writeSchemaChange(ctx, table, sqlbase.InvalidMutationID)
 }
 
 // dropTableImpl does the work of dropping a table (and everything that depends
@@ -407,7 +407,7 @@ func (p *planner) removeFKBackReference(
 			targetIdx.ReferencedBy = append(targetIdx.ReferencedBy[:k], targetIdx.ReferencedBy[k+1:]...)
 		}
 	}
-	return p.saveNonmutationAndNotify(ctx, t)
+	return p.writeSchemaChange(ctx, t, sqlbase.InvalidMutationID)
 }
 
 func (p *planner) removeInterleaveBackReference(
@@ -441,7 +441,7 @@ func (p *planner) removeInterleaveBackReference(
 		}
 	}
 	if t != tableDesc {
-		return p.saveNonmutationAndNotify(ctx, t)
+		return p.writeSchemaChange(ctx, t, sqlbase.InvalidMutationID)
 	}
 	return nil
 }

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -189,7 +189,7 @@ func (p *planner) dropViewImpl(
 			continue
 		}
 		dependencyDesc.DependedOnBy = removeMatchingReferences(dependencyDesc.DependedOnBy, viewDesc.ID)
-		if err := p.saveNonmutationAndNotify(ctx, dependencyDesc); err != nil {
+		if err := p.writeSchemaChange(ctx, dependencyDesc, sqlbase.InvalidMutationID); err != nil {
 			return cascadeDroppedViews, err
 		}
 	}

--- a/pkg/sql/physical_schema_accessors.go
+++ b/pkg/sql/physical_schema_accessors.go
@@ -195,12 +195,5 @@ func (a *CachedPhysicalAccessor) GetDatabaseDesc(
 func (a *CachedPhysicalAccessor) GetObjectDesc(
 	name *ObjectName, flags ObjectLookupFlags,
 ) (*ObjectDescriptor, *DatabaseDescriptor, error) {
-	// Can we use the table cache?
-	// - avoidCached -> the caller said no.
-	if !flags.avoidCached {
-		return a.tc.getTableVersion(flags.ctx, name, flags)
-	}
-
-	// Default path.
-	return a.SchemaAccessor.GetObjectDesc(name, flags)
+	return a.tc.getTableVersion(flags.ctx, name, flags)
 }

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -92,6 +92,8 @@ type PlanHookState interface {
 	BumpRoleMembershipTableVersion(ctx context.Context) error
 	Select(ctx context.Context, n *tree.Select, desiredTypes []types.T) (planNode, error)
 	EvalAsOfTimestamp(asOf tree.AsOfClause, max hlc.Timestamp) (hlc.Timestamp, error)
+	ResolveUncachedDatabaseByName(
+		ctx context.Context, dbName string, required bool) (*UncachedDatabaseDescriptor, error)
 }
 
 // AddPlanHook adds a hook used to short-circuit creating a planNode from a

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -392,7 +392,9 @@ func (p *planner) ResolveTableName(ctx context.Context, tn *tree.TableName) erro
 func (p *planner) lookupFKTable(
 	ctx context.Context, tableID sqlbase.ID,
 ) (sqlbase.TableLookup, error) {
-	table, err := p.Tables().getTableVersionByID(ctx, p.txn, tableID)
+	flags := ObjectLookupFlags{
+		CommonLookupFlags{txn: p.txn, avoidCached: p.avoidCachedDescriptors}}
+	table, err := p.Tables().getTableVersionByID(ctx, tableID, flags)
 	if err != nil {
 		if err == errTableAdding {
 			return sqlbase.TableLookup{IsAdding: true}, nil

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -37,12 +37,8 @@ func (p *planner) RenameColumn(ctx context.Context, n *tree.RenameColumn) (planN
 	if err != nil {
 		return nil, err
 	}
-	var tableDesc *TableDescriptor
-	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
-	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		tableDesc, err = ResolveExistingObject(ctx, p, tn, !n.IfExists, requireTableDesc)
-	})
+
+	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, tn, !n.IfExists, requireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -42,11 +42,7 @@ func (p *planner) RenameDatabase(ctx context.Context, n *tree.RenameDatabase) (p
 		return nil, err
 	}
 
-	var dbDesc *DatabaseDescriptor
-	var err error
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		dbDesc, err = ResolveDatabase(ctx, p, string(n.Name), true /*required*/)
-	})
+	dbDesc, err := p.ResolveUncachedDatabaseByName(ctx, string(n.Name), true /*required*/)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rename_index.go
+++ b/pkg/sql/rename_index.go
@@ -31,13 +31,7 @@ var errEmptyIndexName = pgerror.NewError(pgerror.CodeSyntaxError, "empty index n
 //   notes: postgres requires CREATE on the table.
 //          mysql requires ALTER, CREATE, INSERT on the table.
 func (p *planner) RenameIndex(ctx context.Context, n *tree.RenameIndex) (planNode, error) {
-	var tableDesc *TableDescriptor
-	var err error
-	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
-	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		_, tableDesc, err = expandIndexName(ctx, p, n.Index, true /* requireTable */)
-	})
+	_, tableDesc, err := expandMutableIndexName(ctx, p, n.Index, true /* requireTable */)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -74,20 +74,14 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 			ctx, tableDesc.TypeName(), oldTn.String(), tableDesc.ParentID, tableDesc.DependedOnBy[0].ID)
 	}
 
-	var prevDbDesc *DatabaseDescriptor
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		prevDbDesc, err = ResolveDatabase(ctx, p, oldTn.Catalog(), true /*required*/)
-	})
+	prevDbDesc, err := p.ResolveUncachedDatabase(ctx, oldTn)
 	if err != nil {
 		return nil, err
 	}
 
 	// Check if target database exists.
 	// We also look at uncached descriptors here.
-	var targetDbDesc *DatabaseDescriptor
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		targetDbDesc, err = ResolveTargetObject(ctx, p, newTn)
-	})
+	targetDbDesc, err := p.ResolveUncachedDatabase(ctx, newTn)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -48,12 +48,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 		toRequire = requireSequenceDesc
 	}
 
-	var tableDesc *TableDescriptor
-	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
-	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		tableDesc, err = ResolveExistingObject(ctx, p, oldTn, !n.IfExists, toRequire)
-	})
+	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, oldTn, !n.IfExists, toRequire)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -141,6 +141,15 @@ type resolveFlags struct {
 	skipCache bool
 }
 
+func (p *planner) ResolveMutableTableDescriptor(
+	ctx context.Context, tn *ObjectName, required bool, requiredType requiredType,
+) (table *MutableTableDescriptor, err error) {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
+		table, err = ResolveExistingObject(ctx, p, tn, required, requiredType)
+	})
+	return table, err
+}
+
 // ResolveTargetObject determines a valid target path for an object
 // that may not exist yet. It returns the descriptor for the database
 // where the target object lives.

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -150,6 +150,15 @@ func (p *planner) ResolveMutableTableDescriptor(
 	return table, err
 }
 
+func (p *planner) ResolveUncachedTableDescriptor(
+	ctx context.Context, tn *ObjectName, required bool, requiredType requiredType,
+) (table *UncachedTableDescriptor, err error) {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
+		table, err = ResolveExistingObject(ctx, p, tn, required, requiredType)
+	})
+	return table, err
+}
+
 // ResolveTargetObject determines a valid target path for an object
 // that may not exist yet. It returns the descriptor for the database
 // where the target object lives.

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -175,6 +175,15 @@ func ResolveTargetObject(
 	return descI.(*DatabaseDescriptor), nil
 }
 
+func (p *planner) ResolveUncachedDatabase(
+	ctx context.Context, tn *ObjectName,
+) (res *UncachedDatabaseDescriptor, err error) {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
+		res, err = ResolveTargetObject(ctx, p, tn)
+	})
+	return res, err
+}
+
 // requiredType can be passed to the ResolveExistingObject function to
 // require the returned descriptor to be of a specific type.
 type requiredType int

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -51,6 +51,10 @@ type (
 	// MutableTableDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	MutableTableDescriptor = sqlbase.TableDescriptor
+	// UncachedTableDescriptor is provided for convenience and to make the
+	// interface definitions below more intuitive.
+	// It is an immutable descriptor read from the store.
+	UncachedTableDescriptor = sqlbase.TableDescriptor
 	// TableDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	TableDescriptor = sqlbase.TableDescriptor

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -42,6 +42,9 @@ type (
 	// DatabaseDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	DatabaseDescriptor = sqlbase.DatabaseDescriptor
+	// UncachedDatabaseDescriptor is provided for convenience and to make the
+	// interface definitions below more intuitive.
+	UncachedDatabaseDescriptor = sqlbase.DatabaseDescriptor
 	// ObjectDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	ObjectDescriptor = sqlbase.TableDescriptor

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -45,6 +45,9 @@ type (
 	// ObjectDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	ObjectDescriptor = sqlbase.TableDescriptor
+	// MutableTableDescriptor is provided for convenience and to make the
+	// interface definitions below more intuitive.
+	MutableTableDescriptor = sqlbase.TableDescriptor
 	// TableDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	TableDescriptor = sqlbase.TableDescriptor

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -171,7 +171,7 @@ func (n *scrubNode) Close(ctx context.Context) {
 func (n *scrubNode) startScrubDatabase(ctx context.Context, p *planner, name *tree.Name) error {
 	// Check that the database exists.
 	database := string(*name)
-	dbDesc, err := ResolveDatabase(ctx, p, database, true /*required*/)
+	dbDesc, err := p.ResolveUncachedDatabaseByName(ctx, database, true /*required*/)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/serial.go
+++ b/pkg/sql/serial.go
@@ -97,16 +97,12 @@ func (p *planner) processSerialInColumnDef(
 		tree.Name(tableName.Table() + "_" + string(d.Name) + "_seq"))
 
 	// The first step in the search is to prepare the seqName to fill in
-	// the catalog/schema parent. This is what ResolveTargetObject does.
+	// the catalog/schema parent. This is what ResolveUncachedDatabase does.
 	//
 	// Here and below we skip the cache because name resolution using
 	// the cache does not work (well) if the txn retries and the
 	// descriptor was written already in an early txn attempt.
-	var dbDesc *DatabaseDescriptor
-	var err error
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		dbDesc, err = ResolveTargetObject(ctx, p, seqName)
-	})
+	dbDesc, err := p.ResolveUncachedDatabase(ctx, seqName)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/pkg/sql/serial.go
+++ b/pkg/sql/serial.go
@@ -112,10 +112,7 @@ func (p *planner) processSerialInColumnDef(
 		if i > 0 {
 			seqName.TableName = tree.Name(fmt.Sprintf("%s%d", nameBase, i))
 		}
-		var res *ObjectDescriptor
-		p.runWithOptions(resolveFlags{skipCache: true}, func() {
-			res, err = ResolveExistingObject(ctx, p, seqName, false /*required*/, anyDescType)
-		})
+		res, err := p.ResolveUncachedTableDescriptor(ctx, seqName, false /*required*/, anyDescType)
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -74,12 +74,7 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 		}
 	}
 
-	var table *TableDescriptor
-	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
-	// TODO(vivek): check if the cache can be used.
-	params.p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		table, err = params.p.resolveTableForZone(params.ctx, &n.zoneSpecifier)
-	})
+	table, err := params.p.resolveTableForZone(params.ctx, &n.zoneSpecifier)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -59,14 +59,10 @@ func (p *planner) ShowFingerprints(
 		return nil, err
 	}
 
-	var tableDesc *TableDescriptor
 	// We avoid the cache so that we can observe the fingerprints without
 	// taking a lease, like other SHOW commands.
-	//
-	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		tableDesc, err = ResolveExistingObject(ctx, p, tn, true /*required*/, requireTableDesc)
-	})
+	tableDesc, err := p.ResolveUncachedTableDescriptor(
+		ctx, tn, true /*required*/, requireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/show_schemas.go
+++ b/pkg/sql/show_schemas.go
@@ -33,7 +33,7 @@ func (p *planner) ShowSchemas(ctx context.Context, n *tree.ShowSchemas) (planNod
 	if name == "" {
 		return nil, errNoDatabase
 	}
-	if _, err := ResolveDatabase(ctx, p, name, true /*required*/); err != nil {
+	if _, err := p.ResolveUncachedDatabaseByName(ctx, name, true /*required*/); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -48,14 +48,9 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 		return nil, err
 	}
 
-	var desc *TableDescriptor
 	// We avoid the cache so that we can observe the stats without
 	// taking a lease, like other SHOW commands.
-	//
-	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		desc, err = ResolveExistingObject(ctx, p, tn, true /*required*/, requireTableDesc)
-	})
+	desc, err := p.ResolveUncachedTableDescriptor(ctx, tn, true /*required*/, requireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/show_table.go
+++ b/pkg/sql/show_table.go
@@ -38,14 +38,9 @@ func (p *planner) showTableDetails(
 		return nil, err
 	}
 
-	var desc *TableDescriptor
 	// We avoid the cache so that we can observe the details without
 	// taking a lease, like other SHOW commands.
-	//
-	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		desc, err = ResolveExistingObject(ctx, p, tn, true /*required*/, anyDescType)
-	})
+	desc, err := p.ResolveUncachedTableDescriptor(ctx, tn, true /*required*/, anyDescType)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/show_zone_config.go
+++ b/pkg/sql/show_zone_config.go
@@ -75,15 +75,7 @@ type showZoneConfigRun struct {
 }
 
 func (n *showZoneConfigNode) startExec(params runParams) error {
-	var tblDesc *TableDescriptor
-	var err error
-	// We avoid the cache so that we can observe the zone configuration
-	// without taking a lease, like other SHOW commands.
-	//
-	// TODO(vivek): check if the cache can be used.
-	params.p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		tblDesc, err = params.p.resolveTableForZone(params.ctx, &n.zoneSpecifier)
-	})
+	tblDesc, err := params.p.resolveTableForZone(params.ctx, &n.zoneSpecifier)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -47,12 +47,8 @@ func (p *planner) Truncate(ctx context.Context, n *tree.Truncate) (planNode, err
 		if err != nil {
 			return nil, err
 		}
-		var tableDesc *TableDescriptor
-		// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
-		// TODO(vivek): check if the cache can be used.
-		p.runWithOptions(resolveFlags{skipCache: true}, func() {
-			tableDesc, err = ResolveExistingObject(ctx, p, tn, true /*required*/, requireTableDesc)
-		})
+		tableDesc, err := p.ResolveMutableTableDescriptor(
+			ctx, tn, true /*required*/, requireTableDesc)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
 // GetUserHashedPassword returns the hashedPassword for the given username if
@@ -81,5 +82,5 @@ func (p *planner) BumpRoleMembershipTableVersion(ctx context.Context) error {
 		return err
 	}
 
-	return p.saveNonmutationAndNotify(ctx, tableDesc)
+	return p.writeSchemaChange(ctx, tableDesc, sqlbase.InvalidMutationID)
 }

--- a/pkg/sql/views.go
+++ b/pkg/sql/views.go
@@ -71,12 +71,6 @@ func (d planDependencies) String() string {
 func (p *planner) analyzeViewQuery(
 	ctx context.Context, viewSelect *tree.Select,
 ) (planDependencies, sqlbase.ResultColumns, error) {
-	// To avoid races with ongoing schema changes to tables that the view
-	// depends on, make sure we use the most recent versions of table
-	// descriptors rather than the copies in the lease cache.
-	defer func(prev bool) { p.avoidCachedDescriptors = prev }(p.avoidCachedDescriptors)
-	p.avoidCachedDescriptors = true
-
 	// Request dependency tracking.
 	defer func(prev planDependencies) { p.curPlan.deps = prev }(p.curPlan.deps)
 	p.curPlan.deps = make(planDependencies)

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -172,7 +172,7 @@ func zoneSpecifierNotFoundError(zs tree.ZoneSpecifier) error {
 // Returns res = nil if the zone specifier is not for a table or index.
 func (p *planner) resolveTableForZone(
 	ctx context.Context, zs *tree.ZoneSpecifier,
-) (res *sqlbase.TableDescriptor, err error) {
+) (res *MutableTableDescriptor, err error) {
 	if zs.TargetsIndex() {
 		_, res, err = expandMutableIndexName(ctx, p, &zs.TableOrIndex, true /* requireTable */)
 	} else if zs.TargetsTable() {
@@ -180,7 +180,9 @@ func (p *planner) resolveTableForZone(
 		if err != nil {
 			return nil, err
 		}
-		res, err = ResolveExistingObject(ctx, p, tn, true /*required*/, anyDescType)
+		p.runWithOptions(resolveFlags{skipCache: true}, func() {
+			res, err = ResolveExistingObject(ctx, p, tn, true /*required*/, anyDescType)
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -174,7 +174,7 @@ func (p *planner) resolveTableForZone(
 	ctx context.Context, zs *tree.ZoneSpecifier,
 ) (res *sqlbase.TableDescriptor, err error) {
 	if zs.TargetsIndex() {
-		_, res, err = expandIndexName(ctx, p, &zs.TableOrIndex, true /* requireTable */)
+		_, res, err = expandMutableIndexName(ctx, p, &zs.TableOrIndex, true /* requireTable */)
 	} else if zs.TargetsTable() {
 		tn, err := zs.TableOrIndex.Table.Normalize()
 		if err != nil {


### PR DESCRIPTION
This PR also introduces three type aliases: MutableTableDescriptor, UncachedTableDescriptor (a descriptor read from the store but is immutable), UncachedDatabaseDescriptor.

- MutableTableDescriptor: a descriptor that was mutated in the current txn
- UncachedXDescriptor: a descriptor that was read inside the current txn at that txn's timestamp, cannot be used by other txns

In a followup I'd like to convert MutableTableDescriptor into a real type. There is a lot more refactoring work and I had to stop somewhere.