### PR TITLE
ui: display "--%" instead of "Infinity%" when total memory not available

### DIFF
--- a/pkg/ui/src/util/format.ts
+++ b/pkg/ui/src/util/format.ts
@@ -75,7 +75,7 @@ export function BytesWithPrecision(bytes: number, precision: number): string {
  */
 export function Percentage(numerator: number, denominator: number): string {
   if (denominator === 0) {
-    return "100%";
+    return "--%";
   }
   return Math.floor(numerator / denominator * 100).toString() + "%";
 }

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -22,6 +22,7 @@ import { LongToMoment } from "src/util/convert";
 import { BytesWithPrecision } from "src/util/format";
 import { INodeStatus, MetricConstants, BytesUsed } from "src/util/proto";
 import { FixLong } from "src/util/fixLong";
+import { Percentage } from "src/util/format";
 
 const liveNodesSortSetting = new LocalSetting<AdminUIState, SortSetting>(
   "nodes/live_sort_setting", (s) => s.localSettings,
@@ -143,7 +144,7 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
                     <span title={`Total: ${BytesWithPrecision(usable, 0)}`}>
                       {BytesWithPrecision(used, 0)}
                       {" "}
-                      ({Math.round(used / usable * 100)}%)
+                      ({Percentage(used, usable)})
                     </span>
                   );
                 },
@@ -160,7 +161,7 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
                     <span title={`Total: ${BytesWithPrecision(available, 0)}`}>
                       {BytesWithPrecision(used, 0)}
                       {" "}
-                      ({Math.round(used / available * 100)}%)
+                      ({Percentage(used, available)})
                     </span>
                   );
                 },


### PR DESCRIPTION
Fixes #28990 

There are about 10 seconds right after nodes start up in which total memory is not yet available. If we don't have a denominator for a percentage, show `??%` instead of `Infinity%`.

![image](https://user-images.githubusercontent.com/7341/45854165-a41c0f80-bd17-11e8-8d45-becbab680bcb.png)


Release note: None