### PR TITLE
roachtest: don't disambiguate issue title by branch

### DIFF
--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -682,8 +682,8 @@ func (r *registry) run(
 						}
 						if err := issues.Post(
 							context.Background(),
-							fmt.Sprintf("roachtest: %s failed on %s", t.Name(), branch),
-							"roachtest", t.Name(), string(output), authorEmail,
+							fmt.Sprintf("roachtest: %s failed", t.Name()),
+							"roachtest", t.Name(), "The test failed on "+branch+":\n"+string(output), authorEmail,
 						); err != nil {
 							fmt.Fprintf(r.out, "failed to post issue: %s\n", err)
 						}


### PR DESCRIPTION
This tends to create duplicate issues for a similar root cause. I think
it's better to collect failures from different branches in an umbrella
issue, even though it implies that we need to be more careful about
closing them (on the flip side, it incentivizes looking into all failing
branches simultaneously).

Release note: None