### PR TITLE
release-2.1: teamcity trigger (i.e., nightly stress) fixes

### DIFF
--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -17,6 +17,7 @@ env=(
   "PKG=$PKG"
   "GOFLAGS=${GOFLAGS:-}"
   "TAGS=${TAGS:-}"
+  "STRESSFLAGS=${STRESSFLAGS:-}"
 )
 
 build/builder.sh env "${env[@]}" bash <<'EOF'

--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -22,7 +22,7 @@ env=(
 build/builder.sh env "${env[@]}" bash <<'EOF'
 set -euxo pipefail
 go install ./pkg/cmd/github-post
-make stress PKG="$PKG" TESTTIMEOUT=40m GOFLAGS="$GOFLAGS" TAGS="$TAGS" STRESSFLAGS='-maxruns 100 -maxfails 1 -stderr' \
+make stress PKG="$PKG" TESTTIMEOUT=40m GOFLAGS="$GOFLAGS" TAGS="$TAGS" STRESSFLAGS="-maxruns 100 -maxfails 1 -stderr $STRESSFLAGS" \
   | tee artifacts/stress.log \
   || { go tool test2json < artifacts/stress.log | github-post; exit 1; }
 EOF

--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -61,7 +61,11 @@ func runTC(branches []string, queueBuild func(string, string, map[string]string)
 		// Queue stress builds. One per configuration per package.
 		for _, opts := range []map[string]string{
 			{}, // uninstrumented
-			{"env.GOFLAGS": "-race"},
+			// The race detector is CPU intensive, so we want to run less processes in
+			// parallel. (Stress, by default, will run one process per CPU.)
+			//
+			// TODO(benesch): avoid assuming that TeamCity agents have eight CPUs.
+			{"env.GOFLAGS": "-race", "env.STRESSFLAGS": "-p 4"},
 		} {
 			for _, importPath := range importPaths {
 				opts["env.PKG"] = importPath


### PR DESCRIPTION
Backport:
  * 1/1 commits from "teamcity-{stress,trigger}: use four processes during race stress" (#29819)
  * 1/1 commits from "teamcity-stress: fix an unbound variable error" (#29971)
  * 1/1 commits from "c-deps: bump rocksdb to pick up segfault fix" (#29977)

Please see individual PRs for details.

/cc @cockroachdb/release
