### PR TITLE
storage: refactor GetNeededReplicas to use a notion of available nodes

### DIFF
--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -255,7 +255,7 @@ const minRangeMaxBytes = 64 << 10 // 64 KB
 
 // defaultZoneConfig is the default zone configuration used when no custom
 // config has been specified.
-var defaultZoneConfig = ZoneConfig{
+var defaultZoneConfig = &ZoneConfig{
 	NumReplicas:   3,
 	RangeMinBytes: 1 << 20,  // 1 MB
 	RangeMaxBytes: 64 << 20, // 64 MB
@@ -274,7 +274,7 @@ var defaultZoneConfig = ZoneConfig{
 
 // defaultSystemZoneConfig is the default zone configuration used when no custom
 // config has been specified for system ranges.
-var defaultSystemZoneConfig = ZoneConfig{
+var defaultSystemZoneConfig = &ZoneConfig{
 	NumReplicas:   5,
 	RangeMinBytes: 1 << 20,  // 1 MB
 	RangeMaxBytes: 64 << 20, // 64 MB
@@ -296,14 +296,14 @@ var defaultSystemZoneConfig = ZoneConfig{
 func DefaultZoneConfig() ZoneConfig {
 	testingLock.Lock()
 	defer testingLock.Unlock()
-	return defaultZoneConfig
+	return *defaultZoneConfig
 }
 
 // DefaultZoneConfigRef returns a reference to the default zone config.
 func DefaultZoneConfigRef() *ZoneConfig {
 	testingLock.Lock()
 	defer testingLock.Unlock()
-	return &defaultZoneConfig
+	return defaultZoneConfig
 }
 
 // DefaultSystemZoneConfig is the default zone configuration used when no custom
@@ -311,7 +311,7 @@ func DefaultZoneConfigRef() *ZoneConfig {
 func DefaultSystemZoneConfig() ZoneConfig {
 	testingLock.Lock()
 	defer testingLock.Unlock()
-	return defaultSystemZoneConfig
+	return *defaultSystemZoneConfig
 }
 
 // TestingSetDefaultZoneConfig is a testing-only function that changes the
@@ -319,7 +319,7 @@ func DefaultSystemZoneConfig() ZoneConfig {
 func TestingSetDefaultZoneConfig(cfg ZoneConfig) func() {
 	testingLock.Lock()
 	oldConfig := defaultZoneConfig
-	defaultZoneConfig = cfg
+	defaultZoneConfig = &cfg
 	testingLock.Unlock()
 
 	return func() {
@@ -334,7 +334,7 @@ func TestingSetDefaultZoneConfig(cfg ZoneConfig) func() {
 func TestingSetDefaultSystemZoneConfig(cfg ZoneConfig) func() {
 	testingLock.Lock()
 	oldConfig := defaultZoneConfig
-	defaultSystemZoneConfig = cfg
+	defaultSystemZoneConfig = &cfg
 	testingLock.Unlock()
 
 	return func() {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -542,6 +542,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		s.gossip,
 		s.recorder,
 		s.nodeLiveness,
+		s.storePool,
 		s.rpcContext,
 		s.node.stores,
 		s.stopper,

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -4808,7 +4808,6 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 		live            []roachpb.StoreID
 		dead            []roachpb.StoreID
 		decommissioning []roachpb.StoreID
-		decommissioned  []roachpb.StoreID
 	}{
 		{
 			storeList:       []roachpb.StoreID{1, 2, 3, 4},
@@ -4877,7 +4876,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 
 	for _, prefixKey := range []roachpb.RKey{roachpb.RKey(keys.NodeLivenessPrefix), roachpb.RKey(keys.SystemPrefix)} {
 		for i, tcase := range testCases {
-			mockStorePool(sp, tcase.live, tcase.dead, tcase.decommissioning, tcase.decommissioned, nil)
+			mockStorePool(sp, tcase.live, tcase.dead, tcase.decommissioning, []roachpb.StoreID{}, nil)
 			desc := makeDescriptor(tcase.storeList)
 			desc.EndKey = prefixKey
 			action, _ := a.ComputeAction(ctx, zone, RangeInfo{Desc: &desc})
@@ -4894,72 +4893,48 @@ func TestAllocatorGetNeededReplicas(t *testing.T) {
 
 	testCases := []struct {
 		zoneRepls  int32
-		aliveRepls int
-		decomRepls int
+		availNodes int
 		expected   int
 	}{
 		// If zone.NumReplicas <= 3, GetNeededReplicas should always return zone.NumReplicas.
-		{1, 0, 0, 1},
-		{1, 1, 0, 1},
-		{1, 1, 1, 1},
-		{1, 0, 1, 1},
-		{2, 0, 0, 2},
-		{2, 1, 0, 2},
-		{2, 2, 0, 2},
-		{2, 2, 2, 2},
-		{3, 0, 0, 3},
-		{3, 1, 0, 3},
-		{3, 3, 0, 3},
-		{3, 3, 2, 3},
+		{1, 0, 1},
+		{1, 1, 1},
+		{2, 0, 2},
+		{2, 1, 2},
+		{2, 2, 2},
+		{3, 0, 3},
+		{3, 1, 3},
+		{3, 3, 3},
 		// Things get more involved when zone.NumReplicas > 3.
-		{4, 1, 0, 3},
-		{4, 2, 0, 3},
-		{4, 3, 0, 3},
-		{4, 4, 0, 4},
-		{4, 4, 1, 3},
-		{4, 4, 2, 3},
-		{4, 4, 3, 3},
-		{5, 1, 0, 3},
-		{5, 2, 0, 3},
-		{5, 3, 0, 3},
-		{5, 4, 0, 3},
-		{5, 5, 0, 5},
-		{5, 5, 1, 3},
-		{5, 5, 2, 3},
-		{5, 5, 3, 3},
-		{6, 1, 0, 3},
-		{6, 2, 0, 3},
-		{6, 3, 0, 3},
-		{6, 4, 0, 3},
-		{6, 5, 0, 5},
-		{6, 6, 0, 6},
-		{6, 6, 1, 5},
-		{6, 6, 2, 3},
-		{6, 5, 1, 3},
-		{6, 5, 2, 3},
-		{6, 5, 3, 3},
-		{7, 1, 0, 3},
-		{7, 2, 0, 3},
-		{7, 3, 0, 3},
-		{7, 4, 0, 3},
-		{7, 5, 0, 5},
-		{7, 6, 0, 5},
-		{7, 7, 0, 7},
-		{7, 7, 1, 5},
-		{7, 7, 2, 5},
-		{7, 7, 3, 3},
-		{7, 6, 1, 5},
-		{7, 6, 2, 3},
-		{7, 5, 1, 3},
-		{7, 4, 1, 3},
-		{7, 3, 1, 3},
+		{4, 1, 3},
+		{4, 2, 3},
+		{4, 3, 3},
+		{4, 4, 4},
+		{5, 1, 3},
+		{5, 2, 3},
+		{5, 3, 3},
+		{5, 4, 3},
+		{5, 5, 5},
+		{6, 1, 3},
+		{6, 2, 3},
+		{6, 3, 3},
+		{6, 4, 3},
+		{6, 5, 5},
+		{6, 6, 6},
+		{7, 1, 3},
+		{7, 2, 3},
+		{7, 3, 3},
+		{7, 4, 3},
+		{7, 5, 5},
+		{7, 6, 5},
+		{7, 7, 7},
 	}
 
 	for _, tc := range testCases {
-		if e, a := tc.expected, GetNeededReplicas(tc.zoneRepls, tc.aliveRepls, tc.decomRepls); e != a {
+		if e, a := tc.expected, GetNeededReplicas(tc.zoneRepls, tc.availNodes); e != a {
 			t.Errorf(
-				"GetNeededReplicas(zone.NumReplicas=%d, aliveReplicas=%d, decomReplicas=%d) got %d; want %d",
-				tc.zoneRepls, tc.aliveRepls, tc.decomRepls, a, e)
+				"GetNeededReplicas(zone.NumReplicas=%d, availNodes=%d) got %d; want %d",
+				tc.zoneRepls, tc.availNodes, a, e)
 		}
 	}
 }

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -2221,9 +2221,9 @@ func TestMergeQueue(t *testing.T) {
 
 	// setThresholds simulates a zone config update that updates the ranges'
 	// minimum and maximum sizes.
-	setZones := func(zone *config.ZoneConfig) {
-		lhs().SetZoneConfig(zone)
-		rhs().SetZoneConfig(zone)
+	setZones := func(zone config.ZoneConfig) {
+		lhs().SetZoneConfig(&zone)
+		rhs().SetZoneConfig(&zone)
 	}
 
 	defaultZone := config.DefaultZoneConfig()
@@ -2242,7 +2242,7 @@ func TestMergeQueue(t *testing.T) {
 		if pErr != nil {
 			t.Fatal(pErr)
 		}
-		setZones(&defaultZone)
+		setZones(defaultZone)
 	}
 
 	verifyMerged := func(t *testing.T) {
@@ -2279,7 +2279,7 @@ func TestMergeQueue(t *testing.T) {
 		store.ForceMergeScanAndProcess()
 		verifyUnmerged(t)
 
-		setZones(&zoneTwiceMin)
+		setZones(zoneTwiceMin)
 		store.ForceMergeScanAndProcess()
 		verifyMerged(t)
 	})
@@ -2294,7 +2294,7 @@ func TestMergeQueue(t *testing.T) {
 		store.ForceMergeScanAndProcess()
 		verifyUnmerged(t)
 
-		setZones(&zoneTwiceMin)
+		setZones(zoneTwiceMin)
 		store.ForceMergeScanAndProcess()
 		verifyMerged(t)
 	})
@@ -2307,7 +2307,7 @@ func TestMergeQueue(t *testing.T) {
 		zone := defaultZone
 		zone.RangeMinBytes = 200
 		zone.RangeMaxBytes = 200
-		setZones(&zone)
+		setZones(zone)
 		bytes := randutil.RandBytes(rng, 100)
 		if err := store.DB().Put(ctx, "a-key", bytes); err != nil {
 			t.Fatal(err)
@@ -2319,7 +2319,7 @@ func TestMergeQueue(t *testing.T) {
 		verifyUnmerged(t)
 
 		zone.RangeMaxBytes = 400
-		setZones(&zone)
+		setZones(zone)
 		store.ForceMergeScanAndProcess()
 		verifyMerged(t)
 	})

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -641,8 +641,7 @@ func (nl *NodeLiveness) Self() (*Liveness, error) {
 }
 
 // IsLiveMapEntry encapsulates data about current liveness for a
-// node. A bool indicating liveness and the last-recorded epoch for
-// the node.
+// node.
 type IsLiveMapEntry struct {
 	IsLive bool
 	Epoch  int64

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -6784,7 +6784,7 @@ type ReplicaMetrics struct {
 
 // Metrics returns the current metrics for the replica.
 func (r *Replica) Metrics(
-	ctx context.Context, now hlc.Timestamp, cfg *config.SystemConfig, livenessMap IsLiveMap,
+	ctx context.Context, now hlc.Timestamp, livenessMap IsLiveMap, availableNodes int,
 ) ReplicaMetrics {
 	r.mu.RLock()
 	raftStatus := r.raftStatusRLocked()
@@ -6806,9 +6806,9 @@ func (r *Replica) Metrics(
 	return calcReplicaMetrics(
 		ctx,
 		now,
-		cfg,
 		zone,
 		livenessMap,
+		availableNodes,
 		desc,
 		raftStatus,
 		leaseStatus,
@@ -6818,7 +6818,6 @@ func (r *Replica) Metrics(
 		cmdQMetricsLocal,
 		cmdQMetricsGlobal,
 		raftLogSize,
-		r.store.allocator.storePool,
 	)
 }
 
@@ -6834,9 +6833,9 @@ func HasRaftLeader(raftStatus *raft.Status) bool {
 func calcReplicaMetrics(
 	ctx context.Context,
 	now hlc.Timestamp,
-	cfg *config.SystemConfig,
 	zone *config.ZoneConfig,
 	livenessMap IsLiveMap,
+	availableNodes int,
 	desc *roachpb.RangeDescriptor,
 	raftStatus *raft.Status,
 	leaseStatus LeaseStatus,
@@ -6846,7 +6845,6 @@ func calcReplicaMetrics(
 	cmdQMetricsLocal CommandQueueMetrics,
 	cmdQMetricsGlobal CommandQueueMetrics,
 	raftLogSize int64,
-	storePool *StorePool,
 ) ReplicaMetrics {
 	var m ReplicaMetrics
 
@@ -6862,37 +6860,8 @@ func calcReplicaMetrics(
 	m.Quiescent = quiescent
 	m.Ticking = ticking
 
-	// We compute an estimated range count across the cluster by counting the
-	// first live replica in each descriptor. Note that the first live replica is
-	// an arbitrary choice. We want to select one live replica to do the counting
-	// that all replicas can agree on.
-	//
-	// Note that this heuristic can double count. If the first live replica is on
-	// a node that is partitioned from the other replicas in the range, there may
-	// be multiple nodes which believe they are the first live replica. This
-	// scenario seems rare as it requires the partitioned node to be alive enough
-	// to be performing liveness heartbeats.
-	for _, rd := range desc.Replicas {
-		if livenessMap[rd.NodeID].IsLive {
-			m.RangeCounter = rd.StoreID == storeID
-			break
-		}
-	}
-
-	// We also compute an estimated per-range count of under-replicated and
-	// unavailable ranges for each range based on the liveness table.
-	if m.RangeCounter {
-		liveReplicas := calcLiveReplicas(desc, livenessMap)
-		if liveReplicas < computeQuorum(len(desc.Replicas)) {
-			m.Unavailable = true
-		}
-		decommissioningReplicas := len(storePool.decommissioningReplicas(desc.RangeID, desc.Replicas))
-		_, aliveStoreCount, _ := storePool.getStoreList(desc.RangeID, storeFilterNone)
-
-		if GetNeededReplicas(zone.NumReplicas, aliveStoreCount, decommissioningReplicas) > liveReplicas {
-			m.Underreplicated = true
-		}
-	}
+	m.RangeCounter, m.Unavailable, m.Underreplicated =
+		calcRangeCounter(storeID, desc, livenessMap, zone.NumReplicas, availableNodes)
 
 	// The raft leader computes the number of raft entries that replicas are
 	// behind.
@@ -6908,16 +6877,58 @@ func calcReplicaMetrics(
 	return m
 }
 
+// calcRangeCounter returns whether this replica is designated as the
+// replica in the range responsible for range-level metrics, whether
+// the range doesn't have a quorum of live replicas, and whether the
+// range is currently under-replicated.
+//
+// Note: we compute an estimated range count across the cluster by counting the
+// first live replica in each descriptor. Note that the first live replica is
+// an arbitrary choice. We want to select one live replica to do the counting
+// that all replicas can agree on.
+//
+// Note that this heuristic can double count. If the first live replica is on
+// a node that is partitioned from the other replicas in the range, there may
+// be multiple nodes which believe they are the first live replica. This
+// scenario seems rare as it requires the partitioned node to be alive enough
+// to be performing liveness heartbeats.
+func calcRangeCounter(
+	storeID roachpb.StoreID,
+	desc *roachpb.RangeDescriptor,
+	livenessMap IsLiveMap,
+	numReplicas int32,
+	availableNodes int,
+) (rangeCounter, unavailable, underreplicated bool) {
+	for _, rd := range desc.Replicas {
+		if livenessMap[rd.NodeID].IsLive {
+			rangeCounter = rd.StoreID == storeID
+			break
+		}
+	}
+	// We also compute an estimated per-range count of under-replicated and
+	// unavailable ranges for each range based on the liveness table.
+	if rangeCounter {
+		liveReplicas := calcLiveReplicas(desc, livenessMap)
+		if liveReplicas < computeQuorum(len(desc.Replicas)) {
+			unavailable = true
+		}
+		if GetNeededReplicas(numReplicas, availableNodes) > liveReplicas {
+			underreplicated = true
+		}
+	}
+	return
+}
+
 // calcLiveReplicas returns a count of the live replicas; a live replica is
 // determined by checking its node in the provided liveness map.
 func calcLiveReplicas(desc *roachpb.RangeDescriptor, livenessMap IsLiveMap) int {
-	var goodReplicas int
+	var live int
 	for _, rd := range desc.Replicas {
 		if livenessMap[rd.NodeID].IsLive {
-			goodReplicas++
+			live++
 		}
 	}
-	return goodReplicas
+	return live
 }
 
 // calcBehindCount returns a total count of log entries that follower replicas

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -9182,9 +9182,10 @@ func TestReplicaMetrics(t *testing.T) {
 			c.expected.Quiescent = i%2 == 0
 			c.expected.Ticking = !c.expected.Quiescent
 			metrics := calcReplicaMetrics(
-				context.Background(), hlc.Timestamp{}, config.NewSystemConfig(), &zoneConfig,
-				c.liveness, &c.desc, c.raftStatus, LeaseStatus{},
-				c.storeID, c.expected.Quiescent, c.expected.Ticking, CommandQueueMetrics{}, CommandQueueMetrics{}, c.raftLogSize, tc.store.allocator.storePool)
+				context.Background(), hlc.Timestamp{}, &zoneConfig,
+				c.liveness, 0, &c.desc, c.raftStatus, LeaseStatus{},
+				c.storeID, c.expected.Quiescent, c.expected.Ticking,
+				CommandQueueMetrics{}, CommandQueueMetrics{}, c.raftLogSize)
 			if c.expected != metrics {
 				t.Fatalf("unexpected metrics:\n%s", pretty.Diff(c.expected, metrics))
 			}

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -310,10 +310,8 @@ func (rq *replicateQueue) processOneChange(
 			StoreID: newStore.StoreID,
 		}
 
-		decommissioningReplicas := len(rq.allocator.storePool.decommissioningReplicas(desc.RangeID, desc.Replicas))
-		_, aliveStoreCount, _ := rq.allocator.storePool.getStoreList(desc.RangeID, storeFilterNone)
-
-		need := GetNeededReplicas(zone.NumReplicas, aliveStoreCount, decommissioningReplicas)
+		availableNodes := rq.allocator.storePool.AvailableNodeCount()
+		need := GetNeededReplicas(zone.NumReplicas, availableNodes)
 		willHave := len(desc.Replicas) + 1
 
 		// Only up-replicate if there are suitable allocation targets such

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4326,9 +4326,10 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	if s.cfg.NodeLiveness != nil {
 		livenessMap = s.cfg.NodeLiveness.GetIsLiveMap()
 	}
+	availableNodes := s.cfg.StorePool.AvailableNodeCount()
 
 	newStoreReplicaVisitor(s).Visit(func(rep *Replica) bool {
-		metrics := rep.Metrics(ctx, timestamp, cfg, livenessMap)
+		metrics := rep.Metrics(ctx, timestamp, livenessMap, availableNodes)
 		if metrics.Leader {
 			raftLeaderCount++
 			if metrics.LeaseValid && !metrics.Leaseholder {

--- a/pkg/storage/store_rebalancer_test.go
+++ b/pkg/storage/store_rebalancer_test.go
@@ -165,7 +165,7 @@ func TestChooseLeaseToTransfer(t *testing.T) {
 		loadRanges(rr, s, []testRange{{storeIDs: tc.storeIDs, qps: tc.qps}})
 		hottestRanges := rr.topQPS()
 		_, target, _ := sr.chooseLeaseToTransfer(
-			ctx, config.NewSystemConfig(), &hottestRanges, &localDesc, storeList, storeMap, minQPS, maxQPS)
+			ctx, &hottestRanges, &localDesc, storeList, storeMap, minQPS, maxQPS)
 		if target.StoreID != tc.expectTarget {
 			t.Errorf("got target store %d for range with replicas %v and %f qps; want %d",
 				target.StoreID, tc.storeIDs, tc.qps, tc.expectTarget)
@@ -234,7 +234,7 @@ func TestChooseReplicaToRebalance(t *testing.T) {
 			loadRanges(rr, s, []testRange{{storeIDs: tc.storeIDs, qps: tc.qps}})
 			hottestRanges := rr.topQPS()
 			_, targets := sr.chooseReplicaToRebalance(
-				ctx, config.NewSystemConfig(), &hottestRanges, &localDesc, storeList, storeMap, minQPS, maxQPS)
+				ctx, &hottestRanges, &localDesc, storeList, storeMap, minQPS, maxQPS)
 
 			if len(targets) != len(tc.expectTargets) {
 				t.Fatalf("chooseReplicaToRebalance(existing=%v, qps=%f) got %v; want %v",


### PR DESCRIPTION
Previously, this code incorrectly mixed the count of available stores
with the count of replicas in a range's descriptor which were on
decommissioning stores. The true intent of `GetNeededReplicas` is to
use a notion of the total number of available nodes. That is, nodes which
are live but not decommissioning.

This also allows us to do a better job of optimizing the inner loop
of `Replica.Metrics`, which is a very hot path when computing the 10s
metrics loop.

Release note: None