### PR TITLE
storage: ensure kv.bulk_io_write settings are positive

### DIFF
--- a/pkg/settings/int.go
+++ b/pkg/settings/int.go
@@ -103,6 +103,16 @@ func RegisterNonNegativeIntSetting(key, desc string, defaultValue int64) *IntSet
 	})
 }
 
+// RegisterPositiveIntSetting defines a new setting with type int.
+func RegisterPositiveIntSetting(key, desc string, defaultValue int64) *IntSetting {
+	return RegisterValidatedIntSetting(key, desc, defaultValue, func(v int64) error {
+		if v < 1 {
+			return errors.Errorf("cannot set %s to a value < 1: %d", key, v)
+		}
+		return nil
+	})
+}
+
 // RegisterValidatedIntSetting defines a new setting with type int with a
 // validation function.
 func RegisterValidatedIntSetting(

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -113,7 +113,7 @@ var bulkIOWriteLimit = settings.RegisterByteSizeSetting(
 )
 
 // importRequestsLimit limits concurrent import requests.
-var importRequestsLimit = settings.RegisterIntSetting(
+var importRequestsLimit = settings.RegisterPositiveIntSetting(
 	"kv.bulk_io_write.concurrent_import_requests",
 	"number of import requests a store will handle concurrently before queuing",
 	1,
@@ -126,7 +126,7 @@ var importRequestsLimit = settings.RegisterIntSetting(
 // by a guessing - it could be improved by more measured heuristics. Exported
 // here since we check it in in the caller to limit generated requests as well
 // to prevent excessive queuing.
-var ExportRequestsLimit = settings.RegisterIntSetting(
+var ExportRequestsLimit = settings.RegisterPositiveIntSetting(
 	"kv.bulk_io_write.concurrent_export_requests",
 	"number of export requests a store will handle concurrently before queuing",
 	5,


### PR DESCRIPTION
Fixes #31571

Release note (bug fix): fix a panic when setting some kv.bulk_io_write
settings to a value < 1