### PR TITLE
pretty: remove double space before AS of CREATE TABLE AS

### DIFF
--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1037,7 +1037,7 @@ func (node *CreateTable) doc(p *PrettyCfg) pretty.Doc {
 		d = p.nestUnder(
 			pretty.Concat(
 				d,
-				pretty.Text(" AS"),
+				pretty.Text("AS"),
 			),
 			p.Doc(node.AsSource),
 		)


### PR DESCRIPTION
Release note: None