### PR TITLE
workload: Optimize ticking of histograms for large numbers of workers

### DIFF
--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -181,7 +181,8 @@ func (b *bank) Ops(urls []string, reg *workload.HistogramRegistry) (workload.Que
 			amount := rand.Intn(maxTransfer)
 			start := timeutil.Now()
 			_, err := updateStmt.Exec(from, to, amount)
-			hists.Get(`transfer`).Record(timeutil.Since(start))
+			elapsed := timeutil.Since(start)
+			hists.Get(`transfer`).Record(elapsed)
 			return err
 		}
 		ql.WorkerFns = append(ql.WorkerFns, workerFn)

--- a/pkg/workload/histogram.go
+++ b/pkg/workload/histogram.go
@@ -93,8 +93,8 @@ func (w *NamedHistogram) tick(fn func(h *hdrhistogram.Histogram)) {
 	w.mu.Lock()
 	h := w.mu.current
 	w.mu.current = newHistogram()
-	fn(h)
 	w.mu.Unlock()
+	fn(h)
 }
 
 // HistogramRegistry is a thread-safe enclosure for a (possibly large) number of

--- a/pkg/workload/histogram.go
+++ b/pkg/workload/histogram.go
@@ -74,10 +74,10 @@ func (w *NamedHistogram) Record(elapsed time.Duration) {
 // should be saved via the closure argument.
 func (w *NamedHistogram) tick(fn func(h *hdrhistogram.Histogram)) {
 	w.mu.Lock()
-	defer w.mu.Unlock()
 	h := w.mu.current
 	w.mu.current = newHistogram()
 	fn(h)
+	w.mu.Unlock()
 }
 
 // HistogramRegistry is a thread-safe enclosure for a (possibly large) number of

--- a/pkg/workload/interleavedpartitioned/interleavedpartitioned.go
+++ b/pkg/workload/interleavedpartitioned/interleavedpartitioned.go
@@ -402,7 +402,8 @@ func (w *interleavedPartitioned) Ops(
 			if err != nil {
 				return err
 			}
-			hists.Get(`delete`).Record(timeutil.Since(start))
+			elapsed := timeutil.Since(start)
+			hists.Get(`delete`).Record(elapsed)
 
 			return nil
 		}
@@ -515,7 +516,8 @@ func (w *interleavedPartitioned) Ops(
 			if err := tx.Commit(); err != nil {
 				return nil
 			}
-			hists.Get(`insert`).Record(timeutil.Since(start))
+			elapsed := timeutil.Since(start)
+			hists.Get(`insert`).Record(elapsed)
 			return nil
 		} else if opRand < w.insertPercent+w.retrievePercent { // retrieve
 			sessionID := w.randomSessionID(rng, w.pickLocality(rng, w.retrieveLocalPercent))
@@ -533,7 +535,8 @@ func (w *interleavedPartitioned) Ops(
 					return err
 				}
 			}
-			hists.Get(`retrieve`).Record(timeutil.Since(start))
+			elapsed := timeutil.Since(start)
+			hists.Get(`retrieve`).Record(elapsed)
 			return nil
 		} else if opRand < w.insertPercent+w.retrievePercent+w.updatePercent { // update
 			sessionID := w.randomSessionID(rng, w.pickLocality(rng, w.updateLocalPercent))
@@ -563,7 +566,8 @@ func (w *interleavedPartitioned) Ops(
 				return err
 			}
 			_, err = updateStatement2.ExecContext(ctx, randString(rng, 20), sessionID)
-			hists.Get(`updates`).Record(timeutil.Since(start))
+			elapsed := timeutil.Since(start)
+			hists.Get(`updates`).Record(elapsed)
 			return err
 		}
 

--- a/pkg/workload/jsonload/json.go
+++ b/pkg/workload/jsonload/json.go
@@ -224,7 +224,8 @@ func (o *jsonOp) run(ctx context.Context) error {
 		}
 		for rows.Next() {
 		}
-		o.hists.Get(`read`).Record(timeutil.Since(start))
+		elapsed := timeutil.Since(start)
+		o.hists.Get(`read`).Record(elapsed)
 		return rows.Err()
 	}
 	argCount := 2
@@ -252,7 +253,8 @@ func (o *jsonOp) run(ctx context.Context) error {
 	}
 	start := timeutil.Now()
 	_, err := o.writeStmt.Exec(args...)
-	o.hists.Get(`write`).Record(timeutil.Since(start))
+	elapsed := timeutil.Since(start)
+	o.hists.Get(`write`).Record(elapsed)
 	return err
 }
 

--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -216,7 +216,8 @@ func (o *kvOp) run(ctx context.Context) error {
 		}
 		for rows.Next() {
 		}
-		o.hists.Get(`read`).Record(timeutil.Since(start))
+		elapsed := timeutil.Since(start)
+		o.hists.Get(`read`).Record(elapsed)
 		return rows.Err()
 	}
 	const argCount = 2
