### PR TITLE
backport-2.1: opt: add UnifyComparisonTypes rule

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -190,7 +190,7 @@ select
            │    └── variable: y [type=int, outer=(2)]
            └── const: 7 [type=int]
 
-# Verify that we ignore mixed-type comparisons.
+# Verify that we ignore some mixed-type comparisons.
 opt
 SELECT * FROM a WHERE x > 1.5
 ----
@@ -205,11 +205,12 @@ select
            ├── variable: x [type=int, outer=(1)]
            └── const: 1.5 [type=decimal]
 
+# This is a safe mixed-type comparison.
 opt
 SELECT * FROM kuv WHERE u > 1::INT
 ----
 select
- ├── columns: k:1(int!null) u:2(float) v:3(string)
+ ├── columns: k:1(int!null) u:2(float!null) v:3(string)
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── prune: (1,3)
@@ -220,10 +221,10 @@ select
  │    ├── fd: (1)-->(2,3)
  │    ├── prune: (1-3)
  │    └── interesting orderings: (+1)
- └── filters [type=bool, outer=(2)]
-      └── gt [type=bool, outer=(2)]
+ └── filters [type=bool, outer=(2), constraints=(/2: [/1.0000000000000002 - ]; tight)]
+      └── gt [type=bool, outer=(2), constraints=(/2: [/1.0000000000000002 - ]; tight)]
            ├── variable: u [type=float, outer=(2)]
-           └── const: 1 [type=int]
+           └── const: 1.0 [type=float]
 
 opt
 SELECT * FROM kuv WHERE v <= 'foo' AND v >= 'bar'
@@ -947,3 +948,42 @@ select
                 └── tuple [type=tuple{int, int}]
                      ├── const: 4 [type=int]
                      └── const: 1 [type=int]
+
+exec-ddl
+CREATE TABLE e
+(
+    k INT PRIMARY KEY,
+    t TIMESTAMP,
+    d TIMESTAMP,
+    INDEX (t),
+    INDEX (d)
+)
+----
+TABLE e
+ ├── k int not null
+ ├── t timestamp
+ ├── d timestamp
+ ├── INDEX primary
+ │    └── k int not null
+ ├── INDEX secondary
+ │    ├── t timestamp
+ │    └── k int not null
+ └── INDEX secondary
+      ├── d timestamp
+      └── k int not null
+
+opt
+SELECT k FROM e WHERE d > '2018-07-01' AND d < '2018-07-01'::DATE + '1w'::INTERVAL
+----
+project
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ ├── prune: (1)
+ ├── interesting orderings: (+1)
+ └── scan e@secondary
+      ├── columns: k:1(int!null) d:3(timestamp!null)
+      ├── constraint: /3/1: [/'2018-07-01 00:00:00.000001+00:00' - /'2018-07-07 23:59:59.999999+00:00']
+      ├── key: (1)
+      ├── fd: (1)-->(3)
+      ├── prune: (1,3)
+      └── interesting orderings: (+1) (+3,+1)

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -210,7 +210,7 @@ func (c *CustomFuncs) AnyType() memo.PrivateID {
 func (c *CustomFuncs) CanConstructBinary(op opt.Operator, left, right memo.GroupID) bool {
 	leftType := c.LookupScalar(left).Type
 	rightType := c.LookupScalar(right).Type
-	return memo.BinaryOverloadExists(opt.MinusOp, rightType, leftType)
+	return memo.BinaryOverloadExists(op, rightType, leftType)
 }
 
 // ----------------------------------------------------------------------
@@ -1137,9 +1137,8 @@ func (c *CustomFuncs) FoldArray(elems memo.ListID, typ memo.PrivateID) memo.Grou
 	return c.f.ConstructConst(c.f.InternDatum(a))
 }
 
-// FoldSucceeded returns true if the result of a constant-folding operation
-// is a valid memo group.
-func (c *CustomFuncs) FoldSucceeded(result memo.GroupID) bool {
+// Succeeded returns true if the result of an operation is a valid memo group.
+func (c *CustomFuncs) Succeeded(result memo.GroupID) bool {
 	return result != 0
 }
 
@@ -1188,6 +1187,100 @@ func (c *CustomFuncs) FoldUnary(op opt.Operator, input memo.GroupID) memo.GroupI
 		return 0
 	}
 	return c.f.ConstructConstVal(result)
