### PR TITLE
storage: increase kv.closed_timestamp.target_duration to 10s

### DIFF
--- a/pkg/storage/closedts/setting.go
+++ b/pkg/storage/closedts/setting.go
@@ -25,7 +25,7 @@ import (
 var TargetDuration = settings.RegisterNonNegativeDurationSetting(
 	"kv.closed_timestamp.target_duration",
 	"if nonzero, attempt to provide closed timestamp notifications for timestamps trailing cluster time by approximately this duration",
-	5*time.Second,
+	10*time.Second,
 )
 
 // CloseFraction is the fraction of TargetDuration determining how often closed


### PR DESCRIPTION
The schema change in TestSchemaChangeAfterCreateInTxn would
occasionally take more than 5 seconds and get pushed by the
closed timestamp. Setting to a value that is less likely to
cause grief.

fixes #30492

Release note: None