### PR TITLE
release-2.1: opt: Eliminate Union All if one side has zero cardinality

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -245,3 +245,32 @@ CREATE TABLE c (a INT PRIMARY KEY, b INT)
 query I
 SELECT a FROM a WHERE a > 2 UNION ALL (SELECT a FROM c WHERE b > 2) LIMIT 1;
 ----
+
+statement ok
+INSERT INTO a VALUES (1)
+
+statement ok
+INSERT INTO c VALUES (1,2)
+
+statement ok
+INSERT INTO c VALUES (3,4)
+
+# Check that UNION ALL columns are mapped correctly - even if one side gets optimized out
+query I
+SELECT a FROM (SELECT a FROM a UNION ALL SELECT a FROM c) ORDER BY a
+----
+1
+1
+3
+
+query I
+SELECT a FROM (SELECT a FROM a WHERE a > 3 AND a < 1 UNION ALL SELECT a FROM c) ORDER BY a
+----
+1
+3
+
+query I
+SELECT a FROM (SELECT a FROM c UNION ALL SELECT a FROM a WHERE a > 3 AND a < 1) ORDER BY a
+----
+1
+3

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -328,3 +328,32 @@
 )
 =>
 (ConstructEmptyValues (OutputCols $input))
+
+# EliminateUnionAllLeft replaces a union all with a right side having a
+# cardinality of zero, with just the left side operand.
+[EliminateUnionAllLeft, Normalize]
+(UnionAll
+    $left:*
+    $right:* & (HasZeroRows $right)
+    $colmap:*
+)
+=>
+(Project
+    $left
+    (ProjectColMapLeft $colmap)
+)
+
+
+# EliminateUnionAllRight replaces a union all with a left side having a
+# cardinality of zero, with just the right side operand.
+[EliminateUnionAllRight, Normalize]
+(UnionAll
+    $left:* & (HasZeroRows $left)
+    $right:*
+    $colmap:*
+)
+=>
+(Project
+    $right
+    (ProjectColMapRight $colmap)
+)

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -1156,3 +1156,58 @@ values
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1)
+
+# --------------------------------------------------
+# EliminateUnionAllLeft
+# --------------------------------------------------
+
+opt
+SELECT k FROM
+  (SELECT k FROM b)
+  UNION ALL
+  (SELECT k FROM b WHERE i < 4 AND i > 10)
+----
+project
+ ├── columns: k:11(int)
+ ├── scan b
+ │    ├── columns: b.k:1(int!null)
+ │    └── key: (1)
+ └── projections [outer=(1)]
+      └── variable: b.k [type=int, outer=(1)]
+
+# --------------------------------------------------
+# EliminateUnionAllRight
+# --------------------------------------------------
+
+opt
+SELECT k FROM
+  (SELECT k FROM b WHERE i < 4 AND i > 10)
+  UNION ALL
+  (SELECT k FROM b)
+----
+project
+ ├── columns: k:11(int)
+ ├── scan b
+ │    ├── columns: b.k:6(int!null)
+ │    └── key: (6)
+ └── projections [outer=(6)]
+      └── variable: b.k [type=int, outer=(6)]
+
+opt
+SELECT k FROM
+  (SELECT k FROM b WHERE i < 4 AND i > 10)
+  UNION ALL
+  (SELECT k FROM b WHERE i < 4 AND i > 10)
+----
+project
+ ├── columns: k:11(int)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ ├── fd: ()-->(11)
+ ├── values
+ │    ├── columns: b.k:1(int)
+ │    ├── cardinality: [0 - 0]
+ │    ├── key: ()
+ │    └── fd: ()-->(1)
+ └── projections [outer=(1)]
+      └── variable: b.k [type=int, outer=(1)]


### PR DESCRIPTION
Backport 1/1 commits from #29644.

/cc @cockroachdb/release

---

Adds a norm rule to opt to replace a Union All with a simpler
projection if one side cannot have any rows.

Fixes #29153


