### PR TITLE
storage: clean up placeholder handling

### DIFF
--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -665,15 +665,7 @@ func (r *Replica) handleReplicatedEvalResult(
 
 	if rResult.State != nil {
 		if newDesc := rResult.State.Desc; newDesc != nil {
-			if err := r.setDesc(ctx, newDesc); err != nil {
-				// Log the error. There's not much we can do because the commit may
-				// have already occurred at this point.
-				log.Fatalf(
-					ctx,
-					"failed to update range descriptor to %+v: %s",
-					newDesc, err,
-				)
-			}
+			r.setDesc(ctx, newDesc)
 			rResult.State.Desc = nil
 		}
 

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -721,14 +722,21 @@ func clearRangeData(
 	return nil
 }
 
-// applySnapshot updates the replica based on the given snapshot and associated
-// HardState. All snapshots must pass through Raft for correctness, i.e. the
-// parameters to this method must be taken from a raft.Ready. Any replicas
-// specified in subsumedRepls will be destroyed atomically with the application
-// of the snapshot. It is the caller's responsibility to call
-// r.store.processRangeDescriptorUpdate(r) after a successful applySnapshot.
+// applySnapshot updates the replica and its store based on the given snapshot
+// and associated HardState. All snapshots must pass through Raft for
+// correctness, i.e. the parameters to this method must be taken from a
+// raft.Ready. Any replicas specified in subsumedRepls will be destroyed
+// atomically with the application of the snapshot.
+//
+// If there is a placeholder associated with r, applySnapshot will remove that
+// placeholder from the store if and only if it does not return an error.
+//
 // This method requires that r.raftMu is held, as well as the raftMus of any
 // replicas in subsumedRepls.
+//
+// TODO(benesch): the way this replica method reaches into its store to update
+// replicasByKey is unfortunate, but the fix requires a substantial refactor to
+// maintain the necessary synchronization.
 func (r *Replica) applySnapshot(
 	ctx context.Context,
 	inSnap IncomingSnapshot,
@@ -760,6 +768,14 @@ func (r *Replica) applySnapshot(
 		// Raft discarded the snapshot, indicating that our local state is
 		// already ahead of what the snapshot provides. But we count it for
 		// stats (see the defer above).
+		//
+		// Since we're not returning an error, we're responsible for removing any
+		// placeholder that might exist.
+		r.store.mu.Lock()
+		if r.store.removePlaceholderLocked(ctx, r.RangeID) {
+			atomic.AddInt32(&r.store.counts.filledPlaceholders, 1)
+		}
+		r.store.mu.Unlock()
 		return nil
 	}
 	if raft.IsEmptyHardState(hs) {
@@ -911,11 +927,15 @@ func (r *Replica) applySnapshot(
 	}
 	stats.commit = timeutil.Now()
 
+	// The on-disk state is now committed, but the corresponding in-memory state
+	// has not yet been updated. Any errors past this point must therefore be
+	// treated as fatal.
+
 	for _, sr := range subsumedRepls {
 		// We removed sr's data when we committed the batch. Finish subsumption by
 		// updating the in-memory bookkeping.
 		if err := sr.postDestroyRaftMuLocked(ctx, sr.GetMVCCStats()); err != nil {
-			return err
+			log.Fatalf(ctx, "unable to finish destroying %s while applying snapshot: %s", sr, err)
 		}
 		// We already hold sr's raftMu, so we must call removeReplicaImpl directly.
 		// Note that it's safe to update the store's metadata for sr's removal
@@ -927,9 +947,21 @@ func (r *Replica) applySnapshot(
 		if err := r.store.removeReplicaImpl(ctx, sr, subsumedNextReplicaID, RemoveOptions{
 			DestroyData: false, // data is already destroyed
 		}); err != nil {
-			return err
+			log.Fatalf(ctx, "unable to remove %s while applying snapshot: %s", sr, err)
 		}
 	}
+
+	// Atomically swap the placeholder, if any, for the replica, and update the
+	// replica's descriptor.
+	r.store.mu.Lock()
+	if r.store.removePlaceholderLocked(ctx, r.RangeID) {
+		atomic.AddInt32(&r.store.counts.filledPlaceholders, 1)
+	}
+	r.setDesc(ctx, s.Desc)
+	if err := r.store.maybeMarkReplicaInitializedLocked(ctx, r); err != nil {
+		log.Fatalf(ctx, "unable to mark replica initialized while applying snapshot: %s", err)
+	}
+	r.store.mu.Unlock()
 
 	r.mu.Lock()
 	// We set the persisted last index to the last applied index. This is
@@ -942,12 +974,12 @@ func (r *Replica) applySnapshot(
 	r.mu.lastIndex = s.RaftAppliedIndex
 	r.mu.lastTerm = lastTerm
 	r.mu.raftLogSize = raftLogSize
-	// Update the range and store stats.
+	// Update the store stats for the data in the snapshot.
 	r.store.metrics.subtractMVCCStats(*r.mu.state.Stats)
 	r.store.metrics.addMVCCStats(*s.Stats)
-	// TODO(benesch): the next line updates r.mu.state.Desc, but that's supposed
-	// to be handled by the call to setDescWithoutProcessUpdate below. This is not
-	// a correctness issue right now, but it's liable to become one.
+	// Update the rest of the Raft state. Changes to r.mu.state.Desc must be
+	// managed by r.setDesc, but we called that above, so now it's safe to
+	// wholesale replace r.mu.state.
 	r.mu.state = s
 	r.assertStateLocked(ctx, r.store.Engine())
 	r.mu.Unlock()
@@ -959,17 +991,13 @@ func (r *Replica) applySnapshot(
 		roachpb.RangeFeedRetryError_REASON_RAFT_SNAPSHOT,
 	)
 
-	// As the last deferred action after committing the batch, update other
-	// fields which are uninitialized or need updating. This may not happen
-	// if the system config has not yet been loaded. While config update
-	// will correctly set the fields, there is no order guarantee in
-	// ApplySnapshot.
-	// TODO: should go through the standard store lock when adding a replica.
+	// Update the replica's cached byte thresholds. This is a no-op if the system
+	// config is not available, in which case we rely on the next gossip update
+	// to perform the update.
 	if err := r.updateRangeInfo(s.Desc); err != nil {
-		panic(err)
+		log.Fatalf(ctx, "unable to update range info while applying snapshot: %s", err)
 	}
 
-	r.setDescWithoutProcessUpdate(ctx, s.Desc)
 	return nil
 }
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -332,7 +332,7 @@ func (tc *testContext) addBogusReplicaToRangeDesc(
 		return roachpb.ReplicaDescriptor{}, err
 	}
 
-	tc.repl.setDescWithoutProcessUpdate(ctx, &newDesc)
+	tc.repl.setDesc(ctx, &newDesc)
 	tc.repl.raftMu.Lock()
 	tc.repl.mu.Lock()
 	tc.repl.assertStateLocked(ctx, tc.engine)
@@ -7069,9 +7069,7 @@ func TestReplicaDestroy(t *testing.T) {
 		}
 	}
 
-	if err := repl.setDesc(ctx, newDesc); err != nil {
-		t.Fatal(err)
-	}
+	repl.setDesc(ctx, newDesc)
 	expectedErr := "replica descriptor's ID has changed"
 	if err := tc.store.removeReplicaImpl(ctx, tc.repl, origDesc.NextReplicaID, RemoveOptions{
 		DestroyData: true,


### PR DESCRIPTION
Clean up how placeholders are managed to fix #30110, in which a replica
and an overlapping placeholder could exist in Store.replicasByKey at the
same time.

The new strategy is to make Replica.applySnapshot entirely responsible for
removing the placeholder and updating the replica's descriptor upon a
successful preemptive or Raft snapshot. This allows the removal of the
placeholder and the update of the replica's descriptor to be atomic,
taking place under the same acquisition of Store.mu.

Previously, placeholder removal was handled by the store for preemptive
snapshots but by the replica for Raft snapshots (for no good reason).
To complicate matters, it *appeared* that placeholder removal was atomic
with the update of the replicasByKey map because removePlaceholderLocked
and processRangeDescriptorUpdate were called under the same acquisition
of the store lock. In fact, processRangeDescriptorUpdate was a no-op if
the replica was already initialized, as the replicasByKey map would have
already been updated, indirectly, by an earlier and unsynchronized call
to setDescWithoutProcessUpdate.

To prevent regression, this commit teaches placeholder and replica
removal to check the replicasByKey map for overlapping items after an
item is deleted. With these checks in place, but without the fixes in
the rest of this commit, TestStoreRangeMergeReadoptedLHSFollower detects
the overlapping placeholder and replica and fails.

Fix #30110.

Release note: None