### PR TITLE
release-2.1: client: hold on to the correct txn id

### DIFF
--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -790,9 +790,8 @@ func (txn *Txn) Send(
 		ba.Header.GatewayNodeID = txn.gatewayNodeID
 	}
 
-	requestTxnID := txn.ID()
-
 	txn.mu.Lock()
+	requestTxnID := txn.mu.ID
 	sender := txn.mu.sender
 	txn.mu.Unlock()
 	br, pErr := txn.db.sendUsingSender(ctx, ba, sender)


### PR DESCRIPTION
Backport 1/1 commits from #30038.

/cc @cockroachdb/release

---

When sending requests, Txn.Send() remembers the txn's ID before the send
and asserts that errors received reference the correct txn.
This patch fixes a race where the id we were remembering was not, in
fact, the txn used to send the request. The id was not read atomically
with sending, and so a TransactionAbortedError at the right time could
cause the assertion to fail.

Fixes #29052

Release note (bug fix): Fix a rare crash with the message "retryable
error for the wrong txn".
