### PR TITLE
release-2.1: another week of merge work

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -1084,7 +1084,7 @@ func TestStoreRangeMergeRHSLeaseExpiration(t *testing.T) {
 	// read the meat of the test.
 
 	// Install a hook to control when the merge transaction commits.
-	mergeEndTxnReceived := make(chan struct{})
+	mergeEndTxnReceived := make(chan struct{}, 10) // headroom in case the merge transaction retries
 	finishMerge := make(chan struct{})
 	storeCfg.TestingKnobs.TestingRequestFilter = func(ba roachpb.BatchRequest) *roachpb.Error {
 		for _, r := range ba.Requests {
@@ -1206,7 +1206,7 @@ func TestStoreRangeMergeRHSLeaseExpiration(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Finally, allow the merge to complete. It should complete successfully.
-	finishMerge <- struct{}{}
+	close(finishMerge)
 	if err := <-mergeErr; err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -260,7 +260,7 @@ func (s *Store) AssertInvariants() {
 				log.Fatalf(ctx, "%v misplaced in replicasByKey; found %v instead", repl, ex)
 			}
 		} else if _, ok := s.mu.uninitReplicas[repl.RangeID]; !ok {
-			log.Fatalf(ctx, "%v missing from unitReplicas", repl)
+			log.Fatalf(ctx, "%v missing from uninitReplicas", repl)
 		}
 		return true // keep iterating
 	})

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1688,17 +1688,9 @@ func (r *Replica) GetTxnSpanGCThreshold() hlc.Timestamp {
 	return *r.mu.state.TxnSpanGCThreshold
 }
 
-// setDesc atomically sets the range's descriptor. This method calls
-// processRangeDescriptorUpdate() to make the Store handle the descriptor
-// update. Requires raftMu to be locked.
-func (r *Replica) setDesc(ctx context.Context, desc *roachpb.RangeDescriptor) error {
-	r.setDescWithoutProcessUpdate(ctx, desc)
-	return r.store.processRangeDescriptorUpdate(ctx, r)
-}
-
-// setDescWithoutProcessUpdate updates the range descriptor without calling
-// processRangeDescriptorUpdate. Requires raftMu to be locked.
-func (r *Replica) setDescWithoutProcessUpdate(ctx context.Context, desc *roachpb.RangeDescriptor) {
+// setDesc atomically sets the replica's descriptor. It requires raftMu to be
+// locked.
+func (r *Replica) setDesc(ctx context.Context, desc *roachpb.RangeDescriptor) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -1711,7 +1703,8 @@ func (r *Replica) setDescWithoutProcessUpdate(ctx context.Context, desc *roachpb
 		log.Fatalf(ctx, "cannot replace initialized descriptor with uninitialized one: %+v -> %+v",
 			r.mu.state.Desc, desc)
 	}
-	if r.mu.state.Desc != nil && !r.mu.state.Desc.StartKey.Equal(desc.StartKey) {
+	if r.mu.state.Desc != nil && r.mu.state.Desc.IsInitialized() &&
+		!r.mu.state.Desc.StartKey.Equal(desc.StartKey) {
 		log.Fatalf(ctx, "attempted to change replica's start key from %s to %s",
 			r.mu.state.Desc.StartKey, desc.StartKey)
 	}
@@ -4091,19 +4084,6 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 
 		if err := r.applySnapshot(ctx, inSnap, rd.Snapshot, rd.HardState, subsumedRepls); err != nil {
 			const expl = "while applying snapshot"
-			return stats, expl, errors.Wrap(err, expl)
-		}
-
-		if err := func() error {
-			r.store.mu.Lock()
-			defer r.store.mu.Unlock()
-
-			if r.store.removePlaceholderLocked(ctx, r.RangeID) {
-				atomic.AddInt32(&r.store.counts.filledPlaceholders, 1)
-			}
-			return r.store.processRangeDescriptorUpdateLocked(ctx, r)
-		}(); err != nil {
-			const expl = "could not processRangeDescriptorUpdate after applySnapshot"
 			return stats, expl, errors.Wrap(err, expl)
 		}
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1693,10 +1693,6 @@ func (r *Replica) GetTxnSpanGCThreshold() hlc.Timestamp {
 // update. Requires raftMu to be locked.
 func (r *Replica) setDesc(ctx context.Context, desc *roachpb.RangeDescriptor) error {
 	r.setDescWithoutProcessUpdate(ctx, desc)
-	if r.store == nil {
-		// r.rm is null in some tests.
-		return nil
-	}
 	return r.store.processRangeDescriptorUpdate(ctx, r)
 }
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -6759,13 +6759,13 @@ func (r *Replica) clearPendingSnapshotIndex() {
 	r.mu.Unlock()
 }
 
-func (r *Replica) endKey() roachpb.RKey {
-	return r.Desc().EndKey
+func (r *Replica) startKey() roachpb.RKey {
+	return r.Desc().StartKey
 }
 
 // Less implements the btree.Item interface.
 func (r *Replica) Less(i btree.Item) bool {
-	return r.endKey().Less(i.(rangeKeyItem).endKey())
+	return r.startKey().Less(i.(rangeKeyItem).startKey())
 }
 
 // ReplicaMetrics contains details on the current status of the replica.

--- a/pkg/storage/replica_placeholder.go
+++ b/pkg/storage/replica_placeholder.go
@@ -34,13 +34,13 @@ func (r *ReplicaPlaceholder) Desc() *roachpb.RangeDescriptor {
 	return &r.rangeDesc
 }
 
-func (r *ReplicaPlaceholder) endKey() roachpb.RKey {
-	return r.Desc().EndKey
+func (r *ReplicaPlaceholder) startKey() roachpb.RKey {
+	return r.Desc().StartKey
 }
 
 // Less implements the btree.Item interface.
 func (r *ReplicaPlaceholder) Less(i btree.Item) bool {
-	return r.Desc().EndKey.Less(i.(rangeKeyItem).endKey())
+	return r.Desc().StartKey.Less(i.(rangeKeyItem).startKey())
 }
 
 func (r *ReplicaPlaceholder) String() string {

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -665,15 +665,7 @@ func (r *Replica) handleReplicatedEvalResult(
 
 	if rResult.State != nil {
 		if newDesc := rResult.State.Desc; newDesc != nil {
-			if err := r.setDesc(ctx, newDesc); err != nil {
-				// Log the error. There's not much we can do because the commit may
-				// have already occurred at this point.
-				log.Fatalf(
-					ctx,
-					"failed to update range descriptor to %+v: %s",
-					newDesc, err,
-				)
-			}
+			r.setDesc(ctx, newDesc)
 			rResult.State.Desc = nil
 		}
 

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -665,7 +665,7 @@ func (r *Replica) handleReplicatedEvalResult(
 
 	if rResult.State != nil {
 		if newDesc := rResult.State.Desc; newDesc != nil {
-			if err := r.setDesc(newDesc); err != nil {
+			if err := r.setDesc(ctx, newDesc); err != nil {
 				// Log the error. There's not much we can do because the commit may
 				// have already occurred at this point.
 				log.Fatalf(

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -721,14 +722,21 @@ func clearRangeData(
 	return nil
 }
 
-// applySnapshot updates the replica based on the given snapshot and associated
-// HardState. All snapshots must pass through Raft for correctness, i.e. the
-// parameters to this method must be taken from a raft.Ready. Any replicas
-// specified in subsumedRepls will be destroyed atomically with the application
-// of the snapshot. It is the caller's responsibility to call
-// r.store.processRangeDescriptorUpdate(r) after a successful applySnapshot.
+// applySnapshot updates the replica and its store based on the given snapshot
+// and associated HardState. All snapshots must pass through Raft for
+// correctness, i.e. the parameters to this method must be taken from a
+// raft.Ready. Any replicas specified in subsumedRepls will be destroyed
+// atomically with the application of the snapshot.
+//
+// If there is a placeholder associated with r, applySnapshot will remove that
+// placeholder from the store if and only if it does not return an error.
+//
 // This method requires that r.raftMu is held, as well as the raftMus of any
 // replicas in subsumedRepls.
+//
+// TODO(benesch): the way this replica method reaches into its store to update
+// replicasByKey is unfortunate, but the fix requires a substantial refactor to
+// maintain the necessary synchronization.
 func (r *Replica) applySnapshot(
 	ctx context.Context,
 	inSnap IncomingSnapshot,
@@ -760,6 +768,14 @@ func (r *Replica) applySnapshot(
 		// Raft discarded the snapshot, indicating that our local state is
 		// already ahead of what the snapshot provides. But we count it for
 		// stats (see the defer above).
+		//
+		// Since we're not returning an error, we're responsible for removing any
+		// placeholder that might exist.
+		r.store.mu.Lock()
+		if r.store.removePlaceholderLocked(ctx, r.RangeID) {
+			atomic.AddInt32(&r.store.counts.filledPlaceholders, 1)
+		}
+		r.store.mu.Unlock()
 		return nil
 	}
 	if raft.IsEmptyHardState(hs) {
@@ -911,11 +927,15 @@ func (r *Replica) applySnapshot(
 	}
 	stats.commit = timeutil.Now()
 
+	// The on-disk state is now committed, but the corresponding in-memory state
+	// has not yet been updated. Any errors past this point must therefore be
+	// treated as fatal.
+
 	for _, sr := range subsumedRepls {
 		// We removed sr's data when we committed the batch. Finish subsumption by
 		// updating the in-memory bookkeping.
 		if err := sr.postDestroyRaftMuLocked(ctx, sr.GetMVCCStats()); err != nil {
-			return err
+			log.Fatalf(ctx, "unable to finish destroying %s while applying snapshot: %s", sr, err)
 		}
 		// We already hold sr's raftMu, so we must call removeReplicaImpl directly.
 		// Note that it's safe to update the store's metadata for sr's removal
@@ -927,9 +947,21 @@ func (r *Replica) applySnapshot(
 		if err := r.store.removeReplicaImpl(ctx, sr, subsumedNextReplicaID, RemoveOptions{
 			DestroyData: false, // data is already destroyed
 		}); err != nil {
-			return err
+			log.Fatalf(ctx, "unable to remove %s while applying snapshot: %s", sr, err)
 		}
 	}
+
+	// Atomically swap the placeholder, if any, for the replica, and update the
+	// replica's descriptor.
+	r.store.mu.Lock()
+	if r.store.removePlaceholderLocked(ctx, r.RangeID) {
+		atomic.AddInt32(&r.store.counts.filledPlaceholders, 1)
+	}
+	r.setDesc(ctx, s.Desc)
+	if err := r.store.maybeMarkReplicaInitializedLocked(ctx, r); err != nil {
+		log.Fatalf(ctx, "unable to mark replica initialized while applying snapshot: %s", err)
+	}
+	r.store.mu.Unlock()
 
 	r.mu.Lock()
 	// We set the persisted last index to the last applied index. This is
@@ -942,12 +974,12 @@ func (r *Replica) applySnapshot(
 	r.mu.lastIndex = s.RaftAppliedIndex
 	r.mu.lastTerm = lastTerm
 	r.mu.raftLogSize = raftLogSize
-	// Update the range and store stats.
+	// Update the store stats for the data in the snapshot.
 	r.store.metrics.subtractMVCCStats(*r.mu.state.Stats)
 	r.store.metrics.addMVCCStats(*s.Stats)
-	// TODO(benesch): the next line updates r.mu.state.Desc, but that's supposed
-	// to be handled by the call to setDescWithoutProcessUpdate below. This is not
-	// a correctness issue right now, but it's liable to become one.
+	// Update the rest of the Raft state. Changes to r.mu.state.Desc must be
+	// managed by r.setDesc, but we called that above, so now it's safe to
+	// wholesale replace r.mu.state.
 	r.mu.state = s
 	r.assertStateLocked(ctx, r.store.Engine())
 	r.mu.Unlock()
@@ -959,17 +991,13 @@ func (r *Replica) applySnapshot(
 		roachpb.RangeFeedRetryError_REASON_RAFT_SNAPSHOT,
 	)
 
-	// As the last deferred action after committing the batch, update other
-	// fields which are uninitialized or need updating. This may not happen
-	// if the system config has not yet been loaded. While config update
-	// will correctly set the fields, there is no order guarantee in
-	// ApplySnapshot.
-	// TODO: should go through the standard store lock when adding a replica.
+	// Update the replica's cached byte thresholds. This is a no-op if the system
+	// config is not available, in which case we rely on the next gossip update
+	// to perform the update.
 	if err := r.updateRangeInfo(s.Desc); err != nil {
-		panic(err)
+		log.Fatalf(ctx, "unable to update range info while applying snapshot: %s", err)
 	}
 
-	r.setDescWithoutProcessUpdate(ctx, s.Desc)
 	return nil
 }
 

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -969,7 +969,7 @@ func (r *Replica) applySnapshot(
 		panic(err)
 	}
 
-	r.setDescWithoutProcessUpdate(s.Desc)
+	r.setDescWithoutProcessUpdate(ctx, s.Desc)
 	return nil
 }
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -332,7 +332,7 @@ func (tc *testContext) addBogusReplicaToRangeDesc(
 		return roachpb.ReplicaDescriptor{}, err
 	}
 
-	tc.repl.setDescWithoutProcessUpdate(ctx, &newDesc)
+	tc.repl.setDesc(ctx, &newDesc)
 	tc.repl.raftMu.Lock()
 	tc.repl.mu.Lock()
 	tc.repl.assertStateLocked(ctx, tc.engine)
@@ -7058,9 +7058,7 @@ func TestReplicaDestroy(t *testing.T) {
 		}
 	}
 
-	if err := repl.setDesc(ctx, newDesc); err != nil {
-		t.Fatal(err)
-	}
+	repl.setDesc(ctx, newDesc)
 	expectedErr := "replica descriptor's ID has changed"
 	if err := tc.store.removeReplicaImpl(ctx, tc.repl, origDesc.NextReplicaID, RemoveOptions{
 		DestroyData: true,

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -332,7 +332,7 @@ func (tc *testContext) addBogusReplicaToRangeDesc(
 		return roachpb.ReplicaDescriptor{}, err
 	}
 
-	tc.repl.setDescWithoutProcessUpdate(&newDesc)
+	tc.repl.setDescWithoutProcessUpdate(ctx, &newDesc)
 	tc.repl.raftMu.Lock()
 	tc.repl.mu.Lock()
 	tc.repl.assertStateLocked(ctx, tc.engine)
@@ -7036,9 +7036,10 @@ func TestReplicaLoadSystemConfigSpanIntent(t *testing.T) {
 
 func TestReplicaDestroy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
+	defer stopper.Stop(ctx)
 	tc.Start(t, stopper)
 
 	repl, err := tc.store.GetReplica(1)
@@ -7057,18 +7058,18 @@ func TestReplicaDestroy(t *testing.T) {
 		}
 	}
 
-	if err := repl.setDesc(newDesc); err != nil {
+	if err := repl.setDesc(ctx, newDesc); err != nil {
 		t.Fatal(err)
 	}
 	expectedErr := "replica descriptor's ID has changed"
-	if err := tc.store.removeReplicaImpl(context.Background(), tc.repl, origDesc.NextReplicaID, RemoveOptions{
+	if err := tc.store.removeReplicaImpl(ctx, tc.repl, origDesc.NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); !testutils.IsError(err, expectedErr) {
 		t.Fatalf("expected error %q but got %v", expectedErr, err)
 	}
 
 	// Now try a fresh descriptor and succeed.
-	if err := tc.store.removeReplicaImpl(context.Background(), tc.repl, repl.Desc().NextReplicaID, RemoveOptions{
+	if err := tc.store.removeReplicaImpl(ctx, tc.repl, repl.Desc().NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); err != nil {
 		t.Fatal(err)

--- a/pkg/storage/scanner_test.go
+++ b/pkg/storage/scanner_test.go
@@ -65,10 +65,7 @@ func newTestRangeSet(count int, t *testing.T) *testRangeSet {
 			KeyCount:  1,
 			LiveCount: 1,
 		}
-
-		if err := repl.setDesc(context.TODO(), desc); err != nil {
-			t.Fatal(err)
-		}
+		repl.mu.state.Desc = desc
 		if exRngItem := rs.replicasByKey.ReplaceOrInsert(repl); exRngItem != nil {
 			t.Fatalf("failed to insert range %s", repl)
 		}

--- a/pkg/storage/scanner_test.go
+++ b/pkg/storage/scanner_test.go
@@ -66,7 +66,7 @@ func newTestRangeSet(count int, t *testing.T) *testRangeSet {
 			LiveCount: 1,
 		}
 
-		if err := repl.setDesc(desc); err != nil {
+		if err := repl.setDesc(context.TODO(), desc); err != nil {
 			t.Fatal(err)
 		}
 		if exRngItem := rs.replicasByKey.ReplaceOrInsert(repl); exRngItem != nil {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -245,7 +245,7 @@ func verifyKeys(start, end roachpb.Key, checkEndKey bool) error {
 
 // rangeKeyItem is a common interface for roachpb.Key and Range.
 type rangeKeyItem interface {
-	endKey() roachpb.RKey
+	startKey() roachpb.RKey
 }
 
 // rangeBTreeKey is a type alias of roachpb.RKey that implements the
@@ -254,14 +254,14 @@ type rangeBTreeKey roachpb.RKey
 
 var _ rangeKeyItem = rangeBTreeKey{}
 
-func (k rangeBTreeKey) endKey() roachpb.RKey {
+func (k rangeBTreeKey) startKey() roachpb.RKey {
 	return (roachpb.RKey)(k)
 }
 
 var _ btree.Item = rangeBTreeKey{}
 
 func (k rangeBTreeKey) Less(i btree.Item) bool {
-	return k.endKey().Less(i.(rangeKeyItem).endKey())
+	return k.startKey().Less(i.(rangeKeyItem).startKey())
 }
 
 // A NotBootstrappedError indicates that an engine has not yet been
@@ -535,9 +535,9 @@ type Store struct {
 		// Map of replicas by Range ID (map[roachpb.RangeID]*Replica). This
 		// includes `uninitReplicas`. May be read without holding Store.mu.
 		replicas syncutil.IntMap
-		// A btree key containing objects of type *Replica or
-		// *ReplicaPlaceholder (both of which have an associated key range, on
-		// the EndKey of which the btree is keyed)
+		// A btree key containing objects of type *Replica or *ReplicaPlaceholder.
+		// Both types have an associated key range; the btree is keyed on their
+		// start keys.
 		replicasByKey  *btree.BTree
 		uninitReplicas map[roachpb.RangeID]*Replica // Map of uninitialized replicas by Range ID
 		// replicaPlaceholders is a map to access all placeholders, so they can
@@ -2127,9 +2127,7 @@ func (s *Store) LookupReplica(key roachpb.RKey) *Replica {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	var repl *Replica
-	// Simulate AscendGreater by calling key.Next. We want to skip the replica
-	// whose end key equals key, as end keys are exclusive.
-	s.mu.replicasByKey.AscendGreaterOrEqual(rangeBTreeKey(key.Next()), func(item btree.Item) bool {
+	s.mu.replicasByKey.DescendLessOrEqual(rangeBTreeKey(key), func(item btree.Item) bool {
 		repl, _ = item.(*Replica)
 		// Stop iterating immediately. The first item we see is the only one that
 		// can possibly contain key.
@@ -2153,9 +2151,11 @@ func (s *Store) lookupPrecedingReplica(key roachpb.RKey) *Replica {
 	defer s.mu.RUnlock()
 	var repl *Replica
 	s.mu.replicasByKey.DescendLessOrEqual(rangeBTreeKey(key), func(item btree.Item) bool {
-		var ok bool
-		repl, ok = item.(*Replica)
-		return !ok // keep iterating if not a *Replica
+		if r, ok := item.(*Replica); ok && !r.ContainsKey(key.AsRawKey()) {
+			repl = r
+			return false // stop iterating
+		}
+		return true // keep iterating
 	})
 	return repl
 }
@@ -2164,17 +2164,17 @@ func (s *Store) lookupPrecedingReplica(key roachpb.RKey) *Replica {
 // descriptor (or nil if no such KeyRange exists).
 func (s *Store) getOverlappingKeyRangeLocked(rngDesc *roachpb.RangeDescriptor) KeyRange {
 	var kr KeyRange
-
-	s.mu.replicasByKey.AscendGreaterOrEqual(rangeBTreeKey(rngDesc.StartKey.Next()),
+	s.mu.replicasByKey.DescendLessOrEqual(rangeBTreeKey(rngDesc.EndKey),
 		func(item btree.Item) bool {
-			kr = item.(KeyRange)
-			return false
+			if kr0 := item.(KeyRange); kr0.startKey().Less(rngDesc.EndKey) {
+				kr = kr0
+				return false // stop iterating
+			}
+			return true // keep iterating
 		})
-
-	if kr != nil && kr.Desc().StartKey.Less(rngDesc.EndKey) {
+	if kr != nil && rngDesc.StartKey.Less(kr.Desc().EndKey) {
 		return kr
 	}
-
 	return nil
 }
 
@@ -2444,12 +2444,6 @@ func (s *Store) SplitRange(
 		s.unlinkReplicaByRangeIDLocked(rightDesc.RangeID)
 	}
 
-	// Replace the end key of the original range with the start key of
-	// the new range. Reinsert the range since the btree is keyed by range end keys.
-	if kr := s.mu.replicasByKey.Delete(leftRepl); kr != leftRepl {
-		return errors.Errorf("replicasByKey unexpectedly contains %v instead of replica %s", kr, leftRepl)
-	}
-
 	leftRepl.setDescWithoutProcessUpdate(ctx, &newLeftDesc)
 
 	// Clear the LHS txn wait queue, to redirect to the RHS if
@@ -2472,10 +2466,6 @@ func (s *Store) SplitRange(
 	// spans that are now owned by the new range.
 	leftRepl.leaseholderStats.resetRequestCounts()
 	leftRepl.writeStats.splitRequestCounts(rightRepl.writeStats)
-
-	if kr := s.mu.replicasByKey.ReplaceOrInsert(leftRepl); kr != nil {
-		return errors.Errorf("replicasByKey unexpectedly contains %s when inserting replica %s", kr, leftRepl)
-	}
 
 	if err := s.addReplicaInternalLocked(rightRepl); err != nil {
 		return errors.Errorf("couldn't insert range %v in replicasByKey btree: %s", rightRepl, err)
@@ -2608,7 +2598,7 @@ func (s *Store) addReplicaInternalLocked(repl *Replica) error {
 
 	if exRngItem := s.mu.replicasByKey.ReplaceOrInsert(repl); exRngItem != nil {
 		return errors.Errorf("%s: cannot addReplicaInternalLocked; range for key %v already exists in replicasByKey btree", s,
-			exRngItem.(KeyRange).endKey())
+			exRngItem.(KeyRange).startKey())
 	}
 
 	return nil
@@ -2836,7 +2826,7 @@ func (s *Store) processRangeDescriptorUpdateLocked(ctx context.Context, repl *Re
 	}
 	if exRngItem := s.mu.replicasByKey.ReplaceOrInsert(repl); exRngItem != nil {
 		return errors.Errorf("range for key %v already exists in replicasByKey btree",
-			(exRngItem.(*Replica)).endKey())
+			(exRngItem.(*Replica)).startKey())
 	}
 
 	// Add the range to metrics and maybe gossip on capacity change.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2450,7 +2450,7 @@ func (s *Store) SplitRange(
 		return errors.Errorf("replicasByKey unexpectedly contains %v instead of replica %s", kr, leftRepl)
 	}
 
-	leftRepl.setDescWithoutProcessUpdate(&newLeftDesc)
+	leftRepl.setDescWithoutProcessUpdate(ctx, &newLeftDesc)
 
 	// Clear the LHS txn wait queue, to redirect to the RHS if
 	// appropriate. We do this after setDescWithoutProcessUpdate
@@ -2586,7 +2586,7 @@ func (s *Store) MergeRange(
 	}
 
 	// Update the subsuming range's descriptor.
-	return leftRepl.setDesc(&newLeftDesc)
+	return leftRepl.setDesc(ctx, &newLeftDesc)
 }
 
 // addReplicaInternalLocked adds the replica to the replicas map and the

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2444,7 +2444,7 @@ func (s *Store) SplitRange(
 		s.unlinkReplicaByRangeIDLocked(rightDesc.RangeID)
 	}
 
-	leftRepl.setDescWithoutProcessUpdate(ctx, &newLeftDesc)
+	leftRepl.setDesc(ctx, &newLeftDesc)
 
 	// Clear the LHS txn wait queue, to redirect to the RHS if
 	// appropriate. We do this after setDescWithoutProcessUpdate
@@ -2471,10 +2471,9 @@ func (s *Store) SplitRange(
 		return errors.Errorf("couldn't insert range %v in replicasByKey btree: %s", rightRepl, err)
 	}
 
-	// Update the max bytes and other information of the new range.
-	// This may not happen if the system config has not yet been loaded.
-	// Since this is done under the store lock, system config update will
-	// properly set these fields.
+	// Update the replica's cached byte thresholds. This is a no-op if the system
+	// config is not available, in which case we rely on the next gossip update
+	// to perform the update.
 	if err := rightRepl.updateRangeInfo(rightRepl.Desc()); err != nil {
 		return err
 	}
@@ -2482,8 +2481,7 @@ func (s *Store) SplitRange(
 	// Add the range to metrics and maybe gossip on capacity change.
 	s.metrics.ReplicaCount.Inc(1)
 	s.maybeGossipOnCapacityChange(ctx, rangeAddEvent)
-
-	return s.processRangeDescriptorUpdateLocked(ctx, leftRepl)
+	return nil
 }
 
 // MergeRange expands the left-hand replica, leftRepl, to absorb the right-hand
@@ -2576,7 +2574,8 @@ func (s *Store) MergeRange(
 	}
 
 	// Update the subsuming range's descriptor.
-	return leftRepl.setDesc(ctx, &newLeftDesc)
+	leftRepl.setDesc(ctx, &newLeftDesc)
+	return nil
 }
 
 // addReplicaInternalLocked adds the replica to the replicas map and the
@@ -2646,6 +2645,9 @@ func (s *Store) removePlaceholderLocked(ctx context.Context, rngID roachpb.Range
 	switch exRng := s.mu.replicasByKey.Delete(placeholder).(type) {
 	case *ReplicaPlaceholder:
 		delete(s.mu.replicaPlaceholders, rngID)
+		if exRng2 := s.getOverlappingKeyRangeLocked(&exRng.rangeDesc); exRng2 != nil {
+			log.Fatalf(ctx, "corrupted replicasByKey map: %s and %s overlapped", exRng, exRng2)
+		}
 		return true
 	case nil:
 		log.Fatalf(ctx, "r%d: placeholder not found", rngID)
@@ -2772,6 +2774,9 @@ func (s *Store) removeReplicaImpl(
 		// above. Nothing should have been able to change that.
 		log.Fatalf(ctx, "replica %+v unexpectedly overlapped by %+v", rep, placeholder)
 	}
+	if rep2 := s.getOverlappingKeyRangeLocked(desc); rep2 != nil {
+		log.Fatalf(ctx, "corrupted replicasByKey map: %s and %s overlapped", rep, rep2)
+	}
 	delete(s.mu.replicaPlaceholders, rep.RangeID)
 	// TODO(peter): Could release s.mu.Lock() here.
 	s.maybeGossipOnCapacityChange(ctx, rangeRemoveEvent)
@@ -2795,20 +2800,11 @@ func (s *Store) unlinkReplicaByRangeIDLocked(rangeID roachpb.RangeID) {
 	s.mu.replicas.Delete(int64(rangeID))
 }
 
-// processRangeDescriptorUpdate should be called whenever a replica's range
-// descriptor is updated, to update the store's maps of its ranges to match
-// the updated descriptor. Since the latter update requires acquiring the store
-// lock (which cannot always safely be done by replicas), this function call
-// should be deferred until it is safe to acquire the store lock.
-func (s *Store) processRangeDescriptorUpdate(ctx context.Context, repl *Replica) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.processRangeDescriptorUpdateLocked(ctx, repl)
-}
-
-// processRangeDescriptorUpdateLocked requires that Store.mu and Replica.raftMu
+// maybeMarkReplicaInitializedLocked should be called whenever a previously
+// unintialized replica has become initialized so that the store can update its
+// internal bookkeeping. It requires that Store.mu and Replica.raftMu
 // are locked.
-func (s *Store) processRangeDescriptorUpdateLocked(ctx context.Context, repl *Replica) error {
+func (s *Store) maybeMarkReplicaInitializedLocked(ctx context.Context, repl *Replica) error {
 	if !repl.IsInitialized() {
 		return errors.Errorf("attempted to process uninitialized range %s", repl)
 	}
@@ -2822,7 +2818,8 @@ func (s *Store) processRangeDescriptorUpdateLocked(ctx context.Context, repl *Re
 	delete(s.mu.uninitReplicas, rangeID)
 
 	if exRange := s.getOverlappingKeyRangeLocked(repl.Desc()); exRange != nil {
-		return errors.Errorf("%s: cannot processRangeDescriptorUpdate; range %s has overlapping range %s", s, repl, exRange.Desc())
+		return errors.Errorf("%s: cannot initialize replica; range %s has overlapping range %s",
+			s, repl, exRange.Desc())
 	}
 	if exRngItem := s.mu.replicasByKey.ReplaceOrInsert(repl); exRngItem != nil {
 		return errors.Errorf("range for key %v already exists in replicasByKey btree",
@@ -3609,33 +3606,6 @@ func (s *Store) processRaftSnapshotRequest(
 		}
 
 		if snapHeader.IsPreemptive() {
-			defer func() {
-				s.mu.Lock()
-				defer s.mu.Unlock()
-
-				// We need to remove the placeholder regardless of whether the snapshot
-				// applied successfully or not.
-				if addedPlaceholder {
-					// Clear the replica placeholder; we are about to swap it with a real replica.
-					if !s.removePlaceholderLocked(ctx, snapHeader.RaftMessageRequest.RangeID) {
-						log.Fatalf(ctx, "could not remove placeholder after preemptive snapshot")
-					}
-					if pErr == nil {
-						atomic.AddInt32(&s.counts.filledPlaceholders, 1)
-					} else {
-						atomic.AddInt32(&s.counts.removedPlaceholders, 1)
-					}
-					removePlaceholder = false
-				}
-
-				if pErr == nil {
-					// If the snapshot succeeded, process the range descriptor update.
-					if err := s.processRangeDescriptorUpdateLocked(ctx, r); err != nil {
-						pErr = roachpb.NewError(err)
-					}
-				}
-			}()
-
 			// Requiring that the Term is set in a message makes sure that we
 			// get all of Raft's internal safety checks (it confuses messages
 			// at term zero for internal messages). The sending side uses the
@@ -3742,14 +3712,13 @@ func (s *Store) processRaftSnapshotRequest(
 			); err != nil {
 				return roachpb.NewError(err)
 			}
+			// applySnapshot has already removed the placeholder.
+			removePlaceholder = false
 
 			// At this point, the Replica has data but no ReplicaID. We hope
 			// that it turns into a "real" Replica by means of receiving Raft
 			// messages addressed to it with a ReplicaID, but if that doesn't
 			// happen, at some point the Replica GC queue will have to grab it.
-			//
-			// NB: See the defer at the start of this block for the removal of the
-			// placeholder and processing of the range descriptor update.
 			return nil
 		}
 

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -697,8 +697,9 @@ func TestReplicasByKey(t *testing.T) {
 
 func TestStoreRemoveReplicaOldDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
+	defer stopper.Stop(ctx)
 	store, _ := createTestStore(t, stopper)
 
 	rep, err := store.GetReplica(1)
@@ -717,18 +718,18 @@ func TestStoreRemoveReplicaOldDescriptor(t *testing.T) {
 		}
 	}
 
-	if err := rep.setDesc(newDesc); err != nil {
+	if err := rep.setDesc(ctx, newDesc); err != nil {
 		t.Fatal(err)
 	}
 	expectedErr := "replica descriptor's ID has changed"
-	if err := store.RemoveReplica(context.Background(), rep, origDesc.NextReplicaID, RemoveOptions{
+	if err := store.RemoveReplica(ctx, rep, origDesc.NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); !testutils.IsError(err, expectedErr) {
 		t.Fatalf("expected error %q but got %v", expectedErr, err)
 	}
 
 	// Now try a fresh descriptor and succeed.
-	if err := store.RemoveReplica(context.Background(), rep, rep.Desc().NextReplicaID, RemoveOptions{
+	if err := store.RemoveReplica(ctx, rep, rep.Desc().NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Backport:
  * 2/2 commits from "storage: some minor cleanup" (#29680)
  * 1/1 commits from "storage: don't allow replicas to have a nil store in Replica.setDesc" (#30158)
  * 1/1 commits from "storage: key Store.replicasByKey by replica start key" (#30215)
  * 1/1 commits from "storage: deflake TestStoreRangeMergeRHSLeaseExpiration" (#30272)
  * 1/1 commits from "storage: clean up placeholder handling" (#30175)

Please see individual PRs for details.

/cc @cockroachdb/release
