### PR TITLE
backport-2.1: cli: remove "pretty" as display_format option

### DIFF
--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -286,7 +286,7 @@ var options = map[string]struct {
 		},
 	},
 	`display_format`: {
-		"the output format for tabular data (table, csv, tsv, html, sql, records, raw, pretty)",
+		"the output format for tabular data (table, csv, tsv, html, sql, records, raw)",
 		false,
 		true,
 		func(_ *cliState, val string) error {


### PR DESCRIPTION
Backport 1/1 commits from #28968.

/cc @cockroachdb/release

---

This hasn't been an option since #28465.

Release note: None
