### PR TITLE
ui: implement automated positioning of tooltips

### DIFF
--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -13,6 +13,7 @@
     "lodash": "^4.17.4",
     "moment": "^2.18.1",
     "nvd3": "^1.8.5",
+    "popper.js": "^1.14.4",
     "raw-loader": "^0.5.1",
     "rc-progress": "^2.2.1",
     "react": "^16.3.1",

--- a/pkg/ui/src/views/shared/components/toolTip/index.tsx
+++ b/pkg/ui/src/views/shared/components/toolTip/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import classNames from "classnames";
+import Popper from "popper.js";
 
 import "./tooltip.styl";
 
@@ -22,6 +23,10 @@ interface ToolTipWrapperState {
  * contents.
  */
 export class ToolTipWrapper extends React.Component<ToolTipWrapperProps, ToolTipWrapperState> {
+  popperInstance: Popper;
+  content: React.RefObject<HTMLDivElement> = React.createRef();
+  text: React.RefObject<HTMLDivElement> = React.createRef();
+
   constructor(props?: ToolTipWrapperProps, context?: any) {
     super(props, context);
     this.state = {
@@ -29,8 +34,24 @@ export class ToolTipWrapper extends React.Component<ToolTipWrapperProps, ToolTip
     };
   }
 
+  componentWillUnmount() {
+    if (this.popperInstance) {
+      this.popperInstance.destroy();
+    }
+  }
+
+  initPopper() {
+    // PopperOptions.eventsEnabled should be set to `false` to prevent
+    // performance issues on pages with a large number of tooltips
+    this.popperInstance = new Popper(this.content.current, this.text.current, {
+      placement: "auto",
+      eventsEnabled: false,
+    });
+  }
+
   onMouseEnter = () => {
     this.setState({hovered: true});
+    this.initPopper();
   }
 
   onMouseLeave = () => {
@@ -52,11 +73,11 @@ export class ToolTipWrapper extends React.Component<ToolTipWrapperProps, ToolTip
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
       >
-        <div className="hover-tooltip__text">
-          { text }
-        </div>
-        <div className="hover-tooltip__content">
+        <div className="hover-tooltip__content" ref={this.content}>
           { this.props.children }
+        </div>
+        <div className="hover-tooltip__text" ref={this.text}>
+          { text }
         </div>
       </div>
     );

--- a/pkg/ui/src/views/shared/components/toolTip/tooltip.styl
+++ b/pkg/ui/src/views/shared/components/toolTip/tooltip.styl
@@ -34,7 +34,7 @@
   height 100%
 
   &__text
-    visibility hidden
+    display none
     z-index $z-index-tooltip
     position absolute
     top -10px
@@ -54,7 +54,7 @@
     max-width 400px
 
   &--hovered &__text
-    visibility visible
+    display block
 
   a
     color $link-color

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -308,8 +308,8 @@ export function latencyBreakdown(s: StatementStatistics) {
       const spread = scale(parseSd + (parseSd > parseMean ? parseMean : parseSd));
       const title = renderNumericStatLegend(s.stats.count, parseMean, parseSd, format);
       return (
-        <div className="bar-chart bar-chart--breakdown">
-          <ToolTipWrapper text={ title } short>
+        <ToolTipWrapper text={ title } short>
+          <div className="bar-chart bar-chart--breakdown">
             <div className="label">{ Duration(parseMean * 1e9) }</div>
             <div
               className="latency-parse bar-chart__bar"
@@ -319,8 +319,8 @@ export function latencyBreakdown(s: StatementStatistics) {
               className="latency-parse-dev bar-chart__bar bar-chart__bar--dev"
               style={{ width: spread + "%", position: "absolute", left: width + "%" }}
             />
-          </ToolTipWrapper>
-        </div>
+          </div>
+        </ToolTipWrapper>
       );
     },
 
@@ -331,8 +331,8 @@ export function latencyBreakdown(s: StatementStatistics) {
       const spread = scale(planSd + (planSd > planMean ? planMean : planSd));
       const title = renderNumericStatLegend(s.stats.count, planMean, planSd, format);
       return (
-        <div className="bar-chart bar-chart--breakdown">
-          <ToolTipWrapper text={ title } short>
+        <ToolTipWrapper text={ title } short>
+          <div className="bar-chart bar-chart--breakdown">
             <div className="label">{ Duration(planMean * 1e9) }</div>
             <div
               className="latency-plan bar-chart__bar"
@@ -342,8 +342,8 @@ export function latencyBreakdown(s: StatementStatistics) {
               className="latency-plan-dev bar-chart__bar bar-chart__bar--dev"
               style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
             />
-          </ToolTipWrapper>
-        </div>
+          </div>
+        </ToolTipWrapper>
       );
     },
 
@@ -354,8 +354,8 @@ export function latencyBreakdown(s: StatementStatistics) {
       const spread = scale(runSd + (runSd > runMean ? runMean : runSd));
       const title = renderNumericStatLegend(s.stats.count, runMean, runSd, format);
       return (
-        <div className="bar-chart bar-chart--breakdown">
-          <ToolTipWrapper text={ title } short>
+        <ToolTipWrapper text={ title } short>
+          <div className="bar-chart bar-chart--breakdown">
             <div className="label">{ Duration(runMean * 1e9) }</div>
             <div
               className="latency-run bar-chart__bar"
@@ -365,8 +365,8 @@ export function latencyBreakdown(s: StatementStatistics) {
               className="latency-run-dev bar-chart__bar bar-chart__bar--dev"
               style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
             />
-          </ToolTipWrapper>
-        </div>
+          </div>
+        </ToolTipWrapper>
       );
     },
 
@@ -377,8 +377,8 @@ export function latencyBreakdown(s: StatementStatistics) {
       const spread = scale(overheadSd + (overheadSd > overheadMean ? overheadMean : overheadSd));
       const title = renderNumericStatLegend(s.stats.count, overheadMean, overheadSd, format);
       return (
-        <div className="bar-chart bar-chart--breakdown">
-          <ToolTipWrapper text={ title } short>
+        <ToolTipWrapper text={ title } short>
+          <div className="bar-chart bar-chart--breakdown">
             <div className="label">{ Duration(overheadMean * 1e9) }</div>
             <div
               className="latency-overhead bar-chart__bar"
@@ -388,8 +388,8 @@ export function latencyBreakdown(s: StatementStatistics) {
               className="latency-overhead-dev bar-chart__bar bar-chart__bar--dev"
               style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
             />
-          </ToolTipWrapper>
-        </div>
+          </div>
+        </ToolTipWrapper>
       );
     },
 
@@ -402,8 +402,8 @@ export function latencyBreakdown(s: StatementStatistics) {
       const spread = scale(overallSd + (overallSd > overallMean ? overallMean : overallSd));
       const title = renderNumericStatLegend(s.stats.count, overallMean, overallSd, format);
       return (
-        <div className="bar-chart bar-chart--breakdown">
-          <ToolTipWrapper text={ title } short>
+        <ToolTipWrapper text={ title } short>
+          <div className="bar-chart bar-chart--breakdown">
             <div className="label">{ Duration(overallMean * 1e9) }</div>
             <div
               className="latency-parse bar-chart__bar"
@@ -425,8 +425,8 @@ export function latencyBreakdown(s: StatementStatistics) {
               className="latency-overall-dev bar-chart__bar bar-chart__bar--dev"
               style={{ width: spread + "%", position: "absolute", left: width + "%" }}
             />
-          </ToolTipWrapper>
-        </div>
+          </div>
+        </ToolTipWrapper>
       );
     },
   };

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -5231,6 +5231,10 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+popper.js@^1.14.4:
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.4.tgz#8eec1d8ff02a5a3a152dd43414a15c7b79fd69b6"
+
 portfinder@^1.0.9:
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.13.tgz#bb32ecd87c27104ae6ee44b5a3ccbf0ebb1aede9"


### PR DESCRIPTION
**Note:** this PR is an alternative to #30307  

Fixes #28869 

This PR implements PopperJS as a positioning engine for tooltips on the Admin UI.  The main wins are tooltips that will no longer run off the page (caveat: so long as the page is constrained by the window width) and no hardcoding of tooltip positions is needed when implementing a new instance.

The main drawback is that sometimes the positioning behaves a little heterogeneously within a seemingly identical context.  For example, hovering a data cell in Row A may position the tooltip along the bottom yet hovering a data cell from the same column in Row B may position the tooltip to the right.  In the case where the underlying tooltip-bound element is very wide, the position may be visually very different and this can look a little random.

@vilterp this PR has a change made from the last time we spoke that addresses the page load/layout thrashing issue by initializing a tooltip when hovered for the first time instead of at page load.