### PR TITLE
release-2.1: server: fix panic in data distribution endpoint

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1539,8 +1539,8 @@ func (s *adminServer) DataDistribution(
 	for _, row := range rows2 {
 		zcID := int64(tree.MustBeDInt(row[0]))
 		zcCliSpecifier := string(tree.MustBeDString(row[1]))
-		zcYaml := tree.MustBeDBytes(row[2])
-		zcBytes := tree.MustBeDBytes(row[3])
+		zcYaml := tree.MustBeDString(row[2])
+		zcBytes := tree.MustBeDBytes(row[4])
 		var zcProto config.ZoneConfig
 		if err := protoutil.Unmarshal([]byte(zcBytes), &zcProto); err != nil {
 			return nil, s.serverError(err)


### PR DESCRIPTION
Backport 2/2 commits from #30201.

/cc @cockroachdb/release

---

Fix panic by adapting endpoint to new output schema of `SHOW ZONE CONFIGURATIONS` and unskip the test that would have caught it (deleting the flaky part which got it skipped).

Fixes #30186
