### PR TITLE
release-2.1: gossip: reduce gossip log spam

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1502,11 +1502,9 @@ func (g *Gossip) doDisconnected(c *client) {
 func (g *Gossip) maybeSignalStatusChangeLocked() {
 	ctx := g.AnnotateCtx(context.TODO())
 	orphaned := g.outgoing.len()+g.mu.incoming.len() == 0
-	multiNode := len(g.nodeDescs) > 1
+	multiNode := len(g.bootstrapInfo.Addresses) > 0
 	// We're stalled if we don't have the sentinel key, or if we're a multi node
-	// cluster and have no gossip connections. Note that the multi-node check is
-	// pessimistic: when a node restarts multi-node will be false, but we also
-	// won't have the sentinel key.
+	// cluster and have no gossip connections.
 	stalled := (orphaned && multiNode) || g.mu.is.getInfo(KeySentinel) == nil
 	if stalled {
 		// We employ the stalled boolean to avoid filling logs with warnings.

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1502,7 +1502,12 @@ func (g *Gossip) doDisconnected(c *client) {
 func (g *Gossip) maybeSignalStatusChangeLocked() {
 	ctx := g.AnnotateCtx(context.TODO())
 	orphaned := g.outgoing.len()+g.mu.incoming.len() == 0
-	stalled := orphaned || g.mu.is.getInfo(KeySentinel) == nil
+	multiNode := len(g.nodeDescs) > 1
+	// We're stalled if we don't have the sentinel key, or if we're a multi node
+	// cluster and have no gossip connections. Note that the multi-node check is
+	// pessimistic: when a node restarts multi-node will be false, but we also
+	// won't have the sentinel key.
+	stalled := (orphaned && multiNode) || g.mu.is.getInfo(KeySentinel) == nil
 	if stalled {
 		// We employ the stalled boolean to avoid filling logs with warnings.
 		if !g.stalled {


### PR DESCRIPTION
Backport:
  * 1/1 commits from "gossip: reduce gossip log spam" (#30653)
  * 1/1 commits from "gossip: use a better signal for multi-node vs single-node cluster" (#30671)

Please see individual PRs for details.

/cc @cockroachdb/release
