### PR TITLE
release-2.1: sql: make heuristic planner bail on HAVING without FROM

### DIFF
--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -115,6 +115,9 @@ func (p *planner) groupBy(
 	if n.Having == nil && len(n.GroupBy) == 0 && !r.renderProps.SeenAggregate {
 		return nil, nil, nil
 	}
+	if n.Having != nil && len(n.From.Tables) == 0 {
+		return nil, nil, pgerror.UnimplementedWithIssueError(26349, "HAVING clause without FROM")
+	}
 
 	groupByExprs := make([]tree.Expr, len(n.GroupBy))
 

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -46,7 +46,7 @@ query error window functions are not allowed in WHERE
 SELECT k FROM kv WHERE avg(k) OVER () > 1
 
 query error window functions are not allowed in HAVING
-SELECT 1 GROUP BY 1 HAVING sum(1) OVER (PARTITION BY 1) > 1
+SELECT 1 FROM kv GROUP BY 1 HAVING sum(1) OVER (PARTITION BY 1) > 1
 
 query R
 SELECT avg(k) OVER () FROM kv ORDER BY 1

--- a/pkg/sql/logictest/testdata/planner_test/aggregate
+++ b/pkg/sql/logictest/testdata/planner_test/aggregate
@@ -920,3 +920,8 @@ sort                      ·            ·                 (a)                  
 ·                         table        kv@primary        ·                                        ·
 ·                         spans        ALL               ·                                        ·
 ·                         filter       v IS NOT NULL     ·                                        ·
+
+# Limitation test for #26349
+statement error HAVING clause without FROM
+SELECT 1 HAVING false
+


### PR DESCRIPTION
Backport 1/1 commits from #31346.

/cc @cockroachdb/release

---

Informs #26349.

The heuristic planner is unable to plan HAVING without FROM
properly. Instead of silently and incorrectly accepting this
construct, this patch makes it error out.

Release note (bug fix): CockroachDB does not any more silently and
incorrectly ignore the HAVING clause on SELECT without FROM.
