### PR TITLE
storage: report applied indexes early when there's a gap

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5691,8 +5691,8 @@ func (r *Replica) applyRaftCommand(
 		// If we have an out of order index, there's corruption. No sense in
 		// trying to update anything or running the command. Simply return
 		// a corruption error.
-		return enginepb.MVCCStats{}, errors.Errorf("applied index jumped from %d to %d",
-			oldRaftAppliedIndex, raftAppliedIndex)
+		return enginepb.MVCCStats{}, log.Safe(fmt.Sprintf("applied index jumped from %d to %d",
+			oldRaftAppliedIndex, raftAppliedIndex))
 	}
 
 	batch := r.store.Engine().NewWriteOnlyBatch()

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -522,6 +522,13 @@ func (r *Replica) handleReplicatedEvalResult(
 	r.mu.Lock()
 	r.mu.state.Stats.Add(deltaStats)
 	if raftAppliedIndex != 0 {
+		if raftAppliedIndex != r.mu.state.RaftAppliedIndex+1 {
+			r.mu.Unlock()
+			log.Fatal(ctx, log.Safe(fmt.Sprintf(
+				"applied index updated from %d to %d, leaving a gap",
+				r.mu.state.RaftAppliedIndex, raftAppliedIndex,
+			)))
+		}
 		r.mu.state.RaftAppliedIndex = raftAppliedIndex
 	}
 	if leaseAppliedIndex != 0 {


### PR DESCRIPTION
For future occurrences of #28918 it will be helpful to know which
assertion fires first.

Release note: None