### PR TITLE
roachtest: fix acceptance/decommission on remote clusters

### DIFF
--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -255,7 +255,7 @@ func runDecommissionAcceptance(ctx context.Context, t *test, c *cluster) {
 		runNode int,
 		extraArgs ...string,
 	) (string, error) {
-		args := []string{cockroach}
+		args := []string{"./cockroach"}
 		args = append(args, extraArgs...)
 		args = append(args, "--insecure")
 		args = append(args, fmt.Sprintf("--port={pgport:%d}", runNode))


### PR DESCRIPTION
The test was using the local binary path for running CLI commands, which
works on local clusters but not on remote ones.

Fixes #29570

Release note: None