### PR TITLE
sql: correct help text for EXPORT

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1690,7 +1690,7 @@ import_stmt:
 // %Help: EXPORT - export data to file in a distributed manner
 // %Category: CCL
 // %Text:
-// EXPORT <format> (<datafile> [WITH <option> [= value] [,...]]) FROM <query>
+// EXPORT INTO <format> (<datafile> [WITH <option> [= value] [,...]]) FROM <query>
 //
 // Formats:
 //    CSV


### PR DESCRIPTION
Fixes #29280

Release note (bug fix): Correct help text for EXPORT.