### PR TITLE
release-2.1: kv: complete the logic in IsSerializablePushAndRefreshNotPossible

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -1036,10 +1036,12 @@ func (tc *TxnCoordSender) IsSerializablePushAndRefreshNotPossible() bool {
 	origTimestamp := tc.mu.txn.OrigTimestamp
 	origTimestamp.Forward(tc.mu.txn.RefreshedTimestamp)
 	isTxnPushed := tc.mu.txn.Timestamp != origTimestamp
+	refreshAttemptNotPossible := tc.interceptorAlloc.txnSpanRefresher.refreshInvalid ||
+		tc.mu.txn.OrigTimestampWasObserved
 	// We check OrigTimestampWasObserved here because, if that's set, refreshing
 	// of reads is not performed.
 	return tc.mu.txn.Isolation == enginepb.SERIALIZABLE &&
-		isTxnPushed && tc.mu.txn.OrigTimestampWasObserved
+		isTxnPushed && refreshAttemptNotPossible
 }
 
 // Epoch is part of the client.TxnSender interface.

--- a/pkg/kv/txn_interceptor_span_refresher.go
+++ b/pkg/kv/txn_interceptor_span_refresher.go
@@ -135,7 +135,7 @@ func (sr *txnSpanRefresher) SendLocked(
 	// exhausted, return a non-retryable error indicating that the
 	// transaction is too large and should potentially be split.
 	// We do this to avoid endlessly retrying a txn likely refail.
-	if sr.refreshInvalid && (br.Txn.WriteTooOld || br.Txn.OrigTimestamp != br.Txn.Timestamp) {
+	if sr.refreshInvalid && (br.Txn.OrigTimestamp != br.Txn.Timestamp) {
 		return nil, roachpb.NewErrorWithTxn(
 			errors.New("transaction is too large to complete; try splitting into pieces"), br.Txn,
 		)

--- a/pkg/roachpb/data.pb.go
+++ b/pkg/roachpb/data.pb.go
@@ -452,7 +452,8 @@ type Transaction struct {
 	Writing bool `protobuf:"varint,9,opt,name=writing,proto3" json:"writing,omitempty"`
 	// If this is true, the transaction must retry. Relevant only for
 	// SNAPSHOT transactions: a SERIALIZABLE transaction would have to
-	// retry anyway due to its commit timestamp having moved forward.
+	// retry anyway due to its commit timestamp having moved forward (whenever
+	// write_too_old is set, meta.Timestamp has been pushed above orig_timestamp).
 	// This bool is set instead of immediately returning a txn retry
 	// error so that intents can continue to be laid down, minimizing
 	// work required on txn restart.

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -363,7 +363,8 @@ message Transaction {
   bool writing = 9;
   // If this is true, the transaction must retry. Relevant only for
   // SNAPSHOT transactions: a SERIALIZABLE transaction would have to
-  // retry anyway due to its commit timestamp having moved forward.
+  // retry anyway due to its commit timestamp having moved forward (whenever
+  // write_too_old is set, meta.Timestamp has been pushed above orig_timestamp).
   // This bool is set instead of immediately returning a txn retry
   // error so that intents can continue to be laid down, minimizing
   // work required on txn restart.


### PR DESCRIPTION
Backport 1/1 commits from #30049.

/cc @cockroachdb/release

---

Release note: None
