### PR TITLE
release-2.1: opt: hide stats in logprops tests

### DIFF
--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -24,12 +24,13 @@ import (
 )
 
 func TestMemo(t *testing.T) {
-	flags := memo.ExprFmtHideCost | memo.ExprFmtHideRuleProps | memo.ExprFmtHideQualifications
+	flags := memo.ExprFmtHideCost | memo.ExprFmtHideRuleProps | memo.ExprFmtHideQualifications |
+		memo.ExprFmtHideStats
 	runDataDrivenTest(t, "testdata/memo", flags)
 }
 
 func TestLogicalProps(t *testing.T) {
-	flags := memo.ExprFmtHideCost | memo.ExprFmtHideQualifications
+	flags := memo.ExprFmtHideCost | memo.ExprFmtHideQualifications | memo.ExprFmtHideStats
 	runDataDrivenTest(t, "testdata/logprops/", flags)
 }
 

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -23,11 +23,9 @@ SELECT * FROM a WHERE x > 1
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333.333333]
  ├── prune: (2)
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
       └── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
@@ -39,11 +37,9 @@ SELECT * FROM a WHERE x >= 1
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333.333333]
  ├── prune: (2)
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1), constraints=(/1: [/1 - ]; tight)]
       └── ge [type=bool, outer=(1), constraints=(/1: [/1 - ]; tight)]
@@ -55,11 +51,9 @@ SELECT * FROM a WHERE x < 1
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333.333333]
  ├── prune: (2)
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1), constraints=(/1: (/NULL - /0]; tight)]
       └── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /0]; tight)]
@@ -71,11 +65,9 @@ SELECT * FROM a WHERE x <= 1
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333.333333]
  ├── prune: (2)
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1), constraints=(/1: (/NULL - /1]; tight)]
       └── le [type=bool, outer=(1), constraints=(/1: (/NULL - /1]; tight)]
@@ -87,12 +79,10 @@ SELECT * FROM a WHERE x = 1
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=1.42857143, distinct(1)=1]
  ├── fd: ()-->(1)
  ├── prune: (2)
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000, distinct(1)=700]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
       └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
@@ -104,11 +94,9 @@ SELECT * FROM a WHERE x > 1 AND x < 5
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=4.28571429, distinct(1)=3]
  ├── prune: (2)
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000, distinct(1)=700]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1), constraints=(/1: [/2 - /4]; tight)]
       ├── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
@@ -123,11 +111,9 @@ SELECT * FROM a WHERE x = 1 AND y = 5
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null)
- ├── stats: [rows=0.00204081633, distinct(1)=0.00204081633, distinct(2)=0.00204081633]
  ├── fd: ()-->(1,2)
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000, distinct(1)=700, distinct(2)=700]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1: [/1 - /1]; /2: [/5 - /5]; tight), fd=()-->(1,2)]
       ├── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
@@ -142,10 +128,8 @@ SELECT * FROM a WHERE x > 1 AND x < 5 AND y >= 7 AND y <= 9
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null)
- ├── stats: [rows=0.0183673469, distinct(1)=0.0183673469, distinct(2)=0.0183673469]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000, distinct(1)=700, distinct(2)=700]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1: [/2 - /4]; /2: [/7 - /9]; tight)]
       ├── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
@@ -167,10 +151,8 @@ SELECT * FROM a WHERE x > 1 AND x < 5 AND x + y = 5
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=37.037037]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1: [/2 - /4])]
       ├── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
@@ -190,10 +172,8 @@ SELECT * FROM a WHERE x > 1 AND x + y >= 5 AND x + y <= 7
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=37.037037]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1: [/2 - ])]
       ├── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
@@ -216,11 +196,9 @@ SELECT * FROM a WHERE x > 1.5
 ----
 select
  ├── columns: x:1(int) y:2(int)
- ├── stats: [rows=333.333333]
  ├── prune: (2)
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1)]
       └── gt [type=bool, outer=(1)]
@@ -232,14 +210,12 @@ SELECT * FROM kuv WHERE u > 1::INT
 ----
 select
  ├── columns: k:1(int!null) u:2(float) v:3(string)
- ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── prune: (1,3)
  ├── interesting orderings: (+1)
  ├── scan kuv
  │    ├── columns: k:1(int!null) u:2(float) v:3(string)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3)
  │    ├── prune: (1-3)
@@ -254,14 +230,12 @@ SELECT * FROM kuv WHERE v <= 'foo' AND v >= 'bar'
 ----
 select
  ├── columns: k:1(int!null) u:2(float) v:3(string!null)
- ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── prune: (1,2)
  ├── interesting orderings: (+1)
  ├── scan kuv
  │    ├── columns: k:1(int!null) u:2(float) v:3(string)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3)
  │    ├── prune: (1-3)
@@ -280,11 +254,9 @@ SELECT * FROM a WHERE x IN (1, 2, 3, NULL)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=4.28571429, distinct(1)=3]
  ├── prune: (2)
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000, distinct(1)=700]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1), constraints=(/1: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
       └── in [type=bool, outer=(1), constraints=(/1: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
@@ -301,7 +273,6 @@ SELECT * FROM a WHERE rowid IS NULL
 project
  ├── columns: x:1(int) y:2(int)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=1]
  ├── key: ()
  ├── fd: ()-->(1,2)
  ├── prune: (1,2)
@@ -309,7 +280,6 @@ project
       ├── columns: x:1(int) y:2(int) rowid:3(int!null)
       ├── constraint: /3: contradiction
       ├── cardinality: [0 - 1]
-      ├── stats: [rows=1, distinct(3)=1]
       ├── key: ()
       ├── fd: ()-->(1-3)
       ├── prune: (1-3)
@@ -322,11 +292,9 @@ SELECT * FROM a WHERE x IN (1, 3, 5, 7, 9) AND x > 6
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=2.85714286, distinct(1)=2]
  ├── prune: (2)
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000, distinct(1)=700]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1), constraints=(/1: [/7 - /7] [/9 - /9]; tight)]
       ├── in [type=bool, outer=(1), constraints=(/1: [/1 - /1] [/3 - /3] [/5 - /5] [/7 - /7] [/9 - /9]; tight)]
@@ -347,10 +315,8 @@ SELECT * FROM a WHERE x IN (1, 3) AND y > 4
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null)
- ├── stats: [rows=0.952380952, distinct(1)=0.952380952]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000, distinct(1)=700]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1: [/1 - /1] [/3 - /3]; /2: [/5 - ]; tight)]
       ├── in [type=bool, outer=(1), constraints=(/1: [/1 - /1] [/3 - /3]; tight)]
@@ -368,10 +334,8 @@ SELECT * FROM a WHERE (x, y) > (1, 2)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333.333333]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1/2: [/1/3 - ]; tight)]
       └── gt [type=bool, outer=(1,2), constraints=(/1/2: [/1/3 - ]; tight)]
@@ -387,10 +351,8 @@ SELECT * FROM a WHERE (x, y) >= (1, 2)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333.333333]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1/2: [/1/2 - ]; tight)]
       └── ge [type=bool, outer=(1,2), constraints=(/1/2: [/1/2 - ]; tight)]
@@ -406,10 +368,8 @@ SELECT * FROM a WHERE (x, y) < (1, 2)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333.333333]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1/2: (/NULL - /1/1]; tight)]
       └── lt [type=bool, outer=(1,2), constraints=(/1/2: (/NULL - /1/1]; tight)]
@@ -425,10 +385,8 @@ SELECT * FROM a WHERE (x, y) <= (1, 2)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333.333333]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1/2: (/NULL - /1/2]; tight)]
       └── le [type=bool, outer=(1,2), constraints=(/1/2: (/NULL - /1/2]; tight)]
@@ -445,10 +403,8 @@ SELECT * FROM a WHERE (x, y) >= (1, 2.5)
 ----
 select
  ├── columns: x:1(int) y:2(int)
- ├── stats: [rows=333.333333]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2)]
       └── ge [type=bool, outer=(1,2)]
@@ -465,10 +421,8 @@ SELECT * FROM a WHERE (x, y) >= (1, NULL)
 ----
 select
  ├── columns: x:1(int) y:2(int)
- ├── stats: [rows=333.333333]
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2)]
       └── ge [type=bool, outer=(1,2)]
@@ -486,11 +440,9 @@ SELECT * FROM a WHERE (x, 1) >= (1, 2)
 ----
 select
  ├── columns: x:1(int) y:2(int)
- ├── stats: [rows=333.333333]
  ├── prune: (2)
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1)]
       └── ge [type=bool, outer=(1)]
@@ -517,11 +469,9 @@ SELECT * FROM abc WHERE a != 5
 ----
 select
  ├── columns: a:1(int!null) b:2(bool) c:3(string)
- ├── stats: [rows=333.333333]
  ├── prune: (2,3)
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
- │    ├── stats: [rows=1000]
  │    └── prune: (1-3)
  └── filters [type=bool, outer=(1), constraints=(/1: (/NULL - /4] [/6 - ]; tight)]
       └── ne [type=bool, outer=(1), constraints=(/1: (/NULL - /4] [/6 - ]; tight)]
@@ -533,11 +483,9 @@ SELECT * FROM abc WHERE a IS DISTINCT FROM 5
 ----
 select
  ├── columns: a:1(int) b:2(bool) c:3(string)
- ├── stats: [rows=333.333333]
  ├── prune: (2,3)
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
- │    ├── stats: [rows=1000]
  │    └── prune: (1-3)
  └── filters [type=bool, outer=(1), constraints=(/1: [ - /4] [/6 - ]; tight)]
       └── is-not [type=bool, outer=(1), constraints=(/1: [ - /4] [/6 - ]; tight)]
@@ -549,11 +497,9 @@ SELECT * FROM abc WHERE b != true
 ----
 select
  ├── columns: a:1(int) b:2(bool!null) c:3(string)
- ├── stats: [rows=333.333333]
  ├── prune: (1,3)
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
- │    ├── stats: [rows=1000]
  │    └── prune: (1-3)
  └── filters [type=bool, outer=(2), constraints=(/2: (/NULL - /false]; tight)]
       └── ne [type=bool, outer=(2), constraints=(/2: (/NULL - /false]; tight)]
@@ -565,11 +511,9 @@ SELECT * FROM abc WHERE b != false
 ----
 select
  ├── columns: a:1(int) b:2(bool!null) c:3(string)
- ├── stats: [rows=333.333333]
  ├── prune: (1,3)
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
- │    ├── stats: [rows=1000]
  │    └── prune: (1-3)
  └── filters [type=bool, outer=(2), constraints=(/2: [/true - ]; tight)]
       └── ne [type=bool, outer=(2), constraints=(/2: [/true - ]; tight)]
@@ -581,11 +525,9 @@ SELECT * FROM abc WHERE b IS NOT true
 ----
 select
  ├── columns: a:1(int) b:2(bool) c:3(string)
- ├── stats: [rows=333.333333]
  ├── prune: (1,3)
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
- │    ├── stats: [rows=1000]
  │    └── prune: (1-3)
  └── filters [type=bool, outer=(2), constraints=(/2: [ - /false]; tight)]
       └── is-not [type=bool, outer=(2), constraints=(/2: [ - /false]; tight)]
@@ -597,11 +539,9 @@ SELECT * FROM abc WHERE b IS NOT false
 ----
 select
  ├── columns: a:1(int) b:2(bool) c:3(string)
- ├── stats: [rows=333.333333]
  ├── prune: (1,3)
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
- │    ├── stats: [rows=1000]
  │    └── prune: (1-3)
  └── filters [type=bool, outer=(2), constraints=(/2: [ - /false) [/true - ]; tight)]
       └── is-not [type=bool, outer=(2), constraints=(/2: [ - /false) [/true - ]; tight)]
@@ -613,12 +553,10 @@ SELECT * FROM abc WHERE b
 ----
 select
  ├── columns: a:1(int) b:2(bool!null) c:3(string)
- ├── stats: [rows=500, distinct(2)=1]
  ├── fd: ()-->(2)
  ├── prune: (1,3)
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
- │    ├── stats: [rows=1000, distinct(2)=2]
  │    └── prune: (1-3)
  └── filters [type=bool, outer=(2), constraints=(/2: [/true - /true]; tight), fd=()-->(2)]
       └── variable: b [type=bool, outer=(2), constraints=(/2: [/true - /true]; tight)]
@@ -628,12 +566,10 @@ SELECT * FROM abc WHERE NOT b
 ----
 select
  ├── columns: a:1(int) b:2(bool!null) c:3(string)
- ├── stats: [rows=500, distinct(2)=1]
  ├── fd: ()-->(2)
  ├── prune: (1,3)
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
- │    ├── stats: [rows=1000, distinct(2)=2]
  │    └── prune: (1-3)
  └── filters [type=bool, outer=(2), constraints=(/2: [/false - /false]; tight), fd=()-->(2)]
       └── not [type=bool, outer=(2), constraints=(/2: [/false - /false]; tight)]
@@ -644,12 +580,10 @@ SELECT * FROM abc WHERE a > 5 AND b
 ----
 select
  ├── columns: a:1(int!null) b:2(bool!null) c:3(string)
- ├── stats: [rows=166.666667, distinct(2)=1]
  ├── fd: ()-->(2)
  ├── prune: (3)
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
- │    ├── stats: [rows=1000, distinct(2)=2]
  │    └── prune: (1-3)
  └── filters [type=bool, outer=(1,2), constraints=(/1: [/6 - ]; /2: [/true - /true]; tight), fd=()-->(2)]
       ├── gt [type=bool, outer=(1), constraints=(/1: [/6 - ]; tight)]
@@ -662,11 +596,9 @@ SELECT * FROM abc WHERE c != 'foo'
 ----
 select
  ├── columns: a:1(int) b:2(bool) c:3(string!null)
- ├── stats: [rows=333.333333]
  ├── prune: (1,2)
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
- │    ├── stats: [rows=1000]
  │    └── prune: (1-3)
  └── filters [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo') [/e'foo\x00' - ]; tight)]
       └── ne [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo') [/e'foo\x00' - ]; tight)]
@@ -678,11 +610,9 @@ SELECT * FROM abc WHERE c IS DISTINCT FROM 'foo'
 ----
 select
  ├── columns: a:1(int) b:2(bool) c:3(string)
- ├── stats: [rows=333.333333]
  ├── prune: (1,2)
  ├── scan abc
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
- │    ├── stats: [rows=1000]
  │    └── prune: (1-3)
  └── filters [type=bool, outer=(3), constraints=(/3: [ - /'foo') [/e'foo\x00' - ]; tight)]
       └── is-not [type=bool, outer=(3), constraints=(/3: [ - /'foo') [/e'foo\x00' - ]; tight)]
@@ -694,14 +624,11 @@ SELECT * FROM (SELECT (x, y) AS col FROM a) WHERE col > (1, 2)
 ----
 select
  ├── columns: col:4(tuple{int, int}!null)
- ├── stats: [rows=333.333333]
  ├── project
  │    ├── columns: col:4(tuple{int, int})
- │    ├── stats: [rows=1000]
  │    ├── prune: (4)
  │    ├── scan a
  │    │    ├── columns: x:1(int) y:2(int)
- │    │    ├── stats: [rows=1000]
  │    │    └── prune: (1,2)
  │    └── projections [outer=(1,2)]
  │         └── tuple [type=tuple{int, int}, outer=(1,2)]
@@ -740,7 +667,6 @@ SELECT * FROM c WHERE (v, u) IN ((1, 2), (3, 50), (5, 100))
 scan c@v
  ├── columns: k:1(int!null) u:2(int!null) v:3(int!null)
  ├── constraint: /3/2/1: [/1/2 - /1/2] [/3/50 - /3/50] [/5/100 - /5/100]
- ├── stats: [rows=0.0183673469, distinct(2)=0.0183673469, distinct(3)=0.0183673469]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── prune: (1)
@@ -831,7 +757,6 @@ SELECT * FROM c WHERE (v, u) IN ((1, 2), (3, 50), (5, NULL))
 scan c@v
  ├── columns: k:1(int!null) u:2(int!null) v:3(int!null)
  ├── constraint: /3/2/1: [/1/2 - /1/2] [/3/50 - /3/50]
- ├── stats: [rows=0.00272108844, distinct(2)=0.00272108844, distinct(3)=0.00272108844]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── prune: (1)
@@ -844,7 +769,6 @@ SELECT * FROM c WHERE (v, 2) IN ((1, 2), (3, 50), (5, 100))
 ----
 select
  ├── columns: k:1(int!null) u:2(int) v:3(int!null)
- ├── stats: [rows=1.42857143, distinct(3)=1.42857143]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── prune: (1,2)
@@ -852,7 +776,6 @@ select
  ├── scan c@v
  │    ├── columns: k:1(int!null) u:2(int) v:3(int!null)
  │    ├── constraint: /3/2/1: [/1 - /1] [/3 - /3] [/5 - /5]
- │    ├── stats: [rows=4.28571429, distinct(3)=3]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3)
  │    ├── prune: (1-3)
@@ -881,7 +804,6 @@ SELECT * FROM c WHERE (v, u + v) IN ((1, 2), (3, 50), (5, 100))
 ----
 select
  ├── columns: k:1(int!null) u:2(int) v:3(int!null)
- ├── stats: [rows=1.42857143, distinct(3)=1.42857143]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── prune: (1)
@@ -889,7 +811,6 @@ select
  ├── scan c@v
  │    ├── columns: k:1(int!null) u:2(int) v:3(int!null)
  │    ├── constraint: /3/2/1: [/1 - /1] [/3 - /3] [/5 - /5]
- │    ├── stats: [rows=4.28571429, distinct(3)=3]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3)
  │    ├── prune: (1-3)
