### PR TITLE
sql: expose feature counters via crdb_internal.feature_usage

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -18,6 +18,7 @@ cluster_queries
 cluster_sessions
 cluster_settings
 create_statements
+feature_usage
 forward_dependencies
 gossip_alerts
 gossip_liveness
@@ -134,6 +135,11 @@ query TTTT colnames
 SELECT * FROM crdb_internal.cluster_settings WHERE variable = ''
 ----
 variable  value  type  description
+
+query TI colnames
+SELECT * FROM crdb_internal.feature_usage WHERE feature_name = ''
+----
+feature_name  usage_count
 
 query TT colnames
 SELECT * FROM crdb_internal.session_variables WHERE variable = ''

--- a/pkg/sql/logictest/testdata/logic_test/feature_counts
+++ b/pkg/sql/logictest/testdata/logic_test/feature_counts
@@ -1,0 +1,11 @@
+# LogicTest: local
+
+statement error unimplemented
+SELECT * FROM system.users FOR UPDATE
+
+query TI colnames
+SELECT * FROM crdb_internal.feature_usage
+ WHERE feature_name LIKE '%#6583%'
+----
+feature_name                usage_count
+unimplemented.syntax.#6583  1

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -39,6 +39,7 @@ test           crdb_internal       cluster_queries                    public   S
 test           crdb_internal       cluster_sessions                   public   SELECT
 test           crdb_internal       cluster_settings                   public   SELECT
 test           crdb_internal       create_statements                  public   SELECT
+test           crdb_internal       feature_usage                      public   SELECT
 test           crdb_internal       forward_dependencies               public   SELECT
 test           crdb_internal       gossip_alerts                      public   SELECT
 test           crdb_internal       gossip_liveness                    public   SELECT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -217,6 +217,7 @@ crdb_internal       cluster_queries
 crdb_internal       cluster_sessions
 crdb_internal       cluster_settings
 crdb_internal       create_statements
+crdb_internal       feature_usage
 crdb_internal       forward_dependencies
 crdb_internal       gossip_alerts
 crdb_internal       gossip_liveness
@@ -342,6 +343,7 @@ cluster_queries
 cluster_sessions
 cluster_settings
 create_statements
+feature_usage
 forward_dependencies
 gossip_alerts
 gossip_liveness
@@ -474,6 +476,7 @@ system         crdb_internal       cluster_queries                    SYSTEM VIE
 system         crdb_internal       cluster_sessions                   SYSTEM VIEW  NO                  1
 system         crdb_internal       cluster_settings                   SYSTEM VIEW  NO                  1
 system         crdb_internal       create_statements                  SYSTEM VIEW  NO                  1
+system         crdb_internal       feature_usage                      SYSTEM VIEW  NO                  1
 system         crdb_internal       forward_dependencies               SYSTEM VIEW  NO                  1
 system         crdb_internal       gossip_alerts                      SYSTEM VIEW  NO                  1
 system         crdb_internal       gossip_liveness                    SYSTEM VIEW  NO                  1
@@ -1042,6 +1045,7 @@ NULL     public   system         crdb_internal       cluster_queries            
 NULL     public   system         crdb_internal       cluster_sessions                   SELECT          NULL          NULL
 NULL     public   system         crdb_internal       cluster_settings                   SELECT          NULL          NULL
 NULL     public   system         crdb_internal       create_statements                  SELECT          NULL          NULL
+NULL     public   system         crdb_internal       feature_usage                      SELECT          NULL          NULL
 NULL     public   system         crdb_internal       forward_dependencies               SELECT          NULL          NULL
 NULL     public   system         crdb_internal       gossip_alerts                      SELECT          NULL          NULL
 NULL     public   system         crdb_internal       gossip_liveness                    SELECT          NULL          NULL
@@ -1265,6 +1269,7 @@ NULL     public   system         crdb_internal       cluster_queries            
 NULL     public   system         crdb_internal       cluster_sessions                   SELECT          NULL          NULL
 NULL     public   system         crdb_internal       cluster_settings                   SELECT          NULL          NULL
 NULL     public   system         crdb_internal       create_statements                  SELECT          NULL          NULL
+NULL     public   system         crdb_internal       feature_usage                      SELECT          NULL          NULL
 NULL     public   system         crdb_internal       forward_dependencies               SELECT          NULL          NULL
 NULL     public   system         crdb_internal       gossip_alerts                      SELECT          NULL          NULL
 NULL     public   system         crdb_internal       gossip_liveness                    SELECT          NULL          NULL

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -162,7 +162,7 @@ sort                   ·       ·
       └── filter       ·       ·
            │           filter  table_schema = 'public'
            └── values  ·       ·
-·                      size    6 columns, 91 rows
+·                      size    6 columns, 92 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -233,7 +233,7 @@ sort                                       ·            ·
                      │    └── filter       ·            ·
                      │         │           filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
                      │         └── values  ·            ·
-                     │                     size         20 columns, 927 rows
+                     │                     size         20 columns, 929 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                │           filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
@@ -249,7 +249,7 @@ sort                   ·       ·
       └── filter       ·       ·
            │           filter  (table_catalog, table_schema, table_name) IN (('test', 'public', 'foo'),)
            └── values  ·       ·
-·                      size    8 columns, 580 rows
+·                      size    8 columns, 585 rows
 
 
 query TTT
@@ -273,7 +273,7 @@ sort                             ·         ·
            ├── filter            ·         ·
            │    │                filter    relname = 'foo'
            │    └── values       ·         ·
-           │                     size      27 columns, 93 rows
+           │                     size      27 columns, 94 rows
            └── join              ·         ·
                 │                type      cross
                 ├── filter       ·         ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -153,7 +153,7 @@ sort                   ·       ·
       └── filter       ·       ·
            │           filter  table_schema = 'public'
            └── values  ·       ·
-·                      size    6 columns, 91 rows
+·                      size    6 columns, 92 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -224,7 +224,7 @@ sort                                       ·            ·
                      │    └── filter       ·            ·
                      │         │           filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
                      │         └── values  ·            ·
-                     │                     size         20 columns, 927 rows
+                     │                     size         20 columns, 929 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                │           filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
@@ -240,7 +240,7 @@ sort                   ·       ·
       └── filter       ·       ·
            │           filter  (table_catalog, table_schema, table_name) IN (('test', 'public', 'foo'),)
            └── values  ·       ·
-·                      size    8 columns, 580 rows
+·                      size    8 columns, 585 rows
 
 
 query TTT
@@ -264,7 +264,7 @@ sort                             ·         ·
            ├── filter            ·         ·
            │    │                filter    relname = 'foo'
            │    └── values       ·         ·
-           │                     size      27 columns, 93 rows
+           │                     size      27 columns, 94 rows
            └── join              ·         ·
                 │                type      cross
                 ├── filter       ·         ·


### PR DESCRIPTION
First 3 commits from  #31332.
Only last commit in this PR; will rebase when the other is merged.

I found myself using this extensively to work on that other PR and related PRs adding markers for unimplemented features and new feature counts.