### PR TITLE
workload: change the way we issue SQL for TPCC [DNM]

### DIFF
--- a/pkg/workload/connection.go
+++ b/pkg/workload/connection.go
@@ -28,6 +28,8 @@ type ConnFlags struct {
 	*pflag.FlagSet
 	DBOverride  string
 	Concurrency int
+	// Method for issuing queries; see SQLRunner.
+	Method string
 }
 
 // NewConnFlags returns an initialized ConnFlags.
@@ -38,12 +40,14 @@ func NewConnFlags(genFlags *Flags) *ConnFlags {
 		`Override for the SQL database to use. If empty, defaults to the generator name`)
 	c.IntVar(&c.Concurrency, `concurrency`, 2*runtime.NumCPU(),
 		`Number of concurrent workers`)
+	c.StringVar(&c.Method, `method`, `prepare`, `SQL issue method (prepare, noprepare)`)
 	genFlags.AddFlagSet(c.FlagSet)
 	if genFlags.Meta == nil {
 		genFlags.Meta = make(map[string]FlagMeta)
 	}
 	genFlags.Meta[`db`] = FlagMeta{RuntimeOnly: true}
 	genFlags.Meta[`concurrency`] = FlagMeta{RuntimeOnly: true}
+	genFlags.Meta[`method`] = FlagMeta{RuntimeOnly: true}
 	return c
 }
 

--- a/pkg/workload/sql_runner.go
+++ b/pkg/workload/sql_runner.go
@@ -1,0 +1,162 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package workload
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// SQLRunner is a helper for issuing SQL statements; it supports multiple
+// methods for issuing queries.
+//
+// Queries need to first be defined using calls to Define. Then the runner
+// must be initialized, after which we can use the handles returned by Define.
+//
+// Sample usage:
+//   sr := &workload.SQLRunner{}
+//
+//   sel:= sr.Define("SELECT x FROM t WHERE y = $1")
+//   ins:= sr.Define("INSERT INTO t(x, y) VALUES ($1, $2)")
+//
+//   err := sr.Init(ctx, db, flags)
+//   // [handle err]
+//   defer sr.Close()
+//
+//   row := sel.QueryRow(1)
+//   // [use row]
+//
+//   _, err := ins.Exec(5, 6)
+//   // [handle err]
+//
+// A runner should typically be associated with a single worker.
+type SQLRunner struct {
+	initialized bool
+	stmts       []*stmt
+}
+
+type stmt struct {
+	sql         string
+	initialized bool
+	prepared    *gosql.Stmt
+}
+
+type StmtHandle struct {
+	s *stmt
+}
+
+// Define creates a handle for the given statement. The handle can be used after
+// Init is called.
+func (sr *SQLRunner) Define(sql string) StmtHandle {
+	if sr.initialized {
+		panic("Define can't be called after Init")
+	}
+	s := &stmt{sql: sql}
+	sr.stmts = append(sr.stmts, s)
+	return StmtHandle{s: s}
+}
+
+// Init initializes the runner; must be called after calls to Define and before
+// the StmtHandles are used.
+//
+// The way we issue queries is set by flags.Method:
+//
+//  - "prepare": we prepare the query during Init, then we reuse it. This results
+//    in a Bind and Execute on the server each time we run a query.
+//
+//  - "noprepare": each query is issued separately. This results in Parse,
+//    Bind, Execute on the server each time we run a query.
+//
+func (sr *SQLRunner) Init(ctx context.Context, db *gosql.DB, flags *ConnFlags) error {
+	switch strings.ToLower(flags.Method) {
+
+	case "prepare":
+		for _, s := range sr.stmts {
+			var err error
+			s.prepared, err = db.PrepareContext(ctx, s.sql)
+			if err != nil {
+				return errors.Wrapf(err, "preparing %s", s.sql)
+			}
+		}
+
+	case "noprepare":
+		// Nothing to do.
+
+	default:
+		return fmt.Errorf("unknown method %s", flags.Method)
+	}
+
+	for _, s := range sr.stmts {
+		s.initialized = true
+	}
+	return nil
+}
+
+// Close cleans up the SQLRunner.
+func (sr *SQLRunner) Close() {
+	for _, s := range sr.stmts {
+		s.initialized = false
+		if s.prepared != nil {
+			_ = s.prepared.Close()
+		}
+	}
+
+	sr.initialized = false
+}
+
+func (h StmtHandle) check() {
+	if !h.s.initialized {
+		panic("SQLRunner.Init not called")
+	}
+}
+
+// Exec executes a query that doesn't return rows.
+// See gosql.Tx.ExecContext.
+func (h StmtHandle) Exec(
+	ctx context.Context, tx *gosql.Tx, args ...interface{},
+) (gosql.Result, error) {
+	h.check()
+	if h.s.prepared != nil {
+		return tx.StmtContext(ctx, h.s.prepared).ExecContext(ctx, args...)
+	}
+	return tx.ExecContext(ctx, h.s.sql, args...)
+}
+
+// Query executes a query that returns rows.
+// See gosql.Tx.QueryContext.
+func (h StmtHandle) Query(
+	ctx context.Context, tx *gosql.Tx, args ...interface{},
+) (*gosql.Rows, error) {
+	h.check()
+	if h.s.prepared != nil {
+		return tx.StmtContext(ctx, h.s.prepared).QueryContext(ctx, args...)
+	}
+	return tx.QueryContext(ctx, h.s.sql, args...)
+}
+
+// QueryRow executes a query that is expected to return at most one row.
+// See gosql.Tx.QueryRowContext.
+func (h StmtHandle) QueryRow(ctx context.Context, tx *gosql.Tx, args ...interface{}) *gosql.Row {
+	h.check()
+	if h.s.prepared != nil {
+		return tx.StmtContext(ctx, h.s.prepared).QueryRowContext(ctx, args...)
+	}
+	return tx.QueryRowContext(ctx, h.s.sql, args...)
+}

