### PR TITLE
opt: Upgrade Optgen to infer and check types

### DIFF
--- a/pkg/sql/opt/optgen/cmd/langgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/langgen/exprs_gen.go
@@ -17,6 +17,8 @@ package main
 import (
 	"fmt"
 	"io"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang"
 )
@@ -47,6 +49,7 @@ func (g *exprsGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 		g.genValueFunc(define)
 		g.genVisitFunc(define)
 		g.genSourceFunc(define)
+		g.genInferredType(define)
 		g.genStringFunc(define)
 		g.genFormatFunc(define)
 	}
@@ -72,6 +75,9 @@ func (g *exprsGen) genExprType(define *lang.DefineExpr) {
 
 		if hasSourceField(define) {
 			fmt.Fprintf(g.w, "  Src *SourceLoc\n")
+		}
+		if define.Tags.Contains("HasType") {
+			fmt.Fprintf(g.w, "  Typ DataType")
 		}
 		fmt.Fprintf(g.w, "}\n\n")
 	}
@@ -271,6 +277,23 @@ func (g *exprsGen) genSourceFunc(define *lang.DefineExpr) {
 	fmt.Fprintf(g.w, "}\n\n")
 }
 
+// func (e *SomeExpr) InferredType() DataType {
+//   return e.Typ
+// }
+func (g *exprsGen) genInferredType(define *lang.DefineExpr) {
+	exprType := fmt.Sprintf("%sExpr", define.Name)
+
+	fmt.Fprintf(g.w, "func (e *%s) InferredType() DataType {\n", exprType)
+	if define.Tags.Contains("HasType") {
+		fmt.Fprintf(g.w, "  return e.Typ\n")
+	} else if isValueType(define) {
+		fmt.Fprintf(g.w, "  return %sDataType\n", title(g.translateType(valueType(define))))
+	} else {
+		fmt.Fprintf(g.w, "  return AnyDataType\n")
+	}
+	fmt.Fprintf(g.w, "}\n\n")
+}
+
 // func (e *SomeExpr) String() string {
 //   var buf bytes.Buffer
 //   e.Format(&buf, 0)
@@ -364,5 +387,11 @@ func sliceElementType(d *lang.DefineExpr) string {
 // hasSourceField returns true if the defined expression has a Src field that
 // stores the original source information (file, line, pos).
 func hasSourceField(d *lang.DefineExpr) bool {
-	return !isValueType(d) && !isSliceType(d) && len(d.Fields) > 0
+	return !isValueType(d) && !isSliceType(d)
+}
+
+// title returns the given string with its first letter capitalized.
+func title(name string) string {
+	rune, size := utf8.DecodeRuneInString(name)
+	return fmt.Sprintf("%c%s", unicode.ToUpper(rune), name[size:])
 }

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/compile
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/compile
@@ -33,14 +33,16 @@ define Not {
 					(Func
 						Name=Not
 						Args=(Slice
-							(Bind Label="input" Target=(Any) Src=<test.opt:7:11>)
+							(Bind Label="input" Target=(Any Typ=Expr) Typ=Expr Src=<test.opt:7:11>)
 						)
+						Typ=Not
 						Src=<test.opt:7:6>
 					)
 				)
+				Typ=Not
 				Src=<test.opt:7:1>
 			)
-			Replace=(Ref Label="input" Src=<test.opt:7:25>)
+			Replace=(Ref Label="input" Typ=Expr Src=<test.opt:7:25>)
 			Src=<test.opt:6:1>
 		)
 	)

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
@@ -1018,15 +1018,15 @@ define ScalarGroupBy {
     Def   GroupByDef
 }
 
