### PR TITLE
opt: add rule expectations to norm rule tests

### DIFF
--- a/pkg/sql/opt/norm/testdata/rules/agg
+++ b/pkg/sql/opt/norm/testdata/rules/agg
@@ -15,7 +15,7 @@ TABLE a
 # EliminateAggDistinct
 # --------------------------------------------------
 
-opt
+opt expect=EliminateAggDistinct
 SELECT min(DISTINCT i), max(DISTINCT i), bool_and(DISTINCT i>f), bool_or(DISTINCT i>f) FROM a
 ----
 scalar-group-by
@@ -40,7 +40,7 @@ scalar-group-by
            └── variable: column9 [type=bool, outer=(9)]
 
 # The rule should not apply to these aggregations.
-opt
+opt expect-not=EliminateAggDistinct
 SELECT
     count(DISTINCT i),
     sum(DISTINCT i),

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -16,7 +16,7 @@ TABLE a
 
 # Put variables on both sides of comparison operator to avoid matching constant
 # patterns.
-opt
+opt expect=CommuteVarInequality
 SELECT * FROM a WHERE 1+i<k AND k-1<=i AND i*i>k AND k/2>=i
 ----
 select
@@ -37,7 +37,7 @@ select
 # --------------------------------------------------
 # CommuteConstInequality
 # --------------------------------------------------
-opt
+opt expect=CommuteConstInequality
 SELECT * FROM a WHERE length('foo')+1<i+k AND length('bar')<=i*2 AND 5>i AND 'foo'>=s
 ----
 select
@@ -55,7 +55,7 @@ select
       └── s <= 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - /'foo']; tight)]
 
 # Impure function should not be considered constant.
-opt
+opt expect-not=CommuteConstInequality
 SELECT * FROM a WHERE random()::int>a.i+a.i
 ----
 select
@@ -73,7 +73,7 @@ select
 # --------------------------------------------------
 # NormalizeCmpPlusConst
 # --------------------------------------------------
-opt
+opt expect=NormalizeCmpPlusConst
 SELECT *
 FROM a
 WHERE
@@ -101,7 +101,7 @@ select
       └── i::INTERVAL >= '1h' [type=bool, outer=(2)]
 
 # Try case that should not match pattern because Minus overload is not defined.
-opt
+opt expect-not=NormalizeCmpPlusConst
 SELECT * FROM a WHERE s::date + '02:00:00'::time = '2000-01-01T02:00:00'::timestamp
 ----
 select
@@ -118,7 +118,7 @@ select
 # --------------------------------------------------
 # NormalizeCmpMinusConst
 # --------------------------------------------------
-opt
+opt expect=NormalizeCmpMinusConst
 SELECT *
 FROM a
 WHERE
@@ -146,7 +146,7 @@ select
       └── (f + i::FLOAT8) >= 110.0 [type=bool, outer=(2,3)]
 
 # Try case that should not match pattern because Plus overload is not defined.
-opt
+opt expect-not=NormalizeCmpMinusConst
 SELECT * FROM a WHERE s::json - 1 = '[1]'::json
 ----
 select
@@ -163,7 +163,7 @@ select
 # --------------------------------------------------
 # NormalizeCmpConstMinus
 # --------------------------------------------------
-opt
+opt expect=NormalizeCmpConstMinus
 SELECT *
 FROM a
 WHERE
@@ -191,7 +191,7 @@ select
       └── (f + i::FLOAT8) <= -90.0 [type=bool, outer=(2,3)]
 
 # Try case that should not match pattern because Minus overload is not defined.
-opt
+opt expect-not=NormalizeCmpConstMinus
 SELECT * FROM a WHERE '[1, 2]'::json - i = '[1]'
 ----
 select
@@ -208,7 +208,7 @@ select
 # --------------------------------------------------
 # NormalizeTupleEquality
 # --------------------------------------------------
-opt
+opt expect=NormalizeTupleEquality
 SELECT * FROM a WHERE (i, f, s) = (1, 3.5, 'foo')
 ----
 select
@@ -225,11 +225,11 @@ select
       └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
 
 # --------------------------------------------------
-# NormalizeTupleEquality, FlattenAnd
+# NormalizeTupleEquality, SimplifyAnd
 # --------------------------------------------------
 
 # Nested tuples.
-opt
+opt expect=(NormalizeTupleEquality,SimplifyAnd)
 SELECT * FROM a WHERE (1, (2, 'foo')) = (k, (i, s))
 ----
 select
@@ -252,7 +252,7 @@ select
 # --------------------------------------------------
 
 # Use null::type to circumvent type checker constant folding.
-opt
+opt expect=(FoldNullComparisonLeft,FoldNullComparisonRight)
 SELECT *
 FROM a
 WHERE
@@ -286,7 +286,7 @@ values
 # --------------------------------------------------
 # FoldIsNull
 # --------------------------------------------------
-opt
+opt expect=FoldIsNull
 SELECT NULL IS NULL AS r
 ----
 project
@@ -304,7 +304,7 @@ project
 # --------------------------------------------------
 # FoldNonNullIsNull
 # --------------------------------------------------
-opt
+opt expect=FoldNonNullIsNull
 SELECT 1 IS NULL AS r
 ----
 project
@@ -322,7 +322,7 @@ project
 # --------------------------------------------------
 # FoldIsNotNull
 # --------------------------------------------------
-opt
+opt expect=FoldIsNotNull
 SELECT NULL IS NOT NULL AS r, NULL IS NOT TRUE AS s
 ----
 project
@@ -344,7 +344,7 @@ project
 
 # We could (but do not currently) infer that k IS NOT NULL is always True given
 # that k is declared NOT NULL.
-opt
+opt expect=FoldNonNullIsNotNull
 SELECT 1 IS NOT NULL AS r, k IS NOT NULL AS s, i IS NOT NULL AS t FROM a
 ----
 project
@@ -362,7 +362,7 @@ project
 # --------------------------------------------------
 # CommuteNullIs
 # --------------------------------------------------
-opt
+opt expect=CommuteNullIs
 SELECT NULL IS NOT TRUE AS r, NULL IS TRUE AS s
 ----
 project

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -40,7 +40,7 @@ TABLE cd
 # --------------------------------------------------
 # DecorrelateJoin
 # --------------------------------------------------
-opt
+opt expect=DecorrelateJoin
 SELECT * FROM a WHERE EXISTS(SELECT * FROM xy WHERE x=k)
 ----
 semi-join (merge)
@@ -63,7 +63,7 @@ semi-join (merge)
       └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
            └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
-opt
+opt expect=DecorrelateJoin
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM xy WHERE x=k)
 ----
 anti-join (merge)
@@ -89,7 +89,7 @@ anti-join (merge)
 # --------------------------------------------------
 # TryDecorrelateSelect
 # --------------------------------------------------
-opt
+opt expect=TryDecorrelateSelect
 SELECT * FROM a WHERE EXISTS(SELECT * FROM (VALUES (k), (i)) WHERE column1=k)
 ----
 semi-join-apply
@@ -109,7 +109,7 @@ semi-join-apply
  └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       └── column1 = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
-opt
+opt expect=TryDecorrelateSelect
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM (VALUES (k), (i)) WHERE column1=k)
 ----
 anti-join-apply
@@ -132,7 +132,7 @@ anti-join-apply
 # Attempt to decorrelate query by pulling up outer select. But since limit query
 # cannot be decorrelated, push the outer select back down again (and make sure
 # potential rule cycle is detected and handled).
-opt
+opt expect=TryDecorrelateSelect
 SELECT * FROM a WHERE EXISTS(SELECT * FROM (SELECT * FROM xy WHERE y=k LIMIT 1) WHERE y=10)
 ----
 semi-join-apply
@@ -172,7 +172,7 @@ semi-join-apply
  └── true [type=bool]
 
 # Same as previous, but using anti-join.
-opt
+opt expect=TryDecorrelateSelect
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM (SELECT * FROM xy WHERE y=k LIMIT 1) WHERE y=10)
 ----
 anti-join-apply
@@ -212,36 +212,36 @@ anti-join-apply
  └── true [type=bool]
 
 # Decorrelate Select with reference to outer column and no limit.
-opt
-SELECT * FROM a WHERE (SELECT y FROM xy WHERE x=i) > 100
+opt expect=TryDecorrelateSelect
+SELECT * FROM a WHERE (SELECT x FROM xy WHERE x=i) > 100
 ----
 project
  ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  └── inner-join
-      ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int!null)
+      ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null)
       ├── key: (1)
-      ├── fd: (1)-->(2-5), (6)-->(7), (2)==(6), (6)==(2)
-      ├── scan a
-      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
-      │    ├── key: (1)
-      │    └── fd: (1)-->(2-5)
+      ├── fd: (1)-->(2-5), (2)==(6), (6)==(2)
       ├── select
-      │    ├── columns: x:6(int!null) y:7(int!null)
-      │    ├── key: (6)
-      │    ├── fd: (6)-->(7)
-      │    ├── scan xy
-      │    │    ├── columns: x:6(int!null) y:7(int)
-      │    │    ├── key: (6)
-      │    │    └── fd: (6)-->(7)
-      │    └── filters [type=bool, outer=(7), constraints=(/7: [/101 - ]; tight)]
-      │         └── y > 100 [type=bool, outer=(7), constraints=(/7: [/101 - ]; tight)]
+      │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-5)
+      │    ├── scan a
+      │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2-5)
+      │    └── filters [type=bool, outer=(2), constraints=(/2: [/101 - ]; tight)]
+      │         └── i > 100 [type=bool, outer=(2), constraints=(/2: [/101 - ]; tight)]
+      ├── scan xy
+      │    ├── columns: x:6(int!null)
+      │    ├── constraint: /6: [/101 - ]
+      │    └── key: (6)
       └── filters [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
            └── x = i [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
 
 # Decorrelate Select with LeftJoinApply.
-opt
+opt expect=TryDecorrelateSelect
 SELECT * FROM a WHERE (SELECT x FROM (SELECT * FROM xy LIMIT 1) WHERE k=x) > 100
 ----
 project
@@ -272,7 +272,7 @@ project
            └── k > 100 [type=bool, outer=(1), constraints=(/1: [/101 - ]; tight)]
 
 # Decorrelate with non-apply operator because of multi-level nesting.
-opt
+opt expect=TryDecorrelateSelect
 SELECT *
 FROM a
 WHERE EXISTS(SELECT * FROM xy WHERE x=k AND EXISTS(SELECT * FROM uv WHERE u=10 AND s='foo'))
@@ -315,7 +315,7 @@ semi-join-apply
 # --------------------------------------------------
 
 # Left join caused by correlated ANY clause.
-opt
+opt expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy)
 SELECT 5=ANY(SELECT y FROM xy WHERE x=k) AS r FROM a
 ----
 project
@@ -364,7 +364,7 @@ project
       └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
 
 # Left join caused by zero or one cardinality subquery.
-opt
+opt expect=TryDecorrelateProjectSelect
 SELECT * FROM a WHERE (SELECT y+1 AS r FROM (SELECT * FROM xy LIMIT 1) WHERE x=k) > 10
 ----
 project
@@ -394,7 +394,7 @@ project
            └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Any clause with constant.
-opt
+opt expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy)
 SELECT 5=ANY(SELECT y FROM xy WHERE x=k) AS r FROM a
 ----
 project
@@ -443,7 +443,7 @@ project
       └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
 
 # Any clause with variable.
-opt
+opt expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy)
 SELECT i=ANY(SELECT y FROM xy WHERE x=k) AS r FROM a
 ----
 project
@@ -489,7 +489,7 @@ project
       └── CASE WHEN bool_or AND (i IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(2,10)]
 
 # Any clause with more complex expression that must be cached.
-opt
+opt expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy)
 SELECT i*i/5=ANY(SELECT y FROM xy WHERE x=k) AS r FROM a
 ----
 project
@@ -548,7 +548,7 @@ project
 # --------------------------------------------------
 # TryDecorrelateProject
 # --------------------------------------------------
