### PR TITLE
sql: get rid of planCtx.validExtendedEvalCtx

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -184,7 +184,9 @@ func distChangefeedFlow(
 		finishedSetupFn = func() { resultsCh <- tree.Datums(nil) }
 	}
 
-	dsp.Run(planCtx, noTxn, &p, recv, evalCtx, finishedSetupFn)
+	// Copy the evalCtx, as dsp.Run() might change it.
+	evalCtxCopy := *evalCtx
+	dsp.Run(planCtx, noTxn, &p, recv, &evalCtxCopy, finishedSetupFn)
 	return resultRows.Err()
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -663,7 +663,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	// Now that we have a pgwire.Server (which has a sql.Server), we can close a
 	// circular dependency between the distsqlrun.Server and sql.Server and set
-	// SessionBoundInternalExecutorCtor.
+	// SessionBoundInternalExecutorFactory.
 	s.distSQLServer.ServerConfig.SessionBoundInternalExecutorFactory =
 		func(
 			ctx context.Context, sessionData *sessiondata.SessionData,
@@ -1530,6 +1530,8 @@ func (s *Server) Start(ctx context.Context) error {
 		*s.db,
 		s.node.Descriptor,
 		s.execCfg.DistSQLPlanner,
+		// We're reusing the ieFactory from the distSQLServer.
+		s.distSQLServer.ServerConfig.SessionBoundInternalExecutorFactory,
 	).Start(s.stopper)
 
 	s.distSQLServer.Start()

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -132,7 +132,7 @@ func (sc *SchemaChanger) runBackfill(
 	}
 	version := tableDesc.Version
 
-	log.VEventf(ctx, 0, "Running backfill for %q, v=%d, m=%d",
+	log.Infof(ctx, "Running backfill for %q, v=%d, m=%d",
 		tableDesc.Name, tableDesc.Version, sc.mutationID)
 
 	needColumnBackfill := false

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -1878,20 +1879,32 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 			err.(errorutil.UnexpectedWithIssueErr).SendReport(ex.Ctx(), &ex.server.cfg.Settings.SV)
 			return advanceInfo{}, err
 		}
-		if schemaChangeErr := ex.extraTxnState.schemaChangers.execSchemaChanges(
-			ex.Ctx(), ex.server.cfg, &ex.sessionTracing,
-		); schemaChangeErr != nil {
-			// We got a schema change error. We'll return it to the client as the
-			// result of the current statement - which is either the DDL statement or
-			// a COMMIT statement if the DDL was part of an explicit transaction. In
-			// the explicit transaction case, we return a funky error code to the
-			// client to seed fear about what happened to the transaction. The reality
-			// is that the transaction committed, but at least some of the staged
-			// schema changes failed. We don't have a good way to indicate this.
-			if implicitTxn {
-				res.SetError(schemaChangeErr)
-			} else {
-				res.SetError(sqlbase.NewStatementCompletionUnknownError(schemaChangeErr))
+		scc := &ex.extraTxnState.schemaChangers
+		if len(scc.schemaChangers) != 0 {
+			ieFactory := func(ctx context.Context, sd *sessiondata.SessionData) sqlutil.InternalExecutor {
+				ie := MakeSessionBoundInternalExecutor(
+					ctx,
+					sd,
+					ex.server,
+					ex.memMetrics,
+					ex.server.cfg.Settings)
+				return &ie
+			}
+			if schemaChangeErr := scc.execSchemaChanges(
+				ex.Ctx(), ex.server.cfg, &ex.sessionTracing, ieFactory,
+			); schemaChangeErr != nil {
+				// We got a schema change error. We'll return it to the client as the
+				// result of the current statement - which is either the DDL statement or
+				// a COMMIT statement if the DDL was part of an explicit transaction. In
+				// the explicit transaction case, we return a funky error code to the
+				// client to seed fear about what happened to the transaction. The reality
+				// is that the transaction committed, but at least some of the staged
+				// schema changes failed. We don't have a good way to indicate this.
+				if implicitTxn {
+					res.SetError(schemaChangeErr)
+				} else {
+					res.SetError(sqlbase.NewStatementCompletionUnknownError(schemaChangeErr))
+				}
 			}
 		}
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -965,7 +965,6 @@ func (ex *connExecutor) execWithDistSQLEngine(
 	planCtx.isLocal = !distribute
 	planCtx.planner = planner
 	planCtx.stmtType = recv.stmtType
-	planCtx.validExtendedEvalCtx = true
 
 	if len(planner.curPlan.subqueryPlans) != 0 {
 		evalCtxFactory := func() *extendedEvalContext {

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -470,11 +470,7 @@ func (dsp *DistSQLPlanner) checkSupportForNode(node planNode) (distRecommendatio
 type PlanningCtx struct {
 	ctx             context.Context
 	ExtendedEvalCtx *extendedEvalContext
-	// validExtendedEvalCtx is set to true if a flow can use the ExtendedEvalCtx
-	// of this PlanningCtx directly, without having to instantiate a new one. This
-	// is normally false, with the main exception of the ordinary SQL executor.
-	validExtendedEvalCtx bool
-	spanIter             distsqlplan.SpanResolverIterator
+	spanIter        distsqlplan.SpanResolverIterator
 	// NodeAddresses contains addresses for all NodeIDs that are referenced by any
 	// PhysicalPlan we generate with this context.
 	// Nodes that fail a health check have empty addresses.

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -33,9 +33,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
@@ -165,9 +165,7 @@ type ServerConfig struct {
 	// SessionBoundInternalExecutorFactory is used to construct session-bound
 	// executors. The idea is that a higher-layer binds some of the arguments
 	// required, so that users of ServerConfig don't have to care about them.
-	SessionBoundInternalExecutorFactory func(
-		ctx context.Context, sessionData *sessiondata.SessionData,
-	) sqlutil.InternalExecutor
+	SessionBoundInternalExecutorFactory sqlutil.SessionBoundInternalExecutorFactory
 }
 
 // ServerImpl implements the server for the distributed SQL APIs.
@@ -384,8 +382,8 @@ func (ds *ServerImpl) setupFlow(
 			},
 		}
 
-		evalPlanner := &dummyEvalPlanner{}
-		sequence := &dummySequenceOperators{}
+		evalPlanner := &sqlbase.DummyEvalPlanner{}
+		sequence := &sqlbase.DummySequenceOperators{}
 		evalCtx = &tree.EvalContext{
 			Settings:     ds.ServerConfig.Settings,
 			SessionData:  sd,
@@ -639,89 +637,6 @@ const (
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
 func (*TestingKnobs) ModuleTestingKnobs() {}
-
-var errEvalPlanner = errors.New("cannot backfill such evaluated expression")
-
-// Implements the tree.EvalPlanner interface by returning errors.
-type dummyEvalPlanner struct {
-}
-
-var _ tree.EvalPlanner = &dummyEvalPlanner{}
-
-// Implements the tree.EvalDatabase interface.
-func (ep *dummyEvalPlanner) ParseQualifiedTableName(
-	ctx context.Context, sql string,
-) (*tree.TableName, error) {
-	return nil, errEvalPlanner
-}
-
-// Implements the tree.EvalDatabase interface.
-func (ep *dummyEvalPlanner) LookupSchema(
-	ctx context.Context, dbName, scName string,
-) (bool, tree.SchemaMeta, error) {
-	return false, nil, errEvalPlanner
-}
-
-// Implements the tree.EvalDatabase interface.
-func (ep *dummyEvalPlanner) ResolveTableName(ctx context.Context, tn *tree.TableName) error {
-	return errEvalPlanner
-}
-
-// Implements the tree.EvalPlanner interface.
-func (ep *dummyEvalPlanner) ParseType(sql string) (coltypes.CastTargetType, error) {
-	return nil, errEvalPlanner
-}
-
-// Implements the tree.EvalPlanner interface.
-func (ep *dummyEvalPlanner) EvalSubquery(expr *tree.Subquery) (tree.Datum, error) {
-	return nil, errEvalPlanner
-}
-
-var errSequenceOperators = errors.New("cannot backfill such sequence operation")
-
-// Implements the tree.SequenceOperators interface by returning errors.
-type dummySequenceOperators struct {
-}
-
-// Implements the tree.EvalDatabase interface.
-func (so *dummySequenceOperators) ParseQualifiedTableName(
-	ctx context.Context, sql string,
-) (*tree.TableName, error) {
-	return nil, errSequenceOperators
-}
-
-// Implements the tree.EvalDatabase interface.
-func (so *dummySequenceOperators) ResolveTableName(ctx context.Context, tn *tree.TableName) error {
-	return errSequenceOperators
-}
-
-// Implements the tree.EvalDatabase interface.
-func (so *dummySequenceOperators) LookupSchema(
-	ctx context.Context, dbName, scName string,
-) (bool, tree.SchemaMeta, error) {
-	return false, nil, errSequenceOperators
-}
-
-// Implements the tree.SequenceOperators interface.
-func (so *dummySequenceOperators) IncrementSequence(
-	ctx context.Context, seqName *tree.TableName,
-) (int64, error) {
-	return 0, errSequenceOperators
-}
-
-// Implements the tree.SequenceOperators interface.
-func (so *dummySequenceOperators) GetLatestValueInSessionForSequence(
-	ctx context.Context, seqName *tree.TableName,
-) (int64, error) {
-	return 0, errSequenceOperators
-}
-
-// Implements the tree.SequenceOperators interface.
-func (so *dummySequenceOperators) SetSequenceValue(
-	ctx context.Context, seqName *tree.TableName, newVal int64, isCalled bool,
-) error {
-	return errSequenceOperators
-}
 
 // lazyInternalExecutor is a tree.SessionBoundInternalExecutor that initializes
 // itself only on the first call to QueryRow.

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -67,7 +67,6 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 	planCtx.ignoreClose = true
 	planCtx.planner = params.p
 	planCtx.stmtType = n.stmtType
-	planCtx.validExtendedEvalCtx = true
 
 	plan, err := distSQLPlanner.createPlanForNode(planCtx, n.plan)
 	if err != nil {

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -562,8 +562,10 @@ func scrubRunDistSQL(
 		p.extendedEvalCtx.Tracing,
 	)
 
+	// Copy the evalCtx, as dsp.Run() might change it.
+	evalCtxCopy := p.extendedEvalCtx
 	p.extendedEvalCtx.DistSQLPlanner.Run(
-		planCtx, p.txn, plan, recv, &p.extendedEvalCtx, nil /* finishedSetupFn */)
+		planCtx, p.txn, plan, recv, &evalCtxCopy, nil /* finishedSetupFn */)
 	if rowResultWriter.Err() != nil {
 		return rows, rowResultWriter.Err()
 	} else if rows.Len() == 0 {

--- a/pkg/sql/sqlbase/evalctx.go
+++ b/pkg/sql/sqlbase/evalctx.go
@@ -1,0 +1,109 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlbase
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/pkg/errors"
+)
+
+// DummySequenceOperators implements the tree.SequenceOperators interface by
+// returning errors.
+type DummySequenceOperators struct{}
+
+var _ tree.EvalDatabase = &DummySequenceOperators{}
+
+var errSequenceOperators = errors.New("cannot backfill such sequence operation")
+
+// ParseQualifiedTableName is part of the tree.EvalDatabase interface.
+func (so *DummySequenceOperators) ParseQualifiedTableName(
+	ctx context.Context, sql string,
+) (*tree.TableName, error) {
+	return nil, errSequenceOperators
+}
+
+// ResolveTableName is part of the tree.EvalDatabase interface.
+func (so *DummySequenceOperators) ResolveTableName(ctx context.Context, tn *tree.TableName) error {
+	return errSequenceOperators
+}
+
+// LookupSchema is part of the tree.EvalDatabase interface.
+func (so *DummySequenceOperators) LookupSchema(
+	ctx context.Context, dbName, scName string,
+) (bool, tree.SchemaMeta, error) {
+	return false, nil, errSequenceOperators
+}
+
+// IncrementSequence is part of the tree.SequenceOperators interface.
+func (so *DummySequenceOperators) IncrementSequence(
+	ctx context.Context, seqName *tree.TableName,
+) (int64, error) {
+	return 0, errSequenceOperators
+}
+
+// GetLatestValueInSessionForSequence implements the tree.SequenceOperators
+// interface.
+func (so *DummySequenceOperators) GetLatestValueInSessionForSequence(
+	ctx context.Context, seqName *tree.TableName,
+) (int64, error) {
+	return 0, errSequenceOperators
+}
+
+// SetSequenceValue implements the tree.SequenceOperators interface.
+func (so *DummySequenceOperators) SetSequenceValue(
+	ctx context.Context, seqName *tree.TableName, newVal int64, isCalled bool,
+) error {
+	return errSequenceOperators
+}
+
+// DummyEvalPlanner implements the tree.EvalPlanner interface by returning
+// errors.
+type DummyEvalPlanner struct{}
+
+var _ tree.EvalPlanner = &DummyEvalPlanner{}
+
+var errEvalPlanner = errors.New("cannot backfill such evaluated expression")
+
+// ParseQualifiedTableName is part of the tree.EvalDatabase interface.
+func (ep *DummyEvalPlanner) ParseQualifiedTableName(
+	ctx context.Context, sql string,
+) (*tree.TableName, error) {
+	return nil, errEvalPlanner
+}
+
+// LookupSchema is part of the tree.EvalDatabase interface.
+func (ep *DummyEvalPlanner) LookupSchema(
+	ctx context.Context, dbName, scName string,
+) (bool, tree.SchemaMeta, error) {
+	return false, nil, errEvalPlanner
+}
+
+// ResolveTableName is part of the tree.EvalDatabase interface.
+func (ep *DummyEvalPlanner) ResolveTableName(ctx context.Context, tn *tree.TableName) error {
+	return errEvalPlanner
+}
+
+// ParseType is part of the tree.EvalPlanner interface.
+func (ep *DummyEvalPlanner) ParseType(sql string) (coltypes.CastTargetType, error) {
+	return nil, errEvalPlanner
+}
+
+// EvalSubquery is part of the tree.EvalPlanner interface.
+func (ep *DummyEvalPlanner) EvalSubquery(expr *tree.Subquery) (tree.Datum, error) {
+	return nil, errEvalPlanner
+}

--- a/pkg/sql/sqlutil/internal_executor.go
+++ b/pkg/sql/sqlutil/internal_executor.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
@@ -54,3 +55,9 @@ type InternalExecutor interface {
 		ctx context.Context, opName string, txn *client.Txn, statement string, qargs ...interface{},
 	) (tree.Datums, error)
 }
+
+// SessionBoundInternalExecutorFactory is a function that produces a "session
+// bound" internal executor.
+type SessionBoundInternalExecutorFactory func(
+	context.Context, *sessiondata.SessionData,
+) InternalExecutor


### PR DESCRIPTION
validExtendedEvalCtx was specifying when an EvalCtx used for planning
could be used for plan execution (namely, for the DistSQL local flow).
The idea was that it could be used in certain circumstances, when it was
likely that the execution of a plan was not going to mutate it. When
that was not guaranteed, a new EvalCtx would be created for execution -
which costs some.
This patch removes this knob - it was too confusing. Instead, we're now
always reusing the evalCtx and a few places that do recursive planning
have been modified to make a copy of the evalCtx before recursing.

This necessitated some changes to the evalCtx used by schema changes -
as before it was getting away with a less-complete one because, if the
schema change was executing DistSQL flows, it would have gotten a better
one.

Release note: None