### PR TITLE
workload,cli: whitelist subcommands for public consumption

### DIFF
--- a/pkg/ccl/workloadccl/cliccl/fixtures.go
+++ b/pkg/ccl/workloadccl/cliccl/fixtures.go
@@ -36,9 +36,8 @@ import (
 var useast1bFixtures = workloadccl.FixtureConfig{
 	// TODO(dan): Keep fixtures in more than one region to better support
 	// geo-distributed clusters.
-	GCSBucket:      `cockroach-fixtures`,
-	GCSPrefix:      `workload`,
-	BillingProject: `cockroach-shared`,
+	GCSBucket: `cockroach-fixtures`,
+	GCSPrefix: `workload`,
 }
 
 func config() workloadccl.FixtureConfig {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -178,7 +178,7 @@ func init() {
 		versionCmd,
 		DebugCmd,
 		sqlfmtCmd,
-		workloadcli.WorkloadCmd(),
+		workloadcli.WorkloadCmd(true /* userFacing */),
 	)
 }
 

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1801,7 +1801,7 @@ Available Commands:
   version     output version information
   debug       debugging commands
   sqlfmt      format SQL statements
-  workload    generators for data and query loads
+  workload    [experimental] generators for data and query loads
   help        Help about any command
 
 Flags:

--- a/pkg/cmd/workload/main.go
+++ b/pkg/cmd/workload/main.go
@@ -24,7 +24,7 @@ import (
 )
 
 func main() {
-	if err := workloadcli.WorkloadCmd().Execute(); err != nil {
+	if err := workloadcli.WorkloadCmd(false /* userFacing */).Execute(); err != nil {
 		// Cobra has already printed the error message.
 		os.Exit(1)
 	}


### PR DESCRIPTION
Previously, everything in the internal workload tree was exposed when it
was registered as a subcommand of cockroach. Now just whitelist `init`
and `run`.

`fixtures load` will be useful, but needs a bit more work on our end to
curate a new bucket for public fixtures (or, less likely, expose our
current internal one). Perhaps we'll whitelist it in some 2.1.x release.
The stuff to make fixtures is probably too niche to expose anytime soon.

Since I'm now thinking that our internal fixtures bucket is not likely
to become requestor pays in the near future, also remove it as a the
default billing project (which is spamming up various outputs with
`?GOOGLE_BILLING_PROJECT=...`).

Also stick an `[experimental]` prefix on the help text in case we want
to change some of these. They're also not yet tested to our normal
levels.

Release note: None