### PR TITLE
storage: avoid spurious nodeDialer logs

### DIFF
--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -149,7 +149,9 @@ func (n *Dialer) DialInternalClient(
 	// ConnHealth when scheduling processors, but can then see attempts to send
 	// RPCs fail when dial fails due to an open breaker. Reset the breaker here
 	// as a stop-gap before the reconciliation occurs.
-	n.getBreaker(nodeID).Reset()
+	if breaker := n.getBreaker(nodeID); breaker.Tripped() {
+		breaker.Reset()
+	}
 	return ctx, roachpb.NewInternalClient(conn), nil
 }
 


### PR DESCRIPTION
breaker.Success() retrieves its count from an underlying windowed
counter that resets every 10 seconds. As a result, spurious "established
connection to nX" messages would pop up every 10s.

It turns out it's annoyingly difficult to properly gauge whether an
established connection is the first of its kind. In trying to do so, I
became unconvinced that this is even worth it, so I ended up removing
it. I similarly simplified the logging in the unsuccessful case (though
ConsecutiveFailures is actually not a windowed counter and presumably
worked correctly).

I also downgraded the message in the error case to Infof, as it's
expected to see it when nodes are restarted (which is a routine
operation and nothing to worry about). We want to keep the Warning level
for true warnings.

Release note: None