### PR TITLE
sql: bark at unused CTEs containing mutations

### DIFF
--- a/pkg/sql/explain_test.go
+++ b/pkg/sql/explain_test.go
@@ -160,8 +160,12 @@ func TestStatementReuses(t *testing.T) {
 	t.Run("WITH (cte)", func(t *testing.T) {
 		for _, test := range testData {
 			t.Run(test, func(t *testing.T) {
-				rows, err := db.Query("EXPLAIN WITH a AS (" + test + ") SELECT 1")
+				rows, err := db.Query("EXPLAIN WITH a AS (" + test + ") TABLE a")
 				if err != nil {
+					if testutils.IsError(err, "does not have a RETURNING clause") {
+						// This error is acceptable and does not constitute a test failure.
+						return
+					}
 					t.Fatal(err)
 				}
 				defer rows.Close()

--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -143,3 +143,44 @@ WITH t AS (
     INSERT INTO x(a) VALUES(0)
 )
 SELECT * FROM t
+
+# Regression test for #24307 until CockroachDB learns how to execute
+# side effects no matter what.
+query error unimplemented: common table expression "t" with side effects was not used in query
+WITH t AS (
+   INSERT INTO x(a) VALUES(0) RETURNING a
+)
+SELECT 1
+
+query error unimplemented: common table expression "t" with side effects was not used in query
+WITH t AS (
+   SELECT * FROM (
+      WITH b AS (INSERT INTO x(a) VALUES(0) RETURNING a)
+	  TABLE b
+   )
+)
+SELECT 1
+
+query error unimplemented: common table expression "t" with side effects was not used in query
+WITH t AS (
+   DELETE FROM x RETURNING a
+)
+SELECT 1
+
+query error unimplemented: common table expression "t" with side effects was not used in query
+WITH t AS (
+   UPSERT INTO x(a) VALUES(0) RETURNING a
+)
+SELECT 1
+
+query error unimplemented: common table expression "t" with side effects was not used in query
+WITH t AS (
+   UPDATE x SET a = 0 RETURNING a
+)
+SELECT 1
+
+# however if there are no side effects, no errors are required.
+query I
+WITH t AS (SELECT 1) SELECT 2
+----
+2

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -179,7 +179,7 @@ func (p *planner) SelectClause(
 	with *tree.With,
 	desiredTypes []types.T,
 	scanVisibility scanVisibility,
-) (planNode, error) {
+) (result planNode, err error) {
 	// We need to save and restore the previous value of the field in
 	// semaCtx in case we are recursively called within a subquery
 	// context.
@@ -193,7 +193,16 @@ func (p *planner) SelectClause(
 		return nil, err
 	}
 	if resetter != nil {
-		defer resetter(p)
+		defer func() {
+			if cteErr := resetter(p); cteErr != nil && err == nil {
+				// If no error was found in the inner planning but a CTE error
+				// is occurring during the final checks on the way back from
+				// the recursion, use that error as final error for this
+				// stage.
+				err = cteErr
+				result = nil
+			}
+		}()
 	}
 
 	if err := p.initFrom(ctx, r, parsed, scanVisibility); err != nil {
@@ -302,7 +311,7 @@ func (p *planner) SelectClause(
 		return nil, err
 	}
 
-	result := planNode(r)
+	result = planNode(r)
 	if groupComplex != nil {
 		// group.plan is already r.
 		result = groupComplex


### PR DESCRIPTION
Informs #24307.

The SQL standard (and pg) specifies that CTEs containing mutations are
executed no matter how / how many times they are used in the remainder
of the query.

Meanwhile the heuristic planner + execution machinery is currently
unable to force the execution of CTEs containing mutations if they are
not otherwise used in the rest of the query.

However meanwhile they are also accepted silently -- i.e. CockroachDB
silently fails to do what the semantics require.

This patch changes the behavior to instead report an error "feature
not supported".

Release note (bug fix): CockroachDB now reports an unimplemented error
when a common table expression containing INSERT/UPDATE/UPSERT/DELETE
is not otherwise used in the remainder of the query.