### PR TITLE
backport-2.1: sql: fix panics from mismatched comp. col types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -739,3 +739,12 @@ UPSERT INTO error_check VALUES (1, 'foo')
 # Upsert -> insert
 statement error computed column i:
 UPSERT INTO error_check VALUES (3, 'foo')
+
+statement ok
+CREATE TABLE x (
+  a INT PRIMARY KEY,
+  b INT AS (a+1) STORED
+)
+
+query error value type decimal doesn't match type INT of column "a"
+INSERT INTO x VALUES(1.4)

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -833,6 +833,8 @@ func (p *planner) newPlan(
 		return p.Update(ctx, n, desiredTypes)
 	case *tree.ValuesClause:
 		return p.Values(ctx, n, desiredTypes)
+	case *tree.ValuesClauseWithNames:
+		return p.Values(ctx, n, desiredTypes)
 	default:
 		return nil, errors.Errorf("unknown statement type: %T", stmt)
 	}

--- a/pkg/sql/sem/tree/values.go
+++ b/pkg/sql/sem/tree/values.go
@@ -40,3 +40,15 @@ func (node *ValuesClause) Format(ctx *FmtCtx) {
 		comma = ", "
 	}
 }
+
+// ValuesClauseWithNames is a VALUES clause that has been annotated with column
+// names. This is only produced at plan time, never by the parser. It's used to
+// pass column names to the VALUES planNode, so it can produce intelligible
+// error messages during value type checking.
+type ValuesClauseWithNames struct {
+	ValuesClause
+
+	// Names is a list of the column names that each tuple in the ValuesClause
+	// corresponds to.
+	Names NameList
+}

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -15,13 +15,13 @@
 package sqlbase
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/cockroachdb/apd"
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
@@ -551,6 +551,53 @@ func EncodeDatumsKeyAscending(b []byte, d tree.Datums) ([]byte, error) {
 	return b, nil
 }
 
+// NewMismatchedTypeError creates an error indicating a mismatched value and
+// column type.
+func NewMismatchedTypeError(
+	valType types.T, colType ColumnType_SemanticType, colName string,
+) error {
+	return pgerror.NewErrorWithDepthf(1,
+		pgerror.CodeDatatypeMismatchError,
+		"value type %s doesn't match type %s of column %q",
+		valType, colType, colName)
+}
+
+// NewMismatchedLocaleError creates an error indicating a mismatched collated
+// string locale in a value and column.
+func NewMismatchedLocaleError(valLocale, colLocale string, colName string) error {
+	return pgerror.NewErrorWithDepthf(1,
+		pgerror.CodeDatatypeMismatchError,
+		"locale %q doesn't match locale %q of column %q",
+		valLocale, colLocale, colName)
+}
+
+// CheckColumnValueType checks to see if valType and colType are compatible,
+// returning an error similar to that of MarshalColumnValue if they're not.
+func CheckColumnValueType(valType types.T, colType ColumnType, colName string) error {
+	switch colType.SemanticType {
+	case ColumnType_ARRAY:
+		if t, ok := valType.(types.TArray); ok {
+			if err := checkElementType(t.Typ, colType); err != nil {
+				return err
+			}
+		}
+	case ColumnType_COLLATEDSTRING:
+		if t, ok := valType.(types.TCollatedString); ok {
+			if t.Locale != *colType.Locale {
+				return NewMismatchedLocaleError(t.Locale, *colType.Locale, colName)
+			}
+		}
+	}
+	valColType, err := DatumTypeToColumnType(valType)
+	if err != nil {
+		return err
+	}
+	if !valColType.Equal(colType) {
+		return NewMismatchedTypeError(valType, colType.SemanticType, colName)
+	}
+	return nil
+}
+
 // MarshalColumnValue produces the value encoding of the given datum,
 // constrained by the given column type, into a roachpb.Value.
 //
@@ -663,8 +710,7 @@ func MarshalColumnValue(col ColumnDescriptor, val tree.Datum) (roachpb.Value, er
 				r.SetString(v.Contents)
 				return r, nil
 			}
-			return r, fmt.Errorf("locale %q doesn't match locale %q of column %q",
-				v.Locale, *col.Type.Locale, col.Name)
+			return r, NewMismatchedLocaleError(v.Locale, *col.Type.Locale, col.Name)
 		}
 	case ColumnType_OID:
 		if v, ok := val.(*tree.DOid); ok {
@@ -674,8 +720,7 @@ func MarshalColumnValue(col ColumnDescriptor, val tree.Datum) (roachpb.Value, er
 	default:
 		return r, errors.Errorf("unsupported column type: %s", col.Type.SemanticType)
 	}
-	return r, fmt.Errorf("value type %s doesn't match type %s of column %q",
-		val.ResolvedType(), col.Type.SemanticType, col.Name)
+	return r, NewMismatchedTypeError(val.ResolvedType(), col.Type.SemanticType, col.Name)
 }
 
 // UnmarshalColumnValue is the counterpart to MarshalColumnValues.


### PR DESCRIPTION
Backport 2/2 commits from #25741.

/cc @cockroachdb/release

---

The first commit is #25682.

Fixes #25721.

Previously, inserting a value of the wrong type into a column depended
on by a computed column would panic the server. That's because we used
to defer enforcing type checking of insert values until marshalling
time.

This commit fixes the bug by correcting that long-standing problem: we
now enforce insert-value type checks at plan time instead of run time.

To do so, while preserving the nice error messages of the previous
approach that include the names of the columns that had mismatched
types, this commit introduces a new fake AST node called
ValuesClauseWithNames that is a values clause that includes column name
information. This is populated by insert nodes, so that the values
clause can type check itself at plan time and produce error messages
with column names.

Release note (bug fix): fix panic caused by inserting values of the
wrong type into columns depended on by computed columns.
