### PR TITLE
release-2.1: cli: unbreak the windows build

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -200,6 +200,8 @@ func (a addrSetter) Set(v string) error {
 	return nil
 }
 
+const backgroundEnvVar = "COCKROACH_BACKGROUND_RESTART"
+
 func init() {
 	initCLIDefaults()
 

--- a/pkg/cli/start_unix.go
+++ b/pkg/cli/start_unix.go
@@ -55,8 +55,6 @@ func handleSignalDuringShutdown(sig os.Signal) {
 
 var startBackground bool
 
-const backgroundEnvVar = "COCKROACH_BACKGROUND_RESTART"
-
 func init() {
 	BoolFlag(StartCmd.Flags(), &startBackground, cliflags.Background, false)
 }


### PR DESCRIPTION
Backport 1/1 commits from #29175.

/cc @cockroachdb/release

---

Release note: None
