### PR TITLE
opt: add SimplifyZeroCardinalityGroup

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -3,16 +3,14 @@
 query TTT colnames
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE FALSE
 ----
-tree         field  description
-render       ·      ·
- └── norows  ·      ·
+tree    field  description
+norows  ·      ·
 
 query TTT colnames
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE NULL
 ----
-tree         field  description
-render       ·      ·
- └── norows  ·      ·
+tree    field  description
+norows  ·      ·
 
 query TTT colnames
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE TRUE
@@ -487,15 +485,10 @@ values  ·              ·                  (column1 int, column2 int, column3 i
 query TTTTT
 EXPLAIN (TYPES) SELECT 2*count(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2 AND count(k)>1
 ----
-render                 ·            ·                               (z int, v int)        ·
- │                     render 0     ((agg0)[int] * (2)[int])[int]   ·                     ·
- │                     render 1     (agg1)[int]                     ·                     ·
- └── filter            ·            ·                               (agg0 int, agg1 int)  ·
-      │                filter       ((agg0)[int] > (1)[int])[bool]  ·                     ·
-      └── group        ·            ·                               (agg0 int, agg1 int)  ·
-           │           aggregate 0  count(k)                        ·                     ·
-           │           aggregate 1  any_not_null(v)                 ·                     ·
-           └── norows  ·            ·                               (k int, v int)        ·
+render       ·         ·         (z int, v int)  ·
+ │           render 0  (z)[int]  ·               ·
+ │           render 1  (v)[int]  ·               ·
+ └── norows  ·         ·         (v int, z int)  ·
 
 query TTTTT
 EXPLAIN (TYPES) DELETE FROM t WHERE v > 1

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -826,7 +826,9 @@ func (b *logicalPropsBuilder) buildLimitProps(ev ExprView) props.Logical {
 	limitProps := limit.Logical().Scalar
 
 	constLimit := int64(math.MaxUint32)
+	haveConstLimit := false
 	if limit.Operator() == opt.ConstOp {
+		haveConstLimit = true
 		constLimit = int64(*limit.Private().(*tree.DInt))
 	}
 
@@ -874,6 +876,12 @@ func (b *logicalPropsBuilder) buildLimitProps(ev ExprView) props.Logical {
 	// ----------
 	b.sb.init(b.evalCtx, ev.Metadata())
 	b.sb.buildLimit(ev, relational)
+
+	// Side Effects
+	// ------------
+	if constLimit < 0 || !haveConstLimit {
+		relational.CanHaveSideEffects = true
+	}
 
 	return logical
 }

--- a/pkg/sql/opt/memo/testdata/logprops/limit
+++ b/pkg/sql/opt/memo/testdata/logprops/limit
@@ -72,6 +72,7 @@ SELECT * FROM xyzs LIMIT (SELECT 1)
 ----
 limit
  ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
+ ├── side-effects
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-4)
@@ -125,6 +126,7 @@ SELECT (SELECT x FROM kuv LIMIT y) FROM xyzs
 ----
 project
  ├── columns: x:9(int)
+ ├── side-effects
  ├── prune: (9)
  ├── scan xyzs
  │    ├── columns: xyzs.x:1(int!null) y:2(int) z:3(float!null) s:4(string)
@@ -132,17 +134,19 @@ project
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-4,+3,+1)
- └── projections [outer=(1,2)]
-      └── subquery [type=int, outer=(1,2)]
+ └── projections [outer=(1,2), side-effects]
+      └── subquery [type=int, outer=(1,2), side-effects]
            └── max1-row
                 ├── columns: x:8(int)
                 ├── outer: (1,2)
                 ├── cardinality: [0 - 1]
+                ├── side-effects
                 ├── key: ()
                 ├── fd: ()-->(8)
                 └── limit
                      ├── columns: x:8(int)
                      ├── outer: (1,2)
+                     ├── side-effects
                      ├── fd: ()-->(8)
                      ├── prune: (8)
                      ├── project

--- a/pkg/sql/opt/memo/testdata/logprops/offset
+++ b/pkg/sql/opt/memo/testdata/logprops/offset
@@ -180,29 +180,9 @@ offset
 opt
 SELECT s, x FROM (SELECT * FROM xyzs LIMIT 100) WHERE s='foo' OFFSET 4294967296
 ----
-offset
- ├── columns: s:4(string!null) x:1(int!null)
+values
+ ├── columns: s:4(string) x:1(int)
  ├── cardinality: [0 - 0]
- ├── key: (1)
- ├── fd: ()-->(4)
- ├── prune: (1)
- ├── interesting orderings: (+1) (-4)
- ├── select
- │    ├── columns: x:1(int!null) s:4(string!null)
- │    ├── cardinality: [0 - 100]
- │    ├── key: (1)
- │    ├── fd: ()-->(4)
- │    ├── prune: (1)
- │    ├── interesting orderings: (+1) (-4)
- │    ├── scan xyzs@secondary
- │    │    ├── columns: x:1(int!null) s:4(string)
- │    │    ├── limit: 100
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(4)
- │    │    ├── prune: (1,4)
- │    │    └── interesting orderings: (+1) (-4)
- │    └── filters [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
- │         └── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
- │              ├── variable: s [type=string, outer=(4)]
- │              └── const: 'foo' [type=string]
- └── const: 4294967296 [type=int]
+ ├── key: ()
+ ├── fd: ()-->(1,4)
+ └── prune: (1,4)

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -100,20 +100,12 @@ inner-join
 norm
 SELECT * FROM a JOIN b ON false
 ----
-inner-join
- ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) x:5(int) z:6(int!null)
+values
+ ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) x:5(int) z:6(int)
  ├── cardinality: [0 - 0]
  ├── stats: [rows=0]
- ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
- ├── scan a
- │    ├── columns: a.x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=5000]
- │    ├── key: (1)
- │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
- ├── scan b
- │    ├── columns: b.x:5(int) z:6(int!null)
- │    └── stats: [rows=10000]
- └── false [type=bool]
+ ├── key: ()
+ └── fd: ()-->(1-6)
 
 build
 SELECT *, rowid FROM a INNER JOIN b ON a.x=b.x

--- a/pkg/sql/opt/memo/testdata/stats/limit
+++ b/pkg/sql/opt/memo/testdata/stats/limit
@@ -70,6 +70,7 @@ SELECT * FROM a WHERE s = 'foo' LIMIT (SELECT 5 AS c)
 ----
 limit
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null)
+ ├── side-effects
  ├── stats: [rows=200]
  ├── key: (1)
  ├── fd: ()-->(3), (1)-->(2,4), (4)-->(1,2)

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -597,15 +596,6 @@ func (c *CustomFuncs) ConcatFilters(left, right memo.GroupID) memo.GroupID {
 		lb.AddItem(right)
 	}
 	return c.f.ConstructFilters(lb.BuildList())
-}
-
-// IsContradiction returns true if the given operation is False or a Filter with
-// a contradiction constraint.
-func (c *CustomFuncs) IsContradiction(filter memo.GroupID) bool {
-	if c.mem.NormOp(filter) == opt.FalseOp {
-		return true
-	}
-	return c.LookupLogical(filter).Scalar.Constraints == constraint.Contradiction
 }
 
 // ConstructEmptyValues constructs a Values expression with no rows.

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -304,16 +304,6 @@
      )
 )
 
-# DetectSelectContradiction replaces a Select with an empty Values if
-# it detects a contradiction in the filter.
-[DetectSelectContradiction, Normalize]
-(Select
-    $input:*
-    $filters:(Filters | False) & (IsContradiction $filters)
-)
-=>
-(ConstructEmptyValues (OutputCols $input))
-
 # EliminateUnionAllLeft replaces a union all with a right side having a
 # cardinality of zero, with just the left side operand.
 [EliminateUnionAllLeft, Normalize]
