### PR TITLE
ui: custom chart enhancements

### DIFF
--- a/pkg/ui/src/views/reports/containers/customChart/customChart.styl
+++ b/pkg/ui/src/views/reports/containers/customChart/customChart.styl
@@ -24,16 +24,22 @@
     &:hover
       background-color $dropdown-hover-color
 
+button
+  padding 12px 24px
+  margin 0px 9px
+  background-color inherit
+  text-transform uppercase
+  color $link-color
+  font-size 14px
+  letter-spacing 2px
+  border 1px solid $button-border-color
+  border-radius 3px
+  vertical-align middle
+  cursor pointer
+
 .metric-edit-button
-    padding 3px 9px
-    margin 0px 9px
-
-    &--add
-      margin 17px 9px
-
-.chart-edit-button
-    padding 3px 9px
-    margin 0px 9px
+  &--add
+    margin 17px 9px
 
 .metric-table
   &__header
@@ -46,10 +52,6 @@
     text-transform uppercase
     text-align left
     color $body-color
-
-    &--no-title
-      background inherit
-      padding 0
 
   &__cell
     text-align center

--- a/pkg/ui/src/views/reports/containers/customChart/customChart.styl
+++ b/pkg/ui/src/views/reports/containers/customChart/customChart.styl
@@ -31,6 +31,10 @@
     &--add
       margin 17px 9px
 
+.chart-edit-button
+    padding 3px 9px
+    margin 0px 9px
+
 .metric-table
   &__header
     background white

