### PR TITLE
release-2.1: changefeedccl: fix enterprise `WITH cursor=` option

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -328,6 +328,17 @@ func (b *changefeedResumer) Resume(
 	phs := planHookState.(sql.PlanHookState)
 	details := job.Details().(jobspb.ChangefeedDetails)
 	progress := job.Progress()
+
+	// TODO(dan): This is a workaround for not being able to set an initial
+	// progress high-water when creating a job (currently only the progress
+	// details can be set). I didn't want to pick off the refactor to get this
+	// fix in, but it'd be nice to remove this hack.
+	if _, ok := details.Opts[optCursor]; ok {
+		if h := progress.GetHighWater(); h == nil || *h == (hlc.Timestamp{}) {
+			progress.Progress = &jobspb.Progress_HighWater{HighWater: &details.StatementTime}
+		}
+	}
+
 	err := distChangefeedFlow(ctx, phs, *job.ID(), details, progress, startedCh)
 	if err != nil {
 		log.Infof(ctx, `CHANGEFEED job %d returning with error: %v`, *job.ID(), err)


### PR DESCRIPTION
Backport 1/1 commits from #29611.

/cc @cockroachdb/release

---

`TestChangefeedCursor` would have caught this, but we currently run all
our tests only on the sinkless version. Originally, everything but the
sink code was the same between the core and the enterprise versions, but
they've diverged over time. This has been worrying me and turns out
those fears were well-founded. No test for this fix in this commit, but
I'll very soon send a followup PR that runs all our tests over both
versions.

This also should fix the roachtest.

Closes #28934

Release note (bug fix): enterprise CHANGEFEEDs now correctly skip the
initial scan when started with the `cursor=` option
