### PR TITLE
backport-2.1: sql: disallow RESET CLUSTER SETTING version

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cluster_version
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_version
@@ -71,3 +71,6 @@ SET CLUSTER SETTING version = '1.1'
 
 statement error cannot upgrade to 1.1-999: node running 1.1
 SET CLUSTER SETTING version = '1.1-999'
+
+statement error cannot RESET this cluster setting
+RESET CLUSTER SETTING version

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -89,6 +89,8 @@ func (p *planner) SetClusterSetting(
 			}
 
 			value = typed
+		} else if _, isStateMachineSetting := setting.(*settings.StateMachineSetting); isStateMachineSetting {
+			return nil, errors.New("cannot RESET this cluster setting")
 		}
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #30720.

/cc @cockroachdb/release

---

Fixes #27883.

Release note: None
