### PR TITLE
distsql: remove intentional panic in StreamDecoder.Types

### DIFF
--- a/pkg/sql/distsqlrun/data.pb.go
+++ b/pkg/sql/distsqlrun/data.pb.go
@@ -507,7 +507,8 @@ type ProducerMessage struct {
 	Header *ProducerHeader `protobuf:"bytes,1,opt,name=header" json:"header,omitempty"`
 	// Typing information. There will be one DatumInfo for each element in a row.
 	// This field has to be populated on, or before, a ProducerMessage with data
-	// in it, and can only be populated once.
+	// in it, and can only be populated once. It can be nil if only zero length
+	// rows will be sent.
 	// TODO(andrei): It'd be nice if the typing information for streams would be
 	// configured statically at plan creation time, instead of being discovered
 	// dynamically through the first rows that flow.

--- a/pkg/sql/distsqlrun/data.proto
+++ b/pkg/sql/distsqlrun/data.proto
@@ -223,7 +223,8 @@ message ProducerMessage {
 
   // Typing information. There will be one DatumInfo for each element in a row.
   // This field has to be populated on, or before, a ProducerMessage with data
-  // in it, and can only be populated once.
+  // in it, and can only be populated once. It can be nil if only zero length
+  // rows will be sent.
   // TODO(andrei): It'd be nice if the typing information for streams would be
   // configured statically at plan creation time, instead of being discovered
   // dynamically through the first rows that flow.

--- a/pkg/sql/distsqlrun/stream_decoder.go
+++ b/pkg/sql/distsqlrun/stream_decoder.go
@@ -176,9 +176,6 @@ func (sd *StreamDecoder) GetRow(
 // Types returns the types of the columns; can only be used after we received at
 // least one row.
 func (sd *StreamDecoder) Types() []sqlbase.ColumnType {
-	if !sd.typingReceived {
-		panic("no typing info received yet")
-	}
 	types := make([]sqlbase.ColumnType, len(sd.typing))
 	for i := range types {
 		types[i] = sd.typing[i].Type


### PR DESCRIPTION
Fixes #29553, which panics cockroachdb in three different logic test queries with vmodule logging enabled:
```
SELECT 3 FROM kv HAVING TRUE;
SELECT EXISTS(SELECT 1 FROM kv AS x WHERE x.k = 1);
SELECT count(*) FROM one AS a, one AS b, two AS c;
```

All three cases take advantage of the ability to send empty rows through a fast path.
This means that it is possible for typing information to never be sent, only empty rows. In
that case, calling StreamDecoder.Types() triggers the intentional panic.

The main problem arises due to the fact that the usage of `gogoproto.nullable = true` in our proto definitions means that we cannot distinguish between an intentionally empty slice and a nil slice (see https://github.com/gogo/protobuf/issues/218). Consider:

```
func TestMarshalNilSlice(t *testing.T) {
	foo := &ProducerMessage{
		Typing: make([]DatumInfo, 0),
	}

	if foo.Typing == nil {
		t.Fatalf("foo is nil")
	}

	marshaled, err := protoutil.Marshal(foo)
	if err != nil {
		t.Fatal(err)
	}

	bar := &ProducerMessage{}
	protoutil.Unmarshal(marshaled, bar)
	if err := bar.Unmarshal(marshaled); err != nil {
		t.Fatal(err)
	}

	if bar.Typing == nil {
		t.Fatalf("bar is nil")
	}
}
```

The output of this test is "bar is nil", even though it was a zero-length non-nil slice pre-marshaling and unmarshaling. Changing the proto definition to differentiate between these two cases is a more heavyweight change, and not one that I am convinced fixes the issue in all case. Instead we simply relax the DistSQL contract and accept that sometimes `Typing` will be nil.

I have left the code comment above the definition for `StreamDecoder.Types()`. It is still a correct precondition that only after a single row is received is the output of `Types()` valid. However, now if only empty rows have been received, the output will correctly be a zero-length slice of types.