### PR TITLE
storage/engine: dedupe batch emptiness check

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1769,7 +1769,7 @@ func (r *rocksDBBatch) Commit(syncCommit bool) error {
 	}
 	r.distinctOpen = false
 
-	if r.flushes == 0 && r.builder.count == 0 {
+	if r.Empty() {
 		// Nothing was written to this batch. Fast path.
 		r.committed = true
 		return nil


### PR DESCRIPTION
Avoid reinventing the emptiness check by using the purpose-built
rocksDBBatch.Empty() method.

Release note: None