### PR TITLE
changefeedccl: more avro tests

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -100,7 +100,7 @@ func newChangeAggregatorProcessor(
 	}
 
 	var err error
-	if ca.encoder, err = getEncoder(ca.spec.Feed.Opts, ca.spec.Feed.SinkURI); err != nil {
+	if ca.encoder, err = getEncoder(ca.spec.Feed.Opts); err != nil {
 		return nil, err
 	}
 
@@ -386,7 +386,7 @@ func newChangeFrontierProcessor(
 	}
 
 	var err error
-	if cf.encoder, err = getEncoder(spec.Feed.Opts, spec.Feed.SinkURI); err != nil {
+	if cf.encoder, err = getEncoder(spec.Feed.Opts); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -41,34 +41,34 @@ type envelopeType string
 type formatType string
 
 const (
-	optCursor             = `cursor`
-	optEnvelope           = `envelope`
-	optFormat             = `format`
-	optResolvedTimestamps = `resolved`
-	optUpdatedTimestamps  = `updated`
+	optConfluentSchemaRegistry = `confluent_schema_registry`
+	optCursor                  = `cursor`
+	optEnvelope                = `envelope`
+	optFormat                  = `format`
+	optResolvedTimestamps      = `resolved`
+	optUpdatedTimestamps       = `updated`
 
 	optEnvelopeKeyOnly envelopeType = `key_only`
 	optEnvelopeRow     envelopeType = `row`
 	optEnvelopeDiff    envelopeType = `diff`
 
-	optFormatJSON     formatType = `json`
-	optFormatAvro     formatType = `experimental-avro`
-	optFormatAvroJSON formatType = `experimental-avro-json`
+	optFormatJSON formatType = `json`
+	optFormatAvro formatType = `experimental-avro`
 
-	sinkParamConfluentSchemaRegistry = `confluent_schema_registry`
-	sinkParamTopicPrefix             = `topic_prefix`
-	sinkParamSchemaTopic             = `schema_topic`
-	sinkSchemeBuffer                 = ``
-	sinkSchemeExperimentalSQL        = `experimental-sql`
-	sinkSchemeKafka                  = `kafka`
+	sinkParamTopicPrefix      = `topic_prefix`
+	sinkParamSchemaTopic      = `schema_topic`
+	sinkSchemeBuffer          = ``
+	sinkSchemeExperimentalSQL = `experimental-sql`
+	sinkSchemeKafka           = `kafka`
 )
 
 var changefeedOptionExpectValues = map[string]bool{
-	optCursor:             true,
-	optEnvelope:           true,
-	optFormat:             true,
-	optResolvedTimestamps: false,
-	optUpdatedTimestamps:  false,
+	optConfluentSchemaRegistry: true,
+	optCursor:                  true,
+	optEnvelope:                true,
+	optFormat:                  true,
+	optResolvedTimestamps:      false,
+	optUpdatedTimestamps:       false,
 }
 
 // changefeedPlanHook implements sql.PlanHookFn.
@@ -291,7 +291,7 @@ func validateDetails(details jobspb.ChangefeedDetails) (jobspb.ChangefeedDetails
 	switch formatType(details.Opts[optFormat]) {
 	case ``, optFormatJSON:
 		details.Opts[optFormat] = string(optFormatJSON)
-	case optFormatAvro, optFormatAvroJSON:
+	case optFormatAvro:
 		// No-op.
 	default:
 		return jobspb.ChangefeedDetails{}, errors.Errorf(

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -863,22 +863,17 @@ func TestChangefeedErrors(t *testing.T) {
 		}
 
 		// Check that confluent_schema_registry is only accepted if format is
-		// avro (even excluding avro=json).
+		// avro.
 		s := f.Server()
 		sink, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), t.Name(), url.User(security.RootUser))
 		defer cleanup()
 		sink.Scheme = sinkSchemeExperimentalSQL
 		sink.Path = `d`
 		q := sink.Query()
-		q.Set(sinkParamConfluentSchemaRegistry, `foo`)
+		q.Set(optConfluentSchemaRegistry, `foo`)
 		sink.RawQuery = q.Encode()
 		if _, err := sqlDB.DB.Exec(
 			`CREATE CHANGEFEED FOR foo INTO $1`, sink.String(),
-		); !testutils.IsError(err, `unknown sink query parameter: confluent_schema_registry`) {
-			t.Errorf(`expected "unknown sink query parameter: confluent_schema_registry" error got: %v`, err)
-		}
-		if _, err := sqlDB.DB.Exec(
-			`CREATE CHANGEFEED FOR foo INTO $1 WITH format=$2`, sink.String(), optFormatAvroJSON,
 		); !testutils.IsError(err, `unknown sink query parameter: confluent_schema_registry`) {
 			t.Errorf(`expected "unknown sink query parameter: confluent_schema_registry" error got: %v`, err)
 		}

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -9,39 +9,132 @@
 package changefeedccl
 
 import (
+	"bytes"
 	gosql "database/sql"
+	"encoding/binary"
+	gojson "encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/pkg/errors"
 )
 
-// TODO(dan): This is just a sanity check for the avro stuff. We need an
-// end-to-end test with the avro format that interprets the bytes using a schema
-// it gets from the schema registry.
-func TestEncoderAvro(t *testing.T) {
+type testSchemaRegistry struct {
+	server *httptest.Server
+	mu     struct {
+		syncutil.Mutex
+		idAlloc int32
+		schemas map[int32]string
+	}
+}
+
+func makeTestSchemaRegistry() *testSchemaRegistry {
+	r := &testSchemaRegistry{}
+	r.mu.schemas = make(map[int32]string)
+	r.server = httptest.NewServer(http.HandlerFunc(r.Register))
+	return r
+}
+
+func (r *testSchemaRegistry) Close() {
+	r.server.Close()
+}
+
+func (r *testSchemaRegistry) Register(hw http.ResponseWriter, hr *http.Request) {
+	type confluentSchemaVersionRequest struct {
+		Schema string `json:"schema"`
+	}
+	type confluentSchemaVersionResponse struct {
+		ID int32 `json:"id"`
+	}
+	if err := func() error {
+		defer hr.Body.Close()
+		var req confluentSchemaVersionRequest
+		if err := gojson.NewDecoder(hr.Body).Decode(&req); err != nil {
+			return err
+		}
+
+		r.mu.Lock()
+		id := r.mu.idAlloc
+		r.mu.idAlloc++
+		r.mu.schemas[id] = req.Schema
+		r.mu.Unlock()
+
+		res, err := gojson.Marshal(confluentSchemaVersionResponse{ID: id})
+		if err != nil {
+			return err
+		}
+
+		hw.Header().Set(`Content-type`, `application/json`)
+		_, _ = hw.Write(res)
+		return nil
+	}(); err != nil {
+		http.Error(hw, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (r *testSchemaRegistry) encodedAvroToJSON(b []byte) (string, error) {
+	if len(b) == 0 || b[0] != confluentAvroWireFormatMagic {
+		return ``, errors.Errorf(`bad magic byte`)
+	}
+	b = b[1:]
+	if len(b) < 4 {
+		return ``, errors.Errorf(`missing registry id`)
+	}
+	id := int32(binary.BigEndian.Uint32(b[:4]))
+	b = b[4:]
+
+	r.mu.Lock()
+	jsonSchema := r.mu.schemas[id]
+	r.mu.Unlock()
+	schema, err := parseAvroSchema(jsonSchema)
+	if err != nil {
+		return ``, err
+	}
+	row, err := schema.RowFromBinary(b)
+	if err != nil {
+		return ``, err
+	}
+	m := make(map[string]interface{})
+	for fieldIdx, field := range schema.Fields {
+		datum := row[schema.colIdxByFieldIdx[fieldIdx]].Datum
+		m[field.Name], err = tree.AsJSON(datum)
+		if err != nil {
+			return ``, err
+		}
+	}
+	j, err := json.MakeJSON(m)
+	if err != nil {
+		return ``, err
+	}
+	var buf bytes.Buffer
+	j.Format(&buf)
+	return buf.String(), nil
+}
+
+func TestAvroEncoder(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		reg := makeTestSchemaRegistry()
+		defer reg.Close()
+
 		sqlDB := sqlutils.MakeSQLRunner(db)
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
-		sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'bar')`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'bar'), (2, NULL)`)
 
-		foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH format=$1`, optFormatAvroJSON)
+		foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH format=$1, confluent_schema_registry=$2`, optFormatAvro, reg.server.URL)
 		defer foo.Close(t)
 
-		// There's randomized map iteration deep in the avro lib, so we can't use
-		// the normal assertPayloads helper.
-		table, _, key, value, _, ok := foo.Next(t)
-		if !ok {
-			t.Fatal(`expected row`)
-		}
-		require.Equal(t, `foo`, table)
-		require.Equal(t, `{"a":1}`, string(key))
-		require.Contains(t, string(value), `"a":1`)
-		require.Contains(t, string(value), `"b":{"string":"bar"}`)
+		assertPayloadsAvro(t, reg, foo, []string{
+			`foo: {"a": 1}->{"a": 1, "b": "bar"}`,
+			`foo: {"a": 2}->{"a": 2, "b": null}`,
+		})
 	}
 
 	t.Run(`sinkless`, sinklessTest(testFn))

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -93,14 +93,6 @@ func getSink(
 		return nil, errors.Errorf(`unsupported sink: %s`, u.Scheme)
 	}
 
-	// Skip sink params used only by other parts of the system.
-	switch formatType(opts[optFormat]) {
-	case optFormatAvro:
-		q.Del(sinkParamConfluentSchemaRegistry)
-	default:
-		// No-op.
-	}
-
 	for k := range q {
 		_ = s.Close()
 		return nil, errors.Errorf(`unknown sink query parameter: %s`, k)


### PR DESCRIPTION
Switched confluent_schema_registry from being a query parameter on the
sink uri to being a WITH option, it's much more natural this way.

Switched TestAvroEncoder to use the binary format by mocking out the
schema registry. Ripped out the avro-json format since it wasn't
returning or registering the schema in any way, which is an avro no-no.

Expanded TestAvroSchema to roundtrip the codec through json, which will
help us later check that a column can be recreated exactly from the avro
schema.

Also added the beginnings of an avro schema evolution/resolution test.
The first case checks adding a nullable SQL column.

Still not quite ready for external testing, so again no release note.

For #28637

Release note: None