### PR TITLE
sql: only quantize counts when scrubbing stmt stats

### DIFF
--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -342,8 +342,10 @@ func (s *sqlStats) getStmtStats(
 					data.LastErr = "scrubbed"
 				}
 
-				// Quantize the counts to avoid leaking information that way.
-				quantizeCounts(&data)
+				if scrub {
+					// Quantize the counts to avoid leaking information that way.
+					quantizeCounts(&data)
+				}
 
 				ret = append(ret, roachpb.CollectedStatementStatistics{Key: k, Stats: data})
 			}


### PR DESCRIPTION
The quantize breaks in the case of single-count statistics, which cause it to divide by zero.  Theoretically, this could be addressed in the quantize.  Practically, we don't want to quantize the counts we use on the Statements page anyway.

Fixes #30369.
Release note: None