### PR TITLE
cdc: Retry on certain sink failures

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -181,7 +181,11 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 	}
 	rowsFn := kvsToRows(leaseMgr, tableHist, ca.spec.Feed, buf.Get)
 
-	ca.tickFn = emitEntries(ca.spec.Feed, ca.sink, rowsFn)
+	var knobs TestingKnobs
+	if cfKnobs, ok := ca.flowCtx.TestingKnobs().Changefeed.(*TestingKnobs); ok {
+		knobs = *cfKnobs
+	}
+	ca.tickFn = emitEntries(ca.spec.Feed, ca.sink, rowsFn, knobs)
 
 	// Give errCh enough buffer both possible errors from supporting goroutines,
 	// but only the first one is ever used.

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -121,8 +121,9 @@ func newChangeAggregatorProcessor(
 
 	buf := makeBuffer()
 	ca.poller = makePoller(
-		flowCtx.Settings, flowCtx.ClientDB, flowCtx.ClientDB.Clock(), flowCtx.Gossip, spans,
-		spec.Feed, initialHighWater, buf)
+		flowCtx.Settings, flowCtx.ClientDB, flowCtx.ClientDB.Clock(), flowCtx.Gossip,
+		spans, spec.Feed, initialHighWater, buf,
+	)
 
 	leaseMgr := flowCtx.LeaseManager.(*sql.LeaseManager)
 	tableHist := makeTableHistory(func(desc *sqlbase.TableDescriptor) error {

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -97,53 +97,22 @@ func newChangeAggregatorProcessor(
 		return nil, err
 	}
 
-	initialHighWater := hlc.Timestamp{WallTime: -1}
-	var spans []roachpb.Span
-	for _, watch := range spec.Watches {
-		spans = append(spans, watch.Span)
-		if initialHighWater.WallTime == -1 || watch.InitialResolved.Less(initialHighWater) {
-			initialHighWater = watch.InitialResolved
+	// Due to the possibility of leaked goroutines, it is not safe to start a sink
+	// in this method because there is no guarantee that the TrailingMetaCallback
+	// method will ever be called (this can happen, for example, if an error
+	// occurs during flow setup).  However, we still want to ensure that the user
+	// has not made any obvious errors when specifying the sink in the CREATE
+	// CHANGEFEED statement. Therefore, we create a "canary" sink, which will be
+	// immediately closed, only to check for errors.
+	{
+		canarySink, err := getSink(ca.spec.Feed.SinkURI, ca.spec.Feed.Targets)
+		if err != nil {
+			return nil, err
+		}
+		if err := canarySink.Close(); err != nil {
+			return nil, err
 		}
 	}
-
-	var err error
-	if ca.sink, err = getSink(spec.Feed.SinkURI, spec.Feed.Targets); err != nil {
-		return nil, err
-	}
-	if b, ok := ca.sink.(*bufferSink); ok {
-		ca.changedRowBuf = &b.buf
-	}
-	// The job registry has a set of metrics used to monitor the various jobs it
-	// runs. They're all stored as the `metric.Struct` interface because of
-	// dependency cycles.
-	metrics := flowCtx.JobRegistry.MetricsStruct().Changefeed.(*Metrics)
-	ca.sink = makeMetricsSink(metrics, ca.sink)
-
-	buf := makeBuffer()
-	ca.poller = makePoller(
-		flowCtx.Settings, flowCtx.ClientDB, flowCtx.ClientDB.Clock(), flowCtx.Gossip,
-		spans, spec.Feed, initialHighWater, buf,
-	)
-
-	leaseMgr := flowCtx.LeaseManager.(*sql.LeaseManager)
-	tableHist := makeTableHistory(func(desc *sqlbase.TableDescriptor) error {
-		// NB: Each new `tableDesc.Version` is initially written with an mvcc
-		// timestamp equal to its `ModificationTime`. It might later update that
-		// `Version` with backfill progress, but we only validate a table
-		// descriptor through its `ModificationTime` before using it, so this
-		// validation function can't depend on anything that changes after a new
-		// `Version` of a table desc is written.
-		return validateChangefeedTable(spec.Feed.Targets, desc)
-	}, initialHighWater)
-	ca.tableHistUpdater = &tableHistoryUpdater{
-		settings: flowCtx.Settings,
-		db:       flowCtx.ClientDB,
-		targets:  spec.Feed.Targets,
-		m:        tableHist,
-	}
-	rowsFn := kvsToRows(leaseMgr, tableHist, spec.Feed, buf.Get)
-
-	ca.tickFn = emitEntries(spec.Feed, ca.sink, rowsFn)
 
 	return ca, nil
 }
@@ -155,9 +124,67 @@ func (ca *changeAggregator) OutputTypes() []sqlbase.ColumnType {
 // Start is part of the RowSource interface.
 func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 	ctx, ca.cancel = context.WithCancel(ctx)
+	// StartInternal called at the beginning of the function because there are
+	// early returns if errors are detected.
+	ctx = ca.StartInternal(ctx, changeAggregatorProcName)
 
-	// Give errCh enough buffer for both of these, but only the first one is
-	// ever used.
+	var err error
+	if ca.sink, err = getSink(ca.spec.Feed.SinkURI, ca.spec.Feed.Targets); err != nil {
+		// Early abort in the case that there is an error creating the sink.
+		ca.MoveToDraining(err)
+		ca.cancel()
+		return ctx
+	}
+
+	// This is the correct point to set up certain hooks depending on the sink
+	// type.
+	if b, ok := ca.sink.(*bufferSink); ok {
+		ca.changedRowBuf = &b.buf
+	}
+
+	initialHighWater := hlc.Timestamp{WallTime: -1}
+	var spans []roachpb.Span
+	for _, watch := range ca.spec.Watches {
+		spans = append(spans, watch.Span)
+		if initialHighWater.WallTime == -1 || watch.InitialResolved.Less(initialHighWater) {
+			initialHighWater = watch.InitialResolved
+		}
+	}
+
+	// The job registry has a set of metrics used to monitor the various jobs it
+	// runs. They're all stored as the `metric.Struct` interface because of
+	// dependency cycles.
+	metrics := ca.flowCtx.JobRegistry.MetricsStruct().Changefeed.(*Metrics)
+	ca.sink = makeMetricsSink(metrics, ca.sink)
+
+	buf := makeBuffer()
+	ca.poller = makePoller(
+		ca.flowCtx.Settings, ca.flowCtx.ClientDB, ca.flowCtx.ClientDB.Clock(), ca.flowCtx.Gossip,
+		spans, ca.spec.Feed, initialHighWater, buf,
+	)
+
+	leaseMgr := ca.flowCtx.LeaseManager.(*sql.LeaseManager)
+	tableHist := makeTableHistory(func(desc *sqlbase.TableDescriptor) error {
+		// NB: Each new `tableDesc.Version` is initially written with an mvcc
+		// timestamp equal to its `ModificationTime`. It might later update that
+		// `Version` with backfill progress, but we only validate a table
+		// descriptor through its `ModificationTime` before using it, so this
+		// validation function can't depend on anything that changes after a new
+		// `Version` of a table desc is written.
+		return validateChangefeedTable(ca.spec.Feed.Targets, desc)
+	}, initialHighWater)
+	ca.tableHistUpdater = &tableHistoryUpdater{
+		settings: ca.flowCtx.Settings,
+		db:       ca.flowCtx.ClientDB,
+		targets:  ca.spec.Feed.Targets,
+		m:        tableHist,
+	}
+	rowsFn := kvsToRows(leaseMgr, tableHist, ca.spec.Feed, buf.Get)
+
+	ca.tickFn = emitEntries(ca.spec.Feed, ca.sink, rowsFn)
+
+	// Give errCh enough buffer both possible errors from supporting goroutines,
+	// but only the first one is ever used.
 	ca.errCh = make(chan error, 2)
 	ca.pollerDoneCh = make(chan struct{})
 	go func(ctx context.Context) {
@@ -178,16 +205,26 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 		ca.cancel()
 	}(ctx)
 
-	ctx = ca.StartInternal(ctx, changeAggregatorProcName)
 	return ctx
 }
 
+// close has two purposes: to synchronize on the completion of the helper
+// goroutines created by the Start method, and to clean up any resources used by
+// the processor. Due to the fact that this method may be called even if the
+// processor did not finish completion, there is an excessive amount of nil
+// checking.
 func (ca *changeAggregator) close() {
 	// Wait for the poller and tableHistUpdater to finish shutting down.
-	<-ca.pollerDoneCh
-	<-ca.tableHistUpdaterDoneCh
-	if err := ca.sink.Close(); err != nil {
-		log.Warningf(ca.Ctx, `error closing sink. goroutines may have leaked: %v`, err)
+	if ca.pollerDoneCh != nil {
+		<-ca.pollerDoneCh
+	}
+	if ca.tableHistUpdaterDoneCh != nil {
+		<-ca.tableHistUpdaterDoneCh
+	}
+	if ca.sink != nil {
+		if err := ca.sink.Close(); err != nil {
+			log.Warningf(ca.Ctx, `error closing sink. goroutines may have leaked: %v`, err)
+		}
 	}
 	// Need to close the mem accounting while the context is still valid.
 	ca.memAcc.Close(ca.Ctx)
@@ -274,6 +311,7 @@ type changeFrontier struct {
 	// sink is the Sink to write resolved timestamps to. Rows are never written
 	// by changeFrontier.
 	sink Sink
+
 	// jobProgressedFn, if non-nil, is called to checkpoint the changefeed's
 	// progress in the corresponding system job entry.
 	jobProgressedFn func(context.Context, jobs.HighWaterProgressedFn) error
@@ -328,25 +366,16 @@ func newChangeFrontierProcessor(
 		return nil, err
 	}
 
-	var err error
-	if cf.sink, err = getSink(spec.Feed.SinkURI, spec.Feed.Targets); err != nil {
-		return nil, err
-	}
-	if b, ok := cf.sink.(*bufferSink); ok {
-		cf.resolvedBuf = &b.buf
-	}
-	// The job registry has a set of metrics used to monitor the various jobs it
-	// runs. They're all stored as the `metric.Struct` interface because of
-	// dependency cycles.
-	cf.metrics = flowCtx.JobRegistry.MetricsStruct().Changefeed.(*Metrics)
-	cf.sink = makeMetricsSink(cf.metrics, cf.sink)
-
-	if spec.JobID != 0 {
-		job, err := flowCtx.JobRegistry.LoadJob(ctx, spec.JobID)
+	// See comment in newChangeAggregatorProcessor for details on the use of canary
+	// sinks.
+	{
+		canarySink, err := getSink(spec.Feed.SinkURI, spec.Feed.Targets)
 		if err != nil {
 			return nil, err
 		}
-		cf.jobProgressedFn = job.HighWaterProgressed
+		if err := canarySink.Close(); err != nil {
+			return nil, err
+		}
 	}
 
 	return cf, nil
@@ -359,7 +388,35 @@ func (cf *changeFrontier) OutputTypes() []sqlbase.ColumnType {
 // Start is part of the RowSource interface.
 func (cf *changeFrontier) Start(ctx context.Context) context.Context {
 	cf.input.Start(ctx)
+
+	// StartInternal called at the beginning of the function because there are
+	// early returns if errors are detected.
 	ctx = cf.StartInternal(ctx, changeFrontierProcName)
+
+	var err error
+	if cf.sink, err = getSink(cf.spec.Feed.SinkURI, cf.spec.Feed.Targets); err != nil {
+		cf.MoveToDraining(err)
+		return ctx
+	}
+
+	if b, ok := cf.sink.(*bufferSink); ok {
+		cf.resolvedBuf = &b.buf
+	}
+
+	// The job registry has a set of metrics used to monitor the various jobs it
+	// runs. They're all stored as the `metric.Struct` interface because of
+	// dependency cycles.
+	cf.metrics = cf.flowCtx.JobRegistry.MetricsStruct().Changefeed.(*Metrics)
+	cf.sink = makeMetricsSink(cf.metrics, cf.sink)
+
+	if cf.spec.JobID != 0 {
+		job, err := cf.flowCtx.JobRegistry.LoadJob(ctx, cf.spec.JobID)
+		if err != nil {
+			cf.MoveToDraining(err)
+			return ctx
+		}
+		cf.jobProgressedFn = job.HighWaterProgressed
+	}
 
 	cf.metrics.mu.Lock()
 	cf.metricsID = cf.metrics.mu.id
@@ -383,8 +440,10 @@ func (cf *changeFrontier) Start(ctx context.Context) context.Context {
 }
 
 func (cf *changeFrontier) close() {
-	if err := cf.sink.Close(); err != nil {
-		log.Warningf(cf.Ctx, `error closing sink. goroutines may have leaked: %v`, err)
+	if cf.sink != nil {
+		if err := cf.sink.Close(); err != nil {
+			log.Warningf(cf.Ctx, `error closing sink. goroutines may have leaked: %v`, err)
+		}
 	}
 	// Need to close the mem accounting while the context is still valid.
 	cf.memAcc.Close(cf.Ctx)

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -116,7 +116,7 @@ func createBenchmarkChangefeed(
 		m:        th,
 	}
 	rowsFn := kvsToRows(s.LeaseManager().(*sql.LeaseManager), th, details, buf.Get)
-	tickFn := emitEntries(details, sink, rowsFn)
+	tickFn := emitEntries(details, sink, rowsFn, TestingKnobs{})
 
 	ctx, cancel := context.WithCancel(ctx)
 	go func() { _ = poller.Run(ctx) }()

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -113,17 +113,24 @@ var (
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_TIMESTAMP_NS,
 	}
+	metaChangefeedSinkErrorRetries = metric.Metadata{
+		Name:        "changefeed.sink_error_retries",
+		Help:        "Total retryable errors encountered while emitting to sinks",
+		Measurement: "Errors",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 const noMinHighWaterSentinel = int64(math.MaxInt64)
 
 // Metrics are for production monitoring of changefeeds.
 type Metrics struct {
-	EmittedMessages *metric.Counter
-	EmittedBytes    *metric.Counter
-	EmitNanos       *metric.Counter
-	Flushes         *metric.Counter
-	FlushNanos      *metric.Counter
+	EmittedMessages  *metric.Counter
+	EmittedBytes     *metric.Counter
+	EmitNanos        *metric.Counter
+	Flushes          *metric.Counter
+	FlushNanos       *metric.Counter
+	SinkErrorRetries *metric.Counter
 
 	mu struct {
 		syncutil.Mutex
@@ -139,11 +146,12 @@ func (*Metrics) MetricStruct() {}
 // MakeMetrics makes the metrics for changefeed monitoring.
 func MakeMetrics() metric.Struct {
 	m := &Metrics{
-		EmittedMessages: metric.NewCounter(metaChangefeedEmittedMessages),
-		EmittedBytes:    metric.NewCounter(metaChangefeedEmittedBytes),
-		EmitNanos:       metric.NewCounter(metaChangefeedEmitNanos),
-		Flushes:         metric.NewCounter(metaChangefeedFlushes),
-		FlushNanos:      metric.NewCounter(metaChangefeedFlushNanos),
+		EmittedMessages:  metric.NewCounter(metaChangefeedEmittedMessages),
+		EmittedBytes:     metric.NewCounter(metaChangefeedEmittedBytes),
+		EmitNanos:        metric.NewCounter(metaChangefeedEmitNanos),
+		Flushes:          metric.NewCounter(metaChangefeedFlushes),
+		FlushNanos:       metric.NewCounter(metaChangefeedFlushNanos),
+		SinkErrorRetries: metric.NewCounter(metaChangefeedSinkErrorRetries),
 	}
 	m.mu.resolved = make(map[int]hlc.Timestamp)
 	m.MinHighWater = metric.NewFunctionalGauge(metaChangefeedMinHighWater, func() int64 {

--- a/pkg/ccl/changefeedccl/poller.go
+++ b/pkg/ccl/changefeedccl/poller.go
@@ -120,7 +120,13 @@ func (p *poller) Run(ctx context.Context) error {
 			}
 		}
 
-		nextHighWater := p.clock.Now()
+		var nextHighWater hlc.Timestamp
+		if p.highWater == (hlc.Timestamp{}) {
+			nextHighWater = p.details.StatementTime
+		} else {
+			nextHighWater = p.clock.Now()
+		}
+
 		log.VEventf(ctx, 1, `changefeed poll [%s,%s): %s`,
 			p.highWater, nextHighWater, time.Duration(nextHighWater.WallTime-p.highWater.WallTime))
 

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -274,6 +274,9 @@ func (s *kafkaSink) Flush(ctx context.Context) error {
 		flushErr := s.mu.flushErr
 		s.mu.flushErr = nil
 		s.mu.Unlock()
+		if _, ok := flushErr.(*sarama.ProducerError); ok {
+			flushErr = &retryableSinkError{cause: flushErr}
+		}
 		return flushErr
 	}
 }
@@ -548,4 +551,34 @@ func (s *bufferSink) Flush(_ context.Context) error {
 func (s *bufferSink) Close() error {
 	s.closed = true
 	return nil
+}
+
+// causer matches the (unexported) interface used by Go to allow errors to wrap
+// their parent cause.
+type causer interface {
+	Cause() error
+}
+
+// retryableSinkError should be used by sinks to wrap any error which may
+// be retried.
+type retryableSinkError struct {
+	cause error
+}
+
+func (e retryableSinkError) Error() string { return e.cause.Error() }
+func (e retryableSinkError) Cause() error  { return e.cause }
+
+// isRetryableSinkError returns true if the supplied error, or any of its parent
+// causes, is a retryableSinkError.
+func isRetryableSinkError(err error) bool {
+	for {
+		if _, ok := err.(retryableSinkError); ok {
+			return true
+		}
+		if e, ok := err.(causer); ok {
+			err = e.Cause()
+			continue
+		}
+		return false
+	}
 }

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -392,6 +392,7 @@ func makeSQLSink(uri, tableName string, targets jobspb.ChangefeedTargets) (*sqlS
 		return nil, err
 	}
 	if _, err := db.Exec(fmt.Sprintf(sqlSinkCreateTableStmt, tableName)); err != nil {
+		db.Close()
 		return nil, err
 	}
 

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -1,0 +1,19 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+// TestingKnobs are the testing knobs for changefeed.
+type TestingKnobs struct {
+	// AfterSinkFlush is called after a sink flush operation has returned without
+	// error.
+	AfterSinkFlush func() error
+}
+
+// ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
+func (*TestingKnobs) ModuleTestingKnobs() {}

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -131,6 +131,11 @@ func (ctx *FlowCtx) NewEvalCtx() *tree.EvalContext {
 	return &evalCtx
 }
 
+// TestingKnobs returns the distsql testing knobs for this flow context.
+func (ctx *FlowCtx) TestingKnobs() TestingKnobs {
+	return ctx.testingKnobs
+}
+
 type flowStatus int
 
 // Flow status indicators.

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -617,6 +617,9 @@ type TestingKnobs struct {
 	// DeterministicStats overrides stats which don't have reliable values, like
 	// stall time and bytes sent. It replaces them with a zero value.
 	DeterministicStats bool
+
+	// Changefeed contains testing knobs specific to the changefeed system.
+	Changefeed base.ModuleTestingKnobs
 }
 
 // MetadataTestLevel represents the types of queries where metadata test


### PR DESCRIPTION
Allow changefeeds to retry when emitting to a sink fails under certain
circumstances. The following circumstances are currently considered
retryable:

+ Any ProducerError from Sarama when emitting to Kafka. This may cause
us to retry in some cases that may never succeed, but we don't yet have
enough information do identify these situations, so we take the liberal
position and always retry.
+ Using the experimental sql sink in combination with a new testhook for
throwing fake retryable errors.

Implementation works by detecting retryable errors in
changefeedResumer.Resume(), and re-establishing a new distsql Changefeed
flow using the updated parameters.

Includes a new metric which counts the total number of retry attempts
for sink errors.