### PR TITLE
sql: Use TableCollection cache for by-ID descriptor resolution

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -362,6 +362,13 @@ func (r fkResolver) LookupSchema(
 	return false, nil, errSchemaResolver
 }
 
+// Implements the sql.SchemaResolver interface.
+func (r fkResolver) LookupTableByID(
+	ctx context.Context, id sqlbase.ID,
+) (sqlbase.TableLookup, error) {
+	return sqlbase.TableLookup{}, errSchemaResolver
+}
+
 const csvDatabaseName = "csv"
 
 func finalizeCSVBackup(

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -92,7 +92,7 @@ func (p *planner) Delete(
 		ctx,
 		*desc,
 		sqlbase.CheckDeletes,
-		p.lookupFKTable,
+		p.LookupTableByID,
 		p.CheckPrivilege,
 		p.analyzeExpr,
 	)

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -105,7 +105,7 @@ func (p *planner) Insert(
 		ctx,
 		*desc,
 		fkCheckType,
-		p.lookupFKTable,
+		p.LookupTableByID,
 		p.CheckPrivilege,
 		p.analyzeExpr,
 	)

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -390,7 +390,10 @@ func (p *planner) ResolveTableName(ctx context.Context, tn *tree.TableName) erro
 	return err
 }
 
-func (p *planner) lookupFKTable(
+// LookupTableByID looks up a table, by the given descriptor ID. Based on the
+// CommonLookupFlags, it could use or skip the TableCollection cache. See
+// TableCollection.getTableVersionByID for how it's used.
+func (p *planner) LookupTableByID(
 	ctx context.Context, tableID sqlbase.ID,
 ) (sqlbase.TableLookup, error) {
 	flags := ObjectLookupFlags{

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -43,6 +43,7 @@ type SchemaResolver interface {
 	CurrentSearchPath() sessiondata.SearchPath
 	CommonLookupFlags(ctx context.Context, required bool) CommonLookupFlags
 	ObjectLookupFlags(ctx context.Context, required bool) ObjectLookupFlags
+	LookupTableByID(ctx context.Context, id sqlbase.ID) (sqlbase.TableLookup, error)
 }
 
 var _ SchemaResolver = &planner{}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -93,7 +93,7 @@ func (p *planner) Update(
 		ctx,
 		*desc,
 		sqlbase.CheckUpdates,
-		p.lookupFKTable,
+		p.LookupTableByID,
 		p.CheckPrivilege,
 		p.analyzeExpr,
 	)


### PR DESCRIPTION
This PR updates the optimizer catalog's ResolveDataSourceByID code
path to use the planner's TableCollection descriptor cache instead
of always doing kv reads. It also updates the resolver interface
to have an explicit tableID -> table descriptor resolver method.

Release note: None