### PR TITLE
storage: respect the marker in the leaked Raft entries migration

### DIFF
--- a/pkg/storage/migrations.go
+++ b/pkg/storage/migrations.go
@@ -97,7 +97,6 @@ func removeLeakedRaftEntries(
 	// Check if migration has already been performed.
 	marker := keys.StoreRemovedLeakedRaftEntriesKey()
 	found, err := engine.MVCCGetProto(ctx, eng, marker, hlc.Timestamp{}, false, nil, nil)
-	found = false
 	if found || err != nil {
 		return err
 	}


### PR DESCRIPTION
Release note: None