### PR TITLE
[DNM] opt: add exploration rule for join associativity

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -97,29 +97,36 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) LIMIT 1
 ]
 ----
-limit                     ·         ·
- │                        count     1
- └── join                 ·         ·
-      │                   type      inner
-      │                   equality  (x) = (x)
-      │                   pred      x = x
-      ├── join            ·         ·
-      │    │              type      inner
-      │    │              equality  (x) = (x)
-      │    ├── join       ·         ·
-      │    │    │         type      cross
-      │    │    ├── scan  ·         ·
-      │    │    │         table     onecolumn@primary
-      │    │    │         spans     ALL
-      │    │    └── scan  ·         ·
-      │    │              table     twocolumn@primary
-      │    │              spans     ALL
-      │    └── scan       ·         ·
-      │                   table     onecolumn@primary
-      │                   spans     ALL
-      └── scan            ·         ·
-·                         table     twocolumn@primary
-·                         spans     ALL
+render                         ·         ·
+ │                             render 0  x
+ │                             render 1  x
+ │                             render 2  y
+ │                             render 3  x
+ │                             render 4  x
+ │                             render 5  y
+ └── limit                     ·         ·
+      │                        count     1
+      └── join                 ·         ·
+           │                   type      inner
+           │                   equality  (x) = (x)
+           │                   pred      x = x
+           ├── join            ·         ·
+           │    │              type      cross
+           │    ├── join       ·         ·
+           │    │    │         type      inner
+           │    │    │         equality  (x) = (x)
+           │    │    ├── scan  ·         ·
+           │    │    │         table     onecolumn@primary
+           │    │    │         spans     ALL
+           │    │    └── scan  ·         ·
+           │    │              table     twocolumn@primary
+           │    │              spans     ALL
+           │    └── scan       ·         ·
+           │                   table     onecolumn@primary
+           │                   spans     ALL
+           └── scan            ·         ·
+·                              table     twocolumn@primary
+·                              spans     ALL
 
 # The following queries verify that only the necessary columns are scanned.
 query TTTTT
@@ -337,88 +344,88 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 2   ·              render 12  relname
 3   join           ·          ·
 3   ·              type       inner
-3   ·              equality   (relnamespace) = (oid)
+3   ·              equality   (oid) = (attrelid)
+3   ·              pred       confrelid = oid
 4   join           ·          ·
 4   ·              type       inner
-4   ·              equality   (attrelid) = (oid)
-4   ·              pred       confrelid = oid
-5   join           ·          ·
-5   ·              type       inner
-5   ·              equality   (attnum) = (column167)
-6   virtual table  ·          ·
-6   ·              source     ·
-6   render         ·          ·
-6   ·              render 0   confkey[generate_series]
-6   ·              render 1   nspname
-6   ·              render 2   relname
-6   ·              render 3   attname
-6   ·              render 4   conname
-6   ·              render 5   condeferrable
-6   ·              render 6   condeferred
-6   ·              render 7   confrelid
-6   ·              render 8   confupdtype
-6   ·              render 9   confdeltype
-6   ·              render 10  generate_series
-6   ·              render 11  relname
+4   ·              equality   (oid) = (relnamespace)
+5   virtual table  ·          ·
+5   ·              source     ·
+5   virtual table  ·          ·
+5   ·              source     ·
+4   join           ·          ·
+4   ·              type       inner
+4   ·              equality   (attnum) = (column167)
+5   virtual table  ·          ·
+5   ·              source     ·
+5   render         ·          ·
+5   ·              render 0   confkey[generate_series]
+5   ·              render 1   nspname
+5   ·              render 2   relname
+5   ·              render 3   attname
+5   ·              render 4   conname
+5   ·              render 5   condeferrable
+5   ·              render 6   condeferred
+5   ·              render 7   confrelid
+5   ·              render 8   confupdtype
+5   ·              render 9   confdeltype
+5   ·              render 10  generate_series
+5   ·              render 11  relname
+6   join           ·          ·
+6   ·              type       inner
+6   ·              equality   (attrelid) = (oid)
+6   ·              pred       conrelid = oid
 7   join           ·          ·
 7   ·              type       inner
-7   ·              equality   (relnamespace) = (oid)
-8   join           ·          ·
-8   ·              type       inner
-8   ·              equality   (attrelid) = (oid)
-8   ·              pred       conrelid = oid
+7   ·              equality   (attnum) = (column166)
+8   virtual table  ·          ·
+8   ·              source     ·
+8   render         ·          ·
+8   ·              render 0   conkey[generate_series]
+8   ·              render 1   conname
+8   ·              render 2   condeferrable
+8   ·              render 3   condeferred
+8   ·              render 4   conrelid
+8   ·              render 5   confrelid
+8   ·              render 6   confupdtype
+8   ·              render 7   confdeltype
+8   ·              render 8   confkey
+8   ·              render 9   generate_series
+8   ·              render 10  relname
 9   join           ·          ·
-9   ·              type       inner
-9   ·              equality   (attnum) = (column166)
-10  virtual table  ·          ·
-10  ·              source     ·
-10  render         ·          ·
-10  ·              render 0   conkey[generate_series]
-10  ·              render 1   conname
-10  ·              render 2   condeferrable
-10  ·              render 3   condeferred
-10  ·              render 4   conrelid
-10  ·              render 5   confrelid
-10  ·              render 6   confupdtype
-10  ·              render 7   confdeltype
-10  ·              render 8   confkey
-10  ·              render 9   generate_series
-10  ·              render 10  relname
+9   ·              type       cross
+10  join           ·          ·
+10  ·              type       inner
+10  ·              equality   (objid) = (oid)
 11  join           ·          ·
 11  ·              type       inner
-11  ·              equality   (objid) = (oid)
-12  join           ·          ·
-12  ·              type       cross
-13  join           ·          ·
-13  ·              type       inner
-13  ·              equality   (refobjid) = (oid)
-14  filter         ·          ·
-14  ·              filter     (classid = 139623798) AND (refclassid = 1411792157)
-15  virtual table  ·          ·
-15  ·              source     ·
-14  filter         ·          ·
-14  ·              filter     relkind = 'i'
-15  virtual table  ·          ·
-15  ·              source     ·
-13  project set    ·          ·
-13  ·              render 0   generate_series(1, 32)
-14  emptyrow       ·          ·
+11  ·              equality   (refobjid) = (oid)
 12  filter         ·          ·
-12  ·              filter     contype = 'f'
+12  ·              filter     (classid = 139623798) AND (refclassid = 1411792157)
 13  virtual table  ·          ·
 13  ·              source     ·
-9   filter         ·          ·
-9   ·              filter     relname = 'orders'
-10  virtual table  ·          ·
-10  ·              source     ·
+12  filter         ·          ·
+12  ·              filter     relkind = 'i'
+13  virtual table  ·          ·
+13  ·              source     ·
+11  filter         ·          ·
+11  ·              filter     contype = 'f'
+12  virtual table  ·          ·
+12  ·              source     ·
+10  project set    ·          ·
+10  ·              render 0   generate_series(1, 32)
+11  emptyrow       ·          ·
+7   join           ·          ·
+7   ·              type       inner
+7   ·              equality   (oid) = (relnamespace)
 8   filter         ·          ·
 8   ·              filter     nspname = 'public'
 9   virtual table  ·          ·
 9   ·              source     ·
-5   virtual table  ·          ·
-5   ·              source     ·
-4   virtual table  ·          ·
-4   ·              source     ·
+8   filter         ·          ·
+8   ·              filter     relname = 'orders'
+9   virtual table  ·          ·
+9   ·              source     ·
 
 # Ensure that left joins on non-null foreign keys turn into inner joins
 statement ok

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -388,6 +388,13 @@ func (c *CustomFuncs) IsFilterFalse(filters memo.FiltersExpr) bool {
 	return filters.IsFalse()
 }
 
+// IsFilterTrue returns true if the filters always evaluate to true. The only
+// case that's checked is the fully normalized case, when the list contains a
+// single True condition.
+func (c *CustomFuncs) IsFilterTrue(filters memo.FiltersExpr) bool {
+	return filters.IsTrue()
+}
+
 // IsContradiction returns true if the given filter item contains a
 // contradiction constraint.
 func (c *CustomFuncs) IsContradiction(item *memo.FiltersItem) bool {

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1340,32 +1340,36 @@ project
       │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null) k:5(int!null) i:6(int!null)
       │    │    ├── key: (3)
       │    │    ├── fd: (1)-->(2), (3)-->(4), (1)==(4,5), (4)==(1,5), (5)-->(6), (5)==(1,4)
-      │    │    ├── inner-join
-      │    │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null)
+      │    │    ├── scan uv
+      │    │    │    ├── columns: u:3(int!null) v:4(int)
       │    │    │    ├── key: (3)
-      │    │    │    ├── fd: (1)-->(2), (3)-->(4), (1)==(4), (4)==(1)
+      │    │    │    └── fd: (3)-->(4)
+      │    │    ├── inner-join (merge)
+      │    │    │    ├── columns: x:1(int!null) y:2(int) k:5(int!null) i:6(int!null)
+      │    │    │    ├── left ordering: +5
+      │    │    │    ├── right ordering: +1
+      │    │    │    ├── key: (5)
+      │    │    │    ├── fd: (5)-->(6), (1)-->(2), (1)==(5), (5)==(1)
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: k:5(int!null) i:6(int!null)
+      │    │    │    │    ├── key: (5)
+      │    │    │    │    ├── fd: (5)-->(6)
+      │    │    │    │    ├── ordering: +5
+      │    │    │    │    ├── scan a
+      │    │    │    │    │    ├── columns: k:5(int!null) i:6(int)
+      │    │    │    │    │    ├── key: (5)
+      │    │    │    │    │    ├── fd: (5)-->(6)
+      │    │    │    │    │    └── ordering: +5
+      │    │    │    │    └── filters
+      │    │    │    │         └── i IS NOT NULL [type=bool, outer=(6), constraints=(/6: (/NULL - ]; tight)]
       │    │    │    ├── scan xy
       │    │    │    │    ├── columns: x:1(int!null) y:2(int)
       │    │    │    │    ├── key: (1)
