### PR TITLE
cli/interactive_tests: re-enable the URL tests

### DIFF
--- a/pkg/cli/interactive_tests/test_url_db_override.tcl
+++ b/pkg/cli/interactive_tests/test_url_db_override.tcl
@@ -85,7 +85,7 @@ eexpect eof
 end_test
 
 start_test "Check that the host flag overrides the host if URL is already set."
-spawn $argv sql --url "postgresql://root@localhost:26257?sslmode=disable" --host nonexistent -e "select 1"
+spawn $argv sql --url "postgresql://root@localhost:26257?sslmode=disable" --host nonexistent.example. -e "select 1"
 eexpect "cannot dial server"
 eexpect "nonexistent"
 eexpect eof


### PR DESCRIPTION
Fixes  #30839.

The test needs a DNS server that properly errors out when provided
with a non-existent host name. The test was disabled previously
because apparently the CI environment does not provide such a DNS.

This patch attempts to work around the issue by providing a
fully-qualified, known-not-to-exist hostname:

https://en.wikipedia.org/wiki/.example

https://tools.ietf.org/html/rfc2606

Release note: None