### PR TITLE
release-2.1: assorted deflakes

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -2079,10 +2079,10 @@ func checkNodeStatus(t *testing.T, c cliTest, output string, start time.Time) {
 	if nodeCtx.statusShowStats || nodeCtx.statusShowAll {
 		testcases = append(testcases,
 			testCase{"live_bytes", baseIdx, 100000},
-			testCase{"key_bytes", baseIdx + 1, 30000},
+			testCase{"key_bytes", baseIdx + 1, 50000},
 			testCase{"value_bytes", baseIdx + 2, 100000},
-			testCase{"intent_bytes", baseIdx + 3, 30000},
-			testCase{"system_bytes", baseIdx + 4, 30000},
+			testCase{"intent_bytes", baseIdx + 3, 50000},
+			testCase{"system_bytes", baseIdx + 4, 50000},
 		)
 		baseIdx += len(statusNodesColumnHeadersForStats)
 	}

--- a/pkg/cli/interactive_tests/test_exec_log.tcl
+++ b/pkg/cli/interactive_tests/test_exec_log.tcl
@@ -14,13 +14,15 @@ system "if test -e $logfile; then false; fi"
 end_test
 
 start_test "Check that the exec log is created after enabled"
-send "SET CLUSTER SETTING sql.trace.log_statement_execute = TRUE;\r"
+send "SET CLUSTER   SETTING sql.trace.log_statement_execute = TRUE;\r"
+eexpect "SET CLUSTER SETTING"
 eexpect root@
 system "test -e $logfile"
 end_test
 
 start_test "Check that statements get logged to the exec log but stop logging when disabled"
-send "SELECT 'helloworld';\r"
+send "SELECT 'hello' || 'world';\r"
+eexpect "helloworld"
 eexpect root@
 
 # Errors must be logged too
@@ -33,13 +35,14 @@ eexpect root@
 # Check logging after disable
 send "SET CLUSTER SETTING sql.trace.log_statement_execute = FALSE;\r"
 eexpect root@
-send "SELECT 'lovely';\r"
+send "SELECT 'lov' || 'ely';\r"
+eexpect "lovely"
 eexpect root@
 
 flush_server_logs
 
 # Now check the items are there in the log file.
-system "grep -q helloworld $logfile"
+system "grep -q 'hello.*world' $logfile"
 system "grep -q nonexistent $logfile"
 system "if grep -q lovely $logfile; then false; fi"
 

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -94,23 +94,13 @@ end_test
 
 start_server $argv
 
-start_test "Test that quit does not emit unwanted logging output"
-# Unwanted: between the point the command starts until it
-# either prints the final ok message or fails with some error
-# (e.g. due to no definite answer from the server).
-send "echo marker; $argv quit 2>&1 | grep -vE '^\[IWEF\]\[0-9\]+ .+ vendor/google.golang.org/grpc/' | grep -vE '^\(ok|Error\)'\r"
-set timeout 20
-eexpect "marker\r\n:/# "
-set timeout 5
-end_test
-
-start_test "Test that quit does not show INFO by defaults with --logtostderr"
+start_test "Test that quit does not show INFO by default with --logtostderr"
 # Test quit as non-start command, this time with --logtostderr. Test
 # that the default logging level is WARNING, so that no INFO messages
 # are printed between the marker and the (first line) error message
 # from quit. Quit will error out because the server is already stopped.
-send "echo marker; $argv quit --logtostderr 2>&1 | grep -vE '^\[WEF\]\[0-9\]+ .+ vendor/google.golang.org/grpc/'\r"
-eexpect "marker\r\nError"
+send "echo marker; $argv quit --logtostderr 2>&1 | grep -vE '^\[WEF\]\[0-9\]+'\r"
+eexpect "marker\r\nok"
 eexpect ":/# "
 end_test
 


### PR DESCRIPTION
Backport:
  * 1/1 commits from "cli/interactive_tests: deflake test_exec_log.tcl" (#29452)
  * 1/1 commits from "cli/interactive_tests: deflake test_missing_log_output.tcl" (#29453)
  * 1/1 commits from "cli: deflake TestNodeStatus" (#29454)

Please see individual PRs for details.

/cc @cockroachdb/release
