### PR TITLE
ui: design updates to the Statements pages

### DIFF
--- a/pkg/ui/src/util/sql/summarize.ts
+++ b/pkg/ui/src/util/sql/summarize.ts
@@ -12,6 +12,7 @@ const keywords: { [key: string]: RegExp } = {
   insert: /^insert\s+into\s+([^ \t(]+)/i,
   delete: /^delete\s+from\s+(\S+)/i,
   create: /^create\s+table\s+(\S+)/i,
+  set: /^set\s+((cluster\s+setting\s+)?\S+)/i,
 };
 
 // summarize takes a string SQL statement and produces a structured summary

--- a/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
@@ -124,7 +124,7 @@ export default class Sidebar extends React.Component {
           <IconLink to="/overview" icon={homeIcon} title="Overview" activeFor="/node" />
           <IconLink to="/metrics" icon={metricsIcon} title="Metrics" />
           <IconLink to="/databases" icon={databasesIcon} title="Databases" activeFor="/database" />
-          <IconLink to="/statements" icon={statementsIcon} title="Statements" />
+          <IconLink to="/statements" icon={statementsIcon} title="Statements" activeFor="/statement" />
           <IconLink to="/jobs" icon={jobsIcon} title="Jobs" />
         </ul>
         <ul className="navigation-bar__list navigation-bar__list--bottom">

--- a/pkg/ui/src/views/shared/components/pageconfig/index.tsx
+++ b/pkg/ui/src/views/shared/components/pageconfig/index.tsx
@@ -1,16 +1,31 @@
+import classnames from "classnames";
 import React from "react";
 
-export function PageConfig(props: {children?: React.ReactNode}) {
+export interface PageConfigProps {
+  layout?: "list" | "spread";
+  children?: React.ReactNode;
+}
+
+export function PageConfig(props: PageConfigProps) {
+  const classes = classnames({
+    "page-config__list": props.layout !== "spread",
+    "page-config__spread": props.layout === "spread",
+  });
+
   return (
     <div className="page-config">
-      <ul className="page-config__list">
+      <ul className={ classes }>
         { props.children }
       </ul>
     </div>
   );
 }
 
-export function PageConfigItem(props: {children?: React.ReactNode}) {
+export interface PageConfigItemProps {
+  children?: React.ReactNode;
+}
+
+export function PageConfigItem(props: PageConfigItemProps) {
   return (
     <li className="page-config__item">
       { props.children }

--- a/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
+++ b/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
@@ -14,7 +14,7 @@
           display inline-block
           width 20px
           line-height 12px
-          font-size 6px
+          font-size 10px
           vertical-align middle
           text-align center
           content "▼"

--- a/pkg/ui/src/views/shared/components/sortedtable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortedtable/index.tsx
@@ -10,7 +10,7 @@ import { SortableTable, SortableColumn, SortSetting } from "src/views/shared/com
  */
 export interface ColumnDescriptor<T> {
   // Title string that should appear in the header column.
-  title: string;
+  title: React.ReactNode;
   // Function which generates the contents of an individual cell in this table.
   cell: (obj: T) => React.ReactNode;
   // Function which returns a value that can be used to sort the collection of

--- a/pkg/ui/src/views/shared/components/summaryBar/summarybar.styl
+++ b/pkg/ui/src/views/shared/components/summaryBar/summarybar.styl
@@ -21,6 +21,7 @@
     text-transform uppercase
     letter-spacing 2px
     color $tooltip-color
+    white-space nowrap
 
   &__value
     font-weight 200

--- a/pkg/ui/src/views/shared/components/toolTip/index.tsx
+++ b/pkg/ui/src/views/shared/components/toolTip/index.tsx
@@ -5,6 +5,7 @@ import "./tooltip.styl";
 
 interface ToolTipWrapperProps {
   text: React.ReactNode;
+  short?: boolean;
 }
 
 interface ToolTipWrapperState {
@@ -37,11 +38,12 @@ export class ToolTipWrapper extends React.Component<ToolTipWrapperProps, ToolTip
   }
 
   render() {
-    const { text } = this.props;
+    const { text, short } = this.props;
     const { hovered } = this.state;
     const tooltipClassNames = classNames({
       "hover-tooltip": true,
       "hover-tooltip--hovered": hovered,
+      "hover-tooltip--short": short,
     });
 
     return (

--- a/pkg/ui/src/views/shared/components/toolTip/tooltip.styl
+++ b/pkg/ui/src/views/shared/components/toolTip/tooltip.styl
@@ -30,6 +30,8 @@
 
 .hover-tooltip
   position relative
+  width 100%
+  height 100%
 
   &__text
     visibility hidden

--- a/pkg/ui/src/views/shared/components/toolTip/tooltip.styl
+++ b/pkg/ui/src/views/shared/components/toolTip/tooltip.styl
@@ -47,6 +47,10 @@
     text-align left
     color $body-color
 
+  &--short &__text
+    width unset
+    max-width 400px
+
   &--hovered &__text
     visibility visible
 

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -107,7 +107,7 @@ function makeBarChart(
 
       return (
         <div className={ "bar-chart" + (rows.length === 0 ? " bar-chart--singleton" : "") }>
-          <ToolTipWrapper text={ titleText }>
+          <ToolTipWrapper text={ titleText } short>
             <div className="label">{ formatter(getTotal(d)) }</div>
             { bars }
             { renderStdDev() }
@@ -153,7 +153,7 @@ export function countBreakdown(s: StatementStatistics) {
     firstAttemptsBarChart() {
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <ToolTipWrapper text={"First Try Count: " + firstAttempts}>
+          <ToolTipWrapper text={"First Try Count: " + firstAttempts} short>
             <div
               className="count-first-try bar-chart__bar"
               style={{ width: scale(firstAttempts) + "%" }}
@@ -166,7 +166,7 @@ export function countBreakdown(s: StatementStatistics) {
     retriesBarChart() {
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <ToolTipWrapper text={ "Retry Count: " + retries }>
+          <ToolTipWrapper text={ "Retry Count: " + retries } short>
             <div
               className="count-retry bar-chart__bar"
               style={{ width: scale(retries) + "%", position: "absolute", right: "0" }}
@@ -179,7 +179,7 @@ export function countBreakdown(s: StatementStatistics) {
     maxRetriesBarChart() {
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <ToolTipWrapper text={ "Max Retries: " + retries }>
+          <ToolTipWrapper text={ "Max Retries: " + retries } short>
             <div
               className="count-retry bar-chart__bar"
               style={{ width: scale(maxRetries) + "%", position: "absolute", right: "0" }}
@@ -209,7 +209,7 @@ export function rowsBreakdown(s: StatementStatistics) {
       const title = "Row Count.  Mean: " + format(mean) + " Std.Dev.: " + format(sd);
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <ToolTipWrapper text={ title }>
+          <ToolTipWrapper text={ title } short>
             <div
               className="rows bar-chart__bar"
               style={{ width: right + "%", position: "absolute", left: 0 }}
@@ -263,7 +263,7 @@ export function latencyBreakdown(s: StatementStatistics) {
       const title = "Parse Latency.  Mean: " + format(parseMean) + " Std. Dev.: " + format(parseSd);
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <ToolTipWrapper text={ title }>
+          <ToolTipWrapper text={ title } short>
             <div
               className="latency-parse bar-chart__bar"
               style={{ width: right + "%", position: "absolute", left: 0 }}
@@ -285,7 +285,7 @@ export function latencyBreakdown(s: StatementStatistics) {
       const title = "Plan Latency.  Mean: " + format(planMean) + " Std. Dev.: " + format(planSd);
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <ToolTipWrapper text={ title }>
+          <ToolTipWrapper text={ title } short>
             <div
               className="latency-plan bar-chart__bar"
               style={{ width: right + "%", position: "absolute", left: left + "%" }}
@@ -307,7 +307,7 @@ export function latencyBreakdown(s: StatementStatistics) {
       const title = "Run Latency.  Mean: " + format(runMean) + " Std. Dev.: " + format(runSd);
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <ToolTipWrapper text={ title }>
+          <ToolTipWrapper text={ title } short>
             <div
               className="latency-run bar-chart__bar"
               style={{ width: right + "%", position: "absolute", left: left + "%" }}
@@ -329,7 +329,7 @@ export function latencyBreakdown(s: StatementStatistics) {
       const title = "Overhead Latency.  Mean: " + format(overheadMean) + " Std. Dev.: " + format(overheadSd);
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <ToolTipWrapper text={ title }>
+          <ToolTipWrapper text={ title } short>
             <div
               className="latency-overhead bar-chart__bar"
               style={{ width: right + "%", position: "absolute", left: left + "%" }}
@@ -353,7 +353,7 @@ export function latencyBreakdown(s: StatementStatistics) {
       const title = "Overall Latency.  Mean: " + format(overallMean) + " Std. Dev.: " + format(overallSd);
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <ToolTipWrapper text={ title }>
+          <ToolTipWrapper text={ title } short>
             <div
               className="latency-parse bar-chart__bar"
               style={{ width: parse + "%", position: "absolute", left: 0 }}

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -17,6 +17,9 @@ const clamp = (i: number) => i < 0 ? 0 : i;
 
 const countBars = [
   bar("count-first-try", (d: StatementStatistics) => longToInt(d.stats.first_attempt_count)),
+];
+
+const retryBars = [
   bar("count-retry", (d: StatementStatistics) => longToInt(d.stats.count) - longToInt(d.stats.first_attempt_count)),
 ];
 
@@ -136,6 +139,7 @@ export function approximify(value: number) {
 }
 
 export const countBarChart = makeBarChart("Execution Count", countBars, approximify);
+export const retryBarChart = makeBarChart("Retry Count", retryBars, approximify);
 export const rowsBarChart = makeBarChart("Rows Affected.  Mean", rowsBars, approximify, rowsStdDev);
 export const latencyBarChart = makeBarChart("Latency.  Mean", latencyBars, v => Duration(v * 1e9), latencyStdDev);
 

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -184,12 +184,10 @@ export function countBreakdown(s: StatementStatistics) {
     firstAttemptsBarChart() {
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <ToolTipWrapper text={"First Try Count: " + firstAttempts} short>
-            <div
-              className="count-first-try bar-chart__bar"
-              style={{ width: scale(firstAttempts) + "%" }}
-            />
-          </ToolTipWrapper>
+          <div
+            className="count-first-try bar-chart__bar"
+            style={{ width: scale(firstAttempts) + "%" }}
+          />
         </div>
       );
     },
@@ -197,12 +195,10 @@ export function countBreakdown(s: StatementStatistics) {
     retriesBarChart() {
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <ToolTipWrapper text={ "Retry Count: " + retries } short>
-            <div
-              className="count-retry bar-chart__bar"
-              style={{ width: scale(retries) + "%", position: "absolute", right: "0" }}
-            />
-          </ToolTipWrapper>
+          <div
+            className="count-retry bar-chart__bar"
+            style={{ width: scale(retries) + "%", position: "absolute", right: "0" }}
+          />
         </div>
       );
     },
@@ -210,12 +206,10 @@ export function countBreakdown(s: StatementStatistics) {
     maxRetriesBarChart() {
       return (
         <div className="bar-chart bar-chart--breakdown">
-          <ToolTipWrapper text={ "Max Retries: " + retries } short>
-            <div
-              className="count-retry bar-chart__bar"
-              style={{ width: scale(maxRetries) + "%", position: "absolute", right: "0" }}
-            />
-          </ToolTipWrapper>
+          <div
+            className="count-retry bar-chart__bar"
+            style={{ width: scale(maxRetries) + "%", position: "absolute", right: "0" }}
+          />
         </div>
       );
     },

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -207,8 +207,19 @@ export function countBreakdown(s: StatementStatistics) {
       return (
         <div className="bar-chart bar-chart--breakdown">
           <div
-            className="count-retry bar-chart__bar"
-            style={{ width: scale(maxRetries) + "%", position: "absolute", right: "0" }}
+            className="count-max-retries bar-chart__bar"
+            style={{ width: scale(maxRetries) + "%" }}
+          />
+        </div>
+      );
+    },
+
+    totalCountBarChart() {
+      return (
+        <div className="bar-chart bar-chart--breakdown">
+          <div
+            className="count-total bar-chart__bar"
+            style={{ width: scale(count) + "%" }}
           />
         </div>
       );

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -184,6 +184,7 @@ export function countBreakdown(s: StatementStatistics) {
     firstAttemptsBarChart() {
       return (
         <div className="bar-chart bar-chart--breakdown">
+          <div className="label">{ firstAttempts }</div>
           <div
             className="count-first-try bar-chart__bar"
             style={{ width: scale(firstAttempts) + "%" }}
@@ -195,6 +196,7 @@ export function countBreakdown(s: StatementStatistics) {
     retriesBarChart() {
       return (
         <div className="bar-chart bar-chart--breakdown">
+          <div className="label">{ retries }</div>
           <div
             className="count-retry bar-chart__bar"
             style={{ width: scale(retries) + "%", position: "absolute", right: "0" }}
@@ -206,6 +208,7 @@ export function countBreakdown(s: StatementStatistics) {
     maxRetriesBarChart() {
       return (
         <div className="bar-chart bar-chart--breakdown">
+          <div className="label">{ maxRetries }</div>
           <div
             className="count-max-retries bar-chart__bar"
             style={{ width: scale(maxRetries) + "%" }}
@@ -217,6 +220,7 @@ export function countBreakdown(s: StatementStatistics) {
     totalCountBarChart() {
       return (
         <div className="bar-chart bar-chart--breakdown">
+          <div className="label">{ count }</div>
           <div
             className="count-total bar-chart__bar"
             style={{ width: scale(count) + "%" }}
@@ -246,6 +250,7 @@ export function rowsBreakdown(s: StatementStatistics) {
       return (
         <div className="bar-chart bar-chart--breakdown">
           <ToolTipWrapper text={ title } short>
+            <div className="label">{ Math.round(mean * 100) / 100 }</div>
             <div
               className="rows bar-chart__bar"
               style={{ width: right + "%", position: "absolute", left: 0 }}
@@ -300,6 +305,7 @@ export function latencyBreakdown(s: StatementStatistics) {
       return (
         <div className="bar-chart bar-chart--breakdown">
           <ToolTipWrapper text={ title } short>
+            <div className="label">{ Duration(parseMean * 1e9) }</div>
             <div
               className="latency-parse bar-chart__bar"
               style={{ width: right + "%", position: "absolute", left: 0 }}
@@ -322,6 +328,7 @@ export function latencyBreakdown(s: StatementStatistics) {
       return (
         <div className="bar-chart bar-chart--breakdown">
           <ToolTipWrapper text={ title } short>
+            <div className="label">{ Duration(planMean * 1e9) }</div>
             <div
               className="latency-plan bar-chart__bar"
               style={{ width: right + "%", position: "absolute", left: left + "%" }}
@@ -344,6 +351,7 @@ export function latencyBreakdown(s: StatementStatistics) {
       return (
         <div className="bar-chart bar-chart--breakdown">
           <ToolTipWrapper text={ title } short>
+            <div className="label">{ Duration(runMean * 1e9) }</div>
             <div
               className="latency-run bar-chart__bar"
               style={{ width: right + "%", position: "absolute", left: left + "%" }}
@@ -366,6 +374,7 @@ export function latencyBreakdown(s: StatementStatistics) {
       return (
         <div className="bar-chart bar-chart--breakdown">
           <ToolTipWrapper text={ title } short>
+            <div className="label">{ Duration(overheadMean * 1e9) }</div>
             <div
               className="latency-overhead bar-chart__bar"
               style={{ width: right + "%", position: "absolute", left: left + "%" }}
@@ -390,6 +399,7 @@ export function latencyBreakdown(s: StatementStatistics) {
       return (
         <div className="bar-chart bar-chart--breakdown">
           <ToolTipWrapper text={ title } short>
+            <div className="label">{ Duration(overallMean * 1e9) }</div>
             <div
               className="latency-parse bar-chart__bar"
               style={{ width: parse + "%", position: "absolute", left: 0 }}

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -63,6 +63,7 @@ interface NumericStatRow {
   name: string;
   value: NumericStat;
   bar?: () => ReactNode;
+  summary?: boolean;
 }
 
 interface NumericStatTableProps {
@@ -90,8 +91,10 @@ class NumericStatTable extends React.Component<NumericStatTableProps> {
         <tbody style={{ textAlign: "right" }}>
           {
             this.props.rows.map((row: NumericStatRow) => {
+              const classNames = "numeric-stats-table__row--body" +
+                (row.summary ? " numeric-stats-table__row--summary" : "");
               return (
-                <tr className="numeric-stats-table__row--body">
+                <tr className={classNames}>
                   <th className="numeric-stats-table__cell" style={{ textAlign: "left" }}>{ row.name }</th>
                   <td className="numeric-stats-table__cell">{ this.props.format(row.value.mean) }</td>
                   <td className="numeric-stats-table__cell">{ this.props.format(stdDev(row.value, this.props.count)) }</td>
@@ -214,7 +217,7 @@ class StatementDetails extends React.Component<StatementDetailsProps, StatementD
                   <td className="numeric-stats-table__cell" style={{ textAlign: "right" }}>{ FixLong(stats.max_retries).toInt() }</td>
                   <td className="numeric-stats-table__cell">{ maxRetriesBarChart() }</td>
                 </tr>
-                <tr className="numeric-stats-table__row--body">
+                <tr className="numeric-stats-table__row--body numeric-stats-table__row--summary">
                   <th className="numeric-stats-table__cell" style={{ textAlign: "left" }}>Total</th>
                   <td className="numeric-stats-table__cell" style={{ textAlign: "right" }}>{ count }</td>
                   <td className="numeric-stats-table__cell">{ totalCountBarChart() }</td>

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -67,6 +67,8 @@ interface NumericStatRow {
 }
 
 interface NumericStatTableProps {
+  title?: string;
+  measure: string;
   rows: NumericStatRow[];
   count: number;
   format?: (v: number) => string;
@@ -82,9 +84,11 @@ class NumericStatTable extends React.Component<NumericStatTableProps> {
       <table className="numeric-stats-table">
         <thead>
           <tr className="numeric-stats-table__row--header">
-            <th className="numeric-stats-table__cell" />
-            <th className="numeric-stats-table__cell">Mean</th>
-            <th className="numeric-stats-table__cell">Std. Dev.</th>
+            <th className="numeric-stats-table__cell">
+              { this.props.title }
+            </th>
+            <th className="numeric-stats-table__cell">Mean {this.props.measure}</th>
+            <th className="numeric-stats-table__cell">Standard Deviation</th>
             <th className="numeric-stats-table__cell" />
           </tr>
         </thead>
@@ -199,8 +203,14 @@ class StatementDetails extends React.Component<StatementDetailsProps, StatementD
             <SqlBox value={ statement } />
           </section>
           <section className="section">
-            <h3>Execution Count</h3>
             <table className="numeric-stats-table">
+              <thead>
+                <tr className="numeric-stats-table__row--header">
+                  <th className="numeric-stats-table__cell" colSpan={ 3 }>
+                    Execution Count
+                  </th>
+                </tr>
+              </thead>
               <tbody>
                 <tr className="numeric-stats-table__row--body">
                   <th className="numeric-stats-table__cell" style={{ textAlign: "left" }}>First Attempts</th>
@@ -226,8 +236,9 @@ class StatementDetails extends React.Component<StatementDetailsProps, StatementD
             </table>
           </section>
           <section className="section">
-            <h3>Latency by Phase</h3>
             <NumericStatTable
+              title="Phase"
+              measure="Latency"
               count={ count }
               format={ (v: number) => Duration(v * 1e9) }
               rows={[
@@ -240,12 +251,12 @@ class StatementDetails extends React.Component<StatementDetailsProps, StatementD
             />
           </section>
           <section className="section">
-            <h3>Row Count</h3>
             <NumericStatTable
+              measure="Rows"
               count={ count }
               format={ (v: number) => "" + (Math.round(v * 100) / 100) }
               rows={[
-                { name: "Rows", value: stats.num_rows, bar: rowsBarChart },
+                { name: "Rows Affected", value: stats.num_rows, bar: rowsBarChart },
               ]}
             />
           </section>

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -62,13 +62,13 @@ interface StatementDetailsState {
 interface NumericStatRow {
   name: string;
   value: NumericStat;
-  bar?: () => {};
+  bar?: () => ReactNode;
 }
 
 interface NumericStatTableProps {
   rows: NumericStatRow[];
   count: number;
-  format: (v: number) => string;
+  format?: (v: number) => string;
 }
 
 class NumericStatTable extends React.Component<NumericStatTableProps> {

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -183,7 +183,7 @@ class StatementDetails extends React.Component<StatementDetailsProps, StatementD
     const count = FixLong(stats.count).toInt();
     const firstAttemptCount = FixLong(stats.first_attempt_count).toInt();
 
-    const { firstAttemptsBarChart, retriesBarChart, maxRetriesBarChart } = countBreakdown(this.props.statement);
+    const { firstAttemptsBarChart, retriesBarChart, maxRetriesBarChart, totalCountBarChart } = countBreakdown(this.props.statement);
     const { rowsBarChart } = rowsBreakdown(this.props.statement);
     const { parseBarChart, planBarChart, runBarChart, overheadBarChart, overallBarChart } = latencyBreakdown(this.props.statement);
 
@@ -217,7 +217,7 @@ class StatementDetails extends React.Component<StatementDetailsProps, StatementD
                 <tr className="numeric-stats-table__row--body">
                   <th className="numeric-stats-table__cell" style={{ textAlign: "left" }}>Total</th>
                   <td className="numeric-stats-table__cell" style={{ textAlign: "right" }}>{ count }</td>
-                  <td className="numeric-stats-table__cell" />
+                  <td className="numeric-stats-table__cell">{ totalCountBarChart() }</td>
                 </tr>
               </tbody>
             </table>

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -20,6 +20,7 @@ import { Pick } from "src/util/pick";
 import { SortSetting } from "src/views/shared/components/sortabletable";
 import { SqlBox } from "src/views/shared/components/sql/box";
 import { SummaryBar, SummaryHeadlineStat } from "src/views/shared/components/summaryBar";
+import { ToolTipWrapper } from "src/views/shared/components/toolTip";
 
 import { countBreakdown, rowsBreakdown, latencyBreakdown, approximify } from "./barCharts";
 import { AggregateStatistics, StatementsSortedTable, makeNodesColumns } from "./statementsTable";
@@ -68,6 +69,7 @@ interface NumericStatRow {
 
 interface NumericStatTableProps {
   title?: string;
+  description?: string;
   measure: string;
   rows: NumericStatRow[];
   count: number;
@@ -80,12 +82,23 @@ class NumericStatTable extends React.Component<NumericStatTableProps> {
   };
 
   render() {
+    const tooltip = !this.props.description ? null : (
+        <div className="numeric-stats-table__tooltip">
+          <ToolTipWrapper text={this.props.description}>
+            <div className="numeric-stats-table__tooltip-hover-area">
+              <div className="numeric-stats-table__info-icon">i</div>
+            </div>
+          </ToolTipWrapper>
+        </div>
+      );
+
     return (
       <table className="numeric-stats-table">
         <thead>
           <tr className="numeric-stats-table__row--header">
             <th className="numeric-stats-table__cell">
               { this.props.title }
+              { tooltip }
             </th>
             <th className="numeric-stats-table__cell">Mean {this.props.measure}</th>
             <th className="numeric-stats-table__cell">Standard Deviation</th>
@@ -208,6 +221,13 @@ class StatementDetails extends React.Component<StatementDetailsProps, StatementD
                 <tr className="numeric-stats-table__row--header">
                   <th className="numeric-stats-table__cell" colSpan={ 3 }>
                     Execution Count
+                    <div className="numeric-stats-table__tooltip">
+                      <ToolTipWrapper text="The number of times this statement has been executed.">
+                        <div className="numeric-stats-table__tooltip-hover-area">
+                          <div className="numeric-stats-table__info-icon">i</div>
+                        </div>
+                      </ToolTipWrapper>
+                    </div>
                   </th>
                 </tr>
               </thead>
@@ -238,6 +258,7 @@ class StatementDetails extends React.Component<StatementDetailsProps, StatementD
           <section className="section">
             <NumericStatTable
               title="Phase"
+              description="The execution latency of this statement, broken down by phase."
               measure="Latency"
               count={ count }
               format={ (v: number) => Duration(v * 1e9) }

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -216,6 +216,31 @@ class StatementDetails extends React.Component<StatementDetailsProps, StatementD
             <SqlBox value={ statement } />
           </section>
           <section className="section">
+            <NumericStatTable
+              title="Phase"
+              description="The execution latency of this statement, broken down by phase."
+              measure="Latency"
+              count={ count }
+              format={ (v: number) => Duration(v * 1e9) }
+              rows={[
+                { name: "Parse", value: stats.parse_lat, bar: parseBarChart },
+                { name: "Plan", value: stats.plan_lat, bar: planBarChart },
+                { name: "Run", value: stats.run_lat, bar: runBarChart },
+                { name: "Overhead", value: stats.overhead_lat, bar: overheadBarChart },
+                { name: "Overall", summary: true, value: stats.service_lat, bar: overallBarChart },
+              ]}
+            />
+          </section>
+          <section className="section">
+            <StatementsSortedTable
+              className="statements-table"
+              data={statsByNode}
+              columns={makeNodesColumns(statsByNode, this.props.nodeNames)}
+              sortSetting={this.state.sortSetting}
+              onChangeSortSetting={this.changeSortSetting}
+            />
+          </section>
+          <section className="section">
             <table className="numeric-stats-table">
               <thead>
                 <tr className="numeric-stats-table__row--header">
@@ -257,38 +282,12 @@ class StatementDetails extends React.Component<StatementDetailsProps, StatementD
           </section>
           <section className="section">
             <NumericStatTable
-              title="Phase"
-              description="The execution latency of this statement, broken down by phase."
-              measure="Latency"
-              count={ count }
-              format={ (v: number) => Duration(v * 1e9) }
-              rows={[
-                { name: "Parse", value: stats.parse_lat, bar: parseBarChart },
-                { name: "Plan", value: stats.plan_lat, bar: planBarChart },
-                { name: "Run", value: stats.run_lat, bar: runBarChart },
-                { name: "Overhead", value: stats.overhead_lat, bar: overheadBarChart },
-                { name: "Overall", value: stats.service_lat, bar: overallBarChart },
-              ]}
-            />
-          </section>
-          <section className="section">
-            <NumericStatTable
               measure="Rows"
               count={ count }
               format={ (v: number) => "" + (Math.round(v * 100) / 100) }
               rows={[
                 { name: "Rows Affected", value: stats.num_rows, bar: rowsBarChart },
               ]}
-            />
-          </section>
-          <section className="section">
-            <h3>By Gateway Node</h3>
-            <StatementsSortedTable
-              className="statements-table"
-              data={statsByNode}
-              columns={makeNodesColumns(statsByNode, this.props.nodeNames)}
-              sortSetting={this.state.sortSetting}
-              onChangeSortSetting={this.changeSortSetting}
             />
           </section>
         </div>

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -102,7 +102,6 @@ class NumericStatTable extends React.Component<NumericStatTableProps> {
             </th>
             <th className="numeric-stats-table__cell">Mean {this.props.measure}</th>
             <th className="numeric-stats-table__cell">Standard Deviation</th>
-            <th className="numeric-stats-table__cell" />
           </tr>
         </thead>
         <tbody style={{ textAlign: "right" }}>
@@ -113,9 +112,8 @@ class NumericStatTable extends React.Component<NumericStatTableProps> {
               return (
                 <tr className={classNames}>
                   <th className="numeric-stats-table__cell" style={{ textAlign: "left" }}>{ row.name }</th>
-                  <td className="numeric-stats-table__cell">{ this.props.format(row.value.mean) }</td>
-                  <td className="numeric-stats-table__cell">{ this.props.format(stdDev(row.value, this.props.count)) }</td>
                   <td className="numeric-stats-table__cell">{ row.bar ? row.bar() : null }</td>
+                  <td className="numeric-stats-table__cell">{ this.props.format(stdDev(row.value, this.props.count)) }</td>
                 </tr>
               );
             })
@@ -257,22 +255,18 @@ class StatementDetails extends React.Component<StatementDetailsProps, StatementD
               <tbody>
                 <tr className="numeric-stats-table__row--body">
                   <th className="numeric-stats-table__cell" style={{ textAlign: "left" }}>First Attempts</th>
-                  <td className="numeric-stats-table__cell" style={{ textAlign: "right" }}>{ firstAttemptCount }</td>
                   <td className="numeric-stats-table__cell">{ firstAttemptsBarChart() }</td>
                 </tr>
                 <tr className="numeric-stats-table__row--body">
                   <th className="numeric-stats-table__cell" style={{ textAlign: "left" }}>Retries</th>
-                  <td className="numeric-stats-table__cell" style={{ textAlign: "right" }}>{ count - firstAttemptCount }</td>
                   <td className="numeric-stats-table__cell">{ retriesBarChart() }</td>
                 </tr>
                 <tr className="numeric-stats-table__row--body">
                   <th className="numeric-stats-table__cell" style={{ textAlign: "left" }}>Max Retries</th>
-                  <td className="numeric-stats-table__cell" style={{ textAlign: "right" }}>{ FixLong(stats.max_retries).toInt() }</td>
                   <td className="numeric-stats-table__cell">{ maxRetriesBarChart() }</td>
                 </tr>
                 <tr className="numeric-stats-table__row--body numeric-stats-table__row--summary">
                   <th className="numeric-stats-table__cell" style={{ textAlign: "left" }}>Total</th>
-                  <td className="numeric-stats-table__cell" style={{ textAlign: "right" }}>{ count }</td>
                   <td className="numeric-stats-table__cell">{ totalCountBarChart() }</td>
                 </tr>
               </tbody>

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -160,15 +160,13 @@ class StatementDetails extends React.Component<StatementDetailsProps, StatementD
             { "Details | " + (this.props.params[appAttr] ? this.props.params[appAttr] + " App | " : "") + "Statements" }
           </title>
         </Helmet>
-        <section className="section">
-          <h2>Statement Details</h2>
-          <Loading
-            loading={_.isNil(this.props.statement)}
-            className="loading-image loading-image__spinner"
-            image={spinner}
-            render={this.renderContent}
-          />
-        </section>
+        <section className="section"><h1>Statement Details</h1></section>
+        <Loading
+          loading={_.isNil(this.props.statement)}
+          className="loading-image loading-image__spinner"
+          image={spinner}
+          render={this.renderContent}
+        />
       </div>
     );
   }
@@ -212,7 +210,7 @@ class StatementDetails extends React.Component<StatementDetailsProps, StatementD
     return (
       <div className="content l-columns">
         <div className="l-columns__left">
-          <section className="section">
+          <section className="section section--heading">
             <SqlBox value={ statement } />
           </section>
           <section className="section">

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -164,12 +164,14 @@ class StatementDetails extends React.Component<StatementDetailsProps, StatementD
           </title>
         </Helmet>
         <section className="section"><h1>Statement Details</h1></section>
-        <Loading
-          loading={_.isNil(this.props.statement)}
-          className="loading-image loading-image__spinner"
-          image={spinner}
-          render={this.renderContent}
-        />
+        <section className="section section--container">
+          <Loading
+            loading={_.isNil(this.props.statement)}
+            className="loading-image loading-image__spinner"
+            image={spinner}
+            render={this.renderContent}
+          />
+        </section>
       </div>
     );
   }

--- a/pkg/ui/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/src/views/statements/statements.spec.tsx
@@ -229,9 +229,9 @@ describe("selectStatement", () => {
     assert.equal(result.statement, stmtA.key.key_data.query);
     assert.equal(result.stats.count.toNumber(), stmtA.stats.count.toNumber());
     assert.deepEqual(result.app, [stmtA.key.key_data.app]);
-    assert.deepEqual(result.distSQL, [stmtA.key.key_data.distSQL]);
-    assert.deepEqual(result.opt, [stmtA.key.key_data.opt]);
-    assert.deepEqual(result.failed, [stmtA.key.key_data.failed]);
+    assert.deepEqual(result.distSQL, { numerator: 0, denominator: 1 });
+    assert.deepEqual(result.opt, { numerator: 0, denominator: 1 });
+    assert.deepEqual(result.failed, { numerator: 0, denominator: 1 });
     assert.deepEqual(result.node_id, [stmtA.key.node_id]);
   });
 
@@ -248,9 +248,9 @@ describe("selectStatement", () => {
     assert.equal(result.statement, stmtA.key.key_data.query);
     assert.equal(result.stats.count.toNumber(), sumCount);
     assert.deepEqual(result.app, [stmtA.key.key_data.app, stmtB.key.key_data.app, stmtC.key.key_data.app]);
-    assert.deepEqual(result.distSQL, [stmtA.key.key_data.distSQL]);
-    assert.deepEqual(result.opt, [stmtA.key.key_data.opt]);
-    assert.deepEqual(result.failed, [stmtA.key.key_data.failed]);
+    assert.deepEqual(result.distSQL, { numerator: 0, denominator: 3 });
+    assert.deepEqual(result.opt, { numerator: 0, denominator: 3 });
+    assert.deepEqual(result.failed, { numerator: 0, denominator: 3 });
     assert.deepEqual(result.node_id, [stmtA.key.node_id]);
   });
 
@@ -270,9 +270,9 @@ describe("selectStatement", () => {
     assert.equal(result.statement, stmtA.key.key_data.query);
     assert.equal(result.stats.count.toNumber(), sumCount);
     assert.deepEqual(result.app, [stmtA.key.key_data.app]);
-    assert.deepEqual(result.distSQL, [stmtA.key.key_data.distSQL]);
-    assert.deepEqual(result.opt, [stmtA.key.key_data.opt]);
-    assert.deepEqual(result.failed, [stmtA.key.key_data.failed]);
+    assert.deepEqual(result.distSQL, { numerator: 0, denominator: 3 });
+    assert.deepEqual(result.opt, { numerator: 0, denominator: 3 });
+    assert.deepEqual(result.failed, { numerator: 0, denominator: 3 });
     assert.deepEqual(result.node_id, [1, 2, 3]);
   });
 
@@ -302,9 +302,9 @@ describe("selectStatement", () => {
     assert.equal(result.statement, stmtA.key.key_data.query);
     assert.equal(result.stats.count.toNumber(), sumCount);
     assert.deepEqual(result.app, [stmtA.key.key_data.app]);
-    assert.deepEqual(result.distSQL, [false, true]);
-    assert.deepEqual(result.opt, [false, true]);
-    assert.deepEqual(result.failed, [false, true]);
+    assert.deepEqual(result.distSQL, { numerator: 4, denominator: 8 });
+    assert.deepEqual(result.opt, { numerator: 4, denominator: 8 });
+    assert.deepEqual(result.failed, { numerator: 4, denominator: 8 });
     assert.deepEqual(result.node_id, [stmtA.key.node_id]);
   });
 
@@ -322,9 +322,9 @@ describe("selectStatement", () => {
     assert.equal(result.statement, stmtA.key.key_data.query);
     assert.equal(result.stats.count.toNumber(), stmtA.stats.count.toNumber());
     assert.deepEqual(result.app, [stmtA.key.key_data.app]);
-    assert.deepEqual(result.distSQL, [stmtA.key.key_data.distSQL]);
-    assert.deepEqual(result.opt, [stmtA.key.key_data.opt]);
-    assert.deepEqual(result.failed, [stmtA.key.key_data.failed]);
+    assert.deepEqual(result.distSQL, { numerator: 0, denominator: 1 });
+    assert.deepEqual(result.opt, { numerator: 0, denominator: 1 });
+    assert.deepEqual(result.failed, { numerator: 0, denominator: 1 });
     assert.deepEqual(result.node_id, [stmtA.key.node_id]);
   });
 
@@ -342,9 +342,9 @@ describe("selectStatement", () => {
     assert.equal(result.statement, stmtA.key.key_data.query);
     assert.equal(result.stats.count.toNumber(), stmtA.stats.count.toNumber());
     assert.deepEqual(result.app, [stmtA.key.key_data.app]);
-    assert.deepEqual(result.distSQL, [stmtA.key.key_data.distSQL]);
-    assert.deepEqual(result.opt, [stmtA.key.key_data.opt]);
-    assert.deepEqual(result.failed, [stmtA.key.key_data.failed]);
+    assert.deepEqual(result.distSQL, { numerator: 0, denominator: 1 });
+    assert.deepEqual(result.opt, { numerator: 0, denominator: 1 });
+    assert.deepEqual(result.failed, { numerator: 0, denominator: 1 });
     assert.deepEqual(result.node_id, [stmtA.key.node_id]);
   });
 });

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -45,8 +45,27 @@
     color $tooltip-color
     font-style italic
 
+.statements-table__col-count
+  .bar-chart
+    width 100px
+
+.statements-table__col-retries
+  .bar-chart
+    width 80px
+
+.numeric-stats-table, .statements-table__col-rows, .statements-table__col-latency
+  .bar-chart
+    width 140px
+
+.statements-table__col-count, .statements-table__col-retries, .statements-table__col-rows
+  .bar-chart
+    margin-left 3em
+
+    .label
+      left -3em
+      width 2.5em
+
 .bar-chart
-  width 140px
   height 14px
   margin-left 5em
   position relative

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -92,10 +92,10 @@
       height 3px
       top 6px
 
-  .count-first-try
+  .count-first-try, .count-total
     background-color $link-color
 
-  .count-retry
+  .count-retry, .count-max-retries
     background-color $alert-color
 
   .rows, .latency-parse, .latency-plan, .latency-run, .latency-overhead, .latency-overall

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -16,6 +16,10 @@
   text-decoration none
   color $link-color
 
+.statement-count-title, .last-cleared-title
+  padding 12px 24px
+  color $body-color
+
 .last-cleared-tooltip, .numeric-stats-table
   &__tooltip
     width 36px  // Reserve space for 10px padding around centered 16px icon

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -16,11 +16,18 @@
   text-decoration none
   color $link-color
 
-.last-cleared-tooltip
+.last-cleared-tooltip, .numeric-stats-table
   &__tooltip
     width 36px  // Reserve space for 10px padding around centered 16px icon
     height 16px
     display inline-block
+
+    // Overrides to let the tooltip sit inside a table header.
+    text-transform none
+    font-weight normal
+    white-space normal
+    letter-spacing normal
+    font-size 14px
 
   &__tooltip-hover-area
     width 100%

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -102,10 +102,34 @@
     background-color $link-color
 
   .rows-dev, .latency-parse-dev, .latency-plan-dev, .latency-run-dev, .latency-overhead-dev, .latency-overall-dev
-    background-color #F2C94C
+    background-color $warning-color
 
 .numeric-stats-table
   @extend $table-base
 
 .details-bar
   margin 12px 0
+
+.numeric-stat-legend
+  th
+    position relative
+    padding-left 24px
+    padding-right 5px
+
+  td
+    text-align right
+
+  &__bar
+    position absolute
+    width 21px
+    left 0
+
+    &--mean
+      height 14px
+      top 2px
+      background-color $link-color
+
+    &--dev
+      height 3px
+      top 8px
+      background-color $warning-color

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -107,6 +107,9 @@
 .numeric-stats-table
   @extend $table-base
 
+  &__row--summary
+    color $link-color
+
 .details-bar
   margin 12px 0
 

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -63,7 +63,11 @@
   .bar-chart
     width 80px
 
-.numeric-stats-table, .statements-table__col-rows, .statements-table__col-latency
+.numeric-stats-table
+  .bar-chart
+    width 200px
+
+.statements-table__col-rows, .statements-table__col-latency
   .bar-chart
     width 140px
 

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -46,8 +46,8 @@
     font-style italic
 
 .bar-chart
-  width 10em
-  height 1em
+  width 140px
+  height 14px
   margin-left 5em
   position relative
 
@@ -63,69 +63,24 @@
 
   &__bar
     display inline-block
-    height 1em
-    margin-left -1px
+    height 14px
 
     &--dev
       position absolute
-      height 0.6em
-      top 0.2em
+      height 3px
+      top 6px
 
   .count-first-try
     background-color $link-color
-    border-left 1px solid $link-color
 
   .count-retry
     background-color $alert-color
-    border-left 1px solid $alert-color
 
-  .rows
+  .rows, .latency-parse, .latency-plan, .latency-run, .latency-overhead, .latency-overall
     background-color $link-color
-    border-left 1px solid $link-color
 
-  .rows-dev
-    background-color lighten($link-color, 50%)
-    border-left 1px solid lighten($link-color, 50%)
-
-  .latency-parse
-    background-color $alert-color
-    border-left 1px solid $alert-color
-
-  .latency-parse-dev
-    background-color lighten($alert-color, 50%)
-    border-left 1px solid lighten($alert-color, 50%)
-
-  .latency-plan
-    background-color $warning-color
-    border-left 1px solid $warning-color
-
-  .latency-plan-dev
-    background-color lighten($warning-color, 50%)
-    border-left 1px solid lighten($warning-color, 50%)
-
-  .latency-run
-    background-color $link-color
-    border-left 1px solid $link-color
-
-  .latency-run-dev
-    background-color lighten($link-color, 50%)
-    border-left 1px solid lighten($link-color, 50%)
-
-  .latency-overhead
-    background-color $alert-color
-    border-left 1px solid $alert-color
-
-  .latency-overhead-dev
-    background-color lighten($alert-color, 50%)
-    border-left 1px solid lighten($alert-color, 50%)
-
-  .latency-overall
-    background-color $body-color
-    border-left 1px solid $body-color
-
-  .latency-overall-dev
-    background-color lighten($body-color, 50%)
-    border-left 1px solid lighten($body-color, 50%)
+  .rows-dev, .latency-parse-dev, .latency-plan-dev, .latency-run-dev, .latency-overhead-dev, .latency-overall-dev
+    background-color #F2C94C
 
 .numeric-stats-table
   @extend $table-base

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -40,11 +40,6 @@
     border-color $body-color
     color $body-color
 
-.bar-tooltip
-  &__tooptip-hover-area
-    width 100%
-    height 100%
-
 .app-name
   &__unset
     color $tooltip-color

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -45,6 +45,9 @@
     color $tooltip-color
     font-style italic
 
+.statements-table__col-time
+  text-align right
+
 .statements-table__col-count
   .bar-chart
     width 100px

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -123,7 +123,8 @@
   @extend $table-base
 
   &__row--summary
-    color $link-color
+    color black
+    font-weight bold
 
 .details-bar
   margin 12px 0

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -88,9 +88,6 @@
   margin-left 5em
   position relative
 
-  &--breakdown
-    margin-left 0
-
   .label
     position absolute
     left -5em
@@ -130,6 +127,8 @@
   margin 12px 0
 
 .numeric-stat-legend
+  white-space nowrap
+
   th
     position relative
     padding-left 24px

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -52,6 +52,8 @@
     color $body-color
 
 .app-name
+  white-space nowrap
+
   &__unset
     color $tooltip-color
     font-style italic

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -58,6 +58,7 @@
 
 .statements-table__col-time
   text-align right
+  white-space nowrap
 
 .statements-table__col-count
   .bar-chart

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -86,7 +86,7 @@ class StatementsPage extends React.Component<StatementsPageProps & RouteProps, S
 
     return (
       <React.Fragment>
-        <PageConfig>
+        <PageConfig layout="spread">
           <PageConfigItem>
             <Dropdown
               title="App"

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -85,7 +85,7 @@ class StatementsPage extends React.Component<StatementsPageProps & RouteProps, S
     );
 
     return (
-      <div className="statements">
+      <React.Fragment>
         <PageConfig>
           <PageConfigItem>
             <Dropdown
@@ -95,43 +95,52 @@ class StatementsPage extends React.Component<StatementsPageProps & RouteProps, S
               onChange={this.selectApp}
             />
           </PageConfigItem>
+          <PageConfigItem>
+            <h4 className="statement-count-title">
+              {this.props.statements.length}
+              {selectedApp ? ` of ${this.props.totalFingerprints} ` : " "}
+              statement fingerprints.
+            </h4>
+          </PageConfigItem>
+          <PageConfigItem>
+            <h4 className="last-cleared-title">
+              <div className="last-cleared-tooltip__tooltip">
+                <ToolTipWrapper text={lastClearedHelpText}>
+                  <div className="last-cleared-tooltip__tooltip-hover-area">
+                    <div className="last-cleared-tooltip__info-icon">i</div>
+                  </div>
+                </ToolTipWrapper>
+              </div>
+              Last cleared {this.props.lastReset}.
+            </h4>
+          </PageConfigItem>
         </PageConfig>
 
-        <div className="statements__last-hour-note" style={{ marginTop: 20 }}>
-          {this.props.statements.length}
-          {selectedApp ? ` of ${this.props.totalFingerprints} ` : " "}
-          statement fingerprints.
-          Last cleared {this.props.lastReset}.
-          <div className="last-cleared-tooltip__tooltip">
-            <ToolTipWrapper text={lastClearedHelpText}>
-              <div className="last-cleared-tooltip__tooltip-hover-area">
-                <div className="last-cleared-tooltip__info-icon">i</div>
-              </div>
-            </ToolTipWrapper>
-          </div>
-        </div>
-
-        <StatementsSortedTable
-          className="statements-table"
-          data={this.props.statements}
-          columns={makeStatementsColumns(this.props.statements, selectedApp)}
-          sortSetting={this.state.sortSetting}
-          onChangeSortSetting={this.changeSortSetting}
-        />
-      </div>
+        <section className="section">
+          <StatementsSortedTable
+            className="statements-table"
+            data={this.props.statements}
+            columns={makeStatementsColumns(this.props.statements, selectedApp)}
+            sortSetting={this.state.sortSetting}
+            onChangeSortSetting={this.changeSortSetting}
+          />
+        </section>
+      </React.Fragment>
     );
   }
 
   render() {
     return (
-      <section className="section" style={{ maxWidth: "none" }}>
+      <React.Fragment>
         <Helmet>
           <title>
             { this.props.params[appAttr] ? this.props.params[appAttr] + " App | Statements" : "Statements"}
           </title>
         </Helmet>
 
-        <h1 style={{ marginBottom: 20 }}>Statements</h1>
+        <section className="section">
+          <h1>Statements</h1>
+        </section>
 
         <Loading
           loading={_.isNil(this.props.statements)}
@@ -139,7 +148,7 @@ class StatementsPage extends React.Component<StatementsPageProps & RouteProps, S
           image={spinner}
           render={this.renderStatements}
         />
-      </section>
+      </React.Fragment>
     );
   }
 }

--- a/pkg/ui/src/views/statements/statementsTable.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.tsx
@@ -45,6 +45,7 @@ function shortStatement(summary: StatementSummary, original: string) {
     case "select": return "SELECT FROM " + summary.table;
     case "delete": return "DELETE FROM " + summary.table;
     case "create": return "CREATE TABLE " + summary.table;
+    case "set": return "SET " + summary.table;
     default: return original;
   }
 }

--- a/pkg/ui/src/views/statements/statementsTable.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.tsx
@@ -74,7 +74,7 @@ function NodeLink(props: { nodeId: string, nodeNames: { [nodeId: string]: string
   return (
     <Link to={ `/node/${props.nodeId}` }>
       <div className="node-name__tooltip">
-        <ToolTipWrapper text={props.nodeNames[props.nodeId]}>
+        <ToolTipWrapper text={props.nodeNames[props.nodeId]} short>
           <div className="node-name-tooltip__tooltip-hover-area">
             <div className="node-name-tooltip__info-icon">n{props.nodeId}</div>
           </div>

--- a/pkg/ui/src/views/statements/statementsTable.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.tsx
@@ -89,7 +89,18 @@ export function makeNodesColumns(statements: AggregateStatistics[], nodeNames: {
     : ColumnDescriptor<AggregateStatistics>[] {
   const original: ColumnDescriptor<AggregateStatistics>[] = [
     {
-      title: "Node",
+      title: (
+        <React.Fragment>
+          Node
+          <div className="numeric-stats-table__tooltip">
+            <ToolTipWrapper text="Statement statistics grouped by which node received the request for the statement.">
+              <div className="numeric-stats-table__tooltip-hover-area">
+                <div className="numeric-stats-table__info-icon">i</div>
+              </div>
+            </ToolTipWrapper>
+          </div>
+        </React.Fragment>
+      ),
       cell: (stmt) => <NodeLink nodeId={ stmt.label } nodeNames={ nodeNames } />,
       sort: (stmt) => stmt.label,
     },

--- a/pkg/ui/styl/layout/layout.styl
+++ b/pkg/ui/styl/layout/layout.styl
@@ -49,14 +49,23 @@ $page-padding-top   = 20px
 
   z-index $z-index-page-config
   background-color $background-color
+  max-width 1350px
 
   &__list
-    clearfix()
+    display flex
+    justify-content flex-start
+    align-items center
+
+    .page-config__item
+      margin-right 24px
+
+  &__spread
+    display flex
+    justify-content space-between
+    align-items center
 
   &__item
-    float left
     list-style none
-    margin-right 24px
 
 .l-columns
   display flex

--- a/pkg/ui/styl/layout/layout.styl
+++ b/pkg/ui/styl/layout/layout.styl
@@ -93,6 +93,9 @@ $page-padding-top   = 20px
     padding-top 0
     padding-bottom 0
 
+  &--container
+    padding 0 24px 0 0
+
 .parent-link a
   color $link-color
   font-size 14px


### PR DESCRIPTION
Included are a variety of updates to the Statements list and details pages, working to make these pages as immediately useful as possible.

List page, before:
<img width="1643" alt="screen shot 2018-08-28 at 3 03 46 pm" src="https://user-images.githubusercontent.com/793969/44744784-eadd6780-aad3-11e8-947f-065fbfcfc748.png">

List page, after:
<img width="1411" alt="screen shot 2018-09-05 at 5 05 15 pm" src="https://user-images.githubusercontent.com/793969/45121064-f7923900-b12d-11e8-97c1-801019ef93aa.png">

Details page, before:
<img width="1106" alt="screen shot 2018-08-28 at 3 03 35 pm" src="https://user-images.githubusercontent.com/793969/44744791-ef098500-aad3-11e8-9793-178ca9dbe8a5.png">

Details page, after:
<img width="1413" alt="screen shot 2018-09-05 at 5 05 32 pm" src="https://user-images.githubusercontent.com/793969/45121072-fd881a00-b12d-11e8-8242-7845ec529d3b.png">

