### PR TITLE
workload: switch tpcc to pgx and SQLRunner

### DIFF
--- a/pkg/workload/tpcc/delivery.go
+++ b/pkg/workload/tpcc/delivery.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/pkg/errors"
 )
 
@@ -47,16 +48,40 @@ import (
 
 type delivery struct {
 	config *tpcc
-	db     *gosql.DB
+	mcp    *workload.MultiConnPool
+	sr     workload.SQLRunner
+
+	selectNewOrder workload.StmtHandle
+	sumAmount      workload.StmtHandle
 }
 
 var _ tpccTx = &delivery{}
 
-func createDelivery(ctx context.Context, config *tpcc, db *gosql.DB) (tpccTx, error) {
+func createDelivery(
+	ctx context.Context, config *tpcc, mcp *workload.MultiConnPool,
+) (tpccTx, error) {
 	del := &delivery{
 		config: config,
-		db:     db,
+		mcp:    mcp,
 	}
+
+	del.selectNewOrder = del.sr.Define(`
+		SELECT no_o_id
+		FROM new_order
+		WHERE no_w_id = $1 AND no_d_id = $2
+		ORDER BY no_o_id ASC
+		LIMIT 1`,
+	)
+
+	del.sumAmount = del.sr.Define(`
+		SELECT sum(ol_amount) FROM order_line
+		WHERE ol_w_id = $1 AND ol_d_id = $2 AND ol_o_id = $3`,
+	)
+
+	if err := del.sr.Init(ctx, "delivery", mcp, config.connFlags); err != nil {
+		return nil, err
+	}
+
 	return del, nil
 }
 
@@ -68,23 +93,19 @@ func (del *delivery) run(ctx context.Context, wID int) (interface{}, error) {
 	oCarrierID := rng.Intn(10) + 1
 	olDeliveryD := timeutil.Now()
 
-	err := crdb.ExecuteTx(
-		ctx,
-		del.db,
-		del.config.txOpts,
-		func(tx *gosql.Tx) error {
+	tx, err := del.mcp.Get().BeginEx(ctx, del.config.txOpts)
+	if err != nil {
+		return nil, err
+	}
+	err = crdb.ExecuteInTx(
+		ctx, (*workload.PgxTx)(tx),
+		func() error {
 			// 2.7.4.2. For each district:
 			dIDoIDPairs := make(map[int]int)
 			dIDolTotalPairs := make(map[int]float64)
 			for dID := 1; dID <= 10; dID++ {
 				var oID int
-				if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-					SELECT no_o_id
-					FROM new_order
-					WHERE no_w_id = %d AND no_d_id = %d
-					ORDER BY no_o_id ASC
-					LIMIT 1`,
-					wID, dID)).Scan(&oID); err != nil {
+				if err := del.selectNewOrder.QueryRowTx(ctx, tx, wID, dID).Scan(&oID); err != nil {
 					// If no matching order is found, the delivery of this order is skipped.
 					if err != gosql.ErrNoRows {
 						atomic.AddUint64(&del.config.auditor.skippedDelivieries, 1)
@@ -95,22 +116,26 @@ func (del *delivery) run(ctx context.Context, wID int) (interface{}, error) {
 				dIDoIDPairs[dID] = oID
 
 				var olTotal float64
-				if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-						SELECT sum(ol_amount) FROM order_line
-						WHERE ol_w_id = %d AND ol_d_id = %d AND ol_o_id = %d`,
-					wID, dID, oID)).Scan(&olTotal); err != nil {
+				if err := del.sumAmount.QueryRowTx(
+					ctx, tx, wID, dID, oID,
+				).Scan(&olTotal); err != nil {
 					return err
 				}
 				dIDolTotalPairs[dID] = olTotal
 			}
 			dIDoIDPairsStr := makeInTuples(dIDoIDPairs)
 
-			rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+			rows, err := tx.QueryEx(
+				ctx,
+				fmt.Sprintf(`
 					UPDATE "order"
 					SET o_carrier_id = %d
 					WHERE o_w_id = %d AND (o_d_id, o_id) IN (%s)
 					RETURNING o_d_id, o_c_id`,
-				oCarrierID, wID, dIDoIDPairsStr))
+					oCarrierID, wID, dIDoIDPairsStr,
+				),
+				nil, /* options */
+			)
 			if err != nil {
 				return err
 			}
@@ -134,25 +159,41 @@ func (del *delivery) run(ctx context.Context, wID int) (interface{}, error) {
 			dIDcIDPairsStr := makeInTuples(dIDcIDPairs)
 			dIDToOlTotalStr := makeWhereCases(dIDolTotalPairs)
 
-			if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
-				UPDATE customer
-				SET c_delivery_cnt = c_delivery_cnt + 1,
-					c_balance = c_balance + CASE c_d_id %s END
-				WHERE c_w_id = %d AND (c_d_id, c_id) IN (%s)`,
-				dIDToOlTotalStr, wID, dIDcIDPairsStr)); err != nil {
+			if _, err := tx.ExecEx(
+				ctx,
+				fmt.Sprintf(`
+					UPDATE customer
+					SET c_delivery_cnt = c_delivery_cnt + 1,
+						c_balance = c_balance + CASE c_d_id %s END
+					WHERE c_w_id = %d AND (c_d_id, c_id) IN (%s)`,
+					dIDToOlTotalStr, wID, dIDcIDPairsStr,
+				),
+				nil, /* options */
+			); err != nil {
 				return err
 			}
-			if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
-				DELETE FROM new_order
-				WHERE no_w_id = %d AND (no_d_id, no_o_id) IN (%s)`,
-				wID, dIDoIDPairsStr)); err != nil {
+			if _, err := tx.ExecEx(
+				ctx,
+				fmt.Sprintf(`
+					DELETE FROM new_order
+					WHERE no_w_id = %d AND (no_d_id, no_o_id) IN (%s)`,
+					wID, dIDoIDPairsStr,
+				),
+				nil, /* options */
+			); err != nil {
 				return err
 			}
-			_, err = tx.ExecContext(ctx, fmt.Sprintf(`
-				UPDATE order_line
-				SET ol_delivery_d = '%s'
-				WHERE ol_w_id = %d AND (ol_d_id, ol_o_id) IN (%s)`,
-				olDeliveryD.Format("2006-01-02 15:04:05"), wID, dIDoIDPairsStr))
+
+			_, err = tx.ExecEx(
+				ctx,
+				fmt.Sprintf(`
+					UPDATE order_line
+					SET ol_delivery_d = '%s'
+					WHERE ol_w_id = %d AND (ol_d_id, ol_o_id) IN (%s)`,
+					olDeliveryD.Format("2006-01-02 15:04:05"), wID, dIDoIDPairsStr,
+				),
+				nil, /* options */
+			)
 			return err
 		})
 	return nil, err

--- a/pkg/workload/tpcc/new_order.go
+++ b/pkg/workload/tpcc/new_order.go
@@ -16,7 +16,6 @@
 package tpcc
 
 import (
-	gosql "database/sql"
 	"fmt"
 	"math/rand"
 	"sort"
@@ -29,6 +28,7 @@ import (
 
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
 )
@@ -79,16 +79,60 @@ var errSimulated = errors.New("simulated user error")
 
 type newOrder struct {
 	config *tpcc
-	db     *gosql.DB
+	mcp    *workload.MultiConnPool
+	sr     workload.SQLRunner
+
+	updateDistrict     workload.StmtHandle
+	selectWarehouseTax workload.StmtHandle
+	selectCustomerInfo workload.StmtHandle
+	insertOrder        workload.StmtHandle
+	insertNewOrder     workload.StmtHandle
 }
 
 var _ tpccTx = &newOrder{}
 
-func createNewOrder(ctx context.Context, config *tpcc, db *gosql.DB) (tpccTx, error) {
+func createNewOrder(
+	ctx context.Context, config *tpcc, mcp *workload.MultiConnPool,
+) (tpccTx, error) {
 	n := &newOrder{
 		config: config,
-		db:     db,
+		mcp:    mcp,
 	}
+
+	// Select the district tax rate and next available order number, bumping it.
+	n.updateDistrict = n.sr.Define(`
+		UPDATE district
+		SET d_next_o_id = d_next_o_id + 1
+		WHERE d_w_id = $1 AND d_id = $2
+		RETURNING d_tax, d_next_o_id`,
+	)
+
+	// Select the warehouse tax rate.
+	n.selectWarehouseTax = n.sr.Define(`
+		SELECT w_tax FROM warehouse WHERE w_id = $1`,
+	)
+
+	// Select the customer's discount, last name and credit.
+	n.selectCustomerInfo = n.sr.Define(`
+		SELECT c_discount, c_last, c_credit
+		FROM customer
+		WHERE c_w_id = $1 AND c_d_id = $2 AND c_id = $3`,
+	)
+
+	n.insertOrder = n.sr.Define(`
+		INSERT INTO "order" (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+	)
+
+	n.insertNewOrder = n.sr.Define(`
+		INSERT INTO new_order (no_o_id, no_d_id, no_w_id) 
+		VALUES ($1, $2, $3)`,
+	)
+
+	if err := n.sr.Init(ctx, "new-order", mcp, config.connFlags); err != nil {
+		return nil, err
+	}
+
 	return n, nil
 }
 
@@ -169,38 +213,32 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 
 	d.oEntryD = timeutil.Now()
 
-	err := crdb.ExecuteTx(
-		ctx,
-		n.db,
-		n.config.txOpts,
-		func(tx *gosql.Tx) error {
+	tx, err := n.mcp.Get().BeginEx(ctx, n.config.txOpts)
+	if err != nil {
+		return nil, err
+	}
+	err = crdb.ExecuteInTx(
+		ctx, (*workload.PgxTx)(tx),
+		func() error {
 			// Select the district tax rate and next available order number, bumping it.
 			var dNextOID int
-			if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-				UPDATE district
-				SET d_next_o_id = d_next_o_id + 1
-				WHERE d_w_id = %[1]d AND d_id = %[2]d
-				RETURNING d_tax, d_next_o_id`,
-				d.wID, d.dID),
+			if err := n.updateDistrict.QueryRowTx(
+				ctx, tx, d.wID, d.dID,
 			).Scan(&d.dTax, &dNextOID); err != nil {
 				return err
 			}
 			d.oID = dNextOID - 1
 
 			// Select the warehouse tax rate.
-			if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-				SELECT w_tax FROM warehouse WHERE w_id = %[1]d`,
-				wID),
+			if err := n.selectWarehouseTax.QueryRowTx(
+				ctx, tx, wID,
 			).Scan(&d.wTax); err != nil {
 				return err
 			}
 
 			// Select the customer's discount, last name and credit.
-			if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-				SELECT c_discount, c_last, c_credit
-				FROM customer
-				WHERE c_w_id = %[1]d AND c_d_id = %[2]d AND c_id = %[3]d`,
-				d.wID, d.dID, d.cID),
+			if err := n.selectCustomerInfo.QueryRowTx(
+				ctx, tx, d.wID, d.dID, d.cID,
 			).Scan(&d.cDiscount, &d.cLast, &d.cCredit); err != nil {
 				return err
 			}
@@ -212,12 +250,16 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 			for i, item := range d.items {
 				itemIDs[i] = fmt.Sprint(item.olIID)
 			}
-			rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
-				SELECT i_price, i_name, i_data
-				FROM item
-				WHERE i_id IN (%[1]s)
-				ORDER BY i_id`,
-				strings.Join(itemIDs, ", ")),
+			rows, err := tx.QueryEx(
+				ctx,
+				fmt.Sprintf(`
+					SELECT i_price, i_name, i_data
+					FROM item
+					WHERE i_id IN (%[1]s)
+					ORDER BY i_id`,
+					strings.Join(itemIDs, ", "),
+				),
+				nil, /* options */
 			)
 			if err != nil {
 				return err
@@ -261,12 +303,16 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 			for i, item := range d.items {
 				stockIDs[i] = fmt.Sprintf("(%d, %d)", item.olIID, item.olSupplyWID)
 			}
-			rows, err = tx.QueryContext(ctx, fmt.Sprintf(`
-				SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_%02[1]d
-				FROM stock
-				WHERE (s_i_id, s_w_id) IN (%[2]s)
-				ORDER BY s_i_id`,
-				d.dID, strings.Join(stockIDs, ", ")),
+			rows, err = tx.QueryEx(
+				ctx,
+				fmt.Sprintf(`
+					SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_%02[1]d
+					FROM stock
+					WHERE (s_i_id, s_w_id) IN (%[2]s)
+					ORDER BY s_i_id`,
+					d.dID, strings.Join(stockIDs, ", "),
+				),
+				nil, /* options */
 			)
 			if err != nil {
 				return err
@@ -324,35 +370,36 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 			rows.Close()
 
 			// Insert row into the orders and new orders table.
-			if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
-				INSERT INTO "order" (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local)
-				VALUES (%[1]d, %[2]d, %[3]d, %[4]d, '%[5]s', %[6]d, %[7]d)`,
-				d.oID, d.dID, d.wID, d.cID, d.oEntryD.Format("2006-01-02 15:04:05"),
-				d.oOlCnt, allLocal),
+			if _, err := n.insertOrder.ExecTx(
+				ctx, tx,
+				d.oID, d.dID, d.wID, d.cID, d.oEntryD.Format("2006-01-02 15:04:05"), d.oOlCnt, allLocal,
 			); err != nil {
 				return err
 			}
-			if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
-				INSERT INTO new_order (no_o_id, no_d_id, no_w_id) 
-				VALUES (%[1]d, %[2]d, %[3]d)`,
-				d.oID, d.dID, d.wID)); err != nil {
+			if _, err := n.insertNewOrder.ExecTx(
+				ctx, tx, d.oID, d.dID, d.wID,
+			); err != nil {
 				return err
 			}
 
 			// Update the stock table for each item.
-			if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
-				UPDATE stock
-				SET
-					s_quantity = CASE (s_i_id, s_w_id) %[1]s ELSE crdb_internal.force_error('', 'unknown case') END,
-					s_ytd = CASE (s_i_id, s_w_id) %[2]s END,
-					s_order_cnt = CASE (s_i_id, s_w_id) %[3]s END,
-					s_remote_cnt = CASE (s_i_id, s_w_id) %[4]s END
-				WHERE (s_i_id, s_w_id) IN (%[5]s)`,
-				strings.Join(sQuantityUpdateCases, " "),
-				strings.Join(sYtdUpdateCases, " "),
-				strings.Join(sOrderCntUpdateCases, " "),
-				strings.Join(sRemoteCntUpdateCases, " "),
-				strings.Join(stockIDs, ", ")),
+			if _, err := tx.ExecEx(
+				ctx,
+				fmt.Sprintf(`
+					UPDATE stock
+					SET
+						s_quantity = CASE (s_i_id, s_w_id) %[1]s ELSE crdb_internal.force_error('', 'unknown case') END,
+						s_ytd = CASE (s_i_id, s_w_id) %[2]s END,
+						s_order_cnt = CASE (s_i_id, s_w_id) %[3]s END,
+						s_remote_cnt = CASE (s_i_id, s_w_id) %[4]s END
+					WHERE (s_i_id, s_w_id) IN (%[5]s)`,
+					strings.Join(sQuantityUpdateCases, " "),
+					strings.Join(sYtdUpdateCases, " "),
+					strings.Join(sOrderCntUpdateCases, " "),
+					strings.Join(sRemoteCntUpdateCases, " "),
+					strings.Join(stockIDs, ", "),
+				),
+				nil, /* options */
 			); err != nil {
 				return err
 			}
@@ -376,10 +423,14 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 					distInfos[i],     // ol_dist_info
 				)
 			}
