### PR TITLE
release-2.1: ui: Add debug page for the EnqueueRange admin endpoint

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1013,6 +1013,9 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 		s.raftLogQueue = newRaftLogQueue(s, s.db, s.cfg.Gossip)
 		s.raftSnapshotQueue = newRaftSnapshotQueue(s, s.cfg.Gossip)
 		s.consistencyQueue = newConsistencyQueue(s, s.cfg.Gossip)
+		// NOTE: If more queue types are added, please also add them to the list of
+		// queues on the EnqueueRange debug page as defined in
+		// pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
 		s.scanner.AddQueues(
 			s.gcQueue, s.mergeQueue, s.splitQueue, s.replicateQueue, s.replicaGCQueue,
 			s.raftLogQueue, s.raftSnapshotQueue, s.consistencyQueue)

--- a/pkg/ui/src/index.tsx
+++ b/pkg/ui/src/index.tsx
@@ -38,6 +38,7 @@ import Certificates from "src/views/reports/containers/certificates";
 import CommandQueue from "src/views/reports/containers/commandQueue";
 import CustomChart from "src/views/reports/containers/customChart";
 import Debug from "src/views/reports/containers/debug";
+import EnqueueRange from "src/views/reports/containers/enqueueRange";
 import ProblemRanges from "src/views/reports/containers/problemRanges";
 import Localities from "src/views/reports/containers/localities";
 import Network from "src/views/reports/containers/network";
@@ -134,8 +135,9 @@ ReactDOM.render(
         { /* debug pages */ }
         <Route path="debug">
           <IndexRoute component={Debug} />
-          <Route path="redux" component={ReduxDebug} />
-          <Route path="chart" component={CustomChart} />
+          <Route path="redux" component={ ReduxDebug } />
+          <Route path="chart" component={ CustomChart } />
+          <Route path="enqueue_range" component={ EnqueueRange } />
         </Route>
         <Route path="raft" component={ Raft }>
           <IndexRedirect to="ranges" />

--- a/pkg/ui/src/util/api.ts
+++ b/pkg/ui/src/util/api.ts
@@ -350,4 +350,3 @@ export function getDataDistribution(timeout?: moment.Duration): Promise<DataDist
 export function enqueueRange(req: EnqueueRangeRequestMessage, timeout?: moment.Duration): Promise<EnqueueRangeResponseMessage> {
   return timeoutFetch(serverpb.EnqueueRangeResponse, `${API_PREFIX}/enqueue_range`, req as any, timeout);
 }
-

--- a/pkg/ui/src/util/api.ts
+++ b/pkg/ui/src/util/api.ts
@@ -97,6 +97,9 @@ export type StatementsResponseMessage = protos.cockroach.server.serverpb.Stateme
 
 export type DataDistributionResponseMessage = protos.cockroach.server.serverpb.DataDistributionResponse;
 
+export type EnqueueRangeRequestMessage = protos.cockroach.server.serverpb.EnqueueRangeRequest;
+export type EnqueueRangeResponseMessage = protos.cockroach.server.serverpb.EnqueueRangeResponse;
+
 // API constants
 
 export const API_PREFIX = "_admin/v1";
@@ -343,3 +346,8 @@ export function getStatements(timeout?: moment.Duration): Promise<StatementsResp
 export function getDataDistribution(timeout?: moment.Duration): Promise<DataDistributionResponseMessage> {
   return timeoutFetch(serverpb.DataDistributionResponse, `${API_PREFIX}/data_distribution`, null, timeout);
 }
+
+export function enqueueRange(req: EnqueueRangeRequestMessage, timeout?: moment.Duration): Promise<EnqueueRangeResponseMessage> {
+  return timeoutFetch(serverpb.EnqueueRangeResponse, `${API_PREFIX}/enqueue_range`, req as any, timeout);
+}
+

--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -139,6 +139,13 @@ export default function Debug() {
             note="/debug/logspy?count=[count]&amp;duration=[duration]&amp;grep=[regexp]"
           />
         </DebugTableRow>
+        <DebugTableRow title="Enqueue Range">
+          <DebugTableLink
+            name="Run a range through an internal queue"
+            url="#/debug/enqueue_range"
+            note="#/debug/enqueue_range"
+          />
+        </DebugTableRow>
         <DebugTableRow title="Stopper">
           <DebugTableLink name="Active Tasks" url="/debug/stopper" />
         </DebugTableRow>

--- a/pkg/ui/src/views/reports/containers/enqueueRange/index.styl
+++ b/pkg/ui/src/views/reports/containers/enqueueRange/index.styl
@@ -1,0 +1,4 @@
+@require '~src/views/shared/util/table.styl'
+
+.enqueue-range-table
+  @extend $table-base

--- a/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
+++ b/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
@@ -7,6 +7,7 @@ import { connect } from "react-redux";
 import { enqueueRange } from "src/util/api";
 import { cockroach } from "src/js/protos";
 import Print from "src/views/reports/containers/range/print";
+import "./index.styl";
 
 import EnqueueRangeRequest = cockroach.server.serverpb.EnqueueRangeRequest;
 import EnqueueRangeResponse = cockroach.server.serverpb.EnqueueRangeResponse;
@@ -75,6 +76,35 @@ class EnqueueRange extends React.Component<EnqueueRangeProps & WithRouterProps, 
     );
   }
 
