### PR TITLE
roachtest: Promote rebalance-leases-by-load to stable

### DIFF
--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -114,7 +114,7 @@ func registerRebalanceLoad(r *registry) {
 	r.Add(testSpec{
 		Name:   `rebalance-leases-by-load`,
 		Nodes:  nodes(4), // the last node is just used to generate load
-		Stable: false,    // TODO(a-robinson): Promote to stable
+		Stable: true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if local {
 				concurrency = 32


### PR DESCRIPTION
It hasn't flaked at all since being added last month.

Release note: None