### PR TITLE
release-2.1: opt: Don't hoist ANY with uncorrelated subquery

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/subquery_correlated
+++ b/pkg/sql/logictest/testdata/logic_test/subquery_correlated
@@ -182,6 +182,23 @@ SELECT * FROM c WHERE (bill > ANY(SELECT ship FROM o WHERE o.c_id=c.c_id)) IS NO
 5  NULL
 6  FL
 
+# Customers where bill state matches any ship state.
+query IT rowsort
+SELECT * FROM c WHERE bill = ANY(SELECT ship FROM o);
+----
+1  CA
+2  TX
+4  TX
+
+# Customers where bill state matches any ship state or is null.
+query IT rowsort
+SELECT * FROM c WHERE bill = ANY(SELECT ship FROM o) OR bill IS NULL;
+----
+1  CA
+2  TX
+4  TX
+5  NULL
+
 # Test NULL IN case. Use IS NOT NULL to prevent normalize ANY into EXISTS.
 query IT rowsort
 SELECT * FROM c WHERE (NULL::text IN (SELECT ship FROM o WHERE o.c_id=c.c_id)) IS NOT NULL;
@@ -586,7 +603,7 @@ SELECT c_id, (bill > ANY(SELECT ship FROM o WHERE o.c_id=c.c_id)) IS NULL FROM c
 5  false
 6  false
 
-# Customers where bill state > any ship state is not null result..
+# Customers where bill state > any ship state is not null result.
 query IB
 SELECT c_id, (bill > ANY(SELECT ship FROM o WHERE o.c_id=c.c_id)) IS NOT NULL FROM c ORDER BY c_id;
 ----
@@ -596,6 +613,28 @@ SELECT c_id, (bill > ANY(SELECT ship FROM o WHERE o.c_id=c.c_id)) IS NOT NULL FR
 4  false
 5  true
 6  true
+
+# Customers where bill state matches any non-null ship state.
+query IB rowsort
+SELECT c_id, bill = ANY(SELECT ship FROM o WHERE ship IS NOT NULL) FROM c;
+----
+1  true
+2  true
+3  false
+4  true
+5  NULL
+6  false
+
+# Customers where bill state matches any non-null ship state or is null.
+query IB rowsort
+SELECT c_id, bill = ANY(SELECT ship FROM o WHERE ship IS NOT NULL) OR bill IS NULL FROM c;
+----
+1  true
+2  true
+3  false
+4  true
+5  true
+6  false
 
 # Test NULL IN case.
 query IB

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -126,35 +126,21 @@ WHERE
     OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27))
     AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
 ----
-render                              ·            ·                                                                                                 (col0)                                              ·
- │                                  render 0     col0                                                                                              ·                                                   ·
- └── filter                         ·            ·                                                                                                 ("case", col0, col3, col4)                          ·
-      │                             filter       ((col0 <= 0) AND (col4 <= 5.38)) OR ((("case" AND (col3 <= 5)) AND (col3 >= 7)) AND (col3 <= 9))  ·                                                   ·
-      └── render                    ·            ·                                                                                                 ("case", col0, col3, col4)                          ·
-           │                        render 0     CASE WHEN agg0 AND (agg3 IS NOT NULL) THEN true WHEN agg0 IS NULL THEN false END                  ·                                                   ·
-           │                        render 1     agg1                                                                                              ·                                                   ·
-           │                        render 2     agg2                                                                                              ·                                                   ·
-           │                        render 3     agg3                                                                                              ·                                                   ·
-           └── group                ·            ·                                                                                                 (rowid[hidden], agg0, agg1, agg2, agg3)             ·
-                │                   aggregate 0  rowid                                                                                             ·                                                   ·
-                │                   aggregate 1  bool_or(notnull)                                                                                  ·                                                   ·
-                │                   aggregate 2  any_not_null(col0)                                                                                ·                                                   ·
-                │                   aggregate 3  any_not_null(col3)                                                                                ·                                                   ·
-                │                   aggregate 4  any_not_null(col4)                                                                                ·                                                   ·
-                │                   group by     @4                                                                                                ·                                                   ·
-                └── join            ·            ·                                                                                                 (col0, col3, col4, rowid[hidden], "notnull", col1)  ·
-                     │              type         left outer                                                                                        ·                                                   ·
-                     │              pred         (col4 = col1) IS NOT false                                                                        ·                                                   ·
-                     ├── scan       ·            ·                                                                                                 (col0, col3, col4, rowid[hidden])                   ·
-                     │              table        tab4@primary                                                                                      ·                                                   ·
-                     │              spans        ALL                                                                                               ·                                                   ·
-                     └── render     ·            ·                                                                                                 ("notnull", col1)                                   ·
-                          │         render 0     col1 IS NOT NULL                                                                                  ·                                                   ·
-                          │         render 1     col1                                                                                              ·                                                   ·
-                          └── scan  ·            ·                                                                                                 (col1)                                              ·
-·                                   table        tab4@primary                                                                                      ·                                                   ·
-·                                   spans        ALL                                                                                               ·                                                   ·
-·                                   filter       col1 > 8.27                                                                                       ·                                                   ·
+root            ·             ·                                                                                                           (col0)              ·
+ ├── render     ·             ·                                                                                                           (col0)              ·
+ │    │         render 0      col0                                                                                                        ·                   ·
+ │    └── scan  ·             ·                                                                                                           (col0, col3, col4)  ·
+ │              table         tab4@primary                                                                                                ·                   ·
+ │              spans         ALL                                                                                                         ·                   ·
+ │              filter        ((col0 <= 0) AND (col4 <= 5.38)) OR ((((col4 = ANY @S1) AND (col3 <= 5)) AND (col3 >= 7)) AND (col3 <= 9))  ·                   ·
+ └── subquery   ·             ·                                                                                                           (col0)              ·
+      │         id            @S1                                                                                                         ·                   ·
+      │         original sql  (SELECT col1 FROM tab4 WHERE col1 > 8.27)                                                                   ·                   ·
+      │         exec mode     all rows normalized                                                                                         ·                   ·
+      └── scan  ·             ·                                                                                                           (col1)              ·
+·               table         tab4@primary                                                                                                ·                   ·
+·               spans         ALL                                                                                                         ·                   ·
+·               filter        col1 > 8.27                                                                                                 ·                   ·
 
 # ------------------------------------------------------------------------------
 # Correlated subqueries.

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -831,11 +831,11 @@ Final best expression
 
 # Decorrelation pattern using ANY function.
 optsteps
-SELECT x=ANY(SELECT k FROM a) AS r FROM xy
+SELECT 5=ANY(SELECT i FROM a WHERE k=x) AS r FROM xy
 ----
 ================================================================================
 Initial expression
-  Cost: 2170.00
+  Cost: 2170.01
 ================================================================================
   project
    ├── columns: r:8(bool)
@@ -846,16 +846,27 @@ Initial expression
    └── projections [outer=(1)]
         └── any: eq [type=bool, outer=(1)]
              ├── project
-             │    ├── columns: k:3(int!null)
-             │    ├── key: (3)
-             │    └── scan a
+             │    ├── columns: i:4(int)
+             │    ├── outer: (1)
+             │    ├── cardinality: [0 - 1]
+             │    ├── key: ()
+             │    ├── fd: ()-->(4)
+             │    └── select
              │         ├── columns: k:3(int!null) i:4(int) f:5(float) s:6(string) j:7(jsonb)
-             │         ├── key: (3)
-             │         └── fd: (3)-->(4-7), (5,6)~~>(3,4,7)
-             └── variable: x [type=int, outer=(1)]
+             │         ├── outer: (1)
+             │         ├── cardinality: [0 - 1]
+             │         ├── key: ()
+             │         ├── fd: ()-->(3-7)
+             │         ├── scan a
+             │         │    ├── columns: k:3(int!null) i:4(int) f:5(float) s:6(string) j:7(jsonb)
+             │         │    ├── key: (3)
+             │         │    └── fd: (3)-->(4-7), (5,6)~~>(3,4,7)
+             │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+             │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+             └── const: 5 [type=int]
 ================================================================================
-PruneScanCols
-  Cost: 2130.00
+PruneSelectCols
+  Cost: 2140.01
 ================================================================================
    project
     ├── columns: r:8(bool)
@@ -866,39 +877,31 @@ PruneScanCols
     └── projections [outer=(1)]
          └── any: eq [type=bool, outer=(1)]
               ├── project
-              │    ├── columns: k:3(int!null)
-              │    ├── key: (3)
-              │    └── scan a
+              │    ├── columns: i:4(int)
+              │    ├── outer: (1)
+              │    ├── cardinality: [0 - 1]
+              │    ├── key: ()
+              │    ├── fd: ()-->(4)
+              │    └── select
   -           │         ├── columns: k:3(int!null) i:4(int) f:5(float) s:6(string) j:7(jsonb)
-  -           │         ├── key: (3)
-  -           │         └── fd: (3)-->(4-7), (5,6)~~>(3,4,7)
-  +           │         ├── columns: k:3(int!null)
-  +           │         └── key: (3)
-              └── variable: x [type=int, outer=(1)]
-================================================================================
-EliminateProject
-  Cost: 2120.00
-================================================================================
-   project
-    ├── columns: r:8(bool)
-    ├── scan xy
-    │    ├── columns: x:1(int!null) y:2(int)
-    │    ├── key: (1)
-    │    └── fd: (1)-->(2)
-    └── projections [outer=(1)]
-         └── any: eq [type=bool, outer=(1)]
-  -           ├── project
-  +           ├── scan a
-              │    ├── columns: k:3(int!null)
-  -           │    ├── key: (3)
-  -           │    └── scan a
-  -           │         ├── columns: k:3(int!null)
-  -           │         └── key: (3)
-  +           │    └── key: (3)
-              └── variable: x [type=int, outer=(1)]
+  +           │         ├── columns: k:3(int!null) i:4(int)
+              │         ├── outer: (1)
+              │         ├── cardinality: [0 - 1]
+              │         ├── key: ()
+  -           │         ├── fd: ()-->(3-7)
+  +           │         ├── fd: ()-->(3,4)
+              │         ├── scan a
+  -           │         │    ├── columns: k:3(int!null) i:4(int) f:5(float) s:6(string) j:7(jsonb)
+  +           │         │    ├── columns: k:3(int!null) i:4(int)
+              │         │    ├── key: (3)
+  -           │         │    └── fd: (3)-->(4-7), (5,6)~~>(3,4,7)
+  +           │         │    └── fd: (3)-->(4)
+              │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+              │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+              └── const: 5 [type=int]
 ================================================================================
 PruneScanCols
-  Cost: 2110.00
+  Cost: 2130.01
 ================================================================================
    project
     ├── columns: r:8(bool)
@@ -910,13 +913,28 @@ PruneScanCols
   + │    └── key: (1)
     └── projections [outer=(1)]
          └── any: eq [type=bool, outer=(1)]
-              ├── scan a
-              │    ├── columns: k:3(int!null)
-              │    └── key: (3)
-              └── variable: x [type=int, outer=(1)]
+              ├── project
+              │    ├── columns: i:4(int)
+              │    ├── outer: (1)
+              │    ├── cardinality: [0 - 1]
+              │    ├── key: ()
+              │    ├── fd: ()-->(4)
+              │    └── select
+              │         ├── columns: k:3(int!null) i:4(int)
+              │         ├── outer: (1)
+              │         ├── cardinality: [0 - 1]
+              │         ├── key: ()
+              │         ├── fd: ()-->(3,4)
+              │         ├── scan a
+              │         │    ├── columns: k:3(int!null) i:4(int)
+              │         │    ├── key: (3)
+              │         │    └── fd: (3)-->(4)
+              │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+              │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+              └── const: 5 [type=int]
 ================================================================================
 HoistProjectSubquery
-  Cost: 2152.55
+  Cost: 2152.58
 ================================================================================
    project
     ├── columns: r:8(bool)
@@ -925,10 +943,25 @@ HoistProjectSubquery
   - │    └── key: (1)
   - └── projections [outer=(1)]
   -      └── any: eq [type=bool, outer=(1)]
-  -           ├── scan a
-  -           │    ├── columns: k:3(int!null)
-  -           │    └── key: (3)
-  -           └── variable: x [type=int, outer=(1)]
+  -           ├── project
+  -           │    ├── columns: i:4(int)
+  -           │    ├── outer: (1)
+  -           │    ├── cardinality: [0 - 1]
+  -           │    ├── key: ()
+  -           │    ├── fd: ()-->(4)
+  -           │    └── select
+  -           │         ├── columns: k:3(int!null) i:4(int)
+  -           │         ├── outer: (1)
+  -           │         ├── cardinality: [0 - 1]
+  -           │         ├── key: ()
+  -           │         ├── fd: ()-->(3,4)
+  -           │         ├── scan a
+  -           │         │    ├── columns: k:3(int!null) i:4(int)
+  -           │         │    ├── key: (3)
+  -           │         │    └── fd: (3)-->(4)
+  -           │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  -           │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  -           └── const: 5 [type=int]
   + ├── inner-join-apply
   + │    ├── columns: x:1(int!null) case:11(bool)
   + │    ├── key: (1)
@@ -951,27 +984,47 @@ HoistProjectSubquery
   + │    │    │    ├── project
   + │    │    │    │    ├── columns: notnull:9(bool)
   + │    │    │    │    ├── outer: (1)
+  + │    │    │    │    ├── cardinality: [0 - 1]
+  + │    │    │    │    ├── key: ()
+  + │    │    │    │    ├── fd: ()-->(9)
   + │    │    │    │    ├── select
-  + │    │    │    │    │    ├── columns: k:3(int!null)
+  + │    │    │    │    │    ├── columns: i:4(int)
   + │    │    │    │    │    ├── outer: (1)
