### PR TITLE
backport-2.1: storage: denoise an epoch increment message

### DIFF
--- a/pkg/storage/replica_range_lease.go
+++ b/pkg/storage/replica_range_lease.go
@@ -289,7 +289,9 @@ func (p *pendingLeaseRequest) requestLeaseAsync(
 					if live, liveErr := p.repl.store.cfg.NodeLiveness.IsLive(nextLeaseHolder.NodeID); !live || liveErr != nil {
 						err = errors.Errorf("not incrementing epoch on n%d because next leaseholder (n%d) not live (err = %v)",
 							status.Liveness.NodeID, nextLeaseHolder.NodeID, liveErr)
-						log.Error(ctx, err)
+						if log.V(1) {
+							log.Info(ctx, err)
+						}
 					} else if err = p.repl.store.cfg.NodeLiveness.IncrementEpoch(ctx, status.Liveness); err != nil {
 						log.Error(ctx, err)
 					}


### PR DESCRIPTION
Backport 1/1 commits from #29580.

/cc @cockroachdb/release

---

Release note: None
