### PR TITLE
storage: avoid merge deadlock when concurrent split wins

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -992,8 +993,10 @@ func TestStoreRangeMergeInFlightTxns(t *testing.T) {
 	})
 }
 
-// TestStoreRangeMergeConcurrentSplit (occasionally) reproduces a race where a
-// concurrent merge and split could deadlock.
+// TestStoreRangeMergeSplitRace_MergeWins (occasionally) reproduces a race where
+// a concurrent merge and split could deadlock. It exercises the case where the
+// merge commits and the split aborts. See the SplitWins variant of this test
+// for the inverse case.
 //
 // The bug works like this. A merge of adjacent ranges P and Q and a split of Q
 // execute concurrently, though the merge executes with an earlier timestamp.
@@ -1030,7 +1033,7 @@ func TestStoreRangeMergeInFlightTxns(t *testing.T) {
 // scheduler to occasionally strike the right interleaving. At the time of
 // writing, the test would reliably reproduce the bug in about 50 runs (about
 // ten seconds of stress on an eight core laptop).
-func TestStoreRangeMergeConcurrentSplit(t *testing.T) {
+func TestStoreRangeMergeSplitRace_MergeWins(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
@@ -1062,6 +1065,104 @@ func TestStoreRangeMergeConcurrentSplit(t *testing.T) {
 
 	if err := <-splitErrCh; err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestStoreRangeMergeSplitRace_SplitWins reproduces a race where a concurrent
+// merge and split could deadlock. It exercises the case where the split commits
+// and the merge aborts. See the MergeWins variant of this test for the inverse
+// case.
+//
+// The bug works like this. A merge of adjacent ranges P and Q and a split of Q
+// execute concurrently, though the merge executes with an earlier timestamp.
+// First, the merge transaction writes an intent to update P's local range
+// descriptor. Then it reads Q's local range descriptor to verify that Q hasn't
+// changed since the decision to merge was made.
+//
+// Next, the split transaction runs from start to finish, updating Q's local
+// descriptor and its associated meta2 record. Notably, the split transaction
+// does not encounter any intents from the merge transaction, since the merge
+// transaction's only intent so far is on P's local range descriptor, and so the
+// split transaction can happily commit.
+//
+// The merge transaction then continues, writing an intent on Q's local
+// descriptor. Since the merge transaction is executing at an earlier timestamp
+// than the split transaction, the intent is written "under" the updated
+// descriptor written by the split transaction.
+//
+// In the past, the merge transaction would simply push its commit timestamp
+// forward and proceed, even though, upon committing, it would discover that it
+// was forbidden from committing with a pushed timestamp and abort instead. (For
+// why merge transactions cannot forward their commit timestamps, see the
+// discussion on the retry loop within AdminMerge.) This was problematic. Before
+// the doomed merge transaction attempted to commit, it would send a Subsume
+// request, launching a merge watcher goroutine on Q. This watcher goroutine
+// could incorrectly think that the merge transaction committed. Why? To
+// determine whether a merge has truly aborted, the watcher goroutine sends a
+// Get(/Meta2/QEndKey) request with a read uncommitted isolation level. If the
+// Get request returns either nil or a descriptor for a different range, the
+// merge is assumed to have committed. In this case, unfortunately, QEndKey is
+// the Q's end key post-split. After all, the split has committed and updated
+// Q's in-memory descriptor. The split transactions intents are cleaned up
+// asynchronously, however, and since the watcher goroutine is not performing a
+// consistent read it will not wait for the intents to be cleaned up. So
+// Get(/Meta2/QEndKey) might return nil, in which case the watcher goroutine
+// will incorrectly infer that the merge committed. (Note that the watcher
+// goroutine can't perform a consistent read, as that would look up the
+// transaction record on Q and deadlock, since Q is blocked for merging.)
+//
+// The bug was fixed by updating Q's local descriptor with a conditional put
+// instead of a put. This forces the merge transaction to fail early if writing
+// the intent would require forwarding the commit timestamp. In other words,
+// this ensures that the merge watcher goroutine is never launched if the RHS
+// local descriptor is updated while the merge transaction is executing.
+func TestStoreRangeMergeSplitRace_SplitWins(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	storeCfg := storage.TestStoreConfig(nil)
+	storeCfg.TestingKnobs.DisableReplicateQueue = true
+
+	var distSender *kv.DistSender
+	var launchSplit int64
+	done := make(chan struct{})
+	storeCfg.TestingKnobs.TestingRequestFilter = func(ba roachpb.BatchRequest) *roachpb.Error {
+		for _, req := range ba.Requests {
+			if bt := req.GetBeginTransaction(); bt != nil &&
+				bt.Key.Equal(keys.RangeDescriptorKey(roachpb.RKeyMin)) &&
+				atomic.CompareAndSwapInt64(&launchSplit, 1, 0) {
+				_, pErr := client.SendWrapped(ctx, distSender, adminSplitArgs(roachpb.Key("c")))
+				return pErr
+			}
+			if ri := req.GetResolveIntent(); ri != nil &&
+				ri.Key.Equal(keys.RangeMetaKey(roachpb.RKey("c")).AsRawKey()) &&
+				ri.Status == roachpb.COMMITTED {
+				// Don't allow resolution of the split transaction's meta2 intent until
+				// the test finishes. This ensures that the merge watcher goroutine
+				// sees a nil value when it performs its meta2 lookup, as described in
+				// the comment on this test.
+				<-done
+			}
+		}
+		return nil
+	}
+
+	mtc := &multiTestContext{storeConfig: &storeCfg}
+	mtc.Start(t, 1)
+	defer mtc.Stop()
+	defer close(done)
+	distSender = mtc.distSenders[0]
+
+	lhsDesc, _, err := createSplitRanges(ctx, mtc.Store(0))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	atomic.StoreInt64(&launchSplit, 1)
+	mergeArgs := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
+	_, pErr := client.SendWrapped(ctx, distSender, mergeArgs)
+	if pErr != nil && !testutils.IsPError(pErr, "range changed during merge") {
+		t.Fatal(pErr)
 	}
 }
 

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -308,7 +308,7 @@ func (r *Replica) adminSplitWithDescriptor(
 		{
 			b := txn.NewBatch()
 			leftDescKey := keys.RangeDescriptorKey(leftDesc.StartKey)
-			if err := updateRangeDescriptor(b, leftDescKey, desc, leftDesc); err != nil {
+			if err := updateRangeDescriptor(b, leftDescKey, desc, &leftDesc); err != nil {
 				return err
 			}
 			// Commit this batch first to ensure that the transaction record
@@ -343,7 +343,7 @@ func (r *Replica) adminSplitWithDescriptor(
 
 		// Create range descriptor for right hand side of the split.
 		rightDescKey := keys.RangeDescriptorKey(rightDesc.StartKey)
-		if err := updateRangeDescriptor(b, rightDescKey, nil, *rightDesc); err != nil {
+		if err := updateRangeDescriptor(b, rightDescKey, nil, rightDesc); err != nil {
 			return err
 		}
 
@@ -453,7 +453,7 @@ func (r *Replica) AdminMerge(
 		{
 			b := txn.NewBatch()
 			leftDescKey := keys.RangeDescriptorKey(updatedLeftDesc.StartKey)
-			if err := updateRangeDescriptor(b, leftDescKey, origLeftDesc, updatedLeftDesc); err != nil {
+			if err := updateRangeDescriptor(b, leftDescKey, origLeftDesc, &updatedLeftDesc); err != nil {
 				return err
 			}
 			// Commit this batch on its own to ensure that the transaction record
@@ -501,7 +501,9 @@ func (r *Replica) AdminMerge(
 		}
 
 		// Remove the range descriptor for the deleted range.
-		b.Del(rightDescKey)
+		if err := updateRangeDescriptor(b, rightDescKey, &rightDesc, nil); err != nil {
+			return err
+		}
 
 		// Send off this batch, ensuring that intents are placed on both the local
 		// copy and meta2's copy of the right-hand side range descriptor before we
@@ -817,7 +819,7 @@ func (r *Replica) changeReplicas(
 
 			// Important: the range descriptor must be the first thing touched in the transaction
 			// so the transaction record is co-located with the range being modified.
-			if err := updateRangeDescriptor(b, descKey, desc, updatedDesc); err != nil {
+			if err := updateRangeDescriptor(b, descKey, desc, &updatedDesc); err != nil {
 				return err
 			}
 
@@ -988,14 +990,22 @@ func updateRangeDescriptor(
 	b *client.Batch,
 	descKey roachpb.Key,
 	oldDesc *roachpb.RangeDescriptor,
-	newDesc roachpb.RangeDescriptor,
+	newDesc *roachpb.RangeDescriptor,
 ) error {
-	if err := newDesc.Validate(); err != nil {
-		return err
-	}
 	// This is subtle: []byte(nil) != interface{}(nil). A []byte(nil) refers to
 	// an empty value. An interface{}(nil) refers to a non-existent value. So
-	// we're careful to construct an interface{}(nil) when oldDesc is nil.
+	// we're careful to construct interface{}(nil)s when newDesc/oldDesc are nil.
+	var newValue interface{}
+	if newDesc != nil {
+		if err := newDesc.Validate(); err != nil {
+			return err
+		}
+		newBytes, err := protoutil.Marshal(newDesc)
+		if err != nil {
+			return err
+		}
+		newValue = newBytes
+	}
 	var oldValue interface{}
 	if oldDesc != nil {
 		oldBytes, err := protoutil.Marshal(oldDesc)
@@ -1003,10 +1013,6 @@ func updateRangeDescriptor(
 			return err
 		}
 		oldValue = oldBytes
-	}
-	newValue, err := protoutil.Marshal(&newDesc)
-	if err != nil {
-		return err
 	}
 	b.CPut(descKey, newValue, oldValue)
 	return nil

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -325,7 +325,7 @@ func (tc *testContext) addBogusReplicaToRangeDesc(
 		Header: roachpb.Header{Timestamp: tc.Clock().Now()},
 	}
 	descKey := keys.RangeDescriptorKey(oldDesc.StartKey)
-	if err := updateRangeDescriptor(&ba, descKey, &oldDesc, newDesc); err != nil {
+	if err := updateRangeDescriptor(&ba, descKey, &oldDesc, &newDesc); err != nil {
 		return roachpb.ReplicaDescriptor{}, err
 	}
 	if err := tc.store.DB().Run(ctx, &ba); err != nil {


### PR DESCRIPTION
@bdarnell, in a stroke of luck, the existing conditional put API supports deleting the existing value when you pass nil.

---

When merging two adjacent ranges P and Q, we need to be careful to
delete Q's range descriptor with a conditional put, or we can deadlock
with a concurrent split. See the comments and test case within for
details. This commit fixes the last issue that is blocking merges from
being turned on by default.

Release note: None