### PR TITLE
opt: Store root of normalized tree in Memo in optbuilder

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -316,8 +316,7 @@ func (h *harness) runUsingAPI(tb testing.TB, bmType BenchmarkType, query string)
 		h.optimizer.DisableOptimizations()
 	}
 	bld := optbuilder.New(h.ctx, &h.semaCtx, &h.evalCtx, h.cat, h.optimizer.Factory(), h.stmt)
-	root, props, err := bld.Build()
-	if err != nil {
+	if err := bld.Build(); err != nil {
 		tb.Fatalf("%v", err)
 	}
 
@@ -325,5 +324,5 @@ func (h *harness) runUsingAPI(tb testing.TB, bmType BenchmarkType, query string)
 		return
 	}
 
-	h.optimizer.Optimize(root, props)
+	h.optimizer.Optimize()
 }

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -145,11 +145,11 @@ func TestIndexConstraints(t *testing.T) {
 				}
 				b := optbuilder.NewScalar(ctx, &semaCtx, &evalCtx, &f)
 				b.AllowUnsupportedExpr = true
-				group, err := b.Build(typedExpr)
+				err = b.Build(typedExpr)
 				if err != nil {
 					return fmt.Sprintf("error: %v\n", err)
 				}
-				ev := memo.MakeNormExprView(f.Memo(), group)
+				ev := f.Memo().Root()
 
 				var ic idxconstraint.Instance
 				ic.Init(ev, indexCols, notNullCols, invertedIndex, &evalCtx, &f)