+}
+
+// isMonotonicConversion returns true if conversion of a value from FROM to
+// TO is monotonic.
+// That is, if a and b are values of type FROM, then
+//
+//   1. a = b implies a::TO = b::TO and
+//   2. a < b implies a::TO <= b::TO
+//
+// Property (1) can be violated by cases like:
+//
+//   '-0'::FLOAT = '0'::FLOAT, but '-0'::FLOAT::STRING != '0'::FLOAT::STRING
+//
+// Property (2) can be violated by cases like:
+//
+//   2 < 10, but  2::STRING > 10::STRING.
+//
+// Note that the stronger version of (2),
+//
+//   a < b implies a::TO < b::TO
+//
+// is not required, for instance this is not generally true of conversion from
+// a TIMESTAMP to a DATE, but certain such conversions can still generate spans
+// in some cases where values under FROM and TO are "the same" (such as where a
+// TIMESTAMP precisely falls on a date boundary).  We don't need this property
+// because we will subsequently check that the values can round-trip to ensure
+// that we don't lose any information by doing the conversion.
+// TODO(justin): fill this out with the complete set of such conversions.
+func isMonotonicConversion(from, to coltypes.T) bool {
+	if from == coltypes.Timestamp ||
+		from == coltypes.TimestampWithTZ ||
+		from == coltypes.Date {
+		return to == coltypes.Timestamp ||
+			to == coltypes.TimestampWithTZ ||
+			to == coltypes.Date
+	}
+
+	if from == coltypes.Int ||
+		from == coltypes.Float8 ||
+		from == coltypes.Decimal {
+		return to == coltypes.Int ||
+			to == coltypes.Float8 ||
+			to == coltypes.Decimal
+	}
+
+	return false
+}
+
+// UnifyComparison attempts to convert right to the type of left, if such a
+// conversion can round-trip and is monotonic.
+func (c *CustomFuncs) UnifyComparison(left, right memo.GroupID) memo.GroupID {
+	desiredType := c.LookupScalar(left).Type
+	originalType := c.LookupScalar(right).Type
+
+	// Don't bother if they're already the same.
+	if desiredType.Equivalent(originalType) {
+		return 0
+	}
+
+	desiredColType, err := coltypes.DatumTypeToColumnType(desiredType)
+	if err != nil {
+		return 0
+	}
+
+	originalColType, err := coltypes.DatumTypeToColumnType(originalType)
+	if err != nil {
+		return 0
+	}
+
+	if !isMonotonicConversion(originalColType, desiredColType) {
+		return 0
+	}
+
+	// Check that the datum can round-trip between the types. If this is true, it
+	// means we don't lose any information needed to generate spans, and combined
+	// with monotonicity means that it's safe to convert the RHS to the type of
+	// the LHS.
+	rightDatum := c.ExtractConstValue(right).(tree.Datum)
+
+	convertedRightDatum, err := tree.PerformCast(c.f.evalCtx, rightDatum, desiredColType)
+	if err != nil {
+		return 0
+	}
+
+	convertedBack, err := tree.PerformCast(c.f.evalCtx, convertedRightDatum, originalColType)
+	if err != nil {
+		return 0
+	}
+
+	if convertedBack.Compare(c.f.evalCtx, rightDatum) != 0 {
+		return 0
+	}
+
+	return c.f.ConstructConst(c.f.mem.InternDatum(convertedRightDatum))
 }
 
 // FoldComparison evaluates a comparison expression with constant inputs. It

--- a/pkg/sql/opt/norm/rules/fold_constants.opt
+++ b/pkg/sql/opt/norm/rules/fold_constants.opt
@@ -28,7 +28,7 @@
 [FoldBinary, Normalize, LowPriority]
 (Binary
   $left:* & (IsConstValueOrTuple $left)
-  $right:* & (IsConstValueOrTuple $right) & (FoldSucceeded $result:(FoldBinary (OpName) $left $right))
+  $right:* & (IsConstValueOrTuple $right) & (Succeeded $result:(FoldBinary (OpName) $left $right))
 )
 =>
 $result
@@ -41,7 +41,7 @@ $result
 # can run first.
 [FoldUnary, Normalize, LowPriority]
 (Unary
-  $input:* & (IsConstValueOrTuple $input) & (FoldSucceeded $result:(FoldUnary (OpName) $input))
+  $input:* & (IsConstValueOrTuple $input) & (Succeeded $result:(FoldUnary (OpName) $input))
 )
 =>
 $result
@@ -55,7 +55,7 @@ $result
 [FoldComparison, Normalize, LowPriority]
 (Comparison
   $left:* & (IsConstValueOrTuple $left)
-  $right:* & (IsConstValueOrTuple $right) & (FoldSucceeded $result:(FoldComparison (OpName) $left $right))
+  $right:* & (IsConstValueOrTuple $right) & (Succeeded $result:(FoldComparison (OpName) $left $right))
 )
 =>
 $result

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -139,6 +139,20 @@
 =>
 (Null (BoolType))
 
+# UnifyComparisonTypes takes a mixed-type comparison between a non-constant and
+# a constant and, if appropriate, converts the constant to the type of the
+# non-constant to allow constraints to be generated.
+[UnifyComparisonTypes, Normalize]
+(Comparison
+    $left:(Variable)
+    $right:(Const) & (Succeeded $result:(UnifyComparison $left $right))
+)
+=>
+((OpName)
+    $left
+    $result
+)
+
 # EliminateExistsProject discards a Project input to the Exists operator. The
 # Project operator never changes the row cardinality of its input, and row
 # cardinality is the only thing that Exists cares about, so Project is a no-op.

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -1,5 +1,5 @@
 exec-ddl
-CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
+CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON, d DATE)
 ----
 TABLE a
  ├── k int not null
@@ -7,6 +7,7 @@ TABLE a
  ├── f float
  ├── s string
  ├── j jsonb
+ ├── d date
  └── INDEX primary
       └── k int not null
 
@@ -20,14 +21,14 @@ opt expect=CommuteVarInequality
 SELECT * FROM a WHERE 1+i<k AND k-1<=i AND i*i>k AND k/2>=i
 ----
 select
- ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  ├── side-effects
  ├── key: (1)
- ├── fd: (1)-->(2-5)
+ ├── fd: (1)-->(2-6)
  ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
+ │    └── fd: (1)-->(2-6)
  └── filters [type=bool, outer=(1,2), side-effects, constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
       ├── k > (i + 1) [type=bool, outer=(1,2), constraints=(/1: (/NULL - ])]
       ├── i >= (k - 1) [type=bool, outer=(1,2), constraints=(/2: (/NULL - ])]
@@ -41,13 +42,13 @@ opt expect=CommuteConstInequality
 SELECT * FROM a WHERE length('foo')+1<i+k AND length('bar')<=i*2 AND 5>i AND 'foo'>=s
 ----
 select
- ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null) j:5(jsonb) d:6(date)
  ├── key: (1)
