### PR TITLE
roachtest: assorted debuggability improvements

### DIFF
--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -48,9 +48,8 @@ func registerBackup(r *registry) {
 			m := newMonitor(ctx, c)
 			m.Go(func(ctx context.Context) error {
 				t.Status(`running backup`)
-				c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
+				return c.RunE(ctx, c.Node(1), `./cockroach sql --insecure -e "
 				BACKUP bank.bank TO 'gs://cockroachdb-backup-testing/`+c.name+`'"`)
-				return nil
 			})
 			m.Wait()
 		},

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -117,7 +117,7 @@ Use 'roachtest bench -n' to see a list of all benchmarks.
 		cmd.Flags().IntVar(
 			&count, "count", 1, "the number of times to run each test")
 		cmd.Flags().BoolVarP(
-			&debug, "debug", "d", debug, "don't wipe and destroy cluster if test fails")
+			&debugEnabled, "debug", "d", debugEnabled, "don't wipe and destroy cluster if test fails")
 		cmd.Flags().BoolVarP(
 			&dryrun, "dry-run", "n", dryrun, "dry run (don't run tests)")
 		cmd.Flags().IntVarP(
@@ -151,7 +151,7 @@ Cockroach cluster with existing data.
 		&stores, "stores", "n", stores, "number of stores to distribute data across")
 	storeGenCmd.Flags().SetInterspersed(false) // ignore workload flags
 	storeGenCmd.Flags().BoolVarP(
-		&debug, "debug", "d", debug, "don't wipe and destroy cluster if test fails")
+		&debugEnabled, "debug", "d", debugEnabled, "don't wipe and destroy cluster if test fails")
 
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(benchCmd)

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -41,7 +41,7 @@ import (
 var (
 	parallelism   = 10
 	count         = 1
-	debug         = false
+	debugEnabled  = false
 	dryrun        = false
 	postIssues    = true
 	clusterNameRE = regexp.MustCompile(`^[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?$`)
@@ -395,7 +395,7 @@ func (r *registry) Run(filter []string) int {
 			r.status.Unlock()
 
 		case <-sig:
-			if !debug {
+			if !debugEnabled {
 				destroyAllClusters()
 			}
 		}
@@ -725,7 +725,7 @@ func (r *registry) run(spec *testSpec, filter *regexp.Regexp, c *cluster, done f
 				c = newCluster(ctx, t, t.spec.Nodes)
 				if c != nil {
 					defer func() {
-						if !debug || !t.Failed() {
+						if !debugEnabled || !t.Failed() {
 							c.Destroy(ctx)
 						} else {
 							c.l.printf("not destroying cluster to allow debugging\n")
@@ -772,7 +772,7 @@ func (r *registry) run(spec *testSpec, filter *regexp.Regexp, c *cluster, done f
 						if c != nil {
 							c.FetchLogs(ctx)
 							// NB: c.destroyed is nil for cloned clusters (i.e. in subtests).
-							if !debug && c.destroyed != nil {
+							if !debugEnabled && c.destroyed != nil {
 								c.Destroy(ctx)
 							}
 						}

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -643,3 +643,21 @@ func registerTPCCBench(r *registry) {
 		registerTPCCBenchSpec(r, b)
 	}
 }
+
+func testHarness(ctx context.Context, t *test, c *cluster) {
+	m := newMonitor(ctx, c, c.Range(1, c.nodes))
+	m.ExpectDeaths(int32(c.nodes))
+	m.Go(func(ctx context.Context) error {
+		return c.RunE(ctx, c.Node(1), "sleep", "2000")
+	})
+	m.Go(func(ctx context.Context) error {
+		if false {
+			// If this runs, it'll runtime.Goexit in t.Fatal and
+			// the monitor will catch this and show a stack trace
+			// instead of hanging.
+			c.Run(ctx, c.Node(1), "idontexistihope")
+		}
+		return c.RunE(ctx, c.Range(1, 3), "idontexisttoo")
+	})
+	m.Wait()
+}


### PR DESCRIPTION
    roachtest: fix some Fatal-on-goroutine offenders

    Not all of them. There are more than I have time for right now.

    Release note: None

    roachtest: complain about invalid calls off main goroutine

    Until https://go-review.googlesource.com/c/sync/+/131815 merges
    (if if ever does) an errgroup will not cancel the context when one of its
    goroutines Goexit's. This means it remains a bad idea to call `c.Run` and
    friends from within `m.Go`, as it'll hold back the error until everything
    has "naturally" terminated, which may never happen (since a goroutine just
    stopped doing its work).

    Put annoying warnings in the logs that should be good enough to deter
    anyone developing tests locally from committing these faux-pas.

    I'd rather remove `c.Run` and friends completely, but it's a bigger
    project.

    roachtest: observe ctx cancellation in Run

    Before this patch, roachprod invocations would not observe ctx
    cancellation. Or rather they would, but due to the usual obscure passing of
    Stdout into the child process of roachprod the Run call would not return
    until the child had finished. As a result, the test would continue running,
    which is annoying and also costs money.

Release note: None