### PR TITLE
release-2.1: make: conditionally use AES instruction set on x86_64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -495,13 +495,13 @@ $(CGO_FLAGS_FILES): Makefile
 # Flags needed to make cryptopp to runtime detection of AES cpu instruction sets.
 # pclmul and ssse3 need to be defined for the overall AES switch but are only used
 # in GCM mode (not currently in use by cockroach).
-AES_FLAGS := -maes -mpclmul -mssse3
+$(CRYPTOPP_DIR)/Makefile: aes := $(if $(findstring x86_64,$(TARGET_TRIPLE)),-maes -mpclmul -mssse3)
 $(CRYPTOPP_DIR)/Makefile: $(C_DEPS_DIR)/cryptopp-rebuild | bin/.submodules-initialized
 	rm -rf $(CRYPTOPP_DIR)
 	mkdir -p $(CRYPTOPP_DIR)
 	@# NOTE: If you change the CMake flags below, bump the version in
 	@# $(C_DEPS_DIR)/cryptopp-rebuild. See above for rationale.
-	cd $(CRYPTOPP_DIR) && CFLAGS+=" $(AES_FLAGS)" && CXXFLAGS+=" $(AES_FLAGS)" cmake $(xcmake-flags) $(CRYPTOPP_SRC_DIR) \
+	cd $(CRYPTOPP_DIR) && CFLAGS+=" $(aes)" && CXXFLAGS+=" $(aes)" cmake $(xcmake-flags) $(CRYPTOPP_SRC_DIR) \
 	  -DCMAKE_BUILD_TYPE=Release
 
 $(JEMALLOC_SRC_DIR)/configure.ac: | bin/.submodules-initialized

--- a/build/variables.mk
+++ b/build/variables.mk
@@ -3,7 +3,6 @@
 define VALID_VARS
   .DEFAULT_GOAL
   ACCEPTANCETIMEOUT
-  AES_FLAGS
   ARCHIVE
   ARCHIVE_BASE
   ARCHIVE_EXTRAS
@@ -149,6 +148,7 @@ define VALID_VARS
   XCXX
   XGOARCH
   XGOOS
+  aes
   bindir
   bins
   build-mode


### PR DESCRIPTION
Backport 1/1 commits from #30063.

/cc @cockroachdb/release

---

This change fixes cross-compilation to arm64.

This again indicates that we should be cross-compiling to arm64 on every CI build to avoid future regressions. I held off on this in the past because I was not able to get the full CI test pipeline set up on arm64 due to a clang issue, but it might be worth cross-compiling and creating unstable binaries even if they're not being regularly tested to prevent our arm64 build from rotting. @benesch thoughts?

Release note: None
