### PR TITLE
storage: remove spurious call to maybeInlineSideloadedRaftCommand

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4323,16 +4323,9 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	for _, e := range rd.CommittedEntries {
 		switch e.Type {
 		case raftpb.EntryNormal:
-			// Committed entries come straight from the Raft log. Consequently,
-			// sideloaded SSTables are not usually inlined.
-			if newEnt, err := maybeInlineSideloadedRaftCommand(
-				ctx, r.RangeID, e, r.raftMu.sideloaded, r.store.raftEntryCache,
-			); err != nil {
-				const expl = "maybeInlineSideloadedRaftCommand"
-				return stats, expl, errors.Wrap(err, expl)
-			} else if newEnt != nil {
-				e = *newEnt
-			}
+			// NB: Committed entries are handed to us by Raft. Raft does not
+			// know about sideloading. Consequently the entries here are all
+			// already inlined.
 
 			var commandID storagebase.CmdIDKey
 			var command storagepb.RaftCommand

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -84,6 +84,9 @@ func (r *replicaRaftStorage) Entries(lo, hi, maxBytes uint64) ([]raftpb.Entry, e
 	readonly := r.store.Engine().NewReadOnly()
 	defer readonly.Close()
 	ctx := r.AnnotateCtx(context.TODO())
+	if r.raftMu.sideloaded == nil {
+		return nil, errors.New("sideloaded storage is uninitialized")
+	}
 	return entries(ctx, r.mu.stateLoader, readonly, r.RangeID, r.store.raftEntryCache,
 		r.raftMu.sideloaded, lo, hi, maxBytes)
 }


### PR DESCRIPTION
Entries are "thinned" only when passed to `r.append()` (i.e. written to
disk) and they are always returned "fat" from `Entries()` (i.e. Raft's way
to get entries from disk). Consequently Raft never sees thin entries and
won't ask us to commit them.

Touches #31618.

Release note: None