### PR TITLE
release-2.0: cli/zone: make the client cross-compatible with 2.1

### DIFF
--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -627,6 +627,50 @@ func runQuery(conn *sqlConn, fn queryFunc, showMoreChars bool) ([]string, [][]st
 	return sqlRowsToStrings(rows, showMoreChars)
 }
 
+// runQueryRaw takes a 'query' with optional 'parameters'.
+// It returns the result rows as strings with minimal changes (no escaping, etc).
+func runQueryRaw(conn *sqlConn, fn queryFunc) (cols []string, results [][]string, err error) {
+	rows, err := fn(conn)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	defer func() {
+		rowsErr := rows.Close()
+		if err != nil {
+			err = errors.Wrapf(rowsErr, "error after row-wise error: %v", err)
+		}
+	}()
+	cols = rows.Columns()
+	vals := make([]driver.Value, len(cols))
+	for {
+		err := rows.Next(vals)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return cols, results, err
+		}
+		rowStrings := make([]string, len(cols))
+		for i, v := range vals {
+			switch t := v.(type) {
+			case nil:
+				rowStrings[i] = "NULL"
+			case string:
+				rowStrings[i] = t
+			case []byte:
+				rowStrings[i] = string(t)
+			case time.Time:
+				rowStrings[i] = t.Format(tree.TimestampOutputFormat)
+			default:
+				rowStrings[i] = fmt.Sprintf("%v", t)
+			}
+		}
+		results = append(results, rowStrings)
+	}
+	return cols, results, nil
+}
+
 // handleCopyError ensures the user is properly informed when they issue
 // a COPY statement somewhere in their input.
 func handleCopyError(conn *sqlConn, err error) error {

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -16,50 +16,67 @@ package cli
 
 import (
 	"database/sql/driver"
+	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
+type runQueryRawFn func(q string, parameters ...driver.Value) ([]string, [][]string, error)
+
+// runQueryRawMaybeExperimental tries to run the query without the
+// experimental keyword, and if that fails with a syntax error, with
+// it. The placement of the experimental keyword must be marked with %[1]s in
+// the string. This is intended for backward-compatibility.
+// TODO(knz): Remove this post-2.2.
+func runQueryRawMaybeExperimental(conn *sqlConn, txnFn func(runQuery runQueryRawFn) error) error {
+	withExecute := ""
+	eqSign := "="
+	runQueryFn := func(q string, parameters ...driver.Value) ([]string, [][]string, error) {
+		return runQueryRaw(conn, makeQuery(fmt.Sprintf(q, withExecute, eqSign), parameters...))
+	}
+	queryFn := func(_ *sqlConn) error { return txnFn(runQueryFn) }
+
+	err := conn.ExecTxn(queryFn)
+	if err != nil && strings.Contains(err.Error(), "syntax error") {
+		withExecute = "EXPERIMENTAL"
+		eqSign = ""
+		err = conn.ExecTxn(queryFn)
+	}
+	return err
+}
+
+func getCLISpecifierAndZoneConf(
+	zs *tree.ZoneSpecifier, runQuery runQueryRawFn,
+) ([][]string, error) {
+	_, vals, err := runQuery(fmt.Sprintf(
+		`SELECT cli_specifier, config_yaml FROM [%%[1]s SHOW ZONE CONFIGURATION FOR %s]`,
+		zs))
+	return vals, err
+}
+
 func queryZoneSpecifiers(conn *sqlConn) ([]string, error) {
-	rows, err := makeQuery(
-		`SELECT cli_specifier FROM [EXPERIMENTAL SHOW ZONE CONFIGURATIONS] ORDER BY cli_specifier`,
-	)(conn)
-	if err != nil {
+	var vals [][]string
+	if err := runQueryRawMaybeExperimental(conn,
+		func(runQuery runQueryRawFn) (err error) {
+			_, vals, err = runQuery(
+				`SELECT cli_specifier FROM [%[1]s SHOW ZONE CONFIGURATIONS]
+          WHERE cli_specifier IS NOT NULL
+          ORDER BY cli_specifier`)
+			return
+		}); err != nil {
 		return nil, err
 	}
-	defer func() { _ = rows.Close() }()
-
-	vals := make([]driver.Value, len(rows.Columns()))
-	specifiers := []string{}
-
-	for {
-		if err := rows.Next(vals); err != nil {
-			if err == io.EOF {
-				break
-			}
-			return nil, err
-		}
-
-		if vals[0] == nil {
-			// Zone configs for deleted tables and partitions are left around until
-			// their table descriptors are deleted, which happens after the
-			// configured GC TTL duration. Such zones have no cli_specifier and
-			// shouldn't be displayed.
-			continue
-		}
-
-		s, ok := vals[0].(string)
-		if !ok {
-			return nil, fmt.Errorf("unexpected value: %T", vals[0])
-		}
-		specifiers = append(specifiers, s)
+	specifiers := make([]string, len(vals))
+	for i, v := range vals {
+		specifiers[i] = v[0]
 	}
 	return specifiers, nil
 }
@@ -100,22 +117,21 @@ func runGetZone(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	vals, err := conn.QueryRow(fmt.Sprintf(
-		`SELECT cli_specifier, config_yaml FROM [EXPERIMENTAL SHOW ZONE CONFIGURATION FOR %s]`, &zs), nil)
-	if err != nil {
+	var vals [][]string
+	if err := runQueryRawMaybeExperimental(conn,
+		func(runQuery runQueryRawFn) (err error) {
+			vals, err = getCLISpecifierAndZoneConf(&zs, runQuery)
+			return
+		}); err != nil {
 		return err
 	}
-
-	cliSpecifier, ok := vals[0].(string)
-	if !ok {
-		return fmt.Errorf("unexpected result type: %T", vals[0])
+	if len(vals) == 0 {
+		return fmt.Errorf("no zone configuration found for %s",
+			config.CLIZoneSpecifier(&zs))
 	}
 
-	configYAML, ok := vals[1].([]byte)
-	if !ok {
-		return fmt.Errorf("unexpected result type: %T", vals[0])
-	}
-
+	cliSpecifier := vals[0][0]
+	configYAML := vals[0][1]
 	fmt.Println(cliSpecifier)
 	fmt.Printf("%s", configYAML)
 	return nil
@@ -195,8 +211,15 @@ func runRmZone(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return runQueryAndFormatResults(conn, os.Stdout,
-		makeQuery(fmt.Sprintf(`ALTER %s EXPERIMENTAL CONFIGURE ZONE NULL`, &zs)))
+	// We really want to use runQueryRawMaybeExperimental here,
+	// but v2.0 really wants to print the statement tag (for backward compatibility).
+	err = runQueryAndFormatResults(conn, os.Stdout,
+		makeQuery(fmt.Sprintf(`ALTER %s CONFIGURE ZONE DISCARD`, &zs)))
+	if err != nil && strings.Contains(err.Error(), "syntax error") {
+		err = runQueryAndFormatResults(conn, os.Stdout,
+			makeQuery(fmt.Sprintf(`ALTER %s EXPERIMENTAL CONFIGURE ZONE NULL`, &zs)))
+	}
+	return err
 }
 
 // A setZoneCmd command creates a new or updates an existing zone config.
@@ -277,28 +300,24 @@ func runSetZone(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = conn.ExecTxn(func(conn *sqlConn) error {
-		if err := conn.Exec(fmt.Sprintf(`ALTER %s EXPERIMENTAL CONFIGURE ZONE %s`, &zs,
-			lex.EscapeSQLString(string(configYAML))), nil); err != nil {
-			return err
-		}
-		vals, err := conn.QueryRow(fmt.Sprintf(
-			`SELECT config_yaml FROM [EXPERIMENTAL SHOW ZONE CONFIGURATION FOR %s]`, &zs), nil)
-		if err != nil {
-			return err
-		}
-		var ok bool
-		configYAML, ok = vals[0].([]byte)
-		if !ok {
-			return fmt.Errorf("unexpected result type: %T", vals[0])
-		}
-		return nil
-	})
-	if err != nil {
+	var vals [][]string
+	if err := runQueryRawMaybeExperimental(conn,
+		func(runQuery runQueryRawFn) (err error) {
+			if _, _, err := runQuery(fmt.Sprintf(
+				`ALTER %s %%[1]s CONFIGURE ZONE %%[2]s %s`,
+				&zs, lex.EscapeSQLString(string(configYAML)))); err != nil {
+				return err
+			}
+			vals, err = getCLISpecifierAndZoneConf(&zs, runQuery)
+			return
+		}); err != nil {
 		return err
 	}
 
-	fmt.Printf("%s", configYAML)
+	if len(vals) == 0 {
+		return errors.New("zone configuration disappeared during rm")
+	}
+	fmt.Printf("%s", vals[0][1])
 	return nil
 }
 


### PR DESCRIPTION
Accompanies #28612.

Release note (cli change): The command `cockroach zone` is upgraded to
become compatible with CockroachDB 2.1; note however that `cockroach
zone` also becomes *deprecated* in CockroachDB 2.1 in favor of SQL
ALTER statements to update zone configurations.