### PR TITLE
release-2.1: importccl: improve PGDUMP parse errors

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -572,6 +572,13 @@ COPY t (a, b, c) FROM stdin;
 			data: "create table s.t (i INT)",
 			err:  `non-public schemas unsupported: s`,
 		},
+		{
+			name: "unsupported type",
+			typ:  "PGDUMP",
+			data: "create table t (t time with time zone)",
+			err: `create table t \(t time with time zone\)
+                                 \^`,
+		},
 
 		// Error
 		{

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -92,7 +92,7 @@ func (p *postgreStream) Next() (interface{}, error) {
 			if isIgnoredStatement(t) {
 				continue
 			}
-			return nil, errors.Errorf("%v: (%s)", err, t)
+			return nil, err
 		}
 		switch len(stmts) {
 		case 0:
@@ -287,6 +287,9 @@ func readPostgresCreateTable(
 			return ret, nil
 		}
 		if err != nil {
+			if pg, ok := pgerror.GetPGCause(err); ok {
+				return nil, errors.Errorf("%s\n%s", pg.Message, pg.Detail)
+			}
 			return nil, errors.Wrap(err, "postgres parse error")
 		}
 		switch stmt := stmt.(type) {


### PR DESCRIPTION
Backport 1/1 commits from #29626.

/cc @cockroachdb/release

---

Fixes #29042

Release note: None
