### PR TITLE
backport-2.1: cli: Fix support for deprecated --http-host flag

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -271,23 +271,25 @@ func init() {
 		VarFlag(f, aliasStrVar{&serverListenPort}, cliflags.ServerPort)
 		if markDeprecated {
 			_ = f.MarkDeprecated(cliflags.ServerHost.Name, "use --listen-addr/--advertise-addr instead.")
-			_ = f.MarkDeprecated(cliflags.ServerPort.Name, "use --listen-addr instead.")
+			_ = f.MarkDeprecated(cliflags.ServerPort.Name, "use --listen-addr=...:<port> instead.")
 		}
 
 		VarFlag(f, addrSetter{&serverAdvertiseAddr, &serverAdvertisePort}, cliflags.AdvertiseAddr)
 		VarFlag(f, aliasStrVar{&serverAdvertiseAddr}, cliflags.AdvertiseHost)
+		VarFlag(f, aliasStrVar{&serverAdvertisePort}, cliflags.AdvertisePort)
 		if markDeprecated {
 			_ = f.MarkDeprecated(cliflags.AdvertiseHost.Name, "use --advertise-addr instead.")
+			_ = f.MarkDeprecated(cliflags.AdvertisePort.Name, "use --advertise-addr=...:<port> instead.")
 		}
 
-		StringFlag(f, &serverAdvertisePort, cliflags.AdvertisePort, serverAdvertisePort)
 		VarFlag(f, &localityAdvertiseHosts, cliflags.LocalityAdvertiseAddr)
 		if markDeprecated {
 			_ = f.MarkDeprecated(cliflags.AdvertisePort.Name, "use --advertise-addr=...:<port> instead.")
 		}
 
 		VarFlag(f, addrSetter{&serverHTTPAddr, &serverHTTPPort}, cliflags.ListenHTTPAddr)
-		StringFlag(f, &serverHTTPPort, cliflags.ListenHTTPPort, serverHTTPPort)
+		VarFlag(f, aliasStrVar{&serverHTTPAddr}, cliflags.ListenHTTPAddrAlias)
+		VarFlag(f, aliasStrVar{&serverHTTPPort}, cliflags.ListenHTTPPort)
 		if markDeprecated {
 			_ = f.MarkDeprecated(cliflags.ListenHTTPAddrAlias.Name, "use --http-addr instead.")
 			_ = f.MarkDeprecated(cliflags.ListenHTTPPort.Name, "use --http-addr=...:<port> instead.")

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
@@ -294,6 +295,12 @@ func TestHttpHostFlagValue(t *testing.T) {
 	}{
 		{[]string{"start", "--" + cliflags.ListenHTTPAddr.Name, "127.0.0.1"}, "127.0.0.1:" + base.DefaultHTTPPort},
 		{[]string{"start", "--" + cliflags.ListenHTTPAddr.Name, "192.168.0.111"}, "192.168.0.111:" + base.DefaultHTTPPort},
+		// confirm --http-host still works
+		{[]string{"start", "--" + cliflags.ListenHTTPAddrAlias.Name, "127.0.0.1"}, "127.0.0.1:" + base.DefaultHTTPPort},
+		{[]string{"start", "--" + cliflags.ListenHTTPAddr.Name, ":12345", "--" + cliflags.ListenHTTPAddrAlias.Name, "192.168.0.111"}, "192.168.0.111:12345"},
+		// confirm --http-port still works
+		{[]string{"start", "--" + cliflags.ListenHTTPPort.Name, "12345"}, ":12345"},
+		{[]string{"start", "--" + cliflags.ListenHTTPAddr.Name, "192.168.0.111", "--" + cliflags.ListenHTTPPort.Name, "12345"}, "192.168.0.111:12345"},
 		// confirm hostnames will work
 		{[]string{"start", "--" + cliflags.ListenHTTPAddr.Name, "my.host.name"}, "my.host.name:" + base.DefaultHTTPPort},
 		{[]string{"start", "--" + cliflags.ListenHTTPAddr.Name, "myhostname"}, "myhostname:" + base.DefaultHTTPPort},

--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -48,7 +48,7 @@ end_test
 
 start_test "Check that server --port causes a deprecation warning."
 send "$argv start --insecure --port=26257\r"
-eexpect "port has been deprecated, use --listen-addr instead."
+eexpect "port has been deprecated, use --listen-addr=...:<port> instead."
 eexpect "node starting"
 interrupt
 eexpect ":/# "
@@ -56,7 +56,7 @@ end_test
 
 start_test "Check that server --advertise-port causes a deprecation warning."
 send "$argv start --insecure --advertise-port=12345\r"
-eexpect "advertise-port has been deprecated, use --advertise-addr"
+eexpect "advertise-port has been deprecated, use --advertise-addr=...:<port> instead."
 eexpect "node starting"
 interrupt
 eexpect ":/# "


### PR DESCRIPTION
Backport 1/1 commits from #29213.

/cc @cockroachdb/release

---

It looks like we accidentally stopped registering the --http-host flag
in the cli package's init function recently, which completely removed
support for --http-host rather than the intended effect of deprecating
(but continuing to allow) it.

Also make the handling of deprecated/alias flags more consistent with
each other while I'm here.

Release note (bug fix): Fix support for --http-host flag that was broken
in previous 2.1 beta releases.
