### PR TITLE
release-2.1: opt: adjust cost of the sort wrt key cols

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -165,18 +165,17 @@ distinct   ·            ·            (pk1, pk2)  weak-key(pk1)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
 ----
-sort                      ·            ·            (a, c)     weak-key(a); +a
- │                        order        +a           ·          ·
- └── distinct             ·            ·            (a, c)     weak-key(a)
-      │                   distinct on  a            ·          ·
-      └── render          ·            ·            (a, c)     ·
-           │              render 0     a            ·          ·
-           │              render 1     c            ·          ·
-           └── sort       ·            ·            (a, b, c)  -c,+b
-                │         order        -c,+b        ·          ·
-                └── scan  ·            ·            (a, b, c)  ·
-·                         table        abc@primary  ·          ·
-·                         spans        ALL          ·          ·
+distinct             ·            ·            (a, c)     weak-key(a)
+ │                   distinct on  a            ·          ·
+ │                   order key    a            ·          ·
+ └── render          ·            ·            (a, c)     ·
+      │              render 0     a            ·          ·
+      │              render 1     c            ·          ·
+      └── sort       ·            ·            (a, b, c)  +a,-c,+b
+           │         order        +a,-c,+b     ·          ·
+           └── scan  ·            ·            (a, b, c)  ·
+·                    table        abc@primary  ·          ·
+·                    spans        ALL          ·          ·
 
 #################
 # With ORDER BY #
@@ -211,19 +210,18 @@ render               ·            ·            (y, z, x)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
 ----
-render                    ·            ·            (y, z, x)  ·
- │                        render 0     y            ·          ·
- │                        render 1     z            ·          ·
- │                        render 2     x            ·          ·
- └── sort                 ·            ·            (x, y, z)  weak-key(x); +x
-      │                   order        +x           ·          ·
-      └── distinct        ·            ·            (x, y, z)  weak-key(x); -z,-y
-           │              distinct on  x            ·          ·
-           └── sort       ·            ·            (x, y, z)  -z,-y
-                │         order        -z,-y        ·          ·
-                └── scan  ·            ·            (x, y, z)  ·
-·                         table        xyz@primary  ·          ·
-·                         spans        ALL          ·          ·
+render               ·            ·            (y, z, x)  ·
+ │                   render 0     y            ·          ·
+ │                   render 1     z            ·          ·
+ │                   render 2     x            ·          ·
+ └── distinct        ·            ·            (x, y, z)  weak-key(x); +x,-z,-y
+      │              distinct on  x            ·          ·
+      │              order key    x            ·          ·
+      └── sort       ·            ·            (x, y, z)  +x,-z,-y
+           │         order        +x,-z,-y     ·          ·
+           └── scan  ·            ·            (x, y, z)  ·
+·                    table        xyz@primary  ·          ·
+·                    spans        ALL          ·          ·
 
 #####################
 # With aggregations #

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
@@ -104,20 +104,19 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJyslL-OozAQh_t7itO0N1KwDf
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y) x, y FROM xyz ORDER BY y, x
 ----
