### PR TITLE
ui: implement hard-coded positioning of tooltips

### DIFF
--- a/pkg/ui/src/views/cluster/components/visualization/index.tsx
+++ b/pkg/ui/src/views/cluster/components/visualization/index.tsx
@@ -42,7 +42,7 @@ export default class extends React.Component<VisualizationProps, {}> {
     if (tooltip) {
       tooltipNode = (
         <div className="visualization__tooltip">
-          <ToolTipWrapper text={tooltip}>
+          <ToolTipWrapper text={tooltip} placement="right">
             <div className="visualization__tooltip-hover-area">
               <div className="visualization__info-icon">i</div>
             </div>

--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -254,7 +254,7 @@ class JobsTable extends React.Component<JobsTableProps, {}> {
         <h1>
           Jobs
           <div className="section-heading__tooltip">
-            <ToolTipWrapper text={titleTooltip}>
+            <ToolTipWrapper text={titleTooltip} placement="right">
               <div className="section-heading__tooltip-hover-area">
                 <div className="section-heading__info-icon">i</div>
               </div>

--- a/pkg/ui/src/views/shared/components/summaryBar/index.tsx
+++ b/pkg/ui/src/views/shared/components/summaryBar/index.tsx
@@ -167,7 +167,7 @@ export class SummaryHeadlineStat extends React.Component<SummaryHeadlineStatProp
       <div className="summary-headline__title">
         {this.props.title}
         <div className="section-heading__tooltip">
-          <ToolTipWrapper text={this.props.tooltip}>
+          <ToolTipWrapper text={this.props.tooltip} placement="left">
             <div className="section-heading__tooltip-hover-area">
               <div className="section-heading__info-icon">i</div>
             </div>

--- a/pkg/ui/src/views/shared/components/toolTip/index.tsx
+++ b/pkg/ui/src/views/shared/components/toolTip/index.tsx
@@ -6,6 +6,7 @@ import "./tooltip.styl";
 interface ToolTipWrapperProps {
   text: React.ReactNode;
   short?: boolean;
+  placement?: "top" | "right" | "bottom" | "left";
 }
 
 interface ToolTipWrapperState {
@@ -22,6 +23,10 @@ interface ToolTipWrapperState {
  * contents.
  */
 export class ToolTipWrapper extends React.Component<ToolTipWrapperProps, ToolTipWrapperState> {
+  static defaultProps = {
+    placement: "bottom",
+  };
+
   constructor(props?: ToolTipWrapperProps, context?: any) {
     super(props, context);
     this.state = {
@@ -38,7 +43,7 @@ export class ToolTipWrapper extends React.Component<ToolTipWrapperProps, ToolTip
   }
 
   render() {
-    const { text, short } = this.props;
+    const { text, short, placement } = this.props;
     const { hovered } = this.state;
     const tooltipClassNames = classNames({
       "hover-tooltip": true,
@@ -52,7 +57,7 @@ export class ToolTipWrapper extends React.Component<ToolTipWrapperProps, ToolTip
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
       >
-        <div className="hover-tooltip__text">
+        <div className={"hover-tooltip__text " + placement}>
           { text }
         </div>
         <div className="hover-tooltip__content">

--- a/pkg/ui/src/views/shared/components/toolTip/tooltip.styl
+++ b/pkg/ui/src/views/shared/components/toolTip/tooltip.styl
@@ -37,8 +37,6 @@
     visibility hidden
     z-index $z-index-tooltip
     position absolute
-    top -10px
-    left 100%
     width 400px
     padding 10px
     border-radius 5px
@@ -48,6 +46,20 @@
     font-family Lato-Regular
     text-align left
     color $body-color
+
+    &.top
+      bottom: calc(100% + 5px)
+
+    &.right
+      top: -10px
+      left: 100%
+
+    &.bottom
+      top: calc(100% + 5px)
+
+    &.left
+      top: -10px
+      right: 100%
 
   &--short &__text
     width unset


### PR DESCRIPTION
**Note:** this PR is an alternative to #30297 

Fixes #28869 

This PR implements hardcoded positioning of tooltips using an additional (optional) prop passed to the tooltip instance.  The default position is now `bottom`.

The main win here is tooltips that no longer run off screen as well as a decent amount of control over where the tooltip renders; I say "decent amount of" and not "complete" control because without building something like a positioning engine we can't really do things like center the tooltip against the center of the parent element when setting position to `top` but this is more cosmetic than a functional concern.

The main drawback is the added burden of maintainability.  Hardcoded tooltip positions will have to be updated when necessary however this won't be necessary in every case since it seems that the default positioning works for most cases and is an improvement over the current behavior.