### PR TITLE
cli: make all client commands recognize `--url`

### DIFF
--- a/pkg/cli/client_url.go
+++ b/pkg/cli/client_url.go
@@ -1,0 +1,340 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
+	"github.com/cockroachdb/cockroach/pkg/security"
+)
+
+// This file implements the parsing of the client --url flag.
+//
+// This aims to offer consistent UX between uses the "combined" --url
+// flag and the "discrete" separate flags --host / --port / etc.
+//
+// The flow of data between flags, configuration variables and usage
+// by client commands goes as follows:
+//
+//            flags parser
+//                /    \
+//         .-----'      `-------.
+//         |                    |
+//       --url               --host, --port, etc
+//         |                    |
+//         |                    |
+//   urlParser.Set()            |
+//     (this file)              |
+//         |                    |
+//         `-------.    .-------'
+//                  \  /
+//          sqlCtx/cliCtx/baseCtx
+//                   |
+//                  / \
+//         .-------'   `--------.
+//         |                    |
+//         |                    |
+//      non-SQL           makeClientConnURL()
+//     commands             (this file)
+//    (quit, init, etc)         |
+//                          SQL commands
+//                        (user, zone, etc)
+//
+
+type urlParser struct {
+	cmd    *cobra.Command
+	cliCtx *cliContext
+
+	// sslStrict, when set to true, requires that the SSL file paths in
+	// a URL clearly map to a certificate directory and restricts the
+	// set of supported SSL modes to just "disable" and "require".
+	//
+	// This is set for all non-SQL client commands, which only support
+	// the insecure boolean and certs-dir with maximum SSL validation.
+	sslStrict bool
+}
+
+func (u urlParser) String() string { return "" }
+
+func (u urlParser) Type() string {
+	return "postgresql://[user[:passwd]@]host[:port]/[db][?parameters...]"
+}
+
+func (u urlParser) Set(v string) error {
+	parsedURL, err := url.Parse(v)
+	if err != nil {
+		return err
+	}
+
+	// General URL format compatibility check.
+	//
+	// The canonical PostgreSQL URL scheme is "postgresql", however our
+	// own client commands also accept "postgres" which is the scheme
+	// registered/supported by lib/pq. Internally, lib/pq supports
+	// both.
+	if parsedURL.Scheme != "postgresql" && parsedURL.Scheme != "postgres" {
+		return fmt.Errorf(`URL scheme must be "postgresql", not "%s"`, parsedURL.Scheme)
+	}
+
+	if parsedURL.Opaque != "" {
+		return fmt.Errorf("unknown URL format: %s", v)
+	}
+
+	cliCtx := u.cliCtx
+
+	// If user name / password information is available, forward it to
+	// --user. We store the password for later re-collection by
+	// makeClientConnURL().
+	if parsedURL.User != nil {
+		f := u.cmd.Flags().Lookup(cliflags.User.Name)
+		if f == nil {
+			// A client which does not support --user will also not use
+			// makeClientConnURL(), so we can ignore/forget about the
+			// information. We do not produce an error however, so that a
+			// user can readily copy-paste the URL produced by `cockroach
+			// start` even if the client command does not accept a username.
+			fmt.Fprintf(stderr,
+				"warning: --url specifies user/password, but command %q does not accept user/password details - details ignored\n",
+				u.cmd.Name())
+		} else {
+			if err := f.Value.Set(parsedURL.User.Username()); err != nil {
+				return errors.Wrapf(err, "extracting user")
+			}
+			if pw, pwSet := parsedURL.User.Password(); pwSet {
+				cliCtx.sqlConnPasswd = pw
+			}
+		}
+	}
+
+	// If some host/port information is available, forward it to
+	// --host / --port.
+	if parsedURL.Host != "" {
+		prevHost, prevPort := cliCtx.clientConnHost, cliCtx.clientConnPort
+		if err := u.cmd.Flags().Set(cliflags.ClientHost.Name, parsedURL.Host); err != nil {
+			return errors.Wrapf(err, "extracting host/port")
+		}
+		// Fill in previously set values for each component that wasn't specified.
+		if cliCtx.clientConnHost == "" {
+			cliCtx.clientConnHost = prevHost
+		}
+		if cliCtx.clientConnPort == "" {
+			cliCtx.clientConnPort = prevPort
+		}
+	}
+
+	// If a database path is available, forward it to --database.
+	if parsedURL.Path != "" {
+		dbPath := strings.TrimLeft(parsedURL.Path, "/")
+		f := u.cmd.Flags().Lookup(cliflags.Database.Name)
+		if f == nil {
+			// A client which does not support --database does not need this
+			// bit of information, so we can ignore/forget about it. We do
+			// not produce an error however, so that a user can readily
+			// copy-paste an URL they picked up from another tool (a GUI
+			// tool for example).
+			fmt.Fprintf(stderr,
+				"warning: --url specifies database %q, but command %q does not accept a database name - database name ignored\n",
+				dbPath, u.cmd.Name())
+		} else {
+			if err := f.Value.Set(dbPath); err != nil {
+				return errors.Wrapf(err, "extracting database name")
+			}
+		}
+	}
+
+	// If some query options are available, try to decompose/capture as
+	// much as possible. Anything not decomposed will be accumulated in
+	// cliCtx.extraConnURLOptions.
+	if parsedURL.RawQuery != "" {
+		options, err := url.ParseQuery(parsedURL.RawQuery)
+		if err != nil {
+			return err
+		}
+
+		cliCtx.extraConnURLOptions = options
+
+		fl := u.cmd.Flags()
+
+		switch sslMode := options.Get("sslmode"); sslMode {
+		case "disable":
+			if err := fl.Set(cliflags.ClientInsecure.Name, "true"); err != nil {
+				return errors.Wrapf(err, "setting insecure connection based on --url")
+			}
+		case "require", "verify-ca", "verify-full":
+			if sslMode != "verify-full" && u.sslStrict {
+				return fmt.Errorf("command %q only supports sslmode=disable or sslmode=verify-full", u.cmd.Name())
+			}
+			if err := fl.Set(cliflags.ClientInsecure.Name, "false"); err != nil {
+				return errors.Wrapf(err, "setting secure connection based on --url")
+			}
+
+			if u.sslStrict {
+				// The "sslStrict" flag means the client command is using our
+				// certificate manager instead of the certificate handler in
+				// lib/pq.
+				//
+				// Our certificate manager is peculiar in that it requires
+				// every file in the same directory (the "certs dir") and also
+				// the files to be named after a fixed naming convention.
+				//
+				// Meanwhile, the URL format for security flags consists
+				// of 3 options (sslrootcert, sslcert, sslkey) that *may*
+				// refer to arbitrary files in arbitrary directories.
+				// Regular SQL drivers are fine with that (including lib/pq)
+				// but our cert manager definitely not (or, at least, not yet).
+				//
+				// So here we have to reverse-engineer the parameters needed
+				// for the certificate manager from the URL and verify that
+				// they conform to the restrictions of our cert manager. There
+				// are three things that need to happen:
+				//
+				// - if the flag --certs-dir is not specified in the command
+				//   line, we need to derive a path for the certificate
+				//   directory from the URL options; our cert manager needs
+				//   this as input.
+				//
+				// - we must verify that all 3 url options that determine
+				//   files refer to the same directory; our cert manager does
+				//   not know how to work otherwise.
+				//
+				// - we must also verify that the 3 options specify a file
+				//   name that is compatible with our cert manager (namely,
+				//   "ca.crt", "client.USERNAME.crt" and
+				//   "client.USERNAME.key").
+				//
+
+				candidateCertsDir := ""
+				foundCertsDir := false
+				if fl.Lookup(cliflags.CertsDir.Name).Changed {
+					// If a --certs-dir flag was preceding --url, we want to
+					// check that the paths inside the URL match the value of
+					// that explicit --certs-dir.
+					//
+					// If --certs-dir was not specified, we'll pick up
+					// the first directory encountered below.
+					candidateCertsDir = cliCtx.SSLCertsDir
+					candidateCertsDir = os.ExpandEnv(candidateCertsDir)
+					candidateCertsDir, err = filepath.Abs(candidateCertsDir)
+					if err != nil {
+						return err
+					}
+				}
+
+				// tryCertsDir digs into the SSL URL options to extract a valid
+				// certificate directory. It also checks that the file names are those
+				// expected by the certificate manager.
+				tryCertsDir := func(optName, expectedFilename string) error {
+					opt := options.Get(optName)
+					if opt == "" {
+						// Option not set: nothing to do.
+						return nil
+					}
+
+					// Check the expected base file name.
+					base := filepath.Base(opt)
+					if base != expectedFilename {
+						return fmt.Errorf("invalid file name for %q: expected %q, got %q", optName, expectedFilename, base)
+					}
+
+					// Extract the directory part.
+					dir := filepath.Dir(opt)
+					dir, err = filepath.Abs(dir)
+					if err != nil {
+						return err
+					}
+					if candidateCertsDir != "" {
+						// A certificate directory has already been found in a previous option;
+						// check that the new option uses the same.
+						if candidateCertsDir != dir {
+							return fmt.Errorf("non-homogeneous certificate directory: %s=%q, expected %q", optName, opt, candidateCertsDir)
+						}
+					} else {
+						// First time seeing a directory, remember it.
+						candidateCertsDir = dir
+						foundCertsDir = true
+					}
+
+					return nil
+				}
+
+				userName := security.RootUser
+				if cliCtx.sqlConnUser != "" {
+					userName = cliCtx.sqlConnUser
+				}
+				if err := tryCertsDir("sslrootcert", security.CACertFilename()); err != nil {
+					return err
+				}
+				if err := tryCertsDir("sslcert", security.ClientCertFilename(userName)); err != nil {
+					return err
+				}
+				if err := tryCertsDir("sslkey", security.ClientKeyFilename(userName)); err != nil {
+					return err
+				}
+
+				if foundCertsDir {
+					if err := fl.Set(cliflags.CertsDir.Name, candidateCertsDir); err != nil {
+						return errors.Wrapf(err, "extracting certificate directory")
+					}
+				}
+			}
+		default:
+			return fmt.Errorf("unsupported sslmode=%s (supported: disable, require, verify-ca, verify-full", sslMode)
+		}
+	}
+
+	return nil
+}
+
+// makeClientConnURL constructs a connection URL from the parsed options.
+// Do not call this function before command-line argument parsing has completed:
+// this initializes the certificate manager with the configured --certs-dir.
+func (cliCtx *cliContext) makeClientConnURL() (url.URL, error) {
+	pgurl := url.URL{
+		Scheme: "postgresql",
+		Host:   net.JoinHostPort(cliCtx.clientConnHost, cliCtx.clientConnPort),
+		Path:   cliCtx.sqlConnDBName,
+	}
+
+	if cliCtx.sqlConnUser != "" {
+		if cliCtx.sqlConnPasswd != "" {
+			pgurl.User = url.UserPassword(cliCtx.sqlConnUser, cliCtx.sqlConnPasswd)
+		} else {
+			pgurl.User = url.User(cliCtx.sqlConnUser)
+		}
+	}
+
+	opts := url.Values{}
+	for k, v := range cliCtx.extraConnURLOptions {
+		opts[k] = v
+	}
+
+	userName := cliCtx.sqlConnUser
+	if userName == "" {
+		userName = security.RootUser
+	}
+
+	err := cliCtx.LoadSecurityOptions(opts, userName)
+	pgurl.RawQuery = opts.Encode()
+	return pgurl, err
+}

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -663,9 +663,9 @@ The value "disabled" will disable all local file I/O. `,
 		Name:   "url",
 		EnvVar: "COCKROACH_URL",
 		Description: `