-  + │    │    │    │    │    ├── key: (3)
-  + │    │    │    │    │    ├── scan a
-  + │    │    │    │    │    │    ├── columns: k:3(int!null)
-  + │    │    │    │    │    │    └── key: (3)
-  + │    │    │    │    │    └── (x = k) IS NOT false [type=bool, outer=(1,3)]
-  + │    │    │    │    └── projections [outer=(3)]
-  + │    │    │    │         └── k IS NOT NULL [type=bool, outer=(3)]
+  + │    │    │    │    │    ├── cardinality: [0 - 1]
+  + │    │    │    │    │    ├── key: ()
+  + │    │    │    │    │    ├── fd: ()-->(4)
+  + │    │    │    │    │    ├── project
+  + │    │    │    │    │    │    ├── columns: i:4(int)
+  + │    │    │    │    │    │    ├── outer: (1)
+  + │    │    │    │    │    │    ├── cardinality: [0 - 1]
+  + │    │    │    │    │    │    ├── key: ()
+  + │    │    │    │    │    │    ├── fd: ()-->(4)
+  + │    │    │    │    │    │    └── select
+  + │    │    │    │    │    │         ├── columns: k:3(int!null) i:4(int)
+  + │    │    │    │    │    │         ├── outer: (1)
+  + │    │    │    │    │    │         ├── cardinality: [0 - 1]
+  + │    │    │    │    │    │         ├── key: ()
+  + │    │    │    │    │    │         ├── fd: ()-->(3,4)
+  + │    │    │    │    │    │         ├── scan a
+  + │    │    │    │    │    │         │    ├── columns: k:3(int!null) i:4(int)
+  + │    │    │    │    │    │         │    ├── key: (3)
+  + │    │    │    │    │    │         │    └── fd: (3)-->(4)
+  + │    │    │    │    │    │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  + │    │    │    │    │    │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  + │    │    │    │    │    └── (5 = i) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    │    └── projections [outer=(4)]
+  + │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
   + │    │    │    └── aggregations [outer=(9)]
   + │    │    │         └── bool-or [type=bool, outer=(9)]
   + │    │    │              └── variable: notnull [type=bool, outer=(9)]
