### PR TITLE
sql: use ClearRange for index truncation

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -255,16 +255,20 @@ func (sc *SchemaChanger) truncateIndexes(
 				if err := td.init(txn, nil /* *tree.EvalContext */); err != nil {
 					return err
 				}
-				resume, err = td.deleteIndex(
-					ctx,
-					&desc,
-					resumeAt,
-					chunkSize,
-					noAutoCommit,
-					false, /* traceKV */
-				)
-				done = resume.Key == nil
-				return err
+				if !sc.canClearRangeForDrop(&desc) {
+					resume, err = td.deleteIndex(
+						ctx,
+						&desc,
+						resumeAt,
+						chunkSize,
+						noAutoCommit,
+						false, /* traceKV */
+					)
+					done = resume.Key == nil
+					return err
+				}
+				done = true
+				return td.clearIndex(ctx, &desc)
 			}); err != nil {
 				return err
 			}

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -26,29 +26,25 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/jobs"
-	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/pkg/errors"
 )
 
 type leaseTest struct {
@@ -855,7 +851,7 @@ CREATE TABLE t.foo (v INT);
 }
 
 // Test that a transaction created way in the past will use the correct
-// table descriptor and will thus obey the modififcation time of the
+// table descriptor and will thus obey the modification time of the
 // table descriptor.
 func TestTxnObeysTableModificationTime(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -876,9 +872,6 @@ INSERT INTO t.kv VALUES ('a', 'b');
 		t.Fatal(err)
 	}
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "kv")
-	if _, err := addImmediateGCZoneConfig(sqlDB, tableDesc.ID); err != nil {
-		t.Fatal(err)
-	}
 
 	// A read-write transaction that uses the old version of the descriptor.
 	txReadWrite, err := sqlDB.Begin()
@@ -972,55 +965,93 @@ INSERT INTO t.kv VALUES ('a', 'b');
 	}
 
 	// Test the deadline exceeded error with a CREATE/DROP INDEX.
-	schemaChanges := []struct{ sql string }{
-		{`CREATE INDEX foo ON t.public.kv (v)`},
-		{`DROP INDEX t.public.kv@foo`},
+	txWrite, err = sqlDB.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	txUpdate, err := sqlDB.Begin()
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	for i, change := range schemaChanges {
-
-		txWrite, err := sqlDB.Begin()
-		if err != nil {
-			t.Fatal(err)
-		}
-		txUpdate, err := sqlDB.Begin()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Modify the table descriptor.
-		if _, err := sqlDB.Exec(change.sql); err != nil {
-			t.Fatal(err)
-		}
-		testutils.SucceedsSoon(t, func() error {
-			return jobutils.VerifySystemJob(t, sqlutils.MakeSQLRunner(sqlDB), i+1, jobspb.TypeSchemaChange, jobs.StatusSucceeded, jobs.Record{
-				Username:    security.RootUser,
-				Description: change.sql,
-				DescriptorIDs: sqlbase.IDs{
-					tableDesc.ID,
-				},
-			})
-		})
-
-		// This INSERT will cause the transaction to be pushed transparently,
-		// which will be detected when we attempt to Commit() below only because
-		// a deadline has been set.
-		if _, err := txWrite.Exec(`INSERT INTO t.kv VALUES ('c', 'd');`); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := txWrite.Commit(); !testutils.IsError(err, deadlineError) {
-			t.Fatalf("err = %v", err)
-		}
-
-		if _, err := txUpdate.Exec(`UPDATE t.kv SET v = 'c' WHERE k = 'a';`); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := txUpdate.Commit(); !testutils.IsError(err, deadlineError) {
-			t.Fatalf("err = %v", err)
-		}
+	// Modify the table descriptor.
+	if _, err := sqlDB.Exec(`CREATE INDEX foo ON t.kv (v)`); err != nil {
+		t.Fatal(err)
 	}
+
+	// This INSERT will cause the transaction to be pushed transparently,
+	// which will be detected when we attempt to Commit() below only because
+	// a deadline has been set.
+	if _, err := txWrite.Exec(`INSERT INTO t.kv VALUES ('c', 'd');`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := txWrite.Commit(); !testutils.IsError(err, deadlineError) {
+		t.Fatalf("err = %v", err)
+	}
+
+	if _, err := txUpdate.Exec(`UPDATE t.kv SET v = 'c' WHERE k = 'a';`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := txUpdate.Commit(); !testutils.IsError(err, deadlineError) {
+		t.Fatalf("err = %v", err)
+	}
+
+	txWrite, err = sqlDB.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	txRead, err = sqlDB.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Modify the table descriptor.
+	if _, err := sqlDB.Exec(`DROP INDEX t.kv@foo`); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err = txRead.Query(`SELECT k, v FROM t.kv@foo`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkSelectResults(rows)
+
+	// Uses old descriptor and inserts values into index span which
+	// will be cleaned up.
+	if _, err := txWrite.Exec(`INSERT INTO t.kv VALUES ('c', 'd');`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := txRead.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := txWrite.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	tableSpan := tableDesc.TableSpan()
+	tests.CheckKeyCount(t, kvDB, tableSpan, 4)
+
+	// Allow async schema change waiting for GC to complete (when dropping an
+	// index) and clear the index keys.
+	if _, err := addImmediateGCZoneConfig(sqlDB, tableDesc.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	testutils.SucceedsSoon(t, func() error {
+		if tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "kv"); len(tableDesc.GCMutations) != 0 {
+			return errors.Errorf("%d gc mutations remaining", len(tableDesc.GCMutations))
+		}
+		return nil
+	})
+
+	tests.CheckKeyCount(t, kvDB, tableSpan, 2)
+
+	// TODO(erik, vivek): Transactions using old descriptors should fail and
+	// rollback when the index keys have been removed by ClearRange
+	// and the consistency issue is resolved. See #31563.
 }
 
 // Test that a lease on a table descriptor is always acquired on the latest

--- a/pkg/storage/batcheval/cmd_clear_range.go
+++ b/pkg/storage/batcheval/cmd_clear_range.go
@@ -54,7 +54,8 @@ func declareKeysClearRange(
 //
 // Note that "correct" use of this command is only possible for key
 // spans consisting of user data that we know is not being written to
-// or queried any more, such as after a DROP or TRUNCATE table.
+// or queried any more, such as after a DROP or TRUNCATE table, or
+// DROP index.
 func ClearRange(
 	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {


### PR DESCRIPTION
This change makes the deletion of index data use the ClearRange batch
request. DROP INDEX schema changes in the same transaction as the one
which created the table still uses the slower DelRange because
ClearRange cannot be run inside a transaction and will remove write
intents of the index keys which have not been resolved in the
transaction.

This deletion of index data happens once the GC TTL period has passed
and it is safe to remove all the data. See PR #30566 for which delays
this data deletion.

Note: See #31563 for a limitation with queries with old timestamps which returns inconsistent data which has been deleted with ClearRange.

Fixes #20696.

Release note (performance improvement): Deletion of index data is faster.