### PR TITLE
build: bump crlfmt to pin formatting style

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -302,11 +302,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1e8d6557dd2e9cd72f8a89b1de79f931bee40791119b1d75a70f887e1faea8a8"
+  digest = "1:5c1a738aa52effccd91c780b1514727c347eed563a50bdae35ca9036b910f6bc"
   name = "github.com/cockroachdb/crlfmt"
   packages = ["."]
   pruneopts = "UT"
-  revision = "5895607e5ea790fcbb640260129a12d277b34e46"
+  revision = "ac589b2ed7aaa9410beb9963400c47898216a45e"
 
 [[projects]]
   branch = "master"
@@ -1483,7 +1483,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:38ab68af034d87c7ce7327e1a8e47c0f674ed2e8e7d72d17dd596f58a7ea6faa"
+  digest = "1:08224af962b4f6706598f999d43460f5c6a1080f033c586631d99d7ea8e5654f"
   name = "golang.org/x/tools"
   packages = [
     "cmd/goyacc",
@@ -1496,7 +1496,6 @@
     "go/gcimporter15",
     "go/loader",
     "go/types/typeutil",
-    "imports",
   ]
   pruneopts = "UT"
   revision = "90b807ada4cc7ab5d1409d637b1f3beb5a776be7"

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -550,7 +550,11 @@ func (ts *TestServer) GetAuthenticatedHTTPClient() (http.Client, error) {
 	return httpClient, err
 }
 
-func (ts *TestServer) getAuthenticatedHTTPClientAndCookie() (http.Client, *serverpb.SessionCookie, error) {
+func (ts *TestServer) getAuthenticatedHTTPClientAndCookie() (
+	http.Client,
+	*serverpb.SessionCookie,
+	error,
+) {
 	ts.authClient.once.Do(func() {
 		// Create an authentication session for an arbitrary user. We do not
 		// currently have an authorization mechanism, so a specific user is not

--- a/pkg/sql/distsql_plan_window.go
+++ b/pkg/sql/distsql_plan_window.go
@@ -80,7 +80,10 @@ func (f *windowFuncHolder) samePartition(other *windowFuncHolder) bool {
 // functions that use the same partitioning and updates their isProcessed flag
 // accordingly. It returns the set of unprocessed window functions and indices
 // of the columns in their PARTITION BY clause.
-func (s *windowPlanState) findUnprocessedWindowFnsWithSamePartition() (samePartitionFuncs []*windowFuncHolder, partitionIdxs []uint32) {
+func (s *windowPlanState) findUnprocessedWindowFnsWithSamePartition() (
+	samePartitionFuncs []*windowFuncHolder,
+	partitionIdxs []uint32,
+) {
 	var windowFnToProcess *windowFuncHolder
 	for _, windowFn := range s.infos {
 		if !windowFn.isProcessed {

--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -457,7 +457,11 @@ func (ag *aggregatorBase) matchLastOrdGroupCols(row sqlbase.EncDatumRow) (bool, 
 // into intermediary aggregate results. If it encounters metadata, the metadata
 // is immediately returned. Subsequent calls of this function will resume row
 // accumulation.
-func (ag *hashAggregator) accumulateRows() (aggregatorState, sqlbase.EncDatumRow, *ProducerMetadata) {
+func (ag *hashAggregator) accumulateRows() (
+	aggregatorState,
+	sqlbase.EncDatumRow,
+	*ProducerMetadata,
+) {
 	for {
 		row, meta := ag.input.Next()
 		if meta != nil {
@@ -516,7 +520,11 @@ func (ag *hashAggregator) accumulateRows() (aggregatorState, sqlbase.EncDatumRow
 // into intermediary aggregate results. If it encounters metadata, the metadata
 // is immediately returned. Subsequent calls of this function will resume row
 // accumulation.
-func (ag *orderedAggregator) accumulateRows() (aggregatorState, sqlbase.EncDatumRow, *ProducerMetadata) {
+func (ag *orderedAggregator) accumulateRows() (
+	aggregatorState,
+	sqlbase.EncDatumRow,
+	*ProducerMetadata,
+) {
 	for {
 		row, meta := ag.input.Next()
 		if meta != nil {

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -790,9 +790,9 @@ func TestLint(t *testing.T) {
 				args[i] = strconv.Quote(args[i])
 			}
 			t.Logf("run the following to fix your formatting:\n"+
-				"\n%s %s\n\n"+
+				"\nbin/crlfmt %s\n\n"+
 				"Don't forget to add amend the result to the correct commits.",
-				cmd.Args[0], strings.Join(args, " "),
+				strings.Join(args, " "),
 			)
 		}
 	})

--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -220,7 +220,13 @@ type encodedObjectIterator struct {
 	data        []byte
 }
 
-func (e *encodedObjectIterator) nextEncoded() (nextKey []byte, nextJEntry jEntry, nextVal []byte, ok bool, err error) {
+func (e *encodedObjectIterator) nextEncoded() (
+	nextKey []byte,
+	nextJEntry jEntry,
+	nextVal []byte,
+	ok bool,
+	err error,
+) {
 	if e.idx >= e.len {
 		return nil, jEntry{}, nil, false, nil
 	}


### PR DESCRIPTION
Pick up cockroachdb/crlfmt#21, which pins crlfmt's formatting style to
the vendored version of go/printer irrespective of the Go version.

Release note: None