### PR TITLE
storage: avoid race in TestMergeQueue

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -2656,7 +2656,7 @@ func TestMergeQueue(t *testing.T) {
 		verifyUnmerged(t)
 
 		// Once the maximum size threshold is increased, the merge can occur.
-		*zone.RangeMaxBytes += 1
+		zone.RangeMaxBytes = proto.Int64(*zone.RangeMaxBytes + 1)
 		setZones(zone)
 		store.ForceMergeScanAndProcess()
 		verifyMerged(t)


### PR DESCRIPTION
It is not legal to modify the values pointed to by a zone config. (This
race was recently introduced in 2692aba1.)

Fix #31331.

Release note: None