- ├── fd: (1)-->(2-5)
+ ├── fd: (1)-->(2-6)
  ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
+ │    └── fd: (1)-->(2-6)
  └── filters [type=bool, outer=(1,2,4), constraints=(/2: (/NULL - /4]; /4: (/NULL - /'foo'])]
       ├── (i + k) > (length('foo') + 1) [type=bool, outer=(1,2)]
       ├── (i * 2) >= length('bar') [type=bool, outer=(2)]
@@ -59,14 +60,14 @@ opt expect-not=CommuteConstInequality
 SELECT * FROM a WHERE random()::int>a.i+a.i
 ----
 select
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  ├── side-effects
  ├── key: (1)
- ├── fd: (1)-->(2-5)
+ ├── fd: (1)-->(2-6)
  ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
+ │    └── fd: (1)-->(2-6)
  └── filters [type=bool, outer=(2), side-effects]
       └── random()::INT > (i + i) [type=bool, outer=(2), side-effects]
 
@@ -84,16 +85,16 @@ WHERE
     '1:00:00'::time + i::interval >= '2:00:00'::time
 ----
 select
- ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  ├── cardinality: [0 - 1]
  ├── key: ()
- ├── fd: ()-->(1-5)
+ ├── fd: ()-->(1-6)
  ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  │    ├── constraint: /1: [/1 - /1]
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
- │    └── fd: ()-->(1-5)
+ │    └── fd: ()-->(1-6)
  └── filters [type=bool, outer=(2,3), constraints=(/2: [/7 - ])]
       ├── (f + f) < 3.0 [type=bool, outer=(3)]
       ├── i <= (length('foo') - 1) [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
@@ -105,13 +106,13 @@ opt expect-not=NormalizeCmpPlusConst
 SELECT * FROM a WHERE s::date + '02:00:00'::time = '2000-01-01T02:00:00'::timestamp
 ----
 select
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  ├── key: (1)
- ├── fd: (1)-->(2-5)
+ ├── fd: (1)-->(2-6)
  ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
+ │    └── fd: (1)-->(2-6)
  └── filters [type=bool, outer=(4)]
       └── (s::DATE + '02:00:00') = '2000-01-01 02:00:00+00:00' [type=bool, outer=(4)]
 
@@ -126,37 +127,39 @@ WHERE
     (f+f)-2 < 5 AND
     i-1::decimal <= length('foo') AND
     i-2-2 > 10 AND
-    f+i::float-10.0 >= 100.0
+    f+i::float-10.0 >= 100.0 AND
+    d-'1w'::interval >= '2018-09-23'::date
 ----
 select
- ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) d:6(date!null)
  ├── cardinality: [0 - 1]
  ├── key: ()
- ├── fd: ()-->(1-5)
+ ├── fd: ()-->(1-6)
  ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  │    ├── constraint: /1: [/3 - /3]
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
- │    └── fd: ()-->(1-5)
- └── filters [type=bool, outer=(2,3), constraints=(/2: [/15 - ])]
+ │    └── fd: ()-->(1-6)
+ └── filters [type=bool, outer=(2,3,6), constraints=(/2: [/15 - ]; /6: [/'2018-09-30' - ])]
       ├── (f + f) < 7.0 [type=bool, outer=(3)]
       ├── i <= (length('foo') + 1) [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
       ├── i > 14 [type=bool, outer=(2), constraints=(/2: [/15 - ]; tight)]
-      └── (f + i::FLOAT8) >= 110.0 [type=bool, outer=(2,3)]
+      ├── (f + i::FLOAT8) >= 110.0 [type=bool, outer=(2,3)]
+      └── d >= '2018-09-30' [type=bool, outer=(6), constraints=(/6: [/'2018-09-30' - ]; tight)]
 
 # Try case that should not match pattern because Plus overload is not defined.
 opt expect-not=NormalizeCmpMinusConst
 SELECT * FROM a WHERE s::json - 1 = '[1]'::json
 ----
 select
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  ├── key: (1)
- ├── fd: (1)-->(2-5)
+ ├── fd: (1)-->(2-6)
  ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
+ │    └── fd: (1)-->(2-6)
  └── filters [type=bool, outer=(4)]
       └── (s::JSONB - 1) = '[1]' [type=bool, outer=(4)]
 
@@ -174,16 +177,16 @@ WHERE
     10.0-(f+i::float) >= 100.0
 ----
 select
- ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  ├── cardinality: [0 - 1]
  ├── key: ()
- ├── fd: ()-->(1-5)
+ ├── fd: ()-->(1-6)
  ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  │    ├── constraint: /1: [/-1 - /-1]
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
- │    └── fd: ()-->(1-5)
+ │    └── fd: ()-->(1-6)
  └── filters [type=bool, outer=(2,3), constraints=(/2: [/11 - ])]
       ├── (f + f) > -3.0 [type=bool, outer=(3)]
       ├── i >= (1 - length('foo')) [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
@@ -195,13 +198,13 @@ opt expect-not=NormalizeCmpConstMinus
 SELECT * FROM a WHERE '[1, 2]'::json - i = '[1]'
 ----
 select
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  ├── key: (1)
- ├── fd: (1)-->(2-5)
+ ├── fd: (1)-->(2-6)
  ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
+ │    └── fd: (1)-->(2-6)
  └── filters [type=bool, outer=(2)]
       └── ('[1, 2]' - i) = '[1]' [type=bool, outer=(2)]
 
@@ -212,13 +215,13 @@ opt expect=NormalizeTupleEquality
 SELECT * FROM a WHERE (i, f, s) = (1, 3.5, 'foo')
 ----
 select
- ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb) d:6(date)
  ├── key: (1)
- ├── fd: ()-->(2-4), (1)-->(5)
+ ├── fd: ()-->(2-4), (1)-->(5,6)
  ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
+ │    └── fd: (1)-->(2-6)
  └── filters [type=bool, outer=(2-4), constraints=(/2: [/1 - /1]; /3: [/3.5 - /3.5]; /4: [/'foo' - /'foo']; tight), fd=()-->(2-4)]
       ├── i = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
       ├── f = 3.5 [type=bool, outer=(3), constraints=(/3: [/3.5 - /3.5]; tight)]
@@ -233,16 +236,16 @@ opt expect=(NormalizeTupleEquality,SimplifyAnd)
 SELECT * FROM a WHERE (1, (2, 'foo')) = (k, (i, s))
 ----
 select
- ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null) j:5(jsonb) d:6(date)
  ├── cardinality: [0 - 1]
  ├── key: ()
