### PR TITLE
backport-2.1: storage: resolve intents synchronously for splits/merges

### DIFF
--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -448,6 +449,11 @@ func resolveLocalIntents(
 
 	var externalIntents []roachpb.Span
 	var resolveAllowance int64 = intentResolutionBatchSize
+	if args.InternalCommitTrigger != nil {
+		// If this is a system transaction (such as a split or merge), don't enforce the resolve allowance.
+		// These transactions rely on having their intents resolved synchronously.
+		resolveAllowance = math.MaxInt64
+	}
 	for _, span := range args.IntentSpans {
 		if err := func() error {
 			if resolveAllowance == 0 {


### PR DESCRIPTION
Backport 1/1 commits from #31538.

/cc @cockroachdb/release

---

The resolve allowance isn't known to ever have fired for splits/merges
(it might be trigger-able with giant start/end keys), but it worried me
when I ran across it in:

https://github.com/cockroachdb/cockroach/issues/28005#issuecomment-408632803

Release note: None
