### PR TITLE
sql: fix problem with TRUNCATE messing up SEQUENCE dependency

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/truncate
+++ b/pkg/sql/logictest/testdata/logic_test/truncate
@@ -132,3 +132,22 @@ TRUNCATE a CASCADE
 query I
 SELECT * FROM d
 ----
+
+subtest truncate_29010
+
+statement ok
+CREATE SEQUENCE foo;
+
+statement ok
+CREATE TABLE bar (
+  id INT NOT NULL DEFAULT nextval('foo':::STRING),
+  description STRING NULL,
+  CONSTRAINT "primary" PRIMARY KEY (id ASC),
+  FAMILY "primary" (id, description)
+);
+
+statement ok
+TRUNCATE bar
+
+statement ok
+DROP TABLE bar;

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2451,6 +2451,12 @@ func (desc *TableDescriptor) FindAllReferences() (map[ID]struct{}, error) {
 		return nil, err
 	}
 
+	for _, c := range desc.allNonDropColumns() {
+		for _, id := range c.UsesSequenceIds {
+			refs[id] = struct{}{}
+		}
+	}
+
 	for _, dest := range desc.DependsOn {
 		refs[dest] = struct{}{}
 	}


### PR DESCRIPTION
While truncating a table, the column dependency to a sequence
was being retained correctly, but the reference from the sequence
back to the table was not getting updated, resulting in the
sequence retaining a reference to the old TRUNCATED table.

fix #29010

Release note (sql change): Fixed problem with messing up schema
on running TRUNCATE on a table with a reference to a sequence.