### PR TITLE
roachtest: only run synctest on v2.2.0 and later

### DIFF
--- a/pkg/cmd/roachtest/synctest.go
+++ b/pkg/cmd/roachtest/synctest.go
@@ -33,9 +33,10 @@ fi
 
 func registerSyncTest(r *registry) {
 	r.Add(testSpec{
-		Name:   "synctest",
-		Nodes:  nodes(1),
-		Stable: true, // DO NOT COPY to new tests
+		Name:       "synctest",
+		MinVersion: `v2.2.0`,
+		Nodes:      nodes(1),
+		Stable:     true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			n := c.Node(1)
 			tmpDir, err := ioutil.TempDir("", "synctest")


### PR DESCRIPTION
Fixes #31459

Release note: None