### PR TITLE
release-2.1: sql: temporarily skip TestSplitAt

### DIFF
--- a/pkg/sql/split_test.go
+++ b/pkg/sql/split_test.go
@@ -31,6 +31,8 @@ import (
 func TestSplitAt(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	t.Skip("TODO(benesch): #29169: will be fixed by #29324")
+
 	params, _ := tests.CreateTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())


### PR DESCRIPTION
Backport 1/1 commits from #29347.

/cc @cockroachdb/release

---

See #29169

Release note: None