-  + │    │    └── projections [outer=(1,10)]
-  + │    │         └── CASE WHEN bool_or AND (x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(1,10)]
+  + │    │    └── projections [outer=(10)]
+  + │    │         └── CASE WHEN bool_or AND (5 IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
   + │    └── true [type=bool]
   + └── projections [outer=(11)]
   +      └── variable: case [type=bool, outer=(11)]
 ================================================================================
-EnsureSelectFilters
-  Cost: 2152.55
+CommuteVar
+  Cost: 2152.58
 ================================================================================
    project
     ├── columns: r:8(bool)
@@ -997,29 +1050,608 @@ EnsureSelectFilters
     │    │    │    ├── project
     │    │    │    │    ├── columns: notnull:9(bool)
     │    │    │    │    ├── outer: (1)
+    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    ├── key: ()
+    │    │    │    │    ├── fd: ()-->(9)
     │    │    │    │    ├── select
-    │    │    │    │    │    ├── columns: k:3(int!null)
+    │    │    │    │    │    ├── columns: i:4(int)
     │    │    │    │    │    ├── outer: (1)
-    │    │    │    │    │    ├── key: (3)
-    │    │    │    │    │    ├── scan a
-    │    │    │    │    │    │    ├── columns: k:3(int!null)
-    │    │    │    │    │    │    └── key: (3)
-  - │    │    │    │    │    └── (x = k) IS NOT false [type=bool, outer=(1,3)]
-  + │    │    │    │    │    └── filters [type=bool, outer=(1,3)]
-  + │    │    │    │    │         └── (x = k) IS NOT false [type=bool, outer=(1,3)]
-    │    │    │    │    └── projections [outer=(3)]
-    │    │    │    │         └── k IS NOT NULL [type=bool, outer=(3)]
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    ├── fd: ()-->(4)
+    │    │    │    │    │    ├── project
+    │    │    │    │    │    │    ├── columns: i:4(int)
+    │    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    │    ├── fd: ()-->(4)
+    │    │    │    │    │    │    └── select
+    │    │    │    │    │    │         ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    │         ├── outer: (1)
+    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+    │    │    │    │    │    │         ├── key: ()
+    │    │    │    │    │    │         ├── fd: ()-->(3,4)
+    │    │    │    │    │    │         ├── scan a
+    │    │    │    │    │    │         │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    │         │    ├── key: (3)
+    │    │    │    │    │    │         │    └── fd: (3)-->(4)
+    │    │    │    │    │    │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │    │    │    │    │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  - │    │    │    │    │    └── (5 = i) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    │    │    └── (i = 5) IS NOT false [type=bool, outer=(4)]
+    │    │    │    │    └── projections [outer=(4)]
+    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
     │    │    │    └── aggregations [outer=(9)]
     │    │    │         └── bool-or [type=bool, outer=(9)]
     │    │    │              └── variable: notnull [type=bool, outer=(9)]
-    │    │    └── projections [outer=(1,10)]
-    │    │         └── CASE WHEN bool_or AND (x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(1,10)]
+    │    │    └── projections [outer=(10)]
+    │    │         └── CASE WHEN bool_or AND (5 IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
     │    └── true [type=bool]
     └── projections [outer=(11)]
          └── variable: case [type=bool, outer=(11)]
 ================================================================================
+EnsureSelectFilters
+  Cost: 2152.58
+================================================================================
+   project
+    ├── columns: r:8(bool)
+    ├── inner-join-apply
+    │    ├── columns: x:1(int!null) case:11(bool)
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(11)
+    │    ├── scan xy
+    │    │    ├── columns: x:1(int!null)
+    │    │    └── key: (1)
+    │    ├── project
+    │    │    ├── columns: case:11(bool)
+    │    │    ├── outer: (1)
+    │    │    ├── cardinality: [1 - 1]
+    │    │    ├── key: ()
+    │    │    ├── fd: ()-->(11)
+    │    │    ├── scalar-group-by
+    │    │    │    ├── columns: bool_or:10(bool)
+    │    │    │    ├── outer: (1)
+    │    │    │    ├── cardinality: [1 - 1]
+    │    │    │    ├── key: ()
+    │    │    │    ├── fd: ()-->(10)
+    │    │    │    ├── project
+    │    │    │    │    ├── columns: notnull:9(bool)
+    │    │    │    │    ├── outer: (1)
+    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    ├── key: ()
+    │    │    │    │    ├── fd: ()-->(9)
+    │    │    │    │    ├── select
+    │    │    │    │    │    ├── columns: i:4(int)
+    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    ├── fd: ()-->(4)
+    │    │    │    │    │    ├── project
+    │    │    │    │    │    │    ├── columns: i:4(int)
+    │    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    │    ├── fd: ()-->(4)
+    │    │    │    │    │    │    └── select
+    │    │    │    │    │    │         ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    │         ├── outer: (1)
+    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+    │    │    │    │    │    │         ├── key: ()
+    │    │    │    │    │    │         ├── fd: ()-->(3,4)
+    │    │    │    │    │    │         ├── scan a
+    │    │    │    │    │    │         │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    │         │    ├── key: (3)
+    │    │    │    │    │    │         │    └── fd: (3)-->(4)
+    │    │    │    │    │    │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │    │    │    │    │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  - │    │    │    │    │    └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    │    │    └── filters [type=bool, outer=(4)]
+  + │    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+    │    │    │    │    └── projections [outer=(4)]
+    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+    │    │    │    └── aggregations [outer=(9)]
+    │    │    │         └── bool-or [type=bool, outer=(9)]
+    │    │    │              └── variable: notnull [type=bool, outer=(9)]
+    │    │    └── projections [outer=(10)]
+    │    │         └── CASE WHEN bool_or AND (5 IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
+    │    └── true [type=bool]
+    └── projections [outer=(11)]
+         └── variable: case [type=bool, outer=(11)]
+================================================================================
+PushSelectIntoProject
+  Cost: 2152.57
+================================================================================
+   project
+    ├── columns: r:8(bool)
+    ├── inner-join-apply
+    │    ├── columns: x:1(int!null) case:11(bool)
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(11)
+    │    ├── scan xy
+    │    │    ├── columns: x:1(int!null)
+    │    │    └── key: (1)
+    │    ├── project
+    │    │    ├── columns: case:11(bool)
+    │    │    ├── outer: (1)
+    │    │    ├── cardinality: [1 - 1]
+    │    │    ├── key: ()
+    │    │    ├── fd: ()-->(11)
+    │    │    ├── scalar-group-by
+    │    │    │    ├── columns: bool_or:10(bool)
+    │    │    │    ├── outer: (1)
+    │    │    │    ├── cardinality: [1 - 1]
+    │    │    │    ├── key: ()
+    │    │    │    ├── fd: ()-->(10)
+    │    │    │    ├── project
+    │    │    │    │    ├── columns: notnull:9(bool)
+    │    │    │    │    ├── outer: (1)
+    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    ├── key: ()
+    │    │    │    │    ├── fd: ()-->(9)
+    │    │    │    │    ├── select
+    │    │    │    │    │    ├── columns: i:4(int)
+    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    ├── fd: ()-->(4)
+    │    │    │    │    │    ├── project
+    │    │    │    │    │    │    ├── columns: i:4(int)
+    │    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    │    ├── fd: ()-->(4)
+    │    │    │    │    │    │    └── select
+    │    │    │    │    │    │         ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    │         ├── outer: (1)
+    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+    │    │    │    │    │    │         ├── key: ()
+    │    │    │    │    │    │         ├── fd: ()-->(3,4)
+  - │    │    │    │    │    │         ├── scan a
+  + │    │    │    │    │    │         ├── select
+    │    │    │    │    │    │         │    ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │    │         │    ├── key: (3)
+  - │    │    │    │    │    │         │    └── fd: (3)-->(4)
+  - │    │    │    │    │    │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  - │    │    │    │    │    │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  - │    │    │    │    │    └── filters [type=bool, outer=(4)]
+  - │    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    │    │    │         │    ├── outer: (1)
+  + │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+  + │    │    │    │    │    │         │    ├── key: ()
+  + │    │    │    │    │    │         │    ├── fd: ()-->(3,4)
+  + │    │    │    │    │    │         │    ├── scan a
+  + │    │    │    │    │    │         │    │    ├── columns: k:3(int!null) i:4(int)
+  + │    │    │    │    │    │         │    │    ├── key: (3)
+  + │    │    │    │    │    │         │    │    └── fd: (3)-->(4)
+  + │    │    │    │    │    │         │    └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  + │    │    │    │    │    │         │         └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  + │    │    │    │    │    │         └── filters [type=bool, outer=(4)]
+  + │    │    │    │    │    │              └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    │    │    └── filters [type=bool]
+    │    │    │    │    └── projections [outer=(4)]
+    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+    │    │    │    └── aggregations [outer=(9)]
+    │    │    │         └── bool-or [type=bool, outer=(9)]
+    │    │    │              └── variable: notnull [type=bool, outer=(9)]
+    │    │    └── projections [outer=(10)]
+    │    │         └── CASE WHEN bool_or AND (5 IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
+    │    └── true [type=bool]
+    └── projections [outer=(11)]
+         └── variable: case [type=bool, outer=(11)]
+================================================================================
+MergeSelects
+  Cost: 2152.56
+================================================================================
+   project
+    ├── columns: r:8(bool)
+    ├── inner-join-apply
+    │    ├── columns: x:1(int!null) case:11(bool)
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(11)
+    │    ├── scan xy
+    │    │    ├── columns: x:1(int!null)
+    │    │    └── key: (1)
+    │    ├── project
+    │    │    ├── columns: case:11(bool)
+    │    │    ├── outer: (1)
+    │    │    ├── cardinality: [1 - 1]
+    │    │    ├── key: ()
+    │    │    ├── fd: ()-->(11)
+    │    │    ├── scalar-group-by
+    │    │    │    ├── columns: bool_or:10(bool)
+    │    │    │    ├── outer: (1)
+    │    │    │    ├── cardinality: [1 - 1]
+    │    │    │    ├── key: ()
+    │    │    │    ├── fd: ()-->(10)
+    │    │    │    ├── project
+    │    │    │    │    ├── columns: notnull:9(bool)
+    │    │    │    │    ├── outer: (1)
+    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    ├── key: ()
+    │    │    │    │    ├── fd: ()-->(9)
+    │    │    │    │    ├── select
+    │    │    │    │    │    ├── columns: i:4(int)
+    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    ├── fd: ()-->(4)
+    │    │    │    │    │    ├── project
+    │    │    │    │    │    │    ├── columns: i:4(int)
+    │    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    │    ├── fd: ()-->(4)
+    │    │    │    │    │    │    └── select
+    │    │    │    │    │    │         ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    │         ├── outer: (1)
+    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+    │    │    │    │    │    │         ├── key: ()
+    │    │    │    │    │    │         ├── fd: ()-->(3,4)
+  - │    │    │    │    │    │         ├── select
+  + │    │    │    │    │    │         ├── scan a
+    │    │    │    │    │    │         │    ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │    │         │    ├── outer: (1)
+  - │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+  - │    │    │    │    │    │         │    ├── key: ()
+  - │    │    │    │    │    │         │    ├── fd: ()-->(3,4)
+  - │    │    │    │    │    │         │    ├── scan a
+  - │    │    │    │    │    │         │    │    ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │    │         │    │    ├── key: (3)
+  - │    │    │    │    │    │         │    │    └── fd: (3)-->(4)
+  - │    │    │    │    │    │         │    └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  - │    │    │    │    │    │         │         └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  - │    │    │    │    │    │         └── filters [type=bool, outer=(4)]
+  + │    │    │    │    │    │         │    ├── key: (3)
+  + │    │    │    │    │    │         │    └── fd: (3)-->(4)
+  + │    │    │    │    │    │         └── filters [type=bool, outer=(1,3,4), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  + │    │    │    │    │    │              ├── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+    │    │    │    │    │    │              └── (i = 5) IS NOT false [type=bool, outer=(4)]
+    │    │    │    │    │    └── filters [type=bool]
+    │    │    │    │    └── projections [outer=(4)]
+    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+    │    │    │    └── aggregations [outer=(9)]
+    │    │    │         └── bool-or [type=bool, outer=(9)]
+    │    │    │              └── variable: notnull [type=bool, outer=(9)]
+    │    │    └── projections [outer=(10)]
+    │    │         └── CASE WHEN bool_or AND (5 IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
+    │    └── true [type=bool]
+    └── projections [outer=(11)]
+         └── variable: case [type=bool, outer=(11)]
+================================================================================
+EliminateEmptyAnd
+  Cost: 2152.56
+================================================================================
+   project
+    ├── columns: r:8(bool)
+    ├── inner-join-apply
+    │    ├── columns: x:1(int!null) case:11(bool)
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(11)
+    │    ├── scan xy
+    │    │    ├── columns: x:1(int!null)
+    │    │    └── key: (1)
+    │    ├── project
+    │    │    ├── columns: case:11(bool)
+    │    │    ├── outer: (1)
+    │    │    ├── cardinality: [1 - 1]
+    │    │    ├── key: ()
+    │    │    ├── fd: ()-->(11)
+    │    │    ├── scalar-group-by
+    │    │    │    ├── columns: bool_or:10(bool)
+    │    │    │    ├── outer: (1)
+    │    │    │    ├── cardinality: [1 - 1]
+    │    │    │    ├── key: ()
+    │    │    │    ├── fd: ()-->(10)
+    │    │    │    ├── project
+    │    │    │    │    ├── columns: notnull:9(bool)
+    │    │    │    │    ├── outer: (1)
+    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    ├── key: ()
+    │    │    │    │    ├── fd: ()-->(9)
+    │    │    │    │    ├── select
+    │    │    │    │    │    ├── columns: i:4(int)
+    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    ├── fd: ()-->(4)
+    │    │    │    │    │    ├── project
+    │    │    │    │    │    │    ├── columns: i:4(int)
+    │    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    │    ├── fd: ()-->(4)
+    │    │    │    │    │    │    └── select
+    │    │    │    │    │    │         ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    │         ├── outer: (1)
+    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+    │    │    │    │    │    │         ├── key: ()
+    │    │    │    │    │    │         ├── fd: ()-->(3,4)
+    │    │    │    │    │    │         ├── scan a
+    │    │    │    │    │    │         │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    │         │    ├── key: (3)
+    │    │    │    │    │    │         │    └── fd: (3)-->(4)
+    │    │    │    │    │    │         └── filters [type=bool, outer=(1,3,4), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │    │    │    │    │              ├── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+    │    │    │    │    │    │              └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  - │    │    │    │    │    └── filters [type=bool]
+  + │    │    │    │    │    └── true [type=bool]
+    │    │    │    │    └── projections [outer=(4)]
+    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+    │    │    │    └── aggregations [outer=(9)]
+    │    │    │         └── bool-or [type=bool, outer=(9)]
+    │    │    │              └── variable: notnull [type=bool, outer=(9)]
+    │    │    └── projections [outer=(10)]
+    │    │         └── CASE WHEN bool_or AND (5 IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
+    │    └── true [type=bool]
+    └── projections [outer=(11)]
+         └── variable: case [type=bool, outer=(11)]
+================================================================================
+EliminateSelect
+  Cost: 2152.56
+================================================================================
+   project
+    ├── columns: r:8(bool)
+    ├── inner-join-apply
+    │    ├── columns: x:1(int!null) case:11(bool)
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(11)
+    │    ├── scan xy
+    │    │    ├── columns: x:1(int!null)
+    │    │    └── key: (1)
+    │    ├── project
+    │    │    ├── columns: case:11(bool)
+    │    │    ├── outer: (1)
+    │    │    ├── cardinality: [1 - 1]
+    │    │    ├── key: ()
+    │    │    ├── fd: ()-->(11)
+    │    │    ├── scalar-group-by
+    │    │    │    ├── columns: bool_or:10(bool)
+    │    │    │    ├── outer: (1)
+    │    │    │    ├── cardinality: [1 - 1]
+    │    │    │    ├── key: ()
+    │    │    │    ├── fd: ()-->(10)
+    │    │    │    ├── project
+    │    │    │    │    ├── columns: notnull:9(bool)
+    │    │    │    │    ├── outer: (1)
+    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    ├── key: ()
+    │    │    │    │    ├── fd: ()-->(9)
+  - │    │    │    │    ├── select
+  + │    │    │    │    ├── project
+    │    │    │    │    │    ├── columns: i:4(int)
+    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    ├── fd: ()-->(4)
+  - │    │    │    │    │    ├── project
+  - │    │    │    │    │    │    ├── columns: i:4(int)
+  - │    │    │    │    │    │    ├── outer: (1)
+  - │    │    │    │    │    │    ├── cardinality: [0 - 1]
+  - │    │    │    │    │    │    ├── key: ()
+  - │    │    │    │    │    │    ├── fd: ()-->(4)
+  - │    │    │    │    │    │    └── select
+  - │    │    │    │    │    │         ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │    │         ├── outer: (1)
+  - │    │    │    │    │    │         ├── cardinality: [0 - 1]
+  - │    │    │    │    │    │         ├── key: ()
+  - │    │    │    │    │    │         ├── fd: ()-->(3,4)
+  - │    │    │    │    │    │         ├── scan a
+  - │    │    │    │    │    │         │    ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │    │         │    ├── key: (3)
+  - │    │    │    │    │    │         │    └── fd: (3)-->(4)
+  - │    │    │    │    │    │         └── filters [type=bool, outer=(1,3,4), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  - │    │    │    │    │    │              ├── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  - │    │    │    │    │    │              └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  - │    │    │    │    │    └── true [type=bool]
+  + │    │    │    │    │    └── select
+  + │    │    │    │    │         ├── columns: k:3(int!null) i:4(int)
+  + │    │    │    │    │         ├── outer: (1)
+  + │    │    │    │    │         ├── cardinality: [0 - 1]
+  + │    │    │    │    │         ├── key: ()
+  + │    │    │    │    │         ├── fd: ()-->(3,4)
+  + │    │    │    │    │         ├── scan a
+  + │    │    │    │    │         │    ├── columns: k:3(int!null) i:4(int)
+  + │    │    │    │    │         │    ├── key: (3)
+  + │    │    │    │    │         │    └── fd: (3)-->(4)
+  + │    │    │    │    │         └── filters [type=bool, outer=(1,3,4), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  + │    │    │    │    │              ├── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  + │    │    │    │    │              └── (i = 5) IS NOT false [type=bool, outer=(4)]
+    │    │    │    │    └── projections [outer=(4)]
+    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+    │    │    │    └── aggregations [outer=(9)]
+    │    │    │         └── bool-or [type=bool, outer=(9)]
+    │    │    │              └── variable: notnull [type=bool, outer=(9)]
+    │    │    └── projections [outer=(10)]
+    │    │         └── CASE WHEN bool_or AND (5 IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
+    │    └── true [type=bool]
+    └── projections [outer=(11)]
+         └── variable: case [type=bool, outer=(11)]
+================================================================================
+EliminateProjectProject
+  Cost: 2152.56
+================================================================================
+   project
+    ├── columns: r:8(bool)
+    ├── inner-join-apply
+    │    ├── columns: x:1(int!null) case:11(bool)
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(11)
+    │    ├── scan xy
+    │    │    ├── columns: x:1(int!null)
+    │    │    └── key: (1)
+    │    ├── project
+    │    │    ├── columns: case:11(bool)
+    │    │    ├── outer: (1)
+    │    │    ├── cardinality: [1 - 1]
+    │    │    ├── key: ()
+    │    │    ├── fd: ()-->(11)
+    │    │    ├── scalar-group-by
+    │    │    │    ├── columns: bool_or:10(bool)
+    │    │    │    ├── outer: (1)
+    │    │    │    ├── cardinality: [1 - 1]
+    │    │    │    ├── key: ()
+    │    │    │    ├── fd: ()-->(10)
+    │    │    │    ├── project
+    │    │    │    │    ├── columns: notnull:9(bool)
+    │    │    │    │    ├── outer: (1)
+    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    ├── key: ()
+    │    │    │    │    ├── fd: ()-->(9)
+  - │    │    │    │    ├── project
+  - │    │    │    │    │    ├── columns: i:4(int)
+  + │    │    │    │    ├── select
+  + │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+  - │    │    │    │    │    ├── fd: ()-->(4)
+  - │    │    │    │    │    └── select
+  - │    │    │    │    │         ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │         ├── outer: (1)
+  - │    │    │    │    │         ├── cardinality: [0 - 1]
+  - │    │    │    │    │         ├── key: ()
+  - │    │    │    │    │         ├── fd: ()-->(3,4)
+  - │    │    │    │    │         ├── scan a
+  - │    │    │    │    │         │    ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │         │    ├── key: (3)
+  - │    │    │    │    │         │    └── fd: (3)-->(4)
+  - │    │    │    │    │         └── filters [type=bool, outer=(1,3,4), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  - │    │    │    │    │              ├── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  - │    │    │    │    │              └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    │    │    ├── fd: ()-->(3,4)
+  + │    │    │    │    │    ├── scan a
+  + │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+  + │    │    │    │    │    │    ├── key: (3)
+  + │    │    │    │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │    │    └── filters [type=bool, outer=(1,3,4), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  + │    │    │    │    │         ├── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  + │    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+    │    │    │    │    └── projections [outer=(4)]
+    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+    │    │    │    └── aggregations [outer=(9)]
+    │    │    │         └── bool-or [type=bool, outer=(9)]
+    │    │    │              └── variable: notnull [type=bool, outer=(9)]
+    │    │    └── projections [outer=(10)]
+    │    │         └── CASE WHEN bool_or AND (5 IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
+    │    └── true [type=bool]
+    └── projections [outer=(11)]
+         └── variable: case [type=bool, outer=(11)]
+================================================================================
+FoldNonNullIsNotNull
+  Cost: 2152.56
+================================================================================
+   project
+    ├── columns: r:8(bool)
+    ├── inner-join-apply
+    │    ├── columns: x:1(int!null) case:11(bool)
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(11)
+    │    ├── scan xy
+    │    │    ├── columns: x:1(int!null)
+    │    │    └── key: (1)
+    │    ├── project
+    │    │    ├── columns: case:11(bool)
+    │    │    ├── outer: (1)
+    │    │    ├── cardinality: [1 - 1]
+    │    │    ├── key: ()
+    │    │    ├── fd: ()-->(11)
+    │    │    ├── scalar-group-by
+    │    │    │    ├── columns: bool_or:10(bool)
+    │    │    │    ├── outer: (1)
+    │    │    │    ├── cardinality: [1 - 1]
+    │    │    │    ├── key: ()
+    │    │    │    ├── fd: ()-->(10)
+    │    │    │    ├── project
+    │    │    │    │    ├── columns: notnull:9(bool)
+    │    │    │    │    ├── outer: (1)
+    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    ├── key: ()
+    │    │    │    │    ├── fd: ()-->(9)
+    │    │    │    │    ├── select
+    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    ├── fd: ()-->(3,4)
+    │    │    │    │    │    ├── scan a
+    │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    │    ├── key: (3)
+    │    │    │    │    │    │    └── fd: (3)-->(4)
+    │    │    │    │    │    └── filters [type=bool, outer=(1,3,4), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │    │    │    │         ├── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+    │    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+    │    │    │    │    └── projections [outer=(4)]
+    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+    │    │    │    └── aggregations [outer=(9)]
+    │    │    │         └── bool-or [type=bool, outer=(9)]
+    │    │    │              └── variable: notnull [type=bool, outer=(9)]
+    │    │    └── projections [outer=(10)]
+  - │    │         └── CASE WHEN bool_or AND (5 IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
+  + │    │         └── CASE WHEN bool_or AND true THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
+    │    └── true [type=bool]
+    └── projections [outer=(11)]
+         └── variable: case [type=bool, outer=(11)]
+================================================================================
+SimplifyAnd
+  Cost: 2152.56
+================================================================================
+   project
+    ├── columns: r:8(bool)
+    ├── inner-join-apply
+    │    ├── columns: x:1(int!null) case:11(bool)
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(11)
+    │    ├── scan xy
+    │    │    ├── columns: x:1(int!null)
+    │    │    └── key: (1)
+    │    ├── project
+    │    │    ├── columns: case:11(bool)
+    │    │    ├── outer: (1)
+    │    │    ├── cardinality: [1 - 1]
+    │    │    ├── key: ()
+    │    │    ├── fd: ()-->(11)
+    │    │    ├── scalar-group-by
+    │    │    │    ├── columns: bool_or:10(bool)
+    │    │    │    ├── outer: (1)
+    │    │    │    ├── cardinality: [1 - 1]
+    │    │    │    ├── key: ()
+    │    │    │    ├── fd: ()-->(10)
+    │    │    │    ├── project
+    │    │    │    │    ├── columns: notnull:9(bool)
+    │    │    │    │    ├── outer: (1)
+    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    ├── key: ()
+    │    │    │    │    ├── fd: ()-->(9)
+    │    │    │    │    ├── select
+    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    ├── fd: ()-->(3,4)
+    │    │    │    │    │    ├── scan a
+    │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    │    ├── key: (3)
+    │    │    │    │    │    │    └── fd: (3)-->(4)
+    │    │    │    │    │    └── filters [type=bool, outer=(1,3,4), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │    │    │    │         ├── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+    │    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+    │    │    │    │    └── projections [outer=(4)]
+    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+    │    │    │    └── aggregations [outer=(9)]
+    │    │    │         └── bool-or [type=bool, outer=(9)]
+    │    │    │              └── variable: notnull [type=bool, outer=(9)]
+    │    │    └── projections [outer=(10)]
+  - │    │         └── CASE WHEN bool_or AND true THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
+  + │    │         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
+    │    └── true [type=bool]
+    └── projections [outer=(11)]
+         └── variable: case [type=bool, outer=(11)]
+--------------------------------------------------------------------------------
+EliminateSingletonAndOr (no changes)
+--------------------------------------------------------------------------------
+================================================================================
 TryDecorrelateProject
-  Cost: 2169.19
+  Cost: 2169.20
 ================================================================================
    project
     ├── columns: r:8(bool)
@@ -1058,47 +1690,59 @@ TryDecorrelateProject
   + │    │    │    ├── scalar-group-by
   + │    │    │    │    ├── columns: bool_or:10(bool)
     │    │    │    │    ├── outer: (1)
-  - │    │    │    │    ├── select
-  - │    │    │    │    │    ├── columns: k:3(int!null)
+  - │    │    │    │    ├── cardinality: [0 - 1]
   + │    │    │    │    ├── cardinality: [1 - 1]
-  + │    │    │    │    ├── key: ()
+    │    │    │    │    ├── key: ()
+  - │    │    │    │    ├── fd: ()-->(9)
+  - │    │    │    │    ├── select
+  - │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
   + │    │    │    │    ├── fd: ()-->(10)
   + │    │    │    │    ├── project
   + │    │    │    │    │    ├── columns: notnull:9(bool)
     │    │    │    │    │    ├── outer: (1)
-  - │    │    │    │    │    ├── key: (3)
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+  - │    │    │    │    │    ├── fd: ()-->(3,4)
   - │    │    │    │    │    ├── scan a
+  + │    │    │    │    │    ├── fd: ()-->(9)
   + │    │    │    │    │    ├── select
-    │    │    │    │    │    │    ├── columns: k:3(int!null)
-  - │    │    │    │    │    │    └── key: (3)
-  - │    │    │    │    │    └── filters [type=bool, outer=(1,3)]
-  - │    │    │    │    │         └── (x = k) IS NOT false [type=bool, outer=(1,3)]
-  - │    │    │    │    └── projections [outer=(3)]
-  - │    │    │    │         └── k IS NOT NULL [type=bool, outer=(3)]
+    │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │    │    ├── key: (3)
+  - │    │    │    │    │    │    └── fd: (3)-->(4)
+  - │    │    │    │    │    └── filters [type=bool, outer=(1,3,4), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  - │    │    │    │    │         ├── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  - │    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  - │    │    │    │    └── projections [outer=(4)]
+  - │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
   - │    │    │    └── aggregations [outer=(9)]
   - │    │    │         └── bool-or [type=bool, outer=(9)]
   - │    │    │              └── variable: notnull [type=bool, outer=(9)]
+  - │    │    └── projections [outer=(10)]
   + │    │    │    │    │    │    ├── outer: (1)
-  + │    │    │    │    │    │    ├── key: (3)
+  + │    │    │    │    │    │    ├── cardinality: [0 - 1]
+  + │    │    │    │    │    │    ├── key: ()
+  + │    │    │    │    │    │    ├── fd: ()-->(3,4)
   + │    │    │    │    │    │    ├── scan a
-  + │    │    │    │    │    │    │    ├── columns: k:3(int!null)
-  + │    │    │    │    │    │    │    └── key: (3)
-  + │    │    │    │    │    │    └── filters [type=bool, outer=(1,3)]
-  + │    │    │    │    │    │         └── (x = k) IS NOT false [type=bool, outer=(1,3)]
-  + │    │    │    │    │    └── projections [outer=(3)]
-  + │    │    │    │    │         └── k IS NOT NULL [type=bool, outer=(3)]
+  + │    │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+  + │    │    │    │    │    │    │    ├── key: (3)
+  + │    │    │    │    │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │    │    │    └── filters [type=bool, outer=(1,3,4), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  + │    │    │    │    │    │         ├── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  + │    │    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    │    │    └── projections [outer=(4)]
+  + │    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
   + │    │    │    │    └── aggregations [outer=(9)]
   + │    │    │    │         └── bool-or [type=bool, outer=(9)]
   + │    │    │    │              └── variable: notnull [type=bool, outer=(9)]
   + │    │    │    └── true [type=bool]
-    │    │    └── projections [outer=(1,10)]
-    │    │         └── CASE WHEN bool_or AND (x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(1,10)]
+  + │    │    └── projections [outer=(1,10)]
+    │    │         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
     │    └── true [type=bool]
     └── projections [outer=(11)]
          └── variable: case [type=bool, outer=(11)]
 ================================================================================
 TryDecorrelateScalarGroupBy
-  Cost: 12157.22
+  Cost: 2143.25
 ================================================================================
    project
     ├── columns: r:8(bool)
@@ -1127,8 +1771,11 @@ TryDecorrelateScalarGroupBy
   - │    │    │    │    ├── project
   - │    │    │    │    │    ├── columns: notnull:9(bool)
   - │    │    │    │    │    ├── outer: (1)
+  - │    │    │    │    │    ├── cardinality: [0 - 1]
+  - │    │    │    │    │    ├── key: ()
+  - │    │    │    │    │    ├── fd: ()-->(9)
   - │    │    │    │    │    ├── select
-  - │    │    │    │    │    │    ├── columns: k:3(int!null)
+  - │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
   + │    │    │    ├── group-by
   + │    │    │    │    ├── columns: x:1(int!null) bool_or:10(bool)
   + │    │    │    │    ├── grouping columns: x:1(int!null)
@@ -1136,43 +1783,54 @@ TryDecorrelateScalarGroupBy
   + │    │    │    │    ├── fd: (1)-->(10)
   + │    │    │    │    ├── left-join-apply
   + │    │    │    │    │    ├── columns: x:1(int!null) notnull:9(bool)
+  + │    │    │    │    │    ├── key: (1)
+  + │    │    │    │    │    ├── fd: (1)-->(9)
   + │    │    │    │    │    ├── scan xy
   + │    │    │    │    │    │    ├── columns: x:1(int!null)
   + │    │    │    │    │    │    └── key: (1)
   + │    │    │    │    │    ├── project
   + │    │    │    │    │    │    ├── columns: notnull:9(bool)
     │    │    │    │    │    │    ├── outer: (1)
-  - │    │    │    │    │    │    ├── key: (3)
+    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    │    ├── key: ()
+  - │    │    │    │    │    │    ├── fd: ()-->(3,4)
   - │    │    │    │    │    │    ├── scan a
+  + │    │    │    │    │    │    ├── fd: ()-->(9)
   + │    │    │    │    │    │    ├── select
-    │    │    │    │    │    │    │    ├── columns: k:3(int!null)
-  - │    │    │    │    │    │    │    └── key: (3)
-  - │    │    │    │    │    │    └── filters [type=bool, outer=(1,3)]
-  - │    │    │    │    │    │         └── (x = k) IS NOT false [type=bool, outer=(1,3)]
-  - │    │    │    │    │    └── projections [outer=(3)]
-  - │    │    │    │    │         └── k IS NOT NULL [type=bool, outer=(3)]
+    │    │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │    │    │    ├── key: (3)
+  - │    │    │    │    │    │    │    └── fd: (3)-->(4)
+  - │    │    │    │    │    │    └── filters [type=bool, outer=(1,3,4), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  - │    │    │    │    │    │         ├── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  - │    │    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  - │    │    │    │    │    └── projections [outer=(4)]
+  - │    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
   + │    │    │    │    │    │    │    ├── outer: (1)
-  + │    │    │    │    │    │    │    ├── key: (3)
+  + │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+  + │    │    │    │    │    │    │    ├── key: ()
+  + │    │    │    │    │    │    │    ├── fd: ()-->(3,4)
   + │    │    │    │    │    │    │    ├── scan a
-  + │    │    │    │    │    │    │    │    ├── columns: k:3(int!null)
-  + │    │    │    │    │    │    │    │    └── key: (3)
-  + │    │    │    │    │    │    │    └── filters [type=bool, outer=(1,3)]
-  + │    │    │    │    │    │    │         └── (x = k) IS NOT false [type=bool, outer=(1,3)]
-  + │    │    │    │    │    │    └── projections [outer=(3)]
-  + │    │    │    │    │    │         └── k IS NOT NULL [type=bool, outer=(3)]
+  + │    │    │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+  + │    │    │    │    │    │    │    │    ├── key: (3)
+  + │    │    │    │    │    │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │    │    │    │    └── filters [type=bool, outer=(1,3,4), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  + │    │    │    │    │    │    │         ├── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  + │    │    │    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    │    │    │    └── projections [outer=(4)]
+  + │    │    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
   + │    │    │    │    │    └── true [type=bool]
     │    │    │    │    └── aggregations [outer=(9)]
     │    │    │    │         └── bool-or [type=bool, outer=(9)]
     │    │    │    │              └── variable: notnull [type=bool, outer=(9)]
     │    │    │    └── true [type=bool]
     │    │    └── projections [outer=(1,10)]
-    │    │         └── CASE WHEN bool_or AND (x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(1,10)]
+    │    │         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
     │    └── true [type=bool]
     └── projections [outer=(11)]
          └── variable: case [type=bool, outer=(11)]
 ================================================================================
 TryDecorrelateProjectSelect
-  Cost: 15505.56
+  Cost: 2222.22
 ================================================================================
    project
     ├── columns: r:8(bool)
@@ -1196,54 +1854,65 @@ TryDecorrelateProjectSelect
   - │    │    │    │    ├── left-join-apply
   + │    │    │    │    ├── project
     │    │    │    │    │    ├── columns: x:1(int!null) notnull:9(bool)
+  - │    │    │    │    │    ├── key: (1)
+  - │    │    │    │    │    ├── fd: (1)-->(9)
   - │    │    │    │    │    ├── scan xy
   - │    │    │    │    │    │    ├── columns: x:1(int!null)
   - │    │    │    │    │    │    └── key: (1)
   - │    │    │    │    │    ├── project
   - │    │    │    │    │    │    ├── columns: notnull:9(bool)
   - │    │    │    │    │    │    ├── outer: (1)
+  - │    │    │    │    │    │    ├── cardinality: [0 - 1]
+  - │    │    │    │    │    │    ├── key: ()
+  - │    │    │    │    │    │    ├── fd: ()-->(9)
   - │    │    │    │    │    │    ├── select
-  - │    │    │    │    │    │    │    ├── columns: k:3(int!null)
+  - │    │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
   - │    │    │    │    │    │    │    ├── outer: (1)
-  - │    │    │    │    │    │    │    ├── key: (3)
+  - │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+  - │    │    │    │    │    │    │    ├── key: ()
+  - │    │    │    │    │    │    │    ├── fd: ()-->(3,4)
   - │    │    │    │    │    │    │    ├── scan a
-  - │    │    │    │    │    │    │    │    ├── columns: k:3(int!null)
-  - │    │    │    │    │    │    │    │    └── key: (3)
-  - │    │    │    │    │    │    │    └── filters [type=bool, outer=(1,3)]
-  - │    │    │    │    │    │    │         └── (x = k) IS NOT false [type=bool, outer=(1,3)]
-  - │    │    │    │    │    │    └── projections [outer=(3)]
-  - │    │    │    │    │    │         └── k IS NOT NULL [type=bool, outer=(3)]
+  - │    │    │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │    │    │    │    ├── key: (3)
+  - │    │    │    │    │    │    │    │    └── fd: (3)-->(4)
+  - │    │    │    │    │    │    │    └── filters [type=bool, outer=(1,3,4), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  - │    │    │    │    │    │    │         ├── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  - │    │    │    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  - │    │    │    │    │    │    └── projections [outer=(4)]
+  - │    │    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
   - │    │    │    │    │    └── true [type=bool]
   + │    │    │    │    │    └── left-join-apply
-  + │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
+  + │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) i:4(int) notnull:9(bool)
   + │    │    │    │    │         ├── key: (1,3)
-  + │    │    │    │    │         ├── fd: (1,3)-->(9)
+  + │    │    │    │    │         ├── fd: (1,3)-->(4,9)
   + │    │    │    │    │         ├── scan xy
   + │    │    │    │    │         │    ├── columns: x:1(int!null)
   + │    │    │    │    │         │    └── key: (1)
   + │    │    │    │    │         ├── project
-  + │    │    │    │    │         │    ├── columns: notnull:9(bool) k:3(int!null)
+  + │    │    │    │    │         │    ├── columns: notnull:9(bool) k:3(int!null) i:4(int)
   + │    │    │    │    │         │    ├── key: (3)
-  + │    │    │    │    │         │    ├── fd: (3)-->(9)
+  + │    │    │    │    │         │    ├── fd: (3)-->(4), (4)-->(9)
   + │    │    │    │    │         │    ├── scan a
-  + │    │    │    │    │         │    │    ├── columns: k:3(int!null)
-  + │    │    │    │    │         │    │    └── key: (3)
-  + │    │    │    │    │         │    └── projections [outer=(3)]
-  + │    │    │    │    │         │         └── k IS NOT NULL [type=bool, outer=(3)]
-  + │    │    │    │    │         └── filters [type=bool, outer=(1,3)]
-  + │    │    │    │    │              └── (x = k) IS NOT false [type=bool, outer=(1,3)]
+  + │    │    │    │    │         │    │    ├── columns: k:3(int!null) i:4(int)
+  + │    │    │    │    │         │    │    ├── key: (3)
+  + │    │    │    │    │         │    │    └── fd: (3)-->(4)
+  + │    │    │    │    │         │    └── projections [outer=(3,4)]
+  + │    │    │    │    │         │         └── i IS NOT NULL [type=bool, outer=(4)]
+  + │    │    │    │    │         └── filters [type=bool, outer=(1,3,4), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  + │    │    │    │    │              ├── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  + │    │    │    │    │              └── (i = 5) IS NOT false [type=bool, outer=(4)]
     │    │    │    │    └── aggregations [outer=(9)]
     │    │    │    │         └── bool-or [type=bool, outer=(9)]
     │    │    │    │              └── variable: notnull [type=bool, outer=(9)]
     │    │    │    └── true [type=bool]
     │    │    └── projections [outer=(1,10)]
-    │    │         └── CASE WHEN bool_or AND (x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(1,10)]
+    │    │         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
     │    └── true [type=bool]
     └── projections [outer=(11)]
          └── variable: case [type=bool, outer=(11)]
 ================================================================================
 DecorrelateJoin
-  Cost: 15505.56
+  Cost: 2222.22
 ================================================================================
    project
     ├── columns: r:8(bool)
@@ -1268,36 +1937,470 @@ DecorrelateJoin
     │    │    │    │    │    ├── columns: x:1(int!null) notnull:9(bool)
   - │    │    │    │    │    └── left-join-apply
   + │    │    │    │    │    └── left-join
-    │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
+    │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) i:4(int) notnull:9(bool)
     │    │    │    │    │         ├── key: (1,3)
-  - │    │    │    │    │         ├── fd: (1,3)-->(9)
-  + │    │    │    │    │         ├── fd: (3)-->(9)
+  - │    │    │    │    │         ├── fd: (1,3)-->(4,9)
+  + │    │    │    │    │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
     │    │    │    │    │         ├── scan xy
     │    │    │    │    │         │    ├── columns: x:1(int!null)
     │    │    │    │    │         │    └── key: (1)
     │    │    │    │    │         ├── project
-    │    │    │    │    │         │    ├── columns: notnull:9(bool) k:3(int!null)
+    │    │    │    │    │         │    ├── columns: notnull:9(bool) k:3(int!null) i:4(int)
     │    │    │    │    │         │    ├── key: (3)
-    │    │    │    │    │         │    ├── fd: (3)-->(9)
+    │    │    │    │    │         │    ├── fd: (3)-->(4), (4)-->(9)
     │    │    │    │    │         │    ├── scan a
-    │    │    │    │    │         │    │    ├── columns: k:3(int!null)
-    │    │    │    │    │         │    │    └── key: (3)
-    │    │    │    │    │         │    └── projections [outer=(3)]
-    │    │    │    │    │         │         └── k IS NOT NULL [type=bool, outer=(3)]
-    │    │    │    │    │         └── filters [type=bool, outer=(1,3)]
-    │    │    │    │    │              └── (x = k) IS NOT false [type=bool, outer=(1,3)]
+    │    │    │    │    │         │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │         │    │    ├── key: (3)
+    │    │    │    │    │         │    │    └── fd: (3)-->(4)
+    │    │    │    │    │         │    └── projections [outer=(3,4)]
+    │    │    │    │    │         │         └── i IS NOT NULL [type=bool, outer=(4)]
+    │    │    │    │    │         └── filters [type=bool, outer=(1,3,4), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │    │    │    │              ├── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+    │    │    │    │    │              └── (i = 5) IS NOT false [type=bool, outer=(4)]
     │    │    │    │    └── aggregations [outer=(9)]
     │    │    │    │         └── bool-or [type=bool, outer=(9)]
     │    │    │    │              └── variable: notnull [type=bool, outer=(9)]
     │    │    │    └── true [type=bool]
     │    │    └── projections [outer=(1,10)]
-    │    │         └── CASE WHEN bool_or AND (x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(1,10)]
+    │    │         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
+    │    └── true [type=bool]
+    └── projections [outer=(11)]
+         └── variable: case [type=bool, outer=(11)]
+================================================================================
+PushFilterIntoJoinRight
+  Cost: 2220.56
+================================================================================
+   project
+    ├── columns: r:8(bool)
+    ├── select
+    │    ├── columns: x:1(int!null) case:11(bool)
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(11)
+    │    ├── project
+    │    │    ├── columns: case:11(bool) x:1(int!null)
+    │    │    ├── key: (1)
+    │    │    ├── fd: (1)-->(11)
+    │    │    ├── select
+    │    │    │    ├── columns: x:1(int!null) bool_or:10(bool)
+    │    │    │    ├── key: (1)
+    │    │    │    ├── fd: (1)-->(10)
+    │    │    │    ├── group-by
+    │    │    │    │    ├── columns: x:1(int!null) bool_or:10(bool)
+    │    │    │    │    ├── grouping columns: x:1(int!null)
+    │    │    │    │    ├── key: (1)
+    │    │    │    │    ├── fd: (1)-->(10)
+    │    │    │    │    ├── project
+    │    │    │    │    │    ├── columns: x:1(int!null) notnull:9(bool)
+    │    │    │    │    │    └── left-join
+    │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) i:4(int) notnull:9(bool)
+    │    │    │    │    │         ├── key: (1,3)
+    │    │    │    │    │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
+    │    │    │    │    │         ├── scan xy
+    │    │    │    │    │         │    ├── columns: x:1(int!null)
+    │    │    │    │    │         │    └── key: (1)
+  - │    │    │    │    │         ├── project
+  - │    │    │    │    │         │    ├── columns: notnull:9(bool) k:3(int!null) i:4(int)
+  + │    │    │    │    │         ├── select
+  + │    │    │    │    │         │    ├── columns: k:3(int!null) i:4(int) notnull:9(bool)
+    │    │    │    │    │         │    ├── key: (3)
+    │    │    │    │    │         │    ├── fd: (3)-->(4), (4)-->(9)
+  - │    │    │    │    │         │    ├── scan a
+  - │    │    │    │    │         │    │    ├── columns: k:3(int!null) i:4(int)
+  + │    │    │    │    │         │    ├── project
+  + │    │    │    │    │         │    │    ├── columns: notnull:9(bool) k:3(int!null) i:4(int)
+    │    │    │    │    │         │    │    ├── key: (3)
+  - │    │    │    │    │         │    │    └── fd: (3)-->(4)
+  - │    │    │    │    │         │    └── projections [outer=(3,4)]
+  - │    │    │    │    │         │         └── i IS NOT NULL [type=bool, outer=(4)]
+  - │    │    │    │    │         └── filters [type=bool, outer=(1,3,4), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  - │    │    │    │    │              ├── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  - │    │    │    │    │              └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    │    │         │    │    ├── fd: (3)-->(4), (4)-->(9)
+  + │    │    │    │    │         │    │    ├── scan a
+  + │    │    │    │    │         │    │    │    ├── columns: k:3(int!null) i:4(int)
+  + │    │    │    │    │         │    │    │    ├── key: (3)
+  + │    │    │    │    │         │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │    │         │    │    └── projections [outer=(3,4)]
+  + │    │    │    │    │         │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+  + │    │    │    │    │         │    └── filters [type=bool, outer=(4)]
+  + │    │    │    │    │         │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    │    │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  + │    │    │    │    │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+    │    │    │    │    └── aggregations [outer=(9)]
+    │    │    │    │         └── bool-or [type=bool, outer=(9)]
+    │    │    │    │              └── variable: notnull [type=bool, outer=(9)]
+    │    │    │    └── true [type=bool]
+    │    │    └── projections [outer=(1,10)]
+    │    │         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
+    │    └── true [type=bool]
+    └── projections [outer=(11)]
+         └── variable: case [type=bool, outer=(11)]
+================================================================================
+PushSelectIntoProject
+  Cost: 2206.67
+================================================================================
+   project
+    ├── columns: r:8(bool)
+    ├── select
+    │    ├── columns: x:1(int!null) case:11(bool)
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(11)
+    │    ├── project
+    │    │    ├── columns: case:11(bool) x:1(int!null)
+    │    │    ├── key: (1)
+    │    │    ├── fd: (1)-->(11)
+    │    │    ├── select
+    │    │    │    ├── columns: x:1(int!null) bool_or:10(bool)
+    │    │    │    ├── key: (1)
+    │    │    │    ├── fd: (1)-->(10)
+    │    │    │    ├── group-by
+    │    │    │    │    ├── columns: x:1(int!null) bool_or:10(bool)
+    │    │    │    │    ├── grouping columns: x:1(int!null)
+    │    │    │    │    ├── key: (1)
+    │    │    │    │    ├── fd: (1)-->(10)
+    │    │    │    │    ├── project
+    │    │    │    │    │    ├── columns: x:1(int!null) notnull:9(bool)
+    │    │    │    │    │    └── left-join
+    │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) i:4(int) notnull:9(bool)
+    │    │    │    │    │         ├── key: (1,3)
+    │    │    │    │    │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
+    │    │    │    │    │         ├── scan xy
+    │    │    │    │    │         │    ├── columns: x:1(int!null)
+    │    │    │    │    │         │    └── key: (1)
+    │    │    │    │    │         ├── select
+    │    │    │    │    │         │    ├── columns: k:3(int!null) i:4(int) notnull:9(bool)
+    │    │    │    │    │         │    ├── key: (3)
+    │    │    │    │    │         │    ├── fd: (3)-->(4), (4)-->(9)
+    │    │    │    │    │         │    ├── project
+    │    │    │    │    │         │    │    ├── columns: notnull:9(bool) k:3(int!null) i:4(int)
+    │    │    │    │    │         │    │    ├── key: (3)
+    │    │    │    │    │         │    │    ├── fd: (3)-->(4), (4)-->(9)
+  - │    │    │    │    │         │    │    ├── scan a
+  + │    │    │    │    │         │    │    ├── select
+    │    │    │    │    │         │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │         │    │    │    ├── key: (3)
+  - │    │    │    │    │         │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │    │         │    │    │    ├── fd: (3)-->(4)
+  + │    │    │    │    │         │    │    │    ├── scan a
+  + │    │    │    │    │         │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+  + │    │    │    │    │         │    │    │    │    ├── key: (3)
+  + │    │    │    │    │         │    │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │    │         │    │    │    └── filters [type=bool, outer=(4)]
+  + │    │    │    │    │         │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+    │    │    │    │    │         │    │    └── projections [outer=(3,4)]
+    │    │    │    │    │         │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+  - │    │    │    │    │         │    └── filters [type=bool, outer=(4)]
+  - │    │    │    │    │         │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    │    │         │    └── true [type=bool]
+    │    │    │    │    │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │    │    │    │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+    │    │    │    │    └── aggregations [outer=(9)]
+    │    │    │    │         └── bool-or [type=bool, outer=(9)]
+    │    │    │    │              └── variable: notnull [type=bool, outer=(9)]
+    │    │    │    └── true [type=bool]
+    │    │    └── projections [outer=(1,10)]
+    │    │         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
+    │    └── true [type=bool]
+    └── projections [outer=(11)]
+         └── variable: case [type=bool, outer=(11)]
+================================================================================
+EliminateSelect
+  Cost: 2207.22
+================================================================================
+   project
+    ├── columns: r:8(bool)
+    ├── select
+    │    ├── columns: x:1(int!null) case:11(bool)
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(11)
+    │    ├── project
+    │    │    ├── columns: case:11(bool) x:1(int!null)
+    │    │    ├── key: (1)
+    │    │    ├── fd: (1)-->(11)
+    │    │    ├── select
+    │    │    │    ├── columns: x:1(int!null) bool_or:10(bool)
+    │    │    │    ├── key: (1)
+    │    │    │    ├── fd: (1)-->(10)
+    │    │    │    ├── group-by
+    │    │    │    │    ├── columns: x:1(int!null) bool_or:10(bool)
+    │    │    │    │    ├── grouping columns: x:1(int!null)
+    │    │    │    │    ├── key: (1)
+    │    │    │    │    ├── fd: (1)-->(10)
+    │    │    │    │    ├── project
+    │    │    │    │    │    ├── columns: x:1(int!null) notnull:9(bool)
+    │    │    │    │    │    └── left-join
+    │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) i:4(int) notnull:9(bool)
+    │    │    │    │    │         ├── key: (1,3)
+    │    │    │    │    │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
+    │    │    │    │    │         ├── scan xy
+    │    │    │    │    │         │    ├── columns: x:1(int!null)
+    │    │    │    │    │         │    └── key: (1)
+  - │    │    │    │    │         ├── select
+  - │    │    │    │    │         │    ├── columns: k:3(int!null) i:4(int) notnull:9(bool)
+  + │    │    │    │    │         ├── project
+  + │    │    │    │    │         │    ├── columns: notnull:9(bool) k:3(int!null) i:4(int)
+    │    │    │    │    │         │    ├── key: (3)
+    │    │    │    │    │         │    ├── fd: (3)-->(4), (4)-->(9)
+  - │    │    │    │    │         │    ├── project
+  - │    │    │    │    │         │    │    ├── columns: notnull:9(bool) k:3(int!null) i:4(int)
+  + │    │    │    │    │         │    ├── select
+  + │    │    │    │    │         │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │         │    │    ├── key: (3)
+  - │    │    │    │    │         │    │    ├── fd: (3)-->(4), (4)-->(9)
+  - │    │    │    │    │         │    │    ├── select
+  + │    │    │    │    │         │    │    ├── fd: (3)-->(4)
+  + │    │    │    │    │         │    │    ├── scan a
+    │    │    │    │    │         │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │         │    │    │    ├── key: (3)
+  - │    │    │    │    │         │    │    │    ├── fd: (3)-->(4)
+  - │    │    │    │    │         │    │    │    ├── scan a
+  - │    │    │    │    │         │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │         │    │    │    │    ├── key: (3)
+  - │    │    │    │    │         │    │    │    │    └── fd: (3)-->(4)
+  - │    │    │    │    │         │    │    │    └── filters [type=bool, outer=(4)]
+  - │    │    │    │    │         │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  - │    │    │    │    │         │    │    └── projections [outer=(3,4)]
+  - │    │    │    │    │         │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+  - │    │    │    │    │         │    └── true [type=bool]
+  + │    │    │    │    │         │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │    │         │    │    └── filters [type=bool, outer=(4)]
+  + │    │    │    │    │         │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    │    │         │    └── projections [outer=(3,4)]
+  + │    │    │    │    │         │         └── i IS NOT NULL [type=bool, outer=(4)]
+    │    │    │    │    │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │    │    │    │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+    │    │    │    │    └── aggregations [outer=(9)]
+    │    │    │    │         └── bool-or [type=bool, outer=(9)]
+    │    │    │    │              └── variable: notnull [type=bool, outer=(9)]
+    │    │    │    └── true [type=bool]
+    │    │    └── projections [outer=(1,10)]
+    │    │         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
+    │    └── true [type=bool]
+    └── projections [outer=(11)]
+         └── variable: case [type=bool, outer=(11)]
+================================================================================
+PruneJoinRightCols
+  Cost: 2210.56
+================================================================================
+   project
+    ├── columns: r:8(bool)
+    ├── select
+    │    ├── columns: x:1(int!null) case:11(bool)
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(11)
+    │    ├── project
+    │    │    ├── columns: case:11(bool) x:1(int!null)
+    │    │    ├── key: (1)
+    │    │    ├── fd: (1)-->(11)
+    │    │    ├── select
+    │    │    │    ├── columns: x:1(int!null) bool_or:10(bool)
+    │    │    │    ├── key: (1)
+    │    │    │    ├── fd: (1)-->(10)
+    │    │    │    ├── group-by
+    │    │    │    │    ├── columns: x:1(int!null) bool_or:10(bool)
+    │    │    │    │    ├── grouping columns: x:1(int!null)
+    │    │    │    │    ├── key: (1)
+    │    │    │    │    ├── fd: (1)-->(10)
+    │    │    │    │    ├── project
+    │    │    │    │    │    ├── columns: x:1(int!null) notnull:9(bool)
+    │    │    │    │    │    └── left-join
+  - │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) i:4(int) notnull:9(bool)
+  + │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
+    │    │    │    │    │         ├── key: (1,3)
+  - │    │    │    │    │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
+  + │    │    │    │    │         ├── fd: (3)-->(9)
+    │    │    │    │    │         ├── scan xy
+    │    │    │    │    │         │    ├── columns: x:1(int!null)
+    │    │    │    │    │         │    └── key: (1)
+    │    │    │    │    │         ├── project
+  - │    │    │    │    │         │    ├── columns: notnull:9(bool) k:3(int!null) i:4(int)
+  + │    │    │    │    │         │    ├── columns: k:3(int!null) notnull:9(bool)
+    │    │    │    │    │         │    ├── key: (3)
+  - │    │    │    │    │         │    ├── fd: (3)-->(4), (4)-->(9)
+  - │    │    │    │    │         │    ├── select
+  - │    │    │    │    │         │    │    ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │         │    │    ├── key: (3)
+  - │    │    │    │    │         │    │    ├── fd: (3)-->(4)
+  - │    │    │    │    │         │    │    ├── scan a
+  - │    │    │    │    │         │    │    │    ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │         │    │    │    ├── key: (3)
+  - │    │    │    │    │         │    │    │    └── fd: (3)-->(4)
+  - │    │    │    │    │         │    │    └── filters [type=bool, outer=(4)]
+  - │    │    │    │    │         │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  - │    │    │    │    │         │    └── projections [outer=(3,4)]
+  - │    │    │    │    │         │         └── i IS NOT NULL [type=bool, outer=(4)]
+  + │    │    │    │    │         │    ├── fd: (3)-->(9)
+  + │    │    │    │    │         │    └── project
+  + │    │    │    │    │         │         ├── columns: notnull:9(bool) k:3(int!null) i:4(int)
+  + │    │    │    │    │         │         ├── key: (3)
+  + │    │    │    │    │         │         ├── fd: (3)-->(4), (4)-->(9)
+  + │    │    │    │    │         │         ├── select
+  + │    │    │    │    │         │         │    ├── columns: k:3(int!null) i:4(int)
+  + │    │    │    │    │         │         │    ├── key: (3)
+  + │    │    │    │    │         │         │    ├── fd: (3)-->(4)
+  + │    │    │    │    │         │         │    ├── scan a
+  + │    │    │    │    │         │         │    │    ├── columns: k:3(int!null) i:4(int)
+  + │    │    │    │    │         │         │    │    ├── key: (3)
+  + │    │    │    │    │         │         │    │    └── fd: (3)-->(4)
+  + │    │    │    │    │         │         │    └── filters [type=bool, outer=(4)]
+  + │    │    │    │    │         │         │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    │    │         │         └── projections [outer=(3,4)]
+  + │    │    │    │    │         │              └── i IS NOT NULL [type=bool, outer=(4)]
+    │    │    │    │    │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │    │    │    │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+    │    │    │    │    └── aggregations [outer=(9)]
+    │    │    │    │         └── bool-or [type=bool, outer=(9)]
+    │    │    │    │              └── variable: notnull [type=bool, outer=(9)]
+    │    │    │    └── true [type=bool]
+    │    │    └── projections [outer=(1,10)]
+    │    │         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
+    │    └── true [type=bool]
+    └── projections [outer=(11)]
+         └── variable: case [type=bool, outer=(11)]
+================================================================================
+PruneProjectCols
+  Cost: 2210.56
+================================================================================
+   project
+    ├── columns: r:8(bool)
+    ├── select
+    │    ├── columns: x:1(int!null) case:11(bool)
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(11)
+    │    ├── project
+    │    │    ├── columns: case:11(bool) x:1(int!null)
+    │    │    ├── key: (1)
+    │    │    ├── fd: (1)-->(11)
+    │    │    ├── select
+    │    │    │    ├── columns: x:1(int!null) bool_or:10(bool)
+    │    │    │    ├── key: (1)
+    │    │    │    ├── fd: (1)-->(10)
+    │    │    │    ├── group-by
+    │    │    │    │    ├── columns: x:1(int!null) bool_or:10(bool)
+    │    │    │    │    ├── grouping columns: x:1(int!null)
+    │    │    │    │    ├── key: (1)
+    │    │    │    │    ├── fd: (1)-->(10)
+    │    │    │    │    ├── project
+    │    │    │    │    │    ├── columns: x:1(int!null) notnull:9(bool)
+    │    │    │    │    │    └── left-join
+    │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
+    │    │    │    │    │         ├── key: (1,3)
+    │    │    │    │    │         ├── fd: (3)-->(9)
+    │    │    │    │    │         ├── scan xy
+    │    │    │    │    │         │    ├── columns: x:1(int!null)
+    │    │    │    │    │         │    └── key: (1)
+    │    │    │    │    │         ├── project
+    │    │    │    │    │         │    ├── columns: k:3(int!null) notnull:9(bool)
+    │    │    │    │    │         │    ├── key: (3)
+    │    │    │    │    │         │    ├── fd: (3)-->(9)
+    │    │    │    │    │         │    └── project
+  - │    │    │    │    │         │         ├── columns: notnull:9(bool) k:3(int!null) i:4(int)
+  + │    │    │    │    │         │         ├── columns: notnull:9(bool) k:3(int!null)
+    │    │    │    │    │         │         ├── key: (3)
+  - │    │    │    │    │         │         ├── fd: (3)-->(4), (4)-->(9)
+  + │    │    │    │    │         │         ├── fd: (3)-->(9)
+    │    │    │    │    │         │         ├── select
+    │    │    │    │    │         │         │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │         │         │    ├── key: (3)
+    │    │    │    │    │         │         │    ├── fd: (3)-->(4)
+    │    │    │    │    │         │         │    ├── scan a
+    │    │    │    │    │         │         │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │         │         │    │    ├── key: (3)
+    │    │    │    │    │         │         │    │    └── fd: (3)-->(4)
+    │    │    │    │    │         │         │    └── filters [type=bool, outer=(4)]
+    │    │    │    │    │         │         │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+    │    │    │    │    │         │         └── projections [outer=(3,4)]
+    │    │    │    │    │         │              └── i IS NOT NULL [type=bool, outer=(4)]
+    │    │    │    │    │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │    │    │    │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+    │    │    │    │    └── aggregations [outer=(9)]
+    │    │    │    │         └── bool-or [type=bool, outer=(9)]
+    │    │    │    │              └── variable: notnull [type=bool, outer=(9)]
+    │    │    │    └── true [type=bool]
+    │    │    └── projections [outer=(1,10)]
+    │    │         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
+    │    └── true [type=bool]
+    └── projections [outer=(11)]
+         └── variable: case [type=bool, outer=(11)]
+================================================================================
+EliminateProject
+  Cost: 2207.22
+================================================================================
+   project
+    ├── columns: r:8(bool)
+    ├── select
+    │    ├── columns: x:1(int!null) case:11(bool)
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(11)
+    │    ├── project
+    │    │    ├── columns: case:11(bool) x:1(int!null)
+    │    │    ├── key: (1)
+    │    │    ├── fd: (1)-->(11)
+    │    │    ├── select
+    │    │    │    ├── columns: x:1(int!null) bool_or:10(bool)
+    │    │    │    ├── key: (1)
+    │    │    │    ├── fd: (1)-->(10)
+    │    │    │    ├── group-by
+    │    │    │    │    ├── columns: x:1(int!null) bool_or:10(bool)
+    │    │    │    │    ├── grouping columns: x:1(int!null)
+    │    │    │    │    ├── key: (1)
+    │    │    │    │    ├── fd: (1)-->(10)
+    │    │    │    │    ├── project
+    │    │    │    │    │    ├── columns: x:1(int!null) notnull:9(bool)
+    │    │    │    │    │    └── left-join
+    │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
+    │    │    │    │    │         ├── key: (1,3)
+    │    │    │    │    │         ├── fd: (3)-->(9)
+    │    │    │    │    │         ├── scan xy
+    │    │    │    │    │         │    ├── columns: x:1(int!null)
+    │    │    │    │    │         │    └── key: (1)
+    │    │    │    │    │         ├── project
+  - │    │    │    │    │         │    ├── columns: k:3(int!null) notnull:9(bool)
+  + │    │    │    │    │         │    ├── columns: notnull:9(bool) k:3(int!null)
+    │    │    │    │    │         │    ├── key: (3)
+    │    │    │    │    │         │    ├── fd: (3)-->(9)
+  - │    │    │    │    │         │    └── project
+  - │    │    │    │    │         │         ├── columns: notnull:9(bool) k:3(int!null)
+  - │    │    │    │    │         │         ├── key: (3)
+  - │    │    │    │    │         │         ├── fd: (3)-->(9)
+  - │    │    │    │    │         │         ├── select
+  - │    │    │    │    │         │         │    ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │         │         │    ├── key: (3)
+  - │    │    │    │    │         │         │    ├── fd: (3)-->(4)
+  - │    │    │    │    │         │         │    ├── scan a
+  - │    │    │    │    │         │         │    │    ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │         │         │    │    ├── key: (3)
+  - │    │    │    │    │         │         │    │    └── fd: (3)-->(4)
+  - │    │    │    │    │         │         │    └── filters [type=bool, outer=(4)]
+  - │    │    │    │    │         │         │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  - │    │    │    │    │         │         └── projections [outer=(3,4)]
+  - │    │    │    │    │         │              └── i IS NOT NULL [type=bool, outer=(4)]
+  + │    │    │    │    │         │    ├── select
+  + │    │    │    │    │         │    │    ├── columns: k:3(int!null) i:4(int)
+  + │    │    │    │    │         │    │    ├── key: (3)
+  + │    │    │    │    │         │    │    ├── fd: (3)-->(4)
+  + │    │    │    │    │         │    │    ├── scan a
+  + │    │    │    │    │         │    │    │    ├── columns: k:3(int!null) i:4(int)
+  + │    │    │    │    │         │    │    │    ├── key: (3)
+  + │    │    │    │    │         │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │    │         │    │    └── filters [type=bool, outer=(4)]
+  + │    │    │    │    │         │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    │    │         │    └── projections [outer=(3,4)]
+  + │    │    │    │    │         │         └── i IS NOT NULL [type=bool, outer=(4)]
+    │    │    │    │    │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │    │    │    │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+    │    │    │    │    └── aggregations [outer=(9)]
+    │    │    │    │         └── bool-or [type=bool, outer=(9)]
+    │    │    │    │              └── variable: notnull [type=bool, outer=(9)]
+    │    │    │    └── true [type=bool]
+    │    │    └── projections [outer=(1,10)]
+    │    │         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
     │    └── true [type=bool]
     └── projections [outer=(11)]
          └── variable: case [type=bool, outer=(11)]
 ================================================================================
 EliminateGroupByProject
-  Cost: 12172.22
+  Cost: 2197.22
 ================================================================================
    project
     ├── columns: r:8(bool)
@@ -1331,13 +2434,20 @@ EliminateGroupByProject
   - │    │    │    │    │         │    ├── columns: notnull:9(bool) k:3(int!null)
   - │    │    │    │    │         │    ├── key: (3)
   - │    │    │    │    │         │    ├── fd: (3)-->(9)
-  - │    │    │    │    │         │    ├── scan a
-  - │    │    │    │    │         │    │    ├── columns: k:3(int!null)
-  - │    │    │    │    │         │    │    └── key: (3)
-  - │    │    │    │    │         │    └── projections [outer=(3)]
-  - │    │    │    │    │         │         └── k IS NOT NULL [type=bool, outer=(3)]
-  - │    │    │    │    │         └── filters [type=bool, outer=(1,3)]
-  - │    │    │    │    │              └── (x = k) IS NOT false [type=bool, outer=(1,3)]
+  - │    │    │    │    │         │    ├── select
+  - │    │    │    │    │         │    │    ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │         │    │    ├── key: (3)
+  - │    │    │    │    │         │    │    ├── fd: (3)-->(4)
+  - │    │    │    │    │         │    │    ├── scan a
+  - │    │    │    │    │         │    │    │    ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │         │    │    │    ├── key: (3)
+  - │    │    │    │    │         │    │    │    └── fd: (3)-->(4)
+  - │    │    │    │    │         │    │    └── filters [type=bool, outer=(4)]
+  - │    │    │    │    │         │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  - │    │    │    │    │         │    └── projections [outer=(3,4)]
+  - │    │    │    │    │         │         └── i IS NOT NULL [type=bool, outer=(4)]
+  - │    │    │    │    │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  - │    │    │    │    │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
   + │    │    │    │    ├── left-join
   + │    │    │    │    │    ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
   + │    │    │    │    │    ├── key: (1,3)
@@ -1349,25 +2459,32 @@ EliminateGroupByProject
   + │    │    │    │    │    │    ├── columns: notnull:9(bool) k:3(int!null)
   + │    │    │    │    │    │    ├── key: (3)
   + │    │    │    │    │    │    ├── fd: (3)-->(9)
-  + │    │    │    │    │    │    ├── scan a
-  + │    │    │    │    │    │    │    ├── columns: k:3(int!null)
-  + │    │    │    │    │    │    │    └── key: (3)
-  + │    │    │    │    │    │    └── projections [outer=(3)]
-  + │    │    │    │    │    │         └── k IS NOT NULL [type=bool, outer=(3)]
-  + │    │    │    │    │    └── filters [type=bool, outer=(1,3)]
-  + │    │    │    │    │         └── (x = k) IS NOT false [type=bool, outer=(1,3)]
+  + │    │    │    │    │    │    ├── select
+  + │    │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+  + │    │    │    │    │    │    │    ├── key: (3)
+  + │    │    │    │    │    │    │    ├── fd: (3)-->(4)
+  + │    │    │    │    │    │    │    ├── scan a
+  + │    │    │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+  + │    │    │    │    │    │    │    │    ├── key: (3)
+  + │    │    │    │    │    │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │    │    │    │    └── filters [type=bool, outer=(4)]
+  + │    │    │    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    │    │    │    └── projections [outer=(3,4)]
+  + │    │    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+  + │    │    │    │    │    └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  + │    │    │    │    │         └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
     │    │    │    │    └── aggregations [outer=(9)]
     │    │    │    │         └── bool-or [type=bool, outer=(9)]
     │    │    │    │              └── variable: notnull [type=bool, outer=(9)]
     │    │    │    └── true [type=bool]
     │    │    └── projections [outer=(1,10)]
-    │    │         └── CASE WHEN bool_or AND (x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(1,10)]
+    │    │         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
     │    └── true [type=bool]
     └── projections [outer=(11)]
          └── variable: case [type=bool, outer=(11)]
 ================================================================================
 EliminateSelect
-  Cost: 12186.67
+  Cost: 2211.67
 ================================================================================
    project
     ├── columns: r:8(bool)
@@ -1409,37 +2526,48 @@ EliminateSelect
   - │    │    │    │    │    │    └── key: (1)
   - │    │    │    │    │    ├── project
   - │    │    │    │    │    │    ├── columns: notnull:9(bool) k:3(int!null)
-  - │    │    │    │    │    │    ├── key: (3)
+  + │    │    │    │    │    ├── select
+  + │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    │    ├── key: (3)
   - │    │    │    │    │    │    ├── fd: (3)-->(9)
-  - │    │    │    │    │    │    ├── scan a
-  - │    │    │    │    │    │    │    ├── columns: k:3(int!null)
-  - │    │    │    │    │    │    │    └── key: (3)
-  - │    │    │    │    │    │    └── projections [outer=(3)]
-  - │    │    │    │    │    │         └── k IS NOT NULL [type=bool, outer=(3)]
-  - │    │    │    │    │    └── filters [type=bool, outer=(1,3)]
-  - │    │    │    │    │         └── (x = k) IS NOT false [type=bool, outer=(1,3)]
+  - │    │    │    │    │    │    ├── select
+  + │    │    │    │    │    │    ├── fd: (3)-->(4)
+  + │    │    │    │    │    │    ├── scan a
+    │    │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    │    │    ├── key: (3)
+  - │    │    │    │    │    │    │    ├── fd: (3)-->(4)
+  - │    │    │    │    │    │    │    ├── scan a
+  - │    │    │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │    │    │    │    ├── key: (3)
+  - │    │    │    │    │    │    │    │    └── fd: (3)-->(4)
+  - │    │    │    │    │    │    │    └── filters [type=bool, outer=(4)]
+  - │    │    │    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  - │    │    │    │    │    │    └── projections [outer=(3,4)]
+  - │    │    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+  - │    │    │    │    │    └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  - │    │    │    │    │         └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
   - │    │    │    │    └── aggregations [outer=(9)]
   - │    │    │    │         └── bool-or [type=bool, outer=(9)]
   - │    │    │    │              └── variable: notnull [type=bool, outer=(9)]
   - │    │    │    └── true [type=bool]
-  + │    │    │    │    │    ├── scan a
-  + │    │    │    │    │    │    ├── columns: k:3(int!null)
-  + │    │    │    │    │    │    └── key: (3)
-  + │    │    │    │    │    └── projections [outer=(3)]
-  + │    │    │    │    │         └── k IS NOT NULL [type=bool, outer=(3)]
-  + │    │    │    │    └── filters [type=bool, outer=(1,3)]
-  + │    │    │    │         └── (x = k) IS NOT false [type=bool, outer=(1,3)]
+  + │    │    │    │    │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │    │    │    └── filters [type=bool, outer=(4)]
+  + │    │    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    │    │    └── projections [outer=(3,4)]
+  + │    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+  + │    │    │    │    └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  + │    │    │    │         └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
   + │    │    │    └── aggregations [outer=(9)]
   + │    │    │         └── bool-or [type=bool, outer=(9)]
   + │    │    │              └── variable: notnull [type=bool, outer=(9)]
     │    │    └── projections [outer=(1,10)]
-    │    │         └── CASE WHEN bool_or AND (x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(1,10)]
+    │    │         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
     │    └── true [type=bool]
     └── projections [outer=(11)]
          └── variable: case [type=bool, outer=(11)]
 ================================================================================
 EliminateSelect
-  Cost: 12190.00
+  Cost: 2215.00
 ================================================================================
    project
     ├── columns: r:8(bool)
@@ -1481,38 +2609,49 @@ EliminateSelect
   - │    │    │    │    │    └── key: (1)
   - │    │    │    │    ├── project
   - │    │    │    │    │    ├── columns: notnull:9(bool) k:3(int!null)
-  - │    │    │    │    │    ├── key: (3)
+  + │    │    │    │    ├── select
+  + │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    ├── key: (3)
   - │    │    │    │    │    ├── fd: (3)-->(9)
-  - │    │    │    │    │    ├── scan a
-  - │    │    │    │    │    │    ├── columns: k:3(int!null)
-  - │    │    │    │    │    │    └── key: (3)
-  - │    │    │    │    │    └── projections [outer=(3)]
-  - │    │    │    │    │         └── k IS NOT NULL [type=bool, outer=(3)]
-  - │    │    │    │    └── filters [type=bool, outer=(1,3)]
-  - │    │    │    │         └── (x = k) IS NOT false [type=bool, outer=(1,3)]
+  - │    │    │    │    │    ├── select
+  + │    │    │    │    │    ├── fd: (3)-->(4)
+  + │    │    │    │    │    ├── scan a
+    │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    │    ├── key: (3)
+  - │    │    │    │    │    │    ├── fd: (3)-->(4)
+  - │    │    │    │    │    │    ├── scan a
+  - │    │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │    │    │    ├── key: (3)
+  - │    │    │    │    │    │    │    └── fd: (3)-->(4)
+  - │    │    │    │    │    │    └── filters [type=bool, outer=(4)]
+  - │    │    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  - │    │    │    │    │    └── projections [outer=(3,4)]
+  - │    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+  - │    │    │    │    └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  - │    │    │    │         └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
   - │    │    │    └── aggregations [outer=(9)]
   - │    │    │         └── bool-or [type=bool, outer=(9)]
   - │    │    │              └── variable: notnull [type=bool, outer=(9)]
   - │    │    └── projections [outer=(1,10)]
-  - │    │         └── CASE WHEN bool_or AND (x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(1,10)]
+  - │    │         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
   - │    └── true [type=bool]
-  + │    │    │    │    ├── scan a
-  + │    │    │    │    │    ├── columns: k:3(int!null)
-  + │    │    │    │    │    └── key: (3)
-  + │    │    │    │    └── projections [outer=(3)]
-  + │    │    │    │         └── k IS NOT NULL [type=bool, outer=(3)]
-  + │    │    │    └── filters [type=bool, outer=(1,3)]
-  + │    │    │         └── (x = k) IS NOT false [type=bool, outer=(1,3)]
+  + │    │    │    │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │    │    └── filters [type=bool, outer=(4)]
+  + │    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    │    └── projections [outer=(3,4)]
+  + │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+  + │    │    │    └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  + │    │    │         └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
   + │    │    └── aggregations [outer=(9)]
   + │    │         └── bool-or [type=bool, outer=(9)]
   + │    │              └── variable: notnull [type=bool, outer=(9)]
   + │    └── projections [outer=(1,10)]
-  + │         └── CASE WHEN bool_or AND (x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(1,10)]
+  + │         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
     └── projections [outer=(11)]
          └── variable: case [type=bool, outer=(11)]
 ================================================================================
 PruneProjectCols
-  Cost: 12190.00
+  Cost: 2215.00
 ================================================================================
    project
     ├── columns: r:8(bool)
@@ -1537,23 +2676,31 @@ PruneProjectCols
     │    │    │    │    ├── columns: notnull:9(bool) k:3(int!null)
     │    │    │    │    ├── key: (3)
     │    │    │    │    ├── fd: (3)-->(9)
-    │    │    │    │    ├── scan a
-    │    │    │    │    │    ├── columns: k:3(int!null)
-    │    │    │    │    │    └── key: (3)
-    │    │    │    │    └── projections [outer=(3)]
-    │    │    │    │         └── k IS NOT NULL [type=bool, outer=(3)]
-    │    │    │    └── filters [type=bool, outer=(1,3)]
-    │    │    │         └── (x = k) IS NOT false [type=bool, outer=(1,3)]
+    │    │    │    │    ├── select
+    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    ├── key: (3)
+    │    │    │    │    │    ├── fd: (3)-->(4)
+    │    │    │    │    │    ├── scan a
+    │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    │    ├── key: (3)
+    │    │    │    │    │    │    └── fd: (3)-->(4)
+    │    │    │    │    │    └── filters [type=bool, outer=(4)]
+    │    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+    │    │    │    │    └── projections [outer=(3,4)]
+    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+    │    │    │    └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │    │         └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
     │    │    └── aggregations [outer=(9)]
     │    │         └── bool-or [type=bool, outer=(9)]
     │    │              └── variable: notnull [type=bool, outer=(9)]
-    │    └── projections [outer=(1,10)]
-    │         └── CASE WHEN bool_or AND (x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(1,10)]
+  - │    └── projections [outer=(1,10)]
+  + │    └── projections [outer=(10)]
+    │         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
     └── projections [outer=(11)]
          └── variable: case [type=bool, outer=(11)]
 ================================================================================
 InlineProjectInProject
-  Cost: 12170.00
+  Cost: 2195.00
 ================================================================================
    project
     ├── columns: r:8(bool)
@@ -1588,72 +2735,54 @@ InlineProjectInProject
   - │    │    │    │    └── key: (1)
   - │    │    │    ├── project
   - │    │    │    │    ├── columns: notnull:9(bool) k:3(int!null)
-  - │    │    │    │    ├── key: (3)
+  + │    │    │    ├── select
+  + │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    ├── key: (3)
   - │    │    │    │    ├── fd: (3)-->(9)
-  - │    │    │    │    ├── scan a
-  - │    │    │    │    │    ├── columns: k:3(int!null)
-  - │    │    │    │    │    └── key: (3)
-  - │    │    │    │    └── projections [outer=(3)]
-  - │    │    │    │         └── k IS NOT NULL [type=bool, outer=(3)]
-  - │    │    │    └── filters [type=bool, outer=(1,3)]
-  - │    │    │         └── (x = k) IS NOT false [type=bool, outer=(1,3)]
+  - │    │    │    │    ├── select
+  + │    │    │    │    ├── fd: (3)-->(4)
+  + │    │    │    │    ├── scan a
+    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    ├── key: (3)
+  - │    │    │    │    │    ├── fd: (3)-->(4)
+  - │    │    │    │    │    ├── scan a
+  - │    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+  - │    │    │    │    │    │    ├── key: (3)
+  - │    │    │    │    │    │    └── fd: (3)-->(4)
+  - │    │    │    │    │    └── filters [type=bool, outer=(4)]
+  - │    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  - │    │    │    │    └── projections [outer=(3,4)]
+  - │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+  - │    │    │    └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  - │    │    │         └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
   - │    │    └── aggregations [outer=(9)]
   - │    │         └── bool-or [type=bool, outer=(9)]
   - │    │              └── variable: notnull [type=bool, outer=(9)]
-  - │    └── projections [outer=(1,10)]
-  - │         └── CASE WHEN bool_or AND (x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(1,10)]
+  - │    └── projections [outer=(10)]
+  - │         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
   - └── projections [outer=(11)]
   -      └── variable: case [type=bool, outer=(11)]
-  + │    │    │    ├── scan a
-  + │    │    │    │    ├── columns: k:3(int!null)
-  + │    │    │    │    └── key: (3)
-  + │    │    │    └── projections [outer=(3)]
-  + │    │    │         └── k IS NOT NULL [type=bool, outer=(3)]
-  + │    │    └── filters [type=bool, outer=(1,3)]
-  + │    │         └── (x = k) IS NOT false [type=bool, outer=(1,3)]
+  + │    │    │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │    └── filters [type=bool, outer=(4)]
+  + │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    └── projections [outer=(3,4)]
+  + │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+  + │    │    └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  + │    │         └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
   + │    └── aggregations [outer=(9)]
   + │         └── bool-or [type=bool, outer=(9)]
   + │              └── variable: notnull [type=bool, outer=(9)]
-  + └── projections [outer=(1,10)]
-  +      └── CASE WHEN bool_or AND (x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(1,10)]
+  + └── projections [outer=(10)]
+  +      └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
 --------------------------------------------------------------------------------
 GenerateIndexScans (no changes)
 --------------------------------------------------------------------------------
-================================================================================
-GenerateIndexScans
-  Cost: 12160.00
-================================================================================
-   project
-    ├── columns: r:8(bool)
-    ├── group-by
-    │    ├── columns: x:1(int!null) bool_or:10(bool)
-    │    ├── grouping columns: x:1(int!null)
-    │    ├── key: (1)
-    │    ├── fd: (1)-->(10)
-    │    ├── left-join
-    │    │    ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
-    │    │    ├── key: (1,3)
-    │    │    ├── fd: (3)-->(9)
-    │    │    ├── scan xy
-    │    │    │    ├── columns: x:1(int!null)
-    │    │    │    └── key: (1)
-    │    │    ├── project
-    │    │    │    ├── columns: notnull:9(bool) k:3(int!null)
-    │    │    │    ├── key: (3)
-    │    │    │    ├── fd: (3)-->(9)
-  - │    │    │    ├── scan a
-  + │    │    │    ├── scan a@secondary
-    │    │    │    │    ├── columns: k:3(int!null)
-    │    │    │    │    └── key: (3)
-    │    │    │    └── projections [outer=(3)]
-    │    │    │         └── k IS NOT NULL [type=bool, outer=(3)]
-    │    │    └── filters [type=bool, outer=(1,3)]
-    │    │         └── (x = k) IS NOT false [type=bool, outer=(1,3)]
-    │    └── aggregations [outer=(9)]
-    │         └── bool-or [type=bool, outer=(9)]
-    │              └── variable: notnull [type=bool, outer=(9)]
-    └── projections [outer=(1,10)]
-         └── CASE WHEN bool_or AND (x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(1,10)]
+--------------------------------------------------------------------------------
+GenerateIndexScans (no changes)
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+GenerateConstrainedScans (no changes)
+--------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 CommuteLeftJoin (higher cost)
 --------------------------------------------------------------------------------
@@ -1676,24 +2805,81 @@ CommuteLeftJoin (higher cost)
     │    │    │    ├── columns: notnull:9(bool) k:3(int!null)
     │    │    │    ├── key: (3)
     │    │    │    ├── fd: (3)-->(9)
-    │    │    │    ├── scan a@secondary
-    │    │    │    │    ├── columns: k:3(int!null)
-    │    │    │    │    └── key: (3)
-    │    │    │    └── projections [outer=(3)]
-    │    │    │         └── k IS NOT NULL [type=bool, outer=(3)]
+    │    │    │    ├── select
+    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    ├── key: (3)
+    │    │    │    │    ├── fd: (3)-->(4)
+    │    │    │    │    ├── scan a
+    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    ├── key: (3)
+    │    │    │    │    │    └── fd: (3)-->(4)
+    │    │    │    │    └── filters [type=bool, outer=(4)]
+    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+    │    │    │    └── projections [outer=(3,4)]
+    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
   + │    │    ├── scan xy
   + │    │    │    ├── columns: x:1(int!null)
   + │    │    │    └── key: (1)
-    │    │    └── filters [type=bool, outer=(1,3)]
-    │    │         └── (x = k) IS NOT false [type=bool, outer=(1,3)]
+    │    │    └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │         └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
     │    └── aggregations [outer=(9)]
     │         └── bool-or [type=bool, outer=(9)]
     │              └── variable: notnull [type=bool, outer=(9)]
-    └── projections [outer=(1,10)]
-         └── CASE WHEN bool_or AND (x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(1,10)]
---------------------------------------------------------------------------------
-GenerateMergeJoins (no changes)
---------------------------------------------------------------------------------
+    └── projections [outer=(10)]
+         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
+================================================================================
+GenerateMergeJoins
+  Cost: 2190.00
+================================================================================
+   project
+    ├── columns: r:8(bool)
+    ├── group-by
+    │    ├── columns: x:1(int!null) bool_or:10(bool)
+    │    ├── grouping columns: x:1(int!null)
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(10)
+  - │    ├── left-join
+  + │    ├── left-join (merge)
+    │    │    ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
+    │    │    ├── key: (1,3)
+    │    │    ├── fd: (3)-->(9)
+    │    │    ├── scan xy
+    │    │    │    ├── columns: x:1(int!null)
+  - │    │    │    └── key: (1)
+  + │    │    │    ├── key: (1)
+  + │    │    │    └── ordering: +1
+    │    │    ├── project
+    │    │    │    ├── columns: notnull:9(bool) k:3(int!null)
+    │    │    │    ├── key: (3)
+    │    │    │    ├── fd: (3)-->(9)
+  + │    │    │    ├── ordering: +3
+    │    │    │    ├── select
+    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    ├── key: (3)
+    │    │    │    │    ├── fd: (3)-->(4)
+  + │    │    │    │    ├── ordering: +3
+    │    │    │    │    ├── scan a
+    │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+    │    │    │    │    │    ├── key: (3)
+  - │    │    │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │    │    ├── fd: (3)-->(4)
+  + │    │    │    │    │    └── ordering: +3
+    │    │    │    │    └── filters [type=bool, outer=(4)]
+    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+    │    │    │    └── projections [outer=(3,4)]
+    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+  - │    │    └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  - │    │         └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+  + │    │    └── merge-on
+  + │    │         ├── left ordering: +1
+  + │    │         ├── right ordering: +3
+  + │    │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  + │    │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+    │    └── aggregations [outer=(9)]
+    │         └── bool-or [type=bool, outer=(9)]
+    │              └── variable: notnull [type=bool, outer=(9)]
+    └── projections [outer=(10)]
+         └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
 --------------------------------------------------------------------------------
 CommuteRightJoin (no changes)
 --------------------------------------------------------------------------------
@@ -1702,7 +2888,7 @@ GenerateMergeJoins (no changes)
 --------------------------------------------------------------------------------
 ================================================================================
 Final best expression
-  Cost: 12160.00
+  Cost: 2190.00
 ================================================================================
   project
    ├── columns: r:8(bool)
@@ -1711,26 +2897,40 @@ Final best expression
    │    ├── grouping columns: x:1(int!null)
    │    ├── key: (1)
    │    ├── fd: (1)-->(10)
-   │    ├── left-join
+   │    ├── left-join (merge)
    │    │    ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
    │    │    ├── key: (1,3)
    │    │    ├── fd: (3)-->(9)
    │    │    ├── scan xy
    │    │    │    ├── columns: x:1(int!null)
-   │    │    │    └── key: (1)
+   │    │    │    ├── key: (1)
+   │    │    │    └── ordering: +1
    │    │    ├── project
    │    │    │    ├── columns: notnull:9(bool) k:3(int!null)
    │    │    │    ├── key: (3)
    │    │    │    ├── fd: (3)-->(9)
-   │    │    │    ├── scan a@secondary
-   │    │    │    │    ├── columns: k:3(int!null)
-   │    │    │    │    └── key: (3)
-   │    │    │    └── projections [outer=(3)]
-   │    │    │         └── k IS NOT NULL [type=bool, outer=(3)]
-   │    │    └── filters [type=bool, outer=(1,3)]
-   │    │         └── (x = k) IS NOT false [type=bool, outer=(1,3)]
+   │    │    │    ├── ordering: +3
+   │    │    │    ├── select
+   │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+   │    │    │    │    ├── key: (3)
+   │    │    │    │    ├── fd: (3)-->(4)
+   │    │    │    │    ├── ordering: +3
+   │    │    │    │    ├── scan a
+   │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+   │    │    │    │    │    ├── key: (3)
+   │    │    │    │    │    ├── fd: (3)-->(4)
+   │    │    │    │    │    └── ordering: +3
+   │    │    │    │    └── filters [type=bool, outer=(4)]
+   │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
+   │    │    │    └── projections [outer=(3,4)]
+   │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
+   │    │    └── merge-on
+   │    │         ├── left ordering: +1
+   │    │         ├── right ordering: +3
+   │    │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+   │    │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
    │    └── aggregations [outer=(9)]
    │         └── bool-or [type=bool, outer=(9)]
    │              └── variable: notnull [type=bool, outer=(9)]
-   └── projections [outer=(1,10)]
-        └── CASE WHEN bool_or AND (x IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(1,10)]
+   └── projections [outer=(10)]
+        └── CASE WHEN bool_or THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -3103,7 +3103,7 @@ project
 
 # Any with IS NULL.
 opt
-SELECT * FROM a WHERE (i = ANY(SELECT y FROM xy)) IS NULL
+SELECT * FROM a WHERE (i = ANY(SELECT y FROM xy WHERE x=k)) IS NULL
 ----
 project
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
@@ -3122,22 +3122,33 @@ project
       │    │    ├── grouping columns: k:1(int!null)
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(2-5,9)
-      │    │    ├── left-join
-      │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) y:7(int) notnull:8(bool)
-      │    │    │    ├── fd: (1)-->(2-5), (7)~~>(8)
+      │    │    ├── left-join (merge)
+      │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int) notnull:8(bool)
+      │    │    │    ├── key: (1,6)
+      │    │    │    ├── fd: (1)-->(2-5), (6)-->(7), (7)~~>(8), (1,6)-->(8)
       │    │    │    ├── scan a
       │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
       │    │    │    │    ├── key: (1)
-      │    │    │    │    └── fd: (1)-->(2-5)
+      │    │    │    │    ├── fd: (1)-->(2-5)
+      │    │    │    │    └── ordering: +1
       │    │    │    ├── project
-      │    │    │    │    ├── columns: notnull:8(bool) y:7(int)
-      │    │    │    │    ├── fd: (7)-->(8)
+      │    │    │    │    ├── columns: notnull:8(bool) x:6(int!null) y:7(int)
+      │    │    │    │    ├── key: (6)
+      │    │    │    │    ├── fd: (6)-->(7), (7)-->(8)
+      │    │    │    │    ├── ordering: +6
       │    │    │    │    ├── scan xy
-      │    │    │    │    │    └── columns: y:7(int)
-      │    │    │    │    └── projections [outer=(7)]
+      │    │    │    │    │    ├── columns: x:6(int!null) y:7(int)
+      │    │    │    │    │    ├── key: (6)
+      │    │    │    │    │    ├── fd: (6)-->(7)
+      │    │    │    │    │    └── ordering: +6
+      │    │    │    │    └── projections [outer=(6,7)]
       │    │    │    │         └── y IS NOT NULL [type=bool, outer=(7)]
-      │    │    │    └── filters [type=bool, outer=(2,7)]
-      │    │    │         └── (i = y) IS NOT false [type=bool, outer=(2,7)]
+      │    │    │    └── merge-on
+      │    │    │         ├── left ordering: +1
+      │    │    │         ├── right ordering: +6
+      │    │    │         └── filters [type=bool, outer=(1,2,6,7), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+      │    │    │              ├── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+      │    │    │              └── (i = y) IS NOT false [type=bool, outer=(2,7)]
       │    │    └── aggregations [outer=(2-5,8)]
       │    │         ├── bool-or [type=bool, outer=(8)]
       │    │         │    └── variable: notnull [type=bool, outer=(8)]
@@ -3154,44 +3165,75 @@ project
       └── filters [type=bool, outer=(10), constraints=(/10: [/NULL - /NULL]; tight), fd=()-->(10)]
            └── case IS NULL [type=bool, outer=(10), constraints=(/10: [/NULL - /NULL]; tight)]
 
+# Any with uncorrelated subquery (should not be hoisted).
+opt
+SELECT * FROM a WHERE (i = ANY(SELECT y FROM xy)) IS NULL
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters [type=bool, outer=(2)]
+      └── is [type=bool, outer=(2)]
+           ├── any: eq [type=bool, outer=(2)]
+           │    ├── scan xy
+           │    │    └── columns: y:7(int)
+           │    └── variable: i [type=int, outer=(2)]
+           └── null [type=unknown]
+
 # ALL with non-trivial expression on left.
 opt
-SELECT i*i/100 < ALL(SELECT y FROM xy) AS r, s FROM a
+SELECT i*i/100 < ALL(SELECT y FROM xy WHERE x=k) AS r, s FROM a
 ----
 project
  ├── columns: r:8(bool) s:4(string)
  ├── side-effects
  ├── group-by
- │    ├── columns: s:4(string) scalar:9(decimal) bool_or:11(bool) rownum:13(int!null)
- │    ├── grouping columns: rownum:13(int!null)
+ │    ├── columns: k:1(int!null) s:4(string) scalar:9(decimal) bool_or:11(bool)
+ │    ├── grouping columns: k:1(int!null)
  │    ├── side-effects
- │    ├── key: (13)
- │    ├── fd: (13)-->(4,9,11)
- │    ├── left-join
- │    │    ├── columns: s:4(string) y:7(int) scalar:9(decimal) notnull:10(bool) rownum:13(int!null)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(4,9,11)
+ │    ├── left-join (merge)
+ │    │    ├── columns: k:1(int!null) s:4(string) x:6(int) y:7(int) scalar:9(decimal) notnull:10(bool)
  │    │    ├── side-effects
- │    │    ├── fd: (13)-->(4,9), (7)~~>(10)
- │    │    ├── row-number
- │    │    │    ├── columns: s:4(string) scalar:9(decimal) rownum:13(int!null)
- │    │    │    ├── side-effects
- │    │    │    ├── key: (13)
- │    │    │    ├── fd: (13)-->(4,9)
- │    │    │    └── project
- │    │    │         ├── columns: scalar:9(decimal) s:4(string)
- │    │    │         ├── side-effects
- │    │    │         ├── scan a
- │    │    │         │    └── columns: i:2(int) s:4(string)
- │    │    │         └── projections [outer=(2,4), side-effects]
- │    │    │              └── (i * i) / 100 [type=decimal, outer=(2), side-effects]
+ │    │    ├── key: (1,6)
+ │    │    ├── fd: (1)-->(4,9), (6)-->(7), (7)~~>(10), (1,6)-->(10)
  │    │    ├── project
- │    │    │    ├── columns: notnull:10(bool) y:7(int)
- │    │    │    ├── fd: (7)-->(10)
+ │    │    │    ├── columns: scalar:9(decimal) k:1(int!null) s:4(string)
+ │    │    │    ├── side-effects
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(4,9)
+ │    │    │    ├── ordering: +1
+ │    │    │    ├── scan a
+ │    │    │    │    ├── columns: k:1(int!null) i:2(int) s:4(string)
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    ├── fd: (1)-->(2,4)
+ │    │    │    │    └── ordering: +1
+ │    │    │    └── projections [outer=(1,2,4), side-effects]
+ │    │    │         └── (i * i) / 100 [type=decimal, outer=(2), side-effects]
+ │    │    ├── project
+ │    │    │    ├── columns: notnull:10(bool) x:6(int!null) y:7(int)
+ │    │    │    ├── key: (6)
+ │    │    │    ├── fd: (6)-->(7), (7)-->(10)
+ │    │    │    ├── ordering: +6
  │    │    │    ├── scan xy
- │    │    │    │    └── columns: y:7(int)
- │    │    │    └── projections [outer=(7)]
+ │    │    │    │    ├── columns: x:6(int!null) y:7(int)
+ │    │    │    │    ├── key: (6)
+ │    │    │    │    ├── fd: (6)-->(7)
+ │    │    │    │    └── ordering: +6
+ │    │    │    └── projections [outer=(6,7)]
  │    │    │         └── y IS NOT NULL [type=bool, outer=(7)]
- │    │    └── filters [type=bool, outer=(7,9)]
- │    │         └── (scalar >= y) IS NOT false [type=bool, outer=(7,9)]
+ │    │    └── merge-on
+ │    │         ├── left ordering: +1
+ │    │         ├── right ordering: +6
+ │    │         └── filters [type=bool, outer=(1,6,7,9), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │              ├── x = k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+ │    │              └── (scalar >= y) IS NOT false [type=bool, outer=(7,9)]
  │    └── aggregations [outer=(4,9,10)]
  │         ├── bool-or [type=bool, outer=(10)]
  │         │    └── variable: notnull [type=bool, outer=(10)]
@@ -3436,6 +3478,20 @@ project
                 │         └── true [type=bool]
                 └── filters [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
                      └── y = i [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
+
+# Don't hoist uncorrelated subquery.
+opt
+SELECT i < ANY(SELECT y FROM xy) AS r FROM a
+----
+project
+ ├── columns: r:8(bool)
+ ├── scan a
+ │    └── columns: i:2(int)
+ └── projections [outer=(2)]
+      └── any: lt [type=bool, outer=(2)]
+           ├── scan xy
+           │    └── columns: y:7(int)
+           └── variable: i [type=int, outer=(2)]
 
 # --------------------------------------------------
 # HoistJoinSubquery


### PR DESCRIPTION
Backport 1/1 commits from #30018.

/cc @cockroachdb/release

---

When decorrelating, don't hoist an ANY expression when its subquery is not
correlated, as in this example:

  SELECT b < ANY(SELECT y FROM xy) FROM ab

Executing this as a join + groupby is much slower than caching the subquery
and performing an ANY operation on it for each row in ab.

Note that ANY is still hoisted when it's at the top-level of a WHERE clause,
since it's first transformed to EXISTS, and EXISTS are always hoisted. This is
desirable, however, since EXISTS is implemented by a semi-join, which is much
faster than using a subquery.

Release note: None
