### PR TITLE
ui: move custom chart page to top of debug index

### DIFF
--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -53,6 +53,12 @@ export default function Debug() {
       </Helmet>
       <h1>Advanced Debugging</h1>
       <DebugTable heading="Reports">
+        <DebugTableRow title="Custom Time-Series Chart">
+          <DebugTableLink
+            name="Customizable chart of time series metrics"
+            url="#/debug/chart"
+          />
+        </DebugTableRow>
         <DebugTableRow title="Node Diagnostics">
           <DebugTableLink name="All Nodes" url="#/reports/nodes" />
           <DebugTableLink
@@ -257,12 +263,6 @@ export default function Debug() {
           <DebugTableLink
             name="Export the Redux State of the UI"
             url="#/debug/redux"
-          />
-        </DebugTableRow>
-        <DebugTableRow title="Custom Time-Series Chart">
-          <DebugTableLink
-            name="Customizable chart of time series metrics"
-            url="#/debug/chart"
           />
         </DebugTableRow>
       </DebugTable>


### PR DESCRIPTION
...since it's one of the most useful debug pages.

![image](https://user-images.githubusercontent.com/7341/45853524-e4798e80-bd13-11e8-8947-8f66efc488d6.png)

Release note: None