### PR TITLE
release-2.1: cli: Mark zone command deprecated so it doesn't show up in help text

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1808,7 +1808,6 @@ Available Commands:
 
   sql         open a sql shell
   user        get, set, list and remove users
-  zone        get, set, list and remove zones
   node        list, inspect or remove nodes
   dump        dump sql tables
 

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -318,9 +318,10 @@ var zoneCmds = []*cobra.Command{
 }
 
 var zoneCmd = &cobra.Command{
-	Use:   "zone",
-	Short: "get, set, list and remove zones",
-	RunE:  usageAndErr,
+	Use:        "zone",
+	Short:      "get, set, list and remove zones",
+	RunE:       usageAndErr,
+	Deprecated: "use SHOW ZONE and CONFIGURE ZONE commands in a SQL client instead.",
 }
 
 func init() {


### PR DESCRIPTION
Backport 1/1 commits from #30747.

/cc @cockroachdb/release

---

We had previously marked zone's subcommands as deprecated in
bfc190d964c66cb6d78b11a4900f290e96c01006, which meant they didn't show
up as available subcommands in the help text of `cockroach zone`.
However, there was no deprecation message on the zone command itself,
which made the lack of subcommands confusing, and also meant that it
showed up as a command in the help text of the top level `cockroach`
command. This fixes both issues.

Release note: None