### PR TITLE
opt: remember subquery ASTs for explain

### DIFF
--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -293,7 +293,9 @@ func (e *explainer) populateEntries(ctx context.Context, plan planNode, subquery
 	for i := range subqueryPlans {
 		_, _ = e.enterNode(ctx, "subquery", plan)
 		e.attr("subquery", "id", fmt.Sprintf("@S%d", i+1))
-		e.attr("subquery", "sql", subqueryPlans[i].subquery.String())
+		// This field contains the original subquery (which could have been modified
+		// by optimizer transformations).
+		e.attr("subquery", "original sql", subqueryPlans[i].subquery.String())
 		e.attr("subquery", "exec mode", distsqlrun.SubqueryExecModeNames[subqueryPlans[i].execMode])
 		if subqueryPlans[i].plan != nil {
 			_ = walkPlan(ctx, subqueryPlans[i].plan, observer)

--- a/pkg/sql/logictest/testdata/planner_test/needed_columns
+++ b/pkg/sql/logictest/testdata/planner_test/needed_columns
@@ -121,21 +121,21 @@ nosort                   ·         ·     (x)                 x=CONST
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 = (SELECT 2 AS x FROM (SELECT 3 AS s)) AS y
 ----
-root                               ·          ·                                     (y)           y=CONST
- ├── render                        ·          ·                                     (y)           y=CONST
- │    │                            render 0   @S1 = 1                               ·             ·
- │    └── emptyrow                 ·          ·                                     ()            ·
- └── subquery                      ·          ·                                     (y)           y=CONST
-      │                            id         @S1                                   ·             ·
-      │                            sql        (SELECT 2 AS x FROM (SELECT 3 AS s))  ·             ·
-      │                            exec mode  one row                               ·             ·
-      └── limit                    ·          ·                                     (x)           x=CONST
-           │                       count      2                                     ·             ·
-           └── render              ·          ·                                     (x)           x=CONST
-                │                  render 0   2                                     ·             ·
-                └── render         ·          ·                                     (s[omitted])  ·
-                     │             render 0   NULL                                  ·             ·
-                     └── emptyrow  ·          ·                                     ()            ·
+root                               ·             ·                                     (y)           y=CONST
+ ├── render                        ·             ·                                     (y)           y=CONST
+ │    │                            render 0      @S1 = 1                               ·             ·
+ │    └── emptyrow                 ·             ·                                     ()            ·
+ └── subquery                      ·             ·                                     (y)           y=CONST
+      │                            id            @S1                                   ·             ·
+      │                            original sql  (SELECT 2 AS x FROM (SELECT 3 AS s))  ·             ·
+      │                            exec mode     one row                               ·             ·
+      └── limit                    ·             ·                                     (x)           x=CONST
+           │                       count         2                                     ·             ·
+           └── render              ·             ·                                     (x)           x=CONST
+                │                  render 0      2                                     ·             ·
+                └── render         ·             ·                                     (s[omitted])  ·
+                     │             render 0      NULL                                  ·             ·
+                     └── emptyrow  ·             ·                                     ()            ·
 
 # Propagation through table scans.
 statement ok

--- a/pkg/sql/logictest/testdata/planner_test/subquery
+++ b/pkg/sql/logictest/testdata/planner_test/subquery
@@ -12,17 +12,17 @@ SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
 query TTT
 EXPLAIN ALTER TABLE abc SPLIT AT VALUES ((SELECT 42))
 ----
-root                          ·          ·
- ├── split                    ·          ·
- │    └── values              ·          ·
- │                            size       1 column, 1 row
- └── subquery                 ·          ·
-      │                       id         @S1
-      │                       sql        (SELECT 42)
-      │                       exec mode  one row
-      └── limit               ·          ·
-           └── render         ·          ·
-                └── emptyrow  ·          ·
+root                          ·             ·
+ ├── split                    ·             ·
+ │    └── values              ·             ·
+ │                            size          1 column, 1 row
+ └── subquery                 ·             ·
+      │                       id            @S1
+      │                       original sql  (SELECT 42)
+      │                       exec mode     one row
+      └── limit               ·             ·
+           └── render         ·             ·
+                └── emptyrow  ·             ·
 
 statement ok
 ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))
@@ -30,74 +30,74 @@ ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))
 query TTT
 EXPLAIN SELECT EXISTS (SELECT a FROM abc)
 ----