@@ -256,11 +256,11 @@ func BenchmarkIndexConstraints(b *testing.B) {
 			evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 			bld := optbuilder.NewScalar(context.Background(), &semaCtx, &evalCtx, &f)
 
-			group, err := bld.Build(typedExpr)
+			err = bld.Build(typedExpr)
 			if err != nil {
 				b.Fatal(err)
 			}
-			ev := memo.MakeNormExprView(f.Memo(), group)
+			ev := f.Memo().Root()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				var ic idxconstraint.Instance

--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -211,10 +211,6 @@ func (ev ExprView) bestExpr() *BestExpr {
 	return ev.mem.group(ev.group).bestExpr(ev.best)
 }
 
-func (ev ExprView) bestExprID() BestExprID {
-	return BestExprID{group: ev.group, ordinal: ev.best}
-}
-
 // --------------------------------------------------------------------
 // String representation.
 // --------------------------------------------------------------------

--- a/pkg/sql/opt/memo/expr_view_test.go
+++ b/pkg/sql/opt/memo/expr_view_test.go
@@ -51,11 +51,11 @@ func BenchmarkExprView(b *testing.B) {
 			bld := optbuilder.New(
 				context.Background(), &semaCtx, &evalCtx, catalog, o.Factory(), stmt,
 			)
-			root, props, err := bld.Build()
+			err = bld.Build()
 			if err != nil {
 				b.Fatal(err)
 			}
-			exprView := o.Optimize(root, props)
+			exprView := o.Optimize()
 
 			stack := make([]memo.ExprView, 16)
 			for i := 0; i < b.N; i++ {

--- a/pkg/sql/opt/memo/memo_format.go
+++ b/pkg/sql/opt/memo/memo_format.go
@@ -36,7 +36,7 @@ func (m *Memo) format(f *memoFmtCtx) string {
 	// If requested, we topological sort the memo with respect to its root group.
 	// Otherwise, we simply print out all the groups in the order and with the
 	// names they're referred to physically.
-	if f.flags.HasFlags(FmtRaw) || !m.isOptimized() {
+	if f.flags.HasFlags(FmtRaw) {
 		// In this case we renumber with the identity mapping, so the groups have
 		// the same numbers as they're represented with internally.
 		f.ordering = make([]GroupID, len(m.groups)-1)
@@ -44,7 +44,7 @@ func (m *Memo) format(f *memoFmtCtx) string {
 			f.ordering[i] = GroupID(i + 1)
 		}
 	} else {
-		f.ordering = m.sortGroups(m.root.group)
+		f.ordering = m.sortGroups(m.RootGroup())
 	}
 
 	// We renumber the groups so that they're still printed in order from 1..N.
@@ -78,9 +78,9 @@ func (m *Memo) format(f *memoFmtCtx) string {
 
 	// If showing raw memo, then add header text to point to root expression if
 	// it's available.
-	if f.flags.HasFlags(FmtRaw) && m.isOptimized() {
-		ev := m.Root()
-		return fmt.Sprintf("root: G%d, %s\n%s", f.numbering[ev.Group()], ev.Physical(), tp.String())
+	if f.flags.HasFlags(FmtRaw) {
+		rootProps := m.LookupPhysicalProps(m.RootProps())
+		return fmt.Sprintf("root: G%d, %s\n%s", f.numbering[m.RootGroup()], rootProps, tp.String())
 	}
 	return tp.String()
 }
@@ -168,7 +168,7 @@ func (m *Memo) formatBestExprSet(f *memoFmtCtx, tp treeprinter.Node, mgrp *group
 
 	sort.Slice(beSort, func(i, j int) bool {
 		// Always order the root required properties first.
-		if mgrp.id == m.root.group {
+		if mgrp.id == m.RootGroup() {
 			if beSort[i].required == beSort[i].best.required {
 				return true
 			}

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
@@ -108,11 +107,11 @@ func TestBuilder(t *testing.T) {
 				o.DisableOptimizations()
 				b := optbuilder.NewScalar(ctx, &semaCtx, &evalCtx, o.Factory())
 				b.AllowUnsupportedExpr = tester.Flags.AllowUnsupportedExpr
-				group, err := b.Build(typedExpr)
+				err = b.Build(typedExpr)
 				if err != nil {
 					return fmt.Sprintf("error: %s\n", strings.TrimSpace(err.Error()))
 				}
-				exprView := o.Optimize(group, &props.Physical{})
+				exprView := o.Optimize()
 				return exprView.FormatString(tester.Flags.ExprFormat)
 
 			default:

--- a/pkg/sql/opt/optbuilder/explain.go
+++ b/pkg/sql/opt/optbuilder/explain.go
@@ -56,7 +56,7 @@ func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope 
 	def := memo.ExplainOpDef{
 		Options: opts,
 		ColList: colsToColList(outScope.cols),
-		Props:   stmtScope.makePhysicalProps(),
+		Props:   *stmtScope.makePhysicalProps(),
 	}
 	outScope.group = b.factory.ConstructExplain(stmtScope.group, b.factory.InternExplainOpDef(&def))
 	return outScope

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -667,7 +667,7 @@ func NewScalar(
 
 // Build a memo structure from a TypedExpr: the root group represents a scalar
 // expression equivalent to expr.
-func (sb *ScalarBuilder) Build(expr tree.TypedExpr) (root memo.GroupID, err error) {
+func (sb *ScalarBuilder) Build(expr tree.TypedExpr) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			// This code allows us to propagate builder errors without adding
@@ -682,5 +682,7 @@ func (sb *ScalarBuilder) Build(expr tree.TypedExpr) (root memo.GroupID, err erro
 		}
 	}()
 
-	return sb.buildScalar(expr, &sb.scope, nil, nil, nil), nil
+	group := sb.buildScalar(expr, &sb.scope, nil, nil, nil)
+	sb.factory.Memo().SetRoot(group, memo.MinPhysPropsID)
+	return nil
 }

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -203,8 +203,8 @@ func (s *scope) makeOrderingChoice() props.OrderingChoice {
 
 // makePhysicalProps constructs physical properties using the columns in the
 // scope for presentation and s.ordering for required ordering.
-func (s *scope) makePhysicalProps() props.Physical {
-	p := props.Physical{}
+func (s *scope) makePhysicalProps() *props.Physical {
+	p := &props.Physical{}
 
 	if len(s.cols) > 0 {
 		p.Presentation = make(props.Presentation, 0, len(s.cols))

--- a/pkg/sql/opt/testutils/forcing_opt.go
+++ b/pkg/sql/opt/testutils/forcing_opt.go
@@ -28,9 +28,6 @@ import (
 type forcingOptimizer struct {
 	o xform.Optimizer
 
-	root     memo.GroupID
-	required *props.Physical
-
 	// remaining is the number of "unused" steps remaining.
 	remaining int
 
@@ -111,16 +108,14 @@ func newForcingOptimizer(
 		},
 	)
 
-	var err error
-	fo.root, fo.required, err = tester.buildExpr(fo.o.Factory())
-	if err != nil {
+	if err := tester.buildExpr(fo.o.Factory()); err != nil {
 		return nil, err
 	}
 	return fo, nil
 }
 
 func (fo *forcingOptimizer) optimize() memo.ExprView {
-	return fo.o.Optimize(fo.root, fo.required)
+	return fo.o.Optimize()
 }
 
 // restrictToExprs sets up the optimizer to restrict the result to only those
@@ -135,7 +130,7 @@ func (fo *forcingOptimizer) restrictToExprs(
 ) {
 	coster := newForcingCoster(fo.o.Coster())
 
-	restrictToGroup(coster, mem, fo.root, group)
+	restrictToGroup(coster, mem, mem.RootGroup(), group)
 
 	for e := 0; e < mem.ExprCount(group); e++ {
 		if !exprs.Contains(e) {
@@ -151,7 +146,7 @@ func (fo *forcingOptimizer) restrictToExprs(
 func (fo *forcingOptimizer) restrictToGroup(mem *memo.Memo, group memo.GroupID) {
 	coster := newForcingCoster(fo.o.Coster())
 
-	restrictToGroup(coster, mem, fo.root, group)
+	restrictToGroup(coster, mem, mem.RootGroup(), group)
 	fo.o.SetCoster(coster)
 }
 

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -305,7 +305,7 @@ memo (optimized, ~2KB)
 memo
 SELECT s, i, f FROM a WHERE s='foo' ORDER BY s DESC, i
 ----
-memo (optimized, ~7KB)
+memo (optimized, ~8KB)
  ├── G1: (select G2 G3) (scan a@s_idx,cols=(2-4),constrained) (index-join G4 a,cols=(2-4))
  │    ├── "[presentation: s:4,i:2,f:3] [ordering: +2 opt(4)]"
  │    │    ├── best: (sort G1)

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -141,11 +141,11 @@ func (p *planner) selectIndex(
 		}
 		bld := optbuilder.NewScalar(ctx, &p.semaCtx, p.EvalContext(), optimizer.Factory())
 		bld.AllowUnsupportedExpr = true
-		filterGroup, err := bld.Build(s.filter)
+		err := bld.Build(s.filter)
 		if err != nil {
 			return nil, err
 		}
-		filterExpr := memo.MakeNormExprView(optimizer.Memo(), filterGroup)
+		filterExpr := optimizer.Memo().Root()
 		for _, c := range candidates {
 			if err := c.makeIndexConstraints(
 				&optimizer, filterExpr, p.EvalContext(),

--- a/pkg/sql/opt_index_selection_test.go
+++ b/pkg/sql/opt_index_selection_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -101,11 +100,11 @@ func makeSpans(
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	bld := optbuilder.NewScalar(context.Background(), &semaCtx, &evalCtx, o.Factory())
 	bld.AllowUnsupportedExpr = true
-	filterGroup, err := bld.Build(expr)
+	err := bld.Build(expr)
 	if err != nil {
 		t.Fatal(err)
 	}
-	filterExpr := memo.MakeNormExprView(o.Memo(), filterGroup)
+	filterExpr := o.Memo().Root()
 	err = c.makeIndexConstraints(&o, filterExpr, p.EvalContext())
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
@@ -1488,11 +1487,10 @@ func optBuildScalar(evalCtx *tree.EvalContext, e tree.TypedExpr) (tree.TypedExpr
 	o.Init(evalCtx)
 	b := optbuilder.NewScalar(context.TODO(), &tree.SemaContext{}, evalCtx, o.Factory())
 	b.AllowUnsupportedExpr = true
-	group, err := b.Build(e)
-	if err != nil {
+	if err := b.Build(e); err != nil {
 		return nil, err
 	}
-	ev := o.Optimize(group, &props.Physical{})
+	ev := o.Optimize()
 
 	bld := execbuilder.New(nil /* factory */, ev)
 	ivh := tree.MakeIndexedVarHelper(nil /* container */, 0)


### PR DESCRIPTION
The Memo has always stored the root of the lowest cost expression tree,
once exploration completes. This commit changes optbuilder to store the
root of the normalized tree even before exploration starts. This cleans
up the API and will make it easier to copy the Memo from place to place
during the PREPARE phase and when using a prepared Memo.

Release note: None