### PR TITLE
backport-2.1: sql: make MakeMutationComplete return an error instead of panic

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -590,7 +590,9 @@ func runSchemaChangesInTxn(
 			}
 
 		}
-		tableDesc.MakeMutationComplete(m)
+		if err := tableDesc.MakeMutationComplete(m); err != nil {
+			return err
+		}
 	}
 	tableDesc.Mutations = nil
 

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -275,7 +275,9 @@ func ConvertBackfillError(
 			// of mutations if they have the mutation ID we're looking for.
 			break
 		}
-		desc.MakeMutationComplete(mutation)
+		if err := desc.MakeMutationComplete(mutation); err != nil {
+			return errors.Wrap(err, "backfill error")
+		}
 	}
 	return sqlbase.ConvertBatchError(ctx, desc, b)
 }

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1990,7 +1990,7 @@ func (desc *TableDescriptor) IsInterleaved() bool {
 }
 
 // MakeMutationComplete updates the descriptor upon completion of a mutation.
-func (desc *TableDescriptor) MakeMutationComplete(m DescriptorMutation) {
+func (desc *TableDescriptor) MakeMutationComplete(m DescriptorMutation) error {
 	switch m.Direction {
 	case DescriptorMutation_ADD:
 		switch t := m.Descriptor_.(type) {
@@ -1999,7 +1999,7 @@ func (desc *TableDescriptor) MakeMutationComplete(m DescriptorMutation) {
 
 		case *DescriptorMutation_Index:
 			if err := desc.AddIndex(*t.Index, false); err != nil {
-				panic(err)
+				return err
 			}
 		}
 
@@ -2011,6 +2011,7 @@ func (desc *TableDescriptor) MakeMutationComplete(m DescriptorMutation) {
 		// Nothing else to be done. The column/index was already removed from the
 		// set of column/index descriptors at mutation creation time.
 	}
+	return nil
 }
 
 // AddColumnMutation adds a column mutation to desc.Mutations.

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -235,7 +235,9 @@ func (p *planner) truncateTable(ctx context.Context, id sqlbase.ID, traceKV bool
 	// Resolve all outstanding mutations. Make all new schema elements
 	// public because the table is empty and doesn't need to be backfilled.
 	for _, m := range newTableDesc.Mutations {
-		newTableDesc.MakeMutationComplete(m)
+		if err := newTableDesc.MakeMutationComplete(m); err != nil {
+			return err
+		}
 	}
 	newTableDesc.Mutations = nil
 


### PR DESCRIPTION
Backport 1/1 commits from #30194.

/cc @cockroachdb/release

---

fixes #30187

I can't figure out why this panic is happening, but we really should not be panicking

Release note: None
