### PR TITLE
roachtest,kv: assorted backports

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -150,6 +150,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:752f1e64a07686d354c797fbde07c21f3d0e5a24f096858dbb731765a7e6a449"
+  name = "github.com/armon/circbuf"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "bbbad097214e2918d8543d5201d12bfd7bca254d"
+
+[[projects]]
+  branch = "master"
   digest = "1:9fd3a6ab34bb103ba228eefd044d3f9aa476237ea95a46d12e8cccd3abf3fea2"
   name = "github.com/armon/go-radix"
   packages = ["."]
@@ -1614,6 +1622,7 @@
     "github.com/VividCortex/ewma",
     "github.com/abourget/teamcity",
     "github.com/andy-kimball/arenaskl",
+    "github.com/armon/circbuf",
     "github.com/aws/aws-sdk-go/aws",
     "github.com/aws/aws-sdk-go/aws/awsutil",
     "github.com/aws/aws-sdk-go/aws/credentials",

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -827,8 +827,11 @@ func (c *cluster) Start(ctx context.Context, opts ...option) {
 		args = append(args, "--encrypt")
 	}
 	if local {
-		// This avoids annoying firewall prompts on macos
-		args = append(args, "--args", "--listen-addr=127.0.0.1")
+		// This avoids annoying firewall prompts on macos.
+		// NB: we have to use the deprecated --host flag here
+		// (and not --listen-addr) until we don't run any mixed
+		// version tests involving v2.0 any more.
+		args = append(args, "--args", "--host=127.0.0.1")
 	}
 	if err := execCmd(ctx, c.l, args...); err != nil {
 		c.t.Fatal(err)

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -117,7 +117,7 @@ Use 'roachtest bench -n' to see a list of all benchmarks.
 		cmd.Flags().IntVar(
 			&count, "count", 1, "the number of times to run each test")
 		cmd.Flags().BoolVarP(
-			&debug, "debug", "d", debug, "don't wipe and destroy cluster if test fails")
+			&debugEnabled, "debug", "d", debugEnabled, "don't wipe and destroy cluster if test fails")
 		cmd.Flags().BoolVarP(
 			&dryrun, "dry-run", "n", dryrun, "dry run (don't run tests)")
 		cmd.Flags().IntVarP(
@@ -151,7 +151,7 @@ Cockroach cluster with existing data.
 		&stores, "stores", "n", stores, "number of stores to distribute data across")
 	storeGenCmd.Flags().SetInterspersed(false) // ignore workload flags
 	storeGenCmd.Flags().BoolVarP(
-		&debug, "debug", "d", debug, "don't wipe and destroy cluster if test fails")
+		&debugEnabled, "debug", "d", debugEnabled, "don't wipe and destroy cluster if test fails")
 
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(benchCmd)

