### PR TITLE
storage/engine: split some pure MVCC logic out into storage/mvcc

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
@@ -1224,8 +1225,8 @@ func getAllRevisions(
 		if err := sst.IngestExternalFile(file.SST); err != nil {
 			return nil, err
 		}
-		start, end := engine.MVCCKey{Key: startKey}, engine.MVCCKey{Key: endKey}
-		if err := sst.Iterate(start, end, func(kv engine.MVCCKeyValue) (bool, error) {
+		start, end := mvcc.Key{Key: startKey}, mvcc.Key{Key: endKey}
+		if err := sst.Iterate(start, end, func(kv mvcc.KeyValue) (bool, error) {
 			if len(res) == 0 || !res[len(res)-1].Key.Equal(kv.Key.Key) {
 				res = append(res, versionedValues{Key: kv.Key.Key})
 			}

--- a/pkg/ccl/changefeedccl/poller.go
+++ b/pkg/ccl/changefeedccl/poller.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -256,7 +256,7 @@ func (p *poller) slurpSST(ctx context.Context, sst []byte) error {
 		return err
 	}
 	defer it.Close()
-	for it.Seek(engine.NilKey); ; it.Next() {
+	for it.Seek(mvcc.NilKey); ; it.Next() {
 		if ok, err := it.Valid(); err != nil {
 			return err
 		} else if !ok {

--- a/pkg/ccl/changefeedccl/table_history.go
+++ b/pkg/ccl/changefeedccl/table_history.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -24,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/pkg/errors"
@@ -256,7 +256,7 @@ func fetchTableDescriptorVersions(
 				return err
 			}
 			defer it.Close()
-			for it.Seek(engine.NilKey); ; it.Next() {
+			for it.Seek(mvcc.NilKey); ; it.Next() {
 				if ok, err := it.Valid(); err != nil {
 					return err
 				} else if !ok {

--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -103,7 +104,7 @@ func Load(
 	var tableDesc *sqlbase.TableDescriptor
 	var tableName string
 	var prevKey roachpb.Key
-	var kvs []engine.MVCCKeyValue
+	var kvs []mvcc.KeyValue
 	var kvBytes int64
 	backup := backupccl.BackupDescriptor{
 		Descriptors: []sqlbase.Descriptor{
@@ -208,8 +209,8 @@ func Load(
 				}
 				prevKey = kv.Key
 				kvBytes += int64(len(kv.Key) + len(kv.Value.RawBytes))
-				kvs = append(kvs, engine.MVCCKeyValue{
-					Key:   engine.MVCCKey{Key: kv.Key, Timestamp: kv.Value.Timestamp},
+				kvs = append(kvs, mvcc.KeyValue{
+					Key:   mvcc.Key{Key: kv.Key, Timestamp: kv.Value.Timestamp},
 					Value: kv.Value.RawBytes,
 				})
 			})
@@ -368,7 +369,7 @@ func writeSST(
 	backup *backupccl.BackupDescriptor,
 	base storageccl.ExportStorage,
 	tempPrefix string,
-	kvs []engine.MVCCKeyValue,
+	kvs []mvcc.KeyValue,
 	ts hlc.Timestamp,
 ) error {
 	if len(kvs) == 0 {

--- a/pkg/ccl/importccl/sst_writer_proc.go
+++ b/pkg/ccl/importccl/sst_writer_proc.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -368,7 +369,7 @@ func makeSSTs(
 		return nil
 	}
 
-	var kv engine.MVCCKeyValue
+	var kv mvcc.KeyValue
 	kv.Key.Timestamp.WallTime = walltime
 	// firstKey is always the first key of the span. lastKey, if nil, means the
 	// current SST hasn't yet filled up. Once the SST has filled up, lastKey is

--- a/pkg/ccl/storageccl/add_sstable.go
+++ b/pkg/ccl/storageccl/add_sstable.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -34,7 +35,7 @@ func evalAddSSTable(
 	args := cArgs.Args.(*roachpb.AddSSTableRequest)
 	h := cArgs.Header
 	ms := cArgs.Stats
-	mvccStartKey, mvccEndKey := engine.MVCCKey{Key: args.Key}, engine.MVCCKey{Key: args.EndKey}
+	mvccStartKey, mvccEndKey := mvcc.Key{Key: args.Key}, mvcc.Key{Key: args.EndKey}
 
 	// TODO(tschottdorf): restore the below in some form (gets in the way of testing).
 	// _, span := tracing.ChildSpan(ctx, fmt.Sprintf("AddSSTable [%s,%s)", args.Key, args.EndKey))
@@ -82,7 +83,7 @@ func evalAddSSTable(
 }
 
 func verifySSTable(
-	existingIter engine.SimpleIterator, data []byte, start, end engine.MVCCKey, nowNanos int64,
+	existingIter engine.SimpleIterator, data []byte, start, end mvcc.Key, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
 	// To verify every KV is a valid roachpb.KeyValue in the range [start, end)
 	// we a) pass a verify flag on the iterator so that as ComputeStatsGo calls
@@ -95,7 +96,7 @@ func verifySSTable(
 	defer dataIter.Close()
 
 	// Check that the first key is in the expected range.
-	dataIter.Seek(engine.MVCCKey{Key: keys.MinKey})
+	dataIter.Seek(mvcc.Key{Key: keys.MinKey})
 	ok, err := dataIter.Valid()
 	if err != nil {
 		return enginepb.MVCCStats{}, err

--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -146,7 +147,7 @@ func runIterate(
 		endTime := hlc.Timestamp{WallTime: int64(loadFactor * numBatches * batchTimeSpan)}
 		it := makeIterator(eng, startTime, endTime)
 		defer it.Close()
-		for it.Seek(engine.MVCCKey{}); ; it.Next() {
+		for it.Seek(mvcc.Key{}); ; it.Next() {
 			if ok, err := it.Valid(); !ok {
 				if err != nil {
 					b.Fatal(err)

--- a/pkg/ccl/storageccl/engineccl/multi_iterator.go
+++ b/pkg/ccl/storageccl/engineccl/multi_iterator.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 )
 
 const invalidIdxSentinel = -1
@@ -58,7 +59,7 @@ func (f *multiIterator) Close() {
 
 // Seek advances the iterator to the first key in the engine which is >= the
 // provided key.
-func (f *multiIterator) Seek(key engine.MVCCKey) {
+func (f *multiIterator) Seek(key mvcc.Key) {
 	for _, iter := range f.iters {
 		iter.Seek(key)
 	}
@@ -81,7 +82,7 @@ func (f *multiIterator) Valid() (bool, error) {
 
 // UnsafeKey returns the current key, but the memory is invalidated on the next
 // call to {NextKey,Seek}.
-func (f *multiIterator) UnsafeKey() engine.MVCCKey {
+func (f *multiIterator) UnsafeKey() mvcc.Key {
 	return f.iters[f.currentIdx].UnsafeKey()
 }
 
@@ -135,7 +136,7 @@ func (f *multiIterator) advance() {
 		// Fill proposedMVCCKey with the mvcc key of the current best for the
 		// next value for currentIdx (or a sentinel that sorts after everything
 		// if this is the first non-exhausted iterator).
-		proposedMVCCKey := engine.MVCCKey{Key: keys.MaxKey}
+		proposedMVCCKey := mvcc.Key{Key: keys.MaxKey}
 		if proposedNextIdx != invalidIdxSentinel {
 			proposedMVCCKey = f.iters[proposedNextIdx].UnsafeKey()
 		}

--- a/pkg/ccl/storageccl/engineccl/multi_iterator_test.go
+++ b/pkg/ccl/storageccl/engineccl/multi_iterator_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
@@ -96,7 +97,7 @@ func TestMultiIterator(t *testing.T) {
 						v = []byte{input[i+1]}
 					}
 					i += 2
-					if err := batch.Put(engine.MVCCKey{Key: k, Timestamp: ts}, v); err != nil {
+					if err := batch.Put(mvcc.Key{Key: k, Timestamp: ts}, v); err != nil {
 						t.Fatalf("%+v", err)
 					}
 				}
@@ -117,7 +118,7 @@ func TestMultiIterator(t *testing.T) {
 				t.Run(subtest.name, func(t *testing.T) {
 					var output bytes.Buffer
 					it := MakeMultiIterator(iters)
-					for it.Seek(engine.MVCCKey{Key: keys.MinKey}); ; subtest.fn(it) {
+					for it.Seek(mvcc.Key{Key: keys.MinKey}); ; subtest.fn(it) {
 						ok, err := it.Valid()
 						if err != nil {
 							t.Fatalf("unexpected error: %+v", err)

--- a/pkg/ccl/storageccl/engineccl/mvcc.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/pkg/errors"
 )
@@ -89,7 +90,7 @@ func NewMVCCIncrementalIterator(e engine.Reader, opts IterOptions) *MVCCIncremen
 
 // Seek advances the iterator to the first key in the engine which is >= the
 // provided key.
-func (i *MVCCIncrementalIterator) Seek(startKey engine.MVCCKey) {
+func (i *MVCCIncrementalIterator) Seek(startKey mvcc.Key) {
 	i.iter.Seek(startKey)
 	i.err = nil
 	i.valid = true
@@ -190,7 +191,7 @@ func (i *MVCCIncrementalIterator) Valid() (bool, error) {
 }
 
 // Key returns the current key.
-func (i *MVCCIncrementalIterator) Key() engine.MVCCKey {
+func (i *MVCCIncrementalIterator) Key() mvcc.Key {
 	return i.iter.Key()
 }
 
@@ -201,7 +202,7 @@ func (i *MVCCIncrementalIterator) Value() []byte {
 
 // UnsafeKey returns the same key as Key, but the memory is invalidated on the
 // next call to {Next,Reset,Close}.
-func (i *MVCCIncrementalIterator) UnsafeKey() engine.MVCCKey {
+func (i *MVCCIncrementalIterator) UnsafeKey() mvcc.Key {
 	return i.iter.UnsafeKey()
 }
 

--- a/pkg/ccl/storageccl/engineccl/rocksdb.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/pkg/errors"
 )
 
@@ -39,9 +40,7 @@ func init() {
 
 // VerifyBatchRepr asserts that all keys in a BatchRepr are between the specified
 // start and end keys and computes the enginepb.MVCCStats for it.
-func VerifyBatchRepr(
-	repr []byte, start, end engine.MVCCKey, nowNanos int64,
-) (enginepb.MVCCStats, error) {
+func VerifyBatchRepr(repr []byte, start, end mvcc.Key, nowNanos int64) (enginepb.MVCCStats, error) {
 	// We store a 4 byte checksum of each key/value entry in the value. Make
 	// sure the all ones in this BatchRepr validate.
 	//
@@ -109,7 +108,7 @@ func goToCSlice(b []byte) C.DBSlice {
 	}
 }
 
-func goToCKey(key engine.MVCCKey) C.DBKey {
+func goToCKey(key mvcc.Key) C.DBKey {
 	return C.DBKey{
 		key:       goToCSlice(key.Key),
 		wall_time: C.int64_t(key.Timestamp.WallTime),

--- a/pkg/ccl/storageccl/engineccl/rocksdb_test.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -21,14 +22,14 @@ import (
 func TestVerifyBatchRepr(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	keyA := engine.MVCCKey{Key: []byte("a")}
-	keyB := engine.MVCCKey{Key: []byte("b")}
-	keyC := engine.MVCCKey{Key: []byte("c")}
-	keyD := engine.MVCCKey{Key: []byte("d")}
-	keyE := engine.MVCCKey{Key: []byte("e")}
+	keyA := mvcc.Key{Key: []byte("a")}
+	keyB := mvcc.Key{Key: []byte("b")}
+	keyC := mvcc.Key{Key: []byte("c")}
+	keyD := mvcc.Key{Key: []byte("d")}
+	keyE := mvcc.Key{Key: []byte("e")}
 
 	var batch engine.RocksDBBatchBuilder
-	key := engine.MVCCKey{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
+	key := mvcc.Key{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
 	batch.Put(key, roachpb.MakeValueFromString("1").RawBytes)
 	data := batch.Finish()
 
@@ -52,7 +53,7 @@ func TestVerifyBatchRepr(t *testing.T) {
 	// Invalid key/value entry checksum.
 	{
 		var batch engine.RocksDBBatchBuilder
-		key := engine.MVCCKey{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
+		key := mvcc.Key{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
 		value := roachpb.MakeValueFromString("1")
 		value.InitChecksum([]byte("foo"))
 		batch.Put(key, value.RawBytes)

--- a/pkg/ccl/storageccl/engineccl/sst_iterator.go
+++ b/pkg/ccl/storageccl/engineccl/sst_iterator.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 )
 
 var readerOpts = &db.Options{
@@ -31,7 +32,7 @@ type sstIterator struct {
 
 	valid   bool
 	err     error
-	mvccKey engine.MVCCKey
+	mvccKey mvcc.Key
 
 	// For allocation avoidance in NextKey.
 	nextKeyStart []byte
@@ -95,7 +96,7 @@ func (r *sstIterator) Close() {
 }
 
 // Seek implements the engine.SimpleIterator interface.
-func (r *sstIterator) Seek(key engine.MVCCKey) {
+func (r *sstIterator) Seek(key mvcc.Key) {
 	if r.iter != nil {
 		if r.err = errors.Wrap(r.iter.Close(), "resetting sstable iterator"); r.err != nil {
 			return
@@ -152,7 +153,7 @@ func (r *sstIterator) NextKey() {
 }
 
 // UnsafeKey implements the engine.SimpleIterator interface.
-func (r *sstIterator) UnsafeKey() engine.MVCCKey {
+func (r *sstIterator) UnsafeKey() mvcc.Key {
 	return r.mvccKey
 }
 

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -194,7 +195,7 @@ func evalExport(
 		if err := rows.Count(iter.UnsafeKey().Key); err != nil {
 			return result.Result{}, errors.Wrapf(err, "decoding %s", iter.UnsafeKey())
 		}
-		if err := sst.Add(engine.MVCCKeyValue{Key: iter.UnsafeKey(), Value: iter.UnsafeValue()}); err != nil {
+		if err := sst.Add(mvcc.KeyValue{Key: iter.UnsafeKey(), Value: iter.UnsafeValue()}); err != nil {
 			return result.Result{}, errors.Wrapf(err, "adding key %s", iter.UnsafeKey())
 		}
 	}

--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -53,8 +54,8 @@ func evalWriteBatch(
 		return result.Result{}, errors.New("data spans multiple ranges")
 	}
 
-	mvccStartKey := engine.MVCCKey{Key: args.Key}
-	mvccEndKey := engine.MVCCKey{Key: args.EndKey}
+	mvccStartKey := mvcc.Key{Key: args.Key}
+	mvccEndKey := mvcc.Key{Key: args.EndKey}
 
 	// Verify that the keys in the batch are within the range specified by the
 	// request header.
@@ -79,11 +80,11 @@ func evalWriteBatch(
 }
 
 func clearExistingData(
-	ctx context.Context, batch engine.ReadWriter, start, end engine.MVCCKey, nowNanos int64,
+	ctx context.Context, batch engine.ReadWriter, start, end mvcc.Key, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
 	{
 		isEmpty := true
-		if err := batch.Iterate(start, end, func(_ engine.MVCCKeyValue) (bool, error) {
+		if err := batch.Iterate(start, end, func(_ mvcc.KeyValue) (bool, error) {
 			isEmpty = false
 			return true, nil // stop right away
 		}); err != nil {

--- a/pkg/ccl/storageccl/writebatch_test.go
+++ b/pkg/ccl/storageccl/writebatch_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -42,7 +43,7 @@ func TestDBWriteBatch(t *testing.T) {
 
 	{
 		var batch engine.RocksDBBatchBuilder
-		key := engine.MVCCKey{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
+		key := mvcc.Key{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
 		batch.Put(key, roachpb.MakeValueFromString("1").RawBytes)
 		data := batch.Finish()
 
@@ -72,7 +73,7 @@ func TestDBWriteBatch(t *testing.T) {
 	// Key range in request span is not empty.
 	{
 		var batch engine.RocksDBBatchBuilder
-		key := engine.MVCCKey{Key: []byte("bb2"), Timestamp: hlc.Timestamp{WallTime: 1}}
+		key := mvcc.Key{Key: []byte("bb2"), Timestamp: hlc.Timestamp{WallTime: 1}}
 		batch.Put(key, roachpb.MakeValueFromString("2").RawBytes)
 		data := batch.Finish()
 		if err := db.WriteBatch(ctx, "b", "c", data); err != nil {
@@ -95,7 +96,7 @@ func TestDBWriteBatch(t *testing.T) {
 	// Invalid key/value entry checksum.
 	{
 		var batch engine.RocksDBBatchBuilder
-		key := engine.MVCCKey{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
+		key := mvcc.Key{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
 		value := roachpb.MakeValueFromString("1")
 		value.InitChecksum([]byte("foo"))
 		batch.Put(key, value.RawBytes)
@@ -116,7 +117,7 @@ func TestWriteBatchMVCCStats(t *testing.T) {
 
 	var batch engine.RocksDBBatchBuilder
 	{
-		key := engine.MVCCKey{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
+		key := mvcc.Key{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
 		batch.Put(key, roachpb.MakeValueFromString("1").RawBytes)
 	}
 	data := batch.Finish()
@@ -127,7 +128,7 @@ func TestWriteBatchMVCCStats(t *testing.T) {
 	// adjusted accordingly.
 	const numInitialEntries = 100
 	for i := 0; i < numInitialEntries; i++ {
-		if err := e.Put(engine.MVCCKey{Key: append([]byte("b"), byte(i))}, nil); err != nil {
+		if err := e.Put(mvcc.Key{Key: append([]byte("b"), byte(i))}, nil); err != nil {
 			t.Fatalf("%+v", err)
 		}
 	}

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	isatty "github.com/mattn/go-isatty"
 )
@@ -94,8 +94,8 @@ func initCLIDefaults() {
 	dumpCtx.dumpMode = dumpBoth
 	dumpCtx.asOf = ""
 
-	debugCtx.startKey = engine.NilKey
-	debugCtx.endKey = engine.MVCCKeyMax
+	debugCtx.startKey = mvcc.NilKey
+	debugCtx.endKey = mvcc.KeyMax
 	debugCtx.values = false
 	debugCtx.sizes = false
 	debugCtx.replicated = false
@@ -229,7 +229,7 @@ var dumpCtx struct {
 // debugCtx captures the command-line parameters of the `debug` command.
 // Defaults set by InitCLIDefaults() above.
 var debugCtx struct {
-	startKey, endKey  engine.MVCCKey
+	startKey, endKey  mvcc.Key
 	values            bool
 	sizes             bool
 	replicated        bool

--- a/pkg/cli/flags_util.go
+++ b/pkg/cli/flags_util.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	humanize "github.com/dustin/go-humanize"
@@ -140,14 +141,14 @@ func (m *dumpMode) Set(s string) error {
 	return nil
 }
 
-type mvccKey engine.MVCCKey
+type mvccKey mvcc.Key
 
 // Type implements the pflag.Value interface.
-func (k *mvccKey) Type() string { return "engine.MVCCKey" }
+func (k *mvccKey) Type() string { return "mvcc.Key" }
 
 // String implements the pflag.Value interface.
 func (k *mvccKey) String() string {
-	return engine.MVCCKey(*k).String()
+	return mvcc.Key(*k).String()
 }
 
 // Set implements the pflag.Value interface.

--- a/pkg/sql/sqlbase/dep_test.go
+++ b/pkg/sql/sqlbase/dep_test.go
@@ -23,7 +23,6 @@ import (
 
 func TestNoLinkForbidden(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#30001")
 
 	buildutil.VerifyNoImports(t,
 		"github.com/cockroachdb/cockroach/pkg/sql/sqlbase", true, []string{"c-deps"}, nil,

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -468,12 +468,12 @@ func (rf *RowFetcher) nextKV(
 	}
 	if rf.batchNumKvs > 0 {
 		rf.batchNumKvs--
-		var key engine.MVCCKey
+		var key mvcc.Key
 		var rawBytes []byte
 		var err error
 		newSpan = rf.maybeNewSpan
 		rf.maybeNewSpan = false
-		key, rawBytes, rf.batchResponse, err = engine.MVCCScanDecodeKeyValue(rf.batchResponse)
+		key, rawBytes, rf.batchResponse, err = mvcc.ScanDecodeKeyValue(rf.batchResponse)
 		if err != nil {
 			return false, kv, false, err
 		}

--- a/pkg/sql/sqlbase/rowfetcher_mvcc_test.go
+++ b/pkg/sql/sqlbase/rowfetcher_mvcc_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -41,7 +42,7 @@ func slurpUserDataKVs(t testing.TB, e engine.Engine) []roachpb.KeyValue {
 	var kvs []roachpb.KeyValue
 	it := e.NewIterator(engine.IterOptions{UpperBound: roachpb.KeyMax})
 	defer it.Close()
-	for it.Seek(engine.MVCCKey{Key: keys.UserTableDataMin}); ; it.NextKey() {
+	for it.Seek(mvcc.Key{Key: keys.UserTableDataMin}); ; it.NextKey() {
 		ok, err := it.Valid()
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/storage/batch_spanset_test.go
+++ b/pkg/storage/batch_spanset_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -113,7 +114,7 @@ func TestSpanSetBatch(t *testing.T) {
 		t.Errorf("GetProto: unexpected error %v", err)
 	}
 	if err := batch.Iterate(outsideKey, outsideKey2,
-		func(v engine.MVCCKeyValue) (bool, error) {
+		func(v mvcc.KeyValue) (bool, error) {
 			return false, errors.Errorf("unexpected callback: %v", v)
 		},
 	); !isReadSpanErr(err) {

--- a/pkg/storage/batcheval/cmd_clear_range_test.go
+++ b/pkg/storage/batcheval/cmd_clear_range_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
@@ -35,12 +36,12 @@ type wrappedBatch struct {
 	clearRangeCount int
 }
 
-func (wb *wrappedBatch) Clear(key engine.MVCCKey) error {
+func (wb *wrappedBatch) Clear(key mvcc.Key) error {
 	wb.clearCount++
 	return wb.Batch.Clear(key)
 }
 
-func (wb *wrappedBatch) ClearRange(start, end engine.MVCCKey) error {
+func (wb *wrappedBatch) ClearRange(start, end mvcc.Key) error {
 	wb.clearRangeCount++
 	return wb.Batch.ClearRange(start, end)
 }
@@ -144,8 +145,8 @@ func TestCmdClearRangeBytesThreshold(t *testing.T) {
 				t.Fatal(err)
 			}
 			if err := eng.Iterate(
-				engine.MVCCKey{Key: startKey}, engine.MVCCKey{Key: endKey},
-				func(kv engine.MVCCKeyValue) (bool, error) {
+				mvcc.Key{Key: startKey}, mvcc.Key{Key: endKey},
+				func(kv mvcc.KeyValue) (bool, error) {
 					return true, errors.New("expected no data in underlying engine")
 				},
 			); err != nil {

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
@@ -121,7 +122,7 @@ func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 
 func getEngineKeySet(t *testing.T, e engine.Engine) map[string]struct{} {
 	t.Helper()
-	kvs, err := engine.Scan(e, engine.NilKey, engine.MVCCKeyMax, 0 /* max */)
+	kvs, err := engine.Scan(e, mvcc.NilKey, mvcc.KeyMax, 0 /* max */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/compactor/compactor_test.go
+++ b/pkg/storage/compactor/compactor_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -54,7 +55,7 @@ func newWrappedEngine() *wrappedEngine {
 }
 
 func (we *wrappedEngine) GetSSTables() engine.SSTableInfos {
-	key := func(s string) engine.MVCCKey {
+	key := func(s string) mvcc.Key {
 		return engine.MakeMVCCMetadataKey([]byte(s))
 	}
 	ssti := engine.SSTableInfos{
@@ -574,9 +575,9 @@ func TestCompactorThresholds(t *testing.T) {
 				// spans have been cleared and uncompacted spans remain.
 				var idx int
 				return we.Iterate(
-					engine.MVCCKey{Key: keys.LocalStoreSuggestedCompactionsMin},
-					engine.MVCCKey{Key: keys.LocalStoreSuggestedCompactionsMax},
-					func(kv engine.MVCCKeyValue) (bool, error) {
+					mvcc.Key{Key: keys.LocalStoreSuggestedCompactionsMin},
+					mvcc.Key{Key: keys.LocalStoreSuggestedCompactionsMax},
+					func(kv mvcc.KeyValue) (bool, error) {
 						start, end, err := keys.DecodeStoreSuggestedCompactionKey(kv.Key.Key)
 						if err != nil {
 							t.Fatalf("failed to decode suggested compaction key: %s", err)

--- a/pkg/storage/engine/batch.go
+++ b/pkg/storage/engine/batch.go
@@ -332,7 +332,7 @@ func SplitMVCCKey(mvccKey []byte) (key []byte, ts []byte, ok bool) {
 	return key, ts, true
 }
 
-// DecodeKey decodes an engine.MVCCKey from its serialized representation. This
+// DecodeKey decodes an mvcc.Key from its serialized representation. This
 // decoding must match engine/db.cc:DecodeKey().
 func DecodeKey(encodedKey []byte) (MVCCKey, error) {
 	key, ts, ok := SplitMVCCKey(encodedKey)

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -38,13 +39,13 @@ import (
 func mvccKey(k interface{}) MVCCKey {
 	switch k := k.(type) {
 	case string:
-		return MakeMVCCMetadataKey(roachpb.Key(k))
+		return mvcc.MakeMVCCMetadataKey(roachpb.Key(k))
 	case []byte:
-		return MakeMVCCMetadataKey(roachpb.Key(k))
+		return mvcc.MakeMVCCMetadataKey(roachpb.Key(k))
 	case roachpb.Key:
-		return MakeMVCCMetadataKey(k)
+		return mvcc.MakeMVCCMetadataKey(k)
 	case roachpb.RKey:
-		return MakeMVCCMetadataKey(roachpb.Key(k))
+		return mvcc.MakeMVCCMetadataKey(roachpb.Key(k))
 	default:
 		panic(fmt.Sprintf("unsupported type: %T", k))
 	}
@@ -745,7 +746,7 @@ func TestBatchBuilder(t *testing.T) {
 		{"c", hlc.Timestamp{WallTime: 1, Logical: 1}},
 	}
 	for _, data := range testData {
-		key := MVCCKey{roachpb.Key(data.key), data.ts}
+		key := MVCCKey{Key: roachpb.Key(data.key), Timestamp: data.ts}
 		if err := dbPut(batch.batch, key, []byte("value")); err != nil {
 			t.Fatal(err)
 		}
@@ -1003,9 +1004,9 @@ func TestBatchIteration(t *testing.T) {
 	b := e.NewBatch()
 	defer b.Close()
 
-	k1 := MakeMVCCMetadataKey(roachpb.Key("c"))
-	k2 := MakeMVCCMetadataKey(roachpb.Key("d"))
-	k3 := MakeMVCCMetadataKey(roachpb.Key("e"))
+	k1 := mvcc.MakeMVCCMetadataKey(roachpb.Key("c"))
+	k2 := mvcc.MakeMVCCMetadataKey(roachpb.Key("d"))
+	k3 := mvcc.MakeMVCCMetadataKey(roachpb.Key("e"))
 	v1 := []byte("value1")
 	v2 := []byte("value2")
 

--- a/pkg/storage/engine/bench_rocksdb_test.go
+++ b/pkg/storage/engine/bench_rocksdb_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
@@ -275,7 +276,7 @@ func BenchmarkBatchBuilderPut(b *testing.B) {
 		for j := i; j < end; j++ {
 			key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(j)))
 			ts := hlc.Timestamp{WallTime: int64(j)}
-			batch.Put(MVCCKey{key, ts}, value)
+			batch.Put(mvcc.Key{Key: key, Timestamp: ts}, value)
 		}
 		batch.Finish()
 	}

--- a/pkg/storage/engine/bench_test.go
+++ b/pkg/storage/engine/bench_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -708,7 +709,7 @@ func runBenchmarkClearRange(
 
 	for i := 0; i < b.N; i++ {
 		batch := eng.NewWriteOnlyBatch()
-		if err := clearRange(eng, batch, NilKey, MVCCKeyMax); err != nil {
+		if err := clearRange(eng, batch, mvcc.NilKey, mvcc.KeyMax); err != nil {
 			b.Fatal(err)
 		}
 		// NB: We don't actually commit the batch here as we don't want to delete

--- a/pkg/storage/engine/disk_map_test.go
+++ b/pkg/storage/engine/disk_map_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -199,7 +200,7 @@ func TestRocksDBMapSandbox(t *testing.T) {
 			func() {
 				i := tempEngine.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
 				defer i.Close()
-				for i.Seek(NilKey); ; i.Next() {
+				for i.Seek(mvcc.NilKey); ; i.Next() {
 					if ok, err := i.Valid(); err != nil {
 						t.Fatal(err)
 					} else if !ok {

--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -338,17 +339,17 @@ func TestEnginePutGetDelete(t *testing.T) {
 		// Test for correct handling of empty keys, which should produce errors.
 		for i, err := range []error{
 			engine.Put(mvccKey(""), []byte("")),
-			engine.Put(NilKey, []byte("")),
+			engine.Put(mvcc.NilKey, []byte("")),
 			func() error {
 				_, err := engine.Get(mvccKey(""))
 				return err
 			}(),
-			engine.Clear(NilKey),
+			engine.Clear(mvcc.NilKey),
 			func() error {
-				_, err := engine.Get(NilKey)
+				_, err := engine.Get(mvcc.NilKey)
 				return err
 			}(),
-			engine.Clear(NilKey),
+			engine.Clear(mvcc.NilKey),
 			engine.Clear(mvccKey("")),
 		} {
 			if err == nil {

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/zerofields"
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
@@ -122,7 +123,7 @@ func mvccGetGo(
 	buf := newGetBuffer()
 	defer buf.release()
 
-	metaKey := MakeMVCCMetadataKey(key)
+	metaKey := mvcc.MakeMVCCMetadataKey(key)
 	ok, _, _, err := mvccGetMetadata(iter, metaKey, &buf.meta)
 	if !ok || err != nil {
 		return nil, nil, err
@@ -1316,7 +1317,7 @@ func TestMVCCInvalidateIterator(t *testing.T) {
 			{
 				// Seek the iter to a valid position.
 				iter := batch.NewIterator(iterOptions)
-				iter.Seek(MakeMVCCMetadataKey(key))
+				iter.Seek(mvcc.MakeMVCCMetadataKey(key))
 				iter.Close()
 			}
 
@@ -1330,7 +1331,7 @@ func TestMVCCInvalidateIterator(t *testing.T) {
 				_, err = MVCCFindSplitKey(ctx, batch, roachpb.RKeyMin, roachpb.RKeyMax, 64<<20)
 			case "computeStats":
 				iter := batch.NewIterator(iterOptions)
-				_, err = iter.ComputeStats(NilKey, MVCCKeyMax, 0)
+				_, err = iter.ComputeStats(mvcc.NilKey, mvcc.KeyMax, 0)
 				iter.Close()
 			}
 			if err != nil {

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -1989,7 +1990,7 @@ func (r *rocksDBIterator) setOptions(opts IterOptions) {
 	if !opts.Prefix && len(opts.UpperBound) == 0 {
 		panic("iterator must set prefix or upper bound")
 	}
-	C.DBIterSetUpperBound(r.iter, goToCKey(MakeMVCCMetadataKey(opts.UpperBound)))
+	C.DBIterSetUpperBound(r.iter, goToCKey(mvcc.MakeMVCCMetadataKey(opts.UpperBound)))
 }
 
 func (r *rocksDBIterator) checkEngineOpen() {
@@ -2211,7 +2212,7 @@ func (r *rocksDBIterator) MVCCGet(
 
 	// Extract the value from the batch data.
 	repr := copyFromSliceVector(state.data.bufs, state.data.len)
-	mvccKey, rawValue, _, err := MVCCScanDecodeKeyValue(repr)
+	mvccKey, rawValue, _, err := mvcc.ScanDecodeKeyValue(repr)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2254,7 +2255,7 @@ func (r *rocksDBIterator) MVCCScan(
 }
 
 func (r *rocksDBIterator) SetUpperBound(key roachpb.Key) {
-	C.DBIterSetUpperBound(r.iter, goToCKey(MakeMVCCMetadataKey(key)))
+	C.DBIterSetUpperBound(r.iter, goToCKey(mvcc.MakeMVCCMetadataKey(key)))
 }
 
 func copyFromSliceVector(bufs *C.DBSlice, len C.int32_t) []byte {
@@ -2405,7 +2406,7 @@ func goToCTxn(txn *roachpb.Transaction) C.DBTxn {
 func goToCIterOptions(opts IterOptions) C.DBIterOptions {
 	return C.DBIterOptions{
 		prefix:             C.bool(opts.Prefix),
-		upper_bound:        goToCKey(MakeMVCCMetadataKey(opts.UpperBound)),
+		upper_bound:        goToCKey(mvcc.MakeMVCCMetadataKey(opts.UpperBound)),
 		min_timestamp_hint: goToCTimestamp(opts.MinTimestampHint),
 		max_timestamp_hint: goToCTimestamp(opts.MaxTimestampHint),
 		with_stats:         C.bool(opts.WithStats),
@@ -2561,7 +2562,7 @@ func dbClearRange(rdb *C.DBEngine, start, end MVCCKey) error {
 		prev = prev[:n]
 	}
 	if start.Key.Compare(prev) < 0 {
-		if err := dbClear(rdb, MakeMVCCMetadataKey(prev)); err != nil {
+		if err := dbClear(rdb, mvcc.MakeMVCCMetadataKey(prev)); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/engine/rocksdb_iter_stats_test.go
+++ b/pkg/storage/engine/rocksdb_iter_stats_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
@@ -28,7 +29,7 @@ func TestIterStats(t *testing.T) {
 	db := setupMVCCInMemRocksDB(t, "test_iter_stats")
 	defer db.Close()
 
-	k := MakeMVCCMetadataKey(roachpb.Key("foo"))
+	k := mvcc.MakeMVCCMetadataKey(roachpb.Key("foo"))
 	if err := db.Put(k, []byte("abc")); err != nil {
 		t.Fatal(err)
 	}
@@ -55,8 +56,8 @@ func TestIterStats(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			// Seeking past the tombstone manually counts it.
 			for i := 0; i < 10; i++ {
-				iter.Seek(NilKey)
-				iter.Seek(MVCCKeyMax)
+				iter.Seek(mvcc.NilKey)
+				iter.Seek(mvcc.KeyMax)
 				stats := iter.Stats()
 				if e, a := i+1, stats.InternalDeleteSkippedCount; a != e {
 					t.Errorf("expected internal delete skipped count of %d, not %d", e, a)

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/abortspan"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -725,7 +726,7 @@ func RunGC(
 	var batchGCKeys []roachpb.GCRequest_GCKey
 	var batchGCKeysBytes int64
 	var expBaseKey roachpb.Key
-	var keys []engine.MVCCKey
+	var keys []mvcc.Key
 	var vals [][]byte
 	var keyBytes int64
 	var valBytes int64
@@ -841,12 +842,12 @@ func RunGC(
 			processKeysAndValues()
 			expBaseKey = iterKey.Key
 			if !iterKey.IsValue() {
-				keys = []engine.MVCCKey{iter.Key()}
+				keys = []mvcc.Key{iter.Key()}
 				vals = [][]byte{iter.Value()}
 				continue
 			}
 			// An implicit metadata.
-			keys = []engine.MVCCKey{engine.MakeMVCCMetadataKey(iterKey.Key)}
+			keys = []mvcc.Key{engine.MakeMVCCMetadataKey(iterKey.Key)}
 			// A nil value for the encoded MVCCMetadata. This will unmarshal to an
 			// empty MVCCMetadata which is sufficient for processKeysAndValues to
 			// determine that there is no intent.

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -868,7 +869,7 @@ func TestGCQueueIntentResolution(t *testing.T) {
 	testutils.SucceedsSoon(t, func() error {
 		meta := &enginepb.MVCCMetadata{}
 		return tc.store.Engine().Iterate(engine.MakeMVCCMetadataKey(roachpb.KeyMin),
-			engine.MakeMVCCMetadataKey(roachpb.KeyMax), func(kv engine.MVCCKeyValue) (bool, error) {
+			engine.MakeMVCCMetadataKey(roachpb.KeyMax), func(kv mvcc.KeyValue) (bool, error) {
 				if !kv.Key.IsValue() {
 					if err := protoutil.Unmarshal(kv.Value, meta); err != nil {
 						return false, err

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
 	"github.com/pkg/errors"
 
@@ -452,7 +453,7 @@ func (r *Replica) HasBogusSideloadedData() bool {
 	return true
 }
 
-func MakeSSTable(key, value string, ts hlc.Timestamp) ([]byte, engine.MVCCKeyValue) {
+func MakeSSTable(key, value string, ts hlc.Timestamp) ([]byte, mvcc.KeyValue) {
 	sst, err := engine.MakeRocksDBSstFileWriter()
 	if err != nil {
 		panic(err)
@@ -462,8 +463,8 @@ func MakeSSTable(key, value string, ts hlc.Timestamp) ([]byte, engine.MVCCKeyVal
 	v := roachpb.MakeValueFromBytes([]byte(value))
 	v.InitChecksum([]byte(key))
 
-	kv := engine.MVCCKeyValue{
-		Key: engine.MVCCKey{
+	kv := mvcc.KeyValue{
+		Key: mvcc.Key{
 			Key:       []byte(key),
 			Timestamp: ts,
 		},

--- a/pkg/storage/mvcc/mvcc.go
+++ b/pkg/storage/mvcc/mvcc.go
@@ -1,0 +1,178 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mvcc
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/pkg/errors"
+)
+
+const (
+	// VersionTimestampSize is the size of the timestamp portion of MVCC version keys (used to update stats).
+	VersionTimestampSize int64 = 12
+)
+
+var (
+	// KeyMax is a maximum mvcc-encoded key value which sorts after
+	// all other keys.`
+	KeyMax = MakeMVCCMetadataKey(roachpb.KeyMax)
+	// NilKey is the nil Key.
+	NilKey = Key{}
+)
+
+// Key is a versioned key, distinguished from roachpb.Key with the addition
+// of a timestamp.
+type Key struct {
+	Key       roachpb.Key
+	Timestamp hlc.Timestamp
+}
+
+// MakeMVCCMetadataKey creates an Key from a roachpb.Key.
+func MakeMVCCMetadataKey(key roachpb.Key) Key {
+	return Key{Key: key}
+}
+
+// Next returns the next key.
+func (k Key) Next() Key {
+	ts := k.Timestamp.Prev()
+	if ts == (hlc.Timestamp{}) {
+		return Key{
+			Key: k.Key.Next(),
+		}
+	}
+	return Key{
+		Key:       k.Key,
+		Timestamp: ts,
+	}
+}
+
+// Less compares two keys.
+func (k Key) Less(l Key) bool {
+	if c := k.Key.Compare(l.Key); c != 0 {
+		return c < 0
+	}
+	if !k.IsValue() {
+		return l.IsValue()
+	} else if !l.IsValue() {
+		return false
+	}
+	return l.Timestamp.Less(k.Timestamp)
+}
+
+// Equal returns whether two keys are identical.
+func (k Key) Equal(l Key) bool {
+	return k.Key.Compare(l.Key) == 0 && k.Timestamp == l.Timestamp
+}
+
+// IsValue returns true iff the timestamp is non-zero.
+func (k Key) IsValue() bool {
+	return k.Timestamp != (hlc.Timestamp{})
+}
+
+// EncodedSize returns the size of the Key when encoded.
+func (k Key) EncodedSize() int {
+	n := len(k.Key) + 1
+	if k.IsValue() {
+		// Note that this isn't quite accurate: timestamps consume between 8-13
+		// bytes. Fixing this only adjusts the accounting for timestamps, not the
+		// actual on disk storage.
+		n += int(VersionTimestampSize)
+	}
+	return n
+}
+
+// String returns a string-formatted version of the key.
+func (k Key) String() string {
+	if !k.IsValue() {
+		return k.Key.String()
+	}
+	return fmt.Sprintf("%s/%s", k.Key, k.Timestamp)
+}
+
+// KeyValue contains the raw bytes of the value for a key.
+type KeyValue struct {
+	Key   Key
+	Value []byte
+}
+
+// ScanDecodeKeyValue decodes a key/value pair returned in an MVCCScan
+// "batch" (this is not the RocksDB batch repr format), returning both the
+// key/value and the suffix of data remaining in the batch.
+func ScanDecodeKeyValue(repr []byte) (key Key, value []byte, orepr []byte, err error) {
+	if len(repr) < 8 {
+		return key, nil, repr, errors.Errorf("unexpected batch EOF")
+	}
+	v := binary.LittleEndian.Uint64(repr)
+	keySize := v >> 32
+	valSize := v & ((1 << 32) - 1)
+	if (keySize + valSize) > uint64(len(repr)) {
+		return key, nil, nil, fmt.Errorf("expected %d bytes, but only %d remaining",
+			keySize+valSize, len(repr))
+	}
+	repr = repr[8:]
+	rawKey := repr[:keySize]
+	value = repr[keySize : keySize+valSize]
+	repr = repr[keySize+valSize:]
+	key, err = DecodeKey(rawKey)
+	return key, value, repr, err
+}
+
+// DecodeKey decodes an engine.Key from its serialized representation. This
+// decoding must match engine/db.cc:DecodeKey().
+func DecodeKey(encodedKey []byte) (Key, error) {
+	key, ts, ok := SplitKey(encodedKey)
+	if !ok {
+		return Key{}, errors.Errorf("invalid encoded mvcc key: %x", encodedKey)
+	}
+
+	mvccKey := Key{Key: key}
+	switch len(ts) {
+	case 0:
+		// No-op.
+	case 8:
+		mvccKey.Timestamp.WallTime = int64(binary.BigEndian.Uint64(ts[0:8]))
+	case 12:
+		mvccKey.Timestamp.WallTime = int64(binary.BigEndian.Uint64(ts[0:8]))
+		mvccKey.Timestamp.Logical = int32(binary.BigEndian.Uint32(ts[8:12]))
+	default:
+		return Key{}, errors.Errorf(
+			"invalid encoded mvcc key: %x bad timestamp %x", encodedKey, ts)
+	}
+
+	return mvccKey, nil
+}
+
+// SplitKey returns the key and timestamp components of an encoded MVCC key. This
+// decoding must match engine/db.cc:SplitKey().
+func SplitKey(Key []byte) (key []byte, ts []byte, ok bool) {
+	if len(Key) == 0 {
+		return nil, nil, false
+	}
+	tsLen := int(Key[len(Key)-1])
+	keyPartEnd := len(Key) - 1 - tsLen
+	if keyPartEnd < 0 {
+		return nil, nil, false
+	}
+
+	key = Key[:keyPartEnd]
+	if tsLen > 0 {
+		ts = Key[keyPartEnd+1 : len(Key)-1]
+	}
+	return key, ts, true
+}

--- a/pkg/storage/rangefeed/processor_test.go
+++ b/pkg/storage/rangefeed/processor_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -456,7 +457,7 @@ func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	txn1, txn2 := uuid.MakeV4(), uuid.MakeV4()
-	rtsIter := newTestIterator([]engine.MVCCKeyValue{
+	rtsIter := newTestIterator([]mvcc.KeyValue{
 		makeKV("a", "val1", 10),
 		makeInline("b", "val2"),
 		makeIntent("c", txn1, "txnKey1", 15),
@@ -546,7 +547,7 @@ func TestProcessorCatchUpScan(t *testing.T) {
 	require.Equal(t, hlc.Timestamp{}, p.rts.Get())
 
 	txn1, txn2 := uuid.MakeV4(), uuid.MakeV4()
-	catchUpIter := newTestIterator([]engine.MVCCKeyValue{
+	catchUpIter := newTestIterator([]mvcc.KeyValue{
 		makeKV("a", "val1", 10),
 		makeInline("b", "val2"),
 		makeIntent("c", txn1, "txnKey1", 15),

--- a/pkg/storage/rditer/replica_data_iter.go
+++ b/pkg/storage/rditer/replica_data_iter.go
@@ -18,12 +18,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 )
 
 // KeyRange is a helper struct for the ReplicaDataIterator.
 type KeyRange struct {
-	Start, End engine.MVCCKey
+	Start, End mvcc.Key
 }
 
 // ReplicaDataIterator provides a complete iteration over all key / value
@@ -142,7 +143,7 @@ func (ri *ReplicaDataIterator) Valid() (bool, error) {
 }
 
 // Key returns the current key.
-func (ri *ReplicaDataIterator) Key() engine.MVCCKey {
+func (ri *ReplicaDataIterator) Key() mvcc.Key {
 	key := ri.it.UnsafeKey()
 	ri.a, key.Key = ri.a.Copy(key.Key, 0)
 	return key

--- a/pkg/storage/replica_consistency.go
+++ b/pkg/storage/replica_consistency.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
@@ -365,7 +366,7 @@ func (r *Replica) sha512(
 	var timestampBuf []byte
 	hasher := sha512.New()
 
-	visitor := func(unsafeKey engine.MVCCKey, unsafeValue []byte) error {
+	visitor := func(unsafeKey mvcc.Key, unsafeValue []byte) error {
 		if snapshot != nil {
 			// Add (a copy of) the kv pair into the debug message.
 			kv := roachpb.RaftSnapshotData_KeyValue{

--- a/pkg/storage/replica_consistency_diff.go
+++ b/pkg/storage/replica_consistency_diff.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
@@ -69,7 +70,7 @@ func (rsds ReplicaSnapshotDiffSlice) WriteTo(w io.Writer) (int64, error) {
 			prefix, ts.WallTime/1E9, ts.WallTime%1E9, ts.Logical, d.Key,
 			prefix, prettyTime,
 			prefix, d.Value,
-			prefix, engine.EncodeKey(engine.MVCCKey{Key: d.Key, Timestamp: ts}), d.Value)
+			prefix, engine.EncodeKey(mvcc.Key{Key: d.Key, Timestamp: ts}), d.Value)
 		if err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
More work on #30001.

This splits some pure-go MVCC encoding/decodeing logic out of
`stroage/engine` into a new package `storage/mvcc` so it no longer
shares a package any of the rocksdb interfacing code that lives in
`storage/engine`. This is so that callers can import and use these functions
without introducing our c-deps code to their dependency closure, which
is an issue if callers might end up being used outside of the cockroach build
environment or share packages with code that is.

This is just a mechanical code move with a following rename to avoid
repeating the package name in func/var prefixes, eg. `MVCCKey` ->
`mvcc.Key`, and only includes `MVCCKey` as well as those functions that were
in-use within sqlbase. Significant MVCC encoding/decoding code reamins that can
be moved later as needed.

Release note: none.

sqlbase: unskip c-deps dependency linter.