### PR TITLE
release-2.1: storage: Don't transfer leases to behind replicas in StoreRebalancer

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -1154,23 +1154,32 @@ func filterBehindReplicas(
 		// Raft leader. This is rare enough not to matter.
 		return nil
 	}
+	candidates := make([]roachpb.ReplicaDescriptor, 0, len(replicas))
+	for _, r := range replicas {
+		if !replicaIsBehind(raftStatus, r.ReplicaID) || r.ReplicaID == brandNewReplicaID {
+			candidates = append(candidates, r)
+		}
+	}
+	return candidates
+}
+
+func replicaIsBehind(raftStatus *raft.Status, replicaID roachpb.ReplicaID) bool {
+	if raftStatus == nil || len(raftStatus.Progress) == 0 {
+		return true
+	}
 	// NB: We use raftStatus.Commit instead of getQuorumIndex() because the
 	// latter can return a value that is less than the commit index. This is
 	// useful for Raft log truncation which sometimes wishes to keep those
 	// earlier indexes, but not appropriate for determining which nodes are
 	// behind the actual commit index of the range.
-	candidates := make([]roachpb.ReplicaDescriptor, 0, len(replicas))
-	for _, r := range replicas {
-		if progress, ok := raftStatus.Progress[uint64(r.ReplicaID)]; ok {
-			if uint64(r.ReplicaID) == raftStatus.Lead ||
-				r.ReplicaID == brandNewReplicaID ||
-				(progress.State == raft.ProgressStateReplicate &&
-					progress.Match >= raftStatus.Commit) {
-				candidates = append(candidates, r)
-			}
+	if progress, ok := raftStatus.Progress[uint64(replicaID)]; ok {
+		if uint64(replicaID) == raftStatus.Lead ||
+			(progress.State == raft.ProgressStateReplicate &&
+				progress.Match >= raftStatus.Commit) {
+			return false
 		}
 	}
-	return candidates
+	return true
 }
 
 func simulateFilterUnremovableReplicas(

--- a/pkg/storage/store_rebalancer.go
+++ b/pkg/storage/store_rebalancer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"go.etcd.io/etcd/raft"
 )
 
 const (
@@ -124,10 +125,11 @@ const (
 // will best accomplish the store-level goals.
 type StoreRebalancer struct {
 	log.AmbientContext
-	metrics      StoreRebalancerMetrics
-	st           *cluster.Settings
-	rq           *replicateQueue
-	replRankings *replicaRankings
+	metrics         StoreRebalancerMetrics
+	st              *cluster.Settings
+	rq              *replicateQueue
+	replRankings    *replicaRankings
+	getRaftStatusFn func(replica *Replica) *raft.Status
 }
 
 // NewStoreRebalancer creates a StoreRebalancer to work in tandem with the
@@ -144,6 +146,9 @@ func NewStoreRebalancer(
 		st:             st,
 		rq:             rq,
 		replRankings:   replRankings,
+		getRaftStatusFn: func(replica *Replica) *raft.Status {
+			return replica.RaftStatus()
+		},
 	}
 	sr.AddLogTag("store-rebalancer", nil)
 	sr.rq.store.metrics.registry.AddMetricStruct(&sr.metrics)
@@ -403,6 +408,8 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 			return iQPS < jQPS
 		})
 
+		var raftStatus *raft.Status
+
 		for _, candidate := range replicas {
 			if candidate.StoreID == localDesc.StoreID {
 				continue
@@ -413,11 +420,21 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 				continue
 			}
 
+			if raftStatus == nil {
+				raftStatus = sr.getRaftStatusFn(replWithStats.repl)
+			}
+			if replicaIsBehind(raftStatus, candidate.ReplicaID) {
+				log.VEventf(ctx, 3, "%v is behind or this store isn't the raft leader; raftStatus: %v",
+					candidate, raftStatus)
+				continue
+			}
+
 			zone, err := sysCfg.GetZoneConfigForKey(desc.StartKey)
 			if err != nil {
 				log.Error(ctx, err)
 				return replicaWithStats{}, roachpb.ReplicaDescriptor{}, considerForRebalance
 			}
+
 			preferred := sr.rq.allocator.preferredLeaseholders(zone, desc.Replicas)
 			if len(preferred) > 0 && !storeHasReplica(candidate.StoreID, preferred) {
 				log.VEventf(ctx, 3, "s%d not a preferred leaseholder; preferred: %v", candidate.StoreID, preferred)
@@ -589,7 +606,25 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 		// RelocateRange transfers the lease to the first provided target.
 		newLeaseIdx := 0
 		newLeaseQPS := math.MaxFloat64
+		var raftStatus *raft.Status
 		for i := 0; i < len(targets); i++ {
+			// Ensure we don't transfer the lease to an existing replica that is behind
+			// in processing its raft log.
+			var replicaID roachpb.ReplicaID
+			for _, replica := range desc.Replicas {
+				if replica.StoreID == targets[i].StoreID {
+					replicaID = replica.ReplicaID
+				}
+			}
+			if replicaID != 0 {
+				if raftStatus == nil {
+					raftStatus = sr.getRaftStatusFn(replWithStats.repl)
+				}
+				if replicaIsBehind(raftStatus, replicaID) {
+					continue
+				}
+			}
+
 			storeDesc, ok := storeMap[targets[i].StoreID]
 			if ok && storeDesc.Capacity.QueriesPerSecond < newLeaseQPS {
 				newLeaseIdx = i

--- a/pkg/storage/store_rebalancer_test.go
+++ b/pkg/storage/store_rebalancer_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"go.etcd.io/etcd/raft"
 )
 
 var (
@@ -132,6 +133,24 @@ func TestChooseLeaseToTransfer(t *testing.T) {
 
 	sr := NewStoreRebalancer(cfg.AmbientCtx, cfg.Settings, rq, rr)
 
+	// Rather than trying to populate every Replica with a real raft group in
+	// order to pass replicaIsBehind checks, fake out the function for getting
+	// raft status with one that always returns all replicas as up to date.
+	sr.getRaftStatusFn = func(r *Replica) *raft.Status {
+		status := &raft.Status{
+			Progress: make(map[uint64]raft.Progress),
+		}
+		status.Lead = uint64(r.ReplicaID())
+		status.Commit = 1
+		for _, replica := range r.Desc().Replicas {
+			status.Progress[uint64(replica.ReplicaID)] = raft.Progress{
+				Match: 1,
+				State: raft.ProgressStateReplicate,
+			}
+		}
+		return status
+	}
+
 	testCases := []struct {
 		storeIDs     []roachpb.StoreID
 		qps          float64
@@ -197,6 +216,24 @@ func TestChooseReplicaToRebalance(t *testing.T) {
 
 	sr := NewStoreRebalancer(cfg.AmbientCtx, cfg.Settings, rq, rr)
 
+	// Rather than trying to populate every Replica with a real raft group in
+	// order to pass replicaIsBehind checks, fake out the function for getting
+	// raft status with one that always returns all replicas as up to date.
+	sr.getRaftStatusFn = func(r *Replica) *raft.Status {
+		status := &raft.Status{
+			Progress: make(map[uint64]raft.Progress),
+		}
+		status.Lead = uint64(r.ReplicaID())
+		status.Commit = 1
+		for _, replica := range r.Desc().Replicas {
+			status.Progress[uint64(replica.ReplicaID)] = raft.Progress{
+				Match: 1,
+				State: raft.ProgressStateReplicate,
+			}
+		}
+		return status
+	}
+
 	testCases := []struct {
 		storeIDs      []roachpb.StoreID
 		qps           float64
@@ -259,5 +296,85 @@ func TestChooseReplicaToRebalance(t *testing.T) {
 					tc.storeIDs, tc.qps, targetStores, tc.expectTargets)
 			}
 		})
+	}
+}
+
+func TestNoLeaseTransferToBehindReplicas(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Lots of setup boilerplate.
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	defer stopper.Stop(context.Background())
+	gossiputil.NewStoreGossiper(g).GossipStores(noLocalityStores, t)
+	storeList, _, _ := a.storePool.getStoreList(firstRange, storeFilterThrottled)
+	storeMap := storeListToMap(storeList)
+
+	const minQPS = 800
+	const maxQPS = 1200
+
+	localDesc := *noLocalityStores[0]
+	cfg := TestStoreConfig(nil)
+	s := createTestStoreWithoutStart(t, stopper, &cfg)
+	s.Ident = &roachpb.StoreIdent{StoreID: localDesc.StoreID}
+	rq := newReplicateQueue(s, g, a)
+	rr := newReplicaRankings()
+
+	sr := NewStoreRebalancer(cfg.AmbientCtx, cfg.Settings, rq, rr)
+
+	// Load in a range with replicas on an overfull node, a slightly underfull
+	// node, and a very underfull node.
+	loadRanges(rr, s, []testRange{{storeIDs: []roachpb.StoreID{1, 4, 5}, qps: 100}})
+	hottestRanges := rr.topQPS()
+	repl := hottestRanges[0].repl
+
+	// Set up a fake RaftStatus that indicates s5 is behind (but all other stores
+	// are caught up). We thus shouldn't transfer a lease to s5.
+	sr.getRaftStatusFn = func(r *Replica) *raft.Status {
+		status := &raft.Status{
+			Progress: make(map[uint64]raft.Progress),
+		}
+		status.Lead = uint64(r.ReplicaID())
+		status.Commit = 1
+		for _, replica := range r.Desc().Replicas {
+			match := uint64(1)
+			if replica.StoreID == roachpb.StoreID(5) {
+				match = 0
+			}
+			status.Progress[uint64(replica.ReplicaID)] = raft.Progress{
+				Match: match,
+				State: raft.ProgressStateReplicate,
+			}
+		}
+		return status
+	}
+
+	_, target, _ := sr.chooseLeaseToTransfer(
+		ctx, config.SystemConfig{}, &hottestRanges, &localDesc, storeList, storeMap, minQPS, maxQPS)
+	expectTarget := roachpb.StoreID(4)
+	if target.StoreID != expectTarget {
+		t.Errorf("got target store s%d for range with RaftStatus %v; want s%d",
+			target.StoreID, sr.getRaftStatusFn(repl), expectTarget)
+	}
+
+	// Then do the same, but for replica rebalancing. Make s5 an existing replica
+	// that's behind, and see how a new replica is preferred as the leaseholder
+	// over it.
+	loadRanges(rr, s, []testRange{{storeIDs: []roachpb.StoreID{1, 3, 5}, qps: 100}})
+	hottestRanges = rr.topQPS()
+	repl = hottestRanges[0].repl
+
+	_, targets := sr.chooseReplicaToRebalance(
+		ctx, config.SystemConfig{}, &hottestRanges, &localDesc, storeList, storeMap, minQPS, maxQPS)
+	expectTargets := []roachpb.ReplicationTarget{
+		{NodeID: 4, StoreID: 4}, {NodeID: 5, StoreID: 5}, {NodeID: 3, StoreID: 3},
+	}
+	if !reflect.DeepEqual(targets, expectTargets) {
+		t.Errorf("got targets %v for range with RaftStatus %v; want %v",
+			targets, sr.getRaftStatusFn(repl), expectTargets)
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #30938.

/cc @cockroachdb/release

---

Transferring a lease to a replica that's behind can cause all requests
to the range to stall, as the old leaseholder thinks it's no longer the
leaseholder but the new leaseholder doesn't know it's the leaseholder
yet. This avoids creating such scenarios in the StoreRebalancer.

Release note (bug fix): Avoids an edge case in load-based
rebalancing where we could transfer the lease for a range to a replica
that isn't keeping up with the other replicas, causing brief periods
where no replicas think they're leaseholder for the range and thus no
requests can be processed for the range.

Reproduction in https://github.com/a-robinson/cockroach/commit/933cbd51860299d93d00b50bafdd2d566f37802f, demonstrating that transferring a lease to a behind replica causes all requests to stall.
