### PR TITLE
gossip: fix propagation of unchanging gossip entries

### DIFF
--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -296,8 +296,11 @@ func (c *client) gossip(
 		default:
 		}
 	}
-	// Defer calling "undoer" callback returned from registration.
-	defer g.RegisterCallback(".*", updateCallback)()
+	// We require redundant callbacks here as the update callback is propagating
+	// gossip infos to other nodes and needs to propagate the new expiration
+	// info.
+	unregister := g.RegisterCallback(".*", updateCallback, Redundant)
+	defer unregister()
 
 	errCh := make(chan error, 1)
 	// This wait group is used to allow the caller to wait until gossip

--- a/pkg/gossip/server.go
+++ b/pkg/gossip/server.go
@@ -361,9 +361,12 @@ func (s *server) start(addr net.Addr) {
 		s.mu.ready = ready
 	}
 
+	// We require redundant callbacks here as the broadcast callback is
+	// propagating gossip infos to other nodes and needs to propagate the new
+	// expiration info.
 	unregister := s.mu.is.registerCallback(".*", func(_ string, _ roachpb.Value) {
 		broadcast()
-	})
+	}, Redundant)
 
 	s.stopper.RunWorker(context.TODO(), func(context.Context) {
 		<-s.stopper.ShouldQuiesce()


### PR DESCRIPTION
The gossip client and server code register callbacks that matches all
gossip keys in order to propagate those gossip entries to other
nodes. These callbacks need to fire even if the value is unchanging in
order to properly propagate updated expiration timestamps.

Release note: None