### PR TITLE
release-2.1: sqlmigrations: Downgrade log message from error to info

### DIFF
--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -367,7 +367,7 @@ func (m *Manager) EnsureMigrations(ctx context.Context) error {
 		if err == nil {
 			break
 		}
-		log.Errorf(ctx, "failed attempt to acquire migration lease: %s", err)
+		log.Infof(ctx, "failed attempt to acquire migration lease: %s", err)
 	}
 	if err != nil {
 		return errors.Wrapf(err, "failed to acquire lease for running necessary migrations")


### PR DESCRIPTION
Backport 1/1 commits from #31270.

/cc @cockroachdb/release

---

Fixes #31269

Release note: None