@@ -327,7 +317,6 @@
     $left
     (ProjectColMapLeft $colmap)
 )
-
 
 # EliminateUnionAllRight replaces a union all with a left side having a
 # cardinality of zero, with just the right side operand.

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -252,7 +252,7 @@ project
 # --------------------------------------------------
 # SimplifyFilters
 # --------------------------------------------------
-opt
+opt expect=SimplifyFilters
 SELECT * FROM a WHERE Null
 ----
 values
@@ -261,25 +261,16 @@ values
  ├── key: ()
  └── fd: ()-->(1-5)
 
-opt
+opt expect=SimplifyFilters
 SELECT * FROM a INNER JOIN b ON NULL
 ----
-inner-join
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) z:7(int)
+values
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) z:7(int)
  ├── cardinality: [0 - 0]
- ├── key: (1,6)
- ├── fd: (1)-->(2-5), (6)-->(7)
- ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
- ├── scan b
- │    ├── columns: x:6(int!null) z:7(int)
- │    ├── key: (6)
- │    └── fd: (6)-->(7)
- └── false [type=bool]
+ ├── key: ()
+ └── fd: ()-->(1-7)
 
-opt
+opt expect=SimplifyFilters
 SELECT * FROM a WHERE i=1 AND Null
 ----
 values

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -1622,7 +1622,8 @@ scan a
 # --------------------------------------------------
 # EliminateAntiJoin
 # --------------------------------------------------
-opt expect=EliminateAntiJoin
+# TODO(justin): figure out if there's a good way to make this still apply.
+opt disable=SimplifyZeroCardinalityGroup expect=EliminateAntiJoin
 SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM (VALUES (k)) OFFSET 1)
 ----
 scan a

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -71,25 +71,21 @@ limit
  │    └── fd: (1)-->(2-5)
  └── const: 5100000000 [type=int]
 
-# Don't eliminate in case of zero or negative limit.
+# Don't eliminate in case of negative limit.
 opt
 SELECT * FROM (SELECT * FROM a LIMIT 0) LIMIT -1
 ----
 limit
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── cardinality: [0 - 0]
+ ├── side-effects
  ├── key: ()
  ├── fd: ()-->(1-5)
- ├── limit
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── values
+ │    ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── cardinality: [0 - 0]
  │    ├── key: ()
- │    ├── fd: ()-->(1-5)
- │    ├── scan a
- │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    │    ├── key: (1)
- │    │    └── fd: (1)-->(2-5)
- │    └── const: 0 [type=int]
+ │    └── fd: ()-->(1-5)
  └── const: -1 [type=int]
 
 # --------------------------------------------------
@@ -187,21 +183,6 @@ project
  └── projections [outer=(3)]
       └── f + 1.1 [type=float, outer=(3)]
 
-# Don't push zero limit into Scan.
-opt
-SELECT * FROM a LIMIT 0
-----
-limit
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── cardinality: [0 - 0]
- ├── key: ()
- ├── fd: ()-->(1-5)
- ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
- └── const: 0 [type=int]
-
 # Don't push negative limit into Scan.
 opt
 SELECT * FROM a LIMIT -1
@@ -209,6 +190,7 @@ SELECT * FROM a LIMIT -1
 limit
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── cardinality: [0 - 0]
+ ├── side-effects
  ├── key: ()
  ├── fd: ()-->(1-5)
  ├── scan a

--- a/pkg/sql/opt/norm/testdata/rules/max1row
+++ b/pkg/sql/opt/norm/testdata/rules/max1row
@@ -84,14 +84,11 @@ project
  └── projections
       └── gt [type=bool]
            ├── subquery [type=int]
-           │    └── limit
+           │    └── values
            │         ├── columns: i:2(int)
            │         ├── cardinality: [0 - 0]
            │         ├── key: ()
-           │         ├── fd: ()-->(2)
-           │         ├── scan a
-           │         │    └── columns: i:2(int)
-           │         └── const: 0 [type=int]
+           │         └── fd: ()-->(2)
            └── const: 5 [type=int]
 
 # Don't remove the Max1Row operator.

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -43,6 +43,41 @@ scan a
 # MergeSelects
 # --------------------------------------------------
 opt expect=MergeSelects
