### PR TITLE
storage: add entries to raftEntryCache outside of replica lock

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4216,11 +4216,9 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		}
 	}
 
-	// Update protected state (last index, last term, raft log size and raft
-	// leader ID) and set raft log entry cache. We clear any older, uncommitted
-	// log entries and cache the latest ones.
+	// Update protected state - last index, last term, raft log size, and raft
+	// leader ID.
 	r.mu.Lock()
-	r.store.raftEntryCache.addEntries(r.RangeID, rd.Entries)
 	r.mu.lastIndex = lastIndex
 	r.mu.lastTerm = lastTerm
 	r.mu.raftLogSize = raftLogSize
@@ -4231,6 +4229,10 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		r.mu.remoteProposals = nil
 	}
 	r.mu.Unlock()
+
+	// Update raft log entry cache. We clear any older, uncommitted log entries
+	// and cache the latest ones.
+	r.store.raftEntryCache.addEntries(r.RangeID, rd.Entries)
 
 	r.sendRaftMessages(ctx, otherMsgs)
 


### PR DESCRIPTION
Profiles show that a significant percentage of Mutex blocking
occurs when adding entries to the raftEntryCache (~4% on a
cluster running TPC-C). This is expected because the cache
is shared across all Ranges on a Store. The cache was recently
adjusted to use a RWMutex, which means that the majority of
accesses should be faster. However, adding new entries to the
cache still requires mutual exclusion.

This change adjusts the primary caller of `raftEntryCache.addEntries`
so that it is outside of the individual Replica's lock. This
prevents blocking on the cache from blocking all other access
to the replica (proposals, read-only requests, etc.).

Release note: None