### PR TITLE
sql: don't remove batch limit in local lookup join

### DIFF
--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -553,7 +553,6 @@ func (ef *execFactory) ConstructLookupJoin(
 
 	tableScan.index = indexDesc
 	tableScan.run.isSecondaryIndex = (indexDesc != &tabDesc.PrimaryIndex)
-	tableScan.disableBatchLimit()
 
 	n := &lookupJoinNode{
 		input:    input.(planNode),


### PR DESCRIPTION
Previously, the local lookup join node was created with an underlying
scan with an explicitly disabled batch limit. This is the wrong thing to
do, since that scan will be used as a full table scan - it needs a batch
limit to prevent OOM errors.

Closes #29389.

Release note: None