### PR TITLE
changefeedccl: fix TestAvroSchema/DECIMAL flake

### DIFF
--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -221,7 +221,10 @@ func TestAvroSchema(t *testing.T) {
 			datum = tree.MakeDTimestamp(t, time.Microsecond)
 		case sqlbase.ColumnType_DECIMAL:
 			// TODO(dan): Make RandDatum respect Precision and Width instead.
-			typ.Precision = rng.Int31n(10) + 1
+			// TODO(dan): The precision is really meant to be in [1,10], but it
+			// sure looks like there's an off by one error in the avro library
+			// that makes this test flake if it picks precision of 1.
+			typ.Precision = rng.Int31n(10) + 2
 			typ.Width = rng.Int31n(typ.Precision + 1)
 			coeff := rng.Int63n(int64(math.Pow10(int(typ.Precision))))
 			datum = &tree.DDecimal{Decimal: *apd.New(coeff, -typ.Width)}


### PR DESCRIPTION
The precision is really meant to be in [1,10], but it sure looks like
there's an off by one error in the avro library that makes this test
flake if it picks precision of 1.

Release note: None