### PR TITLE
release-2.1: ui: add "Errors" chart to SQL dashboard

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -15,7 +15,7 @@ export default function (props: GraphDashboardProps) {
       title="SQL Queries"
       sources={nodeSources}
       tooltip={
-        `A ten-second moving average of the # of SELECT, INSERT, UPDATE, and DELETE operations
+        `A ten-second moving average of the # of SELECT, INSERT, UPDATE, and DELETE statements
         started per second ${tooltipSelection}.`
       }
     >

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -37,7 +37,7 @@ export default function (props: GraphDashboardProps) {
       title="SQL Queries"
       sources={nodeSources}
       tooltip={
-        `A ten-second moving average of the # of SELECT, INSERT, UPDATE, and DELETE operations
+        `A ten-second moving average of the # of SELECT, INSERT, UPDATE, and DELETE statements
         started per second ${tooltipSelection}.`
       }
     >
@@ -46,6 +46,16 @@ export default function (props: GraphDashboardProps) {
         <Metric name="cr.node.sql.update.count" title="Updates" nonNegativeRate />
         <Metric name="cr.node.sql.insert.count" title="Inserts" nonNegativeRate />
         <Metric name="cr.node.sql.delete.count" title="Deletes" nonNegativeRate />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="SQL Query Errors"
+      sources={nodeSources}
+      tooltip={"The number of statements which returned a planning or runtime error."}
+    >
+      <Axis label="errors">
+        <Metric name="cr.node.sql.failure.count" title="Errors" nonNegativeRate />
       </Axis>
     </LineGraph>,
 


### PR DESCRIPTION
Backport 1/1 commits from #29380.

/cc @cockroachdb/release

---

This metric shows the number of statements per second resulting in a
planning or execution error:

![image](https://user-images.githubusercontent.com/7341/45514841-89282900-b774-11e8-824c-6a6e6c94aa7a.png)

Fixes #14148
Fixes #29346
