### PR TITLE
release-2.1: sql: fix a panic in txn_state.go when verbose logging

### DIFF
--- a/pkg/sql/conn_fsm.go
+++ b/pkg/sql/conn_fsm.go
@@ -50,6 +50,8 @@ const (
 
 type stateNoTxn struct{}
 
+var _ State = &stateNoTxn{}
+
 func (stateNoTxn) String() string {
 	return NoTxnStr
 }
@@ -62,6 +64,8 @@ type stateOpen struct {
 	RetryIntent Bool
 }
 
+var _ State = &stateOpen{}
+
 func (stateOpen) String() string {
 	return OpenStateStr
 }
@@ -72,17 +76,23 @@ type stateAborted struct {
 	RetryIntent Bool
 }
 
+var _ State = &stateAborted{}
+
 func (stateAborted) String() string {
 	return AbortedStateStr
 }
 
 type stateRestartWait struct{}
 
+var _ State = &stateRestartWait{}
+
 func (stateRestartWait) String() string {
 	return RestartWaitStateStr
 }
 
 type stateCommitWait struct{}
+
+var _ State = &stateCommitWait{}
 
 func (stateCommitWait) String() string {
 	return CommitWaitStateStr
@@ -94,6 +104,8 @@ func (stateCommitWait) String() string {
 // transaction" is finished, however the higher-level transaction is not rolled
 // back.
 type stateInternalError struct{}
+
+var _ State = &stateInternalError{}
 
 func (stateInternalError) String() string {
 	return InternalErrorStateStr

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -256,7 +256,11 @@ func (ts *txnState) finishSQLTxn() {
 // InternalExecutor). These guys don't want to mess with the transaction per-se,
 // but still want to clean up other stuff.
 func (ts *txnState) finishExternalTxn() {
-	ts.mon.Stop(ts.Ctx)
+	if ts.Ctx == nil {
+		ts.mon.Stop(ts.connCtx)
+	} else {
+		ts.mon.Stop(ts.Ctx)
+	}
 	if ts.cancel != nil {
 		ts.cancel()
 		ts.cancel = nil


### PR DESCRIPTION
Backport 2/2 commits from #29520.

/cc @cockroachdb/release

Fix a panic (reproducible with  `make testlogic TESTFLAGS='-verbosity=2' FILES=pg_catalog` )  due to an uninitialized context. The comment on Ctx says that Ctx is uninitialized if we are in `fsm.stateNoTxn`. In that case, use the parent (session) context which is always initialized.