--- a/pkg/workload/tpcc/delivery.go
+++ b/pkg/workload/tpcc/delivery.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/pkg/errors"
 )
 
@@ -48,6 +49,10 @@ import (
 type delivery struct {
 	config *tpcc
 	db     *gosql.DB
+	sr     workload.SQLRunner
+
+	selectNewOrder workload.StmtHandle
+	sumAmount      workload.StmtHandle
 }
 
 var _ tpccTx = &delivery{}
@@ -57,6 +62,24 @@ func createDelivery(ctx context.Context, config *tpcc, db *gosql.DB) (tpccTx, er
 		config: config,
 		db:     db,
 	}
+
+	del.selectNewOrder = del.sr.Define(`
+		SELECT no_o_id
+		FROM new_order
+		WHERE no_w_id = $1 AND no_d_id = $2
+		ORDER BY no_o_id ASC
+		LIMIT 1`,
+	)
+
+	del.sumAmount = del.sr.Define(`
+		SELECT sum(ol_amount) FROM order_line
+		WHERE ol_w_id = $1 AND ol_d_id = $2 AND ol_o_id = $3`,
+	)
+
+	if err := del.sr.Init(ctx, db, config.connFlags); err != nil {
+		return nil, err
+	}
+
 	return del, nil
 }
 
@@ -78,13 +101,7 @@ func (del *delivery) run(ctx context.Context, wID int) (interface{}, error) {
 			dIDolTotalPairs := make(map[int]float64)
 			for dID := 1; dID <= 10; dID++ {
 				var oID int
-				if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-					SELECT no_o_id
-					FROM new_order
-					WHERE no_w_id = %d AND no_d_id = %d
-					ORDER BY no_o_id ASC
-					LIMIT 1`,
-					wID, dID)).Scan(&oID); err != nil {
+				if err := del.selectNewOrder.QueryRow(ctx, tx, wID, dID).Scan(&oID); err != nil {
 					// If no matching order is found, the delivery of this order is skipped.
 					if err != gosql.ErrNoRows {
 						atomic.AddUint64(&del.config.auditor.skippedDelivieries, 1)
@@ -95,10 +112,9 @@ func (del *delivery) run(ctx context.Context, wID int) (interface{}, error) {
 				dIDoIDPairs[dID] = oID
 
 				var olTotal float64
-				if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-						SELECT sum(ol_amount) FROM order_line
-						WHERE ol_w_id = %d AND ol_d_id = %d AND ol_o_id = %d`,
-					wID, dID, oID)).Scan(&olTotal); err != nil {
+				if err := del.sumAmount.QueryRow(
+					ctx, tx, wID, dID, oID,
+				).Scan(&olTotal); err != nil {
 					return err
 				}
 				dIDolTotalPairs[dID] = olTotal

--- a/pkg/workload/tpcc/order_status.go
+++ b/pkg/workload/tpcc/order_status.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload"
 )
 
 // From the TPCC spec, section 2.6:
