### PR TITLE
storage: skip TestClosedTimestampCanServe

### DIFF
--- a/pkg/storage/closed_timestamp_test.go
+++ b/pkg/storage/closed_timestamp_test.go
@@ -35,6 +35,7 @@ import (
 
 func TestClosedTimestampCanServe(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("https://github.com/cockroachdb/cockroach/issues/28607")
 
 	ctx := context.Background()
 	const numNodes = 3


### PR DESCRIPTION
It won't be the first one I'm looking into.

Release note: None