### PR TITLE
sql: fix INSERT INTO t DEFAULT VALUES in presence of schema changes

### DIFF
--- a/pkg/sql/sqlbase/default_exprs.go
+++ b/pkg/sql/sqlbase/default_exprs.go
@@ -108,11 +108,12 @@ func processColumnSet(
 		}
 	}
 
-	// Add any column that has a DEFAULT expression.
+	// Add all public columns that satisfy the condition.
 	for _, col := range tableDesc.Columns {
 		addIf(col)
 	}
-	// Also add any column in a mutation that is DELETE_AND_WRITE_ONLY.
+	// Also add any column in a mutation that is DELETE_AND_WRITE_ONLY that also
+	// satisfies the condition.
 	for _, m := range tableDesc.Mutations {
 		if col := m.GetColumn(); col != nil &&
 			m.State == DescriptorMutation_DELETE_AND_WRITE_ONLY {


### PR DESCRIPTION
Previously, `INSERT INTO t DEFAULT VALUES` would fail if there were
outstanding column schema changes.

Closes #29478.

Release note (bug fix): correct behavior of `INSERT INTO t DEFAULT
VALUES` when there are active schema changes.