-opt
+opt expect=TryDecorrelateProject
 SELECT k FROM a
 WHERE EXISTS
 (
@@ -735,7 +735,7 @@ project
 # --------------------------------------------------
 # TryDecorrelateProjectInnerJoin
 # --------------------------------------------------
-opt
+opt expect=TryDecorrelateProjectInnerJoin
 SELECT (SELECT sum(y + v) FROM xy, uv WHERE x=u AND x=k) FROM a
 ----
 project
@@ -795,7 +795,7 @@ project
 # TryDecorrelateInnerJoin
 # --------------------------------------------------
 # Semi-join as outer.
-opt
+opt expect=TryDecorrelateInnerJoin
 SELECT k FROM a
 WHERE EXISTS
 (
@@ -836,7 +836,7 @@ semi-join (merge)
            └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Anti-join as outer.
-opt
+opt expect=TryDecorrelateInnerJoin
 SELECT k FROM a
 WHERE NOT EXISTS
 (
@@ -877,7 +877,7 @@ anti-join (merge)
            └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Right-join as outer.
-opt
+opt expect=TryDecorrelateInnerJoin
 SELECT k FROM a
 WHERE
 (
@@ -1022,7 +1022,7 @@ semi-join-apply
 # --------------------------------------------------
 # TryDecorrelateInnerLeftJoin
 # --------------------------------------------------
-opt
+opt expect=TryDecorrelateInnerLeftJoin
 SELECT *
 FROM (VALUES (1), (2)) AS v(v1)
 WHERE EXISTS(
@@ -1077,7 +1077,7 @@ semi-join-apply
  │         └── x = v1 [type=bool, outer=(7,11), constraints=(/7: (/NULL - ]; /11: (/NULL - ])]
  └── true [type=bool]
 
-opt
+opt expect=TryDecorrelateInnerLeftJoin
 SELECT *
 FROM xy, uv
 WHERE (SELECT i FROM a WHERE k=x) IS DISTINCT FROM u
@@ -1115,7 +1115,7 @@ project
       └── filters [type=bool, outer=(3,6)]
            └── u IS DISTINCT FROM i [type=bool, outer=(3,6)]
 
-opt
+opt expect=TryDecorrelateInnerLeftJoin
 SELECT generate_series(1, (SELECT u FROM uv WHERE u=x))
 FROM xy
 ----
@@ -1151,7 +1151,7 @@ project
 # --------------------------------------------------
 # TryDecorrelateGroupBy
 # --------------------------------------------------
-opt
+opt expect=TryDecorrelateGroupBy
 SELECT *
 FROM a
 WHERE EXISTS
@@ -1217,7 +1217,7 @@ group-by
       └── const-agg [type=jsonb, outer=(5)]
            └── variable: j [type=jsonb, outer=(5)]
 
-opt
+opt expect=TryDecorrelateGroupBy
 SELECT *
 FROM a
 WHERE EXISTS
@@ -1286,7 +1286,7 @@ group-by
            └── variable: j [type=jsonb, outer=(5)]
 
 # Indirectly decorrelate GROUP BY after decorrelating scalar GROUP BY.
-opt
+opt expect=TryDecorrelateGroupBy
 SELECT *
 FROM xy, uv
 WHERE x=v AND u=(SELECT max(i) FROM a WHERE k=x)
@@ -1348,7 +1348,7 @@ project
 
 # Indirectly decorrelate GROUP BY after decorrelating scalar GROUP BY. Use
 # IS DISTINCT FROM to retain left join.
-opt
+opt expect=TryDecorrelateGroupBy
 SELECT *
 FROM xy, uv
 WHERE x=v AND (SELECT max(i) FROM a WHERE k=x) IS DISTINCT FROM u
@@ -1403,7 +1403,7 @@ project
            └── u IS DISTINCT FROM max [type=bool, outer=(3,10)]
 
 # Synthesize key when one is not present.
-opt
+opt expect=TryDecorrelateGroupBy
 SELECT *
 FROM
 (
@@ -1451,7 +1451,7 @@ project
       └── const: 'foo' [type=string]
 
 # Decorrelate DistinctOn.
-opt
+opt expect=TryDecorrelateGroupBy
 SELECT *
 FROM a
 WHERE EXISTS
@@ -1528,7 +1528,7 @@ group-by
 # --------------------------------------------------
 # TryDecorrelateScalarGroupBy
 # --------------------------------------------------
-opt
+opt expect=TryDecorrelateScalarGroupBy
 SELECT *
 FROM a
 WHERE EXISTS
@@ -1597,7 +1597,7 @@ group-by
            └── variable: j [type=jsonb, outer=(5)]
 
 # Synthesize key when one is not present.
-opt
+opt expect=TryDecorrelateScalarGroupBy
 SELECT * FROM (SELECT i, 'foo' AS cst FROM a) WHERE 5=(SELECT max(y) FROM xy WHERE x=i)
 ----
 project
@@ -1646,7 +1646,7 @@ project
 
 # With an aggregate that can't ignore nulls. xy.y = a.k rejects nulls, so
 # there's no canary column to be synthesized.
-norm
+opt expect=TryDecorrelateScalarGroupBy
 SELECT k, (SELECT array_agg(xy.y) FROM xy WHERE xy.y = a.k) FROM a
 ----
 project
@@ -1676,7 +1676,7 @@ project
       └── CASE WHEN y IS NOT NULL THEN array_agg END [type=int[], outer=(7,10)]
 
 # With multiple columns. Without LATERAL these tests are a bit verbose.
-norm
+norm expect=TryDecorrelateScalarGroupBy
 SELECT k, (SELECT (r, q) FROM (SELECT array_agg(xy.y) r, max(xy.y) q FROM xy WHERE xy.y = a.k)) FROM a
 ----
 project
@@ -1709,7 +1709,7 @@ project
 
 
 # With an aggregate that can't ignore nulls and when a non-nullable column must be synthesized.
-norm
+norm expect=TryDecorrelateScalarGroupBy
 SELECT k, ARRAY(SELECT y FROM xy WHERE xy.y = a.i OR xy.y IS NULL) FROM a
 ----
 project
@@ -1746,7 +1746,7 @@ project
       └── COALESCE(CASE WHEN canary IS NOT NULL THEN array_agg END, ARRAY[]) [type=int[], outer=(10,11)]
 
 # With an ordering.
-norm
+norm expect=TryDecorrelateScalarGroupBy
 SELECT i, ARRAY(SELECT y FROM xy WHERE xy.y = a.k OR xy.y = NULL ORDER BY y) FROM a
 ----
 project
@@ -1789,7 +1789,7 @@ project
 
 # Nest scalar decorrelation within scalar decorrelation, using IS NULL to force
 # use of left joins.
-opt
+opt expect=TryDecorrelateScalarGroupBy
 SELECT *
 FROM a
 WHERE
@@ -1872,7 +1872,7 @@ project
            └── max IS NULL [type=bool, outer=(11), constraints=(/11: [/NULL - /NULL]; tight)]
 
 # ScalarGroupBy with non-null ignoring and a non-nullable column.
-norm
+norm expect=TryDecorrelateScalarGroupBy
 SELECT *
 FROM cd
 WHERE
@@ -1925,7 +1925,7 @@ project
       └── filters [type=bool, outer=(5), constraints=(/5: (/NULL - ])]
            └── array_agg = ARRAY[] [type=bool, outer=(5), constraints=(/5: (/NULL - ])]
 
-norm
+norm expect=TryDecorrelateScalarGroupBy
 SELECT * FROM a WHERE 'foo'=(SELECT concat_agg(y::string) FROM xy WHERE x=k)
 ----
 project
@@ -1984,64 +1984,12 @@ project
       └── filters [type=bool, outer=(9), constraints=(/9: [/'foo' - /'foo']; tight), fd=()-->(9)]
            └── concat_agg = 'foo' [type=bool, outer=(9), constraints=(/9: [/'foo' - /'foo']; tight)]
 
-# Don't decorrelate when the group by input is ordered.
-opt
-SELECT * FROM a WHERE 'foo'=(SELECT max(y::string) FROM (SELECT * FROM xy ORDER BY x+y) WHERE y=k)
-----
-project
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── key: (1)
- ├── fd: (1)-->(2-5)
- └── select
-      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) max:10(string!null)
-      ├── key: (1)
-      ├── fd: ()-->(10), (1)-->(2-5)
-      ├── group-by
-      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) max:10(string)
-      │    ├── grouping columns: k:1(int!null)
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-5,10)
-      │    ├── inner-join
-      │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) y:7(int!null) column9:9(string!null)
-      │    │    ├── fd: (1)-->(2-5), (7)-->(9), (1)==(7), (7)==(1)
-      │    │    ├── scan a
-      │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
-      │    │    │    ├── key: (1)
-      │    │    │    └── fd: (1)-->(2-5)
-      │    │    ├── select
-      │    │    │    ├── columns: y:7(int) column9:9(string!null)
-      │    │    │    ├── fd: (7)-->(9)
-      │    │    │    ├── project
-      │    │    │    │    ├── columns: column9:9(string) y:7(int)
-      │    │    │    │    ├── fd: (7)-->(9)
-      │    │    │    │    ├── scan xy
-      │    │    │    │    │    └── columns: y:7(int)
-      │    │    │    │    └── projections [outer=(7)]
-      │    │    │    │         └── y::STRING [type=string, outer=(7)]
-      │    │    │    └── filters [type=bool, outer=(9), constraints=(/9: (/NULL - ]; tight)]
-      │    │    │         └── column9 IS NOT NULL [type=bool, outer=(9), constraints=(/9: (/NULL - ]; tight)]
-      │    │    └── filters [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
-      │    │         └── y = k [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ])]
-      │    └── aggregations [outer=(2-5,9)]
-      │         ├── max [type=string, outer=(9)]
-      │         │    └── variable: column9 [type=string, outer=(9)]
-      │         ├── const-agg [type=int, outer=(2)]
-      │         │    └── variable: i [type=int, outer=(2)]
-      │         ├── const-agg [type=float, outer=(3)]
-      │         │    └── variable: f [type=float, outer=(3)]
-      │         ├── const-agg [type=string, outer=(4)]
-      │         │    └── variable: s [type=string, outer=(4)]
-      │         └── const-agg [type=jsonb, outer=(5)]
-      │              └── variable: j [type=jsonb, outer=(5)]
-      └── filters [type=bool, outer=(10), constraints=(/10: [/'foo' - /'foo']; tight), fd=()-->(10)]
-           └── max = 'foo' [type=bool, outer=(10), constraints=(/10: [/'foo' - /'foo']; tight)]
-
 # --------------------------------------------------
 # TryDecorrelateSemiJoin
 # --------------------------------------------------
 
 # Right input of SemiJoin is GroupBy.
-opt
+opt expect=TryDecorrelateSemiJoin
 SELECT *
 FROM xy
 WHERE EXISTS
@@ -2100,7 +2048,7 @@ group-by
            └── variable: y [type=int, outer=(2)]
 
 # Right input of SemiJoin is DistinctOn.
-opt
+opt expect=TryDecorrelateSemiJoin
 SELECT *
 FROM xy
 WHERE EXISTS
@@ -2145,7 +2093,7 @@ group-by
            └── variable: y [type=int, outer=(2)]
 
 # Right input of SemiJoin is Project.
-opt
+opt expect=TryDecorrelateSemiJoin
 SELECT k FROM a
 WHERE EXISTS
 (
@@ -2193,7 +2141,7 @@ project
 # --------------------------------------------------
 
 # With inner join.
-opt
+opt expect=TryDecorrelateLimitOne
 SELECT *
 FROM a
 WHERE EXISTS
@@ -2234,7 +2182,7 @@ semi-join
       └── v = i [type=bool, outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ])]
 
 # With left join.
-opt
+opt expect=TryDecorrelateLimitOne
 SELECT (SELECT x FROM xy WHERE y=i LIMIT 1) FROM a
 ----
 project
@@ -2267,7 +2215,7 @@ project
       └── variable: xy.x [type=int, outer=(6)]
 
 # With multiple limited queries.
-opt
+opt expect=TryDecorrelateLimitOne
 SELECT * FROM a WHERE (SELECT x FROM xy WHERE y=i LIMIT 1)=k AND (SELECT u FROM uv WHERE v=i LIMIT 1)=k
 ----
 project
@@ -2344,7 +2292,7 @@ project
            └── k = u [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
 
 # With nested limited queries.
-opt
+opt expect=TryDecorrelateLimitOne
 SELECT *
 FROM a
 WHERE
@@ -2426,7 +2374,7 @@ project
            └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # With inner join + ORDER BY.
-opt
+opt expect=TryDecorrelateLimitOne
 SELECT
 (
     SELECT v
@@ -2479,7 +2427,7 @@ project
       └── variable: uv.v [type=int, outer=(4)]
 
 # With left join + ORDER BY.
-opt
+opt expect=TryDecorrelateLimitOne
 SELECT * FROM xy WHERE (SELECT k FROM a WHERE i=y ORDER BY f,s LIMIT 1)=x
 ----
 project
@@ -2526,7 +2474,7 @@ project
 # --------------------------------------------------
 # HoistSelectExists
 # --------------------------------------------------
-opt
+opt expect=HoistSelectExists
 SELECT * FROM a WHERE EXISTS(SELECT * FROM xy WHERE x=k)
 ----
 semi-join (merge)
@@ -2550,7 +2498,7 @@ semi-join (merge)
            └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Ensure that EXISTS is hoisted even when it is one of several conjuncts.
-opt
+opt expect=HoistSelectExists
 SELECT * FROM a WHERE s='foo' AND EXISTS(SELECT * FROM xy WHERE x=k) AND i>1
 ----
 semi-join (merge)
@@ -2582,7 +2530,7 @@ semi-join (merge)
            └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Multiple Exists operators in same Select list.
-opt
+opt expect=HoistSelectExists
 SELECT * FROM a WHERE EXISTS(SELECT * FROM xy WHERE x=k) AND EXISTS(SELECT * FROM xy WHERE x=i)
 ----
 semi-join
@@ -2611,7 +2559,7 @@ semi-join
       └── xy.x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Don't hoist uncorrelated subqueries.
-opt
+opt expect-not=HoistSelectExists
 SELECT * FROM a WHERE EXISTS(SELECT * FROM xy)
 ----
 select
@@ -2630,7 +2578,7 @@ select
                 └── fd: (6)-->(7)
 
 # Hoist nested EXISTS.
-opt
+opt expect=HoistSelectExists
 SELECT * FROM a WHERE EXISTS(SELECT * FROM xy WHERE EXISTS (SELECT * FROM uv WHERE x=u) AND x=k)
 ----
 semi-join (merge)
@@ -2671,7 +2619,7 @@ semi-join (merge)
 # --------------------------------------------------
 # HoistSelectNotExists
 # --------------------------------------------------
-opt
+opt expect=HoistSelectNotExists
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM xy WHERE x=k)
 ----
 anti-join (merge)
@@ -2695,7 +2643,7 @@ anti-join (merge)
            └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Ensure that NOT EXISTS is hoisted even when one of several conjuncts.
-opt
+opt expect=HoistSelectNotExists
 SELECT * FROM a WHERE s='foo' AND NOT EXISTS(SELECT * FROM xy WHERE x=k) AND i>1
 ----
 anti-join (merge)
@@ -2727,7 +2675,7 @@ anti-join (merge)
            └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Multiple Not Exists operators in same Select list.
-opt
+opt expect=HoistSelectNotExists
 SELECT *
 FROM a
 WHERE NOT EXISTS(SELECT * FROM xy WHERE x=k) AND NOT EXISTS(SELECT * FROM xy WHERE x=i)
@@ -2758,7 +2706,7 @@ anti-join
       └── xy.x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Don't hoist uncorrelated subqueries.
-opt
+opt expect-not=HoistSelectNotExists
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM xy)
 ----
 select
@@ -2780,7 +2728,7 @@ select
 # --------------------------------------------------
 # HoistSelectExists + HoistSelectNotExists
 # --------------------------------------------------
-opt
+opt expect=(HoistSelectExists,HoistSelectNotExists)
 SELECT * FROM a WHERE EXISTS(SELECT * FROM xy WHERE x=k) AND NOT EXISTS(SELECT * FROM xy WHERE x=i)
 ----
 semi-join
@@ -2811,7 +2759,7 @@ semi-join
 # --------------------------------------------------
 # HoistSelectSubquery
 # --------------------------------------------------
-opt
+opt expect=HoistSelectSubquery
 SELECT * FROM a WHERE (SELECT y FROM xy WHERE y=k LIMIT 1) = i
 ----
 project
@@ -2853,7 +2801,7 @@ project
            └── i = y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
 
 # Multiple other conjuncts, including uncorrelated subquery (don't hoist).
-opt
+opt expect=HoistSelectSubquery
 SELECT *
 FROM a
 WHERE k=10 AND (SELECT y FROM xy WHERE y=k LIMIT 1) = i AND (SELECT x FROM xy LIMIT 1) = 100
@@ -2933,7 +2881,7 @@ project
            └── i = xy.y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
 
 # Multiple correlated subqueries.
-opt
+opt expect=HoistSelectSubquery
 SELECT * FROM a
 WHERE (SELECT count(*) FROM xy WHERE y=k) > 0 AND (SELECT y FROM xy WHERE y=k LIMIT 1) = i
 ----
@@ -3006,7 +2954,7 @@ project
 
 # Subquery nested below interesting scalar operators like cast, function, tuple,
 # or, etc).
-opt
+opt expect=HoistSelectSubquery
 SELECT * FROM a WHERE (0, length((SELECT count(*) FROM uv WHERE k=u)::string)) > (0, 1) OR i=1
 ----
 project
@@ -3055,7 +3003,7 @@ project
            └── ((0, length(count_rows::STRING)) > (0, 1)) OR (i = 1) [type=bool, outer=(2,8)]
 
 # Exists within a disjunction.
-opt
+opt expect=HoistSelectSubquery
 SELECT * FROM a WHERE i=1 OR EXISTS(SELECT * FROM xy WHERE y=i)
 ----
 project
@@ -3102,7 +3050,7 @@ project
            └── (i = 1) OR (true_agg IS NOT NULL) [type=bool, outer=(2,9)]
 
 # Any with IS NULL.
-opt
+opt expect=HoistSelectSubquery
 SELECT * FROM a WHERE (i = ANY(SELECT y FROM xy WHERE x=k)) IS NULL
 ----
 project
@@ -3247,7 +3195,7 @@ project
 # --------------------------------------------------
 # HoistProjectSubquery
 # --------------------------------------------------
-opt
+opt expect=HoistProjectSubquery
 SELECT (SELECT x FROM xy WHERE x=k) FROM a
 ----
 project
@@ -3272,7 +3220,7 @@ project
       └── variable: xy.x [type=int, outer=(6)]
 
 # Mixed correlated and uncorrelated subqueries.
-opt
+opt expect=HoistProjectSubquery
 SELECT
     5 AS a,
     (SELECT x FROM xy WHERE x=k),
@@ -3336,7 +3284,7 @@ project
       └── variable: count_rows [type=int, outer=(16)]
 
 # Subquery in GroupBy aggregate (optbuilder creates correlated Project).
-opt
+opt expect=HoistProjectSubquery
 SELECT max((SELECT y FROM xy WHERE y=i)) FROM a
 ----
 scalar-group-by
@@ -3372,7 +3320,7 @@ scalar-group-by
            └── variable: column8 [type=int, outer=(8)]
 
 # Exists in projection list.
-opt
+opt expect=HoistProjectSubquery
 SELECT EXISTS(SELECT * FROM xy WHERE y=i) FROM a
 ----
 project
@@ -3407,7 +3355,7 @@ project
       └── true_agg IS NOT NULL [type=bool, outer=(10)]
 
 # Any in projection list.
-opt
+opt expect=HoistProjectSubquery
 SELECT 5 < ANY(SELECT y FROM xy WHERE y=i) AS r FROM a
 ----
 project
@@ -3446,7 +3394,7 @@ project
       └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
 
 # Correlated subquery nested in uncorrelated subquery.
-opt
+opt expect=HoistProjectSubquery
 SELECT EXISTS(SELECT EXISTS(SELECT * FROM xy WHERE y=i) FROM a)
 ----
 project
@@ -3496,30 +3444,28 @@ project
 # --------------------------------------------------
 # HoistJoinSubquery
 # --------------------------------------------------
-opt
-SELECT i, y FROM a INNER JOIN xy ON (SELECT k+1) = 0
+opt expect=HoistJoinSubquery
+SELECT i, y FROM a INNER JOIN xy ON (SELECT k+1) = x
 ----
 project
  ├── columns: i:2(int) y:7(int)
  └── inner-join
-      ├── columns: k:1(int!null) i:2(int) y:7(int)
-      ├── fd: (1)-->(2)
-      ├── scan xy
-      │    └── columns: y:7(int)
-      ├── select
+      ├── columns: k:1(int!null) i:2(int) x:6(int!null) y:7(int)
+      ├── key: (1,6)
+      ├── fd: (1)-->(2), (6)-->(7)
+      ├── scan a
       │    ├── columns: k:1(int!null) i:2(int)
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2)
-      │    ├── scan a
-      │    │    ├── columns: k:1(int!null) i:2(int)
-      │    │    ├── key: (1)
-      │    │    └── fd: (1)-->(2)
-      │    └── filters [type=bool, outer=(1)]
-      │         └── (k + 1) = 0 [type=bool, outer=(1)]
-      └── true [type=bool]
+      │    └── fd: (1)-->(2)
+      ├── scan xy
+      │    ├── columns: x:6(int!null) y:7(int)
+      │    ├── key: (6)
+      │    └── fd: (6)-->(7)
+      └── filters [type=bool, outer=(1,6), constraints=(/6: (/NULL - ])]
+           └── x = (k + 1) [type=bool, outer=(1,6), constraints=(/6: (/NULL - ])]
 
 # Right join + multiple subqueries.
