### PR TITLE
release-2.1: storage: do not share an error across proposals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -838,7 +838,7 @@ stressrace: ## Run tests under stress with the race detector enabled.
 stress stressrace:
 	$(xgo) test $(GOFLAGS) -exec 'stress $(STRESSFLAGS)' -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run "$(TESTS)" -timeout 0 $(PKG) $(filter-out -v,$(TESTFLAGS)) -v -args -test.timeout $(TESTTIMEOUT)
 
-.PHONE: roachprod-stress
+.PHONY: roachprod-stress
 roachprod-stress: bin/roachprod-stress
 	build/builder.sh make bin/stress
 	build/builder.sh make test GOFLAGS="-i -v -c -o $(notdir $(PKG)).test" PKG=$(PKG)

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -881,13 +881,14 @@ func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb
 
 func (r *Replica) cancelPendingCommandsLocked() {
 	r.mu.AssertHeld()
-	pr := proposalResult{
-		Err:           roachpb.NewError(roachpb.NewAmbiguousResultError("removing replica")),
-		ProposalRetry: proposalRangeNoLongerExists,
-	}
 	for _, p := range r.mu.localProposals {
 		r.cleanupFailedProposalLocked(p)
-		p.finishApplication(pr)
+		// NB: each proposal needs its own version of the error (i.e. don't try to
+		// share the error across proposals).
+		p.finishApplication(proposalResult{
+			Err:           roachpb.NewError(roachpb.NewAmbiguousResultError("removing replica")),
+			ProposalRetry: proposalRangeNoLongerExists,
+		})
 	}
 	r.mu.remoteProposals = nil
 }


### PR DESCRIPTION
Backport 2/2 commits from #31631.

/cc @cockroachdb/release

---

Replica.cancelPendingCommandsLocked was sharing an error across multiple
proposals. This is problematic because Store.Send mutates Error.Now.

Fixes #31535
Fixes #30483

Release note: None
