### PR TITLE
opt: Estimate memory usage of Memo

### DIFF
--- a/pkg/sql/opt/memo/list_storage.go
+++ b/pkg/sql/opt/memo/list_storage.go
@@ -14,6 +14,10 @@
 
 package memo
 
+import (
+	"unsafe"
+)
+
 // ListID identifies a variable-sized list used by a memo expression and stored
 // by the memo. The ID consists of an offset into the memo's lists slice, plus
 // the number of elements in the list. Valid lists have offsets greater than 0;
@@ -137,6 +141,14 @@ type listStorageVal struct {
 func (ls *listStorage) init() {
 	ls.index = nil
 	ls.lists = ls.lists[:0]
+}
+
+// memoryEstimate returns a rough estimate of the list storage memory usage, in
+// bytes. It only includes memory usage that is proportional to the number of
+// list items, rather than constant overhead bytes.
+func (ls *listStorage) memoryEstimate() int64 {
+	const sizeList = int64(unsafe.Sizeof(ListID{}))
+	return int64(len(ls.lists)) * sizeList
 }
 
 // intern adds the given list to storage and returns an id that can later be

--- a/pkg/sql/opt/memo/memo_format.go
+++ b/pkg/sql/opt/memo/memo_format.go
@@ -57,9 +57,9 @@ func (m *Memo) format(f *memoFmtCtx) string {
 
 	var root treeprinter.Node
 	if m.isOptimized() {
-		root = tp.Child("memo (optimized)")
+		root = tp.Childf("memo (optimized, ~%dKB)", m.MemoryEstimate()/1024)
 	} else {
-		root = tp.Child("memo (not optimized)")
+		root = tp.Childf("memo (not optimized, ~%dKB)", m.MemoryEstimate()/1024)
 	}
 
 	for i := range f.ordering {

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -129,7 +129,7 @@ WHERE a.y>1 AND a.x::string=b.x
 ORDER BY y
 LIMIT 10
 ----
-memo (optimized)
+memo (optimized, ~17KB)
  ├── G1: (project G2 G3)
  │    ├── "[presentation: y:2,x:3,c:5] [ordering: +2]"
  │    │    ├── best: (project G2="[ordering: +2]" G3)
@@ -182,7 +182,7 @@ SELECT 1 AS a, 1+z AS b, left(x, 10)::TIMESTAMP AS c, left(x, 10)::TIMESTAMPTZ A
 FROM b
 WHERE z=1 AND concat(x, 'foo', x)=concat(x, 'foo', x)
 ----
-memo (optimized)
+memo (optimized, ~12KB)
  ├── G1: (project G2 G3)
  │    └── "[presentation: a:3,b:4,c:5,d:6]"
  │         ├── best: (project G2 G3)
@@ -215,7 +215,7 @@ memo (optimized)
 memo
 SELECT x FROM a WHERE x = 1 AND x+y = 1
 ----
-memo (optimized)
+memo (optimized, ~9KB)
  ├── G1: (project G2 G3)
  │    └── "[presentation: x:1]"
  │         ├── best: (project G2 G3)
@@ -246,7 +246,7 @@ memo raw-memo
 SELECT x FROM a WHERE x = 1 AND x+y = 1
 ----
 root: G12, [presentation: x:1]
-memo (optimized)
+memo (optimized, ~9KB)
  ├── G1: (scan a)
  │    └── ""
  │         ├── best: (scan a)
@@ -278,7 +278,7 @@ memo (optimized)
 memo 
 SELECT x, y FROM a UNION SELECT x+1, y+1 FROM a
 ----
-memo (optimized)
+memo (optimized, ~6KB)
  ├── G1: (union G2 G3)
  │    └── "[presentation: x:7,y:8]"
  │         ├── best: (union G2 G3)
@@ -305,7 +305,7 @@ memo (optimized)
 memo
 SELECT array_agg(x) FROM (SELECT * FROM a)
 ----
-memo (optimized)
+memo (optimized, ~4KB)
  ├── G1: (scalar-group-by G2 G3 cols=())
  │    └── "[presentation: array_agg:3]"
  │         ├── best: (scalar-group-by G2 G3 cols=())
@@ -321,7 +321,7 @@ memo (optimized)
 memo
 SELECT array_agg(x) FROM (SELECT * FROM a) GROUP BY y
 ----
-memo (optimized)
+memo (optimized, ~4KB)
  ├── G1: (project G2 G3)
  │    └── "[presentation: array_agg:3]"
  │         ├── best: (project G2 G3)
@@ -342,7 +342,7 @@ memo (optimized)
 memo
 SELECT array_agg(x) FROM (SELECT * FROM a ORDER BY y)
 ----
-memo (optimized)
+memo (optimized, ~3KB)
  ├── G1: (scalar-group-by G2 G3 cols=(),ordering=+2)
  │    └── "[presentation: array_agg:3]"
  │         ├── best: (scalar-group-by G2="[ordering: +2]" G3 cols=(),ordering=+2)
@@ -361,7 +361,7 @@ memo (optimized)
 memo
 SELECT DISTINCT field FROM [EXPLAIN SELECT 123 AS k]
 ----
-memo (optimized)
+memo (optimized, ~6KB)
  ├── G1: (distinct-on G2 G3 cols=(3))
  │    └── "[presentation: field:3]"
  │         ├── best: (distinct-on G2 G3 cols=(3))
@@ -386,7 +386,7 @@ memo (optimized)
 memo
 SELECT DISTINCT tag FROM [SHOW TRACE FOR SESSION]
 ----
-memo (optimized)
+memo (optimized, ~3KB)
  ├── G1: (distinct-on G2 G3 cols=(4))
  │    └── "[presentation: tag:4]"
  │         ├── best: (distinct-on G2 G3 cols=(4))

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -166,7 +166,7 @@ project
 memo
 SELECT y, x-1 AS z FROM a WHERE x>y ORDER BY x, y DESC
 ----
-memo (optimized)
+memo (optimized, ~8KB)
  ├── G1: (project G2 G3)
  │    ├── "[presentation: y:2,z:5] [ordering: +1,-2]"
  │    │    ├── best: (project G2="[ordering: +1,-2]" G3)
@@ -215,7 +215,7 @@ sort
 memo
 SELECT y, z FROM a WHERE x>y ORDER BY y
 ----
-memo (optimized)
+memo (optimized, ~6KB)
  ├── G1: (project G2 G3)
  │    ├── "[presentation: y:2,z:3] [ordering: +2]"
  │    │    ├── best: (sort G1)
@@ -291,7 +291,7 @@ explain
 memo
 EXPLAIN (VERBOSE) SELECT * FROM a ORDER BY y
 ----
-memo (optimized)
+memo (optimized, ~1KB)
  ├── G1: (explain G2 [presentation: x:1,y:2,z:3,s:4] [ordering: +2])
  │    └── "[presentation: tree:5,field:8,description:9,columns:10,ordering:11]"
  │         ├── best: (explain G2="[presentation: x:1,y:2,z:3,s:4] [ordering: +2]" [presentation: x:1,y:2,z:3,s:4] [ordering: +2])
@@ -311,7 +311,7 @@ memo (optimized)
 memo
 SELECT y FROM a WITH ORDINALITY ORDER BY ordinality
 ----
-memo (optimized)
+memo (optimized, ~3KB)
  ├── G1: (row-number G2)
  │    ├── "[presentation: y:2] [ordering: +5]"
  │    │    ├── best: (row-number G2)
@@ -327,7 +327,7 @@ memo (optimized)
 memo
 SELECT y FROM a WITH ORDINALITY ORDER BY -ordinality
 ----
-memo (optimized)
+memo (optimized, ~5KB)
  ├── G1: (project G2 G3)
  │    ├── "[presentation: y:2] [ordering: +6]"
  │    │    ├── best: (sort G1)
@@ -350,7 +350,7 @@ memo (optimized)
 memo
 SELECT y FROM a WITH ORDINALITY ORDER BY ordinality, x
 ----
-memo (optimized)
+memo (optimized, ~5KB)
  ├── G1: (row-number G2)
  │    ├── "[presentation: y:2] [ordering: +5]"
  │    │    ├── best: (row-number G2)
@@ -366,7 +366,7 @@ memo (optimized)
 memo
 SELECT y FROM (SELECT * FROM a ORDER BY y) WITH ORDINALITY ORDER BY y, ordinality
 ----
-memo (optimized)
+memo (optimized, ~3KB)
  ├── G1: (row-number G2 ordering=+2)
  │    ├── "[presentation: y:2] [ordering: +2,+5]"
  │    │    ├── best: (row-number G2="[ordering: +2]" ordering=+2)
@@ -385,7 +385,7 @@ memo (optimized)
 memo
 SELECT y FROM (SELECT * FROM a ORDER BY y) WITH ORDINALITY ORDER BY ordinality, y
 ----
-memo (optimized)
+memo (optimized, ~3KB)
  ├── G1: (row-number G2 ordering=+2)
  │    ├── "[presentation: y:2] [ordering: +5]"
  │    │    ├── best: (row-number G2="[ordering: +2]" ordering=+2)
@@ -404,7 +404,7 @@ memo (optimized)
 memo
 SELECT y FROM a WITH ORDINALITY ORDER BY ordinality DESC
 ----
-memo (optimized)
+memo (optimized, ~3KB)
  ├── G1: (row-number G2)
  │    ├── "[presentation: y:2] [ordering: -5]"
  │    │    ├── best: (sort G1)

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -461,7 +461,7 @@ project
 memo
 SELECT min(a) FROM abc
 ----
-memo (optimized)
+memo (optimized, ~10KB)
  ├── G1: (scalar-group-by G6 G2 cols=()) (scalar-group-by G3 G4 cols=())
  │    └── "[presentation: min:5]"
  │         ├── best: (scalar-group-by G3 G4 cols=())
@@ -487,7 +487,7 @@ memo (optimized)
 memo
 SELECT min(b) FROM abc
 ----
-memo (optimized)
+memo (optimized, ~10KB)
  ├── G1: (scalar-group-by G9 G2 cols=()) (scalar-group-by G3 G4 cols=())
  │    └── "[presentation: min:5]"
  │         ├── best: (scalar-group-by G9 G2 cols=())
@@ -523,7 +523,7 @@ memo (optimized)
 memo
 SELECT max(a) FROM abc
 ----
-memo (optimized)
+memo (optimized, ~10KB)
  ├── G1: (scalar-group-by G6 G2 cols=()) (scalar-group-by G3 G4 cols=())
  │    └── "[presentation: max:5]"
  │         ├── best: (scalar-group-by G3 G4 cols=())
@@ -549,7 +549,7 @@ memo (optimized)
 memo
 SELECT max(b) FROM abc
 ----
-memo (optimized)
+memo (optimized, ~10KB)
  ├── G1: (scalar-group-by G9 G2 cols=()) (scalar-group-by G3 G4 cols=())
  │    └── "[presentation: max:5]"
  │         ├── best: (scalar-group-by G9 G2 cols=())
@@ -638,7 +638,7 @@ scalar-group-by
 memo
 select max(b) from abc
 ----
-memo (optimized)
+memo (optimized, ~10KB)
  ├── G1: (scalar-group-by G9 G2 cols=()) (scalar-group-by G3 G4 cols=())
  │    └── "[presentation: max:5]"
  │         ├── best: (scalar-group-by G9 G2 cols=())

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -86,7 +86,7 @@ TABLE xyz
 memo
 SELECT * FROM abc JOIN xyz ON a=z
 ----
-memo (optimized)
+memo (optimized, ~9KB)
  ├── G1: (inner-join G2 G4 G5) (inner-join G4 G2 G5) (merge-join G2 G4 G3) (lookup-join G4 G5 abc@ab,keyCols=[7],lookupCols=(1-3))
  │    └── "[presentation: a:1,b:2,c:3,x:5,y:6,z:7]"
  │         ├── best: (inner-join G2 G4 G5)
@@ -114,7 +114,7 @@ memo (optimized)
 memo
 SELECT * FROM abc FULL OUTER JOIN xyz ON a=z
 ----
-memo (optimized)
+memo (optimized, ~9KB)
  ├── G1: (full-join G2 G3 G5) (full-join G3 G2 G5) (merge-join G2 G3 G4)
  │    └── "[presentation: a:1,b:2,c:3,x:5,y:6,z:7]"
  │         ├── best: (full-join G2 G3 G5)
@@ -181,7 +181,7 @@ full-join
 memo
 SELECT * FROM abc LEFT OUTER JOIN xyz ON a=z
 ----
-memo (optimized)
+memo (optimized, ~9KB)
  ├── G1: (left-join G2 G3 G5) (right-join G3 G2 G5) (merge-join G2 G3 G4)
  │    └── "[presentation: a:1,b:2,c:3,x:5,y:6,z:7]"
  │         ├── best: (left-join G2 G3 G5)
@@ -228,7 +228,7 @@ right-join
 memo
 SELECT * FROM abc RIGHT OUTER JOIN xyz ON a=z
 ----
-memo (optimized)
+memo (optimized, ~9KB)
  ├── G1: (right-join G2 G4 G5) (left-join G4 G2 G5) (merge-join G2 G4 G3) (lookup-join G4 G5 abc@ab,keyCols=[7],lookupCols=(1-3))
  │    └── "[presentation: a:1,b:2,c:3,x:5,y:6,z:7]"
  │         ├── best: (right-join G2 G4 G5)
@@ -293,7 +293,7 @@ inner-join (merge)
 memo
 SELECT * FROM abc JOIN xyz ON a=x
 ----
-memo (optimized)
+memo (optimized, ~10KB)
  ├── G1: (inner-join G3 G5 G6) (inner-join G5 G3 G6) (merge-join G3 G5 G2) (lookup-join G3 G6 xyz@xy,keyCols=[1],lookupCols=(5-7)) (merge-join G5 G3 G4) (lookup-join G5 G6 abc@ab,keyCols=[5],lookupCols=(1-3))
  │    └── "[presentation: a:1,b:2,c:3,x:5,y:6,z:7]"
  │         ├── best: (merge-join G3="[ordering: +1]" G5="[ordering: +5]" G2)
@@ -381,7 +381,7 @@ inner-join
 memo
 SELECT * FROM stu AS l JOIN stu AS r ON (l.s, l.t, l.u) = (r.s, r.t, r.u)
 ----
-memo (optimized)
+memo (optimized, ~15KB)
  ├── G1: (inner-join G5 G7 G8) (inner-join G7 G5 G8) (merge-join G5 G7 G2) (merge-join G5 G7 G3) (lookup-join G5 G8 stu,keyCols=[1 2 3],lookupCols=(4-6)) (lookup-join G5 G8 stu@uts,keyCols=[3 2 1],lookupCols=(4-6)) (merge-join G7 G5 G4) (merge-join G7 G5 G6) (lookup-join G7 G8 stu,keyCols=[4 5 6],lookupCols=(1-3)) (lookup-join G7 G8 stu@uts,keyCols=[6 5 4],lookupCols=(1-3))
  │    └── "[presentation: s:1,t:2,u:3,s:4,t:5,u:6]"
  │         ├── best: (merge-join G5="[ordering: +1,+2,+3]" G7="[ordering: +4,+5,+6]" G2)
@@ -611,7 +611,7 @@ left-join (merge)
 memo
 SELECT * FROM abc JOIN xyz ON a=b
 ----
-memo (optimized)
+memo (optimized, ~12KB)
  ├── G1: (inner-join G3 G2 G4) (inner-join G2 G3 G4)
  │    └── "[presentation: a:1,b:2,c:3,x:5,y:6,z:7]"
  │         ├── best: (inner-join G2 G3 G4)
@@ -653,7 +653,7 @@ TABLE kfloat
 memo
 SELECT * FROM abc JOIN kfloat ON a=k
 ----
-memo (optimized)
+memo (optimized, ~7KB)
  ├── G1: (inner-join G3 G2 G4) (inner-join G2 G3 G4)
  │    └── "[presentation: a:1,b:2,c:3,k:5]"
  │         ├── best: (inner-join G3 G2 G4)

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -117,7 +117,7 @@ limit
 memo
 SELECT s FROM a WHERE s='foo' LIMIT 1
 ----
-memo (optimized)
+memo (optimized, ~8KB)
  ├── G1: (limit G2 G3) (scan a@s_idx,cols=(4),constrained,lim=1) (scan a@si_idx,cols=(4),constrained,lim=1)
  │    └── "[presentation: s:4]"
  │         ├── best: (scan a@s_idx,cols=(4),constrained,lim=1)

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -73,7 +73,7 @@ scan a,rev
 memo
 SELECT k,f FROM a ORDER BY k DESC LIMIT 10
 ----
-memo (optimized)
+memo (optimized, ~3KB)
  ├── G1: (limit G2 G3 ordering=-1) (scan a,rev,cols=(1,3),lim=10(rev))
  │    ├── "[presentation: k:1,f:3] [ordering: -1]"
  │    │    ├── best: (scan a,rev,cols=(1,3),lim=10(rev))
@@ -167,7 +167,7 @@ scan a@si_idx,rev
 memo
 SELECT k FROM a ORDER BY k ASC
 ----
-memo (optimized)
+memo (optimized, ~2KB)
  └── G1: (scan a,cols=(1)) (scan a@s_idx,cols=(1)) (scan a@si_idx,cols=(1))
       ├── "[presentation: k:1] [ordering: +1]"
       │    ├── best: (scan a,cols=(1))
@@ -189,7 +189,7 @@ scan a@s_idx
 memo
 SELECT s, i, f FROM a ORDER BY s, k, i
 ----
-memo (optimized)
+memo (optimized, ~2KB)
  └── G1: (scan a,cols=(1-4)) (scan a@s_idx,cols=(1-4))
       ├── "[presentation: s:4,i:2,f:3] [ordering: +4,+1]"
       │    ├── best: (scan a@s_idx,cols=(1-4))
@@ -281,7 +281,7 @@ New expression 2 of 2:
 memo
 SELECT s, i, f FROM a ORDER BY f
 ----
-memo (optimized)
+memo (optimized, ~2KB)
  └── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4))
       ├── "[presentation: s:4,i:2,f:3] [ordering: +3]"
       │    ├── best: (sort G1)
@@ -293,7 +293,7 @@ memo (optimized)
 memo
 SELECT s, i, f FROM a ORDER BY s DESC, i
 ----
-memo (optimized)
+memo (optimized, ~2KB)
  └── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4))
       ├── "[presentation: s:4,i:2,f:3] [ordering: -4,+2]"
       │    ├── best: (sort G1)
