### PR TITLE
release-2.1: opt: Improve list and optbuilder perf

### DIFF
--- a/pkg/sql/opt/memo/list_storage.go
+++ b/pkg/sql/opt/memo/list_storage.go
@@ -72,22 +72,65 @@ var EmptyList = ListID{Offset: 1, Length: 0}
 //   [2 3 4]: ListID{Offset: 3, Length: 3}
 //   [2 4]  : ListID{Offset: 6, Length: 2}
 //
+// The entire prefix tree is stored in a single Go map, using 8 byte keys and
+// values, which are highly optimized in Go. Each map entry is an edge in the
+// prefix tree, connecting a list to another list that has it as a prefix, but
+// with one additional item appended.
+//
 type listStorage struct {
-	// index maps the path of each node in the prefix tree to an Offset value
-	// (biased index of the list in the lists slice). See listStorageKey comment
-	// for more details about node path format.
-	index map[listStorageKey]uint32
+	// index encodes the list of edges in the prefix tree. Given a (nodeID, item)
+	// pair, the index can lookup the node (i.e. the list) which has the same
+	// elements, except with the item appended to the end. The index maps to an
+	// offset value in the lists slice where the larger list is stored. See
+	// listStorageKey comment for more details.
+	index map[listStorageKey]listStorageVal
 	lists []GroupID
+
+	// unique is an increasing counter that's used to generate unique ids for
+	// nodes in the prefix tree.
+	unique nodeID
 }
 
-// listStorageKey is the path to a node in the prefix tree. The path is a
-// (prefix, item) pair, where prefix is the list of edges from root to parent
-// node, and item is the last edge from parent to child. This representation is
-// a legal and efficient map key type, and it allows the entire prefix tree to
-// be stored in a map, which are highly optimized in Go.
+// nodeID is the unique index of a node in the prefix tree. Each node in the
+// tree corresponds to a list having a particular sequence of items. The prefix
+// tree "interns" all lists with that sequence of items, so that they are mapped
+// to the same nodeID.
+type nodeID uint32
+
+// listStorageKey represents an edge in the prefix tree, linking one node that
+// corresponds to a unique list of items, to another node that corresponds to
+// that list plus one appended item. For example, the list (10, 20, 30) could be
+// represented as the following chain:
+//
+//   (node: 0, item: 10) => (node: 1, offset: 1)
+//   (node: 1, item: 20) => (node: 2, offset: 1)
+//   (node: 2, item: 30) => (node: 3, offset: 1)
+//
+// This representation fits in 8 bytes, and so allows Go to use the
+// mapaccess1_fast64 function for fast lookups.
 type listStorageKey struct {
-	prefix ListID
-	item   GroupID
+	// node is the id of a node in the prefix tree, which corresponds to a list
+	// with a unique sequence of items.
+	node nodeID
+
+	// item links to another node in the prefix tree which corresponds to a list
+	// with the same sequence of items, except with this item appended to it.
+	item GroupID
+}
+
+// listStorageVal represents a node in the prefix tree, having a unique id and
+// the offset of the node's list in the "lists" slice.
+type listStorageVal struct {
+	// node is the id of a node in the prefix tree, which corresponds to a list
+	// with a unique sequence of items. This id can be used in a listStorageKey
+	// to look up lists that are one greater in length, and that have this node's
+	// list as a prefix.
+	node nodeID
+
+	// offset stores the offset of the node's list in the "lists" slice. The
+	// offset is 1-based, so to index into the slice, first subtract one from
+	// this value (0 is reserved to mean "undefined" list).
+	offset uint32
 }
 
 // intern adds the given list to storage and returns an id that can later be
