### PR TITLE
roachtest: change the name of the jepsen top level tests

### DIFF
--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -260,6 +260,13 @@ cd /mnt/data1/jepsen/cockroachdb && set -eo pipefail && \
 }
 
 func registerJepsen(r *registry) {
+	// We're splitting the tests arbitrarily into a number of "groups" - top level
+	// tests. We do this so that we can different groups can run in parallel (as
+	// subtests don't run concurrently with each other). We put more than one test
+	// in a group so that Jepsen's lengthy cluster initialization step can be
+	// amortized (the individual tests are smart enough to not do it if it has
+	// been done already).
+	//
 	// NB: the "comments" test is not included because it requires
 	// linearizability.
 	groups := [][]string{
@@ -270,7 +277,7 @@ func registerJepsen(r *registry) {
 
 	for i := range groups {
 		spec := testSpec{
-			Name:  fmt.Sprintf("jepsen/%d", i+1),
+			Name:  fmt.Sprintf("jepsen-g%d", i+1),
 			Nodes: nodes(6),
 		}
 


### PR DESCRIPTION
Replace slashes; they were confusing as that's what is used for subtests
in different places.

Release note: None