### PR TITLE
kubernetes: Update remaining yaml files from v2.0.5 to v2.0.6

### DIFF
--- a/cloud/kubernetes/cluster-init.yaml
+++ b/cloud/kubernetes/cluster-init.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
       - name: cluster-init
-        image: cockroachdb/cockroach:v2.0.5
+        image: cockroachdb/cockroach:v2.0.6
         imagePullPolicy: IfNotPresent
         command:
           - "/cockroach/cockroach"

--- a/cloud/kubernetes/performance/cockroachdb-daemonset-insecure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-daemonset-insecure.yaml
@@ -78,7 +78,7 @@ spec:
       hostNetwork: true
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v2.0.5
+        image: cockroachdb/cockroach:v2.0.6
         imagePullPolicy: IfNotPresent
         # TODO: If you configured taints to give CockroachDB exclusive access to nodes, feel free
         # to remove the requests and limits sections. If you didn't, you'll need to change these to

--- a/cloud/kubernetes/performance/cockroachdb-daemonset-secure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-daemonset-secure.yaml
@@ -194,7 +194,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v2.0.5
+        image: cockroachdb/cockroach:v2.0.6
         imagePullPolicy: IfNotPresent
         # TODO: If you configured taints to give CockroachDB exclusive access to nodes, feel free
         # to remove the requests and limits sections. If you didn't, you'll need to change these to

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
@@ -222,7 +222,7 @@ spec:
       - name: cockroachdb
         # NOTE: Always use the most recent version of CockroachDB for the best
         # performance and reliability.
-        image: cockroachdb/cockroach:v2.0.5
+        image: cockroachdb/cockroach:v2.0.6
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
         # the amount of allocatable resources on each of your Kubernetes nodes by running:


### PR DESCRIPTION
These got missed by #30826

Release note: None

---

It looks like the old [find/sed command from the wiki](https://github.com/cockroachdb/cockroach/wiki/Release-Process#orchestrator-configurations) no longer works for me on my mac, seemingly due to some images that got added to the `cloud/kubernetes/prometheus` directory and were causing sed to error out. I've changed it to include a file name restriction to only pick up yaml files, which seems to fix it.