### PR TITLE
roachtest: fix tpcc-1000 cdc test

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -278,7 +278,11 @@ func emitResolvedTimestamp(
 	// before emitting the resolved timestamp to the sink.
 	if jobProgressedFn != nil {
 		progressedClosure := func(ctx context.Context, d jobspb.ProgressDetails) hlc.Timestamp {
-			d.(*jobspb.Progress_Changefeed).Changefeed.ResolvedSpans = resolvedSpans
+			// TODO(dan): This was making enormous jobs rows, especially in
+			// combination with how many mvcc versions there are. Cut down on
+			// the amount of data used here dramatically and re-enable.
+			//
+			// d.(*jobspb.Progress_Changefeed).Changefeed.ResolvedSpans = resolvedSpans
 			return resolved
 		}
 		if err := jobProgressedFn(ctx, progressedClosure); err != nil {


### PR DESCRIPTION
The nightly tpcc-1000 roachtest has been consistently failing with
"context deadline exceeded" errors. I tried turning off changefeeds and
they didn't go away, so I dug a bit into what was different about this
setup and noticed that we were neglecting to set nobarrier. I'll let
that fix run for a few nights and see if it helps before digging any
further.

I also noticed that our job row's mvcc history was hundreds of megabytes
in total, which in one test started causing "split failed while applying
backpressure: could not find valid split key" errors. This is almost
certainly caused by excessive span-level progress checkpointing, so rip
that out for now until we reduce the amount of data it makes.

Kafka choas should work now, so unskip the test.

Change the initial scan latency to be computed based on the statement
time, making it more correct and simplifying it in the process.

Release note: None