### PR TITLE
changefeedccl: deflake TestChangefeedRetryableSinkError

### DIFF
--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -87,6 +87,11 @@ func getSink(sinkURI string, targets jobspb.ChangefeedTargets) (Sink, error) {
 		if err != nil {
 			return nil, err
 		}
+		// Mark all query parameters as consumed; since the connection succeeded,
+		// we assume they were valid SQL connection parameters.
+		for k := range q {
+			q.Del(k)
+		}
 	default:
 		return nil, errors.Errorf(`unsupported sink: %s`, u.Scheme)
 	}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1748,8 +1748,16 @@ func (s *Store) startClosedTimestampRangefeedSubscriber(ctx context.Context) {
 			select {
 			case <-ch:
 				// Drain all notifications from the channel.
-				for len(ch) > 0 {
-					<-ch
+			loop:
+				for {
+					select {
+					case _, ok := <-ch:
+						if !ok {
+							break loop
+						}
+					default:
+						break loop
+					}
 				}
 
 				// Gather replicas to notify under lock.


### PR DESCRIPTION
TestChangefeedRetryableSinkError was performing many rounds of bcrypt,
which is excruciatingly slow when the race detector is on. Put its test
cluster into insecure mode to skip bcrypt hashing.

Fix #30156.
Fix #30161.

Release note: None