### PR TITLE
release-2.1: storage: Add minimum cluster version for load-based rebalancing

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -79,6 +79,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>2.0-12</code></td><td>set the active cluster version in the format '<major>.<minor>'.</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>2.0-14</code></td><td>set the active cluster version in the format '<major>.<minor>'.</td></tr>
 </tbody>
 </table>

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -557,7 +557,7 @@ func TestReportUsage(t *testing.T) {
 		"diagnostics.reporting.send_crash_reports": "false",
 		"server.time_until_store_dead":             "1m30s",
 		"trace.debug.enable":                       "false",
-		"version":                                  "2.0-12",
+		"version":                                  "2.0-14",
 		"cluster.secret":                           "<redacted>",
 	} {
 		if got, ok := r.last.AlteredSettings[key]; !ok {

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -69,6 +69,7 @@ const (
 	VersionBatchResponse
 	VersionCreateChangefeed
 	VersionRangeMerges
+	VersionLoadBasedRebalancing
 
 	// Add new versions here (step one of two).
 
@@ -270,6 +271,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionRangeMerges is https://github.com/cockroachdb/cockroach/pull/28865.
 		Key:     VersionRangeMerges,
 		Version: roachpb.Version{Major: 2, Minor: 0, Unstable: 12},
+	},
+	{
+		// VersionLoadBasedRebalancing is https://github.com/cockroachdb/cockroach/pull/28852.
+		Key:     VersionLoadBasedRebalancing,
+		Version: roachpb.Version{Major: 2, Minor: 0, Unstable: 14},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -261,7 +261,7 @@ select crdb_internal.set_vmodule('')
 query T
 select crdb_internal.node_executable_version()
 ----
-2.0-12
+2.0-14
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -358,4 +358,4 @@ select * from crdb_internal.gossip_alerts
 query T
 select crdb_internal.node_executable_version()
 ----
-2.0-12
+2.0-14

--- a/pkg/storage/store_rebalancer.go
+++ b/pkg/storage/store_rebalancer.go
@@ -181,6 +181,10 @@ func (sr *StoreRebalancer) Start(ctx context.Context, stopper *stop.Stopper) {
 			case <-ticker.C:
 			}
 
+			if !sr.st.Version.IsMinSupported(cluster.VersionLoadBasedRebalancing) {
+				continue
+			}
+
 			mode := LBRebalancingMode(LoadBasedRebalancingMode.Get(&sr.st.SV))
 			if mode == LBRebalancingOff {
 				continue


### PR DESCRIPTION
Backport 1/1 commits from #30964.

/cc @cockroachdb/release

---

This is needed because v2.0 didn't gossip QPS data, so in a
mixed-version cluster the 2.1 nodes will think all the 2.0 nodes have no
load on them and continually try to give them more leases and replicas.

Gossiping QPS data was added in #27857.

Release note: None

---

I don't love introducing a hole in the cluster versions between 2.0-12 and 2.0-14, but we definitely don't want to use different numbers on master and release-2.1. The alternative would be go touch up master more to move `VersionBitArrayColumns` (from #28807) to a 2.1-1 version and switch `VersionLoadBasedRebalancing` to 2.0-13. We're going to have to move `VersionBitArrayColumns` to 2.1-1 anyway, but it'd require a weird commit ordering to make for a clean cherry-pick of this to 2.1.