### PR TITLE
release-2.1: *: minor fixes for go1.11 warnings

### DIFF
--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -160,7 +160,7 @@ func runDecommission(t *test, c *cluster, nodes int, duration time.Duration) {
 
 		decom := func(id string) error {
 			port := fmt.Sprintf("{pgport:%d}", nodes) // always use last node
-			t.Status("decommissioning node %s", id)
+			t.Status("decommissioning node", id)
 			return c.RunE(ctx, c.Node(nodes), "./cockroach node decommission --insecure --wait=live --host=:"+port+" "+id)
 		}
 

--- a/pkg/sql/sem/builtins/builtins_test.go
+++ b/pkg/sql/sem/builtins/builtins_test.go
@@ -62,6 +62,12 @@ func TestGenerateUniqueIDOrder(t *testing.T) {
 func TestStringToArrayAndBack(t *testing.T) {
 	// s allows us to have a string pointer literal.
 	s := func(x string) *string { return &x }
+	fs := func(x *string) string {
+		if x != nil {
+			return *x
+		}
+		return "<nil>"
+	}
 	cases := []struct {
 		input    string
 		sep      *string
@@ -89,7 +95,7 @@ func TestStringToArrayAndBack(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(fmt.Sprintf("string_to_array(%q, %q)", tc.input, tc.sep), func(t *testing.T) {
+		t.Run(fmt.Sprintf("string_to_array(%q, %q)", tc.input, fs(tc.sep)), func(t *testing.T) {
 			result, err := stringToArray(tc.input, tc.sep, tc.nullStr)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Backport 2/2 commits from #29062.

/cc @cockroachdb/release

---

Not really necessary, but I'm going to be backporting more roachtest changes and I don't want the roachtest commit in this PR to cause a conflict.