### PR TITLE
engine: avoid committing empty batches

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -655,6 +655,10 @@ DBStatus DBGetEncryptionRegistries(DBEngine* db, DBEncryptionRegistries* result)
 
 DBSSTable* DBGetSSTables(DBEngine* db, int* n) { return db->GetSSTables(n); }
 
+DBStatus DBGetSortedWALFiles(DBEngine* db, DBWALFile** files, int* n) {
+  return db->GetSortedWALFiles(files, n);
+}
+
 DBString DBGetUserProperties(DBEngine* db) { return db->GetUserProperties(); }
 
 DBStatus DBIngestExternalFiles(DBEngine* db, char** paths, size_t len, bool move_files,

--- a/c-deps/libroach/engine.h
+++ b/c-deps/libroach/engine.h
@@ -54,6 +54,7 @@ struct DBEngine {
   virtual DBStatus EnvLinkFile(DBSlice oldname, DBSlice newname) = 0;
 
   DBSSTable* GetSSTables(int* n);
+  DBStatus GetSortedWALFiles(DBWALFile** out_files, int* n);
   DBString GetUserProperties();
 };
 

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -371,6 +371,15 @@ typedef struct {
 // table.
 DBSSTable* DBGetSSTables(DBEngine* db, int* n);
 
+typedef struct {
+  uint64_t log_number;
+  uint64_t size;
+} DBWALFile;
+
+// Retrieve information about all of the write-ahead log files in order from
+// oldest to newest. The files array must be freed.
+DBStatus DBGetSortedWALFiles(DBEngine* db, DBWALFile** files, int* n);
+
 // DBGetUserProperties fetches the user properties stored in each sstable's
 // metadata. These are returned as a serialized SSTUserPropertiesCollection
 // proto.


### PR DESCRIPTION
Committing an empty batch previously wrote an empty entry to the RocksDB
WAL file. Coupled with a bug in Raft (etcd-io/etcd#10106), this was
causing unnecessary synchronous writes to disk during Raft heartbeats.

A non-rigorous benchmark shows that this yields a nearly 10% performance
improvement on a three node cluster under a write-heavy workload (kv5%).

^ @nvanbenschoten can this be right??? I don't trust my numbers, but I don't have time to run another benchmark tonight.

Note that the explosion of C++ is just to get at the RocksDB WAL's file size in a unit test. It's not a code path exercised anywhere but tests.

Release note: None