@@ -917,13 +838,11 @@ SELECT * FROM c WHERE (v, u) IN ((1, 2), (k, 50), (5, 100))
 ----
 select
  ├── columns: k:1(int!null) u:2(int!null) v:3(int)
- ├── stats: [rows=1.42857143, distinct(2)=1.42857143]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── interesting orderings: (+1) (+3,+2,+1)
  ├── scan c
  │    ├── columns: k:1(int!null) u:2(int) v:3(int)
- │    ├── stats: [rows=1000, distinct(2)=700]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3)
  │    ├── prune: (1-3)
@@ -1034,14 +953,12 @@ SELECT * FROM c WHERE (1, 2) IN ((1, 2))
 ----
 select
  ├── columns: k:1(int!null) u:2(int) v:3(int)
- ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── prune: (1-3)
  ├── interesting orderings: (+1) (+3,+2,+1)
  ├── scan c
  │    ├── columns: k:1(int!null) u:2(int) v:3(int)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3)
  │    ├── prune: (1-3)

--- a/pkg/sql/opt/memo/testdata/logprops/constraints-null
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints-null
@@ -15,7 +15,6 @@ SELECT * FROM t WHERE a = NULL
 values
  ├── columns: a:1(int) b:2(bool) c:3(string)
  ├── cardinality: [0 - 0]
- ├── stats: [rows=0]
  ├── key: ()
  ├── fd: ()-->(1-3)
  └── prune: (1-3)
@@ -26,7 +25,6 @@ SELECT * FROM t WHERE a < NULL
 values
  ├── columns: a:1(int) b:2(bool) c:3(string)
  ├── cardinality: [0 - 0]
- ├── stats: [rows=0]
  ├── key: ()
  ├── fd: ()-->(1-3)
  └── prune: (1-3)
@@ -36,12 +34,10 @@ SELECT * FROM t WHERE a IS NULL
 ----
 select
  ├── columns: a:1(int) b:2(bool) c:3(string)
- ├── stats: [rows=1.42857143, distinct(1)=1]
  ├── fd: ()-->(1)
  ├── prune: (2,3)
  ├── scan t
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
- │    ├── stats: [rows=1000, distinct(1)=700]
  │    └── prune: (1-3)
  └── filters [type=bool, outer=(1), constraints=(/1: [/NULL - /NULL]; tight), fd=()-->(1)]
       └── is [type=bool, outer=(1), constraints=(/1: [/NULL - /NULL]; tight)]
@@ -53,11 +49,9 @@ SELECT * FROM t WHERE a IS NOT NULL
 ----
 select
  ├── columns: a:1(int!null) b:2(bool) c:3(string)
- ├── stats: [rows=333.333333]
  ├── prune: (2,3)
  ├── scan t
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
- │    ├── stats: [rows=1000]
  │    └── prune: (1-3)
  └── filters [type=bool, outer=(1), constraints=(/1: (/NULL - ]; tight)]
       └── is-not [type=bool, outer=(1), constraints=(/1: (/NULL - ]; tight)]
@@ -69,12 +63,10 @@ SELECT * FROM t WHERE b IS NULL AND c IS NULL
 ----
 select
  ├── columns: a:1(int) b:2(bool) c:3(string)
- ├── stats: [rows=0.714285714, distinct(2)=0.714285714, distinct(3)=0.714285714]
  ├── fd: ()-->(2,3)
  ├── prune: (1)
  ├── scan t
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
- │    ├── stats: [rows=1000, distinct(2)=2, distinct(3)=700]
  │    └── prune: (1-3)
  └── filters [type=bool, outer=(2,3), constraints=(/2: [/NULL - /NULL]; /3: [/NULL - /NULL]; tight), fd=()-->(2,3)]
       ├── is [type=bool, outer=(2), constraints=(/2: [/NULL - /NULL]; tight)]
@@ -89,11 +81,9 @@ SELECT * FROM t WHERE b IS NOT NULL AND c IS NOT NULL
 ----
 select
  ├── columns: a:1(int) b:2(bool!null) c:3(string!null)
- ├── stats: [rows=111.111111]
  ├── prune: (1)
  ├── scan t
  │    ├── columns: a:1(int) b:2(bool) c:3(string)
- │    ├── stats: [rows=1000]
  │    └── prune: (1-3)
  └── filters [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]; tight)]
       ├── is-not [type=bool, outer=(2), constraints=(/2: (/NULL - ]; tight)]
@@ -122,10 +112,8 @@ SELECT * FROM xy WHERE x > abs(y)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333.333333]
  ├── scan xy
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1: (/NULL - ])]
       └── gt [type=bool, outer=(1,2), constraints=(/1: (/NULL - ])]
@@ -139,11 +127,9 @@ SELECT * FROM xy WHERE sin(x::float)::int < x
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333.333333]
  ├── prune: (2)
  ├── scan xy
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
       └── gt [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
@@ -159,10 +145,8 @@ SELECT * FROM xy WHERE x > y
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null)
- ├── stats: [rows=111.111111]
  ├── scan xy
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
       └── gt [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
@@ -175,11 +159,9 @@ SELECT * FROM xy WHERE x = y
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null)
- ├── stats: [rows=1.42857143, distinct(1)=1.42857143, distinct(2)=1.42857143]
  ├── fd: (1)==(2), (2)==(1)
  ├── scan xy
  │    ├── columns: x:1(int) y:2(int)
- │    ├── stats: [rows=1000, distinct(1)=700, distinct(2)=700]
  │    └── prune: (1,2)
  └── filters [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
       └── eq [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]

--- a/pkg/sql/opt/memo/testdata/logprops/groupby
+++ b/pkg/sql/opt/memo/testdata/logprops/groupby
@@ -28,7 +28,6 @@ SELECT y, sum(z), x, False FROM xyzs GROUP BY x, y
 ----
 project
  ├── columns: y:2(int) sum:5(float) x:1(int!null) bool:6(bool!null)
- ├── stats: [rows=1000]
  ├── key: (1)
  ├── fd: ()-->(6), (1)-->(2,5)
  ├── prune: (1,2,5,6)
@@ -36,21 +35,18 @@ project
  ├── group-by
  │    ├── columns: x:1(int!null) y:2(int) sum:5(float)
  │    ├── grouping columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=1000, distinct(1,2)=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,5)
  │    ├── prune: (5)
  │    ├── interesting orderings: (+1)
  │    ├── project
  │    │    ├── columns: x:1(int!null) y:2(int) z:3(float!null)
- │    │    ├── stats: [rows=1000, distinct(1,2)=1000]
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2,3)
  │    │    ├── prune: (1-3)
  │    │    ├── interesting orderings: (+1)
  │    │    └── scan xyzs
  │    │         ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- │    │         ├── stats: [rows=1000, distinct(1,2)=1000]
  │    │         ├── key: (1)
  │    │         ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    │         ├── prune: (1-4)
@@ -68,20 +64,17 @@ SELECT sum(x), max(y) FROM xyzs
 scalar-group-by
  ├── columns: sum:5(decimal) max:6(int)
  ├── cardinality: [1 - 1]
- ├── stats: [rows=1]
  ├── key: ()
  ├── fd: ()-->(5,6)
  ├── prune: (5,6)
  ├── project
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    ├── prune: (1,2)
  │    ├── interesting orderings: (+1)
  │    └── scan xyzs
  │         ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- │         ├── stats: [rows=1000]
  │         ├── key: (1)
  │         ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │         ├── prune: (1-4)
@@ -98,23 +91,19 @@ SELECT s FROM xyzs GROUP BY z, s
 ----
 project
  ├── columns: s:4(string)
- ├── stats: [rows=1000]
  ├── prune: (4)
  ├── interesting orderings: (-4)
  └── group-by
       ├── columns: z:3(float!null) s:4(string)
       ├── grouping columns: z:3(float!null) s:4(string)
-      ├── stats: [rows=1000, distinct(3,4)=1000]
       ├── key: (3,4)
       ├── interesting orderings: (-4,+3)
       └── project
            ├── columns: z:3(float!null) s:4(string)
-           ├── stats: [rows=1000, distinct(3,4)=1000]
            ├── prune: (3,4)
            ├── interesting orderings: (-4,+3)
            └── scan xyzs
                 ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
-                ├── stats: [rows=1000, distinct(3,4)=1000]
                 ├── key: (1)
                 ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
                 ├── prune: (1-4)
@@ -126,22 +115,18 @@ SELECT y, sum(z) FROM xyzs GROUP BY z, y
 ----
 project
  ├── columns: y:2(int) sum:5(float)
- ├── stats: [rows=1000]
  ├── prune: (2,5)
  └── group-by
       ├── columns: y:2(int) z:3(float!null) sum:5(float)
       ├── grouping columns: y:2(int) z:3(float!null)
-      ├── stats: [rows=1000, distinct(2,3)=1000]
       ├── key: (2,3)
       ├── fd: (2,3)-->(5)
       ├── prune: (5)
       ├── project
       │    ├── columns: y:2(int) z:3(float!null)
-      │    ├── stats: [rows=1000, distinct(2,3)=1000]
       │    ├── prune: (2,3)
       │    └── scan xyzs
       │         ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
-      │         ├── stats: [rows=1000, distinct(2,3)=1000]
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
       │         ├── prune: (1-4)
@@ -157,18 +142,15 @@ SELECT z, max(s) FROM xyzs GROUP BY z
 group-by
  ├── columns: z:3(float!null) max:5(string)
  ├── grouping columns: z:3(float!null)
- ├── stats: [rows=700, distinct(3)=700]
  ├── key: (3)
  ├── fd: (3)-->(5)
  ├── prune: (5)
  ├── project
  │    ├── columns: z:3(float!null) s:4(string)
- │    ├── stats: [rows=1000, distinct(3)=700]
  │    ├── prune: (3,4)
  │    ├── interesting orderings: (-4,+3)
  │    └── scan xyzs
  │         ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- │         ├── stats: [rows=1000, distinct(3)=700]
  │         ├── key: (1)
  │         ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │         ├── prune: (1-4)
@@ -183,19 +165,16 @@ SELECT s FROM xyzs GROUP BY xyzs.*
 ----
 project
  ├── columns: s:4(string)
- ├── stats: [rows=1000]
  ├── prune: (4)
  ├── interesting orderings: (-4)
  └── group-by
       ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
       ├── grouping columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
-      ├── stats: [rows=1000, distinct(1-4)=1000]
       ├── key: (1)
       ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
       ├── interesting orderings: (+1) (-4,+3,+1)
       └── scan xyzs
            ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
-           ├── stats: [rows=1000, distinct(1-4)=1000]
            ├── key: (1)
            ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
            ├── prune: (1-4)
@@ -207,14 +186,12 @@ SELECT * FROM xyzs WHERE (SELECT sum(x) FROM (SELECT y, u FROM kuv) GROUP BY u) 
 ----
 select
  ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (3,4)
  ├── interesting orderings: (+1) (-4,+3,+1)
  ├── scan xyzs
  │    ├── columns: xyzs.x:1(int!null) xyzs.y:2(int) z:3(float!null) s:4(string)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -226,37 +203,31 @@ select
            │         ├── columns: sum:10(decimal)
            │         ├── outer: (1,2)
            │         ├── cardinality: [0 - 1]
-           │         ├── stats: [rows=1]
            │         ├── key: ()
            │         ├── fd: ()-->(10)
            │         └── project
            │              ├── columns: sum:10(decimal)
            │              ├── outer: (1,2)
-           │              ├── stats: [rows=700]
            │              ├── prune: (10)
            │              └── group-by
            │                   ├── columns: u:6(float) sum:10(decimal)
            │                   ├── grouping columns: u:6(float)
            │                   ├── outer: (1,2)
-           │                   ├── stats: [rows=700, distinct(6)=700]
            │                   ├── key: (6)
            │                   ├── fd: (6)-->(10)
            │                   ├── prune: (10)
            │                   ├── project
            │                   │    ├── columns: x:9(int) u:6(float)
            │                   │    ├── outer: (1,2)
-           │                   │    ├── stats: [rows=1000, distinct(6)=700]
            │                   │    ├── fd: ()-->(9)
            │                   │    ├── prune: (6,9)
            │                   │    ├── project
            │                   │    │    ├── columns: y:8(int) u:6(float)
            │                   │    │    ├── outer: (2)
-           │                   │    │    ├── stats: [rows=1000, distinct(6)=700]
            │                   │    │    ├── fd: ()-->(8)
            │                   │    │    ├── prune: (6,8)
            │                   │    │    ├── scan kuv
            │                   │    │    │    ├── columns: k:5(int!null) u:6(float) v:7(string)
-           │                   │    │    │    ├── stats: [rows=1000, distinct(6)=700]
            │                   │    │    │    ├── key: (5)
            │                   │    │    │    ├── fd: (5)-->(6,7)
            │                   │    │    │    ├── prune: (5-7)
@@ -278,12 +249,10 @@ group-by
  ├── columns: column1:1(int)
  ├── grouping columns: column1:1(int)
  ├── cardinality: [1 - 4]
- ├── stats: [rows=3, distinct(1)=3]
  ├── key: (1)
  └── values
       ├── columns: column1:1(int)
       ├── cardinality: [4 - 4]
-      ├── stats: [rows=4, distinct(1)=3]
       ├── prune: (1)
       ├── tuple [type=tuple{int}]
       │    └── const: 1 [type=int]
@@ -301,7 +270,6 @@ SELECT x, count(z) FROM xyzs GROUP BY x HAVING x=1
 group-by
  ├── columns: x:1(int) count:5(int)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=1]
  ├── key: ()
  ├── fd: ()-->(1,5)
  ├── prune: (1,5)
@@ -309,7 +277,6 @@ group-by
  │    ├── columns: x:1(int!null) z:3(float!null)
  │    ├── constraint: /1: [/1 - /1]
  │    ├── cardinality: [0 - 1]
- │    ├── stats: [rows=1, distinct(1)=1]
  │    ├── key: ()
  │    ├── fd: ()-->(1,3)
  │    ├── prune: (3)

--- a/pkg/sql/opt/memo/testdata/logprops/index-join
+++ b/pkg/sql/opt/memo/testdata/logprops/index-join
@@ -54,21 +54,18 @@ SELECT * FROM a WHERE s = 'foo' AND x + y = 10
 ----
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null)
- ├── stats: [rows=0.476190476, distinct(3)=0.476190476]
  ├── key: (1)
  ├── fd: ()-->(3), (1)-->(2,4), (4)-->(1,2), (2,3)~~>(1,4)
  ├── prune: (4)
  ├── interesting orderings: (+1) (-3,+4,+1)
  ├── index-join a
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1.42857143]
  │    ├── key: (1)
  │    ├── fd: ()-->(3), (1)-->(2,4), (4)-->(1), (3,4)~~>(1,2), (2,3)~~>(1,4)
  │    ├── interesting orderings: (+1) (-3,+4,+1)
  │    └── scan a@secondary
  │         ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
  │         ├── constraint: /-3/4: [/'foo' - /'foo']
- │         ├── stats: [rows=1.42857143, distinct(3)=1]
  │         ├── key: (1)
  │         ├── fd: ()-->(3), (1)-->(4), (4)-->(1)
  │         ├── prune: (1,3,4)
@@ -85,24 +82,20 @@ SELECT y FROM a WHERE s = 'foo' AND x + y = 10
 ----
 project
  ├── columns: y:2(int)
- ├── stats: [rows=0.476190476]
  ├── prune: (2)
  └── select
       ├── columns: x:1(int!null) y:2(int) s:3(string!null)
-      ├── stats: [rows=0.476190476, distinct(3)=0.476190476]
       ├── key: (1)
       ├── fd: ()-->(3), (1)-->(2), (2,3)~~>(1)
       ├── interesting orderings: (+1) (-3)
       ├── index-join a
       │    ├── columns: x:1(int!null) y:2(int) s:3(string)
-      │    ├── stats: [rows=1.42857143]
       │    ├── key: (1)
       │    ├── fd: ()-->(3), (1)-->(2), (2,3)~~>(1)
       │    ├── interesting orderings: (+1) (-3)
       │    └── scan a@secondary
       │         ├── columns: x:1(int!null) s:3(string!null)
       │         ├── constraint: /-3/4: [/'foo' - /'foo']
-      │         ├── stats: [rows=1.42857143, distinct(3)=1]
       │         ├── key: (1)
       │         ├── fd: ()-->(3)
       │         ├── prune: (1,3)
@@ -121,19 +114,16 @@ SELECT b, c, d FROM abc WHERE c=1 AND d=2
 ----
 select
  ├── columns: b:2(int!null) c:3(int!null) d:4(int!null)
- ├── stats: [rows=0.00204081633, distinct(3)=0.00204081633, distinct(4)=0.00204081633]
  ├── fd: ()-->(3,4)
  ├── prune: (2)
  ├── interesting orderings: (+1,+2) (+3,+1,+2)
  ├── index-join abc
  │    ├── columns: b:2(int!null) c:3(int) d:4(int)
- │    ├── stats: [rows=1.42857143]
  │    ├── fd: ()-->(3)
  │    ├── interesting orderings: (+1,+2) (+3,+1,+2)
  │    └── scan abc@secondary
  │         ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  │         ├── constraint: /3/1/2: [/1 - /1]
- │         ├── stats: [rows=1.42857143, distinct(3)=1]
  │         ├── key: (1,2)
  │         ├── fd: ()-->(3)
  │         ├── prune: (1-3)

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -41,21 +41,18 @@ SELECT *, rowid FROM xysd INNER JOIN uv ON x=u
 ----
 inner-join
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int!null) v:6(int!null) rowid:7(int!null)
- ├── stats: [rows=1000, distinct(1)=700, distinct(5)=700]
  ├── key: (7)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6), (1)==(5), (5)==(1)
  ├── prune: (2-4,6,7)
  ├── interesting orderings: (+1) (-3,+4,+1) (+7)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000, distinct(1)=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-3,+4,+1)
  ├── scan uv
  │    ├── columns: u:5(int) v:6(int!null) rowid:7(int!null)
