### PR TITLE
storage: give TestReplicateRemovedNodeDisruptiveElection more time

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -3193,7 +3193,7 @@ func TestReplicateRemovedNodeDisruptiveElection(t *testing.T) {
 		default:
 			t.Fatalf("unexpected error type %T: %s", pErr.GetDetail(), pErr)
 		}
-	case <-time.After(5 * time.Second):
+	case <-time.After(45 * time.Second):
 		t.Fatal("did not get expected error")
 	}
 


### PR DESCRIPTION
Perhaps:

Fixes #27253.

Release note: None