### PR TITLE
[wip] kv,storage: introduce a validating btree package

### DIFF
--- a/pkg/kv/txn_interceptor_pipeliner.go
+++ b/pkg/kv/txn_interceptor_pipeliner.go
@@ -17,11 +17,10 @@ package kv
 import (
 	"context"
 
-	"github.com/google/btree"
-
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/btree"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 

--- a/pkg/kv/txn_interceptor_pipeliner_test.go
+++ b/pkg/kv/txn_interceptor_pipeliner_test.go
@@ -20,11 +20,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/btree"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/btree"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -27,7 +27,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/google/btree"
 	"github.com/kr/pretty"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -56,6 +55,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/btree"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"

--- a/pkg/storage/replica_placeholder.go
+++ b/pkg/storage/replica_placeholder.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/google/btree"
+	"github.com/cockroachdb/cockroach/pkg/util/btree"
 )
 
 // ReplicaPlaceholder is created by a Store in anticipation of replacing it at

--- a/pkg/storage/scanner_test.go
+++ b/pkg/storage/scanner_test.go
@@ -20,12 +20,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/btree"
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/btree"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -27,7 +27,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/google/btree"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/raft"
@@ -57,6 +56,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/storage/tscache"
 	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
+	"github.com/cockroachdb/cockroach/pkg/util/btree"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"

--- a/pkg/util/btree/btree.go
+++ b/pkg/util/btree/btree.go
@@ -1,0 +1,30 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build !race ignored
+
+package btree
+
+import googlebtree "github.com/google/btree"
+
+// New is googlebtree.New.
+func New(degree int) *BTree {
+	return googlebtree.New(degree)
+}
+
+// BTree is googlebtree.BTree.
+type BTree = googlebtree.BTree
+
+// Item is googlebtree.Item.
+type Item = googlebtree.Item

--- a/pkg/util/btree/btree_race.go
+++ b/pkg/util/btree/btree_race.go
@@ -1,0 +1,58 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build race
+
+package btree
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	googlebtree "github.com/google/btree"
+)
+
+// BTree is a wrapper around googlebtree.BTree that checks for incorrect usage.
+type BTree struct {
+	*googlebtree.BTree
+}
+
+// New creates a new B-tree with the given degree.
+func New(degree int) *BTree {
+	return &BTree{googlebtree.New(degree)}
+}
+
+// Delete removes an item equal to the passed in item from the tree, returning
+// it. If no such item exists, it returns nil.
+func (b *BTree) Delete(item Item) Item {
+	// In #30110 it was observed that duplicate items were getting silently
+	// inserted into the B-tree. Duplicates should be impossible, because the only
+	// way to insert an item into the B-tree is via the ReplaceOrInsert method. It
+	// is, however, possible to get around this by inserting item I1 with key K1,
+	// inserting another item I2 with key K2, and then *mutating* I1's key to K2.
+	// The fact that we regularly mutate items' keys while they are in the B-tree
+	// is horrible but requires a rather large refactor to fix (#30125).
+	//
+	// For now, the best we can do is detect this situation when we go to remove
+	// an item. If Get(item) returns anything but nil after Delete(item), we know
+	// we have a duplicate.
+	i1 := b.BTree.Delete(item)
+	if i2 := b.Get(item); i2 != nil {
+		log.Fatalf(context.TODO(), "duplicate items in BTree at same key: %s and %s", i1, i2)
+	}
+	return i1
+}
+
+// Item is googlebtree.Item.
+type Item = googlebtree.Item

--- a/pkg/util/btree/doc.go
+++ b/pkg/util/btree/doc.go
@@ -1,0 +1,23 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package btree implements in-memory B-trees of arbitrary degree.
+//
+// In normal builds, this package merely re-exports the github.com/google/btree
+// package. In race builds, however, this package injects additional checks for
+// incorrect usage.
+//
+// TODO(benesch): remove this package once storage.Store stops mutating the
+// keys of the replicas it places into its replicasByKey B-tree (#30125).
+package btree


### PR DESCRIPTION
I'm still working on the actual fix for #30110, but I came up with this solution for getting it to repro reliably and I wanted to get early feedback on the approach.

---

Our usage of btree.BTree in package storage is frightful: we regularly
mutate the keys of the items in the btree while they are in the btree.
See #30125 and the comments within for full context. This usage of
btree.BTree is definitely not supported and extremely hard to reason
about, but we've managed to make it work.

Merges, however, introduced a new codepath that did not properly reason
about these mutable B-tree items, leading to #30110. In that bug, a
duplicate item was getting silently inserted into a btree.
Specifically, a real replica and a replica placeholder with the same end
key were both in a store's replicaByKey map at the same moment. Through
sheer luck, in unit tests, even under stress, the replica placeholder is
always selected, correctly, for removal. It was observed once on a real
cluster, however, that the real replica was selected for removal instead
of the placeholder. I suspect that this occurs when an ill-timed tree
rebalancing happens to invert the internal order of the real replica and
real placeholder.

To make this failure more deterministic, add a new package, util/btree,
that wraps github.com/google/btree and, in race builds, checks for
misuse. This causes TestStoreRangeMergeReadoptedLHSFollower to reliably
fail with a duplicate item error when the bug in #30110 is present.

Note that the real fix to this problem is changing replicasByKey to use
a mutable key, but that's too large of a refactor to undertake this
close to the release date.

Release note: None