### PR TITLE
backport-2.1: pick up small testing and debugging tweaks

### DIFF
--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -46,7 +46,7 @@ go install ./pkg/cmd/github-post
 # Use an `if` so that the `-e` option doesn't stop the script on error.
 if ! make stress PKG="$PKG" TESTTIMEOUT=40m GOFLAGS="$GOFLAGS" TAGS="$TAGS" STRESSFLAGS="-maxruns 100 -maxfails 1 -stderr $STRESSFLAGS" 2>&1 \
   | tee artifacts/stress.log; then
-  exit_status=$?
+  exit_status=${PIPESTATUS[0]}
   go tool test2json -t < artifacts/stress.log | github-post
   exit $exit_status
 fi

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -57,7 +57,10 @@ func registerClearRange(r *registry) {
 			if aggressiveConsistencyChecks {
 				// Run with an env var that runs a synchronous consistency check after each rebalance and merge.
 				// This slows down merges, so it might hide some races.
-				c.Start(ctx, startArgs("--env=COCKROACH_CONSISTENCY_AGGRESSIVE=true"))
+				c.Start(ctx, startArgs(
+					"--env=COCKROACH_CONSISTENCY_AGGRESSIVE=true",
+					"--env=COCKROACH_FATAL_ON_STATS_MISMATCH=true",
+				))
 			} else {
 				c.Start(ctx)
 			}

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -29,8 +29,7 @@ func registerClearRange(r *registry) {
 			Name:       fmt.Sprintf(`clearrange/checks=%t`, checks),
 			MinVersion: `v2.1.0`,
 			Nodes:      nodes(10),
-			// TODO(tschottdorf): seems like this should be stable.
-			Stable: false,
+			Stable:     true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runClearRange(ctx, t, c, checks)
 			},

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -17,167 +17,173 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 func registerClearRange(r *registry) {
-	const aggressiveConsistencyChecks = true
+	for _, checks := range []bool{true, false} {
+		r.Add(testSpec{
+			Name:       fmt.Sprintf(`clearrange/checks=%t`, checks),
+			MinVersion: `v2.1.0`,
+			Nodes:      nodes(10),
+			// TODO(tschottdorf): seems like this should be stable.
+			Stable: false,
+			Run: func(ctx context.Context, t *test, c *cluster) {
+				runClearRange(ctx, t, c, checks)
+			},
+		})
+	}
+}
 
-	r.Add(testSpec{
-		Name:       `clearrange`,
-		MinVersion: `v2.1.0`,
-		Nodes:      nodes(10),
-		Stable:     false,
-		Run: func(ctx context.Context, t *test, c *cluster) {
-			// Created via:
-			// roachtest --cockroach cockroach-v2.0-8 store-gen --stores=10 bank \
-			//           --payload-bytes=10240 --ranges=0 --rows=65104166
-			if err := c.RunE(ctx, c.Node(1), "test -d /mnt/data1/.zfs/snapshot/pristine"); err != nil {
-				// Use ZFS so the initial store dumps can be instantly rolled back to
-				// their pristine state. Useful for iterating quickly on the test.
-				c.Reformat(ctx, c.All(), "zfs")
+func runClearRange(ctx context.Context, t *test, c *cluster, aggressiveChecks bool) {
+	// Created via:
+	// roachtest --cockroach cockroach-v2.0-8 store-gen --stores=10 bank \
+	//           --payload-bytes=10240 --ranges=0 --rows=65104166
+	if err := c.RunE(ctx, c.Node(1), "test -d /mnt/data1/.zfs/snapshot/pristine"); err != nil {
+		// Use ZFS so the initial store dumps can be instantly rolled back to
+		// their pristine state. Useful for iterating quickly on the test.
+		c.Reformat(ctx, c.All(), "zfs")
 
-				t.Status(`downloading store dumps`)
-				fixtureURL := `gs://cockroach-fixtures/workload/bank/version=1.0.0,payload-bytes=10240,ranges=0,rows=65104166,seed=4`
-				location := storeDirURL(fixtureURL, c.nodes, "2.0-8")
+		t.Status(`downloading store dumps`)
+		fixtureURL := `gs://cockroach-fixtures/workload/bank/version=1.0.0,payload-bytes=10240,ranges=0,rows=65104166,seed=4`
+		location := storeDirURL(fixtureURL, c.nodes, "2.0-8")
 
-				// Download this store dump, which measures around 2TB (across all nodes).
-				if err := downloadStoreDumps(ctx, c, location, c.nodes); err != nil {
-					t.Fatal(err)
-				}
-				c.Run(ctx, c.All(), "test -e /sbin/zfs && sudo zfs snapshot data1@pristine")
-			} else {
-				t.Status(`restoring store dumps`)
-				c.Run(ctx, c.All(), "sudo zfs rollback data1@pristine")
-			}
+		// Download this store dump, which measures around 2TB (across all nodes).
+		if err := downloadStoreDumps(ctx, c, location, c.nodes); err != nil {
+			t.Fatal(err)
+		}
+		c.Run(ctx, c.All(), "test -e /sbin/zfs && sudo zfs snapshot data1@pristine")
+	} else {
+		t.Status(`restoring store dumps`)
+		c.Run(ctx, c.All(), "sudo zfs rollback data1@pristine")
+	}
 
-			c.Put(ctx, cockroach, "./cockroach")
-			if aggressiveConsistencyChecks {
-				// Run with an env var that runs a synchronous consistency check after each rebalance and merge.
-				// This slows down merges, so it might hide some races.
-				c.Start(ctx, startArgs(
-					"--env=COCKROACH_CONSISTENCY_AGGRESSIVE=true",
-					"--env=COCKROACH_FATAL_ON_STATS_MISMATCH=true",
-				))
-			} else {
-				c.Start(ctx)
-			}
+	c.Put(ctx, cockroach, "./cockroach")
+	if aggressiveChecks {
+		// Run with an env var that runs a synchronous consistency check after each rebalance and merge.
+		// This slows down merges, so it might hide some races.
+		c.Start(ctx, startArgs(
+			"--env=COCKROACH_CONSISTENCY_AGGRESSIVE=true",
+			"--env=COCKROACH_FATAL_ON_STATS_MISMATCH=true",
+		))
+	} else {
+		c.Start(ctx)
+	}
 
-			// Also restore a much smaller table. We'll use it to run queries against
-			// the cluster after having dropped the large table above, verifying that
-			// the  cluster still works.
-			t.Status(`restoring tiny table`)
-			defer t.WorkerStatus()
+	// Also restore a much smaller table. We'll use it to run queries against
+	// the cluster after having dropped the large table above, verifying that
+	// the  cluster still works.
+	t.Status(`restoring tiny table`)
+	defer t.WorkerStatus()
 
-			c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "CREATE DATABASE tinybank"`)
-			c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
+	c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "CREATE DATABASE tinybank"`)
+	c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
 				RESTORE csv.bank FROM
         'gs://cockroach-fixtures/workload/bank/version=1.0.0,payload-bytes=100,ranges=10,rows=800,seed=1/bank'
 				WITH into_db = 'tinybank'"`)
 
-			t.Status()
+	t.Status()
 
-			// Set up a convenience function that we can call to learn the number of
-			// ranges for the bank.bank table (even after it's been dropped).
-			numBankRanges := func() func() int {
-				conn := c.Conn(ctx, 1)
-				defer conn.Close()
+	// Set up a convenience function that we can call to learn the number of
+	// ranges for the bank.bank table (even after it's been dropped).
+	numBankRanges := func() func() int {
+		conn := c.Conn(ctx, 1)
+		defer conn.Close()
 
-				var startHex string
-				// NB: set this to false to save yourself some time during development. Selecting
-				// from crdb_internal.ranges is very slow because it contacts all of the leaseholders.
-				// You may actually want to run a version of cockroach that doesn't do that because
-				// it'll still slow you down every time the method returned below is called.
-				if true {
-					if err := conn.QueryRow(
-						`SELECT to_hex(start_key) FROM crdb_internal.ranges WHERE "database" = 'bank' AND "table" = 'bank' ORDER BY start_key ASC LIMIT 1`,
-					).Scan(&startHex); err != nil {
-						t.Fatal(err)
-					}
-				} else {
-					startHex = "bd" // extremely likely to be the right thing (b'\275').
-				}
-				return func() int {
-					conn := c.Conn(ctx, 1)
-					defer conn.Close()
-					var n int
-					if err := conn.QueryRow(
-						`SELECT count(*) FROM crdb_internal.ranges WHERE substr(to_hex(start_key), 1, length($1::string)) = $1`, startHex,
-					).Scan(&n); err != nil {
-						t.Fatal(err)
-					}
-					return n
-				}
-			}()
+		var startHex string
+		// NB: set this to false to save yourself some time during development. Selecting
+		// from crdb_internal.ranges is very slow because it contacts all of the leaseholders.
+		// You may actually want to run a version of cockroach that doesn't do that because
+		// it'll still slow you down every time the method returned below is called.
+		if true {
+			if err := conn.QueryRow(
+				`SELECT to_hex(start_key) FROM crdb_internal.ranges WHERE "database" = 'bank' AND "table" = 'bank' ORDER BY start_key ASC LIMIT 1`,
+			).Scan(&startHex); err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			startHex = "bd" // extremely likely to be the right thing (b'\275').
+		}
+		return func() int {
+			conn := c.Conn(ctx, 1)
+			defer conn.Close()
+			var n int
+			if err := conn.QueryRow(
+				`SELECT count(*) FROM crdb_internal.ranges WHERE substr(to_hex(start_key), 1, length($1::string)) = $1`, startHex,
+			).Scan(&n); err != nil {
+				t.Fatal(err)
+			}
+			return n
+		}
+	}()
 
-			m := newMonitor(ctx, c)
-			m.Go(func(ctx context.Context) error {
-				conn := c.Conn(ctx, 1)
-				defer conn.Close()
+	m := newMonitor(ctx, c)
+	m.Go(func(ctx context.Context) error {
+		conn := c.Conn(ctx, 1)
+		defer conn.Close()
 
-				if _, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_merge.queue_enabled = true`); err != nil {
-					return err
-				}
+		if _, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_merge.queue_enabled = true`); err != nil {
+			return err
+		}
 
-				// Merge as fast as possible to put maximum stress on the system.
-				if _, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_merge.queue_interval = '0s'`); err != nil {
-					return err
-				}
+		// Merge as fast as possible to put maximum stress on the system.
+		if _, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_merge.queue_interval = '0s'`); err != nil {
+			return err
+		}
 
-				t.WorkerStatus("dropping table")
-				defer t.WorkerStatus()
+		t.WorkerStatus("dropping table")
+		defer t.WorkerStatus()
 
-				// Set a low TTL so that the ClearRange-based cleanup mechanism can kick in earlier.
-				// This could also be done after dropping the table.
-				if _, err := conn.ExecContext(ctx, `ALTER TABLE bank.bank CONFIGURE ZONE USING gc.ttlseconds = 30`); err != nil {
-					return err
-				}
+		// Set a low TTL so that the ClearRange-based cleanup mechanism can kick in earlier.
+		// This could also be done after dropping the table.
+		if _, err := conn.ExecContext(ctx, `ALTER TABLE bank.bank CONFIGURE ZONE USING gc.ttlseconds = 30`); err != nil {
+			return err
+		}
 
-				t.WorkerStatus("computing number of ranges")
-				initialBankRanges := numBankRanges()
+		t.WorkerStatus("computing number of ranges")
+		initialBankRanges := numBankRanges()
 
-				t.WorkerStatus("dropping bank table")
-				if _, err := conn.ExecContext(ctx, `DROP TABLE bank.bank`); err != nil {
-					return err
-				}
+		t.WorkerStatus("dropping bank table")
+		if _, err := conn.ExecContext(ctx, `DROP TABLE bank.bank`); err != nil {
+			return err
+		}
 
-				// Spend some time reading data with a timeout to make sure the
-				// DROP above didn't brick the cluster. At the time of writing,
-				// clearing all of the table data takes ~6min, so we want to run
-				// for at least a multiple of that duration.
-				const minDuration = 45 * time.Minute
-				deadline := timeutil.Now().Add(minDuration)
-				curBankRanges := numBankRanges()
-				t.WorkerStatus("waiting for ~", curBankRanges, " merges to complete (and for at least ", minDuration, " to pass)")
-				for timeutil.Now().Before(deadline) || curBankRanges > 1 {
-					after := time.After(5 * time.Minute)
-					curBankRanges = numBankRanges() // this call takes minutes, unfortunately
-					t.WorkerProgress(1 - float64(curBankRanges)/float64(initialBankRanges))
+		// Spend some time reading data with a timeout to make sure the
+		// DROP above didn't brick the cluster. At the time of writing,
+		// clearing all of the table data takes ~6min, so we want to run
+		// for at least a multiple of that duration.
+		const minDuration = 45 * time.Minute
+		deadline := timeutil.Now().Add(minDuration)
+		curBankRanges := numBankRanges()
+		t.WorkerStatus("waiting for ~", curBankRanges, " merges to complete (and for at least ", minDuration, " to pass)")
+		for timeutil.Now().Before(deadline) || curBankRanges > 1 {
+			after := time.After(5 * time.Minute)
+			curBankRanges = numBankRanges() // this call takes minutes, unfortunately
+			t.WorkerProgress(1 - float64(curBankRanges)/float64(initialBankRanges))
 
-					var count int
-					// NB: context cancellation in QueryRowContext does not work as expected.
-					// See #25435.
-					if _, err := conn.ExecContext(ctx, `SET statement_timeout = '5s'`); err != nil {
-						return err
-					}
-					// If we can't aggregate over 80kb in 5s, the database is far from usable.
-					if err := conn.QueryRowContext(ctx, `SELECT count(*) FROM tinybank.bank`).Scan(&count); err != nil {
-						return err
-					}
+			var count int
+			// NB: context cancellation in QueryRowContext does not work as expected.
+			// See #25435.
+			if _, err := conn.ExecContext(ctx, `SET statement_timeout = '5s'`); err != nil {
+				return err
+			}
+			// If we can't aggregate over 80kb in 5s, the database is far from usable.
+			if err := conn.QueryRowContext(ctx, `SELECT count(*) FROM tinybank.bank`).Scan(&count); err != nil {
+				return err
+			}
 
-					select {
-					case <-after:
-					case <-ctx.Done():
-						return ctx.Err()
-					}
-				}
-				// TODO(tschottdorf): verify that disk space usage drops below to <some small amount>, but that
-				// may not actually happen (see https://github.com/cockroachdb/cockroach/issues/29290).
-				return nil
-			})
-			m.Wait()
-		},
+			select {
+			case <-after:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		// TODO(tschottdorf): verify that disk space usage drops below to <some small amount>, but that
+		// may not actually happen (see https://github.com/cockroachdb/cockroach/issues/29290).
+		return nil
 	})
+	m.Wait()
 }

--- a/pkg/cmd/roachtest/scaledata.go
+++ b/pkg/cmd/roachtest/scaledata.go
@@ -80,6 +80,10 @@ func runSqlapp(ctx context.Context, t *test, c *cluster, app, flags string, dur 
 	c.Put(ctx, cockroach, "./cockroach", roachNodes)
 	c.Start(ctx, roachNodes)
 
+	// TODO(nvanbenschoten): We are currently running these consistency checks with
+	// basic chaos. We should also run them in more chaotic environments which
+	// could introduce network partitions, ENOSPACE, clock issues, etc.
+
 	// Sqlapps each take a `--cockroach_ip_addresses_csv` flag, which is a
 	// comma-separated list of node IP addresses with optional port specifiers.
 	addrStr := strings.Join(c.InternalAddr(ctx, c.Range(1, roachNodeCount)), ",")
@@ -113,11 +117,6 @@ func runSqlapp(ctx context.Context, t *test, c *cluster, app, flags string, dur 
 			return err
 		}
 
-		// TODO(nvanbenschoten): We are currently running these consistency
-		// checks in the most basic case where are nodes in the Cockroach
-		// cluster are healthy and able to communicate. We should also run them
-		// in a chaos environment, which could introduce network partitions,
-		// node and service restarts, ENOSPACE, clock issues, etc.
 		t.Status("running consistency checker")
 		const workers = 16
 		return c.RunL(ctx, sqlappL, appNode, fmt.Sprintf("./%s  --duration_secs=%d "+

--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -491,10 +491,7 @@ func resolveLocalIntents(
 			}
 			return nil
 		}(); err != nil {
-			// TODO(tschottdorf): any legitimate reason for this to happen?
-			// Figure that out and if not, should still be ReplicaCorruption
-			// and not a panic.
-			panic(fmt.Sprintf("error resolving intent at %s on end transaction [%s]: %s", span, txn.Status, err))
+			log.Fatalf(ctx, "error resolving intent at %s on end transaction [%s]: %s", span, txn.Status, err)
 		}
 	}
 	// If the poison arg is set, make sure to set the abort span entry.


### PR DESCRIPTION
Backport:
  * 1/1 commits from "roachtest: trace slow query in election test" (#30817)
  * 1/1 commits from "roachtest: update comment on scaledata tests" (#30820)
  * 1/1 commits from "build: fix exit status in teamcity-stress" (#30815)
  * 4/4 commits from "roachtest: make clearrange stricter" (#30818)
  * 1/1 commits from "storage: better reporting for a storage panic" (#30870)

Please see individual PRs for details.

/cc @cockroachdb/release
