### PR TITLE
sql: add '2.0' setting for distsql

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -54,7 +54,7 @@
 <tr><td><code>server.shutdown.query_wait</code></td><td>duration</td><td><code>10s</code></td><td>the server will wait for at least this amount of time for active queries to finish</td></tr>
 <tr><td><code>server.time_until_store_dead</code></td><td>duration</td><td><code>5m0s</code></td><td>the time after which if there is no new gossiped information about a store, it is considered dead</td></tr>
 <tr><td><code>server.web_session_timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that a newly created web session will be valid</td></tr>
-<tr><td><code>sql.defaults.distsql</code></td><td>enumeration</td><td><code>1</code></td><td>default distributed SQL execution mode [off = 0, auto = 1, on = 2]</td></tr>
+<tr><td><code>sql.defaults.distsql</code></td><td>enumeration</td><td><code>1</code></td><td>default distributed SQL execution mode [off = 0, auto = 1, on = 2, 2.0-off = 3, 2.0-auto = 4]</td></tr>
 <tr><td><code>sql.defaults.optimizer</code></td><td>enumeration</td><td><code>1</code></td><td>default cost-based optimizer mode [off = 0, on = 1, local = 2]</td></tr>
 <tr><td><code>sql.defaults.serial_normalization</code></td><td>enumeration</td><td><code>0</code></td><td>default handling of SERIAL in table definitions [rowid = 0, virtual_sequence = 1, sql_sequence = 2]</td></tr>
 <tr><td><code>sql.distsql.distribute_index_joins</code></td><td>boolean</td><td><code>true</code></td><td>if set, for index joins we instantiate a join reader on every node that has a stream; if not set, we use a single join reader</td></tr>

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -395,9 +395,9 @@ type testClusterConfig struct {
 // If no configs are indicated, the default one is used (unless overridden
 // via -config).
 var logicTestConfigs = []testClusterConfig{
-	{name: "local", numNodes: 1, overrideDistSQLMode: "off", overrideOptimizerMode: "off"},
+	{name: "local", numNodes: 1, overrideDistSQLMode: "2.0-off", overrideOptimizerMode: "off"},
 	{name: "local-v1.1@v1.0-noupgrade", numNodes: 1,
-		overrideDistSQLMode: "off", overrideOptimizerMode: "off",
+		overrideDistSQLMode: "2.0-off", overrideOptimizerMode: "off",
 		bootstrapVersion: &cluster.ClusterVersion{
 			UseVersion:     cluster.VersionByKey(cluster.VersionBase),
 			MinimumVersion: cluster.VersionByKey(cluster.VersionBase),
@@ -405,15 +405,15 @@ var logicTestConfigs = []testClusterConfig{
 		serverVersion:  &roachpb.Version{Major: 1, Minor: 1},
 		disableUpgrade: 1,
 	},
-	{name: "local-opt", numNodes: 1, overrideDistSQLMode: "off", overrideOptimizerMode: "on"},
-	{name: "local-parallel-stmts", numNodes: 1, parallelStmts: true, overrideDistSQLMode: "off", overrideOptimizerMode: "off"},
+	{name: "local-opt", numNodes: 1, overrideDistSQLMode: "2.0-off", overrideOptimizerMode: "on"},
+	{name: "local-parallel-stmts", numNodes: 1, parallelStmts: true, overrideDistSQLMode: "2.0-off", overrideOptimizerMode: "off"},
 	{name: "fakedist", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "on", overrideOptimizerMode: "off"},
 	{name: "fakedist-opt", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "on", overrideOptimizerMode: "on"},
 	{name: "fakedist-metadata", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "on", overrideOptimizerMode: "off",
 		distSQLMetadataTestEnabled: true, skipShort: true},
 	{name: "fakedist-disk", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "on", overrideOptimizerMode: "off",
 		distSQLUseDisk: true, skipShort: true},
-	{name: "5node-local", numNodes: 5, overrideDistSQLMode: "off", overrideOptimizerMode: "off"},
+	{name: "5node-local", numNodes: 5, overrideDistSQLMode: "2.0-off", overrideOptimizerMode: "off"},
 	{name: "5node-dist", numNodes: 5, overrideDistSQLMode: "on", overrideOptimizerMode: "off"},
 	{name: "5node-dist-opt", numNodes: 5, overrideDistSQLMode: "on", overrideOptimizerMode: "on"},
 	{name: "5node-dist-metadata", numNodes: 5, overrideDistSQLMode: "on", distSQLMetadataTestEnabled: true,

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1333,7 +1333,7 @@ database                           test          NULL      NULL        NULL     
 datestyle                          ISO           NULL      NULL        NULL        string
 default_transaction_isolation      serializable  NULL      NULL        NULL        string
 default_transaction_read_only      off           NULL      NULL        NULL        string
-distsql                            off           NULL      NULL        NULL        string
+distsql                            2.0-off       NULL      NULL        NULL        string
 experimental_force_lookup_join     off           NULL      NULL        NULL        string
 experimental_force_split_at        off           NULL      NULL        NULL        string
 experimental_force_zigzag_join     off           NULL      NULL        NULL        string
@@ -1375,7 +1375,7 @@ database                           test          NULL  user     NULL      test  
 datestyle                          ISO           NULL  user     NULL      ISO           ISO
 default_transaction_isolation      serializable  NULL  user     NULL      serializable  serializable
 default_transaction_read_only      off           NULL  user     NULL      off           off
-distsql                            off           NULL  user     NULL      off           off
+distsql                            2.0-off       NULL  user     NULL      2.0-off       2.0-off
 experimental_force_lookup_join     off           NULL  user     NULL      off           off
 experimental_force_split_at        off           NULL  user     NULL      off           off
 experimental_force_zigzag_join     off           NULL  user     NULL      off           off

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -101,7 +101,7 @@ query T colnames
 SHOW distsql
 ----
 distsql
-off
+2.0-off
 
 ## Test that our no-op compatibility vars work
 
@@ -164,6 +164,12 @@ SET distsql = on
 
 statement ok
 SET distsql = off
+
+statement ok
+SET distsql = '2.0-off'
+
+statement ok
+SET distsql = '2.0-auto'
 
 statement error invalid value for parameter "distsql": "bogus"
 SET distsql = bogus

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -32,7 +32,7 @@ database                           test
 datestyle                          ISO
 default_transaction_isolation      serializable
 default_transaction_read_only      off
-distsql                            off
+distsql                            2.0-off
 experimental_force_lookup_join     off
 experimental_force_split_at        off
 experimental_force_zigzag_join     off
@@ -61,7 +61,7 @@ query I colnames
 SELECT * FROM [SHOW CLUSTER SETTING sql.defaults.distsql]
 ----
 sql.defaults.distsql
-0
+3
 
 query TTTT colnames
 SELECT * FROM [SHOW ALL CLUSTER SETTINGS] WHERE variable LIKE '%organization'

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -2456,8 +2456,6 @@ func TestSecondaryIndexWithOldStoringEncoding(t *testing.T) {
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer server.Stopper().Stop(context.TODO())
 
-	// TODO(knz): We need to disable distributed execution because KV
-	// tracing does not (yet) distribute.
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE d;
 CREATE TABLE d.t (
@@ -2467,7 +2465,6 @@ CREATE TABLE d.t (
   INDEX i (a) STORING (b),
   UNIQUE INDEX u (a) STORING (b)
 );
-SET distsql = off;
 `); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -176,18 +176,33 @@ func BytesEncodeFormatFromString(val string) (_ BytesEncodeFormat, ok bool) {
 	}
 }
 
-// DistSQLExecMode controls if and when the Executor uses DistSQL.
+// DistSQLExecMode controls if and when the Executor uses DistSQL and
+// distributes queries.
+// In 2.0, these settings controlled whether we use DistSQL or we use the
+// local path.
+//
+// Since 2.1, we normally run everything through the DistSQL infrastructure,
+// and these settings control whether to use a distributed plan, or use a plan
+// that only involves local DistSQL processors. We still support 2.0-style
+// "off" and "auto" settings for now (for benchmarks, or in case of
+// regressions).
 type DistSQLExecMode int64
 
 const (
-	// DistSQLOff means that we never use distSQL.
+	// DistSQLOff means that we never distribute queries.
 	DistSQLOff DistSQLExecMode = iota
 	// DistSQLAuto means that we automatically decide on a case-by-case basis if
-	// we use distSQL.
+	// we distribute queries.
 	DistSQLAuto
-	// DistSQLOn means that we use distSQL for queries that are supported.
+	// DistSQLOn means that we distribute queries that are supported.
 	DistSQLOn
-	// DistSQLAlways means that we only use distSQL; unsupported queries fail.
+	// DistSQL2Dot0Off means that we use the "off" setting from 2.0 - never use
+	// the DistSQL engine.
+	DistSQL2Dot0Off
+	// DistSQL2Dot0Auto means that we use the "auto" setting from 2.0 - fall back
+	// to local unless distribution is recommended.
+	DistSQL2Dot0Auto
+	// DistSQLAlways means that we only distribute; unsupported queries fail.
 	DistSQLAlways
 )
 
@@ -199,6 +214,10 @@ func (m DistSQLExecMode) String() string {
 		return "auto"
 	case DistSQLOn:
 		return "on"
+	case DistSQL2Dot0Auto:
+		return "2.0-auto"
+	case DistSQL2Dot0Off:
+		return "2.0-off"
 	case DistSQLAlways:
 		return "always"
 	default:
@@ -215,6 +234,10 @@ func DistSQLExecModeFromString(val string) (_ DistSQLExecMode, ok bool) {
 		return DistSQLAuto, true
 	case "ON":
 		return DistSQLOn, true
+	case "2.0-AUTO":
+		return DistSQL2Dot0Auto, true
+	case "2.0-OFF":
+		return DistSQL2Dot0Off, true
 	case "ALWAYS":
 		return DistSQLAlways, true
 	default:

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -71,8 +71,10 @@ func TestTrace(t *testing.T) {
 						"WHERE operation IS NOT NULL ORDER BY op")
 			},
 			expSpans: []string{
+				"flow",
 				"session recording",
 				"sql txn",
+				"table reader",
 				"consuming rows",
 				"txn coordinator send",
 				"dist sender send",
@@ -157,8 +159,10 @@ func TestTrace(t *testing.T) {
 						"WHERE operation IS NOT NULL ORDER BY op")
 			},
 			expSpans: []string{
+				"flow",
 				"session recording",
 				"sql txn",
+				"table reader",
 				"consuming rows",
 				"txn coordinator send",
 				"dist sender send",

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -238,7 +238,7 @@ var varGen = map[string]sessionVar{
 			}
 			mode, ok := sessiondata.DistSQLExecModeFromString(s)
 			if !ok {
-				return newVarValueError(`distsql`, s, "on", "off", "auto", "always")
+				return newVarValueError(`distsql`, s, "on", "off", "auto", "always", "2.0")
 			}
 			m.SetDistSQLMode(mode)
 


### PR DESCRIPTION
The 2.0 setting for distsql (both a cluster setting and a session
setting) instructs the executor to use the 2.0 method of determining how
to execute a query: the query runs via local sql unless the query is
both distributable and recommended to be distributed, in which case it
runs via the distsql and is actually distributed.

Release note (sql change): add the '2.0' value for both the distsql
session setting and the sql.defaults.distsql cluster setting, which
instructs the database to use the 2.0 'auto' behavior for determining
whether queries run via distsql or not.