### PR TITLE
Makefile: don't symlink during buildshort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -778,11 +778,6 @@ buildshort: $(COCKROACHSHORT)
 build buildoss buildshort: $(DOCGEN_TARGETS)
 build buildshort: $(if $(is-cross-compile),,$(SETTINGS_DOC_PAGE))
 
-# For historical reasons, symlink cockroach to cockroachshort.
-# TODO(benesch): see if it would break anyone's workflow to remove this.
-buildshort:
-	ln -sf $(COCKROACHSHORT) $(COCKROACH)
-
 .PHONY: install
 install: ## Install the CockroachDB binary.
 install: $(COCKROACH)


### PR DESCRIPTION
`make buildshort` currently writes a cockroach -> cockroachshort
to simulate its old behavior of producing a binary named "cockroach."
But it turns out this bandaid is misguided: running `make build` after
running `make buildshort` causes `go build` to follow the symlink and
overwrite the `cockroachshort` binary instead of the `cockroach` binary.

Avoid the bug by not writing the symlink during `make buildshort`.

Release note: None