### PR TITLE
release-2.1: server: avoid "wall of black" on test failure

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -487,7 +487,7 @@ func WaitForInitialSplits(db *client.DB) error {
 		if length == bufSize {
 			continue
 		}
-		log.Infof(context.TODO(), "%s\n%s", err, buf)
+		log.Infof(context.TODO(), "%s\n%s", err, buf[:length])
 		return err
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #30718.

/cc @cockroachdb/release

---

See #30660

Release note: None
