### PR TITLE
opt: fold constants in optbuilder

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -854,11 +854,12 @@ func (b *Builder) initZipBuild(
 			return nil, nil, nil, opt.ColMap{}, err
 		}
 
-		props := child.Private().(*memo.FuncOpDef).Properties
-		if props.Class == tree.GeneratorClass {
-			numColsPerGen[i] = len(props.ReturnLabels)
-		} else {
-			numColsPerGen[i] = 1
+		numColsPerGen[i] = 1
+		if funcOpDef, ok := child.Private().(*memo.FuncOpDef); ok {
+			props := funcOpDef.Properties
+			if props.Class == tree.GeneratorClass {
+				numColsPerGen[i] = len(props.ReturnLabels)
+			}
 		}
 	}
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -583,9 +583,9 @@ scan  ·       ·                                                               
 query TTTTT
 EXPLAIN (TYPES) SELECT abs(2-3) AS a
 ----
-render         ·         ·                      (a int)  ·
- │             render 0  (abs((-1)[int]))[int]  ·        ·
- └── emptyrow  ·         ·                      ()       ·
+render         ·         ·         (a int)  ·
+ │             render 0  (1)[int]  ·        ·
+ └── emptyrow  ·         ·         ()       ·
 
 # Check array subscripts (#13811)
 query TTTTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -519,17 +519,17 @@ render     ·         ·                           ("?column?")  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 = ANY (1, 2, 3) FROM t
 ----
-render     ·         ·                  ("?column?")  ·
- │         render 0  1 = ANY (1, 2, 3)  ·             ·
- └── scan  ·         ·                  ()            ·
-·          table     t@primary          ·             ·
-·          spans     ALL                ·             ·
+render     ·         ·          ("?column?")  ·
+ │         render 0  true       ·             ·
+ └── scan  ·         ·          ()            ·
+·          table     t@primary  ·             ·
+·          spans     ALL        ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 = ANY () FROM t
 ----
-render     ·         ·           ("?column?")  ·
- │         render 0  1 = ANY ()  ·             ·
- └── scan  ·         ·           ()            ·
-·          table     t@primary   ·             ·
-·          spans     ALL         ·             ·
+render     ·         ·          ("?column?")  ·
+ │         render 0  false      ·             ·
+ └── scan  ·         ·          ()            ·
+·          table     t@primary  ·             ·
+·          spans     ALL        ·             ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/values
+++ b/pkg/sql/opt/exec/execbuilder/testdata/values
@@ -32,10 +32,10 @@ EXPLAIN (VERBOSE) VALUES (length('a')), (1 + length('a')), (length('abc')), (len
 ----
 values  ·              ·                 (column1)  ·
 ·       size           1 column, 4 rows  ·          ·
-·       row 0, expr 0  length('a')       ·          ·
-·       row 1, expr 0  1 + length('a')   ·          ·
-·       row 2, expr 0  length('abc')     ·          ·
-·       row 3, expr 0  length('ab') * 2  ·          ·
+·       row 0, expr 0  1                 ·          ·
+·       row 1, expr 0  2                 ·          ·
+·       row 2, expr 0  3                 ·          ·
+·       row 3, expr 0  4                 ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a + b AS r FROM (VALUES (1, 2), (3, 4), (5, 6)) AS v(a, b)

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -53,6 +53,7 @@ func runDataDrivenTest(t *testing.T, path string, fmtFlags memo.ExprFmtFlags) {
 		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
 			tester := testutils.NewOptTester(catalog, d.Input)
 			tester.Flags.ExprFormat = fmtFlags
+			tester.Flags.SkipFoldConstants = true
 			return tester.RunCommand(t, d)
 		})
 	})

--- a/pkg/sql/opt/norm/norm_test.go
+++ b/pkg/sql/opt/norm/norm_test.go
@@ -49,6 +49,7 @@ func TestNormRules(t *testing.T) {
 		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
 			tester := testutils.NewOptTester(catalog, d.Input)
 			tester.Flags.ExprFormat = fmtFlags
+			tester.Flags.SkipFoldConstants = true
 			return tester.RunCommand(t, d)
 		})
 	})

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -83,6 +83,9 @@ type Builder struct {
 	// be used with care.
 	skipSelectPrivilegeChecks bool
 
+	// SkipFoldConstants tells the optbuilder to skip folding of constants.
+	SkipFoldConstants bool
+
 	// views contains a cache of views that have already been parsed, in case they
 	// are referenced multiple times in the same query.
 	views map[opt.View]*tree.Select

--- a/pkg/sql/opt/optbuilder/fold_constants.go
+++ b/pkg/sql/opt/optbuilder/fold_constants.go
@@ -1,0 +1,171 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package optbuilder
+
+import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+
+// NB: most of this code is copied from sql/sem/tree/normalize.go, with the
+// normalization logic removed.
+
+// foldConstantsVisitor supports the folding of constants.
+type foldConstantsVisitor struct {
+	ctx *tree.EvalContext
+	err error
+
+	fastIsConstVisitor fastIsConstVisitor
+}
+
+var _ tree.Visitor = &foldConstantsVisitor{}
+
+// makeFoldConstantsVisitor creates a foldConstantsVisitor instance.
+func makeFoldConstantsVisitor(ctx *tree.EvalContext) foldConstantsVisitor {
+	return foldConstantsVisitor{ctx: ctx, fastIsConstVisitor: fastIsConstVisitor{ctx: ctx}}
+}
+
+// Err retrieves the error field in the foldConstantsVisitor.
+func (v *foldConstantsVisitor) Err() error { return v.err }
+
+// VisitPre implements the Visitor interface.
+func (v *foldConstantsVisitor) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
+	if v.err != nil {
+		return false, expr
+	}
+
+	switch expr.(type) {
+	case *tree.Subquery:
+		// Subqueries are pre-normalized during semantic analysis. There
+		// is nothing to do here.
+		return false, expr
+	}
+
+	return true, expr
+}
+
+// VisitPost implements the Visitor interface.
+func (v *foldConstantsVisitor) VisitPost(expr tree.Expr) tree.Expr {
+	if v.err != nil {
+		return expr
+	}
+	// We don't propagate errors during this step because errors might involve a
+	// branch of code that isn't traversed by normal execution (for example,
+	// IF(2 = 2, 1, 1 / 0)).
+
+	// Evaluate all constant expressions.
+	if v.isConst(expr) {
+		value, err := expr.(tree.TypedExpr).Eval(v.ctx)
+		if err != nil {
+			// Ignore any errors here (e.g. division by zero), so they can happen
+			// during execution where they are correctly handled. Note that in some
+			// cases we might not even get an error (if this particular expression
+			// does not get evaluated when the query runs, e.g. it's inside a CASE).
+			return expr
+		}
+		if value == tree.DNull {
+			// We don't want to return an expression that has a different type; cast
+			// the NULL if necessary.
+			var newExpr tree.TypedExpr
+			newExpr, v.err = tree.ReType(tree.DNull, expr.(tree.TypedExpr).ResolvedType())
+			if v.err != nil {
+				return expr
+			}
+			return newExpr
+		}
+		return value
+	}
+
+	return expr
+}
+
+func (v *foldConstantsVisitor) isConst(expr tree.Expr) bool {
+	return v.fastIsConstVisitor.run(expr)
+}
+
+// fastIsConstVisitor determines if an expression is constant by visiting
+// at most two levels of the tree (with one exception, see below).
+// In essence, it determines whether an expression is constant by checking
+// whether its children are const Datums.
+//
+// This can be used by foldConstantsVisitor since constants are evaluated
+// bottom-up. If a child is *not* a const Datum, that means it was already
+// determined to be non-constant, and therefore was not evaluated.
+type fastIsConstVisitor struct {
+	ctx     *tree.EvalContext
+	isConst bool
+
+	// visited indicates whether we have already visited one level of the tree.
+	// fastIsConstVisitor only visits at most two levels of the tree, with one
+	// exception: If the second level has a Cast expression, fastIsConstVisitor
+	// may visit three levels.
+	visited bool
+}
+
+var _ tree.Visitor = &fastIsConstVisitor{}
+
+func (v *fastIsConstVisitor) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
+	if v.visited {
+		if _, ok := expr.(*tree.CastExpr); ok {
+			// We recurse one more time for cast expressions, since the
+			// foldConstantsVisitor may have wrapped a NULL.
+			return true, expr
+		}
+		if _, ok := expr.(tree.Datum); !ok || isVar(v.ctx, expr) {
+			// If the child expression is not a const Datum, the parent expression is
+			// not constant. Note that all constant literals have already been
+			// normalized to Datum in TypeCheck.
+			v.isConst = false
+		}
+		return false, expr
+	}
+	v.visited = true
+
+	// If the parent expression is a variable or impure function, we know that it
+	// is not constant.
+
+	if isVar(v.ctx, expr) {
+		v.isConst = false
+		return false, expr
+	}
+
+	switch t := expr.(type) {
+	case *tree.FuncExpr:
+		if t.IsImpure() {
+			v.isConst = false
+			return false, expr
+		}
+	}
+
+	return true, expr
+}
+
+func (*fastIsConstVisitor) VisitPost(expr tree.Expr) tree.Expr { return expr }
+
+func (v *fastIsConstVisitor) run(expr tree.Expr) bool {
+	v.isConst = true
+	v.visited = false
+	tree.WalkExprConst(v, expr)
+	return v.isConst
+}
+
+// isVar returns true if the expression's value can vary during plan
+// execution.
+func isVar(evalCtx *tree.EvalContext, expr tree.Expr) bool {
+	switch expr.(type) {
+	case tree.VariableExpr:
+		return true
+	case *tree.Placeholder:
+		return evalCtx != nil && (!evalCtx.HasPlaceholders() || evalCtx.Placeholders.IsUnresolvedPlaceholder(expr))
+	}
+	return false
+}

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
@@ -72,6 +73,9 @@ type scope struct {
 	// context is the current context in the SQL query (e.g., "SELECT" or
 	// "HAVING"). It is used for error messages.
 	context string
+
+	// foldConstantsVisitor is used for constant folding.
+	foldConstantsVisitor foldConstantsVisitor
 }
 
 // groupByStrSet is a set of stringified GROUP BY expressions that map to the