@@ -96,28 +139,30 @@ type listStorageKey struct {
 // that was returned from the previous call. intern is an O(N) operation, where
 // N is the length of the list.
 func (ls *listStorage) intern(list []GroupID) ListID {
-	// Start with empty prefix.
-	prefix := EmptyList
-
-	if ls.index == nil {
-		ls.index = make(map[listStorageKey]uint32)
+	if len(list) == 0 {
+		return EmptyList
 	}
 
+	if ls.index == nil {
+		ls.index = make(map[listStorageKey]listStorageVal)
+	}
+
+	var val listStorageVal
 	for i, item := range list {
 		// Is there an existing list for the prefix + next item?
-		key := listStorageKey{prefix: prefix, item: item}
+		key := listStorageKey{node: val.node, item: item}
 		existing := ls.index[key]
-		if existing == 0 {
+		if existing.offset == 0 {
 			// No, so append the list now.
-			return ls.appendList(prefix, list)
+			return ls.appendList(val, i, list)
 		}
 
-		// Yes, so set the new prefix and keep looping.
-		prefix = ListID{Offset: existing, Length: uint32(i + 1)}
+		// Yes, so keep looping.
+		val = existing
 	}
 
 	// Found an existing list, so return it.
-	return prefix
+	return ListID{Offset: val.offset, Length: uint32(len(list))}
 }
 
 // lookup returns a list that was previously interned by listStorage. Do not
@@ -128,24 +173,25 @@ func (ls *listStorage) lookup(id ListID) []GroupID {
 	return ls.lists[id.Offset-1 : id.Offset+id.Length-1]
 }
 
-func (ls *listStorage) appendList(prefix ListID, list []GroupID) ListID {
+func (ls *listStorage) appendList(val listStorageVal, prefixLen int, list []GroupID) ListID {
 	var offset uint32
 
 	// If prefix is the last list in the slice, then optimize by appending only
 	// the suffix.
-	if prefix.Offset+prefix.Length-1 == uint32(len(ls.lists)) {
-		offset = prefix.Offset
-		ls.lists = append(ls.lists, list[prefix.Length:]...)
+	if int(val.offset)+prefixLen-1 == len(ls.lists) {
+		offset = val.offset
+		ls.lists = append(ls.lists, list[prefixLen:]...)
 	} else {
 		offset = uint32(len(ls.lists)) + 1
 		ls.lists = append(ls.lists, list...)
 	}
 
 	// Add rest of list to the index (prefix is already in the index).
-	for i := prefix.Length; i < uint32(len(list)); i++ {
-		key := listStorageKey{prefix: prefix, item: list[i]}
-		ls.index[key] = offset
-		prefix = ListID{Offset: offset, Length: i + 1}
+	for i := prefixLen; i < len(list); i++ {
+		key := listStorageKey{node: val.node, item: list[i]}
+		ls.unique++
+		val.node = ls.unique
+		ls.index[key] = listStorageVal{node: val.node, offset: offset}
 	}
 
 	return ListID{Offset: offset, Length: uint32(len(list))}

--- a/pkg/sql/opt/memo/list_storage_test.go
+++ b/pkg/sql/opt/memo/list_storage_test.go
@@ -68,6 +68,10 @@ func TestListStorage(t *testing.T) {
 	if s := groupsToString(ls.lookup(catalogID)); s != "catalog" {
 		t.Fatalf("unexpected lookup: %v", s)
 	}
+
+	if s := groupsToString(ls.lookup(catalogingID)); s != "cataloging" {
+		t.Fatalf("unexpected lookup: %v", s)
+	}
 }
 
 func stringToGroups(s string) []GroupID {

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -20,8 +20,7 @@ project
       │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
       ├── scan onecolumn
       │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
-      └── filters [type=bool]
-           └── true [type=bool]
+      └── true [type=bool]
 
 # Check that name resolution chokes on ambiguity when it needs to.
 build
@@ -149,6 +148,26 @@ SELECT * FROM onecolumn AS a, onecolumn AS b ORDER BY x
 error (42P09): ORDER BY "x" is ambiguous
 
 build
+SELECT * FROM (SELECT x, x FROM onecolumn) AS a JOIN onecolumn AS b USING (x)
+----
+error (42701): duplicate column name: "x"
+
+build
+SELECT * FROM onecolumn AS a JOIN (SELECT x, x FROM onecolumn) AS b USING (x)
+----
+error (42701): duplicate column name: "x"
+
+build
+SELECT * FROM (SELECT x, x FROM onecolumn) AS a NATURAL JOIN onecolumn AS b
+----
+error (42701): duplicate column name: "x"
+
+build
+SELECT * FROM onecolumn AS a NATURAL JOIN (SELECT x, x FROM onecolumn) AS b
+----
+error (42701): duplicate column name: "x"
+
+build
 SELECT * FROM onecolumn AS a NATURAL LEFT OUTER JOIN onecolumn AS b
 ----
 project
@@ -236,7 +255,6 @@ project
       ├── scan onecolumn_w
       │    └── columns: w:3(int) onecolumn_w.rowid:4(int!null)
       └── filters [type=bool]
-           └── true [type=bool]
 
 exec-ddl
 CREATE TABLE othercolumn (x INT)
@@ -388,8 +406,7 @@ project
       │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
       ├── scan empty
       │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
-      └── filters [type=bool]
-           └── true [type=bool]
+      └── true [type=bool]
 
 build
 SELECT * FROM empty AS a CROSS JOIN onecolumn AS b
@@ -402,8 +419,7 @@ project
       │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
       ├── scan onecolumn
       │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
-      └── filters [type=bool]
-           └── true [type=bool]
+      └── true [type=bool]
 
 build
 SELECT * FROM onecolumn AS a(x) JOIN empty AS b(y) ON a.x = b.y
@@ -1013,8 +1029,7 @@ limit
  │              │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │              │    │    ├── scan twocolumn
  │              │    │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
- │              │    │    └── filters [type=bool]
- │              │    │         └── true [type=bool]
+ │              │    │    └── true [type=bool]
  │              │    ├── scan onecolumn
  │              │    │    └── columns: onecolumn.x:6(int) onecolumn.rowid:7(int!null)
  │              │    └── filters [type=bool]
@@ -1699,13 +1714,12 @@ project
       ├── scan t2
       │    └── columns: col3:6(int) t2.y:7(int) t2.x:8(int) col4:9(int) t2.rowid:10(int!null)
       └── filters [type=bool]
-           └── and [type=bool]
-                ├── eq [type=bool]
-                │    ├── variable: t1.x [type=int]
-                │    └── variable: t2.x [type=int]
-                └── eq [type=bool]
-                     ├── variable: t1.y [type=int]
-                     └── variable: t2.y [type=int]
+           ├── eq [type=bool]
+           │    ├── variable: t1.x [type=int]
+           │    └── variable: t2.x [type=int]
+           └── eq [type=bool]
+                ├── variable: t1.y [type=int]
+                └── variable: t2.y [type=int]
 
 build
 SELECT x, t1.x, t2.x FROM t1 NATURAL JOIN t2
@@ -1719,13 +1733,12 @@ project
       ├── scan t2
       │    └── columns: col3:6(int) t2.y:7(int) t2.x:8(int) col4:9(int) t2.rowid:10(int!null)
       └── filters [type=bool]
-           └── and [type=bool]
-                ├── eq [type=bool]
-                │    ├── variable: t1.x [type=int]
-                │    └── variable: t2.x [type=int]
-                └── eq [type=bool]
-                     ├── variable: t1.y [type=int]
-                     └── variable: t2.y [type=int]
+           ├── eq [type=bool]
+           │    ├── variable: t1.x [type=int]
+           │    └── variable: t2.x [type=int]
+           └── eq [type=bool]
+                ├── variable: t1.y [type=int]
+                └── variable: t2.y [type=int]
 
 build
 SELECT t1.*, t2.* FROM t1 NATURAL JOIN t2
@@ -1739,13 +1752,12 @@ project
       ├── scan t2
       │    └── columns: col3:6(int) t2.y:7(int) t2.x:8(int) col4:9(int) t2.rowid:10(int!null)
       └── filters [type=bool]
-           └── and [type=bool]
-                ├── eq [type=bool]
-                │    ├── variable: t1.x [type=int]
-                │    └── variable: t2.x [type=int]
-                └── eq [type=bool]
-                     ├── variable: t1.y [type=int]
-                     └── variable: t2.y [type=int]
+           ├── eq [type=bool]
+           │    ├── variable: t1.x [type=int]
+           │    └── variable: t2.x [type=int]
+           └── eq [type=bool]
+                ├── variable: t1.y [type=int]
+                └── variable: t2.y [type=int]
 
 build
 SELECT * FROM t1 JOIN t2 ON t2.x=t1.x
@@ -1799,13 +1811,12 @@ project
       │    ├── scan t2
       │    │    └── columns: col3:6(int) t2.y:7(int) t2.x:8(int) col4:9(int) t2.rowid:10(int!null)
       │    └── filters [type=bool]
-      │         └── and [type=bool]
-      │              ├── eq [type=bool]
-      │              │    ├── variable: t1.x [type=int]
-      │              │    └── variable: t2.x [type=int]
-      │              └── eq [type=bool]
-      │                   ├── variable: t1.y [type=int]
-      │                   └── variable: t2.y [type=int]
+      │         ├── eq [type=bool]
+      │         │    ├── variable: t1.x [type=int]
+      │         │    └── variable: t2.x [type=int]
+      │         └── eq [type=bool]
+      │              ├── variable: t1.y [type=int]
+      │              └── variable: t2.y [type=int]
       └── projections
            ├── coalesce [type=int]
            │    ├── variable: t1.x [type=int]
@@ -1916,13 +1927,12 @@ project
       │    └── scan t2
       │         └── columns: col3:6(int) t2.y:7(int) t2.x:8(int) col4:9(int) t2.rowid:10(int!null)
       └── filters [type=bool]
-           └── and [type=bool]
-                ├── eq [type=bool]
-                │    ├── variable: t1.x [type=int]
-                │    └── variable: t2.x [type=int]
-                └── eq [type=bool]
-                     ├── variable: t1.y [type=int]
-                     └── variable: t2.y [type=int]
+           ├── eq [type=bool]
+           │    ├── variable: t1.x [type=int]
+           │    └── variable: t2.x [type=int]
+           └── eq [type=bool]
+                ├── variable: t1.y [type=int]
+                └── variable: t2.y [type=int]
 
 # Tests for merge join ordering information.
 exec-ddl
@@ -2009,19 +2019,18 @@ project
       ├── scan pkbad
       │    └── columns: pkbad.a:5(int!null) pkbad.b:6(int!null) pkbad.c:7(int) pkbad.d:8(int!null)
       └── filters [type=bool]
-           └── and [type=bool]
-                ├── eq [type=bool]
-                │    ├── variable: pkba.a [type=int]
-                │    └── variable: pkbad.a [type=int]
-                ├── eq [type=bool]
-                │    ├── variable: pkba.b [type=int]
-                │    └── variable: pkbad.b [type=int]
-                ├── eq [type=bool]
-                │    ├── variable: pkba.c [type=int]
-                │    └── variable: pkbad.c [type=int]
-                └── eq [type=bool]
-                     ├── variable: pkba.d [type=int]
-                     └── variable: pkbad.d [type=int]
+           ├── eq [type=bool]
+           │    ├── variable: pkba.a [type=int]
+           │    └── variable: pkbad.a [type=int]
+           ├── eq [type=bool]
+           │    ├── variable: pkba.b [type=int]
+           │    └── variable: pkbad.b [type=int]
+           ├── eq [type=bool]
+           │    ├── variable: pkba.c [type=int]
+           │    └── variable: pkbad.c [type=int]
+           └── eq [type=bool]
+                ├── variable: pkba.d [type=int]
+                └── variable: pkbad.d [type=int]
 
 build
 SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
@@ -2035,16 +2044,15 @@ project
       ├── scan pkbac
       │    └── columns: pkbac.a:5(int!null) pkbac.b:6(int!null) pkbac.c:7(int!null) pkbac.d:8(int)
       └── filters [type=bool]
-           └── and [type=bool]
-                ├── eq [type=bool]
-                │    ├── variable: pkbac.a [type=int]
-                │    └── variable: pkbac.a [type=int]
-                ├── eq [type=bool]
-                │    ├── variable: pkbac.b [type=int]
-                │    └── variable: pkbac.b [type=int]
-                └── eq [type=bool]
-                     ├── variable: pkbac.c [type=int]
-                     └── variable: pkbac.c [type=int]
+           ├── eq [type=bool]
+           │    ├── variable: pkbac.a [type=int]
+           │    └── variable: pkbac.a [type=int]
+           ├── eq [type=bool]
+           │    ├── variable: pkbac.b [type=int]
+           │    └── variable: pkbac.b [type=int]
+           └── eq [type=bool]
+                ├── variable: pkbac.c [type=int]
+                └── variable: pkbac.c [type=int]
 
 build
 SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a = r.a AND l.b = r.b
@@ -2179,13 +2187,12 @@ project
       │    ├── scan str2
       │    │    └── columns: str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
       │    └── filters [type=bool]
-      │         └── and [type=bool]
-      │              ├── eq [type=bool]
-      │              │    ├── variable: str1.a [type=int]
-      │              │    └── variable: str2.a [type=int]
-      │              └── eq [type=bool]
-      │                   ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
-      │                   └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+      │         ├── eq [type=bool]
+      │         │    ├── variable: str1.a [type=int]
+      │         │    └── variable: str2.a [type=int]
+      │         └── eq [type=bool]
+      │              ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
+      │              └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
       └── projections
            └── coalesce [type=collatedstring{en_u_ks_level1}]
                 ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
@@ -2230,13 +2237,12 @@ project
       │    ├── scan xyv
       │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) v:6(int!null)
       │    └── filters [type=bool]
-      │         └── and [type=bool]
-      │              ├── eq [type=bool]
-      │              │    ├── variable: xyu.x [type=int]
-      │              │    └── variable: xyv.x [type=int]
-      │              └── eq [type=bool]
-      │                   ├── variable: xyu.y [type=int]
-      │                   └── variable: xyv.y [type=int]
+      │         ├── eq [type=bool]
+      │         │    ├── variable: xyu.x [type=int]
+      │         │    └── variable: xyv.x [type=int]
+      │         └── eq [type=bool]
+      │              ├── variable: xyu.y [type=int]
+      │              └── variable: xyv.y [type=int]
       └── filters [type=bool]
            └── gt [type=bool]
                 ├── variable: xyu.x [type=int]
@@ -2256,13 +2262,12 @@ project
       │    ├── scan xyv
       │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) v:6(int!null)
       │    └── filters [type=bool]
-      │         └── and [type=bool]
-      │              ├── eq [type=bool]
-      │              │    ├── variable: xyu.x [type=int]
-      │              │    └── variable: xyv.x [type=int]
-      │              └── eq [type=bool]
-      │                   ├── variable: xyu.y [type=int]
-      │                   └── variable: xyv.y [type=int]
+      │         ├── eq [type=bool]
+      │         │    ├── variable: xyu.x [type=int]
+      │         │    └── variable: xyv.x [type=int]
+      │         └── eq [type=bool]
+      │              ├── variable: xyu.y [type=int]
+      │              └── variable: xyv.y [type=int]
       └── filters [type=bool]
            └── gt [type=bool]
                 ├── variable: xyu.x [type=int]
@@ -2282,13 +2287,12 @@ project
       │    ├── scan xyv
       │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) v:6(int!null)
       │    └── filters [type=bool]
-      │         └── and [type=bool]
-      │              ├── eq [type=bool]
-      │              │    ├── variable: xyu.x [type=int]
-      │              │    └── variable: xyv.x [type=int]
-      │              └── eq [type=bool]
-      │                   ├── variable: xyu.y [type=int]
-      │                   └── variable: xyv.y [type=int]
+      │         ├── eq [type=bool]
+      │         │    ├── variable: xyu.x [type=int]
+      │         │    └── variable: xyv.x [type=int]
+      │         └── eq [type=bool]
+      │              ├── variable: xyu.y [type=int]
+      │              └── variable: xyv.y [type=int]
       └── filters [type=bool]
            └── gt [type=bool]
                 ├── variable: xyv.x [type=int]
@@ -2310,13 +2314,12 @@ project
       │    │    ├── scan xyv
       │    │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) v:6(int!null)
       │    │    └── filters [type=bool]
-      │    │         └── and [type=bool]
-      │    │              ├── eq [type=bool]
-      │    │              │    ├── variable: xyu.x [type=int]
-      │    │              │    └── variable: xyv.x [type=int]
-      │    │              └── eq [type=bool]
-      │    │                   ├── variable: xyu.y [type=int]
-      │    │                   └── variable: xyv.y [type=int]
+      │    │         ├── eq [type=bool]
+      │    │         │    ├── variable: xyu.x [type=int]
+      │    │         │    └── variable: xyv.x [type=int]
+      │    │         └── eq [type=bool]
+      │    │              ├── variable: xyu.y [type=int]
+      │    │              └── variable: xyv.y [type=int]
       │    └── projections
       │         ├── coalesce [type=int]
       │         │    ├── variable: xyu.x [type=int]
@@ -2453,13 +2456,12 @@ project
       │    ├── scan xyv
       │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) v:6(int!null)
       │    └── filters [type=bool]
-      │         └── and [type=bool]
-      │              ├── eq [type=bool]
-      │              │    ├── variable: xyu.x [type=int]
-      │              │    └── variable: xyv.x [type=int]
-      │              └── eq [type=bool]
-      │                   ├── variable: xyu.y [type=int]
-      │                   └── variable: xyv.y [type=int]
+      │         ├── eq [type=bool]
+      │         │    ├── variable: xyu.x [type=int]
+      │         │    └── variable: xyv.x [type=int]
+      │         └── eq [type=bool]
+      │              ├── variable: xyu.y [type=int]
+      │              └── variable: xyv.y [type=int]
       └── filters [type=bool]
            └── gt [type=bool]
                 ├── variable: xyu.x [type=int]
@@ -2479,13 +2481,12 @@ project
       │    ├── scan xyv
       │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) v:6(int!null)
       │    └── filters [type=bool]
-      │         └── and [type=bool]
-      │              ├── eq [type=bool]
-      │              │    ├── variable: xyu.x [type=int]
-      │              │    └── variable: xyv.x [type=int]
-      │              └── eq [type=bool]
-      │                   ├── variable: xyu.y [type=int]
-      │                   └── variable: xyv.y [type=int]
+      │         ├── eq [type=bool]
+      │         │    ├── variable: xyu.x [type=int]
+      │         │    └── variable: xyv.x [type=int]
+      │         └── eq [type=bool]
+      │              ├── variable: xyu.y [type=int]
+      │              └── variable: xyv.y [type=int]
       └── filters [type=bool]
            └── gt [type=bool]
                 ├── variable: xyv.x [type=int]
@@ -2507,13 +2508,12 @@ project
       │    │    ├── scan xyv
       │    │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) v:6(int!null)
       │    │    └── filters [type=bool]
-      │    │         └── and [type=bool]
-      │    │              ├── eq [type=bool]
-      │    │              │    ├── variable: xyu.x [type=int]
-      │    │              │    └── variable: xyv.x [type=int]
-      │    │              └── eq [type=bool]
-      │    │                   ├── variable: xyu.y [type=int]
-      │    │                   └── variable: xyv.y [type=int]
+      │    │         ├── eq [type=bool]
+      │    │         │    ├── variable: xyu.x [type=int]
+      │    │         │    └── variable: xyv.x [type=int]
+      │    │         └── eq [type=bool]
+      │    │              ├── variable: xyu.y [type=int]
+      │    │              └── variable: xyv.y [type=int]
       │    └── projections
       │         ├── coalesce [type=int]
       │         │    ├── variable: xyu.x [type=int]
@@ -2593,13 +2593,12 @@ project
       │    ├── scan xyv
       │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) v:6(int!null)
       │    └── filters [type=bool]
