### PR TITLE
release-2.1: cli/sql: avoid a panic upon initial session errors

### DIFF
--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -187,6 +187,9 @@ func (c *sqlConn) checkServerMetadata() error {
 	}
 
 	newServerVersion, newClusterID, err := c.getServerMetadata()
+	if err == driver.ErrBadConn {
+		return err
+	}
 	if err != nil {
 		// It is not an error that the server version cannot be retrieved.
 		fmt.Fprintf(stderr, "warning: unable to retrieve the server's version: %s\n", err)


### PR DESCRIPTION
Backport 1/1 commits from #30688.

/cc @cockroachdb/release

---

Prior to this patch, if the server closed the connection (because of
some internal error) in-between the initial pq.Open() and the middle
of conn.getServerMetaData(), the client conn object would become
invalid. However this error case was turned into a warning and
subsequent accesses by the client code would then in turn into a
panic (instead of a clean "connection error").

This patch fixes this by ensuring the connection is properly cleaned
up if the intermediate SQL query in getServerMetadata() fails.

Release note: None
