### PR TITLE
pgerror: hint what to do upon encountering unimplemented errors

### DIFF
--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -49,11 +49,18 @@ func (p *Parser) parseWithDepth(depth int, sql string) (stmts tree.StatementList
 	if p.parserImpl.Parse(&p.scanner) != 0 {
 		var err *pgerror.Error
 		if feat := p.scanner.lastError.unimplementedFeature; feat != "" {
+			// UnimplementedWithDepth populates the generic hint. However
+			// in some cases we have a more specific hint. This is overridden
+			// below.
 			err = pgerror.UnimplementedWithDepth(depth+1, "syntax."+feat, p.scanner.lastError.msg)
 		} else {
 			err = pgerror.NewErrorWithDepth(depth+1, pgerror.CodeSyntaxError, p.scanner.lastError.msg)
 		}
-		err.Hint = p.scanner.lastError.hint
+		if p.scanner.lastError.hint != "" {
+			// If lastError.hint is not set, e.g. from (*Scanner).Unimplemented(),
+			// we're OK with the default hint. Otherwise, override it.
+			err.Hint = p.scanner.lastError.hint
+		}
 		err.Detail = p.scanner.lastError.detail
 		return nil, err
 	}

--- a/pkg/sql/parser/scan.go
+++ b/pkg/sql/parser/scan.go
@@ -202,6 +202,7 @@ func (s *Scanner) Error(e string) {
 	fmt.Fprintf(&buf, "%s^", strings.Repeat(" ", s.lastTok.pos-j))
 	s.lastError.detail = buf.String()
 	s.lastError.unimplementedFeature = ""
+	s.lastError.hint = ""
 }
 
 // SetHelp marks the "last error" field in the Scanner to become a

--- a/pkg/sql/pgwire/pgerror/errors.go
+++ b/pkg/sql/pgwire/pgerror/errors.go
@@ -194,6 +194,21 @@ func UnimplementedWithIssueError(issue int, msg string) error {
 	return err.SetHintf("See: https://github.com/cockroachdb/cockroach/issues/%d", issue)
 }
 
+const unimplementedErrorHint = `This feature is not yet implemented in CockroachDB.
+
+Please check https://github.com/cockroachdb/cockroach/issues to check
+whether this feature is already tracked. If you cannot find it there,
+please report this error with reproduction steps at:
+
+    https://github.com/cockroachdb/cockroach/issues/new/choose
+
+If you would rather not post publicly, please contact us directly at:
+
+    support@cockroachlabs.com
+
+The Cockroach Labs team appreciates your feedback.
+`
+
 // Unimplemented constructs an unimplemented feature error.
 //
 // `feature` is used for tracking, and is not included when the error printed.
@@ -206,5 +221,6 @@ func Unimplemented(feature, msg string, args ...interface{}) *Error {
 func UnimplementedWithDepth(depth int, feature, msg string, args ...interface{}) *Error {
 	err := NewErrorWithDepthf(depth+1, CodeFeatureNotSupportedError, msg, args...)
 	err.InternalCommand = feature
+	err.Hint = unimplementedErrorHint
 	return err
 }


### PR DESCRIPTION
Requested by @awoods187 . Inspired by @tschottdorf 

Before:

```
root@127.0.0.1:28070/defaultdb> select * from information_schema.view_table_usage;
pq: virtual schema table not implemented: information_schema.view_table_usage
```

After:

```
root@127.0.0.1:28070/defaultdb> select * from information_schema.view_table_usage;
pq: virtual schema table not implemented: information_schema.view_table_usage
HINT: This feature is not yet implemented in CockroachDB.

Please check https://github.com/cockroachdb/cockroach/issues to check
whether this feature is already tracked. If you cannot find it there,
please report this error with example query at:

    https://github.com/cockroachdb/cockroach/issues/new/choose

If you would rather not post publicly, please contact us directly at:

    support@cockroachlabs.com

The Cockroach Labs team appreciates your feedback.
```

Release note: None