### PR TITLE
opt: Replace left joins on foreign keys with inner joins

### DIFF
--- a/pkg/sql/opt/catalog.go
+++ b/pkg/sql/opt/catalog.go
@@ -88,6 +88,9 @@ type Table interface {
 	// information_schema tables.
 	IsVirtualTable() bool
 
+	// InternalID returns the table's globally-unique ID.
+	InternalID() uint64
+
 	// ColumnCount returns the number of columns in the table.
 	ColumnCount() int
 
@@ -183,6 +186,9 @@ type Index interface {
 	// when the query contains a numeric index reference.
 	InternalID() uint64
 
+	// Table returns a reference to the table this index is based on.
+	Table() Table
+
 	// IsInverted returns true if this is a JSON inverted index.
 	IsInverted() bool
 
@@ -249,6 +255,11 @@ type Index interface {
 	// Column returns the ith IndexColumn within the index definition, where
 	// i < ColumnCount.
 	Column(i int) IndexColumn
+
+	// ForeignKey returns a ForeignKeyReference if this index is part
+	// of an outbound foreign key relation. Returns false for the second
+	// return value if there is no foreign key reference on this index.
+	ForeignKey() (ForeignKeyReference, bool)
 }
 
 // TableStatistic is an interface to a table statistic. Each statistic is
@@ -278,6 +289,21 @@ type TableStatistic interface {
 	NullCount() uint64
 
 	// TODO(radu): add Histogram().
+}
+
+// ForeignKeyReference is a struct representing an outbound foreign key reference.
+// It has accessors for table and index IDs, as well as the prefix length.
+type ForeignKeyReference struct {
+	// Table contains the referenced table's internal ID.
+	TableID uint64
+
+	// Index contains the ID of the index that represents the
+	// destination table's side of the foreign key relation.
+	IndexID uint64
+
+	// PrefixLen contains the length of columns that form the foreign key
+	// relation in the current and destination indexes.
+	PrefixLen int32
 }
 
 // FormatCatalogTable nicely formats a catalog table using a treeprinter for

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -360,6 +360,24 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 11  filter       ·          ·
 11  ·            filter     pkic.relkind = 'i'
 
+# Ensure that left joins on non-null foreign keys turn into inner joins
+statement ok
+CREATE TABLE cards(id INT PRIMARY KEY, cust INT NOT NULL REFERENCES customers(id))
+
+query TTT
+EXPLAIN SELECT * FROM cards LEFT OUTER JOIN customers ON customers.id = cards.cust 
+----
+join       ·               ·
+ │         type            inner
+ │         equality        (cust) = (id)
+ │         mergeJoinOrder  +"(cust=id)"
+ ├── scan  ·               ·
+ │         table           cards@cards_auto_index_fk_cust_ref_customers
+ │         spans           ALL
+ └── scan  ·               ·
+·          table           customers@primary
+·          spans           ALL
+
 # Tests for filter propagation through joins.
 
 statement ok

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -363,6 +363,16 @@ func (md *Metadata) Table(tabID TableID) Table {
 	return md.tables[tabID.index()].tab
 }
 
+// TableByDescID looks up the catalog table associated with the given descriptor id.
+func (md *Metadata) TableByDescID(tabID uint64) Table {
+	for _, mdTab := range md.tables {
+		if mdTab.tab.InternalID() == tabID {
+			return mdTab.tab
+		}
+	}
+	return nil
+}
+
 // TableAnnotation returns the given annotation that is associated with the
 // given table. If the table has no such annotation, TableAnnotation returns
 // nil.

--- a/pkg/sql/opt/norm/join.go
+++ b/pkg/sql/opt/norm/join.go
@@ -240,6 +240,38 @@ func (c *CustomFuncs) GetEquivColsWithEquivType(col opt.ColumnID, fd *props.Func
 	return res
 }
 
+// eqConditionsToColMap returns a map of left columns to right columns
+// that are being equated in the specified conditions. leftCols is used
+// to identify which column is a left column.
+func (c *CustomFuncs) eqConditionsToColMap(
+	conds memo.ListID, leftCols opt.ColSet,
+) map[opt.ColumnID]opt.ColumnID {
+	eqColMap := make(map[opt.ColumnID]opt.ColumnID)
+
+	for _, condition := range c.mem.LookupList(conds) {
+		eqExpr := c.mem.NormExpr(condition).AsEq()
+		if eqExpr == nil {
+			continue
+		}
+
+		leftVarExpr := c.mem.NormExpr(eqExpr.Left()).AsVariable()
+		rightVarExpr := c.mem.NormExpr(eqExpr.Right()).AsVariable()
+		if leftVarExpr == nil || rightVarExpr == nil {
+			continue
+		}
+
+		leftCol := c.ExtractColID(leftVarExpr.Col())
+		rightCol := c.ExtractColID(rightVarExpr.Col())
+		// Normalize leftCol to come from leftCols.
+		if !leftCols.Contains(int(leftCol)) {
+			leftCol, rightCol = rightCol, leftCol
+		}
+		eqColMap[leftCol] = rightCol
+	}
+
+	return eqColMap
+}
+
 // JoinFiltersMatchAllLeftRows returns true when each row in the given join's
 // left input matches at least one row from the right input, according to the
 // join filters. This is true when the following conditions are satisfied:
@@ -279,6 +311,9 @@ func (c *CustomFuncs) JoinFiltersMatchAllLeftRows(left, right, filters memo.Grou
 	md := c.f.Metadata()
 
 	var leftTab, rightTab opt.Table
+	var leftTabID, rightTabID opt.TableID
+	// Any left columns that don't match conditions 1-4 end up in this set.
+	var remainingLeftCols opt.ColSet
 	for _, condition := range c.mem.LookupList(filtersExpr.Conditions()) {
 		eqExpr := c.mem.NormExpr(condition).AsEq()
 		if eqExpr == nil {
@@ -312,8 +347,8 @@ func (c *CustomFuncs) JoinFiltersMatchAllLeftRows(left, right, filters memo.Grou
 		}
 
 		if leftTab == nil {
-			leftTabID := md.ColumnTableID(leftCol)
-			rightTabID := md.ColumnTableID(rightCol)
+			leftTabID = md.ColumnTableID(leftCol)
+			rightTabID = md.ColumnTableID(rightCol)
 			if leftTabID == 0 || rightTabID == 0 {
 				// Condition #2: Columns don't come from base tables.
 				return false
@@ -335,12 +370,98 @@ func (c *CustomFuncs) JoinFiltersMatchAllLeftRows(left, right, filters memo.Grou
 				return false
 			}
 		} else {
-			// TODO(andyk): Check foreign key case.
-			return false
+			// Column could be a potential foreign key match so save it.
+			remainingLeftCols.Add(int(leftCol))
 		}
 	}
 
-	return true
+	if remainingLeftCols.Empty() {
+		return true
+	}
+
+	var leftRightColMap map[opt.ColumnID]opt.ColumnID
+	// Condition #5: All remaining left columns correspond to a foreign key relation.
+	for i, cnt := 0, leftTab.IndexCount(); i < cnt; i++ {
+		index := leftTab.Index(i)
+		fkRef, ok := index.ForeignKey()
+
+		if !ok {
+			// No foreign key reference on this index.
+			continue
+		}
+
+		fkTable := md.TableByDescID(fkRef.TableID)
+		fkPrefix := int(fkRef.PrefixLen)
+		if fkPrefix <= 0 {
+			panic("fkPrefix should always be positive")
+		}
+		if fkTable == nil || fkTable.Fingerprint() != rightTab.Fingerprint() {
+			continue
+		}
+
+		// Find the index corresponding to fkRef.IndexID - the index
+		// on the right table that forms the destination end of
+		// the fk relation.
+		var fkIndex opt.Index
+		found := false
+		for j, cnt2 := 0, fkTable.IndexCount(); j < cnt2; j++ {
+			if fkTable.Index(j).InternalID() == fkRef.IndexID {
+				found = true
+				fkIndex = fkTable.Index(j)
+				break
+			}
+		}
+		if !found {
+			panic("Foreign key referenced index not found in table")
+		}
+
+		var leftIndexCols opt.ColSet
+		for j := 0; j < fkPrefix; j++ {
+			ord := index.Column(j).Ordinal
+			leftIndexCols.Add(int(leftTabID.ColumnID(ord)))
+		}
+
+		if !remainingLeftCols.SubsetOf(leftIndexCols) {
+			continue
+		}
+
+		// Build a mapping of left to right columns as specified
+		// in the filter conditions - this is used to detect
+		// whether the filter conditions follow the foreign key
+		// constraint exactly.
+		if leftRightColMap == nil {
+			leftRightColMap = c.eqConditionsToColMap(filtersExpr.Conditions(), leftCols)
+		}
+
+		// Loop through all columns in fk index that also exist in LHS of match condition,
+		// and ensure that they correspond to the correct RHS column according to the
+		// foreign key relation. In other words, each LHS column's index ordinal
+		// in the foreign key index matches that of the RHS column (in the index being
+		// referenced) that it's being equated to.
+		fkMatch := true
+		for j := 0; j < fkPrefix; j++ {
+			indexLeftCol := leftTabID.ColumnID(index.Column(j).Ordinal)
+
+			// Not every fk column needs to be in the equality conditions.
+			if !remainingLeftCols.Contains(int(indexLeftCol)) {
+				continue
+			}
+
+			indexRightCol := rightTabID.ColumnID(fkIndex.Column(j).Ordinal)
+
+			if rightCol, ok := leftRightColMap[indexLeftCol]; !ok || rightCol != indexRightCol {
+				fkMatch = false
+				break
+			}
+		}
+
+		// Condition #5 satisfied.
+		if fkMatch {
+			return true
+		}
+	}
+
+	return false
 }
 
 // deriveUnfilteredCols returns the subset of the given group's output columns

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -20,6 +20,36 @@ TABLE b
       └── x int not null
 
 exec-ddl
+CREATE TABLE c (x INT PRIMARY KEY, y INT NOT NULL REFERENCES a(k), z INT NOT NULL, UNIQUE (x,z))
+----
+TABLE c
+ ├── x int not null
+ ├── y int not null
+ ├── z int not null
+ ├── INDEX primary
+ │    └── x int not null
+ ├── INDEX secondary
+ │    ├── x int not null
+ │    └── z int not null
+ └── INDEX c_auto_index_fk_y_ref_a
+      ├── y int not null
+      └── x int not null
+
+exec-ddl
+CREATE TABLE d (x INT PRIMARY KEY, y INT NOT NULL, z INT NOT NULL, FOREIGN KEY (y,z) REFERENCES c(x,z))
+----
+TABLE d
+ ├── x int not null
+ ├── y int not null
+ ├── z int not null
+ ├── INDEX primary
+ │    └── x int not null
+ └── INDEX d_auto_index_fk_y_ref_c
+      ├── y int not null
+      ├── z int not null
+      └── x int not null
+
+exec-ddl
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
 ----
 TABLE xy
@@ -1398,6 +1428,125 @@ inner-join
  └── filters [type=bool, outer=(1,6,11), constraints=(/1: (/NULL - ]; /6: (/NULL - ]; /11: (/NULL - ]), fd=(1)==(6,11), (6)==(1,11), (11)==(1,6)]
       ├── a.k = a.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
       └── a.k = a.k [type=bool, outer=(1,11), constraints=(/1: (/NULL - ]; /11: (/NULL - ])]
+
+# Left joins on a foreign key turn into inner joins.
+opt
+SELECT *
+FROM c
+LEFT OUTER JOIN a
+ON c.y = a.k
+----
+inner-join
+ ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) k:4(int!null) i:5(int) f:6(float!null) s:7(string) j:8(jsonb)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (4)-->(5-8), (2)==(4), (4)==(2)
+ ├── scan c
+ │    ├── columns: x:1(int!null) y:2(int!null) z:3(int!null)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ ├── scan a
+ │    ├── columns: k:4(int!null) i:5(int) f:6(float!null) s:7(string) j:8(jsonb)
+ │    ├── key: (4)
+ │    └── fd: (4)-->(5-8)
+ └── filters [type=bool, outer=(2,4), constraints=(/2: (/NULL - ]; /4: (/NULL - ]), fd=(2)==(4), (4)==(2)]
+      └── y = k [type=bool, outer=(2,4), constraints=(/2: (/NULL - ]; /4: (/NULL - ])]
+
+# Left joins on a multiple-column foreign key turn into inner joins.
+opt
+SELECT *
+FROM d
+LEFT OUTER JOIN c
+ON d.z = c.z
+AND d.y = c.x
+----
+inner-join (merge)
+ ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (4)-->(5,6), (3)==(6), (6)==(3), (2)==(4), (4)==(2)
+ ├── scan d@d_auto_index_fk_y_ref_c
+ │    ├── columns: d.x:1(int!null) d.y:2(int!null) d.z:3(int!null)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── ordering: +2,+3
+ ├── scan c
+ │    ├── columns: c.x:4(int!null) c.y:5(int!null) c.z:6(int!null)
+ │    ├── key: (4)
+ │    ├── fd: (4)-->(5,6)
+ │    └── ordering: +4
+ └── merge-on
+      ├── left ordering: +2,+3
+      ├── right ordering: +4,+6
+      └── true [type=bool]
+
+# Left join on a part of a foreign key turns into an inner join.
+opt
+SELECT *
+FROM d
+LEFT OUTER JOIN c
+ON d.z = c.z
+----
+inner-join
+ ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
+ ├── key: (1,4)
+ ├── fd: (1)-->(2,3), (4)-->(5,6), (3)==(6), (6)==(3)
+ ├── scan d
+ │    ├── columns: d.x:1(int!null) d.y:2(int!null) d.z:3(int!null)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ ├── scan c
+ │    ├── columns: c.x:4(int!null) c.y:5(int!null) c.z:6(int!null)
+ │    ├── key: (4)
+ │    └── fd: (4)-->(5,6)
+ └── filters [type=bool, outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
+      └── d.z = c.z [type=bool, outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ])]
+
+# Can't simplify: joins on non-foreign keys.
+opt
+SELECT *
+FROM c
+LEFT OUTER JOIN a
+ON c.z = a.k
+----
+left-join
+ ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) k:4(int) i:5(int) f:6(float) s:7(string) j:8(jsonb)
+ ├── key: (1,4)
+ ├── fd: (1)-->(2,3), (4)-->(5-8)
+ ├── scan c
+ │    ├── columns: x:1(int!null) y:2(int!null) z:3(int!null)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ ├── scan a
+ │    ├── columns: k:4(int!null) i:5(int) f:6(float!null) s:7(string) j:8(jsonb)
+ │    ├── key: (4)
+ │    └── fd: (4)-->(5-8)
+ └── filters [type=bool, outer=(3,4), constraints=(/3: (/NULL - ]; /4: (/NULL - ]), fd=(3)==(4), (4)==(3)]
+      └── z = k [type=bool, outer=(3,4), constraints=(/3: (/NULL - ]; /4: (/NULL - ])]
+
+# Can't simplify: joins on non-foreign keys still in foreign key index.
+opt
+SELECT *
+FROM c
+LEFT OUTER JOIN a
+ON c.x = a.k
+----
+left-join (merge)
+ ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) k:4(int) i:5(int) f:6(float) s:7(string) j:8(jsonb)
+ ├── key: (1,4)
+ ├── fd: (1)-->(2,3), (4)-->(5-8)
+ ├── scan c
+ │    ├── columns: x:1(int!null) y:2(int!null) z:3(int!null)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── ordering: +1
+ ├── scan a
+ │    ├── columns: k:4(int!null) i:5(int) f:6(float!null) s:7(string) j:8(jsonb)
+ │    ├── key: (4)
+ │    ├── fd: (4)-->(5-8)
+ │    └── ordering: +4
+ └── merge-on
+      ├── left ordering: +1
+      ├── right ordering: +4
+      └── true [type=bool]
 
 # Can't simplify: non-equality condition.
 opt

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -312,6 +312,11 @@ func (tt *Table) CheckPrivilege(ctx context.Context, priv privilege.Kind) error 
 	return nil
 }
 
