### PR TITLE
backport-2.1: distsqlrun: fix lookup join with limit

### DIFF
--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -351,12 +351,18 @@ func (jr *joinReader) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 		case jrCollectingUnmatched:
 			jr.runningState = jr.collectUnmatched()
 		case jrEmittingRows:
-			jr.runningState, row, meta = jr.emitRow()
+			jr.runningState, row = jr.emitRow()
 		default:
 			log.Fatalf(jr.Ctx, "unsupported state: %d", jr.runningState)
 		}
-		if row != nil || meta != nil {
-			return row, meta
+		if row == nil && meta == nil {
+			continue
+		}
+		if meta != nil {
+			return nil, meta
+		}
+		if outRow := jr.ProcessRowHelper(row); outRow != nil {
+			return outRow, nil
 		}
 	}
 	return nil, jr.DrainHelper()
@@ -504,11 +510,9 @@ func (jr *joinReader) performLookup() (joinReaderState, *ProducerMetadata) {
 				return jrStateUnknown, jr.DrainHelper()
 			}
 			if renderedRow != nil {
-				if row := jr.ProcessRowHelper(renderedRow); row != nil {
-					jr.toEmit = append(jr.toEmit, jr.out.rowAlloc.CopyRow(row))
-					if jr.emitted != nil {
-						jr.emitted[inputRowIdx] = true
-					}
+				jr.toEmit = append(jr.toEmit, jr.out.rowAlloc.CopyRow(renderedRow))
+				if jr.emitted != nil {
+					jr.emitted[inputRowIdx] = true
 				}
 			}
 		}
@@ -527,10 +531,8 @@ func (jr *joinReader) collectUnmatched() joinReaderState {
 	if jr.joinType == sqlbase.LeftOuterJoin {
 		for i := 0; i < len(jr.inputRows); i++ {
 			if !jr.emitted[i] {
-				if renderedRow := jr.renderUnmatchedRow(jr.inputRows[i], leftSide); renderedRow != nil {
-					if row := jr.ProcessRowHelper(renderedRow); row != nil {
-						jr.toEmit = append(jr.toEmit, jr.out.rowAlloc.CopyRow(row))
-					}
+				if row := jr.renderUnmatchedRow(jr.inputRows[i], leftSide); row != nil {
+					jr.toEmit = append(jr.toEmit, jr.out.rowAlloc.CopyRow(row))
 				}
 			}
 		}
@@ -540,21 +542,21 @@ func (jr *joinReader) collectUnmatched() joinReaderState {
 
 // emitRow returns the next row from jr.toEmit, if present. Otherwise it
 // prepares for another input batch.
-func (jr *joinReader) emitRow() (joinReaderState, sqlbase.EncDatumRow, *ProducerMetadata) {
+func (jr *joinReader) emitRow() (joinReaderState, sqlbase.EncDatumRow) {
 	if len(jr.toEmit) == 0 {
 		if jr.finalLookupBatch {
 			// Ready for another input batch. Reset state.
 			jr.inputRows = jr.inputRows[:0]
 			jr.keyToInputRowIndices = make(map[string][]int)
 			jr.finalLookupBatch = false
-			return jrReadingInput, nil, nil
+			return jrReadingInput, nil
 		}
 		// Process the next index lookup batch.
-		return jrPerformingLookup, nil, nil
+		return jrPerformingLookup, nil
 	}
 	row := jr.toEmit[0]
 	jr.toEmit = jr.toEmit[1:]
-	return jrEmittingRows, row, nil
+	return jrEmittingRows, row
 }
 
 func (jr *joinReader) hasNullLookupColumn(row sqlbase.EncDatumRow) bool {

--- a/pkg/sql/logictest/testdata/logic_test/distsql_lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_lookup_join
@@ -355,3 +355,26 @@ SELECT t1.c, t2.d FROM multiples t1 LEFT JOIN multiples@bc t2 ON t1.c = t2.b WHE
 ----
 6   12
 12  24
+
+# Regression test for #30812: make sure that lookup joins with limit don't
+# omit the final row.
+
+statement ok
+CREATE TABLE t_30182_l (id INT PRIMARY KEY, name TEXT NOT NULL)
+
+statement ok
+CREATE TABLE t_30182_r (id INT PRIMARY KEY, name TEXT NOT NULL, l_id int)
+
+statement ok
+INSERT INTO t_30182_l (id, name) values(1, 'a')
+
+statement ok
+INSERT INTO t_30182_r values(1, 'foo', 1);
+
+query ITI
+SELECT r.* FROM t_30182_r r
+JOIN t_30182_l l on r.l_id = l.id
+WHERE r.name = 'foo'
+LIMIT 1
+----
+1 foo 1


### PR DESCRIPTION
Backport 1/1 commits from #30819.

/cc @cockroachdb/release

---

Previously, lookup join used its processRowHelper in an inappropriate
place (not directly before returning a row) which caused the final rows
in a limit query to get omitted in certain cases. Correct this problem.

Fixes #30812.

Release note (bug fix): lookup joins no longer omit rows in certain
circumstances during limit queries.
