### PR TITLE
opt: adjust row estimate for SRFs

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -1226,9 +1226,12 @@ func (sb *statisticsBuilder) buildZip(ev ExprView, relProps *props.Relational) {
 		if child.Operator() == opt.FunctionOp {
 			def := child.Private().(*FuncOpDef)
 			if def.Overload.Generator != nil {
+				// Use a small row count; this allows use of lookup join in cases like
+				// using json_array_elements with a small constant array.
+				//
 				// TODO(rytaft): We may want to estimate the number of rows based on
 				// the type of generator function and its parameters.
-				s.RowCount = unknownRowCount
+				s.RowCount = 10
 				break
 			}
 		}

--- a/pkg/sql/opt/memo/testdata/stats/srfs
+++ b/pkg/sql/opt/memo/testdata/stats/srfs
@@ -6,15 +6,15 @@ JOIN generate_series(1, 4) c ON true
 inner-join
  ├── columns: a:1(string) upper:2(string) generate_series:3(int) upper:4(string) c:5(int)
  ├── side-effects
- ├── stats: [rows=1000000]
+ ├── stats: [rows=100]
  ├── inner-join
  │    ├── columns: upper:1(string) upper:2(string) generate_series:3(int) upper:4(string)
  │    ├── side-effects
- │    ├── stats: [rows=1000]
+ │    ├── stats: [rows=10]
  │    ├── zip
  │    │    ├── columns: upper:2(string) generate_series:3(int) upper:4(string)
  │    │    ├── side-effects
- │    │    ├── stats: [rows=1000]
+ │    │    ├── stats: [rows=10]
  │    │    ├── upper('def') [type=string]
  │    │    ├── generate_series(1, 3) [type=int, side-effects]
  │    │    └── upper('ghi') [type=string]
@@ -26,7 +26,7 @@ inner-join
  ├── zip
  │    ├── columns: generate_series:5(int)
  │    ├── side-effects
- │    ├── stats: [rows=1000]
+ │    ├── stats: [rows=10]
  │    └── generate_series(1, 4) [type=int, side-effects]
  └── true [type=bool]
 
@@ -37,16 +37,16 @@ distinct-on
  ├── columns: a:1(string) b:2(int)
  ├── grouping columns: upper:1(string) generate_series:2(int)
  ├── side-effects
- ├── stats: [rows=100, distinct(1,2)=100]
+ ├── stats: [rows=1, distinct(1,2)=1]
  ├── key: (1,2)
  └── inner-join
       ├── columns: upper:1(string) generate_series:2(int)
       ├── side-effects
-      ├── stats: [rows=1000, distinct(1,2)=100]
+      ├── stats: [rows=10, distinct(1,2)=1]
       ├── zip
       │    ├── columns: generate_series:2(int)
       │    ├── side-effects
-      │    ├── stats: [rows=1000, distinct(2)=100]
+      │    ├── stats: [rows=10, distinct(2)=1]
       │    └── generate_series(1, 2) [type=int, side-effects]
       ├── zip
       │    ├── columns: upper:1(string)

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -749,3 +749,67 @@ scalar-group-by
  └── aggregations [outer=(11)]
       └── count [type=int, outer=(11)]
            └── variable: l_orderkey [type=int, outer=(11)]
+
+# ------------------------------------------------------------------------------
+# Ensure we do a lookup join when one side comes from an SRF.
+# ------------------------------------------------------------------------------
+
+exec-ddl
+CREATE TABLE idtable (
+  primary_id    UUID DEFAULT uuid_v4()::UUID PRIMARY KEY,
+  secondary_id  UUID NOT NULL,
+  data JSONB NOT NULL,
+
+  INDEX secondary_id (secondary_id)
+)
+----
+TABLE idtable
+ ├── primary_id uuid not null
+ ├── secondary_id uuid not null
+ ├── data jsonb not null
+ ├── INDEX primary
+ │    └── primary_id uuid not null
+ └── INDEX secondary_id
+      ├── secondary_id uuid not null
+      └── primary_id uuid not null
+
+opt
+SELECT
+  elem->>'secondary_id' AS secondary_id, data || jsonb_build_object('primary_id', primary_id)
+FROM
+  idtable,
+  json_array_elements('[
+    {"person_id":"8e5dc104-9f38-4255-9283-fd080be16c57", "product_id":"a739c2d3-edec-413b-88d8-9c31d0414b1e"},
+    {"person_id":"308686c4-7415-4c2d-92d5-25b39a1c84e2", "product_id":"3f12802d-5b0f-43d7-a0d0-12ac8e88cb18"}
+  ]') AS elem
+WHERE
+  secondary_id = (elem->>'secondary_id')::UUID
+----
+project
+ ├── columns: secondary_id:6(string) "?column?":7(jsonb)
+ ├── side-effects
+ ├── inner-join (lookup idtable)
+ │    ├── columns: primary_id:1(uuid!null) idtable.secondary_id:2(uuid!null) data:3(jsonb!null) json_array_elements:4(jsonb) column5:5(uuid!null)
+ │    ├── key columns: [1] = [1]
+ │    ├── side-effects
+ │    ├── fd: (1)-->(2,3), (4)-->(5), (2)==(5), (5)==(2)
+ │    ├── inner-join (lookup idtable@secondary_id)
+ │    │    ├── columns: primary_id:1(uuid!null) idtable.secondary_id:2(uuid!null) json_array_elements:4(jsonb) column5:5(uuid!null)
+ │    │    ├── key columns: [5] = [2]
+ │    │    ├── side-effects
+ │    │    ├── fd: (4)-->(5), (1)-->(2), (2)==(5), (5)==(2)
+ │    │    ├── project
+ │    │    │    ├── columns: column5:5(uuid) json_array_elements:4(jsonb)
+ │    │    │    ├── side-effects
+ │    │    │    ├── fd: (4)-->(5)
+ │    │    │    ├── zip
+ │    │    │    │    ├── columns: json_array_elements:4(jsonb)
+ │    │    │    │    ├── side-effects
+ │    │    │    │    └── json_array_elements('[{"person_id": "8e5dc104-9f38-4255-9283-fd080be16c57", "product_id": "a739c2d3-edec-413b-88d8-9c31d0414b1e"}, {"person_id": "308686c4-7415-4c2d-92d5-25b39a1c84e2", "product_id": "3f12802d-5b0f-43d7-a0d0-12ac8e88cb18"}]') [type=jsonb, side-effects]
+ │    │    │    └── projections [outer=(4)]
+ │    │    │         └── (json_array_elements->>'secondary_id')::UUID [type=uuid, outer=(4)]
+ │    │    └── true [type=bool]
+ │    └── true [type=bool]
+ └── projections [outer=(1,3,4)]
+      ├── json_array_elements->>'secondary_id' [type=string, outer=(4)]
+      └── data || jsonb_build_object('primary_id', primary_id) [type=jsonb, outer=(1,3)]


### PR DESCRIPTION
We have a customer query which uses an SRF that returns a few rows,
and we want to use those results as input to a lookup join. To achieve
this, we decrease the estimated row count of Zip to 10.

Release note: None