-      │    │    │    │    └── fd: (1)-->(2)
-      │    │    │    ├── scan uv
-      │    │    │    │    ├── columns: u:3(int!null) v:4(int)
-      │    │    │    │    ├── key: (3)
-      │    │    │    │    └── fd: (3)-->(4)
-      │    │    │    └── filters
-      │    │    │         └── x = v [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
-      │    │    ├── select
-      │    │    │    ├── columns: k:5(int!null) i:6(int!null)
-      │    │    │    ├── key: (5)
-      │    │    │    ├── fd: (5)-->(6)
-      │    │    │    ├── scan a
-      │    │    │    │    ├── columns: k:5(int!null) i:6(int)
-      │    │    │    │    ├── key: (5)
-      │    │    │    │    └── fd: (5)-->(6)
-      │    │    │    └── filters
-      │    │    │         └── i IS NOT NULL [type=bool, outer=(6), constraints=(/6: (/NULL - ]; tight)]
+      │    │    │    │    ├── fd: (1)-->(2)
+      │    │    │    │    └── ordering: +1
+      │    │    │    └── filters (true)
       │    │    └── filters
-      │    │         └── k = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+      │    │         └── x = v [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
       │    └── aggregations
       │         ├── max [type=int, outer=(6)]
       │         │    └── variable: i [type=int]
@@ -2041,31 +2045,31 @@ group-by
  │    │    │    ├── columns: x:1(int!null) y:2(int) a.k:3(int!null) a.i:4(int) a.i:9(int!null) a.f:10(float!null) column14:14(float!null)
  │    │    │    ├── fd: (1)-->(2), (2)-->(14), (3)-->(4), (10)==(14), (14)==(10)
  │    │    │    ├── inner-join
- │    │    │    │    ├── columns: a.k:3(int!null) a.i:4(int) a.i:9(int!null) a.f:10(float)
- │    │    │    │    ├── fd: (3)-->(4)
- │    │    │    │    ├── scan a
- │    │    │    │    │    ├── columns: a.k:3(int!null) a.i:4(int)
- │    │    │    │    │    ├── key: (3)
- │    │    │    │    │    └── fd: (3)-->(4)
+ │    │    │    │    ├── columns: x:1(int!null) y:2(int) a.i:9(int!null) a.f:10(float!null) column14:14(float!null)
+ │    │    │    │    ├── fd: (1)-->(2), (2)-->(14), (10)==(14), (14)==(10)
+ │    │    │    │    ├── project
+ │    │    │    │    │    ├── columns: column14:14(float) x:1(int!null) y:2(int)
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    ├── fd: (1)-->(2), (2)-->(14)
+ │    │    │    │    │    ├── scan xy
+ │    │    │    │    │    │    ├── columns: x:1(int!null) y:2(int)
+ │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    │    └── fd: (1)-->(2)
+ │    │    │    │    │    └── projections
+ │    │    │    │    │         └── y::FLOAT8 [type=float, outer=(2)]
  │    │    │    │    ├── select
  │    │    │    │    │    ├── columns: a.i:9(int!null) a.f:10(float)
  │    │    │    │    │    ├── scan a
  │    │    │    │    │    │    └── columns: a.i:9(int) a.f:10(float)
  │    │    │    │    │    └── filters
  │    │    │    │    │         └── a.i IS NOT NULL [type=bool, outer=(9), constraints=(/9: (/NULL - ]; tight)]
- │    │    │    │    └── filters (true)
- │    │    │    ├── project
- │    │    │    │    ├── columns: column14:14(float) x:1(int!null) y:2(int)
- │    │    │    │    ├── key: (1)
- │    │    │    │    ├── fd: (1)-->(2), (2)-->(14)
- │    │    │    │    ├── scan xy
- │    │    │    │    │    ├── columns: x:1(int!null) y:2(int)
- │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    └── fd: (1)-->(2)
- │    │    │    │    └── projections
- │    │    │    │         └── y::FLOAT8 [type=float, outer=(2)]
- │    │    │    └── filters
- │    │    │         └── column14 = a.f [type=bool, outer=(10,14), constraints=(/10: (/NULL - ]; /14: (/NULL - ]), fd=(10)==(14), (14)==(10)]
+ │    │    │    │    └── filters
+ │    │    │    │         └── column14 = a.f [type=bool, outer=(10,14), constraints=(/10: (/NULL - ]; /14: (/NULL - ]), fd=(10)==(14), (14)==(10)]
+ │    │    │    ├── scan a
+ │    │    │    │    ├── columns: a.k:3(int!null) a.i:4(int)
+ │    │    │    │    ├── key: (3)
+ │    │    │    │    └── fd: (3)-->(4)
+ │    │    │    └── filters (true)
  │    │    └── aggregations
  │    │         ├── max [type=int, outer=(9)]
  │    │         │    └── variable: a.i [type=int]
@@ -2148,21 +2152,22 @@ project
       │    │    ├── key: (1,6)
       │    │    ├── fd: (1)-->(2), (2)==(8), (8)==(2)
       │    │    ├── inner-join
-      │    │    │    ├── columns: x:6(int!null) u:8(int!null)
-      │    │    │    ├── key: (6,8)
-      │    │    │    ├── scan xy
-      │    │    │    │    ├── columns: x:6(int!null)
-      │    │    │    │    └── key: (6)
+      │    │    │    ├── columns: k:1(int!null) i:2(int!null) u:8(int!null)
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2), (2)==(8), (8)==(2)
+      │    │    │    ├── scan a
+      │    │    │    │    ├── columns: k:1(int!null) i:2(int)
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    └── fd: (1)-->(2)
       │    │    │    ├── scan uv
       │    │    │    │    ├── columns: u:8(int!null)
       │    │    │    │    └── key: (8)
-      │    │    │    └── filters (true)
-      │    │    ├── scan a
-      │    │    │    ├── columns: k:1(int!null) i:2(int)
-      │    │    │    ├── key: (1)
-      │    │    │    └── fd: (1)-->(2)
-      │    │    └── filters
-      │    │         └── u = i [type=bool, outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+      │    │    │    └── filters
+      │    │    │         └── u = i [type=bool, outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+      │    │    ├── scan xy
+      │    │    │    ├── columns: x:6(int!null)
+      │    │    │    └── key: (6)
+      │    │    └── filters (true)
       │    └── projections
       │         └── COALESCE(u, 10) [type=int, outer=(8)]
       └── filters

--- a/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
@@ -116,11 +116,11 @@ func (g *factoryGen) genConstructFuncs() {
 			g.w.write("%s", unTitle(g.md.fieldName(field)))
 		}
 
-		g.w.write(")\n")
-
 		if define.Tags.Contains("Relational") {
+			g.w.write(").FirstExpr()\n")
 			g.w.writeIndent("return _f.onConstructRelational(e)\n")
 		} else {
+			g.w.write(")\n")
 			g.w.writeIndent("return _f.onConstructScalar(e)\n")
 		}
 

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
@@ -114,7 +114,7 @@ func (_f *Factory) ConstructSelect(
 		}
 	}
 
-	e := _f.mem.MemoizeSelect(input, filters)
+	e := _f.mem.MemoizeSelect(input, filters).FirstExpr()
 	return _f.onConstructRelational(e)
 }
 
@@ -124,7 +124,7 @@ func (_f *Factory) ConstructInnerJoin(
 	right memo.RelExpr,
 	on memo.FiltersExpr,
 ) memo.RelExpr {
-	e := _f.mem.MemoizeInnerJoin(left, right, on)
+	e := _f.mem.MemoizeInnerJoin(left, right, on).FirstExpr()
 	return _f.onConstructRelational(e)
 }
 
@@ -134,7 +134,7 @@ func (_f *Factory) ConstructInnerJoinApply(
 	right memo.RelExpr,
 	on memo.FiltersExpr,
 ) memo.RelExpr {
-	e := _f.mem.MemoizeInnerJoinApply(left, right, on)
+	e := _f.mem.MemoizeInnerJoinApply(left, right, on).FirstExpr()
 	return _f.onConstructRelational(e)
 }
 

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -35,6 +35,37 @@
 =>
 (LeftJoin $right $left $on)
 
+# AssociateJoin applies the rule of join associativity. It converts an
+# expression like:
+#   A JOIN (B JOIN C ON B.x = C.x) ON A.y = B.y
+# to the logically equivalent expression:
+#   (A JOIN B ON A.y = B.y) JOIN C ON B.x = C.x
+# It applies as long as the outer predicate is not True (we want to avoid
+# pushing cross joins down), and the outer predicate only references one of
+# the two inner relations. (Although this rule only allows references to the
+# left inner relation, the CommuteJoin rule will effectively enable references
+# to the right inner relation as well.)
+[AssociateJoin, Explore]
+(InnerJoin
+    $left:*
+    (InnerJoin
+        $innerLeft:*
+        $innerRight:*
+        $innerOn:*
+    )
+    $on:* & ^(IsFilterTrue $on) & (FiltersBoundBy $on (OutputCols2 $left $innerLeft))
+)
+=>
+(InnerJoin
+    (InnerJoin
+        $left
+        $innerLeft
+        $on
+    )
+    $innerRight
+    $innerOn
+)
+
 # GenerateMergeJoins creates MergeJoin operators for the join, using the
 # interesting orderings property.
 [GenerateMergeJoins, Explore]

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -239,36 +239,39 @@ inner-join
  ├── columns: id1_6_0_:1(int!null) id1_4_1_:6(int!null) phone_nu2_6_0_:2(string) person_i4_6_0_:4(int!null) phone_ty3_6_0_:3(string) person_i1_5_0__:12(int!null) addresse2_5_0__:13(string) addresse3_0__:14(string!null) address2_4_1_:7(string) createdo3_4_1_:8(timestamp) name4_4_1_:9(string) nickname5_4_1_:10(string) version6_4_1_:11(int!null) person_i1_5_0__:12(int!null) addresse2_5_0__:13(string) addresse3_0__:14(string!null)
  ├── key: (1,14)
  ├── fd: (1)-->(2-4), (6)-->(7-11), (4)==(6,12), (6)==(4,12), (12,14)-->(13), (12)==(4,6)
- ├── inner-join
- │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int!null) person.id:6(int!null) address:7(string) createdon:8(timestamp) name:9(string) nickname:10(string) version:11(int!null)
- │    ├── key: (1)
- │    ├── fd: (1)-->(2-4), (6)-->(7-11), (4)==(6), (6)==(4)
- │    ├── semi-join
- │    │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int)
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-4)
- │    │    ├── scan phone
- │    │    │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int)
- │    │    │    ├── key: (1)
- │    │    │    └── fd: (1)-->(2-4)
- │    │    ├── scan phone_call
- │    │    │    ├── columns: phone_call.id:15(int!null) phone_id:18(int)
- │    │    │    ├── key: (15)
- │    │    │    └── fd: (15)-->(18)
- │    │    └── filters
- │    │         └── phone.id = phone_id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+ ├── inner-join (merge)
+ │    ├── columns: person.id:6(int!null) address:7(string) createdon:8(timestamp) name:9(string) nickname:10(string) version:11(int!null) person_addresses.person_id:12(int!null) addresses:13(string) addresses_key:14(string!null)
+ │    ├── left ordering: +12
+ │    ├── right ordering: +6
+ │    ├── key: (12,14)
+ │    ├── fd: (12,14)-->(13), (6)-->(7-11), (6)==(12), (12)==(6)
+ │    ├── scan person_addresses
+ │    │    ├── columns: person_addresses.person_id:12(int!null) addresses:13(string) addresses_key:14(string!null)
+ │    │    ├── key: (12,14)
+ │    │    ├── fd: (12,14)-->(13)
+ │    │    └── ordering: +12
  │    ├── scan person
  │    │    ├── columns: person.id:6(int!null) address:7(string) createdon:8(timestamp) name:9(string) nickname:10(string) version:11(int!null)
  │    │    ├── key: (6)
- │    │    └── fd: (6)-->(7-11)
+ │    │    ├── fd: (6)-->(7-11)
+ │    │    └── ordering: +6
+ │    └── filters (true)
+ ├── semi-join
+ │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── scan phone
+ │    │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-4)
+ │    ├── scan phone_call
+ │    │    ├── columns: phone_call.id:15(int!null) phone_id:18(int)
+ │    │    ├── key: (15)
+ │    │    └── fd: (15)-->(18)
  │    └── filters
- │         └── phone.person_id = person.id [type=bool, outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ]), fd=(4)==(6), (6)==(4)]
- ├── scan person_addresses
- │    ├── columns: person_addresses.person_id:12(int!null) addresses:13(string) addresses_key:14(string!null)
- │    ├── key: (12,14)
- │    └── fd: (12,14)-->(13)
+ │         └── phone.id = phone_id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
  └── filters
-      └── person.id = person_addresses.person_id [type=bool, outer=(6,12), constraints=(/6: (/NULL - ]; /12: (/NULL - ]), fd=(6)==(12), (12)==(6)]
+      └── phone.person_id = person.id [type=bool, outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ]), fd=(4)==(6), (6)==(4)]
 
 opt
 select
@@ -300,33 +303,35 @@ project
  └── inner-join
       ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int!null) person.id:6(int!null) person_addresses.person_id:12(int!null)
       ├── fd: (1)-->(2-4), (4)==(6,12), (6)==(4,12), (12)==(4,6)
