### PR TITLE
release-2.1: logictest: fix a test flake under high verbosity

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -459,7 +459,7 @@ SET tracing = on; INSERT INTO t.kv3 (k, v) VALUES (1,1); SET tracing = off
 # We look for rows containing a BeginTxn and an EndTxn, as proof that the
 # insertNode is committing the txn.
 query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE e'%1 CPut, 1 BeginTxn, 1 EndTxn%'
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE e'%1 CPut, 1 BeginTxn, 1 EndTxn%' AND message NOT LIKE e'%proposing command%'
 ----
 r1: sending batch 1 CPut, 1 BeginTxn, 1 EndTxn to (n1,s1):1
 1 CPut, 1 BeginTxn, 1 EndTxn


### PR DESCRIPTION
Backport 1/1 commits from #29604.

---

Log lines gated under vmodule flags alter what gets logged. Since
`show_trace` tests explicitly check for what is logged, this needs to
be accounted for in the tests if tests are to be consistent across
different vmodules.

This is not a panic, but it must be fixed before I can add a nightly to run all our logictests under vmodule=9. Backporting so that the `release-2.1` branch can also have nightly tests run under high `-vmodule`.
