### PR TITLE
release-2.1: cli: minimize --certs-dir flag description.

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -479,24 +479,9 @@ a public network without combining it with --listen-addr.`,
 	}
 
 	CertsDir = FlagInfo{
-		Name:   "certs-dir",
-		EnvVar: "COCKROACH_CERTS_DIR",
-		Description: `
-The path to the directory containing SSL certificates and keys.
-<PRE>
-
-Cockroach looks for certificates and keys inside the directory using the
-following naming scheme:
-
-  - CA certificate and key: ca.crt, ca.key
-  - Server certificate and key: node.crt, node.key
-  - Client certificate and key: client.<user>.crt, client.<user>.key
-
-When running client commands, the user can be specified with the --user flag.
-</PRE>
-
-Keys have a minimum permission requirement of 0700 (rwx------). This restriction can be
-disabled by setting the environment variable COCKROACH_SKIP_KEY_PERMISSION_CHECK to true.`,
+		Name:        "certs-dir",
+		EnvVar:      "COCKROACH_CERTS_DIR",
+		Description: `Path to the directory containing SSL certificates and keys.`,
 	}
 
 	// Server version of the certs directory flag, cannot be set through environment.


### PR DESCRIPTION
Backport 1/1 commits from #29653.

/cc @cockroachdb/release

---
