### PR TITLE
partitionccl: Clarify license check error when setting zone configs

### DIFF
--- a/pkg/ccl/partitionccl/zone.go
+++ b/pkg/ccl/partitionccl/zone.go
@@ -74,7 +74,7 @@ func GenerateSubzoneSpans(
 	// Removing zone configs does not require a valid license.
 	if hasNewSubzones {
 		org := sql.ClusterOrganization.Get(&st.SV)
-		if err := utilccl.CheckEnterpriseEnabled(st, clusterID, org, "partitions"); err != nil {
+		if err := utilccl.CheckEnterpriseEnabled(st, clusterID, org, "replication zones on indexes or partitions"); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Fixes #30960 in the laziest way possible. We could presumably also scan
through the subzones to determine whether they're for indexes,
partitions, or both, but this seems clear enough for people to
understand.

Release note: None