### PR TITLE
kv: silence spammy log

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -341,9 +341,11 @@ func (ds *DistSender) getNodeDescriptor() *roachpb.NodeDescriptor {
 			return nodeDesc
 		}
 	}
-	ctx := ds.AnnotateCtx(context.TODO())
-	log.Infof(ctx, "unable to determine this node's attributes for replica "+
-		"selection; node is most likely bootstrapping")
+	if log.V(1) {
+		ctx := ds.AnnotateCtx(context.TODO())
+		log.Infof(ctx, "unable to determine this node's attributes for replica "+
+			"selection; node is most likely bootstrapping")
+	}
 	return nil
 }
 


### PR DESCRIPTION
This can fill pages of logs when a cluster starts, especially when it
never manages to connect go Gossip.

Release note: None