### PR TITLE
opt: build IS OF (...) expression

### DIFF
--- a/pkg/sql/opt/idxconstraint/testdata/misc
+++ b/pkg/sql/opt/idxconstraint/testdata/misc
@@ -186,7 +186,6 @@ index-constraints vars=(int, int) index=(@1, @2)
 @1 = 1 AND @2 IS OF (INT)
 ----
 [/1 - /1]
-Remaining filter: @2 IS OF (INT)
 
 # This testcase exposed an issue around extending spans. We don't normalize the
 # expression so we have a hierarchy of ANDs (which requires a more complex path

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -1031,3 +1031,29 @@ tuple [type=tuple{int, string, float}]
  └── indirection [type=float]
       ├── variable: @3 [type=float[]]
       └── variable: @4 [type=int]
+
+build-scalar vars=(int,string,int[])
+(
+    (@1 IS OF (INT), @1 IS OF (INT, STRING), @1 IS OF (STRING)),
+    (@1 IS NOT OF (INT), @1 IS NOT OF (INT, STRING), @1 IS NOT OF (STRING)),
+    (@2 IS NOT OF (INT), @2 IS NOT OF (INT, STRING), @2 IS NOT OF (STRING)),
+    (@3 IS NOT OF (INT[]), @3 IS OF (INT[]), @3 IS OF (STRING[]))
+)
+----
+tuple [type=tuple{tuple{bool, bool, bool}, tuple{bool, bool, bool}, tuple{bool, bool, bool}, tuple{bool, bool, bool}}]
+ ├── tuple [type=tuple{bool, bool, bool}]
+ │    ├── true [type=bool]
+ │    ├── true [type=bool]
+ │    └── false [type=bool]
+ ├── tuple [type=tuple{bool, bool, bool}]
+ │    ├── false [type=bool]
+ │    ├── false [type=bool]
+ │    └── true [type=bool]
+ ├── tuple [type=tuple{bool, bool, bool}]
+ │    ├── true [type=bool]
+ │    ├── false [type=bool]
+ │    └── false [type=bool]
+ └── tuple [type=tuple{bool, bool, bool}]
+      ├── false [type=bool]
+      ├── true [type=bool]
+      └── false [type=bool]

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3630,7 +3630,7 @@ func (expr *IsOfTypeExpr) Eval(ctx *EvalContext) (Datum, error) {
 
 	for _, t := range expr.Types {
 		wantTyp := coltypes.CastTargetToDatumType(t)
-		if datumTyp.FamilyEqual(wantTyp) {
+		if datumTyp.Equivalent(wantTyp) {
 			return MakeDBool(DBool(!expr.Not)), nil
 		}
 	}

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -785,6 +785,14 @@ func TestEval(t *testing.T) {
 		{`'hello' IS OF (BYTES)`, `false`},
 		{`b'hello' IS OF (STRING)`, `false`},
 		{`b'hello' IS OF (BYTES)`, `true`},
+		{`ARRAY['hello']::STRING[] IS OF (STRING[])`, `true`},
+		{`ARRAY['hello']::STRING[] IS OF (INT[])`, `false`},
+		{`3::INT2 IS OF (INT2)`, `true`},
+
+		// TODO(justin): these are currently incorrect, see #31404.
+		{`3 IS OF (INT2)`, `true`},
+		{`3::INT4 IS OF (INT2)`, `true`},
+
 		{`'2012-09-21'::date IS OF (DATE)`, `true`},
 		{`'12:00:00'::time IS OF (TIME)`, `true`},
 		{`'2010-09-28 12:00:00.1'::timestamp IS OF (TIMESTAMP)`, `true`},


### PR DESCRIPTION
This commit builds expressions of the form x IS OF (...). This is an
optbuilder-only change since the value of such an expression is always
known at plan time.

This commit also partially fixes a bug in the heuristic planner's
implementation of this feature by using `Equivalent` instead of
`FamilyEqual` to compare types, resulting in `INT[]` being considered
distinct from `STRING[]`. It also exposes a bug that I think is
difficult to fix at the moment, which is that the lack of a 1-1 mapping
between datum and column types means the following is incorrectly
reported as true:

```
3::INT2 IS OF (INT4)
```

I've added relevant test cases and added a TODO for that case.

Tagging @knz for the heuristic planner change and also to put the
remaining type-related bug on his radar.

Release note (bug fix): Fixed IS OF (...) expressions to no longer
report arrays with different element types as being the same.