### PR TITLE
backport-2.1: sql: fix oid of collated string to match postgres

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1593,3 +1593,13 @@ query OOTT colnames
 SELECT objoid, classoid, provider, label FROM pg_catalog.pg_shseclabel
 ----
 objoid  classoid  provider  label
+
+subtest collated_string_type
+
+statement ok
+CREATE TABLE coltab (a STRING COLLATE en)
+
+query OT
+SELECT typ.oid, typ.typname FROM pg_attribute att JOIN pg_type typ ON atttypid=typ.oid WHERE attrelid='coltab'::regclass AND attname='a'
+----
+25 text

--- a/pkg/sql/sem/types/types.go
+++ b/pkg/sql/sem/types/types.go
@@ -202,7 +202,7 @@ func (TCollatedString) FamilyEqual(other T) bool {
 }
 
 // Oid implements the T interface.
-func (TCollatedString) Oid() oid.Oid { return oid.T_unknown }
+func (TCollatedString) Oid() oid.Oid { return oid.T_text }
 
 // SQLName implements the T interface.
 func (TCollatedString) SQLName() string { return "text" }


### PR DESCRIPTION
Backport 1/1 commits from #29643.

/cc @cockroachdb/release

---

We returned unknown, Postgres returns string.

Release note (bug fix): correct the Postgres type oid returned for
collated string column types.
