### PR TITLE
build: fix exit status in teamcity-stress

### DIFF
--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -46,7 +46,7 @@ go install ./pkg/cmd/github-post
 # Use an `if` so that the `-e` option doesn't stop the script on error.
 if ! make stress PKG="$PKG" TESTTIMEOUT=40m GOFLAGS="$GOFLAGS" TAGS="$TAGS" STRESSFLAGS="-maxruns 100 -maxfails 1 -stderr $STRESSFLAGS" 2>&1 \
   | tee artifacts/stress.log; then
-  exit_status=$?
+  exit_status=${PIPESTATUS[0]}
   go tool test2json -t < artifacts/stress.log | github-post
   exit $exit_status
 fi


### PR DESCRIPTION
A buglet was introduced in #30030 that let this script always exit
zero. The problem is basically that the following script will never
exit nonzero, though that usually isn't the intention:

```
if ! false | tee foo.log; then
	exit_status=$?
	exit $exit_status
fi
```

This is because `$?` refers to the exit status of `tee`. We want
`${PIPESTATUS[0]}`.

cc @andreimatei 

Closes #30754.

Release note: None