### PR TITLE
changefeedccl: error when a watched table backfills

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -69,11 +69,12 @@ type emitEntry struct {
 // returns a closure that may be repeatedly called to advance the changefeed.
 // The returned closure is not threadsafe.
 func kvsToRows(
-	leaseManager *sql.LeaseManager,
+	leaseMgr *sql.LeaseManager,
+	tableHist *tableHistory,
 	details jobspb.ChangefeedDetails,
 	inputFn func(context.Context) (bufferEntry, error),
 ) func(context.Context) ([]emitEntry, error) {
-	rfCache := newRowFetcherCache(leaseManager)
+	rfCache := newRowFetcherCache(leaseMgr, tableHist)
 
 	var kvs sqlbase.SpanKVFetcher
 	appendEmitEntryForKV := func(

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -166,11 +166,11 @@ func changefeedPlanHook(
 		targets := make(jobspb.ChangefeedTargets, len(targetDescs))
 		for _, desc := range targetDescs {
 			if tableDesc := desc.GetTable(); tableDesc != nil {
-				if err := validateChangefeedTable(tableDesc); err != nil {
-					return err
-				}
 				targets[tableDesc.ID] = jobspb.ChangefeedTarget{
 					StatementTimeName: tableDesc.Name,
+				}
+				if err := validateChangefeedTable(targets, tableDesc); err != nil {
+					return err
 				}
 			}
 		}
@@ -275,7 +275,14 @@ func validateDetails(details jobspb.ChangefeedDetails) (jobspb.ChangefeedDetails
 	return details, nil
 }
 
-func validateChangefeedTable(tableDesc *sqlbase.TableDescriptor) error {
+func validateChangefeedTable(
+	targets jobspb.ChangefeedTargets, tableDesc *sqlbase.TableDescriptor,
+) error {
+	t, ok := targets[tableDesc.ID]
+	if !ok {
+		return errors.Errorf(`unwatched table: %s`, tableDesc.Name)
+	}
+
 	// Technically, the only non-user table known not to work is system.jobs
 	// (which creates a cycle since the resolved timestamp high-water mark is
 	// saved in it), but there are subtle differences in the way many of them
@@ -298,6 +305,18 @@ func validateChangefeedTable(tableDesc *sqlbase.TableDescriptor) error {
 			`CHANGEFEEDs are currently supported on tables with exactly 1 column family: %s has %d`,
 			tableDesc.Name, len(tableDesc.Families))
 	}
+
+	if tableDesc.State == sqlbase.TableDescriptor_DROP {
+		return errors.Errorf(`"%s" was dropped or truncated`, t.StatementTimeName)
+	}
+	if tableDesc.Name != t.StatementTimeName {
+		return errors.Errorf(`"%s" was renamed to "%s"`, t.StatementTimeName, tableDesc.Name)
+	}
+
+	if tableDesc.HasColumnBackfillMutation() {
+		return errors.Errorf(`CHANGEFEEDs cannot operate on tables being backfilled`)
+	}
+
 	return nil
 }
 

--- a/pkg/ccl/changefeedccl/table_history.go
+++ b/pkg/ccl/changefeedccl/table_history.go
@@ -1,0 +1,300 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/pkg/errors"
+)
+
+type tableHistoryWaiter struct {
+	ts    hlc.Timestamp
+	errCh chan error
+}
+
+// tableHistory tracks that a some invariants hold over a set of tables as time
+// advances.
+//
+// Internally, two timestamps are tracked. The high-water is the highest
+// timestamp such that every version of a TableDescriptor has met a provided
+// invariant (via `validateFn`). An error timestamp is also kept, which is the
+// lowest timestamp where at least one table doesn't meet the invariant.
+//
+// The `WaitForTS` method allows a user to block until some given timestamp is
+// less (or equal) to either the high-water or the error timestamp. In the
+// latter case, it returns the error.
+type tableHistory struct {
+	validateFn func(*sqlbase.TableDescriptor) error
+
+	mu struct {
+		syncutil.Mutex
+
+		// the highest known valid timestamp
+		highWater hlc.Timestamp
+
+		// the lowest known invalid timestamp
+		errTS hlc.Timestamp
+
+		// the error associated with errTS
+		err error
+
+		// callers waiting on a timestamp to be resolved as valid or invalid
+		waiters []tableHistoryWaiter
+	}
+}
+
+// makeTableHistory creates tableHistory with the given initial high-water and
+// invariant check function. It is expected that `validateFn` is deterministic.
+func makeTableHistory(
+	validateFn func(*sqlbase.TableDescriptor) error, initialHighWater hlc.Timestamp,
+) *tableHistory {
+	m := &tableHistory{validateFn: validateFn}
+	m.mu.highWater = initialHighWater
+	return m
+}
+
+// HighWater returns the current high-water timestamp.
+func (m *tableHistory) HighWater() hlc.Timestamp {
+	m.mu.Lock()
+	highWater := m.mu.highWater
+	m.mu.Unlock()
+	return highWater
+}
+
+// WaitForTS blocks until the given timestamp is less than or equal to the
+// high-water or error timestamp. In the latter case, the error is returned.
+//
+// If called twice with the same timestamp, two different errors may be returned
+// (since the error timestamp can recede). However, the return for a given
+// timestamp will never switch from nil to an error or vice-versa (assuming that
+// `validateFn` is deterministic and the ingested descriptors are read
+// transactionally).
+func (m *tableHistory) WaitForTS(ctx context.Context, ts hlc.Timestamp) error {
+	var errCh chan error
+
+	m.mu.Lock()
+	highWater := m.mu.highWater
+	var err error
+	if m.mu.errTS != (hlc.Timestamp{}) && !ts.Less(m.mu.errTS) {
+		err = m.mu.err
+	}
+	fastPath := err != nil || !highWater.Less(ts)
+	if !fastPath {
+		errCh = make(chan error, 1)
+		m.mu.waiters = append(m.mu.waiters, tableHistoryWaiter{ts: ts, errCh: errCh})
+	}
+	m.mu.Unlock()
+	if fastPath {
+		if log.V(1) {
+			log.Infof(ctx, "fastpath for %s: %v", ts, err)
+		}
+		return err
+	}
+
+	if log.V(1) {
+		log.Infof(ctx, "waiting for %s highwater", ts)
+	}
+	start := timeutil.Now()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-errCh:
+		if log.V(1) {
+			log.Infof(ctx, "waited %s for %s highwater: %v", timeutil.Since(start), ts, err)
+		}
+		return err
+	}
+}
+
+// IngestDescriptors checks the given descriptors against the invariant check
+// function and adjusts the high-water or error timestamp appropriately. It is
+// required that the descriptors represent a transactional kv read between the
+// two given timestamps.
+func (m *tableHistory) IngestDescriptors(
+	startTS, endTS hlc.Timestamp, descs []*sqlbase.TableDescriptor,
+) error {
+	sort.Slice(descs, func(i, j int) bool {
+		return descs[i].ModificationTime.Less(descs[j].ModificationTime)
+	})
+	var validateErr error
+	for _, desc := range descs {
+		if err := m.validateFn(desc); validateErr == nil {
+			validateErr = err
+		}
+	}
+	return m.adjustTimestamps(startTS, endTS, validateErr)
+}
+
+// adjustTimestamps adjusts the high-water or error timestamp appropriately.
+func (m *tableHistory) adjustTimestamps(startTS, endTS hlc.Timestamp, validateErr error) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if validateErr != nil {
+		// don't care about startTS in the invalid case
+		if m.mu.errTS == (hlc.Timestamp{}) || endTS.Less(m.mu.errTS) {
+			m.mu.errTS = endTS
+			m.mu.err = validateErr
+			newWaiters := make([]tableHistoryWaiter, 0, len(m.mu.waiters))
+			for _, w := range m.mu.waiters {
+				if w.ts.Less(m.mu.errTS) {
+					newWaiters = append(newWaiters, w)
+					continue
+				}
+				w.errCh <- validateErr
+			}
+			m.mu.waiters = newWaiters
+		}
+		return validateErr
+	}
+
+	if m.mu.highWater.Less(startTS) {
+		return errors.Errorf(`gap between %s and %s`, m.mu.highWater, startTS)
+	}
+	if m.mu.highWater.Less(endTS) {
+		m.mu.highWater = endTS
+		newWaiters := make([]tableHistoryWaiter, 0, len(m.mu.waiters))
+		for _, w := range m.mu.waiters {
+			if m.mu.highWater.Less(w.ts) {
+				newWaiters = append(newWaiters, w)
+				continue
+			}
+			w.errCh <- nil
+		}
+		m.mu.waiters = newWaiters
+	}
+	return nil
+}
+
+type tableHistoryUpdater struct {
+	settings *cluster.Settings
+	db       *client.DB
+	targets  jobspb.ChangefeedTargets
+	m        *tableHistory
+}
+
+func (u *tableHistoryUpdater) PollTableDescs(ctx context.Context) error {
+	// TODO(dan): Replace this with a RangeFeed once it stabilizes.
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(changefeedPollInterval.Get(&u.settings.SV)):
+		}
+
+		startTS, endTS := u.m.HighWater(), u.db.Clock().Now()
+		if !startTS.Less(endTS) {
+			continue
+		}
+		descs, err := fetchTableDescriptorVersions(ctx, u.db, startTS, endTS, u.targets)
+		if err != nil {
+			return err
+		}
+		if err := u.m.IngestDescriptors(startTS, endTS, descs); err != nil {
+			return err
+		}
+	}
+}
+
+func fetchTableDescriptorVersions(
+	ctx context.Context,
+	db *client.DB,
+	startTS, endTS hlc.Timestamp,
+	targets jobspb.ChangefeedTargets,
+) ([]*sqlbase.TableDescriptor, error) {
+	if log.V(2) {
+		log.Infof(ctx, `fetching table descs [%s,%s)`, startTS, endTS)
+	}
+	start := timeutil.Now()
+	span := roachpb.Span{Key: keys.MakeTablePrefix(keys.DescriptorTableID)}
+	span.EndKey = span.Key.PrefixEnd()
+	header := roachpb.Header{Timestamp: endTS}
+	req := &roachpb.ExportRequest{
+		RequestHeader: roachpb.RequestHeaderFromSpan(span),
+		StartTime:     startTS,
+		MVCCFilter:    roachpb.MVCCFilter_All,
+		ReturnSST:     true,
+	}
+	res, pErr := client.SendWrappedWith(ctx, db.NonTransactionalSender(), header, req)
+	if log.V(2) {
+		log.Infof(ctx, `fetched table descs [%s,%s) took %s`, startTS, endTS, timeutil.Since(start))
+	}
+	if pErr != nil {
+		return nil, errors.Wrapf(
+			pErr.GoError(), `fetching changes for [%s,%s)`, span.Key, span.EndKey)
+	}
+
+	var tableDescs []*sqlbase.TableDescriptor
+	for _, file := range res.(*roachpb.ExportResponse).Files {
+		if err := func() error {
+			it, err := engineccl.NewMemSSTIterator(file.SST, false /* verify */)
+			if err != nil {
+				return err
+			}
+			defer it.Close()
+			for it.Seek(engine.NilKey); ; it.Next() {
+				if ok, err := it.Valid(); err != nil {
+					return err
+				} else if !ok {
+					return nil
+				}
+				remaining, _, _, err := sqlbase.DecodeTableIDIndexID(it.UnsafeKey().Key)
+				if err != nil {
+					return err
+				}
+				_, tableID, err := encoding.DecodeUvarintAscending(remaining)
+				if err != nil {
+					return err
+				}
+				// WIP: I think targets currently doesn't contain interleaved
+				// parents if they are not watched by the changefeed, but this
+				// seems wrong.
+				origName, ok := targets[sqlbase.ID(tableID)]
+				if !ok {
+					// Uninteresting table.
+					continue
+				}
+				unsafeValue := it.UnsafeValue()
+				if unsafeValue == nil {
+					return errors.Errorf(`"%s" was dropped or truncated`, origName)
+				}
+				value := roachpb.Value{RawBytes: unsafeValue}
+				var desc sqlbase.Descriptor
+				if err := value.GetProto(&desc); err != nil {
+					return err
+				}
+				if tableDesc := desc.GetTable(); tableDesc != nil {
+					// WIP
+					log.Infof(ctx, "%s %d %s", desc.GetName(), tableDesc.Version, it.UnsafeKey().Timestamp)
+					tableDescs = append(tableDescs, tableDesc)
+				}
+			}
+		}(); err != nil {
+			return nil, err
+		}
+	}
+	return tableDescs, nil
+}

