### PR TITLE
cli: make `gen haproxy` recognize `--http-addr`.

### DIFF
--- a/pkg/cli/haproxy_test.go
+++ b/pkg/cli/haproxy_test.go
@@ -56,10 +56,13 @@ func TestNodeStatusToNodeInfoConversion(t *testing.T) {
 		{
 			[]status.NodeStatus{
 				{
-					Args: []string{"--unwanted", "-http-port=1234"},
+					Args: []string{"--unwanted", "--http-port=1234"},
 				},
 				{
 					Args: nil,
+				},
+				{
+					Args: []string{"--http-addr=foo:4567"},
 				},
 			},
 			[]haProxyNodeInfo{
@@ -68,6 +71,9 @@ func TestNodeStatusToNodeInfoConversion(t *testing.T) {
 				},
 				{
 					CheckPort: base.DefaultHTTPPort,
+				},
+				{
+					CheckPort: "4567",
 				},
 			},
 		},


### PR DESCRIPTION
Fixes  #29279.

Release note (bug fix): `cockroach gen haproxy` now recognizes nodes
that specify the HTTP port number using `--http-addr` instead of
`--http-port`.