### PR TITLE
release-2.1: sql: make DISTSQL option to EXPLAIN ANALYZE optional

### DIFF
--- a/docs/generated/sql/bnf/explain_stmt.bnf
+++ b/docs/generated/sql/bnf/explain_stmt.bnf
@@ -1,4 +1,5 @@
 explain_stmt ::=
 	'EXPLAIN' preparable_stmt
 	| 'EXPLAIN' '(' ( | 'EXPRS' | 'METADATA' | 'QUALIFY' | 'VERBOSE' | 'TYPES' | 'OPT' | 'DISTSQL' ) ( ( ',' ( | 'EXPRS' | 'METADATA' | 'QUALIFY' | 'VERBOSE' | 'TYPES' | 'OPT' | 'DISTSQL' ) ) )* ')' preparable_stmt
+	| 'EXPLAIN' 'ANALYZE' preparable_stmt
 	| 'EXPLAIN' 'ANALYZE' '(' ( | 'EXPRS' | 'METADATA' | 'QUALIFY' | 'VERBOSE' | 'TYPES' | 'OPT' | 'DISTSQL' ) ( ( ',' ( | 'EXPRS' | 'METADATA' | 'QUALIFY' | 'VERBOSE' | 'TYPES' | 'OPT' | 'DISTSQL' ) ) )* ')' preparable_stmt

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1815,6 +1815,7 @@ func TestParse2(t *testing.T) {
 		{`ALTER TABLE a DROP b`, `ALTER TABLE a DROP COLUMN b`},
 		{`ALTER TABLE a ALTER b DROP NOT NULL`, `ALTER TABLE a ALTER COLUMN b DROP NOT NULL`},
 		{`ALTER TABLE a ALTER b TYPE INT`, `ALTER TABLE a ALTER COLUMN b SET DATA TYPE INT`},
+		{`EXPLAIN ANALYZE SELECT 1`, `EXPLAIN ANALYZE (DISTSQL) SELECT 1`},
 	}
 	for _, d := range testData {
 		stmts, err := parser.Parse(d.sql)

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2212,6 +2212,7 @@ table_name_list:
 // EXPLAIN <statement>
 // EXPLAIN ([PLAN ,] <planoptions...> ) <statement>
 // EXPLAIN [ANALYZE] (DISTSQL) <statement>
+// EXPLAIN ANALYZE [(DISTSQL)] <statement>
 //
 // Explainable statements:
 //     SELECT, CREATE, DROP, ALTER, INSERT, UPSERT, UPDATE, DELETE,
@@ -2230,6 +2231,10 @@ explain_stmt:
 | EXPLAIN '(' explain_option_list ')' preparable_stmt
   {
     $$.val = &tree.Explain{Options: $3.strs(), Statement: $5.stmt()}
+  }
+| EXPLAIN ANALYZE preparable_stmt
+  {
+    $$.val = &tree.Explain{Options: []string{"DISTSQL", $2}, Statement: $3.stmt()}
   }
 | EXPLAIN ANALYZE '(' explain_option_list ')' preparable_stmt
   {


### PR DESCRIPTION
Backport all commits from #31277. There was a merge conflict with the .bnf file because explain_analyze has its own on master. cc @lhirata, does your diagram PR #30036 need to be backported?

Reduce user surprise by not requiring a DISTSQL option in EXPLAIN
ANALYZE.

Release note (sql change): EXPLAIN ANALYZE <statement> is now a valid
equivalent of EXPLAIN ANALYZE (DISTSQL) <statement>