### PR TITLE
teamcity-trigger: plumb TC_BUILD_BRANCH env var into builder

### DIFF
--- a/build/teamcity-trigger.sh
+++ b/build/teamcity-trigger.sh
@@ -11,4 +11,5 @@ run build/builder.sh env \
   TC_API_USER="$TC_API_USER" \
   TC_API_PASSWORD="$TC_API_PASSWORD" \
   TC_SERVER_URL="$TC_SERVER_URL" \
+  TC_BUILD_BRANCH="$TC_BUILD_BRANCH" \
   teamcity-trigger "$@"


### PR DESCRIPTION
c0bc52b1 added a dependency on the TC_BUILD_BRANCH env var to the
teamcity-trigger binary, but the wrapping shell script was not
propagating the variable into the builder's env.

Release note: None