-root                      ·          ·
- ├── render               ·          ·
- │    └── emptyrow        ·          ·
- └── subquery             ·          ·
-      │                   id         @S1
-      │                   sql        EXISTS (SELECT a FROM abc)
-      │                   exec mode  exists
-      └── limit           ·          ·
-           └── render     ·          ·
-                └── scan  ·          ·
-·                         table      abc@primary
-·                         spans      ALL
-·                         limit      1
+root                      ·             ·
+ ├── render               ·             ·
+ │    └── emptyrow        ·             ·
+ └── subquery             ·             ·
+      │                   id            @S1
+      │                   original sql  EXISTS (SELECT a FROM abc)
+      │                   exec mode     exists
+      └── limit           ·             ·
+           └── render     ·             ·
+                └── scan  ·             ·
+·                         table         abc@primary
+·                         spans         ALL
+·                         limit         1
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE a = (SELECT max(a) FROM abc WHERE EXISTS(SELECT * FROM abc WHERE c=a+3))
 ----
-root                              ·            ·                                                                            (a, b, c)                    a!=NULL; key(a)
- ├── scan                         ·            ·                                                                            (a, b, c)                    a!=NULL; key(a)
- │                                table        abc@primary                                                                  ·                            ·
- │                                spans        ALL                                                                          ·                            ·
- │                                filter       a = @S2                                                                      ·                            ·
- ├── subquery                     ·            ·                                                                            (a, b, c)                    a!=NULL; key(a)
- │    │                           id           @S1                                                                          ·                            ·
- │    │                           sql          EXISTS (SELECT * FROM abc WHERE c = (a + 3))                                 ·                            ·
- │    │                           exec mode    exists                                                                       ·                            ·
- │    └── limit                   ·            ·                                                                            (a, b[omitted], c)           a!=NULL; c!=NULL; key(a)
- │         │                      count        1                                                                            ·                            ·
- │         └── scan               ·            ·                                                                            (a, b[omitted], c)           a!=NULL; c!=NULL; key(a)
- │                                table        abc@primary                                                                  ·                            ·
- │                                spans        ALL                                                                          ·                            ·
- │                                filter       c = (a + 3)                                                                  ·                            ·
- └── subquery                     ·            ·                                                                            (a, b, c)                    a!=NULL; key(a)
-      │                           id           @S2                                                                          ·                            ·
-      │                           sql          (SELECT max(a) FROM abc WHERE EXISTS (SELECT * FROM abc WHERE c = (a + 3)))  ·                            ·
-      │                           exec mode    one row                                                                      ·                            ·
-      └── limit                   ·            ·                                                                            (max)                        ·
-           │                      count        2                                                                            ·                            ·
-           └── group              ·            ·                                                                            (max)                        ·
-                │                 aggregate 0  max(a)                                                                       ·                            ·
-                │                 scalar       ·                                                                            ·                            ·
-                └── render        ·            ·                                                                            (a)                          a!=NULL; key(a); -a
-                     │            render 0     test.public.abc.a                                                            ·                            ·
-                     └── revscan  ·            ·                                                                            (a, b[omitted], c[omitted])  a!=NULL; key(a); -a
-·                                 table        abc@primary                                                                  ·                            ·
-·                                 spans        ALL                                                                          ·                            ·
-·                                 filter       @S1 AND (a IS NOT NULL)                                                      ·                            ·
+root                              ·             ·                                                                            (a, b, c)                    a!=NULL; key(a)
+ ├── scan                         ·             ·                                                                            (a, b, c)                    a!=NULL; key(a)
+ │                                table         abc@primary                                                                  ·                            ·
+ │                                spans         ALL                                                                          ·                            ·
+ │                                filter        a = @S2                                                                      ·                            ·
+ ├── subquery                     ·             ·                                                                            (a, b, c)                    a!=NULL; key(a)
+ │    │                           id            @S1                                                                          ·                            ·
+ │    │                           original sql  EXISTS (SELECT * FROM abc WHERE c = (a + 3))                                 ·                            ·
+ │    │                           exec mode     exists                                                                       ·                            ·
+ │    └── limit                   ·             ·                                                                            (a, b[omitted], c)           a!=NULL; c!=NULL; key(a)
+ │         │                      count         1                                                                            ·                            ·
+ │         └── scan               ·             ·                                                                            (a, b[omitted], c)           a!=NULL; c!=NULL; key(a)
+ │                                table         abc@primary                                                                  ·                            ·
+ │                                spans         ALL                                                                          ·                            ·
+ │                                filter        c = (a + 3)                                                                  ·                            ·
+ └── subquery                     ·             ·                                                                            (a, b, c)                    a!=NULL; key(a)
+      │                           id            @S2                                                                          ·                            ·
+      │                           original sql  (SELECT max(a) FROM abc WHERE EXISTS (SELECT * FROM abc WHERE c = (a + 3)))  ·                            ·
+      │                           exec mode     one row                                                                      ·                            ·
+      └── limit                   ·             ·                                                                            (max)                        ·
+           │                      count         2                                                                            ·                            ·
+           └── group              ·             ·                                                                            (max)                        ·
+                │                 aggregate 0   max(a)                                                                       ·                            ·
+                │                 scalar        ·                                                                            ·                            ·
+                └── render        ·             ·                                                                            (a)                          a!=NULL; key(a); -a
+                     │            render 0      test.public.abc.a                                                            ·                            ·
+                     └── revscan  ·             ·                                                                            (a, b[omitted], c[omitted])  a!=NULL; key(a); -a
+·                                 table         abc@primary                                                                  ·                            ·
+·                                 spans         ALL                                                                          ·                            ·
+·                                 filter        @S1 AND (a IS NOT NULL)                                                      ·                            ·
 
 # check that residual filters are not expanded twice
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM abc WHERE a IN (SELECT a FROM abc)
 ----
