### PR TITLE
storage: include summary of prereq batches in cmdQ logs/traces

### DIFF
--- a/pkg/roachpb/batch_generated.go
+++ b/pkg/roachpb/batch_generated.go
@@ -4,9 +4,9 @@
 package roachpb
 
 import (
-	"bytes"
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // GetInner returns the error contained in the union.
@@ -649,25 +649,33 @@ var requestNames = []string{
 
 // Summary prints a short summary of the requests in a batch.
 func (ba *BatchRequest) Summary() string {
+	var b strings.Builder
+	ba.WriteSummary(&b)
+	return b.String()
+}
+
+// WriteSummary writes a short summary of the requests in a batch
+// to the provided builder.
+func (ba *BatchRequest) WriteSummary(b *strings.Builder) {
 	if len(ba.Requests) == 0 {
-		return "empty batch"
+		b.WriteString("empty batch")
+		return
 	}
 	counts := ba.getReqCounts()
-	var buf struct {
-		bytes.Buffer
-		tmp [10]byte
-	}
+	var tmp [10]byte
+	var comma bool
 	for i, v := range counts {
 		if v != 0 {
-			if buf.Len() > 0 {
-				buf.WriteString(", ")
+			if comma {
+				b.WriteString(", ")
 			}
-			buf.Write(strconv.AppendInt(buf.tmp[:0], int64(v), 10))
-			buf.WriteString(" ")
-			buf.WriteString(requestNames[i])
+			comma = true
+
+			b.Write(strconv.AppendInt(tmp[:0], int64(v), 10))
+			b.WriteString(" ")
+			b.WriteString(requestNames[i])
 		}
 	}
-	return buf.String()
 }
 
 // The following types are used to group the allocations of Responses

--- a/pkg/roachpb/gen_batch.go
+++ b/pkg/roachpb/gen_batch.go
@@ -153,9 +153,9 @@ func main() {
 package roachpb
 
 import (
-	"bytes"
 	"fmt"
 	"strconv"
+	"strings"
 )
 `)
 
@@ -230,25 +230,33 @@ var requestNames = []string{`)
 	fmt.Fprint(f, `
 // Summary prints a short summary of the requests in a batch.
 func (ba *BatchRequest) Summary() string {
+	var b strings.Builder
+	ba.WriteSummary(&b)
+	return b.String()
+}
+
+// WriteSummary writes a short summary of the requests in a batch
+// to the provided builder.
+func (ba *BatchRequest) WriteSummary(b *strings.Builder) {
 	if len(ba.Requests) == 0 {
-		return "empty batch"
+		b.WriteString("empty batch")
+		return
 	}
 	counts := ba.getReqCounts()
-	var buf struct {
-		bytes.Buffer
-		tmp [10]byte
-	}
+	var tmp [10]byte
+	var comma bool
 	for i, v := range counts {
 		if v != 0 {
-			if buf.Len() > 0 {
-				buf.WriteString(", ")
+			if comma {
+				b.WriteString(", ")
 			}
-			buf.Write(strconv.AppendInt(buf.tmp[:0], int64(v), 10))
-			buf.WriteString(" ")
-			buf.WriteString(requestNames[i])
+			comma = true
+
+			b.Write(strconv.AppendInt(tmp[:0], int64(v), 10))
+			b.WriteString(" ")
+			b.WriteString(requestNames[i])
 		}
 	}
-	return buf.String()
 }
 `)
 

--- a/pkg/storage/batcheval/cmd_resolve_intent_test.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_test.go
@@ -130,7 +130,7 @@ func TestDeclareKeysResolveIntent(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	abortSpanKey := fmt.Sprintf(`1 1: /Local/RangeID/99/r/AbortSpan/"%s"`, id)
+	abortSpanKey := fmt.Sprintf(`write local: /Local/RangeID/99/r/AbortSpan/"%s"`, id)
 	desc := roachpb.RangeDescriptor{
 		RangeID:  99,
 		StartKey: roachpb.RKey("a"),

--- a/pkg/storage/spanset/spanset.go
+++ b/pkg/storage/spanset/spanset.go
@@ -36,6 +36,18 @@ const (
 	NumSpanAccess
 )
 
+// String returns a string representation of the SpanAccess.
+func (a SpanAccess) String() string {
+	switch a {
+	case SpanReadOnly:
+		return "read"
+	case SpanReadWrite:
+		return "write"
+	default:
+		panic("unreachable")
+	}
+}
+
 // SpanScope divides access types into local and global keys.
 type SpanScope int
 
@@ -45,6 +57,18 @@ const (
 	SpanLocal
 	NumSpanScope
 )
+
+// String returns a string representation of the SpanScope.
+func (a SpanScope) String() string {
+	switch a {
+	case SpanGlobal:
+		return "global"
+	case SpanLocal:
+		return "local"
+	default:
+		panic("unreachable")
+	}
+}
 
 // SpanSet tracks the set of key spans touched by a command. The set
 // is divided into subsets for access type (read-only or read/write)
@@ -60,7 +84,7 @@ func (ss *SpanSet) String() string {
 	for i := SpanAccess(0); i < NumSpanAccess; i++ {
 		for j := SpanScope(0); j < NumSpanScope; j++ {
 			for _, span := range ss.GetSpans(i, j) {
-				fmt.Fprintf(&buf, "%d %d: %s\n", i, j, span)
+				fmt.Fprintf(&buf, "%s %s: %s\n", i, j, span)
 			}
 		}
 	}
@@ -119,12 +143,8 @@ func (ss *SpanSet) CheckAllowed(access SpanAccess, span roachpb.Span) error {
 			}
 		}
 	}
-	action := "read"
-	if access == SpanReadWrite {
-		action = "write"
-	}
 
-	return errors.Errorf("cannot %s undeclared span %s\ndeclared:\n%s", action, span, ss)
+	return errors.Errorf("cannot %s undeclared span %s\ndeclared:\n%s", access, span, ss)
 }
 
 // Validate returns an error if any spans that have been added to the set


### PR DESCRIPTION
This change adds a summary of the batch requests that a command is waiting
on in the command queue to the trace event from before and after the command
enters the queue. It turns the following two traces:

```
waiting for 4 overlapping requests
waited 8.634716ms for overlapping requests
```

into

```
waiting for 4 overlapping requests: {write/local: [1 EndTxn], [1 EndTxn], [1 EndTxn], [1 EndTxn]}
waited 983.742µs for overlapping requests: {read/local: [1 CPut, 1 BeginTxn]} {write/local: [1 CPut, 1 BeginTxn]}
```

This should improve our ability to understand command queue contention
from traces or high-verbosity logs (`V(2)`).

Release note: None