### PR TITLE
storage: remove test-only data race

### DIFF
--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -735,8 +735,6 @@ func TestRaftSSTableSideloadingSnapshot(t *testing.T) {
 
 	ctx := context.Background()
 	tc := testContext{}
-	stopper := stop.NewStopper()
-	defer stopper.Stop(ctx)
 
 	cleanup, cache, eng := newRocksDB(t)
 	tc.engine = eng
@@ -744,6 +742,8 @@ func TestRaftSSTableSideloadingSnapshot(t *testing.T) {
 	defer cache.Release()
 	defer eng.Close()
 
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
 	tc.Start(t, stopper)
 
 	var ba roachpb.BatchRequest


### PR DESCRIPTION
The test was stopping the engine before the stopper, so the compactor
was sometimes able to use the engine while it was being closed.

Fixes #29302.

Release note: None