### PR TITLE
release-2.1: kv: prevent a leaf TCS from returning HandledRetryableError

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -720,6 +720,11 @@ func (tc *TxnCoordSender) maybeRejectClientLocked(
 	if tc.mu.txn.Status == roachpb.ABORTED {
 		abortedErr := roachpb.NewErrorWithTxn(
 			roachpb.NewTransactionAbortedError(roachpb.ABORT_REASON_CLIENT_REJECT), &tc.mu.txn)
+		if tc.typ == client.LeafTxn {
+			// Leaf txns return raw retriable errors (which get handled by the
+			// root) rather than HandledRetryableTxnError.
+			return abortedErr
+		}
 		newTxn := roachpb.PrepareTransactionForRetry(
 			ctx, abortedErr,
 			// priority is not used for aborted errors

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -2484,3 +2484,38 @@ func TestCommitTurnedToRollback(t *testing.T) {
 		t.Fatalf("didn't find trace message: %s", turningCommitToRollbackMsg)
 	}
 }
+
+// Test that a leaf txn returns a raw error when "rejecting a client" (a client
+// sending something after the txn is known to be aborted), not a
+// HandledRetryableError. This is important as leaves are not supposed to create
+// "handled" errors; instead the DistSQL infra knows to recognize raw retryable
+// errors and feed them to the root txn.
+func TestLeafTxnClientRejectError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s := createTestDB(t)
+	defer s.Stop()
+
+	ctx := context.Background()
+	rootTxn := client.NewTxn(ctx, s.DB, 0 /* gatewayNodeID */, client.RootTxn)
+
+	// New create a second, leaf coordinator.
+	leafTxn := client.NewTxnWithCoordMeta(
+		ctx, s.DB, 0 /* gatewayNodeID */, client.LeafTxn, rootTxn.GetTxnCoordMeta(ctx))
+
+	// Poison the leaf. This can happen, for example, if the leaf is used
+	// concurrently by multiple requests, where the first one gets a
+	// TransactionAbortedError.
+	meta := rootTxn.GetTxnCoordMeta(ctx)
+	meta.Txn.Status = roachpb.ABORTED
+	leafTxn.AugmentTxnCoordMeta(ctx, meta)
+
+	// Now use the leaf and check the error. At the TxnCoordSender level, the
+	// pErr will be TransactionAbortedError. When pErr.GoError() is called, that's
+	// transformed into an UnhandledRetryableError. For our purposes, what this
+	// test is interested in demonstrating is that it's not a
+	// HandledRetryableError.
+	_, err := leafTxn.Get(ctx, roachpb.Key("a"))
+	if _, ok := err.(*roachpb.UnhandledRetryableError); !ok {
+		t.Fatalf("expected UnhandledRetryableError(TransactionAbortedError), got: (%T) %v", err, err)
+	}
+}


### PR DESCRIPTION
Backport 1/1 commits from #29036.

/cc @cockroachdb/release

---

A root TxnCoordSender takes retryable errors, prepares the transaction
for a retry and the returns a HandledRetryableError to the client.
Leaf TCS does not prepare transactions for retries, and so has no
business creating HandledRetryableErrors. Instead, it returns raw error
which have to make their way (through DistSQL streams) to the root,
which will "handle" them.
Before this patch, there was a codepath where a leaf TCS would
erroneously return a HandledRetryableError. This was confusing DistSQL
which was not plumbing it properly and it was making its way to the
client with a non-retriable code.

Fixes #28898

Release note: None
