### PR TITLE
sql: increase usage of MutableTableDescriptor

### DIFF
--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -141,7 +141,7 @@ func (replaceMinMaxValVisitor) VisitPost(expr tree.Expr) tree.Expr { return expr
 func createPartitioningImpl(
 	ctx context.Context,
 	evalCtx *tree.EvalContext,
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.MutableTableDescriptor,
 	indexDesc *sqlbase.IndexDescriptor,
 	partBy *tree.PartitionBy,
 	colOffset int,
@@ -239,7 +239,7 @@ func createPartitioning(
 	ctx context.Context,
 	st *cluster.Settings,
 	evalCtx *tree.EvalContext,
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.MutableTableDescriptor,
 	indexDesc *sqlbase.IndexDescriptor,
 	partBy *tree.PartitionBy,
 ) (sqlbase.PartitioningDescriptor, error) {

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -27,7 +27,7 @@ import (
 
 type alterIndexNode struct {
 	n         *tree.AlterIndex
-	tableDesc *sqlbase.TableDescriptor
+	tableDesc *sqlbase.MutableTableDescriptor
 	indexDesc *sqlbase.IndexDescriptor
 }
 

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -24,7 +24,7 @@ import (
 
 type alterSequenceNode struct {
 	n       *tree.AlterSequence
-	seqDesc *sqlbase.TableDescriptor
+	seqDesc *sqlbase.MutableTableDescriptor
 }
 
 // AlterSequence transforms a tree.AlterSequence into a plan node.

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -37,7 +37,7 @@ import (
 
 type alterTableNode struct {
 	n         *tree.AlterTable
-	tableDesc *sqlbase.TableDescriptor
+	tableDesc *MutableTableDescriptor
 	// statsData is populated with data for "alter table inject statistics"
 	// commands - the JSON stats expressions.
 	// It is parallel with n.Cmds (for the inject stats commands).
@@ -214,7 +214,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 
 			case *tree.CheckConstraintTableDef:
 				ck, err := MakeCheckConstraint(params.ctx,
-					*n.tableDesc, d, inuseNames, &params.p.semaCtx, params.EvalContext(), n.n.Table)
+					n.tableDesc, d, inuseNames, &params.p.semaCtx, params.EvalContext(), n.n.Table)
 				if err != nil {
 					return err
 				}
@@ -232,7 +232,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 						return err
 					}
 				}
-				affected := make(map[sqlbase.ID]*sqlbase.TableDescriptor)
+				affected := make(map[sqlbase.ID]*sqlbase.MutableTableDescriptor)
 
 				// If there are any FKs, we will need to update the table descriptor of the
 				// depended-on table (to register this table against its DependedOnBy field).
@@ -645,7 +645,7 @@ func (n *alterTableNode) Close(context.Context)        {}
 // columnDescriptor, and saves the containing table descriptor. If the column's
 // dependencies on sequences change, it updates them as well.
 func applyColumnMutation(
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.MutableTableDescriptor,
 	col *sqlbase.ColumnDescriptor,
 	mut tree.ColumnMutationCmd,
 	params runParams,

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -26,7 +26,7 @@ import (
 
 type createIndexNode struct {
 	n         *tree.CreateIndex
-	tableDesc *sqlbase.TableDescriptor
+	tableDesc *sqlbase.MutableTableDescriptor
 }
 
 // CreateIndex creates an index.

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -146,7 +146,7 @@ func MakeSequenceTableDesc(
 	creationTime hlc.Timestamp,
 	privileges *sqlbase.PrivilegeDescriptor,
 	settings *cluster.Settings,
-) (sqlbase.TableDescriptor, error) {
+) (sqlbase.MutableTableDescriptor, error) {
 	desc := InitTableDescriptor(id, parentID, sequenceName, creationTime, privileges)
 
 	// Mimic a table with one column, "value".

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -208,7 +208,7 @@ func (n *createViewNode) makeViewTableDesc(
 	id sqlbase.ID,
 	resultColumns []sqlbase.ResultColumn,
 	privileges *sqlbase.PrivilegeDescriptor,
-) (sqlbase.TableDescriptor, error) {
+) (sqlbase.MutableTableDescriptor, error) {
 	desc := InitTableDescriptor(id, parentID, viewName,
 		params.p.txn.CommitTimestamp(), privileges)
 	desc.ViewQuery = tree.AsStringWithFlags(n.n.AsSource, tree.FmtParsable)
@@ -248,7 +248,7 @@ func MakeViewTableDesc(
 	privileges *sqlbase.PrivilegeDescriptor,
 	semaCtx *tree.SemaContext,
 	evalCtx *tree.EvalContext,
-) (sqlbase.TableDescriptor, error) {
+) (sqlbase.MutableTableDescriptor, error) {
 	viewName := n.Name.Table()
 	desc := InitTableDescriptor(id, parentID, viewName, creationTime, privileges)
 	desc.ViewQuery = tree.AsStringWithFlags(n.AsSource, tree.FmtParsable)

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -117,7 +117,7 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 	p := params.p
 	tbNameStrings := make([]string, 0, len(n.td))
 	droppedTableDetails := make([]jobspb.DroppedTableDetails, 0, len(n.td))
-	tableDescs := make([]*sqlbase.TableDescriptor, 0, len(n.td))
+	tableDescs := make([]*sqlbase.MutableTableDescriptor, 0, len(n.td))
 
 	for _, toDel := range n.td {
 		if toDel.desc.IsView() {
@@ -233,7 +233,7 @@ func (p *planner) filterCascadedTables(ctx context.Context, tables []toDelete) (
 }
 
 func (p *planner) accumulateDependentTables(
-	ctx context.Context, dependentTables map[sqlbase.ID]bool, desc *sqlbase.TableDescriptor,
+	ctx context.Context, dependentTables map[sqlbase.ID]bool, desc *sqlbase.MutableTableDescriptor,
 ) error {
 	for _, ref := range desc.DependedOnBy {
 		dependentTables[ref.ID] = true

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -109,7 +109,7 @@ func (p *planner) dropIndexByName(
 	ctx context.Context,
 	tn *tree.TableName,
 	idxName tree.UnrestrictedName,
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.MutableTableDescriptor,
 	ifExists bool,
 	behavior tree.DropBehavior,
 	constraintBehavior dropIndexConstraintBehavior,

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -91,7 +91,7 @@ func (*dropSequenceNode) Values() tree.Datums          { return tree.Datums{} }
 func (*dropSequenceNode) Close(context.Context)        {}
 
 func (p *planner) dropSequenceImpl(
-	ctx context.Context, seqDesc *sqlbase.TableDescriptor, behavior tree.DropBehavior,
+	ctx context.Context, seqDesc *sqlbase.MutableTableDescriptor, behavior tree.DropBehavior,
 ) error {
 	return p.initiateDropTable(ctx, seqDesc, true /* drainName */)
 }
@@ -100,7 +100,7 @@ func (p *planner) dropSequenceImpl(
 // a table uses it in a DEFAULT expression on one of its columns, or nil if there is no
 // such dependency.
 func (p *planner) sequenceDependencyError(
-	ctx context.Context, droppedDesc *sqlbase.TableDescriptor,
+	ctx context.Context, droppedDesc *sqlbase.MutableTableDescriptor,
 ) error {
 	if len(droppedDesc.DependedOnBy) > 0 {
 		return pgerror.NewErrorf(

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -122,7 +122,7 @@ func descInSlice(descID sqlbase.ID, td []toDelete) bool {
 
 func (p *planner) canRemoveDependentView(
 	ctx context.Context,
-	from *sqlbase.TableDescriptor,
+	from *sqlbase.MutableTableDescriptor,
 	ref sqlbase.TableDescriptor_Reference,
 	behavior tree.DropBehavior,
 ) error {
@@ -157,7 +157,7 @@ func (p *planner) canRemoveDependentViewGeneric(
 // Returns the names of any additional views that were also dropped
 // due to `cascade` behavior.
 func (p *planner) removeDependentView(
-	ctx context.Context, tableDesc, viewDesc *sqlbase.TableDescriptor,
+	ctx context.Context, tableDesc, viewDesc *sqlbase.MutableTableDescriptor,
 ) ([]string, error) {
 	// In the table whose index is being removed, filter out all back-references
 	// that refer to the view that's being removed.
@@ -170,7 +170,7 @@ func (p *planner) removeDependentView(
 // if `cascade is specified`). Returns the names of any additional views that
 // were also dropped due to `cascade` behavior.
 func (p *planner) dropViewImpl(
-	ctx context.Context, viewDesc *sqlbase.TableDescriptor, behavior tree.DropBehavior,
+	ctx context.Context, viewDesc *sqlbase.MutableTableDescriptor, behavior tree.DropBehavior,
 ) ([]string, error) {
 	var cascadeDroppedViews []string
 
@@ -223,7 +223,7 @@ func (p *planner) getViewDescForCascade(
 	objName string,
 	parentID, viewID sqlbase.ID,
 	behavior tree.DropBehavior,
-) (*sqlbase.TableDescriptor, error) {
+) (*sqlbase.MutableTableDescriptor, error) {
 	viewDesc, err := sqlbase.GetTableDescFromID(ctx, p.txn, viewID)
 	if err != nil {
 		log.Warningf(ctx, "unable to retrieve descriptor for view %d: %v", viewID, err)

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -29,7 +29,7 @@ var errEmptyColumnName = pgerror.NewError(pgerror.CodeSyntaxError, "empty column
 
 type renameColumnNode struct {
 	n         *tree.RenameColumn
-	tableDesc *sqlbase.TableDescriptor
+	tableDesc *sqlbase.MutableTableDescriptor
 }
 
 // RenameColumn renames the column.

--- a/pkg/sql/rename_index.go
+++ b/pkg/sql/rename_index.go
@@ -28,7 +28,7 @@ var errEmptyIndexName = pgerror.NewError(pgerror.CodeSyntaxError, "empty index n
 
 type renameIndexNode struct {
 	n         *tree.RenameIndex
-	tableDesc *sqlbase.TableDescriptor
+	tableDesc *sqlbase.MutableTableDescriptor
 	idx       sqlbase.IndexDescriptor
 }
 

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -29,7 +29,7 @@ import (
 type renameTableNode struct {
 	n            *tree.RenameTable
 	oldTn, newTn *tree.TableName
-	tableDesc    *sqlbase.TableDescriptor
+	tableDesc    *sqlbase.MutableTableDescriptor
 }
 
 // RenameTable renames the table, view or sequence.

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -461,7 +461,7 @@ func (p *planner) getTableAndIndex(
 	table *tree.TableName,
 	tableWithIndex *tree.TableNameWithIndex,
 	privilege privilege.Kind,
-) (*sqlbase.TableDescriptor, *sqlbase.IndexDescriptor, error) {
+) (*MutableTableDescriptor, *sqlbase.IndexDescriptor, error) {
 	var tableDesc *MutableTableDescriptor
 	var err error
 	if tableWithIndex == nil {

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -50,7 +50,7 @@ type (
 	ObjectDescriptor = sqlbase.TableDescriptor
 	// MutableTableDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
-	MutableTableDescriptor = sqlbase.TableDescriptor
+	MutableTableDescriptor = sqlbase.MutableTableDescriptor
 	// UncachedTableDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	// It is an immutable descriptor read from the store.

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -294,24 +294,24 @@ func assignSequenceOptions(
 // The passed-in column descriptor is mutated, and the modified sequence descriptors are returned.
 func maybeAddSequenceDependencies(
 	sc SchemaResolver,
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.MutableTableDescriptor,
 	col *sqlbase.ColumnDescriptor,
 	expr tree.TypedExpr,
 	evalCtx *tree.EvalContext,
-) ([]*MutableTableDescriptor, error) {
+) ([]*sqlbase.MutableTableDescriptor, error) {
 	ctx := evalCtx.Ctx()
 	seqNames, err := getUsedSequenceNames(expr)
 	if err != nil {
 		return nil, err
 	}
-	var seqDescs []*sqlbase.TableDescriptor
+	var seqDescs []*sqlbase.MutableTableDescriptor
 	for _, seqName := range seqNames {
 		parsedSeqName, err := evalCtx.Sequence.ParseQualifiedTableName(ctx, seqName)
 		if err != nil {
 			return nil, err
 		}
 
-		var seqDesc *MutableTableDescriptor
+		var seqDesc *sqlbase.MutableTableDescriptor
 		p, ok := sc.(*planner)
 		if ok {
 			seqDesc, err = p.ResolveMutableTableDescriptor(ctx, parsedSeqName, true /*required*/, requireSequenceDesc)
@@ -342,7 +342,7 @@ func maybeAddSequenceDependencies(
 //   - writes the sequence descriptor and notifies a schema change.
 // The column descriptor is mutated but not saved to persistent storage; the caller must save it.
 func removeSequenceDependencies(
-	tableDesc *sqlbase.TableDescriptor, col *sqlbase.ColumnDescriptor, params runParams,
+	tableDesc *sqlbase.MutableTableDescriptor, col *sqlbase.ColumnDescriptor, params runParams,
 ) error {
 	for _, sequenceID := range col.UsesSequenceIds {
 		// Get the sequence descriptor so we can remove the reference from it.

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -103,6 +103,10 @@ const (
 // MutationID is a custom type for TableDescriptor mutations.
 type MutationID uint32
 
+// MutableTableDescriptor is a custom type for TableDescriptors
+// going through mutations.
+type MutableTableDescriptor = TableDescriptor
+
 // InvalidMutationID is the uninitialised mutation id.
 const InvalidMutationID MutationID = 0
 


### PR DESCRIPTION
This is the first step in replacing the MutableTableDescriptor type
alias with a new struct type which will make schema changes earlier in
the same transaction visible.

Release note: None