### PR TITLE
ui: add cluster/per-node toggle to time series charts

### DIFF
--- a/pkg/ui/src/redux/aggregationLevel.ts
+++ b/pkg/ui/src/redux/aggregationLevel.ts
@@ -1,0 +1,21 @@
+import { LocalSetting } from "src/redux/localsettings";
+import { AdminUIState } from "src/redux/state";
+
+export enum AggregationLevel {
+  Cluster = "cluster",
+  Node = "node",
+}
+
+export const SET_AGGREGATION_LEVEL = "cockroachui/AggregationLevel/SET";
+
+const aggregationLevelSetting = new LocalSetting<AdminUIState, AggregationLevel>(
+  "aggregation_level/setting", s => s.localSettings, AggregationLevel.Cluster,
+);
+
+export function setAggregationLevel(aggregationLevel:  AggregationLevel) {
+  return aggregationLevelSetting.set(aggregationLevel);
+}
+
+export function selectAggregationLevel(state: AdminUIState) {
+  return aggregationLevelSetting.selector(state);
+}

--- a/pkg/ui/src/util/constants.ts
+++ b/pkg/ui/src/util/constants.ts
@@ -1,9 +1,7 @@
 export const appAttr = "app";
-export const dashQueryString = "dash";
 export const dashboardNameAttr = "dashboard_name";
 export const databaseNameAttr = "database_name";
 export const nodeIDAttr = "node_id";
-export const nodeQueryString = "node";
 export const rangeIDAttr = "range_id";
 export const statementAttr = "statement";
 export const tableNameAttr = "table_name";

--- a/pkg/ui/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/src/views/cluster/components/linegraph/index.tsx
@@ -13,8 +13,10 @@ import {
   Metric, MetricProps, Axis, AxisProps,
 } from "src/views/shared/components/metricQuery";
 import { MetricsDataComponentProps } from "src/views/shared/components/metricQuery";
-import Visualization from "src/views/cluster/components/visualization";
+import Visualization, { Group } from "src/views/cluster/components/visualization";
 import { NanoToMilli } from "src/util/convert";
