### PR TITLE
syncutil/semaphore: add new semaphore package, support semaphore resizing

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -61,6 +61,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil/semaphore"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
@@ -1347,7 +1348,7 @@ func (s *statusServer) iterateNodes(
 	}
 
 	// Issue the requests concurrently.
-	sem := make(chan struct{}, maxConcurrentRequests)
+	sem := semaphore.NewWeighted(maxConcurrentRequests)
 	for nodeID := range nodeStatuses {
 		nodeID := nodeID // needed to ensure the closure below captures a copy.
 		if err := s.stopper.RunLimitedAsyncTask(

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil/semaphore"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -1734,7 +1735,7 @@ func (m *LeaseManager) refreshSomeLeases(ctx context.Context) {
 	}
 	m.mu.Unlock()
 	// Limit the number of concurrent lease refreshes.
-	sem := make(chan struct{}, 5)
+	sem := semaphore.NewWeighted(5)
 	var wg sync.WaitGroup
 	for i := range ids {
 		id := ids[i]

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -68,6 +68,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/shuffle"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil/semaphore"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -1097,7 +1098,7 @@ func (s *Store) SetDraining(drain bool) {
 	ctx := log.WithLogTag(context.Background(), "drain", nil)
 	transferAllAway := func() int {
 		// Limit the number of concurrent lease transfers.
-		sem := make(chan struct{}, 100)
+		sem := semaphore.NewWeighted(100)
 		sysCfg, sysCfgSet := s.cfg.Gossip.GetSystemConfig()
 		// Incremented for every lease or Raft leadership transfer attempted. We try
 		// to send both the lease and the Raft leaders away, but this may not

--- a/pkg/util/syncutil/semaphore/semaphore.go
+++ b/pkg/util/syncutil/semaphore/semaphore.go
@@ -40,12 +40,21 @@ type Weighted struct {
 	waiters list.List
 }
 
-// Acquire acquires the semaphore with a weight of n, blocking only until ctx
+// Acquire acquires the semaphore with a weight of 1, blocking only until ctx
 // is done. On success, returns nil. On failure, returns ctx.Err() and leaves
 // the semaphore unchanged.
 //
 // If ctx is already done, Acquire may still succeed without blocking.
-func (s *Weighted) Acquire(ctx context.Context, n int64) error {
+func (s *Weighted) Acquire(ctx context.Context) error {
+	return s.AcquireN(ctx, 1)
+}
+
+// AcquireN acquires the semaphore with a weight of n, blocking only until ctx
+// is done. On success, returns nil. On failure, returns ctx.Err() and leaves
+// the semaphore unchanged.
+//
+// If ctx is already done, AcquireN may still succeed without blocking.
+func (s *Weighted) AcquireN(ctx context.Context, n int64) error {
 	s.mu.Lock()
 	if s.size-s.cur >= n && s.waiters.Len() == 0 {
 		s.cur += n
@@ -85,9 +94,15 @@ func (s *Weighted) Acquire(ctx context.Context, n int64) error {
 	}
 }
 
-// TryAcquire acquires the semaphore with a weight of n without blocking.
+// TryAcquire acquires the semaphore with a weight of 1 without blocking.
 // On success, returns true. On failure, returns false and leaves the semaphore unchanged.
-func (s *Weighted) TryAcquire(n int64) bool {
+func (s *Weighted) TryAcquire() bool {
+	return s.TryAcquireN(1)
+}
+
+// TryAcquireN acquires the semaphore with a weight of n without blocking.
+// On success, returns true. On failure, returns false and leaves the semaphore unchanged.
+func (s *Weighted) TryAcquireN(n int64) bool {
 	s.mu.Lock()
 	success := s.size-s.cur >= n && s.waiters.Len() == 0
 	if success {
@@ -97,8 +112,13 @@ func (s *Weighted) TryAcquire(n int64) bool {
 	return success
 }
 
-// Release releases the semaphore with a weight of n.
-func (s *Weighted) Release(n int64) {
+// Release releases the semaphore with a weight of 1.
+func (s *Weighted) Release() {
+	s.ReleaseN(1)
+}
+
+// ReleaseN releases the semaphore with a weight of n.
+func (s *Weighted) ReleaseN(n int64) {
 	s.mu.Lock()
 	s.releaseLocked(n)
 	s.mu.Unlock()

--- a/pkg/util/syncutil/semaphore/semaphore.go
+++ b/pkg/util/syncutil/semaphore/semaphore.go
@@ -1,0 +1,128 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package semaphore provides a weighted semaphore implementation.
+package semaphore
+
+import (
+	"container/list"
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+type waiter struct {
+	n     int64
+	ready chan<- struct{} // Closed when semaphore acquired.
+}
+
+// NewWeighted creates a new weighted semaphore with the given
+// maximum combined weight for concurrent access.
+func NewWeighted(n int64) *Weighted {
+	w := &Weighted{size: n}
+	return w
+}
+
+// Weighted provides a way to bound concurrent access to a resource.
+// The callers can request access with a given weight.
+type Weighted struct {
+	size    int64
+	cur     int64
+	mu      syncutil.Mutex
+	waiters list.List
+}
+
+// Acquire acquires the semaphore with a weight of n, blocking only until ctx
+// is done. On success, returns nil. On failure, returns ctx.Err() and leaves
+// the semaphore unchanged.
+//
+// If ctx is already done, Acquire may still succeed without blocking.
+func (s *Weighted) Acquire(ctx context.Context, n int64) error {
+	s.mu.Lock()
+	if s.size-s.cur >= n && s.waiters.Len() == 0 {
+		s.cur += n
+		s.mu.Unlock()
+		return nil
+	}
+
+	if n > s.size {
+		// Don't make other Acquire calls block on one that's doomed to fail.
+		s.mu.Unlock()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	ready := make(chan struct{})
+	w := waiter{n: n, ready: ready}
+	elem := s.waiters.PushBack(w)
+	s.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		err := ctx.Err()
+		s.mu.Lock()
+		select {
+		case <-ready:
+			// Acquired the semaphore after we were canceled.  Rather than trying to
+			// fix up the queue, just pretend we didn't notice the cancelation.
+			err = nil
+		default:
+			s.waiters.Remove(elem)
+		}
+		s.mu.Unlock()
+		return err
+
+	case <-ready:
+		return nil
+	}
+}
+
+// TryAcquire acquires the semaphore with a weight of n without blocking.
+// On success, returns true. On failure, returns false and leaves the semaphore unchanged.
+func (s *Weighted) TryAcquire(n int64) bool {
+	s.mu.Lock()
+	success := s.size-s.cur >= n && s.waiters.Len() == 0
+	if success {
+		s.cur += n
+	}
+	s.mu.Unlock()
+	return success
+}
+
+// Release releases the semaphore with a weight of n.
+func (s *Weighted) Release(n int64) {
+	s.mu.Lock()
+	s.cur -= n
+	if s.cur < 0 {
+		s.mu.Unlock()
+		panic("semaphore: bad release")
+	}
+	for {
+		next := s.waiters.Front()
+		if next == nil {
+			break // No more waiters blocked.
+		}
+
+		w := next.Value.(waiter)
+		if s.size-s.cur < w.n {
+			// Not enough tokens for the next waiter.  We could keep going (to try to
+			// find a waiter with a smaller request), but under load that could cause
+			// starvation for large requests; instead, we leave all remaining waiters
+			// blocked.
+			//
+			// Consider a semaphore used as a read-write lock, with N tokens, N
+			// readers, and one writer.  Each reader can Acquire(1) to obtain a read
+			// lock.  The writer can Acquire(N) to obtain a write lock, excluding all
+			// of the readers.  If we allow the readers to jump ahead in the queue,
+			// the writer will starve — there is always one token available for every
+			// reader.
+			break
+		}
+
+		s.cur += w.n
+		s.waiters.Remove(next)
+		close(w.ready)
+	}
+	s.mu.Unlock()
+}

--- a/pkg/util/syncutil/semaphore/semaphore.go
+++ b/pkg/util/syncutil/semaphore/semaphore.go
@@ -17,11 +17,17 @@ type waiter struct {
 	ready chan<- struct{} // Closed when semaphore acquired.
 }
 
+// MakeWeighted returns a weighted semaphore value with the given
+// maximum combined weight for concurrent access.
+func MakeWeighted(n int64) Weighted {
+	return Weighted{size: n}
+}
+
 // NewWeighted creates a new weighted semaphore with the given
 // maximum combined weight for concurrent access.
 func NewWeighted(n int64) *Weighted {
-	w := &Weighted{size: n}
-	return w
+	w := MakeWeighted(n)
+	return &w
 }
 
 // Weighted provides a way to bound concurrent access to a resource.

--- a/pkg/util/syncutil/semaphore/semaphore_bench_test.go
+++ b/pkg/util/syncutil/semaphore/semaphore_bench_test.go
@@ -1,0 +1,133 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.7
+
+package semaphore_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil/semaphore"
+)
+
+// weighted is an interface matching a subset of *Weighted.  It allows
+// alternate implementations for testing and benchmarking.
+type weighted interface {
+	Acquire(context.Context, int64) error
+	TryAcquire(int64) bool
+	Release(int64)
+}
+
+// semChan implements Weighted using a channel for
+// comparing against the condition variable-based implementation.
+type semChan chan struct{}
+
+func newSemChan(n int64) semChan {
+	return semChan(make(chan struct{}, n))
+}
+
+func (s semChan) Acquire(_ context.Context, n int64) error {
+	for i := int64(0); i < n; i++ {
+		s <- struct{}{}
+	}
+	return nil
+}
+
+func (s semChan) TryAcquire(n int64) bool {
+	if int64(len(s))+n > int64(cap(s)) {
+		return false
+	}
+
+	for i := int64(0); i < n; i++ {
+		s <- struct{}{}
+	}
+	return true
+}
+
+func (s semChan) Release(n int64) {
+	for i := int64(0); i < n; i++ {
+		<-s
+	}
+}
+
+// acquireN calls Acquire(size) on sem N times and then calls Release(size) N times.
+func acquireN(b *testing.B, sem weighted, size int64, N int) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < N; j++ {
+			if err := sem.Acquire(context.Background(), size); err != nil {
+				b.Fatalf("Acquire(ctx, %v) = %v", size, err)
+			}
+		}
+		for j := 0; j < N; j++ {
+			sem.Release(size)
+		}
+	}
+}
+
+// tryAcquireN calls TryAcquire(size) on sem N times and then calls Release(size) N times.
+func tryAcquireN(b *testing.B, sem weighted, size int64, N int) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < N; j++ {
+			if !sem.TryAcquire(size) {
+				b.Fatalf("TryAcquire(%v) = false, want true", size)
+			}
+		}
+		for j := 0; j < N; j++ {
+			sem.Release(size)
+		}
+	}
+}
+
+func BenchmarkNewSeq(b *testing.B) {
+	for _, cap := range []int64{1, 128} {
+		b.Run(fmt.Sprintf("Weighted-%d", cap), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = semaphore.NewWeighted(cap)
+			}
+		})
+		b.Run(fmt.Sprintf("semChan-%d", cap), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = newSemChan(cap)
+			}
+		})
+	}
+}
+
+func BenchmarkAcquireSeq(b *testing.B) {
+	for _, c := range []struct {
+		cap, size int64
+		N         int
+	}{
+		{1, 1, 1},
+		{2, 1, 1},
+		{16, 1, 1},
+		{128, 1, 1},
+		{2, 2, 1},
+		{16, 2, 8},
+		{128, 2, 64},
+		{2, 1, 2},
+		{16, 8, 2},
+		{128, 64, 2},
+	} {
+		for _, w := range []struct {
+			name string
+			w    weighted
+		}{
+			{"Weighted", semaphore.NewWeighted(c.cap)},
+			{"semChan", newSemChan(c.cap)},
+		} {
+			b.Run(fmt.Sprintf("%s-acquire-%d-%d-%d", w.name, c.cap, c.size, c.N), func(b *testing.B) {
+				acquireN(b, w.w, c.size, c.N)
+			})
+			b.Run(fmt.Sprintf("%s-tryAcquire-%d-%d-%d", w.name, c.cap, c.size, c.N), func(b *testing.B) {
+				tryAcquireN(b, w.w, c.size, c.N)
+			})
+		}
+	}
+}

--- a/pkg/util/syncutil/semaphore/semaphore_example_test.go
+++ b/pkg/util/syncutil/semaphore/semaphore_example_test.go
@@ -30,13 +30,13 @@ func Example_workerPool() {
 	for i := range out {
 		// When maxWorkers goroutines are in flight, Acquire blocks until one of the
 		// workers finishes.
-		if err := sem.Acquire(ctx, 1); err != nil {
+		if err := sem.AcquireN(ctx, 1); err != nil {
 			fmt.Printf("Failed to acquire semaphore: %v", err)
 			break
 		}
 
 		go func(i int) {
-			defer sem.Release(1)
+			defer sem.ReleaseN(1)
 			out[i] = collatzSteps(i + 1)
 		}(i)
 	}
@@ -45,7 +45,7 @@ func Example_workerPool() {
 	//
 	// If you are already waiting for the workers by some other means (such as an
 	// errgroup.Group), you can omit this final Acquire call.
-	if err := sem.Acquire(ctx, int64(maxWorkers)); err != nil {
+	if err := sem.AcquireN(ctx, int64(maxWorkers)); err != nil {
 		fmt.Printf("Failed to acquire semaphore: %v", err)
 	}
 

--- a/pkg/util/syncutil/semaphore/semaphore_example_test.go
+++ b/pkg/util/syncutil/semaphore/semaphore_example_test.go
@@ -1,0 +1,83 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package semaphore_test
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil/semaphore"
+)
+
+// Example_workerPool demonstrates how to use a semaphore to limit the number of
+// goroutines working on parallel tasks.
+//
+// This use of a semaphore mimics a typical “worker pool” pattern, but without
+// the need to explicitly shut down idle workers when the work is done.
+func Example_workerPool() {
+	ctx := context.TODO()
+
+	var (
+		maxWorkers = runtime.GOMAXPROCS(0)
+		sem        = semaphore.NewWeighted(int64(maxWorkers))
+		out        = make([]int, 32)
+	)
+
+	// Compute the output using up to maxWorkers goroutines at a time.
+	for i := range out {
+		// When maxWorkers goroutines are in flight, Acquire blocks until one of the
+		// workers finishes.
+		if err := sem.Acquire(ctx, 1); err != nil {
+			fmt.Printf("Failed to acquire semaphore: %v", err)
+			break
+		}
+
+		go func(i int) {
+			defer sem.Release(1)
+			out[i] = collatzSteps(i + 1)
+		}(i)
+	}
+
+	// Acquire all of the tokens to wait for any remaining workers to finish.
+	//
+	// If you are already waiting for the workers by some other means (such as an
+	// errgroup.Group), you can omit this final Acquire call.
+	if err := sem.Acquire(ctx, int64(maxWorkers)); err != nil {
+		fmt.Printf("Failed to acquire semaphore: %v", err)
+	}
+
+	fmt.Println(out)
+
+	// Output:
+	// [0 1 7 2 5 8 16 3 19 6 14 9 9 17 17 4 12 20 20 7 7 15 15 10 23 10 111 18 18 18 106 5]
+}
+
+// collatzSteps computes the number of steps to reach 1 under the Collatz
+// conjecture. (See https://en.wikipedia.org/wiki/Collatz_conjecture.)
+func collatzSteps(n int) (steps int) {
+	if n <= 0 {
+		panic("nonpositive input")
+	}
+
+	for ; n > 1; steps++ {
+		if steps < 0 {
+			panic("too many steps")
+		}
+
+		if n%2 == 0 {
+			n /= 2
+			continue
+		}
+
+		const maxInt = int(^uint(0) >> 1)
+		if n > (maxInt-1)/3 {
+			panic("overflow")
+		}
+		n = 3*n + 1
+	}
+
+	return steps
+}

--- a/pkg/util/syncutil/semaphore/semaphore_test.go
+++ b/pkg/util/syncutil/semaphore/semaphore_test.go
@@ -1,0 +1,176 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package semaphore_test
+
+import (
+	"context"
+	"math/rand"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil/semaphore"
+)
+
+const maxSleep = 1 * time.Millisecond
+
+func HammerWeighted(t *testing.T, sem *semaphore.Weighted, n int64, loops int) {
+	for i := 0; i < loops; i++ {
+		require.Nil(t, sem.Acquire(context.Background(), n))
+		time.Sleep(time.Duration(rand.Int63n(int64(maxSleep/time.Nanosecond))) * time.Nanosecond)
+		sem.Release(n)
+	}
+}
+
+func TestWeighted(t *testing.T) {
+	t.Parallel()
+
+	n := runtime.GOMAXPROCS(0)
+	loops := 10000 / n
+	sem := semaphore.NewWeighted(int64(n))
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			HammerWeighted(t, sem, int64(i), loops)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestWeightedPanic(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("release of an unacquired weighted semaphore did not panic")
+		}
+	}()
+	w := semaphore.NewWeighted(1)
+	w.Release(1)
+}
+
+func TestWeightedTryAcquire(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	sem := semaphore.NewWeighted(2)
+	tries := []bool{}
+	require.Nil(t, sem.Acquire(ctx, 1))
+	tries = append(tries, sem.TryAcquire(1))
+	tries = append(tries, sem.TryAcquire(1))
+
+	sem.Release(2)
+
+	tries = append(tries, sem.TryAcquire(1))
+	require.Nil(t, sem.Acquire(ctx, 1))
+	tries = append(tries, sem.TryAcquire(1))
+
+	want := []bool{true, false, true, false}
+	for i := range tries {
+		if tries[i] != want[i] {
+			t.Errorf("tries[%d]: got %t, want %t", i, tries[i], want[i])
+		}
+	}
+}
+
+func TestWeightedAcquire(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	sem := semaphore.NewWeighted(2)
+	tryAcquire := func(n int64) bool {
+		tryCtx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+		defer cancel()
+		return sem.Acquire(tryCtx, n) == nil
+	}
+
+	tries := []bool{}
+	require.Nil(t, sem.Acquire(ctx, 1))
+	tries = append(tries, tryAcquire(1))
+	tries = append(tries, tryAcquire(1))
+
+	sem.Release(2)
+
+	tries = append(tries, tryAcquire(1))
+	require.Nil(t, sem.Acquire(ctx, 1))
+	tries = append(tries, tryAcquire(1))
+
+	want := []bool{true, false, true, false}
+	for i := range tries {
+		if tries[i] != want[i] {
+			t.Errorf("tries[%d]: got %t, want %t", i, tries[i], want[i])
+		}
+	}
+}
+
+func TestWeightedDoesntBlockIfTooBig(t *testing.T) {
+	t.Parallel()
+
+	const n = 2
+	sem := semaphore.NewWeighted(n)
+	{
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go func() {
+			require.Equal(t, context.Canceled, sem.Acquire(ctx, n+1))
+		}()
+	}
+
+	g, ctx := errgroup.WithContext(context.Background())
+	for i := n * 3; i > 0; i-- {
+		g.Go(func() error {
+			err := sem.Acquire(ctx, 1)
+			if err == nil {
+				time.Sleep(1 * time.Millisecond)
+				sem.Release(1)
+			}
+			return err
+		})
+	}
+	if err := g.Wait(); err != nil {
+		t.Errorf("semaphore.NewWeighted(%v) failed to AcquireCtx(_, 1) with AcquireCtx(_, %v) pending", n, n+1)
+	}
+}
+
+// TestLargeAcquireDoesntStarve times out if a large call to Acquire starves.
+// Merely returning from the test function indicates success.
+func TestLargeAcquireDoesntStarve(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	n := int64(runtime.GOMAXPROCS(0))
+	sem := semaphore.NewWeighted(n)
+	running := true
+
+	var wg sync.WaitGroup
+	wg.Add(int(n))
+	for i := n; i > 0; i-- {
+		require.Nil(t, sem.Acquire(ctx, 1))
+		go func() {
+			defer func() {
+				sem.Release(1)
+				wg.Done()
+			}()
+			for running {
+				time.Sleep(1 * time.Millisecond)
+				sem.Release(1)
+				require.Nil(t, sem.Acquire(ctx, 1))
+			}
+		}()
+	}
+
+	require.Nil(t, sem.Acquire(ctx, n))
+	running = false
+	sem.Release(n)
+	wg.Wait()
+}


### PR DESCRIPTION
I'm not necessarily planning on merging this. For now, I'm just publishing to get input and to see how people feel about it. He's an incomplete list of pros and cons for this approach.

Pros:
- ~35% faster than channel approach for single element acquisition (see benchmarks below)
- straightforward `Resize` method (the main reason I'm considering this change)
- constant-time "weighted" acquisition and release
- constant space usage, regardless of permit count

Cons:
- heavy-weight
- not compossible with other channel operations (acquisition takes a `context` for cancellation, but that's it)
- not "Go-like"

This change started life as a direct fork of [`golang.org/x/sync/semaphore`](https://godoc.org/golang.org/x/sync/semaphore). Initially, the only changes were getting it to pass lint checks.

```
BenchmarkNewSeq/Weighted-1-4         	2000000000	         0.31 ns/op
BenchmarkNewSeq/semChan-1-4          	30000000	        34.9 ns/op
BenchmarkNewSeq/Weighted-128-4       	2000000000	         0.31 ns/op
BenchmarkNewSeq/semChan-128-4        	50000000	        34.0 ns/op
BenchmarkAcquireSeq/Weighted-acquire-1-1-1-4         	50000000	        39.4 ns/op
BenchmarkAcquireSeq/Weighted-tryAcquire-1-1-1-4      	30000000	        39.4 ns/op
BenchmarkAcquireSeq/semChan-acquire-1-1-1-4          	20000000	        61.5 ns/op
BenchmarkAcquireSeq/semChan-tryAcquire-1-1-1-4       	20000000	        60.1 ns/op
BenchmarkAcquireSeq/Weighted-acquire-2-1-1-4         	50000000	        39.5 ns/op
BenchmarkAcquireSeq/Weighted-tryAcquire-2-1-1-4      	50000000	        39.4 ns/op
BenchmarkAcquireSeq/semChan-acquire-2-1-1-4          	20000000	        60.4 ns/op
BenchmarkAcquireSeq/semChan-tryAcquire-2-1-1-4       	20000000	        60.1 ns/op
BenchmarkAcquireSeq/Weighted-acquire-16-1-1-4        	30000000	        39.3 ns/op
BenchmarkAcquireSeq/Weighted-tryAcquire-16-1-1-4     	50000000	        39.0 ns/op
BenchmarkAcquireSeq/semChan-acquire-16-1-1-4         	20000000	        62.8 ns/op
BenchmarkAcquireSeq/semChan-tryAcquire-16-1-1-4      	30000000	        59.9 ns/op
BenchmarkAcquireSeq/Weighted-acquire-128-1-1-4       	50000000	        39.5 ns/op
BenchmarkAcquireSeq/Weighted-tryAcquire-128-1-1-4    	50000000	        39.2 ns/op
BenchmarkAcquireSeq/semChan-acquire-128-1-1-4        	20000000	        60.1 ns/op
BenchmarkAcquireSeq/semChan-tryAcquire-128-1-1-4     	20000000	        59.8 ns/op
BenchmarkAcquireSeq/Weighted-acquire-2-2-1-4         	50000000	        39.3 ns/op
BenchmarkAcquireSeq/Weighted-tryAcquire-2-2-1-4      	50000000	        39.5 ns/op
BenchmarkAcquireSeq/semChan-acquire-2-2-1-4          	20000000	       112 ns/op
BenchmarkAcquireSeq/semChan-tryAcquire-2-2-1-4       	20000000	       112 ns/op
BenchmarkAcquireSeq/Weighted-acquire-16-2-8-4        	 5000000	       314 ns/op
BenchmarkAcquireSeq/Weighted-tryAcquire-16-2-8-4     	 5000000	       313 ns/op
BenchmarkAcquireSeq/semChan-acquire-16-2-8-4         	 2000000	       888 ns/op
BenchmarkAcquireSeq/semChan-tryAcquire-16-2-8-4      	 2000000	       895 ns/op
BenchmarkAcquireSeq/Weighted-acquire-128-2-64-4      	  500000	      2558 ns/op
BenchmarkAcquireSeq/Weighted-tryAcquire-128-2-64-4   	  500000	      2493 ns/op
BenchmarkAcquireSeq/semChan-acquire-128-2-64-4       	  200000	      7573 ns/op
BenchmarkAcquireSeq/semChan-tryAcquire-128-2-64-4    	  200000	      7193 ns/op
BenchmarkAcquireSeq/Weighted-acquire-2-1-2-4         	20000000	        78.6 ns/op
BenchmarkAcquireSeq/Weighted-tryAcquire-2-1-2-4      	20000000	        77.4 ns/op
BenchmarkAcquireSeq/semChan-acquire-2-1-2-4          	10000000	       118 ns/op
BenchmarkAcquireSeq/semChan-tryAcquire-2-1-2-4       	20000000	       118 ns/op
BenchmarkAcquireSeq/Weighted-acquire-16-8-2-4        	20000000	        79.9 ns/op
BenchmarkAcquireSeq/Weighted-tryAcquire-16-8-2-4     	20000000	        79.1 ns/op
BenchmarkAcquireSeq/semChan-acquire-16-8-2-4         	 2000000	       848 ns/op
BenchmarkAcquireSeq/semChan-tryAcquire-16-8-2-4      	 2000000	       866 ns/op
BenchmarkAcquireSeq/Weighted-acquire-128-64-2-4      	20000000	        79.0 ns/op
BenchmarkAcquireSeq/Weighted-tryAcquire-128-64-2-4   	20000000	        78.4 ns/op
BenchmarkAcquireSeq/semChan-acquire-128-64-2-4       	  200000	      6697 ns/op
BenchmarkAcquireSeq/semChan-tryAcquire-128-64-2-4    	  200000	      6745 ns/op
```

The way to read these benchmarks is `method-semCapactity-acquisitionWeight-acquisitionCount`. Since most of our semaphores are unweighted (acquisitionWeight=1), the top few benchmarks are the most interesting.

After the package was forked, a new `Resize` method was added to the `semaphore.Weighted` type. This added functionality was the initial reason why I began looking for alternatives to the idiomatic channel-based semaphore approach. With channels, the only way I can think of to support resizing is if we created a channel with a very large capacity and initially reserved most of it such that the effective remaining capacity became the semaphore size. We could then play with this reserved capacity to resize the semaphore. This seems undesirable for a number of reasons, including that this initial allocation would be a huge waste of resources.

The ability to resize semaphores will allow me to accomplish my actual goal of creating cluster settings for `DistSender` and `intentResolver` concurrency. For `DistSender`, this cluster setting will adjust how many batches we allow to be parallelized across ranges before reverting to serial execution. For `intentResolver`, this cluster setting will adjust how many intent resolution processes we allow `BatchRequests` to launch asynchronously before we start launching them synchronously and backpressuring foreground traffic.