### PR TITLE
roachtest: apply timeouts to import/restore tests

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -67,11 +67,19 @@ func registerImportTPCC(r *registry) {
 }
 
 func registerImportTPCH(r *registry) {
-	for _, n := range []int{4, 8, 32} {
+	for _, item := range []struct {
+		nodes   int
+		timeout time.Duration
+	}{
+		{4, 6 * time.Hour},
+		{8, 4 * time.Hour},
+		{32, 3 * time.Hour},
+	} {
 		r.Add(testSpec{
-			Name:   fmt.Sprintf(`import/tpch/nodes=%d`, n),
-			Nodes:  nodes(n),
-			Stable: true, // DO NOT COPY to new tests
+			Name:    fmt.Sprintf(`import/tpch/nodes=%d`, item.nodes),
+			Nodes:   nodes(item.nodes),
+			Timeout: item.timeout,
+			Stable:  true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				c.Put(ctx, cockroach, "./cockroach")
 				c.Start(ctx, t)

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -210,11 +210,18 @@ func (dul *DiskUsageLogger) Runner(ctx context.Context) error {
 }
 
 func registerRestore(r *registry) {
-	for _, nodeCount := range []int{10, 32} {
+	for _, item := range []struct {
+		nodes   int
+		timeout time.Duration
+	}{
+		{10, 6 * time.Hour},
+		{32, 3 * time.Hour},
+	} {
 		r.Add(testSpec{
-			Name:   fmt.Sprintf("restore2TB/nodes=%d", nodeCount),
-			Nodes:  nodes(nodeCount),
-			Stable: true, // DO NOT COPY to new tests
+			Name:    fmt.Sprintf("restore2TB/nodes=%d", item.nodes),
+			Nodes:   nodes(item.nodes),
+			Timeout: item.timeout,
+			Stable:  true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				c.Put(ctx, cockroach, "./cockroach")
 				c.Start(ctx, t)


### PR DESCRIPTION
Make stuck tests less expensive, in particular since 32 node clusters are involved.

Touches #31184.

Release note: None