-      │         └── and [type=bool]
-      │              ├── eq [type=bool]
-      │              │    ├── variable: xyu.x [type=int]
-      │              │    └── variable: xyv.x [type=int]
-      │              └── eq [type=bool]
-      │                   ├── variable: xyu.y [type=int]
-      │                   └── variable: xyv.y [type=int]
+      │         ├── eq [type=bool]
+      │         │    ├── variable: xyu.x [type=int]
+      │         │    └── variable: xyv.x [type=int]
+      │         └── eq [type=bool]
+      │              ├── variable: xyu.y [type=int]
+      │              └── variable: xyv.y [type=int]
       └── filters [type=bool]
            └── gt [type=bool]
                 ├── tuple [type=tuple{int, int, int}]
@@ -2769,13 +2768,12 @@ project
       │    ├── scan abg
       │    │    └── columns: abg.a:7(int!null) abg.b:8(int!null) g:9(int)
       │    └── filters [type=bool]
-      │         └── and [type=bool]
-      │              ├── eq [type=bool]
-      │              │    ├── variable: abcdef.a [type=int]
-      │              │    └── variable: abg.a [type=int]
-      │              └── eq [type=bool]
-      │                   ├── variable: abcdef.b [type=int]
-      │                   └── variable: abg.b [type=int]
+      │         ├── eq [type=bool]
+      │         │    ├── variable: abcdef.a [type=int]
+      │         │    └── variable: abg.a [type=int]
+      │         └── eq [type=bool]
+      │              ├── variable: abcdef.b [type=int]
+      │              └── variable: abg.b [type=int]
       └── filters [type=bool]
            └── or [type=bool]
                 ├── or [type=bool]
