### PR TITLE
backport-2.1: storage: Up-replicate before removing replicas from dead stores

### DIFF
--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -3937,7 +3937,75 @@ func TestAllocatorComputeAction(t *testing.T) {
 		desc           roachpb.RangeDescriptor
 		expectedAction AllocatorAction
 	}{
-		// Needs three replicas, have two
+		// Need three replicas, have three, one is on a dead store.
+		{
+			zone: config.ZoneConfig{
+				NumReplicas:   3,
+				Constraints:   []config.Constraints{{Constraints: []config.Constraint{{Value: "us-east", Type: config.Constraint_DEPRECATED_POSITIVE}}}},
+				RangeMinBytes: 0,
+				RangeMaxBytes: 64000,
+			},
+			desc: roachpb.RangeDescriptor{
+				Replicas: []roachpb.ReplicaDescriptor{
+					{
+						StoreID:   1,
+						NodeID:    1,
+						ReplicaID: 1,
+					},
+					{
+						StoreID:   2,
+						NodeID:    2,
+						ReplicaID: 2,
+					},
+					{
+						StoreID:   6,
+						NodeID:    6,
+						ReplicaID: 6,
+					},
+				},
+			},
+			expectedAction: AllocatorAdd,
+		},
+		// Need five replicas, one is on a dead store.
+		{
+			zone: config.ZoneConfig{
+				NumReplicas:   5,
+				Constraints:   []config.Constraints{{Constraints: []config.Constraint{{Value: "us-east", Type: config.Constraint_DEPRECATED_POSITIVE}}}},
+				RangeMinBytes: 0,
+				RangeMaxBytes: 64000,
+			},
+			desc: roachpb.RangeDescriptor{
+				Replicas: []roachpb.ReplicaDescriptor{
+					{
+						StoreID:   1,
+						NodeID:    1,
+						ReplicaID: 1,
+					},
+					{
+						StoreID:   2,
+						NodeID:    2,
+						ReplicaID: 2,
+					},
+					{
+						StoreID:   3,
+						NodeID:    3,
+						ReplicaID: 3,
+					},
+					{
+						StoreID:   4,
+						NodeID:    4,
+						ReplicaID: 4,
+					},
+					{
+						StoreID:   6,
+						NodeID:    6,
+						ReplicaID: 6,
+					},
+				},
+			},
+			expectedAction: AllocatorAdd,
+		},
+		// Need three replicas, have two.
 		{
 			zone: config.ZoneConfig{
 				NumReplicas:   3,
@@ -3961,7 +4029,41 @@ func TestAllocatorComputeAction(t *testing.T) {
 			},
 			expectedAction: AllocatorAdd,
 		},
-		// Needs Five replicas, have four.
+		// Need five replicas, have four, one is on a dead store.
+		{
+			zone: config.ZoneConfig{
+				NumReplicas:   5,
+				Constraints:   []config.Constraints{{Constraints: []config.Constraint{{Value: "us-east", Type: config.Constraint_DEPRECATED_POSITIVE}}}},
+				RangeMinBytes: 0,
+				RangeMaxBytes: 64000,
+			},
+			desc: roachpb.RangeDescriptor{
+				Replicas: []roachpb.ReplicaDescriptor{
+					{
+						StoreID:   1,
+						NodeID:    1,
+						ReplicaID: 1,
+					},
+					{
+						StoreID:   2,
+						NodeID:    2,
+						ReplicaID: 2,
+					},
+					{
+						StoreID:   3,
+						NodeID:    3,
+						ReplicaID: 3,
+					},
+					{
+						StoreID:   6,
+						NodeID:    6,
+						ReplicaID: 6,
+					},
+				},
+			},
+			expectedAction: AllocatorAdd,
+		},
+		// Need five replicas, have four.
 		{
 			zone: config.ZoneConfig{
 				NumReplicas:   5,
@@ -3995,10 +4097,10 @@ func TestAllocatorComputeAction(t *testing.T) {
 			},
 			expectedAction: AllocatorAdd,
 		},
-		// Needs Five replicas, have four, one is on a dead store
+		// Need three replicas, have four, one is on a dead store.
 		{
 			zone: config.ZoneConfig{
-				NumReplicas:   5,
+				NumReplicas:   3,
 				Constraints:   []config.Constraints{{Constraints: []config.Constraint{{Value: "us-east", Type: config.Constraint_DEPRECATED_POSITIVE}}}},
 				RangeMinBytes: 0,
 				RangeMaxBytes: 64000,
@@ -4027,12 +4129,12 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorAdd,
+			expectedAction: AllocatorRemoveDead,
 		},
-		// Needs three replicas, one is on a dead store.
+		// Need five replicas, have six, one is on a dead store.
 		{
 			zone: config.ZoneConfig{
-				NumReplicas:   3,
+				NumReplicas:   5,
 				Constraints:   []config.Constraints{{Constraints: []config.Constraint{{Value: "us-east", Type: config.Constraint_DEPRECATED_POSITIVE}}}},
 				RangeMinBytes: 0,
 				RangeMaxBytes: 64000,
@@ -4048,6 +4150,21 @@ func TestAllocatorComputeAction(t *testing.T) {
 						StoreID:   2,
 						NodeID:    2,
 						ReplicaID: 2,
+					},
+					{
+						StoreID:   3,
+						NodeID:    3,
+						ReplicaID: 3,
+					},
+					{
+						StoreID:   4,
+						NodeID:    4,
+						ReplicaID: 4,
+					},
+					{
+						StoreID:   5,
+						NodeID:    5,
+						ReplicaID: 5,
 					},
 					{
 						StoreID:   6,
@@ -4058,39 +4175,10 @@ func TestAllocatorComputeAction(t *testing.T) {
 			},
 			expectedAction: AllocatorRemoveDead,
 		},
-		// Needs three replicas, one is dead.
+		// Need three replicas, have five, one is on a dead store.
 		{
 			zone: config.ZoneConfig{
 				NumReplicas:   3,
-				Constraints:   []config.Constraints{{Constraints: []config.Constraint{{Value: "us-east", Type: config.Constraint_DEPRECATED_POSITIVE}}}},
-				RangeMinBytes: 0,
-				RangeMaxBytes: 64000,
-			},
-			desc: roachpb.RangeDescriptor{
-				Replicas: []roachpb.ReplicaDescriptor{
-					{
-						StoreID:   1,
-						NodeID:    1,
-						ReplicaID: 1,
-					},
-					{
-						StoreID:   2,
-						NodeID:    2,
-						ReplicaID: 2,
-					},
-					{
-						StoreID:   8,
-						NodeID:    8,
-						ReplicaID: 8,
-					},
-				},
-			},
-			expectedAction: AllocatorRemoveDead,
-		},
-		// Needs five replicas, one is on a dead store.
-		{
-			zone: config.ZoneConfig{
-				NumReplicas:   5,
 				Constraints:   []config.Constraints{{Constraints: []config.Constraint{{Value: "us-east", Type: config.Constraint_DEPRECATED_POSITIVE}}}},
 				RangeMinBytes: 0,
 				RangeMaxBytes: 64000,
@@ -4430,70 +4518,77 @@ func TestAllocatorRebalanceTargetDisableStatsRebalance(t *testing.T) {
 func TestAllocatorComputeActionRemoveDead(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	zone := config.ZoneConfig{
+		NumReplicas: 3,
+	}
+	threeReplDesc := roachpb.RangeDescriptor{
+		Replicas: []roachpb.ReplicaDescriptor{
+			{
+				StoreID:   1,
+				NodeID:    1,
+				ReplicaID: 1,
+			},
+			{
+				StoreID:   2,
+				NodeID:    2,
+				ReplicaID: 2,
+			},
+			{
+				StoreID:   3,
+				NodeID:    3,
+				ReplicaID: 3,
+			},
+		},
+	}
+	fourReplDesc := threeReplDesc
+	fourReplDesc.Replicas = append(fourReplDesc.Replicas, roachpb.ReplicaDescriptor{
+		StoreID:   4,
+		NodeID:    4,
+		ReplicaID: 4,
+	})
+
 	// Each test case should describe a repair situation which has a lower
 	// priority than the previous test case.
 	testCases := []struct {
-		zone           config.ZoneConfig
 		desc           roachpb.RangeDescriptor
-		expectedAction AllocatorAction
 		live           []roachpb.StoreID
 		dead           []roachpb.StoreID
+		expectedAction AllocatorAction
 	}{
-		// Needs three replicas, one is dead, but there is no replacement.
+		// Needs three replicas, one is dead, and there's no replacement.
 		{
-			zone: config.ZoneConfig{
-				NumReplicas: 3,
-			},
-			desc: roachpb.RangeDescriptor{
-				Replicas: []roachpb.ReplicaDescriptor{
-					{
-						StoreID:   1,
-						NodeID:    1,
-						ReplicaID: 1,
-					},
-					{
-						StoreID:   2,
-						NodeID:    2,
-						ReplicaID: 2,
-					},
-					{
-						StoreID:   3,
-						NodeID:    3,
-						ReplicaID: 3,
-					},
-				},
-			},
-			expectedAction: AllocatorConsiderRebalance,
+			desc:           threeReplDesc,
 			live:           []roachpb.StoreID{1, 2},
 			dead:           []roachpb.StoreID{3},
+			expectedAction: AllocatorAdd,
 		},
 		// Needs three replicas, one is dead, but there is a replacement.
 		{
-			zone: config.ZoneConfig{
-				NumReplicas: 3,
-			},
-			desc: roachpb.RangeDescriptor{
-				Replicas: []roachpb.ReplicaDescriptor{
-					{
-						StoreID:   1,
-						NodeID:    1,
-						ReplicaID: 1,
-					},
-					{
-						StoreID:   2,
-						NodeID:    2,
-						ReplicaID: 2,
-					},
-					{
-						StoreID:   3,
-						NodeID:    3,
-						ReplicaID: 3,
-					},
-				},
-			},
-			expectedAction: AllocatorRemoveDead,
+			desc:           threeReplDesc,
 			live:           []roachpb.StoreID{1, 2, 4},
 			dead:           []roachpb.StoreID{3},
+			expectedAction: AllocatorAdd,
+		},
+		// Needs three replicas, two are dead (i.e. the range lacks a quorum).
+		{
+			desc:           threeReplDesc,
+			live:           []roachpb.StoreID{1, 4},
+			dead:           []roachpb.StoreID{2, 3},
+			expectedAction: AllocatorNoop,
+		},
+		// Needs three replicas, has four, one is dead.
+		{
+			desc:           fourReplDesc,
+			live:           []roachpb.StoreID{1, 2, 4},
+			dead:           []roachpb.StoreID{3},
+			expectedAction: AllocatorRemoveDead,
+		},
+		// Needs three replicas, has four, two are dead (i.e. the range lacks a quorum).
+		{
+			desc:           fourReplDesc,
+			live:           []roachpb.StoreID{1, 4},
+			dead:           []roachpb.StoreID{2, 3},
+			expectedAction: AllocatorNoop,
 		},
 	}
 
@@ -4504,7 +4599,7 @@ func TestAllocatorComputeActionRemoveDead(t *testing.T) {
 	for i, tcase := range testCases {
 		mockStorePool(sp, tcase.live, tcase.dead, nil, nil, nil)
 
-		action, _ := a.ComputeAction(ctx, tcase.zone, RangeInfo{Desc: &tcase.desc}, false)
+		action, _ := a.ComputeAction(ctx, zone, RangeInfo{Desc: &tcase.desc}, false)
 		if tcase.expectedAction != action {
 			t.Errorf("Test case %d expected action %d, got action %d", i, tcase.expectedAction, action)
 		}

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -305,7 +305,7 @@ func (rq *replicateQueue) processOneChange(
 		newStore, details, err := rq.allocator.AllocateTarget(
 			ctx,
 			zone,
-			desc.Replicas,
+			liveReplicas, // only include liveReplicas, since deadReplicas should soon be removed
 			rangeInfo,
 			disableStatsBasedRebalancing,
 		)


### PR DESCRIPTION
Backport 1/1 commits from #28875.

/cc @cockroachdb/release

---

Fixes #25392, by preventing the following series of events:

1. Node x dies
2. We remove node x's replica of some range
3. Node y dies before we up-replicate, leaving the range unavailable (1
   out of 2 replicas dead)
4. Node x comes back online. It can't help the situation, because its
   replica was officially removed from the range.

Instead, we now up-replicate first before removing node x's replica.

Release note: None
