### PR TITLE
config: Fix TestingSetDefaultSystemZoneConfig's cleanup function

### DIFF
--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -333,7 +333,7 @@ func TestingSetDefaultZoneConfig(cfg ZoneConfig) func() {
 // default zone config and returns a function that reverts the change.
 func TestingSetDefaultSystemZoneConfig(cfg ZoneConfig) func() {
 	testingLock.Lock()
-	oldConfig := defaultZoneConfig
+	oldConfig := defaultSystemZoneConfig
 	defaultSystemZoneConfig = &cfg
 	testingLock.Unlock()
 


### PR DESCRIPTION
Apparently we don't rely on the cleanup function's behavior anywhere,
because it was resetting defaultSystemZoneConfig back to the wrong
thing.

Release note: None