### PR TITLE
changefeedccl: support a minimum frequency between resolved ts emits

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -62,8 +62,8 @@ const (
 	backupOptRevisionHistory = "revision_history"
 )
 
-var backupOptionExpectValues = map[string]bool{
-	backupOptRevisionHistory: false,
+var backupOptionExpectValues = map[string]sql.KVStringOptValidate{
+	backupOptRevisionHistory: sql.KVStringOptRequireNoValue,
 }
 
 // BackupCheckpointInterval is the interval at which backup progress is saved

--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -52,10 +52,10 @@ const (
 	restoreOptSkipMissingSequences = "skip_missing_sequences"
 )
 
-var restoreOptionExpectValues = map[string]bool{
-	restoreOptIntoDB:               true,
-	restoreOptSkipMissingFKs:       false,
-	restoreOptSkipMissingSequences: false,
+var restoreOptionExpectValues = map[string]sql.KVStringOptValidate{
+	restoreOptIntoDB:               sql.KVStringOptRequireValue,
+	restoreOptSkipMissingFKs:       sql.KVStringOptRequireNoValue,
+	restoreOptSkipMissingSequences: sql.KVStringOptRequireNoValue,
 }
 
 func loadBackupDescs(

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -228,13 +228,10 @@ func emitEntries(
 	}
 }
 
-// emitResolvedTimestamp emits a changefeed-level resolved timestamp to the sink
-// and checkpoints it and the span-level resolved timestamps to the job record.
-func emitResolvedTimestamp(
+// checkpointResolvedTimestamp checkpoints a changefeed-level resolved timestamp
+// to the jobs record.
+func checkpointResolvedTimestamp(
 	ctx context.Context,
-	details jobspb.ChangefeedDetails,
-	encoder Encoder,
-	sink Sink,
 	jobProgressedFn func(context.Context, jobs.HighWaterProgressedFn) error,
 	sf *spanFrontier,
 ) error {
@@ -265,19 +262,24 @@ func emitResolvedTimestamp(
 			return err
 		}
 	}
+	return nil
+}
 
-	if _, ok := details.Opts[optResolvedTimestamps]; ok {
-		payload, err := encoder.EncodeResolvedTimestamp(resolved)
-		if err != nil {
-			return err
-		}
-		// TODO(dan): Plumb a bufalloc.ByteAllocator to use here.
-		payload = append([]byte(nil), payload...)
-		// TODO(dan): Emit more fine-grained (table level) resolved
-		// timestamps.
-		if err := sink.EmitResolvedTimestamp(ctx, payload); err != nil {
-			return err
-		}
+// emitResolvedTimestamp emits a changefeed-level resolved timestamp to the
+// sink.
+func emitResolvedTimestamp(
+	ctx context.Context, encoder Encoder, sink Sink, resolved hlc.Timestamp,
+) error {
+	payload, err := encoder.EncodeResolvedTimestamp(resolved)
+	if err != nil {
+		return err
+	}
+	// TODO(dan): Plumb a bufalloc.ByteAllocator to use here.
+	payload = append([]byte(nil), payload...)
+	// TODO(dan): Emit more fine-grained (table level) resolved
+	// timestamps.
+	if err := sink.EmitResolvedTimestamp(ctx, payload); err != nil {
+		return err
 	}
 	if log.V(2) {
 		log.Infof(ctx, `resolved %s`, resolved)

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -13,6 +13,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"net/url"
+	"sort"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -32,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -181,7 +183,43 @@ func TestChangefeedTimestamps(t *testing.T) {
 		})
 
 		// Check that we eventually get a resolved timestamp greater than ts1.
-		expectResolvedTimestampGreaterThan(t, foo, ts1)
+		parsed := parseTimeToHLC(t, ts1)
+		for {
+			if resolved := expectResolvedTimestamp(t, foo); parsed.Less(resolved) {
+				break
+			}
+		}
+	}
+
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
+}
+
+func TestChangefeedResolvedFrequency(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+
+		const freq = 10 * time.Millisecond
+		foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH resolved=$1`, freq.String())
+		defer foo.Close(t)
+
+		// We get each resolved timestamp notification once in each partition.
+		// Grab the first `2 * #partitions`, sort because we might get all from
+		// one partition first, and compare the first and last.
+		resolved := make([]hlc.Timestamp, 2*len(foo.Partitions()))
+		for i := range resolved {
+			resolved[i] = expectResolvedTimestamp(t, foo)
+		}
+		sort.Slice(resolved, func(i, j int) bool { return resolved[i].Less(resolved[j]) })
+		first, last := resolved[0], resolved[len(resolved)-1]
+		fmt.Println(resolved)
+
+		if d := last.GoTime().Sub(first.GoTime()); d < freq {
+			t.Errorf(`expected %s between resolved timestamps, but got %s`, freq, d)
+		}
 	}
 
 	t.Run(`sinkless`, sinklessTest(testFn))
@@ -914,6 +952,11 @@ func TestChangefeedErrors(t *testing.T) {
 			`CREATE CHANGEFEED FOR foo WITH envelope=nope`,
 		); !testutils.IsError(err, `unknown envelope: nope`) {
 			t.Errorf(`expected 'unknown envelope: nope' error got: %+v`, err)
+		}
+		if _, err := sqlDB.DB.Exec(
+			`CREATE CHANGEFEED FOR foo WITH resolved='-1s'`,
+		); !testutils.IsError(err, `negative durations are not accepted: resolved='-1s'`) {
+			t.Errorf(`expected 'negative durations are not accepted' error got: %+v`, err)
 		}
 
 		if _, err := sqlDB.DB.Exec(

--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -46,11 +46,11 @@ const (
 	exportOptionFileName  = "filename"
 )
 
-var exportOptionExpectValues = map[string]bool{
-	exportOptionChunkSize: true,
-	exportOptionDelimiter: true,
-	exportOptionFileName:  true,
-	exportOptionNullAs:    true,
+var exportOptionExpectValues = map[string]sql.KVStringOptValidate{
+	exportOptionChunkSize: sql.KVStringOptRequireValue,
+	exportOptionDelimiter: sql.KVStringOptRequireValue,
+	exportOptionFileName:  sql.KVStringOptRequireValue,
+	exportOptionNullAs:    sql.KVStringOptRequireValue,
 }
 
 const exportChunkSizeDefault = 100000

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -69,25 +69,25 @@ const (
 	pgMaxRowSize = "max_row_size"
 )
 
-var importOptionExpectValues = map[string]bool{
-	csvDelimiter: true,
-	csvComment:   true,
-	csvNullIf:    true,
-	csvSkip:      true,
+var importOptionExpectValues = map[string]sql.KVStringOptValidate{
+	csvDelimiter: sql.KVStringOptRequireValue,
+	csvComment:   sql.KVStringOptRequireValue,
+	csvNullIf:    sql.KVStringOptRequireValue,
+	csvSkip:      sql.KVStringOptRequireValue,
 
-	mysqlOutfileRowSep:   true,
-	mysqlOutfileFieldSep: true,
-	mysqlOutfileEnclose:  true,
-	mysqlOutfileEscape:   true,
+	mysqlOutfileRowSep:   sql.KVStringOptRequireValue,
+	mysqlOutfileFieldSep: sql.KVStringOptRequireValue,
+	mysqlOutfileEnclose:  sql.KVStringOptRequireValue,
+	mysqlOutfileEscape:   sql.KVStringOptRequireValue,
 
-	importOptionTransform:  true,
-	importOptionSSTSize:    true,
-	importOptionDecompress: true,
-	importOptionOversample: true,
+	importOptionTransform:  sql.KVStringOptRequireValue,
+	importOptionSSTSize:    sql.KVStringOptRequireValue,
+	importOptionDecompress: sql.KVStringOptRequireValue,
+	importOptionOversample: sql.KVStringOptRequireValue,
 
-	importOptionSkipFKs: false,
+	importOptionSkipFKs: sql.KVStringOptRequireNoValue,
 
-	pgMaxRowSize: true,
+	pgMaxRowSize: sql.KVStringOptRequireValue,
 }
 
 const (
@@ -430,7 +430,9 @@ func importJobDescription(
 			v = clean
 		}
 		opt := tree.KVOption{Key: tree.Name(k)}
-		if importOptionExpectValues[k] {
+		val := importOptionExpectValues[k] == sql.KVStringOptRequireValue
+		val = val || (importOptionExpectValues[k] == sql.KVStringOptAny && len(v) > 0)
+		if val {
 			opt.Value = tree.NewDString(v)
 		}
 		stmt.Options = append(stmt.Options, opt)

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -76,7 +76,7 @@ type PlanHookState interface {
 	TypeAsString(e tree.Expr, op string) (func() (string, error), error)
 	TypeAsStringArray(e tree.Exprs, op string) (func() ([]string, error), error)
 	TypeAsStringOpts(
-		opts tree.KVOptions, valuelessOpts map[string]bool,
+		opts tree.KVOptions, optsValidate map[string]KVStringOptValidate,
 	) (func() (map[string]string, error), error)
 	User() string
 	AuthorizationAccessor


### PR DESCRIPTION
The `WITH resolved` option now take an optional duration which is used
as a lower bound on the duration between emitting resolved timestamps.
It accepts any format that https://golang.org/pkg/time/#ParseDuration
does. (e.g. `WITH resolved='10s'`). If unspecified, the previous
behavior of emitting all resolved timestamps is used.

Closes #30367

Release note (enterprise change): CHANGEFEEDs can now be configured with
a minimum duration between emitting resolved timestamps.