### PR TITLE
engine: pool rocksDBBatch and RocksDBBatchBuilder allocations

### DIFF
--- a/pkg/cli/syncbench/syncbench.go
+++ b/pkg/cli/syncbench/syncbench.go
@@ -103,7 +103,7 @@ func (w *worker) run(wg *sync.WaitGroup) {
 				buf = key[:0]
 			}
 		}
-		bytes := uint64(len(b.Repr()))
+		bytes := uint64(b.Len())
 		if err := b.Commit(true); err != nil {
 			log.Fatal(ctx, err)
 		}

--- a/pkg/storage/engine/disk_map.go
+++ b/pkg/storage/engine/disk_map.go
@@ -250,7 +250,7 @@ func (b *RocksDBMapBatchWriter) Put(k []byte, v []byte) error {
 	if err := b.batch.Put(b.makeKey(k), v); err != nil {
 		return err
 	}
-	if len(b.batch.Repr()) >= b.capacity {
+	if b.batch.Len() >= b.capacity {
 		return b.Flush()
 	}
 	return nil

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -348,8 +348,13 @@ type Batch interface {
 	// situations where we know all of the batched operations are for distinct
 	// keys.
 	Distinct() ReadWriter
-	// Empty returns whether the batch is empty or not.
+	// Empty returns whether the batch has been written to or not.
 	Empty() bool
+	// Len returns the size of the underlying representation of the batch.
+	// Because of the batch header, the size of the batch is never 0 and should
+	// not be used interchangeably with Empty. The method avoids the memory copy
+	// that Repr imposes, but it still may require flushing the batch's mutations.
+	Len() int
 	// Repr returns the underlying representation of the batch and can be used to
 	// reconstitute the batch on a remote node using Writer.ApplyBatchRepr().
 	Repr() []byte

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -634,7 +634,7 @@ func TestConcurrentBatch(t *testing.T) {
 				t.Fatalf("target size (%d) should be larger than the max batch group size (%d)",
 					targetSize, maxBatchGroupSize)
 			}
-			if len(batch.Repr()) >= targetSize {
+			if batch.Len() >= targetSize {
 				break
 			}
 		}

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -347,6 +347,10 @@ func (s spanSetBatch) Empty() bool {
 	return s.b.Empty()
 }
 
+func (s spanSetBatch) Len() int {
+	return s.b.Len()
+}
+
 func (s spanSetBatch) Repr() []byte {
 	return s.b.Repr()
 }

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -185,7 +185,7 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 			return err
 		}
 
-		if int64(len(b.Repr())) >= kvSS.batchSize {
+		if int64(b.Len()) >= kvSS.batchSize {
 			if err := kvSS.limiter.WaitN(ctx, 1); err != nil {
 				return err
 			}


### PR DESCRIPTION
This addresses the first three items from #30512.

I'm not seeing any big throughput improvements when running `kv0`
on my laptop (maybe ~1%, hard to tell), but I can see that this worked.
Total allocated space due to the three items in the issue dropped from
8.95% (1137.04 MB over a 1m run) to 0.32% (37.45 MB over a 1m run).

### Before

<img width="1195" alt="screen shot 2018-09-21 at 6 05 42 pm" src="https://user-images.githubusercontent.com/5438456/45908677-b6578580-bdcb-11e8-9135-52f450656578.png">

### After

<img width="1180" alt="screen shot 2018-09-21 at 6 05 30 pm" src="https://user-images.githubusercontent.com/5438456/45908679-b9eb0c80-bdcb-11e8-91f6-38cb46fd9c9d.png">

Release note (performance improvement): Pool allocations of rocksDBBatch
and RocksDBBatchBuilder objects.