-opt
+opt expect=HoistJoinSubquery
 SELECT y FROM a RIGHT JOIN xy ON (SELECT k+1) = (SELECT x+1)
 ----
 project
@@ -3544,7 +3490,7 @@ project
            └── ?column? = ?column? [type=bool, outer=(8,9), constraints=(/8: (/NULL - ]; /9: (/NULL - ])]
 
 # Hoist Exists in join filter disjunction.
-opt
+opt expect=HoistJoinSubquery
 SELECT s, x FROM a FULL JOIN xy ON EXISTS(SELECT * FROM uv WHERE u=y) OR k=x
 ----
 project
@@ -3594,65 +3540,70 @@ project
            └── exists OR (k = x) [type=bool, outer=(1,6,12)]
 
 # Any in Join filter disjunction.
-opt
-SELECT j, y FROM a INNER JOIN xy ON x IN (SELECT v FROM uv WHERE u=y) OR x IS NULL
+opt expect=HoistJoinSubquery
+SELECT j, y FROM a INNER JOIN xy ON x IN (SELECT v FROM uv WHERE u=y AND v=i) OR x IS NULL
 ----
 project
  ├── columns: j:5(jsonb) y:7(int)
- └── inner-join
+ └── select
       ├── columns: j:5(jsonb) x:6(int!null) y:7(int) case:12(bool)
-      ├── fd: (6)-->(7,12)
-      ├── scan a
-      │    └── columns: j:5(jsonb)
-      ├── select
-      │    ├── columns: x:6(int!null) y:7(int) case:12(bool)
-      │    ├── key: (6)
-      │    ├── fd: (6)-->(7,12)
-      │    ├── project
-      │    │    ├── columns: case:12(bool) x:6(int!null) y:7(int)
-      │    │    ├── key: (6)
-      │    │    ├── fd: (6)-->(7,12)
-      │    │    ├── group-by
-      │    │    │    ├── columns: x:6(int!null) y:7(int) bool_or:11(bool)
-      │    │    │    ├── grouping columns: x:6(int!null)
-      │    │    │    ├── key: (6)
-      │    │    │    ├── fd: (6)-->(7,11)
-      │    │    │    ├── left-join
-      │    │    │    │    ├── columns: x:6(int!null) y:7(int) u:8(int) v:9(int) notnull:10(bool)
-      │    │    │    │    ├── key: (6,8)
-      │    │    │    │    ├── fd: (6)-->(7), (8)-->(9), (9)~~>(10), (6,8)-->(10)
+      ├── fd: (6)-->(7)
+      ├── project
+      │    ├── columns: case:12(bool) j:5(jsonb) x:6(int!null) y:7(int)
+      │    ├── fd: (6)-->(7)
+      │    ├── group-by
+      │    │    ├── columns: k:1(int!null) j:5(jsonb) x:6(int!null) y:7(int) bool_or:11(bool)
+      │    │    ├── grouping columns: k:1(int!null) x:6(int!null)
+      │    │    ├── key: (1,6)
+      │    │    ├── fd: (1)-->(5), (6)-->(7), (1,6)-->(5,7,11)
+      │    │    ├── left-join
+      │    │    │    ├── columns: k:1(int!null) i:2(int) j:5(jsonb) x:6(int!null) y:7(int) u:8(int) v:9(int) notnull:10(bool)
+      │    │    │    ├── key: (1,6,8)
+      │    │    │    ├── fd: (1)-->(2,5), (6)-->(7), (8)-->(9), (9)~~>(10), (1,6,8)-->(10)
+      │    │    │    ├── inner-join
+      │    │    │    │    ├── columns: k:1(int!null) i:2(int) j:5(jsonb) x:6(int!null) y:7(int)
+      │    │    │    │    ├── key: (1,6)
+      │    │    │    │    ├── fd: (1)-->(2,5), (6)-->(7)
+      │    │    │    │    ├── scan a
+      │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) j:5(jsonb)
+      │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    └── fd: (1)-->(2,5)
       │    │    │    │    ├── scan xy
       │    │    │    │    │    ├── columns: x:6(int!null) y:7(int)
       │    │    │    │    │    ├── key: (6)
       │    │    │    │    │    └── fd: (6)-->(7)
-      │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: notnull:10(bool) u:8(int!null) v:9(int)
+      │    │    │    │    └── true [type=bool]
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: notnull:10(bool) u:8(int!null) v:9(int)
+      │    │    │    │    ├── key: (8)
+      │    │    │    │    ├── fd: (8)-->(9), (9)-->(10)
+      │    │    │    │    ├── scan uv
+      │    │    │    │    │    ├── columns: u:8(int!null) v:9(int)
       │    │    │    │    │    ├── key: (8)
-      │    │    │    │    │    ├── fd: (8)-->(9), (9)-->(10)
-      │    │    │    │    │    ├── scan uv
-      │    │    │    │    │    │    ├── columns: u:8(int!null) v:9(int)
-      │    │    │    │    │    │    ├── key: (8)
-      │    │    │    │    │    │    └── fd: (8)-->(9)
-      │    │    │    │    │    └── projections [outer=(8,9)]
-      │    │    │    │    │         └── v IS NOT NULL [type=bool, outer=(9)]
-      │    │    │    │    └── filters [type=bool, outer=(6-9), constraints=(/7: (/NULL - ]; /8: (/NULL - ]), fd=(7)==(8), (8)==(7)]
-      │    │    │    │         ├── u = y [type=bool, outer=(7,8), constraints=(/7: (/NULL - ]; /8: (/NULL - ])]
-      │    │    │    │         └── (x = v) IS NOT false [type=bool, outer=(6,9)]
-      │    │    │    └── aggregations [outer=(7,10)]
-      │    │    │         ├── bool-or [type=bool, outer=(10)]
-      │    │    │         │    └── variable: notnull [type=bool, outer=(10)]
-      │    │    │         └── const-agg [type=int, outer=(7)]
-      │    │    │              └── variable: y [type=int, outer=(7)]
-      │    │    └── projections [outer=(6,7,11)]
-      │    │         └── CASE WHEN bool_or AND (x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(6,11)]
-      │    └── filters [type=bool, outer=(6,12)]
-      │         └── case OR (x IS NULL) [type=bool, outer=(6,12)]
-      └── true [type=bool]
+      │    │    │    │    │    └── fd: (8)-->(9)
+      │    │    │    │    └── projections [outer=(8,9)]
+      │    │    │    │         └── v IS NOT NULL [type=bool, outer=(9)]
+      │    │    │    └── filters [type=bool, outer=(2,6-9), constraints=(/2: (/NULL - ]; /7: (/NULL - ]; /8: (/NULL - ]; /9: (/NULL - ]), fd=(7)==(8), (8)==(7), (2)==(9), (9)==(2)]
+      │    │    │         ├── u = y [type=bool, outer=(7,8), constraints=(/7: (/NULL - ]; /8: (/NULL - ])]
+      │    │    │         ├── v = i [type=bool, outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ])]
+      │    │    │         └── (x = v) IS NOT false [type=bool, outer=(6,9)]
+      │    │    └── aggregations [outer=(5,7,10)]
+      │    │         ├── bool-or [type=bool, outer=(10)]
+      │    │         │    └── variable: notnull [type=bool, outer=(10)]
+      │    │         ├── const-agg [type=int, outer=(7)]
+      │    │         │    └── variable: y [type=int, outer=(7)]
+      │    │         └── const-agg [type=jsonb, outer=(5)]
+      │    │              └── variable: j [type=jsonb, outer=(5)]
+      │    └── projections [outer=(5-7,11)]
+      │         └── CASE WHEN bool_or AND (x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(6,11)]
+      └── filters [type=bool, outer=(6,12)]
+           └── case OR (x IS NULL) [type=bool, outer=(6,12)]
+
 
 # --------------------------------------------------
 # HoistValuesSubquery
 # --------------------------------------------------
-opt
+opt expect=HoistValuesSubquery
 SELECT (VALUES ((SELECT i+1 AS r)), (10), ((SELECT k+1 AS s))) FROM a
 ----
 project
@@ -3706,7 +3657,7 @@ project
       └── variable: column1 [type=int, outer=(8)]
 
 # Exists in values row.
-opt
+opt expect=HoistValuesSubquery
 SELECT (VALUES (EXISTS(SELECT * FROM xy WHERE x=k))) FROM a
 ----
 project
@@ -3775,7 +3726,7 @@ project
       └── variable: column1 [type=bool, outer=(8)]
 
 # Any in values row.
-opt
+opt expect=HoistValuesSubquery
 SELECT (VALUES (5 IN (SELECT y FROM xy WHERE x=k))) FROM a
 ----
 project
@@ -3853,7 +3804,7 @@ project
 # --------------------------------------------------
 # HoistZipSubquery and TryDecorrelateZip
 # --------------------------------------------------
-opt
+opt expect=(HoistZipSubquery,TryDecorrelateZip)
 SELECT generate_series(1, (SELECT v FROM uv WHERE u=x)) FROM xy
 ----
 project
@@ -3890,7 +3841,7 @@ project
       └── true [type=bool]
 
 # Zip correlation within EXISTS.
-opt
+opt expect=HoistZipSubquery
 SELECT * FROM xy WHERE EXISTS(SELECT * FROM generate_series(1, (SELECT v FROM uv WHERE u=x)))
 ----
 semi-join-apply
@@ -3935,7 +3886,7 @@ semi-join-apply
  └── true [type=bool]
 
 # Function contains multiple subqueries in arguments.
-opt
+opt expect=HoistZipSubquery
 SELECT generate_series((select y FROM xy WHERE x=k), (SELECT v FROM uv WHERE u=k)) FROM a
 ----
 project
@@ -3989,7 +3940,7 @@ project
       └── true [type=bool]
 
 # Multiple functions.
-opt
+opt expect=HoistZipSubquery
 SELECT
     generate_series(1, (SELECT v FROM uv WHERE u=k)),
     information_schema._pg_expandarray(ARRAY[(SELECT x FROM xy WHERE x=k)])
@@ -4047,7 +3998,7 @@ project
 # --------------------------------------------------
 # NormalizeAnyFilter
 # --------------------------------------------------
-opt
+opt expect=NormalizeAnyFilter
 SELECT * FROM a WHERE i IN (SELECT y FROM xy)
 ----
 semi-join
@@ -4064,7 +4015,7 @@ semi-join
       └── i = y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
 
 # Any is one of several conjuncts.
-opt
+opt expect=NormalizeAnyFilter
 SELECT * FROM a WHERE k=10 AND i < ANY(SELECT y FROM xy) AND s='foo'
 ----
 semi-join
@@ -4091,7 +4042,7 @@ semi-join
       └── i < y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
 
 # Multiple ANY conjuncts.
-opt
+opt expect=NormalizeAnyFilter
 SELECT * FROM a WHERE i < ANY(SELECT y FROM xy) AND s = ANY(SELECT y::string FROM xy)
 ----
 semi-join
@@ -4120,7 +4071,7 @@ semi-join
       └── i < xy.y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
 
 # Don't hoist uncorrelated ANY (but rewrite it to EXISTS).
-opt
+opt expect=NormalizeAnyFilter
 SELECT * FROM a WHERE 5 IN (SELECT y FROM xy)
 ----
 select
@@ -4142,7 +4093,7 @@ select
                      └── y = 5 [type=bool, outer=(7), constraints=(/7: [/5 - /5]; tight)]
 
 # ANY in Join On condition.
-opt
+opt expect=NormalizeAnyFilter
 SELECT * FROM a INNER JOIN xy ON i IN (SELECT v FROM uv) AND k=x
 ----
 inner-join
@@ -4171,7 +4122,7 @@ inner-join
 # --------------------------------------------------
 # NormalizeNotAnyFilter
 # --------------------------------------------------
-opt
+opt expect=NormalizeNotAnyFilter
 SELECT * FROM a WHERE i NOT IN (SELECT y FROM xy)
 ----
 anti-join
@@ -4189,7 +4140,7 @@ anti-join
 
 # NOT ANY is one of several conjuncts. Note that i > ALL(...) gets mapped to
 # NOT i <= ANY(...) by optbuilder.
-opt
+opt expect=NormalizeNotAnyFilter
 SELECT * FROM a WHERE k > 1 AND k < 5 AND i > ALL(SELECT y FROM xy)
 ----
 anti-join
@@ -4207,7 +4158,7 @@ anti-join
       └── (i <= y) IS NOT false [type=bool, outer=(2,7)]
 
 # Multiple NOT ANY conjuncts.
-opt
+opt expect=NormalizeNotAnyFilter
 SELECT * FROM a WHERE i < ALL(SELECT y FROM xy) AND s <> ALL(SELECT y::string FROM xy)
 ----
 anti-join
@@ -4236,7 +4187,7 @@ anti-join
       └── (i >= xy.y) IS NOT false [type=bool, outer=(2,7)]
 
 # Don't hoist uncorrelated NOT ANY (but rewrite it to NOT EXISTS).
-opt
+opt expect=NormalizeNotAnyFilter
 SELECT * FROM a WHERE 5 NOT IN (SELECT y FROM xy)
 ----
 select
@@ -4258,7 +4209,7 @@ select
                           └── (y = 5) IS NOT false [type=bool, outer=(7)]
 
 # NOT ANY in Join On condition.
-opt
+opt expect=NormalizeNotAnyFilter
 SELECT * FROM a INNER JOIN xy ON i NOT IN (SELECT v FROM uv) AND k=x
 ----
 inner-join
@@ -4287,7 +4238,7 @@ inner-join
 # --------------------------------------------------
 # NormalizeAnyFilter + NormalizeNotAnyFilter
 # --------------------------------------------------
-opt
+opt expect=(NormalizeAnyFilter,NormalizeNotAnyFilter)
 SELECT * FROM a WHERE i = ANY(SELECT y FROM xy) AND s <> ALL(SELECT y::string FROM xy)
 ----
 semi-join

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -91,8 +91,7 @@ TABLE uvwz
 # --------------------------------------------------
 # ConvertGroupByToDistinct
 # --------------------------------------------------
-
-opt
+opt expect=ConvertGroupByToDistinct
 SELECT s, f FROM a GROUP BY s, f
 ----
 distinct-on
@@ -103,7 +102,7 @@ distinct-on
       └── columns: f:3(float) s:4(string!null)
 
 # Group by not converted to DistinctOn because it has an aggregation.
-opt
+opt expect-not=ConvertGroupByToDistinct
 SELECT s, f, sum(f) FROM a GROUP BY s, f
 ----
 group-by
@@ -121,21 +120,21 @@ group-by
 # --------------------------------------------------
 # EliminateDistinct
 # --------------------------------------------------
-opt
+opt expect=EliminateDistinct
 SELECT DISTINCT k FROM a
 ----
 scan a@fi_idx
  ├── columns: k:1(int!null)
  └── key: (1)
 
-opt
+opt expect=EliminateDistinct
 SELECT DISTINCT s, i FROM a
 ----
 scan a@si_idx
  ├── columns: s:4(string!null) i:2(int!null)
  └── key: (2,4)
 
-opt
+opt expect=EliminateDistinct
 SELECT DISTINCT ON (s, i) k, i, f FROM a
 ----
 scan a@fi_idx
@@ -144,7 +143,7 @@ scan a@fi_idx
  └── fd: (1)-->(2,3), (2,3)~~>(1)
 
 # Strict superset of key.
-opt
+opt expect=EliminateDistinct
 SELECT DISTINCT s, i, f FROM a
 ----
 scan a
@@ -153,7 +152,7 @@ scan a
  └── fd: (2,4)-->(3), (2,3)~~>(4)
 
 # Distinct not eliminated because columns aren't superset of any weak key.
-opt
+opt expect-not=EliminateDistinct
 SELECT DISTINCT i FROM a
 ----
 distinct-on
@@ -164,7 +163,7 @@ distinct-on
       └── columns: i:2(int!null)
 
 # Distinct not eliminated despite a unique index on (f, i) because f is nullable.
-opt
+opt expect-not=EliminateDistinct
 SELECT DISTINCT f, i FROM a
 ----
 distinct-on
@@ -177,7 +176,7 @@ distinct-on
 # --------------------------------------------------
 # EliminateGroupByProject
 # --------------------------------------------------
-opt
+opt expect=EliminateGroupByProject
 SELECT min(s) FROM (SELECT i, s FROM (SELECT * FROM a UNION SELECT * FROM a)) GROUP BY i
 ----
 project
@@ -205,7 +204,7 @@ project
                 └── variable: s [type=string, outer=(14)]
 
 # ScalarGroupBy case.
-opt
+opt expect=EliminateGroupByProject
 SELECT min(s) FROM (SELECT i, s FROM (SELECT * FROM a UNION SELECT * FROM a))
 ----
 scalar-group-by
@@ -231,7 +230,7 @@ scalar-group-by
            └── variable: s [type=string, outer=(14)]
 
 # DistinctOn case.
