### PR TITLE
roachtest: adjust for new TPC-H fixture

### DIFF
--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -41,7 +41,7 @@ func registerAllocator(r *registry) {
 		m := newMonitor(ctx, c, c.Range(1, start))
 		m.Go(func(ctx context.Context) error {
 			t.Status("loading fixture")
-			if _, err := db.Exec(`RESTORE DATABASE workload FROM $1`, fixturePath); err != nil {
+			if _, err := db.Exec(`RESTORE DATABASE tpch FROM $1`, fixturePath); err != nil {
 				t.Fatal(err)
 			}
 			return nil

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -43,7 +43,7 @@ func registerSchemaChange(r *registry) {
 			m := newMonitor(ctx, c, c.All())
 			m.Go(func(ctx context.Context) error {
 				t.Status("loading fixture")
-				if _, err := db.Exec(`RESTORE DATABASE workload FROM $1`, fixturePath); err != nil {
+				if _, err := db.Exec(`RESTORE DATABASE tpch FROM $1`, fixturePath); err != nil {
 					t.Fatal(err)
 				}
 				return nil
@@ -81,10 +81,10 @@ func waitForSchemaChanges(ctx context.Context, l *logger, db *gosql.DB) error {
 
 	// These schema changes are over a table that is not actively
 	// being updated.
-	l.Printf("running schema changes over workload.customer\n")
+	l.Printf("running schema changes over tpch.customer\n")
 	schemaChanges := []string{
-		"ALTER TABLE workload.customer ADD COLUMN newcol INT DEFAULT 23456",
-		"CREATE INDEX foo ON workload.customer (c_name)",
+		"ALTER TABLE tpch.customer ADD COLUMN newcol INT DEFAULT 23456",
+		"CREATE INDEX foo ON tpch.customer (c_name)",
 	}
 	if err := runSchemaChanges(ctx, l, db, schemaChanges); err != nil {
 		return err
@@ -97,9 +97,9 @@ func waitForSchemaChanges(ctx context.Context, l *logger, db *gosql.DB) error {
 
 	// All these return the same result.
 	validationQueries := []string{
-		"SELECT count(*) FROM workload.customer AS OF SYSTEM TIME %s",
-		"SELECT count(newcol) FROM workload.customer AS OF SYSTEM TIME %s",
-		"SELECT count(c_name) FROM workload.customer@foo AS OF SYSTEM TIME %s",
+		"SELECT count(*) FROM tpch.customer AS OF SYSTEM TIME %s",
+		"SELECT count(newcol) FROM tpch.customer AS OF SYSTEM TIME %s",
+		"SELECT count(c_name) FROM tpch.customer@foo AS OF SYSTEM TIME %s",
 	}
 	if err := runValidationQueries(ctx, l, db, start, validationQueries, nil); err != nil {
 		return err


### PR DESCRIPTION
The TPC-H fixture was regenerated and the new fixture uses the database
name "tpch" instead of "workload". Adjust the roachtests that depend on
this fixture accordingly.

Fixes #30262.

Release note: None