-root                 ·          ·                    (a)                          a!=NULL; key(a)
- ├── render          ·          ·                    (a)                          a!=NULL; key(a)
- │    │              render 0   test.public.abc.a    ·                            ·
- │    └── scan       ·          ·                    (a, b[omitted], c[omitted])  a!=NULL; key(a)
- │                   table      abc@primary          ·                            ·
- │                   spans      ALL                  ·                            ·
- │                   filter     a IN @S1             ·                            ·
- └── subquery        ·          ·                    (a)                          a!=NULL; key(a)
-      │              id         @S1                  ·                            ·
-      │              sql        (SELECT a FROM abc)  ·                            ·
-      │              exec mode  all rows normalized  ·                            ·
-      └── render     ·          ·                    (a)                          a!=NULL; key(a)
-           │         render 0   test.public.abc.a    ·                            ·
-           └── scan  ·          ·                    (a, b[omitted], c[omitted])  a!=NULL; key(a)
-·                    table      abc@primary          ·                            ·
-·                    spans      ALL                  ·                            ·
+root                 ·             ·                    (a)                          a!=NULL; key(a)
+ ├── render          ·             ·                    (a)                          a!=NULL; key(a)
+ │    │              render 0      test.public.abc.a    ·                            ·
+ │    └── scan       ·             ·                    (a, b[omitted], c[omitted])  a!=NULL; key(a)
+ │                   table         abc@primary          ·                            ·
+ │                   spans         ALL                  ·                            ·
+ │                   filter        a IN @S1             ·                            ·
+ └── subquery        ·             ·                    (a)                          a!=NULL; key(a)
+      │              id            @S1                  ·                            ·
+      │              original sql  (SELECT a FROM abc)  ·                            ·
+      │              exec mode     all rows normalized  ·                            ·
+      └── render     ·             ·                    (a)                          a!=NULL; key(a)
+           │         render 0      test.public.abc.a    ·                            ·
+           └── scan  ·             ·                    (a, b[omitted], c[omitted])  a!=NULL; key(a)
+·                    table         abc@primary          ·                            ·
+·                    spans         ALL                  ·                            ·
 
 query TTT
 EXPLAIN SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1
@@ -111,16 +111,16 @@ sort         ·      ·
 query TTT
 EXPLAIN VALUES (1), ((SELECT 2))
 ----
-root                          ·          ·
- ├── values                   ·          ·
- │                            size       1 column, 2 rows
- └── subquery                 ·          ·
-      │                       id         @S1
-      │                       sql        (SELECT 2)
-      │                       exec mode  one row
-      └── limit               ·          ·
-           └── render         ·          ·
-                └── emptyrow  ·          ·
+root                          ·             ·
+ ├── values                   ·             ·
+ │                            size          1 column, 2 rows
+ └── subquery                 ·             ·
+      │                       id            @S1
+      │                       original sql  (SELECT 2)
+      │                       exec mode     one row
+      └── limit               ·             ·
+           └── render         ·             ·
+                └── emptyrow  ·             ·
 
 # This test checks that the double sub-query plan expansion caused by a
 # sub-expression being shared by two or more plan nodes does not
@@ -134,16 +134,16 @@ CREATE INDEX idx_tab4_0 ON tab4 (col4,col0)
 query TTT
 EXPLAIN SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27)) AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
 ----
-root                 ·          ·
- ├── render          ·          ·
- │    └── scan       ·          ·
- │                   table      tab4@primary
- │                   spans      ALL
- └── subquery        ·          ·
-      │              id         @S1
-      │              sql        (SELECT col1 FROM tab4 WHERE col1 > 8.27)
-      │              exec mode  all rows normalized
-      └── render     ·          ·
-           └── scan  ·          ·
-·                    table      tab4@primary
-·                    spans      ALL
+root                 ·             ·
+ ├── render          ·             ·
+ │    └── scan       ·             ·
+ │                   table         tab4@primary
+ │                   spans         ALL
+ └── subquery        ·             ·
+      │              id            @S1
+      │              original sql  (SELECT col1 FROM tab4 WHERE col1 > 8.27)
+      │              exec mode     all rows normalized
+      └── render     ·             ·
+           └── scan  ·             ·
+·                    table         tab4@primary
+·                    spans         ALL

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -163,25 +163,25 @@ render               ·               ·                                        
 query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_series((SELECT unnest(ARRAY[x, y]) FROM xy), z) FROM xz
 ----
