### PR TITLE
backport-2.1: sql: disable closed timestamp push in TestSchemaChangeAfterCreateInTxn

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -3214,6 +3214,18 @@ func TestSchemaChangeAfterCreateInTxn(t *testing.T) {
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 
+	// The schema change below can occasionally take more than
+	// 5 seconds and gets pushed by the closed timestamp mechanism
+	// in the read timestamp cache. Setting the closed timestamp
+	// target duration to a higher value.
+	// TODO(vivek): Remove the need to do this by removing the use of
+	// txn.CommitTimestamp() in schema changes.
+	if _, err := sqlDB.Exec(`
+SET CLUSTER SETTING kv.closed_timestamp.target_duration = '20s'
+`); err != nil {
+		t.Fatal(err)
+	}
+
 	// A large enough value that the backfills run as part of the
 	// schema change run in many chunks.
 	var maxValue = 4001


### PR DESCRIPTION
Backport 1/1 commits from #30997.

/cc @cockroachdb/release

---

The schema change in TestSchemaChangeAfterCreateInTxn can occasionally
take more than 5 seconds and would get pushed by the read timestamp
cache by the closed timestamp mechanism. This effectively disables the
closed timestamp push for this test.

fixes #30492

Release note: None
