### PR TITLE
pgwire: make conn hold most fields by value, not reference

### DIFF
--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -353,9 +353,15 @@ var _ Command = SendError{}
 // NewStmtBuf creates a StmtBuf.
 func NewStmtBuf() *StmtBuf {
 	var buf StmtBuf
+	buf.Init()
+	return &buf
+}
+
+// Init initializes a StmtBuf. It exists to avoid the allocation imposed by
+// NewStmtBuf.
+func (buf *StmtBuf) Init() {
 	buf.mu.lastPos = -1
 	buf.mu.cond = sync.NewCond(&buf.mu.Mutex)
-	return &buf
 }
 
 // Close marks the buffer as closed. Once Close() is called, no further push()es

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -116,7 +116,7 @@ func TestConn(t *testing.T) {
 
 	// Now we'll expect to receive the commands corresponding to the operations in
 	// client().
-	rd := sql.MakeStmtBufReader(conn.stmtBuf)
+	rd := sql.MakeStmtBufReader(&conn.stmtBuf)
 	expectExecStmt(ctx, t, "SELECT 1", &rd, conn, queryStringComplete)
 	expectSync(ctx, t, &rd)
 	expectExecStmt(ctx, t, "SELECT 2", &rd, conn, queryStringComplete)
@@ -182,7 +182,7 @@ func TestConn(t *testing.T) {
 // processPgxStartup processes the first few queries that the pgx driver
 // automatically sends on a new connection that has been established.
 func processPgxStartup(ctx context.Context, s serverutils.TestServerInterface, c *conn) error {
-	rd := sql.MakeStmtBufReader(c.stmtBuf)
+	rd := sql.MakeStmtBufReader(&c.stmtBuf)
 
 	for {
 		cmd, err := rd.CurCmd()

--- a/pkg/sql/pgwire/write_buffer.go
+++ b/pkg/sql/pgwire/write_buffer.go
@@ -52,11 +52,15 @@ type writeBuffer struct {
 }
 
 func newWriteBuffer(bytecount *metric.Counter) *writeBuffer {
-	b := &writeBuffer{
-		bytecount: bytecount,
-	}
-	b.textFormatter = tree.MakeFmtCtx(&b.variablePutbuf, tree.FmtPgwireText)
+	b := new(writeBuffer)
+	b.init(bytecount)
 	return b
+}
+
+// init exists to avoid the allocation imposed by newWriteBuffer.
+func (b *writeBuffer) init(bytecount *metric.Counter) {
+	b.bytecount = bytecount
+	b.textFormatter = tree.MakeFmtCtx(&b.variablePutbuf, tree.FmtPgwireText)
 }
 
 // Write implements the io.Write interface.


### PR DESCRIPTION
This allows their lifetimes to be more obviously scoped together, reduces the number of pointers we have lying around for each SQL connection, and enables future optimization where we can put entire `pgwire.conn` objects in a pool.