### PR TITLE
roachtest: deflake acceptance/cli/node-status

### DIFF
--- a/pkg/cmd/roachtest/cli.go
+++ b/pkg/cmd/roachtest/cli.go
@@ -24,7 +24,7 @@ import (
 
 func runCLINodeStatus(ctx context.Context, t *test, c *cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx, c.Range(1, 3))
+	c.Start(ctx, c.Range(1, 3), startArgs("--sequential"))
 
 	db := c.Conn(ctx, 1)
 	defer db.Close()


### PR DESCRIPTION
The test expects node IDs to correspond to roachprod node indexes, so
pass `--sequential` when starting the cluster.

Fixes #30249

Release note: None