-root                        ·          ·                         (generate_series)     ·
- ├── render                 ·          ·                         (generate_series)     ·
- │    │                     render 0   generate_series           ·                     ·
- │    └── project set       ·          ·                         (z, generate_series)  ·
- │         │                render 0   generate_series(@S1, @1)  ·                     ·
- │         └── scan         ·          ·                         (z)                   ·
- │                          table      xz@primary                ·                     ·
- │                          spans      ALL                       ·                     ·
- └── subquery               ·          ·                         (generate_series)     ·
-      │                     id         @S1                       ·                     ·
-      │                     sql        <unknown>                 ·                     ·
-      │                     exec mode  one row                   ·                     ·
-      └── render            ·          ·                         (unnest)              ·
-           │                render 0   unnest                    ·                     ·
-           └── project set  ·          ·                         (x, y, unnest)        ·
-                │           render 0   unnest(ARRAY[@1, @2])     ·                     ·
-                └── scan    ·          ·                         (x, y)                ·
-·                           table      xy@primary                ·                     ·
-·                           spans      ALL                       ·                     ·
+root                        ·             ·                         (generate_series)     ·
+ ├── render                 ·             ·                         (generate_series)     ·
+ │    │                     render 0      generate_series           ·                     ·
+ │    └── project set       ·             ·                         (z, generate_series)  ·
+ │         │                render 0      generate_series(@S1, @1)  ·                     ·
+ │         └── scan         ·             ·                         (z)                   ·
+ │                          table         xz@primary                ·                     ·
+ │                          spans         ALL                       ·                     ·
+ └── subquery               ·             ·                         (generate_series)     ·
+      │                     id            @S1                       ·                     ·
+      │                     original sql  <unknown>                 ·                     ·
+      │                     exec mode     one row                   ·                     ·
+      └── render            ·             ·                         (unnest)              ·
+           │                render 0      unnest                    ·                     ·
+           └── project set  ·             ·                         (x, y, unnest)        ·
+                │           render 0      unnest(ARRAY[@1, @2])     ·                     ·
+                └── scan    ·             ·                         (x, y)                ·
+·                           table         xy@primary                ·                     ·
+·                           spans         ALL                       ·                     ·
 
 # Regression test for #24676.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -163,25 +163,25 @@ render               ·               ·                                        
 query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_series((SELECT unnest(ARRAY[x, y]) FROM xy), z) FROM xz
 ----
-root                        ·             ·                         (generate_series)     ·
- ├── render                 ·             ·                         (generate_series)     ·
- │    │                     render 0      generate_series           ·                     ·
- │    └── project set       ·             ·                         (z, generate_series)  ·
- │         │                render 0      generate_series(@S1, @1)  ·                     ·
- │         └── scan         ·             ·                         (z)                   ·
- │                          table         xz@primary                ·                     ·
- │                          spans         ALL                       ·                     ·
- └── subquery               ·             ·                         (generate_series)     ·
-      │                     id            @S1                       ·                     ·
-      │                     original sql  <unknown>                 ·                     ·
-      │                     exec mode     one row                   ·                     ·
-      └── render            ·             ·                         (unnest)              ·
-           │                render 0      unnest                    ·                     ·
-           └── project set  ·             ·                         (x, y, unnest)        ·
-                │           render 0      unnest(ARRAY[@1, @2])     ·                     ·
-                └── scan    ·             ·                         (x, y)                ·
-·                           table         xy@primary                ·                     ·
-·                           spans         ALL                       ·                     ·
+root                        ·             ·                                     (generate_series)     ·
+ ├── render                 ·             ·                                     (generate_series)     ·
+ │    │                     render 0      generate_series                       ·                     ·
+ │    └── project set       ·             ·                                     (z, generate_series)  ·
+ │         │                render 0      generate_series(@S1, @1)              ·                     ·
+ │         └── scan         ·             ·                                     (z)                   ·
+ │                          table         xz@primary                            ·                     ·
+ │                          spans         ALL                                   ·                     ·
+ └── subquery               ·             ·                                     (generate_series)     ·
+      │                     id            @S1                                   ·                     ·
+      │                     original sql  (SELECT unnest(ARRAY[x, y]) FROM xy)  ·                     ·
+      │                     exec mode     one row                               ·                     ·
+      └── render            ·             ·                                     (unnest)              ·
+           │                render 0      unnest                                ·                     ·
+           └── project set  ·             ·                                     (x, y, unnest)        ·
+                │           render 0      unnest(ARRAY[@1, @2])                 ·                     ·
+                └── scan    ·             ·                                     (x, y)                ·
+·                           table         xy@primary                            ·                     ·
+·                           spans         ALL                                   ·                     ·
 
 # Regression test for #24676.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -36,7 +36,7 @@ root                ·             ·
  │    └── emptyrow  ·             ·
  └── subquery       ·             ·
       │             id            @S1
