### PR TITLE
release-2.1: distsql: don't use sortTopK when filter is present

### DIFF
--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -33,10 +33,6 @@ type sorterBase struct {
 	input    RowSource
 	ordering sqlbase.ColumnOrdering
 	matchLen uint32
-	// count is the maximum number of rows that the sorter will push to the
-	// ProcOutputHelper. 0 if the sorter should sort and push all the rows from
-	// the input.
-	count int64
 
 	rows sortableRowContainer
 	i    rowIterator
@@ -56,13 +52,6 @@ func (s *sorterBase) init(
 	matchLen uint32,
 	opts ProcStateOpts,
 ) error {
-	count := int64(0)
-	if post.Limit != 0 {
-		// The sorter needs to produce Offset + Limit rows. The ProcOutputHelper
-		// will discard the first Offset ones.
-		count = int64(post.Limit) + int64(post.Offset)
-	}
-
 	ctx := flowCtx.EvalCtx.Ctx()
 	if sp := opentracing.SpanFromContext(ctx); sp != nil && tracing.IsRecording(sp) {
 		input = NewInputStatCollector(input)
@@ -116,7 +105,6 @@ func (s *sorterBase) init(
 	s.input = input
 	s.ordering = ordering
 	s.matchLen = matchLen
-	s.count = count
 	return nil
 }
 
@@ -209,7 +197,7 @@ func newSorter(
 	output RowReceiver,
 ) (Processor, error) {
 	count := int64(0)
-	if post.Limit != 0 {
+	if post.Limit != 0 && post.Filter.Expr == "" {
 		// The sorter needs to produce Offset + Limit rows. The ProcOutputHelper
 		// will discard the first Offset ones.
 		count = int64(post.Limit) + int64(post.Offset)

--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -142,3 +142,12 @@ SELECT k, v FROM t ORDER BY k LIMIT (SELECT count(*)-3 FROM t) OFFSET (SELECT co
 2  -4
 3  9
 4  -16
+
+# Test sort node with both filter and limit. (https://github.com/cockroachdb/cockroach/issues/31163)
+statement ok
+SET TRACING = ON; SELECT 1; SET TRACING = OFF
+
+query I
+SELECT SPAN FROM [SHOW TRACE FOR SESSION] WHERE span = 1 LIMIT 1
+----
+1


### PR DESCRIPTION
Backport 1/1 commits from #31189.

/cc @cockroachdb/release

---

The sorter was producing incorrect results when both a limit and a
filter were applied. We can't use sortTopK in this case since some
results may be filtered out in post-processing. Note this scenario is
somewhat rare because typically the filter would be pushed down below
the sort. The issue was observed when selecting from the result of a
SHOW TRACE.

Also removed a bit of dead code.

Fixes #31163

Release note: None
