### PR TITLE
storage: correctly handle empty forwarded proposals

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4075,6 +4075,13 @@ func (r *Replica) shouldDropForwardedProposalLocked(req *RaftMessageRequest) boo
 	for _, e := range req.Message.Entries {
 		switch e.Type {
 		case raftpb.EntryNormal:
+			if len(e.Data) == 0 {
+				// Don't drop empty proposals. We don't really expect those to come in from
+				// remote nodes (as they're proposed by new leaders), but it does happen.
+				// Whether these are dropped or not should not matter. We opt to not drop
+				// them.
+				return false
+			}
 			cmdID, _ := DecodeRaftCommand(e.Data)
 			if _, ok := r.mu.remoteProposals[cmdID]; !ok {
 				// Untracked remote proposal. Don't drop.
@@ -4109,12 +4116,12 @@ func (r *Replica) maybeTrackForwardedProposalLocked(rg *raft.RawNode, req *RaftM
 	for _, e := range req.Message.Entries {
 		switch e.Type {
 		case raftpb.EntryNormal:
-			cmdID, data := DecodeRaftCommand(e.Data)
-			if len(data) == 0 {
+			if len(e.Data) == 0 {
 				// An empty command is proposed to unquiesce a range and
 				// wake the leader. Don't keep track of these forwarded
 				// proposals because they will never be cleaned up.
 			} else {
+				cmdID, _ := DecodeRaftCommand(e.Data)
 				if r.mu.remoteProposals == nil {
 					r.mu.remoteProposals = map[storagebase.CmdIDKey]struct{}{}
 				}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -8492,7 +8492,7 @@ func TestReplicaShouldDropForwardedProposal(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	cmdSeen, cmdNotSeen := makeIDKey(), makeIDKey()
-	data, noData := []byte("data"), []byte("")
+	data := []byte("data")
 
 	testCases := []struct {
 		name                string
@@ -8501,6 +8501,30 @@ func TestReplicaShouldDropForwardedProposal(t *testing.T) {
 		expDrop             bool
 		expRemotePropsAfter int
 	}{
+		{
+			name:   "empty proposal (nil):",
+			leader: true,
+			msg: raftpb.Message{
+				Type: raftpb.MsgProp,
+				Entries: []raftpb.Entry{
+					{Type: raftpb.EntryNormal, Data: nil},
+				},
+			},
+			expDrop:             false,
+			expRemotePropsAfter: 1,
+		},
+		{
+			name:   "empty proposal (zero)",
+			leader: true,
+			msg: raftpb.Message{
+				Type: raftpb.MsgProp,
+				Entries: []raftpb.Entry{
+					{Type: raftpb.EntryNormal, Data: []byte{}},
+				},
+			},
+			expDrop:             false,
+			expRemotePropsAfter: 1,
+		},
 		{
 			name:   "new proposal",
 			leader: true,
@@ -8539,16 +8563,16 @@ func TestReplicaShouldDropForwardedProposal(t *testing.T) {
 			expRemotePropsAfter: 2,
 		},
 		{
-			name:   "empty proposal",
+			name:   "proposal with no data (not an empty proposal)",
 			leader: true,
 			msg: raftpb.Message{
 				Type: raftpb.MsgProp,
 				Entries: []raftpb.Entry{
-					{Type: raftpb.EntryNormal, Data: encodeRaftCommandV1(cmdNotSeen, noData)},
+					{Type: raftpb.EntryNormal, Data: encodeRaftCommandV1(cmdNotSeen, nil)},
 				},
 			},
 			expDrop:             false,
-			expRemotePropsAfter: 1,
+			expRemotePropsAfter: 2,
 		},
 		{
 			name:   "conf change",


### PR DESCRIPTION
The code assumed that an empty proposal would be a command ID with empty
data, but it's really the empty slice (command IDs+data is our encoding;
Raft itself emits an entry with completely blank data).

Fixes #31050.

Release note: None