### PR TITLE
sql: optionally enable vectorized planning with experimental_vectorize

### DIFF
--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -1,0 +1,251 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package colencoding
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/pkg/errors"
+)
+
+// DecodeIndexKeyToCols decodes an index key into the idx'th position of the
+// provided slices of exec.ColVecs. The input index key must already have its
+// first table id / index id prefix removed.
+// See the analog in sqlbase/index_encoding.go.
+func DecodeIndexKeyToCols(
+	vecs []exec.ColVec,
+	idx uint16,
+	desc *sqlbase.TableDescriptor,
+	index *sqlbase.IndexDescriptor,
+	indexColIdx []int,
+	types []sqlbase.ColumnType,
+	colDirs []sqlbase.IndexDescriptor_Direction,
+	key []byte,
+) (remainingKey []byte, matches bool, _ error) {
+	var decodedTableID sqlbase.ID
+	var decodedIndexID sqlbase.IndexID
+	var err error
+
+	if len(index.Interleave.Ancestors) > 0 {
+		for i, ancestor := range index.Interleave.Ancestors {
+			// Our input key had its first table id / index id chopped off, so
+			// don't try to decode those for the first ancestor.
+			if i != 0 {
+				key, decodedTableID, decodedIndexID, err = sqlbase.DecodeTableIDIndexID(key)
+				if err != nil {
+					return nil, false, err
+				}
+				if decodedTableID != ancestor.TableID || decodedIndexID != ancestor.IndexID {
+					return nil, false, nil
+				}
+			}
+
+			length := int(ancestor.SharedPrefixLen)
+			key, err = DecodeKeyValsToCols(vecs, idx, indexColIdx, types[:length], colDirs[:length], key)
+			if err != nil {
+				return nil, false, err
+			}
+			types, colDirs = types[length:], colDirs[length:]
+
+			// Consume the interleaved sentinel.
+			var ok bool
+			key, ok = encoding.DecodeIfInterleavedSentinel(key)
+			if !ok {
+				return nil, false, nil
+			}
+		}
+
+		key, decodedTableID, decodedIndexID, err = sqlbase.DecodeTableIDIndexID(key)
+		if err != nil {
+			return nil, false, err
+		}
+		if decodedTableID != desc.ID || decodedIndexID != index.ID {
+			return nil, false, nil
+		}
+	}
+
+	key, err = DecodeKeyValsToCols(vecs, idx, indexColIdx, types, colDirs, key)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// We're expecting a column family id next (a varint). If
+	// interleavedSentinel is actually next, then this key is for a child
+	// table.
+	if _, ok := encoding.DecodeIfInterleavedSentinel(key); ok {
+		return nil, false, nil
+	}
+
+	return key, true, nil
+}
+
+// DecodeKeyValsToCols decodes the values that are part of the key, writing the
+// result to the idx'th slot of the input slice of exec.ColVecs. If the
+// directions slice is nil, the direction used will default to
+// encoding.Ascending.
+// See the analog in sqlbase/index_encoding.go.
+func DecodeKeyValsToCols(
+	vecs []exec.ColVec,
+	idx uint16,
+	indexColIdx []int,
+	types []sqlbase.ColumnType,
+	directions []sqlbase.IndexDescriptor_Direction,
+	key []byte,
+) ([]byte, error) {
+	for j := range types {
+		enc := sqlbase.IndexDescriptor_ASC
+		if directions != nil {
+			enc = directions[j]
+		}
+		var err error
+		i := indexColIdx[j]
+		if i == -1 {
+			// Don't need the col - skip it.
+			key, err = skipTableKey(&types[j], key, enc)
+		} else {
+			key, err = decodeTableKeyToCol(vecs[i], idx, &types[j], key, enc)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	return key, nil
+}
+
+// decodeTableKeyToCol decodes a value encoded by EncodeTableKey, writing the result
+// to the idx'th slot of the input exec.ColVec.
+// See the analog, DecodeTableKey, in
+func decodeTableKeyToCol(
+	vec exec.ColVec,
+	idx uint16,
+	valType *sqlbase.ColumnType,
+	key []byte,
+	dir sqlbase.IndexDescriptor_Direction,
+) ([]byte, error) {
+	if (dir != sqlbase.IndexDescriptor_ASC) && (dir != sqlbase.IndexDescriptor_DESC) {
+		return nil, errors.Errorf("invalid direction: %d", dir)
+	}
+	var isNull bool
+	if key, isNull = encoding.DecodeIfNull(key); isNull {
+		vec.SetNull(idx)
+		return key, nil
+	}
+	var rkey []byte
+	var err error
+	switch valType.SemanticType {
+	case sqlbase.ColumnType_BOOL:
+		var i int64
+		if dir == sqlbase.IndexDescriptor_ASC {
+			rkey, i, err = encoding.DecodeVarintAscending(key)
+		} else {
+			rkey, i, err = encoding.DecodeVarintDescending(key)
+		}
+		vec.Bool()[idx] = i != 0
+	case sqlbase.ColumnType_INT:
+		var i int64
+		if dir == sqlbase.IndexDescriptor_ASC {
+			rkey, i, err = encoding.DecodeVarintAscending(key)
+		} else {
+			rkey, i, err = encoding.DecodeVarintDescending(key)
+		}
+		switch valType.Width {
+		case 8:
+			vec.Int8()[idx] = int8(i)
+		case 16:
+			vec.Int16()[idx] = int16(i)
+		case 32:
+			vec.Int32()[idx] = int32(i)
+		case 0, 64:
+			vec.Int64()[idx] = i
+		}
+	case sqlbase.ColumnType_FLOAT:
+		var f float64
+		if dir == sqlbase.IndexDescriptor_ASC {
+			rkey, f, err = encoding.DecodeFloatAscending(key)
+		} else {
+			rkey, f, err = encoding.DecodeFloatDescending(key)
+		}
+		vec.Float64()[idx] = f
+	case sqlbase.ColumnType_BYTES, sqlbase.ColumnType_STRING, sqlbase.ColumnType_NAME:
+		var r []byte
+		if dir == sqlbase.IndexDescriptor_ASC {
+			rkey, r, err = encoding.DecodeBytesAscending(key, nil)
+		} else {
+			rkey, r, err = encoding.DecodeBytesDescending(key, nil)
+		}
+		vec.Bytes()[idx] = r
+	case sqlbase.ColumnType_DATE:
+		var t int64
+		if dir == sqlbase.IndexDescriptor_ASC {
+			rkey, t, err = encoding.DecodeVarintAscending(key)
+		} else {
+			rkey, t, err = encoding.DecodeVarintDescending(key)
+		}
+		vec.Int64()[idx] = t
+	default:
+		panic(fmt.Sprintf("unsupported type %+v", valType))
+	}
+	return rkey, err
+}
+
+// skipTableKey skips a value of type valType in key, returning the remainder
+// of the key.
+// TODO(jordan): each type could be optimized here.
+// TODO(jordan): should use this approach in the normal row fetcher.
+func skipTableKey(
+	valType *sqlbase.ColumnType, key []byte, dir sqlbase.IndexDescriptor_Direction,
+) ([]byte, error) {
+	if (dir != sqlbase.IndexDescriptor_ASC) && (dir != sqlbase.IndexDescriptor_DESC) {
+		return nil, errors.Errorf("invalid direction: %d", dir)
+	}
+	var isNull bool
+	if key, isNull = encoding.DecodeIfNull(key); isNull {
+		return key, nil
+	}
+	var rkey []byte
+	var err error
+	switch valType.SemanticType {
+	case sqlbase.ColumnType_BOOL, sqlbase.ColumnType_INT, sqlbase.ColumnType_DATE:
+		if dir == sqlbase.IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeVarintAscending(key)
+		} else {
+			rkey, _, err = encoding.DecodeVarintDescending(key)
+		}
+	case sqlbase.ColumnType_FLOAT:
+		if dir == sqlbase.IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeFloatAscending(key)
+		} else {
+			rkey, _, err = encoding.DecodeFloatDescending(key)
+		}
+	case sqlbase.ColumnType_BYTES, sqlbase.ColumnType_STRING, sqlbase.ColumnType_NAME:
+		if dir == sqlbase.IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeBytesAscending(key, nil)
+		} else {
+			rkey, _, err = encoding.DecodeBytesDescending(key, nil)
+		}
+	case sqlbase.ColumnType_DECIMAL:
+		if dir == sqlbase.IndexDescriptor_ASC {
+			rkey, _, err = encoding.DecodeDecimalAscending(key, nil)
+		} else {
+			rkey, _, err = encoding.DecodeDecimalDescending(key, nil)
+		}
+	default:
+		panic(fmt.Sprintf("unsupported type %+v", valType))
+	}
+	return rkey, err
+}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -584,6 +584,11 @@ func (r *DistSQLReceiver) ProducerDone() {
 	r.cleanup()
 }
 
