### PR TITLE
storage: make TestRangeTransferLeaseExpirationBased fail more eargerly

### DIFF
--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -636,8 +636,10 @@ func (l *leaseTransferTest) forceLeaseExtension(storeIdx int, lease roachpb.Leas
 		// attempt fails because it's already been renewed. This used to work
 		// before we compared the proposer's lease with the actual lease because
 		// the renewed lease still encompassed the previous request.
-		if _, ok := err.(*roachpb.NotLeaseHolderError); ok {
-			err = nil
+		if typedErr, ok := err.(*roachpb.NotLeaseHolderError); ok {
+			if typedErr.Replica == *typedErr.LeaseHolder {
+				err = nil
+			}
 		}
 	}
 	return err


### PR DESCRIPTION
Before we were seeing test flakes from
TestRangeTransferLeaseExpirationBased. The reason for this is that
forceLeaseExtension method in client_replica_test.go was swallowing
every NotLeaseHolderError even though it was only supposed to swallow
them when the leaseholder and the proposed leaseholder where the same
replica.

Now we're only going to swallow the error if the proposed leaseholder
and current leaseholder are the same. This will allow tests that depend
on forceLeaseExtension to fail eargely instead of timing out while
waiting for an error.

Release note: None