### PR TITLE
storage: fix split / split-queue race

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -327,12 +327,6 @@ func (ts *TestServer) Start(params base.TestServerArgs) error {
 		params.Stopper.AddCloser(stop.CloserFn(fn))
 	}
 
-	// TODO(peter): Remove once #29144 is understood / fixed.
-	if ts.Cfg.TestingKnobs.Store == nil {
-		ts.Cfg.TestingKnobs.Store = &storage.StoreTestingKnobs{}
-	}
-	ts.Cfg.TestingKnobs.Store.(*storage.StoreTestingKnobs).VerboseSplitQueue = true
-
 	// Needs to be called before NewServer to ensure resolvers are initialized.
 	if err := ts.Cfg.InitNode(); err != nil {
 		return err

--- a/pkg/server/testserver_test.go
+++ b/pkg/server/testserver_test.go
@@ -1,0 +1,30 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestServerTest(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+}

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -3105,3 +3105,16 @@ func TestRangeLookupAsyncResolveIntent(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// Verify that replicas don't temporrily disappear from the replicas map during
+// the splits. See #29144.
+func TestStoreSplitDisappearingReplicas(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+	store, _ := createTestStore(t, stopper)
+	go storage.WatchForDisappearingReplicas(t, store)
+	if err := server.WaitForInitialSplits(store.DB()); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -644,7 +644,12 @@ func (bq *baseQueue) processLoop(stopper *stop.Stopper) {
 				} else {
 					// lastDur will be 0 after the first processing attempt.
 					lastDur := bq.lastProcessDuration()
-					nextTime = time.After(bq.impl.timer(lastDur))
+					switch t := bq.impl.timer(lastDur); t {
+					case 0:
+						nextTime = immediately
+					default:
+						nextTime = time.After(t)
+					}
 				}
 			}
 		}

--- a/pkg/storage/split_queue.go
+++ b/pkg/storage/split_queue.go
@@ -52,7 +52,6 @@ type splitQueue struct {
 	*baseQueue
 	db       *client.DB
 	purgChan <-chan time.Time
-	verbose  bool
 }
 
 // newSplitQueue returns a new instance of splitQueue.
@@ -112,9 +111,6 @@ func (sq *splitQueue) shouldQueue(
 	ctx context.Context, now hlc.Timestamp, repl *Replica, sysCfg *config.SystemConfig,
 ) (shouldQ bool, priority float64) {
 	shouldQ, priority = shouldSplitRange(repl.Desc(), repl.GetMVCCStats(), repl.GetMaxBytes(), sysCfg)
-	if sq.verbose {
-		log.Infof(ctx, "shouldQueue: shouldQ=%t priority=%.1f", shouldQ, priority)
-	}
 	return shouldQ, priority
 }
 
@@ -161,13 +157,7 @@ func (sq *splitQueue) processAttempt(
 			},
 			desc,
 		); err != nil {
-			if sq.verbose {
-				log.Infof(ctx, "split failed: %v", err)
-			}
 			return errors.Wrapf(err, "unable to split %s at key %q", r, splitKey)
-		}
-		if sq.verbose {
-			log.Infof(ctx, "split done")
 		}
 		return nil
 	}
@@ -183,17 +173,7 @@ func (sq *splitQueue) processAttempt(
 			roachpb.AdminSplitRequest{},
 			desc,
 		)
-		if sq.verbose {
-			if err != nil {
-				log.Infof(ctx, "split failed: %v", err)
-			} else {
-				log.Infof(ctx, "split done")
-			}
-		}
 		return err
-	}
-	if sq.verbose {
-		log.Infof(ctx, "split: nothing to do")
 	}
 	return nil
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -793,9 +793,6 @@ type StoreTestingKnobs struct {
 	DisableReplicaRebalancing bool
 	// DisableSplitQueue disables the split queue.
 	DisableSplitQueue bool
-	// VerboseSplitQueue enables verbose logging for the split queue. See
-	// #29144. TODO(peter): remove when that issue is understood / fixed.
-	VerboseSplitQueue bool
 	// DisableTimeSeriesMaintenanceQueue disables the time series maintenance
 	// queue.
 	DisableTimeSeriesMaintenanceQueue bool
@@ -1044,9 +1041,6 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 	}
 	if cfg.TestingKnobs.DisableSplitQueue {
 		s.setSplitQueueActive(false)
-	}
-	if cfg.TestingKnobs.VerboseSplitQueue {
-		s.splitQueue.verbose = true
 	}
 	if cfg.TestingKnobs.DisableTimeSeriesMaintenanceQueue {
 		s.setTimeSeriesMaintenanceQueueActive(false)


### PR DESCRIPTION
Fix a race during splits where the right-hand side of a split was
temporarily removed from the Store.mu.replicas map when the split was being
committed, opening a tiny window where that replica could be added to a
queue (e.g. the split queue) but not be present when it came time to
process the replica. The fix is to simply not perform this temporary
removal from Store.mu.replicas and instead adjust adding a replica to
Store.mu.replicas to be successful if the replica either doesn't exist in
the map, or does exist and is the same object (pointer equality).

Fixes #30660 Fixes #29144

Release note: None