### PR TITLE
server: fix a confusing start message

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -543,7 +543,9 @@ func (n *Node) start(
 	// bumped immediately, which would be possible if gossip got started earlier).
 	n.startGossip(ctx, n.stopper)
 
-	log.Infof(ctx, "%s: started with %v engine(s) and attributes %v", n, bootstrappedEngines, attrs.Attrs)
+	allEngines := append([]engine.Engine(nil), bootstrappedEngines...)
+	allEngines = append(allEngines, emptyEngines...)
+	log.Infof(ctx, "%s: started with %v engine(s) and attributes %v", n, allEngines, attrs.Attrs)
 	return nil
 }
 


### PR DESCRIPTION
Include both bootstrapped (existing) and empty (new) engines in the
start message. Previously the message was only include bootstrapped
engines which was confusing when a node first joined a cluster.

See #27599

Release note: None