### PR TITLE
roachtest: Deflake bank/zerosum-splits' RelocateRange problem

### DIFF
--- a/pkg/cmd/roachtest/bank.go
+++ b/pkg/cmd/roachtest/bank.go
@@ -322,7 +322,7 @@ func (s *bankState) splitMonkey(ctx context.Context, d time.Duration, c *cluster
 }
 
 func isExpectedRelocateError(err error) bool {
-	return testutils.IsError(err, "(descriptor changed|unable to remove replica .* which is not present|unable to add replica .* which is already present)")
+	return testutils.IsError(err, "(descriptor changed|unable to remove replica .* which is not present|unable to add replica .* which is already present|received invalid ChangeReplicasTrigger .* to remove self)")
 }
 
 func accountDistribution(r *rand.Rand) *rand.Zipf {


### PR DESCRIPTION
Touches #31287

Release note: None