### PR TITLE
sql, pgwire: cancel sessions better

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -148,36 +148,38 @@ func (mux *safeServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 type Server struct {
 	nodeIDContainer base.NodeIDContainer
 
-	cfg                Config
-	st                 *cluster.Settings
-	mux                safeServeMux
-	clock              *hlc.Clock
-	rpcContext         *rpc.Context
-	grpc               *grpc.Server
-	gossip             *gossip.Gossip
-	nodeDialer         *nodedialer.Dialer
-	nodeLiveness       *storage.NodeLiveness
-	storePool          *storage.StorePool
-	tcsFactory         *kv.TxnCoordSenderFactory
-	distSender         *kv.DistSender
-	db                 *client.DB
-	pgServer           *pgwire.Server
-	distSQLServer      *distsqlrun.ServerImpl
-	node               *Node
-	registry           *metric.Registry
-	recorder           *status.MetricsRecorder
-	runtime            *status.RuntimeStatSampler
-	admin              *adminServer
-	status             *statusServer
-	authentication     *authenticationServer
-	initServer         *initServer
-	tsDB               *ts.DB
-	tsServer           ts.Server
-	raftTransport      *storage.RaftTransport
-	stopper            *stop.Stopper
-	execCfg            *sql.ExecutorConfig
-	internalExecutor   *sql.InternalExecutor
-	leaseMgr           *sql.LeaseManager
+	cfg              Config
+	st               *cluster.Settings
+	mux              safeServeMux
+	clock            *hlc.Clock
+	rpcContext       *rpc.Context
+	grpc             *grpc.Server
+	gossip           *gossip.Gossip
+	nodeDialer       *nodedialer.Dialer
+	nodeLiveness     *storage.NodeLiveness
+	storePool        *storage.StorePool
+	tcsFactory       *kv.TxnCoordSenderFactory
+	distSender       *kv.DistSender
+	db               *client.DB
+	pgServer         *pgwire.Server
+	distSQLServer    *distsqlrun.ServerImpl
+	node             *Node
+	registry         *metric.Registry
+	recorder         *status.MetricsRecorder
+	runtime          *status.RuntimeStatSampler
+	admin            *adminServer
+	status           *statusServer
+	authentication   *authenticationServer
+	initServer       *initServer
+	tsDB             *ts.DB
+	tsServer         ts.Server
+	raftTransport    *storage.RaftTransport
+	stopper          *stop.Stopper
+	execCfg          *sql.ExecutorConfig
+	internalExecutor *sql.InternalExecutor
+	leaseMgr         *sql.LeaseManager
+	// sessionRegistry can be queried for info on running SQL sessions. It is
+	// shared between the sql.Server and the statusServer.
 	sessionRegistry    *sql.SessionRegistry
 	jobRegistry        *jobs.Registry
 	engines            Engines
@@ -481,7 +483,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	storage.RegisterPerReplicaServer(s.grpc, s.node.perReplicaServer)
 	s.node.storeCfg.ClosedTimestamp.RegisterClosedTimestampServer(s.grpc)
 
-	s.sessionRegistry = sql.MakeSessionRegistry()
+	s.sessionRegistry = sql.NewSessionRegistry()
 	s.jobRegistry = jobs.MakeRegistry(
 		s.cfg.AmbientCtx,
 		s.stopper,


### PR DESCRIPTION
Before this patch, `cancel session <foo>` would cause a connExecutor's
context to be canceled. This patch switches it to cancel the pgwire
connection's ctx instead (which was a parent of the connExecutor's ctx;
now the two are the same), as nature intended. For example, reading from
the network connection should stop ASAP after `cancel session`. It also
opens to door to guaranteeing that the client using the respective
session is unblocked in a timely manner (by the server closing the
network connection), although that is not currently implemented (pgwire
will still wait for the connExecutor to react to cancelation and finish
its task before closing the net.Conn).
This patch also eliminates what I presume to have been a crash when
someone tries to cancel a "session" created by the InternalExecutor. It
will now be a no-op.
This patch also moves a cancelation callback out of
connExecutor.ctxHolder. I'm trying to get rid of that guy, which is how
this patch came to be.

I've also added a TODO with some thoughts on a better design for session
cancelation, originally expressed in
#23861 (comment).
FWIW, I've tried to be the change, but gave up for the moment.

Release note: None