- ├── fd: ()-->(1-5)
+ ├── fd: ()-->(1-6)
  ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  │    ├── constraint: /1: [/1 - /1]
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
- │    └── fd: ()-->(1-5)
+ │    └── fd: ()-->(1-6)
  └── filters [type=bool, outer=(2,4), constraints=(/2: [/2 - /2]; /4: [/'foo' - /'foo']; tight), fd=()-->(2,4)]
       ├── i = 2 [type=bool, outer=(2), constraints=(/2: [/2 - /2]; tight)]
       └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
@@ -278,10 +281,10 @@ WHERE
     null::jsonb ?& ARRAY['foo'] OR '{}' ?& null::string[]
 ----
 values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
  ├── cardinality: [0 - 0]
  ├── key: ()
- └── fd: ()-->(1-5)
+ └── fd: ()-->(1-6)
 
 # --------------------------------------------------
 # FoldIsNull
@@ -363,8 +366,8 @@ opt expect=FoldNonNullIsNotNull
 SELECT 1 IS NOT NULL AS r, k IS NOT NULL AS s, i IS NOT NULL AS t FROM a
 ----
 project
- ├── columns: r:6(bool!null) s:7(bool) t:8(bool)
- ├── fd: ()-->(6)
+ ├── columns: r:7(bool!null) s:8(bool) t:9(bool)
+ ├── fd: ()-->(7)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int)
  │    ├── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -711,3 +711,276 @@ project
  │    └── tuple [type=tuple]
  └── projections
       └── const: 'two' [type=string]
