### PR TITLE
build: make build and tracing able to build cgo-free

### DIFF
--- a/pkg/build/cgo_compiler.go
+++ b/pkg/build/cgo_compiler.go
@@ -1,0 +1,30 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package build
+
+// const char* compilerVersion() {
+// #if defined(__clang__)
+// 	return __VERSION__;
+// #elif defined(__GNUC__) || defined(__GNUG__)
+// 	return "gcc " __VERSION__;
+// #else
+// 	return "non-gcc, non-clang (or an unrecognized version)";
+// #endif
+// }
+import "C"
+
+func cgoVersion() string {
+	return C.GoString(C.compilerVersion())
+}

--- a/pkg/build/cgo_compiler_nocgo.go
+++ b/pkg/build/cgo_compiler_nocgo.go
@@ -1,0 +1,21 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build !cgo
+
+package build
+
+func cgoVersion() string {
+	return "cgo-disabled"
+}

--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -23,17 +23,6 @@ import (
 	version "github.com/hashicorp/go-version"
 )
 
-// const char* compilerVersion() {
-// #if defined(__clang__)
-// 	return __VERSION__;
-// #elif defined(__GNUC__) || defined(__GNUG__)
-// 	return "gcc " __VERSION__;
-// #else
-// 	return "non-gcc, non-clang (or an unrecognized version)";
-// #endif
-// }
-import "C"
-
 // TimeFormat is the reference format for build.Time. Make sure it stays in sync
 // with the string passed to the linker in the root Makefile.
 const TimeFormat = "2006/01/02 15:04:05"
@@ -44,7 +33,7 @@ var (
 	tag             = "unknown" // Tag of this build (git describe --tags w/ optional '-dirty' suffix)
 	utcTime         string      // Build time in UTC (year/month/day hour:min:sec)
 	rev             string      // SHA-1 of this build (git rev-parse)
-	cgoCompiler     = C.GoString(C.compilerVersion())
+	cgoCompiler     = cgoVersion()
 	cgoTargetTriple string
 	platform        = fmt.Sprintf("%s %s", runtime.GOOS, runtime.GOARCH)
 	// Distribution is changed by the CCL init-time hook in non-APL builds.

--- a/pkg/util/tracing/annotate_nocgo.go
+++ b/pkg/util/tracing/annotate_nocgo.go
@@ -1,0 +1,22 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build !cgo
+
+package tracing
+
+// AnnotateTrace adds an annotation to the golang executation tracer by calling
+// a no-op cgo function.
+func AnnotateTrace() {
+}


### PR DESCRIPTION
Release note: none.