-      │             original sql  EXISTS <unknown>
+      │             original sql  EXISTS (SELECT a FROM abc)
       │             exec mode     exists
       └── scan      ·             ·
 ·                   table         abc@primary
@@ -45,30 +45,30 @@ root                ·             ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE a = (SELECT max(a) FROM abc WHERE EXISTS(SELECT * FROM abc WHERE c=a+3))
 ----
-root                 ·             ·                 (a, b, c)  ·
- ├── scan            ·             ·                 (a, b, c)  ·
- │                   table         abc@primary       ·          ·
- │                   spans         ALL               ·          ·
- │                   filter        a = @S2           ·          ·
- ├── subquery        ·             ·                 (a, b, c)  ·
- │    │              id            @S1               ·          ·
- │    │              original sql  EXISTS <unknown>  ·          ·
- │    │              exec mode     exists            ·          ·
- │    └── scan       ·             ·                 (a, b, c)  ·
- │                   table         abc@primary       ·          ·
- │                   spans         ALL               ·          ·
- │                   filter        c = (a + 3)       ·          ·
- └── subquery        ·             ·                 (a, b, c)  ·
-      │              id            @S2               ·          ·
-      │              original sql  <unknown>         ·          ·
-      │              exec mode     one row           ·          ·
-      └── group      ·             ·                 (agg0)     ·
-           │         aggregate 0   max(a)            ·          ·
-           │         scalar        ·                 ·          ·
-           └── scan  ·             ·                 (a)        ·
-·                    table         abc@primary       ·          ·
-·                    spans         ALL               ·          ·
-·                    filter        @S1               ·          ·
+root                 ·             ·                                                                            (a, b, c)  ·
+ ├── scan            ·             ·                                                                            (a, b, c)  ·
+ │                   table         abc@primary                                                                  ·          ·
+ │                   spans         ALL                                                                          ·          ·
+ │                   filter        a = @S2                                                                      ·          ·
+ ├── subquery        ·             ·                                                                            (a, b, c)  ·
+ │    │              id            @S1                                                                          ·          ·
+ │    │              original sql  EXISTS (SELECT * FROM abc WHERE c = (a + 3))                                 ·          ·
+ │    │              exec mode     exists                                                                       ·          ·
+ │    └── scan       ·             ·                                                                            (a, b, c)  ·
+ │                   table         abc@primary                                                                  ·          ·
+ │                   spans         ALL                                                                          ·          ·
+ │                   filter        c = (a + 3)                                                                  ·          ·
+ └── subquery        ·             ·                                                                            (a, b, c)  ·
+      │              id            @S2                                                                          ·          ·
+      │              original sql  (SELECT max(a) FROM abc WHERE EXISTS (SELECT * FROM abc WHERE c = (a + 3)))  ·          ·
+      │              exec mode     one row                                                                      ·          ·
+      └── group      ·             ·                                                                            (agg0)     ·
+           │         aggregate 0   max(a)                                                                       ·          ·
+           │         scalar        ·                                                                            ·          ·
+           └── scan  ·             ·                                                                            (a)        ·
+·                    table         abc@primary                                                                  ·          ·
+·                    spans         ALL                                                                          ·          ·
+·                    filter        @S1                                                                          ·          ·
 
 # IN expression transformed into semi-join.
 query TTTTT
@@ -103,7 +103,7 @@ root                     ·             ·
  │                       size          1 column, 2 rows
  └── subquery            ·             ·
       │                  id            @S1
-      │                  original sql  <unknown>
+      │                  original sql  (SELECT 2)
       │                  exec mode     one row
       └── render         ·             ·
            └── emptyrow  ·             ·
@@ -228,7 +228,7 @@ root                 ·             ·                       ("array")  ·
  │    └── emptyrow   ·             ·                       ()         ·
  └── subquery        ·             ·                       ("array")  ·
       │              id            @S1                     ·          ·
-      │              original sql  <unknown>               ·          ·
+      │              original sql  (SELECT x FROM b)       ·          ·
       │              exec mode     one row                 ·          ·
       └── group      ·             ·                       (agg0)     ·
            │         aggregate 0   array_agg(x)            ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -13,17 +13,17 @@ SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
 query TTT
 EXPLAIN ALTER TABLE abc SPLIT AT VALUES ((SELECT 42))
 ----
-root                          ·          ·
- ├── split                    ·          ·
- │    └── values              ·          ·
- │                            size       1 column, 1 row
- └── subquery                 ·          ·
-      │                       id         @S1
-      │                       sql        (SELECT 42)
-      │                       exec mode  one row
-      └── limit               ·          ·
-           └── render         ·          ·
-                └── emptyrow  ·          ·
+root                          ·             ·
+ ├── split                    ·             ·
+ │    └── values              ·             ·
+ │                            size          1 column, 1 row
+ └── subquery                 ·             ·
+      │                       id            @S1
+      │                       original sql  (SELECT 42)
+      │                       exec mode     one row
+      └── limit               ·             ·
+           └── render         ·             ·
+                └── emptyrow  ·             ·
 
 statement ok
 ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))
