### PR TITLE
workloadccl: de-rot and unskip TestSetup

### DIFF
--- a/pkg/ccl/workloadccl/workload_test.go
+++ b/pkg/ccl/workloadccl/workload_test.go
@@ -23,7 +23,6 @@ import (
 
 func TestSetup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#24655")
 
 	get := func(name string) workload.Meta {
 		meta, err := workload.Get(name)
@@ -41,7 +40,7 @@ func TestSetup(t *testing.T) {
 	}{
 		{
 			meta:        get("roachmart"),
-			flags:       []string{"--users=10", "--orders=100"},
+			flags:       []string{"--users=10", "--orders=100", "--partition=false"},
 			batchSize:   100,
 			concurrency: 4,
 		},


### PR DESCRIPTION
I'm not 100% sure about this, but I think when 1bb7fa04e9c added the
`--partition` flag, the zone configs were silently dropped in this test.
7496288604c would have caught it, but the test had already been skipped
by then.

Didn't see this flake repro with roachprodstress

    60275 runs completed, 0 failures, over 1h24m26s

Closes #24655

Release note: None