### PR TITLE
storage: Attempt to deflake TestReplicateQueueRebalance

### DIFF
--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -51,6 +51,8 @@ func TestReplicateQueueRebalance(t *testing.T) {
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationAuto,
 			ServerArgs: base.TestServerArgs{
+				ScanMinIdleTime: time.Millisecond,
+				ScanMaxIdleTime: time.Millisecond,
 				Knobs: base.TestingKnobs{
 					Store: &storagebase.StoreTestingKnobs{
 						// Prevent the merge queue from immediately discarding our splits.
@@ -104,7 +106,8 @@ func TestReplicateQueueRebalance(t *testing.T) {
 		counts := countReplicas()
 		for _, c := range counts {
 			if c < minReplicas {
-				err := errors.Errorf("not balanced: %d", counts)
+				err := errors.Errorf(
+					"not balanced (want at least %d replicas on all stores): %d", minReplicas, counts)
 				log.Info(context.Background(), err)
 				return err
 			}


### PR DESCRIPTION
Closes #31536 (and hopefully fixes it)

Judging by our one failure log, it looks like the problem is that after
the first round of rebalancing was done, a long wait took place before
any more rebalancing happened, and then during that next round of
rebalancing (which perhaps would have resolved the minor imbalance), the
SucceedsSoon call ran out of time. Attempt to resolve this by speeding
up the scanner, as we already do in TestReplicateQueueDownReplicate. The
scan times were notably increased in 192fc5be5c9fc2d36f34959ff96461e4bf1955a7

Release note: None

---

Simply disabling this test when running under race would also be reasonable. Let me know if you'd prefer that.