### PR TITLE
distsql: ignore misplanned ranges when planning locally

### DIFF
--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -117,6 +117,9 @@ type FlowCtx struct {
 
 	// traceKV is true if KV tracing was requested by the session.
 	traceKV bool
+
+	// local is true if this flow is being run as part of a local-only query.
+	local bool
 }
 
 // NewEvalCtx returns a modifiable copy of the FlowCtx's EvalContext.

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -434,6 +434,7 @@ func (ds *ServerImpl) setupFlow(
 		diskMonitor:    ds.DiskMonitor,
 		JobRegistry:    ds.ServerConfig.JobRegistry,
 		traceKV:        req.TraceKV,
+		local:          localState.IsLocal,
 	}
 	f := newFlow(flowCtx, ds.flowRegistry, syncFlowConsumer, localState.LocalProcs)
 	if err := f.setup(ctx, &req.Flow); err != nil {


### PR DESCRIPTION
cc @nvanbenschoten 

Release note: None