### PR TITLE
ui: remove disk read and write time graphs

### DIFF
--- a/pkg/server/status/disk_counters.go
+++ b/pkg/server/status/disk_counters.go
@@ -18,7 +18,6 @@ package status
 
 import (
 	"context"
-	"time"
 
 	"github.com/shirou/gopsutil/disk"
 )
@@ -34,10 +33,8 @@ func getDiskCounters(ctx context.Context) ([]diskStats, error) {
 	for _, counters := range driveStats {
 		output[i] = diskStats{
 			readBytes:      int64(counters.ReadBytes),
-			readTime:       time.Duration(counters.ReadTime * 1e6),
 			readCount:      int64(counters.ReadCount),
 			writeBytes:     int64(counters.WriteBytes),
-			writeTime:      time.Duration(counters.WriteTime * 1e6),
 			writeCount:     int64(counters.WriteCount),
 			iopsInProgress: int64(counters.IopsInProgress),
 		}

--- a/pkg/server/status/disk_counters_darwin.go
+++ b/pkg/server/status/disk_counters_darwin.go
@@ -33,10 +33,8 @@ func getDiskCounters(context.Context) ([]diskStats, error) {
 		output[i] = diskStats{
 			readBytes:      counters.BytesRead,
 			readCount:      counters.NumRead,
-			readTime:       counters.TotalReadTime,
 			writeBytes:     counters.BytesWritten,
 			writeCount:     counters.NumWrite,
-			writeTime:      counters.TotalWriteTime,
 			iopsInProgress: 0, // Not reported by this library. (#27927)
 		}
 	}

--- a/pkg/server/status/runtime_test.go
+++ b/pkg/server/status/runtime_test.go
@@ -28,30 +28,24 @@ func TestSumDiskCounters(t *testing.T) {
 	counters := []diskStats{
 		{
 			readBytes:      1,
-			readTime:       1,
 			readCount:      1,
 			iopsInProgress: 1,
 			writeBytes:     1,
-			writeTime:      1,
 			writeCount:     1,
 		},
 		{
 			readBytes:      1,
-			readTime:       1,
 			readCount:      1,
 			iopsInProgress: 1,
 			writeBytes:     1,
-			writeTime:      1,
 			writeCount:     1,
 		},
 	}
 	summed := sumDiskCounters(counters)
 	expected := diskStats{
 		readBytes:      2,
-		readTime:       2,
 		readCount:      2,
 		writeBytes:     2,
-		writeTime:      2,
 		writeCount:     2,
 		iopsInProgress: 2,
 	}
@@ -94,28 +88,22 @@ func TestSubtractDiskCounters(t *testing.T) {
 
 	from := diskStats{
 		readBytes:      3,
-		readTime:       3,
 		readCount:      3,
 		writeBytes:     3,
-		writeTime:      3,
 		writeCount:     3,
 		iopsInProgress: 3,
 	}
 	sub := diskStats{
 		readBytes:      1,
-		readTime:       1,
 		readCount:      1,
 		iopsInProgress: 1,
 		writeBytes:     1,
-		writeTime:      1,
 		writeCount:     1,
 	}
 	expected := diskStats{
 		readBytes:  2,
-		readTime:   2,
 		readCount:  2,
 		writeBytes: 2,
-		writeTime:  2,
 		writeCount: 2,
 		// Don't touch iops in progress; it is a gauge, not a counter.
 		iopsInProgress: 3,

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -79,38 +79,6 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Disk Read Time"
-      sources={nodeSources}
-    >
-      <Axis units={AxisUnits.Duration} label="Read Time">
-        {nodeIDs.map((nid) => (
-          <Metric
-            name="cr.node.sys.host.disk.read.time"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={[nid]}
-            nonNegativeRate
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Disk Write Time"
-      sources={nodeSources}
-    >
-      <Axis units={AxisUnits.Duration} label="Write Time">
-        {nodeIDs.map((nid) => (
-          <Metric
-            name="cr.node.sys.host.disk.write.time"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={[nid]}
-            nonNegativeRate
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
       title="Disk Read Ops"
       sources={nodeSources}
     >


### PR DESCRIPTION
The values are suspect (we've seen >>1 disk second per second on machines
with one disk), and it seems that what people really want to see is
latency of individual disk operations, anyway.

Not generally cool to remove time series, but these have only been available in betas.

Release note (admin ui change): Remove read and write graphs from the
hardware dashboard.