### PR TITLE
 sql,settings: make SET CLUSTER SETTING wait for value to update, disallow in txn

### DIFF
--- a/pkg/server/settingsworker_test.go
+++ b/pkg/server/settingsworker_test.go
@@ -206,50 +206,35 @@ func TestSettingsSetAndShow(t *testing.T) {
 	showQ := `SHOW CLUSTER SETTING "%s"`
 
 	db.Exec(t, fmt.Sprintf(setQ, strKey, "'via-set'"))
-	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := "via-set", db.QueryStr(t, fmt.Sprintf(showQ, strKey))[0][0]; expected != actual {
-			return errors.Errorf("expected %v, got %v", expected, actual)
-		}
-		return nil
-	})
+	if expected, actual := "via-set", db.QueryStr(t, fmt.Sprintf(showQ, strKey))[0][0]; expected != actual {
+		t.Fatalf("expected %v, got %v", expected, actual)
+	}
 
 	db.Exec(t, fmt.Sprintf(setQ, intKey, "5"))
-	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := "5", db.QueryStr(t, fmt.Sprintf(showQ, intKey))[0][0]; expected != actual {
-			return errors.Errorf("expected %v, got %v", expected, actual)
-		}
-		return nil
-	})
+	if expected, actual := "5", db.QueryStr(t, fmt.Sprintf(showQ, intKey))[0][0]; expected != actual {
+		t.Fatalf("expected %v, got %v", expected, actual)
+	}
 
 	db.Exec(t, fmt.Sprintf(setQ, durationKey, "'2h'"))
-	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := time.Hour*2, durationA.Get(&st.SV); expected != actual {
-			return errors.Errorf("expected %v, got %v", expected, actual)
-		}
-		if expected, actual := "2h", db.QueryStr(t, fmt.Sprintf(showQ, durationKey))[0][0]; expected != actual {
-			return errors.Errorf("expected %v, got %v", expected, actual)
-		}
-		return nil
-	})
+	if expected, actual := time.Hour*2, durationA.Get(&st.SV); expected != actual {
+		t.Fatalf("expected %v, got %v", expected, actual)
+	}
+	if expected, actual := "2h", db.QueryStr(t, fmt.Sprintf(showQ, durationKey))[0][0]; expected != actual {
+		t.Fatalf("expected %v, got %v", expected, actual)
+	}
 
 	db.Exec(t, fmt.Sprintf(setQ, byteSizeKey, "'1500MB'"))
-	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := int64(1500000000), byteSizeA.Get(&st.SV); expected != actual {
-			return errors.Errorf("expected %v, got %v", expected, actual)
-		}
-		if expected, actual := "1.4 GiB", db.QueryStr(t, fmt.Sprintf(showQ, byteSizeKey))[0][0]; expected != actual {
-			return errors.Errorf("expected %v, got %v", expected, actual)
-		}
-		return nil
-	})
+	if expected, actual := int64(1500000000), byteSizeA.Get(&st.SV); expected != actual {
+		t.Fatalf("expected %v, got %v", expected, actual)
+	}
+	if expected, actual := "1.4 GiB", db.QueryStr(t, fmt.Sprintf(showQ, byteSizeKey))[0][0]; expected != actual {
+		t.Fatalf("expected %v, got %v", expected, actual)
+	}
 
 	db.Exec(t, fmt.Sprintf(setQ, byteSizeKey, "'1450MB'"))
