### PR TITLE
backport-2.1: sql: fix panic with JSON array ops and nulls

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -138,6 +138,22 @@ query T
 SELECT bar FROM foo WHERE bar ?& ARRAY['a','b']
 ----
 
+# ?| and ?& ignore NULLs.
+query T
+SELECT bar FROM foo WHERE bar ?| ARRAY['a', null]
+----
+{"a": "b"}
+
+# TODO(justin): #29355
+# query T
+# SELECT bar FROM foo WHERE bar ?| ARRAY[null, null]::STRING[]
+# ----
+
+query T
+SELECT bar FROM foo WHERE bar ?& ARRAY['a', null]
+----
+{"a": "b"}
+
 query T
 SELECT bar FROM foo WHERE bar->'a' = '"b"'::JSON
 ----
@@ -334,6 +350,11 @@ SELECT '{"a": ["b"]}'::JSONB#>'{a,0}'::STRING[]
 "b"
 
 query T
+SELECT '{"a": 1}'::JSONB#>>ARRAY['foo', null]
+----
+NULL
+
+query T
 SELECT '{"a": 1}'::JSONB#>>'{a}'::STRING[]
 ----
 1
@@ -500,6 +521,12 @@ query T
 SELECT '{"foo": {"bar": 1}}'::JSONB #- ARRAY['foo', 'bar']
 ----
 {"foo": {}}
+
+statement error path element at position 1 is null
+SELECT '{"foo": {"bar": 1}}'::JSONB #- ARRAY[null, 'foo']
+
+statement error path element at position 2 is null
+SELECT '{"foo": {"bar": 1}}'::JSONB #- ARRAY['foo', null]
 
 query T
 SELECT '{"foo": {"bar": 1}}'::JSONB #- ARRAY['foo']

--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -452,6 +452,11 @@ SELECT json_extract_path('{"a": 1}', 'a')
 1
 
 query T
+SELECT json_extract_path('{"a": 1}', 'a', NULL)
+----
+NULL
+
+query T
 SELECT json_extract_path('{"a": 1}')
 ----
 {"a": 1}
@@ -729,6 +734,17 @@ query T
 SELECT jsonb_set('{"a":1}', '{b}'::STRING[], '2')
 ----
 {"a": 1, "b": 2}
+
+statement error path element at position 1 is null
+SELECT jsonb_set('{"a":1}', ARRAY[null, 'foo']::STRING[], '2')
+
+statement error path element at position 1 is null
+SELECT jsonb_set('{"a":1}', '{null,foo}'::STRING[], '2', true)
+
+query T
+SELECT jsonb_set('{"a":1}', '{foo,null}'::STRING[], '2', true)
+----
+{"a": 1}
 
 query T
 SELECT jsonb_set('{"a":1}', '{b}'::STRING[], '2', true)

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -328,6 +328,9 @@ func getJSONPath(j DJSON, ary DArray) (Datum, error) {
 	// a new array since the JSON package isn't aware of DArray.
 	path := make([]string, len(ary.Array))
 	for i, v := range ary.Array {
+		if v == DNull {
+			return DNull, nil
+		}
 		path[i] = string(MustBeDString(v))
 	}
 	result, err := json.FetchPath(j.JSON, path)
@@ -1851,6 +1854,9 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				// TODO(justin): this can be optimized.
 				for _, k := range MustBeDArray(right).Array {
+					if k == DNull {
+						continue
+					}
 					e, err := left.(*DJSON).JSON.Exists(string(MustBeDString(k)))
 					if err != nil {
 						return nil, err
@@ -1871,6 +1877,9 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				// TODO(justin): this can be optimized.
 				for _, k := range MustBeDArray(right).Array {
+					if k == DNull {
+						continue
+					}
 					e, err := left.(*DJSON).JSON.Exists(string(MustBeDString(k)))
 					if err != nil {
 						return nil, err


### PR DESCRIPTION
Backport 1/1 commits from #28830.

/cc @cockroachdb/release

---

Fixes #28811.

Release note (bug fix): Fix a panic with JSON values and operations that
use arrays.
