### PR TITLE
release-2.1: sql: fix planning of wrapped local nodes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/statement_source
+++ b/pkg/sql/logictest/testdata/logic_test/statement_source
@@ -70,3 +70,23 @@ SELECT * FROM a ORDER BY b
 100  2
 -2   3
 7    8
+
+# Regression for #30936: ensure that wrapped planNodes with non-needed columns work ok
+
+statement ok
+CREATE TABLE b (a int, b int)
+
+query II
+SELECT * FROM b WHERE EXISTS (SELECT * FROM [INSERT INTO b VALUES (1,2) RETURNING a,b]);
+----
+1 2
+
+query I
+SELECT 1 FROM [INSERT INTO b VALUES(2,3) RETURNING b] JOIN [INSERT INTO b VALUES(4,5) RETURNING b] ON true;
+----
+1
+
+query III
+SELECT * FROM [INSERT INTO b VALUES(2,3) RETURNING b] JOIN [INSERT INTO b VALUES(4,5) RETURNING b, a] ON true;
+----
+3 5 4

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -105,7 +105,23 @@ func (p *planNodeToRowSource) SetInput(ctx context.Context, input distsqlrun.Row
 	return walkPlan(ctx, p.node, planObserver{
 		replaceNode: func(ctx context.Context, nodeName string, plan planNode) (planNode, error) {
 			if plan == p.firstNotWrapped {
-				return makeRowSourceToPlanNode(input, p, planColumns(p.firstNotWrapped), p.firstNotWrapped), nil
+				cols := planColumns(p.firstNotWrapped)
+				nOmitted := 0
+				for i := range cols {
+					if cols[i].Omitted {
+						nOmitted++
+					}
+				}
+				if nOmitted > 0 {
+					newCols := make(sqlbase.ResultColumns, 0, len(cols)-nOmitted)
+					for i := range cols {
+						if !cols[i].Omitted {
+							newCols = append(newCols, cols[i])
+						}
+					}
+					cols = newCols
+				}
+				return makeRowSourceToPlanNode(input, p, cols, p.firstNotWrapped), nil
 			}
 			return nil, nil
 		},


### PR DESCRIPTION
Backport 1/1 commits from #30942.

/cc @cockroachdb/release

---

Previously, wrapped local nodes that contained omitted columns could
crash the database in various ways. DistSQL physical planning wasn't
taking into account the omitted state of columns for wrapped nodes.

This commit fixes the issue.

Fixes #30936.

Release note: None