@@ -64,6 +65,12 @@ type customerData struct {
 type orderStatus struct {
 	config *tpcc
 	db     *gosql.DB
+	sr     workload.SQLRunner
+
+	selectByCustID   workload.StmtHandle
+	selectByLastName workload.StmtHandle
+	selectOrder      workload.StmtHandle
+	selectItems      workload.StmtHandle
 }
 
 var _ tpccTx = &orderStatus{}
@@ -73,6 +80,48 @@ func createOrderStatus(ctx context.Context, config *tpcc, db *gosql.DB) (tpccTx,
 		config: config,
 		db:     db,
 	}
+
+	// Select by customer id.
+	o.selectByCustID = o.sr.Define(`
+		SELECT c_balance, c_first, c_middle, c_last
+		FROM customer
+		WHERE c_w_id = $1 AND c_d_id = $2 AND c_id = $3`,
+	)
+
+	// TODO(radu): this is only useful for the heuristic planner.
+	indexStr := "@customer_idx"
+	if o.config.usePostgres {
+		indexStr = ""
+	}
+
+	// Pick the middle row, rounded up, from the selection by last name.
+	o.selectByLastName = o.sr.Define(fmt.Sprintf(`
+		SELECT c_id, c_balance, c_first, c_middle
+		FROM customer%s
+		WHERE c_w_id = $1 AND c_d_id = $2 AND c_last = $3
+		ORDER BY c_first ASC`, indexStr),
+	)
+
+	// Select the customer's order.
+	o.selectOrder = o.sr.Define(`
+		SELECT o_id, o_entry_d, o_carrier_id
+		FROM "order"
+		WHERE o_w_id = $1 AND o_d_id = $2 AND o_c_id = $3
+		ORDER BY o_id DESC
+		LIMIT 1`,
+	)
+
+	// Select the items from the customer's order.
+	o.selectItems = o.sr.Define(`
+		SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
+		FROM order_line
+		WHERE ol_w_id = $1 AND ol_d_id = $2 AND ol_o_id = $3`,
+	)
+
+	if err := o.sr.Init(ctx, db, config.connFlags); err != nil {
+		return nil, err
+	}
+
 	return o, nil
 }
 
