### PR TITLE
storage: make ComputeChecksum a point request

### DIFF
--- a/pkg/internal/client/batch.go
+++ b/pkg/internal/client/batch.go
@@ -516,24 +516,6 @@ func (b *Batch) ReverseScan(s, e interface{}) {
 	b.scan(s, e, true)
 }
 
-// CheckConsistency creates a batch request to check the consistency of the
-// ranges holding the span of keys from s to e. It logs a diff of all the
-// keys that are inconsistent when withDiff is set to true.
-func (b *Batch) CheckConsistency(s, e interface{}, withDiff bool) {
-	begin, err := marshalKey(s)
-	if err != nil {
-		b.initResult(0, 0, notRaw, err)
-		return
-	}
-	end, err := marshalKey(e)
-	if err != nil {
-		b.initResult(0, 0, notRaw, err)
-		return
-	}
-	b.appendReqs(roachpb.NewCheckConsistency(begin, end, withDiff))
-	b.initResult(1, 0, notRaw, nil)
-}
-
 // Del deletes one or more keys.
 //
 // A new result will be appended to the batch and each key will have a

--- a/pkg/internal/client/db.go
+++ b/pkg/internal/client/db.go
@@ -506,15 +506,6 @@ func (db *DB) AdminChangeReplicas(
 	return getOneErr(db.Run(ctx, b), b)
 }
 
-// CheckConsistency runs a consistency check on all the ranges containing
-// the key span. It logs a diff of all the keys that are inconsistent
-// when withDiff is set to true.
-func (db *DB) CheckConsistency(ctx context.Context, begin, end interface{}, withDiff bool) error {
-	b := &Batch{}
-	b.CheckConsistency(begin, end, withDiff)
-	return getOneErr(db.Run(ctx, b), b)
-}
-
 // WriteBatch applies the operations encoded in a BatchRepr, which is the
 // serialized form of a RocksDB Batch. The command cannot span Ranges and must
 // be run on an empty keyrange.

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -930,17 +930,6 @@ func NewScan(key, endKey Key) Request {
 	}
 }
 
-// NewCheckConsistency returns a Request initialized to scan from start to end keys.
-func NewCheckConsistency(key, endKey Key, withDiff bool) Request {
-	return &CheckConsistencyRequest{
-		RequestHeader: RequestHeader{
-			Key:    key,
-			EndKey: endKey,
-		},
-		WithDiff: withDiff,
-	}
-}
-
 // NewReverseScan returns a Request initialized to reverse scan from end to
 // start keys with max results.
 func NewReverseScan(key, endKey Key) Request {
@@ -1064,7 +1053,7 @@ func (*TransferLeaseRequest) flags() int {
 	return isWrite | isAlone | skipLeaseCheck
 }
 func (*RecomputeStatsRequest) flags() int   { return isWrite | isAlone }
-func (*ComputeChecksumRequest) flags() int  { return isWrite | isRange }
+func (*ComputeChecksumRequest) flags() int  { return isWrite }
 func (*CheckConsistencyRequest) flags() int { return isAdmin | isRange }
 func (*WriteBatchRequest) flags() int       { return isWrite | isRange }
 func (*ExportRequest) flags() int           { return isRead | isRange | updatesReadTSCache }

--- a/pkg/storage/batcheval/cmd_compute_checksum.go
+++ b/pkg/storage/batcheval/cmd_compute_checksum.go
@@ -21,13 +21,22 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 func init() {
-	RegisterCommand(roachpb.ComputeChecksum, DefaultDeclareKeys, ComputeChecksum)
+	RegisterCommand(roachpb.ComputeChecksum, declareKeysComputeChecksum, ComputeChecksum)
+}
+
+func declareKeysComputeChecksum(
+	roachpb.RangeDescriptor, roachpb.Header, roachpb.Request, *spanset.SpanSet,
+) {
+	// Intentionally declare no keys, as ComputeChecksum does not need to be
+	// serialized with any other commands. It simply needs to be committed into
+	// the Raft log.
 }
 
 // Version numbers for Replica checksum computation. Requests silently no-op

--- a/pkg/storage/replica_consistency.go
+++ b/pkg/storage/replica_consistency.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
@@ -60,21 +59,12 @@ const (
 func (r *Replica) CheckConsistency(
 	ctx context.Context, args roachpb.CheckConsistencyRequest,
 ) (roachpb.CheckConsistencyResponse, *roachpb.Error) {
-	desc := r.Desc()
-	key := desc.StartKey.AsRawKey()
-	// Keep the request from crossing the local->global boundary.
-	if bytes.Compare(key, keys.LocalMax) < 0 {
-		key = keys.LocalMax
-	}
-	endKey := desc.EndKey.AsRawKey()
+	startKey := r.Desc().StartKey.AsRawKey()
 
 	checkArgs := roachpb.ComputeChecksumRequest{
-		RequestHeader: roachpb.RequestHeader{
-			Key:    key,
-			EndKey: endKey,
-		},
-		Version:  batcheval.ReplicaChecksumVersion,
-		Snapshot: args.WithDiff,
+		RequestHeader: roachpb.RequestHeader{Key: startKey},
+		Version:       batcheval.ReplicaChecksumVersion,
+		Snapshot:      args.WithDiff,
 	}
 
 	results, err := r.RunConsistencyCheck(ctx, checkArgs)
@@ -127,7 +117,7 @@ func (r *Replica) CheckConsistency(
 		log.Infof(ctx, "triggering stats recomputation to resolve delta of %+v", results[0].Response.Delta)
 
 		req := roachpb.RecomputeStatsRequest{
-			RequestHeader: roachpb.RequestHeader{Key: desc.StartKey.AsRawKey()},
+			RequestHeader: roachpb.RequestHeader{Key: startKey},
 		}
 
 		var b client.Batch
@@ -157,8 +147,9 @@ func (r *Replica) CheckConsistency(
 	// Note that this will call Fatal recursively in `CheckConsistency` (in the code above).
 	log.Errorf(ctx, "consistency check failed with %d inconsistent replicas; fetching details",
 		inconsistencyCount)
-	if err := r.store.db.CheckConsistency(ctx, key, endKey, true /* withDiff */); err != nil {
-		logFunc(ctx, "replica inconsistency detected; could not obtain actual diff: %s", err)
+	args.WithDiff = true
+	if _, pErr := r.CheckConsistency(ctx, args); pErr != nil {
+		logFunc(ctx, "replica inconsistency detected; could not obtain actual diff: %s", pErr)
 	}
 
 	// Not reached except in tests.


### PR DESCRIPTION
ComputeChecksum was previously implemented as a range request, which
meant it could be split by DistSender, resulting in two ComputeChecksum
requests with identical IDs! If those split ranges get routed to the
same range (e.g. because the ranges were just merged), spurious checksum
failures could occur (#28995). Plus, the ComputeChecksum request would
not actually look at the range boundaries in the request header; it
always operated on the range's entire keyspace at the time the request
was applied.

The fix is simple: make ComputeChecksum a point request. There are no
version compatibility issues here; nodes with this commit are simply
smarter about routing ComputeChecksum requests to only one range.

Fix #29002.

Release note: None