### PR TITLE
workload/tpcc: adjust audit checks for 1 warehouse

### DIFF
--- a/pkg/workload/tpcc/audit.go
+++ b/pkg/workload/tpcc/audit.go
@@ -191,6 +191,10 @@ func check92253(a *auditor) auditResult {
 	a.Lock()
 	defer a.Unlock()
 
+	if a.warehouses == 1 {
+		// Not applicable when there are no remote warehouses.
+		return passResult
+	}
 	if a.newOrderTransactions < minSignificantTransactions {
 		return newSkipResult("not enough orders to be statistically significant")
 	}
@@ -230,6 +234,10 @@ func check92254(a *auditor) auditResult {
 	a.Lock()
 	defer a.Unlock()
 
+	if a.warehouses == 1 {
+		// Not applicable when there are no remote warehouses.
+		return passResult
+	}
 	if a.paymentTransactions < minSignificantTransactions {
 		return newSkipResult("not enough payments to be statistically significant")
 	}


### PR DESCRIPTION
I updated the TPCC audit checks not to complain about a lack of remote
orders/payments when there is only one warehouse.

Fixes #29275

Release note: None