### PR TITLE
distsql: avoid double-closing memory monitors

### DIFF
--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -204,10 +204,10 @@ func (d *Distinct) encode(appendTo []byte, row sqlbase.EncDatumRow) ([]byte, err
 }
 
 func (d *Distinct) close() {
-	// Need to close the mem accounting while the context is still valid.
-	d.memAcc.Close(d.Ctx)
-	d.InternalClose()
-	d.MemMonitor.Stop(d.Ctx)
+	if d.InternalClose() {
+		d.memAcc.Close(d.Ctx)
+		d.MemMonitor.Stop(d.Ctx)
+	}
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/sql/distsqlrun/windower.go
+++ b/pkg/sql/distsqlrun/windower.go
@@ -286,13 +286,13 @@ func (w *windower) ConsumerClosed() {
 }
 
 func (w *windower) close() {
-	// Need to close the mem accounting while the context is still valid.
-	w.accumulationAcc.Close(w.Ctx)
-	w.decodingAcc.Close(w.Ctx)
-	w.resultsAcc.Close(w.Ctx)
-	w.partitionsAcc.Close(w.Ctx)
-	w.InternalClose()
-	w.MemMonitor.Stop(w.Ctx)
+	if w.InternalClose() {
+		w.accumulationAcc.Close(w.Ctx)
+		w.decodingAcc.Close(w.Ctx)
+		w.resultsAcc.Close(w.Ctx)
+		w.partitionsAcc.Close(w.Ctx)
+		w.MemMonitor.Stop(w.Ctx)
+	}
 }
 
 // accumulateRows continually reads rows from the input and accumulates them

--- a/pkg/sql/distsqlrun/zigzagjoiner.go
+++ b/pkg/sql/distsqlrun/zigzagjoiner.go
@@ -417,7 +417,7 @@ func (z *zigzagJoiner) setupInfo(spec *ZigzagJoinerSpec, side int, colOffset int
 }
 
 func (z *zigzagJoiner) close() {
-	if !z.closed {
+	if z.InternalClose() {
 		log.VEventf(z.Ctx, 2, "exiting zigzag joiner run")
 	}
 }


### PR DESCRIPTION
The distinct, windower, and changefeed processors had the potential to
close their memory monitors twice: once in the transition to trailing
metadata, and then again if ConsumerClosed() was called before draining
was complete. This would lead to a "no bytes to release" panic in the
monitor.

I fixed this by changing their close() functions to be no-ops if called
more than once.

Fixes #30536

Release note: None