-opt
+opt expect=EliminateGroupByProject
 SELECT DISTINCT ON (i) s FROM (SELECT i, s, f FROM (SELECT * FROM a UNION SELECT * FROM a))
 ----
 distinct-on
@@ -257,7 +256,7 @@ distinct-on
            └── variable: s [type=string, outer=(14)]
 
 # Don't eliminate project if it computes extra column(s).
-opt
+opt expect-not=EliminateGroupByProject
 SELECT min(s) FROM (SELECT i+1 AS i2, s FROM a) GROUP BY i2
 ----
 project
@@ -281,7 +280,7 @@ project
 # --------------------------------------------------
 # ReduceGroupingCols
 # --------------------------------------------------
-opt
+opt expect=ReduceGroupingCols
 SELECT k, min(i), f, s FROM a GROUP BY s, f, k
 ----
 group-by
@@ -301,7 +300,7 @@ group-by
       └── const-agg [type=string, outer=(4)]
            └── variable: s [type=string, outer=(4)]
 
-opt
+opt expect=ReduceGroupingCols
 SELECT k, sum(DISTINCT i), f, s FROM a, xy GROUP BY s, f, k
 ----
 group-by
@@ -328,7 +327,7 @@ group-by
            └── variable: s [type=string, outer=(4)]
 
 # Eliminated columns are not part of projection.
-opt
+opt expect=ReduceGroupingCols
 SELECT min(f) FROM a GROUP BY i, s, k
 ----
 project
@@ -347,7 +346,7 @@ project
                 └── variable: f [type=float, outer=(3)]
 
 # All grouping columns eliminated.
-opt
+opt expect=ReduceGroupingCols
 SELECT sum(f), i FROM a GROUP BY k, i, f HAVING k=1
 ----
 group-by
@@ -367,7 +366,7 @@ group-by
       └── const-agg [type=int, outer=(2)]
            └── variable: i [type=int, outer=(2)]
 
-opt
+opt expect=ReduceGroupingCols
 SELECT DISTINCT ON (k, f, s) i, f, x FROM a JOIN xy ON i=y
 ----
 distinct-on
@@ -403,7 +402,7 @@ distinct-on
 
 # ScalarGroupBy with key argument. Only the first aggregation can be
 # simplified.
-opt
+opt expect=EliminateAggDistinctForKeys
 SELECT sum(DISTINCT k), sum(DISTINCT i) FROM a
 ----
 scalar-group-by
@@ -423,7 +422,7 @@ scalar-group-by
                 └── variable: i [type=int, outer=(2)]
 
 # GroupBy with key argument.
-opt
+opt expect=EliminateAggDistinctForKeys
 SELECT sum(DISTINCT k) FROM a GROUP BY i
 ----
 project
@@ -442,7 +441,7 @@ project
                 └── variable: k [type=int, outer=(1)]
 
 # GroupBy with no key.
-opt
+opt expect-not=EliminateAggDistinctForKeys
 SELECT sum(DISTINCT a) FROM abc GROUP BY b
 ----
 project
@@ -460,7 +459,7 @@ project
                      └── variable: a [type=int, outer=(1)]
 
 # GroupBy with composite key formed by argument plus grouping columns.
-opt
+opt expect=EliminateAggDistinctForKeys
 SELECT sum(DISTINCT a) FROM abc GROUP BY b, c
 ----
 project
@@ -478,7 +477,7 @@ project
                 └── variable: a [type=int, outer=(1)]
 
 # GroupBy with multiple aggregations simplified.
-opt
+opt expect=EliminateAggDistinctForKeys
 SELECT sum(DISTINCT i), avg(DISTINCT f) FROM a GROUP BY k
 ----
 project
@@ -500,7 +499,7 @@ project
 
 # GroupBy where only some aggregations are simplified (the table has
 # keys u,v and v,w).
-opt
+opt expect=EliminateAggDistinctForKeys
 SELECT sum(DISTINCT u), stddev(DISTINCT w), avg(DISTINCT z) FROM uvwz GROUP BY v
 ----
 project

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -24,7 +24,7 @@ TABLE xy
 # --------------------------------------------------
 
 # Inline comparison.
-opt
+opt expect=PushSelectIntoInlinableProject
 SELECT * FROM (SELECT k=1 AS expr FROM a) a WHERE expr IS NULL
 ----
 project
@@ -41,7 +41,7 @@ project
       └── k = 1 [type=bool, outer=(1)]
 
 # Inline arithmetic.
-opt
+opt expect=PushSelectIntoInlinableProject
 SELECT * FROM (SELECT k*2+1 AS expr FROM a) a WHERE expr > 10
 ----
 project
@@ -58,7 +58,7 @@ project
       └── (k * 2) + 1 [type=int, outer=(1)]
 
 # Inline boolean logic.
-opt
+opt expect=PushSelectIntoInlinableProject
 SELECT * FROM (SELECT NOT(k>1 AND k<=5) AS expr FROM a) a WHERE expr
 ----
 project
@@ -71,7 +71,7 @@ project
       └── (k <= 1) OR (k > 5) [type=bool, outer=(1)]
 
 # Inline constants.
-opt
+opt expect=PushSelectIntoInlinableProject
 SELECT * FROM (SELECT (f IS NULL OR f != 10.5) AS expr FROM a) a WHERE expr
 ----
 project
@@ -86,7 +86,7 @@ project
       └── (f IS NULL) OR (f != 10.5) [type=bool, outer=(3)]
 
 # Reference the expression to inline multiple times.
-opt
+opt expect=PushSelectIntoInlinableProject
 SELECT * FROM (SELECT f+1 AS expr FROM a) a WHERE expr=expr
 ----
 project
@@ -101,7 +101,7 @@ project
       └── f + 1.0 [type=float, outer=(3)]
 
 # Use outer references in both inlined expression and in referencing expression.
-opt
+opt expect=PushSelectIntoInlinableProject
 SELECT * FROM a WHERE EXISTS(SELECT * FROM (SELECT (x-i) AS expr FROM xy) WHERE expr > i*i)
 ----
 semi-join
@@ -232,7 +232,7 @@ project
 # --------------------------------------------------
 # InlineProjectInProject
 # --------------------------------------------------
-opt
+opt expect=InlineProjectInProject
 SELECT expr, i+1 AS r FROM (SELECT k=1 AS expr, i FROM a)
 ----
 project
@@ -246,7 +246,7 @@ project
       └── k = 1 [type=bool, outer=(1)]
 
 # Inline multiple expressions.
-opt
+opt expect=InlineProjectInProject
 SELECT expr+1 AS r, i, expr2 || 'bar' AS s FROM (SELECT k+1 AS expr, s || 'foo' AS expr2, i FROM a)
 ----
 project
@@ -260,7 +260,7 @@ project
       └── (a.s || 'foo') || 'bar' [type=string, outer=(4)]
 
 # Don't inline when there are multiple references.
-opt
+opt expect-not=InlineProjectInProject
 SELECT expr, expr*2 AS r FROM (SELECT k+1 AS expr FROM a)
 ----
 project
@@ -277,7 +277,7 @@ project
       └── expr * 2 [type=int, outer=(6)]
 
 # Uncorrelated subquery should not block inlining.
-opt
+opt expect=InlineProjectInProject
 SELECT EXISTS(SELECT * FROM xy WHERE x=1 OR x=2), expr*2 AS r FROM (SELECT k+1 AS expr FROM a)
 ----
 project
@@ -296,7 +296,7 @@ project
       └── (k + 1) * 2 [type=int, outer=(1)]
 
 # Correlated subquery should be hoisted as usual.
-opt
+opt expect=InlineProjectInProject
 SELECT EXISTS(SELECT * FROM xy WHERE expr<0) FROM (SELECT k+1 AS expr FROM a)
 ----
 project

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -58,7 +58,7 @@ inner-join
 # --------------------------------------------------
 # PushFilterIntoJoinLeft
 # --------------------------------------------------
-opt
+opt expect=PushFilterIntoJoinLeft
 SELECT * FROM a INNER JOIN b ON a.k=b.x AND a.s='foo'
 ----
 inner-join (lookup b)
@@ -79,7 +79,7 @@ inner-join (lookup b)
  └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
-opt
+opt expect=PushFilterIntoJoinLeft
 SELECT * FROM a RIGHT JOIN b ON (a.i<0 OR a.i>10) AND b.y=1 AND a.s='foo' AND a.k=b.x
 ----
 right-join (merge)
@@ -112,7 +112,7 @@ right-join (merge)
            └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # LEFT JOIN should not push down conditions to left side of join.
-opt
+opt expect-not=PushFilterIntoJoinLeft
 SELECT * FROM a LEFT JOIN b ON a.k=b.x AND a.i=1
 ----
 left-join (merge)
@@ -137,7 +137,7 @@ left-join (merge)
            └── i = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
 
 # Semi-join case.
-opt
+opt expect=PushFilterIntoJoinLeft
 SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE x=k AND s='foo')
 ----
 semi-join (merge)
@@ -168,7 +168,7 @@ semi-join (merge)
            └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Do not push anti-join conditions into left input.
-opt
+opt expect-not=PushFilterIntoJoinLeft
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM b WHERE x=k AND s='foo')
 ----
 anti-join (merge)
@@ -195,7 +195,7 @@ anti-join (merge)
 # --------------------------------------------------
 # PushFilterIntoJoinRight
 # --------------------------------------------------
-opt
+opt expect=PushFilterIntoJoinRight
 SELECT * FROM b INNER JOIN a ON b.x=a.k AND a.s='foo'
 ----
 inner-join (lookup b)
@@ -216,7 +216,7 @@ inner-join (lookup b)
  └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
       └── x = k [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
 
-opt
+opt expect=PushFilterIntoJoinRight
 SELECT * FROM b LEFT JOIN a ON (a.i<0 OR a.i>10) AND b.y=1 AND a.s='foo' AND b.x=a.k
 ----
 left-join (merge)
@@ -249,7 +249,7 @@ left-join (merge)
            └── x = k [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
 
 # RIGHT JOIN should not push down conditions to right side of join.
-opt
+opt expect-not=PushFilterIntoJoinRight
 SELECT * FROM b RIGHT JOIN a ON b.x=a.k AND a.i=1
 ----
 right-join (merge)
@@ -274,7 +274,7 @@ right-join (merge)
            └── i = 1 [type=bool, outer=(4), constraints=(/4: [/1 - /1]; tight)]
 
 # Semi-join case.
-opt
+opt expect=PushFilterIntoJoinRight
 SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE x=k AND y>10)
 ----
 semi-join (merge)
@@ -305,7 +305,7 @@ semi-join (merge)
            └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Anti-join case.
-opt
+opt expect=PushFilterIntoJoinRight
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM b WHERE x=k AND y>10)
 ----
 anti-join (merge)
@@ -340,7 +340,7 @@ anti-join (merge)
 # -------------------------------------------------------------------------------
 
 # Can push to both sides with inner join.
-opt
+opt expect=(MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
 SELECT * FROM a INNER JOIN b ON a.k=b.x AND a.k + b.y > 5 AND b.x * a.i = 3
 ----
 inner-join (merge)
@@ -379,7 +379,7 @@ inner-join (merge)
 
 # Multiple equivalent columns.
 # TODO(rytaft): We should also infer the equality predicates a.k=a.i and b.x=b.y.
-opt
+opt expect=MapFilterIntoJoinLeft
 SELECT * FROM a INNER JOIN b ON a.k=b.x AND a.i=b.x AND a.i=b.y AND a.f + b.y::FLOAT > 5 AND a.s || b.x::STRING = 'foo1'
 ----
 inner-join (lookup b)
@@ -404,7 +404,7 @@ inner-join (lookup b)
       └── i = y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
 
 # Can push to both sides with semi-join.
-opt
+opt expect=(MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
 SELECT * FROM a WHERE EXISTS(
   SELECT * FROM b WHERE a.k=b.x AND a.k + b.y > 5 AND b.x * a.i = 3
 )
@@ -443,7 +443,7 @@ semi-join (merge)
       └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
            └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
-opt
+opt expect=PushFilterIntoJoinLeftAndRight
 SELECT * FROM a WHERE EXISTS(
   SELECT * FROM b WHERE a.k=b.x AND a.k > 5 AND b.x IN (3, 7, 10)
 )
@@ -471,7 +471,7 @@ semi-join (merge)
            └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Can only push to right side with left join.
-opt
+opt expect=MapFilterIntoJoinRight expect-not=PushFilterIntoJoinLeftAndRight
 SELECT * FROM a LEFT JOIN b ON a.k=b.x AND a.k + b.y > 5 AND b.x * a.i = 3
 ----
 left-join (merge)
@@ -502,7 +502,7 @@ left-join (merge)
            ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
            └── (x * i) = 3 [type=bool, outer=(2,6)]
 
-opt
+opt expect=MapFilterIntoJoinRight expect-not=PushFilterIntoJoinLeftAndRight
 SELECT * FROM a LEFT JOIN b ON a.k=b.x AND a.k > 5 AND b.x IN (3, 7, 10)
 ----
 left-join (merge)
@@ -527,7 +527,7 @@ left-join (merge)
            └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Can only push to left side with right join.
-opt
+opt expect=MapFilterIntoJoinLeft expect-not=PushFilterIntoJoinLeftAndRight
 SELECT * FROM a RIGHT JOIN b ON a.k=b.x AND a.k + b.y > 5 AND b.x * a.i = 3
 ----
 right-join (merge)
@@ -558,7 +558,7 @@ right-join (merge)
            ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
            └── (k + y) > 5 [type=bool, outer=(1,7)]
 
-opt
+opt expect=MapFilterIntoJoinLeft expect-not=PushFilterIntoJoinLeftAndRight
 SELECT * FROM a RIGHT JOIN b ON a.k=b.x AND a.k > 5 AND b.x IN (3, 7, 10)
 ----
 right-join (merge)
@@ -583,7 +583,7 @@ right-join (merge)
            └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Cannot push with full join.
-opt
+opt expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
 SELECT * FROM a FULL JOIN b ON a.k=b.x AND a.k + b.y > 5 AND b.x * a.i = 3
 ----
 full-join (merge)
@@ -608,7 +608,7 @@ full-join (merge)
            ├── (k + y) > 5 [type=bool, outer=(1,7)]
            └── (x * i) = 3 [type=bool, outer=(2,6)]
 
-opt
+opt expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
 SELECT * FROM a FULL JOIN b ON a.k=b.x AND a.k > 5 AND b.x IN (3, 7, 10)
 ----
 full-join (merge)
@@ -634,7 +634,7 @@ full-join (merge)
            └── x IN (3, 7, 10) [type=bool, outer=(6), constraints=(/6: [/3 - /3] [/7 - /7] [/10 - /10]; tight)]
 
 # Can only push to right side with anti-join.
-opt
+opt expect=MapFilterIntoJoinRight expect-not=PushFilterIntoJoinLeftAndRight
 SELECT * FROM a WHERE NOT EXISTS(
   SELECT * FROM b WHERE a.k=b.x AND a.k + b.y > 5 AND b.x * a.i = 3
 )
@@ -667,7 +667,7 @@ anti-join (merge)
            ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
            └── (x * i) = 3 [type=bool, outer=(2,6)]
 
-opt
+opt expect=MapFilterIntoJoinRight expect-not=PushFilterIntoJoinLeftAndRight
 SELECT * FROM a WHERE NOT EXISTS(
   SELECT * FROM b WHERE a.k=b.x AND a.k > 5 AND b.x IN (3, 7, 10)
 )
@@ -694,7 +694,7 @@ anti-join (merge)
            └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Works with a non-correlated subquery.
-opt
+opt expect=MapFilterIntoJoinLeft
 SELECT * FROM a JOIN b ON a.k = b.x AND b.x * a.i = (SELECT min(b.x) FROM b)
 ----
 inner-join (merge)
@@ -783,7 +783,7 @@ project
            └── (b.x * i) = ?column? [type=bool, outer=(2,6,10)]
 
 # Ensure that we do not map filters for types with composite key encoding.
-opt
+opt expect-not=(MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
 SELECT * FROM (VALUES (1.0)) AS t1(x), (VALUES (1.00)) AS t2(y) WHERE x=y AND x::text = '1.0'
 ----
 inner-join
@@ -993,7 +993,7 @@ project
 # PushFilterIntoJoinLeft + PushFilterIntoJoinRight
 # --------------------------------------------------
 
-opt
+opt expect=(PushFilterIntoJoinLeft,PushFilterIntoJoinRight)
 SELECT * FROM a INNER JOIN b ON a.k=b.x AND a.i=1 AND b.y=1
 ----
 inner-join (lookup a)
@@ -1016,7 +1016,7 @@ inner-join (lookup a)
       └── i = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
 
 # FULL JOIN should not push down conditions to either side of join.
-opt
+opt expect-not=(PushFilterIntoJoinLeft,PushFilterIntoJoinRight)
 SELECT * FROM a FULL JOIN b ON a.k=b.x AND a.i=1 AND b.y=1
 ----
 full-join (merge)
@@ -1042,7 +1042,7 @@ full-join (merge)
            └── y = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight)]
 
 # Nested semi/anti-join case.
-opt
+opt expect=PushFilterIntoJoinRight
 SELECT * FROM b
 WHERE EXISTS
 (
@@ -1090,7 +1090,7 @@ semi-join-apply
 # --------------------------------------------------
 # SimplifyLeftJoinWithoutFilters
 # --------------------------------------------------
-opt
+opt expect=SimplifyLeftJoinWithoutFilters
 SELECT * FROM a LEFT JOIN (SELECT count(*) FROM b) ON True
 ----
 inner-join
@@ -1112,7 +1112,7 @@ inner-join
  └── true [type=bool]
 
 # Full-join.
-opt
+opt expect=SimplifyLeftJoinWithoutFilters
 SELECT * FROM a FULL JOIN (SELECT count(*) FROM b) ON True
 ----
 right-join
@@ -1135,7 +1135,7 @@ right-join
  └── true [type=bool]
 
 # Left-join-apply.
-opt
+opt expect=SimplifyLeftJoinWithoutFilters
 SELECT * FROM a WHERE (SELECT sum(column1) FROM (VALUES (k), (1))) = 1
 ----
 project
@@ -1180,7 +1180,7 @@ project
            └── sum = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight)]
 
 # Don't simplify right join
