### PR TITLE
pgwire: Fix tests on go 1.11

### DIFF
--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -28,7 +28,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
@@ -49,13 +48,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
-// https://golang.org/cl/38533 and https://golang.org/cl/91115 changed the
-// validation message.
 func wrongArgCountString(want, got int) string {
-	if strings.HasPrefix(runtime.Version(), "go1.10") {
-		return fmt.Sprintf("sql: expected %d arguments, got %d", want, got)
-	}
-	return fmt.Sprintf("sql: statement expects %d inputs; got %d", want, got)
+	return fmt.Sprintf("sql: expected %d arguments, got %d", want, got)
 }
 
 func trivialQuery(pgURL url.URL) error {


### PR DESCRIPTION
This message changed between go 1.9 and 1.10, but the check didn't
account for go 1.11. We don't support 1.9 any more, so simplify.

Release note: None

I'm not sure why #30035 isn't running into problems with this test. 