### PR TITLE
release-2.0: storage/txnwait: don't leak waiting queries in MaybeWaitForQuery

### DIFF
--- a/pkg/storage/txnwait/queue.go
+++ b/pkg/storage/txnwait/queue.go
@@ -89,11 +89,12 @@ type waitingPush struct {
 	}
 }
 
-// A waitingQuery represents a QueryTxn command that is waiting on
-// a target transaction to change status or acquire new dependencies.
-type waitingQuery struct {
-	req     *roachpb.QueryTxnRequest
+// A waitingQueries object represents one or more QueryTxn commands that are
+// waiting on the same target transaction to change status or acquire new
+// dependencies.
+type waitingQueries struct {
 	pending chan struct{}
+	count   int
 }
 
 // A pendingTxn represents a transaction waiting to be pushed by one
@@ -154,7 +155,7 @@ type Queue struct {
 	mu    struct {
 		syncutil.Mutex
 		txns    map[uuid.UUID]*pendingTxn
-		queries map[uuid.UUID][]*waitingQuery
+		queries map[uuid.UUID]*waitingQueries
 	}
 }
 
@@ -175,7 +176,7 @@ func (q *Queue) Enable() {
 		q.mu.txns = map[uuid.UUID]*pendingTxn{}
 	}
 	if q.mu.queries == nil {
-		q.mu.queries = map[uuid.UUID][]*waitingQuery{}
+		q.mu.queries = map[uuid.UUID]*waitingQueries{}
 	}
 }
 
@@ -193,11 +194,11 @@ func (q *Queue) Clear(disable bool) {
 		}
 		pt.waitingPushes = nil
 	}
-	var queryWaiters []chan struct{}
-	for _, waitingQueries := range q.mu.queries {
-		for _, w := range waitingQueries {
-			queryWaiters = append(queryWaiters, w.pending)
-		}
+
+	queryWaiters := q.mu.queries
+	queryWaitersCount := 0
+	for _, waitingQueries := range queryWaiters {
+		queryWaitersCount += waitingQueries.count
 	}
 
 	if log.V(1) {
@@ -205,7 +206,7 @@ func (q *Queue) Clear(disable bool) {
 			context.Background(),
 			"clearing %d push waiters and %d query waiters",
 			len(pushWaiters),
-			len(queryWaiters),
+			queryWaitersCount,
 		)
 	}
 
@@ -214,7 +215,7 @@ func (q *Queue) Clear(disable bool) {
 		q.mu.queries = nil
 	} else {
 		q.mu.txns = map[uuid.UUID]*pendingTxn{}
-		q.mu.queries = map[uuid.UUID][]*waitingQuery{}
+		q.mu.queries = map[uuid.UUID]*waitingQueries{}
 	}
 	q.mu.Unlock()
 
@@ -224,7 +225,7 @@ func (q *Queue) Clear(disable bool) {
 	}
 	// Close query waiters outside of the mutex lock.
 	for _, w := range queryWaiters {
-		close(w)
+		close(w.pending)
 	}
 }
 
