### PR TITLE
sql: make TRUNCATE EXPLAINable and PREPAREable 

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -19,7 +19,6 @@ stmt ::=
 	| release_stmt
 	| nonpreparable_set_stmt
 	| transaction_stmt
-	| truncate_stmt
 	| 
 
 explainable_stmt ::=
@@ -73,9 +72,6 @@ transaction_stmt ::=
 	| rollback_stmt
 	| abort_stmt
 
-truncate_stmt ::=
-	'TRUNCATE' opt_table relation_expr_list opt_drop_behavior
-
 preparable_stmt ::=
 	alter_stmt
 	| backup_stmt
@@ -92,6 +88,7 @@ preparable_stmt ::=
 	| select_stmt
 	| preparable_set_stmt
 	| show_stmt
+	| truncate_stmt
 	| update_stmt
 	| upsert_stmt
 
@@ -180,18 +177,6 @@ rollback_stmt ::=
 abort_stmt ::=
 	'ABORT' opt_abort_mod
 
-opt_table ::=
-	'TABLE'
-	| 
-
-relation_expr_list ::=
-	( relation_expr ) ( ( ',' relation_expr ) )*
-
-opt_drop_behavior ::=
-	'CASCADE'
-	| 'RESTRICT'
-	| 
-
 alter_stmt ::=
 	alter_ddl_stmt
 	| alter_user_stmt
@@ -270,6 +255,9 @@ show_stmt ::=
 	| show_trace_stmt
 	| show_users_stmt
 	| show_zone_stmt
+
+truncate_stmt ::=
+	'TRUNCATE' opt_table relation_expr_list opt_drop_behavior
 
 update_stmt ::=
 	opt_with_clause 'UPDATE' relation_expr_opt_alias 'SET' set_clause_list where_clause opt_sort_clause opt_limit_clause returning_clause
@@ -629,12 +617,6 @@ opt_abort_mod ::=
 	| 'WORK'
 	| 
 
-relation_expr ::=
-	table_name
-	| table_name '*'
-	| 'ONLY' table_name
-	| 'ONLY' '(' table_name ')'
-
 alter_ddl_stmt ::=
 	alter_table_stmt
 	| alter_index_stmt
@@ -845,6 +827,18 @@ show_zone_stmt ::=
 	| 'SHOW' 'ZONE' 'CONFIGURATIONS'
 	| 'SHOW' 'ALL' 'ZONE' 'CONFIGURATIONS'
 
+opt_table ::=
+	'TABLE'
+	| 
+
+relation_expr_list ::=
+	( relation_expr ) ( ( ',' relation_expr ) )*
+
+opt_drop_behavior ::=
+	'CASCADE'
+	| 'RESTRICT'
+	| 
+
 set_clause_list ::=
 	( set_clause ) ( ( ',' set_clause ) )*
 
@@ -979,6 +973,12 @@ create_view_stmt ::=
 create_sequence_stmt ::=
 	'CREATE' 'SEQUENCE' sequence_name opt_sequence_option_list
 	| 'CREATE' 'SEQUENCE' 'IF' 'NOT' 'EXISTS' sequence_name opt_sequence_option_list
