### PR TITLE
release-2.1: storage: reduce commit index on quiescence heartbeat, don't drop them

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4778,17 +4778,6 @@ func (r *Replica) quiesceAndNotifyLocked(ctx context.Context, status *raft.Statu
 		if roachpb.ReplicaID(id) == r.mu.replicaID {
 			continue
 		}
-		// In common operation, we only quiesce when all followers are
-		// up-to-date. However, when we quiesce in the presence of dead
-		// nodes, a follower which is behind but considered dead may not
-		// have the log entry referenced by status.Commit and would
-		// explode if it were told to commit up to that point. So if
-		// prog.Match for a replica is not up to date with status.Commit,
-		// assume the replica is considered dead and skip the quiesce
-		// heartbeat.
-		if prog.Match < status.Commit {
-			continue
-		}
 		toReplica, toErr := r.getReplicaDescriptorByIDRLocked(
 			roachpb.ReplicaID(id), r.mu.lastFromReplica)
 		if toErr != nil {
@@ -4798,15 +4787,31 @@ func (r *Replica) quiesceAndNotifyLocked(ctx context.Context, status *raft.Statu
 			r.unquiesceLocked()
 			return false
 		}
+
+		// Attach the commit as min(prog.Match, status.Commit). This is exactly
+		// the same as what raft.sendHeartbeat does. See the comment there for
+		// an explanation.
+		//
+		// If the follower is behind, we don't tell it that we're quiescing.
+		// This ensures that if the follower receives the heartbeat then it will
+		// unquiesce the Range and be caught up by the leader. Remember that we
+		// only allow Ranges to quiesce with straggling Replicas if we believe
+		// those Replicas are on dead nodes.
+		commit := status.Commit
+		quiesce := true
+		if prog.Match < status.Commit {
+			commit = prog.Match
+			quiesce = false
+		}
 		msg := raftpb.Message{
 			From:   uint64(r.mu.replicaID),
 			To:     id,
 			Type:   raftpb.MsgHeartbeat,
 			Term:   status.Term,
-			Commit: status.Commit,
+			Commit: commit,
 		}
 
-		if r.maybeCoalesceHeartbeat(ctx, msg, toReplica, fromReplica, true) {
+		if r.maybeCoalesceHeartbeat(ctx, msg, toReplica, fromReplica, quiesce) {
 			continue
 		}
 
@@ -4815,7 +4820,7 @@ func (r *Replica) quiesceAndNotifyLocked(ctx context.Context, status *raft.Statu
 			ToReplica:   toReplica,
 			FromReplica: fromReplica,
 			Message:     msg,
-			Quiesce:     true,
+			Quiesce:     quiesce,
 		}
 		if !r.sendRaftMessageRequest(ctx, req) {
 			r.unquiesceLocked()

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4811,22 +4811,8 @@ func (r *Replica) quiesceAndNotifyLocked(ctx context.Context, status *raft.Statu
 			Commit: commit,
 		}
 
-		if r.maybeCoalesceHeartbeat(ctx, msg, toReplica, fromReplica, quiesce) {
-			continue
-		}
-
-		req := &RaftMessageRequest{
-			RangeID:     r.RangeID,
-			ToReplica:   toReplica,
-			FromReplica: fromReplica,
-			Message:     msg,
-			Quiesce:     quiesce,
-		}
-		if !r.sendRaftMessageRequest(ctx, req) {
-			r.unquiesceLocked()
-			r.mu.droppedMessages++
-			r.mu.internalRaftGroup.ReportUnreachable(id)
-			return false
+		if !r.maybeCoalesceHeartbeat(ctx, msg, toReplica, fromReplica, quiesce) {
+			log.Fatalf(ctx, "failed to coalesce known heartbeat: %v", msg)
 		}
 	}
 	return true


### PR DESCRIPTION
Backport 2/2 commits from #31112.

/cc @cockroachdb/release

---

Informs #30064.

53dc851 introduced logic to drop quiescence heartbeats to Replicas that
are not caught up to the leader. This turns out to be an issue in cases
where:
- a Range is quiescent
- a Replica needs a heartbeat to join a Raft group
- that Replica's node is unable to update its liveness record because
doing so depends on the Replica joining the Raft group
- so the Replica never gets any heartbeats and never joins the group

This change adjusts the logic. Instead of dropping these heartbeats, the
leader Replica now sends them, but with a reduced commit index and with
Quiesce equal to false.
