### PR TITLE
release-2.1: storage: Jitter the StoreRebalancer loop's timing

### DIFF
--- a/pkg/storage/store_rebalancer.go
+++ b/pkg/storage/store_rebalancer.go
@@ -17,6 +17,7 @@ package storage
 import (
 	"context"
 	"math"
+	"math/rand"
 	"sort"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"go.etcd.io/etcd/raft"
 )
 
@@ -174,8 +176,9 @@ func (sr *StoreRebalancer) Start(ctx context.Context, stopper *stop.Stopper) {
 	// Start a goroutine that watches and proactively renews certain
 	// expiration-based leases.
 	stopper.RunWorker(ctx, func(ctx context.Context) {
-		ticker := time.NewTicker(storeRebalancerTimerDuration)
-		defer ticker.Stop()
+		timer := timeutil.NewTimer()
+		defer timer.Stop()
+		timer.Reset(jitteredInterval(storeRebalancerTimerDuration))
 		for {
 			// Wait out the first tick before doing anything since the store is still
 			// starting up and we might as well wait for some qps/wps stats to
@@ -183,7 +186,9 @@ func (sr *StoreRebalancer) Start(ctx context.Context, stopper *stop.Stopper) {
 			select {
 			case <-stopper.ShouldQuiesce():
 				return
-			case <-ticker.C:
+			case <-timer.C:
+				timer.Read = true
+				timer.Reset(jitteredInterval(storeRebalancerTimerDuration))
 			}
 
 			if !sr.st.Version.IsMinSupported(cluster.VersionLoadBasedRebalancing) {
@@ -698,4 +703,10 @@ func storeListToMap(sl StoreList) map[roachpb.StoreID]*roachpb.StoreDescriptor {
 		storeMap[sl.stores[i].StoreID] = &sl.stores[i]
 	}
 	return storeMap
+}
+
+// jitteredInterval returns a randomly jittered (+/-25%) duration
+// from checkInterval.
+func jitteredInterval(interval time.Duration) time.Duration {
+	return time.Duration(float64(interval) * (0.75 + 0.5*rand.Float64()))
 }


### PR DESCRIPTION
Backport 1/1 commits from #31227.

/cc @cockroachdb/release

---

Release note: None

Just as a best practice. It may make failures like https://github.com/cockroachdb/cockroach/issues/31006 even less likely, although it's hard to say for sure.

---

Opening the PR just to get a final yes/no on this. The code has been tested more thoroughly without this change, so I'm fine to skip it, but there's also a benefit to all future master/2.2 testing being applicable to what's running in 2.1, rather than having 2.1 running code that is effectively only being tested in prod.