### PR TITLE
release-2.1: sql: deflake TestShowTraceReplica

### DIFF
--- a/pkg/sql/show_trace_replica_test.go
+++ b/pkg/sql/show_trace_replica_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
@@ -42,7 +43,8 @@ func TestShowTraceReplica(t *testing.T) {
 	ctx := context.Background()
 	tsArgs := func(node string) base.TestServerArgs {
 		return base.TestServerArgs{
-			StoreSpecs: []base.StoreSpec{{InMemory: true, Attributes: roachpb.Attributes{Attrs: []string{node}}}},
+			ScanInterval: 200 * time.Millisecond,
+			StoreSpecs:   []base.StoreSpec{{InMemory: true, Attributes: roachpb.Attributes{Attrs: []string{node}}}},
 		}
 	}
 	tcArgs := base.TestClusterArgs{ServerArgsPerNode: map[int]base.TestServerArgs{


### PR DESCRIPTION
Backport 1/1 commits from #30696.

/cc @cockroachdb/release

---

Reduce the scan interval for this test to workaround a corner case in
replication which can make convergence of a replica to the desired node
take longer than expected. Specifically, in the case of a single replica
range, the lease can ping-pong between two nodes which are not valid for
the range and each cycle requires the scanner to pick the range up
fresh. We can't (easily) proactively add the range to the replicate queue
when the lease is transferred because the lease transfer happens before
Raft leadership is transferred and the filtering of unremovable replicas
requires Raft leadership.

Fixes #27599

Release note: None
