### PR TITLE
release-2.1: roachtest: miscellaneous fixes

### DIFF
--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -674,7 +674,7 @@ func (r *registry) run(
 					}
 
 					fmt.Fprintf(r.out, "--- FAIL: %s %s(%s)\n%s", t.Name(), stability, dstr, output)
-					if postIssues && issues.CanPost() {
+					if postIssues && issues.CanPost() && t.spec.Run != nil {
 						authorEmail := getAuthorEmail(failLoc.file, failLoc.line)
 						branch := "<unknown branch>"
 						if b := os.Getenv("TC_BUILD_BRANCH"); b != "" {

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -783,10 +783,6 @@ func (r *registry) run(
 							if !debugEnabled && c.destroyed != nil {
 								c.Destroy(ctx)
 							}
-							if local {
-								t.printf("waiting for test to tear down since cluster is local\n")
-								<-done
-							}
 						}
 					case <-done:
 					}


### PR DESCRIPTION
Backport:
  * 1/1 commits from "Revert \"roachtest: wait for teardown if local test times out\"" (#30529)
  * 1/1 commits from "roachtest: only post issues from tests with a non-nil Run" (#30554)

Please see individual PRs for details.

/cc @cockroachdb/release
