### PR TITLE
[WIP] changefeedccl: support tables with more than one column family

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -179,7 +179,7 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 		targets:  ca.spec.Feed.Targets,
 		m:        tableHist,
 	}
-	rowsFn := kvsToRows(leaseMgr, tableHist, ca.spec.Feed, buf.Get)
+	rowsFn := kvsToRows(ca.flowCtx.ClientDB, leaseMgr, tableHist, ca.spec.Feed, buf.Get)
 
 	var knobs TestingKnobs
 	if cfKnobs, ok := ca.flowCtx.TestingKnobs().Changefeed.(*TestingKnobs); ok {

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -326,11 +326,6 @@ func validateChangefeedTable(
 	if tableDesc.IsSequence() {
 		return errors.Errorf(`CHANGEFEED cannot target sequences: %s`, tableDesc.Name)
 	}
-	if len(tableDesc.Families) != 1 {
-		return errors.Errorf(
-			`CHANGEFEEDs are currently supported on tables with exactly 1 column family: %s has %d`,
-			tableDesc.Name, len(tableDesc.Families))
-	}
 
 	if tableDesc.State == sqlbase.TableDescriptor_DROP {
 		return errors.Errorf(`"%s" was dropped or truncated`, t.StatementTimeName)

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -131,7 +131,7 @@ func createBenchmarkChangefeed(
 		targets:  details.Targets,
 		m:        th,
 	}
-	rowsFn := kvsToRows(s.LeaseManager().(*sql.LeaseManager), th, details, buf.Get)
+	rowsFn := kvsToRows(s.DB(), s.LeaseManager().(*sql.LeaseManager), th, details, buf.Get)
 	tickFn := emitEntries(details, sink, rowsFn, TestingKnobs{})
 
 	ctx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
If a table has multiple column families and only one of them is changed
in a given statement, only the kv for that column family will be changed
by the sql system. This means we wouldn't have enough data to
reconstruct the row.

We can fetch the row's entire kv data with a prefix scan that's forced
to be at the timestamp of the changed kv. This has two issues

- it introduces a blocking kv read (in the common case, this is not as
  bad as it sounds since this code is likely running on the leaseholder
  and the data can be served locally)
- if N column families were updated at once, then we'll run this process
  N times and get N exact duplicates in the output

Release note (enterprise change): CHANGEFEEDs now support tables with
multiple column families, though with degraded performance.

Closes #28667