### PR TITLE
changefeedccl: fix panic when pk is updated and a column is not nullable

### DIFF
--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -1267,7 +1267,9 @@ func (rf *RowFetcher) finalizeRow() error {
 			return nil
 		}
 		if table.neededCols.Contains(int(table.cols[i].ID)) && table.row[i].IsUnset() {
-			if !table.cols[i].Nullable {
+			// If the row was deleted, we'll be missing any non-primary key
+			// columns, including nullable ones, but this is expected.
+			if !table.cols[i].Nullable && !table.rowIsDeleted {
 				var indexColValues []string
 				for _, idx := range table.indexColIdx {
 					if idx != -1 {


### PR DESCRIPTION
There's a panic in RowFetcher that fires if a non-null column didn't
have any data, but if the row was deleted, the check isn't applicable.

Fixes #30729

Release note: None