-opt
+opt expect-not=SimplifyLeftJoinWithoutFilters
 SELECT * FROM a RIGHT JOIN (SELECT count(*) FROM b) ON True
 ----
 right-join
@@ -1205,7 +1205,7 @@ right-join
 # --------------------------------------------------
 # SimplifyRightJoinWithoutFilters
 # --------------------------------------------------
-opt
+opt expect=SimplifyRightJoinWithoutFilters
 SELECT * FROM (SELECT count(*) FROM b) RIGHT JOIN a ON True
 ----
 inner-join
@@ -1227,7 +1227,7 @@ inner-join
  └── true [type=bool]
 
 # Full-join.
-opt
+opt expect=SimplifyRightJoinWithoutFilters
 SELECT * FROM (SELECT count(*) FROM b) FULL JOIN a ON True
 ----
 right-join
@@ -1250,7 +1250,7 @@ right-join
  └── true [type=bool]
 
 # Don't simplify left join
-opt
+opt expect-not=SimplifyRightJoinWithoutFilters
 SELECT * FROM (SELECT count(*) FROM b) LEFT JOIN a ON True
 ----
 right-join
@@ -1275,7 +1275,7 @@ right-join
 # --------------------------------------------------
 # SimplifyLeftJoinWithFilters + SimplifyRightJoinWithFilters
 # --------------------------------------------------
-opt
+opt expect=(SimplifyLeftJoinWithFilters,SimplifyRightJoinWithFilters)
 SELECT * FROM a FULL JOIN a AS a2 ON a.k=a2.k
 ----
 inner-join (merge)
@@ -1299,7 +1299,7 @@ inner-join (merge)
            └── a.k = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Right side has partial rows, so only right-join can be simplified.
-opt
+opt expect=SimplifyRightJoinWithFilters
 SELECT * FROM a FULL JOIN (SELECT * FROM a WHERE k>0) AS a2 ON a.k=a2.k
 ----
 left-join (merge)
@@ -1324,7 +1324,7 @@ left-join (merge)
            └── a.k = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Multiple equality conditions, with duplicates and reversed columns.
-opt
+opt expect=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN a AS a2 ON a.k=a2.k AND a.k=a2.k AND a2.f=a.f
 ----
 inner-join
@@ -1345,7 +1345,7 @@ inner-join
       └── a.f = a.f [type=bool, outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ])]
 
 # Input contains Project operator.
-opt
+opt expect=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM (SELECT length(s), f FROM a) AS a FULL JOIN a AS a2 ON a.f=a2.f
 ----
 inner-join
@@ -1365,7 +1365,7 @@ inner-join
       └── a.f = a.f [type=bool, outer=(3,9), constraints=(/3: (/NULL - ]; /9: (/NULL - ])]
 
 # Multiple join levels.
-opt
+opt expect=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN (SELECT * FROM a INNER JOIN a AS a2 ON a.k=a2.k) AS a2 ON a.f=a2.f
 ----
 inner-join
@@ -1399,7 +1399,7 @@ inner-join
       └── a.f = a.f [type=bool, outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ])]
 
 # Cross-join preserves all rows and enables top-level full-join to become inner-join.
-opt
+opt expect=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT *
 FROM a
 FULL JOIN (SELECT a.k AS k1, a2.k AS k2 FROM a, a AS a2) AS a2
@@ -1611,7 +1611,7 @@ right-join
 # --------------------------------------------------
 # EliminateSemiJoin
 # --------------------------------------------------
-opt
+opt expect=EliminateSemiJoin
 SELECT * FROM a WHERE EXISTS(SELECT count(*) FROM b WHERE x=k)
 ----
 scan a
@@ -1622,7 +1622,7 @@ scan a
 # --------------------------------------------------
 # EliminateAntiJoin
 # --------------------------------------------------
-opt
+opt expect=EliminateAntiJoin
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM (VALUES (k)) OFFSET 1)
 ----
 scan a
@@ -1633,7 +1633,7 @@ scan a
 # --------------------------------------------------
 # EliminateJoinNoColsLeft
 # --------------------------------------------------
-opt
+opt expect=EliminateJoinNoColsLeft
 SELECT s FROM (VALUES (1, 2)) INNER JOIN a ON s='foo'
 ----
 select
@@ -1647,7 +1647,7 @@ select
 # --------------------------------------------------
 # EliminateJoinNoColsRight
 # --------------------------------------------------
-opt
+opt expect=EliminateJoinNoColsRight
 SELECT s FROM a INNER JOIN (SELECT count(*) FROM b) ON s='foo'
 ----
 select
@@ -1664,7 +1664,7 @@ select
 # --------------------------------------------------
 
 # Inner-join case.
-opt
+opt expect=HoistJoinProject
 SELECT * FROM a INNER JOIN (SELECT x FROM b WHERE y=10) ON x=k
 ----
 project
@@ -1690,7 +1690,7 @@ project
            └── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Left-join case.
-opt
+opt expect=HoistJoinProject
 SELECT * FROM a LEFT JOIN (SELECT x FROM b WHERE y=10) ON x=k
 ----
 project

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -22,7 +22,7 @@ TABLE b
 # --------------------------------------------------
 # EliminateLimit
 # --------------------------------------------------
-opt
+opt expect=EliminateLimit
 SELECT * FROM (SELECT * FROM a LIMIT 99) LIMIT 100
 ----
 scan a
@@ -31,7 +31,7 @@ scan a
  ├── key: (1)
  └── fd: (1)-->(2-5)
 
-opt
+opt expect=EliminateLimit
 SELECT * FROM (SELECT * FROM a LIMIT 100) LIMIT 100
 ----
 scan a
@@ -95,7 +95,7 @@ limit
 # --------------------------------------------------
 # PushLimitIntoProject
 # --------------------------------------------------
-opt
+opt expect=PushLimitIntoProject
 SELECT k, f*2.0 AS r FROM a LIMIT 5
 ----
 project
@@ -111,7 +111,7 @@ project
  └── projections [outer=(1,3)]
       └── f * 2.0 [type=float, outer=(3)]
 
-opt
+opt expect=PushLimitIntoProject
 SELECT k, f*2.0 AS r FROM a ORDER BY k LIMIT 5
 ----
 project
@@ -131,7 +131,7 @@ project
 
 # Don't push the limit through project when the ordering is on a
 # synthesized column.
-opt
+opt expect-not=PushLimitIntoProject
 SELECT k, f*2.0 AS r FROM a ORDER BY r LIMIT 5 
 ----
 limit
@@ -220,7 +220,7 @@ limit
 # --------------------------------------------------
 # PushOffsetIntoProject
 # --------------------------------------------------
-opt
+opt expect=PushOffsetIntoProject
 SELECT k, f*2.0 AS r FROM a OFFSET 5
 ----
 project
@@ -239,7 +239,7 @@ project
  └── projections [outer=(1,3)]
       └── f * 2.0 [type=float, outer=(3)]
 
-opt
+opt expect=PushOffsetIntoProject
 SELECT k, f*2.0 AS r FROM a ORDER BY k OFFSET 5
 ----
 project
@@ -264,7 +264,7 @@ project
 
 # Don't push the offset through project when the ordering is on a
 # synthesized column.
-opt
+opt expect-not=PushOffsetIntoProject
 SELECT k, f*2.0 AS r FROM a ORDER BY r OFFSET 5
 ----
 offset
@@ -319,7 +319,7 @@ project
 # --------------------------------------------------
 # PushLimitIntoProject + PushOffsetIntoProject
 # --------------------------------------------------
-opt
+opt expect=(PushLimitIntoProject,PushOffsetIntoProject)
 SELECT k, f*2.0 AS r FROM a OFFSET 5 LIMIT 10
 ----
 project
@@ -345,7 +345,7 @@ project
  └── projections [outer=(1,3)]
       └── f * 2.0 [type=float, outer=(3)]
 
-opt
+opt expect=(PushLimitIntoProject,PushOffsetIntoProject)
 SELECT f, f+1.1 AS r FROM (SELECT f, i FROM a GROUP BY f, i) a ORDER BY f OFFSET 5 LIMIT 10
 ----
 project

--- a/pkg/sql/opt/norm/testdata/rules/numeric
+++ b/pkg/sql/opt/norm/testdata/rules/numeric
@@ -15,7 +15,7 @@ TABLE a
 # --------------------------------------------------
 
 # Add columns to prevent NormalizeVar from swapping left and right.
-opt
+opt expect=(FoldPlusZero,FoldZeroPlus)
 SELECT
     (a.i + a.i) + 0 AS r, 0 + (a.i + a.i) AS s,
     (a.f + a.f) + 0 AS t, 0 + (a.f + a.f) AS u,
@@ -39,7 +39,7 @@ project
 # --------------------------------------------------
 
 # Add columns to prevent NormalizeVar from swapping left and right.
-opt
+opt expect=FoldMinusZero
 SELECT
     (a.i + a.i) - 0 AS r,
     (a.f + a.f) - 0 AS s,
@@ -60,7 +60,7 @@ project
 # --------------------------------------------------
 
 # Add columns to prevent NormalizeVar from swapping left and right.
-opt
+opt expect=(FoldMultOne,FoldOneMult)
 SELECT
     (a.i + a.i) * 1 AS r, 1 * (a.i + a.i) AS s,
     (a.f + a.f) * 1 AS t, 1 * (a.f + a.f) AS u,
@@ -83,7 +83,7 @@ project
 # FoldDivOne
 # --------------------------------------------------
 
-opt
+opt expect=FoldDivOne
 SELECT
     a.i / 1 AS r,
     a.f / 1 AS s,
@@ -102,7 +102,7 @@ project
 # --------------------------------------------------
 # InvertMinus
 # --------------------------------------------------
-opt
+opt expect=InvertMinus
 SELECT
     -(a.f - a.f) AS r,
     -(a.d - a.i) AS s,
@@ -121,7 +121,7 @@ project
 # --------------------------------------------------
 # EliminateUnaryMinus
 # --------------------------------------------------
-opt
+opt expect=EliminateUnaryMinus
 SELECT -(-a.i::int) AS r FROM a
 ----
 project

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -25,7 +25,7 @@ TABLE abcde
 # SimplifyLimitOrdering
 # --------------------------------------------------
 # Remove constant column.
-opt
+opt expect=SimplifyLimitOrdering
 SELECT d, e FROM (SELECT d, 1 AS one, e FROM abcde) ORDER BY d, one, e LIMIT 10
 ----
 limit
@@ -41,7 +41,7 @@ limit
  └── const: 10 [type=int]
 
 # Remove multiple constant columns.
-opt
+opt expect=SimplifyLimitOrdering
 SELECT b, c FROM abcde WHERE d=1 AND e=2 ORDER BY b, c, d, e, a LIMIT 10
 ----
 limit
@@ -70,7 +70,7 @@ limit
  └── const: 10 [type=int]
 
 # Remove functionally dependent column that's only used in ordering.
-opt
+opt expect=SimplifyLimitOrdering
 SELECT c FROM abcde ORDER BY b, c, a, d LIMIT 10
 ----
 scan abcde@bc
@@ -84,7 +84,7 @@ scan abcde@bc
 # SimplifyOffsetOrdering
 # --------------------------------------------------
 # Remove all order by columns, because all are constant.
-opt
+opt expect=SimplifyOffsetOrdering
 SELECT d, e FROM (SELECT d, 1 AS one, e FROM abcde) ORDER BY one OFFSET 10
 ----
 offset
@@ -97,6 +97,8 @@ offset
 # SimplifyGroupByOrdering
 # --------------------------------------------------
 # Remove columns functionally dependent on key.
+# TODO(justin): figure out why this doesn't trigger SimplifyGroupByOrdering (it
+# triggers SimplifyRootOrdering).
 opt
 SELECT array_agg(b), a, c FROM abcde GROUP BY b, a, c ORDER BY a, b, c
 ----
@@ -118,7 +120,7 @@ group-by
            └── variable: c [type=int, outer=(3)]
 
 # ScalarGroupBy case.
-opt
+opt expect=SimplifyGroupByOrdering
 SELECT array_agg(b) FROM (SELECT * FROM abcde ORDER BY a, b, c)
 ----
 scalar-group-by
@@ -137,7 +139,7 @@ scalar-group-by
            └── variable: b [type=int, outer=(2)]
 
 # DistinctOn case.
-opt
+opt expect=SimplifyGroupByOrdering
 SELECT DISTINCT ON (b, c) a, b, c FROM abcde ORDER BY b, c, a, d, e
 ----
 distinct-on
@@ -160,7 +162,7 @@ distinct-on
 # SimplifyRowNumberOrdering
 # --------------------------------------------------
 # Remove column functionally dependent on multi-column key.
-opt
+opt expect=SimplifyRowNumberOrdering
 SELECT * FROM (SELECT * FROM abcde WHERE b IS NOT NULL AND c IS NOT NULL ORDER BY c, d, b, e) WITH ORDINALITY
 ----
 row-number
@@ -192,7 +194,7 @@ row-number
 # SimplifyExplainOrdering
 # --------------------------------------------------
 # Remove functionally dependent synthesized column.
-opt
+opt expect=SimplifyExplainOrdering
 EXPLAIN SELECT b, b+1 AS plus, c FROM abcde ORDER BY b, plus, c
 ----
 explain

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -23,7 +23,7 @@ TABLE b
 # --------------------------------------------------
 
 # Same order, same names.
-opt
+opt expect=EliminateProject
 SELECT x, y FROM a
 ----
 scan a
@@ -32,7 +32,7 @@ scan a
  └── fd: (1)-->(2)
 
 # Different order, aliased names.
-opt
+opt expect=EliminateProject
 SELECT a.y AS aliasy, a.x FROM a
 ----
 scan a
@@ -41,7 +41,7 @@ scan a
  └── fd: (1)-->(2)
 
 # Reordered, duplicate, aliased columns.
-opt
+opt expect=EliminateProject
 SELECT a.y AS alias1, a.x, a.y AS alias1, a.x FROM a
 ----
 scan a
@@ -50,7 +50,7 @@ scan a
  └── fd: (1)-->(2)
 
 # Added column (projection should not be eliminated).
-opt
+opt expect-not=EliminateProject
 SELECT *, 1 r FROM a
 ----
 project
@@ -68,7 +68,7 @@ project
 # EliminateProjectProject
 # --------------------------------------------------
 
-opt
+opt expect=EliminateProjectProject
 SELECT y+1 AS r FROM (SELECT a.y FROM a, b WHERE a.x=b.x) a
 ----
 project

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -46,7 +46,7 @@ TABLE abcde
 # --------------------------------------------------
 
 # Discard some of columns.
-opt
+opt expect=PruneProjectCols
 SELECT k FROM (SELECT k, i+1 FROM a) a
 ----
 scan a
@@ -54,7 +54,7 @@ scan a
  └── key: (1)
 
 # Discard all columns.
-opt
+opt expect=PruneProjectCols
 SELECT 1 r FROM (SELECT i+1, k FROM a) a
 ----
 project
@@ -65,7 +65,7 @@ project
       └── const: 1 [type=int]
 
 # Use column values within computed column.
-opt
+opt expect=PruneProjectCols
 SELECT k+i AS r FROM (SELECT i, k, s || 'foo' FROM a) a
 ----
 project
@@ -78,7 +78,7 @@ project
       └── k + i [type=int, outer=(1,2)]
 
 # Discard non-computed columns and keep computed column.
-opt
+opt expect=PruneProjectCols
 SELECT l, k FROM (SELECT length(s) l, * FROM a) a
 ----
 project
@@ -93,7 +93,7 @@ project
       └── length(s) [type=int, outer=(4)]
 
 # Compute column based on another computed column.
