### PR TITLE
backport-2.1: sql: add job id to ROLL BACK job for schema change

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -69,12 +69,12 @@ ALTER TABLE t ADD CONSTRAINT bar UNIQUE (c)
 
 # Test that rollback was successful
 query TTTTRT
-SELECT job_type, description, user_name, status, fraction_completed::decimal(10,2), error
+SELECT job_type, regexp_replace(description, 'JOB \d+', 'JOB ...'), user_name, status, fraction_completed::decimal(10,2), error
 FROM crdb_internal.jobs
 ORDER BY created DESC
 LIMIT 2
 ----
-SCHEMA CHANGE  ROLL BACK ALTER TABLE test.public.t ADD CONSTRAINT bar UNIQUE (c)  root  succeeded  1.00  ·
+SCHEMA CHANGE  ROLL BACK JOB ...: ALTER TABLE test.public.t ADD CONSTRAINT bar UNIQUE (c)  root  succeeded  1.00  ·
 SCHEMA CHANGE  ALTER TABLE test.public.t ADD CONSTRAINT bar UNIQUE (c)            root  failed     0.00  duplicate key value (c)=(1) violates unique constraint "bar"
 
 query IIII colnames,rowsort

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1028,7 +1028,7 @@ func (sc *SchemaChanger) createRollbackJob(
 			}
 			payload := job.Payload()
 			rollbackJob := sc.jobRegistry.NewJob(jobs.Record{
-				Description:   "ROLL BACK " + payload.Description,
+				Description:   fmt.Sprintf("ROLL BACK JOB %d: %s", *job.ID(), payload.Description),
 				Username:      payload.Username,
 				DescriptorIDs: payload.DescriptorIDs,
 				Details:       jobspb.SchemaChangeDetails{ResumeSpanList: spanList},

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1907,10 +1907,13 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 		}
 	}
 
+	jobRolledBack := 0
+	jobID := jobutils.GetJobID(t, &runner, jobRolledBack)
+
 	// Roll back job.
 	if err := jobutils.VerifySystemJob(t, &runner, len(testCases), jobspb.TypeSchemaChange, jobs.StatusSucceeded, jobs.Record{
 		Username:    security.RootUser,
-		Description: "ROLL BACK " + testCases[0].sql,
+		Description: fmt.Sprintf("ROLL BACK JOB %d: %s", jobID, testCases[jobRolledBack].sql),
 		DescriptorIDs: sqlbase.IDs{
 			tableDesc.ID,
 		},
@@ -3388,10 +3391,11 @@ func TestCancelSchemaChange(t *testing.T) {
 			}); err != nil {
 				t.Fatal(err)
 			}
+			jobID := jobutils.GetJobID(t, sqlDB, idx)
 			idx++
 			if err := jobutils.VerifySystemJob(t, sqlDB, idx, jobspb.TypeSchemaChange, jobs.StatusSucceeded, jobs.Record{
 				Username:    security.RootUser,
-				Description: "ROLL BACK " + tc.sql,
+				Description: fmt.Sprintf("ROLL BACK JOB %d: %s", jobID, tc.sql),
 				DescriptorIDs: sqlbase.IDs{
 					tableDesc.ID,
 				},

--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -175,6 +175,15 @@ func VerifySystemJob(
 	return nil
 }
 
+// GetJobID gets a particular job's ID.
+func GetJobID(t testing.TB, db *sqlutils.SQLRunner, offset int) int64 {
+	var jobID int64
+	db.QueryRow(t, `
+	SELECT job_id FROM crdb_internal.jobs ORDER BY created LIMIT 1 OFFSET $1`, offset,
+	).Scan(&jobID)
+	return jobID
+}
+
 // GetJobProgress loads the Progress message associated with the job.
 func GetJobProgress(t *testing.T, db *sqlutils.SQLRunner, jobID int64) *jobspb.Progress {
 	ret := &jobspb.Progress{}


### PR DESCRIPTION
Backport 1/1 commits from #28857.

/cc @cockroachdb/release

---

this will allow a user to know what original job
the roll back job is referring to.

Release note: None