@@ -228,7 +229,8 @@ func (o *kvOp) run(ctx context.Context) error {
 	}
 	start := timeutil.Now()
 	_, err := o.writeStmt.ExecContext(ctx, args...)
-	o.hists.Get(`write`).Record(timeutil.Since(start))
+	elapsed := timeutil.Since(start)
+	o.hists.Get(`write`).Record(elapsed)
 	return err
 }
 

--- a/pkg/workload/ledger/worker.go
+++ b/pkg/workload/ledger/worker.go
@@ -122,6 +122,7 @@ func (w *worker) run(ctx context.Context) error {
 	if _, err := t.run(w.config, w.db, w.rng); err != nil {
 		return errors.Wrapf(err, "error in %s", t.name)
 	}
-	w.hists.Get(t.name).Record(timeutil.Since(start))
+	elapsed := timeutil.Since(start)
+	w.hists.Get(t.name).Record(elapsed)
 	return nil
 }

--- a/pkg/workload/querybench/query_bench.go
+++ b/pkg/workload/querybench/query_bench.go
@@ -193,6 +193,7 @@ func (o *queryBenchWorker) run(ctx context.Context) error {
 	if err := rows.Err(); err != nil {
 		return err
 	}
-	o.hists.Get(stmt.name).Record(timeutil.Since(start))
+	elapsed := timeutil.Since(start)
+	o.hists.Get(stmt.name).Record(elapsed)
 	return nil
 }

--- a/pkg/workload/queue/queue.go
+++ b/pkg/workload/queue/queue.go
@@ -156,12 +156,14 @@ func (o *queueOp) run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	o.hists.Get("write").Record(timeutil.Since(startTime))
+	elapsed := timeutil.Since(startTime)
+	o.hists.Get("write").Record(elapsed)
 
 	// Delete batch which was just written.
 	startTime = timeutil.Now()
 	_, err = o.deleteStmt.Exec(end)
-	o.hists.Get(`delete`).Record(timeutil.Since(startTime))
+	elapsed = timeutil.Since(startTime)
+	o.hists.Get(`delete`).Record(elapsed)
 	return err
 }
 

--- a/pkg/workload/tpcc/worker.go
+++ b/pkg/workload/tpcc/worker.go
@@ -163,7 +163,8 @@ func (w *worker) run(ctx context.Context) error {
 		return errors.Wrapf(err, "error in %s", t.name)
 	}
 	if ctx.Err() == nil {
-		w.hists.Get(t.name).Record(timeutil.Since(start))
+		elapsed := timeutil.Since(start)
+		w.hists.Get(t.name).Record(elapsed)
 	}
 
 	if w.config.doWaits {

--- a/pkg/workload/ycsb/ycsb.go
+++ b/pkg/workload/ycsb/ycsb.go
@@ -293,7 +293,8 @@ func (yw *ycsbWorker) run(ctx context.Context) error {
 		return err
 	}
 
-	yw.hists.Get(string(op)).Record(timeutil.Since(start))
+	elapsed := timeutil.Since(start)
+	yw.hists.Get(string(op)).Record(elapsed)
 	return nil
 }
 


### PR DESCRIPTION
**workload: Avoid defer in NamedHistogram.tick**

Minor, but this was showing up on CPU profiles taking a little over 1%
of CPU. Given that the histogram ticking is CPU-bound for large tpc-c
invocations, saving 1% for basically zero effort seems worth it.

**workload: Use sync.Pool for hdr histograms**

The allocation of these histograms was taking about 20% of CPU on
locally simulated tpc-c 50k runs (not even including all the extra work
it imposed on the garbage collector). This drops newHistogram down to
7%, 6% of which is from the memory clearing done by
hdrhistogram.Reset().

This noticeably cuts down on the amount of output ticks that are skipped
by tpc-c 50k on my laptop, but doesn't totally eliminate them yet.

**workload: Paralellize ticking of different histograms**

This avoided skipped ticks when running on my laptop (with all actual
sql requests mocked out with a time.Sleep(25ms)). Before this, ticks
were only being printed every 3 or 4 seconds instead of every second.

This will also only scale so far and will probably need to be further
optimized in the future, but it appears to be good enough for 50k
warehouses, so it's good enough for now.

There's still some funniness going on at the start of runs, though, with
the first second or two being skipped and with some elevated latencies
about 10 seconds in (even though no real requests are being sent to a
database in this local testing).

**workload: Call callback without mutex held in NamedHistogram.tick**

**workload: Optimize locking in Histograms.Get**

Also avoid including locking in the timing. This has a very noticeable
effect on the tail latencies in my local 50k worker testing with the SQL
queries stubbed out.

---

Touches https://github.com/cockroachdb/cockroach/issues/30284#issuecomment-422801552