### PR TITLE
roachtest: Support default GOPATH

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -102,7 +102,7 @@ func findBinary(binary, defValue string) (string, error) {
 		// look in the cockroach repo.
 		gopath := os.Getenv("GOPATH")
 		if gopath == "" {
-			return "", errors.Wrap(err, "")
+			gopath = filepath.Join(os.Getenv("HOME"), "go")
 		}
 
 		var binSuffix string


### PR DESCRIPTION
GOPATH has been defaulting to `~/go` for several go releases now, but
roachtest would fail to find some binaries (such as `workload`) if it
was not set explicitly.

Release note: None