### PR TITLE
roachtest: skip queue test

### DIFF
--- a/pkg/cmd/roachtest/queue.go
+++ b/pkg/cmd/roachtest/queue.go
@@ -27,6 +27,7 @@ func registerQueue(r *registry) {
 	// One node runs the workload generator, all other nodes host CockroachDB.
 	const numNodes = 2
 	r.Add(testSpec{
+		Skip:  "https://github.com/cockroachdb/cockroach/issues/17229",
 		Name:  fmt.Sprintf("queue/nodes=%d", numNodes-1),
 		Nodes: nodes(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {


### PR DESCRIPTION
We know that this is going to fail until we pick up #17229 again, which
is not going to happen during the stability period.

Release note: None