### PR TITLE
release-2.1: opt: Improve performance of the cost-based optimizer's PREPARE phase

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1128,6 +1128,7 @@ func (ex *connExecutor) run(ctx context.Context, cancel context.CancelFunc) erro
 			res = stmtRes
 			curStmt := Statement{
 				AST:           portal.Stmt.Statement,
+				Prepared:      ex.tryReusePreparedState(portal.Stmt),
 				ExpectedTypes: portal.Stmt.Columns,
 				AnonymizedStr: portal.Stmt.AnonymizedStr,
 			}
@@ -1379,6 +1380,18 @@ func (ex *connExecutor) setTxnRewindPos(ctx context.Context, pos CmdPos) {
 func (ex *connExecutor) stmtDoesntNeedRetry(stmt tree.Statement) bool {
 	wrap := Statement{AST: stmt}
 	return isSavepoint(wrap) || isSetTransaction(wrap)
+}
+
+// tryReusePreparedState checks whether it's possible to reuse information that
+// was previously prepared. If the current transaction has uncommitted DDL
+// statements, then assume they may have changed schema on which the prepared
+// state depends, and don't reuse it. If the prepared state can be reused, then
+// tryReusePreparedState returns it, else returns nil.
+func (ex *connExecutor) tryReusePreparedState(prepStmt *PreparedStatement) *PreparedStatement {
+	if ex.extraTxnState.tables.hasUncommittedTables() {
+		return nil
+	}
+	return prepStmt
 }
 
 func stateToTxnStatusIndicator(s fsm.State) TransactionStatusIndicator {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -304,6 +304,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		}
 
 		stmt.AST = ps.Statement
+		stmt.Prepared = ex.tryReusePreparedState(ps.PreparedStatement)
 		stmt.ExpectedTypes = ps.Columns
 		stmt.AnonymizedStr = ps.AnonymizedStr
 		res.ResetStmtType(ps.Statement)

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -432,3 +432,293 @@ PREPARE forbar AS insert into bar (id) VALUES (1)
 
 statement ok
 COMMIT TRANSACTION
+
+# Test placeholder in aggregate.
+statement ok
+CREATE TABLE aggtab (a INT PRIMARY KEY);
+INSERT INTO aggtab (a) VALUES (1)
+
+statement ok
+PREPARE aggprep AS SELECT max(a + $1:::int) FROM aggtab
+
+query I
+EXECUTE aggprep(10)
+----
+11
+
+query I
+EXECUTE aggprep(20)
+----
+21
+
+#
+# Test prepared statements that rely on context, and ensure they are invalidated
+# when that context changes.
+#
+
+statement ok
+CREATE DATABASE otherdb
+
+statement ok
+USE otherdb
+
+statement ok
+CREATE TABLE othertable (a INT PRIMARY KEY, b INT); INSERT INTO othertable (a, b) VALUES (1, 10)
+
+## Current database change: Use current_database function, and ensure its return
+## value changes when current database changes.
+statement ok
+PREPARE change_db AS SELECT current_database()
+
+query T
+EXECUTE change_db
+----
+otherdb
+
+statement ok
+USE test
+
+query T
+EXECUTE change_db
+----
+test
+
+statement ok
+USE otherdb
+
+## Name resolution change: Query table in current database. Ensure that it is
+## not visible in another database.
+statement ok
+PREPARE change_db_2 AS SELECT * FROM othertable
+
+query II
+EXECUTE change_db_2
+----
+1  10
+
+statement ok
+USE test
+
+query error pq: relation "othertable" does not exist
+EXECUTE change_db_2
+
+statement ok
+USE otherdb
+
+## Search path change: Change the search path and ensure that the prepared plan
+## is invalidated.
+statement ok
+PREPARE change_search_path AS SELECT * FROM othertable
+
+query II
+EXECUTE change_search_path
+----
+1  10
+
+statement ok
+SET search_path = pg_catalog
+
+query error pq: relation "othertable" does not exist
+EXECUTE change_search_path
+
+statement ok
+RESET search_path
+
+## Functions: Use function which depends on context, and which is constant-
+## folded by the heuristic planner. Ensure that it's not constant folded when
+## part of prepared plan.
+query B
+SELECT has_column_privilege('testuser', 'othertable', 1, 'SELECT')
+----
+false
+
+statement ok
+GRANT ALL ON othertable TO testuser
+
+query B
+SELECT has_column_privilege('testuser', 'othertable', 1, 'SELECT')
+----
+true
+
+statement ok
+REVOKE ALL ON othertable FROM testuser
+
+## Location change: Change the current location (affects timezone) and make
+## sure the query is invalidated.
+statement ok
+PREPARE change_loc AS SELECT '2000-01-01 18:05:10.123'::timestamptz
+
+query T
+EXECUTE change_loc
+----
+2000-01-01 18:05:10.123 +0000 +0000
+
+statement ok
+SET TIME ZONE 'EST';
+
+query T
+EXECUTE change_loc
+----
+2000-01-01 18:05:10.123 -0500 -0500
+
+statement ok
+SET TIME ZONE 'UTC';
+
+## Permissions: Grant and then revoke permission to select from a table. The
+## prepared plan should be invalidated.
+statement ok
+GRANT ALL ON othertable TO testuser
+
+user testuser
+
+statement ok
+USE otherdb
+
+statement ok
+PREPARE change_privileges AS SELECT * FROM othertable
+
+query II
+EXECUTE change_privileges
+----
+1  10
+
+user root
+
+statement ok
+REVOKE ALL ON othertable FROM testuser
+
+user testuser
+
+query error pq: user testuser does not have SELECT privilege on relation othertable
+EXECUTE change_privileges
+
+user root
+
+## Schema change (rename): Rename column in table and ensure that the prepared
+## statement is updated to incorporate it.
+statement ok
+PREPARE change_rename AS SELECT * FROM othertable
+
+query II colnames
+EXECUTE change_rename
+----
+a  b
+1  10
+
+statement ok
+ALTER TABLE othertable RENAME COLUMN b TO c
+
+query II colnames
+EXECUTE change_rename
+----
+a  c
+1  10
+
+statement ok
+ALTER TABLE othertable RENAME COLUMN c TO b
+
+query II colnames
+EXECUTE change_rename
+----
+a  b
+1  10
+
+## Schema change (placeholders): Similar to previous case, but with placeholder
+## present.
+statement ok
+PREPARE change_placeholders AS SELECT * FROM othertable WHERE a=$1
+
+query II colnames
+EXECUTE change_placeholders(1)
+----
+a  b
+1  10
+
+statement ok
+ALTER TABLE othertable RENAME COLUMN b TO c
+
+query II colnames
+EXECUTE change_placeholders(1)
+----
+a  c
+1  10
+
+statement ok
+ALTER TABLE othertable RENAME COLUMN c TO b
+
+query II colnames
+EXECUTE change_placeholders(1)
+----
+a  b
+1  10
+
+## Schema change (view): Change view name and ensure that prepared query is
+## invalidated.
+statement ok
+CREATE VIEW otherview AS SELECT a, b FROM othertable
+
+statement ok
+PREPARE change_view AS SELECT * FROM otherview
+
+query II
+EXECUTE change_view
+----
+1  10
+
+statement ok
+ALTER VIEW otherview RENAME TO otherview2
+
+query error pq: relation "otherview" does not exist
+EXECUTE change_view
+
+statement ok
+DROP VIEW otherview2
+
+## Schema change: Drop column and ensure that correct error is reported.
+statement ok
+PREPARE change_drop AS SELECT * FROM othertable WHERE b=10
+
+query II
+EXECUTE change_drop
+----
+1  10
+
+statement ok
+ALTER TABLE othertable DROP COLUMN b
+
+query error pq: column "b" does not exist
+EXECUTE change_drop
+
+statement ok
+ALTER TABLE othertable ADD COLUMN b INT; UPDATE othertable SET b=10
+
+query II
+EXECUTE change_drop
+----
+1  10
+
+## Uncommitted schema change: Rename column in table in same transaction as
+## execution of prepared statement and make prepared statement incorporates it.
+statement ok
+PREPARE change_schema_uncommitted AS SELECT * FROM othertable
+
+statement ok
+BEGIN TRANSACTION
+
+query II colnames
+EXECUTE change_schema_uncommitted
+----
+a  b
+1  10
+
+statement ok
+ALTER TABLE othertable RENAME COLUMN b TO c
+
+query II colnames
+EXECUTE change_schema_uncommitted
+----
+a  c
+1  10
+
+statement ok
+ROLLBACK TRANSACTION

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -1,0 +1,167 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package bench
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+// stubFactory is a do-nothing implementation of exec.Factory, used for testing.
+type stubFactory struct{}
+
+func (f *stubFactory) ConstructValues(
+	rows [][]tree.TypedExpr, cols sqlbase.ResultColumns,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructScan(
+	table opt.Table,
+	index opt.Index,
+	needed exec.ColumnOrdinalSet,
+	indexConstraint *constraint.Constraint,
+	hardLimit int64,
+	reverse bool,
+	reqOrdering exec.OutputOrdering,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructVirtualScan(table opt.Table) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructFilter(n exec.Node, filter tree.TypedExpr) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructSimpleProject(
+	n exec.Node, cols []exec.ColumnOrdinal, colNames []string,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructRender(
+	n exec.Node, exprs tree.TypedExprs, colNames []string,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructHashJoin(
+	joinType sqlbase.JoinType, left, right exec.Node, onCond tree.TypedExpr,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructMergeJoin(
+	joinType sqlbase.JoinType,
+	left, right exec.Node,
+	onCond tree.TypedExpr,
+	leftOrdering, rightOrdering sqlbase.ColumnOrdering,
+	reqOrdering exec.OutputOrdering,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructGroupBy(
+	input exec.Node,
+	groupCols []exec.ColumnOrdinal,
+	orderedGroupCols exec.ColumnOrdinalSet,
+	aggregations []exec.AggInfo,
+	reqOrdering exec.OutputOrdering,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructScalarGroupBy(
+	input exec.Node, aggregations []exec.AggInfo,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructDistinct(
+	input exec.Node, distinctCols, orderedCols exec.ColumnOrdinalSet,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructSetOp(
+	typ tree.UnionType, all bool, left, right exec.Node,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructSort(
+	input exec.Node, ordering sqlbase.ColumnOrdering,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructOrdinality(input exec.Node, colName string) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructIndexJoin(
+	input exec.Node, table opt.Table, cols exec.ColumnOrdinalSet, reqOrdering exec.OutputOrdering,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructLookupJoin(
+	joinType sqlbase.JoinType,
+	input exec.Node,
+	table opt.Table,
+	index opt.Index,
+	keyCols []exec.ColumnOrdinal,
+	lookupCols exec.ColumnOrdinalSet,
+	onCond tree.TypedExpr,
+	reqOrdering exec.OutputOrdering,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructLimit(
+	input exec.Node, limit, offset tree.TypedExpr,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructProjectSet(
+	n exec.Node, exprs tree.TypedExprs, zipCols sqlbase.ResultColumns, numColsPerGen []int,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) RenameColumns(input exec.Node, colNames []string) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructPlan(root exec.Node, subqueries []exec.Subquery) (exec.Plan, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructExplain(
+	options *tree.ExplainOptions, plan exec.Plan,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructShowTrace(typ tree.ShowTraceType, compact bool) (exec.Node, error) {
+	return struct{}{}, nil
+}

--- a/pkg/sql/opt/catalog.go
+++ b/pkg/sql/opt/catalog.go
@@ -34,6 +34,12 @@ import (
 // index, even if it meant adding a hidden unique rowid column.
 const PrimaryIndex = 0
 
+// Fingerprint uniquely identifies a catalog data source. If the schema of the
+// data source changes in any way, then the fingerprint must also change. This
+// enables cached data sources (or other data structures dependent on the data
+// sources) to be invalidated when their schema changes.
+type Fingerprint uint64
+
 // Catalog is an interface to a database catalog, exposing only the information
 // needed by the query optimizer.
 type Catalog interface {
@@ -52,6 +58,11 @@ type Catalog interface {
 // DataSource is an interface to a database object that provides rows, like a
 // table, a view, or a sequence.
 type DataSource interface {
+	// Fingerprint uniquely identifies this data source. If the schema of this
+	// data source changes, then so will the value of this fingerprint. If two
+	// data sources have the same fingerprint, then they are identical.
+	Fingerprint() Fingerprint
+
 	// Name returns the fully normalized, fully qualified, and fully resolved
 	// name of the data source. The ExplicitCatalog and ExplicitSchema fields
 	// will always be true, since all parts of the name are always specified.

--- a/pkg/sql/opt/catalog.go
+++ b/pkg/sql/opt/catalog.go
@@ -38,6 +38,11 @@ const PrimaryIndex = 0
 // data source changes in any way, then the fingerprint must also change. This
 // enables cached data sources (or other data structures dependent on the data
 // sources) to be invalidated when their schema changes.
+//
+// For sqlbase data sources, the fingerprint is simply the concatenation of the
+// 32-bit descriptor ID and version fields. The version is incremented each time
+// a change to a table/view/sequence occurs, including changes to any associated
+// indexes.
 type Fingerprint uint64
 
 // Catalog is an interface to a database catalog, exposing only the information

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -1,0 +1,36 @@
+# LogicTest: local-opt
+
+statement ok
+CREATE TABLE ab (a INT PRIMARY KEY, b INT); INSERT INTO ab (a, b) VALUES (1, 10)
+
+## Table index change: Add/remove index that query depends on, and ensure that
+## the plan is recomputed each time.
+statement ok
+PREPARE change_index AS SELECT * FROM [EXPLAIN SELECT * FROM ab WHERE b=10]
+
+query TTT
+EXECUTE change_index
+----
+scan  ·      ·
+·     table  ab@primary
+·     spans  ALL
+
+statement ok
+CREATE INDEX bindex ON ab (b)
+
+query TTT
+EXECUTE change_index
+----
+scan  ·      ·
+·     table  ab@bindex
+·     spans  /10-/11
+
+statement ok
+DROP INDEX bindex
+
+query TTT
+EXECUTE change_index
+----
+scan  ·      ·
+·     table  ab@primary
+·     spans  ALL

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -232,6 +232,8 @@ func BenchmarkIndexConstraints(b *testing.B) {
 		testCases = append(testCases, tc)
 	}
 
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
 			varTypes, err := testutils.ParseTypes(strings.Split(tc.varTypes, ", "))
@@ -239,7 +241,7 @@ func BenchmarkIndexConstraints(b *testing.B) {
 				b.Fatal(err)
 			}
 			var f norm.Factory
-			f.Init(nil /* evalCtx */)
+			f.Init(&evalCtx)
 			md := f.Metadata()
 			for i, typ := range varTypes {
 				md.AddColumn(fmt.Sprintf("@%d", i+1), typ)

--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -107,6 +107,11 @@ func (ev ExprView) Operator() opt.Operator {
 	return ev.op
 }
 
+// Memo returns the Memo structure over which the ExprView operates.
+func (ev ExprView) Memo() *Memo {
+	return ev.mem
+}
+
 // Logical returns the set of logical properties that this expression provides.
 func (ev ExprView) Logical() *props.Logical {
 	return &ev.mem.group(ev.group).logical
@@ -199,8 +204,7 @@ func (ev ExprView) Replace(evalCtx *tree.EvalContext, replace ReplaceChildFunc) 
 	}
 	existingExpr := ev.mem.NormExpr(ev.group)
 	newExpr := existingExpr.Replace(ev.mem, replace)
-	newGroup := ev.mem.MemoizeNormExpr(evalCtx, newExpr)
-	return MakeNormExprView(ev.mem, newGroup)
+	return ev.mem.MemoizeNormExpr(evalCtx, newExpr)
 }
 
 func (ev ExprView) childGroup(nth int) *group {

--- a/pkg/sql/opt/memo/expr_view_format.go
+++ b/pkg/sql/opt/memo/expr_view_format.go
@@ -241,8 +241,12 @@ func (ev ExprView) formatRelational(f *ExprFmtCtx, tp treeprinter.Node) {
 				tp.Childf("cardinality: %s", logProps.Relational.Cardinality)
 			}
 		}
+
 		if logProps.Relational.CanHaveSideEffects {
 			tp.Child("side-effects")
+		}
+		if logProps.Relational.HasPlaceholder {
+			tp.Child("has-placeholder")
 		}
 	}
 

--- a/pkg/sql/opt/memo/list_storage.go
+++ b/pkg/sql/opt/memo/list_storage.go
@@ -143,6 +143,17 @@ func (ls *listStorage) init() {
 	ls.lists = ls.lists[:0]
 }
 
+// initFrom initializes the list storage with a copy of all lists from another
+// list storage. This list storage can then be modified independent of that one.
+func (ls *listStorage) initFrom(from *listStorage) {
+	ls.index = make(map[listStorageKey]listStorageVal, len(from.index))
+	for k, v := range from.index {
+		ls.index[k] = v
+	}
+	ls.lists = ls.lists[:0]
+	ls.lists = append(ls.lists, from.lists...)
+}
+
 // memoryEstimate returns a rough estimate of the list storage memory usage, in
 // bytes. It only includes memory usage that is proportional to the number of
 // list items, rather than constant overhead bytes.

--- a/pkg/sql/opt/memo/list_storage_test.go
+++ b/pkg/sql/opt/memo/list_storage_test.go
@@ -72,6 +72,21 @@ func TestListStorage(t *testing.T) {
 	if s := groupsToString(ls.lookup(catalogingID)); s != "cataloging" {
 		t.Fatalf("unexpected lookup: %v", s)
 	}
+
+	// Copy the list storage, and make sure the original and copy can be modified
+	// independently. TestMemoInitFrom also indirectly tests this.
+	var ls2 listStorage
+	ls2.initFrom(&ls)
+
+	donutID := ls.intern(stringToGroups("donut"))
+	if donutID != (ListID{Offset: 24, Length: 5}) {
+		t.Fatalf("unexpected id: %v", donutID)
+	}
+
+	doorID := ls2.intern(stringToGroups("door"))
+	if doorID != (ListID{Offset: 24, Length: 4}) {
+		t.Fatalf("unexpected id: %v", doorID)
+	}
 }
 
 func stringToGroups(s string) []GroupID {

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -114,9 +114,12 @@ func (b *logicalPropsBuilder) buildRelationalProps(ev ExprView) props.Logical {
 
 	// If CanHaveSideEffects is true for any child, it's true for the expression.
 	for i, n := 0, ev.ChildCount(); i < n; i++ {
-		if ev.childGroup(i).logical.CanHaveSideEffects() {
+		childLogical := ev.childGroup(i).logical
+		if childLogical.CanHaveSideEffects() {
 			logical.Relational.CanHaveSideEffects = true
-			break
+		}
+		if childLogical.HasPlaceholder() {
+			logical.Relational.HasPlaceholder = true
 		}
 	}
 
@@ -1065,6 +1068,10 @@ func (b *logicalPropsBuilder) buildScalarProps(ev ExprView) props.Logical {
 		// Variable introduces outer column.
 		scalar.OuterCols.Add(int(ev.Private().(opt.ColumnID)))
 		return logical
+
+	case opt.PlaceholderOp:
+		scalar.HasPlaceholder = true
+		return logical
 	}
 
 	// By default, derive OuterCols and CanHaveSideEffects from all children,
@@ -1077,6 +1084,10 @@ func (b *logicalPropsBuilder) buildScalarProps(ev ExprView) props.Logical {
 
 		if childLogical.CanHaveSideEffects() {
 			scalar.CanHaveSideEffects = true
+		}
+
+		if childLogical.HasPlaceholder() {
+			scalar.HasPlaceholder = true
 		}
 
 		if childLogical.Scalar != nil && childLogical.Scalar.HasCorrelatedSubquery {

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1074,9 +1074,9 @@ func (b *logicalPropsBuilder) buildScalarProps(ev ExprView) props.Logical {
 		return logical
 	}
 
-	// By default, derive OuterCols and CanHaveSideEffects from all children,
-	// both relational and scalar. Derive HasCorrelatedSubquery from scalar
-	// children.
+	// By default, derive OuterCols, HasPlaceholder, and CanHaveSideEffects from
+	// all children, both relational and scalar. Derive HasCorrelatedSubquery from
+	// scalar children.
 	for i, n := 0, ev.ChildCount(); i < n; i++ {
 		childLogical := &ev.childGroup(i).logical
 

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -48,6 +48,49 @@ func TestStats(t *testing.T) {
 	runDataDrivenTest(t, "testdata/stats/", flags)
 }
 
+// Ensure that an independent copy of the memo is created by InitFrom.
+func TestMemoInitFrom(t *testing.T) {
+	catalog := testcat.New()
+	_, err := catalog.ExecuteDDL("CREATE TABLE abc (a INT PRIMARY KEY, b INT, c STRING, INDEX (c))")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tester := testutils.NewOptTester(catalog, "SELECT a, b+1 FROM abc WHERE c='foo'")
+	ev, err := tester.Optimize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mem1 := ev.Memo()
+
+	// Copy the memo and ensure that the copy is the same.
+	var mem2 memo.Memo
+	mem2.InitFrom(mem1)
+	mem2Str := mem2.String()
+	if mem2Str != mem1.String() {
+		t.Errorf("expected: %s, actual: %s", mem1.String(), mem2Str)
+	}
+	if mem2.MemoryEstimate() != mem1.MemoryEstimate() {
+		t.Errorf("expected: %d, actual: %d", mem1.MemoryEstimate(), mem2.MemoryEstimate())
+	}
+
+	// Update the original memo with a new query, and make sure the first copy is
+	// unaffected.
+	tester = testutils.NewOptTester(catalog, "SELECT column1 FROM (VALUES (1), (2))")
+	ev, err = tester.Optimize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mem3 := ev.Memo()
+	mem1.InitFrom(mem3)
+	if mem1.String() != mem3.String() {
+		t.Errorf("expected: %s, actual: %s", mem3.String(), mem1.String())
+	}
+	if mem2Str != mem2.String() {
+		t.Errorf("expected: %s, actual: %s", mem2.String(), mem2Str)
+	}
+}
+
 func TestMemoIsStale(t *testing.T) {
 	catalog := testcat.New()
 	_, err := catalog.ExecuteDDL("CREATE TABLE abc (a INT PRIMARY KEY, b INT, c STRING, INDEX (c))")

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -86,8 +86,8 @@ func TestMemoInitFrom(t *testing.T) {
 	if mem1.String() != mem3.String() {
 		t.Errorf("expected: %s, actual: %s", mem3.String(), mem1.String())
 	}
-	if mem2Str != mem2.String() {
-		t.Errorf("expected: %s, actual: %s", mem2.String(), mem2Str)
+	if mem2.String() != mem2Str {
+		t.Errorf("expected: %s, actual: %s", mem2Str, mem2.String())
 	}
 }
 

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -92,7 +92,7 @@ func TestGetStatsFromConstraint(t *testing.T) {
 	}
 
 	var mem Memo
-	mem.Init()
+	mem.Init(&evalCtx)
 	tab := catalog.Table(tree.NewUnqualifiedTableName("sel"))
 	tabID := mem.Metadata().AddTable(tab)
 

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -112,11 +112,11 @@ func TestGetStatsFromConstraint(t *testing.T) {
 		// Make the scan.
 		def := &ScanOpDef{Table: tabID, Cols: cols}
 		scan := MakeScanExpr(mem.InternScanOpDef(def))
-		scanGroup := mem.MemoizeNormExpr(&evalCtx, Expr(scan))
+		scanGroup := mem.MemoizeNormExpr(&evalCtx, Expr(scan)).Group()
 
 		// Make the filter.
 		filter := MakeTrueExpr()
-		filterGroup := mem.MemoizeNormExpr(&evalCtx, Expr(filter))
+		filterGroup := mem.MemoizeNormExpr(&evalCtx, Expr(filter)).Group()
 
 		// Make the select.
 		sel := MakeSelectExpr(scanGroup, filterGroup)

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -15,8 +15,10 @@
 package opt
 
 import (
+	"context"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
@@ -124,6 +126,16 @@ type Metadata struct {
 
 	// tables stores information about each metadata table, indexed by TableID.
 	tables []mdTable
+
+	// deps stores information about all data sources depended on by the query,
+	// as well as the privileges required to access those data sources.
+	deps []mdDependency
+}
+
+type mdDependency struct {
+	ds DataSource
+
+	priv privilege.Kind
 }
 
 // mdTable stores information about one of the tables stored in the metadata.
@@ -165,6 +177,38 @@ func (md *Metadata) Init() {
 	}
 	md.cols = md.cols[:0]
 	md.tables = md.tables[:0]
+	md.deps = md.deps[:0]
+}
+
+// AddDependency tracks one of the data sources on which the query depends, as
+// well as the privilege required to access that data source. If the Memo using
+// this metadata is cached, then a call to CheckDependencies can detect if
+// changes to schema or permissions on the data source has invalidated the
+// cached metadata.
+func (md *Metadata) AddDependency(ds DataSource, priv privilege.Kind) {
+	md.deps = append(md.deps, mdDependency{ds: ds, priv: priv})
+}
+
+// CheckDependencies resolves each data source on which this metadata depends,
+// in order to check that the fully qualified data source names still resolve to
+// the same data source (i.e. having the same fingerprint), and that the user
+// still has sufficient privileges to access the data source.
+func (md *Metadata) CheckDependencies(ctx context.Context, catalog Catalog) bool {
+	for _, dep := range md.deps {
+		ds, err := catalog.ResolveDataSource(ctx, dep.ds.Name())
+		if err != nil {
+			return false
+		}
+		if dep.ds.Fingerprint() != ds.Fingerprint() {
+			return false
+		}
+		if dep.priv != 0 {
+			if err = ds.CheckPrivilege(ctx, dep.priv); err != nil {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // AddColumn assigns a new unique id to a column within the query and records

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -180,6 +180,15 @@ func (md *Metadata) Init() {
 	md.deps = md.deps[:0]
 }
 
+// InitFrom initializes the metadata with a copy of the provided metadata. This
+// metadata can then be modified independent of the copied metadata.
+func (md *Metadata) InitFrom(from *Metadata) {
+	md.Init()
+	md.cols = append(md.cols, from.cols...)
+	md.tables = append(md.tables, from.tables...)
+	md.deps = append(md.deps, from.deps...)
+}
+
 // AddDependency tracks one of the data sources on which the query depends, as
 // well as the privilege required to access that data source. If the Memo using
 // this metadata is cached, then a call to CheckDependencies can detect if

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -72,7 +72,7 @@ func TestMetadataTables(t *testing.T) {
 	var md opt.Metadata
 
 	// Add a table reference to the metadata.
-	a := &testcat.Table{}
+	a := &testcat.Table{TabFingerprint: 1}
 	a.TabName = tree.MakeUnqualifiedTableName(tree.Name("a"))
 	x := &testcat.Column{Name: "x"}
 	y := &testcat.Column{Name: "y"}
@@ -99,7 +99,7 @@ func TestMetadataTables(t *testing.T) {
 	}
 
 	// Add a table reference without a name to the metadata.
-	b := &testcat.Table{}
+	b := &testcat.Table{TabFingerprint: 1}
 	b.TabName = tree.MakeUnqualifiedTableName(tree.Name("b"))
 	b.Columns = append(b.Columns, &testcat.Column{Name: "x"})
 

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -98,7 +98,7 @@ func TestMetadataTables(t *testing.T) {
 		t.Fatalf("unexpected column label: %s", label)
 	}
 
-	// Add a table reference without a name to the metadata.
+	// Add another table reference to the metadata.
 	b := &testcat.Table{TabFingerprint: 1}
 	b.TabName = tree.MakeUnqualifiedTableName(tree.Name("b"))
 	b.Columns = append(b.Columns, &testcat.Column{Name: "x"})

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -104,7 +104,7 @@ type Factory struct {
 // This must be called before the factory can be used (or reused).
 func (f *Factory) Init(evalCtx *tree.EvalContext) {
 	f.evalCtx = evalCtx
-	f.mem.Init()
+	f.mem.Init(evalCtx)
 	f.funcs.Init(f)
 	f.matchedRule = nil
 	f.appliedRule = nil

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -158,6 +158,16 @@ func (f *Factory) InternList(items []memo.GroupID) memo.ListID {
 	return f.mem.InternList(items)
 }
 
+// AssignPlaceholders is used just before execution of a prepared Memo. It walks
+// the tree, replacing any placeholder it finds with its assigned value. This
+// will trigger the rebuild of that node's ancestors, as well as triggering
+// additional normalization rules that can substantially rewrite the tree. Once
+// all placeholders are assigned, the exploration phase can begin.
+func (f *Factory) AssignPlaceholders() {
+	root := f.assignPlaceholders(f.Memo().RootGroup())
+	f.Memo().SetRoot(root, f.Memo().RootProps())
+}
+
 // onConstruct is called as a final step by each factory construction method,
 // so that any custom manual pattern matching/replacement code can be run.
 func (f *Factory) onConstruct(e memo.Expr) memo.GroupID {

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
@@ -160,22 +161,38 @@ func (f *Factory) InternList(items []memo.GroupID) memo.ListID {
 // onConstruct is called as a final step by each factory construction method,
 // so that any custom manual pattern matching/replacement code can be run.
 func (f *Factory) onConstruct(e memo.Expr) memo.GroupID {
-	group := f.mem.MemoizeNormExpr(f.evalCtx, e)
+	ev := f.mem.MemoizeNormExpr(f.evalCtx, e)
 
 	// RaceEnabled ensures that checks are run on every change (as part of make
 	// testrace) while keeping the check code out of non-test builds.
 	if util.RaceEnabled {
-		f.checkExpr(memo.MakeNormExprView(&f.mem, group))
+		f.checkExpr(ev)
 	}
-	return group
+	return ev.Group()
 }
 
 // ----------------------------------------------------------------------
 //
-// Projection construction functions
-//   General helper functions to construct Projections.
+// Convenience construction methods.
 //
 // ----------------------------------------------------------------------
+
+// ConstructConstVal constructs one of the constant value operators from the
+// given datum value. While most constants are represented with Const, there are
+// special-case operators for True, False, and Null, to make matching easier.
+func (f *Factory) ConstructConstVal(d tree.Datum) memo.GroupID {
+	if d == tree.DNull {
+		return f.ConstructNull(f.InternType(types.Unknown))
+	}
+	if boolVal, ok := d.(*tree.DBool); ok {
+		// Map True/False datums to True/False operator.
+		if *boolVal {
+			return f.ConstructTrue()
+		}
+		return f.ConstructFalse()
+	}
+	return f.ConstructConst(f.InternDatum(d))
+}
 
 // ConstructSimpleProject is a convenience wrapper for calling
 // ConstructProject when there are no synthesized columns.

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -211,8 +211,10 @@ SELECT 1 r FROM a WHERE $1<'2000-01-01T02:00:00'::timestamp
 ----
 project
  ├── columns: r:5(int!null)
+ ├── has-placeholder
  ├── fd: ()-->(5)
  ├── select
+ │    ├── has-placeholder
  │    ├── scan a
  │    └── filters [type=bool]
  │         └── $1 < '2000-01-01 02:00:00+00:00' [type=bool]

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -442,10 +442,12 @@ SELECT * FROM a INNER JOIN xy ON True WHERE a.i=100 AND $1>'2000-01-01T1:00:00'
 ----
 inner-join
  ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+ ├── has-placeholder
  ├── key: (1,6)
  ├── fd: ()-->(2), (1)-->(3-5), (6)-->(7)
  ├── select
  │    ├── columns: x:6(int!null) y:7(int)
+ │    ├── has-placeholder
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
  │    ├── scan xy
@@ -456,6 +458,7 @@ inner-join
  │         └── $1 > '2000-01-01T1:00:00' [type=bool]
  ├── select
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── has-placeholder
  │    ├── key: (1)
  │    ├── fd: ()-->(2), (1)-->(3-5)
  │    ├── scan a
@@ -876,10 +879,12 @@ SELECT * FROM a, xy WHERE a.i=100 AND $1>'2000-01-01T1:00:00' AND xy.x=a.k
 inner-join (lookup xy)
  ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── key columns: [1] = [6]
+ ├── has-placeholder
  ├── key: (6)
  ├── fd: ()-->(2), (1)-->(3-5), (6)-->(7), (1)==(6), (6)==(1)
  ├── select
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── has-placeholder
  │    ├── key: (1)
  │    ├── fd: ()-->(2), (1)-->(3-5)
  │    ├── scan a
@@ -1032,6 +1037,7 @@ SELECT * FROM (SELECT count(*) c FROM a) a WHERE $1<'2000-01-01T10:00:00' AND c=
 select
  ├── columns: c:6(int!null)
  ├── cardinality: [0 - 1]
+ ├── has-placeholder
  ├── key: ()
  ├── fd: ()-->(6)
  ├── scalar-group-by

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -56,6 +56,11 @@ type Builder struct {
 	// interfacing with the old planning code.
 	AllowUnsupportedExpr bool
 
+	// KeepPlaceholders is a control knob: if set, optbuilder will never replace
+	// a placeholder operator with its assigned value, even when it is available.
+	// This is used when re-preparing invalidated queries.
+	KeepPlaceholders bool
+
 	// FmtFlags controls the way column names are formatted in test output. For
 	// example, if set to FmtAlwaysQualifyTableNames, the builder fully qualifies
 	// the table name in all column labels before adding them to the metadata.

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -121,7 +120,7 @@ func (b *Builder) analyzeOrderByIndex(
 		panic(builderError{err})
 	}
 
-	tab, ok := b.resolveDataSource(tn, privilege.SELECT).(opt.Table)
+	tab, ok := b.resolveDataSource(tn).(opt.Table)
 	if !ok {
 		panic(builderError{sqlbase.NewWrongObjectTypeError(tn, "table")})
 	}

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -283,7 +283,7 @@ func (b *Builder) buildScalar(
 			elseExpr := b.buildScalar(texpr, inScope, nil, nil, colRefs)
 			whens = append(whens, elseExpr)
 		} else {
-			whens = append(whens, b.buildDatum(tree.DNull))
+			whens = append(whens, b.factory.ConstructConstVal(tree.DNull))
 		}
 		out = b.factory.ConstructCase(input, b.factory.InternList(whens))
 
@@ -301,7 +301,7 @@ func (b *Builder) buildScalar(
 		e1 := b.buildScalar(t.Expr1.(tree.TypedExpr), inScope, nil, nil, colRefs)
 		e2 := b.buildScalar(t.Expr2.(tree.TypedExpr), inScope, nil, nil, colRefs)
 		whens := []memo.GroupID{
-			b.factory.ConstructWhen(e2, b.buildDatum(tree.DNull)),
+			b.factory.ConstructWhen(e2, b.factory.ConstructConstVal(tree.DNull)),
 			e1,
 		}
 		out = b.factory.ConstructCase(e1, b.factory.InternList(whens))
@@ -389,7 +389,7 @@ func (b *Builder) buildScalar(
 			if err != nil {
 				panic(builderError{err})
 			}
-			out = b.buildDatum(d)
+			out = b.factory.ConstructConstVal(d)
 		} else {
 			out = b.factory.ConstructPlaceholder(b.factory.InternTypedExpr(t))
 		}
@@ -431,7 +431,7 @@ func (b *Builder) buildScalar(
 	// tree.Datum case needs to occur after *tree.Placeholder which implements
 	// Datum.
 	case tree.Datum:
-		out = b.buildDatum(t)
+		out = b.factory.ConstructConstVal(t)
 
 	default:
 		if b.AllowUnsupportedExpr {
@@ -470,21 +470,6 @@ func (b *Builder) buildAnyScalar(
 		out = b.factory.ConstructNot(out)
 	}
 	return out
-}
-
-// buildDatum maps certain datums to separate operators, for easier matching.
-func (b *Builder) buildDatum(d tree.Datum) memo.GroupID {
-	if d == tree.DNull {
-		return b.factory.ConstructNull(b.factory.InternType(types.Unknown))
-	}
-	if boolVal, ok := d.(*tree.DBool); ok {
-		// Map True/False datums to True/False operator.
-		if *boolVal {
-			return b.factory.ConstructTrue()
-		}
-		return b.factory.ConstructFalse()
-	}
-	return b.factory.ConstructConst(b.factory.InternDatum(d))
 }
 
 // buildFunction builds a set of memo groups that represent a function

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -383,7 +383,7 @@ func (b *Builder) buildScalar(
 		return b.buildScalar(t.TypedInnerExpr(), inScope, outScope, outCol, colRefs)
 
 	case *tree.Placeholder:
-		if b.evalCtx.HasPlaceholders() {
+		if !b.KeepPlaceholders && b.evalCtx.HasPlaceholders() {
 			// Replace placeholders with their value.
 			d, err := t.Eval(b.evalCtx)
 			if err != nil {

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -67,7 +66,7 @@ func (b *Builder) buildDataSource(
 			panic(builderError{err})
 		}
 
-		ds := b.resolveDataSource(tn, privilege.SELECT)
+		ds := b.resolveDataSource(tn)
 		switch t := ds.(type) {
 		case opt.Table:
 			return b.buildScan(t, tn, nil /* ordinals */, indexFlags, inScope)
@@ -99,7 +98,7 @@ func (b *Builder) buildDataSource(
 		return outScope
 
 	case *tree.TableRef:
-		ds := b.resolveDataSourceRef(source, privilege.SELECT)
+		ds := b.resolveDataSourceRef(source)
 		switch t := ds.(type) {
 		case opt.Table:
 			outScope = b.buildScanFromTableRef(t, source, indexFlags, inScope)

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -393,19 +393,12 @@ func (b *Builder) assertNoAggregationOrWindowing(expr tree.Expr, op string) {
 // resolveDataSource returns the data source in the catalog with the given name.
 // If the name does not resolve to a table, or if the current user does not have
 // the right privileges, then resolveDataSource raises an error.
-func (b *Builder) resolveDataSource(tn *tree.TableName, priv privilege.Kind) opt.DataSource {
+func (b *Builder) resolveDataSource(tn *tree.TableName) opt.DataSource {
 	ds, err := b.catalog.ResolveDataSource(b.ctx, tn)
 	if err != nil {
 		panic(builderError{err})
 	}
-
-	if !b.skipSelectPrivilegeChecks {
-		err := ds.CheckPrivilege(b.ctx, priv)
-		if err != nil {
-			panic(builderError{err})
-		}
-	}
-
+	b.checkPrivilege(ds)
 	return ds
 }
 
@@ -413,18 +406,33 @@ func (b *Builder) resolveDataSource(tn *tree.TableName, priv privilege.Kind) opt
 // the given TableRef spec. If no data source matches, or if the current user
 // does not have the right privileges, then resolveDataSourceFromRef raises an
 // error.
-func (b *Builder) resolveDataSourceRef(ref *tree.TableRef, priv privilege.Kind) opt.DataSource {
+func (b *Builder) resolveDataSourceRef(ref *tree.TableRef) opt.DataSource {
 	ds, err := b.catalog.ResolveDataSourceByID(b.ctx, ref.TableID)
 	if err != nil {
 		panic(builderError{errors.Wrapf(err, "%s", tree.ErrString(ref))})
 	}
+	b.checkPrivilege(ds)
+	return ds
+}
 
+// checkPrivilege ensures that the current user has the privilege needed to
+// access the given data source in the catalog. If not, then checkPrivilege
+// raises an error. It also adds the data source as a dependency to the
+// metadata, so that the privileges can be re-checked on reuse of the memo.
+//
+// TODO(andyk): Add privilegeKind field to Builder when privileges other than
+// SELECT are needed.
+func (b *Builder) checkPrivilege(ds opt.DataSource) {
+	var priv privilege.Kind
 	if !b.skipSelectPrivilegeChecks {
+		priv = privilege.SELECT
 		err := ds.CheckPrivilege(b.ctx, priv)
 		if err != nil {
 			panic(builderError{err})
 		}
 	}
 
-	return ds
+	// Add dependency on this data source to the metadata, so that the metadata
+	// can be cached and later checked for freshness.
+	b.factory.Metadata().AddDependency(ds, priv)
 }

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
@@ -70,6 +70,38 @@ func (_f *Factory) ConstructFuncCall(
 	return _f.onConstruct(memo.Expr(_funcCallExpr))
 }
 
+func (f *Factory) assignPlaceholders(group memo.GroupID) memo.GroupID {
+	if !f.mem.GroupProperties(group).HasPlaceholder() {
+		return group
+	}
+	expr := f.mem.NormExpr(group)
+	switch expr.Operator() {
+	case opt.NotOp:
+		notExpr := expr.AsNot()
+		input := f.assignPlaceholders(notExpr.Input())
+		return f.ConstructNot(input)
+	case opt.FuncCallOp:
+		funcCallExpr := expr.AsFuncCall()
+		lb := MakeListBuilder(&f.funcs)
+		name := f.assignPlaceholders(funcCallExpr.Name())
+		for _, item := range f.mem.LookupList(funcCallExpr.Args()) {
+			lb.AddItem(f.assignPlaceholders(item))
+		}
+		args := lb.BuildList()
+		def := funcCallExpr.Def()
+		return f.ConstructFuncCall(name, args, def)
+	case opt.PlaceholderOp:
+		value := expr.AsPlaceholder().Value()
+		placeholder := f.mem.LookupPrivate(value).(*tree.Placeholder)
+		d, err := placeholder.Eval(f.evalCtx)
+		if err != nil {
+			panic(err)
+		}
+		return f.ConstructConstVal(d)
+	}
+	panic("unhandled operator")
+}
+
 type dynConstructFunc func(f *Factory, operands memo.DynamicOperands) memo.GroupID
 
 var dynConstructLookup [opt.NumOperators]dynConstructFunc
@@ -153,6 +185,29 @@ func (_f *Factory) ConstructInnerJoin(
 	}
 
 	return _f.onConstruct(memo.Expr(_innerJoinExpr))
+}
+
+func (f *Factory) assignPlaceholders(group memo.GroupID) memo.GroupID {
+	if !f.mem.GroupProperties(group).HasPlaceholder() {
+		return group
+	}
+	expr := f.mem.NormExpr(group)
+	switch expr.Operator() {
+	case opt.InnerJoinOp:
+		innerJoinExpr := expr.AsInnerJoin()
+		left := f.assignPlaceholders(innerJoinExpr.Left())
+		right := f.assignPlaceholders(innerJoinExpr.Right())
+		return f.ConstructInnerJoin(left, right)
+	case opt.PlaceholderOp:
+		value := expr.AsPlaceholder().Value()
+		placeholder := f.mem.LookupPrivate(value).(*tree.Placeholder)
+		d, err := placeholder.Eval(f.evalCtx)
+		if err != nil {
+			panic(err)
+		}
+		return f.ConstructConstVal(d)
+	}
+	panic("unhandled operator")
 }
 
 type dynConstructFunc func(f *Factory, operands memo.DynamicOperands) memo.GroupID
@@ -373,6 +428,44 @@ func (_f *Factory) ConstructConst(
 	return _f.onConstruct(memo.Expr(_constExpr))
 }
 
+func (f *Factory) assignPlaceholders(group memo.GroupID) memo.GroupID {
+	if !f.mem.GroupProperties(group).HasPlaceholder() {
+		return group
+	}
+	expr := f.mem.NormExpr(group)
+	switch expr.Operator() {
+	case opt.EqOp:
+		eqExpr := expr.AsEq()
+		left := f.assignPlaceholders(eqExpr.Left())
+		right := f.assignPlaceholders(eqExpr.Right())
+		return f.ConstructEq(left, right)
+	case opt.LtOp:
+		ltExpr := expr.AsLt()
+		left := f.assignPlaceholders(ltExpr.Left())
+		right := f.assignPlaceholders(ltExpr.Right())
+		return f.ConstructLt(left, right)
+	case opt.PlusOp:
+		plusExpr := expr.AsPlus()
+		left := f.assignPlaceholders(plusExpr.Left())
+		right := f.assignPlaceholders(plusExpr.Right())
+		return f.ConstructPlus(left, right)
+	case opt.MinusOp:
+		minusExpr := expr.AsMinus()
+		left := f.assignPlaceholders(minusExpr.Left())
+		right := f.assignPlaceholders(minusExpr.Right())
+		return f.ConstructMinus(left, right)
+	case opt.PlaceholderOp:
+		value := expr.AsPlaceholder().Value()
+		placeholder := f.mem.LookupPrivate(value).(*tree.Placeholder)
+		d, err := placeholder.Eval(f.evalCtx)
+		if err != nil {
+			panic(err)
+		}
+		return f.ConstructConstVal(d)
+	}
+	panic("unhandled operator")
+}
+
 type dynConstructFunc func(f *Factory, operands memo.DynamicOperands) memo.GroupID
 
 var dynConstructLookup [opt.NumOperators]dynConstructFunc
@@ -515,6 +608,34 @@ func (_f *Factory) ConstructVariable(
 	}
 
 	return _f.onConstruct(memo.Expr(_variableExpr))
+}
+
+func (f *Factory) assignPlaceholders(group memo.GroupID) memo.GroupID {
+	if !f.mem.GroupProperties(group).HasPlaceholder() {
+		return group
+	}
+	expr := f.mem.NormExpr(group)
+	switch expr.Operator() {
+	case opt.FuncOp:
+		funcExpr := expr.AsFunc()
+		lb := MakeListBuilder(&f.funcs)
+		name := f.assignPlaceholders(funcExpr.Name())
+		for _, item := range f.mem.LookupList(funcExpr.Args()) {
+			lb.AddItem(f.assignPlaceholders(item))
+		}
+		args := lb.BuildList()
+		def := funcExpr.Def()
+		return f.ConstructFunc(name, args, def)
+	case opt.PlaceholderOp:
+		value := expr.AsPlaceholder().Value()
+		placeholder := f.mem.LookupPrivate(value).(*tree.Placeholder)
+		d, err := placeholder.Eval(f.evalCtx)
+		if err != nil {
+			panic(err)
+		}
+		return f.ConstructConstVal(d)
+	}
+	panic("unhandled operator")
 }
 
 type dynConstructFunc func(f *Factory, operands memo.DynamicOperands) memo.GroupID
@@ -708,6 +829,49 @@ func (_f *Factory) ConstructAnd(
 	}
 
 	return _f.onConstruct(memo.Expr(_andExpr))
+}
+
+func (f *Factory) assignPlaceholders(group memo.GroupID) memo.GroupID {
+	if !f.mem.GroupProperties(group).HasPlaceholder() {
+		return group
+	}
+	expr := f.mem.NormExpr(group)
+	switch expr.Operator() {
+	case opt.SelectOp:
+		selectExpr := expr.AsSelect()
+		input := f.assignPlaceholders(selectExpr.Input())
+		filter := f.assignPlaceholders(selectExpr.Filter())
+		return f.ConstructSelect(input, filter)
+	case opt.InnerJoinOp:
+		innerJoinExpr := expr.AsInnerJoin()
+		left := f.assignPlaceholders(innerJoinExpr.Left())
+		right := f.assignPlaceholders(innerJoinExpr.Right())
+		return f.ConstructInnerJoin(left, right)
+	case opt.FullJoinOp:
+		fullJoinExpr := expr.AsFullJoin()
+		left := f.assignPlaceholders(fullJoinExpr.Left())
+		right := f.assignPlaceholders(fullJoinExpr.Right())
+		return f.ConstructFullJoin(left, right)
+	case opt.UnionOp:
+		unionExpr := expr.AsUnion()
+		left := f.assignPlaceholders(unionExpr.Left())
+		right := f.assignPlaceholders(unionExpr.Right())
+		return f.ConstructUnion(left, right)
+	case opt.AndOp:
+		andExpr := expr.AsAnd()
+		left := f.assignPlaceholders(andExpr.Left())
+		right := f.assignPlaceholders(andExpr.Right())
+		return f.ConstructAnd(left, right)
+	case opt.PlaceholderOp:
+		value := expr.AsPlaceholder().Value()
+		placeholder := f.mem.LookupPrivate(value).(*tree.Placeholder)
+		d, err := placeholder.Eval(f.evalCtx)
+		if err != nil {
+			panic(err)
+		}
+		return f.ConstructConstVal(d)
+	}
+	panic("unhandled operator")
 }
 
 type dynConstructFunc func(f *Factory, operands memo.DynamicOperands) memo.GroupID
@@ -909,6 +1073,47 @@ func (_f *Factory) ConstructLookupJoin(
 	return _f.onConstruct(memo.Expr(_lookupJoinExpr))
 }
 
+func (f *Factory) assignPlaceholders(group memo.GroupID) memo.GroupID {
+	if !f.mem.GroupProperties(group).HasPlaceholder() {
+		return group
+	}
+	expr := f.mem.NormExpr(group)
+	switch expr.Operator() {
+	case opt.SelectOp:
+		selectExpr := expr.AsSelect()
+		input := f.assignPlaceholders(selectExpr.Input())
+		filter := f.assignPlaceholders(selectExpr.Filter())
+		return f.ConstructSelect(input, filter)
+	case opt.GroupByOp:
+		groupByExpr := expr.AsGroupBy()
+		input := f.assignPlaceholders(groupByExpr.Input())
+		aggs := f.assignPlaceholders(groupByExpr.Aggs())
+		def := groupByExpr.Def()
+		return f.ConstructGroupBy(input, aggs, def)
+	case opt.ScalarGroupByOp:
+		scalarGroupByExpr := expr.AsScalarGroupBy()
+		input := f.assignPlaceholders(scalarGroupByExpr.Input())
+		aggs := f.assignPlaceholders(scalarGroupByExpr.Aggs())
+		def := scalarGroupByExpr.Def()
+		return f.ConstructScalarGroupBy(input, aggs, def)
+	case opt.LookupJoinOp:
+		lookupJoinExpr := expr.AsLookupJoin()
+		input := f.assignPlaceholders(lookupJoinExpr.Input())
+		on := f.assignPlaceholders(lookupJoinExpr.On())
+		def := lookupJoinExpr.Def()
+		return f.ConstructLookupJoin(input, on, def)
+	case opt.PlaceholderOp:
+		value := expr.AsPlaceholder().Value()
+		placeholder := f.mem.LookupPrivate(value).(*tree.Placeholder)
+		d, err := placeholder.Eval(f.evalCtx)
+		if err != nil {
+			panic(err)
+		}
+		return f.ConstructConstVal(d)
+	}
+	panic("unhandled operator")
+}
+
 type dynConstructFunc func(f *Factory, operands memo.DynamicOperands) memo.GroupID
 
 var dynConstructLookup [opt.NumOperators]dynConstructFunc
@@ -1040,6 +1245,32 @@ func (_f *Factory) ConstructList(
 	return _f.onConstruct(memo.Expr(_listExpr))
 }
 
+func (f *Factory) assignPlaceholders(group memo.GroupID) memo.GroupID {
+	if !f.mem.GroupProperties(group).HasPlaceholder() {
+		return group
+	}
+	expr := f.mem.NormExpr(group)
+	switch expr.Operator() {
+	case opt.ListOp:
+		listExpr := expr.AsList()
+		lb := MakeListBuilder(&f.funcs)
+		for _, item := range f.mem.LookupList(listExpr.Items()) {
+			lb.AddItem(f.assignPlaceholders(item))
+		}
+		items := lb.BuildList()
+		return f.ConstructList(items)
+	case opt.PlaceholderOp:
+		value := expr.AsPlaceholder().Value()
+		placeholder := f.mem.LookupPrivate(value).(*tree.Placeholder)
+		d, err := placeholder.Eval(f.evalCtx)
+		if err != nil {
+			panic(err)
+		}
+		return f.ConstructConstVal(d)
+	}
+	panic("unhandled operator")
+}
+
 type dynConstructFunc func(f *Factory, operands memo.DynamicOperands) memo.GroupID
 
 var dynConstructLookup [opt.NumOperators]dynConstructFunc
@@ -1117,6 +1348,30 @@ func (_f *Factory) ConstructJoin(
 	}
 
 	return _f.onConstruct(memo.Expr(_joinExpr))
+}
+
+func (f *Factory) assignPlaceholders(group memo.GroupID) memo.GroupID {
+	if !f.mem.GroupProperties(group).HasPlaceholder() {
+		return group
+	}
+	expr := f.mem.NormExpr(group)
+	switch expr.Operator() {
+	case opt.JoinOp:
+		joinExpr := expr.AsJoin()
+		left := f.assignPlaceholders(joinExpr.Left())
+		right := f.assignPlaceholders(joinExpr.Right())
+		on := f.assignPlaceholders(joinExpr.On())
+		return f.ConstructJoin(left, right, on)
+	case opt.PlaceholderOp:
+		value := expr.AsPlaceholder().Value()
+		placeholder := f.mem.LookupPrivate(value).(*tree.Placeholder)
+		d, err := placeholder.Eval(f.evalCtx)
+		if err != nil {
+			panic(err)
+		}
+		return f.ConstructConstVal(d)
+	}
+	panic("unhandled operator")
 }
 
 type dynConstructFunc func(f *Factory, operands memo.DynamicOperands) memo.GroupID
@@ -1227,6 +1482,37 @@ func (_f *Factory) ConstructOp(
 	}
 
 	return _f.onConstruct(memo.Expr(_opExpr))
+}
+
+func (f *Factory) assignPlaceholders(group memo.GroupID) memo.GroupID {
+	if !f.mem.GroupProperties(group).HasPlaceholder() {
+		return group
+	}
+	expr := f.mem.NormExpr(group)
+	switch expr.Operator() {
+	case opt.ListOp:
+		listExpr := expr.AsList()
+		lb := MakeListBuilder(&f.funcs)
+		for _, item := range f.mem.LookupList(listExpr.Items()) {
+			lb.AddItem(f.assignPlaceholders(item))
+		}
+		items := lb.BuildList()
+		return f.ConstructList(items)
+	case opt.OpOp:
+		opExpr := expr.AsOp()
+		empty := f.assignPlaceholders(opExpr.Empty())
+		single := f.assignPlaceholders(opExpr.Single())
+		return f.ConstructOp(empty, single)
+	case opt.PlaceholderOp:
+		value := expr.AsPlaceholder().Value()
+		placeholder := f.mem.LookupPrivate(value).(*tree.Placeholder)
+		d, err := placeholder.Eval(f.evalCtx)
+		if err != nil {
+			panic(err)
+		}
+		return f.ConstructConstVal(d)
+	}
+	panic("unhandled operator")
 }
 
 type dynConstructFunc func(f *Factory, operands memo.DynamicOperands) memo.GroupID
@@ -1406,6 +1692,34 @@ func (_f *Factory) ConstructNe(
 	return _f.onConstruct(memo.Expr(_neExpr))
 }
 
+func (f *Factory) assignPlaceholders(group memo.GroupID) memo.GroupID {
+	if !f.mem.GroupProperties(group).HasPlaceholder() {
+		return group
+	}
+	expr := f.mem.NormExpr(group)
+	switch expr.Operator() {
+	case opt.EqOp:
+		eqExpr := expr.AsEq()
+		left := f.assignPlaceholders(eqExpr.Left())
+		right := f.assignPlaceholders(eqExpr.Right())
+		return f.ConstructEq(left, right)
+	case opt.NeOp:
+		neExpr := expr.AsNe()
+		left := f.assignPlaceholders(neExpr.Left())
+		right := f.assignPlaceholders(neExpr.Right())
+		return f.ConstructNe(left, right)
+	case opt.PlaceholderOp:
+		value := expr.AsPlaceholder().Value()
+		placeholder := f.mem.LookupPrivate(value).(*tree.Placeholder)
+		d, err := placeholder.Eval(f.evalCtx)
+		if err != nil {
+			panic(err)
+		}
+		return f.ConstructConstVal(d)
+	}
+	panic("unhandled operator")
+}
+
 type dynConstructFunc func(f *Factory, operands memo.DynamicOperands) memo.GroupID
 
 var dynConstructLookup [opt.NumOperators]dynConstructFunc
@@ -1545,6 +1859,34 @@ func (_f *Factory) ConstructNull() memo.GroupID {
 	}
 
 	return _f.onConstruct(memo.Expr(_nullExpr))
+}
+
+func (f *Factory) assignPlaceholders(group memo.GroupID) memo.GroupID {
+	if !f.mem.GroupProperties(group).HasPlaceholder() {
+		return group
+	}
+	expr := f.mem.NormExpr(group)
+	switch expr.Operator() {
+	case opt.PlusOp:
+		plusExpr := expr.AsPlus()
+		left := f.assignPlaceholders(plusExpr.Left())
+		right := f.assignPlaceholders(plusExpr.Right())
+		return f.ConstructPlus(left, right)
+	case opt.MinusOp:
+		minusExpr := expr.AsMinus()
+		left := f.assignPlaceholders(minusExpr.Left())
+		right := f.assignPlaceholders(minusExpr.Right())
+		return f.ConstructMinus(left, right)
+	case opt.PlaceholderOp:
+		value := expr.AsPlaceholder().Value()
+		placeholder := f.mem.LookupPrivate(value).(*tree.Placeholder)
+		d, err := placeholder.Eval(f.evalCtx)
+		if err != nil {
+			panic(err)
+		}
+		return f.ConstructConstVal(d)
+	}
+	panic("unhandled operator")
 }
 
 type dynConstructFunc func(f *Factory, operands memo.DynamicOperands) memo.GroupID
@@ -1700,6 +2042,43 @@ func (_f *Factory) ConstructNot(
 	}
 
 	return _f.onConstruct(memo.Expr(_notExpr))
+}
+
+func (f *Factory) assignPlaceholders(group memo.GroupID) memo.GroupID {
+	if !f.mem.GroupProperties(group).HasPlaceholder() {
+		return group
+	}
+	expr := f.mem.NormExpr(group)
+	switch expr.Operator() {
+	case opt.LtOp:
+		ltExpr := expr.AsLt()
+		left := f.assignPlaceholders(ltExpr.Left())
+		right := f.assignPlaceholders(ltExpr.Right())
+		return f.ConstructLt(left, right)
+	case opt.GtOp:
+		gtExpr := expr.AsGt()
+		left := f.assignPlaceholders(gtExpr.Left())
+		right := f.assignPlaceholders(gtExpr.Right())
+		return f.ConstructGt(left, right)
+	case opt.ContainsOp:
+		containsExpr := expr.AsContains()
+		left := f.assignPlaceholders(containsExpr.Left())
+		right := f.assignPlaceholders(containsExpr.Right())
+		return f.ConstructContains(left, right)
+	case opt.NotOp:
+		notExpr := expr.AsNot()
+		input := f.assignPlaceholders(notExpr.Input())
+		return f.ConstructNot(input)
+	case opt.PlaceholderOp:
+		value := expr.AsPlaceholder().Value()
+		placeholder := f.mem.LookupPrivate(value).(*tree.Placeholder)
+		d, err := placeholder.Eval(f.evalCtx)
+		if err != nil {
+			panic(err)
+		}
+		return f.ConstructConstVal(d)
+	}
+	panic("unhandled operator")
 }
 
 type dynConstructFunc func(f *Factory, operands memo.DynamicOperands) memo.GroupID
@@ -1866,6 +2245,28 @@ func (_f *Factory) ConstructProject(
 	return _f.onConstruct(memo.Expr(_projectExpr))
 }
 
+func (f *Factory) assignPlaceholders(group memo.GroupID) memo.GroupID {
+	if !f.mem.GroupProperties(group).HasPlaceholder() {
+		return group
+	}
+	expr := f.mem.NormExpr(group)
+	switch expr.Operator() {
+	case opt.ProjectOp:
+		projectExpr := expr.AsProject()
+		input := f.assignPlaceholders(projectExpr.Input())
+		return f.ConstructProject(input)
+	case opt.PlaceholderOp:
+		value := expr.AsPlaceholder().Value()
+		placeholder := f.mem.LookupPrivate(value).(*tree.Placeholder)
+		d, err := placeholder.Eval(f.evalCtx)
+		if err != nil {
+			panic(err)
+		}
+		return f.ConstructConstVal(d)
+	}
+	panic("unhandled operator")
+}
+
 type dynConstructFunc func(f *Factory, operands memo.DynamicOperands) memo.GroupID
 
 var dynConstructLookup [opt.NumOperators]dynConstructFunc
@@ -1962,6 +2363,30 @@ func (_f *Factory) ConstructInnerJoin(
 	}
 
 	return _f.onConstruct(memo.Expr(_innerJoinExpr))
+}
+
+func (f *Factory) assignPlaceholders(group memo.GroupID) memo.GroupID {
+	if !f.mem.GroupProperties(group).HasPlaceholder() {
+		return group
+	}
+	expr := f.mem.NormExpr(group)
+	switch expr.Operator() {
+	case opt.InnerJoinOp:
+		innerJoinExpr := expr.AsInnerJoin()
+		left := f.assignPlaceholders(innerJoinExpr.Left())
+		right := f.assignPlaceholders(innerJoinExpr.Right())
+		on := f.assignPlaceholders(innerJoinExpr.On())
+		return f.ConstructInnerJoin(left, right, on)
+	case opt.PlaceholderOp:
+		value := expr.AsPlaceholder().Value()
+		placeholder := f.mem.LookupPrivate(value).(*tree.Placeholder)
+		d, err := placeholder.Eval(f.evalCtx)
+		if err != nil {
+			panic(err)
+		}
+		return f.ConstructConstVal(d)
+	}
+	panic("unhandled operator")
 }
 
 type dynConstructFunc func(f *Factory, operands memo.DynamicOperands) memo.GroupID
@@ -2080,6 +2505,29 @@ func (_f *Factory) ConstructScan() memo.GroupID {
 	}
 
 	return _f.onConstruct(memo.Expr(_scanExpr))
+}
+
+func (f *Factory) assignPlaceholders(group memo.GroupID) memo.GroupID {
+	if !f.mem.GroupProperties(group).HasPlaceholder() {
+		return group
+	}
+	expr := f.mem.NormExpr(group)
+	switch expr.Operator() {
+	case opt.LimitOp:
+		limitExpr := expr.AsLimit()
+		input := f.assignPlaceholders(limitExpr.Input())
+		limit := f.assignPlaceholders(limitExpr.Limit())
+		return f.ConstructLimit(input, limit)
+	case opt.PlaceholderOp:
+		value := expr.AsPlaceholder().Value()
+		placeholder := f.mem.LookupPrivate(value).(*tree.Placeholder)
+		d, err := placeholder.Eval(f.evalCtx)
+		if err != nil {
+			panic(err)
+		}
+		return f.ConstructConstVal(d)
+	}
+	panic("unhandled operator")
 }
 
 type dynConstructFunc func(f *Factory, operands memo.DynamicOperands) memo.GroupID

--- a/pkg/sql/opt/props/logical.go
+++ b/pkg/sql/opt/props/logical.go
@@ -99,6 +99,10 @@ type Relational struct {
 	// comment for Logical.CanHaveSideEffects.
 	CanHaveSideEffects bool
 
+	// HasPlaceholder is true if the subtree rooted at this expression contains
+	// at least one Placeholder operator.
+	HasPlaceholder bool
+
 	// FuncDepSet is a set of functional dependencies (FDs) that encode useful
 	// relationships between columns in a base or derived relation. Given two sets
 	// of columns A and B, a functional dependency A-->B holds if A uniquely
@@ -261,6 +265,10 @@ type Scalar struct {
 	// return the same output given the same input. For more details, see the
 	// comment for Logical.CanHaveSideEffects.
 	CanHaveSideEffects bool
+
+	// HasPlaceholder is true if the subtree rooted at this expression contains
+	// at least one Placeholder operator.
+	HasPlaceholder bool
 
 	// HasCorrelatedSubquery is true if the scalar expression tree contains a
 	// subquery having one or more outer columns. The subquery can be a Subquery,
@@ -435,6 +443,15 @@ func (p *Logical) CanHaveSideEffects() bool {
 		return p.Scalar.CanHaveSideEffects
 	}
 	return p.Relational.CanHaveSideEffects
+}
+
+// HasPlaceholder is true if the subtree rooted at this expression contains
+// at least one Placeholder operator.
+func (p *Logical) HasPlaceholder() bool {
+	if p.Scalar != nil {
+		return p.Scalar.HasPlaceholder
+	}
+	return p.Relational.HasPlaceholder
 }
 
 // Verify runs consistency checks against the logical properties, in order to

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -58,7 +58,7 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 	// Update the table name to include catalog and schema if not provided.
 	tc.qualifyTableName(tn)
 
-	tab := &Table{TabName: *tn}
+	tab := &Table{TabFingerprint: tc.nextFingerprint(), TabName: *tn}
 
 	// Assume that every table in the "system" catalog is a virtual table. This
 	// is a simplified assumption for testing purposes.

--- a/pkg/sql/opt/testutils/testcat/create_view.go
+++ b/pkg/sql/opt/testutils/testcat/create_view.go
@@ -36,7 +36,12 @@ func (tc *Catalog) CreateView(stmt *tree.CreateView) *View {
 	fmtCtx := tree.MakeFmtCtx(&buf, tree.FmtParsable)
 	stmt.AsSource.Format(&fmtCtx)
 
-	view := &View{ViewName: *tn, QueryText: buf.String(), ColumnNames: stmt.ColumnNames}
+	view := &View{
+		ViewFingerprint: tc.nextFingerprint(),
+		ViewName:        *tn,
+		QueryText:       buf.String(),
+		ColumnNames:     stmt.ColumnNames,
+	}
 
 	// Add the new view to the catalog.
 	tc.AddView(view)

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -361,14 +361,17 @@ where
 ----
 inner-join
  ├── columns: id1_4_0_:1(int!null) id1_2_1_:7(int!null) address2_4_0_:2(string!null) createdo3_4_0_:3(timestamp) name4_4_0_:4(string) nickname5_4_0_:5(string) version6_4_0_:6(int!null) name2_2_1_:8(string!null) version3_2_1_:9(int!null)
+ ├── has-placeholder
  ├── key: (1,7)
  ├── fd: ()-->(9), (1)-->(2-6), (7)-->(8)
  ├── semi-join
  │    ├── columns: person.id:1(int!null) address:2(string!null) createdon:3(timestamp) person.name:4(string) nickname:5(string) person.version:6(int!null)
+ │    ├── has-placeholder
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-6)
  │    ├── select
  │    │    ├── columns: person.id:1(int!null) address:2(string!null) createdon:3(timestamp) person.name:4(string) nickname:5(string) person.version:6(int!null)
+ │    │    ├── has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-6)
  │    │    ├── scan person
@@ -385,6 +388,7 @@ inner-join
  │         └── person.id = person_id [type=bool, outer=(1,13), constraints=(/1: (/NULL - ]; /13: (/NULL - ])]
  ├── select
  │    ├── columns: partner.id:7(int!null) partner.name:8(string!null) partner.version:9(int!null)
+ │    ├── has-placeholder
  │    ├── key: (7)
  │    ├── fd: ()-->(9), (7)-->(8)
  │    ├── scan partner
@@ -450,23 +454,28 @@ where
 ----
 project
  ├── columns: id1_1_:1(int!null) rev2_1_:2(int!null) revtype3_1_:3(int) created_4_1_:4(timestamp) firstnam5_1_:5(string) lastname6_1_:6(string)
+ ├── has-placeholder
  ├── key: (1,2)
  ├── fd: (1,2)-->(3-6)
  └── select
       ├── columns: customer_aud.id:1(int!null) customer_aud.rev:2(int!null) customer_aud.revtype:3(int) customer_aud.created_on:4(timestamp) customer_aud.firstname:5(string) customer_aud.lastname:6(string) max:13(int!null)
+      ├── has-placeholder
       ├── key: (1,2)
       ├── fd: (1,2)-->(3-6,13), (2)==(13), (13)==(2)
       ├── group-by
       │    ├── columns: customer_aud.id:1(int!null) customer_aud.rev:2(int!null) customer_aud.revtype:3(int) customer_aud.created_on:4(timestamp) customer_aud.firstname:5(string) customer_aud.lastname:6(string) max:13(int)
       │    ├── grouping columns: customer_aud.id:1(int!null) customer_aud.rev:2(int!null)
+      │    ├── has-placeholder
       │    ├── key: (1,2)
       │    ├── fd: (1,2)-->(3-6,13)
       │    ├── inner-join (merge)
       │    │    ├── columns: customer_aud.id:1(int!null) customer_aud.rev:2(int!null) customer_aud.revtype:3(int!null) customer_aud.created_on:4(timestamp) customer_aud.firstname:5(string) customer_aud.lastname:6(string) customer_aud.id:7(int!null) customer_aud.rev:8(int!null)
+      │    │    ├── has-placeholder
       │    │    ├── key: (2,7,8)
       │    │    ├── fd: (1,2)-->(3-6), (1)==(7), (7)==(1)
       │    │    ├── select
       │    │    │    ├── columns: customer_aud.id:1(int!null) customer_aud.rev:2(int!null) customer_aud.revtype:3(int!null) customer_aud.created_on:4(timestamp) customer_aud.firstname:5(string) customer_aud.lastname:6(string)
+      │    │    │    ├── has-placeholder
       │    │    │    ├── key: (1,2)
       │    │    │    ├── fd: (1,2)-->(3-6)
       │    │    │    ├── ordering: +1
@@ -479,6 +488,7 @@ project
       │    │    │         └── customer_aud.revtype != $2 [type=bool, outer=(3), constraints=(/3: (/NULL - ])]
       │    │    ├── select
       │    │    │    ├── columns: customer_aud.id:7(int!null) customer_aud.rev:8(int!null)
+      │    │    │    ├── has-placeholder
       │    │    │    ├── key: (7,8)
       │    │    │    ├── ordering: +7
       │    │    │    ├── scan customer_aud
@@ -567,28 +577,34 @@ order by
 ----
 sort
  ├── columns: id1_3_:1(int!null) rev2_3_:2(int!null) revtype3_3_:3(int) revend4_3_:4(int) created_5_3_:5(timestamp) firstnam6_3_:6(string) lastname7_3_:7(string) address_8_3_:8(int)
+ ├── has-placeholder
  ├── key: (1,2)
  ├── fd: (1,2)-->(3-8)
  ├── ordering: +2
  └── project
       ├── columns: customer_aud.id:1(int!null) customer_aud.rev:2(int!null) customer_aud.revtype:3(int) customer_aud.revend:4(int) customer_aud.created_on:5(timestamp) customer_aud.firstname:6(string) customer_aud.lastname:7(string) customer_aud.address_id:8(int)
+      ├── has-placeholder
       ├── key: (1,2)
       ├── fd: (1,2)-->(3-8)
       └── select
            ├── columns: customer_aud.id:1(int!null) customer_aud.rev:2(int!null) customer_aud.revtype:3(int) customer_aud.revend:4(int) customer_aud.created_on:5(timestamp) customer_aud.firstname:6(string) customer_aud.lastname:7(string) customer_aud.address_id:8(int) max:17(int!null)
+           ├── has-placeholder
            ├── key: (1,2)
            ├── fd: (1,2)-->(3-8,17), (2)==(17), (17)==(2)
            ├── group-by
            │    ├── columns: customer_aud.id:1(int!null) customer_aud.rev:2(int!null) customer_aud.revtype:3(int) customer_aud.revend:4(int) customer_aud.created_on:5(timestamp) customer_aud.firstname:6(string) customer_aud.lastname:7(string) customer_aud.address_id:8(int) max:17(int)
            │    ├── grouping columns: customer_aud.id:1(int!null) customer_aud.rev:2(int!null)
+           │    ├── has-placeholder
            │    ├── key: (1,2)
            │    ├── fd: (1,2)-->(3-8,17)
            │    ├── inner-join (merge)
            │    │    ├── columns: customer_aud.id:1(int!null) customer_aud.rev:2(int!null) customer_aud.revtype:3(int!null) customer_aud.revend:4(int) customer_aud.created_on:5(timestamp) customer_aud.firstname:6(string) customer_aud.lastname:7(string) customer_aud.address_id:8(int) customer_aud.id:9(int!null) customer_aud.rev:10(int!null)
+           │    │    ├── has-placeholder
            │    │    ├── key: (2,9,10)
            │    │    ├── fd: (1,2)-->(3-8), (1)==(9), (9)==(1)
            │    │    ├── select
            │    │    │    ├── columns: customer_aud.id:1(int!null) customer_aud.rev:2(int!null) customer_aud.revtype:3(int!null) customer_aud.revend:4(int) customer_aud.created_on:5(timestamp) customer_aud.firstname:6(string) customer_aud.lastname:7(string) customer_aud.address_id:8(int)
+           │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1,2)
            │    │    │    ├── fd: (1,2)-->(3-8)
            │    │    │    ├── ordering: +1
@@ -833,10 +849,12 @@ where
 ----
 project
  ├── columns: id1_4_:1(int!null) phone_nu2_4_:2(string) person_i4_4_:4(int) phone_ty3_4_:3(string)
+ ├── has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  └── select
       ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) person_id:4(int) max:10(int!null)
+      ├── has-placeholder
       ├── key: (1)
       ├── fd: (1)-->(2-4,10)
       ├── group-by
@@ -950,10 +968,12 @@ where
 ----
 project
  ├── columns: id1_4_:1(int!null) phone_nu2_4_:2(string) person_i4_4_:4(int) phone_ty3_4_:3(string)
+ ├── has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  └── select
       ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) person_id:4(int) min:10(int!null)
+      ├── has-placeholder
       ├── key: (1)
       ├── fd: (1)-->(2-4,10)
       ├── group-by
@@ -1073,6 +1093,7 @@ where
 ----
 semi-join
  ├── columns: id1_2_:1(int!null) address2_2_:2(string) createdo3_2_:3(timestamp) name4_2_:4(string) nickname5_2_:5(string) version6_2_:6(int!null)
+ ├── has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan person
@@ -1081,6 +1102,7 @@ semi-join
  │    └── fd: (1)-->(2-6)
  ├── select
  │    ├── columns: phone.id:7(int!null) person_id:10(int)
+ │    ├── has-placeholder
  │    ├── key: (7)
  │    ├── fd: (7)-->(10)
  │    ├── scan phone
@@ -1114,6 +1136,7 @@ where
 ----
 semi-join
  ├── columns: id1_2_:1(int!null) address2_2_:2(string) createdo3_2_:3(timestamp) name4_2_:4(string) nickname5_2_:5(string) version6_2_:6(int!null)
+ ├── has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan person
@@ -1122,6 +1145,7 @@ semi-join
  │    └── fd: (1)-->(2-6)
  ├── select
  │    ├── columns: phone.id:7(int!null) person_id:10(int)
+ │    ├── has-placeholder
  │    ├── key: (7)
  │    ├── fd: (7)-->(10)
  │    ├── scan phone
@@ -1188,6 +1212,7 @@ where
 ----
 anti-join
  ├── columns: id1_4_:1(int!null) phone_nu2_4_:2(string) person_i4_4_:4(int) phone_ty3_4_:3(string)
+ ├── has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── scan phone
@@ -1196,6 +1221,7 @@ anti-join
  │    └── fd: (1)-->(2-4)
  ├── select
  │    ├── columns: phone_id:6(int!null) repairtimestamps:7(timestamp)
+ │    ├── has-placeholder
  │    ├── scan phone_repairtimestamps
  │    │    └── columns: phone_id:6(int!null) repairtimestamps:7(timestamp)
  │    └── filters [type=bool, outer=(7)]
@@ -2035,15 +2061,18 @@ where
 ----
 project
  ├── columns: auctioni4_1_0_:4(int) id1_1_0_:1(int!null) id1_1_1_:1(int!null) amount2_1_1_:2(decimal) createdd3_1_1_:3(timestamp) auctioni4_1_1_:4(int) formula41_1_:9(bool)
+ ├── has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-4,9)
  ├── group-by
  │    ├── columns: tbid2.id:1(int!null) amount:2(decimal) createddatetime:3(timestamp) auctionid:4(int) true_agg:11(bool)
  │    ├── grouping columns: tbid2.id:1(int!null)
+ │    ├── has-placeholder
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4,11)
  │    ├── right-join
  │    │    ├── columns: tbid2.id:1(int!null) amount:2(decimal) createddatetime:3(timestamp) auctionid:4(int!null) successfulbid:8(int) true:10(bool)
+ │    │    ├── has-placeholder
  │    │    ├── fd: (1)-->(2-4), ()~~>(10)
  │    │    ├── project
  │    │    │    ├── columns: true:10(bool!null) successfulbid:8(int)
@@ -2054,6 +2083,7 @@ project
  │    │    │         └── true [type=bool]
  │    │    ├── select
  │    │    │    ├── columns: tbid2.id:1(int!null) amount:2(decimal) createddatetime:3(timestamp) auctionid:4(int!null)
+ │    │    │    ├── has-placeholder
  │    │    │    ├── key: (1)
  │    │    │    ├── fd: (1)-->(2-4)
  │    │    │    ├── scan tbid2

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -270,11 +270,13 @@ order by anon_1.flavors_id asc
 ----
 sort
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── ordering: +1
  └── right-join
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:25(int) key:26(string) value:27(string) flavor_extra_specs.flavor_id:28(int) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+      ├── has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
       ├── scan flavor_extra_specs
@@ -283,36 +285,43 @@ sort
       │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
       ├── project
       │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    ├── has-placeholder
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │    └── limit
       │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
       │         ├── internal-ordering: +1
+      │         ├── has-placeholder
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         ├── offset
       │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
       │         │    ├── internal-ordering: +1
+      │         │    ├── has-placeholder
       │         │    ├── key: (1)
       │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         │    ├── ordering: +1
       │         │    ├── select
       │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │         │    │    ├── has-placeholder
       │         │    │    ├── key: (1)
       │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         │    │    ├── ordering: +1
       │         │    │    ├── group-by
       │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
       │         │    │    │    ├── grouping columns: flavors.id:1(int!null)
+      │         │    │    │    ├── has-placeholder
       │         │    │    │    ├── key: (1)
       │         │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         │    │    │    ├── ordering: +1
       │         │    │    │    ├── left-join (merge)
       │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+      │         │    │    │    │    ├── has-placeholder
       │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
       │         │    │    │    │    ├── ordering: +1
       │         │    │    │    │    ├── select
       │         │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │         │    │    │    │    │    ├── has-placeholder
       │         │    │    │    │    │    ├── key: (1)
       │         │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         │    │    │    │    │    ├── ordering: +1
@@ -325,10 +334,12 @@ sort
       │         │    │    │    │    │         └── flavorid = $2 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
       │         │    │    │    │    ├── project
       │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+      │         │    │    │    │    │    ├── has-placeholder
       │         │    │    │    │    │    ├── fd: ()-->(22)
       │         │    │    │    │    │    ├── ordering: +17 opt(22)
       │         │    │    │    │    │    ├── select
       │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │         │    │    │    │    │    │    ├── has-placeholder
       │         │    │    │    │    │    │    ├── key: (17,18)
       │         │    │    │    │    │    │    ├── ordering: +17
       │         │    │    │    │    │    │    ├── scan flavor_projects@secondary
@@ -438,54 +449,65 @@ order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 left-join (lookup flavor_extra_specs)
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:38(timestamp) flavor_extra_specs_1_updated_at:39(timestamp) flavor_extra_specs_1_id:34(int) flavor_extra_specs_1_key:35(string) flavor_extra_specs_1_value:36(string) flavor_extra_specs_1_flavor_id:37(int)
  ├── key columns: [34] = [34]
+ ├── has-placeholder
  ├── key: (1,34)
  ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35-39), (35,37)-->(34,36,38,39)
  ├── ordering: +7 opt(11)
  ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx)
  │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:34(int) key:35(string) flavor_extra_specs.flavor_id:37(int)
  │    ├── key columns: [1] = [37]
+ │    ├── has-placeholder
  │    ├── key: (1,34)
  │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35,37), (35,37)-->(34)
  │    ├── ordering: +7 opt(11)
  │    ├── project
  │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │    │    ├── has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
  │    │    ├── ordering: +7 opt(11)
  │    │    └── limit
  │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
  │    │         ├── internal-ordering: +7 opt(11)
+ │    │         ├── has-placeholder
  │    │         ├── key: (1)
  │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
  │    │         ├── ordering: +7 opt(11)
  │    │         ├── offset
  │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
  │    │         │    ├── internal-ordering: +7 opt(11)
+ │    │         │    ├── has-placeholder
  │    │         │    ├── key: (1)
  │    │         │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
  │    │         │    ├── ordering: +7 opt(11)
  │    │         │    ├── sort
  │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+ │    │         │    │    ├── has-placeholder
  │    │         │    │    ├── key: (1)
  │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
  │    │         │    │    ├── ordering: +7 opt(11)
  │    │         │    │    └── select
  │    │         │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+ │    │         │    │         ├── has-placeholder
  │    │         │    │         ├── key: (1)
  │    │         │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
  │    │         │    │         ├── group-by
  │    │         │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
  │    │         │    │         │    ├── grouping columns: flavors.id:1(int!null)
+ │    │         │    │         │    ├── has-placeholder
  │    │         │    │         │    ├── key: (1)
  │    │         │    │         │    ├── fd: ()-->(11), (1)-->(2-12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
  │    │         │    │         │    ├── right-join
  │    │         │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:23(int) true:31(bool)
+ │    │         │    │         │    │    ├── has-placeholder
  │    │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(31)
  │    │         │    │         │    │    ├── project
  │    │         │    │         │    │    │    ├── columns: true:31(bool!null) flavor_projects.flavor_id:23(int!null)
+ │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── fd: ()-->(31)
  │    │         │    │         │    │    │    ├── select
  │    │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) flavor_projects.project_id:24(string!null)
+ │    │         │    │         │    │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    │    ├── key: (23,24)
  │    │         │    │         │    │    │    │    ├── scan flavor_projects@secondary
  │    │         │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) flavor_projects.project_id:24(string!null)
@@ -496,19 +518,23 @@ left-join (lookup flavor_extra_specs)
  │    │         │    │         │    │    │         └── true [type=bool]
  │    │         │    │         │    │    ├── project
  │    │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── key: (1)
  │    │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
  │    │         │    │         │    │    │    └── select
  │    │         │    │         │    │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
+ │    │         │    │         │    │    │         ├── has-placeholder
  │    │         │    │         │    │    │         ├── key: (1)
  │    │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
  │    │         │    │         │    │    │         ├── group-by
  │    │         │    │         │    │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
  │    │         │    │         │    │    │         │    ├── grouping columns: flavors.id:1(int!null)
+ │    │         │    │         │    │    │         │    ├── has-placeholder
  │    │         │    │         │    │    │         │    ├── key: (1)
  │    │         │    │         │    │    │         │    ├── fd: ()-->(11), (1)-->(2-12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
  │    │         │    │         │    │    │         │    ├── left-join (merge)
  │    │         │    │         │    │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:28(bool)
+ │    │         │    │         │    │    │         │    │    ├── has-placeholder
  │    │         │    │         │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(28)
  │    │         │    │         │    │    │         │    │    ├── select
  │    │         │    │         │    │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
@@ -524,10 +550,12 @@ left-join (lookup flavor_extra_specs)
  │    │         │    │         │    │    │         │    │    │         └── disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight)]
  │    │         │    │         │    │    │         │    │    ├── project
  │    │         │    │         │    │    │         │    │    │    ├── columns: true:28(bool!null) flavor_projects.flavor_id:17(int!null)
+ │    │         │    │         │    │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │         │    │    │    ├── fd: ()-->(28)
  │    │         │    │         │    │    │         │    │    │    ├── ordering: +17 opt(28)
  │    │         │    │         │    │    │         │    │    │    ├── select
  │    │         │    │         │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) flavor_projects.project_id:18(string!null)
+ │    │         │    │         │    │    │         │    │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │         │    │    │    │    ├── key: (17,18)
  │    │         │    │         │    │    │         │    │    │    │    ├── ordering: +17
  │    │         │    │         │    │    │         │    │    │    │    ├── scan flavor_projects@secondary
@@ -676,51 +704,61 @@ order by anon_1.instance_types_flavorid asc,
 left-join (lookup instance_type_extra_specs)
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
  ├── key columns: [28] = [28]
+ ├── has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── ordering: +7,+1
  ├── left-join (lookup instance_type_extra_specs@secondary)
  │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
  │    ├── key columns: [1] = [31]
+ │    ├── has-placeholder
  │    ├── key: (1,28)
  │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
  │    ├── ordering: +7,+1
  │    ├── project
  │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │    ├── has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │    ├── ordering: +7,+1
  │    │    └── limit
  │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
  │    │         ├── internal-ordering: +7,+1
+ │    │         ├── has-placeholder
  │    │         ├── key: (1)
  │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         ├── ordering: +7,+1
  │    │         ├── offset
  │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
  │    │         │    ├── internal-ordering: +7,+1
+ │    │         │    ├── has-placeholder
  │    │         │    ├── key: (1)
  │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    ├── ordering: +7,+1
  │    │         │    ├── sort
  │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         │    │    ├── has-placeholder
  │    │         │    │    ├── key: (1)
  │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │    ├── ordering: +7,+1
  │    │         │    │    └── select
  │    │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         │    │         ├── has-placeholder
  │    │         │    │         ├── key: (1)
  │    │         │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │         ├── group-by
  │    │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
  │    │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+ │    │         │    │         │    ├── has-placeholder
  │    │         │    │         │    ├── key: (1)
  │    │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │         │    ├── left-join (merge)
  │    │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+ │    │         │    │         │    │    ├── has-placeholder
  │    │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
  │    │         │    │         │    │    ├── select
  │    │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── key: (1)
  │    │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │         │    │    │    ├── ordering: +1
@@ -733,10 +771,12 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
  │    │         │    │         │    │    ├── project
  │    │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+ │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── fd: ()-->(25)
  │    │         │    │         │    │    │    ├── ordering: +18 opt(25)
  │    │         │    │         │    │    │    ├── select
  │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+ │    │         │    │         │    │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    │    ├── ordering: +18
  │    │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
  │    │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
@@ -835,37 +875,45 @@ order by instance_types.flavorid asc, instance_types.id asc
 left-join (lookup instance_type_extra_specs)
  ├── columns: instance_types_created_at:15(timestamp) instance_types_updated_at:16(timestamp) instance_types_deleted_at:14(timestamp) instance_types_deleted:13(bool) instance_types_id:1(int!null) instance_types_name:2(string) instance_types_memory_mb:3(int) instance_types_vcpus:4(int) instance_types_root_gb:5(int) instance_types_ephemeral_gb:6(int) instance_types_flavorid:7(string) instance_types_swap:8(int) instance_types_rxtx_factor:9(float) instance_types_vcpu_weight:10(int) instance_types_disabled:11(bool) instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:23(timestamp) instance_type_extra_specs_1_updated_at:24(timestamp) instance_type_extra_specs_1_deleted_at:22(timestamp) instance_type_extra_specs_1_deleted:21(bool) instance_type_extra_specs_1_id:17(int) instance_type_extra_specs_1_key:18(string) instance_type_extra_specs_1_value:19(string) instance_type_extra_specs_1_instance_type_id:20(int)
  ├── key columns: [17] = [17]
+ ├── has-placeholder
  ├── key: (1,17)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (17)-->(18-24), (18,20,21)~~>(17,19,22-24)
  ├── ordering: +7,+1
  ├── sort
  │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:17(int) key:18(string) instance_type_extra_specs.instance_type_id:20(int) instance_type_extra_specs.deleted:21(bool)
+ │    ├── has-placeholder
  │    ├── key: (1,17)
  │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (17)-->(18,20,21), (18,20,21)~~>(17)
  │    ├── ordering: +7,+1
  │    └── left-join (lookup instance_type_extra_specs@secondary)
  │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:17(int) key:18(string) instance_type_extra_specs.instance_type_id:20(int) instance_type_extra_specs.deleted:21(bool)
  │         ├── key columns: [1] = [20]
+ │         ├── has-placeholder
  │         ├── key: (1,17)
  │         ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (17)-->(18,20,21), (18,20,21)~~>(17)
  │         ├── project
  │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │         │    ├── has-placeholder
  │         │    ├── key: (1)
  │         │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │         │    └── select
  │         │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
+ │         │         ├── has-placeholder
  │         │         ├── key: (1)
  │         │         ├── fd: (1)-->(2-16,34), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │         │         ├── group-by
  │         │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
  │         │         │    ├── grouping columns: instance_types.id:1(int!null)
+ │         │         │    ├── has-placeholder
  │         │         │    ├── key: (1)
  │         │         │    ├── fd: (1)-->(2-16,34), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │         │         │    ├── left-join (merge)
  │         │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:26(int) true:33(bool)
+ │         │         │    │    ├── has-placeholder
  │         │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(33)
  │         │         │    │    ├── select
  │         │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │         │         │    │    │    ├── has-placeholder
  │         │         │    │    │    ├── key: (1)
  │         │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │         │         │    │    │    ├── ordering: +1
@@ -878,10 +926,12 @@ left-join (lookup instance_type_extra_specs)
  │         │         │    │    │         └── instance_types.deleted = $2 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
  │         │         │    │    ├── project
  │         │         │    │    │    ├── columns: true:33(bool!null) instance_type_projects.instance_type_id:26(int!null)
+ │         │         │    │    │    ├── has-placeholder
  │         │         │    │    │    ├── fd: ()-->(33)
  │         │         │    │    │    ├── ordering: +26 opt(33)
  │         │         │    │    │    ├── select
  │         │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
+ │         │         │    │    │    │    ├── has-placeholder
  │         │         │    │    │    │    ├── ordering: +26
  │         │         │    │    │    │    ├── scan instance_type_projects@secondary
  │         │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) project_id:27(string) instance_type_projects.deleted:28(bool)
@@ -996,43 +1046,53 @@ from (select instance_types.created_at as instance_types_created_at,
 left-join (lookup instance_type_extra_specs)
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
  ├── key columns: [28] = [28]
+ ├── has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── left-join (lookup instance_type_extra_specs@secondary)
  │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
  │    ├── key columns: [1] = [31]
+ │    ├── has-placeholder
  │    ├── key: (1,28)
  │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
  │    ├── project
  │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │    ├── has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
  │    │    └── limit
  │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         ├── has-placeholder
  │    │         ├── key: (1)
  │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
  │    │         ├── offset
  │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         │    ├── has-placeholder
  │    │         │    ├── key: (1)
  │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
  │    │         │    ├── select
  │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         │    │    ├── has-placeholder
  │    │         │    │    ├── key: (1)
  │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
  │    │         │    │    ├── group-by
  │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
  │    │         │    │    │    ├── grouping columns: instance_types.id:1(int!null)
+ │    │         │    │    │    ├── has-placeholder
  │    │         │    │    │    ├── key: (1)
  │    │         │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
  │    │         │    │    │    ├── left-join
  │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+ │    │         │    │    │    │    ├── has-placeholder
  │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), ()~~>(25)
  │    │         │    │    │    │    ├── index-join instance_types
  │    │         │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │         │    │    │    │    │    ├── has-placeholder
  │    │         │    │    │    │    │    ├── key: (1)
  │    │         │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
  │    │         │    │    │    │    │    └── select
  │    │         │    │    │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string!null) instance_types.deleted:13(bool!null)
+ │    │         │    │    │    │    │         ├── has-placeholder
  │    │         │    │    │    │    │         ├── key: (1)
  │    │         │    │    │    │    │         ├── fd: (1)-->(2,13), (2,13)-->(1)
  │    │         │    │    │    │    │         ├── scan instance_types@secondary
@@ -1045,9 +1105,11 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │    │    │    │              └── name = $4 [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
  │    │         │    │    │    │    ├── project
  │    │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+ │    │         │    │    │    │    │    ├── has-placeholder
  │    │         │    │    │    │    │    ├── fd: ()-->(25)
  │    │         │    │    │    │    │    ├── select
  │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+ │    │         │    │    │    │    │    │    ├── has-placeholder
  │    │         │    │    │    │    │    │    ├── scan instance_type_projects@secondary
  │    │         │    │    │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
  │    │         │    │    │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
@@ -1159,39 +1221,48 @@ from (select instance_types.created_at as instance_types_created_at,
 left-join (lookup instance_type_extra_specs)
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
  ├── key columns: [28] = [28]
+ ├── has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── left-join (lookup instance_type_extra_specs@secondary)
  │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
  │    ├── key columns: [1] = [31]
+ │    ├── has-placeholder
  │    ├── key: (1,28)
  │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
  │    ├── project
  │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │    ├── has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │    └── limit
  │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         ├── has-placeholder
  │    │         ├── key: (1)
  │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         ├── offset
  │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         │    ├── has-placeholder
  │    │         │    ├── key: (1)
  │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    ├── select
  │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         │    │    ├── has-placeholder
  │    │         │    │    ├── key: (1)
  │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │    ├── group-by
  │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
  │    │         │    │    │    ├── grouping columns: instance_types.id:1(int!null)
+ │    │         │    │    │    ├── has-placeholder
  │    │         │    │    │    ├── key: (1)
  │    │         │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │    │    ├── left-join (merge)
  │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+ │    │         │    │    │    │    ├── has-placeholder
  │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
  │    │         │    │    │    │    ├── select
  │    │         │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │         │    │    │    │    │    ├── has-placeholder
  │    │         │    │    │    │    │    ├── key: (1)
  │    │         │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │    │    │    │    ├── ordering: +1
@@ -1205,10 +1276,12 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │    │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
  │    │         │    │    │    │    ├── project
  │    │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+ │    │         │    │    │    │    │    ├── has-placeholder
  │    │         │    │    │    │    │    ├── fd: ()-->(25)
  │    │         │    │    │    │    │    ├── ordering: +18 opt(25)
  │    │         │    │    │    │    │    ├── select
  │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+ │    │         │    │    │    │    │    │    ├── has-placeholder
  │    │         │    │    │    │    │    │    ├── ordering: +18
  │    │         │    │    │    │    │    │    ├── scan instance_type_projects@secondary
  │    │         │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
@@ -1316,6 +1389,7 @@ from (select flavors.created_at as flavors_created_at,
 ----
 right-join
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── scan flavor_extra_specs
@@ -1324,30 +1398,37 @@ right-join
  │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── project
  │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │    ├── has-placeholder
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │    └── limit
  │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+ │         ├── has-placeholder
  │         ├── key: (1)
  │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │         ├── offset
  │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+ │         │    ├── has-placeholder
  │         │    ├── key: (1)
  │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │         │    ├── select
  │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+ │         │    │    ├── has-placeholder
  │         │    │    ├── key: (1)
  │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │         │    │    ├── group-by
  │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
  │         │    │    │    ├── grouping columns: flavors.id:1(int!null)
+ │         │    │    │    ├── has-placeholder
  │         │    │    │    ├── key: (1)
  │         │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │         │    │    │    ├── left-join (merge)
  │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+ │         │    │    │    │    ├── has-placeholder
  │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
  │         │    │    │    │    ├── select
  │         │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │         │    │    │    │    │    ├── has-placeholder
  │         │    │    │    │    │    ├── key: (1)
  │         │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │         │    │    │    │    │    ├── ordering: +1
@@ -1360,10 +1441,12 @@ right-join
  │         │    │    │    │    │         └── name = $2 [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
  │         │    │    │    │    ├── project
  │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+ │         │    │    │    │    │    ├── has-placeholder
  │         │    │    │    │    │    ├── fd: ()-->(22)
  │         │    │    │    │    │    ├── ordering: +17 opt(22)
  │         │    │    │    │    │    ├── select
  │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+ │         │    │    │    │    │    │    ├── has-placeholder
  │         │    │    │    │    │    │    ├── key: (17,18)
  │         │    │    │    │    │    │    ├── ordering: +17
  │         │    │    │    │    │    │    ├── scan flavor_projects@secondary
@@ -1465,6 +1548,7 @@ from (select flavors.created_at as flavors_created_at,
 ----
 right-join
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── scan flavor_extra_specs
@@ -1473,30 +1557,37 @@ right-join
  │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── project
  │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │    ├── has-placeholder
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │    └── limit
  │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+ │         ├── has-placeholder
  │         ├── key: (1)
  │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │         ├── offset
  │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+ │         │    ├── has-placeholder
  │         │    ├── key: (1)
  │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │         │    ├── select
  │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+ │         │    │    ├── has-placeholder
  │         │    │    ├── key: (1)
  │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │         │    │    ├── group-by
  │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
  │         │    │    │    ├── grouping columns: flavors.id:1(int!null)
+ │         │    │    │    ├── has-placeholder
  │         │    │    │    ├── key: (1)
  │         │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │         │    │    │    ├── left-join (merge)
  │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+ │         │    │    │    │    ├── has-placeholder
  │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
  │         │    │    │    │    ├── select
  │         │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │         │    │    │    │    │    ├── has-placeholder
  │         │    │    │    │    │    ├── key: (1)
  │         │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │         │    │    │    │    │    ├── ordering: +1
@@ -1509,10 +1600,12 @@ right-join
  │         │    │    │    │    │         └── flavorid = $2 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
  │         │    │    │    │    ├── project
  │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+ │         │    │    │    │    │    ├── has-placeholder
  │         │    │    │    │    │    ├── fd: ()-->(22)
  │         │    │    │    │    │    ├── ordering: +17 opt(22)
  │         │    │    │    │    │    ├── select
  │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+ │         │    │    │    │    │    │    ├── has-placeholder
  │         │    │    │    │    │    │    ├── key: (17,18)
  │         │    │    │    │    │    │    ├── ordering: +17
  │         │    │    │    │    │    │    ├── scan flavor_projects@secondary
@@ -1618,11 +1711,13 @@ order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── ordering: +7
  └── right-join
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:25(int) key:26(string) value:27(string) flavor_extra_specs.flavor_id:28(int) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+      ├── has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
       ├── scan flavor_extra_specs
@@ -1631,38 +1726,46 @@ sort
       │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
       ├── project
       │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    ├── has-placeholder
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │    └── limit
       │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
       │         ├── internal-ordering: +7
+      │         ├── has-placeholder
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         ├── offset
       │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
       │         │    ├── internal-ordering: +7
+      │         │    ├── has-placeholder
       │         │    ├── key: (1)
       │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         │    ├── ordering: +7
       │         │    ├── sort
       │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │         │    │    ├── has-placeholder
       │         │    │    ├── key: (1)
       │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         │    │    ├── ordering: +7
       │         │    │    └── select
       │         │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │         │    │         ├── has-placeholder
       │         │    │         ├── key: (1)
       │         │    │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         │    │         ├── group-by
       │         │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
       │         │    │         │    ├── grouping columns: flavors.id:1(int!null)
+      │         │    │         │    ├── has-placeholder
       │         │    │         │    ├── key: (1)
       │         │    │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         │    │         │    ├── left-join (merge)
       │         │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+      │         │    │         │    │    ├── has-placeholder
       │         │    │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
       │         │    │         │    │    ├── select
       │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │         │    │         │    │    │    ├── has-placeholder
       │         │    │         │    │    │    ├── key: (1)
       │         │    │         │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         │    │         │    │    │    ├── ordering: +1
@@ -1675,10 +1778,12 @@ sort
       │         │    │         │    │    │         └── (flavorid > $2) OR ((flavorid = $3) AND (flavors.id > $4)) [type=bool, outer=(1,7)]
       │         │    │         │    │    ├── project
       │         │    │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+      │         │    │         │    │    │    ├── has-placeholder
       │         │    │         │    │    │    ├── fd: ()-->(22)
       │         │    │         │    │    │    ├── ordering: +17 opt(22)
       │         │    │         │    │    │    ├── select
       │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │         │    │         │    │    │    │    ├── has-placeholder
       │         │    │         │    │    │    │    ├── key: (17,18)
       │         │    │         │    │    │    │    ├── ordering: +17
       │         │    │         │    │    │    │    ├── scan flavor_projects@secondary
@@ -1792,51 +1897,61 @@ order by anon_1.instance_types_flavorid asc,
 left-join (lookup instance_type_extra_specs)
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
  ├── key columns: [28] = [28]
+ ├── has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── ordering: +7,+1
  ├── left-join (lookup instance_type_extra_specs@secondary)
  │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
  │    ├── key columns: [1] = [31]
+ │    ├── has-placeholder
  │    ├── key: (1,28)
  │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
  │    ├── ordering: +7,+1
  │    ├── project
  │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │    ├── has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │    ├── ordering: +7,+1
  │    │    └── limit
  │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
  │    │         ├── internal-ordering: +7,+1
+ │    │         ├── has-placeholder
  │    │         ├── key: (1)
  │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         ├── ordering: +7,+1
  │    │         ├── offset
  │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
  │    │         │    ├── internal-ordering: +7,+1
+ │    │         │    ├── has-placeholder
  │    │         │    ├── key: (1)
  │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    ├── ordering: +7,+1
  │    │         │    ├── sort
  │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         │    │    ├── has-placeholder
  │    │         │    │    ├── key: (1)
  │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │    ├── ordering: +7,+1
  │    │         │    │    └── select
  │    │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         │    │         ├── has-placeholder
  │    │         │    │         ├── key: (1)
  │    │         │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │         ├── group-by
  │    │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
  │    │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+ │    │         │    │         │    ├── has-placeholder
  │    │         │    │         │    ├── key: (1)
  │    │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │         │    ├── left-join (merge)
  │    │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+ │    │         │    │         │    │    ├── has-placeholder
  │    │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
  │    │         │    │         │    │    ├── select
  │    │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── key: (1)
  │    │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │         │    │    │    ├── ordering: +1
@@ -1849,10 +1964,12 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
  │    │         │    │         │    │    ├── project
  │    │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+ │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── fd: ()-->(25)
  │    │         │    │         │    │    │    ├── ordering: +18 opt(25)
  │    │         │    │         │    │    │    ├── select
  │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+ │    │         │    │         │    │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    │    ├── ordering: +18
  │    │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
  │    │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
@@ -1969,43 +2086,53 @@ from (select instance_types.created_at as instance_types_created_at,
 left-join (lookup instance_type_extra_specs)
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
  ├── key columns: [28] = [28]
+ ├── has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── left-join (lookup instance_type_extra_specs@secondary)
  │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
  │    ├── key columns: [1] = [31]
+ │    ├── has-placeholder
  │    ├── key: (1,28)
  │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
  │    ├── project
  │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │    ├── has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │    └── limit
  │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         ├── has-placeholder
  │    │         ├── key: (1)
  │    │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         ├── offset
  │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         │    ├── has-placeholder
  │    │         │    ├── key: (1)
  │    │         │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    ├── select
  │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         │    │    ├── has-placeholder
  │    │         │    │    ├── key: (1)
  │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │    ├── group-by
  │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
  │    │         │    │    │    ├── grouping columns: instance_types.id:1(int!null)
+ │    │         │    │    │    ├── has-placeholder
  │    │         │    │    │    ├── key: (1)
  │    │         │    │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │    │    ├── left-join
  │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+ │    │         │    │    │    │    ├── has-placeholder
  │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
  │    │         │    │    │    │    ├── index-join instance_types
  │    │         │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │         │    │    │    │    │    ├── has-placeholder
  │    │         │    │    │    │    │    ├── key: (1)
  │    │         │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │    │    │    │    └── select
  │    │         │    │    │    │    │         ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool!null)
+ │    │         │    │    │    │    │         ├── has-placeholder
  │    │         │    │    │    │    │         ├── key: (1)
  │    │         │    │    │    │    │         ├── fd: (1)-->(7,13), (7,13)-->(1)
  │    │         │    │    │    │    │         ├── scan instance_types@secondary
@@ -2018,9 +2145,11 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │    │    │    │              └── flavorid = $4 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
  │    │         │    │    │    │    ├── project
  │    │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+ │    │         │    │    │    │    │    ├── has-placeholder
  │    │         │    │    │    │    │    ├── fd: ()-->(25)
  │    │         │    │    │    │    │    ├── select
  │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+ │    │         │    │    │    │    │    │    ├── has-placeholder
  │    │         │    │    │    │    │    │    ├── scan instance_type_projects@secondary
  │    │         │    │    │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
  │    │         │    │    │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
@@ -2105,11 +2234,13 @@ order by flavors.flavorid asc, flavors.id asc
 ----
 sort
  ├── columns: flavors_created_at:14(timestamp) flavors_updated_at:15(timestamp) flavors_id:1(int!null) flavors_name:2(string) flavors_memory_mb:3(int) flavors_vcpus:4(int) flavors_root_gb:5(int) flavors_ephemeral_gb:6(int) flavors_flavorid:7(string) flavors_swap:8(int) flavors_rxtx_factor:9(float) flavors_vcpu_weight:10(int) flavors_disabled:11(bool) flavors_is_public:12(bool) flavor_extra_specs_1_created_at:20(timestamp) flavor_extra_specs_1_updated_at:21(timestamp) flavor_extra_specs_1_id:16(int) flavor_extra_specs_1_key:17(string) flavor_extra_specs_1_value:18(string) flavor_extra_specs_1_flavor_id:19(int)
+ ├── has-placeholder
  ├── key: (1,16)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (16)-->(17-21), (17,19)-->(16,18,20,21)
  ├── ordering: +7
  └── right-join
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:16(int) key:17(string) value:18(string) flavor_extra_specs.flavor_id:19(int) flavor_extra_specs.created_at:20(timestamp) flavor_extra_specs.updated_at:21(timestamp)
+      ├── has-placeholder
       ├── key: (1,16)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (16)-->(17-21), (17,19)-->(16,18,20,21)
       ├── scan flavor_extra_specs
@@ -2118,19 +2249,23 @@ sort
       │    └── fd: (16)-->(17-21), (17,19)-->(16,18,20,21)
       ├── project
       │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    ├── has-placeholder
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │    └── select
       │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
+      │         ├── has-placeholder
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-12,14,15,29), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         ├── group-by
       │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
       │         │    ├── grouping columns: flavors.id:1(int!null)
+      │         │    ├── has-placeholder
       │         │    ├── key: (1)
       │         │    ├── fd: (1)-->(2-12,14,15,29), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         │    ├── left-join (merge)
       │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:23(int) true:28(bool)
+      │         │    │    ├── has-placeholder
       │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(28)
       │         │    │    ├── scan flavors
       │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
@@ -2139,10 +2274,12 @@ sort
       │         │    │    │    └── ordering: +1
       │         │    │    ├── project
       │         │    │    │    ├── columns: true:28(bool!null) flavor_projects.flavor_id:23(int!null)
+      │         │    │    │    ├── has-placeholder
       │         │    │    │    ├── fd: ()-->(28)
       │         │    │    │    ├── ordering: +23 opt(28)
       │         │    │    │    ├── select
       │         │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) project_id:24(string!null)
+      │         │    │    │    │    ├── has-placeholder
       │         │    │    │    │    ├── key: (23,24)
       │         │    │    │    │    ├── ordering: +23
       │         │    │    │    │    ├── scan flavor_projects@secondary
@@ -2257,55 +2394,66 @@ order by anon_1.instance_types_flavorid asc,
 left-join (lookup instance_type_extra_specs)
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
  ├── key columns: [28] = [28]
+ ├── has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── ordering: +7,+1
  ├── left-join (lookup instance_type_extra_specs@secondary)
  │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
  │    ├── key columns: [1] = [31]
+ │    ├── has-placeholder
  │    ├── key: (1,28)
  │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
  │    ├── ordering: +7,+1
  │    ├── project
  │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │    ├── has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │    ├── ordering: +7,+1
  │    │    └── limit
  │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
  │    │         ├── internal-ordering: +7,+1
+ │    │         ├── has-placeholder
  │    │         ├── key: (1)
  │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         ├── ordering: +7,+1
  │    │         ├── offset
  │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
  │    │         │    ├── internal-ordering: +7,+1
+ │    │         │    ├── has-placeholder
  │    │         │    ├── key: (1)
  │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    ├── ordering: +7,+1
  │    │         │    ├── sort
  │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         │    │    ├── has-placeholder
  │    │         │    │    ├── key: (1)
  │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │    ├── ordering: +7,+1
  │    │         │    │    └── select
  │    │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         │    │         ├── has-placeholder
  │    │         │    │         ├── key: (1)
  │    │         │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │         ├── group-by
  │    │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
  │    │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+ │    │         │    │         │    ├── has-placeholder
  │    │         │    │         │    ├── key: (1)
  │    │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │         │    ├── left-join
  │    │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+ │    │         │    │         │    │    ├── has-placeholder
  │    │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
  │    │         │    │         │    │    ├── index-join instance_types
  │    │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── key: (1)
  │    │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │         │    │    │    └── select
  │    │         │    │         │    │    │         ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool!null)
+ │    │         │    │         │    │    │         ├── has-placeholder
  │    │         │    │         │    │    │         ├── key: (1)
  │    │         │    │         │    │    │         ├── fd: (1)-->(7,13), (7,13)-->(1)
  │    │         │    │         │    │    │         ├── scan instance_types@secondary
@@ -2318,9 +2466,11 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │              └── (flavorid > $4) OR ((flavorid = $5) AND (instance_types.id > $6)) [type=bool, outer=(1,7)]
  │    │         │    │         │    │    ├── project
  │    │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+ │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── fd: ()-->(25)
  │    │         │    │         │    │    │    ├── select
  │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+ │    │         │    │         │    │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
  │    │         │    │         │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
  │    │         │    │         │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
@@ -2423,11 +2573,13 @@ order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── ordering: +7
  └── right-join
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:25(int) key:26(string) value:27(string) flavor_extra_specs.flavor_id:28(int) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+      ├── has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
       ├── scan flavor_extra_specs
@@ -2436,35 +2588,42 @@ sort
       │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
       ├── project
       │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    ├── has-placeholder
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │    └── limit
       │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
       │         ├── internal-ordering: +7
+      │         ├── has-placeholder
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         ├── offset
       │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
       │         │    ├── internal-ordering: +7
+      │         │    ├── has-placeholder
       │         │    ├── key: (1)
       │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         │    ├── ordering: +7
       │         │    ├── sort
       │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │         │    │    ├── has-placeholder
       │         │    │    ├── key: (1)
       │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         │    │    ├── ordering: +7
       │         │    │    └── select
       │         │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │         │    │         ├── has-placeholder
       │         │    │         ├── key: (1)
       │         │    │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         │    │         ├── group-by
       │         │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
       │         │    │         │    ├── grouping columns: flavors.id:1(int!null)
+      │         │    │         │    ├── has-placeholder
       │         │    │         │    ├── key: (1)
       │         │    │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │         │    │         │    ├── left-join (merge)
       │         │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+      │         │    │         │    │    ├── has-placeholder
       │         │    │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
       │         │    │         │    │    ├── scan flavors
       │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
@@ -2473,10 +2632,12 @@ sort
       │         │    │         │    │    │    └── ordering: +1
       │         │    │         │    │    ├── project
       │         │    │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+      │         │    │         │    │    │    ├── has-placeholder
       │         │    │         │    │    │    ├── fd: ()-->(22)
       │         │    │         │    │    │    ├── ordering: +17 opt(22)
       │         │    │         │    │    │    ├── select
       │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │         │    │         │    │    │    │    ├── has-placeholder
       │         │    │         │    │    │    │    ├── key: (17,18)
       │         │    │         │    │    │    │    ├── ordering: +17
       │         │    │         │    │    │    │    ├── scan flavor_projects@secondary
@@ -2598,67 +2759,81 @@ order by anon_1.instance_types_flavorid asc,
 left-join (lookup instance_type_extra_specs)
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:45(timestamp) instance_type_extra_specs_1_updated_at:46(timestamp) instance_type_extra_specs_1_deleted_at:44(timestamp) instance_type_extra_specs_1_deleted:43(bool) instance_type_extra_specs_1_id:39(int) instance_type_extra_specs_1_key:40(string) instance_type_extra_specs_1_value:41(string) instance_type_extra_specs_1_instance_type_id:42(int)
  ├── key columns: [39] = [39]
+ ├── has-placeholder
  ├── key: (1,39)
  ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
  ├── ordering: +7,+1 opt(11)
  ├── left-join (lookup instance_type_extra_specs@secondary)
  │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:39(int) key:40(string) instance_type_extra_specs.instance_type_id:42(int) instance_type_extra_specs.deleted:43(bool)
  │    ├── key columns: [1] = [42]
+ │    ├── has-placeholder
  │    ├── key: (1,39)
  │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40,42,43), (40,42,43)~~>(39)
  │    ├── ordering: +7,+1 opt(11)
  │    ├── project
  │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │    ├── has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
  │    │    ├── ordering: +7,+1 opt(11)
  │    │    └── limit
  │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
  │    │         ├── internal-ordering: +7,+1 opt(11)
+ │    │         ├── has-placeholder
  │    │         ├── key: (1)
  │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
  │    │         ├── ordering: +7,+1 opt(11)
  │    │         ├── offset
  │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
  │    │         │    ├── internal-ordering: +7,+1 opt(11)
+ │    │         │    ├── has-placeholder
  │    │         │    ├── key: (1)
  │    │         │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
  │    │         │    ├── ordering: +7,+1 opt(11)
  │    │         │    ├── sort
  │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+ │    │         │    │    ├── has-placeholder
  │    │         │    │    ├── key: (1)
  │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
  │    │         │    │    ├── ordering: +7,+1 opt(11)
  │    │         │    │    └── select
  │    │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+ │    │         │    │         ├── has-placeholder
  │    │         │    │         ├── key: (1)
  │    │         │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
  │    │         │    │         ├── group-by
  │    │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
  │    │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+ │    │         │    │         │    ├── has-placeholder
  │    │         │    │         │    ├── key: (1)
  │    │         │    │         │    ├── fd: ()-->(11), (1)-->(2-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
  │    │         │    │         │    ├── left-join
  │    │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:26(int) true:36(bool)
+ │    │         │    │         │    │    ├── has-placeholder
  │    │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(36)
  │    │         │    │         │    │    ├── project
  │    │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── key: (1)
  │    │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
  │    │         │    │         │    │    │    └── select
  │    │         │    │         │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
+ │    │         │    │         │    │    │         ├── has-placeholder
  │    │         │    │         │    │    │         ├── key: (1)
  │    │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
  │    │         │    │         │    │    │         ├── group-by
  │    │         │    │         │    │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
  │    │         │    │         │    │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+ │    │         │    │         │    │    │         │    ├── has-placeholder
  │    │         │    │         │    │    │         │    ├── key: (1)
  │    │         │    │         │    │    │         │    ├── fd: ()-->(11), (1)-->(2-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
  │    │         │    │         │    │    │         │    ├── left-join (merge)
  │    │         │    │         │    │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:33(bool)
+ │    │         │    │         │    │    │         │    │    ├── has-placeholder
  │    │         │    │         │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(33)
  │    │         │    │         │    │    │         │    │    ├── select
  │    │         │    │         │    │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │         │    │         │    │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │         │    │    │    ├── key: (1)
  │    │         │    │         │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
  │    │         │    │         │    │    │         │    │    │    ├── ordering: +1 opt(11)
@@ -2672,10 +2847,12 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │         │    │    │         └── disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight)]
  │    │         │    │         │    │    │         │    │    ├── project
  │    │         │    │         │    │    │         │    │    │    ├── columns: true:33(bool!null) instance_type_projects.instance_type_id:18(int!null)
+ │    │         │    │         │    │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │         │    │    │    ├── fd: ()-->(33)
  │    │         │    │         │    │    │         │    │    │    ├── ordering: +18 opt(33)
  │    │         │    │         │    │    │         │    │    │    ├── select
  │    │         │    │         │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) instance_type_projects.project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+ │    │         │    │         │    │    │         │    │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │         │    │    │    │    ├── ordering: +18
  │    │         │    │         │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
  │    │         │    │         │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) instance_type_projects.project_id:19(string) instance_type_projects.deleted:20(bool)
@@ -2727,9 +2904,11 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,34)]
  │    │         │    │         │    │    ├── project
  │    │         │    │         │    │    │    ├── columns: true:36(bool!null) instance_type_projects.instance_type_id:26(int!null)
+ │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── fd: ()-->(36)
  │    │         │    │         │    │    │    ├── select
  │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) instance_type_projects.project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
+ │    │         │    │         │    │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
  │    │         │    │         │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:26(int!null) instance_type_projects.project_id:27(string) instance_type_projects.deleted:28(bool)
  │    │         │    │         │    │    │    │    └── filters [type=bool, outer=(27,28), constraints=(/27: (/NULL - ]; /28: (/NULL - ])]
@@ -2845,55 +3024,66 @@ order by anon_1.instance_types_deleted asc,
 left-join (lookup instance_type_extra_specs)
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
  ├── key columns: [28] = [28]
+ ├── has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── ordering: +13,+1
  ├── left-join (lookup instance_type_extra_specs@secondary)
  │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
  │    ├── key columns: [1] = [31]
+ │    ├── has-placeholder
  │    ├── key: (1,28)
  │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
  │    ├── ordering: +13,+1
  │    ├── project
  │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │    ├── has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │    ├── ordering: +13,+1
  │    │    └── limit
  │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
  │    │         ├── internal-ordering: +13,+1
+ │    │         ├── has-placeholder
  │    │         ├── key: (1)
  │    │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         ├── ordering: +13,+1
  │    │         ├── offset
  │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
  │    │         │    ├── internal-ordering: +13,+1
+ │    │         │    ├── has-placeholder
  │    │         │    ├── key: (1)
  │    │         │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    ├── ordering: +13,+1
  │    │         │    ├── sort
  │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         │    │    ├── has-placeholder
  │    │         │    │    ├── key: (1)
  │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │    ├── ordering: +13,+1
  │    │         │    │    └── select
  │    │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         │    │         ├── has-placeholder
  │    │         │    │         ├── key: (1)
  │    │         │    │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │         ├── group-by
  │    │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
  │    │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+ │    │         │    │         │    ├── has-placeholder
  │    │         │    │         │    ├── key: (1)
  │    │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │         │    ├── left-join
  │    │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+ │    │         │    │         │    │    ├── has-placeholder
  │    │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
  │    │         │    │         │    │    ├── index-join instance_types
  │    │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── key: (1)
  │    │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │         │    │         │    │    │    └── select
  │    │         │    │         │    │    │         ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool!null)
+ │    │         │    │         │    │    │         ├── has-placeholder
  │    │         │    │         │    │    │         ├── key: (1)
  │    │         │    │         │    │    │         ├── fd: (1)-->(7,13), (7,13)-->(1)
  │    │         │    │         │    │    │         ├── scan instance_types@secondary
@@ -2906,9 +3096,11 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │              └── flavorid = $4 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
  │    │         │    │         │    │    ├── project
  │    │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+ │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── fd: ()-->(25)
  │    │         │    │         │    │    │    ├── select
  │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+ │    │         │    │         │    │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
  │    │         │    │         │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
  │    │         │    │         │    │    │    │    └── filters [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
@@ -3010,6 +3202,7 @@ from (select flavors.created_at as flavors_created_at,
 ----
 right-join
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── scan flavor_extra_specs
@@ -3018,30 +3211,37 @@ right-join
  │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── project
  │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │    ├── has-placeholder
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │    └── limit
  │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+ │         ├── has-placeholder
  │         ├── key: (1)
  │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │         ├── offset
  │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+ │         │    ├── has-placeholder
  │         │    ├── key: (1)
  │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │         │    ├── select
  │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+ │         │    │    ├── has-placeholder
  │         │    │    ├── key: (1)
  │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │         │    │    ├── group-by
  │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
  │         │    │    │    ├── grouping columns: flavors.id:1(int!null)
+ │         │    │    │    ├── has-placeholder
  │         │    │    │    ├── key: (1)
  │         │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │         │    │    │    ├── left-join (merge)
  │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+ │         │    │    │    │    ├── has-placeholder
  │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
  │         │    │    │    │    ├── select
  │         │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │         │    │    │    │    │    ├── has-placeholder
  │         │    │    │    │    │    ├── key: (1)
  │         │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │         │    │    │    │    │    ├── ordering: +1
@@ -3054,10 +3254,12 @@ right-join
  │         │    │    │    │    │         └── flavors.id = $2 [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
  │         │    │    │    │    ├── project
  │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+ │         │    │    │    │    │    ├── has-placeholder
  │         │    │    │    │    │    ├── fd: ()-->(22)
  │         │    │    │    │    │    ├── ordering: +17 opt(22)
  │         │    │    │    │    │    ├── select
  │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+ │         │    │    │    │    │    │    ├── has-placeholder
  │         │    │    │    │    │    │    ├── key: (17,18)
  │         │    │    │    │    │    │    ├── ordering: +17
  │         │    │    │    │    │    │    ├── scan flavor_projects@secondary
@@ -3162,11 +3364,13 @@ order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) anon_1_flavors_description:13(string) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── ordering: +7
  └── right-join
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:25(int) key:26(string) value:27(string) flavor_extra_specs.flavor_id:28(int) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+      ├── has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (25)-->(26-30), (26,28)-->(25,27,29,30)
       ├── scan flavor_extra_specs
@@ -3175,29 +3379,35 @@ sort
       │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
       ├── project
       │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    ├── has-placeholder
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15)
       │    └── limit
       │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
       │         ├── internal-ordering: +7
+      │         ├── has-placeholder
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)
       │         ├── sort
       │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │         │    ├── has-placeholder
       │         │    ├── key: (1)
       │         │    ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)
       │         │    ├── ordering: +7
       │         │    └── select
       │         │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │         │         ├── has-placeholder
       │         │         ├── key: (1)
       │         │         ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)
       │         │         ├── group-by
       │         │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
       │         │         │    ├── grouping columns: flavors.id:1(int!null)
+      │         │         │    ├── has-placeholder
       │         │         │    ├── key: (1)
       │         │         │    ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)
       │         │         │    ├── left-join (merge)
       │         │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+      │         │         │    │    ├── has-placeholder
       │         │         │    │    ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), ()~~>(22)
       │         │         │    │    ├── scan flavors
       │         │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
@@ -3206,10 +3416,12 @@ sort
       │         │         │    │    │    └── ordering: +1
       │         │         │    │    ├── project
       │         │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+      │         │         │    │    │    ├── has-placeholder
       │         │         │    │    │    ├── fd: ()-->(22)
       │         │         │    │    │    ├── ordering: +17 opt(22)
       │         │         │    │    │    ├── select
       │         │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │         │         │    │    │    │    ├── has-placeholder
       │         │         │    │    │    │    ├── key: (17,18)
       │         │         │    │    │    │    ├── ordering: +17
       │         │         │    │    │    │    ├── scan flavor_projects@secondary

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -148,6 +148,11 @@ func newOptView(cat *optCatalog, desc *sqlbase.TableDescriptor, name *tree.Table
 	return ov
 }
 
+// Fingerprint is part of the opt.DataSource interface.
+func (ov *optView) Fingerprint() opt.Fingerprint {
+	return opt.Fingerprint(ov.desc.ID)<<32 | opt.Fingerprint(ov.desc.Version)
+}
+
 // Name is part of the opt.View interface.
 func (ov *optView) Name() *tree.TableName {
 	return &ov.name
@@ -200,14 +205,19 @@ func newOptSequence(
 	return ot
 }
 
+// Fingerprint is part of the opt.DataSource interface.
+func (os *optSequence) Fingerprint() opt.Fingerprint {
+	return opt.Fingerprint(os.desc.ID)<<32 | opt.Fingerprint(os.desc.Version)
+}
+
 // Name is part of the opt.DataSource interface.
-func (ot *optSequence) Name() *tree.TableName {
-	return &ot.name
+func (os *optSequence) Name() *tree.TableName {
+	return &os.name
 }
 
 // CheckPrivilege is part of the opt.DataSource interface.
-func (ot *optSequence) CheckPrivilege(ctx context.Context, priv privilege.Kind) error {
-	return ot.cat.resolver.CheckPrivilege(ctx, ot.desc, priv)
+func (os *optSequence) CheckPrivilege(ctx context.Context, priv privilege.Kind) error {
+	return os.cat.resolver.CheckPrivilege(ctx, os.desc, priv)
 }
 
 // optTable is a wrapper around sqlbase.TableDescriptor that caches index
@@ -248,6 +258,11 @@ func newOptTable(cat *optCatalog, desc *sqlbase.TableDescriptor, name *tree.Tabl
 	ot.primary.init(ot, &desc.PrimaryIndex)
 
 	return ot
+}
+
+// Fingerprint is part of the opt.DataSource interface.
+func (ot *optTable) Fingerprint() opt.Fingerprint {
+	return opt.Fingerprint(ot.desc.ID)<<32 | opt.Fingerprint(ot.desc.Version)
 }
 
 // Name is part of the opt.DataSource interface.

--- a/pkg/sql/opt_index_selection_test.go
+++ b/pkg/sql/opt_index_selection_test.go
@@ -92,7 +92,7 @@ func makeSpans(
 		index: index,
 	}
 	var o xform.Optimizer
-	o.Init(nil /* evalCtx */)
+	o.Init(p.EvalContext())
 	for _, c := range desc.Columns {
 		o.Memo().Metadata().AddColumn(c.Name, c.Type.ToDatumType())
 	}

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -1441,6 +1441,72 @@ func TestPGPrepareNameQual(t *testing.T) {
 	}
 }
 
+// TestPGPrepareInvalidate ensures that changing table schema triggers recompile
+// of a prepared query.
+func TestPGPrepareInvalidate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+
+	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), t.Name(), url.User(security.RootUser))
+	defer cleanupFn()
+
+	db, err := gosql.Open("postgres", pgURL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	testCases := []struct {
+		stmt    string
+		prep    bool
+		numCols int
+	}{
+		{
+			stmt: `CREATE DATABASE IF NOT EXISTS testing`,
+		},
+		{
+			stmt: `CREATE TABLE IF NOT EXISTS ab (a INT PRIMARY KEY, b INT)`,
+		},
+		{
+			stmt:    `INSERT INTO ab (a, b) VALUES (1, 10)`,
+			prep:    true,
+			numCols: 2,
+		},
+		{
+			stmt:    `ALTER TABLE ab ADD COLUMN c INT`,
+			numCols: 3,
+		},
+		{
+			stmt:    `ALTER TABLE ab DROP COLUMN c`,
+			numCols: 2,
+		},
+	}
+
+	var prep *gosql.Stmt
+	for _, tc := range testCases {
+		if _, err = db.Exec(tc.stmt); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create the prepared statement.
+		if tc.prep {
+			if prep, err = db.Prepare(`SELECT * FROM ab WHERE b=10`); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if prep != nil {
+			rows, _ := prep.Query()
+			defer rows.Close()
+			cols, _ := rows.Columns()
+			if len(cols) != tc.numCols {
+				t.Fatalf("expected %d cols, got %d cols", tc.numCols, len(cols))
+			}
+		}
+	}
+}
+
 // A DDL should return "CommandComplete", not "EmptyQuery" Response.
 func TestCmdCompleteVsEmptyStatements(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -39,6 +40,10 @@ type PreparedStatement struct {
 	// Statement is the parsed, prepared SQL statement. It may be nil if the
 	// prepared statement is empty.
 	Statement tree.Statement
+	// Memo is the memoized data structure constructed by the cost-based optimizer
+	// during prepare of a SQL statement. It can significantly speed up execution
+	// if it is used by the optimizer as a starting point.
+	Memo memo.Memo
 	// TypeHints contains the types of the placeholders set by the client. It
 	// dictates how input parameters for those placeholders will be parsed. If a
 	// placeholder has no type hint, it will be populated during type checking.

--- a/pkg/sql/sessiondata/search_path.go
+++ b/pkg/sql/sessiondata/search_path.go
@@ -35,7 +35,8 @@ type SearchPath struct {
 	containsPgCatalog bool
 }
 
-// MakeSearchPath returns a new SearchPath struct.
+// MakeSearchPath returns a new SearchPath struct. The paths slice must not be
+// modified after hand-off to MakeSearchPath.
 func MakeSearchPath(paths []string) SearchPath {
 	containsPgCatalog := false
 	for _, e := range paths {

--- a/pkg/sql/statement.go
+++ b/pkg/sql/statement.go
@@ -25,6 +25,18 @@ type Statement struct {
 	ExpectedTypes sqlbase.ResultColumns
 	AnonymizedStr string
 	queryID       ClusterWideID
+
+	// Prepared is non-nil during the PREPARE phase, as well as during EXECUTE of
+	// a previously prepared statement. The Prepared statement can be modified
+	// during either phase; the PREPARE phase sets its initial state, and the
+	// EXECUTE phase can re-prepare it. This happens when the original plan has
+	// been invalidated by schema changes, session data changes, permission
+	// changes, or other changes to the context in which the original plan was
+	// prepared.
+	//
+	// Given that the PreparedStatement can be modified during planning, it is
+	// not safe for use on multiple threads.
+	Prepared *PreparedStatement
 }
 
 func (s Statement) String() string {

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -420,6 +420,10 @@ func (tc *TableCollection) waitForCacheToDropDatabases(ctx context.Context) {
 	}
 }
 
+func (tc *TableCollection) hasUncommittedTables() bool {
+	return len(tc.uncommittedTables) > 0
+}
+
 func (tc *TableCollection) addUncommittedTable(desc sqlbase.TableDescriptor) {
 	for i, table := range tc.uncommittedTables {
 		if table.ID == desc.ID {


### PR DESCRIPTION
Backport 4/4 commits from #29686.

/cc @cockroachdb/release

---

Store the cost-based optimizer's Memo struct in the PreparedStatement,
and then use that to speed up the planning process on each execution,
since the `optbuild` and `normalize` phases can be either skipped or
significantly reduced. If there are no placeholders, then the `explore`
phase can be skipped as well.

This PR significantly improves execution times when plans have been
prepared. The "old time" is the planning time when only the AST is
cached. The "new time" is the planning time when both the AST and
Memo data structures are cached.
```
name                               old time/op  new time/op  delta
Phases/kv-read/ExecBuild           24.6µs ± 2%  16.2µs ± 1%  -34.38%  (p=0.008 n=5+5)
Phases/kv-read-const/ExecBuild     24.9µs ± 1%   0.7µs ± 2%  -97.35%  (p=0.008 n=5+5)
Phases/tpcc-new-order/ExecBuild    91.8µs ± 3%  56.5µs ± 1%  -38.53%  (p=0.008 n=5+5)
Phases/tpcc-delivery/ExecBuild     67.6µs ± 1%  41.7µs ± 2%  -38.39%  (p=0.008 n=5+5)
Phases/tpcc-stock-level/ExecBuild   357µs ± 4%   182µs ± 1%  -48.87%  (p=0.008 n=5+5)
Exec/kv-read/ExecOpt                331µs ± 2%   187µs ± 2%  -43.67%  (p=0.008 n=5+5)
Exec/kv-read-const/ExecOpt          235µs ± 1%   160µs ± 1%  -31.83%  (p=0.008 n=5+5)
Exec/tpcc-new-order/ExecOpt         499µs ± 1%   275µs ± 1%  -44.77%  (p=0.008 n=5+5)
Exec/tpcc-delivery/ExecOpt          430µs ± 3%   243µs ± 1%  -43.49%  (p=0.008 n=5+5)
Exec/tpcc-stock-level/ExecOpt      1.03ms ± 1%  0.58ms ± 1%  -43.27%  (p=0.008 n=5+5)
```
Notice that the `kv-read-const` can skip almost all of planning, since it
contains no placeholders. Consequently, it takes only 700ns to plan.

With this change, end-to-end running times (on empty tables) for the
cost-based optimizer are typically lower for prepared queries than the
heuristic optimizer (old time=heuristic, new-time=cost-based):
```
name                        old time/op  new time/op  delta
Exec/kv-read/Exec            196µs ± 3%   187µs ± 2%   -4.78%  (p=0.008 n=5+5)
Exec/kv-read-const/Exec      198µs ± 1%   160µs ± 1%  -18.83%  (p=0.008 n=5+5)
Exec/tpcc-new-order/Exec     287µs ± 3%   275µs ± 1%   -4.04%  (p=0.008 n=5+5)
Exec/tpcc-delivery/Exec      245µs ± 2%   243µs ± 1%     ~     (p=0.421 n=5+5)
Exec/tpcc-stock-level/Exec   552µs ± 1%   583µs ± 1%   +5.54%  (p=0.008 n=5+5)
```
The `tpcc-stock-level` is a bit higher, since the cost-based optimizer is
currently missing constant-folding.