-      ├── inner-join
-      │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int!null) person.id:6(int!null)
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-4), (4)==(6), (6)==(4)
-      │    ├── semi-join
-      │    │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int)
-      │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2-4)
-      │    │    ├── scan phone
-      │    │    │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int)
-      │    │    │    ├── key: (1)
-      │    │    │    └── fd: (1)-->(2-4)
-      │    │    ├── scan phone_call
-      │    │    │    ├── columns: phone_call.id:15(int!null) phone_id:18(int)
-      │    │    │    ├── key: (15)
-      │    │    │    └── fd: (15)-->(18)
-      │    │    └── filters
-      │    │         └── phone.id = phone_id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+      ├── inner-join (merge)
+      │    ├── columns: person.id:6(int!null) person_addresses.person_id:12(int!null)
+      │    ├── left ordering: +12
+      │    ├── right ordering: +6
+      │    ├── fd: (6)==(12), (12)==(6)
+      │    ├── scan person_addresses
+      │    │    ├── columns: person_addresses.person_id:12(int!null)
+      │    │    └── ordering: +12
       │    ├── scan person
       │    │    ├── columns: person.id:6(int!null)
-      │    │    └── key: (6)
+      │    │    ├── key: (6)
+      │    │    └── ordering: +6
+      │    └── filters (true)
+      ├── semi-join
+      │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-4)
+      │    ├── scan phone
+      │    │    ├── columns: phone.id:1(int!null) phone_number:2(string) phone_type:3(string) phone.person_id:4(int)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2-4)
+      │    ├── scan phone_call
+      │    │    ├── columns: phone_call.id:15(int!null) phone_id:18(int)
+      │    │    ├── key: (15)
+      │    │    └── fd: (15)-->(18)
       │    └── filters
-      │         └── phone.person_id = person.id [type=bool, outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ]), fd=(4)==(6), (6)==(4)]
-      ├── scan person_addresses
-      │    └── columns: person_addresses.person_id:12(int!null)
+      │         └── phone.id = phone_id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
       └── filters
-           └── person.id = person_addresses.person_id [type=bool, outer=(6,12), constraints=(/6: (/NULL - ]; /12: (/NULL - ]), fd=(6)==(12), (12)==(6)]
+           └── phone.person_id = person.id [type=bool, outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ]), fd=(4)==(6), (6)==(4)]
 
 opt
 select
@@ -2692,21 +2697,21 @@ group-by
  │    │    │    ├── columns: student.studentid:1(int!null) name:2(string!null) address_city:3(string) address_state:4(string) preferredcoursecode:5(string!null) enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null) enrolment.year:9(int!null) enrolment.coursecode:11(string!null) enrolment.year:13(int!null)
  │    │    │    ├── fd: (1)-->(2-5), (6,7)-->(9), (5)==(11), (11)==(5)
  │    │    │    ├── inner-join
- │    │    │    │    ├── columns: enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null) enrolment.year:9(int!null) enrolment.coursecode:11(string!null) enrolment.year:13(int!null)
- │    │    │    │    ├── fd: (6,7)-->(9)
- │    │    │    │    ├── scan enrolment
- │    │    │    │    │    ├── columns: enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null) enrolment.year:9(int!null)
- │    │    │    │    │    ├── key: (6,7)
- │    │    │    │    │    └── fd: (6,7)-->(9)
+ │    │    │    │    ├── columns: student.studentid:1(int!null) name:2(string!null) address_city:3(string) address_state:4(string) preferredcoursecode:5(string!null) enrolment.coursecode:11(string!null) enrolment.year:13(int!null)
+ │    │    │    │    ├── fd: (1)-->(2-5), (5)==(11), (11)==(5)
+ │    │    │    │    ├── scan student
+ │    │    │    │    │    ├── columns: student.studentid:1(int!null) name:2(string!null) address_city:3(string) address_state:4(string) preferredcoursecode:5(string)
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    └── fd: (1)-->(2-5)
  │    │    │    │    ├── scan enrolment
  │    │    │    │    │    └── columns: enrolment.coursecode:11(string!null) enrolment.year:13(int!null)
- │    │    │    │    └── filters (true)
- │    │    │    ├── scan student
- │    │    │    │    ├── columns: student.studentid:1(int!null) name:2(string!null) address_city:3(string) address_state:4(string) preferredcoursecode:5(string)
- │    │    │    │    ├── key: (1)
- │    │    │    │    └── fd: (1)-->(2-5)
- │    │    │    └── filters
- │    │    │         └── preferredcoursecode = enrolment.coursecode [type=bool, outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ]), fd=(5)==(11), (11)==(5)]
+ │    │    │    │    └── filters
+ │    │    │    │         └── preferredcoursecode = enrolment.coursecode [type=bool, outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ]), fd=(5)==(11), (11)==(5)]
+ │    │    │    ├── scan enrolment
+ │    │    │    │    ├── columns: enrolment.studentid:6(int!null) enrolment.coursecode:7(string!null) enrolment.year:9(int!null)
+ │    │    │    │    ├── key: (6,7)
+ │    │    │    │    └── fd: (6,7)-->(9)
+ │    │    │    └── filters (true)
  │    │    └── aggregations
  │    │         ├── max [type=int, outer=(13)]
  │    │         │    └── variable: enrolment.year [type=int]

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -451,102 +451,81 @@ project
       │         │    │    ├── key: (18,29,34)
       │         │    │    ├── fd: ()-->(6,27,46), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13), (1)==(17,29), (17)==(1,29), (29,30)-->(32), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (30)==(34), (34)==(30), (29)==(1,17)
       │         │    │    ├── inner-join
-      │         │    │    │    ├── columns: partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float!null) supplier.s_suppkey:34(int!null) supplier.s_nationkey:37(int!null) nation.n_nationkey:41(int!null) nation.n_regionkey:43(int!null) region.r_regionkey:45(int!null) region.r_name:46(string!null)
-      │         │    │    │    ├── key: (29,34)
-      │         │    │    │    ├── fd: ()-->(46), (29,30)-->(32), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (30)==(34), (34)==(30)
-      │         │    │    │    ├── scan partsupp
-      │         │    │    │    │    ├── columns: partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float!null)
-      │         │    │    │    │    ├── key: (29,30)
-      │         │    │    │    │    └── fd: (29,30)-->(32)
-      │         │    │    │    ├── inner-join
-      │         │    │    │    │    ├── columns: supplier.s_suppkey:34(int!null) supplier.s_nationkey:37(int!null) nation.n_nationkey:41(int!null) nation.n_regionkey:43(int!null) region.r_regionkey:45(int!null) region.r_name:46(string!null)
-      │         │    │    │    │    ├── key: (34)
-      │         │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37)
-      │         │    │    │    │    ├── scan supplier@s_nk
-      │         │    │    │    │    │    ├── columns: supplier.s_suppkey:34(int!null) supplier.s_nationkey:37(int!null)
-      │         │    │    │    │    │    ├── key: (34)
-      │         │    │    │    │    │    └── fd: (34)-->(37)
-      │         │    │    │    │    ├── inner-join (lookup nation@n_rk)
-      │         │    │    │    │    │    ├── columns: nation.n_nationkey:41(int!null) nation.n_regionkey:43(int!null) region.r_regionkey:45(int!null) region.r_name:46(string!null)
-      │         │    │    │    │    │    ├── key columns: [45] = [43]
-      │         │    │    │    │    │    ├── key: (41)
-      │         │    │    │    │    │    ├── fd: ()-->(46), (41)-->(43), (43)==(45), (45)==(43)
-      │         │    │    │    │    │    ├── select
-      │         │    │    │    │    │    │    ├── columns: region.r_regionkey:45(int!null) region.r_name:46(string!null)
-      │         │    │    │    │    │    │    ├── key: (45)
-      │         │    │    │    │    │    │    ├── fd: ()-->(46)
-      │         │    │    │    │    │    │    ├── scan region
-      │         │    │    │    │    │    │    │    ├── columns: region.r_regionkey:45(int!null) region.r_name:46(string!null)
-      │         │    │    │    │    │    │    │    ├── key: (45)
-      │         │    │    │    │    │    │    │    └── fd: (45)-->(46)
-      │         │    │    │    │    │    │    └── filters
-      │         │    │    │    │    │    │         └── region.r_name = 'EUROPE' [type=bool, outer=(46), constraints=(/46: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(46)]
-      │         │    │    │    │    │    └── filters (true)
-      │         │    │    │    │    └── filters
-      │         │    │    │    │         └── supplier.s_nationkey = nation.n_nationkey [type=bool, outer=(37,41), constraints=(/37: (/NULL - ]; /41: (/NULL - ]), fd=(37)==(41), (41)==(37)]
-      │         │    │    │    └── filters
-      │         │    │    │         └── supplier.s_suppkey = partsupp.ps_suppkey [type=bool, outer=(30,34), constraints=(/30: (/NULL - ]; /34: (/NULL - ]), fd=(30)==(34), (34)==(30)]
-      │         │    │    ├── inner-join
-      │         │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null) supplier.s_suppkey:10(int!null) supplier.s_name:11(string!null) supplier.s_address:12(string!null) supplier.s_nationkey:13(int!null) supplier.s_phone:14(string!null) supplier.s_acctbal:15(float!null) supplier.s_comment:16(string!null) partsupp.ps_partkey:17(int!null) partsupp.ps_suppkey:18(int!null) partsupp.ps_supplycost:20(float!null) nation.n_nationkey:22(int!null) nation.n_name:23(string!null) nation.n_regionkey:24(int!null) region.r_regionkey:26(int!null) region.r_name:27(string!null)
-      │         │    │    │    ├── key: (17,18)
-      │         │    │    │    ├── fd: ()-->(6,27), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13), (1)==(17), (17)==(1)
-      │         │    │    │    ├── inner-join
-      │         │    │    │    │    ├── columns: supplier.s_suppkey:10(int!null) supplier.s_name:11(string!null) supplier.s_address:12(string!null) supplier.s_nationkey:13(int!null) supplier.s_phone:14(string!null) supplier.s_acctbal:15(float!null) supplier.s_comment:16(string!null) partsupp.ps_partkey:17(int!null) partsupp.ps_suppkey:18(int!null) partsupp.ps_supplycost:20(float!null) nation.n_nationkey:22(int!null) nation.n_name:23(string!null) nation.n_regionkey:24(int!null) region.r_regionkey:26(int!null) region.r_name:27(string!null)
-      │         │    │    │    │    ├── key: (17,18)
-      │         │    │    │    │    ├── fd: ()-->(27), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13)
-      │         │    │    │    │    ├── inner-join
-      │         │    │    │    │    │    ├── columns: partsupp.ps_partkey:17(int!null) partsupp.ps_suppkey:18(int!null) partsupp.ps_supplycost:20(float!null) nation.n_nationkey:22(int!null) nation.n_name:23(string!null) nation.n_regionkey:24(int!null) region.r_regionkey:26(int!null) region.r_name:27(string!null)
-      │         │    │    │    │    │    ├── key: (17,18,22)
-      │         │    │    │    │    │    ├── fd: ()-->(27), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24)
-      │         │    │    │    │    │    ├── scan partsupp
-      │         │    │    │    │    │    │    ├── columns: partsupp.ps_partkey:17(int!null) partsupp.ps_suppkey:18(int!null) partsupp.ps_supplycost:20(float!null)
-      │         │    │    │    │    │    │    ├── key: (17,18)
-      │         │    │    │    │    │    │    └── fd: (17,18)-->(20)
+      │         │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null) partsupp.ps_partkey:17(int!null) partsupp.ps_suppkey:18(int!null) partsupp.ps_supplycost:20(float!null) nation.n_nationkey:22(int!null) nation.n_name:23(string!null) nation.n_regionkey:24(int!null) region.r_regionkey:26(int!null) region.r_name:27(string!null) partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float!null) supplier.s_suppkey:34(int!null) supplier.s_nationkey:37(int!null) nation.n_nationkey:41(int!null) nation.n_regionkey:43(int!null) region.r_regionkey:45(int!null) region.r_name:46(string!null)
+      │         │    │    │    ├── key: (18,22,29,34)
+      │         │    │    │    ├── fd: ()-->(6,27,46), (29,30)-->(32), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (30)==(34), (34)==(30), (1)-->(3,5), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (1)==(17,29), (17)==(1,29), (29)==(1,17)
+      │         │    │    │    ├── inner-join (lookup partsupp)
+      │         │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null) partsupp.ps_partkey:17(int!null) partsupp.ps_suppkey:18(int!null) partsupp.ps_supplycost:20(float!null) partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float!null) supplier.s_suppkey:34(int!null) supplier.s_nationkey:37(int!null) nation.n_nationkey:41(int!null) nation.n_regionkey:43(int!null) region.r_regionkey:45(int!null) region.r_name:46(string!null)
+      │         │    │    │    │    ├── key columns: [1] = [17]
+      │         │    │    │    │    ├── key: (18,29,34)
+      │         │    │    │    │    ├── fd: ()-->(6,46), (29,30)-->(32), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (30)==(34), (34)==(30), (1)-->(3,5), (17,18)-->(20), (1)==(17,29), (17)==(1,29), (29)==(1,17)
+      │         │    │    │    │    ├── inner-join (lookup region)
+      │         │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null) partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float!null) supplier.s_suppkey:34(int!null) supplier.s_nationkey:37(int!null) nation.n_nationkey:41(int!null) nation.n_regionkey:43(int!null) region.r_regionkey:45(int!null) region.r_name:46(string!null)
+      │         │    │    │    │    │    ├── key columns: [43] = [45]
+      │         │    │    │    │    │    ├── key: (29,34)
+      │         │    │    │    │    │    ├── fd: ()-->(6,46), (29,30)-->(32), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (30)==(34), (34)==(30), (1)-->(3,5), (1)==(29), (29)==(1)
       │         │    │    │    │    │    ├── inner-join (lookup nation)
