### PR TITLE
release-2.1: sql: correctly handle NULL arrays in generator funcs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -183,10 +183,11 @@ x  generate_series
 
 subtest unnest
 
-query I
+statement error could not determine polymorphic type
 SELECT * FROM unnest(NULL)
-----
 
+statement error could not determine polymorphic type
+SELECT unnest(NULL)
 
 query I colnames
 SELECT * from unnest(ARRAY[1,2])
@@ -259,6 +260,11 @@ query T colnames
 SELECT unnest((SELECT current_schemas((SELECT isnan((SELECT round(3.4, (SELECT generate_series(1, 0)))))))));
 ----
 unnest
+
+query T colnames
+SELECT information_schema._pg_expandarray((SELECT current_schemas((SELECT isnan((SELECT round(3.4, (SELECT generate_series(1, 0)))))))));
+----
+information_schema._pg_expandarray
 
 # Regression for #18021.
 query I colnames
@@ -339,6 +345,12 @@ SELECT information_schema._pg_expandarray(ARRAY[])
 
 query error pq: information_schema\._pg_expandarray\(\): cannot determine type of empty array\. Consider annotating with the desired type, for example ARRAY\[\]:::int\[\]
 SELECT * FROM information_schema._pg_expandarray(ARRAY[])
+
+statement error could not determine polymorphic type
+SELECT * FROM information_schema._pg_expandarray(NULL)
+
+statement error could not determine polymorphic type
+SELECT information_schema._pg_expandarray(NULL)
 
 query I colnames
 SELECT information_schema._pg_expandarray(ARRAY[]:::int[])

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -100,11 +100,8 @@ var generators = map[string]builtinDefinition{
 		makeGeneratorOverloadWithReturnType(
 			tree.ArgTypes{{"input", types.AnyArray}},
 			func(args []tree.TypedExpr) types.T {
-				if len(args) == 0 {
+				if len(args) == 0 || args[0].ResolvedType() == types.Unknown {
 					return tree.UnknownReturnType
-				}
-				if args[0].ResolvedType() == types.Unknown {
-					return types.Unknown
 				}
 				return types.UnwrapType(args[0].ResolvedType()).(types.TArray).Typ
 			},
@@ -117,7 +114,7 @@ var generators = map[string]builtinDefinition{
 		makeGeneratorOverloadWithReturnType(
 			tree.ArgTypes{{"input", types.AnyArray}},
 			func(args []tree.TypedExpr) types.T {
-				if len(args) == 0 {
+				if len(args) == 0 || args[0].ResolvedType() == types.Unknown {
 					return tree.UnknownReturnType
 				}
 				t := types.UnwrapType(args[0].ResolvedType()).(types.TArray).Typ

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -852,6 +852,18 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, e
 	expr.fn = overloadImpl
 	expr.fnProps = &def.FunctionProperties
 	expr.typ = overloadImpl.returnType()(typedSubExprs)
+	if expr.typ == UnknownReturnType {
+		typeNames := make([]string, 0, len(expr.Exprs))
+		for _, expr := range typedSubExprs {
+			typeNames = append(typeNames, expr.ResolvedType().String())
+		}
+		return nil, pgerror.NewErrorf(
+			pgerror.CodeDatatypeMismatchError,
+			"could not determine polymorphic type: %s(%s)",
+			&expr.Func,
+			strings.Join(typeNames, ", "),
+		)
+	}
 	return expr, nil
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #29244.

/cc @cockroachdb/release

---

Change both unnest and _pg_expandarray to return UnknownReturnType if
passed NULL as their first argument during type checking. Teach the type
checker that if a func returns UnknownReturnType after type checking,
then it is because we didn't have enough information to generate a
correct type, and so should produce an error immediately. If these
funcs are passed a NULL array during execution (after type checking),
they should still succeed.

Also fix evalAndReplaceSubqueryVisitor to correctly type expressions
during subquery replacement which allows the previous change to work
both in local and distsql execution.

Fixes #29239 
Fixes #28561

Release note (bug fix): The functions `unnest` and `_pg_expandarray`
now return an error when called with NULL as their first argument.
