### PR TITLE
opt: extract non-trivial join equalities

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -404,15 +404,24 @@ join       ·         ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
 ----
-join       ·      ·               (a, b, n, sq)  ·
- │         type   inner           ·              ·
- │         pred   sq = (a + b)    ·              ·
- ├── scan  ·      ·               (a, b)         ·
- │         table  pairs@primary   ·              ·
- │         spans  ALL             ·              ·
- └── scan  ·      ·               (n, sq)        ·
-·          table  square@primary  ·              ·
-·          spans  ALL             ·              ·
+render               ·         ·                 (a, b, n, sq)           ·
+ │                   render 0  a                 ·                       ·
+ │                   render 1  b                 ·                       ·
+ │                   render 2  n                 ·                       ·
+ │                   render 3  sq                ·                       ·
+ └── join            ·         ·                 (column6, a, b, n, sq)  ·
+      │              type      inner             ·                       ·
+      │              equality  (column6) = (sq)  ·                       ·
+      ├── render     ·         ·                 (column6, a, b)         ·
+      │    │         render 0  a + b             ·                       ·
+      │    │         render 1  a                 ·                       ·
+      │    │         render 2  b                 ·                       ·
+      │    └── scan  ·         ·                 (a, b)                  ·
+      │              table     pairs@primary     ·                       ·
+      │              spans     ALL               ·                       ·
+      └── scan       ·         ·                 (n, sq)                 ·
+·                    table     square@primary    ·                       ·
+·                    spans     ALL               ·                       ·
 
 # Query similar to the one above, but the filter refers to a rendered
 # expression and can't "break through".
@@ -445,30 +454,48 @@ render                    ·         ·               (a, b, n, sq)       ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq
 ----
-join       ·      ·               (a, b, n, sq)  ·
- │         type   full outer      ·              ·
- │         pred   sq = (a + b)    ·              ·
- ├── scan  ·      ·               (a, b)         ·
- │         table  pairs@primary   ·              ·
- │         spans  ALL             ·              ·
- └── scan  ·      ·               (n, sq)        ·
-·          table  square@primary  ·              ·
-·          spans  ALL             ·              ·
+render               ·         ·                 (a, b, n, sq)           ·
+ │                   render 0  a                 ·                       ·
+ │                   render 1  b                 ·                       ·
+ │                   render 2  n                 ·                       ·
+ │                   render 3  sq                ·                       ·
+ └── join            ·         ·                 (column6, a, b, n, sq)  ·
+      │              type      full outer        ·                       ·
+      │              equality  (column6) = (sq)  ·                       ·
+      ├── render     ·         ·                 (column6, a, b)         ·
+      │    │         render 0  a + b             ·                       ·
+      │    │         render 1  a                 ·                       ·
+      │    │         render 2  b                 ·                       ·
+      │    └── scan  ·         ·                 (a, b)                  ·
+      │              table     pairs@primary     ·                       ·
+      │              spans     ALL               ·                       ·
+      └── scan       ·         ·                 (n, sq)                 ·
+·                    table     square@primary    ·                       ·
+·                    spans     ALL               ·                       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2
 ----
-filter          ·       ·                    (a, b, n, sq)  ·
- │              filter  (b % 2) != (sq % 2)  ·              ·
- └── join       ·       ·                    (a, b, n, sq)  ·
-      │         type    full outer           ·              ·
-      │         pred    sq = (a + b)         ·              ·
-      ├── scan  ·       ·                    (a, b)         ·
-      │         table   pairs@primary        ·              ·
-      │         spans   ALL                  ·              ·
-      └── scan  ·       ·                    (n, sq)        ·
-·               table   square@primary       ·              ·
-·               spans   ALL                  ·              ·
+render                    ·         ·                    (a, b, n, sq)           ·
+ │                        render 0  a                    ·                       ·
+ │                        render 1  b                    ·                       ·
+ │                        render 2  n                    ·                       ·
+ │                        render 3  sq                   ·                       ·
+ └── filter               ·         ·                    (column6, a, b, n, sq)  ·
+      │                   filter    (b % 2) != (sq % 2)  ·                       ·
+      └── join            ·         ·                    (column6, a, b, n, sq)  ·
+           │              type      full outer           ·                       ·
+           │              equality  (column6) = (sq)     ·                       ·
+           ├── render     ·         ·                    (column6, a, b)         ·
+           │    │         render 0  a + b                ·                       ·
+           │    │         render 1  a                    ·                       ·
+           │    │         render 2  b                    ·                       ·
+           │    └── scan  ·         ·                    (a, b)                  ·
+           │              table     pairs@primary        ·                       ·
+           │              spans     ALL                  ·                       ·
+           └── scan       ·         ·                    (n, sq)                 ·
+·                         table     square@primary       ·                       ·
+·                         spans     ALL                  ·                       ·
 
 # Filter propagation through outer joins.
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -165,15 +165,19 @@ join       ·               ·          (x, y)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE b.x-1 = a.x)
 ----
-join       ·      ·            (x, y)  ·
- │         type   semi         ·       ·
- │         pred   x = (x - 1)  ·       ·
- ├── scan  ·      ·            (x, y)  ·
- │         table  a@primary    ·       ·
- │         spans  ALL          ·       ·
- └── scan  ·      ·            (x, z)  ·
-·          table  b@primary    ·       ·
-·          spans  ALL          ·       ·
+join            ·         ·                (x, y)           ·
+ │              type      semi             ·                ·
+ │              equality  (x) = (column5)  ·                ·
+ ├── scan       ·         ·                (x, y)           ·
+ │              table     a@primary        ·                ·
+ │              spans     ALL              ·                ·
+ └── render     ·         ·                (column5, x, z)  ·
+      │         render 0  x - 1            ·                ·
+      │         render 1  x                ·                ·
+      │         render 2  z                ·                ·
+      └── scan  ·         ·                (x, z)           ·
+·               table     b@primary        ·                ·
+·               spans     ALL              ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM b WHERE b.x = a.x)
@@ -192,15 +196,19 @@ join       ·               ·          (x, y)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM b WHERE NOT EXISTS(SELECT * FROM a WHERE x-1 = b.x)
 ----
