### PR TITLE
storage: better reporting for a storage panic

### DIFF
--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -492,10 +492,7 @@ func resolveLocalIntents(
 			}
 			return nil
 		}(); err != nil {
-			// TODO(tschottdorf): any legitimate reason for this to happen?
-			// Figure that out and if not, should still be ReplicaCorruption
-			// and not a panic.
-			panic(fmt.Sprintf("error resolving intent at %s on end transaction [%s]: %s", span, txn.Status, err))
+			log.Fatalf(ctx, "error resolving intent at %s on end transaction [%s]: %s", span, txn.Status, err)
 		}
 	}
 	// If the poison arg is set, make sure to set the abort span entry.


### PR DESCRIPTION
Using `Fatalf`, we'll get a redacted version of the error printed. My
assumption is that it is a RocksDB error (while reading data for the
intent resolution).

Closes #30361.

Release note: None