### PR TITLE
ui: allow long table rows to wrap

### DIFF
--- a/pkg/ui/src/views/shared/util/table.styl
+++ b/pkg/ui/src/views/shared/util/table.styl
@@ -16,7 +16,6 @@ $table-base
   font-weight 300
   font-size 14px
   vertical-align top
-  white-space nowrap
   color $stats-table-td--fg
 
   &__row


### PR DESCRIPTION
Fixes: #29132

Release note (admin ui change): Allow long table rows to wrap, if necessary.

Before:
<img width="1351" alt="screen shot 2018-08-27 at 12 19 04 pm" src="https://user-images.githubusercontent.com/7085343/44674574-8e0a8000-a9f3-11e8-8b2a-72358f65c098.png">

After:
<img width="1159" alt="screen shot 2018-08-28 at 3 30 49 pm" src="https://user-images.githubusercontent.com/793969/44746086-67be1080-aad7-11e8-8616-158de5354fe1.png">