-join       ·      ·            (x, z)  ·
- │         type   anti         ·       ·
- │         pred   x = (x - 1)  ·       ·
- ├── scan  ·      ·            (x, z)  ·
- │         table  b@primary    ·       ·
- │         spans  ALL          ·       ·
- └── scan  ·      ·            (x, y)  ·
-·          table  a@primary    ·       ·
-·          spans  ALL          ·       ·
+join            ·         ·                (x, z)           ·
+ │              type      anti             ·                ·
+ │              equality  (x) = (column5)  ·                ·
+ ├── scan       ·         ·                (x, z)           ·
+ │              table     b@primary        ·                ·
+ │              spans     ALL              ·                ·
+ └── render     ·         ·                (column5, x, y)  ·
+      │         render 0  x - 1            ·                ·
+      │         render 1  x                ·                ·
+      │         render 2  y                ·                ·
+      └── scan  ·         ·                (x, y)           ·
+·               table     a@primary        ·                ·
+·               spans     ALL              ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY(SELECT x FROM b)

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -76,46 +76,47 @@ ORDER BY y
 LIMIT 10
 ----
 project
- ├── columns: y:2(int!null) x:3(string!null) c:5(int)
+ ├── columns: y:2(int!null) x:3(string!null) c:6(int)
  ├── cardinality: [0 - 10]
- ├── fd: (2)-->(5)
+ ├── fd: (2)-->(6)
  ├── ordering: +2
  ├── limit
- │    ├── columns: a.x:1(int!null) y:2(int!null) b.x:3(string!null)
+ │    ├── columns: y:2(int!null) b.x:3(string!null) column5:5(string!null)
  │    ├── internal-ordering: +2
  │    ├── cardinality: [0 - 10]
- │    ├── key: (1,3)
- │    ├── fd: (1)-->(2)
+ │    ├── fd: (3)==(5), (5)==(3)
  │    ├── ordering: +2
  │    ├── sort
- │    │    ├── columns: a.x:1(int!null) y:2(int!null) b.x:3(string!null)
- │    │    ├── key: (1,3)
- │    │    ├── fd: (1)-->(2)
+ │    │    ├── columns: y:2(int!null) b.x:3(string!null) column5:5(string!null)
+ │    │    ├── fd: (3)==(5), (5)==(3)
  │    │    ├── ordering: +2
  │    │    └── inner-join
- │    │         ├── columns: a.x:1(int!null) y:2(int!null) b.x:3(string!null)
- │    │         ├── key: (1,3)
- │    │         ├── fd: (1)-->(2)
+ │    │         ├── columns: y:2(int!null) b.x:3(string!null) column5:5(string!null)
+ │    │         ├── fd: (3)==(5), (5)==(3)
  │    │         ├── scan b
  │    │         │    ├── columns: b.x:3(string!null)
  │    │         │    └── key: (3)
- │    │         ├── select
- │    │         │    ├── columns: a.x:1(int!null) y:2(int!null)
- │    │         │    ├── key: (1)
- │    │         │    ├── fd: (1)-->(2)
- │    │         │    ├── scan a
- │    │         │    │    ├── columns: a.x:1(int!null) y:2(int)
+ │    │         ├── project
+ │    │         │    ├── columns: column5:5(string) y:2(int!null)
+ │    │         │    ├── select
+ │    │         │    │    ├── columns: a.x:1(int!null) y:2(int!null)
  │    │         │    │    ├── key: (1)
- │    │         │    │    └── fd: (1)-->(2)
- │    │         │    └── filters [type=bool, outer=(2), constraints=(/2: [/2 - ]; tight)]
- │    │         │         └── gt [type=bool, outer=(2), constraints=(/2: [/2 - ]; tight)]
- │    │         │              ├── variable: y [type=int, outer=(2)]
- │    │         │              └── const: 1 [type=int]
- │    │         └── filters [type=bool, outer=(1,3), constraints=(/3: (/NULL - ])]
- │    │              └── eq [type=bool, outer=(1,3), constraints=(/3: (/NULL - ])]
- │    │                   ├── variable: b.x [type=string, outer=(3)]
- │    │                   └── cast: STRING [type=string, outer=(1)]
- │    │                        └── variable: a.x [type=int, outer=(1)]
+ │    │         │    │    ├── fd: (1)-->(2)
+ │    │         │    │    ├── scan a
+ │    │         │    │    │    ├── columns: a.x:1(int!null) y:2(int)
+ │    │         │    │    │    ├── key: (1)
+ │    │         │    │    │    └── fd: (1)-->(2)
+ │    │         │    │    └── filters [type=bool, outer=(2), constraints=(/2: [/2 - ]; tight)]
+ │    │         │    │         └── gt [type=bool, outer=(2), constraints=(/2: [/2 - ]; tight)]
+ │    │         │    │              ├── variable: y [type=int, outer=(2)]
+ │    │         │    │              └── const: 1 [type=int]
+ │    │         │    └── projections [outer=(1,2)]
+ │    │         │         └── cast: STRING [type=string, outer=(1)]
+ │    │         │              └── variable: a.x [type=int, outer=(1)]
+ │    │         └── filters [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
+ │    │              └── eq [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ])]
+ │    │                   ├── variable: column5 [type=string, outer=(5)]
+ │    │                   └── variable: b.x [type=string, outer=(3)]
  │    └── const: 10 [type=int]
  └── projections [outer=(2,3)]
       └── plus [type=int, outer=(2)]
@@ -129,52 +130,75 @@ WHERE a.y>1 AND a.x::string=b.x
 ORDER BY y
 LIMIT 10
 ----
-memo (optimized, ~17KB)
+memo (optimized, ~24KB)
  ├── G1: (project G2 G3)
- │    ├── "[presentation: y:2,x:3,c:5] [ordering: +2]"
+ │    ├── "[presentation: y:2,x:3,c:6] [ordering: +2]"
  │    │    ├── best: (project G2="[ordering: +2]" G3)
- │    │    └── cost: 41568.95
+ │    │    └── cost: 2167.84
  │    └── ""
  │         ├── best: (project G2 G3)
