### PR TITLE
opt: normalize inlined expressions

### DIFF
--- a/pkg/sql/opt/norm/inline.go
+++ b/pkg/sql/opt/norm/inline.go
@@ -169,8 +169,7 @@ func (c *CustomFuncs) InlineProjections(target, projections memo.GroupID) memo.G
 			return pb.buildProjections()
 		}
 
-		ev := memo.MakeNormExprView(c.mem, child)
-		return ev.Replace(c.f.evalCtx, replace).Group()
+		return c.f.DynamicConstruct(expr.Operator(), expr.ReplaceOperands(c.mem, replace))
 	}
 
 	return replace(target)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -369,13 +369,13 @@ project
  ├── key: ()
  ├── fd: ()-->(1-5)
  └── inner-join (lookup a)
-      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int!null)
       ├── key columns: [6] = [1]
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(1-7)
       ├── select
-      │    ├── columns: x:6(int!null) y:7(int)
+      │    ├── columns: x:6(int!null) y:7(int!null)
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(6,7)
@@ -384,8 +384,8 @@ project
       │    │    ├── limit: 1
       │    │    ├── key: ()
       │    │    └── fd: ()-->(6,7)
-      │    └── filters [type=bool, outer=(7)]
-      │         └── (y + 1) > 10 [type=bool, outer=(7)]
+      │    └── filters [type=bool, outer=(7), constraints=(/7: [/10 - ]; tight)]
+      │         └── y > 9 [type=bool, outer=(7), constraints=(/7: [/10 - ]; tight)]
       └── true [type=bool]
 
 # Any clause with constant.

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -53,7 +53,7 @@ project
  │    │    ├── columns: k:1(int!null)
  │    │    └── key: (1)
  │    └── filters [type=bool, outer=(1)]
- │         └── ((k * 2) + 1) > 10 [type=bool, outer=(1)]
+ │         └── (k * 2) > 9 [type=bool, outer=(1)]
  └── projections [outer=(1)]
       └── (k * 2) + 1 [type=int, outer=(1)]
 
@@ -333,3 +333,16 @@ project
  │              └── variable: true [type=bool, outer=(10)]
  └── projections [outer=(11)]
       └── true_agg IS NOT NULL [type=bool, outer=(11)]
+
+# After c is replaced with k+2, (k+2) > 2 should be simplified to k > 0.
+opt
+SELECT c FROM (SELECT k+2 AS c FROM a) AS t WHERE c > 2;
+----
+project
+ ├── columns: c:6(int)
+ ├── scan a
+ │    ├── columns: k:1(int!null)
+ │    ├── constraint: /1: [/1 - ]
+ │    └── key: (1)
+ └── projections [outer=(1)]
+      └── k + 2 [type=int, outer=(1)]


### PR DESCRIPTION
Prior to this commit, inlined expressions were not re-constructed,
so they could not benefit from normalization rules for simplification.
For example, consider this query:

`SELECT c FROM (SELECT k+2 AS c FROM a) AS t WHERE c > 2;`

The existing inlining rules caused `c` in the outer query to be replaced
with `k+2`. This could be useful for allowing index constraints to be generated
for `k` (assuming there is an index on `k`). However, the resulting expressions
after inlining were not renormalized, so the result was:

`SELECT k+2 FROM a WHERE k+2 > 2;`

It is not possible to generate index constraints for `(k+2) > 2`, so the
benefits of inlining were not fully realized. This commit fixes the issue
by ensuring that inlined expressions are re-constructed and thus
re-normalized. After this commit, the resulting query is:

`SELECT k+2 FROM a WHERE k > 0;`

This allows us to generate the constraint `/k: [/1 - ]`.

Fixes #30364

Release note: None