### PR TITLE
sql: assert no dependencies on storage or CGo

### DIFF
--- a/pkg/sql/dep_test.go
+++ b/pkg/sql/dep_test.go
@@ -23,9 +23,8 @@ import (
 
 func TestNoLinkForbidden(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#30001")
 
 	buildutil.VerifyNoImports(t,
-		"github.com/cockroachdb/cockroach/pkg/sql", true, []string{"c-deps"}, nil,
+		"github.com/cockroachdb/cockroach/pkg/sql", true, []string{"github.com/cockroachdb/cockroach/pkg/storage", "c-deps"}, nil,
 	)
 }


### PR DESCRIPTION
No longer necessary for sql to depend on either storage or CGo - let's keep it that way!

All commits but last one from dependent PRs.

Closes #30001.