### PR TITLE
opt: fix return type of ArrayFlatten, fix ArrayFlatten panic 

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1176,3 +1176,21 @@ FROM documents
 WHERE '3ae3560e-d771-4b63-affb-47e8d7853680'::UUID = ANY (documents.shared_users);
 ----
 {3ae3560e-d771-4b63-affb-47e8d7853680,6cc1b5c1-fe4f-417d-96bd-afd1feeec34f}
+
+statement ok
+CREATE TABLE u (x INT)
+
+statement ok
+INSERT INTO u VALUES (1), (2)
+
+statement ok
+CREATE TABLE v (y INT[])
+
+statement ok
+INSERT INTO v VALUES (ARRAY[1, 2])
+
+# Regression test for #30191. Ensure ArrayFlatten returns correct type.
+query T
+SELECT * FROM v WHERE y = ARRAY(SELECT x FROM u ORDER BY x);
+----
+{1,2}

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1713,7 +1713,7 @@ norm expect=TryDecorrelateScalarGroupBy
 SELECT k, ARRAY(SELECT y FROM xy WHERE xy.y = a.i OR xy.y IS NULL) FROM a
 ----
 project
- ├── columns: k:1(int!null) array:9(tuple{int}[])
+ ├── columns: k:1(int!null) array:9(int[])
  ├── key: (1)
  ├── fd: (1)-->(9)
  ├── group-by
@@ -1750,7 +1750,7 @@ norm expect=TryDecorrelateScalarGroupBy
 SELECT i, ARRAY(SELECT y FROM xy WHERE xy.y = a.k OR xy.y = NULL ORDER BY y) FROM a
 ----
 project
- ├── columns: i:2(int) array:9(tuple{int}[])
+ ├── columns: i:2(int) array:9(int[])
  ├── group-by
  │    ├── columns: k:1(int!null) i:2(int) canary:10(bool) array_agg:11(int[])
  │    ├── grouping columns: k:1(int!null)

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -173,6 +173,11 @@ func (b *Builder) buildScalar(
 		out = b.factory.ConstructArray(elements, b.factory.InternType(arrayType))
 
 	case *tree.ArrayFlatten:
+		if b.AllowUnsupportedExpr {
+			out = b.factory.ConstructUnsupportedExpr(b.factory.InternTypedExpr(scalar))
+			break
+		}
+
 		// We build
 		//
 		//  ARRAY(<subquery>)

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -231,7 +231,7 @@ func (b *Builder) buildScalar(
 						Ordering: oc,
 					}),
 				),
-				b.factory.InternSubqueryDef(&memo.SubqueryDef{OriginalExpr: s.expr}),
+				b.factory.InternSubqueryDef(&memo.SubqueryDef{OriginalExpr: s.Subquery}),
 			),
 			b.factory.ConstructArray(memo.EmptyList, typID),
 		}))
@@ -325,7 +325,7 @@ func (b *Builder) buildScalar(
 		)
 
 	case *tree.ComparisonExpr:
-		if sub, ok := t.Right.(*subquery); ok && sub.multiRow {
+		if sub, ok := t.Right.(*subquery); ok && sub.wrapInTuple {
 			out, _ = b.buildMultiRowSubquery(t, inScope, colRefs)
 			// Perform correctness checks on the outer cols, update colRefs and
 			// b.subquery.outerCols.

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -779,7 +779,7 @@ build
 SELECT ARRAY(SELECT 1)
 ----
 project
- ├── columns: array:3(tuple{int}[])
+ ├── columns: array:3(int[])
  ├── values
  │    └── tuple [type=tuple]
  └── projections
@@ -818,7 +818,7 @@ build
 SELECT b, ARRAY(SELECT a FROM x WHERE x.a = y.b) FROM y
 ----
 project
- ├── columns: b:1(int!null) array:4(tuple{int}[])
+ ├── columns: b:1(int!null) array:4(int[])
  ├── scan y
  │    └── columns: b:1(int!null)
  └── projections
@@ -843,7 +843,7 @@ build
 SELECT b, ARRAY(SELECT a FROM x ORDER BY a) FROM y
 ----
 project
- ├── columns: b:1(int!null) array:4(tuple{int}[])
+ ├── columns: b:1(int!null) array:4(int[])
  ├── scan y
  │    └── columns: b:1(int!null)
  └── projections
@@ -864,7 +864,7 @@ build
 SELECT ARRAY(VALUES ('foo'), ('bar'), ('baz'))
 ----
 project
- ├── columns: array:3(tuple{string}[])
+ ├── columns: array:3(string[])
  ├── values
  │    └── tuple [type=tuple]
  └── projections
@@ -914,7 +914,7 @@ build
 SELECT ARRAY(SELECT generate_series(1,100) ORDER BY 1 DESC)
 ----
 project
- ├── columns: array:3(tuple{int}[])
+ ├── columns: array:3(int[])
  ├── values
  │    └── tuple [type=tuple]
  └── projections

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -2208,7 +2208,7 @@ FROM
 GROUP BY t2.b;
 ----
 project
- ├── columns: array:15(tuple{int}[]) array:17(tuple{int}[])
+ ├── columns: array:15(int[]) array:17(int[])
  ├── group-by
  │    ├── columns: t2.b:2(int) max:12(int)
  │    ├── grouping columns: t2.b:2(int)
@@ -2264,7 +2264,7 @@ FROM
 GROUP BY t2.a, t2.b;
 ----
 project
- ├── columns: array:23(tuple{int}[]) array:25(tuple{int}[]) array:27(tuple{int}[])
+ ├── columns: array:23(int[]) array:25(int[]) array:27(int[])
  ├── group-by
  │    ├── columns: t2.a:1(int) t2.b:2(int) max:13(int)
  │    ├── grouping columns: t2.a:1(int) t2.b:2(int)
@@ -2418,3 +2418,51 @@ project
                                │         │         └── variable: max [type=int]
                                │         └── variable: t2.a [type=int]
                                └── variable: max [type=int]
+
+exec-ddl
+CREATE TABLE v (x INT)
+----
+TABLE v
+ ├── x int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+exec-ddl
+CREATE TABLE w (y INT[])
+----
+TABLE w
+ ├── y int[]
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+# Regression test for #30191. Ensure ArrayFlatten returns correct type.
+build
+SELECT * FROM w WHERE y = ARRAY(SELECT x FROM v ORDER BY x)
+----
+project
+ ├── columns: y:1(int[]!null)
+ └── select
+      ├── columns: y:1(int[]!null) w.rowid:2(int!null)
+      ├── scan w
+      │    └── columns: y:1(int[]) w.rowid:2(int!null)
+      └── filters [type=bool]
+           └── eq [type=bool]
+                ├── variable: y [type=int[]]
+                └── coalesce [type=int[]]
+                     ├── subquery [type=int[]]
+                     │    └── scalar-group-by
+                     │         ├── columns: array_agg:5(int[])
+                     │         ├── internal-ordering: +3
+                     │         ├── sort
+                     │         │    ├── columns: x:3(int)
+                     │         │    ├── ordering: +3
+                     │         │    └── project
+                     │         │         ├── columns: x:3(int)
+                     │         │         └── scan v
+                     │         │              └── columns: x:3(int) v.rowid:4(int!null)
+                     │         └── aggregations
+                     │              └── array-agg [type=int[]]
+                     │                   └── variable: x [type=int]
+                     └── array: [type=int[]]


### PR DESCRIPTION
Prior to this PR, the return type of an `ArrayFlatten`
operation was incorrectly set by the optbuilder to
`tuple{elementType}[]`. This PR fixes the issue so that
now the return type is set to `elementType[]`.

Additionally, this PR fixes a panic that was occuring when the optimizer
was turned off and an `ArrayFlatten` operation was used as an
index constraint.

Fixes #30191

Release note (bug fix): Fixed the return type of an array
built from the results of a subquery to be elementType[]
rather than tuple{elementType}[].

Release note (bug fix): Fixed a panic that was occuring
when the optimizer was disabled and an array built from the
results of a subquery was used in the WHERE clause of an outer
query.