@@ -263,15 +264,7 @@ func (q *Queue) UpdateTxn(ctx context.Context, txn *roachpb.Transaction) {
 	txn.AssertInitialized(ctx)
 	q.mu.Lock()
 
-	if log.V(1) {
-		if count := len(q.mu.queries[txn.ID]); count > 0 {
-			log.Infof(ctx, "returning %d waiting queries for %s", count, txn.ID.Short())
-		}
-	}
-	for _, w := range q.mu.queries[txn.ID] {
-		close(w.pending)
-	}
-	delete(q.mu.queries, txn.ID)
+	q.releaseWaitingQueriesLocked(ctx, txn.ID)
 
 	if q.mu.txns == nil {
 		// Not enabled; do nothing.
@@ -341,20 +334,12 @@ func (q *Queue) isTxnUpdated(pending *pendingTxn, req *roachpb.QueryTxnRequest) 
 	return false
 }
 
-func (q *Queue) clearWaitingQueriesLocked(ctx context.Context, txnID uuid.UUID) {
-	waitingQueries := q.mu.queries[txnID]
-	if log.V(1) && len(waitingQueries) > 0 {
-		log.Infof(
-			ctx,
-			"proceeding with %d query waiters for %s",
-			len(waitingQueries),
-			txnID.Short(),
-		)
-	}
-	for _, w := range waitingQueries {
+func (q *Queue) releaseWaitingQueriesLocked(ctx context.Context, txnID uuid.UUID) {
+	if w, ok := q.mu.queries[txnID]; ok {
+		log.VEventf(ctx, 2, "releasing %d waiting queries for %s", w.count, txnID.Short())
 		close(w.pending)
+		delete(q.mu.queries, txnID)
 	}
-	delete(q.mu.queries, txnID)
 }
 
 // ErrDeadlock is a sentinel error returned when a cyclic dependency between
@@ -411,7 +396,7 @@ func (q *Queue) MaybeWaitForPush(
 	// transaction, send on the waiting queries' channel to
 	// indicate there is a new dependent and they should proceed
 	// to execute the QueryTxn command.
-	q.clearWaitingQueriesLocked(ctx, req.PusheeTxn.ID)
+	q.releaseWaitingQueriesLocked(ctx, req.PusheeTxn.ID)
 
 	if req.PusherTxn.ID != (uuid.UUID{}) {
 		log.VEventf(
@@ -542,7 +527,7 @@ func (q *Queue) MaybeWaitForPush(
 			// Since the pusher has been updated, clear any waiting queries
 			// so that they continue with a query of new dependents added here.
 			q.mu.Lock()
-			q.clearWaitingQueriesLocked(ctx, req.PusheeTxn.ID)
+			q.releaseWaitingQueriesLocked(ctx, req.PusheeTxn.ID)
 			q.mu.Unlock()
 
 			if haveDependency {
@@ -596,11 +581,10 @@ func (q *Queue) MaybeWaitForQuery(
 	}
 
 	var maxWaitCh <-chan time.Time
-	pending, ok := q.mu.txns[req.Txn.ID]
 	// If the transaction we're waiting to query has a queue of txns
 	// in turn waiting on it, and is _already_ updated from what the
 	// caller is expecting, return to query the updates immediately.
-	if ok && q.isTxnUpdated(pending, req) {
+	if pending, ok := q.mu.txns[req.Txn.ID]; ok && q.isTxnUpdated(pending, req) {
 		q.mu.Unlock()
 		return nil
 	} else if !ok {
@@ -612,16 +596,35 @@ func (q *Queue) MaybeWaitForQuery(
 		maxWaitCh = time.After(maxWaitForQueryTxn)
 	}
 
-	query := &waitingQuery{
-		req:     req,
-		pending: make(chan struct{}),
+	// Add a new query to wait for updates to the transaction. If a query
+	// already exists, we can just increment its reference count.
+	query, ok := q.mu.queries[req.Txn.ID]
+	if ok {
+		query.count++
+	} else {
+		query = &waitingQueries{
+			pending: make(chan struct{}),
+			count:   1,
+		}
+		q.mu.queries[req.Txn.ID] = query
 	}
-	q.mu.queries[req.Txn.ID] = append(q.mu.queries[req.Txn.ID], query)
 	q.mu.Unlock()
 
-	if log.V(2) {
-		log.Infof(ctx, "waiting on query for %s", req.Txn.ID.Short())
-	}
+	// When we return, make sure to unregister the query so that it doesn't
+	// leak. If query.pending if closed, the query will have already been
+	// cleaned up, so this will be a no-op.
+	defer func() {
+		q.mu.Lock()
+		if query == q.mu.queries[req.Txn.ID] {
+			query.count--
+			if query.count == 0 {
+				delete(q.mu.queries, req.Txn.ID)
+			}
+		}
+		q.mu.Unlock()
+	}()
+
+	log.VEventf(ctx, 2, "waiting on query for %s", req.Txn.ID.Short())
 	select {
 	case <-ctx.Done():
 		// Caller has given up.


### PR DESCRIPTION
Backport 1/1 commits from #29025.

/cc @cockroachdb/release

---

Fixes #28849.

The theorized leak in #28849 was almost spot on. I instrumented the original
code and pointed 6 workload generators running `tpcc` with `wait=false` at a
single node (adding more workers to a single workload generator wasn't as good
at creating contention). I was pretty quickly able to see the size of
`Queue.mu.queries` grow on a few hot ranges due to context cancellation in
`MaybeWaitForQuery`. It turns out that both context cancellation and the
internal timeout in `MaybeWaitForQuery` (`maxWaitCh`) could result in a memory
leak.

This change fixes this leak by doing a better job ensuring that waiters clean up
after themselves if they stop waiting prematurely. In doing so, it simplifies
the `waitingQueries` structure by changing it from a slice of channels and a
useless `*roachpb.QueryTxnRequest` (that exacerbated the leak and turned out to
be quite useful in debugging it) to a single refcounted channel. With this
structure, its straightforward for waiters to unregister prematurely and clean
up associated resources if necessary.

I could not reproduce the same behavior with `tpcc` after this change. I wasn't
able to get the size of `Queue.mu.queries` to grow without bound.

Release note (bug fix): Fix memory leak when contended queries time out.
