### PR TITLE
storage: move MergeQueueEnabled to storagebase

### DIFF
--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 )
 
 type splitNode struct {
@@ -106,7 +106,7 @@ func (n *splitNode) startExec(params runParams) error {
 	// because of gossip inconsistency, or it could change halfway through the
 	// SPLIT AT's execution. It is, however, likely to prevent user error and
 	// confusion in the common case.
-	if !n.force && storage.MergeQueueEnabled.Get(&params.p.ExecCfg().Settings.SV) {
+	if !n.force && storagebase.MergeQueueEnabled.Get(&params.p.ExecCfg().Settings.SV) {
 		return errors.New("splits would be immediately discarded by merge queue; " +
 			"disable the merge queue first by running 'SET CLUSTER SETTING kv.range_merge.queue_enabled = false'")
 	}

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -2442,7 +2442,7 @@ func TestMergeQueue(t *testing.T) {
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	storeCfg.TestingKnobs.DisableScanner = true
 	sv := &storeCfg.Settings.SV
-	storage.MergeQueueEnabled.Override(sv, true)
+	storagebase.MergeQueueEnabled.Override(sv, true)
 	storage.MergeQueueInterval.Override(sv, 0) // process greedily
 	var mtc multiTestContext
 	mtc.storeConfig = &storeCfg

--- a/pkg/storage/merge_queue.go
+++ b/pkg/storage/merge_queue.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -42,14 +43,6 @@ const (
 	// onto the left-hand range, even when the ranges are collocated. This is
 	// expensive, so limit to one merge at a time.
 	mergeQueueConcurrency = 1
-)
-
-// MergeQueueEnabled is a setting that controls whether the merge queue is
-// enabled.
-var MergeQueueEnabled = settings.RegisterBoolSetting(
-	"kv.range_merge.queue_enabled",
-	"whether the automatic merge queue is enabled",
-	false,
 )
 
 // MergeQueueInterval is a setting that controls how often the merge queue waits
@@ -127,7 +120,7 @@ func newMergeQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *mergeQue
 
 func (mq *mergeQueue) enabled() bool {
 	st := mq.store.ClusterSettings()
-	return st.Version.IsMinSupported(cluster.VersionRangeMerges) && MergeQueueEnabled.Get(&st.SV)
+	return st.Version.IsMinSupported(cluster.VersionRangeMerges) && storagebase.MergeQueueEnabled.Get(&st.SV)
 }
 
 func (mq *mergeQueue) shouldQueue(

--- a/pkg/storage/merge_queue_test.go
+++ b/pkg/storage/merge_queue_test.go
@@ -18,12 +18,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/gogo/protobuf/proto"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -39,7 +40,7 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 	testCtx.Start(t, stopper)
 
 	mq := newMergeQueue(testCtx.store, testCtx.store.DB(), testCtx.gossip)
-	MergeQueueEnabled.Override(&testCtx.store.ClusterSettings().SV, true)
+	storagebase.MergeQueueEnabled.Override(&testCtx.store.ClusterSettings().SV, true)
 
 	tableKey := func(i uint32) []byte {
 		return keys.MakeTablePrefix(keys.MaxReservedDescID + i)

--- a/pkg/storage/storagebase/base.go
+++ b/pkg/storage/storagebase/base.go
@@ -22,7 +22,16 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
+)
+
+// MergeQueueEnabled is a setting that controls whether the merge queue is
+// enabled.
+var MergeQueueEnabled = settings.RegisterBoolSetting(
+	"kv.range_merge.queue_enabled",
+	"whether the automatic merge queue is enabled",
+	false,
 )
 
 // TxnCleanupThreshold is the threshold after which a transaction is


### PR DESCRIPTION
... to avoid dependency edge from sql to storage.

Updates #30001.

Release note: None