### PR TITLE
sql/parser: annotate unimplemented features with suitable errors

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -300,8 +300,8 @@ create_user_stmt ::=
 	| 'CREATE' 'USER' 'IF' 'NOT' 'EXISTS' string_or_placeholder opt_password
 
 create_role_stmt ::=
-	'CREATE' 'ROLE' string_or_placeholder
-	| 'CREATE' 'ROLE' 'IF' 'NOT' 'EXISTS' string_or_placeholder
+	'CREATE' role_or_group string_or_placeholder
+	| 'CREATE' role_or_group 'IF' 'NOT' 'EXISTS' string_or_placeholder
 
 create_ddl_stmt ::=
 	create_changefeed_stmt
@@ -519,6 +519,7 @@ unreserved_keyword ::=
 	| 'ACTION'
 	| 'ADD'
 	| 'ADMIN'
+	| 'AGGREGATE'
 	| 'ALTER'
 	| 'AT'
 	| 'BACKUP'
@@ -526,7 +527,6 @@ unreserved_keyword ::=
 	| 'BIGSERIAL'
 	| 'BLOB'
 	| 'BOOL'
-	| 'BTREE'
 	| 'BY'
 	| 'BYTEA'
 	| 'BYTES'
@@ -545,6 +545,7 @@ unreserved_keyword ::=
 	| 'CONFIGURATIONS'
 	| 'CONFIGURE'
 	| 'CONSTRAINTS'
+	| 'CONVERSION'
 	| 'COPY'
 	| 'COVERING'
 	| 'CUBE'
@@ -573,6 +574,7 @@ unreserved_keyword ::=
 	| 'EXPERIMENTAL_REPLICA'
 	| 'EXPLAIN'
 	| 'EXPORT'
+	| 'EXTENSION'
 	| 'FILES'
 	| 'FILTER'
 	| 'FIRST'
@@ -580,7 +582,8 @@ unreserved_keyword ::=
 	| 'FLOAT8'
 	| 'FOLLOWING'
 	| 'FORCE_INDEX'
-	| 'GIN'
+	| 'FUNCTION'
+	| 'GLOBAL'
 	| 'GRANTS'
 	| 'GROUPS'
 	| 'HIGH'
@@ -608,6 +611,7 @@ unreserved_keyword ::=
 	| 'KEY'
 	| 'KEYS'
 	| 'KV'
+	| 'LANGUAGE'
 	| 'LC_COLLATE'
 	| 'LC_CTYPE'
 	| 'LEASE'
@@ -617,6 +621,7 @@ unreserved_keyword ::=
 	| 'LOCAL'
 	| 'LOW'
 	| 'MATCH'
+	| 'MATERIALIZED'
 	| 'MINUTE'
 	| 'MONTH'
 	| 'NAMES'
@@ -630,6 +635,7 @@ unreserved_keyword ::=
 	| 'OFF'
 	| 'OID'
 	| 'OIDVECTOR'
+	| 'OPERATOR'
 	| 'OPTION'
 	| 'OPTIONS'
 	| 'ORDINALITY'
@@ -645,6 +651,7 @@ unreserved_keyword ::=
 	| 'PRECEDING'
 	| 'PREPARE'
 	| 'PRIORITY'
+	| 'PUBLICATION'
 	| 'QUERIES'
 	| 'QUERY'
 	| 'RANGE'
@@ -660,6 +667,7 @@ unreserved_keyword ::=
 	| 'RELEASE'
 	| 'RENAME'
 	| 'REPEATABLE'
+	| 'REPLACE'
 	| 'RESET'
 	| 'RESTORE'
 	| 'RESTRICT'
@@ -670,6 +678,7 @@ unreserved_keyword ::=
 	| 'ROLLBACK'
 	| 'ROLLUP'
 	| 'ROWS'
+	| 'RULE'
 	| 'SETTING'
 	| 'SETTINGS'
 	| 'STATUS'
@@ -685,6 +694,7 @@ unreserved_keyword ::=
 	| 'SERIAL2'
 	| 'SERIAL4'
 	| 'SERIAL8'
