### PR TITLE
release-2.1: distsqlrun: bump MinAcceptedVersion to 21

### DIFF
--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -80,7 +80,7 @@ const Version DistSQLVersion = 21
 
 // MinAcceptedVersion is the oldest version that the server is
 // compatible with; see above.
-const MinAcceptedVersion DistSQLVersion = 6
+const MinAcceptedVersion DistSQLVersion = 21
 
 // minFlowDrainWait is the minimum amount of time a draining server allows for
 // any incoming flows to be registered. It acts as a grace period in which the

--- a/pkg/sql/distsqlrun/version_history.txt
+++ b/pkg/sql/distsqlrun/version_history.txt
@@ -79,3 +79,10 @@
 - Version: 21 (MinAcceptedVersion: 6)
     - Permit non-public (mutation) columns in TableReader return values, when
       requested. The new processor spec would be ignored by old versions.
+- MinAcceptedVersion: 21
+    - Bump in preparation for the 2.1 release. A large amount of changes
+      in both IMPORT and SQL execution have merged since 2.0. We have not
+      adequately tested them in skewed version clusters to have confidence
+      that they are compatible. We decided it was safer to bump the min
+      version to prevent possible bugs at the cost of performance during
+      the upgrade.


### PR DESCRIPTION
Backport 1/1 commits from #28977.

/cc @cockroachdb/release

---

This change makes 2.0 nodes not schedule distsql work on 2.1 nodes. This
change is being made because we don't adequately test clusters in
a skewed version environment. This means we could have missed actual
breaking changes that should have bumped the min version but didn't. In
lieu of that testing, prevent cross version work from being done.

For example, we have already identified a number of IMPORT problems in
skewed version clusters that are best fixed by preventing the scheduling
of work from 2.0 onto 2.1 nodes. However it is also possible there are
other unknown breakages in distsql land.

This does mean that SQL workloads in a version upgrade environment will
experience performance loss if the entire cluster can't be used and data
has to be streamed to a gateway.

Release note (sql change): Prevent 2.0 nodes from scheduling distsql
work on 2.1 nodes.
