### PR TITLE
storage: Don't transfer leases to behind replicas in StoreRebalancer

### DIFF
--- a/pkg/storage/store_rebalancer.go
+++ b/pkg/storage/store_rebalancer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"go.etcd.io/etcd/raft"
 )
 
 const (
@@ -123,10 +124,11 @@ const (
 // will best accomplish the store-level goals.
 type StoreRebalancer struct {
 	log.AmbientContext
-	metrics      StoreRebalancerMetrics
-	st           *cluster.Settings
-	rq           *replicateQueue
-	replRankings *replicaRankings
+	metrics         StoreRebalancerMetrics
+	st              *cluster.Settings
+	rq              *replicateQueue
+	replRankings    *replicaRankings
+	getRaftStatusFn func(replica *Replica) *raft.Status
 }
 
 // NewStoreRebalancer creates a StoreRebalancer to work in tandem with the
@@ -143,6 +145,9 @@ func NewStoreRebalancer(
 		st:             st,
 		rq:             rq,
 		replRankings:   replRankings,
+		getRaftStatusFn: func(replica *Replica) *raft.Status {
+			return replica.RaftStatus()
+		},
 	}
 	sr.AddLogTag("store-rebalancer", nil)
 	sr.rq.store.metrics.registry.AddMetricStruct(&sr.metrics)
@@ -395,6 +400,8 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 			return iQPS < jQPS
 		})
 
+		var raftStatus *raft.Status
+
 		for _, candidate := range replicas {
 			if candidate.StoreID == localDesc.StoreID {
 				continue
@@ -402,6 +409,15 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 
 			meanQPS := storeList.candidateQueriesPerSecond.mean
 			if shouldNotMoveTo(ctx, storeMap, replWithStats, candidate.StoreID, meanQPS, minQPS, maxQPS) {
+				continue
+			}
+
+			if raftStatus == nil {
+				raftStatus = sr.getRaftStatusFn(replWithStats.repl)
+			}
+			if replicaIsBehind(raftStatus, candidate.ReplicaID) {
+				log.VEventf(ctx, 3, "%v is behind or this store isn't the raft leader; raftStatus: %v",
+					candidate, raftStatus)
 				continue
 			}
 
@@ -566,7 +582,25 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 		// RelocateRange transfers the lease to the first provided target.
 		newLeaseIdx := 0
 		newLeaseQPS := math.MaxFloat64
+		var raftStatus *raft.Status
 		for i := 0; i < len(targets); i++ {
+			// Ensure we don't transfer the lease to an existing replica that is behind
+			// in processing its raft log.
+			var replicaID roachpb.ReplicaID
+			for _, replica := range desc.Replicas {
+				if replica.StoreID == targets[i].StoreID {
+					replicaID = replica.ReplicaID
+				}
+			}
+			if replicaID != 0 {
+				if raftStatus == nil {
+					raftStatus = sr.getRaftStatusFn(replWithStats.repl)
+				}
+				if replicaIsBehind(raftStatus, replicaID) {
+					continue
+				}
+			}
+
 			storeDesc, ok := storeMap[targets[i].StoreID]
 			if ok && storeDesc.Capacity.QueriesPerSecond < newLeaseQPS {
 				newLeaseIdx = i


### PR DESCRIPTION
Transferring a lease to a replica that's behind can cause all requests
to the range to stall, as the old leaseholder thinks it's no longer the
leaseholder but the new leaseholder doesn't know it's the leaseholder
yet. This avoids creating such scenarios in the StoreRebalancer.

Release note (bug fix): Avoids an edge case in load-based
rebalancing where we could transfer the lease for a range to a replica
that isn't keeping up with the other replicas, causing brief periods
where no replicas think they're leaseholder for the range and thus no
requests can be processed for the range.

Reproduction in https://github.com/a-robinson/cockroach/commit/933cbd51860299d93d00b50bafdd2d566f37802f, demonstrating that transferring a lease to a behind replica causes all requests to stall.