### PR TITLE
kv: check transaction status before recording refresh spans

### DIFF
--- a/pkg/kv/txn_interceptor_pipeliner.go
+++ b/pkg/kv/txn_interceptor_pipeliner.go
@@ -163,8 +163,11 @@ func (tp *txnPipeliner) SendLocked(
 		return nil, tp.adjustError(ctx, ba, pErr)
 	}
 
-	// WIP: I think it's possible for this response to be from an earlier
-	// epoch. Fix that.
+	// TODO(nvanbenschoten): It's currently possible for this response to be
+	// from an earlier epoch when txns are used concurrently. That's ok for now
+	// because we always manually restart transactions once all concurrent
+	// operations synchronize. Once we move away from that model to a txnAttempt
+	// model, we'll need to reconsider how this works. It ~should~ just work.
 
 	// Prove any outstanding writes that we proved to exist.
 	br = tp.updateOutstandingWrites(ctx, ba, br)


### PR DESCRIPTION
Fixes #29253.

We previously accounted for refresh spans before checking the
transaction's status. This meant that we would attempt to add new
refresh spans even if the txn had already been committed. If this
attempt failed because the `max_refresh_spans_bytes` threshold was
exceeded, we would erroneously return an error to the client even
though their transaction had already been committed. The simple
fix for this is to only record refresh spans for transactions that
are still PENDING. The new test case would have failed with the
error observed in #29253 without this fix.

This raises an auxiliary question about whether we should be asserting
that a transaction's status is not COMMITTED if we ever return an
error to the client. cc. @andreimatei.

On the positive side, this should be a minor perf win, as we'll
avoid recording refresh spans on the final batch of every txn.

A similar fix will need to be backported to 2.0. The backport
won't be clean though because of the new txnInterceptor structure.
However, the test shouldn't need to change.

Release note (bug fix): Don't return transaction size limit errors
for transactions that have already committed.