--- a/pkg/ccl/changefeedccl/table_history_test.go
+++ b/pkg/ccl/changefeedccl/table_history_test.go
@@ -1,0 +1,144 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestTableHistory(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	ts := func(wt int64) hlc.Timestamp { return hlc.Timestamp{WallTime: wt} }
+
+	validateFn := func(desc *sqlbase.TableDescriptor) error {
+		if desc.Name != `` {
+			return errors.New(desc.Name)
+		}
+		return nil
+	}
+	requireChannelEmpty := func(t *testing.T, ch chan error) {
+		t.Helper()
+		select {
+		case err := <-ch:
+			t.Fatalf(`expected empty channel got %v`, err)
+		default:
+		}
+	}
+
+	m := makeTableHistory(validateFn, ts(0))
+
+	require.Equal(t, ts(0), m.HighWater())
+
+	// advance
+	require.NoError(t, m.IngestDescriptors(ts(0), ts(1), nil))
+	require.Equal(t, ts(1), m.HighWater())
+	require.NoError(t, m.IngestDescriptors(ts(1), ts(2), nil))
+	require.Equal(t, ts(2), m.HighWater())
+
+	// no-ops
+	require.NoError(t, m.IngestDescriptors(ts(0), ts(1), nil))
+	require.Equal(t, ts(2), m.HighWater())
+	require.NoError(t, m.IngestDescriptors(ts(1), ts(2), nil))
+	require.Equal(t, ts(2), m.HighWater())
+
+	// overlap
+	require.NoError(t, m.IngestDescriptors(ts(1), ts(3), nil))
+	require.Equal(t, ts(3), m.HighWater())
+
+	// gap
+	require.EqualError(t, m.IngestDescriptors(ts(4), ts(5), nil),
+		`gap between 0.000000003,0 and 0.000000004,0`)
+	require.Equal(t, ts(3), m.HighWater())
+
+	// validates
+	require.NoError(t, m.IngestDescriptors(ts(3), ts(4), []*sqlbase.TableDescriptor{
+		{ID: 0},
+	}))
+	require.Equal(t, ts(4), m.HighWater())
+
+	// high-water already high enough. fast-path
+	require.NoError(t, m.WaitForTS(ctx, ts(3)))
+	require.NoError(t, m.WaitForTS(ctx, ts(4)))
+
+	// high-water not there yet. blocks
+	errCh6 := make(chan error, 1)
+	errCh7 := make(chan error, 1)
+	go func() { errCh7 <- m.WaitForTS(ctx, ts(7)) }()
+	go func() { errCh6 <- m.WaitForTS(ctx, ts(6)) }()
+	requireChannelEmpty(t, errCh6)
+	requireChannelEmpty(t, errCh7)
+
+	// high-water advances, but not enough
+	require.NoError(t, m.IngestDescriptors(ts(4), ts(5), nil))
+	requireChannelEmpty(t, errCh6)
+	requireChannelEmpty(t, errCh7)
+
+	// high-water advances, unblocks only errCh6
+	require.NoError(t, m.IngestDescriptors(ts(5), ts(6), nil))
+	require.NoError(t, <-errCh6)
+	requireChannelEmpty(t, errCh7)
+
+	// high-water advances again, unblocks errCh7
+	require.NoError(t, m.IngestDescriptors(ts(6), ts(7), nil))
+	require.NoError(t, <-errCh7)
+
+	// validate ctx cancellation
+	errCh8 := make(chan error, 1)
+	ctxTS8, cancelTS8 := context.WithCancel(ctx)
+	go func() { errCh8 <- m.WaitForTS(ctxTS8, ts(8)) }()
+	requireChannelEmpty(t, errCh8)
+	cancelTS8()
+	require.EqualError(t, <-errCh8, `context canceled`)
+
+	// does not validate, high-water does not change
+	require.EqualError(t, m.IngestDescriptors(ts(7), ts(10), []*sqlbase.TableDescriptor{
+		{ID: 0, Name: `whoops!`},
+	}), `whoops!`)
+	require.Equal(t, ts(7), m.HighWater())
+
+	// ts 10 has errored, so validate can return its error without blocking
+	require.EqualError(t, m.WaitForTS(ctx, ts(10)), `whoops!`)
+
+	// ts 8 and 9 are still unknown
+	errCh8 = make(chan error, 1)
+	errCh9 := make(chan error, 1)
+	go func() { errCh8 <- m.WaitForTS(ctx, ts(8)) }()
+	go func() { errCh9 <- m.WaitForTS(ctx, ts(9)) }()
+	requireChannelEmpty(t, errCh8)
+	requireChannelEmpty(t, errCh9)
+
+	// turns out ts 10 is not a tight bound. ts 9 also has an error
+	require.EqualError(t, m.IngestDescriptors(ts(7), ts(9), []*sqlbase.TableDescriptor{
+		{ID: 0, Name: `oh no!`},
+	}), `oh no!`)
+	require.Equal(t, ts(7), m.HighWater())
+	require.EqualError(t, <-errCh9, `oh no!`)
+
+	// ts 8 is still unknown
+	requireChannelEmpty(t, errCh8)
+
+	// always return the earlist error seen (so waiting for ts 10 immediately
+	// returns the 9 error now, it returned the ts 10 error above)
+	require.EqualError(t, m.WaitForTS(ctx, ts(9)), `oh no!`)
+
+	// something earlier than ts 10 can still be okay
+	require.NoError(t, m.IngestDescriptors(ts(7), ts(8), nil))
+	require.Equal(t, ts(8), m.HighWater())
+	require.NoError(t, <-errCh8)
+}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -144,7 +144,7 @@ func (sc *SchemaChanger) runBackfill(
 		case sqlbase.DescriptorMutation_ADD:
 			switch t := m.Descriptor_.(type) {
 			case *sqlbase.DescriptorMutation_Column:
-				if columnNeedsBackfill(m.GetColumn()) {
+				if sqlbase.ColumnNeedsBackfill(m.GetColumn()) {
 					needColumnBackfill = true
 				}
 			case *sqlbase.DescriptorMutation_Index:
@@ -582,10 +582,6 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 		backfill.ColumnMutationFilter)
 }
 
-func columnNeedsBackfill(desc *sqlbase.ColumnDescriptor) bool {
-	return desc.DefaultExpr != nil || !desc.Nullable || desc.IsComputed()
-}
-
 // runSchemaChangesInTxn runs all the schema changes immediately in a
 // transaction. This is called when a CREATE TABLE is followed by
 // schema changes in the same transaction. The CREATE TABLE is
@@ -626,7 +622,7 @@ func runSchemaChangesInTxn(
 		case sqlbase.DescriptorMutation_ADD:
 			switch m.Descriptor_.(type) {
 			case *sqlbase.DescriptorMutation_Column:
-				if doneColumnBackfill || !columnNeedsBackfill(m.GetColumn()) {
+				if doneColumnBackfill || !sqlbase.ColumnNeedsBackfill(m.GetColumn()) {
 					break
 				}
 				if err := columnBackfillInTxn(ctx, txn, tc, evalCtx, tableDesc, traceKV); err != nil {


### PR DESCRIPTION
When a table is currently being backfilled for a schema change (e.g.
adding a column with a default value), it's unclear what the expectation
is for any rows that are changed during the backfill. Our current
invariant is that rows are emitted with an updated timestamp and a later
SELECT ... AS OF SYSTEM TIME for that row would exactly match the
emitted data. During the backfill, there is nothing we can emit that
would definitely meet that invariant (because the backfill can be
aborted and rolled back).

In the meantime, this commit makes sure that we error whenever a
backfill happens, even if it's fast enough that we never get it from
leasing.

This also paves the way for switching to RangeFeed, which doesn't have
the convenient `fetchSpansForTargets` hook that the ExportRequest based
poller was (ab)using.

Closes #28643

Release note (bug fix): CHANGEFEEDs now error when a watched table
backfills (instead of undefined behavior)