### PR TITLE
workload: add SQLRunner, use it in KV

### DIFF
--- a/pkg/workload/connection.go
+++ b/pkg/workload/connection.go
@@ -28,6 +28,8 @@ type ConnFlags struct {
 	*pflag.FlagSet
 	DBOverride  string
 	Concurrency int
+	// Method for issuing queries; see SQLRunner.
+	Method string
 }
 
 // NewConnFlags returns an initialized ConnFlags.
@@ -38,12 +40,14 @@ func NewConnFlags(genFlags *Flags) *ConnFlags {
 		`Override for the SQL database to use. If empty, defaults to the generator name`)
 	c.IntVar(&c.Concurrency, `concurrency`, 2*runtime.NumCPU(),
 		`Number of concurrent workers`)
+	c.StringVar(&c.Method, `method`, `prepare`, `SQL issue method (prepare, noprepare)`)
 	genFlags.AddFlagSet(c.FlagSet)
 	if genFlags.Meta == nil {
 		genFlags.Meta = make(map[string]FlagMeta)
 	}
 	genFlags.Meta[`db`] = FlagMeta{RuntimeOnly: true}
 	genFlags.Meta[`concurrency`] = FlagMeta{RuntimeOnly: true}
+	genFlags.Meta[`method`] = FlagMeta{RuntimeOnly: true}
 	return c
 }
 