@@ -2859,19 +2857,18 @@ project
       ├── scan bar
       │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
       └── filters [type=bool]
-           └── and [type=bool]
-                ├── eq [type=bool]
-                │    ├── variable: foo.a [type=int]
-                │    └── variable: bar.a [type=int]
-                ├── eq [type=bool]
-                │    ├── variable: foo.b [type=int]
-                │    └── variable: bar.b [type=float]
-                ├── eq [type=bool]
-                │    ├── variable: foo.c [type=float]
-                │    └── variable: bar.c [type=float]
-                └── eq [type=bool]
-                     ├── variable: foo.d [type=float]
-                     └── variable: bar.d [type=int]
+           ├── eq [type=bool]
+           │    ├── variable: foo.a [type=int]
+           │    └── variable: bar.a [type=int]
+           ├── eq [type=bool]
+           │    ├── variable: foo.b [type=int]
+           │    └── variable: bar.b [type=float]
+           ├── eq [type=bool]
+           │    ├── variable: foo.c [type=float]
+           │    └── variable: bar.c [type=float]
+           └── eq [type=bool]
+                ├── variable: foo.d [type=float]
+                └── variable: bar.d [type=int]
 
 # b can't be an equality column.
 build
@@ -2903,13 +2900,12 @@ project
       ├── scan bar
       │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
       └── filters [type=bool]
