### PR TITLE
storage: don't allow replicas to have a nil store in Replica.setDesc

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1693,10 +1693,6 @@ func (r *Replica) GetTxnSpanGCThreshold() hlc.Timestamp {
 // update. Requires raftMu to be locked.
 func (r *Replica) setDesc(ctx context.Context, desc *roachpb.RangeDescriptor) error {
 	r.setDescWithoutProcessUpdate(ctx, desc)
-	if r.store == nil {
-		// r.rm is null in some tests.
-		return nil
-	}
 	return r.store.processRangeDescriptorUpdate(ctx, r)
 }
 

--- a/pkg/storage/scanner_test.go
+++ b/pkg/storage/scanner_test.go
@@ -65,10 +65,7 @@ func newTestRangeSet(count int, t *testing.T) *testRangeSet {
 			KeyCount:  1,
 			LiveCount: 1,
 		}
-
-		if err := repl.setDesc(context.TODO(), desc); err != nil {
-			t.Fatal(err)
-		}
+		repl.mu.state.Desc = desc
 		if exRngItem := rs.replicasByKey.ReplaceOrInsert(repl); exRngItem != nil {
 			t.Fatalf("failed to insert range %s", repl)
 		}


### PR DESCRIPTION
Replica.setDesc bailed out early if Replica.store was nil to support
a scanner test that doesn't initialize Replica.store. This was a scary
special-case to have sitting around in production code. Remove it and
teach the test to simply set the replica's descriptor manually.

Release note: None