### PR TITLE
base: fix TestValidateAddrs (cont.)

### DIFF
--- a/pkg/base/addr_validation_test.go
+++ b/pkg/base/addr_validation_test.go
@@ -50,11 +50,10 @@ func TestValidateAddrs(t *testing.T) {
 	if strings.Contains(hostAddr, ":") {
 		hostAddr = "[" + hostAddr + "]"
 	}
-	localAddrs, err := net.DefaultResolver.LookupIPAddr(context.Background(), "localhost")
+	localAddr, err := base.LookupAddr(context.Background(), net.DefaultResolver, "localhost")
 	if err != nil {
 		t.Fatal(err)
 	}
-	localAddr := localAddrs[0].String()
 	if strings.Contains(localAddr, ":") {
 		localAddr = "[" + localAddr + "]"
 	}


### PR DESCRIPTION
The fix in #29287 only fixed half of the test for macOS. This patch
fixes the other half.

Release note: None