-           └── and [type=bool]
-                ├── eq [type=bool]
-                │    ├── variable: foo.a [type=int]
-                │    └── variable: bar.a [type=int]
-                └── eq [type=bool]
-                     ├── variable: foo.b [type=int]
-                     └── variable: bar.b [type=float]
+           ├── eq [type=bool]
+           │    ├── variable: foo.a [type=int]
+           │    └── variable: bar.a [type=int]
+           └── eq [type=bool]
+                ├── variable: foo.b [type=int]
+                └── variable: bar.b [type=float]
 
 # Only a and c can be equality columns.
 build
@@ -2924,16 +2920,15 @@ project
       ├── scan bar
       │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
       └── filters [type=bool]
-           └── and [type=bool]
-                ├── eq [type=bool]
-                │    ├── variable: foo.a [type=int]
-                │    └── variable: bar.a [type=int]
-                ├── eq [type=bool]
-                │    ├── variable: foo.b [type=int]
-                │    └── variable: bar.b [type=float]
-                └── eq [type=bool]
-                     ├── variable: foo.c [type=float]
-                     └── variable: bar.c [type=float]
+           ├── eq [type=bool]
+           │    ├── variable: foo.a [type=int]
+           │    └── variable: bar.a [type=int]
+           ├── eq [type=bool]
+           │    ├── variable: foo.b [type=int]
+           │    └── variable: bar.b [type=float]
+           └── eq [type=bool]
+                ├── variable: foo.c [type=float]
+                └── variable: bar.c [type=float]
 
 # b can't be an equality column.
 build