-			if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
-				INSERT INTO order_line(ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info)
-				VALUES %s`,
-				strings.Join(olValsStrings, ", ")),
+			if _, err := tx.ExecEx(
+				ctx,
+				fmt.Sprintf(`
+					INSERT INTO order_line(ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info)
+					VALUES %s`,
+					strings.Join(olValsStrings, ", "),
+				),
+				nil, /* options */
 			); err != nil {
 				return err
 			}

--- a/pkg/workload/tpcc/order_status.go
+++ b/pkg/workload/tpcc/order_status.go
@@ -16,11 +16,11 @@
 package tpcc
 
 import (
-	gosql "database/sql"
 	"math/rand"
 	"sync/atomic"
 	"time"
 
+	"github.com/jackc/pgx/pgtype"
 	"github.com/pkg/errors"
 
 	"context"
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload"
 )
 
 // From the TPCC spec, section 2.6:
@@ -49,7 +50,7 @@ type orderStatusData struct {
 	cBalance   float64
 	oID        int
 	oEntryD    time.Time
-	oCarrierID gosql.NullInt64
+	oCarrierID pgtype.Int8
 
 	items []orderItem
 }
@@ -63,16 +64,66 @@ type customerData struct {
 
 type orderStatus struct {
 	config *tpcc
-	db     *gosql.DB
+	mcp    *workload.MultiConnPool
+	sr     workload.SQLRunner
+
+	selectByCustID   workload.StmtHandle
+	selectByLastName workload.StmtHandle
+	selectOrder      workload.StmtHandle
+	selectItems      workload.StmtHandle
 }
 
 var _ tpccTx = &orderStatus{}
 
-func createOrderStatus(ctx context.Context, config *tpcc, db *gosql.DB) (tpccTx, error) {
+func createOrderStatus(
+	ctx context.Context, config *tpcc, mcp *workload.MultiConnPool,
+) (tpccTx, error) {
 	o := &orderStatus{
 		config: config,
-		db:     db,
+		mcp:    mcp,
 	}
+
+	// Select by customer id.
+	o.selectByCustID = o.sr.Define(`
+		SELECT c_balance, c_first, c_middle, c_last
+		FROM customer
+		WHERE c_w_id = $1 AND c_d_id = $2 AND c_id = $3`,
+	)
+
+	// TODO(radu): this is only useful for the heuristic planner.
+	indexStr := "@customer_idx"
+	if o.config.usePostgres {
+		indexStr = ""
+	}
+
+	// Pick the middle row, rounded up, from the selection by last name.
+	o.selectByLastName = o.sr.Define(fmt.Sprintf(`
+		SELECT c_id, c_balance, c_first, c_middle
+		FROM customer%s
+		WHERE c_w_id = $1 AND c_d_id = $2 AND c_last = $3
+		ORDER BY c_first ASC`, indexStr),
+	)
+
+	// Select the customer's order.
+	o.selectOrder = o.sr.Define(`
+		SELECT o_id, o_entry_d, o_carrier_id
+		FROM "order"
+		WHERE o_w_id = $1 AND o_d_id = $2 AND o_c_id = $3
+		ORDER BY o_id DESC
+		LIMIT 1`,
+	)
+
+	// Select the items from the customer's order.
+	o.selectItems = o.sr.Define(`
+		SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
+		FROM order_line
+		WHERE ol_w_id = $1 AND ol_d_id = $2 AND ol_o_id = $3`,
+	)
+
+	if err := o.sr.Init(ctx, "order-status", mcp, config.connFlags); err != nil {
+		return nil, err
+	}
+
 	return o, nil
 }
 
@@ -94,37 +145,26 @@ func (o *orderStatus) run(ctx context.Context, wID int) (interface{}, error) {
 		d.cID = randCustomerID(rng)
 	}
 
-	if err := crdb.ExecuteTx(
-		ctx,
-		o.db,
-		o.config.txOpts,
-		func(tx *gosql.Tx) error {
+	tx, err := o.mcp.Get().BeginEx(ctx, o.config.txOpts)
+	if err != nil {
+		return nil, err
+	}
+	if err := crdb.ExecuteInTx(
+		ctx, (*workload.PgxTx)(tx),
+		func() error {
 			// 2.6.2.2 explains this entire transaction.
 
 			// Select the customer
 			if d.cID != 0 {
 				// Case 1: select by customer id
-				if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-					SELECT c_balance, c_first, c_middle, c_last
-					FROM customer
-					WHERE c_w_id = %[1]d AND c_d_id = %[2]d AND c_id = %[3]d`,
-					wID, d.dID, d.cID),
+				if err := o.selectByCustID.QueryRowTx(
+					ctx, tx, wID, d.dID, d.cID,
 				).Scan(&d.cBalance, &d.cFirst, &d.cMiddle, &d.cLast); err != nil {
 					return errors.Wrap(err, "select by customer idfail")
 				}
 			} else {
 				// Case 2: Pick the middle row, rounded up, from the selection by last name.
-				indexStr := "@customer_idx"
-				if o.config.usePostgres {
-					indexStr = ""
-				}
-				queryStr := fmt.Sprintf(`
-					SELECT c_id, c_balance, c_first, c_middle
-					FROM customer%[1]s
-					WHERE c_w_id = %[2]d AND c_d_id = %[3]d AND c_last = '%[4]s'
-					ORDER BY c_first ASC`,
-					indexStr, wID, d.dID, d.cLast)
-				rows, err := tx.QueryContext(ctx, queryStr)
+				rows, err := o.selectByLastName.QueryTx(ctx, tx, wID, d.dID, d.cLast)
 				if err != nil {
 					return errors.Wrap(err, "select by last name fail")
 				}
@@ -143,13 +183,9 @@ func (o *orderStatus) run(ctx context.Context, wID int) (interface{}, error) {
 				}
 				rows.Close()
 				if len(customers) == 0 {
-					return fmt.Errorf("found no customers matching query: %s", queryStr)
+					return errors.New("found no customers matching query orderStatus.selectByLastName")
 				}
-				cIdx := len(customers) / 2
-				if len(customers)%2 == 0 {
-					cIdx--
-				}
-
+				cIdx := (len(customers) - 1) / 2
 				c := customers[cIdx]
 				d.cID = c.cID
 				d.cBalance = c.cBalance
@@ -158,23 +194,14 @@ func (o *orderStatus) run(ctx context.Context, wID int) (interface{}, error) {
 			}
 
 			// Select the customer's order.
-			if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-				SELECT o_id, o_entry_d, o_carrier_id
-				FROM "order"
-				WHERE o_w_id = %[1]d AND o_d_id = %[2]d AND o_c_id = %[3]d
-				ORDER BY o_id DESC
-				LIMIT 1`,
-				wID, d.dID, d.cID),
+			if err := o.selectOrder.QueryRowTx(
+				ctx, tx, wID, d.dID, d.cID,
 			).Scan(&d.oID, &d.oEntryD, &d.oCarrierID); err != nil {
 				return errors.Wrap(err, "select order fail")
 			}
 
 			// Select the items from the customer's order.
-			rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
-				SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
-				FROM order_line
-				WHERE ol_w_id = %[1]d AND ol_d_id = %[2]d AND ol_o_id = %[3]d`,
-				wID, d.dID, d.oID))
+			rows, err := o.selectItems.QueryTx(ctx, tx, wID, d.dID, d.oID)
 			if err != nil {
 				return errors.Wrap(err, "select items fail")
 			}

