### PR TITLE
kv: don't be pessimistic about txn that can't refresh

### DIFF
--- a/pkg/kv/txn_interceptor_span_refresher.go
+++ b/pkg/kv/txn_interceptor_span_refresher.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -131,23 +130,6 @@ func (sr *txnSpanRefresher) SendLocked(
 		sr.refreshWrites = nil
 		sr.refreshInvalid = true
 		sr.refreshSpansBytes = 0
-	}
-	// If the transaction will retry and the refresh spans are
-	// exhausted, return a non-retryable error indicating that the
-	// transaction is too large and should potentially be split.
-	// We do this to avoid endlessly retrying a txn likely refail.
-	//
-	// TODO(nvanbenschoten): this is duplicating some of the logic
-	// in IsSerializablePushAndRefreshNotPossible. We plan to remove
-	// this all shortly (#30074), but if that changes, we should clean
-	// this overlap up.
-	ts := br.Txn.OrigTimestamp
-	ts.Forward(br.Txn.RefreshedTimestamp)
-	pushed := ts != br.Txn.Timestamp
-	if pushed && sr.refreshInvalid {
-		return nil, roachpb.NewErrorWithTxn(
-			errors.New("transaction is too large to complete; try splitting into pieces"), br.Txn,
-		)
 	}
 	return br, nil
 }


### PR DESCRIPTION
Before this patch, the span refresher had code to:
// If the transaction will retry and the refresh spans are
// exhausted, return a non-retryable error indicating that the
// transaction is too large and should potentially be split.
// We do this to avoid endlessly retrying a txn likely refail.

This was uncharacteristically pessimistic for cockroach. There's no
particular indication that the txn in question will need a refresh upon
restart. We don't engage in such judgements anywhere else. This patch
removes this behavior.
Instead of removing it, another option would be to eagerly generate a
retryable error. However, that would probably not be a useful thing to
do given the behavior of the other layers: the server side generally
tries to let a txn run as long as possible before forcing a restart in
the hope that it will lay down more intents, and the SQL layer
implements a policy of eager restarts while the txn can still be
"auto-retried".

Relatedly, I think the protection that we had was deficient because it
didn't handle the txn's RefreshTimestamp, only its OrigTimestamp.

Release note: None