### PR TITLE
release-2.1: roachtest: rework child logger creation

### DIFF
--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -58,7 +58,7 @@ func registerAllocator(r *registry) {
 			// but we can't put it in monitor as-is because the test deadlocks.
 			go func() {
 				const cmd = `./workload run kv --tolerate-errors --min-block-bytes=8 --max-block-bytes=128`
-				l, err := c.l.childLogger(fmt.Sprintf(`kv-%d`, node))
+				l, err := c.l.ChildLogger(fmt.Sprintf(`kv-%d`, node))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -108,7 +108,7 @@ func printRebalanceStats(l *logger, db *gosql.DB) error {
 		).Scan(&rebalanceIntervalStr); err != nil {
 			return err
 		}
-		l.printf("cluster took %s to rebalance\n", rebalanceIntervalStr)
+		l.Printf("cluster took %s to rebalance\n", rebalanceIntervalStr)
 	}
 
 	// Output # of range events that occurred. All other things being equal,
@@ -119,7 +119,7 @@ func printRebalanceStats(l *logger, db *gosql.DB) error {
 		if err := db.QueryRow(q).Scan(&rangeEvents); err != nil {
 			return err
 		}
-		l.printf("%d range events\n", rangeEvents)
+		l.Printf("%d range events\n", rangeEvents)
 	}
 
 	// Output standard deviation of the replica counts for all stores.
@@ -130,7 +130,7 @@ func printRebalanceStats(l *logger, db *gosql.DB) error {
 		).Scan(&stdDev); err != nil {
 			return err
 		}
-		l.printf("stdDev(replica count) = %.2f\n", stdDev)
+		l.Printf("stdDev(replica count) = %.2f\n", stdDev)
 	}
 
 	// Output the number of ranges on each store.
@@ -145,7 +145,7 @@ func printRebalanceStats(l *logger, db *gosql.DB) error {
 			if err := rows.Scan(&storeID, &rangeCount); err != nil {
 				return err
 			}
-			l.printf("s%d has %d ranges\n", storeID, rangeCount)
+			l.Printf("s%d has %d ranges\n", storeID, rangeCount)
 		}
 	}
 
@@ -229,9 +229,9 @@ func waitForRebalance(ctx context.Context, l *logger, db *gosql.DB, maxStdDev fl
 				return err
 			}
 
