### PR TITLE
workload/tpcc: don't cancel in-flight txns after ramp period

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -36,8 +36,11 @@ import (
 
 func registerTPCC(r *registry) {
 	runTPCC := func(ctx context.Context, t *test, c *cluster, warehouses int, extra string) {
-		nodes := c.nodes - 1
+		if !c.isLocal() {
+			c.RemountNoBarrier(ctx)
+		}
 
+		nodes := c.nodes - 1
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 		c.Start(ctx, c.Range(1, nodes))


### PR DESCRIPTION
This had two negative effects. It stalling all throughput for a second
which looked like an issue even though it wasnt. It also synchronized
most workers so that the issued queries in lockstep which could topple
an already heavily-loaded cluster.