### PR TITLE
sql: fix the DDL txn restriction check for TRUNCATE

### DIFF
--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -891,9 +891,6 @@ func (p *planner) newPlan(
 	case *tree.Split:
 		return p.Split(ctx, n)
 	case *tree.Truncate:
-		if err := p.txn.SetSystemConfigTrigger(); err != nil {
-			return nil, err
-		}
 		return p.Truncate(ctx, n)
 	case *tree.UnionClause:
 		return p.Union(ctx, n, desiredTypes)

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -765,6 +765,9 @@ func (*Truncate) StatementType() StatementType { return Ack }
 // StatementTag returns a short string identifying the type of statement.
 func (*Truncate) StatementTag() string { return "TRUNCATE" }
 
+// modifiesSchema implements the canModifySchema interface.
+func (*Truncate) modifiesSchema() bool { return true }
+
 // StatementType implements the Statement interface.
 func (n *Update) StatementType() StatementType { return n.Returning.statementType() }
 


### PR DESCRIPTION
Found while working on  #30409.

TRUNCATE is (currently) a DDL statement because it operates by
creating a new descriptor and dropping the old one.

DDL statements in CockroachDB should undergo special checks during
planning, for example they need to trigger a gossip update (to
circulate the update descriptors) and be restricted about their
ordering within a transaction.

Prior to this patch, the planning code for TRUNCATE was not using the
common code path for other DDL statements. As a result it
was (erroneously) missing half of the checks.

This patch fixes it.

Release note (bug fix): TRUNCATE is now properly restricted in SQL
transactions like other DDL statements.