### PR TITLE
storage,kv: remove some allocations

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -1278,7 +1278,9 @@ func (ds *DistSender) sendToReplicas(
 	}
 
 	curReplica := transport.NextReplica()
-	log.VEventf(ctx, 2, "r%d: sending batch %s to %s", rangeID, ba.Summary(), curReplica)
+	if log.ExpensiveLogEnabled(ctx, 2) {
+		log.VEventf(ctx, 2, "r%d: sending batch %s to %s", rangeID, ba.Summary(), curReplica)
+	}
 	br, err := transport.SendNext(ctx, ba)
 
 	// This loop will retry operations that fail with errors that reflect

--- a/pkg/storage/batcheval/cmd_lease_info.go
+++ b/pkg/storage/batcheval/cmd_lease_info.go
@@ -40,10 +40,10 @@ func LeaseInfo(
 ) (result.Result, error) {
 	reply := resp.(*roachpb.LeaseInfoResponse)
 	lease, nextLease := cArgs.EvalCtx.GetLease()
-	if nextLease != nil {
+	if nextLease != (roachpb.Lease{}) {
 		// If there's a lease request in progress, speculatively return that future
 		// lease.
-		reply.Lease = *nextLease
+		reply.Lease = nextLease
 	} else {
 		reply.Lease = lease
 	}

--- a/pkg/storage/batcheval/cmd_resolve_intent_test.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_test.go
@@ -114,7 +114,7 @@ func (m *mockEvalCtx) GetTxnSpanGCThreshold() hlc.Timestamp {
 func (m *mockEvalCtx) GetLastReplicaGCTimestamp(context.Context) (hlc.Timestamp, error) {
 	panic("unimplemented")
 }
-func (m *mockEvalCtx) GetLease() (roachpb.Lease, *roachpb.Lease) {
+func (m *mockEvalCtx) GetLease() (roachpb.Lease, roachpb.Lease) {
 	panic("unimplemented")
 }
 

--- a/pkg/storage/batcheval/eval_context.go
+++ b/pkg/storage/batcheval/eval_context.go
@@ -78,5 +78,5 @@ type EvalContext interface {
 	GetGCThreshold() hlc.Timestamp
 	GetTxnSpanGCThreshold() hlc.Timestamp
 	GetLastReplicaGCTimestamp(context.Context) (hlc.Timestamp, error)
-	GetLease() (roachpb.Lease, *roachpb.Lease)
+	GetLease() (roachpb.Lease, roachpb.Lease)
 }

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1265,17 +1265,17 @@ func (r *Replica) IsDestroyed() (DestroyReason, error) {
 }
 
 // GetLease returns the lease and, if available, the proposed next lease.
-func (r *Replica) GetLease() (roachpb.Lease, *roachpb.Lease) {
+func (r *Replica) GetLease() (roachpb.Lease, roachpb.Lease) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.getLeaseRLocked()
 }
 
-func (r *Replica) getLeaseRLocked() (roachpb.Lease, *roachpb.Lease) {
+func (r *Replica) getLeaseRLocked() (roachpb.Lease, roachpb.Lease) {
 	if nextLease, ok := r.mu.pendingLeaseRequest.RequestPending(); ok {
-		return *r.mu.state.Lease, &nextLease
+		return *r.mu.state.Lease, nextLease
 	}
-	return *r.mu.state.Lease, nil
+	return *r.mu.state.Lease, roachpb.Lease{}
 }
 
 // OwnsValidLease returns whether this replica is the current valid

--- a/pkg/storage/replica_eval_context_span.go
+++ b/pkg/storage/replica_eval_context_span.go
@@ -182,7 +182,7 @@ func (rec SpanSetReplicaEvalContext) GetLastReplicaGCTimestamp(
 }
 
 // GetLease returns the Replica's current and next lease (if any).
-func (rec SpanSetReplicaEvalContext) GetLease() (roachpb.Lease, *roachpb.Lease) {
+func (rec SpanSetReplicaEvalContext) GetLease() (roachpb.Lease, roachpb.Lease) {
 	rec.ss.AssertAllowed(spanset.SpanReadOnly,
 		roachpb.Span{Key: keys.RangeLeaseKey(rec.GetRangeID())},
 	)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1117,7 +1117,7 @@ func (s *Store) SetDraining(drain bool) {
 						var llHandle *leaseRequestHandle
 						r.mu.Lock()
 						lease, nextLease := r.getLeaseRLocked()
-						if nextLease != nil && nextLease.OwnedBy(s.StoreID()) {
+						if nextLease != (roachpb.Lease{}) && nextLease.OwnedBy(s.StoreID()) {
 							llHandle = r.mu.pendingLeaseRequest.JoinRequest()
 						}
 						r.mu.Unlock()

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -437,7 +437,7 @@ func (s *Store) canApplySnapshotLocked(
 				lease, pendingLease := r.GetLease()
 				now := s.Clock().Now()
 				return !r.IsLeaseValid(lease, now) &&
-					(pendingLease == nil || !r.IsLeaseValid(*pendingLease, now))
+					(pendingLease == (roachpb.Lease{}) || !r.IsLeaseValid(pendingLease, now))
 			}
 
 			// If the existing range shows no signs of recent activity, give it a GC


### PR DESCRIPTION
Guard an expensive log.V in a log.ExpensiveLogEnabled.

Pass roachpb.Lease by value in one situation in which allocating it is
pointless.

cc @benesch

This seems to improve read-only kv performance by almost 5%!

Release note: None