### PR TITLE
roachtest: clean up mixed version roachtest

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -827,8 +827,11 @@ func (c *cluster) Start(ctx context.Context, opts ...option) {
 		args = append(args, "--encrypt")
 	}
 	if local {
-		// This avoids annoying firewall prompts on macos
-		args = append(args, "--args", "--listen-addr=127.0.0.1")
+		// This avoids annoying firewall prompts on macos.
+		// NB: we have to use the deprecated --host flag here
+		// (and not --listen-addr) until we don't run any mixed
+		// version tests involving v2.0 any more.
+		args = append(args, "--args", "--host=127.0.0.1")
 	}
 	if err := execCmd(ctx, c.l, args...); err != nil {
 		c.t.Fatal(err)

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -271,7 +271,7 @@ func registerVersion(r *registry) {
 		}
 	}
 
-	const version = "v2.0.0"
+	const version = "v2.0.5"
 	for _, n := range []int{3, 5} {
 		r.Add(testSpec{
 			Name:       fmt.Sprintf("version/mixedWith=%s/nodes=%d", version, n),

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -18,14 +18,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"runtime"
 	"strconv"
 	"time"
 
 	_ "github.com/lib/pq"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/cockroachdb/cockroach/pkg/util/binfetcher"
 )
@@ -85,48 +82,25 @@ func registerVersion(r *registry) {
 		loadDuration := " --duration=" + (time.Duration(3*nodes+2)*stageDuration + buffer).String()
 
 		workloads := []string{
-			"./workload run tpcc --tolerate-errors --init --warehouses=1" + loadDuration + " {pgurl:1-%d}",
-			// TODO(tschottdorf): adding `--splits=10000` results in a barrage of messages of the type:
-			//
-			// W180301 04:25:28.785116 21 workload/workload.go:323  ALTER TABLE kv
-			// SCATTER FROM (-7199834944475770217) TO (-7199834944475770217): pq:
-			// kv/dist_sender.go:918: truncation resulted in empty batch on
-			// /Table/52/1/-71998349444
-			//
-			// Perhaps the scatter invocation is wrong (it has FROM==TO), but this
-			// looks concerning.
+			"./workload run tpcc --tolerate-errors --wait=false --drop --init --warehouses=1 " + loadDuration + " {pgurl:1-%d}",
 			"./workload run kv --tolerate-errors --init" + loadDuration + " {pgurl:1-%d}",
 		}
 
-		// TODO(tschottdorf): `c.newMonitor` is far from suitable for tests that actually restart nodes
-		// and trying to fix it up does not seem worth it. What would work well here is a monitor that
-		// connects directly to the nodes' PG endpoints and polls their uptime, informing a callback as
-		// needed.
-		var m *errgroup.Group
-		m, ctx = errgroup.WithContext(ctx)
+		m := newMonitor(ctx, c, c.Range(1, nodes))
 		for i, cmd := range workloads {
 			cmd := cmd // loop-local copy
 			i := i     // ditto
-			m.Go(func() error {
+			m.Go(func(ctx context.Context) error {
 				cmd = fmt.Sprintf(cmd, nodes)
-				// TODO(tschottdorf): we need to be able to cleanly terminate processes we
-				// started. In this test, we'd like to send a signal to workload when the
-				// upgrade goroutine has decided the time has come. Perhaps context
-				// cancellation can be used for that purpose, but it doesn't seem quite
-				// right. For now, hold over water with durations, but those don't measure
-				// init time correctly (which can be quite substantial).
-				// TODO(tschottdorf): It's a bit silly that we use a dedicated load gen
-				// machine here, but `c.Stop` calls `roachprod stop` and that kills
-				// *everything* on that machine, not just the cockroach process.
-				quietL, err := newLogger(cmd, strconv.Itoa(i), "workload"+strconv.Itoa(i), ioutil.Discard, os.Stderr)
+				childL, err := c.l.childLogger("workload " + strconv.Itoa(i))
 				if err != nil {
 					return err
 				}
-				return c.RunL(ctx, quietL, c.Node(nodes+1), cmd)
+				return c.RunL(ctx, childL, c.Node(nodes+1), cmd)
 			})
 		}
 
-		m.Go(func() error {
+		m.Go(func(ctx context.Context) error {
 			l, err := c.l.childLogger("upgrader")
 			if err != nil {
 				return err
@@ -164,6 +138,7 @@ func registerVersion(r *registry) {
 			}
 
 			stop := func(node int) error {
+				m.ExpectDeath()
 				l.printf("stopping node %d\n", node)
 				port := fmt.Sprintf("{pgport:%d}", node)
 				// Note that the following command line needs to run against both v2.0
@@ -266,9 +241,7 @@ func registerVersion(r *registry) {
 
 			return sleepAndCheck()
 		})
-		if err := m.Wait(); err != nil {
-			t.Fatal(err)
-		}
+		m.Wait()
 	}
 
 	const version = "v2.0.5"

--- a/pkg/workload/tpcc/ddls.go
+++ b/pkg/workload/tpcc/ddls.go
@@ -163,7 +163,7 @@ const (
 func maybeDisableMergeQueue(db *gosql.DB) error {
 	var ok bool
 	if err := db.QueryRow(
-		`SELECT count(*) > 0 FROM [ SHOW ALL CLUSTER SETTINGS ] WHERE variable = 'kv.range_merge.queue_enabled'`,
+		`SELECT count(*) > 0 FROM [ SHOW ALL CLUSTER SETTINGS ] AS _ (v) WHERE v = 'kv.range_merge.queue_enabled'`,
 	).Scan(&ok); err != nil || !ok {
 		return err
 	}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -363,7 +363,7 @@ func Setup(
 func maybeDisableMergeQueue(db *gosql.DB) error {
 	var ok bool
 	if err := db.QueryRow(
-		`SELECT count(*) > 0 FROM [ SHOW ALL CLUSTER SETTINGS ] WHERE variable = 'kv.range_merge.queue_enabled'`,
+		`SELECT count(*) > 0 FROM [ SHOW ALL CLUSTER SETTINGS ] AS _ (v) WHERE v = 'kv.range_merge.queue_enabled'`,
 	).Scan(&ok); err != nil || !ok {
 		return err
 	}


### PR DESCRIPTION
Reverts a tiny part of #27800.

Fixes #29260.
Fixes #29261.

Release note: None