--- a/pkg/workload/internal/sanitize/sanitize.go
+++ b/pkg/workload/internal/sanitize/sanitize.go
@@ -1,0 +1,262 @@
+// Code copied from github.com/jackc/pgx.
+//
+// Copyright (c) 2013 Jack Christensen
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package sanitize
+
+import (
+	"bytes"
+	"encoding/hex"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/pkg/errors"
+)
+
+// Part is either a string or an int. A string is raw SQL. An int is a
+// argument placeholder.
+type Part interface{}
+
+type Query struct {
+	Parts []Part
+}
+
+func (q *Query) Sanitize(args ...interface{}) (string, error) {
+	argUse := make([]bool, len(args))
+	buf := &bytes.Buffer{}
+
+	for _, part := range q.Parts {
+		var str string
+		switch part := part.(type) {
+		case string:
+			str = part
+		case int:
+			argIdx := part - 1
+			if argIdx >= len(args) {
+				return "", errors.Errorf("insufficient arguments")
+			}
+			arg := args[argIdx]
+			switch arg := arg.(type) {
+			case nil:
+				str = "null"
+			case int64:
+				str = strconv.FormatInt(arg, 10)
+			case float64:
+				str = strconv.FormatFloat(arg, 'f', -1, 64)
+			case bool:
+				str = strconv.FormatBool(arg)
+			case []byte:
+				str = QuoteBytes(arg)
+			case string:
+				str = QuoteString(arg)
+			case time.Time:
+				str = arg.Format("'2006-01-02 15:04:05.999999999Z07:00:00'")
+			default:
+				return "", errors.Errorf("invalid arg type: %T", arg)
+			}
+			argUse[argIdx] = true
+		default:
+			return "", errors.Errorf("invalid Part type: %T", part)
+		}
+		buf.WriteString(str)
+	}
+
+	for i, used := range argUse {
+		if !used {
+			return "", errors.Errorf("unused argument: %d", i)
+		}
+	}
+	return buf.String(), nil
+}
+
+func NewQuery(sql string) (*Query, error) {
+	l := &sqlLexer{
+		src:     sql,
+		stateFn: rawState,
+	}
+
+	for l.stateFn != nil {
+		l.stateFn = l.stateFn(l)
+	}
+
+	query := &Query{Parts: l.parts}
+
+	return query, nil
+}
+
+func QuoteString(str string) string {
+	return "'" + strings.Replace(str, "'", "''", -1) + "'"
+}
+
+func QuoteBytes(buf []byte) string {
+	return `'\x` + hex.EncodeToString(buf) + "'"
+}
+
+type sqlLexer struct {
+	src     string
+	start   int
+	pos     int
+	stateFn stateFn
+	parts   []Part
+}
+
+type stateFn func(*sqlLexer) stateFn
+
+func rawState(l *sqlLexer) stateFn {
+	for {
+		r, width := utf8.DecodeRuneInString(l.src[l.pos:])
+		l.pos += width
+
+		switch r {
+		case 'e', 'E':
+			nextRune, width := utf8.DecodeRuneInString(l.src[l.pos:])
+			if nextRune == '\'' {
+				l.pos += width
+				return escapeStringState
+			}
+		case '\'':
+			return singleQuoteState
+		case '"':
+			return doubleQuoteState
+		case '$':
+			nextRune, _ := utf8.DecodeRuneInString(l.src[l.pos:])
+			if '0' <= nextRune && nextRune <= '9' {
+				if l.pos-l.start > 0 {
+					l.parts = append(l.parts, l.src[l.start:l.pos-width])
+				}
+				l.start = l.pos
+				return placeholderState
+			}
+		case utf8.RuneError:
+			if l.pos-l.start > 0 {
+				l.parts = append(l.parts, l.src[l.start:l.pos])
+				l.start = l.pos
+			}
+			return nil
+		}
+	}
+}
+
+func singleQuoteState(l *sqlLexer) stateFn {
+	for {
+		r, width := utf8.DecodeRuneInString(l.src[l.pos:])
+		l.pos += width
+
+		switch r {
+		case '\'':
+			nextRune, width := utf8.DecodeRuneInString(l.src[l.pos:])
+			if nextRune != '\'' {
+				return rawState
+			}
+			l.pos += width
+		case utf8.RuneError:
+			if l.pos-l.start > 0 {
+				l.parts = append(l.parts, l.src[l.start:l.pos])
+				l.start = l.pos
+			}
+			return nil
+		}
+	}
+}
+
+func doubleQuoteState(l *sqlLexer) stateFn {
+	for {
+		r, width := utf8.DecodeRuneInString(l.src[l.pos:])
+		l.pos += width
+
+		switch r {
+		case '"':
+			nextRune, width := utf8.DecodeRuneInString(l.src[l.pos:])
+			if nextRune != '"' {
+				return rawState
+			}
+			l.pos += width
+		case utf8.RuneError:
+			if l.pos-l.start > 0 {
+				l.parts = append(l.parts, l.src[l.start:l.pos])
+				l.start = l.pos
+			}
+			return nil
+		}
+	}
+}
+
+// placeholderState consumes a placeholder value. The $ must have already has
+// already been consumed. The first rune must be a digit.
+func placeholderState(l *sqlLexer) stateFn {
+	num := 0
+
+	for {
+		r, width := utf8.DecodeRuneInString(l.src[l.pos:])
+		l.pos += width
+
+		if '0' <= r && r <= '9' {
+			num *= 10
+			num += int(r - '0')
+		} else {
+			l.parts = append(l.parts, num)
+			l.pos -= width
+			l.start = l.pos
+			return rawState
+		}
+	}
+}
+
+func escapeStringState(l *sqlLexer) stateFn {
+	for {
+		r, width := utf8.DecodeRuneInString(l.src[l.pos:])
+		l.pos += width
+
+		switch r {
+		case '\\':
+			_, width = utf8.DecodeRuneInString(l.src[l.pos:])
+			l.pos += width
+		case '\'':
+			nextRune, width := utf8.DecodeRuneInString(l.src[l.pos:])
+			if nextRune != '\'' {
+				return rawState
+			}
+			l.pos += width
+		case utf8.RuneError:
+			if l.pos-l.start > 0 {
+				l.parts = append(l.parts, l.src[l.start:l.pos])
+				l.start = l.pos
+			}
+			return nil
+		}
+	}
+}
+
+// SanitizeSQL replaces placeholder values with args. It quotes and escapes args
+// as necessary. This function is only safe when standard_conforming_strings is
+// on.
+func SanitizeSQL(sql string, args ...interface{}) (string, error) {
+	query, err := NewQuery(sql)
+	if err != nil {
+		return "", err
+	}
+	return query.Sanitize(args...)
+}

