### PR TITLE
rpc: allow dialing connections to be cancelled

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -462,6 +462,7 @@ func (ctx *Context) GRPCDialOptions() ([]grpc.DialOption, error) {
 // ensures that our initial heartbeat (and its version/clusterID
 // validation) occurs on every new connection.
 type onlyOnceDialer struct {
+	ctx context.Context
 	syncutil.Mutex
 	dialed     bool
 	closed     bool
@@ -477,7 +478,7 @@ func (ood *onlyOnceDialer) dial(addr string, timeout time.Duration) (net.Conn, e
 			Timeout:   timeout,
 			LocalAddr: sourceAddr,
 		}
-		return dialer.Dial("tcp", addr)
+		return dialer.DialContext(ood.ctx, "tcp", addr)
 	} else if !ood.closed {
 		ood.closed = true
 		close(ood.redialChan)
@@ -505,6 +506,7 @@ func (ctx *Context) GRPCDialRaw(target string) (*grpc.ClientConn, <-chan struct{
 		grpc.WithInitialConnWindowSize(initialConnWindowSize))
 
 	dialer := onlyOnceDialer{
+		ctx:        ctx.masterCtx,
 		redialChan: make(chan struct{}),
 	}
 	dialOpts = append(dialOpts, grpc.WithDialer(dialer.dial))


### PR DESCRIPTION
Use DialContext instead of Dial so the dialing connection will respond
to cancellation and clean up in a prompt manner when the stopper is
quiesced. Fixes leaked goroutine flakes in the gossip package when run
with `make stress`.

Release note: None