### PR TITLE
sql: avoid useless NumVal allocations for every parsed Placeholder

### DIFF
--- a/pkg/sql/parser/scan.go
+++ b/pkg/sql/parser/scan.go
@@ -796,9 +796,6 @@ func (s *Scanner) scanPlaceholder(lval *sqlSymType) {
 		return
 	}
 
-	// uval is now in the range [0, 1<<63]. Casting to an int64 leaves the range
-	// [0, 1<<63 - 1] intact and moves 1<<63 to -1<<63 (a.k.a. math.MinInt64).
-	lval.union.val = &tree.NumVal{Value: constant.MakeUint64(uval)}
 	lval.id = PLACEHOLDER
 }
 

--- a/pkg/sql/parser/scan_test.go
+++ b/pkg/sql/parser/scan_test.go
@@ -211,11 +211,11 @@ func TestScanNumber(t *testing.T) {
 func TestScanPlaceholder(t *testing.T) {
 	testData := []struct {
 		sql      string
-		expected int64
+		expected string
 	}{
-		{`$1`, 1},
-		{`$1a`, 1},
-		{`$123`, 123},
+		{`$1`, "1"},
+		{`$1a`, "1"},
+		{`$123`, "123"},
 	}
 	for _, d := range testData {
 		s := MakeScanner(d.sql)
@@ -224,10 +224,8 @@ func TestScanPlaceholder(t *testing.T) {
 		if id != PLACEHOLDER {
 			t.Errorf("%s: expected %d, but found %d", d.sql, PLACEHOLDER, id)
 		}
-		if i, err := lval.union.numVal().AsInt64(); err != nil {
-			t.Errorf("%s: expected success, but found %v", d.sql, err)
-		} else if d.expected != i {
-			t.Errorf("%s: expected %d, but found %d", d.sql, d.expected, i)
+		if d.expected != lval.str {
+			t.Errorf("%s: expected %s, but found %s", d.sql, d.expected, lval.str)
 		}
 	}
 }


### PR DESCRIPTION
This change removes an unnecessary allocation in `Scanner.scanPlaceholder`.
The method was creating a `NumVal` for the Placeholder's name, which in
turn created a `constant.Value`. This `NumVal` was then stored in the
`sqlSymType` alongside the Placeholder's string representation, but only
the string representation was ever actually used.

When running `workload init tpcc --warehouses=1000` this results in **9%**
of total allocations, every single one of which was 100% useless.

![screen shot 2018-09-11 at 3 28 24 pm](https://user-images.githubusercontent.com/5438456/45386940-97464000-b5e2-11e8-8f2b-d48cc2a2da28.png)

I tracked this back to a series of small mistakes that date back to
the initial implementation of the SQL scanner (e99ffda). I then made
a harmless mistake significantly worse in 01de4ad1.

Release note (performance improvement): Avoid unnecessary allocations
when parsing prepared statement placeholders.