### PR TITLE
roachtest: replace roachtest run --dry-run

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -66,6 +66,8 @@ var (
 	zonesF                string
 	teamCity              bool
 	testingSkipValidation bool
+	// For the "list" command: list benchmarks instead of tests.
+	listBench bool
 )
 
 func ifLocal(trueVal, falseVal string) string {


### PR DESCRIPTION
... with a dedicated `roachtest list`.
The dryrun argument was polluting and indenting the code.

Release note: None