### PR TITLE
sql: fix NOT IN () behavior in normalization

### DIFF
--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -471,7 +471,10 @@ func (expr *ComparisonExpr) normalize(v *NormalizeVisitor) TypedExpr {
 			}
 			if len(tupleCopy.D) == 0 {
 				// NULL IN <empty-tuple> is false.
-				return DBoolFalse
+				if expr.Operator == In {
+					return DBoolFalse
+				}
+				return DBoolTrue
 			}
 			if expr.TypedLeft() == DNull {
 				// NULL IN <non-empty-tuple> is NULL.

--- a/pkg/sql/sem/tree/normalize_test.go
+++ b/pkg/sql/sem/tree/normalize_test.go
@@ -96,6 +96,8 @@ func TestNormalizeExpr(t *testing.T) {
 		{`1 IN (3, 2, 1)`, `true`},
 		{`a IN (3, 2, 1)`, `a IN (1, 2, 3)`},
 		{`1 IN (1, 2, a)`, `1 IN (1, 2, a)`},
+		{`NULL IN ()`, `false`},
+		{`NULL NOT IN ()`, `true`},
 		{`NULL IN (1, 2, 3)`, `NULL`},
 		{`a IN (NULL)`, `NULL`},
 		{`a IN (NULL, NULL)`, `NULL`},


### PR DESCRIPTION
The NormalizeVisitor was incorrectly normalizing `NOT IN ()` to false
rather than true. It's unclear to me if this code path is currently
reachable, since there are existing logic tests which cover this case. I
only noticed the bug when I was experimenting with using normalization
on remote nodes during SQL execution.

Release note: None