-	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := "1.4 GiB", db.QueryStr(t, fmt.Sprintf(showQ, byteSizeKey))[0][0]; expected != actual {
-			return errors.Errorf("expected %v, got %v", expected, actual)
-		}
-		return nil
-	})
+	if expected, actual := "1.4 GiB", db.QueryStr(t, fmt.Sprintf(showQ, byteSizeKey))[0][0]; expected != actual {
+		t.Fatalf("expected %v, got %v", expected, actual)
+	}
 
 	if _, err := db.DB.Exec(fmt.Sprintf(setQ, intKey, "'a-str'")); !testutils.IsError(
 		err, `could not parse "a-str" as type int`,
@@ -258,26 +243,20 @@ func TestSettingsSetAndShow(t *testing.T) {
 	}
 
 	db.Exec(t, fmt.Sprintf(setQ, enumKey, "2"))
-	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := int64(2), enumA.Get(&st.SV); expected != actual {
-			return errors.Errorf("expected %v, got %v", expected, actual)
-		}
-		if expected, actual := "2", db.QueryStr(t, fmt.Sprintf(showQ, enumKey))[0][0]; expected != actual {
-			return errors.Errorf("expected %v, got %v", expected, actual)
-		}
-		return nil
-	})
+	if expected, actual := int64(2), enumA.Get(&st.SV); expected != actual {
+		t.Fatalf("expected %v, got %v", expected, actual)
+	}
+	if expected, actual := "2", db.QueryStr(t, fmt.Sprintf(showQ, enumKey))[0][0]; expected != actual {
+		t.Fatalf("expected %v, got %v", expected, actual)
+	}
 
 	db.Exec(t, fmt.Sprintf(setQ, enumKey, "'foo'"))
