### PR TITLE
backport-2.1: sql: allow DROP DATABASE with dropped tables

### DIFF
--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -17,8 +17,6 @@ package sql
 import (
 	"context"
 
-	"github.com/pkg/errors"
-
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -86,16 +84,14 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 		}
 	}
 
-	td := make([]toDelete, len(tbNames))
+	td := make([]toDelete, 0, len(tbNames))
 	for i := range tbNames {
-		tbDesc, err := p.prepareDrop(ctx, &tbNames[i], true /*required*/, anyDescType)
+		tbDesc, err := p.prepareDrop(ctx, &tbNames[i], false /*required*/, anyDescType)
 		if err != nil {
 			return nil, err
 		}
 		if tbDesc == nil {
-			// Database claims to have this table, but it does not exist.
-			return nil, errors.Errorf("table %q was described by database %q, but does not exist",
-				tree.ErrString(&tbNames[i]), n.Name)
+			continue
 		}
 		// Recursively check permissions on all dependent views, since some may
 		// be in different databases.
@@ -104,7 +100,7 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 				return nil, err
 			}
 		}
-		td[i] = toDelete{&tbNames[i], tbDesc}
+		td = append(td, toDelete{&tbNames[i], tbDesc})
 	}
 
 	td, err = p.filterCascadedTables(ctx, td)


### PR DESCRIPTION
@knz this was originally reviewed by @dt . Thanks!

Backport 1/1 commits from #30344.

/cc @cockroachdb/release

---

A DROP TABLE transaction is followed by a period during which
the name is flushed from the cluster table caches before the
name is dropped in a separate transaction from the namespace.
This is done to prevent the name from being resued before
the name is flushed. If a DROP DATABASE ran in between the two
transactions, the DROP DATABASE would fail. The unittest
successfully reproduces the problem.

fixes #27135

Release note: None
