### PR TITLE
sql: unskip TestSplitAt

### DIFF
--- a/pkg/sql/split_test.go
+++ b/pkg/sql/split_test.go
@@ -31,8 +31,6 @@ import (
 func TestSplitAt(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("TODO(benesch): #29169: will be fixed by #29324")
-
 	params, _ := tests.CreateTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())

--- a/pkg/storage/intent_resolver.go
+++ b/pkg/storage/intent_resolver.go
@@ -347,6 +347,13 @@ func (cq *contentionQueue) add(
 			// contended key (i.e. newWIErr != nil).
 			contended.setLastTxnMeta(nil)
 		}
+		if newIntentTxn != nil {
+			// Shallow copy the TxnMeta. After this request returns (i.e. now), we might
+			// mutate it (DistSender and such), but the receiver of the channel will read
+			// it.
+			newIntentTxnCopy := *newIntentTxn
+			newIntentTxn = &newIntentTxnCopy
+		}
 		curPusher.waitCh <- newIntentTxn
 		close(curPusher.waitCh)
 		cq.mu.Unlock()


### PR DESCRIPTION
The failure was fixed in #29324.

Closes #29169.

Release note: None