### PR TITLE
release-2.1: sql: remove protobuf output from `show zone configurations`

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1516,7 +1516,8 @@ func (s *adminServer) DataDistribution(
 
 	// Get zone configs.
 	// TODO(vilterp): this can be done in parallel with getting table/db names and replica counts.
-	zoneConfigsQuery := `SHOW ALL ZONE CONFIGURATIONS`
+	zoneConfigsQuery := `SELECT zone_id, cli_specifier, config_sql, config_protobuf 
+    FROM crdb_internal.zones WHERE cli_specifier IS NOT NULL`
 	rows2, _ /* cols */, err := s.server.internalExecutor.QueryWithUser(
 		ctx, "admin-replica-matrix", nil /* txn */, userName, zoneConfigsQuery,
 	)

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1644,11 +1644,16 @@ CREATE TABLE crdb_internal.ranges (
 
 // crdbInternalZonesTable decodes and exposes the zone configs in the
 // system.zones table.
+// The cli_specifier column is deprecated and only exists to be used
+// as a hidden field by the CLI for backwards compatibility. Use zone_name
+// instead.
 var crdbInternalZonesTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE crdb_internal.zones (
   zone_id          INT NOT NULL,
-  cli_specifier    STRING,
+  zone_name        STRING,
+  cli_specifier    STRING, -- this column is deprecated in favor of zone_name.
+                           -- It is kept for backwards compatibility with the CLI.
   config_yaml      STRING NOT NULL,
   config_sql       STRING, -- this column can be NULL if there is no specifier syntax
                            -- possible (e.g. the object was deleted).

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -194,10 +194,10 @@ SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name = ''
 ----
 descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
 
-query ITTTT colnames
+query ITTTTT colnames
 SELECT * FROM crdb_internal.zones WHERE false
 ----
-zone_id  cli_specifier  config_yaml  config_sql  config_protobuf
+zone_id  zone_name cli_specifier  config_yaml  config_sql  config_protobuf
 
 statement ok
 INSERT INTO system.zones (id, config) VALUES

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -81,15 +81,15 @@ SELECT * FROM [SHOW DATABASE]
 database
 test
 
-query ITTT colnames
+query TT colnames
 SELECT * FROM [SHOW ZONE CONFIGURATIONS] LIMIT 0
 ----
-zone_id  cli_specifier  config_sql  config_protobuf
+zone_name  config_sql
 
-query ITTT colnames
+query TT colnames
 SELECT * FROM [SHOW ZONE CONFIGURATION FOR TABLE system.users] LIMIT 0
 ----
-zone_id  cli_specifier  config_sql  config_protobuf
+zone_name  config_sql
 
 query T colnames
 SELECT * FROM [SHOW DATABASES]

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -226,7 +226,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         20 columns, 916 rows
+                     │                     size         20 columns, 917 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -217,7 +217,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         20 columns, 916 rows
+                     │                     size         20 columns, 917 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·

--- a/pkg/sql/show_zone_config.go
+++ b/pkg/sql/show_zone_config.go
@@ -37,25 +37,48 @@ type showZoneConfigNode struct {
 	run showZoneConfigRun
 }
 
+// These must match crdb_internal.zones.
+var showZoneConfigNodeColumns = sqlbase.ResultColumns{
+	{Name: "zone_id", Typ: types.Int, Hidden: true},
+	{Name: "zone_name", Typ: types.String},
+	{Name: "cli_specifier", Typ: types.String, Hidden: true},
+	{Name: "config_yaml", Typ: types.String, Hidden: true},
+	{Name: "config_sql", Typ: types.String},
+	{Name: "config_protobuf", Typ: types.Bytes, Hidden: true},
+}
+
+// These must match showZoneConfigColumns.
+const (
+	zoneIDCol int = iota
+	zoneNameCol
+	cliSpecifierCol
+	configYAMLCol
+	configSQLCol
+	configProtobufCol
+)
+
 func (p *planner) ShowZoneConfig(ctx context.Context, n *tree.ShowZoneConfig) (planNode, error) {
 	if n.ZoneSpecifier == (tree.ZoneSpecifier{}) {
-		return p.delegateQuery(ctx, "SHOW ZONE CONFIGURATIONS",
-			`SELECT zone_id, cli_specifier, config_sql, config_protobuf
+		planRenderNode, err := p.delegateQuery(ctx, "SHOW ZONE CONFIGURATIONS",
+			`SELECT zone_id, cli_specifier AS zone_name, cli_specifier, config_sql
          FROM crdb_internal.zones
         WHERE cli_specifier IS NOT NULL`, nil, nil)
+		if err != nil {
+			return planRenderNode, err
+		}
+
+		// Using planMutableColumns to hide the cli_specifier column,
+		// that needs to be supported for backwards compatibility with
+		// the CLI.
+		columns := planMutableColumns(planRenderNode)
+		columns[zoneIDCol].Hidden = true
+		columns[cliSpecifierCol].Hidden = true
+
+		return planRenderNode, nil
 	}
 	return &showZoneConfigNode{
 		zoneSpecifier: n.ZoneSpecifier,
 	}, nil
-}
-
-// These must match crdb_internal.zones.
-var showZoneConfigNodeColumns = sqlbase.ResultColumns{
-	{Name: "zone_id", Typ: types.Int},
-	{Name: "cli_specifier", Typ: types.String},
-	{Name: "config_yaml", Typ: types.String, Hidden: true},
-	{Name: "config_sql", Typ: types.String},
-	{Name: "config_protobuf", Typ: types.Bytes},
 }
 
 // showZoneConfigRun contains the run-time state of showZoneConfigNode
@@ -120,25 +143,26 @@ func generateZoneConfigIntrospectionValues(
 	values tree.Datums, zoneID tree.Datum, zs *tree.ZoneSpecifier, zone *config.ZoneConfig,
 ) error {
 	// Populate the ID column.
-	values[0] = zoneID
+	values[zoneIDCol] = zoneID
 
 	// Populate the specifier column.
 	if zs == nil {
-		values[1] = tree.DNull
+		values[zoneNameCol] = tree.DNull
 	} else {
-		values[1] = tree.NewDString(config.CLIZoneSpecifier(zs))
+		values[zoneNameCol] = tree.NewDString(config.CLIZoneSpecifier(zs))
 	}
+	values[cliSpecifierCol] = values[zoneNameCol]
 
 	// Populate the YAML column.
 	yamlConfig, err := yaml.Marshal(zone)
 	if err != nil {
 		return err
 	}
-	values[2] = tree.NewDString(string(yamlConfig))
+	values[configYAMLCol] = tree.NewDString(string(yamlConfig))
 
 	// Populate the SQL column.
 	if zs == nil {
-		values[3] = tree.DNull
+		values[configSQLCol] = tree.DNull
 	} else {
 		constraints, err := yamlMarshalFlow(config.ConstraintsList(zone.Constraints))
 		if err != nil {
@@ -161,7 +185,7 @@ func generateZoneConfigIntrospectionValues(
 		f.Printf("\tnum_replicas = %d,\n", zone.NumReplicas)
 		f.Printf("\tconstraints = %s,\n", lex.EscapeSQLString(constraints))
 		f.Printf("\tlease_preferences = %s", lex.EscapeSQLString(prefs))
-		values[3] = tree.NewDString(f.String())
+		values[configSQLCol] = tree.NewDString(f.String())
 	}
 
 	// Populate the protobuf column.
@@ -169,7 +193,7 @@ func generateZoneConfigIntrospectionValues(
 	if err != nil {
 		return err
 	}
-	values[4] = tree.NewDBytes(tree.DBytes(protoConfig))
+	values[configProtobufCol] = tree.NewDBytes(tree.DBytes(protoConfig))
 
 	return nil
 }

--- a/pkg/testutils/sqlutils/zone.go
+++ b/pkg/testutils/sqlutils/zone.go
@@ -111,7 +111,8 @@ func VerifyAllZoneConfigs(t testing.TB, sqlDB *SQLRunner, rows ...ZoneRow) {
 	}
 	sqlDB.CheckQueryResults(t, `
 SELECT zone_id, cli_specifier, config_protobuf
-  FROM [SHOW ALL ZONE CONFIGURATIONS]`, expected)
+  FROM crdb_internal.zones
+  WHERE cli_specifier IS NOT NULL`, expected)
 }
 
 // ZoneConfigExists returns whether a zone config with the provided cliSpecifier


### PR DESCRIPTION
Backport 1/1 commits from #30985.

/cc @cockroachdb/release

---

This shouldn't be in the output for the 2.1 release,
the tests that use this to verify zone configs now
can use the `crdb_internal.zones` table.

Also as suggested by @knz we could change the name 
of the column from `cli_specifier` to `zone_name` but still
have an alias to the old name for backwards compat with the cli.
I haven't seen that done anywhere though, how can I do 
that exactly?

Release note: output of `SHOW ZONE CONFIGURATIONS`
and `SHOW ZONE CONFIGURATION FOR` now only shows the zone name
and the SQL representation of the config.