+// InternalID is part of the opt.Table interface.
+func (tt *Table) InternalID() uint64 {
+	return uint64(tt.tableID)
+}
+
 // IsVirtualTable is part of the opt.Table interface.
 func (tt *Table) IsVirtualTable() bool {
 	return tt.IsVirtual
@@ -377,6 +382,9 @@ type Index struct {
 	Ordinal int
 	Columns []opt.IndexColumn
 
+	// Table is a back reference to the table this index is on.
+	table *Table
+
 	// KeyCount is the number of columns that make up the unique key for the
 	// index. See the opt.Index.KeyColumnCount for more details.
 	KeyCount int
@@ -388,6 +396,12 @@ type Index struct {
 
 	// Inverted is true when this index is an inverted index.
 	Inverted bool
+
+	// foreignKey is a struct representing an outgoing foreign key
+	// reference. If fkSet is true, then foreignKey is a valid
+	// index reference.
+	foreignKey opt.ForeignKeyReference
+	fkSet      bool
 }
 
 // IdxName is part of the opt.Index interface.
@@ -398,6 +412,11 @@ func (ti *Index) IdxName() string {
 // InternalID is part of the opt.Index interface.
 func (ti *Index) InternalID() uint64 {
 	return 1 + uint64(ti.Ordinal)
+}
+
+// Table is part of the opt.Index interface.
+func (ti *Index) Table() opt.Table {
+	return ti.table
 }
 
 // IsInverted is part of the opt.Index interface.
@@ -423,6 +442,11 @@ func (ti *Index) LaxKeyColumnCount() int {
 // Column is part of the opt.Index interface.
 func (ti *Index) Column(i int) opt.IndexColumn {
 	return ti.Columns[i]
+}
+
+// ForeignKey is part of the opt.Index interface.
+func (ti *Index) ForeignKey() (opt.ForeignKeyReference, bool) {
+	return ti.foreignKey, ti.fkSet
 }
 
 // Column implements the opt.Column interface for testing purposes.

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -75,12 +75,13 @@ where phoneregis0_.phone_id=1;
 ----
 project
  ├── columns: phone_id1_2_0_:1(int!null) person_i2_2_0_:2(int!null) formula159_0_:11(timestamp) id1_1_1_:3(int!null) number2_1_1_:4(string) since3_1_1_:5(timestamp) type4_1_1_:6(int)
- ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2)
- ├── left-join (lookup phone)
- │    ├── columns: phone_id:1(int!null) person_id:2(int!null) phone.id:3(int!null) phone.number:4(string) phone.since:5(timestamp) phone.type:6(int) phone.id:7(int) phone.since:9(timestamp)
+ ├── key: (3)
+ ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2), (2)-->(11)
+ ├── inner-join (lookup phone)
+ │    ├── columns: phone_id:1(int!null) person_id:2(int!null) phone.id:3(int!null) phone.number:4(string) phone.since:5(timestamp) phone.type:6(int) phone.id:7(int!null) phone.since:9(timestamp)
  │    ├── key columns: [2] = [7]
- │    ├── key: (3,7)
- │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2), (7)-->(9)
+ │    ├── key: (7)
+ │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3,7), (3)==(2,7), (7)-->(9), (7)==(2,3)
  │    ├── inner-join (lookup phone)
  │    │    ├── columns: phone_id:1(int!null) person_id:2(int!null) phone.id:3(int!null) phone.number:4(string) phone.since:5(timestamp) phone.type:6(int)
  │    │    ├── key columns: [2] = [3]

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -275,6 +275,11 @@ func (ot *optTable) CheckPrivilege(ctx context.Context, priv privilege.Kind) err
 	return ot.cat.resolver.CheckPrivilege(ctx, ot.desc, priv)
 }
 
