### PR TITLE
sql: fix a panic in TestSQLEncode

### DIFF
--- a/pkg/sql/lex/encode.go
+++ b/pkg/sql/lex/encode.go
@@ -94,6 +94,9 @@ func EncodeSQLStringWithFlags(buf *bytes.Buffer, in string, flags EncodeFlags) {
 	bareStrings := flags.HasFlags(EncBareStrings)
 	// Loop through each unicode code point.
 	for i, r := range in {
+		if i < start {
+			continue
+		}
 		ch := byte(r)
 		if r >= 0x20 && r < 0x7F {
 			if mustQuoteMap[ch] {
@@ -123,7 +126,9 @@ func EncodeSQLStringWithFlags(buf *bytes.Buffer, in string, flags EncodeFlags) {
 	if quote {
 		buf.WriteByte('\'') // begin 'xxx' string if nothing was escaped
 	}
-	buf.WriteString(in[start:])
+	if start < len(in) {
+		buf.WriteString(in[start:])
+	}
 	if escapedString || quote {
 		buf.WriteByte('\'')
 	}

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -2171,6 +2171,13 @@ CREATE TABLE foo(a CHAR(0))
                          ^
 `,
 		},
+		{
+			`e'\xad'::string`,
+			`invalid UTF-8 byte sequence
+e'\xad'::string
+^
+`,
+		},
 	}
 	for _, d := range testData {
 		_, err := parser.Parse(d.sql)

--- a/pkg/util/stringencoding/string_encoding.go
+++ b/pkg/util/stringencoding/string_encoding.go
@@ -119,7 +119,9 @@ func EncodeEscapedChar(
 		// Make sure this is run at least once in case ln == -1.
 		buf.Write(HexMap[entireString[currentIdx]])
 		for ri := 1; ri < ln; ri++ {
-			buf.Write(HexMap[entireString[currentIdx+ri]])
+			if currentIdx+ri < len(entireString) {
+				buf.Write(HexMap[entireString[currentIdx+ri]])
+			}
 		}
 	} else if ln == 1 {
 		// For single-byte runes, do the same as encodeSQLBytes.


### PR DESCRIPTION
Fixes #29545. Fixes #29636.

This change involves additional test cases that are CC-by-4.0 licensed.