### PR TITLE
storage: re-enable the merge queue by default

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -31,7 +31,7 @@
 <tr><td><code>kv.raft_log.synchronize</code></td><td>boolean</td><td><code>true</code></td><td>set to true to synchronize on Raft log writes to persistent storage ('false' risks data loss)</td></tr>
 <tr><td><code>kv.range.backpressure_range_size_multiplier</code></td><td>float</td><td><code>2</code></td><td>multiple of range_max_bytes that a range is allowed to grow to without splitting before writes to that range are blocked, or 0 to disable</td></tr>
 <tr><td><code>kv.range_descriptor_cache.size</code></td><td>integer</td><td><code>1000000</code></td><td>maximum number of entries in the range descriptor and leaseholder caches</td></tr>
-<tr><td><code>kv.range_merge.queue_enabled</code></td><td>boolean</td><td><code>false</code></td><td>whether the automatic merge queue is enabled</td></tr>
+<tr><td><code>kv.range_merge.queue_enabled</code></td><td>boolean</td><td><code>true</code></td><td>whether the automatic merge queue is enabled</td></tr>
 <tr><td><code>kv.rangefeed.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, rangefeed registration is enabled</td></tr>
 <tr><td><code>kv.snapshot_rebalance.max_rate</code></td><td>byte size</td><td><code>2.0 MiB</code></td><td>the rate limit (bytes/sec) to use for rebalance snapshots</td></tr>
 <tr><td><code>kv.snapshot_recovery.max_rate</code></td><td>byte size</td><td><code>8.0 MiB</code></td><td>the rate limit (bytes/sec) to use for recovery snapshots</td></tr>

--- a/pkg/cmd/roachtest/bank.go
+++ b/pkg/cmd/roachtest/bank.go
@@ -289,7 +289,11 @@ func (s *bankState) splitMonkey(ctx context.Context, d time.Duration, c *cluster
 			key := zipF.Uint64()
 			const splitQuery = `ALTER TABLE bank.accounts SPLIT AT VALUES ($1)`
 			c.l.Printf("round %d: splitting key %v\n", curRound, key)
-			_, err := client.db.Exec(splitQuery, key)
+			_, err := client.db.Exec(`SET experimental_force_split_at = true`)
+			if err != nil && !testutils.IsSQLRetryableError(err) {
+				s.errChan <- err
+			}
+			_, err = client.db.Exec(splitQuery, key)
 			if err != nil && !(testutils.IsSQLRetryableError(err) || isExpectedRelocateError(err)) {
 				s.errChan <- err
 			}

--- a/pkg/sql/distsqlplan/span_resolver_test.go
+++ b/pkg/sql/distsqlplan/span_resolver_test.go
@@ -316,6 +316,11 @@ func TestMixedDirections(t *testing.T) {
 func setupRanges(
 	db *gosql.DB, s *server.TestServer, cdb *client.DB, t *testing.T,
 ) ([]roachpb.RangeDescriptor, *sqlbase.TableDescriptor) {
+	// Prevent the merge queue from immediately discarding our splits.
+	if _, err := db.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false"); err != nil {
+		t.Fatal(err)
+	}
+
 	if _, err := db.Exec(`CREATE DATABASE t`); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -346,6 +346,7 @@ ORDER BY "timestamp"
 ----
 0  1  {"SettingName":"diagnostics.reporting.enabled","Value":"true","User":"root"}
 0  1  {"SettingName":"trace.debug.enable","Value":"false","User":"root"}
+0  1  {"SettingName":"kv.range_merge.queue_enabled","Value":"false","User":"root"}
 0  1  {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"false","User":"root"}
 0  1  {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"DEFAULT","User":"root"}
 0  1  {"SettingName":"cluster.organization","Value":"'some string'","User":"root"}

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -428,6 +428,7 @@ ORDER BY name
 ----
 cluster.secret
 diagnostics.reporting.enabled
+kv.range_merge.queue_enabled
 trace.debug.enable
 version
 
@@ -441,6 +442,7 @@ WHERE name NOT IN ('version', 'sql.defaults.distsql', 'cluster.secret')
 ORDER BY name
 ----
 diagnostics.reporting.enabled  true
+kv.range_merge.queue_enabled   false
 somesetting                    somevalue
 trace.debug.enable             false
 

--- a/pkg/storage/log_test.go
+++ b/pkg/storage/log_test.go
@@ -21,8 +21,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
-
 	_ "github.com/lib/pq"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -31,6 +29,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -149,7 +149,13 @@ func TestLogMerges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Store: &storagebase.StoreTestingKnobs{
+				DisableMergeQueue: true,
+			},
+		},
+	})
 	defer s.Stopper().Stop(ctx)
 
 	ts := s.(*server.TestServer)

--- a/pkg/storage/storagebase/base.go
+++ b/pkg/storage/storagebase/base.go
@@ -31,7 +31,7 @@ import (
 var MergeQueueEnabled = settings.RegisterBoolSetting(
 	"kv.range_merge.queue_enabled",
 	"whether the automatic merge queue is enabled",
-	false,
+	true,
 )
 
 // TxnCleanupThreshold is the threshold after which a transaction is

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -1463,7 +1463,9 @@ func TestStoreSetRangesMaxBytes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
-	store, _ := createTestStore(t, stopper)
+	cfg := TestStoreConfig(nil)
+	cfg.TestingKnobs.DisableMergeQueue = true
+	store := createTestStoreWithConfig(t, stopper, &cfg)
 
 	baseID := uint32(keys.MinUserDescID)
 	testData := []struct {

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -251,6 +251,19 @@ func (tc *TestCluster) doAddServer(t testing.TB, serverArgs base.TestServerArgs)
 	}
 
 	s, conn, _ := serverutils.StartServer(t, serverArgs)
+
+	if tc.replicationMode == base.ReplicationManual && len(tc.Servers) == 0 {
+		// We've already disabled the merge queue via testing knobs above, but ALTER
+		// TABLE ... SPLIT AT will throw an error unless we also disable merges via
+		// the cluster setting.
+		//
+		// TODO(benesch): this won't be necessary once we have sticky bits for
+		// splits.
+		if _, err := conn.Exec(`SET CLUSTER SETTING kv.range_merge.queue_enabled = false`); err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	tc.Servers = append(tc.Servers, s.(*server.TestServer))
 	tc.Conns = append(tc.Conns, conn)
 	tc.mu.Lock()


### PR DESCRIPTION
This reverts commit a1cc4c5540501f570db0b46b6f8adfed788b86e1.

The results from last night's stress run on were extremely promising. All the failures were existing flaky tests. You can see for yourself here:

https://teamcity.cockroachdb.com/viewType.html?buildTypeId=Cockroach_Nightlies_Stress&tab=buildTypeStatusDiv&branch_Cockroach_Nightlies=refs%2Fheads%2Fmerge-default&state=failed