@@ -305,7 +305,7 @@ memo (optimized)
 memo
 SELECT s, i, f FROM a WHERE s='foo' ORDER BY s DESC, i
 ----
-memo (optimized)
+memo (optimized, ~7KB)
  ├── G1: (select G2 G3) (scan a@s_idx,cols=(2-4),constrained) (index-join G4 a,cols=(2-4))
  │    ├── "[presentation: s:4,i:2,f:3] [ordering: +2 opt(4)]"
  │    │    ├── best: (sort G1)
@@ -380,7 +380,7 @@ TABLE abc
 memo
 SELECT d FROM abc ORDER BY lower(d)
 ----
-memo (optimized)
+memo (optimized, ~4KB)
  ├── G1: (project G2 G3)
  │    ├── "[presentation: d:4] [ordering: +5]"
  │    │    ├── best: (sort G1)
@@ -399,7 +399,7 @@ memo (optimized)
 memo
 SELECT j FROM a WHERE s = 'foo'
 ----
-memo (optimized)
+memo (optimized, ~8KB)
  ├── G1: (project G2 G3)
  │    └── "[presentation: j:5]"
  │         ├── best: (project G2 G3)
@@ -435,7 +435,7 @@ scan a
 memo
 SELECT s, i, f FROM a ORDER BY k, i, s
 ----
