### PR TITLE
sql,storage,ccl: new diskmap pkg to rm dep edge

### DIFF
--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -31,7 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -108,7 +108,7 @@ type FlowCtx struct {
 	// working set is larger than can be stored in memory.
 	// This is not supposed to be used as a general engine.Engine and thus
 	// one should sparingly use the set of features offered by it.
-	TempStorage engine.Engine
+	TempStorage diskmap.Factory
 	// diskMonitor is used to monitor temporary storage disk usage.
 	diskMonitor *mon.BytesMonitor
 

--- a/pkg/sql/distsqlrun/hash_row_container.go
+++ b/pkg/sql/distsqlrun/hash_row_container.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -398,7 +398,7 @@ type hashDiskRowContainer struct {
 	// rows are stored with one less column (which usually specifies that row's
 	// mark).
 	shouldMark    bool
-	engine        engine.Engine
+	engine        diskmap.Factory
 	scratchEncRow sqlbase.EncDatumRow
 }
 
@@ -412,7 +412,9 @@ var (
 // makeHashDiskRowContainer creates a hashDiskRowContainer with the given engine
 // as the underlying store that rows are stored on. shouldMark specifies whether
 // the hashDiskRowContainer should set itself up to mark rows.
-func makeHashDiskRowContainer(diskMonitor *mon.BytesMonitor, e engine.Engine) hashDiskRowContainer {
+func makeHashDiskRowContainer(
+	diskMonitor *mon.BytesMonitor, e diskmap.Factory,
+) hashDiskRowContainer {
 	return hashDiskRowContainer{
 		diskMonitor: diskMonitor,
 		engine:      e,

--- a/pkg/sql/distsqlrun/row_container.go
+++ b/pkg/sql/distsqlrun/row_container.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/pkg/errors"
@@ -311,7 +311,7 @@ type diskBackedRowContainer struct {
 
 	// The following fields are used to create a diskRowContainer when spilling
 	// to disk.
-	engine      engine.Engine
+	engine      diskmap.Factory
 	diskMonitor *mon.BytesMonitor
 }
 
@@ -333,7 +333,7 @@ func (f *diskBackedRowContainer) init(
 	ordering sqlbase.ColumnOrdering,
 	types []sqlbase.ColumnType,
 	evalCtx *tree.EvalContext,
-	engine engine.Engine,
+	engine diskmap.Factory,
 	memoryMonitor *mon.BytesMonitor,
 	diskMonitor *mon.BytesMonitor,
 ) {

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -37,7 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -137,7 +137,7 @@ type ServerConfig struct {
 
 	// TempStorage is used by some DistSQL processors to store rows when the
 	// working set is larger than can be stored in memory.
-	TempStorage engine.Engine
+	TempStorage diskmap.Factory
 	// DiskMonitor is used to monitor temporary storage disk usage. Actual disk
 	// space used will be a small multiple (~1.1) of this because of RocksDB
 	// space amplification.

--- a/pkg/storage/diskmap/disk_map.go
+++ b/pkg/storage/diskmap/disk_map.go
@@ -1,0 +1,111 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package diskmap
+
+import (
+	"context"
+)
+
+// Factory is an interface that can produce SortedDiskMaps.
+type Factory interface {
+	// NewSortedDiskMap returns a fresh SortedDiskMap with no contents.
+	NewSortedDiskMap() SortedDiskMap
+	// NewSortedDiskMultiMap returns a fresh SortedDiskMap with no contents that permits
+	// duplicate keys.
+	NewSortedDiskMultiMap() SortedDiskMap
+}
+
+// SortedDiskMapIterator is a simple iterator used to iterate over keys and/or
+// values.
+// Example use of iterating over all keys:
+// 	var i SortedDiskMapIterator
+// 	for i.Rewind(); ; i.Next() {
+// 		if ok, err := i.Valid(); err != nil {
+//			// Handle error.
+// 		} else if !ok {
+//			break
+// 		}
+// 		key := i.Key()
+//		// Do something.
+// 	}
+type SortedDiskMapIterator interface {
+	// Seek sets the iterator's position to the first key greater than or equal
+	// to the provided key.
+	Seek(key []byte)
+	// Rewind seeks to the start key.
+	Rewind()
+	// Valid must be called after any call to Seek(), Rewind(), or Next(). It
+	// returns (true, nil) if the iterator points to a valid key and
+	// (false, nil) if the iterator has moved past the end of the valid range.
+	// If an error has occurred, the returned bool is invalid.
+	Valid() (bool, error)
+	// Next advances the iterator to the next key in the iteration.
+	Next()
+	// Key returns the current key. The resulting byte slice is still valid
+	// after the next call to Seek(), Rewind(), or Next().
+	Key() []byte
+	// Value returns the current value. The resulting byte slice is still valid
+	// after the next call to Seek(), Rewind(), or Next().
+	Value() []byte
+
+	// UnsafeKey returns the same value as Key, but the memory is invalidated on
+	// the next call to {Next,Rewind,Seek,Close}.
+	UnsafeKey() []byte
+	// UnsafeValue returns the same value as Value, but the memory is
+	// invalidated on the next call to {Next,Rewind,Seek,Close}.
+	UnsafeValue() []byte
+
+	// Close frees up resources held by the iterator.
+	Close()
+}
+
+// SortedDiskMapBatchWriter batches writes to a SortedDiskMap.
+type SortedDiskMapBatchWriter interface {
+	// Put writes the given key/value pair to the batch. The write to the
+	// underlying store happens on Flush(), Close(), or when the batch writer
+	// reaches its capacity.
+	Put(k []byte, v []byte) error
+	// Flush flushes all writes to the underlying store. The batch can be reused
+	// after a call to Flush().
+	Flush() error
+
+	// Close flushes all writes to the underlying store and frees up resources
+	// held by the batch writer.
+	Close(context.Context) error
+}
+
+// SortedDiskMap is an on-disk map. Keys are iterated over in sorted order.
+type SortedDiskMap interface {
+	// Put writes the given key/value pair.
+	Put(k []byte, v []byte) error
+	// Get reads the value for the given key.
+	Get(k []byte) ([]byte, error)
+
+	// NewIterator returns a SortedDiskMapIterator that can be used to iterate
+	// over key/value pairs in sorted order.
+	NewIterator() SortedDiskMapIterator
+	// NewBatchWriter returns a SortedDiskMapBatchWriter that can be used to
+	// batch writes to this map for performance improvements.
+	NewBatchWriter() SortedDiskMapBatchWriter
+	// NewBatchWriterCapacity is identical to NewBatchWriter, but overrides the
+	// SortedDiskMapBatchWriter's default capacity with capacityBytes.
+	NewBatchWriterCapacity(capacityBytes int) SortedDiskMapBatchWriter
+
+	// Clear clears the map's data for reuse.
+	Clear() error
+
+	// Close frees up resources held by the map.
+	Close(context.Context)
+}

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -313,6 +314,13 @@ type Engine interface {
 	// the engine implementation. For RocksDB, this means using the Env responsible for the file
 	// which may handle extra logic (eg: copy encryption settings for EncryptedEnv).
 	LinkFile(oldname, newname string) error
+}
+
+// MapProvidingEngine is an Engine that also provides facilities for making a
+// sorted map that's persisted by the Engine.
+type MapProvidingEngine interface {
+	Engine
+	diskmap.Factory
 }
 
 // WithSSTables extends the Engine interface with a method to get info

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -2853,6 +2854,16 @@ func (r *RocksDB) LinkFile(oldname, newname string) error {
 		}
 	}
 	return nil
+}
+
+// NewSortedDiskMap implements the MapProvidingEngine interface.
+func (r *RocksDB) NewSortedDiskMap() diskmap.SortedDiskMap {
+	return NewRocksDBMap(r)
+}
+
+// NewSortedDiskMultiMap implements the MapProvidingEngine interface.
+func (r *RocksDB) NewSortedDiskMultiMap() diskmap.SortedDiskMap {
+	return NewRocksDBMultiMap(r)
 }
 
 // IsValidSplitKey returns whether the key is a valid split key. Certain key

--- a/pkg/storage/engine/temp_engine.go
+++ b/pkg/storage/engine/temp_engine.go
@@ -21,7 +21,9 @@ import (
 
 // NewTempEngine creates a new engine for DistSQL processors to use when the
 // working set is larger than can be stored in memory.
-func NewTempEngine(tempStorage base.TempStorageConfig, storeSpec base.StoreSpec) (Engine, error) {
+func NewTempEngine(
+	tempStorage base.TempStorageConfig, storeSpec base.StoreSpec,
+) (MapProvidingEngine, error) {
 	if tempStorage.InMemory {
 		// TODO(arjun): Limit the size of the store once #16750 is addressed.
 		// Technically we do not pass any attributes to temporary store.


### PR DESCRIPTION
Previously, `distsqlrun` needed to depend on the `engine` package to
pick up some functionality for temporary storage. This commit introduces
a new `diskmap` package that provides the necessary interfaces, so that
`distsqlrun` can depend on just `diskmap` and not all of `engine`.

Release note: None