### PR TITLE
release-2.0: sql/parser: fix the action for empty rules

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1659,7 +1659,10 @@ opt_with_options:
   {
     $$.val = $4.kvOptions()
   }
-| /* EMPTY */ {}
+| /* EMPTY */
+  {
+    $$.val = nil
+  }
 
 copy_from_stmt:
   COPY table_name opt_column_list FROM STDIN
@@ -4908,7 +4911,10 @@ opt_with_clause:
   {
     $$.val = $1.with()
   }
-| /* EMPTY */ {}
+| /* EMPTY */
+  {
+    $$.val = nil
+  }
 
 opt_table:
   TABLE {}


### PR DESCRIPTION
Backport 1/1 commits from #30197.

/cc @cockroachdb/release

---

Fixes #30141.