+	| 'SERVER'
 	| 'SEQUENCE'
 	| 'SEQUENCES'
 	| 'SESSION'
@@ -704,6 +714,7 @@ unreserved_keyword ::=
 	| 'STRICT'
 	| 'STRING'
 	| 'SPLIT'
+	| 'SUBSCRIPTION'
 	| 'SYNTAX'
 	| 'SYSTEM'
 	| 'TABLES'
@@ -716,11 +727,14 @@ unreserved_keyword ::=
 	| 'TIMESTAMPTZ'
 	| 'TRACE'
 	| 'TRANSACTION'
+	| 'TRIGGER'
 	| 'TRUNCATE'
+	| 'TRUSTED'
 	| 'TYPE'
 	| 'UNBOUNDED'
 	| 'UNCOMMITTED'
 	| 'UNKNOWN'
+	| 'UNLOGGED'
 	| 'UPDATE'
 	| 'UPSERT'
 	| 'UUID'
@@ -870,6 +884,9 @@ alter_user_password_stmt ::=
 opt_password ::=
 	opt_with 'PASSWORD' string_or_placeholder
 	| 
+
+role_or_group ::=
+	'ROLE'
 
 create_changefeed_stmt ::=
 	'CREATE' 'CHANGEFEED' 'FOR' changefeed_targets opt_changefeed_sink opt_with_options
@@ -1204,8 +1221,7 @@ opt_index_name ::=
 	opt_name
 
 opt_using_gin_btree ::=
-	'USING' 'GIN'
-	| 'USING' 'BTREE'
+	'USING' name
 	| 
 
 index_params ::=
@@ -1333,7 +1349,7 @@ simple_typename ::=
 	const_typename
 	| bit_with_length
 	| character_with_length
-	| const_interval opt_interval
+	| const_interval
 
 opt_array_bounds ::=
 	'[' ']'
@@ -1555,7 +1571,7 @@ opt_name ::=
 	| 
 
 index_elem ::=
-	column_name opt_asc_desc
+	a_expr opt_asc_desc
 
 storing ::=
 	'COVERING'
@@ -1676,22 +1692,6 @@ character_with_length ::=
 
 const_interval ::=
 	'INTERVAL'
-
-opt_interval ::=
-	'YEAR'
-	| 'MONTH'
-	| 'DAY'
-	| 'HOUR'
-	| 'MINUTE'
-	| interval_second
-	| 'YEAR' 'TO' 'MONTH'
-	| 'DAY' 'TO' 'HOUR'
-	| 'DAY' 'TO' 'MINUTE'
-	| 'DAY' 'TO' interval_second
-	| 'HOUR' 'TO' 'MINUTE'
-	| 'HOUR' 'TO' interval_second
-	| 'MINUTE' 'TO' interval_second
-	| 
 
 tuple1_ambiguous_values ::=
 	a_expr
@@ -1867,6 +1867,10 @@ const_json ::=
 	'JSON'
 	| 'JSONB'
 
+opt_interval ::=
+	interval_qualifier
+	| 
+
 column_path ::=
 	name
 	| prefixed_column_path
@@ -1935,9 +1939,6 @@ character_base ::=
 	| char_aliases 'VARYING'
 	| 'VARCHAR'
 	| 'STRING'
-
-interval_second ::=
-	'SECOND'
 
 from_list ::=
 	( table_ref ) ( ( ',' table_ref ) )*
@@ -2030,6 +2031,21 @@ opt_numeric_modifiers ::=
 	| '(' iconst64 ',' iconst64 ')'
 	| 
 
+interval_qualifier ::=
+	'YEAR'
+	| 'MONTH'
+	| 'DAY'
+	| 'HOUR'
+	| 'MINUTE'
+	| interval_second
+	| 'YEAR' 'TO' 'MONTH'
+	| 'DAY' 'TO' 'HOUR'
+	| 'DAY' 'TO' 'MINUTE'
+	| 'DAY' 'TO' interval_second
+	| 'HOUR' 'TO' 'MINUTE'
+	| 'HOUR' 'TO' interval_second
+	| 'MINUTE' 'TO' interval_second
+
 prefixed_column_path ::=
 	name '.' unrestricted_name
 	| name '.' unrestricted_name '.' unrestricted_name
