### PR TITLE
sql: present the output of SHOW JOBS in sorted order

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -472,15 +472,13 @@ CREATE TABLE crdb_internal.jobs (
 					}
 					modified = tsOrNull(progress.ModifiedMicros)
 
-					runningStatusStr := ""
 					if len(progress.RunningStatus) > 0 {
 						if s, ok := status.(*tree.DString); ok {
 							if jobs.Status(string(*s)) == jobs.StatusRunning {
-								runningStatusStr = progress.RunningStatus
+								runningStatus = tree.NewDString(progress.RunningStatus)
 							}
 						}
 					}
-					runningStatus = tree.NewDString(runningStatusStr)
 				}
 			}
 

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -110,9 +110,11 @@ drop database  ·  ·
 query TTT
 EXPLAIN SHOW JOBS
 ----
-render       ·     ·
- └── values  ·     ·
-·            size  15 columns, 0 rows
+sort              ·      ·
+ │                order  -"coalesce",-started
+ └── render       ·      ·
+      └── values  ·      ·
+·                 size   15 columns, 0 rows
 
 statement ok
 CREATE INDEX a ON foo(x)

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -101,9 +101,11 @@ drop database  ·  ·
 query TTT
 EXPLAIN SHOW JOBS
 ----
-render       ·     ·
- └── values  ·     ·
-·            size  15 columns, 0 rows
+sort              ·      ·
+ │                order  -"coalesce",-started
+ └── render       ·      ·
+      └── values  ·      ·
+·                 size   15 columns, 0 rows
 
 statement ok
 CREATE INDEX a ON foo(x)

--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -142,6 +142,7 @@ func verifySystemJob(
 	var rawDescriptorIDs pq.Int64Array
 	var actualType string
 	var statusString string
+	var runningStatus gosql.NullString
 	var runningStatusString string
 	// We have to query for the nth job created rather than filtering by ID,
 	// because job-generating SQL queries (e.g. BACKUP) do not currently return
@@ -152,8 +153,11 @@ func verifySystemJob(
 		offset,
 	).Scan(
 		&actualType, &actual.Description, &actual.Username, &rawDescriptorIDs,
-		&statusString, &runningStatusString,
+		&statusString, &runningStatus,
 	)
+	if runningStatus.Valid {
+		runningStatusString = runningStatus.String
+	}
 
 	for _, id := range rawDescriptorIDs {
 		actual.DescriptorIDs = append(actual.DescriptorIDs, sqlbase.ID(id))


### PR DESCRIPTION
Fixes #30835.
Requested by @rolandcrosby and @a-robinson.

Release note (sql change): The output of `SHOW JOBS` now reports
ongoing jobs first in start time order, then completed jobs in
finished time order. The `running_status` column becomes NULL when the
status cannot be determined.