### PR TITLE
scripts: fix a bug in the release note script

### DIFF
--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -313,10 +313,6 @@ def collect_authors(commit):
 
 def extract_release_notes(pr, title, commit):
     authors = collect_authors(commit)
-    if norelnote.search(commit.message) is not None:
-        # Explicitly no release note. Nothing to do.
-        # Just report the author(s).
-        return None, authors
 
     msglines = commit.message.split('\n')
     curnote = []


### PR DESCRIPTION
Prior to this patch, if an engineer mistakenly left the text "Release
note: none" inside their commit message, *while adding an actual
release note next to it*, the release note script would ignore the
actual release note.

For example, this is why the release note failed to pick up the
security fix prior to this change.

Release note: None