### PR TITLE
*: Fork circuitbreaker repo and update path to cenk/backoff repo

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -250,12 +250,12 @@
   version = "v1.3.1"
 
 [[projects]]
-  digest = "1:4ba637038f22c9065994c0cd734118fc75e0c744f855fd3edbd3b923d1f41d44"
-  name = "github.com/cenk/backoff"
+  digest = "1:2209584c0f7c9b68c23374e659357ab546e1b70eec2761f03280f69a8fd23d77"
+  name = "github.com/cenkalti/backoff"
   packages = ["."]
   pruneopts = "UT"
-  revision = "61153c768f31ee5f130071d08fc82b85208528de"
-  version = "v1.1.0"
+  revision = "2ea60e5f094469f9e65adb9cd103795b73ae743e"
+  version = "v2.0.0"
 
 [[projects]]
   digest = "1:9ce437e6e6b97d9430e29ac9324e241b3ba77969f14499636e47d4c59fcc236b"
@@ -283,6 +283,14 @@
   pruneopts = "UT"
   revision = "bced77f817b446cc6f6453d6cab5891e43f9ba17"
   version = "v2.0.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:e9b4bf63bdb977f0343e8c1d7a7aa7ff37f4a7126bd7f4a6df0d6b976ee0bf0a"
+  name = "github.com/cockroachdb/circuitbreaker"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "4f5b16865f3ccc4bb8e09413d5c7308e00888b98"
 
 [[projects]]
   branch = "master"
@@ -1227,14 +1235,6 @@
   revision = "1f30fe9094a513ce4c700b9a54458bbb0c96996c"
 
 [[projects]]
-  branch = "master"
-  digest = "1:2704976bbe3459cc3a93c0af2e9e1fc6f0a622db805bbcd1500dfe5977a7ecdf"
-  name = "github.com/rubyist/circuitbreaker"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "2074adba5ddc7d5f7559448a9c3066573521c5bf"
-
-[[projects]]
   digest = "1:9945e4ef330ecb1ca328916effe63b46453c3f39c420c0db97dbdbe832b77662"
   name = "github.com/russross/blackfriday"
   packages = ["."]
@@ -1656,9 +1656,10 @@
     "github.com/backtrace-labs/go-bcd",
     "github.com/benesch/cgosymbolizer",
     "github.com/biogo/store/llrb",
-    "github.com/cenk/backoff",
+    "github.com/cenkalti/backoff",
     "github.com/client9/misspell/cmd/misspell",
     "github.com/cockroachdb/apd",
+    "github.com/cockroachdb/circuitbreaker",
     "github.com/cockroachdb/cmux",
     "github.com/cockroachdb/cockroach-go/crdb",
     "github.com/cockroachdb/crlfmt",
@@ -1743,7 +1744,6 @@
     "github.com/prometheus/common/expfmt",
     "github.com/rcrowley/go-metrics",
     "github.com/rcrowley/go-metrics/exp",
-    "github.com/rubyist/circuitbreaker",
     "github.com/sasha-s/go-deadlock",
     "github.com/satori/go.uuid",
     "github.com/shirou/gopsutil/cpu",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -57,9 +57,9 @@ ignored = [
   name = "github.com/montanaflynn/stats"
   branch = "master"
 
-# https://github.com/rubyist/circuitbreaker/commit/af95830
+# https://github.com/cockroachdb/circuitbreaker/commit/4f5b168
 [[constraint]]
-  name = "github.com/rubyist/circuitbreaker"
+  name = "github.com/cockroachdb/circuitbreaker"
   branch = "master"
 
 [[constraint]]

--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -21,8 +21,8 @@ import (
 	"sync"
 	"time"
 
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/pkg/errors"
-	circuit "github.com/rubyist/circuitbreaker"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -65,9 +65,9 @@ import (
 
 	"google.golang.org/grpc"
 
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
-	circuit "github.com/rubyist/circuitbreaker"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"

--- a/pkg/rpc/breaker.go
+++ b/pkg/rpc/breaker.go
@@ -17,9 +17,9 @@ package rpc
 import (
 	"time"
 
-	"github.com/cenk/backoff"
+	"github.com/cenkalti/backoff"
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/facebookgo/clock"
-	"github.com/rubyist/circuitbreaker"
 
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -24,10 +24,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
-	"github.com/rubyist/circuitbreaker"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -20,8 +20,8 @@ import (
 	"time"
 	"unsafe"
 
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/pkg/errors"
-	"github.com/rubyist/circuitbreaker"
 	"google.golang.org/grpc"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -103,12 +103,6 @@ func (n *Dialer) Dial(ctx context.Context, nodeID roachpb.NodeID) (_ *grpc.Clien
 		return nil, err
 	}
 	breaker.Success()
-	// This really shouldn't be necessary, but Success() isn't guaranteed to
-	// close the breaker and the upstream vendored repo is dead, so just work
-	// around it by resetting the breaker manually if it's still tripped.
-	if breaker.Tripped() {
-		breaker.Reset()
-	}
 	return conn, nil
 }
 
@@ -138,15 +132,19 @@ func (n *Dialer) DialInternalClient(
 		return localCtx, localClient, nil
 	}
 
+	breaker := n.getBreaker(nodeID)
+
 	log.VEventf(ctx, 2, "sending request to %s", addr)
 	conn, err := n.rpcContext.GRPCDial(addr.String()).Connect(ctx)
 	if err != nil {
+		breaker.Fail()
 		return nil, nil, err
 	}
 	// Check to see if the connection is in the transient failure state. This can
 	// happen if the connection already existed, but a recent heartbeat has
 	// failed and we haven't yet torn down the connection.
 	if err := grpcutil.ConnectionReady(conn); err != nil {
+		breaker.Fail()
 		return nil, nil, err
 	}
 	// TODO(bdarnell): Reconcile the different health checks and circuit breaker
@@ -155,9 +153,7 @@ func (n *Dialer) DialInternalClient(
 	// ConnHealth when scheduling processors, but can then see attempts to send
 	// RPCs fail when dial fails due to an open breaker. Reset the breaker here
 	// as a stop-gap before the reconciliation occurs.
-	if breaker := n.getBreaker(nodeID); breaker.Tripped() {
-		breaker.Reset()
-	}
+	breaker.Success()
 	return ctx, roachpb.NewInternalClient(conn), nil
 }
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -24,10 +24,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cenk/backoff"
+	"github.com/cenkalti/backoff"
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
-	"github.com/rubyist/circuitbreaker"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -33,10 +33,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cenk/backoff"
+	"github.com/cenkalti/backoff"
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/kr/pretty"
 	"github.com/pkg/errors"
-	circuit "github.com/rubyist/circuitbreaker"
 	"go.etcd.io/etcd/raft"
 	"google.golang.org/grpc"
 

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 	"unsafe"
 
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
@@ -43,7 +44,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
-	"github.com/rubyist/circuitbreaker"
 )
 
 // AddReplica adds the replica to the store's replica map and to the sorted


### PR DESCRIPTION
Resolves discussion on #31295
Fixes #23362 (rename cenk/backoff)

Release note: None

---

rpc: Improve usage of circuitbreaker in node dialer

Now that breaker.Success() properly resets the breaker's state if it's
tripped, we can avoid manually resetting it. Also add breaker.Fail()
calls that appear to be missing.

Release note: None