### PR TITLE
backport-2.1: storage: deflake TestReplicateQueueRebalance

### DIFF
--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -45,7 +45,17 @@ func TestReplicateQueueRebalance(t *testing.T) {
 
 	const numNodes = 5
 	tc := testcluster.StartTestCluster(t, numNodes,
-		base.TestClusterArgs{ReplicationMode: base.ReplicationAuto},
+		base.TestClusterArgs{
+			ReplicationMode: base.ReplicationAuto,
+			ServerArgs: base.TestServerArgs{
+				Knobs: base.TestingKnobs{
+					Store: &storage.StoreTestingKnobs{
+						// Prevent the merge queue from immediately discarding our splits.
+						DisableMergeQueue: true,
+					},
+				},
+			},
+		},
 	)
 	defer tc.Stopper().Stop(context.TODO())
 


### PR DESCRIPTION
Backport 1/1 commits from #29221.

/cc @cockroachdb/release

---

Temporarily disable the merge queue in this test.

Fixes #28563

Release note: None