- │         └── cost: 41568.95
+ │         └── cost: 2167.84
  ├── G2: (limit G4 G5 ordering=+2)
  │    ├── ""
  │    │    ├── best: (limit G4="[ordering: +2]" G5 ordering=+2)
- │    │    └── cost: 41568.75
+ │    │    └── cost: 2167.64
  │    └── "[ordering: +2]"
  │         ├── best: (limit G4="[ordering: +2]" G5 ordering=+2)
- │         └── cost: 41568.75
+ │         └── cost: 2167.64
  ├── G3: (projections G6 y x)
- ├── G4: (inner-join G8 G7 G9) (inner-join G7 G8 G9)
+ ├── G4: (inner-join G9 G8 G7) (inner-join G8 G9 G7) (lookup-join G9 G14 b,keyCols=[5],outCols=(2,3,5)) (merge-join G8 G9 G10)
  │    ├── ""
- │    │    ├── best: (inner-join G7 G8 G9)
- │    │    └── cost: 3209.44
+ │    │    ├── best: (inner-join G8 G9 G7)
+ │    │    └── cost: 2108.33
  │    └── "[ordering: +2]"
  │         ├── best: (sort G4)
- │         └── cost: 41568.65
+ │         └── cost: 2167.54
  ├── G5: (const 10)
- ├── G6: (plus G16 G17)
- ├── G7: (scan b,cols=(3))
- │    └── ""
+ ├── G6: (plus G22 G23)
+ ├── G7: (filters G11)
+ ├── G8: (scan b,cols=(3))
+ │    ├── ""
+ │    │    ├── best: (scan b,cols=(3))
+ │    │    └── cost: 1030.00
+ │    └── "[ordering: +3]"
  │         ├── best: (scan b,cols=(3))
  │         └── cost: 1030.00
- ├── G8: (select G10 G11)
- │    └── ""
- │         ├── best: (select G10 G11)
- │         └── cost: 1050.00
- ├── G9: (filters G12)
- ├── G10: (scan a)
- │    └── ""
- │         ├── best: (scan a)
- │         └── cost: 1040.00
- ├── G11: (filters G13)
- ├── G12: (eq G14 G15)
- ├── G13: (gt G16 G17)
- ├── G14: (variable b.x)
- ├── G15: (cast G18 STRING)
- ├── G16: (variable y)
- ├── G17: (const 1)
- └── G18: (variable a.x)
+ ├── G9: (project G12 G13)
+ │    ├── ""
+ │    │    ├── best: (project G12 G13)
+ │    │    └── cost: 1056.67
+ │    ├── "[ordering: +2]"
+ │    │    ├── best: (sort G9)
+ │    │    └── cost: 1115.87
+ │    └── "[ordering: +5]"
+ │         ├── best: (sort G9)
+ │         └── cost: 1115.87
+ ├── G10: (merge-on G14 inner-join,+3,+5)
+ ├── G11: (eq G15 G16)
+ ├── G12: (select G17 G18)
+ │    ├── ""
+ │    │    ├── best: (select G17 G18)
+ │    │    └── cost: 1050.00
+ │    └── "[ordering: +2]"
+ │         ├── best: (sort G12)
+ │         └── cost: 1109.21
+ ├── G13: (projections G19 y)
+ ├── G14: (true)
+ ├── G15: (variable column5)
+ ├── G16: (variable b.x)
+ ├── G17: (scan a)
+ │    ├── ""
+ │    │    ├── best: (scan a)
+ │    │    └── cost: 1040.00
+ │    └── "[ordering: +2]"
+ │         ├── best: (sort G17)
+ │         └── cost: 1249.32
+ ├── G18: (filters G20)
+ ├── G19: (cast G21 STRING)
+ ├── G20: (gt G22 G23)
+ ├── G21: (variable a.x)
+ ├── G22: (variable y)
+ └── G23: (const 1)
 
 # Test interning of expressions.
 memo

--- a/pkg/sql/opt/memo/testdata/typing
+++ b/pkg/sql/opt/memo/testdata/typing
@@ -386,13 +386,17 @@ project
  │    │    ├── columns: a.x:1(int!null) y:2(int) max:6(string)
  │    │    ├── grouping columns: a.x:1(int!null)
  │    │    ├── inner-join
- │    │    │    ├── columns: a.x:1(int!null) y:2(int!null) b.x:4(string!null) z:5(decimal!null)
+ │    │    │    ├── columns: a.x:1(int!null) y:2(int!null) b.x:4(string!null) column7:7(int!null)
  │    │    │    ├── scan a
  │    │    │    │    └── columns: a.x:1(int!null) y:2(int)
- │    │    │    ├── scan b
- │    │    │    │    └── columns: b.x:4(string!null) z:5(decimal!null)
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: column7:7(int) b.x:4(string!null)
+ │    │    │    │    ├── scan b
+ │    │    │    │    │    └── columns: b.x:4(string!null) z:5(decimal!null)
+ │    │    │    │    └── projections
+ │    │    │    │         └── z::INT [type=int]
  │    │    │    └── filters [type=bool]
- │    │    │         └── y = z::INT [type=bool]
+ │    │    │         └── y = column7 [type=bool]
  │    │    └── aggregations
  │    │         ├── max [type=string]
  │    │         │    └── variable: b.x [type=string]

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -16,6 +16,7 @@ package opt
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -221,8 +222,11 @@ func (md *Metadata) CheckDependencies(ctx context.Context, catalog Catalog) bool
 }
 
 // AddColumn assigns a new unique id to a column within the query and records
-// its label and type.
+// its label and type. If the label is empty, a "column<ID>" label is created.
 func (md *Metadata) AddColumn(label string, typ types.T) ColumnID {
+	if label == "" {
+		label = fmt.Sprintf("column%d", len(md.cols)+1)
+	}
 	md.cols = append(md.cols, mdColumn{label: label, typ: typ})
 	return ColumnID(len(md.cols))
 }

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -394,3 +394,30 @@ $left
         )
     )
 )
