### PR TITLE
*: linter to keep c-deps out of some packages

### DIFF
--- a/pkg/roachpb/dep_test.go
+++ b/pkg/roachpb/dep_test.go
@@ -1,0 +1,30 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package roachpb
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestNoLinkForbidden(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	buildutil.VerifyNoImports(t,
+		"github.com/cockroachdb/cockroach/pkg/roachpb", true, []string{"c-deps"}, nil,
+	)
+}

--- a/pkg/server/diagnosticspb/dep_test.go
+++ b/pkg/server/diagnosticspb/dep_test.go
@@ -1,0 +1,30 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package diagnosticspb
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestNoLinkForbidden(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	t.Skip("#30001")
+	buildutil.VerifyNoImports(t,
+		"github.com/cockroachdb/cockroach/pkg/server/diagnosticspb", true, []string{"c-deps"}, nil,
+	)
+}

--- a/pkg/sql/dep_test.go
+++ b/pkg/sql/dep_test.go
@@ -1,0 +1,31 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestNoLinkForbidden(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	t.Skip("#30001")
+
+	buildutil.VerifyNoImports(t,
+		"github.com/cockroachdb/cockroach/pkg/sql", true, []string{"c-deps"}, nil,
+	)
+}

--- a/pkg/sql/sqlbase/dep_test.go
+++ b/pkg/sql/sqlbase/dep_test.go
@@ -1,0 +1,31 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlbase
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestNoLinkForbidden(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	t.Skip("#30001")
+
+	buildutil.VerifyNoImports(t,
+		"github.com/cockroachdb/cockroach/pkg/sql/sqlbase", true, []string{"c-deps"}, nil,
+	)
+}

--- a/pkg/testutils/buildutil/build.go
+++ b/pkg/testutils/buildutil/build.go
@@ -19,28 +19,64 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/pkg/errors"
 )
 
-// TransitiveImports returns a set containing all of importPath's transitive
-// dependencies.
-func TransitiveImports(importPath string, cgo bool) (map[string]struct{}, error) {
+// VerifyNoImports verifies that a package doesn't depend (directly or
+// indirectly) on forbidden packages. The forbidden packages are specified as
+// either exact matches or prefix matches.
+// If GOPATH isn't set, it is an indication that the source is not available and
+// the test is skipped.
+func VerifyNoImports(
+	t testing.TB, pkgPath string, cgo bool, forbiddenPkgs, forbiddenPrefixes []string,
+) {
+
+	// Skip test if source is not available.
+	if build.Default.GOPATH == "" {
+		t.Skip("GOPATH isn't set")
+	}
+
 	buildContext := build.Default
 	buildContext.CgoEnabled = cgo
 
-	imports := make(map[string]struct{})
+	checked := make(map[string]struct{})
 
-	var addImports func(string) error
-	addImports = func(root string) error {
-		pkg, err := buildContext.Import(root, "", 0)
+	short := func(in string) string {
+		return strings.Replace(in, "github.com/cockroachdb/cockroach/pkg/", "./pkg/", -1)
+	}
+
+	var check func(string) error
+	check = func(path string) error {
+		pkg, err := buildContext.Import(path, "", 0)
 		if err != nil {
-			return err
+			t.Fatal(err)
 		}
 
 		for _, imp := range pkg.Imports {
+			for _, forbidden := range forbiddenPkgs {
+				if forbidden == imp {
+					return errors.Errorf("%s imports %s, which is forbidden", short(path), short(imp))
+				}
+				if forbidden == "c-deps" && imp == "C" && strings.HasPrefix(path, "github.com/cockroachdb/cockroach/pkg") {
+					for _, name := range pkg.CgoFiles {
+						if strings.Contains(name, "zcgo_flags") {
+							return errors.Errorf("%s imports %s (%s), which is forbidden", short(path), short(imp), name)
+						}
+					}
+				}
+			}
+			for _, prefix := range forbiddenPrefixes {
+				if strings.HasPrefix(path, prefix) {
+					return errors.Errorf("%s imports %s which has prefix %s, which is forbidden", short(path), short(imp), prefix)
+				}
+			}
+
 			// https://github.com/golang/tools/blob/master/refactor/importgraph/graph.go#L159
 			if imp == "C" {
 				continue // "C" is fake
 			}
+
 			importPkg, err := buildContext.Import(imp, pkg.Dir, build.FindOnly)
 			if err != nil {
 				// go/build does not know that gccgo's standard packages don't have
@@ -51,50 +87,20 @@ func TransitiveImports(importPath string, cgo bool) (map[string]struct{}, error)
 				if runtime.Compiler == "gccgo" {
 					continue
 				}
-				return err
+				t.Fatal(err)
 			}
 			imp = importPkg.ImportPath
-			if _, ok := imports[imp]; !ok {
-				imports[imp] = struct{}{}
-				if err := addImports(imp); err != nil {
-					return err
-				}
+			if _, ok := checked[imp]; ok {
+				continue
 			}
+			if err := check(imp); err != nil {
+				return errors.Wrapf(err, "%s depends on", short(path))
+			}
+			checked[pkg.ImportPath] = struct{}{}
 		}
 		return nil
 	}
-
-	return imports, addImports(importPath)
-}
-
-// VerifyNoImports verifies that a package doesn't depend (directly or
-// indirectly) on forbidden packages. The forbidden packages are specified as
-// either exact matches or prefix matches.
-// If GOPATH isn't set, it is an indication that the source is not available and
-// the test is skipped.
-func VerifyNoImports(
-	t testing.TB, pkgPath string, cgo bool, forbiddenPkgs, forbiddenPrefixes []string,
-) {
-	// Skip test if source is not available.
-	if build.Default.GOPATH == "" {
-		t.Skip("GOPATH isn't set")
-	}
-
-	imports, err := TransitiveImports(pkgPath, true)
-	if err != nil {
+	if err := check(pkgPath); err != nil {
 		t.Fatal(err)
-	}
-
-	for _, forbidden := range forbiddenPkgs {
-		if _, ok := imports[forbidden]; ok {
-			t.Errorf("Package %s includes %s, which is forbidden", pkgPath, forbidden)
-		}
-	}
-	for _, forbiddenPrefix := range forbiddenPrefixes {
-		for k := range imports {
-			if strings.HasPrefix(k, forbiddenPrefix) {
-				t.Errorf("Package %s includes %s, which is forbidden", pkgPath, k)
-			}
-		}
 	}
 }


### PR DESCRIPTION
As discussed in #30001, many packages contain code that ideally is usable outside of the cockroach binary and build process.
However, making that code buildable outside out usual build process requires ensuring that it does not depend on our make-built c-deps.

This adds a (skipped) linter that inspects the transtive deps of some key packages (protos and sql so far).

Release note: none.