### PR TITLE
ui: scope table padding under debug index panel section class

### DIFF
--- a/pkg/ui/src/views/shared/components/panelSection/panels.styl
+++ b/pkg/ui/src/views/shared/components/panelSection/panels.styl
@@ -26,14 +26,14 @@
   p
     color $body-color
 
+  th + th, td + td
+    border-left 2px solid $background-color
+
+  tr + tr
+    border-top 2px solid $background-color
+
 .panel-title, .panel
   background-color white 
-
-th + th, td + td
-  border-left 2px solid $background-color
-
-tr + tr
-  border-top 2px solid $background-color
 
 .panel-title
   text-align left


### PR DESCRIPTION
...so it doesn't apply to the jobs page and other pages.

This styling for the debug pages also applied to the jobs page (and the custom graph page), but the debug index and jobs page changes were both on master.

|             | Before                                                                                                     | After                                                                                                      | Expectation |
|-------------|------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|-------------|
| Jobs Page   | ![image](https://user-images.githubusercontent.com/7341/46781401-6fd0b900-ccef-11e8-9a8d-a85e36f00cd6.png) | ![image](https://user-images.githubusercontent.com/7341/46781383-50399080-ccef-11e8-9c1a-05af81a026c8.png) | Fix vertical line that shows up in expanded area |
| Debug Index | ![image](https://user-images.githubusercontent.com/7341/46781426-90990e80-ccef-11e8-8f7d-d4d1ebec6fbe.png) | ![image](https://user-images.githubusercontent.com/7341/46781367-41eb7480-ccef-11e8-814f-8897d6734b2f.png) | Same        |

Release note: None