--- a/pkg/workload/tpcc/payment.go
+++ b/pkg/workload/tpcc/payment.go
@@ -17,7 +17,6 @@ package tpcc
 
 import (
 	"context"
-	gosql "database/sql"
 	"fmt"
 	"math/rand"
 	"sync/atomic"
@@ -25,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/pkg/errors"
 )
 
@@ -77,17 +77,85 @@ type paymentData struct {
 
 type payment struct {
 	config *tpcc
-	db     *gosql.DB
+	mcp    *workload.MultiConnPool
+	sr     workload.SQLRunner
+
+	updateWarehouse   workload.StmtHandle
+	updateDistrict    workload.StmtHandle
+	selectByLastName  workload.StmtHandle
+	updateWithPayment workload.StmtHandle
+	insertHistory     workload.StmtHandle
 }
 
 var _ tpccTx = &payment{}
 
-func createPayment(ctx context.Context, config *tpcc, db *gosql.DB) (tpccTx, error) {
-	n := &payment{
+func createPayment(ctx context.Context, config *tpcc, mcp *workload.MultiConnPool) (tpccTx, error) {
+	p := &payment{
 		config: config,
-		db:     db,
+		mcp:    mcp,
 	}
-	return n, nil
+
+	// Update warehouse with payment
+	p.updateWarehouse = p.sr.Define(`
+		UPDATE warehouse
+		SET w_ytd = w_ytd + $1
+		WHERE w_id = $2
+		RETURNING w_name, w_street_1, w_street_2, w_city, w_state, w_zip`,
+	)
+
+	// Update district with payment
+	p.updateDistrict = p.sr.Define(`
+		UPDATE district
+		SET d_ytd = d_ytd + $1
+		WHERE d_w_id = $2 AND d_id = $3
+		RETURNING d_name, d_street_1, d_street_2, d_city, d_state, d_zip`,
+	)
+
+	// TODD(radu): this is no longer necessary with the optimizer. Keep it for now
+	// for comparisons against the heuristic planner.
+	custIndexStr := "@customer_idx"
+	if config.usePostgres {
+		custIndexStr = ""
+	}
+
+	// 2.5.2.2 Case 2: Pick the middle row, rounded up, from the selection by last name.
+	p.selectByLastName = p.sr.Define(fmt.Sprintf(`
+		SELECT c_id
+		FROM customer%s
+		WHERE c_w_id = $1 AND c_d_id = $2 AND c_last = $3
+		ORDER BY c_first ASC`,
+		custIndexStr),
+	)
+
+	// Update customer with payment.
+	// If the customer has bad credit, update the customer's C_DATA and return
+	// the first 200 characters of it, which is supposed to get displayed by
+	// the terminal. See 2.5.3.3 and 2.5.2.2.
+	p.updateWithPayment = p.sr.Define(`
+		UPDATE customer
+		SET (c_balance, c_ytd_payment, c_payment_cnt, c_data) =
+		(c_balance - ($1:::float)::decimal, c_ytd_payment + ($1:::float)::decimal, c_payment_cnt + 1,
+			 case c_credit when 'BC' then
+			 left(c_id::text || c_d_id::text || c_w_id::text || ($5:::int)::text || ($6:::int)::text || ($1:::float)::text || c_data, 500)
+			 else c_data end)
+		WHERE c_w_id = $2 AND c_d_id = $3 AND c_id = $4
+		RETURNING c_first, c_middle, c_last, c_street_1, c_street_2,
+					c_city, c_state, c_zip, c_phone, c_since, c_credit,
+					c_credit_lim, c_discount, c_balance, case c_credit when 'BC' then left(c_data, 200) else '' end`,
+	)
+
+	// Insert history line.
+
+	p.insertHistory = p.sr.Define(`
+		INSERT INTO history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_amount, h_date, h_data)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+	)
+
+	if err := p.sr.Init(ctx, "payment", mcp, config.connFlags); err != nil {
+		return nil, err
+	}
+
+	return p, nil
 }
 
 func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
@@ -128,30 +196,24 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
 		d.cID = randCustomerID(rng)
 	}
 
-	if err := crdb.ExecuteTx(
-		ctx,
-		p.db,
-		p.config.txOpts,
-		func(tx *gosql.Tx) error {
+	tx, err := p.mcp.Get().BeginEx(ctx, p.config.txOpts)
+	if err != nil {
+		return nil, err
+	}
+	if err := crdb.ExecuteInTx(
+		ctx, (*workload.PgxTx)(tx),
+		func() error {
 			var wName, dName string
 			// Update warehouse with payment
-			if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-				UPDATE warehouse
-				SET w_ytd = w_ytd + %[1]f
-				WHERE w_id = %[2]d
-				RETURNING w_name, w_street_1, w_street_2, w_city, w_state, w_zip`,
-				d.hAmount, wID),
+			if err := p.updateWarehouse.QueryRowTx(
+				ctx, tx, d.hAmount, wID,
 			).Scan(&wName, &d.wStreet1, &d.wStreet2, &d.wCity, &d.wState, &d.wZip); err != nil {
 				return err
 			}
 
 			// Update district with payment
-			if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-				UPDATE district
-				SET d_ytd = d_ytd + %[1]f
-				WHERE d_w_id = %[2]d AND d_id = %[3]d
-				RETURNING d_name, d_street_1, d_street_2, d_city, d_state, d_zip`,
-				d.hAmount, wID, d.dID),
+			if err := p.updateDistrict.QueryRowTx(
+				ctx, tx, d.hAmount, wID, d.dID,
 			).Scan(&dName, &d.dStreet1, &d.dStreet2, &d.dCity, &d.dState, &d.dZip); err != nil {
 				return err
 			}
@@ -160,16 +222,7 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
 			// then proceed.
 			if d.cID == 0 {
 				// 2.5.2.2 Case 2: Pick the middle row, rounded up, from the selection by last name.
-				indexStr := "@customer_idx"
-				if p.config.usePostgres {
-					indexStr = ""
-				}
-				rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
-					SELECT c_id
-					FROM customer%[1]s
-					WHERE c_w_id = %[2]d AND c_d_id = %[3]d AND c_last = '%[4]s'
-					ORDER BY c_first ASC`,
-					indexStr, wID, d.dID, d.cLast))
+				rows, err := p.selectByLastName.QueryTx(ctx, tx, wID, d.dID, d.cLast)
 				if err != nil {
 					return errors.Wrap(err, "select by last name fail")
 				}
@@ -187,11 +240,7 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
 					return err
 				}
 				rows.Close()
-				cIdx := len(customers) / 2
-				if len(customers)%2 == 0 {
-					cIdx--
-				}
-
+				cIdx := (len(customers) - 1) / 2
 				d.cID = customers[cIdx]
 			}
 
