### PR TITLE
release-2.1: storage: Fix average qps metric

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4370,7 +4370,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	s.metrics.LeaseExpirationCount.Update(leaseExpirationCount)
 	s.metrics.LeaseEpochCount.Update(leaseEpochCount)
 	s.metrics.QuiescentCount.Update(quiescentCount)
-	s.metrics.AverageQueriesPerSecond.Update(averageWritesPerSecond)
+	s.metrics.AverageQueriesPerSecond.Update(averageQueriesPerSecond)
 	s.metrics.AverageWritesPerSecond.Update(averageWritesPerSecond)
 	s.recordNewPerSecondStats(averageQueriesPerSecond, averageWritesPerSecond)
 


### PR DESCRIPTION
Backport 1/1 commits from #30844.

/cc @cockroachdb/release

---

:facepalm:

We don't expose this in the admin UI (yet), so it isn't a very user
visible bug, but it affects our ability to inspect load-based
rebalancing decisions.

Release note: None
