### PR TITLE
cdc: Test for falling behind schema TTL

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -24,12 +24,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
-	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -890,9 +887,6 @@ func TestChangefeedDataTTL(t *testing.T) {
 		// versions.
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
 
-		// Set a one second GC time; all historical rows subject to GC ASAP.
-		sqlDB.Exec(t, `ALTER TABLE foo CONFIGURE ZONE USING gc.ttlseconds = $1`, 1)
-
 		counter := 0
 		upsertRow := func() {
 			counter++
@@ -916,31 +910,9 @@ func TestChangefeedDataTTL(t *testing.T) {
 		upsertRow()
 		upsertRow()
 
-		// TODO(mrtracy): Even though the GC TTL on the table is set to 1 second,
-		// this does not work at 1 or even 2 seconds. Investigate why this is the
-		// case.
-		time.Sleep(3 * time.Second)
-
 		// Force a GC of the table. This should cause both older versions of the
 		// table to be deleted, with the middle version being lost to the changefeed.
-		tblID, err := sqlutils.QueryTableID(sqlDB.DB, "d", "foo")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		tablePrefix := keys.MakeTablePrefix(tblID)
-		tableStartKey := roachpb.RKey(tablePrefix)
-		tableSpan := roachpb.RSpan{
-			Key:    tableStartKey,
-			EndKey: tableStartKey.PrefixEnd(),
-		}
-
-		ts := f.Server().(*server.TestServer)
-		if err := ts.GetStores().(*storage.Stores).VisitStores(func(st *storage.Store) error {
-			return st.ManuallyEnqueueSpan(context.Background(), "gc", tableSpan, true /* skipShouldQueue */)
-		}); err != nil {
-			t.Fatal(err)
-		}
+		forceTableGC(t, f.Server(), sqlDB, "d", "foo")
 
 		// Resume our changefeed normally.
 		atomic.StoreInt32(&shouldWait, 0)
@@ -957,8 +929,84 @@ func TestChangefeedDataTTL(t *testing.T) {
 		}
 	}
 
-	// Due to the minimum 3 second run time (due to needing to wait that long for
-	// rows to be properly GCed), only run an enterprise test.
+	t.Run("sinkless", enterpriseTest(testFn))
+	t.Run("enterprise", enterpriseTest(testFn))
+}
+
+// TestChangefeedSchemaTTL ensures that changefeeds fail with an error in the case
+// where the feed has fallen behind the GC TTL of the table's schema.
+func TestChangefeedSchemaTTL(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		// Set a very simple channel-based, wait-and-resume function as the
+		// BeforeEmitRow hook.
+		var shouldWait int32
+		wait := make(chan struct{})
+		resume := make(chan struct{})
+		knobs := f.Server().(*server.TestServer).Cfg.TestingKnobs.
+			DistSQL.(*distsqlrun.TestingKnobs).
+			Changefeed.(*TestingKnobs)
+		knobs.BeforeEmitRow = func() error {
+			if atomic.LoadInt32(&shouldWait) == 0 {
+				return nil
+			}
+			wait <- struct{}{}
+			<-resume
+			return nil
+		}
+
+		sqlDB := sqlutils.MakeSQLRunner(db)
+
+		// Create the data table; it will only contain a single row with multiple
+		// versions.
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+
+		counter := 0
+		upsertRow := func() {
+			counter++
+			sqlDB.Exec(t, `UPSERT INTO foo (a, b) VALUES (1, $1)`, fmt.Sprintf("version %d", counter))
+		}
+
+		// Create the initial version of the row and the changefeed itself. The initial
+		// version is necessary to prevent CREATE CHANGEFEED itself from hanging.
+		upsertRow()
+		dataExpiredRows := f.Feed(t, "CREATE CHANGEFEED FOR TABLE foo")
+		defer dataExpiredRows.Close(t)
+
+		// Set up our emit trap and update the row, which will allow us to "pause" the
+		// changefeed in order to force a GC.
+		atomic.StoreInt32(&shouldWait, 1)
+		upsertRow()
+		<-wait
+
+		// Upsert two additional versions. One of these will be deleted by the GC
+		// process before changefeed polling is resumed.
+		waitForSchemaChange(t, sqlDB, "ALTER TABLE foo ADD COLUMN c STRING")
+		upsertRow()
+		waitForSchemaChange(t, sqlDB, "ALTER TABLE foo ADD COLUMN d STRING")
+		upsertRow()
+
+		// Force a GC of the table. This should cause both older versions of the
+		// table to be deleted, with the middle version being lost to the changefeed.
+		forceTableGC(t, f.Server(), sqlDB, "system", "descriptor")
+
+		// Resume our changefeed normally.
+		atomic.StoreInt32(&shouldWait, 0)
+		resume <- struct{}{}
+
+		// Verify that the third call to Next() returns an error (the first is the
+		// initial row, the second is the first change. The third should detect the
+		// GC interval mismatch).
+		_, _, _, _, _, _ = dataExpiredRows.Next(t)
+		_, _, _, _, _, _ = dataExpiredRows.Next(t)
+		_, _, _, _, _, _ = dataExpiredRows.Next(t)
+		if err := dataExpiredRows.Err(); !testutils.IsError(err, `GC threshold`) {
+			t.Errorf(`expected "GC threshold" error got: %+v`, err)
+		}
+	}
+
+	t.Run("sinkless", enterpriseTest(testFn))
 	t.Run("enterprise", enterpriseTest(testFn))
 }
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4603,28 +4603,6 @@ func (s *Store) ManuallyEnqueue(
 	return collect(), "", nil
 }
 
-// ManuallyEnqueueSpan runs all replicas in the supplied span through the named
-// queue. This is currently intended for use in internal tests which have access
-// to the store directly.
-func (s *Store) ManuallyEnqueueSpan(
-	ctx context.Context, queueName string, span roachpb.RSpan, skipShouldQueue bool,
-) error {
-	var outerErr error
-	newStoreReplicaVisitor(s).Visit(func(repl *Replica) bool {
-		desc := repl.Desc()
-		if bytes.Compare(span.Key, desc.EndKey) >= 0 || bytes.Compare(desc.StartKey, span.EndKey) >= 0 {
-			return true // continue
-		}
-
-		if _, _, err := s.ManuallyEnqueue(ctx, queueName, repl, skipShouldQueue); err != nil {
-			outerErr = err
-			return false
-		}
-		return true
-	})
-	return outerErr
-}
-
 // WriteClusterVersion writes the given cluster version to the store-local cluster version key.
 func WriteClusterVersion(
 	ctx context.Context, writer engine.ReadWriter, cv cluster.ClusterVersion,


### PR DESCRIPTION
Add a test that ensures that changefeeds properly exit if they fall far
enough behind that schema information has been lost due to the GC TTL
(that is, a historical row version can no longer be read because the
schema at its timestamp has been garbage collected).

I have also discovered why the sister test (for the table TTL, not the
schema) required a 3 second sleep: the GC queue enforces that replicas
must have an appropriately high "score" before being GCed, even when the
"shouldQueue" process is skipped. To get around this, I have changed
"ManuallyEnqueueSpan" to a more explicit "ManuallyGCSpan", which
directly calls the processing implementation of the gcQueue on the
appropriate replicas. Both that sister test, and the new schema TTL
test, now only require a more predictable 1 second sleep.

Resolves #28644

Release note: None