@@ -31,44 +31,44 @@ ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))
 query TTT
 EXPLAIN SELECT EXISTS (SELECT a FROM abc)
 ----
-root                ·          ·
- ├── render         ·          ·
- │    └── emptyrow  ·          ·
- └── subquery       ·          ·
-      │             id         @S1
-      │             sql        EXISTS <unknown>
-      │             exec mode  exists
-      └── scan      ·          ·
-·                   table      abc@primary
-·                   spans      ALL
+root                ·             ·
+ ├── render         ·             ·
+ │    └── emptyrow  ·             ·
+ └── subquery       ·             ·
+      │             id            @S1
+      │             original sql  EXISTS <unknown>
+      │             exec mode     exists
+      └── scan      ·             ·
+·                   table         abc@primary
+·                   spans         ALL
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE a = (SELECT max(a) FROM abc WHERE EXISTS(SELECT * FROM abc WHERE c=a+3))
 ----
-root                 ·            ·                 (a, b, c)  ·
- ├── scan            ·            ·                 (a, b, c)  ·
- │                   table        abc@primary       ·          ·
- │                   spans        ALL               ·          ·
- │                   filter       a = @S2           ·          ·
- ├── subquery        ·            ·                 (a, b, c)  ·
- │    │              id           @S1               ·          ·
- │    │              sql          EXISTS <unknown>  ·          ·
- │    │              exec mode    exists            ·          ·
- │    └── scan       ·            ·                 (a, b, c)  ·
- │                   table        abc@primary       ·          ·
- │                   spans        ALL               ·          ·
- │                   filter       c = (a + 3)       ·          ·
- └── subquery        ·            ·                 (a, b, c)  ·
-      │              id           @S2               ·          ·
-      │              sql          <unknown>         ·          ·
-      │              exec mode    one row           ·          ·
-      └── group      ·            ·                 (agg0)     ·
-           │         aggregate 0  max(a)            ·          ·
-           │         scalar       ·                 ·          ·
-           └── scan  ·            ·                 (a)        ·
-·                    table        abc@primary       ·          ·
-·                    spans        ALL               ·          ·
-·                    filter       @S1               ·          ·
+root                 ·             ·                 (a, b, c)  ·
+ ├── scan            ·             ·                 (a, b, c)  ·
+ │                   table         abc@primary       ·          ·
+ │                   spans         ALL               ·          ·
+ │                   filter        a = @S2           ·          ·
+ ├── subquery        ·             ·                 (a, b, c)  ·
+ │    │              id            @S1               ·          ·
+ │    │              original sql  EXISTS <unknown>  ·          ·
+ │    │              exec mode     exists            ·          ·
+ │    └── scan       ·             ·                 (a, b, c)  ·
+ │                   table         abc@primary       ·          ·
+ │                   spans         ALL               ·          ·
+ │                   filter        c = (a + 3)       ·          ·
+ └── subquery        ·             ·                 (a, b, c)  ·
+      │              id            @S2               ·          ·
+      │              original sql  <unknown>         ·          ·
+      │              exec mode     one row           ·          ·
+      └── group      ·             ·                 (agg0)     ·
+           │         aggregate 0   max(a)            ·          ·
+           │         scalar        ·                 ·          ·
+           └── scan  ·             ·                 (a)        ·
+·                    table         abc@primary       ·          ·
+·                    spans         ALL               ·          ·
+·                    filter        @S1               ·          ·
 
 # IN expression transformed into semi-join.
 query TTTTT
@@ -98,15 +98,15 @@ sort         ·      ·
 query TTT
 EXPLAIN VALUES (1), ((SELECT 2))
 ----
-root                     ·          ·
- ├── values              ·          ·
- │                       size       1 column, 2 rows
- └── subquery            ·          ·
-      │                  id         @S1
-      │                  sql        <unknown>
-      │                  exec mode  one row
-      └── render         ·          ·
-           └── emptyrow  ·          ·
+root                     ·             ·
+ ├── values              ·             ·
+ │                       size          1 column, 2 rows
+ └── subquery            ·             ·
+      │                  id            @S1
+      │                  original sql  <unknown>
+      │                  exec mode     one row
+      └── render         ·             ·
+           └── emptyrow  ·             ·
 
 # This test checks that the double sub-query plan expansion caused by a
 # sub-expression being shared by two or more plan nodes does not
@@ -222,20 +222,20 @@ join       ·      ·            (x, z)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY(SELECT x FROM b)
 ----
