### PR TITLE
ui: add bar chart for node list memory & capacity

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodesOverview/barChart.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/barChart.tsx
@@ -1,0 +1,109 @@
+import d3 from "d3";
+import React from "react";
+
+import { Bytes, Percentage } from "src/util/format";
+
+interface BytesBarChartProps {
+  used: number;
+  usable: number;
+}
+
+const width = 175;
+const height = 28;
+
+const chartHeight = 14;
+
+export class BytesBarChart extends React.Component<BytesBarChartProps> {
+  chart: React.RefObject<HTMLDivElement> = React.createRef();
+
+  componentDidMount() {
+    this.renderChart(this.props);
+  }
+
+  shouldComponentUpdate(props: BytesBarChartProps) {
+    this.renderChart(props);
+    return false;
+  }
+
+  renderChart(props: BytesBarChartProps) {
+    const svg = d3.select(this.chart.current)
+      .selectAll("svg")
+      .data([{ width, height }]);
+
+    const svgEnter = svg
+      .enter()
+      .append("svg")
+      .attr("width", d => d.width)
+      .attr("height", d => d.height);
+
+    svgEnter.append("text")
+      .attr("y", chartHeight - 4)
+      .attr("class", "bar-chart__label percent");
+
+    const label = svg.select(".bar-chart__label.percent")
+      .text("100%");
+
+    const textNode = label.node();
+    const reserveWidth = !textNode ? 100 : (textNode as SVGSVGElement).getBBox().width;
+
+    svg.selectAll(".bar-chart__label.percent")
+      .text(Percentage(props.used, props.usable));
+
+    const labelWidth = !textNode ? 100 : (textNode as SVGSVGElement).getBBox().width;
+
+    label.attr("x", reserveWidth - labelWidth);
+
+    const spacing = 3;
+
+    const chartEnter = svgEnter.append("g")
+      .attr("class", "bar-chart__bars")
+      .attr("transform", `translate(${reserveWidth + spacing},0)`);
+
+    const chart = svg.selectAll(".bar-chart__bars");
+
+    const chartWidth = width - reserveWidth - spacing;
+
+    chartEnter.append("rect")
+      .attr("width", chartWidth * 0.9)
+      .attr("height", chartHeight)
+      .attr("fill", "#e2e5ee");
+
+    chartEnter.append("rect")
+      .attr("x", chartWidth * 0.9)
+      .attr("width", chartWidth * 0.1)
+      .attr("height", chartHeight)
+      .attr("fill", "#cfd2dc");
+
+    chartEnter.append("rect")
+      .attr("class", "bar-chart__bar used")
+      .attr("height", 5)
+      .attr("y", (chartHeight - 5) / 2)
+      .attr("fill", "#3a7de1");
+
+    chart.selectAll(".bar-chart__bar.used")
+      .attr("width", chartWidth * props.used / props.usable);
+
+    chartEnter.append("text")
+      .attr("y", height)
+      .attr("class", "bar-chart__label used");
+
+    chart.selectAll(".bar-chart__label.used")
+      .text(Bytes(props.used));
+
+    chartEnter.append("text")
+      .attr("y", height)
+      .attr("class", "bar-chart__label total");
+
+    const total = chart.selectAll(".bar-chart__label.total")
+      .text(Bytes(props.usable));
+
+    const totalNode = total.node();
+    const totalWidth = !totalNode ? 100 : (totalNode as SVGSVGElement).getBBox().width;
+
+    total.attr("x", chartWidth - totalWidth - 0);
+  }
+
+  render() {
+    return <div ref={this.chart} />;
+  }
+}

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/barChart.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/barChart.tsx
@@ -76,7 +76,7 @@ export class BytesBarChart extends React.Component<BytesBarChartProps> {
 
     chartEnter.append("rect")
       .attr("class", "bar-chart__bar used")
-      .attr("height", 5)
+      .attr("height", 5) // This attr's for FF, the CSS rule is for Chrome.
       .attr("y", (chartHeight - 5) / 2)
       .attr("fill", "#3a7de1");
 

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -19,11 +19,10 @@ import { LocalSetting } from "src/redux/localsettings";
 import { SortSetting } from "src/views/shared/components/sortabletable";
 import { SortedTable } from "src/views/shared/components/sortedtable";
 import { LongToMoment } from "src/util/convert";
-import { BytesWithPrecision } from "src/util/format";
 import { INodeStatus, MetricConstants, BytesUsed } from "src/util/proto";
 import { FixLong } from "src/util/fixLong";
-import { Percentage } from "src/util/format";
 
+import { BytesBarChart } from "./barChart";
 import "./nodes.styl";
 
 const liveNodesSortSetting = new LocalSetting<AdminUIState, SortSetting>(
@@ -141,16 +140,9 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
               cell: (ns) => {
                 const { usable } = nodeCapacityStats(ns);
                 const used = BytesUsed(ns);
-                return (
-                  <span title={`Total: ${BytesWithPrecision(usable, 0)}`}>
-                    {BytesWithPrecision(used, 0)}
-                    {" "}
-                    ({Percentage(used, usable)})
-                  </span>
-                );
+                return <BytesBarChart used={used} usable={usable} />;
               },
               sort: (ns) => BytesUsed(ns),
-              className: "sort-table__cell--right-aligned-stat",
             },
             // Mem Usage - total memory being used on this node.
             {
@@ -158,16 +150,9 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
               cell: (ns) => {
                 const used = ns.metrics[MetricConstants.rss];
                 const available = FixLong(ns.total_system_memory).toNumber();
-                return (
-                  <span title={`Total: ${BytesWithPrecision(available, 0)}`}>
-                    {BytesWithPrecision(used, 0)}
-                    {" "}
-                    ({Percentage(used, available)})
-                  </span>
-                );
+                return <BytesBarChart used={used} usable={available} />;
               },
               sort: (ns) => ns.metrics[MetricConstants.rss],
-              className: "sort-table__cell--right-aligned-stat",
             },
             // Version - the currently running version of cockroach.
             {

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -24,6 +24,8 @@ import { INodeStatus, MetricConstants, BytesUsed } from "src/util/proto";
 import { FixLong } from "src/util/fixLong";
 import { Percentage } from "src/util/format";
 
+import "./nodes.styl";
+
 const liveNodesSortSetting = new LocalSetting<AdminUIState, SortSetting>(
   "nodes/live_sort_setting", (s) => s.localSettings,
 );
@@ -62,126 +64,124 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
     }
 
     return (
-      <div>
+      <div className="embedded-table">
         <section className="section section--heading">
           <h2>Live Nodes</h2>
         </section>
-        <section className="section">
-          <NodeSortedTable
-            data={statuses}
-            sortSetting={sortSetting}
-            onChangeSortSetting={(setting) => this.props.setSort(setting)}
-            columns={[
-              // Node ID column.
-              {
-                title: "ID",
-                cell: (ns) => `n${ns.desc.node_id}`,
-                sort: (ns) => ns.desc.node_id,
+        <NodeSortedTable
+          data={statuses}
+          sortSetting={sortSetting}
+          onChangeSortSetting={(setting) => this.props.setSort(setting)}
+          columns={[
+            // Node ID column.
+            {
+              title: "ID",
+              cell: (ns) => `n${ns.desc.node_id}`,
+              sort: (ns) => ns.desc.node_id,
+            },
+            // Node address column - displays the node address, links to the
+            // node-specific page for this node.
+            {
+              title: "Address",
+              cell: (ns) => {
+                const status = nodesSummary.livenessStatusByNodeID[ns.desc.node_id] || LivenessStatus.LIVE;
+                const s = livenessNomenclature(status);
+                let tooltip: string;
+                switch (status) {
+                  case LivenessStatus.LIVE:
+                    tooltip = "This node is currently healthy.";
+                    break;
+                  case LivenessStatus.DECOMMISSIONING:
+                    tooltip = "This node is currently being decommissioned.";
+                    break;
+                  default:
+                    tooltip = "This node has not recently reported as being live. " +
+                      "It may not be functioning correctly, but no automatic action has yet been taken.";
+                }
+                return (
+                  <div className="sort-table__unbounded-column">
+                    <div className={"icon-circle-filled node-status-icon node-status-icon--" + s} title={tooltip} />
+                    <Link to={`/node/${ns.desc.node_id}`}>{ns.desc.address.address_field}</Link>
+                  </div>
+                );
               },
-              // Node address column - displays the node address, links to the
-              // node-specific page for this node.
-              {
-                title: "Address",
-                cell: (ns) => {
-                  const status = nodesSummary.livenessStatusByNodeID[ns.desc.node_id] || LivenessStatus.LIVE;
-                  const s = livenessNomenclature(status);
-                  let tooltip: string;
-                  switch (status) {
-                    case LivenessStatus.LIVE:
-                      tooltip = "This node is currently healthy.";
-                      break;
-                    case LivenessStatus.DECOMMISSIONING:
-                      tooltip = "This node is currently being decommissioned.";
-                      break;
-                    default:
-                      tooltip = "This node has not recently reported as being live. " +
-                        "It may not be functioning correctly, but no automatic action has yet been taken.";
-                  }
-                  return (
-                    <div className="sort-table__unbounded-column">
-                      <div className={"icon-circle-filled node-status-icon node-status-icon--" + s} title={tooltip} />
-                      <Link to={`/node/${ns.desc.node_id}`}>{ns.desc.address.address_field}</Link>
-                    </div>
-                  );
-                },
-                sort: (ns) => ns.desc.node_id,
-                // TODO(mrtracy): Consider if there is a better way to use BEM
-                // style CSS in cases like this; it is a bit awkward to write out
-                // the entire modifier class here, but it might not be better to
-                // construct the full BEM class in the table component itself.
-                className: "sort-table__cell--link",
+              sort: (ns) => ns.desc.node_id,
+              // TODO(mrtracy): Consider if there is a better way to use BEM
+              // style CSS in cases like this; it is a bit awkward to write out
+              // the entire modifier class here, but it might not be better to
+              // construct the full BEM class in the table component itself.
+              className: "sort-table__cell--link",
+            },
+            // Started at - displays the time that the node started.
+            {
+              title: "Uptime",
+              cell: (ns) => {
+                const startTime = LongToMoment(ns.started_at);
+                return moment.duration(startTime.diff(moment())).humanize();
               },
-              // Started at - displays the time that the node started.
-              {
-                title: "Uptime",
-                cell: (ns) => {
-                  const startTime = LongToMoment(ns.started_at);
-                  return moment.duration(startTime.diff(moment())).humanize();
-                },
-                sort: (ns) => ns.started_at,
-                className: "sort-table__cell--right-aligned-stats",
+              sort: (ns) => ns.started_at,
+              className: "sort-table__cell--right-aligned-stats",
+            },
+            // Replicas - displays the total number of replicas on the node.
+            {
+              title: "Replicas",
+              cell: (ns) => ns.metrics[MetricConstants.replicas].toString(),
+              sort: (ns) => ns.metrics[MetricConstants.replicas],
+              className: "sort-table__cell--right-aligned-stat",
+            },
+            // CPUs - the number of CPUs on this node
+            {
+              title: "CPUs",
+              cell: (ns) => ns.num_cpus,
+              className: "sort-table__cell--right-aligned-stat",
+            },
+            // Used Capacity - displays the total persisted bytes maintained by the node.
+            {
+              title: "Capacity Usage",
+              cell: (ns) => {
+                const { usable } = nodeCapacityStats(ns);
+                const used = BytesUsed(ns);
+                return (
+                  <span title={`Total: ${BytesWithPrecision(usable, 0)}`}>
+                    {BytesWithPrecision(used, 0)}
+                    {" "}
+                    ({Percentage(used, usable)})
+                  </span>
+                );
               },
-              // Replicas - displays the total number of replicas on the node.
-              {
-                title: "Replicas",
-                cell: (ns) => ns.metrics[MetricConstants.replicas].toString(),
-                sort: (ns) => ns.metrics[MetricConstants.replicas],
-                className: "sort-table__cell--right-aligned-stat",
+              sort: (ns) => BytesUsed(ns),
+              className: "sort-table__cell--right-aligned-stat",
+            },
+            // Mem Usage - total memory being used on this node.
+            {
+              title: "Mem Usage",
+              cell: (ns) => {
+                const used = ns.metrics[MetricConstants.rss];
+                const available = FixLong(ns.total_system_memory).toNumber();
+                return (
+                  <span title={`Total: ${BytesWithPrecision(available, 0)}`}>
+                    {BytesWithPrecision(used, 0)}
+                    {" "}
+                    ({Percentage(used, available)})
+                  </span>
+                );
               },
-              // CPUs - the number of CPUs on this node
-              {
-                title: "CPUs",
-                cell: (ns) => ns.num_cpus,
-                className: "sort-table__cell--right-aligned-stat",
-              },
-              // Used Capacity - displays the total persisted bytes maintained by the node.
-              {
-                title: "Capacity Usage",
-                cell: (ns) => {
-                  const { usable } = nodeCapacityStats(ns);
-                  const used = BytesUsed(ns);
-                  return (
-                    <span title={`Total: ${BytesWithPrecision(usable, 0)}`}>
-                      {BytesWithPrecision(used, 0)}
-                      {" "}
-                      ({Percentage(used, usable)})
-                    </span>
-                  );
-                },
-                sort: (ns) => BytesUsed(ns),
-                className: "sort-table__cell--right-aligned-stat",
-              },
-              // Mem Usage - total memory being used on this node.
-              {
-                title: "Mem Usage",
-                cell: (ns) => {
-                  const used = ns.metrics[MetricConstants.rss];
-                  const available = FixLong(ns.total_system_memory).toNumber();
-                  return (
-                    <span title={`Total: ${BytesWithPrecision(available, 0)}`}>
-                      {BytesWithPrecision(used, 0)}
-                      {" "}
-                      ({Percentage(used, available)})
-                    </span>
-                  );
-                },
-                sort: (ns) => ns.metrics[MetricConstants.rss],
-                className: "sort-table__cell--right-aligned-stat",
-              },
-              // Version - the currently running version of cockroach.
-              {
-                title: "Version",
-                cell: (ns) => ns.build_info.tag,
-                sort: (ns) => ns.build_info.tag,
-              },
-              // Logs - a link to the logs data for this node.
-              {
-                title: "Logs",
-                cell: (ns) => <Link to={`/node/${ns.desc.node_id}/logs`}>Logs</Link>,
-                className: "expand-link",
-              },
-            ]} />
-        </section>
+              sort: (ns) => ns.metrics[MetricConstants.rss],
+              className: "sort-table__cell--right-aligned-stat",
+            },
+            // Version - the currently running version of cockroach.
+            {
+              title: "Version",
+              cell: (ns) => ns.build_info.tag,
+              sort: (ns) => ns.build_info.tag,
+            },
+            // Logs - a link to the logs data for this node.
+            {
+              title: "Logs",
+              cell: (ns) => <Link to={`/node/${ns.desc.node_id}/logs`}>Logs</Link>,
+              className: "expand-link",
+            },
+          ]} />
       </div>
     );
   }
@@ -208,69 +208,67 @@ class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
     const statusName = _.capitalize(LivenessStatus[status]);
 
     return (
-      <div>
+      <div className="embedded-table">
         <section className="section section--heading">
           <h2>{`${statusName} Nodes`}</h2>
         </section>
-        <section className="section">
-          <NodeSortedTable
-            data={statuses}
-            sortSetting={sortSetting}
-            onChangeSortSetting={(setting) => this.props.setSort(setting)}
-            columns={[
-              // Node ID column.
-              {
-                title: "ID",
-                cell: (ns) => `n${ns.desc.node_id}`,
-                sort: (ns) => ns.desc.node_id,
+        <NodeSortedTable
+          data={statuses}
+          sortSetting={sortSetting}
+          onChangeSortSetting={(setting) => this.props.setSort(setting)}
+          columns={[
+            // Node ID column.
+            {
+              title: "ID",
+              cell: (ns) => `n${ns.desc.node_id}`,
+              sort: (ns) => ns.desc.node_id,
+            },
+            // Node address column - displays the node address, links to the
+            // node-specific page for this node.
+            {
+              title: "Address",
+              cell: (ns) => {
+                return (
+                  <div>
+                    <div
+                      className="icon-circle-filled node-status-icon node-status-icon--dead"
+                      title={
+                        "This node has not reported as live for a significant period and is considered dead. " +
+                        "The cut-off period for dead nodes is configurable as cluster setting " +
+                        "'server.time_until_store_dead'"
+                      }
+                    />
+                    <Link to={`/node/${ns.desc.node_id}`}>{ns.desc.address.address_field}</Link>
+                  </div>
+                );
               },
-              // Node address column - displays the node address, links to the
-              // node-specific page for this node.
-              {
-                title: "Address",
-                cell: (ns) => {
-                  return (
-                    <div>
-                      <div
-                        className="icon-circle-filled node-status-icon node-status-icon--dead"
-                        title={
-                          "This node has not reported as live for a significant period and is considered dead. " +
-                          "The cut-off period for dead nodes is configurable as cluster setting " +
-                          "'server.time_until_store_dead'"
-                        }
-                      />
-                      <Link to={`/node/${ns.desc.node_id}`}>{ns.desc.address.address_field}</Link>
-                    </div>
-                  );
-                },
-                sort: (ns) => ns.desc.node_id,
-                // TODO(mrtracy): Consider if there is a better way to use BEM
-                // style CSS in cases like this; it is a bit awkward to write out
-                // the entire modifier class here, but it might not be better to
-                // construct the full BEM class in the table component itself.
-                className: "sort-table__cell--link",
-              },
-              // Down/decommissioned since - displays how long the node has been
-              // considered dead.
-              {
-                title: `${statusName} Since`,
-                cell: (ns) => {
-                  const liveness = nodesSummary.livenessByNodeID[ns.desc.node_id];
-                  if (!liveness) {
-                    return "no information";
-                  }
+              sort: (ns) => ns.desc.node_id,
+              // TODO(mrtracy): Consider if there is a better way to use BEM
+              // style CSS in cases like this; it is a bit awkward to write out
+              // the entire modifier class here, but it might not be better to
+              // construct the full BEM class in the table component itself.
+              className: "sort-table__cell--link",
+            },
+            // Down/decommissioned since - displays how long the node has been
+            // considered dead.
+            {
+              title: `${statusName} Since`,
+              cell: (ns) => {
+                const liveness = nodesSummary.livenessByNodeID[ns.desc.node_id];
+                if (!liveness) {
+                  return "no information";
+                }
 
-                  const deadTime = liveness.expiration.wall_time;
-                  const deadMoment = LongToMoment(deadTime);
-                  return `${moment.duration(deadMoment.diff(moment())).humanize()} ago`;
-                },
-                sort: (ns) => {
-                  const liveness = nodesSummary.livenessByNodeID[ns.desc.node_id];
-                  return liveness.expiration.wall_time;
-                },
+                const deadTime = liveness.expiration.wall_time;
+                const deadMoment = LongToMoment(deadTime);
+                return `${moment.duration(deadMoment.diff(moment())).humanize()} ago`;
               },
-            ]} />
-        </section>
+              sort: (ns) => {
+                const liveness = nodesSummary.livenessByNodeID[ns.desc.node_id];
+                return liveness.expiration.wall_time;
+              },
+            },
+          ]} />
       </div>
     );
   }

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -142,7 +142,7 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
                 const used = BytesUsed(ns);
                 return <BytesBarChart used={used} usable={usable} />;
               },
-              sort: (ns) => BytesUsed(ns),
+              sort: (ns) => BytesUsed(ns) / nodeCapacityStats(ns).usable,
             },
             // Mem Usage - total memory being used on this node.
             {
@@ -152,7 +152,7 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
                 const available = FixLong(ns.total_system_memory).toNumber();
                 return <BytesBarChart used={used} usable={available} />;
               },
-              sort: (ns) => ns.metrics[MetricConstants.rss],
+              sort: (ns) => ns.metrics[MetricConstants.rss] / FixLong(ns.total_system_memory).toNumber(),
             },
             // Version - the currently running version of cockroach.
             {

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/nodes.styl
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/nodes.styl
@@ -4,3 +4,12 @@
 
   .sort-table__cell:last-child
     border-right none
+
+.bar-chart__label
+  font-family Lato-Regular
+  font-size 12px
+  font-weight 300
+  fill #5f6c87
+
+.bar-chart__label.total
+  fill #cfd2dc

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/nodes.styl
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/nodes.styl
@@ -13,3 +13,9 @@
 
 .bar-chart__label.total
   fill #cfd2dc
+
+
+// The following rule is for Chrome, the height attribute applied
+// from JavaScript is for Firefox.
+.bar-chart__bar.used
+  height 5px

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/nodes.styl
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/nodes.styl
@@ -1,0 +1,6 @@
+.embedded-table .sort-table
+  border-left none
+  border-right none
+
+  .sort-table__cell:last-child
+    border-right none


### PR DESCRIPTION
Adds bar charts to capacity and memory columns on the node list.

![new-node-list](https://user-images.githubusercontent.com/793969/46502317-dccae700-c7f5-11e8-9c02-b3795137f10d.png)

Closes #29373