### PR TITLE
release-2.1: ui: never wrap summary bar values

### DIFF
--- a/pkg/ui/src/views/shared/components/summaryBar/summarybar.styl
+++ b/pkg/ui/src/views/shared/components/summaryBar/summarybar.styl
@@ -27,6 +27,7 @@
     font-weight 200
     font-size 30px
     color $body-color
+    white-space nowrap
 
 .summary-label
   font-family Lato-Bold


### PR DESCRIPTION
Backport 1/1 commits from #30280.

/cc @cockroachdb/release

---

Fixes: #26281
Release note: None