+SELECT * FROM (SELECT * FROM a WHERE k=3) WHERE s='foo'
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string!null) j:5(jsonb)
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── constraint: /1: [/3 - /3]
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    └── fd: ()-->(1-5)
+ └── filters [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+      └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
+
+opt expect=MergeSelects
+SELECT * FROM (SELECT * FROM a WHERE i=1) WHERE False
+----
+values
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
+opt expect=MergeSelects
+SELECT * FROM (SELECT * FROM a WHERE i=1) WHERE False
+----
+values
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
+opt expect=MergeSelects
 SELECT * FROM (SELECT * FROM a WHERE i<5) WHERE s='foo'
 ----
 select
@@ -658,20 +693,11 @@ inner-join (merge)
 opt expect=MergeSelectInnerJoin
 SELECT * FROM a INNER JOIN xy ON a.k=xy.x WHERE False
 ----
-inner-join
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+values
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
  ├── cardinality: [0 - 0]
- ├── key: (1,6)
- ├── fd: (1)-->(2-5), (6)-->(7)
- ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
- ├── scan xy
- │    ├── columns: x:6(int!null) y:7(int)
- │    ├── key: (6)
- │    └── fd: (6)-->(7)
- └── false [type=bool]
+ ├── key: ()
+ └── fd: ()-->(1-7)
 
 # Don't merge with LEFT JOIN.
 opt expect-not=MergeSelectInnerJoin
@@ -1053,28 +1079,6 @@ project
            └── (i + k) IS NOT NULL [type=bool, outer=(1,2)]
 
 # --------------------------------------------------
-# DetectSelectContradiction
-# --------------------------------------------------
-
-opt expect=DetectSelectContradiction
-SELECT k FROM b WHERE false
-----
-values
- ├── columns: k:1(int)
- ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1)
-
-opt expect=DetectSelectContradiction
-SELECT k FROM b WHERE i > 2 AND i < 1
-----
-values
- ├── columns: k:1(int)
- ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1)
-
-# --------------------------------------------------
 # EliminateUnionAllLeft
 # --------------------------------------------------
 
@@ -1116,40 +1120,8 @@ SELECT k FROM
   UNION ALL
   (SELECT k FROM b WHERE i < 4 AND i > 10)
 ----
-project
+values
  ├── columns: k:11(int)
  ├── cardinality: [0 - 0]
  ├── key: ()
