### PR TITLE
storage: remove logging on GC suggestion

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3636,8 +3636,6 @@ func (s *Store) HandleRaftResponse(ctx context.Context, resp *RaftMessageRespons
 
 			if _, err := s.replicaGCQueue.Add(repl, replicaGCPriorityRemoved); err != nil {
 				log.Errorf(ctx, "unable to add to replica GC queue: %s", err)
-			} else {
-				log.Infof(ctx, "added to replica GC queue (peer suggestion)")
 			}
 		case *roachpb.RaftGroupDeletedError:
 			if replErr != nil {
@@ -3655,8 +3653,6 @@ func (s *Store) HandleRaftResponse(ctx context.Context, resp *RaftMessageRespons
 			// proper check.
 			if _, err := s.replicaGCQueue.Add(repl, replicaGCPriorityDefault); err != nil {
 				log.Errorf(ctx, "unable to add to replica GC queue: %s", err)
-			} else {
-				log.Infof(ctx, "added to replica GC queue (contacted deleted peer)")
 			}
 		case *roachpb.StoreNotFoundError:
 			log.Warningf(ctx, "raft error: node %d claims to not contain store %d for replica %s: %s",


### PR DESCRIPTION
These are expected during regular rebalancing activity and they can get
quite spammy, see for example:

https://github.com/cockroachdb/cockroach/issues/31622

Release note: None