### PR TITLE
storage: Respect zone.NumReplicas even if it's an even number

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -251,10 +251,16 @@ func GetNeededReplicas(
 	// replicas specified in the zone config, the cluster can still function.
 	need = int(math.Min(float64(aliveReplicas-decommissioningReplicas), float64(need)))
 
-	// Ensure that we don't up- or down-replicate to an even number of replicas.
-	// Note that in the case of 5 desired replicas and a decommissioning store, this prefers
-	// down-replicating from 5 to 3 rather than sticking with 4 desired stores or blocking
-	// the decommissioning from completing.
+	// Ensure that we don't up- or down-replicate to an even number of replicas
+	// unless an even number of replicas was specifically requested by the user
+	// in the zone config.
+	//
+	// Note that in the case of 5 desired replicas and a decommissioning store,
+	// this prefers down-replicating from 5 to 3 rather than sticking with 4
+	// desired stores or blocking the decommissioning from completing.
+	if need == numZoneReplicas {
+		return need
+	}
 	if need%2 == 0 {
 		need = need - 1
 	}


### PR DESCRIPTION
Undoes a change in behavior introduced by #27349. We allow users to set
NumReplicas to even numbers (except for 2, which is disallowed), so we
should respect such settings when we encounter them.

Also add a proper test for GetNeededReplicas.

Fixes #30435

Release note: None