### PR TITLE
sqlbase: ShouldSplitAtIDHook should return false for unknown IDs

### DIFF
--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -98,6 +98,38 @@ func (s *SystemConfig) Equal(other *SystemConfigEntries) bool {
 	return true
 }
 
+// GetDesc looks for the descriptor value given a key, if a zone is created in
+// a test without creating a Descriptor, a dummy descriptor is returned.
+// If the key is invalid in decoding an ID, GetDesc panics.
+func (s *SystemConfig) GetDesc(key roachpb.Key) *roachpb.Value {
+	if getVal := s.GetValue(key); getVal != nil {
+		return getVal
+	}
+
+	id, err := keys.DecodeDescMetadataID(key)
+	if err != nil {
+		// No ID found for key. No roachpb.Value corresponds to this key.
+		panic(err)
+	}
+
+	testingLock.Lock()
+	_, ok := testingZoneConfig[uint32(id)]
+	testingLock.Unlock()
+
+	if ok {
+		// A test installed a zone config for this ID, but no descriptor.
+		// Synthesize an empty descriptor to force split to occur, or else the
+		// zone config won't apply to any ranges. Most tests that use
+		// TestingSetZoneConfig are too low-level to create tables and zone
+		// configs through proper channels.
+		//
+		// Getting here outside tests is impossible.
+		val := roachpb.MakeValueFromBytes(nil)
+		return &val
+	}
+	return nil
+}
+
 // GetValue searches the kv list for 'key' and returns its
 // roachpb.Value if found.
 func (s *SystemConfig) GetValue(key roachpb.Key) *roachpb.Value {
@@ -410,7 +442,12 @@ func (s *SystemConfig) shouldSplit(ID uint32) bool {
 	shouldSplit, ok := s.mu.shouldSplitCache[ID]
 	s.mu.RUnlock()
 	if !ok {
-		shouldSplit = SplitAtIDHook(ID, s)
+		// Check if the descriptor ID is not one of the reserved
+		// IDs that refer to ranges but not any actual descriptors.
+		shouldSplit = true
+		if ID >= keys.MinUserDescID {
+			shouldSplit = SplitAtIDHook(ID, s)
+		}
 		s.mu.Lock()
 		s.mu.shouldSplitCache[ID] = shouldSplit
 		s.mu.Unlock()

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -33,19 +33,20 @@ func init() {
 // should be considered for a split at all. If it is a database
 // or a view table descriptor, it should not be considered.
 func SplitAtIDHook(id uint32, cfg *config.SystemConfig) bool {
-	descVal := cfg.GetValue(MakeDescMetadataKey(ID(id)))
-	if descVal != nil {
-		var desc Descriptor
-		if err := descVal.GetProto(&desc); err != nil {
+	descVal := cfg.GetDesc(MakeDescMetadataKey(ID(id)))
+	if descVal == nil {
+		return false
+	}
+	var desc Descriptor
+	if err := descVal.GetProto(&desc); err != nil {
+		return false
+	}
+	if dbDesc := desc.GetDatabase(); dbDesc != nil {
+		return false
+	}
+	if tableDesc := desc.GetTable(); tableDesc != nil {
+		if viewStr := tableDesc.GetViewQuery(); viewStr != "" {
 			return false
-		}
-		if dbDesc := desc.GetDatabase(); dbDesc != nil {
-			return false
-		}
-		if tableDesc := desc.GetTable(); tableDesc != nil {
-			if viewStr := tableDesc.GetViewQuery(); viewStr != "" {
-				return false
-			}
 		}
 	}
 	return true

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1227,6 +1227,7 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 	store, _ := createTestStore(t, stopper)
 
 	userTableMax := keys.MinUserDescID + 4
+	var exceptions map[int]struct{}
 	schema := sqlbase.MakeMetadataSchema()
 	// Write table descriptors for the tables in the metadata schema as well as
 	// five dummy user tables. This does two things:
@@ -1278,9 +1279,11 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 			)
 		}
 		for i := keys.MinUserDescID; i <= userTableMax; i++ {
-			expKeys = append(expKeys,
-				testutils.MakeKey(keys.Meta2Prefix, keys.MakeTablePrefix(uint32(i))),
-			)
+			if _, ok := exceptions[i]; !ok {
+				expKeys = append(expKeys,
+					testutils.MakeKey(keys.Meta2Prefix, keys.MakeTablePrefix(uint32(i))),
+				)
+			}
 		}
 		expKeys = append(expKeys, testutils.MakeKey(keys.Meta2Prefix, roachpb.RKeyMax))
 
@@ -1304,12 +1307,13 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 
 	// Write another, disjoint (+3) descriptor for a user table.
 	userTableMax += 3
+	exceptions = map[int]struct{}{userTableMax - 1: {}, userTableMax - 2: {}}
 	if err := store.DB().Txn(context.TODO(), func(ctx context.Context, txn *client.Txn) error {
 		if err := txn.SetSystemConfigTrigger(); err != nil {
 			return err
 		}
-		// This time, only write the last table descriptor. Splits still occur for
-		// every intervening ID. We don't care about the value, just the key.
+		// This time, only write the last table descriptor. Splits only occur for
+		// the descriptor we add. We don't care about the value, just the key.
 		k := sqlbase.MakeDescMetadataKey(sqlbase.ID(userTableMax))
 		return txn.Put(ctx, k, &sqlbase.TableDescriptor{})
 	}); err != nil {


### PR DESCRIPTION
If descriptor value is not found for a given ID, the hook
should immediately say that it shouldn't be considered for a split.

I think this resolves #31128.

Release note: None