-opt
+opt expect=PruneProjectCols
 SELECT l*l AS r, k FROM (SELECT k, length(s) l, i FROM a) a
 ----
 project
@@ -118,7 +118,7 @@ project
 # --------------------------------------------------
 
 # Project subset of columns.
-opt
+opt expect=PruneScanCols
 SELECT k FROM a
 ----
 scan a
@@ -126,7 +126,7 @@ scan a
  └── key: (1)
 
 # Project subset of columns, some used in computed columns.
-opt
+opt expect=PruneScanCols
 SELECT k, k+1 AS r, i+1 AS s FROM a
 ----
 project
@@ -142,7 +142,7 @@ project
       └── i + 1 [type=int, outer=(2)]
 
 # Use columns only in computed columns.
-opt
+opt expect=PruneScanCols
 SELECT k+i AS r FROM a
 ----
 project
@@ -155,7 +155,7 @@ project
       └── k + i [type=int, outer=(1,2)]
 
 # Use no scan columns.
-opt
+opt expect=PruneScanCols
 SELECT 1 r FROM a
 ----
 project
@@ -170,7 +170,7 @@ project
 # --------------------------------------------------
 
 # Columns used only by projection or filter, but not both.
-opt
+opt expect=PruneSelectCols
 SELECT k FROM a WHERE i<5
 ----
 project
@@ -188,7 +188,7 @@ project
            └── i < 5 [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
 
 # Columns used by both projection and filter.
-opt
+opt expect=PruneSelectCols
 SELECT k, i FROM a WHERE k=1 AND i<5
 ----
 select
@@ -206,7 +206,7 @@ select
       └── i < 5 [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
 
 # No needed select columns.
-opt
+opt expect=PruneSelectCols
 SELECT 1 r FROM a WHERE $1<'2000-01-01T02:00:00'::timestamp
 ----
 project
@@ -222,7 +222,7 @@ project
       └── const: 1 [type=int]
 
 # Select columns used in computed columns.
-opt
+opt expect=PruneSelectCols
 SELECT i-1 AS r, k*k AS t FROM a WHERE k+1<5 AND s||'o'='foo'
 ----
 project
@@ -243,7 +243,7 @@ project
       └── k * k [type=int, outer=(1)]
 
 # Select nested in select.
-opt
+opt expect=PruneSelectCols
 SELECT i FROM (SELECT k, i, s, f/2.0 f FROM a WHERE k = 5) a2 WHERE i::float = f
 ----
 project
@@ -308,17 +308,17 @@ project
 # PruneLimitCols
 # --------------------------------------------------
 
-opt
-SELECT i, s FROM a LIMIT 1
+opt expect=PruneLimitCols
+SELECT i FROM (SELECT i, s FROM a LIMIT 1)
 ----
 scan a
- ├── columns: i:2(int) s:4(string)
+ ├── columns: i:2(int)
  ├── limit: 1
  ├── key: ()
- └── fd: ()-->(2,4)
+ └── fd: ()-->(2)
 
 # The projection on top of Limit should trickle down and we shouldn't scan f.
-opt
+opt expect=PruneLimitCols
 SELECT k FROM (SELECT k, i, f FROM a ORDER BY i LIMIT 10)
 ----
 project
@@ -343,7 +343,7 @@ project
       └── const: 10 [type=int]
 
 # We should scan k, i, s.
-opt
+opt expect=PruneLimitCols
 SELECT s FROM (SELECT k, i, f, s FROM a ORDER BY i, k LIMIT 10)
 ----
 project
@@ -367,7 +367,7 @@ project
       └── const: 10 [type=int]
 
 # We should scan k, i, s.
-opt
+opt expect=PruneLimitCols
 SELECT k, s FROM (SELECT k, i, f, s FROM a ORDER BY i, k LIMIT 10)
 ----
 project
@@ -418,8 +418,8 @@ project
 # PruneOffsetCols
 # --------------------------------------------------
 
-opt
-SELECT f FROM a OFFSET 1
+opt expect=PruneOffsetCols
+SELECT f FROM (SELECT * FROM a OFFSET 1)
 ----
 offset
  ├── columns: f:3(float)
@@ -427,7 +427,7 @@ offset
  │    └── columns: f:3(float)
  └── const: 1 [type=int]
 
-opt
+opt expect=PruneOffsetCols
 SELECT k FROM (SELECT k, i, f FROM a ORDER BY i OFFSET 10)
 ----
 project
@@ -450,7 +450,7 @@ project
       └── const: 10 [type=int]
 
 # We should scan k, i, s.
-opt
+opt expect=PruneOffsetCols
 SELECT s FROM (SELECT k, i, f, s FROM a ORDER BY i, k OFFSET 10)
 ----
 project
@@ -472,7 +472,7 @@ project
       └── const: 10 [type=int]
 
 # We should scan k, i, s.
-opt
+opt expect=PruneOffsetCols
 SELECT k, s FROM (SELECT k, i, f, s FROM a ORDER BY i, k OFFSET 10)
 ----
 project
@@ -527,7 +527,7 @@ project
 # PruneLimitCols + PruneOffsetCols
 # --------------------------------------------------
 
-opt
+opt expect=(PruneLimitCols,PruneOffsetCols)
 SELECT k FROM (SELECT k, i, f FROM a ORDER BY i LIMIT 10 OFFSET 10)
 ----
 project
@@ -559,7 +559,7 @@ project
       └── const: 10 [type=int]
 
 # We should scan k, i, s.
-opt
+opt expect=(PruneLimitCols,PruneOffsetCols)
 SELECT s FROM (SELECT k, i, f, s FROM a ORDER BY i, k LIMIT 10 OFFSET 10)
 ----
 project
@@ -590,7 +590,7 @@ project
       └── const: 10 [type=int]
 
 # We should scan k, i, s.
-opt
+opt expect=(PruneLimitCols,PruneOffsetCols)
 SELECT k, s FROM (SELECT k, i, f, s FROM a ORDER BY i, k LIMIT 10 OFFSET 10)
 ----
 project
@@ -652,7 +652,7 @@ project
 # --------------------------------------------------
 
 # Columns used only by projection or on condition, but not both.
-opt
+opt expect=PruneJoinLeftCols
 SELECT a.i, xy.* FROM a INNER JOIN xy ON a.k=xy.x
 ----
 project
@@ -680,7 +680,7 @@ project
                 └── k = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
 
 # Columns used by both projection and on condition, left join.
-opt
+opt expect=PruneJoinLeftCols
 SELECT a.k, a.i, xy.* FROM a LEFT JOIN xy ON a.k=xy.x AND a.i<5
 ----
 left-join (merge)
@@ -705,7 +705,7 @@ left-join (merge)
            └── i < 5 [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
 
 # Columns only used by on condition, right join
-opt
+opt expect=PruneJoinLeftCols
 SELECT xy.* FROM a RIGHT JOIN xy ON a.k=xy.x
 ----
 project
@@ -731,7 +731,7 @@ project
                 └── k = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
 
 # Columns needed only by projection, full join.
-opt
+opt expect=PruneJoinLeftCols
 SELECT a.k+1 AS r, xy.* FROM a FULL JOIN xy ON True
 ----
 project
@@ -753,7 +753,7 @@ project
       └── k + 1 [type=int, outer=(1)]
 
 # No columns needed from left side of join.
-opt
+opt expect=PruneJoinLeftCols
 SELECT xy.* FROM a, xy
 ----
 inner-join
@@ -767,7 +767,7 @@ inner-join
  └── true [type=bool]
 
 # Computed columns.
-opt
+opt expect=PruneJoinLeftCols
 SELECT a.k+1 AS r, a.i/2 AS s, xy.* FROM a INNER JOIN xy ON a.k*a.k=xy.x AND a.s||'o'='foo'
 ----
 project
@@ -799,7 +799,7 @@ project
       └── i / 2 [type=decimal, outer=(2), side-effects]
 
 # Join that is nested in another join.
-opt
+opt expect=PruneJoinLeftCols
 SELECT a.k, xy.*
 FROM
 (
@@ -842,7 +842,7 @@ project
            └── i < xy.y [type=bool, outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ])]
 
 # ApplyJoin operator.
-opt
+opt expect=PruneJoinLeftCols
 SELECT k, i
 FROM a
 WHERE (SELECT k+1 AS r FROM xy WHERE y=k) = 1
@@ -890,7 +890,7 @@ project
       └── true [type=bool]
 
 # SemiJoin operator.
-opt
+opt expect=PruneJoinLeftCols
 SELECT a.i
 FROM a
 WHERE
@@ -934,7 +934,7 @@ project
                 └── k = xy.x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
 
 # AntiJoin operator.
-opt
+opt expect=PruneJoinLeftCols
 SELECT a.i
 FROM a
 WHERE
@@ -982,7 +982,7 @@ project
 # --------------------------------------------------
 
 # Columns used only by projection or on condition, but not both.
-opt
+opt expect=PruneJoinRightCols
 SELECT xy.*, a.i FROM xy INNER JOIN a ON xy.x=a.k
 ----
 project
@@ -1010,7 +1010,7 @@ project
                 └── x = k [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
 
 # Columns used by both projection and on condition, left join.
-opt
+opt expect=PruneJoinRightCols
 SELECT xy.*, a.k, a.i FROM xy LEFT JOIN a ON xy.x=a.k AND a.i<xy.x
 ----
 left-join (merge)
@@ -1041,7 +1041,7 @@ left-join (merge)
            └── x = k [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
 
 # Columns only used by on condition, right join
-opt
+opt expect=PruneJoinRightCols
 SELECT xy.* FROM xy RIGHT JOIN a ON xy.x=a.k
 ----
 project
@@ -1067,7 +1067,7 @@ project
                 └── x = k [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
 
 # Columns needed only by projection, full join.
-opt
+opt expect=PruneJoinRightCols
 SELECT xy.*, a.k+1 AS r FROM xy FULL JOIN a ON True
 ----
 project
@@ -1089,7 +1089,7 @@ project
       └── k + 1 [type=int, outer=(3)]
 
 # No columns needed from right side of join.
-opt
+opt expect=PruneJoinRightCols
 SELECT xy.* FROM xy, a
 ----
 inner-join
@@ -1103,7 +1103,7 @@ inner-join
  └── true [type=bool]
 
 # Computed columns.
-opt
+opt expect=PruneJoinRightCols
 SELECT xy.*, a.k+1 AS r, a.i/2 AS s FROM xy INNER JOIN a ON xy.x=a.k*a.k AND a.s||'o'='foo'
 ----
 project
@@ -1135,7 +1135,7 @@ project
       └── i / 2 [type=decimal, outer=(4), side-effects]
 
 # Join that is nested in another join.
-opt
+opt expect=PruneJoinRightCols
 SELECT a.k, xy.*
 FROM xy
 INNER JOIN
@@ -1182,7 +1182,7 @@ project
 # --------------------------------------------------
 
 # Columns not needed by either side of join.
-opt
+opt expect=(PruneJoinLeftCols,PruneJoinRightCols)
 SELECT 1 r FROM a,xy
 ----
 project
@@ -1196,7 +1196,7 @@ project
       └── const: 1 [type=int]
 
 # Subset of columns needed by each side of join.
-opt
+opt expect=(PruneJoinLeftCols,PruneJoinRightCols)
 SELECT a.k, xy.x, a.k+xy.x AS r FROM a LEFT JOIN xy ON a.k=xy.x
 ----
 project
@@ -1227,7 +1227,7 @@ project
 # --------------------------------------------------
 
 # Discard all aggregates.
-opt
+opt expect=PruneAggCols
 SELECT s FROM (SELECT s, sum(i), min(s||'foo') FROM a GROUP BY s) a
 ----
 distinct-on
@@ -1238,7 +1238,7 @@ distinct-on
       └── columns: s:4(string)
 
 # Discard subset of aggregates.
-opt
+opt expect=PruneAggCols
 SELECT s, sumi FROM (SELECT sum(i) sumi, s, min(s||'foo') FROM a GROUP BY s) a
 ----
 group-by
@@ -1253,7 +1253,7 @@ group-by
            └── variable: i [type=int, outer=(2)]
 
 # No aggregates to discard.
-opt
+opt expect-not=PruneAggCols
 SELECT 1 r FROM (SELECT s FROM a GROUP BY s) a
 ----
 project
@@ -1269,7 +1269,7 @@ project
       └── const: 1 [type=int]
 
 # Scalar GroupBy case.
-opt
+opt expect=PruneAggCols
 SELECT sumi FROM (SELECT sum(i) sumi, min(s||'foo') FROM a) a
 ----
 scalar-group-by
@@ -1287,7 +1287,7 @@ scalar-group-by
       └── sum [type=decimal, outer=(2)]
            └── variable: i [type=int, outer=(2)]
 
-opt
+opt expect=PruneAggCols
 SELECT f FROM (SELECT DISTINCT ON (i) f, s FROM a)
 ----
 project
@@ -1303,13 +1303,32 @@ project
            └── first-agg [type=float, outer=(3)]
                 └── variable: f [type=float, outer=(3)]
 
+# Columns used only by aggregation, no grouping columns.
+opt expect=PruneAggCols
+SELECT min(i), max(k), max(k) FROM a ORDER BY max(f)
+----
+scalar-group-by
+ ├── columns: min:5(int) max:6(int) max:6(int)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(5,6)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── aggregations [outer=(1,2)]
+      ├── min [type=int, outer=(2)]
+      │    └── variable: i [type=int, outer=(2)]
+      └── max [type=int, outer=(1)]
+           └── variable: k [type=int, outer=(1)]
+
 # --------------------------------------------------
 # PruneGroupByCols
 # --------------------------------------------------
 
-# Columns used by grouping or aggregation, but not both.
-opt
-SELECT s, sum(i) FROM a GROUP BY s
+# Columns used by grouping or aggregation, but not both should not be pruned.
+opt expect=PruneGroupByCols
+SELECT s, sum(i) FROM a GROUP BY s, s||'foo'
 ----
 group-by
  ├── columns: s:4(string) sum:5(decimal)
@@ -1322,9 +1341,9 @@ group-by
       └── sum [type=decimal, outer=(2)]
            └── variable: i [type=int, outer=(2)]
 
-# Columns used by both grouping and aggregation.
-opt
-SELECT avg(s::int+i), s, i FROM a GROUP BY s, i
+# Columns used by both grouping and aggregation should not be pruned.
+opt expect=PruneGroupByCols
+SELECT avg(s::int+i), s, i FROM a GROUP BY s, i, i+1
 ----
 group-by
  ├── columns: avg:6(decimal) s:4(string) i:2(int)
@@ -1342,31 +1361,12 @@ group-by
       └── avg [type=decimal, outer=(5)]
            └── variable: column5 [type=int, outer=(5)]
 
-# Columns used only by aggregation, no grouping columns.
-opt
-SELECT min(i), max(k), max(k) FROM a
-----
-scalar-group-by
- ├── columns: min:5(int) max:6(int) max:6(int)
- ├── cardinality: [1 - 1]
- ├── key: ()
- ├── fd: ()-->(5,6)
- ├── scan a
- │    ├── columns: k:1(int!null) i:2(int)
- │    ├── key: (1)
- │    └── fd: (1)-->(2)
- └── aggregations [outer=(1,2)]
-      ├── min [type=int, outer=(2)]
-      │    └── variable: i [type=int, outer=(2)]
-      └── max [type=int, outer=(1)]
-           └── variable: k [type=int, outer=(1)]
-
 # Columns used only by groupings, no aggregation columns.
-opt
-SELECT s, i+1 AS r FROM a GROUP BY i, s
+opt expect=PruneGroupByCols
+SELECT s, i+1 AS r FROM a GROUP BY i, s, s||'foo'
 ----
 project
- ├── columns: s:4(string) r:5(int)
+ ├── columns: s:4(string) r:6(int)
  ├── distinct-on
  │    ├── columns: i:2(int) s:4(string)
  │    ├── grouping columns: i:2(int) s:4(string)
@@ -1377,8 +1377,8 @@ project
       └── i + 1 [type=int, outer=(2)]
 
 # Groupby a groupby.
-opt
-SELECT min(sm), i FROM (SELECT s, i, sum(k) sm, avg(k) av FROM a GROUP BY i, s) a GROUP BY i
+opt expect=PruneGroupByCols
+SELECT min(sm), i FROM (SELECT s, i, sum(k) sm, avg(k) av FROM a GROUP BY i, s) a GROUP BY i, i+1
 ----
 group-by
  ├── columns: min:7(decimal) i:2(int)
@@ -1402,22 +1402,26 @@ group-by
            └── variable: sum [type=decimal, outer=(5)]
 
 # Distinct (GroupBy operator with no aggregates).
-opt
-SELECT DISTINCT s, f FROM a
+opt expect=PruneGroupByCols
+SELECT DISTINCT ON (s, s||'foo') s, f FROM a
 ----
 distinct-on
  ├── columns: s:4(string) f:3(float)
- ├── grouping columns: f:3(float) s:4(string)
- ├── key: (3,4)
- └── scan a
-      └── columns: f:3(float) s:4(string)
+ ├── grouping columns: s:4(string)
+ ├── key: (4)
+ ├── fd: (4)-->(3)
+ ├── scan a
+ │    └── columns: f:3(float) s:4(string)
+ └── aggregations [outer=(3)]
+      └── first-agg [type=float, outer=(3)]
+           └── variable: f [type=float, outer=(3)]
 
 # --------------------------------------------------
-# PruneValueCols
+# PruneValuesCols
 # --------------------------------------------------
 
 # Discard all but first Values column.
-opt
+opt expect=PruneValuesCols
 SELECT column1 FROM (VALUES (1, 2), (3, 4)) a
 ----
 values
@@ -1427,7 +1431,7 @@ values
  └── (3,) [type=tuple{int}]
 
 # Discard all but middle Values column.
-opt
+opt expect=PruneValuesCols
 SELECT column2 FROM (VALUES (1, 2, 3), (4, 5, 6)) a
 ----
 values
@@ -1437,7 +1441,7 @@ values
  └── (5,) [type=tuple{int}]
 
 # Discard all but last Values column.
-opt
+opt expect=PruneValuesCols
 SELECT column3 FROM (VALUES ('foo', 'bar', 'baz'), ('apple', 'banana', 'cherry')) a
 ----
 values
@@ -1447,7 +1451,7 @@ values
  └── ('cherry',) [type=tuple{string}]
 
 # Discard all Values columns.
-opt
+opt expect=PruneValuesCols
 SELECT 1 r FROM (VALUES ('foo', 'bar', 'baz'), ('apple', 'banana', 'cherry')) a
 ----
 project
@@ -1527,7 +1531,7 @@ project
 # --------------------------------------------------
 # PruneRowNumberCols
 # --------------------------------------------------
-opt
+opt expect=PruneRowNumberCols
 SELECT i, s FROM a WITH ORDINALITY
 ----
 project
@@ -1540,7 +1544,7 @@ project
            └── columns: i:2(int) s:4(string)
 
 # With order by.
-opt
+opt expect=PruneRowNumberCols
 SELECT i, s FROM (SELECT * FROM a ORDER BY f) WITH ORDINALITY
 ----
 project
@@ -1558,7 +1562,7 @@ project
 # --------------------------------------------------
 # PruneExplainCols
 # --------------------------------------------------
-opt
+opt expect=PruneExplainCols
 EXPLAIN SELECT a FROM abcde WHERE b=1 AND c IS NOT NULL ORDER BY c, d
 ----
 explain

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -31,7 +31,7 @@ TABLE uv
 # RejectNullsLeftJoin + RejectNullsRightJoin
 # ----------------------------------------------------------
 
-opt
+opt expect=RejectNullsRightJoin
 SELECT * FROM a FULL JOIN xy ON true WHERE a.k IS NOT NULL
 ----
 left-join
@@ -48,7 +48,7 @@ left-join
  │    └── fd: (5)-->(6)
  └── true [type=bool]
 
-opt
+opt expect=RejectNullsLeftJoin
 SELECT * FROM a FULL JOIN xy ON true WHERE xy.x > 5
 ----
 right-join
@@ -67,7 +67,7 @@ right-join
  └── true [type=bool]
 
 # Inner-join operator.
-opt
+opt expect=RejectNullsLeftJoin
 SELECT *
 FROM (SELECT * FROM a LEFT JOIN uv ON True) AS l
 INNER JOIN (SELECT * FROM a LEFT JOIN uv ON True) AS r
@@ -114,7 +114,7 @@ inner-join
  └── true [type=bool]
 
 # Left-join operator.
-opt
+opt expect=RejectNullsLeftJoin
 SELECT * FROM a LEFT JOIN xy ON true WHERE xy.x = a.k
 ----
 inner-join (merge)
@@ -138,7 +138,7 @@ inner-join (merge)
            └── x = k [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
 
 # Right-join operator.
-opt
+opt expect=RejectNullsRightJoin
 SELECT * FROM a RIGHT JOIN xy ON true WHERE a.k > xy.y
 ----
 inner-join
@@ -157,7 +157,7 @@ inner-join
       └── k > y [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Full-join operator.
-opt
+opt expect=(RejectNullsLeftJoin,RejectNullsRightJoin)
 SELECT * FROM a FULL JOIN xy ON true WHERE a.k IS NOT NULL AND xy.x > 5
 ----
 inner-join
@@ -176,7 +176,7 @@ inner-join
  └── true [type=bool]
 
 # Apply operators.
-opt
+opt expect=(RejectNullsLeftJoin,RejectNullsRightJoin)
 SELECT *
 FROM (SELECT * FROM a FULL JOIN xy ON True)
 WHERE (SELECT u FROM uv WHERE v=k)=i
@@ -231,7 +231,7 @@ right-join
 # ----------------------------------------------------------
 
 # Single max aggregate function.
-opt
+opt expect=RejectNullsGroupBy
 SELECT max(x)
 FROM (SELECT k FROM a)
 LEFT JOIN (SELECT x FROM xy)
@@ -268,7 +268,7 @@ project
            └── max = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight)]
 
 # Single max aggregate function without grouping columns.
-opt
+opt expect=RejectNullsGroupBy
 SELECT max(x)
 FROM (SELECT k FROM a)
 LEFT JOIN (SELECT x FROM xy)
@@ -299,7 +299,7 @@ select
       └── max = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight)]
 
 # Multiple aggregate functions on same column.
-opt
+opt expect=RejectNullsGroupBy
 SELECT min(x), max(x)
 FROM a
 LEFT JOIN xy
@@ -338,7 +338,7 @@ project
            └── min = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight)]
 
 # Ignore ConstAgg aggregates on other columns.
-opt
+opt expect=RejectNullsGroupBy
 SELECT * FROM a WHERE (SELECT sum(x) FROM xy WHERE x=k)>i
 ----
 project
@@ -385,7 +385,7 @@ project
            └── i < sum [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
 
 # Don't reject nulls when multiple columns are used.
-opt
+opt expect-not=RejectNullsGroupBy
 SELECT min(x), max(y)
 FROM (select k from a)
 LEFT JOIN (select x, y from xy)
@@ -427,7 +427,7 @@ project
 
 # Don't reject column when count function is used (it doesn't return nil when
 # input is empty).
-opt
+opt expect-not=RejectNullsGroupBy
 SELECT count(x)
 FROM (SELECT k FROM a)
 LEFT JOIN (SELECT x FROM xy)
@@ -464,7 +464,7 @@ project
            └── count = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight)]
 
 # ConstNotNullAgg rejects nulls (regression test for #28810).
