### PR TITLE
release-2.1: storage: add verbose split-queue logging

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -327,6 +327,12 @@ func (ts *TestServer) Start(params base.TestServerArgs) error {
 		params.Stopper.AddCloser(stop.CloserFn(fn))
 	}
 
+	// TODO(peter): Remove once #29144 is understood / fixed.
+	if ts.Cfg.TestingKnobs.Store == nil {
+		ts.Cfg.TestingKnobs.Store = &storage.StoreTestingKnobs{}
+	}
+	ts.Cfg.TestingKnobs.Store.(*storage.StoreTestingKnobs).VerboseSplitQueue = true
+
 	// Needs to be called before NewServer to ensure resolvers are initialized.
 	if err := ts.Cfg.InitNode(); err != nil {
 		return err

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -791,6 +791,9 @@ type StoreTestingKnobs struct {
 	DisableReplicaRebalancing bool
 	// DisableSplitQueue disables the split queue.
 	DisableSplitQueue bool
+	// VerboseSplitQueue enables verbose logging for the split queue. See
+	// #29144. TODO(peter): remove when that issue is understood / fixed.
+	VerboseSplitQueue bool
 	// DisableTimeSeriesMaintenanceQueue disables the time series maintenance
 	// queue.
 	DisableTimeSeriesMaintenanceQueue bool
@@ -1039,6 +1042,9 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 	}
 	if cfg.TestingKnobs.DisableSplitQueue {
 		s.setSplitQueueActive(false)
+	}
+	if cfg.TestingKnobs.VerboseSplitQueue {
+		s.splitQueue.verbose = true
 	}
 	if cfg.TestingKnobs.DisableTimeSeriesMaintenanceQueue {
 		s.setTimeSeriesMaintenanceQueueActive(false)


### PR DESCRIPTION
Backport 1/1 commits from #30395.

/cc @cockroachdb/release

---

Add verbose split queue logging from tests.

See #29144

Release note: None
