### PR TITLE
server: bail out of auth mux if cluster version not yet initialized

### DIFF
--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -355,6 +355,10 @@ const webSessionUserKeyStr = "webSessionUser"
 const webSessionIDKeyStr = "webSessionID"
 
 func (am *authenticationMux) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if !am.server.server.node.storeCfg.Settings.Version.IsInitialized() {
+		http.Error(w, "cluster version has not yet been initialized", 403)
+		return
+	}
 	username, cookie, err := am.getSession(w, req)
 	if err == nil {
 		ctx := req.Context()


### PR DESCRIPTION
This fixes #25771, in which the auth mux was using the internal executor
to run SQL before the cluster version, which the internal executor is
dependent upon, was initialized.

A preferable solution would be to not register any handlers using the
auth mux until the cluster setting is initialized, but it's not
immediately apparent what reordering of things in Server.Start would
achieve this without breaking anything else.

Release note: None