### PR TITLE
sql, opt: decompose ranges queries to allow pushdown of filters

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/crdb_internal
+++ b/pkg/sql/opt/exec/execbuilder/testdata/crdb_internal
@@ -1,0 +1,63 @@
+# LogicTest: local-opt
+
+query T
+EXPLAIN (OPT) SELECT * FROM crdb_internal.ranges
+----
+project
+ ├── columns: range_id:11(int) start_key:12(bytes) start_pretty:13(string) end_key:14(bytes) end_pretty:15(string) database:16(string) table:17(string) index:18(string) replicas:19(int[]) lease_holder:20(int)
+ ├── stats: [rows=1000]
+ ├── cost: 30
+ ├── fd: (12)-->(20)
+ ├── prune: (11-20)
+ ├── virtual-scan test.crdb_internal.ranges_no_leases
+ │    ├── columns: ranges_no_leases.range_id:11(int) ranges_no_leases.start_key:12(bytes) ranges_no_leases.start_pretty:13(string) ranges_no_leases.end_key:14(bytes) ranges_no_leases.end_pretty:15(string) ranges_no_leases.database:16(string) ranges_no_leases.table:17(string) ranges_no_leases.index:18(string) ranges_no_leases.replicas:19(int[])
+ │    ├── stats: [rows=1000]
+ │    └── cost: 10
+ └── projections [outer=(11-19)]
+      └── function: crdb_internal.lease_holder [type=int, outer=(12)]
+           └── variable: ranges_no_leases.start_key [type=bytes, outer=(12)]
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM crdb_internal.ranges WHERE range_id = 1
+----
+render                   ·         ·                                      (range_id, start_key, start_pretty, end_key, end_pretty, database, "table", "index", replicas, lease_holder)  ·
+ │                       render 0  range_id                               ·                                                                                                             ·
+ │                       render 1  start_key                              ·                                                                                                             ·
+ │                       render 2  start_pretty                           ·                                                                                                             ·
+ │                       render 3  end_key                                ·                                                                                                             ·
+ │                       render 4  end_pretty                             ·                                                                                                             ·
+ │                       render 5  database                               ·                                                                                                             ·
+ │                       render 6  "table"                                ·                                                                                                             ·
+ │                       render 7  "index"                                ·                                                                                                             ·
+ │                       render 8  replicas                               ·                                                                                                             ·
+ │                       render 9  crdb_internal.lease_holder(start_key)  ·                                                                                                             ·
+ └── filter              ·         ·                                      (range_id, start_key, start_pretty, end_key, end_pretty, database, "table", "index", replicas)                ·
+      │                  filter    range_id = 1                           ·                                                                                                             ·
+      └── virtual table  ·         ·                                      (range_id, start_key, start_pretty, end_key, end_pretty, database, "table", "index", replicas)                ·
+·                        source    ·                                      ·                                                                                                             ·
+
+query T
+EXPLAIN (OPT) SELECT * FROM crdb_internal.ranges WHERE range_id = 1
+----
+project
+ ├── columns: range_id:11(int!null) start_key:12(bytes) start_pretty:13(string) end_key:14(bytes) end_pretty:15(string) database:16(string) table:17(string) index:18(string) replicas:19(int[]) lease_holder:20(int)
+ ├── stats: [rows=10]
+ ├── cost: 20.2
+ ├── fd: ()-->(11), (12)-->(20)
+ ├── prune: (11-20)
+ ├── select
+ │    ├── columns: ranges_no_leases.range_id:11(int!null) ranges_no_leases.start_key:12(bytes) ranges_no_leases.start_pretty:13(string) ranges_no_leases.end_key:14(bytes) ranges_no_leases.end_pretty:15(string) ranges_no_leases.database:16(string) ranges_no_leases.table:17(string) ranges_no_leases.index:18(string) ranges_no_leases.replicas:19(int[])
+ │    ├── stats: [rows=10, distinct(11)=1]
+ │    ├── cost: 20
+ │    ├── fd: ()-->(11)
+ │    ├── virtual-scan test.crdb_internal.ranges_no_leases
+ │    │    ├── columns: ranges_no_leases.range_id:11(int) ranges_no_leases.start_key:12(bytes) ranges_no_leases.start_pretty:13(string) ranges_no_leases.end_key:14(bytes) ranges_no_leases.end_pretty:15(string) ranges_no_leases.database:16(string) ranges_no_leases.table:17(string) ranges_no_leases.index:18(string) ranges_no_leases.replicas:19(int[])
+ │    │    ├── stats: [rows=1000, distinct(11)=100]
+ │    │    └── cost: 10
+ │    └── filters [type=bool, outer=(11), constraints=(/11: [/1 - /1]; tight), fd=()-->(11)]
+ │         └── eq [type=bool, outer=(11), constraints=(/11: [/1 - /1]; tight)]
+ │              ├── variable: ranges_no_leases.range_id [type=int, outer=(11)]
+ │              └── const: 1 [type=int]
+ └── projections [outer=(11-19)]
+      └── function: crdb_internal.lease_holder [type=int, outer=(12)]
+           └── variable: ranges_no_leases.start_key [type=bytes, outer=(12)]