@@ -104,27 +153,14 @@ func (o *orderStatus) run(ctx context.Context, wID int) (interface{}, error) {
 			// Select the customer
 			if d.cID != 0 {
 				// Case 1: select by customer id
-				if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-					SELECT c_balance, c_first, c_middle, c_last
-					FROM customer
-					WHERE c_w_id = %[1]d AND c_d_id = %[2]d AND c_id = %[3]d`,
-					wID, d.dID, d.cID),
+				if err := o.selectByCustID.QueryRow(
+					ctx, tx, wID, d.dID, d.cID,
 				).Scan(&d.cBalance, &d.cFirst, &d.cMiddle, &d.cLast); err != nil {
 					return errors.Wrap(err, "select by customer idfail")
 				}
 			} else {
 				// Case 2: Pick the middle row, rounded up, from the selection by last name.
-				indexStr := "@customer_idx"
-				if o.config.usePostgres {
-					indexStr = ""
-				}
-				queryStr := fmt.Sprintf(`
-					SELECT c_id, c_balance, c_first, c_middle
-					FROM customer%[1]s
-					WHERE c_w_id = %[2]d AND c_d_id = %[3]d AND c_last = '%[4]s'
-					ORDER BY c_first ASC`,
-					indexStr, wID, d.dID, d.cLast)
-				rows, err := tx.QueryContext(ctx, queryStr)
+				rows, err := o.selectByLastName.Query(ctx, tx, wID, d.dID, d.cLast)
 				if err != nil {
 					return errors.Wrap(err, "select by last name fail")
 				}
@@ -143,13 +179,9 @@ func (o *orderStatus) run(ctx context.Context, wID int) (interface{}, error) {
 				}
 				rows.Close()
 				if len(customers) == 0 {
-					return fmt.Errorf("found no customers matching query: %s", queryStr)
+					return errors.New("found no customers matching query orderStatus.selectByLastName")
 				}
-				cIdx := len(customers) / 2
-				if len(customers)%2 == 0 {
-					cIdx--
-				}
-
+				cIdx := (len(customers) - 1) / 2
 				c := customers[cIdx]
 				d.cID = c.cID
 				d.cBalance = c.cBalance
@@ -158,23 +190,14 @@ func (o *orderStatus) run(ctx context.Context, wID int) (interface{}, error) {
 			}
 
 			// Select the customer's order.
-			if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-				SELECT o_id, o_entry_d, o_carrier_id
-				FROM "order"
-				WHERE o_w_id = %[1]d AND o_d_id = %[2]d AND o_c_id = %[3]d
-				ORDER BY o_id DESC
-				LIMIT 1`,
-				wID, d.dID, d.cID),
+			if err := o.selectOrder.QueryRow(
+				ctx, tx, wID, d.dID, d.cID,
 			).Scan(&d.oID, &d.oEntryD, &d.oCarrierID); err != nil {
 				return errors.Wrap(err, "select order fail")
 			}
 
 			// Select the items from the customer's order.
-			rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
-				SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
-				FROM order_line
-				WHERE ol_w_id = %[1]d AND ol_d_id = %[2]d AND ol_o_id = %[3]d`,
-				wID, d.dID, d.oID))
+			rows, err := o.selectItems.Query(ctx, tx, wID, d.dID, d.oID)
 			if err != nil {
 				return errors.Wrap(err, "select items fail")
 			}

--- a/pkg/workload/tpcc/payment.go
+++ b/pkg/workload/tpcc/payment.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/pkg/errors"
 )
 
@@ -78,16 +79,84 @@ type paymentData struct {
 type payment struct {
 	config *tpcc
 	db     *gosql.DB
+	sr     workload.SQLRunner
+
+	updateWarehouse   workload.StmtHandle
+	updateDistrict    workload.StmtHandle
+	selectByLastName  workload.StmtHandle
+	updateWithPayment workload.StmtHandle
+	insertHistory     workload.StmtHandle
 }
 
 var _ tpccTx = &payment{}
 
 func createPayment(ctx context.Context, config *tpcc, db *gosql.DB) (tpccTx, error) {
-	n := &payment{
+	p := &payment{
 		config: config,
 		db:     db,
 	}
-	return n, nil
+
+	// Update warehouse with payment
+	p.updateWarehouse = p.sr.Define(`
+		UPDATE warehouse
+		SET w_ytd = w_ytd + $1
+		WHERE w_id = $2
+		RETURNING w_name, w_street_1, w_street_2, w_city, w_state, w_zip`,
+	)
+
+	// Update district with payment
+	p.updateDistrict = p.sr.Define(`
+		UPDATE district
+		SET d_ytd = d_ytd + $1
+		WHERE d_w_id = $2 AND d_id = $3
+		RETURNING d_name, d_street_1, d_street_2, d_city, d_state, d_zip`,
+	)
+
+	// TODD(radu): this is no longer necessary with the optimizer. Keep it for now
+	// for comparisons against the heuristic planner.
+	custIndexStr := "@customer_idx"
+	if config.usePostgres {
+		custIndexStr = ""
+	}
+
+	// 2.5.2.2 Case 2: Pick the middle row, rounded up, from the selection by last name.
+	p.selectByLastName = p.sr.Define(fmt.Sprintf(`
+		SELECT c_id
+		FROM customer%s
+		WHERE c_w_id = $1 AND c_d_id = $2 AND c_last = $3
+		ORDER BY c_first ASC`,
+		custIndexStr),
+	)
+
+	// Update customer with payment.
+	// If the customer has bad credit, update the customer's C_DATA and return
+	// the first 200 characters of it, which is supposed to get displayed by
+	// the terminal. See 2.5.3.3 and 2.5.2.2.
+	p.updateWithPayment = p.sr.Define(`
+		UPDATE customer
+		SET (c_balance, c_ytd_payment, c_payment_cnt, c_data) =
+		(c_balance - ($1:::float)::decimal, c_ytd_payment + ($1:::float)::decimal, c_payment_cnt + 1,
+			 case c_credit when 'BC' then
+			 left(c_id::text || c_d_id::text || c_w_id::text || ($5:::int)::text || ($6:::int)::text || ($1:::float)::text || c_data, 500)
+			 else c_data end)
+		WHERE c_w_id = $2 AND c_d_id = $3 AND c_id = $4
+		RETURNING c_first, c_middle, c_last, c_street_1, c_street_2,
+					c_city, c_state, c_zip, c_phone, c_since, c_credit,
+					c_credit_lim, c_discount, c_balance, case c_credit when 'BC' then left(c_data, 200) else '' end`,
+	)
+
+	// Insert history line.
+
+	p.insertHistory = p.sr.Define(`
+		INSERT INTO history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_amount, h_date, h_data)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+	)
+
+	if err := p.sr.Init(ctx, db, config.connFlags); err != nil {
+		return nil, err
+	}
+
+	return p, nil
 }
 
 func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
