### PR TITLE
cli: Provide helpful error message if quit run before init

### DIFF
--- a/pkg/server/servemode_test.go
+++ b/pkg/server/servemode_test.go
@@ -1,0 +1,37 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+func TestWaitingForInitError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	if err := WaitingForInitError("foo"); !IsWaitingForInit(err) {
+		t.Errorf("WaitingForInitError() not recognized by IsWaitingForInit(): %v", err)
+	}
+	if err := grpcstatus.Errorf(codes.Unavailable, "foo"); IsWaitingForInit(err) {
+		t.Errorf("unavailable error undesirably recognized by IsWaitingForInit(): %v", err)
+	}
+	if err := fmt.Errorf("node waiting for init"); IsWaitingForInit(err) {
+		t.Errorf("non-grpc error undesirably recognized by IsWaitingForInit(): %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #27957.

Previously it would log an error but then print "ok".

Release note (cli change): Improved error message printed when quit is
run on a node that has not yet been initialized.

Running quit against an uninitialized node now looks like:

```
$ ./cockroach quit --insecure
Error: node cannot be shut down before it has been initialized
Failed running "quit"
```