### PR TITLE
release-2.1: opt: add missing ColSet.Copy

### DIFF
--- a/pkg/sql/opt/norm/decorrelate.go
+++ b/pkg/sql/opt/norm/decorrelate.go
@@ -470,7 +470,7 @@ func (c *CustomFuncs) TranslateNonIgnoreAggs(
 
 	var aggCanaryVar memo.GroupID
 	pb := projectionsBuilder{f: c.f}
-	passthroughCols := c.OutputCols(newIn)
+	passthroughCols := c.OutputCols(newIn).Copy()
 	passthroughCols.Remove(int(canaryCol))
 
 	for i, elem := range aggsElems {


### PR DESCRIPTION
Backport 1/1 commits from #30436.

/cc @cockroachdb/release

---

This leads to a crash if the small cutoff for FastIntSet is set to 1.

Release note: None
