### PR TITLE
build: speed up Docker for Mac protobuf compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1055,13 +1055,15 @@ bin/.go_protobuf_sources: $(PROTOC) $(GO_PROTOS) $(GOGOPROTO_PROTO) bin/.bootstr
 	set -e; for dir in $(sort $(dir $(GO_PROTOS))); do \
 	  build/werror.sh $(PROTOC) -Ipkg:./vendor/github.com:$(GOGO_PROTOBUF_PATH):$(PROTOBUF_PATH):$(COREOS_PATH):$(GRPC_GATEWAY_GOOGLEAPIS_PATH) --gogoroach_out=$(PROTO_MAPPINGS),plugins=grpc,import_prefix=github.com/cockroachdb/cockroach/pkg/:./pkg $$dir/*.proto; \
 	done
-	$(SED_INPLACE) '/import _/d' $(GO_SOURCES)
-	$(SED_INPLACE) -E 's!import (fmt|math) "github.com/cockroachdb/cockroach/pkg/(fmt|math)"! !g' $(GO_SOURCES)
-	$(SED_INPLACE) -E 's!github\.com/cockroachdb/cockroach/pkg/(etcd)!go.etcd.io/\1!g' $(GO_SOURCES)
-	$(SED_INPLACE) -E 's!cockroachdb/cockroach/pkg/(prometheus/client_model)!\1/go!g' $(GO_SOURCES)
-	$(SED_INPLACE) -E 's!github.com/cockroachdb/cockroach/pkg/(bytes|encoding/binary|errors|fmt|io|math|github\.com|(google\.)?golang\.org)!\1!g' $(GO_SOURCES)
-	@# TODO(benesch): Remove after https://github.com/grpc/grpc-go/issues/711.
-	$(SED_INPLACE) -E 's!golang.org/x/net/context!context!g' $(GO_SOURCES)
+	$(SED_INPLACE) -E \
+		-e '/import _/d' \
+		-e 's!import (fmt|math) "github.com/cockroachdb/cockroach/pkg/(fmt|math)"! !g' \
+		-e 's!github\.com/cockroachdb/cockroach/pkg/(etcd)!go.etcd.io/\1!g' \
+		-e 's!cockroachdb/cockroach/pkg/(prometheus/client_model)!\1/go!g' \
+		-e 's!github.com/cockroachdb/cockroach/pkg/(bytes|encoding/binary|errors|fmt|io|math|github\.com|(google\.)?golang\.org)!\1!g' \
+		-e 's!golang.org/x/net/context!context!g' \
+		$(GO_SOURCES)
+	@# TODO(benesch): Remove the last sed command after https://github.com/grpc/grpc-go/issues/711.
 	gofmt -s -w $(GO_SOURCES)
 	touch $@
 

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20181015-212512
+version=20181019-161416
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -153,6 +153,28 @@ RUN ln -s /usr/bin/ccache /usr/local/lib/ccache/x86_64-apple-darwin13-cc \
 
 ENV PATH $PATH:/x-tools/x86_64-apple-darwin13/bin
 
+# automake - sed build
+# autopoint - sed build
+# gettext - sed build
+# rsync - sed build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    automake \
+    autopoint \
+    gettext \
+    rsync
+
+# Compile GNU sed from source to pick up an unreleased change that buffers
+# output. This speeds up compiles on Docker for Mac by *minutes*.
+RUN git clone git://git.sv.gnu.org/sed \
+ && cd sed \
+ && git checkout 8e52c0aff039f0a88127ca131b060050c107b0e2 \
+ && ./bootstrap \
+ && ./configure \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf sed
+
 # Compile Go from source so that CC defaults to clang instead of gcc. This
 # requires a Go toolchain to bootstrap.
 #
@@ -222,15 +244,19 @@ ENV PATH /opt/backtrace/bin:$PATH
 
 RUN apt-get purge -y \
     apt-transport-https \
+    automake \
+    autopoint \
     bison \
     bzip2 \
     file \
     flex \
     gawk \
+    gettext \
     golang \
     gperf \
     help2man \
     python \
+    rsync \
     texinfo \
  && apt-get autoremove -y
 


### PR DESCRIPTION
Building Cockroach via Docker for Mac has always been slow because Docker for Mac filesystem sharing mechanism is extremely high latency. But protobuf compilation was unacceptably slow. Here are timings from my MacBook Pro before this change:

```bash
rm -f bin.docker_amd64/.go_protobuf_sources && build/builder.sh bash -c "time make bin/.go_protobuf_sources"

real	11m48.185s
user	0m25.080s
sys	1m35.160s
```

It is literally faster to compile all of the C++ and Go dependencies than it is to compile some 60 protobufs. The [repeated sed invocations](https://github.com/cockroachdb/cockroach/blob/7def504233099e4906b04eba2a3bafbe61ead4b4/Makefile#L1058-L1064) were almost entirely to blame. The problem, as it turns out, is that `sed -i` writes out files line-by-line, and every call to `write(2)` involves a high-latency roundtrip to macOS and back. 

The first commit in this PR upgrades the builder to the latest version of GNU sed (as yet unreleased, so we compile from source), which properly buffers output. This shaves more than 10m off the compile time:

```
real	0m32.263s
user	0m7.250s
sys	0m4.720s
```

The next commit shaves another 10s off the compile times by coalescing sed invocations. Sed supports running multiple replacements in the same invocation, which means we only need to make one pass over the files. This brings the compile time down yet another 10s:

```
real	0m21.752s
user	0m6.380s
sys	0m3.550s
```

20s to compile protobufs is still far from "ideal", but at least it's approaching the bounds of "reasonable."