### PR TITLE
backport-2.1: opt: improve test coverage and remove unused rules

### DIFF
--- a/pkg/sql/opt/norm/check_expr.go
+++ b/pkg/sql/opt/norm/check_expr.go
@@ -97,6 +97,24 @@ func (f *Factory) checkExpr(ev memo.ExprView) {
 		if def.LookupCols.Empty() {
 			panic(fmt.Sprintf("lookup join with no lookup columns"))
 		}
+
+	case opt.SelectOp:
+		filter := ev.Child(1)
+		switch filter.Operator() {
+		case opt.FiltersOp:
+		default:
+			panic(fmt.Sprintf("select contains %s", filter.Operator()))
+		}
+
+	default:
+		if ev.IsJoin() {
+			on := ev.Child(2)
+			switch on.Operator() {
+			case opt.FiltersOp, opt.TrueOp, opt.FalseOp:
+			default:
+				panic(fmt.Sprintf("join contains %s", on.Operator()))
+			}
+		}
 	}
 
 	f.checkExprOrdering(ev)

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -99,6 +99,11 @@ type Factory struct {
 	// temporary results that are accumulated before constructing a new
 	// Projections operator.
 	scratchColList opt.ColList
+
+	// skipSanityChecks disables the checks performed by checkExpr. This is
+	// needed in cases where we might construct not-fully-normalized expressions,
+	// such as in optsteps.
+	skipSanityChecks bool
 }
 
 // Init initializes a Factory structure with a new, blank memo structure inside.
