### PR TITLE
backport-2.1: sqlbase: don't permit PK columns in STORING list

### DIFF
--- a/pkg/sql/delete_test.go
+++ b/pkg/sql/delete_test.go
@@ -78,7 +78,7 @@ CREATE TABLE IF NOT EXISTS child_with_index(
 	PRIMARY KEY (pid, child_id),
 	FOREIGN KEY (pid) REFERENCES parent(id),
 	UNIQUE (other_field)
-) INTERLEAVE IN PARENT parent(pid); CREATE INDEX ON child_with_index (other_field) STORING (child_id)
+) INTERLEAVE IN PARENT parent(pid); CREATE INDEX ON child_with_index (other_field)
 `,
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -433,7 +433,7 @@ CREATE TABLE x (
   k INT PRIMARY KEY,
   a JSON,
   b TEXT AS (a->>'q') STORED,
-  INDEX (b) STORING (k)
+  INDEX (b)
 )
 
 statement error cannot write directly to computed column

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -3,7 +3,7 @@
 statement ok
 CREATE TABLE test_kv(k INT PRIMARY KEY, v INT, w DECIMAL);
   CREATE UNIQUE INDEX test_v_idx ON test_kv(v);
-  CREATE INDEX test_v_idx2 ON test_kv(v DESC) STORING(k);
+  CREATE INDEX test_v_idx2 ON test_kv(v DESC) STORING(w);
   CREATE INDEX test_v_idx3 ON test_kv(w) STORING(v);
   CREATE TABLE test_kvr1(k INT PRIMARY KEY REFERENCES test_kv(k));
   CREATE TABLE test_kvr2(k INT, v INT UNIQUE REFERENCES test_kv(k));
@@ -62,6 +62,7 @@ descriptor_id  descriptor_name  index_id  index_name       column_type  column_i
 53             test_kv          2         test_v_idx       key          2          v            ASC
 53             test_kv          3         test_v_idx2      extra        1          NULL         NULL
 53             test_kv          3         test_v_idx2      key          2          v            DESC
+53             test_kv          3         test_v_idx2      storing      3          NULL         NULL
 53             test_kv          4         test_v_idx3      composite    3          NULL         NULL
 53             test_kv          4         test_v_idx3      extra        1          NULL         NULL
 53             test_kv          4         test_v_idx3      key          3          w            ASC

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -316,7 +316,7 @@ CREATE TABLE t1 (id1 INT PRIMARY KEY, id2 INT, id3 INT);
 
 statement ok
 CREATE INDEX c on t1 (id2)
-   STORING (id1,id3)
+   STORING (id3)
    INTERLEAVE in PARENT t1 (id2);
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/storing
+++ b/pkg/sql/logictest/testdata/logic_test/storing
@@ -7,7 +7,7 @@ CREATE TABLE t (
   c INT,
   d INT,
   INDEX b_idx (b) STORING (c, d),
-  UNIQUE INDEX c_idx (c) STORING (a, b, d)
+  UNIQUE INDEX c_idx (c) STORING (b, d)
 )
 
 query TTBITTBB colnames
@@ -20,9 +20,9 @@ t           b_idx       true        2             c            N/A        true  
 t           b_idx       true        3             d            N/A        true     false
 t           b_idx       true        4             a            ASC        false    true
 t           c_idx       false       1             c            ASC        false    false
-t           c_idx       false       2             a            N/A        true     false
-t           c_idx       false       3             b            N/A        true     false
-t           c_idx       false       4             d            N/A        true     false
+t           c_idx       false       2             b            N/A        true     false
+t           c_idx       false       3             d            N/A        true     false
+t           c_idx       false       4             a            ASC        false    true
 
 statement ok
 INSERT INTO t VALUES (1, 2, 3, 4)
@@ -40,7 +40,7 @@ SELECT a, b, c, d FROM t@c_idx
 # Test index backfill for UNIQUE and non-UNIQUE indexes with STORING columns.
 
 statement ok
-CREATE INDEX d_idx ON t (d) STORING (a, b)
+CREATE INDEX d_idx ON t (d) STORING ( b)
 
 query III
 SELECT a, b, d FROM t@d_idx
@@ -49,6 +49,35 @@ SELECT a, b, d FROM t@d_idx
 
 statement error index "error" already contains column "d"
 CREATE INDEX error ON t (d) STORING (d)
+
+statement error index "error" already contains column "a"
+CREATE INDEX error ON t (d) STORING (a)
+
+statement error index "b_idx" already contains column "a"
+CREATE TABLE t30984 (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  INDEX b_idx (b) STORING (c, a)
+)
+
+statement error index "b_idx" already contains column "a"
+CREATE TABLE t30984 (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  UNIQUE INDEX b_idx (b) STORING (c, a)
+)
+
+statement error index "b_idx" already contains column "d"
+CREATE TABLE t30984 (
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  PRIMARY KEY (a, d),
+  UNIQUE INDEX b_idx (b) STORING (c, d)
+)
 
 statement ok
 CREATE UNIQUE INDEX a_idx ON t (a) STORING (b)

--- a/pkg/sql/logictest/testdata/planner_test/ddl
+++ b/pkg/sql/logictest/testdata/planner_test/ddl
@@ -215,7 +215,7 @@ DROP table t
 statement ok
 CREATE TABLE test_kv(k INT PRIMARY KEY, v INT, w DECIMAL);
   CREATE UNIQUE INDEX test_v_idx ON test_kv(v);
-  CREATE INDEX test_v_idx2 ON test_kv(v DESC) STORING(k);
+  CREATE INDEX test_v_idx2 ON test_kv(v DESC) STORING(w);
   CREATE INDEX test_v_idx3 ON test_kv(w) STORING(v);
   CREATE TABLE test_kvr1(k INT PRIMARY KEY REFERENCES test_kv(k));
   CREATE TABLE test_kvr2(k INT, v INT UNIQUE REFERENCES test_kv(k));

--- a/pkg/sql/logictest/testdata/planner_test/select
+++ b/pkg/sql/logictest/testdata/planner_test/select
@@ -10,7 +10,7 @@ CREATE TABLE t (
   c INT,
   d INT,
   INDEX b_idx (b) STORING (c, d),
-  UNIQUE INDEX c_idx (c) STORING (a, b, d)
+  UNIQUE INDEX c_idx (c) STORING (b, d)
 )
 
 query TTBITTBB colnames
@@ -23,9 +23,9 @@ t           b_idx       true        2             c            N/A        true  
 t           b_idx       true        3             d            N/A        true     false
 t           b_idx       true        4             a            ASC        false    true
 t           c_idx       false       1             c            ASC        false    false
-t           c_idx       false       2             a            N/A        true     false
-t           c_idx       false       3             b            N/A        true     false
-t           c_idx       false       4             d            N/A        true     false
+t           c_idx       false       2             b            N/A        true     false
+t           c_idx       false       3             d            N/A        true     false
+t           c_idx       false       4             a            ASC        false    true
 
 statement ok
 INSERT INTO t VALUES (1, 2, 3, 4)
@@ -47,13 +47,13 @@ query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
 ----
-fetched: /t/c_idx/3 -> /1/2/4
+fetched: /t/c_idx/3/b/d -> /2/4
 output row: [1 2 3 4]
 
 # Test index backfill for UNIQUE and non-UNIQUE indexes with STORING columns.
 
 statement ok
-CREATE INDEX d_idx ON t (d) STORING (a, b)
+CREATE INDEX d_idx ON t (d) STORING (b)
 
 statement ok
 SET tracing = on,kv,results; SELECT a, b, d FROM t@d_idx; SET tracing = off
@@ -191,7 +191,7 @@ CREATE TABLE computed (
   k INT PRIMARY KEY,
   a JSON,
   b TEXT AS (a->>'q') STORED,
-  INDEX (b) STORING (k)
+  INDEX (b)
 )
 
 query TTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/ddl
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ddl
@@ -215,7 +215,7 @@ DROP table t
 statement ok
 CREATE TABLE test_kv(k INT PRIMARY KEY, v INT, w DECIMAL);
   CREATE UNIQUE INDEX test_v_idx ON test_kv(v);
-  CREATE INDEX test_v_idx2 ON test_kv(v DESC) STORING(k);
+  CREATE INDEX test_v_idx2 ON test_kv(v DESC) STORING(w);
   CREATE INDEX test_v_idx3 ON test_kv(w) STORING(v);
   CREATE TABLE test_kvr1(k INT PRIMARY KEY REFERENCES test_kv(k));
   CREATE TABLE test_kvr2(k INT, v INT UNIQUE REFERENCES test_kv(k));

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -321,7 +321,7 @@ CREATE TABLE t (
   c INT,
   d INT,
   INDEX b_idx (b) STORING (c, d),
-  UNIQUE INDEX c_idx (c) STORING (a, b, d)
+  UNIQUE INDEX c_idx (c) STORING (b, d)
 )
 
 query TTBITTBB colnames
@@ -334,9 +334,9 @@ t           b_idx       true        2             c            N/A        true  
 t           b_idx       true        3             d            N/A        true     false
 t           b_idx       true        4             a            ASC        false    true
 t           c_idx       false       1             c            ASC        false    false
-t           c_idx       false       2             a            N/A        true     false
-t           c_idx       false       3             b            N/A        true     false
-t           c_idx       false       4             d            N/A        true     false
+t           c_idx       false       2             b            N/A        true     false
+t           c_idx       false       3             d            N/A        true     false
+t           c_idx       false       4             a            ASC        false    true
 
 statement ok
 INSERT INTO t VALUES (1, 2, 3, 4)
@@ -358,13 +358,13 @@ query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
 ----
-fetched: /t/c_idx/3 -> /1/2/4
+fetched: /t/c_idx/3/b/d -> /2/4
 output row: [1 2 3 4]
 
 # Test index backfill for UNIQUE and non-UNIQUE indexes with STORING columns.
 
 statement ok
-CREATE INDEX d_idx ON t (d) STORING (a, b)
+CREATE INDEX d_idx ON t (d) STORING (b)
 
 statement ok
 SET tracing = on,kv,results; SELECT a, b, d FROM t@d_idx; SET tracing = off
@@ -537,7 +537,7 @@ CREATE TABLE computed (
   k INT PRIMARY KEY,
   a JSON,
   b TEXT AS (a->>'q') STORED,
-  INDEX (b) STORING (k)
+  INDEX (b)
 )
 
 query TTTTT

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -735,10 +735,16 @@ func (desc *TableDescriptor) allocateIndexIDs(columnNames map[string]ColumnID) e
 					return err
 				}
 				if desc.PrimaryIndex.ContainsColumnID(col.ID) {
-					continue
+					// If the primary index contains a stored column, we don't need to
+					// store it - it's already part of the index.
+					return pgerror.NewErrorf(
+						pgerror.CodeDuplicateColumnError, "index %q already contains column %q", index.Name, col.Name).
+						SetDetailf("column %q is part of the primary index and therefore implicit in all indexes", col.Name)
 				}
 				if index.ContainsColumnID(col.ID) {
-					return fmt.Errorf("index %q already contains column %q", index.Name, col.Name)
+					return pgerror.NewErrorf(
+						pgerror.CodeDuplicateColumnError,
+						"index %q already contains column %q", index.Name, col.Name)
 				}
 				if indexHasOldStoredColumns {
 					index.ExtraColumnIDs = append(index.ExtraColumnIDs, col.ID)


### PR DESCRIPTION
Backport 1/1 commits from #31019.

/cc @cockroachdb/release

---

Previously, users could create indexes that included PRIMARY KEY columns
in the STORING list. This was effectively a no-op and misleading to
users, since PRIMARY KEY columns are always stored in indexes regardless
of the STORING list. Separately, permitting this tickled a bug in the
descriptor accounting system.

Now, this behavior is prevented by returning an error to the user if
they try to do such a thing, with a helpful message explaining why it's
not allowed.

Fixes #30984.

Release note (sql change): don't allow specifying STORING columns in
indexes that are already part of the index's corresponding PRIMARY
INDEX.