- │    ├── stats: [rows=1000, distinct(5)=700]
  │    ├── key: (7)
  │    ├── fd: (7)-->(5,6)
  │    ├── prune: (5-7)
@@ -71,17 +68,14 @@ SELECT (SELECT (VALUES (x), (y))) FROM xysd
 ----
 project
  ├── columns: column1:7(int)
- ├── stats: [rows=1000]
  ├── prune: (7)
  ├── inner-join-apply
  │    ├── columns: x:1(int!null) y:2(int) column1:5(int)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,5)
  │    ├── interesting orderings: (+1)
  │    ├── scan xysd
  │    │    ├── columns: x:1(int!null) y:2(int)
- │    │    ├── stats: [rows=1000]
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2)
  │    │    ├── prune: (1,2)
@@ -90,14 +84,12 @@ project
  │    │    ├── columns: column1:5(int)
  │    │    ├── outer: (1,2)
  │    │    ├── cardinality: [1 - 1]
- │    │    ├── stats: [rows=1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(5)
  │    │    └── values
  │    │         ├── columns: column1:5(int)
  │    │         ├── outer: (1,2)
  │    │         ├── cardinality: [2 - 2]
- │    │         ├── stats: [rows=2]
  │    │         ├── prune: (5)
  │    │         ├── tuple [type=tuple{int}, outer=(1)]
  │    │         │    └── variable: x [type=int, outer=(1)]
@@ -114,21 +106,18 @@ SELECT * FROM xysd WHERE (SELECT v FROM uv WHERE (SELECT n FROM mn WHERE n=v)=x)
 ----
 project
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- ├── stats: [rows=1]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-4)
  ├── interesting orderings: (+1) (-3,+4,+1)
  └── inner-join-apply
       ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) v:6(int!null)
-      ├── stats: [rows=1, distinct(1)=1, distinct(6)=1]
       ├── key: (1)
       ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (1)==(6), (6)==(1)
       ├── prune: (2-4)
       ├── interesting orderings: (+1) (-3,+4,+1)
       ├── scan xysd
       │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
-      │    ├── stats: [rows=1000, distinct(1)=1000]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
       │    ├── prune: (1-4)
@@ -137,40 +126,33 @@ project
       │    ├── columns: v:6(int!null)
       │    ├── outer: (1)
       │    ├── cardinality: [0 - 1]
-      │    ├── stats: [rows=1, distinct(6)=1]
       │    ├── key: ()
       │    ├── fd: ()-->(6)
       │    └── project
       │         ├── columns: v:6(int!null)
       │         ├── outer: (1)
-      │         ├── stats: [rows=1000]
       │         ├── prune: (6)
       │         └── inner-join-apply
       │              ├── columns: v:6(int!null) n:9(int!null)
       │              ├── outer: (1)
-      │              ├── stats: [rows=1000, distinct(1)=1, distinct(9)=1]
       │              ├── fd: ()-->(9)
       │              ├── scan uv
       │              │    ├── columns: v:6(int!null)
-      │              │    ├── stats: [rows=1000]
       │              │    └── prune: (6)
       │              ├── max1-row
       │              │    ├── columns: n:9(int!null)
       │              │    ├── outer: (6)
       │              │    ├── cardinality: [0 - 1]
-      │              │    ├── stats: [rows=1, distinct(9)=1]
       │              │    ├── key: ()
       │              │    ├── fd: ()-->(9)
       │              │    └── select
       │              │         ├── columns: n:9(int!null)
       │              │         ├── outer: (6)
-      │              │         ├── stats: [rows=1, distinct(6)=1, distinct(9)=1]
       │              │         ├── fd: ()-->(9)
       │              │         ├── interesting orderings: (+9)
       │              │         ├── scan mn@secondary
       │              │         │    ├── columns: n:9(int!null)
       │              │         │    ├── constraint: /9: (/NULL - ]
-      │              │         │    ├── stats: [rows=333.333333]
       │              │         │    ├── key: (9)
       │              │         │    ├── prune: (9)
       │              │         │    └── interesting orderings: (+9)
@@ -194,21 +176,18 @@ SELECT * FROM xysd WHERE (SELECT v FROM uv WHERE (SELECT m FROM mn WHERE m=y)=x)
 ----
 project
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- ├── stats: [rows=1]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-4)
  ├── interesting orderings: (+1) (-3,+4,+1)
  └── inner-join-apply
       ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) v:6(int!null)
-      ├── stats: [rows=1, distinct(1)=1, distinct(6)=1]
       ├── key: (1)
       ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (1)==(6), (6)==(1)
       ├── prune: (3,4)
       ├── interesting orderings: (+1) (-3,+4,+1)
       ├── scan xysd
       │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
-      │    ├── stats: [rows=1000, distinct(1)=1000]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
       │    ├── prune: (1-4)
@@ -217,28 +196,23 @@ project
       │    ├── columns: v:6(int!null)
       │    ├── outer: (1,2)
       │    ├── cardinality: [0 - 1]
-      │    ├── stats: [rows=1, distinct(6)=1]
       │    ├── key: ()
       │    ├── fd: ()-->(6)
       │    └── project
       │         ├── columns: v:6(int!null)
       │         ├── outer: (1,2)
-      │         ├── stats: [rows=1000]
       │         ├── prune: (6)
       │         └── inner-join
       │              ├── columns: v:6(int!null) m:8(int!null)
       │              ├── outer: (1,2)
-      │              ├── stats: [rows=1000, distinct(1)=1, distinct(2)=1, distinct(8)=1]
       │              ├── fd: ()-->(8)
       │              ├── prune: (6)
       │              ├── interesting orderings: (+8)
       │              ├── scan uv
       │              │    ├── columns: v:6(int!null)
-      │              │    ├── stats: [rows=1000]
       │              │    └── prune: (6)
       │              ├── scan mn
       │              │    ├── columns: m:8(int!null)
-      │              │    ├── stats: [rows=1000, distinct(8)=1000]
       │              │    ├── key: (8)
       │              │    ├── prune: (8)
       │              │    └── interesting orderings: (+8)
@@ -260,7 +234,6 @@ SELECT *, rowid FROM xysd LEFT JOIN uv ON x=u
 ----
 left-join
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int) rowid:7(int)
- ├── stats: [rows=1000, distinct(5)=700]
  ├── key: (1,7)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
  ├── prune: (2-4,6,7)
@@ -268,14 +241,12 @@ left-join
  ├── interesting orderings: (+1) (-3,+4,+1) (+7)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000, distinct(1)=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-3,+4,+1)
  ├── scan uv
  │    ├── columns: u:5(int) v:6(int!null) rowid:7(int!null)
- │    ├── stats: [rows=1000, distinct(5)=700]
  │    ├── key: (7)
  │    ├── fd: (7)-->(5,6)
  │    ├── prune: (5-7)
@@ -291,21 +262,18 @@ SELECT * FROM xysd WHERE (SELECT u FROM uv WHERE u=x) IS NULL
 ----
 project
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- ├── stats: [rows=1000]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-4)
  ├── interesting orderings: (+1) (-3,+4,+1)
  └── select
       ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int)
-      ├── stats: [rows=1000, distinct(5)=1]
       ├── key: (1)
       ├── fd: ()-->(5), (1)-->(2-4), (3,4)~~>(1,2)
       ├── prune: (2-4)
       ├── interesting orderings: (+1) (-3,+4,+1)
       ├── left-join-apply
       │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int)
-      │    ├── stats: [rows=1000, distinct(5)=1]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-5), (3,4)~~>(1,2)
       │    ├── prune: (2-4)
@@ -313,7 +281,6 @@ project
       │    ├── interesting orderings: (+1) (-3,+4,+1)
       │    ├── scan xysd
       │    │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
-      │    │    ├── stats: [rows=1000]
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
       │    │    ├── prune: (1-4)
@@ -322,17 +289,14 @@ project
       │    │    ├── columns: u:5(int!null)
       │    │    ├── outer: (1)
       │    │    ├── cardinality: [0 - 1]
-      │    │    ├── stats: [rows=1, distinct(5)=1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(5)
       │    │    └── select
       │    │         ├── columns: u:5(int!null)
       │    │         ├── outer: (1)
-      │    │         ├── stats: [rows=1.42857143, distinct(1)=1, distinct(5)=1]
       │    │         ├── fd: ()-->(5)
       │    │         ├── scan uv
       │    │         │    ├── columns: u:5(int)
-      │    │         │    ├── stats: [rows=1000, distinct(5)=700]
       │    │         │    └── prune: (5)
       │    │         └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
       │    │              └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
@@ -350,7 +314,6 @@ SELECT *, rowid FROM xysd RIGHT JOIN uv ON x=u
 ----
 right-join
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int!null) rowid:7(int!null)
- ├── stats: [rows=1000, distinct(1)=700]
  ├── key: (1,7)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
  ├── prune: (2-4,6,7)
@@ -358,14 +321,12 @@ right-join
  ├── interesting orderings: (+1) (-3,+4,+1) (+7)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000, distinct(1)=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-3,+4,+1)
  ├── scan uv
  │    ├── columns: u:5(int) v:6(int!null) rowid:7(int!null)
- │    ├── stats: [rows=1000, distinct(5)=700]
  │    ├── key: (7)
  │    ├── fd: (7)-->(5,6)
  │    ├── prune: (5-7)
@@ -381,28 +342,24 @@ SELECT * FROM xysd RIGHT JOIN uv ON (SELECT u FROM uv WHERE u=x OFFSET 1) IS NUL
 ----
 right-join
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int!null)
- ├── stats: [rows=1000000]
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-6)
  ├── reject-nulls: (1-4)
  ├── interesting orderings: (+1) (-3,+4,+1)
  ├── project
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
  │    ├── interesting orderings: (+1) (-3,+4,+1)
  │    └── select
  │         ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) uv.u:8(int)
- │         ├── stats: [rows=1000, distinct(8)=1]
  │         ├── key: (1)
  │         ├── fd: ()-->(8), (1)-->(2-4), (3,4)~~>(1,2)
  │         ├── prune: (2-4)
  │         ├── interesting orderings: (+1) (-3,+4,+1)
  │         ├── left-join-apply
  │         │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) uv.u:8(int)
- │         │    ├── stats: [rows=1000, distinct(8)=1]
  │         │    ├── key: (1)
  │         │    ├── fd: (1)-->(2-4,8), (3,4)~~>(1,2)
  │         │    ├── prune: (2-4)
@@ -410,7 +367,6 @@ right-join
  │         │    ├── interesting orderings: (+1) (-3,+4,+1)
  │         │    ├── scan xysd
  │         │    │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │         │    │    ├── stats: [rows=1000]
  │         │    │    ├── key: (1)
  │         │    │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │         │    │    ├── prune: (1-4)
@@ -419,22 +375,18 @@ right-join
  │         │    │    ├── columns: uv.u:8(int!null)
  │         │    │    ├── outer: (1)
  │         │    │    ├── cardinality: [0 - 1]
- │         │    │    ├── stats: [rows=1, distinct(8)=1]
  │         │    │    ├── key: ()
  │         │    │    ├── fd: ()-->(8)
  │         │    │    └── offset
  │         │    │         ├── columns: uv.u:8(int!null)
  │         │    │         ├── outer: (1)
- │         │    │         ├── stats: [rows=0.428571429]
  │         │    │         ├── fd: ()-->(8)
  │         │    │         ├── select
  │         │    │         │    ├── columns: uv.u:8(int!null)
  │         │    │         │    ├── outer: (1)
- │         │    │         │    ├── stats: [rows=1.42857143, distinct(1)=1, distinct(8)=1]
  │         │    │         │    ├── fd: ()-->(8)
  │         │    │         │    ├── scan uv
  │         │    │         │    │    ├── columns: uv.u:8(int)
- │         │    │         │    │    ├── stats: [rows=1000, distinct(8)=700]
  │         │    │         │    │    └── prune: (8)
  │         │    │         │    └── filters [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
  │         │    │         │         └── eq [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
@@ -448,7 +400,6 @@ right-join
  │                   └── null [type=unknown]
  ├── scan uv
  │    ├── columns: uv.u:5(int) uv.v:6(int!null)
- │    ├── stats: [rows=1000]
  │    └── prune: (5,6)
  └── true [type=bool]
 
@@ -458,7 +409,6 @@ SELECT *, rowid FROM xysd FULL JOIN uv ON x=u
 ----
 full-join
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int) rowid:7(int)
- ├── stats: [rows=1000]
  ├── key: (1,7)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
  ├── prune: (2-4,6,7)
@@ -466,14 +416,12 @@ full-join
  ├── interesting orderings: (+1) (-3,+4,+1) (+7)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000, distinct(1)=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-3,+4,+1)
  ├── scan uv
  │    ├── columns: u:5(int) v:6(int!null) rowid:7(int!null)
- │    ├── stats: [rows=1000, distinct(5)=700]
  │    ├── key: (7)
  │    ├── fd: (7)-->(5,6)
  │    ├── prune: (5-7)
@@ -489,20 +437,17 @@ SELECT * FROM xysd FULL JOIN uv ON (SELECT u FROM uv WHERE u=x OFFSET 1) IS NULL
 ----
 project
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int)
- ├── stats: [rows=1000000]
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-6)
  ├── interesting orderings: (+1) (-3,+4,+1)
  └── full-join-apply
       ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) uv.u:5(int) uv.v:6(int) uv.u:8(int)
-      ├── stats: [rows=1000000]
       ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
       ├── prune: (2-6)
       ├── reject-nulls: (1-6,8)
       ├── interesting orderings: (+1) (-3,+4,+1)
       ├── scan xysd
       │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
-      │    ├── stats: [rows=1000]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
       │    ├── prune: (1-4)
@@ -510,34 +455,28 @@ project
       ├── left-join
       │    ├── columns: uv.u:5(int) uv.v:6(int!null) uv.u:8(int)
       │    ├── outer: (1)
-      │    ├── stats: [rows=1000, distinct(8)=1]
       │    ├── fd: ()~~>(8)
       │    ├── prune: (5,6)
       │    ├── reject-nulls: (8)
       │    ├── scan uv
       │    │    ├── columns: uv.u:5(int) uv.v:6(int!null)
-      │    │    ├── stats: [rows=1000]
       │    │    └── prune: (5,6)
       │    ├── max1-row
       │    │    ├── columns: uv.u:8(int!null)
       │    │    ├── outer: (1)
       │    │    ├── cardinality: [0 - 1]
