### PR TITLE
release-2.1: testutils/lint: add a nightly lint test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -910,7 +910,7 @@ lint: bin/returncheck
 	@# packages. In Go 1.10, only 'go vet' recompiles on demand. For details:
 	@# https://groups.google.com/forum/#!msg/golang-dev/qfa3mHN4ZPA/X2UzjNV1BAAJ.
 	$(xgo) build -i -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' $(PKG)
-	$(xgo) test ./pkg/testutils/lint -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run 'TestLint/$(TESTS)'
+	$(xgo) test ./pkg/testutils/lint -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run 'Lint/$(TESTS)'
 
 .PHONY: lintshort
 lintshort: override TAGS += lint

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -34,8 +34,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/cmd/urlcheck/lib/urlcheck"
-	sqlparser "github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/ghemawat/stream"
 	"github.com/kisielk/gotool"
@@ -921,28 +919,6 @@ func TestLint(t *testing.T) {
 			if out := stderr.String(); len(out) > 0 {
 				t.Fatalf("err=%s, stderr=%s", err, out)
 			}
-		}
-	})
-
-	// TestHelpURLs checks that all help texts have a valid documentation URL.
-	t.Run("TestHelpURLs", func(t *testing.T) {
-		if testing.Short() {
-			t.Skip("short flag")
-		}
-		if pkgSpecified {
-			t.Skip("PKG specified")
-		}
-
-		t.Parallel()
-		var buf bytes.Buffer
-		for key, body := range sqlparser.HelpMessages {
-			msg := sqlparser.HelpMessage{Command: key, HelpMessageBody: body}
-			buf.WriteString(msg.String())
-		}
-		cmd := exec.Command("grep", "-nE", urlcheck.URLRE)
-		cmd.Stdin = &buf
-		if err := urlcheck.CheckURLsFromGrepOutput(cmd); err != nil {
-			t.Fatal(err)
 		}
 	})
 

--- a/pkg/testutils/lint/nightly_lint_test.go
+++ b/pkg/testutils/lint/nightly_lint_test.go
@@ -1,0 +1,53 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build lint,nightly
+
+package lint
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/urlcheck/lib/urlcheck"
+	sqlparser "github.com/cockroachdb/cockroach/pkg/sql/parser"
+)
+
+func TestNightlyLint(t *testing.T) {
+	_, pkgSpecified := os.LookupEnv("PKG")
+
+	// TestHelpURLs checks that all help texts have a valid documentation URL.
+	t.Run("TestHelpURLs", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("short flag")
+		}
+		if pkgSpecified {
+			t.Skip("PKG specified")
+		}
+
+		t.Parallel()
+		var buf bytes.Buffer
+		for key, body := range sqlparser.HelpMessages {
+			msg := sqlparser.HelpMessage{Command: key, HelpMessageBody: body}
+			buf.WriteString(msg.String())
+		}
+		cmd := exec.Command("grep", "-nE", urlcheck.URLRE)
+		cmd.Stdin = &buf
+		if err := urlcheck.CheckURLsFromGrepOutput(cmd); err != nil {
+			t.Fatal(err)
+		}
+	})
+}


### PR DESCRIPTION
Backport 1/1 commits from #29265.

/cc @cockroachdb/release

---

Move TestHelpURLs to a nightly lint test. It isn't terribly useful to be
failing CI builds due to flaky internet.

Release note: None
