### PR TITLE
opt: fix lookup join bug, cross-check logical props in testrace

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -352,31 +352,38 @@ func (b *Builder) buildSelect(ev memo.ExprView) (execPlan, error) {
 	}, nil
 }
 
+// applySimpleProject adds a simple projection on top of an existing plan.
+func (b *Builder) applySimpleProject(input execPlan, cols opt.ColSet) (execPlan, error) {
+	// We have only pass-through columns.
+	colList := make([]exec.ColumnOrdinal, 0, cols.Len())
+	var outputCols opt.ColMap
+	cols.ForEach(func(i int) {
+		outputCols.Set(i, len(colList))
+		colList = append(colList, input.getColumnOrdinal(opt.ColumnID(i)))
+	})
+	node, err := b.factory.ConstructSimpleProject(input.root, colList, nil /* colNames */)
+	if err != nil {
+		return execPlan{}, err
+	}
+	return execPlan{root: node, outputCols: outputCols}, nil
+}
+
 func (b *Builder) buildProject(ev memo.ExprView) (execPlan, error) {
 	input, err := b.buildRelational(ev.Child(0))
 	if err != nil {
 		return execPlan{}, err
 	}
-	var outputCols opt.ColMap
 	projections := ev.Child(1)
 	def := projections.Private().(*memo.ProjectionsOpDef)
 	if len(def.SynthesizedCols) == 0 {
 		// We have only pass-through columns.
-		cols := make([]exec.ColumnOrdinal, 0, def.PassthroughCols.Len())
-		def.PassthroughCols.ForEach(func(i int) {
-			outputCols.Set(i, len(cols))
-			cols = append(cols, input.getColumnOrdinal(opt.ColumnID(i)))
-		})
-		node, err := b.factory.ConstructSimpleProject(input.root, cols, nil /* colNames */)
-		if err != nil {
-			return execPlan{}, err
-		}
-		return execPlan{root: node, outputCols: outputCols}, nil
+		return b.applySimpleProject(input, def.PassthroughCols)
 	}
 
 	exprs := make(tree.TypedExprs, 0, len(def.SynthesizedCols)+def.PassthroughCols.Len())
 	colNames := make([]string, 0, len(exprs))
 	ctx := input.makeBuildScalarCtx()
+	var outputCols opt.ColMap
 	for i, col := range def.SynthesizedCols {
 		expr, err := b.buildScalar(&ctx, projections.Child(i))
 		if err != nil {
@@ -861,7 +868,10 @@ func (b *Builder) buildLookupJoin(ev memo.ExprView) (execPlan, error) {
 		keyCols[i] = input.getColumnOrdinal(c)
 	}
 
-	lookupCols, lookupColMap := b.getColumns(md, def.LookupCols, def.Table)
+	inputProps := ev.Child(0).Logical().Relational
+	lookupCols := def.Cols.Difference(inputProps.OutputCols)
+
+	lookupOrdinals, lookupColMap := b.getColumns(md, lookupCols, def.Table)
 	allCols := joinOutputMap(input.outputCols, lookupColMap)
 
 	res := execPlan{outputCols: allCols}
@@ -887,12 +897,17 @@ func (b *Builder) buildLookupJoin(ev memo.ExprView) (execPlan, error) {
 		tab,
 		tab.Index(def.Index),
 		keyCols,
-		lookupCols,
+		lookupOrdinals,
 		onExpr,
 		exec.OutputOrdering(reqOrdering),
 	)
 	if err != nil {
 		return execPlan{}, err
+	}
+
+	// Apply a post-projection if Cols doesn't contain all input columns.
+	if !inputProps.OutputCols.SubsetOf(def.Cols) {
+		return b.applySimpleProject(res, def.Cols)
 	}
 	return res, nil
 }

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -98,10 +98,11 @@ func (m *Memo) CheckExpr(eid ExprID) {
 
 	case opt.LookupJoinOp:
 		def := expr.Private(m).(*LookupJoinDef)
+		inputProps := m.GroupProperties(expr.AsLookupJoin().Input()).Relational
 		if len(def.KeyCols) == 0 {
 			panic(fmt.Sprintf("lookup join with no key columns"))
 		}
-		if def.LookupCols.Empty() {
+		if def.Cols.SubsetOf(inputProps.OutputCols) {
 			panic(fmt.Sprintf("lookup join with no lookup columns"))
 		}
 

--- a/pkg/sql/opt/memo/memo_format.go
+++ b/pkg/sql/opt/memo/memo_format.go
@@ -121,7 +121,7 @@ func (m *Memo) formatPrivate(f *memoFmtCtx, private interface{}, physProps *prop
 		fmt.Fprintf(f.buf, ",cols=%s", t.Cols)
 
 	case *LookupJoinDef:
-		fmt.Fprintf(f.buf, ",keyCols=%v,lookupCols=%s", t.KeyCols, t.LookupCols)
+		fmt.Fprintf(f.buf, ",keyCols=%v,outCols=%s", t.KeyCols, t.Cols)
 
 	case *ExplainOpDef:
 		propsStr := t.Props.String()

--- a/pkg/sql/opt/memo/private_defs.go
+++ b/pkg/sql/opt/memo/private_defs.go
@@ -308,11 +308,16 @@ type LookupJoinDef struct {
 	// index columns (or a prefix of them).
 	KeyCols opt.ColList
 
-	// LookupCols is the set of columns retrieved from the index. The LookupJoin
-	// operator produces the columns in its input plus these columns. This set may
-	// or may not contain the columns from the index we are using for the lookups
-	// (which correspond to KeyCols).
-	LookupCols opt.ColSet
+	// Cols is the set of columns produced by the lookup join. This set can
+	// contain columns from the input and columns from the index. Any columns not
+	// in the input are retrieved from the index.
+	//
+	// TODO(radu): this effectively allows an arbitrary projection; it should be
+	// just a LookupCols set indicating which columns we should add from the
+	// index. However, this requires extra Project operators in the lookup join
+	// exploration transforms which currently leads to problems related to lookup
+	// join statistics.
+	Cols opt.ColSet
 }
 
 // ExplainOpDef defines the value of the Def private field of the Explain operator.

--- a/pkg/sql/opt/memo/private_storage.go
+++ b/pkg/sql/opt/memo/private_storage.go
@@ -362,7 +362,7 @@ func (ps *privateStorage) internLookupJoinDef(def *LookupJoinDef) PrivateID {
 	// Add a separator between the list and the set. Note that the column IDs
 	// cannot be 0.
 	ps.keyBuf.writeUvarint(0)
-	ps.keyBuf.writeColSet(def.LookupCols)
+	ps.keyBuf.writeColSet(def.Cols)
 	typ := (*LookupJoinDef)(nil)
 	if id, ok := ps.privatesMap[privateKey{iface: typ, str: ps.keyBuf.String()}]; ok {
 		return id

--- a/pkg/sql/opt/memo/private_storage_test.go
+++ b/pkg/sql/opt/memo/private_storage_test.go
@@ -234,46 +234,46 @@ func TestLookupJoinDef(t *testing.T) {
 	}
 
 	def1 := &LookupJoinDef{
-		JoinType:   opt.InnerJoinOp,
-		Table:      0,
-		Index:      0,
-		KeyCols:    opt.ColList{10, 11},
-		LookupCols: util.MakeFastIntSet(1, 2),
+		JoinType: opt.InnerJoinOp,
+		Table:    0,
+		Index:    0,
+		KeyCols:  opt.ColList{10, 11},
+		Cols:     util.MakeFastIntSet(1, 2),
 	}
 	def2 := &LookupJoinDef{
-		JoinType:   opt.LeftJoinOp,
-		Table:      0,
-		Index:      0,
-		KeyCols:    opt.ColList{10, 11},
-		LookupCols: util.MakeFastIntSet(1, 2),
+		JoinType: opt.LeftJoinOp,
+		Table:    0,
+		Index:    0,
+		KeyCols:  opt.ColList{10, 11},
+		Cols:     util.MakeFastIntSet(1, 2),
 	}
 	def3 := &LookupJoinDef{
-		JoinType:   opt.InnerJoinOp,
-		Table:      1,
-		Index:      0,
-		KeyCols:    opt.ColList{10, 11},
-		LookupCols: util.MakeFastIntSet(1, 2),
+		JoinType: opt.InnerJoinOp,
+		Table:    1,
+		Index:    0,
+		KeyCols:  opt.ColList{10, 11},
+		Cols:     util.MakeFastIntSet(1, 2),
 	}
 	def4 := &LookupJoinDef{
-		JoinType:   opt.InnerJoinOp,
-		Table:      0,
-		Index:      1,
-		KeyCols:    opt.ColList{10, 11},
-		LookupCols: util.MakeFastIntSet(1, 2),
+		JoinType: opt.InnerJoinOp,
+		Table:    0,
+		Index:    1,
+		KeyCols:  opt.ColList{10, 11},
+		Cols:     util.MakeFastIntSet(1, 2),
 	}
 	def5 := &LookupJoinDef{
-		JoinType:   opt.InnerJoinOp,
-		Table:      0,
-		Index:      0,
-		KeyCols:    opt.ColList{10},
-		LookupCols: util.MakeFastIntSet(1, 2),
+		JoinType: opt.InnerJoinOp,
+		Table:    0,
+		Index:    0,
+		KeyCols:  opt.ColList{10},
+		Cols:     util.MakeFastIntSet(1, 2),
 	}
 	def6 := &LookupJoinDef{
-		JoinType:   opt.InnerJoinOp,
-		Table:      0,
-		Index:      0,
-		KeyCols:    opt.ColList{10, 11},
-		LookupCols: util.MakeFastIntSet(1, 2, 3),
+		JoinType: opt.InnerJoinOp,
+		Table:    0,
+		Index:    0,
+		KeyCols:  opt.ColList{10, 11},
+		Cols:     util.MakeFastIntSet(1, 2, 3),
 	}
 	testEQ(def1, def1)
 	testNE(def1, def2)
@@ -915,7 +915,7 @@ func TestPrivateStorageAllocations(t *testing.T) {
 		RightOrdering: props.ParseOrderingChoice("+4,+5,+6"),
 	}
 	indexJoinDef := &IndexJoinDef{Table: 1, Cols: colSet}
-	lookupJoinDef := &LookupJoinDef{Table: 1, Index: 2, KeyCols: colList, LookupCols: colSet}
+	lookupJoinDef := &LookupJoinDef{Table: 1, Index: 2, KeyCols: colList, Cols: colSet}
 	subqueryDef := &SubqueryDef{OriginalExpr: &tree.Subquery{}, Cmp: opt.LtOp}
 	setOpColMap := &SetOpColMap{Left: colList, Right: colList, Out: colList}
 	datum := tree.NewDInt(1)
@@ -977,7 +977,7 @@ func BenchmarkPrivateStorage(b *testing.B) {
 		RightOrdering: props.ParseOrderingChoice("+4,+5,+6"),
 	}
 	indexJoinDef := &IndexJoinDef{Table: 1, Cols: colSet}
-	lookupJoinDef := &LookupJoinDef{Table: 1, Index: 2, KeyCols: colList, LookupCols: colSet}
+	lookupJoinDef := &LookupJoinDef{Table: 1, Index: 2, KeyCols: colList, Cols: colSet}
 	subqueryDef := &SubqueryDef{OriginalExpr: &tree.Subquery{}, Cmp: opt.LtOp}
 	setOpColMap := &SetOpColMap{Left: colList, Right: colList, Out: colList}
 	datum := tree.NewDInt(1)

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -278,6 +278,9 @@ func (sb *statisticsBuilder) colStat(colSet opt.ColSet, ev ExprView) *props.Colu
 		opt.LookupJoinOp:
 		return sb.colStatJoin(colSet, ev)
 
+	case opt.IndexJoinOp:
+		return sb.colStatIndexJoin(colSet, ev)
+
 	case opt.UnionOp, opt.IntersectOp, opt.ExceptOp,
 		opt.UnionAllOp, opt.IntersectAllOp, opt.ExceptAllOp:
 		return sb.colStatSetOp(colSet, ev)
@@ -839,6 +842,18 @@ func (sb *statisticsBuilder) buildIndexJoin(ev ExprView, relProps *props.Relatio
 
 	s.RowCount = inputStats.RowCount
 	sb.finalizeFromCardinality(relProps)
+}
+
+func (sb *statisticsBuilder) colStatIndexJoin(
+	colSet opt.ColSet, ev ExprView,
+) *props.ColumnStatistic {
+	relProps := ev.Logical().Relational
+	s := &relProps.Stats
+
+	// TODO(#30288): implement this.
+	colStat, _ := s.ColStats.Add(colSet)
+	colStat.DistinctCount = 1
+	return colStat
 }
 
 // +----------+

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -210,10 +210,11 @@ func (sb *statisticsBuilder) colStatFromInput(
 	}
 
 	if lookupJoinDef != nil || ev.IsJoin() {
-		intersectsLeft := ev.Child(0).Logical().Relational.OutputCols.Intersects(colSet)
+		leftProps := ev.Child(0).Logical().Relational
+		intersectsLeft := leftProps.OutputCols.Intersects(colSet)
 		var intersectsRight bool
 		if lookupJoinDef != nil {
-			intersectsRight = lookupJoinDef.LookupCols.Intersects(colSet)
+			intersectsRight = lookupJoinDef.Cols.Difference(leftProps.OutputCols).Intersects(colSet)
 		} else {
 			intersectsRight = ev.Child(1).Logical().Relational.OutputCols.Intersects(colSet)
 		}
@@ -744,11 +745,11 @@ func (sb *statisticsBuilder) colStatJoin(colSet opt.ColSet, ev ExprView) *props.
 		leftCols.IntersectionWith(colSet)
 		var rightCols opt.ColSet
 		if lookupJoinDef == nil {
-			rightCols = ev.Child(1).Logical().Relational.OutputCols.Copy()
+			rightCols = ev.Child(1).Logical().Relational.OutputCols.Intersection(colSet)
 		} else {
-			rightCols = lookupJoinDef.LookupCols.Copy()
+			rightCols = lookupJoinDef.Cols.Intersection(colSet)
+			rightCols.DifferenceWith(leftCols)
 		}
-		rightCols.IntersectionWith(colSet)
 
 		// Join selectivity affects the distinct counts for different columns
 		// in different ways depending on the type of join.

--- a/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
@@ -694,7 +694,7 @@ func (g *ruleGen) genExploreReplace(define *lang.DefineExpr, rule *lang.RuleExpr
 		}
 		g.w.unnest(")\n")
 		g.w.writeIndent("_before := _e.mem.ExprCount(_root.Group)\n")
-		g.w.writeIndent("_e.mem.MemoizeDenormExpr(_root.Group, memo.Expr(_expr))\n")
+		g.w.writeIndent("_e.mem.MemoizeDenormExpr(_e.evalCtx, _root.Group, memo.Expr(_expr))\n")
 
 	case *lang.CustomFuncExpr:
 		// Top-level custom function returns a memo.Expr slice, so iterate
@@ -705,7 +705,7 @@ func (g *ruleGen) genExploreReplace(define *lang.DefineExpr, rule *lang.RuleExpr
 		g.w.newline()
 		g.w.writeIndent("_before := _e.mem.ExprCount(_root.Group)\n")
 		g.w.nestIndent("for i := range _exprs {\n")
-		g.w.writeIndent("_e.mem.MemoizeDenormExpr(_root.Group, _exprs[i])\n")
+		g.w.writeIndent("_e.mem.MemoizeDenormExpr(_e.evalCtx, _root.Group, _exprs[i])\n")
 		g.w.unnest("}\n")
 
 	default:

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/explorer
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/explorer
@@ -176,7 +176,7 @@ func (_e *explorer) exploreInnerJoin(_rootState *exploreState, _root memo.ExprID
 					r,
 				)
 				_before := _e.mem.ExprCount(_root.Group)
-				_e.mem.MemoizeDenormExpr(_root.Group, memo.Expr(_expr))
+				_e.mem.MemoizeDenormExpr(_e.evalCtx, _root.Group, memo.Expr(_expr))
 				if _e.o.appliedRule != nil {
 					_after := _e.mem.ExprCount(_root.Group)
 					_e.o.appliedRule(opt.CommuteJoin, _root.Group, _root.Expr, _after-_before)
@@ -229,7 +229,7 @@ func (_e *explorer) exploreInnerJoin(_rootState *exploreState, _root memo.ExprID
 										),
 									)
 									_before := _e.mem.ExprCount(_root.Group)
-									_e.mem.MemoizeDenormExpr(_root.Group, memo.Expr(_expr))
+									_e.mem.MemoizeDenormExpr(_e.evalCtx, _root.Group, memo.Expr(_expr))
 									if _e.o.appliedRule != nil {
 										_after := _e.mem.ExprCount(_root.Group)
 										_e.o.appliedRule(opt.AssociateJoin, _root.Group, _root.Expr, _after-_before)
@@ -296,7 +296,7 @@ func (_e *explorer) exploreSelect(_rootState *exploreState, _root memo.ExprID) (
 									on,
 								)
 								_before := _e.mem.ExprCount(_root.Group)
-								_e.mem.MemoizeDenormExpr(_root.Group, memo.Expr(_expr))
+								_e.mem.MemoizeDenormExpr(_e.evalCtx, _root.Group, memo.Expr(_expr))
 								if _e.o.appliedRule != nil {
 									_after := _e.mem.ExprCount(_root.Group)
 									_e.o.appliedRule(opt.PushDownGroupBy, _root.Group, _root.Expr, _after-_before)
@@ -325,7 +325,7 @@ func (_e *explorer) exploreScan(_rootState *exploreState, _root memo.ExprID) (_f
 					_exprs := _e.funcs.GenerateIndexScans(def)
 					_before := _e.mem.ExprCount(_root.Group)
 					for i := range _exprs {
-						_e.mem.MemoizeDenormExpr(_root.Group, _exprs[i])
+						_e.mem.MemoizeDenormExpr(_e.evalCtx, _root.Group, _exprs[i])
 					}
 					if _e.o.appliedRule != nil {
 						_after := _e.mem.ExprCount(_root.Group)
@@ -402,7 +402,7 @@ func (_e *explorer) exploreList(_rootState *exploreState, _root memo.ExprID) (_f
 																_exprs := _e.funcs.Construct(any, first, last, single, empty)
 																_before := _e.mem.ExprCount(_root.Group)
 																for i := range _exprs {
-																	_e.mem.MemoizeDenormExpr(_root.Group, _exprs[i])
+																	_e.mem.MemoizeDenormExpr(_e.evalCtx, _root.Group, _exprs[i])
 																}
 																if _e.o.appliedRule != nil {
 																	_after := _e.mem.ExprCount(_root.Group)
@@ -465,7 +465,7 @@ func (_e *explorer) exploreOp(_rootState *exploreState, _root memo.ExprID) (_ful
 										single,
 									)
 									_before := _e.mem.ExprCount(_root.Group)
-									_e.mem.MemoizeDenormExpr(_root.Group, memo.Expr(_expr))
+									_e.mem.MemoizeDenormExpr(_e.evalCtx, _root.Group, memo.Expr(_expr))
 									if _e.o.appliedRule != nil {
 										_after := _e.mem.ExprCount(_root.Group)
 										_e.o.appliedRule(opt.ListNot, _root.Group, _root.Expr, _after-_before)
@@ -554,7 +554,7 @@ func (_e *explorer) exploreInnerJoin(_rootState *exploreState, _root memo.ExprID
 					_e.funcs.MakeOn(varname, varname2),
 				)
 				_before := _e.mem.ExprCount(_root.Group)
-				_e.mem.MemoizeDenormExpr(_root.Group, memo.Expr(_expr))
+				_e.mem.MemoizeDenormExpr(_e.evalCtx, _root.Group, memo.Expr(_expr))
 				if _e.o.appliedRule != nil {
 					_after := _e.mem.ExprCount(_root.Group)
 					_e.o.appliedRule(opt.BindVarsOp, _root.Group, _root.Expr, _after-_before)
@@ -575,7 +575,7 @@ func (_e *explorer) exploreInnerJoin(_rootState *exploreState, _root memo.ExprID
 				_exprs := _e.funcs.TopLevelFunc(varname, varname2, _e.funcs.MakeOn(varname, varname2))
 				_before := _e.mem.ExprCount(_root.Group)
 				for i := range _exprs {
-					_e.mem.MemoizeDenormExpr(_root.Group, _exprs[i])
+					_e.mem.MemoizeDenormExpr(_e.evalCtx, _root.Group, _exprs[i])
 				}
 				if _e.o.appliedRule != nil {
 					_after := _e.mem.ExprCount(_root.Group)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -87,7 +87,7 @@ memo
 SELECT * FROM abc JOIN xyz ON a=z
 ----
 memo (optimized, ~9KB)
- ├── G1: (inner-join G2 G4 G5) (inner-join G4 G2 G5) (merge-join G2 G4 G3) (lookup-join G4 G5 abc@ab,keyCols=[7],lookupCols=(1-3))
+ ├── G1: (inner-join G2 G4 G5) (inner-join G4 G2 G5) (merge-join G2 G4 G3) (lookup-join G4 G5 abc@ab,keyCols=[7],outCols=(1-3,5-7))
  │    └── "[presentation: a:1,b:2,c:3,x:5,y:6,z:7]"
  │         ├── best: (inner-join G2 G4 G5)
  │         └── cost: 2270.00
@@ -229,7 +229,7 @@ memo
 SELECT * FROM abc RIGHT OUTER JOIN xyz ON a=z
 ----
 memo (optimized, ~9KB)
- ├── G1: (right-join G2 G4 G5) (left-join G4 G2 G5) (merge-join G2 G4 G3) (lookup-join G4 G5 abc@ab,keyCols=[7],lookupCols=(1-3))
+ ├── G1: (right-join G2 G4 G5) (left-join G4 G2 G5) (merge-join G2 G4 G3) (lookup-join G4 G5 abc@ab,keyCols=[7],outCols=(1-3,5-7))
  │    └── "[presentation: a:1,b:2,c:3,x:5,y:6,z:7]"
  │         ├── best: (right-join G2 G4 G5)
  │         └── cost: 2270.00
@@ -294,7 +294,7 @@ memo
 SELECT * FROM abc JOIN xyz ON a=x
 ----
 memo (optimized, ~10KB)
- ├── G1: (inner-join G3 G5 G6) (inner-join G5 G3 G6) (merge-join G3 G5 G2) (lookup-join G3 G6 xyz@xy,keyCols=[1],lookupCols=(5-7)) (merge-join G5 G3 G4) (lookup-join G5 G6 abc@ab,keyCols=[5],lookupCols=(1-3))
+ ├── G1: (inner-join G3 G5 G6) (inner-join G5 G3 G6) (merge-join G3 G5 G2) (lookup-join G3 G6 xyz@xy,keyCols=[1],outCols=(1-3,5-7)) (merge-join G5 G3 G4) (lookup-join G5 G6 abc@ab,keyCols=[5],outCols=(1-3,5-7))
  │    └── "[presentation: a:1,b:2,c:3,x:5,y:6,z:7]"
  │         ├── best: (merge-join G3="[ordering: +1]" G5="[ordering: +5]" G2)
  │         └── cost: 2260.00
@@ -382,7 +382,7 @@ memo
 SELECT * FROM stu AS l JOIN stu AS r ON (l.s, l.t, l.u) = (r.s, r.t, r.u)
 ----
 memo (optimized, ~15KB)
- ├── G1: (inner-join G5 G7 G8) (inner-join G7 G5 G8) (merge-join G5 G7 G2) (merge-join G5 G7 G3) (lookup-join G5 G8 stu,keyCols=[1 2 3],lookupCols=(4-6)) (lookup-join G5 G8 stu@uts,keyCols=[3 2 1],lookupCols=(4-6)) (merge-join G7 G5 G4) (merge-join G7 G5 G6) (lookup-join G7 G8 stu,keyCols=[4 5 6],lookupCols=(1-3)) (lookup-join G7 G8 stu@uts,keyCols=[6 5 4],lookupCols=(1-3))
+ ├── G1: (inner-join G5 G7 G8) (inner-join G7 G5 G8) (merge-join G5 G7 G2) (merge-join G5 G7 G3) (lookup-join G5 G8 stu,keyCols=[1 2 3],outCols=(1-6)) (lookup-join G5 G8 stu@uts,keyCols=[3 2 1],outCols=(1-6)) (merge-join G7 G5 G4) (merge-join G7 G5 G6) (lookup-join G7 G8 stu,keyCols=[4 5 6],outCols=(1-6)) (lookup-join G7 G8 stu@uts,keyCols=[6 5 4],outCols=(1-6))
  │    └── "[presentation: s:1,t:2,u:3,s:4,t:5,u:6]"
  │         ├── best: (merge-join G5="[ordering: +1,+2,+3]" G7="[ordering: +4,+5,+6]" G2)
  │         └── cost: 2140.01


### PR DESCRIPTION
#### opt: fix lookup join generating extra column

A separate change that cross-checks logical properties across
expressions in a group revealed that in some cases we have a lookup
join expression which generates more columns than in OutputCols.

The case is when we are using a non-covering secondary index, and not
all PK columns were output columns of the original join. For example:

```
CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX (b));
CREATE TABLE x (x INT);
SELECT b, c, x FROM abc JOIN x ON x=b;
```

The plan here would be to do a lookup in the index on `b` and
index-join those results to get the corresponding values of `c`:

```
inner-join (lookup abc)
 ├── columns: b:2(int!null) c:3(int) x:4(int!null)
 ├── key columns: [1] = [1]
 ├── fd: (2)==(4), (4)==(2)
 ├── inner-join (lookup abc@secondary)
 │    ├── columns: a:1(int!null) b:2(int!null) x:4(int!null)
 │    ├── key columns: [4] = [2]
 │    ├── fd: (1)-->(2), (2)==(4), (4)==(2)
 │    ├── scan x
 │    │    └── columns: x:4(int)
 │    └── filters [type=bool, outer=(2,4), constraints=(/2: (/NULL - ]; /4: (/NULL - ]), fd=(2)==(4), (4)==(2)]
 │         └── x = b [type=bool, outer=(2,4), constraints=(/2: (/NULL - ]; /4: (/NULL - ])]
 └── true [type=bool]
```

The top lookup join would also produce column `a`, which is not an
`OutputCol` of the original join. Note that in practice I wasn't able
to observe a problem caused by this bug; the execbuilder seems to
tolerate extra columns just fine (though it's possible there are
cornercases where things could blow up).

Normally the fix for this problem would be to simply add a `ProjectOp`
on top of the lookup join. However, going down that path results in a
lot of problems related to statistics - the lookup join would use its
own derived statistics (since it would be in a separate group) and
that results in much larger costs. Trying to address that problem (by
taking into account that the equality columns form a key) opened up
other problems, affecting many plans.

This change fixes this issue by changing the `LookupJoin` semantics to
effectively include a projection. In the future, we can revert this
change once we address the stat issues.

Release note: None

#### opt: cross-check logical properties within memo groups

This change adds testrace-only code to cross-check logical properties
whenever we add a denormalized expression to a group (during
exploration).

Release note: None
