### PR TITLE
ui: don't show 125% axis label on percentage chart

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
-import {GraphDashboardProps, nodeDisplayName, storeIDsForNode} from "./dashboardUtils";
+import { GraphDashboardProps, nodeDisplayName, storeIDsForNode } from "./dashboardUtils";
 
 // TODO(vilterp): tooltips
 

--- a/pkg/ui/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/src/views/cluster/util/graphs.ts
@@ -63,7 +63,10 @@ class AxisDomain {
     const max = extent[1];
     if (alignMinMax) {
       const alignedMin = min - min % increment;
-      const alignedMax = max - max % increment + increment;
+      let alignedMax = max;
+      if (max % increment !== 0) {
+        alignedMax = max - max % increment + increment;
+      }
       this.extent = [alignedMin, alignedMax];
     } else {
       this.extent = extent;


### PR DESCRIPTION
Showing 125% on the axis is confusing to users, since the metric maxes out at 100%.

*Before*
![image](https://user-images.githubusercontent.com/7341/44868807-f064ba00-ac59-11e8-8780-eff56914a679.png)

*After*
![image](https://user-images.githubusercontent.com/7341/44868837-ff4b6c80-ac59-11e8-92fe-3e9a38930f1e.png)

Fixes #28719
