### PR TITLE
rangefeed: small perf-related changes

### DIFF
--- a/pkg/storage/rangefeed/processor.go
+++ b/pkg/storage/rangefeed/processor.go
@@ -37,7 +37,7 @@ const (
 	defaultPushTxnsAge = 10 * time.Second
 	// defaultCheckStreamsInterval is the default interval at which a Processor
 	// will check all streams to make sure they have not been canceled.
-	defaultCheckStreamsInterval = 100 * time.Millisecond
+	defaultCheckStreamsInterval = 1 * time.Second
 )
 
 // newErrBufferCapacityExceeded creates an error that is returned to subscribers

--- a/pkg/storage/rangefeed/registry.go
+++ b/pkg/storage/rangefeed/registry.go
@@ -204,18 +204,20 @@ func (reg *registry) forOverlappingRegs(
 	span roachpb.Span, fn func(*registration) (disconnect bool, pErr *roachpb.Error),
 ) {
 	var toDelete []interval.Interface
-	reg.tree.DoMatching(
-		func(i interval.Interface) (done bool) {
-			r := i.(*registration)
-			dis, pErr := fn(r)
-			if dis {
-				r.errC <- pErr
-				toDelete = append(toDelete, i)
-			}
-			return false
-		},
-		span.AsRange(),
-	)
+	matchFn := func(i interval.Interface) (done bool) {
+		r := i.(*registration)
+		dis, pErr := fn(r)
+		if dis {
+			r.errC <- pErr
+			toDelete = append(toDelete, i)
+		}
+		return false
+	}
+	if span.EqualValue(all) {
+		reg.tree.Do(matchFn)
+	} else {
+		reg.tree.DoMatching(matchFn, span.AsRange())
+	}
 
 	if len(toDelete) == reg.tree.Len() {
 		reg.tree.Clear()


### PR DESCRIPTION
This PR includes two small perf tweak that came up
which running cdc/w=100/nodes=3/init=true.

Release note: None