### PR TITLE
release-2.1: cli: improve node status output (without deadlocking)

### DIFF
--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -82,6 +82,7 @@ var baseNodeColumnHeaders = []string{
 	"build",
 	"started_at",
 	"updated_at",
+	"is_available",
 	"is_live",
 }
 
@@ -162,9 +163,11 @@ FROM crdb_internal.gossip_liveness JOIN crdb_internal.gossip_nodes USING (node_i
                 CASE WHEN split_part(expiration,',',1)::decimal > now()::decimal
                      THEN true
                      ELSE false
-                     END AS is_live
+                     END AS is_available
          FROM crdb_internal.gossip_liveness`,
 			),
+			`SELECT node_id AS id, is_live
+         FROM crdb_internal.gossip_nodes`,
 		},
 	)
 

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -336,7 +336,7 @@ func runDecommissionAcceptance(ctx context.Context, t *test, c *cluster) {
 			"Please verify cluster health before removing the nodes.",
 	}
 	statusHeader := []string{
-		"id", "address", "build", "started_at", "updated_at", "is_live",
+		"id", "address", "build", "started_at", "updated_at", "is_available", "is_live",
 	}
 	waitLiveDeprecated := "--wait=live is deprecated and is treated as --wait=all"
 
@@ -392,10 +392,10 @@ func runDecommissionAcceptance(ctx context.Context, t *test, c *cluster) {
 		}
 		exp := [][]string{
 			statusHeader,
-			{`1`, `.*`, `.*`, `.*`, `.*`, `.*`},
-			{`2`, `.*`, `.*`, `.*`, `.*`, `.*`},
-			{`3`, `.*`, `.*`, `.*`, `.*`, `.*`},
-			{`4`, `.*`, `.*`, `.*`, `.*`, `.*`},
+			{`1`, `.*`, `.*`, `.*`, `.*`, `.*`, `.*`},
+			{`2`, `.*`, `.*`, `.*`, `.*`, `.*`, `.*`},
+			{`3`, `.*`, `.*`, `.*`, `.*`, `.*`, `.*`},
+			{`4`, `.*`, `.*`, `.*`, `.*`, `.*`, `.*`},
 		}
 		if err := matchCSV(o, exp); err != nil {
 			t.Fatal(err)
@@ -586,9 +586,9 @@ func runDecommissionAcceptance(ctx context.Context, t *test, c *cluster) {
 
 		exp := [][]string{
 			statusHeader,
-			{`2`, `.*`, `.*`, `.*`, `.*`, `.*`},
-			{`3`, `.*`, `.*`, `.*`, `.*`, `.*`},
-			{`4`, `.*`, `.*`, `.*`, `.*`, `.*`},
+			{`2`, `.*`, `.*`, `.*`, `.*`, `.*`, `.*`},
+			{`3`, `.*`, `.*`, `.*`, `.*`, `.*`, `.*`},
+			{`4`, `.*`, `.*`, `.*`, `.*`, `.*`, `.*`},
 		}
 		if err := matchCSV(o, exp); err != nil {
 			time.Sleep(time.Second)

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -224,7 +224,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         20 columns, 914 rows
+                     │                     size         20 columns, 915 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -217,7 +217,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         20 columns, 914 rows
+                     │                     size         20 columns, 915 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·


### PR DESCRIPTION
Backport:
  * 1/1 commits from "cli: improve node status output" (#30081)
  * 1/1 commits from "gossip,sql: avoid deadlocking in crdb_internal.gossip_nodes" (#30264)

Please see individual PRs for details.

/cc @cockroachdb/release