@@ -199,18 +248,8 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
 			// If the customer has bad credit, update the customer's C_DATA and return
 			// the first 200 characters of it, which is supposed to get displayed by
 			// the terminal. See 2.5.3.3 and 2.5.2.2.
-			if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-				UPDATE customer
-				SET (c_balance, c_ytd_payment, c_payment_cnt, c_data) =
-					(c_balance - %[1]f, c_ytd_payment + %[1]f, c_payment_cnt + 1,
-					 case c_credit when 'BC' then
-					 left(c_id::text || c_d_id::text || c_w_id::text || %[5]d::text || %[6]d::text || %[1]f::text || c_data, 500)
-					 else c_data end)
-				WHERE c_w_id = %[2]d AND c_d_id = %[3]d AND c_id = %[4]d
-				RETURNING c_first, c_middle, c_last, c_street_1, c_street_2,
-						  c_city, c_state, c_zip, c_phone, c_since, c_credit,
-						  c_credit_lim, c_discount, c_balance, case c_credit when 'BC' then left(c_data, 200) else '' end`,
-				d.hAmount, d.cWID, d.cDID, d.cID, d.dID, wID),
+			if err := p.updateWithPayment.QueryRowTx(
+				ctx, tx, d.hAmount, d.cWID, d.cDID, d.cID, d.dID, wID,
 			).Scan(&d.cFirst, &d.cMiddle, &d.cLast, &d.cStreet1, &d.cStreet2,
 				&d.cCity, &d.cState, &d.cZip, &d.cPhone, &d.cSince, &d.cCredit,
 				&d.cCreditLim, &d.cDiscount, &d.cBalance, &d.cData,
@@ -221,11 +260,9 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
 			hData := fmt.Sprintf("%s    %s", wName, dName)
 
 			// Insert history line.
-			_, err := tx.ExecContext(ctx, fmt.Sprintf(`
-				INSERT INTO history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_amount, h_date, h_data)
-				VALUES (%[1]d, %[2]d, %[3]d, %[4]d, %[5]d, %[6]f, '%[7]s', '%[8]s')`,
-				d.cID, d.cDID, d.cWID, d.dID, wID, d.hAmount,
-				d.hDate.Format("2006-01-02 15:04:05"), hData),
+			_, err := p.insertHistory.ExecTx(
+				ctx, tx,
+				d.cID, d.cDID, d.cWID, d.dID, wID, d.hAmount, d.hDate.Format("2006-01-02 15:04:05"), hData,
 			)
 			return err
 		}); err != nil {

--- a/pkg/workload/tpcc/stock_level.go
+++ b/pkg/workload/tpcc/stock_level.go
@@ -16,14 +16,13 @@
 package tpcc
 
 import (
-	gosql "database/sql"
-	"fmt"
 	"math/rand"
 
 	"context"
 
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload"
 )
 
 // 2.8 The Stock-Level Transaction
@@ -49,16 +48,50 @@ type stockLevelData struct {
 
 type stockLevel struct {
 	config *tpcc
-	db     *gosql.DB
+	mcp    *workload.MultiConnPool
+	sr     workload.SQLRunner
+
+	selectDNextOID    workload.StmtHandle
+	countRecentlySold workload.StmtHandle
 }
 
 var _ tpccTx = &stockLevel{}
 
-func createStockLevel(ctx context.Context, config *tpcc, db *gosql.DB) (tpccTx, error) {
+func createStockLevel(
+	ctx context.Context, config *tpcc, mcp *workload.MultiConnPool,
+) (tpccTx, error) {
 	s := &stockLevel{
 		config: config,
-		db:     db,
+		mcp:    mcp,
 	}
+
+	s.selectDNextOID = s.sr.Define(`
+		SELECT d_next_o_id
+		FROM district
+		WHERE d_w_id = $1 AND d_id = $2`,
+	)
+
+	// Count the number of recently sold items that have a stock level below
+	// the threshold.
+	// TODO(radu): we use count(DISTINCT s_i_id) because DISTINCT inside
+	// aggregates was not supported by the optimizer. This can be cleaned up.
+	s.countRecentlySold = s.sr.Define(`
+		SELECT count(*) FROM (
+			SELECT DISTINCT s_i_id
+			FROM order_line
+			JOIN stock
+			ON s_i_id=ol_i_id AND s_w_id=ol_w_id
+			WHERE ol_w_id = $1
+				AND ol_d_id = $2
+				AND ol_o_id BETWEEN $3 - 20 AND $3 - 1
+				AND s_quantity < $4
+		)`,
+	)
+
+	if err := s.sr.Init(ctx, "stock-level", mcp, config.connFlags); err != nil {
+		return nil, err
+	}
+
 	return s, nil
 }
 
@@ -72,11 +105,13 @@ func (s *stockLevel) run(ctx context.Context, wID int) (interface{}, error) {
 		dID:       rng.Intn(10) + 1,
 	}
 
-	if err := crdb.ExecuteTx(
-		ctx,
-		s.db,
-		s.config.txOpts,
-		func(tx *gosql.Tx) error {
+	tx, err := s.mcp.Get().BeginEx(ctx, s.config.txOpts)
+	if err != nil {
+		return nil, err
+	}
+	if err := crdb.ExecuteInTx(
+		ctx, (*workload.PgxTx)(tx),
+		func() error {
 			// This is the only join in the application, so we don't need to worry about
 			// this setting persisting incorrectly across queries.
 			// Note that this is not needed (and doesn't do anything) when the
@@ -87,31 +122,16 @@ func (s *stockLevel) run(ctx context.Context, wID int) (interface{}, error) {
 			}
 
 			var dNextOID int
-			if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-				SELECT d_next_o_id
-				FROM district
-				WHERE d_w_id = %[1]d AND d_id = %[2]d`,
-				wID, d.dID),
+			if err := s.selectDNextOID.QueryRowTx(
+				ctx, tx, wID, d.dID,
 			).Scan(&dNextOID); err != nil {
 				return err
 			}
 
 			// Count the number of recently sold items that have a stock level below
 			// the threshold.