-      │         │    │    │    │    │    │    ├── columns: nation.n_nationkey:22(int!null) nation.n_name:23(string!null) nation.n_regionkey:24(int!null) region.r_regionkey:26(int!null) region.r_name:27(string!null)
-      │         │    │    │    │    │    │    ├── key columns: [22] = [22]
-      │         │    │    │    │    │    │    ├── key: (22)
-      │         │    │    │    │    │    │    ├── fd: ()-->(27), (22)-->(23,24), (24)==(26), (26)==(24)
-      │         │    │    │    │    │    │    ├── inner-join (lookup nation@n_rk)
-      │         │    │    │    │    │    │    │    ├── columns: nation.n_nationkey:22(int!null) nation.n_regionkey:24(int!null) region.r_regionkey:26(int!null) region.r_name:27(string!null)
-      │         │    │    │    │    │    │    │    ├── key columns: [26] = [24]
-      │         │    │    │    │    │    │    │    ├── key: (22)
-      │         │    │    │    │    │    │    │    ├── fd: ()-->(27), (22)-->(24), (24)==(26), (26)==(24)
-      │         │    │    │    │    │    │    │    ├── select
-      │         │    │    │    │    │    │    │    │    ├── columns: region.r_regionkey:26(int!null) region.r_name:27(string!null)
-      │         │    │    │    │    │    │    │    │    ├── key: (26)
-      │         │    │    │    │    │    │    │    │    ├── fd: ()-->(27)
-      │         │    │    │    │    │    │    │    │    ├── scan region
-      │         │    │    │    │    │    │    │    │    │    ├── columns: region.r_regionkey:26(int!null) region.r_name:27(string!null)
-      │         │    │    │    │    │    │    │    │    │    ├── key: (26)
-      │         │    │    │    │    │    │    │    │    │    └── fd: (26)-->(27)
-      │         │    │    │    │    │    │    │    │    └── filters
-      │         │    │    │    │    │    │    │    │         └── region.r_name = 'EUROPE' [type=bool, outer=(27), constraints=(/27: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(27)]
+      │         │    │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null) partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float!null) supplier.s_suppkey:34(int!null) supplier.s_nationkey:37(int!null) nation.n_nationkey:41(int!null) nation.n_regionkey:43(int!null)
+      │         │    │    │    │    │    │    ├── key columns: [37] = [41]
+      │         │    │    │    │    │    │    ├── key: (29,34)
+      │         │    │    │    │    │    │    ├── fd: ()-->(6), (29,30)-->(32), (34)-->(37), (41)-->(43), (37)==(41), (41)==(37), (30)==(34), (34)==(30), (1)-->(3,5), (1)==(29), (29)==(1)
+      │         │    │    │    │    │    │    ├── inner-join (lookup supplier)
+      │         │    │    │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null) partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float!null) supplier.s_suppkey:34(int!null) supplier.s_nationkey:37(int!null)
+      │         │    │    │    │    │    │    │    ├── key columns: [30] = [34]
+      │         │    │    │    │    │    │    │    ├── key: (29,34)
+      │         │    │    │    │    │    │    │    ├── fd: ()-->(6), (29,30)-->(32), (34)-->(37), (30)==(34), (34)==(30), (1)-->(3,5), (1)==(29), (29)==(1)
+      │         │    │    │    │    │    │    │    ├── inner-join (lookup partsupp)
+      │         │    │    │    │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null) partsupp.ps_partkey:29(int!null) partsupp.ps_suppkey:30(int!null) partsupp.ps_supplycost:32(float!null)
+      │         │    │    │    │    │    │    │    │    ├── key columns: [1] = [29]
+      │         │    │    │    │    │    │    │    │    ├── key: (29,30)
+      │         │    │    │    │    │    │    │    │    ├── fd: ()-->(6), (29,30)-->(32), (1)-->(3,5), (1)==(29), (29)==(1)
+      │         │    │    │    │    │    │    │    │    ├── select
+      │         │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null)
+      │         │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │         │    │    │    │    │    │    │    │    │    ├── fd: ()-->(6), (1)-->(3,5)
+      │         │    │    │    │    │    │    │    │    │    ├── scan part
+      │         │    │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null)
+      │         │    │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │         │    │    │    │    │    │    │    │    │    │    └── fd: (1)-->(3,5,6)
+      │         │    │    │    │    │    │    │    │    │    └── filters
+      │         │    │    │    │    │    │    │    │    │         ├── p_size = 15 [type=bool, outer=(6), constraints=(/6: [/15 - /15]; tight), fd=()-->(6)]
+      │         │    │    │    │    │    │    │    │    │         └── p_type LIKE '%BRASS' [type=bool, outer=(5), constraints=(/5: (/NULL - ])]
+      │         │    │    │    │    │    │    │    │    └── filters (true)
       │         │    │    │    │    │    │    │    └── filters (true)
       │         │    │    │    │    │    │    └── filters (true)
+      │         │    │    │    │    │    └── filters
+      │         │    │    │    │    │         └── region.r_name = 'EUROPE' [type=bool, outer=(46), constraints=(/46: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(46)]
+      │         │    │    │    │    └── filters (true)
+      │         │    │    │    ├── inner-join (lookup nation)
+      │         │    │    │    │    ├── columns: nation.n_nationkey:22(int!null) nation.n_name:23(string!null) nation.n_regionkey:24(int!null) region.r_regionkey:26(int!null) region.r_name:27(string!null)
+      │         │    │    │    │    ├── key columns: [22] = [22]
+      │         │    │    │    │    ├── key: (22)
+      │         │    │    │    │    ├── fd: ()-->(27), (22)-->(23,24), (24)==(26), (26)==(24)
+      │         │    │    │    │    ├── inner-join (lookup nation@n_rk)
+      │         │    │    │    │    │    ├── columns: nation.n_nationkey:22(int!null) nation.n_regionkey:24(int!null) region.r_regionkey:26(int!null) region.r_name:27(string!null)
+      │         │    │    │    │    │    ├── key columns: [26] = [24]
+      │         │    │    │    │    │    ├── key: (22)
+      │         │    │    │    │    │    ├── fd: ()-->(27), (22)-->(24), (24)==(26), (26)==(24)
+      │         │    │    │    │    │    ├── select
+      │         │    │    │    │    │    │    ├── columns: region.r_regionkey:26(int!null) region.r_name:27(string!null)
+      │         │    │    │    │    │    │    ├── key: (26)
+      │         │    │    │    │    │    │    ├── fd: ()-->(27)
+      │         │    │    │    │    │    │    ├── scan region
+      │         │    │    │    │    │    │    │    ├── columns: region.r_regionkey:26(int!null) region.r_name:27(string!null)
+      │         │    │    │    │    │    │    │    ├── key: (26)
+      │         │    │    │    │    │    │    │    └── fd: (26)-->(27)
+      │         │    │    │    │    │    │    └── filters
+      │         │    │    │    │    │    │         └── region.r_name = 'EUROPE' [type=bool, outer=(27), constraints=(/27: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(27)]
       │         │    │    │    │    │    └── filters (true)
-      │         │    │    │    │    ├── scan supplier
-      │         │    │    │    │    │    ├── columns: supplier.s_suppkey:10(int!null) supplier.s_name:11(string!null) supplier.s_address:12(string!null) supplier.s_nationkey:13(int!null) supplier.s_phone:14(string!null) supplier.s_acctbal:15(float!null) supplier.s_comment:16(string!null)
-      │         │    │    │    │    │    ├── key: (10)
-      │         │    │    │    │    │    └── fd: (10)-->(11-16)
-      │         │    │    │    │    └── filters
-      │         │    │    │    │         ├── supplier.s_suppkey = partsupp.ps_suppkey [type=bool, outer=(10,18), constraints=(/10: (/NULL - ]; /18: (/NULL - ]), fd=(10)==(18), (18)==(10)]
-      │         │    │    │    │         └── supplier.s_nationkey = nation.n_nationkey [type=bool, outer=(13,22), constraints=(/13: (/NULL - ]; /22: (/NULL - ]), fd=(13)==(22), (22)==(13)]
-      │         │    │    │    ├── select
-      │         │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null)
-      │         │    │    │    │    ├── key: (1)
-      │         │    │    │    │    ├── fd: ()-->(6), (1)-->(3,5)
-      │         │    │    │    │    ├── scan part
-      │         │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null)
-      │         │    │    │    │    │    ├── key: (1)
-      │         │    │    │    │    │    └── fd: (1)-->(3,5,6)
-      │         │    │    │    │    └── filters
-      │         │    │    │    │         ├── p_size = 15 [type=bool, outer=(6), constraints=(/6: [/15 - /15]; tight), fd=()-->(6)]
-      │         │    │    │    │         └── p_type LIKE '%BRASS' [type=bool, outer=(5), constraints=(/5: (/NULL - ])]
-      │         │    │    │    └── filters
-      │         │    │    │         └── p_partkey = partsupp.ps_partkey [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
+      │         │    │    │    │    └── filters (true)
+      │         │    │    │    └── filters (true)
+      │         │    │    ├── scan supplier
+      │         │    │    │    ├── columns: supplier.s_suppkey:10(int!null) supplier.s_name:11(string!null) supplier.s_address:12(string!null) supplier.s_nationkey:13(int!null) supplier.s_phone:14(string!null) supplier.s_acctbal:15(float!null) supplier.s_comment:16(string!null)
+      │         │    │    │    ├── key: (10)
+      │         │    │    │    └── fd: (10)-->(11-16)
       │         │    │    └── filters
-      │         │    │         └── p_partkey = partsupp.ps_partkey [type=bool, outer=(1,29), constraints=(/1: (/NULL - ]; /29: (/NULL - ]), fd=(1)==(29), (29)==(1)]
+      │         │    │         ├── supplier.s_suppkey = partsupp.ps_suppkey [type=bool, outer=(10,18), constraints=(/10: (/NULL - ]; /18: (/NULL - ]), fd=(10)==(18), (18)==(10)]
+      │         │    │         └── supplier.s_nationkey = nation.n_nationkey [type=bool, outer=(13,22), constraints=(/13: (/NULL - ]; /22: (/NULL - ]), fd=(13)==(22), (22)==(13)]
       │         │    └── aggregations
       │         │         ├── min [type=float, outer=(32)]
       │         │         │    └── variable: partsupp.ps_supplycost [type=float]
@@ -628,47 +607,35 @@ limit
  │         ├── project
  │         │    ├── columns: column34:34(float) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null)
  │         │    ├── fd: (18)-->(13,16)