-sort                 ·            ·            (x, y)  weak-key(y); +y
- │                   order        +y           ·       ·
- └── distinct        ·            ·            (x, y)  weak-key(y); +x
-      │              distinct on  y            ·       ·
-      └── sort       ·            ·            (x, y)  +x
-           │         order        +x           ·       ·
-           └── scan  ·            ·            (x, y)  ·
-·                    table        xyz@primary  ·       ·
-·                    spans        ALL          ·       ·
+distinct        ·            ·            (x, y)  weak-key(y); +y,+x
+ │              distinct on  y            ·       ·
+ │              order key    y            ·       ·
+ └── sort       ·            ·            (x, y)  +y,+x
+      │         order        +y,+x        ·       ·
+      └── scan  ·            ·            (x, y)  ·
+·               table        xyz@primary  ·       ·
+·               spans        ALL          ·       ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (y) x, y FROM xyz ORDER BY y, x]
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html#eJyslUFvm0AQhe_9FdVcu5I9u2DHnDj0kktTpb1VPlB2FCE5rLW7lpJG_u-VAYmCwgwlHGH93pv5_LS8Qe0sfSueKUD2CxAUaFBgQEECClI4Kjh7V1IIzt9-0gru7QtkWwVVfb7E2-ujgtJ5guwNYhVPBBn8LH6f6JEKS36zBQWWYlGdmpizr54L_5q_vP4BBQ-XmH3OtcoNHK8K3CX2piEWTwQZXtX84B_OR_KbdJiZ45dJe_0_9l-rEKu6jBscbZXryQAzGdD7Om_Jk31vanaK8Z7TUyQLKOJubD-NMR344_x64Kr1EIK7xcZ7za6HYN__MbiwHno-OL0qOCG4A7dfCk6w78HpheDMfHBmVXBCcAfubik4wb4HZxaCS-aDS1YFJwR34A5LwQn2PbhkhZv8nYBHCmdXBxq4Tzlvb9c82SdqPwvBXXxJ370rm5j28aHRNS8shdieYvtwX7dHtwH_FSMr1rxYs2IzEONYbFhxwicn_M57Xp2y6h0v3rFiIXn_EWJ3rPjAJx94YluhJnzJhMGRbxkKNUO-Z2gEOd80aXahaqkQzncNhbIh37bx7Mfrp78BAAD__06g0ss=
+https://cockroachdb.github.io/distsqlplan/decode.html#eJyslb9u2zAQh_c-RXFrCNhHyo6tSUOXLE2Rdis0qOIhEOCIAkkBSQO_e6E_gCq3OioQR0n-8bv77kC_Q200fS1eyEH6ExAESBCgQEACAg6QC2isKck5Y7ufDIEH_QrpXkBVN63vXucCSmMJ0nfwlb8QpPCj-HWhJyo02d0eBGjyRXXpMY2tXgr7lr2-_QYBj61PP2dSZAryqwDT-ulQ54tnghSvYj34u7Ge7O4wZ2byTmR4t4iQH0F8qZyv6tLvcH9L6RqymizprqlFnFrETRQznLPUB1vXP92vrCuZ1YXrR4xRRxwAjyM-bhlxADGpxCgjlutVyqgqA-BR5f0WlQHEpFJGUanWq1RRVQbAo8rTFpUBxKRSRVGZrFeZRFUZAI8qz1tUBhCTyiT6Hf4f3BO5xtSOZqylk_fd5U76mYY_BGdaW9I3a8oeMzw-9rn-hSbnh684PDzUw6euwL_DyIYlH5ZsWM3CeBtWfNlHHp2w6QMfPrDhAPm4pel7NnziySc2fObD5y1lY2DHQkvGbxkG1gw37RkGFi0JwPlNw8CqIb9rt7Xn109_AgAA__8Zbbvp
 
 # Distinct processors elided becaue of strong key.
 query TTTTT

--- a/pkg/sql/opt/optbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/optbuilder/testdata/distinct_on
@@ -207,25 +207,23 @@ sort
 build
 SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
 ----
-sort
+distinct-on
  ├── columns: y:2(int) z:3(int) x:1(int)
+ ├── grouping columns: x:1(int)
+ ├── internal-ordering: -3,-2 opt(1)
  ├── ordering: +1
