### PR TITLE
release-2.1: build: check out submodules before yarn install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ $(GITHOOKSDIR)/%: githooks/%
 endif
 
 .SECONDARY: pkg/ui/yarn.installed
-pkg/ui/yarn.installed: pkg/ui/package.json pkg/ui/yarn.lock pkg/ui/yarn.protobufjs-cli.lock
+pkg/ui/yarn.installed: pkg/ui/package.json pkg/ui/yarn.lock pkg/ui/yarn.protobufjs-cli.lock | bin/.submodules-initialized
 	$(NODE_RUN) -C pkg/ui yarn install --offline
 	# Prevent ProtobufJS from trying to install its own packages because a) the
 	# the feature is buggy, and b) it introduces an unnecessary dependency on NPM.


### PR DESCRIPTION
Backport 1/1 commits from #30993.

/cc @cockroachdb/release

---

`yarn install` requires the yarn-vendor submodule to be available.
This was missed when we started vendoring our Yarn dependencies in
PR #27035.

Fix #30619.

Release note: None
