### PR TITLE
release-2.1: opt: fix bug in lookup join column stat

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -719,13 +719,16 @@ func (sb *statisticsBuilder) colStatJoin(colSet opt.ColSet, ev ExprView) *props.
 	relProps := ev.Logical().Relational
 	s := &relProps.Stats
 	leftStats := &ev.childGroup(0).logical.Relational.Stats
-	rightStats := &ev.childGroup(1).logical.Relational.Stats
 
 	var lookupJoinDef *LookupJoinDef
+	var rightStats *props.Statistics
 	joinType := ev.Operator()
 	if joinType == opt.LookupJoinOp {
 		lookupJoinDef = ev.Private().(*LookupJoinDef)
 		joinType = lookupJoinDef.JoinType
+		rightStats = sb.makeTableStatistics(lookupJoinDef.Table)
+	} else {
+		rightStats = &ev.childGroup(1).logical.Relational.Stats
 	}
 
 	switch joinType {

--- a/pkg/sql/opt/memo/testdata/stats/lookup-join
+++ b/pkg/sql/opt/memo/testdata/stats/lookup-join
@@ -252,3 +252,21 @@ inner-join (merge)
       ├── right ordering: +5
       └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
            └── a = e [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+
+# Check column statistics for lookup join.
+opt colstat=1 colstat=2 colstat=3 colstat=4 colstat=5 colstat=6 colstat=(2,5,6)
+SELECT * FROM abc JOIN DEF ON a = f
+----
+inner-join (lookup def)
+ ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) e:5(int!null) f:6(int!null)
+ ├── key columns: [1] = [6]
+ ├── stats: [rows=100, distinct(1)=100, distinct(2)=9.99954623, distinct(3)=9.99954623, distinct(4)=95.1671064, distinct(5)=63.2138954, distinct(6)=100, distinct(2,5,6)=100]
+ ├── key: (3,5,6)
+ ├── fd: (1,3)-->(2), (5,6)-->(4), (1)==(6), (6)==(1)
+ ├── scan abc
+ │    ├── columns: a:1(int!null) b:2(int) c:3(int!null)
+ │    ├── stats: [rows=100, distinct(1)=100, distinct(2)=10, distinct(3)=10]
+ │    ├── key: (1,3)
+ │    └── fd: (1,3)-->(2)
+ └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+      └── a = f [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]


### PR DESCRIPTION
Backport 1/1 commits from #30276.

/cc @cockroachdb/release

---

Fixing a crash in `colStatJoin` for the lookup join case and adding a
test.

Release note: None
