### PR TITLE
sql, importccl: allow and use AS OF SYSTEM TIME in EXPORT's query

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -671,6 +671,8 @@ func (p *planner) isAsOf(stmt tree.Statement, max hlc.Timestamp) (*hlc.Timestamp
 			return nil, nil
 		}
 		asOf = s.AsOf
+	case *tree.Export:
+		return p.isAsOf(s.Query, max)
 	default:
 		return nil, nil
 	}


### PR DESCRIPTION
Ideally EXPORT is just like a normal SELECT, including any AS OF SYSTEM TIME, just with the output redirected to cloud storage.

Release note: none.