### PR TITLE
sql: do not add mutations to underlying column/index array

### DIFF
--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -166,13 +166,17 @@ func initRowFetcher(
 
 	cols := desc.Columns
 	if scanVisibility == ScanVisibility_PUBLIC_AND_NOT_PUBLIC {
-		for _, mutation := range desc.Mutations {
-			if c := mutation.GetColumn(); c != nil {
-				col := *c
-				// Even if the column is non-nullable it can be null in the
-				// middle of a schema change.
-				col.Nullable = true
-				cols = append(cols, col)
+		if len(desc.Mutations) > 0 {
+			cols = make([]sqlbase.ColumnDescriptor, 0, len(desc.Columns)+len(desc.Mutations))
+			cols = append(cols, desc.Columns...)
+			for _, mutation := range desc.Mutations {
+				if c := mutation.GetColumn(); c != nil {
+					col := *c
+					// Even if the column is non-nullable it can be null in the
+					// middle of a schema change.
+					col.Nullable = true
+					cols = append(cols, col)
+				}
 			}
 		}
 	}

--- a/pkg/sql/sqlbase/rowwriter.go
+++ b/pkg/sql/sqlbase/rowwriter.go
@@ -182,10 +182,14 @@ func MakeRowInserter(
 	indexes := tableDesc.Indexes
 	// Also include the secondary indexes in mutation state
 	// DELETE_AND_WRITE_ONLY.
-	for _, m := range tableDesc.Mutations {
-		if m.State == DescriptorMutation_DELETE_AND_WRITE_ONLY {
-			if index := m.GetIndex(); index != nil {
-				indexes = append(indexes, *index)
+	if len(tableDesc.Mutations) > 0 {
+		indexes = make([]IndexDescriptor, 0, len(tableDesc.Indexes)+len(tableDesc.Mutations))
+		indexes = append(indexes, tableDesc.Indexes...)
+		for _, m := range tableDesc.Mutations {
+			if m.State == DescriptorMutation_DELETE_AND_WRITE_ONLY {
+				if index := m.GetIndex(); index != nil {
+					indexes = append(indexes, *index)
+				}
 			}
 		}
 	}
@@ -999,9 +1003,13 @@ func makeRowDeleterWithoutCascader(
 	alloc *DatumAlloc,
 ) (RowDeleter, error) {
 	indexes := tableDesc.Indexes
-	for _, m := range tableDesc.Mutations {
-		if index := m.GetIndex(); index != nil {
-			indexes = append(indexes, *index)
+	if len(tableDesc.Mutations) > 0 {
+		indexes = make([]IndexDescriptor, 0, len(tableDesc.Indexes)+len(tableDesc.Mutations))
+		indexes = append(indexes, tableDesc.Indexes...)
+		for _, m := range tableDesc.Mutations {
+			if index := m.GetIndex(); index != nil {
+				indexes = append(indexes, *index)
+			}
 		}
 	}
 


### PR DESCRIPTION
This stops modifying the underlying immutable data structures
stored as part of the table descriptor by sql statements.
The sql can be executed by many threads on the same node
and it is illegal for them to be modifying the underlying
descriptor.

Release note: None