### PR TITLE
opt: fix panic with correlated subquery in WHERE

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -2466,3 +2466,75 @@ project
                      │              └── array-agg [type=int[]]
                      │                   └── variable: x [type=int]
                      └── array: [type=int[]]
+
+# Regression test for #30424. Aggregate function in the WHERE subquery
+# is aggregated in the outer scope, so it's not allowed.
+build
+SELECT s FROM a WHERE (SELECT count(i) >= 100) GROUP BY s
+----
+error (42803): aggregate functions are not allowed in WHERE
+
+# Aggregate function in the WHERE subquery is aggregated in the subquery scope,
+# so it's allowed.
+build
+SELECT s FROM a WHERE (SELECT count(i) >= 100 FROM a) GROUP BY s
+----
+group-by
+ ├── columns: s:4(string)
+ ├── grouping columns: a.s:4(string)
+ └── project
+      ├── columns: a.s:4(string)
+      └── select
+           ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+           ├── scan a
+           │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+           └── filters [type=bool]
+                └── subquery [type=bool]
+                     └── max1-row
+                          ├── columns: "?column?":12(bool)
+                          └── project
+                               ├── columns: "?column?":12(bool)
+                               ├── scalar-group-by
+                               │    ├── columns: count:11(int)
+                               │    ├── project
+                               │    │    ├── columns: a.i:7(int)
+                               │    │    └── scan a
+                               │    │         └── columns: a.k:6(int!null) a.i:7(int) a.f:8(float) a.s:9(string) a.j:10(jsonb)
+                               │    └── aggregations
+                               │         └── count [type=int]
+                               │              └── variable: a.i [type=int]
+                               └── projections
+                                    └── ge [type=bool]
+                                         ├── variable: count [type=int]
+                                         └── const: 100 [type=int]
+
+exec-ddl
+CREATE TABLE xyzs (x INT PRIMARY KEY, y INT, z FLOAT NOT NULL, s STRING, UNIQUE (s DESC, z));
+----
+TABLE xyzs
+ ├── x int not null
+ ├── y int
+ ├── z float not null
+ ├── s string
+ ├── INDEX primary
+ │    └── x int not null
+ └── INDEX secondary
+      ├── s string desc
+      ├── z float not null
+      └── x int not null (storing)
+
+exec-ddl
+CREATE TABLE kuv (k INT PRIMARY KEY, u FLOAT, v STRING);
+----
+TABLE kuv
+ ├── k int not null
+ ├── u float
+ ├── v string
+ └── INDEX primary
+      └── k int not null
+
+# Regression test for #29114.
+build
+SELECT * FROM xyzs WHERE (SELECT sum(x) FROM (SELECT u FROM kuv) GROUP BY u) > 100;
+----
+error (42803): aggregate functions are not allowed in WHERE

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -102,6 +102,11 @@ func (s *SemaProperties) Require(context string, rejectFlags SemaRejectFlags) {
 	s.Derived.Clear()
 }
 
+// IsSet checks if the given rejectFlag is set as a required property.
+func (s *SemaProperties) IsSet(rejectFlags SemaRejectFlags) bool {
+	return s.required.rejectFlags&rejectFlags != 0
+}
+
 // Restore restores a copy of a SemaProperties. Use with:
 // defer semaCtx.Properties.Restore(semaCtx.Properties)
 func (s *SemaProperties) Restore(orig SemaProperties) {


### PR DESCRIPTION
This commit fixes a panic which was occuring when a correlated
aggregate was contained in a subquery in the `WHERE` clause, and
the level of aggregation was the outer query. For example:

  `SELECT s FROM a WHERE (SELECT COUNT(i) >= 100) GROUP BY s`

In this case, `COUNT(i)` in the subquery is scoped at the level of
the outer query. Since it's not legal to have aggregates in the
WHERE clause, this now causes an error instead of a panic.

Fixes #29114
Fixes #30424

Release note (bug fix): Fixed a panic when a correlated subquery
in the WHERE clause contained an aggregate referencing the outer query.
This now causes an error since aggregates are not allowed in WHERE.