### PR TITLE
ui: Add Average QPS per Store graph to Replication dashboard

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -57,6 +57,21 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
+    <LineGraph title="Average Queries per Store" tooltip={`Exponentially weighted moving average of the number of KV batch requests processed by leaseholder replicas on each store per second. Tracks roughly the last 30 minutes of requests. Used for load-based rebalancing decisions.`}>
+      <Axis label="queries">
+        {
+          _.map(nodeIDs, (nid) => (
+            <Metric
+              key={nid}
+              name="cr.store.rebalancing.queriespersecond"
+              title={nodeDisplayName(nodesSummary, nid)}
+              sources={storeIDsForNode(nodesSummary, nid)}
+            />
+          ))
+        }
+      </Axis>
+    </LineGraph>,
+
     <LineGraph title="Logical Bytes per Store" tooltip={`The number of logical bytes of data on each store.`}>
       <Axis units={AxisUnits.Bytes} label="logical store size">
         {


### PR DESCRIPTION
This has the potential to confuse people because it uses an EWMA rather
than an instantaneous measurement of QPS, but it's also helpful for
understanding the behavior of load-based lease and replica rebalancing,
which are now enabled by default.

Release note (admin ui change): Added graph of average QPS per store to
the Replication dashboard. Note that this uses an exponentially weighted
moving average, not an instantaneous measurement. It is primarily of
interest because it's the data that's used when making load-based
rebalancing decisions.