### PR TITLE
workload: make split concurrency constant

### DIFF
--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -279,8 +279,8 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 		return err
 	}
 
+	const splitConcurrency = 384 // TODO(dan): Don't hardcode this.
 	for _, table := range gen.Tables() {
-		splitConcurrency := len(ops.WorkerFns)
 		if err := workload.Split(ctx, initDB, table, splitConcurrency); err != nil {
 			return err
 		}


### PR DESCRIPTION
I had originally made the split concurrency for workload
dynamic, based on the concurrency of the workload itself.
This turned out to be a bad idea as it allowed for too
much contention during pre-splitting and resulted in
lots of split retries. The end result was that splits
slowed down over time instead of staying at a constant
rate.

This change makes the split concurrency constant like it
already is with fixture restoration:

https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/workloadccl/fixture.go#L449

This results in pre-splits on large cluster being more stable
and taking much less time (~50%).

Release note: None