### PR TITLE
release-2.1: opt: increase checkExpr coverage

### DIFF
--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -12,27 +12,26 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package norm
+package memo
 
 import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 )
 
-// checkExpr does sanity checking on an Expr. This code is called from
-// onConstruct in testrace builds (which gives us test/CI coverage but elides
-// this code in regular builds).
+// CheckExpr does sanity checking on an Expr. This code is called in testrace
+// builds (which gives us test/CI coverage but elides this code in regular
+// builds).
 // This function does not assume that the expression has been fully normalized.
-func (f *Factory) checkExpr(ev memo.ExprView) {
+func CheckExpr(ev ExprView) {
 	// Check logical properties.
 	ev.Logical().Verify()
 
 	switch ev.Operator() {
 	case opt.ScanOp:
-		def := ev.Private().(*memo.ScanOpDef)
+		def := ev.Private().(*ScanOpDef)
 		if def.Flags.NoIndexJoin && def.Flags.ForceIndex {
 			panic("NoIndexJoin and ForceIndex set")
 		}
@@ -40,7 +39,7 @@ func (f *Factory) checkExpr(ev memo.ExprView) {
 	case opt.ProjectionsOp:
 		// Check that we aren't passing through columns in projection expressions.
 		n := ev.ChildCount()
-		def := ev.Private().(*memo.ProjectionsOpDef)
+		def := ev.Private().(*ProjectionsOpDef)
 		colList := def.SynthesizedCols
 		if len(colList) != n {
 			panic(fmt.Sprintf("%d projections but %d columns", n, len(colList)))
@@ -85,13 +84,13 @@ func (f *Factory) checkExpr(ev memo.ExprView) {
 		}
 
 	case opt.IndexJoinOp:
-		def := ev.Private().(*memo.IndexJoinDef)
+		def := ev.Private().(*IndexJoinDef)
 		if def.Cols.Empty() {
 			panic(fmt.Sprintf("index join with no columns"))
 		}
 
 	case opt.LookupJoinOp:
-		def := ev.Private().(*memo.LookupJoinDef)
+		def := ev.Private().(*LookupJoinDef)
 		if len(def.KeyCols) == 0 {
 			panic(fmt.Sprintf("lookup join with no key columns"))
 		}
@@ -118,11 +117,11 @@ func (f *Factory) checkExpr(ev memo.ExprView) {
 		}
 	}
 
-	f.checkExprOrdering(ev)
+	checkExprOrdering(ev)
 }
 
 // checkExprOrdering runs checks on orderings stored inside operators.
-func (f *Factory) checkExprOrdering(ev memo.ExprView) {
+func checkExprOrdering(ev ExprView) {
 	// Verify that orderings stored in operators only refer to columns produced by
 	// their input.
 	var ordering *props.OrderingChoice
@@ -130,9 +129,9 @@ func (f *Factory) checkExprOrdering(ev memo.ExprView) {
 	case opt.LimitOp, opt.OffsetOp:
 		ordering = ev.Private().(*props.OrderingChoice)
 	case opt.RowNumberOp:
-		ordering = &ev.Private().(*memo.RowNumberDef).Ordering
+		ordering = &ev.Private().(*RowNumberDef).Ordering
 	case opt.GroupByOp, opt.ScalarGroupByOp, opt.DistinctOnOp:
-		ordering = &ev.Private().(*memo.GroupByDef).Ordering
+		ordering = &ev.Private().(*GroupByDef).Ordering
 	default:
 		return
 	}

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 // PhysicalPropsID identifies a set of physical properties that has been
@@ -445,6 +446,13 @@ func (m *Memo) MemoizeNormExpr(evalCtx *tree.EvalContext, norm Expr) ExprView {
 	mgrp := m.newGroup(norm)
 	ev := MakeNormExprView(m, mgrp.id)
 	mgrp.logical = m.logPropsBuilder.buildProps(evalCtx, ev)
+
+	// RaceEnabled ensures that checks are run on every PR (as part of make
+	// testrace) while keeping the check code out of non-test builds.
+	if util.RaceEnabled {
+		CheckExpr(ev)
+	}
+
 	return ev
 }
 

--- a/pkg/sql/opt/norm/check_expr.go
+++ b/pkg/sql/opt/norm/check_expr.go
@@ -25,6 +25,7 @@ import (
 // checkExpr does sanity checking on an Expr. This code is called from
 // onConstruct in testrace builds (which gives us test/CI coverage but elides
 // this code in regular builds).
+// This function does not assume that the expression has been fully normalized.
 func (f *Factory) checkExpr(ev memo.ExprView) {
 	// Check logical properties.
 	ev.Logical().Verify()
@@ -101,7 +102,7 @@ func (f *Factory) checkExpr(ev memo.ExprView) {
 	case opt.SelectOp:
 		filter := ev.Child(1)
 		switch filter.Operator() {
-		case opt.FiltersOp:
+		case opt.FiltersOp, opt.TrueOp, opt.FalseOp:
 		default:
 			panic(fmt.Sprintf("select contains %s", filter.Operator()))
 		}

--- a/pkg/sql/opt/norm/decorrelate.go
+++ b/pkg/sql/opt/norm/decorrelate.go
@@ -942,9 +942,13 @@ func (r *subqueryHoister) constructGroupByAny(
 			r.f.ConstructProject(
 				r.f.ConstructSelect(
 					input,
-					r.f.ConstructIsNot(
-						r.f.funcs.ConstructBinary(cmp, scalar, inputVar),
-						r.f.ConstructFalse(),
+					r.f.ConstructFilters(
+						r.f.InternList([]memo.GroupID{
+							r.f.ConstructIsNot(
+								r.f.funcs.ConstructBinary(cmp, scalar, inputVar),
+								r.f.ConstructFalse(),
+							),
+						}),
 					),
 				),
 				r.f.ConstructProjections(

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -99,11 +99,6 @@ type Factory struct {
 	// temporary results that are accumulated before constructing a new
 	// Projections operator.
 	scratchColList opt.ColList
-
-	// skipSanityChecks disables the checks performed by checkExpr. This is
-	// needed in cases where we might construct not-fully-normalized expressions,
-	// such as in optsteps.
-	skipSanityChecks bool
 }
 
 // Init initializes a Factory structure with a new, blank memo structure inside.
@@ -122,12 +117,6 @@ func (f *Factory) Init(evalCtx *tree.EvalContext) {
 // are applied).
 func (f *Factory) DisableOptimizations() {
 	f.NotifyOnMatchedRule(func(opt.RuleName) bool { return false })
-}
-
-// SkipSanityChecks disables the checkExpr validation checks on expressions
-// produced by this factory.
-func (f *Factory) SkipSanityChecks() {
-	f.skipSanityChecks = true
 }
 
 // NotifyOnMatchedRule sets a callback function which is invoked each time a
@@ -184,9 +173,9 @@ func (f *Factory) AssignPlaceholders() {
 func (f *Factory) onConstruct(e memo.Expr) memo.GroupID {
 	ev := f.mem.MemoizeNormExpr(f.evalCtx, e)
 
-	// RaceEnabled ensures that checks are run on every change (as part of make
+	// RaceEnabled ensures that checks are run on every PR (as part of make
 	// testrace) while keeping the check code out of non-test builds.
-	if util.RaceEnabled && !f.skipSanityChecks {
+	if util.RaceEnabled {
 		f.checkExpr(ev)
 	}
 	return ev.Group()

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 // MatchedRuleFunc defines the callback function for the NotifyOnMatchedRule
@@ -172,12 +171,6 @@ func (f *Factory) AssignPlaceholders() {
 // so that any custom manual pattern matching/replacement code can be run.
 func (f *Factory) onConstruct(e memo.Expr) memo.GroupID {
 	ev := f.mem.MemoizeNormExpr(f.evalCtx, e)
-
-	// RaceEnabled ensures that checks are run on every PR (as part of make
-	// testrace) while keeping the check code out of non-test builds.
-	if util.RaceEnabled {
-		f.checkExpr(ev)
-	}
 	return ev.Group()
 }
 

--- a/pkg/sql/opt/norm/factory_test.go
+++ b/pkg/sql/opt/norm/factory_test.go
@@ -99,7 +99,7 @@ func TestFactoryProjectColsFromBoth(t *testing.T) {
 
 	for _, tc := range testCases {
 		combined := f.funcs.ProjectColsFromBoth(tc.left, tc.right)
-		f.checkExpr(memo.MakeNormExprView(f.Memo(), combined))
+		memo.CheckExpr(memo.MakeNormExprView(f.Memo(), combined))
 		actual := f.funcs.OutputCols(combined).String()
 		if actual != tc.expected {
 			t.Errorf("expected: %s, actual: %s", tc.expected, actual)

--- a/pkg/sql/opt/norm/factory_test.go
+++ b/pkg/sql/opt/norm/factory_test.go
@@ -99,7 +99,7 @@ func TestFactoryProjectColsFromBoth(t *testing.T) {
 
 	for _, tc := range testCases {
 		combined := f.funcs.ProjectColsFromBoth(tc.left, tc.right)
-		memo.CheckExpr(memo.MakeNormExprView(f.Memo(), combined))
+		f.Memo().CheckExpr(memo.MakeNormExprID(combined))
 		actual := f.funcs.OutputCols(combined).String()
 		if actual != tc.expected {
 			t.Errorf("expected: %s, actual: %s", tc.expected, actual)

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -9,21 +9,6 @@
 [EliminateSelect, Normalize]
 (Select $input:* (True)) => $input
 
-# EnsureSelectFilters adds a Filters operator to a Select's filter condition
-# if it does not already exist. This allows other rules to rely upon the
-# presence of the Filters when matching. See comment at top of bool.opt for
-# more details.
-[EnsureSelectFilters, Normalize]
-(Select
-    $input:*
-    $filter:^(Filters | And | True | False)
-)
-=>
-(Select
-    $input
-    (Filters [ $filter ])
-)
-
 # MergeSelects combines two nested Select operators into a single Select that
 # ANDs the filter conditions of the two Selects.
 [MergeSelects, Normalize]

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -1059,7 +1059,8 @@ HoistProjectSubquery
   + │    │    │    │    │    │         │    └── fd: (3)-->(4)
   + │    │    │    │    │    │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
   + │    │    │    │    │    │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
-  + │    │    │    │    │    └── (5 = i) IS NOT false [type=bool, outer=(4)]
+  + │    │    │    │    │    └── filters [type=bool, outer=(4)]
+  + │    │    │    │    │         └── (5 = i) IS NOT false [type=bool, outer=(4)]
   + │    │    │    │    └── projections [outer=(4)]
   + │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
   + │    │    │    └── aggregations [outer=(9)]
@@ -1125,75 +1126,8 @@ CommuteVar
     │    │    │    │    │    │         │    └── fd: (3)-->(4)
     │    │    │    │    │    │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
     │    │    │    │    │    │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
-  - │    │    │    │    │    └── (5 = i) IS NOT false [type=bool, outer=(4)]
-  + │    │    │    │    │    └── (i = 5) IS NOT false [type=bool, outer=(4)]
-    │    │    │    │    └── projections [outer=(4)]
-    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]
-    │    │    │    └── aggregations [outer=(9)]
-    │    │    │         └── bool-or [type=bool, outer=(9)]
-    │    │    │              └── variable: notnull [type=bool, outer=(9)]
-    │    │    └── projections [outer=(10)]
-    │    │         └── CASE WHEN bool_or AND (5 IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
-    │    └── true [type=bool]
-    └── projections [outer=(11)]
-         └── variable: case [type=bool, outer=(11)]
-================================================================================
-EnsureSelectFilters
-  Cost: 2152.58
-================================================================================
-   project
-    ├── columns: r:8(bool)
-    ├── inner-join-apply
-    │    ├── columns: x:1(int!null) case:11(bool)
-    │    ├── key: (1)
-    │    ├── fd: (1)-->(11)
-    │    ├── scan xy
-    │    │    ├── columns: x:1(int!null)
-    │    │    └── key: (1)
-    │    ├── project
-    │    │    ├── columns: case:11(bool)
-    │    │    ├── outer: (1)
-    │    │    ├── cardinality: [1 - 1]
-    │    │    ├── key: ()
-    │    │    ├── fd: ()-->(11)
-    │    │    ├── scalar-group-by
-    │    │    │    ├── columns: bool_or:10(bool)
-    │    │    │    ├── outer: (1)
-    │    │    │    ├── cardinality: [1 - 1]
-    │    │    │    ├── key: ()
-    │    │    │    ├── fd: ()-->(10)
-    │    │    │    ├── project
-    │    │    │    │    ├── columns: notnull:9(bool)
-    │    │    │    │    ├── outer: (1)
-    │    │    │    │    ├── cardinality: [0 - 1]
-    │    │    │    │    ├── key: ()
-    │    │    │    │    ├── fd: ()-->(9)
-    │    │    │    │    ├── select
-    │    │    │    │    │    ├── columns: i:4(int)
-    │    │    │    │    │    ├── outer: (1)
-    │    │    │    │    │    ├── cardinality: [0 - 1]
-    │    │    │    │    │    ├── key: ()
-    │    │    │    │    │    ├── fd: ()-->(4)
-    │    │    │    │    │    ├── project
-    │    │    │    │    │    │    ├── columns: i:4(int)
-    │    │    │    │    │    │    ├── outer: (1)
-    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-    │    │    │    │    │    │    ├── key: ()
-    │    │    │    │    │    │    ├── fd: ()-->(4)
-    │    │    │    │    │    │    └── select
-    │    │    │    │    │    │         ├── columns: k:3(int!null) i:4(int)
-    │    │    │    │    │    │         ├── outer: (1)
-    │    │    │    │    │    │         ├── cardinality: [0 - 1]
-    │    │    │    │    │    │         ├── key: ()
-    │    │    │    │    │    │         ├── fd: ()-->(3,4)
-    │    │    │    │    │    │         ├── scan a
-    │    │    │    │    │    │         │    ├── columns: k:3(int!null) i:4(int)
-    │    │    │    │    │    │         │    ├── key: (3)
-    │    │    │    │    │    │         │    └── fd: (3)-->(4)
-    │    │    │    │    │    │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
-    │    │    │    │    │    │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
-  - │    │    │    │    │    └── (i = 5) IS NOT false [type=bool, outer=(4)]
-  + │    │    │    │    │    └── filters [type=bool, outer=(4)]
+    │    │    │    │    │    └── filters [type=bool, outer=(4)]
+  - │    │    │    │    │         └── (5 = i) IS NOT false [type=bool, outer=(4)]
   + │    │    │    │    │         └── (i = 5) IS NOT false [type=bool, outer=(4)]
     │    │    │    │    └── projections [outer=(4)]
     │    │    │    │         └── i IS NOT NULL [type=bool, outer=(4)]

--- a/pkg/sql/opt/testutils/forcing_opt.go
+++ b/pkg/sql/opt/testutils/forcing_opt.go
@@ -66,12 +66,6 @@ func newForcingOptimizer(
 		lastMatched: opt.InvalidRuleName,
 	}
 	fo.o.Init(&tester.evalCtx)
-	// If we could possibly produce expressions that are not fully
-	// normalized, they won't necessarily pass the sanity check
-	// validations.
-	if !ignoreNormRules {
-		fo.o.Factory().SkipSanityChecks()
-	}
 
 	fo.o.NotifyOnMatchedRule(func(ruleName opt.RuleName) bool {
 		if ignoreNormRules && ruleName.IsNormalize() {


### PR DESCRIPTION
Backport 3/3 commits from #30252.

/cc @cockroachdb/release

---

These commits enable the expression checks to run during optsteps and during exploration.

#### opt: run checkExpr with optsteps

Currently `checkExpr` is disabled when normalization is not fully
enabled (e.g. optsteps), because some checks can fail. This change
fixes the failing checks and enables `checkExpr` even with optsteps.

The failing checks are around `Select` with filters that are missing
`Filters`; this happens in some decorrelation rules which are now
fixed to create `Filters`. The optbuilder already takes this approach.
We can now remove the `EnsureSelectFilters` rule; any future code that
doesn't create `Filters` will trigger a `checkExpr` failure.

Release note: None

#### opt: move checkExpr to memo

We now call checkExpr from `MemoizeNormExpr`.

Release note: None

#### opt: check denormalized expressions

Change `CheckExpr` to operate on `ExprID` instead of `ExprView` and
run it for expressions added during exploration as well.

Release note: None

