### PR TITLE
release-2.1: storage: adjust system replica count based on node availibility

### DIFF
--- a/pkg/ccl/cliccl/cli_test.go
+++ b/pkg/ccl/cliccl/cli_test.go
@@ -193,8 +193,10 @@ func Example_cclzone() {
 	// .default
 	// .liveness
 	// .meta
+	// .system
 	// db.t.p1
 	// db.t@primary
+	// system
 	// system.jobs
 	// zone rm db.t@primary
 	// zone get db.t.p0
@@ -219,7 +221,9 @@ func Example_cclzone() {
 	// .default
 	// .liveness
 	// .meta
+	// .system
 	// db.t.p1
+	// system
 	// system.jobs
 	// zone rm db.t.p0
 	// zone rm db.t.p1
@@ -227,6 +231,8 @@ func Example_cclzone() {
 	// .default
 	// .liveness
 	// .meta
+	// .system
+	// system
 	// system.jobs
 	// zone set db.t@primary --file=./../../cli/testdata/zone_attrs_advanced.yaml
 	// range_min_bytes: 1048576

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -509,6 +509,8 @@ func Example_zone() {
 	// .default
 	// .liveness
 	// .meta
+	// .system
+	// system
 	// system.jobs
 	// zone set system --file=./testdata/zone_attrs.yaml
 	// range_min_bytes: 1048576
@@ -523,6 +525,7 @@ func Example_zone() {
 	// .default
 	// .liveness
 	// .meta
+	// .system
 	// system
 	// system.jobs
 	// zone get .liveness
@@ -531,7 +534,7 @@ func Example_zone() {
 	// range_max_bytes: 67108864
 	// gc:
 	//   ttlseconds: 600
-	// num_replicas: 1
+	// num_replicas: 5
 	// constraints: []
 	// lease_preferences: []
 	// zone get .meta
@@ -540,7 +543,7 @@ func Example_zone() {
 	// range_max_bytes: 67108864
 	// gc:
 	//   ttlseconds: 3600
-	// num_replicas: 1
+	// num_replicas: 5
 	// constraints: []
 	// lease_preferences: []
 	// zone get system.nonexistent
@@ -583,6 +586,7 @@ func Example_zone() {
 	// .default
 	// .liveness
 	// .meta
+	// .system
 	// system.jobs
 	// zone rm .default
 	// pq: cannot remove default zone

--- a/pkg/cmd/roachtest/gossip.go
+++ b/pkg/cmd/roachtest/gossip.go
@@ -325,6 +325,8 @@ func runGossipRestartNodeOne(ctx context.Context, t *test, c *cluster) {
 	// Evacuate all of the ranges off node 1 with zone config constraints. See
 	// the racks setting specified when the cluster was started.
 	run(`ALTER RANGE default %[1]s CONFIGURE ZONE %[2]s 'constraints: {"-rack=0"}'`)
+	run(`ALTER RANGE system %[1]s CONFIGURE ZONE %[2]s 'constraints: {"-rack=0"}'`)
+	run(`ALTER DATABASE system %[1]s CONFIGURE ZONE %[2]s 'constraints: {"-rack=0"}'`)
 	run(`ALTER RANGE meta %[1]s CONFIGURE ZONE %[2]s 'constraints: {"-rack=0"}'`)
 	run(`ALTER RANGE liveness %[1]s CONFIGURE ZONE %[2]s 'constraints: {"-rack=0"}'`)
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -74,7 +74,14 @@ func TestSelfBootstrap(t *testing.T) {
 // TestHealthCheck runs a basic sanity check on the health checker.
 func TestHealthCheck(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	cfg := config.DefaultZoneConfig()
+	cfg.NumReplicas = 1
+	fnSys := config.TestingSetDefaultSystemZoneConfig(cfg)
+	defer fnSys()
+
 	s, err := serverutils.StartServerRaw(base.TestServerArgs{})
+
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -201,7 +201,6 @@ zone_id  cli_specifier  config_yaml  config_sql  config_protobuf
 
 statement ok
 INSERT INTO system.zones (id, config) VALUES
-  (17, (SELECT config_protobuf FROM crdb_internal.zones WHERE zone_id = 0)),
   (18, (SELECT config_protobuf FROM crdb_internal.zones WHERE zone_id = 0)),
   (53, (SELECT config_protobuf FROM crdb_internal.zones WHERE zone_id = 0)),
   (54, (SELECT config_protobuf FROM crdb_internal.zones WHERE zone_id = 0))
@@ -210,6 +209,7 @@ query IT
 SELECT zone_id, cli_specifier FROM crdb_internal.zones ORDER BY 1
 ----
 0   .default
+1   system
 15  system.jobs
 16  .meta
 17  .system

--- a/pkg/sql/show_trace_replica_test.go
+++ b/pkg/sql/show_trace_replica_test.go
@@ -37,6 +37,7 @@ func TestShowTraceReplica(t *testing.T) {
 	cfg := config.DefaultZoneConfig()
 	cfg.NumReplicas = 1
 	defer config.TestingSetDefaultZoneConfig(cfg)()
+	defer config.TestingSetDefaultSystemZoneConfig(cfg)()
 
 	ctx := context.Background()
 	tsArgs := func(node string) base.TestServerArgs {
@@ -59,6 +60,7 @@ func TestShowTraceReplica(t *testing.T) {
 
 	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
 	sqlDB.Exec(t, `ALTER RANGE "default" CONFIGURE ZONE USING constraints = '[+n4]'`)
+	sqlDB.Exec(t, `ALTER DATABASE system CONFIGURE ZONE USING constraints = '[+n4]'`)
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 	sqlDB.Exec(t, `CREATE TABLE d.t1 (a INT PRIMARY KEY)`)
 	sqlDB.Exec(t, `CREATE TABLE d.t2 (a INT PRIMARY KEY)`)

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -846,17 +846,24 @@ func addSystemDatabaseToSchema(target *MetadataSchema) {
 	zoneConf := config.DefaultZoneConfig()
 	target.otherKV = append(target.otherKV, createZoneConfigKV(keys.RootNamespaceID, zoneConf))
 
-	// .meta zone config entry with a shorter GC time.
-	zoneConf.GC.TTLSeconds = 60 * 60 // 1h
-	target.otherKV = append(target.otherKV, createZoneConfigKV(keys.MetaRangesID, zoneConf))
+	systemZoneConf := config.DefaultSystemZoneConfig()
+	metaRangeZoneConf := config.DefaultSystemZoneConfig()
+	jobsZoneConf := config.DefaultSystemZoneConfig()
+	livenessZoneConf := config.DefaultSystemZoneConfig()
 
-	// Liveness zone config entry with a shorter GC time.
-	zoneConf.GC.TTLSeconds = 10 * 60 // 10m
-	target.otherKV = append(target.otherKV, createZoneConfigKV(keys.LivenessRangesID, zoneConf))
+	// .meta zone config entry with a shorter GC time.
+	metaRangeZoneConf.GC.TTLSeconds = 60 * 60 // 1h
+	target.otherKV = append(target.otherKV, createZoneConfigKV(keys.MetaRangesID, metaRangeZoneConf))
 
 	// Jobs zone config entry with a shorter GC time.
-	zoneConf.GC.TTLSeconds = 10 * 60 // 10m
-	target.otherKV = append(target.otherKV, createZoneConfigKV(keys.JobsTableID, zoneConf))
+	jobsZoneConf.GC.TTLSeconds = 10 * 60 // 10m
+	target.otherKV = append(target.otherKV, createZoneConfigKV(keys.JobsTableID, jobsZoneConf))
+
+	// Liveness zone config entry with a shorter GC time.
+	livenessZoneConf.GC.TTLSeconds = 10 * 60 // 10m
+	target.otherKV = append(target.otherKV, createZoneConfigKV(keys.LivenessRangesID, livenessZoneConf))
+	target.otherKV = append(target.otherKV, createZoneConfigKV(keys.SystemRangesID, systemZoneConf))
+	target.otherKV = append(target.otherKV, createZoneConfigKV(keys.SystemDatabaseID, systemZoneConf))
 }
 
 // IsSystemConfigID returns whether this ID is for a system config object.

--- a/pkg/sql/tests/system_table_test.go
+++ b/pkg/sql/tests/system_table_test.go
@@ -34,7 +34,7 @@ func TestInitialKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const keysPerDesc = 2
-	const nonDescKeys = 5
+	const nonDescKeys = 7
 
 	ms := sqlbase.MakeMetadataSchema()
 	kv := ms.GetInitialValues()

--- a/pkg/sql/zone_config_test.go
+++ b/pkg/sql/zone_config_test.go
@@ -88,6 +88,15 @@ func waitForConfigChange(t testing.TB, s *server.TestServer) config.SystemConfig
 func TestGetZoneConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params, _ := tests.CreateTestServerParams()
+	cfg := config.DefaultSystemZoneConfig()
+	cfg.NumReplicas = 1
+	cfg.RangeMinBytes = 1 << 20
+	cfg.RangeMaxBytes = 1 << 20
+	cfg.GC.TTLSeconds = 60
+
+	fnSys := config.TestingSetDefaultSystemZoneConfig(cfg)
+	defer fnSys()
+
 	srv, sqlDB, _ := serverutils.StartServer(t, params)
 	defer srv.Stopper().Stop(context.TODO())
 	s := srv.(*server.TestServer)

--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -251,10 +251,16 @@ func GetNeededReplicas(
 	// replicas specified in the zone config, the cluster can still function.
 	need = int(math.Min(float64(aliveReplicas-decommissioningReplicas), float64(need)))
 
-	// Ensure that we don't up- or down-replicate to an even number of replicas.
-	// Note that in the case of 5 desired replicas and a decommissioning store, this prefers
-	// down-replicating from 5 to 3 rather than sticking with 4 desired stores or blocking
-	// the decommissioning from completing.
+	// Ensure that we don't up- or down-replicate to an even number of replicas
+	// unless an even number of replicas was specifically requested by the user
+	// in the zone config.
+	//
+	// Note that in the case of 5 desired replicas and a decommissioning store,
+	// this prefers down-replicating from 5 to 3 rather than sticking with 4
+	// desired stores or blocking the decommissioning from completing.
+	if need == numZoneReplicas {
+		return need
+	}
 	if need%2 == 0 {
 		need = need - 1
 	}

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1367,7 +1367,7 @@ func TestStoreRangeUpReplicate(t *testing.T) {
 func TestStoreRangeCorruptionChangeReplicas(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	const numReplicas = 3
+	const numReplicas = 5
 	const extraStores = 3
 
 	ctx := context.Background()
@@ -2801,7 +2801,7 @@ func TestStoreRangeMoveDecommissioning(t *testing.T) {
 	sc.TestingKnobs.DisableReplicaRebalancing = true
 	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
-	mtc.Start(t, 4)
+	mtc.Start(t, 6)
 	mtc.initGossipNetwork()
 
 	// Replicate the range to 2 more stores. Note that there are 4 stores in the
@@ -2828,8 +2828,8 @@ func TestStoreRangeMoveDecommissioning(t *testing.T) {
 		// Wait for a replacement replica for the decommissioning node to be added
 		// and the replica on the decommissioning node to be removed.
 		curReplicas := getRangeMetadata(roachpb.RKeyMin, mtc, t).Replicas
-		if len(curReplicas) != 3 {
-			return errors.Errorf("expected 3 replicas, got %v", curReplicas)
+		if len(curReplicas) != 5 {
+			return errors.Errorf("expected 5 replicas, got %v", curReplicas)
 		}
 		if reflect.DeepEqual(origReplicas, curReplicas) {
 			return errors.Errorf("expected replica to be moved, but found them to be same as original %v", origReplicas)
@@ -2853,7 +2853,7 @@ func TestStoreRangeRemoveDead(t *testing.T) {
 	mtc := &multiTestContext{storeConfig: &sc}
 	mtc.timeUntilStoreDead = storage.TestTimeUntilStoreDead
 	defer mtc.Stop()
-	mtc.Start(t, 4)
+	mtc.Start(t, 5)
 
 	// Replicate the range to 2 more stores. Note that there are 4 stores in the
 	// cluster leaving an extra store available as a replication target once the

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -2534,6 +2534,12 @@ func TestUnsplittableRange(t *testing.T) {
 			TTLSeconds: int32(ttl.Seconds()),
 		},
 	})()
+	defer config.TestingSetDefaultSystemZoneConfig(config.ZoneConfig{
+		RangeMaxBytes: maxBytes,
+		GC: config.GCPolicy{
+			TTLSeconds: int32(ttl.Seconds()),
+		},
+	})()
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -6809,6 +6809,7 @@ func (r *Replica) Metrics(
 		cmdQMetricsLocal,
 		cmdQMetricsGlobal,
 		raftLogSize,
+		r.store.allocator.storePool,
 	)
 }
 
@@ -6835,6 +6836,7 @@ func calcReplicaMetrics(
 	cmdQMetricsLocal CommandQueueMetrics,
 	cmdQMetricsGlobal CommandQueueMetrics,
 	raftLogSize int64,
+	storePool *StorePool,
 ) ReplicaMetrics {
 	var m ReplicaMetrics
 
@@ -6876,8 +6878,13 @@ func calcReplicaMetrics(
 		}
 		if zoneConfig, err := cfg.GetZoneConfigForKey(desc.StartKey); err != nil {
 			log.Error(ctx, err)
-		} else if int32(liveReplicas) < zoneConfig.NumReplicas {
-			m.Underreplicated = true
+		} else {
+			decommissioningReplicas := len(storePool.decommissioningReplicas(desc.RangeID, desc.Replicas))
+			_, aliveStoreCount, _ := storePool.getStoreList(desc.RangeID, storeFilterNone)
+
+			if GetNeededReplicas(zoneConfig.NumReplicas, aliveStoreCount, decommissioningReplicas) > liveReplicas {
+				m.Underreplicated = true
+			}
 		}
 	}
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -8974,6 +8974,12 @@ func TestReplicaMetrics(t *testing.T) {
 		return m
 	}
 
+	var tc testContext
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+	cfg := TestStoreConfig(nil)
+	tc.StartWithStoreConfig(t, stopper, cfg)
+
 	testCases := []struct {
 		replicas    int32
 		storeID     roachpb.StoreID
@@ -9162,6 +9168,7 @@ func TestReplicaMetrics(t *testing.T) {
 				RaftLogTooLarge: true,
 			}},
 	}
+
 	for i, c := range testCases {
 		t.Run("", func(t *testing.T) {
 			zoneConfig := config.ZoneConfig{NumReplicas: c.replicas}
@@ -9174,7 +9181,7 @@ func TestReplicaMetrics(t *testing.T) {
 			metrics := calcReplicaMetrics(
 				context.Background(), hlc.Timestamp{}, config.SystemConfig{},
 				c.liveness, &c.desc, c.raftStatus, LeaseStatus{},
-				c.storeID, c.expected.Quiescent, c.expected.Ticking, CommandQueueMetrics{}, CommandQueueMetrics{}, c.raftLogSize)
+				c.storeID, c.expected.Quiescent, c.expected.Ticking, CommandQueueMetrics{}, CommandQueueMetrics{}, c.raftLogSize, tc.store.allocator.storePool)
 			if c.expected != metrics {
 				t.Fatalf("unexpected metrics:\n%s", pretty.Diff(c.expected, metrics))
 			}

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -315,7 +315,10 @@ func (rq *replicateQueue) processOneChange(
 			StoreID: newStore.StoreID,
 		}
 
-		need := int(zone.NumReplicas)
+		decommissioningReplicas := len(rq.allocator.storePool.decommissioningReplicas(desc.RangeID, desc.Replicas))
+		_, aliveStoreCount, _ := rq.allocator.storePool.getStoreList(desc.RangeID, storeFilterNone)
+
+		need := GetNeededReplicas(zone.NumReplicas, aliveStoreCount, decommissioningReplicas)
 		willHave := len(desc.Replicas) + 1
 
 		// Only up-replicate if there are suitable allocation targets such

--- a/pkg/storage/store_rebalancer.go
+++ b/pkg/storage/store_rebalancer.go
@@ -514,7 +514,10 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 			log.Error(ctx, err)
 			return replicaWithStats{}, nil
 		}
-		desiredReplicas := int(zone.NumReplicas)
+		decommissioningReplicas := len(sr.rq.allocator.storePool.decommissioningReplicas(desc.RangeID, desc.Replicas))
+		_, aliveStoreCount, _ := sr.rq.allocator.storePool.getStoreList(desc.RangeID, storeFilterNone)
+
+		desiredReplicas := GetNeededReplicas(zone.NumReplicas, aliveStoreCount, decommissioningReplicas)
 		targets := make([]roachpb.ReplicationTarget, 0, desiredReplicas)
 		targetReplicas := make([]roachpb.ReplicaDescriptor, 0, desiredReplicas)
 


### PR DESCRIPTION
Backport:
  * 1/1 commits from "storage: adjust system replica count based on node availibility" (#27349)
  * 1/1 commits from "storage: Respect zone.NumReplicas even if it's an even number" (#30441)

Please see individual PRs for details.

/cc @cockroachdb/release
