### PR TITLE
backport-2.0: storage: fix use of context with closed trace

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1507,7 +1507,7 @@ func (s *Store) startGossip() {
 func (s *Store) startLeaseRenewer(ctx context.Context) {
 	// Start a goroutine that watches and proactively renews certain
 	// expiration-based leases.
-	s.stopper.RunWorker(ctx, func(context.Context) {
+	s.stopper.RunWorker(ctx, func(ctx context.Context) {
 		repls := make(map[*Replica]struct{})
 		timer := timeutil.NewTimer()
 		defer timer.Stop()


### PR DESCRIPTION
Backport 1/1 commits from #25581

---

Fixes #25575

Release note: None