- │         │    ├── inner-join
+ │         │    ├── inner-join (lookup lineitem)
  │         │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
+ │         │    │    ├── key columns: [9] = [18]
  │         │    │    ├── fd: ()-->(7), (9)-->(10,13,16), (9)==(18), (18)==(9), (1)==(10), (10)==(1)
- │         │    │    ├── inner-join (merge)
- │         │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
- │         │    │    │    ├── left ordering: +9
- │         │    │    │    ├── right ordering: +18
- │         │    │    │    ├── fd: (9)-->(10,13,16), (9)==(18), (18)==(9)
- │         │    │    │    ├── select
- │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
+ │         │    │    ├── inner-join (lookup orders)
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
+ │         │    │    │    ├── key columns: [9] = [9]
+ │         │    │    │    ├── key: (9)
+ │         │    │    │    ├── fd: ()-->(7), (9)-->(10,13,16), (1)==(10), (10)==(1)
+ │         │    │    │    ├── inner-join (lookup orders@o_ck)
+ │         │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null) o_orderkey:9(int!null) o_custkey:10(int!null)
+ │         │    │    │    │    ├── key columns: [1] = [10]
  │         │    │    │    │    ├── key: (9)
- │         │    │    │    │    ├── fd: (9)-->(10,13,16)
- │         │    │    │    │    ├── ordering: +9
- │         │    │    │    │    ├── scan orders
- │         │    │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
- │         │    │    │    │    │    ├── key: (9)
- │         │    │    │    │    │    ├── fd: (9)-->(10,13,16)
- │         │    │    │    │    │    └── ordering: +9
- │         │    │    │    │    └── filters
- │         │    │    │    │         └── o_orderdate < '1995-03-15' [type=bool, outer=(13), constraints=(/13: (/NULL - /'1995-03-14']; tight)]
- │         │    │    │    ├── select
- │         │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
- │         │    │    │    │    ├── ordering: +18
- │         │    │    │    │    ├── scan lineitem
- │         │    │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
- │         │    │    │    │    │    └── ordering: +18
- │         │    │    │    │    └── filters
- │         │    │    │    │         └── l_shipdate > '1995-03-15' [type=bool, outer=(28), constraints=(/28: [/'1995-03-16' - ]; tight)]
- │         │    │    │    └── filters (true)
- │         │    │    ├── select
- │         │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null)
- │         │    │    │    ├── key: (1)
- │         │    │    │    ├── fd: ()-->(7)
- │         │    │    │    ├── scan customer
- │         │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null)
- │         │    │    │    │    ├── key: (1)
- │         │    │    │    │    └── fd: (1)-->(7)
+ │         │    │    │    │    ├── fd: ()-->(7), (9)-->(10), (1)==(10), (10)==(1)
+ │         │    │    │    │    ├── select
+ │         │    │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null)
+ │         │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    ├── fd: ()-->(7)
+ │         │    │    │    │    │    ├── scan customer
+ │         │    │    │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null)
+ │         │    │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    │    └── fd: (1)-->(7)
+ │         │    │    │    │    │    └── filters
+ │         │    │    │    │    │         └── c_mktsegment = 'BUILDING' [type=bool, outer=(7), constraints=(/7: [/'BUILDING' - /'BUILDING']; tight), fd=()-->(7)]
+ │         │    │    │    │    └── filters (true)
  │         │    │    │    └── filters
- │         │    │    │         └── c_mktsegment = 'BUILDING' [type=bool, outer=(7), constraints=(/7: [/'BUILDING' - /'BUILDING']; tight), fd=()-->(7)]
+ │         │    │    │         └── o_orderdate < '1995-03-15' [type=bool, outer=(13), constraints=(/13: (/NULL - /'1995-03-14']; tight)]
  │         │    │    └── filters
- │         │    │         └── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+ │         │    │         └── l_shipdate > '1995-03-15' [type=bool, outer=(28), constraints=(/28: [/'1995-03-16' - ]; tight)]
  │         │    └── projections
  │         │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(23,24)]
  │         └── aggregations
@@ -803,69 +770,52 @@ sort
       ├── fd: (42)-->(49)
       ├── project
       │    ├── columns: column48:48(float) n_name:42(string!null)
-      │    ├── inner-join
+      │    ├── inner-join (lookup region)
       │    │    ├── columns: c_custkey:1(int!null) c_nationkey:4(int!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    ├── key columns: [43] = [45]
       │    │    ├── fd: ()-->(46), (1)-->(4), (9)-->(10,13), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(4,41), (41)==(4,37), (20)==(34), (34)==(20), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(37,41)
-      │    │    ├── inner-join
-      │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
-      │    │    │    ├── fd: ()-->(46), (9)-->(10,13), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (20)==(34), (34)==(20), (9)==(18), (18)==(9)
+      │    │    ├── inner-join (lookup nation)
+      │    │    │    ├── columns: c_custkey:1(int!null) c_nationkey:4(int!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null)
+      │    │    │    ├── key columns: [37] = [41]
+      │    │    │    ├── fd: (1)-->(4), (9)-->(10,13), (34)-->(37), (41)-->(42,43), (37)==(4,41), (41)==(4,37), (20)==(34), (34)==(20), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(37,41)
       │    │    │    ├── inner-join
-      │    │    │    │    ├── columns: l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
-      │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (20)==(34), (34)==(20)
-      │    │    │    │    ├── scan lineitem
-      │    │    │    │    │    └── columns: l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null)
+      │    │    │    │    ├── columns: c_custkey:1(int!null) c_nationkey:4(int!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null)
+      │    │    │    │    ├── fd: (1)-->(4), (9)-->(10,13), (34)-->(37), (20)==(34), (34)==(20), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(37), (37)==(4)
+      │    │    │    │    ├── scan customer@c_nk
+      │    │    │    │    │    ├── columns: c_custkey:1(int!null) c_nationkey:4(int!null)
+      │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    └── fd: (1)-->(4)
       │    │    │    │    ├── inner-join
-      │    │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
-      │    │    │    │    │    ├── key: (34)
-      │    │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37)
-      │    │    │    │    │    ├── scan supplier@s_nk
-      │    │    │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null)
-      │    │    │    │    │    │    ├── key: (34)
-      │    │    │    │    │    │    └── fd: (34)-->(37)
-      │    │    │    │    │    ├── inner-join (lookup nation)
-      │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
-      │    │    │    │    │    │    ├── key columns: [41] = [41]
-      │    │    │    │    │    │    ├── key: (41)
-      │    │    │    │    │    │    ├── fd: ()-->(46), (41)-->(42,43), (43)==(45), (45)==(43)
-      │    │    │    │    │    │    ├── inner-join (lookup nation@n_rk)
-      │    │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
-      │    │    │    │    │    │    │    ├── key columns: [45] = [43]
-      │    │    │    │    │    │    │    ├── key: (41)
-      │    │    │    │    │    │    │    ├── fd: ()-->(46), (41)-->(43), (43)==(45), (45)==(43)
-      │    │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
-      │    │    │    │    │    │    │    │    ├── key: (45)
-      │    │    │    │    │    │    │    │    ├── fd: ()-->(46)
-      │    │    │    │    │    │    │    │    ├── scan region
-      │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
-      │    │    │    │    │    │    │    │    │    ├── key: (45)
-      │    │    │    │    │    │    │    │    │    └── fd: (45)-->(46)
-      │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │         └── r_name = 'ASIA' [type=bool, outer=(46), constraints=(/46: [/'ASIA' - /'ASIA']; tight), fd=()-->(46)]
-      │    │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null)
+      │    │    │    │    │    ├── fd: (9)-->(10,13), (34)-->(37), (20)==(34), (34)==(20), (9)==(18), (18)==(9)
+      │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    │    ├── columns: l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null)
+      │    │    │    │    │    │    ├── fd: (34)-->(37), (20)==(34), (34)==(20)
+      │    │    │    │    │    │    ├── scan lineitem
+      │    │    │    │    │    │    │    └── columns: l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null)
+      │    │    │    │    │    │    ├── scan supplier@s_nk
+      │    │    │    │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null)
+      │    │    │    │    │    │    │    ├── key: (34)
+      │    │    │    │    │    │    │    └── fd: (34)-->(37)
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── l_suppkey = s_suppkey [type=bool, outer=(20,34), constraints=(/20: (/NULL - ]; /34: (/NULL - ]), fd=(20)==(34), (34)==(20)]
+      │    │    │    │    │    ├── index-join orders
+      │    │    │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
+      │    │    │    │    │    │    ├── key: (9)
+      │    │    │    │    │    │    ├── fd: (9)-->(10,13)
+      │    │    │    │    │    │    └── scan orders@o_od
+      │    │    │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
+      │    │    │    │    │    │         ├── constraint: /13/9: [/'1994-01-01' - /'1994-12-31']
+      │    │    │    │    │    │         ├── key: (9)
+      │    │    │    │    │    │         └── fd: (9)-->(13)
       │    │    │    │    │    └── filters
-      │    │    │    │    │         └── s_nationkey = n_nationkey [type=bool, outer=(37,41), constraints=(/37: (/NULL - ]; /41: (/NULL - ]), fd=(37)==(41), (41)==(37)]
+      │    │    │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
       │    │    │    │    └── filters
-      │    │    │    │         └── l_suppkey = s_suppkey [type=bool, outer=(20,34), constraints=(/20: (/NULL - ]; /34: (/NULL - ]), fd=(20)==(34), (34)==(20)]
-      │    │    │    ├── index-join orders
-      │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
-      │    │    │    │    ├── key: (9)
-      │    │    │    │    ├── fd: (9)-->(10,13)
-      │    │    │    │    └── scan orders@o_od
-      │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
-      │    │    │    │         ├── constraint: /13/9: [/'1994-01-01' - /'1994-12-31']
-      │    │    │    │         ├── key: (9)
-      │    │    │    │         └── fd: (9)-->(13)
-      │    │    │    └── filters
-      │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
-      │    │    ├── scan customer@c_nk
-      │    │    │    ├── columns: c_custkey:1(int!null) c_nationkey:4(int!null)
-      │    │    │    ├── key: (1)
-      │    │    │    └── fd: (1)-->(4)
+      │    │    │    │         ├── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+      │    │    │    │         └── c_nationkey = s_nationkey [type=bool, outer=(4,37), constraints=(/4: (/NULL - ]; /37: (/NULL - ]), fd=(4)==(37), (37)==(4)]
+      │    │    │    └── filters (true)
       │    │    └── filters
