### PR TITLE
storage: reduce commit index on quiescence heartbeat, don't drop them

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4882,22 +4882,8 @@ func (r *Replica) quiesceAndNotifyLocked(ctx context.Context, status *raft.Statu
 			Commit: commit,
 		}
 
-		if r.maybeCoalesceHeartbeat(ctx, msg, toReplica, fromReplica, quiesce) {
-			continue
-		}
-
-		req := &RaftMessageRequest{
-			RangeID:     r.RangeID,
-			ToReplica:   toReplica,
-			FromReplica: fromReplica,
-			Message:     msg,
-			Quiesce:     quiesce,
-		}
-		if !r.sendRaftMessageRequest(ctx, req) {
-			r.unquiesceLocked()
-			r.mu.droppedMessages++
-			r.mu.internalRaftGroup.ReportUnreachable(id)
-			return false
+		if !r.maybeCoalesceHeartbeat(ctx, msg, toReplica, fromReplica, quiesce) {
+			log.Fatalf(ctx, "failed to coalesce known heartbeat: %v", msg)
 		}
 	}
 	return true


### PR DESCRIPTION
Informs #30064.

53dc851 introduced logic to drop quiescence heartbeats to Replicas that
are not caught up to the leader. This turns out to be an issue in cases
where:
- a Range is quiescent
- a Replica needs a heartbeat to join a Raft group
- that Replica's node is unable to update its liveness record because
doing so depends on the Replica joining the Raft group
- so the Replica never gets any heartbeats and never joins the group

This change adjusts the logic. Instead of dropping these heartbeats, the
leader Replica now sends them, but with a reduced commit index and with
Quiesce equal to false.