### PR TITLE
ui: fix the color of the logout link

### DIFF
--- a/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
@@ -102,15 +102,13 @@ function LoginIndicator({ loginState, handleLogout }: LoginIndicatorProps) {
   return (
     <li className="login-indicator">
       <Link to={LOGOUT_PAGE} onClick={handleLogout}>
-        <div>
-          <div
-            className="login-indicator__initial"
-            title={`Signed in as ${user}`}
-          >
-            {user[0]}
-          </div>
-          Log Out
+        <div
+          className="login-indicator__initial"
+          title={`Signed in as ${user}`}
+        >
+          {user[0]}
         </div>
+        <div>Log Out</div>
       </Link>
     </li>
   );

--- a/pkg/ui/styl/layout/navigation-bar.styl
+++ b/pkg/ui/styl/layout/navigation-bar.styl
@@ -97,6 +97,7 @@ $subnav-underline-height = 3px
         display inline
         padding 0
         text-decoration none
+        color inherit
 
         &:hover
           color $link-color


### PR DESCRIPTION
Release note: None

---

Before:
<img width="89" alt="screen shot 2018-10-16 at 3 02 06 pm" src="https://user-images.githubusercontent.com/793969/47040553-7b3f3c80-d154-11e8-8f8b-f7469cbc6e8c.png">

After:
<img width="158" alt="screen shot 2018-10-16 at 3 00 42 pm" src="https://user-images.githubusercontent.com/793969/47040563-809c8700-d154-11e8-8c98-b98066ad7582.png">