-      │    │         ├── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
-      │    │         └── c_nationkey = s_nationkey [type=bool, outer=(4,37), constraints=(/4: (/NULL - ]; /37: (/NULL - ]), fd=(4)==(37), (37)==(4)]
+      │    │         └── r_name = 'ASIA' [type=bool, outer=(46), constraints=(/46: [/'ASIA' - /'ASIA']; tight), fd=()-->(46)]
       │    └── projections
       │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(23,24)]
       └── aggregations
@@ -996,49 +946,34 @@ group-by
  │         │    ├── inner-join
  │         │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) nation.n_nationkey:41(int!null) nation.n_name:42(string!null) nation.n_nationkey:45(int!null) nation.n_name:46(string!null)
  │         │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8)
- │         │    │    ├── inner-join
- │         │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) nation.n_nationkey:41(int!null) nation.n_name:42(string!null) nation.n_nationkey:45(int!null) nation.n_name:46(string!null)
- │         │    │    │    ├── key: (24,41)
- │         │    │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25)
- │         │    │    │    ├── inner-join
- │         │    │    │    │    ├── columns: c_custkey:33(int!null) c_nationkey:36(int!null) nation.n_nationkey:41(int!null) nation.n_name:42(string!null) nation.n_nationkey:45(int!null) nation.n_name:46(string!null)
- │         │    │    │    │    ├── key: (33,41)
- │         │    │    │    │    ├── fd: (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36)
- │         │    │    │    │    ├── inner-join
- │         │    │    │    │    │    ├── columns: nation.n_nationkey:41(int!null) nation.n_name:42(string!null) nation.n_nationkey:45(int!null) nation.n_name:46(string!null)
- │         │    │    │    │    │    ├── key: (41,45)
- │         │    │    │    │    │    ├── fd: (41)-->(42), (45)-->(46)
- │         │    │    │    │    │    ├── scan nation
- │         │    │    │    │    │    │    ├── columns: nation.n_nationkey:41(int!null) nation.n_name:42(string!null)
- │         │    │    │    │    │    │    ├── key: (41)
- │         │    │    │    │    │    │    └── fd: (41)-->(42)
- │         │    │    │    │    │    ├── scan nation
- │         │    │    │    │    │    │    ├── columns: nation.n_nationkey:45(int!null) nation.n_name:46(string!null)
- │         │    │    │    │    │    │    ├── key: (45)
- │         │    │    │    │    │    │    └── fd: (45)-->(46)
- │         │    │    │    │    │    └── filters
- │         │    │    │    │    │         └── ((nation.n_name = 'FRANCE') AND (nation.n_name = 'GERMANY')) OR ((nation.n_name = 'GERMANY') AND (nation.n_name = 'FRANCE')) [type=bool, outer=(42,46)]
- │         │    │    │    │    ├── scan customer@c_nk
- │         │    │    │    │    │    ├── columns: c_custkey:33(int!null) c_nationkey:36(int!null)
- │         │    │    │    │    │    ├── key: (33)
- │         │    │    │    │    │    └── fd: (33)-->(36)
- │         │    │    │    │    └── filters
- │         │    │    │    │         └── c_nationkey = nation.n_nationkey [type=bool, outer=(36,45), constraints=(/36: (/NULL - ]; /45: (/NULL - ]), fd=(36)==(45), (45)==(36)]
- │         │    │    │    ├── scan orders@o_ck
- │         │    │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null)
- │         │    │    │    │    ├── key: (24)
- │         │    │    │    │    └── fd: (24)-->(25)
- │         │    │    │    └── filters
- │         │    │    │         └── c_custkey = o_custkey [type=bool, outer=(25,33), constraints=(/25: (/NULL - ]; /33: (/NULL - ]), fd=(25)==(33), (33)==(25)]
- │         │    │    ├── index-join lineitem
- │         │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
- │         │    │    │    └── scan lineitem@l_sd
- │         │    │    │         ├── columns: l_orderkey:8(int!null) l_linenumber:11(int!null) l_shipdate:18(date!null)
- │         │    │    │         ├── constraint: /18/8/11: [/'1995-01-01' - /'1996-12-31']
- │         │    │    │         ├── key: (8,11)
- │         │    │    │         └── fd: (8,11)-->(18)
+ │         │    │    ├── scan nation
+ │         │    │    │    ├── columns: nation.n_nationkey:41(int!null) nation.n_name:42(string!null)
+ │         │    │    │    ├── key: (41)
+ │         │    │    │    └── fd: (41)-->(42)
+ │         │    │    ├── inner-join (lookup nation)
+ │         │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) nation.n_nationkey:45(int!null) nation.n_name:46(string!null)
+ │         │    │    │    ├── key columns: [36] = [45]
+ │         │    │    │    ├── fd: (24)-->(25), (33)-->(36), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8)
+ │         │    │    │    ├── inner-join (lookup customer)
+ │         │    │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null)
+ │         │    │    │    │    ├── key columns: [25] = [33]
+ │         │    │    │    │    ├── fd: (24)-->(25), (33)-->(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8)
+ │         │    │    │    │    ├── inner-join (lookup orders)
+ │         │    │    │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null)
+ │         │    │    │    │    │    ├── key columns: [8] = [24]
+ │         │    │    │    │    │    ├── fd: (24)-->(25), (8)==(24), (24)==(8)
+ │         │    │    │    │    │    ├── index-join lineitem
+ │         │    │    │    │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
+ │         │    │    │    │    │    │    └── scan lineitem@l_sd
+ │         │    │    │    │    │    │         ├── columns: l_orderkey:8(int!null) l_linenumber:11(int!null) l_shipdate:18(date!null)
+ │         │    │    │    │    │    │         ├── constraint: /18/8/11: [/'1995-01-01' - /'1996-12-31']
+ │         │    │    │    │    │    │         ├── key: (8,11)
+ │         │    │    │    │    │    │         └── fd: (8,11)-->(18)
+ │         │    │    │    │    │    └── filters (true)
+ │         │    │    │    │    └── filters (true)
+ │         │    │    │    └── filters (true)
  │         │    │    └── filters
- │         │    │         └── o_orderkey = l_orderkey [type=bool, outer=(8,24), constraints=(/8: (/NULL - ]; /24: (/NULL - ]), fd=(8)==(24), (24)==(8)]
+ │         │    │         └── ((nation.n_name = 'FRANCE') AND (nation.n_name = 'GERMANY')) OR ((nation.n_name = 'GERMANY') AND (nation.n_name = 'FRANCE')) [type=bool, outer=(42,46)]
  │         │    ├── scan supplier@s_nk
  │         │    │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null)
  │         │    │    ├── key: (1)
@@ -1128,83 +1063,78 @@ sort
       │    │    ├── columns: column63:63(float) o_year:61(int) volume:62(float)
       │    │    ├── project
       │    │    │    ├── columns: o_year:61(int) volume:62(float) nation.n_name:55(string!null)
-      │    │    │    ├── inner-join (lookup part)
+      │    │    │    ├── inner-join
       │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) nation.n_nationkey:50(int!null) nation.n_regionkey:52(int!null) nation.n_nationkey:54(int!null) nation.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
-      │    │    │    │    ├── key columns: [18] = [1]
       │    │    │    │    ├── fd: ()-->(5,59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13), (1)==(18), (18)==(1)
       │    │    │    │    ├── inner-join
-      │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) nation.n_nationkey:50(int!null) nation.n_regionkey:52(int!null) nation.n_nationkey:54(int!null) nation.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
-      │    │    │    │    │    ├── fd: ()-->(59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13)
+      │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) nation.n_nationkey:50(int!null) nation.n_regionkey:52(int!null) nation.n_nationkey:54(int!null) nation.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    ├── fd: ()-->(5,59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (1)==(18), (18)==(1)
+      │    │    │    │    │    ├── scan nation
+      │    │    │    │    │    │    ├── columns: nation.n_nationkey:54(int!null) nation.n_name:55(string!null)
+      │    │    │    │    │    │    ├── key: (54)
+      │    │    │    │    │    │    └── fd: (54)-->(55)
       │    │    │    │    │    ├── inner-join
-      │    │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) nation.n_nationkey:50(int!null) nation.n_regionkey:52(int!null) nation.n_nationkey:54(int!null) nation.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
-      │    │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17)
-      │    │    │    │    │    │    ├── inner-join
-      │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) nation.n_nationkey:50(int!null) nation.n_regionkey:52(int!null) nation.n_nationkey:54(int!null) nation.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
-      │    │    │    │    │    │    │    ├── key: (33,54)
-      │    │    │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34)
-      │    │    │    │    │    │    │    ├── inner-join
-      │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) nation.n_nationkey:50(int!null) nation.n_regionkey:52(int!null) nation.n_nationkey:54(int!null) nation.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
-      │    │    │    │    │    │    │    │    ├── key: (42,54)
-      │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45)
-      │    │    │    │    │    │    │    │    ├── inner-join
-      │    │    │    │    │    │    │    │    │    ├── columns: nation.n_nationkey:50(int!null) nation.n_regionkey:52(int!null) nation.n_nationkey:54(int!null) nation.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
-      │    │    │    │    │    │    │    │    │    ├── key: (50,54)
-      │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52)
-      │    │    │    │    │    │    │    │    │    ├── inner-join
-      │    │    │    │    │    │    │    │    │    │    ├── columns: nation.n_nationkey:54(int!null) nation.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
-      │    │    │    │    │    │    │    │    │    │    ├── key: (54,58)
-      │    │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (54)-->(55)
-      │    │    │    │    │    │    │    │    │    │    ├── scan nation
-      │    │    │    │    │    │    │    │    │    │    │    ├── columns: nation.n_nationkey:54(int!null) nation.n_name:55(string!null)
-      │    │    │    │    │    │    │    │    │    │    │    ├── key: (54)
-      │    │    │    │    │    │    │    │    │    │    │    └── fd: (54)-->(55)
+      │    │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) nation.n_nationkey:50(int!null) nation.n_regionkey:52(int!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    ├── fd: ()-->(5,59), (33)-->(34,37), (42)-->(45), (50)-->(52), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (1)==(18), (18)==(1)
+      │    │    │    │    │    │    ├── inner-join (lookup customer)
+      │    │    │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null)
+      │    │    │    │    │    │    │    ├── key columns: [34] = [42]
+      │    │    │    │    │    │    │    ├── fd: ()-->(5), (33)-->(34,37), (42)-->(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (1)==(18), (18)==(1)
+      │    │    │    │    │    │    │    ├── inner-join (lookup orders)
+      │    │    │    │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null)
+      │    │    │    │    │    │    │    │    ├── key columns: [17] = [33]
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(5), (33)-->(34,37), (17)==(33), (33)==(17), (1)==(18), (18)==(1)
+      │    │    │    │    │    │    │    │    ├── inner-join (lookup lineitem)
+      │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null)
+      │    │    │    │    │    │    │    │    │    ├── key columns: [17 20] = [17 20]
+      │    │    │    │    │    │    │    │    │    ├── fd: ()-->(5), (1)==(18), (18)==(1)
+      │    │    │    │    │    │    │    │    │    ├── inner-join (lookup lineitem@l_pk)
+      │    │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_linenumber:20(int!null)
+      │    │    │    │    │    │    │    │    │    │    ├── key columns: [1] = [18]
+      │    │    │    │    │    │    │    │    │    │    ├── key: (17,20)
+      │    │    │    │    │    │    │    │    │    │    ├── fd: ()-->(5), (17,20)-->(18), (1)==(18), (18)==(1)
       │    │    │    │    │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
