### PR TITLE
opt: error out on correlated Exists and Any subqueries

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -219,9 +219,6 @@ join       ·      ·            (x, z)  ·
 ·          table  a@primary    ·       ·
 ·          spans  ALL          ·       ·
 
-query error could not decorrelate subquery
-SELECT * FROM abc WHERE EXISTS(SELECT * FROM (VALUES (a), (b)) WHERE column1=a)
-
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY(SELECT x FROM b)
 ----
@@ -239,3 +236,64 @@ root                 ·            ·                       ("array")  ·
            └── scan  ·            ·                       (x)        ·
 ·                    table        b@primary               ·          ·
 ·                    spans        ALL                     ·          ·
+
+# Case where the plan has an apply join.
+query error could not decorrelate subquery
+SELECT * FROM abc WHERE EXISTS(SELECT * FROM (VALUES (a), (b)) WHERE column1=a)
+
+# Case where the EXISTS subquery still has outer columns in the subquery
+# (regression test for #28816).
+query error could not decorrelate subquery
+SELECT
+  subq_0.c1 AS c1
+FROM
+  (SELECT ref_0.attrs AS c1 FROM crdb_internal.kv_store_status AS ref_0) AS subq_0
+WHERE
+  5 >= CASE WHEN subq_0.c1 IS NOT NULL
+    THEN 5
+    ELSE pg_catalog.extract(
+      CAST(
+        CASE WHEN (
+          EXISTS(
+            SELECT ref_1.config_yaml AS c0
+            FROM crdb_internal.zones AS ref_1
+            WHERE subq_0.c1 IS NOT NULL
+          )
+        )
+        THEN pg_catalog.version()
+        ELSE pg_catalog.version()
+        END
+          AS STRING
+      ),
+      CAST(pg_catalog.current_date() AS DATE)
+    )
+    END
+
+# Case where the ANY subquery still has outer columns.
+query error could not decorrelate subquery
+SELECT
+  subq_0.c1 AS c1
+FROM
+  (SELECT ref_0.attrs AS c1 FROM crdb_internal.kv_store_status AS ref_0) AS subq_0
+WHERE
+  5 >= CASE WHEN subq_0.c1 IS NOT NULL
+    THEN 5
+    ELSE pg_catalog.extract(
+      CAST(
+        CASE
+        WHEN (
+          '12'::BYTES
+          = ANY (
+              SELECT ref_1.config_yaml AS c0
+              FROM crdb_internal.zones AS ref_1
+              WHERE subq_0.c1 IS NOT NULL
+            )
+        )
+        THEN pg_catalog.version()
+        ELSE pg_catalog.version()
+        END
+          AS STRING
+      ),
+      CAST(pg_catalog.current_date() AS DATE)
+    )
+    END


### PR DESCRIPTION
Adding missing checks for outer columns on Exists and Any subqueries.
These are cases where we couldn't even convert to an apply variant.

Fixes #28816.

Release note: None