### PR TITLE
roachtest: cluster ctors no longer take a test

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/user"
 
 	"github.com/spf13/cobra"
 )
@@ -53,7 +54,9 @@ func main() {
 	rootCmd.PersistentFlags().BoolVarP(
 		&local, "local", "l", local, "run tests locally")
 	rootCmd.PersistentFlags().StringVarP(
-		&username, "user", "u", username, "username to run under, detect if blank")
+		&username, "user", "u", username,
+		"Username to use as a cluster name prefix. "+
+			"If blank, the current OS user is detected and specified.")
 	rootCmd.PersistentFlags().StringVar(
 		&cockroach, "cockroach", "", "path to cockroach binary to use")
 	rootCmd.PersistentFlags().StringVar(
@@ -108,6 +111,15 @@ If no pattern is given, all tests are run.
 			if count <= 0 {
 				return fmt.Errorf("--count (%d) must by greater than 0", count)
 			}
+
+			if username == "" {
+				usr, err := user.Current()
+				if err != nil {
+					panic(fmt.Sprintf("user.Current: %s", err))
+				}
+				username = usr.Username
+			}
+
 			r := newRegistry()
 			if buildTag != "" {
 				if err := r.setBuildVersion(buildTag); err != nil {

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -269,7 +269,7 @@ func TestRegistryVerifyClusterName(t *testing.T) {
 		{[]string{"hel+lo", "hel++lo"}, "have equivalent nightly cluster names"},
 		{[]string{"hello+"}, "must match regex"},
 		{[]string{strings.Repeat("y", 46)}, ""},
-		{[]string{strings.Repeat("y", 47)}, "must match regex"},
+		{[]string{strings.Repeat("y", 100)}, "must match regex"},
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {


### PR DESCRIPTION
The divorcing of clusters from tests is now unavoidable, and this patch
is another step in that direction.
This patch changes the cluster ctors to not take a test at all. Instead,
c.setTest() needs to be called later to set c.t. The idea is that it can
be called multiple times on the same cluster (and also that eventually
it will not be needed at all).

Release note: None