### PR TITLE
opt: fold constants in execbuilder

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -574,7 +574,7 @@ func (h *harness) runUsingAPI(tb testing.TB, bmType BenchmarkType) {
 	}
 
 	execFactory := stubFactory{}
-	if _, err = execbuilder.New(&execFactory, ev).Build(); err != nil {
+	if _, err = execbuilder.New(&execFactory, ev, &h.evalCtx).Build(); err != nil {
 		tb.Fatalf("%v", err)
 	}
 }

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -24,8 +24,10 @@ import (
 // Builder constructs a tree of execution nodes (exec.Node) from an optimized
 // expression tree (memo.ExprView).
 type Builder struct {
-	factory exec.Factory
-	ev      memo.ExprView
+	factory            exec.Factory
+	ev                 memo.ExprView
+	evalCtx            *tree.EvalContext
+	fastIsConstVisitor fastIsConstVisitor
 
 	// subqueries accumulates information about subqueries that are part of scalar
 	// expressions we built. Each entry is associated with a tree.Subquery
@@ -36,8 +38,8 @@ type Builder struct {
 // New constructs an instance of the execution node builder using the
 // given factory to construct nodes. The Build method will build the execution
 // node tree from the given optimized expression tree.
-func New(factory exec.Factory, ev memo.ExprView) *Builder {
-	return &Builder{factory: factory, ev: ev}
+func New(factory exec.Factory, ev memo.ExprView, evalCtx *tree.EvalContext) *Builder {
+	return &Builder{factory: factory, ev: ev, evalCtx: evalCtx}
 }
 
 // Build constructs the execution node tree and returns its root node if no

--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -84,7 +84,32 @@ func init() {
 // according to ctx.
 func (b *Builder) buildScalar(ctx *buildScalarCtx, ev memo.ExprView) (tree.TypedExpr, error) {
 	if fn := scalarBuildFuncMap[ev.Operator()]; fn != nil {
-		return fn(b, ctx, ev)
+		texpr, err := fn(b, ctx, ev)
+		if err != nil {
+			return nil, err
+		}
+		if b.evalCtx != nil && b.isConst(texpr) {
+			value, err := texpr.Eval(b.evalCtx)
+			if err != nil {
+				// Ignore any errors here (e.g. division by zero), so they can happen
+				// during execution where they are correctly handled. Note that in some
+				// cases we might not even get an error (if this particular expression
+				// does not get evaluated when the query runs, e.g. it's inside a CASE).
+				return texpr, nil
+			}
+			if value == tree.DNull {
+				// We don't want to return an expression that has a different type; cast
+				// the NULL if necessary.
+				var newExpr tree.TypedExpr
+				newExpr, err = tree.ReType(tree.DNull, texpr.ResolvedType())
+				if err != nil {
+					return texpr, nil
+				}
+				return newExpr, nil
+			}
+			return value, nil
+		}
+		return texpr, nil
 	}
 	return nil, errors.Errorf("unsupported op %s", ev.Operator())
 }
@@ -442,4 +467,85 @@ func (b *Builder) addSubquery(
 	// by index (1-based).
 	exprNode.Idx = len(b.subqueries)
 	return exprNode
+}
+
+func (b *Builder) isConst(expr tree.Expr) bool {
+	return b.fastIsConstVisitor.run(expr)
+}
+
+// fastIsConstVisitor determines if an expression is constant by visiting
+// at most two levels of the tree (with one exception, see below).
+// In essence, it determines whether an expression is constant by checking
+// whether its children are const Datums.
+//
+// This can be used by the execbuilder since constants are evaluated
+// bottom-up. If a child is *not* a const Datum, that means it was already
+// determined to be non-constant, and therefore was not evaluated.
+type fastIsConstVisitor struct {
+	isConst bool
+
+	// visited indicates whether we have already visited one level of the tree.
+	// fastIsConstVisitor only visits at most two levels of the tree, with one
+	// exception: If the second level has a Cast expression, fastIsConstVisitor
+	// may visit three levels.
+	visited bool
+}
+
+var _ tree.Visitor = &fastIsConstVisitor{}
+
+func (v *fastIsConstVisitor) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
+	if v.visited {
+		if _, ok := expr.(*tree.CastExpr); ok {
+			// We recurse one more time for cast expressions, since the
+			// execbuilder may have wrapped a NULL.
+			return true, expr
+		}
+		if _, ok := expr.(tree.Datum); !ok || isVar(expr) {
+			// If the child expression is not a const Datum, the parent expression is
+			// not constant. Note that all constant literals have already been
+			// normalized to Datum in TypeCheck.
+			v.isConst = false
+		}
+		return false, expr
+	}
+	v.visited = true
+
+	// If the parent expression is a variable or impure function, we know that it
+	// is not constant.
+
+	if isVar(expr) {
+		v.isConst = false
+		return false, expr
+	}
+
+	switch t := expr.(type) {
+	case *tree.FuncExpr:
+		if t.IsImpure() {
+			v.isConst = false
+			return false, expr
+		}
+	}
+
+	return true, expr
+}
+
+func (*fastIsConstVisitor) VisitPost(expr tree.Expr) tree.Expr { return expr }
+
+func (v *fastIsConstVisitor) run(expr tree.Expr) bool {
+	v.isConst = true
+	v.visited = false
+	tree.WalkExprConst(v, expr)
+	return v.isConst
+}
+
+// isVar returns true if the expression's value can vary during plan
+// execution.
+func isVar(expr tree.Expr) bool {
+	switch expr.(type) {
+	case tree.VariableExpr:
+		return true
+	case *tree.Placeholder:
+		panic("placeholder should have been replaced")
+	}
+	return false
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -583,9 +583,9 @@ scan  ·       ·                                                               
 query TTTTT
 EXPLAIN (TYPES) SELECT abs(2-3) AS a
 ----
-render         ·         ·                      (a int)  ·
- │             render 0  (abs((-1)[int]))[int]  ·        ·
- └── emptyrow  ·         ·                      ()       ·
+render         ·         ·         (a int)  ·
+ │             render 0  (1)[int]  ·        ·
+ └── emptyrow  ·         ·         ()       ·
 
 # Check array subscripts (#13811)
 query TTTTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -519,17 +519,71 @@ render     ·         ·                           ("?column?")  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 = ANY (1, 2, 3) FROM t
 ----
-render     ·         ·                  ("?column?")  ·
- │         render 0  1 = ANY (1, 2, 3)  ·             ·
- └── scan  ·         ·                  ()            ·
-·          table     t@primary          ·             ·
-·          spans     ALL                ·             ·
+render     ·         ·          ("?column?")  ·
+ │         render 0  true       ·             ·
+ └── scan  ·         ·          ()            ·
+·          table     t@primary  ·             ·
+·          spans     ALL        ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 = ANY () FROM t
 ----
-render     ·         ·           ("?column?")  ·
- │         render 0  1 = ANY ()  ·             ·
- └── scan  ·         ·           ()            ·
-·          table     t@primary   ·             ·
-·          spans     ALL         ·             ·
+render     ·         ·          ("?column?")  ·
+ │         render 0  false      ·             ·
+ └── scan  ·         ·          ()            ·
+·          table     t@primary  ·             ·
+·          spans     ALL        ·             ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT least(NULL, greatest(NULL, least(1, NULL), 2, 3), greatest(5, 6), a) FROM t
+----
+render     ·         ·                     ("least")  ·
+ │         render 0  least(NULL, 3, 6, a)  ·          ·
+ └── scan  ·         ·                     (a)        ·
+·          table     t@primary             ·          ·
+·          spans     ALL                   ·          ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM pg_attribute WHERE attrelid='foo'::regclass
+----
+filter              ·       ·                           (attrelid, attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions)  ·
+ │                  filter  attrelid = 'foo'::REGCLASS  ·                                                                                                                                                                                                                                              ·
+ └── virtual table  ·       ·                           (attrelid, attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions)  ·
+·                   source  ·                           ·                                                                                                                                                                                                                                              ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT CASE WHEN length('foo') = 3 THEN 42 ELSE 1/3 END
+----
+render         ·         ·   ("case")  ·
+ │             render 0  42  ·         ·
+ └── emptyrow  ·         ·   ()        ·
+
+# Don't fold the CASE since there is an error in the ELSE clause.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT CASE WHEN length('foo') = 3 THEN 42 ELSE 1/0 END
+----
+render         ·         ·                                      ("case")  ·
+ │             render 0  CASE WHEN true THEN 42 ELSE 1 / 0 END  ·         ·
+ └── emptyrow  ·         ·                                      ()        ·
+
+# Don't fold random() or now(), which are impure functions.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT random(), current_database(), now()
+----
+render         ·         ·         (random, current_database, now)  ·
+ │             render 0  random()  ·                                ·
+ │             render 1  'test'    ·                                ·
+ │             render 2  now()     ·                                ·
+ └── emptyrow  ·         ·         ()                               ·
+
+# Don't fold non-constants.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT 1::FLOAT + length(upper(concat('a', 'b', 'c')))::FLOAT AS r1,
+                         1::FLOAT + length(upper(concat('a', 'b', s)))::FLOAT AS r2 FROM t
+----
+render     ·         ·                                                 (r1, r2)  ·
+ │         render 0  4.0                                               ·         ·
+ │         render 1  length(upper(concat('a', 'b', s)))::FLOAT8 + 1.0  ·         ·
+ └── scan  ·         ·                                                 (s)       ·
+·          table     t@primary                                         ·         ·
+·          spans     ALL                                               ·         ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/values
+++ b/pkg/sql/opt/exec/execbuilder/testdata/values
@@ -32,10 +32,10 @@ EXPLAIN (VERBOSE) VALUES (length('a')), (1 + length('a')), (length('abc')), (len
 ----
 values  ·              ·                 (column1)  ·
 ·       size           1 column, 4 rows  ·          ·
-·       row 0, expr 0  length('a')       ·          ·
-·       row 1, expr 0  1 + length('a')   ·          ·
-·       row 2, expr 0  length('abc')     ·          ·
-·       row 3, expr 0  length('ab') * 2  ·          ·
+·       row 0, expr 0  1                 ·          ·
+·       row 1, expr 0  2                 ·          ·
+·       row 2, expr 0  3                 ·          ·
+·       row 3, expr 0  4                 ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a + b AS r FROM (VALUES (1, 2), (3, 4), (5, 6)) AS v(a, b)

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -161,7 +161,7 @@ func TestIndexConstraints(t *testing.T) {
 				remainingFilter := ic.RemainingFilter()
 				remEv := memo.MakeNormExprView(f.Memo(), remainingFilter)
 				if remEv.Operator() != opt.TrueOp {
-					execBld := execbuilder.New(nil /* execFactory */, remEv)
+					execBld := execbuilder.New(nil /* execFactory */, remEv, &evalCtx)
 					expr, err := execBld.BuildScalar(&iVarHelper)
 					if err != nil {
 						return fmt.Sprintf("error: %v\n", err)

--- a/pkg/sql/opt/idxconstraint/testdata/misc
+++ b/pkg/sql/opt/idxconstraint/testdata/misc
@@ -196,7 +196,7 @@ index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4) nonormalize
 @1 = 1 AND @2 = 2 AND @3 = 3 AND @4 IN (4,5,6)
 ----
 [/1/2/3/4 - /1/2/3/6]
-Remaining filter: ((true AND true) AND true) AND true
+Remaining filter: true
 
 index-constraints vars=(int, int) index=(@1, @2)
 (@1 = 1) AND (@2 > 5) AND (@2 < 1)

--- a/pkg/sql/opt/testutils/format.go
+++ b/pkg/sql/opt/testutils/format.go
@@ -47,7 +47,7 @@ func fmtInterceptor(f *memo.ExprFmtCtx, tp treeprinter.Node, ev memo.ExprView) b
 	}
 
 	// Build the scalar expression and format it as a single tree node.
-	bld := execbuilder.New(nil /* factory */, ev)
+	bld := execbuilder.New(nil /* factory */, ev, nil /* evalCtx */)
 	md := ev.Metadata()
 	ivh := tree.MakeIndexedVarHelper(nil /* container */, md.NumColumns())
 	expr, err := bld.BuildScalar(&ivh)

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -249,7 +249,7 @@ func (p *planner) selectIndex(
 		if remEv.Operator() == opt.TrueOp {
 			s.filter = nil
 		} else {
-			execBld := execbuilder.New(nil /* execFactory */, remEv)
+			execBld := execbuilder.New(nil /* execFactory */, remEv, nil /* evalCtx */)
 			s.filter, err = execBld.BuildScalar(&s.filterVars)
 			if err != nil {
 				return nil, err

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -471,7 +471,7 @@ func (p *planner) makeOptimizerPlan(ctx context.Context, stmt Statement) error {
 
 	// Build the plan tree and store it in planner.curPlan.
 	execFactory := makeExecFactory(p)
-	plan, err := execbuilder.New(&execFactory, ev).Build()
+	plan, err := execbuilder.New(&execFactory, ev, p.EvalContext()).Build()
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -1492,7 +1492,7 @@ func optBuildScalar(evalCtx *tree.EvalContext, e tree.TypedExpr) (tree.TypedExpr
 	}
 	ev := o.Optimize()
 
-	bld := execbuilder.New(nil /* factory */, ev)
+	bld := execbuilder.New(nil /* factory */, ev, evalCtx)
 	ivh := tree.MakeIndexedVarHelper(nil /* container */, 0)
 
 	expr, err := bld.BuildScalar(&ivh)


### PR DESCRIPTION
This commit adds logic to fold constants in the `execbuilder`
after optimization is complete. It is similar to the logic
in `sql/sem/tree/normalize.go` used by the heuristic planner,
but it does not perform any normalization other than constant
folding. Constants are evaluated bottom-up, so it is only
necessary to check two levels of the tree to determine if
an expression is constant and can therefore be evaluated.

Fixes #30112

Release note: None