### PR TITLE
release-2.1: cli: hint the syntax of client commands in `start` output

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -881,7 +881,7 @@ func hintServerCmdFlags(ctx context.Context, cmd *cobra.Command) {
 }
 
 func clientFlags() string {
-	flags := []string{os.Args[0]}
+	flags := []string{os.Args[0], "<client cmd>"}
 	host, port, err := net.SplitHostPort(serverCfg.AdvertiseAddr)
 	if err == nil {
 		flags = append(flags, "--host="+host+":"+port)


### PR DESCRIPTION
Backport 1/1 commits from #30210.

/cc @cockroachdb/release

---

Fixes #30171.

Requested by @jseldess to improve UX.

Before:

```
client flags:        ./cockroach --host=kenabook:26257 --insecure
```

After:

```
client flags:        ./cockroach <client cmd> --host=kenabook:26257 --insecure
```

Release note: None
