### PR TITLE
release-2.1: storage: use 1PC path for pushed serializable txns without refresh spans

### DIFF
--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -405,7 +405,7 @@ func IsEndTransactionTriggeringRetryError(
 // be safely committed with a forwarded timestamp. This requires that
 // the transaction's timestamp has not leaked and that the transaction
 // has encountered no spans which require refreshing at the forwarded
-// timestamp. If either of those conditions are true, a cient-side
+// timestamp. If either of those conditions are true, a client-side
 // retry is required.
 func canForwardSerializableTimestamp(txn *roachpb.Transaction, noRefreshSpans bool) bool {
 	return !txn.OrigTimestampWasObserved && noRefreshSpans

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -6100,14 +6100,11 @@ func isOnePhaseCommit(ba roachpb.BatchRequest, knobs *StoreTestingKnobs) bool {
 	if retry, _ := batcheval.IsEndTransactionTriggeringRetryError(ba.Txn, *etArg); retry {
 		return false
 	}
-	if ba.Txn != nil && ba.Txn.OrigTimestamp != ba.Txn.Timestamp {
-		// Transactions that have been pushed are never eligible for the
-		// 1PC path. For serializable transactions this is covered by
-		// batcheval.IsEndTransactionTriggeringRetryError, but even snapshot
-		// transactions must go through the slow path when their
-		// transaction has been pushed. See comments on
-		// Transaction.orig_timestamp for the reasons why this is necessary
-		// to prevent lost update anomalies.
+	if ba.Txn.Isolation == enginepb.SNAPSHOT && ba.Txn.OrigTimestamp != ba.Txn.Timestamp {
+		// Snapshot transactions that have been pushed are never eligible for
+		// the 1PC path. Instead, they must go through the slow path when their
+		// timestamp has been pushed. See comments on Transaction.orig_timestamp
+		// for the reasons why this is necessary to prevent lost update anomalies.
 		return false
 	}
 	return !knobs.DisableOptional1PC || etArg.Require1PC

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -387,11 +387,14 @@ func createReplicaSets(replicaNumbers []roachpb.StoreID) []roachpb.ReplicaDescri
 // transactional batch can be committed as an atomic write.
 func TestIsOnePhaseCommit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	txnReqs := []roachpb.RequestUnion{
-		{Value: &roachpb.RequestUnion_BeginTransaction{BeginTransaction: &roachpb.BeginTransactionRequest{}}},
-		{Value: &roachpb.RequestUnion_Put{Put: &roachpb.PutRequest{}}},
-		{Value: &roachpb.RequestUnion_EndTransaction{EndTransaction: &roachpb.EndTransactionRequest{}}},
-	}
+	txnReqs := make([]roachpb.RequestUnion, 3)
+	txnReqs[0].MustSetInner(&roachpb.BeginTransactionRequest{})
+	txnReqs[1].MustSetInner(&roachpb.PutRequest{})
+	txnReqs[2].MustSetInner(&roachpb.EndTransactionRequest{})
+	txnReqsNoRefresh := make([]roachpb.RequestUnion, 3)
+	txnReqsNoRefresh[0].MustSetInner(&roachpb.BeginTransactionRequest{})
+	txnReqsNoRefresh[1].MustSetInner(&roachpb.PutRequest{})
+	txnReqsNoRefresh[2].MustSetInner(&roachpb.EndTransactionRequest{NoRefreshSpans: true})
 	testCases := []struct {
 		bu      []roachpb.RequestUnion
 		isTxn   bool
@@ -414,6 +417,14 @@ func TestIsOnePhaseCommit(t *testing.T) {
 		{txnReqs, true, false, true, enginepb.SNAPSHOT, false},
 		{txnReqs, true, true, true, enginepb.SERIALIZABLE, false},
 		{txnReqs, true, true, true, enginepb.SNAPSHOT, false},
+		{txnReqsNoRefresh, true, false, false, enginepb.SERIALIZABLE, true},
+		{txnReqsNoRefresh, true, false, false, enginepb.SNAPSHOT, true},
+		{txnReqsNoRefresh, true, true, false, enginepb.SERIALIZABLE, true},
+		{txnReqsNoRefresh, true, true, false, enginepb.SNAPSHOT, false},
+		{txnReqsNoRefresh, true, false, true, enginepb.SERIALIZABLE, true},
+		{txnReqsNoRefresh, true, false, true, enginepb.SNAPSHOT, false},
+		{txnReqsNoRefresh, true, true, true, enginepb.SERIALIZABLE, true},
+		{txnReqsNoRefresh, true, true, true, enginepb.SNAPSHOT, false},
 	}
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
@@ -10058,6 +10069,19 @@ func TestReplicaLocalRetries(t *testing.T) {
 			},
 			expTSCUpdateKeys: []string{"b-iput"},
 		},
+		{
+			name: "serializable push without retry",
+			setupFn: func() (hlc.Timestamp, error) {
+				return get("a")
+			},
+			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+				ba.Timestamp = ts.Prev()
+				expTS = ts.Next()
+				put := putArgs(roachpb.Key("a"), []byte("put2"))
+				ba.Add(&put)
+				return
+			},
+		},
 		// Non-1PC serializable txn cput will fail with write too old error.
 		{
 			name: "no local retry of write too old on non-1PC txn",
@@ -10214,6 +10238,26 @@ func TestReplicaLocalRetries(t *testing.T) {
 				return
 			},
 			expTSCUpdateKeys: []string{"h"},
+		},
+		// Serializable 1PC transaction will commit with forwarded timestamp
+		// using the 1PC path if no refresh spans.
+		{
+			name: "serializable commit with forwarded timestamp on 1PC txn",
+			setupFn: func() (hlc.Timestamp, error) {
+				return get("a")
+			},
+			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+				ba.Txn = newTxn("a", ts.Prev())
+				expTS = ts.Next()
+				bt, _ := beginTxnArgs(ba.Txn.Key, ba.Txn)
+				cput := putArgs(ba.Txn.Key, []byte("put"))
+				et, _ := endTxnArgs(ba.Txn, true /* commit */)
+				et.Require1PC = true     // don't allow this to bypass the 1PC optimization
+				et.NoRefreshSpans = true // necessary to indicate local retry is possible
+				ba.Add(&bt, &cput, &et)
+				assignSeqNumsForReqs(ba.Txn, &bt, &cput, &et)
+				return
+			},
 		},
 		// Serializable transaction will commit with WriteTooOld flag if no refresh spans.
 		{


### PR DESCRIPTION
Backport 1/1 commits from #30039.

/cc @cockroachdb/release

---

This change allows serializable 1PC transactions to use the 1PC
fast-path (avoid txn records, avoid intents, etc.) even when their
timestamp has been pushed by the timestamp cache. This is allowed
when the transaction has no refresh spans.

This should reduce replication and storage traffic for workloads
like `kv95`, where it's often the case that 1PC transactions run
into the timestamp cache.

I believe this is actually fixing a regression introduced in 7cef8d4
which made part of d87a94e less effective for 1PC transactions.

Release note (performance improvement): 1PC transactions avoid writing
transaction record and intents when pushed due to reads at a higher
timestamp.
