### PR TITLE
opt: add testing infrastructure to disable rules

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -362,6 +362,9 @@ var (
 	)
 	sqlfmtLen = flag.Int("line-length", tree.DefaultPrettyCfg().LineWidth,
 		"target line length when using -rewrite-sql")
+	disableOptRuleProbability = flag.Float64(
+		"disable-opt-rule-probability", 0,
+		"disable transformation rules in the cost-based optimizer with the given probability.")
 )
 
 type testClusterConfig struct {
@@ -937,9 +940,10 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 					BootstrapVersion: cfg.bootstrapVersion,
 				},
 				SQLEvalContext: &tree.EvalContextTestingKnobs{
-					AssertBinaryExprReturnTypes: true,
-					AssertUnaryExprReturnTypes:  true,
-					AssertFuncExprReturnTypes:   true,
+					AssertBinaryExprReturnTypes:     true,
+					AssertUnaryExprReturnTypes:      true,
+					AssertFuncExprReturnTypes:       true,
+					DisableOptimizerRuleProbability: *disableOptRuleProbability,
 				},
 				Upgrade: &server.UpgradeTestingKnobs{
 					DisableUpgrade: cfg.disableUpgrade,

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2393,6 +2393,9 @@ type EvalContextTestingKnobs struct {
 	// evaluations should assert that the returned Datum matches the
 	// expected ReturnType of the function.
 	AssertBinaryExprReturnTypes bool
+	// DisableOptimizerRuleProbability is the probability that any given
+	// transformation rule in the optimizer is disabled.
+	DisableOptimizerRuleProbability float64
 }
 
 var _ base.ModuleTestingKnobs = &EvalContextTestingKnobs{}


### PR DESCRIPTION
This commit adds testing infrastructure for randomly disabling
some transformation rules in the optimizer. The goal is to test that
alternate plans produced by the optimizer are logically equivalent.
It can be used to test that the logic tests still pass with some
rules randomly disabled as follows:
```
  > make test PKG=./pkg/sql/logictest/... TESTS='TestLogic/local-opt/.*' \
    TESTFLAGS='-disable-opt-rule-probability=0.1'
```
This test indicates that each transformation rule may be disabled with
10% probability. The value of -disable-opt-rule-probability can be any
value between 0.0 and 1.0.

Release note: None