- ├── fd: ()-->(11)
- ├── values
- │    ├── columns: b.k:1(int)
- │    ├── cardinality: [0 - 0]
- │    ├── key: ()
- │    └── fd: ()-->(1)
- └── projections [outer=(1)]
-      └── variable: b.k [type=int, outer=(1)]
-
-opt expect=DetectSelectContradiction
-SELECT * FROM (SELECT * FROM a WHERE i=1) WHERE False
-----
-values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-5)
-
-opt expect=DetectSelectContradiction
-SELECT * FROM (SELECT * FROM a WHERE False) WHERE s='foo'
-----
-select
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string!null) j:5(jsonb)
- ├── cardinality: [0 - 0]
- ├── key: ()
- ├── fd: ()-->(1-5)
- ├── values
- │    ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── cardinality: [0 - 0]
- │    ├── key: ()
- │    └── fd: ()-->(1-5)
- └── filters [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
-      └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
+ └── fd: ()-->(11)

--- a/pkg/sql/opt/norm/testdata/rules/zero_cardinality
+++ b/pkg/sql/opt/norm/testdata/rules/zero_cardinality
@@ -1,0 +1,104 @@
+exec-ddl
+CREATE TABLE b (k INT PRIMARY KEY, i INT, f FLOAT, s STRING NOT NULL, j JSON)
+----
+TABLE b
+ ├── k int not null
+ ├── i int
+ ├── f float
+ ├── s string not null
+ ├── j jsonb
+ └── INDEX primary
+      └── k int not null
+
+# --------------------------------------------------
+# SimplifyZeroCardinalityGroup
+# --------------------------------------------------
+
+opt expect=SimplifyZeroCardinalityGroup
+SELECT k FROM b WHERE false
+----
+values
+ ├── columns: k:1(int)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1)
+
+opt expect=SimplifyZeroCardinalityGroup
+SELECT k FROM b WHERE i > 2 AND i < 1
+----
+values
+ ├── columns: k:1(int)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1)
+
+opt expect=SimplifyZeroCardinalityGroup
+SELECT * FROM (VALUES (1) OFFSET 1)
+----
+values
+ ├── columns: column1:1(int)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1)
+
+opt expect=SimplifyZeroCardinalityGroup
+SELECT * FROM b INNER JOIN b b2 ON False
+----
+values
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) k:6(int) i:7(int) f:8(float) s:9(string) j:10(jsonb)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-10)
+
+opt expect=SimplifyZeroCardinalityGroup
+SELECT * FROM b LIMIT 0
+----
+values
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
+opt expect=SimplifyZeroCardinalityGroup
+SELECT * FROM (SELECT * FROM b WHERE i=1) WHERE False
+----
+values
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
+opt expect=SimplifyZeroCardinalityGroup
+SELECT * FROM (SELECT * FROM b WHERE False) WHERE s='foo'
+----
+values
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
+opt expect=SimplifyZeroCardinalityGroup
+SELECT * FROM (SELECT * FROM b WHERE False) WHERE s='foo'
+----
+values
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
+opt
+SELECT * FROM (SELECT CASE WHEN k < 0 THEN 3 / 0 ELSE 3 END FROM b) WHERE false
+----
+select
+ ├── columns: case:6(decimal)
+ ├── cardinality: [0 - 0]
+ ├── side-effects
+ ├── project
+ │    ├── columns: case:6(decimal)
+ │    ├── side-effects
+ │    ├── scan b
+ │    │    ├── columns: k:1(int!null)
+ │    │    └── key: (1)
+ │    └── projections [outer=(1), side-effects]
+ │         └── CASE WHEN k < 0 THEN 3 / 0 ELSE 3 END [type=decimal, outer=(1), side-effects]
+ └── false [type=bool]

--- a/pkg/sql/opt/rule_name.go
+++ b/pkg/sql/opt/rule_name.go
@@ -30,6 +30,7 @@ const (
 	SimplifyProjectOrdering
 	SimplifyRootOrdering
 	PruneRootCols
+	SimplifyZeroCardinalityGroup
 
 	// NumManualRules tracks the number of manually-defined rules.
 	NumManualRuleNames

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -270,12 +270,14 @@ order by anon_1.flavors_id asc
 ----
 left-join (merge)
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── side-effects
  ├── has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── ordering: +1
  ├── project
  │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │    ├── side-effects
  │    ├── has-placeholder
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
@@ -283,6 +285,7 @@ left-join (merge)
  │    └── limit
  │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
  │         ├── internal-ordering: +1
+ │         ├── side-effects
  │         ├── has-placeholder
  │         ├── key: (1)
  │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
@@ -453,12 +456,14 @@ order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:38(timestamp) flavor_extra_specs_1_updated_at:39(timestamp) flavor_extra_specs_1_id:34(int) flavor_extra_specs_1_key:35(string) flavor_extra_specs_1_value:36(string) flavor_extra_specs_1_flavor_id:37(int)
+ ├── side-effects
  ├── has-placeholder
  ├── key: (1,34)
  ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35-39), (35,37)-->(34,36,38,39)
  ├── ordering: +7 opt(11)
  └── right-join
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:34(int) key:35(string) value:36(string) flavor_extra_specs.flavor_id:37(int) flavor_extra_specs.created_at:38(timestamp) flavor_extra_specs.updated_at:39(timestamp)
+      ├── side-effects
       ├── has-placeholder
       ├── key: (1,34)
       ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35-39), (35,37)-->(34,36,38,39)
