### PR TITLE
release-2.1: ui: Adjust the size of custom chart to match regular charts

### DIFF
--- a/pkg/ui/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/src/views/reports/containers/customChart/index.tsx
@@ -157,7 +157,7 @@ class CustomChart extends React.Component<CustomChartProps & WithRouterProps> {
     }
 
     return (
-      <section className="section">
+      <div>
         <MetricsDataProvider id="debug-custom-chart">
           <LineGraph>
             <Axis units={units}>
@@ -200,7 +200,7 @@ class CustomChart extends React.Component<CustomChartProps & WithRouterProps> {
             </Axis>
           </LineGraph>
         </MetricsDataProvider>
-      </section>
+      </div>
     );
   }
 
@@ -242,10 +242,10 @@ class CustomChart extends React.Component<CustomChartProps & WithRouterProps> {
     }
 
     return (
-      <section className="section">
+      <div>
         { table }
         <button className="metric-edit-button metric-edit-button--add" onClick={this.addMetric}>Add Metric</button>
-      </section>
+      </div>
     );
   }
 
@@ -270,8 +270,18 @@ class CustomChart extends React.Component<CustomChartProps & WithRouterProps> {
             />
           </PageConfigItem>
         </PageConfig>
-        { this.renderChart() }
-        { this.renderMetricsTable() }
+        <section className="section">
+          <div className="l-columns">
+            <div className="chart-group l-columns__left">
+              { this.renderChart() }
+            </div>
+            <div className="l-columns__right">
+            </div>
+          </div>
+        </section>
+        <section className="section">
+          { this.renderMetricsTable() }
+        </section>
       </div>
     );
   }

--- a/pkg/ui/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/src/views/reports/containers/customChart/index.tsx
@@ -150,9 +150,9 @@ class CustomChart extends React.Component<CustomChartProps & WithRouterProps> {
     const { nodesSummary } = this.props;
     if (_.isEmpty(metrics)) {
       return (
-        <section className="section">
+        <div>
           <h3>Click "Add Metric" to add a metric to the custom chart.</h3>
-        </section>
+        </div>
       );
     }
 


### PR DESCRIPTION
Backport 2/2 commits from #30075.

/cc @cockroachdb/release

---

Unlike regular charts which are wrapped within a section and a flex
container, custom chart is placed directly under a section. This leads
to a noticable size(width) difference between reguar charts and custom
chart.

This fixes that by wrapping custom chart with a flex container.

Resolves: #27550

Release note (admin ui change): Make sure that custom chart and regular
charts have the same width.

- Before:

<img width="1382" alt="screen shot 2018-09-11 at 12 09 33 pm" src="https://user-images.githubusercontent.com/39347736/45377467-4d4c6280-b5c0-11e8-8e84-ea318b637130.png">

- After:
<img width="1381" alt="screen shot 2018-09-11 at 12 10 14 pm" src="https://user-images.githubusercontent.com/39347736/45377478-53424380-b5c0-11e8-840f-1e58fb54588f.png">




