### PR TITLE
backport-2.1: storage: Add exponential backoff in relocate range retry loop

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1037,6 +1037,7 @@ func RelocateRange(
 	}
 
 	every := log.Every(time.Minute)
+	re := retry.StartWithCtx(ctx, retry.Options{MaxBackoff: 5 * time.Second})
 	for len(addTargets) > 0 {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -1053,6 +1054,7 @@ func RelocateRange(
 			if every.ShouldLog() {
 				log.Warning(ctx, returnErr)
 			}
+			re.Next()
 			continue
 		}
 		addTargets = addTargets[1:]
@@ -1090,6 +1092,7 @@ func RelocateRange(
 		}
 	}
 
+	re.Reset()
 	for len(removeTargets) > 0 {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -1104,6 +1107,7 @@ func RelocateRange(
 			if !canRetry(err) {
 				return err
 			}
+			re.Next()
 			continue
 		}
 		removeTargets = removeTargets[1:]


### PR DESCRIPTION
Backport 1/1 commits from #29013.

/cc @cockroachdb/release

---

Retrying snapshots as aggressively as we were before this change is not
helpful in any way.

Release note: None