+
+# --------------------------------------------------
+# UnifyComparisonTypes
+# --------------------------------------------------
+
+exec-ddl
+CREATE TABLE e
+(
+    k INT PRIMARY KEY,
+    i INT,
+    t TIMESTAMP,
+    tz TIMESTAMPTZ,
+    d DATE,
+    INDEX (i),
+    INDEX (t),
+    INDEX (tz),
+    INDEX (d)
+)
+----
+TABLE e
+ ├── k int not null
+ ├── i int
+ ├── t timestamp
+ ├── tz timestamptz
+ ├── d date
+ ├── INDEX primary
+ │    └── k int not null
+ ├── INDEX secondary
+ │    ├── i int
+ │    └── k int not null
+ ├── INDEX secondary
+ │    ├── t timestamp
+ │    └── k int not null
+ ├── INDEX secondary
+ │    ├── tz timestamptz
+ │    └── k int not null
+ └── INDEX secondary
+      ├── d date
+      └── k int not null
+
+## --------------------------------------------------
+## INT / FLOAT / DECIMAL
+## --------------------------------------------------
+
+# Compare how we can generate spans with and without the rule enabled.
+opt expect=UnifyComparisonTypes
+SELECT * FROM e WHERE k > '1.0'::FLOAT
+----
+scan e
+ ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
+ ├── constraint: /1: [/2 - ]
+ ├── key: (1)
+ └── fd: (1)-->(2-5)
+
+opt disable=UnifyComparisonTypes
+SELECT * FROM e WHERE k > '1.0'::FLOAT
+----
+select
+ ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan e
+ │    ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters [type=bool, outer=(1)]
+      └── k > 1.0 [type=bool, outer=(1)]
+
+# Ensure the rest of normalization does its work and we move things around appropriately.
+opt expect=UnifyComparisonTypes
+SELECT * FROM e WHERE '1.0'::FLOAT > k
+----
+scan e
+ ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
+ ├── constraint: /1: [ - /0]
+ ├── key: (1)
+ └── fd: (1)-->(2-5)
+
+opt expect=UnifyComparisonTypes
+SELECT * FROM e WHERE k - 1 = 2::DECIMAL
+----
+scan e
+ ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
+ ├── constraint: /1: [/3 - /3]
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
+# TODO(justin): we should theoretically be able to generate constraints in this
+# case.
+opt expect-not=UnifyComparisonTypes
+SELECT * FROM e WHERE k > '1.1'::FLOAT
+----
+select
+ ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan e
+ │    ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters [type=bool, outer=(1)]
+      └── k > 1.1 [type=bool, outer=(1)]
+
+# -0 can generate spans
+opt expect=UnifyComparisonTypes
+SELECT * FROM e WHERE k > '-0'::FLOAT
+----
+scan e
+ ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
+ ├── constraint: /1: [/1 - ]
+ ├── key: (1)
+ └── fd: (1)-->(2-5)
+
+# NaN cannot generate spans.
+opt expect-not=UnifyComparisonTypes
+SELECT * FROM e WHERE k > 'NaN'::FLOAT
+----
+select
+ ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan e
+ │    ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters [type=bool, outer=(1)]
+      └── k > NaN [type=bool, outer=(1)]
+
+# IS/IS NOT
+# We do not do the unification here (the rule matches on Const and NULL is its
+# own operator), but this is fine because when an explicit NULL is involved we
+# can generate spans anyway.
+opt expect-not=UnifyComparisonTypes format=show-all
+SELECT k FROM e WHERE i IS NOT DISTINCT FROM NULL::FLOAT
+----
+project
+ ├── columns: k:1(int!null)
+ ├── stats: [rows=10]
+ ├── cost: 10.5
+ ├── key: (1)
+ ├── prune: (1)
+ ├── interesting orderings: (+1)
+ └── scan e@secondary
+      ├── columns: t.public.e.k:1(int!null) t.public.e.i:2(int)
+      ├── constraint: /2/1: [/NULL - /NULL]
+      ├── stats: [rows=10, distinct(2)=1]
+      ├── cost: 10.4
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      ├── prune: (1,2)
+      └── interesting orderings: (+1) (+2,+1)
+
+opt expect-not=UnifyComparisonTypes format=show-all
+SELECT k FROM e WHERE i IS DISTINCT FROM NULL::FLOAT
+----
+project
+ ├── columns: k:1(int!null)
+ ├── stats: [rows=895.95846]
+ ├── cost: 940.756383
+ ├── key: (1)
+ ├── prune: (1)
+ ├── interesting orderings: (+1)
+ └── scan e@secondary
+      ├── columns: t.public.e.k:1(int!null) t.public.e.i:2(int!null)
+      ├── constraint: /2/1: (/NULL - ]
+      ├── stats: [rows=895.95846]
+      ├── cost: 931.796798
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── prune: (1,2)
+      └── interesting orderings: (+1) (+2,+1)
+
+opt expect=UnifyComparisonTypes
+SELECT * FROM e WHERE k IS NOT DISTINCT FROM '1.0'::FLOAT
+----
+scan e
+ ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
+ ├── constraint: /1: [/1 - /1]
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
+## --------------------------------------------------
+## TIMESTAMP / TIMESTAMPTZ / DATE
+## --------------------------------------------------
+
+opt disable=UnifyComparisonTypes
+SELECT k FROM e WHERE tz > '2017-11-12 07:35:01+00:00'::TIMESTAMP
+----
+project
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ └── select
+      ├── columns: k:1(int!null) tz:4(timestamptz)
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── scan e@secondary
+      │    ├── columns: k:1(int!null) tz:4(timestamptz!null)
+      │    ├── constraint: /4/1: (/NULL - ]
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4)
+      └── filters [type=bool, outer=(4)]
+           └── tz > '2017-11-12 07:35:01+00:00' [type=bool, outer=(4)]
+
+opt expect=UnifyComparisonTypes
+SELECT k FROM e WHERE tz > '2017-11-12 07:35:01+00:00'::TIMESTAMP
+----
+project
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ └── scan e@secondary
+      ├── columns: k:1(int!null) tz:4(timestamptz!null)
+      ├── constraint: /4/1: [/'2017-11-12 07:35:01.000001+00:00' - ]
+      ├── key: (1)
+      └── fd: (1)-->(4)
+
+# Common case arising from constant folding: the folding here results in a
+# TIMESTAMP, but we would still like to be able to generate DATE spans.
+opt
+SELECT k FROM e WHERE d > '2018-07-01' AND d < '2018-07-01'::DATE + '1w'::INTERVAL
+----
+project
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ └── scan e@secondary
+      ├── columns: k:1(int!null) d:5(date!null)
+      ├── constraint: /5/1: [/'2018-07-02' - /'2018-07-07']
+      ├── key: (1)
+      └── fd: (1)-->(5)
+
+# A case where we can theoretically generate spans, but do not.
+# TODO(justin): modify the logic to allow us to create spans in this case.
+opt
+SELECT k FROM e WHERE d > '2018-07-01' AND d < '2018-07-01'::DATE + '1w1s'::INTERVAL
+----
+project
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ └── select
+      ├── columns: k:1(int!null) d:5(date!null)
+      ├── key: (1)
+      ├── fd: (1)-->(5)
+      ├── scan e@secondary
+      │    ├── columns: k:1(int!null) d:5(date!null)
+      │    ├── constraint: /5/1: [/'2018-07-02' - ]
+      │    ├── key: (1)
+      │    └── fd: (1)-->(5)
+      └── filters [type=bool, outer=(5)]
+           └── d < '2018-07-08 00:00:01+00:00' [type=bool, outer=(5)]
+
+# NULL value.
+opt
+SELECT k FROM e WHERE tz > NULL::TIMESTAMP
+----
+values
+ ├── columns: k:1(int)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1)
+
+# Working in concert with other norm rules
+opt
+SELECT k FROM e WHERE d - '1w'::INTERVAL > '2018-07-01'::DATE
+----
+project
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ └── scan e@secondary
+      ├── columns: k:1(int!null) d:5(date!null)
+      ├── constraint: /5/1: [/'2018-07-09' - ]
+      ├── key: (1)
+      └── fd: (1)-->(5)

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -323,8 +323,8 @@ sort
       │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(string!null) l_linestatus:10(string!null) l_shipdate:11(date!null)
       │    │    ├── scan lineitem
       │    │    │    └── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(string!null) l_linestatus:10(string!null) l_shipdate:11(date!null)
