### PR TITLE
release-2.1: workload and tpcc roachtest fixes

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -254,7 +254,11 @@ func emitResolvedTimestamp(
 	// before emitting the resolved timestamp to the sink.
 	if jobProgressedFn != nil {
 		progressedClosure := func(ctx context.Context, d jobspb.ProgressDetails) hlc.Timestamp {
-			d.(*jobspb.Progress_Changefeed).Changefeed.ResolvedSpans = resolvedSpans
+			// TODO(dan): This was making enormous jobs rows, especially in
+			// combination with how many mvcc versions there are. Cut down on
+			// the amount of data used here dramatically and re-enable.
+			//
+			// d.(*jobspb.Progress_Changefeed).Changefeed.ResolvedSpans = resolvedSpans
 			return resolved
 		}
 		if err := jobProgressedFn(ctx, progressedClosure); err != nil {

--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -356,8 +356,12 @@ func MakeFixture(
 	g, gCtx := errgroup.WithContext(ctx)
 	for _, t := range gen.Tables() {
 		table := t
-		tableCSVPathsCh := make(chan string)
+		if t.InitialRows.Batch == nil {
+			return Fixture{}, errors.Errorf(
+				`make fixture is not supported for workload %s`, gen.Meta().Name)
+		}
 
+		tableCSVPathsCh := make(chan string)
 		g.Go(func() error {
 			defer close(tableCSVPathsCh)
 			if len(config.CSVServerURL) == 0 {

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -36,8 +36,11 @@ import (
 
 func registerTPCC(r *registry) {
 	runTPCC := func(ctx context.Context, t *test, c *cluster, warehouses int, extra string) {
-		nodes := c.nodes - 1
+		if !c.isLocal() {
+			c.RemountNoBarrier(ctx)
+		}
 
+		nodes := c.nodes - 1
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 		c.Start(ctx, c.Range(1, nodes))

--- a/pkg/workload/csv.go
+++ b/pkg/workload/csv.go
@@ -123,6 +123,9 @@ func HandleCSV(w http.ResponseWriter, req *http.Request, prefix string, meta Met
 	if table == nil {
 		return errors.Errorf(`could not find table %s in generator %s`, tableName, meta.Name)
 	}
+	if table.InitialRows.Batch == nil {
+		return errors.Errorf(`csv-server is not supported for workload %s`, meta.Name)
+	}
 
 	rowStart, rowEnd := 0, table.InitialRows.NumBatches
 	if vals, ok := req.Form[rowStartParam]; ok && len(vals) > 0 {


### PR DESCRIPTION
@nvanbenschoten I grabbed one of yours in here to avoid the merge conflict.

Backport:
  * 2/2 commits from "workload/tpcc: don't cancel in-flight txns after ramp period" (#29181)
  * 1/1 commits from "roachtest: fix tpcc-1000 cdc test" (#30440)
  * 1/1 commits from "workload: error instead of crash when initial data is not supported" (#30502)
  * 1/1 commits from "roachtest: test our expected max tpcc warehouses" (#30574)
  * 1/1 commits from "workloadccl: add a retry when looking for a fixture" (#30675)

Please see individual PRs for details.

/cc @cockroachdb/release
