### PR TITLE
release-2.1: storage: eagerly queue undersize ranges for merging

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -6801,6 +6801,10 @@ func (r *Replica) needsSplitBySizeRLocked() bool {
 	return r.exceedsMultipleOfSplitSizeRLocked(1)
 }
 
+func (r *Replica) needsMergeBySizeRLocked() bool {
+	return r.mu.state.Stats.Total() < r.mu.minBytes
+}
+
 func (r *Replica) exceedsMultipleOfSplitSizeRLocked(mult float64) bool {
 	maxBytes := r.mu.maxBytes
 	size := r.mu.state.Stats.Total()


### PR DESCRIPTION
Backport 1/1 commits from #30590.

/cc @cockroachdb/release

---

When processing a write, check if the range has dropped beneath the
minimum size threshold. If it has, check whether the merge queue would
like to process it. This is analogous to our logic for eagerly splitting
oversize ranges.

Fix #29004.

Release note: None

Before (courtesy of @tschottdorf):

![](https://user-images.githubusercontent.com/5076964/44524851-4d52f400-a6df-11e8-99e0-e523fb6fa42f.png)

After:

![image](https://user-images.githubusercontent.com/882976/45973007-3a4b8080-c00b-11e8-8955-5943e3951e33.png)
