### PR TITLE
packer: unbreak teamcity-image.sh

### DIFF
--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -82,7 +82,7 @@ cd "$repo"
 for branch in $(git branch --all --list --sort=-committerdate 'origin/release-*' | head -n1) master
 do
   git checkout "$branch"
-  COCKROACH_BUILDER_CCACHE=1 build/builder.sh make gotestdashi
+  COCKROACH_BUILDER_CCACHE=1 build/builder.sh make test testrace TESTS=-
   # TODO(benesch): store the postgres-test version somewhere more accessible.
   docker pull $(git grep cockroachdb/postgres-test -- '*.go' | sed -E 's/.*"([^"]*).*"/\1/') || true
 done


### PR DESCRIPTION
It was calling the nonexistent `make testdashi`. Instead, run `test` and
`testrace` without `TESTS=-` to produce the desired effect of warming
the caches.

Release note: None