### PR TITLE
release-2.1: sql: fall back to local instead of panic in EXPORT

### DIFF
--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -58,6 +58,10 @@ func PlanAndRunExport(
 	resultRows *RowResultWriter,
 ) error {
 	planCtx := dsp.NewPlanningCtx(ctx, evalCtx, txn)
+
+	rec, err := dsp.checkSupportForNode(in)
+	planCtx.isLocal = err != nil || rec == cannotDistribute
+
 	p, err := dsp.createPlanForNode(&planCtx, in)
 	if err != nil {
 		return errors.Wrap(err, "constructing distSQL plan")


### PR DESCRIPTION
Backport 1/1 commits from #29299.

/cc @cockroachdb/release

---

Previously the query in the test would panic the node.

Fixes #29238.

Release note: none.
