### PR TITLE
kubernetes: Always create default namespace svc in multi-region setup

### DIFF
--- a/cloud/kubernetes/multiregion/external-name-svc.yaml
+++ b/cloud/kubernetes/multiregion/external-name-svc.yaml
@@ -13,6 +13,11 @@
 # After completing these steps, you should be able to access the cockroachdb
 # cluster at the name `cockroachdb-public` in the default Kubernetes namespace
 # (or at the name `cockroachdb-public.default` from any namespace).
+#
+# Note that the ServiceAccount and roles defined below are only needed for
+# accessing the Secret containing the root client certificate. If you are
+# managing client certificates (or passwords) some other way, you can do away
+# with everything in this file other than the Service.
 kind: Service
 apiVersion: v1
 metadata:

--- a/cloud/kubernetes/multiregion/teardown.py
+++ b/cloud/kubernetes/multiregion/teardown.py
@@ -26,6 +26,8 @@ generated_files_dir = './generated'
 # other resources we created that weren't in that namespace
 for zone, context in contexts.items():
     call(['kubectl', 'delete', 'namespace', zone, '--context', context])
+    call(['kubectl', 'delete', 'secret', 'cockroachdb.client.root', '--context', context])
+    call(['kubectl', 'delete', '-f', 'external-name-svc.yaml', '--context', context])
     call(['kubectl', 'delete', '-f', 'dns-lb.yaml', '--context', context])
     call(['kubectl', 'delete', 'configmap', 'kube-dns', '--namespace', 'kube-system', '--context', context])
     # Restart the DNS pods to clear out our stub-domains configuration.


### PR DESCRIPTION
Previously we left it as an extra manual task, but there's no great
reason not to just automate it for people.

Release note: None