### PR TITLE
release-2.1: sql: fix panic when normalizing ->(NULL::STRING)

### DIFF
--- a/pkg/sql/logictest/testdata/planner_test/inverted_index
+++ b/pkg/sql/logictest/testdata/planner_test/inverted_index
@@ -97,6 +97,23 @@ index-join  ·      ·                            (a, b)           b=CONST; a!=N
 ·           table  d@primary                    ·                ·
 
 query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b->'a'->'c' = '"b"'
+----
+index-join  ·      ·                                    (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   ·      ·                                    (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          table  d@foo_inv                            ·                ·
+ │          spans  /"a"/"c"/"b"-/"a"/"c"/"b"/PrefixEnd  ·                ·
+ └── scan   ·      ·                                    (a, b)           ·
+·           table  d@primary                            ·                ·
+
+# Regression test for #29399. Do not panic when NULL::STRING is on the right
+# hand side of ->.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b->(NULL::STRING) = '"b"'
+----
+norows  ·  ·  (a, b)  ·
+
+query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where '"b"' = b->'a'
 ----
 index-join  ·      ·                            (a, b)           b=CONST; a!=NULL; key(a)

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -427,6 +427,10 @@ func (expr *ComparisonExpr) normalize(v *NormalizeVisitor) TypedExpr {
 				if err != nil {
 					break
 				}
+				// Check that we still have a string after evaluation.
+				if _, ok := str.(*DString); !ok {
+					break
+				}
 
 				rhs, err := expr.TypedRight().Eval(v.ctx)
 				if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #29404.

/cc @cockroachdb/release

---

Prior to this commit, when `(NULL::STRING)` was on the right-hand side
of a `->` operator, the normalization code caused a panic:
```
interface conversion: tree.Datum is tree.dNull, not *tree.DString
```
This was due to the fact that `Eval` returns `dNull` instead of a `*DString`
when evaluating `NULL::STRING`, but the code in `ComparisonExpr.normalize` was
expecting a `*DString`.

This commit adds a check to make sure that we still have a string after
`Eval` is called.

This bug was uncovered because `opt/exec/execbuilder` had some tests in
the `inverted_index` test file that were not present in
`logictest/testdata/planner_test/inverted_index`, which contained an expression
with `->(NULL::STRING)`. These tests have been added as regression tests
in `planner_test`.

Fixes #29399

Release note (bug fix): Fixed a panic with SQL statements containing
"->(NULL::STRING)".
