### PR TITLE
sql: don't startExec planHook subplans

### DIFF
--- a/pkg/ccl/importccl/exportcsv_test.go
+++ b/pkg/ccl/importccl/exportcsv_test.go
@@ -168,3 +168,25 @@ func TestExportJoin(t *testing.T) {
 	sqlDB.Exec(t, `CREATE TABLE t AS VALUES (1, 2)`)
 	sqlDB.Exec(t, `EXPORT INTO CSV 'nodelocal:///join' FROM SELECT * FROM t, t as u`)
 }
+
+func TestExportOrder(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	dir, cleanupDir := testutils.TempDir(t)
+	defer cleanupDir()
+
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{ExternalIODir: dir})
+	defer srv.Stopper().Stop(context.Background())
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	sqlDB.Exec(t, `create table foo (i int primary key, x int, y int, z int, index (y))`)
+	sqlDB.Exec(t, `insert into foo values (1, 12, 3, 14), (2, 22, 2, 24), (3, 32, 1, 34)`)
+
+	sqlDB.Exec(t, `EXPORT INTO CSV 'nodelocal:///order' from select * from foo order by y asc limit 2`)
+	content, err := ioutil.ReadFile(filepath.Join(dir, "order", "n1.0.csv"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expected, got := "3,32,1,34\n2,22,2,24\n", string(content); expected != got {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -130,12 +130,6 @@ func (f *hookFnNode) startExec(params runParams) error {
 	// TODO(dan): Make sure the resultCollector is set to flush after every row.
 	f.run.resultsCh = make(chan tree.Datums)
 	f.run.errCh = make(chan error)
-	// Since hook plans are opaque to the plan walker, these haven't been started.
-	for _, sub := range f.subplans {
-		if err := startExec(params, sub); err != nil {
-			return err
-		}
-	}
 	go func() {
 		err := f.f(params.ctx, f.subplans, f.run.resultsCh)
 		select {

--- a/pkg/sql/tests/planhook.go
+++ b/pkg/sql/tests/planhook.go
@@ -37,24 +37,11 @@ func init() {
 		header := sqlbase.ResultColumns{
 			{Name: "value", Typ: types.String},
 		}
-		rows := tree.Exprs{tree.NewStrVal(show.Name)}
-		sel := &tree.Select{Select: &tree.ValuesClause{Rows: []tree.Exprs{rows}}}
-		subPlan, err := state.Select(ctx, sel, nil)
 
 		return func(_ context.Context, subPlans []sql.PlanNode, resultsCh chan<- tree.Datums) error {
-			for {
-				ok, err := subPlans[0].Next(state.RunParams(ctx))
-				if err != nil {
-					return err
-				}
-				if !ok {
-					break
-				}
-				resultsCh <- subPlans[0].Values()
-			}
-			subPlans[0].Close(ctx)
+			resultsCh <- tree.Datums{tree.NewDString(show.Name)}
 			return nil
-		}, header, []sql.PlanNode{subPlan}, err
+		}, header, []sql.PlanNode{}, nil
 	}
 	sql.AddPlanHook(testingPlanHook)
 }


### PR DESCRIPTION
Sub-plans of hooked plans are never run locally, so they do not want to be started.
Sub-plans are only ever used as the basis for distsql planning which is run my the
hook functions directly.

Fixes #29024.

Release note: none.