### PR TITLE
 engine: move a couple decoding helpers to enginepb

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -346,7 +346,7 @@ Decode a hexadecimal-encoded key and pretty-print it. For example:
 			if err != nil {
 				return err
 			}
-			k, err := engine.DecodeKey(b)
+			k, err := engine.DecodeMVCCKey(b)
 			if err != nil {
 				return err
 			}
@@ -376,7 +376,7 @@ Decode and print a hexadecimal-encoded key-value pair.
 			bs = append(bs, b)
 		}
 
-		k, err := engine.DecodeKey(bs[0])
+		k, err := engine.DecodeMVCCKey(bs[0])
 		if err != nil {
 			// Older versions of the consistency checker give you diffs with a raw_key that
 			// is already a roachpb.Key, so make a half-assed attempt to support both.

--- a/pkg/cli/flags_util.go
+++ b/pkg/cli/flags_util.go
@@ -172,7 +172,7 @@ func (k *mvccKey) Set(value string) error {
 		if err != nil {
 			return err
 		}
-		newK, err := engine.DecodeKey(b)
+		newK, err := engine.DecodeMVCCKey(b)
 		if err != nil {
 			encoded := gohex.EncodeToString(engine.EncodeKey(engine.MakeMVCCMetadataKey(roachpb.Key(b))))
 			return errors.Wrapf(err, "perhaps this is just a hex-encoded key; you need an "+

--- a/pkg/sql/sqlbase/dep_test.go
+++ b/pkg/sql/sqlbase/dep_test.go
@@ -23,7 +23,6 @@ import (
 
 func TestNoLinkForbidden(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#30001")
 
 	buildutil.VerifyNoImports(t,
 		"github.com/cockroachdb/cockroach/pkg/sql/sqlbase", true, []string{"c-deps"}, nil,

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -468,17 +468,17 @@ func (rf *RowFetcher) nextKV(
 	}
 	if rf.batchNumKvs > 0 {
 		rf.batchNumKvs--
-		var key engine.MVCCKey
+		var key []byte
 		var rawBytes []byte
 		var err error
 		newSpan = rf.maybeNewSpan
 		rf.maybeNewSpan = false
-		key, rawBytes, rf.batchResponse, err = engine.MVCCScanDecodeKeyValue(rf.batchResponse)
+		key, _, rawBytes, rf.batchResponse, err = enginepb.ScanDecodeKeyValue(rf.batchResponse)
 		if err != nil {
 			return false, kv, false, err
 		}
 		return true, roachpb.KeyValue{
-			Key: key.Key,
+			Key: key,
 			Value: roachpb.Value{
 				RawBytes: rawBytes,
 			},

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -1150,7 +1150,7 @@ func TestDecodeKey(t *testing.T) {
 			if !r.Next() {
 				t.Fatalf("could not get the first entry: %+v", r.Error())
 			}
-			decodedKey, err := DecodeKey(r.Key())
+			decodedKey, err := DecodeMVCCKey(r.Key())
 			if err != nil {
 				t.Fatalf("unexpected err: %+v", err)
 			}

--- a/pkg/storage/engine/enginepb/decode.go
+++ b/pkg/storage/engine/enginepb/decode.go
@@ -1,0 +1,96 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package enginepb
+
+import (
+	"encoding/binary"
+
+	"github.com/pkg/errors"
+
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+// Helpers here are split out of storage/engine since that package also contains
+// rocksdb-interfacing code that pulls in our c-deps build requirements. These
+// helpers are used by packages that do not want to pull in all of that, so they
+// live here instead. We might want to undertake a larger refactor to split up
+// the engine package, pulling MVCC logic out and/or pulling concrete rocksdb
+// code out from abstract interfaces -- See #30114 and #30001.
+
+// SplitMVCCKey returns the key and timestamp components of an encoded MVCC key.
+// This decoding must match engine/db.cc:SplitKey().
+func SplitMVCCKey(mvccKey []byte) (key []byte, ts []byte, ok bool) {
+	if len(mvccKey) == 0 {
+		return nil, nil, false
+	}
+	tsLen := int(mvccKey[len(mvccKey)-1])
+	keyPartEnd := len(mvccKey) - 1 - tsLen
+	if keyPartEnd < 0 {
+		return nil, nil, false
+	}
+
+	key = mvccKey[:keyPartEnd]
+	if tsLen > 0 {
+		ts = mvccKey[keyPartEnd+1 : len(mvccKey)-1]
+	}
+	return key, ts, true
+}
+
+// DecodeKey decodes an key/timestamp from its serialized representation. This
+// decoding must match engine/db.cc:DecodeKey().
+func DecodeKey(encodedKey []byte) (key []byte, timestamp hlc.Timestamp, _ error) {
+	key, ts, ok := SplitMVCCKey(encodedKey)
+	if !ok {
+		return nil, timestamp, errors.Errorf("invalid encoded mvcc key: %x", encodedKey)
+	}
+	switch len(ts) {
+	case 0:
+		// No-op.
+	case 8:
+		timestamp.WallTime = int64(binary.BigEndian.Uint64(ts[0:8]))
+	case 12:
+		timestamp.WallTime = int64(binary.BigEndian.Uint64(ts[0:8]))
+		timestamp.Logical = int32(binary.BigEndian.Uint32(ts[8:12]))
+	default:
+		return nil, timestamp, errors.Errorf(
+			"invalid encoded mvcc key: %x bad timestamp %x", encodedKey, ts)
+	}
+
+	return key, timestamp, nil
+}
+
+// ScanDecodeKeyValue decodes a key/value pair from a binary stream, such as in
+// an MVCCScan "batch" (this is not the RocksDB batch repr format), returning
+// both the key/value and the suffix of data remaining in the batch.
+func ScanDecodeKeyValue(
+	repr []byte,
+) (key []byte, ts hlc.Timestamp, value []byte, orepr []byte, err error) {
+	if len(repr) < 8 {
+		return key, ts, nil, repr, errors.Errorf("unexpected batch EOF")
+	}
+	v := binary.LittleEndian.Uint64(repr)
+	keySize := v >> 32
+	valSize := v & ((1 << 32) - 1)
+	if (keySize + valSize) > uint64(len(repr)) {
+		return key, ts, nil, nil, errors.Errorf("expected %d bytes, but only %d remaining",
+			keySize+valSize, len(repr))
+	}
+	repr = repr[8:]
+	rawKey := repr[:keySize]
+	value = repr[keySize : keySize+valSize]
+	repr = repr[keySize+valSize:]
+	key, ts, err = DecodeKey(rawKey)
+	return key, ts, value, repr, err
+}

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2913,22 +2913,8 @@ func mvccScanSkipKeyValue(repr []byte) ([]byte, error) {
 // "batch" (this is not the RocksDB batch repr format), returning both the
 // key/value and the suffix of data remaining in the batch.
 func MVCCScanDecodeKeyValue(repr []byte) (key MVCCKey, value []byte, orepr []byte, err error) {
-	if len(repr) < 8 {
-		return key, nil, repr, errors.Errorf("unexpected batch EOF")
-	}
-	v := binary.LittleEndian.Uint64(repr)
-	keySize := v >> 32
-	valSize := v & ((1 << 32) - 1)
-	if (keySize + valSize) > uint64(len(repr)) {
-		return key, nil, nil, fmt.Errorf("expected %d bytes, but only %d remaining",
-			keySize+valSize, len(repr))
-	}
-	repr = repr[8:]
-	rawKey := repr[:keySize]
-	value = repr[keySize : keySize+valSize]
-	repr = repr[keySize+valSize:]
-	key, err = DecodeKey(rawKey)
-	return key, value, repr, err
+	k, ts, value, orepr, err := enginepb.ScanDecodeKeyValue(repr)
+	return MVCCKey{k, ts}, value, orepr, err
 }
 
 func notFoundErrOrDefault(err error) error {


### PR DESCRIPTION
Working on #30001.

This moves a couple key decoding helpers from engine, where they share a package with lots of c-deps, to enginepb.
This leaves the old function signatures in place, but calling through to their moved implementations.

This allows sqlbase to call these helpers without pulling in engine and its cdeps dependencies.

Release note: none.

Smaller alternative to #30043.