### PR TITLE
release-2.0: storage: optimistically resolve pending prereqs in cmdQ before canceling

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1126,7 +1126,7 @@ func TestRefreshPendingCommands(t *testing.T) {
 }
 
 // Test that when a Raft group is not able to establish a quorum, its Raft log
-// does not grow without bound. It tests two different scenerios where this used
+// does not grow without bound. It tests two different scenarios where this used
 // to be possible (see #27772):
 // 1. The leader proposes a command and cannot establish a quorum. The leader
 //    continually re-proposes the command.

--- a/pkg/storage/command_queue.go
+++ b/pkg/storage/command_queue.go
@@ -87,6 +87,10 @@ type cmd struct {
 	// don't need to keep multiple *cmd slices in-sync.
 	prereqs    *[]*cmd
 	prereqsBuf []*cmd
+	// Only initialized if needed and only ever initialized
+	// on a parent cmd. Stores all of the IDs of commands
+	// in the prereq slice to avoid duplicates.
+	prereqIDs map[int64]struct{}
 
 	pending chan struct{} // closed when complete
 }
@@ -222,7 +226,26 @@ func (c *cmd) ResolvePendingPrereq() {
 	// dependencies (see rules in command_queue.go) will work as expected with
 	// regard to properly transferring dependencies. This is because these
 	// timestamp rules all exhibit a transitive relationship.
-	*c.prereqs = append(*c.prereqs, *pre.prereqs...)
+	if len(*pre.prereqs) > 0 {
+		// Avoid adding duplicate prereqs into the prereq slice. If we naively
+		// inserted duplicate prereqs into the slice then it could grow
+		// quadratically in cases where multiple prereqs of cmd each share
+		// common prerequisites themselves.
+		if c.prereqIDs == nil {
+			// Lazily compute prereq ID set. This is only necessary during
+			// command cancellation scenario.
+			c.prereqIDs = make(map[int64]struct{}, len(*c.prereqs))
+			for _, pre := range *c.prereqs {
+				c.prereqIDs[pre.id] = struct{}{}
+			}
+		}
+		for _, newPre := range *pre.prereqs {
+			if _, ok := c.prereqIDs[newPre.id]; !ok {
+				*c.prereqs = append(*c.prereqs, newPre)
+				c.prereqIDs[newPre.id] = struct{}{}
+			}
+		}
+	}
 
 	// Truncate the command's prerequisite list so that it no longer includes
 	// the first prerequisite. Before doing so, nil out prefix of slice to allow
@@ -231,6 +254,9 @@ func (c *cmd) ResolvePendingPrereq() {
 	// especially during cascade command cancellation.
 	(*c.prereqs)[0] = nil
 	(*c.prereqs) = (*c.prereqs)[1:]
+
+	// Delete from the prereq ID set (if c.prereqIDs is nil, this is a no-op).
+	delete(c.prereqIDs, pre.id)
 }
 
 // OptimisticallyResolvePrereqs removes all prerequisite in the cmd's prereq

--- a/pkg/storage/command_queue.go
+++ b/pkg/storage/command_queue.go
@@ -137,10 +137,19 @@ func (c *cmd) String() string {
 	return buf.String()
 }
 
+// PrereqLen returns the number of immediate prerequisite command that the
+// command is waiting on.
+func (c *cmd) PrereqLen() int {
+	if c == nil {
+		return 0
+	}
+	return len(*c.prereqs)
+}
+
 // PendingPrereq returns the prerequisite command that should be waited on next,
 // or nil if the receiver has no more prerequisites to wait on.
 func (c *cmd) PendingPrereq() *cmd {
-	if len(*c.prereqs) == 0 {
+	if c.PrereqLen() == 0 {
 		return nil
 	}
 	return (*c.prereqs)[0]
@@ -222,6 +231,30 @@ func (c *cmd) ResolvePendingPrereq() {
 	// especially during cascade command cancellation.
 	(*c.prereqs)[0] = nil
 	(*c.prereqs) = (*c.prereqs)[1:]
+}
+
+// OptimisticallyResolvePrereqs removes all prerequisite in the cmd's prereq
+// slice that have already finished without blocking on pending commands.
+// Prerequisite commands that are still pending or that were canceled are left
+// in the prereq slice.
+func (c *cmd) OptimisticallyResolvePrereqs() {
+	j := 0
+	for i, pre := range *c.prereqs {
+		select {
+		case <-pre.pending:
+			if len(*pre.prereqs) == 0 {
+				// Nil to allow GC.
+				(*c.prereqs)[i] = nil
+				continue
+			}
+			// Command canceled. Don't expand.
+		default:
+			// Command still pending.
+		}
+		(*c.prereqs)[j] = pre
+		j++
+	}
+	(*c.prereqs) = (*c.prereqs)[:j]
 }
 
 // NewCommandQueue returns a new command queue. The boolean specifies whether

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2244,16 +2244,18 @@ func (r *Replica) beginCmds(
 						err := ctx.Err()
 						log.VEventf(ctx, 2, "%s while in command queue: %s", err, ba)
 
-						// Remove the command from the command queue immediately. Dependents will
-						// transfer transitive dependencies when they try to block on this command,
-						// because our prereqs slice is not empty. This migration of dependencies
-						// will happen for each dependent in ResolvePendingPrereq, which will notice
-						// that our prereqs slice was not empty when we stopped pending and will
-						// adopt our prerequisites in turn. New commands that would have established
-						// a dependency on this command will never see it, which is fine.
 						if fn := r.store.cfg.TestingKnobs.OnCommandQueueAction; fn != nil {
 							fn(ba, storagebase.CommandQueueCancellation)
 						}
+
+						// Remove the command from the command queue immediately. New commands that
+						// would have established a dependency on this command will never see it,
+						// which is fine. Current dependents that already have a dependency on this
+						// command will transfer transitive dependencies when they try to block on
+						// this command, because our prereqs slice is not empty. This migration of
+						// dependencies will happen for each dependent in ResolvePendingPrereq,
+						// which will notice that our prereqs slice was not empty when we stopped
+						// pending and will adopt our prerequisites in turn.
 						r.removeCmdsFromCommandQueue(newCmds)
 						return nil, err
 					case <-r.store.stopper.ShouldQuiesce():
@@ -2305,6 +2307,16 @@ func (r *Replica) removeCmdsFromCommandQueue(cmds batchCmdSet) {
 	r.cmdQMu.Lock()
 	for _, accessCmds := range cmds {
 		for scope, cmd := range accessCmds {
+			if cmd.PrereqLen() > 0 {
+				// The command was canceled while it still had prerequisites to
+				// wait on. To avoid transferring already resolved prerequisites
+				// to our dependencies, we perform one last optimistic scan over
+				// our prerequisites and resolve any that are no longer pending
+				// and were not canceled themselves. This helps bound the
+				// quadratic blowup of prerequisites during cascading
+				// cancellations.
+				cmd.OptimisticallyResolvePrereqs()
+			}
 			r.cmdQMu.queues[scope].remove(cmd)
 		}
 	}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -2468,6 +2468,88 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 	}
 }
 
+// TestReplicaCommandQueueCancellationCascade verifies that commands which are
+// waiting on the command queue properly handle cascading cancellations without
+// resulting in quadratic memory growth.
+func TestReplicaCommandQueueCancellationCascade(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Create a dependency graph that looks like:
+	//
+	//   --- --- --- ---
+	//    |   |   |   |
+	//   ---------------
+	//    |   |   |   |
+	//   --- --- --- ---  ...
+	//    |   |   |   |
+	//   ---------------
+	//    |   |   |   |
+	//
+	//         ...
+	//
+	// The test then creates a cascade cancellation scenario
+	// where most commands are canceled:
+	//
+	//   --- xxx xxx xxx
+	//    |   |   |   |
+	//   xxxxxxxxxxxxxxx
+	//    |   |   |   |
+	//   --- xxx xxx xxx  ...
+	//    |   |   |   |
+	//   xxxxxxxxxxxxxxx
+	//    |   |   |   |
+	//
+	//         ...
+	//
+	// Canceling commands in this pattern stresses two operations that
+	// are necessary to avoid quadratic prerequisite count growth:
+	// 1. Canceling all but the first command in each of the multi-command
+	//    levels stresses OptimisticallyResolvePrereqs. Without scanning
+	//    through all of a command's prereqs and ignoring already completed
+	//    commands, commands that were finished would be transferred to
+	//    dependent commands.
+	// 2. Alternating multi-command layers and single command layers creates
+	//    a scenario where dependencies would add duplicate prereqs to their
+	//    prereq slice if not careful. This duplication of commands would
+	//    result in quadratic growth.
+	//
+	// Without these operations, the test fails.
+	const spansPerLevel = 25
+	const levels = 25
+
+	var levelSpans [spansPerLevel]roachpb.Span
+	keyBuf := bytes.Repeat([]byte("a"), spansPerLevel+1)
+	for i := 0; i < len(levelSpans); i++ {
+		levelSpans[i] = roachpb.Span{
+			Key:    keyBuf[:i+1],
+			EndKey: keyBuf[:i+2],
+		}
+	}
+	globalSpan := roachpb.Span{
+		Key:    levelSpans[0].Key,
+		EndKey: levelSpans[len(levelSpans)-1].EndKey,
+	}
+
+	var instrs []cancelInstr
+	var cancelOrder []int
+	for level := 0; level < levels; level++ {
+		for i, span := range levelSpans {
+			if i != 0 {
+				cancelOrder = append(cancelOrder, len(instrs))
+			}
+			instrs = append(instrs, cancelInstr{span: span})
+		}
+
+		cancelOrder = append(cancelOrder, len(instrs))
+		instrs = append(instrs, cancelInstr{span: globalSpan})
+	}
+
+	// Fails with "command never left CommandQueue after cancellation"
+	// timeout without proper handling of cascade cancellation.
+	ct := newCmdQCancelTest(t)
+	ct.Run(instrs, cancelOrder)
+}
+
 // TestReplicaCommandQueueCancellationRandom verifies that commands in a
 // random dependency graph which are waiting on the command queue do not
 // execute or deadlock if their context is canceled, and that commands


### PR DESCRIPTION
Backport 2/2 commits from #27117.

/cc @cockroachdb/release

---

In a privately reported issue we have seen cases where cascading
cancellations of commands in the CommandQueue can cause an OOM
in `storage.(*cmd).ResolvePendingPrereq`. This is caused by a quadratic
blowup of prerequisites as canceled commands transfer their prerequisites
to their dependents.

This change introduces a measure to bound this quadratic blowup by
adding in a new optimistic resolution step to command cancellation,
during which time a command will optimistically resolve all prerequisites
that have already finished without blocking on any pending commands. This
should improve the cascading cancellation scenario because it will
allow a command to trim its prerequisite list before passing it on
to its dependents. Notably, since we consider all commands in the
prereq list instead of just the first, like we usually do, a single
pending command at the front of the list can't allow the rest of the
prereq list to grow full of finished/canceled commands.

Release note: None
