### PR TITLE
roachtest: move the logger from cluster to test

### DIFF
--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -58,19 +58,19 @@ func registerAllocator(r *registry) {
 			// but we can't put it in monitor as-is because the test deadlocks.
 			go func() {
 				const cmd = `./workload run kv --tolerate-errors --min-block-bytes=8 --max-block-bytes=128`
-				l, err := c.l.ChildLogger(fmt.Sprintf(`kv-%d`, node))
+				l, err := t.l.ChildLogger(fmt.Sprintf(`kv-%d`, node))
 				if err != nil {
 					t.Fatal(err)
 				}
 				defer l.close()
-				_ = execCmd(ctx, c.l, roachprod, "ssh", c.makeNodes(c.Node(node)), "--", cmd)
+				_ = execCmd(ctx, t.l, roachprod, "ssh", c.makeNodes(c.Node(node)), "--", cmd)
 			}()
 		}
 
 		m = newMonitor(ctx, c, c.All())
 		m.Go(func(ctx context.Context) error {
 			t.Status("waiting for reblance")
-			return waitForRebalance(ctx, c.l, db, maxStdDev)
+			return waitForRebalance(ctx, t.l, db, maxStdDev)
 		})
 		m.Wait()
 	}

--- a/pkg/cmd/roachtest/bank.go
+++ b/pkg/cmd/roachtest/bank.go
@@ -145,7 +145,7 @@ CREATE TABLE bank.accounts (
 
 // Continuously transfers money until done().
 func (s *bankState) transferMoney(
-	ctx context.Context, c *cluster, idx, numAccounts, maxTransfer int,
+	ctx context.Context, l *logger, c *cluster, idx, numAccounts, maxTransfer int,
 ) {
 	defer c.l.Printf("client %d shutting down\n", idx)
 	client := &s.clients[idx-1]
@@ -238,12 +238,12 @@ func (s *bankState) startChaosMonkey(
 					s.clients[i].Lock()
 				}
 			}
-			c.l.Printf("round %d: restarting nodes %v\n", curRound, nodes)
+			t.l.Printf("round %d: restarting nodes %v\n", curRound, nodes)
 			for _, i := range nodes {
 				if s.done(ctx) {
 					break
 				}
-				c.l.Printf("round %d: restarting %d\n", curRound, i)
+				t.l.Printf("round %d: restarting %d\n", curRound, i)
 				c.Stop(ctx, c.Node(i))
 				c.Start(ctx, t, c.Node(i))
 				if stopClients {
@@ -263,7 +263,7 @@ func (s *bankState) startChaosMonkey(
 				newCounts := s.counts()
 				for i := range newCounts {
 					if newCounts[i] > preCount[i] {
-						c.l.Printf("round %d: progress made by client %d\n", curRound, i)
+						t.l.Printf("round %d: progress made by client %d\n", curRound, i)
 						return true
 					}
 				}
@@ -281,7 +281,7 @@ func (s *bankState) startChaosMonkey(
 				return
 			}
 
-			c.l.Printf("round %d: cluster recovered\n", curRound)
+			t.l.Printf("round %d: cluster recovered\n", curRound)
 		}
 	}()
 }
@@ -409,7 +409,7 @@ func (s *bankState) waitClientsStop(
 			}
 			// This just stops the logs from being a bit too spammy.
 			if newOutput != prevOutput {
-				c.l.Printf("%s\n", newOutput)
+				t.l.Printf("%s\n", newOutput)
 				prevOutput = newOutput
 			}
 		}
@@ -434,12 +434,12 @@ func runBankClusterRecovery(ctx context.Context, t *test, c *cluster) {
 		s.clients[i].Lock()
 		s.initClient(ctx, c, i+1)
 		s.clients[i].Unlock()
-		go s.transferMoney(ctx, c, i+1, bankNumAccounts, bankMaxTransfer)
+		go s.transferMoney(ctx, t.l, c, i+1, bankNumAccounts, bankMaxTransfer)
 	}
 
 	// Chaos monkey.
 	rnd, seed := randutil.NewPseudoRand()