+
+relation_expr ::=
+	table_name
+	| table_name '*'
+	| 'ONLY' table_name
+	| 'ONLY' '(' table_name ')'
 
 limit_clause ::=
 	'LIMIT' select_limit_value

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -340,6 +340,7 @@ func doExpandPlan(
 	case *renameIndexNode:
 	case *renameTableNode:
 	case *scrubNode:
+	case *truncateNode:
 	case *createDatabaseNode:
 	case *createIndexNode:
 	case *CreateUserNode:
@@ -846,6 +847,7 @@ func (p *planner) simplifyOrderings(plan planNode, usefulOrdering sqlbase.Column
 	case *renameIndexNode:
 	case *renameTableNode:
 	case *scrubNode:
+	case *truncateNode:
 	case *createDatabaseNode:
 	case *createIndexNode:
 	case *CreateUserNode:

--- a/pkg/sql/logictest/testdata/logic_test/truncate
+++ b/pkg/sql/logictest/testdata/logic_test/truncate
@@ -156,3 +156,19 @@ TRUNCATE bar
 
 statement ok
 DROP TABLE bar;
+
+subtest truncate_30547
+
+statement ok
+CREATE TABLE tt AS SELECT 'foo'
+
+query TTT
+EXPLAIN TRUNCATE TABLE tt
+----
+truncate  ·  ·
+
+# Verify that EXPLAIN did not cause the truncate to be performed.
+query T
+SELECT * FROM tt
+----
+foo

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -365,6 +365,7 @@ func (p *planner) propagateFilters(
 	case *renameIndexNode:
 	case *renameTableNode:
 	case *scrubNode:
+	case *truncateNode:
 	case *createDatabaseNode:
 	case *createIndexNode:
 	case *CreateUserNode:

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -212,6 +212,7 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 	case *renameIndexNode:
 	case *renameTableNode:
 	case *scrubNode:
+	case *truncateNode:
 	case *createDatabaseNode:
 	case *createIndexNode:
 	case *CreateUserNode:

--- a/pkg/sql/opt_needed.go
+++ b/pkg/sql/opt_needed.go
@@ -260,6 +260,7 @@ func setNeededColumns(plan planNode, needed []bool) {
 	case *renameIndexNode:
 	case *renameTableNode:
 	case *scrubNode:
+	case *truncateNode:
 	case *createDatabaseNode:
 	case *createIndexNode:
 	case *CreateUserNode:

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -956,7 +956,8 @@ func TestParse(t *testing.T) {
 		{`EXPLAIN TABLE a`},
 		{`TABLE [123 AS a]`},
 
-		{`TRUNCATE TABLE a`}, // TODO(knz): Make this explainable.
+		{`TRUNCATE TABLE a`},
+		{`EXPLAIN TRUNCATE TABLE a`},
 		{`TRUNCATE TABLE a, b.c`},
 		{`TRUNCATE TABLE a CASCADE`},
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1066,7 +1066,6 @@ stmt:
 | release_stmt      // EXTEND WITH HELP: RELEASE
 | nonpreparable_set_stmt // help texts in sub-rule
 | transaction_stmt  // help texts in sub-rule
-| truncate_stmt     // EXTEND WITH HELP: TRUNCATE
 | /* EMPTY */
   {
     $$.val = tree.Statement(nil)
@@ -2263,6 +2262,7 @@ preparable_stmt:
   }
 | preparable_set_stmt // help texts in sub-rule
 | show_stmt         // help texts in sub-rule
+| truncate_stmt     // EXTEND WITH HELP: TRUNCATE
 | update_stmt       // EXTEND WITH HELP: UPDATE
 | upsert_stmt       // EXTEND WITH HELP: UPSERT
 

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -957,6 +957,9 @@ func TestPGPreparedQuery(t *testing.T) {
 		{"ALTER RANGE liveness CONFIGURE ZONE = $1", []preparedQueryTest{
 			baseTest.SetArgs(gosql.NullString{}),
 		}},
+		{"TRUNCATE TABLE d.str", []preparedQueryTest{
+			baseTest.SetArgs(),
+		}},
 
 		// TODO(nvanbenschoten): Same class of limitation as that in logic_test/typing:
 		//   Nested constants are not exposed to the same constant type resolution rules

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -203,6 +203,7 @@ var _ planNode = &showRangesNode{}
 var _ planNode = &showTraceNode{}
 var _ planNode = &sortNode{}
 var _ planNode = &splitNode{}
+var _ planNode = &truncateNode{}
 var _ planNode = &unaryNode{}
 var _ planNode = &unionNode{}
 var _ planNode = &updateNode{}
@@ -1008,6 +1009,8 @@ func (p *planner) doPrepare(ctx context.Context, stmt tree.Statement) (planNode,
 		return p.ShowRanges(ctx, n)
 	case *tree.Split:
 		return p.Split(ctx, n)
+	case *tree.Truncate:
+		return p.Truncate(ctx, n)
 	case *tree.Relocate:
 		return p.Relocate(ctx, n)
 	case *tree.Scatter:

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -32,11 +32,23 @@ import (
 // during a table truncation.
 const TableTruncateChunkSize = indexTruncateChunkSize
 
+type truncateNode struct {
+	n *tree.Truncate
+}
+
 // Truncate deletes all rows from a table.
 // Privileges: DROP on table.
 //   Notes: postgres requires TRUNCATE.
 //          mysql requires DROP (for mysql >= 5.1.16, DELETE before that).
 func (p *planner) Truncate(ctx context.Context, n *tree.Truncate) (planNode, error) {
+	return &truncateNode{n: n}, nil
+}
+
+func (t *truncateNode) startExec(params runParams) error {
+	p := params.p
+	n := t.n
+	ctx := params.ctx
+
 	// Since truncation may cascade to a given table any number of times, start by
 	// building the unique set (ID->name) of tables to truncate.
 	toTruncate := make(map[sqlbase.ID]string, len(n.Tables))
@@ -52,16 +64,16 @@ func (p *planner) Truncate(ctx context.Context, n *tree.Truncate) (planNode, err
 	for _, name := range n.Tables {
 		tn, err := name.Normalize()
 		if err != nil {
-			return nil, err
+			return err
 		}
 		tableDesc, err := p.ResolveMutableTableDescriptor(
 			ctx, tn, true /*required*/, requireTableDesc)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		if err := p.CheckPrivilege(ctx, tableDesc, privilege.DROP); err != nil {
-			return nil, err
+			return err
 		}
 
 		toTruncate[tableDesc.ID] = tn.FQString()
@@ -77,7 +89,7 @@ func (p *planner) Truncate(ctx context.Context, n *tree.Truncate) (planNode, err
 	dropJobID, err := p.createDropTablesJob(ctx, stmtTableDescs, droppedTableDetails, tree.AsStringWithFlags(n,
 		tree.FmtAlwaysQualifyTableNames), false /* drainNames */)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Check that any referencing tables are contained in the set, or, if CASCADE
@@ -116,13 +128,13 @@ func (p *planner) Truncate(ctx context.Context, n *tree.Truncate) (planNode, err
 		for _, idx := range tableDesc.AllNonDropIndexes() {
 			for _, ref := range idx.ReferencedBy {
 				if err := maybeEnqueue(ref, "referenced by foreign key from"); err != nil {
-					return nil, err
+					return err
 				}
 			}
 
 			for _, ref := range idx.InterleavedBy {
 				if err := maybeEnqueue(ref, "interleaved by"); err != nil {
-					return nil, err
+					return err
 				}
 			}
 		}
@@ -130,19 +142,13 @@ func (p *planner) Truncate(ctx context.Context, n *tree.Truncate) (planNode, err
 
 	// Mark this query as non-cancellable if autocommitting.
 	if err := p.cancelChecker.Check(); err != nil {
-		return nil, err
+		return err
 	}
 
-	// TODO(knz,andrei): The current code runs the risk of executing the
-	// truncation at prepare time. That doesn't happen currently because
-	// we don't prepare TRUNCATE statements.
-	if p.extendedEvalCtx.PrepareOnly {
-		return nil, errors.Errorf("programming error: cannot prepare a TRUNCATE statement")
-	}
 	traceKV := p.extendedEvalCtx.Tracing.KVTracingEnabled()
 	for id, name := range toTruncate {
 		if err := p.truncateTable(ctx, id, dropJobID, traceKV); err != nil {
-			return nil, err
+			return err
 		}
 
 		// Log a Truncate Table event for this table.
@@ -158,12 +164,16 @@ func (p *planner) Truncate(ctx context.Context, n *tree.Truncate) (planNode, err
 				User      string
 			}{name, n.String(), p.SessionData().User},
 		); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return newZeroNode(nil /* columns */), nil
+	return nil
 }
+
+func (t *truncateNode) Next(runParams) (bool, error) { return false, nil }
+func (t *truncateNode) Values() tree.Datums          { return tree.Datums{} }
+func (t *truncateNode) Close(context.Context)        {}
 
 // truncateTable truncates the data of a table in a single transaction. It
 // drops the table and recreates it with a new ID. The dropped table is

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -677,6 +677,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&sortNode{}):                 "sort",
 	reflect.TypeOf(&splitNode{}):                "split",
 	reflect.TypeOf(&spoolNode{}):                "spool",
+	reflect.TypeOf(&truncateNode{}):             "truncate",
 	reflect.TypeOf(&unaryNode{}):                "emptyrow",
 	reflect.TypeOf(&unionNode{}):                "union",
 	reflect.TypeOf(&updateNode{}):               "update",


### PR DESCRIPTION
Fixes #30547.
Done while looking at #30409.

Release note (bug fix): TRUNCATE can now be used with EXPLAIN and as a
prepared statement.