### PR TITLE
release-2.1: cli: avoid deprecation warnings for deprecated flags

### DIFF
--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -38,30 +38,6 @@ interrupt
 eexpect ":/# "
 end_test
 
-start_test "Check that --host causes a deprecation warning."
-send "$argv start --insecure --host=localhost\r"
-eexpect "host has been deprecated, use --listen-addr/--advertise-addr instead."
-eexpect "node starting"
-interrupt
-eexpect ":/# "
-end_test
-
-start_test "Check that server --port causes a deprecation warning."
-send "$argv start --insecure --port=26257\r"
-eexpect "port has been deprecated, use --listen-addr=...:<port> instead."
-eexpect "node starting"
-interrupt
-eexpect ":/# "
-end_test
-
-start_test "Check that server --advertise-port causes a deprecation warning."
-send "$argv start --insecure --advertise-port=12345\r"
-eexpect "advertise-port has been deprecated, use --advertise-addr=...:<port> instead."
-eexpect "node starting"
-interrupt
-eexpect ":/# "
-end_test
-
 start_test "Check that not using --host nor --advertise causes a user warning."
 send "$argv start --insecure\r"
 eexpect "WARNING: neither --listen-addr nor --advertise-addr was specified"


### PR DESCRIPTION
Backport 1/1 commits from #29446.

/cc @cockroachdb/release

---

Suggested/recommended by @a-robinson.

The flags `--host`, `--advertise-host`, etc are now deprecated, but
there is no cost in continuing to support them. Also users migrating
from previous versions are not losing anything (or missing out) by
continuing to use them. Forcing a warning to appear when they are used
does not bring any tangible benefit and risks creating operator
fatigue.

So this patch removes the warning (but keeps the deprecated flags
hidden, so that new users are guided to the new flags).

Release note: None
