### PR TITLE
gossip: propagate most-distant markers on every connection

### DIFF
--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -172,9 +172,13 @@ func (c *client) requestGossip(g *Gossip, stream Gossip_GossipClient) error {
 
 // sendGossip sends the latest gossip to the remote server, based on
 // the remote server's notion of other nodes' high water timestamps.
-func (c *client) sendGossip(g *Gossip, stream Gossip_GossipClient) error {
+func (c *client) sendGossip(g *Gossip, stream Gossip_GossipClient, firstReq bool) error {
 	g.mu.Lock()
-	if delta := g.mu.is.delta(c.remoteHighWaterStamps); len(delta) > 0 {
+	delta := g.mu.is.delta(c.remoteHighWaterStamps)
+	if firstReq {
+		g.mu.is.populateMostDistantMarkers(delta)
+	}
+	if len(delta) > 0 {
 		// Ensure that the high water stamps for the remote server are kept up to
 		// date so that we avoid resending the same gossip infos as infos are
 		// updated locally.
@@ -363,7 +367,7 @@ func (c *client) gossip(
 	initTimer := time.NewTimer(time.Second)
 	defer initTimer.Stop()
 
-	for {
+	for count := 0; ; {
 		select {
 		case <-c.closer:
 			return nil
@@ -376,9 +380,10 @@ func (c *client) gossip(
 		case <-initTimer.C:
 			maybeRegister()
 		case <-sendGossipChan:
-			if err := c.sendGossip(g, stream); err != nil {
+			if err := c.sendGossip(g, stream, count == 0); err != nil {
 				return err
 			}
+			count++
 		}
 	}
 }

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -377,6 +377,110 @@ func TestGossipOutgoingLimitEnforced(t *testing.T) {
 	local.clientsMu.Unlock()
 }
 
+func TestGossipMostDistant(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	t.Skipf("demonstrates bug, doesn't currently pass")
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+
+	connect := func(from, to *Gossip) {
+		to.mu.Lock()
+		addr := to.mu.is.NodeAddr
+		to.mu.Unlock()
+		from.mu.Lock()
+		from.startClientLocked(&addr)
+		from.mu.Unlock()
+	}
+
+	mostDistant := func(g *Gossip) (roachpb.NodeID, uint32) {
+		g.mu.Lock()
+		distantNodeID, distantHops := g.mu.is.mostDistant(func(roachpb.NodeID) bool {
+			return false
+		})
+		g.mu.Unlock()
+		return distantNodeID, distantHops
+	}
+
+	const n = 10
+	testCases := []struct {
+		from, to int
+	}{
+		{0, n - 1}, // n1 connects to n10
+		{n - 1, 0}, // n10 connects to n1
+	}
+
+	for _, c := range testCases {
+		t.Run("", func(t *testing.T) {
+
+			// Set up a gossip network of 10 nodes connected in a single line:
+			//
+			//   1 <- 2 <- 3 <- 4 <- 5 <- 6 <- 7 <- 8 <- 9 <- 10
+			nodes := make([]*Gossip, n)
+			for i := range nodes {
+				nodes[i] = startGossip(roachpb.NodeID(i+1), stopper, t, metric.NewRegistry())
+				if i == 0 {
+					continue
+				}
+				connect(nodes[i], nodes[i-1])
+			}
+
+			// Wait for n1 to determine that n10 is the most distant node.
+			testutils.SucceedsSoon(t, func() error {
+				g := nodes[0]
+				distantNodeID, distantHops := mostDistant(g)
+				if distantNodeID == 10 && distantHops == 9 {
+					return nil
+				}
+				return fmt.Errorf("n%d: distantHops: %d from n%d", g.NodeID.Get(), distantHops, distantNodeID)
+			})
+			// Wait for the infos to be fully propagated.
+			testutils.SucceedsSoon(t, func() error {
+				infosCount := func(g *Gossip) int {
+					g.mu.Lock()
+					defer g.mu.Unlock()
+					return len(g.mu.is.Infos)
+				}
+				count := infosCount(nodes[0])
+				for _, g := range nodes[1:] {
+					if tmp := infosCount(g); tmp != count {
+						return fmt.Errorf("unexpected info count: %d != %d", tmp, count)
+					}
+				}
+				return nil
+			})
+
+			// Connect the network in a loop. This should halve the
+			connect(nodes[c.from], nodes[c.to])
+
+			// Wait for n1 to determine that n6 is now the most distant hops from 9
+			// to 5 and change the most distant node to n6.
+			testutils.SucceedsSoon(t, func() error {
+				g := nodes[0]
+				g.mu.Lock()
+				var buf bytes.Buffer
+				_ = g.mu.is.visitInfos(func(key string, i *Info) error {
+					if i.NodeID != 1 && IsNodeIDKey(key) {
+						fmt.Fprintf(&buf, "n%d: hops=%d\n", i.NodeID, i.Hops)
+					}
+					return nil
+				}, true /* deleteExpired */)
+				g.mu.Unlock()
+
+				distantNodeID, distantHops := mostDistant(g)
+				if distantNodeID == 6 && distantHops == 5 {
+					log.Infof(context.TODO(), "n%d: distantHops: %d from n%d\n%s", g.NodeID.Get(), distantHops, distantNodeID, buf.String())
+					return nil
+				}
+				err := fmt.Errorf("n%d: distantHops: %d from n%d", g.NodeID.Get(), distantHops, distantNodeID)
+				log.Infof(context.TODO(), "%v\n%s", err, buf.String())
+				return err
+			})
+		})
+	}
+}
+
 // TestGossipNoForwardSelf verifies that when a Gossip instance is full, it
 // redirects clients elsewhere (in particular not to itself).
 //

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -380,8 +380,6 @@ func TestGossipOutgoingLimitEnforced(t *testing.T) {
 func TestGossipMostDistant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skipf("demonstrates bug, doesn't currently pass")
-
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
 
@@ -451,7 +449,9 @@ func TestGossipMostDistant(t *testing.T) {
 				return nil
 			})
 
-			// Connect the network in a loop. This should halve the
+			// Connect the network in a loop. This will cut the distance to the most
+			// distant node in half.
+			log.Infof(context.Background(), "connecting from n%d to n%d", c.from, c.to)
 			connect(nodes[c.from], nodes[c.to])
 
 			// Wait for n1 to determine that n6 is now the most distant hops from 9
@@ -470,12 +470,10 @@ func TestGossipMostDistant(t *testing.T) {
 
 				distantNodeID, distantHops := mostDistant(g)
 				if distantNodeID == 6 && distantHops == 5 {
-					log.Infof(context.TODO(), "n%d: distantHops: %d from n%d\n%s", g.NodeID.Get(), distantHops, distantNodeID, buf.String())
 					return nil
 				}
-				err := fmt.Errorf("n%d: distantHops: %d from n%d", g.NodeID.Get(), distantHops, distantNodeID)
-				log.Infof(context.TODO(), "%v\n%s", err, buf.String())
-				return err
+				return fmt.Errorf("n%d: distantHops: %d from n%d\n%s",
+					g.NodeID.Get(), distantHops, distantNodeID, buf.String())
 			})
 		})
 	}

--- a/pkg/gossip/infostore.go
+++ b/pkg/gossip/infostore.go
@@ -432,6 +432,20 @@ func (is *infoStore) delta(highWaterTimestamps map[roachpb.NodeID]int64) map[str
 	return infos
 }
 
+// populateMostDistantMarkers adds the node ID infos to the infos map. The node
+// ID infos are used as markers in the mostDistant calculation and need to be
+// propagated regardless of high water stamps.
+func (is *infoStore) populateMostDistantMarkers(infos map[string]*Info) {
+	if err := is.visitInfos(func(key string, i *Info) error {
+		if IsNodeIDKey(key) {
+			infos[key] = i
+		}
+		return nil
+	}, true /* deleteExpired */); err != nil {
+		panic(err)
+	}
+}
+
 // mostDistant returns the most distant gossip node known to the store
 // as well as the number of hops to reach it.
 //

--- a/pkg/gossip/server.go
+++ b/pkg/gossip/server.go
@@ -151,7 +151,7 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 
 	reply := new(Response)
 
-	for {
+	for init := true; ; init = false {
 		s.mu.Lock()
 		// Store the old ready so that if it gets replaced with a new one
 		// (once the lock is released) and is closed, we still trigger the
@@ -162,7 +162,10 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 			args.HighWaterStamps = make(map[roachpb.NodeID]int64)
 		}
 
-		if infoCount := len(delta); infoCount > 0 {
+		// Send a response if this is the first response on the connection, or if
+		// there are deltas to send. The first condition is necessary to make sure
+		// the remote node receives our high water stamps in a timely fashion.
+		if infoCount := len(delta); init || infoCount > 0 {
 			if log.V(1) {
 				log.Infof(ctx, "returning %d info(s) to n%d: %s",
 					infoCount, args.NodeID, extractKeys(delta))

--- a/pkg/gossip/server.go
+++ b/pkg/gossip/server.go
@@ -158,6 +158,9 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 		// select below.
 		ready := s.mu.ready
 		delta := s.mu.is.delta(args.HighWaterStamps)
+		if init {
+			s.mu.is.populateMostDistantMarkers(delta)
+		}
 		if args.HighWaterStamps == nil {
 			args.HighWaterStamps = make(map[roachpb.NodeID]int64)
 		}


### PR DESCRIPTION
Whenever a gossip connection is created, propagate the most-distant
marker infos (i.e. `node:<id>` infos) to the remote node. These infos
are used for the `mostDistant` calculation and need to accurately
reflect the number of hops to a node.

Note that this is a bandaid. Using the info hops value to calculate the
distance to a node does not work correctly unless infos are always
propagated. The high water stamps mechanism that avoids sending an info
that the remote already has can allow the info hops value to remain
higher or lower than the actual value. Consider the following gossip
network:

```
  1 -> 2
  1 -> 3
  2 -> 3
  3 -> 4
```

When n1 gossips its `node:1` info it has multiple paths to get to n4. We
can either see `1 -> 2 -> 3 -> 4` or `1 -> 3 -> 4`. Depending on the
path the hops value will differ and the path is timing dependent. Even
worse, consider what happens when the network changes. For example,
start with the network `1 -> 2 -> 3 -> 4`. The network then changes to:

```
  1 -> 3
  2 -> 3
  3 -> 4
```

The `node:<id>` keys have a TTL of 2h. In the initial configuration, n2
is considered to be 1 hop distant from n1. But after the
reconfiguration, n2 is in reality 2 hops distant from n1, yet the
`node:2` key living on n1 will not have been updated because it hasn't
changed and the new hops value is higher. The new `gossip-clients:*`
keys give us a way out of this complexity as each node can compute the
shortest path to every other node, but those keys are not generated by
v2.0.x of CockroachDB so we'll have to wait to use them for that
purpose.

Fixes #30895

Release note: None