### PR TITLE
release-2.1: rangefeed: bump TestProcessorSlowConsumer event timeout

### DIFF
--- a/pkg/storage/rangefeed/processor_test.go
+++ b/pkg/storage/rangefeed/processor_test.go
@@ -378,7 +378,7 @@ func TestProcessorSlowConsumer(t *testing.T) {
 	defer stopper.Stop(context.Background())
 
 	// Set the Processor's eventC timeout.
-	p.EventChanTimeout = 30 * time.Millisecond
+	p.EventChanTimeout = 100 * time.Millisecond
 
 	// Add a registration.
 	r1Stream := newTestStream()


### PR DESCRIPTION
Backport 1/1 commits from #30004.

/cc @cockroachdb/release

---

Fixes #29671.

Before this, the test would fail in about 3 minutes of stress. After this change, it didn't fail in over 30 minutes.

Will need to be backported.

Release note: None
