### PR TITLE
rangefeed: add release valve to logical op consumption

### DIFF
--- a/pkg/storage/rangefeed/registry_test.go
+++ b/pkg/storage/rangefeed/registry_test.go
@@ -100,6 +100,11 @@ func (s *testStream) Events() []*roachpb.RangeFeedEvent {
 	return es
 }
 
+func (s *testStream) BlockSend() func() {
+	s.mu.Lock()
+	return s.mu.Unlock
+}
+
 type testRegistration struct {
 	registration
 	stream *testStream


### PR DESCRIPTION
This change adds a new `EventChanTimeout` configuration to
`rangefeed.Processor`. The config specifies the maximum duration
that `ConsumeLogicalOps` and `ForwardClosedTS` will block on the
Processor's input channel. Once the duration is exceeded, these
methods will stops the processor with an error and tear it down.
This prevents slow consumers from making callers of the two methods
block.

The first method is used downstream of Raft, where blocking due to
slow rangefeed consumers for an unbounded amount of time is unacceptable.
It may require that we resize the processor's input buffer.

A TODO is left about reducing the impact of a single slow consumer
on an entire rangefeed.Processor. This can be left as a future
improvement.

Release note: None