### PR TITLE
storage: Eliminate use of hlc.Clock in replicaStats

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -658,11 +658,11 @@ func newReplica(rangeID roachpb.RangeID, store *Store) *Replica {
 		r.leaseHistory = newLeaseHistory()
 	}
 	if store.cfg.StorePool != nil {
-		r.leaseholderStats = newReplicaStats(store.Clock(), store.cfg.StorePool.getNodeLocalityString)
+		r.leaseholderStats = newReplicaStats(timeutil.Now, store.cfg.StorePool.getNodeLocalityString)
 	}
 	// Pass nil for the localityOracle because we intentionally don't track the
 	// origin locality of write load.
-	r.writeStats = newReplicaStats(store.Clock(), nil)
+	r.writeStats = newReplicaStats(timeutil.Now, nil)
 
 	// Init rangeStr with the range ID.
 	r.rangeStr.store(0, &roachpb.RangeDescriptor{RangeID: rangeID})

--- a/pkg/storage/store_rebalancer_test.go
+++ b/pkg/storage/store_rebalancer_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -98,8 +99,8 @@ func loadRanges(rr *replicaRankings, s *Store, ranges []testRange) {
 		// TODO(a-robinson): The below three lines won't be needed once the old
 		// rangeInfo code is ripped out of the allocator.
 		repl.mu.state.Stats = &enginepb.MVCCStats{}
-		repl.leaseholderStats = newReplicaStats(s.Clock(), nil)
-		repl.writeStats = newReplicaStats(s.Clock(), nil)
+		repl.leaseholderStats = newReplicaStats(func() time.Time { return s.Clock().PhysicalTime() }, nil)
+		repl.writeStats = newReplicaStats(func() time.Time { return s.Clock().PhysicalTime() }, nil)
 		acc.addReplica(replicaWithStats{
 			repl: repl,
 			qps:  r.qps,


### PR DESCRIPTION
Touches #30520. This was almost certainly the worst offender because it
was getting the hlc physical time in recordCount, which is called once
(or twice for writes) on every replica.Send call.

Release note: None