### PR TITLE
encoding: use lookup table for PeekType

### DIFF
--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -1200,8 +1200,29 @@ const (
 	BitArrayDesc Type = 18 // BitArray encoded descendingly
 )
 
+// typMap maps an encoded type byte to a decoded Type. It's got 256 slots, one
+// for every possible byte value.
+var typMap [256]Type
+
+func init() {
+	buf := []byte{0}
+	for i := range typMap {
+		buf[0] = byte(i)
+		typMap[i] = slowPeekType(buf)
+	}
+}
+
 // PeekType peeks at the type of the value encoded at the start of b.
 func PeekType(b []byte) Type {
+	if len(b) >= 1 {
+		return typMap[b[0]]
+	}
+	return Unknown
+}
+
+// slowPeekType is the old implementation of PeekType. It's used to generate
+// the lookup table for PeekType.
+func slowPeekType(b []byte) Type {
 	if len(b) >= 1 {
 		m := b[0]
 		switch {

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -1172,6 +1172,17 @@ func TestPeekType(t *testing.T) {
 	}
 }
 
+var sink string
+
+func BenchmarkPeekType(b *testing.B) {
+	buf := EncodeVarintAscending(nil, 0)
+	var typ Type
+	for i := 0; i < b.N; i++ {
+		typ = PeekType(buf)
+	}
+	sink = string(typ)
+}
+
 type randData struct {
 	*rand.Rand
 }


### PR DESCRIPTION
It's faster than the switch statement, which had to do a lot of comparisons. Even making the switch statement not use arbitrary statements doesn't cause the compiler to make a lookup table, so we do it by hand.

```
name         old time/op    new time/op    delta
PeekType-24    4.92ns ± 0%    0.38ns ± 0%  -92.27%  (p=0.000 n=10+10)

name         old alloc/op   new alloc/op   delta
PeekType-24     0.00B          0.00B          ~     (all equal)

name         old allocs/op  new allocs/op  delta
PeekType-24      0.00           0.00          ~     (all equal)
```