-root                 ·            ·                       ("array")  ·
- ├── render          ·            ·                       ("array")  ·
- │    │              render 0     COALESCE(@S1, ARRAY[])  ·          ·
- │    └── emptyrow   ·            ·                       ()         ·
- └── subquery        ·            ·                       ("array")  ·
-      │              id           @S1                     ·          ·
-      │              sql          <unknown>               ·          ·
-      │              exec mode    one row                 ·          ·
-      └── group      ·            ·                       (agg0)     ·
-           │         aggregate 0  array_agg(x)            ·          ·
-           │         scalar       ·                       ·          ·
-           └── scan  ·            ·                       (x)        ·
-·                    table        b@primary               ·          ·
-·                    spans        ALL                     ·          ·
+root                 ·             ·                       ("array")  ·
+ ├── render          ·             ·                       ("array")  ·
+ │    │              render 0      COALESCE(@S1, ARRAY[])  ·          ·
+ │    └── emptyrow   ·             ·                       ()         ·
+ └── subquery        ·             ·                       ("array")  ·
+      │              id            @S1                     ·          ·
+      │              original sql  <unknown>               ·          ·
+      │              exec mode     one row                 ·          ·
+      └── group      ·             ·                       (agg0)     ·
+           │         aggregate 0   array_agg(x)            ·          ·
+           │         scalar        ·                       ·          ·
+           └── scan  ·             ·                       (x)        ·
+·                    table         b@primary               ·          ·
+·                    spans         ALL                     ·          ·
 
 # Case where the plan has an apply join.
 query error could not decorrelate subquery

--- a/pkg/sql/opt/memo/expr_view_format.go
+++ b/pkg/sql/opt/memo/expr_view_format.go
@@ -387,6 +387,14 @@ func (ev ExprView) formatScalarPrivate(f *ExprFmtCtx, private interface{}) {
 		// columns for their containing op (Project or GroupBy), so no need to
 		// print again.
 		private = nil
+
+	case opt.AnyOp:
+		// We don't want to show the OriginalExpr; just show Cmp.
+		private = private.(*SubqueryDef).Cmp
+
+	case opt.SubqueryOp, opt.ExistsOp:
+		// We don't want to show the OriginalExpr.
+		private = nil
 	}
 
 	if private != nil {

--- a/pkg/sql/opt/memo/private_defs.go
+++ b/pkg/sql/opt/memo/private_defs.go
@@ -459,3 +459,11 @@ func (m *MergeOnDef) CanProvideOrdering(required *props.OrderingChoice) bool {
 		return false
 	}
 }
+
+// SubqueryDef contains information related to a subquery (Subquery, Any,
+// Exists).
+type SubqueryDef struct {
+	OriginalExpr *tree.Subquery
+	// Cmp is only used for AnyOp.
+	Cmp opt.Operator
+}

--- a/pkg/sql/opt/memo/private_storage.go
+++ b/pkg/sql/opt/memo/private_storage.go
@@ -413,6 +413,18 @@ func (ps *privateStorage) internRowNumberDef(def *RowNumberDef) PrivateID {
 	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, def)
 }
 
+func (ps *privateStorage) internSubqueryDef(def *SubqueryDef) PrivateID {
+	ps.keyBuf.Reset()
+	ps.keyBuf.writeUvarint(uint64(uintptr(unsafe.Pointer(def.OriginalExpr))))
+	ps.keyBuf.writeUvarint(uint64(def.Cmp))
+
+	typ := (*SubqueryDef)(nil)
+	if id, ok := ps.privatesMap[privateKey{iface: typ, str: ps.keyBuf.String()}]; ok {
+		return id
+	}
+	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, def)
+}
+
 // internSetOpColMap adds the given value to storage and returns an id that can
 // later be used to retrieve the value by calling the lookup method. If the
 // value has been previously added to storage, then internSetOpColMap always

