### PR TITLE
sql: don't allocate PlaceholderInfo maps multiple times

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1816,7 +1816,7 @@ func (ex *connExecutor) resetPlanner(
 		p.statsCollector.Reset(&ex.server.sqlStats, ex.appStats, &ex.phaseTimes)
 	}
 
-	p.semaCtx = tree.MakeSemaContext(ex.sessionData.User == security.RootUser)
+	p.semaCtx.Reset(ex.sessionData.User == security.RootUser)
 	p.semaCtx.Location = &ex.sessionData.DataConversion.Location
 	p.semaCtx.SearchPath = ex.sessionData.SearchPath
 	p.semaCtx.AsOfTimestamp = nil

--- a/pkg/sql/sem/tree/placeholders.go
+++ b/pkg/sql/sem/tree/placeholders.go
@@ -67,15 +67,8 @@ type PlaceholderInfo struct {
 	permitUnassigned bool
 }
 
-// MakePlaceholderInfo constructs an empty PlaceholderInfo.
-func MakePlaceholderInfo() PlaceholderInfo {
-	res := PlaceholderInfo{}
-	res.Clear()
-	return res
-}
-
-// Clear resets the placeholder info map.
-func (p *PlaceholderInfo) Clear() {
+// Init initializes the placeholder info map.
+func (p *PlaceholderInfo) Init() {
 	p.TypeHints = PlaceholderTypes{}
 	p.Types = PlaceholderTypes{}
 	p.Values = QueryArguments{}
@@ -88,7 +81,22 @@ func (p *PlaceholderInfo) Assign(src *PlaceholderInfo) {
 	if src != nil {
 		*p = *src
 	} else {
-		p.Clear()
+		p.Init()
+	}
+}
+
+// SetTypeHints resets the type and values in the map and replaces the
+// type hints map by an alias to src. If src is nil, the map is cleared.
+// The type hints map is aliased because the invoking code from
+// pgwire/v3.go for sql.Prepare needs to receive the updated type
+// assignments after Prepare completes.
+func (p *PlaceholderInfo) SetTypeHints(src PlaceholderTypes) {
+	if src != nil {
+		p.TypeHints = src
+		p.Types = PlaceholderTypes{}
+		p.Values = QueryArguments{}
+	} else {
+		p.Init()
 	}
 }
 
@@ -160,21 +168,6 @@ func (p *PlaceholderInfo) SetType(name string, typ types.T) error {
 		p.TypeHints[name] = typ
 	}
 	return nil
-}
-
-// SetTypeHints resets the type and values in the map and replaces the
-// type hints map by an alias to src. If src is nil, the map is cleared.
-// The type hints map is aliased because the invoking code from
-// pgwire/v3.go for sql.Prepare needs to receive the updated type
-// assignments after Prepare completes.
-func (p *PlaceholderInfo) SetTypeHints(src PlaceholderTypes) {
-	if src != nil {
-		p.TypeHints = src
-		p.Types = PlaceholderTypes{}
-		p.Values = QueryArguments{}
-	} else {
-		p.Clear()
-	}
 }
 
 // IsUnresolvedPlaceholder returns whether expr is an unresolved placeholder. In

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -182,10 +182,16 @@ func (sp *ScalarProperties) Clear() {
 // for "lightweight" type checking such as the one performed for default
 // expressions.
 func MakeSemaContext(privileged bool) SemaContext {
-	return SemaContext{
-		Placeholders: MakePlaceholderInfo(),
-		privileged:   privileged,
-	}
+	var sc SemaContext
+	sc.Reset(privileged)
+	sc.Placeholders.Init()
+	return sc
+}
+
+// Reset resets the SemaContext. PlaceholdersInfo will not be initialized
+// after Reset is called.
+func (sc *SemaContext) Reset(privileged bool) {
+	*sc = SemaContext{privileged: privileged}
 }
 
 // isUnresolvedPlaceholder provides a nil-safe method to determine whether expr is an


### PR DESCRIPTION
Before this change, we would allocate three placeholder maps in
`MakeSemaContext`, only to replace them immediately in when calling
`PlaceholderInfo.Assign` or `PlaceholderInfo.SetTypeHints`. We now
avoid these useless initial allocations.

Release note: None