### PR TITLE
release-2.1: opt: fix panic during SELECT MIN(NULL)

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -16,6 +16,12 @@ SELECT min(1), max(1), count(1), sum_int(1), avg(1), sum(1), stddev(1), variance
 ----
 NULL NULL 0 NULL NULL NULL NULL NULL NULL NULL NULL
 
+# Regression test for #29695
+query T
+SELECT min(NULL)
+----
+NULL
+
 # Aggregate functions return NULL if there are no rows.
 query T
 SELECT array_agg(1) FROM kv

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -855,7 +855,7 @@ func (s *scope) replaceSRF(f *tree.FuncExpr, def *tree.FunctionDefinition) *srf 
 // the variables referenced by the aggregate (or the current scope if the
 // aggregate references no variables). The aggOutScope.groupby.aggs slice is
 // used later by the Builder to build aggregations in the aggregation scope.
-func (s *scope) replaceAggregate(f *tree.FuncExpr, def *tree.FunctionDefinition) *aggregateInfo {
+func (s *scope) replaceAggregate(f *tree.FuncExpr, def *tree.FunctionDefinition) tree.Expr {
 	if f.Filter != nil {
 		panic(unimplementedf("aggregates with FILTER are not supported yet"))
 	}
@@ -875,6 +875,10 @@ func (s *scope) replaceAggregate(f *tree.FuncExpr, def *tree.FunctionDefinition)
 	if err != nil {
 		panic(builderError{err})
 	}
+	if typedFunc == tree.DNull {
+		return tree.DNull
+	}
+
 	f = typedFunc.(*tree.FuncExpr)
 
 	funcDef := memo.FuncOpDef{


### PR DESCRIPTION
Backport 1/1 commits from #30006.

/cc @cockroachdb/release

Release note (bug fix): fix a crash when SELECT MIN(NULL) was run with
the optimizer enabled.
