### PR TITLE
teamcity-trigger: queue builds for the current branch only

### DIFF
--- a/pkg/cmd/teamcity-trigger/main_test.go
+++ b/pkg/cmd/teamcity-trigger/main_test.go
@@ -21,11 +21,8 @@ import (
 
 func TestRunTC(t *testing.T) {
 	count := 0
-	runTC([]string{"master"}, func(buildID, branch string, opts map[string]string) {
+	runTC(func(buildID string, opts map[string]string) {
 		count++
-		if branch != "master" {
-			t.Errorf("unexpected branch %q", branch)
-		}
 		if pkg, ok := opts["env.PKG"]; ok {
 			if strings.Contains(pkg, "/vendor/") {
 				t.Errorf("unexpected package %s", pkg)


### PR DESCRIPTION
teamcity-trigger was previously capable of triggering a stress build
for every package on every specified branch. This proved to be
problematic. When a package exists on master but not on a release
branch, for example, teamcity-trigger will trigger a stress build on
that release branch that is guaranteed to fail.

Adjust teamcity-trigger to only trigger builds for the current branch.
The TeamCity build configuration will be adjusted to run
a teamcity-trigger job on every release branch, instead of just one job
on master.

Fix #29980.
Fix #29981.

Release note: None