+// InternalID is part of the opt.Table interface.
+func (ot *optTable) InternalID() uint64 {
+	return uint64(ot.desc.ID)
+}
+
 // IsVirtualTable is part of the opt.Table interface.
 func (ot *optTable) IsVirtualTable() bool {
 	return ot.desc.IsVirtualTable()
@@ -396,6 +401,10 @@ type optIndex struct {
 	numCols       int
 	numKeyCols    int
 	numLaxKeyCols int
+
+	// foreignKey stores IDs of another table and one of its indexes,
+	// if this index is part of an outbound foreign key relation.
+	foreignKey opt.ForeignKeyReference
 }
 
 var _ opt.Index = &optIndex{}
@@ -457,6 +466,12 @@ func (oi *optIndex) init(tab *optTable, desc *sqlbase.IndexDescriptor) {
 		oi.numLaxKeyCols = len(desc.ColumnIDs) + len(desc.ExtraColumnIDs)
 		oi.numKeyCols = oi.numLaxKeyCols
 	}
+
+	if desc.ForeignKey.IsSet() {
+		oi.foreignKey.TableID = uint64(desc.ForeignKey.Table)
+		oi.foreignKey.IndexID = uint64(desc.ForeignKey.Index)
+		oi.foreignKey.PrefixLen = desc.ForeignKey.SharedPrefixLen
+	}
 }
 
 // IdxName is part of the opt.Index interface.