-      │    │    ├── stats: [rows=1, distinct(8)=1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(8)
       │    │    └── offset
       │    │         ├── columns: uv.u:8(int!null)
       │    │         ├── outer: (1)
-      │    │         ├── stats: [rows=0.428571429]
       │    │         ├── fd: ()-->(8)
       │    │         ├── select
       │    │         │    ├── columns: uv.u:8(int!null)
       │    │         │    ├── outer: (1)
-      │    │         │    ├── stats: [rows=1.42857143, distinct(1)=1, distinct(8)=1]
       │    │         │    ├── fd: ()-->(8)
       │    │         │    ├── scan uv
       │    │         │    │    ├── columns: uv.u:8(int)
-      │    │         │    │    ├── stats: [rows=1000, distinct(8)=700]
       │    │         │    │    └── prune: (8)
       │    │         │    └── filters [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
       │    │         │         └── eq [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
@@ -556,21 +495,18 @@ SELECT * FROM xysd WHERE EXISTS(SELECT * FROM uv WHERE x=u)
 ----
 semi-join
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- ├── stats: [rows=1000]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (2-4)
  ├── interesting orderings: (+1) (-3,+4,+1)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-3,+4,+1)
  ├── scan uv
  │    ├── columns: u:5(int) v:6(int!null)
- │    ├── stats: [rows=1000, distinct(5)=700]
  │    └── prune: (5,6)
  └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
       └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
@@ -583,14 +519,12 @@ SELECT * FROM xysd WHERE EXISTS(SELECT * FROM uv WHERE v=x OFFSET 1)
 ----
 semi-join-apply
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- ├── stats: [rows=1000]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (2-4)
  ├── interesting orderings: (+1) (-3,+4,+1)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -598,18 +532,15 @@ semi-join-apply
  ├── offset
  │    ├── columns: u:5(int) v:6(int!null)
  │    ├── outer: (1)
- │    ├── stats: [rows=0.428571429]
  │    ├── fd: ()-->(6)
  │    ├── prune: (5)
  │    ├── select
  │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    ├── outer: (1)
- │    │    ├── stats: [rows=1.42857143, distinct(1)=1, distinct(6)=1]
  │    │    ├── fd: ()-->(6)
  │    │    ├── prune: (5)
  │    │    ├── scan uv
  │    │    │    ├── columns: u:5(int) v:6(int!null)
- │    │    │    ├── stats: [rows=1000, distinct(6)=700]
  │    │    │    └── prune: (5,6)
  │    │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         └── eq [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
@@ -624,14 +555,12 @@ SELECT * FROM xysd WHERE EXISTS(SELECT * FROM uv WHERE EXISTS(SELECT * FROM mn W
 ----
 semi-join-apply
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- ├── stats: [rows=1000]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (2-4)
  ├── interesting orderings: (+1) (-3,+4,+1)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -639,16 +568,13 @@ semi-join-apply
  ├── semi-join
  │    ├── columns: u:5(int) v:6(int!null)
  │    ├── outer: (1)
- │    ├── stats: [rows=1000]
  │    ├── fd: ()-->(6)
  │    ├── prune: (5)
  │    ├── scan uv
  │    │    ├── columns: u:5(int) v:6(int!null)
- │    │    ├── stats: [rows=1000]
  │    │    └── prune: (5,6)
  │    ├── scan mn
  │    │    ├── columns: m:8(int!null) n:9(int)
- │    │    ├── stats: [rows=1000, distinct(8)=1000]
  │    │    ├── key: (8)
  │    │    ├── fd: (8)-->(9), (9)~~>(8)
  │    │    ├── prune: (8,9)
@@ -668,21 +594,18 @@ SELECT * FROM xysd WHERE NOT EXISTS(SELECT * FROM uv WHERE x=u)
 ----
 anti-join
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- ├── stats: [rows=1000]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (2-4)
  ├── interesting orderings: (+1) (-3,+4,+1)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-3,+4,+1)
  ├── scan uv
  │    ├── columns: u:5(int) v:6(int!null)
- │    ├── stats: [rows=1000, distinct(5)=700]
  │    └── prune: (5,6)
  └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
       └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
@@ -695,14 +618,12 @@ SELECT * FROM xysd WHERE NOT EXISTS(SELECT * FROM uv WHERE v=x OFFSET 1)
 ----
 anti-join-apply
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- ├── stats: [rows=1000]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (2-4)
  ├── interesting orderings: (+1) (-3,+4,+1)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -710,18 +631,15 @@ anti-join-apply
  ├── offset
  │    ├── columns: u:5(int) v:6(int!null)
  │    ├── outer: (1)
- │    ├── stats: [rows=0.428571429]
  │    ├── fd: ()-->(6)
  │    ├── prune: (5)
  │    ├── select
  │    │    ├── columns: u:5(int) v:6(int!null)
  │    │    ├── outer: (1)
- │    │    ├── stats: [rows=1.42857143, distinct(1)=1, distinct(6)=1]
  │    │    ├── fd: ()-->(6)
  │    │    ├── prune: (5)
  │    │    ├── scan uv
  │    │    │    ├── columns: u:5(int) v:6(int!null)
- │    │    │    ├── stats: [rows=1000, distinct(6)=700]
  │    │    │    └── prune: (5,6)
  │    │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         └── eq [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
@@ -736,27 +654,23 @@ SELECT * FROM xysd, uv
 ----
 project
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int!null)
- ├── stats: [rows=1000000]
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-6)
  ├── interesting orderings: (+1) (-3,+4,+1)
  └── inner-join
       ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int!null) rowid:7(int!null)
-      ├── stats: [rows=1000000]
       ├── key: (1,7)
       ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
       ├── prune: (1-7)
       ├── interesting orderings: (+1) (-3,+4,+1) (+7)
       ├── scan xysd
       │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
-      │    ├── stats: [rows=1000]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
       │    ├── prune: (1-4)
       │    └── interesting orderings: (+1) (-3,+4,+1)
       ├── scan uv
       │    ├── columns: u:5(int) v:6(int!null) rowid:7(int!null)
-      │    ├── stats: [rows=1000]
       │    ├── key: (7)
       │    ├── fd: (7)-->(5,6)
       │    ├── prune: (5-7)
@@ -769,21 +683,18 @@ SELECT * FROM xysd, xysd AS xysd
 ----
 inner-join
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) x:5(int!null) y:6(int) s:7(string) d:8(decimal!null)
- ├── stats: [rows=1000000]
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (5)-->(6-8), (7,8)~~>(5,6)
  ├── prune: (1-8)
  ├── interesting orderings: (+1) (-3,+4,+1) (+5) (-7,+8,+5)
  ├── scan xysd
  │    ├── columns: xysd.x:1(int!null) xysd.y:2(int) xysd.s:3(string) xysd.d:4(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-3,+4,+1)
  ├── scan xysd
  │    ├── columns: xysd.x:5(int!null) xysd.y:6(int) xysd.s:7(string) xysd.d:8(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (5)
  │    ├── fd: (5)-->(6-8), (7,8)~~>(5,6)
  │    ├── prune: (5-8)
@@ -796,14 +707,12 @@ SELECT * FROM xysd WHERE EXISTS(SELECT * FROM (SELECT x) INNER JOIN (SELECT y) O
 ----
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (4)
  ├── interesting orderings: (+1) (-3,+4,+1)
  ├── scan xysd
  │    ├── columns: xysd.x:1(int!null) xysd.y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -814,7 +723,6 @@ select
                 ├── columns: x:5(int) y:6(int)
                 ├── outer: (1-3)
                 ├── cardinality: [0 - 1]
-                ├── stats: [rows=0.333333333]
                 ├── key: ()
                 ├── fd: ()-->(5,6)
                 ├── prune: (6)
@@ -822,13 +730,11 @@ select
                 │    ├── columns: x:5(int)
                 │    ├── outer: (1)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1]
                 │    ├── key: ()
                 │    ├── fd: ()-->(5)
                 │    ├── prune: (5)
                 │    ├── values
                 │    │    ├── cardinality: [1 - 1]
-                │    │    ├── stats: [rows=1]
                 │    │    ├── key: ()
                 │    │    └── tuple [type=tuple]
                 │    └── projections [outer=(1)]
@@ -837,13 +743,11 @@ select
                 │    ├── columns: y:6(int)
                 │    ├── outer: (2)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1]
                 │    ├── key: ()
                 │    ├── fd: ()-->(6)
                 │    ├── prune: (6)
                 │    ├── values
                 │    │    ├── cardinality: [1 - 1]
-                │    │    ├── stats: [rows=1]
                 │    │    ├── key: ()
                 │    │    └── tuple [type=tuple]
                 │    └── projections [outer=(2)]
@@ -861,24 +765,20 @@ SELECT * FROM (SELECT count(*) cnt FROM xysd) WHERE EXISTS(SELECT * FROM uv WHER
 semi-join
  ├── columns: cnt:5(int!null)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=1]
  ├── key: ()
  ├── fd: ()-->(5)
  ├── select
  │    ├── columns: cnt:5(int!null)
  │    ├── cardinality: [0 - 1]
- │    ├── stats: [rows=1, distinct(5)=1]
  │    ├── key: ()
  │    ├── fd: ()-->(5)
  │    ├── scalar-group-by
  │    │    ├── columns: cnt:5(int)
  │    │    ├── cardinality: [1 - 1]
- │    │    ├── stats: [rows=1, distinct(5)=1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(5)
  │    │    ├── prune: (5)
  │    │    ├── scan xysd@secondary
- │    │    │    └── stats: [rows=1000]
  │    │    └── aggregations
  │    │         └── count-rows [type=int]
  │    └── filters [type=bool, outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
@@ -887,7 +787,6 @@ semi-join
  │              └── const: 1 [type=int]
  ├── scan uv
  │    ├── columns: u:6(int) v:7(int!null)
- │    ├── stats: [rows=1000]
  │    └── prune: (6,7)
  └── true [type=bool]
 
@@ -898,7 +797,6 @@ SELECT * FROM (SELECT * FROM xysd LIMIT 10) WHERE EXISTS(SELECT * FROM uv WHERE 
 semi-join-apply
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  ├── cardinality: [0 - 10]
- ├── stats: [rows=10]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (2-4)
@@ -906,7 +804,6 @@ semi-join-apply
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── limit: 10
- │    ├── stats: [rows=10]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -915,18 +812,15 @@ semi-join-apply
  │    ├── columns: u:5(int!null) v:6(int!null)
  │    ├── outer: (1)
  │    ├── cardinality: [0 - 5]
- │    ├── stats: [rows=1.42857143]
  │    ├── fd: ()-->(5)
  │    ├── prune: (6)
  │    ├── select
  │    │    ├── columns: u:5(int!null) v:6(int!null)
  │    │    ├── outer: (1)
- │    │    ├── stats: [rows=1.42857143, distinct(1)=1, distinct(5)=1]
  │    │    ├── fd: ()-->(5)
  │    │    ├── prune: (6)
  │    │    ├── scan uv
  │    │    │    ├── columns: u:5(int) v:6(int!null)
- │    │    │    ├── stats: [rows=1000, distinct(5)=700]
  │    │    │    └── prune: (5,6)
  │    │    └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
  │    │         └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
@@ -942,13 +836,11 @@ SELECT * FROM (SELECT * FROM (VALUES (1))) WHERE NOT EXISTS(SELECT * FROM uv WHE
 anti-join
  ├── columns: column1:1(int)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=1]
  ├── key: ()
  ├── fd: ()-->(1)
  ├── values
  │    ├── columns: column1:1(int)
  │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1]
  │    ├── key: ()
  │    ├── fd: ()-->(1)
  │    ├── prune: (1)
@@ -956,7 +848,6 @@ anti-join
  │         └── const: 1 [type=int]
  ├── scan uv
  │    ├── columns: u:2(int) v:3(int!null)
- │    ├── stats: [rows=1000, distinct(2)=700]
  │    └── prune: (2,3)
  └── filters [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
       └── eq [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
@@ -970,7 +861,6 @@ SELECT * FROM (SELECT * FROM xysd LIMIT 10) WHERE NOT EXISTS(SELECT * FROM uv WH
 anti-join-apply
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  ├── cardinality: [0 - 10]
- ├── stats: [rows=10]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (2-4)
@@ -978,7 +868,6 @@ anti-join-apply
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── limit: 10
- │    ├── stats: [rows=10]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -987,18 +876,15 @@ anti-join-apply
  │    ├── columns: u:5(int!null) v:6(int!null)
  │    ├── outer: (1)
  │    ├── cardinality: [0 - 5]
- │    ├── stats: [rows=1.42857143]
  │    ├── fd: ()-->(5)
  │    ├── prune: (6)
  │    ├── select
  │    │    ├── columns: u:5(int!null) v:6(int!null)
  │    │    ├── outer: (1)
- │    │    ├── stats: [rows=1.42857143, distinct(1)=1, distinct(5)=1]
  │    │    ├── fd: ()-->(5)
  │    │    ├── prune: (6)
  │    │    ├── scan uv
  │    │    │    ├── columns: u:5(int) v:6(int!null)
- │    │    │    ├── stats: [rows=1000, distinct(5)=700]
  │    │    │    └── prune: (5,6)
  │    │    └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
  │    │         └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
@@ -1014,12 +900,10 @@ SELECT * FROM (VALUES (1), (2)) INNER JOIN (SELECT * FROM uv LIMIT 2) ON True
 inner-join
  ├── columns: column1:1(int) u:2(int) v:3(int!null)
  ├── cardinality: [0 - 4]
- ├── stats: [rows=1.33333333]
  ├── prune: (1-3)
  ├── values
  │    ├── columns: column1:1(int)
  │    ├── cardinality: [2 - 2]
- │    ├── stats: [rows=2]
  │    ├── prune: (1)
  │    ├── tuple [type=tuple{int}]
  │    │    └── const: 1 [type=int]
@@ -1028,15 +912,12 @@ inner-join
  ├── limit
  │    ├── columns: u:2(int) v:3(int!null)
  │    ├── cardinality: [0 - 2]
- │    ├── stats: [rows=2]
  │    ├── prune: (2,3)
  │    ├── project
  │    │    ├── columns: u:2(int) v:3(int!null)
- │    │    ├── stats: [rows=1000]
  │    │    ├── prune: (2,3)
  │    │    └── scan uv
  │    │         ├── columns: u:2(int) v:3(int!null) rowid:4(int!null)
- │    │         ├── stats: [rows=1000]
  │    │         ├── key: (4)
  │    │         ├── fd: (4)-->(2,3)
  │    │         ├── prune: (2-4)
@@ -1052,13 +933,11 @@ SELECT * FROM (VALUES (1), (2), (3)) LEFT JOIN (SELECT * FROM uv LIMIT 2) ON Tru
 left-join
  ├── columns: column1:1(int) u:2(int) v:3(int)
  ├── cardinality: [3 - 6]
- ├── stats: [rows=3]
  ├── prune: (1-3)
  ├── reject-nulls: (2,3)
  ├── values
  │    ├── columns: column1:1(int)
  │    ├── cardinality: [3 - 3]
- │    ├── stats: [rows=3]
  │    ├── prune: (1)
  │    ├── tuple [type=tuple{int}]
  │    │    └── const: 1 [type=int]
@@ -1069,15 +948,12 @@ left-join
  ├── limit
  │    ├── columns: u:2(int) v:3(int!null)
  │    ├── cardinality: [0 - 2]
- │    ├── stats: [rows=2]
  │    ├── prune: (2,3)
  │    ├── project
  │    │    ├── columns: u:2(int) v:3(int!null)
- │    │    ├── stats: [rows=1000]
  │    │    ├── prune: (2,3)
  │    │    └── scan uv
  │    │         ├── columns: u:2(int) v:3(int!null) rowid:4(int!null)
- │    │         ├── stats: [rows=1000]
  │    │         ├── key: (4)
  │    │         ├── fd: (4)-->(2,3)
  │    │         ├── prune: (2-4)
@@ -1093,21 +969,17 @@ SELECT * FROM (SELECT * FROM uv LIMIT 2) RIGHT JOIN (VALUES (1), (2), (3)) ON Tr
 right-join
  ├── columns: u:1(int) v:2(int) column1:4(int)
  ├── cardinality: [3 - 6]
- ├── stats: [rows=3]
  ├── prune: (1,2,4)
  ├── reject-nulls: (1,2)
  ├── limit
  │    ├── columns: u:1(int) v:2(int!null)
  │    ├── cardinality: [0 - 2]
- │    ├── stats: [rows=2]
  │    ├── prune: (1,2)
  │    ├── project
  │    │    ├── columns: u:1(int) v:2(int!null)
- │    │    ├── stats: [rows=1000]
  │    │    ├── prune: (1,2)
  │    │    └── scan uv
  │    │         ├── columns: u:1(int) v:2(int!null) rowid:3(int!null)
- │    │         ├── stats: [rows=1000]
  │    │         ├── key: (3)
  │    │         ├── fd: (3)-->(1,2)
  │    │         ├── prune: (1-3)
@@ -1116,7 +988,6 @@ right-join
  ├── values
  │    ├── columns: column1:4(int)
  │    ├── cardinality: [3 - 3]
- │    ├── stats: [rows=3]
  │    ├── prune: (4)
  │    ├── tuple [type=tuple{int}]
  │    │    └── const: 1 [type=int]
@@ -1134,13 +1005,11 @@ SELECT * FROM (VALUES (NULL), (NULL)) a FULL JOIN (VALUES (NULL), (NULL)) b ON T
 full-join
  ├── columns: column1:1(unknown) column1:2(unknown)
  ├── cardinality: [2 - 4]
- ├── stats: [rows=2.66666667]
  ├── prune: (1,2)
  ├── reject-nulls: (1,2)
  ├── values
  │    ├── columns: column1:1(unknown)
  │    ├── cardinality: [2 - 2]
- │    ├── stats: [rows=2]
  │    ├── prune: (1)
  │    ├── tuple [type=tuple{unknown}]
  │    │    └── null [type=unknown]
@@ -1149,7 +1018,6 @@ full-join
  ├── values
  │    ├── columns: column1:2(unknown)
  │    ├── cardinality: [2 - 2]
- │    ├── stats: [rows=2]
  │    ├── prune: (2)
  │    ├── tuple [type=tuple{unknown}]
  │    │    └── null [type=unknown]
@@ -1165,13 +1033,11 @@ SELECT * FROM (VALUES (NULL), (NULL)) a FULL JOIN (VALUES (NULL), (NULL)) b ON a
 full-join
  ├── columns: column1:1(unknown) column1:2(unknown)
  ├── cardinality: [2 - 4]
- ├── stats: [rows=4]
  ├── prune: (1,2)
  ├── reject-nulls: (1,2)
  ├── values
  │    ├── columns: column1:1(unknown)
  │    ├── cardinality: [2 - 2]
- │    ├── stats: [rows=2]
  │    ├── prune: (1)
  │    ├── tuple [type=tuple{unknown}]
  │    │    └── null [type=unknown, constraints=(contradiction; tight)]
@@ -1180,7 +1046,6 @@ full-join
  ├── values
  │    ├── columns: column1:2(unknown)
  │    ├── cardinality: [2 - 2]
- │    ├── stats: [rows=2]
  │    ├── prune: (2)
  │    ├── tuple [type=tuple{unknown}]
  │    │    └── null [type=unknown, constraints=(contradiction; tight)]
@@ -1196,14 +1061,12 @@ SELECT * FROM xysd FULL JOIN (SELECT * FROM (VALUES (1), (2))) ON True
 full-join
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) column1:5(int)
  ├── cardinality: [2 - ]
- ├── stats: [rows=1000]
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-5)
  ├── reject-nulls: (1-5)
  ├── interesting orderings: (+1) (-3,+4,+1)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -1211,7 +1074,6 @@ full-join
  ├── values
  │    ├── columns: column1:5(int)
  │    ├── cardinality: [2 - 2]
- │    ├── stats: [rows=2]
  │    ├── prune: (5)
  │    ├── tuple [type=tuple{int}]
  │    │    └── const: 1 [type=int]
@@ -1227,7 +1089,6 @@ SELECT * FROM (SELECT * FROM xysd LIMIT 1) FULL JOIN (SELECT * FROM xysd LIMIT 1
 full-join
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) x:5(int) y:6(int) s:7(string) d:8(decimal)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=1]
  ├── key: ()
  ├── fd: ()-->(1-8)
  ├── prune: (1-8)
@@ -1236,14 +1097,12 @@ full-join
  ├── limit
  │    ├── columns: xysd.x:1(int!null) xysd.y:2(int) xysd.s:3(string) xysd.d:4(decimal!null)
  │    ├── cardinality: [0 - 1]
- │    ├── stats: [rows=1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
  │    ├── prune: (1-4)
  │    ├── interesting orderings: (+1) (-3,+4,+1)
  │    ├── scan xysd
  │    │    ├── columns: xysd.x:1(int!null) xysd.y:2(int) xysd.s:3(string) xysd.d:4(decimal!null)
- │    │    ├── stats: [rows=1000]
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    │    ├── prune: (1-4)
@@ -1252,14 +1111,12 @@ full-join
  ├── limit
  │    ├── columns: xysd.x:5(int!null) xysd.y:6(int) xysd.s:7(string) xysd.d:8(decimal!null)
  │    ├── cardinality: [0 - 1]
- │    ├── stats: [rows=1]
  │    ├── key: ()
  │    ├── fd: ()-->(5-8)
  │    ├── prune: (5-8)
  │    ├── interesting orderings: (+5) (-7,+8,+5)
  │    ├── scan xysd
  │    │    ├── columns: xysd.x:5(int!null) xysd.y:6(int) xysd.s:7(string) xysd.d:8(decimal!null)
- │    │    ├── stats: [rows=1000]
  │    │    ├── key: (5)
  │    │    ├── fd: (5)-->(6-8), (7,8)~~>(5,6)
  │    │    ├── prune: (5-8)
@@ -1274,7 +1131,6 @@ SELECT * FROM xysd LEFT JOIN (SELECT u, sum(v) FROM uv GROUP BY u) ON u IS NOT N
 ----
 left-join
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) sum:8(decimal)
- ├── stats: [rows=233333.333]
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (5)~~>(8), (1,5)-->(8)
  ├── prune: (1-4,8)
@@ -1282,7 +1138,6 @@ left-join
  ├── interesting orderings: (+1) (-3,+4,+1)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -1290,17 +1145,14 @@ left-join
  ├── group-by
  │    ├── columns: u:5(int) sum:8(decimal)
  │    ├── grouping columns: u:5(int)
- │    ├── stats: [rows=700, distinct(5)=700]
  │    ├── key: (5)
  │    ├── fd: (5)-->(8)
  │    ├── prune: (8)
  │    ├── project
  │    │    ├── columns: u:5(int) v:6(int!null)
- │    │    ├── stats: [rows=1000, distinct(5)=700]
  │    │    ├── prune: (5,6)
  │    │    └── scan uv
  │    │         ├── columns: u:5(int) v:6(int!null) rowid:7(int!null)
- │    │         ├── stats: [rows=1000, distinct(5)=700]
  │    │         ├── key: (7)
  │    │         ├── fd: (7)-->(5,6)
  │    │         ├── prune: (5-7)
@@ -1319,7 +1171,6 @@ SELECT * FROM xysd LEFT JOIN (SELECT u, sum(v) FROM uv WHERE u IS NOT NULL GROUP
 ----
 left-join
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) sum:8(decimal)
- ├── stats: [rows=102590.515]
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (5)-->(8)
  ├── prune: (1-4,8)
@@ -1327,7 +1178,6 @@ left-join
  ├── interesting orderings: (+1) (-3,+4,+1)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -1335,24 +1185,20 @@ left-join
  ├── group-by
  │    ├── columns: u:5(int!null) sum:8(decimal)
  │    ├── grouping columns: u:5(int!null)
- │    ├── stats: [rows=307.771544, distinct(5)=307.771544]
  │    ├── key: (5)
  │    ├── fd: (5)-->(8)
  │    ├── prune: (8)
  │    ├── project
  │    │    ├── columns: u:5(int!null) v:6(int!null)
- │    │    ├── stats: [rows=333.333333, distinct(5)=307.771544]
  │    │    ├── prune: (5,6)
  │    │    └── select
  │    │         ├── columns: u:5(int!null) v:6(int!null) rowid:7(int!null)
- │    │         ├── stats: [rows=333.333333, distinct(5)=307.771544]
  │    │         ├── key: (7)
  │    │         ├── fd: (7)-->(5,6)
  │    │         ├── prune: (6,7)
  │    │         ├── interesting orderings: (+7)
  │    │         ├── scan uv
  │    │         │    ├── columns: u:5(int) v:6(int!null) rowid:7(int!null)
- │    │         │    ├── stats: [rows=1000, distinct(5)=700]
  │    │         │    ├── key: (7)
  │    │         │    ├── fd: (7)-->(5,6)
  │    │         │    ├── prune: (5-7)
@@ -1373,7 +1219,6 @@ SELECT * FROM (SELECT u, sum(v) FROM uv GROUP BY u) RIGHT JOIN xysd ON u IS NOT 
 ----
 right-join
  ├── columns: u:1(int) sum:4(decimal) x:5(int!null) y:6(int) s:7(string) d:8(decimal!null)
- ├── stats: [rows=233333.333]
  ├── key: (1,5)
  ├── fd: (5)-->(6-8), (7,8)~~>(5,6), (1)~~>(4), (1,5)-->(4)
  ├── prune: (4-8)
@@ -1382,17 +1227,14 @@ right-join
  ├── group-by
  │    ├── columns: u:1(int) sum:4(decimal)
  │    ├── grouping columns: u:1(int)
- │    ├── stats: [rows=700, distinct(1)=700]
  │    ├── key: (1)
  │    ├── fd: (1)-->(4)
  │    ├── prune: (4)
  │    ├── project
  │    │    ├── columns: u:1(int) v:2(int!null)
- │    │    ├── stats: [rows=1000, distinct(1)=700]
  │    │    ├── prune: (1,2)
  │    │    └── scan uv
  │    │         ├── columns: u:1(int) v:2(int!null) rowid:3(int!null)
- │    │         ├── stats: [rows=1000, distinct(1)=700]
  │    │         ├── key: (3)
  │    │         ├── fd: (3)-->(1,2)
  │    │         ├── prune: (1-3)
@@ -1402,7 +1244,6 @@ right-join
  │              └── variable: v [type=int, outer=(2)]
  ├── scan xysd
  │    ├── columns: x:5(int!null) y:6(int) s:7(string) d:8(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (5)
  │    ├── fd: (5)-->(6-8), (7,8)~~>(5,6)
  │    ├── prune: (5-8)
@@ -1418,7 +1259,6 @@ SELECT * FROM (SELECT u, sum(v) FROM uv WHERE u IS NOT NULL GROUP BY u) RIGHT JO
 ----
 right-join
  ├── columns: u:1(int) sum:4(decimal) x:5(int!null) y:6(int) s:7(string) d:8(decimal!null)
- ├── stats: [rows=102590.515]
  ├── key: (1,5)
  ├── fd: (1)-->(4), (5)-->(6-8), (7,8)~~>(5,6)
  ├── prune: (4-8)
@@ -1427,24 +1267,20 @@ right-join
  ├── group-by
  │    ├── columns: u:1(int!null) sum:4(decimal)
  │    ├── grouping columns: u:1(int!null)
- │    ├── stats: [rows=307.771544, distinct(1)=307.771544]
  │    ├── key: (1)
  │    ├── fd: (1)-->(4)
  │    ├── prune: (4)
  │    ├── project
  │    │    ├── columns: u:1(int!null) v:2(int!null)
- │    │    ├── stats: [rows=333.333333, distinct(1)=307.771544]
  │    │    ├── prune: (1,2)
  │    │    └── select
  │    │         ├── columns: u:1(int!null) v:2(int!null) rowid:3(int!null)
- │    │         ├── stats: [rows=333.333333, distinct(1)=307.771544]
  │    │         ├── key: (3)
  │    │         ├── fd: (3)-->(1,2)
  │    │         ├── prune: (2,3)
  │    │         ├── interesting orderings: (+3)
  │    │         ├── scan uv
  │    │         │    ├── columns: u:1(int) v:2(int!null) rowid:3(int!null)
- │    │         │    ├── stats: [rows=1000, distinct(1)=700]
  │    │         │    ├── key: (3)
  │    │         │    ├── fd: (3)-->(1,2)
  │    │         │    ├── prune: (1-3)
@@ -1458,7 +1294,6 @@ right-join
  │              └── variable: v [type=int, outer=(2)]
  ├── scan xysd
  │    ├── columns: x:5(int!null) y:6(int) s:7(string) d:8(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (5)
  │    ├── fd: (5)-->(6-8), (7,8)~~>(5,6)
  │    ├── prune: (5-8)
@@ -1472,7 +1307,6 @@ SELECT * FROM xysd FULL JOIN (SELECT u, sum(v) FROM uv GROUP BY u) ON u IS NOT N
 ----
 full-join
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) sum:8(decimal)
- ├── stats: [rows=233333.333]
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (5)~~>(8), (1,5)-->(8)
  ├── prune: (1-4,8)
@@ -1480,7 +1314,6 @@ full-join
  ├── interesting orderings: (+1) (-3,+4,+1)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -1488,17 +1321,14 @@ full-join
  ├── group-by
  │    ├── columns: u:5(int) sum:8(decimal)
  │    ├── grouping columns: u:5(int)
- │    ├── stats: [rows=700, distinct(5)=700]
  │    ├── key: (5)
  │    ├── fd: (5)-->(8)
  │    ├── prune: (8)
  │    ├── project
  │    │    ├── columns: u:5(int) v:6(int!null)
- │    │    ├── stats: [rows=1000, distinct(5)=700]
  │    │    ├── prune: (5,6)
  │    │    └── scan uv
  │    │         ├── columns: u:5(int) v:6(int!null) rowid:7(int!null)
- │    │         ├── stats: [rows=1000, distinct(5)=700]
  │    │         ├── key: (7)
  │    │         ├── fd: (7)-->(5,6)
  │    │         ├── prune: (5-7)
@@ -1517,7 +1347,6 @@ SELECT * FROM (SELECT u, sum(v) FROM uv GROUP BY u) FULL JOIN xysd ON u IS NOT N
 ----
 full-join
  ├── columns: u:1(int) sum:4(decimal) x:5(int) y:6(int) s:7(string) d:8(decimal)
- ├── stats: [rows=233333.333]
  ├── key: (1,5)
  ├── fd: (5)-->(6-8), (7,8)~~>(5,6), (1)~~>(4), (1,5)-->(4)
  ├── prune: (4-8)
@@ -1526,17 +1355,14 @@ full-join
  ├── group-by
  │    ├── columns: u:1(int) sum:4(decimal)
  │    ├── grouping columns: u:1(int)
- │    ├── stats: [rows=700, distinct(1)=700]
  │    ├── key: (1)
  │    ├── fd: (1)-->(4)
  │    ├── prune: (4)
  │    ├── project
  │    │    ├── columns: u:1(int) v:2(int!null)
- │    │    ├── stats: [rows=1000, distinct(1)=700]
  │    │    ├── prune: (1,2)
  │    │    └── scan uv
  │    │         ├── columns: u:1(int) v:2(int!null) rowid:3(int!null)
- │    │         ├── stats: [rows=1000, distinct(1)=700]
  │    │         ├── key: (3)
  │    │         ├── fd: (3)-->(1,2)
  │    │         ├── prune: (1-3)
@@ -1546,7 +1372,6 @@ full-join
  │              └── variable: v [type=int, outer=(2)]
  ├── scan xysd
  │    ├── columns: x:5(int!null) y:6(int) s:7(string) d:8(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (5)
  │    ├── fd: (5)-->(6-8), (7,8)~~>(5,6)
  │    ├── prune: (5-8)

--- a/pkg/sql/opt/memo/testdata/logprops/limit
+++ b/pkg/sql/opt/memo/testdata/logprops/limit
@@ -29,14 +29,12 @@ SELECT * FROM xyzs LIMIT 1
 limit
  ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=1]
  ├── key: ()
  ├── fd: ()-->(1-4)
  ├── prune: (1-4)
  ├── interesting orderings: (+1) (-4,+3,+1)
  ├── scan xyzs
  │    ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -49,22 +47,18 @@ SELECT count(*) FROM xyzs LIMIT 10
 limit
  ├── columns: count:5(int)
  ├── cardinality: [1 - 1]
- ├── stats: [rows=1]
  ├── key: ()
  ├── fd: ()-->(5)
  ├── prune: (5)
  ├── scalar-group-by
  │    ├── columns: count:5(int)
  │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1]
  │    ├── key: ()
  │    ├── fd: ()-->(5)
  │    ├── prune: (5)
  │    ├── project
- │    │    ├── stats: [rows=1000]
  │    │    └── scan xyzs
  │    │         ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- │    │         ├── stats: [rows=1000]
  │    │         ├── key: (1)
  │    │         ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    │         ├── prune: (1-4)
@@ -78,14 +72,12 @@ SELECT * FROM xyzs LIMIT (SELECT 1)
 ----
 limit
  ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- ├── stats: [rows=1000]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-4)
  ├── interesting orderings: (+1) (-4,+3,+1)
  ├── scan xyzs
  │    ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -94,19 +86,16 @@ limit
       └── max1-row
            ├── columns: "?column?":5(int!null)
            ├── cardinality: [1 - 1]
-           ├── stats: [rows=1]
            ├── key: ()
            ├── fd: ()-->(5)
            └── project
                 ├── columns: "?column?":5(int!null)
                 ├── cardinality: [1 - 1]
-                ├── stats: [rows=1]
                 ├── key: ()
                 ├── fd: ()-->(5)
                 ├── prune: (5)
                 ├── values
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1]
                 │    ├── key: ()
                 │    └── tuple [type=tuple]
                 └── projections
@@ -118,14 +107,12 @@ SELECT * FROM xyzs LIMIT 0
 limit
  ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
  ├── cardinality: [0 - 0]
- ├── stats: [rows=0]
  ├── key: ()
  ├── fd: ()-->(1-4)
  ├── prune: (1-4)
  ├── interesting orderings: (+1) (-4,+3,+1)
  ├── scan xyzs
  │    ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -138,11 +125,9 @@ SELECT (SELECT x FROM kuv LIMIT y) FROM xyzs
 ----
 project
  ├── columns: x:9(int)
- ├── stats: [rows=1000]
  ├── prune: (9)
  ├── scan xyzs
  │    ├── columns: xyzs.x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -153,24 +138,20 @@ project
                 ├── columns: x:8(int)
                 ├── outer: (1,2)
                 ├── cardinality: [0 - 1]
-                ├── stats: [rows=1]
                 ├── key: ()
                 ├── fd: ()-->(8)
                 └── limit
                      ├── columns: x:8(int)
                      ├── outer: (1,2)
-                     ├── stats: [rows=1000]
                      ├── fd: ()-->(8)
                      ├── prune: (8)
                      ├── project
                      │    ├── columns: x:8(int)
                      │    ├── outer: (1)
-                     │    ├── stats: [rows=1000]
                      │    ├── fd: ()-->(8)
                      │    ├── prune: (8)
                      │    ├── scan kuv
                      │    │    ├── columns: k:5(int!null) u:6(float) v:7(string)
-                     │    │    ├── stats: [rows=1000]
                      │    │    ├── key: (5)
                      │    │    ├── fd: (5)-->(6,7)
                      │    │    ├── prune: (5-7)
@@ -187,7 +168,6 @@ scan xyzs@secondary
  ├── columns: s:4(string!null) x:1(int!null)
  ├── constraint: /-4/3: [/'foo' - /'foo']
  ├── limit: 4294967296
- ├── stats: [rows=1.42857143]
  ├── key: (1)
  ├── fd: ()-->(4)
  ├── prune: (1)

--- a/pkg/sql/opt/memo/testdata/logprops/max1row
+++ b/pkg/sql/opt/memo/testdata/logprops/max1row
@@ -28,14 +28,12 @@ SELECT * FROM xyzs WHERE (SELECT v FROM kuv) = 'foo'
 ----
 select
  ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-4)
  ├── interesting orderings: (+1) (-4,+3,+1)
  ├── scan xyzs
  │    ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -46,16 +44,13 @@ select
            │    └── max1-row
            │         ├── columns: v:7(string)
            │         ├── cardinality: [0 - 1]
