### PR TITLE
release-2.1: ui: add events summary tooltip

### DIFF
--- a/pkg/ui/src/views/cluster/containers/events/events.spec.tsx
+++ b/pkg/ui/src/views/cluster/containers/events/events.spec.tsx
@@ -82,8 +82,8 @@ describe("<EventRow>", function () {
 
       const provider = makeEvent(e);
       assert.lengthOf(provider.first().children(), 2);
-      const text = provider.first().childAt(0).text();
-      assert(_.includes(text, "created database"));
+      const tooltip = provider.first().childAt(0).childAt(0).childAt(0).childAt(0).childAt(0);
+      assert(_.includes(tooltip.text(), "created database"));
     });
 
     it("correctly renders an unknown event", function () {
@@ -94,8 +94,8 @@ describe("<EventRow>", function () {
 
       const provider = makeEvent(e);
       assert.lengthOf(provider.first().children(), 2);
-      const text = provider.first().childAt(0).text();
-      assert(_.includes(text, "Unknown Event Type"));
+      const tooltip = provider.first().childAt(0).childAt(0).childAt(0).childAt(0).childAt(0);
+      assert(_.includes(tooltip.text(), "Unknown Event Type"));
     });
   });
 });

--- a/pkg/ui/src/views/cluster/containers/events/events.styl
+++ b/pkg/ui/src/views/cluster/containers/events/events.styl
@@ -12,12 +12,6 @@
         border 0
     td
       padding-left 0
-      text-overflow ellipsis
-      overflow hidden
-
-      div
-        text-overflow ellipsis
-        overflow hidden
 
 .events__message
   font-size 14

--- a/pkg/ui/src/views/cluster/containers/events/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/events/index.tsx
@@ -17,6 +17,7 @@ import { TimestampToMoment } from "src/util/convert";
 import { getEventDescription } from "src/util/events";
 import { SortSetting } from "src/views/shared/components/sortabletable";
 import { SortedTable } from "src/views/shared/components/sortedtable";
+import { ToolTipWrapper } from "src/views/shared/components/toolTip";
 
 type Event$Properties = protos.cockroach.server.serverpb.EventsResponse.IEvent;
 
@@ -55,7 +56,11 @@ export class EventRow extends React.Component<EventRowProps, {}> {
     const { event } = this.props;
     const e = getEventInfo(event);
     return <tr>
-      <td><div className="events__message">{e.content}</div></td>
+      <td>
+        <ToolTipWrapper text={ e.content }>
+          <div className="events__message">{e.content}</div>
+        </ToolTipWrapper>
+      </td>
       <td><div className="events__timestamp">{e.fromNowString}</div></td>
     </tr>;
   }


### PR DESCRIPTION
Backport 1/1 commits from #30382.

/cc @cockroachdb/release

---

Fixes: #22742
Release note (admin ui change): Hovering over an entry in the Events
log now shows the full description of the event.

<img width="502" alt="screen shot 2018-09-18 at 3 08 56 pm" src="https://user-images.githubusercontent.com/793969/45710526-daf5f800-bb54-11e8-818e-e58bb3a12700.png">

