### PR TITLE
release-2.1: more merge work

### DIFF
--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -216,6 +216,8 @@ func runTestImport(t *testing.T, init func(*cluster.Settings)) {
 				return roachpb.NewError(roachpb.NewAmbiguousResultError(strconv.Itoa(int(r))))
 			},
 		},
+		// Prevent the merge queue from immediately discarding our splits.
+		DisableMergeQueue: true,
 	}}
 
 	ctx := context.Background()

--- a/pkg/kv/split_test.go
+++ b/pkg/kv/split_test.go
@@ -238,7 +238,11 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 // on the same splitKey succeeds.
 func TestRangeSplitsWithSameKeyTwice(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s := createTestDBWithContextAndKnobs(t, client.DefaultDBContext(), &storage.StoreTestingKnobs{
+		DisableScanner:    true,
+		DisableSplitQueue: true,
+		DisableMergeQueue: true,
+	})
 	defer s.Stop()
 
 	ctx := context.TODO()

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -289,7 +289,11 @@ func TestTxnCoordSenderCondenseIntentSpans(t *testing.T) {
 // Test that the theartbeat loop detects aborted transactions and stops.
 func TestTxnCoordSenderHeartbeat(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s := createTestDBWithContextAndKnobs(t, client.DefaultDBContext(), &storage.StoreTestingKnobs{
+		DisableScanner:    true,
+		DisableSplitQueue: true,
+		DisableMergeQueue: true,
+	})
 	defer s.Stop()
 	ctx := context.Background()
 

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/tscache"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -473,7 +474,11 @@ func TestTxnLongDelayBetweenWritesWithConcurrentRead(t *testing.T) {
 // See issue #676 for full details about original bug.
 func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s := createTestDBWithContextAndKnobs(t, client.DefaultDBContext(), &storage.StoreTestingKnobs{
+		DisableScanner:    true,
+		DisableSplitQueue: true,
+		DisableMergeQueue: true,
+	})
 	defer s.Stop()
 
 	keyA := roachpb.Key("a")

--- a/pkg/server/intent_test.go
+++ b/pkg/server/intent_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
+// TODO(benesch): move this test to somewhere more specific than package server.
 func TestIntentResolution(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -111,7 +112,11 @@ func TestIntentResolution(t *testing.T) {
 					}
 					return nil
 				}
+			// Prevent the merge queue from immediately discarding our splits.
+			storeKnobs.DisableMergeQueue = true
 
+			// TODO(benesch): starting a test server for every test case is needlessly
+			// inefficient.
 			s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{
 				Knobs: base.TestingKnobs{Store: &storeKnobs}})
 			defer s.Stopper().Stop(context.TODO())

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -544,6 +544,12 @@ func TestNodeStatusWritten(t *testing.T) {
 	// ========================================
 	srv, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{
 		DisableEventLog: true,
+		Knobs: base.TestingKnobs{
+			Store: &storage.StoreTestingKnobs{
+				// Prevent the merge queue from immediately discarding our splits.
+				DisableMergeQueue: true,
+			},
+		},
 	})
 	defer srv.Stopper().Stop(context.TODO())
 	ts := srv.(*TestServer)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -302,7 +302,14 @@ func TestAcceptEncoding(t *testing.T) {
 // ranges are carried out properly.
 func TestMultiRangeScanDeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+	s, _, db := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Store: &storage.StoreTestingKnobs{
+				// Prevent the merge queue from immediately discarding our splits.
+				DisableMergeQueue: true,
+			},
+		},
+	})
 	defer s.Stopper().Stop(context.TODO())
 	ts := s.(*TestServer)
 	tds := db.NonTransactionalSender()
@@ -398,7 +405,14 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 	for i, tc := range testCases {
 		t.Run("", func(t *testing.T) {
 			ctx := context.Background()
-			s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+			s, _, db := serverutils.StartServer(t, base.TestServerArgs{
+				Knobs: base.TestingKnobs{
+					Store: &storage.StoreTestingKnobs{
+						// Prevent the merge queue from immediately discarding our splits.
+						DisableMergeQueue: true,
+					},
+				},
+			})
 			defer s.Stopper().Stop(ctx)
 			ts := s.(*TestServer)
 			tds := db.NonTransactionalSender()

--- a/pkg/sql/distsqlplan/span_resolver_test.go
+++ b/pkg/sql/distsqlplan/span_resolver_test.go
@@ -331,6 +331,11 @@ func setupRanges(
 		}
 	}
 
+	// Prevent the merge queue from immediately discarding our splits.
+	if _, err := db.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false"); err != nil {
+		t.Fatal(err)
+	}
+
 	tableDesc := sqlbase.GetTableDescriptor(cdb, "t", "test")
 	// Split every SQL row to its own range.
 	rowRanges := make([]roachpb.RangeDescriptor, len(values))

--- a/pkg/sql/distsqlplan/span_resolver_test.go
+++ b/pkg/sql/distsqlplan/span_resolver_test.go
@@ -331,11 +331,6 @@ func setupRanges(
 		}
 	}
 