-           │         ├── stats: [rows=1]
            │         ├── key: ()
            │         ├── fd: ()-->(7)
            │         └── project
            │              ├── columns: v:7(string)
-           │              ├── stats: [rows=1000]
            │              ├── prune: (7)
            │              └── scan kuv
            │                   ├── columns: k:5(int!null) u:6(float) v:7(string)
-           │                   ├── stats: [rows=1000]
            │                   ├── key: (5)
            │                   ├── fd: (5)-->(6,7)
            │                   ├── prune: (5-7)

--- a/pkg/sql/opt/memo/testdata/logprops/offset
+++ b/pkg/sql/opt/memo/testdata/logprops/offset
@@ -28,14 +28,12 @@ SELECT * FROM xyzs OFFSET 1
 ----
 offset
  ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- ├── stats: [rows=999]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-4)
  ├── interesting orderings: (+1) (-4,+3,+1)
  ├── scan xyzs
  │    ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -47,14 +45,12 @@ SELECT * FROM xyzs OFFSET (SELECT 1)
 ----
 offset
  ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- ├── stats: [rows=1000]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-4)
  ├── interesting orderings: (+1) (-4,+3,+1)
  ├── scan xyzs
  │    ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -63,19 +59,16 @@ offset
       └── max1-row
            ├── columns: "?column?":5(int!null)
            ├── cardinality: [1 - 1]
-           ├── stats: [rows=1]
            ├── key: ()
            ├── fd: ()-->(5)
            └── project
                 ├── columns: "?column?":5(int!null)
                 ├── cardinality: [1 - 1]
-                ├── stats: [rows=1]
                 ├── key: ()
                 ├── fd: ()-->(5)
                 ├── prune: (5)
                 ├── values
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1]
                 │    ├── key: ()
                 │    └── tuple [type=tuple]
                 └── projections
