### PR TITLE
release-2.1: storage: proactively add to replicate queue on leader acquisition

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -487,7 +487,7 @@ func WaitForInitialSplits(db *client.DB) error {
 		if length == bufSize {
 			continue
 		}
-		log.Infof(context.TODO(), "%s\n%s", err, buf)
+		log.Infof(context.TODO(), "%s\n%s", err, buf[:length])
 		return err
 	}
 }

--- a/pkg/sql/show_trace_replica_test.go
+++ b/pkg/sql/show_trace_replica_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
@@ -43,8 +42,7 @@ func TestShowTraceReplica(t *testing.T) {
 	ctx := context.Background()
 	tsArgs := func(node string) base.TestServerArgs {
 		return base.TestServerArgs{
-			ScanInterval: 200 * time.Millisecond,
-			StoreSpecs:   []base.StoreSpec{{InMemory: true, Attributes: roachpb.Attributes{Attrs: []string{node}}}},
+			StoreSpecs: []base.StoreSpec{{InMemory: true, Attributes: roachpb.Attributes{Attrs: []string{node}}}},
 		}
 	}
 	tcArgs := base.TestClusterArgs{ServerArgsPerNode: map[int]base.TestServerArgs{

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4229,13 +4229,22 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	r.mu.lastIndex = lastIndex
 	r.mu.lastTerm = lastTerm
 	r.mu.raftLogSize = raftLogSize
+	var becameLeader bool
 	if r.mu.leaderID != leaderID {
 		r.mu.leaderID = leaderID
 		// Clear the remote proposal set. Would have been nil already if not
 		// previously the leader.
 		r.mu.remoteProposals = nil
+		becameLeader = r.mu.leaderID == r.mu.replicaID
 	}
 	r.mu.Unlock()
+
+	// When becoming the leader, proactively add the replica to the replicate
+	// queue. We might have been handed leadership by a remote node which wanted
+	// to remove itself from the range.
+	if becameLeader && r.store.replicateQueue != nil {
+		r.store.replicateQueue.MaybeAdd(r, r.store.Clock().Now())
+	}
 
 	// Update raft log entry cache. We clear any older, uncommitted log entries
 	// and cache the latest ones.


### PR DESCRIPTION
Backport:
  * 1/1 commits from "server: avoid \"wall of black\" on test failure" (#30718)
  * 1/1 commits from "storage: proactively add to replicate queue on leader acquisition" (#30716)

Please see individual PRs for details.

/cc @cockroachdb/release