@@ -511,6 +526,22 @@ func (oi *optIndex) Column(i int) opt.IndexColumn {
 	i -= length
 	ord, _ := oi.tab.lookupColumnOrdinal(oi.storedCols[i])
 	return opt.IndexColumn{Column: oi.tab.Column(ord), Ordinal: ord}
+}
+
+// ForeignKey is part of the opt.Index interface.
+func (oi *optIndex) ForeignKey() (opt.ForeignKeyReference, bool) {
+	desc := oi.desc
+	if desc.ForeignKey.IsSet() {
+		oi.foreignKey.TableID = uint64(desc.ForeignKey.Table)
+		oi.foreignKey.IndexID = uint64(desc.ForeignKey.Index)
+		oi.foreignKey.PrefixLen = desc.ForeignKey.SharedPrefixLen
+	}
+	return oi.foreignKey, oi.desc.ForeignKey.IsSet()
+}
+
+// Table is part of the opt.Index interface.
+func (oi *optIndex) Table() opt.Table {
+	return oi.tab
 }
 
 type optTableStat struct {


### PR DESCRIPTION
This change updates the SimplifyLeftJoinWithFilters matcher
to also match cases where we are left joining from an outgoing
foreign key relation i.e. we're always guaranteed to have a match
in the other table.

Fixes #29217

Release note: None