### PR TITLE
githooks: fix the commit message pre-fill

### DIFF
--- a/githooks/prepare-commit-msg
+++ b/githooks/prepare-commit-msg
@@ -2,6 +2,12 @@
 #
 # Prepare the commit message by adding a release note.
 
+if test "$2" = "message"; then
+    # This git command is non-interactive, and will not filter out the
+    # comments out so there is nothing for us to do here.
+    exit 0
+fi
+
 oldmain=$(cat "$1"|grep -v '^#')
 oldcomm=$(cat "$1"|grep '^#' | sed -ne '/^# Changes to be committed/{q;};p')
 


### PR DESCRIPTION
This should not run when the git command is non-interactive,
because in that case git will not filter comments in the git
message automatically.

Thanks to @andy-kimball for noticing this.

Release note: None