### PR TITLE
opt: Reuse Memo data structure

### DIFF
--- a/pkg/sql/opt/memo/list_storage.go
+++ b/pkg/sql/opt/memo/list_storage.go
@@ -133,6 +133,12 @@ type listStorageVal struct {
 	offset uint32
 }
 
+// init prepares the list storage for use (or reuse).
+func (ls *listStorage) init() {
+	ls.index = nil
+	ls.lists = ls.lists[:0]
+}
+
 // intern adds the given list to storage and returns an id that can later be
 // used to retrieve the list by calling the lookup method. If the list has been
 // previously added to storage, then intern always returns the same list id

--- a/pkg/sql/opt/memo/private_storage.go
+++ b/pkg/sql/opt/memo/private_storage.go
@@ -71,11 +71,21 @@ type privateKey struct {
 	str   string
 }
 
-// init must be called before privateStorage can be used.
+// init prepares privateStorage for use (or reuse).
 func (ps *privateStorage) init() {
 	ps.datumCtx = tree.MakeFmtCtx(&ps.keyBuf.Buffer, tree.FmtSimple)
 	ps.privatesMap = make(map[privateKey]PrivateID)
-	ps.privates = make([]interface{}, 1, 8)
+
+	if ps.privates == nil {
+		ps.privates = make([]interface{}, 1, 8)
+	} else {
+		// Clear the privates to release memory (this clearing pattern is
+		// optimized by Go).
+		for i := range ps.privates {
+			ps.privates[i] = nil
+		}
+		ps.privates = ps.privates[:1]
+	}
 }
 
 // lookup returns a private value previously interned by privateStorage.

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -91,9 +91,10 @@ func TestGetStatsFromConstraint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mem := New()
+	var mem Memo
+	mem.Init()
 	tab := catalog.Table(tree.NewUnqualifiedTableName("sel"))
-	tabID := mem.metadata.AddTable(tab)
+	tabID := mem.Metadata().AddTable(tab)
 
 	// Test that applyConstraintSet correctly updates the statistics from
 	// constraint set cs, and selectivity is calculated correctly.
