### PR TITLE
[wip] document that race detector reports wrong goroutine ids

### DIFF
--- a/pkg/testutils/error_test.go
+++ b/pkg/testutils/error_test.go
@@ -15,9 +15,15 @@
 package testutils
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/petermattis/goid"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"time"
+	"runtime/debug"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 func TestIsSQLRetryableError(t *testing.T) {
@@ -25,4 +31,23 @@ func TestIsSQLRetryableError(t *testing.T) {
 	if !IsSQLRetryableError(roachpb.NewError(errAmbiguous).GoError()) {
 		t.Fatalf("%s should be a SQLRetryableError", errAmbiguous)
 	}
+}
+
+func TestGoroutine(t *testing.T) {
+	ctx := context.TODO()
+
+	var a int
+	f := func() {
+		myid := goid.Get()
+		tBegin := timeutil.Now()
+		log.Infof(ctx, "my id is %d", myid)
+		time.Sleep(time.Second)
+		debug.PrintStack()
+		for timeutil.Since(tBegin) < 3*time.Second {
+			a = 5
+		}
+	}
+	go f()
+	f()
+	t.Log(a)
 }


### PR DESCRIPTION
@petermattis I don't have time to pull on this thread right now, but it's interesting

Spawned from
https://github.com/cockroachdb/cockroach/issues/31535#issuecomment-430697339.

```
[tschottdorf@toblerone cockroach (fix/race-goroutine-id)]$ make testrace PKG=./pkg/testutils
Running make with -j8
GOPATH set to /Users/tschottdorf/go
go test -race -tags ' make x86_64_apple_darwin18.0.0' -ldflags '-X github.com/cockroachdb/cockroach/pkg/build.typ=development -extldflags "" -X "github.com/cockroachdb/cockroach/pkg/build.tag=v2.2.0-alpha.00000000-1804-g91b9c04cfe-dirty" -X "github.com/cockroachdb/cockroach/pkg/build.rev=91b9c04cfe72a501e084cd21eaf44569b19e5d56" -X "github.com/cockroachdb/cockroach/pkg/build.cgoTargetTriple=x86_64-apple-darwin18.0.0"  ' -run "."  -timeout 25m ./pkg/testutils
I181019 16:29:57.839687 26 testutils/error_test.go:43  my id is 26
I181019 16:29:57.839720 27 testutils/error_test.go:43  my id is 27
goroutine 26 [running]:
runtime/debug.Stack(0x4bcef99, 0xc000070e70, 0x404fe5f)
	/usr/local/Cellar/go/1.11.1/libexec/src/runtime/debug/stack.go:24 +0xb5
runtime/debug.PrintStack()
	/usr/local/Cellar/go/1.11.1/libexec/src/runtime/debug/stack.go:16 +0x34
github.com/cockroachdb/cockroach/pkg/testutils.TestGoroutine.func1()
	/Users/tschottdorf/go/src/github.com/cockroachdb/cockroach/pkg/testutils/error_test.go:45 +0x129
github.com/cockroachdb/cockroach/pkg/testutils.TestGoroutine(0xc000190300)
	/Users/tschottdorf/go/src/github.com/cockroachdb/cockroach/pkg/testutils/error_test.go:51 +0x127
testing.tRunner(0xc000190300, 0x4e66458)
	/usr/local/Cellar/go/1.11.1/libexec/src/testing/testing.go:827 +0x163
created by testing.(*T).Run
	/usr/local/Cellar/go/1.11.1/libexec/src/testing/testing.go:878 +0x651
goroutine 27 [running]:
runtime/debug.Stack(0x4bcef99, 0xc000531f38, 0x404fe5f)
	/usr/local/Cellar/go/1.11.1/libexec/src/runtime/debug/stack.go:24 +0xb5
runtime/debug.PrintStack()
	/usr/local/Cellar/go/1.11.1/libexec/src/runtime/debug/stack.go:16 +0x34
github.com/cockroachdb/cockroach/pkg/testutils.TestGoroutine.func1()
	/Users/tschottdorf/go/src/github.com/cockroachdb/cockroach/pkg/testutils/error_test.go:45 +0x129
created by github.com/cockroachdb/cockroach/pkg/testutils.TestGoroutine
	/Users/tschottdorf/go/src/github.com/cockroachdb/cockroach/pkg/testutils/error_test.go:50 +0x11d
==================
WARNING: DATA RACE
Write at 0x00c0000ba1a8 by goroutine 24:
  github.com/cockroachdb/cockroach/pkg/testutils.TestGoroutine.func1()
      /Users/tschottdorf/go/src/github.com/cockroachdb/cockroach/pkg/testutils/error_test.go:47 +0x138

Previous write at 0x00c0000ba1a8 by goroutine 23:
  github.com/cockroachdb/cockroach/pkg/testutils.TestGoroutine.func1()
      /Users/tschottdorf/go/src/github.com/cockroachdb/cockroach/pkg/testutils/error_test.go:47 +0x138
  github.com/cockroachdb/cockroach/pkg/testutils.TestGoroutine()
      /Users/tschottdorf/go/src/github.com/cockroachdb/cockroach/pkg/testutils/error_test.go:51 +0x126
  testing.tRunner()
      /usr/local/Cellar/go/1.11.1/libexec/src/testing/testing.go:827 +0x162

Goroutine 24 (running) created at:
  github.com/cockroachdb/cockroach/pkg/testutils.TestGoroutine()
      /Users/tschottdorf/go/src/github.com/cockroachdb/cockroach/pkg/testutils/error_test.go:50 +0x11c
  testing.tRunner()
      /usr/local/Cellar/go/1.11.1/libexec/src/testing/testing.go:827 +0x162

Goroutine 23 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go/1.11.1/libexec/src/testing/testing.go:878 +0x650
  testing.runTests.func1()
      /usr/local/Cellar/go/1.11.1/libexec/src/testing/testing.go:1119 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go/1.11.1/libexec/src/testing/testing.go:827 +0x162
  testing.runTests()
      /usr/local/Cellar/go/1.11.1/libexec/src/testing/testing.go:1117 +0x4ee
  testing.(*M).Run()
      /usr/local/Cellar/go/1.11.1/libexec/src/testing/testing.go:1034 +0x2ee
  main.main()
      _testmain.go:56 +0x221
==================
FAIL	github.com/cockroachdb/cockroach/pkg/testutils	1.107s
make: *** [testrace] Error 1
```

Release note: None