### PR TITLE
log: include a call to action with fatal errors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,10 @@
 ---
-name: Bug report
-about: Create a report to help us improve
+name: Bug or crash report
+about: Report unexpected behavior to help us improve
 
 ---
 
-**Describe the bug**
+**Describe the problem**
 
 Please describe the issue you observed, and any steps we can take to reproduce it:
 
@@ -19,14 +19,21 @@ If possible, provide steps to reproduce the behavior:
 3. Look at UI / log file / client app ...
 4. See error
 
-
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
 **Additional data / screenshots**
-If applicable, add screenshots / log files to help explain your problem.
+If the problem is SQL-related, include a copy of the SQL query and the schema
+of the supporting tables.
 
-If the problem is SQL-related, include a copy of the SQL query and the schema of the supporting tables.
+If a node in your cluster encountered a fatal error, supply the contents of the
+log directories (at minimum of the affected node(s), but preferably all nodes).
+
+Note that log files can contain confidential information. Please continue
+creating this issue, but contact support@cockroachlabs.com to submit the log
+files in private.
+
+If applicable, add screenshots to help explain your problem.
 
 **Environment:**
  - CockroachDB version [e.g. 2.0.x]

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -46,6 +46,30 @@ import (
 	"github.com/petermattis/goid"
 )
 
+const fatalErrorPostamble = `
+
+****************************************************************************
+
+This node experienced a fatal error (printed above this message) as a result
+of which the process is terminating.
+
+Fatal errors can occur due to faulty hardware (disks, memory, clocks) or a
+problem in CockroachDB. With your help, the support team at Cockroach Labs
+can help you determine the root cause, recommend next steps, and will improve
+CockroachDB based on your report.
+
+Please consider submitting a report about this crash according to the
+instructions at
+
+    https://github.com/cockroachdb/cockroach/issues/new/choose
+
+If you would rather not post on a public forum, instead please contact
+
+    support@cockroachlabs.com
+
+The Cockroach Labs team appreciates your feedback.
+`
+
 // FatalChan is closed when Fatal is called. This can be used to make
 // the process stop handling requests while the final log messages and
 // crash report are being written.
@@ -842,6 +866,8 @@ func (l *loggingT) outputLogEntry(s Severity, file string, line int, msg string)
 		case tracebackAll:
 			stacks = getStacks(true)
 		}
+		stacks = append(stacks, []byte(fatalErrorPostamble)...)
+
 		logExitFunc = func(error) {} // If we get a write error, we'll still exit.
 
 		// We don't want to hang forever writing our final log message. If


### PR DESCRIPTION
When rare errors happen in the wild, they are a) often unreported or b)
reported only in anonymized form, with little context that can help
pinpoint the root cause.

Users can help us out tremendously by contacting us, and so we should
incentivize that.

Do so by concluding fatal errors (i.e. most crashes) with a call to
action.

Touches #28699.
Touches #24033.
Touches #25173.

Release note: None