### PR TITLE
tracing: add log tags as span tags

### DIFF
--- a/pkg/kv/transport.go
+++ b/pkg/kv/transport.go
@@ -333,7 +333,7 @@ func (s *senderTransport) SendNext(
 	}
 	s.called = true
 
-	sp := s.tracer.StartSpan("node")
+	sp := s.tracer.StartSpan("node", tracing.LogTagsFromCtx(ctx))
 	defer sp.Finish()
 	ba.Replica = s.replica
 	ctx = opentracing.ContextWithSpan(ctx, sp)

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1083,7 +1083,10 @@ func (n *Node) setupSpanForIncomingRPC(
 			// If tracing information was passed via gRPC metadata, the gRPC interceptor
 			// should have opened a span for us. If not, open a span now (if tracing is
 			// disabled, this will be a noop span).
-			newSpan = n.storeCfg.AmbientCtx.Tracer.StartSpan(opName)
+			newSpan = n.storeCfg.AmbientCtx.Tracer.StartSpan(
+				opName,
+				tracing.LogTags(n.storeCfg.AmbientCtx.LogTags()),
+			)
 			ctx = opentracing.ContextWithSpan(ctx, newSpan)
 		}
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -83,6 +83,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
@@ -1978,4 +1979,8 @@ func serveUIAssets(fileServer http.Handler, cfg Config) http.Handler {
 			return
 		}
 	})
