### PR TITLE
log: disable error logging during log.Scope

### DIFF
--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -52,7 +52,7 @@ var showLogs bool
 
 // Scope creates a TestLogScope which corresponds to the lifetime of a logging
 // directory. The logging directory is named after the calling test. It also
-// disables logging to stderr for severity levels below ERROR.
+// disables logging to stderr.
 func Scope(t tShim) *TestLogScope {
 	if showLogs {
 		return (*TestLogScope)(nil)
@@ -73,7 +73,7 @@ func ScopeWithoutShowLogs(t tShim) *TestLogScope {
 	if err := dirTestOverride("", tempDir); err != nil {
 		t.Fatal(err)
 	}
-	undo, err := enableLogFileOutput(tempDir, Severity_ERROR)
+	undo, err := enableLogFileOutput(tempDir, Severity_NONE)
 	if err != nil {
 		undo()
 		t.Fatal(err)


### PR DESCRIPTION
Previously, log.Scope only prevented non-error-level logs from getting
sent to stderr. This breaks benchmarks and things that expect no logs to
go to stderr. Now, log.Scope prevents error level logs from going to
stderr as well.

Release note: None