### PR TITLE
storage: create an IsLiveMap for node liveness which contains epoch

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1590,7 +1590,7 @@ func (s *adminServer) EnqueueRange(
 	// only it, since we choose which nodes to send the request to based on
 	// what's in isLiveMap.
 	if req.NodeID > 0 {
-		isLiveMap = map[roachpb.NodeID]bool{req.NodeID: isLiveMap[req.NodeID]}
+		isLiveMap = storage.IsLiveMap{req.NodeID: isLiveMap[req.NodeID]}
 	}
 
 	response := &serverpb.EnqueueRangeResponse{}

--- a/pkg/server/problem_ranges.go
+++ b/pkg/server/problem_ranges.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 )
 
 func (s *statusServer) ProblemRanges(
@@ -44,8 +45,8 @@ func (s *statusServer) ProblemRanges(
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, err.Error())
 		}
-		isLiveMap = map[roachpb.NodeID]bool{
-			requestedNodeID: true,
+		isLiveMap = storage.IsLiveMap{
+			requestedNodeID: storage.IsLiveMapEntry{IsLive: true},
 		}
 	}
 

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -381,10 +381,10 @@ func (mr *MetricsRecorder) getNetworkActivity(
 		if mr.rpcContext.RemoteClocks != nil {
 			currentAverages = mr.rpcContext.RemoteClocks.AllLatencies()
 		}
-		for nodeID, alive := range isLiveMap {
+		for nodeID, entry := range isLiveMap {
 			address, err := mr.gossip.GetNodeIDAddress(nodeID)
 			if err != nil {
-				if alive {
+				if entry.IsLive {
 					log.Warning(ctx, err.Error())
 				}
 				continue
@@ -396,7 +396,7 @@ func (mr *MetricsRecorder) getNetworkActivity(
 				na.Incoming = stats.Incoming()
 				na.Outgoing = stats.Outgoing()
 			}
-			if alive {
+			if entry.IsLive {
 				if latency, ok := currentAverages[key]; ok {
 					na.Latency = latency.Nanoseconds()
 				}

--- a/pkg/storage/node_liveness_test.go
+++ b/pkg/storage/node_liveness_test.go
@@ -462,7 +462,11 @@ func TestNodeLivenessGetIsLiveMap(t *testing.T) {
 	verifyLiveness(t, mtc)
 	pauseNodeLivenessHeartbeats(mtc, true)
 	lMap := mtc.nodeLivenesses[0].GetIsLiveMap()
-	expectedLMap := map[roachpb.NodeID]bool{1: true, 2: true, 3: true}
+	expectedLMap := storage.IsLiveMap{
+		1: {IsLive: true, Epoch: 1},
+		2: {IsLive: true, Epoch: 1},
+		3: {IsLive: true, Epoch: 1},
+	}
 	if !reflect.DeepEqual(expectedLMap, lMap) {
 		t.Errorf("expected liveness map %+v; got %+v", expectedLMap, lMap)
 	}
@@ -483,7 +487,11 @@ func TestNodeLivenessGetIsLiveMap(t *testing.T) {
 
 	// Now verify only node 0 is live.
 	lMap = mtc.nodeLivenesses[0].GetIsLiveMap()
-	expectedLMap = map[roachpb.NodeID]bool{1: true, 2: false, 3: false}
+	expectedLMap = storage.IsLiveMap{
+		1: {IsLive: true, Epoch: 1},
+		2: {IsLive: false, Epoch: 1},
+		3: {IsLive: false, Epoch: 1},
+	}
 	if !reflect.DeepEqual(expectedLMap, lMap) {
 		t.Errorf("expected liveness map %+v; got %+v", expectedLMap, lMap)
 	}


### PR DESCRIPTION
This will be used in an upcoming PR to compute stats for non-resident
replicas. The addition of the node liveness epoch in the map allows
non-resident replica leases to be tested for validity.

Release note: None