+
+export { Group } from "src/views/cluster/components/visualization";
 
 interface LineGraphProps extends MetricsDataComponentProps {
   title?: string;
@@ -25,6 +27,7 @@ interface LineGraphProps extends MetricsDataComponentProps {
   hoverOn?: typeof hoverOn;
   hoverOff?: typeof hoverOff;
   hoverState?: HoverState;
+  group?: Group;
 }
 
 /**
@@ -181,7 +184,7 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
   }
 
   render() {
-    const { title, subtitle, tooltip, data } = this.props;
+    const { title, subtitle, tooltip, data, group } = this.props;
 
     let hoverProps: Partial<React.SVGProps<SVGSVGElement>> = {};
     if (this.props.hoverOn) {
@@ -192,7 +195,7 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
     }
 
     return (
-      <Visualization title={title} subtitle={subtitle} tooltip={tooltip} loading={!data} >
+      <Visualization title={title} subtitle={subtitle} tooltip={tooltip} loading={!data} group={group} >
         <div className="linegraph">
           <svg className="graph linked-guideline" ref={(svg) => this.graphEl = svg} {...hoverProps} />
         </div>

--- a/pkg/ui/src/views/cluster/components/visualization/index.tsx
+++ b/pkg/ui/src/views/cluster/components/visualization/index.tsx
@@ -26,7 +26,7 @@ interface VisualizationProps {
  * charts). It surrounds a visual element with some standard information, such
  * as a title and a tooltip icon.
  */
-export default class extends React.Component<VisualizationProps, {}> {
+export default class Visualization extends React.Component<VisualizationProps, {}> {
   render() {
     const { title, tooltip, stale } = this.props;
     const vizClasses = classNames(

--- a/pkg/ui/src/views/cluster/components/visualization/index.tsx
+++ b/pkg/ui/src/views/cluster/components/visualization/index.tsx
@@ -19,6 +19,23 @@ interface VisualizationProps {
   stale?: boolean;
   // If loading is true a spinner is shown instead of the graph.
   loading?: boolean;
+
+  group?: Group;
+}
+
+export enum Group {
+  Solo,
+  Top,
+  Bottom,
+  Middle,
+}
+
+function group_class(group?: Group) {
+  return {
+    "visualization--top": group === Group.Top,
+    "visualization--middle": group === Group.Middle,
+    "visualization--bottom": group === Group.Bottom,
+  };
 }
 
 /**
@@ -32,6 +49,7 @@ export default class Visualization extends React.Component<VisualizationProps, {
     const vizClasses = classNames(
       "visualization",
       { "visualization--faded": stale || false },
+      group_class(this.props.group),
     );
     const contentClasses = classNames(
       "visualization__content",

--- a/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
+++ b/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
@@ -29,6 +29,15 @@ $viz-sides = 62px
   // prevents borders from doubling up
   margin-bottom 10px
 
+  &--top, &--middle
+    border-radius 5px 5px 0 0
+    border-bottom none
+    margin-bottom 0
+
+  &--bottom, &--middle
+    border-radius 0 0 5px 5px
+    border-top none
+
   &__content
     padding 0 10px 15px
     height 200px
@@ -48,6 +57,9 @@ $viz-sides = 62px
     font-family Lato-Bold
     color $body-color
 
+  &--bottom &__title, &--middle &__title
+    visibility hidden
+
   &__subtitle
     color $tooltip-color
     margin-left 5px
@@ -61,6 +73,9 @@ $viz-sides = 62px
   &__tooltip
     width 36px  // Reserve space for 10px padding around centered 16px icon
     height 16px
+
+  &--bottom &__tooltip, &--middle &__tooltip
+    display none
 
   &__tooltip-hover-area
     width 100%

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/dashboardUtils.ts
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/dashboardUtils.ts
@@ -1,4 +1,5 @@
 import { NodesSummary } from "src/redux/nodes";
+import { AggregationLevel } from "src/redux/aggregationLevel";
 
 /**
  * GraphDashboardProps are the properties accepted by the renderable component
@@ -30,6 +31,8 @@ export interface GraphDashboardProps {
    * all nodes" or "on node X".
    */
   tooltipSelection: string;
+
+  aggregationLevel: AggregationLevel;
 }
 
 export function nodeDisplayName(nodesSummary: NodesSummary, nid: string) {

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { AggregationLevel } from "src/redux/aggregationLevel";
-import { LineGraph } from "src/views/cluster/components/linegraph";
+import { LineGraph, Group } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
 import { GraphDashboardProps, nodeDisplayName, storeIDsForNode } from "./dashboardUtils";
@@ -93,6 +93,7 @@ export default function (props: GraphDashboardProps) {
         title="Disk Throughput"
         subtitle="Reads"
         sources={nodeSources}
+        group={Group.Top}
       >
         <Axis units={AxisUnits.Bytes} label="throughput">
           {nodeIDs.map((nid) => (
@@ -111,6 +112,7 @@ export default function (props: GraphDashboardProps) {
         title="Disk Throughput"
         subtitle="Writes"
         sources={nodeSources}
+        group={Group.Bottom}
       >
         <Axis units={AxisUnits.Bytes} label="bytes">
           {nodeIDs.map((nid) => (
@@ -148,6 +150,7 @@ export default function (props: GraphDashboardProps) {
         title="Disk Ops"
         subtitle="Reads"
         sources={nodeSources}
+        group={Group.Top}
       >
         <Axis units={AxisUnits.Count} label="Read Ops">
           {nodeIDs.map((nid) => (
@@ -166,6 +169,7 @@ export default function (props: GraphDashboardProps) {
         title="Disk Ops"
         subtitle="Writes"
         sources={nodeSources}
+        group={Group.Bottom}
       >
         <Axis units={AxisUnits.Count} label="Write Ops">
           {nodeIDs.map((nid) => (
@@ -270,6 +274,7 @@ export default function (props: GraphDashboardProps) {
         title="Network Throughput"
         subtitle="Received"
         sources={nodeSources}
+        group={Group.Top}
       >
         <Axis units={AxisUnits.Bytes} label="bytes">
           {nodeIDs.map((nid) => (
@@ -288,6 +293,7 @@ export default function (props: GraphDashboardProps) {
         title="Network Throughput"
         subtitle="Sent"
         sources={nodeSources}
+        group={Group.Bottom}
       >
         <Axis units={AxisUnits.Bytes} label="bytes">
           {nodeIDs.map((nid) => (

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { AggregationLevel } from "src/redux/aggregationLevel";
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
@@ -10,7 +11,10 @@ import { GraphDashboardProps, nodeDisplayName, storeIDsForNode } from "./dashboa
 export default function (props: GraphDashboardProps) {
   const { nodeIDs, nodesSummary, nodeSources, storeSources, tooltipSelection } = props;
 
-  return [
+  const charts = [];
+
+  // We can't really aggregate CPU percent at the moment.
+  charts.push(
     <LineGraph
       title="CPU Percent"
       sources={nodeSources}
@@ -25,151 +29,279 @@ export default function (props: GraphDashboardProps) {
         ))}
       </Axis>
     </LineGraph>,
+  );
 
-    <LineGraph
-      title="Memory Usage"
-      sources={nodeSources}
-      tooltip={(
-        <div>
-          Memory in use {tooltipSelection}
-        </div>
-      )}
-    >
-      <Axis units={AxisUnits.Bytes} label="memory usage">
-        {nodeIDs.map((nid) => (
-          <Metric
-            name="cr.node.sys.rss"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={[nid]}
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
+  if (props.aggregationLevel === AggregationLevel.Cluster) {
+    charts.push(
+      <LineGraph
+        title="Memory Usage"
+        sources={nodeSources}
+        tooltip={(
+          <div>
+            Memory in use {tooltipSelection}
+          </div>
+        )}
+      >
+        <Axis units={AxisUnits.Bytes} label="memory usage">
+          <Metric name="cr.node.sys.rss" title="Resident set size" />
+        </Axis>
+      </LineGraph>,
+    );
+  } else {
+    charts.push(
+      <LineGraph
+        title="Memory Usage"
+        sources={nodeSources}
+        tooltip={(
+          <div>
+            Memory in use {tooltipSelection}
+          </div>
+        )}
+      >
+        <Axis units={AxisUnits.Bytes} label="memory usage">
+          {nodeIDs.map((nid) => (
+            <Metric
+              name="cr.node.sys.rss"
+              title={nodeDisplayName(nodesSummary, nid)}
+              sources={[nid]}
+            />
+          ))}
+        </Axis>
+      </LineGraph>,
+    );
+  }
 
-    <LineGraph
-      title="Disk Read Bytes"
-      sources={nodeSources}
-    >
-      <Axis units={AxisUnits.Bytes} label="bytes">
-        {nodeIDs.map((nid) => (
+  if (props.aggregationLevel === AggregationLevel.Cluster) {
+    charts.push(
+      <LineGraph
+        title="Disk Throughput"
+        sources={nodeSources}
+      >
+        <Axis units={AxisUnits.Bytes} label="throughput">
           <Metric
             name="cr.node.sys.host.disk.read.bytes"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={[nid]}
-            nonNegativeRate
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Disk Write Bytes"
-      sources={nodeSources}
-    >
-      <Axis units={AxisUnits.Bytes} label="bytes">
-        {nodeIDs.map((nid) => (
+            title="Bytes Read" />
           <Metric
             name="cr.node.sys.host.disk.write.bytes"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={[nid]}
-            nonNegativeRate
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
+            title="Bytes Written" />
+        </Axis>
+      </LineGraph>,
+    );
+  } else {
+    charts.push(
+      <LineGraph
+        title="Disk Throughput"
+        subtitle="Reads"
+        sources={nodeSources}
+      >
+        <Axis units={AxisUnits.Bytes} label="throughput">
+          {nodeIDs.map((nid) => (
+            <Metric
+              name="cr.node.sys.host.disk.read.bytes"
+              title={nodeDisplayName(nodesSummary, nid)}
+              sources={[nid]}
+              nonNegativeRate
+            />
+          ))}
+        </Axis>
+      </LineGraph>,
+    );
+    charts.push(
+      <LineGraph
+        title="Disk Throughput"
+        subtitle="Writes"
+        sources={nodeSources}
+      >
+        <Axis units={AxisUnits.Bytes} label="bytes">
+          {nodeIDs.map((nid) => (
+            <Metric
+              name="cr.node.sys.host.disk.write.bytes"
+              title={nodeDisplayName(nodesSummary, nid)}
+              sources={[nid]}
+              nonNegativeRate
+            />
+          ))}
+        </Axis>
+      </LineGraph>,
+    );
+  }
 
-    <LineGraph
-      title="Disk Read Ops"
-      sources={nodeSources}
-    >
-      <Axis units={AxisUnits.Count} label="Read Ops">
-        {nodeIDs.map((nid) => (
+  if (props.aggregationLevel === AggregationLevel.Cluster) {
+    charts.push(
+      <LineGraph
+        title="Disk Ops"
+        sources={nodeSources}
+      >
+        <Axis units={AxisUnits.Count} label="Read Ops">
           <Metric
             name="cr.node.sys.host.disk.read.count"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={[nid]}
-            nonNegativeRate
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Disk Write Ops"
-      sources={nodeSources}
-    >
-      <Axis units={AxisUnits.Count} label="Write Ops">
-        {nodeIDs.map((nid) => (
+            title="Disk Read Operations" />
           <Metric
             name="cr.node.sys.host.disk.write.count"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={[nid]}
-            nonNegativeRate
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
+            title="Disk Write Operations" />
+        </Axis>
+      </LineGraph>,
+    );
+  } else {
+    charts.push(
+      <LineGraph
+        title="Disk Ops"
+        subtitle="Reads"
+        sources={nodeSources}
+      >
+        <Axis units={AxisUnits.Count} label="Read Ops">
+          {nodeIDs.map((nid) => (
+            <Metric
+              name="cr.node.sys.host.disk.read.count"
+              title={nodeDisplayName(nodesSummary, nid)}
+              sources={[nid]}
+              nonNegativeRate
+            />
+          ))}
+        </Axis>
+      </LineGraph>,
+    );
+    charts.push(
+      <LineGraph
+        title="Disk Ops"
+        subtitle="Writes"
+        sources={nodeSources}
+      >
+        <Axis units={AxisUnits.Count} label="Write Ops">
+          {nodeIDs.map((nid) => (
+            <Metric
+              name="cr.node.sys.host.disk.write.count"
+              title={nodeDisplayName(nodesSummary, nid)}
+              sources={[nid]}
+              nonNegativeRate
+            />
+          ))}
+        </Axis>
+      </LineGraph>,
+    );
+  }
 
-    <LineGraph
-      title="Disk IOPS In Progress"
-      sources={nodeSources}
-    >
-      <Axis units={AxisUnits.Count} label="IOPS">
-        {nodeIDs.map((nid) => (
+  if (props.aggregationLevel === AggregationLevel.Cluster) {
+    charts.push(
+      <LineGraph
+        title="Disk IOPS In Progress"
+        sources={nodeSources}
+      >
+        <Axis units={AxisUnits.Count} label="IOPS">
           <Metric
             name="cr.node.sys.host.disk.iopsinprogress"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={[nid]}
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
+            title="IOPS in Progress" />
+        </Axis>
+      </LineGraph>,
+    );
+  } else {
+    charts.push(
+      <LineGraph
+        title="Disk IOPS In Progress"
+        sources={nodeSources}
+      >
+        <Axis units={AxisUnits.Count} label="IOPS">
+          {nodeIDs.map((nid) => (
+            <Metric
+              name="cr.node.sys.host.disk.iopsinprogress"
+              title={nodeDisplayName(nodesSummary, nid)}
+              sources={[nid]}
+            />
+          ))}
+        </Axis>
+      </LineGraph>,
+    );
+  }
 
-    <LineGraph
-      title="Available Disk Capacity"
-      sources={storeSources}
-    >
-      <Axis units={AxisUnits.Bytes} label="capacity">
-        {nodeIDs.map((nid) => (
+  if (props.aggregationLevel === AggregationLevel.Cluster) {
+    charts.push(
+      <LineGraph
+        title="Available Disk Capacity"
+        sources={storeSources}
+      >
+        <Axis units={AxisUnits.Bytes} label="capacity">
           <Metric
             name="cr.store.capacity.available"
-            sources={storeIDsForNode(nodesSummary, nid)}
-            title={nodeDisplayName(nodesSummary, nid)}
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
+            title="Available" />
+          <Metric
+            name="cr.store.capacity.used"
+            title="Used" />
+        </Axis>
+      </LineGraph>,
+    );
+  } else {
+    charts.push(
+      <LineGraph
+        title="Available Disk Capacity"
+        sources={storeSources}
+      >
+        <Axis units={AxisUnits.Bytes} label="capacity">
+          {nodeIDs.map((nid) => (
+            <Metric
+              name="cr.store.capacity.available"
+              sources={storeIDsForNode(nodesSummary, nid)}
+              title={nodeDisplayName(nodesSummary, nid)}
+            />
+          ))}
+        </Axis>
+      </LineGraph>,
+    );
+  }
 
-    <LineGraph
-      title="Network Bytes Received"
-      sources={nodeSources}
-    >
-      <Axis units={AxisUnits.Bytes} label="bytes">
-        {nodeIDs.map((nid) => (
+  if (props.aggregationLevel === AggregationLevel.Cluster) {
+    charts.push(
+      <LineGraph
+        title="Network Throughput"
+        sources={nodeSources}
+      >
+        <Axis units={AxisUnits.Bytes} label="bytes">
           <Metric
             name="cr.node.sys.host.net.recv.bytes"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={[nid]}
-            nonNegativeRate
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Network Bytes Sent"
-      sources={nodeSources}
-    >
-      <Axis units={AxisUnits.Bytes} label="bytes">
-        {nodeIDs.map((nid) => (
+            title="Bytes Received" />
           <Metric
             name="cr.node.sys.host.net.send.bytes"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={[nid]}
-            nonNegativeRate
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
-  ];
+            title="Bytes Sent" />
+        </Axis>
+      </LineGraph>,
+    );
+  } else {
+    charts.push(
+      <LineGraph
+        title="Network Throughput"
+        subtitle="Received"
+        sources={nodeSources}
+      >
+        <Axis units={AxisUnits.Bytes} label="bytes">
+          {nodeIDs.map((nid) => (
+            <Metric
+              name="cr.node.sys.host.net.recv.bytes"
+              title={nodeDisplayName(nodesSummary, nid)}
+              sources={[nid]}
+              nonNegativeRate
+            />
+          ))}
+        </Axis>
+      </LineGraph>,
+    );
+    charts.push(
+      <LineGraph
+        title="Network Throughput"
+        subtitle="Sent"
+        sources={nodeSources}
+      >
+        <Axis units={AxisUnits.Bytes} label="bytes">
+          {nodeIDs.map((nid) => (
+            <Metric
+              name="cr.node.sys.host.net.send.bytes"
+              title={nodeDisplayName(nodesSummary, nid)}
+              sources={[nid]}
+              nonNegativeRate
+            />
+          ))}
+        </Axis>
+      </LineGraph>,
+    );
+  }
+
+  return charts;
 }

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import _ from "lodash";
 
 import { AggregationLevel } from "src/redux/aggregationLevel";
-import { LineGraph } from "src/views/cluster/components/linegraph";
+import { LineGraph, Group } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
 import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
@@ -59,6 +59,7 @@ export default function (props: GraphDashboardProps) {
         tooltip={
           `The total amount of SQL client network traffic in bytes per second ${tooltipSelection}.`
         }
+        group={Group.Top}
       >
         <Axis units={AxisUnits.Bytes} label="byte traffic">
           {nodeIDs.map((nid) => (
@@ -79,6 +80,7 @@ export default function (props: GraphDashboardProps) {
         tooltip={
           `The total amount of SQL client network traffic in bytes per second ${tooltipSelection}.`
         }
+        group={Group.Bottom}
       >
         <Axis units={AxisUnits.Bytes} label="byte traffic">
           {nodeIDs.map((nid) => (

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -1,92 +1,178 @@
 import React from "react";
 import _ from "lodash";
 
+import { AggregationLevel } from "src/redux/aggregationLevel";
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
 import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
-  const { nodeIDs, nodesSummary, nodeSources, tooltipSelection } = props;
+  const { nodeIDs, nodesSummary, nodeSources, tooltipSelection, aggregationLevel } = props;
 
-  return [
+  function default_aggregate(name: string, title: string, otherProps?: { [key: string]: boolean }) {
+    if (aggregationLevel === AggregationLevel.Cluster) {
+      return (
+        <Metric name={name} title={title} sources={nodeSources} {...otherProps} />
+      );
+    }
+
+    return nodeIDs.map((nid) => (
+      <Metric name={name} title={nodeDisplayName(nodesSummary, nid)} sources={[nid]} {...otherProps} />
+    ));
+  }
+
+  const charts = [];
+
+  charts.push(
     <LineGraph
       title="SQL Connections"
-      sources={nodeSources}
       tooltip={`The total number of active SQL connections ${tooltipSelection}.`}
     >
       <Axis label="connections">
-        <Metric name="cr.node.sql.conns" title="Client Connections" />
+        {default_aggregate("cr.node.sql.conns", "Client Connections")}
       </Axis>
     </LineGraph>,
+  );
 
-    <LineGraph
-      title="SQL Byte Traffic"
-      sources={nodeSources}
-      tooltip={
-        `The total amount of SQL client network traffic in bytes per second ${tooltipSelection}.`
-      }
-    >
-      <Axis units={AxisUnits.Bytes} label="byte traffic">
-        <Metric name="cr.node.sql.bytesin" title="Bytes In" nonNegativeRate />
-        <Metric name="cr.node.sql.bytesout" title="Bytes Out" nonNegativeRate />
-      </Axis>
-    </LineGraph>,
+  if (aggregationLevel === AggregationLevel.Cluster) {
+    charts.push(
+      <LineGraph
+        title="SQL Byte Traffic"
+        sources={nodeSources}
+        tooltip={
+          `The total amount of SQL client network traffic in bytes per second ${tooltipSelection}.`
+        }
+      >
+        <Axis units={AxisUnits.Bytes} label="byte traffic">
+          <Metric name="cr.node.sql.bytesin" title="Bytes In" nonNegativeRate />
+          <Metric name="cr.node.sql.bytesout" title="Bytes Out" nonNegativeRate />
+        </Axis>
+      </LineGraph>,
+    );
+  } else {
+    charts.push(
+      <LineGraph
+        title="SQL Byte Traffic"
+        subtitle="In"
+        sources={nodeSources}
+        tooltip={
+          `The total amount of SQL client network traffic in bytes per second ${tooltipSelection}.`
+        }
+      >
+        <Axis units={AxisUnits.Bytes} label="byte traffic">
+          {nodeIDs.map((nid) => (
+            <Metric
+              name="cr.node.sql.bytesin"
+              title={nodeDisplayName(nodesSummary, nid)}
+              nonNegativeRate
+            />
+          ))}
+        </Axis>
+      </LineGraph>,
+    );
+    charts.push(
+      <LineGraph
+        title="SQL Byte Traffic"
+        subtitle="Out"
+        sources={nodeSources}
+        tooltip={
+          `The total amount of SQL client network traffic in bytes per second ${tooltipSelection}.`
+        }
+      >
+        <Axis units={AxisUnits.Bytes} label="byte traffic">
+          {nodeIDs.map((nid) => (
+            <Metric
+              name="cr.node.sql.bytesout"
+              title={nodeDisplayName(nodesSummary, nid)}
+              nonNegativeRate
+            />
+          ))}
+        </Axis>
+      </LineGraph>,
+    );
+  }
 
-    <LineGraph
-      title="SQL Queries"
-      sources={nodeSources}
-      tooltip={
-        `A ten-second moving average of the # of SELECT, INSERT, UPDATE, and DELETE statements
-        started per second ${tooltipSelection}.`
-      }
-    >
-      <Axis label="queries">
-        <Metric name="cr.node.sql.select.count" title="Selects" nonNegativeRate />
-        <Metric name="cr.node.sql.update.count" title="Updates" nonNegativeRate />
-        <Metric name="cr.node.sql.insert.count" title="Inserts" nonNegativeRate />
-        <Metric name="cr.node.sql.delete.count" title="Deletes" nonNegativeRate />
-      </Axis>
-    </LineGraph>,
+  if (props.aggregationLevel === AggregationLevel.Cluster) {
+    charts.push(
+      <LineGraph
+        title="Statements"
+        sources={nodeSources}
+        tooltip={
+          `A ten-second moving average of the count of SELECT, INSERT, UPDATE, and DELETE statements
+          started per second ${tooltipSelection}.`
+        }
+      >
+        <Axis label="statements">
+          <Metric name="cr.node.sql.select.count" title="Selects" nonNegativeRate />
+          <Metric name="cr.node.sql.update.count" title="Updates" nonNegativeRate />
+          <Metric name="cr.node.sql.insert.count" title="Inserts" nonNegativeRate />
+          <Metric name="cr.node.sql.delete.count" title="Deletes" nonNegativeRate />
+        </Axis>
+      </LineGraph>,
+    );
+  } else {
+    charts.push(
+      <LineGraph
+        title="Statements"
+        tooltip={
+          `A ten-second moving average of the count of SQL statements
+          started per second ${tooltipSelection}.`
+        }
+      >
+        <Axis label="statements">
+          {
+            _.map(nodeIDs, (node) => (
+              <Metric
+                key={node}
+                name="cr.node.sql.query.count"
+                title={nodeDisplayName(nodesSummary, node)}
+                sources={[node]}
+                nonNegativeRate
+              />
+            ))
+          }
+        </Axis>
+      </LineGraph>,
+    );
+  }
 
+  charts.push(
     <LineGraph
       title="SQL Query Errors"
       sources={nodeSources}
       tooltip={"The number of statements which returned a planning or runtime error."}
     >
       <Axis label="errors">
-        <Metric name="cr.node.sql.failure.count" title="Errors" nonNegativeRate />
+        {default_aggregate("cr.node.sql.failure.count", "Errors", { nonNegativeRate: true })}
       </Axis>
     </LineGraph>,
+  );
 
+  charts.push(
     <LineGraph
       title="Active Distributed SQL Queries"
       sources={nodeSources}
       tooltip={`The total number of distributed SQL queries currently running ${tooltipSelection}.`}
     >
       <Axis label="queries">
-        <Metric name="cr.node.sql.distsql.queries.active" title="Active Queries" />
+        {default_aggregate("cr.node.sql.distsql.queries.active", "Active Queries")}
       </Axis>
     </LineGraph>,
+  );
 
+  charts.push(
     <LineGraph
       title="Active Flows for Distributed SQL Queries"
       tooltip="The number of flows on each node contributing to currently running distributed SQL queries."
     >
       <Axis label="flows">
-        {
-          _.map(nodeIDs, (node) => (
-            <Metric
-              key={node}
-              name="cr.node.sql.distsql.flows.active"
-              title={nodeDisplayName(nodesSummary, node)}
-              sources={[node]}
-            />
-          ))
-        }
+        {default_aggregate("cr.node.sql.distsql.flows.active", "Flows")}
       </Axis>
     </LineGraph>,
+  );
 
+  charts.push(
     <LineGraph
       title="Service Latency: SQL, 99th percentile"
       tooltip={(
@@ -111,7 +197,9 @@ export default function (props: GraphDashboardProps) {
         }
       </Axis>
     </LineGraph>,
+  );
 
+  charts.push(
     <LineGraph
       title="Service Latency: SQL, 90th percentile"
       tooltip={(
@@ -136,7 +224,9 @@ export default function (props: GraphDashboardProps) {
         }
       </Axis>
     </LineGraph>,
+  );
 
+  charts.push(
     <LineGraph
       title="Service Latency: DistSQL, 99th percentile"
       tooltip={
@@ -158,7 +248,9 @@ export default function (props: GraphDashboardProps) {
         }
       </Axis>
     </LineGraph>,
+  );
 
+  charts.push(
     <LineGraph
       title="Service Latency: DistSQL, 90th percentile"
       tooltip={
@@ -180,7 +272,9 @@ export default function (props: GraphDashboardProps) {
         }
       </Axis>
     </LineGraph>,
+  );
 
+  charts.push(
     <LineGraph
       title="Execution Latency: 99th percentile"
       tooltip={
@@ -202,7 +296,9 @@ export default function (props: GraphDashboardProps) {
         }
       </Axis>
     </LineGraph>,
+  );
 
+  charts.push(
     <LineGraph
       title="Execution Latency: 90th percentile"
       tooltip={
@@ -224,7 +320,9 @@ export default function (props: GraphDashboardProps) {
         }
       </Axis>
     </LineGraph>,
+  );
 
+  charts.push(
     <LineGraph
       title="Transactions"
       sources={nodeSources}
@@ -240,15 +338,19 @@ export default function (props: GraphDashboardProps) {
         <Metric name="cr.node.sql.txn.abort.count" title="Aborts" nonNegativeRate />
       </Axis>
     </LineGraph>,
+  );
 
+  charts.push(
     <LineGraph
       title="Schema Changes"
       sources={nodeSources}
       tooltip={`The total number of DDL statements per second ${tooltipSelection}.`}
     >
       <Axis label="statements">
-        <Metric name="cr.node.sql.ddl.count" title="DDL Statements" nonNegativeRate />
+        {default_aggregate("cr.node.sql.ddl.count", "DDL Statements", { nonNegativeRate: true })}
       </Axis>
     </LineGraph>,
-  ];
+  );
+
+  return charts;
 }

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -3,7 +3,7 @@ import _ from "lodash";
 
 import { AggregationLevel } from "src/redux/aggregationLevel";
 import * as docsURL from "src/util/docs";
-import { LineGraph } from "src/views/cluster/components/linegraph";
+import { LineGraph, Group } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
 import { GraphDashboardProps, nodeDisplayName, storeIDsForNode } from "./dashboardUtils";
@@ -269,6 +269,7 @@ export default function (props: GraphDashboardProps) {
           `The number of successfully written time series samples, and number of errors attempting
           to write time series, per second ${tooltipSelection}.`
         }
+      group={Group.Top}
       >
         <Axis label="count">
           {nodeIDs.map((nid) => (
@@ -287,6 +288,7 @@ export default function (props: GraphDashboardProps) {
         title="Time Series"
         subtitle="Errors"
         sources={nodeSources}
+        group={Group.Bottom}
       >
         <Axis label="count">
           {nodeIDs.map((nid) => (

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -13,9 +13,11 @@ import {
 import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
 import { PageConfig, PageConfigItem } from "src/views/shared/components/pageconfig";
 import TimeScaleDropdown from "src/views/cluster/containers/timescale";
+import AggregationSelector from "src/views/shared/containers/aggregationSelector";
 import ClusterSummaryBar from "./summaryBar";
 
 import { AdminUIState } from "src/redux/state";
+import { AggregationLevel, selectAggregationLevel } from "src/redux/aggregationLevel";
 import { refreshNodes, refreshLiveness } from "src/redux/apiReducers";
 import { hoverStateSelector, HoverState, hoverOn, hoverOff } from "src/redux/hover";
 import { nodesSummarySelector, NodesSummary, LivenessStatus } from "src/redux/nodes";
@@ -72,6 +74,7 @@ interface NodeGraphsOwnProps {
   livenessQueryValid: boolean;
   nodesSummary: NodesSummary;
   hoverState: HoverState;
+  aggregationLevel: AggregationLevel;
 }
 
 type NodeGraphsProps = NodeGraphsOwnProps & RouterState;
@@ -145,7 +148,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
   }
 
   render() {
-    const { params, nodesSummary } = this.props;
+    const { params, nodesSummary, aggregationLevel } = this.props;
     const selectedDashboard = params[dashboardNameAttr];
     const dashboard = _.has(dashboards, selectedDashboard)
       ? selectedDashboard
@@ -179,6 +182,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
       nodeSources,
       storeSources,
       tooltipSelection,
+      aggregationLevel,
     };
 
     const forwardParams = {
@@ -224,6 +228,13 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
               onChange={this.dashChange}
             />
           </PageConfigItem>
+          {
+            nodeSources ? null : (
+              <PageConfigItem>
+                <AggregationSelector />
+              </PageConfigItem>
+            )
+          }
           <PageConfigItem>
             <TimeScaleDropdown />
           </PageConfigItem>
@@ -251,6 +262,7 @@ export default connect(
       nodesQueryValid: state.cachedData.nodes.valid,
       livenessQueryValid: state.cachedData.nodes.valid,
       hoverState: hoverStateSelector(state),
+      aggregationLevel: selectAggregationLevel(state),
     };
   },
   {

--- a/pkg/ui/src/views/devtools/containers/raftMessages/index.tsx
+++ b/pkg/ui/src/views/devtools/containers/raftMessages/index.tsx
@@ -5,6 +5,7 @@ import { connect } from "react-redux";
 import { InjectedRouter, RouterState } from "react-router";
 import { createSelector } from "reselect";
 
+import { AggregationLevel } from "src/redux/aggregationLevel";
 import { refreshNodes, refreshLiveness } from "src/redux/apiReducers";
 import { hoverStateSelector, HoverState, hoverOn as hoverOnAction, hoverOff as hoverOffAction } from "src/redux/hover";
 import { nodesSummarySelector, NodesSummary } from "src/redux/nodes";
@@ -124,6 +125,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
       nodeSources,
       storeSources,
       tooltipSelection,
+      aggregationLevel: AggregationLevel.Cluster,
     };
 
     // Generate graphs for the current dashboard, wrapping each one in a

--- a/pkg/ui/src/views/shared/containers/aggregationSelector/index.tsx
+++ b/pkg/ui/src/views/shared/containers/aggregationSelector/index.tsx
@@ -1,0 +1,54 @@
+import classNames from "classnames";
+import React from "react";
+import { connect } from "react-redux";
+
+import { AdminUIState } from "src/redux/state";
+import { AggregationLevel, selectAggregationLevel, setAggregationLevel } from "src/redux/aggregationLevel";
+
+import "./toggle.styl";
+
+interface AggregationSelectorProps {
+  aggregationLevel: AggregationLevel;
+  setAggregationLevel: typeof setAggregationLevel;
+}
+
+/**
+ * A component to choose the level at which aggregation takes place,
+ */
+class AggregationSelector extends React.Component<AggregationSelectorProps> {
+  setClusterAggregation = () => {
+    if (this.props.aggregationLevel !== AggregationLevel.Cluster) {
+      this.props.setAggregationLevel(AggregationLevel.Cluster);
+    }
+  }
+
+  setPerNodeAggregation = () => {
+    if (this.props.aggregationLevel !== AggregationLevel.Node) {
+      this.props.setAggregationLevel(AggregationLevel.Node);
+    }
+  }
+
+  render() {
+    const { aggregationLevel } = this.props;
+
+    const clusterClasses = classNames("toggle__option", { "toggle__option--selected": aggregationLevel === AggregationLevel.Cluster });
+    const perNodeClasses = classNames("toggle__option", { "toggle__option--selected": aggregationLevel === AggregationLevel.Node });
+
+    return <div className="toggle">
+      <span className={clusterClasses} onClick={this.setClusterAggregation}>Cluster</span>
+      <span className={perNodeClasses} onClick={this.setPerNodeAggregation}>Per Node</span>
+    </div>;
+  }
+}
+
+function mapStateToProps(state: AdminUIState) {
+  return {
+    aggregationLevel: selectAggregationLevel(state),
+  };
+}
+
+const actions = {
+  setAggregationLevel,
+};
+
+export default connect(mapStateToProps, actions)(AggregationSelector);

--- a/pkg/ui/src/views/shared/containers/aggregationSelector/toggle.styl
+++ b/pkg/ui/src/views/shared/containers/aggregationSelector/toggle.styl
@@ -1,0 +1,43 @@
+@require nib
+@require "~styl/base/palette.styl"
+
+$toggle-hover-color = darken($background-color, 2.5%)
+
+.toggle
+  text-transform uppercase
+  letter-spacing 2px
+  line-height 17px
+  padding 0
+  vertical-align middle
+  border 1px solid $button-border-color
+  border-radius 4px
+  display inline-flex
+  white-space nowrap
+  color $body-color
+
+  &__option
+    color $button-border-color
+    cursor pointer
+    border-right 1px solid $button-border-color
+
+    &:hover
+      background-color $toggle-hover-color
+      color $link-color
+
+    &:first-child
+      padding 12px 24px
+      border-top-left-radius 4px
+      border-bottom-left-radius 4px
+
+    &:last-child
+      padding 12px 24px
+      border-top-right-radius 4px
+      border-bottom-right-radius 4px
+      border-right none
+
+    &--selected
+      cursor default
+      color $link-color
+
+      &:hover
+        background-color $background-color


### PR DESCRIPTION
Adds a toggle to switch between cluster-wide aggregated data and per-node data for many of the charts on the time series dashboards.

Fixes: #14598
Fixes: #18452
Fixes: #20571

New:
![new-per-node](https://user-images.githubusercontent.com/793969/46106325-64857580-c1a6-11e8-94b2-abd3073e3ee6.png)

Old:
![old-no-per-node](https://user-images.githubusercontent.com/793969/46106313-5f282b00-c1a6-11e8-8126-3cf5632e791b.png)