--- a/pkg/sql/opt/norm/decorrelate.go
+++ b/pkg/sql/opt/norm/decorrelate.go
@@ -611,10 +611,11 @@ func (c *CustomFuncs) AddColsToGroupByDef(
 // expression with the first (and only) column of the input rowset, using the
 // given comparison operator.
 func (c *CustomFuncs) ConstructAnyCondition(
-	input, scalar memo.GroupID, cmp memo.PrivateID,
+	input, scalar memo.GroupID, subqueryDef memo.PrivateID,
 ) memo.GroupID {
 	inputVar := c.referenceSingleColumn(input)
-	return c.ConstructBinary(c.f.mem.LookupPrivate(cmp).(opt.Operator), scalar, inputVar)
+	def := c.f.mem.LookupPrivate(subqueryDef).(*memo.SubqueryDef)
+	return c.ConstructBinary(def.Cmp, scalar, inputVar)
 }
 
 // ConstructBinary builds a dynamic binary expression, given the binary
@@ -731,7 +732,7 @@ func (r *subqueryHoister) hoistAll(root memo.GroupID) memo.GroupID {
 		case opt.AnyOp:
 			input := ev.ChildGroup(0)
 			scalar := ev.ChildGroup(1)
-			cmp := ev.Private().(opt.Operator)
+			cmp := ev.Private().(*memo.SubqueryDef).Cmp
 			subquery = r.constructGroupByAny(scalar, cmp, input)
 		}
 

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -674,7 +674,7 @@
 # addition, the Exists can be transformed into a semi-join.
 [NormalizeAnyFilter, Normalize]
 (Filters
-    $list:[ ... $any:(Any $input:* $scalar:* $cmp:*) ... ]
+    $list:[ ... $any:(Any $input:* $scalar:* $subqueryDef:*) ... ]
 )
 =>
 (Filters
@@ -684,8 +684,9 @@
         (Exists
             (Select
                 $input
-                (Filters [ (ConstructAnyCondition $input $scalar $cmp) ])
+                (Filters [ (ConstructAnyCondition $input $scalar $subqueryDef) ])
             )
+            $subqueryDef
         )
     )
 )
@@ -700,7 +701,7 @@
 # Citations: [5] (section 3.5)
 [NormalizeNotAnyFilter, Normalize]
 (Filters
-    $list:[ ... $notany:(Not (Any $input:* $scalar:* $cmp:*)) ... ]
+    $list:[ ... $notany:(Not (Any $input:* $scalar:* $subqueryDef:*)) ... ]
 )
 =>
 (Filters
@@ -712,9 +713,10 @@
                 (Select
                     $input
                     (Filters
-                        [ (IsNot (ConstructAnyCondition $input $scalar $cmp) (False)) ]
+                        [ (IsNot (ConstructAnyCondition $input $scalar $subqueryDef) (False)) ]
                     )
                 )
+                $subqueryDef
             )
         )
     )

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -143,7 +143,7 @@
 # Project operator never changes the row cardinality of its input, and row
 # cardinality is the only thing that Exists cares about, so Project is a no-op.
 [EliminateExistsProject, Normalize]
-(Exists (Project $input:*)) => (Exists $input)
+(Exists (Project $input:*) $def:*) => (Exists $input $def)
 
 # EliminateExistsGroupBy discards a non-scalar GroupBy input to the Exists
 # operator. While non-scalar GroupBy (or DistinctOn) can change row cardinality,
@@ -151,7 +151,7 @@
 # input is empty, then it returns the empty set. Therefore, it's a no-op for
 # Exists.
 [EliminateExistsGroupBy, Normalize]
-(Exists (GroupBy | DistinctOn $input:*)) => (Exists $input)
+(Exists (GroupBy | DistinctOn $input:*) $def:*) => (Exists $input $def)
 
 # NormalizeJSONFieldAccess transforms field access into a containment with a
 # simpler LHS. This allows inverted index constraints to be generated in some

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -27,6 +27,7 @@
 [Scalar]
 define Subquery {
     Input Expr
+    Def   SubqueryDef
 }
 
 # Any is a SQL operator that applies a comparison to every row of an input
@@ -53,7 +54,7 @@ define Subquery {
 define Any {
     Input  Expr
     Scalar Expr
-    Cmp    Operator
+    Def    SubqueryDef
 }
 
 # Variable is the typed scalar value of a column in the query. The private
@@ -163,6 +164,7 @@ define MergeOn {
 [Scalar]
 define Exists {
     Input Expr
+    Def   SubqueryDef
 }
 
 # Filters is a boolean And operator that only appears as the Filters child of

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -231,6 +231,7 @@ func (b *Builder) buildScalar(
 						Ordering: oc,
 					}),
 				),
+				b.factory.InternSubqueryDef(&memo.SubqueryDef{OriginalExpr: s.expr}),
 			),
 			b.factory.ConstructArray(memo.EmptyList, typID),
 		}))

--- a/pkg/sql/opt/optgen/cmd/optgen/utils.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/utils.go
@@ -80,6 +80,8 @@ func mapPrivateType(typ string) string {
 		return "*memo.ShowTraceOpDef"
 	case "MergeOnDef":
 		return "*memo.MergeOnDef"
+	case "SubqueryDef":
+		return "*memo.SubqueryDef"
 	case "TupleOrdinal":
 		return "memo.TupleOrdinal"
 	case "Datum":


### PR DESCRIPTION
#### sql: rename "sql" to "original sql" in subquery EXPLAIN

With the optimizer, this field will show the original subquery which
might have been modified by transforms.

Release note: None

#### opt: remember subquery ASTs for explain

Store the original `*tree.Subquery` in `Any`, `Exists`, `Subquery` and
use it to populate the subquery during execbuild. This causes the
original subquery to show up in `EXPLAIN`.

Fixes #29350.

Release note: None
