### PR TITLE
ui: fix default jobs page sort

### DIFF
--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -172,7 +172,7 @@ const jobsTableColumns: ColumnDescriptor<Job>[] = [
 const sortSetting = new LocalSetting<AdminUIState, SortSetting>(
   "jobs/sort_setting",
   s => s.localSettings,
-  { sortKey: 2 /* creation time */, ascending: false },
+  { sortKey: 3 /* creation time */, ascending: false },
 );
 
 interface JobsTableProps {


### PR DESCRIPTION
In #18137 a column was added, but the default sort
(which is specified by index) was not updated.  This
updates it to correctly sort on creation time.

Fixes: #30418
Release note (admin ui change): Fixes an issue where
the default sort on the Jobs page was incorrectly
the User column rather than the Creation Time.