### PR TITLE
release-2.1: sql: bump SET CLUSTER SETTING gossip timeout

### DIFF
--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -171,7 +171,7 @@ func (n *setClusterSettingNode) startExec(params runParams) error {
 	}
 	errNotReady := errors.New("setting updated but timed out waiting to read new value")
 	var observed string
-	err := retry.ForDuration(1*time.Second, func() error {
+	err := retry.ForDuration(10*time.Second, func() error {
 		observed = n.setting.Encoded(&execCfg.Settings.SV)
 		if observed != expectedEncodedValue {
 			return errNotReady


### PR DESCRIPTION
Backport 1/1 commits from #31194.

/cc @cockroachdb/release

---

Closes #31193.

This change bumps the timeout that SET CLUSTER SETTING statements
wait for gossip to reflect their expected value. I had seen this
timeout fail when running in highly-distributed, large clusters under
load. 10 seconds seems more reasonable.

Release note: None
