### PR TITLE
gossip: Don't include gossip connectivity in periodic status logs

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -561,10 +561,8 @@ func (g *Gossip) LogStatus() {
 	g.mu.RUnlock()
 
 	ctx := g.AnnotateCtx(context.TODO())
-	log.Infof(
-		ctx, "gossip status (%s, %d node%s)\n%s%s%s", status, n, util.Pluralize(int64(n)),
-		g.clientStatus(), g.server.status(), g.Connectivity(),
-	)
+	log.Infof(ctx, "gossip status (%s, %d node%s)\n%s%s",
+		status, n, util.Pluralize(int64(n)), g.clientStatus(), g.server.status())
 }
 
 func (g *Gossip) clientStatus() ClientStatus {


### PR DESCRIPTION
As discussed on #30088. It can be absolutely massive on large clusters,
and isn't needed because we still log the connectivity info whenever it
changes.

Release note: None

I still think that logging on every change in connectivity is going to be a mess in large clusters during rolling restarts even if gossip is otherwise perfectly stable, but this is useful regardless of whether we do anything about that.