### PR TITLE
release-2.1: storage: grab RLock in Replica.propose when checking destroyStatus

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2944,6 +2944,7 @@ func (r *Replica) executeReadOnlyBatch(
 		endCmds.done(br, pErr, proposalNoRetry)
 	}()
 
+	// TODO(nvanbenschoten): Can this be moved into Replica.requestCanProceed?
 	if _, err := r.IsDestroyed(); err != nil {
 		return nil, roachpb.NewError(err)
 	}
@@ -3504,13 +3505,14 @@ func (r *Replica) propose(
 	endCmds *endCmds,
 	spans *spanset.SpanSet,
 ) (_ chan proposalResult, _ func() bool, _ int64, pErr *roachpb.Error) {
-	r.mu.Lock()
+	// TODO(nvanbenschoten): Can this be moved into Replica.requestCanProceed?
+	r.mu.RLock()
 	if !r.mu.destroyStatus.IsAlive() {
 		err := r.mu.destroyStatus.err
-		r.mu.Unlock()
+		r.mu.RUnlock()
 		return nil, nil, 0, roachpb.NewError(err)
 	}
-	r.mu.Unlock()
+	r.mu.RUnlock()
 
 	rSpan, err := keys.Range(ba)
 	if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #30909.

/cc @cockroachdb/release

---

This was missed when the destroyStatus code was refactored. Making
the change provides a modest but stable **3.4%** speedup to
single-replica kv95 on my 4vCPU laptop. The change is likely more
impactful on a machine with a larger number of processors.

The real fix is probably to move the destroyStatus check in both the
read and write path into `replica.requestCanProceed`. That's called
beneath Raft though, so it's too scary of a change for the stability
period. I left TODOs.

I caught this while preparing my lunch & learn. All the more reason
to do them!

Release note (performance improvement): Avoid acquiring exclusive
lock when checking Replica status in write proposal path.
