### PR TITLE
storage: Fix AmbientCtx handling during Store construction/startup

### DIFF
--- a/pkg/storage/scheduler.go
+++ b/pkg/storage/scheduler.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
@@ -140,7 +139,7 @@ type raftScheduler struct {
 }
 
 func newRaftScheduler(
-	ambient log.AmbientContext, metrics *StoreMetrics, processor raftProcessor, numWorkers int,
+	metrics *StoreMetrics, processor raftProcessor, numWorkers int,
 ) *raftScheduler {
 	s := &raftScheduler{
 		processor:  processor,

--- a/pkg/storage/scheduler_test.go
+++ b/pkg/storage/scheduler_test.go
@@ -26,10 +26,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 func TestRangeIDChunk(t *testing.T) {
@@ -196,7 +194,7 @@ func TestSchedulerLoop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	p := newTestProcessor()
-	s := newRaftScheduler(log.AmbientContext{Tracer: tracing.NewTracer()}, nil, p, 1)
+	s := newRaftScheduler(nil, p, 1)
 	stopper := stop.NewStopper()
 	ctx := context.TODO()
 	defer stopper.Stop(ctx)
@@ -218,7 +216,7 @@ func TestSchedulerBuffering(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	p := newTestProcessor()
-	s := newRaftScheduler(log.AmbientContext{Tracer: tracing.NewTracer()}, nil, p, 1)
+	s := newRaftScheduler(nil, p, 1)
 	stopper := stop.NewStopper()
 	ctx := context.TODO()
 	defer stopper.Stop(ctx)

--- a/pkg/storage/store_rebalancer.go
+++ b/pkg/storage/store_rebalancer.go
@@ -138,7 +138,6 @@ func NewStoreRebalancer(
 	rq *replicateQueue,
 	replRankings *replicaRankings,
 ) *StoreRebalancer {
-	ambientCtx.AddLogTag("store-rebalancer", nil)
 	sr := &StoreRebalancer{
 		AmbientContext: ambientCtx,
 		metrics:        makeStoreRebalancerMetrics(),
@@ -146,6 +145,7 @@ func NewStoreRebalancer(
 		rq:             rq,
 		replRankings:   replRankings,
 	}
+	sr.AddLogTag("store-rebalancer", nil)
 	sr.rq.store.metrics.registry.AddMetricStruct(&sr.metrics)
 	return sr
 }


### PR DESCRIPTION
The AmbientCtx present in NewStore() does not yet include the store ID,
but was getting passed to the Scanner and StoreRebalancer, leaving
their log tags without the store ID (or in practice for the store
rebalancer's case, with the store ID out of order).

This fixes that (albeit very awkwardly for the Scanner), and removes a
passing of the AmbientCtx to a constructor that didn't actually use it.

Release note: None

The improperly ordered store rebalancer log tags (`s1,n1,store-rebalancer`) were annoying me while looking at https://github.com/cockroachdb/cockroach/issues/29969, and the lack of a store tag could conceivably get confusing for the scanner on a node with multiple stores.