### PR TITLE
sql: deflake TestGossipAlertsTable

### DIFF
--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -49,7 +49,7 @@ func TestGossipAlertsTable(t *testing.T) {
 	}
 
 	ie := s.InternalExecutor().(*sql.InternalExecutor)
-	row, err := ie.QueryRow(ctx, "test", nil /* txn */, "SELECT * FROM crdb_internal.gossip_alerts")
+	row, err := ie.QueryRow(ctx, "test", nil /* txn */, "SELECT * FROM crdb_internal.gossip_alerts WHERE store_id = 123")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The test was manually adding something to Gossip and querying it, but it
wasn't taking into account that there could be actual health alerts,
too. Now it queries for something exclusive.

Fixes #30392.

Release note: None