### PR TITLE
importccl: remove duplicates in split list

### DIFF
--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -15,6 +15,7 @@
 package sql
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -324,6 +325,16 @@ func LoadCSV(
 
 	splits = append(splits, samples...)
 	sort.Slice(splits, func(a, b int) bool { return roachpb.Key(splits[a]).Compare(splits[b]) < 0 })
+
+	// Remove duplicates. These occur when the end span of a descriptor is the
+	// same as the start span of another.
+	origSplits := splits
+	splits = splits[:0]
+	for _, x := range origSplits {
+		if len(splits) == 0 || !bytes.Equal(x, splits[len(splits)-1]) {
+			splits = append(splits, x)
+		}
+	}
 
 	// jobSpans is a slice of split points, including table start and end keys
 	// for the table. We create router range spans then from taking each pair


### PR DESCRIPTION
Since we add all table descriptor spans to the split list, the end of
table 1 is the same as the start of table 2, and thus the start of table
2 would appear in the list twice. Since we now support multiple tables
and sequences, we can reduce the size of the split list (and thus the
routing table) by removing these duplicate split points. No correctness
problems, just a small perf/memory boost.

Release note: None