### PR TITLE
opt: Modify internal interfaces for statistics

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -130,7 +130,7 @@ func TestGetStatsFromConstraint(t *testing.T) {
 		numUnappliedConstraints := sb.applyConstraintSet(cs, ev, relProps)
 
 		// Calculate row count and selectivity.
-		s.RowCount = mem.GroupProperties(scanGroup).Relational.Stats.RowCount
+		s.UpdateRowCount(mem.GroupProperties(scanGroup).Relational.Stats.RowCount())
 		s.ApplySelectivity(sb.selectivityFromDistinctCounts(cols, ev, s))
 		s.ApplySelectivity(sb.selectivityFromUnappliedConstraints(numUnappliedConstraints))
 
@@ -272,7 +272,7 @@ func testStats(
 		t.Fatalf("\nexpected: %s\nactual  : %s", expectedStats, actual)
 	}
 
-	if s.Selectivity != expectedSelectivity {
-		t.Fatalf("\nexpected: %f\nactual  : %f", expectedSelectivity, s.Selectivity)
+	if s.Selectivity() != expectedSelectivity {
+		t.Fatalf("\nexpected: %f\nactual  : %f", expectedSelectivity, s.Selectivity())
 	}
 }

--- a/pkg/sql/opt/props/col_stats_map.go
+++ b/pkg/sql/opt/props/col_stats_map.go
@@ -92,6 +92,24 @@ type ColStatsMap struct {
 	unique prefixID
 }
 
+// Copy returns a copy of the given ColStatsMap
+func (m *ColStatsMap) Copy() ColStatsMap {
+	c := ColStatsMap{}
+	for i, k := range m.initial {
+		c.initial[i] = k.Copy()
+	}
+	for _, k := range m.other {
+		c.other = append(c.other, k.Copy())
+	}
+
+	for k, v := range m.index {
+		c.index[k] = v
+	}
+	c.count = m.count
+	c.unique = m.unique
+	return c
+}
+
 // Count returns the number of column statistics in the map.
 func (m *ColStatsMap) Count() int {
 	return m.count


### PR DESCRIPTION
This commit changes the internal interface for table statistics. All
attributes are accesible via getter/setting methods. Additionally,
copy functions are added for all statistic fields.

These wrapper functions are used in order to provide the
functionality for stats debugging and testing.

Release note: None