-	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := int64(1), enumA.Get(&st.SV); expected != actual {
-			return errors.Errorf("expected %v, got %v", expected, actual)
-		}
-		if expected, actual := "1", db.QueryStr(t, fmt.Sprintf(showQ, enumKey))[0][0]; expected != actual {
-			return errors.Errorf("expected %v, got %v", expected, actual)
-		}
-		return nil
-	})
+	if expected, actual := int64(1), enumA.Get(&st.SV); expected != actual {
+		t.Fatalf("expected %v, got %v", expected, actual)
+	}
+	if expected, actual := "1", db.QueryStr(t, fmt.Sprintf(showQ, enumKey))[0][0]; expected != actual {
+		t.Fatalf("expected %v, got %v", expected, actual)
+	}
 
 	if _, err := db.DB.Exec(fmt.Sprintf(setQ, enumKey, "'unknown'")); !testutils.IsError(err,
 		`invalid string value 'unknown' for enum setting`,

--- a/pkg/settings/bool.go
+++ b/pkg/settings/bool.go
@@ -33,6 +33,16 @@ func (b *BoolSetting) String(sv *Values) string {
 	return EncodeBool(b.Get(sv))
 }
 
+// Encoded returns the encoded value of the current value of the setting.
+func (b *BoolSetting) Encoded(sv *Values) string {
+	return b.String(sv)
+}
+
+// EncodedDefault returns the encoded value of the default value of the setting.
+func (b *BoolSetting) EncodedDefault() string {
+	return EncodeBool(b.defaultValue)
+}
+
 // Typ returns the short (1 char) string denoting the type of setting.
 func (*BoolSetting) Typ() string {
 	return "b"

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -40,6 +40,16 @@ func (d *DurationSetting) String(sv *Values) string {
 	return EncodeDuration(d.Get(sv))
 }
 
+// Encoded returns the encoded value of the current value of the setting.
+func (d *DurationSetting) Encoded(sv *Values) string {
+	return d.String(sv)
+}
+
+// EncodedDefault returns the encoded value of the default value of the setting.
+func (d *DurationSetting) EncodedDefault() string {
+	return EncodeDuration(d.defaultValue)
+}
+
 // Typ returns the short (1 char) string denoting the type of setting.
 func (*DurationSetting) Typ() string {
 	return "d"

--- a/pkg/settings/float.go
+++ b/pkg/settings/float.go
@@ -40,6 +40,16 @@ func (f *FloatSetting) String(sv *Values) string {
 	return EncodeFloat(f.Get(sv))
 }
 
+// Encoded returns the encoded value of the current value of the setting.
+func (f *FloatSetting) Encoded(sv *Values) string {
+	return f.String(sv)
+}
+
+// EncodedDefault returns the encoded value of the default value of the setting.
+func (f *FloatSetting) EncodedDefault() string {
+	return EncodeFloat(f.defaultValue)
+}
+
 // Typ returns the short (1 char) string denoting the type of setting.
 func (*FloatSetting) Typ() string {
 	return "f"

--- a/pkg/settings/int.go
+++ b/pkg/settings/int.go
@@ -38,6 +38,16 @@ func (i *IntSetting) String(sv *Values) string {
 	return EncodeInt(i.Get(sv))
 }
 
+// Encoded returns the encoded value of the current value of the setting.
+func (i *IntSetting) Encoded(sv *Values) string {
+	return i.String(sv)
+}
+
+// EncodedDefault returns the encoded value of the default value of the setting.
+func (i *IntSetting) EncodedDefault() string {
+	return EncodeInt(i.defaultValue)
+}
+
 // Typ returns the short (1 char) string denoting the type of setting.
 func (*IntSetting) Typ() string {
 	return "i"

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -130,6 +130,9 @@ type Setting interface {
 	// Typ returns the short (1 char) string denoting the type of setting.
 	Typ() string
 	String(sv *Values) string
+	Encoded(sv *Values) string
+
+	EncodedDefault() string
 
 	Description() string
 	setDescription(desc string)

--- a/pkg/settings/statemachine.go
+++ b/pkg/settings/statemachine.go
@@ -97,6 +97,16 @@ func (s *StateMachineSetting) Get(sv *Values) string {
 	return string(encV.([]byte))
 }
 
+// Encoded returns the encoded value of the current value of the setting.
+func (s *StateMachineSetting) Encoded(sv *Values) string {
+	return s.Get(sv)
+}
+
+// EncodedDefault returns the encoded value of the default value of the setting.
+func (s *StateMachineSetting) EncodedDefault() string {
+	return "unsupported"
+}
+
 // Validate that the state machine accepts the user input. Returns new encoded
 // state, unencoded state, or an error. If no update is given, round trips
 // current state.

--- a/pkg/settings/string.go
+++ b/pkg/settings/string.go
@@ -33,6 +33,16 @@ func (s *StringSetting) String(sv *Values) string {
 	return s.Get(sv)
 }
 
+// Encoded returns the encoded value of the current value of the setting.
+func (s *StringSetting) Encoded(sv *Values) string {
+	return s.String(sv)
+}
+
+// EncodedDefault returns the encoded value of the default value of the setting.
+func (s *StringSetting) EncodedDefault() string {
+	return s.defaultValue
+}
+
 // Typ returns the short (1 char) string denoting the type of setting.
 func (*StringSetting) Typ() string {
 	return "s"

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -93,53 +94,76 @@ func (p *planner) SetClusterSetting(
 }
 
 func (n *setClusterSettingNode) startExec(params runParams) error {
-	var reportedValue string
-	if n.value == nil {
-		if _, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.Exec(
-			params.ctx, "reset-setting", params.p.txn,
-			"DELETE FROM system.settings WHERE name = $1", n.name,
-		); err != nil {
-			return err
-		}
-		reportedValue = "DEFAULT"
-	} else {
-		value, err := n.value.Eval(params.p.EvalContext())
-		if err != nil {
-			return err
-		}
-		// TODO(dt): validate and properly encode str according to type.
-		encoded, err := params.p.toSettingString(params.ctx, n.st, n.name, n.setting, value)
-		if err != nil {
-			return err
-		}
-		if _, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.Exec(
-			params.ctx, "update-setting", params.p.txn,
-			`UPSERT INTO system.settings (name, value, "lastUpdated", "valueType") VALUES ($1, $2, now(), $3)`,
-			n.name, encoded, n.setting.Typ(),
-		); err != nil {
-			return err
-		}
-		reportedValue = tree.AsStringWithFlags(value, tree.FmtBareStrings)
+	if !params.p.ExtendedEvalContext().TxnImplicit {
+		return errors.Errorf("SET CLUSTER SETTING cannot be used inside a transaction")
 	}
 
-	return MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
-		params.ctx,
-		params.p.txn,
-		EventLogSetClusterSetting,
-		0, /* no target */
-		int32(params.extendedEvalCtx.NodeID),
-		EventLogSetClusterSettingDetail{n.name, reportedValue, params.SessionData().User},
-	)
+	execCfg := params.extendedEvalCtx.ExecCfg
+	return execCfg.DB.Txn(params.ctx, func(ctx context.Context, txn *client.Txn) error {
+		var reportedValue string
+		if n.value == nil {
+			reportedValue = "DEFAULT"
+			if _, err := execCfg.InternalExecutor.Exec(
+				ctx, "reset-setting", txn,
+				"DELETE FROM system.settings WHERE name = $1", n.name,
+			); err != nil {
+				return err
+			}
+		} else {
+			value, err := n.value.Eval(params.p.EvalContext())
+			if err != nil {
+				return err
+			}
+			reportedValue = tree.AsStringWithFlags(value, tree.FmtBareStrings)
+			var prev tree.Datum
+			if _, ok := n.setting.(*settings.StateMachineSetting); ok {
+				datums, err := execCfg.InternalExecutor.QueryRow(
+					ctx, "retrieve-prev-setting", txn, "SELECT value FROM system.settings WHERE name = $1", n.name,
+				)
+				if err != nil {
+					return err
+				}
+				if len(datums) == 0 {
+					// There is a SQL migration which adds this value. If it
+					// hasn't run yet, we can't update the version as we don't
+					// have good enough information about the current cluster
+					// version.
+					return errors.New("no persisted cluster version found, please retry later")
+				}
+				prev = datums[0]
+			}
+			encoded, err := toSettingString(ctx, n.st, n.name, n.setting, value, prev)
+			if err != nil {
+				return err
+			}
+			if _, err = execCfg.InternalExecutor.Exec(
+				ctx, "update-setting", txn,
+				`UPSERT INTO system.settings (name, value, "lastUpdated", "valueType") VALUES ($1, $2, now(), $3)`,
+				n.name, encoded, n.setting.Typ(),
+			); err != nil {
+				return err
+			}
+		}
+
+		return MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
+			ctx,
+			txn,
+			EventLogSetClusterSetting,
+			0, /* no target */
+			int32(params.extendedEvalCtx.NodeID),
+			EventLogSetClusterSettingDetail{n.name, reportedValue, params.SessionData().User},
+		)
+	})
 }
 
 func (n *setClusterSettingNode) Next(_ runParams) (bool, error) { return false, nil }
 func (n *setClusterSettingNode) Values() tree.Datums            { return nil }
 func (n *setClusterSettingNode) Close(_ context.Context)        {}
 
-func (p *planner) toSettingString(
-	ctx context.Context, st *cluster.Settings, name string, setting settings.Setting, d tree.Datum,
+func toSettingString(
+	ctx context.Context, st *cluster.Settings, name string, s settings.Setting, d, prev tree.Datum,
 ) (string, error) {
-	switch setting := setting.(type) {
+	switch setting := s.(type) {
 	case *settings.StringSetting:
 		if s, ok := d.(*tree.DString); ok {
 			if err := setting.Validate(&st.SV, string(*s)); err != nil {
@@ -150,23 +174,7 @@ func (p *planner) toSettingString(
 		return "", errors.Errorf("cannot use %s %T value for string setting", d.ResolvedType(), d)
 	case *settings.StateMachineSetting:
 		if s, ok := d.(*tree.DString); ok {
-			datums, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryRow(
-				ctx, "retrieve-prev-setting",
-				p.txn,
-				"SELECT value FROM system.settings WHERE name = $1", name,
-			)
-			if err != nil {
-				return "", err
-			}
-			if len(datums) == 0 {
-				// There is a SQL migration which adds this value. If it
-				// hasn't run yet, we can't update the version as we don't
-				// have good enough information about the current cluster
-				// version.
-				return "", errors.New("no persisted cluster version found, please retry later")
-			}
-
-			dStr, ok := datums[0].(*tree.DString)
+			dStr, ok := prev.(*tree.DString)
 			if !ok {
 				return "", errors.New("the existing value is not a string")
 			}


### PR DESCRIPTION
SET CLUSTER SETTING does a transactional write to the system table. However
settings values are _read_ from an in-memory cache which is not updated until
the system table write is gossiped and that gossip update is processed by the
settings worker.

Release note (sql change): SET CLUSTER SETTING cannot be used inside a
transaction.

Settings values are cached in memory and that cache is updated via gossip after
a SET commits. That delay -- for the update to arrive via gosssip and be
processed and the cache updated -- can mean that a statement executed
immediately following a SET CLUSTER SETTING may execute before the new setting
takes effect, and knowing when it is safe to execute a statement that uses the
new setting is tricky.

Instead, we can make SET CLUSTER SETTING _wait_ until it sees the value it set
returned when reading the settings cache (or return an error if it does not
appear after a timeout of 30s). This should make it easier to set a setting and
then use that value in subsequent statements.

Release note (sql change): SET CLUSTER SETTING attempts to wait until change has
been gossiped.