-      │    │    │    │    │    │    │    │    │    │    │    ├── key: (58)
-      │    │    │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59)
-      │    │    │    │    │    │    │    │    │    │    │    ├── scan region
-      │    │    │    │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
-      │    │    │    │    │    │    │    │    │    │    │    │    ├── key: (58)
-      │    │    │    │    │    │    │    │    │    │    │    │    └── fd: (58)-->(59)
+      │    │    │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null)
+      │    │    │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │    │    │    │    ├── fd: ()-->(5)
+      │    │    │    │    │    │    │    │    │    │    │    ├── scan part
+      │    │    │    │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null)
+      │    │    │    │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │    │    │    │    │    └── fd: (1)-->(5)
       │    │    │    │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │    │    │    │         └── r_name = 'AMERICA' [type=bool, outer=(59), constraints=(/59: [/'AMERICA' - /'AMERICA']; tight), fd=()-->(59)]
+      │    │    │    │    │    │    │    │    │    │    │         └── p_type = 'ECONOMY ANODIZED STEEL' [type=bool, outer=(5), constraints=(/5: [/'ECONOMY ANODIZED STEEL' - /'ECONOMY ANODIZED STEEL']; tight), fd=()-->(5)]
       │    │    │    │    │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │    │    │    │    │    ├── scan nation@n_rk
-      │    │    │    │    │    │    │    │    │    │    ├── columns: nation.n_nationkey:50(int!null) nation.n_regionkey:52(int!null)
-      │    │    │    │    │    │    │    │    │    │    ├── key: (50)
-      │    │    │    │    │    │    │    │    │    │    └── fd: (50)-->(52)
-      │    │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │    │         └── nation.n_regionkey = r_regionkey [type=bool, outer=(52,58), constraints=(/52: (/NULL - ]; /58: (/NULL - ]), fd=(52)==(58), (58)==(52)]
-      │    │    │    │    │    │    │    │    ├── scan customer@c_nk
-      │    │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null)
-      │    │    │    │    │    │    │    │    │    ├── key: (42)
-      │    │    │    │    │    │    │    │    │    └── fd: (42)-->(45)
+      │    │    │    │    │    │    │    │    │    └── filters (true)
       │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │         └── c_nationkey = nation.n_nationkey [type=bool, outer=(45,50), constraints=(/45: (/NULL - ]; /50: (/NULL - ]), fd=(45)==(50), (50)==(45)]
-      │    │    │    │    │    │    │    ├── index-join orders
-      │    │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null)
-      │    │    │    │    │    │    │    │    ├── key: (33)
-      │    │    │    │    │    │    │    │    ├── fd: (33)-->(34,37)
-      │    │    │    │    │    │    │    │    └── scan orders@o_od
-      │    │    │    │    │    │    │    │         ├── columns: o_orderkey:33(int!null) o_orderdate:37(date!null)
-      │    │    │    │    │    │    │    │         ├── constraint: /37/33: [/'1995-01-01' - /'1996-12-31']
-      │    │    │    │    │    │    │    │         ├── key: (33)
-      │    │    │    │    │    │    │    │         └── fd: (33)-->(37)
-      │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         └── o_custkey = c_custkey [type=bool, outer=(34,42), constraints=(/34: (/NULL - ]; /42: (/NULL - ]), fd=(34)==(42), (42)==(34)]
-      │    │    │    │    │    │    ├── scan lineitem
-      │    │    │    │    │    │    │    └── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null)
+      │    │    │    │    │    │    │    │         ├── o_orderdate >= '1995-01-01' [type=bool, outer=(37), constraints=(/37: [/'1995-01-01' - ]; tight)]
+      │    │    │    │    │    │    │    │         └── o_orderdate <= '1996-12-31' [type=bool, outer=(37), constraints=(/37: (/NULL - /'1996-12-31']; tight)]
+      │    │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    │    ├── inner-join (lookup nation@n_rk)
+      │    │    │    │    │    │    │    ├── columns: nation.n_nationkey:50(int!null) nation.n_regionkey:52(int!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    │    ├── key columns: [58] = [52]
+      │    │    │    │    │    │    │    ├── key: (50)
+      │    │    │    │    │    │    │    ├── fd: ()-->(59), (50)-->(52), (52)==(58), (58)==(52)
+      │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    │    │    ├── key: (58)
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(59)
+      │    │    │    │    │    │    │    │    ├── scan region
+      │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    │    │    │    ├── key: (58)
+      │    │    │    │    │    │    │    │    │    └── fd: (58)-->(59)
+      │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         └── r_name = 'AMERICA' [type=bool, outer=(59), constraints=(/59: [/'AMERICA' - /'AMERICA']; tight), fd=()-->(59)]
+      │    │    │    │    │    │    │    └── filters (true)
       │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(17,33), constraints=(/17: (/NULL - ]; /33: (/NULL - ]), fd=(17)==(33), (33)==(17)]
-      │    │    │    │    │    ├── scan supplier@s_nk
-      │    │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null)
-      │    │    │    │    │    │    ├── key: (10)
-      │    │    │    │    │    │    └── fd: (10)-->(13)
-      │    │    │    │    │    └── filters
-      │    │    │    │    │         ├── s_suppkey = l_suppkey [type=bool, outer=(10,19), constraints=(/10: (/NULL - ]; /19: (/NULL - ]), fd=(10)==(19), (19)==(10)]
-      │    │    │    │    │         └── s_nationkey = nation.n_nationkey [type=bool, outer=(13,54), constraints=(/13: (/NULL - ]; /54: (/NULL - ]), fd=(13)==(54), (54)==(13)]
+      │    │    │    │    │    │         └── c_nationkey = nation.n_nationkey [type=bool, outer=(45,50), constraints=(/45: (/NULL - ]; /50: (/NULL - ]), fd=(45)==(50), (50)==(45)]
+      │    │    │    │    │    └── filters (true)
+      │    │    │    │    ├── scan supplier@s_nk
+      │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null)
+      │    │    │    │    │    ├── key: (10)
+      │    │    │    │    │    └── fd: (10)-->(13)
       │    │    │    │    └── filters
-      │    │    │    │         └── p_type = 'ECONOMY ANODIZED STEEL' [type=bool, outer=(5), constraints=(/5: [/'ECONOMY ANODIZED STEEL' - /'ECONOMY ANODIZED STEEL']; tight), fd=()-->(5)]
+      │    │    │    │         ├── s_suppkey = l_suppkey [type=bool, outer=(10,19), constraints=(/10: (/NULL - ]; /19: (/NULL - ]), fd=(10)==(19), (19)==(10)]
+      │    │    │    │         └── s_nationkey = nation.n_nationkey [type=bool, outer=(13,54), constraints=(/13: (/NULL - ]; /54: (/NULL - ]), fd=(13)==(54), (54)==(13)]
       │    │    │    └── projections
       │    │    │         ├── extract('year', o_orderdate) [type=int, outer=(37)]
       │    │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(22,23)]
@@ -1411,32 +1341,26 @@ limit
  │         │    │    ├── inner-join
  │         │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
  │         │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (34)-->(35), (9)==(18), (18)==(9)
- │         │    │    │    ├── inner-join
- │         │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
- │         │    │    │    │    ├── fd: ()-->(26), (34)-->(35)
- │         │    │    │    │    ├── scan nation
- │         │    │    │    │    │    ├── columns: n_nationkey:34(int!null) n_name:35(string!null)
- │         │    │    │    │    │    ├── key: (34)
- │         │    │    │    │    │    └── fd: (34)-->(35)
- │         │    │    │    │    ├── select
- │         │    │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
- │         │    │    │    │    │    ├── fd: ()-->(26)
- │         │    │    │    │    │    ├── scan lineitem
- │         │    │    │    │    │    │    └── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
- │         │    │    │    │    │    └── filters
- │         │    │    │    │    │         └── l_returnflag = 'R' [type=bool, outer=(26), constraints=(/26: [/'R' - /'R']; tight), fd=()-->(26)]
- │         │    │    │    │    └── filters (true)
- │         │    │    │    ├── index-join orders
- │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
- │         │    │    │    │    ├── key: (9)
- │         │    │    │    │    ├── fd: (9)-->(10,13)
- │         │    │    │    │    └── scan orders@o_od
- │         │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
- │         │    │    │    │         ├── constraint: /13/9: [/'1993-10-01' - /'1993-12-31']
- │         │    │    │    │         ├── key: (9)
- │         │    │    │    │         └── fd: (9)-->(13)
- │         │    │    │    └── filters
- │         │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
+ │         │    │    │    ├── scan nation
+ │         │    │    │    │    ├── columns: n_nationkey:34(int!null) n_name:35(string!null)
+ │         │    │    │    │    ├── key: (34)
+ │         │    │    │    │    └── fd: (34)-->(35)
+ │         │    │    │    ├── inner-join (lookup lineitem)
+ │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
+ │         │    │    │    │    ├── key columns: [9] = [18]
+ │         │    │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (9)==(18), (18)==(9)
+ │         │    │    │    │    ├── index-join orders
+ │         │    │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
+ │         │    │    │    │    │    ├── key: (9)
+ │         │    │    │    │    │    ├── fd: (9)-->(10,13)
+ │         │    │    │    │    │    └── scan orders@o_od
+ │         │    │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
+ │         │    │    │    │    │         ├── constraint: /13/9: [/'1993-10-01' - /'1993-12-31']
+ │         │    │    │    │    │         ├── key: (9)
+ │         │    │    │    │    │         └── fd: (9)-->(13)
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── l_returnflag = 'R' [type=bool, outer=(26), constraints=(/26: [/'R' - /'R']; tight), fd=()-->(26)]
+ │         │    │    │    └── filters (true)
  │         │    │    ├── scan customer
  │         │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) c_address:3(string!null) c_nationkey:4(int!null) c_phone:5(string!null) c_acctbal:6(float!null) c_comment:8(string!null)
  │         │    │    │    ├── key: (1)
@@ -2556,71 +2480,74 @@ limit
  │         │    ├── inner-join
  │         │    │    ├── columns: lineitem.l_orderkey:8(int!null) lineitem.l_suppkey:10(int!null) lineitem.l_commitdate:19(date!null) lineitem.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(string!null) n_nationkey:33(int!null) n_name:34(string!null)
  │         │    │    ├── fd: ()-->(26,34), (8)==(24), (24)==(8)
- │         │    │    ├── semi-join (merge)
- │         │    │    │    ├── columns: lineitem.l_orderkey:8(int!null) lineitem.l_suppkey:10(int!null) lineitem.l_commitdate:19(date!null) lineitem.l_receiptdate:20(date!null)
+ │         │    │    ├── inner-join (merge)
+ │         │    │    │    ├── columns: lineitem.l_orderkey:8(int!null) lineitem.l_suppkey:10(int!null) lineitem.l_commitdate:19(date!null) lineitem.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(string!null)
  │         │    │    │    ├── left ordering: +8
- │         │    │    │    ├── right ordering: +37
- │         │    │    │    ├── anti-join (merge)
+ │         │    │    │    ├── right ordering: +24
+ │         │    │    │    ├── fd: ()-->(26), (8)==(24), (24)==(8)
+ │         │    │    │    ├── semi-join (merge)
  │         │    │    │    │    ├── columns: lineitem.l_orderkey:8(int!null) lineitem.l_suppkey:10(int!null) lineitem.l_commitdate:19(date!null) lineitem.l_receiptdate:20(date!null)
  │         │    │    │    │    ├── left ordering: +8
- │         │    │    │    │    ├── right ordering: +53
+ │         │    │    │    │    ├── right ordering: +37
  │         │    │    │    │    ├── ordering: +8
- │         │    │    │    │    ├── select
+ │         │    │    │    │    ├── anti-join (merge)
  │         │    │    │    │    │    ├── columns: lineitem.l_orderkey:8(int!null) lineitem.l_suppkey:10(int!null) lineitem.l_commitdate:19(date!null) lineitem.l_receiptdate:20(date!null)
