### PR TITLE
ui: add empty state to databases page

### DIFF
--- a/pkg/ui/assets/tableIcon.svg
+++ b/pkg/ui/assets/tableIcon.svg
@@ -1,0 +1,6 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.09096 1V16.6522" stroke="#5F6C87" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17 5.86963H6.09091" stroke="#5F6C87" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17 11.4348H6.09091" stroke="#5F6C87" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M17 3C17 1.89543 16.1046 1 15 1H3C1.89543 1 1 1.89543 1 3V15C1 16.1046 1.89543 17 3 17H15C16.1046 17 17 16.1046 17 15V3Z" stroke="#5F6C87" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/pkg/ui/src/views/databases/containers/databaseTables/databaseTables.styl
+++ b/pkg/ui/src/views/databases/containers/databaseTables/databaseTables.styl
@@ -1,0 +1,14 @@
+.empty-state
+  display flex
+  justify-content center
+  align-items center
+  min-height 157px
+  flex-direction column
+
+  &__line
+    margin 12px
+
+.table-icon
+  position relative
+  top 3px
+  right 2px

--- a/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
@@ -14,6 +14,7 @@ import {
 } from "src/redux/apiReducers";
 
 import { Bytes } from "src/util/format";
+import { trustIcon } from "src/util/trust";
 
 import { TableInfo } from "src/views/databases/data/tableInfo";
 
@@ -21,11 +22,54 @@ import {
     DatabaseSummaryBase, DatabaseSummaryExplicitData, databaseDetails, tableInfos as selectTableInfos, grants,
 } from "src/views/databases/containers/databaseSummary";
 
+import tableIcon from "!!raw-loader!assets/tableIcon.svg";
+import "./databaseTables.styl";
+
 const databaseTablesSortSetting = new LocalSetting<AdminUIState, SortSetting>(
   "databases/sort_setting/tables", (s) => s.localSettings,
 );
 
 class DatabaseTableListSortedTable extends SortedTable<TableInfo> {}
+
+class DatabaseTableListEmpty extends React.Component {
+  render() {
+    return (
+      <table className="sort-table">
+        <thead>
+          <tr className="sort-table__row sort-table__row--header">
+            <th className="sort-table__cell sort-table__cell--sortable">
+              Table Name
+            </th>
+            <th className="sort-table__cell sort-table__cell--sortable">
+              Size
+            </th>
+            <th className="sort-table__cell sort-table__cell--sortable">
+              Ranges
+            </th>
+            <th className="sort-table__cell sort-table__cell--sortable">
+              # of Columns
+            </th>
+            <th className="sort-table__cell sort-table__cell--sortable">
+              # of Indices
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr className="sort-table__row sort-table__row--body">
+            <td className="sort-table__cell" colSpan={5}>
+              <div className="empty-state">
+                <div className="empty-state__line">
+                  <span className="table-icon" dangerouslySetInnerHTML={trustIcon(tableIcon)} />
+                  This database has no tables.
+                </div>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    );
+  }
+}
 
 // DatabaseSummaryTables displays a summary section describing the tables
 // contained in a single database.
@@ -55,7 +99,7 @@ class DatabaseSummaryTables extends DatabaseSummaryBase {
           <div className="l-columns__left">
             <div className="database-summary-table sql-table">
               {
-                (numTables === 0) ? "" :
+                (numTables === 0) ? <DatabaseTableListEmpty /> :
                   <DatabaseTableListSortedTable
                     data={tableInfos}
                     sortSetting={sortSetting}


### PR DESCRIPTION
Fixes: #27620
Fixes: #28234
Release note (admin ui change): Improve the view of databases with no tables.

---

Before:
<img width="1157" alt="screen shot 2018-10-09 at 11 59 43 am" src="https://user-images.githubusercontent.com/793969/46682254-0e0f3280-cbbb-11e8-8ed9-9cbca2a5c100.png">

After:
<img width="1151" alt="screen shot 2018-10-09 at 3 38 41 pm" src="https://user-images.githubusercontent.com/793969/46694006-81c03800-cbd9-11e8-982d-6083173fb583.png">
