### PR TITLE
release-2.1: importccl: fix race condition in CSV import with collated strings

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -199,6 +199,15 @@ d
 				`SELECT * FROM t ORDER BY a`: {{"1"}, {"3"}, {"5"}},
 			},
 		},
+		{
+			name:   "collated strings",
+			create: `s string collate en_u_ks_level1`,
+			typ:    "CSV",
+			data:   strings.Repeat("1\n", 2000),
+			query: map[string][][]string{
+				`SELECT s, count(*) FROM t GROUP BY s`: {{"1", "2000"}},
+			},
+		},
 
 		// MySQL OUTFILE
 		{

--- a/pkg/ccl/importccl/read_import_proc.go
+++ b/pkg/ccl/importccl/read_import_proc.go
@@ -423,7 +423,7 @@ func (cp *readImportDataProcessor) doRun(ctx context.Context, wg *sync.WaitGroup
 	var err error
 	switch cp.spec.Format.Format {
 	case roachpb.IOFileFormat_CSV:
-		conv = newCSVInputReader(kvCh, cp.spec.Format.Csv, singleTable, evalCtx)
+		conv = newCSVInputReader(kvCh, cp.spec.Format.Csv, singleTable, cp.flowCtx)
 	case roachpb.IOFileFormat_MysqlOutfile:
 		conv, err = newMysqloutfileReader(kvCh, cp.spec.Format.MysqlOut, singleTable, evalCtx)
 	case roachpb.IOFileFormat_Mysqldump:


### PR DESCRIPTION
Backport 1/1 commits from #29322.

/cc @cockroachdb/release

---

evalCtx's collationenv was being accessed in parallel by multiple go
routines during CSV processing. Making a copy of the evalCtx per go
routine gives each one its own.

Release note (bug fix): fixed a race condition in IMPORT CSV with a
column that was a collated string.
