### PR TITLE
distsqlrun: simplify Processor implementation burden

### DIFF
--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -155,6 +155,103 @@ type RowSource interface {
 	ConsumerClosed()
 }
 
+// SimpleRowSource is a RowSource extended with a SimpleNext method that doesn't
+// know about ProducerMetadata. A Processor can be implemented more simply by
+// embedding ProcessorBase and implementing SimpleNext, and leaving the actual
+// Next() implementation up to ProcessorBase.
+//
+// If a Processor implements the SimpleRowSource interface, its implementation
+// is expected to look something like this:
+//
+//   // concatProcessor concatenates rows from two sources (first returns rows
+//   // from the left, then from the right).
+//   type concatProcessor struct {
+//     ProcessorBase
+//     l, r RowSource
+//
+//     // leftConsumed is set once we've exhausted the left input; once set, we start
+//     // consuming the right input.
+//     leftConsumed bool
+//   }
+//
+//   func newConcatProcessor(
+//     flowCtx *FlowCtx, l RowSource, r RowSource, post *PostProcessSpec, output RowReceiver,
+//   ) (*concatProcessor, error) {
+//     p := &concatProcessor{}
+//     p.l = MakeRowSourceInput(l, &p.ProcessorBase)
+//     p.r = MakeRowSourceInput(r, &p.ProcessorBase)
+//     if err := p.init(
+//       post, l.OutputTypes(), flowCtx, output,
+//       // We pass the inputs to the helper, to be consumed by DrainHelper() later.
+//       ProcStateOpts{
+//         InputsToDrain: []RowSource{l, r},
+//         // If the proc needed to return any metadata at the end other than the
+//         // tracing info, or if it needed to cleanup any resources other than those
+//         // handled by InternalClose() (say, close some memory account), it'd pass
+//         // a TrailingMetaCallback here.
+//       },
+//     ); err != nil {
+//       return nil, err
+//     }
+//     return p, nil
+//   }
+//
+//   // Start is part of the RowSource interface.
+//   func (p *concatProcessor) Start(ctx context.Context) context.Context {
+//     p.l.Start(ctx)
+//     p.r.Start(ctx)
+//     return p.StartInternal(ctx, concatProcName)
+//   }
+//
+//   // Next is part of the SimpleRowSource interface.
+//   func (p *concatProcessor) SimpleNext() (sqlbase.EncDatumRow, err) {
+//     for {
+//       var row sqlbase.EncDatumRow
+//       if !p.leftConsumed {
+//         row, err = p.l.SimpleNext()
+//       } else {
+//         row, err = p.r.SimpleNext()
+//       }
+//
+//       if err != nil {
+//         return nil, err
+//       }
+//       if row == nil {
+//         if !p.leftConsumed {
+//           p.leftConsumed = true
+//         } else {
+//           return nil, nil
+//         }
+//         continue
+//       }
+//
+//       return row, nil
+//     }
+//   }
+//
+//   // ConsumerClosed is part of the RowSource interface.
+//   func (p *concatProcessor) ConsumerClosed() {
+//     // The consumer is done, Next() will not be called again.
+//     p.InternalClose()
+//   }
+//
+type SimpleRowSource interface {
+	RowSource
+	SimpleNext() (sqlbase.EncDatumRow, error)
+}
+
+// SimpleInput is an interface that presents a simplified Next method,
+// NextFromInput, which returns a row or nil and never errors. This interface
+// shouldn't be implemented by Processor code - it's designed to be used by
+// Processors that implement the SimpleRowSource interface with help from
+// ProcessorBase. The inputs to SimpleRowSource implementors should be wrapped
+// by one of these, so that Processor implementations don't have to worry about
+// errors or metadata from upstream.
+type SimpleInput interface {
+	RowSource
+	NextFromInput() sqlbase.EncDatumRow
+}
+
 // RowSourcedProcessor is the union of RowSource and Processor.
 type RowSourcedProcessor interface {
 	RowSource

--- a/pkg/sql/distsqlrun/noop.go
+++ b/pkg/sql/distsqlrun/noop.go
@@ -26,18 +26,19 @@ import (
 // need the synchronizer to join streams.
 type noopProcessor struct {
 	ProcessorBase
-	input RowSource
+	input SimpleInput
 }
 
 var _ Processor = &noopProcessor{}
-var _ RowSource = &noopProcessor{}
+var _ SimpleRowSource = &noopProcessor{}
 
 const noopProcName = "noop"
 
 func newNoopProcessor(
 	flowCtx *FlowCtx, processorID int32, input RowSource, post *PostProcessSpec, output RowReceiver,
 ) (*noopProcessor, error) {
-	n := &noopProcessor{input: input}
+	n := &noopProcessor{}
+	n.input = MakeRowSourceInput(input, &n.ProcessorBase)
 	if err := n.Init(
 		n,
 		post,
@@ -59,27 +60,10 @@ func (n *noopProcessor) Start(ctx context.Context) context.Context {
 	return n.StartInternal(ctx, noopProcName)
 }
 
-// Next is part of the RowSource interface.
-func (n *noopProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
-	for n.State == StateRunning {
-		row, meta := n.input.Next()
-
-		if meta != nil {
-			if meta.Err != nil {
-				n.MoveToDraining(nil /* err */)
-			}
-			return nil, meta
-		}
-		if row == nil {
-			n.MoveToDraining(nil /* err */)
-			break
-		}
-
-		if outRow := n.ProcessRowHelper(row); outRow != nil {
-			return outRow, nil
-		}
-	}
-	return nil, n.DrainHelper()
+// SimpleNext is part of the SimpleRowSource interface.
+func (n *noopProcessor) SimpleNext() (sqlbase.EncDatumRow, error) {
+	// noop - just pass row through.
+	return n.input.NextFromInput(), nil
 }
 
 // ConsumerClosed is part of the RowSource interface.


### PR DESCRIPTION
Note to reviewers: here's my stab at making processors not have to deal with ProducerMetadata. As a freebie, they also don't have to deal with ProcOutputHelper. Seeking input on the names (SimpleRowSource is not great, RowSourceInput might be better, and the combination of the two is probably horrible).

This commit adds a new set of interfaces to distsqlrun that seeks to
make it easier to implement Processors. Specifically, there are two
goals: to prevent implementations from having to deal with

1. metadata or errors from upstream Processors
2. cooking their output rows with ProcOutputHelper

This is accomplished by two new interfaces and two new implementations /
helpers:

1. `SimpleRowSource`, which is an extension of `RowSource` with a method
   `SimpleNext() (EncDatumRow, error)` that is meant to be implemented
   by Processors instead of `Next`.
2. `RowSourceInput`, which is an extension of `RowSource` with a method
   `NextFromInput() EncDatumRow` that is meant to be consumed by
   Processors instead of a raw `RowSource`.

These interfaces are made possible by:

1. A default implementation of `Next` on `ProcessorBase` that calls
   `SimpleNext` on the `ProcessorBase`'s embedding struct, taking care of
   converting any output errors or nil rows into the corresponding
   creation of metadata or draining, as well as cooking output rows from
   processors with their corresponding `ProcOutputHelper`.
2. A function called `MakeRowSourceInput` that wraps a `RowSource` along
   with a consuming `ProcessorBase` into a `RowSourceInput` that takes
   care of forwarding metadata from upstream processors.

As a result, processor implementations can be less confusing. They don't
have to properly forward metadata from upstream processors, which has
proven to be error-prone and a source of bugs that are difficult to test
for ahead of time.

This commit converts 2 processors to the new interface, the no-op
processor and the distinct processor. The rest can be done later.

Release note: None