### PR TITLE
release-2.1: opt: fix panic when srf used with GROUP BY

### DIFF
--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -515,3 +515,10 @@ var aggOpLookup = map[string]opt.Operator{
 	"json_agg":   opt.JsonAggOp,
 	"jsonb_agg":  opt.JsonbAggOp,
 }
+
+func newGroupingError(name *tree.Name) error {
+	return pgerror.NewErrorf(pgerror.CodeGroupingError,
+		"column \"%s\" must appear in the GROUP BY clause or be used in an aggregate function",
+		tree.ErrString(name),
+	)
+}

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -908,3 +908,19 @@ project
                      │         │                   └── true [type=bool]
                      │         └── const: 1000 [type=int]
                      └── true [type=bool]
+
+# Regression test for #30412.
+build
+SELECT 0, unnest(ARRAY[0]) GROUP BY 1
+----
+error (42803): column "unnest" must appear in the GROUP BY clause or be used in an aggregate function
+
+build
+SELECT 0, unnest(ARRAY[0]) GROUP BY 1, 2
+----
+error: unnest(): generator functions are not allowed in GROUP BY
+
+build
+SELECT 0, information_schema._pg_expandarray(ARRAY[0]) GROUP BY 1
+----
+error (42803): column "x" must appear in the GROUP BY clause or be used in an aggregate function


### PR DESCRIPTION
Backport 1/1 commits from #30446.

/cc @cockroachdb/release

---

Instead of panicking, we now throw an appropriate error.

Fixes #30412

Release note (bug fix): Fixed a panic that occurred when a
generator function such as unnest was used in the SELECT list
in the presence of GROUP BY.
