### PR TITLE
release-2.1: sql: fix evaluation of <tuple> IS NULL

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -888,3 +888,8 @@ SELECT (t).a FROM t
 
 statement ok
 DROP TABLE t
+
+query B
+SELECT (1, 2, 3) IS NULL AS r
+----
+false

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1746,8 +1746,9 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 
 		// Tuple comparison.
 		CmpOp{
-			LeftType:  types.FamTuple,
-			RightType: types.FamTuple,
+			LeftType:     types.FamTuple,
+			RightType:    types.FamTuple,
+			NullableArgs: true,
 			fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
 				if left == DNull || right == DNull {
 					return MakeDBool(left == DNull && right == DNull), nil


### PR DESCRIPTION
Backport 1/3 commits from #30022.

/cc @cockroachdb/release

---

Prior to this patch, the comparison op overload for the
IsNotDistinctFrom operation with tuple inputs had NullableArgs
incorrectly set to false. As a result, the output was incorrect
for queries such as:

SELECT (1, 2, 3) IS NULL

This query should return false, but instead it returned NULL.
This commit fixes this bug.

Release note (bug fix): Fixed the evaluation of <tuple> IS NOT NULL and
<tuple> IS NULL comparison operations involving a non-null constant tuple
to return true or false rather than NULL.