-memo (optimized)
+memo (optimized, ~2KB)
  └── G1: (scan a,cols=(1-4)) (scan a@s_idx,cols=(1-4))
       ├── "[presentation: s:4,i:2,f:3] [ordering: +1]"
       │    ├── best: (scan a,cols=(1-4))
@@ -455,7 +455,7 @@ scan a@si_idx,rev
 memo
 SELECT s, j FROM a ORDER BY s
 ----
-memo (optimized)
+memo (optimized, ~2KB)
  └── G1: (scan a,cols=(4,5)) (scan a@si_idx,cols=(4,5))
       ├── "[presentation: s:4,j:5] [ordering: +4]"
       │    ├── best: (scan a@si_idx,rev,cols=(4,5))
@@ -481,7 +481,7 @@ sort
 memo
 SELECT i, k FROM a ORDER BY s DESC, i, k
 ----
-memo (optimized)
+memo (optimized, ~2KB)
  └── G1: (scan a,cols=(1,2,4)) (scan a@s_idx,cols=(1,2,4)) (scan a@si_idx,cols=(1,2,4))
       ├── "[presentation: i:2,k:1] [ordering: -4,+2,+1]"
       │    ├── best: (sort G1)
@@ -493,7 +493,7 @@ memo (optimized)
 memo
 SELECT i, k FROM a WHERE s >= 'foo'
 ----
