### PR TITLE
roachtest: for dryrun, skip initBinaries

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -40,7 +40,9 @@ func main() {
 			if clusterName != "" && local {
 				return fmt.Errorf("cannot specify both an existing cluster (%s) and --local", clusterName)
 			}
-			initBinaries()
+			if !dryrun {
+				initBinaries()
+			}
 			return nil
 		},
 	}


### PR DESCRIPTION
For a dryRun since nothing is actually being run, it is not necessary to
have any of the binaries at all. I ran into this when just trying to
list the roachtests but couldn't because of this issue. Can do so now,
 without any problems. cc @andreimatei  for helping solve the issue.
If this was a desired behaviour do let me know

Release note (roachtest): changes behaviour of `roachtest run -n` to not
check or initialise binaries as they are not required for a dry run