--- a/pkg/ui/src/views/reports/containers/customChart/customMetric.tsx
+++ b/pkg/ui/src/views/reports/containers/customChart/customMetric.tsx
@@ -40,8 +40,12 @@ export class CustomMetricState {
 }
 
 export class CustomChartState {
-  metrics: CustomMetricState[] = [];
+  metrics: CustomMetricState[];
   axisUnits: AxisUnits = AxisUnits.Count;
+
+  constructor() {
+    this.metrics = [new CustomMetricState()];
+  }
 }
 
 interface CustomMetricRowProps {
@@ -235,7 +239,9 @@ export class CustomChartTable extends React.Component<CustomChartTableProps> {
 
   render() {
     const metrics = this.currentMetrics();
-    let table: JSX.Element = null;
+    let table: JSX.Element = (
+      <h3>Click "Add Metric" to add a metric to the custom chart.</h3>
+    );
 
     if (!_.isEmpty(metrics)) {
       table = (

--- a/pkg/ui/src/views/reports/containers/customChart/customMetric.tsx
+++ b/pkg/ui/src/views/reports/containers/customChart/customMetric.tsx
@@ -3,10 +3,17 @@ import * as React from "react";
 import Select from "react-select";
 
 import * as protos from  "src/js/protos";
-import { DropdownOption } from "src/views/shared/components/dropdown";
+import { AxisUnits } from "src/views/shared/components/metricQuery";
+import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
 
 import TimeSeriesQueryAggregator = protos.cockroach.ts.tspb.TimeSeriesQueryAggregator;
 import TimeSeriesQueryDerivative = protos.cockroach.ts.tspb.TimeSeriesQueryDerivative;
+
+const axisUnitsOptions: DropdownOption[] = [
+  AxisUnits.Count,
+  AxisUnits.Bytes,
+  AxisUnits.Duration,
+].map(au => ({ label: AxisUnits[au], value: au.toString() }));
 
 const downsamplerOptions: DropdownOption[] = [
   TimeSeriesQueryAggregator.AVG,
@@ -30,6 +37,11 @@ export class CustomMetricState {
   derivative = TimeSeriesQueryDerivative.NONE;
   perNode = false;
   source = "";
+}
+
+export class CustomChartState {
+  metrics: CustomMetricState[] = [];
+  axisUnits: AxisUnits = AxisUnits.Count;
 }
 
 interface CustomMetricRowProps {
@@ -161,9 +173,113 @@ export class CustomMetricRow extends React.Component<CustomMetricRowProps> {
           <input type="checkbox" checked={perNode} onChange={this.changePerNode} />
         </td>
         <td>
-          <button className="metric-edit-button" onClick={this.deleteOption}>Remove</button>
+          <button className="metric-edit-button" onClick={this.deleteOption}>Remove Metric</button>
         </td>
       </tr>
+    );
+  }
+}
+
+interface CustomChartTableProps {
+  metricOptions: DropdownOption[];
+  nodeOptions: DropdownOption[];
+  index: number;
+  chartState: CustomChartState;
+  onChange: (index: number, newState: CustomChartState) => void;
+  onDelete: (index: number) => void;
+}
+
+export class CustomChartTable extends React.Component<CustomChartTableProps> {
+  currentMetrics() {
+    return this.props.chartState.metrics;
+  }
+
+  addMetric = () => {
+    this.props.onChange(this.props.index, {
+      metrics: [...this.currentMetrics(), new CustomMetricState()],
+      axisUnits: this.currentAxisUnits(),
+    });
+  }
+
+  updateMetricRow = (index: number, newState: CustomMetricState) => {
+    const metrics = this.currentMetrics().slice();
+    metrics[index] = newState;
+    this.props.onChange(this.props.index, {
+      metrics,
+      axisUnits: this.currentAxisUnits(),
+    });
+  }
+
+  removeMetric = (index: number) => {
+    const metrics = this.currentMetrics();
+    this.props.onChange(this.props.index, {
+      metrics: metrics.slice(0, index).concat(metrics.slice(index + 1)),
+      axisUnits: this.currentAxisUnits(),
+    });
+  }
+
+  currentAxisUnits(): AxisUnits {
+    return this.props.chartState.axisUnits;
+  }
+
+  changeAxisUnits = (selected: DropdownOption) => {
+    this.props.onChange(this.props.index, {
+      metrics: this.currentMetrics(),
+      axisUnits: +selected.value,
+    });
+  }
+
+  removeChart = () => {
+    this.props.onDelete(this.props.index);
+  }
+
+  render() {
+    const metrics = this.currentMetrics();
+    let table: JSX.Element = null;
+
+    if (!_.isEmpty(metrics)) {
+      table = (
+        <table className="metric-table">
+          <thead>
+            <tr>
+              <td className="metric-table__header">Metric Name</td>
+              <td className="metric-table__header">Downsampler</td>
+              <td className="metric-table__header">Aggregator</td>
+              <td className="metric-table__header">Rate</td>
+              <td className="metric-table__header">Source</td>
+              <td className="metric-table__header">Per Node</td>
+              <td className="metric-table__header"></td>
+            </tr>
+          </thead>
+          <tbody>
+            { metrics.map((row, i) =>
+              <CustomMetricRow
+                key={i}
+                metricOptions={this.props.metricOptions}
+                nodeOptions={this.props.nodeOptions}
+                index={i}
+                rowState={row}
+                onChange={this.updateMetricRow}
+                onDelete={this.removeMetric}
+              />,
+            )}
+          </tbody>
+        </table>
+      );
+    }
+
+    return (
+      <div>
+        <Dropdown
+          title="Units"
+          selected={this.currentAxisUnits().toString()}
+          options={axisUnitsOptions}
+          onChange={this.changeAxisUnits}
+        />
+        <button className="chart-edit-button chart-edit-button--remove" onClick={this.removeChart}>Remove Chart</button>
+        { table }
+        <button className="metric-edit-button metric-edit-button--add" onClick={this.addMetric}>Add Metric</button>
+      </div>
     );
   }
 }

--- a/pkg/ui/src/views/reports/containers/customChart/customMetric.tsx
+++ b/pkg/ui/src/views/reports/containers/customChart/customMetric.tsx
@@ -172,7 +172,7 @@ export class CustomMetricRow extends React.Component<CustomMetricRowProps> {
         <td className="metric-table__cell">
           <input type="checkbox" checked={perNode} onChange={this.changePerNode} />
         </td>
-        <td>
+        <td className="metric-table__cell">
           <button className="metric-edit-button" onClick={this.deleteOption}>Remove Metric</button>
         </td>
       </tr>

--- a/pkg/ui/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/src/views/reports/containers/customChart/index.tsx
@@ -96,14 +96,14 @@ class CustomChart extends React.Component<CustomChartProps & WithRouterProps> {
           axisUnits: AxisUnits.Count,
         }];
       } catch (e) {
-        return [];
+        return [new CustomChartState()];
       }
     }
 
     try {
       return JSON.parse(this.props.location.query.charts);
     } catch (e) {
-      return [];
+      return [new CustomChartState()];
     }
   }
 
@@ -142,12 +142,6 @@ class CustomChart extends React.Component<CustomChartProps & WithRouterProps> {
     const metrics = chart.metrics;
     const units = chart.axisUnits;
     const { nodesSummary } = this.props;
-
-    if (_.isEmpty(metrics)) {
-      return (
-        <h3>Click "Add Metric" to add a metric to the custom chart.</h3>
-      );
-    }
 
     return (
       <MetricsDataProvider id={`debug-custom-chart.${index}`} key={ index }>

--- a/pkg/ui/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/src/views/reports/containers/customChart/index.tsx
@@ -162,7 +162,7 @@ class CustomChart extends React.Component<CustomChartProps & WithRouterProps> {
                     if (m.perNode) {
                       return _.map(nodesSummary.nodeIDs, (nodeID) => (
                         <Metric
-                          key={"${i}${nodeID}"}
+                          key={`${index}${i}${nodeID}`}
                           title={`${nodeID}: ${m.metric} (${i})`}
                           name={m.metric}
                           aggregator={m.aggregator}

--- a/pkg/ui/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/src/views/reports/containers/customChart/index.tsx
@@ -145,57 +145,53 @@ class CustomChart extends React.Component<CustomChartProps & WithRouterProps> {
 
     if (_.isEmpty(metrics)) {
       return (
-        <div>
-          <h3>Click "Add Metric" to add a metric to the custom chart.</h3>
-        </div>
+        <h3>Click "Add Metric" to add a metric to the custom chart.</h3>
       );
     }
 
     return (
-      <React.Fragment key={ index }>
-        <MetricsDataProvider id={`debug-custom-chart.${index}`}>
-          <LineGraph>
-            <Axis units={units}>
-              {
-                metrics.map((m, i) => {
-                  if (m.metric !== "") {
-                    if (m.perNode) {
-                      return _.map(nodesSummary.nodeIDs, (nodeID) => (
-                        <Metric
-                          key={`${index}${i}${nodeID}`}
-                          title={`${nodeID}: ${m.metric} (${i})`}
-                          name={m.metric}
-                          aggregator={m.aggregator}
-                          downsampler={m.downsampler}
-                          derivative={m.derivative}
-                          sources={
-                            isStoreMetric(nodesSummary.nodeStatuses[0], m.metric)
-                            ? _.map(nodesSummary.storeIDsByNodeID[nodeID] || [], n => n.toString())
-                            : [nodeID]
-                          }
-                        />
-                      ));
-                    } else {
-                      return (
-                        <Metric
-                          key={i}
-                          title={`${m.metric} (${i}) `}
-                          name={m.metric}
-                          aggregator={m.aggregator}
-                          downsampler={m.downsampler}
-                          derivative={m.derivative}
-                          sources={m.source === "" ? [] : [m.source]}
-                        />
-                      );
-                    }
+      <MetricsDataProvider id={`debug-custom-chart.${index}`} key={ index }>
+        <LineGraph>
+          <Axis units={units}>
+            {
+              metrics.map((m, i) => {
+                if (m.metric !== "") {
+                  if (m.perNode) {
+                    return _.map(nodesSummary.nodeIDs, (nodeID) => (
+                      <Metric
+                        key={`${index}${i}${nodeID}`}
+                        title={`${nodeID}: ${m.metric} (${i})`}
+                        name={m.metric}
+                        aggregator={m.aggregator}
+                        downsampler={m.downsampler}
+                        derivative={m.derivative}
+                        sources={
+                          isStoreMetric(nodesSummary.nodeStatuses[0], m.metric)
+                          ? _.map(nodesSummary.storeIDsByNodeID[nodeID] || [], n => n.toString())
+                          : [nodeID]
+                        }
+                      />
+                    ));
+                  } else {
+                    return (
+                      <Metric
+                        key={i}
+                        title={`${m.metric} (${i}) `}
+                        name={m.metric}
+                        aggregator={m.aggregator}
+                        downsampler={m.downsampler}
+                        derivative={m.derivative}
+                        sources={m.source === "" ? [] : [m.source]}
+                      />
+                    );
                   }
-                  return "";
-                })
-              }
-            </Axis>
-          </LineGraph>
-        </MetricsDataProvider>
-      </React.Fragment>
+                }
+                return "";
+              })
+            }
+          </Axis>
+        </LineGraph>
+      </MetricsDataProvider>
     );
   }
 
@@ -221,7 +217,7 @@ class CustomChart extends React.Component<CustomChartProps & WithRouterProps> {
     const charts = this.currentCharts();
 
     return (
-      <div>
+      <React.Fragment>
         {
           charts.map((chart, i) => (
             <CustomChartTable
@@ -234,14 +230,13 @@ class CustomChart extends React.Component<CustomChartProps & WithRouterProps> {
             />
           ))
         }
-        <button className="chart-edit-button chart-edit-button--add" onClick={this.addChart}>Add Chart</button>
-      </div>
+      </React.Fragment>
     );
   }
 
   render() {
     return (
-      <div>
+      <React.Fragment>
         <Helmet>
           <title>Custom Chart | Debug</title>
         </Helmet>
@@ -250,6 +245,7 @@ class CustomChart extends React.Component<CustomChartProps & WithRouterProps> {
           <PageConfigItem>
             <TimeScaleDropdown />
           </PageConfigItem>
+          <button className="chart-edit-button chart-edit-button--add" onClick={this.addChart}>Add Chart</button>
         </PageConfig>
         <section className="section">
           <div className="l-columns">
@@ -263,7 +259,7 @@ class CustomChart extends React.Component<CustomChartProps & WithRouterProps> {
         <section className="section">
           { this.renderChartTables() }
         </section>
-      </div>
+      </React.Fragment>
     );
   }
 }


### PR DESCRIPTION
Allow multiple independent charts on the custom chart page, and some other minor improvements.

Before:
<img width="1202" alt="screen shot 2018-09-11 at 5 08 45 pm" src="https://user-images.githubusercontent.com/793969/45387870-5c91d700-b5e5-11e8-876e-82a2b2463dec.png">

After:
<img width="1263" alt="screen shot 2018-09-11 at 5 06 19 pm" src="https://user-images.githubusercontent.com/793969/45387807-33714680-b5e5-11e8-9fc3-2993a3c3397e.png">