@@ -2100,6 +2116,9 @@ reference_action ::=
 	| 'CASCADE'
 	| 'SET' 'NULL'
 	| 'SET' 'DEFAULT'
+
+interval_second ::=
+	'SECOND'
 
 type_function_name ::=
 	'identifier'

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -480,7 +480,7 @@ var specs = []stmtSpec{
 	{
 		name:    "create_index_stmt",
 		inline:  []string{"opt_unique", "opt_storing", "storing", "opt_name", "index_params", "index_elem", "opt_asc_desc"},
-		replace: map[string]string{"opt_using_gin_btree": ""},
+		replace: map[string]string{"opt_using_gin_btree": "", "a_expr": "column_name"},
 		exclude: []*regexp.Regexp{regexp.MustCompile("'CREATE' 'INVERTED'")},
 	},
 	{
@@ -489,6 +489,7 @@ var specs = []stmtSpec{
 		match:  []*regexp.Regexp{regexp.MustCompile("'INTERLEAVE'")},
 		inline: []string{"opt_unique", "opt_storing", "opt_interleave"},
 		replace: map[string]string{
+			"a_expr":                               "column_name",
 			" opt_index_name":                      "",
 			" opt_partition_by":                    "",
 			" opt_using_gin_btree":                 "",
@@ -528,7 +529,8 @@ var specs = []stmtSpec{
 		inline: []string{"opt_column_list"},
 	},
 	{
-		name: "create_role_stmt",
+		name:   "create_role_stmt",
+		inline: []string{"role_or_group"},
 		replace: map[string]string{
 			"string_or_placeholder": "name",
 		},

--- a/pkg/cmd/docgen/extract/extract.go
+++ b/pkg/cmd/docgen/extract/extract.go
@@ -128,7 +128,7 @@ func GenerateBNF(addr string) (ebnf []byte, err error) {
 	for _, p := range t.Productions {
 		var impl [][]yacc.Item
 		for _, e := range p.Expressions {
-			if strings.Contains(e.Command, "unimplemented") {
+			if strings.Contains(e.Command, "unimplemented") && !strings.Contains(e.Command, "FORCE DOC") {
 				continue
 			}
 			if strings.Contains(e.Command, "SKIP DOC") {

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -554,7 +554,10 @@ func TestReportUsage(t *testing.T) {
 		t.Fatalf("expected %d unimplemented feature errors, got %d", expected, actual)
 	}
 
-	for _, feat := range []string{"alter table rename constraint", "simple_type const_interval", "#9148"} {
+	for _, feat := range []string{
+		"syntax.alter table rename constraint",
+		"syntax.interval with precision",
+		"#9148"} {
 		if expected, actual := int64(10), r.last.UnimplementedErrors[feat]; expected != actual {
 			t.Fatalf(
 				"unexpected %d hits to unimplemented %q, got %d from %v",

--- a/pkg/sql/coltypes/aliases.go
+++ b/pkg/sql/coltypes/aliases.go
@@ -171,10 +171,37 @@ func init() {
 }
 
 // TypeForNonKeywordTypeName returns the column type for the string name of a
-// type, if one exists.
-func TypeForNonKeywordTypeName(name string) (T, error) {
-	if typ, ok := typNameLiterals[name]; ok {
-		return typ, nil
+// type, if one exists. The third return value indicates:
+// 0 if no error or the type is not known in postgres.
+// -1 if the type is known in postgres.
+// >0 for a github issue number.
+func TypeForNonKeywordTypeName(name string) (T, bool, int) {
+	t, ok := typNameLiterals[name]
+	if ok {
+		return t, ok, 0
 	}
-	return nil, pgerror.NewError(pgerror.CodeUndefinedObjectError, "type does not exist")
+	return nil, false, postgresPredefinedTypeIssues[name]
+}
+
+// The following map must include all types predefined in PostgreSQL
+// that are also not yet defined in CockroachDB and link them to
+// github issues. It is also possible, but not necessary, to include
+// PostgreSQL types that are already implemented in CockroachDB.
+var postgresPredefinedTypeIssues = map[string]int{
+	"box":           21286,
+	"cidr":          18846,
+	"circle":        21286,
+	"line":          21286,
+	"lseg":          21286,
+	"macaddr":       -1,
+	"macaddr8":      -1,
+	"money":         -1,
+	"path":          21286,
+	"pg_lsn":        -1,
+	"point":         21286,
+	"polygon":       21286,
+	"tsquery":       7821,
+	"tsvector":      7821,
+	"txid_snapshot": -1,
+	"xml":           -1,
 }

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -49,7 +49,7 @@ func (p *Parser) parseWithDepth(depth int, sql string) (stmts tree.StatementList
 	if p.parserImpl.Parse(&p.scanner) != 0 {
 		var err *pgerror.Error
 		if feat := p.scanner.lastError.unimplementedFeature; feat != "" {
-			err = pgerror.UnimplementedWithDepth(depth+1, feat, p.scanner.lastError.msg)
+			err = pgerror.UnimplementedWithDepth(depth+1, "syntax."+feat, p.scanner.lastError.msg)
 		} else {
 			err = pgerror.NewErrorWithDepth(depth+1, pgerror.CodeSyntaxError, p.scanner.lastError.msg)
 		}

--- a/pkg/sql/parser/scan.go
+++ b/pkg/sql/parser/scan.go
@@ -166,6 +166,13 @@ func (s *Scanner) UnimplementedWithIssue(issue int) {
 	s.lastError.hint = fmt.Sprintf("See: https://github.com/cockroachdb/cockroach/issues/%d", issue)
 }
 
+// UnimplementedWithIssueDetail wraps Error, setting lastUnimplementedError.
+func (s *Scanner) UnimplementedWithIssueDetail(issue int, detail string) {
+	s.Error("unimplemented")
+	s.lastError.unimplementedFeature = fmt.Sprintf("#%d.%s", issue, detail)
+	s.lastError.hint = fmt.Sprintf("See: https://github.com/cockroachdb/cockroach/issues/%d", issue)
+}
+
 func (s *Scanner) Error(e string) {
 	s.initLastErr()
 	if s.lastTok.id == ERROR {


### PR DESCRIPTION
Requested by @awoods187.
Fixes #28301.
Fixes #28304.
Fixes #28302.
Fixes #28300.
Fixes #28297.
Fixes #28295.
Fixes #28294.
Fixes #28292.

This patch recognizes more syntax from PostgreSQL for the purpose of
reporting more fine grained "unimplemented feature" errors.

- new:
  - CREATE/DROP
    AGGREGATE / CAST / COLLATION / CONVERSION / DOMAIN / EXTENSION /
    FOREIGN TABLE / FOREIGN DATA (WRAPPER) / FUNCTION / LANGUAGE /
    OPERATOR / PUBLICATION / RULE / SERVER / SUBSCRIPTION /
    TEXT (SEARCH) / TRIGGER / MATERIALIZED VIEW.
  - CREATE OR REPLACE VIEW
  - CREATE RECURSIVE VIEW
  - CREATE TEMP TABLE / VIEW / SEQUENCE and variants
  - CREATE INDEX USING GIST / HASH / SPGIST / BRIN
  - CREATE INDEX ... WHERE ... (partial indexes)
  - CREATE INDEX ON ... (<complex expr>)   (computed indexes)
  - CREATE GROUP is really an alias for CREATE USER and is not "unsupported"
  - type names point/circle/etc   (unsupported pg data types)
  - INTERVAL SECONDS / MINUTES / etc  (interval type with unit qualifier)
  - SELECT .. FOR UPDATE (and other locks)
  - Geometric types: POINT, CIRCLE etc
  - Other predefined pg types: XML, MACADDR, etc
  - Full text search: CREATE TEXT SEARCH, types TSVECTOR, TSQUERY, etc

- modified:
  - COMMENT ON accounting split in "table", "column" and other
  - TIMETZ support accounting split in "data type" and "current_time"
  - WITH RECURSIVE gets an issue number

Additionally unimplemented feature errors that stem during parsing
will now be prefixed with `syntax.` to ease integration in the feature
count hierarchy.

Release note: None