### PR TITLE
ui: avoid using font which isn't loaded yet in alert banner

### DIFF
--- a/pkg/ui/src/views/shared/components/alertBox/alertbox.styl
+++ b/pkg/ui/src/views/shared/components/alertBox/alertbox.styl
@@ -24,7 +24,7 @@
   border 1px solid $headings-color
   border-radius 5px
   font-family Lato-Regular
-  
+
   &__icon
     flex 0
 
@@ -36,7 +36,7 @@
     flex 0
 
   &__title
-    font-family Lato-Bold
+    font-weight bold
     padding-right 25px
 
   &__link


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7341/46770089-04212880-ccbc-11e8-89a4-53b2ef9f06fd.png)

After:
![image](https://user-images.githubusercontent.com/7341/46770099-0be0cd00-ccbc-11e8-9946-aea2c1dfaca0.png)

The "we're having trouble connecting to the cluster" banner, while already annoying, also often looks janky because it's in `Times New Roman`. This happens because it's styled to use `Lato-Bold`, which isn't used much in the UI and as such usually hasn't been loaded at the point that the banner appears. It can't be loaded when the banner appears because the UI can't connect to the cluster.

This change uses `Lato-Regular` with `font-face: bold` applied, which looks almost the same but is always loaded so we don't see the banner in `Times New Roman`.

Release note: None