@@ -117,6 +122,12 @@ func (f *Factory) Init(evalCtx *tree.EvalContext) {
 // are applied).
 func (f *Factory) DisableOptimizations() {
 	f.NotifyOnMatchedRule(func(opt.RuleName) bool { return false })
+}
+
+// SkipSanityChecks disables the checkExpr validation checks on expressions
+// produced by this factory.
+func (f *Factory) SkipSanityChecks() {
+	f.skipSanityChecks = true
 }
 
 // NotifyOnMatchedRule sets a callback function which is invoked each time a
@@ -175,7 +186,7 @@ func (f *Factory) onConstruct(e memo.Expr) memo.GroupID {
 
 	// RaceEnabled ensures that checks are run on every change (as part of make
 	// testrace) while keeping the check code out of non-test builds.
-	if util.RaceEnabled {
+	if util.RaceEnabled && !f.skipSanityChecks {
 		f.checkExpr(ev)
 	}
 	return ev.Group()

--- a/pkg/sql/opt/norm/rules/bool.opt
+++ b/pkg/sql/opt/norm/rules/bool.opt
@@ -22,21 +22,13 @@
 # =============================================================================
 
 
-# EliminateEmptyAnd maps an empty And or Filters list to True.
-[EliminateEmptyAnd, Normalize]
-(And | Filters
+# EliminateEmptyFilters maps an empty Filters list to True.
+[EliminateEmptyFilters, Normalize]
+(Filters
     $conditions:[]
 )
 =>
 (True)
-
-# EliminateEmptyOr maps an empty Or list to False.
-[EliminateEmptyOr, Normalize]
-(Or
-    $conditions:[]
-)
-=>
-(False)
 
 # EliminateSingletonAndOr discards an And or Or operator that has only one
 # condition.

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -3,40 +3,6 @@
 # =============================================================================
 
 
-# EnsureJoinFiltersAnd replaces an And operator in a Join's On condition with
-# the Filters operator. This allows other rules to rely upon the presence of
-# the Filters when matching. See comment at top of bool.opt for more details.
-# This rule is a special-case of the EnsureJoinFilters rule, for performance
-# reasons (no need to construct a new conditions list) in a common case.
-[EnsureJoinFiltersAnd, Normalize]
-(Join
-    $left:*
-    $right:*
-    (And $conditions:*)
-)
-=>
-((OpName)
-    $left
-    $right
-    (Filters $conditions)
-)
-
-# EnsureJoinFilters adds a Filters operator to a Join's On condition if it does
-# not already exist. This allows other rules to rely upon the presence of the
-# Filters when matching. See comment at top of bool.opt for more details.
-[EnsureJoinFilters, Normalize]
-(Join
-    $left:*
-    $right:*
-    $filter:^(Filters | And | True | False)
-)
-=>
-((OpName)
-    $left
-    $right
-    (Filters [ $filter ])
-)
-
 # PushFilterIntoJoinLeftAndRight pushes a filter into both the left and right
 # sides of an InnerJoin or SemiJoin if it can be mapped to use the columns of
 # both sides. For example, consider this query:

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -9,22 +9,6 @@
 [EliminateSelect, Normalize]
 (Select $input:* (True)) => $input
 
-# EnsureSelectFiltersAnd replaces an And operator in a Select filter with the
-# Filters operator. This allows other rules to rely upon the presence of the
-# Filters when matching. See comment at top of bool.opt for more details. This
-# rule is a special-case of the EnsureSelectFilters rule, for performance
-# reasons (no need to construct a new conditions list) in a common case.
-[EnsureSelectFiltersAnd, Normalize]
-(Select
-    $input:*
-    (And $conditions:*)
-)
-=>
-(Select
-    $input
-    (Filters $conditions)
-)
-
 # EnsureSelectFilters adds a Filters operator to a Select's filter condition
 # if it does not already exist. This allows other rules to rely upon the
 # presence of the Filters when matching. See comment at top of bool.opt for

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -34,7 +34,7 @@ TABLE c
 
 
 # --------------------------------------------------
-# EliminateEmptyAnd
+# EliminateEmptyFilters
 # --------------------------------------------------
 opt
 SELECT * FROM a WHERE True AND True
@@ -458,18 +458,15 @@ select
 # EliminateNot
 # --------------------------------------------------
 opt
-SELECT * FROM a WHERE NOT(NOT(j = '{}'))
+SELECT * FROM c WHERE NOT(NOT(a))
 ----
 select
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb!null)
- ├── key: (1)
- ├── fd: ()-->(5), (1)-->(2-4)
- ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
- └── filters [type=bool, outer=(5), constraints=(/5: [/'{}' - /'{}']; tight), fd=()-->(5)]
-      └── j = '{}' [type=bool, outer=(5), constraints=(/5: [/'{}' - /'{}']; tight)]
+ ├── columns: a:1(bool!null) b:2(bool) c:3(bool) d:4(bool) e:5(bool)
+ ├── fd: ()-->(1)
+ ├── scan c
+ │    └── columns: a:1(bool) b:2(bool) c:3(bool) d:4(bool) e:5(bool)
+ └── filters [type=bool, outer=(1), constraints=(/1: [/true - /true]; tight), fd=()-->(1)]
+      └── variable: a [type=bool, outer=(1), constraints=(/1: [/true - /true]; tight)]
 
 # --------------------------------------------------
 # NegateAnd + NegateComparison

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -794,7 +794,7 @@ DecorrelateJoin
     │         └── y = i [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
     └── filters [type=bool]
 ================================================================================
-EliminateEmptyAnd
+EliminateEmptyFilters
   Cost: 2190.00
 ================================================================================
    select
@@ -1366,7 +1366,7 @@ MergeSelects
     └── projections [outer=(11)]
          └── variable: case [type=bool, outer=(11)]
 ================================================================================
-EliminateEmptyAnd
+EliminateEmptyFilters
   Cost: 2152.56
 ================================================================================
    project

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -37,59 +37,6 @@ TABLE uv
  └── INDEX primary
       └── u int not null
 
-# --------------------------------------------------
-# EnsureJoinFiltersAnd
-# --------------------------------------------------
-opt
-SELECT * FROM a INNER JOIN b ON a.k=b.x AND b.y<a.i
-----
-inner-join (merge)
- ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int!null)
- ├── key: (6)
- ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
- ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
- │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
- ├── scan b
- │    ├── columns: x:6(int!null) y:7(int)
- │    ├── key: (6)
- │    ├── fd: (6)-->(7)
- │    └── ordering: +6
- └── merge-on
-      ├── left ordering: +1
-      ├── right ordering: +6
-      └── filters [type=bool, outer=(1,2,6,7), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /6: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-           ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
-           └── y < i [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
-
-# --------------------------------------------------
-# EnsureJoinFilters
-# --------------------------------------------------
-opt
-SELECT * FROM a INNER JOIN b ON a.k=b.x
-----
-inner-join (merge)
- ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
- ├── key: (6)
- ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
- ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
- │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    └── ordering: +1
- ├── scan b
- │    ├── columns: x:6(int!null) y:7(int)
- │    ├── key: (6)
- │    ├── fd: (6)-->(7)
- │    └── ordering: +6
- └── merge-on
-      ├── left ordering: +1
-      ├── right ordering: +6
-      └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-           └── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
-
 opt
 SELECT * FROM a INNER JOIN b ON a.s='foo' OR b.y<10
 ----

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -161,28 +161,32 @@ distinct-on
 # --------------------------------------------------
 # Remove column functionally dependent on multi-column key.
 opt
-SELECT * FROM abcde WITH ORDINALITY WHERE b IS NOT NULL AND c IS NOT NULL ORDER BY c, d, b, e
+SELECT * FROM (SELECT * FROM abcde WHERE b IS NOT NULL AND c IS NOT NULL ORDER BY c, d, b, e) WITH ORDINALITY
 ----
-sort
+row-number
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) e:5(int) ordinality:6(int!null)
  ├── key: (1)
  ├── fd: (1)-->(2-6), (2,3)-->(1,4,5), (6)-->(1-5)
- ├── ordering: +3,+4,+2
- └── select
-      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) e:5(int) ordinality:6(int!null)
+ └── sort
+      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) e:5(int)
       ├── key: (1)
-      ├── fd: (1)-->(2-6), (2,3)-->(1,4,5), (6)-->(1-5)
-      ├── row-number
-      │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int) e:5(int) ordinality:6(int!null)
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-6), (2,3)~~>(1,4,5), (6)-->(1-5)
-      │    └── scan abcde
-      │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int) e:5(int)
-      │         ├── key: (1)
-      │         └── fd: (1)-->(2-5), (2,3)~~>(1,4,5)
-      └── filters [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]; tight)]
-           ├── b IS NOT NULL [type=bool, outer=(2), constraints=(/2: (/NULL - ]; tight)]
-           └── c IS NOT NULL [type=bool, outer=(3), constraints=(/3: (/NULL - ]; tight)]
+      ├── fd: (1)-->(2-5), (2,3)-->(1,4,5)
+      ├── ordering: +3,+4,+2
+      └── index-join abcde
+           ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) e:5(int)
+           ├── key: (1)
+           ├── fd: (1)-->(2-5), (2,3)-->(1,4,5)
+           └── select
+                ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+                ├── key: (1)
+                ├── fd: (1)-->(2,3), (2,3)-->(1)
+                ├── scan abcde@bc
+                │    ├── columns: a:1(int!null) b:2(int!null) c:3(int)
+                │    ├── constraint: /2/3: (/NULL - ]
+                │    ├── key: (1)
+                │    └── fd: (1)-->(2,3), (2,3)~~>(1)
+                └── filters [type=bool, outer=(3), constraints=(/3: (/NULL - ]; tight)]
+                     └── c IS NOT NULL [type=bool, outer=(3), constraints=(/3: (/NULL - ]; tight)]
 
 # --------------------------------------------------
 # SimplifyExplainOrdering

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -29,24 +29,6 @@ TABLE uv
       └── u int not null
 
 # --------------------------------------------------
