### PR TITLE
ui: fix command queue page always crashing on load

### DIFF
--- a/pkg/ui/src/views/reports/containers/commandQueue/index.tsx
+++ b/pkg/ui/src/views/reports/containers/commandQueue/index.tsx
@@ -42,7 +42,7 @@ class CommandQueue extends React.Component<CommandQueueProps, {}> {
     this.refresh();
   }
 
-  renderReportBody() {
+  renderReportBody = () => {
     const commandQueue = this.props.commandQueue;
     if (_.isNil(commandQueue)) {
       return null;


### PR DESCRIPTION
Due to a subtle mistake in a refactoring of the `Loading` component, the
function passed in to the `Loading` component on this page was not bound
properly to the `CommandQueue` component instance.

Fixes #28966

Release note: None