### PR TITLE
gossip: reduce gossip log spam

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1499,7 +1499,12 @@ func (g *Gossip) doDisconnected(c *client) {
 func (g *Gossip) maybeSignalStatusChangeLocked() {
 	ctx := g.AnnotateCtx(context.TODO())
 	orphaned := g.outgoing.len()+g.mu.incoming.len() == 0
-	stalled := orphaned || g.mu.is.getInfo(KeySentinel) == nil
+	multiNode := len(g.nodeDescs) > 1
+	// We're stalled if we don't have the sentinel key, or if we're a multi node
+	// cluster and have no gossip connections. Note that the multi-node check is
+	// pessimistic: when a node restarts multi-node will be false, but we also
+	// won't have the sentinel key.
+	stalled := (orphaned && multiNode) || g.mu.is.getInfo(KeySentinel) == nil
 	if stalled {
 		// We employ the stalled boolean to avoid filling logs with warnings.
 		if !g.stalled {


### PR DESCRIPTION
Don't consider gossip "stalled" in a single-node cluster.

Fixes #29438

Release note: None