### PR TITLE
release-2.1: kv: check transaction status before recording refresh spans

### DIFF
--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -2065,14 +2065,83 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				// Scan sufficient times to exceed the limit on refresh spans. This
 				// will propagate a failure because our timestamp has been pushed.
 				keybase := strings.Repeat("a", 1024)
-				for i := 0; ; i++ {
+				maxRefreshBytes := kv.MaxTxnRefreshSpansBytes.Get(&s.ClusterSettings().SV)
+				scanToExceed := int(maxRefreshBytes) / len(keybase)
+				for i := 0; i < scanToExceed; i++ {
 					key := roachpb.Key(fmt.Sprintf("%s%10d", keybase, i))
 					if _, err := txn.Scan(ctx, key, key.Next(), 0); err != nil {
 						return err
 					}
 				}
+				return nil
 			},
 			expFailure: "transaction is too large to complete; try splitting into pieces",
+		},
+		{
+			// Even if accounting for the refresh spans would have exhausted the
+			// limit for tracking refresh spans and our transaction's timestamp
+			// has been pushed, if we successfully commit then we won't hit an
+			// error.
+			name: "forwarded timestamp with too many refreshes in batch commit",
+			afterTxnStart: func(ctx context.Context, db *client.DB) error {
+				_, err := db.Get(ctx, "a") // set ts cache
+				return err
+			},
+			retryable: func(ctx context.Context, txn *client.Txn) error {
+				// Advance timestamp.
+				if err := txn.Put(ctx, "a", "put"); err != nil {
+					return err
+				}
+				// Make the final batch large enough such that if we accounted
+				// for all of its spans then we would exceed the limit on
+				// refresh spans. This is not an issue because we never need to
+				// account for them. The txn has no refresh spans, so it can
+				// forward its timestamp while committing.
+				keybase := strings.Repeat("a", 1024)
+				maxRefreshBytes := kv.MaxTxnRefreshSpansBytes.Get(&s.ClusterSettings().SV)
+				scanToExceed := int(maxRefreshBytes) / len(keybase)
+				b := txn.NewBatch()
+				for i := 0; i < scanToExceed; i++ {
+					key := roachpb.Key(fmt.Sprintf("%s%10d", keybase, i))
+					b.Scan(key, key.Next())
+				}
+				return txn.CommitInBatch(ctx, b)
+			},
+			txnCoordRetry: false,
+		},
+		{
+			// Even if accounting for the refresh spans would have exhausted the
+			// limit for tracking refresh spans and our transaction's timestamp
+			// has been pushed, if we successfully commit then we won't hit an
+			// error. This is the case even if the final batch itself causes a
+			// refresh.
+			name: "forwarded timestamp with too many refreshes in batch commit triggering refresh",
+			afterTxnStart: func(ctx context.Context, db *client.DB) error {
+				_, err := db.Get(ctx, "a") // set ts cache
+				return err
+			},
+			retryable: func(ctx context.Context, txn *client.Txn) error {
+				// Advance timestamp. This also creates a refresh span which
+				// will prevent the txn from committing without a refresh.
+				if err := txn.InitPut(ctx, "a", "put", false); err != nil {
+					return err
+				}
+				// Make the final batch large enough such that if we accounted
+				// for all of its spans then we would exceed the limit on
+				// refresh spans. This is not an issue because we never need to
+				// account for them until the final batch, at which time we
+				// perform a span refresh and successfully commit.
+				keybase := strings.Repeat("a", 1024)
+				maxRefreshBytes := kv.MaxTxnRefreshSpansBytes.Get(&s.ClusterSettings().SV)
+				scanToExceed := int(maxRefreshBytes) / len(keybase)
+				b := txn.NewBatch()
+				for i := 0; i < scanToExceed; i++ {
+					key := roachpb.Key(fmt.Sprintf("%s%10d", keybase, i))
+					b.Scan(key, key.Next())
+				}
+				return txn.CommitInBatch(ctx, b)
+			},
+			txnCoordRetry: true,
 		},
 		{
 			name: "write too old with put",

--- a/pkg/kv/txn_interceptor_pipeliner.go
+++ b/pkg/kv/txn_interceptor_pipeliner.go
@@ -163,8 +163,11 @@ func (tp *txnPipeliner) SendLocked(
 		return nil, tp.adjustError(ctx, ba, pErr)
 	}
 
-	// WIP: I think it's possible for this response to be from an earlier
-	// epoch. Fix that.
+	// TODO(nvanbenschoten): It's currently possible for this response to be
+	// from an earlier epoch when txns are used concurrently. That's ok for now
+	// because we always manually restart transactions once all concurrent
+	// operations synchronize. Once we move away from that model to a txnAttempt
+	// model, we'll need to reconsider how this works. It ~should~ just work.
 
 	// Prove any outstanding writes that we proved to exist.
 	br = tp.updateOutstandingWrites(ctx, ba, br)


### PR DESCRIPTION
Backport 2/2 commits from #29685.

/cc @cockroachdb/release

---

Fixes #29253.

We previously accounted for refresh spans before checking the
transaction's status. This meant that we would attempt to add new
refresh spans even if the txn had already been committed. If this
attempt failed because the `max_refresh_spans_bytes` threshold was
exceeded, we would erroneously return an error to the client even
though their transaction had already been committed. The simple
fix for this is to only record refresh spans for transactions that
are still PENDING. The new test case would have failed with the
error observed in #29253 without this fix.

This raises an auxiliary question about whether we should be asserting
that a transaction's status is not COMMITTED if we ever return an
error to the client. cc. @andreimatei.

On the positive side, this should be a minor perf win, as we'll
avoid recording refresh spans on the final batch of every txn.

A similar fix will need to be backported to 2.0. The backport
won't be clean though because of the new txnInterceptor structure.
However, the test shouldn't need to change.

Release note (bug fix): Don't return transaction size limit errors
for transactions that have already committed.
