### PR TITLE
sql: remove protobuf output from `show zone configurations`

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1516,7 +1516,8 @@ func (s *adminServer) DataDistribution(
 
 	// Get zone configs.
 	// TODO(vilterp): this can be done in parallel with getting table/db names and replica counts.
-	zoneConfigsQuery := `SHOW ALL ZONE CONFIGURATIONS`
+	zoneConfigsQuery := `SELECT zone_id, cli_specifier, config_sql, config_protobuf 
+    FROM crdb_internal.zones WHERE cli_specifier IS NOT NULL`
 	rows2, _ /* cols */, err := s.server.internalExecutor.QueryWithUser(
 		ctx, "admin-replica-matrix", nil /* txn */, userName, zoneConfigsQuery,
 	)

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1676,11 +1676,16 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 
 // crdbInternalZonesTable decodes and exposes the zone configs in the
 // system.zones table.
+// The cli_specifier column is deprecated and only exists to be used
+// as a hidden field by the CLI for backwards compatibility. Use zone_name
+// instead.
 var crdbInternalZonesTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE crdb_internal.zones (
   zone_id          INT NOT NULL,
-  cli_specifier    STRING,
+  zone_name        STRING,
+  cli_specifier    STRING, -- this column is deprecated in favor of zone_name.
+                           -- It is kept for backwards compatibility with the CLI.
   config_yaml      STRING NOT NULL,
   config_sql       STRING, -- this column can be NULL if there is no specifier syntax
                            -- possible (e.g. the object was deleted).

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -195,10 +195,10 @@ SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name = ''
 ----
 descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
 
-query ITTTT colnames
+query ITTTTT colnames
 SELECT * FROM crdb_internal.zones WHERE false
 ----
-zone_id  cli_specifier  config_yaml  config_sql  config_protobuf
+zone_id  zone_name cli_specifier  config_yaml  config_sql  config_protobuf
 
 statement ok
 INSERT INTO system.zones (id, config) VALUES

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -81,15 +81,15 @@ SELECT * FROM [SHOW DATABASE]
 database
 test
 
-query ITTT colnames
+query TT colnames
 SELECT * FROM [SHOW ZONE CONFIGURATIONS] LIMIT 0
 ----
-zone_id  cli_specifier  config_sql  config_protobuf
+zone_name  config_sql
 
-query ITTT colnames
+query TT colnames
 SELECT * FROM [SHOW ZONE CONFIGURATION FOR TABLE system.users] LIMIT 0
 ----
-zone_id  cli_specifier  config_sql  config_protobuf
+zone_name  config_sql
 
 query T colnames
 SELECT * FROM [SHOW DATABASES]

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -226,7 +226,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         20 columns, 926 rows
+                     │                     size         20 columns, 927 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -217,7 +217,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         20 columns, 926 rows
+                     │                     size         20 columns, 927 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·

--- a/pkg/testutils/sqlutils/zone.go
+++ b/pkg/testutils/sqlutils/zone.go
@@ -111,7 +111,8 @@ func VerifyAllZoneConfigs(t testing.TB, sqlDB *SQLRunner, rows ...ZoneRow) {
 	}
 	sqlDB.CheckQueryResults(t, `
 SELECT zone_id, cli_specifier, config_protobuf
-  FROM [SHOW ALL ZONE CONFIGURATIONS]`, expected)
+  FROM crdb_internal.zones
+  WHERE cli_specifier IS NOT NULL`, expected)
 }
 
 // ZoneConfigExists returns whether a zone config with the provided cliSpecifier


### PR DESCRIPTION
This shouldn't be in the output for the 2.1 release,
the tests that use this to verify zone configs now
can use the `crdb_internal.zones` table.

Also as suggested by @knz we could change the name 
of the column from `cli_specifier` to `zone_name` but still
have an alias to the old name for backwards compat with the cli.
I haven't seen that done anywhere though, how can I do 
that exactly?

Release note: None