### PR TITLE
cdc: Fix Sink Error Retries + Chaos Test

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -115,6 +115,11 @@ func newChangeAggregatorProcessor(
 	{
 		canarySink, err := getSink(spec.Feed.SinkURI, spec.Feed.Opts, spec.Feed.Targets)
 		if err != nil {
+			// In this context, we don't want to retry even retryable errors from the
+			// sync. Unwrap any retryable errors encountered.
+			if rErr, ok := err.(*retryableSinkError); ok {
+				return nil, rErr.cause
+			}
 			return nil, err
 		}
 		if err := canarySink.Close(); err != nil {
@@ -418,6 +423,11 @@ func newChangeFrontierProcessor(
 	{
 		canarySink, err := getSink(spec.Feed.SinkURI, spec.Feed.Opts, spec.Feed.Targets)
 		if err != nil {
+			// In this context, we don't want to retry even retryable errors from the
+			// sync. Unwrap any retryable errors encountered.
+			if rErr, ok := err.(*retryableSinkError); ok {
+				return nil, rErr.cause
+			}
 			return nil, err
 		}
 		if err := canarySink.Close(); err != nil {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -769,7 +769,7 @@ func TestChangefeedRetryableSinkError(t *testing.T) {
 	var failSink int64
 	failSinkHook := func() error {
 		if atomic.LoadInt64(&failSink) != 0 {
-			return retryableSinkError{cause: fmt.Errorf("synthetic retryable error")}
+			return &retryableSinkError{cause: fmt.Errorf("synthetic retryable error")}
 		}
 		return nil
 	}

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -38,7 +38,7 @@ func installKafka(ctx context.Context, c *cluster, kafkaNode nodeListOption) {
 
 func startKafka(ctx context.Context, c *cluster, kafkaNode nodeListOption) {
 	// This isn't necessary for the nightly tests, but it's nice for iteration.
-	c.Run(ctx, kafkaNode, `CONFLUENT_CURRENT=/mnt/data1/confluent ./confluent-4.0.0/bin/confluent destroy | true`)
+	c.Run(ctx, kafkaNode, `CONFLUENT_CURRENT=/mnt/data1/confluent ./confluent-4.0.0/bin/confluent destroy || true`)
 	c.Run(ctx, kafkaNode, `CONFLUENT_CURRENT=/mnt/data1/confluent ./confluent-4.0.0/bin/confluent start kafka`)
 }
 


### PR DESCRIPTION
Fixes a few related bugs that were causing the CDC kafka chaos test to
fail-

The `retryableSinkError` returned from kafkaSink was not being returned
as a pointer, meaning it was not being detected correctly. Additionally,
retryable connection errors could be thrown while attempting to connect
the sink initially, but these were not being marked as retryable.

If the kafka error occurs on a remote node in the DistSQL operation, it
is marshalled over the wire as a `pgerror.Error`, meaning it can no
longer be detected with type assertions. We now check for this in
`isRetryableError`.

Finally, the CDC chaos test itself was not properly silencing possible
errors from `confluent destroy`.

Fixes #29243

Release note: None