+
+# ExtractJoinEqualities finds equality conditions such that one side only
+# depends on left columns and the other only on right columns and pushes the
+# expressions down into ProjectOps. The result is a join that has an equality
+# constraint, which is much more efficient. For example:
+#   SELECT * FROM abc JOIN xyz ON a=x+1
+# This join would be quadratic because we have no equality columns.
+# This rule rewrites it as:
+#   SELECT a,b,c,x,y,z FROM abc JOIN (SELECT *, x+1 AS x1 FROM xyz) ON a=x1
+# This join can use hash join or lookup on the equality columns.
+#
+# Depending on the expressions involved, one or both sides require a projection.
+[ExtractJoinEqualities, Normalize]
+(JoinNonApply
+    $left:* & ^(HasOuterCols $left)
+    $right:* & ^(HasOuterCols $right)
+    (Filters
+        $list:[
+            ...
+            (Eq $a:* $b:*) &
+            (CanExtractJoinEquality $a $b (OutputCols $left) (OutputCols $right))
+            ...
+        ]
+    )
+)
+=>
+(ExtractJoinEqualities (OpName) $left $right $list)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1994,8 +1994,8 @@ group-by
  │    │    ├── key: (1,3)
  │    │    ├── fd: (1)-->(2), (3)-->(4), (1,3)-->(2,4,13)
  │    │    ├── inner-join
- │    │    │    ├── columns: x:1(int!null) y:2(int) a.k:3(int!null) a.i:4(int) a.i:9(int!null) a.f:10(float!null)
- │    │    │    ├── fd: (1)-->(2), (3)-->(4)
+ │    │    │    ├── columns: x:1(int!null) y:2(int) a.k:3(int!null) a.i:4(int) a.i:9(int!null) a.f:10(float!null) column14:14(float!null)
+ │    │    │    ├── fd: (1)-->(2), (2)-->(14), (3)-->(4), (10)==(14), (14)==(10)
  │    │    │    ├── inner-join
  │    │    │    │    ├── columns: a.k:3(int!null) a.i:4(int) a.i:9(int!null) a.f:10(float)
  │    │    │    │    ├── fd: (3)-->(4)
@@ -2010,12 +2010,18 @@ group-by
  │    │    │    │    │    └── filters [type=bool, outer=(9), constraints=(/9: (/NULL - ]; tight)]
  │    │    │    │    │         └── a.i IS NOT NULL [type=bool, outer=(9), constraints=(/9: (/NULL - ]; tight)]
  │    │    │    │    └── true [type=bool]
- │    │    │    ├── scan xy
- │    │    │    │    ├── columns: x:1(int!null) y:2(int)
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: column14:14(float) x:1(int!null) y:2(int)
  │    │    │    │    ├── key: (1)
- │    │    │    │    └── fd: (1)-->(2)
- │    │    │    └── filters [type=bool, outer=(2,10), constraints=(/10: (/NULL - ])]
- │    │    │         └── a.f = y::FLOAT8 [type=bool, outer=(2,10), constraints=(/10: (/NULL - ])]
+ │    │    │    │    ├── fd: (1)-->(2), (2)-->(14)
+ │    │    │    │    ├── scan xy
+ │    │    │    │    │    ├── columns: x:1(int!null) y:2(int)
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    └── fd: (1)-->(2)
+ │    │    │    │    └── projections [outer=(1,2)]
+ │    │    │    │         └── y::FLOAT8 [type=float, outer=(2)]
+ │    │    │    └── filters [type=bool, outer=(10,14), constraints=(/10: (/NULL - ]; /14: (/NULL - ]), fd=(10)==(14), (14)==(10)]
+ │    │    │         └── column14 = a.f [type=bool, outer=(10,14), constraints=(/10: (/NULL - ]; /14: (/NULL - ])]
  │    │    └── aggregations [outer=(2,4,9)]
  │    │         ├── max [type=int, outer=(9)]
  │    │         │    └── variable: a.i [type=int, outer=(9)]
@@ -3418,19 +3424,22 @@ SELECT i, y FROM a INNER JOIN xy ON (SELECT k+1) = x
 project
  ├── columns: i:2(int) y:7(int)
  └── inner-join
-      ├── columns: k:1(int!null) i:2(int) x:6(int!null) y:7(int)
-      ├── key: (1,6)
-      ├── fd: (1)-->(2), (6)-->(7)
-      ├── scan a
-      │    ├── columns: k:1(int!null) i:2(int)
-      │    ├── key: (1)
-      │    └── fd: (1)-->(2)
+      ├── columns: i:2(int) x:6(int!null) y:7(int) column9:9(int!null)
+      ├── fd: (6)-->(7), (6)==(9), (9)==(6)
+      ├── project
+      │    ├── columns: column9:9(int) i:2(int)
+      │    ├── scan a
+      │    │    ├── columns: k:1(int!null) i:2(int)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2)
+      │    └── projections [outer=(1,2)]
+      │         └── k + 1 [type=int, outer=(1)]
       ├── scan xy
       │    ├── columns: x:6(int!null) y:7(int)
       │    ├── key: (6)
       │    └── fd: (6)-->(7)
-      └── filters [type=bool, outer=(1,6), constraints=(/6: (/NULL - ])]
-           └── x = (k + 1) [type=bool, outer=(1,6), constraints=(/6: (/NULL - ])]
+      └── filters [type=bool, outer=(6,9), constraints=(/6: (/NULL - ]; /9: (/NULL - ]), fd=(6)==(9), (9)==(6)]
+           └── column9 = x [type=bool, outer=(6,9), constraints=(/6: (/NULL - ]; /9: (/NULL - ])]
 
 # Right join + multiple subqueries.
 opt expect=HoistJoinSubquery

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -2006,3 +2006,378 @@ inner-join
  └── filters [type=bool, outer=(1,2,6,7)]
       ├── (k = y) IS true [type=bool, outer=(1,7)]
       └── (i = x) IS false [type=bool, outer=(2,6)]
