### PR TITLE
sql: make ShowCreate funcs usable as standalone tools

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1037,14 +1037,14 @@ CREATE TABLE crdb_internal.create_statements (
 				var err error
 				if table.IsView() {
 					descType = typeView
-					stmt, err = p.showCreateView(ctx, (*tree.Name)(&table.Name), table)
+					stmt, err = ShowCreateView(ctx, (*tree.Name)(&table.Name), table)
 				} else if table.IsSequence() {
 					descType = typeSequence
-					stmt, err = p.showCreateSequence(ctx, (*tree.Name)(&table.Name), table)
+					stmt, err = ShowCreateSequence(ctx, (*tree.Name)(&table.Name), table)
 				} else {
 					descType = typeTable
 					tn := (*tree.Name)(&table.Name)
-					createNofk, err = p.showCreateTable(ctx, tn, contextName, table, lCtx, true /* ignoreFKs */)
+					createNofk, err = ShowCreateTable(ctx, tn, contextName, table, lCtx, true /* ignoreFKs */)
 					if err != nil {
 						return err
 					}
@@ -1058,7 +1058,7 @@ CREATE TABLE crdb_internal.create_statements (
 							f.WriteString(" ADD CONSTRAINT ")
 							f.FormatNameP(&fk.Name)
 							f.WriteByte(' ')
-							if err := p.printForeignKeyConstraint(ctx, f.Buffer, contextName, idx, lCtx); err != nil {
+							if err := printForeignKeyConstraint(ctx, f.Buffer, contextName, idx, lCtx); err != nil {
 								return err
 							}
 							if err := alterStmts.Append(tree.NewDString(f.CloseAndGetString())); err != nil {
@@ -1076,7 +1076,7 @@ CREATE TABLE crdb_internal.create_statements (
 							}
 						}
 					}
-					stmt, err = p.showCreateTable(ctx, tn, contextName, table, lCtx, false /* ignoreFKs */)
+					stmt, err = ShowCreateTable(ctx, tn, contextName, table, lCtx, false /* ignoreFKs */)
 				}
 				if err != nil {
 					return err

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -561,7 +561,7 @@ CREATE TABLE pg_catalog.pg_constraint (
 						return err
 					}
 					var buf bytes.Buffer
-					if err := p.printForeignKeyConstraint(ctx, &buf, db.Name, con.Index, tableLookup); err != nil {
+					if err := printForeignKeyConstraint(ctx, &buf, db.Name, con.Index, tableLookup); err != nil {
 						return err
 					}
 					condef = tree.NewDString(buf.String())

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -39,9 +39,9 @@ func (p *planner) ShowCreate(ctx context.Context, n *tree.ShowCreate) (planNode,
 	return p.showTableDetails(ctx, "SHOW CREATE", n.Name, showCreateQuery)
 }
 
-// showCreateView returns a valid SQL representation of the CREATE
+// ShowCreateView returns a valid SQL representation of the CREATE
 // VIEW statement used to create the given view.
-func (p *planner) showCreateView(
+func ShowCreateView(
 	ctx context.Context, tn *tree.Name, desc *sqlbase.TableDescriptor,
 ) (string, error) {
 	f := tree.NewFmtCtxWithBuf(tree.FmtSimple)
@@ -59,7 +59,7 @@ func (p *planner) showCreateView(
 	return f.CloseAndGetString(), nil
 }
 
-func (p *planner) printForeignKeyConstraint(
+func printForeignKeyConstraint(
 	ctx context.Context,
 	buf *bytes.Buffer,
 	dbPrefix string,
@@ -104,9 +104,9 @@ func (p *planner) printForeignKeyConstraint(
 	return nil
 }
 
-// showCreateSequence returns a valid SQL representation of the
+// ShowCreateSequence returns a valid SQL representation of the
 // CREATE SEQUENCE statement used to create the given sequence.
-func (p *planner) showCreateSequence(
+func ShowCreateSequence(
 	ctx context.Context, tn *tree.Name, desc *sqlbase.TableDescriptor,
 ) (string, error) {
 	f := tree.NewFmtCtxWithBuf(tree.FmtSimple)
@@ -123,7 +123,7 @@ func (p *planner) showCreateSequence(
 	return f.CloseAndGetString(), nil
 }
 
-// showCreateTable returns a valid SQL representation of the CREATE
+// ShowCreateTable returns a valid SQL representation of the CREATE
 // TABLE statement used to create the given table.
 //
 // The names of the tables references by foreign keys, and the
@@ -131,7 +131,7 @@ func (p *planner) showCreateSequence(
 // unless it is equal to the given dbPrefix. This allows us to elide
 // the prefix when the given table references other tables in the
 // current database.
-func (p *planner) showCreateTable(
+func ShowCreateTable(
 	ctx context.Context,
 	tn *tree.Name,
 	dbPrefix string,
@@ -171,7 +171,7 @@ func (p *planner) showCreateTable(
 			f.WriteString(",\n\tCONSTRAINT ")
 			f.FormatNameP(&fk.Name)
 			f.WriteString(" ")
-			if err := p.printForeignKeyConstraint(ctx, f.Buffer, dbPrefix, idx, lCtx); err != nil {
+			if err := printForeignKeyConstraint(ctx, f.Buffer, dbPrefix, idx, lCtx); err != nil {
 				return "", err
 			}
 		}
@@ -181,7 +181,7 @@ func (p *planner) showCreateTable(
 			f.WriteString(idx.SQLString(&sqlbase.AnonymousTable))
 			// Showing the INTERLEAVE and PARTITION BY for the primary index are
 			// handled last.
-			if err := p.showCreateInterleave(ctx, idx, f.Buffer, dbPrefix, lCtx); err != nil {
+			if err := showCreateInterleave(ctx, idx, f.Buffer, dbPrefix, lCtx); err != nil {
 				return "", err
 			}
 			if err := ShowCreatePartitioning(
@@ -220,7 +220,7 @@ func (p *planner) showCreateTable(
 
 	f.WriteString("\n)")
 
-	if err := p.showCreateInterleave(ctx, &desc.PrimaryIndex, f.Buffer, dbPrefix, lCtx); err != nil {
+	if err := showCreateInterleave(ctx, &desc.PrimaryIndex, f.Buffer, dbPrefix, lCtx); err != nil {
 		return "", err
 	}
 	if err := ShowCreatePartitioning(
@@ -249,7 +249,7 @@ func formatQuoteNames(buf *bytes.Buffer, names ...string) {
 // The name of the parent table is prefixed by its database name unless
 // it is equal to the given dbPrefix. This allows us to elide the prefix
 // when the given index is interleaved in a table of the current database.
-func (p *planner) showCreateInterleave(
+func showCreateInterleave(
 	ctx context.Context,
 	idx *sqlbase.IndexDescriptor,
 	buf *bytes.Buffer,

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -17,6 +17,7 @@ package sql
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -70,27 +71,37 @@ func printForeignKeyConstraint(
 	if !fk.IsSet() {
 		return nil
 	}
-	fkTable, err := lCtx.getTableByID(fk.Table)
-	if err != nil {
-		return err
+	var refNames []string
+	var fkTableName tree.TableName
+	if lCtx != nil {
+		fkTable, err := lCtx.getTableByID(fk.Table)
+		if err != nil {
+			return err
+		}
+		fkDb, err := lCtx.getDatabaseByID(fkTable.ParentID)
+		if err != nil {
+			return err
+		}
+		fkIdx, err := fkTable.FindIndexByID(fk.Index)
+		if err != nil {
+			return err
+		}
+		refNames = fkIdx.ColumnNames
+		fkTableName = tree.MakeTableName(tree.Name(fkDb.Name), tree.Name(fkTable.Name))
+		fkTableName.ExplicitSchema = fkDb.Name != dbPrefix
+	} else {
+		refNames = []string{"???"}
+		fkTableName = tree.MakeTableName(tree.Name(""), tree.Name(fmt.Sprintf("[%d as ref]", fk.Table)))
+		fkTableName.ExplicitSchema = false
+		fkTableName.ExplicitSchema = false
 	}
-	fkDb, err := lCtx.getDatabaseByID(fkTable.ParentID)
-	if err != nil {
-		return err
-	}
-	fkIdx, err := fkTable.FindIndexByID(fk.Index)
-	if err != nil {
-		return err
-	}
-	fkTableName := tree.MakeTableName(tree.Name(fkDb.Name), tree.Name(fkTable.Name))
-	fkTableName.ExplicitSchema = fkDb.Name != dbPrefix
 	fmtCtx := tree.MakeFmtCtx(buf, tree.FmtSimple)
 	buf.WriteString("FOREIGN KEY (")
 	formatQuoteNames(buf, idx.ColumnNames[0:idx.ForeignKey.SharedPrefixLen]...)
 	buf.WriteString(") REFERENCES ")
 	fmtCtx.FormatNode(&fkTableName)
 	buf.WriteString(" (")
-	formatQuoteNames(buf, fkIdx.ColumnNames...)
+	formatQuoteNames(buf, refNames...)
 	buf.WriteByte(')')
 	idx.ColNamesString()
 	if fk.OnDelete != sqlbase.ForeignKeyReference_NO_ACTION {
@@ -260,16 +271,25 @@ func showCreateInterleave(
 		return nil
 	}
 	intl := idx.Interleave
-	parentTable, err := lCtx.getTableByID(intl.Ancestors[len(intl.Ancestors)-1].TableID)
-	if err != nil {
-		return err
+	parentTableID := intl.Ancestors[len(intl.Ancestors)-1].TableID
+
+	var parentName tree.TableName
+	if lCtx != nil {
+		parentTable, err := lCtx.getTableByID(parentTableID)
+		if err != nil {
+			return err
+		}
+		parentDbDesc, err := lCtx.getDatabaseByID(parentTable.ParentID)
+		if err != nil {
+			return err
+		}
+		parentName = tree.MakeTableName(tree.Name(parentDbDesc.Name), tree.Name(parentTable.Name))
+		parentName.ExplicitSchema = parentDbDesc.Name != dbPrefix
+	} else {
+		parentName = tree.MakeTableName(tree.Name(""), tree.Name(fmt.Sprintf("[%d as parent]", parentTableID)))
+		parentName.ExplicitCatalog = false
+		parentName.ExplicitSchema = false
 	}
-	parentDbDesc, err := lCtx.getDatabaseByID(parentTable.ParentID)
-	if err != nil {
-		return err
-	}
-	parentName := tree.MakeTableName(tree.Name(parentDbDesc.Name), tree.Name(parentTable.Name))
-	parentName.ExplicitSchema = parentDbDesc.Name != dbPrefix
 	var sharedPrefixLen int
 	for _, ancestor := range intl.Ancestors {
 		sharedPrefixLen += int(ancestor.SharedPrefixLen)

--- a/pkg/sql/show_create_test.go
+++ b/pkg/sql/show_create_test.go
@@ -1,0 +1,58 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func eqWhitespace(a, b string) bool {
+	return strings.Replace(a, "\t", "", -1) == strings.Replace(b, "\t", "", -1)
+}
+
+func TestStandAloneShowCreateTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	want := `CREATE TABLE jobs (
+			id INT NOT NULL DEFAULT unique_rowid(),
+			status STRING NOT NULL,
+			created TIMESTAMP NOT NULL DEFAULT now():::TIMESTAMP,
+			payload BYTES NOT NULL,
+			CONSTRAINT "primary" PRIMARY KEY (id ASC),
+			CONSTRAINT fk FOREIGN KEY (status) REFERENCES "[52 as ref]" ("???"),
+			INDEX jobs_status_created_idx (status ASC, created ASC) INTERLEAVE IN PARENT "[51 as parent]" (status),
+			FAMILY fam_0_id_status_created_payload (id, status, created, payload)
+		)`
+
+	desc := sqlbase.JobsTable
+	desc.Indexes = []sqlbase.IndexDescriptor{sqlbase.JobsTable.Indexes[0]}
+	desc.Indexes[0].ForeignKey = sqlbase.ForeignKeyReference{Table: 52, Name: "fk", Index: 1, SharedPrefixLen: 1}
+	desc.Indexes[0].Interleave.Ancestors = []sqlbase.InterleaveDescriptor_Ancestor{{TableID: 51, IndexID: 10, SharedPrefixLen: 1}}
+
+	name := tree.Name(desc.Name)
+	got, err := ShowCreateTable(context.TODO(), &name, "", &desc, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !eqWhitespace(got, want) {
+		t.Fatalf("%s, want %s", got, want)
+	}
+}


### PR DESCRIPTION
These didn't actually use the planner of which they were methods anyway so it is easy to promote them to standalone methods.
Doing so and exporting them to start on a 'given a table desc, show me the schema it represents' tool.

Passing a nil lookup helper prints just what is in the descriptor itself, making these functions useful as standalone tools for printing a descriptor, regardless of where it came from.
