### PR TITLE
changefeedccl: escape kafka and avro names

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -79,21 +79,11 @@ type avroSchemaRecord struct {
 	alloc            sqlbase.DatumAlloc
 }
 
-func avroEscapeName(name string) string {
-	// TODO(dan): Name escaping.
-	return name
-}
-
-func avroUnescapeName(name string) string {
-	// TODO(dan): Name escaping.
-	return name
-}
-
 // columnDescToAvroSchema converts a column descriptor into its corresponding
 // avro field schema.
 func columnDescToAvroSchema(colDesc *sqlbase.ColumnDescriptor) (*avroSchemaField, error) {
 	schema := &avroSchemaField{
-		Name: avroEscapeName(colDesc.Name),
+		Name: SQLNameToAvroName(colDesc.Name),
 		typ:  colDesc.Type,
 	}
 
@@ -221,7 +211,7 @@ func indexToAvroSchema(
 	tableDesc *sqlbase.TableDescriptor, indexDesc *sqlbase.IndexDescriptor,
 ) (*avroSchemaRecord, error) {
 	schema := &avroSchemaRecord{
-		Name:             avroEscapeName(tableDesc.Name),
+		Name:             SQLNameToAvroName(tableDesc.Name),
 		SchemaType:       `record`,
 		fieldIdxByName:   make(map[string]int),
 		colIdxByFieldIdx: make(map[int]int),
@@ -256,7 +246,7 @@ func indexToAvroSchema(
 // record schema. The fields are kept in the same order as `tableDesc.Columns`.
 func tableToAvroSchema(tableDesc *sqlbase.TableDescriptor) (*avroSchemaRecord, error) {
 	schema := &avroSchemaRecord{
-		Name:             avroEscapeName(tableDesc.Name),
+		Name:             SQLNameToAvroName(tableDesc.Name),
 		SchemaType:       `record`,
 		fieldIdxByName:   make(map[string]int),
 		colIdxByFieldIdx: make(map[int]int),

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -102,14 +102,14 @@ func parseAvroSchema(j string) (*avroSchemaRecord, error) {
 	// serde. Instead of duplicating the logic, fake out a TableDescriptor, so
 	// we can reuse tableToAvroSchema and get them for free.
 	tableDesc := &sqlbase.TableDescriptor{
-		Name: avroUnescapeName(s.Name),
+		Name: AvroNameToSQLName(s.Name),
 	}
 	for _, f := range s.Fields {
 		// s.Fields[idx] has `Name` and `SchemaType` set but nonething else.
 		// They're needed for serialization/deserialization, so fake out a
 		// column descriptor so that we can reuse columnDescToAvroSchema to get
 		// all the various fields of avroSchemaField populated for free.
-		colDesc, err := avroSchemaToColDesc(avroUnescapeName(f.Name), f.SchemaType)
+		colDesc, err := avroSchemaToColDesc(AvroNameToSQLName(f.Name), f.SchemaType)
 		if err != nil {
 			return nil, err
 		}
@@ -273,6 +273,21 @@ func TestAvroSchema(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("escaping", func(t *testing.T) {
+		tableDesc, err := parseTableDesc(`CREATE TABLE "☃" (🍦 INT PRIMARY KEY)`)
+		require.NoError(t, err)
+		tableSchema, err := tableToAvroSchema(tableDesc)
+		require.NoError(t, err)
+		require.Equal(t,
+			`{"type":"record","name":"_u2603_","fields":[{"type":"long","name":"_u0001f366_"}]}`,
+			tableSchema.codec.Schema())
+		indexSchema, err := indexToAvroSchema(tableDesc, &tableDesc.PrimaryIndex)
+		require.NoError(t, err)
+		require.Equal(t,
+			`{"type":"record","name":"_u2603_","fields":[{"type":"long","name":"_u0001f366_"}]}`,
+			indexSchema.codec.Schema())
+	})
 }
 
 func (f *avroSchemaField) defaultValueNative() (interface{}, bool) {

--- a/pkg/ccl/changefeedccl/name.go
+++ b/pkg/ccl/changefeedccl/name.go
@@ -1,0 +1,117 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+var escapeRE = regexp.MustCompile(`_u[0-9a-fA-F]{2,8}_`)
+var kafkaDisallowedRE = regexp.MustCompile(`[^a-zA-Z0-9\._\-]`)
+var avroDisallowedRE = regexp.MustCompile(`[^A-Za-z0-9_]`)
+
+func escapeRune(r rune) string {
+	if r <= 1<<16 {
+		return fmt.Sprintf(`_u%04x_`, r)
+	}
+	return fmt.Sprintf(`_u%08x_`, r)
+}
+
+// SQLNameToKafkaName escapes a sql table name into a valid kafka topic name.
+// This is reversible by KafkaNameToSQLName except when the escaped string is
+// longer than kafka's length limit.
+//
+// Kafka allows names matching `[a-zA-Z0-9\._\-]{1,249}` excepting `.` and `..`.
+//
+// Runes are escaped with _u<hex>_ in an attempt to look like U+0021. For
+// example `!` escapes to `_u0021_`.
+func SQLNameToKafkaName(s string) string {
+	if s == `.` {
+		return escapeRune('.')
+	} else if s == `..` {
+		return escapeRune('.') + escapeRune('.')
+	}
+	s = escapeSQLName(s, kafkaDisallowedRE)
+	if len(s) > 249 {
+		// Not going to roundtrip, but not much we can do about that.
+		return s[:249]
+	}
+	return s
+}
+
+// KafkaNameToSQLName is the inverse of SQLNameToKafkaName except when
+// SQLNameToKafkaName had to truncate.
+func KafkaNameToSQLName(s string) string {
+	return unescapeSQLName(s)
+}
+
+// SQLNameToAvroName escapes a sql table name into a valid avro record or field
+// name. This is reversible by AvroNameToSQLName.
+//
+// Avro allows names matching `[a-zA-Z_][a-zA-Z0-9_]*`.
+//
+// Runes are escaped with _u<hex>_ in an attempt to look like U+0021. For
+// example `!` escapes to `_u0021_`.
+func SQLNameToAvroName(s string) string {
+	r, firstSize := utf8.DecodeRuneInString(s)
+	if r == utf8.RuneError {
+		// Invalid or empty string. Not much we can do here.
+		return s
+	}
+	// Avro disallows a leading 0-9, but allows them otherwise.
+	if r >= '0' && r <= '9' {
+		return escapeRune(r) + escapeSQLName(s[firstSize:], avroDisallowedRE)
+	}
+	return escapeSQLName(s, avroDisallowedRE)
+}
+
+// AvroNameToSQLName is the inverse of SQLNameToAvroName.
+func AvroNameToSQLName(s string) string {
+	return unescapeSQLName(s)
+}
+
+func escapeSQLName(s string, disallowedRE *regexp.Regexp) string {
+	// First replace anything that looks like an escape, so we can roundtrip.
+	s = escapeRE.ReplaceAllStringFunc(s, func(match string) string {
+		var ret strings.Builder
+		for _, r := range match {
+			ret.WriteString(escapeRune(r))
+		}
+		return ret.String()
+	})
+	// Then replace anything disallowed.
+	s = disallowedRE.ReplaceAllStringFunc(s, func(match string) string {
+		var ret strings.Builder
+		for _, r := range match {
+			ret.WriteString(escapeRune(r))
+		}
+		return ret.String()
+	})
+	return s
+}
+
+func unescapeSQLName(s string) string {
+	var buf [utf8.UTFMax]byte
+	s = escapeRE.ReplaceAllStringFunc(s, func(match string) string {
+		// Cut off the `_u` prefix and the `_` suffix.
+		hex := match[2 : len(match)-1]
+		r, err := strconv.ParseInt(hex, 16, 32)
+		if err != nil {
+			// Should be unreachable.
+			return match
+		}
+		n := utf8.EncodeRune(buf[:utf8.UTFMax], rune(r))
+		return string(buf[:n])
+	})
+	return s
+}

--- a/pkg/ccl/changefeedccl/name_test.go
+++ b/pkg/ccl/changefeedccl/name_test.go
@@ -1,0 +1,90 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLNameToKafkaName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		sql, kafka string
+	}{
+		{`foo`, `foo`},
+		{`abcdefghijklmnopqrstuvwxyz`, `abcdefghijklmnopqrstuvwxyz`},
+		{`ABCDEFGHIJKLMNOPQRSTUVWXYZ`, `ABCDEFGHIJKLMNOPQRSTUVWXYZ`},
+		{`0123456789_-.`, `0123456789_-.`},
+		{`!`, `_u0021_`},
+		{`!@#$%^&*()`, `_u0021__u0040__u0023__u0024__u0025__u005e__u0026__u002a__u0028__u0029_`},
+		{`foo!`, `foo_u0021_`},
+		{`!bar`, `_u0021_bar`},
+		{`foo!bar`, `foo_u0021_bar`},
+		{`foo_u0021_bar`, `foo_u005f__u0075__u0030__u0030__u0032__u0031__u005f_bar`},
+		{`/`, `_u002f_`},
+		{`☃`, `_u2603_`},
+		{"\x00", `_u0000_`},
+		{string(utf8.RuneSelf), `_u0080_`},
+		{string(utf8.MaxRune), `_u0010ffff_`},
+		// special case: exact match of . and .. are disallowed by kafka
+		{`.`, `_u002e_`},
+		{`..`, `_u002e__u002e_`},
+	}
+	for i, test := range tests {
+		if k := SQLNameToKafkaName(test.sql); k != test.kafka {
+			t.Errorf(`%d: %s did not escape to %s got %s`, i, test.sql, test.kafka, k)
+		}
+		if s := KafkaNameToSQLName(test.kafka); s != test.sql {
+			t.Errorf(`%d: %s did not unescape to %s got %s`, i, test.kafka, test.sql, s)
+		}
+	}
+	// We don't produce capital letters in escapes but check them anyway.
+	require.Equal(t, `/`, KafkaNameToSQLName(`_u2F_`))
+}
+
+func TestSQLNameToAvroName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		sql, avro string
+	}{
+		{`foo`, `foo`},
+		{`abcdefghijklmnopqrstuvwxyz`, `abcdefghijklmnopqrstuvwxyz`},
+		{`ABCDEFGHIJKLMNOPQRSTUVWXYZ`, `ABCDEFGHIJKLMNOPQRSTUVWXYZ`},
+		// special case: avro disallows 0-9 in the first character, but allows them otherwise
+		{`0123456789_-.`, `_u0030_123456789__u002d__u002e_`},
+		{`99`, `_u0039_9`},
+		{`!`, `_u0021_`},
+		{`!@#$%^&*()`, `_u0021__u0040__u0023__u0024__u0025__u005e__u0026__u002a__u0028__u0029_`},
+		{`foo!`, `foo_u0021_`},
+		{`!bar`, `_u0021_bar`},
+		{`foo!bar`, `foo_u0021_bar`},
+		{`foo_u0021_bar`, `foo_u005f__u0075__u0030__u0030__u0032__u0031__u005f_bar`},
+		{`/`, `_u002f_`},
+		{`☃`, `_u2603_`},
+		{"\x00", `_u0000_`},
+		{string(utf8.RuneSelf), `_u0080_`},
+		{string(utf8.MaxRune), `_u0010ffff_`},
+	}
+	for i, test := range tests {
+		if a := SQLNameToAvroName(test.sql); a != test.avro {
+			t.Errorf(`%d: %s did not escape to %s got %s`, i, test.sql, test.avro, a)
+		}
+		if s := AvroNameToSQLName(test.avro); s != test.sql {
+			t.Errorf(`%d: %s did not unescape to %s got %s`, i, test.avro, test.sql, s)
+		}
+	}
+	// We don't produce capital letters in escapes but check them anyway.
+	require.Equal(t, `/`, KafkaNameToSQLName(`_u2F_`))
+}

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -134,7 +134,7 @@ func getKafkaSink(
 	}
 	sink.topics = make(map[string]struct{})
 	for _, t := range targets {
-		sink.topics[kafkaTopicPrefix+t.StatementTimeName] = struct{}{}
+		sink.topics[kafkaTopicPrefix+SQLNameToKafkaName(t.StatementTimeName)] = struct{}{}
 	}
 
 	config := sarama.NewConfig()
@@ -211,7 +211,7 @@ func (s *kafkaSink) Close() error {
 
 // EmitRow implements the Sink interface.
 func (s *kafkaSink) EmitRow(ctx context.Context, tableName string, key, value []byte) error {
-	topic := s.kafkaTopicPrefix + tableName
+	topic := s.kafkaTopicPrefix + SQLNameToKafkaName(tableName)
 	if _, ok := s.topics[topic]; !ok {
 		return errors.Errorf(`cannot emit to undeclared topic: %s`, topic)
 	}


### PR DESCRIPTION
Our sql table and field names can be strings that are not allowed as
kafka topics or avro record/field names. This escapes disallowed runes
with `_u<hex>_`. For example `!` escapes to `_u0021_`.

Closes #30378

Release note (bug fix): CHANGEFEEDs now escape kafka topic names when
necessary