-norm
+opt expect=RejectNullsGroupBy
 SELECT 1 FROM a AS ref_0 LEFT JOIN a AS ref_1 ON EXISTS(SELECT 1 FROM a WHERE a.s = ref_0.s)
 ----
 project

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -17,7 +17,7 @@ TABLE a
 
 # Put variables on both sides of comparison operator to avoid matching constant
 # patterns.
-opt
+opt expect=CommuteVar
 SELECT
     (1+i) = k AS r,
     (2-k) <> i AS s,
@@ -51,7 +51,7 @@ project
 # --------------------------------------------------
 # CommuteConst
 # --------------------------------------------------
-opt
+opt expect=CommuteConst
 SELECT
     (length('foo')+1) = (i+k) AS r,
     length('bar') <> (i*2) AS s,
@@ -85,7 +85,7 @@ project
 # --------------------------------------------------
 # EliminateCoalesce
 # --------------------------------------------------
-opt
+opt expect=EliminateCoalesce
 SELECT COALESCE(i) FROM a
 ----
 project
@@ -95,10 +95,7 @@ project
  └── projections [outer=(2)]
       └── variable: i [type=int, outer=(2)]
 
-# --------------------------------------------------
-# SimplifyCoalesce
-# --------------------------------------------------
-opt
+opt expect=EliminateCoalesce
 SELECT COALESCE(NULL) FROM a
 ----
 project
@@ -108,7 +105,11 @@ project
  └── projections
       └── null [type=unknown]
 
-opt
+# --------------------------------------------------
+# SimplifyCoalesce
+# --------------------------------------------------
+
+opt expect=SimplifyCoalesce
 SELECT COALESCE(NULL, 'foo', s) FROM a
 ----
 project
@@ -118,7 +119,7 @@ project
  └── projections
       └── const: 'foo' [type=string]
 
-opt
+opt expect=SimplifyCoalesce
 SELECT COALESCE(NULL, NULL, s, s || 'foo') FROM a
 ----
 project
@@ -142,7 +143,7 @@ project
 # --------------------------------------------------
 # EliminateCast
 # --------------------------------------------------
-opt
+opt expect=EliminateCast
 SELECT
     i::int, arr::int[], '[1, 2]'::jsonb::json, null::char(2)::bit, s::string::string
 FROM a
@@ -190,7 +191,7 @@ project
 # --------------------------------------------------
 # FoldNullCast
 # --------------------------------------------------
-opt
+opt expect=FoldNullCast
 SELECT
     null::int,
     null::timestamptz,
@@ -217,7 +218,7 @@ project
 # --------------------------------------------------
 # FoldNullUnary
 # --------------------------------------------------
-opt
+opt expect=FoldNullUnary
 SELECT +null::int AS r, -null::int AS s, ~null::int AS t FROM a
 ----
 project
@@ -232,7 +233,7 @@ project
 # --------------------------------------------------
 # FoldNullBinaryLeft, FoldNullBinaryRight
 # --------------------------------------------------
-opt
+opt expect=(FoldNullBinaryLeft,FoldNullBinaryRight)
 SELECT
     null::int & 1 AS ra, 1 & null::int AS rb,
     null::decimal + 1 AS sa, 1 + null::decimal AS sb,
@@ -294,7 +295,7 @@ project
 # --------------------------------------------------
 # FoldNullInNonEmpty
 # --------------------------------------------------
-opt
+opt expect=FoldNullInNonEmpty
 SELECT null IN (i) AS r, null NOT IN (s) AS s FROM a
 ----
 project
@@ -308,7 +309,7 @@ project
 # --------------------------------------------------
 # FoldInNull
 # --------------------------------------------------
-opt
+opt expect=FoldInNull
 SELECT i IN (null, null) AS r, k NOT IN (1 * null, null::int, 1 < null) AS s FROM a
 ----
 project
@@ -322,7 +323,7 @@ project
 # --------------------------------------------------
 # NormalizeInConst
 # --------------------------------------------------
-opt
+opt expect=NormalizeInConst
 SELECT i IN (2, 1, 1, null, 3, null, 2, 3.0) AS r FROM a
 ----
 project
@@ -332,7 +333,7 @@ project
  └── projections [outer=(2)]
       └── i IN (NULL, 1, 2, 3) [type=bool, outer=(2)]
 
-opt
+opt expect=NormalizeInConst
 SELECT s NOT IN ('foo', s || 'foo', 'bar', length(s)::string, NULL) AS r FROM a
 ----
 project
@@ -345,7 +346,7 @@ project
 # --------------------------------------------------
 # EliminateExistsProject
 # --------------------------------------------------
-opt
+opt expect=EliminateExistsProject
 SELECT * FROM a WHERE EXISTS(SELECT i+1, i*k FROM a)
 ----
 select
@@ -368,7 +369,7 @@ select
 # --------------------------------------------------
 
 # Scalar group by shouldn't get eliminated.
-opt
+opt expect-not=EliminateExistsGroupBy
 SELECT * FROM a WHERE EXISTS(SELECT max(s) FROM a WHERE False)
 ----
 select
@@ -395,7 +396,7 @@ select
                      └── max [type=string, outer=(10)]
                           └── variable: a.s [type=string, outer=(10)]
 
-opt
+opt expect=EliminateExistsGroupBy
 SELECT * FROM a WHERE EXISTS(SELECT DISTINCT s FROM a)
 ----
 select
@@ -411,7 +412,7 @@ select
            └── scan a
                 └── columns: a.s:10(string)
 
-opt
+opt expect=EliminateExistsGroupBy
 SELECT * FROM a WHERE EXISTS(SELECT DISTINCT ON (i) s FROM a)
 ----
 select
@@ -430,7 +431,7 @@ select
 # --------------------------------------------------
 # EliminateExistsGroupBy + EliminateExistsProject
 # --------------------------------------------------
-opt
+opt expect=(EliminateExistsGroupBy,EliminateExistsProject)
 SELECT * FROM a WHERE EXISTS(SELECT max(s) FROM a GROUP BY i)
 ----
 select
@@ -449,7 +450,7 @@ select
 # --------------------------------------------------
 # NormalizeJSONFieldAccess
 # --------------------------------------------------
-opt
+opt expect=NormalizeJSONFieldAccess
 SELECT * FROM a WHERE j->'a' = '"b"'::JSON
 ----
 select
@@ -463,21 +464,7 @@ select
  └── filters [type=bool, outer=(5)]
       └── j @> '{"a": "b"}' [type=bool, outer=(5)]
 
-opt
-SELECT * FROM a WHERE j->'a' @> '{"x": "b"}'::JSON
-----
-select
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
- ├── key: (1)
- ├── fd: (1)-->(2-6)
- ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
- │    ├── key: (1)
- │    └── fd: (1)-->(2-6)
- └── filters [type=bool, outer=(5)]
-      └── j @> '{"a": {"x": "b"}}' [type=bool, outer=(5)]
-
-opt
+opt expect=NormalizeJSONFieldAccess
 SELECT * FROM a WHERE j->'a'->'x' = '"b"'::JSON
 ----
 select
@@ -492,7 +479,7 @@ select
       └── j @> '{"a": {"x": "b"}}' [type=bool, outer=(5)]
 
 # The transformation is not valid in this case.
-opt
+opt expect-not=NormalizeJSONFieldAccess
 SELECT * FROM a WHERE j->2 = '"b"'::JSON
 ----
 select
@@ -507,7 +494,7 @@ select
       └── (j->2) = '"b"' [type=bool, outer=(5)]
 
 # The transformation is not valid in this case, since j->'a' could be an array.
-opt
+opt expect-not=NormalizeJSONFieldAccess
 SELECT * FROM a WHERE j->'a' @> '"b"'::JSON
 ----
 select
@@ -520,3 +507,21 @@ select
  │    └── fd: (1)-->(2-6)
  └── filters [type=bool, outer=(5)]
       └── (j->'a') @> '"b"' [type=bool, outer=(5)]
+
+# --------------------------------------------------
+# NormalizeJSONContains
+# --------------------------------------------------
+
+opt expect=NormalizeJSONContains
+SELECT * FROM a WHERE j->'a' @> '{"x": "b"}'::JSON
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
+ ├── key: (1)
+ ├── fd: (1)-->(2-6)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
+ └── filters [type=bool, outer=(5)]
+      └── j @> '{"a": {"x": "b"}}' [type=bool, outer=(5)]

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -29,58 +29,9 @@ TABLE uv
       └── u int not null
 
 # --------------------------------------------------
-# EnsureSelectFilters
-# --------------------------------------------------
-opt
-SELECT * FROM a WHERE i<5
-----
-select
- ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
- ├── key: (1)
- ├── fd: (1)-->(2-5)
- ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
- └── filters [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
-      └── i < 5 [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
-
-opt
-SELECT * FROM a WHERE i<5 OR s='foo'
-----
-select
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── key: (1)
- ├── fd: (1)-->(2-5)
- ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
- └── filters [type=bool, outer=(2,4)]
-      └── (i < 5) OR (s = 'foo') [type=bool, outer=(2,4)]
-
-# Don't use Filters for True or False condition.
-opt
-SELECT * FROM a WHERE True
-----
-scan a
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── key: (1)
- └── fd: (1)-->(2-5)
-
-opt
-SELECT * FROM a WHERE False
-----
-values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-5)
-
-# --------------------------------------------------
 # EliminateSelect
 # --------------------------------------------------
-opt
+opt expect=EliminateSelect
 SELECT * FROM a WHERE True
 ----
 scan a
@@ -91,41 +42,7 @@ scan a
 # --------------------------------------------------
 # MergeSelects
 # --------------------------------------------------
-opt
-SELECT * FROM (SELECT * FROM a WHERE False) WHERE s='foo'
-----
-select
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string!null) j:5(jsonb)
- ├── cardinality: [0 - 0]
- ├── key: ()
- ├── fd: ()-->(1-5)
- ├── values
- │    ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── cardinality: [0 - 0]
- │    ├── key: ()
- │    └── fd: ()-->(1-5)
- └── filters [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
-      └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
-
-opt
-SELECT * FROM (SELECT * FROM a WHERE i=1) WHERE False
-----
-values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-5)
-
-opt
-SELECT * FROM (SELECT * FROM a WHERE i=1) WHERE False
-----
-values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-5)
-
-opt
+opt expect=MergeSelects
 SELECT * FROM (SELECT * FROM a WHERE i<5) WHERE s='foo'
 ----
 select
