### PR TITLE
changefeedccl: also run tests on the enterprise impl

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -202,6 +202,11 @@ func emitEntries(
 		var keyCopy, valueCopy []byte
 		scratch, keyCopy = scratch.Copy(key.Bytes(), 0 /* extraCap */)
 		scratch, valueCopy = scratch.Copy(value.Bytes(), 0 /* extraCap */)
+		if knobs.BeforeEmitRow != nil {
+			if err := knobs.BeforeEmitRow(); err != nil {
+				return err
+			}
+		}
 		if err := sink.EmitRow(ctx, row.tableDesc.Name, keyCopy, valueCopy); err != nil {
 			return err
 		}

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -218,6 +218,10 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 // processor did not finish completion, there is an excessive amount of nil
 // checking.
 func (ca *changeAggregator) close() {
+	// Shut down the poller and tableHistUpdater if they weren't already.
+	if ca.cancel != nil {
+		ca.cancel()
+	}
 	// Wait for the poller and tableHistUpdater to finish shutting down.
 	if ca.pollerDoneCh != nil {
 		<-ca.pollerDoneCh

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -11,751 +11,682 @@ package changefeedccl
 import (
 	"context"
 	gosql "database/sql"
-	gojson "encoding/json"
 	"fmt"
 	"net/url"
-	"reflect"
-	"sort"
-	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach-go/crdb"
+	"github.com/pkg/errors"
 
-	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/pkg/errors"
 )
 
 func TestChangefeedBasics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	ctx := context.Background()
-	s, sqlDBRaw, _ := serverutils.StartServer(t, base.TestServerArgs{
-		UseDatabase: "d",
-		// TODO(dan): HACK until the changefeed can control pgwire flushing.
-		ConnResultsBufferBytes: 1,
-	})
-	defer s.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
-	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
-	sqlDB.Exec(t, `CREATE DATABASE d`)
-	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
-	sqlDB.Exec(t, `INSERT INTO foo VALUES (0, 'initial')`)
-	sqlDB.Exec(t, `UPSERT INTO foo VALUES (0, 'updated')`)
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (0, 'initial')`)
+		sqlDB.Exec(t, `UPSERT INTO foo VALUES (0, 'updated')`)
 
-	rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR foo`)
-	defer closeFeedRowsHack(t, sqlDB, rows)
+		foo := f.Feed(t, `CREATE CHANGEFEED FOR foo`)
+		defer foo.Close(t)
 
-	// 'initial' is skipped because only the latest value ('updated') is emitted
-	// by the initial scan.
-	assertPayloads(t, rows, []string{
-		`foo: [0]->{"a": 0, "b": "updated"}`,
-	})
+		// 'initial' is skipped because only the latest value ('updated') is
+		// emitted by the initial scan.
+		assertPayloads(t, foo, []string{
+			`foo: [0]->{"a": 0, "b": "updated"}`,
+		})
 
-	sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'a'), (2, 'b')`)
-	assertPayloads(t, rows, []string{
-		`foo: [1]->{"a": 1, "b": "a"}`,
-		`foo: [2]->{"a": 2, "b": "b"}`,
-	})
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'a'), (2, 'b')`)
+		assertPayloads(t, foo, []string{
+			`foo: [1]->{"a": 1, "b": "a"}`,
+			`foo: [2]->{"a": 2, "b": "b"}`,
+		})
 
-	sqlDB.Exec(t, `UPSERT INTO foo VALUES (2, 'c'), (3, 'd')`)
-	assertPayloads(t, rows, []string{
-		`foo: [2]->{"a": 2, "b": "c"}`,
-		`foo: [3]->{"a": 3, "b": "d"}`,
-	})
+		sqlDB.Exec(t, `UPSERT INTO foo VALUES (2, 'c'), (3, 'd')`)
+		assertPayloads(t, foo, []string{
+			`foo: [2]->{"a": 2, "b": "c"}`,
+			`foo: [3]->{"a": 3, "b": "d"}`,
+		})
 
-	sqlDB.Exec(t, `DELETE FROM foo WHERE a = 1`)
-	assertPayloads(t, rows, []string{
-		`foo: [1]->`,
-	})
+		sqlDB.Exec(t, `DELETE FROM foo WHERE a = 1`)
+		assertPayloads(t, foo, []string{
+			`foo: [1]->`,
+		})
+	}
+
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
 func TestChangefeedEnvelope(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	ctx := context.Background()
-	s, sqlDBRaw, _ := serverutils.StartServer(t, base.TestServerArgs{
-		UseDatabase: "d",
-		// TODO(dan): HACK until the changefeed can control pgwire flushing.
-		ConnResultsBufferBytes: 1,
-	})
-	defer s.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'a')`)
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
-	sqlDB.Exec(t, `CREATE DATABASE d`)
-	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
-	sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'a')`)
+		t.Run(`envelope=row`, func(t *testing.T) {
+			foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH envelope='row'`)
+			defer foo.Close(t)
+			assertPayloads(t, foo, []string{`foo: [1]->{"a": 1, "b": "a"}`})
+		})
+		t.Run(`envelope=key_only`, func(t *testing.T) {
+			foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH envelope='key_only'`)
+			defer foo.Close(t)
+			assertPayloads(t, foo, []string{`foo: [1]->`})
+		})
+	}
 
-	t.Run(`envelope=row`, func(t *testing.T) {
-		rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR foo WITH envelope='row'`)
-		defer closeFeedRowsHack(t, sqlDB, rows)
-		assertPayloads(t, rows, []string{`foo: [1]->{"a": 1, "b": "a"}`})
-	})
-	t.Run(`envelope=key_only`, func(t *testing.T) {
-		rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR foo WITH envelope='key_only'`)
-		defer closeFeedRowsHack(t, sqlDB, rows)
-		assertPayloads(t, rows, []string{`foo: [1]->`})
-	})
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
 func TestChangefeedMultiTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	ctx := context.Background()
-	s, sqlDBRaw, _ := serverutils.StartServer(t, base.TestServerArgs{
-		UseDatabase: "d",
-		// TODO(dan): HACK until the changefeed can control pgwire flushing.
-		ConnResultsBufferBytes: 1,
-	})
-	defer s.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
-	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'a')`)
+		sqlDB.Exec(t, `CREATE TABLE bar (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `INSERT INTO bar VALUES (2, 'b')`)
 
-	sqlDB.Exec(t, `CREATE DATABASE d`)
-	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
-	sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'a')`)
-	sqlDB.Exec(t, `CREATE TABLE bar (a INT PRIMARY KEY, b STRING)`)
-	sqlDB.Exec(t, `INSERT INTO bar VALUES (2, 'b')`)
+		fooAndBar := f.Feed(t, `CREATE CHANGEFEED FOR foo, bar`)
+		defer fooAndBar.Close(t)
 
-	rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR foo, bar`)
-	defer closeFeedRowsHack(t, sqlDB, rows)
+		assertPayloads(t, fooAndBar, []string{
+			`foo: [1]->{"a": 1, "b": "a"}`,
+			`bar: [2]->{"a": 2, "b": "b"}`,
+		})
+	}
 
-	assertPayloads(t, rows, []string{
-		`foo: [1]->{"a": 1, "b": "a"}`,
-		`bar: [2]->{"a": 2, "b": "b"}`,
-	})
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
 func TestChangefeedCursor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	ctx := context.Background()
-	s, sqlDBRaw, _ := serverutils.StartServer(t, base.TestServerArgs{
-		UseDatabase: "d",
-		// TODO(dan): HACK until the changefeed can control pgwire flushing.
-		ConnResultsBufferBytes: 1,
-	})
-	defer s.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
-	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'before')`)
+		var ts string
+		sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (2, 'after')`)
 
-	sqlDB.Exec(t, `CREATE DATABASE d`)
-	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
-	sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'before')`)
-	var ts string
-	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts)
-	sqlDB.Exec(t, `INSERT INTO foo VALUES (2, 'after')`)
+		foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH cursor=$1`, ts)
+		defer foo.Close(t)
 
-	rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR foo WITH cursor=$1`, ts)
-	defer closeFeedRowsHack(t, sqlDB, rows)
+		assertPayloads(t, foo, []string{
+			`foo: [2]->{"a": 2, "b": "after"}`,
+		})
+	}
 
-	assertPayloads(t, rows, []string{
-		`foo: [2]->{"a": 2, "b": "after"}`,
-	})
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
 func TestChangefeedTimestamps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	ctx := context.Background()
-	s, sqlDBRaw, _ := serverutils.StartServer(t, base.TestServerArgs{
-		UseDatabase: "d",
-		// TODO(dan): HACK until the changefeed can control pgwire flushing.
-		ConnResultsBufferBytes: 1,
-	})
-	defer s.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
-	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
-	sqlDB.Exec(t, `CREATE DATABASE d`)
-	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		ctx := context.Background()
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
 
-	var ts0 string
-	if err := crdb.ExecuteTx(ctx, sqlDB.DB, nil /* txopts */, func(tx *gosql.Tx) error {
-		return tx.QueryRow(
-			`INSERT INTO foo VALUES (0) RETURNING cluster_logical_timestamp()`,
-		).Scan(&ts0)
-	}); err != nil {
-		t.Fatal(err)
+		var ts0 string
+		if err := crdb.ExecuteTx(ctx, sqlDB.DB, nil /* txopts */, func(tx *gosql.Tx) error {
+			return tx.QueryRow(
+				`INSERT INTO foo VALUES (0) RETURNING cluster_logical_timestamp()`,
+			).Scan(&ts0)
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH updated, resolved`)
+		defer foo.Close(t)
+
+		var ts1 string
+		if err := crdb.ExecuteTx(ctx, sqlDB.DB, nil /* txopts */, func(tx *gosql.Tx) error {
+			return tx.QueryRow(
+				`INSERT INTO foo VALUES (1) RETURNING cluster_logical_timestamp()`,
+			).Scan(&ts1)
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		assertPayloads(t, foo, []string{
+			`foo: [0]->{"__crdb__": {"updated": "` + ts0 + `"}, "a": 0}`,
+			`foo: [1]->{"__crdb__": {"updated": "` + ts1 + `"}, "a": 1}`,
+		})
+
+		// Check that we eventually get a resolved timestamp greater than ts1.
+		expectResolvedTimestampGreaterThan(t, foo, ts1)
 	}
 
-	rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR foo WITH updated, resolved`)
-	defer closeFeedRowsHack(t, sqlDB, rows)
-
-	var ts1 string
-	if err := crdb.ExecuteTx(ctx, sqlDB.DB, nil /* txopts */, func(tx *gosql.Tx) error {
-		return tx.QueryRow(
-			`INSERT INTO foo VALUES (1) RETURNING cluster_logical_timestamp()`,
-		).Scan(&ts1)
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	assertPayloads(t, rows, []string{
-		`foo: [0]->{"__crdb__": {"updated": "` + ts0 + `"}, "a": 0}`,
-		`foo: [1]->{"__crdb__": {"updated": "` + ts1 + `"}, "a": 1}`,
-	})
-
-	// Check that we eventually get a resolved timestamp greater than ts1.
-	expectResolvedTimestampGreaterThan(t, rows, ts1)
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
 func TestChangefeedSchemaChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	ctx := context.Background()
-	s, sqlDBRaw, _ := serverutils.StartServer(t, base.TestServerArgs{
-		UseDatabase: "d",
-		// TODO(dan): HACK until the changefeed can control pgwire flushing.
-		ConnResultsBufferBytes: 1,
-	})
-	defer s.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
-	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
-	sqlDB.Exec(t, `CREATE DATABASE d`)
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
 
-	t.Run(`historical`, func(t *testing.T) {
-		sqlDB.Exec(t, `CREATE TABLE historical (a INT PRIMARY KEY, b STRING DEFAULT 'before')`)
-		var start string
-		sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&start)
-		sqlDB.Exec(t, `INSERT INTO historical (a, b) VALUES (0, '0')`)
-		sqlDB.Exec(t, `INSERT INTO historical (a) VALUES (1)`)
-		sqlDB.Exec(t, `ALTER TABLE historical ALTER COLUMN b SET DEFAULT 'after'`)
-		sqlDB.Exec(t, `INSERT INTO historical (a) VALUES (2)`)
-		sqlDB.Exec(t, `ALTER TABLE historical ADD COLUMN c INT`)
-		sqlDB.Exec(t, `INSERT INTO historical (a) VALUES (3)`)
-		sqlDB.Exec(t, `INSERT INTO historical (a, c) VALUES (4, 14)`)
-		rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR historical WITH cursor=$1`, start)
-		defer closeFeedRowsHack(t, sqlDB, rows)
-		assertPayloads(t, rows, []string{
-			`historical: [0]->{"a": 0, "b": "0"}`,
-			`historical: [1]->{"a": 1, "b": "before"}`,
-			`historical: [2]->{"a": 2, "b": "after"}`,
-			`historical: [3]->{"a": 3, "b": "after", "c": null}`,
-			`historical: [4]->{"a": 4, "b": "after", "c": 14}`,
+		t.Run(`historical`, func(t *testing.T) {
+			sqlDB.Exec(t, `CREATE TABLE historical (a INT PRIMARY KEY, b STRING DEFAULT 'before')`)
+			var start string
+			sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&start)
+			sqlDB.Exec(t, `INSERT INTO historical (a, b) VALUES (0, '0')`)
+			sqlDB.Exec(t, `INSERT INTO historical (a) VALUES (1)`)
+			sqlDB.Exec(t, `ALTER TABLE historical ALTER COLUMN b SET DEFAULT 'after'`)
+			sqlDB.Exec(t, `INSERT INTO historical (a) VALUES (2)`)
+			sqlDB.Exec(t, `ALTER TABLE historical ADD COLUMN c INT`)
+			sqlDB.Exec(t, `INSERT INTO historical (a) VALUES (3)`)
+			sqlDB.Exec(t, `INSERT INTO historical (a, c) VALUES (4, 14)`)
+			historical := f.Feed(t, `CREATE CHANGEFEED FOR historical WITH cursor=$1`, start)
+			defer historical.Close(t)
+			assertPayloads(t, historical, []string{
+				`historical: [0]->{"a": 0, "b": "0"}`,
+				`historical: [1]->{"a": 1, "b": "before"}`,
+				`historical: [2]->{"a": 2, "b": "after"}`,
+				`historical: [3]->{"a": 3, "b": "after", "c": null}`,
+				`historical: [4]->{"a": 4, "b": "after", "c": 14}`,
+			})
 		})
-	})
 
