### PR TITLE
storage: use 1PC path for pushed serializable txns without refresh spans

### DIFF
--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -404,7 +404,7 @@ func IsEndTransactionTriggeringRetryError(
 // be safely committed with a forwarded timestamp. This requires that
 // the transaction's timestamp has not leaked and that the transaction
 // has encountered no spans which require refreshing at the forwarded
-// timestamp. If either of those conditions are true, a cient-side
+// timestamp. If either of those conditions are true, a client-side
 // retry is required.
 func canForwardSerializableTimestamp(txn *roachpb.Transaction, noRefreshSpans bool) bool {
 	return !txn.OrigTimestampWasObserved && noRefreshSpans


### PR DESCRIPTION
This change allows serializable 1PC transactions to use the 1PC
fast-path (avoid txn records, avoid intents, etc.) even when their
timestamp has been pushed by the timestamp cache. This is allowed
when the transaction has no refresh spans.

This should reduce replication and storage traffic for workloads
like `kv95`, where it's often the case that 1PC transactions run
into the timestamp cache.

I believe this is actually fixing a regression introduced in 7cef8d4
which made part of d87a94e less effective for 1PC transactions.

Release note (performance improvement): 1PC transactions avoid writing
transaction record and intents when pushed due to reads at a higher
timestamp.