### PR TITLE
roachtest: wait for teardown if local test times out

### DIFF
--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -776,12 +776,16 @@ func (r *registry) run(
 
 					select {
 					case <-time.After(timeout):
-						t.printf("test timed out (%s)", timeout)
+						t.printf("test timed out (%s)\n", timeout)
 						if c != nil {
 							c.FetchLogs(ctx)
 							// NB: c.destroyed is nil for cloned clusters (i.e. in subtests).
 							if !debugEnabled && c.destroyed != nil {
 								c.Destroy(ctx)
+							}
+							if local {
+								t.printf("waiting for test to tear down since cluster is local\n")
+								<-done
 							}
 						}
 					case <-done:


### PR DESCRIPTION
I suspect not doing so previously can cause issues like #30397.
Local roachtests are simply not set up to run concurrently, but once a
test times out we're doing that (though we attempt to teardown the
cluster, tests can apparently still "do stuff" with it, for example
the rapid restarts test was running one-off invocations of CockroachDB
via Exec; also note the comment near the added lines suggesting that
in local clusters we may not actually be destroying them).

We can revisit this when we allow multiple local clusters in parallel,
as we can then use a different one.

Optimistically:

Fixes #30397.

Release note: None