### PR TITLE
roachtest: fix flake in TestMonitor

### DIFF
--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -95,7 +95,7 @@ func TestClusterMonitor(t *testing.T) {
 			return ctx.Err()
 		})
 
-		err := m.wait(`echo`, `1`)
+		err := m.wait(`sleep`, `100`)
 		expectedErr := `worker-fail`
 		if !testutils.IsError(err, expectedErr) {
 			t.Errorf(`expected %s err got: %+v`, expectedErr, err)


### PR DESCRIPTION
Accidentally changed this in #29178.

Fixes https://github.com/cockroachdb/cockroach/issues/29325.

Release note: None