### PR TITLE
release-2.1: opt: fix panic with srfs and aggregates

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -1724,3 +1724,9 @@ query T
 SELECT string_agg('foo', CAST ((SELECT NULL) AS BYTES)) OVER ();
 ----
 foo
+
+# Regression test for #30166.
+query T
+SELECT array_agg(generate_series(1, 2))
+----
+{1,2}

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -232,6 +232,9 @@ func (b *Builder) buildAggregation(
 	b.buildProjectionList(fromScope, projectionsScope)
 	b.buildOrderBy(fromScope, projectionsScope, orderByScope)
 	b.buildDistinctOnArgs(fromScope, projectionsScope, distinctOnScope)
+	if len(fromScope.srfs) > 0 {
+		fromScope.group = b.constructProjectSet(fromScope.group, fromScope.srfs)
+	}
 
 	aggInfos := aggOutScope.groupby.aggs
 

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -868,7 +868,7 @@ func (s *scope) replaceAggregate(f *tree.FuncExpr, def *tree.FunctionDefinition)
 	defer s.builder.semaCtx.Properties.Restore(s.builder.semaCtx.Properties)
 
 	s.builder.semaCtx.Properties.Require(s.context,
-		tree.RejectNestedAggregates|tree.RejectWindowApplications|tree.RejectGenerators)
+		tree.RejectNestedAggregates|tree.RejectWindowApplications)
 
 	expr := f.Walk(s)
 	typedFunc, err := tree.TypeCheck(expr, s.builder.semaCtx, types.Any)

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -450,11 +450,10 @@ func (b *Builder) buildSelectClause(
 		b.buildProjectionList(fromScope, projectionsScope)
 		b.buildOrderBy(fromScope, projectionsScope, orderByScope)
 		b.buildDistinctOnArgs(fromScope, projectionsScope, distinctOnScope)
+		if len(fromScope.srfs) > 0 {
+			fromScope.group = b.constructProjectSet(fromScope.group, fromScope.srfs)
+		}
 		outScope = fromScope
-	}
-
-	if len(fromScope.srfs) > 0 {
-		outScope.group = b.constructProjectSet(outScope.group, fromScope.srfs)
 	}
 
 	// Construct the projection.

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -2852,3 +2852,23 @@ scalar-group-by
  └── aggregations
       └── array-agg [type=int[]]
            └── variable: y [type=int]
+
+# Regression test for #30166.
+build
+SELECT array_agg(generate_series(1, 2))
+----
+scalar-group-by
+ ├── columns: array_agg:2(int[])
+ ├── inner-join-apply
+ │    ├── columns: generate_series:1(int)
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    ├── zip
+ │    │    ├── columns: generate_series:1(int)
+ │    │    └── function: generate_series [type=int]
+ │    │         ├── const: 1 [type=int]
+ │    │         └── const: 2 [type=int]
+ │    └── true [type=bool]
+ └── aggregations
+      └── array-agg [type=int[]]
+           └── variable: generate_series [type=int]


### PR DESCRIPTION
Backport 1/1 commits from #30274.

/cc @cockroachdb/release

---

Prior to this commit, queries such as
`SELECT array_agg(generate_series(1, 2))` were causing a panic
in the optimizer. This commit fixes the issue so now this query
correctly returns `{1,2}`.

Fixes #30166

Release note (bug fix): Fixed a panic in the optimizer code when
generator functions such as generate_series() were used as the
argument to an aggregate function.
