### PR TITLE
release-2.1: changefeedccl: more avro tests

### DIFF
--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -10,6 +10,7 @@ package changefeedccl
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -88,16 +89,73 @@ func parseValues(tableDesc *sqlbase.TableDescriptor, values string) ([]sqlbase.E
 	return rows, nil
 }
 
+func parseAvroSchema(j string) (*avroSchemaRecord, error) {
+	var s avroSchemaRecord
+	if err := json.Unmarshal([]byte(j), &s); err != nil {
+		return nil, err
+	}
+	// This avroSchemaRecord doesn't have any of the derived fields we need for
+	// serde. Instead of duplicating the logic, fake out a TableDescriptor, so
+	// we can reuse tableToAvroSchema and get them for free.
+	tableDesc := &sqlbase.TableDescriptor{
+		Name: avroUnescapeName(s.Name),
+	}
+	for _, f := range s.Fields {
+		// s.Fields[idx] has `Name` and `SchemaType` set but nonething else.
+		// They're needed for serialization/deserialization, so fake out a
+		// column descriptor so that we can reuse columnDescToAvroSchema to get
+		// all the various fields of avroSchemaField populated for free.
+		colDesc, err := avroSchemaToColDesc(avroUnescapeName(f.Name), f.SchemaType)
+		if err != nil {
+			return nil, err
+		}
+		tableDesc.Columns = append(tableDesc.Columns, *colDesc)
+	}
+	return tableToAvroSchema(tableDesc)
+}
+
+func avroSchemaToColDesc(
+	name string, schemaType avroSchemaType,
+) (*sqlbase.ColumnDescriptor, error) {
+	colDesc := &sqlbase.ColumnDescriptor{Name: name}
+
+	union, ok := schemaType.([]interface{})
+	if ok {
+		if len(union) == 2 && union[0] == avroSchemaNull {
+			colDesc.Nullable = true
+			schemaType = union[1]
+		} else {
+			return nil, errors.Errorf(`unsupported union: %v`, union)
+		}
+	}
+
+	switch schemaType {
+	case avroSchemaLong:
+		colDesc.Type = sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT}
+	case avroSchemaString:
+		colDesc.Type = sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_STRING}
+	case avroSchemaBoolean:
+		colDesc.Type = sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_BOOL}
+	case avroSchemaBytes:
+		colDesc.Type = sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_BYTES}
+	case avroSchemaDouble:
+		colDesc.Type = sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_FLOAT}
+	default:
+		return nil, errors.Errorf(`unknown schema type: %s`, schemaType)
+	}
+	return colDesc, nil
+}
+
 func TestAvroSchema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	rng, _ := randutil.NewPseudoRand()
 