+// Types is part of the RowReceiver interface.
+func (r *DistSQLReceiver) Types() []sqlbase.ColumnType {
+	return r.outputTypes
+}
+
 // updateCaches takes information about some ranges that were mis-planned and
 // updates the range descriptor and lease-holder caches accordingly.
 //

--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -78,6 +78,10 @@ type RowReceiver interface {
 	// Implementations of Push() must be thread-safe.
 	Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) ConsumerStatus
 
+	// Types returns the types of the EncDatumRow that this RowReceiver expects
+	// to be pushed.
+	Types() []sqlbase.ColumnType
+
 	// ProducerDone is called when the producer has pushed all the rows and
 	// metadata; it causes the RowReceiver to process all rows and clean up.
 	//
@@ -484,6 +488,11 @@ func (rc *RowChannel) ConsumerClosed() {
 	}
 }
 
+// Types is part of the RowReceiver interface.
+func (rc *RowChannel) Types() []sqlbase.ColumnType {
+	return rc.types
+}
+
 // BufferedRecord represents a row or metadata record that has been buffered
 // inside a RowBuffer.
 type BufferedRecord struct {
@@ -592,6 +601,11 @@ func (rb *RowBuffer) ProducerDone() {
 		panic("RowBuffer already closed")
 	}
 	rb.ProducerClosed = true
+}
+
+// Types is part of the RowReceiver interface.
+func (rb *RowBuffer) Types() []sqlbase.ColumnType {
+	return rb.types
 }
 
 // OutputTypes is part of the RowSource interface.

