### PR TITLE
contextutil: add CancelWithReason

### DIFF
--- a/pkg/util/contextutil/context.go
+++ b/pkg/util/contextutil/context.go
@@ -17,14 +17,54 @@ import (
 	"fmt"
 	"net"
 	"runtime/debug"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
-// WithCancel adds an info log to context.WithCancel's CancelFunc.
+// WithCancel adds an info log to context.WithCancel's CancelFunc. Prefer using
+// WithCancelReason when possible.
 func WithCancel(parent context.Context) (context.Context, context.CancelFunc) {
 	return wrap(context.WithCancel(parent))
+}
+
+// reasonKey is a marker struct that's used to save the reason a context was
+// canceled.
+type reasonKey struct{}
+
+// CancelWithReasonFunc is a context.CancelFunc that also passes along an error
+// that is the reason for cancellation.
+type CancelWithReasonFunc func(reason error)
+
+// WithCancelReason adds a CancelFunc to this context, returning a new
+// cancellable context and a CancelWithReasonFunc, which is like
+// context.CancelFunc, except it also takes a "reason" error. The context that
+// is canceled with this CancelWithReasonFunc will immediately be updated to
+// contain this "reason". The reason can be retrieved with GetCancelReason.
+// This function doesn't change the deadline of a context if it already exists.
+func WithCancelReason(ctx context.Context) (context.Context, CancelWithReasonFunc) {
+	val := new(atomic.Value)
+	ctx = context.WithValue(ctx, reasonKey{}, val)
+	ctx, cancel := wrap(context.WithCancel(ctx))
+	return ctx, func(reason error) {
+		val.Store(reason)
+		cancel()
+	}
+}
+
+// GetCancelReason retrieves the cancel reason for a context that has been
+// created via WithCancelReason. The reason will be nil if the context was not
+// created with WithCancelReason, or if the context has not been canceled yet.
+// Otherwise, the reason will be the error that the context's
+// CancelWithReasonFunc was invoked with.
+func GetCancelReason(ctx context.Context) error {
+	i := ctx.Value(reasonKey{})
+	switch t := i.(type) {
+	case *atomic.Value:
+		return t.Load().(error)
+	}
+	return nil
 }
 
 func wrap(ctx context.Context, cancel context.CancelFunc) (context.Context, context.CancelFunc) {

--- a/pkg/util/contextutil/context_test.go
+++ b/pkg/util/contextutil/context_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRunWithTimeout(t *testing.T) {
@@ -92,4 +93,23 @@ func TestRunWithTimeoutWithoutDeadlineExceeded(t *testing.T) {
 		t.Fatalf("RunWithTimeout should return an error caused by the underlying " +
 			"returned error")
 	}
+}
+
+func TestCancelWithReason(t *testing.T) {
+	ctx := context.Background()
+
+	var cancel CancelWithReasonFunc
+	ctx, cancel = WithCancelReason(ctx)
+
+	e := errors.New("hodor")
+	go func() {
+		cancel(e)
+	}()
+
+	<-ctx.Done()
+
+	expected := "context canceled"
+	found := ctx.Err().Error()
+	assert.Equal(t, expected, found)
+	assert.Equal(t, e, GetCancelReason(ctx))
 }


### PR DESCRIPTION
contextutil.WithCancel now returns a new context type that holds its
reason for cancellation when canceled with CancelWithReason instead of
its normal cancelfunc.

Alternative / new approach to #29318.

Release note: None