### PR TITLE
sql: add a minimum allocation field to bound accounts

### DIFF
--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -76,6 +76,7 @@ crdb_folk = set([
     "Andrew Couch",
     "Andrew Kimball",
     "Andy Woods",
+    "Angela Chang",
     "Arjun Narayan",
     "Ben Darnell",
     "Bob Vawter",


### PR DESCRIPTION
This change adds on to the work done in #30924.

Currently, a bound account will reserve a small buffer of up to `poolAllocationSize`. When the account grows, this buffer is first used up before additional memory is reserved from the monitor. When the account shrinks, memory is released from this buffer to a minimum of `poolAllocationSize`. We want to be able to dynamically set a minimum allocated value in order to amortize the cost of constantly growing and shrinking a account. This field is different from `poolAllocationSize` in the
following ways:

- there is overhead introduced by a call to `releaseBytes` and if we are always "shrinking" the reserved buffer to a constant size of `poolAllocationSize`, this overhead becomes quite prominent. Instead, if we establish a minimum value for `allocated = reserved + used`, then the call to `releaseBytes` becomes much less frequent.
- in the case where we "grow" the account to above the `minAllocated` size, then we don't want the account to buffer up another chunk of `minAllocated`, instead it will reserve memory in conservative `poolAllocationSize` blocks.

This PR mainly adds the necessary documentation and comments that was not present in #30924.

Release note: None