### PR TITLE
release-2.1: storage: tweak raft ready log message

### DIFF
--- a/pkg/storage/raft.go
+++ b/pkg/storage/raft.go
@@ -132,7 +132,7 @@ func logRaftReady(ctx context.Context, ready raft.Ready) {
 			fmt.Fprintf(&buf, "  Outgoing Message[%d]: %.200s\n",
 				i, raftDescribeMessage(m, raftEntryFormatter))
 		}
-		log.Infof(ctx, "raft ready\n%s", buf.String())
+		log.Infof(ctx, "raft ready (must-sync=%t)\n%s", ready.MustSync, buf.String())
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #30407.

/cc @cockroachdb/release

---

Include the `Ready.MustSync` field in the log message.

Release note: None