@@ -468,12 +473,14 @@ sort
       │    └── fd: (34)-->(35-39), (35,37)-->(34,36,38,39)
       ├── project
       │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    ├── side-effects
       │    ├── has-placeholder
       │    ├── key: (1)
       │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
       │    └── limit
       │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
       │         ├── internal-ordering: +7 opt(11)
+      │         ├── side-effects
       │         ├── has-placeholder
       │         ├── key: (1)
       │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
@@ -706,12 +713,14 @@ order by anon_1.instance_types_flavorid asc,
 ----
 sort
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
+ ├── side-effects
  ├── has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── ordering: +7,+1
  └── right-join
       ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      ├── side-effects
       ├── has-placeholder
       ├── key: (1,28)
       ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
@@ -728,12 +737,14 @@ sort
       │         └── instance_type_extra_specs.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
       ├── project
       │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    ├── side-effects
       │    ├── has-placeholder
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
       │    └── limit
       │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
       │         ├── internal-ordering: +7,+1
+      │         ├── side-effects
       │         ├── has-placeholder
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
@@ -1054,22 +1065,26 @@ from (select instance_types.created_at as instance_types_created_at,
 left-join (lookup instance_type_extra_specs)
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
  ├── key columns: [28] = [28]
+ ├── side-effects
  ├── has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── left-join (lookup instance_type_extra_specs@secondary)
  │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
  │    ├── key columns: [1] = [31]
+ │    ├── side-effects
  │    ├── has-placeholder
  │    ├── key: (1,28)
  │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
  │    ├── project
  │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │    ├── side-effects
  │    │    ├── has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
  │    │    └── limit
  │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         ├── side-effects
  │    │         ├── has-placeholder
  │    │         ├── key: (1)
  │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
@@ -1229,22 +1244,26 @@ from (select instance_types.created_at as instance_types_created_at,
 left-join (lookup instance_type_extra_specs)
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
  ├── key columns: [28] = [28]
+ ├── side-effects
  ├── has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── left-join (lookup instance_type_extra_specs@secondary)
  │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
  │    ├── key columns: [1] = [31]
+ │    ├── side-effects
  │    ├── has-placeholder
  │    ├── key: (1,28)
  │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
  │    ├── project
  │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │    ├── side-effects
  │    │    ├── has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │    └── limit
  │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         ├── side-effects
  │    │         ├── has-placeholder
  │    │         ├── key: (1)
  │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
@@ -1397,6 +1416,7 @@ from (select flavors.created_at as flavors_created_at,
 ----
 right-join
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── side-effects
  ├── has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
@@ -1406,11 +1426,13 @@ right-join
  │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── project
  │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │    ├── side-effects
  │    ├── has-placeholder
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │    └── limit
  │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+ │         ├── side-effects
  │         ├── has-placeholder
  │         ├── key: (1)
  │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
@@ -1556,6 +1578,7 @@ from (select flavors.created_at as flavors_created_at,
 ----
 right-join
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── side-effects
  ├── has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
@@ -1565,11 +1588,13 @@ right-join
  │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── project
  │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │    ├── side-effects
  │    ├── has-placeholder
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │    └── limit
  │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+ │         ├── side-effects
  │         ├── has-placeholder
  │         ├── key: (1)
  │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
@@ -1719,12 +1744,14 @@ order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── side-effects
  ├── has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── ordering: +7
  └── right-join
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:25(int) key:26(string) value:27(string) flavor_extra_specs.flavor_id:28(int) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+      ├── side-effects
       ├── has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
@@ -1734,12 +1761,14 @@ sort
       │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
       ├── project
       │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    ├── side-effects
       │    ├── has-placeholder
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │    └── limit
       │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
       │         ├── internal-ordering: +7
+      │         ├── side-effects
       │         ├── has-placeholder
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
@@ -1904,12 +1933,14 @@ order by anon_1.instance_types_flavorid asc,
 ----
 sort
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
+ ├── side-effects
  ├── has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── ordering: +7,+1
  └── right-join
       ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) value:30(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool) instance_type_extra_specs.deleted_at:33(timestamp) instance_type_extra_specs.created_at:34(timestamp) instance_type_extra_specs.updated_at:35(timestamp)
+      ├── side-effects
       ├── has-placeholder
       ├── key: (1,28)
       ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
@@ -1926,12 +1957,14 @@ sort
       │         └── instance_type_extra_specs.deleted = $6 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
       ├── project
       │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    ├── side-effects
       │    ├── has-placeholder
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
       │    └── limit
       │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
       │         ├── internal-ordering: +7,+1
+      │         ├── side-effects
       │         ├── has-placeholder
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
@@ -2098,22 +2131,26 @@ from (select instance_types.created_at as instance_types_created_at,
 left-join (lookup instance_type_extra_specs)
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
  ├── key columns: [28] = [28]
+ ├── side-effects
  ├── has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── left-join (lookup instance_type_extra_specs@secondary)
  │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
  │    ├── key columns: [1] = [31]
+ │    ├── side-effects
  │    ├── has-placeholder
  │    ├── key: (1,28)
  │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
  │    ├── project
  │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │    ├── side-effects
  │    │    ├── has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
  │    │    └── limit
  │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+ │    │         ├── side-effects
  │    │         ├── has-placeholder
  │    │         ├── key: (1)
  │    │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
@@ -2406,6 +2443,7 @@ order by anon_1.instance_types_flavorid asc,
 left-join (lookup instance_type_extra_specs)
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
  ├── key columns: [28] = [28]
+ ├── side-effects
  ├── has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
@@ -2413,12 +2451,14 @@ left-join (lookup instance_type_extra_specs)
  ├── left-join (lookup instance_type_extra_specs@secondary)
  │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
  │    ├── key columns: [1] = [31]
+ │    ├── side-effects
  │    ├── has-placeholder
  │    ├── key: (1,28)
  │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
  │    ├── ordering: +7,+1
  │    ├── project
  │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │    ├── side-effects
  │    │    ├── has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
@@ -2426,6 +2466,7 @@ left-join (lookup instance_type_extra_specs)
  │    │    └── limit
  │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
  │    │         ├── internal-ordering: +7,+1
+ │    │         ├── side-effects
  │    │         ├── has-placeholder
  │    │         ├── key: (1)
  │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
@@ -2585,12 +2626,14 @@ order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── side-effects
  ├── has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── ordering: +7
  └── right-join
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:25(int) key:26(string) value:27(string) flavor_extra_specs.flavor_id:28(int) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+      ├── side-effects
       ├── has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
@@ -2600,12 +2643,14 @@ sort
       │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
       ├── project
       │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    ├── side-effects
       │    ├── has-placeholder
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │    └── limit
       │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
       │         ├── internal-ordering: +7
+      │         ├── side-effects
       │         ├── has-placeholder
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
@@ -2771,6 +2816,7 @@ order by anon_1.instance_types_flavorid asc,
 left-join (lookup instance_type_extra_specs)
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:45(timestamp) instance_type_extra_specs_1_updated_at:46(timestamp) instance_type_extra_specs_1_deleted_at:44(timestamp) instance_type_extra_specs_1_deleted:43(bool) instance_type_extra_specs_1_id:39(int) instance_type_extra_specs_1_key:40(string) instance_type_extra_specs_1_value:41(string) instance_type_extra_specs_1_instance_type_id:42(int)
  ├── key columns: [39] = [39]
+ ├── side-effects
  ├── has-placeholder
  ├── key: (1,39)
  ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
@@ -2778,12 +2824,14 @@ left-join (lookup instance_type_extra_specs)
  ├── left-join (lookup instance_type_extra_specs@secondary)
  │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:39(int) key:40(string) instance_type_extra_specs.instance_type_id:42(int) instance_type_extra_specs.deleted:43(bool)
  │    ├── key columns: [1] = [42]
+ │    ├── side-effects
  │    ├── has-placeholder
  │    ├── key: (1,39)
  │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40,42,43), (40,42,43)~~>(39)
  │    ├── ordering: +7,+1 opt(11)
  │    ├── project
  │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │    ├── side-effects
  │    │    ├── has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
@@ -2791,6 +2839,7 @@ left-join (lookup instance_type_extra_specs)
  │    │    └── limit
  │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
  │    │         ├── internal-ordering: +7,+1 opt(11)
+ │    │         ├── side-effects
  │    │         ├── has-placeholder
  │    │         ├── key: (1)
  │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
@@ -3036,6 +3085,7 @@ order by anon_1.instance_types_deleted asc,
 left-join (lookup instance_type_extra_specs)
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
  ├── key columns: [28] = [28]
+ ├── side-effects
  ├── has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
@@ -3043,12 +3093,14 @@ left-join (lookup instance_type_extra_specs)
  ├── left-join (lookup instance_type_extra_specs@secondary)
  │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:28(int) key:29(string) instance_type_extra_specs.instance_type_id:31(int) instance_type_extra_specs.deleted:32(bool)
  │    ├── key columns: [1] = [31]
+ │    ├── side-effects
  │    ├── has-placeholder
  │    ├── key: (1,28)
  │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
  │    ├── ordering: +13,+1
  │    ├── project
  │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+ │    │    ├── side-effects
  │    │    ├── has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
@@ -3056,6 +3108,7 @@ left-join (lookup instance_type_extra_specs)
  │    │    └── limit
  │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
  │    │         ├── internal-ordering: +13,+1
+ │    │         ├── side-effects
  │    │         ├── has-placeholder
  │    │         ├── key: (1)
  │    │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
@@ -3214,6 +3267,7 @@ from (select flavors.created_at as flavors_created_at,
 ----
 right-join
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── side-effects
  ├── has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
@@ -3223,11 +3277,13 @@ right-join
  │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── project
  │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+ │    ├── side-effects
  │    ├── has-placeholder
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
  │    └── limit
  │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+ │         ├── side-effects
  │         ├── has-placeholder
  │         ├── key: (1)
  │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
@@ -3376,12 +3432,14 @@ order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) anon_1_flavors_description:13(string) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
+ ├── side-effects
  ├── has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── ordering: +7
  └── right-join
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:25(int) key:26(string) value:27(string) flavor_extra_specs.flavor_id:28(int) flavor_extra_specs.created_at:29(timestamp) flavor_extra_specs.updated_at:30(timestamp)
+      ├── side-effects
       ├── has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (25)-->(26-30), (26,28)-->(25,27,29,30)
@@ -3391,12 +3449,14 @@ sort
       │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
       ├── project
       │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    ├── side-effects
       │    ├── has-placeholder
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15)
       │    └── limit
       │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
       │         ├── internal-ordering: +7
+      │         ├── side-effects
       │         ├── has-placeholder
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -105,6 +105,7 @@ SELECT s FROM a LIMIT (SELECT k FROM a LIMIT 1)
 ----
 limit
  ├── columns: s:4(string)
+ ├── side-effects
  ├── scan a@s_idx
  │    └── columns: a.s:4(string)
  └── subquery [type=int]


### PR DESCRIPTION
This commit adds SimplifyZeroCardinalityGroup, which is a new manual
rule which replaces a group which has been proven to have zero rows with
an empty ValuesOp.

This rule is different from most other rules because it depends on the
logical properties of the group being constructed, so it gets checked in
onConstruct rather than normal rule checking. This means that we can
sometimes create groups which end up getting immediately discarded, but
since this is something of an edge case I think that's not a huge deal.

This replaces DetectSelectContradiction.

There's an annoying edge case with negative limits - I'm not super fond
of the solution I ended up at, but I couldn't think of anything
substantially better given the restrictions. Open to suggestions here.

Release note: None