### PR TITLE
changefeedccl: resurrect changefeed benchmark

### DIFF
--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -14,8 +14,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -25,12 +23,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/workload/bank"
 )
 
-func BenchmarkChangefeed(b *testing.B) {
-	if testing.Short() {
-		b.Skip("TODO: fix benchmark")
-	}
+func BenchmarkChangefeedTicks(b *testing.B) {
 	defer leaktest.AfterTest(b)()
-	defer utilccl.TestingEnableEnterprise()()
 	defer log.Scope(b).Close(b)
 
 	ctx := context.Background()
@@ -40,40 +34,54 @@ func BenchmarkChangefeed(b *testing.B) {
 	sqlDB.Exec(b, `CREATE DATABASE d`)
 	sqlDB.Exec(b, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
 
-	const numRows = 1000
+	numRows := 1000
+	if testing.Short() {
+		numRows = 100
+	}
 	bankTable := bank.FromRows(numRows).Tables()[0]
-	timestamps, benchBytes, err := loadWorkloadBatches(sqlDB.DB, bankTable)
+	timestamps, _, err := loadWorkloadBatches(sqlDB.DB, bankTable)
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.SetBytes(benchBytes)
 
-	// TODO(dan): This advances the clock through the timestamps of the ingested
-	// data every time it's called, but that's a little unsatisfying. Instead,
-	// wait for each batch to come out of the feed before advancing the
-	// timestamp.
-	var feedTimeIdx int
-	feedClock := hlc.NewClock(func() int64 {
-		if feedTimeIdx < len(timestamps) {
-			feedTimeIdx++
-			return timestamps[feedTimeIdx-1].UnixNano()
+	runBench := func(b *testing.B, feedClock *hlc.Clock) {
+		var sinkBytes int64
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			b.StartTimer()
+			sink, cancelFeed := createBenchmarkChangefeed(ctx, s, feedClock, `d`, `bank`)
+			for rows := 0; rows < numRows; {
+				r, sb := sink.WaitForEmit()
+				rows += r
+				sinkBytes += sb
+			}
+			b.StopTimer()
+			if err := cancelFeed(); err != nil {
+				b.Errorf(`%+v`, err)
+			}
 		}
-		return timeutil.Now().UnixNano()
-	}, time.Nanosecond)
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		resultsCh := make(chan tree.Datums, 1)
-
-		b.StartTimer()
-		cancelFeed := createBenchmarkChangefeed(ctx, s, feedClock, `d`, `bank`, resultsCh)
-		for rows := 0; rows < numRows; rows++ {
-			<-resultsCh
-		}
-		b.StopTimer()
-
-		if err := cancelFeed(); err != nil {
-			b.Errorf(`%+v`, err)
-		}
+		b.SetBytes(sinkBytes / int64(b.N))
 	}
+
+	b.Run(`InitialScan`, func(b *testing.B) {
+		// Use a clock that's immediately larger than any timestamp the data was
+		// loaded at to catch it all in the initial scan.
+		runBench(b, s.Clock())
+	})
+
+	b.Run(`SteadyState`, func(b *testing.B) {
+		// TODO(dan): This advances the clock through the timestamps of the ingested
+		// data every time it's called, but that's a little unsatisfying. Instead,
+		// wait for each batch to come out of the feed before advancing the
+		// timestamp.
+		var feedTimeIdx int
+		feedClock := hlc.NewClock(func() int64 {
+			if feedTimeIdx < len(timestamps) {
+				feedTimeIdx++
+				return timestamps[feedTimeIdx-1].UnixNano()
+			}
+			return timeutil.Now().UnixNano()
+		}, time.Nanosecond)
+		runBench(b, feedClock)
+	})
 }


### PR DESCRIPTION
    name                           time/op
    ChangefeedTicks/InitialScan-8    12.3ms ± 3%
    ChangefeedTicks/SteadyState-8    52.3ms ± 3%

    name                           speed
    ChangefeedTicks/InitialScan-8  11.6MB/s ± 3%
    ChangefeedTicks/SteadyState-8  2.73MB/s ± 3%

    name                           alloc/op
    ChangefeedTicks/InitialScan-8    2.08MB ± 0%
    ChangefeedTicks/SteadyState-8    5.37MB ± 0%

    name                           allocs/op
    ChangefeedTicks/InitialScan-8     35.1k ± 0%
    ChangefeedTicks/SteadyState-8     68.6k ± 0%

Release note: None