### PR TITLE
release-2.1: server: Fix EnqueueRange to respect its NodeID parameter

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1567,18 +1567,16 @@ func (s *adminServer) EnqueueRange(
 	}
 
 	// If the request is targeted at this node, serve it directly. Otherwise,
-	// forward it to the appropriate node(s).
+	// forward it to the appropriate node(s). If no node was specified, forward
+	// it to all nodes.
 	if req.NodeID == s.server.NodeID() {
 		return s.enqueueRangeLocal(ctx, req)
-	}
-
-	isLiveMap := s.server.nodeLiveness.GetIsLiveMap()
-
-	// If a specific NodeID was requested, then shrink down isLiveMap to contain
-	// only it, since we choose which nodes to send the request to based on
-	// what's in isLiveMap.
-	if req.NodeID > 0 {
-		isLiveMap = map[roachpb.NodeID]bool{req.NodeID: isLiveMap[req.NodeID]}
+	} else if req.NodeID != 0 {
+		admin, err := s.dialNode(ctx, req.NodeID)
+		if err != nil {
+			return nil, err
+		}
+		return admin.EnqueueRange(ctx, req)
 	}
 
 	response := &serverpb.EnqueueRangeResponse{}

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -1465,6 +1465,8 @@ func TestEnqueueRange(t *testing.T) {
 		{0, "consistencyChecker", realRangeID, allReplicas, leaseholder},
 		{0, "TIMESERIESmaintenance", realRangeID, allReplicas, leaseholder},
 		{1, "raftlog", realRangeID, leaseholder, leaseholder},
+		{2, "raftlog", realRangeID, leaseholder, 1},
+		{3, "raftlog", realRangeID, leaseholder, 1},
 		// Error cases
 		{0, "gv", realRangeID, allReplicas, none},
 		{0, "GC", fakeRangeID, allReplicas, none},


### PR DESCRIPTION
Backport 1/1 commits from #31036.

/cc @cockroachdb/release

---

This got broken by some sloppy refactoring to make the method use
iterateNodes rather than a more one-off approach to forwarding the
request to nodes using the isLiveMap.

Release note (bug fix): Fix the _admin/v1/enqueue_range debug endpoint
to always respect its node_id parameter.

Found while testing #31035
