### PR TITLE
buildutil: fix bug in dependencies test

### DIFF
--- a/pkg/testutils/buildutil/build.go
+++ b/pkg/testutils/buildutil/build.go
@@ -52,7 +52,6 @@ func VerifyNoImports(
 		if err != nil {
 			t.Fatal(err)
 		}
-
 		for _, imp := range pkg.Imports {
 			for _, forbidden := range forbiddenPkgs {
 				if forbidden == imp {
@@ -67,7 +66,7 @@ func VerifyNoImports(
 				}
 			}
 			for _, prefix := range forbiddenPrefixes {
-				if strings.HasPrefix(path, prefix) {
+				if strings.HasPrefix(imp, prefix) {
 					return errors.Errorf("%s imports %s which has prefix %s, which is forbidden", short(path), short(imp), prefix)
 				}
 			}


### PR DESCRIPTION
I think this was supposed to check each imported path against the prefix, not the package path itself over and over.

Release note: none.