### PR TITLE
distsqlrun: factor out ConsumerDone

### DIFF
--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -721,11 +721,6 @@ func (ag *orderedAggregator) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	return nil, ag.DrainHelper()
 }
 
-// ConsumerDone is part of the RowSource interface.
-func (ag *aggregatorBase) ConsumerDone() {
-	ag.MoveToDraining(nil /* err */)
-}
-
 // ConsumerClosed is part of the RowSource interface.
 func (ag *hashAggregator) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -313,11 +313,6 @@ func (d *SortedDistinct) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	return nil, d.DrainHelper()
 }
 
-// ConsumerDone is part of the RowSource interface.
-func (d *Distinct) ConsumerDone() {
-	d.input.ConsumerDone()
-}
-
 // ConsumerClosed is part of the RowSource interface.
 func (d *Distinct) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -266,11 +266,6 @@ func (h *hashJoiner) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	return nil, h.DrainHelper()
 }
 
-// ConsumerDone is part of the RowSource interface.
-func (h *hashJoiner) ConsumerDone() {
-	h.MoveToDraining(nil /* err */)
-}
-
 // ConsumerClosed is part of the RowSource interface.
 func (h *hashJoiner) ConsumerClosed() {
 	h.close()

--- a/pkg/sql/distsqlrun/indexjoiner.go
+++ b/pkg/sql/distsqlrun/indexjoiner.go
@@ -185,11 +185,6 @@ func (ij *indexJoiner) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	return nil, ij.DrainHelper()
 }
 
-// ConsumerDone is part of the RowSource interface.
-func (ij *indexJoiner) ConsumerDone() {
-	ij.MoveToDraining(nil /* err */)
-}
-
 // ConsumerClosed is part of the RowSource interface.
 func (ij *indexJoiner) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner.go
@@ -259,10 +259,6 @@ func (irj *interleavedReaderJoiner) nextRow() (irjState, sqlbase.EncDatumRow, *P
 	return newState, unmatchedAncestor, nil
 }
 
-func (irj *interleavedReaderJoiner) ConsumerDone() {
-	irj.MoveToDraining(nil /* err */)
-}
-
 func (irj *interleavedReaderJoiner) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.
 	irj.InternalClose()

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -651,11 +651,6 @@ func (jr *joinReader) Start(ctx context.Context) context.Context {
 	return jr.StartInternal(ctx, joinReaderProcName)
 }
 
-// ConsumerDone is part of the RowSource interface.
-func (jr *joinReader) ConsumerDone() {
-	jr.MoveToDraining(nil /* err */)
-}
-
 // ConsumerClosed is part of the RowSource interface.
 func (jr *joinReader) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.

--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -240,11 +240,6 @@ func (m *mergeJoiner) nextRow() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	}
 }
 
-// ConsumerDone is part of the RowSource interface.
-func (m *mergeJoiner) ConsumerDone() {
-	m.MoveToDraining(nil /* err */)
-}
-
 func (m *mergeJoiner) close() {
 	if m.InternalClose() {
 		ctx := m.evalCtx.Ctx()

--- a/pkg/sql/distsqlrun/metadata_test_sender.go
+++ b/pkg/sql/distsqlrun/metadata_test_sender.go
@@ -117,11 +117,6 @@ func (mts *metadataTestSender) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	return nil, mts.DrainHelper()
 }
 
-// ConsumerDone is part of the RowSource interface.
-func (mts *metadataTestSender) ConsumerDone() {
-	mts.MoveToDraining(nil /* err */)
-}
-
 // ConsumerClosed is part of the RowSource interface.
 func (mts *metadataTestSender) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.

--- a/pkg/sql/distsqlrun/noop.go
+++ b/pkg/sql/distsqlrun/noop.go
@@ -82,11 +82,6 @@ func (n *noopProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	return nil, n.DrainHelper()
 }
 
-// ConsumerDone is part of the RowSource interface.
-func (n *noopProcessor) ConsumerDone() {
-	n.MoveToDraining(nil /* err */)
-}
-
 // ConsumerClosed is part of the RowSource interface.
 func (n *noopProcessor) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -843,6 +843,11 @@ func (pb *ProcessorBase) InternalClose() bool {
 	return closing
 }
 
+// ConsumerDone is part of the RowSource interface.
+func (pb *ProcessorBase) ConsumerDone() {
+	pb.MoveToDraining(nil /* err */)
+}
+
 // NewMonitor is a utility function used by processors to create a new
 // memory monitor with the given name and start it. The returned monitor must
 // be closed.

--- a/pkg/sql/distsqlrun/project_set.go
+++ b/pkg/sql/distsqlrun/project_set.go
@@ -262,11 +262,6 @@ func (ps *projectSetProcessor) toEncDatum(d tree.Datum, colIdx int) sqlbase.EncD
 	return sqlbase.DatumToEncDatum(ctyp, d)
 }
 
-// ConsumerDone is part of the RowSource interface.
-func (ps *projectSetProcessor) ConsumerDone() {
-	ps.MoveToDraining(nil /* err */)
-}
-
 // ConsumerClosed is part of the RowSource interface.
 func (ps *projectSetProcessor) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -632,11 +632,6 @@ func (s *sortChunksProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	return nil, s.DrainHelper()
 }
 
-// ConsumerDone is part of the RowSource interface.
-func (s *sortChunksProcessor) ConsumerDone() {
-	s.MoveToDraining(nil /* err */)
-}
-
 // ConsumerClosed is part of the RowSource interface.
 func (s *sortChunksProcessor) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -259,11 +259,6 @@ func (tr *tableReader) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	return nil, tr.DrainHelper()
 }
 
-// ConsumerDone is part of the RowSource interface.
-func (tr *tableReader) ConsumerDone() {
-	tr.MoveToDraining(nil /* err */)
-}
-
 // ConsumerClosed is part of the RowSource interface.
 func (tr *tableReader) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.

--- a/pkg/sql/distsqlrun/values.go
+++ b/pkg/sql/distsqlrun/values.go
@@ -130,11 +130,6 @@ func (v *valuesProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 
 }
 
-// ConsumerDone is part of the RowSource interface.
-func (v *valuesProcessor) ConsumerDone() {
-	v.MoveToDraining(nil /* err */)
-}
-
 // ConsumerClosed is part of the RowSource interface.
 func (v *valuesProcessor) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.

--- a/pkg/sql/distsqlrun/windower.go
+++ b/pkg/sql/distsqlrun/windower.go
@@ -279,11 +279,6 @@ func (w *windower) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	return nil, w.DrainHelper()
 }
 
-// ConsumerDone is part of the RowSource interface.
-func (w *windower) ConsumerDone() {
-	w.MoveToDraining(nil /* err */)
-}
-
 // ConsumerClosed is part of the RowSource interface.
 func (w *windower) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.

--- a/pkg/sql/distsqlrun/zigzagjoiner.go
+++ b/pkg/sql/distsqlrun/zigzagjoiner.go
@@ -877,10 +877,6 @@ func (z *zigzagJoiner) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	return nil, z.DrainHelper()
 }
 
-// ConsumerDone is part of the RowSource interface.
-func (z *zigzagJoiner) ConsumerDone() {
-}
-
 // ConsumerClosed is part of the RowSource interface.
 func (z *zigzagJoiner) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.


### PR DESCRIPTION
All processors had this implemented the same way. It should live in
ProcessorBase.

Release note: None