### PR TITLE
sql: whitelist system.rangelog to use table descriptor cache

### DIFF
--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -218,15 +218,17 @@ func (tc *TableCollection) getTableVersion(
 
 	// We don't go through the normal lease mechanism for system tables
 	// that are not the role members table.
-	if flags.avoidCached || testDisableTableLeases || (tn.Catalog() == sqlbase.SystemDB.Name &&
-		tn.TableName.String() != sqlbase.RoleMembersTable.Name) {
+	if flags.avoidCached || testDisableTableLeases ||
+		(tn.Catalog() == sqlbase.SystemDB.Name &&
+			tn.TableName.String() != sqlbase.RoleMembersTable.Name &&
+			tn.TableName.String() != sqlbase.RangeEventTable.Name) {
 		// TODO(vivek): Ideally we'd avoid caching for only the
 		// system.descriptor and system.lease tables, because they are
 		// used for acquiring leases, creating a chicken&egg problem.
 		// But doing so turned problematic and the tests pass only by also
-		// disabling caching of system.eventlog, system.rangelog, and
-		// system.users. For now we're sticking to disabling caching of
-		// all system descriptors except the role-members-table.
+		// disabling caching of system.eventlog and system.users. For
+		// now we're sticking to disabling caching of all system
+		// descriptors except a few whitelisted tables.
 		flags.avoidCached = true
 		phyAccessor := UncachedPhysicalAccessor{}
 		return phyAccessor.GetObjectDesc(tn, flags)


### PR DESCRIPTION
See https://github.com/cockroachdb/cockroach/issues/23937#issuecomment-417122933.

This speeds up `kv/splits/nodes=3` by 10%, dropping its runtime from
4598s to 4136s.

I hesitated on doing this because I'd much prefer a real fix for #23937,
but I guess that shouldn't prevent such an easy win.

Release note: None