### PR TITLE
storage: remove entries from RaftEntryCache on Raft application

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4232,10 +4232,6 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	}
 	r.mu.Unlock()
 
-	// Update raft log entry cache. We clear any older, uncommitted log entries
-	// and cache the latest ones.
-	r.store.raftEntryCache.addEntries(r.RangeID, rd.Entries)
-
 	r.sendRaftMessages(ctx, otherMsgs)
 
 	for _, e := range rd.CommittedEntries {
@@ -4355,6 +4351,35 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		r.mu.Lock()
 		r.refreshProposalsLocked(0, refreshReason)
 		r.mu.Unlock()
+	}
+
+	// Update the raft entry cache.
+	if len(rd.Entries) > 0 || len(rd.CommittedEntries) > 0 {
+		allCommitted := false
+		if len(rd.Entries) == len(rd.CommittedEntries) {
+			// If all newly proposed entries are also being committed in the
+			// same Raft Ready processing iteration, then we can skip adding
+			// them to the cache because we'd just immediately remove them. This
+			// effectively means that we never use the raftEntryCache in
+			// single-node clusters.
+			allCommitted = rd.Entries[0].Index == rd.CommittedEntries[0].Index
+		}
+		if !allCommitted {
+			// Update raft log entry cache. We clear any older, uncommitted log entries
+			// and cache the latest ones.
+			r.store.raftEntryCache.addEntries(r.RangeID, rd.Entries)
+
+			if len(rd.CommittedEntries) > 0 {
+				// Clear the entries that we just applied out of the Raft log entry
+				// cache. We may pull these entries back into the cache if we need
+				// to catch up a slow follower which doesn't need a snapshot, but
+				// this should be rare and we don't mind hitting RocksDB in that
+				// case.
+				lo := rd.CommittedEntries[0].Index
+				hi := rd.CommittedEntries[len(rd.CommittedEntries)-1].Index
+				r.store.raftEntryCache.delEntries(r.RangeID, lo, hi+1)
+			}
+		}
 	}
 
 	// TODO(bdarnell): need to check replica id and not Advance if it

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -7190,8 +7190,10 @@ func TestEntries(t *testing.T) {
 		// Setup, if not nil, is called before running the test case.
 		setup func()
 	}{
-		// Case 0: All of the entries from cache.
-		{lo: indexes[0], hi: indexes[9] + 1, expResultCount: 10, expCacheCount: 10, setup: nil},
+		// Case 0: All of the entries from cache. Entries would never have
+		// been added to the cache because they were immediately applied,
+		// so all miss and populate.
+		{lo: indexes[0], hi: indexes[9] + 1, expResultCount: 10, expCacheCount: 0, setup: nil},
 		// Case 1: Get the first entry from cache.
 		{lo: indexes[0], hi: indexes[1], expResultCount: 1, expCacheCount: 1, setup: nil},
 		// Case 2: Get the last entry from cache.
@@ -7214,40 +7216,45 @@ func TestEntries(t *testing.T) {
 		// Case 8: hi value is just past the last index, should return all
 		// available entries.
 		{lo: indexes[5], hi: indexes[9] + 1, expResultCount: 5, expCacheCount: 5, setup: nil},
-		// Case 9: all values have been truncated from cache and storage.
+		// Case 9: hi value is just past the index of log truncation, should
+		// return all available entries.
+		{lo: indexes[5], hi: indexes[9] + 2, expResultCount: 6, expCacheCount: 5, setup: nil},
+		// Case 10: all values have been truncated from cache and storage.
 		{lo: indexes[1], hi: indexes[2], expCacheCount: 0, expError: raft.ErrCompacted, setup: nil},
-		// Case 10: hi has just been truncated from cache and storage.
+		// Case 11: hi has just been truncated from cache and storage.
 		{lo: indexes[1], hi: indexes[4], expCacheCount: 0, expError: raft.ErrCompacted, setup: nil},
-		// Case 11: another case where hi has just been truncated from
+		// Case 12: another case where hi has just been truncated from
 		// cache and storage.
 		{lo: indexes[3], hi: indexes[4], expCacheCount: 0, expError: raft.ErrCompacted, setup: nil},
-		// Case 12: lo has been truncated and hi is the truncation point.
+		// Case 13: lo has been truncated and hi is the truncation point.
 		{lo: indexes[4], hi: indexes[5], expCacheCount: 0, expError: raft.ErrCompacted, setup: nil},
-		// Case 13: lo has been truncated but hi is available.
+		// Case 14: lo has been truncated but hi is available.
 		{lo: indexes[4], hi: indexes[9], expCacheCount: 0, expError: raft.ErrCompacted, setup: nil},
-		// Case 14: lo has been truncated and hi is not available.
+		// Case 15: lo has been truncated and hi is not available.
 		{lo: indexes[4], hi: indexes[9] + 100, expCacheCount: 0, expError: raft.ErrCompacted, setup: nil},
-		// Case 15: lo has been truncated but hi is available, and maxBytes is
+		// Case 16: lo has been truncated but hi is available, and maxBytes is
 		// set low.
 		{lo: indexes[4], hi: indexes[9], maxBytes: 1, expCacheCount: 0, expError: raft.ErrCompacted, setup: nil},
-		// Case 16: lo is available but hi is not.
+		// Case 17: lo is available but hi is not.
 		{lo: indexes[5], hi: indexes[9] + 100, expCacheCount: 6, expError: raft.ErrUnavailable, setup: nil},
-		// Case 17: both lo and hi are not available, cache miss.
+		// Case 18: both lo and hi are not available, cache miss.
 		{lo: indexes[9] + 100, hi: indexes[9] + 1000, expCacheCount: 0, expError: raft.ErrUnavailable, setup: nil},
-		// Case 18: lo is available, hi is not, but it was cut off by maxBytes.
+		// Case 19: lo is available, hi is not, but it was cut off by maxBytes.
 		{lo: indexes[5], hi: indexes[9] + 1000, maxBytes: 1, expResultCount: 1, expCacheCount: 1, setup: nil},
 
-		// Case 19: lo and hi are available, but entry cache evicted.
+		// Case 20: lo and hi are available, but entry cache evicted.
 		{lo: indexes[5], hi: indexes[9], expResultCount: 4, expCacheCount: 0, setup: func() {
 			// Manually evict cache for the first 10 log entries.
 			repl.store.raftEntryCache.delEntries(rangeID, indexes[0], indexes[9]+1)
 			indexes = append(indexes, populateLogs(10, 40)...)
 		}},
-		// Case 20: lo and hi are available, entry cache evicted and hi available in cache.
+		// Case 21: lo and hi are available, entry cache evicted and hi available in cache.
 		{lo: indexes[5], hi: indexes[9] + 5, expResultCount: 9, expCacheCount: 4, setup: nil},
-		// Case 21: lo and hi are available and in entry cache.
+		// Case 22: lo and hi not yet available in entry cache.
+		{lo: indexes[9] + 2, hi: indexes[9] + 32, expResultCount: 30, expCacheCount: 3, setup: nil},
+		// Case 23: lo and hi are available and in entry cache.
 		{lo: indexes[9] + 2, hi: indexes[9] + 32, expResultCount: 30, expCacheCount: 30, setup: nil},
-		// Case 22: lo is available and hi is not.
+		// Case 24: lo is available and hi is not.
 		{lo: indexes[9] + 2, hi: indexes[9] + 33, expCacheCount: 30, expError: raft.ErrUnavailable, setup: nil},
 	} {
 		if tc.setup != nil {


### PR DESCRIPTION
Before this change, we only removed entries from the RaftEntryCache when the entries were truncated. We now remove them from the cache immediately after applying them. We may pull these entries back into the cache if we need to catch up a slow follower which doesn't need a snapshot, but this should be rare.

## Problem

Profiles are showing that the `raftEntryCache` is a performance bottleneck on certain workloads. `tpcc1000` on a 3-node cluster with `n1-highcpu-16` machines presents the following profiles.

<img width="1173" alt="3 of cpu usage" src="https://user-images.githubusercontent.com/5438456/45452035-d9d34f80-b6aa-11e8-8b9a-683cccf10b9e.png">

This CPU profile shows that the `raftEntryCache` is responsible for just over **3%** of all CPU utilization on the node. Interestingly, the cost isn't centralized in a single method. Instead we can see both `addEntries` and `getEntries` in the profile. Most of what we see is `OrderedCache` manipulation as the cache interacts with its underlying red-black tree.

<img width="1177" alt="99 of all mutex contention" src="https://user-images.githubusercontent.com/5438456/45452037-dcce4000-b6aa-11e8-809e-ba2c97e34a23.png">

This blocking profile is filtered to show all Mutex contention (ignoring other forms like channels and Cond vars). We can see that blocking in the `raftEntryCache` is responsible for **99%** of all Mutex contention. This seems absurd, but it adds up given that the cache is responsible for **3%** of CPU utilization on a node and requires mutual exclusion across an entire `Store`.

We've also seen in changes like #29596 how expensive these cache accesses have become, especially as the cache grows because most entry accesses take `log(n)` time, where `n` is the number of `raftpb.Entry`s in the cache across all Ranges on a Store.

## Improvement

By pruning the `raftEntryCache` more aggresively, we're able to dramatically reduce the size of the underlying llrb tree, all without sacrificing our cache hit ratio. In the following experiment, I was running `tpcc1000` against a 3-node cluster and switched a cluster setting to enable this change. The top graph shows that the cache hit rate was the same before and after the change (~100%). The bottom graph shows that its size dropped dramatically, from **80k** entries to around **150**.

![screen shot 2018-09-12 at 3 32 21 pm](https://user-images.githubusercontent.com/5438456/45452227-70077580-b6ab-11e8-972d-ad70128e7da9.png)

CPU and blocking profiles were both affected by this: 

<img width="1186" alt="screen shot 2018-09-12 at 3 38 53 pm" src="https://user-images.githubusercontent.com/5438456/45452401-df7d6500-b6ab-11e8-804b-8c62663b6c25.png">

_The CPU utilization due to raftEntryCache operations dropped to **1.25%**, a reduction of **58%**._

<img width="1184" alt="screen shot 2018-09-12 at 3 39 11 pm" src="https://user-images.githubusercontent.com/5438456/45452408-e3a98280-b6ab-11e8-93e4-b88a9b7a888a.png">

_The blocking profile dropped to **83%** of all Mutex contention._

Release note (performance improvement): More aggressively prune the raft entry cache, keeping it to a more manageable size.