--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -212,28 +212,20 @@ func (w *kv) Ops(urls []string, reg *workload.HistogramRegistry) (workload.Query
 	seq := &sequence{config: w, val: int64(writeSeq)}
 	numEmptyResults := new(int64)
 	for i := 0; i < w.connFlags.Concurrency; i++ {
-		// Give each kvOp worker its own SQL connection and prepare statements
-		// using this connection. This avoids lock contention in the sql.Rows
-		// objects they produce.
+		// Give each kvOp worker its own SQL connection.
 		conn, err := db.Conn(ctx)
 		if err != nil {
 			return workload.QueryLoad{}, err
 		}
-		readStmt, err := conn.PrepareContext(ctx, readStmtStr)
-		if err != nil {
-			return workload.QueryLoad{}, err
-		}
-		writeStmt, err := conn.PrepareContext(ctx, writeStmtStr)
-		if err != nil {
-			return workload.QueryLoad{}, err
-		}
-		op := kvOp{
+		op := &kvOp{
 			config:          w,
 			hists:           reg.GetHandle(),
-			conn:            conn,
-			readStmt:        readStmt,
-			writeStmt:       writeStmt,
 			numEmptyResults: numEmptyResults,
+		}
+		op.readStmt = op.sr.Define(readStmtStr)
+		op.writeStmt = op.sr.Define(writeStmtStr)
+		if err := op.sr.Init(ctx, conn, w.connFlags); err != nil {
+			return workload.QueryLoad{}, err
 		}
 		if w.sequential {
 			op.g = newSequentialGenerator(seq)
@@ -249,9 +241,9 @@ func (w *kv) Ops(urls []string, reg *workload.HistogramRegistry) (workload.Query
 type kvOp struct {
 	config          *kv
 	hists           *workload.Histograms
-	conn            *gosql.Conn
-	readStmt        *gosql.Stmt
-	writeStmt       *gosql.Stmt
+	sr              workload.SQLRunner
+	readStmt        workload.StmtHandle
+	writeStmt       workload.StmtHandle
 	g               keyGenerator
 	numEmptyResults *int64 // accessed atomically
 }
@@ -263,7 +255,7 @@ func (o *kvOp) run(ctx context.Context) error {
 			args[i] = o.g.readKey()
 		}
 		start := timeutil.Now()
-		rows, err := o.readStmt.QueryContext(ctx, args...)
+		rows, err := o.readStmt.Query(ctx, args...)
 		if err != nil {
 			return err
 		}
@@ -286,7 +278,7 @@ func (o *kvOp) run(ctx context.Context) error {
 		args[j+1] = randomBlock(o.config, o.g.rand())
 	}
 	start := timeutil.Now()
-	_, err := o.writeStmt.ExecContext(ctx, args...)
+	_, err := o.writeStmt.Exec(ctx, args...)
 	elapsed := timeutil.Since(start)
 	o.hists.Get(`write`).Record(elapsed)
 	return err

--- a/pkg/workload/sql_runner.go
+++ b/pkg/workload/sql_runner.go
@@ -1,0 +1,310 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package workload
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/cockroachdb/cockroach/pkg/workload/internal/sanitize"
+)
+
+// SQLRunner is a helper for issuing SQL statements; it supports multiple
+// methods for issuing queries.
+//
+// Queries need to first be defined using calls to Define. Then the runner
+// must be initialized, after which we can use the handles returned by Define.
+//
+// Sample usage:
+//   sr := &workload.SQLRunner{}
+//
+//   sel:= sr.Define("SELECT x FROM t WHERE y = $1")
+//   ins:= sr.Define("INSERT INTO t(x, y) VALUES ($1, $2)")
+//
+//   err := sr.Init(ctx, conn, flags)
+//   // [handle err]
+//   defer sr.Close()
+//
+//   row := sel.QueryRow(1)
+//   // [use row]
+//
+//   _, err := ins.Exec(5, 6)
+//   // [handle err]
+//
+// A runner should typically be associated with a single worker.
+type SQLRunner struct {
+	stmts       []*stmt
+	initialized bool
+	method      method
+	conn        *gosql.Conn
+}
+
+type stmt struct {
+	sr  *SQLRunner
+	sql string
+	// prepared is only used for the prepare method.
+	prepared *gosql.Stmt
+	// simpleFmt is only used for the simple method. It is the sql string with
+	// placeholders "$1" converted to printf-style "%[1]v".
+	simpleFmt string
+}
+
+type StmtHandle struct {
+	s *stmt
+}
+
+type method int
+
+const (
+	prepare method = iota
+	noprepare
+	simple
+)
+
+var stringToMethod = map[string]method{
+	"prepare":   prepare,
+	"noprepare": noprepare,
+	"simple":    simple,
+}
+
+// Define creates a handle for the given statement. The handle can be used after
+// Init is called.
+func (sr *SQLRunner) Define(sql string) StmtHandle {
+	if sr.initialized {
+		panic("Define can't be called after Init")
+	}
+	s := &stmt{sr: sr, sql: sql}
+	sr.stmts = append(sr.stmts, s)
+	return StmtHandle{s: s}
+}
+
+// Init initializes the runner; must be called after calls to Define and before
+// the StmtHandles are used.
+//
+// The way we issue queries is set by flags.Method:
+//
+//  - "prepare": we prepare the query once during Init, then we reuse it for
+//    each execution. This results in a Bind and Execute on the server each time
+//    we run a query (on the given connection). Note that it's important to
+//    prepare on separate connections if there are many parallel workers; this
+//    avoids lock contention in the sql.Rows objects they produce. See #30811.
+//
+//  - "noprepare": each query is issued separately (on the given connection).
+//    This results in Parse, Bind, Execute on the server each time we run a
+//    query.
+//
+//  - "simple": each query is issued in a single string; parameters are
+//    rendered inside the string. This results in a single SimpleExecute
+//    request to the server for each query. Note that only a few parameter types
+//    are supported.
+//
+func (sr *SQLRunner) Init(ctx context.Context, conn *gosql.Conn, flags *ConnFlags) error {
+	if sr.initialized {
+		panic("already initialized")
+	}
+
+	var ok bool
+	sr.method, ok = stringToMethod[strings.ToLower(flags.Method)]
+	if !ok {
+		return errors.Errorf("unknown method %s", flags.Method)
+	}
+
+	if sr.method == prepare {
+		for _, s := range sr.stmts {
+			var err error
+			s.prepared, err = conn.PrepareContext(ctx, s.sql)
+			if err != nil {
+				return errors.Wrapf(err, "preparing %s", s.sql)
+			}
+		}
+	}
+
+	sr.conn = conn
+	sr.initialized = true
+	return nil
+}
+
+// Close cleans up the SQLRunner.
+func (sr *SQLRunner) Close() {
+	for _, s := range sr.stmts {
+		if s.prepared != nil {
+			_ = s.prepared.Close()
+			s.prepared = nil
+		}
+	}
+
+	sr.initialized = false
+}
+
+func (h StmtHandle) check() {
+	if !h.s.sr.initialized {
+		panic("SQLRunner.Init not called")
+	}
+}
+
+// Exec executes a query that doesn't return rows. The query is executed on the
+// connection that was passed to SQLRunner.Init.
+//
+// See gosql.Conn.ExecContext / gosql.Stmt.ExecContext.
+func (h StmtHandle) Exec(ctx context.Context, args ...interface{}) (gosql.Result, error) {
+	h.check()
+	switch h.s.sr.method {
+	case prepare:
+		return h.s.prepared.ExecContext(ctx, args...)
+
+	case noprepare:
+		return h.s.sr.conn.ExecContext(ctx, h.s.sql, args...)
+
+	case simple:
+		sql, err := sanitize.SanitizeSQL(h.s.sql, args...)
+		if err != nil {
+			panic(fmt.Sprintf("error sanitizing `%s`: %v", h.s.sql, err))
+		}
+		return h.s.sr.conn.ExecContext(ctx, sql)
+
+	default:
+		panic("invalid method")
+	}
+}
+
+// ExecTx executes a query that doesn't return rows, in a transaction.
+//
+// See gosql.Tx.ExecContext.
+func (h StmtHandle) ExecTx(
+	ctx context.Context, tx *gosql.Tx, args ...interface{},
+) (gosql.Result, error) {
+	h.check()
+	switch h.s.sr.method {
+	case prepare:
+		return tx.StmtContext(ctx, h.s.prepared).ExecContext(ctx, args...)
+
+	case noprepare:
+		return tx.ExecContext(ctx, h.s.sql, args...)
+
+	case simple:
+		sql, err := sanitize.SanitizeSQL(h.s.sql, args...)
+		if err != nil {
+			panic(fmt.Sprintf("error sanitizing `%s`: %v", h.s.sql, err))
+		}
+		return tx.ExecContext(ctx, sql)
+
+	default:
+		panic("invalid method")
+	}
+}
+
+// Query executes a query that returns rows.
+//
+// See gosql.Conn.QueryContext / gosql.Stmt.QueryContext.
+func (h StmtHandle) Query(ctx context.Context, args ...interface{}) (*gosql.Rows, error) {
+	h.check()
+	switch h.s.sr.method {
+	case prepare:
+		return h.s.prepared.QueryContext(ctx, args...)
+
+	case noprepare:
+		return h.s.sr.conn.QueryContext(ctx, h.s.sql, args...)
+
+	case simple:
+		sql, err := sanitize.SanitizeSQL(h.s.sql, args...)
+		if err != nil {
+			panic(fmt.Sprintf("error sanitizing `%s`: %v", h.s.sql, err))
+		}
+		return h.s.sr.conn.QueryContext(ctx, sql)
+
+	default:
+		panic("invalid method")
+	}
+}
+
+// QueryTx executes a query that returns rows, in a transaction.
+//
+// See gosql.Tx.QueryContext.
+func (h StmtHandle) QueryTx(
+	ctx context.Context, tx *gosql.Tx, args ...interface{},
+) (*gosql.Rows, error) {
+	h.check()
+	switch h.s.sr.method {
+	case prepare:
+		return tx.StmtContext(ctx, h.s.prepared).QueryContext(ctx, args...)
+
+	case noprepare:
+		return tx.QueryContext(ctx, h.s.sql, args...)
+
+	case simple:
+		sql, err := sanitize.SanitizeSQL(h.s.sql, args...)
+		if err != nil {
+			panic(fmt.Sprintf("error sanitizing `%s`: %v", h.s.sql, err))
+		}
+		return tx.QueryContext(ctx, sql)
+
+	default:
+		panic("invalid method")
+	}
+}
+
+// QueryRow executes a query that is expected to return at most one row.
+//
+// See gosql.Conn.QueryRowContext / gosql.Stmt.QueryRowContext.
+func (h StmtHandle) QueryRow(ctx context.Context, args ...interface{}) *gosql.Row {
+	h.check()
+	switch h.s.sr.method {
+	case prepare:
+		return h.s.prepared.QueryRowContext(ctx, args...)
+
+	case noprepare:
+		return h.s.sr.conn.QueryRowContext(ctx, h.s.sql, args...)
+
+	case simple:
+		sql, err := sanitize.SanitizeSQL(h.s.sql, args...)
+		if err != nil {
+			panic(fmt.Sprintf("error sanitizing `%s`: %v", h.s.sql, err))
+		}
+		return h.s.sr.conn.QueryRowContext(ctx, sql)
+
+	default:
+		panic("invalid method")
+	}
+}
+
+// QueryRowTx executes a query that is expected to return at most one row, in a
+// transaction.
+//
+// See gosql.Tx.QueryRowContext.
+func (h StmtHandle) QueryRowTx(ctx context.Context, tx *gosql.Tx, args ...interface{}) *gosql.Row {
+	h.check()
+	switch h.s.sr.method {
+	case prepare:
+		return tx.StmtContext(ctx, h.s.prepared).QueryRowContext(ctx, args...)
+
+	case noprepare:
+		return tx.QueryRowContext(ctx, h.s.sql, args...)
+
+	case simple:
+		sql, err := sanitize.SanitizeSQL(h.s.sql, args...)
+		if err != nil {
+			panic(fmt.Sprintf("error sanitizing `%s`: %v", h.s.sql, err))
+		}
+		return tx.QueryRowContext(ctx, sql)
+
+	default:
+		panic("invalid method")
+	}
+}


### PR DESCRIPTION
#### workload: add SQLRunner

A common facility for issuing SQL queries. It supports multiple
issuing methods, specified by the `--method` flag:
 - prepare: each statement is prepared once per session and then
   reused.
 - noprepare: each statement is executed directly (which internally
   is equivalent to preparing and executing each statement
   separately).
 - simple: parameters are formatted as text and replaced in the query
   before it is issued.

Release note: None

#### workload: switch KV to use SQLRunner

The default `prepare` method should be equivalent to the old code.

Ran a performance benchmark (on gceworker, 10 interleaved runs each). 
Ops/s:
 - before: 14890 avg (717 stddev)
 - prepare: 14942 avg (513 stddev)
 - noprepare: 13692 avg (376 stddev)
 - simple: 14685 avg (382 stddev)

Release note: None
