### PR TITLE
release-2.1: opt: fold comparison operations during normalization

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -181,7 +181,11 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 	}
 	rowsFn := kvsToRows(leaseMgr, tableHist, ca.spec.Feed, buf.Get)
 
-	ca.tickFn = emitEntries(ca.spec.Feed, ca.sink, rowsFn)
+	var knobs TestingKnobs
+	if cfKnobs, ok := ca.flowCtx.TestingKnobs().Changefeed.(*TestingKnobs); ok {
+		knobs = *cfKnobs
+	}
+	ca.tickFn = emitEntries(ca.spec.Feed, ca.sink, rowsFn, knobs)
 
 	// Give errCh enough buffer both possible errors from supporting goroutines,
 	// but only the first one is ever used.

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -121,8 +121,9 @@ func newChangeAggregatorProcessor(
 
 	buf := makeBuffer()
 	ca.poller = makePoller(
-		flowCtx.Settings, flowCtx.ClientDB, flowCtx.ClientDB.Clock(), flowCtx.Gossip, spans,
-		spec.Feed, initialHighWater, buf)
+		flowCtx.Settings, flowCtx.ClientDB, flowCtx.ClientDB.Clock(), flowCtx.Gossip,
+		spans, spec.Feed, initialHighWater, buf,
+	)
 
 	leaseMgr := flowCtx.LeaseManager.(*sql.LeaseManager)
 	tableHist := makeTableHistory(func(desc *sqlbase.TableDescriptor) error {

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -97,53 +97,22 @@ func newChangeAggregatorProcessor(
 		return nil, err
 	}
 
-	initialHighWater := hlc.Timestamp{WallTime: -1}
-	var spans []roachpb.Span
-	for _, watch := range spec.Watches {
-		spans = append(spans, watch.Span)
-		if initialHighWater.WallTime == -1 || watch.InitialResolved.Less(initialHighWater) {
-			initialHighWater = watch.InitialResolved
+	// Due to the possibility of leaked goroutines, it is not safe to start a sink
+	// in this method because there is no guarantee that the TrailingMetaCallback
+	// method will ever be called (this can happen, for example, if an error
+	// occurs during flow setup).  However, we still want to ensure that the user
+	// has not made any obvious errors when specifying the sink in the CREATE
+	// CHANGEFEED statement. Therefore, we create a "canary" sink, which will be
+	// immediately closed, only to check for errors.
+	{
+		canarySink, err := getSink(ca.spec.Feed.SinkURI, ca.spec.Feed.Targets)
+		if err != nil {
+			return nil, err
+		}
+		if err := canarySink.Close(); err != nil {
+			return nil, err
 		}
 	}
-
-	var err error
-	if ca.sink, err = getSink(spec.Feed.SinkURI, spec.Feed.Targets); err != nil {
-		return nil, err
-	}
-	if b, ok := ca.sink.(*bufferSink); ok {
-		ca.changedRowBuf = &b.buf
-	}
-	// The job registry has a set of metrics used to monitor the various jobs it
-	// runs. They're all stored as the `metric.Struct` interface because of
-	// dependency cycles.
-	metrics := flowCtx.JobRegistry.MetricsStruct().Changefeed.(*Metrics)
-	ca.sink = makeMetricsSink(metrics, ca.sink)
-
-	buf := makeBuffer()
-	ca.poller = makePoller(
-		flowCtx.Settings, flowCtx.ClientDB, flowCtx.ClientDB.Clock(), flowCtx.Gossip,
-		spans, spec.Feed, initialHighWater, buf,
-	)
-
-	leaseMgr := flowCtx.LeaseManager.(*sql.LeaseManager)
-	tableHist := makeTableHistory(func(desc *sqlbase.TableDescriptor) error {
-		// NB: Each new `tableDesc.Version` is initially written with an mvcc
-		// timestamp equal to its `ModificationTime`. It might later update that
-		// `Version` with backfill progress, but we only validate a table
-		// descriptor through its `ModificationTime` before using it, so this
-		// validation function can't depend on anything that changes after a new
-		// `Version` of a table desc is written.
-		return validateChangefeedTable(spec.Feed.Targets, desc)
-	}, initialHighWater)
-	ca.tableHistUpdater = &tableHistoryUpdater{
-		settings: flowCtx.Settings,
-		db:       flowCtx.ClientDB,
-		targets:  spec.Feed.Targets,
-		m:        tableHist,
-	}
-	rowsFn := kvsToRows(leaseMgr, tableHist, spec.Feed, buf.Get)
-
-	ca.tickFn = emitEntries(spec.Feed, ca.sink, rowsFn)
 
 	return ca, nil
 }
@@ -155,9 +124,67 @@ func (ca *changeAggregator) OutputTypes() []sqlbase.ColumnType {
 // Start is part of the RowSource interface.
 func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 	ctx, ca.cancel = context.WithCancel(ctx)
+	// StartInternal called at the beginning of the function because there are
+	// early returns if errors are detected.
+	ctx = ca.StartInternal(ctx, changeAggregatorProcName)
 
-	// Give errCh enough buffer for both of these, but only the first one is
-	// ever used.
+	var err error
+	if ca.sink, err = getSink(ca.spec.Feed.SinkURI, ca.spec.Feed.Targets); err != nil {
+		// Early abort in the case that there is an error creating the sink.
+		ca.MoveToDraining(err)
+		ca.cancel()
+		return ctx
+	}
+
+	// This is the correct point to set up certain hooks depending on the sink
+	// type.
+	if b, ok := ca.sink.(*bufferSink); ok {
+		ca.changedRowBuf = &b.buf
+	}
+
+	initialHighWater := hlc.Timestamp{WallTime: -1}
+	var spans []roachpb.Span
+	for _, watch := range ca.spec.Watches {
+		spans = append(spans, watch.Span)
+		if initialHighWater.WallTime == -1 || watch.InitialResolved.Less(initialHighWater) {
+			initialHighWater = watch.InitialResolved
+		}
+	}
+
+	// The job registry has a set of metrics used to monitor the various jobs it
+	// runs. They're all stored as the `metric.Struct` interface because of
+	// dependency cycles.
+	metrics := ca.flowCtx.JobRegistry.MetricsStruct().Changefeed.(*Metrics)
+	ca.sink = makeMetricsSink(metrics, ca.sink)
+
+	buf := makeBuffer()
+	ca.poller = makePoller(
+		ca.flowCtx.Settings, ca.flowCtx.ClientDB, ca.flowCtx.ClientDB.Clock(), ca.flowCtx.Gossip,
+		spans, ca.spec.Feed, initialHighWater, buf,
+	)
+
+	leaseMgr := ca.flowCtx.LeaseManager.(*sql.LeaseManager)
+	tableHist := makeTableHistory(func(desc *sqlbase.TableDescriptor) error {
+		// NB: Each new `tableDesc.Version` is initially written with an mvcc
+		// timestamp equal to its `ModificationTime`. It might later update that
+		// `Version` with backfill progress, but we only validate a table
+		// descriptor through its `ModificationTime` before using it, so this
+		// validation function can't depend on anything that changes after a new
+		// `Version` of a table desc is written.
+		return validateChangefeedTable(ca.spec.Feed.Targets, desc)
+	}, initialHighWater)
+	ca.tableHistUpdater = &tableHistoryUpdater{
+		settings: ca.flowCtx.Settings,
+		db:       ca.flowCtx.ClientDB,
+		targets:  ca.spec.Feed.Targets,
+		m:        tableHist,
+	}
+	rowsFn := kvsToRows(leaseMgr, tableHist, ca.spec.Feed, buf.Get)
+
+	ca.tickFn = emitEntries(ca.spec.Feed, ca.sink, rowsFn)
+
+	// Give errCh enough buffer both possible errors from supporting goroutines,
+	// but only the first one is ever used.
 	ca.errCh = make(chan error, 2)
 	ca.pollerDoneCh = make(chan struct{})
 	go func(ctx context.Context) {
@@ -178,16 +205,26 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 		ca.cancel()
 	}(ctx)
 
-	ctx = ca.StartInternal(ctx, changeAggregatorProcName)
 	return ctx
 }
 
+// close has two purposes: to synchronize on the completion of the helper
+// goroutines created by the Start method, and to clean up any resources used by
+// the processor. Due to the fact that this method may be called even if the
+// processor did not finish completion, there is an excessive amount of nil
+// checking.
 func (ca *changeAggregator) close() {
 	// Wait for the poller and tableHistUpdater to finish shutting down.
-	<-ca.pollerDoneCh
-	<-ca.tableHistUpdaterDoneCh
-	if err := ca.sink.Close(); err != nil {
-		log.Warningf(ca.Ctx, `error closing sink. goroutines may have leaked: %v`, err)
+	if ca.pollerDoneCh != nil {
+		<-ca.pollerDoneCh
+	}
+	if ca.tableHistUpdaterDoneCh != nil {
+		<-ca.tableHistUpdaterDoneCh
+	}
+	if ca.sink != nil {
+		if err := ca.sink.Close(); err != nil {
+			log.Warningf(ca.Ctx, `error closing sink. goroutines may have leaked: %v`, err)
+		}
 	}
 	// Need to close the mem accounting while the context is still valid.
 	ca.memAcc.Close(ca.Ctx)
@@ -274,6 +311,7 @@ type changeFrontier struct {
 	// sink is the Sink to write resolved timestamps to. Rows are never written
 	// by changeFrontier.
 	sink Sink
+
 	// jobProgressedFn, if non-nil, is called to checkpoint the changefeed's
 	// progress in the corresponding system job entry.
 	jobProgressedFn func(context.Context, jobs.HighWaterProgressedFn) error
@@ -328,25 +366,16 @@ func newChangeFrontierProcessor(
 		return nil, err
 	}
 
-	var err error
-	if cf.sink, err = getSink(spec.Feed.SinkURI, spec.Feed.Targets); err != nil {
-		return nil, err
-	}
-	if b, ok := cf.sink.(*bufferSink); ok {
-		cf.resolvedBuf = &b.buf
-	}
-	// The job registry has a set of metrics used to monitor the various jobs it
-	// runs. They're all stored as the `metric.Struct` interface because of
-	// dependency cycles.
-	cf.metrics = flowCtx.JobRegistry.MetricsStruct().Changefeed.(*Metrics)
-	cf.sink = makeMetricsSink(cf.metrics, cf.sink)
-
-	if spec.JobID != 0 {
-		job, err := flowCtx.JobRegistry.LoadJob(ctx, spec.JobID)
+	// See comment in newChangeAggregatorProcessor for details on the use of canary
+	// sinks.
+	{
+		canarySink, err := getSink(spec.Feed.SinkURI, spec.Feed.Targets)
 		if err != nil {
 			return nil, err
 		}
-		cf.jobProgressedFn = job.HighWaterProgressed
+		if err := canarySink.Close(); err != nil {
+			return nil, err
+		}
 	}
 
 	return cf, nil
@@ -359,7 +388,35 @@ func (cf *changeFrontier) OutputTypes() []sqlbase.ColumnType {
 // Start is part of the RowSource interface.
 func (cf *changeFrontier) Start(ctx context.Context) context.Context {
 	cf.input.Start(ctx)
+
+	// StartInternal called at the beginning of the function because there are
+	// early returns if errors are detected.
 	ctx = cf.StartInternal(ctx, changeFrontierProcName)
+
+	var err error
+	if cf.sink, err = getSink(cf.spec.Feed.SinkURI, cf.spec.Feed.Targets); err != nil {
+		cf.MoveToDraining(err)
+		return ctx
+	}
+
+	if b, ok := cf.sink.(*bufferSink); ok {
+		cf.resolvedBuf = &b.buf
+	}
+
+	// The job registry has a set of metrics used to monitor the various jobs it
+	// runs. They're all stored as the `metric.Struct` interface because of
+	// dependency cycles.
+	cf.metrics = cf.flowCtx.JobRegistry.MetricsStruct().Changefeed.(*Metrics)
+	cf.sink = makeMetricsSink(cf.metrics, cf.sink)
+
+	if cf.spec.JobID != 0 {
+		job, err := cf.flowCtx.JobRegistry.LoadJob(ctx, cf.spec.JobID)
+		if err != nil {
+			cf.MoveToDraining(err)
+			return ctx
+		}
+		cf.jobProgressedFn = job.HighWaterProgressed
+	}
 
 	cf.metrics.mu.Lock()
 	cf.metricsID = cf.metrics.mu.id
@@ -383,8 +440,10 @@ func (cf *changeFrontier) Start(ctx context.Context) context.Context {
 }
 
 func (cf *changeFrontier) close() {
-	if err := cf.sink.Close(); err != nil {
-		log.Warningf(cf.Ctx, `error closing sink. goroutines may have leaked: %v`, err)
+	if cf.sink != nil {
+		if err := cf.sink.Close(); err != nil {
+			log.Warningf(cf.Ctx, `error closing sink. goroutines may have leaked: %v`, err)
+		}
 	}
 	// Need to close the mem accounting while the context is still valid.
 	cf.memAcc.Close(cf.Ctx)

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -116,7 +116,7 @@ func createBenchmarkChangefeed(
 		m:        th,
 	}
 	rowsFn := kvsToRows(s.LeaseManager().(*sql.LeaseManager), th, details, buf.Get)
-	tickFn := emitEntries(details, sink, rowsFn)
+	tickFn := emitEntries(details, sink, rowsFn, TestingKnobs{})
 
 	ctx, cancel := context.WithCancel(ctx)
 	go func() { _ = poller.Run(ctx) }()

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -113,17 +113,24 @@ var (
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_TIMESTAMP_NS,
 	}
+	metaChangefeedSinkErrorRetries = metric.Metadata{
+		Name:        "changefeed.sink_error_retries",
+		Help:        "Total retryable errors encountered while emitting to sinks",
+		Measurement: "Errors",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 const noMinHighWaterSentinel = int64(math.MaxInt64)
 
 // Metrics are for production monitoring of changefeeds.
 type Metrics struct {
-	EmittedMessages *metric.Counter
-	EmittedBytes    *metric.Counter
-	EmitNanos       *metric.Counter
-	Flushes         *metric.Counter
-	FlushNanos      *metric.Counter
+	EmittedMessages  *metric.Counter
+	EmittedBytes     *metric.Counter
+	EmitNanos        *metric.Counter
+	Flushes          *metric.Counter
+	FlushNanos       *metric.Counter
+	SinkErrorRetries *metric.Counter
 
 	mu struct {
 		syncutil.Mutex
@@ -139,11 +146,12 @@ func (*Metrics) MetricStruct() {}
 // MakeMetrics makes the metrics for changefeed monitoring.
 func MakeMetrics() metric.Struct {
 	m := &Metrics{
-		EmittedMessages: metric.NewCounter(metaChangefeedEmittedMessages),
-		EmittedBytes:    metric.NewCounter(metaChangefeedEmittedBytes),
-		EmitNanos:       metric.NewCounter(metaChangefeedEmitNanos),
-		Flushes:         metric.NewCounter(metaChangefeedFlushes),
-		FlushNanos:      metric.NewCounter(metaChangefeedFlushNanos),
+		EmittedMessages:  metric.NewCounter(metaChangefeedEmittedMessages),
+		EmittedBytes:     metric.NewCounter(metaChangefeedEmittedBytes),
+		EmitNanos:        metric.NewCounter(metaChangefeedEmitNanos),
+		Flushes:          metric.NewCounter(metaChangefeedFlushes),
+		FlushNanos:       metric.NewCounter(metaChangefeedFlushNanos),
+		SinkErrorRetries: metric.NewCounter(metaChangefeedSinkErrorRetries),
 	}
 	m.mu.resolved = make(map[int]hlc.Timestamp)
 	m.MinHighWater = metric.NewFunctionalGauge(metaChangefeedMinHighWater, func() int64 {

--- a/pkg/ccl/changefeedccl/poller.go
+++ b/pkg/ccl/changefeedccl/poller.go
@@ -120,7 +120,13 @@ func (p *poller) Run(ctx context.Context) error {
 			}
 		}
 
-		nextHighWater := p.clock.Now()
+		var nextHighWater hlc.Timestamp
+		if p.highWater == (hlc.Timestamp{}) {
+			nextHighWater = p.details.StatementTime
+		} else {
+			nextHighWater = p.clock.Now()
+		}
+
 		log.VEventf(ctx, 1, `changefeed poll [%s,%s): %s`,
 			p.highWater, nextHighWater, time.Duration(nextHighWater.WallTime-p.highWater.WallTime))
 

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -274,6 +274,9 @@ func (s *kafkaSink) Flush(ctx context.Context) error {
 		flushErr := s.mu.flushErr
 		s.mu.flushErr = nil
 		s.mu.Unlock()
+		if _, ok := flushErr.(*sarama.ProducerError); ok {
+			flushErr = &retryableSinkError{cause: flushErr}
+		}
 		return flushErr
 	}
 }
@@ -548,4 +551,34 @@ func (s *bufferSink) Flush(_ context.Context) error {
 func (s *bufferSink) Close() error {
 	s.closed = true
 	return nil
+}
+
+// causer matches the (unexported) interface used by Go to allow errors to wrap
+// their parent cause.
+type causer interface {
+	Cause() error
+}
+
+// retryableSinkError should be used by sinks to wrap any error which may
+// be retried.
+type retryableSinkError struct {
+	cause error
+}
+
+func (e retryableSinkError) Error() string { return e.cause.Error() }
+func (e retryableSinkError) Cause() error  { return e.cause }
+
+// isRetryableSinkError returns true if the supplied error, or any of its parent
+// causes, is a retryableSinkError.
+func isRetryableSinkError(err error) bool {
+	for {
+		if _, ok := err.(retryableSinkError); ok {
+			return true
+		}
+		if e, ok := err.(causer); ok {
+			err = e.Cause()
+			continue
+		}
+		return false
+	}
 }

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -392,6 +392,7 @@ func makeSQLSink(uri, tableName string, targets jobspb.ChangefeedTargets) (*sqlS
 		return nil, err
 	}
 	if _, err := db.Exec(fmt.Sprintf(sqlSinkCreateTableStmt, tableName)); err != nil {
+		db.Close()
 		return nil, err
 	}
 

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -1,0 +1,19 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+// TestingKnobs are the testing knobs for changefeed.
+type TestingKnobs struct {
+	// AfterSinkFlush is called after a sink flush operation has returned without
+	// error.
+	AfterSinkFlush func() error
+}
+
+// ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
+func (*TestingKnobs) ModuleTestingKnobs() {}

--- a/pkg/cmd/docgen/funcs.go
+++ b/pkg/cmd/docgen/funcs.go
@@ -134,7 +134,7 @@ func generateOperators() []byte {
 	for optyp, overloads := range tree.CmpOps {
 		op := optyp.String()
 		for _, untyped := range overloads {
-			v := untyped.(tree.CmpOp)
+			v := untyped.(*tree.CmpOp)
 			left := v.LeftType.String()
 			right := v.RightType.String()
 			ops[op] = append(ops[op], operation{

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -131,6 +131,11 @@ func (ctx *FlowCtx) NewEvalCtx() *tree.EvalContext {
 	return &evalCtx
 }
 
+// TestingKnobs returns the distsql testing knobs for this flow context.
+func (ctx *FlowCtx) TestingKnobs() TestingKnobs {
+	return ctx.testingKnobs
+}
+
 type flowStatus int
 
 // Flow status indicators.

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -617,6 +617,9 @@ type TestingKnobs struct {
 	// DeterministicStats overrides stats which don't have reliable values, like
 	// stall time and bytes sent. It replaces them with a zero value.
 	DeterministicStats bool
+
+	// Changefeed contains testing knobs specific to the changefeed system.
+	Changefeed base.ModuleTestingKnobs
 }
 
 // MetadataTestLevel represents the types of queries where metadata test

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -888,3 +888,8 @@ SELECT (t).a FROM t
 
 statement ok
 DROP TABLE t
+
+query B
+SELECT (1, 2, 3) IS NULL AS r
+----
+false

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -947,28 +947,3 @@ select
                 └── tuple [type=tuple{int, int}]
                      ├── const: 4 [type=int]
                      └── const: 1 [type=int]
-
-opt
-SELECT * FROM c WHERE (1, 2) IN ((1, 2))
-----
-select
- ├── columns: k:1(int!null) u:2(int) v:3(int)
- ├── key: (1)
- ├── fd: (1)-->(2,3)
- ├── prune: (1-3)
- ├── interesting orderings: (+1) (+3,+2,+1)
- ├── scan c
- │    ├── columns: k:1(int!null) u:2(int) v:3(int)
- │    ├── key: (1)
- │    ├── fd: (1)-->(2,3)
- │    ├── prune: (1-3)
- │    └── interesting orderings: (+1) (+3,+2,+1)
- └── filters [type=bool]
-      └── in [type=bool]
-           ├── tuple [type=tuple{int, int}]
-           │    ├── const: 1 [type=int]
-           │    └── const: 2 [type=int]
-           └── tuple [type=tuple{tuple{int, int}}]
-                └── tuple [type=tuple{int, int}]
-                     ├── const: 1 [type=int]
-                     └── const: 2 [type=int]

--- a/pkg/sql/opt/memo/typing_test.go
+++ b/pkg/sql/opt/memo/typing_test.go
@@ -137,6 +137,32 @@ func TestTypingBinaryAssumptions(t *testing.T) {
 	}
 }
 
+// TestTypingComparisonAssumptions ensures that comparison overloads conform to
+// certain assumptions we're making in the type inference code:
+//   1. The overload can be inferred from the operator type and the data
+//      types of its operands.
+func TestTypingComparisonAssumptions(t *testing.T) {
+	for name, overloads := range tree.CmpOps {
+		for i, overload := range overloads {
+			op := overload.(*tree.CmpOp)
+
+			// Check for basic ambiguity where two different comparison op overloads
+			// both allow equivalent operand types.
+			for i2, overload2 := range overloads {
+				if i == i2 {
+					continue
+				}
+
+				op2 := overload2.(*tree.CmpOp)
+				if op.LeftType.Equivalent(op2.LeftType) && op.RightType.Equivalent(op2.RightType) {
+					format := "found equivalent operand type ambiguity for %s:\n%+v\n%+v"
+					t.Errorf(format, name, op, op2)
+				}
+			}
+		}
+	}
+}
+
 // TestTypingAggregateAssumptions ensures that aggregate overloads conform to
 // certain assumptions we're making in the type inference code:
 //   1. The return type can be inferred from the operator type and the data

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -930,11 +930,11 @@ func (c *CustomFuncs) SimplifyCoalesce(args memo.ListID) memo.GroupID {
 	for i := 0; i < int(args.Length-1); i++ {
 		// If item is not a constant value, then its value may turn out to be
 		// null, so no more folding. Return operands from then on.
-		item := c.mem.NormExpr(argList[i])
-		if !item.IsConstValue() {
+		if !c.IsConstValueOrTuple(argList[i]) {
 			return c.f.ConstructCoalesce(c.f.InternList(argList[i:]))
 		}
 
+		item := c.mem.NormExpr(argList[i])
 		if item.Operator() != opt.NullOp {
 			return argList[i]
 		}
@@ -1031,38 +1031,76 @@ func (c *CustomFuncs) EqualsNumber(private memo.PrivateID, value int64) bool {
 //
 // ----------------------------------------------------------------------
 
+// IsListOfConstants returns true if elems is a list of constant values or
+// tuples.
+func (c *CustomFuncs) IsListOfConstants(elems memo.ListID) bool {
+	for _, elem := range c.mem.LookupList(elems) {
+		if !c.IsConstValueOrTuple(elem) {
+			return false
+		}
+	}
+	return true
+}
+
+// FoldArray evaluates an Array expression with constant inputs. It returns the
+// array as a Const datum with type TArray.
+func (c *CustomFuncs) FoldArray(elems memo.ListID, typ memo.PrivateID) memo.GroupID {
+	elements := c.mem.LookupList(elems)
+	elementType := c.ExtractType(typ).(types.TArray).Typ
+	a := tree.NewDArray(elementType)
+	a.Array = make(tree.Datums, len(elements))
+	for i := range a.Array {
+		elem := memo.MakeNormExprView(c.mem, elements[i])
+		a.Array[i] = memo.ExtractConstDatum(elem)
+		if a.Array[i] == tree.DNull {
+			a.HasNulls = true
+		}
+	}
+	return c.f.ConstructConst(c.f.InternDatum(a))
+}
+
 // FoldSucceeded returns true if the result of a constant-folding operation
 // is a valid memo group.
 func (c *CustomFuncs) FoldSucceeded(result memo.GroupID) bool {
 	return result != 0
 }
 
+// IsConstValueOrTuple returns true if the input is a constant or a tuple of
+// constants.
+func (c *CustomFuncs) IsConstValueOrTuple(input memo.GroupID) bool {
+	ev := memo.MakeNormExprView(c.mem, input)
+	return ev.IsConstValue() || memo.MatchesTupleOfConstants(ev)
+}
+
 // FoldBinary evaluates a binary expression with constant inputs. It returns
 // a constant expression as long as it finds an appropriate overload function
 // for the given operator and input types, and the evaluation causes no error.
 func (c *CustomFuncs) FoldBinary(op opt.Operator, left, right memo.GroupID) memo.GroupID {
-	leftDatum := c.ExtractConstValue(left).(tree.Datum)
-	rightDatum := c.ExtractConstValue(right).(tree.Datum)
+	lEv, rEv := memo.MakeNormExprView(c.mem, left), memo.MakeNormExprView(c.mem, right)
+	lDatum, rDatum := memo.ExtractConstDatum(lEv), memo.ExtractConstDatum(rEv)
+	lType, rType := lEv.Logical().Scalar.Type, rEv.Logical().Scalar.Type
 
-	o, ok := memo.FindBinaryOverload(op, leftDatum.ResolvedType(), rightDatum.ResolvedType())
+	o, ok := memo.FindBinaryOverload(op, lType, rType)
 	if !ok {
 		return 0
 	}
 
-	result, err := o.Fn(c.f.evalCtx, leftDatum, rightDatum)
+	result, err := o.Fn(c.f.evalCtx, lDatum, rDatum)
 	if err != nil {
 		return 0
 	}
-	return c.f.ConstructConst(c.f.InternDatum(result))
+	return c.f.ConstructConstVal(result)
 }
 
 // FoldUnary evaluates a unary expression with a constant input. It returns
 // a constant expression as long as it finds an appropriate overload function
 // for the given operator and input type, and the evaluation causes no error.
 func (c *CustomFuncs) FoldUnary(op opt.Operator, input memo.GroupID) memo.GroupID {
-	datum := c.ExtractConstValue(input).(tree.Datum)
+	ev := memo.MakeNormExprView(c.mem, input)
+	datum := memo.ExtractConstDatum(ev)
+	typ := ev.Logical().Scalar.Type
 
-	o, ok := memo.FindUnaryOverload(op, datum.ResolvedType())
+	o, ok := memo.FindUnaryOverload(op, typ)
 	if !ok {
 		return 0
 	}
@@ -1071,5 +1109,26 @@ func (c *CustomFuncs) FoldUnary(op opt.Operator, input memo.GroupID) memo.GroupI
 	if err != nil {
 		return 0
 	}
-	return c.f.ConstructConst(c.f.InternDatum(result))
+	return c.f.ConstructConstVal(result)
+}
+
+// FoldComparison evaluates a comparison expression with constant inputs. It
+// returns a constant expression as long as it finds an appropriate overload
+// function for the given operator and input types, and the evaluation causes
+// no error.
+func (c *CustomFuncs) FoldComparison(op opt.Operator, left, right memo.GroupID) memo.GroupID {
+	lEv, rEv := memo.MakeNormExprView(c.mem, left), memo.MakeNormExprView(c.mem, right)
+	lDatum, rDatum := memo.ExtractConstDatum(lEv), memo.ExtractConstDatum(rEv)
+	lType, rType := lEv.Logical().Scalar.Type, rEv.Logical().Scalar.Type
+
+	o, ok := memo.FindComparisonOverload(op, lType, rType)
+	if !ok {
+		return 0
+	}
+
+	result, err := o.Fn(c.f.evalCtx, lDatum, rDatum)
+	if err != nil {
+		return 0
+	}
+	return c.f.ConstructConstVal(result)
 }

--- a/pkg/sql/opt/norm/rules/comp.opt
+++ b/pkg/sql/opt/norm/rules/comp.opt
@@ -146,7 +146,7 @@
 # FoldNonNullIsNull replaces x IS NULL with False where x is a non-Null constant.
 [FoldNonNullIsNull, Normalize]
 (Is
-  (ConstValue) & ^(Null)
+  $left:^(Null) & (IsConstValueOrTuple $left)
   (Null)
 )
 =>
@@ -159,7 +159,7 @@
 # FoldNonNullIsNotNull replaces x IS NOT NULL with True where x is a non-Null constant.
 [FoldNonNullIsNotNull, Normalize]
 (IsNot
-  (ConstValue) & ^(Null)
+  $left:^(Null) & (IsConstValueOrTuple $left)
   (Null)
 )
 =>

--- a/pkg/sql/opt/norm/rules/fold_constants.opt
+++ b/pkg/sql/opt/norm/rules/fold_constants.opt
@@ -2,6 +2,16 @@
 # fold_constants.opt contains normalization rules for folding constants.
 # =============================================================================
 
+# FoldArray evaluates an Array expression with constant inputs. It replaces the
+# Array with a Const datum with type TArray.
+[FoldArray, Normalize]
+(Array
+  $elems:* & (IsListOfConstants $elems)
+  $typ:*
+)
+=>
+(FoldArray $elems $typ)
+
 # FoldBinary evaluates a binary operation over constant inputs, replacing the
 # entire expression with a constant. The rule applies as long as the evaluation
 # would not cause an error. Any errors should be saved for execution time,
@@ -12,10 +22,13 @@
 #
 # In this query, the ELSE clause is not executed, so the divide-by-zero error
 # should not be triggered.
-[FoldBinary, Normalize]
+#
+# This rule is marked as low priority so that the FoldNull rules in scalar.opt
+# can run first.
+[FoldBinary, Normalize, LowPriority]
 (Binary
-  $left:(Const)
-  $right:(Const) & (FoldSucceeded $result:(FoldBinary (OpName) $left $right))
+  $left:* & (IsConstValueOrTuple $left)
+  $right:* & (IsConstValueOrTuple $right) & (FoldSucceeded $result:(FoldBinary (OpName) $left $right))
 )
 =>
 $result
@@ -23,9 +36,26 @@ $result
 # FoldUnary is similar to FoldBinary, but it involves a unary operation over a
 # single constant input. As with FoldBinary, FoldUnary applies as long as the
 # evaluation would not cause an error.
-[FoldUnary, Normalize]
+#
+# This rule is marked as low priority so that the FoldNull rules in scalar.opt
+# can run first.
+[FoldUnary, Normalize, LowPriority]
 (Unary
-  $input:(Const) & (FoldSucceeded $result:(FoldUnary (OpName) $input))
+  $input:* & (IsConstValueOrTuple $input) & (FoldSucceeded $result:(FoldUnary (OpName) $input))
+)
+=>
+$result
+
+# FoldComparison is similar to FoldBinary, but it involves a comparison
+# operation. As with FoldBinary, FoldComparison applies as long as the
+# evaluation would not cause an error.
+#
+# This rule is marked as low priority so that the FoldNull rules in scalar.opt
+# can run first.
+[FoldComparison, Normalize, LowPriority]
+(Comparison
+  $left:* & (IsConstValueOrTuple $left)
+  $right:* & (IsConstValueOrTuple $right) & (FoldSucceeded $result:(FoldComparison (OpName) $left $right))
 )
 =>
 $result

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -48,7 +48,7 @@
 # operand is a constant, replaces with that constant. Note that ConstValue
 # matches nulls as well as other constants.
 [SimplifyCoalesce, Normalize]
-(Coalesce $args:[ (ConstValue) ... ]) => (SimplifyCoalesce $args)
+(Coalesce $args:[ $arg:* & (IsConstValueOrTuple $arg) ... ]) => (SimplifyCoalesce $args)
 
 # EliminateCast discards the cast operator if its input already has a type
 # that's equivalent to the desired static type.

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -319,6 +319,21 @@ project
  └── projections
       └── false [type=bool]
 
+opt expect=FoldNonNullIsNull
+SELECT (1, 2, 3) IS NULL AS r
+----
+project
+ ├── columns: r:1(bool!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── projections
+      └── false [type=bool]
+
 # --------------------------------------------------
 # FoldIsNotNull
 # --------------------------------------------------
@@ -358,6 +373,21 @@ project
       ├── true [type=bool]
       ├── k IS NOT NULL [type=bool, outer=(1)]
       └── i IS NOT NULL [type=bool, outer=(2)]
+
+opt expect=FoldNonNullIsNotNull
+SELECT (1, 2, 3) IS NOT NULL AS r
+----
+project
+ ├── columns: r:1(bool!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── projections
+      └── true [type=bool]
 
 # --------------------------------------------------
 # CommuteNullIs

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1889,7 +1889,7 @@ project
  └── select
       ├── columns: c:1(int!null) d:2(int) array_agg:5(int[]!null)
       ├── key: (1)
-      ├── fd: (1)-->(2,5)
+      ├── fd: ()-->(5), (1)-->(2)
       ├── project
       │    ├── columns: array_agg:5(int[]) c:1(int!null) d:2(int)
       │    ├── key: (1)
@@ -1922,8 +1922,8 @@ project
       │    │              └── variable: x [type=int, outer=(3)]
       │    └── projections [outer=(1-3,6)]
       │         └── CASE WHEN x IS NOT NULL THEN array_agg END [type=int[], outer=(3,6)]
-      └── filters [type=bool, outer=(5), constraints=(/5: (/NULL - ])]
-           └── array_agg = ARRAY[] [type=bool, outer=(5), constraints=(/5: (/NULL - ])]
+      └── filters [type=bool, outer=(5), constraints=(/5: [/ARRAY[] - /ARRAY[]]; tight), fd=()-->(5)]
+           └── array_agg = ARRAY[] [type=bool, outer=(5), constraints=(/5: [/ARRAY[] - /ARRAY[]]; tight)]
 
 norm
 SELECT * FROM a WHERE 'foo'=(SELECT concat_agg(y::string) FROM xy WHERE x=k)

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -1,13 +1,44 @@
 # --------------------------------------------------
-# FoldBinary
+# FoldArray
 # --------------------------------------------------
 
-# Fold constant.
-opt
-SELECT 1 + 2
+exec-ddl
+CREATE TABLE t (
+  x INT PRIMARY KEY
+)
+----
+TABLE t
+ ├── x int not null
+ └── INDEX primary
+      └── x int not null
+
+opt expect=FoldArray
+SELECT ARRAY[1, 2, 3] FROM t
 ----
 project
- ├── columns: "?column?":1(int!null)
+ ├── columns: array:2(int[]!null)
+ ├── fd: ()-->(2)
+ ├── scan t
+ └── projections
+      └── const: ARRAY[1,2,3] [type=int[]]
+
+# Do not fold if there is a non-constant element.
+opt expect-not=FoldArray
+SELECT ARRAY[1, 2, 3, x] FROM t
+----
+project
+ ├── columns: array:2(int[])
+ ├── scan t
+ │    ├── columns: x:1(int!null)
+ │    └── key: (1)
+ └── projections [outer=(1)]
+      └── ARRAY[1, 2, 3, x] [type=int[], outer=(1)]
+
+opt expect=FoldArray
+SELECT ARRAY['foo', 'bar']
+----
+project
+ ├── columns: array:1(string[]!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -16,10 +47,30 @@ project
  │    ├── key: ()
  │    └── tuple [type=tuple]
  └── projections
-      └── const: 3 [type=int]
+      └── const: ARRAY['foo','bar'] [type=string[]]
+
+# --------------------------------------------------
+# FoldBinary
+# --------------------------------------------------
+
+# Fold constant.
+opt expect=FoldBinary
+SELECT 1::INT + 2::DECIMAL
+----
+project
+ ├── columns: "?column?":1(decimal!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── projections
+      └── const: 3 [type=decimal]
 
 # Don't fold: out of range error.
-opt
+opt expect-not=FoldBinary
 SELECT 9223372036854775800::INT + 9223372036854775800::INT
 ----
 project
@@ -35,7 +86,7 @@ project
       └── 9223372036854775800 + 9223372036854775800 [type=int]
 
 # Fold constant.
-opt
+opt expect=FoldBinary
 SELECT 1::INT - 2::INT
 ----
 project
@@ -51,7 +102,7 @@ project
       └── const: -1 [type=int]
 
 # Don't fold: out of range error.
-opt
+opt expect-not=FoldBinary
 SELECT (-9223372036854775800)::INT - 9223372036854775800::INT
 ----
 project
@@ -67,8 +118,8 @@ project
       └── -9223372036854775800 - 9223372036854775800 [type=int]
 
 # Fold constant.
-opt
-SELECT 1 * 2
+opt expect=FoldBinary
+SELECT 4::INT * 2::INT
 ----
 project
  ├── columns: "?column?":1(int!null)
@@ -80,10 +131,10 @@ project
  │    ├── key: ()
  │    └── tuple [type=tuple]
  └── projections
-      └── const: 2 [type=int]
+      └── const: 8 [type=int]
 
 # Don't fold: out of range error.
-opt
+opt expect-not=FoldBinary
 SELECT 9223372036854775800::INT * 9223372036854775800::INT
 ----
 project
@@ -99,11 +150,11 @@ project
       └── 9223372036854775800 * 9223372036854775800 [type=int]
 
 # Fold constant.
-opt
-SELECT 1 / 2
+opt expect=FoldBinary
+SELECT 1::FLOAT / 2::FLOAT
 ----
 project
- ├── columns: "?column?":1(decimal!null)
+ ├── columns: "?column?":1(float!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -112,11 +163,11 @@ project
  │    ├── key: ()
  │    └── tuple [type=tuple]
  └── projections
-      └── const: 0.5 [type=decimal]
+      └── const: 0.5 [type=float]
 
 # Don't fold: divide by zero error.
-opt
-SELECT 1 / 0
+opt expect-not=FoldBinary
+SELECT 1::INT / 0::INT
 ----
 project
  ├── columns: "?column?":1(decimal)
@@ -132,7 +183,7 @@ project
       └── 1 / 0 [type=decimal, side-effects]
 
 # Fold constant.
-opt
+opt expect=FoldBinary
 SELECT '2000-05-05 10:00:00+03':::TIMESTAMP - '2000-05-06 10:00:00+03':::TIMESTAMP
 ----
 project
@@ -148,7 +199,7 @@ project
       └── const: '-24h' [type=interval]
 
 # Fold constant.
-opt
+opt expect=FoldBinary
 SELECT '2000-05-05 10:00:00+03':::TIMESTAMP - '2000-05-06 10:00:00+03':::TIMESTAMPTZ
 ----
 project
@@ -163,10 +214,58 @@ project
  └── projections
       └── const: '-21h' [type=interval]
 
+# Fold constant.
+opt expect=FoldBinary
+SELECT ARRAY['a','b','c'] || 'd'
+----
+project
+ ├── columns: "?column?":1(string[]!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── projections
+      └── const: ARRAY['a','b','c','d'] [type=string[]]
+
+# Fold constant.
+opt expect=FoldBinary
+SELECT ARRAY['a','b','c'] || ARRAY['d','e','f']
+----
+project
+ ├── columns: "?column?":1(string[]!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── projections
+      └── const: ARRAY['a','b','c','d','e','f'] [type=string[]]
+
+# NULL should not be added to the array.
+opt expect=FoldBinary
+SELECT ARRAY[1,2,3] || NULL
+----
+project
+ ├── columns: "?column?":1(int[]!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── projections
+      └── const: ARRAY[1,2,3] [type=int[]]
+
 # --------------------------------------------------
 # FoldUnary
 # --------------------------------------------------
-opt
+opt expect=FoldUnary
 SELECT -(1:::int)
 ----
 project
@@ -181,7 +280,7 @@ project
  └── projections
       └── const: -1 [type=int]
 
-opt
+opt expect=FoldUnary
 SELECT -(1:::float)
 ----
 project
@@ -198,7 +297,7 @@ project
 
 # TODO(justin): it would be better if this produced an error in the optimizer
 # rather than falling back to execution to error.
-opt format=show-all
+opt expect-not=FoldUnary format=show-all
 SELECT -((-9223372036854775808)::int)
 ----
 project
@@ -219,7 +318,7 @@ project
       └── unary-minus [type=int]
            └── const: -9223372036854775808 [type=int]
 
-opt format=show-all
+opt expect=FoldUnary format=show-all
 SELECT -(1:::decimal)
 ----
 project
@@ -239,7 +338,7 @@ project
  └── projections
       └── const: -1 [type=decimal]
 
-opt format=show-all
+opt expect=FoldUnary format=show-all
 SELECT -('-1d'::interval);
 ----
 project
@@ -261,7 +360,7 @@ project
 
 # TODO(justin): this seems incorrect but it's consistent with the existing
 # planner. Revisit this: #26932.
-opt
+opt expect=FoldUnary
 SELECT -('-9223372036854775808d'::interval);
 ----
 project
@@ -277,7 +376,7 @@ project
       └── const: '-9223372036854775808d' [type=interval]
 
 # Fold constant.
-opt
+opt expect=FoldUnary
 SELECT ~(500::INT)
 ----
 project
@@ -293,7 +392,7 @@ project
       └── const: -501 [type=int]
 
 # Fold constant.
-opt
+opt expect=FoldUnary
 SELECT ~('35.231.178.195'::INET)
 ----
 project
@@ -307,3 +406,103 @@ project
  │    └── tuple [type=tuple]
  └── projections
       └── const: '220.24.77.60' [type=inet]
+
+# --------------------------------------------------
+# FoldComparison
+# --------------------------------------------------
+
+# Fold constant.
+opt expect=FoldComparison
+SELECT 1::INT < 2::INT
+----
+project
+ ├── columns: "?column?":1(bool!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── projections
+      └── true [type=bool]
+
+# Fold constant.
+opt expect=FoldComparison
+SELECT 2.0::DECIMAL = 2::INT
+----
+project
+ ├── columns: "?column?":1(bool!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── projections
+      └── true [type=bool]
+
+# Fold constant.
+opt expect=FoldComparison
+SELECT 100 IS NOT DISTINCT FROM 200
+----
+project
+ ├── columns: "?column?":1(bool!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── projections
+      └── false [type=bool]
+
+# Fold constant.
+opt expect=FoldComparison
+SELECT 'foo' IN ('a', 'b', 'c')
+----
+project
+ ├── columns: "?column?":1(bool!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── projections
+      └── false [type=bool]
+
+# Fold constant.
+opt expect=FoldComparison
+SELECT '[1, 2]'::JSONB <@ '[1, 2, 3]'::JSONB
+----
+project
+ ├── columns: "?column?":1(bool!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── projections
+      └── true [type=bool]
+
+# Fold constant.
+opt expect=FoldComparison
+SELECT ('a', 'b', 'c') = ('d', 'e', 'f')
+----
+project
+ ├── columns: "?column?":1(bool!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── projections
+      └── false [type=bool]

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -139,6 +139,17 @@ project
  └── projections [outer=(2)]
       └── COALESCE(i, NULL, NULL) [type=int, outer=(2)]
 
+opt expect=SimplifyCoalesce
+SELECT COALESCE((1, 2, 3), (2, 3, 4)) FROM a
+----
+project
+ ├── columns: coalesce:7(tuple{int, int, int})
+ ├── fd: ()-->(7)
+ ├── scan a
+ └── projections
+      └── (1, 2, 3) [type=tuple{int, int, int}]
+
+
 # --------------------------------------------------
 # EliminateCast
 # --------------------------------------------------

--- a/pkg/sql/sem/tree/compare_test.go
+++ b/pkg/sql/sem/tree/compare_test.go
@@ -62,7 +62,7 @@ func TestEvalComparisonExprCaching(t *testing.T) {
 		if _, err := typedExpr.Eval(ctx); err != nil {
 			t.Fatalf("%v: %v", d, err)
 		}
-		if typedExpr.(*ComparisonExpr).fn.fn == nil {
+		if typedExpr.(*ComparisonExpr).fn.Fn == nil {
 			t.Errorf("%s: expected the comparison function to be looked up and memoized, but it wasn't", expr)
 		}
 		if count := ctx.ReCache.Len(); count != d.cacheCount {

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1485,43 +1485,43 @@ type CmpOp struct {
 	NullableArgs bool
 
 	// Datum return type is a union between *DBool and dNull.
-	fn func(*EvalContext, Datum, Datum) (Datum, error)
+	Fn func(*EvalContext, Datum, Datum) (Datum, error)
 
 	types       TypeList
 	isPreferred bool
 }
 
-func (op CmpOp) params() TypeList {
+func (op *CmpOp) params() TypeList {
 	return op.types
 }
 
-func (op CmpOp) matchParams(l, r types.T) bool {
+func (op *CmpOp) matchParams(l, r types.T) bool {
 	return op.params().MatchAt(l, 0) && op.params().MatchAt(r, 1)
 }
 
 var cmpOpReturnType = FixedReturnType(types.Bool)
 
-func (op CmpOp) returnType() ReturnTyper {
+func (op *CmpOp) returnType() ReturnTyper {
 	return cmpOpReturnType
 }
 
-func (op CmpOp) preferred() bool {
+func (op *CmpOp) preferred() bool {
 	return op.isPreferred
 }
 
 func init() {
 	// Array equality comparisons.
 	for _, t := range types.AnyNonArray {
-		CmpOps[EQ] = append(CmpOps[EQ], CmpOp{
+		CmpOps[EQ] = append(CmpOps[EQ], &CmpOp{
 			LeftType:  types.TArray{Typ: t},
 			RightType: types.TArray{Typ: t},
-			fn:        cmpOpScalarEQFn,
+			Fn:        cmpOpScalarEQFn,
 		})
 
-		CmpOps[IsNotDistinctFrom] = append(CmpOps[IsNotDistinctFrom], CmpOp{
+		CmpOps[IsNotDistinctFrom] = append(CmpOps[IsNotDistinctFrom], &CmpOp{
 			LeftType:     types.TArray{Typ: t},
 			RightType:    types.TArray{Typ: t},
-			fn:           cmpOpScalarIsFn,
+			Fn:           cmpOpScalarIsFn,
 			NullableArgs: true,
 		})
 	}
@@ -1530,7 +1530,7 @@ func init() {
 func init() {
 	for op, overload := range CmpOps {
 		for i, impl := range overload {
-			casted := impl.(CmpOp)
+			casted := impl.(*CmpOp)
 			casted.types = ArgTypes{{"left", casted.LeftType}, {"right", casted.RightType}}
 			CmpOps[op][i] = casted
 		}
@@ -1540,37 +1540,37 @@ func init() {
 // cmpOpOverload is an overloaded set of comparison operator implementations.
 type cmpOpOverload []overloadImpl
 
-func (o cmpOpOverload) lookupImpl(left, right types.T) (CmpOp, bool) {
+func (o cmpOpOverload) lookupImpl(left, right types.T) (*CmpOp, bool) {
 	for _, fn := range o {
-		casted := fn.(CmpOp)
+		casted := fn.(*CmpOp)
 		if casted.matchParams(left, right) {
 			return casted, true
 		}
 	}
-	return CmpOp{}, false
+	return nil, false
 }
 
 func makeCmpOpOverload(
 	fn func(ctx *EvalContext, left, right Datum) (Datum, error), a, b types.T, nullableArgs bool,
-) CmpOp {
-	return CmpOp{
+) *CmpOp {
+	return &CmpOp{
 		LeftType:     a,
 		RightType:    b,
-		fn:           fn,
+		Fn:           fn,
 		NullableArgs: nullableArgs,
 	}
 }
 
-func makeEqFn(a, b types.T) CmpOp {
+func makeEqFn(a, b types.T) *CmpOp {
 	return makeCmpOpOverload(cmpOpScalarEQFn, a, b, false /* NullableArgs */)
 }
-func makeLtFn(a, b types.T) CmpOp {
+func makeLtFn(a, b types.T) *CmpOp {
 	return makeCmpOpOverload(cmpOpScalarLTFn, a, b, false /* NullableArgs */)
 }
-func makeLeFn(a, b types.T) CmpOp {
+func makeLeFn(a, b types.T) *CmpOp {
 	return makeCmpOpOverload(cmpOpScalarLEFn, a, b, false /* NullableArgs */)
 }
-func makeIsFn(a, b types.T) CmpOp {
+func makeIsFn(a, b types.T) *CmpOp {
 	return makeCmpOpOverload(cmpOpScalarIsFn, a, b, true /* NullableArgs */)
 }
 
@@ -1610,10 +1610,10 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		makeEqFn(types.TimestampTZ, types.Timestamp),
 
 		// Tuple comparison.
-		CmpOp{
+		&CmpOp{
 			LeftType:  types.FamTuple,
 			RightType: types.FamTuple,
-			fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
 				return cmpOpTupleFn(ctx, *left.(*DTuple), *right.(*DTuple), EQ), nil
 			},
 		},
@@ -1652,10 +1652,10 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		makeLtFn(types.TimestampTZ, types.Timestamp),
 
 		// Tuple comparison.
-		CmpOp{
+		&CmpOp{
 			LeftType:  types.FamTuple,
 			RightType: types.FamTuple,
-			fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
 				return cmpOpTupleFn(ctx, *left.(*DTuple), *right.(*DTuple), LT), nil
 			},
 		},
@@ -1694,20 +1694,20 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		makeLeFn(types.TimestampTZ, types.Timestamp),
 
 		// Tuple comparison.
-		CmpOp{
+		&CmpOp{
 			LeftType:  types.FamTuple,
 			RightType: types.FamTuple,
-			fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
 				return cmpOpTupleFn(ctx, *left.(*DTuple), *right.(*DTuple), LE), nil
 			},
 		},
 	},
 
 	IsNotDistinctFrom: {
-		CmpOp{
+		&CmpOp{
 			LeftType:     types.Unknown,
 			RightType:    types.Unknown,
-			fn:           cmpOpScalarIsFn,
+			Fn:           cmpOpScalarIsFn,
 			NullableArgs: true,
 			// Avoids ambiguous comparison error for NULL IS NOT DISTINCT FROM NULL>
 			isPreferred: true,
@@ -1745,10 +1745,11 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		makeIsFn(types.TimestampTZ, types.Timestamp),
 
 		// Tuple comparison.
-		CmpOp{
-			LeftType:  types.FamTuple,
-			RightType: types.FamTuple,
-			fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+		&CmpOp{
+			LeftType:     types.FamTuple,
+			RightType:    types.FamTuple,
+			NullableArgs: true,
+			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
 				if left == DNull || right == DNull {
 					return MakeDBool(left == DNull && right == DNull), nil
 				}
@@ -1778,30 +1779,30 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 	},
 
 	Like: {
-		CmpOp{
+		&CmpOp{
 			LeftType:  types.String,
 			RightType: types.String,
-			fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
 				return matchLike(ctx, left, right, false)
 			},
 		},
 	},
 
 	ILike: {
-		CmpOp{
+		&CmpOp{
 			LeftType:  types.String,
 			RightType: types.String,
-			fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
 				return matchLike(ctx, left, right, true)
 			},
 		},
 	},
 
 	SimilarTo: {
-		CmpOp{
+		&CmpOp{
 			LeftType:  types.String,
 			RightType: types.String,
-			fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
 				key := similarToKey{s: string(MustBeDString(right)), escape: '\\'}
 				return matchRegexpWithKey(ctx, left, key)
 			},
@@ -1809,10 +1810,10 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 	},
 
 	RegMatch: {
-		CmpOp{
+		&CmpOp{
 			LeftType:  types.String,
 			RightType: types.String,
-			fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
 				key := regexpKey{s: string(MustBeDString(right)), caseInsensitive: false}
 				return matchRegexpWithKey(ctx, left, key)
 			},
@@ -1820,10 +1821,10 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 	},
 
 	RegIMatch: {
-		CmpOp{
+		&CmpOp{
 			LeftType:  types.String,
 			RightType: types.String,
-			fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
 				key := regexpKey{s: string(MustBeDString(right)), caseInsensitive: true}
 				return matchRegexpWithKey(ctx, left, key)
 			},
@@ -1831,10 +1832,10 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 	},
 
 	JSONExists: {
-		CmpOp{
+		&CmpOp{
 			LeftType:  types.JSON,
 			RightType: types.String,
-			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
+			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				e, err := left.(*DJSON).JSON.Exists(string(MustBeDString(right)))
 				if err != nil {
 					return nil, err
@@ -1848,10 +1849,10 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 	},
 
 	JSONSomeExists: {
-		CmpOp{
+		&CmpOp{
 			LeftType:  types.JSON,
 			RightType: types.TArray{Typ: types.String},
-			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
+			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				// TODO(justin): this can be optimized.
 				for _, k := range MustBeDArray(right).Array {
 					if k == DNull {
@@ -1871,10 +1872,10 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 	},
 
 	JSONAllExists: {
-		CmpOp{
+		&CmpOp{
 			LeftType:  types.JSON,
 			RightType: types.TArray{Typ: types.String},
-			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
+			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				// TODO(justin): this can be optimized.
 				for _, k := range MustBeDArray(right).Array {
 					if k == DNull {
@@ -1894,10 +1895,10 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 	},
 
 	Contains: {
-		CmpOp{
+		&CmpOp{
 			LeftType:  types.JSON,
 			RightType: types.JSON,
-			fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
 				c, err := json.Contains(left.(*DJSON).JSON, right.(*DJSON).JSON)
 				if err != nil {
 					return nil, err
@@ -1908,10 +1909,10 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 	},
 
 	ContainedBy: {
-		CmpOp{
+		&CmpOp{
 			LeftType:  types.JSON,
 			RightType: types.JSON,
-			fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
 				c, err := json.Contains(right.(*DJSON).JSON, left.(*DJSON).JSON)
 				if err != nil {
 					return nil, err
@@ -2030,11 +2031,11 @@ func cmpOpTupleFn(ctx *EvalContext, left, right DTuple, op ComparisonOperator) D
 	return b
 }
 
-func makeEvalTupleIn(typ types.T) CmpOp {
-	return CmpOp{
+func makeEvalTupleIn(typ types.T) *CmpOp {
+	return &CmpOp{
 		LeftType:  typ,
 		RightType: types.FamTuple,
-		fn: func(ctx *EvalContext, arg, values Datum) (Datum, error) {
+		Fn: func(ctx *EvalContext, arg, values Datum) (Datum, error) {
 			vtuple := values.(*DTuple)
 			// If the tuple was sorted during normalization, we can perform an
 			// efficient binary search to find if the arg is in the tuple (as
@@ -2104,7 +2105,7 @@ func makeEvalTupleIn(typ types.T) CmpOp {
 // evalArrayCmp would be called with:
 //   evalDatumsCmp(ctx, LT, Any, CmpOp(LT, leftType, rightParamType), leftDatum, rightArray.Array).
 func evalDatumsCmp(
-	ctx *EvalContext, op, subOp ComparisonOperator, fn CmpOp, left Datum, right Datums,
+	ctx *EvalContext, op, subOp ComparisonOperator, fn *CmpOp, left Datum, right Datums,
 ) (Datum, error) {
 	all := op == All
 	any := !all
@@ -2116,7 +2117,7 @@ func evalDatumsCmp(
 		}
 
 		_, newLeft, newRight, _, not := foldComparisonExpr(subOp, left, elem)
-		d, err := fn.fn(ctx, newLeft.(Datum), newRight.(Datum))
+		d, err := fn.Fn(ctx, newLeft.(Datum), newRight.(Datum))
 		if err != nil {
 			return nil, err
 		}
@@ -3354,7 +3355,7 @@ func (expr *ComparisonExpr) Eval(ctx *EvalContext) (Datum, error) {
 	if !expr.fn.NullableArgs && (newLeft == DNull || newRight == DNull) {
 		return DNull, nil
 	}
-	d, err := expr.fn.fn(ctx, newLeft.(Datum), newRight.(Datum))
+	d, err := expr.fn.Fn(ctx, newLeft.(Datum), newRight.(Datum))
 	if err != nil {
 		return nil, err
 	}
@@ -3838,7 +3839,7 @@ func evalComparison(ctx *EvalContext, op ComparisonOperator, left, right Datum) 
 	ltype := left.ResolvedType()
 	rtype := right.ResolvedType()
 	if fn, ok := CmpOps[op].lookupImpl(ltype, rtype); ok {
-		return fn.fn(ctx, left, right)
+		return fn.Fn(ctx, left, right)
 	}
 	return nil, pgerror.NewErrorf(
 		pgerror.CodeUndefinedFunctionError, "unsupported comparison operator: <%s> %s <%s>", ltype, op, rtype)
@@ -4522,7 +4523,7 @@ func FindEqualComparisonFunction(
 ) (func(*EvalContext, Datum, Datum) (Datum, error), bool) {
 	fn, found := CmpOps[EQ].lookupImpl(leftType, rightType)
 	if found {
-		return fn.fn, true
+		return fn.Fn, true
 	}
 	return nil, false
 }

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -399,7 +399,7 @@ type ComparisonExpr struct {
 	Left, Right Expr
 
 	typeAnnotation
-	fn CmpOp
+	fn *CmpOp
 }
 
 func (*ComparisonExpr) operatorExpr() {}

--- a/pkg/sql/sem/tree/like_test.go
+++ b/pkg/sql/sem/tree/like_test.go
@@ -64,7 +64,7 @@ func benchmarkLike(b *testing.B, ctx *EvalContext, caseInsensitive bool) {
 	likeFn, _ := CmpOps[op].lookupImpl(types.String, types.String)
 	iter := func() {
 		for _, p := range benchmarkLikePatterns {
-			if _, err := likeFn.fn(ctx, NewDString("test"), NewDString(p)); err != nil {
+			if _, err := likeFn.Fn(ctx, NewDString("test"), NewDString(p)); err != nil {
 				b.Fatalf("LIKE evaluation failed with error: %v", err)
 			}
 		}

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -609,7 +609,7 @@ func (expr *CoalesceExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExp
 // TypeCheck implements the Expr interface.
 func (expr *ComparisonExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, error) {
 	var leftTyped, rightTyped TypedExpr
-	var fn CmpOp
+	var fn *CmpOp
 	var alwaysNull bool
 	var err error
 	if expr.Operator.hasSubOperator() {
@@ -1434,7 +1434,7 @@ const (
 
 func typeCheckComparisonOpWithSubOperator(
 	ctx *SemaContext, op, subOp ComparisonOperator, left, right Expr,
-) (_ TypedExpr, _ TypedExpr, _ CmpOp, alwaysNull bool, _ error) {
+) (_ TypedExpr, _ TypedExpr, _ *CmpOp, alwaysNull bool, _ error) {
 	// Parentheses are semantically unimportant and can be removed/replaced
 	// with its nested expression in our plan. This makes type checking cleaner.
 	left = StripParens(left)
@@ -1457,7 +1457,7 @@ func typeCheckComparisonOpWithSubOperator(
 		typedSubExprs, retType, err := TypeCheckSameTypedExprs(ctx, types.Any, sameTypeExprs...)
 		if err != nil {
 			sigWithErr := fmt.Sprintf(compExprsWithSubOpFmt, left, subOp, op, right, err)
-			return nil, nil, CmpOp{}, false,
+			return nil, nil, nil, false,
 				pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError, unsupportedCompErrFmt, sigWithErr)
 		}
 
@@ -1477,7 +1477,7 @@ func typeCheckComparisonOpWithSubOperator(
 
 		// Return early without looking up a CmpOp if the comparison type is types.Null.
 		if leftTyped.ResolvedType() == types.Unknown || retType == types.Unknown {
-			return leftTyped, rightTyped, CmpOp{}, true /* alwaysNull */, nil
+			return leftTyped, rightTyped, nil, true /* alwaysNull */, nil
 		}
 	} else {
 		// If the right expression is not an array constructor, we type the left
@@ -1485,7 +1485,7 @@ func typeCheckComparisonOpWithSubOperator(
 		var err error
 		leftTyped, err = left.TypeCheck(ctx, types.Any)
 		if err != nil {
-			return nil, nil, CmpOp{}, false, err
+			return nil, nil, nil, false, err
 		}
 		cmpTypeLeft = leftTyped.ResolvedType()
 
@@ -1494,7 +1494,7 @@ func typeCheckComparisonOpWithSubOperator(
 			// type is equivalent to the left's type.
 			rightTyped, err = typeCheckAndRequireTupleElems(ctx, leftTyped, tuple, subOp)
 			if err != nil {
-				return nil, nil, CmpOp{}, false, err
+				return nil, nil, nil, false, err
 			}
 		} else {
 			// Try to type the right expression as an array of the left's type.
@@ -1503,13 +1503,13 @@ func typeCheckComparisonOpWithSubOperator(
 			// propagate the left type as a desired type for the result column.
 			rightTyped, err = right.TypeCheck(ctx, types.TArray{Typ: cmpTypeLeft})
 			if err != nil {
-				return nil, nil, CmpOp{}, false, err
+				return nil, nil, nil, false, err
 			}
 		}
 
 		rightReturn := rightTyped.ResolvedType()
 		if cmpTypeLeft == types.Unknown || rightReturn == types.Unknown {
-			return leftTyped, rightTyped, CmpOp{}, true /* alwaysNull */, nil
+			return leftTyped, rightTyped, nil, true /* alwaysNull */, nil
 		}
 
 		switch rightUnwrapped := types.UnwrapType(rightReturn).(type) {
@@ -1531,12 +1531,12 @@ func typeCheckComparisonOpWithSubOperator(
 		default:
 			sigWithErr := fmt.Sprintf(compExprsWithSubOpFmt, left, subOp, op, right,
 				fmt.Sprintf("op %s <right> requires array, tuple or subquery on right side", op))
-			return nil, nil, CmpOp{}, false, pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError, unsupportedCompErrFmt, sigWithErr)
+			return nil, nil, nil, false, pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError, unsupportedCompErrFmt, sigWithErr)
 		}
 	}
 	fn, ok := ops.lookupImpl(cmpTypeLeft, cmpTypeRight)
 	if !ok {
-		return nil, nil, CmpOp{}, false, subOpCompError(cmpTypeLeft, rightTyped.ResolvedType(), subOp, op)
+		return nil, nil, nil, false, subOpCompError(cmpTypeLeft, rightTyped.ResolvedType(), subOp, op)
 	}
 	return leftTyped, rightTyped, fn, false, nil
 }
@@ -1566,7 +1566,7 @@ func typeCheckSubqueryWithIn(left, right types.T) error {
 
 func typeCheckComparisonOp(
 	ctx *SemaContext, op ComparisonOperator, left, right Expr,
-) (_ TypedExpr, _ TypedExpr, _ CmpOp, alwaysNull bool, _ error) {
+) (_ TypedExpr, _ TypedExpr, _ *CmpOp, alwaysNull bool, _ error) {
 	foldedOp, foldedLeft, foldedRight, switched, _ := foldComparisonExpr(op, left, right)
 	ops := CmpOps[foldedOp]
 
@@ -1581,14 +1581,14 @@ func typeCheckComparisonOp(
 		typedSubExprs, retType, err := TypeCheckSameTypedExprs(ctx, types.Any, sameTypeExprs...)
 		if err != nil {
 			sigWithErr := fmt.Sprintf(compExprsFmt, left, op, right, err)
-			return nil, nil, CmpOp{}, false,
+			return nil, nil, nil, false,
 				pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError, unsupportedCompErrFmt, sigWithErr)
 		}
 
 		fn, ok := ops.lookupImpl(retType, types.FamTuple)
 		if !ok {
 			sig := fmt.Sprintf(compSignatureFmt, retType, op, types.FamTuple)
-			return nil, nil, CmpOp{}, false,
+			return nil, nil, nil, false,
 				pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError, unsupportedCompErrFmt, sig)
 		}
 
@@ -1609,13 +1609,13 @@ func typeCheckComparisonOp(
 		fn, ok := ops.lookupImpl(types.FamTuple, types.FamTuple)
 		if !ok {
 			sig := fmt.Sprintf(compSignatureFmt, types.FamTuple, op, types.FamTuple)
-			return nil, nil, CmpOp{}, false,
+			return nil, nil, nil, false,
 				pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError, unsupportedCompErrFmt, sig)
 		}
 		// Using non-folded left and right to avoid having to swap later.
 		typedLeft, typedRight, err := typeCheckTupleComparison(ctx, op, left.(*Tuple), right.(*Tuple))
 		if err != nil {
-			return nil, nil, CmpOp{}, false, err
+			return nil, nil, nil, false, err
 		}
 		return typedLeft, typedRight, fn, false, nil
 	}
@@ -1629,7 +1629,7 @@ func typeCheckComparisonOp(
 		ctx, types.Any, ops, true /* inBinOp */, foldedLeft, foldedRight,
 	)
 	if err != nil {
-		return nil, nil, CmpOp{}, false, err
+		return nil, nil, nil, false, err
 	}
 
 	leftExpr, rightExpr := typedSubExprs[0], typedSubExprs[1]
@@ -1641,7 +1641,7 @@ func typeCheckComparisonOp(
 
 	if foldedOp == In {
 		if err := typeCheckSubqueryWithIn(leftReturn, rightReturn); err != nil {
-			return nil, nil, CmpOp{}, false, err
+			return nil, nil, nil, false, err
 		}
 	}
 
@@ -1651,13 +1651,13 @@ func typeCheckComparisonOp(
 		if len(fns) > 0 {
 			noneAcceptNull := true
 			for _, e := range fns {
-				if e.(CmpOp).NullableArgs {
+				if e.(*CmpOp).NullableArgs {
 					noneAcceptNull = false
 					break
 				}
 			}
 			if noneAcceptNull {
-				return leftExpr, rightExpr, CmpOp{}, true /* alwaysNull */, err
+				return leftExpr, rightExpr, nil, true /* alwaysNull */, err
 			}
 		}
 	}
@@ -1668,16 +1668,16 @@ func typeCheckComparisonOp(
 	if len(fns) != 1 || collationMismatch {
 		sig := fmt.Sprintf(compSignatureFmt, leftReturn, op, rightReturn)
 		if len(fns) == 0 || collationMismatch {
-			return nil, nil, CmpOp{}, false,
+			return nil, nil, nil, false,
 				pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError, unsupportedCompErrFmt, sig)
 		}
 		fnsStr := formatCandidates(op.String(), fns)
-		return nil, nil, CmpOp{}, false,
+		return nil, nil, nil, false,
 			pgerror.NewErrorf(pgerror.CodeAmbiguousFunctionError,
 				ambiguousCompErrFmt, sig).SetHintf(candidatesHintFmt, fnsStr)
 	}
 
-	return leftExpr, rightExpr, fns[0].(CmpOp), false, nil
+	return leftExpr, rightExpr, fns[0].(*CmpOp), false, nil
 }
 
 type typeCheckExprsState struct {
@@ -2142,7 +2142,7 @@ func (v stripFuncsVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 	case *BinaryExpr:
 		t.fn = nil
 	case *ComparisonExpr:
-		t.fn = CmpOp{}
+		t.fn = nil
 	case *FuncExpr:
 		t.fn = nil
 		t.fnProps = nil

--- a/pkg/storage/scheduler.go
+++ b/pkg/storage/scheduler.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
@@ -140,7 +139,7 @@ type raftScheduler struct {
 }
 
 func newRaftScheduler(
-	ambient log.AmbientContext, metrics *StoreMetrics, processor raftProcessor, numWorkers int,
+	metrics *StoreMetrics, processor raftProcessor, numWorkers int,
 ) *raftScheduler {
 	s := &raftScheduler{
 		processor:  processor,

--- a/pkg/storage/scheduler_test.go
+++ b/pkg/storage/scheduler_test.go
@@ -26,10 +26,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 func TestRangeIDChunk(t *testing.T) {
@@ -196,7 +194,7 @@ func TestSchedulerLoop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	p := newTestProcessor()
-	s := newRaftScheduler(log.AmbientContext{Tracer: tracing.NewTracer()}, nil, p, 1)
+	s := newRaftScheduler(nil, p, 1)
 	stopper := stop.NewStopper()
 	ctx := context.TODO()
 	defer stopper.Stop(ctx)
@@ -218,7 +216,7 @@ func TestSchedulerBuffering(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	p := newTestProcessor()
-	s := newRaftScheduler(log.AmbientContext{Tracer: tracing.NewTracer()}, nil, p, 1)
+	s := newRaftScheduler(nil, p, 1)
 	stopper := stop.NewStopper()
 	ctx := context.TODO()
 	defer stopper.Stop(ctx)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -940,7 +940,7 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 	s.intentResolver = newIntentResolver(s, cfg.IntentResolverTaskLimit)
 	s.raftEntryCache = newRaftEntryCache(cfg.RaftEntryCacheSize)
 	s.draining.Store(false)
-	s.scheduler = newRaftScheduler(s.cfg.AmbientCtx, s.metrics, s, storeSchedulerConcurrency)
+	s.scheduler = newRaftScheduler(s.metrics, s, storeSchedulerConcurrency)
 
 	s.coalescedMu.Lock()
 	s.coalescedMu.heartbeats = map[roachpb.StoreIdent][]RaftHeartbeat{}
@@ -1022,9 +1022,6 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 			)
 			s.scanner.AddQueues(s.tsMaintenanceQueue)
 		}
-
-		s.storeRebalancer = NewStoreRebalancer(
-			s.cfg.AmbientCtx, cfg.Settings, s.replicateQueue, s.replRankings)
 	}
 
 	if cfg.TestingKnobs.DisableGCQueue {
@@ -1387,6 +1384,15 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	ctx = s.AnnotateCtx(ctx)
 	log.Event(ctx, "read store identity")
 
+	// Add the store ID to the scanner's AmbientContext before starting it, since
+	// the AmbientContext provided during construction did not include it.
+	// Note that this is just a hacky way of getting around that without
+	// refactoring the scanner/queue construction/start logic more broadly, and
+	// depends on the scanner not having added its own log tag.
+	if s.scanner != nil {
+		s.scanner.AmbientContext.AddLogTag("s", s.StoreID())
+	}
+
 	// If the nodeID is 0, it has not be assigned yet.
 	if s.nodeDesc.NodeID != 0 && s.Ident.NodeID != s.nodeDesc.NodeID {
 		return errors.Errorf("node id:%d does not equal the one in node descriptor:%d", s.Ident.NodeID, s.nodeDesc.NodeID)
@@ -1561,7 +1567,9 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	// Connect rangefeeds to closed timestamp updates.
 	s.startClosedTimestampRangefeedSubscriber(ctx)
 
-	if s.storeRebalancer != nil {
+	if s.replicateQueue != nil {
+		s.storeRebalancer = NewStoreRebalancer(
+			s.cfg.AmbientCtx, s.cfg.Settings, s.replicateQueue, s.replRankings)
 		s.storeRebalancer.Start(ctx, s.stopper)
 	}
 

--- a/pkg/storage/store_rebalancer.go
+++ b/pkg/storage/store_rebalancer.go
@@ -138,7 +138,6 @@ func NewStoreRebalancer(
 	rq *replicateQueue,
 	replRankings *replicaRankings,
 ) *StoreRebalancer {
-	ambientCtx.AddLogTag("store-rebalancer", nil)
 	sr := &StoreRebalancer{
 		AmbientContext: ambientCtx,
 		metrics:        makeStoreRebalancerMetrics(),
@@ -146,6 +145,7 @@ func NewStoreRebalancer(
 		rq:             rq,
 		replRankings:   replRankings,
 	}
+	sr.AddLogTag("store-rebalancer", nil)
 	sr.rq.store.metrics.registry.AddMetricStruct(&sr.metrics)
 	return sr
 }


### PR DESCRIPTION
Backport 3/3 commits from #30022.

/cc @cockroachdb/release

---

This PR contains 3 commits:
1. A bug fix for the evaluation of `<tuple> IS (NOT) NULL`
2. Minor fixes to the existing `FoldUnary` and `FoldBinary` rules, as well as the addition of a new `FoldArray` rule
3. Folding of comparison operations with a new `FoldComparison` rule.

See the individual commit messages for details.
