### PR TITLE
release-2.1: jobs: run using stopper.RunAsyncTask

### DIFF
--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -90,7 +90,7 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 		nodeID := &base.NodeIDContainer{}
 		nodeID.Reset(id)
 		r := jobs.MakeRegistry(
-			ac, clock, db, s.InternalExecutor().(sqlutil.InternalExecutor),
+			ac, s.Stopper(), clock, db, s.InternalExecutor().(sqlutil.InternalExecutor),
 			nodeID, s.ClusterSettings(), jobs.FakePHS,
 		)
 		if err := r.Start(ctx, s.Stopper(), nodeLiveness, cancelInterval, adoptInterval); err != nil {

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -43,7 +43,9 @@ func TestRegistryCancelation(t *testing.T) {
 	// Insulate this test from wall time.
 	mClock := hlc.NewManualClock(hlc.UnixNano())
 	clock := hlc.NewClock(mClock.UnixNano, time.Nanosecond)
-	registry := MakeRegistry(log.AmbientContext{}, clock, db, nil /* ex */, FakeNodeID, cluster.NoSettings, FakePHS)
+	registry := MakeRegistry(
+		log.AmbientContext{}, stopper, clock, db, nil /* ex */, FakeNodeID, cluster.NoSettings,
+		FakePHS)
 
 	const nodeCount = 1
 	nodeLiveness := NewFakeNodeLiveness(nodeCount)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -488,6 +488,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	s.sessionRegistry = sql.MakeSessionRegistry()
 	s.jobRegistry = jobs.MakeRegistry(
 		s.cfg.AmbientCtx,
+		s.stopper,
 		s.clock,
 		s.db,
 		internalExecutor,


### PR DESCRIPTION
Backport 1/1 commits from #30306.

/cc @cockroachdb/release

---

A job should finish shutting down before we consider the server shut
down. The immediate motivation for this is fixing some flaky tests, but
this is also more correct.

Closes #30258
Closes #30259

Release note: None
