### PR TITLE
distsql: eagerly evaluate constant expressions

### DIFF
--- a/pkg/sql/distsqlrun/expr.go
+++ b/pkg/sql/distsqlrun/expr.go
@@ -54,7 +54,10 @@ func (*ivarBinder) VisitPost(expr tree.Expr) tree.Expr { return expr }
 // processExpression parses the string expression inside an Expression,
 // and associates ordinal references (@1, @2, etc) with the given helper.
 func processExpression(
-	exprSpec Expression, semaCtx *tree.SemaContext, h *tree.IndexedVarHelper,
+	exprSpec Expression,
+	evalCtx *tree.EvalContext,
+	semaCtx *tree.SemaContext,
+	h *tree.IndexedVarHelper,
 ) (tree.TypedExpr, error) {
 	if exprSpec.Expr == "" {
 		return nil, nil
@@ -78,7 +81,18 @@ func processExpression(
 		return nil, errors.Wrap(err, expr.String())
 	}
 
-	return typedExpr, nil
+	// Pre-evaluate constant expressions. This is necessary to avoid repeatedly
+	// re-evaluating constant values every time the expression is applied.
+	//
+	// TODO(solon): It would be preferable to enhance our expression serialization
+	// format so this wouldn't be necessary.
+	c := tree.MakeConstantEvalVisitor(evalCtx)
+	expr, _ = tree.WalkExpr(&c, typedExpr)
+	if err := c.Err(); err != nil {
+		return nil, err
+	}
+
+	return expr.(tree.TypedExpr), nil
 }
 
 // exprHelper implements the common logic around evaluating an expression that
@@ -139,7 +153,7 @@ func (eh *exprHelper) init(
 	eh.vars = tree.MakeIndexedVarHelper(eh, len(types))
 	var err error
 	semaContext := tree.MakeSemaContext(evalCtx.SessionData.User == security.RootUser)
-	eh.expr, err = processExpression(expr, &semaContext, &eh.vars)
+	eh.expr, err = processExpression(expr, evalCtx, &semaContext, &eh.vars)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/sem/tree/constant_eval.go
+++ b/pkg/sql/sem/tree/constant_eval.go
@@ -1,0 +1,77 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tree
+
+// ConstantEvalVisitor replaces constant TypedExprs with the result of Eval.
+type ConstantEvalVisitor struct {
+	ctx *EvalContext
+	err error
+
+	fastIsConstVisitor fastIsConstVisitor
+}
+
+var _ Visitor = &ConstantEvalVisitor{}
+
+// MakeConstantEvalVisitor creates a ConstantEvalVisitor instance.
+func MakeConstantEvalVisitor(ctx *EvalContext) ConstantEvalVisitor {
+	return ConstantEvalVisitor{ctx: ctx, fastIsConstVisitor: fastIsConstVisitor{ctx: ctx}}
+}
+
+// Err retrieves the error field in the ConstantEvalVisitor.
+func (v *ConstantEvalVisitor) Err() error { return v.err }
+
+// VisitPre implements the Visitor interface.
+func (v *ConstantEvalVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
+	if v.err != nil {
+		return false, expr
+	}
+	return true, expr
+}
+
+// VisitPost implements the Visitor interface.
+func (v *ConstantEvalVisitor) VisitPost(expr Expr) Expr {
+	if v.err != nil {
+		return expr
+	}
+
+	typedExpr, ok := expr.(TypedExpr)
+	if !ok || !v.isConst(expr) {
+		return expr
+	}
+
+	value, err := typedExpr.Eval(v.ctx)
+	if err != nil {
+		// Ignore any errors here (e.g. division by zero), so they can happen
+		// during execution where they are correctly handled. Note that in some
+		// cases we might not even get an error (if this particular expression
+		// does not get evaluated when the query runs, e.g. it's inside a CASE).
+		return expr
+	}
+	if value == DNull {
+		// We don't want to return an expression that has a different type; cast
+		// the NULL if necessary.
+		var newExpr TypedExpr
+		newExpr, v.err = ReType(DNull, typedExpr.ResolvedType())
+		if v.err != nil {
+			return expr
+		}
+		return newExpr
+	}
+	return value
+}
+
+func (v *ConstantEvalVisitor) isConst(expr Expr) bool {
+	return v.fastIsConstVisitor.run(expr)
+}

--- a/pkg/sql/sem/tree/constant_eval_test.go
+++ b/pkg/sql/sem/tree/constant_eval_test.go
@@ -1,0 +1,62 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tree_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+func TestConstantEvalArrayComparison(t *testing.T) {
+	defer tree.MockNameTypes(map[string]types.T{"a": types.TArray{Typ: types.Int}})()
+
+	expr, err := parser.ParseExpr("a = ARRAY[1:::INT,2:::INT]")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	semaCtx := tree.MakeSemaContext(true /* privileged */)
+	typedExpr, err := expr.TypeCheck(&semaCtx, types.Any)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	defer ctx.Mon.Stop(context.Background())
+	defer ctx.ActiveMemAcc.Close(context.Background())
+	c := tree.MakeConstantEvalVisitor(ctx)
+	expr, _ = tree.WalkExpr(&c, typedExpr)
+	if err := c.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	left := tree.ColumnItem{
+		ColumnName: "a",
+	}
+	right := tree.DArray{
+		ParamTyp: types.Int,
+		Array:    tree.Datums{tree.NewDInt(1), tree.NewDInt(2)},
+	}
+	expected := tree.NewTypedComparisonExpr(tree.EQ, &left, &right)
+	if !reflect.DeepEqual(expr, expected) {
+		t.Errorf("invalid expr '%v', expected '%v'", expr, expected)
+	}
+}


### PR DESCRIPTION
exprHelper now normalizes its expression upon initialization. This
causes constant subexpressions to be evaluated up front, rather than re-
evaluating them every time `eval` or `evalFilter` is called, and thus
avoids a hefty per-row cost for expensive expressions. For example, the
SELECT query in the example below now returns in ~100ms rather than
~10s.

```
CREATE TABLE t (x int[]);
INSERT INTO t SELECT array[x] FROM generate_series(1, 10000) AS x;
SELECT * FROM t WHERE x = (SELECT array_agg(generate_series(1,10000)));
```

This also uncovered a bug in the normalizer where `NOT IN ()` returned
false rather than true.

Fixes #30167

Release note: None