### PR TITLE
sql: rename EXPERIMENTAL_OPT setting to OPTIMIZER

### DIFF
--- a/pkg/bench/foreachdb.go
+++ b/pkg/bench/foreachdb.go
@@ -42,7 +42,7 @@ func benchmarkCockroach(b *testing.B, f func(b *testing.B, db *gosql.DB)) {
 		b.Fatal(err)
 	}
 
-	if _, err := db.Exec(`SET EXPERIMENTAL_OPT=OFF`); err != nil {
+	if _, err := db.Exec(`SET OPTIMIZER=OFF`); err != nil {
 		b.Fatal(err)
 	}
 
@@ -58,7 +58,7 @@ func benchmarkCockroachOpt(b *testing.B, f func(b *testing.B, db *gosql.DB)) {
 		b.Fatal(err)
 	}
 
-	if _, err := db.Exec(`SET EXPERIMENTAL_OPT=ON`); err != nil {
+	if _, err := db.Exec(`SET OPTIMIZER=ON`); err != nil {
 		b.Fatal(err)
 	}
 

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -904,7 +904,7 @@ func (t *logicTest) setUser(user string) func() {
 	}
 	// Enable the cost-based optimizer rather than the heuristic planner.
 	if optMode := t.cfg.overrideOptimizerMode; optMode != "" {
-		if _, err := db.Exec(fmt.Sprintf("SET EXPERIMENTAL_OPT = %s;", optMode)); err != nil {
+		if _, err := db.Exec(fmt.Sprintf("SET OPTIMIZER = %s;", optMode)); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -16,7 +16,7 @@ statement ok
 INSERT INTO xy VALUES (2, 200), (3, 300), (4, 400)
 
 statement ok
-SET EXPERIMENTAL_OPT = ON
+SET OPTIMIZER = ON
 
 # ParenSelect
 query II rowsort
@@ -95,7 +95,7 @@ statement ok
 CREATE SEQUENCE seq
 
 statement ok
-SET EXPERIMENTAL_OPT = ALWAYS
+SET OPTIMIZER = ALWAYS
 
 query error pq: unsupported statement: \*tree\.Insert
 INSERT INTO test (k, v) VALUES (5, 50)
@@ -108,7 +108,7 @@ query error pq: sequences are not supported
 SELECT * FROM seq
 
 statement ok
-SET EXPERIMENTAL_OPT = LOCAL
+SET OPTIMIZER = LOCAL
 
 # In local mode, we should always get the results in order (no rowsort).
 query II

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1294,10 +1294,15 @@ query             STRING       true         NULL            ·                  
 statement ok
 SET DATABASE = test
 
-# We filter here because experimental_opt will be different depending on which
+# We filter here because 'optimizer' will be different depending on which
 # configuration this logic test is running in.
 query TTTTTT colnames
-SELECT name, setting, category, short_desc, extra_desc, vartype FROM pg_catalog.pg_settings WHERE name != 'experimental_opt'
+SELECT
+  name, setting, category, short_desc, extra_desc, vartype
+FROM
+  pg_catalog.pg_settings
+WHERE
+  name != 'optimizer'
 ----
 name                               setting       category  short_desc  extra_desc  vartype
 application_name                   ·             NULL      NULL        NULL        string
@@ -1334,7 +1339,12 @@ transaction_read_only              off           NULL      NULL        NULL     
 transaction_status                 NoTxn         NULL      NULL        NULL        string
 
 query TTTTTTT colnames
-SELECT name, setting, unit, context, enumvals, boot_val, reset_val FROM pg_catalog.pg_settings WHERE name != 'experimental_opt'
+SELECT
+  name, setting, unit, context, enumvals, boot_val, reset_val
+FROM
+  pg_catalog.pg_settings
+WHERE
+  name != 'optimizer'
 ----
 name                               setting       unit  context  enumvals  boot_val      reset_val
 application_name                   ·             NULL  user     NULL      ·             ·
@@ -1386,13 +1396,13 @@ distsql                            NULL    NULL     NULL     NULL        NULL
 experimental_force_lookup_join     NULL    NULL     NULL     NULL        NULL
 experimental_force_split_at        NULL    NULL     NULL     NULL        NULL
 experimental_force_zigzag_join     NULL    NULL     NULL     NULL        NULL
-experimental_opt                   NULL    NULL     NULL     NULL        NULL
 experimental_serial_normalization  NULL    NULL     NULL     NULL        NULL
 extra_float_digits                 NULL    NULL     NULL     NULL        NULL
 integer_datetimes                  NULL    NULL     NULL     NULL        NULL
 intervalstyle                      NULL    NULL     NULL     NULL        NULL
 max_index_keys                     NULL    NULL     NULL     NULL        NULL
 node_id                            NULL    NULL     NULL     NULL        NULL
+optimizer                          NULL    NULL     NULL     NULL        NULL
 search_path                        NULL    NULL     NULL     NULL        NULL
 server_encoding                    NULL    NULL     NULL     NULL        NULL
 server_version                     NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -169,16 +169,16 @@ statement error invalid value for parameter "distsql": "bogus"
 SET distsql = bogus
 
 statement ok
-SET experimental_opt = on
+SET optimizer = on
 
 statement ok
-SET experimental_opt = local
+SET optimizer = local
 
 statement ok
-SET experimental_opt = off
+SET optimizer = off
 
-statement error invalid value for parameter "experimental_opt": "bogus"
-SET experimental_opt = bogus
+statement error invalid value for parameter "optimizer": "bogus"
+SET optimizer = bogus
 
 statement ok
 SET bytea_output = escape

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -18,10 +18,10 @@ SELECT * FROM [SHOW client_encoding] WITH ORDINALITY
 client_encoding     ordinality
 UTF8                1
 
-# We filter here because experimental_opt will be different depending on which
+# We filter here because optimizer will be different depending on which
 # configuration this logic test is running in.
 query TT colnames
-SELECT * FROM [SHOW ALL] WHERE variable != 'experimental_opt'
+SELECT * FROM [SHOW ALL] WHERE variable != 'optimizer'
 ----
 variable                           value
 application_name                   ·

--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -57,7 +57,7 @@ func TestQueryCounts(t *testing.T) {
 
 	var testcases = []queryCounter{
 		// The counts are deltas for each query.
-		{query: "SET EXPERIMENTAL_OPT = 'off'", miscCount: 1},
+		{query: "SET OPTIMIZER = 'off'", miscCount: 1},
 		{query: "SET DISTSQL = 'off'", miscCount: 1},
 		{query: "BEGIN; END", txnBeginCount: 1, txnCommitCount: 1},
 		{query: "SELECT 1", selectCount: 1, txnCommitCount: 1},
@@ -85,11 +85,11 @@ func TestQueryCounts(t *testing.T) {
 		{query: "SET DISTSQL = 'off'", miscCount: 1},
 		{query: "DROP TABLE mt.n", ddlCount: 1},
 		{query: "SET database = system", miscCount: 1},
-		{query: "SET EXPERIMENTAL_OPT = 'on'", miscCount: 1, fallbackCount: 1},
+		{query: "SET OPTIMIZER = 'on'", miscCount: 1, fallbackCount: 1},
 		{query: "SELECT 3", selectCount: 1, optCount: 1},
 		{query: "CREATE TABLE mt.n (num INTEGER PRIMARY KEY)", ddlCount: 1, fallbackCount: 1},
 		{query: "UPDATE mt.n SET num = num + 1", updateCount: 1, fallbackCount: 1},
-		{query: "SET EXPERIMENTAL_OPT = 'off'", miscCount: 1},
+		{query: "SET OPTIMIZER = 'off'", miscCount: 1},
 	}
 
 	accum := initializeQueryCounter(s)

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -272,9 +272,9 @@ func (h *harness) prepareUsingServer(tb testing.TB, bmType BenchmarkType) {
 
 	// Set session state.
 	if bmType == ExecPlan {
-		h.sr.Exec(tb, `SET EXPERIMENTAL_OPT=OFF`)
+		h.sr.Exec(tb, `SET OPTIMIZER=OFF`)
 	} else {
-		h.sr.Exec(tb, `SET EXPERIMENTAL_OPT=ON`)
+		h.sr.Exec(tb, `SET OPTIMIZER=ON`)
 	}
 }
 

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -145,7 +145,7 @@ func TestTrace(t *testing.T) {
 				// TODO(justin): remove this and make sure the new results make sense.
 				// The optimizer elides some renders that the heuristic planner does
 				// not which makes the results different.
-				if _, err := sqlDB.Exec("SET EXPERIMENTAL_OPT = OFF"); err != nil {
+				if _, err := sqlDB.Exec("SET OPTIMIZER = OFF"); err != nil {
 					t.Fatal(err)
 				}
 				if _, err := sqlDB.Exec("SET tracing = on; SELECT * FROM test.foo; SET tracing = off"); err != nil {
@@ -173,7 +173,7 @@ func TestTrace(t *testing.T) {
 				// TODO(justin): remove this and make sure the new results make sense.
 				// The optimizer elides some renders that the heuristic planner does
 				// not which makes the results different.
-				if _, err := sqlDB.Exec("SET experimental_opt = off"); err != nil {
+				if _, err := sqlDB.Exec("SET OPTIMIZER = off"); err != nil {
 					t.Fatal(err)
 				}
 				if _, err := sqlDB.Exec("SET tracing = on; SELECT * FROM test.foo; SET tracing = off"); err != nil {

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -324,18 +324,18 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
-	`experimental_opt`: {
+	`optimizer`: {
 		Set: func(
 			_ context.Context, m *sessionDataMutator,
 			evalCtx *extendedEvalContext, values []tree.TypedExpr,
 		) error {
-			s, err := getStringVal(&evalCtx.EvalContext, `experimental_opt`, values)
+			s, err := getStringVal(&evalCtx.EvalContext, `optimizer`, values)
 			if err != nil {
 				return err
 			}
 			mode, ok := sessiondata.OptimizerModeFromString(s)
 			if !ok {
-				return newVarValueError(`experimental_opt`, s, "on", "off", "local", "always")
+				return newVarValueError(`optimizer`, s, "on", "off", "local", "always")
 			}
 			m.SetOptimizerMode(mode)
 


### PR DESCRIPTION
The cluster setting `sql.defaults.optimizer` is already ok.

Release note (sql change): Renamed EXPERIMENTAL_OPT session setting to
OPTIMIZER. The default value is ON, as before.