### PR TITLE
roachtest: make newCluster return errors instead of t.Fatal

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -544,9 +544,9 @@ const (
 // to figure out how to make that work with `roachprod create`. Perhaps one
 // invocation of `roachprod create` per unique node-spec. Are there guarantees
 // we're making here about the mapping of nodeSpecs to node IDs?
-func newCluster(ctx context.Context, t testI, nodes []nodeSpec, opt clusterOpt) *cluster {
+func newCluster(ctx context.Context, t testI, nodes []nodeSpec, opt clusterOpt) (*cluster, error) {
 	if atomic.LoadInt32(&interrupted) == 1 {
-		t.Fatal("interrupted")
+		return nil, fmt.Errorf("newCluster interrupted")
 	}
 
 	switch {
@@ -554,16 +554,16 @@ func newCluster(ctx context.Context, t testI, nodes []nodeSpec, opt clusterOpt) 
 		// For tests. Return the minimum that makes them happy.
 		return &cluster{
 			expiration: timeutil.Now().Add(24 * time.Hour),
-		}
+		}, nil
 	case len(nodes) > 1:
 		// TODO(peter): Need a motivating test that has different specs per node.
-		t.Fatalf("TODO(peter): unsupported nodes spec: %v", nodes)
+		return nil, fmt.Errorf("TODO(peter): unsupported nodes spec: %v", nodes)
 	}
 
 	logPath := filepath.Join(t.ArtifactsDir(), "test.log")
 	l, err := rootLogger(logPath)
 	if err != nil {
-		t.Fatal(err)
+		return nil, err
 	}
 
 	var name string
@@ -595,12 +595,11 @@ func newCluster(ctx context.Context, t testI, nodes []nodeSpec, opt clusterOpt) 
 
 	c.status("creating cluster")
 	if err := execCmd(ctx, l, sargs...); err != nil {
-		t.Fatal(err)
-		return nil
+		return nil, err
 	}
 
 	c.status("running test")
-	return c
+	return c, nil
 }
 
 type attachOpt struct {

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -576,6 +576,13 @@ func (t *test) Fatalf(format string, args ...interface{}) {
 	runtime.Goexit()
 }
 
+// FatalIfErr calls t.Fatal() if err != nil.
+func FatalIfErr(t *test, err error) {
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func (t *test) printAndFail(args ...interface{}) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -842,7 +849,9 @@ func (r *registry) runAsync(
 				if local {
 					opt = localCluster
 				}
-				c = newCluster(ctx, t, t.spec.Nodes, opt)
+				var err error
+				c, err = newCluster(ctx, t, t.spec.Nodes, opt)
+				FatalIfErr(t, err)
 			} else {
 				opt := attachOpt{
 					skipValidation: r.config.skipClusterValidationOnAttach,


### PR DESCRIPTION
In the hope of making clusters more independent of tests.

Release note: None