### PR TITLE
roachtest: Use --sequential flag in rebalancer tests

### DIFF
--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -49,7 +49,7 @@ func registerRebalanceLoad(r *registry) {
 		appNode := c.Node(c.nodes)
 
 		c.Put(ctx, cockroach, "./cockroach", roachNodes)
-		args := startArgs(
+		args := startArgs("--sequential",
 			"--args=--vmodule=store_rebalancer=5,allocator=5,allocator_scorer=5,replicate_queue=5")
 		c.Start(ctx, roachNodes, args)
 


### PR DESCRIPTION
It's annoying when node IDs and store IDs don't match their server's
index, especially when debugging rebalancing-related tests where looking
up the logs for a given store ID is a common need.

Also, it's not obvious whether the test's logging output about the
number of leases on each store is using node IDs or store IDs. This
makes that more understandable without needing to add custom printing
logic.

Release note: None

Is there a reason we don't use this more broadly in roachtests? There are a few that use it, but they're a minority.