### PR TITLE
teamcity-stress: fix an unbound variable error

### DIFF
--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -17,6 +17,7 @@ env=(
   "PKG=$PKG"
   "GOFLAGS=${GOFLAGS:-}"
   "TAGS=${TAGS:-}"
+  "STRESSFLAGS=${STRESSFLAGS:-}"
 )
 
 build/builder.sh env "${env[@]}" bash <<'EOF'


### PR DESCRIPTION
I accidentally introduced this in 7869a313.

Release note: None