+
+# --------------------------------------------------
+# ExtractJoinEqualities
+# --------------------------------------------------
+
+opt expect=ExtractJoinEqualities
+SELECT * FROM xy JOIN uv ON x+y=u
+----
+project
+ ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
+ ├── key: (1)
+ ├── fd: (1)-->(2), (1,2)-->(3,4), (3)-->(4)
+ └── inner-join
+      ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) column5:5(int!null)
+      ├── key: (1)
+      ├── fd: (1)-->(2), (1,2)-->(5), (3)-->(4), (3)==(5), (5)==(3)
+      ├── project
+      │    ├── columns: column5:5(int) x:1(int!null) y:2(int)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2), (1,2)-->(5)
+      │    ├── scan xy
+      │    │    ├── columns: x:1(int!null) y:2(int)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2)
+      │    └── projections [outer=(1,2)]
+      │         └── x + y [type=int, outer=(1,2)]
+      ├── scan uv
+      │    ├── columns: u:3(int!null) v:4(int)
+      │    ├── key: (3)
+      │    └── fd: (3)-->(4)
+      └── filters [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
+           └── column5 = u [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ])]
+
+opt expect=ExtractJoinEqualities
+SELECT * FROM xy JOIN uv ON u=x+y
+----
+project
+ ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
+ ├── key: (1)
+ ├── fd: (1)-->(2), (1,2)-->(3,4), (3)-->(4)
+ └── inner-join
+      ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) column5:5(int!null)
+      ├── key: (1)
+      ├── fd: (1)-->(2), (1,2)-->(5), (3)-->(4), (3)==(5), (5)==(3)
+      ├── project
+      │    ├── columns: column5:5(int) x:1(int!null) y:2(int)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2), (1,2)-->(5)
+      │    ├── scan xy
+      │    │    ├── columns: x:1(int!null) y:2(int)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2)
+      │    └── projections [outer=(1,2)]
+      │         └── x + y [type=int, outer=(1,2)]
+      ├── scan uv
+      │    ├── columns: u:3(int!null) v:4(int)
+      │    ├── key: (3)
+      │    └── fd: (3)-->(4)
+      └── filters [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
+           └── column5 = u [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ])]
+
+opt expect=ExtractJoinEqualities
+SELECT * FROM xy JOIN uv ON x=u+v
+----
+project
+ ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
+ ├── key: (3)
+ ├── fd: (1)-->(2), (3)-->(4), (3,4)-->(1,2)
+ └── inner-join
+      ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) column5:5(int!null)
+      ├── key: (3)
+      ├── fd: (1)-->(2), (3)-->(4), (3,4)-->(5), (1)==(5), (5)==(1)
+      ├── scan xy
+      │    ├── columns: x:1(int!null) y:2(int)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      ├── project
+      │    ├── columns: column5:5(int) u:3(int!null) v:4(int)
+      │    ├── key: (3)
+      │    ├── fd: (3)-->(4), (3,4)-->(5)
+      │    ├── scan uv
+      │    │    ├── columns: u:3(int!null) v:4(int)
+      │    │    ├── key: (3)
+      │    │    └── fd: (3)-->(4)
+      │    └── projections [outer=(3,4)]
+      │         └── u + v [type=int, outer=(3,4)]
+      └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+           └── x = column5 [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+
+opt expect=ExtractJoinEqualities
+SELECT * FROM xy JOIN uv ON u+v=x
+----
+project
+ ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
+ ├── key: (3)
+ ├── fd: (1)-->(2), (3)-->(4), (3,4)-->(1,2)
+ └── inner-join
+      ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) column5:5(int!null)
+      ├── key: (3)
+      ├── fd: (1)-->(2), (3)-->(4), (3,4)-->(5), (1)==(5), (5)==(1)
+      ├── scan xy
+      │    ├── columns: x:1(int!null) y:2(int)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      ├── project
+      │    ├── columns: column5:5(int) u:3(int!null) v:4(int)
+      │    ├── key: (3)
+      │    ├── fd: (3)-->(4), (3,4)-->(5)
+      │    ├── scan uv
+      │    │    ├── columns: u:3(int!null) v:4(int)
+      │    │    ├── key: (3)
+      │    │    └── fd: (3)-->(4)
+      │    └── projections [outer=(3,4)]
+      │         └── u + v [type=int, outer=(3,4)]
+      └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+           └── x = column5 [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
+
+opt expect=ExtractJoinEqualities
+SELECT * FROM xy JOIN uv ON x+y=u+v
+----
+project
+ ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
+ ├── key: (1,3)
+ ├── fd: (1)-->(2), (3)-->(4)
+ └── inner-join
+      ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) column5:5(int!null) column6:6(int!null)
+      ├── key: (1,3)
+      ├── fd: (1)-->(2), (1,2)-->(5), (3)-->(4), (3,4)-->(6), (5)==(6), (6)==(5)
+      ├── project
+      │    ├── columns: column5:5(int) x:1(int!null) y:2(int)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2), (1,2)-->(5)
+      │    ├── scan xy
+      │    │    ├── columns: x:1(int!null) y:2(int)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2)
+      │    └── projections [outer=(1,2)]
+      │         └── x + y [type=int, outer=(1,2)]
+      ├── project
+      │    ├── columns: column6:6(int) u:3(int!null) v:4(int)
+      │    ├── key: (3)
+      │    ├── fd: (3)-->(4), (3,4)-->(6)
+      │    ├── scan uv
+      │    │    ├── columns: u:3(int!null) v:4(int)
+      │    │    ├── key: (3)
+      │    │    └── fd: (3)-->(4)
+      │    └── projections [outer=(3,4)]
+      │         └── u + v [type=int, outer=(3,4)]
+      └── filters [type=bool, outer=(5,6), constraints=(/5: (/NULL - ]; /6: (/NULL - ]), fd=(5)==(6), (6)==(5)]
+           └── column5 = column6 [type=bool, outer=(5,6), constraints=(/5: (/NULL - ]; /6: (/NULL - ])]
+
+# Multiple extractable equalities.
+opt expect=ExtractJoinEqualities
+SELECT * FROM xy JOIN uv ON x+y=u AND x=u+v AND x+1=u+2
+----
+project
+ ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
+ ├── key: (1)
+ ├── fd: (1)-->(2), (1,2)-->(3,4), (3)-->(4), (3,4)-->(1,2)
+ └── inner-join
+      ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) column5:5(int!null) column6:6(int!null) column7:7(int!null) column8:8(int!null)
+      ├── key: (1)
+      ├── fd: (1)-->(2,7), (1,2)-->(5), (3)-->(4,8), (3,4)-->(6), (3)==(5), (5)==(3), (1)==(6), (6)==(1), (7)==(8), (8)==(7)
+      ├── project
+      │    ├── columns: column5:5(int) column7:7(int) x:1(int!null) y:2(int)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,7), (1,2)-->(5)
+      │    ├── scan xy
+      │    │    ├── columns: x:1(int!null) y:2(int)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2)
+      │    └── projections [outer=(1,2)]
+      │         ├── x + y [type=int, outer=(1,2)]
+      │         └── x + 1 [type=int, outer=(1)]
+      ├── project
+      │    ├── columns: column6:6(int) column8:8(int) u:3(int!null) v:4(int)
+      │    ├── key: (3)
+      │    ├── fd: (3)-->(4,8), (3,4)-->(6)
+      │    ├── scan uv
+      │    │    ├── columns: u:3(int!null) v:4(int)
+      │    │    ├── key: (3)
+      │    │    └── fd: (3)-->(4)
+      │    └── projections [outer=(3,4)]
+      │         ├── u + v [type=int, outer=(3,4)]
+      │         └── u + 2 [type=int, outer=(3)]
+      └── filters [type=bool, outer=(1,3,5-8), constraints=(/1: (/NULL - ]; /3: (/NULL - ]; /5: (/NULL - ]; /6: (/NULL - ]; /7: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(5), (5)==(3), (1)==(6), (6)==(1), (7)==(8), (8)==(7)]
+           ├── column5 = u [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ])]
+           ├── x = column6 [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+           └── column7 = column8 [type=bool, outer=(7,8), constraints=(/7: (/NULL - ]; /8: (/NULL - ])]
+
+# An extractable equality with another expression.
+opt expect=ExtractJoinEqualities
+SELECT * FROM xy JOIN uv ON x+y=u AND x+u=v
+----
+project
+ ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2), (1,2)-->(3,4), (3)-->(4)
+ └── inner-join
+      ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null) column5:5(int!null)
+      ├── key: (1)
+      ├── fd: (1)-->(2), (1,2)-->(5), (3)-->(4), (3)==(5), (5)==(3)
+      ├── project
+      │    ├── columns: column5:5(int) x:1(int!null) y:2(int)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2), (1,2)-->(5)
+      │    ├── scan xy
+      │    │    ├── columns: x:1(int!null) y:2(int)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2)
+      │    └── projections [outer=(1,2)]
+      │         └── x + y [type=int, outer=(1,2)]
+      ├── scan uv
+      │    ├── columns: u:3(int!null) v:4(int)
+      │    ├── key: (3)
+      │    └── fd: (3)-->(4)
+      └── filters [type=bool, outer=(1,3-5), constraints=(/3: (/NULL - ]; /4: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
+           ├── column5 = u [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ])]
+           └── v = (x + u) [type=bool, outer=(1,3,4), constraints=(/4: (/NULL - ])]
+
+# Cases with non-extractable equality.
+opt expect-not=ExtractJoinEqualities
+SELECT * FROM xy FULL OUTER JOIN uv ON x=u
+----
+full-join (merge)
+ ├── columns: x:1(int) y:2(int) u:3(int) v:4(int)
+ ├── key: (1,3)
+ ├── fd: (1)-->(2), (3)-->(4)
+ ├── scan xy
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    └── ordering: +1
+ ├── scan uv
+ │    ├── columns: u:3(int!null) v:4(int)
+ │    ├── key: (3)
+ │    ├── fd: (3)-->(4)
+ │    └── ordering: +3
+ └── merge-on
+      ├── left ordering: +1
+      ├── right ordering: +3
+      └── true [type=bool]
+
+opt expect-not=ExtractJoinEqualities
+SELECT * FROM xy FULL OUTER JOIN uv ON x+y=1
+----
+full-join
+ ├── columns: x:1(int) y:2(int) u:3(int) v:4(int)
+ ├── key: (1,3)
+ ├── fd: (1)-->(2), (3)-->(4)
+ ├── scan xy
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ ├── scan uv
+ │    ├── columns: u:3(int!null) v:4(int)
+ │    ├── key: (3)
+ │    └── fd: (3)-->(4)
+ └── filters [type=bool, outer=(1,2)]
+      └── (x + y) = 1 [type=bool, outer=(1,2)]
+
+opt expect-not=ExtractJoinEqualities
+SELECT * FROM xy FULL OUTER JOIN uv ON 1=u+v
+----
+full-join
+ ├── columns: x:1(int) y:2(int) u:3(int) v:4(int)
+ ├── key: (1,3)
+ ├── fd: (1)-->(2), (3)-->(4)
+ ├── scan xy
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ ├── scan uv
+ │    ├── columns: u:3(int!null) v:4(int)
+ │    ├── key: (3)
+ │    └── fd: (3)-->(4)
+ └── filters [type=bool, outer=(3,4)]
+      └── (u + v) = 1 [type=bool, outer=(3,4)]
+
+opt expect-not=ExtractJoinEqualities
+SELECT * FROM xy FULL OUTER JOIN uv ON (SELECT k FROM a WHERE i=x)=u
+----
+project
+ ├── columns: x:1(int) y:2(int) u:3(int) v:4(int)
+ ├── key: (1,3)
+ ├── fd: (1)-->(2), (1,3)-->(4)
+ └── full-join-apply
+      ├── columns: x:1(int) y:2(int) u:3(int) v:4(int) k:5(int)
+      ├── key: (1,3)
+      ├── fd: (1)-->(2), (1,3)-->(4,5)
+      ├── scan xy
+      │    ├── columns: x:1(int!null) y:2(int)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      ├── left-join
+      │    ├── columns: u:3(int!null) v:4(int) k:5(int)
+      │    ├── outer: (1)
+      │    ├── key: (3)
+      │    ├── fd: (3)-->(4,5), ()~~>(5)
+      │    ├── scan uv
+      │    │    ├── columns: u:3(int!null) v:4(int)
+      │    │    ├── key: (3)
+      │    │    └── fd: (3)-->(4)
+      │    ├── max1-row
+      │    │    ├── columns: k:5(int!null)
+      │    │    ├── outer: (1)
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(5)
+      │    │    └── project
+      │    │         ├── columns: k:5(int!null)
+      │    │         ├── outer: (1)
+      │    │         ├── key: (5)
+      │    │         └── select
+      │    │              ├── columns: k:5(int!null) i:6(int!null)
+      │    │              ├── outer: (1)
+      │    │              ├── key: (5)
+      │    │              ├── fd: ()-->(6)
+      │    │              ├── scan a
+      │    │              │    ├── columns: k:5(int!null) i:6(int)
+      │    │              │    ├── key: (5)
+      │    │              │    └── fd: (5)-->(6)
+      │    │              └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+      │    │                   └── i = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+      │    └── true [type=bool]
+      └── filters [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
+           └── u = k [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ])]
+
+opt expect-not=ExtractJoinEqualities
+SELECT * FROM xy FULL OUTER JOIN uv ON x=(SELECT k FROM a WHERE i=u)
+----
+project
+ ├── columns: x:1(int) y:2(int) u:3(int) v:4(int)
+ ├── key: (1,3)
+ ├── fd: (1)-->(2), (3)-->(4)
+ └── full-join
+      ├── columns: x:1(int) y:2(int) u:3(int) v:4(int) k:5(int)
+      ├── key: (1,3)
+      ├── fd: (1)-->(2), (3)-->(4,5)
+      ├── scan xy
+      │    ├── columns: x:1(int!null) y:2(int)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      ├── left-join-apply
+      │    ├── columns: u:3(int!null) v:4(int) k:5(int)
+      │    ├── key: (3)
+      │    ├── fd: (3)-->(4,5)
+      │    ├── scan uv
+      │    │    ├── columns: u:3(int!null) v:4(int)
+      │    │    ├── key: (3)
+      │    │    └── fd: (3)-->(4)
+      │    ├── max1-row
+      │    │    ├── columns: k:5(int!null)
+      │    │    ├── outer: (3)
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(5)
+      │    │    └── project
+      │    │         ├── columns: k:5(int!null)
+      │    │         ├── outer: (3)
+      │    │         ├── key: (5)
+      │    │         └── select
+      │    │              ├── columns: k:5(int!null) i:6(int!null)
+      │    │              ├── outer: (3)
+      │    │              ├── key: (5)
+      │    │              ├── fd: ()-->(6)
+      │    │              ├── scan a
+      │    │              │    ├── columns: k:5(int!null) i:6(int)
+      │    │              │    ├── key: (5)
+      │    │              │    └── fd: (5)-->(6)
+      │    │              └── filters [type=bool, outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
+      │    │                   └── i = u [type=bool, outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ])]
+      │    └── true [type=bool]
+      └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+           └── x = k [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -768,29 +768,35 @@ opt expect=PruneJoinLeftCols
 SELECT a.k+1 AS r, a.i/2 AS s, xy.* FROM a INNER JOIN xy ON a.k*a.k=xy.x AND a.s||'o'='foo'
 ----
 project
- ├── columns: r:7(int) s:8(decimal) x:5(int!null) y:6(int)
+ ├── columns: r:8(int) s:9(decimal) x:5(int!null) y:6(int)
  ├── side-effects
  ├── fd: (5)-->(6)
  ├── inner-join
- │    ├── columns: k:1(int!null) i:2(int) a.s:4(string) x:5(int!null) y:6(int)
- │    ├── key: (1,5)
- │    ├── fd: (1)-->(2,4), (5)-->(6)
+ │    ├── columns: k:1(int!null) i:2(int) x:5(int!null) y:6(int) column7:7(int!null)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,7), (5)-->(6), (5)==(7), (7)==(5)
  │    ├── scan xy
  │    │    ├── columns: x:5(int!null) y:6(int)
  │    │    ├── key: (5)
  │    │    └── fd: (5)-->(6)
