### PR TITLE
release-2.1: storage: Avoid printing writes-per-second info to logs and rangelog

### DIFF
--- a/pkg/storage/allocator_scorer.go
+++ b/pkg/storage/allocator_scorer.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
@@ -71,17 +71,14 @@ type scorerOptions struct {
 
 type balanceDimensions struct {
 	ranges rangeCountStatus
-	bytes  float64
-	writes float64
 }
 
 func (bd *balanceDimensions) totalScore() float64 {
-	return float64(bd.ranges) + bd.bytes + bd.writes
+	return float64(bd.ranges)
 }
 
 func (bd balanceDimensions) String() string {
-	return fmt.Sprintf("%.2f(ranges=%d, bytes=%.2f, writes=%.2f)",
-		bd.totalScore(), int(bd.ranges), bd.bytes, bd.writes)
+	return strconv.Itoa(int(bd.ranges))
 }
 
 func (bd balanceDimensions) compactString(options scorerOptions) string {
@@ -103,10 +100,9 @@ type candidate struct {
 
 func (c candidate) String() string {
 	str := fmt.Sprintf("s%d, valid:%t, fulldisk:%t, necessary:%t, diversity:%.2f, converges:%d, "+
-		"balance:%s, rangeCount:%d, logicalBytes:%s, writesPerSecond:%.2f",
+		"balance:%s, rangeCount:%d, queriesPerSecond:%.2f",
 		c.store.StoreID, c.valid, c.fullDisk, c.necessary, c.diversityScore, c.convergesScore,
-		c.balanceScore, c.rangeCount, humanizeutil.IBytes(c.store.Capacity.LogicalBytes),
-		c.store.Capacity.WritesPerSecond)
+		c.balanceScore, c.rangeCount, c.store.Capacity.QueriesPerSecond)
 	if c.details != "" {
 		return fmt.Sprintf("%s, details:(%s)", str, c.details)
 	}

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -542,22 +542,21 @@ func makeStoreList(descriptors []roachpb.StoreDescriptor) StoreList {
 func (sl StoreList) String() string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf,
-		"  candidate: avg-ranges=%v avg-leases=%v avg-disk-usage=%v avg-queries-per-second=%v avg-writes-per-second=%v",
+		"  candidate: avg-ranges=%v avg-leases=%v avg-disk-usage=%v avg-queries-per-second=%v",
 		sl.candidateRanges.mean,
 		sl.candidateLeases.mean,
 		humanizeutil.IBytes(int64(sl.candidateLogicalBytes.mean)),
-		sl.candidateQueriesPerSecond.mean,
-		sl.candidateWritesPerSecond.mean)
+		sl.candidateQueriesPerSecond.mean)
 	if len(sl.stores) > 0 {
 		fmt.Fprintf(&buf, "\n")
 	} else {
 		fmt.Fprintf(&buf, " <no candidates>")
 	}
 	for _, desc := range sl.stores {
-		fmt.Fprintf(&buf, "  %d: ranges=%d leases=%d disk-usage=%s queries-per-second=%.2f writes-per-second=%.2f\n",
+		fmt.Fprintf(&buf, "  %d: ranges=%d leases=%d disk-usage=%s queries-per-second=%.2f\n",
 			desc.StoreID, desc.Capacity.RangeCount,
 			desc.Capacity.LeaseCount, humanizeutil.IBytes(desc.Capacity.LogicalBytes),
-			desc.Capacity.QueriesPerSecond, desc.Capacity.WritesPerSecond)
+			desc.Capacity.QueriesPerSecond)
 	}
 	return buf.String()
 }


### PR DESCRIPTION
Backport 1/1 commits from #30907.

/cc @cockroachdb/release

---

This logging has been bugging me when looking into rebalancing details
over the last few weeks, since logical bytes and writes per second
aren't used in any decisions (even any experimental decisions) anymore.
They may be again in the future, so we may not want to completely remove
the code that tracks writes per second (because it'll be easier for 2.2
to use it in cross-version clusters if it's already there), but we
certainly don't need to be printing info about them in rebalancing logs.

I've taken care to avoid modifying any decision-making logic, only
printing methods, such that this is safe to backport to release-2.1.
Removing `bytes` and `writes` from `balanceDimensions` is safe since, as
you can tell from the fact that this compiles, they weren't used
anywhere anymore.

Release note: None
