### PR TITLE
base: fix TestValidateAddrs

### DIFF
--- a/pkg/base/addr_validation.go
+++ b/pkg/base/addr_validation.go
@@ -220,13 +220,21 @@ func resolveAddr(ctx context.Context, host, port string) (string, string, error)
 		return host, port, nil
 	}
 
+	addr, err := LookupAddr(ctx, resolver, host)
+	return addr, port, err
+}
+
+// LookupAddr resolves the given address/host to an IP address. If
+// multiple addresses are resolved, it returns the first IPv4 address
+// available if there is one, otherwise the first address.
+func LookupAddr(ctx context.Context, resolver *net.Resolver, host string) (string, error) {
 	// Resolve the IP address or hostname to an IP address.
 	addrs, err := resolver.LookupIPAddr(ctx, host)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 	if len(addrs) == 0 {
-		return "", "", fmt.Errorf("cannot resolve %q to an address", host)
+		return "", fmt.Errorf("cannot resolve %q to an address", host)
 	}
 
 	// TODO(knz): the remainder function can be changed to return all
@@ -239,11 +247,11 @@ func resolveAddr(ctx context.Context, host, port string) (string, string, error)
 	// versions, we still prefer an IPv4 address if there is one.
 	for _, addr := range addrs {
 		if ip := addr.IP.To4(); ip != nil {
-			return ip.String(), port, nil
+			return ip.String(), nil
 		}
 	}
 	// No IPv4 address, return the first resolved address instead.
-	return addrs[0].String(), port, nil
+	return addrs[0].String(), nil
 }
 
 // CheckCertificateAddrs validates the addresses inside the configured

--- a/pkg/base/addr_validation_test.go
+++ b/pkg/base/addr_validation_test.go
@@ -43,11 +43,10 @@ func TestValidateAddrs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	hostAddrs, err := net.DefaultResolver.LookupIPAddr(context.Background(), hostname)
+	hostAddr, err := base.LookupAddr(context.Background(), net.DefaultResolver, hostname)
 	if err != nil {
 		t.Fatal(err)
 	}
-	hostAddr := hostAddrs[0].String()
 	if strings.Contains(hostAddr, ":") {
 		hostAddr = "[" + hostAddr + "]"
 	}


### PR DESCRIPTION
Fixes #29186.

The code prefers IPv4 now; make the test prefer IPv4 too.
(This is not captured in CI because the failure is macOS-specific)

Release note: None