@@ -252,6 +256,11 @@ func (s *scope) resolveType(expr tree.Expr, desired types.T) tree.TypedExpr {
 		panic(builderError{err})
 	}
 
+	texpr, err = s.foldConstants(s.builder.evalCtx, texpr)
+	if err != nil {
+		panic(builderError{err})
+	}
+
 	return texpr
 }
 
@@ -266,6 +275,11 @@ func (s *scope) resolveType(expr tree.Expr, desired types.T) tree.TypedExpr {
 func (s *scope) resolveAndRequireType(expr tree.Expr, desired types.T) tree.TypedExpr {
 	expr = s.walkExprTree(expr)
 	texpr, err := tree.TypeCheckAndRequire(expr, s.builder.semaCtx, desired, s.context)
+	if err != nil {
+		panic(builderError{err})
+	}
+
+	texpr, err = s.foldConstants(s.builder.evalCtx, texpr)
 	if err != nil {
 		panic(builderError{err})
 	}
@@ -731,6 +745,11 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 		}
 		return false, colI.(*scopeColumn)
 
+	case *tree.CastExpr:
+		if t.Type == coltypes.RegClass {
+			s.builder.SkipFoldConstants = true
+		}
+
 	case *tree.FuncExpr:
 		if t.WindowDef != nil {
 			panic(unimplementedf("window functions are not supported"))
@@ -825,6 +844,11 @@ func (s *scope) replaceSRF(f *tree.FuncExpr, def *tree.FunctionDefinition) *srf 
 		panic(builderError{err})
 	}
 
+	typedFunc, err = s.foldConstants(s.builder.evalCtx, typedFunc)
+	if err != nil {
+		panic(builderError{err})
+	}
+
 	srfScope := s.push()
 	var outCol *scopeColumn
 	if len(def.ReturnLabels) == 1 {
@@ -872,6 +896,11 @@ func (s *scope) replaceAggregate(f *tree.FuncExpr, def *tree.FunctionDefinition)
 
 	expr := f.Walk(s)
 	typedFunc, err := tree.TypeCheck(expr, s.builder.semaCtx, types.Any)
+	if err != nil {
+		panic(builderError{err})
+	}
+
+	typedFunc, err = s.foldConstants(s.builder.evalCtx, typedFunc)
 	if err != nil {
 		panic(builderError{err})
 	}
@@ -954,8 +983,8 @@ func (s *scope) replaceSubquery(sub *tree.Subquery, multiRow bool, desiredColumn
 	}
 
 	subq := subquery{
+		Subquery: sub,
 		multiRow: multiRow,
-		expr:     sub,
 	}
 
 	// Save and restore the previous value of s.builder.subquery in case we are
@@ -1029,6 +1058,20 @@ func (s *scope) IndexedVarResolvedType(idx int) types.T {
 // IndexedVarNodeFormatter is part of the IndexedVarContainer interface.
 func (s *scope) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 	panic("unimplemented: scope.IndexedVarNodeFormatter")
+}
+
+func (s *scope) foldConstants(
+	ctx *tree.EvalContext, typedExpr tree.TypedExpr,
+) (tree.TypedExpr, error) {
+	if s.builder.SkipFoldConstants {
+		return typedExpr, nil
+	}
+	s.foldConstantsVisitor = makeFoldConstantsVisitor(ctx)
+	expr, _ := tree.WalkExpr(&s.foldConstantsVisitor, typedExpr)
+	if err := s.foldConstantsVisitor.Err(); err != nil {
+		return nil, err
+	}
+	return expr.(tree.TypedExpr), nil
 }
 
 // newAmbiguousColumnError returns an error with a helpful error message to be

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -26,6 +26,9 @@ import (
 // subquery represents a subquery expression in an expression tree
 // after it has been type-checked and added to the memo.
 type subquery struct {
+	// The AST Subquery expression.
+	*tree.Subquery
+
 	// cols contains the output columns of the subquery.
 	cols []scopeColumn
 
@@ -43,23 +46,10 @@ type subquery struct {
 	// typ is the lazily resolved type of the subquery.
 	typ types.T
 
-	// expr is the AST Subquery expression.
-	expr *tree.Subquery
-
 	// outerCols stores the set of outer columns in the subquery. These are
 	// columns which are referenced within the subquery but are bound in an
 	// outer scope.
 	outerCols opt.ColSet
-}
-
-// String is part of the tree.Expr interface.
-func (s *subquery) String() string {
-	return s.expr.String()
-}
-
-// Format is part of the tree.Expr interface.
-func (s *subquery) Format(ctx *tree.FmtCtx) {
-	s.expr.Format(ctx)
 }
 
 // Walk is part of the tree.Expr interface.
@@ -129,7 +119,7 @@ func (s *subquery) TypeCheck(_ *tree.SemaContext, desired types.T) (tree.TypedEx
 	// Without that auto-unwrapping of single-column subqueries, this query would
 	// type check as "<int> IN <tuple{tuple{int}}>" which would fail.
 
-	if s.expr.Exists {
+	if s.Exists {
 		s.typ = types.Bool
 		return s, nil
 	}
@@ -225,7 +215,7 @@ func (b *Builder) buildSubqueryProjection(
 func (b *Builder) buildSingleRowSubquery(
 	s *subquery, inScope *scope,
 ) (out memo.GroupID, outScope *scope) {
-	if s.expr.Exists {
+	if s.Exists {
 		return b.factory.ConstructExists(s.group), inScope
 	}
 

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -467,15 +467,14 @@ SELECT count(*) FROM kv GROUP BY length('abc')
 project
  ├── columns: count:5(int)
  └── group-by
-      ├── columns: count_rows:5(int) column6:6(int)
-      ├── grouping columns: column6:6(int)
+      ├── columns: count_rows:5(int) column6:6(int!null)
+      ├── grouping columns: column6:6(int!null)
       ├── project
-      │    ├── columns: column6:6(int)
+      │    ├── columns: column6:6(int!null)
       │    ├── scan kv
       │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
       │    └── projections
-      │         └── function: length [type=int]
-      │              └── const: 'abc' [type=string]
+      │         └── const: 3 [type=int]
       └── aggregations
            └── count-rows [type=int]
 
@@ -1616,16 +1615,13 @@ project
  ├── scalar-group-by
  │    ├── columns: avg:2(decimal) avg:4(float) avg:6(decimal)
  │    ├── project
- │    │    ├── columns: column1:1(int) column3:3(float) column5:5(decimal)
+ │    │    ├── columns: column1:1(int!null) column3:3(float!null) column5:5(decimal!null)
  │    │    ├── values
  │    │    │    └── tuple [type=tuple]
  │    │    └── projections
- │    │         ├── cast: INT [type=int]
- │    │         │    └── const: 1 [type=int]
- │    │         ├── cast: FLOAT8 [type=float]
- │    │         │    └── const: 2.0 [type=float]
- │    │         └── cast: DECIMAL [type=decimal]
- │    │              └── const: 3 [type=decimal]
+ │    │         ├── const: 1 [type=int]
+ │    │         ├── const: 2.0 [type=float]
+ │    │         └── const: 3 [type=decimal]
  │    └── aggregations
  │         ├── avg [type=decimal]
  │         │    └── variable: column1 [type=int]
@@ -1647,16 +1643,13 @@ SELECT count(2::int), count(3::float), count(4::decimal)
 scalar-group-by
  ├── columns: count:2(int) count:4(int) count:6(int)
  ├── project
- │    ├── columns: column1:1(int) column3:3(float) column5:5(decimal)
+ │    ├── columns: column1:1(int!null) column3:3(float!null) column5:5(decimal!null)
  │    ├── values
  │    │    └── tuple [type=tuple]
  │    └── projections
- │         ├── cast: INT [type=int]
- │         │    └── const: 2 [type=int]
- │         ├── cast: FLOAT8 [type=float]
- │         │    └── const: 3.0 [type=float]
- │         └── cast: DECIMAL [type=decimal]
- │              └── const: 4 [type=decimal]
+ │         ├── const: 2 [type=int]
+ │         ├── const: 3.0 [type=float]
+ │         └── const: 4 [type=decimal]
  └── aggregations
       ├── count [type=int]
       │    └── variable: column1 [type=int]
@@ -1671,16 +1664,13 @@ SELECT sum(1::int), sum(2::float), sum(3::decimal)
 scalar-group-by
  ├── columns: sum:2(decimal) sum:4(float) sum:6(decimal)
  ├── project
- │    ├── columns: column1:1(int) column3:3(float) column5:5(decimal)
+ │    ├── columns: column1:1(int!null) column3:3(float!null) column5:5(decimal!null)
  │    ├── values
  │    │    └── tuple [type=tuple]
  │    └── projections
- │         ├── cast: INT [type=int]
- │         │    └── const: 1 [type=int]
- │         ├── cast: FLOAT8 [type=float]
- │         │    └── const: 2.0 [type=float]
- │         └── cast: DECIMAL [type=decimal]
- │              └── const: 3 [type=decimal]
+ │         ├── const: 1 [type=int]
+ │         ├── const: 2.0 [type=float]
+ │         └── const: 3 [type=decimal]
  └── aggregations
       ├── sum [type=decimal]
       │    └── variable: column1 [type=int]
@@ -1695,16 +1685,13 @@ SELECT variance(1::int), variance(1::float), variance(1::decimal)
 scalar-group-by
  ├── columns: variance:2(decimal) variance:4(float) variance:6(decimal)
  ├── project
- │    ├── columns: column1:1(int) column3:3(float) column5:5(decimal)
+ │    ├── columns: column1:1(int!null) column3:3(float!null) column5:5(decimal!null)
  │    ├── values
  │    │    └── tuple [type=tuple]
  │    └── projections
- │         ├── cast: INT [type=int]
- │         │    └── const: 1 [type=int]
- │         ├── cast: FLOAT8 [type=float]
- │         │    └── const: 1.0 [type=float]
- │         └── cast: DECIMAL [type=decimal]
- │              └── const: 1 [type=decimal]
+ │         ├── const: 1 [type=int]
+ │         ├── const: 1.0 [type=float]
+ │         └── const: 1 [type=decimal]
  └── aggregations
       ├── variance [type=decimal]
       │    └── variable: column1 [type=int]
@@ -1719,16 +1706,13 @@ SELECT stddev(1::int), stddev(1::float), stddev(1::decimal)
 scalar-group-by
  ├── columns: stddev:2(decimal) stddev:4(float) stddev:6(decimal)
  ├── project
- │    ├── columns: column1:1(int) column3:3(float) column5:5(decimal)
+ │    ├── columns: column1:1(int!null) column3:3(float!null) column5:5(decimal!null)
  │    ├── values
  │    │    └── tuple [type=tuple]
  │    └── projections
- │         ├── cast: INT [type=int]
- │         │    └── const: 1 [type=int]
- │         ├── cast: FLOAT8 [type=float]
- │         │    └── const: 1.0 [type=float]
- │         └── cast: DECIMAL [type=decimal]
- │              └── const: 1 [type=decimal]
+ │         ├── const: 1 [type=int]
+ │         ├── const: 1.0 [type=float]
+ │         └── const: 1 [type=decimal]
  └── aggregations
       ├── std-dev [type=decimal]
       │    └── variable: column1 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -505,12 +505,11 @@ sort
  ├── columns: a:1(int!null) b:2(int) c:3(bool)
  ├── ordering: +4
  └── project
-      ├── columns: column4:4(int) a:1(int!null) b:2(int) c:3(bool)
+      ├── columns: column4:4(int!null) a:1(int!null) b:2(int) c:3(bool)
       ├── scan t
       │    └── columns: a:1(int!null) b:2(int) c:3(bool)
       └── projections
-           └── function: length [type=int]
-                └── const: 'abc' [type=string]
+           └── const: 3 [type=int]
 
 build
 SELECT b+2 AS r FROM t ORDER BY b+2

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -157,7 +157,7 @@ project
            │    └── variable: b [type=int]
            └── variable: c [type=int]
 
-build allow-unsupported
+build
 SELECT a,b FROM abc WHERE CASE WHEN a != 0 THEN b/a > 1.5 ELSE false END
 ----
 project
@@ -577,7 +577,7 @@ project
  └── scan boolean_table
       └── columns: id:1(int!null) value:2(bool)
 
-build allow-unsupported
+build skip-fold-constants
 SELECT CASE WHEN NULL THEN 1 ELSE 2 END
 ----
 project
@@ -591,6 +591,16 @@ project
            │    ├── null [type=unknown]
            │    └── const: 1 [type=int]
            └── const: 2 [type=int]
+
+build
+SELECT CASE WHEN NULL THEN 1 ELSE 2 END
+----
+project
+ ├── columns: case:1(int!null)
+ ├── values
+ │    └── tuple [type=tuple]
+ └── projections
+      └── const: 2 [type=int]
 
 build
 SELECT 0 * b AS r, b % 1 AS s, 0 % b AS t from abc
@@ -615,15 +625,11 @@ build
 SELECT 1 IN (1, 2) AS r
 ----
 project
- ├── columns: r:1(bool)
+ ├── columns: r:1(bool!null)
  ├── values
  │    └── tuple [type=tuple]
  └── projections
-      └── in [type=bool]
-           ├── const: 1 [type=int]
-           └── tuple [type=tuple{int, int}]
-                ├── const: 1 [type=int]
-                └── const: 2 [type=int]
+      └── true [type=bool]
 
 build
 SELECT NULL IN (1, 2) AS r
@@ -633,11 +639,8 @@ project
  ├── values
  │    └── tuple [type=tuple]
  └── projections
-      └── in [type=bool]
-           ├── null [type=unknown]
-           └── tuple [type=tuple{int, int}]
-                ├── const: 1 [type=int]
-                └── const: 2 [type=int]
+      └── cast: BOOL [type=bool]
+           └── null [type=unknown]
 
 build
 SELECT 1 IN (NULL, 2) AS r
@@ -647,11 +650,8 @@ project
  ├── values
  │    └── tuple [type=tuple]
  └── projections
-      └── in [type=bool]
-           ├── const: 1 [type=int]
-           └── tuple [type=tuple{int, int}]
-                ├── null [type=unknown]
-                └── const: 2 [type=int]
+      └── cast: BOOL [type=bool]
+           └── null [type=unknown]
 
 build
 SELECT (1, NULL) IN ((1, 1)) AS r
@@ -661,14 +661,8 @@ project
  ├── values
  │    └── tuple [type=tuple]
  └── projections
-      └── in [type=bool]
-           ├── tuple [type=tuple{int, int}]
-           │    ├── const: 1 [type=int]
-           │    └── null [type=unknown]
-           └── tuple [type=tuple{tuple{int, int}}]
-                └── tuple [type=tuple{int, int}]
-                     ├── const: 1 [type=int]
-                     └── const: 1 [type=int]
+      └── cast: BOOL [type=bool]
+           └── null [type=unknown]
 
 # Tests with a tuple coming from a subquery.
 build
@@ -709,8 +703,7 @@ project
            │              └── variable: column2 [type=int]
            └── tuple [type=tuple{int, int}]
                 ├── const: 1 [type=int]
-                └── cast: INT [type=int]
-                     └── null [type=unknown]
+                └── null [type=unknown]
 
 build
 SELECT NULL::int NOT IN (SELECT * FROM (VALUES (1)) AS t(a)) AS r
@@ -752,8 +745,7 @@ project
                 │              └── variable: column2 [type=int]
                 └── tuple [type=tuple{int, int}]
                      ├── const: 1 [type=int]
-                     └── cast: INT [type=int]
-                          └── null [type=unknown]
+                     └── null [type=unknown]
 
 # Tests with an empty IN tuple.
 build
@@ -806,7 +798,60 @@ project
            │              └── variable: column2 [type=int]
            └── tuple [type=tuple{int, int}]
                 ├── const: 1 [type=int]
+                └── null [type=unknown]
+
+build
+SELECT NULL::int NOT IN (SELECT * FROM (VALUES (1)) AS t(a) WHERE a > 1) AS r
+----
+project
+ ├── columns: r:2(bool)
+ ├── values
+ │    └── tuple [type=tuple]
+ └── projections
+      └── not [type=bool]
+           └── any: eq [type=bool]
+                ├── select
+                │    ├── columns: column1:1(int!null)
+                │    ├── values
+                │    │    ├── columns: column1:1(int)
+                │    │    └── tuple [type=tuple{int}]
+                │    │         └── const: 1 [type=int]
+                │    └── filters [type=bool]
+                │         └── gt [type=bool]
+                │              ├── variable: column1 [type=int]
+                │              └── const: 1 [type=int]
                 └── cast: INT [type=int]
+                     └── null [type=unknown]
+
+build
+SELECT (1, NULL::int) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b) WHERE a > 1) AS r
+----
+project
+ ├── columns: r:4(bool)
+ ├── values
+ │    └── tuple [type=tuple]
+ └── projections
+      └── not [type=bool]
+           └── any: eq [type=bool]
+                ├── project
+                │    ├── columns: column3:3(tuple{int, int})
+                │    ├── select
+                │    │    ├── columns: column1:1(int!null) column2:2(int)
+                │    │    ├── values
+                │    │    │    ├── columns: column1:1(int) column2:2(int)
+                │    │    │    └── tuple [type=tuple{int, int}]
+                │    │    │         ├── const: 1 [type=int]
+                │    │    │         └── const: 1 [type=int]
+                │    │    └── filters [type=bool]
+                │    │         └── gt [type=bool]
+                │    │              ├── variable: column1 [type=int]
+                │    │              └── const: 1 [type=int]
+                │    └── projections
+                │         └── tuple [type=tuple{int, int}]
+                │              ├── variable: column1 [type=int]
+                │              └── variable: column2 [type=int]
+                └── tuple [type=tuple{int, int}]
+                     ├── const: 1 [type=int]
                      └── null [type=unknown]
 
 build
@@ -861,8 +906,7 @@ project
                 │              └── variable: column2 [type=int]
                 └── tuple [type=tuple{int, int}]
                      ├── const: 1 [type=int]
-                     └── cast: INT [type=int]
-                          └── null [type=unknown]
+                     └── null [type=unknown]
 
 build
 SELECT NULL::int NOT IN (SELECT * FROM (VALUES (1)) AS t(a) WHERE a > 1) AS r
@@ -916,63 +960,7 @@ project
                 │              └── variable: column2 [type=int]
                 └── tuple [type=tuple{int, int}]
                      ├── const: 1 [type=int]
-                     └── cast: INT [type=int]
-                          └── null [type=unknown]
-
-build
-SELECT NULL::int NOT IN (SELECT * FROM (VALUES (1)) AS t(a) WHERE a > 1) AS r
-----
-project
- ├── columns: r:2(bool)
- ├── values
- │    └── tuple [type=tuple]
- └── projections
-      └── not [type=bool]
-           └── any: eq [type=bool]
-                ├── select
-                │    ├── columns: column1:1(int!null)
-                │    ├── values
-                │    │    ├── columns: column1:1(int)
-                │    │    └── tuple [type=tuple{int}]
-                │    │         └── const: 1 [type=int]
-                │    └── filters [type=bool]
-                │         └── gt [type=bool]
-                │              ├── variable: column1 [type=int]
-                │              └── const: 1 [type=int]
-                └── cast: INT [type=int]
                      └── null [type=unknown]
-
-build
-SELECT (1, NULL::int) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b) WHERE a > 1) AS r
-----
-project
- ├── columns: r:4(bool)
- ├── values
- │    └── tuple [type=tuple]
- └── projections
-      └── not [type=bool]
-           └── any: eq [type=bool]
-                ├── project
-                │    ├── columns: column3:3(tuple{int, int})
-                │    ├── select
-                │    │    ├── columns: column1:1(int!null) column2:2(int)
-                │    │    ├── values
-                │    │    │    ├── columns: column1:1(int) column2:2(int)
-                │    │    │    └── tuple [type=tuple{int, int}]
-                │    │    │         ├── const: 1 [type=int]
-                │    │    │         └── const: 1 [type=int]
-                │    │    └── filters [type=bool]
-                │    │         └── gt [type=bool]
-                │    │              ├── variable: column1 [type=int]
-                │    │              └── const: 1 [type=int]
-                │    └── projections
-                │         └── tuple [type=tuple{int, int}]
-                │              ├── variable: column1 [type=int]
-                │              └── variable: column2 [type=int]
-                └── tuple [type=tuple{int, int}]
-                     ├── const: 1 [type=int]
-                     └── cast: INT [type=int]
-                          └── null [type=unknown]
 
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, y FLOAT)

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -173,9 +173,7 @@ SELECT * from unnest(ARRAY[1,2])
 zip
  ├── columns: unnest:1(int)
  └── function: unnest [type=int]
-      └── array: [type=int[]]
-           ├── const: 1 [type=int]
-           └── const: 2 [type=int]
+      └── const: ARRAY[1,2] [type=int[]]
 
 build
 SELECT unnest(ARRAY[1,2]), unnest(ARRAY['a', 'b'])
@@ -187,13 +185,9 @@ inner-join-apply
  ├── zip
  │    ├── columns: unnest:1(int) unnest:2(string)
  │    ├── function: unnest [type=int]
- │    │    └── array: [type=int[]]
- │    │         ├── const: 1 [type=int]
- │    │         └── const: 2 [type=int]
+ │    │    └── const: ARRAY[1,2] [type=int[]]
  │    └── function: unnest [type=int]
- │         └── array: [type=string[]]
- │              ├── const: 'a' [type=string]
- │              └── const: 'b' [type=string]
+ │         └── const: ARRAY['a','b'] [type=string[]]
  └── true [type=bool]
 
 build
@@ -208,9 +202,7 @@ project
  │    ├── zip
  │    │    ├── columns: unnest:1(int)
  │    │    └── function: unnest [type=int]
- │    │         └── array: [type=int[]]
- │    │              ├── const: 3 [type=int]
- │    │              └── const: 4 [type=int]
+ │    │         └── const: ARRAY[3,4] [type=int[]]
  │    └── true [type=bool]
  └── projections
       └── minus [type=int]
@@ -232,9 +224,7 @@ project
  │    │    │    ├── const: 0 [type=int]
  │    │    │    └── const: 1 [type=int]
  │    │    └── function: unnest [type=int]
- │    │         └── array: [type=int[]]
- │    │              ├── const: 2 [type=int]
- │    │              └── const: 4 [type=int]
+ │    │         └── const: ARRAY[2,4] [type=int[]]
  │    └── true [type=bool]
  └── projections
       ├── plus [type=int]
@@ -256,10 +246,7 @@ project
  │    ├── zip
  │    │    ├── columns: unnest:1(string)
  │    │    └── function: unnest [type=string]
- │    │         └── array: [type=string[]]
- │    │              ├── const: 'a' [type=string]
- │    │              ├── const: 'b' [type=string]
- │    │              └── const: 'c' [type=string]
+ │    │         └── const: ARRAY['a','b','c'] [type=string[]]
  │    └── true [type=bool]
  └── projections
       └── function: ascii [type=int]
@@ -417,8 +404,7 @@ limit
  │    │    ├── zip
  │    │    │    ├── columns: unnest:2(int)
  │    │    │    └── function: unnest [type=int]
- │    │    │         └── array: [type=int[]]
- │    │    │              └── const: 1 [type=int]
+ │    │    │         └── const: ARRAY[1] [type=int[]]
  │    │    └── true [type=bool]
  │    ├── zip
  │    │    ├── columns: word:3(string) catcode:4(string) catdesc:5(string)
@@ -504,8 +490,7 @@ SELECT * FROM upper('abc')
 ----
 zip
  ├── columns: upper:1(string)
- └── function: upper [type=string]
-      └── const: 'abc' [type=string]
+ └── const: 'ABC' [type=string]
 
 # current_schema
 
@@ -516,7 +501,8 @@ row-number
  ├── columns: b:1(string) ordinality:2(int!null)
  └── zip
       ├── columns: current_schema:1(string)
-      └── function: current_schema [type=string]
+      └── cast: STRING [type=string]
+           └── null [type=unknown]
 
 # expandArray
 
@@ -532,9 +518,7 @@ project
  │    ├── zip
  │    │    ├── columns: x:1(string) n:2(int)
  │    │    └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
- │    │         └── array: [type=string[]]
- │    │              ├── const: 'b' [type=string]
- │    │              └── const: 'a' [type=string]
+ │    │         └── const: ARRAY['b','a'] [type=string[]]
  │    └── true [type=bool]
  └── projections
       └── tuple [type=tuple{string AS x, int AS n}]
@@ -547,9 +531,7 @@ SELECT * FROM information_schema._pg_expandarray(ARRAY['b', 'a'])
 zip
  ├── columns: x:1(string) n:2(int)
  └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
-      └── array: [type=string[]]
-           ├── const: 'b' [type=string]
-           └── const: 'a' [type=string]
+      └── const: ARRAY['b','a'] [type=string[]]
 
 # srf_accessor
 
@@ -580,10 +562,7 @@ project
  │    ├── zip
  │    │    ├── columns: x:1(string) n:2(int)
  │    │    └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
- │    │         └── array: [type=string[]]
- │    │              ├── const: 'c' [type=string]
- │    │              ├── const: 'b' [type=string]
- │    │              └── const: 'a' [type=string]
+ │    │         └── const: ARRAY['c','b','a'] [type=string[]]
  │    └── true [type=bool]
  └── projections
       ├── column-access: 0 [type=string]
@@ -607,10 +586,7 @@ project
  │    ├── zip
  │    │    ├── columns: x:1(string) n:2(int)
  │    │    └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
- │    │         └── array: [type=string[]]
- │    │              ├── const: 'c' [type=string]
- │    │              ├── const: 'b' [type=string]
- │    │              └── const: 'a' [type=string]
+ │    │         └── const: ARRAY['c','b','a'] [type=string[]]
  │    └── true [type=bool]
  └── projections
       └── column-access: 0 [type=string]
@@ -631,10 +607,7 @@ project
  └── zip
       ├── columns: x:1(string) n:2(int)
       └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
-           └── array: [type=string[]]
-                ├── const: 'c' [type=string]
-                ├── const: 'b' [type=string]
-                └── const: 'a' [type=string]
+           └── const: ARRAY['c','b','a'] [type=string[]]
 
 build
 SELECT temp.* from information_schema._pg_expandarray(ARRAY['c','b','a']) AS temp;
@@ -642,10 +615,7 @@ SELECT temp.* from information_schema._pg_expandarray(ARRAY['c','b','a']) AS tem
 zip
  ├── columns: x:1(string) n:2(int)
  └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
-      └── array: [type=string[]]
-           ├── const: 'c' [type=string]
-           ├── const: 'b' [type=string]
-           └── const: 'a' [type=string]
+      └── const: ARRAY['c','b','a'] [type=string[]]
 
 build
 SELECT * from information_schema._pg_expandarray(ARRAY['c','b','a']) AS temp;
@@ -653,10 +623,7 @@ SELECT * from information_schema._pg_expandarray(ARRAY['c','b','a']) AS temp;
 zip
  ├── columns: x:1(string) n:2(int)
  └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
-      └── array: [type=string[]]
-           ├── const: 'c' [type=string]
-           ├── const: 'b' [type=string]
-           └── const: 'a' [type=string]
+      └── const: ARRAY['c','b','a'] [type=string[]]
 
 # generate_subscripts
 
@@ -666,10 +633,7 @@ SELECT * FROM generate_subscripts(ARRAY[3,2,1])
 zip
  ├── columns: generate_subscripts:1(int)
  └── function: generate_subscripts [type=int]
-      └── array: [type=int[]]
-           ├── const: 3 [type=int]
-           ├── const: 2 [type=int]
-           └── const: 1 [type=int]
+      └── const: ARRAY[3,2,1] [type=int[]]
 
 # Zip with multiple SRFs.
 build
@@ -686,10 +650,7 @@ zip
  │    └── const: 3 [type=int]
  ├── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
  └── function: unnest [type=string]
-      └── array: [type=string[]]
-           ├── const: 'a' [type=string]
-           ├── const: 'b' [type=string]
-           └── const: 'c' [type=string]
+      └── const: ARRAY['a','b','c'] [type=string[]]
 
 # Don't rename columns if the zip contains two functions.
 build
@@ -703,12 +664,10 @@ inner-join
  │    ├── columns: upper:1(string) upper:2(string) generate_series:3(int)
  │    ├── zip
  │    │    ├── columns: upper:1(string)
- │    │    └── function: upper [type=string]
- │    │         └── const: 'abc' [type=string]
+ │    │    └── const: 'ABC' [type=string]
  │    ├── zip
  │    │    ├── columns: upper:2(string) generate_series:3(int)
- │    │    ├── function: upper [type=string]
- │    │    │    └── const: 'def' [type=string]
+ │    │    ├── const: 'DEF' [type=string]
  │    │    └── function: generate_series [type=int]
  │    │         ├── const: 1 [type=int]
  │    │         └── const: 3 [type=int]

--- a/pkg/sql/opt/testutils/opt_tester.go
+++ b/pkg/sql/opt/testutils/opt_tester.go
@@ -109,6 +109,9 @@ type OptTesterFlags struct {
 	UnexpectedRules RuleSet
 
 	ColStats []opt.ColSet
+
+	// SkipFoldConstants causes the optbuilder to skip folding of constants.
+	SkipFoldConstants bool
 }
 
 // NewOptTester constructs a new instance of the OptTester for the given SQL
@@ -197,6 +200,8 @@ func NewOptTester(catalog opt.Catalog, sql string) *OptTester {
 //  - colstat: requests the calculation of a column statistic on the top-level
 //    expression. The value is a column or a list of columns. The flag can
 //    be used multiple times to request different statistics.
+//
+//  - skip-fold-constants: skip the folding of constants in the optbuilder.
 //
 func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 	// Allow testcases to override the flags.
@@ -441,6 +446,9 @@ func (f *OptTesterFlags) Set(arg datadriven.CmdArg) error {
 			cols.Add(col)
 		}
 		f.ColStats = append(f.ColStats, cols)
+
+	case "skip-fold-constants":
+		f.SkipFoldConstants = true
 
 	default:
 		return fmt.Errorf("unknown argument: %s", arg.Key)
@@ -780,6 +788,7 @@ func (ot *OptTester) buildExpr(
 	if ot.Flags.FullyQualifyNames {
 		b.FmtFlags = tree.FmtAlwaysQualifyTableNames
 	}
+	b.SkipFoldConstants = ot.Flags.SkipFoldConstants
 	return b.Build()
 }
 

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -358,7 +358,7 @@ project
  │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
  │    │    │         │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
  │    │    │         │    │    │    │    │    │    │    └── filters [type=bool, outer=(17)]
- │    │    │         │    │    │    │    │    │    │         └── (pg_class.relkind = 'r'::CHAR) OR (pg_class.relkind = 'f'::CHAR) [type=bool, outer=(17)]
+ │    │    │         │    │    │    │    │    │    │         └── (pg_class.relkind = 'r') OR (pg_class.relkind = 'f') [type=bool, outer=(17)]
  │    │    │         │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index
  │    │    │         │    │    │    │    │    │    │    ├── columns: pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null)
  │    │    │         │    │    │    │    │    │    │    ├── constraint: /29: [/'public' - /'public']

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -361,7 +361,7 @@ sort
       │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
       │    │    │         │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
       │    │    │         │    │    │    │    │    │    │    └── filters [type=bool, outer=(17)]
-      │    │    │         │    │    │    │    │    │    │         └── (pg_class.relkind = 'r'::CHAR) OR (pg_class.relkind = 'f'::CHAR) [type=bool, outer=(17)]
+      │    │    │         │    │    │    │    │    │    │         └── (pg_class.relkind = 'r') OR (pg_class.relkind = 'f') [type=bool, outer=(17)]
       │    │    │         │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index
       │    │    │         │    │    │    │    │    │    │    ├── columns: pg_namespace.oid:28(oid!null) pg_namespace.nspname:29(string!null)
       │    │    │         │    │    │    │    │    │    │    ├── constraint: /29: [/'public' - /'public']

--- a/pkg/sql/opt/xform/testdata/external/pgadmin
+++ b/pkg/sql/opt/xform/testdata/external/pgadmin
@@ -122,6 +122,60 @@ WHERE
 ----
 project
  ├── columns: PID:3(int) User:5(name) Database:2(name) "Backend start":10(timestamptz) Client:37(string) Application:6(string) Query:19(string) "Query start":12(timestamptz) "Xact start":11(timestamptz)
+ ├── cardinality: [0 - 0]
+ ├── inner-join
+ │    ├── columns: datname:2(name) pid:3(int) usesysid:4(oid) username:5(name) application_name:6(string) client_addr:7(inet) client_hostname:8(string) client_port:9(int) backend_start:10(timestamptz) xact_start:11(timestamptz) query_start:12(timestamptz) query:19(string) oid:21(oid) rolsuper:23(bool)
+ │    ├── cardinality: [0 - 0]
+ │    ├── fd: ()-->(21,23)
+ │    ├── scan pg_stat_activity
+ │    │    └── columns: datname:2(name) pid:3(int) usesysid:4(oid) username:5(name) application_name:6(string) client_addr:7(inet) client_hostname:8(string) client_port:9(int) backend_start:10(timestamptz) xact_start:11(timestamptz) query_start:12(timestamptz) query:19(string)
+ │    ├── values
+ │    │    ├── columns: oid:21(oid) rolsuper:23(bool)
+ │    │    ├── cardinality: [0 - 0]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(21,23)
+ │    └── filters [type=bool, outer=(4,21,23)]
+ │         └── rolsuper OR (oid = usesysid) [type=bool, outer=(4,21,23)]
+ └── projections [outer=(2,3,5-12,19)]
+      └── CASE WHEN (client_hostname IS NOT NULL) AND (client_hostname != '') THEN (client_hostname || ':') || client_port::STRING WHEN (client_addr IS NOT NULL) AND (client_addr::STRING != '') THEN (client_addr::STRING || ':') || client_port::STRING WHEN client_port = -1 THEN 'local pipe' ELSE 'localhost:' || client_port::STRING END [type=string, outer=(7-9)]
+
+opt skip-fold-constants
+SELECT
+    pid AS "PID",
+    username AS "User",
+    datname AS "Database",
+    backend_start AS "Backend start",
+    CASE
+    WHEN client_hostname IS NOT NULL
+    AND client_hostname != ''
+    THEN client_hostname::STRING
+    || ':'
+    || client_port::STRING
+    WHEN client_addr IS NOT NULL
+    AND client_addr::STRING != ''
+    THEN client_addr::STRING || ':' || client_port::STRING
+    WHEN client_port = -1 THEN 'local pipe'
+    ELSE 'localhost:' || client_port::STRING
+    END
+        AS "Client",
+    application_name AS "Application",
+    query AS "Query",
+    query_start AS "Query start",
+    xact_start AS "Xact start"
+FROM
+    pg_stat_activity AS sa
+WHERE
+    (
+        SELECT
+            r.rolsuper OR r.oid = sa.usesysid
+        FROM
+            pg_roles AS r
+        WHERE
+            r.rolname = current_user()
+    )
+----
+project
+ ├── columns: PID:3(int) User:5(name) Database:2(name) "Backend start":10(timestamptz) Client:37(string) Application:6(string) Query:19(string) "Query start":12(timestamptz) "Xact start":11(timestamptz)
  ├── inner-join-apply
  │    ├── columns: datname:2(name) pid:3(int) usesysid:4(oid) username:5(name) application_name:6(string) client_addr:7(inet) client_hostname:8(string) client_port:9(int) backend_start:10(timestamptz) xact_start:11(timestamptz) query_start:12(timestamptz) query:19(string) "?column?":36(bool!null)
  │    ├── scan pg_stat_activity

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -283,11 +283,11 @@ sort
       ├── project
       │    ├── columns: column19:19(float) column21:21(float) l_quantity:5(float) l_extendedprice:6(float) l_discount:7(float) l_returnflag:9(string) l_linestatus:10(string)
       │    ├── select
-      │    │    ├── columns: l_quantity:5(float) l_extendedprice:6(float) l_discount:7(float) l_tax:8(float) l_returnflag:9(string) l_linestatus:10(string) l_shipdate:11(date!null)
+      │    │    ├── columns: l_quantity:5(float) l_extendedprice:6(float) l_discount:7(float) l_tax:8(float) l_returnflag:9(string) l_linestatus:10(string) l_shipdate:11(date)
       │    │    ├── scan lineitem
       │    │    │    └── columns: l_quantity:5(float) l_extendedprice:6(float) l_discount:7(float) l_tax:8(float) l_returnflag:9(string) l_linestatus:10(string) l_shipdate:11(date)
-      │    │    └── filters [type=bool, outer=(11), constraints=(/11: (/NULL - ])]
-      │    │         └── l_shipdate <= ('1998-12-01' - '90d') [type=bool, outer=(11), constraints=(/11: (/NULL - ])]
+      │    │    └── filters [type=bool, outer=(11)]
+      │    │         └── l_shipdate <= '1998-09-02 00:00:00+00:00' [type=bool, outer=(11)]
       │    └── projections [outer=(5-10)]
       │         ├── l_extendedprice * (1.0 - l_discount) [type=float, outer=(6,7)]
       │         └── (l_extendedprice * (1.0 - l_discount)) * (l_tax + 1.0) [type=float, outer=(6-8)]
@@ -680,7 +680,7 @@ sort
       │    │    │    └── ordering: +1
       │    │    └── filters [type=bool, outer=(5), constraints=(/5: [/'1993-07-01' - ])]
       │    │         ├── o_orderdate >= '1993-07-01' [type=bool, outer=(5), constraints=(/5: [/'1993-07-01' - ]; tight)]
-      │    │         └── o_orderdate < ('1993-07-01' + '3mon') [type=bool, outer=(5), constraints=(/5: (/NULL - ])]
+      │    │         └── o_orderdate < '1993-10-01 00:00:00+00:00' [type=bool, outer=(5)]
       │    ├── select
       │    │    ├── columns: l_orderkey:10(int!null) l_commitdate:21(date!null) l_receiptdate:22(date!null)
       │    │    ├── ordering: +10
@@ -783,7 +783,7 @@ sort
       │    │    │    │    │    │    │    │    └── fd: (9)-->(10,13)
       │    │    │    │    │    │    │    └── filters [type=bool, outer=(13), constraints=(/13: [/'1994-01-01' - ])]
       │    │    │    │    │    │    │         ├── o_orderdate >= '1994-01-01' [type=bool, outer=(13), constraints=(/13: [/'1994-01-01' - ]; tight)]
-      │    │    │    │    │    │    │         └── o_orderdate < ('1994-01-01' + '1y') [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │    │    │    │    │    │    │         └── o_orderdate < '1995-01-01 00:00:00+00:00' [type=bool, outer=(13)]
       │    │    │    │    │    │    └── filters [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
       │    │    │    │    │    │         └── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ])]
       │    │    │    │    │    └── filters [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
@@ -841,7 +841,7 @@ scalar-group-by
  │    │    │    └── columns: l_quantity:5(float) l_extendedprice:6(float) l_discount:7(float) l_shipdate:11(date)
  │    │    └── filters [type=bool, outer=(5,7,11), constraints=(/5: (/NULL - /23.999999999999996]; /7: [/0.05 - /0.07]; /11: [/'1994-01-01' - ])]
  │    │         ├── l_shipdate >= '1994-01-01' [type=bool, outer=(11), constraints=(/11: [/'1994-01-01' - ]; tight)]
- │    │         ├── l_shipdate < ('1994-01-01' + '1y') [type=bool, outer=(11), constraints=(/11: (/NULL - ])]
+ │    │         ├── l_shipdate < '1995-01-01 00:00:00+00:00' [type=bool, outer=(11)]
  │    │         ├── l_discount >= 0.05 [type=bool, outer=(7), constraints=(/7: [/0.05 - ]; tight)]
  │    │         ├── l_discount <= 0.07 [type=bool, outer=(7), constraints=(/7: (/NULL - /0.07]; tight)]
  │    │         └── l_quantity < 24.0 [type=bool, outer=(5), constraints=(/5: (/NULL - /23.999999999999996]; tight)]
@@ -1338,7 +1338,7 @@ limit
  │         │    │    │    │    │    │    └── fd: (9)-->(10,13)
  │         │    │    │    │    │    └── filters [type=bool, outer=(13), constraints=(/13: [/'1993-10-01' - ])]
  │         │    │    │    │    │         ├── o_orderdate >= '1993-10-01' [type=bool, outer=(13), constraints=(/13: [/'1993-10-01' - ]; tight)]
- │         │    │    │    │    │         └── o_orderdate < ('1993-10-01' + '3mon') [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+ │         │    │    │    │    │         └── o_orderdate < '1994-01-01 00:00:00+00:00' [type=bool, outer=(13)]
  │         │    │    │    │    └── filters [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
  │         │    │    │    │         └── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ])]
  │         │    │    │    └── filters [type=bool, outer=(9,18,26), constraints=(/9: (/NULL - ]; /18: (/NULL - ]; /26: [/'R' - /'R']), fd=()-->(26), (9)==(18), (18)==(9)]
@@ -1574,7 +1574,7 @@ sort
       │    │    │         ├── l_commitdate < l_receiptdate [type=bool, outer=(21,22), constraints=(/21: (/NULL - ]; /22: (/NULL - ])]
       │    │    │         ├── l_shipdate < l_commitdate [type=bool, outer=(20,21), constraints=(/20: (/NULL - ]; /21: (/NULL - ])]
       │    │    │         ├── l_receiptdate >= '1994-01-01' [type=bool, outer=(22), constraints=(/22: [/'1994-01-01' - ]; tight)]
-      │    │    │         └── l_receiptdate < ('1994-01-01' + '1y') [type=bool, outer=(22), constraints=(/22: (/NULL - ])]
+      │    │    │         └── l_receiptdate < '1995-01-01 00:00:00+00:00' [type=bool, outer=(22)]
       │    │    └── filters [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
       │    │         └── o_orderkey = l_orderkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ])]
       │    └── projections [outer=(6,24)]
@@ -1707,7 +1707,7 @@ project
  │    │    │    │    │    └── columns: l_partkey:2(int!null) l_extendedprice:6(float) l_discount:7(float) l_shipdate:11(date)
  │    │    │    │    └── filters [type=bool, outer=(11), constraints=(/11: [/'1995-09-01' - ])]
  │    │    │    │         ├── l_shipdate >= '1995-09-01' [type=bool, outer=(11), constraints=(/11: [/'1995-09-01' - ]; tight)]
- │    │    │    │         └── l_shipdate < ('1995-09-01' + '1mon') [type=bool, outer=(11), constraints=(/11: (/NULL - ])]
+ │    │    │    │         └── l_shipdate < '1995-10-01 00:00:00+00:00' [type=bool, outer=(11)]
  │    │    │    └── filters [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ]), fd=(2)==(17), (17)==(2)]
  │    │    │         └── l_partkey = p_partkey [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ])]
  │    │    └── projections [outer=(6,7,21)]