- └── distinct-on
-      ├── columns: x:1(int) y:2(int) z:3(int)
-      ├── grouping columns: x:1(int)
-      ├── internal-ordering: -3,-2 opt(1)
-      ├── sort
-      │    ├── columns: x:1(int) y:2(int) z:3(int)
-      │    ├── ordering: -3,-2 opt(1)
-      │    └── project
-      │         ├── columns: x:1(int) y:2(int) z:3(int)
-      │         └── scan xyz
-      │              └── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
-      └── aggregations
-           ├── first-agg [type=int]
-           │    └── variable: y [type=int]
-           └── first-agg [type=int]
-                └── variable: z [type=int]
+ ├── sort
+ │    ├── columns: x:1(int) y:2(int) z:3(int)
+ │    ├── ordering: +1,-3,-2
+ │    └── project
+ │         ├── columns: x:1(int) y:2(int) z:3(int)
+ │         └── scan xyz
+ │              └── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
+ └── aggregations
+      ├── first-agg [type=int]
+      │    └── variable: y [type=int]
+      └── first-agg [type=int]
+           └── variable: z [type=int]
 
 #####################
 # With aggregations #

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -207,10 +207,25 @@ func (c *coster) computeVirtualScanCost(
 // rowSortCost is the CPU cost to sort one row, which depends on the number of
 // columns in the sort key.
 func (c *coster) rowSortCost(numKeyCols int) memo.Cost {
+	// Sorting involves comparisons on the key columns, but the cost isn't
+	// directly proportional: we only compare the second column if the rows are
+	// equal on the first column; and so on. We also account for a fixed
+	// "non-comparison" cost related to processing the
+	// row. The formula is:
+	//
+	//   cpuCostFactor * [ 1 + Sum eqProb^(i-1) with i=1 to numKeyCols ]
+	//
+	const eqProb = 0.1
+	cost := cpuCostFactor
+	for i, c := 0, cpuCostFactor; i < numKeyCols; i, c = i+1, c*eqProb {
+		// c is cpuCostFactor * eqProb^i.
+		cost += c
+	}
+
 	// There is a fixed "non-comparison" cost and a comparison cost proportional
 	// to the key columns. Note that the cost has to be high enough so that a
 	// sort is almost always more expensive than a reverse scan or an index scan.
-	return (1 + memo.Cost(numKeyCols)) * cpuCostFactor
+	return memo.Cost(cost)
 }
 
 // rowScanCost is the CPU cost to scan one row, which depends on the number of

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -1171,7 +1171,7 @@ ORDER BY ol_w_id, ol_d_id
 sort
  ├── columns: count:11(int)
  ├── stats: [rows=100, distinct(2,3)=100]
- ├── cost: 1100021.93
+ ├── cost: 1100015.95
  ├── key: (2,3)
  ├── fd: (2,3)-->(11)
  ├── ordering: +3,+2

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -994,21 +994,19 @@ sort
 opt
 SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
 ----
-sort
+distinct-on
  ├── columns: a:1(int!null) c:3(int)
+ ├── grouping columns: a:1(int!null)
+ ├── internal-ordering: -3,+2 opt(1)
  ├── ordering: +1
- └── distinct-on
-      ├── columns: a:1(int!null) c:3(int)
-      ├── grouping columns: a:1(int!null)
-      ├── internal-ordering: -3,+2 opt(1)
-      ├── sort
-      │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
-      │    ├── ordering: -3,+2 opt(1)
-      │    └── scan abc
-      │         └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
-      └── aggregations
-           └── first-agg [type=int]
-                └── variable: c [type=int]
+ ├── sort
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── ordering: +1,-3,+2
+ │    └── scan abc
+ │         └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ └── aggregations
+      └── first-agg [type=int]
+           └── variable: c [type=int]
 
 # Pass through the ordering from above.
 opt

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -297,7 +297,7 @@ memo (optimized, ~2KB)
  └── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4))
       ├── "[presentation: s:4,i:2,f:3] [ordering: -4,+2]"
       │    ├── best: (sort G1)
-      │    └── cost: 1378.97
+      │    └── cost: 1289.28
       └── ""
            ├── best: (scan a@s_idx,cols=(2-4))
            └── cost: 1070.00
@@ -485,7 +485,7 @@ memo (optimized, ~2KB)
  └── G1: (scan a,cols=(1,2,4)) (scan a@s_idx,cols=(1,2,4)) (scan a@si_idx,cols=(1,2,4))
       ├── "[presentation: i:2,k:1] [ordering: -4,+2,+1]"
       │    ├── best: (sort G1)
-      │    └── cost: 1478.63
+      │    └── cost: 1290.28
       └── ""
            ├── best: (scan a@s_idx,cols=(1,2,4))
            └── cost: 1070.00


### PR DESCRIPTION
Backport 1/1 commits from #30202.

/cc @cockroachdb/release

---

The cost of the sort takes into account the number of the key columns,
because the more columns we have the more costly each comparison is.

However, the cost increase should not be proportional. We only look at
the second column when we have equality on the first column; this
should normally not be very frequent. This change tweaks the formula
to apply an "equality probability" factor for each subsequent key
column.

This fixes cases like sorting twice with distinct-on (once on the
input, once on the output) instead of sorting once using all columns.
This plan sounds crazy but would actually make sense if the sorting
cost was proportional to the number of key columns (because the
distinct-on output is smaller than the input). Note that these cases
showed up recently as a consequence of decreasing
`unknownDistinctCountRatio` which decreases the row estimate for
distinct-on.

Fixes #30190.

Release note: None
