### PR TITLE
opt: add Spool operator

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -204,7 +204,6 @@ query error unimplemented: multiple WITH clauses in parentheses
     (WITH waa AS (VALUES (2))
 	   TABLE waa))
 
-
 # When #24303 is fixed, the following query should fail with
 # error "no such relation woo".
 query error unimplemented: multiple WITH clauses in parentheses

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -148,6 +148,10 @@ func (f *stubFactory) ConstructProjectSet(
 	return struct{}{}, nil
 }
 
+func (f *stubFactory) ConstructSpool(input exec.Node) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
 func (f *stubFactory) RenameColumns(input exec.Node, colNames []string) (exec.Node, error) {
 	return struct{}{}, nil
 }

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -145,6 +145,9 @@ func (b *Builder) buildRelational(ev memo.ExprView) (execPlan, error) {
 	case opt.ZipOp:
 		ep, err = b.buildZip(ev)
 
+	case opt.SpoolOp:
+		ep, err = b.buildSpool(ev)
+
 	default:
 		if ev.IsJoinNonApply() {
 			ep, err = b.buildHashJoin(ev)
@@ -978,6 +981,23 @@ func (b *Builder) buildZip(ev memo.ExprView) (execPlan, error) {
 	ep := execPlan{root: node}
 	ep.outputCols = outputCols
 	return ep, nil
+}
+
+func (b *Builder) buildSpool(ev memo.ExprView) (execPlan, error) {
+	input, err := b.buildRelational(ev.Child(0))
+	if err != nil {
+		return execPlan{}, err
+	}
+
+	node, err := b.factory.ConstructSpool(input.root)
+	if err != nil {
+		return execPlan{}, err
+	}
+
+	return execPlan{
+		root:       node,
+		outputCols: input.outputCols,
+	}, nil
 }
 
 func (b *Builder) buildProjectSet(ev memo.ExprView) (execPlan, error) {

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -1,0 +1,52 @@
+# LogicTest: local-opt
+
+statement ok
+CREATE TABLE x(a INT)
+
+query TTTTT
+EXPLAIN (VERBOSE)
+  WITH t AS (SELECT a/0 FROM x WHERE a < 3)
+    SELECT * FROM x NATURAL JOIN t
+----
+render                    ·         ·           (a, "?column?")                 ·
+ │                        render 0  a           ·                               ·
+ │                        render 1  "?column?"  ·                               ·
+ └── spool                ·         ·           (a, rowid[hidden], "?column?")  ·
+      └── join            ·         ·           (a, rowid[hidden], "?column?")  ·
+           │              type      cross       ·                               ·
+           ├── scan       ·         ·           (a, rowid[hidden])              ·
+           │              table     x@primary   ·                               ·
+           │              spans     ALL         ·                               ·
+           └── render     ·         ·           ("?column?")                    ·
+                │         render 0  a / 0       ·                               ·
+                └── scan  ·         ·           (a)                             ·
+·                         table     x@primary   ·                               ·
+·                         spans     ALL         ·                               ·
+·                         filter    a < 3       ·                               ·
+
+query TTTTT
+EXPLAIN (VERBOSE)
+WITH t AS (SELECT a/0 FROM x)
+  SELECT * FROM t LIMIT 0
+----
+limit                ·         ·          ("?column?")  ·
+ │                   count     0          ·             ·
+ └── spool           ·         ·          ("?column?")  ·
+      └── render     ·         ·          ("?column?")  ·
+           │         render 0  a / 0      ·             ·
+           └── scan  ·         ·          (a)           ·
+·                    table     x@primary  ·             ·
+·                    spans     ALL        ·             ·
+
+# Chaining multiple CTEs.
+query TTTTT
+EXPLAIN (VERBOSE)
+  WITH
+      t1 AS (SELECT a FROM x WHERE a < 3),
+      t2 AS (SELECT * FROM t1 WHERE a > 1)
+  SELECT * FROM t2
+----
+scan  ·       ·                    (a)  ·
+·     table   x@primary            ·    ·
+·     spans   ALL                  ·    ·
+·     filter  (a < 3) AND (a > 1)  ·    ·

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -178,6 +178,9 @@ type Factory interface {
 		n Node, exprs tree.TypedExprs, zipCols sqlbase.ResultColumns, numColsPerGen []int,
 	) (Node, error)
 
+	// ConstructSpool returns the input wrapped in a spooling node.
+	ConstructSpool(n Node) (Node, error)
+
 	// RenameColumns modifies the column names of a node.
 	RenameColumns(input Node, colNames []string) (Node, error)
 

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -108,6 +108,9 @@ func (b *logicalPropsBuilder) buildRelationalProps(ev ExprView) props.Logical {
 	case opt.ZipOp:
 		logical = b.buildZipProps(ev)
 
+	case opt.SpoolOp:
+		logical = b.buildSpoolProps(ev)
+
 	default:
 		panic(fmt.Sprintf("unrecognized relational expression type: %v", ev.op))
 	}
@@ -1078,6 +1081,14 @@ func (b *logicalPropsBuilder) buildZipProps(ev ExprView) props.Logical {
 	b.sb.buildZip(ev, relational)
 
 	return logical
+}
+
+func (b *logicalPropsBuilder) buildSpoolProps(ev ExprView) props.Logical {
+	// Spool's props are identical to its input.
+	// TODO(justin): though I think we might actually be able to claim that a
+	// Spool "doesn't" have side-effects even if its input does, since they'll
+	// get executed regardless, and the Spool itself can be a pure result set?
+	return b.buildRelationalProps(ev.Child(0))
 }
 
 func (b *logicalPropsBuilder) buildScalarProps(ev ExprView) props.Logical {

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -303,6 +303,9 @@ func (sb *statisticsBuilder) colStat(colSet opt.ColSet, ev ExprView) *props.Colu
 	case opt.ZipOp:
 		return sb.colStatZip(colSet, ev)
 
+	case opt.SpoolOp:
+		return sb.colStat(colSet, ev.Child(0))
+
 	case opt.ExplainOp, opt.ShowTraceForSessionOp:
 		relProps := ev.Logical().Relational
 		return sb.colStatLeaf(colSet, &relProps.Stats, &relProps.FuncDeps)

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -309,6 +309,13 @@ func (c *CustomFuncs) HasOuterCols(group memo.GroupID) bool {
 	return !c.OuterCols(group).Empty()
 }
 
+// CanHaveSideEffects returns true if the group can possible have side
+// effects.
+func (c *CustomFuncs) CanHaveSideEffects(group memo.GroupID) bool {
+	relational := c.LookupRelational(group)
+	return relational.CanHaveSideEffects
+}
+
 // OnlyConstants returns true if the scalar expression is a "constant
 // expression tree", meaning that it will always evaluate to the same result.
 // See the CommuteConst pattern comment for more details.

--- a/pkg/sql/opt/norm/rules/spool.opt
+++ b/pkg/sql/opt/norm/rules/spool.opt
@@ -1,0 +1,80 @@
+# =============================================================================
+# spool.opt contains normalization rules for the Spool operator.
+# =============================================================================
+
+# EliminateSpool removes a Spool which provably has no effect. It should be at the top
+# of this file so we don't push a Spool around when we could just eliminate it
+# immediately.
+[EliminateSpool, Normalize]
+(Spool
+    $input:* & ^(CanHaveSideEffects $input)
+)
+=>
+$input
+
+# EliminateSpoolSpool flattens composed spools into a single Spool.
+[EliminateSpoolSpool, Normalize]
+(Spool
+    (Spool
+        $input:*
+    )
+)
+=>
+(Spool
+    $input
+)
+
+# PullSpoolAboveSelect attempts to pull a Spool up higher so that
+# it can either eventually reach the root and be eliminated by
+# EliminateRootSpool or be combined with another Spool.
+[PullSpoolAboveSelect, Normalize]
+(Select
+    (Spool $input:*)
+    $filter:*
+)
+=>
+(Spool
+    (Select
+        $input
+        $filter
+    )
+)
+
+# PullSpoolAboveJoinLeft attempts to pull a Spool up higher so that
+# it can either eventually reach the root and be eliminated by
+# EliminateRootSpool or be combined with another Spool.
+[PullSpoolAboveJoinLeft, Normalize]
+(Join
+    (Spool $left:*)
+    $right:*
+    $on:*
+)
+=>
+(Spool
+    ((OpName)
+        $left
+        $right
+        $on
+    )
+)
+
+# PullSpoolAboveJoinRight attempts to pull a Spool up higher so that
+# it can either eventually reach the root and be eliminated by
+# EliminateRootSpool or be combined with another Spool.
+[PullSpoolAboveJoinRight, Normalize]
+(Join
+    $left:*
+    (Spool $right:*)
+    $on:*
+)
+=>
+(Spool
+    ((OpName)
+        $left
+        $right
+        $on
+    )
+)
+
+# TODO(justin): figure out what other operators it is legal to pull a Spool
+# above. It's certainly not legal for Limit.

--- a/pkg/sql/opt/norm/testdata/rules/spool
+++ b/pkg/sql/opt/norm/testdata/rules/spool
@@ -1,0 +1,273 @@
+exec-ddl
+CREATE TABLE x(a INT)
+----
+TABLE x
+ ├── a int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+# Verify with optsteps that a spool is introduced and subsequently eliminated.
+optsteps
+WITH t AS (SELECT a, rowid FROM x)
+  SELECT a, rowid FROM t
+----
+================================================================================
+Initial expression
+  Cost: 1040.00
+================================================================================
+  spool
+   ├── columns: a:1(int) rowid:2(int!null)
+   ├── key: (2)
+   ├── fd: (2)-->(1)
+   └── scan x
+        ├── columns: a:1(int) rowid:2(int!null)
+        ├── key: (2)
+        └── fd: (2)-->(1)
+================================================================================
+EliminateSpool
+  Cost: 1040.00
+================================================================================
+  -spool
+  +scan x
+    ├── columns: a:1(int) rowid:2(int!null)
+    ├── key: (2)
+  - ├── fd: (2)-->(1)
+  - └── scan x
+  -      ├── columns: a:1(int) rowid:2(int!null)
+  -      ├── key: (2)
+  -      └── fd: (2)-->(1)
+  + └── fd: (2)-->(1)
+--------------------------------------------------------------------------------
+GenerateIndexScans (no changes)
+--------------------------------------------------------------------------------
+================================================================================
+Final best expression
+  Cost: 1040.00
+================================================================================
+  scan x
+   ├── columns: a:1(int) rowid:2(int!null)
+   ├── key: (2)
+   └── fd: (2)-->(1)
+
+# We can't eliminate spool in the presence of side effects.
+
+norm expect-not=EliminateSpool
+WITH t AS (SELECT a/0 FROM x)
+  SELECT * FROM t LIMIT 0
+----
+limit
+ ├── columns: "?column?":3(decimal)
+ ├── cardinality: [0 - 0]
+ ├── side-effects
+ ├── key: ()
+ ├── fd: ()-->(3)
+ ├── spool
+ │    ├── columns: "?column?":3(decimal)
+ │    ├── side-effects
+ │    └── project
+ │         ├── columns: "?column?":3(decimal)
+ │         ├── side-effects
+ │         ├── scan x
+ │         │    └── columns: a:1(int)
+ │         └── projections [outer=(1), side-effects]
+ │              └── a / 0 [type=decimal, outer=(1), side-effects]
+ └── const: 0 [type=int]
+
+# --------------------------------------------------
+# EliminateRootSpool
+# --------------------------------------------------
+
+norm expect=EliminateRootSpool
+WITH t AS (SELECT a/0 FROM x)
+  SELECT * FROM t
+----
+project
+ ├── columns: "?column?":3(decimal)
+ ├── side-effects
+ ├── scan x
+ │    └── columns: a:1(int)
+ └── projections [outer=(1), side-effects]
+      └── a / 0 [type=decimal, outer=(1), side-effects]
+
+norm expect-not=EliminateRootSpool
+WITH t AS (SELECT a/0 FROM x)
+  SELECT * FROM t LIMIT 0
+----
+limit
+ ├── columns: "?column?":3(decimal)
+ ├── cardinality: [0 - 0]
+ ├── side-effects
+ ├── key: ()
+ ├── fd: ()-->(3)
+ ├── spool
+ │    ├── columns: "?column?":3(decimal)
+ │    ├── side-effects
+ │    └── project
+ │         ├── columns: "?column?":3(decimal)
+ │         ├── side-effects
+ │         ├── scan x
+ │         │    └── columns: a:1(int)
+ │         └── projections [outer=(1), side-effects]
+ │              └── a / 0 [type=decimal, outer=(1), side-effects]
+ └── const: 0 [type=int]
+
+# --------------------------------------------------
+# PullSpoolAboveSelect
+# --------------------------------------------------
+
+norm expect=PullSpoolAboveSelect
+WITH
+    t1 AS (SELECT a/0 AS b FROM x)
+SELECT * FROM t1 WHERE b = 3 LIMIT 0
+----
+limit
+ ├── columns: b:3(decimal!null)
+ ├── cardinality: [0 - 0]
+ ├── side-effects
+ ├── key: ()
+ ├── fd: ()-->(3)
+ ├── spool
+ │    ├── columns: b:3(decimal!null)
+ │    ├── side-effects
+ │    ├── fd: ()-->(3)
+ │    └── select
+ │         ├── columns: b:3(decimal!null)
+ │         ├── side-effects
+ │         ├── fd: ()-->(3)
+ │         ├── project
+ │         │    ├── columns: b:3(decimal)
+ │         │    ├── side-effects
+ │         │    ├── scan x
+ │         │    │    └── columns: a:1(int)
+ │         │    └── projections [outer=(1), side-effects]
+ │         │         └── a / 0 [type=decimal, outer=(1), side-effects]
+ │         └── filters [type=bool, outer=(3), constraints=(/3: [/3 - /3]; tight), fd=()-->(3)]
+ │              └── b = 3 [type=bool, outer=(3), constraints=(/3: [/3 - /3]; tight)]
+ └── const: 0 [type=int]
+
+# --------------------------------------------------
+# PullSpoolAboveJoinLeft
+# --------------------------------------------------
+
+norm expect=PullSpoolAboveJoinLeft
+WITH
+    t1 AS (SELECT a/0 AS b FROM x)
+SELECT * FROM t1 NATURAL JOIN (VALUES (1)) LIMIT 0
+----
+limit
+ ├── columns: b:3(decimal) column1:4(int)
+ ├── cardinality: [0 - 0]
+ ├── side-effects
+ ├── key: ()
+ ├── fd: ()-->(3,4)
+ ├── spool
+ │    ├── columns: b:3(decimal) column1:4(int)
+ │    ├── side-effects
+ │    ├── fd: ()-->(4)
+ │    └── inner-join
+ │         ├── columns: b:3(decimal) column1:4(int)
+ │         ├── side-effects
+ │         ├── fd: ()-->(4)
+ │         ├── project
+ │         │    ├── columns: b:3(decimal)
+ │         │    ├── side-effects
+ │         │    ├── scan x
+ │         │    │    └── columns: a:1(int)
+ │         │    └── projections [outer=(1), side-effects]
+ │         │         └── a / 0 [type=decimal, outer=(1), side-effects]
+ │         ├── values
+ │         │    ├── columns: column1:4(int)
+ │         │    ├── cardinality: [1 - 1]
+ │         │    ├── key: ()
+ │         │    ├── fd: ()-->(4)
+ │         │    └── (1,) [type=tuple{int}]
+ │         └── true [type=bool]
+ └── const: 0 [type=int]
+
+# --------------------------------------------------
+# PullSpoolAboveJoinRight
+# --------------------------------------------------
+
+norm expect=PullSpoolAboveJoinRight
+WITH
+    t1 AS (SELECT a/0 AS b FROM x)
+SELECT * FROM (VALUES (1)) NATURAL JOIN t1 LIMIT 0
+----
+limit
+ ├── columns: column1:4(int) b:3(decimal)
+ ├── cardinality: [0 - 0]
+ ├── side-effects
+ ├── key: ()
+ ├── fd: ()-->(3,4)
+ ├── spool
+ │    ├── columns: b:3(decimal) column1:4(int)
+ │    ├── side-effects
+ │    ├── fd: ()-->(4)
+ │    └── inner-join
+ │         ├── columns: b:3(decimal) column1:4(int)
+ │         ├── side-effects
+ │         ├── fd: ()-->(4)
+ │         ├── values
+ │         │    ├── columns: column1:4(int)
+ │         │    ├── cardinality: [1 - 1]
+ │         │    ├── key: ()
+ │         │    ├── fd: ()-->(4)
+ │         │    └── (1,) [type=tuple{int}]
+ │         ├── project
+ │         │    ├── columns: b:3(decimal)
+ │         │    ├── side-effects
+ │         │    ├── scan x
+ │         │    │    └── columns: a:1(int)
+ │         │    └── projections [outer=(1), side-effects]
+ │         │         └── a / 0 [type=decimal, outer=(1), side-effects]
+ │         └── true [type=bool]
+ └── const: 0 [type=int]
+
+# --------------------------------------------------
+# EliminateSpoolSpool
+# --------------------------------------------------
+
+norm expect=EliminateSpoolSpool
+WITH
+    t1 AS (SELECT a/0 AS b FROM x),
+    t2 AS (SELECT a/0 AS b FROM x)
+SELECT * FROM t1 NATURAL JOIN t2 LIMIT 0
+----
+project
+ ├── columns: b:3(decimal!null)
+ ├── cardinality: [0 - 0]
+ ├── side-effects
+ ├── key: ()
+ ├── fd: ()-->(3)
+ └── limit
+      ├── columns: b:3(decimal!null) b:6(decimal!null)
+      ├── cardinality: [0 - 0]
+      ├── side-effects
+      ├── key: ()
+      ├── fd: ()-->(3,6)
+      ├── spool
+      │    ├── columns: b:3(decimal!null) b:6(decimal!null)
+      │    ├── side-effects
+      │    ├── fd: (3)==(6), (6)==(3)
+      │    └── inner-join
+      │         ├── columns: b:3(decimal!null) b:6(decimal!null)
+      │         ├── side-effects
+      │         ├── fd: (3)==(6), (6)==(3)
+      │         ├── project
+      │         │    ├── columns: b:3(decimal)
+      │         │    ├── side-effects
+      │         │    ├── scan x
+      │         │    │    └── columns: x.a:1(int)
+      │         │    └── projections [outer=(1), side-effects]
+      │         │         └── x.a / 0 [type=decimal, outer=(1), side-effects]
+      │         ├── project
+      │         │    ├── columns: b:6(decimal)
+      │         │    ├── side-effects
+      │         │    ├── scan x
+      │         │    │    └── columns: x.a:4(int)
+      │         │    └── projections [outer=(4), side-effects]
+      │         │         └── x.a / 0 [type=decimal, outer=(4), side-effects]
+      │         └── filters [type=bool, outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
+      │              └── b = b [type=bool, outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ])]
+      └── const: 0 [type=int]

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -484,3 +484,12 @@ define Zip {
     Funcs ExprList
     Cols  ColList
 }
+
+# Spool represents a relational spool. It passes through its input unchanged,
+# but guarantees that its entire input will be exhausted no matter what.  This
+# is important in the presence of expressions with side-effects (in particular,
+# mutations).
+[Relational]
+define Spool {
+    Input Expr
+}

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -75,9 +75,7 @@ func (b *Builder) buildDataSource(
 
 			outScope = inScope.push()
 
-			// TODO(justin): once we support mutations here, we will want to include a
-			// spool operation.
-			outScope.group = cte.group
+			outScope.group = b.factory.ConstructSpool(cte.group)
 			outScope.cols = cte.cols
 			return outScope
 		}

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -26,16 +26,18 @@ project
       ├── columns: y.a:1(int!null) x.a:3(int!null) x.rowid:4(int!null)
       ├── scan x
       │    └── columns: x.a:3(int) x.rowid:4(int!null)
-      ├── project
+      ├── spool
       │    ├── columns: y.a:1(int!null)
-      │    └── select
-      │         ├── columns: y.a:1(int!null) y.rowid:2(int!null)
-      │         ├── scan y
-      │         │    └── columns: y.a:1(int) y.rowid:2(int!null)
-      │         └── filters [type=bool]
-      │              └── lt [type=bool]
-      │                   ├── variable: y.a [type=int]
-      │                   └── const: 3 [type=int]
+      │    └── project
+      │         ├── columns: y.a:1(int!null)
+      │         └── select
+      │              ├── columns: y.a:1(int!null) y.rowid:2(int!null)
+      │              ├── scan y
+      │              │    └── columns: y.a:1(int) y.rowid:2(int!null)
+      │              └── filters [type=bool]
+      │                   └── lt [type=bool]
+      │                        ├── variable: y.a [type=int]
+      │                        └── const: 3 [type=int]
       └── filters [type=bool]
            └── eq [type=bool]
                 ├── variable: x.a [type=int]
@@ -45,16 +47,18 @@ build
 WITH t AS (SELECT a FROM y WHERE a < 3)
   SELECT * FROM t
 ----
-project
+spool
  ├── columns: a:1(int!null)
- └── select
-      ├── columns: a:1(int!null) rowid:2(int!null)
-      ├── scan y
-      │    └── columns: a:1(int) rowid:2(int!null)
-      └── filters [type=bool]
-           └── lt [type=bool]
-                ├── variable: a [type=int]
-                └── const: 3 [type=int]
+ └── project
+      ├── columns: a:1(int!null)
+      └── select
+           ├── columns: a:1(int!null) rowid:2(int!null)
+           ├── scan y
+           │    └── columns: a:1(int) rowid:2(int!null)
+           └── filters [type=bool]
+                └── lt [type=bool]
+                     ├── variable: a [type=int]
+                     └── const: 3 [type=int]
 
 # Chaining multiple CTEs.
 build
@@ -63,22 +67,26 @@ WITH
     t2 AS (SELECT * FROM t1 WHERE a > 1)
 SELECT * FROM t2
 ----
-select
+spool
  ├── columns: a:1(int!null)
- ├── project
- │    ├── columns: a:1(int!null)
- │    └── select
- │         ├── columns: a:1(int!null) rowid:2(int!null)
- │         ├── scan y
- │         │    └── columns: a:1(int) rowid:2(int!null)
- │         └── filters [type=bool]
- │              └── lt [type=bool]
- │                   ├── variable: a [type=int]
- │                   └── const: 3 [type=int]
- └── filters [type=bool]
-      └── gt [type=bool]
-           ├── variable: a [type=int]
-           └── const: 1 [type=int]
+ └── select
+      ├── columns: a:1(int!null)
+      ├── spool
+      │    ├── columns: a:1(int!null)
+      │    └── project
+      │         ├── columns: a:1(int!null)
+      │         └── select
+      │              ├── columns: a:1(int!null) rowid:2(int!null)
+      │              ├── scan y
+      │              │    └── columns: a:1(int) rowid:2(int!null)
+      │              └── filters [type=bool]
+      │                   └── lt [type=bool]
+      │                        ├── variable: a [type=int]
+      │                        └── const: 3 [type=int]
+      └── filters [type=bool]
+           └── gt [type=bool]
+                ├── variable: a [type=int]
+                └── const: 1 [type=int]
 
 build
 WITH
@@ -87,28 +95,34 @@ WITH
     t3 AS (SELECT * FROM t2 WHERE a = 2)
 SELECT * FROM t3
 ----
-select
+spool
  ├── columns: a:1(int!null)
- ├── select
- │    ├── columns: a:1(int!null)
- │    ├── project
- │    │    ├── columns: a:1(int!null)
- │    │    └── select
- │    │         ├── columns: a:1(int!null) rowid:2(int!null)
- │    │         ├── scan y
- │    │         │    └── columns: a:1(int) rowid:2(int!null)
- │    │         └── filters [type=bool]
- │    │              └── lt [type=bool]
- │    │                   ├── variable: a [type=int]
- │    │                   └── const: 3 [type=int]
- │    └── filters [type=bool]
- │         └── gt [type=bool]
- │              ├── variable: a [type=int]
- │              └── const: 1 [type=int]
- └── filters [type=bool]
-      └── eq [type=bool]
-           ├── variable: a [type=int]
-           └── const: 2 [type=int]
+ └── select
+      ├── columns: a:1(int!null)
+      ├── spool
+      │    ├── columns: a:1(int!null)
+      │    └── select
+      │         ├── columns: a:1(int!null)
+      │         ├── spool
+      │         │    ├── columns: a:1(int!null)
+      │         │    └── project
+      │         │         ├── columns: a:1(int!null)
+      │         │         └── select
+      │         │              ├── columns: a:1(int!null) rowid:2(int!null)
+      │         │              ├── scan y
+      │         │              │    └── columns: a:1(int) rowid:2(int!null)
+      │         │              └── filters [type=bool]
+      │         │                   └── lt [type=bool]
+      │         │                        ├── variable: a [type=int]
+      │         │                        └── const: 3 [type=int]
+      │         └── filters [type=bool]
+      │              └── gt [type=bool]
+      │                   ├── variable: a [type=int]
+      │                   └── const: 1 [type=int]
+      └── filters [type=bool]
+           └── eq [type=bool]
+                ├── variable: a [type=int]
+                └── const: 2 [type=int]
 
 build
 WITH
@@ -122,38 +136,46 @@ project
  ├── columns: a:1(int!null)
  └── inner-join
       ├── columns: y.a:1(int!null) y.a:3(int!null)
-      ├── select
+      ├── spool
       │    ├── columns: y.a:1(int!null)
-      │    ├── project
-      │    │    ├── columns: y.a:1(int!null)
-      │    │    └── select
-      │    │         ├── columns: y.a:1(int!null) y.rowid:2(int!null)
-      │    │         ├── scan y
-      │    │         │    └── columns: y.a:1(int) y.rowid:2(int!null)
-      │    │         └── filters [type=bool]
-      │    │              └── lt [type=bool]
-      │    │                   ├── variable: y.a [type=int]
-      │    │                   └── const: 3 [type=int]
-      │    └── filters [type=bool]
-      │         └── lt [type=bool]
-      │              ├── variable: y.a [type=int]
-      │              └── const: 4 [type=int]
-      ├── select
+      │    └── select
+      │         ├── columns: y.a:1(int!null)
+      │         ├── spool
+      │         │    ├── columns: y.a:1(int!null)
+      │         │    └── project
+      │         │         ├── columns: y.a:1(int!null)
+      │         │         └── select
+      │         │              ├── columns: y.a:1(int!null) y.rowid:2(int!null)
+      │         │              ├── scan y
+      │         │              │    └── columns: y.a:1(int) y.rowid:2(int!null)
+      │         │              └── filters [type=bool]
+      │         │                   └── lt [type=bool]
+      │         │                        ├── variable: y.a [type=int]
+      │         │                        └── const: 3 [type=int]
+      │         └── filters [type=bool]
+      │              └── lt [type=bool]
+      │                   ├── variable: y.a [type=int]
+      │                   └── const: 4 [type=int]
+      ├── spool
       │    ├── columns: y.a:3(int!null)
-      │    ├── project
-      │    │    ├── columns: y.a:3(int!null)
-      │    │    └── select
-      │    │         ├── columns: y.a:3(int!null) y.rowid:4(int!null)
-      │    │         ├── scan y
-      │    │         │    └── columns: y.a:3(int) y.rowid:4(int!null)
-      │    │         └── filters [type=bool]
-      │    │              └── gt [type=bool]
-      │    │                   ├── variable: y.a [type=int]
-      │    │                   └── const: 1 [type=int]
-      │    └── filters [type=bool]
-      │         └── gt [type=bool]
-      │              ├── variable: y.a [type=int]
-      │              └── const: 3 [type=int]
+      │    └── select
+      │         ├── columns: y.a:3(int!null)
+      │         ├── spool
+      │         │    ├── columns: y.a:3(int!null)
+      │         │    └── project
+      │         │         ├── columns: y.a:3(int!null)
+      │         │         └── select
+      │         │              ├── columns: y.a:3(int!null) y.rowid:4(int!null)
+      │         │              ├── scan y
+      │         │              │    └── columns: y.a:3(int) y.rowid:4(int!null)
+      │         │              └── filters [type=bool]
+      │         │                   └── gt [type=bool]
+      │         │                        ├── variable: y.a [type=int]
+      │         │                        └── const: 1 [type=int]
+      │         └── filters [type=bool]
+      │              └── gt [type=bool]
+      │                   ├── variable: y.a [type=int]
+      │                   └── const: 3 [type=int]
       └── filters [type=bool]
            └── eq [type=bool]
                 ├── variable: y.a [type=int]
@@ -163,12 +185,14 @@ project
 build
 WITH t AS (SELECT true) SELECT * FROM (WITH t AS (SELECT false) SELECT * FROM t)
 ----
-project
+spool
  ├── columns: bool:2(bool!null)
- ├── values
- │    └── tuple [type=tuple]
- └── projections
-      └── false [type=bool]
+ └── project
+      ├── columns: bool:2(bool!null)
+      ├── values
+      │    └── tuple [type=tuple]
+      └── projections
+           └── false [type=bool]
 
 build
 WITH
@@ -197,20 +221,24 @@ project
  ├── columns: a:3(int!null)
  └── inner-join
       ├── columns: x.a:3(int!null) x.a:5(int!null) x.rowid:6(int!null)
-      ├── project
+      ├── spool
       │    ├── columns: x.a:3(int!null)
-      │    └── inner-join
-      │         ├── columns: x.a:1(int!null) x.a:3(int!null) x.rowid:4(int!null)
-      │         ├── scan x
-      │         │    └── columns: x.a:3(int) x.rowid:4(int!null)
-      │         ├── project
-      │         │    ├── columns: x.a:1(int)
-      │         │    └── scan x
-      │         │         └── columns: x.a:1(int) x.rowid:2(int!null)
-      │         └── filters [type=bool]
-      │              └── eq [type=bool]
-      │                   ├── variable: x.a [type=int]
-      │                   └── variable: x.a [type=int]
+      │    └── project
+      │         ├── columns: x.a:3(int!null)
+      │         └── inner-join
+      │              ├── columns: x.a:1(int!null) x.a:3(int!null) x.rowid:4(int!null)
+      │              ├── scan x
+      │              │    └── columns: x.a:3(int) x.rowid:4(int!null)
+      │              ├── spool
+      │              │    ├── columns: x.a:1(int)
+      │              │    └── project
+      │              │         ├── columns: x.a:1(int)
+      │              │         └── scan x
+      │              │              └── columns: x.a:1(int) x.rowid:2(int!null)
+      │              └── filters [type=bool]
+      │                   └── eq [type=bool]
+      │                        ├── variable: x.a [type=int]
+      │                        └── variable: x.a [type=int]
       ├── scan x
       │    └── columns: x.a:5(int) x.rowid:6(int!null)
       └── filters [type=bool]
@@ -228,34 +256,40 @@ build
 WITH t(x) AS (SELECT a FROM x)
   SELECT x FROM (SELECT x FROM t)
 ----
-project
+spool
  ├── columns: x:1(int)
- └── scan x
-      └── columns: a:1(int) rowid:2(int!null)
+ └── project
+      ├── columns: a:1(int)
+      └── scan x
+           └── columns: a:1(int) rowid:2(int!null)
 
 build
 WITH t(a, b) AS (SELECT true a, false b)
   SELECT a, b FROM t
 ----
-project
+spool
  ├── columns: a:1(bool!null) b:2(bool!null)
- ├── values
- │    └── tuple [type=tuple]
- └── projections
-      ├── true [type=bool]
-      └── false [type=bool]
+ └── project
+      ├── columns: a:1(bool!null) b:2(bool!null)
+      ├── values
+      │    └── tuple [type=tuple]
+      └── projections
+           ├── true [type=bool]
+           └── false [type=bool]
 
 build
 WITH t(b, a) AS (SELECT true a, false b)
   SELECT a, b FROM t
 ----
-project
+spool
  ├── columns: a:2(bool!null) b:1(bool!null)
- ├── values
- │    └── tuple [type=tuple]
- └── projections
-      ├── true [type=bool]
-      └── false [type=bool]
+ └── project
+      ├── columns: a:1(bool!null) b:2(bool!null)
+      ├── values
+      │    └── tuple [type=tuple]
+      └── projections
+           ├── true [type=bool]
+           └── false [type=bool]
 
 build
 WITH t AS (SELECT a FROM x)
@@ -269,10 +303,12 @@ project
       │    └── columns: y.a:3(int) y.rowid:4(int!null)
       └── filters [type=bool]
            └── any: eq [type=bool]
-                ├── project
+                ├── spool
                 │    ├── columns: x.a:1(int)
-                │    └── scan x
-                │         └── columns: x.a:1(int) x.rowid:2(int!null)
+                │    └── project
+                │         ├── columns: x.a:1(int)
+                │         └── scan x
+                │              └── columns: x.a:1(int) x.rowid:2(int!null)
                 └── variable: y.a [type=int]
 
 build
@@ -287,10 +323,12 @@ project
       │    └── columns: y.a:3(int) y.rowid:4(int!null)
       └── filters [type=bool]
            └── any: eq [type=bool]
-                ├── project
+                ├── spool
                 │    ├── columns: x.a:1(int)
-                │    └── scan x
-                │         └── columns: x.a:1(int) x.rowid:2(int!null)
+                │    └── project
+                │         ├── columns: x.a:1(int)
+                │         └── scan x
+                │              └── columns: x.a:1(int) x.rowid:2(int!null)
                 └── variable: y.a [type=int]
 
 # Using a subquery inside a CTE
@@ -306,16 +344,18 @@ project
       │    └── columns: x.a:1(int) x.rowid:2(int!null)
       └── filters [type=bool]
            └── any: eq [type=bool]
-                ├── project
+                ├── spool
                 │    ├── columns: y.a:3(int!null)
-                │    └── select
-                │         ├── columns: y.a:3(int!null) y.rowid:4(int!null)
-                │         ├── scan y
-                │         │    └── columns: y.a:3(int) y.rowid:4(int!null)
-                │         └── filters [type=bool]
-                │              └── lt [type=bool]
-                │                   ├── variable: y.a [type=int]
-                │                   └── const: 3 [type=int]
+                │    └── project
+                │         ├── columns: y.a:3(int!null)
+                │         └── select
+                │              ├── columns: y.a:3(int!null) y.rowid:4(int!null)
+                │              ├── scan y
+                │              │    └── columns: y.a:3(int) y.rowid:4(int!null)
+                │              └── filters [type=bool]
+                │                   └── lt [type=bool]
+                │                        ├── variable: y.a [type=int]
+                │                        └── const: 3 [type=int]
                 └── variable: x.a [type=int]
 
 # Using a correlated subquery inside a CTE
@@ -332,26 +372,30 @@ project
                 ├── columns: y.a:3(int!null)
                 └── limit
                      ├── columns: y.a:3(int!null)
-                     ├── project
+                     ├── spool
                      │    ├── columns: y.a:3(int!null)
-                     │    └── select
-                     │         ├── columns: y.a:3(int!null) y.rowid:4(int!null)
-                     │         ├── scan y
-                     │         │    └── columns: y.a:3(int) y.rowid:4(int!null)
-                     │         └── filters [type=bool]
-                     │              └── eq [type=bool]
-                     │                   ├── variable: x.a [type=int]
-                     │                   └── variable: y.a [type=int]
+                     │    └── project
+                     │         ├── columns: y.a:3(int!null)
+                     │         └── select
+                     │              ├── columns: y.a:3(int!null) y.rowid:4(int!null)
+                     │              ├── scan y
+                     │              │    └── columns: y.a:3(int) y.rowid:4(int!null)
+                     │              └── filters [type=bool]
+                     │                   └── eq [type=bool]
+                     │                        ├── variable: x.a [type=int]
+                     │                        └── variable: y.a [type=int]
                      └── const: 1 [type=int]
 
 # Rename columns
 build
 WITH t(b) AS (SELECT a FROM x) SELECT b, t.b FROM t
 ----
-project
+spool
  ├── columns: b:1(int) b:1(int)
- └── scan x
-      └── columns: a:1(int) rowid:2(int!null)
+ └── project
+      ├── columns: a:1(int)
+      └── scan x
+           └── columns: a:1(int) rowid:2(int!null)
 
 build
 WITH t(b, c) AS (SELECT a FROM x) SELECT b, t.b FROM t
@@ -370,18 +414,22 @@ WITH t(x) AS (WITH t(x) AS (SELECT 1) SELECT x * 10 FROM t) SELECT x + 2 FROM t
 ----
 project
  ├── columns: "?column?":3(int)
- ├── project
+ ├── spool
  │    ├── columns: "?column?":2(int)
- │    ├── project
- │    │    ├── columns: "?column?":1(int!null)
- │    │    ├── values
- │    │    │    └── tuple [type=tuple]
- │    │    └── projections
- │    │         └── const: 1 [type=int]
- │    └── projections
- │         └── mult [type=int]
- │              ├── variable: ?column? [type=int]
- │              └── const: 10 [type=int]
+ │    └── project
+ │         ├── columns: "?column?":2(int)
+ │         ├── spool
+ │         │    ├── columns: "?column?":1(int!null)
+ │         │    └── project
+ │         │         ├── columns: "?column?":1(int!null)
+ │         │         ├── values
+ │         │         │    └── tuple [type=tuple]
+ │         │         └── projections
+ │         │              └── const: 1 [type=int]
+ │         └── projections
+ │              └── mult [type=int]
+ │                   ├── variable: ?column? [type=int]
+ │                   └── const: 10 [type=int]
  └── projections
       └── plus [type=int]
            ├── variable: ?column? [type=int]

--- a/pkg/sql/opt/rule_name.go
+++ b/pkg/sql/opt/rule_name.go
@@ -31,6 +31,7 @@ const (
 	SimplifyRootOrdering
 	PruneRootCols
 	SimplifyZeroCardinalityGroup
+	EliminateRootSpool
 
 	// NumManualRules tracks the number of manually-defined rules.
 	NumManualRuleNames

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -600,6 +600,21 @@ func (o *Optimizer) optimizeRootWithProps() {
 			}
 		}
 	}
+
+	// [EliminateRootSpool]
+	// The root of a plan naturally spools, and thus an explicit spool node
+	// can be eliminated.
+	expr := o.mem.NormExpr(root)
+	if expr.Operator() == opt.SpoolOp {
+		if o.matchedRule == nil || o.matchedRule(opt.EliminateRootSpool) {
+			root = expr.AsSpool().Input()
+			o.mem.SetRoot(root, o.mem.InternPhysicalProps(rootProps))
+
+			if o.appliedRule != nil {
+				o.appliedRule(opt.EliminateRootSpool, root, 0, 0)
+			}
+		}
+	}
 }
 
 // optStateKey associates optState with a group that is being optimized with

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -649,6 +649,11 @@ func (ef *execFactory) ConstructProjectSet(
 	return p, nil
 }
 
+// ConstructSpool is part of the exec.Factory interface.
+func (ef *execFactory) ConstructSpool(input exec.Node) (exec.Node, error) {
+	return &spoolNode{source: asDataSource(input).plan}, nil
+}
+
 // ConstructPlan is part of the exec.Factory interface.
 func (ef *execFactory) ConstructPlan(
 	root exec.Node, subqueries []exec.Subquery,


### PR DESCRIPTION
This commit introduces the relational Spool operator to the optimizer. A
Spool ensures that its input will always be completely consumed, which
can be important in the presence of side effects. This commit also
introduces a handful (very incomplete) set of rules for pushing Spools
around and eliminating them. I'm generally a bit unsure about this - it
makes sense that we want to pull spools up towards the root so that we
can hopefully eliminate them for free (since the root naturally spools),
but if we pull a spool above a join and fail to completely eliminate it
we could end up buffering more data in memory than we otherwise would.
Open to suggestions here. Perhaps we should just accept that we will
not eliminate some spools that we otherwise could and not risk moving
them around.

Release note: None