### PR TITLE
release-2.1: assorted CTE fixes

### DIFF
--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -57,36 +57,6 @@ func (p *planner) CreateView(ctx context.Context, n *tree.CreateView) (planNode,
 		return nil, err
 	}
 
-	// Ensure that all the table names are properly qualified.  The
-	// traversal will update the NormalizableTableNames in-place, so the
-	// changes are persisted in n.AsSource. We use tree.FormatNode
-	// merely as a traversal method; its output buffer is discarded
-	// immediately after the traversal because it is not needed further.
-	var fmtErr error
-	{
-		f := tree.NewFmtCtxWithBuf(tree.FmtParsable)
-		f.WithReformatTableNames(
-			func(_ *tree.FmtCtx, t *tree.NormalizableTableName) {
-				tn, err := p.QualifyWithDatabase(ctx, t)
-				if err != nil {
-					log.Warningf(ctx, "failed to qualify table name %q with database name: %v",
-						tree.ErrString(t), err)
-					fmtErr = err
-					return
-				}
-				// Persist the database prefix expansion.
-				tn.ExplicitSchema = true
-				tn.ExplicitCatalog = true
-			},
-		)
-		f.FormatNode(n.AsSource)
-		f.Close() // We don't need the string.
-	}
-
-	if fmtErr != nil {
-		return nil, fmtErr
-	}
-
 	var planDeps planDependencies
 	var sourceColumns sqlbase.ResultColumns
 	// To avoid races with ongoing schema changes to tables that the view
@@ -97,6 +67,42 @@ func (p *planner) CreateView(ctx context.Context, n *tree.CreateView) (planNode,
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	// Ensure that all the table names pretty-print as fully qualified,
+	// so we store that in the view descriptor.
+	// The traversal will update the NormalizableTableNames in-place, so
+	// the changes are persisted in n.AsSource. We exploit the fact
+	// that semantic analysis above has populated any missing db/schema
+	// details in the table names in-place.
+	// We use tree.FormatNode merely as a traversal method; its output
+	// buffer is discarded immediately after the traversal because it is
+	// not needed further.
+	var fmtErr error
+	{
+		f := tree.NewFmtCtxWithBuf(tree.FmtParsable)
+		f.WithReformatTableNames(
+			func(_ *tree.FmtCtx, t *tree.NormalizableTableName) {
+				tn, err := t.Normalize()
+				if err != nil {
+					fmtErr = err
+					return
+				}
+				// Persist the database prefix expansion.
+				if tn.SchemaName != "" {
+					// All CTE or table aliases have no schema
+					// information. Those do not turn into explicit.
+					tn.ExplicitSchema = true
+					tn.ExplicitCatalog = true
+				}
+			},
+		)
+		f.FormatNode(n.AsSource)
+		f.Close() // We don't need the string.
+	}
+
+	if fmtErr != nil {
+		return nil, fmtErr
 	}
 
 	numColNames := len(n.ColumnNames)

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -195,21 +195,6 @@ func (p *planner) getDataSource(
 	}
 }
 