-# EnsureSelectFiltersAnd
-# --------------------------------------------------
-opt
-SELECT * FROM a WHERE i=5 AND s<'foo'
-----
-select
- ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null) j:5(jsonb)
- ├── key: (1)
- ├── fd: ()-->(2), (1)-->(3-5)
- ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
- └── filters [type=bool, outer=(2,4), constraints=(/2: [/5 - /5]; /4: (/NULL - /'foo'); tight), fd=()-->(2)]
-      ├── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
-      └── s < 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - /'foo'); tight)]
-
-# --------------------------------------------------
 # EnsureSelectFilters
 # --------------------------------------------------
 opt

--- a/pkg/sql/opt/testutils/forcing_opt.go
+++ b/pkg/sql/opt/testutils/forcing_opt.go
@@ -66,6 +66,12 @@ func newForcingOptimizer(
 		lastMatched: opt.InvalidRuleName,
 	}
 	fo.o.Init(&tester.evalCtx)
+	// If we could possibly produce expressions that are not fully
+	// normalized, they won't necessarily pass the sanity check
+	// validations.
+	if !ignoreNormRules {
+		fo.o.Factory().SkipSanityChecks()
+	}
 
 	fo.o.NotifyOnMatchedRule(func(ruleName opt.RuleName) bool {
 		if ignoreNormRules && ruleName.IsNormalize() {


### PR DESCRIPTION
Backport 1/1 commits from #29050.

/cc @cockroachdb/release

---

EliminateEmpty{And,Or} were superseded by SimplifyAnd and SimplifyOr.
Ensure{Join,Select}FiltersAnd were superseded by SimplifyFilters.

I'm not sure about removing EnsureJoinFilters - I can't see a way to
trigger it since I think we're generally pretty careful about
constructing Joins with Filters, but its removal does increase the
probability that we'll create an invalid Join in the future (possibly
without noticing).

Also change tests so that SimplifyRowNumberOrdering and EliminateNot
trigger now.

One thought I have is that we have lots of these clearly demarcated tests that are intended to test a particular rule - perhaps we should consider introducing a directive which fails a test if a certain set of rules aren't triggered.

Release note: None
