### PR TITLE
workload/roachtest: Fix load-based rebalancing test flakes by splitting kv keyspace evenly

### DIFF
--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -72,8 +72,8 @@ func registerRebalanceLoad(r *registry) {
 			splits := len(roachNodes) - 1 // n-1 splits => n ranges => 1 lease per node
 			return c.RunL(ctx, quietL, appNode, fmt.Sprintf(
 				"./workload run kv --read-percent=95 --splits=%d --tolerate-errors --concurrency=%d "+
-					"--duration=%s {pgurl:1-3}",
-				splits, concurrency, duration.String()))
+					"--duration=%s {pgurl:1-%d}",
+				splits, concurrency, duration.String(), len(roachNodes)))
 		})
 
 		m.Go(func() error {

--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -20,6 +20,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -76,7 +77,7 @@ func registerRebalanceLoad(r *registry) {
 		})
 
 		m.Go(func() error {
-			t.Status(fmt.Sprintf("starting checks for lease balance"))
+			t.Status("checking for lease balance")
 
 			db := c.Conn(ctx, 1)
 			defer db.Close()
@@ -91,7 +92,7 @@ func registerRebalanceLoad(r *registry) {
 				if done, err := isLoadEvenlyDistributed(c.l, db, len(roachNodes)); err != nil {
 					return err
 				} else if done {
-					c.l.Printf("successfully achieved lease balance\n")
+					t.Status("successfully achieved lease balance; waiting for kv to finish running")
 					return nil
 				}
 
@@ -156,10 +157,9 @@ func isLoadEvenlyDistributed(l *logger, db *gosql.DB, numNodes int) (bool, error
 		leaseCounts[storeID] = leaseCount
 		rangeCount += leaseCount
 	}
-	l.Printf("numbers of test.kv leases on each store: %v\n", leaseCounts)
 
 	if len(leaseCounts) < numNodes {
-		l.Printf("not all nodes have a lease yet: %v\n", leaseCounts)
+		l.Printf("not all nodes have a lease yet: %v\n", formatLeaseCounts(leaseCounts))
 		return false, nil
 	}
 
@@ -168,10 +168,11 @@ func isLoadEvenlyDistributed(l *logger, db *gosql.DB, numNodes int) (bool, error
 	if rangeCount == numNodes {
 		for _, leaseCount := range leaseCounts {
 			if leaseCount != 1 {
-				l.Printf("uneven lease distribution: %v\n", leaseCounts)
+				l.Printf("uneven lease distribution: %s\n", formatLeaseCounts(leaseCounts))
 				return false, nil
 			}
 		}
+		l.Printf("leases successfully distributed: %s\n", formatLeaseCounts(leaseCounts))
 		return true, nil
 	}
 
@@ -183,9 +184,23 @@ func isLoadEvenlyDistributed(l *logger, db *gosql.DB, numNodes int) (bool, error
 	}
 	sort.Ints(leases)
 	if leases[0]+1 < leases[len(leases)-1] {
-		l.Printf("leases per store differ by more than one: %v\n", leaseCounts)
+		l.Printf("leases per store differ by more than one: %s\n", formatLeaseCounts(leaseCounts))
 		return false, nil
 	}
 
+	l.Printf("leases successfully distributed: %s\n", formatLeaseCounts(leaseCounts))
 	return true, nil
+}
+
+func formatLeaseCounts(counts map[int]int) string {
+	storeIDs := make([]int, 0, len(counts))
+	for storeID := range counts {
+		storeIDs = append(storeIDs, storeID)
+	}
+	sort.Ints(storeIDs)
+	strs := make([]string, 0, len(counts))
+	for _, storeID := range storeIDs {
+		strs = append(strs, fmt.Sprintf("s%d: %d", storeID, counts[storeID]))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(strs, ", "))
 }

--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -114,11 +114,9 @@ func (w *kv) Tables() []workload.Table {
 		Splits: workload.Tuples(
 			w.splits,
 			func(splitIdx int) []interface{} {
-				rng := rand.New(rand.NewSource(w.seed + int64(splitIdx)))
-				g := newHashGenerator(&sequence{config: w, val: w.writeSeq})
-				return []interface{}{
-					int(g.hash(rng.Int63())),
-				}
+				stride := (float64(math.MaxInt64) - float64(math.MinInt64)) / float64(w.splits+1)
+				splitPoint := int(math.MinInt64 + float64(splitIdx+1)*stride)
+				return []interface{}{splitPoint}
 			},
 		),
 	}


### PR DESCRIPTION
**workload/kv: Add option to split key space evenly**

The default splitting behavior randomly chooses split points, which can
lead to ranges that encompass drastically different amounts of the key
space (e.g. I saw a 9x size difference in the run I examined that
motivated this). Having drastically different range sizes is a pain for
any tests that expect roughly even qps across the ranges.

If you'd prefer I can just write this into the rebalancing roachtest,
but it seemed like something that may be useful more broadly as well.

**roachtest: Split kv ranges evenly in load-based rebalancing tests**

Fixes #29969. The rebalance-replicas-by-load roachtest sometimes failed
to properly rebalance one range leaseholder for the kv table to each
node because the ranges could receive drastically different qps (where
two smaller ranges don't even come close to the qps of one larger one).

--------------

Also, while I'm here, improve the output of the test a bit and send SQL load to all of the nodes, not just the first three.