-	c.l.Printf("monkey starts (seed %d)\n", seed)
+	t.l.Printf("monkey starts (seed %d)\n", seed)
 	pickNodes := func() []int {
 		nodes := rnd.Perm(c.nodes)[:rnd.Intn(c.nodes)+1]
 		for i := range nodes {
@@ -460,7 +460,7 @@ func runBankClusterRecovery(ctx context.Context, t *test, c *cluster) {
 	for _, c := range counts {
 		count += c
 	}
-	c.l.Printf("%d transfers (%.1f/sec) in %.1fs\n", count, float64(count)/elapsed, elapsed)
+	t.l.Printf("%d transfers (%.1f/sec) in %.1fs\n", count, float64(count)/elapsed, elapsed)
 }
 
 func runBankNodeRestart(ctx context.Context, t *test, c *cluster) {
@@ -481,11 +481,11 @@ func runBankNodeRestart(ctx context.Context, t *test, c *cluster) {
 	client := &s.clients[0]
 	client.db = c.Conn(ctx, clientIdx)
 
-	go s.transferMoney(ctx, c, 1, bankNumAccounts, bankMaxTransfer)
+	go s.transferMoney(ctx, t.l, c, 1, bankNumAccounts, bankMaxTransfer)
 
 	// Chaos monkey.
 	rnd, seed := randutil.NewPseudoRand()
-	c.l.Printf("monkey starts (seed %d)\n", seed)
+	t.l.Printf("monkey starts (seed %d)\n", seed)
 	pickNodes := func() []int {
 		return []int{1 + rnd.Intn(clientIdx)}
 	}
@@ -498,7 +498,7 @@ func runBankNodeRestart(ctx context.Context, t *test, c *cluster) {
 
 	elapsed := timeutil.Since(start).Seconds()
 	count := atomic.LoadUint64(&client.count)
-	c.l.Printf("%d transfers (%.1f/sec) in %.1fs\n", count, float64(count)/elapsed, elapsed)
+	t.l.Printf("%d transfers (%.1f/sec) in %.1fs\n", count, float64(count)/elapsed, elapsed)
 }
 
 func runBankNodeZeroSum(ctx context.Context, t *test, c *cluster) {
@@ -518,7 +518,7 @@ func runBankNodeZeroSum(ctx context.Context, t *test, c *cluster) {
 		s.clients[i].Lock()
 		s.initClient(ctx, c, i+1)
 		s.clients[i].Unlock()
-		go s.transferMoney(ctx, c, i+1, bankNumAccounts, bankMaxTransfer)
+		go s.transferMoney(ctx, t.l, c, i+1, bankNumAccounts, bankMaxTransfer)
 	}
 
 	s.startSplitMonkey(ctx, 2*time.Second, c)
@@ -554,7 +554,7 @@ func runBankZeroSumRestart(ctx context.Context, t *test, c *cluster) {
 		s.clients[i].Lock()
 		s.initClient(ctx, c, i+1)
 		s.clients[i].Unlock()
-		go s.transferMoney(ctx, c, i+1, bankNumAccounts, bankMaxTransfer)
+		go s.transferMoney(ctx, t.l, c, i+1, bankNumAccounts, bankMaxTransfer)
 	}
 
 	rnd, seed := randutil.NewPseudoRand()

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -134,7 +134,7 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 		return nil
 	})
 	m.Go(func(ctx context.Context) error {
-		l, err := c.l.ChildLogger(`changefeed`)
+		l, err := t.l.ChildLogger(`changefeed`)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/cli.go
+++ b/pkg/cmd/roachtest/cli.go
@@ -43,7 +43,7 @@ func runCLINodeStatus(ctx context.Context, t *test, c *cluster) {
 	}
 
 	nodeStatus := func() []string {
-		out, err := c.RunWithBuffer(ctx, c.l, c.Node(1),
+		out, err := c.RunWithBuffer(ctx, t.l, c.Node(1),
 			"./cockroach node status --insecure -p {pgport:1}")
 		if err != nil {
 			t.Fatalf("%v\n%s", err, out)
@@ -72,7 +72,7 @@ func runCLINodeStatus(ctx context.Context, t *test, c *cluster) {
 			if reflect.DeepEqual(expected, actual) {
 				break
 			}
-			c.l.Printf("not done: %s vs %s\n", expected, actual)
+			t.l.Printf("not done: %s vs %s\n", expected, actual)
 			time.Sleep(time.Second)
 		}
 		if !reflect.DeepEqual(expected, actual) {

--- a/pkg/cmd/roachtest/clock_monotonic.go
+++ b/pkg/cmd/roachtest/clock_monotonic.go
@@ -80,10 +80,10 @@ func runClockMonotonicity(ctx context.Context, t *test, c *cluster, tc clockMono
 	}
 
 	t.Status("validating clock monotonicity")
-	c.l.Printf("pre-restart time:  %f\n", preRestartTime)
-	c.l.Printf("post-restart time: %f\n", postRestartTime)
+	t.l.Printf("pre-restart time:  %f\n", preRestartTime)
+	t.l.Printf("post-restart time: %f\n", postRestartTime)
 	difference := postRestartTime - preRestartTime
-	c.l.Printf("time-difference: %v\n", time.Duration(difference*float64(time.Second)))
+	t.l.Printf("time-difference: %v\n", time.Duration(difference*float64(time.Second)))
 
 	if tc.expectIncreasingWallTime {
 		if preRestartTime > postRestartTime {

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -50,10 +50,7 @@ import (
 )
 
 var (
-	local bool
-	// Path to a local dir where the test logs and artifacts collected from
-	// cluster will be placed.
-	artifacts   string
+	local       bool
 	cockroach   string
 	cloud       = "gce"
 	encrypt     bool
@@ -631,8 +628,9 @@ type cluster struct {
 
 type clusterConfig struct {
 	// name must be empty if localCluster is specified.
-	name         string
-	nodes        []nodeSpec
+	name  string
+	nodes []nodeSpec
+	// artifactsDir is the path where log file will be stored.
 	artifactsDir string
 	localCluster bool
 	teeOpt       teeOptType

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -418,6 +418,7 @@ type testI interface {
 	// Path to a directory where the test is supposed to store its log and other
 	// artifacts.
 	ArtifactsDir() string
+	logger() *logger
 }
 
 // TODO(tschottdorf): Consider using a more idiomatic approach in which options
@@ -608,16 +609,23 @@ func nodes(count int, opts ...createOption) []nodeSpec {
 // A cluster is intended to be shared between all the subtests under a root.
 // A cluster is safe for concurrent use by multiple goroutines.
 type cluster struct {
-	name       string
-	nodes      int
-	status     func(...interface{})
-	t          testI
-	l          *logger
+	name   string
+	nodes  int
+	status func(...interface{})
+	t      testI
+	// l is the logger used to log various cluster operations.
+	// DEPRECATED for use outside of cluster methods: Use a test's t.l instead.
+	// This is generally set to the current test's logger.
+	l *logger
+	// destroyed is used to coordinate between different goroutines that want to
+	// destroy a cluster. It is nil when the cluster should not be destroyed (i.e.
+	// when Destroy() should not be called).
 	destroyed  chan struct{}
 	expiration time.Time
-	// owned is set if this instance is responsible for destroying the roachprod
+	// owned is set if this instance is responsible for `roachprod destroy`ing the
 	// cluster. It is set when a new cluster is created, but not when one is
 	// cloned or when we attach to an existing roachprod cluster.
+	// If not set, Destroy() only wipes the cluster.
 	owned bool
 }
 
@@ -642,7 +650,7 @@ type clusterConfig struct {
 // to figure out how to make that work with `roachprod create`. Perhaps one
 // invocation of `roachprod create` per unique node-spec. Are there guarantees
 // we're making here about the mapping of nodeSpecs to node IDs?
-func newCluster(ctx context.Context, cfg clusterConfig) (*cluster, error) {
+func newCluster(ctx context.Context, l *logger, cfg clusterConfig) (*cluster, error) {
 	if atomic.LoadInt32(&interrupted) == 1 {
 		return nil, fmt.Errorf("newCluster interrupted")
 	}
@@ -666,12 +674,6 @@ func newCluster(ctx context.Context, cfg clusterConfig) (*cluster, error) {
 	case len(cfg.nodes) > 1:
 		// TODO(peter): Need a motivating test that has different specs per node.
 		return nil, fmt.Errorf("TODO(peter): unsupported nodes spec: %v", cfg.nodes)
-	}
-
-	logPath := filepath.Join(cfg.artifactsDir, "test.log")
-	l, err := rootLogger(logPath, cfg.teeOpt)
-	if err != nil {
-		return nil, err
 	}
 
 	c := &cluster{
@@ -701,9 +703,6 @@ func newCluster(ctx context.Context, cfg clusterConfig) (*cluster, error) {
 }
 
 type attachOpt struct {
-	// If set, the c.l will output to stdout/stderr.
-	teeToStdout bool
-
 	skipValidation bool
 	// Implies skipWipe.
 	skipStop bool
@@ -715,21 +714,11 @@ type attachOpt struct {
 //
 // NOTE: setTest() needs to be called before a test can use this cluster.
 func attachToExistingCluster(
-	ctx context.Context, name string, artifactsDir string, nodes []nodeSpec, opt attachOpt,
+	ctx context.Context, name string, l *logger, nodes []nodeSpec, opt attachOpt,
 ) (*cluster, error) {
 	if len(nodes) > 1 {
 		// TODO(peter): Need a motivating test that has different specs per node.
 		return nil, fmt.Errorf("TODO(peter): unsupported nodes spec: %v", nodes)
-	}
-
-	logPath := filepath.Join(artifactsDir, "test.log")
-	teeOpt := noTee
-	if opt.teeToStdout {
-		teeOpt = teeToStdout
-	}
-	l, err := rootLogger(logPath, teeOpt)
-	if err != nil {
-		return nil, err
 	}
 
 	c := &cluster{
@@ -772,9 +761,10 @@ func attachToExistingCluster(
 
 // setTest prepares c for being used on behalf of t.
 //
-// TODO(andrei): Get rid of c.t and of this method.
+// TODO(andrei): Get rid of c.t, c.l and of this method.
 func (c *cluster) setTest(t testI) {
 	c.t = t
+	c.l = t.logger()
 	if impl, ok := t.(*test); ok {
 		c.status = impl.Status
 	}
@@ -825,24 +815,19 @@ func (c *cluster) validate(ctx context.Context, nodes []nodeSpec, l *logger) err
 	return nil
 }
 
-// clone creates a new cluster object that refers to the same cluster as the
-// receiver, but is associated with the specified test.
-func (c *cluster) clone(t *test, teeOpt teeOptType) *cluster {
-	logPath := filepath.Join(t.ArtifactsDir(), "test.log")
-	l, err := rootLogger(logPath, teeOpt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return &cluster{
-		name:       c.name,
-		nodes:      c.nodes,
-		status:     t.Status,
-		t:          t,
-		l:          l,
-		expiration: c.expiration,
-		// This cloned cluster is not taking ownership. The parent retains it.
-		owned: false,
-	}
+// clone creates a non-owned handle on the same cluster.
+//
+// NOTE: If the cloning has been done for a subtest, setTest() needs to be
+// called on the returned cluster.
+//
+// TODO(andrei): Get rid of the funky concept of cloning once we implement a
+// more principled aproach to wiping and destroying cluster.
+func (c *cluster) clone() *cluster {
+	cpy := *c
+	// This cloned cluster is not taking ownership. The parent retains it.
+	cpy.owned = false
+	cpy.destroyed = nil
+	return &cpy
 }
 
 // All returns a node list containing all of the nodes in the cluster.

--- a/pkg/cmd/roachtest/cluster_init.go
+++ b/pkg/cmd/roachtest/cluster_init.go
@@ -193,7 +193,7 @@ func runClusterInit(ctx context.Context, t *test, c *cluster) {
 				args = append(args, "--insecure")
 				args = append(args, fmt.Sprintf("--port={pgport:%d}", runNode))
 				buf, err := c.RunWithBuffer(ctx, c.l, c.Node(runNode), args...)
-				c.l.Printf("%s\n", buf)
+				t.l.Printf("%s\n", buf)
 				return string(buf), err
 			}
 

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -65,6 +65,10 @@ func (t testWrapper) ArtifactsDir() string {
 	return ""
 }
 
+func (t testWrapper) logger() *logger {
+	return nil
+}
+
 func TestClusterMonitor(t *testing.T) {
 	logger := &logger{stdout: os.Stdout, stderr: os.Stderr}
 	t.Run(`success`, func(t *testing.T) {

--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -121,7 +121,7 @@ func registerCopy(r *registry) {
 			}
 
 			rc := rangeCount()
-			c.l.Printf("range count after copy = %d\n", rc)
+			t.l.Printf("range count after copy = %d\n", rc)
 			highExp := (rows * rowEstimate) / (32 << 20 /* 32MB */)
 			lowExp := (rows * rowEstimate) / (64 << 20 /* 64MB */)
 			if rc > highExp || rc < lowExp {

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -86,12 +86,12 @@ func registerDrop(r *registry) {
 			}
 
 			for j := 1; j <= nodes; j++ {
-				size, err := getDiskUsageInBytes(ctx, c, c.l, j)
+				size, err := getDiskUsageInBytes(ctx, c, t.l, j)
 				if err != nil {
 					return err
 				}
 
-				c.l.Printf("Node %d space used: %s\n", j, humanizeutil.IBytes(int64(size)))
+				t.l.Printf("Node %d space used: %s\n", j, humanizeutil.IBytes(int64(size)))
 
 				// Return if the size of the directory is less than 100mb
 				if size < initDiskSpace {
@@ -127,13 +127,13 @@ func registerDrop(r *registry) {
 				sizeReport = ""
 				allNodesSpaceCleared = true
 				for j := 1; j <= nodes; j++ {
-					size, err := getDiskUsageInBytes(ctx, c, c.l, j)
+					size, err := getDiskUsageInBytes(ctx, c, t.l, j)
 					if err != nil {
 						return err
 					}
 
 					nodeSpaceUsed := fmt.Sprintf("Node %d space after deletion used: %s\n", j, humanizeutil.IBytes(int64(size)))
-					c.l.Printf(nodeSpaceUsed)
+					t.l.Printf(nodeSpaceUsed)
 
 					// Return if the size of the directory is less than 100mb
 					if size > maxSizeBytes {

--- a/pkg/cmd/roachtest/election.go
+++ b/pkg/cmd/roachtest/election.go
@@ -44,7 +44,7 @@ func registerElectionAfterRestart(r *registry) {
 			c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
         SELECT * FROM test.kv"`)
 			duration := timeutil.Since(start)
-			c.l.Printf("pre-restart, query took %s\n", duration)
+			t.l.Printf("pre-restart, query took %s\n", duration)
 
 			t.Status("restarting")
 			c.Stop(ctx)
@@ -57,7 +57,7 @@ func registerElectionAfterRestart(r *registry) {
 			// this up are working (we trigger elections eagerly, but not so
 			// eagerly that multiple elections conflict with each other).
 			start = timeutil.Now()
-			buf, err := c.RunWithBuffer(ctx, c.l, c.Node(1), `./cockroach sql --insecure -e "
+			buf, err := c.RunWithBuffer(ctx, t.l, c.Node(1), `./cockroach sql --insecure -e "
 SET TRACING = on;
 SELECT * FROM test.kv;
 SET TRACING = off;
@@ -67,7 +67,7 @@ SHOW TRACE FOR SESSION;
 				t.Fatalf("%s\n\n%s", buf, err)
 			}
 			duration = timeutil.Since(start)
-			c.l.Printf("post-restart, query took %s\n", duration)
+			t.l.Printf("post-restart, query took %s\n", duration)
 			if expected := 15 * time.Second; duration > expected {
 				// In the happy case, this query runs in around 250ms. Prior
 				// to the introduction of this test, a bug caused most
@@ -76,7 +76,7 @@ SHOW TRACE FOR SESSION;
 				// elections to fail (the biggest one as I write this is
 				// #26448), so we must use a generous timeout here. We may be
 				// able to tighten the bounds as we make more improvements.
-				c.l.Printf("%s\n", buf)
+				t.l.Printf("%s\n", buf)
 				t.Fatalf("expected query to succeed in less than %s, took %s", expected, duration)
 			}
 		},

--- a/pkg/cmd/roachtest/gossip.go
+++ b/pkg/cmd/roachtest/gossip.go
@@ -201,7 +201,7 @@ func (gossipUtil) hasClusterID(infos map[string]gossip.Info) error {
 }
 
 func (g *gossipUtil) checkConnectedAndFunctional(ctx context.Context, t *test, c *cluster) {
-	c.l.Printf("waiting for gossip to be connected\n")
+	t.l.Printf("waiting for gossip to be connected\n")
 	if err := g.check(ctx, c, g.hasPeers(c.nodes)); err != nil {
 		t.Fatal(err)
 	}
@@ -265,11 +265,11 @@ func runGossipPeerings(ctx context.Context, t *test, c *cluster) {
 		if err := g.check(ctx, c, g.hasSentinel); err != nil {
 			t.Fatal(err)
 		}
-		c.l.Printf("%d: OK\n", i)
+		t.l.Printf("%d: OK\n", i)
 
 		// Restart a random node.
 		node := c.All().randNode()
-		c.l.Printf("%d: restarting node %d\n", i, node[0])
+		t.l.Printf("%d: restarting node %d\n", i, node[0])
 		c.Stop(ctx, node)
 		c.Start(ctx, t, node)
 	}
@@ -289,12 +289,12 @@ func runGossipRestart(ctx context.Context, t *test, c *cluster) {
 
 	for i := 1; timeutil.Now().Before(deadline); i++ {
 		g.checkConnectedAndFunctional(ctx, t, c)
-		c.l.Printf("%d: OK\n", i)
+		t.l.Printf("%d: OK\n", i)
 
-		c.l.Printf("%d: killing all nodes\n", i)
+		t.l.Printf("%d: killing all nodes\n", i)
 		c.Stop(ctx)
 
-		c.l.Printf("%d: restarting all nodes\n", i)
+		t.l.Printf("%d: restarting all nodes\n", i)
 		c.Start(ctx, t)
 	}
 }
@@ -309,13 +309,13 @@ func runGossipRestartNodeOne(ctx context.Context, t *test, c *cluster) {
 
 	run := func(stmtStr string) {
 		stmt := fmt.Sprintf(stmtStr, "", "=")
-		c.l.Printf("%s\n", stmt)
+		t.l.Printf("%s\n", stmt)
 		_, err := db.ExecContext(ctx, stmt)
 		if err != nil && strings.Contains(err.Error(), "syntax error") {
 			// Pre-2.1 was EXPERIMENTAL.
 			// TODO(knz): Remove this in 2.2.
 			stmt = fmt.Sprintf(stmtStr, "EXPERIMENTAL", "")
-			c.l.Printf("%s\n", stmt)
+			t.l.Printf("%s\n", stmt)
 			_, err = db.ExecContext(ctx, stmt)
 		}
 		if err != nil {
@@ -338,7 +338,7 @@ func runGossipRestartNodeOne(ctx context.Context, t *test, c *cluster) {
 				count, util.Pluralize(int64(count)))
 			if count != lastNodeCount {
 				lastNodeCount = count
-				c.l.Printf("%s\n", err)
+				t.l.Printf("%s\n", err)
 			}
 			return err
 		}
@@ -370,7 +370,7 @@ SELECT count(replicas)
 			err := errors.Errorf("node 1 still has %d replicas", count)
 			if count != lastReplCount {
 				lastReplCount = count
-				c.l.Printf("%s\n", err)
+				t.l.Printf("%s\n", err)
 			}
 			return err
 		}
@@ -379,7 +379,7 @@ SELECT count(replicas)
 		t.Fatal(err)
 	}
 
-	c.l.Printf("killing all nodes\n")
+	t.l.Printf("killing all nodes\n")
 	c.Stop(ctx)
 
 	// Restart node 1, but have it listen on a different port for internal

--- a/pkg/cmd/roachtest/hibernate.go
+++ b/pkg/cmd/roachtest/hibernate.go
@@ -97,7 +97,7 @@ func registerHibernate(r *registry) {
 
 		// Load the list of all test results files and parse them individually.
 		// Files are here: /mnt/data1/hibernate/hibernate-core/target/test-results/test
-		output, err := c.RunWithBuffer(ctx, c.l, node,
+		output, err := c.RunWithBuffer(ctx, t.l, node,
 			`ls /mnt/data1/hibernate/hibernate-core/target/test-results/test/*.xml`,
 		)
 		if err != nil {
@@ -115,11 +115,11 @@ func registerHibernate(r *registry) {
 		for i, file := range files {
 			file = strings.TrimSpace(file)
 			if len(file) == 0 {
-				c.l.Printf("Skipping %d of %d: %s\n", i, len(files), file)
+				t.l.Printf("Skipping %d of %d: %s\n", i, len(files), file)
 				continue
 			}
-			c.l.Printf("Parsing %d of %d: %s\n", i, len(files), file)
-			fileOutput, err := c.RunWithBuffer(ctx, c.l, node, `cat `+file)
+			t.l.Printf("Parsing %d of %d: %s\n", i, len(files), file)
+			fileOutput, err := c.RunWithBuffer(ctx, t.l, node, `cat `+file)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -171,31 +171,31 @@ func registerHibernate(r *registry) {
 			if !ok {
 				t.Fatalf("can't find %s in test result list", test)
 			}
-			c.l.Printf("%s\n", result)
+			t.l.Printf("%s\n", result)
 		}
 
-		c.l.Printf("------------------------\n")
-		c.l.Printf("%d Total Test Run\n",
+		t.l.Printf("------------------------\n")
+		t.l.Printf("%d Total Test Run\n",
 			passExpectedCount+passUnexpectedCount+failExpectedCount+failUnexpectedCount,
 		)
-		c.l.Printf("%d tests passed\n", passUnexpectedCount+passExpectedCount)
-		c.l.Printf("%d tests failed\n", failUnexpectedCount+failExpectedCount)
-		c.l.Printf("%d tests passed unexpectedly\n", passUnexpectedCount)
-		c.l.Printf("%d tests failed unexpectedly\n", failUnexpectedCount)
-		c.l.Printf("%d tests expected failed, but not run \n", notRunCount)
-		c.l.Printf("For a full summary, look at artifacts/hibernate/logs/logs/report/index.html\n")
-		c.l.Printf("------------------------\n")
+		t.l.Printf("%d tests passed\n", passUnexpectedCount+passExpectedCount)
+		t.l.Printf("%d tests failed\n", failUnexpectedCount+failExpectedCount)
+		t.l.Printf("%d tests passed unexpectedly\n", passUnexpectedCount)
+		t.l.Printf("%d tests failed unexpectedly\n", failUnexpectedCount)
+		t.l.Printf("%d tests expected failed, but not run \n", notRunCount)
+		t.l.Printf("For a full summary, look at artifacts/hibernate/logs/logs/report/index.html\n")
+		t.l.Printf("------------------------\n")
 
 		if failUnexpectedCount > 0 || passUnexpectedCount > 0 || notRunCount > 0 {
 			// Create a new hibernate_blacklist so we can easily update this test.
 			sort.Strings(currentFailures)
-			c.l.Printf("Here is new hibernate blacklist that can be used to update the test:\n\n")
-			c.l.Printf("var hibernateBlackList = []string{\n")
+			t.l.Printf("Here is new hibernate blacklist that can be used to update the test:\n\n")
+			t.l.Printf("var hibernateBlackList = []string{\n")
 			for _, test := range currentFailures {
-				c.l.Printf("\"%s\",\n", test)
+				t.l.Printf("\"%s\",\n", test)
 			}
-			c.l.Printf("}\n\n")
-			c.l.Printf("------------------------\n")
+			t.l.Printf("}\n\n")
+			t.l.Printf("------------------------\n")
 			t.Fatalf("\n"+
 				"%d tests failed unexpectedly\n"+
 				"%d tests passed unexpectedly\n"+

--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -46,9 +46,9 @@ func registerHotSpotSplits(r *registry) {
 		m, ctx = errgroup.WithContext(ctx)
 
 		m.Go(func() error {
-			c.l.Printf("starting load generator\n")
+			t.l.Printf("starting load generator\n")
 
-			quietL, err := c.l.ChildLogger("kv-0", quietStdout)
+			quietL, err := t.l.ChildLogger("kv-0", quietStdout)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/roachtest/interleavedpartitioned.go
+++ b/pkg/cmd/roachtest/interleavedpartitioned.go
@@ -114,7 +114,7 @@ func registerInterleaved(r *registry) {
 
 		runLocality := func(name string, node nodeListOption, cmd string) {
 			m.Go(func(ctx context.Context) error {
-				l, err := c.l.ChildLogger(name)
+				l, err := t.l.ChildLogger(name)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -65,10 +65,10 @@ func initJepsen(ctx context.Context, t *test, c *cluster) {
 
 	// Check to see if the cluster has already been initialized.
 	if err := c.RunE(ctx, c.Node(1), "test -e jepsen_initialized"); err == nil {
-		c.l.Printf("cluster already initialized\n")
+		t.l.Printf("cluster already initialized\n")
 		return
 	}
-	c.l.Printf("initializing cluster\n")
+	t.l.Printf("initializing cluster\n")
 	t.Status("initializing cluster")
 	defer func() {
 		c.Run(ctx, c.Node(1), "touch jepsen_initialized")
@@ -138,9 +138,9 @@ func runJepsen(ctx context.Context, t *test, c *cluster, testName, nemesis strin
 	// Wrap roachtest's primitive logging in something more like util/log
 	logf := func(f string, args ...interface{}) {
 		// This log prefix matches the one (sometimes) used in roachprod
-		c.l.Printf(timeutil.Now().Format("2006/01/02 15:04:05 "))
-		c.l.Printf(f, args...)
-		c.l.Printf("\n")
+		t.l.Printf(timeutil.Now().Format("2006/01/02 15:04:05 "))
+		t.l.Printf(f, args...)
+		t.l.Printf("\n")
 	}
 	run := func(c *cluster, ctx context.Context, node nodeListOption, args ...string) {
 		if !c.isLocal() {
@@ -148,14 +148,14 @@ func runJepsen(ctx context.Context, t *test, c *cluster, testName, nemesis strin
 			return
 		}
 		args = append([]string{roachprod, "run", c.makeNodes(node), "--"}, args...)
-		c.l.Printf("> %s\n", strings.Join(args, " "))
+		t.l.Printf("> %s\n", strings.Join(args, " "))
 	}
 	runE := func(c *cluster, ctx context.Context, node nodeListOption, args ...string) error {
 		if !c.isLocal() {
 			return c.RunE(ctx, node, args...)
 		}
 		args = append([]string{roachprod, "run", c.makeNodes(node), "--"}, args...)
-		c.l.Printf("> %s\n", strings.Join(args, " "))
+		t.l.Printf("> %s\n", strings.Join(args, " "))
 		return nil
 	}
 
@@ -241,8 +241,8 @@ cd /mnt/data1/jepsen/cockroachdb && set -eo pipefail && \
 			cmd := c.LoggedCommand(ctx, roachprod, "get", c.makeNodes(controller),
 				"/mnt/data1/jepsen/cockroachdb/store/latest/"+file,
 				filepath.Join(outputDir, file))
-			cmd.Stdout = c.l.stdout
-			cmd.Stderr = c.l.stderr
+			cmd.Stdout = t.l.stdout
+			cmd.Stderr = t.l.stderr
 			if err := cmd.Run(); err != nil {
 				logf("failed to retrieve %s: %s", file, err)
 			}
@@ -252,8 +252,8 @@ cd /mnt/data1/jepsen/cockroachdb && set -eo pipefail && \
 			cmd := c.LoggedCommand(ctx, roachprod, "get", c.makeNodes(controller),
 				"/mnt/data1/jepsen/cockroachdb/invoke.log",
 				filepath.Join(outputDir, "invoke.log"))
-			cmd.Stdout = c.l.stdout
-			cmd.Stderr = c.l.stderr
+			cmd.Stdout = t.l.stdout
+			cmd.Stderr = t.l.stderr
 			if err := cmd.Run(); err != nil {
 				logf("failed to retrieve invoke.log: %s", err)
 			}

--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -188,7 +188,7 @@ cd /mnt/data1/jepsen/cockroachdb && set -eo pipefail && \
 "`, nodesStr, testName, nemesis))
 	}()
 
-	outputDir := filepath.Join(artifacts, t.Name())
+	outputDir := t.ArtifactsDir()
 	if err := os.MkdirAll(outputDir, 0777); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -156,7 +156,7 @@ func registerKVQuiescenceDead(r *registry) {
 					qpsAllUp, qpsOneDown, actFrac, minFrac,
 				)
 			}
-			c.l.Printf("QPS went from %.2f to %2.f with one node down\n", qpsAllUp, qpsOneDown)
+			t.l.Printf("QPS went from %.2f to %2.f with one node down\n", qpsAllUp, qpsOneDown)
 		},
 	})
 }
@@ -222,7 +222,7 @@ func registerKVScalability(r *registry) {
 					" {pgurl:1-%d}",
 					percent, nodes)
 
-				l, err := c.l.ChildLogger(fmt.Sprint(i))
+				l, err := t.l.ChildLogger(fmt.Sprint(i))
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/cmd/roachtest/log.go
+++ b/pkg/cmd/roachtest/log.go
@@ -70,8 +70,10 @@ type logger struct {
 
 // newLogger constructs a new logger object. Not intended for direct
 // use. Please use logger.ChildLogger instead.
+//
+// If path is empty, logs will go to stdout/stderr.
 func (cfg *loggerConfig) newLogger(path string) (*logger, error) {
-	if artifacts == "" {
+	if path == "" {
 		// Log to stdout/stderr if there is no artifacts directory.
 		return &logger{
 			stdout: os.Stdout,
@@ -113,6 +115,9 @@ const (
 	noTee       teeOptType = false
 )
 
+// rootLogger creates a logger.
+//
+// If path is empty, all logs go to stdout/stderr regardless of teeOpt.
 func rootLogger(path string, teeOpt teeOptType) (*logger, error) {
 	var stdout, stderr io.Writer
 	if teeOpt == teeToStdout {
@@ -154,7 +159,11 @@ func (l *logger) ChildLogger(name string, opts ...loggerOption) (*logger, error)
 		opt.apply(cfg)
 	}
 
-	return cfg.newLogger(filepath.Join(filepath.Dir(l.path), name+".log"))
+	var path string
+	if l.path != "" {
+		path = filepath.Join(filepath.Dir(l.path), name+".log")
+	}
+	return cfg.newLogger(path)
 }
 
 func (l *logger) Printf(f string, args ...interface{}) {

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -25,6 +25,9 @@ import (
 
 func main() {
 	parallelism := 10
+	// Path to a local dir where the test logs and artifacts collected from
+	// cluster will be placed.
+	var artifacts string
 
 	cobra.EnableCommandSorting = false
 
@@ -131,7 +134,7 @@ If no pattern is given, all tests are run.
 				r.loadBuildVersion()
 			}
 			registerTests(r)
-			os.Exit(r.Run(args, parallelism))
+			os.Exit(r.Run(args, parallelism, artifacts))
 			return nil
 		},
 	}
@@ -153,7 +156,7 @@ If no pattern is given, all tests are run.
 			}
 			r := newRegistry()
 			registerBenchmarks(r)
-			os.Exit(r.Run(args, parallelism))
+			os.Exit(r.Run(args, parallelism, artifacts))
 			return nil
 		},
 	}
@@ -193,7 +196,7 @@ Cockroach cluster with existing data.
 			registerStoreGen(r, args)
 			// We've only registered one store generation "test" that does its own
 			// argument processing, so no need to provide any arguments to r.Run.
-			os.Exit(r.Run(nil /* filter */, parallelism))
+			os.Exit(r.Run(nil /* filter */, parallelism, artifacts))
 			return nil
 		},
 	}

--- a/pkg/cmd/roachtest/rapid_restart.go
+++ b/pkg/cmd/roachtest/rapid_restart.go
@@ -75,7 +75,7 @@ func runRapidRestart(ctx context.Context, t *test, c *cluster) {
 				case <-time.After(10 * time.Second):
 					// We likely ended up killing before the process spawned.
 					// Loop around.
-					c.l.Printf("no exit status yet, killing again")
+					t.l.Printf("no exit status yet, killing again")
 				}
 			}
 			cause := errors.Cause(err)
@@ -109,6 +109,6 @@ func runRapidRestart(ctx context.Context, t *test, c *cluster) {
 			}
 		}
 
-		c.l.Printf("%d OK\n", j)
+		t.l.Printf("%d OK\n", j)
 	}
 }

--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -71,9 +71,9 @@ func registerRebalanceLoad(r *registry) {
 		ctx, cancel := context.WithCancel(ctx)
 
 		m.Go(func() error {
-			c.l.Printf("starting load generator\n")
+			t.l.Printf("starting load generator\n")
 
-			quietL, err := c.l.ChildLogger("kv-0", quietStdout)
+			quietL, err := t.l.ChildLogger("kv-0", quietStdout)
 			if err != nil {
 				return err
 			}
@@ -106,7 +106,7 @@ func registerRebalanceLoad(r *registry) {
 			}
 
 			for tBegin := timeutil.Now(); timeutil.Since(tBegin) <= maxDuration; {
-				if done, err := isLoadEvenlyDistributed(c.l, db, len(roachNodes)); err != nil {
+				if done, err := isLoadEvenlyDistributed(t.l, db, len(roachNodes)); err != nil {
 					return err
 				} else if done {
 					t.Status("successfully achieved lease balance; waiting for kv to finish running")

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -44,7 +44,7 @@ func registerRoachmart(r *registry) {
 				"--orders=100",
 				fmt.Sprintf("--partition=%v", partition))
 
-			l, err := c.l.ChildLogger(fmt.Sprint(nodes[i].i))
+			l, err := t.l.ChildLogger(fmt.Sprint(nodes[i].i))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cmd/roachtest/scaledata.go
+++ b/pkg/cmd/roachtest/scaledata.go
@@ -104,7 +104,7 @@ func runSqlapp(ctx context.Context, t *test, c *cluster, app, flags string, dur 
 		// they often have the effect of slowing down the test so much that it
 		// fails. To get around this we create a new logger that writes to an
 		// artifacts file but does not output to stdout or stderr.
-		sqlappL, err := c.l.ChildLogger("sqlapp", logPrefix(""), quietStdout, quietStderr)
+		sqlappL, err := t.l.ChildLogger("sqlapp", logPrefix(""), quietStdout, quietStderr)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -57,19 +57,19 @@ func registerSchemaChange(r *registry) {
 				// but we can't put it in monitor as-is because the test deadlocks.
 				go func() {
 					const cmd = `./workload run kv --tolerate-errors --min-block-bytes=8 --max-block-bytes=128 --db=test`
-					l, err := c.l.ChildLogger(fmt.Sprintf(`kv-%d`, node))
+					l, err := t.l.ChildLogger(fmt.Sprintf(`kv-%d`, node))
 					if err != nil {
 						t.Fatal(err)
 					}
 					defer l.close()
-					_ = execCmd(ctx, c.l, roachprod, "ssh", c.makeNodes(c.Node(node)), "--", cmd)
+					_ = execCmd(ctx, t.l, roachprod, "ssh", c.makeNodes(c.Node(node)), "--", cmd)
 				}()
 			}
 
 			m = newMonitor(ctx, c, c.All())
 			m.Go(func(ctx context.Context) error {
 				t.Status("running schema change tests")
-				return waitForSchemaChanges(ctx, c.l, db)
+				return waitForSchemaChanges(ctx, t.l, db)
 			})
 			m.Wait()
 		},

--- a/pkg/cmd/roachtest/status_server.go
+++ b/pkg/cmd/roachtest/status_server.go
@@ -64,7 +64,7 @@ func runStatusServer(ctx context.Context, t *test, c *cluster) {
 		if resp.StatusCode != http.StatusOK {
 			t.Fatalf("could not GET %s - statuscode: %d - body: %s", url, resp.StatusCode, body)
 		}
-		c.l.Printf("OK response from %s\n", url)
+		t.l.Printf("OK response from %s\n", url)
 		return body
 	}
 

--- a/pkg/cmd/roachtest/synctest.go
+++ b/pkg/cmd/roachtest/synctest.go
@@ -58,7 +58,7 @@ func registerSyncTest(r *registry) {
 			c.Run(ctx, n, "mkdir -p {store-dir}/{real,faulty} || true")
 			t.Status("setting up charybdefs")
 
-			if err := execCmd(ctx, c.l, roachprod, "install", c.makeNodes(n), "charybdefs"); err != nil {
+			if err := execCmd(ctx, t.l, roachprod, "install", c.makeNodes(n), "charybdefs"); err != nil {
 				t.Fatal(err)
 			}
 			c.Run(ctx, n, "sudo charybdefs {store-dir}/faulty -oallow_other,modules=subdir,subdir={store-dir}/real && chmod 777 {store-dir}/{real,faulty}")

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -299,7 +299,12 @@ func (r *registry) ListAll(filter []string) []string {
 	return names
 }
 
-func (r *registry) Run(filter []string, parallelism int) int {
+// Run runs the tests that match the filter.
+//
+// Args:
+// artifactsDir: The path to the dir where log files will be put. If empty, all
+//   logging will go to stdout/stderr.
+func (r *registry) Run(filter []string, parallelism int, artifactsDir string) int {
 	filterRE := makeFilterRE(filter)
 	// Find the top-level tests to run.
 	tests := r.ListTopLevel(filterRE)
@@ -350,9 +355,20 @@ func (r *registry) Run(filter []string, parallelism int) int {
 				if parallelism == 1 {
 					teeOpt = teeToStdout
 				}
+
+				artifactsSuffix := ""
+				if runNum != 0 {
+					artifactsSuffix = "run_" + strconv.Itoa(runNum)
+				}
+				var runDir string
+				if artifactsDir != "" {
+					runDir = filepath.Join(
+						artifactsDir, teamCityNameEscape(tests[i].subtestName), artifactsSuffix)
+				}
+
 				r.runAsync(
 					ctx, tests[i], filterRE, nil /* parent */, nil, /* cluster */
-					runNum, teeOpt, func(failed bool) {
+					runNum, teeOpt, runDir, func(failed bool) {
 						wg.Done()
 						<-sem
 					})
@@ -721,27 +737,18 @@ func (r *registry) runAsync(
 	c *cluster,
 	runNum int,
 	teeOpt teeOptType,
+	artifactsDir string,
 	done func(failed bool),
 ) {
-	artifactsSuffix := ""
-	// Only roots get a "run_<n>" suffix to their artifacts dir; the subtests will
-	// write in the parent's dir.
-	if parent == nil && runNum != 0 {
-		artifactsSuffix = "run_" + strconv.Itoa(runNum)
-	}
-	parentDir := artifacts
-	if parent != nil {
-		parentDir = parent.ArtifactsDir()
-	}
-	// Each subtest gets its own subdir in the parent's artifacts dir.
-	artifactsDir := filepath.Join(parentDir, teamCityNameEscape(spec.subtestName), artifactsSuffix)
-
 	t := &test{
 		spec:         spec,
 		registry:     r,
 		artifactsDir: artifactsDir,
 	}
-	logPath := filepath.Join(artifactsDir, "test.log")
+	var logPath string
+	if artifactsDir != "" {
+		logPath = filepath.Join(artifactsDir, "test.log")
+	}
 	l, err := rootLogger(logPath, teeOpt)
 	FatalIfErr(t, err)
 	t.l = l
@@ -845,10 +852,12 @@ func (r *registry) runAsync(
 			if teamCity {
 				fmt.Fprintf(r.out, "##teamcity[testFinished name='%s' flowId='%s']\n", t.Name(), t.Name())
 
-				escapedTestName := teamCityNameEscape(t.Name())
-				artifactsGlobPath := filepath.Join(artifacts, escapedTestName, "**")
-				artifactsSpec := fmt.Sprintf("%s => %s", artifactsGlobPath, escapedTestName)
-				fmt.Fprintf(r.out, "##teamcity[publishArtifacts '%s']\n", artifactsSpec)
+				if artifactsDir != "" {
+					escapedTestName := teamCityNameEscape(t.Name())
+					artifactsGlobPath := filepath.Join(artifactsDir, escapedTestName, "**")
+					artifactsSpec := fmt.Sprintf("%s => %s", artifactsGlobPath, escapedTestName)
+					fmt.Fprintf(r.out, "##teamcity[publishArtifacts '%s']\n", artifactsSpec)
+				}
 			}
 
 			r.status.Lock()
@@ -921,11 +930,19 @@ func (r *registry) runAsync(
 		// If we have subtests, handle them here and return.
 		if t.spec.Run == nil {
 			for i := range t.spec.SubTests {
-				if t.spec.SubTests[i].matchRegex(filter) {
+				childSpec := t.spec.SubTests[i]
+				if childSpec.matchRegex(filter) {
 					var wg sync.WaitGroup
 					wg.Add(1)
-					r.runAsync(ctx, &t.spec.SubTests[i], filter, t, c,
-						runNum, teeOpt, func(failed bool) {
+
+					// Each subtest gets its own subdir in the parent's artifacts dir.
+					var childDir string
+					if t.ArtifactsDir() != "" {
+						childDir = filepath.Join(t.ArtifactsDir(), teamCityNameEscape(childSpec.subtestName))
+					}
+
+					r.runAsync(ctx, &childSpec, filter, t, c,
+						runNum, teeOpt, childDir, func(failed bool) {
 							if failed {
 								// Mark the parent test as failed since one of the subtests
 								// failed.

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -71,7 +71,7 @@ func TestRegistryRun(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			code := r.Run(c.filters, defaultParallelism)
+			code := r.Run(c.filters, defaultParallelism, "" /* artifactsDir */)
 			if c.expected != code {
 				t.Fatalf("expected code %d, but found code %d. Filters: %s", c.expected, code, c.filters)
 			}
@@ -136,7 +136,7 @@ func TestRegistryStatus(t *testing.T) {
 			}
 		},
 	})
-	r.Run([]string{"status"}, defaultParallelism)
+	r.Run([]string{"status"}, defaultParallelism, "" /* artifactsDir */)
 
 	status := buf.String()
 	if !waitingRE.MatchString(status) {
@@ -170,7 +170,7 @@ func TestRegistryStatusUnknown(t *testing.T) {
 			}
 		},
 	})
-	r.Run([]string{"status"}, defaultParallelism)
+	r.Run([]string{"status"}, defaultParallelism, "" /* artifactsDir */)
 
 	status := buf.String()
 	if !unknownRE.MatchString(status) {
@@ -196,7 +196,7 @@ func TestRegistryRunTimeout(t *testing.T) {
 			<-ctx.Done()
 		},
 	})
-	r.Run([]string{"timeout"}, defaultParallelism)
+	r.Run([]string{"timeout"}, defaultParallelism, "" /* artifactsDir */)
 
 	out := buf.String()
 	if !timeoutRE.MatchString(out) {
@@ -222,7 +222,7 @@ func TestRegistryRunSubTestFailed(t *testing.T) {
 		}},
 	})
 
-	r.Run([]string{"."}, defaultParallelism)
+	r.Run([]string{"."}, defaultParallelism, "" /* artifactsDir */)
 	out := buf.String()
 	if !failedRE.MatchString(out) {
 		t.Fatalf("unable to find \"FAIL: parent\" message:\n%s", out)
@@ -251,7 +251,7 @@ func TestRegistryRunClusterExpired(t *testing.T) {
 			panic("not reached")
 		},
 	})
-	r.Run([]string{"expired"}, defaultParallelism)
+	r.Run([]string{"expired"}, defaultParallelism, "" /* artifactsDir */)
 
 	out := buf.String()
 	if !expiredRE.MatchString(out) {
@@ -452,7 +452,7 @@ func TestRegistryMinVersion(t *testing.T) {
 			if err := r.setBuildVersion(c.buildVersion); err != nil {
 				t.Fatal(err)
 			}
-			r.Run(nil /* filter */, defaultParallelism)
+			r.Run(nil /* filter */, defaultParallelism, "" /* artifactsDir */)
 			if c.expectedA != runA || c.expectedB != runB {
 				t.Fatalf("expected %t,%t, but got %t,%t\n%s",
 					c.expectedA, c.expectedB, runA, runB, buf.String())

--- a/pkg/cmd/roachtest/upgrade.go
+++ b/pkg/cmd/roachtest/upgrade.go
@@ -329,7 +329,7 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
 	binaryVersionUpgrade := func(newVersion string, nodes nodeListOption) versionStep {
 		return versionStep{
 			run: func() {
-				c.l.Printf("%s: binary\n", newVersion)
+				t.l.Printf("%s: binary\n", newVersion)
 				args := uploadVersion(newVersion)
 
 				// Restart nodes in a random order; otherwise node 1 would be running all
@@ -338,7 +338,7 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
 					nodes[i], nodes[j] = nodes[j], nodes[i]
 				})
 				for _, node := range nodes {
-					c.l.Printf("%s: upgrading node %d\n", newVersion, node)
+					t.l.Printf("%s: upgrading node %d\n", newVersion, node)
 					c.Stop(ctx, c.Node(node))
 					c.Start(ctx, t, c.Node(node), args)
 
@@ -360,7 +360,7 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
 		return versionStep{
 			clusterVersion: newVersion,
 			run: func() {
-				c.l.Printf("%s: cluster\n", newVersion)
+				t.l.Printf("%s: cluster\n", newVersion)
 
 				// hasShowSettingBug is true when we're working around
 				// https://github.com/cockroachdb/cockroach/issues/22796.
@@ -384,7 +384,7 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
 						db := c.Conn(ctx, node)
 						defer db.Close()
 
-						c.l.Printf("%s: upgrading cluster version (node %d)\n", newVersion, node)
+						t.l.Printf("%s: upgrading cluster version (node %d)\n", newVersion, node)
 						if _, err := db.Exec(fmt.Sprintf(`SET CLUSTER SETTING version = '%s'`, newVersion)); err != nil {
 							t.Fatal(err)
 						}
@@ -392,7 +392,7 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
 				}
 
 				if hasShowSettingBug {
-					c.l.Printf("%s: using workaround for upgrade\n", newVersion)
+					t.l.Printf("%s: using workaround for upgrade\n", newVersion)
 				}
 
 				for i := 1; i < c.nodes; i++ {
@@ -423,7 +423,7 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
 					}
 				}
 
-				c.l.Printf("%s: cluster is upgraded\n", newVersion)
+				t.l.Printf("%s: cluster is upgraded\n", newVersion)
 
 				// TODO(nvanbenschoten): add upgrade qualification step.
 				time.Sleep(1 * time.Second)
@@ -501,12 +501,12 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
 			if err == nil {
 				t.Fatalf("expected %s to fail on cluster version %s", f.name, cv)
 			}
-			c.l.Printf("%s: %s fails expected\n", cv, f.name)
+			t.l.Printf("%s: %s fails expected\n", cv, f.name)
 		} else {
 			if err != nil {
 				t.Fatalf("expected %s to succeed on cluster version %s, got %s", f.name, cv, err)
 			}
-			c.l.Printf("%s: %s works as expected\n", cv, f.name)
+			t.l.Printf("%s: %s works as expected\n", cv, f.name)
 		}
 	}
 

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -52,7 +52,7 @@ func registerVersion(r *registry) {
 		stageDuration := 10 * time.Minute
 		buffer := 10 * time.Minute
 		if local {
-			c.l.Printf("local mode: speeding up test\n")
+			t.l.Printf("local mode: speeding up test\n")
 			stageDuration = 10 * time.Second
 			buffer = time.Minute
 		}
@@ -72,7 +72,7 @@ func registerVersion(r *registry) {
 				cmd = fmt.Sprintf(cmd, nodes)
 				// Direct stderr only to disk. We expect errors from the workload as
 				// nodes are stopped and started.
-				childL, err := c.l.ChildLogger("workload"+strconv.Itoa(i), quietStderr)
+				childL, err := t.l.ChildLogger("workload"+strconv.Itoa(i), quietStderr)
 				if err != nil {
 					return err
 				}
@@ -81,7 +81,7 @@ func registerVersion(r *registry) {
 		}
 
 		m.Go(func(ctx context.Context) error {
-			l, err := c.l.ChildLogger("upgrader")
+			l, err := t.l.ChildLogger("upgrader")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Before this patch, c.l was essentially a test's logger. But that logger
belongs better on a test than on a cluster, and so I've moved it.
c.l still exists, and it's being set at a high level to t.l. The idea is
that c.l will still be used, at least for the time being, by other
cluster methods, but otherwise tests will switch to using t.l instead of
c.l (this is being done in the next commit).

Release note: None