--- a/pkg/sql/opt/memo/testdata/logprops/virtual-scan
+++ b/pkg/sql/opt/memo/testdata/logprops/virtual-scan
@@ -62,3 +62,89 @@ project
                 └── eq [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
                      ├── variable: schema_name [type=string, outer=(2)]
                      └── variable: table_schema [type=string, outer=(6)]
+
+# The system.crdb_internal.ranges_no_leases and system.crdb_internal.ranges
+# tables are dynamically classified as virtual tables based on the 'system'
+# catalog in their names
+exec-ddl
+CREATE TABLE system.crdb_internal.ranges_no_leases (
+  range_id     INT NOT NULL,
+  start_key    BYTES NOT NULL,
+  start_pretty STRING NOT NULL,
+  end_key      BYTES NOT NULL,
+  end_pretty   STRING NOT NULL,
+  database     STRING NOT NULL,
+  "table"      STRING NOT NULL,
+  "index"      STRING NOT NULL,
+  replicas     INT[] NOT NULL
+)
+----
+TABLE ranges_no_leases
+ ├── range_id int not null
+ ├── start_key bytes not null
+ ├── start_pretty string not null
+ ├── end_key bytes not null
+ ├── end_pretty string not null
+ ├── database string not null
+ ├── table string not null
+ ├── index string not null
+ └── replicas int[] not null
+
+exec-ddl
+CREATE TABLE system.crdb_internal.ranges (
+  range_id     INT NOT NULL,
+  start_key    BYTES NOT NULL,
+  start_pretty STRING NOT NULL,
+  end_key      BYTES NOT NULL,
+  end_pretty   STRING NOT NULL,
+  database     STRING NOT NULL,
+  "table"      STRING NOT NULL,
+  "index"      STRING NOT NULL,
+  replicas     INT[] NOT NULL,
+  lease_holder INT NOT NULL
+)
+----
+TABLE ranges
+ ├── range_id int not null
+ ├── start_key bytes not null
+ ├── start_pretty string not null
+ ├── end_key bytes not null
+ ├── end_pretty string not null
+ ├── database string not null
+ ├── table string not null
+ ├── index string not null
+ ├── replicas int[] not null
+ └── lease_holder int not null
+
+build
+SELECT * FROM system.crdb_internal.ranges
+----
+project
+ ├── columns: range_id:11(int) start_key:12(bytes) start_pretty:13(string) end_key:14(bytes) end_pretty:15(string) database:16(string) table:17(string) index:18(string) replicas:19(int[]) lease_holder:20(int)
+ ├── fd: (12)-->(20)
+ ├── prune: (11-20)
+ ├── virtual-scan system.crdb_internal.ranges_no_leases
+ │    └── columns: ranges_no_leases.range_id:11(int) ranges_no_leases.start_key:12(bytes) ranges_no_leases.start_pretty:13(string) ranges_no_leases.end_key:14(bytes) ranges_no_leases.end_pretty:15(string) ranges_no_leases.database:16(string) ranges_no_leases.table:17(string) ranges_no_leases.index:18(string) ranges_no_leases.replicas:19(int[])
+ └── projections [outer=(11-19)]
+      └── function: crdb_internal.lease_holder [type=int, outer=(12)]
+           └── variable: ranges_no_leases.start_key [type=bytes, outer=(12)]
+
+opt
+SELECT * FROM system.crdb_internal.ranges WHERE range_id = 1
+----
+project
+ ├── columns: range_id:11(int!null) start_key:12(bytes) start_pretty:13(string) end_key:14(bytes) end_pretty:15(string) database:16(string) table:17(string) index:18(string) replicas:19(int[]) lease_holder:20(int)
+ ├── fd: ()-->(11), (12)-->(20)
+ ├── prune: (11-20)
+ ├── select
+ │    ├── columns: ranges_no_leases.range_id:11(int!null) ranges_no_leases.start_key:12(bytes) ranges_no_leases.start_pretty:13(string) ranges_no_leases.end_key:14(bytes) ranges_no_leases.end_pretty:15(string) ranges_no_leases.database:16(string) ranges_no_leases.table:17(string) ranges_no_leases.index:18(string) ranges_no_leases.replicas:19(int[])
+ │    ├── fd: ()-->(11)
+ │    ├── virtual-scan system.crdb_internal.ranges_no_leases
+ │    │    └── columns: ranges_no_leases.range_id:11(int) ranges_no_leases.start_key:12(bytes) ranges_no_leases.start_pretty:13(string) ranges_no_leases.end_key:14(bytes) ranges_no_leases.end_pretty:15(string) ranges_no_leases.database:16(string) ranges_no_leases.table:17(string) ranges_no_leases.index:18(string) ranges_no_leases.replicas:19(int[])
+ │    └── filters [type=bool, outer=(11), constraints=(/11: [/1 - /1]; tight), fd=()-->(11)]
+ │         └── eq [type=bool, outer=(11), constraints=(/11: [/1 - /1]; tight)]
+ │              ├── variable: ranges_no_leases.range_id [type=int, outer=(11)]
+ │              └── const: 1 [type=int]
+ └── projections [outer=(11-19)]
+      └── function: crdb_internal.lease_holder [type=int, outer=(12)]
+           └── variable: ranges_no_leases.start_key [type=bytes, outer=(12)]


### PR DESCRIPTION
Transform all queries over the `crdb_internal.ranges` query into a query over
the `crdb_internal.ranges_no_leases` table with a projection for the
`lease_holder` column. This allows for pushdown of filters in the optimizer
stage.

For example, the query `SELECT * FROM crdb_internal.ranges WHERE range_id = 1` would translate to `SELECT *, crdb_internal.lease_holder(start_key) FROM crdb_internal.ranges_no_leases WHERE range_id = 1` and is further optimized.

When I tested this code on my local machine with `50000` splits, the query `SELECT * FROM crdb_internal.ranges WHERE range_id = 1` takes 400ms to complete. Previously, this same query took 2s.

Release note: None