### PR TITLE
Revert "roachtest: wait for teardown if local test times out"

### DIFF
--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -783,10 +783,6 @@ func (r *registry) run(
 							if !debugEnabled && c.destroyed != nil {
 								c.Destroy(ctx)
 							}
-							if local {
-								t.printf("waiting for test to tear down since cluster is local\n")
-								<-done
-							}
 						}
 					case <-done:
 					}


### PR DESCRIPTION
This reverts commit 91438cbc22862cb95bb0fc8db979c1bd6c98dcf8.

Neither the author or reviewer recognized it was broken along multiple
axes.

See #30497

Release note: None