### PR TITLE
sql: Apply timeouts to generators

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -870,3 +870,16 @@ rows affected: 1
 
 statement ok
 DROP SEQUENCE sv
+
+# Check that generators can be interrupted by statement timeouts.
+subtest generator_timeout
+
+statement ok
+SET statement_timeout = 1
+
+statement error pq: query execution canceled due to statement timeout
+select * from generate_series(1,10000000) where generate_series = 0;
+
+# Clean up
+statement ok
+SET statement_timeout = 0


### PR DESCRIPTION
The value-generation loop didn't have a check for whether or not the execution
context had timed out.

Resolves #28864

Release note: None