### PR TITLE
server: Fix EnqueueRange to respect its NodeID parameter

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -1465,6 +1465,8 @@ func TestEnqueueRange(t *testing.T) {
 		{0, "consistencyChecker", realRangeID, allReplicas, leaseholder},
 		{0, "TIMESERIESmaintenance", realRangeID, allReplicas, leaseholder},
 		{1, "raftlog", realRangeID, leaseholder, leaseholder},
+		{2, "raftlog", realRangeID, leaseholder, 1},
+		{3, "raftlog", realRangeID, leaseholder, 1},
 		// Error cases
 		{0, "gv", realRangeID, allReplicas, none},
 		{0, "GC", fakeRangeID, allReplicas, none},


### PR DESCRIPTION
This got broken by some sloppy refactoring to make the method use
iterateNodes rather than a more one-off approach to forwarding the
request to nodes using the isLiveMap.

Release note (bug fix): Fix the _admin/v1/enqueue_range debug endpoint
to always respect its node_id parameter.

Found while testing #31035