### PR TITLE
sql: fix problems with reusing descriptor names

### DIFF
--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -329,7 +329,7 @@ func (p *planner) initiateDropTable(
 	//
 	// TODO(bram): If interleaved and ON DELETE CASCADE, we will be
 	// able to use this faster mechanism.
-	if !tableDesc.IsInterleaved() &&
+	if tableDesc.IsTable() && !tableDesc.IsInterleaved() &&
 		p.ExecCfg().Settings.Version.IsActive(cluster.VersionClearRange) {
 		// Get the zone config applying to this table in order to
 		// ensure there is a GC TTL.


### PR DESCRIPTION
This change fixes two problems with descriptor name reuse
when a session ends after committing a schema change but before
executing it. The asynchronous execution of schema changes had
two bugs.
1. The table data GC delay was being incorrectly applied to
VIEW and SEQUENCE types.
2. A table that was dropped was put on the delayed deletion
queue without first checking if its name had been GC-ed.

fixes #28409
related to #27135

Release note (sql change): Fix problem with VIEW/TABLE name not
being recycled quickly after DROP VIEW/TABLE.