### PR TITLE
backport-2.1: webui: fix display of merges in rangelog

### DIFF
--- a/pkg/ui/src/views/reports/containers/range/logTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/logTable.tsx
@@ -37,6 +37,8 @@ function printLogEventType(
       return "Remove";
     case protos.cockroach.storage.RangeLogEventType.split:
       return "Split";
+    case protos.cockroach.storage.RangeLogEventType.merge:
+      return "Merge";
     default:
       return "Unknown";
   }


### PR DESCRIPTION
Backport 1/1 commits from #31543.

/cc @cockroachdb/release

---

It would previously show "unknown".

Observed in #31409.

Release note: None
