### PR TITLE
distsql: reduce memory usage for subqueries exec

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -676,8 +676,9 @@ func (dsp *DistSQLPlanner) PlanAndRunSubqueries(
 			subqueryPlans[planIdx].result = tree.MakeDBool(tree.DBool(hasRows))
 		case distsqlrun.SubqueryExecModeAllRows, distsqlrun.SubqueryExecModeAllRowsNormalized:
 			var result tree.DTuple
-			for i := 0; i < rows.Len(); i++ {
-				row := rows.At(i)
+			for rows.Len() > 0 {
+				row := rows.At(0)
+				rows.PopFirst()
 				if row.Len() == 1 {
 					// This seems hokey, but if we don't do this then the subquery expands
 					// to a tuple of tuples instead of a tuple of values and an expression


### PR DESCRIPTION
Subqueries in distsql are executed, and their results stored in a
RowContainer. The rows are then serialized into expressions and sent
to the outer query execution. Previously, the expressions were
constructed by scanning over the RowContainer, so twice as much memory
was used. Now, we construct the expressions by popping rows
one-by-one, so that we use less memory when there are many rows.

Release note: None