@@ -120,7 +121,7 @@ func TestGetStatsFromConstraint(t *testing.T) {
 		// Make the select.
 		sel := MakeSelectExpr(scanGroup, filterGroup)
 		selGroup := mem.newGroup(Expr(sel))
-		ev := MakeNormExprView(mem, selGroup.id)
+		ev := MakeNormExprView(&mem, selGroup.id)
 		relProps := &props.Relational{Cardinality: props.AnyCardinality}
 		s := &relProps.Stats
 		s.Init(relProps)

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -153,6 +153,20 @@ type mdColumn struct {
 	typ types.T
 }
 
+// Init prepares the metadata for use (or reuse).
+func (md *Metadata) Init() {
+	// Clear the columns and tables to release memory (this clearing pattern is
+	// optimized by Go).
+	for i := range md.cols {
+		md.cols[i] = mdColumn{}
+	}
+	for i := range md.tables {
+		md.tables[i] = mdTable{}
+	}
+	md.cols = md.cols[:0]
+	md.tables = md.tables[:0]
+}
+
 // AddColumn assigns a new unique id to a column within the query and records
 // its label and type.
 func (md *Metadata) AddColumn(label string, typ types.T) ColumnID {

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -46,7 +46,7 @@ type CustomFuncs struct {
 // Init initializes a new CustomFuncs with the given factory.
 func (c *CustomFuncs) Init(f *Factory) {
 	c.f = f
-	c.mem = f.mem
+	c.mem = f.Memo()
 }
 
 // ----------------------------------------------------------------------

--- a/pkg/sql/opt/norm/decorrelate.go
+++ b/pkg/sql/opt/norm/decorrelate.go
@@ -41,7 +41,7 @@ func (c *CustomFuncs) HasHoistableSubquery(group memo.GroupID) bool {
 	}
 	scalar.SetAvailable(props.HasHoistableSubquery)
 
-	ev := memo.MakeNormExprView(c.f.mem, group)
+	ev := memo.MakeNormExprView(c.mem, group)
 	switch ev.Operator() {
 	case opt.SubqueryOp, opt.ExistsOp, opt.AnyOp:
 		scalar.Rule.HasHoistableSubquery = !scalar.OuterCols.Empty()
@@ -528,7 +528,7 @@ func (c *CustomFuncs) EnsureAggsCanIgnoreNulls(in, aggs memo.GroupID) memo.Group
 		switch expr.Operator() {
 		case opt.ConstAggOp:
 			// Translate ConstAgg(...) to ConstNotNullAgg(...).
-			newElem = c.f.ConstructConstNotNullAgg(expr.ChildGroup(c.f.mem, 0))
+			newElem = c.f.ConstructConstNotNullAgg(expr.ChildGroup(c.mem, 0))
 
 		case opt.CountRowsOp:
 			// Translate CountRows() to Count(notNullCol).
@@ -663,7 +663,7 @@ type subqueryHoister struct {
 func (r *subqueryHoister) init(c *CustomFuncs, input memo.GroupID) {
 	r.c = c
 	r.f = c.f
-	r.mem = c.f.mem
+	r.mem = c.mem
 	r.hoisted = input
 }
 

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -63,7 +63,7 @@ type Factory struct {
 	evalCtx *tree.EvalContext
 
 	// mem is the Memo data structure that the factory builds.
-	mem *memo.Memo
+	mem memo.Memo
 
 	// funcs is the struct used to call all custom match and replace functions
 	// used by the normalization rules. It wraps an unnamed xfunc.CustomFuncs,
@@ -109,7 +109,7 @@ type Factory struct {
 // This must be called before the factory can be used (or reused).
 func (f *Factory) Init(evalCtx *tree.EvalContext) {
 	f.evalCtx = evalCtx
-	f.mem = memo.New()
+	f.mem.Init()
 	f.funcs.Init(f)
 	f.matchedRule = nil
 	f.appliedRule = nil
@@ -147,7 +147,7 @@ func (f *Factory) NotifyOnAppliedRule(appliedRule AppliedRuleFunc) {
 
 // Memo returns the memo structure that the factory is operating upon.
 func (f *Factory) Memo() *memo.Memo {
-	return f.mem
+	return &f.mem
 }
 
 // Metadata returns the query-specific metadata, which includes information
@@ -176,7 +176,7 @@ func (f *Factory) onConstruct(e memo.Expr) memo.GroupID {
 	// RaceEnabled ensures that checks are run on every change (as part of make
 	// testrace) while keeping the check code out of non-test builds.
 	if util.RaceEnabled && !f.skipSanityChecks {
-		f.checkExpr(memo.MakeNormExprView(f.mem, group))
+		f.checkExpr(memo.MakeNormExprView(&f.mem, group))
 	}
 	return group
 }

--- a/pkg/sql/opt/norm/factory_test.go
+++ b/pkg/sql/opt/norm/factory_test.go
@@ -99,13 +99,13 @@ func TestFactoryProjectColsFromBoth(t *testing.T) {
 
 	for _, tc := range testCases {
 		combined := f.funcs.ProjectColsFromBoth(tc.left, tc.right)
-		f.checkExpr(memo.MakeNormExprView(f.mem, combined))
+		f.checkExpr(memo.MakeNormExprView(f.Memo(), combined))
 		actual := f.funcs.OutputCols(combined).String()
 		if actual != tc.expected {
 			t.Errorf("expected: %s, actual: %s", tc.expected, actual)
 		}
 
-		def := f.funcs.ExtractProjectionsOpDef(f.mem.NormExpr(combined).AsProjections().Def())
+		def := f.funcs.ExtractProjectionsOpDef(f.Memo().NormExpr(combined).AsProjections().Def())
 		expectedCount := def.PassthroughCols.Len() + len(def.SynthesizedCols)
 		actualCount := f.funcs.OutputCols(combined).Len()
 		if actualCount != expectedCount {

--- a/pkg/sql/opt/norm/groupby.go
+++ b/pkg/sql/opt/norm/groupby.go
@@ -208,13 +208,13 @@ func (c *CustomFuncs) hasRemovableAggDistinct(
 ) (ok bool, aggDistinctInput memo.GroupID) {
 	aggExpr := c.f.mem.NormExpr(aggregation)
 	if aggExpr.ChildCount() == 1 {
-		argExpr := c.f.mem.NormExpr(aggExpr.ChildGroup(c.f.mem, 0))
+		argExpr := c.f.mem.NormExpr(aggExpr.ChildGroup(c.mem, 0))
 		if argExpr.Operator() == opt.AggDistinctOp {
-			aggDistinctInput := argExpr.ChildGroup(c.f.mem, 0)
+			aggDistinctInput := argExpr.ChildGroup(c.mem, 0)
 			v := c.f.mem.NormExpr(aggDistinctInput)
 			if v.Operator() == opt.VariableOp {
 				cols := groupingCols.Copy()
-				cols.Add(int(v.Private(c.f.mem).(opt.ColumnID)))
+				cols.Add(int(v.Private(c.mem).(opt.ColumnID)))
 				if inputFDs.ColsAreStrictKey(cols) {
 					return true, aggDistinctInput
 				}

--- a/pkg/sql/opt/norm/inline.go
+++ b/pkg/sql/opt/norm/inline.go
@@ -74,7 +74,7 @@ func (c *CustomFuncs) HasDuplicateRefs(target memo.GroupID) bool {
 		}
 
 		for i := 0; i < expr.ChildCount(); i++ {
-			if findDupRefs(expr.ChildGroup(c.f.mem, i)) {
+			if findDupRefs(expr.ChildGroup(c.mem, i)) {
 				return true
 			}
 		}
@@ -100,7 +100,7 @@ func (c *CustomFuncs) CanInline(group memo.GroupID) bool {
 
 		// Recursively verify that children are also inlinable.
 		for i := 0; i < expr.ChildCount(); i++ {
-			if !c.CanInline(expr.ChildGroup(c.f.mem, i)) {
+			if !c.CanInline(expr.ChildGroup(c.mem, i)) {
 				return false
 			}
 		}
@@ -169,7 +169,7 @@ func (c *CustomFuncs) InlineProjections(target, projections memo.GroupID) memo.G
 			return pb.buildProjections()
 		}
 
-		ev := memo.MakeNormExprView(c.f.mem, child)
+		ev := memo.MakeNormExprView(c.mem, child)
 		return ev.Replace(c.f.evalCtx, replace).Group()
 	}
 

--- a/pkg/sql/opt/norm/reject_nulls.go
+++ b/pkg/sql/opt/norm/reject_nulls.go
@@ -24,7 +24,7 @@ import (
 // rejection filter pushdown. See the Relational.Rule.RejectNullCols comment for
 // more details.
 func (c *CustomFuncs) RejectNullCols(group memo.GroupID) opt.ColSet {
-	return DeriveRejectNullCols(memo.MakeNormExprView(c.f.mem, group))
+	return DeriveRejectNullCols(memo.MakeNormExprView(c.mem, group))
 }
 
 // HasNullRejectingFilter returns true if the filter causes some of the columns
@@ -46,14 +46,14 @@ func (c *CustomFuncs) HasNullRejectingFilter(filter memo.GroupID, nullRejectCols
 // null-rejection column was identified by the deriveGroupByRejectNullCols
 // method (see its comment for more details).
 func (c *CustomFuncs) NullRejectAggVar(aggs memo.GroupID) memo.GroupID {
-	aggsExpr := c.f.mem.NormExpr(aggs).AsAggregations()
-	aggsElems := c.f.mem.LookupList(aggsExpr.Aggs())
+	aggsExpr := c.mem.NormExpr(aggs).AsAggregations()
+	aggsElems := c.mem.LookupList(aggsExpr.Aggs())
 
 	for i := len(aggsElems) - 1; i >= 0; i-- {
-		agg := c.f.mem.NormExpr(aggsElems[i])
+		agg := c.mem.NormExpr(aggsElems[i])
 		if agg.Operator() != opt.ConstAggOp {
 			// Return the input Variable operator.
-			return agg.ChildGroup(c.f.mem, 0)
+			return agg.ChildGroup(c.mem, 0)
 		}
 	}
 	panic("couldn't find an aggregate that is not ConstAgg")

--- a/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
@@ -584,7 +584,7 @@ func (g *ruleGen) genDynamicMatch(
 			if isPrivateType(string(prototype.Fields[index].Type)) {
 				context = fmt.Sprintf("%s.PrivateID()", exprName)
 			} else {
-				context = fmt.Sprintf("%s.ChildGroup(%s.mem, %d)", exprName, g.thisVar, index)
+				context = fmt.Sprintf("%s.ChildGroup(%s.Memo(), %d)", exprName, g.thisVar, index)
 			}
 			g.genMatch(matchArg, context, false /* noMatch */)
 		}

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/explorer
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/explorer
@@ -205,7 +205,7 @@ func (_e *explorer) exploreInnerJoin(_rootState *exploreState, _root memo.ExprID
 				_eid := memo.MakeNormExprID(_innerJoinExpr.On())
 				_expr := _e.mem.Expr(_eid)
 				if _expr.Operator() == opt.FiltersOp || _expr.IsHasConditions() || _expr.Operator() == opt.AndOp {
-					lowerConditions := _expr.ChildGroup(_e.mem, 0)
+					lowerConditions := _expr.ChildGroup(_e.Memo(), 0)
 					t := _rootExpr.Right()
 					filters := _rootExpr.On()
 					_eid := memo.MakeNormExprID(_rootExpr.On())
@@ -275,9 +275,9 @@ func (_e *explorer) exploreSelect(_rootState *exploreState, _root memo.ExprID) (
 					_eid := memo.ExprID{Group: _groupByExpr.Input(), Expr: _ord}
 					_expr := _e.mem.Expr(_eid)
 					if _expr.Operator() == opt.InnerJoinOp || _expr.IsJoin() {
-						left := _expr.ChildGroup(_e.mem, 0)
-						right := _expr.ChildGroup(_e.mem, 1)
-						on := _expr.ChildGroup(_e.mem, 2)
+						left := _expr.ChildGroup(_e.Memo(), 0)
+						right := _expr.ChildGroup(_e.Memo(), 1)
+						on := _expr.ChildGroup(_e.Memo(), 2)
 						aggregations := _groupByExpr.Aggregations()
 						def := _groupByExpr.GroupingCols()
 						filter := _rootExpr.Filter()

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
@@ -616,8 +616,8 @@ func (_f *Factory) ConstructSelect(
 		_match := false
 		_expr := _f.mem.NormExpr(input)
 		if _expr.IsJoin() || _expr.Operator() == opt.UnionOp {
-			r := _expr.ChildGroup(_f.mem, 0)
-			s := _expr.ChildGroup(_f.mem, 1)
+			r := _expr.ChildGroup(_f.Memo(), 0)
+			s := _expr.ChildGroup(_f.Memo(), 1)
 			_match = true
 		}
 
@@ -627,8 +627,8 @@ func (_f *Factory) ConstructSelect(
 				item := _item
 				_expr2 := _f.mem.NormExpr(_item)
 				if _expr2.IsJoin() {
-					t := _expr2.ChildGroup(_f.mem, 0)
-					u := _expr2.ChildGroup(_f.mem, 1)
+					t := _expr2.ChildGroup(_f.Memo(), 0)
+					u := _expr2.ChildGroup(_f.Memo(), 1)
 					if _f.matchedRule == nil || _f.matchedRule(opt.Test) {
 						_group = _f.DynamicConstruct(
 							_f.mem.NormOp(item),
@@ -838,8 +838,8 @@ func (_f *Factory) ConstructSelect(
 	{
 		_expr := _f.mem.NormExpr(input)
 		if _expr.Operator() == opt.LookupJoinOp || _expr.IsGroupByOps() {
-			expr1 := _expr.ChildGroup(_f.mem, 0)
-			expr2 := _expr.ChildGroup(_f.mem, 1)
+			expr1 := _expr.ChildGroup(_f.Memo(), 0)
+			expr2 := _expr.ChildGroup(_f.Memo(), 1)
 			private := _expr.PrivateID()
 			if _f.funcs.True() {
 				if _f.matchedRule == nil || _f.matchedRule(opt.Test) {
@@ -1369,16 +1369,16 @@ func (_f *Factory) ConstructNe(
 	{
 		_expr := _f.mem.NormExpr(left)
 		if _expr.Operator() == opt.EqOp || _expr.Operator() == opt.NeOp {
-			_expr2 := _f.mem.NormExpr(_expr.ChildGroup(_f.mem, 0))
+			_expr2 := _f.mem.NormExpr(_expr.ChildGroup(_f.Memo(), 0))
 			if _expr2.Operator() == opt.EqOp || _expr2.Operator() == opt.NeOp {
-				_expr3 := _f.mem.NormExpr(_expr.ChildGroup(_f.mem, 1))
+				_expr3 := _f.mem.NormExpr(_expr.ChildGroup(_f.Memo(), 1))
 				if !(_expr3.Operator() == opt.EqOp || _expr3.Operator() == opt.NeOp) {
 					_match := false
 					_expr4 := _f.mem.NormExpr(right)
 					if _expr4.Operator() == opt.EqOp || _expr4.Operator() == opt.NeOp {
-						_expr5 := _f.mem.NormExpr(_expr4.ChildGroup(_f.mem, 0))
+						_expr5 := _f.mem.NormExpr(_expr4.ChildGroup(_f.Memo(), 0))
 						if _expr5.Operator() == opt.EqOp || _expr5.Operator() == opt.NeOp {
-							_expr6 := _f.mem.NormExpr(_expr4.ChildGroup(_f.mem, 1))
+							_expr6 := _f.mem.NormExpr(_expr4.ChildGroup(_f.Memo(), 1))
 							if !(_expr6.Operator() == opt.EqOp || _expr6.Operator() == opt.NeOp) {
 								_match = true
 							}
@@ -1681,8 +1681,8 @@ func (_f *Factory) ConstructNot(
 	{
 		_expr := _f.mem.NormExpr(input)
 		if _expr.IsComparison() {
-			left := _expr.ChildGroup(_f.mem, 0)
-			right := _expr.ChildGroup(_f.mem, 1)
+			left := _expr.ChildGroup(_f.Memo(), 0)
+			right := _expr.ChildGroup(_f.Memo(), 1)
 			_containsExpr := _f.mem.NormExpr(input).AsContains()
 			if _containsExpr == nil {
 				if _f.funcs.SomeOtherCondition(input) {


### PR DESCRIPTION
Embed the Memo data structure in Factory and allow it to be reused.
This gives a sizeable speedup on simple queries:
```
name                      old time/op  new time/op  delta
Phases/kv-read/Explore    26.2µs ± 2%  23.3µs ± 1%  -11.02%  (p=0.008 n=5+5)
Phases/planning1/Explore  10.6µs ± 1%   8.5µs ± 0%  -19.96%  (p=0.008 n=5+5)
Phases/planning2/Explore  31.9µs ± 2%  28.7µs ± 4%  -10.12%  (p=0.008 n=5+5)
Phases/planning3/Explore  34.6µs ± 2%  31.9µs ± 4%   -7.87%  (p=0.008 n=5+5)
Phases/planning4/Explore  42.1µs ± 2%  38.6µs ± 2%   -8.37%  (p=0.008 n=5+5)
Phases/planning5/Explore  34.0µs ± 1%  30.8µs ± 1%   -9.44%  (p=0.008 n=5+5)
Phases/planning6/Explore  57.8µs ± 2%  54.3µs ± 2%   -6.11%  (p=0.008 n=5+5)
```

Release note: None