### PR TITLE
rpc: Make sure circuitbreaker gets un-tripped upon success

### DIFF
--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -103,6 +103,12 @@ func (n *Dialer) Dial(ctx context.Context, nodeID roachpb.NodeID) (_ *grpc.Clien
 		return nil, err
 	}
 	breaker.Success()
+	// This really shouldn't be necessary, but Success() isn't guaranteed to
+	// close the breaker and the upstream vendored repo is dead, so just work
+	// around it by resetting the breaker manually if it's still tripped.
+	if breaker.Tripped() {
+		breaker.Reset()
+	}
 	return conn, nil
 }
 


### PR DESCRIPTION
This should really be part of the Success() method itself, but as noted
in #31295 it only resets whether it's tripped if it's currently in the
halfopen state, but sometimes it can be in the open state.

This band-aid is just working around the fact that the upstream repo has
had no activity for a year and a half.

Fixes #31295

Release note: None