### PR TITLE
release-2.1: sql: present the output of SHOW JOBS in sorted order

### DIFF
--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -110,9 +110,11 @@ drop database  ·  ·
 query TTT
 EXPLAIN SHOW JOBS
 ----
-render       ·     ·
- └── values  ·     ·
-·            size  14 columns, 0 rows
+sort              ·      ·
+ │                order  -"coalesce",-started
+ └── render       ·      ·
+      └── values  ·      ·
+·                 size   14 columns, 0 rows
 
 statement ok
 CREATE INDEX a ON foo(x)

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -101,9 +101,11 @@ drop database  ·  ·
 query TTT
 EXPLAIN SHOW JOBS
 ----
-render       ·     ·
- └── values  ·     ·
-·            size  14 columns, 0 rows
+sort              ·      ·
+ │                order  -"coalesce",-started
+ └── render       ·      ·
+      └── values  ·      ·
+·                 size   14 columns, 0 rows
 
 statement ok
 CREATE INDEX a ON foo(x)

--- a/pkg/sql/show_jobs.go
+++ b/pkg/sql/show_jobs.go
@@ -23,9 +23,15 @@ import (
 // ShowJobs returns all the jobs.
 // Privileges: None.
 func (p *planner) ShowJobs(ctx context.Context, n *tree.ShowJobs) (planNode, error) {
+	// The query intends to present:
+	// - first all the running jobs sorted in order of start time,
+	// - then all completed jobs sorted in order of completion time.
+	// The "ORDER BY" clause below exploits the fact that all
+	// running jobs have finished = NULL.
 	return p.delegateQuery(ctx, "SHOW JOBS",
-		`SELECT job_id, job_type, description, user_name, status, created, started, finished, modified,
-            fraction_completed, error, coordinator_id
-       FROM crdb_internal.jobs`,
+		`SELECT job_id, job_type, description, user_name, status, created,
+            started, finished, modified, fraction_completed, error, coordinator_id
+       FROM crdb_internal.jobs
+   ORDER BY COALESCE(finished, now()) DESC, started DESC`,
 		nil, nil)
 }


### PR DESCRIPTION
Backport 1/1 commits from #30917.

/cc @cockroachdb/release

---

Fixes #30835.
Requested by @rolandcrosby and @a-robinson.

Release note (sql change): The output of `SHOW JOBS` now reports
ongoing jobs first in start time order, then completed jobs in
finished time order. 
