### PR TITLE
release-2.1: gossip: avoid allocation of UnresolvedAddr in getNodeIDAddressLocked

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1000,13 +1000,13 @@ func (g *Gossip) getNodeIDAddressLocked(nodeID roachpb.NodeID) (*util.Unresolved
 	if err != nil {
 		return nil, err
 	}
-	address := &nd.Address
-	for _, locality := range nd.LocalityAddress {
+	for i := range nd.LocalityAddress {
+		locality := &nd.LocalityAddress[i]
 		if _, ok := g.localityTierMap[locality.LocalityTier.String()]; ok {
 			return &locality.Address, nil
 		}
 	}
-	return address, nil
+	return &nd.Address, nil
 }
 
 // AddInfo adds or updates an info object. Returns an error if info


### PR DESCRIPTION
Backport 1/1 commits from #29585.

/cc @cockroachdb/release

---

`getNodeIDAddressLocked` is called from `Dialer.ConnHealth` and
`Dialer.DialInternalClient`. It was responsible for **1.71%** of all
allocations (`alloc_objects`) on a 3-node long-running cluster that
was running TPC-C 1K.

Pointing into `nd.LocalityAddress` is safe because even if the `NodeDescriptor`
itself is replaced in `Gossip`, the struct is never internally mutated. This is
the same reason why taking the address of `nd.Address` was already safe.

Release note (performance improvement): Avoid allocation when
checking RPC connection health.
