### PR TITLE
syncutil: embed Mutex in syncutil.Mutex in non-race builds

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -297,6 +297,7 @@ func TestLint(t *testing.T) {
 			"--",
 			"*.go",
 			":!util/syncutil/mutex_sync.go",
+			":!util/syncutil/mutex_sync_race.go",
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/util/syncutil/mutex_sync_race_test.go
+++ b/pkg/util/syncutil/mutex_sync_race_test.go
@@ -13,6 +13,7 @@
 // permissions and limitations under the License.
 
 // +build !deadlock
+// +build race
 
 package syncutil
 


### PR DESCRIPTION
This change embeds the `sync.Mutex`/`sync.RWMutex` field of
`syncutil.Mutex`/`syncutil.RWMutex` and make their AssertHeld
methods no-ops. This has two major benefits:
- It saves ~15ns per lock-unlock pair. Dropping the latency from
  ~30ns to ~15ns. This is because we can avoid a function call
  and an extra atomic for each lock and unlock.
- It improves blocking profiles significantly because
  `syncutil.(*Mutex).Lock` is no longer the primary caller of
  `sync.(*Mutex).Lock`. In pprof modes like `peek`, this is
  important.

Release note: None