@@ -86,14 +79,12 @@ SELECT * FROM xyzs OFFSET 0
 ----
 offset
  ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- ├── stats: [rows=1000]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-4)
  ├── interesting orderings: (+1) (-4,+3,+1)
  ├── scan xyzs
  │    ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -106,11 +97,9 @@ SELECT (SELECT x FROM kuv OFFSET y) FROM xyzs
 ----
 project
  ├── columns: x:9(int)
- ├── stats: [rows=1000]
  ├── prune: (9)
  ├── scan xyzs
  │    ├── columns: xyzs.x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -121,24 +110,20 @@ project
                 ├── columns: x:8(int)
                 ├── outer: (1,2)
                 ├── cardinality: [0 - 1]
-                ├── stats: [rows=1]
                 ├── key: ()
                 ├── fd: ()-->(8)
                 └── offset
                      ├── columns: x:8(int)
                      ├── outer: (1,2)
-                     ├── stats: [rows=1000]
                      ├── fd: ()-->(8)
                      ├── prune: (8)
                      ├── project
                      │    ├── columns: x:8(int)
                      │    ├── outer: (1)
-                     │    ├── stats: [rows=1000]
                      │    ├── fd: ()-->(8)
                      │    ├── prune: (8)
                      │    ├── scan kuv
                      │    │    ├── columns: k:5(int!null) u:6(float) v:7(string)
-                     │    │    ├── stats: [rows=1000]
                      │    │    ├── key: (5)
                      │    │    ├── fd: (5)-->(6,7)
                      │    │    ├── prune: (5-7)
@@ -156,29 +141,24 @@ OFFSET 2
 offset
  ├── columns: x:6(int)
  ├── cardinality: [1 - 11]
- ├── stats: [rows=11]
  ├── union-all
  │    ├── columns: x:6(int)
  │    ├── left columns: xyzs.x:1(int)
  │    ├── right columns: column1:5(int)
  │    ├── cardinality: [3 - 13]
- │    ├── stats: [rows=13]
  │    ├── limit
  │    │    ├── columns: xyzs.x:1(int!null)
  │    │    ├── cardinality: [0 - 10]
- │    │    ├── stats: [rows=10]
  │    │    ├── key: (1)
  │    │    ├── prune: (1)
  │    │    ├── interesting orderings: (+1)
  │    │    ├── project
  │    │    │    ├── columns: xyzs.x:1(int!null)
- │    │    │    ├── stats: [rows=1000]
  │    │    │    ├── key: (1)
  │    │    │    ├── prune: (1)
  │    │    │    ├── interesting orderings: (+1)
  │    │    │    └── scan xyzs
  │    │    │         ├── columns: xyzs.x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- │    │    │         ├── stats: [rows=1000]
  │    │    │         ├── key: (1)
  │    │    │         ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    │    │         ├── prune: (1-4)
@@ -187,7 +167,6 @@ offset
  │    └── values
  │         ├── columns: column1:5(int)
  │         ├── cardinality: [3 - 3]
- │         ├── stats: [rows=3]
  │         ├── prune: (5)
  │         ├── tuple [type=tuple{int}]
  │         │    └── const: 1 [type=int]
@@ -204,7 +183,6 @@ SELECT s, x FROM (SELECT * FROM xyzs LIMIT 100) WHERE s='foo' OFFSET 4294967296
 offset
  ├── columns: s:4(string!null) x:1(int!null)
  ├── cardinality: [0 - 0]
- ├── stats: [rows=0]
  ├── key: (1)
  ├── fd: ()-->(4)
  ├── prune: (1)
@@ -212,7 +190,6 @@ offset
  ├── select
  │    ├── columns: x:1(int!null) s:4(string!null)
  │    ├── cardinality: [0 - 100]
- │    ├── stats: [rows=1.0223419, distinct(4)=1]
  │    ├── key: (1)
  │    ├── fd: ()-->(4)
  │    ├── prune: (1)
@@ -220,7 +197,6 @@ offset
  │    ├── scan xyzs@secondary
  │    │    ├── columns: x:1(int!null) s:4(string)
  │    │    ├── limit: 100
- │    │    ├── stats: [rows=100, distinct(4)=97.8146353]
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(4)
  │    │    ├── prune: (1,4)

--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -28,14 +28,12 @@ SELECT y, x+1 AS a, 1 AS b, x FROM xysd
 ----
 project
  ├── columns: y:2(int) a:5(int) b:6(int!null) x:1(int!null)
- ├── stats: [rows=1000]
  ├── key: (1)
  ├── fd: ()-->(6), (1)-->(2,5)
  ├── prune: (1,2,5,6)
  ├── interesting orderings: (+1)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -51,12 +49,10 @@ SELECT s FROM xysd
 ----
 project
  ├── columns: s:3(string)
- ├── stats: [rows=1000]
  ├── prune: (3)
  ├── interesting orderings: (-3)
  └── scan xysd
       ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
-      ├── stats: [rows=1000]
       ├── key: (1)
       ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
       ├── prune: (1-4)
@@ -68,14 +64,12 @@ SELECT * FROM xysd WHERE (SELECT (SELECT y) FROM kuv WHERE k=x) > 5
 ----
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (3,4)
  ├── interesting orderings: (+1) (-3,+4,+1)
  ├── scan xysd
  │    ├── columns: x:1(int!null) xysd.y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -87,14 +81,12 @@ select
            │         ├── columns: y:9(int)
            │         ├── outer: (1,2)
            │         ├── cardinality: [0 - 1]
-           │         ├── stats: [rows=1]
            │         ├── key: ()
            │         ├── fd: ()-->(9)
            │         └── project
            │              ├── columns: y:9(int)
            │              ├── outer: (1,2)
            │              ├── cardinality: [0 - 1]
-           │              ├── stats: [rows=1]
            │              ├── key: ()
            │              ├── fd: ()-->(9)
            │              ├── prune: (9)
@@ -102,14 +94,12 @@ select
            │              │    ├── columns: k:5(int!null) u:6(float) v:7(string)
            │              │    ├── outer: (1)
            │              │    ├── cardinality: [0 - 1]
-           │              │    ├── stats: [rows=1, distinct(1)=1, distinct(5)=1]
            │              │    ├── key: ()
            │              │    ├── fd: ()-->(5-7)
            │              │    ├── prune: (6,7)
            │              │    ├── interesting orderings: (+5)
            │              │    ├── scan kuv
            │              │    │    ├── columns: k:5(int!null) u:6(float) v:7(string)
-           │              │    │    ├── stats: [rows=1000, distinct(5)=1000]
            │              │    │    ├── key: (5)
            │              │    │    ├── fd: (5)-->(6,7)
            │              │    │    ├── prune: (5-7)
@@ -124,20 +114,17 @@ select
            │                             ├── columns: y:8(int)
            │                             ├── outer: (2)
            │                             ├── cardinality: [1 - 1]
-           │                             ├── stats: [rows=1]
            │                             ├── key: ()
            │                             ├── fd: ()-->(8)
            │                             └── project
            │                                  ├── columns: y:8(int)
            │                                  ├── outer: (2)
            │                                  ├── cardinality: [1 - 1]
-           │                                  ├── stats: [rows=1]
            │                                  ├── key: ()
            │                                  ├── fd: ()-->(8)
            │                                  ├── prune: (8)
            │                                  ├── values
            │                                  │    ├── cardinality: [1 - 1]
-           │                                  │    ├── stats: [rows=1]
            │                                  │    ├── key: ()
            │                                  │    └── tuple [type=tuple]
            │                                  └── projections [outer=(2)]
@@ -151,7 +138,6 @@ SELECT x, y FROM (SELECT * FROM xysd LIMIT 10)
 project
  ├── columns: x:1(int!null) y:2(int)
  ├── cardinality: [0 - 10]
- ├── stats: [rows=10]
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── prune: (1,2)
@@ -159,14 +145,12 @@ project
  └── limit
       ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
       ├── cardinality: [0 - 10]
-      ├── stats: [rows=10]
       ├── key: (1)
       ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
       ├── prune: (1-4)
       ├── interesting orderings: (+1) (-3,+4,+1)
       ├── scan xysd
       │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
-      │    ├── stats: [rows=1000]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
       │    ├── prune: (1-4)
@@ -179,12 +163,10 @@ SELECT 1 AS a, 'foo' AS b, NULL AS c, 1::decimal + NULL AS d, NULL::STRING AS e 
 ----
 project
  ├── columns: a:5(int!null) b:6(string!null) c:7(unknown) d:7(unknown) e:8(string)
- ├── stats: [rows=1000]
  ├── fd: ()-->(5-8)
  ├── prune: (5-8)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -203,11 +185,9 @@ SELECT 1 FROM (SELECT x FROM xysd)
 ----
 project
  ├── columns: "?column?":5(int!null)
- ├── stats: [rows=1000]
  ├── fd: ()-->(5)
  ├── prune: (5)
  ├── scan xysd@secondary
- │    └── stats: [rows=1000]
  └── projections
       └── const: 1 [type=int]
 
@@ -217,14 +197,12 @@ SELECT k, (SELECT y FROM xysd WHERE x=k) FROM kuv
 ----
 project
  ├── columns: k:1(int!null) y:8(int)
- ├── stats: [rows=1000]
  ├── key: (1)
  ├── fd: (1)-->(8)
  ├── prune: (1,8)
  ├── interesting orderings: (+1)
  ├── scan kuv
  │    ├── columns: k:1(int!null) u:2(float) v:3(string)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3)
  │    ├── prune: (1-3)
@@ -235,14 +213,12 @@ project
                 ├── columns: xysd.y:5(int)
                 ├── outer: (1)
                 ├── cardinality: [0 - 1]
-                ├── stats: [rows=1]
                 ├── key: ()
                 ├── fd: ()-->(5)
                 └── project
                      ├── columns: xysd.y:5(int)
                      ├── outer: (1)
                      ├── cardinality: [0 - 1]
-                     ├── stats: [rows=1]
                      ├── key: ()
                      ├── fd: ()-->(5)
                      ├── prune: (5)
@@ -250,14 +226,12 @@ project
                           ├── columns: x:4(int!null) xysd.y:5(int) s:6(string) d:7(decimal!null)
                           ├── outer: (1)
                           ├── cardinality: [0 - 1]
-                          ├── stats: [rows=1, distinct(1)=1, distinct(4)=1]
                           ├── key: ()
                           ├── fd: ()-->(4-7)
                           ├── prune: (5-7)
                           ├── interesting orderings: (+4) (-6,+7,+4)
                           ├── scan xysd
                           │    ├── columns: x:4(int!null) xysd.y:5(int) s:6(string) d:7(decimal!null)
-                          │    ├── stats: [rows=1000, distinct(4)=1000]
                           │    ├── key: (4)
                           │    ├── fd: (4)-->(5-7), (6,7)~~>(4,5)
                           │    ├── prune: (4-7)
@@ -273,14 +247,12 @@ SELECT k, EXISTS(SELECT EXISTS(SELECT y FROM xysd WHERE x=k) FROM xysd) FROM kuv
 ----
 project
  ├── columns: k:1(int!null) exists:13(bool)
- ├── stats: [rows=1000]
  ├── key: (1)
  ├── fd: (1)-->(13)
  ├── prune: (1,13)
  ├── interesting orderings: (+1)
  ├── scan kuv
  │    ├── columns: k:1(int!null) u:2(float) v:3(string)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3)
  │    ├── prune: (1-3)
@@ -290,12 +262,10 @@ project
            └── project
                 ├── columns: exists:12(bool)
                 ├── outer: (1)
-                ├── stats: [rows=1000]
                 ├── fd: ()-->(12)
                 ├── prune: (12)
                 ├── scan xysd
                 │    ├── columns: xysd.x:4(int!null) xysd.y:5(int) xysd.s:6(string) xysd.d:7(decimal!null)
-                │    ├── stats: [rows=1000]
                 │    ├── key: (4)
                 │    ├── fd: (4)-->(5-7), (6,7)~~>(4,5)
                 │    ├── prune: (4-7)
@@ -306,7 +276,6 @@ project
                                ├── columns: xysd.y:9(int)
                                ├── outer: (1)
                                ├── cardinality: [0 - 1]
-                               ├── stats: [rows=1]
                                ├── key: ()
                                ├── fd: ()-->(9)
                                ├── prune: (9)
@@ -314,14 +283,12 @@ project
                                     ├── columns: xysd.x:8(int!null) xysd.y:9(int) xysd.s:10(string) xysd.d:11(decimal!null)
                                     ├── outer: (1)
                                     ├── cardinality: [0 - 1]
-                                    ├── stats: [rows=1, distinct(1)=1, distinct(8)=1]
                                     ├── key: ()
                                     ├── fd: ()-->(8-11)
                                     ├── prune: (9-11)
                                     ├── interesting orderings: (+8) (-10,+11,+8)
                                     ├── scan xysd
                                     │    ├── columns: xysd.x:8(int!null) xysd.y:9(int) xysd.s:10(string) xysd.d:11(decimal!null)
-                                    │    ├── stats: [rows=1000, distinct(8)=1000]
                                     │    ├── key: (8)
                                     │    ├── fd: (8)-->(9-11), (10,11)~~>(8,9)
                                     │    ├── prune: (8-11)
@@ -337,12 +304,10 @@ SELECT y, y::TEXT FROM xysd
 ----
 project
  ├── columns: y:2(int) y:5(string)
- ├── stats: [rows=1000]
  ├── fd: (2)-->(5)
  ├── prune: (2,5)
  ├── scan xysd
  │    ├── columns: x:1(int!null) xysd.y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -358,11 +323,9 @@ SELECT d, d::TEXT FROM xysd
 ----
 project
  ├── columns: d:4(decimal!null) d:5(string)
- ├── stats: [rows=1000]
  ├── prune: (4,5)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) xysd.d:4(decimal!null)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)

--- a/pkg/sql/opt/memo/testdata/logprops/rownumber
+++ b/pkg/sql/opt/memo/testdata/logprops/rownumber
@@ -12,13 +12,11 @@ SELECT * FROM xy WITH ORDINALITY
 ----
 row-number
  ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)
- ├── stats: [rows=1000]
  ├── key: (1)
  ├── fd: (1)-->(2,3), (3)-->(1,2)
  ├── prune: (1,2)
  └── scan xy
       ├── columns: x:1(int!null) y:2(int)
-      ├── stats: [rows=1000]
       ├── key: (1)
       ├── fd: (1)-->(2)
       ├── prune: (1,2)

--- a/pkg/sql/opt/memo/testdata/logprops/scalar
+++ b/pkg/sql/opt/memo/testdata/logprops/scalar
@@ -22,14 +22,12 @@ SELECT * FROM xy WHERE x < 5
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── prune: (2)
  ├── interesting orderings: (+1)
  ├── scan xy
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    ├── prune: (1,2)
@@ -44,25 +42,21 @@ SELECT xy.x + 1 = length('foo') + xy.y AS a, uv.rowid * xy.x AS b FROM xy, uv
 ----
 project
  ├── columns: a:6(bool) b:7(int)
- ├── stats: [rows=1000000]
  ├── prune: (6,7)
  ├── inner-join
  │    ├── columns: x:1(int!null) y:2(int) u:3(int) v:4(int!null) rowid:5(int!null)
- │    ├── stats: [rows=1000000]
  │    ├── key: (1,5)
  │    ├── fd: (1)-->(2), (5)-->(3,4)
  │    ├── prune: (1-5)
  │    ├── interesting orderings: (+1) (+5)
  │    ├── scan xy
  │    │    ├── columns: x:1(int!null) y:2(int)
- │    │    ├── stats: [rows=1000]
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2)
  │    │    ├── prune: (1,2)
  │    │    └── interesting orderings: (+1)
  │    ├── scan uv
  │    │    ├── columns: u:3(int) v:4(int!null) rowid:5(int!null)
- │    │    ├── stats: [rows=1000]
  │    │    ├── key: (5)
  │    │    ├── fd: (5)-->(3,4)
  │    │    ├── prune: (3-5)
@@ -86,14 +80,12 @@ SELECT * FROM xy WHERE EXISTS(SELECT * FROM uv WHERE u=x)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── prune: (2)
  ├── interesting orderings: (+1)
  ├── scan xy
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    ├── prune: (1,2)
@@ -103,20 +95,17 @@ select
            └── project
                 ├── columns: u:3(int!null) v:4(int!null)
                 ├── outer: (1)
-                ├── stats: [rows=1.42857143]
                 ├── fd: ()-->(3)
                 ├── prune: (3,4)
                 └── select
                      ├── columns: u:3(int!null) v:4(int!null) rowid:5(int!null)
                      ├── outer: (1)
-                     ├── stats: [rows=1.42857143, distinct(1)=1, distinct(3)=1]
                      ├── key: (5)
                      ├── fd: ()-->(3), (5)-->(4)
                      ├── prune: (4,5)
                      ├── interesting orderings: (+5)
                      ├── scan uv
                      │    ├── columns: u:3(int) v:4(int!null) rowid:5(int!null)
-                     │    ├── stats: [rows=1000, distinct(3)=700]
                      │    ├── key: (5)
                      │    ├── fd: (5)-->(3,4)
                      │    ├── prune: (3-5)
@@ -131,13 +120,11 @@ SELECT * FROM xy WHERE y IN (SELECT v FROM uv WHERE u=x)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── interesting orderings: (+1)
  ├── scan xy
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    ├── prune: (1,2)
@@ -147,19 +134,16 @@ select
            ├── project
            │    ├── columns: v:4(int!null)
            │    ├── outer: (1)
-           │    ├── stats: [rows=1.42857143]
            │    ├── prune: (4)
            │    └── select
            │         ├── columns: u:3(int!null) v:4(int!null) rowid:5(int!null)
            │         ├── outer: (1)
