### PR TITLE
release-2.1: roachtest: don't include "parent" tests in slack summary

### DIFF
--- a/pkg/cmd/roachtest/slack.go
+++ b/pkg/cmd/roachtest/slack.go
@@ -54,11 +54,12 @@ func sortTests(tests []*test) {
 	})
 }
 
-func postSlackReport(pass, fail map[*test]struct{}, skip int) {
+func postSlackReport(pass, fail, skip map[*test]struct{}) {
 	var stablePass []*test
 	var stableFail []*test
 	var unstablePass []*test
 	var unstableFail []*test
+	var skipped []*test
 	for t := range pass {
 		if t.spec.Stable {
 			stablePass = append(stablePass, t)
@@ -72,6 +73,9 @@ func postSlackReport(pass, fail map[*test]struct{}, skip int) {
 		} else {
 			unstableFail = append(unstableFail, t)
 		}
+	}
+	for t := range skip {
+		skipped = append(skipped, t)
 	}
 
 	client := makeSlackClient()
@@ -93,7 +97,7 @@ func postSlackReport(pass, fail map[*test]struct{}, skip int) {
 		branch = b
 	}
 	message := fmt.Sprintf("%s: %d passed, %d failed, %d skipped",
-		branch, len(stablePass), len(stableFail), skip)
+		branch, len(stablePass), len(stableFail), len(skipped))
 
 	{
 		status := "good"
@@ -123,6 +127,7 @@ func postSlackReport(pass, fail map[*test]struct{}, skip int) {
 		{stableFail, "Failures", "danger"},
 		{unstablePass, "Successes [unstable]", "good"},
 		{unstableFail, "Failures [unstable]", "warning"},
+		{skipped, "Skipped", "warning"},
 	}
 	for _, d := range data {
 		if len(d.tests) > 0 {


### PR DESCRIPTION
Backport 1/1 commits from #30803.

/cc @cockroachdb/release

---

This mirrors the behavior for issue posting which only posts about
failures for tests with a Run function.

Rework how skipped tests are reported. The previous reporting of the
number of skipped tests has been broken since the introduction of
subtests. Now we also report the names of the skipped tests as a
reminder that they are skipped.

Fixes #30800

Release note: None
