### PR TITLE
kv,storage: annotate context cancellation errors

### DIFF
--- a/pkg/kv/range_cache.go
+++ b/pkg/kv/range_cache.go
@@ -356,7 +356,7 @@ func (rdc *RangeDescriptorCache) lookupRangeDescriptorInternal(
 	select {
 	case res = <-resC:
 	case <-ctxDone:
-		return nil, nil, ctx.Err()
+		return nil, nil, errors.Wrap(ctx.Err(), "aborted during range descriptor lookup")
 	}
 
 	if res.Shared {

--- a/pkg/kv/range_cache_test.go
+++ b/pkg/kv/range_cache_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/pkg/errors"
 )
 
 type testDescriptorDB struct {
@@ -493,7 +494,7 @@ func TestRangeCacheContextCancellation(t *testing.T) {
 	}
 
 	expectContextCancellation := func(t *testing.T, c <-chan error) {
-		if err := <-c; err.Error() != context.Canceled.Error() {
+		if err := <-c; errors.Cause(err) != context.Canceled {
 			t.Errorf("expected context cancellation error, found %v", err)
 		}
 	}

--- a/pkg/kv/transport.go
+++ b/pkg/kv/transport.go
@@ -189,7 +189,7 @@ func (gt *grpcTransport) sendBatch(
 	// detect this pretty quickly, but the first check of the context
 	// in the local server comes pretty late)
 	if ctx.Err() != nil {
-		return nil, ctx.Err()
+		return nil, errors.Wrap(ctx.Err(), "aborted before batch send")
 	}
 
 	gt.opts.metrics.SentCount.Inc(1)

--- a/pkg/storage/intent_resolver.go
+++ b/pkg/storage/intent_resolver.go
@@ -933,7 +933,7 @@ func (ir *intentResolver) resolveIntents(
 	// Avoid doing any work on behalf of expired contexts. See
 	// https://github.com/cockroachdb/cockroach/issues/15997.
 	if err := ctx.Err(); err != nil {
-		return err
+		return errors.Wrap(err, "aborted resolving intents")
 	}
 	log.Eventf(ctx, "resolving intents [wait=%t]", opts.Wait)
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2323,7 +2323,7 @@ func (r *Replica) beginCmds(
 		// out early if we can.
 		if err := ctx.Err(); err != nil {
 			log.VEventf(ctx, 2, "%s before command queue: %s", err, ba.Summary())
-			return nil, err
+			return nil, errors.Wrap(err, "aborted before command queue")
 		}
 
 		// Get the requested timestamp for a given scope. This is used for
@@ -2418,7 +2418,7 @@ func (r *Replica) beginCmds(
 						// which will notice that our prereqs slice was not empty when we stopped
 						// pending and will adopt our prerequisites in turn.
 						r.removeCmdsFromCommandQueue(newCmds)
-						return nil, err
+						return nil, errors.Wrap(err, "aborted while in command queue")
 					case <-r.store.stopper.ShouldQuiesce():
 						// While shutting down, commands may have been added to the
 						// command queue that will never finish.
@@ -3659,7 +3659,7 @@ func (r *Replica) propose(
 	if err := ctx.Err(); err != nil {
 		errStr := fmt.Sprintf("%s before proposing: %s", err, ba.Summary())
 		log.Warning(ctx, errStr)
-		return nil, nil, 0, roachpb.NewError(err)
+		return nil, nil, 0, roachpb.NewError(errors.Wrap(err, "aborted before proposing"))
 	}
 
 	// Only need to check that the request is in bounds at proposal time,

--- a/pkg/storage/replica_backpressure.go
+++ b/pkg/storage/replica_backpressure.go
@@ -151,7 +151,7 @@ func (r *Replica) maybeBackpressureWriteBatch(ctx context.Context, ba roachpb.Ba
 		// Wait for the callback to be called.
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return errors.Wrap(ctx.Err(), "aborted while applying backpressure")
 		case err := <-splitC:
 			if err != nil {
 				return errors.Wrap(err, "split failed while applying backpressure")

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3148,7 +3148,7 @@ func (s *Store) Send(
 	for {
 		// Exit loop if context has been canceled or timed out.
 		if err := ctx.Err(); err != nil {
-			return nil, roachpb.NewError(err)
+			return nil, roachpb.NewError(errors.Wrap(err, "aborted during Store.Send"))
 		}
 
 		// Get range and add command to the range for execution.
@@ -3281,7 +3281,7 @@ func (s *Store) Send(
 				case <-mergeCompleteCh:
 					// Merge complete. Retry the command.
 				case <-ctx.Done():
-					return nil, roachpb.NewError(ctx.Err())
+					return nil, roachpb.NewError(errors.Wrap(ctx.Err(), "aborted during merge"))
 				case <-s.stopper.ShouldQuiesce():
 					return nil, roachpb.NewError(&roachpb.NodeUnavailableError{})
 				}


### PR DESCRIPTION
Previously, errors retrieved from cancelled context were frequently
passed up the stack without annotation, making it very difficult to
understand later what cancelled a context.

This commit annotates several potential context cancellation errors that
can occur on the synchronous query path with more context (no pun
intended).

Hopefully informs #30886, #31094, #30659, etc.

Release note: None