### PR TITLE
release-2.1: ui: Have the range debug page correctly handle missing lease times

### DIFF
--- a/pkg/ui/src/views/reports/containers/range/rangeTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/rangeTable.tsx
@@ -192,10 +192,16 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
   }
 
   contentTimestamp(timestamp: protos.cockroach.util.hlc.ITimestamp): RangeTableCellContent {
+    if (_.isNil(timestamp) || _.isNil(timestamp.wall_time)) {
+      return {
+        value: ["no timestamp"],
+        className: ["range-table__cell--warning"],
+      };
+    }
     const humanized = Print.Timestamp(timestamp);
     return {
       value: [humanized],
-      title: [humanized, timestamp.wall_time.toString()],
+      title: [humanized, FixLong(timestamp.wall_time).toString()],
     };
   }
 


### PR DESCRIPTION
Backport 1/1 commits from #31362.

/cc @cockroachdb/release

---

Before this change, the value was always assumed to be not-null and it was null
would crash. It will now correctly handled the missing value and display a
`no timestamp` warning.

Fixes #31260.

Release note (bug fix): The range debug page will now correctly handle cases in
which there is no lease start or expiration time.

![screen shot 2018-10-15 at 10 35 07](https://user-images.githubusercontent.com/1614265/46958094-08a46300-d067-11e8-92cb-182882f8dd19.png)

