### PR TITLE
release-2.1: opt: fold NOT(True) and NOT(False)

### DIFF
--- a/pkg/sql/opt/norm/rules/bool.opt
+++ b/pkg/sql/opt/norm/rules/bool.opt
@@ -87,6 +87,14 @@ $item
 =>
 (Null (BoolType))
 
+# FoldNotTrue replaces NOT(True) with False.
+[FoldNotTrue, Normalize]
+(Not (True)) => (False)
+
+# FoldNotFalse replaces NOT(False) with True.
+[FoldNotFalse, Normalize]
+(Not (False)) => (True)
+
 # NegateComparison inverts eligible comparison operators when they are negated
 # by the Not operator. For example, Eq maps to Ne, and Gt maps to Le. All
 # comparisons can be negated except for the JSON comparisons.

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -335,6 +335,26 @@ project
       └── NULL AND (k = 1) [type=bool, outer=(1)]
 
 # --------------------------------------------------
+# FoldNotTrue + FoldNotFalse
+# --------------------------------------------------
+
+opt expect=(FoldNotTrue,FoldNotFalse)
+SELECT NOT(1=1), NOT(1=2)
+----
+project
+ ├── columns: "?column?":1(bool!null) "?column?":2(bool!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── projections
+      ├── false [type=bool]
+      └── true [type=bool]
+
+# --------------------------------------------------
 # NegateComparison
 # --------------------------------------------------
 


### PR DESCRIPTION
Backport 1/1 commits from #30580.

/cc @cockroachdb/release

---

This commit adds normalization rules to fold:
NOT(True) -> (False)
and
NOT(False) -> (True)

Release note: None