-			l.printf("%v\n", stats)
+			l.Printf("%v\n", stats)
 			if stableSeconds <= stats.SecondsSinceLastEvent {
-				l.printf("replica count stddev = %f, max allowed stddev = %f\n", stats.ReplicaCountStdDev, maxStdDev)
+				l.Printf("replica count stddev = %f, max allowed stddev = %f\n", stats.ReplicaCountStdDev, maxStdDev)
 				if stats.ReplicaCountStdDev > maxStdDev {
 					_ = printRebalanceStats(l, db)
 					return errors.Errorf(

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -127,7 +127,7 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 		return nil
 	})
 	m.Go(func(ctx context.Context) error {
-		l, err := c.l.childLogger(`changefeed`)
+		l, err := c.l.ChildLogger(`changefeed`)
 		if err != nil {
 			return err
 		}
@@ -136,7 +136,7 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 		if err := db.QueryRow(`SELECT cluster_logical_timestamp()`).Scan(&cursor); err != nil {
 			c.t.Fatal(err)
 		}
-		c.l.printf("starting cursor at %s\n", cursor)
+		c.l.Printf("starting cursor at %s\n", cursor)
 
 		var jobID int
 		createStmt := `CREATE CHANGEFEED FOR
@@ -183,7 +183,7 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 				}
 				if initialScanLatency == 0 {
 					initialScanLatency = timeutil.Since(timeutil.Unix(0, hwWallTime))
-					l.printf("initial scan latency %s\n", initialScanLatency)
+					l.Printf("initial scan latency %s\n", initialScanLatency)
 					t.Status("finished initial scan")
 					continue
 				}
@@ -197,14 +197,14 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 					// tracking the max latency once we seen a latency
 					// that's less than the max allowed. Verify at the end
 					// of the test that this happens at some point.
-					l.printf("end-to-end latency %s not yet below max allowed %s\n",
+					l.Printf("end-to-end latency %s not yet below max allowed %s\n",
 						latency, maxLatencyAllowed)
 					continue
 				}
 				if latency > maxSeenLatency {
 					maxSeenLatency = latency
 				}
-				l.printf("end-to-end latency %s max so far %s\n", latency, maxSeenLatency)
+				l.Printf("end-to-end latency %s max so far %s\n", latency, maxSeenLatency)
 			}
 		}
 	})

--- a/pkg/cmd/roachtest/chaos.go
+++ b/pkg/cmd/roachtest/chaos.go
@@ -55,7 +55,7 @@ type Chaos struct {
 // duration.
 func (ch *Chaos) Runner(c *cluster, m *monitor) func(context.Context) error {
 	return func(ctx context.Context) error {
-		l, err := c.l.childLogger("CHAOS")
+		l, err := c.l.ChildLogger("CHAOS")
 		if err != nil {
 			return err
 		}
@@ -74,10 +74,10 @@ func (ch *Chaos) Runner(c *cluster, m *monitor) func(context.Context) error {
 			m.ExpectDeath()
 
 			if ch.DrainAndQuit {
-				l.printf("stopping and draining %v\n", target)
+				l.Printf("stopping and draining %v\n", target)
 				c.Stop(ctx, target, stopArgs("--sig=15"))
 			} else {
-				l.printf("killing %v\n", target)
+				l.Printf("killing %v\n", target)
 				c.Stop(ctx, target)
 			}
 
@@ -89,7 +89,7 @@ func (ch *Chaos) Runner(c *cluster, m *monitor) func(context.Context) error {
 			case <-time.After(downTime):
 			}
 
-			c.l.printf("restarting %v after %s of downtime\n", target, downTime)
+			c.l.Printf("restarting %v after %s of downtime\n", target, downTime)
 			c.Start(ctx, target)
 		}
 	}

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -111,7 +111,7 @@ func registerClearRange(r *registry) {
 					if err := conn.QueryRowContext(ctx, `SELECT count(*) FROM tinybank.bank`).Scan(&count); err != nil {
 						return err
 					}
-					c.l.printf("read %d rows in %0.1fs\n", count, timeutil.Since(start).Seconds())
+					c.l.Printf("read %d rows in %0.1fs\n", count, timeutil.Since(start).Seconds())
 					t.WorkerProgress(float64(i+1) / float64(minutes))
 					select {
 					case <-after:

--- a/pkg/cmd/roachtest/cli.go
+++ b/pkg/cmd/roachtest/cli.go
@@ -74,7 +74,7 @@ func runCLINodeStatus(ctx context.Context, t *test, c *cluster) {
 			if reflect.DeepEqual(expected, actual) {
 				break
 			}
-			c.l.printf("not done: %s vs %s\n", expected, actual)
+			c.l.Printf("not done: %s vs %s\n", expected, actual)
 			time.Sleep(time.Second)
 		}
 		if !reflect.DeepEqual(expected, actual) {

--- a/pkg/cmd/roachtest/clock_monotonic.go
+++ b/pkg/cmd/roachtest/clock_monotonic.go
@@ -80,10 +80,10 @@ func runClockMonotonicity(ctx context.Context, t *test, c *cluster, tc clockMono
 	}
 
 	t.Status("validating clock monotonicity")
-	c.l.printf("pre-restart time:  %f\n", preRestartTime)
-	c.l.printf("post-restart time: %f\n", postRestartTime)
+	c.l.Printf("pre-restart time:  %f\n", preRestartTime)
+	c.l.Printf("post-restart time: %f\n", postRestartTime)
 	difference := postRestartTime - preRestartTime
-	c.l.printf("time-difference: %v\n", time.Duration(difference*float64(time.Second)))
+	c.l.Printf("time-difference: %v\n", time.Duration(difference*float64(time.Second)))
 
 	if tc.expectIncreasingWallTime {
 		if preRestartTime > postRestartTime {

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -218,7 +218,7 @@ func execCmd(ctx context.Context, l *logger, args ...string) error {
 	ctx, cancel = context.WithCancel(ctx)
 	defer cancel()
 
-	l.printf("> %s\n", strings.Join(args, " "))
+	l.Printf("> %s\n", strings.Join(args, " "))
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 
 	debugStdoutBuffer, _ := circbuf.NewBuffer(1024)
@@ -292,7 +292,7 @@ func execCmd(ctx context.Context, l *logger, args ...string) error {
 }
 
 func execCmdWithBuffer(ctx context.Context, l *logger, args ...string) ([]byte, error) {
-	l.printf("> %s\n", strings.Join(args, " "))
+	l.Printf("> %s\n", strings.Join(args, " "))
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 
 	out, err := cmd.CombinedOutput()
@@ -628,7 +628,7 @@ func newCluster(ctx context.Context, t testI, nodes []nodeSpec) *cluster {
 		if clusterWipe {
 			c.Wipe(ctx, c.All())
 		} else {
-			l.printf("skipping cluster wipe\n")
+			l.Printf("skipping cluster wipe\n")
 		}
 	}
 	c.status("running test")
@@ -710,16 +710,16 @@ func (c *cluster) destroy(ctx context.Context) {
 		if c.name != clusterName {
 			c.status("destroying cluster")
 			if err := execCmd(ctx, c.l, roachprod, "destroy", c.name); err != nil {
-				c.l.errorf("%s", err)
+				c.l.Errorf("%s", err)
 			}
 		} else {
 			c.status("wiping cluster")
 			if err := execCmd(ctx, c.l, roachprod, "wipe", c.name); err != nil {
-				c.l.errorf("%s", err)
+				c.l.Errorf("%s", err)
 			}
 		}
 	} else {
-		c.l.printf("skipping cluster wipe\n")
+		c.l.Printf("skipping cluster wipe\n")
 	}
 }
 
@@ -1273,7 +1273,7 @@ func (m *monitor) wait(args ...string) error {
 			// on the error if the monitoring command exits peacefully.
 		}()
 
-		monL, err := m.l.childLogger(`MONITOR`)
+		monL, err := m.l.ChildLogger(`MONITOR`)
 		if err != nil {
 			setErr(err)
 			return

--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -121,7 +121,7 @@ func registerCopy(r *registry) {
 			}
 
 			rc := rangeCount()
-			c.l.printf("range count after copy = %d\n", rc)
+			c.l.Printf("range count after copy = %d\n", rc)
 			highExp := (rows * rowEstimate) / (32 << 20 /* 32MB */)
 			lowExp := (rows * rowEstimate) / (64 << 20 /* 64MB */)
 			if rc > highExp || rc < lowExp {

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -18,8 +18,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"strconv"
 	"time"
 
@@ -122,7 +120,7 @@ func runDecommission(t *test, c *cluster, nodes int, duration time.Duration) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c.l.printf(fmt.Sprintf("run: %s\n", stmt))
+		c.l.Printf(fmt.Sprintf("run: %s\n", stmt))
 	}
 
 	var m *errgroup.Group // see comment in version.go
@@ -133,10 +131,11 @@ func runDecommission(t *test, c *cluster, nodes int, duration time.Duration) {
 
 		cmd = fmt.Sprintf(cmd, nodes)
 		m.Go(func() error {
-			quietL, err := newLogger(cmd, strconv.Itoa(i), "workload"+strconv.Itoa(i), ioutil.Discard, os.Stderr)
+			quietL, err := c.l.ChildLogger("kv-"+strconv.Itoa(i), quietStdout)
 			if err != nil {
 				return err
 			}
+			defer quietL.close()
 			return c.RunL(ctx, quietL, c.Node(nodes), cmd)
 		})
 	}

--- a/pkg/cmd/roachtest/disk_space.go
+++ b/pkg/cmd/roachtest/disk_space.go
@@ -18,10 +18,8 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
-	"os"
 	"strconv"
 	"time"
 
@@ -81,10 +79,11 @@ func runDiskUsage(t *test, c *cluster, duration time.Duration, tc diskUsageTestC
 
 		cmd = fmt.Sprintf(cmd, nodes)
 		m.Go(func() error {
-			quietL, err := newLogger(cmd, strconv.Itoa(i), "workload"+strconv.Itoa(i), ioutil.Discard, os.Stderr)
+			quietL, err := c.l.ChildLogger("kv-"+strconv.Itoa(i), quietStdout)
 			if err != nil {
 				return err
 			}
+			defer quietL.close()
 			return c.RunL(ctxWG, quietL, c.Node(numNodes), cmd)
 		})
 	}
@@ -182,12 +181,16 @@ func runDiskUsage(t *test, c *cluster, duration time.Duration, tc diskUsageTestC
 
 	printDiskUsages := func() {
 		for i := 1; i <= numNodes; i++ {
-			quietL, _ := newLogger("disk_space", strconv.Itoa(i), "", ioutil.Discard, os.Stderr)
+			quietL, err := c.l.ChildLogger(fmt.Sprintf("df-%d", i), quietStdout)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer quietL.close()
 			output, err := c.RunWithBuffer(ctx, quietL, c.Node(i), "df", "-h", "{store-dir}")
 			if err != nil {
-				c.l.printf("Failed to run df on node %d due to error: %v\n", i, err)
+				c.l.Printf("Failed to run df on node %d due to error: %v\n", i, err)
 			} else {
-				c.l.printf("node %d, df output:\n %s\n", i, string(output))
+				c.l.Printf("node %d, df output:\n %s\n", i, string(output))
 			}
 		}
 	}
@@ -249,7 +252,7 @@ func runDiskUsage(t *test, c *cluster, duration time.Duration, tc diskUsageTestC
 			"rm",
 			ballastFilePath,
 		); err != nil {
-			c.l.printf("Failed to remove ballast file on node %d due to error: %v\n", i, err)
+			c.l.Printf("Failed to remove ballast file on node %d due to error: %v\n", i, err)
 		}
 	}
 }

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -77,7 +77,7 @@ func registerDrop(r *registry) {
 					return err
 				}
 
-				c.l.printf("Node %d space used: %s\n", j, humanizeutil.IBytes(int64(size)))
+				c.l.Printf("Node %d space used: %s\n", j, humanizeutil.IBytes(int64(size)))
 
 				// Return if the size of the directory is less than 100mb
 				if size < initDiskSpace {
@@ -118,7 +118,7 @@ gc:
 					}
 
 					nodeSpaceUsed := fmt.Sprintf("Node %d space after deletion used: %s\n", j, humanizeutil.IBytes(int64(size)))
-					c.l.printf(nodeSpaceUsed)
+					c.l.Printf(nodeSpaceUsed)
 
 					// Return if the size of the directory is less than 100mb
 					if size > maxSizeBytes {

--- a/pkg/cmd/roachtest/election.go
+++ b/pkg/cmd/roachtest/election.go
@@ -44,7 +44,7 @@ func registerElectionAfterRestart(r *registry) {
 			c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
         SELECT * FROM test.kv"`)
 			duration := timeutil.Since(start)
-			c.l.printf("pre-restart, query took %s\n", duration)
+			c.l.Printf("pre-restart, query took %s\n", duration)
 
 			t.Status("restarting")
 			c.Stop(ctx)
@@ -60,7 +60,7 @@ func registerElectionAfterRestart(r *registry) {
 			c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
         SELECT * FROM test.kv"`)
 			duration = timeutil.Since(start)
-			c.l.printf("post-restart, query took %s\n", duration)
+			c.l.Printf("post-restart, query took %s\n", duration)
 			if expected := 15 * time.Second; duration > expected {
 				// In the happy case, this query runs in around 250ms. Prior
 				// to the introduction of this test, a bug caused most

--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -18,9 +18,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"os"
-	"strconv"
 	"time"
 
 	_ "github.com/lib/pq"
@@ -49,12 +46,14 @@ func registerHotSpotSplits(r *registry) {
 		m, ctx = errgroup.WithContext(ctx)
 
 		m.Go(func() error {
-			c.l.printf("starting load generator\n")
+			c.l.Printf("starting load generator\n")
 
-			quietL, err := newLogger("run kv", strconv.Itoa(0), "workload"+strconv.Itoa(0), ioutil.Discard, os.Stderr)
+			quietL, err := c.l.ChildLogger("kv-0", quietStdout)
 			if err != nil {
 				return err
 			}
+			defer quietL.close()
+
 			const blockSize = 1 << 19 // 512 KB
 			return c.RunL(ctx, quietL, appNode, fmt.Sprintf(
 				"./workload run kv --read-percent=0 --splits=0 --tolerate-errors --concurrency=%d "+

--- a/pkg/cmd/roachtest/interleavedpartitioned.go
+++ b/pkg/cmd/roachtest/interleavedpartitioned.go
@@ -114,7 +114,7 @@ func registerInterleaved(r *registry) {
 
 		runLocality := func(name string, node nodeListOption, cmd string) {
 			m.Go(func(ctx context.Context) error {
-				l, err := c.l.childLogger(name)
+				l, err := c.l.ChildLogger(name)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -65,10 +65,10 @@ func initJepsen(ctx context.Context, t *test, c *cluster) {
 
 	// Check to see if the cluster has already been initialized.
 	if err := c.RunE(ctx, c.Node(1), "test -e jepsen_initialized"); err == nil {
-		c.l.printf("cluster already initialized\n")
+		c.l.Printf("cluster already initialized\n")
 		return
 	}
-	c.l.printf("initializing cluster\n")
+	c.l.Printf("initializing cluster\n")
 	t.Status("initializing cluster")
 	defer func() {
 		c.Run(ctx, c.Node(1), "touch jepsen_initialized")
@@ -136,9 +136,9 @@ func runJepsen(ctx context.Context, t *test, c *cluster, testName, nemesis strin
 	// Wrap roachtest's primitive logging in something more like util/log
 	logf := func(f string, args ...interface{}) {
 		// This log prefix matches the one (sometimes) used in roachprod
-		c.l.printf(timeutil.Now().Format("2006/01/02 15:04:05 "))
-		c.l.printf(f, args...)
-		c.l.printf("\n")
+		c.l.Printf(timeutil.Now().Format("2006/01/02 15:04:05 "))
+		c.l.Printf(f, args...)
+		c.l.Printf("\n")
 	}
 	run := func(c *cluster, ctx context.Context, node nodeListOption, args ...string) {
 		if !c.isLocal() {
@@ -146,14 +146,14 @@ func runJepsen(ctx context.Context, t *test, c *cluster, testName, nemesis strin
 			return
 		}
 		args = append([]string{roachprod, "run", c.makeNodes(node), "--"}, args...)
-		c.l.printf("> %s\n", strings.Join(args, " "))
+		c.l.Printf("> %s\n", strings.Join(args, " "))
 	}
 	runE := func(c *cluster, ctx context.Context, node nodeListOption, args ...string) error {
 		if !c.isLocal() {
 			return c.RunE(ctx, node, args...)
 		}
 		args = append([]string{roachprod, "run", c.makeNodes(node), "--"}, args...)
-		c.l.printf("> %s\n", strings.Join(args, " "))
+		c.l.Printf("> %s\n", strings.Join(args, " "))
 		return nil
 	}
 

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -155,7 +155,7 @@ func registerKVQuiescenceDead(r *registry) {
 					qpsAllUp, qpsOneDown, actFrac, minFrac,
 				)
 			}
-			c.l.printf("QPS went from %.2f to %2.f with one node down\n", qpsAllUp, qpsOneDown)
+			c.l.Printf("QPS went from %.2f to %2.f with one node down\n", qpsAllUp, qpsOneDown)
 		},
 	})
 }
@@ -214,7 +214,7 @@ func registerKVScalability(r *registry) {
 					" {pgurl:1-%d}",
 					percent, nodes)
 
-				l, err := c.l.childLogger(fmt.Sprint(i))
+				l, err := c.l.ChildLogger(fmt.Sprint(i))
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -44,7 +44,7 @@ func registerRoachmart(r *registry) {
 				"--orders=100",
 				fmt.Sprintf("--partition=%v", partition))
 
-			l, err := c.l.childLogger(fmt.Sprint(nodes[i].i))
+			l, err := c.l.ChildLogger(fmt.Sprint(nodes[i].i))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cmd/roachtest/scaledata.go
+++ b/pkg/cmd/roachtest/scaledata.go
@@ -18,7 +18,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"runtime"
 	"strings"
 	"time"
@@ -101,10 +100,11 @@ func runSqlapp(ctx context.Context, t *test, c *cluster, app, flags string, dur 
 		// they often have the effect of slowing down the test so much that it
 		// fails. To get around this we create a new logger that writes to an
 		// artifacts file but does not output to stdout or stderr.
-		sqlappL, err := newLogger(c.l.name, "sqlapp", "", ioutil.Discard, ioutil.Discard)
+		sqlappL, err := c.l.ChildLogger("sqlapp", logPrefix(""), quietStdout, quietStderr)
 		if err != nil {
 			return err
 		}
+		defer sqlappL.close()
 
 		t.Status("installing schema")
 		err = c.RunL(ctx, sqlappL, appNode, fmt.Sprintf("./%s --install_schema "+

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -57,7 +57,7 @@ func registerSchemaChange(r *registry) {
 				// but we can't put it in monitor as-is because the test deadlocks.
 				go func() {
 					const cmd = `./workload run kv --tolerate-errors --min-block-bytes=8 --max-block-bytes=128 --db=test`
-					l, err := c.l.childLogger(fmt.Sprintf(`kv-%d`, node))
+					l, err := c.l.ChildLogger(fmt.Sprintf(`kv-%d`, node))
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -81,7 +81,7 @@ func waitForSchemaChanges(ctx context.Context, l *logger, db *gosql.DB) error {
 
 	// These schema changes are over a table that is not actively
 	// being updated.
-	l.printf("running schema changes over workload.customer\n")
+	l.Printf("running schema changes over workload.customer\n")
 	schemaChanges := []string{
 		"ALTER TABLE workload.customer ADD COLUMN newcol INT DEFAULT 23456",
 		"CREATE INDEX foo ON workload.customer (c_name)",
@@ -110,7 +110,7 @@ func waitForSchemaChanges(ctx context.Context, l *logger, db *gosql.DB) error {
 	// an opportunity to get populate through the load generator. These
 	// schema changes are acting upon a decent sized table that is also
 	// being updated.
-	l.printf("running schema changes over test.kv\n")
+	l.Printf("running schema changes over test.kv\n")
 	schemaChanges = []string{
 		"ALTER TABLE test.kv ADD COLUMN created_at TIMESTAMP DEFAULT now()",
 		"CREATE INDEX foo ON test.kv (v)",
@@ -141,12 +141,12 @@ func waitForSchemaChanges(ctx context.Context, l *logger, db *gosql.DB) error {
 func runSchemaChanges(ctx context.Context, l *logger, db *gosql.DB, schemaChanges []string) error {
 	for _, cmd := range schemaChanges {
 		start := timeutil.Now()
-		l.printf("starting schema change: %s\n", cmd)
+		l.Printf("starting schema change: %s\n", cmd)
 		if _, err := db.Exec(cmd); err != nil {
-			l.errorf("hit schema change error: %s, for %s, in %s\n", err, cmd, timeutil.Since(start))
+			l.Errorf("hit schema change error: %s, for %s, in %s\n", err, cmd, timeutil.Since(start))
 			return err
 		}
-		l.printf("completed schema change: %s, in %s\n", cmd, timeutil.Since(start))
+		l.Printf("completed schema change: %s, in %s\n", cmd, timeutil.Since(start))
 		// TODO(vivek): Monitor progress of schema changes and log progress.
 	}
 
@@ -189,7 +189,7 @@ func runValidationQueries(
 		if err := db.QueryRow(q).Scan(&count); err != nil {
 			return err
 		}
-		l.printf("query: %s, found %d rows\n", q, count)
+		l.Printf("query: %s, found %d rows\n", q, count)
 		if count == 0 {
 			return errors.Errorf("%s: %d rows found", q, count)
 		}
@@ -236,7 +236,7 @@ func checkIndexOverTimeSpan(
 	if err := db.QueryRow(q, s.start, s.end).Scan(&count); err != nil {
 		return false, err
 	}
-	l.printf("counts seen %d, %d, over [%s, %s]\n", count, eCount, s.start, s.end)
+	l.Printf("counts seen %d, %d, over [%s, %s]\n", count, eCount, s.start, s.end)
 	return count != eCount, nil
 }
 
@@ -259,7 +259,7 @@ func findIndexProblem(
 		leftSpan, rightSpan := s, s
 		d := s.end.Sub(s.start) / 2
 		if d < 50*time.Millisecond {
-			l.printf("problem seen over [%s, %s]\n", s.start, s.end)
+			l.Printf("problem seen over [%s, %s]\n", s.start, s.end)
 			continue
 		}
 		m := s.start.Add(d)
@@ -283,7 +283,7 @@ func findIndexProblem(
 			spans = append(spans, rightSpan)
 		}
 		if !(leftState || rightState) {
-			l.printf("no problem seen over [%s, %s]\n", s.start, s.end)
+			l.Printf("no problem seen over [%s, %s]\n", s.start, s.end)
 		}
 	}
 	return nil

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -728,7 +728,7 @@ func (r *registry) run(spec *testSpec, filter *regexp.Regexp, c *cluster, done f
 						if !debugEnabled || !t.Failed() {
 							c.Destroy(ctx)
 						} else {
-							c.l.printf("not destroying cluster to allow debugging\n")
+							c.l.Printf("not destroying cluster to allow debugging\n")
 						}
 					}()
 				}

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -248,7 +248,7 @@ func loadTPCCBench(
 	// Check if the dataset already exists and is already large enough to
 	// accommodate this benchmarking. If so, we can skip the fixture RESTORE.
 	if _, err := db.ExecContext(ctx, `USE tpcc`); err == nil {
-		c.l.printf("found existing tpcc database\n")
+		c.l.Printf("found existing tpcc database\n")
 
 		var curWarehouses int
 		if err := db.QueryRowContext(ctx,
@@ -272,7 +272,7 @@ func loadTPCCBench(
 
 	// If the fixture has a corresponding store dump, use it.
 	if b.StoreDirVersion != "" {
-		c.l.printf("ingesting existing tpcc store dump\n")
+		c.l.Printf("ingesting existing tpcc store dump\n")
 
 		urlBase, err := c.RunWithBuffer(ctx, c.l, c.Node(loadNode[0]),
 			fmt.Sprintf(`./workload fixtures url tpcc --warehouses=%d`, b.LoadWarehouses))
@@ -286,7 +286,7 @@ func loadTPCCBench(
 	}
 
 	// Load the corresponding fixture.
-	c.l.printf("restoring tpcc fixture\n")
+	c.l.Printf("restoring tpcc fixture\n")
 	cmd := fmt.Sprintf(
 		"./workload fixtures load tpcc --checks=false --warehouses=%d {pgurl:1}", b.LoadWarehouses)
 	if err := c.RunE(ctx, loadNode, cmd); err != nil {
@@ -297,13 +297,13 @@ func loadTPCCBench(
 	rebalanceWait := time.Duration(b.LoadWarehouses/150) * time.Minute
 	switch b.LoadConfig {
 	case singleLoadgen:
-		c.l.printf("splitting and scattering\n")
+		c.l.Printf("splitting and scattering\n")
 	case singlePartitionedLoadgen:
-		c.l.printf("splitting, scattering, and partitioning\n")
+		c.l.Printf("splitting, scattering, and partitioning\n")
 		partArgs = fmt.Sprintf(`--partitions=%d`, b.partitions())
 		rebalanceWait = time.Duration(b.LoadWarehouses/50) * time.Minute
 	case multiLoadgen:
-		c.l.printf("splitting, scattering, and partitioning\n")
+		c.l.Printf("splitting, scattering, and partitioning\n")
 		partArgs = fmt.Sprintf(`--partitions=%d --zones="%s" --partition-affinity=0`,
 			b.partitions(), strings.Join(b.Distribution.zones(), ","))
 		rebalanceWait = time.Duration(b.LoadWarehouses/20) * time.Minute
@@ -320,7 +320,7 @@ func loadTPCCBench(
 		return errors.Wrapf(err, "failed with output %q", string(out))
 	}
 
-	c.l.printf("waiting %v for rebalancing\n", rebalanceWait)
+	c.l.Printf("waiting %v for rebalancing\n", rebalanceWait)
 	_, err := db.ExecContext(ctx, `SET CLUSTER SETTING kv.snapshot_rebalance.max_rate='64MiB'`)
 	if err != nil {
 		return err
@@ -497,7 +497,7 @@ func runTPCCBench(ctx context.Context, t *test, c *cluster, b tpccBenchSpec) {
 						}
 					}
 					headerLine, statsLine := lines[0], lines[1]
-					c.l.printf("%s\n%s\n", headerLine, statsLine)
+					c.l.Printf("%s\n%s\n", headerLine, statsLine)
 
 					// Parse tpmC value from stats line.
 					fields := strings.Fields(statsLine)
@@ -545,7 +545,7 @@ func runTPCCBench(ctx context.Context, t *test, c *cluster, b tpccBenchSpec) {
 				ttycolor.Stdout(ttycolor.Red)
 				passStr = "FAIL"
 			}
-			c.l.printf("--- %s: tpcc %d resulted in %.1f tpmC (%.1f%% of max tpmC)\n\n",
+			c.l.Printf("--- %s: tpcc %d resulted in %.1f tpmC (%.1f%% of max tpmC)\n\n",
 				passStr, warehouses, tpmC, tpmCRatio*100)
 			ttycolor.Stdout(ttycolor.Reset)
 
@@ -556,7 +556,7 @@ func runTPCCBench(ctx context.Context, t *test, c *cluster, b tpccBenchSpec) {
 		}
 
 		ttycolor.Stdout(ttycolor.Green)
-		c.l.printf("------\nMAX WAREHOUSES = %d\n------\n\n", res)
+		c.l.Printf("------\nMAX WAREHOUSES = %d\n------\n\n", res)
 		ttycolor.Stdout(ttycolor.Reset)
 		return nil
 	})


### PR DESCRIPTION
Backport 1/1 commits from #29311.

/cc @cockroachdb/release

Not really necessary, but I'm going to be backporting more PRs involving roachtests (i.e. all of the acceptance -> roachtest migration) and don't want any conflicts.

---

Many tests were creating loggers via newLogger and doing so
incorrectly (i.e. specifying a command string for the parameter which
control the directory to log in). Revamped the creation of loggers to
make it harder to accidentally call newLogger. Added a loggerConfig
struct which holds the configuration for a logger and loggerOption
interface for easily applying changes to a log config. These combine and
are mostly invisible behind varargs that are passed to
logger.ChildLogger. Changed all of the existing uses of newLogger to use
ChildLogger.

Also took the opportunity to export logger.Printf and logger.Errorf to
make it clearer that these are part of the public interface to a
logger.

Fixes #29139

Release note: None