+}
+
+func init() {
+	tracing.RegisterTagRemapping("n", "node")
 }

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -899,12 +899,7 @@ func (rb *rowSourceBase) consumerClosed(name string) {
 // processorSpan creates a child span for a processor (if we are doing any
 // tracing). The returned span needs to be finished using tracing.FinishSpan.
 func processorSpan(ctx context.Context, name string) (context.Context, opentracing.Span) {
-	parentSp := opentracing.SpanFromContext(ctx)
-	if parentSp == nil || tracing.IsBlackHoleSpan(parentSp) {
-		return ctx, nil
-	}
-	newSpan := tracing.StartChildSpan(name, parentSp, true /* separateRecording */)
-	return opentracing.ContextWithSpan(ctx, newSpan), newSpan
+	return tracing.ChildSpanSeparateRecording(ctx, name)
 }
 
 func newProcessor(

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -297,10 +297,14 @@ func (ds *ServerImpl) setupFlow(
 	const opName = "flow"
 	var sp opentracing.Span
 	if parentSpan == nil {
-		sp = ds.Tracer.StartSpan(opName)
+		sp = ds.Tracer.StartSpan(opName, tracing.LogTagsFromCtx(ctx))
 	} else {
 		// We use FollowsFrom because the flow's span outlives the SetupFlow request.
-		sp = ds.Tracer.StartSpan(opName, opentracing.FollowsFrom(parentSpan.Context()))
+		sp = ds.Tracer.StartSpan(
+			opName,
+			opentracing.FollowsFrom(parentSpan.Context()),
+			tracing.LogTagsFromCtx(ctx),
+		)
 	}
 	ctx = opentracing.ContextWithSpan(ctx, sp)
 

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -161,10 +161,13 @@ func (ts *txnState) resetForNewSQLTxn(
 	if parentSp := opentracing.SpanFromContext(connCtx); parentSp != nil {
 		// Create a child span for this SQL txn.
 		sp = parentSp.Tracer().StartSpan(
-			opName, opentracing.ChildOf(parentSp.Context()), tracing.Recordable)
+			opName,
+			opentracing.ChildOf(parentSp.Context()), tracing.Recordable,
+			tracing.LogTagsFromCtx(connCtx),
+		)
 	} else {
 		// Create a root span for this SQL txn.
-		sp = tranCtx.tracer.StartSpan(opName, tracing.Recordable)
+		sp = tranCtx.tracer.StartSpan(opName, tracing.Recordable, tracing.LogTagsFromCtx(connCtx))
 	}
 
 	if txnType == implicitTxn {

--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/pkg/errors"
 )
 
@@ -764,7 +765,7 @@ func splitTrigger(
 ) (enginepb.MVCCStats, result.Result, error) {
 	// TODO(tschottdorf): should have an incoming context from the corresponding
 	// EndTransaction, but the plumbing has not been done yet.
-	sp := rec.Tracer().StartSpan("split")
+	sp := rec.Tracer().StartSpan("split", tracing.LogTagsFromCtx(ctx))
 	defer sp.Finish()
 	desc := rec.Desc()
 	if !bytes.Equal(desc.StartKey, split.LeftDesc.StartKey) ||

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -7008,3 +7008,7 @@ func (r *Replica) EmitMLAI() {
 	_, untrack := r.store.cfg.ClosedTimestamp.Tracker.Track(ctx)
 	untrack(ctx, r.RangeID, ctpb.LAI(lai))
 }
+
+func init() {
+	tracing.RegisterTagRemapping("r", "range")
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4664,3 +4664,7 @@ func (s *Store) setConsistencyQueueActive(active bool) {
 func (s *Store) setScannerActive(active bool) {
 	s.scanner.SetDisabled(!active)
 }
+
+func init() {
+	tracing.RegisterTagRemapping("s", "store")
+}

--- a/pkg/util/log/ambient_context.go
+++ b/pkg/util/log/ambient_context.go
@@ -72,6 +72,11 @@ type AmbientContext struct {
 	backgroundCtx context.Context
 }
 
+// LogTags returns the tags in the ambient context.
+func (ac *AmbientContext) LogTags() *logtags.Buffer {
+	return ac.tags
+}
+
 // AddLogTag adds a tag to the ambient context.
 func (ac *AmbientContext) AddLogTag(name string, value interface{}) {
 	ac.tags = ac.tags.Add(name, value)

--- a/pkg/util/log/ambient_context_test.go
+++ b/pkg/util/log/ambient_context_test.go
@@ -70,6 +70,7 @@ func TestAnnotateCtxSpan(t *testing.T) {
 			event: a
 			event: c
 		span child:
+			tags: ambient=
 			event: [ambient] b
 	`); err != nil {
 		t.Fatal(err)

--- a/pkg/util/log/logtags/tag.go
+++ b/pkg/util/log/logtags/tag.go
@@ -14,6 +14,8 @@
 
 package logtags
 
+import "fmt"
+
 // Tag is a log tag, which has a string key and an arbitrary value.
 // The value must support testing for equality. It can be nil.
 type Tag struct {
@@ -29,4 +31,19 @@ func (t *Tag) Key() string {
 // Value returns the value.
 func (t *Tag) Value() interface{} {
 	return t.value
+}
+
+// ValueStr returns the value as a string.
+func (t *Tag) ValueStr() string {
+	if t.value == nil {
+		return ""
+	}
+	switch v := t.value.(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	default:
+		return fmt.Sprint(t.value)
+	}
 }

--- a/pkg/util/tracing/tags.go
+++ b/pkg/util/tracing/tags.go
@@ -1,0 +1,72 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tracing
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log/logtags"
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+// LogTagsOption is a StartSpanOption that uses log tags to populate the span tags.
+type logTagsOption logtags.Buffer
+
+var _ opentracing.StartSpanOption = &logTagsOption{}
+
+// Apply is part of the opentracing.StartSpanOption interface.
+func (lt *logTagsOption) Apply(o *opentracing.StartSpanOptions) {
+	if lt == nil {
+		return
+	}
+	tags := (*logtags.Buffer)(lt).Get()
+	if len(tags) == 0 {
+		return
+	}
+	if o.Tags == nil {
+		o.Tags = make(map[string]interface{}, len(tags))
+	}
+	for i := range tags {
+		o.Tags[tagName(tags[i].Key())] = tags[i].ValueStr()
+	}
+}
+
+// LogTags returns a StartSpanOption that sets the span tags to the given log
+// tags.
+func LogTags(tags *logtags.Buffer) opentracing.StartSpanOption {
+	return (*logTagsOption)(tags)
+}
+
+// LogTagsFromCtx returns a StartSpanOption that sets the span tags to the log
+// tags in the context.
+func LogTagsFromCtx(ctx context.Context) opentracing.StartSpanOption {
+	return (*logTagsOption)(logtags.FromContext(ctx))
+}
+
+// tagRemap is a map that records desired conversions
+var tagRemap = make(map[string]string)
+
+// RegisterTagRemapping sets the span tag name that corresponds to the given log
+// tag name. Should be called as part of an init() function.
+func RegisterTagRemapping(logTag, spanTag string) {
+	tagRemap[logTag] = spanTag
+}
+
+func tagName(logTag string) string {
+	if v, ok := tagRemap[logTag]; ok {
+		return v
+	}
+	return logTag
+}

--- a/pkg/util/tracing/tags_test.go
+++ b/pkg/util/tracing/tags_test.go
@@ -1,0 +1,50 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tracing
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log/logtags"
+)
+
+func TestLogTags(t *testing.T) {
+	tr := NewTracer()
+
+	l := logtags.SingleTagBuffer("tag1", "val1")
+	l = l.Add("tag2", "val2")
+	sp1 := tr.StartSpan("foo", Recordable, LogTags(l))
+	StartRecording(sp1, SingleNodeRecording)
+
+	if err := TestingCheckRecordedSpans(GetRecording(sp1), `
+		span foo:
+		  tags: tag1=val1 tag2=val2
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	RegisterTagRemapping("tag1", "one")
+	RegisterTagRemapping("tag2", "two")
+
+	sp2 := tr.StartSpan("bar", Recordable, LogTags(l))
+	StartRecording(sp2, SingleNodeRecording)
+
+	if err := TestingCheckRecordedSpans(GetRecording(sp2), `
+		span bar:
+			tags: one=val1 two=val2
+	`); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Whenever we create a span, we get the log tags from the context and
add them as tags to the span. The tags show up and can be queried in
Jaeger. Note that the events inside the span can contain more/other
tags if the context is annotated after the span is started.

We include a facility for remapping log tag names, and use it to make
`n`, `s`, `r` show up as `node`, `store`, `range`.

Unfortunately the zipkin library serializes the tags in map iteration
order, so the ordering will be arbitrary and varying across spans. I
filed an issue proposing that the tags get sorted first.

Release note: None