### PR TITLE
backport-2.1: sql: fix two bugs with TRUNCATE

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -343,7 +343,7 @@ func (sc *SchemaChanger) getJobIDForMutation(
 			return makeErrTableVersionMismatch(tableDesc.Version, version)
 		}
 
-		jobID, err = sc.getJobIDForMutationWithDescriptor(ctx, tableDesc, mutationID)
+		jobID, err = getJobIDForMutationWithDescriptor(ctx, tableDesc, mutationID)
 		return err
 	})
 	return jobID, err
@@ -351,7 +351,7 @@ func (sc *SchemaChanger) getJobIDForMutation(
 
 // getJobIDForMutationWithDescriptor returns a job id associated with a mutation given
 // a table descriptor. Unlike getJobIDForMutation this doesn't need transaction.
-func (sc *SchemaChanger) getJobIDForMutationWithDescriptor(
+func getJobIDForMutationWithDescriptor(
 	ctx context.Context, tableDesc *sqlbase.TableDescriptor, mutationID sqlbase.MutationID,
 ) (int64, error) {
 	for _, job := range tableDesc.MutationJobs {
@@ -360,7 +360,7 @@ func (sc *SchemaChanger) getJobIDForMutationWithDescriptor(
 		}
 	}
 
-	return 0, errors.Errorf("job not found for table id %d, mutation %d", sc.tableID, mutationID)
+	return 0, errors.Errorf("job not found for table id %d, mutation %d", tableDesc.ID, mutationID)
 }
 
 // nRanges returns the number of ranges that cover a set of spans.

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -101,7 +101,7 @@ func doCreateSequence(
 	// desc.ValidateTable() needed here.
 
 	key := getSequenceKey(dbDesc, name.Table()).Key()
-	if err = params.p.createDescriptorWithID(params.ctx, key, id, &desc); err != nil {
+	if err = params.p.createDescriptorWithID(params.ctx, key, id, &desc, params.EvalContext().Settings); err != nil {
 		return err
 	}
 

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -148,13 +148,6 @@ func (n *createTableNode) startExec(params runParams) error {
 		return err
 	}
 
-	// We need to validate again after adding the FKs.
-	// Only validate the table because backreferences aren't created yet.
-	// Everything is validated below.
-	if err := desc.ValidateTable(params.EvalContext().Settings); err != nil {
-		return err
-	}
-
 	if desc.Adding() {
 		// if this table and all its references are created in the same
 		// transaction it can be made PUBLIC.
@@ -175,7 +168,8 @@ func (n *createTableNode) startExec(params runParams) error {
 	}
 
 	// Descriptor written to store here.
-	if err := params.p.createDescriptorWithID(params.ctx, key, id, &desc); err != nil {
+	if err := params.p.createDescriptorWithID(
+		params.ctx, key, id, &desc, params.EvalContext().Settings); err != nil {
 		return err
 	}
 

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -146,16 +146,13 @@ func (n *createViewNode) startExec(params runParams) error {
 		return err
 	}
 
-	if err = desc.ValidateTable(params.EvalContext().Settings); err != nil {
-		return err
-	}
-
 	// Collect all the tables/views this view depends on.
 	for backrefID := range n.planDeps {
 		desc.DependsOn = append(desc.DependsOn, backrefID)
 	}
 
-	if err = params.p.createDescriptorWithID(params.ctx, key, id, &desc); err != nil {
+	if err = params.p.createDescriptorWithID(
+		params.ctx, key, id, &desc, params.EvalContext().Settings); err != nil {
 		return err
 	}
 

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -253,13 +253,6 @@ func (dc *databaseCache) getDatabaseID(
 	return desc.ID, nil
 }
 
-// createDatabase implements the DatabaseDescEditor interface.
-func (p *planner) createDatabase(
-	ctx context.Context, desc *sqlbase.DatabaseDescriptor, ifNotExists bool,
-) (bool, error) {
-	return p.createDescriptor(ctx, databaseKey{desc.Name}, desc, ifNotExists)
-}
-
 // renameDatabase implements the DatabaseDescEditor interface.
 func (p *planner) renameDatabase(
 	ctx context.Context, oldDesc *sqlbase.DatabaseDescriptor, newName string,

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -233,13 +233,10 @@ func (p *planner) truncateTable(ctx context.Context, id sqlbase.ID, traceKV bool
 	}
 	newTableDesc.Mutations = nil
 
-	if err = newTableDesc.ValidateTable(p.ExtendedEvalContext().Settings); err != nil {
-		return err
-	}
-
 	tKey := tableKey{parentID: newTableDesc.ParentID, name: newTableDesc.Name}
 	key := tKey.Key()
-	if err := p.createDescriptorWithID(ctx, key, newID, &newTableDesc); err != nil {
+	if err := p.createDescriptorWithID(
+		ctx, key, newID, &newTableDesc, p.ExtendedEvalContext().Settings); err != nil {
 		return err
 	}
 

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -229,16 +229,14 @@ func (p *planner) truncateTable(ctx context.Context, id sqlbase.ID, traceKV bool
 	// Resolve all outstanding mutations. Make all new schema elements
 	// public because the table is empty and doesn't need to be backfilled.
 	for _, m := range newTableDesc.Mutations {
-		if m.Direction == sqlbase.DescriptorMutation_ADD {
-			if col := m.GetColumn(); col != nil {
-				newTableDesc.Columns = append(newTableDesc.Columns, *col)
-			}
-			if idx := m.GetIndex(); idx != nil {
-				newTableDesc.Indexes = append(newTableDesc.Indexes, *idx)
-			}
-		}
+		newTableDesc.MakeMutationComplete(m)
 	}
 	newTableDesc.Mutations = nil
+
+	if err = newTableDesc.ValidateTable(p.ExtendedEvalContext().Settings); err != nil {
+		return err
+	}
+
 	tKey := tableKey{parentID: newTableDesc.ParentID, name: newTableDesc.Name}
 	key := tKey.Key()
 	if err := p.createDescriptorWithID(ctx, key, newID, &newTableDesc); err != nil {


### PR DESCRIPTION
Backport 3/3 commits from #28721.

/cc @cockroachdb/release

---

sql: correctly resolve schema mutations during TRUNCATE
related to #27687

sql: mark schema change job as successful when table DROP/TRUNCATE
The job is modified in the same transaction as the user's DROP/TRUNCATE transaction.

