### PR TITLE
storage: de-race TestMergeQueue

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -2555,6 +2556,7 @@ func TestMergeQueue(t *testing.T) {
 		verifyUnmerged(t)
 
 		// Once the maximum size threshold is increased, the merge can occur.
+		zone = *protoutil.Clone(&zone).(*config.ZoneConfig)
 		*zone.RangeMaxBytes += 1
 		setZones(zone)
 		store.ForceMergeScanAndProcess()


### PR DESCRIPTION
It was mutating memory passed to the running cluster.

Fixes #31331.

Release note: None