@@ -135,23 +204,15 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
 		func(tx *gosql.Tx) error {
 			var wName, dName string
 			// Update warehouse with payment
-			if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-				UPDATE warehouse
-				SET w_ytd = w_ytd + %[1]f
-				WHERE w_id = %[2]d
-				RETURNING w_name, w_street_1, w_street_2, w_city, w_state, w_zip`,
-				d.hAmount, wID),
+			if err := p.updateWarehouse.QueryRow(
+				ctx, tx, d.hAmount, wID,
 			).Scan(&wName, &d.wStreet1, &d.wStreet2, &d.wCity, &d.wState, &d.wZip); err != nil {
 				return err
 			}
 
 			// Update district with payment
-			if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-				UPDATE district
-				SET d_ytd = d_ytd + %[1]f
-				WHERE d_w_id = %[2]d AND d_id = %[3]d
-				RETURNING d_name, d_street_1, d_street_2, d_city, d_state, d_zip`,
-				d.hAmount, wID, d.dID),
+			if err := p.updateDistrict.QueryRow(
+				ctx, tx, d.hAmount, wID, d.dID,
 			).Scan(&dName, &d.dStreet1, &d.dStreet2, &d.dCity, &d.dState, &d.dZip); err != nil {
 				return err
 			}
@@ -160,16 +221,7 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
 			// then proceed.
 			if d.cID == 0 {
 				// 2.5.2.2 Case 2: Pick the middle row, rounded up, from the selection by last name.
-				indexStr := "@customer_idx"
-				if p.config.usePostgres {
-					indexStr = ""
-				}
-				rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
-					SELECT c_id
-					FROM customer%[1]s
-					WHERE c_w_id = %[2]d AND c_d_id = %[3]d AND c_last = '%[4]s'
-					ORDER BY c_first ASC`,
-					indexStr, wID, d.dID, d.cLast))
+				rows, err := p.selectByLastName.Query(ctx, tx, wID, d.dID, d.cLast)
 				if err != nil {
 					return errors.Wrap(err, "select by last name fail")
 				}
@@ -187,11 +239,7 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
 					return err
 				}
 				rows.Close()
-				cIdx := len(customers) / 2
-				if len(customers)%2 == 0 {
-					cIdx--
-				}
-
+				cIdx := (len(customers) - 1) / 2
 				d.cID = customers[cIdx]
 			}
 
@@ -199,18 +247,8 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
 			// If the customer has bad credit, update the customer's C_DATA and return
 			// the first 200 characters of it, which is supposed to get displayed by
 			// the terminal. See 2.5.3.3 and 2.5.2.2.
-			if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-				UPDATE customer
-				SET (c_balance, c_ytd_payment, c_payment_cnt, c_data) =
-					(c_balance - %[1]f, c_ytd_payment + %[1]f, c_payment_cnt + 1,
-					 case c_credit when 'BC' then
-					 left(c_id::text || c_d_id::text || c_w_id::text || %[5]d::text || %[6]d::text || %[1]f::text || c_data, 500)
-					 else c_data end)
-				WHERE c_w_id = %[2]d AND c_d_id = %[3]d AND c_id = %[4]d
-				RETURNING c_first, c_middle, c_last, c_street_1, c_street_2,
-						  c_city, c_state, c_zip, c_phone, c_since, c_credit,
-						  c_credit_lim, c_discount, c_balance, case c_credit when 'BC' then left(c_data, 200) else '' end`,
-				d.hAmount, d.cWID, d.cDID, d.cID, d.dID, wID),
+			if err := p.updateWithPayment.QueryRow(
+				ctx, tx, d.hAmount, d.cWID, d.cDID, d.cID, d.dID, wID,
 			).Scan(&d.cFirst, &d.cMiddle, &d.cLast, &d.cStreet1, &d.cStreet2,
 				&d.cCity, &d.cState, &d.cZip, &d.cPhone, &d.cSince, &d.cCredit,
 				&d.cCreditLim, &d.cDiscount, &d.cBalance, &d.cData,
@@ -221,11 +259,9 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
 			hData := fmt.Sprintf("%s    %s", wName, dName)
 
 			// Insert history line.
-			_, err := tx.ExecContext(ctx, fmt.Sprintf(`
-				INSERT INTO history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_amount, h_date, h_data)
-				VALUES (%[1]d, %[2]d, %[3]d, %[4]d, %[5]d, %[6]f, '%[7]s', '%[8]s')`,
-				d.cID, d.cDID, d.cWID, d.dID, wID, d.hAmount,
-				d.hDate.Format("2006-01-02 15:04:05"), hData),
+			_, err := p.insertHistory.Exec(
+				ctx, tx,
+				d.cID, d.cDID, d.cWID, d.dID, wID, d.hAmount, d.hDate.Format("2006-01-02 15:04:05"), hData,
 			)
 			return err
 		}); err != nil {

--- a/pkg/workload/tpcc/stock_level.go
+++ b/pkg/workload/tpcc/stock_level.go
@@ -17,13 +17,13 @@ package tpcc
 
 import (
 	gosql "database/sql"
-	"fmt"
 	"math/rand"
 
 	"context"
 
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload"
 )
 
 // 2.8 The Stock-Level Transaction
@@ -50,6 +50,10 @@ type stockLevelData struct {
 type stockLevel struct {
 	config *tpcc
 	db     *gosql.DB
+	sr     workload.SQLRunner
+
+	selectDNextOID    workload.StmtHandle
+	countRecentlySold workload.StmtHandle
 }
 
 var _ tpccTx = &stockLevel{}
@@ -59,6 +63,34 @@ func createStockLevel(ctx context.Context, config *tpcc, db *gosql.DB) (tpccTx, 
 		config: config,
 		db:     db,
 	}
+
+	s.selectDNextOID = s.sr.Define(`
+		SELECT d_next_o_id
+		FROM district
+		WHERE d_w_id = $1 AND d_id = $2`,
+	)
+
+	// Count the number of recently sold items that have a stock level below
+	// the threshold.
+	// TODO(radu): we use count(DISTINCT s_i_id) because DISTINCT inside
+	// aggregates was not supported by the optimizer. This can be cleaned up.
+	s.countRecentlySold = s.sr.Define(`
+		SELECT count(*) FROM (
+			SELECT DISTINCT s_i_id
+			FROM order_line
+			JOIN stock
+			ON s_i_id=ol_i_id AND s_w_id=ol_w_id
+			WHERE ol_w_id = $1
+				AND ol_d_id = $2
+				AND ol_o_id BETWEEN $3 - 20 AND $3 - 1
+				AND s_quantity < $4
+		)`,
+	)
+
+	if err := s.sr.Init(ctx, db, config.connFlags); err != nil {
+		return nil, err
+	}
+
 	return s, nil
 }
 
@@ -87,31 +119,16 @@ func (s *stockLevel) run(ctx context.Context, wID int) (interface{}, error) {
 			}
 
 			var dNextOID int
-			if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-				SELECT d_next_o_id
-				FROM district
-				WHERE d_w_id = %[1]d AND d_id = %[2]d`,
-				wID, d.dID),
+			if err := s.selectDNextOID.QueryRow(
+				ctx, tx, wID, d.dID,
 			).Scan(&dNextOID); err != nil {
 				return err
 			}
 
 			// Count the number of recently sold items that have a stock level below
 			// the threshold.
-			// Note: we don't use count(DISTINCT s_i_id) because DISTINCT inside
-			// aggregates is not yet supported by the optimizer.
-			return tx.QueryRowContext(ctx, fmt.Sprintf(`
-			  SELECT count(*) FROM (
-			  	SELECT DISTINCT s_i_id
-			  	FROM order_line
-			  	JOIN stock
-			  	ON s_i_id=ol_i_id AND s_w_id=ol_w_id
-			  	WHERE ol_w_id = %[1]d
-			  	  AND ol_d_id = %[2]d
-			  	  AND ol_o_id BETWEEN %[3]d - 20 AND %[3]d - 1
-			  	  AND s_quantity < %[4]d
-			  )`,
-				wID, d.dID, dNextOID, d.threshold),
+			return s.countRecentlySold.QueryRow(
+				ctx, tx, wID, d.dID, dNextOID, d.threshold,
 			).Scan(&d.lowStock)
 		}); err != nil {
 		return nil, err

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -49,8 +49,8 @@ type tpcc struct {
 	fks        bool
 	dbOverride string
 
-	txs []tx
-	// deck contains indexes into the txs slice.
+	txInfos []txInfo
+	// deck contains indexes into the txInfos slice.
 	deck []int
 
 	auditor *auditor
@@ -474,16 +474,12 @@ func (w *tpcc) Ops(urls []string, reg *workload.HistogramRegistry) (workload.Que
 		p := (warehouse * w.partitions) / w.activeWarehouses
 		dbs := partitionDBs[p]
 		db := dbs[warehouse%len(dbs)]
-		worker := &worker{
-			config:    w,
-			hists:     reg.GetHandle(),
-			idx:       workerIdx,
-			db:        db,
-			warehouse: warehouse + startWarehouse,
-			deckPerm:  make([]int, len(w.deck)),
-			permIdx:   len(w.deck),
+		worker, err := newWorker(
+			context.TODO(), w, db, reg.GetHandle(), workerIdx, warehouse+startWarehouse,
+		)
+		if err != nil {
+			return workload.QueryLoad{}, err
 		}
-		copy(worker.deckPerm, w.deck)
 
 		ql.WorkerFns = append(ql.WorkerFns, worker.run)
 	}

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -35,7 +35,8 @@ import (
 )
 
 type tpcc struct {
-	flags workload.Flags
+	flags     workload.Flags
+	connFlags *workload.ConnFlags
 
 	seed             int64
 	warehouses       int
@@ -140,6 +141,7 @@ var tpccMeta = workload.Meta{
 		g.flags.StringSliceVar(&g.zones, "zones", []string{}, "Zones for partitioning, the number of zones should match the number of partitions and the zones used to start cockroach.")
 
 		g.flags.BoolVar(&g.expensiveChecks, `expensive-checks`, false, `Run expensive checks`)
+		g.connFlags = workload.NewConnFlags(&g.flags)
 		return g
 	},
 }

--- a/pkg/workload/tpcc/worker.go
+++ b/pkg/workload/tpcc/worker.go
@@ -34,61 +34,61 @@ const (
 	numWorkersPerWarehouse = 10
 )
 
-type worker struct {
-	config    *tpcc
-	hists     *workload.Histograms
-	idx       int
-	db        *gosql.DB
-	warehouse int
-
-	deckPerm []int
-	permIdx  int
-}
-
+// tpccTX is an interface for running a TPCC transaction.
 type tpccTx interface {
-	run(ctx context.Context, config *tpcc, db *gosql.DB, wID int) (interface{}, error)
+	// run executes the TPCC transaction against the given warehouse ID.
+	run(ctx context.Context, wID int) (interface{}, error)
 }
 
-type tx struct {
-	tpccTx
-	weight     int     // percent likelihood that each transaction type is run
-	name       string  // display name
-	keyingTime int     // keying time in seconds, see 5.2.5.7
-	thinkTime  float64 // minimum mean of think time distribution, 5.2.5.7
+type createTxFn func(ctx context.Context, config *tpcc, db *gosql.DB) (tpccTx, error)
+
+// txInfo stores high-level information about the TPCC transactions. The create
+// function is used to create an object that implements tpccTx.
+type txInfo struct {
+	name        string // display name
+	constructor createTxFn
+	keyingTime  int     // keying time in seconds, see 5.2.5.7
+	thinkTime   float64 // minimum mean of think time distribution, 5.2.5.7
+	weight      int     // percent likelihood that each transaction type is run
 }
 
-var allTxs = [...]tx{
+var allTxs = [...]txInfo{
 	{
-		tpccTx: newOrder{}, name: "newOrder",
-		keyingTime: 18,
-		thinkTime:  12,
+		name:        "newOrder",
+		constructor: createNewOrder,
+		keyingTime:  18,
+		thinkTime:   12,
 	},
 	{
-		tpccTx: payment{}, name: "payment",
-		keyingTime: 3,
-		thinkTime:  12,
+		name:        "payment",
+		constructor: createPayment,
+		keyingTime:  3,
+		thinkTime:   12,
 	},
 	{
-		tpccTx: orderStatus{}, name: "orderStatus",
-		keyingTime: 2,
-		thinkTime:  10,
+		name:        "orderStatus",
+		constructor: createOrderStatus,
+		keyingTime:  2,
+		thinkTime:   10,
 	},
 	{
-		tpccTx: delivery{}, name: "delivery",
-		keyingTime: 2,
-		thinkTime:  5,
+		name:        "delivery",
+		constructor: createDelivery,
+		keyingTime:  2,
+		thinkTime:   5,
 	},
 	{
-		tpccTx: stockLevel{}, name: "stockLevel",
-		keyingTime: 2,
-		thinkTime:  5,
+		name:        "stockLevel",
+		constructor: createStockLevel,
+		keyingTime:  2,
+		thinkTime:   5,
 	},
 }
 
 func initializeMix(config *tpcc) error {
-	config.txs = append([]tx(nil), allTxs[0:]...)
+	config.txInfos = append([]txInfo(nil), allTxs[0:]...)
 	nameToTx := make(map[string]int)
-	for i, tx := range config.txs {
+	for i, tx := range config.txInfos {
 		nameToTx[tx.name] = i
 	}
 
@@ -113,18 +113,57 @@ func initializeMix(config *tpcc) error {
 				`Invalid percentage mix %s: no such transaction %s`, config.mix, txName)
 		}
 
-		config.txs[i].weight = weight
+		config.txInfos[i].weight = weight
 		totalWeight += weight
 	}
 
 	config.deck = make([]int, 0, totalWeight)
-	for i, t := range config.txs {
+	for i, t := range config.txInfos {
 		for j := 0; j < t.weight; j++ {
 			config.deck = append(config.deck, i)
 		}
 	}
 
 	return nil
+}
+
+type worker struct {
+	config *tpcc
+	// txs maps 1-to-1 with config.txInfos.
+	txs       []tpccTx
+	hists     *workload.Histograms
+	idx       int
+	warehouse int
+
+	deckPerm []int
+	permIdx  int
+}
+
+func newWorker(
+	ctx context.Context,
+	config *tpcc,
+	db *gosql.DB,
+	hists *workload.Histograms,
+	workerIdx int,
+	warehouse int,
+) (*worker, error) {
+	w := &worker{
+		config:    config,
+		txs:       make([]tpccTx, len(config.txInfos)),
+		hists:     hists,
+		idx:       workerIdx,
+		warehouse: warehouse,
+		deckPerm:  append([]int(nil), config.deck...),
+		permIdx:   len(config.deck),
+	}
+	for i := range w.txs {
+		var err error
+		w.txs[i], err = config.txInfos[i].constructor(ctx, config, db)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return w, nil
 }
 
 func (w *worker) run(ctx context.Context) error {
@@ -140,9 +179,10 @@ func (w *worker) run(ctx context.Context) error {
 	}
 	// Move through our permutation slice until its exhausted, using each value to
 	// to index into our deck of transactions, which contains indexes into the
-	// txs slice.
+	// txInfos / txs slices.
 	opIdx := w.deckPerm[w.permIdx]
-	t := w.config.txs[opIdx]
+	txInfo := &w.config.txInfos[opIdx]
+	tx := w.txs[opIdx]
 	w.permIdx++
 
 	warehouseID := w.warehouse
@@ -152,19 +192,19 @@ func (w *worker) run(ctx context.Context) error {
 		// Wait out the entire keying and think time even if the context is
 		// expired. This prevents all workers from immediately restarting when
 		// the workload's ramp period expires, which can overload a cluster.
-		time.Sleep(time.Duration(t.keyingTime) * time.Second)
+		time.Sleep(time.Duration(txInfo.keyingTime) * time.Second)
 	}
 
 	// Run transactions with a background context because we don't want to
 	// cancel them when the context expires. Instead, let them finish normally
 	// but don't account for them in the histogram.
 	start := timeutil.Now()
-	if _, err := t.run(context.Background(), w.config, w.db, warehouseID); err != nil {
-		return errors.Wrapf(err, "error in %s", t.name)
+	if _, err := tx.run(context.Background(), warehouseID); err != nil {
+		return errors.Wrapf(err, "error in %s", txInfo.name)
 	}
 	if ctx.Err() == nil {
 		elapsed := timeutil.Since(start)
-		w.hists.Get(t.name).Record(elapsed)
+		w.hists.Get(txInfo.name).Record(elapsed)
 	}
 
 	if w.config.doWaits {
@@ -172,9 +212,9 @@ func (w *worker) run(ctx context.Context) error {
 		// distribution. Think time = -log(r) * u, where r is a uniform random number
 		// between 0 and 1 and u is the mean think time per operation.
 		// Each distribution is truncated at 10 times its mean value.
-		thinkTime := -math.Log(rand.Float64()) * t.thinkTime
-		if thinkTime > (t.thinkTime * 10) {
-			thinkTime = t.thinkTime * 10
+		thinkTime := -math.Log(rand.Float64()) * txInfo.thinkTime
+		if thinkTime > (txInfo.thinkTime * 10) {
+			thinkTime = txInfo.thinkTime * 10
 		}
 		time.Sleep(time.Duration(thinkTime) * time.Second)
 	}


### PR DESCRIPTION
This PR changes the SQL issue method for the TPCC workload (for the queries that don't use variable-length tuples).

Before, we were putting the entire query in a single string (no parameters) and it was issued as a "simple query". After, we issue with parameters and support two methods. With `--method=prepare`, we prepare once per session and re-execute the same query. With `--method=noprepare`, we don't prepare explicitly, which internally results in each statement being prepared and executed every time.

I made some test runs and I'm baffled at the results (link below). I expected `prepare` to be the fastest but it is the slowest. I can't understand how it can be slower than `noprepare`.. These were interleaved runs on a single-node gceworker (which ran both the workload and the server). Maybe I'm missing some subtlety of `lib/pq` and `Tx.Stmt`? (CC @mjibson)

https://docs.google.com/spreadsheets/d/14TrUwte2QMN6L3y_H6RRtrYt1q9xJkm5yF5CNX9U3X0/edit?usp=sharing


#### workload: add SQLRunner

A common facility for issuing SQL queries. It supports multiple
issuing methods, speciifed the `--method` flag:
 - prepare: each statement is prepared once per session and then
   reused.
 - noprepare: each statement is executed directly (which internally
   is equivalent to preparing and executing each statement
   separately).

#### workload: refactor tpccTx

Refactoring tpccTx to allow per-worker state. This will be necessary
for preparing statements in advance.

#### workload: use SQLRunner for queries without tuples

Switch TPCC to use SQLRunner for queries that have a fixed number of
arguments.