### PR TITLE
roachtest: mark acceptance as stable

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -25,8 +25,9 @@ func registerAcceptance(r *registry) {
 	// local mode the acceptance tests should be configured to run within a
 	// minute or so as these tests are run on every merge to master.
 	spec := testSpec{
-		Name:  "acceptance",
-		Nodes: nodes(4),
+		Name:   "acceptance",
+		Nodes:  nodes(4),
+		Stable: true, // DO NOT COPY to new tests
 	}
 
 	testCases := []struct {


### PR DESCRIPTION
all of its subtests are already stable, but in running a test locally I
noticed that the top-level test was marked as passing as unstable. I'm
not sure, but this might mean that the top-level test would actually not
fail? Either way, better to mark it as stable explicitly.

We should also spend some thought on how diverging notions of Stable in
sub vs top level test are treated, not sure that this is well-defined.

Release note: None