### PR TITLE
ui: add attributes to login form so LastPass will autofill it

### DIFF
--- a/pkg/ui/src/views/login/loginPage.tsx
+++ b/pkg/ui/src/views/login/loginPage.tsx
@@ -129,9 +129,10 @@ class LoginPage extends React.Component<LoginPageProps & WithRouterProps, LoginP
             <div className="form-container">
               <h1 className="heading">Log in to the Web UI</h1>
               {this.renderError()}
-              <form onSubmit={this.handleSubmit} className="form-internal">
+              <form onSubmit={this.handleSubmit} className="form-internal" method="post">
                 <input
                   type="text"
+                  name="username"
                   className={inputClasses}
                   onChange={this.handleUpdateUsername}
                   value={this.state.username}
@@ -139,6 +140,7 @@ class LoginPage extends React.Component<LoginPageProps & WithRouterProps, LoginP
                 />
                 <input
                   type="password"
+                  name="password"
                   className={inputClasses}
                   onChange={this.handleUpdatePassword}
                   value={this.state.password}


### PR DESCRIPTION
LastPass wasn't confident enough to autofill and autologin without these
attributes.

Fixes #29529 (fixes for LastPass, but maybe not other PW managers)

Release note (admin ui change): Add attributes to the login form to allow LastPass to properly recognize it.