### PR TITLE
sql: improve the table name prefix resolution error message

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/namespace
+++ b/pkg/sql/logictest/testdata/logic_test/namespace
@@ -104,7 +104,7 @@ ALTER INDEX public.public."primary" RENAME TO t_pk
 statement ok
 SET search_path = invalid
 
-statement error no schema has been selected to search index: "a_pk3"
+statement error schema or database was not found while searching index: "a_pk3"
 ALTER INDEX a_pk3 RENAME TO a_pk4
 
 # But qualification resolves the problem.

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -3,7 +3,7 @@
 statement ok
 SET DATABASE = ""
 
-statement error no schema has been selected to create "a" in
+statement error cannot create "a" because the target database or schema does not exist
 CREATE TABLE a (id INT PRIMARY KEY)
 
 statement error invalid table name: test.""

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -178,8 +178,8 @@ func ResolveTargetObject(
 	}
 	if !found {
 		return nil, pgerror.NewErrorf(pgerror.CodeInvalidSchemaNameError,
-			"no schema has been selected to create %q in",
-			tree.ErrString(tn)).SetHintf("verify that the current database and search_path are valid")
+			"cannot create %q because the target database or schema does not exist",
+			tree.ErrString(tn)).SetHintf("verify that the current database and search_path are valid and/or the target database exists")
 	}
 	if tn.Schema() != tree.PublicSchema {
 		return nil, pgerror.NewErrorf(pgerror.CodeInvalidNameError,
@@ -432,7 +432,7 @@ func expandIndexName(
 		if !found {
 			if requireTable {
 				return nil, nil, pgerror.NewErrorf(pgerror.CodeUndefinedObjectError,
-					"no schema has been selected to search index: %q",
+					"schema or database was not found while searching index: %q",
 					tree.ErrString(&index.Index)).SetHintf(
 					"check the current database and search_path are valid")
 			}


### PR DESCRIPTION
Fixes #29594.

Before:

```
root@127.0.0.1:44824/defaultdb> create table t.t(x int);
pq: no schema has been selected to create "t.t" in
HINT: verify that the current database and search_path are valid
```

After:

```
root@127.0.0.1:36392/defaultdb> create table t.t(x int);
pq: cannot create "t.t" because the target database or schema does not exist
HINT: verify that the current database and search_path are valid and/or the target database exists
```

Release note: None