### PR TITLE
 changefeedccl: add experimental support format=avro

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -943,6 +943,14 @@
   version = "v0.15.0"
 
 [[projects]]
+  digest = "1:b22c26daf3e7af2e1bf09da50ab9bc6d7744d7b8c0cba6502e40d2e6163283bc"
+  name = "github.com/linkedin/goavro"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9e3ffbc22b459192a7090bfd06433b24be086370"
+  version = "v2.6.0"
+
+[[projects]]
   branch = "master"
   digest = "1:9e23318fb92c60935e4de2ce13710979f1dffd5c7a4ec4b29a740c27da9b735c"
   name = "github.com/lufia/iostat"
@@ -1713,6 +1721,7 @@
     "github.com/lib/pq",
     "github.com/lib/pq/oid",
     "github.com/lightstep/lightstep-tracer-go",
+    "github.com/linkedin/goavro",
     "github.com/lufia/iostat",
     "github.com/marusama/semaphore",
     "github.com/mattn/go-isatty",

--- a/pkg/ccl/acceptanceccl/cdc_kafka_test.go
+++ b/pkg/ccl/acceptanceccl/cdc_kafka_test.go
@@ -218,12 +218,6 @@ func testErrors(ctx context.Context, t *testing.T, k *dockerKafka) {
 	); !testutils.IsError(err, `schema_topic is not yet supported`) {
 		t.Errorf(`expected "schema_topic is not yet supported" error got: %v`, err)
 	}
