### PR TITLE
opt: fix crash caused by tuple IN tuples

### DIFF
--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -177,6 +177,7 @@ func (c *indexConstraintCtx) makeSpansForSingleColumn(
 				*si, *sj = *sj, *si
 			}
 		}
+		spans.SortAndMerge(keyCtx)
 		out.Init(keyCtx, &spans)
 		return true
 	}

--- a/pkg/sql/opt/memo/constraint_builder.go
+++ b/pkg/sql/opt/memo/constraint_builder.go
@@ -70,6 +70,7 @@ func (cb *constraintsBuilder) buildSingleColumnConstraint(
 			spans.Append(&sp)
 		}
 		var c constraint.Constraint
+		spans.SortAndMerge(&keyCtx)
 		c.Init(&keyCtx, &spans)
 		return constraint.SingleConstraint(&c), true
 	}

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -987,3 +987,30 @@ project
       ├── fd: (1)-->(3)
       ├── prune: (1,3)
       └── interesting orderings: (+1) (+3,+1)
+
+# Verify constraints for tuple IN (tuple, ..), when the tuples are not sorted.
+opt
+SELECT * FROM (SELECT (x, y) AS foo FROM a) WHERE foo IN ((3, 4), (1, 2))
+----
+select
+ ├── columns: foo:4(tuple{int, int}!null)
+ ├── project
+ │    ├── columns: foo:4(tuple{int, int})
+ │    ├── prune: (4)
+ │    ├── scan a
+ │    │    ├── columns: x:1(int) y:2(int)
+ │    │    └── prune: (1,2)
+ │    └── projections [outer=(1,2)]
+ │         └── tuple [type=tuple{int, int}, outer=(1,2)]
+ │              ├── variable: x [type=int, outer=(1)]
+ │              └── variable: y [type=int, outer=(2)]
+ └── filters [type=bool, outer=(4), constraints=(/4: [/(1, 2) - /(1, 2)] [/(3, 4) - /(3, 4)]; tight)]
+      └── in [type=bool, outer=(4), constraints=(/4: [/(1, 2) - /(1, 2)] [/(3, 4) - /(3, 4)]; tight)]
+           ├── variable: foo [type=tuple{int, int}, outer=(4)]
+           └── tuple [type=tuple{tuple{int, int}, tuple{int, int}}]
+                ├── tuple [type=tuple{int, int}]
+                │    ├── const: 3 [type=int]
+                │    └── const: 4 [type=int]
+                └── tuple [type=tuple{int, int}]
+                     ├── const: 1 [type=int]
+                     └── const: 2 [type=int]


### PR DESCRIPTION
Some of the constraint generation code relies on the values in the
right-hand side tuple of an IN expression being sorted (which is done
by NormalizeInConst). However, this rule does not sort tuples of
tuples.

Fixing the code to call `spans.MergeAndSort`. Note that this function
has a fast-path if the spans are already sorted.

Release note (bug fix): Fixed a possible crash when using filters with
"tuple IN tuples" expressions.