### PR TITLE
roachtest: deflake acceptance/bank/zerosum-splits

### DIFF
--- a/pkg/cmd/roachtest/bank.go
+++ b/pkg/cmd/roachtest/bank.go
@@ -309,13 +309,9 @@ func (s *bankState) startSplitMonkey(ctx context.Context, d time.Duration, c *cl
 				client.RLock()
 				zipF := accountDistribution(r)
 				key := zipF.Uint64()
-				const splitQuery = `ALTER TABLE bank.accounts SPLIT AT VALUES ($1)`
 				c.l.Printf("round %d: splitting key %v\n", curRound, key)
-				_, err := client.db.Exec(`SET experimental_force_split_at = true`)
-				if err != nil && !testutils.IsSQLRetryableError(err) {
-					s.errChan <- err
-				}
-				_, err = client.db.Exec(splitQuery, key)
+				_, err := client.db.Exec(fmt.Sprintf(
+					`SET experimental_force_split_at = true; ALTER TABLE bank.accounts SPLIT AT VALUES (%d)`, key))
 				if err != nil && !(testutils.IsSQLRetryableError(err) || isExpectedRelocateError(err)) {
 					s.errChan <- err
 				}


### PR DESCRIPTION
This test requires that the experimental_force_split_at session var be
set to force ALTER ... SPLIT AT to work even with the merge queue
enabled. gosql.DB's connection pool will occasionally open a new
connection which does not have the var set. Set the session var in the
same batch of statements as the ALTER ... SPLIT AT command so that the
session var is always set in the session that executes the ALTER ...
SPLIT AT command.

Fix #31510.

Release note: None