@@ -3031,13 +3026,12 @@ project
       │    ├── scan bar
       │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
       │    └── filters [type=bool]
-      │         └── and [type=bool]
-      │              ├── eq [type=bool]
-      │              │    ├── variable: foo.a [type=int]
-      │              │    └── variable: bar.a [type=int]
-      │              └── eq [type=bool]
-      │                   ├── variable: foo.b [type=int]
-      │                   └── variable: bar.b [type=float]
+      │         ├── eq [type=bool]
+      │         │    ├── variable: foo.a [type=int]
+      │         │    └── variable: bar.a [type=int]
+      │         └── eq [type=bool]
+      │              ├── variable: foo.b [type=int]
+      │              └── variable: bar.b [type=float]
       └── filters [type=bool]
            └── and [type=bool]
                 ├── eq [type=bool]
@@ -3129,13 +3123,12 @@ project
       │    │         ├── const: 1 [type=int]
       │    │         └── const: 1 [type=int]
       │    └── filters [type=bool]
-      │         └── and [type=bool]
-      │              ├── eq [type=bool]
-      │              │    ├── variable: column1 [type=unknown]
-      │              │    └── variable: column1 [type=int]
-      │              └── eq [type=bool]
-      │                   ├── variable: column2 [type=unknown]
-      │                   └── variable: column2 [type=int]
+      │         ├── eq [type=bool]
+      │         │    ├── variable: column1 [type=unknown]
+      │         │    └── variable: column1 [type=int]
+      │         └── eq [type=bool]
+      │              ├── variable: column2 [type=unknown]
+      │              └── variable: column2 [type=int]
       └── projections
            ├── coalesce [type=int]
            │    ├── variable: column1 [type=unknown]