-memo (optimized)
+memo (optimized, ~7KB)
  ├── G1: (project G2 G3)
  │    └── "[presentation: i:2,k:1]"
  │         ├── best: (project G2 G3)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -69,7 +69,7 @@ scan a
 memo
 SELECT k FROM a WHERE k = 1
 ----
-memo (optimized)
+memo (optimized, ~7KB)
  ├── G1: (select G2 G3) (scan a,cols=(1),constrained)
  │    └── "[presentation: k:1]"
  │         ├── best: (scan a,cols=(1),constrained)
@@ -98,7 +98,7 @@ project
 memo
 SELECT k FROM a WHERE v > 1
 ----
-memo (optimized)
+memo (optimized, ~7KB)
  ├── G1: (project G2 G3)
  │    └── "[presentation: k:1]"
  │         ├── best: (project G2 G3)
@@ -135,7 +135,7 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND k = 5
 ----
-memo (optimized)
+memo (optimized, ~11KB)
  ├── G1: (project G2 G3)
  │    └── "[presentation: k:1]"
  │         ├── best: (project G2 G3)
@@ -184,7 +184,7 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND k+u = 1
 ----
-memo (optimized)
+memo (optimized, ~11KB)
  ├── G1: (project G2 G3)
  │    └── "[presentation: k:1]"
  │         ├── best: (project G2 G3)
