### PR TITLE
release-2.1: partitionccl: Clarify license check error when setting zone configs

### DIFF
--- a/pkg/ccl/partitionccl/zone.go
+++ b/pkg/ccl/partitionccl/zone.go
@@ -74,7 +74,7 @@ func GenerateSubzoneSpans(
 	// Removing zone configs does not require a valid license.
 	if hasNewSubzones {
 		org := sql.ClusterOrganization.Get(&st.SV)
-		if err := utilccl.CheckEnterpriseEnabled(st, clusterID, org, "partitions"); err != nil {
+		if err := utilccl.CheckEnterpriseEnabled(st, clusterID, org, "replication zones on indexes or partitions"); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Backport 1/1 commits from #30962.

/cc @cockroachdb/release

---

Fixes #30960 in the laziest way possible. We could presumably also scan
through the subzones to determine whether they're for indexes,
partitions, or both, but this seems clear enough for people to
understand.

Release note: None

---

This is a pretty weak backport (it only fixes an S-3 issue), but it also comes with basically zero risk. I haven't yet heard any feedback that this sort of thing shouldn't be backported, so here we go again.