### PR TITLE
workload/cli: throttle how often errors are logged

### DIFF
--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -70,7 +70,9 @@ func registerVersion(r *registry) {
 			i := i     // ditto
 			m.Go(func(ctx context.Context) error {
 				cmd = fmt.Sprintf(cmd, nodes)
-				childL, err := c.l.ChildLogger("workload " + strconv.Itoa(i))
+				// Direct stderr only to disk. We expect errors from the workload as
+				// nodes are stopped and started.
+				childL, err := c.l.ChildLogger("workload"+strconv.Itoa(i), quietStderr)
 				if err != nil {
 					return err
 				}

--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -388,12 +388,15 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 		jsonEnc = json.NewEncoder(jsonF)
 	}
 
+	everySecond := log.Every(time.Second)
 	for i := 0; ; {
 		select {
 		case err := <-errCh:
 			numErr++
 			if *tolerateErrors {
-				log.Error(ctx, err)
+				if everySecond.ShouldLog() {
+					log.Error(ctx, err)
+				}
 				continue
 			}
 			return err


### PR DESCRIPTION
Throttle logging of errors to once every second. When
`--tolerate-errors` is specified, errors can be logged at a
fantastically high rate when a node goes down. Spamming the log with the
repeated error messages is both useless and can lead to high disk usage
if the logs are being directed to disk.

Fixes #31031

Release note: None