### PR TITLE
gossip: use "n%d" instead of "node %d" in log messages

### DIFF
--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -131,7 +131,7 @@ func (c *client) startLocked(
 			if !grpcutil.IsClosedConnection(err) {
 				g.mu.RLock()
 				if c.peerID != 0 {
-					log.Infof(ctx, "closing client to node %d (%s): %s", c.peerID, c.addr, err)
+					log.Infof(ctx, "closing client to n%d (%s): %s", c.peerID, c.addr, err)
 				} else {
 					log.Infof(ctx, "closing client to %s: %s", c.addr, err)
 				}
@@ -200,7 +200,7 @@ func (c *client) sendGossip(g *Gossip, stream Gossip_GossipClient) error {
 		if log.V(1) {
 			ctx := c.AnnotateCtx(stream.Context())
 			if c.peerID != 0 {
-				log.Infof(ctx, "sending %s to node %d (%s)", extractKeys(args.Delta), c.peerID, c.addr)
+				log.Infof(ctx, "sending %s to n%d (%s)", extractKeys(args.Delta), c.peerID, c.addr)
 			} else {
 				log.Infof(ctx, "sending %s to %s", extractKeys(args.Delta), c.addr)
 			}
@@ -230,11 +230,11 @@ func (c *client) handleResponse(ctx context.Context, g *Gossip, reply *Response)
 	if reply.Delta != nil {
 		freshCount, err := g.mu.is.combine(reply.Delta, reply.NodeID)
 		if err != nil {
-			log.Warningf(ctx, "failed to fully combine delta from node %d: %s", reply.NodeID, err)
+			log.Warningf(ctx, "failed to fully combine delta from n%d: %s", reply.NodeID, err)
 		}
 		if infoCount := len(reply.Delta); infoCount > 0 {
 			if log.V(1) {
-				log.Infof(ctx, "received %s from node %d (%d fresh)", extractKeys(reply.Delta), reply.NodeID, freshCount)
+				log.Infof(ctx, "received %s from n%d (%d fresh)", extractKeys(reply.Delta), reply.NodeID, freshCount)
 			}
 		}
 		g.maybeTightenLocked()
@@ -254,17 +254,20 @@ func (c *client) handleResponse(ctx context.Context, g *Gossip, reply *Response)
 	// Handle remote forwarding.
 	if reply.AlternateAddr != nil {
 		if g.hasIncomingLocked(reply.AlternateNodeID) || g.hasOutgoingLocked(reply.AlternateNodeID) {
-			return errors.Errorf("received forward from node %d to %d (%s); already have active connection, skipping",
+			return errors.Errorf(
+				"received forward from n%d to n%d (%s); already have active connection, skipping",
 				reply.NodeID, reply.AlternateNodeID, reply.AlternateAddr)
 		}
 		// We try to resolve the address, but don't actually use the result.
 		// The certificates (if any) may only be valid for the unresolved
 		// address.
 		if _, err := reply.AlternateAddr.Resolve(); err != nil {
-			return errors.Errorf("unable to resolve alternate address %s for node %d: %s", reply.AlternateAddr, reply.AlternateNodeID, err)
+			return errors.Errorf("unable to resolve alternate address %s for n%d: %s",
+				reply.AlternateAddr, reply.AlternateNodeID, err)
 		}
 		c.forwardAddr = reply.AlternateAddr
-		return errors.Errorf("received forward from node %d to %d (%s)", reply.NodeID, reply.AlternateNodeID, reply.AlternateAddr)
+		return errors.Errorf("received forward from n%d to %d (%s)",
+			reply.NodeID, reply.AlternateNodeID, reply.AlternateAddr)
 	}
 
 	// Check whether we're connected at this point.
@@ -274,11 +277,11 @@ func (c *client) handleResponse(ctx context.Context, g *Gossip, reply *Response)
 	// being done by an incoming client, either because an outgoing
 	// matches an incoming or the client is connecting to itself.
 	if nodeID := g.NodeID.Get(); nodeID == c.peerID {
-		return errors.Errorf("stopping outgoing client to node %d (%s); loopback connection", c.peerID, c.addr)
+		return errors.Errorf("stopping outgoing client to n%d (%s); loopback connection", c.peerID, c.addr)
 	} else if g.hasIncomingLocked(c.peerID) && nodeID > c.peerID {
 		// To avoid mutual shutdown, we only shutdown our client if our
 		// node ID is higher than the peer's.
-		return errors.Errorf("stopping outgoing client to node %d (%s); already have incoming", c.peerID, c.addr)
+		return errors.Errorf("stopping outgoing client to n%d (%s); already have incoming", c.peerID, c.addr)
 	}
 
 	return nil

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -392,7 +392,7 @@ func (g *Gossip) SetNodeDescriptor(desc *roachpb.NodeDescriptor) error {
 	ctx := g.AnnotateCtx(context.TODO())
 	log.Infof(ctx, "NodeDescriptor set to %+v", desc)
 	if err := g.AddInfoProto(MakeNodeIDKey(desc.NodeID), desc, NodeDescriptorTTL); err != nil {
-		return errors.Errorf("node %d: couldn't gossip descriptor: %v", desc.NodeID, err)
+		return errors.Errorf("n%d: couldn't gossip descriptor: %v", desc.NodeID, err)
 	}
 	g.updateClients()
 	return nil
@@ -803,7 +803,7 @@ func (g *Gossip) updateNodeAddress(key string, content roachpb.Value) {
 			log.Errorf(ctx, "unable to update node address for removed node: %s", err)
 			return
 		}
-		log.Infof(ctx, "removed node %d from gossip", nodeID)
+		log.Infof(ctx, "removed n%d from gossip", nodeID)
 		g.removeNodeDescriptorLocked(nodeID)
 		return
 	}
@@ -841,7 +841,7 @@ func (g *Gossip) updateNodeAddress(key string, content roachpb.Value) {
 	// connect to its previous identity (as came up in issue #10266).
 	oldNodeID, ok := g.bootstrapAddrs[desc.Address]
 	if ok && oldNodeID != unknownNodeID && oldNodeID != desc.NodeID {
-		log.Infof(ctx, "removing node %d which was at same address (%s) as new node %v",
+		log.Infof(ctx, "removing n%d which was at same address (%s) as new node %v",
 			oldNodeID, desc.Address, desc)
 		g.removeNodeDescriptorLocked(oldNodeID)
 
@@ -856,7 +856,7 @@ func (g *Gossip) updateNodeAddress(key string, content roachpb.Value) {
 		key := MakeNodeIDKey(oldNodeID)
 		var emptyProto []byte
 		if err := g.addInfoLocked(key, emptyProto, NodeDescriptorTTL); err != nil {
-			log.Errorf(ctx, "failed to empty node descriptor for node %d: %s", oldNodeID, err)
+			log.Errorf(ctx, "failed to empty node descriptor for n%d: %s", oldNodeID, err)
 		}
 	}
 	// Add new address (if it's not already there) to bootstrap info and
@@ -964,13 +964,13 @@ func (g *Gossip) getNodeDescriptorLocked(nodeID roachpb.NodeID) (*roachpb.NodeDe
 		// Don't return node descriptors that are empty, because that's meant to
 		// indicate that the node has been removed from the cluster.
 		if nodeDescriptor.NodeID == 0 || nodeDescriptor.Address.IsEmpty() {
-			return nil, errors.Errorf("node %d has been removed from the cluster", nodeID)
+			return nil, errors.Errorf("n%d has been removed from the cluster", nodeID)
 		}
 
 		return nodeDescriptor, nil
 	}
 
-	return nil, errors.Errorf("unable to look up descriptor for node %d", nodeID)
+	return nil, errors.Errorf("unable to look up descriptor for n%d", nodeID)
 }
 
 // getNodeIDAddressLocked looks up the address of the node by ID. The mutex is
@@ -1253,7 +1253,7 @@ func (g *Gossip) hasOutgoingLocked(nodeID roachpb.NodeID) bool {
 		// If we don't have the address, fall back to using the outgoing nodeSet
 		// since at least it's better than nothing.
 		ctx := g.AnnotateCtx(context.TODO())
-		log.Errorf(ctx, "unable to get address for node %d: %s", nodeID, err)
+		log.Errorf(ctx, "unable to get address for n%d: %s", nodeID, err)
 		return g.outgoing.hasNode(nodeID)
 	}
 	c := g.findClient(func(c *client) bool {
@@ -1450,9 +1450,9 @@ func (g *Gossip) tightenNetwork(ctx context.Context) {
 			return
 		}
 		if nodeAddr, err := g.getNodeIDAddressLocked(distantNodeID); err != nil {
-			log.Errorf(ctx, "unable to get address for distant node %d: %s", distantNodeID, err)
+			log.Errorf(ctx, "unable to get address for n%d: %s", distantNodeID, err)
 		} else {
-			log.Infof(ctx, "starting client to distant node %d (%d > %d) to tighten network graph",
+			log.Infof(ctx, "starting client to n%d (%d > %d) to tighten network graph",
 				distantNodeID, distantHops, maxHops)
 			log.Eventf(ctx, "tightening network with new client to %s", nodeAddr)
 			g.startClientLocked(nodeAddr)

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -80,12 +80,12 @@ func TestGossipOverwriteNode(t *testing.T) {
 	if val, err := g.GetNodeDescriptor(node1.NodeID); err != nil {
 		t.Error(err)
 	} else if val.NodeID != node1.NodeID {
-		t.Errorf("expected node %d, got %+v", node1.NodeID, val)
+		t.Errorf("expected n%d, got %+v", node1.NodeID, val)
 	}
 	if val, err := g.GetNodeDescriptor(node2.NodeID); err != nil {
 		t.Error(err)
 	} else if val.NodeID != node2.NodeID {
-		t.Errorf("expected node %d, got %+v", node2.NodeID, val)
+		t.Errorf("expected n%d, got %+v", node2.NodeID, val)
 	}
 
 	// Give node3 the same address as node1, which should cause node1 to be
@@ -97,13 +97,13 @@ func TestGossipOverwriteNode(t *testing.T) {
 	if val, err := g.GetNodeDescriptor(node3.NodeID); err != nil {
 		t.Error(err)
 	} else if val.NodeID != node3.NodeID {
-		t.Errorf("expected node %d, got %+v", node3.NodeID, val)
+		t.Errorf("expected n%d, got %+v", node3.NodeID, val)
 	}
 
 	testutils.SucceedsSoon(t, func() error {
-		expectedErr := "node.*has been removed from the cluster"
+		expectedErr := `n\d+ has been removed from the cluster`
 		if val, err := g.GetNodeDescriptor(node1.NodeID); !testutils.IsError(err, expectedErr) {
-			return fmt.Errorf("expected error %q fetching node %d; got error %v and node %+v",
+			return fmt.Errorf("expected error %q fetching n%d; got error %v and node %+v",
 				expectedErr, node1.NodeID, err, val)
 		}
 		return nil
@@ -153,9 +153,9 @@ func TestGossipMoveNode(t *testing.T) {
 		} else if !proto.Equal(movedNode, val) {
 			return fmt.Errorf("expected node %+v, got %+v", movedNode, val)
 		}
-		expectedErr := "node.*has been removed from the cluster"
+		expectedErr := `n\d+ has been removed from the cluster`
 		if val, err := g.GetNodeDescriptor(replacedNode.NodeID); !testutils.IsError(err, expectedErr) {
-			return fmt.Errorf("expected error %q fetching node %d; got error %v and node %+v",
+			return fmt.Errorf("expected error %q fetching n%d; got error %v and node %+v",
 				expectedErr, replacedNode.NodeID, err, val)
 		}
 		return nil
@@ -542,7 +542,7 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 				return nil
 			}
 		}
-		return errors.Errorf("node %d not yet connected", peerNodeID)
+		return errors.Errorf("n%d not yet connected", peerNodeID)
 	})
 
 	testutils.SucceedsSoon(t, func() error {
@@ -551,7 +551,7 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 				return nil
 			}
 		}
-		return errors.Errorf("node %d descriptor not yet available", peerNodeID)
+		return errors.Errorf("n%d descriptor not yet available", peerNodeID)
 	})
 
 	local.bootstrap()
@@ -562,7 +562,7 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 	testutils.SucceedsSoon(t, func() error {
 		for _, peerID := range local.Outgoing() {
 			if peerID == peerNodeID {
-				return errors.Errorf("node %d still connected", peerNodeID)
+				return errors.Errorf("n%d still connected", peerNodeID)
 			}
 		}
 		return nil
@@ -578,7 +578,7 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 				return nil
 			}
 		}
-		return errors.Errorf("node %d not yet connected", peerNodeID)
+		return errors.Errorf("n%d not yet connected", peerNodeID)
 	})
 }
 

--- a/pkg/gossip/infostore.go
+++ b/pkg/gossip/infostore.go
@@ -398,7 +398,7 @@ func (is *infoStore) combine(
 		infoCopy.Hops++
 		infoCopy.PeerID = nodeID
 		if infoCopy.OrigStamp == 0 {
-			panic(errors.Errorf("combining info from node %d with 0 original timestamp", nodeID))
+			panic(errors.Errorf("combining info from n%d with 0 original timestamp", nodeID))
 		}
 		// errNotFresh errors from addInfo are ignored; they indicate that
 		// the data in *is is newer than in *delta.

--- a/pkg/gossip/infostore_test.go
+++ b/pkg/gossip/infostore_test.go
@@ -347,7 +347,7 @@ func TestInfoStoreMostDistant(t *testing.T) {
 		}
 		nodeID, hops := is.mostDistant(func(roachpb.NodeID) bool { return false })
 		if expectedNodeID != nodeID {
-			t.Errorf("%d: expected node %d; got %d", i, expectedNodeID, nodeID)
+			t.Errorf("%d: expected n%d; got %d", i, expectedNodeID, nodeID)
 		}
 		if expectedHops != hops {
 			t.Errorf("%d: expected hops %d; got %d", i, expectedHops, hops)
@@ -364,7 +364,7 @@ func TestInfoStoreMostDistant(t *testing.T) {
 		return nodeID == filteredNode
 	})
 	if nodeID != expectedNode {
-		t.Errorf("expected node %d; got %d", expectedNode, nodeID)
+		t.Errorf("expected n%d; got %d", expectedNode, nodeID)
 	}
 	if hops != expectedHops {
 		t.Errorf("expected hops %d; got %d", expectedHops, hops)

--- a/pkg/gossip/server.go
+++ b/pkg/gossip/server.go
@@ -164,7 +164,7 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 
 		if infoCount := len(delta); infoCount > 0 {
 			if log.V(1) {
-				log.Infof(ctx, "returning %d info(s) to node %d: %s",
+				log.Infof(ctx, "returning %d info(s) to n%d: %s",
 					infoCount, args.NodeID, extractKeys(delta))
 			}
 			// Ensure that the high water stamps for the remote client are kept up to
@@ -233,18 +233,18 @@ func (s *server) gossipReceiver(
 				// This is an incoming loopback connection which should be closed by
 				// the client.
 				if log.V(2) {
-					log.Infof(ctx, "ignoring gossip from node %d (loopback)", args.NodeID)
+					log.Infof(ctx, "ignoring gossip from n%d (loopback)", args.NodeID)
 				}
 			} else if _, ok := s.mu.nodeMap[args.Addr]; ok {
 				// This is a duplicate incoming connection from the same node as an existing
 				// connection. This can happen when bootstrap connections are initiated
 				// through a load balancer.
 				if log.V(2) {
-					log.Infof(ctx, "duplicate connection received from node %d at %s", args.NodeID, args.Addr)
+					log.Infof(ctx, "duplicate connection received from n%d at %s", args.NodeID, args.Addr)
 				}
 				return errors.Errorf("duplicate connection from node at %s", args.Addr)
 			} else if s.mu.incoming.hasSpace() {
-				log.VEventf(ctx, 2, "adding node %d to incoming set", args.NodeID)
+				log.VEventf(ctx, 2, "adding n%d to incoming set", args.NodeID)
 
 				s.mu.incoming.addNode(args.NodeID)
 				s.mu.nodeMap[args.Addr] = serverInfo{
@@ -253,7 +253,7 @@ func (s *server) gossipReceiver(
 				}
 
 				defer func(nodeID roachpb.NodeID, addr util.UnresolvedAddr) {
-					log.VEventf(ctx, 2, "removing node %d from incoming set", args.NodeID)
+					log.VEventf(ctx, 2, "removing n%d from incoming set", args.NodeID)
 					s.mu.incoming.removeNode(nodeID)
 					delete(s.mu.nodeMap, addr)
 				}(args.NodeID, args.Addr)
@@ -273,7 +273,7 @@ func (s *server) gossipReceiver(
 				}
 
 				s.nodeMetrics.ConnectionsRefused.Inc(1)
-				log.Infof(ctx, "refusing gossip from node %d (max %d conns); forwarding to %d (%s)",
+				log.Infof(ctx, "refusing gossip from n%d (max %d conns); forwarding to n%d (%s)",
 					args.NodeID, s.mu.incoming.maxSize, alternateNodeID, alternateAddr)
 
 				*reply = Response{
@@ -306,10 +306,10 @@ func (s *server) gossipReceiver(
 
 		freshCount, err := s.mu.is.combine(args.Delta, args.NodeID)
 		if err != nil {
-			log.Warningf(ctx, "failed to fully combine gossip delta from node %d: %s", args.NodeID, err)
+			log.Warningf(ctx, "failed to fully combine gossip delta from n%d: %s", args.NodeID, err)
 		}
 		if log.V(1) {
-			log.Infof(ctx, "received %s from node %d (%d fresh)", extractKeys(args.Delta), args.NodeID, freshCount)
+			log.Infof(ctx, "received %s from n%d (%d fresh)", extractKeys(args.Delta), args.NodeID, freshCount)
 		}
 		s.maybeTightenLocked()
 

--- a/pkg/gossip/storage_test.go
+++ b/pkg/gossip/storage_test.go
@@ -264,7 +264,7 @@ func TestGossipStorageCleanup(t *testing.T) {
 			}
 			for _, addr := range p.Info().Addresses {
 				if addr.String() == invalidAddr {
-					return errors.Errorf("node %d still needs bootstrap cleanup", i)
+					return errors.Errorf("n%d still needs bootstrap cleanup", i)
 				}
 			}
 		}


### PR DESCRIPTION
This normalizes node IDs in gossip log messages with the rest of the
code base.

Release note: None