### PR TITLE
backport-2.1: distsqlrun: bugfixes/perf change to joinReader 

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -363,3 +363,46 @@ SELECT small.c, large.d FROM small LEFT JOIN large ON small.c = large.b AND larg
 24  NULL
 27  NULL
 30  NULL
+
+# Lookup joins against interleaved tables. Regression test for #28981.
+# This is now tested more thoroughly by joinreader_test.go.
+
+statement ok
+CREATE TABLE parent (a INT, b INT, PRIMARY KEY(a, b))
+
+statement ok
+CREATE TABLE child (a INT, b INT, c INT, PRIMARY KEY(a, b, c)) INTERLEAVE IN PARENT parent(a, b)
+
+statement ok
+CREATE TABLE source (a INT)
+
+statement ok
+ALTER TABLE source INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1,
+    "distinct_count": 1
+  }
+]'
+
+statement ok
+ALTER TABLE child INJECT STATISTICS '[
+  {
+    "columns": ["a", "b", "c"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10,
+    "distinct_count": 10
+  }
+]'
+
+statement ok
+INSERT INTO child VALUES(1, 2, 3)
+
+statement ok
+INSERT INTO source VALUES(1)
+
+query IIII
+SELECT * FROM source JOIN child ON source.a = child.a
+----
+1 1 2 3

--- a/pkg/sql/sqlbase/index_encoding.go
+++ b/pkg/sql/sqlbase/index_encoding.go
@@ -184,11 +184,21 @@ func MakeKeyFromEncDatums(
 				key = encoding.EncodeUvarintAscending(key, uint64(ancestor.IndexID))
 			}
 
+			partial := false
 			length := int(ancestor.SharedPrefixLen)
+			if length > len(types) {
+				length = len(types)
+				partial = true
+			}
 			var err error
 			key, err = appendEncDatumsToKey(key, types[:length], values[:length], dirs[:length], alloc)
 			if err != nil {
 				return nil, err
+			}
+			if partial {
+				// Early stop - the number of desired columns was fewer than the number
+				// left in the current interleave.
+				return key, nil
 			}
 			types, values, dirs = types[length:], values[length:], dirs[length:]
 
@@ -455,6 +465,63 @@ func DecodeIndexKeyWithoutTableIDIndexIDPrefix(
 	}
 
 	return key, true, nil
+}
+
+// consumeIndexKeyWithoutTableIDIndexIDPrefix consumes an index key that's
+// already pre-stripped of its table ID index ID prefix, up to nCols columns,
+// returning the number of bytes consumed. For example, given an input key
+// with values (6,7,8,9) such as /Table/60/1/6/7/#/61/1/8/9, stripping 3 columns
+// from this key would eat all but the final, 4th column 9 in this example,
+// producing /Table/60/1/6/7/#/61/1/8. If nCols was 2, instead, the result
+// would include the trailing table ID index ID pair, since that's a more
+// precise key: /Table/60/1/6/7/#/61/1.
+func consumeIndexKeyWithoutTableIDIndexIDPrefix(
+	index *IndexDescriptor, nCols int, key []byte,
+) (int, error) {
+	origKeyLen := len(key)
+	consumedCols := 0
+	for _, ancestor := range index.Interleave.Ancestors {
+		length := int(ancestor.SharedPrefixLen)
+		// Skip up to length values.
+		for j := 0; j < length; j++ {
+			if consumedCols == nCols {
+				// We're done early, in the middle of an interleave.
+				return origKeyLen - len(key), nil
+			}
+			l, err := encoding.PeekLength(key)
+			if err != nil {
+				return 0, err
+			}
+			key = key[l:]
+			consumedCols++
+		}
+		var ok bool
+		key, ok = encoding.DecodeIfInterleavedSentinel(key)
+		if !ok {
+			return 0, errors.New("unexpected lack of sentinel key")
+		}
+
+		// Skip the TableID/IndexID pair for each ancestor except for the
+		// first, which has already been skipped in our input.
+		for j := 0; j < 2; j++ {
+			idLen, err := encoding.PeekLength(key)
+			if err != nil {
+				return 0, err
+			}
+			key = key[idLen:]
+		}
+	}
+
+	// Decode the remaining values in the key, in the final interleave.
+	for ; consumedCols < nCols; consumedCols++ {
+		l, err := encoding.PeekLength(key)
+		if err != nil {
+			return 0, err
+		}
+		key = key[l:]
+	}
+
+	return origKeyLen - len(key), nil
 }
 
 // DecodeKeyVals decodes the values that are part of the key. The decoded


### PR DESCRIPTION
Backport 1/1 commits from #28980.

/cc @cockroachdb/release

---

Previously, joinReader used pretty-printed string keys to correlate its
input rows with its looked-up rows. This was incorrect and inefficient.

Now, it uses bytes keys like everything else. Also, fix a bug that
caused partial key creation from EncDatums on tables with interleaves to
panic and/or return incorrect results.

Closes #28981.

```
name                      old time/op    new time/op     delta
JoinReader/rows=16-24        134µs ± 1%       57µs ± 1%   -57.39%  (p=0.000 n=9+10)
JoinReader/rows=256-24      1.54ms ± 1%     0.42ms ± 1%   -72.43%  (p=0.000 n=10+9)
JoinReader/rows=4096-24     45.4ms ± 1%     24.5ms ± 1%   -46.14%  (p=0.000 n=8+10)
JoinReader/rows=65536-24     5.03s ± 1%      4.80s ± 1%    -4.64%  (p=0.000 n=9+10)

name                      old speed      new speed       delta
JoinReader/rows=16-24     2.87MB/s ± 1%   6.74MB/s ± 1%  +134.76%  (p=0.000 n=7+10)
JoinReader/rows=256-24    4.00MB/s ± 1%  14.52MB/s ± 1%  +262.83%  (p=0.000 n=10+10)
JoinReader/rows=4096-24   2.17MB/s ± 1%   4.02MB/s ± 1%   +85.64%  (p=0.000 n=8+10)
JoinReader/rows=65536-24   310kB/s ± 0%    327kB/s ± 2%    +5.48%  (p=0.000 n=10+10)

name                      old alloc/op   new alloc/op    delta
JoinReader/rows=16-24       40.4kB ± 1%     18.1kB ± 1%   -55.08%  (p=0.000 n=10+10)
JoinReader/rows=256-24       390kB ± 0%       93kB ± 1%   -76.07%  (p=0.000 n=8+9)
JoinReader/rows=4096-24     5.96MB ± 0%     1.25MB ± 1%   -78.99%  (p=0.000 n=9+9)
JoinReader/rows=65536-24    99.2MB ± 6%     23.2MB ±15%   -76.66%  (p=0.000 n=10+10)

name                      old allocs/op  new allocs/op   delta
JoinReader/rows=16-24          646 ± 0%        179 ± 0%   -72.37%  (p=0.000 n=10+10)
JoinReader/rows=256-24       8.77k ± 0%      1.33k ± 0%   -84.83%  (p=0.000 n=10+9)
JoinReader/rows=4096-24       139k ± 0%        20k ± 0%   -85.48%  (p=0.000 n=9+9)
JoinReader/rows=65536-24     2.24M ± 1%      0.33M ± 7%   -85.14%  (p=0.000 n=9+9)
```
