### PR TITLE
storage: proactively add to replicate queue on leader acquisition

### DIFF
--- a/pkg/sql/show_trace_replica_test.go
+++ b/pkg/sql/show_trace_replica_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
@@ -43,8 +42,7 @@ func TestShowTraceReplica(t *testing.T) {
 	ctx := context.Background()
 	tsArgs := func(node string) base.TestServerArgs {
 		return base.TestServerArgs{
-			ScanInterval: 200 * time.Millisecond,
-			StoreSpecs:   []base.StoreSpec{{InMemory: true, Attributes: roachpb.Attributes{Attrs: []string{node}}}},
+			StoreSpecs: []base.StoreSpec{{InMemory: true, Attributes: roachpb.Attributes{Attrs: []string{node}}}},
 		}
 	}
 	tcArgs := base.TestClusterArgs{ServerArgsPerNode: map[int]base.TestServerArgs{


### PR DESCRIPTION
Proactively add replicas to the replicate queue on Raft leader
acquisition. This is done in order to speed up removal of a replica when
the replica to be removed is the leaseholder. When that happens the
leaseholder transfers the lease to another replica and after the lease
is transferred Raft leadership is transferred. Prior to this change the
system then had to wait for the scanner on the new leaseholder node to
pick up the replica and complete the removal. Note that we wait for Raft
leadership to transfer because removal of a replica requires the
leaseholder to also be the Raft leader due to the checks in
`filterUnremovableReplicas` which ensure we're not removing a replica
that is critical for quorum.

Fixes #30695

Release note: None