### PR TITLE
build: revert to outputing the stress output to the build log

### DIFF
--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -23,17 +23,32 @@ env=(
 build/builder.sh env "${env[@]}" bash <<'EOF'
 set -euxo pipefail
 go install ./pkg/cmd/github-post
+
 # We're going to run stress, pipe its output to test2json to add a bit of
 # structure, then pipe that to our github-post script which creates issues for
 # failed tests.
-# Note that, even though we stream the results into test2json, this streaming is
-# meaningless for the purposes of the timing information recorded by test2json
-# because stress captures the test output and prints it all at once. github-post
-# compensates for this.
+# Note that we don't stream the results into test2json, as the tool generally
+# expects. We don't stream because we want the failing stress output to make it
+# to Team City's build log (i.e. to the stdout of this file).
+# The streaming would be meaningless for the purposes of the timing information
+# recorded by test2json because stress captures the test output and prints it
+# all at once. github-post compensates for this.
+# TODO(andrei): Something we could do is teach the `make stress` target (or a
+# new target) to pass the test2son invocation to the `go test -exec` flag (note
+# that test2json knows how to take a test binary and flags). This way we could
+# get rid of some logic specific to supporting stress output in github-post.
+# But then the problem would be that the TC build log would contain json, which
+# is not the most readable. So I guess we'd also need a json2test tool to strip
+# the json and go back to raw logs.
 #
 # We've set pipefail, so the exit status is going to come from stress if there
 # are test failures.
-make stress PKG="$PKG" TESTTIMEOUT=40m GOFLAGS="$GOFLAGS" TAGS="$TAGS" STRESSFLAGS="-maxruns 100 -maxfails 1 -stderr $STRESSFLAGS" 2>&1 \
-  | tee artifacts/stress.log \
-  | go tool test2json -t | github-post
+# Use an `if` so that the `-e` option doesn't stop the script on error.
+if ! make stress PKG="$PKG" TESTTIMEOUT=40m GOFLAGS="$GOFLAGS" TAGS="$TAGS" STRESSFLAGS="-maxruns 100 -maxfails 1 -stderr $STRESSFLAGS" 2>&1 \
+  | tee artifacts/stress.log; then
+  exit_status=$?
+  go tool test2json -t < artifacts/stress.log | github-post
+  exit $exit_status
+fi
+
 EOF


### PR DESCRIPTION
My recent change to teamcity-stress.sh piped the stress output to
test2json cause it sounded like a good idea, but I've then realized that
in the process we've lost that output from the build log (relegating it
only to artifacts/stress.log).
I like the build log, so this patch puts the output back there.

Release note: None