@@ -1800,7 +1800,7 @@ sort
            │    │    │    │    │    └── columns: lineitem.l_suppkey:10(int!null) lineitem.l_extendedprice:13(float) lineitem.l_discount:14(float) lineitem.l_shipdate:18(date)
            │    │    │    │    └── filters [type=bool, outer=(18), constraints=(/18: [/'1996-01-01' - ])]
            │    │    │    │         ├── lineitem.l_shipdate >= '1996-01-01' [type=bool, outer=(18), constraints=(/18: [/'1996-01-01' - ]; tight)]
-           │    │    │    │         └── lineitem.l_shipdate < ('1996-01-01' + '3mon') [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+           │    │    │    │         └── lineitem.l_shipdate < '1996-04-01 00:00:00+00:00' [type=bool, outer=(18)]
            │    │    │    └── projections [outer=(10,13,14)]
            │    │    │         └── lineitem.l_extendedprice * (1.0 - lineitem.l_discount) [type=float, outer=(13,14)]
            │    │    └── aggregations [outer=(24)]
@@ -1828,7 +1828,7 @@ sort
            │                        │    │    │    │    └── columns: lineitem.l_suppkey:28(int!null) lineitem.l_extendedprice:31(float) lineitem.l_discount:32(float) lineitem.l_shipdate:36(date)
            │                        │    │    │    └── filters [type=bool, outer=(36), constraints=(/36: [/'1996-01-01' - ])]
            │                        │    │    │         ├── lineitem.l_shipdate >= '1996-01-01' [type=bool, outer=(36), constraints=(/36: [/'1996-01-01' - ]; tight)]
-           │                        │    │    │         └── lineitem.l_shipdate < ('1996-01-01' + '3mon') [type=bool, outer=(36), constraints=(/36: (/NULL - ])]
+           │                        │    │    │         └── lineitem.l_shipdate < '1996-04-01 00:00:00+00:00' [type=bool, outer=(36)]
            │                        │    │    └── projections [outer=(28,31,32)]
            │                        │    │         └── lineitem.l_extendedprice * (1.0 - lineitem.l_discount) [type=float, outer=(31,32)]
            │                        │    └── aggregations [outer=(42)]
@@ -2334,7 +2334,7 @@ sort
            │    │    │         │    │    │    │    └── columns: l_partkey:27(int!null) l_suppkey:28(int!null) l_quantity:30(float) l_shipdate:36(date)
            │    │    │         │    │    │    └── filters [type=bool, outer=(36), constraints=(/36: [/'1994-01-01' - ])]
            │    │    │         │    │    │         ├── l_shipdate >= '1994-01-01' [type=bool, outer=(36), constraints=(/36: [/'1994-01-01' - ]; tight)]
-           │    │    │         │    │    │         └── l_shipdate < ('1994-01-01' + '1y') [type=bool, outer=(36), constraints=(/36: (/NULL - ])]
+           │    │    │         │    │    │         └── l_shipdate < '1995-01-01 00:00:00+00:00' [type=bool, outer=(36)]
            │    │    │         │    │    └── filters [type=bool, outer=(12,13,27,28), constraints=(/12: (/NULL - ]; /13: (/NULL - ]; /27: (/NULL - ]; /28: (/NULL - ]), fd=(12)==(27), (27)==(12), (13)==(28), (28)==(13)]
            │    │    │         │    │         ├── l_partkey = ps_partkey [type=bool, outer=(12,27), constraints=(/12: (/NULL - ]; /27: (/NULL - ])]
            │    │    │         │    │         └── l_suppkey = ps_suppkey [type=bool, outer=(13,28), constraints=(/13: (/NULL - ]; /28: (/NULL - ])]


### PR DESCRIPTION
This commit adds logic to fold constants in the `optbuilder`
after type checking is complete. It is similar to the logic
in `sql/sem/tree/normalize.go` used by the heuristic planner,
but it does not perform any normalization other than constant
folding. Constants are evaluated bottom-up, so it is only
necessary to check two levels of the tree to determine if
an expression is constant and can therefore be evaluated.

Release note: None