### PR TITLE
release-2.1: cli: avoid logging during flag initialization

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -429,15 +429,11 @@ func Example_logging() {
 	defer c.cleanup()
 
 	c.RunWithArgs([]string{`sql`, `--logtostderr=false`, `-e`, `select 1 as "1"`})
-	c.RunWithArgs([]string{`sql`, `--log-dir=`, `-e`, `select 1 as "1"`})
 	c.RunWithArgs([]string{`sql`, `--logtostderr=true`, `-e`, `select 1 as "1"`})
 	c.RunWithArgs([]string{`sql`, `--vmodule=foo=1`, `-e`, `select 1 as "1"`})
 
 	// Output:
 	// sql --logtostderr=false -e select 1 as "1"
-	// 1
-	// 1
-	// sql --log-dir= -e select 1 as "1"
 	// 1
 	// 1
 	// sql --logtostderr=true -e select 1 as "1"
@@ -1822,10 +1818,6 @@ Available Commands:
 
 Flags:
   -h, --help                             help for cockroach
-      --log-dir string                   if non-empty, write log files in this directory
-      --log-dir-max-size bytes           maximum combined size of all log files (default 100 MiB)
-      --log-file-max-size bytes          maximum size of each log file (default 10 MiB)
-      --log-file-verbosity Severity      minimum verbosity of messages written to the log file (default INFO)
       --logtostderr Severity[=DEFAULT]   logs at or above this threshold go to stderr (default NONE)
       --no-color                         disable standard error log colorization
 

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -790,4 +790,33 @@ in the history of the cluster.`,
 		Name:        "align",
 		Description: `Align the output.`,
 	}
+
+	LogDir = FlagInfo{
+		Name: "log-dir",
+		Description: `
+If non-empty, write log files in this directory. If empty, write log files to
+<store-dir>/logs where <store-dir> is the directory of the first on disk store.
+`,
+	}
+
+	LogDirMaxSize = FlagInfo{
+		Name: "log-dir-max-size",
+		Description: `
+Maximum combined size of all log files.
+`,
+	}
+
+	LogFileMaxSize = FlagInfo{
+		Name: "log-file-max-size",
+		Description: `
+Maximum size of each log file.
+`,
+	}
+
+	LogFileVerbosity = FlagInfo{
+		Name: "log-file-verbosity",
+		Description: `
+Minimum verbosity of messages written to the log file.
+`,
+	}
 )

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -271,6 +271,10 @@ var startCtx struct {
 	// pidFile indicates the file to which the server writes its PID
 	// when it is ready.
 	pidFile string
+
+	// logging settings specific to file logging.
+	logDir     log.DirName
+	logDirFlag *pflag.Flag
 }
 
 // quitCtx captures the command-line parameters of the `quit` command.

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -74,7 +74,7 @@ func setupTransientServer(
 	cleanup = func() {}
 	ctx := context.Background()
 
-	df := cmd.Flags().Lookup(logflags.LogDirName)
+	df := startCtx.logDirFlag
 	sf := cmd.Flags().Lookup(logflags.LogToStderrName)
 	if !df.Changed && !sf.Changed {
 		// User did not request logging flags; shut down logging under

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -235,13 +235,17 @@ func init() {
 			// is only overriding the default value for the pflag package (and what
 			// is visible in help text), not the stdlib flag value.
 			flag.DefValue = "NONE"
+		case logflags.LogDirName,
+			logflags.LogFileMaxSizeName,
+			logflags.LogFilesCombinedMaxSizeName,
+			logflags.LogFileVerbosityThresholdName:
+			// The --log-dir* and --log-file* flags are specified only for the
+			// `start` and `demo` commands.
+			return
 		}
 		pf.AddFlag(flag)
 	})
 
-	// The --log-dir default changes depending on the command. Avoid confusion by
-	// simply clearing it.
-	pf.Lookup(logflags.LogDirName).DefValue = ""
 	// When a flag is specified but without a value, pflag assigns its
 	// NoOptDefVal to it via Set(). This is also the value used to
 	// generate the implicit assigned value in the usage text
@@ -332,6 +336,22 @@ func init() {
 		StringFlag(f, &startCtx.externalIODir, cliflags.ExternalIODir, startCtx.externalIODir)
 
 		VarFlag(f, serverCfg.SQLAuditLogDirName, cliflags.SQLAuditLogDirName)
+	}
+
+	// Log flags.
+	for _, cmd := range []*cobra.Command{demoCmd, StartCmd} {
+		f := cmd.Flags()
+		VarFlag(f, &startCtx.logDir, cliflags.LogDir)
+		startCtx.logDirFlag = f.Lookup(cliflags.LogDir.Name)
+		VarFlag(f,
+			pflag.PFlagFromGoFlag(flag.Lookup(logflags.LogFilesCombinedMaxSizeName)).Value,
+			cliflags.LogDirMaxSize)
+		VarFlag(f,
+			pflag.PFlagFromGoFlag(flag.Lookup(logflags.LogFileMaxSizeName)).Value,
+			cliflags.LogFileMaxSize)
+		VarFlag(f,
+			pflag.PFlagFromGoFlag(flag.Lookup(logflags.LogFileVerbosityThresholdName)).Value,
+			cliflags.LogFileVerbosity)
 	}
 
 	for _, cmd := range certCmds {

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
 )
 
 func TestStdFlagToPflag(t *testing.T) {
@@ -39,6 +40,13 @@ func TestStdFlagToPflag(t *testing.T) {
 	cf := cockroachCmd.PersistentFlags()
 	flag.VisitAll(func(f *flag.Flag) {
 		if strings.HasPrefix(f.Name, "test.") {
+			return
+		}
+		switch f.Name {
+		case logflags.LogDirName,
+			logflags.LogFileMaxSizeName,
+			logflags.LogFilesCombinedMaxSizeName,
+			logflags.LogFileVerbosityThresholdName:
 			return
 		}
 		if pf := cf.Lookup(f.Name); pf == nil {

--- a/pkg/cli/flags_util.go
+++ b/pkg/cli/flags_util.go
@@ -15,7 +15,6 @@
 package cli
 
 import (
-	"context"
 	gohex "encoding/hex"
 	"fmt"
 	"math"
@@ -387,7 +386,7 @@ type percentResolverFunc func(percent int) (int64, error)
 // memoryPercentResolver turns a percent into the respective fraction of the
 // system's internal memory.
 func memoryPercentResolver(percent int) (int64, error) {
-	sizeBytes, err := status.GetTotalMemory(context.TODO())
+	sizeBytes, _, err := status.GetTotalMemoryWithoutLogging()
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -961,7 +961,7 @@ func maybeWarnMemorySizes(ctx context.Context) {
 }
 
 func logOutputDirectory() string {
-	return cockroachCmd.PersistentFlags().Lookup(logflags.LogDirName).Value.String()
+	return startCtx.logDir.String()
 }
 
 // setupAndInitializeLoggingAndProfiling does what it says on the label.
@@ -974,9 +974,7 @@ func setupAndInitializeLoggingAndProfiling(ctx context.Context) (*stop.Stopper, 
 	// non-memory store. If more than one non-memory stores is detected,
 	// print a warning.
 	ambiguousLogDirs := false
-	pf := cockroachCmd.PersistentFlags()
-	f := pf.Lookup(logflags.LogDirName)
-	if !log.DirSet() && !f.Changed {
+	if !startCtx.logDir.IsSet() && !startCtx.logDirFlag.Changed {
 		// We only override the log directory if the user has not explicitly
 		// disabled file logging using --log-dir="".
 		newDir := ""
@@ -990,20 +988,29 @@ func setupAndInitializeLoggingAndProfiling(ctx context.Context) (*stop.Stopper, 
 			}
 			newDir = filepath.Join(spec.Path, "logs")
 		}
-		if err := f.Value.Set(newDir); err != nil {
+		if err := startCtx.logDir.Set(newDir); err != nil {
 			return nil, err
 		}
 	}
 
-	if logDir := f.Value.String(); logDir != "" {
-
-		ls := pf.Lookup(logflags.LogToStderrName)
+	if logDir := startCtx.logDir.String(); logDir != "" {
+		ls := cockroachCmd.PersistentFlags().Lookup(logflags.LogToStderrName)
 		if !ls.Changed {
 			// Unless the settings were overridden by the user, silence
 			// logging to stderr because the messages will go to a log file.
 			if err := ls.Value.Set(log.Severity_NONE.String()); err != nil {
 				return nil, err
 			}
+		}
+
+		// Note that we configured the --log-dir flag to set
+		// startContext.logDir. This is the point at which we set log-dir for the
+		// util/log package. We don't want to set it earlier to avoid spuriously
+		// creating a file in an incorrect log directory or if something is
+		// accidentally logging after flag parsing but before the --background
+		// dispatch has occurred.
+		if err := flag.Lookup(logflags.LogDirName).Value.Set(logDir); err != nil {
+			return nil, err
 		}
 
 		// Make sure the path exists.


### PR DESCRIPTION
Backport 2/2 commits from #30123.

/cc @cockroachdb/release

---

Avoid logging during flag initialization which happens before we've had
a chance to examine the --background flag. This was spuriously creating
a log file that was mostly empty.

Fixes #30120

Release note: None
