### PR TITLE
release-2.1: storage: avoid repetitive locking before and during quotaPool acquisition

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1058,8 +1058,10 @@ func (r *Replica) maybeAcquireProposalQuota(ctx context.Context, quota int64) er
 
 	// Trace if we're running low on available proposal quota; it might explain
 	// why we're taking so long.
-	if q := quotaPool.approximateQuota(); q < quotaPool.maxQuota()/10 && log.HasSpanOrEvent(ctx) {
-		log.Eventf(ctx, "quota running low, currently available ~%d", q)
+	if log.HasSpanOrEvent(ctx) {
+		if q := quotaPool.approximateQuota(); q < quotaPool.maxQuota()/10 {
+			log.Eventf(ctx, "quota running low, currently available ~%d", q)
+		}
 	}
 
 	return quotaPool.acquire(ctx, quota)


### PR DESCRIPTION
Backport 2/2 commits from #30111.

/cc @cockroachdb/release

---

This PR includes two improvements to the `quotaPool` that avoid repeated unnecessary locking and unlocking of its mutex. Since this is on the hot path of all proposals, this should provide a small throughput win.
