### PR TITLE
release-2.1: opt: minor ColList cleanup

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -594,7 +594,7 @@ func (b *logicalPropsBuilder) buildGroupByProps(ev ExprView) props.Logical {
 	// aggregate projection list.
 	groupingColSet := ev.Private().(*GroupByDef).GroupingCols
 	aggColList := ev.Child(1).Private().(opt.ColList)
-	relational.OutputCols = groupingColSet.Union(opt.ColListToSet(aggColList))
+	relational.OutputCols = groupingColSet.Union(aggColList.ToSet())
 
 	// Not Null Columns
 	// ----------------
@@ -659,7 +659,7 @@ func (b *logicalPropsBuilder) buildSetProps(ev ExprView) props.Logical {
 	// Output Columns
 	// --------------
 	// Output columns are stored in the definition.
-	relational.OutputCols = opt.ColListToSet(colMap.Out)
+	relational.OutputCols = colMap.Out.ToSet()
 
 	// Not Null Columns
 	// ----------------
@@ -711,7 +711,7 @@ func (b *logicalPropsBuilder) buildValuesProps(ev ExprView) props.Logical {
 	// Output Columns
 	// --------------
 	// Use output columns that are attached to the values op.
-	relational.OutputCols = opt.ColListToSet(ev.Private().(opt.ColList))
+	relational.OutputCols = ev.Private().(opt.ColList).ToSet()
 
 	// Not Null Columns
 	// ----------------
@@ -752,7 +752,7 @@ func (b *logicalPropsBuilder) buildExplainProps(ev ExprView) props.Logical {
 	// Output Columns
 	// --------------
 	// Output columns are stored in the definition.
-	relational.OutputCols = opt.ColListToSet(def.ColList)
+	relational.OutputCols = def.ColList.ToSet()
 
 	// Not Null Columns
 	// ----------------
@@ -787,7 +787,7 @@ func (b *logicalPropsBuilder) buildShowTraceProps(ev ExprView) props.Logical {
 	// Output Columns
 	// --------------
 	// Output columns are stored in the definition.
-	relational.OutputCols = opt.ColListToSet(def.ColList)
+	relational.OutputCols = def.ColList.ToSet()
 
 	// Not Null Columns
 	// ----------------
@@ -1024,7 +1024,7 @@ func (b *logicalPropsBuilder) buildZipProps(ev ExprView) props.Logical {
 	// Output Columns
 	// --------------
 	// Output columns are stored in the definition.
-	relational.OutputCols = opt.ColListToSet(ev.Private().(opt.ColList))
+	relational.OutputCols = ev.Private().(opt.ColList).ToSet()
 
 	// Not Null Columns
 	// ----------------

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -936,7 +936,7 @@ func (sb *statisticsBuilder) buildSetOp(ev ExprView, relProps *props.Relational)
 		// Since UNION, INTERSECT and EXCEPT eliminate duplicate rows, the row
 		// count will equal the distinct count of the set of output columns.
 		colMap := ev.Private().(*SetOpColMap)
-		outputCols := opt.ColListToSet(colMap.Out)
+		outputCols := colMap.Out.ToSet()
 		colStat := sb.colStatSetOpImpl(outputCols, ev, relProps)
 		s.RowCount = colStat.DistinctCount
 	}

--- a/pkg/sql/opt/metadata_column.go
+++ b/pkg/sql/opt/metadata_column.go
@@ -30,7 +30,16 @@ type ColSet = util.FastIntSet
 //
 // TODO(radu): perhaps implement a FastIntList with the same "small"
 // representation as FastIntMap but with a slice for large cases.
-type ColList = []ColumnID
+type ColList []ColumnID
+
+// ToSet converts a column id list to a column id set.
+func (cl ColList) ToSet() ColSet {
+	var r ColSet
+	for _, col := range cl {
+		r.Add(int(col))
+	}
+	return r
+}
 
 // ColMap provides a 1:1 mapping from one column id to another. It is used by
 // operators that need to match columns from its inputs.

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -256,7 +256,7 @@ func (c *CustomFuncs) OutputCols(group memo.GroupID) opt.ColSet {
 	expr := c.mem.NormExpr(group)
 	switch expr.Operator() {
 	case opt.AggregationsOp:
-		return opt.ColListToSet(c.ExtractColList(expr.AsAggregations().Cols()))
+		return c.ExtractColList(expr.AsAggregations().Cols()).ToSet()
 
 	case opt.ProjectionsOp:
 		return c.ExtractProjectionsOpDef(expr.AsProjections().Def()).AllCols()

--- a/pkg/sql/opt/ordering.go
+++ b/pkg/sql/opt/ordering.go
@@ -67,15 +67,6 @@ func (c OrderingColumn) Format(buf *bytes.Buffer) {
 	fmt.Fprintf(buf, "%d", c.ID())
 }
 
-// ColListToSet converts a column id list to a column id set.
-func ColListToSet(colList ColList) ColSet {
-	var r ColSet
-	for _, col := range colList {
-		r.Add(int(col))
-	}
-	return r
-}
-
 // Ordering defines the order of rows provided or required by an operator. A
 // negative value indicates descending order on the column id "-(value)".
 type Ordering []OrderingColumn

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -546,7 +546,7 @@ func (c *CustomFuncs) ConstructMergeJoins(
 	// left side. The CommuteJoin rule will ensure that we actually try both
 	// sides.
 	leftOrders := DeriveInterestingOrderings(memo.MakeNormExprView(c.e.mem, left)).Copy()
-	leftOrders.RestrictToCols(opt.ColListToSet(leftEq))
+	leftOrders.RestrictToCols(leftEq.ToSet())
 	if len(leftOrders) == 0 {
 		return nil
 	}


### PR DESCRIPTION
Backport 1/1 commits from #29120.

/cc @cockroachdb/release

---

Making `ColList` a type instead of an alias, and moving `ColListToSet`
to a method on this type.

Release note: None
