### PR TITLE
release-2.1: distsql: don't modify distsql planner's metadataTestTolerance

### DIFF
--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -69,12 +69,6 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 	planCtx.stmtType = n.stmtType
 	planCtx.validExtendedEvalCtx = true
 
-	// This stanza ensures that EXPLAIN(DISTSQL) won't include metadata test
-	// senders or receivers.
-	curTol := distSQLPlanner.metadataTestTolerance
-	distSQLPlanner.metadataTestTolerance = distsqlrun.On
-	defer func() { distSQLPlanner.metadataTestTolerance = curTol }()
-
 	plan, err := distSQLPlanner.createPlanForNode(&planCtx, n.plan)
 	if err != nil {
 		return err

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -958,7 +958,7 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 		distSQLKnobs.MemoryLimitBytes = 1
 	}
 	if cfg.distSQLMetadataTestEnabled {
-		distSQLKnobs.MetadataTestLevel = distsqlrun.NoExplain
+		distSQLKnobs.MetadataTestLevel = distsqlrun.On
 	}
 	params.ServerArgs.Knobs.DistSQL = distSQLKnobs
 


### PR DESCRIPTION
Backport 1/1 commits from #29375.

/cc @cockroachdb/release

---

This was done unnecessarily and resulted in races since the distsql
planner can be used concurrently.

Fixes #28999

Release note: None
