### PR TITLE
kv: prevent a leaf TCS from returning HandledRetryableError

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -728,6 +728,11 @@ func (tc *TxnCoordSender) maybeRejectClientLocked(
 	if tc.mu.txn.Status == roachpb.ABORTED {
 		abortedErr := roachpb.NewErrorWithTxn(
 			roachpb.NewTransactionAbortedError(roachpb.ABORT_REASON_CLIENT_REJECT), &tc.mu.txn)
+		if tc.typ == client.LeafTxn {
+			// Leaf txns return raw retriable errors (which get handled by the
+			// root) rather than HandledRetryableTxnError.
+			return abortedErr
+		}
 		newTxn := roachpb.PrepareTransactionForRetry(
 			ctx, abortedErr,
 			// priority is not used for aborted errors


### PR DESCRIPTION
A root TxnCoordSender takes retryable errors, prepares the transaction
for a retry and the returns a HandledRetryableError to the client.
Leaf TCS does not prepare transactions for retries, and so has no
business creating HandledRetryableErrors. Instead, it returns raw error
which have to make their way (through DistSQL streams) to the root,
which will "handle" them.
Before this patch, there was a codepath where a leaf TCS would
erroneously return a HandledRetryableError. This was confusing DistSQL
which was not plumbing it properly and it was making its way to the
client with a non-retriable code.

Fixes #28898

Release note: None