### PR TITLE
release-2.1: storage/engine: dedupe batch emptiness check

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1768,7 +1768,7 @@ func (r *rocksDBBatch) Commit(syncCommit bool) error {
 	}
 	r.distinctOpen = false
 
-	if r.flushes == 0 && r.builder.count == 0 {
+	if r.Empty() {
 		// Nothing was written to this batch. Fast path.
 		r.committed = true
 		return nil


### PR DESCRIPTION
Backport 1/1 commits from #30578.

/cc @cockroachdb/release

---

Avoid reinventing the emptiness check by using the purpose-built
rocksDBBatch.Empty() method.

Release note: None
