### PR TITLE
sqlbase: don't casecade through NULL values

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -3224,3 +3224,147 @@ UPDATE a SET id = 'updated' WHERE id = 'original';
 # Clean up after the test.
 statement ok
 DROP TABLE b, a;
+
+subtest NoNullCascades
+
+# First with a non-composite index
+statement ok
+CREATE TABLE IF NOT EXISTS example (
+  a INT UNIQUE,
+  b INT REFERENCES example (a) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+statement ok
+INSERT INTO example VALUES (20, NULL);
+INSERT INTO example VALUES (30, 20);
+INSERT INTO example VALUES (NULL, 30);
+
+statement ok
+DELETE FROM example where a = 30;
+
+query II colnames
+SELECT * FROM example;
+----
+a  b
+20 NULL
+
+# Clean up after the test.
+statement ok
+DROP TABLE example;
+
+# With a composite index
+statement ok
+CREATE TABLE a (
+  x INT
+ ,y INT
+ ,UNIQUE (x, y)
+);
+
+statement ok
+CREATE TABLE b (
+  x INT
+ ,y INT
+ ,INDEX (x, y)
+ ,FOREIGN KEY (x, y) REFERENCES a (x, y) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+statement ok
+INSERT INTO a VALUES (NULL, NULL), (NULL, 1), (2, NULL), (3, 3);
+INSERT INTO b VALUES (NULL, NULL), (NULL, 1), (2, NULL), (3, 3);
+
+# Note that these match our current incorrect style of MATCH FULL and allow
+# matching of NULLs if one exists in the referencing table.
+
+statement ok
+DELETE FROM a WHERE y = 1;
+
+query II colnames
+SELECT * FROM b ORDER BY x, y;
+----
+x    y
+NULL NULL
+2    NULL
+3    3
+
+statement ok
+DELETE FROM a WHERE x = 2;
+
+query II colnames
+SELECT * FROM b ORDER BY x, y;
+----
+x    y
+NULL NULL
+3    3
+
+statement ok
+DELETE FROM a;
+
+# A match consisting of only NULLs is not cascaded.
+query II colnames
+SELECT * FROM b ORDER BY x, y;
+----
+x    y
+NULL NULL
+
+query II colnames
+SELECT * FROM a ORDER BY x;
+----
+x    y
+
+# Now try the same with inserts
+statement ok
+TRUNCATE b, a;
+INSERT INTO a VALUES (NULL, NULL), (NULL, 4), (5, NULL), (6, 6);
+INSERT INTO b VALUES (NULL, NULL), (NULL, 4), (5, NULL), (6, 6);
+
+statement ok
+UPDATE a SET y = y*10 WHERE y > 0;
+UPDATE a SET x = x*10 WHERE x > 0;
+
+query II colnames
+SELECT * FROM b ORDER BY x, y;
+----
+x    y
+NULL  NULL
+NULL  40
+50    NULL
+60    60
+
+statement ok
+UPDATE a SET y = 100 WHERE y IS NULL;
+UPDATE a SET x = 100 WHERE x IS NULL;
+
+query II colnames
+SELECT * FROM b ORDER BY x, y;
+----
+x    y
+NULL NULL
+50   100
+60   60
+100  40
+
+# Note that the double NULL should not get cascaded.
+statement ok
+UPDATE a SET (x,y) = (100, 100) WHERE y IS NULL AND x IS NULL;
+
+query II colnames
+SELECT * FROM b ORDER BY x, y;
+----
+x    y
+NULL NULL
+50   100
+60   60
+100  40
+
+query II colnames
+SELECT * FROM a ORDER BY x, y;
+----
+x    y
+50   100
+60   60
+100  40
+100  100
+
+# Clean up after the test.
+statement ok
+DROP TABLE b, a;

--- a/pkg/sql/sqlbase/cascader.go
+++ b/pkg/sql/sqlbase/cascader.go
@@ -201,6 +201,18 @@ func spanForIndexValues(
 	values []tree.Datum,
 	keyPrefix []byte,
 ) (roachpb.Span, error) {
+	// Currently, we only offer MATCH FULL, so this checks to ensure that if a
+	// reference is composed of all NULLs, then we don't cascade it.
+	nulls := true
+	for _, rowIndex := range indexColIDs {
+		if values[rowIndex] != tree.DNull {
+			nulls = false
+			break
+		}
+	}
+	if nulls {
+		return roachpb.Span{}, nil
+	}
 	keyBytes, _, err := EncodePartialIndexKey(table, index, prefixLen, indexColIDs, values, keyPrefix)
 	if err != nil {
 		return roachpb.Span{}, err
@@ -255,7 +267,9 @@ func batchRequestForIndexValues(
 		if err != nil {
 			return roachpb.BatchRequest{}, nil, err
 		}
-		req.Add(&roachpb.ScanRequest{RequestHeader: roachpb.RequestHeaderFromSpan(span)})
+		if span.EndKey != nil {
+			req.Add(&roachpb.ScanRequest{RequestHeader: roachpb.RequestHeaderFromSpan(span)})
+		}
 	}
 	return req, colIDtoRowIndex, nil
 }
@@ -286,7 +300,9 @@ func batchRequestForPKValues(
 		if err != nil {
 			return roachpb.BatchRequest{}, err
 		}
-		req.Add(&roachpb.ScanRequest{RequestHeader: roachpb.RequestHeaderFromSpan(span)})
+		if span.EndKey != nil {
+			req.Add(&roachpb.ScanRequest{RequestHeader: roachpb.RequestHeaderFromSpan(span)})
+		}
 	}
 	return req, nil
 }
@@ -483,6 +499,10 @@ func (c *cascader) deleteRows(
 	if err != nil {
 		return nil, nil, 0, err
 	}
+	// If there are no spans to search, there is no need to cascade.
+	if len(req.Requests) == 0 {
+		return nil, nil, 0, nil
+	}
 	br, roachErr := c.txn.Send(ctx, req)
 	if roachErr != nil {
 		return nil, nil, 0, roachErr.GoError()
@@ -544,6 +564,10 @@ func (c *cascader) deleteRows(
 		return nil, nil, 0, err
 	}
 	primaryKeysToDelete.Clear(ctx)
+	// If there are no spans to search, there is no need to cascade.
+	if len(pkLookupReq.Requests) == 0 {
+		return nil, nil, 0, nil
+	}
 	pkResp, roachErr := c.txn.Send(ctx, pkLookupReq)
 	if roachErr != nil {
 		return nil, nil, 0, roachErr.GoError()
@@ -704,6 +728,10 @@ func (c *cascader) updateRows(
 		if err != nil {
 			return nil, nil, nil, 0, err
 		}
+		// If there are no spans to search, there is no need to cascade.
+		if len(req.Requests) == 0 {
+			return nil, nil, nil, 0, nil
+		}
 		br, roachErr := c.txn.Send(ctx, req)
 		if roachErr != nil {
 			return nil, nil, nil, 0, roachErr.GoError()
@@ -759,6 +787,10 @@ func (c *cascader) updateRows(
 			return nil, nil, nil, 0, err
 		}
 		primaryKeysToUpdate.Clear(ctx)
+		// If there are no spans to search, there is no need to cascade.
+		if len(pkLookupReq.Requests) == 0 {
+			return nil, nil, nil, 0, nil
+		}
 		pkResp, roachErr := c.txn.Send(ctx, pkLookupReq)
 		if roachErr != nil {
 			return nil, nil, nil, 0, roachErr.GoError()


### PR DESCRIPTION
Prior to this fix, we would cascade updates or deletes through NULLs. See #28896
for a great test case.

This however did remind me that we use MATCH FULL instead of MATCH SIMPLE and we
should add support for MATCH SIMPLE (and make it the default).  See #20305.

Closes #28896

Release note (bug fix): ON DELETE/ON UPDATE CASCADE should not cascade through
NULLs.