-	type avroTest struct {
+	type test struct {
 		name   string
 		schema string
 		values string
 	}
-	tests := []avroTest{
+	tests := []test{
 		{
 			name:   `NULLABLE`,
 			schema: `(a INT PRIMARY KEY, b INT NULL)`,
@@ -133,12 +191,12 @@ func TestAvroSchema(t *testing.T) {
 		// schema is used in a fmt.Sprintf to fill in the table name, so we have
 		// to escape any stray %s.
 		escapedDatum := strings.Replace(serializedDatum, `%`, `%%`, -1)
-		test := avroTest{
+		randTypeTest := test{
 			name:   semTypeName,
 			schema: fmt.Sprintf(`(a %s PRIMARY KEY)`, colType),
 			values: fmt.Sprintf(`(%s)`, escapedDatum),
 		}
-		tests = append(tests, test)
+		tests = append(tests, randTypeTest)
 	}
 
 	for _, test := range tests {
@@ -146,24 +204,140 @@ func TestAvroSchema(t *testing.T) {
 			tableDesc, err := parseTableDesc(
 				fmt.Sprintf(`CREATE TABLE "%s" %s`, test.name, test.schema))
 			require.NoError(t, err)
-			tableSchema, err := tableToAvroSchema(tableDesc)
+			origSchema, err := tableToAvroSchema(tableDesc)
 			require.NoError(t, err)
+			jsonSchema := origSchema.codec.Schema()
+			roundtrippedSchema, err := parseAvroSchema(jsonSchema)
+			require.NoError(t, err)
+			// It would require some work, but we could also check that the
+			// roundtrippedSchema can be used to recreate the original `CREATE
+			// TABLE`.
 
 			rows, err := parseValues(tableDesc, `VALUES `+test.values)
 			require.NoError(t, err)
 
 			for _, row := range rows {
-				serialized, err := tableSchema.TextualFromRow(row)
+				serialized, err := origSchema.textualFromRow(row)
 				require.NoError(t, err)
-				roundtripped, err := tableSchema.RowFromTextual(serialized)
+				roundtripped, err := roundtrippedSchema.rowFromTextual(serialized)
 				require.NoError(t, err)
 				require.Equal(t, row, roundtripped)
 
-				serialized, err = tableSchema.BinaryFromRow(nil, row)
+				serialized, err = origSchema.BinaryFromRow(nil, row)
 				require.NoError(t, err)
-				roundtripped, err = tableSchema.RowFromBinary(serialized)
+				roundtripped, err = roundtrippedSchema.RowFromBinary(serialized)
 				require.NoError(t, err)
 				require.Equal(t, row, roundtripped)
+			}
+		})
+	}
+}
+
+func (f *avroSchemaField) defaultValueNative() (interface{}, bool) {
+	schemaType := f.SchemaType
+	if union, ok := schemaType.([]avroSchemaType); ok {
+		// "Default values for union fields correspond to the first schema in
+		// the union."
+		schemaType = union[0]
+	}
+	switch schemaType {
+	case avroSchemaNull:
+		return nil, true
+	}
+	panic(errors.Errorf(`unimplemented %T: %v`, schemaType, schemaType))
+}
+
+// rowFromBinaryEvolved decodes `buf` using writerSchema but evolves/resolves it
+// to readerSchema using the rules from the avro spec:
+// https://avro.apache.org/docs/1.8.2/spec.html#Schema+Resolution
+//
+// It'd be nice if our avro library handled this for us, but neither of the
+// popular golang once seem to have it implemented.
+func rowFromBinaryEvolved(
+	buf []byte, writerSchema, readerSchema *avroSchemaRecord,
+) (sqlbase.EncDatumRow, error) {
+	native, newBuf, err := writerSchema.codec.NativeFromBinary(buf)
+	if err != nil {
+		return nil, err
+	}
+	if len(newBuf) > 0 {
+		return nil, errors.New(`only one row was expected`)
+	}
+	nativeMap, ok := native.(map[string]interface{})
+	if !ok {
+		return nil, errors.Errorf(`unknown avro native type: %T`, native)
+	}
+	adjustNative(nativeMap, writerSchema, readerSchema)
+	return readerSchema.rowFromNative(nativeMap)
+}
+
+func adjustNative(native map[string]interface{}, writerSchema, readerSchema *avroSchemaRecord) {
+	for _, writerField := range writerSchema.Fields {
+		if _, inReader := readerSchema.fieldIdxByName[writerField.Name]; !inReader {
+			// "If the writer's record contains a field with a name not present
+			// in the reader's record, the writer's value for that field is
+			// ignored."
+			delete(native, writerField.Name)
+		}
+	}
+	for _, readerField := range readerSchema.Fields {
+		if _, inWriter := writerSchema.fieldIdxByName[readerField.Name]; !inWriter {
+			// "If the reader's record schema has a field that contains a
+			// default value, and writer's schema does not have a field with the
+			// same name, then the reader should use the default value from its
+			// field."
+			if readerFieldDefault, ok := readerField.defaultValueNative(); ok {
+				native[readerField.Name] = readerFieldDefault
+			}
+		}
+	}
+}
+
+func TestAvroMigration(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	type test struct {
+		name           string
+		writerSchema   string
+		writerValues   string
+		readerSchema   string
+		expectedValues string
+	}
+	tests := []test{
+		{
+			name:           `add_nullable`,
+			writerSchema:   `(a INT PRIMARY KEY)`,
+			writerValues:   `(1)`,
+			readerSchema:   `(a INT PRIMARY KEY, b INT)`,
+			expectedValues: `(1, NULL)`,
+		},
+		// TODO(dan): add a column with a default value
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			writerDesc, err := parseTableDesc(
+				fmt.Sprintf(`CREATE TABLE "%s" %s`, test.name, test.writerSchema))
+			require.NoError(t, err)
+			writerSchema, err := tableToAvroSchema(writerDesc)
+			require.NoError(t, err)
+			readerDesc, err := parseTableDesc(
+				fmt.Sprintf(`CREATE TABLE "%s" %s`, test.name, test.readerSchema))
+			require.NoError(t, err)
+			readerSchema, err := tableToAvroSchema(readerDesc)
+			require.NoError(t, err)
+
+			writerRows, err := parseValues(writerDesc, `VALUES `+test.writerValues)
+			require.NoError(t, err)
+			expectedRows, err := parseValues(readerDesc, `VALUES `+test.expectedValues)
+			require.NoError(t, err)
+
+			for i := range writerRows {
+				writerRow, expectedRow := writerRows[i], expectedRows[i]
+				encoded, err := writerSchema.BinaryFromRow(nil, writerRow)
+				require.NoError(t, err)
+				row, err := rowFromBinaryEvolved(encoded, writerSchema, readerSchema)
+				require.NoError(t, err)
+				require.Equal(t, expectedRow, row)
 			}
 		})
 	}

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -100,7 +100,7 @@ func newChangeAggregatorProcessor(
 	}
 
 	var err error
-	if ca.encoder, err = getEncoder(ca.spec.Feed.Opts, ca.spec.Feed.SinkURI); err != nil {
+	if ca.encoder, err = getEncoder(ca.spec.Feed.Opts); err != nil {
 		return nil, err
 	}
 
@@ -386,7 +386,7 @@ func newChangeFrontierProcessor(
 	}
 
 	var err error
-	if cf.encoder, err = getEncoder(spec.Feed.Opts, spec.Feed.SinkURI); err != nil {
+	if cf.encoder, err = getEncoder(spec.Feed.Opts); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -41,34 +41,34 @@ type envelopeType string
 type formatType string
 
 const (
-	optCursor             = `cursor`
-	optEnvelope           = `envelope`
-	optFormat             = `format`
-	optResolvedTimestamps = `resolved`
-	optUpdatedTimestamps  = `updated`
+	optConfluentSchemaRegistry = `confluent_schema_registry`
+	optCursor                  = `cursor`
+	optEnvelope                = `envelope`
+	optFormat                  = `format`
+	optResolvedTimestamps      = `resolved`
+	optUpdatedTimestamps       = `updated`
 
 	optEnvelopeKeyOnly envelopeType = `key_only`
 	optEnvelopeRow     envelopeType = `row`
 	optEnvelopeDiff    envelopeType = `diff`
 
-	optFormatJSON     formatType = `json`
-	optFormatAvro     formatType = `experimental-avro`
-	optFormatAvroJSON formatType = `experimental-avro-json`
+	optFormatJSON formatType = `json`
+	optFormatAvro formatType = `experimental-avro`
 
-	sinkParamConfluentSchemaRegistry = `confluent_schema_registry`
-	sinkParamTopicPrefix             = `topic_prefix`
-	sinkParamSchemaTopic             = `schema_topic`
-	sinkSchemeBuffer                 = ``
-	sinkSchemeExperimentalSQL        = `experimental-sql`
-	sinkSchemeKafka                  = `kafka`
+	sinkParamTopicPrefix      = `topic_prefix`
+	sinkParamSchemaTopic      = `schema_topic`
+	sinkSchemeBuffer          = ``
+	sinkSchemeExperimentalSQL = `experimental-sql`
+	sinkSchemeKafka           = `kafka`
 )
 
 var changefeedOptionExpectValues = map[string]bool{
-	optCursor:             true,
-	optEnvelope:           true,
-	optFormat:             true,
-	optResolvedTimestamps: false,
-	optUpdatedTimestamps:  false,
+	optConfluentSchemaRegistry: true,
+	optCursor:                  true,
+	optEnvelope:                true,
+	optFormat:                  true,
+	optResolvedTimestamps:      false,
+	optUpdatedTimestamps:       false,
 }
 
 // changefeedPlanHook implements sql.PlanHookFn.
@@ -291,7 +291,7 @@ func validateDetails(details jobspb.ChangefeedDetails) (jobspb.ChangefeedDetails
 	switch formatType(details.Opts[optFormat]) {
 	case ``, optFormatJSON:
 		details.Opts[optFormat] = string(optFormatJSON)
-	case optFormatAvro, optFormatAvroJSON:
+	case optFormatAvro:
 		// No-op.
 	default:
 		return jobspb.ChangefeedDetails{}, errors.Errorf(

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -863,22 +863,17 @@ func TestChangefeedErrors(t *testing.T) {
 		}
 
 		// Check that confluent_schema_registry is only accepted if format is
-		// avro (even excluding avro=json).
+		// avro.
 		s := f.Server()
 		sink, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), t.Name(), url.User(security.RootUser))
 		defer cleanup()
 		sink.Scheme = sinkSchemeExperimentalSQL
 		sink.Path = `d`
 		q := sink.Query()
-		q.Set(sinkParamConfluentSchemaRegistry, `foo`)
+		q.Set(optConfluentSchemaRegistry, `foo`)
 		sink.RawQuery = q.Encode()
 		if _, err := sqlDB.DB.Exec(
 			`CREATE CHANGEFEED FOR foo INTO $1`, sink.String(),
-		); !testutils.IsError(err, `unknown sink query parameter: confluent_schema_registry`) {
-			t.Errorf(`expected "unknown sink query parameter: confluent_schema_registry" error got: %v`, err)
-		}
-		if _, err := sqlDB.DB.Exec(
-			`CREATE CHANGEFEED FOR foo INTO $1 WITH format=$2`, sink.String(), optFormatAvroJSON,
 		); !testutils.IsError(err, `unknown sink query parameter: confluent_schema_registry`) {
 			t.Errorf(`expected "unknown sink query parameter: confluent_schema_registry" error got: %v`, err)
 		}

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -9,39 +9,132 @@
 package changefeedccl
 
 import (
+	"bytes"
 	gosql "database/sql"
+	"encoding/binary"
+	gojson "encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/pkg/errors"
 )
 
-// TODO(dan): This is just a sanity check for the avro stuff. We need an
-// end-to-end test with the avro format that interprets the bytes using a schema
-// it gets from the schema registry.
-func TestEncoderAvro(t *testing.T) {
+type testSchemaRegistry struct {
+	server *httptest.Server
+	mu     struct {
+		syncutil.Mutex
+		idAlloc int32
+		schemas map[int32]string
+	}
+}
+
+func makeTestSchemaRegistry() *testSchemaRegistry {
+	r := &testSchemaRegistry{}
+	r.mu.schemas = make(map[int32]string)
+	r.server = httptest.NewServer(http.HandlerFunc(r.Register))
+	return r
+}
+
+func (r *testSchemaRegistry) Close() {
+	r.server.Close()
+}
+
+func (r *testSchemaRegistry) Register(hw http.ResponseWriter, hr *http.Request) {
+	type confluentSchemaVersionRequest struct {
+		Schema string `json:"schema"`
+	}
+	type confluentSchemaVersionResponse struct {
+		ID int32 `json:"id"`
+	}
+	if err := func() error {
+		defer hr.Body.Close()
+		var req confluentSchemaVersionRequest
+		if err := gojson.NewDecoder(hr.Body).Decode(&req); err != nil {
+			return err
+		}
+
+		r.mu.Lock()
+		id := r.mu.idAlloc
+		r.mu.idAlloc++
+		r.mu.schemas[id] = req.Schema
+		r.mu.Unlock()
+
+		res, err := gojson.Marshal(confluentSchemaVersionResponse{ID: id})
+		if err != nil {
+			return err
+		}
+
+		hw.Header().Set(`Content-type`, `application/json`)
+		_, _ = hw.Write(res)
+		return nil
+	}(); err != nil {
+		http.Error(hw, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (r *testSchemaRegistry) encodedAvroToJSON(b []byte) (string, error) {
+	if len(b) == 0 || b[0] != confluentAvroWireFormatMagic {
+		return ``, errors.Errorf(`bad magic byte`)
+	}
+	b = b[1:]
+	if len(b) < 4 {
+		return ``, errors.Errorf(`missing registry id`)
+	}
+	id := int32(binary.BigEndian.Uint32(b[:4]))
+	b = b[4:]
+
+	r.mu.Lock()
+	jsonSchema := r.mu.schemas[id]
+	r.mu.Unlock()
+	schema, err := parseAvroSchema(jsonSchema)
+	if err != nil {
+		return ``, err
+	}
+	row, err := schema.RowFromBinary(b)
+	if err != nil {
+		return ``, err
+	}
+	m := make(map[string]interface{})
+	for fieldIdx, field := range schema.Fields {
+		datum := row[schema.colIdxByFieldIdx[fieldIdx]].Datum
+		m[field.Name], err = tree.AsJSON(datum)
+		if err != nil {
+			return ``, err
+		}
+	}
+	j, err := json.MakeJSON(m)
+	if err != nil {
+		return ``, err
+	}
+	var buf bytes.Buffer
+	j.Format(&buf)
+	return buf.String(), nil
+}
+
+func TestAvroEncoder(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		reg := makeTestSchemaRegistry()
+		defer reg.Close()
+
 		sqlDB := sqlutils.MakeSQLRunner(db)
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
-		sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'bar')`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'bar'), (2, NULL)`)
 
-		foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH format=$1`, optFormatAvroJSON)
+		foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH format=$1, confluent_schema_registry=$2`, optFormatAvro, reg.server.URL)
 		defer foo.Close(t)
 
-		// There's randomized map iteration deep in the avro lib, so we can't use
-		// the normal assertPayloads helper.
-		table, _, key, value, _, ok := foo.Next(t)
-		if !ok {
-			t.Fatal(`expected row`)
-		}
-		require.Equal(t, `foo`, table)
-		require.Equal(t, `{"a":1}`, string(key))
-		require.Contains(t, string(value), `"a":1`)
-		require.Contains(t, string(value), `"b":{"string":"bar"}`)
+		assertPayloadsAvro(t, reg, foo, []string{
+			`foo: {"a": 1}->{"a": 1, "b": "bar"}`,
+			`foo: {"a": 2}->{"a": 2, "b": null}`,
+		})
 	}
 
 	t.Run(`sinkless`, sinklessTest(testFn))

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -93,14 +93,6 @@ func getSink(
 		return nil, errors.Errorf(`unsupported sink: %s`, u.Scheme)
 	}
 
-	// Skip sink params used only by other parts of the system.
-	switch formatType(opts[optFormat]) {
-	case optFormatAvro:
-		q.Del(sinkParamConfluentSchemaRegistry)
-	default:
-		// No-op.
-	}
-
 	for k := range q {
 		_ = s.Close()
 		return nil, errors.Errorf(`unknown sink query parameter: %s`, k)


### PR DESCRIPTION
Backport 1/1 commits from #30484.

/cc @cockroachdb/release

---

Switched confluent_schema_registry from being a query parameter on the
sink uri to being a WITH option, it's much more natural this way.

Switched TestAvroEncoder to use the binary format by mocking out the
schema registry. Ripped out the avro-json format since it wasn't
returning or registering the schema in any way, which is an avro no-no.

Expanded TestAvroSchema to roundtrip the codec through json, which will
help us later check that a column can be recreated exactly from the avro
schema.

Also added the beginnings of an avro schema evolution/resolution test.
The first case checks adding a nullable SQL column.

Still not quite ready for external testing, so again no release note.

For #28637

Release note: None