-	t.Run(`add column`, func(t *testing.T) {
-		// NB: the default is a nullable column
-		sqlDB.Exec(t, `CREATE TABLE add_column (a INT PRIMARY KEY)`)
-		sqlDB.Exec(t, `INSERT INTO add_column VALUES (1)`)
-		rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR add_column`)
-		defer closeFeedRowsHack(t, sqlDB, rows)
-		sqlDB.Exec(t, `ALTER TABLE add_column ADD COLUMN b STRING`)
-		sqlDB.Exec(t, `INSERT INTO add_column VALUES (2, '2')`)
-		assertPayloads(t, rows, []string{
-			`add_column: [1]->{"a": 1}`,
-			`add_column: [2]->{"a": 2, "b": "2"}`,
+		t.Run(`add column`, func(t *testing.T) {
+			// NB: the default is a nullable column
+			sqlDB.Exec(t, `CREATE TABLE add_column (a INT PRIMARY KEY)`)
+			sqlDB.Exec(t, `INSERT INTO add_column VALUES (1)`)
+			addColumn := f.Feed(t, `CREATE CHANGEFEED FOR add_column`)
+			defer addColumn.Close(t)
+			sqlDB.Exec(t, `ALTER TABLE add_column ADD COLUMN b STRING`)
+			sqlDB.Exec(t, `INSERT INTO add_column VALUES (2, '2')`)
+			assertPayloads(t, addColumn, []string{
+				`add_column: [1]->{"a": 1}`,
+				`add_column: [2]->{"a": 2, "b": "2"}`,
+			})
 		})
-	})
 
-	t.Run(`add column not null`, func(t *testing.T) {
-		sqlDB.Exec(t, `CREATE TABLE add_column_notnull (a INT PRIMARY KEY)`)
-		rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR add_column_notnull WITH resolved`)
-		defer closeFeedRowsHack(t, sqlDB, rows)
-		sqlDB.Exec(t, `ALTER TABLE add_column_notnull ADD COLUMN b STRING NOT NULL`)
-		sqlDB.Exec(t, `INSERT INTO add_column_notnull VALUES (2, '2')`)
-		skipResolvedTimestamps(t, rows)
-		if err := rows.Err(); !testutils.IsError(err, `cannot operate on tables being backfilled`) {
-			t.Fatalf(`expected "cannot operate on tables being backfilled" error got: %+v`, err)
-		}
-	})
-
-	t.Run(`add column with default`, func(t *testing.T) {
-		sqlDB.Exec(t, `CREATE TABLE add_column_def (a INT PRIMARY KEY)`)
-		sqlDB.Exec(t, `INSERT INTO add_column_def VALUES (1)`)
-		rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR add_column_def`)
-		defer closeFeedRowsHack(t, sqlDB, rows)
-		sqlDB.Exec(t, `ALTER TABLE add_column_def ADD COLUMN b STRING DEFAULT 'd'`)
-		sqlDB.Exec(t, `INSERT INTO add_column_def VALUES (2, '2')`)
-		assertPayloads(t, rows, []string{
-			`add_column_def: [1]->{"a": 1}`,
+		t.Run(`add column not null`, func(t *testing.T) {
+			sqlDB.Exec(t, `CREATE TABLE add_column_notnull (a INT PRIMARY KEY)`)
+			addColumnNotNull := f.Feed(t, `CREATE CHANGEFEED FOR add_column_notnull WITH resolved`)
+			defer addColumnNotNull.Close(t)
+			sqlDB.Exec(t, `ALTER TABLE add_column_notnull ADD COLUMN b STRING NOT NULL`)
+			sqlDB.Exec(t, `INSERT INTO add_column_notnull VALUES (2, '2')`)
+			skipResolvedTimestamps(t, addColumnNotNull)
+			if err := addColumnNotNull.Err(); !testutils.IsError(err, `tables being backfilled`) {
+				t.Fatalf(`expected "tables being backfilled" error got: %+v`, err)
+			}
 		})
-		if rows.Next() {
-			t.Fatal(`unexpected row`)
-		}
-		if err := rows.Err(); !testutils.IsError(err, `cannot operate on tables being backfilled`) {
-			t.Fatalf(`expected "cannot operate on tables being backfilled" error got: %+v`, err)
-		}
-	})
 
-	t.Run(`add column computed`, func(t *testing.T) {
-		sqlDB.Exec(t, `CREATE TABLE add_column_comp (a INT PRIMARY KEY, b INT AS (a + 5) STORED)`)
-		sqlDB.Exec(t, `INSERT INTO add_column_comp VALUES (1)`)
-		rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR add_column_comp`)
-		defer closeFeedRowsHack(t, sqlDB, rows)
-		sqlDB.Exec(t, `ALTER TABLE add_column_comp ADD COLUMN c INT AS (a + 10) STORED`)
-		sqlDB.Exec(t, `INSERT INTO add_column_comp (a) VALUES (2)`)
-		assertPayloads(t, rows, []string{
-			`add_column_comp: [1]->{"a": 1, "b": 6}`,
+		t.Run(`add column with default`, func(t *testing.T) {
+			sqlDB.Exec(t, `CREATE TABLE add_column_def (a INT PRIMARY KEY)`)
+			sqlDB.Exec(t, `INSERT INTO add_column_def VALUES (1)`)
+			addColumnDef := f.Feed(t, `CREATE CHANGEFEED FOR add_column_def`)
+			defer addColumnDef.Close(t)
+			assertPayloads(t, addColumnDef, []string{
+				`add_column_def: [1]->{"a": 1}`,
+			})
+			sqlDB.Exec(t, `ALTER TABLE add_column_def ADD COLUMN b STRING DEFAULT 'd'`)
+			sqlDB.Exec(t, `INSERT INTO add_column_def VALUES (2, '2')`)
+			if _, _, _, _, _, ok := addColumnDef.Next(t); ok {
+				t.Fatal(`unexpected row`)
+			}
+			if err := addColumnDef.Err(); !testutils.IsError(err, `tables being backfilled`) {
+				t.Fatalf(`expected "tables being backfilled" error got: %+v`, err)
+			}
 		})
-		if rows.Next() {
-			t.Fatal(`unexpected row`)
-		}
-		if err := rows.Err(); !testutils.IsError(err, `cannot operate on tables being backfilled`) {
-			t.Fatalf(`expected "cannot operate on tables being backfilled" error got: %+v`, err)
-		}
-	})
 
-	t.Run(`rename column`, func(t *testing.T) {
-		sqlDB.Exec(t, `CREATE TABLE rename_column (a INT PRIMARY KEY, b STRING)`)
-		sqlDB.Exec(t, `INSERT INTO rename_column VALUES (1, '1')`)
-		rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR rename_column`)
-		defer closeFeedRowsHack(t, sqlDB, rows)
-		sqlDB.Exec(t, `ALTER TABLE rename_column RENAME COLUMN b TO c`)
-		sqlDB.Exec(t, `INSERT INTO rename_column VALUES (2, '2')`)
-		assertPayloads(t, rows, []string{
-			`rename_column: [1]->{"a": 1, "b": "1"}`,
-			`rename_column: [2]->{"a": 2, "c": "2"}`,
+		t.Run(`add column computed`, func(t *testing.T) {
+			sqlDB.Exec(t, `CREATE TABLE add_col_comp (a INT PRIMARY KEY, b INT AS (a + 5) STORED)`)
+			sqlDB.Exec(t, `INSERT INTO add_col_comp VALUES (1)`)
+			addColComp := f.Feed(t, `CREATE CHANGEFEED FOR add_col_comp`)
+			defer addColComp.Close(t)
+			assertPayloads(t, addColComp, []string{
+				`add_col_comp: [1]->{"a": 1, "b": 6}`,
+			})
+			sqlDB.Exec(t, `ALTER TABLE add_col_comp ADD COLUMN c INT AS (a + 10) STORED`)
+			sqlDB.Exec(t, `INSERT INTO add_col_comp (a) VALUES (2)`)
+			if _, _, _, _, _, ok := addColComp.Next(t); ok {
+				t.Fatal(`unexpected row`)
+			}
+			if err := addColComp.Err(); !testutils.IsError(err, `tables being backfilled`) {
+				t.Fatalf(`expected "tables being backfilled" error got: %+v`, err)
+			}
 		})
-	})
 
-	t.Run(`drop column`, func(t *testing.T) {
-		sqlDB.Exec(t, `CREATE TABLE drop_column (a INT PRIMARY KEY, b STRING)`)
-		sqlDB.Exec(t, `INSERT INTO drop_column VALUES (1, '1')`)
-		rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR drop_column`)
-		defer closeFeedRowsHack(t, sqlDB, rows)
-		sqlDB.Exec(t, `ALTER TABLE drop_column DROP COLUMN b`)
-		sqlDB.Exec(t, `INSERT INTO drop_column VALUES (2)`)
-		assertPayloads(t, rows, []string{
-			`drop_column: [1]->{"a": 1, "b": "1"}`,
+		t.Run(`rename column`, func(t *testing.T) {
+			sqlDB.Exec(t, `CREATE TABLE rename_column (a INT PRIMARY KEY, b STRING)`)
+			sqlDB.Exec(t, `INSERT INTO rename_column VALUES (1, '1')`)
+			renameColumn := f.Feed(t, `CREATE CHANGEFEED FOR rename_column`)
+			defer renameColumn.Close(t)
+			sqlDB.Exec(t, `ALTER TABLE rename_column RENAME COLUMN b TO c`)
+			sqlDB.Exec(t, `INSERT INTO rename_column VALUES (2, '2')`)
+			assertPayloads(t, renameColumn, []string{
+				`rename_column: [1]->{"a": 1, "b": "1"}`,
+				`rename_column: [2]->{"a": 2, "c": "2"}`,
+			})
 		})
-		if rows.Next() {
-			t.Fatal(`unexpected row`)
-		}
-		if err := rows.Err(); !testutils.IsError(err, `cannot operate on tables being backfilled`) {
-			t.Fatalf(`expected "cannot operate on tables being backfilled" error got: %+v`, err)
-		}
-	})
 
-	t.Run(`add default`, func(t *testing.T) {
-		sqlDB.Exec(t, `CREATE TABLE add_default (a INT PRIMARY KEY, b STRING)`)
-		sqlDB.Exec(t, `INSERT INTO add_default (a, b) VALUES (1, '1')`)
-		rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR add_default`)
-		defer closeFeedRowsHack(t, sqlDB, rows)
-		sqlDB.Exec(t, `ALTER TABLE add_default ALTER COLUMN b SET DEFAULT 'd'`)
-		sqlDB.Exec(t, `INSERT INTO add_default (a) VALUES (2)`)
-		assertPayloads(t, rows, []string{
-			`add_default: [1]->{"a": 1, "b": "1"}`,
-			`add_default: [2]->{"a": 2, "b": "d"}`,
+		t.Run(`drop column`, func(t *testing.T) {
+			sqlDB.Exec(t, `CREATE TABLE drop_column (a INT PRIMARY KEY, b STRING)`)
+			sqlDB.Exec(t, `INSERT INTO drop_column VALUES (1, '1')`)
+			dropColumn := f.Feed(t, `CREATE CHANGEFEED FOR drop_column`)
+			defer dropColumn.Close(t)
+			assertPayloads(t, dropColumn, []string{
+				`drop_column: [1]->{"a": 1, "b": "1"}`,
+			})
+			sqlDB.Exec(t, `ALTER TABLE drop_column DROP COLUMN b`)
+			sqlDB.Exec(t, `INSERT INTO drop_column VALUES (2)`)
+			if _, _, _, _, _, ok := dropColumn.Next(t); ok {
+				t.Fatal(`unexpected row`)
+			}
+			if err := dropColumn.Err(); !testutils.IsError(err, `tables being backfilled`) {
+				t.Fatalf(`expected "tables being backfilled" error got: %+v`, err)
+			}
 		})
-	})
 
-	t.Run(`alter default`, func(t *testing.T) {
-		sqlDB.Exec(t, `CREATE TABLE alter_default (a INT PRIMARY KEY, b STRING DEFAULT 'before')`)
-		sqlDB.Exec(t, `INSERT INTO alter_default (a) VALUES (1)`)
-		rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR alter_default`)
-		defer closeFeedRowsHack(t, sqlDB, rows)
-		sqlDB.Exec(t, `ALTER TABLE alter_default ALTER COLUMN b SET DEFAULT 'after'`)
-		sqlDB.Exec(t, `INSERT INTO alter_default (a) VALUES (2)`)
-		assertPayloads(t, rows, []string{
-			`alter_default: [1]->{"a": 1, "b": "before"}`,
-			`alter_default: [2]->{"a": 2, "b": "after"}`,
+		t.Run(`add default`, func(t *testing.T) {
+			sqlDB.Exec(t, `CREATE TABLE add_default (a INT PRIMARY KEY, b STRING)`)
+			sqlDB.Exec(t, `INSERT INTO add_default (a, b) VALUES (1, '1')`)
+			addDefault := f.Feed(t, `CREATE CHANGEFEED FOR add_default`)
+			defer addDefault.Close(t)
+			sqlDB.Exec(t, `ALTER TABLE add_default ALTER COLUMN b SET DEFAULT 'd'`)
+			sqlDB.Exec(t, `INSERT INTO add_default (a) VALUES (2)`)
+			assertPayloads(t, addDefault, []string{
+				`add_default: [1]->{"a": 1, "b": "1"}`,
+				`add_default: [2]->{"a": 2, "b": "d"}`,
+			})
 		})
-	})
 
-	t.Run(`drop default`, func(t *testing.T) {
-		sqlDB.Exec(t, `CREATE TABLE drop_default (a INT PRIMARY KEY, b STRING DEFAULT 'd')`)
-		sqlDB.Exec(t, `INSERT INTO drop_default (a) VALUES (1)`)
-		rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR drop_default`)
-		defer closeFeedRowsHack(t, sqlDB, rows)
-		sqlDB.Exec(t, `ALTER TABLE drop_default ALTER COLUMN b DROP DEFAULT`)
-		sqlDB.Exec(t, `INSERT INTO drop_default (a) VALUES (2)`)
-		assertPayloads(t, rows, []string{
-			`drop_default: [1]->{"a": 1, "b": "d"}`,
-			`drop_default: [2]->{"a": 2, "b": null}`,
+		t.Run(`alter default`, func(t *testing.T) {
+			sqlDB.Exec(
+				t, `CREATE TABLE alter_default (a INT PRIMARY KEY, b STRING DEFAULT 'before')`)
+			sqlDB.Exec(t, `INSERT INTO alter_default (a) VALUES (1)`)
+			alterDefault := f.Feed(t, `CREATE CHANGEFEED FOR alter_default`)
+			defer alterDefault.Close(t)
+			sqlDB.Exec(t, `ALTER TABLE alter_default ALTER COLUMN b SET DEFAULT 'after'`)
+			sqlDB.Exec(t, `INSERT INTO alter_default (a) VALUES (2)`)
+			assertPayloads(t, alterDefault, []string{
+				`alter_default: [1]->{"a": 1, "b": "before"}`,
+				`alter_default: [2]->{"a": 2, "b": "after"}`,
+			})
 		})
-	})
 
-	t.Run(`drop not null`, func(t *testing.T) {
-		sqlDB.Exec(t, `CREATE TABLE drop_notnull (a INT PRIMARY KEY, b STRING NOT NULL)`)
-		sqlDB.Exec(t, `INSERT INTO drop_notnull VALUES (1, '1')`)
-		rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR drop_notnull`)
-		defer closeFeedRowsHack(t, sqlDB, rows)
-		sqlDB.Exec(t, `ALTER TABLE drop_notnull ALTER b DROP NOT NULL`)
-		sqlDB.Exec(t, `INSERT INTO drop_notnull VALUES (2, NULL)`)
-		assertPayloads(t, rows, []string{
-			`drop_notnull: [1]->{"a": 1, "b": "1"}`,
-			`drop_notnull: [2]->{"a": 2, "b": null}`,
+		t.Run(`drop default`, func(t *testing.T) {
+			sqlDB.Exec(t, `CREATE TABLE drop_default (a INT PRIMARY KEY, b STRING DEFAULT 'd')`)
+			sqlDB.Exec(t, `INSERT INTO drop_default (a) VALUES (1)`)
+			dropDefault := f.Feed(t, `CREATE CHANGEFEED FOR drop_default`)
+			defer dropDefault.Close(t)
+			sqlDB.Exec(t, `ALTER TABLE drop_default ALTER COLUMN b DROP DEFAULT`)
+			sqlDB.Exec(t, `INSERT INTO drop_default (a) VALUES (2)`)
+			assertPayloads(t, dropDefault, []string{
+				`drop_default: [1]->{"a": 1, "b": "d"}`,
+				`drop_default: [2]->{"a": 2, "b": null}`,
+			})
 		})
-	})
 
-	t.Run(`checks`, func(t *testing.T) {
-		sqlDB.Exec(t, `CREATE TABLE checks (a INT PRIMARY KEY)`)
-		sqlDB.Exec(t, `INSERT INTO checks VALUES (1)`)
-		rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR checks`)
-		defer closeFeedRowsHack(t, sqlDB, rows)
-		sqlDB.Exec(t, `ALTER TABLE checks ADD CONSTRAINT c CHECK (a < 5) NOT VALID`)
-		sqlDB.Exec(t, `INSERT INTO checks VALUES (2)`)
-		sqlDB.Exec(t, `ALTER TABLE checks VALIDATE CONSTRAINT c`)
-		sqlDB.Exec(t, `INSERT INTO checks VALUES (3)`)
-		sqlDB.Exec(t, `ALTER TABLE checks DROP CONSTRAINT c`)
-		sqlDB.Exec(t, `INSERT INTO checks VALUES (6)`)
-		assertPayloads(t, rows, []string{
-			`checks: [1]->{"a": 1}`,
-			`checks: [2]->{"a": 2}`,
-			`checks: [3]->{"a": 3}`,
-			`checks: [6]->{"a": 6}`,
+		t.Run(`drop not null`, func(t *testing.T) {
+			sqlDB.Exec(t, `CREATE TABLE drop_notnull (a INT PRIMARY KEY, b STRING NOT NULL)`)
+			sqlDB.Exec(t, `INSERT INTO drop_notnull VALUES (1, '1')`)
+			dropNotNull := f.Feed(t, `CREATE CHANGEFEED FOR drop_notnull`)
+			defer dropNotNull.Close(t)
+			sqlDB.Exec(t, `ALTER TABLE drop_notnull ALTER b DROP NOT NULL`)
+			sqlDB.Exec(t, `INSERT INTO drop_notnull VALUES (2, NULL)`)
+			assertPayloads(t, dropNotNull, []string{
+				`drop_notnull: [1]->{"a": 1, "b": "1"}`,
+				`drop_notnull: [2]->{"a": 2, "b": null}`,
+			})
 		})
-	})
 
-	t.Run(`add index`, func(t *testing.T) {
-		sqlDB.Exec(t, `CREATE TABLE add_index (a INT PRIMARY KEY, b STRING)`)
-		sqlDB.Exec(t, `INSERT INTO add_index VALUES (1, '1')`)
-		rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR add_index`)
-		defer closeFeedRowsHack(t, sqlDB, rows)
-		sqlDB.Exec(t, `CREATE INDEX b_idx ON add_index (b)`)
-		sqlDB.Exec(t, `SELECT * FROM add_index@b_idx`)
-		sqlDB.Exec(t, `INSERT INTO add_index VALUES (2, '2')`)
-		assertPayloads(t, rows, []string{
-			`add_index: [1]->{"a": 1, "b": "1"}`,
-			`add_index: [2]->{"a": 2, "b": "2"}`,
+		t.Run(`checks`, func(t *testing.T) {
+			sqlDB.Exec(t, `CREATE TABLE checks (a INT PRIMARY KEY)`)
+			sqlDB.Exec(t, `INSERT INTO checks VALUES (1)`)
+			checks := f.Feed(t, `CREATE CHANGEFEED FOR checks`)
+			defer checks.Close(t)
+			sqlDB.Exec(t, `ALTER TABLE checks ADD CONSTRAINT c CHECK (a < 5) NOT VALID`)
+			sqlDB.Exec(t, `INSERT INTO checks VALUES (2)`)
+			sqlDB.Exec(t, `ALTER TABLE checks VALIDATE CONSTRAINT c`)
+			sqlDB.Exec(t, `INSERT INTO checks VALUES (3)`)
+			sqlDB.Exec(t, `ALTER TABLE checks DROP CONSTRAINT c`)
+			sqlDB.Exec(t, `INSERT INTO checks VALUES (6)`)
+			assertPayloads(t, checks, []string{
+				`checks: [1]->{"a": 1}`,
+				`checks: [2]->{"a": 2}`,
+				`checks: [3]->{"a": 3}`,
+				`checks: [6]->{"a": 6}`,
+			})
 		})
-	})
 
-	t.Run(`unique`, func(t *testing.T) {
-		sqlDB.Exec(t, `CREATE TABLE "unique" (a INT PRIMARY KEY, b STRING)`)
-		sqlDB.Exec(t, `INSERT INTO "unique" VALUES (1, '1')`)
-		rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR "unique"`)
-		defer closeFeedRowsHack(t, sqlDB, rows)
-		sqlDB.Exec(t, `ALTER TABLE "unique" ADD CONSTRAINT u UNIQUE (b)`)
-		sqlDB.Exec(t, `INSERT INTO "unique" VALUES (2, '2')`)
-		assertPayloads(t, rows, []string{
-			`unique: [1]->{"a": 1, "b": "1"}`,
-			`unique: [2]->{"a": 2, "b": "2"}`,
+		t.Run(`add index`, func(t *testing.T) {
+			sqlDB.Exec(t, `CREATE TABLE add_index (a INT PRIMARY KEY, b STRING)`)
+			sqlDB.Exec(t, `INSERT INTO add_index VALUES (1, '1')`)
+			addIndex := f.Feed(t, `CREATE CHANGEFEED FOR add_index`)
+			defer addIndex.Close(t)
+			sqlDB.Exec(t, `CREATE INDEX b_idx ON add_index (b)`)
+			sqlDB.Exec(t, `SELECT * FROM add_index@b_idx`)
+			sqlDB.Exec(t, `INSERT INTO add_index VALUES (2, '2')`)
+			assertPayloads(t, addIndex, []string{
+				`add_index: [1]->{"a": 1, "b": "1"}`,
+				`add_index: [2]->{"a": 2, "b": "2"}`,
+			})
 		})
-	})
+
+		t.Run(`unique`, func(t *testing.T) {
+			sqlDB.Exec(t, `CREATE TABLE "unique" (a INT PRIMARY KEY, b STRING)`)
+			sqlDB.Exec(t, `INSERT INTO "unique" VALUES (1, '1')`)
+			unique := f.Feed(t, `CREATE CHANGEFEED FOR "unique"`)
+			defer unique.Close(t)
+			sqlDB.Exec(t, `ALTER TABLE "unique" ADD CONSTRAINT u UNIQUE (b)`)
+			sqlDB.Exec(t, `INSERT INTO "unique" VALUES (2, '2')`)
+			assertPayloads(t, unique, []string{
+				`unique: [1]->{"a": 1, "b": "1"}`,
+				`unique: [2]->{"a": 2, "b": "2"}`,
+			})
+		})
+	}
+
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
 func TestChangefeedInterleaved(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	ctx := context.Background()
-	s, sqlDBRaw, _ := serverutils.StartServer(t, base.TestServerArgs{
-		UseDatabase: "d",
-		// TODO(dan): HACK until the changefeed can control pgwire flushing.
-		ConnResultsBufferBytes: 1,
-	})
-	defer s.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
-	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
-	sqlDB.Exec(t, `CREATE DATABASE d`)
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
 
-	// TODO(dan): Work around a race in CANCEL QUERIES (#28033) by only
-	// canceling them once.
-	var cancelQueriesOnce sync.Once
-	closeFeedRowsCancelOnceHack := func(t *testing.T, sqlDB *sqlutils.SQLRunner, rows *gosql.Rows) {
-		cancelQueriesOnce.Do(func() {
-			// TODO(dan): We should just be able to close the `gosql.Rows` but
-			// that currently blocks forever without this.
-			sqlDB.Exec(t, `CANCEL QUERIES (
-			SELECT query_id FROM [SHOW QUERIES] WHERE query LIKE 'CREATE CHANGEFEED%'
-		)`)
+		sqlDB.Exec(t, `CREATE TABLE grandparent (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `INSERT INTO grandparent VALUES (0, 'grandparent-0')`)
+		grandparent := f.Feed(t, `CREATE CHANGEFEED FOR grandparent`)
+		defer grandparent.Close(t)
+		assertPayloads(t, grandparent, []string{
+			`grandparent: [0]->{"a": 0, "b": "grandparent-0"}`,
 		})
-		rows.Close()
+
+		sqlDB.Exec(t,
+			`CREATE TABLE parent (a INT PRIMARY KEY, b STRING) `+
+				`INTERLEAVE IN PARENT grandparent (a)`)
+		sqlDB.Exec(t, `INSERT INTO grandparent VALUES (1, 'grandparent-1')`)
+		sqlDB.Exec(t, `INSERT INTO parent VALUES (1, 'parent-1')`)
+		parent := f.Feed(t, `CREATE CHANGEFEED FOR parent`)
+		defer parent.Close(t)
+		assertPayloads(t, grandparent, []string{
+			`grandparent: [1]->{"a": 1, "b": "grandparent-1"}`,
+		})
+		assertPayloads(t, parent, []string{
+			`parent: [1]->{"a": 1, "b": "parent-1"}`,
+		})
+
+		sqlDB.Exec(t,
+			`CREATE TABLE child (a INT PRIMARY KEY, b STRING) INTERLEAVE IN PARENT parent (a)`)
+		sqlDB.Exec(t, `INSERT INTO grandparent VALUES (2, 'grandparent-2')`)
+		sqlDB.Exec(t, `INSERT INTO parent VALUES (2, 'parent-2')`)
+		sqlDB.Exec(t, `INSERT INTO child VALUES (2, 'child-2')`)
+		child := f.Feed(t, `CREATE CHANGEFEED FOR child`)
+		defer child.Close(t)
+		assertPayloads(t, grandparent, []string{
+			`grandparent: [2]->{"a": 2, "b": "grandparent-2"}`,
+		})
+		assertPayloads(t, parent, []string{
+			`parent: [2]->{"a": 2, "b": "parent-2"}`,
+		})
+		assertPayloads(t, child, []string{
+			`child: [2]->{"a": 2, "b": "child-2"}`,
+		})
 	}
 
-	sqlDB.Exec(t, `CREATE TABLE grandparent (a INT PRIMARY KEY, b STRING)`)
-	sqlDB.Exec(t, `INSERT INTO grandparent VALUES (0, 'grandparent-0')`)
-	grandparent := sqlDB.Query(t, `CREATE CHANGEFEED FOR grandparent`)
-	defer closeFeedRowsCancelOnceHack(t, sqlDB, grandparent)
-	assertPayloads(t, grandparent, []string{
-		`grandparent: [0]->{"a": 0, "b": "grandparent-0"}`,
-	})
-
-	sqlDB.Exec(t,
-		`CREATE TABLE parent (a INT PRIMARY KEY, b STRING) INTERLEAVE IN PARENT grandparent (a)`)
-	sqlDB.Exec(t, `INSERT INTO grandparent VALUES (1, 'grandparent-1')`)
-	sqlDB.Exec(t, `INSERT INTO parent VALUES (1, 'parent-1')`)
-	parent := sqlDB.Query(t, `CREATE CHANGEFEED FOR parent`)
-	defer closeFeedRowsCancelOnceHack(t, sqlDB, parent)
-	assertPayloads(t, grandparent, []string{
-		`grandparent: [1]->{"a": 1, "b": "grandparent-1"}`,
-	})
-	assertPayloads(t, parent, []string{
-		`parent: [1]->{"a": 1, "b": "parent-1"}`,
-	})
-
-	sqlDB.Exec(t,
-		`CREATE TABLE child (a INT PRIMARY KEY, b STRING) INTERLEAVE IN PARENT parent (a)`)
-	sqlDB.Exec(t, `INSERT INTO grandparent VALUES (2, 'grandparent-2')`)
-	sqlDB.Exec(t, `INSERT INTO parent VALUES (2, 'parent-2')`)
-	sqlDB.Exec(t, `INSERT INTO child VALUES (2, 'child-2')`)
-	child := sqlDB.Query(t, `CREATE CHANGEFEED FOR child`)
-	defer closeFeedRowsCancelOnceHack(t, sqlDB, child)
-	assertPayloads(t, grandparent, []string{
-		`grandparent: [2]->{"a": 2, "b": "grandparent-2"}`,
-	})
-	assertPayloads(t, parent, []string{
-		`parent: [2]->{"a": 2, "b": "parent-2"}`,
-	})
-	assertPayloads(t, child, []string{
-		`child: [2]->{"a": 2, "b": "child-2"}`,
-	})
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
 func TestChangefeedColumnFamily(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	ctx := context.Background()
-	s, sqlDBRaw, _ := serverutils.StartServer(t, base.TestServerArgs{
-		UseDatabase: "d",
-		// TODO(dan): HACK until the changefeed can control pgwire flushing.
-		ConnResultsBufferBytes: 1,
-	})
-	defer s.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
-	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
-	sqlDB.Exec(t, `CREATE DATABASE d`)
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
 
-	// Table with 2 column families.
-	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING, FAMILY (a), FAMILY (b))`)
-	if _, err := sqlDB.DB.Query(
-		`CREATE CHANGEFEED FOR foo`,
-	); !testutils.IsError(err, `exactly 1 column family`) {
-		t.Errorf(`expected "exactly 1 column family" error got: %+v`, err)
+		// Table with 2 column families.
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING, FAMILY (a), FAMILY (b))`)
+		if _, err := sqlDB.DB.Query(
+			`CREATE CHANGEFEED FOR foo`,
+		); !testutils.IsError(err, `exactly 1 column family`) {
+			t.Errorf(`expected "exactly 1 column family" error got: %+v`, err)
+		}
+
+		// Table with a second column family added after the changefeed starts.
+		sqlDB.Exec(t, `CREATE TABLE bar (a INT PRIMARY KEY, FAMILY f_a (a))`)
+		sqlDB.Exec(t, `INSERT INTO bar VALUES (0)`)
+		bar := f.Feed(t, `CREATE CHANGEFEED FOR bar`)
+		defer bar.Close(t)
+		assertPayloads(t, bar, []string{
+			`bar: [0]->{"a": 0}`,
+		})
+		sqlDB.Exec(t, `ALTER TABLE bar ADD COLUMN b STRING CREATE FAMILY f_b`)
+		sqlDB.Exec(t, `INSERT INTO bar VALUES (1)`)
+		_, _, _, _, _, _ = bar.Next(t)
+		if err := bar.Err(); !testutils.IsError(err, `exactly 1 column family`) {
+			t.Errorf(`expected "exactly 1 column family" error got: %+v`, err)
+		}
 	}
 
-	// Table with a second column family added after the changefeed starts.
-	sqlDB.Exec(t, `CREATE TABLE bar (a INT PRIMARY KEY, FAMILY f_a (a))`)
-	sqlDB.Exec(t, `INSERT INTO bar VALUES (0)`)
-	bar := sqlDB.Query(t, `CREATE CHANGEFEED FOR bar`)
-	defer closeFeedRowsHack(t, sqlDB, bar)
-	assertPayloads(t, bar, []string{
-		`bar: [0]->{"a": 0}`,
-	})
-	sqlDB.Exec(t, `ALTER TABLE bar ADD COLUMN b STRING CREATE FAMILY f_b`)
-	sqlDB.Exec(t, `INSERT INTO bar VALUES (1)`)
-	bar.Next()
-	if err := bar.Err(); !testutils.IsError(err, `exactly 1 column family`) {
-		t.Errorf(`expected "exactly 1 column family" error got: %+v`, err)
-	}
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
 func TestChangefeedComputedColumn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	ctx := context.Background()
-	s, sqlDBRaw, _ := serverutils.StartServer(t, base.TestServerArgs{
-		UseDatabase: "d",
-		// TODO(dan): HACK until the changefeed can control pgwire flushing.
-		ConnResultsBufferBytes: 1,
-	})
-	defer s.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
-	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
-	sqlDB.Exec(t, `CREATE DATABASE d`)
-	// TODO(dan): Also test a non-STORED computed column once we support them.
-	sqlDB.Exec(t, `CREATE TABLE cc (
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		// TODO(dan): Also test a non-STORED computed column once we support them.
+		sqlDB.Exec(t, `CREATE TABLE cc (
 		a INT, b INT AS (a + 1) STORED, c INT AS (a + 2) STORED, PRIMARY KEY (b, a)
 	)`)
-	sqlDB.Exec(t, `INSERT INTO cc (a) VALUES (1)`)
+		sqlDB.Exec(t, `INSERT INTO cc (a) VALUES (1)`)
 
-	rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR cc`)
-	defer closeFeedRowsHack(t, sqlDB, rows)
+		cc := f.Feed(t, `CREATE CHANGEFEED FOR cc`)
+		defer cc.Close(t)
 
-	assertPayloads(t, rows, []string{
-		`cc: [2, 1]->{"a": 1, "b": 2, "c": 3}`,
-	})
+		assertPayloads(t, cc, []string{
+			`cc: [2, 1]->{"a": 1, "b": 2, "c": 3}`,
+		})
 
-	sqlDB.Exec(t, `INSERT INTO cc (a) VALUES (10)`)
-	assertPayloads(t, rows, []string{
-		`cc: [11, 10]->{"a": 10, "b": 11, "c": 12}`,
-	})
+		sqlDB.Exec(t, `INSERT INTO cc (a) VALUES (10)`)
+		assertPayloads(t, cc, []string{
+			`cc: [11, 10]->{"a": 10, "b": 11, "c": 12}`,
+		})
+	}
+
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
 func TestChangefeedTruncateRenameDrop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	ctx := context.Background()
-	s, sqlDBRaw, _ := serverutils.StartServer(t, base.TestServerArgs{
-		UseDatabase: "d",
-		// TODO(dan): HACK until the changefeed can control pgwire flushing.
-		ConnResultsBufferBytes: 1,
-	})
-	defer s.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
-	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
-	sqlDB.Exec(t, `CREATE DATABASE d`)
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
 
-	// TODO(dan): TRUNCATE cascades, test for this too.
-	sqlDB.Exec(t, `CREATE TABLE truncate (a INT PRIMARY KEY)`)
-	sqlDB.Exec(t, `INSERT INTO truncate VALUES (1)`)
-	truncate := sqlDB.Query(t, `CREATE CHANGEFEED FOR truncate`)
-	defer closeFeedRowsHack(t, sqlDB, truncate)
-	assertPayloads(t, truncate, []string{`truncate: [1]->{"a": 1}`})
-	sqlDB.Exec(t, `TRUNCATE TABLE truncate`)
-	truncate.Next()
-	if err := truncate.Err(); !testutils.IsError(err, `"truncate" was dropped or truncated`) {
-		t.Errorf(`expected ""truncate" was dropped or truncated" error got: %+v`, err)
+		// TODO(dan): TRUNCATE cascades, test for this too.
+		sqlDB.Exec(t, `CREATE TABLE truncate (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO truncate VALUES (1)`)
+		truncate := f.Feed(t, `CREATE CHANGEFEED FOR truncate`)
+		defer truncate.Close(t)
+		assertPayloads(t, truncate, []string{`truncate: [1]->{"a": 1}`})
+		sqlDB.Exec(t, `TRUNCATE TABLE truncate`)
+		truncate.Next(t)
+		if err := truncate.Err(); !testutils.IsError(err, `"truncate" was dropped or truncated`) {
+			t.Errorf(`expected ""truncate" was dropped or truncated" error got: %+v`, err)
+		}
+
+		sqlDB.Exec(t, `CREATE TABLE rename (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO rename VALUES (1)`)
+		rename := f.Feed(t, `CREATE CHANGEFEED FOR rename`)
+		defer rename.Close(t)
+		assertPayloads(t, rename, []string{`rename: [1]->{"a": 1}`})
+		sqlDB.Exec(t, `ALTER TABLE rename RENAME TO renamed`)
+		sqlDB.Exec(t, `INSERT INTO renamed VALUES (2)`)
+		rename.Next(t)
+		if err := rename.Err(); !testutils.IsError(err, `"rename" was renamed to "renamed"`) {
+			t.Errorf(`expected ""rename" was renamed to "renamed"" error got: %+v`, err)
+		}
+
+		sqlDB.Exec(t, `CREATE TABLE drop (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO drop VALUES (1)`)
+		drop := f.Feed(t, `CREATE CHANGEFEED FOR drop`)
+		defer drop.Close(t)
+		assertPayloads(t, drop, []string{`drop: [1]->{"a": 1}`})
+		sqlDB.Exec(t, `DROP TABLE drop`)
+		drop.Next(t)
+		if err := drop.Err(); !testutils.IsError(err, `"drop" was dropped or truncated`) {
+			t.Errorf(`expected ""drop" was dropped or truncated" error got: %+v`, err)
+		}
 	}
 
-	sqlDB.Exec(t, `CREATE TABLE rename (a INT PRIMARY KEY)`)
-	sqlDB.Exec(t, `INSERT INTO rename VALUES (1)`)
-	rename := sqlDB.Query(t, `CREATE CHANGEFEED FOR rename`)
-	defer closeFeedRowsHack(t, sqlDB, rename)
-	assertPayloads(t, rename, []string{`rename: [1]->{"a": 1}`})
-	sqlDB.Exec(t, `ALTER TABLE rename RENAME TO renamed`)
-	sqlDB.Exec(t, `INSERT INTO renamed VALUES (2)`)
-	rename.Next()
-	if err := rename.Err(); !testutils.IsError(err, `"rename" was renamed to "renamed"`) {
-		t.Errorf(`expected ""rename" was renamed to "renamed"" error got: %+v`, err)
-	}
-
-	sqlDB.Exec(t, `CREATE TABLE drop (a INT PRIMARY KEY)`)
-	sqlDB.Exec(t, `INSERT INTO drop VALUES (1)`)
-	drop := sqlDB.Query(t, `CREATE CHANGEFEED FOR drop`)
-	defer closeFeedRowsHack(t, sqlDB, drop)
-	assertPayloads(t, drop, []string{`drop: [1]->{"a": 1}`})
-	sqlDB.Exec(t, `DROP TABLE drop`)
-	drop.Next()
-	if err := drop.Err(); !testutils.IsError(err, `"drop" was dropped or truncated`) {
-		t.Errorf(`expected ""drop" was dropped or truncated" error got: %+v`, err)
-	}
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
 func TestChangefeedMonitoring(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	ctx := context.Background()
-	s, sqlDBRaw, _ := serverutils.StartServer(t, base.TestServerArgs{
-		UseDatabase: "d",
-		// TODO(dan): HACK until the changefeed can control pgwire flushing.
-		ConnResultsBufferBytes: 1,
-	})
-	defer s.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
-	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
-	sqlDB.Exec(t, `CREATE DATABASE d`)
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		beforeEmitRowCh := make(chan struct{}, 2)
+		knobs := f.Server().(*server.TestServer).Cfg.TestingKnobs.
+			DistSQL.(*distsqlrun.TestingKnobs).
+			Changefeed.(*TestingKnobs)
+		knobs.BeforeEmitRow = func() error {
+			<-beforeEmitRowCh
+			return nil
+		}
 
-	// TODO(dan): Work around a race in CANCEL QUERIES (#28033) by only
-	// canceling them once.
-	var cancelQueriesOnce sync.Once
-	closeFeedRowsCancelOnceHack := func(t *testing.T, sqlDB *sqlutils.SQLRunner, rows *gosql.Rows) {
-		cancelQueriesOnce.Do(func() {
-			// TODO(dan): We should just be able to close the `gosql.Rows` but
-			// that currently blocks forever without this.
-			sqlDB.Exec(t, `CANCEL QUERIES (
-				SELECT query_id FROM [SHOW QUERIES] WHERE query LIKE 'CREATE CHANGEFEED%'
-			)`)
-		})
-		rows.Close()
-	}
-	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
 
-	start := timeutil.Now()
-	sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
+		start := timeutil.Now()
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
 
-	if c := s.MustGetSQLCounter(`changefeed.emitted_messages`); c != 0 {
-		t.Errorf(`expected 0 got %d`, c)
-	}
-	if c := s.MustGetSQLCounter(`changefeed.emitted_bytes`); c != 0 {
-		t.Errorf(`expected 0 got %d`, c)
-	}
-	if c := s.MustGetSQLCounter(`changefeed.emit_nanos`); c != 0 {
-		t.Errorf(`expected 0 got %d`, c)
-	}
-	if c := s.MustGetSQLCounter(`changefeed.flushes`); c != 0 {
-		t.Errorf(`expected 0 got %d`, c)
-	}
-	if c := s.MustGetSQLCounter(`changefeed.flush_nanos`); c != 0 {
-		t.Errorf(`expected 0 got %d`, c)
-	}
-	if c := s.MustGetSQLCounter(`changefeed.min_high_water`); c != noMinHighWaterSentinel {
-		t.Errorf(`expected %d got %d`, noMinHighWaterSentinel, c)
-	}
-
-	foo := sqlDB.Query(t, `CREATE CHANGEFEED FOR foo`)
-	defer closeFeedRowsCancelOnceHack(t, sqlDB, foo)
-	foo.Next()
-	testutils.SucceedsSoon(t, func() error {
-		if c := s.MustGetSQLCounter(`changefeed.emitted_messages`); c != 1 {
-			return errors.Errorf(`expected 1 got %d`, c)
+		s := f.Server()
+		if c := s.MustGetSQLCounter(`changefeed.emitted_messages`); c != 0 {
+			t.Errorf(`expected 0 got %d`, c)
 		}
-		if c := s.MustGetSQLCounter(`changefeed.emitted_bytes`); c != 11 {
-			return errors.Errorf(`expected 11 got %d`, c)
+		if c := s.MustGetSQLCounter(`changefeed.emitted_bytes`); c != 0 {
+			t.Errorf(`expected 0 got %d`, c)
 		}
-		if c := s.MustGetSQLCounter(`changefeed.emit_nanos`); c <= 0 {
-			return errors.Errorf(`expected > 0 got %d`, c)
+		if c := s.MustGetSQLCounter(`changefeed.emit_nanos`); c != 0 {
+			t.Errorf(`expected 0 got %d`, c)
 		}
-		if c := s.MustGetSQLCounter(`changefeed.flushes`); c <= 0 {
-			return errors.Errorf(`expected > 0 got %d`, c)
+		if c := s.MustGetSQLCounter(`changefeed.flushes`); c != 0 {
+			t.Errorf(`expected 0 got %d`, c)
 		}
-		if c := s.MustGetSQLCounter(`changefeed.flush_nanos`); c <= 0 {
-			return errors.Errorf(`expected > 0 got %d`, c)
+		if c := s.MustGetSQLCounter(`changefeed.flush_nanos`); c != 0 {
+			t.Errorf(`expected 0 got %d`, c)
 		}
-		if c := s.MustGetSQLCounter(`changefeed.min_high_water`); c <= start.UnixNano() {
-			return errors.Errorf(`expected > %d got %d`, start.UnixNano(), c)
-		}
-		return nil
-	})
-
-	// Check that two changefeeds add correctly.
-	sqlDB.Exec(t, `INSERT INTO foo VALUES (2)`)
-	fooCopy := sqlDB.Query(t, `CREATE CHANGEFEED FOR foo`)
-	defer closeFeedRowsCancelOnceHack(t, sqlDB, fooCopy)
-	fooCopy.Next()
-	testutils.SucceedsSoon(t, func() error {
-		if c := s.MustGetSQLCounter(`changefeed.emitted_messages`); c != 4 {
-			return errors.Errorf(`expected 4 got %d`, c)
-		}
-		if c := s.MustGetSQLCounter(`changefeed.emitted_bytes`); c != 44 {
-			return errors.Errorf(`expected 44 got %d`, c)
-		}
-		return nil
-	})
-
-	// Not reading from fooTimestamps will backpressure the changefeed and the
-	// min_high_water will stagnate.
-	fooTimestamps := sqlDB.Query(t, `CREATE CHANGEFEED FOR foo WITH resolved`)
-	defer closeFeedRowsCancelOnceHack(t, sqlDB, fooTimestamps)
-	stalled := s.MustGetSQLCounter(`changefeed.min_high_water`)
-	for i := 0; i < 100; {
-		i++
-		newMinResolved := s.MustGetSQLCounter(`changefeed.min_high_water`)
-		if newMinResolved != stalled {
-			stalled = newMinResolved
-			i = 0
-		}
-	}
-	// Reading until a resolved timestamp past that should updated the
-	// min_high_water.
-	fooTimestamps.Next()
-	fooTimestamps.Next()
-	expectResolvedTimestampGreaterThan(t, fooTimestamps, fmt.Sprintf("%d.0", stalled))
-	testutils.SucceedsSoon(t, func() error {
-		if c := s.MustGetSQLCounter(`changefeed.min_high_water`); c <= stalled {
-			return errors.Errorf(`expected > %d got %d`, stalled, c)
-		}
-		return nil
-	})
-
-	// Cancel all the changefeeds and check that the min_high_water returns to the
-	// no high-water sentinel.
-	cancelQueriesOnce.Do(func() {
-		// TODO(dan): We should just be able to close the `gosql.Rows` but
-		// that currently blocks forever without this.
-		sqlDB.Exec(t, `CANCEL QUERIES (
-			SELECT query_id FROM [SHOW QUERIES] WHERE query LIKE 'CREATE CHANGEFEED%'
-		)`)
-	})
-	testutils.SucceedsSoon(t, func() error {
 		if c := s.MustGetSQLCounter(`changefeed.min_high_water`); c != noMinHighWaterSentinel {
-			return errors.Errorf(`expected %d got %d`, noMinHighWaterSentinel, c)
+			t.Errorf(`expected %d got %d`, noMinHighWaterSentinel, c)
 		}
-		return nil
-	})
+
+		beforeEmitRowCh <- struct{}{}
+		foo := f.Feed(t, `CREATE CHANGEFEED FOR foo`)
+		foo.Next(t)
+		testutils.SucceedsSoon(t, func() error {
+			if c := s.MustGetSQLCounter(`changefeed.emitted_messages`); c != 1 {
+				return errors.Errorf(`expected 1 got %d`, c)
+			}
+			if c := s.MustGetSQLCounter(`changefeed.emitted_bytes`); c != 11 {
+				return errors.Errorf(`expected 11 got %d`, c)
+			}
+			if c := s.MustGetSQLCounter(`changefeed.emit_nanos`); c <= 0 {
+				return errors.Errorf(`expected > 0 got %d`, c)
+			}
+			if c := s.MustGetSQLCounter(`changefeed.flushes`); c <= 0 {
+				return errors.Errorf(`expected > 0 got %d`, c)
+			}
+			if c := s.MustGetSQLCounter(`changefeed.flush_nanos`); c <= 0 {
+				return errors.Errorf(`expected > 0 got %d`, c)
+			}
+			if c := s.MustGetSQLCounter(`changefeed.min_high_water`); c == noMinHighWaterSentinel {
+				return errors.New(`waiting for high-water to not be sentinel`)
+			} else if c <= start.UnixNano() {
+				return errors.Errorf(`expected > %d got %d`, start.UnixNano(), c)
+			}
+			return nil
+		})
+
+		// Not reading from foo will backpressure it and the min_high_water will
+		// stagnate.
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (2)`)
+		stalled := s.MustGetSQLCounter(`changefeed.min_high_water`)
+		for i := 0; i < 100; {
+			i++
+			newMinResolved := s.MustGetSQLCounter(`changefeed.min_high_water`)
+			if newMinResolved != stalled {
+				stalled = newMinResolved
+				i = 0
+			}
+		}
+		// Unblocking the emit should update the min_high_water.
+		beforeEmitRowCh <- struct{}{}
+		foo.Next(t)
+		testutils.SucceedsSoon(t, func() error {
+			if c := s.MustGetSQLCounter(`changefeed.min_high_water`); c <= stalled {
+				return errors.Errorf(`expected > %d got %d`, stalled, c)
+			}
+			return nil
+		})
+
+		// Check that two changefeeds add correctly.
+		beforeEmitRowCh <- struct{}{}
+		beforeEmitRowCh <- struct{}{}
+		fooCopy := f.Feed(t, `CREATE CHANGEFEED FOR foo`)
+		fooCopy.Next(t)
+		fooCopy.Next(t)
+		testutils.SucceedsSoon(t, func() error {
+			if c := s.MustGetSQLCounter(`changefeed.emitted_messages`); c != 4 {
+				return errors.Errorf(`expected 4 got %d`, c)
+			}
+			if c := s.MustGetSQLCounter(`changefeed.emitted_bytes`); c != 44 {
+				return errors.Errorf(`expected 44 got %d`, c)
+			}
+			return nil
+		})
+
+		// Cancel all the changefeeds and check that the min_high_water returns to the
+		// no high-water sentinel.
+		close(beforeEmitRowCh)
+		foo.Close(t)
+		fooCopy.Close(t)
+		testutils.SucceedsSoon(t, func() error {
+			if c := s.MustGetSQLCounter(`changefeed.min_high_water`); c != noMinHighWaterSentinel {
+				return errors.Errorf(`expected %d got %d`, noMinHighWaterSentinel, c)
+			}
+			return nil
+		})
+	}
+
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
 func TestChangefeedRetryableSinkError(t *testing.T) {
@@ -860,196 +791,190 @@ func TestChangefeedRetryableSinkError(t *testing.T) {
 func TestChangefeedErrors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	ctx := context.Background()
-	s, sqlDBRaw, _ := serverutils.StartServer(t, base.TestServerArgs{UseDatabase: "d"})
-	defer s.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
 
-	sqlDB.Exec(t, `CREATE DATABASE d`)
-	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+		if _, err := sqlDB.DB.Exec(
+			`CREATE CHANGEFEED FOR foo WITH format=avro`,
+		); !testutils.IsError(err, `format=avro is not yet supported`) {
+			t.Errorf(`expected 'format=avro is not yet supported' error got: %+v`, err)
+		}
+		if _, err := sqlDB.DB.Exec(
+			`CREATE CHANGEFEED FOR foo WITH format=nope`,
+		); !testutils.IsError(err, `unknown format: nope`) {
+			t.Errorf(`expected 'unknown format: nope' error got: %+v`, err)
+		}
 
-	if _, err := sqlDB.DB.Exec(
-		`CREATE CHANGEFEED FOR foo WITH format=avro`,
-	); !testutils.IsError(err, `format=avro is not yet supported`) {
-		t.Errorf(`expected 'format=avro is not yet supported' error got: %+v`, err)
-	}
-	if _, err := sqlDB.DB.Exec(
-		`CREATE CHANGEFEED FOR foo WITH format=nope`,
-	); !testutils.IsError(err, `unknown format: nope`) {
-		t.Errorf(`expected 'unknown format: nope' error got: %+v`, err)
+		if _, err := sqlDB.DB.Exec(
+			`CREATE CHANGEFEED FOR foo WITH envelope=diff`,
+		); !testutils.IsError(err, `envelope=diff is not yet supported`) {
+			t.Errorf(`expected 'envelope=diff is not yet supported' error got: %+v`, err)
+		}
+		if _, err := sqlDB.DB.Exec(
+			`CREATE CHANGEFEED FOR foo WITH envelope=nope`,
+		); !testutils.IsError(err, `unknown envelope: nope`) {
+			t.Errorf(`expected 'unknown envelope: nope' error got: %+v`, err)
+		}
+
+		if _, err := sqlDB.DB.Exec(
+			`CREATE CHANGEFEED FOR foo INTO ''`,
+		); !testutils.IsError(err, `omit the SINK clause`) {
+			t.Errorf(`expected 'omit the SINK clause' error got: %+v`, err)
+		}
+		if _, err := sqlDB.DB.Exec(
+			`CREATE CHANGEFEED FOR foo INTO $1`, ``,
+		); !testutils.IsError(err, `omit the SINK clause`) {
+			t.Errorf(`expected 'omit the SINK clause' error got: %+v`, err)
+		}
+
+		enableEnterprise := utilccl.TestingDisableEnterprise()
+		if _, err := sqlDB.DB.Exec(
+			`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope`,
+		); !testutils.IsError(err, `CHANGEFEED requires an enterprise license`) {
+			t.Errorf(`expected 'CHANGEFEED requires an enterprise license' error got: %+v`, err)
+		}
+		enableEnterprise()
+
+		// Watching system.jobs would create a cycle, since the resolved timestamp
+		// high-water mark is saved in it.
+		if _, err := sqlDB.DB.Exec(
+			`CREATE CHANGEFEED FOR system.jobs`,
+		); !testutils.IsError(err, `not supported on system tables`) {
+			t.Errorf(`expected 'not supported on system tables' error got: %+v`, err)
+		}
+		if _, err := sqlDB.DB.Exec(
+			`CREATE CHANGEFEED FOR bar`,
+		); !testutils.IsError(err, `table "bar" does not exist`) {
+			t.Errorf(`expected 'table "bar" does not exist' error got: %+v`, err)
+		}
+		sqlDB.Exec(t, `CREATE SEQUENCE seq`)
+		if _, err := sqlDB.DB.Exec(
+			`CREATE CHANGEFEED FOR seq`,
+		); !testutils.IsError(err, `CHANGEFEED cannot target sequences: seq`) {
+			t.Errorf(`expected 'CHANGEFEED cannot target sequences: seq' error got: %+v`, err)
+		}
+		sqlDB.Exec(t, `CREATE VIEW vw AS SELECT a, b FROM foo`)
+		if _, err := sqlDB.DB.Exec(
+			`CREATE CHANGEFEED FOR vw`,
+		); !testutils.IsError(err, `CHANGEFEED cannot target views: vw`) {
+			t.Errorf(`expected 'CHANGEFEED cannot target views: vw' error got: %+v`, err)
+		}
+		// Backup has the same bad error message #28170.
+		if _, err := sqlDB.DB.Exec(
+			`CREATE CHANGEFEED FOR information_schema.tables`,
+		); !testutils.IsError(err, `"information_schema.tables" does not exist`) {
+			t.Errorf(`expected '"information_schema.tables" does not exist' error got: %+v`, err)
+		}
 	}
 
-	if _, err := sqlDB.DB.Exec(
-		`CREATE CHANGEFEED FOR foo WITH envelope=diff`,
-	); !testutils.IsError(err, `envelope=diff is not yet supported`) {
-		t.Errorf(`expected 'envelope=diff is not yet supported' error got: %+v`, err)
-	}
-	if _, err := sqlDB.DB.Exec(
-		`CREATE CHANGEFEED FOR foo WITH envelope=nope`,
-	); !testutils.IsError(err, `unknown envelope: nope`) {
-		t.Errorf(`expected 'unknown envelope: nope' error got: %+v`, err)
-	}
-
-	if _, err := sqlDB.DB.Exec(
-		`CREATE CHANGEFEED FOR foo INTO ''`,
-	); !testutils.IsError(err, `omit the SINK clause`) {
-		t.Errorf(`expected 'omit the SINK clause' error got: %+v`, err)
-	}
-	if _, err := sqlDB.DB.Exec(
-		`CREATE CHANGEFEED FOR foo INTO $1`, ``,
-	); !testutils.IsError(err, `omit the SINK clause`) {
-		t.Errorf(`expected 'omit the SINK clause' error got: %+v`, err)
-	}
-
-	if _, err := sqlDB.DB.Exec(
-		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope`,
-	); !testutils.IsError(err, `use of CHANGEFEED requires an enterprise license`) {
-		t.Errorf(`expected 'use of CHANGEFEED requires an enterprise license' error got: %+v`, err)
-	}
-
-	// Watching system.jobs would create a cycle, since the resolved timestamp
-	// high-water mark is saved in it.
-	if _, err := sqlDB.DB.Exec(
-		`CREATE CHANGEFEED FOR system.jobs`,
-	); !testutils.IsError(err, `CHANGEFEEDs are not supported on system tables`) {
-		t.Errorf(`expected 'CHANGEFEEDs are not supported on system tables' error got: %+v`, err)
-	}
-	if _, err := sqlDB.DB.Exec(
-		`CREATE CHANGEFEED FOR bar`,
-	); !testutils.IsError(err, `table "bar" does not exist`) {
-		t.Errorf(`expected 'table "bar" does not exist' error got: %+v`, err)
-	}
-	sqlDB.Exec(t, `CREATE SEQUENCE seq`)
-	if _, err := sqlDB.DB.Exec(
-		`CREATE CHANGEFEED FOR seq`,
-	); !testutils.IsError(err, `CHANGEFEED cannot target sequences: seq`) {
-		t.Errorf(`expected 'CHANGEFEED cannot target sequences: seq' error got: %+v`, err)
-	}
-	sqlDB.Exec(t, `CREATE VIEW vw AS SELECT a, b FROM foo`)
-	if _, err := sqlDB.DB.Exec(
-		`CREATE CHANGEFEED FOR vw`,
-	); !testutils.IsError(err, `CHANGEFEED cannot target views: vw`) {
-		t.Errorf(`expected 'CHANGEFEED cannot target views: vw' error got: %+v`, err)
-	}
-	// Backup has the same bad error message #28170.
-	if _, err := sqlDB.DB.Exec(
-		`CREATE CHANGEFEED FOR information_schema.tables`,
-	); !testutils.IsError(err, `table "information_schema.tables" does not exist`) {
-		t.Errorf(`expected 'table "information_schema.tables" does not exist' error got: %+v`, err)
-	}
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
 func TestChangefeedPermissions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	ctx := context.Background()
-	s, sqlDBRaw, _ := serverutils.StartServer(t, base.TestServerArgs{UseDatabase: "d"})
-	defer s.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
-	sqlDB.Exec(t, `CREATE DATABASE d`)
-	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
-	sqlDB.Exec(t, `CREATE USER testuser`)
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `CREATE USER testuser`)
 
-	pgURL, cleanupFunc := sqlutils.PGUrl(
-		t, s.ServingAddr(), "TestChangefeedPermissions-testuser", url.User("testuser"),
-	)
-	defer cleanupFunc()
-	testuser, err := gosql.Open("postgres", pgURL.String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer testuser.Close()
-
-	if _, err := testuser.Exec(
-		`CREATE CHANGEFEED FOR foo`,
-	); !testutils.IsError(err, `only superusers are allowed to CREATE CHANGEFEED`) {
-		t.Errorf(`expected 'only superusers are allowed to CREATE CHANGEFEED' error got: %+v`, err)
-	}
-}
-
-func assertPayloads(t *testing.T, rows *gosql.Rows, expected []string) {
-	t.Helper()
-
-	var actual []string
-	for len(actual) < len(expected) && rows.Next() {
-		var topic gosql.NullString
-		var key, value []byte
-		if err := rows.Scan(&topic, &key, &value); err != nil {
-			t.Fatalf(`%+v`, err)
-		}
-		if !topic.Valid {
-			// Ignore resolved timestamp notifications.
-			continue
-		}
-		actual = append(actual, fmt.Sprintf(`%s: %s->%s`, topic.String, key, value))
-	}
-	if err := rows.Err(); err != nil {
-		t.Fatalf(`%+v`, err)
-	}
-
-	// The tests that use this aren't concerned with order, just that these are
-	// the next len(expected) messages.
-	sort.Strings(expected)
-	sort.Strings(actual)
-	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("expected\n  %s\ngot\n  %s",
-			strings.Join(expected, "\n  "), strings.Join(actual, "\n  "))
-	}
-}
-
-func skipResolvedTimestamps(t *testing.T, rows *gosql.Rows) {
-	for rows.Next() {
-		var table gosql.NullString
-		var key, value []byte
-		if err := rows.Scan(&table, &key, &value); err != nil {
+		s := f.Server()
+		pgURL, cleanupFunc := sqlutils.PGUrl(
+			t, s.ServingAddr(), "TestChangefeedPermissions-testuser", url.User("testuser"),
+		)
+		defer cleanupFunc()
+		testuser, err := gosql.Open("postgres", pgURL.String())
+		if err != nil {
 			t.Fatal(err)
 		}
-		if table.Valid {
-			t.Errorf(`unexpected row %s: %s->%s`, table.String, key, value)
+		defer testuser.Close()
+
+		if _, err := testuser.Exec(
+			`CREATE CHANGEFEED FOR foo`,
+		); !testutils.IsError(err, `only superusers`) {
+			t.Errorf(`expected 'only superusers' error got: %+v`, err)
 		}
 	}
+
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
-func expectResolvedTimestampGreaterThan(t testing.TB, rows *gosql.Rows, ts string) {
-	t.Helper()
-	for {
-		if !rows.Next() {
-			t.Fatal(`expected a resolved timestamp notification`)
-		}
-		var ignored interface{}
-		var value []byte
-		if err := rows.Scan(&ignored, &ignored, &value); err != nil {
-			t.Fatal(err)
-		}
+func TestChangefeedDescription(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 
-		var valueRaw struct {
-			CRDB struct {
-				Resolved string `json:"resolved"`
-			} `json:"__crdb__"`
-		}
-		if err := gojson.Unmarshal(value, &valueRaw); err != nil {
-			t.Fatal(err)
-		}
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
 
-		parseTimeToDecimal := func(s string) *apd.Decimal {
-			t.Helper()
-			d, _, err := apd.NewFromString(s)
-			if err != nil {
-				t.Fatal(err)
-			}
-			return d
-		}
-		if parseTimeToDecimal(valueRaw.CRDB.Resolved).Cmp(parseTimeToDecimal(ts)) > 0 {
-			break
+		// Intentionally don't use the testfeedFactory because we want to
+		// control the placeholders.
+		s := f.Server()
+		sink, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), t.Name(), url.User(security.RootUser))
+		defer cleanup()
+		sink.Scheme = sinkSchemeExperimentalSQL
+		sink.Path = `d`
+
+		var jobID int64
+		sqlDB.QueryRow(t,
+			`CREATE CHANGEFEED FOR foo INTO $1 WITH updated, envelope = $2`, sink.String(), `row`,
+		).Scan(&jobID)
+
+		var description string
+		sqlDB.QueryRow(t,
+			`SELECT description FROM [SHOW JOBS] WHERE job_id = $1`, jobID,
+		).Scan(&description)
+		expected := `CREATE CHANGEFEED FOR TABLE foo INTO '` + sink.String() +
+			`' WITH envelope = 'row', updated`
+		if description != expected {
+			t.Errorf(`got "%s" expected "%s"`, description, expected)
 		}
 	}
+
+	// Only the enterprise version uses jobs.
+	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
-func closeFeedRowsHack(t *testing.T, sqlDB *sqlutils.SQLRunner, rows *gosql.Rows) {
-	// TODO(dan): We should just be able to close the `gosql.Rows` but that
-	// currently blocks forever without this.
-	sqlDB.Exec(t, `CANCEL QUERIES (
-		SELECT query_id FROM [SHOW QUERIES] WHERE query LIKE 'CREATE CHANGEFEED%'
-	)`)
-	rows.Close()
+func TestChangefeedPauseUnpause(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	defer func(i time.Duration) { jobs.DefaultAdoptInterval = i }(jobs.DefaultAdoptInterval)
+	jobs.DefaultAdoptInterval = 10 * time.Millisecond
+
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'a'), (2, 'b'), (4, 'c'), (7, 'd'), (8, 'e')`)
+
+		foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH resolved`).(*tableFeed)
+		defer foo.Close(t)
+
+		assertPayloads(t, foo, []string{
+			`foo: [1]->{"a": 1, "b": "a"}`,
+			`foo: [2]->{"a": 2, "b": "b"}`,
+			`foo: [4]->{"a": 4, "b": "c"}`,
+			`foo: [7]->{"a": 7, "b": "d"}`,
+			`foo: [8]->{"a": 8, "b": "e"}`,
+		})
+
+		// Wait for the high-water mark on the job to be updated after the initial
+		// scan, to make sure we don't get the initial scan data again.
+		topic, _, key, value, _, ok := foo.Next(t)
+		if !ok || key != nil {
+			t.Fatalf(`expected a resolved timestamp got %s: %s->%s`, topic, key, value)
+		}
+
+		sqlDB.Exec(t, `PAUSE JOB $1`, foo.jobID)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (16, 'f')`)
+		sqlDB.Exec(t, `RESUME JOB $1`, foo.jobID)
+		assertPayloads(t, foo, []string{
+			`foo: [16]->{"a": 16, "b": "f"}`,
+		})
+	}
+
+	// Only the enterprise version uses jobs.
+	t.Run(`enterprise`, enterpriseTest(testFn))
 }

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -12,11 +12,26 @@ import (
 	"bytes"
 	"context"
 	gosql "database/sql"
+	gojson "encoding/json"
 	"fmt"
+	"net/url"
+	"reflect"
+	"sort"
+	"strings"
 	"sync"
+	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+
+	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -28,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 )
 
 type benchSink struct {
@@ -223,4 +239,404 @@ func loadWorkloadBatches(sqlDB *gosql.DB, table workload.Table) ([]time.Time, in
 	}
 
 	return timestamps, benchBytes, nil
+}
+
+type testfeedFactory interface {
+	Feed(t testing.TB, create string, args ...interface{}) testfeed
+	Server() serverutils.TestServerInterface
+}
+
+type testfeed interface {
+	Partitions() []string
+	Next(t testing.TB) (topic, partition string, key, value, payload []byte, ok bool)
+	Err() error
+	Close(t testing.TB)
+}
+
+type sinklessFeedFactory struct {
+	s  serverutils.TestServerInterface
+	db *gosql.DB
+}
+
+func makeSinkless(s serverutils.TestServerInterface, db *gosql.DB) *sinklessFeedFactory {
+	return &sinklessFeedFactory{s: s, db: db}
+}
+
+func (f *sinklessFeedFactory) Feed(t testing.TB, create string, args ...interface{}) testfeed {
+	t.Helper()
+
+	if _, err := f.db.Exec(
+		`SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &sinklessFeed{db: f.db}
+	now := timeutil.Now()
+	var err error
+	s.rows, err = s.db.Query(create, args...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	queryIDRows, err := s.db.Query(
+		`SELECT query_id FROM [SHOW QUERIES] WHERE query LIKE 'CREATE CHANGEFEED%' AND start > $1`,
+		now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !queryIDRows.Next() {
+		t.Fatalf(`could not find query id`)
+	}
+	if err := queryIDRows.Scan(&s.queryID); err != nil {
+		t.Fatal(err)
+	}
+	if queryIDRows.Next() {
+		t.Fatalf(`found too many query ids`)
+	}
+	return s
+}
+
+func (f *sinklessFeedFactory) Server() serverutils.TestServerInterface {
+	return f.s
+}
+
+type sinklessFeed struct {
+	db      *gosql.DB
+	rows    *gosql.Rows
+	queryID string
+}
+
+func (c *sinklessFeed) Partitions() []string { return []string{`sinkless`} }
+
+func (c *sinklessFeed) Next(
+	t testing.TB,
+) (topic, partition string, key, value, resolved []byte, ok bool) {
+	t.Helper()
+	partition = `sinkless`
+	var noKey, noValue, noResolved []byte
+	if !c.rows.Next() {
+		return ``, ``, nil, nil, nil, false
+	}
+	var maybeTopic gosql.NullString
+	if err := c.rows.Scan(&maybeTopic, &key, &value); err != nil {
+		t.Fatal(err)
+	}
+	if maybeTopic.Valid {
+		return maybeTopic.String, partition, key, value, noResolved, true
+	}
+	resolvedPayload := value
+	return ``, partition, noKey, noValue, resolvedPayload, true
+}
+
+func (c *sinklessFeed) Err() error {
+	if c.rows != nil {
+		return c.rows.Err()
+	}
+	return nil
+}
+
+func (c *sinklessFeed) Close(t testing.TB) {
+	t.Helper()
+	// TODO(dan): We should just be able to close the `gosql.Rows` but that
+	// currently blocks forever without this.
+	if _, err := c.db.Exec(`CANCEL QUERY IF EXISTS $1`, c.queryID); err != nil {
+		t.Error(err)
+	}
+	// Ignore the error because we just force canceled the feed.
+	_ = c.rows.Close()
+}
+
+type tableFeedFactory struct {
+	s       serverutils.TestServerInterface
+	db      *gosql.DB
+	flushCh chan struct{}
+}
+
+func makeTable(
+	s serverutils.TestServerInterface, db *gosql.DB, flushCh chan struct{},
+) *tableFeedFactory {
+	return &tableFeedFactory{s: s, db: db, flushCh: flushCh}
+}
+
+func (f *tableFeedFactory) Feed(t testing.TB, create string, args ...interface{}) testfeed {
+	t.Helper()
+
+	sink, cleanup := sqlutils.PGUrl(t, f.s.ServingAddr(), t.Name(), url.User(security.RootUser))
+	sink.Path = fmt.Sprintf(`table_%d`, timeutil.Now().UnixNano())
+
+	db, err := gosql.Open("postgres", sink.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sink.Scheme = sinkSchemeExperimentalSQL
+	c := &tableFeed{db: db, urlCleanup: cleanup, sinkURI: sink.String(), flushCh: f.flushCh}
+	if _, err := c.db.Exec(
+		`SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.db.Exec(`CREATE DATABASE ` + sink.Path); err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := parser.ParseOne(create)
+	if err != nil {
+		t.Fatal(err)
+	}
+	createStmt := parsed.(*tree.CreateChangefeed)
+	if createStmt.SinkURI != nil {
+		t.Fatalf(`unexpected sink provided: "INTO %s"`, tree.AsString(createStmt.SinkURI))
+	}
+	createStmt.SinkURI = tree.NewStrVal(c.sinkURI)
+
+	if err := f.db.QueryRow(createStmt.String(), args...).Scan(&c.jobID); err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func (f *tableFeedFactory) Server() serverutils.TestServerInterface {
+	return f.s
+}
+
+type tableFeed struct {
+	db         *gosql.DB
+	sinkURI    string
+	urlCleanup func()
+	jobID      int64
+	flushCh    chan struct{}
+
+	rows   *gosql.Rows
+	jobErr error
+}
+
+func (c *tableFeed) Partitions() []string {
+	// The sqlSink hardcodes these.
+	return []string{`0`, `1`, `2`}
+}
+
+func (c *tableFeed) Next(
+	t testing.TB,
+) (topic, partition string, key, value, payload []byte, ok bool) {
+	// sinkSink writes all changes to a table with primary key of topic,
+	// partition, message_id. To simulate the semantics of kafka, message_ids
+	// are only comparable within a given (topic, partition). Internally the
+	// message ids are generated as a 64 bit int with a timestamp in bits 1-49
+	// and a hash of the partition in 50-64. This tableFeed.Next function works
+	// by repeatedly fetching and deleting all rows in the table. Then it pages
+	// through the results until they are empty and repeats.
+	//
+	// To avoid busy waiting, we wait for the AfterFlushHook (which is called
+	// after results are flushed to a sink) in between polls. It is required
+	// that this is hooked up to `flushCh`, which is usually handled by the
+	// `enterpriseTest` helper.
+	//
+	// The trickiest bit is handling errors in the changefeed. The tests want to
+	// eventually notice them, but want to return all generated results before
+	// giving up and returning the error. This is accomplished by checking the
+	// job error immediately before every poll. If it's set, the error is
+	// stashed and one more poll's result set is paged through, before finally
+	// returning the error. If we're careful to run the last poll after getting
+	// the error, then it's guaranteed to contain everything flushed by the
+	// changefeed before it shut down.
+	for {
+		if c.rows != nil && c.rows.Next() {
+			var msgID int64
+			if err := c.rows.Scan(&topic, &partition, &msgID, &key, &value, &payload); err != nil {
+				t.Fatal(err)
+			}
+			// Scan turns NULL bytes columns into a 0-length, non-nil byte
+			// array, which is pretty unexpected. Nil them out before returning.
+			// Either key+value or payload will be set, but not both.
+			if len(key) > 0 {
+				payload = nil
+			} else {
+				key, value = nil, nil
+			}
+			return topic, partition, key, value, payload, true
+		}
+		if c.rows != nil {
+			if err := c.rows.Close(); err != nil {
+				t.Fatal(err)
+			}
+			c.rows = nil
+		}
+		if c.jobErr != nil {
+			return ``, ``, nil, nil, nil, false
+		}
+
+		// We're not guaranteed to get a flush notification if the feed exits,
+		// so bound how long we wait.
+		select {
+		case <-c.flushCh:
+		case <-time.After(30 * time.Millisecond):
+		}
+
+		// If the error was set, save it, but do one more poll as described
+		// above.
+		var errorStr gosql.NullString
+		if err := c.db.QueryRow(
+			`SELECT error FROM [SHOW JOBS] WHERE job_id=$1`, c.jobID,
+		).Scan(&errorStr); err != nil {
+			t.Fatal(err)
+		}
+		if len(errorStr.String) > 0 {
+			c.jobErr = errors.New(errorStr.String)
+		}
+
+		// TODO(dan): It's a bummer that this mutates the sqlsink table. I
+		// originally tried paging through message_id by repeatedly generating a
+		// new high-water with GenerateUniqueInt, but this was racy with rows
+		// being flushed out by the sink. An alternative is to steal the nanos
+		// part from `high_water_timestamp` in `crdb_internal.jobs` and run it
+		// through `builtins.GenerateUniqueID`, but that would mean we're only
+		// ever running tests on rows that have gotten a resolved timestamp,
+		// which seems limiting.
+		var err error
+		c.rows, err = c.db.Query(
+			`DELETE FROM sqlsink ORDER BY PRIMARY KEY sqlsink RETURNING *`)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func (c *tableFeed) Err() error {
+	return c.jobErr
+}
+
+func (c *tableFeed) Close(t testing.TB) {
+	if c.rows != nil {
+		if err := c.rows.Close(); err != nil {
+			t.Errorf(`could not close rows: %v`, err)
+		}
+	}
+	if _, err := c.db.Exec(`CANCEL JOB $1`, c.jobID); err != nil {
+		log.Infof(context.Background(), `could not cancel feed %d: %v`, c.jobID, err)
+	}
+	if err := c.db.Close(); err != nil {
+		t.Error(err)
+	}
+	c.urlCleanup()
+}
+
+func assertPayloads(t testing.TB, f testfeed, expected []string) {
+	t.Helper()
+
+	var actual []string
+	for len(actual) < len(expected) {
+		topic, _, key, value, resolved, ok := f.Next(t)
+		if !ok {
+			break
+		} else if key != nil {
+			actual = append(actual, fmt.Sprintf(`%s: %s->%s`, topic, key, value))
+		} else if resolved != nil {
+			continue
+		}
+	}
+
+	// The tests that use this aren't concerned with order, just that these are
+	// the next len(expected) messages.
+	sort.Strings(expected)
+	sort.Strings(actual)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected\n  %s\ngot\n  %s",
+			strings.Join(expected, "\n  "), strings.Join(actual, "\n  "))
+	}
+}
+
+func skipResolvedTimestamps(t *testing.T, f testfeed) {
+	for {
+		table, _, key, value, _, ok := f.Next(t)
+		if !ok {
+			break
+		}
+		if key != nil {
+			t.Errorf(`unexpected row %s: %s->%s`, table, key, value)
+		}
+	}
+}
+
+func expectResolvedTimestampGreaterThan(t testing.TB, f testfeed, ts string) {
+	t.Helper()
+	for {
+		topic, _, key, value, resolved, _ := f.Next(t)
+		if key != nil {
+			t.Fatalf(`unexpected row %s: %s -> %s`, topic, key, value)
+		}
+		if resolved == nil {
+			t.Fatal(`expected a resolved timestamp notification`)
+		}
+
+		var valueRaw struct {
+			CRDB struct {
+				Resolved string `json:"resolved"`
+			} `json:"__crdb__"`
+		}
+		if err := gojson.Unmarshal(resolved, &valueRaw); err != nil {
+			t.Fatal(err)
+		}
+		parseTimeToDecimal := func(s string) *apd.Decimal {
+			t.Helper()
+			d, _, err := apd.NewFromString(s)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return d
+		}
+		if parseTimeToDecimal(valueRaw.CRDB.Resolved).Cmp(parseTimeToDecimal(ts)) > 0 {
+			break
+		}
+	}
+}
+
+func sinklessTest(testFn func(*testing.T, *gosql.DB, testfeedFactory)) func(*testing.T) {
+	return func(t *testing.T) {
+		ctx := context.Background()
+		knobs := base.TestingKnobs{DistSQL: &distsqlrun.TestingKnobs{Changefeed: &TestingKnobs{}}}
+		s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+			UseDatabase: "d",
+			Knobs:       knobs,
+			// TODO(dan): HACK until the changefeed can control pgwire flushing.
+			ConnResultsBufferBytes: 1,
+		})
+		defer s.Stopper().Stop(ctx)
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
+		sqlDB.Exec(t, `CREATE DATABASE d`)
+		f := makeSinkless(s, db)
+		testFn(t, db, f)
+	}
+}
+
+func enterpriseTest(testFn func(*testing.T, *gosql.DB, testfeedFactory)) func(*testing.T) {
+	return func(t *testing.T) {
+		ctx := context.Background()
+
+		flushCh := make(chan struct{}, 1)
+		defer close(flushCh)
+		knobs := base.TestingKnobs{DistSQL: &distsqlrun.TestingKnobs{Changefeed: &TestingKnobs{
+			AfterSinkFlush: func() error {
+				select {
+				case flushCh <- struct{}{}:
+				default:
+				}
+				return nil
+			},
+		}}}
+
+		s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+			UseDatabase: "d",
+			Knobs:       knobs,
+		})
+		defer s.Stopper().Stop(ctx)
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`)
+		sqlDB.Exec(t, `CREATE DATABASE d`)
+		f := makeTable(s, db, flushCh)
+
+		testFn(t, db, f)
+	}
 }

--- a/pkg/ccl/changefeedccl/main_test.go
+++ b/pkg/ccl/changefeedccl/main_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -22,6 +23,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	defer utilccl.TestingEnableEnterprise()()
 	security.SetAssetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -87,11 +87,11 @@ func getSink(sinkURI string, targets jobspb.ChangefeedTargets) (Sink, error) {
 		if err != nil {
 			return nil, err
 		}
-		// Mark all query parameters as consumed; since the connection succeeded,
-		// we assume they were valid SQL connection parameters.
-		for k := range q {
-			q.Del(k)
-		}
+		// Remove parameters we know about for the unknown parameter check.
+		q.Del(`sslcert`)
+		q.Del(`sslkey`)
+		q.Del(`sslmode`)
+		q.Del(`sslrootcert`)
 	default:
 		return nil, errors.Errorf(`unsupported sink: %s`, u.Scheme)
 	}

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -10,6 +10,8 @@ package changefeedccl
 
 // TestingKnobs are the testing knobs for changefeed.
 type TestingKnobs struct {
+	// BeforeEmitRow is called before every sink emit row operation.
+	BeforeEmitRow func() error
 	// AfterSinkFlush is called after a sink flush operation has returned without
 	// error.
 	AfterSinkFlush func() error

--- a/pkg/ccl/changefeedccl/validations_test.go
+++ b/pkg/ccl/changefeedccl/validations_test.go
@@ -15,9 +15,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
-	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -29,98 +27,91 @@ func TestValidations(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer utilccl.TestingEnableEnterprise()()
 
-	ctx := context.Background()
-	s, sqlDBRaw, _ := serverutils.StartServer(t, base.TestServerArgs{
-		UseDatabase: "bank",
-		// TODO(dan): HACK until the changefeed can control pgwire flushing.
-		ConnResultsBufferBytes: 1,
-	})
-	defer s.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
-	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '1ms'`)
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
 
-	t.Run("bank", func(t *testing.T) {
-		const numRows, numRanges, payloadBytes, maxTransfer = 10, 10, 10, 999
-		sqlDB.Exec(t, `CREATE DATABASE bank`)
-		gen := bank.FromConfig(numRows, payloadBytes, numRanges)
-		if _, err := workload.Setup(ctx, sqlDB.DB, gen, 0, 0); err != nil {
-			t.Fatal(err)
-		}
-
-		rows := sqlDB.Query(t, `CREATE CHANGEFEED FOR bank WITH updated, resolved`)
-		defer closeFeedRowsHack(t, sqlDB, rows)
-
-		var done int64
-		g := ctxgroup.WithContext(ctx)
-		g.GoCtx(func(ctx context.Context) error {
-			for {
-				if atomic.LoadInt64(&done) > 0 {
-					return nil
-				}
-
-				// TODO(dan): This bit is copied from the bank workload. It's
-				// currently much easier to do this than to use the real Ops,
-				// which is silly. Fixme.
-				from := rand.Intn(numRows)
-				to := rand.Intn(numRows)
-				for from == to {
-					to = rand.Intn(numRows)
-				}
-				amount := rand.Intn(maxTransfer)
-				if _, err := sqlDB.DB.Exec(`UPDATE bank.bank
-					SET balance = CASE id WHEN $1 THEN balance-$3 WHEN $2 THEN balance+$3 END
-					WHERE id IN ($1, $2)
-				`, from, to, amount); err != nil {
-					return err
-				}
-			}
-		})
-
-		const requestedResolved = 5
-		var numResolved, rowsSinceResolved int
-		v := Validators{
-			NewOrderValidator(`bank`),
-			NewFingerprintValidator(sqlDB.DB, `bank`, `fprint`, []string{`pgwire`}),
-		}
-		sqlDB.Exec(t, `CREATE TABLE fprint (id INT PRIMARY KEY, balance INT, payload STRING)`)
-		for {
-			if !rows.Next() {
-				t.Fatal(`expected more rows`)
-			}
-			var topic gosql.NullString
-			var key, value []byte
-			if err := rows.Scan(&topic, &key, &value); err != nil {
-				t.Fatalf(`%+v`, err)
-			}
-			updated, resolved, err := ParseJSONValueTimestamps(value)
-			if err != nil {
+		t.Run("bank", func(t *testing.T) {
+			ctx := context.Background()
+			const numRows, numRanges, payloadBytes, maxTransfer = 10, 10, 10, 999
+			gen := bank.FromConfig(numRows, payloadBytes, numRanges)
+			if _, err := workload.Setup(ctx, db, gen, 0, 0); err != nil {
 				t.Fatal(err)
 			}
 
-			if topic.Valid {
-				v.NoteRow(`pgwire`, string(key), string(value), updated)
-				rowsSinceResolved++
-			} else {
-				if rowsSinceResolved > 0 {
-					if err := v.NoteResolved(`pgwire`, resolved); err != nil {
-						t.Fatal(err)
+			bank := f.Feed(t, `CREATE CHANGEFEED FOR bank WITH updated, resolved`)
+			defer bank.Close(t)
+
+			var done int64
+			g := ctxgroup.WithContext(ctx)
+			g.GoCtx(func(ctx context.Context) error {
+				for {
+					if atomic.LoadInt64(&done) > 0 {
+						return nil
 					}
 
-					numResolved++
-					if numResolved > requestedResolved {
-						atomic.StoreInt64(&done, 1)
-						break
+					// TODO(dan): This bit is copied from the bank workload. It's
+					// currently much easier to do this than to use the real Ops,
+					// which is silly. Fixme.
+					from := rand.Intn(numRows)
+					to := rand.Intn(numRows)
+					for from == to {
+						to = rand.Intn(numRows)
+					}
+					amount := rand.Intn(maxTransfer)
+					if _, err := db.Exec(`UPDATE bank
+					SET balance = CASE id WHEN $1 THEN balance-$3 WHEN $2 THEN balance+$3 END
+					WHERE id IN ($1, $2)
+				`, from, to, amount); err != nil {
+						return err
 					}
 				}
-				rowsSinceResolved = 0
-			}
-		}
-		for _, f := range v.Failures() {
-			t.Error(f)
-		}
+			})
 
-		if err := g.Wait(); err != nil {
-			t.Errorf(`%+v`, err)
-		}
-	})
+			const requestedResolved = 5
+			var numResolved, rowsSinceResolved int
+			v := Validators{
+				NewOrderValidator(`bank`),
+				NewFingerprintValidator(db, `bank`, `fprint`, bank.Partitions()),
+			}
+			sqlDB.Exec(t, `CREATE TABLE fprint (id INT PRIMARY KEY, balance INT, payload STRING)`)
+			for {
+				_, partition, key, value, resolved, ok := bank.Next(t)
+				if !ok {
+					t.Fatal(`expected more rows`)
+				} else if key != nil {
+					updated, _, err := ParseJSONValueTimestamps(value)
+					if err != nil {
+						t.Fatal(err)
+					}
+					v.NoteRow(partition, string(key), string(value), updated)
+					rowsSinceResolved++
+				} else if resolved != nil {
+					_, resolved, err := ParseJSONValueTimestamps(resolved)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if rowsSinceResolved > 0 || true {
+						if err := v.NoteResolved(partition, resolved); err != nil {
+							t.Fatal(err)
+						}
+						numResolved++
+						if numResolved > requestedResolved {
+							atomic.StoreInt64(&done, 1)
+							break
+						}
+					}
+					rowsSinceResolved = 0
+				}
+			}
+			for _, f := range v.Failures() {
+				t.Error(f)
+			}
+
+			if err := g.Wait(); err != nil {
+				t.Errorf(`%+v`, err)
+			}
+		})
+	}
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
 }


### PR DESCRIPTION
Originally the only difference between the sinkless and the enterprise
implementations was the sink (which was separately tested), so it was
reasonable to only test one of them. Kafka is hard to test without a
real impl, which is too heavyweight, so we used the one that returned
results over pgwire. However, the two impls have  since diverged and at
least two bugs happened in the untested enterprise code. Now that we
have the `experimental-sql` sink which uses all the same codepaths,
including jobs, distsql physical planning, etc, we can run the tests on
them both.

This introduces a new abstraction between the a sinkless feed and an
experimental-sql one and rewrites the tests to use it. The `CDC//Errors`
and `CDC//Description` tests are moved out of acceptancecc since they
don't care about kafka.

Most of the tests are unchanged, but a couple hacks around cleaning up
feed are removed and TestChangefeedMonitoring was essentially rewritten.

Manually verified that this would have caught #29613.

Closes #28657

Release note: None