### PR TITLE
importccl: parse zero mysql dates as null

### DIFF
--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -150,6 +150,12 @@ func (m *mysqldumpReader) readFile(
 	return nil
 }
 
+const (
+	zeroDate = "0000-00-00"
+	zeroYear = "0000"
+	zeroTime = "0000-00-00 00:00:00"
+)
+
 // mysqlValueToDatum attempts to convert a value, as parsed from a mysqldump
 // INSERT statement, in to a Cockroach Datum of type `desired`. The MySQL parser
 // does not parse the values themselves to Go primitivies, rather leaving the
@@ -168,7 +174,22 @@ func mysqlValueToDatum(
 	case *mysql.SQLVal:
 		switch v.Type {
 		case mysql.StrVal:
-			return tree.ParseStringAs(desired, string(v.Val), evalContext)
+			s := string(v.Val)
+			// https://github.com/cockroachdb/cockroach/issues/29298
+
+			if strings.HasPrefix(s, zeroYear) {
+				switch desired {
+				case types.TimestampTZ, types.Timestamp:
+					if s == zeroTime {
+						return tree.DNull, nil
+					}
+				case types.Date:
+					if s == zeroDate {
+						return tree.DNull, nil
+					}
+				}
+			}
+			return tree.ParseStringAs(desired, s, evalContext)
 		case mysql.IntVal:
 			return tree.ParseStringAs(desired, string(v.Val), evalContext)
 		case mysql.FloatVal:
@@ -561,12 +582,21 @@ func mysqlColToCockroach(
 
 	case mysqltypes.Date:
 		def.Type = coltypes.Date
+		if col.Default != nil && bytes.Equal(col.Default.Val, []byte(zeroDate)) {
+			col.Default = nil
+		}
 	case mysqltypes.Time:
 		def.Type = coltypes.Time
 	case mysqltypes.Timestamp:
 		def.Type = coltypes.TimestampWithTZ
+		if col.Default != nil && bytes.Equal(col.Default.Val, []byte(zeroTime)) {
+			col.Default = nil
+		}
 	case mysqltypes.Datetime:
 		def.Type = coltypes.TimestampWithTZ
+		if col.Default != nil && bytes.Equal(col.Default.Val, []byte(zeroTime)) {
+			col.Default = nil
+		}
 	case mysqltypes.Year:
 		def.Type = coltypes.Int2
 


### PR DESCRIPTION
these nonsense values are permitted by older / less strict mysql versions but have no cockroach counterpart -- a date is either null, or an actual date, which cannot have a zero day or month. Mapping these values to null is the closest we can get them, and in schemas that allow null values, hopefully makes migration easier. In schemas that do not allow nulls these will of course produce errors but we do not really have another option in those cases.

Release note: none.