-      │    │    └── filters [type=bool, outer=(11)]
-      │    │         └── l_shipdate <= '1998-09-02 00:00:00+00:00' [type=bool, outer=(11)]
+      │    │    └── filters [type=bool, outer=(11), constraints=(/11: (/NULL - /'1998-09-02']; tight)]
+      │    │         └── l_shipdate <= '1998-09-02' [type=bool, outer=(11), constraints=(/11: (/NULL - /'1998-09-02']; tight)]
       │    └── projections [outer=(5-10)]
       │         ├── l_extendedprice * (1.0 - l_discount) [type=float, outer=(6,7)]
       │         └── (l_extendedprice * (1.0 - l_discount)) * (l_tax + 1.0) [type=float, outer=(6-8)]
@@ -724,17 +724,11 @@ sort
       │    │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(string!null)
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(5,6)
-      │    │    └── select
+      │    │    └── scan orders@o_od
       │    │         ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null)
+      │    │         ├── constraint: /5/1: [/'1993-07-01' - /'1993-09-30']
       │    │         ├── key: (1)
-      │    │         ├── fd: (1)-->(5)
-      │    │         ├── scan orders@o_od
-      │    │         │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null)
-      │    │         │    ├── constraint: /5/1: [/'1993-07-01' - ]
-      │    │         │    ├── key: (1)
-      │    │         │    └── fd: (1)-->(5)
-      │    │         └── filters [type=bool, outer=(5)]
-      │    │              └── o_orderdate < '1993-10-01 00:00:00+00:00' [type=bool, outer=(5)]
+      │    │         └── fd: (1)-->(5)
       │    ├── select
       │    │    ├── columns: l_orderkey:10(int!null) l_commitdate:21(date!null) l_receiptdate:22(date!null)
       │    │    ├── scan lineitem
@@ -850,17 +844,11 @@ sort
       │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
       │    │    │    │    ├── key: (9)
       │    │    │    │    ├── fd: (9)-->(10,13)
-      │    │    │    │    └── select
+      │    │    │    │    └── scan orders@o_od
       │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
+      │    │    │    │         ├── constraint: /13/9: [/'1994-01-01' - /'1994-12-31']
       │    │    │    │         ├── key: (9)
-      │    │    │    │         ├── fd: (9)-->(13)
-      │    │    │    │         ├── scan orders@o_od
-      │    │    │    │         │    ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
-      │    │    │    │         │    ├── constraint: /13/9: [/'1994-01-01' - ]
-      │    │    │    │         │    ├── key: (9)
-      │    │    │    │         │    └── fd: (9)-->(13)
-      │    │    │    │         └── filters [type=bool, outer=(13)]
-      │    │    │    │              └── o_orderdate < '1995-01-01 00:00:00+00:00' [type=bool, outer=(13)]
+      │    │    │    │         └── fd: (9)-->(13)
       │    │    │    └── filters [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
       │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ])]
       │    │    ├── scan customer@c_nk
@@ -913,17 +901,11 @@ scalar-group-by
  │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
  │    │    ├── index-join lineitem
  │    │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
- │    │    │    └── select
+ │    │    │    └── scan lineitem@l_sd
  │    │    │         ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
+ │    │    │         ├── constraint: /11/1/4: [/'1994-01-01' - /'1994-12-31']
  │    │    │         ├── key: (1,4)
- │    │    │         ├── fd: (1,4)-->(11)
- │    │    │         ├── scan lineitem@l_sd
- │    │    │         │    ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
- │    │    │         │    ├── constraint: /11/1/4: [/'1994-01-01' - ]
- │    │    │         │    ├── key: (1,4)
- │    │    │         │    └── fd: (1,4)-->(11)
- │    │    │         └── filters [type=bool, outer=(11)]
- │    │    │              └── l_shipdate < '1995-01-01 00:00:00+00:00' [type=bool, outer=(11)]
+ │    │    │         └── fd: (1,4)-->(11)
  │    │    └── filters [type=bool, outer=(5,7), constraints=(/5: (/NULL - /23.999999999999996]; /7: [/0.05 - /0.07]; tight)]
  │    │         ├── l_discount >= 0.05 [type=bool, outer=(7), constraints=(/7: [/0.05 - ]; tight)]
  │    │         ├── l_discount <= 0.07 [type=bool, outer=(7), constraints=(/7: (/NULL - /0.07]; tight)]
@@ -1441,17 +1423,11 @@ limit
  │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
  │         │    │    │    │    ├── key: (9)
  │         │    │    │    │    ├── fd: (9)-->(10,13)
- │         │    │    │    │    └── select
+ │         │    │    │    │    └── scan orders@o_od
  │         │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
+ │         │    │    │    │         ├── constraint: /13/9: [/'1993-10-01' - /'1993-12-31']
  │         │    │    │    │         ├── key: (9)
- │         │    │    │    │         ├── fd: (9)-->(13)
- │         │    │    │    │         ├── scan orders@o_od
- │         │    │    │    │         │    ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
- │         │    │    │    │         │    ├── constraint: /13/9: [/'1993-10-01' - ]
- │         │    │    │    │         │    ├── key: (9)
- │         │    │    │    │         │    └── fd: (9)-->(13)
- │         │    │    │    │         └── filters [type=bool, outer=(13)]
- │         │    │    │    │              └── o_orderdate < '1994-01-01 00:00:00+00:00' [type=bool, outer=(13)]
+ │         │    │    │    │         └── fd: (9)-->(13)
  │         │    │    │    └── filters [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
  │         │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ])]
  │         │    │    ├── scan customer