-           │         ├── stats: [rows=1.42857143, distinct(1)=1, distinct(3)=1]
            │         ├── key: (5)
            │         ├── fd: ()-->(3), (5)-->(4)
            │         ├── prune: (4,5)
            │         ├── interesting orderings: (+5)
            │         ├── scan uv
            │         │    ├── columns: u:3(int) v:4(int!null) rowid:5(int!null)
-           │         │    ├── stats: [rows=1000, distinct(3)=700]
            │         │    ├── key: (5)
            │         │    ├── fd: (5)-->(3,4)
            │         │    ├── prune: (3-5)
@@ -182,35 +166,30 @@ group-by
  ├── columns: sum:7(decimal) div:3(decimal)
  ├── grouping columns: div:3(decimal)
  ├── side-effects
- ├── stats: [rows=283.588181, distinct(3)=283.588181]
  ├── key: (3)
  ├── fd: (3)-->(7)
  ├── prune: (7)
  ├── project
  │    ├── columns: x:1(int!null) div:3(decimal)
  │    ├── side-effects
- │    ├── stats: [rows=333.333333, distinct(3)=283.588181]
  │    ├── fd: (1)-->(3)
  │    ├── prune: (1,3)
  │    ├── interesting orderings: (+1)
  │    └── inner-join
  │         ├── columns: x:1(int!null) y:2(int) div:3(decimal) u:4(int!null) v:5(int!null)
  │         ├── side-effects
- │         ├── stats: [rows=333.333333, distinct(1)=307.771544, distinct(3)=283.588181, distinct(4)=307.771544]
  │         ├── fd: (1)-->(2,3), (1)==(4), (4)==(1)
  │         ├── prune: (2,3,5)
  │         ├── interesting orderings: (+1)
  │         ├── project
  │         │    ├── columns: div:3(decimal) x:1(int!null) y:2(int)
  │         │    ├── side-effects
- │         │    ├── stats: [rows=1000, distinct(1)=1000, distinct(3)=1000]
  │         │    ├── key: (1)
  │         │    ├── fd: (1)-->(2,3)
  │         │    ├── prune: (1-3)
  │         │    ├── interesting orderings: (+1)
  │         │    ├── scan xy
  │         │    │    ├── columns: x:1(int!null) y:2(int)
- │         │    │    ├── stats: [rows=1000, distinct(1)=1000, distinct(1,2)=1000]
  │         │    │    ├── key: (1)
  │         │    │    ├── fd: (1)-->(2)
  │         │    │    ├── prune: (1,2)
@@ -222,19 +201,16 @@ group-by
  │         ├── project
  │         │    ├── columns: u:4(int) v:5(int!null)
  │         │    ├── side-effects
- │         │    ├── stats: [rows=333.333333, distinct(4)=307.771544]
  │         │    ├── prune: (4,5)
  │         │    └── select
  │         │         ├── columns: u:4(int) v:5(int!null) rowid:6(int!null)
  │         │         ├── side-effects
- │         │         ├── stats: [rows=333.333333, distinct(4)=307.771544]
  │         │         ├── key: (6)
  │         │         ├── fd: (6)-->(4,5)
  │         │         ├── prune: (4-6)
  │         │         ├── interesting orderings: (+6)
  │         │         ├── scan uv
  │         │         │    ├── columns: u:4(int) v:5(int!null) rowid:6(int!null)
- │         │         │    ├── stats: [rows=1000, distinct(4)=700]
  │         │         │    ├── key: (6)
  │         │         │    ├── fd: (6)-->(4,5)
  │         │         │    ├── prune: (4-6)

--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -28,7 +28,6 @@ SELECT * FROM a
 ----
 scan a
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- ├── stats: [rows=1000]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-4)
@@ -39,11 +38,9 @@ SELECT * FROM b
 ----
 project
  ├── columns: x:1(int) z:2(int!null)
- ├── stats: [rows=1000]
  ├── prune: (1,2)
  └── scan b
       ├── columns: x:1(int) z:2(int!null) rowid:3(int!null)
-      ├── stats: [rows=1000]
       ├── key: (3)
       ├── fd: (3)-->(1,2)
       ├── prune: (1-3)
@@ -55,7 +52,6 @@ SELECT s, x FROM a
 ----
 scan a@secondary
  ├── columns: s:3(string) x:1(int!null)
- ├── stats: [rows=1000]
  ├── key: (1)
  ├── fd: (1)-->(3)
  ├── prune: (1,3)
@@ -69,7 +65,6 @@ scan a
  ├── columns: s:3(string) x:1(int!null)
  ├── constraint: /1: [/1 - /1]
  ├── cardinality: [0 - 1]
- ├── stats: [rows=1, distinct(1)=1]
  ├── key: ()
  ├── fd: ()-->(1,3)
  ├── prune: (3)
@@ -83,7 +78,6 @@ scan a
  ├── columns: s:3(string) x:1(int!null)
  ├── constraint: /1: [/2 - ]
  ├── limit: 2
- ├── stats: [rows=2]
  ├── key: (1)
  ├── fd: (1)-->(3)
  ├── prune: (3)
@@ -97,7 +91,6 @@ scan a
  ├── columns: s:3(string) x:1(int!null)
  ├── constraint: /1: [/2 - ]
  ├── limit: 1
- ├── stats: [rows=1]
  ├── key: ()
  ├── fd: ()-->(1,3)
  ├── prune: (3)
@@ -109,7 +102,6 @@ SELECT d FROM a
 ----
 scan a@secondary
  ├── columns: d:4(decimal!null)
- ├── stats: [rows=1000]
  └── prune: (4)
 
 exec-ddl
@@ -156,7 +148,6 @@ SELECT * FROM t WHERE a > 1 AND a < 2
 values
  ├── columns: a:1(int) b:2(string) c:3(int) d:4(string)
  ├── cardinality: [0 - 0]
- ├── stats: [rows=0]
  ├── key: ()
  ├── fd: ()-->(1-4)
  └── prune: (1-4)

--- a/pkg/sql/opt/memo/testdata/logprops/select
+++ b/pkg/sql/opt/memo/testdata/logprops/select
@@ -23,14 +23,12 @@ SELECT * FROM xy WHERE x=1
 select
  ├── columns: x:1(int!null) y:2(int)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=1, distinct(1)=1]
  ├── key: ()
  ├── fd: ()-->(1,2)
  ├── prune: (2)
  ├── interesting orderings: (+1)
  ├── scan xy
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=1000, distinct(1)=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    ├── prune: (1,2)
@@ -45,28 +43,24 @@ SELECT * FROM xy,kuv WHERE xy.x=kuv.k
 ----
 select
  ├── columns: x:1(int!null) y:2(int) k:3(int!null) u:4(float) v:5(string)
- ├── stats: [rows=1000, distinct(1)=1000, distinct(3)=1000]
  ├── key: (3)
  ├── fd: (1)-->(2), (3)-->(4,5), (1)==(3), (3)==(1)
  ├── prune: (2,4,5)
  ├── interesting orderings: (+1) (+3)
  ├── inner-join
  │    ├── columns: x:1(int!null) y:2(int) k:3(int!null) u:4(float) v:5(string)
- │    ├── stats: [rows=1000000, distinct(1)=1000, distinct(3)=1000]
  │    ├── key: (1,3)
  │    ├── fd: (1)-->(2), (3)-->(4,5)
  │    ├── prune: (1-5)
  │    ├── interesting orderings: (+1) (+3)
  │    ├── scan xy
  │    │    ├── columns: x:1(int!null) y:2(int)
- │    │    ├── stats: [rows=1000, distinct(1)=1000]
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2)
  │    │    ├── prune: (1,2)
  │    │    └── interesting orderings: (+1)
  │    ├── scan kuv
  │    │    ├── columns: k:3(int!null) u:4(float) v:5(string)
- │    │    ├── stats: [rows=1000, distinct(3)=1000]
  │    │    ├── key: (3)
  │    │    ├── fd: (3)-->(4,5)
  │    │    ├── prune: (3-5)
@@ -83,13 +77,11 @@ SELECT * FROM xy WHERE EXISTS(SELECT * FROM (SELECT * FROM kuv WHERE k=y) WHERE 
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── interesting orderings: (+1)
  ├── scan xy
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    ├── prune: (1,2)
@@ -100,7 +92,6 @@ select
                 ├── columns: k:3(int!null) u:4(float) v:5(string)
                 ├── outer: (1,2)
                 ├── cardinality: [0 - 1]
-                ├── stats: [rows=1, distinct(1)=1, distinct(3)=1]
                 ├── key: ()
                 ├── fd: ()-->(3-5)
                 ├── prune: (4,5)
@@ -109,14 +100,12 @@ select
                 │    ├── columns: k:3(int!null) u:4(float) v:5(string)
                 │    ├── outer: (2)
                 │    ├── cardinality: [0 - 1]
-                │    ├── stats: [rows=1, distinct(2)=1, distinct(3)=1]
                 │    ├── key: ()
                 │    ├── fd: ()-->(3-5)
                 │    ├── prune: (4,5)
                 │    ├── interesting orderings: (+3)
                 │    ├── scan kuv
                 │    │    ├── columns: k:3(int!null) u:4(float) v:5(string)
-                │    │    ├── stats: [rows=1000, distinct(3)=1000]
                 │    │    ├── key: (3)
                 │    │    ├── fd: (3)-->(4,5)
                 │    │    ├── prune: (3-5)
@@ -137,21 +126,17 @@ SELECT count(*) FROM xy HAVING count(*) = 5
 select
  ├── columns: count:3(int!null)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=1, distinct(3)=1]
  ├── key: ()
  ├── fd: ()-->(3)
  ├── scalar-group-by
  │    ├── columns: column3:3(int)
  │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1, distinct(3)=1]
  │    ├── key: ()
  │    ├── fd: ()-->(3)
  │    ├── prune: (3)
  │    ├── project
- │    │    ├── stats: [rows=1000]
  │    │    └── scan xy
  │    │         ├── columns: x:1(int!null) y:2(int)
- │    │         ├── stats: [rows=1000]
  │    │         ├── key: (1)
  │    │         ├── fd: (1)-->(2)
  │    │         ├── prune: (1,2)
@@ -168,13 +153,11 @@ SELECT * FROM xy WITH ORDINALITY
 ----
 row-number
  ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)
- ├── stats: [rows=1000]
  ├── key: (1)
  ├── fd: (1)-->(2,3), (3)-->(1,2)
  ├── prune: (1,2)
  └── scan xy
       ├── columns: x:1(int!null) y:2(int)
-      ├── stats: [rows=1000]
       ├── key: (1)
       ├── fd: (1)-->(2)
       ├── prune: (1,2)
@@ -198,18 +181,15 @@ SELECT * FROM abcd WHERE true
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int)
- ├── stats: [rows=333.333333]
  ├── prune: (1-4)
  └── select
       ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int) rowid:5(int!null)
-      ├── stats: [rows=333.333333]
       ├── key: (5)
       ├── fd: (5)-->(1-4)
       ├── prune: (1-5)
       ├── interesting orderings: (+5)
       ├── scan abcd
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int) rowid:5(int!null)
-      │    ├── stats: [rows=1000]
       │    ├── key: (5)
       │    ├── fd: (5)-->(1-4)
       │    ├── prune: (1-5)
@@ -222,18 +202,15 @@ SELECT * FROM abcd WHERE c IS NOT NULL
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int)
- ├── stats: [rows=333.333333]
  ├── prune: (1-4)
  └── select
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) rowid:5(int!null)
-      ├── stats: [rows=333.333333]
       ├── key: (5)
       ├── fd: (5)-->(1-4)
       ├── prune: (1,2,4,5)
       ├── interesting orderings: (+5)
       ├── scan abcd
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int) rowid:5(int!null)
-      │    ├── stats: [rows=1000]
       │    ├── key: (5)
       │    ├── fd: (5)-->(1-4)
       │    ├── prune: (1-5)
@@ -248,19 +225,16 @@ SELECT * FROM abcd WHERE c = d
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null)
- ├── stats: [rows=1.42857143]
  ├── fd: (3)==(4), (4)==(3)
  ├── prune: (1-4)
  └── select
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null) rowid:5(int!null)
-      ├── stats: [rows=1.42857143, distinct(3)=1.42857143, distinct(4)=1.42857143]
       ├── key: (5)
       ├── fd: (5)-->(1-4), (3)==(4), (4)==(3)
       ├── prune: (1,2,5)
       ├── interesting orderings: (+5)
       ├── scan abcd
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int) rowid:5(int!null)
-      │    ├── stats: [rows=1000, distinct(3)=700, distinct(4)=700]
       │    ├── key: (5)
       │    ├── fd: (5)-->(1-4)
       │    ├── prune: (1-5)
@@ -275,18 +249,15 @@ SELECT * FROM abcd WHERE a > c
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int)
- ├── stats: [rows=111.111111]
  ├── prune: (1-4)
  └── select
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) rowid:5(int!null)
-      ├── stats: [rows=111.111111]
       ├── key: (5)
       ├── fd: (5)-->(1-4)
       ├── prune: (2,4,5)
       ├── interesting orderings: (+5)
       ├── scan abcd
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int) rowid:5(int!null)
-      │    ├── stats: [rows=1000]
       │    ├── key: (5)
       │    ├── fd: (5)-->(1-4)
       │    ├── prune: (1-5)
@@ -301,24 +272,20 @@ SELECT * FROM (SELECT * FROM abcd WHERE a = c) WHERE b < d
 ----
 select
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null)
- ├── stats: [rows=0.158730159]
  ├── fd: (1)==(3), (3)==(1)
  ├── prune: (1,3)
  ├── project
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int)
- │    ├── stats: [rows=1.42857143]
  │    ├── fd: (1)==(3), (3)==(1)
  │    ├── prune: (1-4)
  │    └── select
  │         ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) rowid:5(int!null)
- │         ├── stats: [rows=1.42857143, distinct(1)=1.42857143, distinct(3)=1.42857143]
  │         ├── key: (5)
  │         ├── fd: (5)-->(1-4), (1)==(3), (3)==(1)
  │         ├── prune: (2,4,5)
  │         ├── interesting orderings: (+5)
  │         ├── scan abcd
  │         │    ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int) rowid:5(int!null)
- │         │    ├── stats: [rows=1000, distinct(1)=700, distinct(3)=700]
  │         │    ├── key: (5)
  │         │    ├── fd: (5)-->(1-4)
  │         │    ├── prune: (1-5)
@@ -338,18 +305,15 @@ SELECT * FROM abcd WHERE (SELECT count(*) FROM xy WHERE y = b) > 0
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int)
- ├── stats: [rows=333.333333]
  ├── prune: (1-4)
  └── select
       ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int) rowid:5(int!null)
-      ├── stats: [rows=333.333333]
       ├── key: (5)
       ├── fd: (5)-->(1-4)
       ├── prune: (1,3-5)
       ├── interesting orderings: (+5)
       ├── scan abcd
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int) rowid:5(int!null)
-      │    ├── stats: [rows=1000]
       │    ├── key: (5)
       │    ├── fd: (5)-->(1-4)
       │    ├── prune: (1-5)
@@ -361,31 +325,26 @@ project
                 │         ├── columns: count:8(int)
                 │         ├── outer: (2)
                 │         ├── cardinality: [1 - 1]
-                │         ├── stats: [rows=1]
                 │         ├── key: ()
                 │         ├── fd: ()-->(8)
                 │         └── scalar-group-by
                 │              ├── columns: count:8(int)
                 │              ├── outer: (2)
                 │              ├── cardinality: [1 - 1]
-                │              ├── stats: [rows=1]
                 │              ├── key: ()
                 │              ├── fd: ()-->(8)
                 │              ├── prune: (8)
                 │              ├── project
                 │              │    ├── outer: (2)
-                │              │    ├── stats: [rows=1.42857143]
                 │              │    └── select
                 │              │         ├── columns: x:6(int!null) y:7(int!null)
                 │              │         ├── outer: (2)
-                │              │         ├── stats: [rows=1.42857143, distinct(2)=1, distinct(7)=1]
                 │              │         ├── key: (6)
                 │              │         ├── fd: ()-->(7)
                 │              │         ├── prune: (6)
                 │              │         ├── interesting orderings: (+6)
                 │              │         ├── scan xy
                 │              │         │    ├── columns: x:6(int!null) y:7(int)
-                │              │         │    ├── stats: [rows=1000, distinct(7)=700]
                 │              │         │    ├── key: (6)
                 │              │         │    ├── fd: (6)-->(7)
                 │              │         │    ├── prune: (6,7)

--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -24,22 +24,18 @@ union
  ├── columns: x:6(int) y:7(int)
  ├── left columns: xy.x:1(int) xy.y:2(int)
  ├── right columns: u:3(int) v:4(int)
- ├── stats: [rows=2000, distinct(6,7)=2000]
  ├── key: (6,7)
  ├── scan xy
  │    ├── columns: xy.x:1(int!null) xy.y:2(int)
