### PR TITLE
vendor: bump vitess

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1592,8 +1592,8 @@
   version = "2017.2.2"
 
 [[projects]]
-  branch = "no-flag-on-delete"
-  digest = "1:6bb9595c618513fb891816ffe5693278f03a990333d6138ad2d7bedab0256bc8"
+  branch = "no-flag-names-parens"
+  digest = "1:6e89f05e68e4ea82a79459599d20ad0ec7a8c6d6110c3a926b1efd509f65dd85"
   name = "vitess.io/vitess"
   packages = [
     "go/bytes2",
@@ -1607,7 +1607,7 @@
     "go/vt/vterrors",
   ]
   pruneopts = "UT"
-  revision = "0ce4a891bcc56213538df72f3b6d85d30e43ceb8"
+  revision = "1740ce8b3188b99cd3c88fb38ad734eda711519f"
   source = "https://github.com/cockroachdb/vitess"
 
 [solve-meta]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -67,7 +67,7 @@ ignored = [
 [[constraint]]
   name = "vitess.io/vitess"
   source = "https://github.com/cockroachdb/vitess"
-  branch = "no-flag-on-delete"
+  branch = "no-flag-names-parens"
 
 # The master version of go.uuid has an incompatible interface and (as
 # of 2018-06-06) a serious bug. Don't upgrade without making sure


### PR DESCRIPTION
This picks up fixes for mysqldump output with indexes with no name or parens after current_timestamp.

These do not appear in the default output of mysqldump  Ver 10.13 Distrib 5.7.22, so our current testdata does not contain them.

Release note: none.