### PR TITLE
backport-2.1: sql: fix crash caused by missing memory account

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -607,6 +607,8 @@ func (dsp *DistSQLPlanner) PlanAndRunSubqueries(
 		subqueryMemAccount = subqueryMonitor.MakeBoundAccount()
 		defer subqueryMemAccount.Close(ctx)
 
+		evalCtx.ActiveMemAcc = &subqueryMemAccount
+
 		var subqueryPlanCtx PlanningCtx
 		var distributeSubquery bool
 		if maybeDistribute {

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -505,3 +505,12 @@ query B
 EXECUTE b(3)
 ----
 true
+
+# Regression test for #29205 - make sure the memory account for wrapped local
+# planNode within subqueries is properly hooked up.
+
+statement ok
+CREATE TABLE a (a TEXT PRIMARY KEY)
+
+statement ok
+SELECT (SELECT repeat(a::STRING, 2) FROM [INSERT INTO a VALUES('foo') RETURNING a]);


### PR DESCRIPTION
Backport 1/1 commits from #29286.

/cc @cockroachdb/release

---

Previously, wrapped local planNodes within subqueries would not always
be properly hooked up with memory accounts, leading to crashes.

Fixes #29205.

Release note: None
