### PR TITLE
ui: open docs links in new tab

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/components/instructionsBox/index.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/components/instructionsBox/index.tsx
@@ -35,6 +35,7 @@ class InstructionsBox extends React.Component<InstructionsBoxProps> {
             </span>{" "}
             <a
               href={docsURL.enableNodeMap}
+              target="_blank"
               className="instructions-box-top-bar__setup_link"
             >
               Follow our configuration guide

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/needEnterpriseLicense.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/needEnterpriseLicense.tsx
@@ -21,23 +21,25 @@ export default class NeedEnterpriseLicense extends React.Component<NodeCanvasCon
             <p className="need-license-blurb__text">
               The Node Map shows the geographical layout of your cluster, along
               with metrics and health indicators. To enable the Node Map,
-              request an <a href={docsURL.enterpriseLicensing}>Enterprise trial license</a> and refer to
-              this <a href={docsURL.enableNodeMap}>configuration guide</a>.
+              request an
+              <a href={docsURL.enterpriseLicensing} target="_blank">Enterprise trial license</a>
+              and refer to this
+              <a href={docsURL.enableNodeMap} target="_blank">configuration guide</a>.
             </p>
           </div>
-          <a href={docsURL.startTrial} className="need-license-blurb__trial-link">
+          <a href={docsURL.startTrial} className="need-license-blurb__trial-link" target="_blank">
             GET A 30-DAY ENTERPRISE TRIAL
           </a>
         </div>
         <div className="need-license-steps">
           <Step num={1} img={step1Img}>
-            <a href={docsURL.startTrial}>Get a trial license</a> delivered straight to your inbox.
+            <a href={docsURL.startTrial} target="_blank">Get a trial license</a> delivered straight to your inbox.
           </Step>
           <Step num={2} img={step2Img}>
             Activate the trial license with two simple SQL commands.
           </Step>
           <Step num={3} img={step3Img}>
-            Follow <a href={docsURL.enableNodeMap}>this guide</a> to configure localities
+            Follow <a href={docsURL.enableNodeMap} target="_blank">this guide</a> to configure localities
             and locations.
           </Step>
         </div>

--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -192,8 +192,9 @@ interface JobsTableProps {
 const titleTooltip = (
   <span>
     Some jobs can be paused or canceled through SQL. For details, view the docs
-    on the <a href={docsURL.pauseJob}><code>PAUSE JOB</code></a> and <a
-    href={docsURL.cancelJob}><code>CANCEL JOB</code></a> statements.
+    on the <a href={docsURL.pauseJob} target="_blank"><code>PAUSE JOB</code></a>
+    and <a href={docsURL.cancelJob} target="_blank"><code>CANCEL JOB</code></a>
+    statements.
   </span>
 );
 

--- a/pkg/ui/src/views/login/loginPage.tsx
+++ b/pkg/ui/src/views/login/loginPage.tsx
@@ -116,7 +116,7 @@ class LoginPage extends React.Component<LoginPageProps & WithRouterProps, LoginP
                 <span className="sql-keyword">;</span>
               </pre>
               <p className="aside">
-                <a href={docsURL.adminUILogin} className="login-docs-link">
+                <a href={docsURL.adminUILogin} className="login-docs-link" target="_blank">
                   <span className="login-docs-link__icon" dangerouslySetInnerHTML={trustIcon(docsIcon)} />
                   <span className="login-docs-link__text">Read more about configuring login</span>
                 </a>


### PR DESCRIPTION
Closes: #24780
Release note (admin ui change): Links to documentation pages
now open in a new tab.