### PR TITLE
sql: properly rename stored columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -5,7 +5,7 @@ CREATE TABLE users (
   uid    INT PRIMARY KEY,
   name  VARCHAR NOT NULL,
   title VARCHAR,
-  INDEX foo (name),
+  INDEX foo (name) STORING (title),
   UNIQUE INDEX bar (uid, name)
 )
 
@@ -78,7 +78,8 @@ SHOW INDEXES FROM users
 table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
 users       primary     false       1             id           ASC        false    false
 users       foo         true        1             username     ASC        false    false
-users       foo         true        2             id           ASC        false    true
+users       foo         true        2             species      N/A        true     false
+users       foo         true        3             id           ASC        false    true
 users       bar         false       1             id           ASC        false    false
 users       bar         false       2             username     ASC        false    false
 

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1731,6 +1731,11 @@ func (desc *TableDescriptor) RenameColumnDescriptor(column ColumnDescriptor, new
 				idx.ColumnNames[i] = newColName
 			}
 		}
+		for i, id := range idx.StoreColumnIDs {
+			if id == colID {
+				idx.StoreColumnNames[i] = newColName
+			}
+		}
 	}
 	renameColumnInIndex(&desc.PrimaryIndex)
 	for i := range desc.Indexes {


### PR DESCRIPTION
Fixes #31009.

Prior to this patch ALTER TABLE RENAME COLUMN did not properly rename
stored column in indexes. This patch fixes it.

Release note (bug fix): CockroachDB now properly supports renamining a
column that's also stored in an index.