@@ -140,7 +57,7 @@ select
       ├── i < 5 [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
       └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
 
-opt
+opt expect=MergeSelects
 SELECT * FROM (SELECT * FROM a WHERE i>1 AND i<10) WHERE s='foo' OR k=5
 ----
 select
@@ -159,7 +76,7 @@ select
 # --------------------------------------------------
 # PushSelectIntoProject
 # --------------------------------------------------
-opt
+opt expect=PushSelectIntoProject
 SELECT * FROM (SELECT i, i+1 AS r, f FROM a) a WHERE f=10.0
 ----
 project
@@ -176,7 +93,7 @@ project
       └── i + 1 [type=int, outer=(2)]
 
 # Don't push down select if it depends on computed column that can't be inlined.
-opt
+opt expect-not=PushSelectIntoProject
 SELECT * FROM (SELECT i, i/2 div, f FROM a) a WHERE div=2
 ----
 select
@@ -194,7 +111,7 @@ select
       └── div = 2 [type=bool, outer=(6), constraints=(/6: [/2 - /2]; tight)]
 
 # Push down some conjuncts, but not others.
-opt
+opt expect=PushSelectIntoProject
 SELECT * FROM (SELECT i, i/2 div, f FROM a) a WHERE 10.0=f AND 2=div AND i=1
 ----
 select
@@ -249,7 +166,7 @@ project
 # --------------------------------------------------
 
 # Only the filters bound by the left side are mapped and pushed down.
-opt
+opt expect=PushSelectCondLeftIntoJoinLeftAndRight
 SELECT * FROM a LEFT JOIN xy ON a.k=xy.x WHERE a.k > 5 AND (xy.x = 6 OR xy.x IS NULL)
 ----
 select
@@ -280,7 +197,7 @@ select
  └── filters [type=bool, outer=(6)]
       └── (x = 6) OR (x IS NULL) [type=bool, outer=(6)]
 
-opt
+opt expect=PushSelectCondLeftIntoJoinLeftAndRight
 SELECT * FROM a WHERE EXISTS (SELECT * FROM xy WHERE a.k=xy.x) AND a.k > 5
 ----
 semi-join (merge)
@@ -305,7 +222,7 @@ semi-join (merge)
       └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
            └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
-opt
+opt expect=PushSelectCondLeftIntoJoinLeftAndRight
 SELECT * FROM a WHERE NOT EXISTS (SELECT * FROM xy WHERE a.k=xy.x) AND a.k > 5
 ----
 anti-join (merge)
@@ -331,7 +248,7 @@ anti-join (merge)
            └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Only the filters bound by the right side are mapped and pushed down.
-opt
+opt expect=PushSelectCondRightIntoJoinLeftAndRight
 SELECT * FROM a RIGHT JOIN xy ON a.k=xy.x AND a.i=xy.y
 WHERE xy.x + xy.y > 5 AND (xy.x + a.i = 6 OR xy.x IS NULL) AND (xy.y % 2 = 0) AND xy.x >= 10
 ----
@@ -368,14 +285,14 @@ select
 # --------------------------------------------------
 # PushSelectIntoJoinLeft
 # --------------------------------------------------
-opt
-SELECT * FROM a INNER JOIN xy ON a.k=xy.x WHERE a.f=1.1
+opt expect=PushSelectIntoJoinLeft
+SELECT * FROM a LEFT JOIN xy ON a.k=xy.x WHERE a.f=1.1
 ----
-inner-join (lookup xy)
- ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+left-join (lookup xy)
+ ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int) y:7(int)
  ├── key columns: [1] = [6]
- ├── key: (6)
- ├── fd: ()-->(3), (1)-->(2,4,5), (6)-->(7), (1)==(6), (6)==(1)
+ ├── key: (1,6)
+ ├── fd: ()-->(3), (1)-->(2,4,5), (6)-->(7)
  ├── select
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
@@ -389,7 +306,7 @@ inner-join (lookup xy)
  └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
-opt
+opt expect=PushSelectIntoJoinLeft
 SELECT * FROM a LEFT JOIN xy ON a.k=xy.x
 WHERE a.f=1.1 AND (a.i<xy.y OR xy.y IS NULL) AND (a.s='foo' OR a.s='bar')
 ----
@@ -419,25 +336,14 @@ select
       └── (i < y) OR (y IS NULL) [type=bool, outer=(2,7)]
 
 # Pushdown constant condition.
-opt
-SELECT * FROM a INNER JOIN xy ON True WHERE a.i=100 AND $1>'2000-01-01T1:00:00'
+norm expect=PushSelectIntoJoinLeft
+SELECT * FROM a LEFT JOIN xy ON True WHERE a.i=100 AND $1>'2000-01-01T1:00:00'
 ----
-inner-join
- ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+left-join
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
  ├── has-placeholder
  ├── key: (1,6)
  ├── fd: ()-->(2), (1)-->(3-5), (6)-->(7)
- ├── select
- │    ├── columns: x:6(int!null) y:7(int)
- │    ├── has-placeholder
- │    ├── key: (6)
- │    ├── fd: (6)-->(7)
- │    ├── scan xy
- │    │    ├── columns: x:6(int!null) y:7(int)
- │    │    ├── key: (6)
- │    │    └── fd: (6)-->(7)
- │    └── filters [type=bool]
- │         └── $1 > '2000-01-01T1:00:00' [type=bool]
  ├── select
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
  │    ├── has-placeholder
@@ -450,6 +356,17 @@ inner-join
  │    └── filters [type=bool, outer=(2), constraints=(/2: [/100 - /100]), fd=()-->(2)]
  │         ├── $1 > '2000-01-01T1:00:00' [type=bool]
  │         └── i = 100 [type=bool, outer=(2), constraints=(/2: [/100 - /100]; tight)]
+ ├── select
+ │    ├── columns: x:6(int!null) y:7(int)
+ │    ├── has-placeholder
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(7)
+ │    ├── scan xy
+ │    │    ├── columns: x:6(int!null) y:7(int)
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7)
+ │    └── filters [type=bool]
+ │         └── $1 > '2000-01-01T1:00:00' [type=bool]
  └── true [type=bool]
 
 # Don't push down conditions in case of RIGHT JOIN.
@@ -513,7 +430,7 @@ select
       └── (i = 100) OR (i IS NULL) [type=bool, outer=(2)]
 
 # Push into semi-join.
-opt
+opt expect=PushSelectIntoJoinLeft
 SELECT * FROM a WHERE EXISTS(SELECT * FROM xy WHERE k=x) AND a.i=0
 ----
 semi-join (merge)
@@ -544,7 +461,7 @@ semi-join (merge)
            └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Push into anti-join.
-opt
+opt expect=PushSelectIntoJoinLeft
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM xy WHERE k=x) AND a.i=0
 ----
 anti-join (merge)
@@ -577,14 +494,14 @@ anti-join (merge)
 # --------------------------------------------------
 # PushSelectIntoJoinRight
 # --------------------------------------------------
-opt
-SELECT * FROM xy INNER JOIN a ON xy.x=a.k WHERE a.f=1.1
+opt expect=PushSelectIntoJoinRight
+SELECT * FROM xy RIGHT JOIN a ON xy.x=a.k WHERE a.f=1.1
 ----
-inner-join (lookup xy)
- ├── columns: x:1(int!null) y:2(int) k:3(int!null) i:4(int) f:5(float!null) s:6(string) j:7(jsonb)
+left-join (lookup xy)
+ ├── columns: x:1(int) y:2(int) k:3(int!null) i:4(int) f:5(float!null) s:6(string) j:7(jsonb)
  ├── key columns: [3] = [1]
- ├── key: (3)
- ├── fd: ()-->(5), (1)-->(2), (3)-->(4,6,7), (1)==(3), (3)==(1)
+ ├── key: (1,3)
+ ├── fd: ()-->(5), (1)-->(2), (3)-->(4,6,7)
  ├── select
  │    ├── columns: k:3(int!null) i:4(int) f:5(float!null) s:6(string) j:7(jsonb)
  │    ├── key: (3)
@@ -598,7 +515,7 @@ inner-join (lookup xy)
  └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
       └── x = k [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
 
-opt
+opt expect=PushSelectIntoJoinRight
 SELECT * FROM xy RIGHT JOIN a ON xy.x=a.k
 WHERE a.f=1.1 AND (a.i<xy.y OR xy.y IS NULL) AND (a.s='foo' OR a.s='bar')
 ----
@@ -690,7 +607,7 @@ select
 # --------------------------------------------------
 # MergeSelectInnerJoin
 # --------------------------------------------------
-opt
+opt expect=MergeSelectInnerJoin
 SELECT * FROM a, xy WHERE a.k=xy.x AND (a.s='foo' OR xy.y<100)
 ----
 inner-join (merge)
@@ -714,7 +631,7 @@ inner-join (merge)
            ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
            └── (s = 'foo') OR (y < 100) [type=bool, outer=(4,7)]
 
-opt
+opt expect=MergeSelectInnerJoin
 SELECT * FROM a INNER JOIN xy ON a.k=xy.x WHERE (a.s='foo' OR xy.y<100)
 ----
 inner-join (merge)
@@ -738,7 +655,7 @@ inner-join (merge)
            ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
            └── (s = 'foo') OR (y < 100) [type=bool, outer=(4,7)]
 
-opt
+opt expect=MergeSelectInnerJoin
 SELECT * FROM a INNER JOIN xy ON a.k=xy.x WHERE False
 ----
 inner-join
@@ -757,7 +674,7 @@ inner-join
  └── false [type=bool]
 
 # Don't merge with LEFT JOIN.
-opt
+opt expect-not=MergeSelectInnerJoin
 SELECT * FROM a LEFT JOIN xy ON True WHERE a.k=xy.x OR xy.x IS NULL
 ----
 select
@@ -781,7 +698,7 @@ select
       └── (k = x) OR (x IS NULL) [type=bool, outer=(1,6)]
 
 # Don't merge with RIGHT JOIN.
-opt
+opt expect-not=MergeSelectInnerJoin
 SELECT * FROM a RIGHT JOIN xy ON True WHERE a.k=xy.x OR a.k IS NULL
 ----
 select
@@ -805,7 +722,7 @@ select
       └── (k = x) OR (k IS NULL) [type=bool, outer=(1,6)]
 
 # Don't merge with FULL JOIN.
-opt
+opt expect-not=MergeSelectInnerJoin
 SELECT * FROM a FULL JOIN xy ON True WHERE a.k=xy.x OR a.k IS NULL OR xy.x IS NULL
 ----
 select
@@ -885,7 +802,7 @@ inner-join (lookup xy)
 # --------------------------------------------------
 
 # Push down into GroupBy with aggregations.
-opt
+opt expect=PushSelectIntoGroupBy
 SELECT * FROM (SELECT i, count(*) FROM a GROUP BY i) a WHERE i=1
 ----
 group-by
@@ -906,7 +823,7 @@ group-by
            └── variable: i [type=int, outer=(2)]
 
 # Push down into GroupBy with no aggregations.
-opt
+opt expect=PushSelectIntoGroupBy
 SELECT * FROM (SELECT i FROM a GROUP BY i) a WHERE i=1
 ----
 distinct-on
@@ -926,7 +843,7 @@ distinct-on
            └── variable: i [type=int, outer=(2)]
 
 # Push down only conditions that do not depend on aggregations.
-opt
+opt expect=PushSelectIntoGroupBy
 SELECT * FROM (SELECT k, i, max(s) m FROM a GROUP BY k, i) a WHERE i=k AND m='foo'
 ----
 select
@@ -957,7 +874,7 @@ select
       └── max = 'foo' [type=bool, outer=(6), constraints=(/6: [/'foo' - /'foo']; tight)]
 
 # DistinctOn case.
-opt
+opt expect=PushSelectIntoGroupBy
 SELECT * FROM (SELECT DISTINCT ON (i, f) i, s, f FROM a) WHERE i>f
 ----
 distinct-on
@@ -976,7 +893,7 @@ distinct-on
            └── variable: s [type=string, outer=(4)]
 
 # DistinctOn case with a ConstAgg.
-opt
+opt expect=PushSelectIntoGroupBy
 SELECT * FROM (SELECT DISTINCT ON (k, f, s) k, i, f, x FROM a JOIN xy ON i=y) WHERE k > f
 ----
 distinct-on
@@ -1013,7 +930,7 @@ distinct-on
            └── variable: f [type=float, outer=(3)]
 
 # Do *not* push down into scalar GroupBy.
-opt
+opt expect-not=PushSelectIntoGroupBy
 SELECT * FROM (SELECT count(*) c FROM a) a WHERE $1<'2000-01-01T10:00:00' AND c=0
 ----
 select
@@ -1049,7 +966,7 @@ TABLE b
  └── INDEX primary
       └── k int not null
 
-opt
+opt expect=RemoveNotNullCondition
 SELECT k FROM b WHERE k IS NOT NULL AND k > 4
 ----
 scan b
@@ -1067,7 +984,7 @@ scan b
  ├── key: ()
  └── fd: ()-->(1)
 
-opt
+opt expect=RemoveNotNullCondition
 SELECT k,i FROM b WHERE k IS NOT NULL AND k > 4 AND i < 100 AND i IS NOT NULL
 ----
 select
@@ -1083,7 +1000,7 @@ select
       ├── i < 100 [type=bool, outer=(2), constraints=(/2: (/NULL - /99]; tight)]
       └── i IS NOT NULL [type=bool, outer=(2), constraints=(/2: (/NULL - ]; tight)]
 
-opt
+opt expect=RemoveNotNullCondition
 SELECT k,s FROM b WHERE k IS NOT NULL AND s IS NOT NULL
 ----
 scan b
@@ -1092,7 +1009,7 @@ scan b
  └── fd: (1)-->(4)
 
 # RemoveNotNullCondition partially applied
-opt
+opt expect=RemoveNotNullCondition
 SELECT k,s,i FROM b WHERE k IS NOT NULL AND s IS NOT NULL AND i IS NOT NULL
 ----
 select
@@ -1107,7 +1024,7 @@ select
       └── i IS NOT NULL [type=bool, outer=(2), constraints=(/2: (/NULL - ]; tight)]
 
 # RemoveNotNullCondition rule is not applied
-opt
+opt expect-not=RemoveNotNullCondition
 SELECT i FROM b WHERE i IS NOT NULL
 ----
 select
@@ -1118,7 +1035,7 @@ select
       └── i IS NOT NULL [type=bool, outer=(2), constraints=(/2: (/NULL - ]; tight)]
 
 # RemoveNotNullCondition rule is not applied
-opt
+opt expect-not=RemoveNotNullCondition
 SELECT k FROM b WHERE i+k IS NOT NULL
 ----
 project
@@ -1139,7 +1056,7 @@ project
 # DetectSelectContradiction
 # --------------------------------------------------
 
-opt
+opt expect=DetectSelectContradiction
 SELECT k FROM b WHERE false
 ----
 values
@@ -1148,7 +1065,7 @@ values
  ├── key: ()
  └── fd: ()-->(1)
 
-opt
+opt expect=DetectSelectContradiction
 SELECT k FROM b WHERE i > 2 AND i < 1
 ----
 values
@@ -1161,7 +1078,7 @@ values
 # EliminateUnionAllLeft
 # --------------------------------------------------
 
-opt
+opt expect=EliminateUnionAllLeft
 SELECT k FROM
   (SELECT k FROM b)
   UNION ALL
@@ -1179,7 +1096,7 @@ project
 # EliminateUnionAllRight
 # --------------------------------------------------
 
-opt
+opt expect=EliminateUnionAllRight
 SELECT k FROM
   (SELECT k FROM b WHERE i < 4 AND i > 10)
   UNION ALL
@@ -1193,7 +1110,7 @@ project
  └── projections [outer=(6)]
       └── variable: b.k [type=int, outer=(6)]
 
-opt
+opt 
 SELECT k FROM
   (SELECT k FROM b WHERE i < 4 AND i > 10)
   UNION ALL
@@ -1211,3 +1128,28 @@ project
  │    └── fd: ()-->(1)
  └── projections [outer=(1)]
       └── variable: b.k [type=int, outer=(1)]
+
+opt expect=DetectSelectContradiction
+SELECT * FROM (SELECT * FROM a WHERE i=1) WHERE False
+----
+values
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
+opt expect=DetectSelectContradiction
+SELECT * FROM (SELECT * FROM a WHERE False) WHERE s='foo'
+----
+select
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string!null) j:5(jsonb)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ ├── values
+ │    ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── cardinality: [0 - 0]
+ │    ├── key: ()
+ │    └── fd: ()-->(1-5)
+ └── filters [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+      └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]


### PR DESCRIPTION
This commit adds assertions that the rules norm tests claim to be
testing actually do test them. There's a couple cases where there was an
easy fix to fix a rule that wasn't actually tested, and some were less
clear and so I added a TODO.

Release note: None.