- │    ├── select
- │    │    ├── columns: k:1(int!null) i:2(int) a.s:4(string)
+ │    ├── project
+ │    │    ├── columns: column7:7(int) k:1(int!null) i:2(int)
  │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2,4)
- │    │    ├── scan a
+ │    │    ├── fd: (1)-->(2,7)
+ │    │    ├── select
  │    │    │    ├── columns: k:1(int!null) i:2(int) a.s:4(string)
  │    │    │    ├── key: (1)
- │    │    │    └── fd: (1)-->(2,4)
- │    │    └── filters [type=bool, outer=(4)]
- │    │         └── (a.s || 'o') = 'foo' [type=bool, outer=(4)]
- │    └── filters [type=bool, outer=(1,5), constraints=(/5: (/NULL - ])]
- │         └── x = (k * k) [type=bool, outer=(1,5), constraints=(/5: (/NULL - ])]
+ │    │    │    ├── fd: (1)-->(2,4)
+ │    │    │    ├── scan a
+ │    │    │    │    ├── columns: k:1(int!null) i:2(int) a.s:4(string)
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    └── fd: (1)-->(2,4)
+ │    │    │    └── filters [type=bool, outer=(4)]
+ │    │    │         └── (a.s || 'o') = 'foo' [type=bool, outer=(4)]
+ │    │    └── projections [outer=(1,2)]
+ │    │         └── k * k [type=int, outer=(1)]
+ │    └── filters [type=bool, outer=(5,7), constraints=(/5: (/NULL - ]; /7: (/NULL - ]), fd=(5)==(7), (7)==(5)]
+ │         └── column7 = x [type=bool, outer=(5,7), constraints=(/5: (/NULL - ]; /7: (/NULL - ])]
  └── projections [outer=(1,2,5,6), side-effects]
       ├── k + 1 [type=int, outer=(1)]
       └── i / 2 [type=decimal, outer=(2), side-effects]