@@ -1677,17 +1653,11 @@ sort
       │    │    │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(string!null)
       │    │    │    ├── index-join lineitem
       │    │    │    │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(string!null)
-      │    │    │    │    └── select
+      │    │    │    │    └── scan lineitem@l_rd
       │    │    │    │         ├── columns: l_orderkey:10(int!null) l_linenumber:13(int!null) l_receiptdate:22(date!null)
+      │    │    │    │         ├── constraint: /22/10/13: [/'1994-01-01' - /'1994-12-31']
       │    │    │    │         ├── key: (10,13)
-      │    │    │    │         ├── fd: (10,13)-->(22)
-      │    │    │    │         ├── scan lineitem@l_rd
-      │    │    │    │         │    ├── columns: l_orderkey:10(int!null) l_linenumber:13(int!null) l_receiptdate:22(date!null)
-      │    │    │    │         │    ├── constraint: /22/10/13: [/'1994-01-01' - ]
-      │    │    │    │         │    ├── key: (10,13)
-      │    │    │    │         │    └── fd: (10,13)-->(22)
-      │    │    │    │         └── filters [type=bool, outer=(22)]
-      │    │    │    │              └── l_receiptdate < '1995-01-01 00:00:00+00:00' [type=bool, outer=(22)]
+      │    │    │    │         └── fd: (10,13)-->(22)
       │    │    │    └── filters [type=bool, outer=(20-22,24), constraints=(/20: (/NULL - ]; /21: (/NULL - ]; /22: (/NULL - ]; /24: [/'MAIL' - /'MAIL'] [/'SHIP' - /'SHIP'])]
       │    │    │         ├── l_shipmode IN ('MAIL', 'SHIP') [type=bool, outer=(24), constraints=(/24: [/'MAIL' - /'MAIL'] [/'SHIP' - /'SHIP']; tight)]
       │    │    │         ├── l_commitdate < l_receiptdate [type=bool, outer=(21,22), constraints=(/21: (/NULL - ]; /22: (/NULL - ])]
@@ -1819,17 +1789,11 @@ project
  │    │    │    ├── fd: (17)-->(21), (2)==(17), (17)==(2)
  │    │    │    ├── index-join lineitem
  │    │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
- │    │    │    │    └── select
+ │    │    │    │    └── scan lineitem@l_sd
  │    │    │    │         ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
+ │    │    │    │         ├── constraint: /11/1/4: [/'1995-09-01' - /'1995-09-30']
  │    │    │    │         ├── key: (1,4)
- │    │    │    │         ├── fd: (1,4)-->(11)
- │    │    │    │         ├── scan lineitem@l_sd
- │    │    │    │         │    ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
- │    │    │    │         │    ├── constraint: /11/1/4: [/'1995-09-01' - ]
- │    │    │    │         │    ├── key: (1,4)
- │    │    │    │         │    └── fd: (1,4)-->(11)
- │    │    │    │         └── filters [type=bool, outer=(11)]
- │    │    │    │              └── l_shipdate < '1995-10-01 00:00:00+00:00' [type=bool, outer=(11)]
+ │    │    │    │         └── fd: (1,4)-->(11)
  │    │    │    └── true [type=bool]
  │    │    └── projections [outer=(6,7,21)]
  │    │         ├── CASE WHEN p_type LIKE 'PROMO%' THEN l_extendedprice * (1.0 - l_discount) ELSE 0.0 END [type=float, outer=(6,7,21)]
@@ -1917,17 +1881,11 @@ sort
            │    │    │    ├── columns: column24:24(float) lineitem.l_suppkey:10(int!null)
            │    │    │    ├── index-join lineitem
            │    │    │    │    ├── columns: lineitem.l_suppkey:10(int!null) lineitem.l_extendedprice:13(float!null) lineitem.l_discount:14(float!null) lineitem.l_shipdate:18(date!null)
-           │    │    │    │    └── select
+           │    │    │    │    └── scan lineitem@l_sd
            │    │    │    │         ├── columns: lineitem.l_orderkey:8(int!null) lineitem.l_linenumber:11(int!null) lineitem.l_shipdate:18(date!null)
+           │    │    │    │         ├── constraint: /18/8/11: [/'1996-01-01' - /'1996-03-31']
            │    │    │    │         ├── key: (8,11)
-           │    │    │    │         ├── fd: (8,11)-->(18)
-           │    │    │    │         ├── scan lineitem@l_sd
-           │    │    │    │         │    ├── columns: lineitem.l_orderkey:8(int!null) lineitem.l_linenumber:11(int!null) lineitem.l_shipdate:18(date!null)
-           │    │    │    │         │    ├── constraint: /18/8/11: [/'1996-01-01' - ]
-           │    │    │    │         │    ├── key: (8,11)
-           │    │    │    │         │    └── fd: (8,11)-->(18)
-           │    │    │    │         └── filters [type=bool, outer=(18)]
-           │    │    │    │              └── lineitem.l_shipdate < '1996-04-01 00:00:00+00:00' [type=bool, outer=(18)]
+           │    │    │    │         └── fd: (8,11)-->(18)
            │    │    │    └── projections [outer=(10,13,14)]
            │    │    │         └── lineitem.l_extendedprice * (1.0 - lineitem.l_discount) [type=float, outer=(13,14)]
            │    │    └── aggregations [outer=(24)]