+ │         │    │    │    │    │    ├── left ordering: +8
+ │         │    │    │    │    │    ├── right ordering: +53
  │         │    │    │    │    │    ├── ordering: +8
- │         │    │    │    │    │    ├── scan lineitem
+ │         │    │    │    │    │    ├── select
  │         │    │    │    │    │    │    ├── columns: lineitem.l_orderkey:8(int!null) lineitem.l_suppkey:10(int!null) lineitem.l_commitdate:19(date!null) lineitem.l_receiptdate:20(date!null)
- │         │    │    │    │    │    │    └── ordering: +8
- │         │    │    │    │    │    └── filters
- │         │    │    │    │    │         └── lineitem.l_receiptdate > lineitem.l_commitdate [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
- │         │    │    │    │    ├── select
- │         │    │    │    │    │    ├── columns: lineitem.l_orderkey:53(int!null) lineitem.l_partkey:54(int!null) lineitem.l_suppkey:55(int!null) lineitem.l_linenumber:56(int!null) lineitem.l_quantity:57(float!null) lineitem.l_extendedprice:58(float!null) lineitem.l_discount:59(float!null) lineitem.l_tax:60(float!null) lineitem.l_returnflag:61(string!null) lineitem.l_linestatus:62(string!null) lineitem.l_shipdate:63(date!null) lineitem.l_commitdate:64(date!null) lineitem.l_receiptdate:65(date!null) lineitem.l_shipinstruct:66(string!null) lineitem.l_shipmode:67(string!null) lineitem.l_comment:68(string!null)
- │         │    │    │    │    │    ├── key: (53,56)
- │         │    │    │    │    │    ├── fd: (53,56)-->(54,55,57-68)
- │         │    │    │    │    │    ├── ordering: +53
- │         │    │    │    │    │    ├── scan lineitem
+ │         │    │    │    │    │    │    ├── ordering: +8
+ │         │    │    │    │    │    │    ├── scan lineitem
+ │         │    │    │    │    │    │    │    ├── columns: lineitem.l_orderkey:8(int!null) lineitem.l_suppkey:10(int!null) lineitem.l_commitdate:19(date!null) lineitem.l_receiptdate:20(date!null)
+ │         │    │    │    │    │    │    │    └── ordering: +8
+ │         │    │    │    │    │    │    └── filters
+ │         │    │    │    │    │    │         └── lineitem.l_receiptdate > lineitem.l_commitdate [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+ │         │    │    │    │    │    ├── select
  │         │    │    │    │    │    │    ├── columns: lineitem.l_orderkey:53(int!null) lineitem.l_partkey:54(int!null) lineitem.l_suppkey:55(int!null) lineitem.l_linenumber:56(int!null) lineitem.l_quantity:57(float!null) lineitem.l_extendedprice:58(float!null) lineitem.l_discount:59(float!null) lineitem.l_tax:60(float!null) lineitem.l_returnflag:61(string!null) lineitem.l_linestatus:62(string!null) lineitem.l_shipdate:63(date!null) lineitem.l_commitdate:64(date!null) lineitem.l_receiptdate:65(date!null) lineitem.l_shipinstruct:66(string!null) lineitem.l_shipmode:67(string!null) lineitem.l_comment:68(string!null)
  │         │    │    │    │    │    │    ├── key: (53,56)
  │         │    │    │    │    │    │    ├── fd: (53,56)-->(54,55,57-68)
- │         │    │    │    │    │    │    └── ordering: +53
+ │         │    │    │    │    │    │    ├── ordering: +53
+ │         │    │    │    │    │    │    ├── scan lineitem
+ │         │    │    │    │    │    │    │    ├── columns: lineitem.l_orderkey:53(int!null) lineitem.l_partkey:54(int!null) lineitem.l_suppkey:55(int!null) lineitem.l_linenumber:56(int!null) lineitem.l_quantity:57(float!null) lineitem.l_extendedprice:58(float!null) lineitem.l_discount:59(float!null) lineitem.l_tax:60(float!null) lineitem.l_returnflag:61(string!null) lineitem.l_linestatus:62(string!null) lineitem.l_shipdate:63(date!null) lineitem.l_commitdate:64(date!null) lineitem.l_receiptdate:65(date!null) lineitem.l_shipinstruct:66(string!null) lineitem.l_shipmode:67(string!null) lineitem.l_comment:68(string!null)
+ │         │    │    │    │    │    │    │    ├── key: (53,56)
+ │         │    │    │    │    │    │    │    ├── fd: (53,56)-->(54,55,57-68)
+ │         │    │    │    │    │    │    │    └── ordering: +53
+ │         │    │    │    │    │    │    └── filters
+ │         │    │    │    │    │    │         └── lineitem.l_receiptdate > lineitem.l_commitdate [type=bool, outer=(64,65), constraints=(/64: (/NULL - ]; /65: (/NULL - ])]
  │         │    │    │    │    │    └── filters
- │         │    │    │    │    │         └── lineitem.l_receiptdate > lineitem.l_commitdate [type=bool, outer=(64,65), constraints=(/64: (/NULL - ]; /65: (/NULL - ])]
+ │         │    │    │    │    │         └── lineitem.l_suppkey != lineitem.l_suppkey [type=bool, outer=(10,55), constraints=(/10: (/NULL - ]; /55: (/NULL - ])]
+ │         │    │    │    │    ├── scan lineitem
+ │         │    │    │    │    │    ├── columns: lineitem.l_orderkey:37(int!null) lineitem.l_partkey:38(int!null) lineitem.l_suppkey:39(int!null) lineitem.l_linenumber:40(int!null) lineitem.l_quantity:41(float!null) lineitem.l_extendedprice:42(float!null) lineitem.l_discount:43(float!null) lineitem.l_tax:44(float!null) lineitem.l_returnflag:45(string!null) lineitem.l_linestatus:46(string!null) lineitem.l_shipdate:47(date!null) lineitem.l_commitdate:48(date!null) lineitem.l_receiptdate:49(date!null) lineitem.l_shipinstruct:50(string!null) lineitem.l_shipmode:51(string!null) lineitem.l_comment:52(string!null)
+ │         │    │    │    │    │    ├── key: (37,40)
+ │         │    │    │    │    │    ├── fd: (37,40)-->(38,39,41-52)
+ │         │    │    │    │    │    └── ordering: +37
  │         │    │    │    │    └── filters
- │         │    │    │    │         └── lineitem.l_suppkey != lineitem.l_suppkey [type=bool, outer=(10,55), constraints=(/10: (/NULL - ]; /55: (/NULL - ])]
- │         │    │    │    ├── scan lineitem
- │         │    │    │    │    ├── columns: lineitem.l_orderkey:37(int!null) lineitem.l_partkey:38(int!null) lineitem.l_suppkey:39(int!null) lineitem.l_linenumber:40(int!null) lineitem.l_quantity:41(float!null) lineitem.l_extendedprice:42(float!null) lineitem.l_discount:43(float!null) lineitem.l_tax:44(float!null) lineitem.l_returnflag:45(string!null) lineitem.l_linestatus:46(string!null) lineitem.l_shipdate:47(date!null) lineitem.l_commitdate:48(date!null) lineitem.l_receiptdate:49(date!null) lineitem.l_shipinstruct:50(string!null) lineitem.l_shipmode:51(string!null) lineitem.l_comment:52(string!null)
- │         │    │    │    │    ├── key: (37,40)
- │         │    │    │    │    ├── fd: (37,40)-->(38,39,41-52)
- │         │    │    │    │    └── ordering: +37
- │         │    │    │    └── filters
- │         │    │    │         └── lineitem.l_suppkey != lineitem.l_suppkey [type=bool, outer=(10,39), constraints=(/10: (/NULL - ]; /39: (/NULL - ])]
- │         │    │    ├── inner-join
- │         │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null) n_nationkey:33(int!null) n_name:34(string!null)
- │         │    │    │    ├── key: (24,33)
- │         │    │    │    ├── fd: ()-->(26,34)
+ │         │    │    │    │         └── lineitem.l_suppkey != lineitem.l_suppkey [type=bool, outer=(10,39), constraints=(/10: (/NULL - ]; /39: (/NULL - ])]
  │         │    │    │    ├── select
  │         │    │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null)
  │         │    │    │    │    ├── key: (24)
  │         │    │    │    │    ├── fd: ()-->(26)
+ │         │    │    │    │    ├── ordering: +24 opt(26) [provided: +24]
  │         │    │    │    │    ├── scan orders
  │         │    │    │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null)
  │         │    │    │    │    │    ├── key: (24)
- │         │    │    │    │    │    └── fd: (24)-->(26)
+ │         │    │    │    │    │    ├── fd: (24)-->(26)
+ │         │    │    │    │    │    └── ordering: +24 opt(26) [provided: +24]
  │         │    │    │    │    └── filters
  │         │    │    │    │         └── o_orderstatus = 'F' [type=bool, outer=(26), constraints=(/26: [/'F' - /'F']; tight), fd=()-->(26)]
- │         │    │    │    ├── select
+ │         │    │    │    └── filters (true)
+ │         │    │    ├── select
+ │         │    │    │    ├── columns: n_nationkey:33(int!null) n_name:34(string!null)
+ │         │    │    │    ├── key: (33)
+ │         │    │    │    ├── fd: ()-->(34)
+ │         │    │    │    ├── scan nation
  │         │    │    │    │    ├── columns: n_nationkey:33(int!null) n_name:34(string!null)
  │         │    │    │    │    ├── key: (33)
- │         │    │    │    │    ├── fd: ()-->(34)
- │         │    │    │    │    ├── scan nation
- │         │    │    │    │    │    ├── columns: n_nationkey:33(int!null) n_name:34(string!null)
- │         │    │    │    │    │    ├── key: (33)
- │         │    │    │    │    │    └── fd: (33)-->(34)
- │         │    │    │    │    └── filters
- │         │    │    │    │         └── n_name = 'SAUDI ARABIA' [type=bool, outer=(34), constraints=(/34: [/'SAUDI ARABIA' - /'SAUDI ARABIA']; tight), fd=()-->(34)]
- │         │    │    │    └── filters (true)
- │         │    │    └── filters
- │         │    │         └── o_orderkey = lineitem.l_orderkey [type=bool, outer=(8,24), constraints=(/8: (/NULL - ]; /24: (/NULL - ]), fd=(8)==(24), (24)==(8)]
+ │         │    │    │    │    └── fd: (33)-->(34)
+ │         │    │    │    └── filters
+ │         │    │    │         └── n_name = 'SAUDI ARABIA' [type=bool, outer=(34), constraints=(/34: [/'SAUDI ARABIA' - /'SAUDI ARABIA']; tight), fd=()-->(34)]
+ │         │    │    └── filters (true)
  │         │    └── filters
  │         │         ├── s_suppkey = lineitem.l_suppkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
  │         │         └── s_nationkey = n_nationkey [type=bool, outer=(4,33), constraints=(/4: (/NULL - ]; /33: (/NULL - ]), fd=(4)==(33), (33)==(4)]


### PR DESCRIPTION
This commit adds an exploration rule for join associativity. The new rule
converts an expression like:
   `A JOIN (B JOIN C ON B.x = C.x) ON A.y = B.y`
to the logically equivalent expression:
   `(A JOIN B ON A.y = B.y) JOIN C ON B.x = C.x`
The rule applies as long as the outer predicate is not True (we want to avoid
pushing cross joins down), and the outer predicate only references one of
the two inner relations.

I don't think we should merge this commit until we have join hints and/or
automated collection of table stats (and possibly more aggressive pruning
of the search space), but just wanted share how easy it is to add the
capability for join reordering.

Release note: None