@@ -1096,29 +1102,35 @@ opt expect=PruneJoinRightCols
 SELECT xy.*, a.k+1 AS r, a.i/2 AS s FROM xy INNER JOIN a ON xy.x=a.k*a.k AND a.s||'o'='foo'
 ----
 project
- ├── columns: x:1(int!null) y:2(int) r:7(int) s:8(decimal)
+ ├── columns: x:1(int!null) y:2(int) r:8(int) s:9(decimal)
  ├── side-effects
  ├── fd: (1)-->(2)
  ├── inner-join
- │    ├── columns: x:1(int!null) y:2(int) k:3(int!null) i:4(int) a.s:6(string)
- │    ├── key: (1,3)
- │    ├── fd: (1)-->(2), (3)-->(4,6)
+ │    ├── columns: x:1(int!null) y:2(int) k:3(int!null) i:4(int) column7:7(int!null)
+ │    ├── key: (3)
+ │    ├── fd: (1)-->(2), (3)-->(4,7), (1)==(7), (7)==(1)
  │    ├── scan xy
  │    │    ├── columns: x:1(int!null) y:2(int)
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2)
- │    ├── select
- │    │    ├── columns: k:3(int!null) i:4(int) a.s:6(string)
+ │    ├── project
+ │    │    ├── columns: column7:7(int) k:3(int!null) i:4(int)
  │    │    ├── key: (3)
