### PR TITLE
backport-2.1: opt: normalize ANY = ... to IN ...

### DIFF
--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -243,3 +243,41 @@
 )
 =>
 (SimplifyWhens $condition $whens)
+
+# SimplifyEqualsAnyTuple converts a scalar ANY operation to an IN comparison.
+# It transforms
+#
+#   x = ANY (...)
+#
+# to
+#
+#   x IN (...)
+#
+# Which allows scans to be constrained.
+[SimplifyEqualsAnyTuple, Normalize]
+(AnyScalar
+  $input:*
+  $tuple:(Tuple)
+  $cmp:(IsEquality $cmp)
+)
+=>
+(In
+  $input
+  $tuple
+)
+
+# SimplifyAnyScalarArray converts a scalar ANY operation on a constant ARRAY to a scalar
+# ANY operation on a tuple. In particular, this allows SimplifyEqualsAnyTuple to be
+# triggered, which allows constraints to be generated.
+[SimplifyAnyScalarArray, Normalize]
+(AnyScalar
+  $input:*
+  $ary:(Const) & (IsArray $ary)
+  $cmp:*
+)
+=>
+(AnyScalar
+  $input
+  (ConvertConstArrayToTuple $ary)
+  $cmp
+)

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -984,3 +984,103 @@ project
       ├── constraint: /5/1: [/'2018-07-09' - ]
       ├── key: (1)
       └── fd: (1)-->(5)
+
+# --------------------------------------------------
+# SimplifyEqualsAnyTuple
+# --------------------------------------------------
+
+opt expect=SimplifyEqualsAnyTuple
+SELECT k FROM a WHERE k = ANY (1, 2, 3)
+----
+scan a
+ ├── columns: k:1(int!null)
+ ├── constraint: /1: [/1 - /3]
+ └── key: (1)
+
+opt expect=SimplifyEqualsAnyTuple
+SELECT k FROM a WHERE k = ANY ()
+----
+values
+ ├── columns: k:1(int)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1)
+
+# --------------------------------------------------
+# SimplifyAnyScalarArray
+# --------------------------------------------------
+
+opt expect=SimplifyAnyScalarArray
+SELECT k FROM a WHERE k > ANY ARRAY[1, 2, 3]
+----
+select
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ ├── scan a
+ │    ├── columns: k:1(int!null)
+ │    └── key: (1)
+ └── filters [type=bool, outer=(1)]
+      └── k > ANY (1, 2, 3) [type=bool, outer=(1)]
+
+opt expect-not=SimplifyAnyScalarArray
+SELECT k FROM a WHERE k > ANY ARRAY[1, 2, 3, i]
+----
+project
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ └── select
+      ├── columns: k:1(int!null) i:2(int)
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── scan a
+      │    ├── columns: k:1(int!null) i:2(int)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters [type=bool, outer=(1,2)]
+           └── k > ANY ARRAY[1, 2, 3, i] [type=bool, outer=(1,2)]
+
+opt expect=SimplifyAnyScalarArray
+SELECT k FROM a WHERE k > ANY ARRAY[]:::INT[]
+----
+select
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ ├── scan a
+ │    ├── columns: k:1(int!null)
+ │    └── key: (1)
+ └── filters [type=bool, outer=(1)]
+      └── k > ANY () [type=bool, outer=(1)]
+
+# --------------------------------------------------
+# SimplifyEqualsAnyTuple + SimplifyAnyScalarArray
+# --------------------------------------------------
+
+opt expect=(SimplifyAnyScalarArray,SimplifyEqualsAnyTuple)
+SELECT k FROM a WHERE k = ANY ARRAY[1, 2, 3]
+----
+scan a
+ ├── columns: k:1(int!null)
+ ├── constraint: /1: [/1 - /3]
+ └── key: (1)
+
+opt expect=(SimplifyAnyScalarArray,SimplifyEqualsAnyTuple)
+SELECT k FROM a WHERE k = ANY ARRAY[]:::INT[]
+----
+values
+ ├── columns: k:1(int)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1)
+
+# TODO(justin): fold casts.
+opt
+SELECT k FROM a WHERE k = ANY '{1,2,3}'::INT[]
+----
+select
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ ├── scan a
+ │    ├── columns: k:1(int!null)
+ │    └── key: (1)
+ └── filters [type=bool, outer=(1)]
+      └── k = ANY '{1,2,3}'::INT[] [type=bool, outer=(1)]

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -350,6 +350,8 @@ define JsonSomeExists {
    Right Expr
 }
 
+# AnyScalar is the form of ANY which refers to an ANY operation on a
+# tuple or array, as opposed to Any which operates on a subquery.
 [Scalar]
 define AnyScalar {
    Left  Expr


### PR DESCRIPTION
Backport 1/1 commits from #30973.

/cc @cockroachdb/release

---

This commit adds two rules which, in concert, allow a filter of the form

    x = ANY ARRAY[...]

to constrain a scan on an index of x.

It's unclear to me if this is a win in the general case, but addressing
the conversation from a couple days ago where we discussed enabling a
placeholder ARRAY to be used instead of a tuple to possible make better
use of the plan cache.

Note this only converts constant arrays, but I don't think there's a reason
we couldn't also do array expressions.

Release note: None
