### PR TITLE
distsql: don't use sortTopK when filter is present

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -142,3 +142,12 @@ SELECT k, v FROM t ORDER BY k LIMIT (SELECT count(*)-3 FROM t) OFFSET (SELECT co
 2  -4
 3  9
 4  -16
+
+# Test sort node with both filter and limit. (https://github.com/cockroachdb/cockroach/issues/31163)
+statement ok
+SET TRACING = ON; SELECT 1; SET TRACING = OFF
+
+query I
+SELECT SPAN FROM [SHOW TRACE FOR SESSION] WHERE span = 1 LIMIT 1
+----
+1


### PR DESCRIPTION
The sorter was producing incorrect results when both a limit and a
filter were applied. We can't use sortTopK in this case since some
results may be filtered out in post-processing. Note this scenario is
somewhat rare because typically the filter would be pushed down below
the sort. The issue was observed when selecting from the result of a
SHOW TRACE.

Also removed a bit of dead code.

Fixes #31163

Release note: None