### PR TITLE
roachtest: de-flake acceptance/rapid-restart

### DIFF
--- a/build/teamcity-local-roachtest.sh
+++ b/build/teamcity-local-roachtest.sh
@@ -28,5 +28,5 @@ run build/builder.sh ./bin/roachtest run '(acceptance|kv/splits)' \
   --cockroach "cockroach" \
   --workload "bin/workload" \
   --artifacts artifacts \
-  --teamcity
+  --teamcity 2>&1 | tee artifacts/roachtest.log
 tc_end_block "Run local roachtests"


### PR DESCRIPTION
The kill signal was sometimes a noop (when issued before the process to be
killed started). Prior to this patch, that would leave the test stuck.

Fixes #30475.

Release note: None