### PR TITLE
gossip: remove unnecessary gossip traffic

### DIFF
--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -175,6 +175,13 @@ func (c *client) requestGossip(g *Gossip, stream Gossip_GossipClient) error {
 func (c *client) sendGossip(g *Gossip, stream Gossip_GossipClient) error {
 	g.mu.Lock()
 	if delta := g.mu.is.delta(c.remoteHighWaterStamps); len(delta) > 0 {
+		// Ensure that the high water stamps for the remote server are kept up to
+		// date so that we avoid resending the same gossip infos as infos are
+		// updated locally.
+		for _, i := range delta {
+			ratchetHighWaterStamp(c.remoteHighWaterStamps, i.NodeID, i.OrigStamp)
+		}
+
 		args := Request{
 			NodeID:          g.NodeID.Get(),
 			Addr:            g.mu.is.NodeAddr,
@@ -233,7 +240,7 @@ func (c *client) handleResponse(ctx context.Context, g *Gossip, reply *Response)
 		g.maybeTightenLocked()
 	}
 	c.peerID = reply.NodeID
-	c.remoteHighWaterStamps = reply.HighWaterStamps
+	mergeHighWaterStamps(&c.remoteHighWaterStamps, reply.HighWaterStamps)
 
 	// If we haven't yet recorded which node ID we're connected to in the outgoing
 	// nodeSet, do so now. Note that we only want to do this if the peer has a


### PR DESCRIPTION
The previous handling of high water stamps left a gap during which an
info could be resent over a connection multiple times. The general
gossip send loop is to wait for a new info to be added to the local info
store, to compute a delta between the local info store and the remote
info store using the remote's high water stamps and to update the
remote's high water stamps when the remote sends a reply on the
connection. The problem here is that updating the remote's high water
stamps when the remote sends a reply leaves a window where an info added
to the local store would be sent multiple times (every time an
additional info was added) until the remote replied. The fix is to keep
track of a per connection high water stamp map and ratchet the contained
stamps both when we receive a reply from the remote and when we send the
remote an info. The result is a 30-40% reduction in gossip
traffic (bytes sent/received) as measured on idle 3, 9 and 27 node
clusters.

See #30088

Release note: None