-define LookupJoin {
+define DistinctOn {
     Input Expr
     On    Expr
-    Def   LookupJoinDef
+    Def   GroupByDef
 }
 
 [Test, Normalize]
 (Select
-    $input:(LookupJoin | GroupByOps
+    $input:(DistinctOn | GroupByOps
         $expr1:*
         $expr2:*
         $private:*
@@ -1057,13 +1057,6 @@ func (_f *Factory) InternGroupByDef(val *memo.GroupByDef) memo.PrivateID {
 	return _f.mem.InternGroupByDef(val)
 }
 
-// InternLookupJoinDef adds the given value to the memo and returns an ID that
-// can be used for later lookup. If the same value was added previously,
-// this method is a no-op and returns the ID of the previous value.
-func (_f *Factory) InternLookupJoinDef(val *memo.LookupJoinDef) memo.PrivateID {
-	return _f.mem.InternLookupJoinDef(val)
-}
-
 // ConstructSelect constructs an expression for the Select operator.
 func (_f *Factory) ConstructSelect(
 	input memo.GroupID,
@@ -1078,7 +1071,7 @@ func (_f *Factory) ConstructSelect(
 	// [Test]
 	{
 		_expr := _f.mem.NormExpr(input)
-		if _expr.Operator() == opt.LookupJoinOp || _expr.IsGroupByOps() {
+		if _expr.Operator() == opt.DistinctOnOp || _expr.IsGroupByOps() {
 			expr1 := _expr.ChildGroup(_f.Memo(), 0)
 			expr2 := _expr.ChildGroup(_f.Memo(), 1)
 			private := _expr.PrivateID()
@@ -1135,19 +1128,19 @@ func (_f *Factory) ConstructScalarGroupBy(
 	return _f.onConstruct(memo.Expr(_scalarGroupByExpr))
 }
 
-// ConstructLookupJoin constructs an expression for the LookupJoin operator.
-func (_f *Factory) ConstructLookupJoin(
+// ConstructDistinctOn constructs an expression for the DistinctOn operator.
+func (_f *Factory) ConstructDistinctOn(
 	input memo.GroupID,
 	on memo.GroupID,
 	def memo.PrivateID,
 ) memo.GroupID {
-	_lookupJoinExpr := memo.MakeLookupJoinExpr(input, on, def)
-	_group := _f.mem.GroupByFingerprint(_lookupJoinExpr.Fingerprint())
+	_distinctOnExpr := memo.MakeDistinctOnExpr(input, on, def)
+	_group := _f.mem.GroupByFingerprint(_distinctOnExpr.Fingerprint())
 	if _group != 0 {
 		return _group
 	}
 
-	return _f.onConstruct(memo.Expr(_lookupJoinExpr))
+	return _f.onConstruct(memo.Expr(_distinctOnExpr))
 }
 
 func (f *Factory) assignPlaceholders(group memo.GroupID) (memo.GroupID, error) {
@@ -1191,18 +1184,18 @@ func (f *Factory) assignPlaceholders(group memo.GroupID) (memo.GroupID, error) {
 		}
 		def := scalarGroupByExpr.Def()
 		return f.ConstructScalarGroupBy(input, aggs, def), nil
-	case opt.LookupJoinOp:
-		lookupJoinExpr := expr.AsLookupJoin()
-		input, err := f.assignPlaceholders(lookupJoinExpr.Input())
+	case opt.DistinctOnOp:
+		distinctOnExpr := expr.AsDistinctOn()
+		input, err := f.assignPlaceholders(distinctOnExpr.Input())
 		if err != nil {
 			return 0, err
 		}
-		on, err := f.assignPlaceholders(lookupJoinExpr.On())
+		on, err := f.assignPlaceholders(distinctOnExpr.On())
 		if err != nil {
 			return 0, err
 		}
-		def := lookupJoinExpr.Def()
-		return f.ConstructLookupJoin(input, on, def), nil
+		def := distinctOnExpr.Def()
+		return f.ConstructDistinctOn(input, on, def), nil
 	case opt.PlaceholderOp:
 		value := expr.AsPlaceholder().Value()
 		placeholder := f.mem.LookupPrivate(value).(*tree.Placeholder)
@@ -1240,9 +1233,9 @@ func init() {
 		return f.ConstructScalarGroupBy(memo.GroupID(operands[0]), memo.GroupID(operands[1]), memo.PrivateID(operands[2]))
 	}
 
-	// LookupJoinOp
-	dynConstructLookup[opt.LookupJoinOp] = func(f *Factory, operands memo.DynamicOperands) memo.GroupID {
-		return f.ConstructLookupJoin(memo.GroupID(operands[0]), memo.GroupID(operands[1]), memo.PrivateID(operands[2]))
+	// DistinctOnOp
+	dynConstructLookup[opt.DistinctOnOp] = func(f *Factory, operands memo.DynamicOperands) memo.GroupID {
+		return f.ConstructDistinctOn(memo.GroupID(operands[0]), memo.GroupID(operands[1]), memo.PrivateID(operands[2]))
 	}
 
 }

--- a/pkg/sql/opt/optgen/lang/data_type.go
+++ b/pkg/sql/opt/optgen/lang/data_type.go
@@ -1,0 +1,194 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package lang
+
+import (
+	"bytes"
+)
+
+// AnyDataType is a data type about which nothing is known, and so could be any
+// data type. Among other uses, it is assigned to custom functions:
+//
+//   (Scan $def:*) => (ConstrainScan $def)
+//
+// The ConstrainScan custom function has the AnyDataType assigned to it, since
+// the return type of the function is not known.
+var AnyDataType = &ExternalDataType{Name: "<any>"}
+
+// ListDataType indicates that a pattern matches or constructs a list of
+// expressions. For example:
+//
+//   (Tuple $list:[ $item:* ]) => $item
+//
+// The $list binding will have the ListDataType.
+var ListDataType = &ExternalDataType{Name: "<list>"}
+
+// StringDataType is a singleton instance of the "string" external data type.
+var StringDataType = &ExternalDataType{Name: "<string>"}
+
+// Int64DataType is a singleton instance of the "int64" external data type.
+var Int64DataType = &ExternalDataType{Name: "<int64>"}
+
+// DataType is a marker interface implemented by structs that describe the kind
+// of data that will be returned by an expression in a match or replace pattern.
+// See DataType implementations for more specific information.
+type DataType interface {
+	dataType()
+	String() string
+}
+
+// DefineSetDataType indicates that a pattern matches or constructs one of
+// several possible defined operators. For example:
+//
+//   (Eq | Ne $left:* $right:*) => (True)
+//
+// The top-level match pattern would have a DefineSetDataType that referenced
+// the defines for the Eq and Ne operators.
+type DefineSetDataType struct {
+	Defines DefineSetExpr
+}
+
+// dataType is part of the DataType interface.
+func (d *DefineSetDataType) dataType() {}
+
+// String is part of the DataType interface.
+func (d *DefineSetDataType) String() string {
+	var buf bytes.Buffer
+	if len(d.Defines) > 1 {
+		buf.WriteRune('[')
+	}
+	for i, define := range d.Defines {
+		if i != 0 {
+			buf.WriteString(" | ")
+		}
+		buf.WriteString(string(define.Name))
+	}
+	if len(d.Defines) > 1 {
+		buf.WriteRune(']')
+	}
+	return buf.String()
+}
+
+// ExternalDataType indicates that a pattern matches or constructs a non-
+// operator type referenced in a Define. For example:
+//
+//   define Scan {
+//     Def ScanDef
+//   }
+//
+//   (Scan $def:*) => (ConstrainScan $def)
+//
+// Here, $def will have an ExternalDataType with Name equal to "ScanDef".
+type ExternalDataType struct {
+	Name string
+}
+
+// dataType is part of the DataType interface.
+func (d *ExternalDataType) dataType() {}
+
+// String is part of the DataType interface.
+func (d *ExternalDataType) String() string {
+	return d.Name
+}
+
+// DoTypesContradict returns true if two types cannot both be assigned to same
+// expression.
+func DoTypesContradict(dt1, dt2 DataType) bool {
+	if dt1 == dt2 || dt1 == AnyDataType || dt2 == AnyDataType {
+		return false
+	}
+
+	switch t1 := dt1.(type) {
+	case *DefineSetDataType:
+		switch t2 := dt2.(type) {
+		case *DefineSetDataType:
+			// Ensure that smaller set is a subset of the larger set.
+			if len(t2.Defines) > len(t1.Defines) {
+				t1, t2 = t2, t1
+			}
+			set := make(map[StringExpr]bool)
+			for _, d := range t1.Defines {
+				set[d.Name] = true
+			}
+			for _, d := range t2.Defines {
+				if !set[d.Name] {
+					return true
+				}
+			}
+			return false
+
+		case *ExternalDataType:
+			// An operator type is not assignable to a list, string, or int64,
+			// so return contradiction for builtin types. However, an operator
+			// type might be assignable to other external data types (e.g.
+			// opt.Expr), so no conclusions can be drawn there.
+			return IsBuiltinType(dt2)
+		}
+
+	case *ExternalDataType:
+		switch t2 := dt2.(type) {
+		case *DefineSetDataType:
+			// See above comment for flipped case.
+			return IsBuiltinType(dt1)
+
+		case *ExternalDataType:
+			// If neither or both types are builtin, require names to match,
+			// since it's known that list, string, and int64 types are not
+			// assignable to one another.
+			if !IsBuiltinType(dt1) && !IsBuiltinType(dt2) {
+				return t1.Name != t2.Name
+			}
+			if IsBuiltinType(dt1) && IsBuiltinType(dt2) {
+				return t1.Name != t2.Name
+			}
+
+			// Otherwise, assume types are compatible, since nothing more is
+			// known about the external data type.
+			return false
+		}
+	}
+	panic("unhandled data type")
+}
+
+// IsBuiltinType returns true if the data type is one of List, String, or Int64.
+func IsBuiltinType(dt DataType) bool {
+	return dt == ListDataType || dt == StringDataType || dt == Int64DataType
+}
+
+// IsTypeMoreRestrictive returns true if the first data type gives more complete
+// and detailed information than the second.
+func IsTypeMoreRestrictive(dt1, dt2 DataType) bool {
+	switch t1 := dt1.(type) {
+	case *DefineSetDataType:
+		if t2, ok := dt2.(*DefineSetDataType); ok {
+			// More restrictive data type is assumed to be one that matches or
+			// constructs fewer possible operators.
+			return len(t1.Defines) < len(t2.Defines)
+		}
+
+		// DefineSetDataType is more restrictive than other concrete data types.
+		return true
+
+	case *ExternalDataType:
+		if dt1 == AnyDataType {
+			return false
+		}
+		if dt1 == ListDataType {
+			return dt2 == AnyDataType
+		}
+		return dt2 == ListDataType || dt2 == AnyDataType
+	}
+	panic("unhandled data type")
+}

--- a/pkg/sql/opt/optgen/lang/doc.go
+++ b/pkg/sql/opt/optgen/lang/doc.go
@@ -388,9 +388,9 @@ invocations, or lists. Here is an example:
 
 Dynamic Construction
 
-Sometimes the name of a constructed node can be one of several choices, and may
-not even be known at compile-time. The built-in "OpName" function can be used
-to dynamically construct the right kind of node. For example:
+Sometimes the name of a constructed node can be one of several choices. The
+built-in "OpName" function can be used to dynamically construct the right kind
+of node. For example:
 
   [NormalizeVar]
   (Eq | Ne
@@ -454,6 +454,45 @@ name is passed as a parameter to two functions in this example:
   =>
   (ConstructBinary Minus $right $left)
 
+Type Inference
+
+Expressions in both the match and replace patterns are assigned a data type
+that describes the kind of data that will be returned by the expression. These
+types are inferred using a combination of top-down and bottom-up type inference
+rules. For example:
+
+  define Select {
+    Input  Expr
+    Filter Expr
+  }
+
+  (Select $input:(LeftJoin | RightJoin) $filter:*) => $input
+
+The type of $input is inferred as "LeftJoin | RightJoin" by bubbling up the type
+of the bound expression. That type is propagated to the $input reference in the
+replace pattern. By contrast, the type of the * expression is inferred to be
+"Expr" using a top-down type inference rule, since the second argument to the
+Select operator is known to have type "Expr".
+
+When multiple types are inferred for an expression using different type
+inference rules, the more restrictive type is assigned to the expression. For
+example:
+
+  (Select $input:* & (LeftJoin)) => $input
+
+Here, the left input to the And expression was inferred to have type "Expr" and
+the right input to have type "LeftJoin". Since "LeftJoin" is the more
+restrictive type, the And expression and the $input binding are typed as
+"LeftJoin".
+
+Type inference detects and reports type contradictions, which occur when
+multiple incompatible types are inferred for an expression. For example:
+
+  (Select $input:(InnerJoin) & (LeftJoin)) => $input
+
+Because the input cannot be both an InnerJoin and a LeftJoin, Optgen reports a
+type contradiction error.
+
 Syntax
 
 This section describes the Optgen language syntax in a variant of extended
@@ -495,7 +534,7 @@ represented as single-quoted strings above:
 
   STRING     = " [^"\n]* "
   NUMBER     = UnicodeDigit+
-  IDENT      = UnicodeLetter (UnicodeLetter | UnicodeNumber)*
+  IDENT      = (UnicodeLetter | '_') (UnicodeLetter | '_' | UnicodeNumber)*
   COMMENT    = '#' .* \n
   WHITESPACE = UnicodeSpace+
 

--- a/pkg/sql/opt/optgen/lang/expr.og.go
+++ b/pkg/sql/opt/optgen/lang/expr.og.go
@@ -57,6 +57,10 @@ func (e *RootExpr) Source() *SourceLoc {
 	return e.Src
 }
 
+func (e *RootExpr) InferredType() DataType {
+	return AnyDataType
+}
+
 func (e *RootExpr) String() string {
 	var buf bytes.Buffer
 	e.Format(&buf, 0)
@@ -105,6 +109,10 @@ func (e *DefineSetExpr) Source() *SourceLoc {
 	return nil
 }
 
+func (e *DefineSetExpr) InferredType() DataType {
+	return AnyDataType
+}
+
 func (e *DefineSetExpr) String() string {
 	var buf bytes.Buffer
 	e.Format(&buf, 0)
@@ -151,6 +159,10 @@ func (e *RuleSetExpr) Visit(visit VisitFunc) Expr {
 
 func (e *RuleSetExpr) Source() *SourceLoc {
 	return nil
+}
+
+func (e *RuleSetExpr) InferredType() DataType {
+	return AnyDataType
 }
 
 func (e *RuleSetExpr) String() string {
@@ -223,6 +235,10 @@ func (e *DefineExpr) Source() *SourceLoc {
 	return e.Src
 }
 
+func (e *DefineExpr) InferredType() DataType {
+	return AnyDataType
+}
+
 func (e *DefineExpr) String() string {
 	var buf bytes.Buffer
 	e.Format(&buf, 0)
@@ -271,6 +287,10 @@ func (e *CommentsExpr) Source() *SourceLoc {
 	return nil
 }
 
+func (e *CommentsExpr) InferredType() DataType {
+	return AnyDataType
+}
+
 func (e *CommentsExpr) String() string {
 	var buf bytes.Buffer
 	e.Format(&buf, 0)
@@ -309,6 +329,10 @@ func (e *CommentExpr) Visit(visit VisitFunc) Expr {
 
 func (e *CommentExpr) Source() *SourceLoc {
 	return nil
+}
+
+func (e *CommentExpr) InferredType() DataType {
+	return StringDataType
 }
 
 func (e *CommentExpr) String() string {
@@ -359,6 +383,10 @@ func (e *TagsExpr) Source() *SourceLoc {
 	return nil
 }
 
+func (e *TagsExpr) InferredType() DataType {
+	return AnyDataType
+}
+
 func (e *TagsExpr) String() string {
 	var buf bytes.Buffer
 	e.Format(&buf, 0)
@@ -397,6 +425,10 @@ func (e *TagExpr) Visit(visit VisitFunc) Expr {
 
 func (e *TagExpr) Source() *SourceLoc {
 	return nil
+}
+
+func (e *TagExpr) InferredType() DataType {
+	return StringDataType
 }
 
 func (e *TagExpr) String() string {
@@ -445,6 +477,10 @@ func (e *DefineFieldsExpr) Visit(visit VisitFunc) Expr {
 
 func (e *DefineFieldsExpr) Source() *SourceLoc {
 	return nil
+}
+
+func (e *DefineFieldsExpr) InferredType() DataType {
+	return AnyDataType
 }
 
 func (e *DefineFieldsExpr) String() string {
@@ -505,6 +541,10 @@ func (e *DefineFieldExpr) Visit(visit VisitFunc) Expr {
 
 func (e *DefineFieldExpr) Source() *SourceLoc {
 	return e.Src
+}
+
+func (e *DefineFieldExpr) InferredType() DataType {
+	return AnyDataType
 }
 
 func (e *DefineFieldExpr) String() string {
@@ -582,6 +622,10 @@ func (e *RuleExpr) Source() *SourceLoc {
 	return e.Src
 }
 
+func (e *RuleExpr) InferredType() DataType {
+	return AnyDataType
+}
+
 func (e *RuleExpr) String() string {
 	var buf bytes.Buffer
 	e.Format(&buf, 0)
@@ -596,6 +640,7 @@ type FuncExpr struct {
 	Name Expr
 	Args SliceExpr
 	Src  *SourceLoc
+	Typ  DataType
 }
 
 func (e *FuncExpr) Op() Operator {
@@ -640,6 +685,10 @@ func (e *FuncExpr) Visit(visit VisitFunc) Expr {
 
 func (e *FuncExpr) Source() *SourceLoc {
 	return e.Src
+}
+
+func (e *FuncExpr) InferredType() DataType {
+	return e.Typ
 }
 
 func (e *FuncExpr) String() string {
@@ -690,6 +739,10 @@ func (e *NamesExpr) Source() *SourceLoc {
 	return nil
 }
 
+func (e *NamesExpr) InferredType() DataType {
+	return AnyDataType
+}
+
 func (e *NamesExpr) String() string {
 	var buf bytes.Buffer
 	e.Format(&buf, 0)
@@ -730,6 +783,10 @@ func (e *NameExpr) Source() *SourceLoc {
 	return nil
 }
 
+func (e *NameExpr) InferredType() DataType {
+	return StringDataType
+}
+
 func (e *NameExpr) String() string {
 	var buf bytes.Buffer
 	e.Format(&buf, 0)
@@ -744,6 +801,7 @@ type AndExpr struct {
 	Left  Expr
 	Right Expr
 	Src   *SourceLoc
+	Typ   DataType
 }
 
 func (e *AndExpr) Op() Operator {
@@ -790,6 +848,10 @@ func (e *AndExpr) Source() *SourceLoc {
 	return e.Src
 }
 
+func (e *AndExpr) InferredType() DataType {
+	return e.Typ
+}
+
 func (e *AndExpr) String() string {
 	var buf bytes.Buffer
 	e.Format(&buf, 0)
@@ -803,6 +865,7 @@ func (e *AndExpr) Format(buf *bytes.Buffer, level int) {
 type NotExpr struct {
 	Input Expr
 	Src   *SourceLoc
+	Typ   DataType
 }
 
 func (e *NotExpr) Op() Operator {
@@ -845,6 +908,10 @@ func (e *NotExpr) Source() *SourceLoc {
 	return e.Src
 }
 
+func (e *NotExpr) InferredType() DataType {
+	return e.Typ
+}
+
 func (e *NotExpr) String() string {
 	var buf bytes.Buffer
 	e.Format(&buf, 0)
@@ -858,6 +925,7 @@ func (e *NotExpr) Format(buf *bytes.Buffer, level int) {
 type ListExpr struct {
 	Items SliceExpr
 	Src   *SourceLoc
+	Typ   DataType
 }
 
 func (e *ListExpr) Op() Operator {
@@ -900,6 +968,10 @@ func (e *ListExpr) Source() *SourceLoc {
 	return e.Src
 }
 
+func (e *ListExpr) InferredType() DataType {
+	return e.Typ
+}
+
 func (e *ListExpr) String() string {
 	var buf bytes.Buffer
 	e.Format(&buf, 0)
@@ -911,6 +983,7 @@ func (e *ListExpr) Format(buf *bytes.Buffer, level int) {
 }
 
 type ListAnyExpr struct {
+	Src *SourceLoc
 }
 
 func (e *ListAnyExpr) Op() Operator {
@@ -938,7 +1011,11 @@ func (e *ListAnyExpr) Visit(visit VisitFunc) Expr {
 }
 
 func (e *ListAnyExpr) Source() *SourceLoc {
-	return nil
+	return e.Src
+}
+
+func (e *ListAnyExpr) InferredType() DataType {
+	return AnyDataType
 }
 
 func (e *ListAnyExpr) String() string {
@@ -955,6 +1032,7 @@ type BindExpr struct {
 	Label  StringExpr
 	Target Expr
 	Src    *SourceLoc
+	Typ    DataType
 }
 
 func (e *BindExpr) Op() Operator {
@@ -1001,6 +1079,10 @@ func (e *BindExpr) Source() *SourceLoc {
 	return e.Src
 }
 
+func (e *BindExpr) InferredType() DataType {
+	return e.Typ
+}
+
 func (e *BindExpr) String() string {
 	var buf bytes.Buffer
 	e.Format(&buf, 0)
@@ -1014,6 +1096,7 @@ func (e *BindExpr) Format(buf *bytes.Buffer, level int) {
 type RefExpr struct {
 	Label StringExpr
 	Src   *SourceLoc
+	Typ   DataType
 }
 
 func (e *RefExpr) Op() Operator {
@@ -1056,6 +1139,10 @@ func (e *RefExpr) Source() *SourceLoc {
 	return e.Src
 }
 
+func (e *RefExpr) InferredType() DataType {
+	return e.Typ
+}
+
 func (e *RefExpr) String() string {
 	var buf bytes.Buffer
 	e.Format(&buf, 0)
@@ -1067,6 +1154,8 @@ func (e *RefExpr) Format(buf *bytes.Buffer, level int) {
 }
 
 type AnyExpr struct {
+	Src *SourceLoc
+	Typ DataType
 }
 
 func (e *AnyExpr) Op() Operator {
@@ -1094,7 +1183,11 @@ func (e *AnyExpr) Visit(visit VisitFunc) Expr {
 }
 
 func (e *AnyExpr) Source() *SourceLoc {
-	return nil
+	return e.Src
+}
+
+func (e *AnyExpr) InferredType() DataType {
+	return e.Typ
 }
 
 func (e *AnyExpr) String() string {
@@ -1142,6 +1235,10 @@ func (e *SliceExpr) Source() *SourceLoc {
 	return nil
 }
 
+func (e *SliceExpr) InferredType() DataType {
+	return AnyDataType
+}
+
 func (e *SliceExpr) String() string {
 	var buf bytes.Buffer
 	e.Format(&buf, 0)
@@ -1180,6 +1277,10 @@ func (e *StringExpr) Visit(visit VisitFunc) Expr {
 
 func (e *StringExpr) Source() *SourceLoc {
 	return nil
+}
+
+func (e *StringExpr) InferredType() DataType {
+	return StringDataType
 }
 
 func (e *StringExpr) String() string {
@@ -1222,6 +1323,10 @@ func (e *NumberExpr) Source() *SourceLoc {
 	return nil
 }
 
+func (e *NumberExpr) InferredType() DataType {
+	return Int64DataType
+}
+
 func (e *NumberExpr) String() string {
 	var buf bytes.Buffer
 	e.Format(&buf, 0)
@@ -1236,6 +1341,7 @@ type CustomFuncExpr struct {
 	Name NameExpr
 	Args SliceExpr
 	Src  *SourceLoc
+	Typ  DataType
 }
 
 func (e *CustomFuncExpr) Op() Operator {
@@ -1280,6 +1386,10 @@ func (e *CustomFuncExpr) Visit(visit VisitFunc) Expr {
 
 func (e *CustomFuncExpr) Source() *SourceLoc {
 	return e.Src
+}
+
+func (e *CustomFuncExpr) InferredType() DataType {
+	return e.Typ
 }
 
 func (e *CustomFuncExpr) String() string {

--- a/pkg/sql/opt/optgen/lang/lang.opt
+++ b/pkg/sql/opt/optgen/lang/lang.opt
@@ -92,6 +92,7 @@ define Rule {
     Replace  Expr
 }
 
+[HasType]
 define Func {
     Name Expr
     Args Slice
@@ -109,15 +110,18 @@ define Name {
     Value string
 }
 
+[HasType]
 define And {
     Left  Expr
     Right Expr
 }
 
+[HasType]
 define Not {
     Input Expr
 }
 
+[HasType]
 define List {
     Items Slice
 }
@@ -125,15 +129,18 @@ define List {
 define ListAny {
 }
 
+[HasType]
 define Bind {
     Label  String
     Target Expr
 }
 
+[HasType]
 define Ref {
     Label String
 }
 
+[HasType]
 define Any {
 }
 
@@ -160,6 +167,7 @@ define Number {
 # compiler, in order to make further processing of the tree easier.
 #
 
+[HasType]
 define CustomFunc {
     Name Name
     Args Slice

--- a/pkg/sql/opt/optgen/lang/parser.go
+++ b/pkg/sql/opt/optgen/lang/parser.go
@@ -425,7 +425,8 @@ func (p *Parser) parseExpr() Expr {
 		return p.parseList()
 
 	case ASTERISK:
-		return &AnyExpr{}
+		src := p.src
+		return &AnyExpr{Src: &src}
 
 	case IDENT:
 		name := NameExpr(p.s.Literal())
@@ -487,7 +488,8 @@ func (p *Parser) parseList() Expr {
 // list-child = list-any | arg
 func (p *Parser) parseListChild() Expr {
 	if p.scan() == ELLIPSES {
-		return &ListAnyExpr{}
+		src := p.src
+		return &ListAnyExpr{Src: &src}
 	}
 	p.unscan()
 	return p.parseArg()

--- a/pkg/sql/opt/optgen/lang/scanner.go
+++ b/pkg/sql/opt/optgen/lang/scanner.go
@@ -145,8 +145,8 @@ func (s *Scanner) Scan() Token {
 		return s.scanWhitespace()
 	}
 
-	// If we see a letter then consume as an identifier or keyword.
-	if unicode.IsLetter(ch) {
+	// If we see a letter or underscore then consume as an identifier or keyword.
+	if unicode.IsLetter(ch) || ch == '_' {
 		s.unread()
 		return s.scanIdentifier()
 	}
@@ -358,7 +358,7 @@ func (s *Scanner) scanIdentifier() Token {
 			break
 		}
 
-		if !unicode.IsLetter(ch) && !unicode.IsDigit(ch) {
+		if !unicode.IsLetter(ch) && !unicode.IsDigit(ch) && ch != '_' {
 			s.unread()
 			break
 		}

--- a/pkg/sql/opt/optgen/lang/testdata/compiler
+++ b/pkg/sql/opt/optgen/lang/testdata/compiler
@@ -33,17 +33,19 @@ define Join {
 			Match=(Func
 				Name=Join
 				Args=(Slice
-					(Bind Label="left" Target=(Any) Src=<test.opt:9:7>)
-					(Bind Label="right" Target=(Any) Src=<test.opt:9:15>)
+					(Bind Label="left" Target=(Any Typ=Expr) Typ=Expr Src=<test.opt:9:7>)
+					(Bind Label="right" Target=(Any Typ=Expr) Typ=Expr Src=<test.opt:9:15>)
 				)
+				Typ=Join
 				Src=<test.opt:9:1>
 			)
 			Replace=(Func
 				Name=Join
 				Args=(Slice
-					(Ref Label="right" Src=<test.opt:9:34>)
-					(Ref Label="left" Src=<test.opt:9:41>)
+					(Ref Label="right" Typ=Expr Src=<test.opt:9:34>)
+					(Ref Label="left" Typ=Expr Src=<test.opt:9:41>)
 				)
+				Typ=Join
 				Src=<test.opt:9:28>
 			)
 			Src=<test.opt:8:1>
@@ -115,20 +117,24 @@ define Project {
 				Name=InnerJoin
 				Args=(Slice
 					(And
-						Left=(Any)
+						Left=(Any Typ=Expr)
 						Right=(CustomFunc
 							Name=Func
 							Args=(Slice InnerJoin)
+							Typ=Expr
 							Src=<test.opt:17:21>
 						)
+						Typ=Expr
 						Src=<test.opt:17:17>
 					)
 				)
+				Typ=InnerJoin
 				Src=<test.opt:17:1>
 			)
 			Replace=(Func
 				Name=InnerJoin
 				Args=(Slice InnerJoin)
+				Typ=InnerJoin
 				Src=<test.opt:17:41>
 			)
 			Src=<test.opt:16:1>
@@ -141,20 +147,24 @@ define Project {
 				Name=LeftJoin
 				Args=(Slice
 					(And
-						Left=(Any)
+						Left=(Any Typ=Expr)
 						Right=(CustomFunc
 							Name=Func
 							Args=(Slice LeftJoin)
+							Typ=Expr
 							Src=<test.opt:17:21>
 						)
+						Typ=Expr
 						Src=<test.opt:17:17>
 					)
 				)
+				Typ=LeftJoin
 				Src=<test.opt:17:1>
 			)
 			Replace=(Func
 				Name=LeftJoin
 				Args=(Slice LeftJoin)
+				Typ=LeftJoin
 				Src=<test.opt:17:41>
 			)
 			Src=<test.opt:16:1>
@@ -167,20 +177,24 @@ define Project {
 				Name=Project
 				Args=(Slice
 					(And
-						Left=(Any)
+						Left=(Any Typ=Expr)
 						Right=(CustomFunc
 							Name=Func
 							Args=(Slice Project)
+							Typ=Expr
 							Src=<test.opt:17:21>
 						)
+						Typ=Expr
 						Src=<test.opt:17:17>
 					)
 				)
+				Typ=Project
 				Src=<test.opt:17:1>
 			)
 			Replace=(Func
 				Name=Project
 				Args=(Slice Project)
+				Typ=Project
 				Src=<test.opt:17:41>
 			)
 			Src=<test.opt:16:1>
@@ -229,7 +243,7 @@ define SubOp2 {}
 					(Bind
 						Label="input"
 						Target=(And
-							Left=(Func Name=SubOp1 Args=(Slice) Src=<test.opt:8:12>)
+							Left=(Func Name=SubOp1 Args=(Slice) Typ=SubOp1 Src=<test.opt:8:12>)
 							Right=(Not
 								Input=(CustomFunc
 									Name=Func
@@ -242,28 +256,23 @@ define SubOp2 {}
 											Src=<test.opt:8:30>
 										)
 									)
+									Typ=Expr
 									Src=<test.opt:8:24>
 								)
+								Typ=Expr
 								Src=<test.opt:8:23>
 							)
+							Typ=SubOp1
 							Src=<test.opt:8:12>
 						)
+						Typ=SubOp1
 						Src=<test.opt:8:5>
 					)
 				)
+				Typ=Op
 				Src=<test.opt:8:1>
 			)
-			Replace=(Func
-				Name=(CustomFunc
-					Name=OpName
-					Args=(Slice
-						(Ref Label="input" Src=<test.opt:8:60>)
-					)
-					Src=<test.opt:8:52>
-				)
-				Args=(Slice)
-				Src=<test.opt:8:51>
-			)
+			Replace=(Func Name=SubOp1 Args=(Slice) Typ=SubOp1 Src=<test.opt:8:51>)
 			Src=<test.opt:7:1>
 		)
 		(Rule
@@ -279,6 +288,7 @@ define SubOp2 {}
 							Left=(Func
 								Name=(Names SubOp1 SubOp2)
 								Args=(Slice)
+								Typ=[SubOp1 | SubOp2]
 								Src=<test.opt:11:12>
 							)
 							Right=(CustomFunc
@@ -292,24 +302,29 @@ define SubOp2 {}
 										Src=<test.opt:11:38>
 									)
 								)
+								Typ=Expr
 								Src=<test.opt:11:32>
 							)
+							Typ=[SubOp1 | SubOp2]
 							Src=<test.opt:11:12>
 						)
+						Typ=[SubOp1 | SubOp2]
 						Src=<test.opt:11:5>
 					)
 				)
+				Typ=Op
 				Src=<test.opt:11:1>
 			)
 			Replace=(Func
 				Name=(CustomFunc
 					Name=OpName
 					Args=(Slice
-						(Ref Label="input" Src=<test.opt:11:68>)
+						(Ref Label="input" Typ=[SubOp1 | SubOp2] Src=<test.opt:11:68>)
 					)
 					Src=<test.opt:11:60>
 				)
 				Args=(Slice)
+				Typ=[SubOp1 | SubOp2]
 				Src=<test.opt:11:59>
 			)
 			Src=<test.opt:10:1>
@@ -351,7 +366,7 @@ define Op {
 					(Bind
 						Label="input"
 						Target=(And
-							Left=(Any)
+							Left=(Any Typ=Expr)
 							Right=(CustomFunc
 								Name=Func
 								Args=(Slice
@@ -365,16 +380,20 @@ define Op {
 										Src=<test.opt:6:29>
 									)
 								)
+								Typ=Expr
 								Src=<test.opt:6:16>
 							)
+							Typ=Expr
 							Src=<test.opt:6:12>
 						)
+						Typ=Expr
 						Src=<test.opt:6:5>
 					)
 				)
+				Typ=Op
 				Src=<test.opt:6:1>
 			)
-			Replace=(Ref Label="input" Src=<test.opt:6:64>)
+			Replace=(Ref Label="input" Typ=Expr Src=<test.opt:6:64>)
 			Src=<test.opt:5:1>
 		)
 	)
@@ -418,13 +437,17 @@ define Op {
 							Right=(CustomFunc
 								Name=Func
 								Args=(Slice "bar")
+								Typ=Expr
 								Src=<test.opt:6:20>
 							)
+							Typ=<string>
 							Src=<test.opt:6:12>
 						)
+						Typ=<string>
 						Src=<test.opt:6:5>
 					)
 				)
+				Typ=Op
 				Src=<test.opt:6:1>
 			)
 			Replace=(Func
@@ -433,9 +456,11 @@ define Op {
 					(CustomFunc
 						Name=Func
 						Args=(Slice "bar")
+						Typ=Expr
 						Src=<test.opt:6:41>
 					)
 				)
+				Typ=Op
 				Src=<test.opt:6:37>
 			)
 			Src=<test.opt:5:1>
@@ -501,37 +526,43 @@ define Op {
 					(List
 						Items=(Slice
 							(ListAny)
-							(Func Name=Op Args=(Slice) Src=<test.opt:12:11>)
+							(Func Name=Op Args=(Slice) Typ=Op Src=<test.opt:12:11>)
 							(ListAny)
 						)
+						Typ=Expr
 						Src=<test.opt:12:5>
 					)
 					(List
 						Items=(Slice
-							(Func Name=Op Args=(Slice) Src=<test.opt:13:7>)
+							(Func Name=Op Args=(Slice) Typ=Op Src=<test.opt:13:7>)
 							(ListAny)
 						)
+						Typ=Expr
 						Src=<test.opt:13:5>
 					)
 					(List
 						Items=(Slice
 							(ListAny)
-							(Func Name=Op Args=(Slice) Src=<test.opt:14:11>)
+							(Func Name=Op Args=(Slice) Typ=Op Src=<test.opt:14:11>)
 						)
+						Typ=Expr
 						Src=<test.opt:14:5>
 					)
 					(List
 						Items=(Slice (ListAny) (ListAny))
+						Typ=Expr
 						Src=<test.opt:15:5>
 					)
 					(List
 						Items=(Slice
-							(Func Name=Op Args=(Slice) Src=<test.opt:16:7>)
+							(Func Name=Op Args=(Slice) Typ=Op Src=<test.opt:16:7>)
 						)
+						Typ=Expr
 						Src=<test.opt:16:5>
 					)
-					(List Items=(Slice) Src=<test.opt:17:5>)
+					(List Items=(Slice) Typ=Expr Src=<test.opt:17:5>)
 				)
+				Typ=Op
 				Src=<test.opt:11:1>
 			)
 			Replace=(Func
@@ -539,32 +570,37 @@ define Op {
 				Args=(Slice
 					(List
 						Items=(Slice
-							(Func Name=Op Args=(Slice) Src=<test.opt:21:7>)
-							(Func Name=Op Args=(Slice) Src=<test.opt:21:12>)
+							(Func Name=Op Args=(Slice) Typ=Op Src=<test.opt:21:7>)
+							(Func Name=Op Args=(Slice) Typ=Op Src=<test.opt:21:12>)
 						)
+						Typ=Expr
 						Src=<test.opt:21:5>
 					)
 					(List
 						Items=(Slice
-							(Func Name=Op Args=(Slice) Src=<test.opt:22:7>)
+							(Func Name=Op Args=(Slice) Typ=Op Src=<test.opt:22:7>)
 						)
+						Typ=Expr
 						Src=<test.opt:22:5>
 					)
-					(List Items=(Slice) Src=<test.opt:23:5>)
+					(List Items=(Slice) Typ=Expr Src=<test.opt:23:5>)
 					(CustomFunc
 						Name=Func
 						Args=(Slice
 							(List
 								Items=(Slice
-									(Func Name=Op Args=(Slice) Src=<test.opt:24:13>)
-									(Func Name=Op Args=(Slice) Src=<test.opt:24:18>)
+									(Func Name=Op Args=(Slice) Typ=Op Src=<test.opt:24:13>)
+									(Func Name=Op Args=(Slice) Typ=Op Src=<test.opt:24:18>)
 								)
+								Typ=<list>
 								Src=<test.opt:24:11>
 							)
 						)
+						Typ=Expr
 						Src=<test.opt:24:5>
 					)
 				)
+				Typ=Op
 				Src=<test.opt:20:1>
 			)
 			Src=<test.opt:10:1>
@@ -613,16 +649,20 @@ define Op {
 								(CustomFunc
 									Name=Func
 									Args=(Slice
-										(Bind Label="matchArg" Target="foo" Src=<test.opt:6:24>)
+										(Bind Label="matchArg" Target="foo" Typ=<string> Src=<test.opt:6:24>)
 									)
+									Typ=Expr
 									Src=<test.opt:6:18>
 								)
 							)
+							Typ=Op
 							Src=<test.opt:6:14>
 						)
+						Typ=Op
 						Src=<test.opt:6:5>
 					)
 				)
+				Typ=Op
 				Src=<test.opt:6:1>
 			)
 			Replace=(Func
@@ -636,19 +676,346 @@ define Op {
 								(CustomFunc
 									Name=Func
 									Args=(Slice
-										(Bind Label="replaceArg" Target="foo" Src=<test.opt:8:26>)
+										(Bind Label="replaceArg" Target="foo" Typ=<string> Src=<test.opt:8:26>)
 									)
+									Typ=Expr
 									Src=<test.opt:8:20>
 								)
 							)
+							Typ=Op
 							Src=<test.opt:8:16>
 						)
+						Typ=Op
 						Src=<test.opt:8:5>
 					)
 				)
+				Typ=Op
 				Src=<test.opt:8:1>
 			)
 			Src=<test.opt:5:1>
+		)
+	)
+)
+
+#
+# Test type inference.
+#
+compile
+[Join]
+define InnerJoin {
+    Left  Expr
+    Right Expr
+    On    FiltersExpr
+}
+
+[Join]
+define LeftJoin {
+    Left  Expr
+    Right Expr
+    On    FiltersExpr
+}
+
+# Test AndExpr with left type as a subset of right type.
+[AndExpr1]
+(InnerJoin $left:(LeftJoin) & (InnerJoin | LeftJoin)) => $left
+
+# Test AndExpr with right type as a subset of left type.
+[AndExpr2]
+(InnerJoin $left:(LeftJoin | InnerJoin) & (LeftJoin)) => $left
+
+# Test NotExpr.
+[NotExpr]
+(InnerJoin $left:* & ^(LeftJoin | InnerJoin)) => $left
+
+# Test list matching and construction.
+[ListExpr]
+(InnerJoin $left:* $right:* $on:[ ... $item:* ... ]) => (LeftJoin $left $right [ $item ])
+
+# Test custom match function and custom construct function.
+[CustomFunction]
+(InnerJoin $left:* & (MatchFunc $left) $right:* $on:*) => (ConstructFunc $left $on)
+
+# Test construction with dynamic choice of names.
+[DynamicName]
+(InnerJoin $left:* $right:(Join $innerLeft:*) $on:*) => ((OpName $right) $left $innerLeft $on)
+
+# Test strings + numbers.
+[Values]
+(InnerJoin $left:"foo" $right:5) => (LeftJoin $left $right)
+----
+(Compiled
+	(Defines
+		(Define
+			Comments=(Comments)
+			Tags=(Tags Join)
+			Name="InnerJoin"
+			Fields=(DefineFields
+				(DefineField Name="Left" Type="Expr" Src=<test.opt:3:5>)
+				(DefineField Name="Right" Type="Expr" Src=<test.opt:4:5>)
+				(DefineField Name="On" Type="FiltersExpr" Src=<test.opt:5:5>)
+			)
+			Src=<test.opt:1:1>
+		)
+		(Define
+			Comments=(Comments)
+			Tags=(Tags Join)
+			Name="LeftJoin"
+			Fields=(DefineFields
+				(DefineField Name="Left" Type="Expr" Src=<test.opt:10:5>)
+				(DefineField Name="Right" Type="Expr" Src=<test.opt:11:5>)
+				(DefineField Name="On" Type="FiltersExpr" Src=<test.opt:12:5>)
+			)
+			Src=<test.opt:8:1>
+		)
+	)
+	(Rules
+		(Rule
+			Comments=(Comments # Test AndExpr with left type as a subset of right type.)
+			Name="AndExpr1"
+			Tags=(Tags)
+			Match=(Func
+				Name=InnerJoin
+				Args=(Slice
+					(Bind
+						Label="left"
+						Target=(And
+							Left=(Func Name=LeftJoin Args=(Slice) Typ=LeftJoin Src=<test.opt:17:18>)
+							Right=(Func
+								Name=(Names InnerJoin LeftJoin)
+								Args=(Slice)
+								Typ=[InnerJoin | LeftJoin]
+								Src=<test.opt:17:31>
+							)
+							Typ=LeftJoin
+							Src=<test.opt:17:18>
+						)
+						Typ=LeftJoin
+						Src=<test.opt:17:12>
+					)
+				)
+				Typ=InnerJoin
+				Src=<test.opt:17:1>
+			)
+			Replace=(Ref Label="left" Typ=LeftJoin Src=<test.opt:17:58>)
+			Src=<test.opt:16:1>
+		)
+		(Rule
+			Comments=(Comments # Test AndExpr with right type as a subset of left type.)
+			Name="AndExpr2"
+			Tags=(Tags)
+			Match=(Func
+				Name=InnerJoin
+				Args=(Slice
+					(Bind
+						Label="left"
+						Target=(And
+							Left=(Func
+								Name=(Names LeftJoin InnerJoin)
+								Args=(Slice)
+								Typ=[LeftJoin | InnerJoin]
+								Src=<test.opt:21:18>
+							)
+							Right=(Func Name=LeftJoin Args=(Slice) Typ=LeftJoin Src=<test.opt:21:43>)
+							Typ=LeftJoin
+							Src=<test.opt:21:18>
+						)
+						Typ=LeftJoin
+						Src=<test.opt:21:12>
+					)
+				)
+				Typ=InnerJoin
+				Src=<test.opt:21:1>
+			)
+			Replace=(Ref Label="left" Typ=LeftJoin Src=<test.opt:21:58>)
+			Src=<test.opt:20:1>
+		)
+		(Rule
+			Comments=(Comments # Test NotExpr.)
+			Name="NotExpr"
+			Tags=(Tags)
+			Match=(Func
+				Name=InnerJoin
+				Args=(Slice
+					(Bind
+						Label="left"
+						Target=(And
+							Left=(Any Typ=Expr)
+							Right=(Not
+								Input=(Func
+									Name=(Names LeftJoin InnerJoin)
+									Args=(Slice)
+									Typ=[LeftJoin | InnerJoin]
+									Src=<test.opt:25:23>
+								)
+								Typ=Expr
+								Src=<test.opt:25:22>
+							)
+							Typ=Expr
+							Src=<test.opt:25:18>
+						)
+						Typ=Expr
+						Src=<test.opt:25:12>
+					)
+				)
+				Typ=InnerJoin
+				Src=<test.opt:25:1>
+			)
+			Replace=(Ref Label="left" Typ=Expr Src=<test.opt:25:50>)
+			Src=<test.opt:24:1>
+		)
+		(Rule
+			Comments=(Comments # Test list matching and construction.)
+			Name="ListExpr"
+			Tags=(Tags)
+			Match=(Func
+				Name=InnerJoin
+				Args=(Slice
+					(Bind Label="left" Target=(Any Typ=Expr) Typ=Expr Src=<test.opt:29:12>)
+					(Bind Label="right" Target=(Any Typ=Expr) Typ=Expr Src=<test.opt:29:20>)
+					(Bind
+						Label="on"
+						Target=(List
+							Items=(Slice
+								(ListAny)
+								(Bind Label="item" Target=(Any) Src=<test.opt:29:39>)
+								(ListAny)
+							)
+							Typ=FiltersExpr
+							Src=<test.opt:29:33>
+						)
+						Typ=FiltersExpr
+						Src=<test.opt:29:29>
+					)
+				)
+				Typ=InnerJoin
+				Src=<test.opt:29:1>
+			)
+			Replace=(Func
+				Name=LeftJoin
+				Args=(Slice
+					(Ref Label="left" Typ=Expr Src=<test.opt:29:67>)
+					(Ref Label="right" Typ=Expr Src=<test.opt:29:73>)
+					(List
+						Items=(Slice
+							(Ref Label="item" Src=<test.opt:29:82>)
+						)
+						Typ=FiltersExpr
+						Src=<test.opt:29:80>
+					)
+				)
+				Typ=LeftJoin
+				Src=<test.opt:29:57>
+			)
+			Src=<test.opt:28:1>
+		)
+		(Rule
+			Comments=(Comments # Test custom match function and custom construct function.)
+			Name="CustomFunction"
+			Tags=(Tags)
+			Match=(Func
+				Name=InnerJoin
+				Args=(Slice
+					(Bind
+						Label="left"
+						Target=(And
+							Left=(Any Typ=Expr)
+							Right=(CustomFunc
+								Name=MatchFunc
+								Args=(Slice
+									(Ref Label="left" Src=<test.opt:33:33>)
+								)
+								Typ=Expr
+								Src=<test.opt:33:22>
+							)
+							Typ=Expr
+							Src=<test.opt:33:18>
+						)
+						Typ=Expr
+						Src=<test.opt:33:12>
+					)
+					(Bind Label="right" Target=(Any Typ=Expr) Typ=Expr Src=<test.opt:33:40>)
+					(Bind Label="on" Target=(Any Typ=FiltersExpr) Typ=FiltersExpr Src=<test.opt:33:49>)
+				)
+				Typ=InnerJoin
+				Src=<test.opt:33:1>
+			)
+			Replace=(CustomFunc
+				Name=ConstructFunc
+				Args=(Slice
+					(Ref Label="left" Typ=Expr Src=<test.opt:33:74>)
+					(Ref Label="on" Typ=FiltersExpr Src=<test.opt:33:80>)
+				)
+				Src=<test.opt:33:59>
+			)
+			Src=<test.opt:32:1>
+		)
+		(Rule
+			Comments=(Comments # Test construction with dynamic choice of names.)
+			Name="DynamicName"
+			Tags=(Tags)
+			Match=(Func
+				Name=InnerJoin
+				Args=(Slice
+					(Bind Label="left" Target=(Any Typ=Expr) Typ=Expr Src=<test.opt:37:12>)
+					(Bind
+						Label="right"
+						Target=(Func
+							Name=Join
+							Args=(Slice
+								(Bind Label="innerLeft" Target=(Any Typ=Expr) Typ=Expr Src=<test.opt:37:33>)
+							)
+							Typ=[InnerJoin | LeftJoin]
+							Src=<test.opt:37:27>
+						)
+						Typ=[InnerJoin | LeftJoin]
+						Src=<test.opt:37:20>
+					)
+					(Bind Label="on" Target=(Any Typ=FiltersExpr) Typ=FiltersExpr Src=<test.opt:37:47>)
+				)
+				Typ=InnerJoin
+				Src=<test.opt:37:1>
+			)
+			Replace=(Func
+				Name=(CustomFunc
+					Name=OpName
+					Args=(Slice
+						(Ref Label="right" Typ=[InnerJoin | LeftJoin] Src=<test.opt:37:66>)
+					)
+					Src=<test.opt:37:58>
+				)
+				Args=(Slice
+					(Ref Label="left" Typ=Expr Src=<test.opt:37:74>)
+					(Ref Label="innerLeft" Typ=Expr Src=<test.opt:37:80>)
+					(Ref Label="on" Typ=FiltersExpr Src=<test.opt:37:91>)
+				)
+				Typ=[InnerJoin | LeftJoin]
+				Src=<test.opt:37:57>
+			)
+			Src=<test.opt:36:1>
+		)
+		(Rule
+			Comments=(Comments # Test strings + numbers.)
+			Name="Values"
+			Tags=(Tags)
+			Match=(Func
+				Name=InnerJoin
+				Args=(Slice
+					(Bind Label="left" Target="foo" Typ=<string> Src=<test.opt:41:12>)
+					(Bind Label="right" Target=5 Typ=<int64> Src=<test.opt:41:24>)
+				)
+				Typ=InnerJoin
+				Src=<test.opt:41:1>
+			)
+			Replace=(Func
+				Name=LeftJoin
+				Args=(Slice
+					(Ref Label="left" Typ=<string> Src=<test.opt:41:47>)
+					(Ref Label="right" Typ=<int64> Src=<test.opt:41:53>)
+				)
+				Typ=LeftJoin
+				Src=<test.opt:41:37>
+			)
+			Src=<test.opt:40:1>
 		)
 	)
 )
@@ -761,7 +1128,7 @@ test.opt:39:5: custom function cannot have multiple names
 test.opt:42:11: custom match function cannot use lists
 test.opt:45:11: custom match function cannot use lists
 test.opt:48:11: custom match function cannot use boolean expressions
-test.opt:51:5: custom match function cannot use wildcard matcher
+test.opt:51:11: custom match function cannot use wildcard matcher
 test.opt:54:11: custom function name cannot be an operator name
 test.opt:57:9: construct name cannot be a tag
 test.opt:60:5: cannot match literal name 'Op'
@@ -770,8 +1137,42 @@ test.opt:66:9: Unknown is not an operator name
 test.opt:69:1: cannot match dynamic name
 test.opt:72:5: cannot match dynamic name
 test.opt:75:5: custom function cannot have multiple names
-test.opt:78:13: custom function cannot have multiple names
+test.opt:78:13: constructor cannot have multiple names
 test.opt:81:25: list matcher cannot contain multiple expressions
 test.opt:84:13: list constructor cannot use '...'
 test.opt:87:9: constructor cannot have multiple names
 test.opt:90:1: Op has only 3 fields
+
+# Type inference errors.
+compile
+[Tag]
+define Op {
+    Input1 Expr
+    Input2 Expr
+}
+
+define SubOp {
+    Input Expr
+    def SubOpDef
+}
+
+define SubOp2 {
+    Input Expr
+}
+
+[CannotInferConstructOps]
+(Op $input1:*) => ((OpName $input))
+
+[ConstructOpsNotEquivalent]
+(Op $input1:(SubOp2 | SubOp $input:* $def:*)) => ((OpName $input1))
+
+[ConstructOpsNotEquivalent2]
+(Op $input1:(Op | SubOp $input:* $def:*)) => ((OpName $input1))
+
+[MatchPatternsContradict]
+(Op $input1:(Op) & (SubOp)) => $input1
+----
+test.opt:17:28: unrecognized variable name 'input'
+test.opt:20:13: SubOp2 has only 1 fields
+test.opt:23:13: SubOp and Op fields do not have same types
+test.opt:26:13: match patterns contradict one another; both cannot match

--- a/pkg/sql/opt/optgen/lang/testdata/scanner
+++ b/pkg/sql/opt/optgen/lang/testdata/scanner
@@ -2,7 +2,7 @@
 # Simple identifiers, strings, numbers, comments
 #
 scan
-foo define f123 "hello world" 1 0045 foo# comment ()[]
+foo define f123 "hello world" 1 0045 foo _ _123foo# comment ()[]
 ----
 (IDENT foo)
 (WHITESPACE  )
@@ -17,6 +17,10 @@ foo define f123 "hello world" 1 0045 foo# comment ()[]
 (NUMBER 0045)
 (WHITESPACE  )
 (IDENT foo)
+(WHITESPACE  )
+(IDENT _)
+(WHITESPACE  )
+(IDENT _123foo)
 (COMMENT # comment ()[])
 
 #


### PR DESCRIPTION
The new opt node representation is more strongly-typed than the old, and
this requires more awareness of types. This commit adds new support to
Optgen to track and check types.

Expressions in both the match and replace patterns are assigned a data type
that describes the kind of data that will be returned by the expression. These
types are inferred using a combination of top-down and bottom-up type inference
rules. For example:
```
  define Select {
    Input  Expr
    Filter Expr
  }

  (Select $input:(LeftJoin | RightJoin) $filter:*) => $input
```
The type of $input is inferred as "LeftJoin | RightJoin" by bubbling up the type
of the bound expression. That type is propagated to the $input reference in the
replace pattern. By contrast, the type of the * expression is inferred to be
"Expr" using a top-down type inference rule, since the second argument to the
Select operator is known to have type "Expr".

When multiple types are inferred for an expression using different type
inference rules, the more restrictive type is assigned to the expression. For
example:
```
  (Select $input:* & (LeftJoin)) => $input
```
Here, the left input to the And expression was inferred to have type "Expr" and
the right input to have type "LeftJoin". Since "LeftJoin" is the more
restrictive type, the And expression and the $input binding are typed as
"LeftJoin".

Type inference detect and report type contradictions, which occur when multiple
incompatible types are inferred for an expression. For example:
```
  (Select $input:(InnerJoin) & (LeftJoin)) => $input
```
Because the input cannot be both an InnerJoin and a LeftJoin, Optgen reports a
type contradiction error.

Release note: None