-			// Note: we don't use count(DISTINCT s_i_id) because DISTINCT inside
-			// aggregates is not yet supported by the optimizer.
-			return tx.QueryRowContext(ctx, fmt.Sprintf(`
-			  SELECT count(*) FROM (
-			  	SELECT DISTINCT s_i_id
-			  	FROM order_line
-			  	JOIN stock
-			  	ON s_i_id=ol_i_id AND s_w_id=ol_w_id
-			  	WHERE ol_w_id = %[1]d
-			  	  AND ol_d_id = %[2]d
-			  	  AND ol_o_id BETWEEN %[3]d - 20 AND %[3]d - 1
-			  	  AND s_quantity < %[4]d
-			  )`,
-				wID, d.dID, dNextOID, d.threshold),
+			return s.countRecentlySold.QueryRowTx(
+				ctx, tx, wID, d.dID, dNextOID, d.threshold,
 			).Scan(&d.lowStock)
 		}); err != nil {
 		return nil, err

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -49,8 +49,8 @@ type tpcc struct {
 	fks        bool
 	dbOverride string
 
-	txs []tx
-	// deck contains indexes into the txs slice.
+	txInfos []txInfo
+	// deck contains indexes into the txInfos slice.
 	deck []int
 
 	auditor *auditor
@@ -474,16 +474,12 @@ func (w *tpcc) Ops(urls []string, reg *workload.HistogramRegistry) (workload.Que
 		p := (warehouse * w.partitions) / w.activeWarehouses
 		dbs := partitionDBs[p]
 		db := dbs[warehouse%len(dbs)]
-		worker := &worker{
-			config:    w,
-			hists:     reg.GetHandle(),
-			idx:       workerIdx,
-			db:        db,
-			warehouse: warehouse + startWarehouse,
-			deckPerm:  make([]int, len(w.deck)),
-			permIdx:   len(w.deck),
+		worker, err := newWorker(
+			context.TODO(), w, db, reg.GetHandle(), workerIdx, warehouse+startWarehouse,
+		)
+		if err != nil {
+			return workload.QueryLoad{}, err
 		}
-		copy(worker.deckPerm, w.deck)
 
 		ql.WorkerFns = append(ql.WorkerFns, worker.run)
 	}

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -30,12 +30,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/jackc/pgx"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
 
 type tpcc struct {
-	flags workload.Flags
+	flags     workload.Flags
+	connFlags *workload.ConnFlags
 
 	seed             int64
 	warehouses       int
@@ -66,7 +68,7 @@ type tpcc struct {
 
 	usePostgres  bool
 	serializable bool
-	txOpts       *gosql.TxOptions
+	txOpts       *pgx.TxOptions
 
 	expensiveChecks bool
 
@@ -140,6 +142,7 @@ var tpccMeta = workload.Meta{
 		g.flags.StringSliceVar(&g.zones, "zones", []string{}, "Zones for partitioning, the number of zones should match the number of partitions and the zones used to start cockroach.")
 
 		g.flags.BoolVar(&g.expensiveChecks, `expensive-checks`, false, `Run expensive checks`)
+		g.connFlags = workload.NewConnFlags(&g.flags)
 		return g
 	},
 }
@@ -166,7 +169,7 @@ func (w *tpcc) Hooks() workload.Hooks {
 				w.workers = w.activeWarehouses * numWorkersPerWarehouse
 			}
 			if w.doWaits && w.workers != w.activeWarehouses*numWorkersPerWarehouse {
-				return errors.Errorf(`--waits=true and --warehouses=%d requires --workers=%d`,
+				return errors.Errorf(`--wait=true and --warehouses=%d requires --workers=%d`,
 					w.activeWarehouses, w.warehouses*numWorkersPerWarehouse)
 			}
 
@@ -191,7 +194,7 @@ func (w *tpcc) Hooks() workload.Hooks {
 			}
 
 			if w.serializable {
-				w.txOpts = &gosql.TxOptions{Isolation: gosql.LevelSerializable}
+				w.txOpts = &pgx.TxOptions{IsoLevel: pgx.Serializable}
 			}
 
 			w.auditor = newAuditor(w.warehouses)
@@ -405,31 +408,33 @@ func (w *tpcc) Ops(urls []string, reg *workload.HistogramRegistry) (workload.Que
 	w.usePostgres = parsedURL.Port() == "5432"
 
 	nConns := w.activeWarehouses / len(urls)
-	dbs := make([]*gosql.DB, len(urls))
+
+	// We can't use a single MultiConnPool because we want to implement partition
+	// affinity. Instead we have one MultiConnPool per server (we use
+	// MultiConnPool in order to use SQLRunner, but it's otherwise equivalent to a
+	// pgx.ConnPool).
+	dbs := make([]*workload.MultiConnPool, len(urls))
 	for i, url := range urls {
-		dbs[i], err = gosql.Open(`postgres`, url)
+		dbs[i], err = workload.NewMultiConnPool(nConns, url)
 		if err != nil {
 			return workload.QueryLoad{}, err
 		}
-		// Allow a maximum of concurrency+1 connections to the database.
-		dbs[i].SetMaxOpenConns(nConns)
-		dbs[i].SetMaxIdleConns(nConns)
 	}
 
 	// We're adding this check here because repartitioning a table can take
 	// upwards of 10 minutes so if a cluster is already set up correctly we won't
 	// do this operation again.
-	alreadyPartitioned, err := isTableAlreadyPartitioned(dbs[0])
+	alreadyPartitioned, err := isTableAlreadyPartitioned(dbs[0].Get())
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
 
 	if !alreadyPartitioned {
 		if w.split {
-			splitTables(dbs[0], w.warehouses)
+			splitTables(dbs[0].Get(), w.warehouses)
 
 			if w.partitions > 0 {
-				partitionTables(dbs[0], w.warehouses, w.partitions, w.zones)
+				partitionTables(dbs[0].Get(), w.warehouses, w.partitions, w.zones)
 			}
 		}
 	} else {
@@ -437,7 +442,7 @@ func (w *tpcc) Ops(urls []string, reg *workload.HistogramRegistry) (workload.Que
 	}
 
 	if w.scatter {
-		scatterRanges(dbs[0])
+		scatterRanges(dbs[0].Get())
 	}
 
 	// If no partitions were specified, pretend there is a single partition
@@ -447,7 +452,7 @@ func (w *tpcc) Ops(urls []string, reg *workload.HistogramRegistry) (workload.Que
 	}
 	// Assign each DB connection pool to a partition. This assumes that dbs[i] is
 	// a machine that holds partition "i % *partitions".
-	partitionDBs := make([][]*gosql.DB, w.partitions)
+	partitionDBs := make([][]*workload.MultiConnPool, w.partitions)
 	if w.affinityPartition == -1 {
 		for i, db := range dbs {
 			p := i % w.partitions

--- a/pkg/workload/tpcc/worker.go
+++ b/pkg/workload/tpcc/worker.go
@@ -17,7 +17,6 @@ package tpcc
 
 import (
 	"context"
-	gosql "database/sql"
 	"math"
 	"math/rand"
 	"strconv"
@@ -40,7 +39,7 @@ type tpccTx interface {
 	run(ctx context.Context, wID int) (interface{}, error)
 }
 
-type createTxFn func(ctx context.Context, config *tpcc, db *gosql.DB) (tpccTx, error)
+type createTxFn func(ctx context.Context, config *tpcc, mcp *workload.MultiConnPool) (tpccTx, error)
 
 // txInfo stores high-level information about the TPCC transactions. The create
 // function is used to create an object that implements tpccTx.
@@ -142,7 +141,7 @@ type worker struct {
 func newWorker(
 	ctx context.Context,
 	config *tpcc,
-	db *gosql.DB,
+	mcp *workload.MultiConnPool,
 	hists *workload.Histograms,
 	workerIdx int,
 	warehouse int,
@@ -158,7 +157,7 @@ func newWorker(
 	}
 	for i := range w.txs {
 		var err error
-		w.txs[i], err = config.txInfos[i].constructor(ctx, config, db)
+		w.txs[i], err = config.txInfos[i].constructor(ctx, config, mcp)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/workload/tpcc/worker.go
+++ b/pkg/workload/tpcc/worker.go
@@ -34,61 +34,61 @@ const (
 	numWorkersPerWarehouse = 10
 )
 
-type worker struct {
-	config    *tpcc
-	hists     *workload.Histograms
-	idx       int
-	db        *gosql.DB
-	warehouse int
-
-	deckPerm []int
-	permIdx  int
-}
-
+// tpccTX is an interface for running a TPCC transaction.
 type tpccTx interface {
-	run(ctx context.Context, config *tpcc, db *gosql.DB, wID int) (interface{}, error)
+	// run executes the TPCC transaction against the given warehouse ID.
+	run(ctx context.Context, wID int) (interface{}, error)
 }
 
-type tx struct {
-	tpccTx
-	weight     int     // percent likelihood that each transaction type is run
-	name       string  // display name
-	keyingTime int     // keying time in seconds, see 5.2.5.7
-	thinkTime  float64 // minimum mean of think time distribution, 5.2.5.7
+type createTxFn func(ctx context.Context, config *tpcc, db *gosql.DB) (tpccTx, error)
+
+// txInfo stores high-level information about the TPCC transactions. The create
+// function is used to create an object that implements tpccTx.
+type txInfo struct {
+	name        string // display name
+	constructor createTxFn
+	keyingTime  int     // keying time in seconds, see 5.2.5.7
+	thinkTime   float64 // minimum mean of think time distribution, 5.2.5.7
+	weight      int     // percent likelihood that each transaction type is run
 }
 
-var allTxs = [...]tx{
+var allTxs = [...]txInfo{
 	{
-		tpccTx: newOrder{}, name: "newOrder",
-		keyingTime: 18,
-		thinkTime:  12,
+		name:        "newOrder",
+		constructor: createNewOrder,
+		keyingTime:  18,
+		thinkTime:   12,
 	},
 	{
-		tpccTx: payment{}, name: "payment",
-		keyingTime: 3,
-		thinkTime:  12,
+		name:        "payment",
+		constructor: createPayment,
+		keyingTime:  3,
+		thinkTime:   12,
 	},
 	{
-		tpccTx: orderStatus{}, name: "orderStatus",
-		keyingTime: 2,
-		thinkTime:  10,
+		name:        "orderStatus",
+		constructor: createOrderStatus,
+		keyingTime:  2,
+		thinkTime:   10,
 	},
 	{
-		tpccTx: delivery{}, name: "delivery",
-		keyingTime: 2,
-		thinkTime:  5,
+		name:        "delivery",
+		constructor: createDelivery,
+		keyingTime:  2,
+		thinkTime:   5,
 	},
 	{
-		tpccTx: stockLevel{}, name: "stockLevel",
-		keyingTime: 2,
-		thinkTime:  5,
+		name:        "stockLevel",
+		constructor: createStockLevel,
+		keyingTime:  2,
+		thinkTime:   5,
 	},
 }
 
 func initializeMix(config *tpcc) error {
-	config.txs = append([]tx(nil), allTxs[0:]...)
+	config.txInfos = append([]txInfo(nil), allTxs[0:]...)
 	nameToTx := make(map[string]int)
-	for i, tx := range config.txs {
+	for i, tx := range config.txInfos {
 		nameToTx[tx.name] = i
 	}
 
@@ -113,18 +113,57 @@ func initializeMix(config *tpcc) error {
 				`Invalid percentage mix %s: no such transaction %s`, config.mix, txName)
 		}
 
-		config.txs[i].weight = weight
+		config.txInfos[i].weight = weight
 		totalWeight += weight
 	}
 
 	config.deck = make([]int, 0, totalWeight)
-	for i, t := range config.txs {
+	for i, t := range config.txInfos {
 		for j := 0; j < t.weight; j++ {
 			config.deck = append(config.deck, i)
 		}
 	}
 
 	return nil
+}
+
+type worker struct {
+	config *tpcc
+	// txs maps 1-to-1 with config.txInfos.
+	txs       []tpccTx
+	hists     *workload.Histograms
+	idx       int
+	warehouse int
+
+	deckPerm []int
+	permIdx  int
+}
+
+func newWorker(
+	ctx context.Context,
+	config *tpcc,
+	db *gosql.DB,
+	hists *workload.Histograms,
+	workerIdx int,
+	warehouse int,
+) (*worker, error) {
+	w := &worker{
+		config:    config,
+		txs:       make([]tpccTx, len(config.txInfos)),
+		hists:     hists,
+		idx:       workerIdx,
+		warehouse: warehouse,
+		deckPerm:  append([]int(nil), config.deck...),
+		permIdx:   len(config.deck),
+	}
+	for i := range w.txs {
+		var err error
+		w.txs[i], err = config.txInfos[i].constructor(ctx, config, db)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return w, nil
 }
 
 func (w *worker) run(ctx context.Context) error {
@@ -140,9 +179,10 @@ func (w *worker) run(ctx context.Context) error {
 	}
 	// Move through our permutation slice until its exhausted, using each value to
 	// to index into our deck of transactions, which contains indexes into the
-	// txs slice.
+	// txInfos / txs slices.
 	opIdx := w.deckPerm[w.permIdx]
-	t := w.config.txs[opIdx]
+	txInfo := &w.config.txInfos[opIdx]
+	tx := w.txs[opIdx]
 	w.permIdx++
 
 	warehouseID := w.warehouse
@@ -152,19 +192,19 @@ func (w *worker) run(ctx context.Context) error {
 		// Wait out the entire keying and think time even if the context is
 		// expired. This prevents all workers from immediately restarting when
 		// the workload's ramp period expires, which can overload a cluster.
-		time.Sleep(time.Duration(t.keyingTime) * time.Second)
+		time.Sleep(time.Duration(txInfo.keyingTime) * time.Second)
 	}
 
 	// Run transactions with a background context because we don't want to
 	// cancel them when the context expires. Instead, let them finish normally
 	// but don't account for them in the histogram.
 	start := timeutil.Now()
-	if _, err := t.run(context.Background(), w.config, w.db, warehouseID); err != nil {
-		return errors.Wrapf(err, "error in %s", t.name)
+	if _, err := tx.run(context.Background(), warehouseID); err != nil {
+		return errors.Wrapf(err, "error in %s", txInfo.name)
 	}
 	if ctx.Err() == nil {
 		elapsed := timeutil.Since(start)
-		w.hists.Get(t.name).Record(elapsed)
+		w.hists.Get(txInfo.name).Record(elapsed)
 	}
 
 	if w.config.doWaits {
@@ -172,9 +212,9 @@ func (w *worker) run(ctx context.Context) error {
 		// distribution. Think time = -log(r) * u, where r is a uniform random number
 		// between 0 and 1 and u is the mean think time per operation.
 		// Each distribution is truncated at 10 times its mean value.
-		thinkTime := -math.Log(rand.Float64()) * t.thinkTime
-		if thinkTime > (t.thinkTime * 10) {
-			thinkTime = t.thinkTime * 10
+		thinkTime := -math.Log(rand.Float64()) * txInfo.thinkTime
+		if thinkTime > (txInfo.thinkTime * 10) {
+			thinkTime = txInfo.thinkTime * 10
 		}
 		time.Sleep(time.Duration(thinkTime) * time.Second)
 	}


### PR DESCRIPTION
#### workload: refactor tpccTx

Refactoring tpccTx to allow per-worker state. This will be necessary
for preparing statements in advance.

Release note: None

#### workload: use SQLRunner for queries without tuples

Switch TPCC to use pgx; use SQLRunner for queries that have a fixed
number of arguments.

Release note: None


Benchmark results here: https://docs.google.com/spreadsheets/d/13tcnYoRA3ArkZQtEHUMbJOOVdayyhgf43D94fFMiAPY/edit#gid=1942348447

The averages are about the same, but the distribution is very different (p50 through p95 are way better and p99, pMax are much worse). This is probably due to differences in how `pgx` and `gosql` manage their connection pools (we have 100 workers using 10 connections).