### PR TITLE
release-2.1: changefeedccl: fix panic when pk is updated and a column is not nullable

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -522,6 +522,38 @@ func TestChangefeedComputedColumn(t *testing.T) {
 	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
+func TestChangefeedUpdatePrimaryKey(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		// This NOT NULL column checks a regression when used with UPDATE-ing a
+		// primary key column or with DELETE.
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING NOT NULL)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (0, 'bar')`)
+
+		foo := f.Feed(t, `CREATE CHANGEFEED FOR foo`)
+		defer foo.Close(t)
+		assertPayloads(t, foo, []string{
+			`foo: [0]->{"a": 0, "b": "bar"}`,
+		})
+
+		sqlDB.Exec(t, `UPDATE foo SET a = 1`)
+		assertPayloads(t, foo, []string{
+			`foo: [0]->`,
+			`foo: [1]->{"a": 1, "b": "bar"}`,
+		})
+
+		sqlDB.Exec(t, `DELETE FROM foo`)
+		assertPayloads(t, foo, []string{
+			`foo: [1]->`,
+		})
+	}
+
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
+}
+
 func TestChangefeedTruncateRenameDrop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -1227,7 +1227,9 @@ func (rf *RowFetcher) finalizeRow() error {
 			return nil
 		}
 		if table.neededCols.Contains(int(table.cols[i].ID)) && table.row[i].IsUnset() {
-			if !table.cols[i].Nullable {
+			// If the row was deleted, we'll be missing any non-primary key
+			// columns, including nullable ones, but this is expected.
+			if !table.cols[i].Nullable && !table.rowIsDeleted {
 				var indexColValues []string
 				for _, idx := range table.indexColIdx {
 					if idx != -1 {


### PR DESCRIPTION
Backport 1/1 commits from #30896.

/cc @cockroachdb/release

---

There's a panic in RowFetcher that fires if a non-null column didn't
have any data, but if the row was deleted, the check isn't applicable.

Fixes #30729

Release note: None