- │    ├── stats: [rows=1000, distinct(1,2)=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    ├── prune: (1,2)
  │    └── interesting orderings: (+1)
  └── project
       ├── columns: u:3(int) v:4(int!null)
-      ├── stats: [rows=1000, distinct(3,4)=1000]
       ├── prune: (3,4)
       └── scan uv
            ├── columns: u:3(int) v:4(int!null) rowid:5(int!null)
-           ├── stats: [rows=1000, distinct(3,4)=1000]
            ├── key: (5)
            ├── fd: (5)-->(3,4)
            ├── prune: (3-5)
@@ -52,25 +48,21 @@ intersect
  ├── columns: x:1(int!null) y:2(int) x:1(int!null)
  ├── left columns: x:1(int!null) y:2(int) x:1(int!null)
  ├── right columns: v:4(int) u:3(int) rowid:5(int)
- ├── stats: [rows=1.42857143, distinct(1,2)=1.42857143]
  ├── key: (1,2)
  ├── scan xy
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=1000, distinct(1,2)=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    ├── prune: (1,2)
  │    └── interesting orderings: (+1)
  └── select
       ├── columns: u:3(int!null) v:4(int!null) rowid:5(int!null)
-      ├── stats: [rows=1.42857143, distinct(3)=1, distinct(3-5)=1.42857143]
       ├── key: (5)
       ├── fd: ()-->(3), (5)-->(4)
       ├── prune: (4,5)
       ├── interesting orderings: (+5)
       ├── scan uv
       │    ├── columns: u:3(int) v:4(int!null) rowid:5(int!null)
-      │    ├── stats: [rows=1000, distinct(3)=700, distinct(3-5)=1000]
       │    ├── key: (5)
       │    ├── fd: (5)-->(3,4)
       │    ├── prune: (3-5)
@@ -87,30 +79,25 @@ except
  ├── columns: x:1(int!null) x:1(int!null) y:2(int)
  ├── left columns: x:1(int!null) x:1(int!null) y:2(int)
  ├── right columns: u:3(int) v:4(int) v:4(int)
- ├── stats: [rows=1000, distinct(1,2)=1000]
  ├── key: (1,2)
  ├── scan xy
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=1000, distinct(1,2)=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    ├── prune: (1,2)
  │    └── interesting orderings: (+1)
  └── project
       ├── columns: u:3(int!null) v:4(int!null)
-      ├── stats: [rows=1.42857143, distinct(3,4)=1.42857143]
       ├── fd: ()-->(3)
       ├── prune: (3,4)
       └── select
            ├── columns: u:3(int!null) v:4(int!null) rowid:5(int!null)
-           ├── stats: [rows=1.42857143, distinct(3)=1, distinct(3,4)=1.42857143]
            ├── key: (5)
            ├── fd: ()-->(3), (5)-->(4)
            ├── prune: (4,5)
            ├── interesting orderings: (+5)
            ├── scan uv
            │    ├── columns: u:3(int) v:4(int!null) rowid:5(int!null)
-           │    ├── stats: [rows=1000, distinct(3)=700, distinct(3,4)=1000]
            │    ├── key: (5)
            │    ├── fd: (5)-->(3,4)
            │    ├── prune: (3-5)
@@ -126,13 +113,11 @@ SELECT * FROM xy WHERE (SELECT x, u FROM uv UNION SELECT y, v FROM uv) = (1, 2)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── stats: [rows=333.333333]
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── interesting orderings: (+1)
  ├── scan xy
  │    ├── columns: xy.x:1(int!null) xy.y:2(int)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    ├── prune: (1,2)
@@ -144,30 +129,25 @@ select
            │         ├── columns: column13:13(tuple{int, int})
            │         ├── outer: (1,2)
            │         ├── cardinality: [0 - 1]
-           │         ├── stats: [rows=1]
            │         ├── key: ()
            │         ├── fd: ()-->(13)
            │         └── project
            │              ├── columns: column13:13(tuple{int, int})
            │              ├── outer: (1,2)
-           │              ├── stats: [rows=1400]
            │              ├── prune: (13)
            │              ├── union
            │              │    ├── columns: x:11(int) u:12(int)
            │              │    ├── left columns: x:6(int) uv.u:3(int)
            │              │    ├── right columns: y:10(int) uv.v:8(int)
            │              │    ├── outer: (1,2)
-           │              │    ├── stats: [rows=1400, distinct(11,12)=1400]
            │              │    ├── key: (11,12)
            │              │    ├── project
            │              │    │    ├── columns: x:6(int) uv.u:3(int)
            │              │    │    ├── outer: (1)
-           │              │    │    ├── stats: [rows=1000, distinct(3,6)=700]
            │              │    │    ├── fd: ()-->(6)
            │              │    │    ├── prune: (3,6)
            │              │    │    ├── scan uv
            │              │    │    │    ├── columns: uv.u:3(int) uv.v:4(int!null) uv.rowid:5(int!null)
-           │              │    │    │    ├── stats: [rows=1000, distinct(3)=700]
            │              │    │    │    ├── key: (5)
            │              │    │    │    ├── fd: (5)-->(3,4)
            │              │    │    │    ├── prune: (3-5)
@@ -177,12 +157,10 @@ select
            │              │    └── project
            │              │         ├── columns: y:10(int) uv.v:8(int!null)
            │              │         ├── outer: (2)
-           │              │         ├── stats: [rows=1000, distinct(8,10)=700]
            │              │         ├── fd: ()-->(10)
            │              │         ├── prune: (8,10)
            │              │         ├── scan uv
            │              │         │    ├── columns: uv.u:7(int) uv.v:8(int!null) uv.rowid:9(int!null)
-           │              │         │    ├── stats: [rows=1000, distinct(8)=700]
            │              │         │    ├── key: (9)
            │              │         │    ├── fd: (9)-->(7,8)
            │              │         │    ├── prune: (7-9)
@@ -210,18 +188,15 @@ union
  ├── left columns: column1:3(int)
  ├── right columns: column1:4(int)
  ├── cardinality: [1 - 8]
- ├── stats: [rows=8, distinct(5)=8]
  ├── key: (5)
  ├── union-all
  │    ├── columns: column1:3(int)
  │    ├── left columns: column1:1(int)
  │    ├── right columns: column1:2(int)
  │    ├── cardinality: [5 - 5]
- │    ├── stats: [rows=5, distinct(3)=5]
  │    ├── values
  │    │    ├── columns: column1:1(int)
  │    │    ├── cardinality: [3 - 3]
- │    │    ├── stats: [rows=3, distinct(1)=3]
  │    │    ├── prune: (1)
  │    │    ├── tuple [type=tuple{int}]
  │    │    │    └── const: 1 [type=int]
@@ -232,7 +207,6 @@ union
  │    └── values
  │         ├── columns: column1:2(int)
  │         ├── cardinality: [2 - 2]
- │         ├── stats: [rows=2, distinct(2)=2]
  │         ├── prune: (2)
  │         ├── tuple [type=tuple{int}]
  │         │    └── const: 4 [type=int]
@@ -241,7 +215,6 @@ union
  └── values
       ├── columns: column1:4(int)
       ├── cardinality: [3 - 3]
-      ├── stats: [rows=3, distinct(4)=3]
       ├── prune: (4)
       ├── tuple [type=tuple{int}]
       │    └── const: 6 [type=int]
@@ -263,18 +236,15 @@ intersect
  ├── left columns: column1:1(int)
  ├── right columns: column1:3(int)
  ├── cardinality: [0 - 2]
- ├── stats: [rows=2, distinct(1)=2]
  ├── key: (1)
  ├── intersect-all
  │    ├── columns: column1:1(int)
  │    ├── left columns: column1:1(int)
  │    ├── right columns: column1:2(int)
  │    ├── cardinality: [0 - 2]
- │    ├── stats: [rows=2, distinct(1)=2]
  │    ├── values
  │    │    ├── columns: column1:1(int)
  │    │    ├── cardinality: [3 - 3]
- │    │    ├── stats: [rows=3, distinct(1)=3]
  │    │    ├── prune: (1)
  │    │    ├── tuple [type=tuple{int}]
  │    │    │    └── const: 1 [type=int]
@@ -285,7 +255,6 @@ intersect
  │    └── values
  │         ├── columns: column1:2(int)
  │         ├── cardinality: [2 - 2]
- │         ├── stats: [rows=2, distinct(2)=2]
  │         ├── prune: (2)
  │         ├── tuple [type=tuple{int}]
  │         │    └── const: 4 [type=int]
@@ -294,7 +263,6 @@ intersect
  └── values
       ├── columns: column1:3(int)
       ├── cardinality: [3 - 3]
-      ├── stats: [rows=3, distinct(3)=3]
       ├── prune: (3)
       ├── tuple [type=tuple{int}]
       │    └── const: 6 [type=int]
@@ -316,18 +284,15 @@ except
  ├── left columns: column1:1(int)
  ├── right columns: column1:3(int)
  ├── cardinality: [0 - 3]
- ├── stats: [rows=3, distinct(1)=3]
  ├── key: (1)
  ├── except-all
  │    ├── columns: column1:1(int)
  │    ├── left columns: column1:1(int)
  │    ├── right columns: column1:2(int)
  │    ├── cardinality: [1 - 3]
- │    ├── stats: [rows=3, distinct(1)=3]
  │    ├── values
  │    │    ├── columns: column1:1(int)
  │    │    ├── cardinality: [3 - 3]
- │    │    ├── stats: [rows=3, distinct(1)=3]
  │    │    ├── prune: (1)
  │    │    ├── tuple [type=tuple{int}]
  │    │    │    └── const: 1 [type=int]
@@ -338,7 +303,6 @@ except
  │    └── values
  │         ├── columns: column1:2(int)
  │         ├── cardinality: [2 - 2]
- │         ├── stats: [rows=2, distinct(2)=2]
  │         ├── prune: (2)
  │         ├── tuple [type=tuple{int}]
  │         │    └── const: 4 [type=int]
@@ -347,7 +311,6 @@ except
  └── values
       ├── columns: column1:3(int)
       ├── cardinality: [4 - 4]
-      ├── stats: [rows=4, distinct(3)=4]
       ├── prune: (3)
       ├── tuple [type=tuple{int}]
       │    └── const: 6 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/values
+++ b/pkg/sql/opt/memo/testdata/logprops/values
@@ -13,7 +13,6 @@ SELECT * FROM (VALUES (1, 2), (3, 4), (NULL, 5))
 values
  ├── columns: column1:1(int) column2:2(int)
  ├── cardinality: [3 - 3]
- ├── stats: [rows=3]
  ├── prune: (1,2)
  ├── tuple [type=tuple{int, int}]
  │    ├── const: 1 [type=int]
@@ -31,11 +30,9 @@ SELECT (VALUES (x), (y+1)) FROM xy
 ----
 project
  ├── columns: column1:4(int)
- ├── stats: [rows=1000]
  ├── prune: (4)
  ├── scan xy
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=1000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    ├── prune: (1,2)
@@ -46,14 +43,12 @@ project
                 ├── columns: column1:3(int)
                 ├── outer: (1,2)
                 ├── cardinality: [1 - 1]
-                ├── stats: [rows=1]
                 ├── key: ()
                 ├── fd: ()-->(3)
                 └── values
                      ├── columns: column1:3(int)
                      ├── outer: (1,2)
                      ├── cardinality: [2 - 2]
-                     ├── stats: [rows=2]
                      ├── prune: (3)
                      ├── tuple [type=tuple{int}, outer=(1)]
                      │    └── variable: x [type=int, outer=(1)]
@@ -69,7 +64,6 @@ SELECT * FROM (VALUES (1, 2))
 values
  ├── columns: column1:1(int) column2:2(int)
  ├── cardinality: [1 - 1]
- ├── stats: [rows=1]
  ├── key: ()
  ├── fd: ()-->(1,2)
  ├── prune: (1,2)

--- a/pkg/sql/opt/memo/testdata/logprops/virtual-scan
+++ b/pkg/sql/opt/memo/testdata/logprops/virtual-scan
@@ -38,27 +38,22 @@ ON CATALOG_NAME=TABLE_CATALOG AND SCHEMA_NAME=TABLE_SCHEMA
 ----
 project
  ├── columns: catalog_name:1(string) sql_path:4(string)
- ├── stats: [rows=17.6366843]
  ├── prune: (1,4)
  └── left-join
       ├── columns: catalog_name:1(string) schema_name:2(string!null) default_character_set_name:3(string) sql_path:4(string) table_catalog:5(string) table_schema:6(string) table_name:7(string) table_type:8(string) is_insertable_into:9(string) version:10(int)
-      ├── stats: [rows=17.6366843]
       ├── fd: ()-->(2)
       ├── reject-nulls: (5-10)
       ├── select
       │    ├── columns: catalog_name:1(string) schema_name:2(string!null) default_character_set_name:3(string) sql_path:4(string)
-      │    ├── stats: [rows=1.42857143, distinct(2)=1]
       │    ├── fd: ()-->(2)
       │    ├── virtual-scan system.information_schema.schemata
-      │    │    ├── columns: catalog_name:1(string) schema_name:2(string) default_character_set_name:3(string) sql_path:4(string)
-      │    │    └── stats: [rows=1000, distinct(2)=700]
+      │    │    └── columns: catalog_name:1(string) schema_name:2(string) default_character_set_name:3(string) sql_path:4(string)
       │    └── filters [type=bool, outer=(2), constraints=(/2: [/'public' - /'public']; tight), fd=()-->(2)]
       │         └── eq [type=bool, outer=(2), constraints=(/2: [/'public' - /'public']; tight)]
       │              ├── variable: schema_name [type=string, outer=(2)]
       │              └── const: 'public' [type=string]
       ├── virtual-scan system.information_schema.tables
-      │    ├── columns: table_catalog:5(string) table_schema:6(string) table_name:7(string) table_type:8(string) is_insertable_into:9(string) version:10(int)
-      │    └── stats: [rows=1000]
+      │    └── columns: table_catalog:5(string) table_schema:6(string) table_name:7(string) table_type:8(string) is_insertable_into:9(string) version:10(int)
       └── filters [type=bool, outer=(1,2,5,6), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /5: (/NULL - ]; /6: (/NULL - ])]
            └── and [type=bool, outer=(1,2,5,6), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /5: (/NULL - ]; /6: (/NULL - ])]
                 ├── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -27,36 +27,29 @@ limit
  ├── columns: y:2(int!null) x:3(string!null) c:5(int)
  ├── internal-ordering: +2
  ├── cardinality: [0 - 10]
- ├── stats: [rows=10]
  ├── fd: (2)-->(5)
  ├── ordering: +2
  ├── sort
  │    ├── columns: y:2(int!null) b.x:3(string!null) c:5(int)
- │    ├── stats: [rows=333333.333]
  │    ├── fd: (2)-->(5)
  │    ├── ordering: +2
  │    └── project
  │         ├── columns: c:5(int) y:2(int!null) b.x:3(string!null)
- │         ├── stats: [rows=333333.333]
  │         ├── fd: (2)-->(5)
  │         ├── select
  │         │    ├── columns: a.x:1(int!null) y:2(int!null) b.x:3(string!null) z:4(decimal!null)
- │         │    ├── stats: [rows=333333.333]
  │         │    ├── key: (1,3)
  │         │    ├── fd: (1)-->(2), (3)-->(4)
  │         │    ├── inner-join
  │         │    │    ├── columns: a.x:1(int!null) y:2(int) b.x:3(string!null) z:4(decimal!null)
- │         │    │    ├── stats: [rows=1000000]
  │         │    │    ├── key: (1,3)
  │         │    │    ├── fd: (1)-->(2), (3)-->(4)
  │         │    │    ├── scan a
  │         │    │    │    ├── columns: a.x:1(int!null) y:2(int)
- │         │    │    │    ├── stats: [rows=1000]
  │         │    │    │    ├── key: (1)
  │         │    │    │    └── fd: (1)-->(2)
  │         │    │    ├── scan b
  │         │    │    │    ├── columns: b.x:3(string!null) z:4(decimal!null)
- │         │    │    │    ├── stats: [rows=1000]
  │         │    │    │    ├── key: (3)
  │         │    │    │    └── fd: (3)-->(4)
  │         │    │    └── true [type=bool]
@@ -85,40 +78,33 @@ LIMIT 10
 project
  ├── columns: y:2(int!null) x:3(string!null) c:5(int)
  ├── cardinality: [0 - 10]
- ├── stats: [rows=10]
  ├── fd: (2)-->(5)
  ├── ordering: +2
  ├── limit
  │    ├── columns: a.x:1(int!null) y:2(int!null) b.x:3(string!null)
  │    ├── internal-ordering: +2
  │    ├── cardinality: [0 - 10]
- │    ├── stats: [rows=10]
  │    ├── key: (1,3)
  │    ├── fd: (1)-->(2)
  │    ├── ordering: +2
  │    ├── sort
  │    │    ├── columns: a.x:1(int!null) y:2(int!null) b.x:3(string!null)
- │    │    ├── stats: [rows=111111.111]
  │    │    ├── key: (1,3)
  │    │    ├── fd: (1)-->(2)
  │    │    ├── ordering: +2
  │    │    └── inner-join
  │    │         ├── columns: a.x:1(int!null) y:2(int!null) b.x:3(string!null)
- │    │         ├── stats: [rows=111111.111]
  │    │         ├── key: (1,3)
  │    │         ├── fd: (1)-->(2)
  │    │         ├── scan b
  │    │         │    ├── columns: b.x:3(string!null)
- │    │         │    ├── stats: [rows=1000]
  │    │         │    └── key: (3)
  │    │         ├── select
  │    │         │    ├── columns: a.x:1(int!null) y:2(int!null)
- │    │         │    ├── stats: [rows=333.333333]
  │    │         │    ├── key: (1)
  │    │         │    ├── fd: (1)-->(2)
  │    │         │    ├── scan a
  │    │         │    │    ├── columns: a.x:1(int!null) y:2(int)
- │    │         │    │    ├── stats: [rows=1000]
  │    │         │    │    ├── key: (1)
  │    │         │    │    └── fd: (1)-->(2)
  │    │         │    └── filters [type=bool, outer=(2), constraints=(/2: [/2 - ]; tight)]


### PR DESCRIPTION
Backport 1/1 commits from #29141.

/cc @cockroachdb/release

---

Hiding stats in the logprops tests since stats have their own tests.

Release note: None
