### PR TITLE
status: fix a comment

### DIFF
--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -550,7 +550,7 @@ func getSummedDiskCounters(ctx context.Context) (diskStats, error) {
 }
 
 func getSummedNetStats(ctx context.Context) (net.IOCountersStat, error) {
-	netCounters, err := net.IOCountersWithContext(ctx, true /* idk what this bool means */)
+	netCounters, err := net.IOCountersWithContext(ctx, true /* per NIC */)
 	if err != nil {
 		return net.IOCountersStat{}, err
 	}


### PR DESCRIPTION
Passing `true` here gives results for each NIC. If `false` were passed,
things would be summed up and a single result returned.

Release note: None