### PR TITLE
scripts: helper for finding commits needing backports

### DIFF
--- a/scripts/compare-branches.sh
+++ b/scripts/compare-branches.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" == "0" ]; then
+	echo "usage: $0 <base> <branch> [git args...]"
+    echo ""
+    echo "print commits on <base> since merge-base with branch that are not cherrypicked to <branch>"
+    echo "extra args are passed though to git log e.g. --author=jsmith or -n 100"
+	exit 1
+fi
+
+base="$1"
+shift
+branch="$1"
+shift
+
+from="$(git merge-base $base $branch)"
+
+base_log="$(mktemp)"
+branch_log="$(mktemp)"
+
+git log --no-merges "$from..$base" --pretty=format:'%s @ %ai	%an	https://github.com/cockroachdb/cockroach/commit/%h ' "$@" \
+           | sort > "$base_log"
+git log --no-merges "$from..$branch" --pretty=format:'%s @ %ai	%an	https://github.com/cockroachdb/cockroach/commit/%h ' "$@" \
+    | sort > "$branch_log"
+
+# NB: head -n 100 | sort catches a SIGPIPE, so don't use that.
+# http://www.pixelbeat.org/programming/sigpipe_handling.html
+
+join -t '@' -v 1 "$base_log" "$branch_log" |
+    awk 'BEGIN { FS="@"; } {print $2,$1}' |
+    sort


### PR DESCRIPTION
Various version of this script are floating around, but right now one has to get them from someome via slack or other channels.
Checking in a script should make it easier for people to find/share/improve.

I added a couple tweaks to the script floating around on slack: ability to filter by author or pass other args to git log, not leaving files in cwd, and linking SHAs to the webui which annotates them with the PR numbers, making it easier to then use those in `backport`.

Release note: none.