### PR TITLE
sql: add EXPLAIN(DISTSQL) support for subqueries

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -499,6 +499,10 @@ type PlanningCtx struct {
 	// keep track of whether it's valid to run a root node in a special fast path
 	// mode.
 	planDepth int
+
+	// noEvalSubqueries indicates that the plan expects any subqueries to not
+	// be replaced by evaluation. Should only be set by EXPLAIN.
+	noEvalSubqueries bool
 }
 
 var _ distsqlplan.ExprContext = &PlanningCtx{}
@@ -515,6 +519,14 @@ func (p *PlanningCtx) EvalContext() *tree.EvalContext {
 // has no remote flows.
 func (p *PlanningCtx) IsLocal() bool {
 	return p.isLocal
+}
+
+// EvaluateSubqueries returns true if this plan requires subqueries be fully
+// executed before trying to marshal. This is normally true except for in the
+// case of EXPLAIN queries, which ultimately want to describe the subquery that
+// will run, without actually running it.
+func (p *PlanningCtx) EvaluateSubqueries() bool {
+	return !p.noEvalSubqueries
 }
 
 // sanityCheckAddresses returns an error if the same address is used by two

--- a/pkg/sql/distsqlplan/utils_test.go
+++ b/pkg/sql/distsqlplan/utils_test.go
@@ -29,3 +29,7 @@ func (fakeExprContext) EvalContext() *tree.EvalContext {
 func (fakeExprContext) IsLocal() bool {
 	return false
 }
+
+func (fakeExprContext) EvaluateSubqueries() bool {
+	return true
+}

--- a/pkg/sql/distsqlrun/data.go
+++ b/pkg/sql/distsqlrun/data.go
@@ -116,7 +116,7 @@ func (e *Expression) Empty() bool {
 func (e Expression) String() string {
 	if e.LocalExpr != nil {
 		buf := bytes.Buffer{}
-		ctx := ExprFmtCtxBase(&buf, &tree.EvalContext{})
+		ctx := tree.MakeFmtCtx(&buf, tree.FmtCheckEquivalence)
 		ctx.FormatNode(e.LocalExpr)
 		return ctx.String()
 	} else if e.Expr != "" {

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -46,9 +46,10 @@ func (p *planner) Explain(ctx context.Context, n *tree.Explain) (planNode, error
 			return nil, err
 		}
 		return &explainDistSQLNode{
-			plan:     plan,
-			analyze:  analyze,
-			stmtType: n.Statement.StatementType(),
+			plan:          plan,
+			subqueryPlans: p.curPlan.subqueryPlans,
+			analyze:       analyze,
+			stmtType:      n.Statement.StatementType(),
 		}, nil
 
 	case tree.ExplainPlan:

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -33,14 +33,31 @@ EXPLAIN ANALYZE (DISTSQL) UPSERT INTO a VALUES(10)
 statement error EXPLAIN ANALYZE does not support RETURNING NOTHING statements
 EXPLAIN ANALYZE (DISTSQL) UPSERT INTO a VALUES(11) RETURNING NOTHING
 
-# Enable once #29350 is fixed, this fails with
-# pq: programming error: invalid index 1 for "<unknown>" when run with the
-# optimizer.
-# statement ok
-# EXPLAIN ANALYZE (DISTSQL) SELECT (SELECT 1);
+statement ok
+EXPLAIN ANALYZE (DISTSQL) SELECT (SELECT 1);
 
 statement ok
 EXPLAIN ANALYZE (DISTSQL) DELETE FROM a
 
 statement ok
 EXPLAIN ANALYZE (DISTSQL) DROP TABLE a
+
+# Tests with EXPLAIN ANALYZE and subqueries.
+
+statement ok
+CREATE TABLE a (a INT PRIMARY KEY)
+
+statement ok
+INSERT INTO a VALUES(1)
+
+statement ok
+PREPARE x AS EXPLAIN ANALYZE(DISTSQL) SELECT 1 WHERE EXISTS (SELECT * FROM a WHERE a = $1) AND EXISTS (SELECT 1 WHERE EXISTS (SELECT * FROM a WHERE a = $2))
+
+statement ok
+EXECUTE x(1, 2)
+
+statement ok
+PREPARE y AS EXPLAIN ANALYZE(DISTSQL) SELECT 1 WHERE EXISTS (SELECT * FROM a WHERE a = $1) AND EXISTS (SELECT 1 WHERE EXISTS (SELECT * FROM a WHERE a = $1))
+
+statement ok
+EXECUTE x(1, 1)

--- a/pkg/sql/logictest/testdata/planner_test/distsql_subquery
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_subquery
@@ -1,0 +1,37 @@
+# LogicTest: 5node-dist 5node-dist-opt
+
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT 1 WHERE EXISTS (SELECT 1)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJyMj0FLxDAUhO_-ijCnFQKm13dUKhRklW0RQXIoyWMt1qTkJSAs_e_S5iAehD3OfMnMvAtC9Hwcv1hA72hgNZYUHYvEtFn1Qee_QUZjCkvJm201XEwMuiBPeWYQXse5sNwZaHjO4zTviUbdq4NR7qOET7mFxuM0Z06k2reuH3p16Nun9mFQzcZOHPzGGiLqjgPsqhFL_u2UPJ4ZZFZ9_a4TyxKD8J9d_ydbDfZnrrdLLMnxS4pur6nyef-3G54lV9pU0YWKVrve_AQAAP__IpRvnA==
+
+statement ok
+CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
+
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT EXISTS (SELECT * FROM abc WHERE a = 1)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJyMj0FLxDAUhO_-ijKnXQmYXgNelIgFdaVdVJAcYvJYizUpeQkIS_-7bHMQD4LH-SaZmXdEiJ4e7Ccx1CtaGIE5RUfMMZ1QfdD5LygpMIa55BM2Ai4mgjoij3kiKDzZqRBfSAh4ynac1kTZXDUb2bj3Ej54C4GegqekGv3SDfthM-g7fb0_v-l39_bNPd_qXtvLdguzCMSSf-o42wNByUX8f1JPPMfA9GvS38lGgPyB6tkcS3L0mKJba6rcrf9W4IlzddsqulCtxSxn3wEAAP__zL5u_w==
+
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM abc WHERE a = (SELECT max(a) FROM abc WHERE EXISTS(SELECT * FROM abc WHERE c=a+3))]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJyMUE9L_DAQvf8-RXin7c-ALd4CwoJ0saCutAUF6WGaDEuhbUqSwsrS7y5tQFEQPL4_82beXDBaw080sId6Q4ZGYnJWs_fWrVQ0FOYMlUp04zSHlW4ktHUMdUHoQs9QqKntuWQy7K5TSBgO1PVb7OS6gdz7nloNiUPXB3ZK7DNxK3ZV_pDf1WKg844ScSiPj4JaLV7u8zIX-WtR1dWn6f9PXa8JJK7ETZIkaBYJO4evE32gE0Nli_x7jZL9ZEfP3xr8lpwujQSbE8dXeTs7zc_O6m1NhMdtbiMM-xDVLIJijNLSLP8-AgAA__-7tHzp
+
+query T
+SELECT url FROM [EXPLAIN ANALYZE (DISTSQL) SELECT EXISTS (SELECT max(a) FROM abc)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJyMj0FLAzEUhO_-imVOLQRMr7m1ngriSiteJIclGerimix5LyCU_e_SzUE8CB7nm2Rm3hUpRz4NnxS4N-zgDeaSA0VyuaH24Bi_4KzBmOaqN-wNQi6Eu0JHnQiH12GqlHsLg0gdxmlNtN2h29guvNf0IVsYnJgii-se9ueXjZbK_fnQ949b-MUgV_0pEB0uhLOL-f-IE2XOSfhrxN_J3oDxwnao5FoCn0sOa02T_fpvBZGizd01cUzNWvxy9x0AAP__guVrPA==
+
+query T
+SELECT url FROM [EXPLAIN ANALYZE (DISTSQL) SELECT * FROM abc WHERE a = (SELECT max(a) FROM abc WHERE EXISTS(SELECT * FROM abc WHERE c=a+3))]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJyckEFLxDAQhe_-ivBOCgHba0DYRRAKS5XdepIess2wBNKmzKSoLPnv0uYg3mSP772ZNx9zxRQdtXYkgflAjV5j5jiQSOTVKgON-4KpNPw0L2m1e40hMsFckXwKBIPOngMdyTrixwoajpL1Yaud2Y-Wv3f2PEDjxYdEbNSuVk_qeX_q7tv3w0HtT6ppuwdocPwUxWSdUWuRJBuCSn4koypBnzXikn5BJNkLwdRZ_x_2SDLHSegv522Hq9xrkLtQ-ZfEhQd64zhsFEW-bnub4UhSSesimqlEuc93PwEAAP__33uBjw==
+
+
+# Ensure subquery outside of the explain doesn't mess anything up
+
+query TB
+SELECT url, exists (SELECT 1) FROM [EXPLAIN ANALYZE (DISTSQL) SELECT * FROM abc WHERE a = (SELECT max(a) FROM abc)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJyckEFLxDAQhe_-ivBOCgHba0DYRRAKS5XdepIess2wBNKmzKSoLPnv0uYg3mSP772ZNx9zxRQdtXYkgflAjV5j5jiQSOTVKgON-4KpNPw0L2m1e40hMsFckXwKBIPOngMdyTrixwoajpL1Yaud2Y-Wv3f2PEDjxYdEbNSuVk_qeX_q7tv3w0HtT6ppuwdocPwUxWSdUWuRJBuCSn4koypBnzXikn5BJNkLwdRZ_x_2SDLHSegv522Hq9xrkLtQ-ZfEhQd64zhsFEW-bnub4UhSSesimqlEuc93PwEAAP__33uBjw== true

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -690,12 +690,10 @@ func (ef *execFactory) ConstructExplain(
 
 	switch options.Mode {
 	case tree.ExplainDistSQL:
-		if len(p.subqueryPlans) > 0 {
-			return nil, fmt.Errorf("subqueries not supported yet")
-		}
 		return &explainDistSQLNode{
-			plan:    p.plan,
-			analyze: analyzeSet,
+			plan:          p.plan,
+			subqueryPlans: p.subqueryPlans,
+			analyze:       analyzeSet,
 		}, nil
 
 	case tree.ExplainPlan:


### PR DESCRIPTION
This currently does not provide the plans for the subqueries
themselves, just the outer query. But this no longer pops up the old
error message of "subqueries not supported", preventing a UX problem
where some queries are explainable and some are not.

Fixes #28729.

Release note: None