### PR TITLE
testcluster: make manual replication mode disable the merge queue

### DIFF
--- a/pkg/sql/distsqlplan/span_resolver_test.go
+++ b/pkg/sql/distsqlplan/span_resolver_test.go
@@ -331,11 +331,6 @@ func setupRanges(
 		}
 	}
 
-	// Prevent the merge queue from immediately discarding our splits.
-	if _, err := db.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false"); err != nil {
-		t.Fatal(err)
-	}
-
 	tableDesc := sqlbase.GetTableDescriptor(cdb, "t", "test")
 	// Split every SQL row to its own range.
 	rowRanges := make([]roachpb.RangeDescriptor, len(values))

--- a/pkg/sql/distsqlrun/cluster_test.go
+++ b/pkg/sql/distsqlrun/cluster_test.go
@@ -563,8 +563,6 @@ func TestDistSQLReadsFillGatewayID(t *testing.T) {
 		sqlutils.ToRowFn(sqlutils.RowIdxFn))
 
 	if _, err := db.Exec(`
--- Prevent the merge queue from immediately discarding our splits.
-SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
 ALTER TABLE t SPLIT AT VALUES (1), (2), (3);
 ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[3], 3);
 `); err != nil {

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -197,8 +197,6 @@ func TestMisplannedRangesMetadata(t *testing.T) {
 		sqlutils.ToRowFn(sqlutils.RowIdxFn))
 
 	_, err := db.Exec(`
--- Prevent the merge queue from immediately discarding our splits.
-SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
 ALTER TABLE t SPLIT AT VALUES (1), (2), (3);
 ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[3], 3);
 `)

--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -233,11 +233,6 @@ func TestCancelDistSQLQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Prevent the merge queue from immediately discarding our splits.
-	if _, err := conn1.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false"); err != nil {
-		t.Fatal(err)
-	}
-
 	if _, err := conn1.Exec("ALTER TABLE nums SPLIT AT VALUES (50)"); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -523,8 +523,6 @@ func TestKVTraceDistSQL(t *testing.T) {
 	r.Exec(t, "CREATE DATABASE test")
 	r.Exec(t, "CREATE TABLE test.a (a INT PRIMARY KEY, b INT)")
 	r.Exec(t, "INSERT INTO test.a VALUES (1,1), (2,2)")
-	// Prevent the merge queue from immediately discarding our splits.
-	r.Exec(t, "SET CLUSTER SETTING kv.range_merge.queue_enabled = false")
 	r.Exec(t, "ALTER TABLE a SPLIT AT VALUES(1)")
 	r.Exec(t, "SET tracing = on,kv; SELECT count(*) FROM test.a; SET tracing = off")
 

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -1535,8 +1535,6 @@ func TestDistSQLRetryableError(t *testing.T) {
 
 	// We're going to split one of the tables, but node 4 is unaware of this.
 	_, err := db.Exec(fmt.Sprintf(`
-	-- Prevent the merge queue from immediately discarding our splits.
-	SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
 	ALTER TABLE "t" SPLIT AT VALUES (1), (2), (3);
 	ALTER TABLE "t" EXPERIMENTAL_RELOCATE VALUES (ARRAY[%d], 1), (ARRAY[%d], 2), (ARRAY[%d], 3);
 	`,

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1578,7 +1578,6 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 		EvalKnobs: batcheval.TestingKnobs{
 			TestingEvalFilter: filter,
 		},
-		DisableMergeQueue: true,
 	}
 
 	tc := testcluster.StartTestCluster(t, 2, args)
@@ -1760,7 +1759,6 @@ func TestStoreSplitOnRemovedReplica(t *testing.T) {
 	args.ReplicationMode = base.ReplicationManual
 	args.ServerArgs.Knobs.Store = &storage.StoreTestingKnobs{
 		TestingRequestFilter: filter,
-		DisableMergeQueue:    true,
 	}
 
 	tc := testcluster.StartTestCluster(t, 3, args)
@@ -1850,7 +1848,6 @@ func TestStoreSplitFailsAfterMaxRetries(t *testing.T) {
 	args.ReplicationMode = base.ReplicationManual
 	args.ServerArgs.Knobs.Store = &storage.StoreTestingKnobs{
 		TestingRequestFilter: filter,
-		DisableMergeQueue:    true,
 	}
 
 	tc := testcluster.StartTestCluster(t, 1, args)

--- a/pkg/storage/consistency_queue_test.go
+++ b/pkg/storage/consistency_queue_test.go
@@ -300,11 +300,6 @@ func TestConsistencyQueueRecomputeStats(t *testing.T) {
 		ScanInterval:    time.Second,
 		ScanMinIdleTime: 0,
 		ScanMaxIdleTime: 100 * time.Millisecond,
-		Knobs: base.TestingKnobs{
-			Store: &storage.StoreTestingKnobs{
-				DisableMergeQueue: true,
-			},
-		},
 	}
 	nodeZeroArgs := tsArgs
 	nodeZeroArgs.StoreSpecs = []base.StoreSpec{{

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -92,6 +92,10 @@ type TestClusterInterface interface {
 
 	// Target returns a roachpb.ReplicationTarget for the specified server.
 	Target(serverIdx int) roachpb.ReplicationTarget
+
+	// ReplicationMode returns the ReplicationMode that the test cluster was
+	// configured with.
+	ReplicationMode() base.TestClusterReplicationMode
 }
 
 // TestClusterFactory encompasses the actual implementation of the shim

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -244,6 +244,7 @@ func (tc *TestCluster) doAddServer(t testing.TB, serverArgs base.TestServerArgs)
 			stkCopy = *stk.(*storage.StoreTestingKnobs)
 		}
 		stkCopy.DisableSplitQueue = true
+		stkCopy.DisableMergeQueue = true
 		stkCopy.DisableReplicateQueue = true
 		serverArgs.Knobs.Store = &stkCopy
 	}
@@ -574,6 +575,11 @@ func (tc *TestCluster) WaitForNodeStatuses(t testing.TB) {
 		}
 		return nil
 	})
+}
+
+// ReplicationMode implements TestClusterInterface.
+func (tc *TestCluster) ReplicationMode() base.TestClusterReplicationMode {
+	return tc.replicationMode
 }
 
 type testClusterFactoryImpl struct{}


### PR DESCRIPTION
TestClusters have a manual replication mode for use in tests that need
to precisely control replication on a cluster. Teach that mode to
disable the merge queue in addition to the split and replicate queues.
This decreases the number of tests that need to directly disable the
merge queue.

Release note: None