### PR TITLE
opt: Fix bug in function interning.

### DIFF
--- a/pkg/sql/opt/memo/private_storage.go
+++ b/pkg/sql/opt/memo/private_storage.go
@@ -230,11 +230,14 @@ func (ps *privateStorage) internFuncOpDef(def *FuncOpDef) PrivateID {
 	// The below code is carefully constructed to not allocate in the case where
 	// the value is already in the map. Be careful when modifying.
 	// The Overload field is already interned, because it's the address of one
-	// of the Builtin structs in the builtins package.
-	if id, ok := ps.privatesMap[privateKey{iface: def.Overload}]; ok {
+	// of the Builtin structs in the builtins package. Add the return type, since
+	// some functions use the same overload, but with a different return type
+	// (e.g. unnest).
+	typ := def.Type.String()
+	if id, ok := ps.privatesMap[privateKey{iface: def.Overload, str: typ}]; ok {
 		return id
 	}
-	return ps.addValue(privateKey{iface: def.Overload}, def)
+	return ps.addValue(privateKey{iface: def.Overload, str: typ}, def)
 }
 
 // internProjectionsOpDef adds the given value to storage and returns an id

--- a/pkg/sql/opt/memo/private_storage_test.go
+++ b/pkg/sql/opt/memo/private_storage_test.go
@@ -557,11 +557,19 @@ func TestInternFuncOpDef(t *testing.T) {
 	ttuple1 := types.TTuple{Types: []types.T{types.Int}}
 	ttuple2 := types.TTuple{Types: []types.T{types.Decimal}}
 	nowProps, nowOvls := builtins.GetBuiltinProperties("now")
+
+	// Same type, same overloads.
 	funcDef1 := &FuncOpDef{Name: "foo", Type: ttuple1, Properties: nowProps, Overload: &nowOvls[0]}
-	funcDef2 := &FuncOpDef{Name: "bar", Type: ttuple2, Properties: nowProps, Overload: &nowOvls[0]}
+	funcDef2 := &FuncOpDef{Name: "bar", Type: ttuple1, Properties: nowProps, Overload: &nowOvls[0]}
 	test(funcDef1, funcDef2, true)
-	funcDef3 := &FuncOpDef{Name: "bar", Type: ttuple2, Properties: nowProps, Overload: &nowOvls[1]}
+
+	// Same type, different overloads.
+	funcDef3 := &FuncOpDef{Name: "bar", Type: ttuple1, Properties: nowProps, Overload: &nowOvls[1]}
 	test(funcDef2, funcDef3, false)
+
+	// Same overload, different types.
+	funcDef4 := &FuncOpDef{Name: "bar", Type: ttuple2, Properties: nowProps, Overload: &nowOvls[1]}
+	test(funcDef3, funcDef4, false)
 }
 
 func TestInternSubqueryDef(t *testing.T) {

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -190,7 +190,7 @@ inner-join-apply
  │    │    └── array: [type=int[]]
  │    │         ├── const: 1 [type=int]
  │    │         └── const: 2 [type=int]
- │    └── function: unnest [type=int]
+ │    └── function: unnest [type=string]
  │         └── array: [type=string[]]
  │              ├── const: 'a' [type=string]
  │              └── const: 'b' [type=string]


### PR DESCRIPTION
Some builtin function overloads have a return type that's dependent on
the type of its parameters (e.g. unnest). This means that two FuncOpDef
structs with the same overload can have different Type fields. Therefore,
the FuncOpDef interning needs to incorporate that type.

Release note: None