### PR TITLE
backport-2.1: storage: fix slow quota pool log

### DIFF
--- a/pkg/storage/quota_pool.go
+++ b/pkg/storage/quota_pool.go
@@ -100,10 +100,10 @@ func (qp *quotaPool) add(v int64) {
 
 func logSlowQuota(ctx context.Context, v int64, start time.Time) func() {
 	log.Warningf(ctx, "have been waiting %s attempting to acquire %s of proposal quota",
-		humanizeutil.IBytes(v),
-		timeutil.Since(start))
+		timeutil.Since(start), humanizeutil.IBytes(v))
 	return func() {
-		log.Infof(ctx, "acquiring %v of proposal quota after %s resulted in %v", v, humanizeutil.IBytes(v), timeutil.Since(start))
+		log.Infof(ctx, "acquired %s of proposal quota after %s",
+			humanizeutil.IBytes(v), timeutil.Since(start))
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #29054.

/cc @cockroachdb/release

---

"have been waiting 86 B attempting to acquire 1m0.000123123s of
proposal quota" didn't quite look right. The other log below didn't
look much better.

Release note: None
