### PR TITLE
release-2.1: cli: remove --log-backtrace-at and --verbosity

### DIFF
--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -502,7 +502,7 @@ func (l *DockerCluster) startNode(ctx context.Context, node *testNode) {
 		"start",
 		"--certs-dir=/certs/",
 		"--listen-addr=" + node.nodeStr,
-		"--verbosity=1",
+		"--vmodule=*=1",
 	}
 
 	// Forward the vmodule flag to the nodes.

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -82,8 +82,8 @@ func Main() {
 func commandName(args []string) string {
 	rootName := cockroachCmd.CommandPath()
 	// Ask Cobra to find the command so that flags and their arguments are
-	// ignored. The name of "cockroach --verbosity 2 start" is "start", not
-	// "--verbosity" or "2".
+	// ignored. The name of "cockroach --log-dir foo start" is "start", not
+	// "--log-dir" or "foo".
 	if cmd, _, _ := cockroachCmd.Find(os.Args[1:]); cmd != nil {
 		return strings.TrimPrefix(cmd.CommandPath(), rootName+" ")
 	}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -429,26 +429,18 @@ func Example_logging() {
 	defer c.cleanup()
 
 	c.RunWithArgs([]string{`sql`, `--logtostderr=false`, `-e`, `select 1 as "1"`})
-	c.RunWithArgs([]string{`sql`, `--log-backtrace-at=foo.go:1`, `-e`, `select 1 as "1"`})
 	c.RunWithArgs([]string{`sql`, `--log-dir=`, `-e`, `select 1 as "1"`})
 	c.RunWithArgs([]string{`sql`, `--logtostderr=true`, `-e`, `select 1 as "1"`})
-	c.RunWithArgs([]string{`sql`, `--verbosity=0`, `-e`, `select 1 as "1"`})
 	c.RunWithArgs([]string{`sql`, `--vmodule=foo=1`, `-e`, `select 1 as "1"`})
 
 	// Output:
 	// sql --logtostderr=false -e select 1 as "1"
 	// 1
 	// 1
-	// sql --log-backtrace-at=foo.go:1 -e select 1 as "1"
-	// 1
-	// 1
 	// sql --log-dir= -e select 1 as "1"
 	// 1
 	// 1
 	// sql --logtostderr=true -e select 1 as "1"
-	// 1
-	// 1
-	// sql --verbosity=0 -e select 1 as "1"
 	// 1
 	// 1
 	// sql --vmodule=foo=1 -e select 1 as "1"
@@ -1810,7 +1802,6 @@ Available Commands:
 
 Flags:
   -h, --help                             help for cockroach
-      --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                   if non-empty, write log files in this directory
       --log-dir-max-size bytes           maximum combined size of all log files (default 100 MiB)
       --log-file-max-size bytes          maximum size of each log file (default 10 MiB)
@@ -1861,7 +1852,7 @@ Use "cockroach [command] --help" for more information about a command.
 			}
 
 			// Filter out all test flags.
-			testFlagRE := regexp.MustCompile(`--(test\.|verbosity|vmodule|rewrite)`)
+			testFlagRE := regexp.MustCompile(`--(test\.|vmodule|rewrite)`)
 			lines := strings.Split(buf.String(), "\n")
 			final := []string{}
 			for _, l := range lines {

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -222,11 +222,13 @@ func init() {
 		// TODO(peter): Decide if we want to make the lightstep flags visible.
 		if strings.HasPrefix(flag.Name, "lightstep_") {
 			flag.Hidden = true
-		} else if flag.Name == logflags.NoRedirectStderrName {
+		}
+		switch flag.Name {
+		case logflags.NoRedirectStderrName:
 			flag.Hidden = true
-		} else if flag.Name == logflags.ShowLogsName {
+		case logflags.ShowLogsName:
 			flag.Hidden = true
-		} else if flag.Name == logflags.LogToStderrName {
+		case logflags.LogToStderrName:
 			// The actual default value for --logtostderr is overridden in
 			// cli.Main. We don't override it here as doing so would affect all of
 			// the cli tests and any package which depends on cli. The following line

--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -55,17 +55,17 @@ eexpect ":/# "
 end_test
 
 start_test {Check that the "failed running SUBCOMMAND" message does not consider a flag the subcommand}
-send "$argv --verbosity 2 start --garbage\r"
+send "$argv --vmodule=*=2 start --garbage\r"
 eexpect {Failed running "start"}
 end_test
 
 start_test {Check that the "failed running SUBCOMMAND" message handles nested subcommands}
-send "$argv --verbosity 2 debug zip --garbage\r"
+send "$argv --vmodule=*=2 debug zip --garbage\r"
 eexpect {Failed running "debug zip"}
 end_test
 
 start_test {Check that the "failed running SUBCOMMAND" message handles missing subcommands}
-send "$argv --verbosity 2 --garbage\r"
+send "$argv --vmodule=*=2 --garbage\r"
 eexpect {Failed running "cockroach"}
 end_test
 

--- a/pkg/cli/interactive_tests/test_high_verbosity.tcl
+++ b/pkg/cli/interactive_tests/test_high_verbosity.tcl
@@ -2,7 +2,7 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
-system "mkfifo url_fifo || true; $argv start --insecure --verbosity 3 --pid-file=server_pid --listening-url-file=url_fifo -s=path=logs/db & cat url_fifo > server_url"
+system "mkfifo url_fifo || true; $argv start --insecure --vmodule=*=3 --pid-file=server_pid --listening-url-file=url_fifo -s=path=logs/db & cat url_fifo > server_url"
 
 spawn /bin/bash
 send "PS1=':''/# '\r"

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -19,7 +19,7 @@ eexpect ":/# "
 end_test
 
 start_test "Check that a broken stderr prints a message to the log files."
-send "$argv start -s=path=logs/db --insecure --logtostderr --verbosity=1 2>&1 | cat\r"
+send "$argv start -s=path=logs/db --insecure --logtostderr --vmodule=*=1 2>&1 | cat\r"
 eexpect "CockroachDB node starting"
 system "killall cat"
 eexpect ":/# "

--- a/pkg/sql/pgwire/pgerror/main_test.go
+++ b/pkg/sql/pgwire/pgerror/main_test.go
@@ -15,7 +15,7 @@ package pgerror
 
 import (
 	// Import the logging package so that tests in this package can accept the
-	// --verbosity flag and friends. As of 03/2017, no test in this package needs
+	// --vmodule flag and friends. As of 03/2017, no test in this package needs
 	// logging, but we want the test binary to accept the flags for uniformity
 	// with the other tests.
 	_ "github.com/cockroachdb/cockroach/pkg/util/log"

--- a/pkg/util/log/doc.go
+++ b/pkg/util/log/doc.go
@@ -32,7 +32,7 @@
 // V-Style
 //
 // The V functions can be used to selectively enable logging at a call
-// site. Invoking the binary with --verbosity=N will enable V functions
+// site. Invoking the binary with --vmodule=*=N will enable V functions
 // at level N or higher. Invoking the binary with --vmodule="glob=N" will
 // enable V functions at level N or higher with a filename matching glob.
 //
@@ -78,15 +78,6 @@
 //
 // Other flags provide aids to debugging.
 //
-//  --log-backtrace-at=""
-//    When set to a file and line number holding a logging statement,
-//    such as
-//      -log_backtrace_at=gopherflakes.go:234
-//    a stack trace will be written to the Info log whenever execution
-//    hits that statement. (Unlike with --vmodule, the ".go" must be
-//    present.)
-//  --verbosity=0
-//    Enable V-leveled logging at the specified level.
 //  --vmodule=""
 //    The syntax of the argument is a comma-separated list of pattern=N,
 //    where pattern is a literal file name (minus the ".go" suffix) or

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -23,8 +23,8 @@ import (
 func init() {
 	logflags.InitFlags(
 		&logging.noStderrRedirect,
-		&logging.logDir, &showLogs, &noColor, &logging.verbosity,
-		&logging.vmodule, &logging.traceLocation,
+		&logging.logDir, &showLogs, &noColor,
+		&logging.vmodule,
 		&LogFileMaxSize, &LogFilesCombinedMaxSize,
 	)
 	// We define these flags here because they have the type Severity

--- a/pkg/util/log/logflags/logflags.go
+++ b/pkg/util/log/logflags/logflags.go
@@ -61,9 +61,7 @@ var _ flag.Value = &atomicBool{}
 const (
 	LogToStderrName               = "logtostderr"
 	NoColorName                   = "no-color"
-	VerbosityName                 = "verbosity"
 	VModuleName                   = "vmodule"
-	LogBacktraceAtName            = "log-backtrace-at"
 	LogDirName                    = "log-dir"
 	NoRedirectStderrName          = "no-redirect-stderr"
 	ShowLogsName                  = "show-logs"
@@ -79,14 +77,12 @@ func InitFlags(
 	logDir flag.Value,
 	showLogs *bool,
 	nocolor *bool,
-	verbosity, vmodule, traceLocation flag.Value,
+	vmodule flag.Value,
 	logFileMaxSize, logFilesCombinedMaxSize *int64,
 ) {
 	flag.BoolVar(nocolor, NoColorName, *nocolor, "disable standard error log colorization")
 	flag.BoolVar(noRedirectStderr, NoRedirectStderrName, *noRedirectStderr, "disable redirect of stderr to the log file")
-	flag.Var(verbosity, VerbosityName, "log level for V logs (significantly increases log output)")
 	flag.Var(vmodule, VModuleName, "comma-separated list of pattern=N settings for file-filtered logging (significantly hurts performance)")
-	flag.Var(traceLocation, LogBacktraceAtName, "when logging hits line file:N, emit a stack trace")
 	flag.Var(logDir, LogDirName, "if non-empty, write log files in this directory")
 	flag.BoolVar(showLogs, ShowLogsName, *showLogs, "print logs instead of saving them in files")
 	flag.Var(humanizeutil.NewBytesValue(logFileMaxSize), LogFileMaxSizeName, "maximum size of each log file")


### PR DESCRIPTION
Backport 1/1 commits from #30015.

/cc @cockroachdb/release

---

The --log-backtrace-at flag is essentially never used. The --verbosity
flag is dangerous as it significantly affects performance, causes too
much log output to be useful, and tickles code paths only used when
verbosity is enabled which can cause crashes. The last problem should
be fixed, yet we should also make it harder to run with verbosity.

Note that `--verbosity=N` can still be achieved via `--vmodule=*=N`.

Fixes #30012

Release note (cli change): Remove --log-backtrace-at and --verbosity
flags which were documented as being only useful by CockroachDB
developers yet never actually used by CockroachDB developers.
