### PR TITLE
storage: Transfer lease to least-loaded store when rebalancing replicas

### DIFF
--- a/pkg/storage/allocator_scorer.go
+++ b/pkg/storage/allocator_scorer.go
@@ -414,8 +414,10 @@ func allocateCandidates(
 				convergesScore = 1
 			} else if s.Capacity.QueriesPerSecond < sl.candidateQueriesPerSecond.mean {
 				convergesScore = 0
-			} else {
+			} else if s.Capacity.QueriesPerSecond < overfullThreshold(sl.candidateQueriesPerSecond.mean, options.qpsRebalanceThreshold) {
 				convergesScore = -1
+			} else {
+				convergesScore = -2
 			}
 		}
 		candidates = append(candidates, candidate{

--- a/pkg/storage/store_rebalancer.go
+++ b/pkg/storage/store_rebalancer.go
@@ -596,7 +596,7 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 		newLeaseIdx := 0
 		newLeaseQPS := math.MaxFloat64
 		for i := 0; i < len(targets); i++ {
-			storeDesc, ok := storeMap[desc.Replicas[i].StoreID]
+			storeDesc, ok := storeMap[targets[i].StoreID]
 			if ok && storeDesc.Capacity.QueriesPerSecond < newLeaseQPS {
 				newLeaseIdx = i
 				newLeaseQPS = storeDesc.Capacity.QueriesPerSecond

--- a/pkg/storage/store_rebalancer.go
+++ b/pkg/storage/store_rebalancer.go
@@ -407,25 +407,9 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 			if candidate.StoreID == localDesc.StoreID {
 				continue
 			}
-			storeDesc, ok := storeMap[candidate.StoreID]
-			if !ok {
-				log.VEventf(ctx, 3, "missing store descriptor for s%d", candidate.StoreID)
-				continue
-			}
 
-			newCandidateQPS := storeDesc.Capacity.QueriesPerSecond + replWithStats.qps
-			if storeDesc.Capacity.QueriesPerSecond < minQPS {
-				if newCandidateQPS > maxQPS {
-					log.VEventf(ctx, 3,
-						"r%d's %.2f qps would push s%d over the max threshold (%.2f) with %.2f qps afterwards",
-						desc.RangeID, replWithStats.qps, candidate.StoreID, maxQPS, newCandidateQPS)
-					continue
-				}
-			} else if newCandidateQPS > storeList.candidateQueriesPerSecond.mean {
-				log.VEventf(ctx, 3,
-					"r%d's %.2f qps would push s%d over the mean (%.2f) with %.2f qps afterwards",
-					desc.RangeID, replWithStats.qps, candidate.StoreID,
-					storeList.candidateQueriesPerSecond.mean, newCandidateQPS)
+			meanQPS := storeList.candidateQueriesPerSecond.mean
+			if shouldNotMoveTo(ctx, storeMap, replWithStats, candidate.StoreID, meanQPS, minQPS, maxQPS) {
 				continue
 			}
 
@@ -540,13 +524,13 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 		}
 
 		// Then pick out which new stores to add the remaining replicas to.
+		rangeInfo := rangeInfoForRepl(replWithStats.repl, desc)
+		options := sr.rq.allocator.scorerOptions()
+		options.qpsRebalanceThreshold = qpsRebalanceThreshold.Get(&sr.st.SV)
 		for len(targets) < desiredReplicas {
 			// Use the preexisting AllocateTarget logic to ensure that considerations
 			// such as zone constraints, locality diversity, and full disk come
 			// into play.
-			rangeInfo := rangeInfoForRepl(replWithStats.repl, desc)
-			options := sr.rq.allocator.scorerOptions()
-			options.qpsRebalanceThreshold = qpsRebalanceThreshold.Get(&sr.st.SV)
 			target, _ := sr.rq.allocator.allocateTargetFromList(
 				ctx,
 				storeList,
@@ -558,6 +542,11 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 			if target == nil {
 				log.VEventf(ctx, 3, "no rebalance targets found to replace the current store for r%d",
 					desc.RangeID)
+				break
+			}
+
+			meanQPS := storeList.candidateQueriesPerSecond.mean
+			if shouldNotMoveTo(ctx, storeMap, replWithStats, target.StoreID, meanQPS, minQPS, maxQPS) {
 				break
 			}
 
@@ -623,6 +612,39 @@ func shouldNotMoveAway(
 			replWithStats.repl.RangeID, replWithStats.qps, localDesc.StoreID, minQPS)
 		return true
 	}
+	return false
+}
+
+func shouldNotMoveTo(
+	ctx context.Context,
+	storeMap map[roachpb.StoreID]*roachpb.StoreDescriptor,
+	replWithStats replicaWithStats,
+	candidateStore roachpb.StoreID,
+	meanQPS float64,
+	minQPS float64,
+	maxQPS float64,
+) bool {
+	storeDesc, ok := storeMap[candidateStore]
+	if !ok {
+		log.VEventf(ctx, 3, "missing store descriptor for s%d", candidateStore)
+		return true
+	}
+
+	newCandidateQPS := storeDesc.Capacity.QueriesPerSecond + replWithStats.qps
+	if storeDesc.Capacity.QueriesPerSecond < minQPS {
+		if newCandidateQPS > maxQPS {
+			log.VEventf(ctx, 3,
+				"r%d's %.2f qps would push s%d over the max threshold (%.2f) with %.2f qps afterwards",
+				replWithStats.repl.RangeID, replWithStats.qps, candidateStore, maxQPS, newCandidateQPS)
+			return true
+		}
+	} else if newCandidateQPS > meanQPS {
+		log.VEventf(ctx, 3,
+			"r%d's %.2f qps would push s%d over the mean (%.2f) with %.2f qps afterwards",
+			replWithStats.repl.RangeID, replWithStats.qps, candidateStore, meanQPS, newCandidateQPS)
+		return true
+	}
+
 	return false
 }
 

--- a/pkg/storage/store_rebalancer_test.go
+++ b/pkg/storage/store_rebalancer_test.go
@@ -16,6 +16,8 @@ package storage
 
 import (
 	"context"
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
@@ -161,6 +163,95 @@ func TestChooseLeaseToTransfer(t *testing.T) {
 		if target.StoreID != tc.expectTarget {
 			t.Errorf("got target store %d for range with replicas %v and %f qps; want %d",
 				target.StoreID, tc.storeIDs, tc.qps, tc.expectTarget)
+		}
+	}
+}
+
+func TestChooseReplicaToRebalance(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	defer stopper.Stop(context.Background())
+	gossiputil.NewStoreGossiper(g).GossipStores(noLocalityStores, t)
+	storeList, _, _ := a.storePool.getStoreList(firstRange, storeFilterThrottled)
+	storeMap := storeListToMap(storeList)
+
+	const minQPS = 800
+	const maxQPS = 1200
+
+	localDesc := *noLocalityStores[0]
+	cfg := TestStoreConfig(nil)
+	s := createTestStoreWithoutStart(t, stopper, &cfg)
+	s.Ident = &roachpb.StoreIdent{StoreID: localDesc.StoreID}
+	rq := newReplicateQueue(s, g, a)
+	rr := newReplicaRankings()
+
+	sr := NewStoreRebalancer(cfg.AmbientCtx, cfg.Settings, rq, rr)
+
+	testCases := []struct {
+		storeIDs      []roachpb.StoreID
+		qps           float64
+		expectTargets []roachpb.StoreID // the first listed store is expected to be the leaseholder
+	}{
+		// TODO: localDesc assumes s1 is always the leaseholder...
+		{[]roachpb.StoreID{3}, 100, nil},
+		/*
+			{[]roachpb.StoreID{1, 2}, 100, 0},
+			{[]roachpb.StoreID{1, 3}, 100, 0},
+			{[]roachpb.StoreID{1, 4}, 100, 4},
+			{[]roachpb.StoreID{1, 5}, 100, 5},
+			{[]roachpb.StoreID{5, 1}, 100, 0},
+			{[]roachpb.StoreID{1, 2}, 200, 0},
+			{[]roachpb.StoreID{1, 3}, 200, 0},
+			{[]roachpb.StoreID{1, 4}, 200, 0},
+			{[]roachpb.StoreID{1, 5}, 200, 5},
+			{[]roachpb.StoreID{1, 2}, 500, 0},
+			{[]roachpb.StoreID{1, 3}, 500, 0},
+			{[]roachpb.StoreID{1, 4}, 500, 0},
+			{[]roachpb.StoreID{1, 5}, 500, 5},
+			{[]roachpb.StoreID{1, 5}, 600, 5},
+			{[]roachpb.StoreID{1, 5}, 700, 5},
+			{[]roachpb.StoreID{1, 5}, 800, 0},
+			{[]roachpb.StoreID{1, 4}, 1.5, 4},
+			{[]roachpb.StoreID{1, 5}, 1.5, 5},
+			{[]roachpb.StoreID{1, 4}, 1.49, 0},
+			{[]roachpb.StoreID{1, 5}, 1.49, 0},
+		*/
+	}
+
+	for _, tc := range testCases {
+		loadRanges(rr, s, []testRange{{storeIDs: tc.storeIDs, qps: tc.qps}})
+		hottestRanges := rr.topQPS()
+		_, targets := sr.chooseReplicaToRebalance(
+			ctx, config.SystemConfig{}, &hottestRanges, &localDesc, storeList, storeMap, minQPS, maxQPS)
+
+		if len(targets) != len(tc.expectTargets) {
+			t.Errorf("chooseReplicaToRebalance(existing=%v, qps=%f) got %v; want %v",
+				tc.storeIDs, tc.qps, targets, tc.expectTargets)
+			continue
+		}
+		if len(targets) == 0 {
+			continue
+		}
+
+		if targets[0].StoreID != tc.expectTargets[0] {
+			t.Errorf("chooseReplicaToRebalance(existing=%v, qps=%f) chose s%d as leaseholder; want s%v",
+				tc.storeIDs, tc.qps, targets[0], tc.expectTargets[0])
+		}
+
+		targetStores := make([]roachpb.StoreID, len(targets))
+		for i, target := range targets {
+			targetStores[i] = target.StoreID
+		}
+		sort.Sort(roachpb.StoreIDSlice(targetStores))
+		sort.Sort(roachpb.StoreIDSlice(tc.expectTargets))
+		if !reflect.DeepEqual(targetStores, tc.expectTargets) {
+			t.Errorf("chooseReplicaToRebalance(existing=%v, qps=%f) chose targets %v; want %v",
+				tc.storeIDs, tc.qps, targetStores, tc.expectTargets)
 		}
 	}
 }

--- a/pkg/storage/store_rebalancer_test.go
+++ b/pkg/storage/store_rebalancer_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/gossiputil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -94,6 +95,11 @@ func loadRanges(rr *replicaRankings, s *Store, ranges []testRange) {
 			Expiration: &hlc.MaxTimestamp,
 			Replica:    repl.mu.state.Desc.Replicas[0],
 		}
+		// TODO(a-robinson): The below three lines won't be needed once the old
+		// rangeInfo code is ripped out of the allocator.
+		repl.mu.state.Stats = &enginepb.MVCCStats{}
+		repl.leaseholderStats = newReplicaStats(s.Clock(), nil)
+		repl.writeStats = newReplicaStats(s.Clock(), nil)
 		acc.addReplica(replicaWithStats{
 			repl: repl,
 			qps:  r.qps,
@@ -197,61 +203,62 @@ func TestChooseReplicaToRebalance(t *testing.T) {
 		qps           float64
 		expectTargets []roachpb.StoreID // the first listed store is expected to be the leaseholder
 	}{
-		// TODO: localDesc assumes s1 is always the leaseholder...
-		{[]roachpb.StoreID{3}, 100, nil},
-		/*
-			{[]roachpb.StoreID{1, 2}, 100, 0},
-			{[]roachpb.StoreID{1, 3}, 100, 0},
-			{[]roachpb.StoreID{1, 4}, 100, 4},
-			{[]roachpb.StoreID{1, 5}, 100, 5},
-			{[]roachpb.StoreID{5, 1}, 100, 0},
-			{[]roachpb.StoreID{1, 2}, 200, 0},
-			{[]roachpb.StoreID{1, 3}, 200, 0},
-			{[]roachpb.StoreID{1, 4}, 200, 0},
-			{[]roachpb.StoreID{1, 5}, 200, 5},
-			{[]roachpb.StoreID{1, 2}, 500, 0},
-			{[]roachpb.StoreID{1, 3}, 500, 0},
-			{[]roachpb.StoreID{1, 4}, 500, 0},
-			{[]roachpb.StoreID{1, 5}, 500, 5},
-			{[]roachpb.StoreID{1, 5}, 600, 5},
-			{[]roachpb.StoreID{1, 5}, 700, 5},
-			{[]roachpb.StoreID{1, 5}, 800, 0},
-			{[]roachpb.StoreID{1, 4}, 1.5, 4},
-			{[]roachpb.StoreID{1, 5}, 1.5, 5},
-			{[]roachpb.StoreID{1, 4}, 1.49, 0},
-			{[]roachpb.StoreID{1, 5}, 1.49, 0},
-		*/
+		{[]roachpb.StoreID{1}, 100, []roachpb.StoreID{5}},
+		{[]roachpb.StoreID{1}, 500, []roachpb.StoreID{5}},
+		{[]roachpb.StoreID{1}, 700, []roachpb.StoreID{5}},
+		{[]roachpb.StoreID{1}, 800, nil},
+		{[]roachpb.StoreID{1}, 1.5, []roachpb.StoreID{5}},
+		{[]roachpb.StoreID{1}, 1.49, nil},
+		{[]roachpb.StoreID{1, 2}, 100, []roachpb.StoreID{5, 2}},
+		{[]roachpb.StoreID{1, 3}, 100, []roachpb.StoreID{5, 3}},
+		{[]roachpb.StoreID{1, 4}, 100, []roachpb.StoreID{5, 4}},
+		{[]roachpb.StoreID{1, 2}, 800, nil},
+		{[]roachpb.StoreID{1, 2}, 1.49, nil},
+		{[]roachpb.StoreID{1, 4, 5}, 500, nil},
+		{[]roachpb.StoreID{1, 4, 5}, 100, nil},
+		{[]roachpb.StoreID{1, 3, 5}, 500, nil},
+		{[]roachpb.StoreID{1, 3, 4}, 500, []roachpb.StoreID{5, 4, 3}},
+		{[]roachpb.StoreID{1, 3, 5}, 100, []roachpb.StoreID{5, 4, 3}},
+		// Rebalancing to s2 isn't chosen even though it's better than s1 because it's above the mean.
+		{[]roachpb.StoreID{1, 3, 4, 5}, 100, nil},
+		{[]roachpb.StoreID{1, 2, 4, 5}, 100, nil},
+		{[]roachpb.StoreID{1, 2, 3, 5}, 100, []roachpb.StoreID{5, 4, 3, 2}},
+		{[]roachpb.StoreID{1, 2, 3, 4}, 100, []roachpb.StoreID{5, 4, 3, 2}},
 	}
 
 	for _, tc := range testCases {
-		loadRanges(rr, s, []testRange{{storeIDs: tc.storeIDs, qps: tc.qps}})
-		hottestRanges := rr.topQPS()
-		_, targets := sr.chooseReplicaToRebalance(
-			ctx, config.SystemConfig{}, &hottestRanges, &localDesc, storeList, storeMap, minQPS, maxQPS)
+		t.Run("", func(t *testing.T) {
+			zone := config.DefaultZoneConfig()
+			zone.NumReplicas = int32(len(tc.storeIDs))
+			defer config.TestingSetDefaultZoneConfig(zone)()
+			loadRanges(rr, s, []testRange{{storeIDs: tc.storeIDs, qps: tc.qps}})
+			hottestRanges := rr.topQPS()
+			_, targets := sr.chooseReplicaToRebalance(
+				ctx, config.NewSystemConfig(), &hottestRanges, &localDesc, storeList, storeMap, minQPS, maxQPS)
 
-		if len(targets) != len(tc.expectTargets) {
-			t.Errorf("chooseReplicaToRebalance(existing=%v, qps=%f) got %v; want %v",
-				tc.storeIDs, tc.qps, targets, tc.expectTargets)
-			continue
-		}
-		if len(targets) == 0 {
-			continue
-		}
+			if len(targets) != len(tc.expectTargets) {
+				t.Fatalf("chooseReplicaToRebalance(existing=%v, qps=%f) got %v; want %v",
+					tc.storeIDs, tc.qps, targets, tc.expectTargets)
+			}
+			if len(targets) == 0 {
+				return
+			}
 
-		if targets[0].StoreID != tc.expectTargets[0] {
-			t.Errorf("chooseReplicaToRebalance(existing=%v, qps=%f) chose s%d as leaseholder; want s%v",
-				tc.storeIDs, tc.qps, targets[0], tc.expectTargets[0])
-		}
+			if targets[0].StoreID != tc.expectTargets[0] {
+				t.Errorf("chooseReplicaToRebalance(existing=%v, qps=%f) chose s%d as leaseholder; want s%v",
+					tc.storeIDs, tc.qps, targets[0], tc.expectTargets[0])
+			}
 
-		targetStores := make([]roachpb.StoreID, len(targets))
-		for i, target := range targets {
-			targetStores[i] = target.StoreID
-		}
-		sort.Sort(roachpb.StoreIDSlice(targetStores))
-		sort.Sort(roachpb.StoreIDSlice(tc.expectTargets))
-		if !reflect.DeepEqual(targetStores, tc.expectTargets) {
-			t.Errorf("chooseReplicaToRebalance(existing=%v, qps=%f) chose targets %v; want %v",
-				tc.storeIDs, tc.qps, targetStores, tc.expectTargets)
-		}
+			targetStores := make([]roachpb.StoreID, len(targets))
+			for i, target := range targets {
+				targetStores[i] = target.StoreID
+			}
+			sort.Sort(roachpb.StoreIDSlice(targetStores))
+			sort.Sort(roachpb.StoreIDSlice(tc.expectTargets))
+			if !reflect.DeepEqual(targetStores, tc.expectTargets) {
+				t.Errorf("chooseReplicaToRebalance(existing=%v, qps=%f) chose targets %v; want %v",
+					tc.storeIDs, tc.qps, targetStores, tc.expectTargets)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This logic was totally busted before due to indexing into the wrong
replicas slice, meaning we would often transfer the lease to the wrong
store.

Release note: None