-	// Prevent the merge queue from immediately discarding our splits.
-	if _, err := db.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false"); err != nil {
-		t.Fatal(err)
-	}
-
 	tableDesc := sqlbase.GetTableDescriptor(cdb, "t", "test")
 	// Split every SQL row to its own range.
 	rowRanges := make([]roachpb.RangeDescriptor, len(values))

--- a/pkg/sql/distsqlrun/cluster_test.go
+++ b/pkg/sql/distsqlrun/cluster_test.go
@@ -563,8 +563,6 @@ func TestDistSQLReadsFillGatewayID(t *testing.T) {
 		sqlutils.ToRowFn(sqlutils.RowIdxFn))
 
 	if _, err := db.Exec(`
--- Prevent the merge queue from immediately discarding our splits.
-SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
 ALTER TABLE t SPLIT AT VALUES (1), (2), (3);
 ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[3], 3);
 `); err != nil {

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -197,8 +197,6 @@ func TestMisplannedRangesMetadata(t *testing.T) {
 		sqlutils.ToRowFn(sqlutils.RowIdxFn))
 
 	_, err := db.Exec(`
--- Prevent the merge queue from immediately discarding our splits.
-SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
 ALTER TABLE t SPLIT AT VALUES (1), (2), (3);
 ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[3], 3);
 `)

--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -233,11 +233,6 @@ func TestCancelDistSQLQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Prevent the merge queue from immediately discarding our splits.
-	if _, err := conn1.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false"); err != nil {
-		t.Fatal(err)
-	}
-
 	if _, err := conn1.Exec("ALTER TABLE nums SPLIT AT VALUES (50)"); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -523,8 +523,6 @@ func TestKVTraceDistSQL(t *testing.T) {
 	r.Exec(t, "CREATE DATABASE test")
 	r.Exec(t, "CREATE TABLE test.a (a INT PRIMARY KEY, b INT)")
 	r.Exec(t, "INSERT INTO test.a VALUES (1,1), (2,2)")
-	// Prevent the merge queue from immediately discarding our splits.
-	r.Exec(t, "SET CLUSTER SETTING kv.range_merge.queue_enabled = false")
 	r.Exec(t, "ALTER TABLE a SPLIT AT VALUES(1)")
 	r.Exec(t, "SET tracing = on,kv; SELECT count(*) FROM test.a; SET tracing = off")
 

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -1535,8 +1535,6 @@ func TestDistSQLRetryableError(t *testing.T) {
 
 	// We're going to split one of the tables, but node 4 is unaware of this.
 	_, err := db.Exec(fmt.Sprintf(`
-	-- Prevent the merge queue from immediately discarding our splits.
-	SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
 	ALTER TABLE "t" SPLIT AT VALUES (1), (2), (3);
 	ALTER TABLE "t" EXPERIMENTAL_RELOCATE VALUES (ARRAY[%d], 1), (ARRAY[%d], 2), (ARRAY[%d], 3);
 	`,

--- a/pkg/storage/client_lease_test.go
+++ b/pkg/storage/client_lease_test.go
@@ -38,6 +38,7 @@ func TestStoreRangeLease(t *testing.T) {
 
 	testutils.RunTrueAndFalse(t, "enableEpoch", func(t *testing.T, enableEpoch bool) {
 		sc := storage.TestStoreConfig(nil)
+		sc.TestingKnobs.DisableMergeQueue = true
 		sc.EnableEpochRangeLeases = enableEpoch
 		mtc := &multiTestContext{storeConfig: &sc}
 		defer mtc.Stop()
@@ -104,6 +105,7 @@ func TestStoreRangeLease(t *testing.T) {
 func TestStoreRangeLeaseSwitcheroo(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	sc := storage.TestStoreConfig(nil)
+	sc.TestingKnobs.DisableMergeQueue = true
 	sc.EnableEpochRangeLeases = true
 	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
@@ -169,6 +171,7 @@ func TestStoreRangeLeaseSwitcheroo(t *testing.T) {
 func TestStoreGossipSystemData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	sc := storage.TestStoreConfig(nil)
+	sc.TestingKnobs.DisableMergeQueue = true
 	sc.EnableEpochRangeLeases = true
 	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()

--- a/pkg/storage/client_metrics_test.go
+++ b/pkg/storage/client_metrics_test.go
@@ -237,7 +237,11 @@ func TestStoreResolveMetrics(t *testing.T) {
 func TestStoreMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	mtc := &multiTestContext{}
+	storeCfg := storage.TestStoreConfig(nil /* clock */)
+	storeCfg.TestingKnobs.DisableMergeQueue = true
+	mtc := &multiTestContext{
+		storeConfig: &storeCfg,
+	}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -71,6 +71,7 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
+	storeCfg.TestingKnobs.DisableMergeQueue = true
 
 	const rangeID = roachpb.RangeID(1)
 	splitKey := roachpb.Key("m")
@@ -917,6 +918,7 @@ func TestReplicateAfterRemoveAndSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	sc := storage.TestStoreConfig(nil)
+	sc.TestingKnobs.DisableMergeQueue = true
 	// Disable the replica GC queue so that it doesn't accidentally pick up the
 	// removed replica and GC it. We'll explicitly enable it later in the test.
 	sc.TestingKnobs.DisableReplicaGCQueue = true
@@ -2278,7 +2280,11 @@ outer:
 // is not KeyMin replicating to a fresh store can apply snapshots correctly.
 func TestReplicateAfterSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	mtc := &multiTestContext{}
+	storeCfg := storage.TestStoreConfig(nil /* clock */)
+	storeCfg.TestingKnobs.DisableMergeQueue = true
+	mtc := &multiTestContext{
+		storeConfig: &storeCfg,
+	}
 	defer mtc.Stop()
 	mtc.Start(t, 2)
 
@@ -2351,7 +2357,11 @@ func TestReplicaRemovalCampaign(t *testing.T) {
 
 	for i, td := range testData {
 		func() {
-			mtc := &multiTestContext{}
+			storeCfg := storage.TestStoreConfig(nil /* clock */)
+			storeCfg.TestingKnobs.DisableMergeQueue = true
+			mtc := &multiTestContext{
+				storeConfig: &storeCfg,
+			}
 			defer mtc.Stop()
 			mtc.Start(t, 2)
 
@@ -2428,7 +2438,11 @@ func TestReplicaRemovalCampaign(t *testing.T) {
 // a remote node correctly after the Replica was removed from the Store.
 func TestRaftAfterRemoveRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	mtc := &multiTestContext{}
+	storeCfg := storage.TestStoreConfig(nil /* clock */)
+	storeCfg.TestingKnobs.DisableMergeQueue = true
+	mtc := &multiTestContext{
+		storeConfig: &storeCfg,
+	}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 
@@ -3256,6 +3270,7 @@ func TestReplicaLazyLoad(t *testing.T) {
 	sc.RaftTickInterval = 10 * time.Millisecond // safe because there is only a single node
 	sc.TestingKnobs.DisableScanner = true
 	sc.TestingKnobs.DisablePeriodicGossips = true
+	sc.TestingKnobs.DisableMergeQueue = true
 	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 1)
@@ -3484,6 +3499,7 @@ func TestTransferRaftLeadership(t *testing.T) {
 
 	const numStores = 3
 	sc := storage.TestStoreConfig(nil)
+	sc.TestingKnobs.DisableMergeQueue = true
 	// Suppress timeout-based elections (which also includes a previous
 	// leader stepping down due to a quorum check). Running tests on a
 	// heavily loaded CPU is enough to reach the raft election timeout
@@ -3613,6 +3629,7 @@ func TestRaftBlockedReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	sc := storage.TestStoreConfig(nil)
+	sc.TestingKnobs.DisableMergeQueue = true
 	sc.TestingKnobs.DisableScanner = true
 	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
@@ -3737,7 +3754,11 @@ func TestRangeQuiescence(t *testing.T) {
 // lease points to a different replica.
 func TestInitRaftGroupOnRequest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	mtc := &multiTestContext{}
+	storeCfg := storage.TestStoreConfig(nil /* clock */)
+	storeCfg.TestingKnobs.DisableMergeQueue = true
+	mtc := &multiTestContext{
+		storeConfig: &storeCfg,
+	}
 	defer mtc.Stop()
 	mtc.Start(t, 2)
 

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1578,7 +1578,6 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 		EvalKnobs: batcheval.TestingKnobs{
 			TestingEvalFilter: filter,
 		},
-		DisableMergeQueue: true,
 	}
 
 	tc := testcluster.StartTestCluster(t, 2, args)
@@ -1760,7 +1759,6 @@ func TestStoreSplitOnRemovedReplica(t *testing.T) {
 	args.ReplicationMode = base.ReplicationManual
 	args.ServerArgs.Knobs.Store = &storage.StoreTestingKnobs{
 		TestingRequestFilter: filter,
-		DisableMergeQueue:    true,
 	}
 
 	tc := testcluster.StartTestCluster(t, 3, args)
@@ -1850,7 +1848,6 @@ func TestStoreSplitFailsAfterMaxRetries(t *testing.T) {
 	args.ReplicationMode = base.ReplicationManual
 	args.ServerArgs.Knobs.Store = &storage.StoreTestingKnobs{
 		TestingRequestFilter: filter,
-		DisableMergeQueue:    true,
 	}
 
 	tc := testcluster.StartTestCluster(t, 1, args)

--- a/pkg/storage/client_status_test.go
+++ b/pkg/storage/client_status_test.go
@@ -22,13 +22,18 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func TestComputeStatsForKeySpan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	mtc := &multiTestContext{}
+	storeCfg := storage.TestStoreConfig(nil /* clock */)
+	storeCfg.TestingKnobs.DisableMergeQueue = true
+	mtc := &multiTestContext{
+		storeConfig: &storeCfg,
+	}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 

--- a/pkg/storage/consistency_queue_test.go
+++ b/pkg/storage/consistency_queue_test.go
@@ -300,11 +300,6 @@ func TestConsistencyQueueRecomputeStats(t *testing.T) {
 		ScanInterval:    time.Second,
 		ScanMinIdleTime: 0,
 		ScanMaxIdleTime: 100 * time.Millisecond,
-		Knobs: base.TestingKnobs{
-			Store: &storage.StoreTestingKnobs{
-				DisableMergeQueue: true,
-			},
-		},
 	}
 	nodeZeroArgs := tsArgs
 	nodeZeroArgs.StoreSpecs = []base.StoreSpec{{

--- a/pkg/storage/consistency_queue_test.go
+++ b/pkg/storage/consistency_queue_test.go
@@ -300,6 +300,11 @@ func TestConsistencyQueueRecomputeStats(t *testing.T) {
 		ScanInterval:    time.Second,
 		ScanMinIdleTime: 0,
 		ScanMaxIdleTime: 100 * time.Millisecond,
+		Knobs: base.TestingKnobs{
+			Store: &storage.StoreTestingKnobs{
+				DisableMergeQueue: true,
+			},
+		},
 	}
 	nodeZeroArgs := tsArgs
 	nodeZeroArgs.StoreSpecs = []base.StoreSpec{{

--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -105,6 +105,7 @@ func TestTimeSeriesMaintenanceQueue(t *testing.T) {
 	cfg.TimeSeriesDataStore = model
 	cfg.TestingKnobs.DisableScanner = true
 	cfg.TestingKnobs.DisableSplitQueue = true
+	cfg.TestingKnobs.DisableMergeQueue = true
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -92,6 +92,10 @@ type TestClusterInterface interface {
 
 	// Target returns a roachpb.ReplicationTarget for the specified server.
 	Target(serverIdx int) roachpb.ReplicationTarget
+
+	// ReplicationMode returns the ReplicationMode that the test cluster was
+	// configured with.
+	ReplicationMode() base.TestClusterReplicationMode
 }
 
 // TestClusterFactory encompasses the actual implementation of the shim

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -244,6 +244,7 @@ func (tc *TestCluster) doAddServer(t testing.TB, serverArgs base.TestServerArgs)
 			stkCopy = *stk.(*storage.StoreTestingKnobs)
 		}
 		stkCopy.DisableSplitQueue = true
+		stkCopy.DisableMergeQueue = true
 		stkCopy.DisableReplicateQueue = true
 		serverArgs.Knobs.Store = &stkCopy
 	}
@@ -574,6 +575,11 @@ func (tc *TestCluster) WaitForNodeStatuses(t testing.TB) {
 		}
 		return nil
 	})
+}
+
+// ReplicationMode implements TestClusterInterface.
+func (tc *TestCluster) ReplicationMode() base.TestClusterReplicationMode {
+	return tc.replicationMode
 }
 
 type testClusterFactoryImpl struct{}

--- a/pkg/testutils/testcluster/testcluster_test.go
+++ b/pkg/testutils/testcluster/testcluster_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
@@ -40,6 +41,12 @@ func TestManualReplication(t *testing.T) {
 			ReplicationMode: base.ReplicationManual,
 			ServerArgs: base.TestServerArgs{
 				UseDatabase: "t",
+				Knobs: base.TestingKnobs{
+					Store: &storage.StoreTestingKnobs{
+						// Prevent the merge queue from immediately discarding our splits.
+						DisableMergeQueue: true,
+					},
+				},
 			},
 		})
 	defer tc.Stopper().Stop(context.TODO())


### PR DESCRIPTION
Backport:
  * 1/1 commits from "*: disable merge queue in more tests" (#29235)
  * 1/1 commits from "testcluster: make manual replication mode disable the merge queue" (#29550)

Please see individual PRs for details.

/cc @cockroachdb/release
