### PR TITLE
issues: suggest stressrace, not stress

### DIFF
--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -264,11 +264,11 @@ To repro, try:
 ` + "```" + `
 # Don't forget to check out a clean suitable branch and experiment with the
 # stress invocation until the desired results present themselves. For example,
-# using stressrace instead of stress and passing the '-p' stressflag which
+# using stress instead of stressrace and passing the '-p' stressflag which
 # controls concurrency.
 ./scripts/gceworker.sh start && ./scripts/gceworker.sh mosh
 cd ~/go/src/github.com/cockroachdb/cockroach && \
-make stress TESTS=%[5]s PKG=%[4]s TESTTIMEOUT=5m STRESSFLAGS='-stderr=false -maxtime 20m -timeout 10m'
+make stressrace TESTS=%[5]s PKG=%[4]s TESTTIMEOUT=5m STRESSFLAGS='-maxtime 20m -timeout 10m' 2>&1 | tee /tmp/stress.log
 ` + "```" + `
 
 Failed test: %[3]s`

--- a/pkg/cmd/internal/issues/issues_test.go
+++ b/pkg/cmd/internal/issues/issues_test.go
@@ -115,11 +115,11 @@ To repro, try:
 `+"```"+`
 # Don't forget to check out a clean suitable branch and experiment with the
 # stress invocation until the desired results present themselves. For example,
-# using stressrace instead of stress and passing the '-p' stressflag which
+# using stress instead of stressrace and passing the '-p' stressflag which
 # controls concurrency.
 `+regexp.QuoteMeta(`./scripts/gceworker.sh start && ./scripts/gceworker.sh mosh
 cd ~/go/src/github.com/cockroachdb/cockroach && \
-make stress TESTS=%s PKG=%s TESTTIMEOUT=5m STRESSFLAGS='-stderr=false -maxtime 20m -timeout 10m'`)+`
+make stressrace TESTS=%s PKG=%s TESTTIMEOUT=5m STRESSFLAGS='-maxtime 20m -timeout 10m' 2>&1 | tee /tmp/stress.log`)+`
 `+"```"+`
 
 Failed test: %s`,


### PR DESCRIPTION
Anecdotally, stressrace reproduces a larger percentage of failures.

Inspired by
https://github.com/cockroachdb/cockroach/issues/31000#issuecomment-430690035.

Release note: None