### PR TITLE
stats: invalidate stats on INJECT STATISTICS

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -24,3 +24,28 @@ scan  ·       ·          (u, v)  ·
 ·     table   b@b_v_idx  ·       ·
 ·     spans   /1-/2      ·       ·
 ·     filter  u = 1      ·       ·
+
+# Verify that injecting different statistics changes the plan.
+statement ok
+ALTER TABLE b INJECT STATISTICS '[
+  {
+    "columns": ["u"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 100,
+    "distinct_count": 100
+  },
+  {
+    "columns": ["v"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 100,
+    "distinct_count": 10
+  }
+]'
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM b WHERE u = 1 AND v = 1
+----
+scan  ·       ·          (u, v)  ·
+·     table   b@b_u_idx  ·       ·
+·     spans   /1-/2      ·       ·
+·     filter  v = 1      ·       ·

--- a/pkg/sql/stats/new_stat.go
+++ b/pkg/sql/stats/new_stat.go
@@ -82,7 +82,12 @@ func InsertNewStat(
 	}
 
 	// TODO(radu): we need to clear out old stats that are superseded.
+	return GossipTableStatAdded(g, tableID)
+}
 
+// GossipTableStatAdded causes the statistic caches for this table to be
+// invalidated.
+func GossipTableStatAdded(g *gossip.Gossip, tableID sqlbase.ID) error {
 	// TODO(radu): perhaps use a TTL here to avoid having a key per table floating
 	// around forever (we would need the stat cache to evict old entries
 	// automatically though).


### PR DESCRIPTION
I was fiddling with a test and noticed that `INJECT STATISTICS` wasn't
causing different plans. We weren't invalidating the stat cache in
this case so we kept using the previous stats.

Release note: None