### PR TITLE
release-2.1: gossip: infoStore.mostDistant should never return the local node-id

### DIFF
--- a/pkg/gossip/infostore.go
+++ b/pkg/gossip/infostore.go
@@ -409,6 +409,7 @@ func (is *infoStore) delta(highWaterTimestamps map[roachpb.NodeID]int64) map[str
 func (is *infoStore) mostDistant(
 	hasOutgoingConn func(roachpb.NodeID) bool,
 ) (roachpb.NodeID, uint32) {
+	localNodeID := is.nodeID.Get()
 	var nodeID roachpb.NodeID
 	var maxHops uint32
 	if err := is.visitInfos(func(key string, i *Info) error {
@@ -417,7 +418,8 @@ func (is *infoStore) mostDistant(
 		// likely to be accurate than keys which are rarely re-gossiped, which can
 		// acquire unreliably high Hops values in some pathological cases such as
 		// those described in #9819.
-		if i.Hops > maxHops && IsNodeIDKey(key) && !hasOutgoingConn(i.NodeID) {
+		if i.NodeID != localNodeID && i.Hops > maxHops &&
+			IsNodeIDKey(key) && !hasOutgoingConn(i.NodeID) {
 			maxHops = i.Hops
 			nodeID = i.NodeID
 		}

--- a/pkg/gossip/infostore_test.go
+++ b/pkg/gossip/infostore_test.go
@@ -187,6 +187,25 @@ func TestAddInfoSameKeyDifferentHops(t *testing.T) {
 	}
 }
 
+// Verify that combine will not add infos that originated on the local node.
+func TestCombineInfosLocalNode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	is, stopper := newTestInfoStore()
+	defer stopper.Stop(context.Background())
+	info := is.newInfo(nil, time.Second)
+	info.OrigStamp = 1
+	fresh, err := is.combine(map[string]*Info{"hello": info}, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fresh != 0 {
+		t.Fatalf("expected no infos to be added, but found %d", fresh)
+	}
+	if i := is.getInfo("hello"); i != nil {
+		t.Fatalf("expected to not find info, but found: %+v", i)
+	}
+}
+
 // Helper method creates an infostore with 10 infos.
 func createTestInfoStore(t *testing.T) *infoStore {
 	is, stopper := newTestInfoStore()
@@ -296,7 +315,7 @@ func TestInfoStoreMostDistant(t *testing.T) {
 			t.Errorf("%d: expected node %d; got %d", i, expectedNodeID, nodeID)
 		}
 		if expectedHops != hops {
-			t.Errorf("%d: expected node %d; got %d", i, expectedHops, hops)
+			t.Errorf("%d: expected hops %d; got %d", i, expectedHops, hops)
 		}
 	}
 
@@ -313,7 +332,7 @@ func TestInfoStoreMostDistant(t *testing.T) {
 		t.Errorf("expected node %d; got %d", expectedNode, nodeID)
 	}
 	if hops != expectedHops {
-		t.Errorf("expected node %d; got %d", expectedHops, hops)
+		t.Errorf("expected hops %d; got %d", expectedHops, hops)
 	}
 }
 


### PR DESCRIPTION
Backport 2/2 commits from #29398.

/cc @cockroachdb/release

---

Fixes #28517

Release note: None
