### PR TITLE
release-2.1: client: remove a bad assertion

### DIFF
--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -694,10 +694,7 @@ func (txn *Txn) exec(ctx context.Context, fn func(context.Context, *Txn) error) 
 		// Commit on success, unless the txn has already been committed by the
 		// closure. We allow that, as closure might want to run 1PC transactions.
 		if err == nil {
-			if txn.status() == roachpb.ABORTED {
-				log.Fatalf(ctx, "no err but aborted txn proto. txn: %+v", txn)
-			}
-			if txn.status() == roachpb.PENDING {
+			if txn.status() != roachpb.COMMITTED {
 				err = txn.Commit(ctx)
 				log.Eventf(ctx, "client.Txn did AutoCommit. err: %v\n", err)
 				if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #29442.

/cc @cockroachdb/release

---

We were asserting that a txn closure doesn't declare success if the txn
is marked as ABORTED. Some sort of error is generally expected in that
case.
Unfortunately, the assertion is naive. The proto can be marked as
ABORTED async by the heartbeat loop, in which case the client only finds
out on the imminent commit attempt.

Fix #28743

Release note: bug fix: fix a rare crash with the message "no err but
aborted txn proto"
