### PR TITLE
*: move RowFetcher and co to a new package, row

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -71,7 +72,7 @@ func kvsToRows(
 ) func(context.Context) ([]emitEntry, error) {
 	rfCache := newRowFetcherCache(leaseMgr)
 
-	var kvs sqlbase.SpanKVFetcher
+	var kvs row.SpanKVFetcher
 	appendEmitEntryForKV := func(
 		ctx context.Context, output []emitEntry, kv roachpb.KeyValue, schemaTimestamp hlc.Timestamp,
 	) ([]emitEntry, error) {

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -363,10 +364,8 @@ func (r fkResolver) LookupSchema(
 }
 
 // Implements the sql.SchemaResolver interface.
-func (r fkResolver) LookupTableByID(
-	ctx context.Context, id sqlbase.ID,
-) (sqlbase.TableLookup, error) {
-	return sqlbase.TableLookup{}, errSchemaResolver
+func (r fkResolver) LookupTableByID(ctx context.Context, id sqlbase.ID) (row.TableLookup, error) {
+	return row.TableLookup{}, errSchemaResolver
 }
 
 const csvDatabaseName = "csv"

--- a/pkg/server/settingsworker.go
+++ b/pkg/server/settingsworker.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -34,7 +35,7 @@ func (s *Server) refreshSettings() {
 
 	a := &sqlbase.DatumAlloc{}
 	settingsTablePrefix := keys.MakeTablePrefix(uint32(tbl.ID))
-	colIdxMap := sqlbase.ColIDtoRowIndexFromCols(tbl.Columns)
+	colIdxMap := row.ColIDtoRowIndexFromCols(tbl.Columns)
 
 	processKV := func(ctx context.Context, kv roachpb.KeyValue, u settings.Updater) error {
 		if !bytes.HasPrefix(kv.Key, settingsTablePrefix) {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -214,8 +215,8 @@ func (n *createTableNode) startExec(params runParams) error {
 
 		// Instantiate a row inserter and table writer. It has a 1-1
 		// mapping to the definitions in the descriptor.
-		ri, err := sqlbase.MakeRowInserter(
-			params.p.txn, &desc, nil, desc.Columns, sqlbase.SkipFKs, &params.p.alloc)
+		ri, err := row.MakeInserter(
+			params.p.txn, &desc, nil, desc.Columns, row.SkipFKs, &params.p.alloc)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/delete_test.go
+++ b/pkg/sql/delete_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -119,20 +120,20 @@ CREATE TABLE IF NOT EXISTS child_with_index(
 				}
 			}
 
-			lookup := func(ctx context.Context, tableID sqlbase.ID) (sqlbase.TableLookup, error) {
+			lookup := func(ctx context.Context, tableID sqlbase.ID) (row.TableLookup, error) {
 				table, exists := tablesByID[tableID]
 				if !exists {
-					return sqlbase.TableLookup{}, errors.Errorf("Could not lookup table:%d", tableID)
+					return row.TableLookup{}, errors.Errorf("Could not lookup table:%d", tableID)
 				}
-				return sqlbase.TableLookup{Table: table}, nil
+				return row.TableLookup{Table: table}, nil
 			}
 
-			fkTables, err := sqlbase.TablesNeededForFKs(
+			fkTables, err := row.TablesNeededForFKs(
 				context.TODO(),
 				*pd,
-				sqlbase.CheckDeletes,
+				row.CheckDeletes,
 				lookup,
-				sqlbase.NoCheckPrivilege,
+				row.NoCheckPrivilege,
 				nil, /* AnalyzeExprFunction */
 			)
 			if err != nil {

--- a/pkg/sql/distsqlrun/indexjoiner.go
+++ b/pkg/sql/distsqlrun/indexjoiner.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -40,7 +41,7 @@ type indexJoiner struct {
 	// to get rows from the fetcher. This enables the indexJoiner to wrap the
 	// fetcherInput with a stat collector when necessary.
 	fetcherInput RowSource
-	fetcher      sqlbase.RowFetcher
+	fetcher      row.Fetcher
 	// fetcherReady indicates that we have started an index scan and there are
 	// potentially more rows to retrieve.
 	fetcherReady bool
@@ -112,7 +113,7 @@ func newIndexJoiner(
 	); err != nil {
 		return nil, err
 	}
-	ij.fetcherInput = &rowFetcherWrapper{RowFetcher: &ij.fetcher}
+	ij.fetcherInput = &rowFetcherWrapper{Fetcher: &ij.fetcher}
 
 	if sp := opentracing.SpanFromContext(flowCtx.EvalCtx.Ctx()); sp != nil && tracing.IsRecording(sp) {
 		// Enable stats collection.

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -63,7 +64,7 @@ type interleavedReaderJoiner struct {
 	allSpans  roachpb.Spans
 	limitHint int64
 
-	fetcher sqlbase.RowFetcher
+	fetcher row.Fetcher
 	alloc   sqlbase.DatumAlloc
 
 	// TODO(richardwu): If we need to buffer more than 1 ancestor row for
@@ -296,7 +297,7 @@ func newInterleavedReaderJoiner(
 
 	tables := make([]tableInfo, len(spec.Tables))
 	// We need to take spans from all tables and merge them together
-	// for RowFetcher.
+	// for Fetcher.
 	allSpans := make(roachpb.Spans, 0, len(spec.Tables))
 
 	// We need to figure out which table is the ancestor.
@@ -389,7 +390,7 @@ func newInterleavedReaderJoiner(
 func (irj *interleavedReaderJoiner) initRowFetcher(
 	tables []InterleavedReaderJoinerSpec_Table, reverseScan bool, alloc *sqlbase.DatumAlloc,
 ) error {
-	args := make([]sqlbase.RowFetcherTableArgs, len(tables))
+	args := make([]row.FetcherTableArgs, len(tables))
 
 	for i, table := range tables {
 		desc := table.Desc

--- a/pkg/sql/distsqlrun/scrub_tablereader.go
+++ b/pkg/sql/distsqlrun/scrub_tablereader.go
@@ -46,7 +46,7 @@ var ScrubTypes = []sqlbase.ColumnType{
 type scrubTableReader struct {
 	tableReader
 	tableDesc sqlbase.TableDescriptor
-	// fetcherResultToColIdx maps RowFetcher results to the column index in
+	// fetcherResultToColIdx maps Fetcher results to the column index in
 	// the TableDescriptor. This is only initialized and used during scrub
 	// physical checks.
 	fetcherResultToColIdx []int
@@ -92,7 +92,7 @@ func newScrubTableReader(
 		nil, /* memMonitor */
 		ProcStateOpts{
 			// We don't pass tr.input as an inputToDrain; tr.input is just an adapter
-			// on top of a RowFetcher; draining doesn't apply to it. Moreover, Andrei
+			// on top of a Fetcher; draining doesn't apply to it. Moreover, Andrei
 			// doesn't trust that the adapter will do the right thing on a Next() call
 			// after it had previously returned an error.
 			InputsToDrain:        nil,

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -295,7 +295,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 }
 
 // Test that a scan with a limit doesn't touch more ranges than necessary (i.e.
-// we properly set the limit on the underlying RowFetcher/KVFetcher).
+// we properly set the limit on the underlying Fetcher/KVFetcher).
 func TestLimitScans(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()

--- a/pkg/sql/distsqlrun/zigzagjoiner.go
+++ b/pkg/sql/distsqlrun/zigzagjoiner.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -326,7 +327,7 @@ func (z *zigzagJoiner) Start(ctx context.Context) context.Context {
 // zigzagJoinerInfo contains all the information that needs to be
 // stored for each side of the join.
 type zigzagJoinerInfo struct {
-	fetcher sqlbase.RowFetcher
+	fetcher row.Fetcher
 	alloc   *sqlbase.DatumAlloc
 	table   *sqlbase.TableDescriptor
 	index   *sqlbase.IndexDescriptor
@@ -390,7 +391,7 @@ func (z *zigzagJoiner) setupInfo(spec *ZigzagJoinerSpec, side int, colOffset int
 	// Setup the RowContainers.
 	info.container.Reset()
 
-	// Setup the RowFetcher.
+	// Setup the Fetcher.
 	_, _, err := initRowFetcher(
 		&(info.fetcher),
 		info.table,

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -105,13 +106,13 @@ func (p *planner) Insert(
 	}
 
 	// Determine what are the foreign key tables that are involved in the update.
-	var fkCheckType sqlbase.FKCheck
+	var fkCheckType row.FKCheck
 	if n.OnConflict == nil || n.OnConflict.DoNothing {
-		fkCheckType = sqlbase.CheckInserts
+		fkCheckType = row.CheckInserts
 	} else {
-		fkCheckType = sqlbase.CheckUpdates
+		fkCheckType = row.CheckUpdates
 	}
-	fkTables, err := sqlbase.TablesNeededForFKs(
+	fkTables, err := row.TablesNeededForFKs(
 		ctx,
 		*desc,
 		fkCheckType,
@@ -268,8 +269,8 @@ func (p *planner) Insert(
 	}
 
 	// Create the table insert, which does the bulk of the work.
-	ri, err := sqlbase.MakeRowInserter(p.txn, desc, fkTables, insertCols,
-		sqlbase.CheckFKs, &p.alloc)
+	ri, err := row.MakeInserter(p.txn, desc, fkTables, insertCols,
+		row.CheckFKs, &p.alloc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -49,9 +49,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
@@ -1588,7 +1588,7 @@ func (t *logicTest) processSubtest(
 				return errors.Errorf("kv-batch-size needs an integer argument; %s", err)
 			}
 			t.outf("Setting kv batch size %d", batchSize)
-			defer sqlbase.SetKVBatchSize(int64(batchSize))()
+			defer row.SetKVBatchSize(int64(batchSize))()
 
 		default:
 			return errors.Errorf("%s:%d: unknown command: %s",

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -395,17 +396,17 @@ func (p *planner) ResolveTableName(ctx context.Context, tn *tree.TableName) erro
 // TableCollection.getTableVersionByID for how it's used.
 func (p *planner) LookupTableByID(
 	ctx context.Context, tableID sqlbase.ID,
-) (sqlbase.TableLookup, error) {
+) (row.TableLookup, error) {
 	flags := ObjectLookupFlags{
 		CommonLookupFlags{txn: p.txn, avoidCached: p.avoidCachedDescriptors}}
 	table, err := p.Tables().getTableVersionByID(ctx, tableID, flags)
 	if err != nil {
 		if err == errTableAdding {
-			return sqlbase.TableLookup{IsAdding: true}, nil
+			return row.TableLookup{IsAdding: true}, nil
 		}
-		return sqlbase.TableLookup{}, err
+		return row.TableLookup{}, err
 	}
-	return sqlbase.TableLookup{Table: table}, nil
+	return row.TableLookup{Table: table}, nil
 }
 
 // TypeAsString enforces (not hints) that the given expression typechecks as a

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -43,7 +44,7 @@ type SchemaResolver interface {
 	CurrentSearchPath() sessiondata.SearchPath
 	CommonLookupFlags(ctx context.Context, required bool) CommonLookupFlags
 	ObjectLookupFlags(ctx context.Context, required bool) ObjectLookupFlags
-	LookupTableByID(ctx context.Context, id sqlbase.ID) (sqlbase.TableLookup, error)
+	LookupTableByID(ctx context.Context, id sqlbase.ID) (row.TableLookup, error)
 }
 
 var _ SchemaResolver = &planner{}

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -1,0 +1,140 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package row
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+// singleKVFetcher is a kvFetcher that returns a single kv.
+type singleKVFetcher struct {
+	kvs  [1]roachpb.KeyValue
+	done bool
+}
+
+// nextBatch implements the kvFetcher interface.
+func (f *singleKVFetcher) nextBatch(
+	_ context.Context,
+) (ok bool, kvs []roachpb.KeyValue, batchResponse []byte, numKvs int64, err error) {
+	if f.done {
+		return false, nil, nil, 0, nil
+	}
+	f.done = true
+	return true, f.kvs[:], nil, 0, nil
+}
+
+// getRangesInfo implements the kvFetcher interface.
+func (f *singleKVFetcher) getRangesInfo() []roachpb.RangeInfo {
+	panic("getRangesInfo() called on singleKVFetcher")
+}
+
+// ConvertBatchError returns a user friendly constraint violation error.
+func ConvertBatchError(
+	ctx context.Context, tableDesc *sqlbase.TableDescriptor, b *client.Batch,
+) error {
+	origPErr := b.MustPErr()
+	if origPErr.Index == nil {
+		return origPErr.GoError()
+	}
+	j := origPErr.Index.Index
+	if j >= int32(len(b.Results)) {
+		panic(fmt.Sprintf("index %d outside of results: %+v", j, b.Results))
+	}
+	result := b.Results[j]
+	if cErr, ok := origPErr.GetDetail().(*roachpb.ConditionFailedError); ok && len(result.Rows) > 0 {
+		key := result.Rows[0].Key
+		// TODO(dan): There's too much internal knowledge of the sql table
+		// encoding here (and this callsite is the only reason
+		// DecodeIndexKeyPrefix is exported). Refactor this bit out.
+		indexID, _, err := sqlbase.DecodeIndexKeyPrefix(tableDesc, key)
+		if err != nil {
+			return err
+		}
+		index, err := tableDesc.FindIndexByID(indexID)
+		if err != nil {
+			return err
+		}
+		var rf Fetcher
+
+		var valNeededForCol util.FastIntSet
+		valNeededForCol.AddRange(0, len(index.ColumnIDs)-1)
+
+		colIdxMap := make(map[sqlbase.ColumnID]int, len(index.ColumnIDs))
+		cols := make([]sqlbase.ColumnDescriptor, len(index.ColumnIDs))
+		for i, colID := range index.ColumnIDs {
+			colIdxMap[colID] = i
+			col, err := tableDesc.FindColumnByID(colID)
+			if err != nil {
+				return err
+			}
+			cols[i] = *col
+		}
+
+		tableArgs := FetcherTableArgs{
+			Desc:             tableDesc,
+			Index:            index,
+			ColIdxMap:        colIdxMap,
+			IsSecondaryIndex: indexID != tableDesc.PrimaryIndex.ID,
+			Cols:             cols,
+			ValNeededForCol:  valNeededForCol,
+		}
+		if err := rf.Init(
+			false /* reverse */, false /* returnRangeInfo */, false /* isCheck */, &sqlbase.DatumAlloc{}, tableArgs,
+		); err != nil {
+			return err
+		}
+		f := singleKVFetcher{kvs: [1]roachpb.KeyValue{{Key: key}}}
+		if cErr.ActualValue != nil {
+			f.kvs[0].Value = *cErr.ActualValue
+		}
+		// Use the Fetcher to decode the single kv pair above by passing in
+		// this singleKVFetcher implementation, which doesn't actually hit KV.
+		if err := rf.StartScanFrom(ctx, &f); err != nil {
+			return err
+		}
+		datums, _, _, err := rf.NextRowDecoded(ctx)
+		if err != nil {
+			return err
+		}
+		return NewUniquenessConstraintViolationError(index, datums)
+	}
+	return origPErr.GoError()
+}
+
+// NewUniquenessConstraintViolationError creates an error that represents a
+// violation of a UNIQUE constraint.
+func NewUniquenessConstraintViolationError(
+	index *sqlbase.IndexDescriptor, vals []tree.Datum,
+) error {
+	valStrs := make([]string, 0, len(vals))
+	for _, val := range vals {
+		valStrs = append(valStrs, val.String())
+	}
+
+	return pgerror.NewErrorf(pgerror.CodeUniqueViolationError,
+		"duplicate key value (%s)=(%s) violates unique constraint %q",
+		strings.Join(index.ColumnNames, ","),
+		strings.Join(valStrs, ","),
+		index.Name)
+}

--- a/pkg/sql/row/fk.go
+++ b/pkg/sql/row/fk.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package sqlbase
+package row
 
 import (
 	"context"
@@ -26,8 +26,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
+
+// ID is an alias for sqlbase.ID.
+type ID = sqlbase.ID
 
 // TableLookupsByID maps table IDs to looked up descriptors or, for tables that
 // exist but are not yet public/leasable, entries with just the IsAdding flag.
@@ -38,9 +42,9 @@ type TableLookupsByID map[ID]TableLookup
 // flag.
 // This also includes an optional CheckHelper for the table.
 type TableLookup struct {
-	Table       *TableDescriptor
+	Table       *sqlbase.TableDescriptor
 	IsAdding    bool
-	CheckHelper *CheckHelper
+	CheckHelper *sqlbase.CheckHelper
 }
 
 // TableLookupFunction is the function type used by TablesNeededForFKs that will
@@ -55,11 +59,11 @@ func NoLookup(_ context.Context, _ ID) (TableLookup, error) {
 
 // CheckPrivilegeFunction is the function type used by TablesNeededForFKs that will
 // check the privileges of the current user to access specific tables.
-type CheckPrivilegeFunction func(context.Context, DescriptorProto, privilege.Kind) error
+type CheckPrivilegeFunction func(context.Context, sqlbase.DescriptorProto, privilege.Kind) error
 
 // NoCheckPrivilege can be used to not perform any privilege checks during a
 // TablesNeededForFKs function call.
-func NoCheckPrivilege(_ context.Context, _ DescriptorProto, _ privilege.Kind) error {
+func NoCheckPrivilege(_ context.Context, _ sqlbase.DescriptorProto, _ privilege.Kind) error {
 	return nil
 }
 
@@ -86,15 +90,17 @@ type tableLookupQueue struct {
 	tableLookups   TableLookupsByID
 	lookup         TableLookupFunction
 	checkPrivilege CheckPrivilegeFunction
-	analyzeExpr    AnalyzeExprFunction
+	analyzeExpr    sqlbase.AnalyzeExprFunction
 }
 
-func (tl *TableLookup) addCheckHelper(ctx context.Context, analyzeExpr AnalyzeExprFunction) error {
+func (tl *TableLookup) addCheckHelper(
+	ctx context.Context, analyzeExpr sqlbase.AnalyzeExprFunction,
+) error {
 	if analyzeExpr == nil {
 		return nil
 	}
 	tableName := tree.MakeUnqualifiedTableName(tree.Name(tl.Table.Name))
-	tl.CheckHelper = &CheckHelper{}
+	tl.CheckHelper = &sqlbase.CheckHelper{}
 	return tl.CheckHelper.Init(ctx, analyzeExpr, &tableName, tl.Table)
 }
 
@@ -176,11 +182,11 @@ func (q *tableLookupQueue) dequeue() (TableLookup, FKCheck, bool) {
 // CheckHelpers are required.
 func TablesNeededForFKs(
 	ctx context.Context,
-	table TableDescriptor,
+	table sqlbase.TableDescriptor,
 	usage FKCheck,
 	lookup TableLookupFunction,
 	checkPrivilege CheckPrivilegeFunction,
-	analyzeExpr AnalyzeExprFunction,
+	analyzeExpr sqlbase.AnalyzeExprFunction,
 ) (TableLookupsByID, error) {
 	queue := tableLookupQueue{
 		tableLookups:   make(TableLookupsByID),
@@ -238,9 +244,9 @@ func TablesNeededForFKs(
 					if curUsage == CheckDeletes {
 						var nextUsage FKCheck
 						switch referencedIdx.ForeignKey.OnDelete {
-						case ForeignKeyReference_CASCADE:
+						case sqlbase.ForeignKeyReference_CASCADE:
 							nextUsage = CheckDeletes
-						case ForeignKeyReference_SET_DEFAULT, ForeignKeyReference_SET_NULL:
+						case sqlbase.ForeignKeyReference_SET_DEFAULT, sqlbase.ForeignKeyReference_SET_NULL:
 							nextUsage = CheckUpdates
 						default:
 							// There is no need to check any other relationships.
@@ -251,9 +257,9 @@ func TablesNeededForFKs(
 						}
 					} else {
 						// curUsage == CheckUpdates
-						if referencedIdx.ForeignKey.OnUpdate == ForeignKeyReference_CASCADE ||
-							referencedIdx.ForeignKey.OnUpdate == ForeignKeyReference_SET_DEFAULT ||
-							referencedIdx.ForeignKey.OnUpdate == ForeignKeyReference_SET_NULL {
+						if referencedIdx.ForeignKey.OnUpdate == sqlbase.ForeignKeyReference_CASCADE ||
+							referencedIdx.ForeignKey.OnUpdate == sqlbase.ForeignKeyReference_SET_DEFAULT ||
+							referencedIdx.ForeignKey.OnUpdate == sqlbase.ForeignKeyReference_SET_NULL {
 							if err := queue.enqueue(
 								ctx, referencedTableLookup.Table.ID, CheckUpdates,
 							); err != nil {
@@ -389,7 +395,7 @@ type fkInsertHelper struct {
 	// each index. These slices will have at most one entry, since there can be
 	// at most one outgoing foreign key per index. We use this data structure
 	// instead of a one-to-one map for consistency with the other insert helpers.
-	fks map[IndexID][]baseFKHelper
+	fks map[sqlbase.IndexID][]baseFKHelper
 
 	checker *fkBatchChecker
 }
@@ -398,10 +404,10 @@ var errSkipUnusedFK = errors.New("no columns involved in FK included in writer")
 
 func makeFKInsertHelper(
 	txn *client.Txn,
-	table TableDescriptor,
+	table sqlbase.TableDescriptor,
 	otherTables TableLookupsByID,
-	colMap map[ColumnID]int,
-	alloc *DatumAlloc,
+	colMap map[sqlbase.ColumnID]int,
+	alloc *sqlbase.DatumAlloc,
 ) (fkInsertHelper, error) {
 	h := fkInsertHelper{
 		checker: &fkBatchChecker{
@@ -418,7 +424,7 @@ func makeFKInsertHelper(
 				return h, err
 			}
 			if h.fks == nil {
-				h.fks = make(map[IndexID][]baseFKHelper)
+				h.fks = make(map[sqlbase.IndexID][]baseFKHelper)
 			}
 			h.fks[idx.ID] = append(h.fks[idx.ID], fk)
 		}
@@ -451,8 +457,8 @@ func (h fkInsertHelper) CollectSpansForValues(values tree.Datums) (roachpb.Spans
 func checkIdx(
 	ctx context.Context,
 	checker *fkBatchChecker,
-	fks map[IndexID][]baseFKHelper,
-	idx IndexID,
+	fks map[sqlbase.IndexID][]baseFKHelper,
+	idx sqlbase.IndexID,
 	row tree.Datums,
 ) error {
 	for i, fk := range fks[idx] {
@@ -478,19 +484,19 @@ func checkIdx(
 }
 
 type fkDeleteHelper struct {
-	fks         map[IndexID][]baseFKHelper
+	fks         map[sqlbase.IndexID][]baseFKHelper
 	otherTables TableLookupsByID
-	alloc       *DatumAlloc
+	alloc       *sqlbase.DatumAlloc
 
 	checker *fkBatchChecker
 }
 
 func makeFKDeleteHelper(
 	txn *client.Txn,
-	table TableDescriptor,
+	table sqlbase.TableDescriptor,
 	otherTables TableLookupsByID,
-	colMap map[ColumnID]int,
-	alloc *DatumAlloc,
+	colMap map[sqlbase.ColumnID]int,
+	alloc *sqlbase.DatumAlloc,
 ) (fkDeleteHelper, error) {
 	h := fkDeleteHelper{
 		otherTables: otherTables,
@@ -514,7 +520,7 @@ func makeFKDeleteHelper(
 				return fkDeleteHelper{}, err
 			}
 			if h.fks == nil {
-				h.fks = make(map[IndexID][]baseFKHelper)
+				h.fks = make(map[sqlbase.IndexID][]baseFKHelper)
 			}
 			h.fks[idx.ID] = append(h.fks[idx.ID], fk)
 		}
@@ -548,20 +554,20 @@ type fkUpdateHelper struct {
 	inbound  fkDeleteHelper // Check old values are not referenced.
 	outbound fkInsertHelper // Check rows referenced by new values still exist.
 
-	indexIDsToCheck map[IndexID]struct{} // List of Index IDs to check
+	indexIDsToCheck map[sqlbase.IndexID]struct{} // List of Index IDs to check
 
 	checker *fkBatchChecker
 }
 
 func makeFKUpdateHelper(
 	txn *client.Txn,
-	table TableDescriptor,
+	table sqlbase.TableDescriptor,
 	otherTables TableLookupsByID,
-	colMap map[ColumnID]int,
-	alloc *DatumAlloc,
+	colMap map[sqlbase.ColumnID]int,
+	alloc *sqlbase.DatumAlloc,
 ) (fkUpdateHelper, error) {
 	ret := fkUpdateHelper{
-		indexIDsToCheck: make(map[IndexID]struct{}),
+		indexIDsToCheck: make(map[sqlbase.IndexID]struct{}),
 	}
 	var err error
 	if ret.inbound, err = makeFKDeleteHelper(txn, table, otherTables, colMap, alloc); err != nil {
@@ -573,8 +579,10 @@ func makeFKUpdateHelper(
 	return ret, err
 }
 
-func (fks fkUpdateHelper) addCheckForIndex(indexID IndexID, descriptorType IndexDescriptor_Type) {
-	if descriptorType == IndexDescriptor_FORWARD {
+func (fks fkUpdateHelper) addCheckForIndex(
+	indexID sqlbase.IndexID, descriptorType sqlbase.IndexDescriptor_Type,
+) {
+	if descriptorType == sqlbase.IndexDescriptor_FORWARD {
 		fks.indexIDsToCheck[indexID] = struct{}{}
 	}
 }
@@ -619,30 +627,30 @@ func (fks fkUpdateHelper) CollectSpansForValues(values tree.Datums) (roachpb.Spa
 
 type baseFKHelper struct {
 	txn          *client.Txn
-	rf           RowFetcher
-	searchTable  *TableDescriptor // the table being searched (for err msg)
-	searchIdx    *IndexDescriptor // the index that must (not) contain a value
+	rf           Fetcher
+	searchTable  *sqlbase.TableDescriptor // the table being searched (for err msg)
+	searchIdx    *sqlbase.IndexDescriptor // the index that must (not) contain a value
 	prefixLen    int
-	writeIdx     IndexDescriptor  // the index we want to modify
-	searchPrefix []byte           // prefix of keys in searchIdx
-	ids          map[ColumnID]int // col IDs
-	dir          FKCheck          // direction of check
+	writeIdx     sqlbase.IndexDescriptor  // the index we want to modify
+	searchPrefix []byte                   // prefix of keys in searchIdx
+	ids          map[sqlbase.ColumnID]int // col IDs
+	dir          FKCheck                  // direction of check
 }
 
 func makeBaseFKHelper(
 	txn *client.Txn,
 	otherTables TableLookupsByID,
-	writeIdx IndexDescriptor,
-	ref ForeignKeyReference,
-	colMap map[ColumnID]int,
-	alloc *DatumAlloc,
+	writeIdx sqlbase.IndexDescriptor,
+	ref sqlbase.ForeignKeyReference,
+	colMap map[sqlbase.ColumnID]int,
+	alloc *sqlbase.DatumAlloc,
 	dir FKCheck,
 ) (baseFKHelper, error) {
 	b := baseFKHelper{txn: txn, writeIdx: writeIdx, searchTable: otherTables[ref.Table].Table, dir: dir}
 	if b.searchTable == nil {
 		return b, errors.Errorf("referenced table %d not in provided table map %+v", ref.Table, otherTables)
 	}
-	b.searchPrefix = MakeIndexKeyPrefix(b.searchTable, ref.Index)
+	b.searchPrefix = sqlbase.MakeIndexKeyPrefix(b.searchTable, ref.Index)
 	searchIdx, err := b.searchTable.FindIndexByID(ref.Index)
 	if err != nil {
 		return b, err
@@ -652,7 +660,7 @@ func makeBaseFKHelper(
 		b.prefixLen = len(writeIdx.ColumnIDs)
 	}
 	b.searchIdx = searchIdx
-	tableArgs := RowFetcherTableArgs{
+	tableArgs := FetcherTableArgs{
 		Desc:             b.searchTable,
 		Index:            b.searchIdx,
 		ColIdxMap:        b.searchTable.ColumnIdxMap(),
@@ -666,7 +674,7 @@ func makeBaseFKHelper(
 
 	// Check for all NULL values, since these can skip FK checking in MATCH FULL
 	// TODO(bram): add MATCH SIMPLE and fix MATCH FULL #30026
-	b.ids = make(map[ColumnID]int, len(writeIdx.ColumnIDs))
+	b.ids = make(map[sqlbase.ColumnID]int, len(writeIdx.ColumnIDs))
 	nulls := true
 	var missingColumns []string
 	for i, writeColID := range writeIdx.ColumnIDs[:b.prefixLen] {
@@ -695,7 +703,7 @@ func makeBaseFKHelper(
 func (f baseFKHelper) spanForValues(values tree.Datums) (roachpb.Span, error) {
 	var key roachpb.Key
 	if values != nil {
-		keyBytes, _, err := EncodePartialIndexKey(
+		keyBytes, _, err := sqlbase.EncodePartialIndexKey(
 			f.searchTable, f.searchIdx, f.prefixLen, f.ids, values, f.searchPrefix)
 		if err != nil {
 			return roachpb.Span{}, err
@@ -722,7 +730,7 @@ var _ FkSpanCollector = fkInsertHelper{}
 var _ FkSpanCollector = fkDeleteHelper{}
 var _ FkSpanCollector = fkUpdateHelper{}
 
-func collectSpansWithFKMap(fks map[IndexID][]baseFKHelper) roachpb.Spans {
+func collectSpansWithFKMap(fks map[sqlbase.IndexID][]baseFKHelper) roachpb.Spans {
 	var reads roachpb.Spans
 	for idx := range fks {
 		for _, fk := range fks[idx] {
@@ -733,7 +741,7 @@ func collectSpansWithFKMap(fks map[IndexID][]baseFKHelper) roachpb.Spans {
 }
 
 func collectSpansForValuesWithFKMap(
-	fks map[IndexID][]baseFKHelper, values tree.Datums,
+	fks map[sqlbase.IndexID][]baseFKHelper, values tree.Datums,
 ) (roachpb.Spans, error) {
 	var reads roachpb.Spans
 	for idx := range fks {

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -1,0 +1,138 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package row
+
+import (
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/pkg/errors"
+)
+
+// rowHelper has the common methods for table row manipulations.
+type rowHelper struct {
+	TableDesc *sqlbase.TableDescriptor
+	// Secondary indexes.
+	Indexes      []sqlbase.IndexDescriptor
+	indexEntries []sqlbase.IndexEntry
+
+	// Computed during initialization for pretty-printing.
+	primIndexValDirs []encoding.Direction
+	secIndexValDirs  [][]encoding.Direction
+
+	// Computed and cached.
+	primaryIndexKeyPrefix []byte
+	primaryIndexCols      map[sqlbase.ColumnID]struct{}
+	sortedColumnFamilies  map[sqlbase.FamilyID][]sqlbase.ColumnID
+}
+
+func newRowHelper(desc *sqlbase.TableDescriptor, indexes []sqlbase.IndexDescriptor) rowHelper {
+	rh := rowHelper{TableDesc: desc, Indexes: indexes}
+
+	// Pre-compute the encoding directions of the index key values for
+	// pretty-printing in traces.
+	rh.primIndexValDirs = sqlbase.IndexKeyValDirs(&rh.TableDesc.PrimaryIndex)
+
+	rh.secIndexValDirs = make([][]encoding.Direction, len(rh.Indexes))
+	for i, index := range rh.Indexes {
+		rh.secIndexValDirs[i] = sqlbase.IndexKeyValDirs(&index)
+	}
+
+	return rh
+}
+
+// encodeIndexes encodes the primary and secondary index keys. The
+// secondaryIndexEntries are only valid until the next call to encodeIndexes or
+// encodeSecondaryIndexes.
+func (rh *rowHelper) encodeIndexes(
+	colIDtoRowIndex map[sqlbase.ColumnID]int, values []tree.Datum,
+) (primaryIndexKey []byte, secondaryIndexEntries []sqlbase.IndexEntry, err error) {
+	if rh.primaryIndexKeyPrefix == nil {
+		rh.primaryIndexKeyPrefix = sqlbase.MakeIndexKeyPrefix(rh.TableDesc,
+			rh.TableDesc.PrimaryIndex.ID)
+	}
+	primaryIndexKey, _, err = sqlbase.EncodeIndexKey(
+		rh.TableDesc, &rh.TableDesc.PrimaryIndex, colIDtoRowIndex, values, rh.primaryIndexKeyPrefix)
+	if err != nil {
+		return nil, nil, err
+	}
+	secondaryIndexEntries, err = rh.encodeSecondaryIndexes(colIDtoRowIndex, values)
+	if err != nil {
+		return nil, nil, err
+	}
+	return primaryIndexKey, secondaryIndexEntries, nil
+}
+
+// encodeSecondaryIndexes encodes the secondary index keys. The
+// secondaryIndexEntries are only valid until the next call to encodeIndexes or
+// encodeSecondaryIndexes.
+func (rh *rowHelper) encodeSecondaryIndexes(
+	colIDtoRowIndex map[sqlbase.ColumnID]int, values []tree.Datum,
+) (secondaryIndexEntries []sqlbase.IndexEntry, err error) {
+	if len(rh.indexEntries) != len(rh.Indexes) {
+		rh.indexEntries = make([]sqlbase.IndexEntry, len(rh.Indexes))
+	}
+	rh.indexEntries, err = sqlbase.EncodeSecondaryIndexes(
+		rh.TableDesc, rh.Indexes, colIDtoRowIndex, values, rh.indexEntries)
+	if err != nil {
+		return nil, err
+	}
+	return rh.indexEntries, nil
+}
+
+// skipColumnInPK returns true if the value at column colID does not need
+// to be encoded because it is already part of the primary key. Composite
+// datums are considered too, so a composite datum in a PK will return false.
+// TODO(dan): This logic is common and being moved into TableDescriptor (see
+// #6233). Once it is, use the shared one.
+func (rh *rowHelper) skipColumnInPK(
+	colID sqlbase.ColumnID, family sqlbase.FamilyID, value tree.Datum,
+) (bool, error) {
+	if rh.primaryIndexCols == nil {
+		rh.primaryIndexCols = make(map[sqlbase.ColumnID]struct{})
+		for _, colID := range rh.TableDesc.PrimaryIndex.ColumnIDs {
+			rh.primaryIndexCols[colID] = struct{}{}
+		}
+	}
+	if _, ok := rh.primaryIndexCols[colID]; !ok {
+		return false, nil
+	}
+	if family != 0 {
+		return false, errors.Errorf("primary index column %d must be in family 0, was %d", colID, family)
+	}
+	if cdatum, ok := value.(tree.CompositeDatum); ok {
+		// Composite columns are encoded in both the key and the value.
+		return !cdatum.IsComposite(), nil
+	}
+	// Skip primary key columns as their values are encoded in the key of
+	// each family. Family 0 is guaranteed to exist and acts as a
+	// sentinel.
+	return true, nil
+}
+
+func (rh *rowHelper) sortedColumnFamily(famID sqlbase.FamilyID) ([]sqlbase.ColumnID, bool) {
+	if rh.sortedColumnFamilies == nil {
+		rh.sortedColumnFamilies = make(map[sqlbase.FamilyID][]sqlbase.ColumnID, len(rh.TableDesc.Families))
+		for _, family := range rh.TableDesc.Families {
+			colIDs := append([]sqlbase.ColumnID(nil), family.ColumnIDs...)
+			sort.Sort(sqlbase.ColumnIDs(colIDs))
+			rh.sortedColumnFamilies[family.ID] = colIDs
+		}
+	}
+	colIDs, ok := rh.sortedColumnFamilies[famID]
+	return colIDs, ok
+}

--- a/pkg/sql/row/kvfetcher.go
+++ b/pkg/sql/row/kvfetcher.go
@@ -12,120 +12,20 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package sqlbase
+package row
 
 import (
 	"bytes"
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
-
-// IndexKeyValDirs returns the corresponding encoding.Directions for all the
-// encoded values in index's "fullest" possible index key, including directions
-// for table/index IDs, the interleaved sentinel and the index column values.
-// For example, given
-//    CREATE INDEX foo ON bar (a, b DESC) INTERLEAVED IN PARENT bar (a)
-// a typical index key with all values specified could be
-//    /51/1/42/#/51/2/1337
-// which would return the slice
-//    {ASC, ASC, ASC, 0, ASC, ASC, DESC}
-func IndexKeyValDirs(index *IndexDescriptor) []encoding.Direction {
-	if index == nil {
-		return nil
-	}
-
-	dirs := make([]encoding.Direction, 0, (len(index.Interleave.Ancestors)+1)*2+len(index.ColumnDirections))
-
-	colIdx := 0
-	for _, ancs := range index.Interleave.Ancestors {
-		// Table/Index IDs are always encoded ascending.
-		dirs = append(dirs, encoding.Ascending, encoding.Ascending)
-		for i := 0; i < int(ancs.SharedPrefixLen); i++ {
-			d, err := index.ColumnDirections[colIdx].ToEncodingDirection()
-			if err != nil {
-				panic(err)
-			}
-			dirs = append(dirs, d)
-			colIdx++
-		}
-
-		// The interleaved sentinel uses the 0 value for
-		// encoding.Direction when pretty-printing (see
-		// encoding.go:prettyPrintFirstValue).
-		dirs = append(dirs, 0)
-	}
-
-	// The index's table/index ID.
-	dirs = append(dirs, encoding.Ascending, encoding.Ascending)
-
-	for colIdx < len(index.ColumnDirections) {
-		d, err := index.ColumnDirections[colIdx].ToEncodingDirection()
-		if err != nil {
-			panic(err)
-		}
-		dirs = append(dirs, d)
-		colIdx++
-	}
-
-	return dirs
-}
-
-// PrettyKey pretty-prints the specified key, skipping over the first `skip`
-// fields. The pretty printed key looks like:
-//
-//   /Table/<tableID>/<indexID>/...
-//
-// We always strip off the /Table prefix and then `skip` more fields. Note that
-// this assumes that the fields themselves do not contain '/', but that is
-// currently true for the fields we care about stripping (the table and index
-// ID).
-func PrettyKey(valDirs []encoding.Direction, key roachpb.Key, skip int) string {
-	p := key.StringWithDirs(valDirs)
-	for i := 0; i <= skip; i++ {
-		n := strings.IndexByte(p[1:], '/')
-		if n == -1 {
-			return ""
-		}
-		p = p[n+1:]
-	}
-	return p
-}
-
-// PrettySpan returns a human-readable representation of a span.
-func PrettySpan(valDirs []encoding.Direction, span roachpb.Span, skip int) string {
-	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "%s-%s", PrettyKey(valDirs, span.Key, skip), PrettyKey(valDirs, span.EndKey, skip))
-	return buf.String()
-}
-
-// PrettySpans returns a human-readable description of the spans.
-// If index is nil, then pretty print subroutines will use their default
-// settings.
-func PrettySpans(index *IndexDescriptor, spans []roachpb.Span, skip int) string {
-	if len(spans) == 0 {
-		return ""
-	}
-
-	valDirs := IndexKeyValDirs(index)
-
-	var buf bytes.Buffer
-	for i, span := range spans {
-		if i > 0 {
-			buf.WriteString(" ")
-		}
-		buf.WriteString(PrettySpan(valDirs, span, skip))
-	}
-	return buf.String()
-}
 
 // kvBatchSize is the number of keys we request at a time.
 // On a single node, 1000 was enough to avoid any performance degradation. On
@@ -345,7 +245,7 @@ func (f *txnKVFetcher) fetch(ctx context.Context) error {
 			return errors.Errorf(
 				"span with results after resume span; it shouldn't happen given that "+
 					"we're only scanning non-overlapping spans. New spans: %s",
-				PrettySpans(nil, f.spans, 0 /* skip */))
+				sqlbase.PrettySpans(nil, f.spans, 0 /* skip */))
 		}
 
 		if resumeSpan := header.ResumeSpan; resumeSpan != nil {

--- a/pkg/sql/row/main_test.go
+++ b/pkg/sql/row/main_test.go
@@ -1,0 +1,33 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package row_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -193,11 +194,11 @@ type scanRun struct {
 	// only true when running SCRUB commands.
 	isCheck bool
 
-	fetcher sqlbase.RowFetcher
+	fetcher row.Fetcher
 }
 
 func (n *scanNode) startExec(params runParams) error {
-	tableArgs := sqlbase.RowFetcherTableArgs{
+	tableArgs := row.FetcherTableArgs{
 		Desc:             n.desc,
 		Index:            n.index,
 		ColIdxMap:        n.colIdxMap,

--- a/pkg/sql/scan_test.go
+++ b/pkg/sql/scan_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
@@ -129,7 +129,7 @@ func TestScanBatches(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	// The test will screw around with KVBatchSize; make sure to restore it at the end.
-	restore := sqlbase.SetKVBatchSize(10)
+	restore := row.SetKVBatchSize(10)
 	defer restore()
 
 	s, db, _ := serverutils.StartServer(
@@ -175,7 +175,7 @@ func TestScanBatches(t *testing.T) {
 	numSpanValues := []int{0, 1, 2, 3}
 
 	for _, batch := range batchSizes {
-		sqlbase.SetKVBatchSize(int64(batch))
+		row.SetKVBatchSize(int64(batch))
 		for _, numSpans := range numSpanValues {
 			testScanBatchQuery(t, db, numSpans, numAs, numBs, false)
 			testScanBatchQuery(t, db, numSpans, numAs, numBs, true)

--- a/pkg/sql/sqlbase/encoded_datum.go
+++ b/pkg/sql/sqlbase/encoded_datum.go
@@ -72,6 +72,16 @@ func (ed *EncDatum) String(typ *ColumnType) string {
 	return ed.stringWithAlloc(typ, nil)
 }
 
+// BytesEqual is true if the EncDatum's encoded field is equal to the input.
+func (ed *EncDatum) BytesEqual(b []byte) bool {
+	return bytes.Equal(ed.encoded, b)
+}
+
+// EncodedString returns an immutable copy of this EncDatum's encoded field.
+func (ed *EncDatum) EncodedString() string {
+	return string(ed.encoded)
+}
+
 // EncDatumOverhead is the overhead of EncDatum in bytes.
 const EncDatumOverhead = unsafe.Sizeof(EncDatum{})
 

--- a/pkg/sql/sqlbase/keys.go
+++ b/pkg/sql/sqlbase/keys.go
@@ -15,6 +15,10 @@
 package sqlbase
 
 import (
+	"bytes"
+	"fmt"
+	"strings"
+
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -45,4 +49,102 @@ func MakeDescMetadataKey(descID ID) roachpb.Key {
 	k := MakeAllDescsMetadataKey()
 	k = encoding.EncodeUvarintAscending(k, uint64(descID))
 	return keys.MakeFamilyKey(k, uint32(DescriptorTable.Columns[1].ID))
+}
+
+// IndexKeyValDirs returns the corresponding encoding.Directions for all the
+// encoded values in index's "fullest" possible index key, including directions
+// for table/index IDs, the interleaved sentinel and the index column values.
+// For example, given
+//    CREATE INDEX foo ON bar (a, b DESC) INTERLEAVED IN PARENT bar (a)
+// a typical index key with all values specified could be
+//    /51/1/42/#/51/2/1337
+// which would return the slice
+//    {ASC, ASC, ASC, 0, ASC, ASC, DESC}
+func IndexKeyValDirs(index *IndexDescriptor) []encoding.Direction {
+	if index == nil {
+		return nil
+	}
+
+	dirs := make([]encoding.Direction, 0, (len(index.Interleave.Ancestors)+1)*2+len(index.ColumnDirections))
+
+	colIdx := 0
+	for _, ancs := range index.Interleave.Ancestors {
+		// Table/Index IDs are always encoded ascending.
+		dirs = append(dirs, encoding.Ascending, encoding.Ascending)
+		for i := 0; i < int(ancs.SharedPrefixLen); i++ {
+			d, err := index.ColumnDirections[colIdx].ToEncodingDirection()
+			if err != nil {
+				panic(err)
+			}
+			dirs = append(dirs, d)
+			colIdx++
+		}
+
+		// The interleaved sentinel uses the 0 value for
+		// encoding.Direction when pretty-printing (see
+		// encoding.go:prettyPrintFirstValue).
+		dirs = append(dirs, 0)
+	}
+
+	// The index's table/index ID.
+	dirs = append(dirs, encoding.Ascending, encoding.Ascending)
+
+	for colIdx < len(index.ColumnDirections) {
+		d, err := index.ColumnDirections[colIdx].ToEncodingDirection()
+		if err != nil {
+			panic(err)
+		}
+		dirs = append(dirs, d)
+		colIdx++
+	}
+
+	return dirs
+}
+
+// PrettyKey pretty-prints the specified key, skipping over the first `skip`
+// fields. The pretty printed key looks like:
+//
+//   /Table/<tableID>/<indexID>/...
+//
+// We always strip off the /Table prefix and then `skip` more fields. Note that
+// this assumes that the fields themselves do not contain '/', but that is
+// currently true for the fields we care about stripping (the table and index
+// ID).
+func PrettyKey(valDirs []encoding.Direction, key roachpb.Key, skip int) string {
+	p := key.StringWithDirs(valDirs)
+	for i := 0; i <= skip; i++ {
+		n := strings.IndexByte(p[1:], '/')
+		if n == -1 {
+			return ""
+		}
+		p = p[n+1:]
+	}
+	return p
+}
+
+// PrettySpan returns a human-readable representation of a span.
+func PrettySpan(valDirs []encoding.Direction, span roachpb.Span, skip int) string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%s-%s", PrettyKey(valDirs, span.Key, skip), PrettyKey(valDirs, span.EndKey, skip))
+	return buf.String()
+}
+
+// PrettySpans returns a human-readable description of the spans.
+// If index is nil, then pretty print subroutines will use their default
+// settings.
+func PrettySpans(index *IndexDescriptor, spans []roachpb.Span, skip int) string {
+	if len(spans) == 0 {
+		return ""
+	}
+
+	valDirs := IndexKeyValDirs(index)
+
+	var buf bytes.Buffer
+	for i, span := range spans {
+		if i > 0 {
+			buf.WriteString(" ")
+		}
+		buf.WriteString(PrettySpan(valDirs, span, skip))
+	}
+	return buf.String()
 }

--- a/pkg/sql/sqlbase/row_container.go
+++ b/pkg/sql/sqlbase/row_container.go
@@ -120,7 +120,9 @@ func (ti ColTypeInfo) Type(idx int) types.T {
 	return ti.colTypes[idx].ToDatumType()
 }
 
-func makeColTypeInfo(
+// MakeColTypeInfo returns a ColTypeInfo initialized from the given
+// TableDescriptor and map from column ID to row index.
+func MakeColTypeInfo(
 	tableDesc *TableDescriptor, colIDToRowIndex map[ColumnID]int,
 ) (ColTypeInfo, error) {
 	colTypeInfo := ColTypeInfo{

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -76,7 +77,7 @@ type tableWriter interface {
 	tableDesc() *sqlbase.TableDescriptor
 
 	// fkSpanCollector returns the FkSpanCollector for the tableWriter.
-	fkSpanCollector() sqlbase.FkSpanCollector
+	fkSpanCollector() row.FkSpanCollector
 
 	// close frees all resources held by the tableWriter.
 	close(context.Context)
@@ -139,7 +140,7 @@ func (tb *tableWriterBase) flushAndStartNewBatch(
 	ctx context.Context, tableDesc *sqlbase.TableDescriptor,
 ) error {
 	if err := tb.txn.Run(ctx, tb.b); err != nil {
-		return sqlbase.ConvertBatchError(ctx, tableDesc, tb.b)
+		return row.ConvertBatchError(ctx, tableDesc, tb.b)
 	}
 	tb.b = tb.txn.NewBatch()
 	tb.batchSize = 0
@@ -163,7 +164,7 @@ func (tb *tableWriterBase) finalize(
 	}
 
 	if err != nil {
-		return sqlbase.ConvertBatchError(ctx, tableDesc, tb.b)
+		return row.ConvertBatchError(ctx, tableDesc, tb.b)
 	}
 	return nil
 }

--- a/pkg/sql/tablewriter_insert.go
+++ b/pkg/sql/tablewriter_insert.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -25,7 +26,7 @@ import (
 // tableInserter handles writing kvs and forming table rows for inserts.
 type tableInserter struct {
 	tableWriterBase
-	ri sqlbase.RowInserter
+	ri row.Inserter
 }
 
 // init is part of the tableWriter interface.
@@ -39,7 +40,7 @@ func (ti *tableInserter) row(
 	ctx context.Context, values tree.Datums, traceKV bool,
 ) (tree.Datums, error) {
 	ti.batchSize++
-	return nil, ti.ri.InsertRow(ctx, ti.b, values, false, sqlbase.CheckFKs, traceKV)
+	return nil, ti.ri.InsertRow(ctx, ti.b, values, false, row.CheckFKs, traceKV)
 }
 
 // atBatchEnd is part of the extendedTableWriter interface.
@@ -63,7 +64,7 @@ func (ti *tableInserter) tableDesc() *sqlbase.TableDescriptor {
 }
 
 // fkSpanCollector is part of the tableWriter interface.
-func (ti *tableInserter) fkSpanCollector() sqlbase.FkSpanCollector {
+func (ti *tableInserter) fkSpanCollector() row.FkSpanCollector {
 	return ti.ri.Fks
 }
 

--- a/pkg/sql/tablewriter_update.go
+++ b/pkg/sql/tablewriter_update.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -25,7 +26,7 @@ import (
 // tableUpdater handles writing kvs and forming table rows for updates.
 type tableUpdater struct {
 	tableWriterBase
-	ru sqlbase.RowUpdater
+	ru row.Updater
 }
 
 // init is part of the tableWriter interface.
@@ -47,7 +48,7 @@ func (tu *tableUpdater) rowForUpdate(
 	ctx context.Context, oldValues, updateValues tree.Datums, traceKV bool,
 ) (tree.Datums, error) {
 	tu.batchSize++
-	return tu.ru.UpdateRow(ctx, tu.b, oldValues, updateValues, sqlbase.CheckFKs, traceKV)
+	return tu.ru.UpdateRow(ctx, tu.b, oldValues, updateValues, row.CheckFKs, traceKV)
 }
 
 // atBatchEnd is part of the extendedTableWriter interface.
@@ -71,7 +72,7 @@ func (tu *tableUpdater) tableDesc() *sqlbase.TableDescriptor {
 }
 
 // fkSpanCollector is part of the tableWriter interface.
-func (tu *tableUpdater) fkSpanCollector() sqlbase.FkSpanCollector {
+func (tu *tableUpdater) fkSpanCollector() row.FkSpanCollector {
 	return tu.ru.Fks
 }
 

--- a/pkg/sql/tablewriter_upsert_fast.go
+++ b/pkg/sql/tablewriter_upsert_fast.go
@@ -18,8 +18,8 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
 // fastTableUpserter implements the fast path for an upsert. See
@@ -44,12 +44,12 @@ func (tu *fastTableUpserter) init(txn *client.Txn, _ *tree.EvalContext) error {
 
 // row is part of the tableWriter interface.
 func (tu *fastTableUpserter) row(
-	ctx context.Context, row tree.Datums, traceKV bool,
+	ctx context.Context, d tree.Datums, traceKV bool,
 ) (tree.Datums, error) {
 	tu.batchSize++
 	// Use the fast path, ignore conflicts.
 	return nil, tu.ri.InsertRow(
-		ctx, tu.b, row, true /* ignoreConflicts */, sqlbase.CheckFKs, traceKV)
+		ctx, tu.b, d, true /* ignoreConflicts */, row.CheckFKs, traceKV)
 }
 
 // batchedCount is part of the batchedTableWriter interface.

--- a/pkg/sql/tablewriter_upsert_strict.go
+++ b/pkg/sql/tablewriter_upsert_strict.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -62,7 +63,7 @@ func (tu *strictTableUpserter) atBatchEnd(ctx context.Context, traceKV bool) err
 			continue
 		}
 
-		if err := tu.ri.InsertRow(ctx, tu.b, insertRow, true, sqlbase.CheckFKs, traceKV); err != nil {
+		if err := tu.ri.InsertRow(ctx, tu.b, insertRow, true, row.CheckFKs, traceKV); err != nil {
 			return err
 		}
 

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -50,7 +51,7 @@ func (p *planner) newUpsertNode(
 	ctx context.Context,
 	n *tree.Insert,
 	desc *sqlbase.TableDescriptor,
-	ri sqlbase.RowInserter,
+	ri row.Inserter,
 	tn, alias *tree.TableName,
 	sourceRows planNode,
 	needRows bool,
@@ -58,7 +59,7 @@ func (p *planner) newUpsertNode(
 	defaultExprs []tree.TypedExpr,
 	computeExprs []tree.TypedExpr,
 	computedCols []sqlbase.ColumnDescriptor,
-	fkTables sqlbase.TableLookupsByID,
+	fkTables row.TableLookupsByID,
 	desiredTypes []types.T,
 ) (res batchedPlanNode, err error) {
 	// Extract the index that will detect upsert conflicts
@@ -657,7 +658,7 @@ func (p *planner) newUpsertHelper(
 	// column IDs to row datum positions is straightforward.
 	helper.ccIvarContainer = sqlbase.RowIndexedVarContainer{
 		Cols:    tableDesc.Columns,
-		Mapping: sqlbase.ColIDtoRowIndexFromCols(tableDesc.Columns),
+		Mapping: row.ColIDtoRowIndexFromCols(tableDesc.Columns),
 	}
 
 	return helper, nil


### PR DESCRIPTION
This was purely mechanical renaming. The purpose is to lessen the width
of the sqlbase package, which is imported in many places.

The new package now depends on sqlbase, but far fewer packages consume
it than sqlbase.

Major changes:

RowFetcher -> row.Fetcher
RowUpdater -> row.Updater
RowDeleter -> row.Deleter

FK and cascade stuff -> row package

The only unfortunate thing here is that the FK enums all begin with
`row` now (e.g. `row.CheckDeletes`). It would be better if those got a
different package name, like `fk`, but I'll leave that refactor for
another time.

Somewhat related to #30001.

cc @dt, @benesch 

Release note: None