### PR TITLE
backport-2.0: storage: Up-replicate before removing replicas from dead stores

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -46,6 +46,7 @@ const (
 	minReplicaWeight = 0.001
 
 	// priorities for various repair operations.
+	addDeadReplacementPriority            float64 = 12000
 	addMissingReplicaPriority             float64 = 10000
 	addDecommissioningReplacementPriority float64 = 5000
 	removeDeadReplicaPriority             float64 = 1000
@@ -232,12 +233,13 @@ func (a *Allocator) ComputeAction(
 	// TODO(mrtracy): Handle non-homogeneous and mismatched attribute sets.
 	need := int(zone.NumReplicas)
 	have := len(rangeInfo.Desc.Replicas)
-	quorum := computeQuorum(need)
+	desiredQuorum := computeQuorum(need)
+	quorum := computeQuorum(have)
 	if have < need {
 		// Range is under-replicated, and should add an additional replica.
 		// Priority is adjusted by the difference between the current replica
 		// count and the quorum of the desired replica count.
-		priority := addMissingReplicaPriority + float64(quorum-have)
+		priority := addMissingReplicaPriority + float64(desiredQuorum-have)
 		log.VEventf(ctx, 3, "AllocatorAdd - missing replica need=%d, have=%d, priority=%.2f", need, have, priority)
 		return AllocatorAdd, priority
 	}
@@ -261,39 +263,34 @@ func (a *Allocator) ComputeAction(
 			liveReplicas, quorum)
 		return AllocatorNoop, 0
 	}
-	// Removal actions follow.
-	if len(deadReplicas) > 0 {
-		// The range has dead replicas, which should be removed immediately.
-		removeDead := false
-		switch {
-		case have > need:
-			// Allow removal of a dead replica if we have more than we need.
-			// Reduce priority for this case?
-			removeDead = true
-		default: // have == need
-			// Only allow removal of a dead replica if we have a suitable allocation
-			// target that we can up-replicate to. This isn't necessarily the target
-			// we'll up-replicate to, just an indication that such a target exists.
-			if _, _, err := a.AllocateTarget(
-				ctx,
-				zone,
-				liveReplicas,
-				rangeInfo,
-				disableStatsBasedRebalancing,
-			); err == nil {
-				removeDead = true
-			}
-		}
-		if removeDead {
-			// Adjust the priority by the distance of live replicas from quorum.
-			priority := removeDeadReplicaPriority + float64(quorum-len(liveReplicas))
-			log.VEventf(ctx, 3, "AllocatorRemoveDead - dead=%d, live=%d, quorum=%d, priority=%.2f",
-				len(deadReplicas), len(liveReplicas), quorum, priority)
-			return AllocatorRemoveDead, priority
-		}
+
+	if have == need && len(deadReplicas) > 0 {
+		// Range has dead replica(s). We should up-replicate to add another before
+		// before removing the dead one. This can avoid permanent data loss in cases
+		// where the node is only temporarily dead, but we remove it from the range
+		// and lose a second node before we can up-replicate (#25392).
+		// The dead replica(s) will be down-replicated later.
+		priority := addDeadReplacementPriority
+		log.VEventf(ctx, 3, "AllocatorAdd - replacement for %d dead replicas priority=%.2f",
+			len(deadReplicas), priority)
+		return AllocatorAdd, priority
 	}
 
-	if have > need && len(decommissioningReplicas) > 0 {
+	// Removal actions follow.
+	// TODO(a-robinson): There's an additional case related to dead replicas that
+	// we should handle above. If there are one or more dead replicas, have <
+	// need, and there are no available stores to up-replicate to, then we should
+	// try to remove the dead replica(s) to get down to an odd number of
+	// replicas.
+	if len(deadReplicas) > 0 {
+		// The range has dead replicas, which should be removed immediately.
+		priority := removeDeadReplicaPriority + float64(quorum-len(liveReplicas))
+		log.VEventf(ctx, 3, "AllocatorRemoveDead - dead=%d, live=%d, quorum=%d, priority=%.2f",
+			len(deadReplicas), len(liveReplicas), quorum, priority)
+		return AllocatorRemoveDead, priority
+	}
+
+	if len(decommissioningReplicas) > 0 {
 		// Range is over-replicated, and has a decommissioning replica which
 		// should be removed.
 		priority := removeDecommissioningReplicaPriority
@@ -338,7 +335,7 @@ func (a *Allocator) AllocateTarget(
 	sl, aliveStoreCount, throttledStoreCount := a.storePool.getStoreList(rangeInfo.Desc.RangeID, storeFilterThrottled)
 
 	analyzedConstraints := analyzeConstraints(
-		ctx, a.storePool.getStoreDescriptor, rangeInfo.Desc.Replicas, zone)
+		ctx, a.storePool.getStoreDescriptor, existing, zone)
 	options := a.scorerOptions(disableStatsBasedRebalancing)
 	candidates := allocateCandidates(
 		sl, analyzedConstraints, existing, rangeInfo, a.storePool.getLocalities(existing), options,

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -3935,7 +3935,75 @@ func TestAllocatorComputeAction(t *testing.T) {
 		desc           roachpb.RangeDescriptor
 		expectedAction AllocatorAction
 	}{
-		// Needs three replicas, have two
+		// Need three replicas, have three, one is on a dead store.
+		{
+			zone: config.ZoneConfig{
+				NumReplicas:   3,
+				Constraints:   []config.Constraints{{Constraints: []config.Constraint{{Value: "us-east", Type: config.Constraint_DEPRECATED_POSITIVE}}}},
+				RangeMinBytes: 0,
+				RangeMaxBytes: 64000,
+			},
+			desc: roachpb.RangeDescriptor{
+				Replicas: []roachpb.ReplicaDescriptor{
+					{
+						StoreID:   1,
+						NodeID:    1,
+						ReplicaID: 1,
+					},
+					{
+						StoreID:   2,
+						NodeID:    2,
+						ReplicaID: 2,
+					},
+					{
+						StoreID:   6,
+						NodeID:    6,
+						ReplicaID: 6,
+					},
+				},
+			},
+			expectedAction: AllocatorAdd,
+		},
+		// Need five replicas, one is on a dead store.
+		{
+			zone: config.ZoneConfig{
+				NumReplicas:   5,
+				Constraints:   []config.Constraints{{Constraints: []config.Constraint{{Value: "us-east", Type: config.Constraint_DEPRECATED_POSITIVE}}}},
+				RangeMinBytes: 0,
+				RangeMaxBytes: 64000,
+			},
+			desc: roachpb.RangeDescriptor{
+				Replicas: []roachpb.ReplicaDescriptor{
+					{
+						StoreID:   1,
+						NodeID:    1,
+						ReplicaID: 1,
+					},
+					{
+						StoreID:   2,
+						NodeID:    2,
+						ReplicaID: 2,
+					},
+					{
+						StoreID:   3,
+						NodeID:    3,
+						ReplicaID: 3,
+					},
+					{
+						StoreID:   4,
+						NodeID:    4,
+						ReplicaID: 4,
+					},
+					{
+						StoreID:   6,
+						NodeID:    6,
+						ReplicaID: 6,
+					},
+				},
+			},
+			expectedAction: AllocatorAdd,
+		},
+		// Need three replicas, have two.
 		{
 			zone: config.ZoneConfig{
 				NumReplicas:   3,
@@ -3959,7 +4027,41 @@ func TestAllocatorComputeAction(t *testing.T) {
 			},
 			expectedAction: AllocatorAdd,
 		},
-		// Needs Five replicas, have four.
+		// Need five replicas, have four, one is on a dead store.
+		{
+			zone: config.ZoneConfig{
+				NumReplicas:   5,
+				Constraints:   []config.Constraints{{Constraints: []config.Constraint{{Value: "us-east", Type: config.Constraint_DEPRECATED_POSITIVE}}}},
+				RangeMinBytes: 0,
+				RangeMaxBytes: 64000,
+			},
+			desc: roachpb.RangeDescriptor{
+				Replicas: []roachpb.ReplicaDescriptor{
+					{
+						StoreID:   1,
+						NodeID:    1,
+						ReplicaID: 1,
+					},
+					{
+						StoreID:   2,
+						NodeID:    2,
+						ReplicaID: 2,
+					},
+					{
+						StoreID:   3,
+						NodeID:    3,
+						ReplicaID: 3,
+					},
+					{
+						StoreID:   6,
+						NodeID:    6,
+						ReplicaID: 6,
+					},
+				},
+			},
+			expectedAction: AllocatorAdd,
+		},
+		// Need five replicas, have four.
 		{
 			zone: config.ZoneConfig{
 				NumReplicas:   5,
@@ -3993,10 +4095,10 @@ func TestAllocatorComputeAction(t *testing.T) {
 			},
 			expectedAction: AllocatorAdd,
 		},
-		// Needs Five replicas, have four, one is on a dead store
+		// Need three replicas, have four, one is on a dead store.
 		{
 			zone: config.ZoneConfig{
-				NumReplicas:   5,
+				NumReplicas:   3,
 				Constraints:   []config.Constraints{{Constraints: []config.Constraint{{Value: "us-east", Type: config.Constraint_DEPRECATED_POSITIVE}}}},
 				RangeMinBytes: 0,
 				RangeMaxBytes: 64000,
@@ -4025,12 +4127,12 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorAdd,
+			expectedAction: AllocatorRemoveDead,
 		},
-		// Needs three replicas, one is on a dead store.
+		// Need five replicas, have six, one is on a dead store.
 		{
 			zone: config.ZoneConfig{
-				NumReplicas:   3,
+				NumReplicas:   5,
 				Constraints:   []config.Constraints{{Constraints: []config.Constraint{{Value: "us-east", Type: config.Constraint_DEPRECATED_POSITIVE}}}},
 				RangeMinBytes: 0,
 				RangeMaxBytes: 64000,
@@ -4046,6 +4148,21 @@ func TestAllocatorComputeAction(t *testing.T) {
 						StoreID:   2,
 						NodeID:    2,
 						ReplicaID: 2,
+					},
+					{
+						StoreID:   3,
+						NodeID:    3,
+						ReplicaID: 3,
+					},
+					{
+						StoreID:   4,
+						NodeID:    4,
+						ReplicaID: 4,
+					},
+					{
+						StoreID:   5,
+						NodeID:    5,
+						ReplicaID: 5,
 					},
 					{
 						StoreID:   6,
@@ -4056,39 +4173,10 @@ func TestAllocatorComputeAction(t *testing.T) {
 			},
 			expectedAction: AllocatorRemoveDead,
 		},
-		// Needs three replicas, one is dead.
+		// Need three replicas, have five, one is on a dead store.
 		{
 			zone: config.ZoneConfig{
 				NumReplicas:   3,
-				Constraints:   []config.Constraints{{Constraints: []config.Constraint{{Value: "us-east", Type: config.Constraint_DEPRECATED_POSITIVE}}}},
-				RangeMinBytes: 0,
-				RangeMaxBytes: 64000,
-			},
-			desc: roachpb.RangeDescriptor{
-				Replicas: []roachpb.ReplicaDescriptor{
-					{
-						StoreID:   1,
-						NodeID:    1,
-						ReplicaID: 1,
-					},
-					{
-						StoreID:   2,
-						NodeID:    2,
-						ReplicaID: 2,
-					},
-					{
-						StoreID:   8,
-						NodeID:    8,
-						ReplicaID: 8,
-					},
-				},
-			},
-			expectedAction: AllocatorRemoveDead,
-		},
-		// Needs five replicas, one is on a dead store.
-		{
-			zone: config.ZoneConfig{
-				NumReplicas:   5,
 				Constraints:   []config.Constraints{{Constraints: []config.Constraint{{Value: "us-east", Type: config.Constraint_DEPRECATED_POSITIVE}}}},
 				RangeMinBytes: 0,
 				RangeMaxBytes: 64000,
@@ -4428,70 +4516,77 @@ func TestAllocatorRebalanceTargetDisableStatsRebalance(t *testing.T) {
 func TestAllocatorComputeActionRemoveDead(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	zone := config.ZoneConfig{
+		NumReplicas: 3,
+	}
+	threeReplDesc := roachpb.RangeDescriptor{
+		Replicas: []roachpb.ReplicaDescriptor{
+			{
+				StoreID:   1,
+				NodeID:    1,
+				ReplicaID: 1,
+			},
+			{
+				StoreID:   2,
+				NodeID:    2,
+				ReplicaID: 2,
+			},
+			{
+				StoreID:   3,
+				NodeID:    3,
+				ReplicaID: 3,
+			},
+		},
+	}
+	fourReplDesc := threeReplDesc
+	fourReplDesc.Replicas = append(fourReplDesc.Replicas, roachpb.ReplicaDescriptor{
+		StoreID:   4,
+		NodeID:    4,
+		ReplicaID: 4,
+	})
+
 	// Each test case should describe a repair situation which has a lower
 	// priority than the previous test case.
 	testCases := []struct {
-		zone           config.ZoneConfig
 		desc           roachpb.RangeDescriptor
-		expectedAction AllocatorAction
 		live           []roachpb.StoreID
 		dead           []roachpb.StoreID
+		expectedAction AllocatorAction
 	}{
-		// Needs three replicas, one is dead, but there is no replacement.
+		// Needs three replicas, one is dead, and there's no replacement.
 		{
-			zone: config.ZoneConfig{
-				NumReplicas: 3,
-			},
-			desc: roachpb.RangeDescriptor{
-				Replicas: []roachpb.ReplicaDescriptor{
-					{
-						StoreID:   1,
-						NodeID:    1,
-						ReplicaID: 1,
-					},
-					{
-						StoreID:   2,
-						NodeID:    2,
-						ReplicaID: 2,
-					},
-					{
-						StoreID:   3,
-						NodeID:    3,
-						ReplicaID: 3,
-					},
-				},
-			},
-			expectedAction: AllocatorConsiderRebalance,
+			desc:           threeReplDesc,
 			live:           []roachpb.StoreID{1, 2},
 			dead:           []roachpb.StoreID{3},
+			expectedAction: AllocatorAdd,
 		},
 		// Needs three replicas, one is dead, but there is a replacement.
 		{
-			zone: config.ZoneConfig{
-				NumReplicas: 3,
-			},
-			desc: roachpb.RangeDescriptor{
-				Replicas: []roachpb.ReplicaDescriptor{
-					{
-						StoreID:   1,
-						NodeID:    1,
-						ReplicaID: 1,
-					},
-					{
-						StoreID:   2,
-						NodeID:    2,
-						ReplicaID: 2,
-					},
-					{
-						StoreID:   3,
-						NodeID:    3,
-						ReplicaID: 3,
-					},
-				},
-			},
-			expectedAction: AllocatorRemoveDead,
+			desc:           threeReplDesc,
 			live:           []roachpb.StoreID{1, 2, 4},
 			dead:           []roachpb.StoreID{3},
+			expectedAction: AllocatorAdd,
+		},
+		// Needs three replicas, two are dead (i.e. the range lacks a quorum).
+		{
+			desc:           threeReplDesc,
+			live:           []roachpb.StoreID{1, 4},
+			dead:           []roachpb.StoreID{2, 3},
+			expectedAction: AllocatorNoop,
+		},
+		// Needs three replicas, has four, one is dead.
+		{
+			desc:           fourReplDesc,
+			live:           []roachpb.StoreID{1, 2, 4},
+			dead:           []roachpb.StoreID{3},
+			expectedAction: AllocatorRemoveDead,
+		},
+		// Needs three replicas, has four, two are dead (i.e. the range lacks a quorum).
+		{
+			desc:           fourReplDesc,
+			live:           []roachpb.StoreID{1, 4},
+			dead:           []roachpb.StoreID{2, 3},
+			expectedAction: AllocatorNoop,
 		},
 	}
 
@@ -4502,7 +4597,7 @@ func TestAllocatorComputeActionRemoveDead(t *testing.T) {
 	for i, tcase := range testCases {
 		mockStorePool(sp, tcase.live, tcase.dead, nil, nil, nil)
 
-		action, _ := a.ComputeAction(ctx, tcase.zone, RangeInfo{Desc: &tcase.desc}, false)
+		action, _ := a.ComputeAction(ctx, zone, RangeInfo{Desc: &tcase.desc}, false)
 		if tcase.expectedAction != action {
 			t.Errorf("Test case %d expected action %d, got action %d", i, tcase.expectedAction, action)
 		}

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -271,7 +271,7 @@ func (rq *replicateQueue) processOneChange(
 		newStore, details, err := rq.allocator.AllocateTarget(
 			ctx,
 			zone,
-			desc.Replicas,
+			liveReplicas, // only include liveReplicas, since deadReplicas should soon be removed
 			rangeInfo,
 			disableStatsBasedRebalancing,
 		)


### PR DESCRIPTION
Backport 1/1 commits from #28875.

/cc @cockroachdb/release

---

Fixes #25392, by preventing the following series of events:

1. Node x dies
2. We remove node x's replica of some range
3. Node y dies before we up-replicate, leaving the range unavailable (1
   out of 2 replicas dead)
4. Node x comes back online. It can't help the situation, because its
   replica was officially removed from the range.

Instead, we now up-replicate first before removing node x's replica.

Release note: None
