### PR TITLE
release-2.1: sql, ui: include distsql queries in `sql.{service,exec}.latency` metrics 

### DIFF
--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -143,10 +143,9 @@ func (ex *connExecutor) recordStatementSummary(
 			}
 			m.DistSQLExecLatency.RecordValue(runLatRaw.Nanoseconds())
 			m.DistSQLServiceLatency.RecordValue(svcLatRaw.Nanoseconds())
-		} else {
-			m.SQLExecLatency.RecordValue(runLatRaw.Nanoseconds())
-			m.SQLServiceLatency.RecordValue(svcLatRaw.Nanoseconds())
 		}
+		m.SQLExecLatency.RecordValue(runLatRaw.Nanoseconds())
+		m.SQLServiceLatency.RecordValue(svcLatRaw.Nanoseconds())
 	}
 
 	planner.statsCollector.RecordStatement(

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -138,50 +138,6 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Service Latency: DistSQL, 99th percentile"
-      tooltip={
-        `The latency of distributed SQL statements serviced over
-           10 second periods ${tooltipSelection}.`
-      }
-    >
-      <Axis units={AxisUnits.Duration} label="latency">
-        {
-          _.map(nodeIDs, (node) => (
-            <Metric
-              key={node}
-              name="cr.node.sql.distsql.service.latency-p99"
-              title={nodeDisplayName(nodesSummary, node)}
-              sources={[node]}
-              downsampleMax
-            />
-          ))
-        }
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Service Latency: DistSQL, 90th percentile"
-      tooltip={
-        `The latency of distributed SQL statements serviced over
-           10 second periods ${tooltipSelection}.`
-      }
-    >
-      <Axis units={AxisUnits.Duration} label="latency">
-        {
-          _.map(nodeIDs, (node) => (
-            <Metric
-              key={node}
-              name="cr.node.sql.distsql.service.latency-p90"
-              title={nodeDisplayName(nodesSummary, node)}
-              sources={[node]}
-              downsampleMax
-            />
-          ))
-        }
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
       title="Execution Latency: 99th percentile"
       tooltip={
         `The 99th percentile of latency between query requests and responses over a


### PR DESCRIPTION
Backport 2/2 commits from #31098.

/cc @cockroachdb/release

---

Fixes #31093

Previously, the `sql.{service,exec}.latency` histogram metrics only
included local queries; distributed queries' latencies were recorded in
the `sql.distsql.{service,exec}.latency` metrics.

However, the UI had assumed that the `sql.service.latency` included all
SQL statements both local and distributed, and therefore had a graph of
it on the Overview dashboard, as well as having its most recent value
in the sidebar of the time series area.

With this change, the latencies of all statements are recorded in
`sql.{service,exec}.latency`, changing those metrics to mean what we had
assumed they meant. DistSQL queries will no longer be left out of this
prominent graph and sidebar metric.

Release note (admin ui change): The "service latency: {90,99}th
percentile" graphs on the Overview and SQL dashboard, as well as the P50
and P99 latency numbers in the time series area sidebar, now reflect
latencies of both local and distributed queries. Previously, they only
included local queries.

The second commit could also just remove those graphs entirely.
