### PR TITLE
release-2.1: storage: re-enable the merge queue by default

### DIFF
--- a/pkg/sql/distsqlplan/span_resolver_test.go
+++ b/pkg/sql/distsqlplan/span_resolver_test.go
@@ -316,6 +316,11 @@ func TestMixedDirections(t *testing.T) {
 func setupRanges(
 	db *gosql.DB, s *server.TestServer, cdb *client.DB, t *testing.T,
 ) ([]roachpb.RangeDescriptor, *sqlbase.TableDescriptor) {
+	// Prevent the merge queue from immediately discarding our splits.
+	if _, err := db.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false"); err != nil {
+		t.Fatal(err)
+	}
+
 	if _, err := db.Exec(`CREATE DATABASE t`); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -346,6 +346,7 @@ ORDER BY "timestamp"
 ----
 0  1  {"SettingName":"diagnostics.reporting.enabled","Value":"true","User":"root"}
 0  1  {"SettingName":"trace.debug.enable","Value":"false","User":"root"}
+0  1  {"SettingName":"kv.range_merge.queue_enabled","Value":"false","User":"root"}
 0  1  {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"false","User":"root"}
 0  1  {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"DEFAULT","User":"root"}
 0  1  {"SettingName":"cluster.organization","Value":"'some string'","User":"root"}

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -428,6 +428,7 @@ ORDER BY name
 ----
 cluster.secret
 diagnostics.reporting.enabled
+kv.range_merge.queue_enabled
 trace.debug.enable
 version
 
@@ -441,6 +442,7 @@ WHERE name NOT IN ('version', 'sql.defaults.distsql', 'cluster.secret')
 ORDER BY name
 ----
 diagnostics.reporting.enabled  true
+kv.range_merge.queue_enabled   false
 somesetting                    somevalue
 trace.debug.enable             false
 

--- a/pkg/storage/log_test.go
+++ b/pkg/storage/log_test.go
@@ -148,7 +148,13 @@ func TestLogMerges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Store: &storage.StoreTestingKnobs{
+				DisableMergeQueue: true,
+			},
+		},
+	})
 	defer s.Stopper().Stop(ctx)
 
 	ts := s.(*server.TestServer)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -1460,7 +1460,9 @@ func TestStoreSetRangesMaxBytes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
-	store, _ := createTestStore(t, stopper)
+	cfg := TestStoreConfig(nil)
+	cfg.TestingKnobs.DisableMergeQueue = true
+	store := createTestStoreWithConfig(t, stopper, &cfg)
 
 	baseID := uint32(keys.MinUserDescID)
 	testData := []struct {


### PR DESCRIPTION
Backport 4/6 commits from #29583.

/cc @cockroachdb/release

---

This reverts commit a1cc4c5540501f570db0b46b6f8adfed788b86e1.

The results from last night's stress run on were extremely promising. All the failures were existing flaky tests. You can see for yourself here:

https://teamcity.cockroachdb.com/viewType.html?buildTypeId=Cockroach_Nightlies_Stress&tab=buildTypeStatusDiv&branch_Cockroach_Nightlies=refs%2Fheads%2Fmerge-default&state=failed