--- a/pkg/cmd/roachtest/queue.go
+++ b/pkg/cmd/roachtest/queue.go
@@ -27,6 +27,7 @@ func registerQueue(r *registry) {
 	// One node runs the workload generator, all other nodes host CockroachDB.
 	const numNodes = 2
 	r.Add(testSpec{
+		Skip:  "https://github.com/cockroachdb/cockroach/issues/17229",
 		Name:  fmt.Sprintf("queue/nodes=%d", numNodes-1),
 		Nodes: nodes(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -41,7 +41,7 @@ import (
 var (
 	parallelism   = 10
 	count         = 1
-	debug         = false
+	debugEnabled  = false
 	dryrun        = false
 	postIssues    = true
 	clusterNameRE = regexp.MustCompile(`^[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?$`)
@@ -395,7 +395,7 @@ func (r *registry) Run(filter []string) int {
 			r.status.Unlock()
 
 		case <-sig:
-			if !debug {
+			if !debugEnabled {
 				destroyAllClusters()
 			}
 		}
@@ -725,7 +725,7 @@ func (r *registry) run(spec *testSpec, filter *regexp.Regexp, c *cluster, done f
 				c = newCluster(ctx, t, t.spec.Nodes)
 				if c != nil {
 					defer func() {
-						if !debug || !t.Failed() {
+						if !debugEnabled || !t.Failed() {
 							c.Destroy(ctx)
 						} else {
 							c.l.printf("not destroying cluster to allow debugging\n")
@@ -772,7 +772,7 @@ func (r *registry) run(spec *testSpec, filter *regexp.Regexp, c *cluster, done f
 						if c != nil {
 							c.FetchLogs(ctx)
 							// NB: c.destroyed is nil for cloned clusters (i.e. in subtests).
-							if !debug && c.destroyed != nil {
+							if !debugEnabled && c.destroyed != nil {
 								c.Destroy(ctx)
 							}
 						}

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -271,7 +271,7 @@ func registerVersion(r *registry) {
 		}
 	}
 
-	const version = "v2.0.0"
+	const version = "v2.0.5"
 	for _, n := range []int{3, 5} {
 		r.Add(testSpec{
 			Name:       fmt.Sprintf("version/mixedWith=%s/nodes=%d", version, n),

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -18,14 +18,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"runtime"
 	"strconv"
 	"time"
 
 	_ "github.com/lib/pq"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/cockroachdb/cockroach/pkg/util/binfetcher"
 )
@@ -85,48 +82,25 @@ func registerVersion(r *registry) {
 		loadDuration := " --duration=" + (time.Duration(3*nodes+2)*stageDuration + buffer).String()
 
 		workloads := []string{
-			"./workload run tpcc --tolerate-errors --init --warehouses=1" + loadDuration + " {pgurl:1-%d}",
-			// TODO(tschottdorf): adding `--splits=10000` results in a barrage of messages of the type:
-			//
-			// W180301 04:25:28.785116 21 workload/workload.go:323  ALTER TABLE kv
-			// SCATTER FROM (-7199834944475770217) TO (-7199834944475770217): pq:
-			// kv/dist_sender.go:918: truncation resulted in empty batch on
-			// /Table/52/1/-71998349444
-			//
-			// Perhaps the scatter invocation is wrong (it has FROM==TO), but this
-			// looks concerning.
+			"./workload run tpcc --tolerate-errors --wait=false --drop --init --warehouses=1 " + loadDuration + " {pgurl:1-%d}",
 			"./workload run kv --tolerate-errors --init" + loadDuration + " {pgurl:1-%d}",
 		}
 
-		// TODO(tschottdorf): `c.newMonitor` is far from suitable for tests that actually restart nodes
-		// and trying to fix it up does not seem worth it. What would work well here is a monitor that
-		// connects directly to the nodes' PG endpoints and polls their uptime, informing a callback as
-		// needed.
-		var m *errgroup.Group
-		m, ctx = errgroup.WithContext(ctx)
+		m := newMonitor(ctx, c, c.Range(1, nodes))
 		for i, cmd := range workloads {
 			cmd := cmd // loop-local copy
 			i := i     // ditto
-			m.Go(func() error {
+			m.Go(func(ctx context.Context) error {
 				cmd = fmt.Sprintf(cmd, nodes)
-				// TODO(tschottdorf): we need to be able to cleanly terminate processes we
-				// started. In this test, we'd like to send a signal to workload when the
-				// upgrade goroutine has decided the time has come. Perhaps context
-				// cancellation can be used for that purpose, but it doesn't seem quite
-				// right. For now, hold over water with durations, but those don't measure
-				// init time correctly (which can be quite substantial).
-				// TODO(tschottdorf): It's a bit silly that we use a dedicated load gen
-				// machine here, but `c.Stop` calls `roachprod stop` and that kills
-				// *everything* on that machine, not just the cockroach process.
-				quietL, err := newLogger(cmd, strconv.Itoa(i), "workload"+strconv.Itoa(i), ioutil.Discard, os.Stderr)
+				childL, err := c.l.childLogger("workload " + strconv.Itoa(i))
 				if err != nil {
 					return err
 				}
-				return c.RunL(ctx, quietL, c.Node(nodes+1), cmd)
+				return c.RunL(ctx, childL, c.Node(nodes+1), cmd)
 			})
 		}
 
-		m.Go(func() error {
+		m.Go(func(ctx context.Context) error {
 			l, err := c.l.childLogger("upgrader")
 			if err != nil {
 				return err
@@ -164,6 +138,7 @@ func registerVersion(r *registry) {
 			}
 
 			stop := func(node int) error {
+				m.ExpectDeath()
 				l.printf("stopping node %d\n", node)
 				port := fmt.Sprintf("{pgport:%d}", node)
 				// Note that the following command line needs to run against both v2.0
@@ -266,9 +241,7 @@ func registerVersion(r *registry) {
 
 			return sleepAndCheck()
 		})
-		if err := m.Wait(); err != nil {
-			t.Fatal(err)
-		}
+		m.Wait()
 	}
 
 	const version = "v2.0.5"

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -341,9 +341,11 @@ func (ds *DistSender) getNodeDescriptor() *roachpb.NodeDescriptor {
 			return nodeDesc
 		}
 	}
-	ctx := ds.AnnotateCtx(context.TODO())
-	log.Infof(ctx, "unable to determine this node's attributes for replica "+
-		"selection; node is most likely bootstrapping")
+	if log.V(1) {
+		ctx := ds.AnnotateCtx(context.TODO())
+		log.Infof(ctx, "unable to determine this node's attributes for replica "+
+			"selection; node is most likely bootstrapping")
+	}
 	return nil
 }
 

--- a/pkg/workload/tpcc/ddls.go
+++ b/pkg/workload/tpcc/ddls.go
@@ -163,7 +163,7 @@ const (
 func maybeDisableMergeQueue(db *gosql.DB) error {
 	var ok bool
 	if err := db.QueryRow(
-		`SELECT count(*) > 0 FROM [ SHOW ALL CLUSTER SETTINGS ] WHERE variable = 'kv.range_merge.queue_enabled'`,
+		`SELECT count(*) > 0 FROM [ SHOW ALL CLUSTER SETTINGS ] AS _ (v) WHERE v = 'kv.range_merge.queue_enabled'`,
 	).Scan(&ok); err != nil || !ok {
 		return err
 	}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -363,7 +363,7 @@ func Setup(
 func maybeDisableMergeQueue(db *gosql.DB) error {
 	var ok bool
 	if err := db.QueryRow(
-		`SELECT count(*) > 0 FROM [ SHOW ALL CLUSTER SETTINGS ] WHERE variable = 'kv.range_merge.queue_enabled'`,
+		`SELECT count(*) > 0 FROM [ SHOW ALL CLUSTER SETTINGS ] AS _ (v) WHERE v = 'kv.range_merge.queue_enabled'`,
 	).Scan(&ok); err != nil || !ok {
 		return err
 	}


### PR DESCRIPTION
b270b3cb83 (Tobias Schottdorf, 16 hours ago)
   roachtest: skip queue test

   We know that this is going to fail until we pick up #17229 again, which is
   not going to happen during the stability period.

   Release note: None

8396c34b4c (Tobias Schottdorf, 17 hours ago)
   roachtest: remove hack from version test

   It's now running against v2.0.5 which does not require the workaround.

   Release note: None

db5f5cf5e3 (Tobias Schottdorf, 17 hours ago)
   roachtest: further clean up mixedVersion test

   Remove spurious TODO, use a monitor instead of an errgroup, fix the TPCC
   invocation which previously was barely doing anything.

cbad2da7c2 (Tobias Schottdorf, 18 hours ago)
   roachtest: run mixed version tests against v2.0.5

   v2.0.0 contains many bugs that we don't need to revisit.

   Release note: None

eab9ba8688 (Tobias Schottdorf, 18 hours ago)
   roachtest: disable merge queue via query that works on v2.0

   We renamed the first column in 2.1.

   Release note: None

ddeea8a3d5 (Tobias Schottdorf, 18 hours ago)
   roachtest: don't use flags v2.0 doesn't know

   Reverts a tiny part of #27800.

   Fixes #29260. Fixes #29261.

   Release note: None

8e1108ea4a (Tobias Schottdorf, 23 hours ago)
   roachtest: observe ctx cancellation in Run

   Before this patch, roachprod invocations would not observe ctx
   cancellation. Or rather they would, but due to the usual obscure passing of
   Stdout into the child process of roachprod the Run call would not return
   until the child had finished. As a result, the test would continue running,
   which is annoying and also costs money.

   Also fixes up the handling of calling `c.t.Fatal` on a monitor goroutine
   (using what is perhaps unspecified behavior of the Go runtime). Anyway, the
   result is that you can do basically whatever inside of a monitor and get
   away with it:

   ```go m.Go(func(ctx context.Context) error {
   // Make sure the context cancellation works (not true prior to the PR
   // adding this test).
   return c.RunE(ctx, c.Node(1), "sleep", "2000")
   }) m.Go(func(ctx context.Context) error {
   // This will call c.t.Fatal which also used to wreak havoc on the test
   // harness. Now it exits just fine (and all it took were some mean hacks).
   // Note how it will exit with stderr and stdout in the failure message,
   // which is extremely helpful.
   c.Run(ctx, c.Node(1), "echo foo && echo bar && notfound")
   return errors.New("impossible")
   }) m.Wait()
   ```

   now returns

   ```
   --- FAIL: tpmc/w=1/nodes=3 (0.24s)
   ...,errgroup.go:58: /Users/tschottdorf/go/bin/roachprod run local:1 -- echo
   foo && echo bar && notfound returned:
   stderr:
   bash: notfound: command not found
   Error:  exit status 127

   	stdout:
   foo
   bar
   : exit status 1
   ...,tpcc.go:661: Goexit() was called FAIL
   ```

   Release note: None

e66d6ff263 (Tobias Schottdorf, 2 days ago)
   kv: silence spammy log

   This can fill pages of logs when a cluster starts, especially when it never
   manages to connect go Gossip.

   Release note: None

2ad96571a7 (Tobias Schottdorf, 3 days ago)
   workload: only change merge settings if they exist

   Fixes #29112. Fixes #29111.

   Release note: None