### PR TITLE
roachtest: add CREATE INDEX on tpcc 1000 cluster

### DIFF
--- a/pkg/cmd/roachtest/create_index.go
+++ b/pkg/cmd/roachtest/create_index.go
@@ -1,0 +1,52 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func registerCreateIndexTPCC(r *registry) {
+	warehouses := 1000
+	numNodes := 5
+	r.Add(testSpec{
+		Name:    fmt.Sprintf("createindex/tpcc/warehouses=%d/nodes=%d", warehouses, numNodes),
+		Nodes:   nodes(numNodes),
+		Timeout: 3 * time.Hour,
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runTPCC(ctx, t, c, tpccOptions{
+				Warehouses: warehouses,
+				Extra:      "--wait=false --tolerate-errors",
+				During: func(ctx context.Context) error {
+					conn := c.Conn(ctx, 1)
+					start := timeutil.Now()
+					if _, err := conn.Exec(`
+					CREATE UNIQUE INDEX foo ON tpcc.order (o_entry_d, o_w_id, o_d_id, o_carrier_id, o_id);
+				`); err != nil {
+						t.Fatal(err)
+					}
+					c.l.Printf("CREATE INDEX took %s", timeutil.Since(start))
+					return nil
+				},
+				Duration: 2 * time.Hour,
+			})
+		},
+	})
+}

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -28,6 +28,7 @@ func registerTests(r *registry) {
 	registerClearRange(r)
 	registerClock(r)
 	registerCopy(r)
+	registerCreateIndexTPCC(r)
 	registerDebug(r)
 	registerDebugHeap(r)
 	registerDecommission(r)

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -38,7 +38,8 @@ import (
 type tpccOptions struct {
 	Warehouses int
 	Extra      string
-	Chaos      func() Chaos // for late binding of stopper
+	Chaos      func() Chaos                // for late binding of stopper
+	During     func(context.Context) error // for running a function during the test
 	Duration   time.Duration
 	ZFS        bool
 }
@@ -113,6 +114,9 @@ func runTPCC(ctx context.Context, t *test, c *cluster, opts tpccOptions) {
 	if opts.Chaos != nil {
 		chaos := opts.Chaos()
 		m.Go(chaos.Runner(c, m))
+	}
+	if opts.During != nil {
+		m.Go(opts.During)
 	}
 	m.Wait()
 }


### PR DESCRIPTION
The roachtest creates an index against a table with
30M rows on a tpcc cluster with a 1000 warehouses.

The test takes around 3 hours to run.

Release note: None