### PR TITLE
storage: prohibit splitting on Range.StartKey for non-SQL ranges

### DIFF
--- a/c-deps/libroach/mvcc.cc
+++ b/c-deps/libroach/mvcc.cc
@@ -229,7 +229,6 @@ DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, DBKey min_sp
   std::string best_split_key = start_key;
   int64_t best_split_diff = std::numeric_limits<int64_t>::max();
   std::string prev_key;
-  int n = 0;
 
   for (; iter_rep->Valid() && kComparator.Compare(iter_rep->key(), end_key) < 0; iter_rep->Next()) {
     const rocksdb::Slice key = iter_rep->key();
@@ -240,9 +239,7 @@ DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, DBKey min_sp
       return FmtStatus("unable to decode key");
     }
 
-    ++n;
-    const bool valid =
-        n > 1 && IsValidSplitKey(decoded_key) && decoded_key.compare(min_split_key) >= 0;
+    const bool valid = IsValidSplitKey(decoded_key) && decoded_key.compare(min_split_key) >= 0;
     int64_t diff = target_size - size_so_far;
     if (diff < 0) {
       diff = -diff;

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -99,7 +99,8 @@ type Iterator interface {
 	ComputeStats(start, end MVCCKey, nowNanos int64) (enginepb.MVCCStats, error)
 	// FindSplitKey finds a key from the given span such that the left side of
 	// the split is roughly targetSize bytes. The returned key will never be
-	// chosen from the key ranges listed in keys.NoSplitSpans.
+	// chosen from the key ranges listed in keys.NoSplitSpans and will always
+	// sort equal to or after minSplitKey.
 	FindSplitKey(start, end, minSplitKey MVCCKey, targetSize int64) (MVCCKey, error)
 	// MVCCGet retrieves the value for the key at the specified timestamp. The
 	// value is returned in batch repr format with the key being present as the

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -2684,9 +2685,15 @@ func MVCCFindSplitKey(
 	it := engine.NewIterator(IterOptions{UpperBound: endKey.AsRawKey()})
 	defer it.Close()
 
-	// We must never return a split key that falls within a table row. (Rows in
-	// tables with multiple column families are comprised of multiple keys, one
-	// key per column family.)
+	// We want to avoid splitting at the first key in the range because that
+	// could result in an empty left-hand range. To prevent this, we scan for
+	// the first key in the range and consider the key that sorts directly after
+	// this as the minimum split key.
+	//
+	// In addition, we must never return a split key that falls within a table
+	// row. (Rows in tables with multiple column families are comprised of
+	// multiple keys, one key per column family.) However, we do allow a split
+	// key that falls between a row and its interleaved rows.
 	//
 	// Managing this is complicated: the logic for picking a split key that
 	// creates ranges of the right size lives in C++, while the logic for
@@ -2736,7 +2743,9 @@ func MVCCFindSplitKey(
 		if err != nil {
 			return nil, err
 		}
-		minSplitKey = firstRowKey.PrefixEnd()
+		// Allow a split key before other rows in the same table or before any
+		// rows in interleaved tables.
+		minSplitKey = encoding.EncodeInterleavedSentinel(firstRowKey)
 	} else {
 		// The first key in the range does not represent a row in a SQL table.
 		// Allow a split at any key that sorts after it.

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -2728,7 +2728,7 @@ func MVCCFindSplitKey(
 	} else if !ok {
 		return nil, nil
 	}
-	minSplitKey := key
+	var minSplitKey roachpb.Key
 	if _, _, err := keys.DecodeTablePrefix(it.UnsafeKey().Key); err == nil {
 		// The first key in this range represents a row in a SQL table. Advance the
 		// minSplitKey past this row to avoid the problems described above.
@@ -2736,13 +2736,17 @@ func MVCCFindSplitKey(
 		if err != nil {
 			return nil, err
 		}
-		minSplitKey = roachpb.RKey(firstRowKey.PrefixEnd())
+		minSplitKey = firstRowKey.PrefixEnd()
+	} else {
+		// The first key in the range does not represent a row in a SQL table.
+		// Allow a split at any key that sorts after it.
+		minSplitKey = it.Key().Key.Next()
 	}
 
 	splitKey, err := it.FindSplitKey(
 		MakeMVCCMetadataKey(key.AsRawKey()),
 		MakeMVCCMetadataKey(endKey.AsRawKey()),
-		MakeMVCCMetadataKey(minSplitKey.AsRawKey()),
+		MakeMVCCMetadataKey(minSplitKey),
 		targetSize)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -3483,18 +3483,27 @@ func TestFindValidSplitKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const userID = keys.MinUserDescID
+	const interleave1 = userID + 1
+	const interleave2 = userID + 2
+	const interleave3 = userID + 3
 	// Manually creates rows corresponding to the schema:
 	// CREATE TABLE t (id1 STRING, id2 STRING, ... PRIMARY KEY (id1, id2, ...))
-	tablePrefix := func(id uint32, rowVals ...string) roachpb.Key {
-		tableKey := keys.MakeTablePrefix(id)
-		rowKey := roachpb.Key(encoding.EncodeVarintAscending(append([]byte(nil), tableKey...), 1))
+	addTablePrefix := func(prefix roachpb.Key, id uint32, rowVals ...string) roachpb.Key {
+		tableKey := append(prefix, keys.MakeTablePrefix(id)...)
+		rowKey := roachpb.Key(encoding.EncodeVarintAscending(tableKey, 1))
 		for _, rowVal := range rowVals {
 			rowKey = encoding.EncodeStringAscending(rowKey, rowVal)
 		}
 		return rowKey
 	}
+	tablePrefix := func(id uint32, rowVals ...string) roachpb.Key {
+		return addTablePrefix(nil, id, rowVals...)
+	}
 	addColFam := func(rowKey roachpb.Key, colFam uint32) roachpb.Key {
 		return keys.MakeFamilyKey(append([]byte(nil), rowKey...), colFam)
+	}
+	addInterleave := func(rowKey roachpb.Key) roachpb.Key {
+		return encoding.EncodeInterleavedSentinel(rowKey)
 	}
 
 	testCases := []struct {
@@ -3688,6 +3697,84 @@ func TestFindValidSplitKeys(t *testing.T) {
 			rangeStart: tablePrefix(userID, "a"),
 			expSplit:   tablePrefix(userID, "a", "b"),
 			expError:   false,
+		},
+		// One large first row with interleaved child rows. Check that we can
+		// split before the first interleaved row.
+		{
+			keys: []roachpb.Key{
+				addColFam(tablePrefix(userID, "a"), 0),
+				addColFam(tablePrefix(userID, "a"), 1),
+				addColFam(tablePrefix(userID, "a"), 2),
+				addColFam(addTablePrefix(addInterleave(tablePrefix(userID, "a")), interleave1, "b"), 0),
+				addColFam(addTablePrefix(addInterleave(tablePrefix(userID, "a")), interleave1, "b"), 1),
+				addColFam(addTablePrefix(addInterleave(tablePrefix(userID, "a")), interleave2, "c"), 1),
+			},
+			rangeStart: tablePrefix(userID, "a"),
+			expSplit:   addTablePrefix(addInterleave(tablePrefix(userID, "a")), interleave1, "b"),
+			expError:   false,
+		},
+		// One large first row with a double interleaved child row. Check that
+		// we can split before the double interleaved row.
+		{
+			keys: []roachpb.Key{
+				addColFam(tablePrefix(userID, "a"), 0),
+				addColFam(tablePrefix(userID, "a"), 1),
+				addColFam(tablePrefix(userID, "a"), 2),
+				addColFam(addTablePrefix(addInterleave(
+					addTablePrefix(addInterleave(tablePrefix(userID, "a")), interleave1, "b"),
+				), interleave2, "d"), 3),
+			},
+			rangeStart: tablePrefix(userID, "a"),
+			expSplit: addTablePrefix(addInterleave(
+				addTablePrefix(addInterleave(tablePrefix(userID, "a")), interleave1, "b"),
+			), interleave2, "d"),
+			expError: false,
+		},
+		// Two interleaved rows. Check that we can split between them.
+		{
+			keys: []roachpb.Key{
+				addColFam(addTablePrefix(addInterleave(tablePrefix(userID, "a")), interleave1, "b"), 0),
+				addColFam(addTablePrefix(addInterleave(tablePrefix(userID, "a")), interleave1, "b"), 1),
+				addColFam(addTablePrefix(addInterleave(tablePrefix(userID, "a")), interleave2, "c"), 3),
+				addColFam(addTablePrefix(addInterleave(tablePrefix(userID, "a")), interleave2, "c"), 4),
+			},
+			rangeStart: addTablePrefix(addInterleave(tablePrefix(userID, "a")), interleave1, "b"),
+			expSplit:   addTablePrefix(addInterleave(tablePrefix(userID, "a")), interleave2, "c"),
+			expError:   false,
+		},
+		// Two small rows with interleaved child rows after the second. Check
+		// that we can split before the first interleaved row.
+		{
+			keys: []roachpb.Key{
+				addColFam(tablePrefix(userID, "a"), 0),
+				addColFam(tablePrefix(userID, "b"), 0),
+				addColFam(addTablePrefix(addInterleave(tablePrefix(userID, "b")), interleave1, "b"), 0),
+				addColFam(addTablePrefix(addInterleave(tablePrefix(userID, "b")), interleave1, "b"), 1),
+				addColFam(addTablePrefix(addInterleave(tablePrefix(userID, "b")), interleave2, "c"), 1),
+			},
+			rangeStart: tablePrefix(userID, "a"),
+			expSplit:   addTablePrefix(addInterleave(tablePrefix(userID, "b")), interleave1, "b"),
+			expError:   false,
+		},
+		// A chain of interleaved rows. Check that we can split them.
+		{
+			keys: []roachpb.Key{
+				addColFam(tablePrefix(userID, "a"), 0),
+				addColFam(addTablePrefix(addInterleave(tablePrefix(userID, "a")), interleave1, "b"), 0),
+				addColFam(addTablePrefix(addInterleave(
+					addTablePrefix(addInterleave(tablePrefix(userID, "a")), interleave1, "b"),
+				), interleave2, "c"), 0),
+				addColFam(addTablePrefix(addInterleave(
+					addTablePrefix(addInterleave(
+						addTablePrefix(addInterleave(tablePrefix(userID, "a")), interleave1, "b"),
+					), interleave2, "c"),
+				), interleave3, "d"), 0),
+			},
+			rangeStart: tablePrefix(userID, "a"),
+			expSplit: addTablePrefix(addInterleave(
+				addTablePrefix(addInterleave(tablePrefix(userID, "a")), interleave1, "b"),
+			), interleave2, "c"),
+			expError: false,
 		},
 	}
 


### PR DESCRIPTION
Fixes #30396.

Before this change, we allowed splits on a range's StartKey as long as
that key had multiple MVCC versions. This change logically extends #24896
to fix this issue as well by preventing MVCCFindSplitKey from returning
the range's start key. In doing so, it also prevents MVCCFindSplitKey
from returning the first key in its range, even if it's not equal to the
range's StartKey. This is free to enforce and seems like the right thing
to do.

Release note: None