### PR TITLE
storage: log Epoch lease only when changing hands

### DIFF
--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -204,9 +204,9 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease) {
 	leaseChangingHands := prevLease.Replica.StoreID != newLease.Replica.StoreID || prevLease.Sequence != newLease.Sequence
 
 	if iAmTheLeaseHolder {
-		// Always log lease acquisition for epoch-based leases which are
-		// infrequent.
-		if newLease.Type() == roachpb.LeaseEpoch || (log.V(1) && leaseChangingHands) {
+		// Log lease acquisition whenever an Epoch-based lease changes hands (or verbose
+		// logging is enabled).
+		if (newLease.Type() == roachpb.LeaseEpoch && leaseChangingHands) || log.V(1) {
 			log.Infof(ctx, "new range lease %s following %s", newLease, prevLease)
 		}
 	}


### PR DESCRIPTION
This should noticeably denoise the logs for clusters that have
lots of ranges. After restarting a node in such a cluster, a
long tail of these messages would crop up as the various queues
acquired lease on otherwise dormant ranges previously lead by
the restarted node.

I think we'll need to do more to reign in these messages in
the future, but this is a good start.

Release note: None