### PR TITLE
release-2.1: sql, util: turn a panic into an UnexpectedWithIssueErr

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -508,7 +509,7 @@ func (p *PlanningCtx) sanityCheckAddresses() error {
 	inverted := make(map[string]roachpb.NodeID)
 	for nodeID, addr := range p.NodeAddresses {
 		if otherNodeID, ok := inverted[addr]; ok {
-			return util.UnexpectedWithIssueErrorf(
+			return errorutil.UnexpectedWithIssueErrorf(
 				12876,
 				"different nodes %d and %d with the same address '%s'", nodeID, otherNodeID, addr)
 		}

--- a/pkg/util/errorutil/error_test.go
+++ b/pkg/util/errorutil/error_test.go
@@ -12,14 +12,26 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package util
+package errorutil
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestUnexpectedWithIssueErrorf(t *testing.T) {
 	err := UnexpectedWithIssueErrorf(1234, "args: %d %s %f", 1, "two", 3.0)
-	exp := "unexpected error: args: 1 two 3.000000 (we've been trying to track this particular issue down; please report your reproduction at https://github.com/cockroachdb/cockroach/issues/1234)"
+	exp := "unexpected error: args: 1 two 3.000000\n" +
+		"We've been trying to track this particular issue down. Please report your " +
+		"reproduction at https://github.com/cockroachdb/cockroach/issues/1234 unless " +
+		"that issue seems to have been resolved (in which case you might want to " +
+		"update crdb to a newer version)."
 	if err.Error() != exp {
 		t.Errorf("Expected message:\n  %s\ngot:\n  %s", exp, err.Error())
+	}
+
+	safeMsg := err.(UnexpectedWithIssueErr).SafeMessage()
+	exp = "issue #1234: error_test.go:22: args: %d %s %f | int; string; float64"
+	if safeMsg != exp {
+		t.Errorf("Expected SafeMessage:\n%s\ngot:\n%s", exp, safeMsg)
 	}
 }

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -292,7 +292,7 @@ func (e *safeError) Error() string {
 // anonymized reporting.
 func Redact(r interface{}) string {
 	typAnd := func(i interface{}, text string) string {
-		typ := util.ErrorSource(i)
+		typ := ErrorSource(i)
 		if typ == "" {
 			typ = fmt.Sprintf("%T", i)
 		}
@@ -517,4 +517,19 @@ var tagFns []tagFn
 // This is intended to be called by other packages at init time.
 func RegisterTagFn(key string, value func(context.Context) string) {
 	tagFns = append(tagFns, tagFn{key, value})
+}
+
+// ErrorSource attempts to return the file:line where `i` was created if `i` has
+// that information (i.e. if it is an errors.withStack). Returns "" otherwise.
+func ErrorSource(i interface{}) string {
+	type stackTracer interface {
+		StackTrace() errors.StackTrace
+	}
+	if e, ok := i.(stackTracer); ok {
+		tr := e.StackTrace()
+		if len(tr) > 0 {
+			return fmt.Sprintf("%v", tr[0]) // prints file:line
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
Backport 1/1 commits from #30575.

/cc @cockroachdb/release

---

In #26687 we're observing that sometimes a schema change overwrites an
already existing error, which is a panic. It's unclear what causes this;
the schema change should not be running at all if there's been an error.
This patch traps attempts to run schema changes after an error occured
and returns a conn-closing error, it logs it asking the user to
contribute to the respective issue, and also sends a sentry report.

Release note: None
