### PR TITLE
server: de-flake TestAuthenticationAPIUserLogin

### DIFF
--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -428,6 +428,9 @@ func TestAuthenticationAPIUserLogin(t *testing.T) {
 		// We need to instantiate our own HTTP Request, because we must inspect
 		// the returned headers.
 		httpClient, err := ts.GetHTTPClient()
+		if util.RaceEnabled {
+			httpClient.Timeout += 30 * time.Second
+		}
 		if err != nil {
 			t.Fatalf("could not get HTTP client: %s", err)
 		}


### PR DESCRIPTION
The default 5s timeout isn't enough for race builds. Be generous with
the timeout when running the test under race.

Fixes #30150.

Release note: None