@@ -1951,17 +1909,11 @@ sort
            │                        │    │    ├── columns: column42:42(float) lineitem.l_suppkey:28(int!null)
            │                        │    │    ├── index-join lineitem
            │                        │    │    │    ├── columns: lineitem.l_suppkey:28(int!null) lineitem.l_extendedprice:31(float!null) lineitem.l_discount:32(float!null) lineitem.l_shipdate:36(date!null)
-           │                        │    │    │    └── select
+           │                        │    │    │    └── scan lineitem@l_sd
            │                        │    │    │         ├── columns: lineitem.l_orderkey:26(int!null) lineitem.l_linenumber:29(int!null) lineitem.l_shipdate:36(date!null)
+           │                        │    │    │         ├── constraint: /36/26/29: [/'1996-01-01' - /'1996-03-31']
            │                        │    │    │         ├── key: (26,29)
-           │                        │    │    │         ├── fd: (26,29)-->(36)
-           │                        │    │    │         ├── scan lineitem@l_sd
-           │                        │    │    │         │    ├── columns: lineitem.l_orderkey:26(int!null) lineitem.l_linenumber:29(int!null) lineitem.l_shipdate:36(date!null)
-           │                        │    │    │         │    ├── constraint: /36/26/29: [/'1996-01-01' - ]
-           │                        │    │    │         │    ├── key: (26,29)
-           │                        │    │    │         │    └── fd: (26,29)-->(36)
-           │                        │    │    │         └── filters [type=bool, outer=(36)]
-           │                        │    │    │              └── lineitem.l_shipdate < '1996-04-01 00:00:00+00:00' [type=bool, outer=(36)]
+           │                        │    │    │         └── fd: (26,29)-->(36)
            │                        │    │    └── projections [outer=(28,31,32)]
            │                        │    │         └── lineitem.l_extendedprice * (1.0 - lineitem.l_discount) [type=float, outer=(31,32)]
            │                        │    └── aggregations [outer=(42)]
@@ -2468,17 +2420,11 @@ sort
            │    │    │         │    │    │    └── fd: (12,13)-->(14)
            │    │    │         │    │    ├── index-join lineitem
            │    │    │         │    │    │    ├── columns: l_partkey:27(int!null) l_suppkey:28(int!null) l_quantity:30(float!null) l_shipdate:36(date!null)
-           │    │    │         │    │    │    └── select
+           │    │    │         │    │    │    └── scan lineitem@l_sd
            │    │    │         │    │    │         ├── columns: l_orderkey:26(int!null) l_linenumber:29(int!null) l_shipdate:36(date!null)
+           │    │    │         │    │    │         ├── constraint: /36/26/29: [/'1994-01-01' - /'1994-12-31']
            │    │    │         │    │    │         ├── key: (26,29)
-           │    │    │         │    │    │         ├── fd: (26,29)-->(36)
-           │    │    │         │    │    │         ├── scan lineitem@l_sd
-           │    │    │         │    │    │         │    ├── columns: l_orderkey:26(int!null) l_linenumber:29(int!null) l_shipdate:36(date!null)
-           │    │    │         │    │    │         │    ├── constraint: /36/26/29: [/'1994-01-01' - ]
-           │    │    │         │    │    │         │    ├── key: (26,29)
-           │    │    │         │    │    │         │    └── fd: (26,29)-->(36)
-           │    │    │         │    │    │         └── filters [type=bool, outer=(36)]
-           │    │    │         │    │    │              └── l_shipdate < '1995-01-01 00:00:00+00:00' [type=bool, outer=(36)]
+           │    │    │         │    │    │         └── fd: (26,29)-->(36)
            │    │    │         │    │    └── filters [type=bool, outer=(12,13,27,28), constraints=(/12: (/NULL - ]; /13: (/NULL - ]; /27: (/NULL - ]; /28: (/NULL - ]), fd=(12)==(27), (27)==(12), (13)==(28), (28)==(13)]
            │    │    │         │    │         ├── l_partkey = ps_partkey [type=bool, outer=(12,27), constraints=(/12: (/NULL - ]; /27: (/NULL - ])]
            │    │    │         │    │         └── l_suppkey = ps_suppkey [type=bool, outer=(13,28), constraints=(/13: (/NULL - ]; /28: (/NULL - ])]


### PR DESCRIPTION
Backport 1/1 commits from #30504.

/cc @cockroachdb/release

---

A comparison of the form

  column of time TIMESTAMP <comparison> constant DATE

should be able to generate index constraints if we have an index on the
timestamp column. However, prior to this commit, we did not.

This commit allows such comparisons to generate spans by casting the
constant if the following two conditions hold:

* The conversion between the two types is monotonic
  (a < b => f(a) < f(b)). This condition guarantees that such index
  constraints are valid for the original comparison. An example of a
  conversion for which this condition would not hold is INT -> STRING
  conversion, or virtually any collated string comparison.
* the constant can successfully round-trip. This guarantees that we do
  not lose any precision in the conversion between the two. For instance,
  we would need logic dependent on the nature of the conversion to know
  whether we need to convert `x > 3.3` to `x > 3` or `x > 4`.

This means that this commit can create spans in the case of a comparison
like `x > 3.0::FLOAT`, but not `x > 3.1::FLOAT`, which might be
unintuitive in some cases.

I feel like there are probably some edge cases to this code I'm not considering,
help coming up with problematic test cases would be appreciated!

Release note: None
