### PR TITLE
libroach: Be more paranoid in DBBatchInserter

### DIFF
--- a/c-deps/libroach/batch.cc
+++ b/c-deps/libroach/batch.cc
@@ -417,20 +417,35 @@ class DBBatchInserter : public rocksdb::WriteBatch::Handler {
  public:
   DBBatchInserter(rocksdb::WriteBatchBase* batch) : batch_(batch) {}
 
-  virtual void Put(const rocksdb::Slice& key, const rocksdb::Slice& value) {
-    batch_->Put(key, value);
+  virtual rocksdb::Status PutCF(uint32_t column_family_id, const rocksdb::Slice& key,
+    const rocksdb::Slice& value) {
+    if (column_family_id != 0) {
+      return rocksdb::Status::InvalidArgument("DBBatchInserter: column families not supported");
+    }
+    return batch_->Put(key, value);
   }
-  virtual void Delete(const rocksdb::Slice& key) { batch_->Delete(key); }
-  virtual void Merge(const rocksdb::Slice& key, const rocksdb::Slice& value) {
-    batch_->Merge(key, value);
+  virtual rocksdb::Status DeleteCF(uint32_t column_family_id, const rocksdb::Slice& key) {
+    if (column_family_id != 0) {
+      return rocksdb::Status::InvalidArgument("DBBatchInserter: column families not supported");
+    }
+    return batch_->Delete(key);
+  }
+  virtual rocksdb::Status SingleDeleteCF(uint32_t column_family_id, const rocksdb::Slice& key) {
+    return rocksdb::Status::InvalidArgument("DBBatchInserter: SingleDelete not supported");
+  }
+  virtual rocksdb::Status MergeCF(uint32_t column_family_id, const rocksdb::Slice& key,
+    const rocksdb::Slice& value) {
+    if (column_family_id != 0) {
+      return rocksdb::Status::InvalidArgument("DBBatchInserter: column families not supported");
+    }
+    return batch_->Merge(key, value);
   }
   virtual rocksdb::Status DeleteRangeCF(uint32_t column_family_id, const rocksdb::Slice& begin_key,
                                         const rocksdb::Slice& end_key) {
-    if (column_family_id == 0) {
-      batch_->DeleteRange(begin_key, end_key);
-      return rocksdb::Status::OK();
+    if (column_family_id != 0) {
+      return rocksdb::Status::InvalidArgument("DBBatchInserter: column families not supported");
     }
-    return rocksdb::Status::InvalidArgument("DeleteRangeCF not implemented");
+    return batch_->DeleteRange(begin_key, end_key);
   }
   virtual void LogData(const rocksdb::Slice& blob) { batch_->PutLogData(blob); }
 


### PR DESCRIPTION
Use the "CF" method variants which allow us to pass through errors
from our underlying batch instead of ignoring them. These methods
cannot currently fail (unless the optional batch max_size feature is
used, but we don't use it), but if that ever changes the errors would
be mystifying.

Also add a stub for SingleDeleteCF so the need to update this class
will be more apparent if we ever start using SingleDelete.

Release note: None