-Connection url. eg: postgresql://myuser@localhost:26257/mydb
+Connection URL, e.g. "postgresql://myuser@localhost:26257/mydb".
 If left empty, the connection flags are used (host, port, user,
-database, insecure, certs).`,
+database, insecure, certs-dir).`,
 	}
 
 	User = FlagInfo{

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -74,6 +74,8 @@ func initCLIDefaults() {
 	}
 	cliCtx.showTimes = false
 	cliCtx.cmdTimeout = 0 // no timeout
+	cliCtx.clientConnHost = ""
+	cliCtx.clientConnPort = base.DefaultPort
 	cliCtx.sqlConnURL = ""
 	cliCtx.sqlConnUser = ""
 	cliCtx.sqlConnDBName = ""
@@ -155,6 +157,12 @@ type cliContext struct {
 	// cmdTimeout sets the maximum run time for the command.
 	// Commands that wish to use this must use cmdTimeoutContext().
 	cmdTimeout time.Duration
+
+	// clientConnHost is the hostname/address to use to connect to a server.
+	clientConnHost string
+
+	// clientConnPort is the port name/number to use to connect to a server.
+	clientConnPort string
 
 	// for CLI commands that use the SQL interface, these parameters
 	// determine how to connect to the server.

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -16,8 +16,12 @@ package cli
 
 import (
 	"context"
+	"net/url"
 	"os"
 	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -78,7 +82,9 @@ func initCLIDefaults() {
 	cliCtx.clientConnPort = base.DefaultPort
 	cliCtx.sqlConnURL = ""
 	cliCtx.sqlConnUser = ""
+	cliCtx.sqlConnPasswd = ""
 	cliCtx.sqlConnDBName = ""
+	cliCtx.extraConnURLOptions = nil
 
 	sqlCtx.setStmts = nil
 	sqlCtx.execStmts = nil
@@ -130,6 +136,16 @@ func initCLIDefaults() {
 	sqlfmtCtx.execStmts = nil
 
 	initPreFlagsDefaults()
+
+	// Clear the "Changed" state of all the registered command-line flags.
+	clearFlagChanges(cockroachCmd)
+}
+
+func clearFlagChanges(cmd *cobra.Command) {
+	cmd.LocalFlags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
+	for _, subCmd := range cmd.Commands() {
+		clearFlagChanges(subCmd)
+	}
 }
 
 // cliContext captures the command-line parameters of most CLI commands.
@@ -167,6 +183,13 @@ type cliContext struct {
 	// for CLI commands that use the SQL interface, these parameters
 	// determine how to connect to the server.
 	sqlConnURL, sqlConnUser, sqlConnDBName string
+
+	// The client password to use. This can be set via the --url flag.
+	sqlConnPasswd string
+
+	// extraConnURLOptions contains any additional query URL options
+	// specified in --url that do not have discrete equivalents.
+	extraConnURLOptions url.Values
 }
 
 // cliCtx captures the command-line parameters common to most CLI utilities.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -461,18 +461,19 @@ func init() {
 	// By default, query times are not displayed. The default is overridden
 	// in the CLI shell.
 	for _, cmd := range tableOutputCommands {
-		f := cmd.Flags()
+		f := cmd.PersistentFlags()
 		VarFlag(f, &cliCtx.tableDisplayFormat, cliflags.TableDisplayFormat)
 	}
 
 	// sqlfmt command.
-	VarFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.execStmts, cliflags.Execute)
+	fmtFlags := sqlfmtCmd.Flags()
+	VarFlag(fmtFlags, &sqlfmtCtx.execStmts, cliflags.Execute)
 	cfg := tree.DefaultPrettyCfg()
-	IntFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.len, cliflags.SQLFmtLen, cfg.LineWidth)
-	BoolFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.useSpaces, cliflags.SQLFmtSpaces, !cfg.UseTabs)
-	IntFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.tabWidth, cliflags.SQLFmtTabWidth, cfg.TabWidth)
-	BoolFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.noSimplify, cliflags.SQLFmtNoSimplify, !cfg.Simplify)
-	BoolFlag(sqlfmtCmd.Flags(), &sqlfmtCtx.align, cliflags.SQLFmtAlign, (cfg.Align != tree.PrettyNoAlign))
+	IntFlag(fmtFlags, &sqlfmtCtx.len, cliflags.SQLFmtLen, cfg.LineWidth)
+	BoolFlag(fmtFlags, &sqlfmtCtx.useSpaces, cliflags.SQLFmtSpaces, !cfg.UseTabs)
+	IntFlag(fmtFlags, &sqlfmtCtx.tabWidth, cliflags.SQLFmtTabWidth, cfg.TabWidth)
+	BoolFlag(fmtFlags, &sqlfmtCtx.noSimplify, cliflags.SQLFmtNoSimplify, !cfg.Simplify)
+	BoolFlag(fmtFlags, &sqlfmtCtx.align, cliflags.SQLFmtAlign, (cfg.Align != tree.PrettyNoAlign))
 
 	// Debug commands.
 	{

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -47,7 +47,6 @@ import (
 //   flags logic, because some tests to not use the flag logic at all.
 var serverListenPort, serverAdvertiseAddr, serverAdvertisePort string
 var serverHTTPAddr, serverHTTPPort string
-var clientConnHost, clientConnPort string
 var localityAdvertiseHosts localityList
 
 // initPreFlagsDefaults initializes the values of the global variables
@@ -60,8 +59,6 @@ func initPreFlagsDefaults() {
 	serverHTTPAddr = ""
 	serverHTTPPort = base.DefaultHTTPPort
 
-	clientConnHost = ""
-	clientConnPort = base.DefaultPort
 	localityAdvertiseHosts = localityList{}
 }
 
@@ -382,8 +379,8 @@ func init() {
 	clientCmds = append(clientCmds, initCmd)
 	for _, cmd := range clientCmds {
 		f := cmd.PersistentFlags()
-		VarFlag(f, addrSetter{&clientConnHost, &clientConnPort}, cliflags.ClientHost)
-		StringFlag(f, &clientConnPort, cliflags.ClientPort, clientConnPort)
+		VarFlag(f, addrSetter{&cliCtx.clientConnHost, &cliCtx.clientConnPort}, cliflags.ClientHost)
+		StringFlag(f, &cliCtx.clientConnPort, cliflags.ClientPort, cliCtx.clientConnPort)
 		_ = f.MarkHidden(cliflags.ClientPort.Name)
 
 		BoolFlag(f, &baseCfg.Insecure, cliflags.ClientInsecure, baseCfg.Insecure)
@@ -517,7 +514,7 @@ func extraServerFlagInit() {
 }
 
 func extraClientFlagInit() {
-	serverCfg.Addr = net.JoinHostPort(clientConnHost, clientConnPort)
+	serverCfg.Addr = net.JoinHostPort(cliCtx.clientConnHost, cliCtx.clientConnPort)
 	serverCfg.AdvertiseAddr = serverCfg.Addr
 	if serverHTTPAddr == "" {
 		serverHTTPAddr = startCtx.serverListenAddr

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -436,17 +436,27 @@ func init() {
 	sqlCmds = append(sqlCmds, zoneCmds...)
 	sqlCmds = append(sqlCmds, userCmds...)
 	for _, cmd := range sqlCmds {
-		f := cmd.PersistentFlags()
+		f := cmd.Flags()
 		BoolFlag(f, &sqlCtx.echo, cliflags.EchoSQL, sqlCtx.echo)
 
 		if cmd != demoCmd {
-			StringFlag(f, &cliCtx.sqlConnURL, cliflags.URL, cliCtx.sqlConnURL)
+			VarFlag(f, urlParser{cmd, &cliCtx, false /* strictSSL */}, cliflags.URL)
 			StringFlag(f, &cliCtx.sqlConnUser, cliflags.User, cliCtx.sqlConnUser)
 		}
 
 		if cmd == sqlShellCmd {
 			StringFlag(f, &cliCtx.sqlConnDBName, cliflags.Database, cliCtx.sqlConnDBName)
 		}
+	}
+
+	// Make the other non-SQL client commands also recognize --url in
+	// strict SSL mode.
+	for _, cmd := range clientCmds {
+		if f := cmd.Flags().Lookup(cliflags.URL.Name); f != nil {
+			// --url already registered above, nothing to do.
+			continue
+		}
+		VarFlag(cmd.PersistentFlags(), urlParser{cmd, &cliCtx, true /* strictSSL */}, cliflags.URL)
 	}
 
 	// Commands that print tables.

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -89,7 +89,7 @@ end_test
 
 start_test "Check that root cannot use password."
 # Run as root but with a non-existent certs directory.
-send "$argv sql --url='postgresql://root@localhost:26257?sslmode=verify-full'\r"
+send "$argv sql --url='postgresql://root@localhost:26257?sslmode=verify-full&sslrootcert=$certs_dir/ca.crt'\r"
 eexpect "Error: connections with user root must use a client certificate"
 eexpect "Failed running \"sql\""
 end_test

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -479,97 +479,28 @@ func getPasswordAndMakeSQLClient(appName string) (*sqlConn, error) {
 	return makeSQLClient(appName)
 }
 
-// makeURLFromFlags constructs a pg connection URL using the values
-// initialized by command-line flags.
-func makeURLFromFlags(userinfo *url.Userinfo) *url.URL {
-	host := serverCfg.Addr
-	if !strings.HasPrefix(cliCtx.Addr, ":") {
-		host = cliCtx.Addr
-	}
-
-	// Build the URL object.
-	return &url.URL{
-		Scheme: "postgresql",
-		Path:   cliCtx.sqlConnDBName,
-		Host:   host,
-		User:   userinfo,
-	}
-}
-
 var sqlConnTimeout = envutil.EnvOrDefaultString("COCKROACH_CONNECT_TIMEOUT", "5")
 
 // makeSQLClient connects to the database using the connection
-// settings set by the command-line flags. The value of --url, if any
-// is provided is used as the source of configuration; otherwise a URL
-// is constructed from the other command-line parameters.
-//
-// If --url is specified but any of the following items is _missing_
-// from the URL, the remaining command-line flags are used to "fill it
-// in":
-//
-// - the current database (--database)
-// - the user (--user)
-// - the SSL configuration (--insecure, --certs-dir, etc)
-//
-// Otherwise, if an item is present both in the URL and specified
-// otherwise, a warning is printed to indicate that the URL prevails.
+// settings set by the command-line flags.
 //
 // The appName given as argument is added to the URL even if --url is
 // specified, but only if the URL didn't already specify
 // application_name. It is prefixed with '$ ' to mark it as internal.
 func makeSQLClient(appName string) (*sqlConn, error) {
-	var baseURL *url.URL
-	var options url.Values
-
-	defaultUserinfo := url.User(security.RootUser)
-	if cliCtx.sqlConnUser != "" {
-		defaultUserinfo = url.User(cliCtx.sqlConnUser)
+	baseURL, err := cliCtx.makeClientConnURL()
+	if err != nil {
+		return nil, err
 	}
 
-	// Determine the starting point.
-	if cliCtx.sqlConnURL == "" {
-		baseURL = makeURLFromFlags(defaultUserinfo)
-		options = url.Values{}
-	} else {
-		// User-specified --url is the starting point.
-		var err error
-		baseURL, err = url.Parse(cliCtx.sqlConnURL)
-		if err != nil {
-			return nil, err
-		}
-		options, err = url.ParseQuery(baseURL.RawQuery)
-		if err != nil {
-			return nil, err
-		}
-
-		// Check that any argument otherwise used to
-		// populate a URL, if --url was not specified, have
-		// not been specified if --url was.
-		if baseURL.Path != "" && cliCtx.sqlConnDBName != "" {
-			log.Warning(context.Background(), "parameter --database ignored, using --url instead")
-		}
-		if baseURL.User.Username() != "" && cliCtx.sqlConnUser != "" {
-			log.Warning(context.Background(), "parameter --user ignored, using --url instead")
-		}
-		if !strings.HasPrefix(cliCtx.Addr, ":") {
-			log.Warning(context.Background(), "parameter --host ignored, using --url instead")
-		}
-		if options.Get("sslmode") != "" && cliCtx.Insecure {
-			log.Warning(context.Background(), "parameter --insecure ignored, using --url instead")
-		}
-	}
-
-	// If there is no user in the URL already, use the one passed as
-	// command-line flag.
+	// If there is no user in the URL already, fill in the default user.
 	if baseURL.User.Username() == "" {
-		baseURL.User = defaultUserinfo
+		baseURL.User = url.User(security.RootUser)
 	}
 
-	// If there are no SSL options yet, use the command-line flags to set them.
-	if options.Get("sslmode") == "" {
-		if err := cliCtx.LoadSecurityOptions(options, baseURL.User.Username()); err != nil {
-			return nil, err
-		}
+	options, err := url.ParseQuery(baseURL.RawQuery)
+	if err != nil {
+		return nil, err
 	}
 
 	// Insecure connections are insecure and should never see a password. Reject
@@ -598,12 +529,6 @@ func makeSQLClient(appName string) (*sqlConn, error) {
 				baseURL.User = url.UserPassword(baseURL.User.Username(), pwd)
 			}
 		}
-	}
-
-	// If there is no database in the URL already, use the one passed as
-	// command-line flag.
-	if baseURL.Path == "" || baseURL.Path == "/" {
-		baseURL.Path = cliCtx.sqlConnDBName
 	}
 
 	// Load the application name. It's not a command-line flag, so

--- a/pkg/cli/start_test.go
+++ b/pkg/cli/start_test.go
@@ -24,12 +24,16 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func TestInitInsecure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	// Avoid leaking configuration changes after the tests end.
+	defer initCLIDefaults()
 
 	f := StartCmd.Flags()
 
@@ -75,6 +79,13 @@ func TestInitInsecure(t *testing.T) {
 
 func TestStartArgChecking(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	// Avoid leaking configuration changes after the tests end.
+	// In addition to the usual initCLIDefaults, we need to reset
+	// the serverCfg because --store modifies it in a way that
+	// initCLIDefaults does not restore.
+	defer func(save server.Config) { serverCfg = save }(serverCfg)
+	defer initCLIDefaults()
 
 	f := StartCmd.Flags()
 

--- a/pkg/security/certificate_manager.go
+++ b/pkg/security/certificate_manager.go
@@ -194,8 +194,11 @@ func (cm *CertificateManager) RegisterSignalHandler(stopper *stop.Stopper) {
 
 // CACertPath returns the expected file path for the CA certificate.
 func (cm *CertificateManager) CACertPath() string {
-	return filepath.Join(cm.certsDir, "ca"+certExtension)
+	return filepath.Join(cm.certsDir, CACertFilename())
 }
+
+// CACertFilename returns the expected file name for the CA certificate.
+func CACertFilename() string { return "ca" + certExtension }
 
 // ClientCACertPath returns the expected file path for the CA certificate
 // used to verify client certificates.
@@ -231,13 +234,19 @@ func (cm *CertificateManager) UIKeyPath() string {
 
 // ClientCertPath returns the expected file path for the user's certificate.
 func (cm *CertificateManager) ClientCertPath(user string) string {
-	return filepath.Join(cm.certsDir, "client."+user+certExtension)
+	return filepath.Join(cm.certsDir, ClientCertFilename(user))
 }
+
+// ClientCertFilename returns the expected file name for the user's certificate.
+func ClientCertFilename(user string) string { return "client." + user + certExtension }
 
 // ClientKeyPath returns the expected file path for the user's key.
 func (cm *CertificateManager) ClientKeyPath(user string) string {
-	return filepath.Join(cm.certsDir, "client."+user+keyExtension)
+	return filepath.Join(cm.certsDir, ClientKeyFilename(user))
 }
+
+// ClientKeyFilename returns the expected file name for the user's key.
+func ClientKeyFilename(user string) string { return "client." + user + keyExtension }
 
 // CACert returns the CA cert. May be nil.
 // Callers should check for an internal Error field.


### PR DESCRIPTION
Fixes #4984.
Fixes #29567.

Prior to this patch, the client commands using a SQL connection under
the hood would accept `--url` in addition to discrete
parameters (`--host`, `--port`, etc); however, non-SQL client commands
did not recognize `--url`.

This was causing UX pain/fatigue because users had to remember which
commands accept a URL and which commands do not. It also made
automation more difficult.

(For context, it was not reasonable to propose to users to _never_ use
`--url` and always stick to discrete flags, because some parameters
can only be specified via `--url`, for example the application name.)

This patch resolves the UX problem by ensuring that all client
commands accept `--url`, in addition to the discrete flags. This
effectively makes all CockroachDB commands (*) homogeneous/consistent
wrt their connection flags.

The value provided via `--url` and via the other discrete flags mesh
as follows:

```
//            flags parser
//                /    \
//         .-----'      `-------.
//         |                    |
//       --url               --host, --port, etc
//         |                    |
//   urlParser.Set()            |
//         |                    |
//         `-------.    .-------'
//                  \  /
//          sqlCtx/cliCtx/baseCtx
//                   |
//                  / \
//         .-------'   `--------.
//         |                    |
//         |                    |
//      non-SQL           makeClientConnURL()
//     commands                 |
//    (quit, init, etc)         |
//                          SQL commands
//                        (user, zone, etc)
```

(*) except for `cockroach workload`, which still has the status an
adopted appendage with its separate argument handling.

Release note (cli change): All `cockroach` client sub-commands (except
for `cockroach workload`) now support the `--url` flag.