### PR TITLE
roachtest: add a cluster.Start() flavor

### DIFF
--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -34,7 +34,7 @@ func registerAllocator(r *registry) {
 
 		// Start the first `start` nodes and restore the fixture
 		args := startArgs("--args=--vmodule=store_rebalancer=5,allocator=5,allocator_scorer=5,replicate_queue=5")
-		c.Start(ctx, c.Range(1, start), args)
+		c.Start(ctx, t, c.Range(1, start), args)
 		db := c.Conn(ctx, 1)
 		defer db.Close()
 
@@ -49,7 +49,7 @@ func registerAllocator(r *registry) {
 		m.Wait()
 
 		// Start the remaining nodes to kick off upreplication/rebalancing.
-		c.Start(ctx, c.Range(start+1, c.nodes), args)
+		c.Start(ctx, t, c.Range(start+1, c.nodes), args)
 
 		c.Run(ctx, c.Node(1), `./workload init kv --drop`)
 		for node := 1; node <= c.nodes; node++ {

--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -44,7 +44,7 @@ func registerBackup(r *registry) {
 			}
 
 			c.Put(ctx, cockroach, "./cockroach")
-			c.Start(ctx)
+			c.Start(ctx, t)
 			m := newMonitor(ctx, c)
 			m.Go(func(ctx context.Context) error {
 				t.Status(`running backup`)
@@ -67,7 +67,7 @@ func registerBackup(r *registry) {
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			c.Put(ctx, cockroach, "./cockroach")
 			c.Put(ctx, workload, "./workload")
-			c.Start(ctx)
+			c.Start(ctx, t)
 			conn := c.Conn(ctx, 1)
 
 			duration := 5 * time.Minute

--- a/pkg/cmd/roachtest/bank.go
+++ b/pkg/cmd/roachtest/bank.go
@@ -221,7 +221,7 @@ func (s *bankState) chaosMonkey(
 			}
 			c.l.Printf("round %d: restarting %d\n", curRound, i)
 			c.Stop(ctx, c.Node(i))
-			c.Start(ctx, c.Node(i))
+			c.Start(ctx, t, c.Node(i))
 			if stopClients {
 				// Reinitialize the client talking to the restarted node.
 				s.initClient(ctx, c, i)
@@ -319,7 +319,7 @@ func (s *bankState) waitClientsStop(
 
 func runBankClusterRecovery(ctx context.Context, t *test, c *cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx)
+	c.Start(ctx, t)
 
 	// TODO(peter): Run for longer when !local.
 	start := timeutil.Now()
@@ -370,7 +370,7 @@ func runBankClusterRecovery(ctx context.Context, t *test, c *cluster) {
 
 func runBankNodeRestart(ctx context.Context, t *test, c *cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx)
+	c.Start(ctx, t)
 
 	// TODO(peter): Run for longer when !local.
 	start := timeutil.Now()

--- a/pkg/cmd/roachtest/build_info.go
+++ b/pkg/cmd/roachtest/build_info.go
@@ -25,7 +25,7 @@ import (
 
 func runBuildInfo(ctx context.Context, t *test, c *cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx)
+	c.Start(ctx, t)
 
 	var details serverpb.DetailsResponse
 	url := `http://` + c.ExternalAdminUIAddr(ctx, c.Node(1))[0] + `/_status/details/local`

--- a/pkg/cmd/roachtest/cancel.go
+++ b/pkg/cmd/roachtest/cancel.go
@@ -42,7 +42,7 @@ func registerCancel(r *registry) {
 		queries []string, warehouses int, useDistsql bool) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Put(ctx, workload, "./workload", c.All())
-		c.Start(ctx, c.All())
+		c.Start(ctx, t, c.All())
 
 		m := newMonitor(ctx, c, c.All())
 		m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -99,7 +99,7 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 
 	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
 	c.Put(ctx, workload, "./workload", workloadNode)
-	c.Start(ctx, crdbNodes, startArgs(`--args=--vmodule=changefeed=2,poller=2`))
+	c.Start(ctx, t, crdbNodes, startArgs(`--args=--vmodule=changefeed=2,poller=2`))
 
 	tpcc := tpccWorkload{
 		sqlNodes:       crdbNodes,

--- a/pkg/cmd/roachtest/chaos.go
+++ b/pkg/cmd/roachtest/chaos.go
@@ -101,7 +101,7 @@ func (ch *Chaos) Runner(c *cluster, m *monitor) func(context.Context) error {
 			}
 			l.Printf("restarting %v after %s of downtime\n", target, downTime)
 			t.Reset(period)
-			c.Start(ctx, target)
+			c.Start(ctx, c.t.(*test), target)
 		}
 	}
 }

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -64,12 +64,12 @@ func runClearRange(ctx context.Context, t *test, c *cluster, aggressiveChecks bo
 	if aggressiveChecks {
 		// Run with an env var that runs a synchronous consistency check after each rebalance and merge.
 		// This slows down merges, so it might hide some races.
-		c.Start(ctx, startArgs(
+		c.Start(ctx, t, startArgs(
 			"--env=COCKROACH_CONSISTENCY_AGGRESSIVE=true",
 			"--env=COCKROACH_FATAL_ON_STATS_MISMATCH=true",
 		))
 	} else {
-		c.Start(ctx)
+		c.Start(ctx, t)
 	}
 
 	// Also restore a much smaller table. We'll use it to run queries against

--- a/pkg/cmd/roachtest/cli.go
+++ b/pkg/cmd/roachtest/cli.go
@@ -24,7 +24,7 @@ import (
 
 func runCLINodeStatus(ctx context.Context, t *test, c *cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx, c.Range(1, 3), startArgs("--sequential"))
+	c.Start(ctx, t, c.Range(1, 3), startArgs("--sequential"))
 
 	db := c.Conn(ctx, 1)
 	defer db.Close()

--- a/pkg/cmd/roachtest/clock_jump_crash.go
+++ b/pkg/cmd/roachtest/clock_jump_crash.go
@@ -38,7 +38,7 @@ func runClockJump(ctx context.Context, t *test, c *cluster, tc clockJumpTestCase
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 	}
 	c.Wipe(ctx)
-	c.Start(ctx)
+	c.Start(ctx, t)
 
 	db := c.Conn(ctx, c.nodes)
 	defer db.Close()

--- a/pkg/cmd/roachtest/clock_monotonic.go
+++ b/pkg/cmd/roachtest/clock_monotonic.go
@@ -38,7 +38,7 @@ func runClockMonotonicity(ctx context.Context, t *test, c *cluster, tc clockMono
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 	}
 	c.Wipe(ctx)
-	c.Start(ctx)
+	c.Start(ctx, t)
 
 	db := c.Conn(ctx, c.nodes)
 	defer db.Close()
@@ -68,7 +68,7 @@ func runClockMonotonicity(ctx context.Context, t *test, c *cluster, tc clockMono
 	t.Status("injecting offset")
 	offsetInjector.offset(ctx, c.nodes, tc.offset)
 	t.Status("starting cockroach post offset")
-	c.Start(ctx, c.Node(c.nodes))
+	c.Start(ctx, t, c.Node(c.nodes))
 
 	if !isAlive(db) {
 		t.Fatal("Node unexpectedly crashed")

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -905,6 +905,10 @@ func (c *cluster) StartE(ctx context.Context, opts ...option) error {
 	if atomic.LoadInt32(&interrupted) == 1 {
 		return fmt.Errorf("cluster.Start() interrupted")
 	}
+	// If the test failed (indicated by a canceled ctx), short-circuit.
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 	c.status("starting cluster")
 	defer c.status()
 	args := []string{
@@ -921,10 +925,6 @@ func (c *cluster) StartE(ctx context.Context, opts ...option) error {
 
 // Start is like StartE() except it takes a test and, on error, calls t.Fatal().
 func (c *cluster) Start(ctx context.Context, t *test, opts ...option) {
-	if t.Failed() {
-		// If the test has failed, don't try to limp along.
-		return
-	}
 	FatalIfErr(t, c.StartE(ctx, opts...))
 }
 

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -898,16 +898,12 @@ func roachprodArgs(opts []option) []string {
 	return args
 }
 
-// Start cockroach nodes on a subset of the cluster. The nodes parameter can
-// either be a specific node, empty (to indicate all nodes), or a pair of nodes
-// indicating a range.
-func (c *cluster) Start(ctx context.Context, opts ...option) {
-	if c.t.Failed() {
-		// If the test has failed, don't try to limp along.
-		return
-	}
+// StartE starts cockroach nodes on a subset of the cluster. The nodes parameter
+// can either be a specific node, empty (to indicate all nodes), or a pair of
+// nodes indicating a range.
+func (c *cluster) StartE(ctx context.Context, opts ...option) error {
 	if atomic.LoadInt32(&interrupted) == 1 {
-		c.t.Fatal("interrupted")
+		return fmt.Errorf("cluster.Start() interrupted")
 	}
 	c.status("starting cluster")
 	defer c.status()
@@ -920,9 +916,16 @@ func (c *cluster) Start(ctx context.Context, opts ...option) {
 	if encrypt && !argExists(args, "--encrypt") {
 		args = append(args, "--encrypt")
 	}
-	if err := execCmd(ctx, c.l, args...); err != nil {
-		c.t.Fatal(err)
+	return execCmd(ctx, c.l, args...)
+}
+
+// Start is like StartE() except it takes a test and, on error, calls t.Fatal().
+func (c *cluster) Start(ctx context.Context, t *test, opts ...option) {
+	if t.Failed() {
+		// If the test has failed, don't try to limp along.
+		return
 	}
+	FatalIfErr(t, c.StartE(ctx, opts...))
 }
 
 func argExists(args []string, target string) bool {

--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -43,7 +43,7 @@ func registerCopy(r *registry) {
 
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Put(ctx, workload, "./workload", c.All())
-		c.Start(ctx, c.All())
+		c.Start(ctx, t, c.All())
 
 		m := newMonitor(ctx, c, c.All())
 		m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/debug.go
+++ b/pkg/cmd/roachtest/debug.go
@@ -24,7 +24,7 @@ func registerDebug(r *registry) {
 	runDebug := func(ctx context.Context, t *test, c *cluster) {
 		nodes := c.nodes
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
-		c.Start(ctx, c.Range(1, nodes))
+		c.Start(ctx, t, c.Range(1, nodes))
 		db := c.Conn(ctx, nodes)
 
 		// Run debug zip command against a node, produce a zip file, extract it, and
@@ -94,7 +94,7 @@ func registerDebugHeap(r *registry) {
 	runDebug := func(ctx context.Context, t *test, c *cluster) {
 		nodes := c.nodes
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
-		c.Start(ctx, c.Range(1, nodes))
+		c.Start(ctx, t, c.Range(1, nodes))
 		db := c.Conn(ctx, nodes)
 
 		// Run debug zip command against a node, produce a zip file, extract it, and

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -55,10 +55,10 @@ func runDecommission(t *test, c *cluster, nodes int, duration time.Duration) {
 	c.Put(ctx, cockroach, "./cockroach", c.All())
 
 	for i := 1; i <= numDecom; i++ {
-		c.Start(ctx, c.Node(i), startArgs(fmt.Sprintf("-a=--attrs=node%d", i)))
+		c.Start(ctx, t, c.Node(i), startArgs(fmt.Sprintf("-a=--attrs=node%d", i)))
 	}
 
-	c.Start(ctx, c.Range(numDecom+1, nodes))
+	c.Start(ctx, t, c.Range(numDecom+1, nodes))
 	c.Run(ctx, c.Node(nodes), `./workload init kv --drop`)
 
 	waitReplicatedAwayFrom := func(downNodeID string) error {
@@ -223,7 +223,7 @@ func runDecommission(t *test, c *cluster, nodes int, duration time.Duration) {
 			db := c.Conn(ctx, 1)
 			defer db.Close()
 
-			c.Start(ctx, c.Node(node), startArgs(fmt.Sprintf("-a=--join %s --attrs=node%d",
+			c.Start(ctx, t, c.Node(node), startArgs(fmt.Sprintf("-a=--join %s --attrs=node%d",
 				c.InternalAddr(ctx, c.Node(nodes))[0], node)))
 		}
 		// TODO(tschottdorf): run some ui sanity checks about decommissioned nodes
@@ -257,7 +257,7 @@ func registerDecommission(r *registry) {
 func runDecommissionAcceptance(ctx context.Context, t *test, c *cluster) {
 	args := startArgs("--sequential", "--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx, args)
+	c.Start(ctx, t, args)
 
 	execCLI := func(
 		ctx context.Context,
@@ -469,7 +469,7 @@ func runDecommissionAcceptance(ctx context.Context, t *test, c *cluster) {
 
 		// Bring the node back up. It's still decommissioned, so it won't be of much use.
 		c.Stop(ctx, c.Node(3))
-		c.Start(ctx, c.Node(3), args)
+		c.Start(ctx, t, c.Node(3), args)
 
 		// Recommission. Welcome back!
 		if _, err = decommission(ctx, 2, c.Node(3), "recommission"); err != nil {
@@ -491,7 +491,7 @@ func runDecommissionAcceptance(ctx context.Context, t *test, c *cluster) {
 		if strings.Split(o, "\n")[1] != waitLiveDeprecated {
 			t.Fatal("missing deprecate message for --wait=live")
 		}
-		c.Start(ctx, c.Node(1), args)
+		c.Start(ctx, t, c.Node(1), args)
 		// Run a second time to wait until the replicas have all been GC'ed.
 		// Note that we specify "all" because even though the first node is
 		// now running, it may not be live by the time the command runs.

--- a/pkg/cmd/roachtest/disk_space.go
+++ b/pkg/cmd/roachtest/disk_space.go
@@ -65,7 +65,7 @@ func runDiskUsage(t *test, c *cluster, duration time.Duration, tc diskUsageTestC
 	ctx := context.Background()
 	c.Put(ctx, workload, "./workload", c.Node(numNodes))
 	c.Put(ctx, cockroach, "./cockroach", c.All())
-	c.Start(ctx, c.All())
+	c.Start(ctx, t, c.All())
 
 	loadDuration := " --duration=" + (duration / 2).String()
 

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -37,7 +37,7 @@ func registerDrop(r *registry) {
 	runDrop := func(ctx context.Context, t *test, c *cluster, warehouses, nodes int, initDiskSpace int) {
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Range(1, nodes))
-		c.Start(ctx, c.Range(1, nodes), startArgs("-e", "COCKROACH_MEMPROF_INTERVAL=15s"))
+		c.Start(ctx, t, c.Range(1, nodes), startArgs("-e", "COCKROACH_MEMPROF_INTERVAL=15s"))
 
 		m := newMonitor(ctx, c, c.Range(1, nodes))
 		m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/election.go
+++ b/pkg/cmd/roachtest/election.go
@@ -30,7 +30,7 @@ func registerElectionAfterRestart(r *registry) {
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			t.Status("starting up")
 			c.Put(ctx, cockroach, "./cockroach")
-			c.Start(ctx)
+			c.Start(ctx, t)
 
 			t.Status("creating table and splits")
 			c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
@@ -48,7 +48,7 @@ func registerElectionAfterRestart(r *registry) {
 
 			t.Status("restarting")
 			c.Stop(ctx)
-			c.Start(ctx)
+			c.Start(ctx, t)
 
 			// Each of the 100 ranges in this table must elect a leader for
 			// this query to complete. In naive raft, each of these

--- a/pkg/cmd/roachtest/encryption.go
+++ b/pkg/cmd/roachtest/encryption.go
@@ -29,7 +29,7 @@ func registerEncryption(r *registry) {
 	runEncryption := func(ctx context.Context, t *test, c *cluster) {
 		nodes := c.nodes
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
-		c.Start(ctx, c.Range(1, nodes), startArgs("--encrypt"))
+		c.Start(ctx, t, c.Range(1, nodes), startArgs("--encrypt"))
 
 		// Check that /_status/stores/local endpoint has encryption status.
 		for _, addr := range c.InternalAdminUIAddr(ctx, c.Range(1, nodes)) {
@@ -54,7 +54,7 @@ func registerEncryption(r *registry) {
 		}
 
 		// Restart node with encryption turned on to verify old key works.
-		c.Start(ctx, c.Range(1, nodes), startArgs("--encrypt"))
+		c.Start(ctx, t, c.Range(1, nodes), startArgs("--encrypt"))
 
 		testCLIGenKey := func(size int) error {
 			// Generate encryption store key through `./cockroach gen encryption-key -s=size aes-size.key`.

--- a/pkg/cmd/roachtest/event_log.go
+++ b/pkg/cmd/roachtest/event_log.go
@@ -34,7 +34,7 @@ func runEventLog(ctx context.Context, t *test, c *cluster) {
 	}
 
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx)
+	c.Start(ctx, t)
 
 	// Verify that "node joined" and "node restart" events are recorded whenever
 	// a node starts and contacts the cluster.
@@ -104,7 +104,7 @@ func runEventLog(ctx context.Context, t *test, c *cluster) {
 
 	// Stop and Start Node 3, and verify the node restart message.
 	c.Stop(ctx, c.Node(3))
-	c.Start(ctx, c.Node(3))
+	c.Start(ctx, t, c.Node(3))
 
 	err = retry.ForDuration(10*time.Second, func() error {
 		// Query all node restart events. There should only be one.

--- a/pkg/cmd/roachtest/gossip.go
+++ b/pkg/cmd/roachtest/gossip.go
@@ -38,7 +38,7 @@ import (
 func registerGossip(r *registry) {
 	runGossipChaos := func(ctx context.Context, t *test, c *cluster) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
-		c.Start(ctx, c.All(), startArgs("--sequential"))
+		c.Start(ctx, t, c.All(), startArgs("--sequential"))
 
 		gossipNetwork := func(node int) string {
 			const query = `
@@ -114,7 +114,7 @@ SELECT string_agg(source_id::TEXT || ':' || target_id::TEXT, ',')
 			deadNode = nodes.randNode()[0]
 			c.Stop(ctx, c.Node(deadNode))
 			waitForGossip()
-			c.Start(ctx, c.Node(deadNode))
+			c.Start(ctx, t, c.Node(deadNode))
 		}
 	}
 
@@ -247,7 +247,7 @@ func (g *gossipUtil) checkConnectedAndFunctional(ctx context.Context, t *test, c
 
 func runGossipPeerings(ctx context.Context, t *test, c *cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx)
+	c.Start(ctx, t)
 
 	// Repeatedly restart a random node and verify that all of the nodes are
 	// seeing the gossiped values.
@@ -271,13 +271,13 @@ func runGossipPeerings(ctx context.Context, t *test, c *cluster) {
 		node := c.All().randNode()
 		c.l.Printf("%d: restarting node %d\n", i, node[0])
 		c.Stop(ctx, node)
-		c.Start(ctx, node)
+		c.Start(ctx, t, node)
 	}
 }
 
 func runGossipRestart(ctx context.Context, t *test, c *cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx)
+	c.Start(ctx, t)
 
 	// Repeatedly stop and restart a cluster and verify that we can perform basic
 	// operations. This is stressing the gossiping of the first range descriptor
@@ -295,14 +295,14 @@ func runGossipRestart(ctx context.Context, t *test, c *cluster) {
 		c.Stop(ctx)
 
 		c.l.Printf("%d: restarting all nodes\n", i)
-		c.Start(ctx)
+		c.Start(ctx, t)
 	}
 }
 
 func runGossipRestartNodeOne(ctx context.Context, t *test, c *cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
 	// Reduce the scan max idle time to speed up evacuation of node 1.
-	c.Start(ctx, racks(c.nodes), startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms"))
+	c.Start(ctx, t, racks(c.nodes), startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms"))
 
 	db := c.Conn(ctx, 1)
 	defer db.Close()
@@ -397,7 +397,7 @@ SELECT count(replicas)
 	// Restart the other nodes. These nodes won't be able to talk to node 1 until
 	// node 1 talks to it (they have out of date address info). Node 1 needs
 	// incoming gossip info in order to determine where range 1 is.
-	c.Start(ctx, c.Range(2, c.nodes))
+	c.Start(ctx, t, c.Range(2, c.nodes))
 
 	// We need to override DB connection creation to use the correct port for
 	// node 1. This is more complicated than it should be and a limitation of the
@@ -442,7 +442,7 @@ func runCheckLocalityIPAddress(ctx context.Context, t *test, c *cluster) {
 		}
 		extAddr := externalIP[i-1]
 
-		c.Start(ctx, c.Node(i), startArgs("--racks=1",
+		c.Start(ctx, t, c.Node(i), startArgs("--racks=1",
 			fmt.Sprintf("--args=--locality-advertise-addr=rack=0@%s", extAddr)))
 	}
 

--- a/pkg/cmd/roachtest/hibernate.go
+++ b/pkg/cmd/roachtest/hibernate.go
@@ -38,7 +38,7 @@ func registerHibernate(r *registry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		c.Put(ctx, cockroach, "./cockroach", c.All())
-		c.Start(ctx, c.All())
+		c.Start(ctx, t, c.All())
 
 		t.Status("cloning hibernate and installing prerequisites")
 		c.Run(ctx, node, `rm -rf /mnt/data1/hibernate`)

--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -37,7 +37,7 @@ func registerHotSpotSplits(r *registry) {
 		appNode := c.Node(c.nodes)
 
 		c.Put(ctx, cockroach, "./cockroach", roachNodes)
-		c.Start(ctx, roachNodes)
+		c.Start(ctx, t, roachNodes)
 
 		c.Put(ctx, workload, "./workload", appNode)
 		c.Run(ctx, appNode, `./workload init kv --drop {pgurl:1}`)

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -30,7 +30,7 @@ func registerImportTPCC(r *registry) {
 		c.Put(ctx, cockroach, "./cockroach")
 		c.Put(ctx, workload, "./workload")
 		t.Status("starting csv servers")
-		c.Start(ctx)
+		c.Start(ctx, t)
 		c.Run(ctx, c.All(), `./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
 
 		t.Status("running workload")
@@ -74,7 +74,7 @@ func registerImportTPCH(r *registry) {
 			Stable: true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				c.Put(ctx, cockroach, "./cockroach")
-				c.Start(ctx)
+				c.Start(ctx, t)
 				conn := c.Conn(ctx, 1)
 				if _, err := conn.Exec(`
 					CREATE DATABASE csv;

--- a/pkg/cmd/roachtest/interleavedpartitioned.go
+++ b/pkg/cmd/roachtest/interleavedpartitioned.go
@@ -49,7 +49,7 @@ func registerInterleaved(r *registry) {
 		nodes := c.nodes
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Range(1, nodes))
-		c.Start(ctx, c.Range(1, nodes))
+		c.Start(ctx, t, c.Range(1, nodes))
 
 		zones := fmt.Sprintf(" --east-zone-name %s --west-zone-name %s --central-zone-name %s ",
 			config.eastName, config.westName, config.centralName)

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -32,7 +32,7 @@ func registerKV(r *registry) {
 		nodes := c.nodes - 1
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
-		c.Start(ctx, c.Range(1, nodes), encryption)
+		c.Start(ctx, t, c.Range(1, nodes), encryption)
 
 		t.Status("running workload")
 		m := newMonitor(ctx, c, c.Range(1, nodes))
@@ -90,7 +90,7 @@ func registerKVQuiescenceDead(r *registry) {
 			nodes := c.nodes - 1
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
-			c.Start(ctx, c.Range(1, nodes))
+			c.Start(ctx, t, c.Range(1, nodes))
 
 			run := func(cmd string, lastDown bool) {
 				n := nodes
@@ -172,7 +172,7 @@ func registerKVSplits(r *registry) {
 				nodes := c.nodes - 1
 				c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 				c.Put(ctx, workload, "./workload", c.Node(nodes+1))
-				c.Start(ctx, c.Range(1, nodes),
+				c.Start(ctx, t, c.Range(1, nodes),
 					startArgs(
 						"--env=COCKROACH_MEMPROF_INTERVAL=1m",
 						"--env=COCKROACH_DISABLE_QUIESCENCE="+strconv.FormatBool(!quiesce),
@@ -212,7 +212,7 @@ func registerKVScalability(r *registry) {
 		const maxPerNodeConcurrency = 64
 		for i := nodes; i <= nodes*maxPerNodeConcurrency; i += nodes {
 			c.Wipe(ctx, c.Range(1, nodes))
-			c.Start(ctx, c.Range(1, nodes))
+			c.Start(ctx, t, c.Range(1, nodes))
 
 			t.Status("running workload")
 			m := newMonitor(ctx, c, c.Range(1, nodes))

--- a/pkg/cmd/roachtest/large_range.go
+++ b/pkg/cmd/roachtest/large_range.go
@@ -72,7 +72,7 @@ func runLargeRangeSplits(ctx context.Context, t *test, c *cluster, size int) {
 
 	c.Put(ctx, cockroach, "./cockroach", c.All())
 	c.Put(ctx, workload, "./workload", c.All())
-	c.Start(ctx, c.All())
+	c.Start(ctx, t, c.All())
 
 	m := newMonitor(ctx, c, c.All())
 	m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/queue.go
+++ b/pkg/cmd/roachtest/queue.go
@@ -44,7 +44,7 @@ func runQueue(ctx context.Context, t *test, c *cluster) {
 	// Distribute programs to the correct nodes and start CockroachDB.
 	c.Put(ctx, cockroach, "./cockroach", c.Range(1, dbNodeCount))
 	c.Put(ctx, workload, "./workload", c.Node(workloadNode))
-	c.Start(ctx, c.Range(1, dbNodeCount))
+	c.Start(ctx, t, c.Range(1, dbNodeCount))
 
 	runQueueWorkload := func(duration time.Duration, initTables bool) {
 		m := newMonitor(ctx, c, c.Range(1, dbNodeCount))

--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -52,7 +52,7 @@ func registerRebalanceLoad(r *registry) {
 		c.Put(ctx, cockroach, "./cockroach", roachNodes)
 		args := startArgs("--sequential",
 			"--args=--vmodule=store_rebalancer=5,allocator=5,allocator_scorer=5,replicate_queue=5")
-		c.Start(ctx, roachNodes, args)
+		c.Start(ctx, t, roachNodes, args)
 
 		c.Put(ctx, workload, "./workload", appNode)
 		c.Run(ctx, appNode, `./workload init kv --drop {pgurl:1}`)

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -217,7 +217,7 @@ func registerRestore(r *registry) {
 			Stable: true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				c.Put(ctx, cockroach, "./cockroach")
-				c.Start(ctx)
+				c.Start(ctx, t)
 				m := newMonitor(ctx, c)
 
 				// Run the disk usage logger in the monitor to guarantee its

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -24,7 +24,7 @@ func registerRoachmart(r *registry) {
 	runRoachmart := func(ctx context.Context, t *test, c *cluster, partition bool) {
 		c.Put(ctx, cockroach, "./cockroach")
 		c.Put(ctx, workload, "./workload")
-		c.Start(ctx)
+		c.Start(ctx, t)
 
 		// TODO(benesch): avoid hardcoding this list.
 		nodes := []struct {

--- a/pkg/cmd/roachtest/scaledata.go
+++ b/pkg/cmd/roachtest/scaledata.go
@@ -78,7 +78,7 @@ func runSqlapp(ctx context.Context, t *test, c *cluster, app, flags string, dur 
 
 	c.Put(ctx, b, app, appNode)
 	c.Put(ctx, cockroach, "./cockroach", roachNodes)
-	c.Start(ctx, roachNodes)
+	c.Start(ctx, t, roachNodes)
 
 	// TODO(nvanbenschoten): We are currently running these consistency checks with
 	// basic chaos. We should also run them in more chaotic environments which

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -36,7 +36,7 @@ func registerSchemaChange(r *registry) {
 			c.Put(ctx, cockroach, "./cockroach")
 			c.Put(ctx, workload, "./workload")
 
-			c.Start(ctx, c.All())
+			c.Start(ctx, t, c.All())
 			db := c.Conn(ctx, 1)
 			defer db.Close()
 

--- a/pkg/cmd/roachtest/status_server.go
+++ b/pkg/cmd/roachtest/status_server.go
@@ -29,7 +29,7 @@ import (
 
 func runStatusServer(ctx context.Context, t *test, c *cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx)
+	c.Start(ctx, t)
 
 	// Get the ids for each node.
 	idMap := make(map[int]roachpb.NodeID)

--- a/pkg/cmd/roachtest/store_gen.go
+++ b/pkg/cmd/roachtest/store_gen.go
@@ -65,7 +65,7 @@ func registerStoreGen(r *registry, args []string) {
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			c.Put(ctx, cockroach, "./cockroach")
 			c.Put(ctx, workload, "./workload")
-			c.Start(ctx, startArgs("--sequential"))
+			c.Start(ctx, t, startArgs("--sequential"))
 
 			{
 				m := newMonitor(ctx, c)

--- a/pkg/cmd/roachtest/upgrade.go
+++ b/pkg/cmd/roachtest/upgrade.go
@@ -48,7 +48,7 @@ func registerUpgrade(r *registry) {
 		c.Put(ctx, b, "./cockroach", c.Range(1, nodes))
 		// Force disable encryption.
 		// TODO(mberhault): allow it once oldVersion >= 2.1.
-		c.Start(ctx, c.Range(1, nodes), startArgsDontEncrypt)
+		c.Start(ctx, t, c.Range(1, nodes), startArgsDontEncrypt)
 
 		const stageDuration = 30 * time.Second
 		const timeUntilStoreDead = 90 * time.Second
@@ -140,7 +140,7 @@ func registerUpgrade(r *registry) {
 				t.Fatal(err)
 			}
 			c.Put(ctx, cockroach, "./cockroach", c.Node(i))
-			c.Start(ctx, c.Node(i), startArgsDontEncrypt)
+			c.Start(ctx, t, c.Node(i), startArgsDontEncrypt)
 			if err := sleep(stageDuration); err != nil {
 				t.Fatal(err)
 			}
@@ -162,7 +162,7 @@ func registerUpgrade(r *registry) {
 			t.Fatal(err)
 		}
 		c.Put(ctx, cockroach, "./cockroach", c.Node(nodes))
-		c.Start(ctx, c.Node(nodes), startArgsDontEncrypt)
+		c.Start(ctx, t, c.Node(nodes), startArgsDontEncrypt)
 		if err := sleep(stageDuration); err != nil {
 			t.Fatal(err)
 		}
@@ -203,7 +203,7 @@ func registerUpgrade(r *registry) {
 		}
 
 		// Restart the previously stopped node.
-		c.Start(ctx, c.Node(nodes-1), startArgsDontEncrypt)
+		c.Start(ctx, t, c.Node(nodes-1), startArgsDontEncrypt)
 		if err := sleep(stageDuration); err != nil {
 			t.Fatal(err)
 		}
@@ -340,7 +340,7 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
 				for _, node := range nodes {
 					c.l.Printf("%s: upgrading node %d\n", newVersion, node)
 					c.Stop(ctx, c.Node(node))
-					c.Start(ctx, c.Node(node), args)
+					c.Start(ctx, t, c.Node(node), args)
 
 					checkNode(node, newVersion)
 
@@ -514,7 +514,7 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
 	// Hack to skip initializing settings which doesn't work on very old versions
 	// of cockroach.
 	c.Run(ctx, c.Node(1), "mkdir -p {store-dir} && touch {store-dir}/settings-initialized")
-	c.Start(ctx, nodes, args)
+	c.Start(ctx, t, nodes, args)
 
 	func() {
 		// Create a bunch of tables, over the batch size on which some migrations

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -47,7 +47,7 @@ func registerVersion(r *registry) {
 		c.Put(ctx, b, "./cockroach", c.Range(1, nodes))
 		// Force disable encryption.
 		// TODO(mberhault): allow it once version >= 2.1.
-		c.Start(ctx, c.Range(1, nodes), startArgsDontEncrypt)
+		c.Start(ctx, t, c.Range(1, nodes), startArgsDontEncrypt)
 
 		stageDuration := 10 * time.Minute
 		buffer := 10 * time.Minute
@@ -154,7 +154,7 @@ func registerVersion(r *registry) {
 					return err
 				}
 				c.Put(ctx, cockroach, "./cockroach", c.Node(i))
-				c.Start(ctx, c.Node(i), startArgsDontEncrypt)
+				c.Start(ctx, t, c.Node(i), startArgsDontEncrypt)
 				if err := sleepAndCheck(); err != nil {
 					return err
 				}
@@ -178,7 +178,7 @@ func registerVersion(r *registry) {
 			// Do upgrade for the last node.
 			l.Printf("upgrading last node\n")
 			c.Put(ctx, cockroach, "./cockroach", c.Node(nodes))
-			c.Start(ctx, c.Node(nodes), startArgsDontEncrypt)
+			c.Start(ctx, t, c.Node(nodes), startArgsDontEncrypt)
 			if err := sleepAndCheck(); err != nil {
 				return err
 			}
@@ -191,7 +191,7 @@ func registerVersion(r *registry) {
 					return err
 				}
 				c.Put(ctx, b, "./cockroach", c.Node(i))
-				c.Start(ctx, c.Node(i), startArgsDontEncrypt)
+				c.Start(ctx, t, c.Node(i), startArgsDontEncrypt)
 				if err := sleepAndCheck(); err != nil {
 					return err
 				}
@@ -205,7 +205,7 @@ func registerVersion(r *registry) {
 					return err
 				}
 				c.Put(ctx, cockroach, "./cockroach", c.Node(i))
-				c.Start(ctx, c.Node(i), startArgsDontEncrypt)
+				c.Start(ctx, t, c.Node(i), startArgsDontEncrypt)
 				if err := sleepAndCheck(); err != nil {
 					return err
 				}

--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -30,7 +30,7 @@ func registerYCSB(r *registry) {
 
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
-		c.Start(ctx, c.Range(1, nodes))
+		c.Start(ctx, t, c.Range(1, nodes))
 
 		t.Status("running workload")
 		m := newMonitor(ctx, c, c.Range(1, nodes))


### PR DESCRIPTION
that returns an error.

Release note: None