### PR TITLE
cli: Make "unknown sub-command" error clearer for empty subcommands

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -200,5 +200,5 @@ func usageAndErr(cmd *cobra.Command, args []string) error {
 	if err := cmd.Usage(); err != nil {
 		return err
 	}
-	return fmt.Errorf("unknown sub-command: %s", strings.Join(args, " "))
+	return fmt.Errorf("unknown sub-command: %q", strings.Join(args, " "))
 }


### PR DESCRIPTION
I ran `cockroach zone` to try and get the list of available sub-commands
printed as help text, but ended up getting confused by what it printed:

Error: unknown sub-command:
Failed running "zone"

I wasn't really sure what this meant. Now it'll print:

Error: unknown sub-command: ""
Failed running "zone"

It may also be better to say something like "unknown or missing
sub-command". Let me know if you'd prefer that.

Release note: None

---

Along these lines, how come the available subcommands don't get printed anymore? I can't get them listed either with `cockroach zone` or `cockroach zone -h`. I could have sworn we used to list them. Did cobra change? Maybe I'm conflating cockroach with other tools. It'd certainly be nice if we did, though.