### PR TITLE
release-2.1: engine: avoid committing empty batches

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -655,6 +655,10 @@ DBStatus DBGetEncryptionRegistries(DBEngine* db, DBEncryptionRegistries* result)
 
 DBSSTable* DBGetSSTables(DBEngine* db, int* n) { return db->GetSSTables(n); }
 
+DBStatus DBGetSortedWALFiles(DBEngine* db, DBWALFile** files, int* n) {
+  return db->GetSortedWALFiles(files, n);
+}
+
 DBString DBGetUserProperties(DBEngine* db) { return db->GetUserProperties(); }
 
 DBStatus DBIngestExternalFiles(DBEngine* db, char** paths, size_t len, bool move_files,

--- a/c-deps/libroach/engine.h
+++ b/c-deps/libroach/engine.h
@@ -54,6 +54,7 @@ struct DBEngine {
   virtual DBStatus EnvLinkFile(DBSlice oldname, DBSlice newname) = 0;
 
   DBSSTable* GetSSTables(int* n);
+  DBStatus GetSortedWALFiles(DBWALFile** out_files, int* n);
   DBString GetUserProperties();
 };
 

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -371,6 +371,15 @@ typedef struct {
 // table.
 DBSSTable* DBGetSSTables(DBEngine* db, int* n);
 
+typedef struct {
+  uint64_t log_number;
+  uint64_t size;
+} DBWALFile;
+
+// Retrieve information about all of the write-ahead log files in order from
+// oldest to newest. The files array must be freed.
+DBStatus DBGetSortedWALFiles(DBEngine* db, DBWALFile** files, int* n);
+
 // DBGetUserProperties fetches the user properties stored in each sstable's
 // metadata. These are returned as a serialized SSTUserPropertiesCollection
 // proto.

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1103,6 +1103,41 @@ func (r *RocksDB) GetSSTables() SSTableInfos {
 	return res
 }
 
+// WALFileInfo contains metadata about a single write-ahead log file. Note this
+// mirrors the C.DBWALFile struct.
+type WALFileInfo struct {
+	LogNumber int64
+	Size      int64
+}
+
+// GetSortedWALFiles retrievews information about all of the write-ahead log
+// files in this engine in order from oldest to newest.
+func (r *RocksDB) GetSortedWALFiles() ([]WALFileInfo, error) {
+	var n C.int
+	var files *C.DBWALFile
+	status := C.DBGetSortedWALFiles(r.rdb, &files, &n)
+	if err := statusToError(status); err != nil {
+		return nil, errors.Wrap(err, "could not get sorted WAL files")
+	}
+	defer C.free(unsafe.Pointer(files))
+
+	// We can't index into files because it is a pointer, not a slice. The hackery
+	// below treats the pointer as an array and then constructs a slice from it.
+
+	structSize := unsafe.Sizeof(C.DBWALFile{})
+	getWALFile := func(i int) *C.DBWALFile {
+		return (*C.DBWALFile)(unsafe.Pointer(uintptr(unsafe.Pointer(files)) + uintptr(i)*structSize))
+	}
+
+	res := make([]WALFileInfo, n)
+	for i := range res {
+		wf := getWALFile(i)
+		res[i].LogNumber = int64(wf.log_number)
+		res[i].Size = int64(wf.size)
+	}
+	return res, nil
+}
+
 // getUserProperties fetches the user properties stored in each sstable's
 // metadata.
 func (r *RocksDB) getUserProperties() (enginepb.SSTUserPropertiesCollection, error) {
@@ -1733,6 +1768,12 @@ func (r *rocksDBBatch) Commit(syncCommit bool) error {
 	}
 	r.distinctOpen = false
 
+	if r.flushes == 0 && r.builder.count == 0 {
+		// Nothing was written to this batch. Fast path.
+		r.committed = true
+		return nil
+	}
+
 	// Combine multiple write-only batch commits into a single call to
 	// RocksDB. RocksDB is supposed to be performing such batching internally,
 	// but whether Cgo or something else, it isn't achieving the same degree of
@@ -1859,6 +1900,8 @@ func (r *rocksDBBatch) commitInternal(sync bool) error {
 			C.DBClose(r.batch)
 			r.batch = nil
 		}
+	} else {
+		panic("commitInternal called on empty batch")
 	}
 	r.committed = true
 


### PR DESCRIPTION
Backport 1/1 commits from #30398.

/cc @cockroachdb/release

---

Committing an empty batch previously wrote an empty entry to the RocksDB
WAL file. Coupled with a bug in Raft (etcd-io/etcd#10106), this was
causing unnecessary synchronous writes to disk during Raft heartbeats.

A non-rigorous benchmark shows that this yields a nearly 10% performance
improvement on a three node cluster under a write-heavy workload (kv5%).

^ @nvanbenschoten can this be right??? I don't trust my numbers, but I don't have time to run another benchmark tonight.

Note that the explosion of C++ is just to get at the RocksDB WAL's file size in a unit test. It's not a code path exercised anywhere but tests.

Release note: None
