### PR TITLE
backport-2.1: sql: statement_timeout default units are now ms

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -265,6 +265,16 @@ SELECT * FROM generate_series(1,1000000)
 statement ok
 SET statement_timeout = '0ms'
 
+# Test that statement_timeout can be set with an interval string, defaulting to
+# milliseconds as a unit.
+statement ok
+SET statement_timeout = '100'
+
+query T
+SHOW statement_timeout
+----
+100ms
+
 # Test that composite variable names get rejected properly, especially
 # when "tracing" is used as prefix.
 

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -2029,6 +2029,12 @@ const (
 	Hour
 	Minute
 	Second
+
+	// While not technically part of the SQL standard for intervals, we provide
+	// Millisecond as a field to allow code to parse intervals with a default unit
+	// of milliseconds, which is useful for some internal use cases like
+	// statement_timeout.
+	Millisecond
 )
 
 // ParseDInterval parses and returns the *DInterval Datum value represented by the provided
@@ -2110,6 +2116,8 @@ func parseDInterval(s string, field DurationField) (*DInterval, error) {
 			ret.Nanos = time.Minute.Nanoseconds() * int64(f)
 		case Second:
 			ret.Nanos = int64(float64(time.Second.Nanoseconds()) * f)
+		case Millisecond:
+			ret.Nanos = int64(float64(time.Millisecond.Nanoseconds()) * f)
 		default:
 			panic(fmt.Sprintf("unhandled DurationField constant %d", field))
 		}

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -242,7 +242,7 @@ func setStmtTimeout(
 	var timeout time.Duration
 	switch v := tree.UnwrapDatum(&evalCtx.EvalContext, d).(type) {
 	case *tree.DString:
-		interval, err := tree.ParseDInterval(string(*v))
+		interval, err := tree.ParseDIntervalWithField(string(*v), tree.Millisecond)
 		if err != nil {
 			return wrapSetVarError("statement_timeout", values[0].String(), "%v", err)
 		}


### PR DESCRIPTION
Backport 1/1 commits from #30605.

/cc @cockroachdb/release

---

Previously, setting statement_timeout to a unitless numeric constant
within a string (e.g. `set statement_timeout='100'`) would result in
the given number of seconds, not milliseconds, being set. This differs
from our behavior with actual numbers, which turn into milliseconds, and
from Postgres, which also expects milliseconds.

Now, settings of this form correctly result in milliseconds being set.

Closes #28866.

cc @rolandcrosby 

Release note: None
