### PR TITLE
*: Avoid printing empty lines to the log

### DIFF
--- a/pkg/gossip/status.go
+++ b/pkg/gossip/status.go
@@ -99,10 +99,12 @@ func (c Connectivity) String() string {
 	if c.SentinelNodeID != 0 {
 		fmt.Fprintf(&buf, "  n%d [sentinel];\n", c.SentinelNodeID)
 	}
-	fmt.Fprintf(&buf, " ")
-	for _, conn := range c.ClientConns {
-		fmt.Fprintf(&buf, " n%d -> n%d;", conn.SourceID, conn.TargetID)
+	if len(c.ClientConns) > 0 {
+		fmt.Fprintf(&buf, " ")
+		for _, conn := range c.ClientConns {
+			fmt.Fprintf(&buf, " n%d -> n%d;", conn.SourceID, conn.TargetID)
+		}
+		fmt.Fprintf(&buf, "\n")
 	}
-	fmt.Fprintf(&buf, "\n")
 	return buf.String()
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4521,7 +4521,7 @@ func (s *Store) ComputeMetrics(ctx context.Context, tick int) error {
 		// Log this metric infrequently.
 		if tick%60 == 0 /* every 10m */ {
 			log.Infof(ctx, "sstables (read amplification = %d):\n%s", readAmp, sstables)
-			log.Infof(ctx, "%s\nestimated_pending_compaction_bytes: %s",
+			log.Infof(ctx, "%sestimated_pending_compaction_bytes: %s",
 				rocksdb.GetCompactionStats(), humanizeutil.IBytes(stats.PendingCompactionBytesEstimate))
 		}
 	}


### PR DESCRIPTION
The gossip connectivity logs would print an empty line in one node
clusters:

before:
```
...
[n1] gossip connectivity
  n1 [sentinel];

...
```

after:
```
...
[n1] gossip connectivity
  n1 [sentinel];
...
```

And the rocksdb metrics always included an empty line:

before:
```
...
[n1,s1]
...
Stalls(count): ...

estimated_pending_compaction_bytes: 0 B
...
```

after:
```
...
[n1,s1]
...
Stalls(count): ...
estimated_pending_compaction_bytes: 0 B
...
```

Release note: None