### PR TITLE
roachtest: kill a global

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -117,7 +117,7 @@ If no pattern is given, all tests are run.
 				r.loadBuildVersion()
 			}
 			registerTests(r)
-			os.Exit(r.Run(args))
+			os.Exit(r.Run(args, parallelism))
 			return nil
 		},
 	}
@@ -139,7 +139,7 @@ If no pattern is given, all tests are run.
 			}
 			r := newRegistry()
 			registerBenchmarks(r)
-			os.Exit(r.Run(args))
+			os.Exit(r.Run(args, parallelism))
 			return nil
 		},
 	}
@@ -177,7 +177,7 @@ Cockroach cluster with existing data.
 			registerStoreGen(r, args)
 			// We've only registered one store generation "test" that does its own
 			// argument processing, so no need to provide any arguments to r.Run.
-			os.Exit(r.Run(nil /* filter */))
+			os.Exit(r.Run(nil /* filter */, parallelism))
 			return nil
 		},
 	}

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -296,7 +296,7 @@ func (r *registry) ListAll(filter []string) []string {
 	return names
 }
 
-func (r *registry) Run(filter []string) int {
+func (r *registry) Run(filter []string, parallelism int) int {
 	filterRE := makeFilterRE(filter)
 	// Find the top-level tests to run.
 	tests := r.ListTopLevel(filterRE)

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/kr/pretty"
 )
 
+const defaultParallelism = 10
+
 func TestRegistryRun(t *testing.T) {
 	r := newRegistry()
 	r.out = ioutil.Discard
@@ -69,7 +71,7 @@ func TestRegistryRun(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			code := r.Run(c.filters)
+			code := r.Run(c.filters, defaultParallelism)
 			if c.expected != code {
 				t.Fatalf("expected code %d, but found code %d. Filters: %s", c.expected, code, c.filters)
 			}
@@ -134,7 +136,7 @@ func TestRegistryStatus(t *testing.T) {
 			}
 		},
 	})
-	r.Run([]string{"status"})
+	r.Run([]string{"status"}, defaultParallelism)
 
 	status := buf.String()
 	if !waitingRE.MatchString(status) {
@@ -168,7 +170,7 @@ func TestRegistryStatusUnknown(t *testing.T) {
 			}
 		},
 	})
-	r.Run([]string{"status"})
+	r.Run([]string{"status"}, defaultParallelism)
 
 	status := buf.String()
 	if !unknownRE.MatchString(status) {
@@ -194,7 +196,7 @@ func TestRegistryRunTimeout(t *testing.T) {
 			<-ctx.Done()
 		},
 	})
-	r.Run([]string{"timeout"})
+	r.Run([]string{"timeout"}, defaultParallelism)
 
 	out := buf.String()
 	if !timeoutRE.MatchString(out) {
@@ -220,7 +222,7 @@ func TestRegistryRunSubTestFailed(t *testing.T) {
 		}},
 	})
 
-	r.Run([]string{"."})
+	r.Run([]string{"."}, defaultParallelism)
 	out := buf.String()
 	if !failedRE.MatchString(out) {
 		t.Fatalf("unable to find \"FAIL: parent\" message:\n%s", out)
@@ -249,7 +251,7 @@ func TestRegistryRunClusterExpired(t *testing.T) {
 			panic("not reached")
 		},
 	})
-	r.Run([]string{"expired"})
+	r.Run([]string{"expired"}, defaultParallelism)
 
 	out := buf.String()
 	if !expiredRE.MatchString(out) {
@@ -450,7 +452,7 @@ func TestRegistryMinVersion(t *testing.T) {
 			if err := r.setBuildVersion(c.buildVersion); err != nil {
 				t.Fatal(err)
 			}
-			r.Run(nil)
+			r.Run(nil /* filter */, defaultParallelism)
 			if c.expectedA != runA || c.expectedB != runB {
 				t.Fatalf("expected %t,%t, but got %t,%t\n%s",
 					c.expectedA, c.expectedB, runA, runB, buf.String())


### PR DESCRIPTION
The registry was using (and worse, updating) a global. This was nothing
short of a tragedy for tests, which would do one thing when run in
isolation and another thing when running after another test that updated
that global.

Release note: None