### PR TITLE
backport-2.1: sql: make sure lookup join closes its inputs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/sqlsmith
+++ b/pkg/sql/logictest/testdata/logic_test/sqlsmith
@@ -7,3 +7,12 @@
 
 statement ok
 SELECT subq_0.c3 AS c0, subq_0.c6 AS c1, subq_0.c4 AS c2, CASE WHEN (SELECT start_key FROM crdb_internal.ranges LIMIT 1 OFFSET 6) < CAST(NULLIF(pg_catalog.string_agg(CAST((SELECT start_key FROM crdb_internal.ranges LIMIT 1 OFFSET 7) AS BYTES), CAST((SELECT pg_catalog.xor_agg(tgargs) FROM pg_catalog.pg_trigger) AS BYTES)) OVER (PARTITION BY subq_0.c0 ORDER BY subq_0.c0, subq_0.c5, subq_0.c2), CAST(NULL AS BYTES)) AS BYTES) THEN subq_0.c6 ELSE subq_0.c6 END AS c3, subq_0.c2 AS c4, subq_0.c7 AS c5, CAST(COALESCE(subq_0.c7, subq_0.c7) AS INT8) AS c6 FROM (SELECT ref_0.table_name AS c0, ref_0.table_catalog AS c1, ref_0.table_type AS c2, (SELECT rolcreatedb FROM pg_catalog.pg_roles LIMIT 1 OFFSET 79) AS c3, ref_0.table_name AS c4, ref_0.version AS c5, ref_0.version AS c6, ref_0.version AS c7 FROM information_schema.tables AS ref_0 WHERE (ref_0.version IS NOT NULL) OR (pg_catalog.set_masklen(CAST(CAST(NULL AS INET) AS INET), CAST(ref_0.version AS INT8)) != (SELECT pg_catalog.max(client_addr) FROM pg_catalog.pg_stat_activity)) LIMIT 101) AS subq_0 WHERE subq_0.c7 IS NOT NULL
+
+# Regression: make sure lookup join planNode propagates its close signal. This
+# query could panic otherwise with a failure to empty all memory accounts.
+
+statement ok
+CREATE TABLE a (a INT PRIMARY KEY);
+
+statement ok
+SELECT true FROM (SELECT ref_1.a AS c0 FROM crdb_internal.cluster_queries AS ref_0 JOIN a AS ref_1 ON (ref_0.node_id = ref_1.a) WHERE (SELECT a from a limit 1 offset 1) is null);

--- a/pkg/sql/lookup_join.go
+++ b/pkg/sql/lookup_join.go
@@ -150,5 +150,8 @@ func (lj *lookupJoinNode) Values() tree.Datums {
 func (lj *lookupJoinNode) Close(ctx context.Context) {
 	if lj.run.n != nil {
 		lj.run.n.Close(ctx)
+	} else {
+		lj.input.Close(ctx)
+		lj.table.Close(ctx)
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #29073.

/cc @cockroachdb/release

---

Previously, local lookup join wasn't programmed to close itself properly
- if it wasn't running in local fallback mode, it would fail to
propagate its close signal to its upstream planNodes. This could lead to
memory account errors if the upstream planNodes were retaining memory.

Needs a backport.

Release note: None
