### PR TITLE
kv: properly mark r/o txns as committed

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -566,6 +566,11 @@ func (tc *TxnCoordSender) commitReadOnlyTxnLocked(
 		return roachpb.NewError(
 			roachpb.NewTransactionStatusError("deadline exceeded before transaction finalization"))
 	}
+	tc.mu.txnState = txnFinalized
+	// Mark the transaction as committed so that, in case this commit is done by
+	// the closure passed to db.Txn()), db.Txn() doesn't attempt to commit again.
+	// Also so that the correct metric gets incremented.
+	tc.mu.txn.Status = roachpb.COMMITTED
 	tc.cleanupTxnLocked(ctx)
 	return nil
 }

--- a/pkg/kv/txn_interceptor_metrics.go
+++ b/pkg/kv/txn_interceptor_metrics.go
@@ -109,6 +109,8 @@ func (m *txnMetrics) closeLocked() {
 		// transactions should be accounted.
 		m.metrics.Aborts.Inc(1)
 	case roachpb.COMMITTED:
+		// Note that successful read-only txn are also counted as committed, even
+		// though they never had a txn record.
 		m.metrics.Commits.Inc(1)
 	}
 }


### PR DESCRIPTION
Readonly txns have a special commit path. This path wasn't marking the
txn as committed correctly, which had a couple of consequences:
- db.Txn() would potentially try to commit again, in case the closure
already did it
- the txn.aborted metric was incremented

Fixes #31595

Release note: Fix a bug causing committed read-only txns to be counted
as aborted in the metrics.