### PR TITLE
roachtest: fix artifacts publishing on TeamCity

### DIFF
--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -854,7 +854,7 @@ func (r *registry) runAsync(
 
 				if artifactsDir != "" {
 					escapedTestName := teamCityNameEscape(t.Name())
-					artifactsGlobPath := filepath.Join(artifactsDir, escapedTestName, "**")
+					artifactsGlobPath := filepath.Join(artifactsDir, "**")
 					artifactsSpec := fmt.Sprintf("%s => %s", artifactsGlobPath, escapedTestName)
 					fmt.Fprintf(r.out, "##teamcity[publishArtifacts '%s']\n", artifactsSpec)
 				}


### PR DESCRIPTION
Artifacts publishing broke recently when the way artifacts dirs started
being explicitly plumbed around. Before this patch, the wrong path was
being indicated to TC because test name was doubly-represented; it was
there both in the artifactsDir var and then we appended it again.

Release note: None