### PR TITLE
sqlbase: bugfix in rowfetcher with multiple cfs

### DIFF
--- a/pkg/sql/distsqlrun/indexjoiner_test.go
+++ b/pkg/sql/distsqlrun/indexjoiner_test.go
@@ -90,28 +90,6 @@ func TestIndexJoiner(t *testing.T) {
 			},
 		},
 		{
-			description: "Test duplicate rows in input stream on index join",
-			post: PostProcessSpec{
-				Projection:    true,
-				OutputColumns: []uint32{0, 1, 2},
-			},
-			input: sqlbase.EncDatumRows{
-				{v[0], v[2]},
-				{v[0], v[2]},
-				{v[0], v[5]},
-				{v[0], v[5]},
-				{v[0], v[2]},
-			},
-			outputTypes: threeIntCols,
-			expected: sqlbase.EncDatumRows{
-				{v[0], v[2], v[2]},
-				{v[0], v[2], v[2]},
-				{v[0], v[5], v[5]},
-				{v[0], v[5], v[5]},
-				{v[0], v[2], v[2]},
-			},
-		},
-		{
 			description: "Test a filter in the post process spec and using a secondary index",
 			post: PostProcessSpec{
 				Filter:        Expression{Expr: "@3 <= 5"}, // sum <= 5

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -255,19 +255,12 @@ type singleKVFetcher struct {
 // nextBatch implements the kvFetcher interface.
 func (f *singleKVFetcher) nextBatch(
 	_ context.Context,
-) (
-	ok bool,
-	kvs []roachpb.KeyValue,
-	batchResponse []byte,
-	numKvs int64,
-	maybeNewSpan bool,
-	err error,
-) {
+) (ok bool, kvs []roachpb.KeyValue, batchResponse []byte, numKvs int64, err error) {
 	if f.done {
-		return false, nil, nil, 0, true, nil
+		return false, nil, nil, 0, nil
 	}
 	f.done = true
-	return true, f.kvs[:], nil, 0, true, nil
+	return true, f.kvs[:], nil, 0, nil
 }
 
 // getRangesInfo implements the kvFetcher interface.

--- a/pkg/sql/sqlbase/fk.go
+++ b/pkg/sql/sqlbase/fk.go
@@ -275,20 +275,13 @@ type SpanKVFetcher struct {
 // nextBatch implements the kvFetcher interface.
 func (f *SpanKVFetcher) nextBatch(
 	_ context.Context,
-) (
-	ok bool,
-	kvs []roachpb.KeyValue,
-	batchResponse []byte,
-	numKvs int64,
-	maybeNewSpan bool,
-	err error,
-) {
+) (ok bool, kvs []roachpb.KeyValue, batchResponse []byte, numKvs int64, err error) {
 	if len(f.KVs) == 0 {
-		return false, nil, nil, 0, true, nil
+		return false, nil, nil, 0, nil
 	}
 	res := f.KVs
 	f.KVs = nil
-	return true, res, nil, 0, true, nil
+	return true, res, nil, 0, nil
 }
 
 // getRangesInfo implements the kvFetcher interface.

--- a/pkg/sql/sqlbase/rowfetcher_test.go
+++ b/pkg/sql/sqlbase/rowfetcher_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -326,6 +327,111 @@ func TestNextRowBatchLimiting(t *testing.T) {
 				t.Fatalf("expected %d rows, got %d rows", table.nRows, count)
 			}
 		})
+	}
+}
+
+// Regression test for #29374. Ensure that RowFetcher can handle multi-span
+// fetches where individual batches end in the middle of a multi-column family
+// row with not-null columns.
+func TestNextRowPartialColumnFamily(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	tableName := "t1"
+	table := fetcherEntryArgs{
+		modFactor: 42,
+		nRows:     2,
+		nCols:     4,
+	}
+
+	// Initialize a table with multiple column families with some not null ones.
+	// We'll insert rows that contain nulls for the nullable column families, to
+	// trick the rowfetcher heuristic that multiplies the input batch size by the
+	// number of columns in the table.
+	sqlutils.CreateTable(
+		t, sqlDB, tableName,
+		`
+k INT PRIMARY KEY, a INT NOT NULL, b INT NOT NULL, c INT NULL,
+FAMILY f1 (k), FAMILY f2(a), FAMILY f3(b), FAMILY f4(c),
+INDEX(c)
+`,
+		table.nRows,
+		sqlutils.ToRowFn(sqlutils.RowIdxFn,
+			sqlutils.RowModuloFn(table.modFactor),
+			sqlutils.RowModuloFn(table.modFactor),
+		),
+	)
+
+	alloc := &DatumAlloc{}
+
+	tableDesc := GetTableDescriptor(kvDB, sqlutils.TestDB, tableName)
+
+	var valNeededForCol util.FastIntSet
+	valNeededForCol.AddRange(0, table.nCols-1)
+
+	args := []initFetcherArgs{
+		{
+			tableDesc:       tableDesc,
+			indexIdx:        0,
+			valNeededForCol: valNeededForCol,
+		},
+	}
+
+	rf, err := initFetcher(args, false /*reverseScan*/, alloc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Start a scan that has multiple input spans, to tickle the codepath that
+	// sees an "empty batch". When we have multiple input spans, the kv server
+	// will always return one response per input span. Make sure that the
+	// empty response that will be produced in the case where the first span
+	// does not end before the limit is satisfied doesn't cause the rowfetcher
+	// to think that a row has ended, and therefore have issues when it sees
+	// the next kvs from that row in isolation in the next batch.
+
+	// We'll make the first span go to some random key in the middle of the
+	// key space (by appending a number to the index's start key) and the
+	// second span go from that key to the end of the index.
+	indexSpan := tableDesc.IndexSpan(tableDesc.PrimaryIndex.ID)
+	endKey := indexSpan.EndKey
+	midKey := encoding.EncodeUvarintAscending(indexSpan.Key, uint64(100))
+	indexSpan.EndKey = midKey
+
+	if err := rf.StartScan(
+		context.TODO(),
+		client.NewTxn(ctx, kvDB, 0, client.RootTxn),
+		roachpb.Spans{indexSpan,
+			roachpb.Span{Key: midKey, EndKey: endKey},
+		},
+		true, /*limitBatches*/
+		// Set a limitHint of 1 to more quickly end the first batch, causing a
+		// batch that ends between rows.
+		1,     /*limitHint*/
+		false, /*traceKV*/
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	var count int
+	for {
+		// Just try to grab the row - we don't need to validate the contents
+		// in this test.
+		datums, _, _, err := rf.NextRowDecoded(context.TODO())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if datums == nil {
+			break
+		}
+		count++
+	}
+
+	if table.nRows != count {
+		t.Fatalf("expected %d rows, got %d rows", table.nRows, count)
 	}
 }
 


### PR DESCRIPTION
A bug (introduced during the 2.1 cycle) caused scans issued via distsql
against tables with multiple column families to return incorrect results
or panic the server if some of the column families were marked as
non-nullable. This bug could only occur in distsql because it only
manifested when a rowfetcher was initialized with multiple input spans,
which only occurs in distsql where a particular node owns 2
non-contiguous portions of the keyspace. In this case, the code would
misinterpret the empty response from the scan request on the second
input span to mean that there was a limit on the last scan and that
we might have entered a new input span, which caused the rowfetcher to
mark the current row as ended and expect a full row starting from the
next key retrieved.

This was not the case, as this could happen in normal circumstances.
When a row had multiple column families, the rowfetcher would fail to
remember the results it had already seen for the earlier column families
in a row, if a batch happened to end half way through the row's column
families, and return incorrect and/or panic depending on the definition
of the table.

This patch removes this problem and adds a test for it. The test is a
little complicated but I verified that it does in fact panic before the
patch. It should catch problems like this in the future. We had no
explicit tests of the rowfetcher before with multiple input spans.

Note that this patch also deletes a test case, that tests correct
behavior in the case of seeing duplicate rows from the input stream
during an index join. This test case is contrived - index joins can
never encounter duplicate rows from the input stream - so it's safe to
delete.

Closes #29374.
Partially reverts #23474. The code no longer has protection against the condition that that PR was trying to guard against. But I don't think this is a problem in practice. If it crops up in new code it'll be very easy to notice and fix at that point.

cc @vivekmenezes

Release note: None