### PR TITLE
ui: make cluster overview layout more fluid

### DIFF
--- a/pkg/ui/src/views/cluster/containers/clusterOverview/capacity.tsx
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/capacity.tsx
@@ -35,7 +35,7 @@ function capacityChart() {
 
   const margin = {
     top: 12,
-    right: 35,
+    right: 20,
     bottom: 25,
     left: 20,
   };
@@ -71,6 +71,11 @@ function capacityChart() {
   }
 
   return function chart(svg: d3.Selection<CapacityChartProps>) {
+    const rect = (svg.node().parentNode as HTMLElement).getBoundingClientRect();
+    size.width = rect.width;
+
+    scale.range([0, size.width]);
+
     svg
       .attr("width", size.width + margin.left + margin.right)
       .attr("height", size.height + margin.top + margin.bottom);

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
@@ -38,7 +38,7 @@
 
     display grid
     align-items end
-    grid-template-columns 6fr 8fr 6fr 8fr 2fr 6fr 6fr 6fr 2fr 6fr 10fr 6fr
+    grid-template-columns 6fr 8fr 6fr minmax(auto,8fr) minmax(10px, 2fr) 6fr 6fr 6fr 2fr 6fr 10fr 6fr
     grid-template-rows repeat(3, auto)
     grid-template-areas "cap-t cap-t cap-t cap-t . live-t live-t live-t . rep-t rep-t rep-t" "cap-m cap-c cap-c cap-c . live-a live-b live-c . rep-a rep-b rep-c" "cap-a1 cap-a2 cap-a3 cap-a4 . live-1 live-2 live-3 . rep-1 rep-2 rep-3"
 
@@ -50,10 +50,10 @@
       grid-template-areas "cap-t cap-t live-t live-t rep-t rep-t" "cap-m2 cap-m live-1 live-a rep-1 rep-a" "cap-a1 cap-a2 live-2 live-b rep-2 rep-b" "cap-a3 cap-a4 live-3 live-c rep-3 rep-c"
 
     @media screen and (min-width: 1400px)
-      grid-template-columns 100px 135px 100px 135px 1fr 100px 100px 100px 1fr 100px 168px 100px
+      grid-template-columns 2fr 3fr 2fr 3fr 4fr 2fr 2fr 2fr 4fr 2fr 3fr 2fr
 
     @media screen and (min-width: 1720px)
-      grid-template-columns 125px 135px 125px 135px 1fr 125px 125px 125px 1fr 168px 168px 168px
+      grid-template-columns 3fr 4fr 3fr 4fr 8fr 3fr 3fr 3fr 8fr 4fr 4fr 4fr
 
     .capacity-usage
       &.cluster-summary__title

--- a/pkg/ui/src/views/shared/util/d3-react.tsx
+++ b/pkg/ui/src/views/shared/util/d3-react.tsx
@@ -26,17 +26,36 @@ export default function createChartComponent<T>(containerTy: string, chart: Char
     containerEl: React.RefObject<Element> = React.createRef();
 
     componentDidMount() {
-      d3.select(this.containerEl.current)
-        .datum(this.props)
-        .call(chart);
+      this.redraw();
+      this.addResizeHandler();
+    }
+
+    componentWillUnmount() {
+      this.removeResizeHandler();
     }
 
     shouldComponentUpdate(props: T) {
+      this.redraw(props);
+
+      return false;
+    }
+
+    redraw(props: T = this.props) {
       d3.select(this.containerEl.current)
         .datum(props)
         .call(chart);
+    }
 
-      return false;
+    handleResize = () => {
+      this.redraw();
+    }
+
+    addResizeHandler() {
+      window.addEventListener("resize", this.handleResize);
+    }
+
+    removeResizeHandler() {
+      window.removeEventListener("resize", this.handleResize);
     }
 
     render() {


### PR DESCRIPTION
Fixes: #31414
Fixes: #24314
Release note (admin ui change): Improve the layout of the Cluster Overview
on large clusters with many nodes and ranges.

---

<img width="967" alt="screen shot 2018-10-16 at 2 43 12 pm" src="https://user-images.githubusercontent.com/793969/47039622-5fd33200-d152-11e8-8fa6-a2abc401bc48.png">
<img width="1376" alt="screen shot 2018-10-16 at 2 43 33 pm" src="https://user-images.githubusercontent.com/793969/47039623-5fd33200-d152-11e8-87a1-5ee9a7fb6398.png">
<img width="1505" alt="screen shot 2018-10-16 at 2 43 41 pm" src="https://user-images.githubusercontent.com/793969/47039624-5fd33200-d152-11e8-925e-476454e652fc.png">
<img width="1680" alt="screen shot 2018-10-16 at 2 43 53 pm" src="https://user-images.githubusercontent.com/793969/47039625-5fd33200-d152-11e8-925d-a5a831e21f46.png">
<img width="1853" alt="screen shot 2018-10-16 at 2 44 00 pm" src="https://user-images.githubusercontent.com/793969/47039626-606bc880-d152-11e8-9d46-c9e8ff47486f.png">
<img width="2102" alt="screen shot 2018-10-16 at 2 44 10 pm" src="https://user-images.githubusercontent.com/793969/47039627-606bc880-d152-11e8-9d21-fb8f1d1ddd0a.png">
