### PR TITLE
release-2.1: distsqlrun,kv,client: don't create flows in aborted txns

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -88,7 +88,7 @@ func newChangeAggregatorProcessor(
 		output,
 		memMonitor,
 		distsqlrun.ProcStateOpts{
-			TrailingMetaCallback: func() []distsqlrun.ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []distsqlrun.ProducerMetadata {
 				ca.close()
 				return nil
 			},
@@ -317,7 +317,7 @@ func newChangeFrontierProcessor(
 		output,
 		memMonitor,
 		distsqlrun.ProcStateOpts{
-			TrailingMetaCallback: func() []distsqlrun.ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []distsqlrun.ProducerMetadata {
 				cf.close()
 				return nil
 			},

--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -161,7 +161,7 @@ func TestRemoveDeadReplicas(t *testing.T) {
 		s := sqlutils.MakeSQLRunner(tc.Conns[0])
 		s.Exec(t, "set cluster setting cluster.organization='remove dead replicas test'")
 
-		txn := client.NewTxn(tc.Servers[0].DB(), 1, client.RootTxn)
+		txn := client.NewTxn(ctx, tc.Servers[0].DB(), 1, client.RootTxn)
 		var desc roachpb.RangeDescriptor
 		// Pick one of the predefined split points.
 		rdKey := keys.RangeDescriptorKey(roachpb.RKey(keys.TimeseriesPrefix))

--- a/pkg/internal/client/client_test.go
+++ b/pkg/internal/client/client_test.go
@@ -963,7 +963,7 @@ func TestNodeIDAndObservedTimestamps(t *testing.T) {
 	}
 	for i, test := range directCases {
 		t.Run(fmt.Sprintf("direct-txn-%d", i), func(t *testing.T) {
-			txn := client.NewTxn(db, test.nodeID, test.typ)
+			txn := client.NewTxn(ctx, db, test.nodeID, test.typ)
 			ots := txn.Serialize().ObservedTimestamps
 			if (len(ots) == 1 && ots[0].NodeID == test.nodeID) != test.expObserved {
 				t.Errorf("expected observed ts %t; got %+v", test.expObserved, ots)

--- a/pkg/internal/client/db.go
+++ b/pkg/internal/client/db.go
@@ -570,7 +570,7 @@ func (db *DB) Txn(ctx context.Context, retryable func(context.Context, *Txn) err
 	// TODO(radu): we should open a tracing Span here (we need to figure out how
 	// to use the correct tracer).
 
-	txn := NewTxn(db, db.ctx.NodeID.Get(), RootTxn)
+	txn := NewTxn(ctx, db, db.ctx.NodeID.Get(), RootTxn)
 	txn.SetDebugName("unnamed")
 	err := txn.exec(ctx, func(ctx context.Context, txn *Txn) error {
 		return retryable(ctx, txn)

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -822,23 +822,6 @@ func (txn *Txn) GetTxnCoordMeta() roachpb.TxnCoordMeta {
 	return txn.mu.sender.GetMeta()
 }
 
-// GetStrippedTxnCoordMeta is like GetTxnCoordMeta, but it strips out all
-// information that is unnecessary to communicate to other distributed
-// transaction coordinators that are all operating on the same transaction.
-func (txn *Txn) GetStrippedTxnCoordMeta() roachpb.TxnCoordMeta {
-	meta := txn.GetTxnCoordMeta()
-	switch txn.typ {
-	case RootTxn:
-		meta.Intents = nil
-		meta.CommandCount = 0
-		meta.RefreshReads = nil
-		meta.RefreshWrites = nil
-	case LeafTxn:
-		meta.OutstandingWrites = nil
-	}
-	return meta
-}
-
 // AugmentTxnCoordMeta augments this transaction's TxnCoordMeta
 // information with the supplied meta. For use with GetTxnCoordMeta().
 func (txn *Txn) AugmentTxnCoordMeta(ctx context.Context, meta roachpb.TxnCoordMeta) {

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -135,6 +135,10 @@ func NewTxnWithCoordMeta(
 	if db == nil {
 		log.Fatalf(context.TODO(), "attempting to create txn with nil db for Transaction: %s", meta.Txn)
 	}
+	if meta.Txn.Status != roachpb.PENDING {
+		log.Fatal(context.TODO(), "can't create txn with non-PENDING proto: %s",
+			meta.Txn)
+	}
 	meta.Txn.AssertInitialized(context.TODO())
 	txn := &Txn{db: db, typ: typ, gatewayNodeID: gatewayNodeID}
 	txn.mu.ID = meta.Txn.ID

--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -1811,10 +1811,10 @@ func TestAsyncAbortPoisons(t *testing.T) {
 	db := s.DB()
 
 	// Write values to key "a".
-	txn := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)
+	txn := client.NewTxn(ctx, db, 0 /* gatewayNodeID */, client.RootTxn)
 	b := txn.NewBatch()
 	b.Put(keyA, []byte("value"))
-	if err := txn.Run(context.TODO(), b); err != nil {
+	if err := txn.Run(ctx, b); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kv/integration_test.go
+++ b/pkg/kv/integration_test.go
@@ -150,13 +150,13 @@ func TestDelayedBeginRetryable(t *testing.T) {
 		s.DistSender(),
 	)
 	db := client.NewDB(ambient, tsf, s.Clock())
-	txn := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)
+	txn := client.NewTxn(ctx, db, 0 /* gatewayNodeID */, client.RootTxn)
 
 	pushErr := make(chan error)
 	go func() {
 		<-unblockPush
 		// Conflicting transaction that pushes the above transaction.
-		conflictTxn := client.NewTxn(origDB, 0 /* gatewayNodeID */, client.RootTxn)
+		conflictTxn := client.NewTxn(ctx, origDB, 0 /* gatewayNodeID */, client.RootTxn)
 		// Push through a Put, as opposed to a Get, so that the pushee gets aborted.
 		if err := conflictTxn.Put(ctx, key2, "pusher was here"); err != nil {
 			pushErr <- err

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -481,7 +481,9 @@ func (tcf *TxnCoordSenderFactory) Metrics() TxnMetrics {
 }
 
 // GetMeta is part of the client.TxnSender interface.
-func (tc *TxnCoordSender) GetMeta() roachpb.TxnCoordMeta {
+func (tc *TxnCoordSender) GetMeta(
+	ctx context.Context, opt client.TxnStatusOpt,
+) (roachpb.TxnCoordMeta, error) {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 	// Copy mutable state so access is safe for the caller.
@@ -490,7 +492,14 @@ func (tc *TxnCoordSender) GetMeta() roachpb.TxnCoordMeta {
 	for _, reqInt := range tc.interceptorStack {
 		reqInt.populateMetaLocked(&meta)
 	}
-	return meta
+	if opt == client.OnlyPending && meta.Txn.Status != roachpb.PENDING {
+		rejectErr := tc.maybeRejectClientLocked(ctx, nil /* ba */)
+		if rejectErr == nil {
+			log.Fatal(ctx, "expected non-nil rejectErr")
+		}
+		return roachpb.TxnCoordMeta{}, rejectErr.GoError()
+	}
+	return meta, nil
 }
 
 // AugmentMeta is part of the client.TxnSender interface.
@@ -683,6 +692,9 @@ func (tc *TxnCoordSender) maybeSleepForLinearizable(
 // maybeRejectClientLocked checks whether the transaction is in a state that
 // prevents it from continuing, such as the heartbeat having detected the
 // transaction to have been aborted.
+//
+// ba is the batch that the client is trying to send. It's inspected because
+// rollbacks are always allowed. Can be nil.
 func (tc *TxnCoordSender) maybeRejectClientLocked(
 	ctx context.Context, ba *roachpb.BatchRequest,
 ) *roachpb.Error {

--- a/pkg/kv/txn_coord_sender_server_test.go
+++ b/pkg/kv/txn_coord_sender_server_test.go
@@ -77,7 +77,7 @@ func TestHeartbeatFindsOutAboutAbortedTransaction(t *testing.T) {
 
 	push := func(ctx context.Context, key roachpb.Key) error {
 		// Conflicting transaction that pushes the above transaction.
-		conflictTxn := client.NewTxn(origDB, 0 /* gatewayNodeID */, client.RootTxn)
+		conflictTxn := client.NewTxn(ctx, origDB, 0 /* gatewayNodeID */, client.RootTxn)
 		// We need to explicitly set a high priority for the push to happen.
 		if err := conflictTxn.SetUserPriority(roachpb.MaxUserPriority); err != nil {
 			return err
@@ -103,7 +103,7 @@ func TestHeartbeatFindsOutAboutAbortedTransaction(t *testing.T) {
 		s.DistSender(),
 	)
 	db := client.NewDB(ambient, tsf, s.Clock())
-	txn := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)
+	txn := client.NewTxn(ctx, db, 0 /* gatewayNodeID */, client.RootTxn)
 	if err := txn.Put(ctx, key, "val"); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/txn_coord_sender_server_test.go
+++ b/pkg/kv/txn_coord_sender_server_test.go
@@ -117,7 +117,7 @@ func TestHeartbeatFindsOutAboutAbortedTransaction(t *testing.T) {
 
 	// Now wait until the heartbeat loop notices that the transaction is aborted.
 	testutils.SucceedsSoon(t, func() error {
-		if txn.GetTxnCoordMeta().Txn.Status != roachpb.ABORTED {
+		if txn.GetTxnCoordMeta(ctx).Txn.Status != roachpb.ABORTED {
 			return fmt.Errorf("txn not aborted yet")
 		}
 		return nil

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -133,6 +133,8 @@ func TestTxnCoordSenderBeginTransaction(t *testing.T) {
 // the minimum number of ranges.
 func TestTxnCoordSenderKeyRanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	ctx := context.TODO()
 	ranges := []struct {
 		start, end roachpb.Key
 	}{
@@ -152,11 +154,11 @@ func TestTxnCoordSenderKeyRanges(t *testing.T) {
 
 	for _, rng := range ranges {
 		if rng.end != nil {
-			if err := txn.DelRange(context.TODO(), rng.start, rng.end); err != nil {
+			if err := txn.DelRange(ctx, rng.start, rng.end); err != nil {
 				t.Fatal(err)
 			}
 		} else {
-			if err := txn.Put(context.TODO(), rng.start, []byte("value")); err != nil {
+			if err := txn.Put(ctx, rng.start, []byte("value")); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -164,7 +166,11 @@ func TestTxnCoordSenderKeyRanges(t *testing.T) {
 
 	// Verify that the transaction metadata contains only two entries
 	// in its intents slice. "a" and range "aa"-"c".
-	intents, _ := roachpb.MergeSpans(tc.GetMeta().Intents)
+	meta, err := tc.GetMeta(ctx, client.AnyTxnStatus)
+	if err != nil {
+		t.Fatal(err)
+	}
+	intents, _ := roachpb.MergeSpans(meta.Intents)
 	if len(intents) != 2 {
 		t.Errorf("expected 2 entries in keys range group; got %v", intents)
 	}
@@ -260,19 +266,20 @@ func TestTxnCoordSenderCondenseIntentSpans(t *testing.T) {
 		ds,
 	)
 	db := client.NewDB(ambient, tsf, s.Clock)
+	ctx := context.Background()
 
 	txn := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)
 	for i, tc := range testCases {
 		if tc.span.EndKey != nil {
-			if err := txn.DelRange(context.TODO(), tc.span.Key, tc.span.EndKey); err != nil {
+			if err := txn.DelRange(ctx, tc.span.Key, tc.span.EndKey); err != nil {
 				t.Fatal(err)
 			}
 		} else {
-			if err := txn.Put(context.TODO(), tc.span.Key, []byte("value")); err != nil {
+			if err := txn.Put(ctx, tc.span.Key, []byte("value")); err != nil {
 				t.Fatal(err)
 			}
 		}
-		meta := txn.GetTxnCoordMeta()
+		meta := txn.GetTxnCoordMeta(ctx)
 		if a, e := meta.Intents, tc.expIntents; !reflect.DeepEqual(a, e) {
 			t.Errorf("%d: expected keys %+v; got %+v", i, e, a)
 		}
@@ -532,23 +539,31 @@ func TestTxnCoordSenderAddIntentOnError(t *testing.T) {
 	s := createTestDB(t)
 	defer s.Stop()
 
+	ctx := context.Background()
+
 	// Create a transaction with intent at "x".
 	key := roachpb.Key("x")
 	txn := client.NewTxn(s.DB, 0 /* gatewayNodeID */, client.RootTxn)
 	tc := txn.Sender().(*TxnCoordSender)
 
 	// Write so that the coordinator begins tracking this txn.
-	if err := txn.Put(context.TODO(), "x", "y"); err != nil {
+	if err := txn.Put(ctx, "x", "y"); err != nil {
 		t.Fatal(err)
 	}
-	err, ok := txn.CPut(context.TODO(), key, []byte("x"), []byte("born to fail")).(*roachpb.ConditionFailedError)
-	if !ok {
+	{
+		err, ok := txn.CPut(ctx, key, []byte("x"), []byte("born to fail")).(*roachpb.ConditionFailedError)
+		if !ok {
+			t.Fatal(err)
+		}
+	}
+	meta, err := tc.GetMeta(ctx, client.AnyTxnStatus)
+	if err != nil {
 		t.Fatal(err)
 	}
-	intentSpans, _ := roachpb.MergeSpans(tc.GetMeta().Intents)
+	intentSpans, _ := roachpb.MergeSpans(meta.Intents)
 	expSpans := []roachpb.Span{{Key: key, EndKey: []byte("")}}
 	equal := !reflect.DeepEqual(intentSpans, expSpans)
-	if err := txn.Rollback(context.TODO()); err != nil {
+	if err := txn.Rollback(ctx); err != nil {
 		t.Fatal(err)
 	}
 	if !equal {
@@ -867,9 +882,13 @@ func TestTxnMultipleCoord(t *testing.T) {
 	}
 
 	// Augment txn with txn2's meta & commit.
-	txn.AugmentTxnCoordMeta(ctx, txn2.GetTxnCoordMeta())
+	txn.AugmentTxnCoordMeta(ctx, txn2.GetTxnCoordMeta(ctx))
 	// Verify presence of both intents.
-	if a, e := tc.GetMeta().RefreshReads, []roachpb.Span{{Key: key}, {Key: key2}}; !reflect.DeepEqual(a, e) {
+	meta, err := tc.GetMeta(ctx, client.AnyTxnStatus)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a, e := meta.RefreshReads, []roachpb.Span{{Key: key}, {Key: key2}}; !reflect.DeepEqual(a, e) {
 		t.Fatalf("expected read spans %+v; got %+v", e, a)
 	}
 	ba := txn.NewBatch()
@@ -1604,7 +1623,11 @@ func TestIntentTrackingBeforeBeginTransaction(t *testing.T) {
 		t.Fatal(pErr)
 	}
 
-	if numSpans := len(tcs.GetMeta().Intents); numSpans != 1 {
+	meta, err := tcs.GetMeta(ctx, client.AnyTxnStatus)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if numSpans := len(meta.Intents); numSpans != 1 {
 		t.Fatalf("expected 1 intent span, got: %d", numSpans)
 	}
 }

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -20,12 +20,10 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -2457,12 +2455,9 @@ func TestCommitTurnedToRollback(t *testing.T) {
 
 	// Attempt to commit again, at the next epoch. This should succeed, and the
 	// commit should be turned to a rollback.
-	tr := tracing.NewTracer()
-	sp := tr.StartSpan("test", tracing.Recordable)
-	tracing.StartRecording(sp, tracing.SingleNodeRecording)
-	commitCtx := opentracing.ContextWithSpan(ctx, sp)
+	commitCtx, getRec, cancel := tracing.ContextWithRecordingSpan(ctx, "test")
+	defer cancel()
 	err = txn.Commit(commitCtx)
-	sp.Finish()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2478,20 +2473,7 @@ func TestCommitTurnedToRollback(t *testing.T) {
 
 	// Look for a specific log message indicating that this test is not fooling
 	// itself and indeed we transformed a commit to a rollback.
-	var found bool
-	for _, recSp := range tracing.GetRecording(sp) {
-		msg := ""
-		for _, l := range recSp.Logs {
-			for _, f := range l.Fields {
-				msg = msg + fmt.Sprintf("  %s: %v", f.Key, f.Value)
-			}
-		}
-		if strings.Contains(msg, turningCommitToRollbackMsg) {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if tracing.FindMsgInRecording(getRec(), turningCommitToRollbackMsg) == -1 {
 		t.Fatalf("didn't find trace message: %s", turningCommitToRollbackMsg)
 	}
 }

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -741,6 +741,23 @@ func MakeTxnCoordMeta(txn Transaction) TxnCoordMeta {
 	return TxnCoordMeta{Txn: txn, DeprecatedRefreshValid: true}
 }
 
+// StripRootToLeaf strips out all information that is unnecessary to communicate
+// to leaf transactions.
+func (meta *TxnCoordMeta) StripRootToLeaf() *TxnCoordMeta {
+	meta.Intents = nil
+	meta.CommandCount = 0
+	meta.RefreshReads = nil
+	meta.RefreshWrites = nil
+	return meta
+}
+
+// StripLeafToRoot strips out all information that is unnecessary to communicate
+// back to the root transaction.
+func (meta *TxnCoordMeta) StripLeafToRoot() *TxnCoordMeta {
+	meta.OutstandingWrites = nil
+	return meta
+}
+
 // LastActive returns the last timestamp at which client activity definitely
 // occurred, i.e. the maximum of OrigTimestamp and LastHeartbeat.
 func (t Transaction) LastActive() hlc.Timestamp {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -244,7 +244,8 @@ func (ex *connExecutor) execStmtInOpenState(
 		// We want to disallow SAVEPOINTs to be issued after a transaction has
 		// started running. The client txn's statement count indicates how many
 		// statements have been executed as part of this transaction.
-		if ex.state.mu.txn.GetTxnCoordMeta().CommandCount > 0 {
+		meta := ex.state.mu.txn.GetTxnCoordMeta(ctx)
+		if meta.CommandCount > 0 {
 			err := fmt.Errorf("SAVEPOINT %s needs to be the first statement in a "+
 				"transaction", tree.RestartSavepointName)
 			return makeErrEvent(err)

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -556,7 +556,7 @@ func (ex *connExecutor) checkTableTwoVersionInvariant(ctx context.Context) error
 
 	// Create a new transaction to retry with a higher timestamp than the
 	// timestamps used in the retry loop above.
-	ex.state.mu.txn = client.NewTxn(ex.transitionCtx.db, ex.transitionCtx.nodeID, client.RootTxn)
+	ex.state.mu.txn = client.NewTxn(ctx, ex.transitionCtx.db, ex.transitionCtx.nodeID, client.RootTxn)
 	if err := ex.state.mu.txn.SetIsolation(isolation); err != nil {
 		return err
 	}

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -172,7 +172,7 @@ func (ex *connExecutor) prepare(
 	// TODO(andrei): Needing a transaction for preparing seems non-sensical, as
 	// the prepared statement outlives the txn. I hope that it's not used for
 	// anything other than getting a timestamp.
-	txn := client.NewTxn(ex.server.cfg.DB, ex.server.cfg.NodeID.Get(), client.RootTxn)
+	txn := client.NewTxn(ctx, ex.server.cfg.DB, ex.server.cfg.NodeID.Get(), client.RootTxn)
 
 	// Create a plan for the statement to figure out the typing, then close the
 	// plan.

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -283,7 +283,7 @@ func (c *copyMachine) preparePlanner(ctx context.Context) func(context.Context, 
 	stmtTs := c.txnOpt.stmtTimestamp
 	autoCommit := false
 	if txn == nil {
-		txn = client.NewTxn(c.p.execCfg.DB, c.p.execCfg.NodeID.Get(), client.RootTxn)
+		txn = client.NewTxn(ctx, c.p.execCfg.DB, c.p.execCfg.NodeID.Get(), client.RootTxn)
 		txnTs = c.p.execCfg.Clock.PhysicalTime()
 		stmtTs = txnTs
 		autoCommit = true

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -135,7 +135,8 @@ func (dsp *DistSQLPlanner) Run(
 	} else if txn != nil {
 		// If the plan is not local, we will have to set up leaf txns using the
 		// txnCoordMeta.
-		meta := txn.GetStrippedTxnCoordMeta()
+		meta := txn.GetTxnCoordMeta()
+		meta.StripRootToLeaf()
 		txnCoordMeta = &meta
 	}
 

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -41,6 +41,8 @@ import (
 // multiple queries.
 const numRunners = 16
 
+const clientRejectedMsg string = "client rejected when attempting to run DistSQL plan"
+
 // runnerRequest is the request that is sent (via a channel) to a worker.
 type runnerRequest struct {
 	ctx        context.Context
@@ -135,7 +137,12 @@ func (dsp *DistSQLPlanner) Run(
 	} else if txn != nil {
 		// If the plan is not local, we will have to set up leaf txns using the
 		// txnCoordMeta.
-		meta := txn.GetTxnCoordMeta()
+		meta, err := txn.GetTxnCoordMetaOrRejectClient(ctx)
+		if err != nil {
+			log.Infof(ctx, "%s: %s", clientRejectedMsg, err)
+			recv.SetError(err)
+			return
+		}
 		meta.StripRootToLeaf()
 		txnCoordMeta = &meta
 	}

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -1,0 +1,176 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+)
+
+// Test that we don't attempt to create flows in an aborted transaction.
+// Instead, a retryable error is created on the gateway. The point is to
+// simulate a race where the heartbeat loop finds out that the txn is aborted
+// just before a plan starts execution and check that we don't create flows in
+// an aborted txn (which isn't allowed). Note that, once running, each flow can
+// discover on its own that its txn is aborted - that's handled separately. But
+// flows can't start in a txn that's already known to be aborted.
+//
+// We test this by manually aborting a txn and then attempting to execute a plan
+// in it. We're careful to not use the transaction for anything but running the
+// plan; planning will be performed outside of the transaction.
+func TestDistSQLRunningInAbortedTxn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	s, sqlDB, db := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	if _, err := sqlDB.ExecContext(
+		ctx, "create database test; create table test.t(a int)"); err != nil {
+		t.Fatal(err)
+	}
+	key := roachpb.Key("a")
+
+	// Plan a statement.
+	execCfg := s.ExecutorConfig().(ExecutorConfig)
+	internalPlanner, cleanup := NewInternalPlanner(
+		"test",
+		client.NewTxn(db, s.NodeID(), client.RootTxn),
+		security.RootUser,
+		&MemoryMetrics{},
+		&execCfg,
+	)
+	defer cleanup()
+	p := internalPlanner.(*planner)
+	stmt, err := parser.ParseOne("select * from test.t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.makePlan(ctx, Statement{AST: stmt}); err != nil {
+		t.Fatal(err)
+	}
+
+	push := func(ctx context.Context, key roachpb.Key) error {
+		// Conflicting transaction that pushes another transaction.
+		conflictTxn := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)
+		// We need to explicitly set a high priority for the push to happen.
+		if err := conflictTxn.SetUserPriority(roachpb.MaxUserPriority); err != nil {
+			return err
+		}
+		// Push through a Put, as opposed to a Get, so that the pushee gets aborted.
+		if err := conflictTxn.Put(ctx, key, "pusher was here"); err != nil {
+			return err
+		}
+		return conflictTxn.CommitOrCleanup(ctx)
+	}
+
+	// Make a db with a short heartbeat interval, so that the aborted txn finds
+	// out quickly.
+	ambient := log.AmbientContext{Tracer: tracing.NewTracer()}
+	tsf := kv.NewTxnCoordSenderFactory(
+		kv.TxnCoordSenderFactoryConfig{
+			AmbientCtx: ambient,
+			// Short heartbeat interval.
+			HeartbeatInterval: time.Millisecond,
+			Settings:          s.ClusterSettings(),
+			Clock:             s.Clock(),
+			Stopper:           s.Stopper(),
+		},
+		s.DistSender(),
+	)
+	shortDB := client.NewDB(ambient, tsf, s.Clock())
+
+	iter := 0
+	// We'll trace to make sure the test isn't fooling itself.
+	runningCtx, getRec, cancel := tracing.ContextWithRecordingSpan(ctx, "test")
+	defer cancel()
+	err = shortDB.Txn(runningCtx, func(ctx context.Context, txn *client.Txn) error {
+		iter++
+		if iter == 1 {
+			// On the first iteration, abort the txn.
+
+			if err := txn.Put(ctx, key, "val"); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := push(ctx, key); err != nil {
+				t.Fatal(err)
+			}
+
+			// Now wait until the heartbeat loop notices that the transaction is aborted.
+			testutils.SucceedsSoon(t, func() error {
+				if txn.GetTxnCoordMeta(ctx).Txn.Status != roachpb.ABORTED {
+					return fmt.Errorf("txn not aborted yet")
+				}
+				return nil
+			})
+		}
+
+		// Create and run a DistSQL plan.
+		rw := newCallbackResultWriter(func(ctx context.Context, row tree.Datums) error {
+			return nil
+		})
+		recv := MakeDistSQLReceiver(
+			ctx,
+			rw,
+			stmt.StatementType(),
+			execCfg.RangeDescriptorCache,
+			execCfg.LeaseHolderCache,
+			txn,
+			func(ts hlc.Timestamp) {
+				_ = execCfg.Clock.Update(ts)
+			},
+			p.ExtendedEvalContext().Tracing,
+		)
+
+		evalCtx := p.ExtendedEvalContext()
+		planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, nil /* txn */)
+		// We need isLocal = false so that we executing the plan involves marshaling
+		// the root txn meta to leaf txns. Local flows can start in aborted txns
+		// because they just use the root txn.
+		planCtx.isLocal = false
+		planCtx.planner = p
+		planCtx.stmtType = recv.stmtType
+
+		execCfg.DistSQLPlanner.PlanAndRun(
+			ctx, evalCtx, &planCtx, txn, p.curPlan.plan, recv)
+		return rw.Err()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if iter != 2 {
+		t.Fatalf("expected two iterations, but txn took %d to succeed", iter)
+	}
+	if tracing.FindMsgInRecording(getRec(), clientRejectedMsg) == -1 {
+		t.Fatalf("didn't find expected message in trace: %s", clientRejectedMsg)
+	}
+}

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -63,7 +63,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 	execCfg := s.ExecutorConfig().(ExecutorConfig)
 	internalPlanner, cleanup := NewInternalPlanner(
 		"test",
-		client.NewTxn(db, s.NodeID(), client.RootTxn),
+		client.NewTxn(ctx, db, s.NodeID(), client.RootTxn),
 		security.RootUser,
 		&MemoryMetrics{},
 		&execCfg,
@@ -80,7 +80,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 
 	push := func(ctx context.Context, key roachpb.Key) error {
 		// Conflicting transaction that pushes another transaction.
-		conflictTxn := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)
+		conflictTxn := client.NewTxn(ctx, db, 0 /* gatewayNodeID */, client.RootTxn)
 		// We need to explicitly set a high priority for the push to happen.
 		if err := conflictTxn.SetUserPriority(roachpb.MaxUserPriority); err != nil {
 			return err

--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -110,6 +110,7 @@ func runTestFlow(
 // table. We assume the table's first column is the primary key, with values
 // from 1 to numRows. A non-PK column that works with the function is chosen.
 func checkDistAggregationInfo(
+	ctx context.Context,
 	t *testing.T,
 	srv serverutils.TestServerInterface,
 	tableDesc *sqlbase.TableDescriptor,
@@ -151,7 +152,7 @@ func checkDistAggregationInfo(
 		}
 	}
 
-	txn := client.NewTxn(srv.DB(), srv.NodeID(), client.RootTxn)
+	txn := client.NewTxn(ctx, srv.DB(), srv.NodeID(), client.RootTxn)
 
 	// First run a flow that aggregates all the rows without any local stages.
 
@@ -425,7 +426,8 @@ func TestDistAggregationTable(t *testing.T) {
 			for _, numRows := range []int{5, numRows / 10, numRows / 2, numRows} {
 				name := fmt.Sprintf("%s/%s/%d", fn, desc.Columns[colIdx].Name, numRows)
 				t.Run(name, func(t *testing.T) {
-					checkDistAggregationInfo(t, tc.Server(0), desc, colIdx, numRows, fn, info)
+					checkDistAggregationInfo(
+						context.Background(), t, tc.Server(0), desc, colIdx, numRows, fn, info)
 				})
 			}
 		}

--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -57,7 +57,7 @@ func runTestFlow(
 ) sqlbase.EncDatumRows {
 	distSQLSrv := srv.DistSQLServer().(*distsqlrun.ServerImpl)
 
-	txnCoordMeta := txn.GetTxnCoordMeta()
+	txnCoordMeta := txn.GetTxnCoordMeta(context.TODO())
 	txnCoordMeta.StripRootToLeaf()
 	req := distsqlrun.SetupFlowRequest{
 		Version:      distsqlrun.Version,

--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -57,7 +57,8 @@ func runTestFlow(
 ) sqlbase.EncDatumRows {
 	distSQLSrv := srv.DistSQLServer().(*distsqlrun.ServerImpl)
 
-	txnCoordMeta := txn.GetStrippedTxnCoordMeta()
+	txnCoordMeta := txn.GetTxnCoordMeta()
+	txnCoordMeta.StripRootToLeaf()
 	req := distsqlrun.SetupFlowRequest{
 		Version:      distsqlrun.Version,
 		TxnCoordMeta: &txnCoordMeta,

--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -149,7 +149,7 @@ func (ag *aggregatorBase) init(
 	input RowSource,
 	post *PostProcessSpec,
 	output RowReceiver,
-	trailingMetaCallback func() []ProducerMetadata,
+	trailingMetaCallback func(context.Context) []ProducerMetadata,
 ) error {
 	ctx := flowCtx.EvalCtx.Ctx()
 	memMonitor := NewMonitor(ctx, flowCtx.EvalCtx.Mon, "aggregator-mem")
@@ -346,7 +346,7 @@ func newAggregator(
 		input,
 		post,
 		output,
-		func() []ProducerMetadata {
+		func(context.Context) []ProducerMetadata {
 			ag.close()
 			return nil
 		},
@@ -375,7 +375,7 @@ func newOrderedAggregator(
 		input,
 		post,
 		output,
-		func() []ProducerMetadata {
+		func(context.Context) []ProducerMetadata {
 			ag.close()
 			return nil
 		},

--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -255,7 +255,8 @@ func sendTraceData(ctx context.Context, dst RowReceiver) {
 // thing multiple times.
 func getTxnCoordMeta(txn *client.Txn) *roachpb.TxnCoordMeta {
 	if txn.Type() == client.LeafTxn {
-		txnMeta := txn.GetStrippedTxnCoordMeta()
+		txnMeta := txn.GetTxnCoordMeta()
+		txnMeta.StripLeafToRoot()
 		if txnMeta.Txn.ID != uuid.Nil {
 			return &txnMeta
 		}

--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -253,9 +253,9 @@ func sendTraceData(ctx context.Context, dst RowReceiver) {
 // a node, and so it's possible for multiple processors to send the same
 // TxnCoordMeta. The root TxnCoordSender doesn't care if it receives the same
 // thing multiple times.
-func getTxnCoordMeta(txn *client.Txn) *roachpb.TxnCoordMeta {
+func getTxnCoordMeta(ctx context.Context, txn *client.Txn) *roachpb.TxnCoordMeta {
 	if txn.Type() == client.LeafTxn {
-		txnMeta := txn.GetTxnCoordMeta()
+		txnMeta := txn.GetTxnCoordMeta(ctx)
 		txnMeta.StripLeafToRoot()
 		if txnMeta.Txn.ID != uuid.Nil {
 			return &txnMeta

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -119,7 +119,7 @@ func NewDistinct(
 		d, post, d.types, flowCtx, processorID, output, memMonitor, /* memMonitor */
 		ProcStateOpts{
 			InputsToDrain: []RowSource{d.input},
-			TrailingMetaCallback: func() []ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []ProducerMetadata {
 				d.close()
 				return nil
 			},

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -169,7 +169,7 @@ func newHashJoiner(
 		output,
 		ProcStateOpts{
 			InputsToDrain: []RowSource{h.leftSource, h.rightSource},
-			TrailingMetaCallback: func() []ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []ProducerMetadata {
 				h.close()
 				return nil
 			},

--- a/pkg/sql/distsqlrun/indexjoiner.go
+++ b/pkg/sql/distsqlrun/indexjoiner.go
@@ -88,7 +88,7 @@ func newIndexJoiner(
 		nil, /* memMonitor */
 		ProcStateOpts{
 			InputsToDrain: []RowSource{ij.input},
-			TrailingMetaCallback: func() []ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []ProducerMetadata {
 				ij.InternalClose()
 				if meta := getTxnCoordMeta(ij.flowCtx.txn); meta != nil {
 					return []ProducerMetadata{{TxnCoordMeta: meta}}

--- a/pkg/sql/distsqlrun/indexjoiner.go
+++ b/pkg/sql/distsqlrun/indexjoiner.go
@@ -88,9 +88,9 @@ func newIndexJoiner(
 		nil, /* memMonitor */
 		ProcStateOpts{
 			InputsToDrain: []RowSource{ij.input},
-			TrailingMetaCallback: func(context.Context) []ProducerMetadata {
+			TrailingMetaCallback: func(ctx context.Context) []ProducerMetadata {
 				ij.InternalClose()
-				if meta := getTxnCoordMeta(ij.flowCtx.txn); meta != nil {
+				if meta := getTxnCoordMeta(ctx, ij.flowCtx.txn); meta != nil {
 					return []ProducerMetadata{{TxnCoordMeta: meta}}
 				}
 				return nil

--- a/pkg/sql/distsqlrun/indexjoiner_test.go
+++ b/pkg/sql/distsqlrun/indexjoiner_test.go
@@ -145,7 +145,7 @@ func TestIndexJoiner(t *testing.T) {
 				Table:    *td,
 				IndexIdx: 0,
 			}
-			txn := client.NewTxn(s.DB(), s.NodeID(), client.RootTxn)
+			txn := client.NewTxn(context.Background(), s.DB(), s.NodeID(), client.RootTxn)
 			runProcessorTest(
 				t,
 				ProcessorCoreUnion{JoinReader: &spec},

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner.go
@@ -420,13 +420,13 @@ func (irj *interleavedReaderJoiner) initRowFetcher(
 		args...)
 }
 
-func (irj *interleavedReaderJoiner) generateTrailingMeta(context.Context) []ProducerMetadata {
+func (irj *interleavedReaderJoiner) generateTrailingMeta(ctx context.Context) []ProducerMetadata {
 	var trailingMeta []ProducerMetadata
 	ranges := misplannedRanges(irj.Ctx, irj.fetcher.GetRangeInfo(), irj.flowCtx.nodeID)
 	if ranges != nil {
 		trailingMeta = append(trailingMeta, ProducerMetadata{Ranges: ranges})
 	}
-	if meta := getTxnCoordMeta(irj.flowCtx.txn); meta != nil {
+	if meta := getTxnCoordMeta(ctx, irj.flowCtx.txn); meta != nil {
 		trailingMeta = append(trailingMeta, ProducerMetadata{TxnCoordMeta: meta})
 	}
 	irj.InternalClose()

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner.go
@@ -420,7 +420,7 @@ func (irj *interleavedReaderJoiner) initRowFetcher(
 		args...)
 }
 
-func (irj *interleavedReaderJoiner) generateTrailingMeta() []ProducerMetadata {
+func (irj *interleavedReaderJoiner) generateTrailingMeta(context.Context) []ProducerMetadata {
 	var trailingMeta []ProducerMetadata
 	ranges := misplannedRanges(irj.Ctx, irj.fetcher.GetRangeInfo(), irj.flowCtx.nodeID)
 	if ranges != nil {

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -175,7 +175,7 @@ func newJoinReader(
 		output,
 		ProcStateOpts{
 			InputsToDrain: []RowSource{jr.input},
-			TrailingMetaCallback: func() []ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []ProducerMetadata {
 				jr.InternalClose()
 				if meta := getTxnCoordMeta(jr.flowCtx.txn); meta != nil {
 					return []ProducerMetadata{{TxnCoordMeta: meta}}

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -175,9 +175,9 @@ func newJoinReader(
 		output,
 		ProcStateOpts{
 			InputsToDrain: []RowSource{jr.input},
-			TrailingMetaCallback: func(context.Context) []ProducerMetadata {
+			TrailingMetaCallback: func(ctx context.Context) []ProducerMetadata {
 				jr.InternalClose()
-				if meta := getTxnCoordMeta(jr.flowCtx.txn); meta != nil {
+				if meta := getTxnCoordMeta(ctx, jr.flowCtx.txn); meta != nil {
 					return []ProducerMetadata{{TxnCoordMeta: meta}}
 				}
 				return nil

--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -86,7 +86,7 @@ func newMergeJoiner(
 		spec.Type, spec.OnExpr, leftEqCols, rightEqCols, 0, post, output,
 		ProcStateOpts{
 			InputsToDrain: []RowSource{leftSource, rightSource},
-			TrailingMetaCallback: func() []ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []ProducerMetadata {
 				m.close()
 				return nil
 			},

--- a/pkg/sql/distsqlrun/metadata_test_receiver.go
+++ b/pkg/sql/distsqlrun/metadata_test_receiver.go
@@ -70,7 +70,7 @@ func newMetadataTestReceiver(
 		nil, /* memMonitor */
 		ProcStateOpts{
 			InputsToDrain: []RowSource{input},
-			TrailingMetaCallback: func() []ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []ProducerMetadata {
 				var trailingMeta []ProducerMetadata
 				if mtr.rowCounts != nil {
 					if meta := mtr.checkRowNumMetadata(); meta != nil {

--- a/pkg/sql/distsqlrun/metadata_test_sender.go
+++ b/pkg/sql/distsqlrun/metadata_test_sender.go
@@ -56,7 +56,7 @@ func newMetadataTestSender(
 		nil, /* memMonitor */
 		ProcStateOpts{
 			InputsToDrain: []RowSource{mts.input},
-			TrailingMetaCallback: func() []ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []ProducerMetadata {
 				mts.InternalClose()
 				// Send a final record with LastMsg set.
 				meta := ProducerMetadata{

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -524,7 +524,7 @@ type ProcessorBase struct {
 	// other than what has otherwise been manually put in trailingMeta) and no
 	// closing other than InternalClose is needed, then no callback needs to be
 	// specified.
-	trailingMetaCallback func() []ProducerMetadata
+	trailingMetaCallback func(context.Context) []ProducerMetadata
 	// trailingMeta is scratch space where metadata is stored to be returned
 	// later.
 	trailingMeta []ProducerMetadata
@@ -690,7 +690,7 @@ func (pb *ProcessorBase) moveToTrailingMeta() {
 	// generally calls InternalClose, indirectly, which switches the context and
 	// the span.
 	if pb.trailingMetaCallback != nil {
-		pb.trailingMeta = append(pb.trailingMeta, pb.trailingMetaCallback()...)
+		pb.trailingMeta = append(pb.trailingMeta, pb.trailingMetaCallback(pb.Ctx)...)
 	} else {
 		pb.InternalClose()
 	}
@@ -740,7 +740,7 @@ func (pb *ProcessorBase) Run(ctx context.Context, wg *sync.WaitGroup) {
 type ProcStateOpts struct {
 	// TrailingMetaCallback, if specified, is a callback to be called by
 	// moveToTrailingMeta(). See ProcessorBase.TrailingMetaCallback.
-	TrailingMetaCallback func() []ProducerMetadata
+	TrailingMetaCallback func(context.Context) []ProducerMetadata
 	// InputsToDrain, if specified, will be drained by DrainHelper().
 	// MoveToDraining() calls ConsumerDone() on them, InternalClose() calls
 	// ConsumerClosed() on them.

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -327,8 +327,12 @@ func (ds *ServerImpl) setupFlow(
 	}
 	if meta := req.TxnCoordMeta; meta != nil {
 		if !localState.IsLocal {
-			// The flow will run in a Txn that specifies child=true because we
-			// do not want each distributed Txn to heartbeat the transaction.
+			if meta.Txn.Status != roachpb.PENDING {
+				return nil, nil, errors.Errorf("cannot create flow in non-PENDING txn: %s",
+					meta.Txn)
+			}
+			// The flow will run in a LeafTxn because we do not want each distributed
+			// Txn to heartbeat the transaction.
 			txn = client.NewTxnWithCoordMeta(ds.FlowDB, req.Flow.Gateway, client.LeafTxn, *meta)
 		}
 	}

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -333,7 +333,7 @@ func (ds *ServerImpl) setupFlow(
 			}
 			// The flow will run in a LeafTxn because we do not want each distributed
 			// Txn to heartbeat the transaction.
-			txn = client.NewTxnWithCoordMeta(ds.FlowDB, req.Flow.Gateway, client.LeafTxn, *meta)
+			txn = client.NewTxnWithCoordMeta(ctx, ds.FlowDB, req.Flow.Gateway, client.LeafTxn, *meta)
 		}
 	}
 

--- a/pkg/sql/distsqlrun/server_test.go
+++ b/pkg/sql/distsqlrun/server_test.go
@@ -33,9 +33,10 @@ import (
 func TestServer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	ctx := context.Background()
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(context.TODO())
-	conn, err := s.RPCContext().GRPCDial(s.ServingAddr()).Connect(context.Background())
+	defer s.Stopper().Stop(ctx)
+	conn, err := s.RPCContext().GRPCDial(s.ServingAddr()).Connect(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +62,7 @@ func TestServer(t *testing.T) {
 	}
 
 	txn := client.NewTxn(kvDB, s.NodeID(), client.RootTxn)
-	txnCoordMeta := txn.GetTxnCoordMeta()
+	txnCoordMeta := txn.GetTxnCoordMeta(ctx)
 	txnCoordMeta.StripRootToLeaf()
 
 	req := &SetupFlowRequest{Version: Version, TxnCoordMeta: &txnCoordMeta}
@@ -77,7 +78,7 @@ func TestServer(t *testing.T) {
 	}
 
 	distSQLClient := NewDistSQLClient(conn)
-	stream, err := distSQLClient.RunSyncFlow(context.Background())
+	stream, err := distSQLClient.RunSyncFlow(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/distsqlrun/server_test.go
+++ b/pkg/sql/distsqlrun/server_test.go
@@ -61,7 +61,8 @@ func TestServer(t *testing.T) {
 	}
 
 	txn := client.NewTxn(kvDB, s.NodeID(), client.RootTxn)
-	txnCoordMeta := txn.GetStrippedTxnCoordMeta()
+	txnCoordMeta := txn.GetTxnCoordMeta()
+	txnCoordMeta.StripRootToLeaf()
 
 	req := &SetupFlowRequest{Version: Version, TxnCoordMeta: &txnCoordMeta}
 	req.Flow = FlowSpec{

--- a/pkg/sql/distsqlrun/server_test.go
+++ b/pkg/sql/distsqlrun/server_test.go
@@ -61,7 +61,7 @@ func TestServer(t *testing.T) {
 		OutputColumns: []uint32{0, 1}, // a
 	}
 
-	txn := client.NewTxn(kvDB, s.NodeID(), client.RootTxn)
+	txn := client.NewTxn(ctx, kvDB, s.NodeID(), client.RootTxn)
 	txnCoordMeta := txn.GetTxnCoordMeta(ctx)
 	txnCoordMeta.StripRootToLeaf()
 

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -270,7 +270,7 @@ func newSortAllProcessor(
 		spec.OrderingMatchLen,
 		ProcStateOpts{
 			InputsToDrain: []RowSource{input},
-			TrailingMetaCallback: func() []ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []ProducerMetadata {
 				proc.close()
 				return nil
 			},
@@ -382,7 +382,7 @@ func newSortTopKProcessor(
 		ordering, spec.OrderingMatchLen,
 		ProcStateOpts{
 			InputsToDrain: []RowSource{input},
-			TrailingMetaCallback: func() []ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []ProducerMetadata {
 				proc.close()
 				return nil
 			},
@@ -481,7 +481,7 @@ func newSortChunksProcessor(
 		proc, flowCtx, processorID, input, post, out, ordering, spec.OrderingMatchLen,
 		ProcStateOpts{
 			InputsToDrain: []RowSource{input},
-			TrailingMetaCallback: func() []ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []ProducerMetadata {
 				proc.close()
 				return nil
 			},

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -197,13 +197,13 @@ func initRowFetcher(
 	return index, isSecondaryIndex, nil
 }
 
-func (tr *tableReader) generateTrailingMeta(context.Context) []ProducerMetadata {
+func (tr *tableReader) generateTrailingMeta(ctx context.Context) []ProducerMetadata {
 	var trailingMeta []ProducerMetadata
 	ranges := misplannedRanges(tr.Ctx, tr.fetcher.GetRangeInfo(), tr.flowCtx.nodeID)
 	if ranges != nil {
 		trailingMeta = append(trailingMeta, ProducerMetadata{Ranges: ranges})
 	}
-	if meta := getTxnCoordMeta(tr.flowCtx.txn); meta != nil {
+	if meta := getTxnCoordMeta(ctx, tr.flowCtx.txn); meta != nil {
 		trailingMeta = append(trailingMeta, ProducerMetadata{TxnCoordMeta: meta})
 	}
 	tr.InternalClose()

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -197,7 +197,7 @@ func initRowFetcher(
 	return index, isSecondaryIndex, nil
 }
 
-func (tr *tableReader) generateTrailingMeta() []ProducerMetadata {
+func (tr *tableReader) generateTrailingMeta(context.Context) []ProducerMetadata {
 	var trailingMeta []ProducerMetadata
 	ranges := misplannedRanges(tr.Ctx, tr.fetcher.GetRangeInfo(), tr.flowCtx.nodeID)
 	if ranges != nil {

--- a/pkg/sql/distsqlrun/windower.go
+++ b/pkg/sql/distsqlrun/windower.go
@@ -234,7 +234,7 @@ func newWindower(
 		output,
 		memMonitor,
 		ProcStateOpts{InputsToDrain: []RowSource{w.input},
-			TrailingMetaCallback: func() []ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []ProducerMetadata {
 				w.close()
 				return nil
 			}},

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -1533,7 +1533,7 @@ CREATE TABLE t.test0 (k CHAR PRIMARY KEY, v CHAR);
 			// the transaction commit time (and that the txn commit time wasn't
 			// bumped past it).
 			log.Infof(ctx, "checking version %d", table.Version)
-			txn := client.NewTxn(t.kvDB, roachpb.NodeID(0), client.RootTxn)
+			txn := client.NewTxn(ctx, t.kvDB, roachpb.NodeID(0), client.RootTxn)
 			// Make the txn look back at the known modification timestamp.
 			txn.SetFixedTimestamp(ctx, table.ModificationTime)
 

--- a/pkg/sql/parallel_stmts_test.go
+++ b/pkg/sql/parallel_stmts_test.go
@@ -314,7 +314,7 @@ func TestParallelizeQueueAddAfterError(t *testing.T) {
 
 func planQuery(t *testing.T, s serverutils.TestServerInterface, sql string) (*planner, func()) {
 	kvDB := s.DB()
-	txn := client.NewTxn(kvDB, s.NodeID(), client.RootTxn)
+	txn := client.NewTxn(context.TODO(), kvDB, s.NodeID(), client.RootTxn)
 	execCfg := s.ExecutorConfig().(ExecutorConfig)
 	p, cleanup := newInternalPlanner(
 		"plan", txn, security.RootUser, &MemoryMetrics{}, &execCfg)

--- a/pkg/sql/sem/tree/timeconv_test.go
+++ b/pkg/sql/sem/tree/timeconv_test.go
@@ -58,6 +58,7 @@ func TestClusterTimestampConversion(t *testing.T) {
 		ts := hlc.Timestamp{WallTime: d.walltime, Logical: d.logical}
 		ctx := tree.EvalContext{
 			Txn: client.NewTxnWithProto(
+				context.Background(),
 				db,
 				1, /* gatewayNodeID */
 				client.RootTxn,

--- a/pkg/sql/sqlbase/rowfetcher_test.go
+++ b/pkg/sql/sqlbase/rowfetcher_test.go
@@ -91,9 +91,10 @@ type fetcherEntryArgs struct {
 
 func TestNextRowSingle(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(context.Background())
+	defer s.Stopper().Stop(ctx)
 
 	tables := map[string]fetcherEntryArgs{
 		"t1": {
@@ -153,7 +154,7 @@ func TestNextRowSingle(t *testing.T) {
 
 			if err := rf.StartScan(
 				context.TODO(),
-				client.NewTxn(kvDB, 0, client.RootTxn),
+				client.NewTxn(ctx, kvDB, 0, client.RootTxn),
 				roachpb.Spans{tableDesc.IndexSpan(tableDesc.PrimaryIndex.ID)},
 				false, /*limitBatches*/
 				0,     /*limitHint*/
@@ -210,9 +211,10 @@ func TestNextRowSingle(t *testing.T) {
 
 func TestNextRowBatchLimiting(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(context.Background())
+	defer s.Stopper().Stop(ctx)
 
 	tables := map[string]fetcherEntryArgs{
 		"t1": {
@@ -272,7 +274,7 @@ func TestNextRowBatchLimiting(t *testing.T) {
 
 			if err := rf.StartScan(
 				context.TODO(),
-				client.NewTxn(kvDB, 0, client.RootTxn),
+				client.NewTxn(ctx, kvDB, 0, client.RootTxn),
 				roachpb.Spans{tableDesc.IndexSpan(tableDesc.PrimaryIndex.ID)},
 				true,  /*limitBatches*/
 				10,    /*limitHint*/
@@ -331,9 +333,10 @@ func TestNextRowBatchLimiting(t *testing.T) {
 // as well as STORING columns).
 func TestNextRowSecondaryIndex(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(context.Background())
+	defer s.Stopper().Stop(ctx)
 
 	// Modulo to use for s1, s2 storing columns.
 	storingMods := [2]int{7, 13}
@@ -446,7 +449,7 @@ func TestNextRowSecondaryIndex(t *testing.T) {
 
 			if err := rf.StartScan(
 				context.TODO(),
-				client.NewTxn(kvDB, 0, client.RootTxn),
+				client.NewTxn(ctx, kvDB, 0, client.RootTxn),
 				roachpb.Spans{tableDesc.IndexSpan(tableDesc.Indexes[0].ID)},
 				false, /*limitBatches*/
 				0,     /*limitHint*/
@@ -574,9 +577,10 @@ func generateIdxSubsets(maxIdx int, subsets [][]int) [][]int {
 // We test reading rows from every non-empty subset for completeness.
 func TestNextRowInterleaved(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(context.Background())
+	defer s.Stopper().Stop(ctx)
 
 	tableArgs := map[string]*fetcherEntryArgs{
 		"parent1": {
@@ -806,7 +810,7 @@ func TestNextRowInterleaved(t *testing.T) {
 
 			if err := rf.StartScan(
 				context.TODO(),
-				client.NewTxn(kvDB, 0, client.RootTxn),
+				client.NewTxn(ctx, kvDB, 0, client.RootTxn),
 				lookupSpans,
 				false, /*limitBatches*/
 				0,     /*limitHint*/

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -626,8 +626,10 @@ func TestValidateTableDesc(t *testing.T) {
 
 func TestValidateCrossTableReferences(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(context.TODO())
+	defer s.Stopper().Stop(ctx)
 
 	tests := []struct {
 		err        string
@@ -829,7 +831,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 		if err := v.SetProto(desc); err != nil {
 			t.Fatal(err)
 		}
-		if err := kvDB.Put(context.TODO(), MakeDescMetadataKey(0), &v); err != nil {
+		if err := kvDB.Put(ctx, MakeDescMetadataKey(0), &v); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -841,18 +843,18 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			if err := v.SetProto(desc); err != nil {
 				t.Fatal(err)
 			}
-			if err := kvDB.Put(context.TODO(), MakeDescMetadataKey(referencedDesc.ID), &v); err != nil {
+			if err := kvDB.Put(ctx, MakeDescMetadataKey(referencedDesc.ID), &v); err != nil {
 				t.Fatal(err)
 			}
 		}
-		txn := client.NewTxn(kvDB, s.NodeID(), client.RootTxn)
-		if err := test.desc.validateCrossReferences(context.TODO(), txn); err == nil {
+		txn := client.NewTxn(ctx, kvDB, s.NodeID(), client.RootTxn)
+		if err := test.desc.validateCrossReferences(ctx, txn); err == nil {
 			t.Errorf("%d: expected \"%s\", but found success: %+v", i, test.err, test.desc)
 		} else if test.err != err.Error() {
 			t.Errorf("%d: expected \"%s\", but found \"%s\"", i, test.err, err.Error())
 		}
 		for _, referencedDesc := range test.referenced {
-			if err := kvDB.Del(context.TODO(), MakeDescMetadataKey(referencedDesc.ID)); err != nil {
+			if err := kvDB.Del(ctx, MakeDescMetadataKey(referencedDesc.ID)); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -193,7 +193,7 @@ func (ts *txnState) resetForNewSQLTxn(
 
 	ts.mu.Lock()
 	if txn == nil {
-		ts.mu.txn = client.NewTxn(tranCtx.db, tranCtx.nodeID, client.RootTxn)
+		ts.mu.txn = client.NewTxn(ts.Ctx, tranCtx.db, tranCtx.nodeID, client.RootTxn)
 		ts.mu.txn.SetDebugName(opName)
 	} else {
 		ts.mu.txn = txn

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -126,7 +126,7 @@ func (tc *testContext) createOpenState(
 		mon:           &txnStateMon,
 		txnAbortCount: metric.NewCounter(MetaTxnAbort),
 	}
-	ts.mu.txn = client.NewTxn(tc.mockDB, roachpb.NodeID(1) /* gatewayNodeID */, client.RootTxn)
+	ts.mu.txn = client.NewTxn(ctx, tc.mockDB, roachpb.NodeID(1) /* gatewayNodeID */, client.RootTxn)
 
 	state := stateOpen{
 		ImplicitTxn: FromBool(typ == implicitTxn),

--- a/pkg/storage/addressing_test.go
+++ b/pkg/storage/addressing_test.go
@@ -153,8 +153,8 @@ func TestUpdateRangeAddressing(t *testing.T) {
 			store.TestSender(),
 		)
 		db := client.NewDB(actx, tcsf, store.cfg.Clock)
-		txn := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)
 		ctx := context.Background()
+		txn := client.NewTxn(ctx, db, 0 /* gatewayNodeID */, client.RootTxn)
 		if err := txn.Run(ctx, b); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -741,22 +741,22 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	// will leave a record on the RHS, and txn3 will leave a record on both. This
 	// tests whether the merge code properly accounts for merging abort span
 	// records for the same transaction.
-	txn1 := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+	txn1 := client.NewTxn(ctx, store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
 	if err := txn1.Put(ctx, "a-txn1", "val"); err != nil {
 		t.Fatal(err)
 	}
-	txn2 := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+	txn2 := client.NewTxn(ctx, store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
 	if err := txn2.Put(ctx, "c-txn2", "val"); err != nil {
 		t.Fatal(err)
 	}
-	txn3 := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+	txn3 := client.NewTxn(ctx, store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
 	if err := txn3.Put(ctx, "a-txn3", "val"); err != nil {
 		t.Fatal(err)
 	}
 	if err := txn3.Put(ctx, "c-txn3", "val"); err != nil {
 		t.Fatal(err)
 	}
-	hiPriTxn := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+	hiPriTxn := client.NewTxn(ctx, store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
 	hiPriTxn.InternalSetPriority(roachpb.MaxTxnPriority)
 	for _, key := range []string{"a-txn1", "c-txn2", "a-txn3", "c-txn3"} {
 		if err := hiPriTxn.Put(ctx, key, "val"); err != nil {
@@ -841,7 +841,7 @@ func TestStoreRangeMergeInFlightTxns(t *testing.T) {
 		}
 		lhsKey, rhsKey := roachpb.Key("aa"), roachpb.Key("cc")
 
-		txn := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+		txn := client.NewTxn(ctx, store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
 		// Put the key on the RHS side first so ownership of the transaction record
 		// will need to transfer to the LHS range during the merge.
 		if err := txn.Put(ctx, rhsKey, t.Name()); err != nil {
@@ -879,7 +879,7 @@ func TestStoreRangeMergeInFlightTxns(t *testing.T) {
 
 		// Create a transaction that will be aborted before the merge but won't
 		// realize until after the merge.
-		txn1 := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+		txn1 := client.NewTxn(ctx, store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
 		// Put the key on the RHS side so ownership of the transaction record and
 		// abort span records will need to transfer to the LHS during the merge.
 		if err := txn1.Put(ctx, rhsKey, t.Name()); err != nil {
@@ -887,7 +887,7 @@ func TestStoreRangeMergeInFlightTxns(t *testing.T) {
 		}
 
 		// Create and commit a txn that aborts txn1.
-		txn2 := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+		txn2 := client.NewTxn(ctx, store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
 		txn2.InternalSetPriority(roachpb.MaxTxnPriority)
 		if err := txn2.Put(ctx, rhsKey, "muhahahah"); err != nil {
 			t.Fatal(err)
@@ -927,7 +927,7 @@ func TestStoreRangeMergeInFlightTxns(t *testing.T) {
 		txnwait.TxnLivenessThreshold = 2 * testutils.DefaultSucceedsSoonDuration
 
 		// Create a transaction that won't complete until after the merge.
-		txn1 := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+		txn1 := client.NewTxn(ctx, store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
 		// Put the key on the RHS side so ownership of the transaction record and
 		// abort span records will need to transfer to the LHS during the merge.
 		if err := txn1.Put(ctx, rhsKey, t.Name()); err != nil {
@@ -935,7 +935,7 @@ func TestStoreRangeMergeInFlightTxns(t *testing.T) {
 		}
 
 		// Create a txn that will conflict with txn1.
-		txn2 := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+		txn2 := client.NewTxn(ctx, store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
 		txn2ErrCh := make(chan error)
 		go func() {
 			txn2ErrCh <- txn2.Put(ctx, rhsKey, "muhahahah")
@@ -2157,7 +2157,7 @@ func TestStoreRangeMergeDuringShutdown(t *testing.T) {
 
 	// Simulate a merge transaction by launching a transaction that lays down
 	// intents on the two copies of the RHS range descriptor.
-	txn := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+	txn := client.NewTxn(ctx, store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
 	if err := txn.Del(ctx, keys.RangeDescriptorKey(rhsDesc.StartKey)); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1601,7 +1601,7 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 	defer cancel()
 
 	// This transaction will try to write "under" a served read.
-	txnOld := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)
+	txnOld := client.NewTxn(ctx, db, 0 /* gatewayNodeID */, client.RootTxn)
 
 	// Do something with txnOld so that its timestamp gets set.
 	if _, err := txnOld.Scan(ctx, "a", "b", 0); err != nil {
@@ -2459,7 +2459,7 @@ func TestDistributedTxnCleanup(t *testing.T) {
 			// Run a distributed transaction involving the lhsKey and rhsKey.
 			var txnKey roachpb.Key
 			ctx := context.Background()
-			txn := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
+			txn := client.NewTxn(ctx, store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
 			txnFn := func(ctx context.Context, txn *client.Txn) error {
 				b := txn.NewBatch()
 				b.Put(fmt.Sprintf("%s.force=%t,commit=%t", string(lhsKey), force, commit), "lhsValue")

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -564,7 +564,7 @@ func (r *Replica) AdminMerge(
 	// Note that client.DB.Txn performs retries using the same transaction, so we
 	// have to use our own retry loop.
 	for {
-		txn := client.NewTxn(r.store.DB(), r.NodeID(), client.RootTxn)
+		txn := client.NewTxn(ctx, r.store.DB(), r.NodeID(), client.RootTxn)
 		err := runMergeTxn(txn)
 		if err != nil {
 			txn.CleanupOnError(ctx, err)

--- a/pkg/util/tracing/test_utils.go
+++ b/pkg/util/tracing/test_utils.go
@@ -1,0 +1,37 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tracing
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FindMsgInRecording returns the index of the first span containing msg in its
+// logs, or -1 if no span is found.
+func FindMsgInRecording(recording []RecordedSpan, msg string) int {
+	for i, recSp := range recording {
+		spMsg := ""
+		for _, l := range recSp.Logs {
+			for _, f := range l.Fields {
+				spMsg = spMsg + fmt.Sprintf("  %s: %v", f.Key, f.Value)
+			}
+		}
+		if strings.Contains(spMsg, msg) {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -725,8 +725,11 @@ func matchesWithoutFileLine(msg string, expected string) bool {
 
 // ContextWithRecordingSpan returns a context with an embedded trace span which
 // returns its contents when getRecording is called and must be stopped by
-// calling the cancel method when done with the context. Note that to convert
-// the recorded spans into text, you can use FormatRecordedSpans.
+// calling the cancel method when done with the context (getRecording() needs to
+// be called before cancel()).
+//
+// Note that to convert the recorded spans into text, you can use
+// FormatRecordedSpans. Tests can also use FindMsgInRecording().
 func ContextWithRecordingSpan(
 	ctx context.Context, opName string,
 ) (retCtx context.Context, getRecording func() []RecordedSpan, cancel func()) {


### PR DESCRIPTION
Backport 6/6 commits from #29455.

/cc @cockroachdb/release

---

Before this patch, we had a race between a heartbeat find out (async)
that a txn has been aborted and a client using the txn to create DistSQL
flows. We could end up creating flows in aborted txns, which are going
to have a bad time: at the moment, leaf TxnCoordSenders don't react well
to what appears to be an async abort: tcs.maybeRejectClientLocked()
returns a HandledRetryableError, but the DistSQL infrastructure only
expects raw retriable errors - so the HandledRetryableError was
ironically losing its "retryable" character and was making it to a
sql client with the wrong pgwire code.
This patch resolves the situation by atomically checking that the txn is
still good (i.e. status==PENDING) before extracting its metadata that is
sent to leaves.

Fixes #28898
Fixes #29271

Release note: Fix an issue where, under severe load, clients were
sometimes receiving retryable errors with a non-retryable error code (a
client would get an error with the message "HandledRetryableError: ..."
but an internal error code instead of the expected retryable error
code).
