### PR TITLE
release-2.1: distsql: embed ProcessorBase in planNodeToRowSource

### DIFF
--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -580,7 +580,7 @@ func (ag *aggregatorBase) getAggResults(
 	}
 	bucket.close(ag.Ctx)
 
-	if outRow := ag.processRowHelper(ag.row); outRow != nil {
+	if outRow := ag.ProcessRowHelper(ag.row); outRow != nil {
 		return aggEmittingRows, outRow, nil
 	}
 	// We might have switched to draining, we might not have. In case we

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -267,7 +267,7 @@ func (d *Distinct) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 			d.seen[s] = struct{}{}
 		}
 
-		if outRow := d.processRowHelper(row); outRow != nil {
+		if outRow := d.ProcessRowHelper(row); outRow != nil {
 			return outRow, nil
 		}
 	}
@@ -300,7 +300,7 @@ func (d *SortedDistinct) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 		d.haveLastGroupKey = true
 		copy(d.lastGroupKey, row)
 
-		if outRow := d.processRowHelper(row); outRow != nil {
+		if outRow := d.ProcessRowHelper(row); outRow != nil {
 			return outRow, nil
 		}
 	}

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -259,7 +259,7 @@ func (h *hashJoiner) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 		if meta != nil {
 			return nil, meta
 		}
-		if outRow := h.processRowHelper(row); outRow != nil {
+		if outRow := h.ProcessRowHelper(row); outRow != nil {
 			return outRow, nil
 		}
 	}

--- a/pkg/sql/distsqlrun/indexjoiner.go
+++ b/pkg/sql/distsqlrun/indexjoiner.go
@@ -178,7 +178,7 @@ func (ij *indexJoiner) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 		if row == nil {
 			// Done with this batch.
 			ij.fetcherReady = false
-		} else if outRow := ij.processRowHelper(row); outRow != nil {
+		} else if outRow := ij.ProcessRowHelper(row); outRow != nil {
 			return outRow, nil
 		}
 	}

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner.go
@@ -109,7 +109,7 @@ func (irj *interleavedReaderJoiner) Next() (sqlbase.EncDatumRow, *ProducerMetada
 			irj.runningState, row, meta = irj.nextRow()
 		case irjUnmatchedChild:
 			rendered := irj.renderUnmatchedRow(irj.unmatchedChild, irj.descendantJoinSide)
-			row = irj.processRowHelper(rendered)
+			row = irj.ProcessRowHelper(rendered)
 			irj.unmatchedChild = nil
 			irj.runningState = irjReading
 		default:
@@ -236,7 +236,7 @@ func (irj *interleavedReaderJoiner) nextRow() (irjState, sqlbase.EncDatumRow, *P
 		if renderedRow != nil {
 			irj.ancestorJoined = true
 		}
-		return irjReading, irj.processRowHelper(renderedRow), nil
+		return irjReading, irj.ProcessRowHelper(renderedRow), nil
 	}
 
 	// Child does not match previous ancestorRow.
@@ -444,7 +444,7 @@ func (irj *interleavedReaderJoiner) maybeUnmatchedAncestor() sqlbase.EncDatumRow
 		}
 
 		rendered := irj.renderUnmatchedRow(irj.ancestorRow, irj.ancestorJoinSide)