@@ -3173,13 +3166,12 @@ project
  │         │    │         ├── const: 1 [type=int]
  │         │    │         └── const: 1 [type=int]
  │         │    └── filters [type=bool]
- │         │         └── and [type=bool]
- │         │              ├── eq [type=bool]
- │         │              │    ├── variable: column1 [type=unknown]
- │         │              │    └── variable: column1 [type=int]
- │         │              └── eq [type=bool]
- │         │                   ├── variable: column2 [type=unknown]
- │         │                   └── variable: column2 [type=int]
+ │         │         ├── eq [type=bool]
+ │         │         │    ├── variable: column1 [type=unknown]
+ │         │         │    └── variable: column1 [type=int]
+ │         │         └── eq [type=bool]
+ │         │              ├── variable: column2 [type=unknown]
+ │         │              └── variable: column2 [type=int]
  │         └── projections
  │              ├── coalesce [type=int]
  │              │    ├── variable: column1 [type=unknown]


### PR DESCRIPTION
Backport 2/2 commits from #29472.

/cc @cockroachdb/release

---

- Improve perf of list storage
- Improve perf of USING and natural joins

Together, the changes give a perf boost for this case:
```
SELECT * FROM foo NATURAL JOIN bar

name                 old time/op    new time/op    delta
Phases/test/Explore     115µs ± 2%     109µs ± 1%  -4.63%  (p=0.008 n=5+5)

name                 old alloc/op   new alloc/op   delta
Phases/test/Explore    44.3kB ± 0%    42.6kB ± 0%  -3.76%  (p=0.008 n=5+5)

name                 old allocs/op  new allocs/op  delta
Phases/test/Explore       189 ± 0%       181 ± 0%  -4.23%  (p=0.008 n=5+5)
```
