### PR TITLE
ui: cleanup cluster summary widest breakpoint

### DIFF
--- a/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
@@ -38,6 +38,9 @@
     @media screen and (min-width: 1400px)
       grid-template-columns 100px 135px 100px 135px 1fr 100px 100px 100px 1fr 100px 168px 100px
 
+    @media screen and (min-width: 1720px)
+      grid-template-columns 125px 135px 125px 135px 1fr 125px 125px 125px 1fr 168px 168px 168px
+
     .capacity-usage
       &.cluster-summary__title
           grid-area cap-t


### PR DESCRIPTION
Letting the font size increase without increasing the grid cells
on the widest breakpoint allows the text to overflow.  This tweak
should give it enough room for the common cases, but we should
come back and make this more principled soon.

Release note (admin ui change): Fix a bug that would allow the
cluster summary text to overflow its space.

Before:
<img width="1749" alt="screen shot 2018-08-27 at 2 53 48 pm" src="https://user-images.githubusercontent.com/793969/44679471-10ea0580-aa09-11e8-93e6-071e63d4211f.png">

After:
<img width="1746" alt="screen shot 2018-08-27 at 2 53 39 pm" src="https://user-images.githubusercontent.com/793969/44679473-15162300-aa09-11e8-9bf2-157f17488a9d.png">