+  renderNodeResponse(details: EnqueueRangeResponse.IDetails) {
+    if (details.error) {
+      return <div><b>Error:</b> {details.error}</div>;
+    }
+
+    return (
+      <table className="enqueue-range-table">
+        <thead>
+          <tr className="enqueue-range-table__row enqueue-range-table__row--header">
+            <th className="enqueue-range-table__cell enqueue-range-table__cell--header">Timestamp</th>
+            <th className="enqueue-range-table__cell enqueue-range-table__cell--header">Message</th>
+          </tr>
+        </thead>
+        <tbody>
+          {details.events.map((event) => (
+            <tr className="enqueue-range-table__row--body">
+              <td className="enqueue-range-table__cell enqueue-range-table__cell--date">
+                {Print.Timestamp(event.time)}
+              </td>
+              <td className="enqueue-range-table__cell">
+                <pre>{event.message}</pre>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+
   renderResponse() {
     const { response } = this.state;
 
@@ -85,30 +115,13 @@ class EnqueueRange extends React.Component<EnqueueRangeProps & WithRouterProps, 
     return (
       <div>
         <h2>Enqueue Range Output</h2>
-        {
-          _.map(response.details, (details) => (
-            <div>
-              <h3>Node n{details.node_id}</h3>
-              <table className="enqueue-range-table">
-                <tbody>
-                  <tr className="enqueue-range-table__row enqueue-range-table__row--header">
-                    <th className="enqueue-range-table__cell enqueue-range-table__cell--header">Timestamp</th>
-                    <th className="enqueue-range-table__cell enqueue-range-table__cell--header">Message</th>
-                  </tr>
-                  {
-                    _.map(details.events, (event) => (
-                      <tr className="enqueue-range-table__row">
-                        <td className="enqueue-range-table__cell enqueue-range-table__cell--date">{Print.Timestamp(event.time)}</td>
-                        <td className="enqueue-range-table__cell">{event.message}</td>
-                      </tr>
-                    ))
-                  }
-                </tbody>
-              </table>
-            {details.error ? <div><b>Error:</b> {details.error}</div> : null}
-            </div>
-          ))
-        }
+        {response.details.map((details) => (
+          <div>
+            <h3>Node n{details.node_id}</h3>
+
+            {this.renderNodeResponse(details)}
+          </div>
+        ))}
       </div>
     );
   }

--- a/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
+++ b/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
@@ -1,0 +1,213 @@
+import React from "react";
+import Helmet from "react-helmet";
+import { withRouter, WithRouterProps } from "react-router";
+import { connect } from "react-redux";
+
+import { enqueueRange } from "src/util/api";
+import { AdminUIState } from "src/redux/state";
+import { cockroach } from "src/js/protos";
+import { getDataFromServer } from "src/util/dataFromServer";
+import Print from "src/views/reports/containers/range/print";
+
+import EnqueueRangeRequest = cockroach.server.serverpb.EnqueueRangeRequest;
+import EnqueueRangeResponse = cockroach.server.serverpb.EnqueueRangeResponse;
+
+interface EnqueueRangeProps {
+  handleEnqueueRange: (queue: string, rangeID: string, nodeID: string, skipShouldQueue: boolean) => Promise<EnqueueRangeResponse>;
+}
+
+interface EnqueueRangeState {
+  queue: string;
+  rangeID: string;
+  nodeID: string;
+  skipShouldQueue: boolean;
+  response: EnqueueRangeResponse;
+  error: Error;
+  // TODO: nodeID, skipShouldQueue
+}
+
+class EnqueueRange extends React.Component<EnqueueRangeProps & WithRouterProps, EnqueueRangeState> {
+  constructor(props: EnqueueRangeProps & WithRouterProps) {
+    super(props);
+    this.state = {
+      queue: "",
+      rangeID: "",
+      nodeID: "",
+      skipShouldQueue: false,
+    };
+  }
+
+  handleUpdateQueue = (evt: React.FormEvent<{ value: string }>) => {
+    this.setState({
+      queue: evt.currentTarget.value,
+    });
+  }
+
+  handleUpdateRangeID = (evt: React.FormEvent<{ value: string }>) => {
+    this.setState({
+      rangeID: evt.currentTarget.value,
+    });
+  }
+
+  handleUpdateNodeID = (evt: React.FormEvent<{ value: string }>) => {
+    this.setState({
+      nodeID: evt.currentTarget.value,
+    });
+  }
+
+  handleSubmit = (evt: React.FormEvent<any>) => {
+    evt.preventDefault();
+
+    this.props.handleEnqueueRange(
+      this.state.queue,
+      this.state.rangeID,
+      this.state.nodeID,
+      this.state.skipShouldQueue
+    ).then(
+      (response) => {
+        this.setState({ response: response, error: null });
+      },
+      (err) => {
+        this.setState({ response: null, error: err });
+      },
+    );
+  }
+
+  renderResponse() {
+    const { response } = this.state;
+
+    if (!response) {
+      return null;
+    }
+
+    return (
+      <div>
+        <h2>Enqueue Range Output</h2>
+        {
+          _.map(response.details, (details) => (
+            <div>
+              <h3>Node n{details.node_id}</h3>
+              <table className="enqueue-range-table">
+                <tbody>
+                  <tr className="enqueue-range-table__row enqueue-range-table__row--header">
+                    <th className="enqueue-range-table__cell enqueue-range-table__cell--header">Timestamp</th>
+                    <th className="enqueue-range-table__cell enqueue-range-table__cell--header">Message</th>
+                  </tr>
+                  {
+                    _.map(details.events, (event) => (
+                      <tr className="enqueue-range-table__row">
+                        <td className="enqueue-range-table__cell enqueue-range-table__cell--date">{Print.Timestamp(event.time)}</td>
+                        <td className="enqueue-range-table__cell">{event.message}</td>
+                      </tr>
+                    ))
+                  }
+                </tbody>
+              </table>
+            {details.error ? <div><b>Error:</b> {details.error}</div> : null}
+            </div>
+          ))
+        }
+      </div>
+    );
+  }
+
+  renderError() {
+    const { error } = this.state;
+
+    if (!error) {
+      return null;
+    }
+
+    return (
+      <div>Error running EnqueueRange: { error.message }</div>
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        <Helmet>
+          <title>Login</title>
+        </Helmet>
+        <div className="content">
+          <section className="section">
+            <div className="form-container">
+              <h1 className="heading">Manually enqueue range in a replica queue</h1>
+              <br />
+              <form onSubmit={this.handleSubmit} className="form-internal" method="post">
+                <input
+                  type="text"
+                  name="queue"
+                  className="input-text"
+                  onChange={this.handleUpdateQueue}
+                  value={this.state.queue}
+                  placeholder="Queue"
+                />
+                <br />
+                <input
+                  type="text"
+                  name="rangeID"
+                  className="input-text"
+                  onChange={this.handleUpdateRangeID}
+                  value={this.state.rangeID}
+                  placeholder="RangeID"
+                />
+                <br />
+                <input
+                  type="text"
+                  name="nodeID"
+                  className="input-text"
+                  onChange={this.handleUpdateNodeID}
+                  value={this.state.nodeID}
+                  placeholder="NodeID (optional)"
+                />
+                <br />
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={this.state.skipShouldQueue}
+                    name="skipShouldQueue"
+                    onChange={() => this.setState({ skipShouldQueue: !this.state.skipShouldQueue })}
+                  />
+                  SkipShouldQueue
+                </label>
+                <br />
+                <input
+                  type="submit"
+                  className="submit-button"
+                  value="Submit"
+                />
+              </form>
+            </div>
+          </section>
+        </div>
+        <div>
+          <section className="section">
+            {this.renderResponse()}
+            {this.renderError()}
+          </section>
+        </div>
+      </div>
+    );
+  }
+}
+
+// tslint:disable-next-line:variable-name
+const EnqueueRangeConnected = connect(
+  (state: AdminUIState) => {
+    return {};
+  },
+  (dispatch) => ({
+    handleEnqueueRange: (queue: string, rangeID: string, nodeID: string, skipShouldQueue: boolean) => {
+      const req = new EnqueueRangeRequest({
+        queue: queue,
+        range_id: rangeID,
+        node_id: nodeID,
+        skip_should_queue: skipShouldQueue,
+      });
+      return enqueueRange(req);
+    },
+  }),
+)(withRouter(EnqueueRange));
+
+export default EnqueueRangeConnected;

--- a/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
+++ b/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
@@ -12,6 +12,18 @@ import "./index.styl";
 import EnqueueRangeRequest = cockroach.server.serverpb.EnqueueRangeRequest;
 import EnqueueRangeResponse = cockroach.server.serverpb.EnqueueRangeResponse;
 
+const QUEUES = [
+  "replicate",
+  "gc",
+  "merge",
+  "split",
+  "replicaGC",
+  "raftlog",
+  "raftsnapshot",
+  "consistencyChecker",
+  "timeSeriesMaintenance",
+];
+
 interface EnqueueRangeProps {
   handleEnqueueRange: (queue: string, rangeID: number, nodeID: number, skipShouldQueue: boolean) => Promise<EnqueueRangeResponse>;
 }
@@ -29,7 +41,7 @@ class EnqueueRange extends React.Component<EnqueueRangeProps & WithRouterProps, 
   constructor(props: EnqueueRangeProps & WithRouterProps) {
     super(props);
     this.state = {
-      queue: "",
+      queue: QUEUES[0],
       rangeID: "",
       nodeID: "",
       skipShouldQueue: false,
@@ -150,14 +162,12 @@ class EnqueueRange extends React.Component<EnqueueRangeProps & WithRouterProps, 
               <h1 className="heading">Manually enqueue range in a replica queue</h1>
               <br />
               <form onSubmit={this.handleSubmit} className="form-internal" method="post">
-                <input
-                  type="text"
-                  name="queue"
-                  className="input-text"
-                  onChange={this.handleUpdateQueue}
-                  value={this.state.queue}
-                  placeholder="Queue"
-                />
+                Queue:{" "}
+                <select onChange={this.handleUpdateQueue}>
+                  {QUEUES.map((queue) => (
+                    <option key={queue} value={queue}>{queue}</option>
+                  ))}
+                </select>
                 <br />
                 <input
                   type="number"

--- a/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
+++ b/pkg/ui/src/views/reports/containers/enqueueRange/index.tsx
@@ -38,17 +38,14 @@ interface EnqueueRangeState {
 }
 
 class EnqueueRange extends React.Component<EnqueueRangeProps & WithRouterProps, EnqueueRangeState> {
-  constructor(props: EnqueueRangeProps & WithRouterProps) {
-    super(props);
-    this.state = {
-      queue: QUEUES[0],
-      rangeID: "",
-      nodeID: "",
-      skipShouldQueue: false,
-      response: null,
-      error: null,
-    };
-  }
+  state: EnqueueRangeState = {
+    queue: QUEUES[0],
+    rangeID: "",
+    nodeID: "",
+    skipShouldQueue: false,
+    response: null,
+    error: null,
+  };
 
   handleUpdateQueue = (evt: React.FormEvent<{ value: string }>) => {
     this.setState({
@@ -90,7 +87,7 @@ class EnqueueRange extends React.Component<EnqueueRangeProps & WithRouterProps, 
 
   renderNodeResponse(details: EnqueueRangeResponse.IDetails) {
     if (details.error) {
-      return <div><b>Error:</b> {details.error}</div>;
+      return <React.Fragment><b>Error:</b> {details.error}</React.Fragment>;
     }
 
     return (
@@ -125,7 +122,7 @@ class EnqueueRange extends React.Component<EnqueueRangeProps & WithRouterProps, 
     }
 
     return (
-      <div>
+      <React.Fragment>
         <h2>Enqueue Range Output</h2>
         {response.details.map((details) => (
           <div>
@@ -134,7 +131,7 @@ class EnqueueRange extends React.Component<EnqueueRangeProps & WithRouterProps, 
             {this.renderNodeResponse(details)}
           </div>
         ))}
-      </div>
+      </React.Fragment>
     );
   }
 
@@ -146,13 +143,13 @@ class EnqueueRange extends React.Component<EnqueueRangeProps & WithRouterProps, 
     }
 
     return (
-      <div>Error running EnqueueRange: { error.message }</div>
+      <React.Fragment>Error running EnqueueRange: { error.message }</React.Fragment>
     );
   }
 
   render() {
     return (
-      <div>
+      <React.Fragment>
         <Helmet>
           <title>Enqueue Range</title>
         </Helmet>
@@ -162,39 +159,47 @@ class EnqueueRange extends React.Component<EnqueueRangeProps & WithRouterProps, 
               <h1 className="heading">Manually enqueue range in a replica queue</h1>
               <br />
               <form onSubmit={this.handleSubmit} className="form-internal" method="post">
-                Queue:{" "}
-                <select onChange={this.handleUpdateQueue}>
-                  {QUEUES.map((queue) => (
-                    <option key={queue} value={queue}>{queue}</option>
-                  ))}
-                </select>
-                <br />
-                <input
-                  type="number"
-                  name="rangeID"
-                  className="input-text"
-                  onChange={this.handleUpdateRangeID}
-                  value={this.state.rangeID}
-                  placeholder="RangeID"
-                />
-                <br />
-                <input
-                  type="number"
-                  name="nodeID"
-                  className="input-text"
-                  onChange={this.handleUpdateNodeID}
-                  value={this.state.nodeID}
-                  placeholder="NodeID (optional)"
-                />
+                <label>
+                  Queue:{" "}
+                  <select onChange={this.handleUpdateQueue}>
+                    {QUEUES.map((queue) => (
+                      <option key={queue} value={queue}>{queue}</option>
+                    ))}
+                  </select>
+                </label>
                 <br />
                 <label>
+                  RangeID:{" "}
+                  <input
+                    type="number"
+                    name="rangeID"
+                    className="input-text"
+                    onChange={this.handleUpdateRangeID}
+                    value={this.state.rangeID}
+                    placeholder="RangeID"
+                  />
+                </label>
+                <br />
+                <label>
+                  NodeID:{" "}
+                  <input
+                    type="number"
+                    name="nodeID"
+                    className="input-text"
+                    onChange={this.handleUpdateNodeID}
+                    value={this.state.nodeID}
+                    placeholder="NodeID (optional)"
+                  />
+                </label>
+                <br />
+                <label>
+                  SkipShouldQueue:{" "}
                   <input
                     type="checkbox"
                     checked={this.state.skipShouldQueue}
                     name="skipShouldQueue"
                     onChange={() => this.setState({ skipShouldQueue: !this.state.skipShouldQueue })}
                   />
-                  SkipShouldQueue
                 </label>
                 <br />
                 <input
@@ -206,13 +211,11 @@ class EnqueueRange extends React.Component<EnqueueRangeProps & WithRouterProps, 
             </div>
           </section>
         </div>
-        <div>
-          <section className="section">
-            {this.renderResponse()}
-            {this.renderError()}
-          </section>
-        </div>
-      </div>
+        <section className="section">
+          {this.renderResponse()}
+          {this.renderError()}
+        </section>
+      </React.Fragment>
     );
   }
 }


### PR DESCRIPTION
Backport 5/5 commits from #31035.

/cc @cockroachdb/release

---

It's probably the worst-constructed page this UI has ever seen, but I
managed to get something working. Feedback appreciated, but keep in mind
that we'd like to squeeze something in for 2.1 (unless there are
security-related reasons to keep it out, in which case the endpoint
itself would be a concern moreseo than this page), since without this
sort of page using the endpoint is pretty tough.

The only issue I still have is that 400 errors don't display any detail
about the error, just "Bad Request", and I'm not sure how to fix that.
It's far from a show stopper, though.

Release note (admin ui change): Added a debug page with a form that lets
you manually enqueue a range in one of the various store-level replica
queues on the store of your choice. For advanced users only.

Fixes #28538