@@ -236,7 +236,7 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND v = 5
 ----
-memo (optimized)
+memo (optimized, ~11KB)
  ├── G1: (project G2 G3)
  │    └── "[presentation: k:1]"
  │         ├── best: (project G2 G3)
@@ -326,7 +326,7 @@ index-join b
 memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10
 ----
-memo (optimized)
+memo (optimized, ~7KB)
  ├── G1: (select G2 G3) (index-join G4 b,cols=(1-4))
  │    └── "[presentation: k:1,u:2,v:3,j:4]"
  │         ├── best: (index-join G4 b,cols=(1-4))
@@ -383,7 +383,7 @@ index-join b
 memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k > 5
 ----
-memo (optimized)
+memo (optimized, ~12KB)
  ├── G1: (select G2 G3) (select G4 G5) (index-join G6 b,cols=(1-4))
  │    └── "[presentation: k:1,u:2,v:3,j:4]"
  │         ├── best: (index-join G6 b,cols=(1-4))
@@ -475,7 +475,7 @@ select
 memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1
 ----
-memo (optimized)
+memo (optimized, ~12KB)
  ├── G1: (select G2 G3) (select G4 G5)
  │    └── "[presentation: k:1,u:2,v:3,j:4]"
  │         ├── best: (select G4 G5)
@@ -532,7 +532,7 @@ select
 memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1 AND k > 5
 ----
-memo (optimized)
+memo (optimized, ~17KB)
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7)
  │    └── "[presentation: k:1,u:2,v:3,j:4]"
  │         ├── best: (select G6 G7)
@@ -597,7 +597,7 @@ select
 memo
 SELECT * FROM b WHERE (u, k, v) > (1, 2, 3) AND (u, k, v) < (8, 9, 10)
 ----
-memo (optimized)
+memo (optimized, ~13KB)
  ├── G1: (select G2 G4) (select G3 G4)
  │    └── "[presentation: k:1,u:2,v:3,j:4]"
  │         ├── best: (select G3 G4)


### PR DESCRIPTION
Add a bit of code to derive a rough estimate of a Memo's memory usage.
This (deliberately) focuses on memory usage that is proportional to the
size and complexity of the query, rather than constant overhead bytes.

This PR is a prerequisite to caching prepared memos.

Release note: None