-// QualifyWithDatabase asserts that the table with the given name
-// exists, and expands its table name with the details about its path.
-func (p *planner) QualifyWithDatabase(
-	ctx context.Context, t *tree.NormalizableTableName,
-) (*tree.TableName, error) {
-	tn, err := t.Normalize()
-	if err != nil {
-		return nil, err
-	}
-	if _, err := ResolveExistingObject(ctx, p, tn, true /*required*/, anyDescType); err != nil {
-		return nil, err
-	}
-	return tn, nil
-}
-
 func (p *planner) getTableScanByRef(
 	ctx context.Context,
 	tref *tree.TableRef,

--- a/pkg/sql/explain_test.go
+++ b/pkg/sql/explain_test.go
@@ -160,8 +160,12 @@ func TestStatementReuses(t *testing.T) {
 	t.Run("WITH (cte)", func(t *testing.T) {
 		for _, test := range testData {
 			t.Run(test, func(t *testing.T) {
-				rows, err := db.Query("EXPLAIN WITH a AS (" + test + ") SELECT 1")
+				rows, err := db.Query("EXPLAIN WITH a AS (" + test + ") TABLE a")
 				if err != nil {
+					if testutils.IsError(err, "does not have a RETURNING clause") {
+						// This error is acceptable and does not constitute a test failure.
+						return
+					}
 					t.Fatal(err)
 				}
 				defer rows.Close()

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -700,8 +701,22 @@ func extractInsertSource(
 	wrapped := s.Select
 	limit := s.Limit
 	orderBy := s.OrderBy
+	with := s.With
 
+	// Be careful to not unwrap expressions with a WITH clause. These
+	// need to be handled generically.
 	for s, ok := wrapped.(*tree.ParenSelect); ok; s, ok = wrapped.(*tree.ParenSelect) {
+		if s.Select.With != nil {
+			if with != nil {
+				// (WITH ... (WITH ...))
+				// Currently we are unable to nest the scopes inside ParenSelect so we
+				// must refuse the syntax so that the query does not get invalid results.
+				return nil, nil, pgerror.UnimplementedWithIssueError(24303,
+					"multiple WITH clauses in parentheses")
+			}
+			with = s.Select.With
+		}
+
 		wrapped = s.Select.Select
 		if s.Select.OrderBy != nil {
 			if orderBy != nil {
@@ -717,7 +732,7 @@ func extractInsertSource(
 		}
 	}
 
-	if orderBy == nil && limit == nil {
+	if with == nil && orderBy == nil && limit == nil {
 		values, _ := wrapped.(*tree.ValuesClause)
 		if values != nil {
 			return wrapped, &tree.ValuesClauseWithNames{ValuesClause: *values, Names: colNames}, nil
@@ -725,7 +740,7 @@ func extractInsertSource(
 		return wrapped, nil, nil
 	}
 	return &tree.ParenSelect{
-		Select: &tree.Select{Select: wrapped, OrderBy: orderBy, Limit: limit},
+		Select: &tree.Select{Select: wrapped, OrderBy: orderBy, Limit: limit, With: with},
 	}, nil, nil
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -32,7 +32,7 @@ descriptor_id  descriptor_name  column_id  column_name  column_type             
 58             test_kvi2        1          k            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
 58             test_kvi2        2          v            semantic_type:INT width:0 precision:0 visible_type:NONE       true      NULL            false
 59             test_v1          1          v            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
-61             test_v2          1          v            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
+60             test_v2          1          v            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
 
 query ITITTB colnames
 SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id
@@ -51,7 +51,7 @@ descriptor_id  descriptor_name  index_id  index_name       index_type  is_unique
 58             test_kvi2        1         primary          primary     true
 58             test_kvi2        2         test_kvi2_idx    secondary   true
 59             test_v1          0         ·                primary     false
-61             test_v2          0         ·                primary     false
+60             test_v2          0         ·                primary     false
 
 query ITITTITT colnames
 SELECT * FROM crdb_internal.index_columns WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id, column_type, column_id
@@ -88,7 +88,7 @@ descriptor_id  descriptor_name  index_id  column_id  dependson_id  dependson_typ
 57             test_kvi1        1         NULL       53            interleave      1                   NULL              SharedPrefixLen: 1
 58             test_kvi2        2         NULL       53            interleave      1                   NULL              SharedPrefixLen: 1
 59             test_v1          NULL      NULL       53            view            NULL                NULL              NULL
-61             test_v2          NULL      NULL       59            view            NULL                NULL              NULL
+60             test_v2          NULL      NULL       59            view            NULL                NULL              NULL
 
 query ITIITITT colnames
 SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id, dependedonby_type, dependedonby_id, dependedonby_index_id
@@ -100,7 +100,7 @@ descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  de
 53             test_kv          1         57               interleave         1                      NULL               SharedPrefixLen: 0
 53             test_kv          1         58               interleave         2                      NULL               SharedPrefixLen: 0
 53             test_kv          2         56               fk                 2                      ·                  SharedPrefixLen: 0
-59             test_v1          NULL      61               view               0                      NULL               Columns: [1]
+59             test_v1          NULL      60               view               0                      NULL               Columns: [1]
 
 # Checks view dependencies (#17306)
 statement ok
@@ -111,13 +111,13 @@ query ITIIITITT colnames
 SELECT * FROM crdb_internal.backward_dependencies WHERE descriptor_name LIKE 'moretest_%' ORDER BY descriptor_id, index_id, dependson_type, dependson_id, dependson_index_id
 ----
 descriptor_id  descriptor_name  index_id  column_id  dependson_id  dependson_type  dependson_index_id  dependson_name  dependson_details
-64             moretest_v       NULL      NULL       62            view            NULL                NULL            NULL
+62             moretest_v       NULL      NULL       61            view            NULL                NULL            NULL
 
 query ITIITITT colnames
 SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name LIKE 'moretest_%' ORDER BY descriptor_id, index_id, dependedonby_type, dependedonby_id, dependedonby_index_id
 ----
 descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
-62             moretest_t       NULL      64               view               0                      NULL               Columns: [1 2 3]
+61             moretest_t       NULL      62               view               0                      NULL               Columns: [1 2 3]
 
 # Check sequence dependencies.
 
@@ -131,13 +131,13 @@ query ITIIITITT colnames
 SELECT * FROM crdb_internal.backward_dependencies WHERE descriptor_name LIKE 'blog_posts'
 ----
 descriptor_id  descriptor_name  index_id  column_id  dependson_id  dependson_type  dependson_index_id  dependson_name  dependson_details
-66             blog_posts       NULL      1          65            sequence        NULL                NULL            NULL
+64             blog_posts       NULL      1          63            sequence        NULL                NULL            NULL
 
 query ITIITITT colnames
 SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name LIKE 'blog_posts%'
 ----
 descriptor_id  descriptor_name    index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
-65             blog_posts_id_seq  NULL      66               sequence           0                      NULL               Columns: [0]
+63             blog_posts_id_seq  NULL      64               sequence           0                      NULL               Columns: [0]
 
 # Verify that we report a dependency on a column that is being mutated.
   #CREATE VIEW v AS WITH a AS (UPDATE kv SET v = 444 RETURNING k) SELECT k FROM a;
@@ -152,4 +152,4 @@ query ITIITITT colnames
 SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name = 'kv'
 ----
 descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
-67             kv               NULL      68               view               0                      NULL               Columns: [1 2 3]
+65             kv               NULL      66               view               0                      NULL               Columns: [1 2 3]

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -281,7 +281,7 @@ oid         relname       relnamespace  reltype  relowner  relam  relfilenode  r
 226054345   t3            393119649     0        NULL      NULL   0            0
 4084598993  primary       393119649     0        NULL      NULL   0            0
 4084598994  t3_a_b_idx    393119649     0        NULL      NULL   0            0
-4218730311  v1            393119649     0        NULL      NULL   0            0
+4252432642  v1            393119649     0        NULL      NULL   0            0
 
 query TIRIOBBT colnames
 SELECT relname, relpages, reltuples, relallvisible, reltoastrelid, relhasindex, relisshared, relpersistence
@@ -369,10 +369,10 @@ attrelid    relname       attname  atttypid  attstattarget  attlen  attnum  attn
 4084598993  primary       rowid    20        0              8       1       0         -1
 4084598994  t3_a_b_idx    a        20        0              8       1       0         -1
 4084598994  t3_a_b_idx    b        20        0              8       2       0         -1
-4218730311  v1            p        701       0              8       1       0         -1
-4218730311  v1            a        20        0              8       2       0         -1
-4218730311  v1            b        20        0              8       3       0         -1
-4218730311  v1            c        20        0              8       4       0         -1
+4252432642  v1            p        701       0              8       1       0         -1
+4252432642  v1            a        20        0              8       2       0         -1
+4252432642  v1            b        20        0              8       3       0         -1
+4252432642  v1            c        20        0              8       4       0         -1
 
 query TTIBTTBB colnames
 SELECT c.relname, attname, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef
@@ -1437,8 +1437,8 @@ query OOIIIIIB colnames
 SELECT * FROM pg_catalog.pg_sequence
 ----
 seqrelid    seqtypid  seqstart  seqincrement  seqmax               seqmin  seqcache  seqcycle
-162412526   20        1         1             9223372036854775807  1       1         false
-2864600840  20        6         2             10                   5       1         false
+1978455413  20        1         1             9223372036854775807  1       1         false
+3953462681  20        6         2             10                   5       1         false
 
 statement ok
 DROP DATABASE seq

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -499,3 +499,29 @@ SELECT sum ("QuotedCaps15951". a) FROM "QuotedCaps15951" GROUP BY b ORDER BY b
 1
 3
 6
+
+# Regression tests for #23833
+
+statement ok
+CREATE VIEW w AS WITH a AS (SELECT 1 AS x) SELECT x FROM a
+
+query T
+SELECT create_statement FROM [SHOW CREATE w]
+----
+CREATE VIEW w (x) AS WITH a AS (SELECT 1 AS x) SELECT x FROM a
+
+statement ok
+CREATE VIEW w2 AS WITH t AS (SELECT x FROM w) SELECT x FROM t
+
+query T
+SELECT create_statement FROM [SHOW CREATE w2]
+----
+CREATE VIEW w2 (x) AS WITH t AS (SELECT x FROM test.public.w) SELECT x FROM t
+
+statement ok
+CREATE VIEW w3 AS (WITH t AS (SELECT x FROM w) SELECT x FROM t)
+
+query T
+SELECT create_statement FROM [SHOW CREATE w3]
+----
+CREATE VIEW w3 (x) AS (WITH t AS (SELECT x FROM test.public.w) SELECT x FROM t)

--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -143,3 +143,44 @@ WITH t AS (
     INSERT INTO x(a) VALUES(0)
 )
 SELECT * FROM t
+
+# Regression test for #24307 until CockroachDB learns how to execute
+# side effects no matter what.
+query error unimplemented: common table expression "t" with side effects was not used in query
+WITH t AS (
+   INSERT INTO x(a) VALUES(0) RETURNING a
+)
+SELECT 1
+
+query error unimplemented: common table expression "t" with side effects was not used in query
+WITH t AS (
+   SELECT * FROM (
+      WITH b AS (INSERT INTO x(a) VALUES(0) RETURNING a)
+	  TABLE b
+   )
+)
+SELECT 1
+
+query error unimplemented: common table expression "t" with side effects was not used in query
+WITH t AS (
+   DELETE FROM x RETURNING a
+)
+SELECT 1
+
+query error unimplemented: common table expression "t" with side effects was not used in query
+WITH t AS (
+   UPSERT INTO x(a) VALUES(0) RETURNING a
+)
+SELECT 1
+
+query error unimplemented: common table expression "t" with side effects was not used in query
+WITH t AS (
+   UPDATE x SET a = 0 RETURNING a
+)
+SELECT 1
+
+# however if there are no side effects, no errors are required.
+query I
+WITH t AS (SELECT 1) SELECT 2
+----
+2

--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -21,7 +21,6 @@ WITH t AS (SELECT * FROM y WHERE a < 3)
 ----
 2
 
-
 # Using a CTE inside a subquery
 query I rowsort
 WITH t(x) AS (SELECT a FROM x)
@@ -44,6 +43,24 @@ WITH t(b) AS (SELECT a FROM x) SELECT b, t.b FROM t
 1 1
 2 2
 3 3
+
+query BB
+WITH t(a, b) AS (SELECT true a, false b)
+  SELECT a, b FROM t
+----
+true  false
+
+query BB
+WITH t(b, a) AS (SELECT true a, false b)
+  SELECT a, b FROM t
+----
+false  true
+
+statement error WITH query name t specified more than once
+WITH
+    t AS (SELECT true),
+    t AS (SELECT false)
+SELECT * FROM t
 
 query error source "t" has 1 columns available but 2 columns specified
 WITH t(b, c) AS (SELECT a FROM x) SELECT b, t.b FROM t

--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -184,3 +184,57 @@ query I
 WITH t AS (SELECT 1) SELECT 2
 ----
 2
+
+# Regression tests for #24303.
+
+statement ok
+CREATE TABLE a(x INT);
+
+statement count 3
+INSERT INTO a(x)
+        (WITH b(z) AS (VALUES (1),(2),(3)) SELECT z+1 AS w FROM b)
+
+statement count 1
+INSERT INTO a(x)
+      (WITH a(z) AS (VALUES (1)) SELECT z+1 AS w FROM a);
+
+# When #24303 is fixed, the following query should succeed.
+query error unimplemented: multiple WITH clauses in parentheses
+(WITH woo AS (VALUES (1))
+    (WITH waa AS (VALUES (2))
+	   TABLE waa))
+
+
+# When #24303 is fixed, the following query should fail with
+# error "no such relation woo".
+query error unimplemented: multiple WITH clauses in parentheses
+(WITH woo AS (VALUES (1))
+    (WITH waa AS (VALUES (2))
+	   TABLE woo))
+
+statement ok
+CREATE TABLE lim(x) AS SELECT 0
+
+# This is an oddity in PostgreSQL: even though the WITH clause
+# occurs in the inside parentheses, the scope of the alias `lim`
+# extends to the outer parentheses.
+query I
+((WITH lim(x) AS (SELECT 1) SELECT 123)
+ LIMIT (
+    SELECT x FROM lim -- intuitively this should refer to the real table lim defined above
+                      -- and use LIMIT 0;
+                      -- however, postgres flattens the inner WITH and outer LIMIT
+                      -- at the same scope so the limit becomes 1.
+ ))
+----
+123
+
+# Ditto if table `lim` did not even exist.
+statement ok
+DROP TABLE lim
+
+query I
+((WITH lim(x) AS (SELECT 1) SELECT 123) LIMIT (SELECT x FROM lim))
+----
+123
+

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -16,6 +16,7 @@ package optbuilder
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
@@ -342,16 +343,12 @@ func (b *Builder) buildScalar(
 
 			fn := comparisonOpMap[t.Operator]
 
-			if fn != nil {
-				// Most comparison ops map directly to a factory method.
-				out = fn(b.factory, left, right)
-			} else if b.AllowUnsupportedExpr {
-				out = b.factory.ConstructUnsupportedExpr(b.factory.InternTypedExpr(scalar))
-			} else {
-				// TODO(rytaft): remove this check when we are confident that
-				// all operators are included in comparisonOpMap.
-				panic(unimplementedf("unsupported comparison operator: %s", t.Operator))
+			if fn == nil {
+				panic(builderError{fmt.Errorf("unknown comparison operator: %s", t.Operator)})
 			}
+
+			// Most comparison ops map directly to a factory method.
+			out = fn(b.factory, left, right)
 		}
 
 	case *tree.DTuple:

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -125,7 +125,7 @@ func (b *Builder) buildDataSource(
 		return outScope
 
 	default:
-		panic(unimplementedf("not yet implemented: table expr: %T", texpr))
+		panic(builderError{fmt.Errorf("unknown table expr: %T", texpr)})
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -20,4 +20,369 @@ build
 WITH t AS (SELECT a FROM y WHERE a < 3)
   SELECT * FROM x NATURAL JOIN t
 ----
-error (0A000): with clause not supported
+project
+ ├── columns: a:3(int!null)
+ └── inner-join
+      ├── columns: y.a:1(int!null) x.a:3(int!null) x.rowid:4(int!null)
+      ├── scan x
+      │    └── columns: x.a:3(int) x.rowid:4(int!null)
+      ├── project
+      │    ├── columns: y.a:1(int!null)
+      │    └── select
+      │         ├── columns: y.a:1(int!null) y.rowid:2(int!null)
+      │         ├── scan y
+      │         │    └── columns: y.a:1(int) y.rowid:2(int!null)
+      │         └── filters [type=bool]
+      │              └── lt [type=bool]
+      │                   ├── variable: y.a [type=int]
+      │                   └── const: 3 [type=int]
+      └── filters [type=bool]
+           └── eq [type=bool]
+                ├── variable: x.a [type=int]
+                └── variable: y.a [type=int]
+
+build
+WITH t AS (SELECT a FROM y WHERE a < 3)
+  SELECT * FROM t
+----
+project
+ ├── columns: a:1(int!null)
+ └── select
+      ├── columns: a:1(int!null) rowid:2(int!null)
+      ├── scan y
+      │    └── columns: a:1(int) rowid:2(int!null)
+      └── filters [type=bool]
+           └── lt [type=bool]
+                ├── variable: a [type=int]
+                └── const: 3 [type=int]
+
+# Chaining multiple CTEs.
+build
+WITH
+    t1 AS (SELECT a FROM y WHERE a < 3),
+    t2 AS (SELECT * FROM t1 WHERE a > 1)
+SELECT * FROM t2
+----
+select
+ ├── columns: a:1(int!null)
+ ├── project
+ │    ├── columns: a:1(int!null)
+ │    └── select
+ │         ├── columns: a:1(int!null) rowid:2(int!null)
+ │         ├── scan y
+ │         │    └── columns: a:1(int) rowid:2(int!null)
+ │         └── filters [type=bool]
+ │              └── lt [type=bool]
+ │                   ├── variable: a [type=int]
+ │                   └── const: 3 [type=int]
+ └── filters [type=bool]
+      └── gt [type=bool]
+           ├── variable: a [type=int]
+           └── const: 1 [type=int]
+
+build
+WITH
+    t1 AS (SELECT a FROM y WHERE a < 3),
+    t2 AS (SELECT * FROM t1 WHERE a > 1),
+    t3 AS (SELECT * FROM t2 WHERE a = 2)
+SELECT * FROM t3
+----
+select
+ ├── columns: a:1(int!null)
+ ├── select
+ │    ├── columns: a:1(int!null)
+ │    ├── project
+ │    │    ├── columns: a:1(int!null)
+ │    │    └── select
+ │    │         ├── columns: a:1(int!null) rowid:2(int!null)
+ │    │         ├── scan y
+ │    │         │    └── columns: a:1(int) rowid:2(int!null)
+ │    │         └── filters [type=bool]
+ │    │              └── lt [type=bool]
+ │    │                   ├── variable: a [type=int]
+ │    │                   └── const: 3 [type=int]
+ │    └── filters [type=bool]
+ │         └── gt [type=bool]
+ │              ├── variable: a [type=int]
+ │              └── const: 1 [type=int]
+ └── filters [type=bool]
+      └── eq [type=bool]
+           ├── variable: a [type=int]
+           └── const: 2 [type=int]
+
+build
+WITH
+    t1 AS (SELECT * FROM y WHERE a < 3),
+    t2 AS (SELECT * FROM y WHERE a > 1),
+    t3 AS (SELECT * FROM t1 WHERE a < 4),
+    t4 AS (SELECT * FROM t2 WHERE a > 3)
+SELECT * FROM t3 NATURAL JOIN t4
+----
+project
+ ├── columns: a:1(int!null)
+ └── inner-join
+      ├── columns: y.a:1(int!null) y.a:3(int!null)
+      ├── select
+      │    ├── columns: y.a:1(int!null)
+      │    ├── project
+      │    │    ├── columns: y.a:1(int!null)
+      │    │    └── select
+      │    │         ├── columns: y.a:1(int!null) y.rowid:2(int!null)
+      │    │         ├── scan y
+      │    │         │    └── columns: y.a:1(int) y.rowid:2(int!null)
+      │    │         └── filters [type=bool]
+      │    │              └── lt [type=bool]
+      │    │                   ├── variable: y.a [type=int]
+      │    │                   └── const: 3 [type=int]
+      │    └── filters [type=bool]
+      │         └── lt [type=bool]
+      │              ├── variable: y.a [type=int]
+      │              └── const: 4 [type=int]
+      ├── select
+      │    ├── columns: y.a:3(int!null)
+      │    ├── project
+      │    │    ├── columns: y.a:3(int!null)
+      │    │    └── select
+      │    │         ├── columns: y.a:3(int!null) y.rowid:4(int!null)
+      │    │         ├── scan y
+      │    │         │    └── columns: y.a:3(int) y.rowid:4(int!null)
+      │    │         └── filters [type=bool]
+      │    │              └── gt [type=bool]
+      │    │                   ├── variable: y.a [type=int]
+      │    │                   └── const: 1 [type=int]
+      │    └── filters [type=bool]
+      │         └── gt [type=bool]
+      │              ├── variable: y.a [type=int]
+      │              └── const: 3 [type=int]
+      └── filters [type=bool]
+           └── eq [type=bool]
+                ├── variable: y.a [type=int]
+                └── variable: y.a [type=int]
+
+# Make sure they scope properly.
+build
+WITH t AS (SELECT true) SELECT * FROM (WITH t AS (SELECT false) SELECT * FROM t)
+----
+project
+ ├── columns: bool:2(bool!null)
+ ├── values
+ │    └── tuple [type=tuple]
+ └── projections
+      └── false [type=bool]
+
+build
+WITH
+    t AS (SELECT true),
+    t AS (SELECT false)
+SELECT * FROM t
+----
+error: WITH query name t specified more than once
+
+# Using a CTE once in another CTE and once otherwise.
+build
+WITH
+    t1 AS (SELECT true),
+    t2 AS (SELECT * FROM t1)
+SELECT * FROM t1 NATURAL JOIN t2
+----
+error: unsupported multiple use of CTE clause "t1"
+
+build
+WITH
+    t1 AS (SELECT * FROM x),
+    t2 AS (SELECT * FROM x NATURAL JOIN t1)
+SELECT * FROM t2 NATURAL JOIN x
+----
+project
+ ├── columns: a:3(int!null)
+ └── inner-join
+      ├── columns: x.a:3(int!null) x.a:5(int!null) x.rowid:6(int!null)
+      ├── project
+      │    ├── columns: x.a:3(int!null)
+      │    └── inner-join
+      │         ├── columns: x.a:1(int!null) x.a:3(int!null) x.rowid:4(int!null)
+      │         ├── scan x
+      │         │    └── columns: x.a:3(int) x.rowid:4(int!null)
+      │         ├── project
+      │         │    ├── columns: x.a:1(int)
+      │         │    └── scan x
+      │         │         └── columns: x.a:1(int) x.rowid:2(int!null)
+      │         └── filters [type=bool]
+      │              └── eq [type=bool]
+      │                   ├── variable: x.a [type=int]
+      │                   └── variable: x.a [type=int]
+      ├── scan x
+      │    └── columns: x.a:5(int) x.rowid:6(int!null)
+      └── filters [type=bool]
+           └── eq [type=bool]
+                ├── variable: x.a [type=int]
+                └── variable: x.a [type=int]
+
+build
+WITH t AS (SELECT a FROM y WHERE a < 3)
+  SELECT * FROM t NATURAL JOIN t
+----
+error: unsupported multiple use of CTE clause "t"
+
+build
+WITH t(x) AS (SELECT a FROM x)
+  SELECT x FROM (SELECT x FROM t)
+----
+project
+ ├── columns: x:1(int)
+ └── scan x
+      └── columns: a:1(int) rowid:2(int!null)
+
+build
+WITH t(a, b) AS (SELECT true a, false b)
+  SELECT a, b FROM t
+----
+project
+ ├── columns: a:1(bool!null) b:2(bool!null)
+ ├── values
+ │    └── tuple [type=tuple]
+ └── projections
+      ├── true [type=bool]
+      └── false [type=bool]
+
+build
+WITH t(b, a) AS (SELECT true a, false b)
+  SELECT a, b FROM t
+----
+project
+ ├── columns: a:2(bool!null) b:1(bool!null)
+ ├── values
+ │    └── tuple [type=tuple]
+ └── projections
+      ├── true [type=bool]
+      └── false [type=bool]
+
+build
+WITH t AS (SELECT a FROM x)
+    SELECT * FROM y WHERE a IN (SELECT * FROM t)
+----
+project
+ ├── columns: a:3(int)
+ └── select
+      ├── columns: y.a:3(int) y.rowid:4(int!null)
+      ├── scan y
+      │    └── columns: y.a:3(int) y.rowid:4(int!null)
+      └── filters [type=bool]
+           └── any: eq [type=bool]
+                ├── project
+                │    ├── columns: x.a:1(int)
+                │    └── scan x
+                │         └── columns: x.a:1(int) x.rowid:2(int!null)
+                └── variable: y.a [type=int]
+
+build
+WITH t(x) AS (SELECT a FROM x)
+    SELECT * FROM y WHERE a IN (SELECT x FROM t)
+----
+project
+ ├── columns: a:3(int)
+ └── select
+      ├── columns: y.a:3(int) y.rowid:4(int!null)
+      ├── scan y
+      │    └── columns: y.a:3(int) y.rowid:4(int!null)
+      └── filters [type=bool]
+           └── any: eq [type=bool]
+                ├── project
+                │    ├── columns: x.a:1(int)
+                │    └── scan x
+                │         └── columns: x.a:1(int) x.rowid:2(int!null)
+                └── variable: y.a [type=int]
+
+# Using a subquery inside a CTE
+build
+SELECT * FROM x WHERE a IN
+  (WITH t AS (SELECT * FROM y WHERE a < 3) SELECT * FROM t)
+----
+project
+ ├── columns: a:1(int)
+ └── select
+      ├── columns: x.a:1(int) x.rowid:2(int!null)
+      ├── scan x
+      │    └── columns: x.a:1(int) x.rowid:2(int!null)
+      └── filters [type=bool]
+           └── any: eq [type=bool]
+                ├── project
+                │    ├── columns: y.a:3(int!null)
+                │    └── select
+                │         ├── columns: y.a:3(int!null) y.rowid:4(int!null)
+                │         ├── scan y
+                │         │    └── columns: y.a:3(int) y.rowid:4(int!null)
+                │         └── filters [type=bool]
+                │              └── lt [type=bool]
+                │                   ├── variable: y.a [type=int]
+                │                   └── const: 3 [type=int]
+                └── variable: x.a [type=int]
+
+# Using a correlated subquery inside a CTE
+build
+SELECT (WITH t AS (SELECT * FROM y WHERE x.a = y.a) SELECT * FROM t LIMIT 1) FROM x
+----
+project
+ ├── columns: "?column?":5(int)
+ ├── scan x
+ │    └── columns: x.a:1(int) x.rowid:2(int!null)
+ └── projections
+      └── subquery [type=int]
+           └── max1-row
+                ├── columns: y.a:3(int!null)
+                └── limit
+                     ├── columns: y.a:3(int!null)
+                     ├── project
+                     │    ├── columns: y.a:3(int!null)
+                     │    └── select
+                     │         ├── columns: y.a:3(int!null) y.rowid:4(int!null)
+                     │         ├── scan y
+                     │         │    └── columns: y.a:3(int) y.rowid:4(int!null)
+                     │         └── filters [type=bool]
+                     │              └── eq [type=bool]
+                     │                   ├── variable: x.a [type=int]
+                     │                   └── variable: y.a [type=int]
+                     └── const: 1 [type=int]
+
+# Rename columns
+build
+WITH t(b) AS (SELECT a FROM x) SELECT b, t.b FROM t
+----
+project
+ ├── columns: b:1(int) b:1(int)
+ └── scan x
+      └── columns: a:1(int) rowid:2(int!null)
+
+build
+WITH t(b, c) AS (SELECT a FROM x) SELECT b, t.b FROM t
+----
+error: source "t" has 1 columns available but 2 columns specified
+
+# Ensure you can't reference the original table name
+build
+WITH t AS (SELECT a FROM x) SELECT a, x.t FROM t
+----
+error (42P01): no data source matches prefix: x
+
+# Nested WITH, name shadowing
+build
+WITH t(x) AS (WITH t(x) AS (SELECT 1) SELECT x * 10 FROM t) SELECT x + 2 FROM t
+----
+project
+ ├── columns: "?column?":3(int)
+ ├── project
+ │    ├── columns: "?column?":2(int)
+ │    ├── project
+ │    │    ├── columns: "?column?":1(int!null)
+ │    │    ├── values
+ │    │    │    └── tuple [type=tuple]
+ │    │    └── projections
+ │    │         └── const: 1 [type=int]
+ │    └── projections
+ │         └── mult [type=int]
+ │              ├── variable: ?column? [type=int]
+ │              └── const: 10 [type=int]
+ └── projections
+      └── plus [type=int]
+           ├── variable: ?column? [type=int]
+           └── const: 2 [type=int]

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -179,7 +179,7 @@ func (p *planner) SelectClause(
 	with *tree.With,
 	desiredTypes []types.T,
 	scanVisibility scanVisibility,
-) (planNode, error) {
+) (result planNode, err error) {
 	// We need to save and restore the previous value of the field in
 	// semaCtx in case we are recursively called within a subquery
 	// context.
@@ -193,7 +193,16 @@ func (p *planner) SelectClause(
 		return nil, err
 	}
 	if resetter != nil {
-		defer resetter(p)
+		defer func() {
+			if cteErr := resetter(p); cteErr != nil && err == nil {
+				// If no error was found in the inner planning but a CTE error
+				// is occurring during the final checks on the way back from
+				// the recursion, use that error as final error for this
+				// stage.
+				err = cteErr
+				result = nil
+			}
+		}()
 	}
 
 	if err := p.initFrom(ctx, r, parsed, scanVisibility); err != nil {
@@ -302,7 +311,7 @@ func (p *planner) SelectClause(
 		return nil, err
 	}
 
-	result := planNode(r)
+	result = planNode(r)
 	if groupComplex != nil {
 		// group.plan is already r.
 		result = groupComplex

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -101,6 +101,13 @@ func (p *planner) Select(
 
 	for s, ok := wrapped.(*tree.ParenSelect); ok; s, ok = wrapped.(*tree.ParenSelect) {
 		wrapped = s.Select.Select
+		if s.Select.With != nil {
+			if with != nil {
+				return nil, pgerror.UnimplementedWithIssueError(24303,
+					"multiple WITH clauses in parentheses")
+			}
+			with = s.Select.With
+		}
 		if s.Select.OrderBy != nil {
 			if orderBy != nil {
 				return nil, pgerror.NewErrorf(

--- a/pkg/sql/views.go
+++ b/pkg/sql/views.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -89,7 +90,7 @@ func (p *planner) analyzeViewQuery(
 
 	// TODO(a-robinson): Support star expressions as soon as we can (#10028).
 	if p.curPlan.hasStar {
-		return nil, nil, fmt.Errorf("views do not currently support * expressions")
+		return nil, nil, pgerror.UnimplementedWithIssueError(10028, "views do not currently support * expressions")
 	}
 
 	return p.curPlan.deps, planColumns(sourcePlan), nil

--- a/pkg/sql/with.go
+++ b/pkg/sql/with.go
@@ -137,8 +137,9 @@ func (p *planner) getCTEDataSource(tn *tree.TableName) (planDataSource, bool, er
 		return planDataSource{}, false, nil
 	}
 	// Iterate backward through the environment, most recent frame first.
-	for i := range p.curPlan.cteNameEnvironment {
-		frame := p.curPlan.cteNameEnvironment[len(p.curPlan.cteNameEnvironment)-1-i]
+	env := p.curPlan.cteNameEnvironment
+	for i := len(env) - 1; i >= 0; i-- {
+		frame := p.curPlan.cteNameEnvironment[i]
 		if cteSource, ok := frame[tn.TableName]; ok {
 			if cteSource.used {
 				// TODO(jordan): figure out how to lift this restriction.


### PR DESCRIPTION
Backport:
  * 1/1 commits from "opt: support single-use CTEs" (#30858)
  * 1/1 commits from "opt: remove some unimplementedfs" (#30939)
  * 1/1 commits from "sql: bark at unused CTEs containing mutations" (#31003)
  * 2/2 commits from "sql: do not silently ignore CTEs inside parentheses" (#31004)
  * 2/2 commits from "sql: properly support CTEs inside views" (#31007)

Please see individual PRs for details.

/cc @cockroachdb/release
