### PR TITLE
backport-2.1: sql: use octal instead of hex in arrays and tuples

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -85,7 +85,7 @@ SELECT ARRAY['one', 'two', 'fünf']
 query T
 SELECT ARRAY[e'\n', e'g\x10h']
 ----
-{"\x0a","g\x10h"}
+{"\012","g\020h"}
 
 query T
 SELECT ARRAY['foo', 'bar']
@@ -161,6 +161,27 @@ SELECT '{hello}'::VARCHAR(2)[]
 {"he"}
 
 # array casting
+
+query T
+SELECT ARRAY['foo']::STRING
+----
+{"foo"}
+
+query T
+SELECT ARRAY[e'foo\nbar']::STRING
+----
+{"foo\012bar"}
+
+query TTTTTT
+SELECT
+  ARRAY[e'foo\000bar']::STRING,
+  ARRAY[e'foo\001bar']::STRING,
+  ARRAY[e'foo\002bar']::STRING,
+  ARRAY[e'foo\030bar']::STRING,
+  ARRAY[e'foo\034bar']::STRING,
+  ARRAY[e'foo\100bar']::STRING
+----
+{"foo\000bar"}  {"foo\001bar"}  {"foo\002bar"}  {"foo\030bar"}  {"foo\034bar"}  {"foo@bar"}
 
 query T
 SELECT ARRAY[1,2,3]::INT[]

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -29,6 +29,11 @@ SELECT (1, 2, 'hello', NULL, NULL) AS t, (true, NULL, (false, 6.6, false)) AS u 
 t                u
 (1,2,"hello",,)  (t,,"(f,6.6,f)")
 
+query T
+SELECT (1, e'hello\nworld')
+----
+(1,"hello\012world")
+
 query BBBBBBBBB colnames
 SELECT
   (2, 2) < (1, 1) AS a,

--- a/pkg/util/stringencoding/string_encoding.go
+++ b/pkg/util/stringencoding/string_encoding.go
@@ -41,6 +41,8 @@ var (
 	HexMap [256][]byte
 	// RawHexMap is a mapping from each byte to the `%%` hex form as a []byte.
 	RawHexMap [256][]byte
+	// OctalMap is a mapping from each byte to the `\%%%` octal form as a []byte.
+	OctalMap [256][]byte
 )
 
 func init() {
@@ -79,6 +81,24 @@ func init() {
 		HexMap[i] = underlyingHexBytes[i*4 : i*4+4]
 		RawHexMap[i] = underlyingHexBytes[i*4+2 : i*4+4]
 	}
+
+	// underlyingOctalMap contains the string "\000\001\002..." which OctalMap
+	// then indexes into.
+	var underlyingOctalMap bytes.Buffer
+	underlyingOctalMap.Grow(1024)
+
+	for i := 0; i < 256; i++ {
+		underlyingOctalMap.WriteByte('\\')
+		writeHexDigit(&underlyingOctalMap, i/64)
+		writeHexDigit(&underlyingOctalMap, (i/8)%8)
+		writeHexDigit(&underlyingOctalMap, i%8)
+	}
+
+	underlyingOctalBytes := underlyingOctalMap.Bytes()
+
+	for i := 0; i < 256; i++ {
+		OctalMap[i] = underlyingOctalBytes[i*4 : i*4+4]
+	}
 }
 
 // EncodeChar is used internally to write out a character from
@@ -88,13 +108,13 @@ func EncodeChar(buf *bytes.Buffer, entireString string, currentRune rune, curren
 	if currentRune == utf8.RuneError {
 		// Errors are due to invalid unicode points, so escape the bytes.
 		// Make sure this is run at least once in case ln == -1.
-		buf.Write(HexMap[entireString[currentIdx]])
+		buf.Write(OctalMap[entireString[currentIdx]])
 		for ri := 1; ri < ln; ri++ {
-			buf.Write(HexMap[entireString[currentIdx+ri]])
+			buf.Write(OctalMap[entireString[currentIdx+ri]])
 		}
 	} else if ln == 1 {
 		// Escape non-printable characters.
-		buf.Write(HexMap[byte(currentRune)])
+		buf.Write(OctalMap[byte(currentRune)])
 	} else if ln == 2 {
 		// For multi-byte runes, print them based on their width.
 		fmt.Fprintf(buf, `\u%04X`, currentRune)


### PR DESCRIPTION
Backport 1/1 commits from #29558.

/cc @cockroachdb/release

---

Fixes #29483.

Release note (bug fix): Previously special characters such as newlines
would be formatted using hex, which is different from Postgres. This
change formats them using octal, matching Postgres.
