### PR TITLE
roachtest: only post issues from tests with a non-nil Run

### DIFF
--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -674,7 +674,7 @@ func (r *registry) run(
 					}
 
 					fmt.Fprintf(r.out, "--- FAIL: %s %s(%s)\n%s", t.Name(), stability, dstr, output)
-					if postIssues && issues.CanPost() {
+					if postIssues && issues.CanPost() && t.spec.Run != nil {
 						authorEmail := getAuthorEmail(failLoc.file, failLoc.line)
 						branch := "<unknown branch>"
 						if b := os.Getenv("TC_BUILD_BRANCH"); b != "" {


### PR DESCRIPTION
This prevents duplicate issue posts when a subtest fails. Previously,
the subtest would post, and any parent test would post as well (usually
to the same issue).

Fixes #30541

Release note: None