### PR TITLE
release-2.1: sql: capture and report internal/assertion errors

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -907,6 +907,8 @@ may increase either contention or retry errors, or both.</p>
 </span></td></tr>
 <tr><td><code>crdb_internal.cluster_id() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Returns the cluster ID.</p>
 </span></td></tr>
+<tr><td><code>crdb_internal.force_assertion_error(msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
 <tr><td><code>crdb_internal.force_error(errorCode: <a href="string.html">string</a>, msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td></tr>
 <tr><td><code>crdb_internal.force_log_fatal(msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -377,7 +377,10 @@ func (s *Server) getReportingInfo(ctx context.Context) *diagnosticspb.Diagnostic
 	}
 
 	info.SqlStats = s.pgServer.SQLServer.GetScrubbedStmtStats()
-	s.pgServer.SQLServer.FillErrorCounts(info.ErrorCounts, info.UnimplementedErrors)
+	s.pgServer.SQLServer.FillErrorCounts(
+		info.ErrorCounts,
+		info.UnimplementedErrors,
+	)
 	return &info
 }
 

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -312,6 +312,11 @@ func TestReportUsage(t *testing.T) {
 		) {
 			t.Fatal(err)
 		}
+		if _, err := db.Exec(`SELECT crdb_internal.force_assertion_error('woo')`); !testutils.IsError(
+			err, "internal error",
+		) {
+			t.Fatal(err)
+		}
 		// pass args to force a prepare/exec path as that may differ.
 		if _, err := db.Exec(`SELECT 1::INTERVAL(1), $1`, 1); !testutils.IsError(
 			err, "unimplemented",
@@ -487,13 +492,26 @@ func TestReportUsage(t *testing.T) {
 		}
 	}
 
-	if expected, actual := 3, len(r.last.FeatureUsage); expected != actual {
+	// This test would be infuriating if it had to be updated on every
+	// edit to the Go code that changed the line number of the trace
+	// produced by force_assertion_error, so just scrub the trace
+	// here.
+	for k := range r.last.FeatureUsage {
+		if strings.HasPrefix(k, "internalerror.") {
+			r.last.FeatureUsage["internalerror."] = r.last.FeatureUsage[k]
+			delete(r.last.FeatureUsage, k)
+			break
+		}
+	}
+
+	if expected, actual := 4, len(r.last.FeatureUsage); expected != actual {
 		t.Fatalf("expected %d feature usage counts, got %d: %v", expected, actual, r.last.FeatureUsage)
 	}
 	for key, expected := range map[string]int32{
-		"test.a": 1,
-		"test.b": 2,
-		"test.c": 3,
+		"test.a":         1,
+		"test.b":         2,
+		"test.c":         3,
+		"internalerror.": 10,
 	} {
 		if got, ok := r.last.FeatureUsage[key]; !ok {
 			t.Fatalf("expected report of feature %q", key)
@@ -502,11 +520,11 @@ func TestReportUsage(t *testing.T) {
 		}
 	}
 
-	if expected, actual := 5, len(r.last.ErrorCounts); expected != actual {
+	if expected, actual := 6, len(r.last.ErrorCounts); expected != actual {
 		t.Fatalf("expected %d error codes counts in report, got %d (%v)", expected, actual, r.last.ErrorCounts)
 	}
 
-	// this test would be infuriating if it had to be updated on every edit to
+	// This test would be infuriating if it had to be updated on every edit to
 	// builtins.go that changed the line number of force_error, so just scrub the
 	// line number here.
 	for k := range r.last.ErrorCounts {
@@ -663,6 +681,7 @@ func TestReportUsage(t *testing.T) {
 		`[true,false,false] SELECT (_, _, __more2__) = (SELECT _, _, _, _ FROM _ LIMIT _)`,
 		`[true,false,true] SELECT _ / $1`,
 		`[true,false,true] SELECT _ / _`,
+		`[true,false,true] SELECT crdb_internal.force_assertion_error(_)`,
 		`[true,false,true] SELECT crdb_internal.force_error(_, $1)`,
 		`[true,true,false] SELECT * FROM _ WHERE (_ = _) AND (_ = _)`,
 		`[true,true,false] SELECT * FROM _ WHERE (_ = length($1::STRING)) OR (_ = $2)`,
@@ -706,6 +725,7 @@ func TestReportUsage(t *testing.T) {
 			`SELECT * FROM _ WHERE (_ = _) AND (_ = _)`,
 			`SELECT _ / $1`,
 			`SELECT _ / _`,
+			`SELECT crdb_internal.force_assertion_error(_)`,
 			`SELECT crdb_internal.force_error(_, $1)`,
 			`SET CLUSTER SETTING "server.time_until_store_dead" = _`,
 			`SET CLUSTER SETTING "diagnostics.reporting.send_crash_reports" = _`,

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -572,14 +572,14 @@ func (n *alterTableNode) startExec(params runParams) error {
 		case *tree.AlterTableInjectStats:
 			sd, ok := n.statsData[i]
 			if !ok {
-				return errors.Errorf("programming error: missing stats data")
+				return pgerror.NewAssertionErrorf("missing stats data")
 			}
 			if err := injectTableStats(params, n.tableDesc, sd); err != nil {
 				return err
 			}
 
 		default:
-			return fmt.Errorf("unsupported alter command: %T", cmd)
+			return pgerror.NewAssertionErrorf("unsupported alter command: %T", cmd)
 		}
 	}
 	// Were some changes made?

--- a/pkg/sql/cancel_queries.go
+++ b/pkg/sql/cancel_queries.go
@@ -67,8 +67,7 @@ func (n *cancelQueriesNode) Next(params runParams) (bool, error) {
 	statusServer := params.extendedEvalCtx.StatusServer
 	queryIDString, ok := tree.AsDString(datum)
 	if !ok {
-		return false, pgerror.NewErrorf(pgerror.CodeInternalError,
-			"programming error: %q: expected *DString, found %T", datum, datum)
+		return false, pgerror.NewAssertionErrorf("%q: expected *DString, found %T", datum, datum)
 	}
 
 	queryID, err := StringToClusterWideID(string(queryIDString))

--- a/pkg/sql/cancel_sessions.go
+++ b/pkg/sql/cancel_sessions.go
@@ -66,8 +66,7 @@ func (n *cancelSessionsNode) Next(params runParams) (bool, error) {
 	statusServer := params.extendedEvalCtx.StatusServer
 	sessionIDString, ok := tree.AsDString(datum)
 	if !ok {
-		return false, pgerror.NewErrorf(pgerror.CodeInternalError,
-			"programming error: %q: expected *DString, found %T", datum, datum)
+		return false, pgerror.NewAssertionErrorf("%q: expected *DString, found %T", datum, datum)
 	}
 
 	sessionID, err := StringToClusterWideID(string(sessionIDString))

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -309,8 +310,10 @@ func (s *Server) Start(ctx context.Context, stopper *stop.Stopper) {
 	s.PeriodicallyClearStmtStats(ctx, stopper)
 }
 
-// recordError takes an error and increments the corresponding count for its
-// error code, and, if it is an unimplemented error, the count for that feature.
+// recordError takes an error and increments the corresponding count
+// for its error code, and, if it is an unimplemented or internal
+// error, the count for that feature or the internal error's shortened
+// stack trace.
 func (s *Server) recordError(err error) {
 	if err == nil {
 		return
@@ -323,12 +326,17 @@ func (s *Server) recordError(err error) {
 	if pgErr, ok := pgerror.GetPGCause(err); ok {
 		s.errorCounts.codes[pgErr.Code]++
 
-		if pgErr.Code == pgerror.CodeFeatureNotSupportedError {
+		switch pgErr.Code {
+		case pgerror.CodeFeatureNotSupportedError:
 			if feature := pgErr.InternalCommand; feature != "" {
 				if s.errorCounts.unimplemented == nil {
 					s.errorCounts.unimplemented = make(map[string]int64)
 				}
 				s.errorCounts.unimplemented[feature]++
+			}
+		case pgerror.CodeInternalError:
+			if trace := pgErr.InternalCommand; trace != "" {
+				telemetry.Count("internalerror." + trace)
 			}
 		}
 	} else {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1186,8 +1186,7 @@ func (ex *connExecutor) runObserverStatement(
 		ex.runSetTracing(ctx, sqlStmt, res)
 		return nil
 	default:
-		res.SetError(pgerror.NewErrorf(pgerror.CodeInternalError,
-			"programming error: unrecognized observer statement type %T", stmt.AST))
+		res.SetError(pgerror.NewAssertionErrorf("unrecognized observer statement type %T", stmt.AST))
 		return nil
 	}
 }

--- a/pkg/sql/control_jobs.go
+++ b/pkg/sql/control_jobs.go
@@ -81,8 +81,7 @@ func (n *controlJobsNode) startExec(params runParams) error {
 
 		jobID, ok := tree.AsDInt(jobIDDatum)
 		if !ok {
-			return pgerror.NewErrorf(pgerror.CodeInternalError,
-				"programming error: %q: expected *DInt, found %T", jobIDDatum, jobIDDatum)
+			return pgerror.NewAssertionErrorf("%q: expected *DInt, found %T", jobIDDatum, jobIDDatum)
 		}
 
 		switch n.desiredStatus {
@@ -93,8 +92,7 @@ func (n *controlJobsNode) startExec(params runParams) error {
 		case jobs.StatusCanceled:
 			err = reg.Cancel(params.ctx, params.p.txn, int64(jobID))
 		default:
-			err = pgerror.NewErrorf(pgerror.CodeInternalError,
-				"programming error: unhandled status %v", n.desiredStatus)
+			err = pgerror.NewAssertionErrorf("unhandled status %v", n.desiredStatus)
 		}
 		if err != nil {
 			return err

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -73,8 +73,7 @@ func (p *planner) CreateStatistics(ctx context.Context, n *tree.CreateStats) (pl
 }
 
 func (*createStatsNode) Next(runParams) (bool, error) {
-	return false, pgerror.NewErrorf(pgerror.CodeInternalError,
-		"programming error: createStatsNode cannot be executed locally")
+	return false, pgerror.NewAssertionErrorf("createStatsNode cannot be executed locally")
 }
 func (*createStatsNode) Close(context.Context) {}
 func (*createStatsNode) Values() tree.Datums   { return nil }

--- a/pkg/sql/create_user.go
+++ b/pkg/sql/create_user.go
@@ -132,8 +132,7 @@ func (n *CreateUserNode) startExec(params runParams) error {
 	if err != nil {
 		return err
 	} else if n.run.rowsAffected != 1 {
-		return errors.Errorf(
-			"programming error: %d rows affected by user creation; expected exactly one row affected",
+		return pgerror.NewAssertionErrorf("%d rows affected by user creation; expected exactly one row affected",
 			n.run.rowsAffected,
 		)
 	}

--- a/pkg/sql/discard.go
+++ b/pkg/sql/discard.go
@@ -39,8 +39,7 @@ func (p *planner) Discard(ctx context.Context, s *tree.Discard) (planNode, error
 		// DEALLOCATE ALL
 		p.preparedStatements.DeleteAll(ctx)
 	default:
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
-			"unknown mode for DISCARD: %d", s.Mode)
+		return nil, pgerror.NewAssertionErrorf("unknown mode for DISCARD: %d", s.Mode)
 	}
 	return newZeroNode(nil /* columns */), nil
 }

--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -49,10 +49,7 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 	// We know they are scan nodes from useInterleaveJoin, but we add
 	// this check to prevent future panics.
 	if !leftOk || !rightOk {
-		return PhysicalPlan{}, false, pgerror.NewErrorf(
-			pgerror.CodeInternalError,
-			"left and right children of join node must be scan nodes to execute an interleaved join",
-		)
+		return PhysicalPlan{}, false, pgerror.NewAssertionErrorf("left and right children of join node must be scan nodes to execute an interleaved join")
 	}
 
 	// We iterate through each table and collate their metadata for

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -20,14 +20,15 @@ import (
 
 	"fmt"
 
+	opentracing "github.com/opentracing/opentracing-go"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stringarena"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
 )
 
 // Distinct is the physical processor implementation of the DISTINCT relational operator.
@@ -73,7 +74,7 @@ func NewDistinct(
 	output RowReceiver,
 ) (RowSourcedProcessor, error) {
 	if len(spec.DistinctColumns) == 0 {
-		return nil, errors.New("programming error: 0 distinct columns specified for distinct processor")
+		return nil, pgerror.NewAssertionErrorf("0 distinct columns specified for distinct processor")
 	}
 
 	var distinctCols, orderedCols util.FastIntSet
@@ -89,7 +90,7 @@ func NewDistinct(
 		distinctCols.Add(int(col))
 	}
 	if !orderedCols.SubsetOf(distinctCols) {
-		return nil, errors.New("ordered cols must be a subset of distinct cols")
+		return nil, pgerror.NewAssertionErrorf("ordered cols must be a subset of distinct cols")
 	}
 
 	ctx := flowCtx.EvalCtx.Ctx()

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -17,11 +17,12 @@ package distsqlrun
 import (
 	"context"
 
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -133,7 +134,7 @@ func newJoinReader(
 	output RowReceiver,
 ) (*joinReader, error) {
 	if spec.Visibility != ScanVisibility_PUBLIC {
-		return nil, errors.Errorf("internal error: joinReader specified with visibility %+v", spec.Visibility)
+		return nil, pgerror.NewAssertionErrorf("joinReader specified with visibility %+v", spec.Visibility)
 	}
 
 	jr := &joinReader{

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -657,8 +657,7 @@ func (v *extractAggregatesVisitor) VisitPre(expr tree.Expr) (recurse bool, newEx
 						var err error
 						arguments[i-1], err = t.Exprs[i].(tree.TypedExpr).Eval(evalContext)
 						if err != nil {
-							v.err = pgerror.NewErrorf(pgerror.CodeInternalError,
-								"programming error: can't evaluate %s - %v", t.Exprs[i].String(), err)
+							v.err = pgerror.NewAssertionErrorf("can't evaluate %s - %v", t.Exprs[i].String(), err)
 							return false, expr
 						}
 					}

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -487,8 +488,7 @@ func (ie *internalExecutorImpl) execInternal(
 				return
 			}
 		}
-		resCh <- result{err: errors.Errorf(
-			"programming error: missing result for pos: %d and no previous error", resPos)}
+		resCh <- result{err: pgerror.NewAssertionErrorf("missing result for pos: %d and no previous error", resPos)}
 	}
 	errCallback := func(err error) {
 		if resultsReceived {

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -520,7 +520,7 @@ func (s LeaseStore) getForExpiration(
 			return sqlbase.ErrDescriptorNotFound
 		}
 		if !tableDesc.ModificationTime.Less(prevTimestamp) {
-			return errors.Errorf("internal error: unable to read table= (%d, %s)", id, expiration)
+			return pgerror.NewAssertionErrorf("unable to read table= (%d, %s)", id, expiration)
 		}
 		// Create a tableVersionState with the table and without a lease.
 		table = &tableVersionState{

--- a/pkg/sql/lex/encode.go
+++ b/pkg/sql/lex/encode.go
@@ -322,8 +322,7 @@ func DecodeRawBytesToByteArray(data string, be sessiondata.BytesEncodeFormat) ([
 		return base64.StdEncoding.DecodeString(data)
 
 	default:
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
-			"programming error: unhandled format: %s", be)
+		return nil, pgerror.NewAssertionErrorf("unhandled format: %s", be)
 	}
 }
 

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -574,9 +574,7 @@ func encodeConstraintKey(
 				return nil, err
 			}
 			if len(keys) > 1 {
-				err := pgerror.NewError(
-					pgerror.CodeInternalError, "trying to use multiple keys in index lookup",
-				)
+				err := pgerror.NewAssertionErrorf("trying to use multiple keys in index lookup")
 				return nil, err
 			}
 			key = keys[0]

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -93,8 +93,7 @@ func ParseOne(sql string) (tree.Statement, error) {
 		return nil, err
 	}
 	if len(stmts) != 1 {
-		return nil, pgerror.NewErrorf(
-			pgerror.CodeInternalError, "expected 1 statement, but found %d", len(stmts))
+		return nil, pgerror.NewAssertionErrorf("expected 1 statement, but found %d", len(stmts))
 	}
 	return stmts[0], nil
 }
@@ -109,8 +108,7 @@ func ParseTableNameWithIndex(sql string) (tree.TableNameWithIndex, error) {
 	}
 	rename, ok := stmt.(*tree.RenameIndex)
 	if !ok {
-		return tree.TableNameWithIndex{}, pgerror.NewErrorf(
-			pgerror.CodeInternalError, "expected an ALTER INDEX statement, but found %T", stmt)
+		return tree.TableNameWithIndex{}, pgerror.NewAssertionErrorf("expected an ALTER INDEX statement, but found %T", stmt)
 	}
 	return *rename.Index, nil
 }
@@ -125,8 +123,7 @@ func ParseTableName(sql string) (*tree.TableName, error) {
 	}
 	rename, ok := stmt.(*tree.RenameTable)
 	if !ok {
-		return nil, pgerror.NewErrorf(
-			pgerror.CodeInternalError, "expected an ALTER TABLE statement, but found %T", stmt)
+		return nil, pgerror.NewAssertionErrorf("expected an ALTER TABLE statement, but found %T", stmt)
 	}
 	return rename.Name.Normalize()
 }
@@ -139,7 +136,7 @@ func parseExprs(exprs []string) (tree.Exprs, error) {
 	}
 	set, ok := stmt.(*tree.SetVar)
 	if !ok {
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "expected a SET statement, but found %T", stmt)
+		return nil, pgerror.NewAssertionErrorf("expected a SET statement, but found %T", stmt)
 	}
 	return set.Values, nil
 }
@@ -159,7 +156,7 @@ func ParseExpr(sql string) (tree.Expr, error) {
 		return nil, err
 	}
 	if len(exprs) != 1 {
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "expected 1 expression, found %d", len(exprs))
+		return nil, pgerror.NewAssertionErrorf("expected 1 expression, found %d", len(exprs))
 	}
 	return exprs[0], nil
 }
@@ -173,7 +170,7 @@ func ParseType(sql string) (coltypes.CastTargetType, error) {
 
 	cast, ok := expr.(*tree.CastExpr)
 	if !ok {
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "expected a tree.CastExpr, but found %T", expr)
+		return nil, pgerror.NewAssertionErrorf("expected a tree.CastExpr, but found %T", expr)
 	}
 
 	return cast.Type, nil

--- a/pkg/sql/project_set.go
+++ b/pkg/sql/project_set.go
@@ -85,8 +85,7 @@ func (p *planner) ProjectSet(
 	exprs ...tree.Expr,
 ) (planDataSource, error) {
 	if len(exprs) == 0 {
-		return planDataSource{}, pgerror.NewErrorf(pgerror.CodeInternalError,
-			"programming error: ProjectSet invoked with no projected expression")
+		return planDataSource{}, pgerror.NewAssertionErrorf("ProjectSet invoked with no projected expression")
 	}
 
 	srcCols := sourceInfo.SourceColumns

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -417,8 +417,7 @@ func expandIndexName(
 
 		// Just an assertion: if we got there, there cannot be a value in index.Index yet.
 		if index.Index != "" {
-			return nil, nil, pgerror.NewErrorf(pgerror.CodeInternalError,
-				"programmer error: not-searched index name found already qualified: %s@%s", tn, index.Index)
+			return nil, nil, pgerror.NewAssertionErrorf("programmer error: not-searched index name found already qualified: %s@%s", tn, index.Index)
 		}
 
 		index.Index = tree.UnrestrictedName(tn.TableName)

--- a/pkg/sql/returning.go
+++ b/pkg/sql/returning.go
@@ -82,7 +82,6 @@ func (p *planner) Returning(
 		return r, nil
 
 	default:
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
-			"programming error: unexpected ReturningClause type: %T", t)
+		return nil, pgerror.NewAssertionErrorf("unexpected ReturningClause type: %T", t)
 	}
 }

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -120,8 +120,7 @@ func (n *scrubNode) startExec(params runParams) error {
 			return err
 		}
 	default:
-		return pgerror.NewErrorf(pgerror.CodeInternalError,
-			"unexpected SCRUB type received, got: %v", n.n.Typ)
+		return pgerror.NewAssertionErrorf("unexpected SCRUB type received, got: %v", n.n.Typ)
 	}
 	return nil
 }

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -573,7 +573,7 @@ func (a *avgAggregate) Result() (tree.Datum, error) {
 		_, err := tree.DecimalCtx.Quo(&t.Decimal, &t.Decimal, count)
 		return t, err
 	default:
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unexpected SUM result type: %s", t)
+		return nil, pgerror.NewAssertionErrorf("unexpected SUM result type: %s", t)
 	}
 }
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2785,6 +2785,22 @@ may increase either contention or retry errors, or both.`,
 		},
 	),
 
+	"crdb_internal.force_assertion_error": makeBuiltin(
+		tree.FunctionProperties{
+			Category: categorySystemInfo,
+			Impure:   true,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"msg", types.String}},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				msg := string(*args[0].(*tree.DString))
+				return nil, pgerror.NewAssertionErrorf("%s", msg)
+			},
+			Info: "This function is used only by CockroachDB's developers for testing purposes.",
+		},
+	),
+
 	"crdb_internal.force_panic": makeBuiltin(
 		tree.FunctionProperties{
 			Category:   categorySystemInfo,
@@ -3224,7 +3240,7 @@ var jsonTypeOfImpl = tree.Overload{
 		case json.ObjectJSONType:
 			return jsonObjectDString, nil
 		}
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unexpected JSON type %d", t)
+		return nil, pgerror.NewAssertionErrorf("unexpected JSON type %d", t)
 	},
 	Info: "Returns the type of the outermost JSON value as a text string.",
 }
@@ -4246,7 +4262,7 @@ func asJSONBuildObjectKey(d tree.Datum) (string, error) {
 	case *tree.DBool, *tree.DInt, *tree.DFloat, *tree.DDecimal, *tree.DTimestamp, *tree.DTimestampTZ, *tree.DDate, *tree.DUuid, *tree.DInterval, *tree.DBytes, *tree.DIPAddr, *tree.DOid, *tree.DTime:
 		return tree.AsStringWithFlags(d, tree.FmtBareStrings), nil
 	default:
-		return "", pgerror.NewErrorf(pgerror.CodeInternalError, "unexpected type %T for key value", d)
+		return "", pgerror.NewAssertionErrorf("unexpected type %T for key value", d)
 	}
 }
 
@@ -4255,7 +4271,7 @@ func asJSONObjectKey(d tree.Datum) (string, error) {
 	case *tree.DString:
 		return string(*t), nil
 	default:
-		return "", pgerror.NewErrorf(pgerror.CodeInternalError, "unexpected type %T for asJSONObjectKey", d)
+		return "", pgerror.NewAssertionErrorf("unexpected type %T for asJSONObjectKey", d)
 	}
 }
 

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -179,8 +179,9 @@ func makeGeneratorOverload(
 	return makeGeneratorOverloadWithReturnType(in, tree.FixedReturnType(ret), g, info)
 }
 
-var errUnsuitableUseOfGenerator = pgerror.NewErrorf(pgerror.CodeInternalError,
-	"programming error: generator functions cannot be evaluated as scalars")
+func newUnsuitableUseOfGeneratorError() error {
+	return pgerror.NewAssertionErrorf("generator functions cannot be evaluated as scalars")
+}
 
 func makeGeneratorOverloadWithReturnType(
 	in tree.ArgTypes, retType tree.ReturnTyper, g tree.GeneratorFactory, info string,
@@ -190,7 +191,7 @@ func makeGeneratorOverloadWithReturnType(
 		ReturnType: retType,
 		Generator:  g,
 		Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-			return nil, errUnsuitableUseOfGenerator
+			return nil, newUnsuitableUseOfGeneratorError()
 		},
 		Info: info,
 	}

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -213,7 +213,7 @@ func makePGGetIndexDef(argTypes tree.ArgTypes) tree.Overload {
 				return tree.NewDString(""), nil
 			}
 			if len(r) > 1 {
-				return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "programming error: pg_get_indexdef query has more than 1 result row: %+v", r)
+				return nil, pgerror.NewAssertionErrorf("pg_get_indexdef query has more than 1 result row: %+v", r)
 			}
 			return r[0], nil
 		},

--- a/pkg/sql/sem/builtins/window_frame_builtins.go
+++ b/pkg/sql/sem/builtins/window_frame_builtins.go
@@ -166,7 +166,7 @@ func (w *slidingWindowSumFunc) removeAllBefore(
 		case *tree.DInterval:
 			err = w.agg.Add(ctx, &tree.DInterval{Duration: duration.Duration{}.Sub(v.Duration)})
 		default:
-			err = pgerror.NewErrorf(pgerror.CodeInternalError, "unexpected value %v", v)
+			err = pgerror.NewAssertionErrorf("unexpected value %v", v)
 		}
 		if err != nil {
 			return err
@@ -261,7 +261,7 @@ func (w *avgWindowFunc) Compute(
 		_, err := tree.DecimalCtx.Quo(&avg.Decimal, &dd.Decimal, count)
 		return &avg, err
 	default:
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unexpected SUM result type: %s", t)
+		return nil, pgerror.NewAssertionErrorf("unexpected SUM result type: %s", t)
 	}
 }
 

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -319,8 +319,7 @@ func (expr *NumVal) ResolveAsType(ctx *SemaContext, typ types.T) (Datum, error) 
 		oid.semanticType = coltypes.OidTypeToColType(typ)
 		return oid, nil
 	default:
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
-			"could not resolve %T %v into a %T", expr, expr, typ)
+		return nil, pgerror.NewAssertionErrorf("could not resolve %T %v into a %T", expr, expr, typ)
 	}
 }
 
@@ -482,8 +481,7 @@ func (expr *StrVal) ResolveAsType(ctx *SemaContext, typ types.T) (Datum, error) 
 			expr.resString = DString(expr.s)
 			return &expr.resString, nil
 		}
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
-			"programming error: attempt to type byte array literal to %T", typ)
+		return nil, pgerror.NewAssertionErrorf("attempt to type byte array literal to %T", typ)
 	}
 
 	// Typing a string literal constant into some value type.
@@ -500,8 +498,7 @@ func (expr *StrVal) ResolveAsType(ctx *SemaContext, typ types.T) (Datum, error) 
 
 	datum, err := parseStringAs(typ, expr.s, ctx)
 	if datum == nil && err == nil {
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
-			"could not resolve %T %v into a %T", expr, expr, typ)
+		return nil, pgerror.NewAssertionErrorf("could not resolve %T %v into a %T", expr, expr, typ)
 	}
 	return datum, err
 }

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -209,7 +209,7 @@ func MakeDBool(d DBool) *DBool {
 func MustBeDBool(e Expr) DBool {
 	b, ok := AsDBool(e)
 	if !ok {
-		panic(pgerror.NewErrorf(pgerror.CodeInternalError, "expected *DBool, found %T", e))
+		panic(pgerror.NewAssertionErrorf("expected *DBool, found %T", e))
 	}
 	return b
 }
@@ -346,8 +346,7 @@ func GetBool(d Datum) (DBool, error) {
 	if d == DNull {
 		return DBool(false), nil
 	}
-	return false, pgerror.NewErrorf(
-		pgerror.CodeInternalError, "cannot convert %s to type %s", d.ResolvedType(), types.Bool)
+	return false, pgerror.NewAssertionErrorf("cannot convert %s to type %s", d.ResolvedType(), types.Bool)
 }
 
 // ResolvedType implements the TypedExpr interface.
@@ -462,7 +461,7 @@ func AsDInt(e Expr) (DInt, bool) {
 func MustBeDInt(e Expr) DInt {
 	i, ok := AsDInt(e)
 	if !ok {
-		panic(pgerror.NewErrorf(pgerror.CodeInternalError, "expected *DInt, found %T", e))
+		panic(pgerror.NewAssertionErrorf("expected *DInt, found %T", e))
 	}
 	return i
 }
@@ -892,7 +891,7 @@ func AsDString(e Expr) (DString, bool) {
 func MustBeDString(e Expr) DString {
 	i, ok := AsDString(e)
 	if !ok {
-		panic(pgerror.NewErrorf(pgerror.CodeInternalError, "expected *DString, found %T", e))
+		panic(pgerror.NewAssertionErrorf("expected *DString, found %T", e))
 	}
 	return i
 }
@@ -1104,7 +1103,7 @@ func NewDBytes(d DBytes) *DBytes {
 func MustBeDBytes(e Expr) DBytes {
 	i, ok := AsDBytes(e)
 	if !ok {
-		panic(pgerror.NewErrorf(pgerror.CodeInternalError, "expected *DBytes, found %T", e))
+		panic(pgerror.NewAssertionErrorf("expected *DBytes, found %T", e))
 	}
 	return i
 }
@@ -1332,7 +1331,7 @@ func AsDIPAddr(e Expr) (DIPAddr, bool) {
 func MustBeDIPAddr(e Expr) DIPAddr {
 	i, ok := AsDIPAddr(e)
 	if !ok {
-		panic(pgerror.NewErrorf(pgerror.CodeInternalError, "expected *DIPAddr, found %T", e))
+		panic(pgerror.NewAssertionErrorf("expected *DIPAddr, found %T", e))
 	}
 	return i
 }
@@ -2280,7 +2279,7 @@ func AsDJSON(e Expr) (*DJSON, bool) {
 func MustBeDJSON(e Expr) DJSON {
 	i, ok := AsDJSON(e)
 	if !ok {
-		panic(pgerror.NewErrorf(pgerror.CodeInternalError, "expected *DJSON, found %T", e))
+		panic(pgerror.NewAssertionErrorf("expected *DJSON, found %T", e))
 	}
 	return *i
 }
@@ -2329,7 +2328,7 @@ func AsJSON(d Datum) (json.JSON, error) {
 			return json.NullJSONValue, nil
 		}
 
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unexpected type %T for AsJSON", d)
+		return nil, pgerror.NewAssertionErrorf("unexpected type %T for AsJSON", d)
 	}
 }
 
@@ -2853,7 +2852,7 @@ func AsDArray(e Expr) (*DArray, bool) {
 func MustBeDArray(e Expr) *DArray {
 	i, ok := AsDArray(e)
 	if !ok {
-		panic(pgerror.NewErrorf(pgerror.CodeInternalError, "expected *DArray, found %T", e))
+		panic(pgerror.NewAssertionErrorf("expected *DArray, found %T", e))
 	}
 	return i
 }
@@ -2984,8 +2983,7 @@ var errNonHomogeneousArray = pgerror.NewError(pgerror.CodeArraySubscriptError, "
 // consistent with the type of the Datum.
 func (d *DArray) Append(v Datum) error {
 	if v != DNull && !d.ParamTyp.Equivalent(v.ResolvedType()) {
-		return pgerror.NewErrorf(
-			pgerror.CodeInternalError, "cannot append %s to array containing %s", d.ParamTyp,
+		return pgerror.NewAssertionErrorf("cannot append %s to array containing %s", d.ParamTyp,
 			v.ResolvedType())
 	}
 	if d.Len() >= maxArrayLength {
@@ -3172,14 +3170,13 @@ func wrapWithOid(d Datum, oid oid.Oid) Datum {
 	case *DString:
 	case *DArray:
 	case dNull, *DOidWrapper:
-		panic(pgerror.NewErrorf(
-			pgerror.CodeInternalError, "cannot wrap %T with an Oid", v))
+		panic(pgerror.NewAssertionErrorf("cannot wrap %T with an Oid", v))
 	default:
 		// Currently only *DInt, *DString, *DArray are hooked up to work with
 		// *DOidWrapper. To support another base Datum type, replace all type
 		// assertions to that type with calls to functions like AsDInt and
 		// MustBeDInt.
-		panic(pgerror.NewErrorf(pgerror.CodeInternalError, "unsupported Datum type passed to wrapWithOid: %T", d))
+		panic(pgerror.NewAssertionErrorf("unsupported Datum type passed to wrapWithOid: %T", d))
 	}
 	return &DOidWrapper{
 		Wrapped: d,

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3346,7 +3346,7 @@ func (expr *ComparisonExpr) Eval(ctx *EvalContext) (Datum, error) {
 		} else if array, ok := AsDArray(right); ok {
 			datums = array.Array
 		} else {
-			return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unhandled right expression %s", right)
+			return nil, pgerror.NewAssertionErrorf("unhandled right expression %s", right)
 		}
 		return evalDatumsCmp(ctx, op, expr.SubOperator, expr.fn, left, datums)
 	}
@@ -3369,8 +3369,7 @@ func (expr *ComparisonExpr) Eval(ctx *EvalContext) (Datum, error) {
 // ValueGenerator for use by set projections.
 func (expr *FuncExpr) EvalArgsAndGetGenerator(ctx *EvalContext) (ValueGenerator, error) {
 	if expr.fn == nil || expr.fnProps.Class != GeneratorClass {
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
-			"programming error: cannot call EvalArgsAndGetGenerator() on non-aggregate function: %q", ErrString(expr))
+		return nil, pgerror.NewAssertionErrorf("cannot call EvalArgsAndGetGenerator() on non-aggregate function: %q", ErrString(expr))
 	}
 	nullArg, args, err := expr.evalArgs(ctx)
 	if err != nil || nullArg {
@@ -3572,7 +3571,7 @@ func (expr *ParenExpr) Eval(ctx *EvalContext) (Datum, error) {
 
 // Eval implements the TypedExpr interface.
 func (expr *RangeCond) Eval(ctx *EvalContext) (Datum, error) {
-	return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unhandled type %T", expr)
+	return nil, pgerror.NewAssertionErrorf("unhandled type %T", expr)
 }
 
 // Eval implements the TypedExpr interface.
@@ -3598,32 +3597,32 @@ func (expr *UnaryExpr) Eval(ctx *EvalContext) (Datum, error) {
 
 // Eval implements the TypedExpr interface.
 func (expr DefaultVal) Eval(ctx *EvalContext) (Datum, error) {
-	return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unhandled type %T", expr)
+	return nil, pgerror.NewAssertionErrorf("unhandled type %T", expr)
 }
 
 // Eval implements the TypedExpr interface.
 func (expr UnqualifiedStar) Eval(ctx *EvalContext) (Datum, error) {
-	return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unhandled type %T", expr)
+	return nil, pgerror.NewAssertionErrorf("unhandled type %T", expr)
 }
 
 // Eval implements the TypedExpr interface.
 func (expr *UnresolvedName) Eval(ctx *EvalContext) (Datum, error) {
-	return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unhandled type %T", expr)
+	return nil, pgerror.NewAssertionErrorf("unhandled type %T", expr)
 }
 
 // Eval implements the TypedExpr interface.
 func (expr *AllColumnsSelector) Eval(ctx *EvalContext) (Datum, error) {
-	return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unhandled type %T", expr)
+	return nil, pgerror.NewAssertionErrorf("unhandled type %T", expr)
 }
 
 // Eval implements the TypedExpr interface.
 func (expr *TupleStar) Eval(ctx *EvalContext) (Datum, error) {
-	return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unhandled type %T", expr)
+	return nil, pgerror.NewAssertionErrorf("unhandled type %T", expr)
 }
 
 // Eval implements the TypedExpr interface.
 func (expr *ColumnItem) Eval(ctx *EvalContext) (Datum, error) {
-	return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unhandled type %T", expr)
+	return nil, pgerror.NewAssertionErrorf("unhandled type %T", expr)
 }
 
 // Eval implements the TypedExpr interface.
@@ -3643,8 +3642,7 @@ func (t *Tuple) Eval(ctx *EvalContext) (Datum, error) {
 func arrayOfType(typ types.T) (*DArray, error) {
 	arrayTyp, ok := typ.(types.TArray)
 	if !ok {
-		return nil, pgerror.NewErrorf(
-			pgerror.CodeInternalError, "array node type (%v) is not types.TArray", typ)
+		return nil, pgerror.NewAssertionErrorf("array node type (%v) is not types.TArray", typ)
 	}
 	if !types.IsValidArrayElementType(arrayTyp.Typ) {
 		return nil, pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError, "arrays of %s not allowed", arrayTyp.Typ)
@@ -3690,8 +3688,7 @@ func (t *ArrayFlatten) Eval(ctx *EvalContext) (Datum, error) {
 
 	tuple, ok := d.(*DTuple)
 	if !ok {
-		return nil, pgerror.NewErrorf(
-			pgerror.CodeInternalError, "array subquery result (%v) is not DTuple", d)
+		return nil, pgerror.NewAssertionErrorf("array subquery result (%v) is not DTuple", d)
 	}
 	array.Array = tuple.D
 	return array, nil
@@ -3814,7 +3811,7 @@ func (t *Placeholder) Eval(ctx *EvalContext) (Datum, error) {
 	typ, typed := ctx.Placeholders.Type(t.Name, false)
 	if !typed {
 		// All placeholders should be typed at this point.
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "missing type for placeholder %s", t.Name)
+		return nil, pgerror.NewAssertionErrorf("missing type for placeholder %s", t.Name)
 	}
 	if !e.ResolvedType().Equivalent(typ) {
 		// This happens when we overrode the placeholder's type during type

--- a/pkg/sql/sem/tree/function_name.go
+++ b/pkg/sql/sem/tree/function_name.go
@@ -59,8 +59,7 @@ func (fn *ResolvableFunctionReference) Resolve(
 		fn.FunctionReference = fd
 		return fd, nil
 	default:
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
-			"programming error: unknown function name type: %+v (%T)",
+		return nil, pgerror.NewAssertionErrorf("unknown function name type: %+v (%T)",
 			fn.FunctionReference, fn.FunctionReference,
 		)
 	}

--- a/pkg/sql/sem/tree/normalizable_table_name.go
+++ b/pkg/sql/sem/tree/normalizable_table_name.go
@@ -60,8 +60,8 @@ func (nt *NormalizableTableName) Normalize() (*TableName, error) {
 		nt.TableNameReference = &tn
 		return &tn, nil
 	default:
-		return nil, pgerror.NewErrorWithDepthf(1, pgerror.CodeInternalError,
-			"programming error: unsupported table name reference: %+v (%T)",
+		return nil, pgerror.NewAssertionErrorf(
+			"unsupported table name reference: %+v (%T)",
 			nt.TableNameReference, nt.TableNameReference)
 	}
 }

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -793,7 +793,7 @@ func invertComparisonOp(op ComparisonOperator) (ComparisonOperator, error) {
 	case LT:
 		return GT, nil
 	default:
-		return op, pgerror.NewErrorf(pgerror.CodeInternalError, "internal error: unable to invert: %s", op)
+		return op, pgerror.NewAssertionErrorf("unable to invert: %s", op)
 	}
 }
 

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -390,7 +390,7 @@ func typeCheckOverloadedExprs(
 	ctx *SemaContext, desired types.T, overloads []overloadImpl, inBinOp bool, exprs ...Expr,
 ) ([]TypedExpr, []overloadImpl, error) {
 	if len(overloads) > math.MaxUint8 {
-		return nil, nil, pgerror.NewErrorf(pgerror.CodeInternalError, "too many overloads (%d > 255)", len(overloads))
+		return nil, nil, pgerror.NewAssertionErrorf("too many overloads (%d > 255)", len(overloads))
 	}
 
 	var s typeCheckOverloadState
@@ -773,8 +773,7 @@ func checkReturn(
 			if err != nil {
 				return s.typedExprs, nil, true, errors.Wrap(err, "error type checking constant value")
 			} else if des != nil && !typ.ResolvedType().Equivalent(des) {
-				panic(pgerror.NewErrorf(
-					pgerror.CodeInternalError, "desired constant value type %s but set type %s", des, typ.ResolvedType()))
+				panic(pgerror.NewAssertionErrorf("desired constant value type %s but set type %s", des, typ.ResolvedType()))
 			}
 			s.typedExprs[i] = typ
 		}

--- a/pkg/sql/sem/tree/parse_string.go
+++ b/pkg/sql/sem/tree/parse_string.go
@@ -46,7 +46,7 @@ func ParseStringAs(t types.T, s string, evalCtx *EvalContext) (Datum, error) {
 		default:
 			d, err = parseStringAs(t, s, evalCtx)
 			if d == nil && err == nil {
-				return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unknown type %s (%T)", t, t)
+				return nil, pgerror.NewAssertionErrorf("unknown type %s (%T)", t, t)
 			}
 		}
 	}

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -718,7 +718,7 @@ func walkReturningClause(v Visitor, clause ReturningClause) (ReturningClause, bo
 	case *ReturningNothing, *NoReturningClause:
 		return t, false
 	default:
-		panic(pgerror.NewErrorf(pgerror.CodeInternalError, "unexpected ReturningClause type: %T", t))
+		panic(pgerror.NewAssertionErrorf("unexpected ReturningClause type: %T", t))
 	}
 }
 

--- a/pkg/sql/sem/types/oid.go
+++ b/pkg/sql/sem/types/oid.go
@@ -213,7 +213,7 @@ func (t TOidWrapper) Oid() oid.Oid { return t.oid }
 func WrapTypeWithOid(t T, oid oid.Oid) T {
 	switch v := t.(type) {
 	case tUnknown, tAny, TOidWrapper:
-		panic(pgerror.NewErrorf(pgerror.CodeInternalError, "cannot wrap %T with an Oid", v))
+		panic(pgerror.NewAssertionErrorf("cannot wrap %T with an Oid", v))
 	}
 	return TOidWrapper{
 		T:   t,

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -358,8 +358,7 @@ func removeSequenceDependencies(
 			}
 		}
 		if refIdx == -1 {
-			return pgerror.NewError(
-				pgerror.CodeInternalError, "couldn't find reference from sequence to this column")
+			return pgerror.NewAssertionErrorf("couldn't find reference from sequence to this column")
 		}
 		seqDesc.DependedOnBy = append(seqDesc.DependedOnBy[:refIdx], seqDesc.DependedOnBy[refIdx+1:]...)
 		if err := params.p.writeSchemaChange(params.ctx, &seqDesc, sqlbase.InvalidMutationID); err != nil {

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/pkg/errors"
 )
 
 type showFingerprintsNode struct {
@@ -164,8 +164,8 @@ func (n *showFingerprintsNode) Next(params runParams) (bool, error) {
 	}
 
 	if len(fingerprintCols) != 1 {
-		return false, errors.Errorf(
-			"programming error: unexpected number of columns returned: 1 vs %d",
+		return false, pgerror.NewAssertionErrorf(
+			"unexpected number of columns returned: 1 vs %d",
 			len(fingerprintCols))
 	}
 	fingerprint := fingerprintCols[0]

--- a/pkg/sql/show_histogram.go
+++ b/pkg/sql/show_histogram.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/pkg/errors"
 )
 
 // Ideally, we would want upper_bound to have the type of the column the
@@ -59,7 +59,7 @@ func (p *planner) ShowHistogram(ctx context.Context, n *tree.ShowHistogram) (pla
 				return nil, fmt.Errorf("histogram %d not found", n.HistogramID)
 			}
 			if len(row) != 1 {
-				return nil, errors.Errorf("programming error: expected 1 column from internal query")
+				return nil, pgerror.NewAssertionErrorf("expected 1 column from internal query")
 			}
 			if row[0] == tree.DNull {
 				// We found a statistic, but it has no histogram.

--- a/pkg/sql/show_syntax.go
+++ b/pkg/sql/show_syntax.go
@@ -89,7 +89,7 @@ func runShowSyntax(
 
 		pqErr, ok := pgerror.GetPGCause(err)
 		if !ok {
-			return pgerror.NewErrorf(pgerror.CodeInternalError, "unknown parser error: %v", err)
+			return pgerror.NewAssertionErrorf("unknown parser error: %v", err)
 		}
 		if err := report(ctx, "error", pqErr.Message); err != nil {
 			return err

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -441,7 +441,7 @@ func (p *planner) rewriteIndexOrderings(
 			for _, id := range idxDesc.ExtraColumnIDs {
 				col, err := desc.FindColumnByID(id)
 				if err != nil {
-					return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "column with ID %d not found", id)
+					return nil, pgerror.NewAssertionErrorf("column with ID %d not found", id)
 				}
 
 				newOrderBy = append(newOrderBy, &tree.Order{

--- a/pkg/sql/sqlbase/cascader.go
+++ b/pkg/sql/sqlbase/cascader.go
@@ -58,7 +58,7 @@ func makeDeleteCascader(
 	alloc *DatumAlloc,
 ) (*cascader, error) {
 	if evalCtx == nil {
-		return nil, pgerror.NewError(pgerror.CodeInternalError, "programming error: evalContext is nil")
+		return nil, pgerror.NewAssertionErrorf("evalContext is nil")
 	}
 	var required bool
 Outer:
@@ -66,9 +66,7 @@ Outer:
 		for _, ref := range referencedIndex.ReferencedBy {
 			referencingTable, ok := tablesByID[ref.Table]
 			if !ok {
-				return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
-					"programming error: could not find table:%d in table descriptor map", ref.Table,
-				)
+				return nil, pgerror.NewAssertionErrorf("could not find table:%d in table descriptor map", ref.Table)
 			}
 			if referencingTable.IsAdding {
 				// We can assume that a table being added but not yet public is empty,
@@ -117,7 +115,7 @@ func makeUpdateCascader(
 	alloc *DatumAlloc,
 ) (*cascader, error) {
 	if evalCtx == nil {
-		return nil, pgerror.NewError(pgerror.CodeInternalError, "programming error: evalContext is nil")
+		return nil, pgerror.NewAssertionErrorf("evalContext is nil")
 	}
 	var required bool
 	colIDs := make(map[ColumnID]struct{})
@@ -139,9 +137,7 @@ Outer:
 		for _, ref := range referencedIndex.ReferencedBy {
 			referencingTable, ok := tablesByID[ref.Table]
 			if !ok {
-				return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
-					"programming error: could not find table:%d in table descriptor map", ref.Table,
-				)
+				return nil, pgerror.NewAssertionErrorf("could not find table:%d in table descriptor map", ref.Table)
 			}
 			if referencingTable.IsAdding {
 				// We can assume that a table being added but not yet public is empty,
@@ -364,8 +360,7 @@ func (c *cascader) addRowDeleter(table *TableDescriptor) (RowDeleter, RowFetcher
 	if rowDeleter, exists := c.rowDeleters[table.ID]; exists {
 		rowFetcher, existsFetcher := c.deleterRowFetchers[table.ID]
 		if !existsFetcher {
-			return RowDeleter{}, RowFetcher{}, pgerror.NewErrorf(pgerror.CodeInternalError,
-				"programming error: no corresponding row fetcher for the row deleter for table: (%d)%s",
+			return RowDeleter{}, RowFetcher{}, pgerror.NewAssertionErrorf("no corresponding row fetcher for the row deleter for table: (%d)%s",
 				table.ID, table.Name,
 			)
 		}
@@ -422,8 +417,7 @@ func (c *cascader) addRowUpdater(table *TableDescriptor) (RowUpdater, RowFetcher
 	if existsUpdater {
 		rowFetcher, existsFetcher := c.updaterRowFetchers[table.ID]
 		if !existsFetcher {
-			return RowUpdater{}, RowFetcher{}, pgerror.NewErrorf(pgerror.CodeInternalError,
-				"programming error: no corresponding row fetcher for the row updater for table: (%d)%s",
+			return RowUpdater{}, RowFetcher{}, pgerror.NewAssertionErrorf("no corresponding row fetcher for the row updater for table: (%d)%s",
 				table.ID, table.Name,
 			)
 		}
@@ -839,8 +833,7 @@ func (c *cascader) updateRows(
 							updateRow[rowIndex] = rowToUpdate[fetchRowIndex]
 							continue
 						}
-						return nil, nil, nil, 0, pgerror.NewErrorf(pgerror.CodeInternalError,
-							"could find find colID %d in either updated columns or the fetched row",
+						return nil, nil, nil, 0, pgerror.NewAssertionErrorf("could find find colID %d in either updated columns or the fetched row",
 							colID,
 						)
 					}
@@ -857,8 +850,7 @@ func (c *cascader) updateRows(
 							updateRow[rowIndex] = rowToUpdate[fetchRowIndex]
 							continue
 						}
-						return nil, nil, nil, 0, pgerror.NewErrorf(pgerror.CodeInternalError,
-							"could find find colID %d in either the index columns or the fetched row",
+						return nil, nil, nil, 0, pgerror.NewAssertionErrorf("could find find colID %d in either the index columns or the fetched row",
 							colID,
 						)
 					}
@@ -999,9 +991,7 @@ func (c *cascader) cascadeAll(
 			for _, ref := range referencedIndex.ReferencedBy {
 				referencingTable, ok := c.tablesByID[ref.Table]
 				if !ok {
-					return pgerror.NewErrorf(pgerror.CodeInternalError,
-						"programming error: could not find table:%d in table descriptor map", ref.Table,
-					)
+					return pgerror.NewAssertionErrorf("could not find table:%d in table descriptor map", ref.Table)
 				}
 				if referencingTable.IsAdding {
 					// We can assume that a table being added but not yet public is empty,
@@ -1112,9 +1102,7 @@ func (c *cascader) cascadeAll(
 		}
 		rowDeleter, exists := c.rowDeleters[tableID]
 		if !exists {
-			return pgerror.NewErrorf(pgerror.CodeInternalError,
-				"programming error: could not find row deleter for table %d", tableID,
-			)
+			return pgerror.NewAssertionErrorf("could not find row deleter for table %d", tableID)
 		}
 		for deletedRows.Len() > 0 {
 			if err := rowDeleter.Fks.addAllIdxChecks(ctx, deletedRows.At(0)); err != nil {
@@ -1137,9 +1125,7 @@ func (c *cascader) cascadeAll(
 		// Fetch the original and updated rows for the updater.
 		originalRows, originalRowsExists := c.originalRows[tableID]
 		if !originalRowsExists {
-			return pgerror.NewErrorf(pgerror.CodeInternalError,
-				"programming error: could not find original rows for table %d", tableID,
-			)
+			return pgerror.NewAssertionErrorf("could not find original rows for table %d", tableID)
 		}
 		totalRows := originalRows.Len()
 		if totalRows == 0 {
@@ -1148,14 +1134,11 @@ func (c *cascader) cascadeAll(
 
 		updatedRows, updatedRowsExists := c.updatedRows[tableID]
 		if !updatedRowsExists {
-			return pgerror.NewErrorf(pgerror.CodeInternalError,
-				"programming error: could not find updated rows for table %d", tableID,
-			)
+			return pgerror.NewAssertionErrorf("could not find updated rows for table %d", tableID)
 		}
 
 		if totalRows != updatedRows.Len() {
-			return pgerror.NewErrorf(pgerror.CodeInternalError,
-				"programming error: original rows length:%d not equal to updated rows length:%d for table %d",
+			return pgerror.NewAssertionErrorf("original rows length:%d not equal to updated rows length:%d for table %d",
 				totalRows, updatedRows.Len(), tableID,
 			)
 		}

--- a/pkg/sql/sqlbase/index_encoding.go
+++ b/pkg/sql/sqlbase/index_encoding.go
@@ -686,8 +686,7 @@ func EncodeInvertedIndexKeys(
 	keyPrefix []byte,
 ) (key [][]byte, err error) {
 	if len(index.ColumnIDs) > 1 {
-		return nil, pgerror.NewError(pgerror.CodeInternalError,
-			"trying to apply inverted index to more than one column")
+		return nil, pgerror.NewAssertionErrorf("trying to apply inverted index to more than one column")
 	}
 
 	var val tree.Datum
@@ -712,7 +711,7 @@ func EncodeInvertedIndexTableKeys(val tree.Datum, inKey []byte) (key [][]byte, e
 	case *tree.DJSON:
 		return json.EncodeInvertedIndexKeys(inKey, (t.JSON))
 	}
-	return nil, pgerror.NewError(pgerror.CodeInternalError, "trying to apply inverted index to non JSON type")
+	return nil, pgerror.NewAssertionErrorf("trying to apply inverted index to non JSON type")
 }
 
 // EncodeSecondaryIndex encodes key/values for a secondary

--- a/pkg/sql/sqlbase/rowwriter.go
+++ b/pkg/sql/sqlbase/rowwriter.go
@@ -417,8 +417,7 @@ func prepareInsertOrUpdateBatch(
 		var lastColID ColumnID
 		familySortedColumnIDs, ok := helper.sortedColumnFamily(family.ID)
 		if !ok {
-			return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
-				"programming error: invalid family sorted column id map")
+			return nil, pgerror.NewAssertionErrorf("invalid family sorted column id map")
 		}
 		for _, colID := range familySortedColumnIDs {
 			idx, ok := valColIDMapping[colID]
@@ -436,8 +435,7 @@ func prepareInsertOrUpdateBatch(
 			col := updatedCols[idx]
 
 			if lastColID > col.ID {
-				return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
-					"programming error: cannot write column id %d after %d", col.ID, lastColID)
+				return nil, pgerror.NewAssertionErrorf("cannot write column id %d after %d", col.ID, lastColID)
 			}
 			colIDDiff := col.ID - lastColID
 			lastColID = col.ID

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -43,18 +43,15 @@ type subquery struct {
 // retrieve the Datum result of a subquery.
 func (p *planner) EvalSubquery(expr *tree.Subquery) (result tree.Datum, err error) {
 	if expr.Idx == 0 {
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
-			"programming error: subquery %q was not processed, analyzeSubqueries not called?", expr)
+		return nil, pgerror.NewAssertionErrorf("subquery %q was not processed, analyzeSubqueries not called?", expr)
 	}
 	if expr.Idx < 0 || expr.Idx-1 >= len(p.curPlan.subqueryPlans) {
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
-			"programming error: invalid index %d for %q", expr.Idx, expr)
+		return nil, pgerror.NewAssertionErrorf("invalid index %d for %q", expr.Idx, expr)
 	}
 
 	s := &p.curPlan.subqueryPlans[expr.Idx-1]
 	if !s.started {
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
-			"programming error: subquery %d (%q) not started prior to evaluation", expr.Idx, expr)
+		return nil, pgerror.NewAssertionErrorf("subquery %d (%q) not started prior to evaluation", expr.Idx, expr)
 	}
 	return s.result, nil
 }
@@ -68,8 +65,7 @@ func (p *planTop) evalSubqueries(params runParams) error {
 		}
 
 		if !sq.expanded {
-			return pgerror.NewErrorf(pgerror.CodeInternalError,
-				"programming error: subquery %d (%q) was not expanded properly", i+1, sq.subquery)
+			return pgerror.NewAssertionErrorf("subquery %d (%q) was not expanded properly", i+1, sq.subquery)
 		}
 
 		if log.V(2) {

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -703,8 +703,7 @@ func (p *planner) writeTableDescToBatch(
 	b *client.Batch,
 ) error {
 	if isVirtualDescriptor(tableDesc) {
-		return pgerror.NewErrorf(pgerror.CodeInternalError,
-			"programming error: virtual descriptors cannot be stored, found: %v", tableDesc)
+		return pgerror.NewAssertionErrorf("virtual descriptors cannot be stored, found: %v", tableDesc)
 	}
 
 	if p.Tables().isCreatedTable(tableDesc.ID) {
@@ -733,8 +732,7 @@ func (p *planner) writeTableDescToBatch(
 	}
 
 	if err := tableDesc.ValidateTable(p.extendedEvalCtx.Settings); err != nil {
-		return pgerror.NewErrorf(pgerror.CodeInternalError,
-			"programming error: table descriptor is not valid: %s\n%v", err, tableDesc)
+		return pgerror.NewAssertionErrorf("table descriptor is not valid: %s\n%v", err, tableDesc)
 	}
 
 	p.Tables().addUncommittedTable(*tableDesc)

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -62,7 +62,7 @@ func (p *planner) Values(
 	case *tree.ValuesClause:
 		n = t
 	default:
-		log.Fatalf(ctx, "programming error. unhandled case in values: %T %v", origN, origN)
+		return nil, pgerror.NewAssertionErrorf("unhandled case in values: %T %v", origN, origN)
 	}
 
 	if len(n.Rows) == 0 {


### PR DESCRIPTION
Backport 1/1 commits from #31261.

/cc @cockroachdb/release

---

Requested by @petermattis. Desired by @awoods187. Inspired by @tschottdorf.