-	into = `kafka://localhost:` + k.kafkaPort + `?confluent_schema_registry=foo`
-	if _, err := sqlDBRaw.Exec(
-		`CREATE CHANGEFEED FOR foo INTO $1`, into,
-	); !testutils.IsError(err, `confluent_schema_registry is not yet supported`) {
-		t.Errorf(`expected "confluent_schema_registry is not yet supported" error got: %v`, err)
-	}
 }
 
 const (

--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -1,0 +1,281 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"encoding/json"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/linkedin/goavro"
+	"github.com/pkg/errors"
+)
+
+// avroSchemaType is one of the set of avro primitive types.
+type avroSchemaType interface{}
+
+const (
+	avroSchemaBoolean = `boolean`
+	avroSchemaBytes   = `bytes`
+	avroSchemaDouble  = `double`
+	avroSchemaLong    = `long`
+	avroSchemaNull    = `null`
+	avroSchemaString  = `string`
+)
+
+// avroSchemaField is our representation of the schema of a field in an avro
+// record. Serializing it to JSON gives the standard schema representation.
+type avroSchemaField struct {
+	SchemaType avroSchemaType `json:"type"`
+	Name       string         `json:"name"`
+
+	// TODO(dan): typ should be derivable from the json `type` and `logicalType`
+	// fields. This would make it possible to roundtrip CockroachDB schemas
+	// through avro.
+	typ sqlbase.ColumnType
+
+	encodeFn func(tree.Datum) interface{}
+	decodeFn func(interface{}) tree.Datum
+}
+
+// avroSchemaRecord is our representation of the schema of an avro record.
+// Serializing it to JSON gives the standard schema representation.
+type avroSchemaRecord struct {
+	SchemaType string             `json:"type"`
+	Name       string             `json:"name"`
+	Fields     []*avroSchemaField `json:"fields"`
+
+	colIdxByFieldIdx map[int]int
+	fieldIdxByName   map[string]int
+	codec            *goavro.Codec
+	alloc            sqlbase.DatumAlloc
+}
+
+func avroEscapeName(name string) string {
+	// TODO(dan): Name escaping.
+	return name
+}
+
+// columnDescToAvroSchema converts a column descriptor into its corresponding
+// avro field schema.
+func columnDescToAvroSchema(colDesc *sqlbase.ColumnDescriptor) (*avroSchemaField, error) {
+	schema := &avroSchemaField{
+		Name: avroEscapeName(colDesc.Name),
+		typ:  colDesc.Type,
+	}
+
+	var avroType string
+	switch colDesc.Type.SemanticType {
+	case sqlbase.ColumnType_INT:
+		avroType = avroSchemaLong
+		schema.encodeFn = func(d tree.Datum) interface{} {
+			return int64(*d.(*tree.DInt))
+		}
+		schema.decodeFn = func(x interface{}) tree.Datum {
+			return tree.NewDInt(tree.DInt(x.(int64)))
+		}
+	case sqlbase.ColumnType_BOOL:
+		avroType = avroSchemaBoolean
+		schema.encodeFn = func(d tree.Datum) interface{} {
+			return bool(*d.(*tree.DBool))
+		}
+		schema.decodeFn = func(x interface{}) tree.Datum {
+			return tree.MakeDBool(tree.DBool(x.(bool)))
+		}
+	case sqlbase.ColumnType_FLOAT:
+		avroType = avroSchemaDouble
+		schema.encodeFn = func(d tree.Datum) interface{} {
+			return float64(*d.(*tree.DFloat))
+		}
+		schema.decodeFn = func(x interface{}) tree.Datum {
+			return tree.NewDFloat(tree.DFloat(x.(float64)))
+		}
+	case sqlbase.ColumnType_STRING:
+		avroType = avroSchemaString
+		schema.encodeFn = func(d tree.Datum) interface{} {
+			return string(*d.(*tree.DString))
+		}
+		schema.decodeFn = func(x interface{}) tree.Datum {
+			return tree.NewDString(x.(string))
+		}
+	case sqlbase.ColumnType_BYTES:
+		avroType = avroSchemaBytes
+		schema.encodeFn = func(d tree.Datum) interface{} {
+			return []byte(*d.(*tree.DBytes))
+		}
+		schema.decodeFn = func(x interface{}) tree.Datum {
+			return tree.NewDBytes(tree.DBytes(x.([]byte)))
+		}
+	default:
+		// TODO(dan): Support the other column types.
+		return nil, errors.Errorf(`unsupported column type: %s`, colDesc.Type.SemanticType)
+	}
+	schema.SchemaType = avroType
+
+	if colDesc.Nullable {
+		schema.SchemaType = []avroSchemaType{avroType, avroSchemaNull}
+		encodeFn := schema.encodeFn
+		decodeFn := schema.decodeFn
+		schema.encodeFn = func(d tree.Datum) interface{} {
+			if d == tree.DNull {
+				return goavro.Union(avroSchemaNull, nil)
+			}
+			return goavro.Union(avroType, encodeFn(d))
+		}
+		schema.decodeFn = func(x interface{}) tree.Datum {
+			if x == nil {
+				return tree.DNull
+			}
+			return decodeFn(x.(map[string]interface{})[avroType])
+		}
+	}
+
+	// TODO(dan): Handle default and computed values.
+
+	return schema, nil
+}
+
+// indexToAvroSchema converts a column descriptor into its corresponding avro
+// record schema. The fields are kept in the same order as columns in the index.
+func indexToAvroSchema(
+	tableDesc *sqlbase.TableDescriptor, indexDesc *sqlbase.IndexDescriptor,
+) (*avroSchemaRecord, error) {
+	schema := &avroSchemaRecord{
+		Name:             avroEscapeName(tableDesc.Name),
+		SchemaType:       `record`,
+		fieldIdxByName:   make(map[string]int),
+		colIdxByFieldIdx: make(map[int]int),
+	}
+	colIdxByID := tableDesc.ColumnIdxMap()
+	for _, colID := range indexDesc.ColumnIDs {
+		colIdx, ok := colIdxByID[colID]
+		if !ok {
+			return nil, errors.Errorf(`unknown column id: %d`, colID)
+		}
+		col := tableDesc.Columns[colIdx]
+		field, err := columnDescToAvroSchema(&col)
+		if err != nil {
+			return nil, err
+		}
+		schema.colIdxByFieldIdx[len(schema.Fields)] = colIdx
+		schema.fieldIdxByName[field.Name] = len(schema.Fields)
+		schema.Fields = append(schema.Fields, field)
+	}
+	schemaJSON, err := json.Marshal(schema)
+	if err != nil {
+		return nil, err
+	}
+	schema.codec, err = goavro.NewCodec(string(schemaJSON))
+	if err != nil {
+		return nil, err
+	}
+	return schema, nil
+}
+
+// tableToAvroSchema converts a column descriptor into its corresponding avro
+// record schema. The fields are kept in the same order as `tableDesc.Columns`.
+func tableToAvroSchema(tableDesc *sqlbase.TableDescriptor) (*avroSchemaRecord, error) {
+	schema := &avroSchemaRecord{
+		Name:             avroEscapeName(tableDesc.Name),
+		SchemaType:       `record`,
+		fieldIdxByName:   make(map[string]int),
+		colIdxByFieldIdx: make(map[int]int),
+	}
+	for colIdx, col := range tableDesc.Columns {
+		field, err := columnDescToAvroSchema(&col)
+		if err != nil {
+			return nil, err
+		}
+		schema.colIdxByFieldIdx[len(schema.Fields)] = colIdx
+		schema.fieldIdxByName[field.Name] = len(schema.Fields)
+		schema.Fields = append(schema.Fields, field)
+	}
+	schemaJSON, err := json.Marshal(schema)
+	if err != nil {
+		return nil, err
+	}
+	schema.codec, err = goavro.NewCodec(string(schemaJSON))
+	if err != nil {
+		return nil, err
+	}
+	return schema, nil
+}
+
+// TextualFromRow encodes the given row data into avro's defined JSON format.
+func (r *avroSchemaRecord) TextualFromRow(row sqlbase.EncDatumRow) ([]byte, error) {
+	native, err := r.nativeFromRow(row)
+	if err != nil {
+		return nil, err
+	}
+	return r.codec.TextualFromNative(nil /* buf */, native)
+}
+
+// BinaryFromRow encodes the given row data into avro's defined binary format.
+func (r *avroSchemaRecord) BinaryFromRow(buf []byte, row sqlbase.EncDatumRow) ([]byte, error) {
+	native, err := r.nativeFromRow(row)
+	if err != nil {
+		return nil, err
+	}
+	return r.codec.BinaryFromNative(buf, native)
+}
+
+// RowFromTextual decodes the given row data from avro's defined JSON format.
+func (r *avroSchemaRecord) RowFromTextual(buf []byte) (sqlbase.EncDatumRow, error) {
+	native, newBuf, err := r.codec.NativeFromTextual(buf)
+	if err != nil {
+		return nil, err
+	}
+	if len(newBuf) > 0 {
+		return nil, errors.New(`only one row was expected`)
+	}
+	return r.rowFromNative(native)
+}
+
+// RowFromBinary decodes the given row data from avro's defined binary format.
+func (r *avroSchemaRecord) RowFromBinary(buf []byte) (sqlbase.EncDatumRow, error) {
+	native, newBuf, err := r.codec.NativeFromBinary(buf)
+	if err != nil {
+		return nil, err
+	}
+	if len(newBuf) > 0 {
+		return nil, errors.New(`only one row was expected`)
+	}
+	return r.rowFromNative(native)
+}
+
+func (r *avroSchemaRecord) nativeFromRow(row sqlbase.EncDatumRow) (interface{}, error) {
+	avroDatums := make(map[string]interface{}, len(row))
+	for fieldIdx, field := range r.Fields {
+		d := row[r.colIdxByFieldIdx[fieldIdx]]
+		if err := d.EnsureDecoded(&field.typ, &r.alloc); err != nil {
+			return nil, err
+		}
+		avroDatums[field.Name] = field.encodeFn(d.Datum)
+	}
+	return avroDatums, nil
+}
+
+func (r *avroSchemaRecord) rowFromNative(native interface{}) (sqlbase.EncDatumRow, error) {
+	avroDatums, ok := native.(map[string]interface{})
+	if !ok {
+		return nil, errors.Errorf(`unknown avro native type: %T`, native)
+	}
+	if len(r.Fields) != len(avroDatums) {
+		return nil, errors.Errorf(
+			`expected row with %d columns got %d`, len(r.Fields), len(avroDatums))
+	}
+	row := make(sqlbase.EncDatumRow, len(r.Fields))
+	for fieldName, avroDatum := range avroDatums {
+		fieldIdx := r.fieldIdxByName[fieldName]
+		field := r.Fields[fieldIdx]
+		row[r.colIdxByFieldIdx[fieldIdx]] = sqlbase.DatumToEncDatum(
+			field.typ, field.decodeFn(avroDatum))
+	}
+	return row, nil
+}

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -1,0 +1,171 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/importccl"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/pkg/errors"
+
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func parseTableDesc(createTableStmt string) (*sqlbase.TableDescriptor, error) {
+	ctx := context.Background()
+	stmt, err := parser.ParseOne(createTableStmt)
+	if err != nil {
+		return nil, errors.Wrapf(err, `parsing %s`, createTableStmt)
+	}
+	createTable, ok := stmt.(*tree.CreateTable)
+	if !ok {
+		return nil, errors.Errorf("expected *tree.CreateTable got %T", stmt)
+	}
+	st := cluster.MakeTestingClusterSettings()
+	const parentID = sqlbase.ID(keys.MaxReservedDescID + 1)
+	const tableID = sqlbase.ID(keys.MaxReservedDescID + 2)
+	tableDesc, err := importccl.MakeSimpleTableDescriptor(
+		ctx, st, createTable, parentID, tableID, importccl.NoFKs, hlc.UnixNano())
+	if err != nil {
+		return nil, err
+	}
+	return tableDesc, tableDesc.ValidateTable(st)
+}
+
+func parseValues(tableDesc *sqlbase.TableDescriptor, values string) ([]sqlbase.EncDatumRow, error) {
+	semaCtx := &tree.SemaContext{}
+	evalCtx := &tree.EvalContext{}
+
+	valuesStmt, err := parser.ParseOne(values)
+	if err != nil {
+		return nil, err
+	}
+	selectStmt, ok := valuesStmt.(*tree.Select)
+	if !ok {
+		return nil, errors.Errorf("expected *tree.Select got %T", valuesStmt)
+	}
+	valuesClause, ok := selectStmt.Select.(*tree.ValuesClause)
+	if !ok {
+		return nil, errors.Errorf("expected *tree.ValuesClause got %T", selectStmt.Select)
+	}
+
+	var rows []sqlbase.EncDatumRow
+	for _, rowTuple := range valuesClause.Rows {
+		var row sqlbase.EncDatumRow
+		for colIdx, expr := range rowTuple {
+			col := tableDesc.Columns[colIdx]
+			typedExpr, err := sqlbase.SanitizeVarFreeExpr(
+				expr, col.Type.ToDatumType(), "avro", semaCtx, evalCtx, false /* allowImpure */)
+			if err != nil {
+				return nil, err
+			}
+			datum, err := typedExpr.Eval(evalCtx)
+			if err != nil {
+				return nil, errors.Wrap(err, typedExpr.String())
+			}
+			row = append(row, sqlbase.DatumToEncDatum(col.Type, datum))
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func TestAvroSchema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	rng, _ := randutil.NewPseudoRand()
+
+	type avroTest struct {
+		name   string
+		schema string
+		values string
+	}
+	tests := []avroTest{
+		{
+			name:   `NULLABLE`,
+			schema: `(a INT PRIMARY KEY, b INT NULL)`,
+			values: `(1, 2), (3, NULL)`,
+		},
+		{
+			name:   `TUPLE`,
+			schema: `(a INT PRIMARY KEY, b STRING)`,
+			values: `(1, 'a')`,
+		},
+	}
+	// Generate a test for each column type with a random datum of that type.
+	for semTypeID, semTypeName := range sqlbase.ColumnType_SemanticType_name {
+		typ := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_SemanticType(semTypeID)}
+		colType := semTypeName
+		switch typ.SemanticType {
+		case sqlbase.ColumnType_DECIMAL, sqlbase.ColumnType_DATE, sqlbase.ColumnType_TIMESTAMP,
+			sqlbase.ColumnType_INTERVAL, sqlbase.ColumnType_TIMESTAMPTZ,
+			sqlbase.ColumnType_COLLATEDSTRING, sqlbase.ColumnType_NAME, sqlbase.ColumnType_OID,
+			sqlbase.ColumnType_UUID, sqlbase.ColumnType_ARRAY, sqlbase.ColumnType_INET,
+			sqlbase.ColumnType_TIME, sqlbase.ColumnType_JSONB, sqlbase.ColumnType_BIT,
+			sqlbase.ColumnType_TUPLE:
+			continue
+			// TODO(dan): Implement these.
+		}
+		datum := sqlbase.RandDatum(rng, typ, false /* nullOk */)
+		if datum == tree.DNull {
+			// DNull is returned by RandDatum for ColumnType_NULL or if the
+			// column type is unimplemented in RandDatum. In either case, the
+			// correct thing to do is skip this one.
+			continue
+		}
+		serializedDatum := tree.Serialize(datum)
+		// schema is used in a fmt.Sprintf to fill in the table name, so we have
+		// to escape any stray %s.
+		escapedDatum := strings.Replace(serializedDatum, `%`, `%%`, -1)
+		test := avroTest{
+			name:   semTypeName,
+			schema: fmt.Sprintf(`(a %s PRIMARY KEY)`, colType),
+			values: fmt.Sprintf(`(%s)`, escapedDatum),
+		}
+		tests = append(tests, test)
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tableDesc, err := parseTableDesc(
+				fmt.Sprintf(`CREATE TABLE "%s" %s`, test.name, test.schema))
+			require.NoError(t, err)
+			tableSchema, err := tableToAvroSchema(tableDesc)
+			require.NoError(t, err)
+
+			rows, err := parseValues(tableDesc, `VALUES `+test.values)
+			require.NoError(t, err)
+
+			for _, row := range rows {
+				serialized, err := tableSchema.TextualFromRow(row)
+				require.NoError(t, err)
+				roundtripped, err := tableSchema.RowFromTextual(serialized)
+				require.NoError(t, err)
+				require.Equal(t, row, roundtripped)
+
+				serialized, err = tableSchema.BinaryFromRow(nil, row)
+				require.NoError(t, err)
+				roundtripped, err = tableSchema.RowFromBinary(serialized)
+				require.NoError(t, err)
+				require.Equal(t, row, roundtripped)
+			}
+		})
+	}
+}

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -9,9 +9,7 @@
 package changefeedccl
 
 import (
-	"bytes"
 	"context"
-	gojson "encoding/json"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -19,11 +17,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
@@ -43,7 +39,7 @@ const (
 
 type emitRow struct {
 	// datums is the new value of a changed table row.
-	datums tree.Datums
+	datums sqlbase.EncDatumRow
 	// timestamp is the mvcc timestamp corresponding to the latest update in
 	// `row`.
 	timestamp hlc.Timestamp
@@ -107,14 +103,14 @@ func kvsToRows(
 
 		for {
 			var r emitEntry
-			r.row.datums, r.row.tableDesc, _, err = rf.NextRowDecoded(ctx)
+			r.row.datums, r.row.tableDesc, _, err = rf.NextRow(ctx)
 			if err != nil {
 				return nil, err
 			}
 			if r.row.datums == nil {
 				break
 			}
-			r.row.datums = append(tree.Datums(nil), r.row.datums...)
+			r.row.datums = append(sqlbase.EncDatumRow(nil), r.row.datums...)
 
 			r.row.deleted = rf.RowIsDeleted()
 			r.row.timestamp = kv.Value.Timestamp
@@ -157,51 +153,30 @@ func kvsToRows(
 // updates. The returned closure is not threadsafe.
 func emitEntries(
 	details jobspb.ChangefeedDetails,
+	encoder Encoder,
 	sink Sink,
 	inputFn func(context.Context) ([]emitEntry, error),
 	knobs TestingKnobs,
 ) func(context.Context) ([]jobspb.ResolvedSpan, error) {
 	var scratch bufalloc.ByteAllocator
-	var key, value bytes.Buffer
 	emitRowFn := func(ctx context.Context, row emitRow) error {
-		key.Reset()
-		value.Reset()
+		var keyCopy, valueCopy []byte
 
-		keyColumns := row.tableDesc.PrimaryIndex.ColumnNames
-		jsonKeyRaw := make([]interface{}, len(keyColumns))
-		jsonValueRaw := make(map[string]interface{}, len(row.datums))
-		if _, ok := details.Opts[optUpdatedTimestamps]; ok {
-			jsonValueRaw[jsonMetaSentinel] = map[string]interface{}{
-				`updated`: tree.TimestampToDecimal(row.timestamp).Decimal.String(),
-			}
-		}
-		for i := range row.datums {
-			var err error
-			jsonValueRaw[row.tableDesc.Columns[i].Name], err = tree.AsJSON(row.datums[i])
-			if err != nil {
-				return err
-			}
-		}
-		for i, columnName := range keyColumns {
-			jsonKeyRaw[i] = jsonValueRaw[columnName]
-		}
-
-		jsonKey, err := json.MakeJSON(jsonKeyRaw)
+		encodedKey, err := encoder.EncodeKey(row.tableDesc, row.datums)
 		if err != nil {
 			return err
 		}
-		jsonKey.Format(&key)
+		scratch, keyCopy = scratch.Copy(encodedKey, 0 /* extraCap */)
+
 		if !row.deleted && envelopeType(details.Opts[optEnvelope]) == optEnvelopeRow {
-			jsonValue, err := json.MakeJSON(jsonValueRaw)
+			var encodedValue []byte
+			encodedValue, err = encoder.EncodeValue(row.tableDesc, row.datums, row.timestamp)
 			if err != nil {
 				return err
 			}
-			jsonValue.Format(&value)
+			scratch, valueCopy = scratch.Copy(encodedValue, 0 /* extraCap */)
 		}
 
-		var keyCopy, valueCopy []byte
-		scratch, keyCopy = scratch.Copy(key.Bytes(), 0 /* extraCap */)
-		scratch, valueCopy = scratch.Copy(value.Bytes(), 0 /* extraCap */)
 		if knobs.BeforeEmitRow != nil {
 			if err := knobs.BeforeEmitRow(); err != nil {
 				return err
@@ -258,6 +233,7 @@ func emitEntries(
 func emitResolvedTimestamp(
 	ctx context.Context,
 	details jobspb.ChangefeedDetails,
+	encoder Encoder,
 	sink Sink,
 	jobProgressedFn func(context.Context, jobs.HighWaterProgressedFn) error,
 	sf *spanFrontier,
@@ -287,19 +263,15 @@ func emitResolvedTimestamp(
 	}
 
 	if _, ok := details.Opts[optResolvedTimestamps]; ok {
-		resolvedMetaRaw := map[string]interface{}{
-			jsonMetaSentinel: map[string]interface{}{
-				`resolved`: tree.TimestampToDecimal(resolved).Decimal.String(),
-			},
-		}
-		resolvedMeta, err := gojson.Marshal(resolvedMetaRaw)
+		payload, err := encoder.EncodeResolvedTimestamp(resolved)
 		if err != nil {
 			return err
 		}
-
+		// TODO(dan): Plumb a bufalloc.ByteAllocator to use here.
+		payload = append([]byte(nil), payload...)
 		// TODO(dan): Emit more fine-grained (table level) resolved
 		// timestamps.
-		if err := sink.EmitResolvedTimestamp(ctx, resolvedMeta); err != nil {
+		if err := sink.EmitResolvedTimestamp(ctx, payload); err != nil {
 			return err
 		}
 	}

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -100,7 +100,7 @@ func newChangeAggregatorProcessor(
 	}
 
 	var err error
-	if ca.encoder, err = getEncoder(ca.spec.Feed.Opts); err != nil {
+	if ca.encoder, err = getEncoder(ca.spec.Feed.Opts, ca.spec.Feed.SinkURI); err != nil {
 		return nil, err
 	}
 
@@ -112,7 +112,7 @@ func newChangeAggregatorProcessor(
 	// CHANGEFEED statement. Therefore, we create a "canary" sink, which will be
 	// immediately closed, only to check for errors.
 	{
-		canarySink, err := getSink(ca.spec.Feed.SinkURI, ca.spec.Feed.Targets)
+		canarySink, err := getSink(spec.Feed.SinkURI, spec.Feed.Opts, spec.Feed.Targets)
 		if err != nil {
 			return nil, err
 		}
@@ -136,7 +136,9 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 	ctx = ca.StartInternal(ctx, changeAggregatorProcName)
 
 	var err error
-	if ca.sink, err = getSink(ca.spec.Feed.SinkURI, ca.spec.Feed.Targets); err != nil {
+	if ca.sink, err = getSink(
+		ca.spec.Feed.SinkURI, ca.spec.Feed.Opts, ca.spec.Feed.Targets,
+	); err != nil {
 		// Early abort in the case that there is an error creating the sink.
 		ca.MoveToDraining(err)
 		ca.cancel()
@@ -384,14 +386,14 @@ func newChangeFrontierProcessor(
 	}
 
 	var err error
-	if cf.encoder, err = getEncoder(spec.Feed.Opts); err != nil {
+	if cf.encoder, err = getEncoder(spec.Feed.Opts, spec.Feed.SinkURI); err != nil {
 		return nil, err
 	}
 
 	// See comment in newChangeAggregatorProcessor for details on the use of canary
 	// sinks.
 	{
-		canarySink, err := getSink(spec.Feed.SinkURI, spec.Feed.Targets)
+		canarySink, err := getSink(spec.Feed.SinkURI, spec.Feed.Opts, spec.Feed.Targets)
 		if err != nil {
 			return nil, err
 		}
@@ -416,7 +418,9 @@ func (cf *changeFrontier) Start(ctx context.Context) context.Context {
 	ctx = cf.StartInternal(ctx, changeFrontierProcName)
 
 	var err error
-	if cf.sink, err = getSink(cf.spec.Feed.SinkURI, cf.spec.Feed.Targets); err != nil {
+	if cf.sink, err = getSink(
+		cf.spec.Feed.SinkURI, cf.spec.Feed.Opts, cf.spec.Feed.Targets,
+	); err != nil {
 		cf.MoveToDraining(err)
 		return ctx
 	}

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -51,8 +51,9 @@ const (
 	optEnvelopeRow     envelopeType = `row`
 	optEnvelopeDiff    envelopeType = `diff`
 
-	optFormatJSON formatType = `json`
-	optFormatAvro formatType = `avro`
+	optFormatJSON     formatType = `json`
+	optFormatAvro     formatType = `experimental-avro`
+	optFormatAvroJSON formatType = `experimental-avro-json`
 
 	sinkParamConfluentSchemaRegistry = `confluent_schema_registry`
 	sinkParamTopicPrefix             = `topic_prefix`
@@ -290,9 +291,8 @@ func validateDetails(details jobspb.ChangefeedDetails) (jobspb.ChangefeedDetails
 	switch formatType(details.Opts[optFormat]) {
 	case ``, optFormatJSON:
 		details.Opts[optFormat] = string(optFormatJSON)
-	case optFormatAvro:
-		return jobspb.ChangefeedDetails{}, errors.Errorf(
-			`%s=%s is not yet supported`, optFormat, optFormatAvro)
+	case optFormatAvro, optFormatAvroJSON:
+		// No-op.
 	default:
 		return jobspb.ChangefeedDetails{}, errors.Errorf(
 			`unknown %s: %s`, optFormat, details.Opts[optFormat])

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -10,13 +10,24 @@ package changefeedccl
 
 import (
 	"bytes"
+	"encoding/binary"
 	gojson "encoding/json"
+	"net/http"
+	"net/url"
+	"path/filepath"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/pkg/errors"
+)
+
+const (
+	confluentSchemaContentType   = `application/vnd.schemaregistry.v1+json`
+	confluentSubjectSuffixKey    = `-key`
+	confluentSubjectSuffixValue  = `-value`
+	confluentAvroWireFormatMagic = byte(0)
 )
 
 // Encoder turns a row into a serialized changefeed key, value, or resolved
@@ -37,10 +48,17 @@ type Encoder interface {
 	EncodeResolvedTimestamp(hlc.Timestamp) ([]byte, error)
 }
 
-func getEncoder(opts map[string]string) (Encoder, error) {
+func getEncoder(opts map[string]string, sinkURI string) (Encoder, error) {
 	switch formatType(opts[optFormat]) {
 	case ``, optFormatJSON:
 		return makeJSONEncoder(opts), nil
+	case optFormatAvro, optFormatAvroJSON:
+		uri, err := url.Parse(sinkURI)
+		if err != nil {
+			return nil, err
+		}
+		registryURL := uri.Query().Get(sinkParamConfluentSchemaRegistry)
+		return newConfluentAvroEncoder(opts, registryURL)
 	default:
 		return nil, errors.Errorf(`unknown %s: %s`, optFormat, opts[optFormat])
 	}
@@ -132,4 +150,162 @@ func (e *jsonEncoder) EncodeResolvedTimestamp(resolved hlc.Timestamp) ([]byte, e
 		},
 	}
 	return gojson.Marshal(resolvedMetaRaw)
+}
+
+// confluentAvroEncoder encodes changefeed entries as Avro's binary or textual
+// JSON format. Keys are the primary key columns in a record. Values are all
+// columns in a record.
+type confluentAvroEncoder struct {
+	registryURL string
+	json        bool
+
+	keyCache   map[tableIDAndVersion]confluentRegisteredSchema
+	valueCache map[tableIDAndVersion]confluentRegisteredSchema
+}
+
+type tableIDAndVersion uint64
+
+func makeTableIDAndVersion(id sqlbase.ID, version sqlbase.DescriptorVersion) tableIDAndVersion {
+	return tableIDAndVersion(id)<<32 + tableIDAndVersion(version)
+}
+
+type confluentRegisteredSchema struct {
+	schema     *avroSchemaRecord
+	registryID int32
+}
+
+var _ Encoder = &confluentAvroEncoder{}
+
+func newConfluentAvroEncoder(
+	opts map[string]string, registryURL string,
+) (*confluentAvroEncoder, error) {
+	// TODO(dan): Figure out what updated and resolved timestamps should
+	// look like with avro.
+	for _, opt := range []string{optUpdatedTimestamps, optResolvedTimestamps} {
+		if _, ok := opts[optUpdatedTimestamps]; ok {
+			return nil, errors.Errorf(
+				`%s=%s is not yet compatible with %s`, optFormat, optFormatAvro, opt)
+		}
+	}
+	e := &confluentAvroEncoder{
+		registryURL: registryURL,
+		json:        formatType(opts[optFormat]) == optFormatAvroJSON,
+		keyCache:    make(map[tableIDAndVersion]confluentRegisteredSchema),
+		valueCache:  make(map[tableIDAndVersion]confluentRegisteredSchema),
+	}
+	if !e.json && len(e.registryURL) == 0 {
+		return nil, errors.Errorf(`parameter %s is required with %s=%s`,
+			sinkParamConfluentSchemaRegistry, optFormat, optFormatAvro)
+	}
+	return e, nil
+}
+
+// EncodeKey implements the Encoder interface.
+func (e *confluentAvroEncoder) EncodeKey(
+	tableDesc *sqlbase.TableDescriptor, row sqlbase.EncDatumRow,
+) ([]byte, error) {
+	cacheKey := makeTableIDAndVersion(tableDesc.ID, tableDesc.Version)
+	registered, ok := e.keyCache[cacheKey]
+	if !ok {
+		var err error
+		registered.schema, err = indexToAvroSchema(tableDesc, &tableDesc.PrimaryIndex)
+		if err != nil {
+			return nil, err
+		}
+
+		if !e.json {
+			registered.registryID, err = e.register(registered.schema, confluentSubjectSuffixKey)
+			if err != nil {
+				return nil, err
+			}
+		}
+		// TODO(dan): Bound the size of this cache.
+		e.keyCache[cacheKey] = registered
+	}
+
+	if e.json {
+		return registered.schema.TextualFromRow(row)
+	}
+	// https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html#wire-format
+	header := []byte{
+		confluentAvroWireFormatMagic,
+		0, 0, 0, 0, // Placeholder for the ID.
+	}
+	binary.BigEndian.PutUint32(header[1:5], uint32(registered.registryID))
+	return registered.schema.BinaryFromRow(header, row)
+}
+
+// EncodeValue implements the Encoder interface.
+func (e *confluentAvroEncoder) EncodeValue(
+	tableDesc *sqlbase.TableDescriptor, row sqlbase.EncDatumRow, _ hlc.Timestamp,
+) ([]byte, error) {
+	cacheKey := makeTableIDAndVersion(tableDesc.ID, tableDesc.Version)
+	registered, ok := e.valueCache[cacheKey]
+	if !ok {
+		var err error
+		registered.schema, err = tableToAvroSchema(tableDesc)
+		if err != nil {
+			return nil, err
+		}
+
+		if !e.json {
+			registered.registryID, err = e.register(registered.schema, confluentSubjectSuffixValue)
+			if err != nil {
+				return nil, err
+			}
+		}
+		// TODO(dan): Bound the size of this cache.
+		e.valueCache[cacheKey] = registered
+	}
+	if e.json {
+		return registered.schema.TextualFromRow(row)
+	}
+	// https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html#wire-format
+	header := []byte{
+		confluentAvroWireFormatMagic,
+		0, 0, 0, 0, // Placeholder for the ID.
+	}
+	binary.BigEndian.PutUint32(header[1:5], uint32(registered.registryID))
+	return registered.schema.BinaryFromRow(header, row)
+}
+
+// EncodeResolvedTimestamp implements the Encoder interface.
+func (e *confluentAvroEncoder) EncodeResolvedTimestamp(resolved hlc.Timestamp) ([]byte, error) {
+	panic(`unimplemented`)
+}
+
+func (e *confluentAvroEncoder) register(
+	schema *avroSchemaRecord, subjectSuffix string,
+) (int32, error) {
+	type confluentSchemaVersionRequest struct {
+		Schema string `json:"schema"`
+	}
+	type confluentSchemaVersionResponse struct {
+		ID int32 `json:"id"`
+	}
+
+	url, err := url.Parse(e.registryURL)
+	if err != nil {
+		return 0, err
+	}
+	subject := schema.Name + subjectSuffix
+	url.Path = filepath.Join(url.EscapedPath(), `subjects`, subject, `versions`)
+
+	req := confluentSchemaVersionRequest{Schema: schema.codec.Schema()}
+	var buf bytes.Buffer
+	if err := gojson.NewEncoder(&buf).Encode(req); err != nil {
+		return 0, err
+	}
+
+	resp, err := http.Post(url.String(), confluentSchemaContentType, &buf)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	var res confluentSchemaVersionResponse
+	if err := gojson.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return 0, err
+	}
+
+	return res.ID, nil
 }

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -1,0 +1,135 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"bytes"
+	gojson "encoding/json"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/pkg/errors"
+)
+
+// Encoder turns a row into a serialized changefeed key, value, or resolved
+// timestamp. It represents one of the `format=` changefeed options.
+type Encoder interface {
+	// EncodeKey encodes the primary key of the given row. The columns of the
+	// row are expected to match 1:1 with the `Columns` field of the
+	// `TableDescriptor`, but only the primary key fields will be used. The
+	// returned bytes are only valid until the next call to Encode*.
+	EncodeKey(*sqlbase.TableDescriptor, sqlbase.EncDatumRow) ([]byte, error)
+	// EncodeKey encodes the primary key of the given row. The columns of the
+	// row are expected to match 1:1 with the `Columns` field of the
+	// `TableDescriptor`. The returned bytes are only valid until the next call
+	// to Encode*.
+	EncodeValue(*sqlbase.TableDescriptor, sqlbase.EncDatumRow, hlc.Timestamp) ([]byte, error)
+	// EncodeKey encodes a resolved timestamp payload. The returned bytes are
+	// only valid until the next call to Encode*.
+	EncodeResolvedTimestamp(hlc.Timestamp) ([]byte, error)
+}
+
+func getEncoder(opts map[string]string) (Encoder, error) {
+	switch formatType(opts[optFormat]) {
+	case ``, optFormatJSON:
+		return makeJSONEncoder(opts), nil
+	default:
+		return nil, errors.Errorf(`unknown %s: %s`, optFormat, opts[optFormat])
+	}
+}
+
+// jsonEncoder encodes changefeed entries as JSON. Keys are the primary key
+// columns in a JSON array. Values are a JSON object mapping every column name
+// to its value. Updated timestamps in rows and resolved timestamp payloads are
+// stored in a sub-object under the `__crdb__` key in the top-level JSON object.
+type jsonEncoder struct {
+	opts map[string]string
+
+	alloc sqlbase.DatumAlloc
+	buf   bytes.Buffer
+}
+
+var _ Encoder = &jsonEncoder{}
+
+func makeJSONEncoder(opts map[string]string) *jsonEncoder {
+	return &jsonEncoder{opts: opts}
+}
+
+// EncodeKey implements the Encoder interface.
+func (e *jsonEncoder) EncodeKey(
+	tableDesc *sqlbase.TableDescriptor, row sqlbase.EncDatumRow,
+) ([]byte, error) {
+	colIdxByID := tableDesc.ColumnIdxMap()
+	jsonEntries := make([]interface{}, len(tableDesc.PrimaryIndex.ColumnIDs))
+	for i, colID := range tableDesc.PrimaryIndex.ColumnIDs {
+		idx, ok := colIdxByID[colID]
+		if !ok {
+			return nil, errors.Errorf(`unknown column id: %d`, colID)
+		}
+		datum, col := row[idx], tableDesc.Columns[idx]
+		if err := datum.EnsureDecoded(&col.Type, &e.alloc); err != nil {
+			return nil, err
+		}
+		var err error
+		jsonEntries[i], err = tree.AsJSON(datum.Datum)
+		if err != nil {
+			return nil, err
+		}
+	}
+	j, err := json.MakeJSON(jsonEntries)
+	if err != nil {
+		return nil, err
+	}
+	e.buf.Reset()
+	j.Format(&e.buf)
+	return e.buf.Bytes(), nil
+}
+
+// EncodeValue implements the Encoder interface.
+func (e *jsonEncoder) EncodeValue(
+	tableDesc *sqlbase.TableDescriptor, row sqlbase.EncDatumRow, updated hlc.Timestamp,
+) ([]byte, error) {
+	columns := tableDesc.Columns
+	jsonEntries := make(map[string]interface{}, len(columns))
+	if _, ok := e.opts[optUpdatedTimestamps]; ok {
+		jsonEntries[jsonMetaSentinel] = map[string]interface{}{
+			`updated`: tree.TimestampToDecimal(updated).Decimal.String(),
+		}
+	}
+	for i, col := range columns {
+		datum := row[i]
+		if err := datum.EnsureDecoded(&col.Type, &e.alloc); err != nil {
+			return nil, err
+		}
+		var err error
+		jsonEntries[col.Name], err = tree.AsJSON(datum.Datum)
+		if err != nil {
+			return nil, err
+		}
+	}
+	j, err := json.MakeJSON(jsonEntries)
+	if err != nil {
+		return nil, err
+	}
+	e.buf.Reset()
+	j.Format(&e.buf)
+	return e.buf.Bytes(), nil
+}
+
+// EncodeResolvedTimestamp implements the Encoder interface.
+func (e *jsonEncoder) EncodeResolvedTimestamp(resolved hlc.Timestamp) ([]byte, error) {
+	resolvedMetaRaw := map[string]interface{}{
+		jsonMetaSentinel: map[string]interface{}{
+			`resolved`: tree.TimestampToDecimal(resolved).Decimal.String(),
+		},
+	}
+	return gojson.Marshal(resolvedMetaRaw)
+}

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -1,0 +1,49 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	gosql "database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+// TODO(dan): This is just a sanity check for the avro stuff. We need an
+// end-to-end test with the avro format that interprets the bytes using a schema
+// it gets from the schema registry.
+func TestEncoderAvro(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'bar')`)
+
+		foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH format=$1`, optFormatAvroJSON)
+		defer foo.Close(t)
+
+		// There's randomized map iteration deep in the avro lib, so we can't use
+		// the normal assertPayloads helper.
+		table, _, key, value, _, ok := foo.Next(t)
+		if !ok {
+			t.Fatal(`expected row`)
+		}
+		require.Equal(t, `foo`, table)
+		require.Equal(t, `{"a":1}`, string(key))
+		require.Contains(t, string(value), `"a":1`)
+		require.Contains(t, string(value), `"b":{"string":"bar"}`)
+	}
+
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
+}


### PR DESCRIPTION
Avro is specifically designed to encode data and to enforce backward
and/or forward compatibility of that data as its schema changes.

https://avro.apache.org/docs/current/

This commit adds a method to convert our internal respresention of a
table schema into an avro schema. Avro foundationally includes the
schema with the data, either in the same bytes as the encoded records or
by pointing at unique ID in some instance of the Confluent Schema
Registry. The convention with Kafka is the latter, so when the Avro
format is used, we require the user also provide the url of their schema
registry.

A bunch of column types are still unsupported and this needs some
end-to-end tests to make sure the table descriptor to avro schema
mapping is right, so no release note for now.

Release note: None