### PR TITLE
build: Fix references to bin directory in build readme

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -60,8 +60,8 @@ https://github.com/cockroachdb/vendored and checked out as a submodule at
 This snapshot was built and is managed using `dep` and we manage `vendor` as a
 submodule.
 
-Use the version of `dep` in `.bin` (may need to `make` first): import your new
-dependency from the Go source you're working on, then run `.bin/dep ensure`.
+Use the version of `dep` in `bin` (may need to `make` first): import your new
+dependency from the Go source you're working on, then run `./bin/dep ensure`.
 
 ### Working with Submodules
 


### PR DESCRIPTION
Did we used to name the directory ".bin" or something? This confused me
for a few seconds when I copied/pasted the command today.

Release note: None