### PR TITLE
config: prefer IPv4 in mixed IPv4/IPv6 environments

### DIFF
--- a/pkg/base/addr_validation.go
+++ b/pkg/base/addr_validation.go
@@ -229,9 +229,20 @@ func resolveAddr(ctx context.Context, host, port string) (string, string, error)
 		return "", "", fmt.Errorf("cannot resolve %q to an address", host)
 	}
 
-	// TODO(knz): this function can be changed to return all resolved
-	// addresses once the server is taught to listen on multiple
-	// interfaces. #5816
+	// TODO(knz): the remainder function can be changed to return all
+	// resolved addresses once the server is taught to listen on
+	// multiple interfaces. #5816
+
+	// LookupIPAddr() can return a mix of IPv6 and IPv4
+	// addresses. Conventionally, the first resolved address is
+	// "preferred"; however, for compatibility with previous CockroachDB
+	// versions, we still prefer an IPv4 address if there is one.
+	for _, addr := range addrs {
+		if ip := addr.IP.To4(); ip != nil {
+			return ip.String(), port, nil
+		}
+	}
+	// No IPv4 address, return the first resolved address instead.
 	return addrs[0].String(), port, nil
 }
 


### PR DESCRIPTION
Fixes #28713.

CockroachDB has traditionally relied on name resolution by Go's
`net.Listen()` function. This code, for better or for worse, is
written to prefer IPv4 if the name provided resolves to both IPv4 and
IPv6 addresses.

When the CockroachDB code was recently changed to perform resolution
upfront, this behavior was not preserved and may have induced UX
surprise.

This patch recovers the pre-2.1 behavior by again preferring IPv4 if
both address types are available.

Release note (bug fix): CockroachDB will now again prefer using
an IPv4 listen address if a host name with both IPv4 and IPv6
addresses is provided to `--host`/`--listen-addr`/`--advertise`.