### PR TITLE
release-2.1: roachtest: fix acceptance/cluster-init on remote clusters

### DIFF
--- a/pkg/cmd/roachtest/cluster_init.go
+++ b/pkg/cmd/roachtest/cluster_init.go
@@ -165,7 +165,7 @@ func runClusterInit(ctx context.Context, t *test, c *cluster) {
 			waitForFullReplication(t, dbs[0])
 
 			execCLI := func(runNode int, extraArgs ...string) (string, error) {
-				args := []string{cockroach}
+				args := []string{"./cockroach"}
 				args = append(args, extraArgs...)
 				args = append(args, "--insecure")
 				args = append(args, fmt.Sprintf("--port={pgport:%d}", runNode))


### PR DESCRIPTION
Backport 1/1 commits from #29635.

/cc @cockroachdb/release

---

The test was using the local binary path for running the 'init' command,
which works on local clusters but not on remote ones.

Fixes #29627

Release note: None
