### PR TITLE
roachtest: fix acceptance/version-upgrade on remote clusters

### DIFF
--- a/pkg/cmd/roachtest/upgrade.go
+++ b/pkg/cmd/roachtest/upgrade.go
@@ -443,7 +443,6 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
 
 	const baseVersion = "v1.0.6"
 	steps := []versionStep{
-		binaryVersionUpgrade(baseVersion, nodes),
 		// v1.1.0 is the first binary version that knows about cluster versions,
 		// but thinks it can only support up to 1.0-3.
 		binaryVersionUpgrade("v1.1.0", nodes),


### PR DESCRIPTION
No need to run a versionStep for the base version as we manually do that
before executing the version steps. Duplicating this work was failing on
the second upload because we can't overwrite the executable for a
running binary.

Fixes #29542

Release note: None