-		return irj.processRowHelper(rendered)
+		return irj.ProcessRowHelper(rendered)
 	}
 	return nil
 }

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -504,7 +504,7 @@ func (jr *joinReader) performLookup() (joinReaderState, *ProducerMetadata) {
 				return jrStateUnknown, jr.DrainHelper()
 			}
 			if renderedRow != nil {
-				if row := jr.processRowHelper(renderedRow); row != nil {
+				if row := jr.ProcessRowHelper(renderedRow); row != nil {
 					jr.toEmit = append(jr.toEmit, jr.out.rowAlloc.CopyRow(row))
 					if jr.emitted != nil {
 						jr.emitted[inputRowIdx] = true
@@ -528,7 +528,7 @@ func (jr *joinReader) collectUnmatched() joinReaderState {
 		for i := 0; i < len(jr.inputRows); i++ {
 			if !jr.emitted[i] {
 				if renderedRow := jr.renderUnmatchedRow(jr.inputRows[i], leftSide); renderedRow != nil {
-					if row := jr.processRowHelper(renderedRow); row != nil {
+					if row := jr.ProcessRowHelper(renderedRow); row != nil {
 						jr.toEmit = append(jr.toEmit, jr.out.rowAlloc.CopyRow(row))
 					}
 				}

--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -136,7 +136,7 @@ func (m *mergeJoiner) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 			break
 		}
 
-		if outRow := m.processRowHelper(row); outRow != nil {
+		if outRow := m.ProcessRowHelper(row); outRow != nil {
 			return outRow, nil
 		}
 	}

--- a/pkg/sql/distsqlrun/metadata_test_receiver.go
+++ b/pkg/sql/distsqlrun/metadata_test_receiver.go
@@ -208,7 +208,7 @@ func (mtr *metadataTestReceiver) Next() (sqlbase.EncDatumRow, *ProducerMetadata)
 			continue
 		}
 
-		// We don't use ProcessorBase.processRowHelper() here because we need
+		// We don't use ProcessorBase.ProcessRowHelper() here because we need
 		// special handling for errors: this proc never starts draining in order for
 		// it to be as unintrusive as possible.
 		outRow, ok, err := mtr.out.ProcessRow(mtr.Ctx, row)

--- a/pkg/sql/distsqlrun/metadata_test_sender.go
+++ b/pkg/sql/distsqlrun/metadata_test_sender.go
@@ -109,7 +109,7 @@ func (mts *metadataTestSender) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 			break
 		}
 
-		if outRow := mts.processRowHelper(row); outRow != nil {
+		if outRow := mts.ProcessRowHelper(row); outRow != nil {
 			mts.sendRowNumMeta = true
 			return outRow, nil
 		}

--- a/pkg/sql/distsqlrun/noop.go
+++ b/pkg/sql/distsqlrun/noop.go
@@ -75,7 +75,7 @@ func (n *noopProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 			break
 		}
 
-		if outRow := n.processRowHelper(row); outRow != nil {
+		if outRow := n.ProcessRowHelper(row); outRow != nil {
 			return outRow, nil
 		}
 	}

--- a/pkg/sql/distsqlrun/project_set.go
+++ b/pkg/sql/distsqlrun/project_set.go
@@ -244,7 +244,7 @@ func (ps *projectSetProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 			return nil, ps.DrainHelper()
 		}
 		if newValAvail {
-			if outRow := ps.processRowHelper(ps.rowBuffer); outRow != nil {
+			if outRow := ps.ProcessRowHelper(ps.rowBuffer); outRow != nil {
 				return outRow, nil
 			}
 		} else {

--- a/pkg/sql/distsqlrun/scrub_tablereader.go
+++ b/pkg/sql/distsqlrun/scrub_tablereader.go
@@ -258,7 +258,7 @@ func (tr *scrubTableReader) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 			break
 		}
 
-		if outRow := tr.processRowHelper(row); outRow != nil {
+		if outRow := tr.ProcessRowHelper(row); outRow != nil {
 			return outRow, nil
 		}
 	}

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -137,7 +137,7 @@ func (s *sorterBase) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 		}
 		s.i.Next()
 
-		if outRow := s.processRowHelper(row); outRow != nil {
+		if outRow := s.ProcessRowHelper(row); outRow != nil {
 			return outRow, nil
 		}
 	}
@@ -618,7 +618,7 @@ func (s *sortChunksProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 		}
 		s.i.Next()
 
-		if outRow := s.processRowHelper(row); outRow != nil {
+		if outRow := s.ProcessRowHelper(row); outRow != nil {
 			return outRow, nil
 		}
 	}

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -245,7 +245,7 @@ func (tr *tableReader) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 			break
 		}
 
-		if outRow := tr.processRowHelper(row); outRow != nil {
+		if outRow := tr.ProcessRowHelper(row); outRow != nil {
 			return outRow, nil
 		}
 	}

--- a/pkg/sql/distsqlrun/values.go
+++ b/pkg/sql/distsqlrun/values.go
@@ -122,7 +122,7 @@ func (v *valuesProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 			continue
 		}
 
-		if outRow := v.processRowHelper(row); outRow != nil {
+		if outRow := v.ProcessRowHelper(row); outRow != nil {
 			return outRow, nil
 		}
 	}

--- a/pkg/sql/distsqlrun/windower.go
+++ b/pkg/sql/distsqlrun/windower.go
@@ -392,7 +392,7 @@ func (w *windower) emitRow() (windowerState, sqlbase.EncDatumRow, *ProducerMetad
 		}
 
 		if w.populateNextOutputRow() {
-			return windowerEmittingRows, w.processRowHelper(w.outputRow), nil
+			return windowerEmittingRows, w.ProcessRowHelper(w.outputRow), nil
 		}
 
 		w.MoveToDraining(nil /* err */)

--- a/pkg/sql/distsqlrun/zigzagjoiner.go
+++ b/pkg/sql/distsqlrun/zigzagjoiner.go
@@ -868,7 +868,7 @@ func (z *zigzagJoiner) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 			break
 		}
 
-		outRow := z.processRowHelper(row)
+		outRow := z.ProcessRowHelper(row)
 		if outRow == nil {
 			continue
 		}

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -15,6 +15,9 @@ EXPLAIN ANALYZE (DISTSQL) INSERT INTO a VALUES (1)
 statement error duplicate
 EXPLAIN ANALYZE (DISTSQL) INSERT INTO a VALUES (1)
 
+statement error value type string doesn't match type
+EXPLAIN ANALYZE (DISTSQL) INSERT INTO a VALUES ('a'::string)
+
 statement ok
 EXPLAIN ANALYZE (DISTSQL) INSERT INTO a SELECT a+1 FROM a
 


### PR DESCRIPTION
Backport 2/2 commits from #29267.

/cc @cockroachdb/release

---

    planNodeToRowSource had incorrect closing semantics. When closing itself
    (in any case), it would call `ConsumerClosed` on `toDrain` and proceed to
    drain it. The contract is that `Next` should never be called after
    `ConsumerClosed`. The underlying issue here is that we are trying to
    re-implement RowSource semantics. To solve this, and any other possible
    issues, we embed ProcessorBase and reuse existing code.

This change also adds an `EXPLAIN ANALYZE` test that was previously failing because of these closing semantics.
