### PR TITLE
cdc: Test for feed falling behind table GC

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4594,6 +4594,28 @@ func (s *Store) ManuallyEnqueue(
 	return collect(), "", nil
 }
 
+// ManuallyEnqueueSpan runs all replicas in the supplied span through the named
+// queue. This is currently intended for use in internal tests which have access
+// to the store directly.
+func (s *Store) ManuallyEnqueueSpan(
+	ctx context.Context, queueName string, span roachpb.RSpan, skipShouldQueue bool,
+) error {
+	var outerErr error
+	newStoreReplicaVisitor(s).Visit(func(repl *Replica) bool {
+		desc := repl.Desc()
+		if bytes.Compare(span.Key, desc.EndKey) >= 0 || bytes.Compare(desc.StartKey, span.EndKey) >= 0 {
+			return true // continue
+		}
+
+		if _, _, err := s.ManuallyEnqueue(ctx, queueName, repl, skipShouldQueue); err != nil {
+			outerErr = err
+			return false
+		}
+		return true
+	})
+	return outerErr
+}
+
 // WriteClusterVersion writes the given cluster version to the store-local cluster version key.
 func WriteClusterVersion(
 	ctx context.Context, writer engine.ReadWriter, cv cluster.ClusterVersion,


### PR DESCRIPTION
Constructs a test which verifies that Changefeeds exit with an error if
they fall behind the GC TTL of the table data being read.

In order to test this correctly, a new "ManuallyEnqueueSpan()" function
has been added to the Store object, intended for internal tests with
access to the Store to manually force any replicas in the provided span
through a specific replica queue.

Release note: None