### PR TITLE
storage: do not share an error across proposals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -838,7 +838,7 @@ stressrace: ## Run tests under stress with the race detector enabled.
 stress stressrace:
 	$(xgo) test $(GOFLAGS) -exec 'stress $(STRESSFLAGS)' -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run "$(TESTS)" -timeout 0 $(PKG) $(filter-out -v,$(TESTFLAGS)) -v -args -test.timeout $(TESTTIMEOUT)
 
-.PHONE: roachprod-stress roachprod-stressrace
+.PHONY: roachprod-stress roachprod-stressrace
 roachprod-stress roachprod-stressrace: bin/roachprod-stress
 	# The bootstrap target creates, among other things, ./bin/stress.
 	build/builder.sh make bin/.bootstrap


### PR DESCRIPTION
Replica.cancelPendingCommandsLocked was sharing an error across multiple
proposals. This is problematic because Store.Send mutates Error.Now.

Fixes #31535
Fixes #30483

Release note: None