### PR TITLE
gossip: use a better signal for multi-node vs single-node cluster

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1499,11 +1499,9 @@ func (g *Gossip) doDisconnected(c *client) {
 func (g *Gossip) maybeSignalStatusChangeLocked() {
 	ctx := g.AnnotateCtx(context.TODO())
 	orphaned := g.outgoing.len()+g.mu.incoming.len() == 0
-	multiNode := len(g.nodeDescs) > 1
+	multiNode := len(g.bootstrapInfo.Addresses) > 0
 	// We're stalled if we don't have the sentinel key, or if we're a multi node
-	// cluster and have no gossip connections. Note that the multi-node check is
-	// pessimistic: when a node restarts multi-node will be false, but we also
-	// won't have the sentinel key.
+	// cluster and have no gossip connections.
 	stalled := (orphaned && multiNode) || g.mu.is.getInfo(KeySentinel) == nil
 	if stalled {
 		// We employ the stalled boolean to avoid filling logs with warnings.


### PR DESCRIPTION
Use `bootstrapInfo.Addresses` rather than the `nodeDescs` map to
determine whether a cluster is multi-node or single-node. The former is
persistent while the latter is ephemeral.

Release note: None