--- a/pkg/sql/distsqlrun/colbatch_scan.go
+++ b/pkg/sql/distsqlrun/colbatch_scan.go
@@ -1,0 +1,160 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package distsqlrun
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+// colBatchScan is the exec.Operator implementation of TableReader. It reads a table
+// from kv, presenting it as ColBatches via the exec.Operator interface.
+type colBatchScan struct {
+	spans     roachpb.Spans
+	flowCtx   *FlowCtx
+	rf        *row.CFetcher
+	limitHint int64
+	ctx       context.Context
+}
+
+var _ exec.Operator = &colBatchScan{}
+
+func (s *colBatchScan) Init() {
+	s.ctx = context.Background()
+	if err := s.rf.StartScan(
+		s.ctx, s.flowCtx.txn, s.spans,
+		true /* limit batches */, s.limitHint, s.flowCtx.traceKV,
+	); err != nil {
+		panic(err)
+	}
+}
+
+func (s *colBatchScan) Next() exec.ColBatch {
+	bat, _, _, err := s.rf.NextBatch(s.ctx)
+	if err != nil {
+		panic(err)
+	}
+	return bat
+}
+
+// newColBatchScan creates a new colBatchScan operator.
+func newColBatchScan(
+	flowCtx *FlowCtx, spec *TableReaderSpec, post *PostProcessSpec,
+) (*colBatchScan, error) {
+	if flowCtx.nodeID == 0 {
+		return nil, errors.Errorf("attempting to create a colBatchScan with uninitialized NodeID")
+	}
+
+	limitHint := limitHint(spec.LimitHint, post)
+
+	numCols := len(spec.Table.Columns)
+	returnMutations := spec.Visibility == ScanVisibility_PUBLIC_AND_NOT_PUBLIC
+	if returnMutations {
+		for i := range spec.Table.Mutations {
+			if spec.Table.Mutations[i].GetColumn() != nil {
+				numCols++
+			}
+		}
+	}
+	typs := spec.Table.ColumnTypesWithMutations(returnMutations)
+	helper := ProcOutputHelper{}
+	if err := helper.Init(
+		post,
+		typs,
+		flowCtx.NewEvalCtx(),
+		nil,
+	); err != nil {
+		return nil, err
+	}
+
+	neededColumns := helper.neededColumns()
+
+	columnIdxMap := spec.Table.ColumnIdxMapWithMutations(returnMutations)
+	fetcher := row.CFetcher{}
+	if _, _, err := initCRowFetcher(
+		&fetcher, &spec.Table, int(spec.IndexIdx), columnIdxMap, spec.Reverse,
+		neededColumns, spec.IsCheck, spec.Visibility,
+	); err != nil {
+		return nil, err
+	}
+
+	nSpans := len(spec.Spans)
+	spans := make(roachpb.Spans, nSpans)
+	for i := range spans {
+		spans[i] = spec.Spans[i].Span
+	}
+	return &colBatchScan{
+		spans:     spans,
+		flowCtx:   flowCtx,
+		rf:        &fetcher,
+		limitHint: limitHint,
+	}, nil
+}
+
+// initCRowFetcher initializes a row.CFetcher. See initRowFetcher.
+func initCRowFetcher(
+	fetcher *row.CFetcher,
+	desc *sqlbase.TableDescriptor,
+	indexIdx int,
+	colIdxMap map[sqlbase.ColumnID]int,
+	reverseScan bool,
+	valNeededForCol util.FastIntSet,
+	isCheck bool,
+	scanVisibility ScanVisibility,
+) (index *sqlbase.IndexDescriptor, isSecondaryIndex bool, err error) {
+	index, isSecondaryIndex, err = desc.FindIndexByIndexIdx(indexIdx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	cols := desc.Columns
+	if scanVisibility == ScanVisibility_PUBLIC_AND_NOT_PUBLIC {
+		if len(desc.Mutations) > 0 {
+			cols = make([]sqlbase.ColumnDescriptor, 0, len(desc.Columns)+len(desc.Mutations))
+			cols = append(cols, desc.Columns...)
+			for _, mutation := range desc.Mutations {
+				if c := mutation.GetColumn(); c != nil {
+					col := *c
+					// Even if the column is non-nullable it can be null in the
+					// middle of a schema change.
+					col.Nullable = true
+					cols = append(cols, col)
+				}
+			}
+		}
+	}
+	tableArgs := row.FetcherTableArgs{
+		Desc:             desc,
+		Index:            index,
+		ColIdxMap:        colIdxMap,
+		IsSecondaryIndex: isSecondaryIndex,
+		Cols:             cols,
+		ValNeededForCol:  valNeededForCol,
+	}
+	if err := fetcher.Init(
+		reverseScan, true /* returnRangeInfo */, isCheck, tableArgs,
+	); err != nil {
+		return nil, false, err
+	}
+
+	return index, isSecondaryIndex, nil
+}

--- a/pkg/sql/distsqlrun/colbatch_scan_test.go
+++ b/pkg/sql/distsqlrun/colbatch_scan_test.go
@@ -1,0 +1,93 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package distsqlrun
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+func BenchmarkColBatchScan(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	logScope := log.Scope(b)
+	defer logScope.Close(b)
+	ctx := context.Background()
+
+	s, sqlDB, kvDB := serverutils.StartServer(b, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	const numCols = 2
+	for _, numRows := range []int{1 << 4, 1 << 8, 1 << 12, 1 << 16} {
+		tableName := fmt.Sprintf("t%d", numRows)
+		sqlutils.CreateTable(
+			b, sqlDB, tableName,
+			"k INT PRIMARY KEY, v INT",
+			numRows,
+			sqlutils.ToRowFn(sqlutils.RowIdxFn, sqlutils.RowModuloFn(42)),
+		)
+		tableDesc := sqlbase.GetTableDescriptor(kvDB, "test", tableName)
+		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {
+			spec := TableReaderSpec{
+				Table: *tableDesc,
+				Spans: []TableReaderSpan{{Span: tableDesc.PrimaryIndexSpan()}},
+			}
+			post := PostProcessSpec{
+				Projection:    true,
+				OutputColumns: []uint32{0, 1},
+			}
+
+			evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())
+			defer evalCtx.Stop(ctx)
+
+			flowCtx := FlowCtx{
+				EvalCtx:  &evalCtx,
+				Settings: s.ClusterSettings(),
+				txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
+				nodeID:   s.NodeID(),
+			}
+
+			b.SetBytes(int64(numRows * numCols * 8))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				tr, err := newColBatchScan(&flowCtx, &spec, &post)
+				tr.Init()
+				b.StartTimer()
+				if err != nil {
+					b.Fatal(err)
+				}
+				for {
+					bat := tr.Next()
+					if err != nil {
+						b.Fatal(err)
+					}
+					if bat.Length() == 0 {
+						break
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -1,0 +1,220 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package distsqlrun
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/util"
+
+	"github.com/pkg/errors"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+)
+
+func checkNumIn(inputs []exec.Operator, numIn int) error {
+	if len(inputs) != numIn {
+		return errors.Errorf("expected %d input(s), got %d", numIn, len(inputs))
+	}
+	return nil
+}
+
+func newColOperator(
+	ctx context.Context, flowCtx *FlowCtx, spec *ProcessorSpec, inputs []exec.Operator,
+) (exec.Operator, error) {
+	core := &spec.Core
+	post := &spec.Post
+	var err error
+	var op exec.Operator
+	switch {
+	case core.TableReader != nil:
+		if err := checkNumIn(inputs, 0); err != nil {
+			return nil, err
+		}
+		op, err = newColBatchScan(flowCtx, core.TableReader, post)
+	case core.Aggregator != nil:
+		if err := checkNumIn(inputs, 1); err != nil {
+			return nil, err
+		}
+		spec := core.Aggregator
+		if len(spec.GroupCols) == 0 &&
+			len(spec.Aggregations) == 1 &&
+			spec.Aggregations[0].FilterColIdx == nil &&
+			spec.Aggregations[0].Func == AggregatorSpec_COUNT_ROWS &&
+			!spec.Aggregations[0].Distinct {
+			return exec.NewCountOp(inputs[0]), nil
+		}
+		return nil, errors.Errorf("unsupported aggregator %+v", core.Aggregator)
+
+	case core.Distinct != nil:
+		if err := checkNumIn(inputs, 1); err != nil {
+			return nil, err
+		}
+
+		var distinctCols, orderedCols util.FastIntSet
+		allSorted := true
+
+		for _, col := range core.Distinct.OrderedColumns {
+			orderedCols.Add(int(col))
+		}
+		for _, col := range core.Distinct.DistinctColumns {
+			if !orderedCols.Contains(int(col)) {
+				allSorted = false
+			}
+			distinctCols.Add(int(col))
+		}
+		if !orderedCols.SubsetOf(distinctCols) {
+			return nil, pgerror.NewAssertionErrorf("ordered cols must be a subset of distinct cols")
+		}
+		if !allSorted {
+			return nil, errors.New("unsorted distinct not supported")
+		}
+
+		typs := types.FromColumnTypes(spec.Input[0].ColumnTypes)
+		op, err = exec.NewOrderedDistinct(inputs[0], core.Distinct.OrderedColumns, typs)
+
+	default:
+		return nil, errors.Errorf("unsupported processor core %s", core)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if !post.Filter.Empty() {
+		// TODO(solon): plan selection op
+		return nil, errors.New("filters unsupported")
+	}
+	if post.Projection {
+		op = exec.NewSimpleProjectOp(op, post.OutputColumns)
+	} else if post.RenderExprs != nil {
+		// TODO(solon): plan renders
+		return nil, errors.New("renders unsupported")
+	}
+	return op, nil
+}
+
+func (f *Flow) setupVectorized(ctx context.Context) error {
+	f.processors = make([]Processor, 1)
+
+	streamIDToInputOp := make(map[StreamID]exec.Operator)
+	streamIDToSpecIdx := make(map[StreamID]int)
+	// queue is a queue of indices into f.spec.Processors, for topologically
+	// ordered processing.
+	queue := make([]int, 0, len(f.spec.Processors))
+	for i := range f.spec.Processors {
+		if len(f.spec.Processors[i].Input) == 0 {
+			// Queue all procs with no inputs.
+			queue = append(queue, i)
+		}
+		for j := range f.spec.Processors[i].Input {
+			input := &f.spec.Processors[i].Input[j]
+			for k := range input.Streams {
+				if input.Streams[k].Type == StreamEndpointSpec_LOCAL {
+					id := input.Streams[k].StreamID
+					streamIDToSpecIdx[id] = i
+				} else {
+					return errors.Errorf("unsupported input stream type %s", input.Streams[k].Type)
+				}
+			}
+		}
+	}
+
+	inputs := make([]exec.Operator, 0, 2)
+	for len(queue) > 0 {
+		pspec := &f.spec.Processors[queue[0]]
+		queue = queue[1:]
+		if len(pspec.Output) > 1 {
+			return errors.Errorf("unsupported multi-output proc (%d outputs)", len(pspec.Output))
+		}
+		output := pspec.Output[0]
+		if output.Type != OutputRouterSpec_PASS_THROUGH {
+			return errors.Errorf("unsupported routed proc %s", output.Type)
+		}
+		if len(output.Streams) != 1 {
+			return errors.Errorf("unsupported multi outputstream proc (%d streams)", len(output.Streams))
+		}
+		inputs = inputs[:0]
+		for i := range pspec.Input {
+			input := &pspec.Input[i]
+			if len(input.Streams) > 1 {
+				return errors.Errorf("unsupported multi inputstream proc (%d streams)", len(input.Streams))
+			}
+			inputStream := &input.Streams[0]
+			if inputStream.Type != StreamEndpointSpec_LOCAL {
+				return errors.Errorf("unsupported input stream type %s", inputStream.Type)
+			}
+			inputs = append(inputs, streamIDToInputOp[inputStream.StreamID])
+		}
+
+		op, err := newColOperator(ctx, &f.FlowCtx, pspec, inputs)
+		if err != nil {
+			return err
+		}
+
+		outputStream := output.Streams[0]
+		switch outputStream.Type {
+		case StreamEndpointSpec_LOCAL:
+		case StreamEndpointSpec_SYNC_RESPONSE:
+			// Make the materializer, which will write to the given receiver.
+			columnTypes := f.syncFlowConsumer.Types()
+			outputToInputColIdx := make([]int, len(columnTypes))
+			for i := range outputToInputColIdx {
+				outputToInputColIdx[i] = i
+			}
+			proc, err := newMaterializer(&f.FlowCtx, pspec.ProcessorID, op, columnTypes, outputToInputColIdx, &PostProcessSpec{}, f.syncFlowConsumer)
+			if err != nil {
+				return err
+			}
+			f.processors[0] = proc
+		default:
+			return errors.Errorf("unsupported output stream type %s", outputStream.Type)
+		}
+
+		streamIDToInputOp[outputStream.StreamID] = op
+
+		// Now queue all outputs from this op whose inputs are already all
+		// populated.
+	NEXTOUTPUT:
+		for i := range pspec.Output {
+			for j := range pspec.Output[i].Streams {
+				stream := &pspec.Output[i].Streams[j]
+				if stream.Type != StreamEndpointSpec_LOCAL {
+					continue
+				}
+				procIdx, ok := streamIDToSpecIdx[stream.StreamID]
+				if !ok {
+					return errors.Errorf("Couldn't find stream %d", stream.StreamID)
+				}
+				outputSpec := &f.spec.Processors[procIdx]
+				for k := range outputSpec.Input {
+					for l := range outputSpec.Input[k].Streams {
+						id := outputSpec.Input[k].Streams[l].StreamID
+						if _, ok := streamIDToInputOp[id]; !ok {
+							continue NEXTOUTPUT
+						}
+					}
+				}
+				// We found an input op for every single stream in this output. Queue
+				// it for processing.
+				queue = append(queue, procIdx)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -521,6 +521,16 @@ func (f *Flow) setup(ctx context.Context, spec *FlowSpec) error {
 	if err != nil {
 		return err
 	}
+
+	if f.EvalCtx.SessionData.Vectorize {
+		err := f.setupVectorized(ctx)
+		if err == nil {
+			log.VEventf(ctx, 1, "vectorized flow.")
+			return nil
+		}
+		log.VEventf(ctx, 1, "failed to vectorize: %s", err)
+	}
+
 	// Then, populate f.processors.
 	return f.setupProcessors(ctx, inputSyncs)
 }

--- a/pkg/sql/distsqlrun/routers.go
+++ b/pkg/sql/distsqlrun/routers.go
@@ -381,6 +381,10 @@ func (rb *routerBase) ProducerDone() {
 	}
 }
 
+func (rb *routerBase) Types() []sqlbase.ColumnType {
+	return rb.types
+}
+
 // updateStreamState updates the status of one stream and, if this was the last
 // open stream, it also updates rb.aggregatedStatus.
 func (rb *routerBase) updateStreamState(streamStatus *ConsumerStatus, newState ConsumerStatus) {

--- a/pkg/sql/distsqlrun/utils_test.go
+++ b/pkg/sql/distsqlrun/utils_test.go
@@ -103,6 +103,10 @@ func (r *RowDisposer) Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) Cons
 // ProducerDone is part of the RowReceiver interface.
 func (r *RowDisposer) ProducerDone() {}
 
+func (r *RowDisposer) Types() []sqlbase.ColumnType {
+	return nil
+}
+
 // NextNoMeta is a version of Next which fails the test if
 // it encounters any metadata.
 func (rb *RowBuffer) NextNoMeta(tb testing.TB) sqlbase.EncDatumRow {

--- a/pkg/sql/exec/colbatch.go
+++ b/pkg/sql/exec/colbatch.go
@@ -29,6 +29,8 @@ type ColBatch interface {
 	SetLength(uint16)
 	// ColVec returns the ith ColVec in this batch.
 	ColVec(i int) ColVec
+	// ColVecs returns all of the underlying ColVecs in this batch.
+	ColVecs() []ColVec
 	// Selection, if not nil, returns the selection vector on this batch: a
 	// densely-packed list of the indices in each column that have not been
 	// filtered out by a previous step.
@@ -88,6 +90,10 @@ func (m *memBatch) Length() uint16 {
 
 func (m *memBatch) ColVec(i int) ColVec {
 	return m.b[i]
+}
+
+func (m *memBatch) ColVecs() []ColVec {
+	return m.b
 }
 
 func (m *memBatch) Selection() []uint16 {

--- a/pkg/sql/row/cfetcher.go
+++ b/pkg/sql/row/cfetcher.go
@@ -1,0 +1,870 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package row
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/colencoding"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// Only unique secondary indexes have extra columns to decode (namely the
+// primary index columns).
+func cHasExtraCols(table *cTableInfo) bool {
+	return table.isSecondaryIndex && table.index.Unique
+}
+
+type cTableInfo struct {
+	// -- Fields initialized once --
+
+	// Used to determine whether a key retrieved belongs to the span we
+	// want to scan.
+	spans            roachpb.Spans
+	desc             *sqlbase.TableDescriptor
+	index            *sqlbase.IndexDescriptor
+	isSecondaryIndex bool
+	indexColumnDirs  []sqlbase.IndexDescriptor_Direction
+
+	// The table columns to use for fetching, possibly including ones currently in
+	// schema changes.
+	cols []sqlbase.ColumnDescriptor
+
+	// The set of ColumnIDs that are required.
+	neededCols util.FastIntSet
+
+	// The set of indexes into the cols array that are required for columns
+	// in the value part.
+	neededValueColsByIdx util.FastIntSet
+
+	// The number of needed columns from the value part of the row. Once we've
+	// seen this number of value columns for a particular row, we can stop
+	// decoding values in that row.
+	neededValueCols int
+
+	// Map used to get the index for columns in cols.
+	colIdxMap map[sqlbase.ColumnID]int
+
+	// One value per column that is part of the key; each value is a column
+	// index (into cols); -1 if we don't need the value for that column.
+	indexColOrdinals []int
+
+	// One value per column that is part of the key; each value is a column
+	// index (into cols); -1 if we don't need the value for that column.
+	extraValColOrdinals []int
+
+	// -- Fields updated during a scan --
+
+	rowIdx uint16
+	batch  exec.ColBatch
+
+	colvecs []exec.ColVec
+
+	keyValTypes []sqlbase.ColumnType
+	extraTypes  []sqlbase.ColumnType
+}
+
+// CFetcher handles fetching kvs and forming table rows for an
+// arbitrary number of tables.
+// Usage:
+//   var rf CFetcher
+//   err := rf.Init(..)
+//   // Handle err
+//   err := rf.StartScan(..)
+//   // Handle err
+//   for {
+//      res, err := rf.NextBatch()
+//      // Handle err
+//      if res.colBatch.Length() == 0 {
+//         // Done
+//         break
+//      }
+//      // Process res.colBatch
+//   }
+type CFetcher struct {
+	// tables is a slice of all the tables and their descriptors for which
+	// rows are returned.
+	tables []cTableInfo
+
+	// allEquivSignatures is a map used for checking if an equivalence
+	// signature belongs to any table or table's ancestor. It also maps the
+	// string representation of every table's and every table's ancestors'
+	// signature to the table's index in 'tables' for lookup during decoding.
+	// If 2+ tables share the same ancestor signature, allEquivSignatures
+	// will map the signature to the largest 'tables' index.
+	// The full signature for a given table in 'tables' will always map to
+	// its own index in 'tables'.
+	allEquivSignatures map[string]int
+
+	// reverse denotes whether or not the spans should be read in reverse
+	// or not when StartScan is invoked.
+	reverse bool
+
+	// maxKeysPerRow memoizes the maximum number of keys per row
+	// out of all the tables. This is used to calculate the kvFetcher's
+	// firstBatchLimit.
+	maxKeysPerRow int
+
+	// True if the index key must be decoded.
+	// If there is more than one table, the index key must always be decoded.
+	// This is only false if there are no needed columns and the (single)
+	// table has no interleave children.
+	mustDecodeIndexKey bool
+
+	// knownPrefixLength is the number of bytes in the index key prefix this
+	// Fetcher is configured for. The index key prefix is the table id, index
+	// id pair at the start of the key.
+	knownPrefixLength int
+
+	// returnRangeInfo, if set, causes the underlying kvFetcher to return
+	// information about the ranges descriptors/leases uses in servicing the
+	// requests. This has some cost, so it's only enabled by DistSQL when this
+	// info is actually useful for correcting the plan (e.g. not for the PK-side
+	// of an index-join).
+	// If set, GetRangeInfo() can be used to retrieve the accumulated info.
+	returnRangeInfo bool
+
+	// traceKV indicates whether or not session tracing is enabled. It is set
+	// when beginning a new scan.
+	traceKV bool
+
+	// -- Fields updated during a scan --
+
+	kvFetcher      kvFetcher
+	indexKey       []byte // the index key of the current row
+	prettyValueBuf *bytes.Buffer
+
+	valueColsFound int // how many needed cols we've found so far in the value
+
+	rowReadyTable *cTableInfo // the table for which a row was fully decoded and ready for output
+	currentTable  *cTableInfo // the most recent table for which a key was decoded
+
+	// The current key/value, unless kvEnd is true.
+	kv                roachpb.KeyValue
+	keyRemainingBytes []byte
+	kvEnd             bool
+
+	kvs []roachpb.KeyValue
+
+	batchResponse []byte
+	batchNumKvs   int64
+
+	// isCheck indicates whether or not we are running checks for k/v
+	// correctness. It is set only during SCRUB commands.
+	isCheck bool
+}
+
+// Init sets up a Fetcher for a given table and index. If we are using a
+// non-primary index, tables.ValNeededForCol can only refer to columns in the
+// index.
+func (rf *CFetcher) Init(
+	reverse,
+	returnRangeInfo bool, isCheck bool, tables ...FetcherTableArgs,
+) error {
+	if len(tables) == 0 {
+		panic("no tables to fetch from")
+	}
+
+	rf.reverse = reverse
+	rf.returnRangeInfo = returnRangeInfo
+	rf.isCheck = isCheck
+
+	// We must always decode the index key if we need to distinguish between
+	// rows from more than one table.
+	nTables := len(tables)
+	multipleTables := nTables >= 2
+	rf.mustDecodeIndexKey = multipleTables
+	if multipleTables {
+		rf.allEquivSignatures = make(map[string]int, len(tables))
+	}
+
+	if cap(rf.tables) >= nTables {
+		rf.tables = rf.tables[:nTables]
+	} else {
+		rf.tables = make([]cTableInfo, nTables)
+	}
+	for tableIdx, tableArgs := range tables {
+		oldTable := rf.tables[tableIdx]
+
+		table := cTableInfo{
+			spans:            tableArgs.Spans,
+			desc:             tableArgs.Desc,
+			colIdxMap:        tableArgs.ColIdxMap,
+			index:            tableArgs.Index,
+			isSecondaryIndex: tableArgs.IsSecondaryIndex,
+			cols:             tableArgs.Cols,
+
+			// These slice fields might get re-allocated below, so reslice them from
+			// the old table here in case they've got enough capacity already.
+			indexColOrdinals:    oldTable.indexColOrdinals[:0],
+			extraValColOrdinals: oldTable.extraValColOrdinals[:0],
+		}
+		typs := make([]types.T, len(table.cols))
+		for i := range typs {
+			typs[i] = types.FromColumnType(table.cols[i].Type)
+			if typs[i] == types.Unhandled {
+				return errors.Errorf("unhandled type %+v", table.cols[i].Type)
+			}
+		}
+		table.batch = exec.NewMemBatch(typs)
+		table.colvecs = table.batch.ColVecs()
+
+		var err error
+		if multipleTables {
+			panic("CFetcher doesn't support multi-table reads yet.")
+		}
+
+		// Scan through the entire columns map to see which columns are
+		// required.
+		for col, idx := range table.colIdxMap {
+			if tableArgs.ValNeededForCol.Contains(idx) {
+				// The idx-th column is required.
+				table.neededCols.Add(int(col))
+			}
+		}
+
+		rf.knownPrefixLength = len(sqlbase.MakeIndexKeyPrefix(table.desc, table.index.ID))
+
+		var indexColumnIDs []sqlbase.ColumnID
+		indexColumnIDs, table.indexColumnDirs = table.index.FullColumnIDs()
+
+		table.neededValueColsByIdx = tableArgs.ValNeededForCol.Copy()
+		neededIndexCols := 0
+		nIndexCols := len(indexColumnIDs)
+		if cap(table.indexColOrdinals) >= nIndexCols {
+			table.indexColOrdinals = table.indexColOrdinals[:nIndexCols]
+		} else {
+			table.indexColOrdinals = make([]int, nIndexCols)
+		}
+		for i, id := range indexColumnIDs {
+			colIdx, ok := table.colIdxMap[id]
+			if ok {
+				table.indexColOrdinals[i] = colIdx
+				if table.neededCols.Contains(int(id)) {
+					neededIndexCols++
+					table.neededValueColsByIdx.Remove(colIdx)
+				}
+			} else {
+				table.indexColOrdinals[i] = -1
+				if table.neededCols.Contains(int(id)) {
+					panic(fmt.Sprintf("needed column %d not in colIdxMap", id))
+				}
+			}
+		}
+
+		// - If there is more than one table, we have to decode the index key to
+		//   figure out which table the row belongs to.
+		// - If there are interleaves, we need to read the index key in order to
+		//   determine whether this row is actually part of the index we're scanning.
+		// - If there are needed columns from the index key, we need to read it.
+		//
+		// Otherwise, we can completely avoid decoding the index key.
+		if !rf.mustDecodeIndexKey && (neededIndexCols > 0 || len(table.index.InterleavedBy) > 0 || len(table.index.Interleave.Ancestors) > 0) {
+			rf.mustDecodeIndexKey = true
+		}
+
+		// The number of columns we need to read from the value part of the key.
+		// It's the total number of needed columns minus the ones we read from the
+		// index key, except for composite columns.
+		table.neededValueCols = table.neededCols.Len() - neededIndexCols + len(table.index.CompositeColumnIDs)
+
+		if table.isSecondaryIndex {
+			for i := range table.cols {
+				if table.neededCols.Contains(int(table.cols[i].ID)) && !table.index.ContainsColumnID(table.cols[i].ID) {
+					return fmt.Errorf("requested column %s not in index", table.cols[i].Name)
+				}
+			}
+		}
+
+		// Prepare our index key vals slice.
+		table.keyValTypes, err = sqlbase.GetColumnTypes(table.desc, indexColumnIDs)
+		if err != nil {
+			return err
+		}
+		if cHasExtraCols(&table) {
+			// Unique secondary indexes have a value that is the
+			// primary index key.
+			// Primary indexes only contain ascendingly-encoded
+			// values. If this ever changes, we'll probably have to
+			// figure out the directions here too.
+			table.extraTypes, err = sqlbase.GetColumnTypes(table.desc, table.index.ExtraColumnIDs)
+			nExtraColumns := len(table.index.ExtraColumnIDs)
+			if cap(table.extraValColOrdinals) >= nExtraColumns {
+				table.extraValColOrdinals = table.extraValColOrdinals[:nExtraColumns]
+			} else {
+				table.extraValColOrdinals = make([]int, nExtraColumns)
+			}
+			for i, id := range table.index.ExtraColumnIDs {
+				if table.neededCols.Contains(int(id)) {
+					table.extraValColOrdinals[i] = table.colIdxMap[id]
+				} else {
+					table.extraValColOrdinals[i] = -1
+				}
+			}
+			if err != nil {
+				return err
+			}
+		}
+
+		// Keep track of the maximum keys per row to accommodate a
+		// limitHint when StartScan is invoked.
+		if keysPerRow := table.desc.KeysPerRow(table.index.ID); keysPerRow > rf.maxKeysPerRow {
+			rf.maxKeysPerRow = keysPerRow
+		}
+
+		rf.tables[tableIdx] = table
+	}
+
+	if len(tables) == 1 {
+		// If there is more than one table, currentTable will be
+		// updated every time NextKey is invoked and rowReadyTable
+		// will be updated when a row is fully decoded.
+		rf.currentTable = &(rf.tables[0])
+		rf.rowReadyTable = &(rf.tables[0])
+	}
+
+	return nil
+}
+
+// StartScan initializes and starts the key-value scan. Can be used multiple
+// times.
+func (rf *CFetcher) StartScan(
+	ctx context.Context,
+	txn *client.Txn,
+	spans roachpb.Spans,
+	limitBatches bool,
+	limitHint int64,
+	traceKV bool,
+) error {
+	if len(spans) == 0 {
+		panic("no spans")
+	}
+
+	rf.traceKV = traceKV
+
+	// If we have a limit hint, we limit the first batch size. Subsequent
+	// batches get larger to avoid making things too slow (e.g. in case we have
+	// a very restrictive filter and actually have to retrieve a lot of rows).
+	firstBatchLimit := limitHint
+	if firstBatchLimit != 0 {
+		// The limitHint is a row limit, but each row could be made up
+		// of more than one key. We take the maximum possible keys
+		// per row out of all the table rows we could potentially
+		// scan over.
+		firstBatchLimit = limitHint * int64(rf.maxKeysPerRow)
+		// We need an extra key to make sure we form the last row.
+		firstBatchLimit++
+	}
+
+	f, err := makeKVFetcher(txn, spans, rf.reverse, limitBatches, firstBatchLimit, rf.returnRangeInfo)
+	if err != nil {
+		return err
+	}
+	return rf.StartScanFrom(ctx, &f)
+}
+
+// StartScanFrom initializes and starts a scan from the given kvFetcher. Can be
+// used multiple times.
+func (rf *CFetcher) StartScanFrom(ctx context.Context, f kvFetcher) error {
+	rf.indexKey = nil
+	rf.kvFetcher = f
+	rf.kvs = nil
+	rf.batchNumKvs = 0
+	rf.batchResponse = nil
+	// Retrieve the first key.
+	_, err := rf.NextKey(ctx)
+	return err
+}
+
+// Pops off the first kv stored in rf.kvs. If none are found attempts to fetch
+// the next batch until there are no more kvs to fetch.
+// Returns whether or not there are more kvs to fetch, the kv that was fetched,
+// and any errors that may have occurred.
+func (rf *CFetcher) nextKV(ctx context.Context) (ok bool, kv roachpb.KeyValue, err error) {
+	if len(rf.kvs) != 0 {
+		kv = rf.kvs[0]
+		rf.kvs = rf.kvs[1:]
+		return true, kv, nil
+	}
+	if rf.batchNumKvs > 0 {
+		rf.batchNumKvs--
+		var key []byte
+		var rawBytes []byte
+		var err error
+		key, _, rawBytes, rf.batchResponse, err = enginepb.ScanDecodeKeyValue(rf.batchResponse)
+		if err != nil {
+			return false, kv, err
+		}
+		return true, roachpb.KeyValue{
+			Key: key,
+			Value: roachpb.Value{
+				RawBytes: rawBytes,
+			},
+		}, nil
+	}
+
+	var numKeys int64
+	ok, rf.kvs, rf.batchResponse, numKeys, err = rf.kvFetcher.nextBatch(ctx)
+	if rf.batchResponse != nil {
+		rf.batchNumKvs = numKeys
+	}
+	if err != nil {
+		return ok, kv, err
+	}
+	if !ok {
+		return false, kv, nil
+	}
+	return rf.nextKV(ctx)
+}
+
+// NextKey retrieves the next key/value and sets kv/kvEnd. Returns whether a row
+// has been completed.
+func (rf *CFetcher) NextKey(ctx context.Context) (rowDone bool, err error) {
+	var ok bool
+
+	for {
+		ok, rf.kv, err = rf.nextKV(ctx)
+		if err != nil {
+			return false, err
+		}
+		rf.kvEnd = !ok
+		if rf.kvEnd {
+			// No more keys in the scan. We need to transition
+			// rf.rowReadyTable to rf.currentTable for the last
+			// row.
+			rf.rowReadyTable = rf.currentTable
+			return true, nil
+		}
+
+		// unchangedPrefix will be set to true if we can skip decoding the index key
+		// completely, because the last key we saw has identical prefix to the
+		// current key.
+		unchangedPrefix := rf.indexKey != nil && bytes.HasPrefix(rf.kv.Key, rf.indexKey)
+		if unchangedPrefix {
+			keySuffix := rf.kv.Key[len(rf.indexKey):]
+			if _, foundSentinel := encoding.DecodeIfInterleavedSentinel(keySuffix); foundSentinel {
+				// We found an interleaved sentinel, which means that the key we just
+				// found belongs to a different interleave. That means we have to go
+				// through with index key decoding.
+				unchangedPrefix = false
+			} else {
+				rf.keyRemainingBytes = keySuffix
+			}
+		}
+		// See Init() for a detailed description of when we can get away with not
+		// reading the index key.
+		if unchangedPrefix {
+			// Skip decoding!
+			// We must set the rowReadyTable to the currentTable like ReadIndexKey
+			// would do. This will happen when we see 2 rows in a row with the same
+			// prefix. If the previous prefix was from a different table, then we must
+			// update the ready table to the current table, updating the fetcher state
+			// machine to recognize that the next row that it outputs will be from
+			// rf.currentTable, which will be set to the table of the key that was
+			// last sent to ReadIndexKey.
+			//
+			// TODO(jordan): this is a major (but correct) mess. The fetcher is past
+			// due for a refactor, now that it's (more) clear what the state machine
+			// it's trying to model is.
+		} else if rf.mustDecodeIndexKey || rf.traceKV {
+			rf.keyRemainingBytes, ok, err = colencoding.DecodeIndexKeyToCols(
+				rf.currentTable.colvecs,
+				rf.currentTable.rowIdx,
+				rf.currentTable.desc,
+				rf.currentTable.index,
+				rf.currentTable.indexColOrdinals,
+				rf.currentTable.keyValTypes,
+				rf.currentTable.indexColumnDirs,
+				rf.kv.Key[rf.knownPrefixLength:],
+			)
+			if err != nil {
+				return false, err
+			}
+			if !ok {
+				// The key did not match any of the table
+				// descriptors, which means it's interleaved
+				// data from some other table or index.
+				continue
+			}
+		} else {
+			// We still need to consume the key until the family
+			// id, so processKV can know whether we've finished a
+			// row or not.
+			prefixLen, err := keys.GetRowPrefixLength(rf.kv.Key)
+			if err != nil {
+				return false, err
+			}
+			rf.keyRemainingBytes = rf.kv.Key[prefixLen:]
+		}
+
+		// For unique secondary indexes, the index-key does not distinguish one row
+		// from the next if both rows contain identical values along with a NULL.
+		// Consider the keys:
+		//
+		//   /test/unique_idx/NULL/0
+		//   /test/unique_idx/NULL/1
+		//
+		// The index-key extracted from the above keys is /test/unique_idx/NULL. The
+		// trailing /0 and /1 are the primary key used to unique-ify the keys when a
+		// NULL is present. Currently we don't detect NULLs on decoding. If we did
+		// we could detect this case and enlarge the index-key. A simpler fix for
+		// this problem is to simply always output a row for each key scanned from a
+		// secondary index as secondary indexes have only one key per row.
+		// If rf.rowReadyTable differs from rf.currentTable, this denotes
+		// a row is ready for output.
+		switch {
+		case rf.currentTable.isSecondaryIndex:
+			// Secondary indexes have only one key per row.
+			rowDone = true
+		case !bytes.HasPrefix(rf.kv.Key, rf.indexKey):
+			// If the prefix of the key has changed, current key is from a different
+			// row than the previous one.
+			rowDone = true
+		case rf.rowReadyTable != rf.currentTable:
+			// For rowFetchers with more than one table, if the table changes the row
+			// is done.
+			rowDone = true
+		default:
+			rowDone = false
+		}
+
+		if rf.indexKey != nil && rowDone {
+			// The current key belongs to a new row. Output the
+			// current row.
+			rf.indexKey = nil
+			return true, nil
+		}
+
+		return false, nil
+	}
+}
+
+// processKV processes the given key/value, setting values in the row
+// accordingly. If debugStrings is true, returns pretty printed key and value
+// information in prettyKey/prettyValue (otherwise they are empty strings).
+func (rf *CFetcher) processKV(
+	ctx context.Context, kv roachpb.KeyValue,
+) (prettyKey string, prettyValue string, err error) {
+	table := rf.currentTable
+
+	if rf.traceKV {
+		prettyKey = fmt.Sprintf(
+			"/%s/%s?",
+			table.desc.Name,
+			table.index.Name,
+			// TODO(jordan): handle this case. Can pull out values from the column
+			// slices.
+			//rf.prettyEncDatums(table.keyValTypes, table.keyVals),
+		)
+	}
+
+	// Either this is the first key of the fetch or the first key of a new
+	// row.
+	if rf.indexKey == nil {
+		// This is the first key for the row.
+		rf.indexKey = []byte(kv.Key[:len(kv.Key)-len(rf.keyRemainingBytes)])
+
+		// Reset the row to nil; it will get filled in with the column
+		// values as we decode the key-value pairs for the row.
+		// We only need to reset the needed columns in the value component, because
+		// non-needed columns are never set and key columns are unconditionally set
+		// below.
+		for idx, ok := table.neededValueColsByIdx.Next(0); ok; idx, ok = table.neededValueColsByIdx.Next(idx + 1) {
+			// TODO(jordan): null out batch.
+			//table.row[idx].UnsetDatum()
+		}
+
+		rf.valueColsFound = 0
+	}
+
+	if table.neededCols.Empty() {
+		// We don't need to decode any values.
+		if rf.traceKV {
+			prettyValue = tree.DNull.String()
+		}
+		return prettyKey, prettyValue, nil
+	}
+
+	if !table.isSecondaryIndex && len(rf.keyRemainingBytes) > 0 {
+		// If familyID is 0, kv.Value contains values for composite key columns.
+		// These columns already have a table.row value assigned above, but that value
+		// (obtained from the key encoding) might not be correct (e.g. for decimals,
+		// it might not contain the right number of trailing 0s; for collated
+		// strings, it is one of potentially many strings with the same collation
+		// key).
+		//
+		// In these cases, the correct value will be present in family 0 and the
+		// table.row value gets overwritten.
+
+		switch kv.Value.GetTag() {
+		case roachpb.ValueType_TUPLE:
+			// In this case, we don't need to decode the column family ID, because
+			// the ValueType_TUPLE encoding includes the column id with every encoded
+			// column value.
+			prettyKey, prettyValue, err = rf.processValueTuple(ctx, table, kv, prettyKey)
+		default:
+			var familyID uint64
+			_, familyID, err = encoding.DecodeUvarintAscending(rf.keyRemainingBytes)
+			if err != nil {
+				return "", "", scrub.WrapError(scrub.IndexKeyDecodingError, err)
+			}
+
+			var family *sqlbase.ColumnFamilyDescriptor
+			family, err = table.desc.FindFamilyByID(sqlbase.FamilyID(familyID))
+			if err != nil {
+				return "", "", scrub.WrapError(scrub.IndexKeyDecodingError, err)
+			}
+
+			prettyKey, prettyValue, err = rf.processValueSingle(ctx, table, family, kv, prettyKey)
+		}
+		if err != nil {
+			return "", "", scrub.WrapError(scrub.IndexValueDecodingError, err)
+		}
+	} else {
+		valueBytes, err := kv.Value.GetBytes()
+		if err != nil {
+			return "", "", scrub.WrapError(scrub.IndexValueDecodingError, err)
+		}
+
+		if cHasExtraCols(table) {
+			// This is a unique secondary index; decode the extra
+			// column values from the value.
+			var err error
+			valueBytes, err = colencoding.DecodeKeyValsToCols(
+				table.colvecs,
+				table.rowIdx,
+				table.extraValColOrdinals,
+				table.extraTypes,
+				nil,
+				valueBytes,
+			)
+			if err != nil {
+				return "", "", scrub.WrapError(scrub.SecondaryIndexKeyExtraValueDecodingError, err)
+			}
+		}
+
+		if len(valueBytes) > 0 {
+			prettyKey, prettyValue, err = rf.processValueBytes(
+				ctx, table, kv, valueBytes, prettyKey,
+			)
+			if err != nil {
+				return "", "", scrub.WrapError(scrub.IndexValueDecodingError, err)
+			}
+		}
+	}
+
+	if rf.traceKV && prettyValue == "" {
+		prettyValue = tree.DNull.String()
+	}
+
+	return prettyKey, prettyValue, nil
+}
+
+// processValueSingle processes the given value (of column
+// family.DefaultColumnID), setting values in table.row accordingly. The key is
+// only used for logging.
+func (rf *CFetcher) processValueSingle(
+	ctx context.Context,
+	table *cTableInfo,
+	family *sqlbase.ColumnFamilyDescriptor,
+	kv roachpb.KeyValue,
+	prettyKeyPrefix string,
+) (prettyKey string, prettyValue string, err error) {
+	return "", "", errors.New("CFetcher doesn't support directly marshaled single values yet")
+}
+
+func (rf *CFetcher) processValueBytes(
+	ctx context.Context,
+	table *cTableInfo,
+	kv roachpb.KeyValue,
+	valueBytes []byte,
+	prettyKeyPrefix string,
+) (prettyKey string, prettyValue string, err error) {
+	prettyKey = prettyKeyPrefix
+	if rf.traceKV {
+		if rf.prettyValueBuf == nil {
+			rf.prettyValueBuf = &bytes.Buffer{}
+		}
+		rf.prettyValueBuf.Reset()
+	}
+
+	var colIDDiff uint32
+	var lastColID sqlbase.ColumnID
+	var typeOffset, dataOffset int
+	var typ encoding.Type
+	for len(valueBytes) > 0 && rf.valueColsFound < table.neededValueCols {
+		typeOffset, dataOffset, colIDDiff, typ, err = encoding.DecodeValueTag(valueBytes)
+		if err != nil {
+			return "", "", err
+		}
+		colID := lastColID + sqlbase.ColumnID(colIDDiff)
+		lastColID = colID
+		if !table.neededCols.Contains(int(colID)) {
+			// This column wasn't requested, so read its length and skip it.
+			len, err := encoding.PeekValueLengthWithOffsetsAndType(valueBytes, dataOffset, typ)
+			if err != nil {
+				return "", "", err
+			}
+			valueBytes = valueBytes[len:]
+			if debugRowFetch {
+				log.Infof(ctx, "Scan %s -> [%d] (skipped)", kv.Key, colID)
+			}
+			continue
+		}
+		idx := table.colIdxMap[colID]
+
+		if rf.traceKV {
+			prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.desc.Columns[idx].Name)
+		}
+
+		vec := table.batch.ColVec(idx)
+
+		valTyp := &table.cols[idx].Type
+		valueBytes, err = colencoding.DecodeTableValueToCol(vec, table.rowIdx, typ, dataOffset, valTyp, valueBytes[typeOffset:])
+		if err != nil {
+			return "", "", err
+		}
+		if rf.traceKV {
+			fmt.Fprintf(rf.prettyValueBuf, "/?")
+		}
+		rf.valueColsFound++
+	}
+	if rf.traceKV {
+		prettyValue = rf.prettyValueBuf.String()
+	}
+	return prettyKey, prettyValue, nil
+}
+
+// processValueTuple processes the given values (of columns family.ColumnIDs),
+// setting values in the rf.row accordingly. The key is only used for logging.
+func (rf *CFetcher) processValueTuple(
+	ctx context.Context, table *cTableInfo, kv roachpb.KeyValue, prettyKeyPrefix string,
+) (prettyKey string, prettyValue string, err error) {
+	tupleBytes, err := kv.Value.GetTuple()
+	if err != nil {
+		return "", "", err
+	}
+	return rf.processValueBytes(ctx, table, kv, tupleBytes, prettyKeyPrefix)
+}
+
+// NextBatch processes keys until we complete one batch of rows, ColBatchSize
+// in length, which are returned in columnar format as an exec.ColBatch. The
+// batch contains one ColVec per table column, regardless of the index used;
+// columns that are not needed (as per neededCols) are empty. The
+// ColBatch should not be modified and is only valid until the next call.
+// When there are no more rows, the ColBatch.Length is 0.
+// It also returns the table and index descriptor associated with the row
+// (relevant when more than one table is specified during initialization).
+func (rf *CFetcher) NextBatch(
+	ctx context.Context,
+) (
+	batch exec.ColBatch,
+	table *sqlbase.TableDescriptor,
+	index *sqlbase.IndexDescriptor,
+	err error,
+) {
+	rf.rowReadyTable.rowIdx = 0
+	if rf.kvEnd {
+		rf.rowReadyTable.batch.SetLength(0)
+		return rf.rowReadyTable.batch, nil, nil, nil
+	}
+
+	// All of the columns for a particular row will be grouped together. We
+	// loop over the key/value pairs and decode the key to extract the
+	// columns encoded within the key and the column ID. We use the column
+	// ID to lookup the column and decode the value. All of these values go
+	// into a map keyed by column name. When the index key changes we
+	// output a row containing the current values.
+	for rf.rowReadyTable.rowIdx < exec.ColBatchSize {
+		prettyKey, prettyVal, err := rf.processKV(ctx, rf.kv)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if rf.traceKV {
+			log.VEventf(ctx, 2, "fetched: %s -> %s", prettyKey, prettyVal)
+		}
+
+		rowDone, err := rf.NextKey(ctx)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if rowDone {
+			err := rf.finalizeRow()
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			rf.rowReadyTable.rowIdx++
+		}
+		if rf.kvEnd {
+			break
+		}
+	}
+	rf.rowReadyTable.batch.SetLength(rf.rowReadyTable.rowIdx)
+	return rf.rowReadyTable.batch, rf.rowReadyTable.desc, rf.rowReadyTable.index, err
+}
+
+func (rf *CFetcher) finalizeRow() error {
+	table := rf.rowReadyTable
+	// Fill in any missing values with NULLs
+	for i := range table.cols {
+		if rf.valueColsFound == table.neededValueCols {
+			// Found all cols - done!
+			return nil
+		}
+		if table.neededCols.Contains(int(table.cols[i].ID)) && table.batch.ColVec(i).NullAt(table.rowIdx) {
+			// If the row was deleted, we'll be missing any non-primary key
+			// columns, including nullable ones, but this is expected.
+			if !table.cols[i].Nullable {
+				var indexColValues []string
+				for i := range table.indexColOrdinals {
+					indexColValues = append(indexColValues, "?"+string(i))
+				}
+				if rf.isCheck {
+					return scrub.WrapError(scrub.UnexpectedNullValueError, errors.Errorf(
+						"Non-nullable column \"%s:%s\" with no value! Index scanned was %q with the index key columns (%s) and the values (%s)",
+						table.desc.Name, table.cols[i].Name, table.index.Name,
+						strings.Join(table.index.ColumnNames, ","), strings.Join(indexColValues, ",")))
+				}
+				panic(fmt.Sprintf(
+					"Non-nullable column \"%s:%s\" with no value! Index scanned was %q with the index key columns (%s) and the values (%s)",
+					table.desc.Name, table.cols[i].Name, table.index.Name,
+					strings.Join(table.index.ColumnNames, ","), strings.Join(indexColValues, ",")))
+			}
+			table.colvecs[i].SetNull(table.rowIdx)
+			// We've set valueColsFound to the number of present columns in the row
+			// already, in processValueBytes. Now, we're filling in columns that have
+			// no encoded values with NULL - so we increment valueColsFound to permit
+			// early exit from this loop once all needed columns are filled in.
+			rf.valueColsFound++
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This commit adds optional, best-effort flow setup time planning of
columnar operators. When experimental_vectorize is set, flow setup will
attempt to convert DistSQL Processors into their columnar Operator
equivalents, if such equivalents exist.

Release note (sql change): the experimental_vectorize session setting,
when enabled, causes columnar operators to be planned instead of
row-by-row processors, when possible.

Release note: None