- │    │    ├── fd: (3)-->(4,6)
- │    │    ├── scan a
+ │    │    ├── fd: (3)-->(4,7)
+ │    │    ├── select
  │    │    │    ├── columns: k:3(int!null) i:4(int) a.s:6(string)
  │    │    │    ├── key: (3)
- │    │    │    └── fd: (3)-->(4,6)
- │    │    └── filters [type=bool, outer=(6)]
- │    │         └── (a.s || 'o') = 'foo' [type=bool, outer=(6)]
- │    └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ])]
- │         └── x = (k * k) [type=bool, outer=(1,3), constraints=(/1: (/NULL - ])]
+ │    │    │    ├── fd: (3)-->(4,6)
+ │    │    │    ├── scan a
+ │    │    │    │    ├── columns: k:3(int!null) i:4(int) a.s:6(string)
+ │    │    │    │    ├── key: (3)
+ │    │    │    │    └── fd: (3)-->(4,6)
+ │    │    │    └── filters [type=bool, outer=(6)]
+ │    │    │         └── (a.s || 'o') = 'foo' [type=bool, outer=(6)]
+ │    │    └── projections [outer=(3,4)]
+ │    │         └── k * k [type=int, outer=(3)]
+ │    └── filters [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+ │         └── x = column7 [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ])]
  └── projections [outer=(1-4), side-effects]
       ├── k + 1 [type=int, outer=(3)]
       └── i / 2 [type=decimal, outer=(4), side-effects]

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -160,10 +160,6 @@ func (b *Builder) expandStarAndResolveType(
 func (b *Builder) synthesizeColumn(
 	scope *scope, label string, typ types.T, expr tree.TypedExpr, group memo.GroupID,
 ) *scopeColumn {
-	if label == "" {
-		label = fmt.Sprintf("column%d", b.factory.Metadata().NumColumns()+1)
-	}
-
 	name := tree.Name(label)
 	colID := b.factory.Metadata().AddColumn(label, typ)
 	scope.cols = append(scope.cols, scopeColumn{
@@ -179,10 +175,6 @@ func (b *Builder) synthesizeColumn(
 // populateSynthesizedColumn is similar to synthesizeColumn, but it fills in
 // the given existing column rather than allocating a new one.
 func (b *Builder) populateSynthesizedColumn(col *scopeColumn, group memo.GroupID) {
-	if col.name == "" {
-		col.name = tree.Name(fmt.Sprintf("column%d", b.factory.Metadata().NumColumns()+1))
-	}
-
 	colID := b.factory.Metadata().AddColumn(string(col.name), col.typ)
 	col.id = colID
 	col.group = group

--- a/pkg/sql/opt/testutils/opt_tester.go
+++ b/pkg/sql/opt/testutils/opt_tester.go
@@ -211,11 +211,11 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 	case "exec-ddl":
 		testCatalog, ok := ot.catalog.(*testcat.Catalog)
 		if !ok {
-			tb.Fatal("exec-ddl can only be used with TestCatalog")
+			d.Fatalf(tb, "exec-ddl can only be used with TestCatalog")
 		}
 		s, err := testCatalog.ExecuteDDL(d.Input)
 		if err != nil {
-			tb.Fatal(err)
+			d.Fatalf(tb, "%v", err)
 		}
 		return s
 
@@ -230,7 +230,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			return fmt.Sprintf("error: %s\n", text)
 		}
 		if err := ot.postProcess(ev); err != nil {
-			tb.Fatal(err)
+			d.Fatalf(tb, "%v", err)
 		}
 		return ev.FormatString(ot.Flags.ExprFormat)
 
@@ -245,7 +245,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			return fmt.Sprintf("error: %s\n", text)
 		}
 		if err := ot.postProcess(ev); err != nil {
-			tb.Fatal(err)
+			d.Fatalf(tb, "%v", err)
 		}
 		return ev.FormatString(ot.Flags.ExprFormat)
 
@@ -255,7 +255,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			d.Fatalf(tb, "%v", err)
 		}
 		if err := ot.postProcess(ev); err != nil {
-			tb.Fatal(err)
+			d.Fatalf(tb, "%v", err)
 		}
 		return ev.FormatString(ot.Flags.ExprFormat)
 


### PR DESCRIPTION
Consider `SELECT * FROM ab JOIN xy ON a+b=x`. Currently this is a
quadratic join because we have no equality columns (which need to be
of the form `<left-var>=<right-var>`). This change adds a
normalization rule that extracts the `a+b` expression as a
pre-projection, resulting in a join that has an equality column (and
consequently can use hash or lookup join):

`SELECT a, b, x, y FROM (SELECT a, b, a + b AS foo FROM abc) JOIN xyz ON foo = x`

Release note: None