### PR TITLE
workload: error instead of crash when initial data is not supported

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -356,8 +356,12 @@ func MakeFixture(
 	g, gCtx := errgroup.WithContext(ctx)
 	for _, t := range gen.Tables() {
 		table := t
-		tableCSVPathsCh := make(chan string)
+		if t.InitialRows.Batch == nil {
+			return Fixture{}, errors.Errorf(
+				`make fixture is not supported for workload %s`, gen.Meta().Name)
+		}
 
+		tableCSVPathsCh := make(chan string)
 		g.Go(func() error {
 			defer close(tableCSVPathsCh)
 			if len(config.CSVServerURL) == 0 {

--- a/pkg/workload/csv.go
+++ b/pkg/workload/csv.go
@@ -123,6 +123,9 @@ func HandleCSV(w http.ResponseWriter, req *http.Request, prefix string, meta Met
 	if table == nil {
 		return errors.Errorf(`could not find table %s in generator %s`, tableName, meta.Name)
 	}
+	if table.InitialRows.Batch == nil {
+		return errors.Errorf(`csv-server is not supported for workload %s`, meta.Name)
+	}
 
 	rowStart, rowEnd := 0, table.InitialRows.NumBatches
 	if vals, ok := req.Form[rowStartParam]; ok && len(vals) > 0 {


### PR DESCRIPTION
TPCH requires a go port of the initial data generation logic for
fixtures make to work, so it has an incomplete workload implementation.
In the meantime, error instead of crash.

    $ ./bin/workload fixtures make tpch
    Error: make fixture is not supported for workload tpch
    $ curl "http://localhost:8081/csv/tpch/nation"
    csv-server is not supported for workload tpch

There was already an error message for `init tpch`.

For #30155

Release note: None