### PR TITLE
roachtest: properly initialize the username

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -60,7 +60,6 @@ var (
 	clusterName string
 	clusterID   string
 	clusterWipe bool
-	username    = os.Getenv("ROACHPROD_USER")
 	zonesF      string
 	teamCity    bool
 	// For the "list" command: list benchmarks instead of tests.
@@ -634,6 +633,7 @@ type clusterConfig struct {
 	artifactsDir string
 	localCluster bool
 	teeOpt       teeOptType
+	user         string
 }
 
 // newCluster creates a new roachprod cluster.
@@ -660,7 +660,7 @@ func newCluster(ctx context.Context, l *logger, cfg clusterConfig) (*cluster, er
 		}
 		name = "local" // The roachprod tool understands this magic name.
 	} else {
-		name = makeClusterName(username + "-" + cfg.name)
+		name = makeClusterName(cfg.user + "-" + cfg.name)
 	}
 
 	switch {

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -304,7 +304,7 @@ func (r *registry) ListAll(filter []string) []string {
 // Args:
 // artifactsDir: The path to the dir where log files will be put. If empty, all
 //   logging will go to stdout/stderr.
-func (r *registry) Run(filter []string, parallelism int, artifactsDir string) int {
+func (r *registry) Run(filter []string, parallelism int, artifactsDir string, user string) int {
 	filterRE := makeFilterRE(filter)
 	// Find the top-level tests to run.
 	tests := r.ListTopLevel(filterRE)
@@ -368,7 +368,7 @@ func (r *registry) Run(filter []string, parallelism int, artifactsDir string) in
 
 				r.runAsync(
 					ctx, tests[i], filterRE, nil /* parent */, nil, /* cluster */
-					runNum, teeOpt, runDir, func(failed bool) {
+					runNum, teeOpt, runDir, user, func(failed bool) {
 						wg.Done()
 						<-sem
 					})
@@ -738,6 +738,7 @@ func (r *registry) runAsync(
 	runNum int,
 	teeOpt teeOptType,
 	artifactsDir string,
+	user string,
 	done func(failed bool),
 ) {
 	t := &test{
@@ -899,6 +900,7 @@ func (r *registry) runAsync(
 					artifactsDir: t.ArtifactsDir(),
 					localCluster: local,
 					teeOpt:       teeOpt,
+					user:         user,
 				}
 				var err error
 				c, err = newCluster(ctx, t.l, cfg)
@@ -942,7 +944,7 @@ func (r *registry) runAsync(
 					}
 
 					r.runAsync(ctx, &childSpec, filter, t, c,
-						runNum, teeOpt, childDir, func(failed bool) {
+						runNum, teeOpt, childDir, user, func(failed bool) {
 							if failed {
 								// Mark the parent test as failed since one of the subtests
 								// failed.

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -71,7 +71,7 @@ func TestRegistryRun(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			code := r.Run(c.filters, defaultParallelism, "" /* artifactsDir */)
+			code := r.Run(c.filters, defaultParallelism, "" /* artifactsDir */, "myuser")
 			if c.expected != code {
 				t.Fatalf("expected code %d, but found code %d. Filters: %s", c.expected, code, c.filters)
 			}
@@ -136,7 +136,7 @@ func TestRegistryStatus(t *testing.T) {
 			}
 		},
 	})
-	r.Run([]string{"status"}, defaultParallelism, "" /* artifactsDir */)
+	r.Run([]string{"status"}, defaultParallelism, "" /* artifactsDir */, "myuser")
 
 	status := buf.String()
 	if !waitingRE.MatchString(status) {
@@ -170,7 +170,7 @@ func TestRegistryStatusUnknown(t *testing.T) {
 			}
 		},
 	})
-	r.Run([]string{"status"}, defaultParallelism, "" /* artifactsDir */)
+	r.Run([]string{"status"}, defaultParallelism, "" /* artifactsDir */, "myuser")
 
 	status := buf.String()
 	if !unknownRE.MatchString(status) {
@@ -196,7 +196,7 @@ func TestRegistryRunTimeout(t *testing.T) {
 			<-ctx.Done()
 		},
 	})
-	r.Run([]string{"timeout"}, defaultParallelism, "" /* artifactsDir */)
+	r.Run([]string{"timeout"}, defaultParallelism, "" /* artifactsDir */, "myuser")
 
 	out := buf.String()
 	if !timeoutRE.MatchString(out) {
@@ -222,7 +222,7 @@ func TestRegistryRunSubTestFailed(t *testing.T) {
 		}},
 	})
 
-	r.Run([]string{"."}, defaultParallelism, "" /* artifactsDir */)
+	r.Run([]string{"."}, defaultParallelism, "" /* artifactsDir */, "myuser")
 	out := buf.String()
 	if !failedRE.MatchString(out) {
 		t.Fatalf("unable to find \"FAIL: parent\" message:\n%s", out)
@@ -251,7 +251,7 @@ func TestRegistryRunClusterExpired(t *testing.T) {
 			panic("not reached")
 		},
 	})
-	r.Run([]string{"expired"}, defaultParallelism, "" /* artifactsDir */)
+	r.Run([]string{"expired"}, defaultParallelism, "" /* artifactsDir */, "myuser")
 
 	out := buf.String()
 	if !expiredRE.MatchString(out) {
@@ -452,7 +452,7 @@ func TestRegistryMinVersion(t *testing.T) {
 			if err := r.setBuildVersion(c.buildVersion); err != nil {
 				t.Fatal(err)
 			}
-			r.Run(nil /* filter */, defaultParallelism, "" /* artifactsDir */)
+			r.Run(nil /* filter */, defaultParallelism, "" /* artifactsDir */, "myuser")
 			if c.expectedA != runA || c.expectedB != runB {
 				t.Fatalf("expected %t,%t, but got %t,%t\n%s",
 					c.expectedA, c.expectedB, runA, runB, buf.String())


### PR DESCRIPTION
Before this patch, the user was only initilized properly for the run
command, but not for bench or others that need it.

Release note: None