### PR TITLE
release-2.1: gossip: rework how infostore callbacks are run

### DIFF
--- a/pkg/gossip/infostore.go
+++ b/pkg/gossip/infostore.go
@@ -71,9 +71,9 @@ type infoStore struct {
 	highWaterStamps map[roachpb.NodeID]int64 // Per-node information for gossip peers
 	callbacks       []*callback
 
-	callbackMu     syncutil.Mutex // Serializes callbacks
 	callbackWorkMu syncutil.Mutex // Protects callbackWork
 	callbackWork   []func()
+	callbackCh     chan struct{} // Channel to signal the callback goroutine
 }
 
 var monoTime struct {
@@ -130,14 +130,40 @@ func newInfoStore(
 	nodeAddr util.UnresolvedAddr,
 	stopper *stop.Stopper,
 ) *infoStore {
-	return &infoStore{
+	is := &infoStore{
 		AmbientContext:  ambient,
 		nodeID:          nodeID,
 		stopper:         stopper,
 		Infos:           make(infoMap),
 		NodeAddr:        nodeAddr,
 		highWaterStamps: map[roachpb.NodeID]int64{},
+		callbackCh:      make(chan struct{}, 1),
 	}
+
+	is.stopper.RunWorker(context.Background(), func(ctx context.Context) {
+		for {
+			for {
+				is.callbackWorkMu.Lock()
+				work := is.callbackWork
+				is.callbackWork = nil
+				is.callbackWorkMu.Unlock()
+
+				if len(work) == 0 {
+					break
+				}
+				for _, w := range work {
+					w()
+				}
+			}
+
+			select {
+			case <-is.callbackCh:
+			case <-is.stopper.ShouldQuiesce():
+				return
+			}
+		}
+	})
+	return is
 }
 
 // newInfo allocates and returns a new info object using the specified
@@ -278,28 +304,13 @@ func (is *infoStore) runCallbacks(key string, content roachpb.Value, callbacks .
 	is.callbackWork = append(is.callbackWork, f)
 	is.callbackWorkMu.Unlock()
 
-	// Run callbacks in a goroutine to avoid mutex reentry. We also guarantee
-	// callbacks are run in order such that if a key is updated twice in
-	// succession, the second callback will never be run before the first.
-	if err := is.stopper.RunAsyncTask(
-		context.Background(), "gossip.infoStore: callback", func(_ context.Context,
-		) {
-			// Grab the callback mutex to serialize execution of the callbacks.
-			is.callbackMu.Lock()
-			defer is.callbackMu.Unlock()
-
-			// Grab and execute the list of work.
-			is.callbackWorkMu.Lock()
-			work := is.callbackWork
-			is.callbackWork = nil
-			is.callbackWorkMu.Unlock()
-
-			for _, w := range work {
-				w()
-			}
-		}); err != nil {
-		ctx := is.AnnotateCtx(context.TODO())
-		log.Warning(ctx, err)
+	// Signal the callback goroutine. Callbacks run in a goroutine to avoid mutex
+	// reentry. We also guarantee callbacks are run in order such that if a key
+	// is updated twice in succession, the second callback will never be run
+	// before the first.
+	select {
+	case is.callbackCh <- struct{}{}:
+	default:
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #29338.

/cc @cockroachdb/release

---

Rather than starting a goroutine per call of `infostore.runCallbacks`,
now there is a single goroutine per infostore that runs the
callbacks. Callback invocation was already serialized by
`infostore.callbackMu`, so the per-runCallbacks goroutine was nothing
but a resource waste. Additionally, it was causing flakiness in
TestNetworkReachesEquilibrium when run under race because that test
would frequently hits the error "race: limit on 8192 simultaneously
alive goroutines is exceeded, dying". Instrumentation revealed that a
majority of the goroutines were from runCallbacks.

Fixes #29335

Release note: None
