### PR TITLE
release-2.1: vendor: update pprof

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -257,14 +257,6 @@
   version = "2017.07.27"
 
 [[projects]]
-  digest = "1:b95738a1e6ace058b5b8544303c0871fc01d224ef0d672f778f696265d0f2917"
-  name = "github.com/chzyer/readline"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "62c6fe6193755f722b8b8788aa7357be55a50ff1"
-  version = "v1.4"
-
-[[projects]]
   digest = "1:be16f4bb5e875f3e5e90d08055e5f24c0aa75ca6b595d035380ce1f42db756dc"
   name = "github.com/client9/misspell"
   packages = [
@@ -708,10 +700,9 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1c6a34e679d4ef0df533ed5aadaa44feb5548435f48bf3d0bf1f4e2fc8aad891"
+  digest = "1:26fcd5801e409b8883ab1e89ae2432284d0f5aad0e44236a172a13401299db17"
   name = "github.com/google/pprof"
   packages = [
-    ".",
     "driver",
     "internal/binutils",
     "internal/driver",
@@ -1679,7 +1670,6 @@
     "github.com/golang/snappy",
     "github.com/google/btree",
     "github.com/google/go-github/github",
-    "github.com/google/pprof",
     "github.com/google/pprof/driver",
     "github.com/google/pprof/profile",
     "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -257,6 +257,14 @@
   version = "2017.07.27"
 
 [[projects]]
+  digest = "1:b95738a1e6ace058b5b8544303c0871fc01d224ef0d672f778f696265d0f2917"
+  name = "github.com/chzyer/readline"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "62c6fe6193755f722b8b8788aa7357be55a50ff1"
+  version = "v1.4"
+
+[[projects]]
   digest = "1:be16f4bb5e875f3e5e90d08055e5f24c0aa75ca6b595d035380ce1f42db756dc"
   name = "github.com/client9/misspell"
   packages = [
@@ -700,7 +708,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:296b06d527d1b5b96ebb48f006f2da7f41f6caa480d942feb2e002cdf788e924"
+  digest = "1:1c6a34e679d4ef0df533ed5aadaa44feb5548435f48bf3d0bf1f4e2fc8aad891"
   name = "github.com/google/pprof"
   packages = [
     ".",
@@ -717,11 +725,10 @@
     "profile",
     "third_party/d3",
     "third_party/d3flamegraph",
-    "third_party/d3tip",
     "third_party/svgpan",
   ]
   pruneopts = "UT"
-  revision = "60840899638bfaf3fd6f2b17b9785f1dac67a4a4"
+  revision = "d723c7237b64c7871a69e4c411acb04245bcd23d"
 
 [[projects]]
   digest = "1:e145e9710a10bc114a6d3e2738aadf8de146adaa031854ffdf7bbfe15da85e63"
@@ -1263,6 +1270,14 @@
   pruneopts = "UT"
   revision = "4a180b209f5f494e5923cfce81ea30ba23915877"
   version = "v2.18.06"
+
+[[projects]]
+  branch = "master"
+  digest = "1:99c6a6dab47067c9b898e8c8b13d130c6ab4ffbcc4b7cc6236c2cd0b1e344f5b"
+  name = "github.com/shirou/w32"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "bb4de0191aa41b5507caa14b0650cdbddcd9280b"
 
 [[projects]]
   digest = "1:5f2aaa360f48d1711795bd88c7e45a38f86cf81e4bc01453d20983baa67e2d51"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,6 @@ required = [
  "github.com/cockroachdb/stress",
  "github.com/golang/dep/cmd/dep",
  "github.com/golang/lint/golint",
- "github.com/google/pprof",
  "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway",
  "github.com/jteeuwen/go-bindata/go-bindata",
  "github.com/kisielk/errcheck",

--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,6 @@ bin/.bootstrap: $(GITHOOKS) Gopkg.lock | bin/.submodules-initialized
 		./vendor/github.com/cockroachdb/crlfmt \
 		./vendor/github.com/cockroachdb/stress \
 		./vendor/github.com/golang/lint/golint \
-		./vendor/github.com/google/pprof \
 		./vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
 		./vendor/github.com/jteeuwen/go-bindata/go-bindata \
 		./vendor/github.com/kisielk/errcheck \


### PR DESCRIPTION
Backport 2/2 commits from #28834.

/cc @cockroachdb/release

---

Picks up:
- https://github.com/google/pprof/pull/412
- https://github.com/google/pprof/pull/414
