### PR TITLE
opt: improve func deps to remember lax keys

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct
@@ -177,16 +177,12 @@ distinct   ·            ·       (v)  weak-key(v)
 ·          spans        ALL     ·    ·
 
 # Here we can infer that v is not-NULL so eliding the node is correct.
-# TODO(radu,andyk): we can't represent that v is a weak key (at the level of
-# the scan) when it is the only column.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx WHERE v > 0
 ----
-distinct   ·            ·       (v)  weak-key(v)
- │         distinct on  v       ·    ·
- └── scan  ·            ·       (v)  ·
-·          table        kv@idx  ·    ·
-·          spans        /1-     ·    ·
+scan  ·      ·       (v)  ·
+·     table  kv@idx  ·    ·
+·     spans  /1-     ·    ·
 
 statement ok
 CREATE TABLE kv2 (k INT PRIMARY KEY, v INT NOT NULL, UNIQUE INDEX idx(v))

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -298,16 +298,14 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 
 	// Format functional dependencies.
 	if !f.HasFlags(ExprFmtHideFuncDeps) {
-		// Show the key separately from the rest of the FDs. Do this by copying
-		// the FD to the stack (fast shallow copy), and then calling ClearKey.
-		fd := relational.FuncDeps
-		key, ok := fd.Key()
-		if ok {
+		// Show the key separately from the rest of the FDs.
+		if key, ok := relational.FuncDeps.StrictKey(); ok {
 			tp.Childf("key: %s", key)
+		} else if key, ok := relational.FuncDeps.LaxKey(); ok {
+			tp.Childf("lax-key: %s", key)
 		}
-		fd.ClearKey()
-		if !fd.Empty() {
-			tp.Childf("fd: %s", fd)
+		if fdStr := relational.FuncDeps.StringOnlyFDs(); fdStr != "" {
+			tp.Childf("fd: %s", fdStr)
 		}
 	}
 

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -841,7 +841,7 @@ func (b *logicalPropsBuilder) buildRowNumberProps(rowNum *RowNumberExpr, rel *pr
 	// Inherit functional dependencies from input, and add strict key FD for the
 	// additional key column.
 	rel.FuncDeps.CopyFrom(&inputProps.FuncDeps)
-	if key, ok := rel.FuncDeps.Key(); ok {
+	if key, ok := rel.FuncDeps.StrictKey(); ok {
 		// Any existing keys are still keys.
 		rel.FuncDeps.AddStrictKey(key, rel.OutputCols)
 	}
@@ -1302,7 +1302,7 @@ func (h *joinPropsHelper) setFuncDeps(rel *props.Relational) {
 			//
 			inputCols := h.leftProps.OutputCols.Union(h.rightProps.OutputCols)
 			if !inputCols.Intersects(notNullInputCols) {
-				rel.FuncDeps.ClearKey()
+				rel.FuncDeps.DowngradeKey()
 			}
 			rel.FuncDeps.MakeOuter(h.leftProps.OutputCols, notNullInputCols)
 			rel.FuncDeps.MakeOuter(h.rightProps.OutputCols, notNullInputCols)

--- a/pkg/sql/opt/memo/testdata/logprops/groupby
+++ b/pkg/sql/opt/memo/testdata/logprops/groupby
@@ -100,6 +100,7 @@ project
       ├── interesting orderings: (-4,+3)
       └── project
            ├── columns: z:3(float!null) s:4(string)
+           ├── lax-key: (3,4)
            ├── prune: (3,4)
            ├── interesting orderings: (-4,+3)
            └── scan xyzs
@@ -147,6 +148,7 @@ group-by
  ├── prune: (5)
  ├── project
  │    ├── columns: z:3(float!null) s:4(string)
+ │    ├── lax-key: (3,4)
  │    ├── prune: (3,4)
  │    ├── interesting orderings: (-4,+3)
  │    └── scan xyzs

--- a/pkg/sql/opt/memo/testdata/logprops/index-join
+++ b/pkg/sql/opt/memo/testdata/logprops/index-join
@@ -82,6 +82,7 @@ SELECT y FROM a WHERE s = 'foo' AND x + y = 10
 ----
 project
  ├── columns: y:2(int)
+ ├── lax-key: (2)
  ├── prune: (2)
  └── select
       ├── columns: x:1(int!null) y:2(int) s:3(string!null)

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -131,36 +131,25 @@ project
       │    └── project
       │         ├── columns: v:6(int!null)
       │         ├── outer: (1)
+      │         ├── fd: ()-->(6)
       │         ├── prune: (6)
-      │         └── inner-join-apply
+      │         └── inner-join
       │              ├── columns: v:6(int!null) n:9(int!null)
       │              ├── outer: (1)
-      │              ├── fd: ()-->(9)
+      │              ├── fd: ()-->(6,9)
+      │              ├── interesting orderings: (+9)
       │              ├── scan uv
       │              │    ├── columns: v:6(int!null)
       │              │    └── prune: (6)
-      │              ├── max1-row
-      │              │    ├── columns: n:9(int!null)
-      │              │    ├── outer: (6)
-      │              │    ├── cardinality: [0 - 1]
-      │              │    ├── key: ()
-      │              │    ├── fd: ()-->(9)
-      │              │    └── select
-      │              │         ├── columns: n:9(int!null)
-      │              │         ├── outer: (6)
-      │              │         ├── fd: ()-->(9)
-      │              │         ├── interesting orderings: (+9)
-      │              │         ├── scan mn@secondary
-      │              │         │    ├── columns: n:9(int!null)
-      │              │         │    ├── constraint: /9: (/NULL - ]
-      │              │         │    ├── key: (9)
-      │              │         │    ├── prune: (9)
-      │              │         │    └── interesting orderings: (+9)
-      │              │         └── filters
-      │              │              └── eq [type=bool, outer=(6,9), constraints=(/6: (/NULL - ]; /9: (/NULL - ]), fd=(6)==(9), (9)==(6)]
-      │              │                   ├── variable: n [type=int]
-      │              │                   └── variable: v [type=int]
+      │              ├── scan mn
+      │              │    ├── columns: n:9(int)
+      │              │    ├── lax-key: (9)
+      │              │    ├── prune: (9)
+      │              │    └── interesting orderings: (+9)
       │              └── filters
+      │                   ├── eq [type=bool, outer=(6,9), constraints=(/6: (/NULL - ]; /9: (/NULL - ]), fd=(6)==(9), (9)==(6)]
+      │                   │    ├── variable: n [type=int]
+      │                   │    └── variable: v [type=int]
       │                   └── eq [type=bool, outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
       │                        ├── variable: x [type=int]
       │                        └── variable: n [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -23,6 +23,20 @@ TABLE kuv
  └── INDEX primary
       └── k int not null
 
+exec-ddl
+CREATE TABLE ab (a INT, b INT, UNIQUE (a, b))
+----
+TABLE ab
+ ├── a int
+ ├── b int
+ ├── rowid int not null (hidden)
+ ├── INDEX primary
+ │    └── rowid int not null (hidden)
+ └── INDEX secondary
+      ├── a int
+      ├── b int
+      └── rowid int not null (hidden) (storing)
+
 build
 SELECT y, x+1 AS a, 1 AS b, x FROM xysd
 ----
@@ -333,3 +347,49 @@ project
  └── projections
       └── cast: STRING [type=string, outer=(4)]
            └── variable: xysd.d [type=decimal]
+
+# Verify that a,b form a key.
+norm
+SELECT a, b FROM ab WHERE a IS NOT NULL and b IS NOT NULL
+----
+select
+ ├── columns: a:1(int!null) b:2(int!null)
+ ├── key: (1,2)
+ ├── interesting orderings: (+1,+2)
+ ├── scan ab
+ │    ├── columns: a:1(int) b:2(int)
+ │    ├── lax-key: (1,2)
+ │    ├── prune: (1,2)
+ │    └── interesting orderings: (+1,+2)
+ └── filters
+      ├── is-not [type=bool, outer=(1), constraints=(/1: (/NULL - ]; tight)]
+      │    ├── variable: a [type=int]
+      │    └── null [type=unknown]
+      └── is-not [type=bool, outer=(2), constraints=(/2: (/NULL - ]; tight)]
+           ├── variable: b [type=int]
+           └── null [type=unknown]
+
+norm
+SELECT a, b FROM ab WHERE (a, b) IN ((1, 1), (2, 2))
+----
+select
+ ├── columns: a:1(int!null) b:2(int!null)
+ ├── key: (1,2)
+ ├── interesting orderings: (+1,+2)
+ ├── scan ab
+ │    ├── columns: a:1(int) b:2(int)
+ │    ├── lax-key: (1,2)
+ │    ├── prune: (1,2)
+ │    └── interesting orderings: (+1,+2)
+ └── filters
+      └── in [type=bool, outer=(1,2), constraints=(/1/2: [/1/1 - /1/1] [/2/2 - /2/2]; /2: [/1 - /1] [/2 - /2]; tight)]
+           ├── tuple [type=tuple{int, int}]
+           │    ├── variable: a [type=int]
+           │    └── variable: b [type=int]
+           └── tuple [type=tuple{tuple{int, int}, tuple{int, int}}]
+                ├── tuple [type=tuple{int, int}]
+                │    ├── const: 1 [type=int]
+                │    └── const: 1 [type=int]
+                └── tuple [type=tuple{int, int}]
+                     ├── const: 2 [type=int]
+                     └── const: 2 [type=int]

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -605,10 +605,12 @@ SELECT * FROM c WHERE x >= 0 AND x < 100
 select
  ├── columns: x:1(int!null) z:2(int!null)
  ├── stats: [rows=111.111111]
+ ├── key: (1)
  ├── fd: (1)-->(2)
  ├── scan c
  │    ├── columns: x:1(int) z:2(int!null)
  │    ├── stats: [rows=1000]
+ │    ├── lax-key: (1,2)
  │    └── fd: (1)~~>(2)
  └── filters
       ├── x >= 0 [type=bool, outer=(1), constraints=(/1: [/0 - ]; tight)]

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -178,7 +178,7 @@ func (c *CustomFuncs) OutputCols2(left, right memo.RelExpr) opt.ColSet {
 // CandidateKey returns the candidate key columns from the given input
 // expression. If there is no candidate key, CandidateKey returns ok=false.
 func (c *CustomFuncs) CandidateKey(input memo.RelExpr) (key opt.ColSet, ok bool) {
-	return input.Relational().FuncDeps.Key()
+	return input.Relational().FuncDeps.StrictKey()
 }
 
 // IsColNotNull returns true if the given input column is never null.

--- a/pkg/sql/opt/norm/groupby.go
+++ b/pkg/sql/opt/norm/groupby.go
@@ -143,7 +143,7 @@ func (c *CustomFuncs) CanRemoveAggDistinctForKeys(
 	aggs memo.AggregationsExpr, private *memo.GroupingPrivate, input memo.RelExpr,
 ) bool {
 	inputFDs := &input.Relational().FuncDeps
-	if _, hasKey := inputFDs.Key(); !hasKey {
+	if _, hasKey := inputFDs.StrictKey(); !hasKey {
 		// Fast-path for the case when the input has no keys.
 		return false
 	}

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -171,7 +171,8 @@ distinct-on
  ├── grouping columns: i:2(int!null) f:3(float)
  ├── key: (2,3)
  └── scan a@fi_idx
-      └── columns: i:2(int!null) f:3(float)
+      ├── columns: i:2(int!null) f:3(float)
+      └── lax-key: (2,3)
 
 # --------------------------------------------------
 # EliminateGroupByProject

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -197,10 +197,12 @@ explain
  ├── columns: tree:7(string) field:8(string) description:9(string)
  └── project
       ├── columns: b:2(int) plus:6(int) c:3(int)
+      ├── lax-key: (2,3)
       ├── fd: (2)-->(6)
       ├── ordering: +2,+3
       ├── scan abcde@bc
       │    ├── columns: b:2(int) c:3(int)
+      │    ├── lax-key: (2,3)
       │    └── ordering: +2,+3
       └── projections
            └── b + 1 [type=int, outer=(2)]

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -15,8 +15,8 @@
 package props
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -24,10 +24,10 @@ import (
 
 // FuncDepSet is a set of functional dependencies (FDs) that encode useful
 // relationships between columns in a base or derived relation. Given two sets
-// of columns A and B, a functional dependency A-->B holds if A uniquely
-// determines B. In other words, if two different rows have equal values for
-// columns in A, then those two rows will also have equal values for columns in
-// B. For example:
+// of columns A and B, a functional dependency A-->B holds if A fully determines
+// B. In other words, if two different rows have equal values for columns in A,
+// then those two rows will also have equal values for columns in B. For
+// example:
 //
 //   a1 a2 b1
 //   --------
@@ -361,22 +361,37 @@ type FuncDepSet struct {
 	// all referencing sets are treated as immutable.
 	deps []funcDep
 
-	// hasKey is true if the relation has no duplicate rows, which means at least
-	// one subset of its columns form a key (all columns, if no other subset).
-	// The key field contains one such key. See the "Keys" section above for more
-	// details.
-	hasKey bool
+	// hasKey is:
+	//  - strictKey if the relation has no duplicate rows, which means at least
+	//    one subset of its columns form a key (all columns, if no other subset).
+	//    The key field contains one such key. See the "Keys" section above for
+	//    more details.
+	//  - laxKey if there is a at least one subset of columns that form a lax key.
+	//    The key field contains one such key.
+	//
+	// See the "Keys" section above for more details.
+	hasKey keyType
 
-	// key contains a set of columns that form a key for the relation, as long as
-	// hasKey is true. There is no guarantee that the key has the minimum possible
-	// number of columns, or even that it's a candidate key, but a best effort is
-	// made to keep it as short as possible. See the "Keys" section above for
-	// more details.
+	// key contains a set of columns that form a key or a lax key for the
+	// relation, depending on hasKey; empty if hasKey is noKey.
+	//
+	// There is no guarantee that the key has the minimum possible number of
+	// columns, but a best effort is made to keep it as short as possible.
+	//
+	// See the "Keys" section above for more details.
 	//
 	// This set is immutable; to update it, replace it with a different set
 	// containing the desired columns.
 	key opt.ColSet
 }
+
+type keyType int8
+
+const (
+	noKey keyType = iota
+	laxKey
+	strictKey
+)
 
 // funcDep stores a single functional dependency. See the comment for FuncDepSet
 // for more details.
@@ -408,16 +423,29 @@ type funcDep struct {
 	equiv bool
 }
 
-// Key returns a boolean indicating whether a key exists for the relation, as
-// well as one of the keys if the boolean is true. A best effort is made to
-// return a candidate key that has the fewest columns.
-func (f *FuncDepSet) Key() (_ opt.ColSet, ok bool) {
-	return f.key, f.hasKey
+// StrictKey returns a strict key for the relation, if there is one.
+// A best effort is made to return a candidate key that has the fewest columns.
+func (f *FuncDepSet) StrictKey() (_ opt.ColSet, ok bool) {
+	if f.hasKey == strictKey {
+		return f.key, true
+	}
+	return opt.ColSet{}, false
+}
+
+// LaxKey returns a lax key for the relation, if there is one.
+// Note that strict keys are implicitly also lax keys, so if the relation has a
+// strict key, this returns the same key as StrictKey().
+// A best effort is made to return a lax key that has the fewest columns.
+func (f *FuncDepSet) LaxKey() (_ opt.ColSet, ok bool) {
+	if f.hasKey != noKey {
+		return f.key, true
+	}
+	return opt.ColSet{}, false
 }
 
 // Empty is true if the set contains no FDs and no key.
 func (f *FuncDepSet) Empty() bool {
-	return len(f.deps) == 0 && !f.hasKey && f.key.Empty()
+	return len(f.deps) == 0 && f.hasKey == noKey
 }
 
 // ColSet returns all columns referenced by the FD set.
@@ -433,13 +461,15 @@ func (f *FuncDepSet) ColSet() opt.ColSet {
 
 // HasMax1Row returns true if the relation has zero or one rows.
 func (f *FuncDepSet) HasMax1Row() bool {
-	return f.hasKey && f.key.Empty()
+	return f.hasKey == strictKey && f.key.Empty()
 }
 
-// ClearKey marks the FD set as having no key.
-func (f *FuncDepSet) ClearKey() {
-	f.hasKey = false
-	f.key = opt.ColSet{}
+// ClearKey marks the FD set as having no strict key. If there was a strict key,
+// it becomes a lax key.
+func (f *FuncDepSet) DowngradeKey() {
+	if f.hasKey == strictKey {
+		f.hasKey = laxKey
+	}
 }
 
 // CopyFrom copies the given FD into this FD, replacing any existing data.
@@ -466,7 +496,7 @@ func (f *FuncDepSet) CopyFrom(fdset *FuncDepSet) {
 //   1     1     1
 //
 func (f *FuncDepSet) ColsAreStrictKey(cols opt.ColSet) bool {
-	return f.colsAreKey(cols, true /* strict */)
+	return f.colsAreKey(cols, strictKey)
 }
 
 // ColsAreLaxKey returns true if the given columns contain a lax key for the
@@ -488,7 +518,7 @@ func (f *FuncDepSet) ColsAreStrictKey(cols opt.ColSet) bool {
 //   1     1     1
 //
 func (f *FuncDepSet) ColsAreLaxKey(cols opt.ColSet) bool {
-	return f.colsAreKey(cols, false /* strict */)
+	return f.colsAreKey(cols, laxKey)
 }
 
 // ReduceCols removes redundant columns from the given set. Redundant columns
@@ -593,8 +623,8 @@ func (f *FuncDepSet) AddStrictKey(keyCols, allCols opt.ColSet) {
 	keyCols = f.ReduceCols(keyCols)
 	f.addDependency(keyCols, allCols, true /* strict */, false /* equiv */)
 
-	if !f.hasKey || keyCols.Len() < f.key.Len() {
-		f.setKey(keyCols)
+	if f.hasKey != strictKey || keyCols.Len() < f.key.Len() {
+		f.setKey(keyCols, strictKey)
 	}
 }
 
@@ -614,6 +644,10 @@ func (f *FuncDepSet) AddLaxKey(keyCols, allCols opt.ColSet) {
 	// determined by other columns).
 	keyCols = f.ReduceCols(keyCols)
 	f.addDependency(keyCols, allCols, false /* strict */, false /* equiv */)
+
+	if f.hasKey == noKey || (f.hasKey == laxKey && keyCols.Len() < f.key.Len()) {
+		f.setKey(keyCols, laxKey)
+	}
 }
 
 // MakeMax1Row initializes the FD set for a relation containing either zero or
@@ -631,11 +665,15 @@ func (f *FuncDepSet) MakeMax1Row(cols opt.ColSet) {
 	if !cols.Empty() {
 		f.deps = append(f.deps, funcDep{to: cols, strict: true})
 	}
-	f.setKey(opt.ColSet{})
+	f.setKey(opt.ColSet{}, strictKey)
 }
 
 // MakeNotNull modifies the FD set based on which columns cannot contain NULL
-// values. This often allows upgrading lax dependencies to strict dependencies.
+// values. This often allows upgrading lax dependencies to strict dependencies,
+// and lax keys to strict keys.
+//
+// Note: this function should be called with all known null columns; it won't do
+// as good of a job if it's called multiple times with different subsets.
 func (f *FuncDepSet) MakeNotNull(notNullCols opt.ColSet) {
 	var constCols opt.ColSet
 	var laxFDs util.FastIntSet
@@ -671,8 +709,11 @@ func (f *FuncDepSet) MakeNotNull(notNullCols opt.ColSet) {
 	}
 
 	// Try to reduce the key based on any new strict FDs.
-	if f.hasKey {
+	if f.hasKey != noKey {
 		f.key = f.ReduceCols(f.key)
+		if f.hasKey == laxKey && f.key.SubsetOf(notNullCols) {
+			f.hasKey = strictKey
+		}
 	}
 }
 
@@ -754,7 +795,7 @@ func (f *FuncDepSet) AddConstants(cols opt.ColSet) {
 	f.deps = f.deps[:n]
 
 	// Try to reduce the key based on the new constants.
-	if f.hasKey {
+	if f.hasKey != noKey {
 		f.key = f.ReduceCols(f.key)
 	}
 }
@@ -788,17 +829,19 @@ func (f *FuncDepSet) ProjectCols(cols opt.ColSet) {
 	// Ensure that any existing key contains only projected columns. Do this
 	// before removing any FDs from the set, in order to take advantage of all
 	// existing transitive relationships.
-	if f.hasKey && !f.key.SubsetOf(cols) {
+	if f.hasKey != noKey && !f.key.SubsetOf(cols) {
 		// Derive new candidate key (or key is no longer possible).
-		if f.ColsAreStrictKey(cols) {
-			f.setKey(f.ReduceCols(cols))
+		if f.hasKey == strictKey && f.ColsAreStrictKey(cols) {
+			f.setKey(f.ReduceCols(cols), strictKey)
+		} else if f.ColsAreLaxKey(cols) {
+			f.setKey(f.ReduceCols(cols), laxKey)
 		} else {
-			f.ClearKey()
+			f.clearKey()
 		}
 	}
 
 	// Special case of <= 1 row.
-	if f.hasKey && f.key.Empty() {
+	if f.hasKey == strictKey && f.key.Empty() {
 		f.MakeMax1Row(cols)
 		return
 	}
@@ -961,10 +1004,17 @@ func (f *FuncDepSet) MakeProduct(inner *FuncDepSet) {
 		}
 	}
 
-	if f.hasKey && inner.hasKey {
-		f.setKey(f.key.Union(inner.key))
+	if f.hasKey != noKey && inner.hasKey != noKey {
+		// If both sides have a strict key, the union of keys is a strict key.
+		// If one side has a lax key and the other has a lax or strict key, the
+		// union is a lax key.
+		typ := laxKey
+		if f.hasKey == strictKey && inner.hasKey == strictKey {
+			typ = strictKey
+		}
+		f.setKey(f.key.Union(inner.key), typ)
 	} else {
-		f.ClearKey()
+		f.clearKey()
 	}
 }
 
@@ -999,16 +1049,18 @@ func (f *FuncDepSet) MakeApply(inner *FuncDepSet) {
 		fd := &inner.deps[i]
 		if fd.equiv {
 			f.addDependency(fd.from, fd.to, fd.strict, fd.equiv)
-		} else if !fd.from.Empty() && f.hasKey {
+		} else if !fd.from.Empty() && f.hasKey == strictKey {
 			f.addDependency(f.key.Union(fd.from), fd.to, fd.strict, fd.equiv)
 		}
+		// TODO(radu): can we use a laxKey here?
 	}
 
-	if f.hasKey && inner.hasKey {
-		f.setKey(f.key.Union(inner.key))
+	if f.hasKey == strictKey && inner.hasKey == strictKey {
+		f.setKey(f.key.Union(inner.key), strictKey)
 		f.ensureKeyClosure(inner.ColSet())
 	} else {
-		f.ClearKey()
+		// TODO(radu): can we use a laxKey here?
+		f.clearKey()
 	}
 }
 
@@ -1156,14 +1208,17 @@ func (f *FuncDepSet) ComputeEquivGroup(rep opt.ColumnID) opt.ColSet {
 }
 
 // ensureKeyClosure checks whether the closure for this FD set's key (if there
-// is one) includes the given columns. If not, then it adds a strict dependency
-// so that the key determines the columns.
+// is one) includes the given columns. If not, then it adds a dependency so that
+// the key determines the columns.
 func (f *FuncDepSet) ensureKeyClosure(cols opt.ColSet) {
-	if f.hasKey {
+	if f.hasKey != noKey {
 		closure := f.ComputeClosure(f.key)
 		if !cols.SubsetOf(closure) {
 			cols = cols.Difference(closure)
-			f.addDependency(f.key, cols, true /* strict */, false /* equiv */)
+			// If we have a strict key, we add a strict dependency; otherwise we add a
+			// lax dependency.
+			strict := f.hasKey == strictKey
+			f.addDependency(f.key, cols, strict, false /* equiv */)
 		}
 	}
 }
@@ -1209,15 +1264,17 @@ func (f *FuncDepSet) Verify() {
 		}
 	}
 
-	if f.hasKey {
+	if f.hasKey != noKey {
 		if reduced := f.ReduceCols(f.key); !reduced.Equals(f.key) {
 			panic(fmt.Sprintf("expected FD to have candidate key: %s", f))
 		}
 
-		allCols := f.ColSet()
-		allCols.UnionWith(f.key)
-		if !f.ComputeClosure(f.key).Equals(allCols) {
-			panic(fmt.Sprintf("expected closure of FD key to include all known cols: %s", f))
+		if f.hasKey == strictKey {
+			allCols := f.ColSet()
+			allCols.UnionWith(f.key)
+			if !f.ComputeClosure(f.key).Equals(allCols) {
+				panic(fmt.Sprintf("expected closure of FD key to include all known cols: %s", f))
+			}
 		}
 	} else {
 		if !f.key.Empty() {
@@ -1226,37 +1283,57 @@ func (f *FuncDepSet) Verify() {
 	}
 }
 
+func (f FuncDepSet) StringOnlyFDs() string {
+	var b strings.Builder
+	f.formatFDs(&b)
+	return b.String()
+}
+
 func (f FuncDepSet) String() string {
-	var buf bytes.Buffer
-	if f.hasKey {
-		fmt.Fprintf(&buf, "%s: ", f.key)
+	var b strings.Builder
+
+	if f.hasKey != noKey {
+		// The key shows up as key(1,2) or lax-key(1,2).
+		if f.hasKey == laxKey {
+			b.WriteString("lax-")
+		}
+		fmt.Fprintf(&b, "key%s", f.key)
+		if len(f.deps) > 0 {
+			b.WriteString("; ")
+		}
 	}
+
+	f.formatFDs(&b)
+	return b.String()
+}
+
+func (f FuncDepSet) formatFDs(b *strings.Builder) {
 	for i := range f.deps {
 		fd := &f.deps[i]
 		if i != 0 {
-			buf.WriteString(", ")
+			b.WriteString(", ")
 		}
 		if fd.equiv {
 			if !fd.strict {
 				panic("lax equivalent columns are not supported")
 			}
-			fmt.Fprintf(&buf, "%s==%s", fd.from, fd.to)
+			fmt.Fprintf(b, "%s==%s", fd.from, fd.to)
 		} else {
 			if fd.strict {
-				fmt.Fprintf(&buf, "%s-->%s", fd.from, fd.to)
+				fmt.Fprintf(b, "%s-->%s", fd.from, fd.to)
 			} else {
-				fmt.Fprintf(&buf, "%s~~>%s", fd.from, fd.to)
+				fmt.Fprintf(b, "%s~~>%s", fd.from, fd.to)
 			}
 		}
 	}
-	return buf.String()
 }
 
 // colsAreKey returns true if the given columns contain a strict or lax key for
 // the relation.
-func (f *FuncDepSet) colsAreKey(cols opt.ColSet, strict bool) bool {
-	if !f.hasKey {
-		// No key exists for the relation.
+func (f *FuncDepSet) colsAreKey(cols opt.ColSet, typ keyType) bool {
+	if f.hasKey == noKey || (typ == strictKey && f.hasKey == laxKey) {
+		// No key exists for the relation, or there exists a lax key and we
+		// need a strict key.
 		return false
 	}
 
@@ -1268,7 +1345,7 @@ func (f *FuncDepSet) colsAreKey(cols opt.ColSet, strict bool) bool {
 	//   cols  = (b,c)
 	//
 	// and yet both column sets form keys for the relation.
-	return f.inClosureOf(f.key, cols, strict)
+	return f.inClosureOf(f.key, cols, typ == strictKey)
 }
 
 // inClosureOf computes the strict or lax closure of the "in" column set, and
@@ -1468,15 +1545,20 @@ func (f *FuncDepSet) addEquivalency(equiv opt.ColSet) {
 	}
 
 	// Try to reduce the key based on the new equivalency.
-	if f.hasKey {
+	if f.hasKey != noKey {
 		f.key = f.ReduceCols(f.key)
 	}
 }
 
 // setKey updates the key that the set is currently maintaining.
-func (f *FuncDepSet) setKey(key opt.ColSet) {
-	f.hasKey = true
+func (f *FuncDepSet) setKey(key opt.ColSet, typ keyType) {
+	f.hasKey = typ
 	f.key = key
+}
+
+// clearKey removes any strict or lax key.
+func (f *FuncDepSet) clearKey() {
+	f.setKey(opt.ColSet{}, noKey)
 }
 
 // makeEquivMap constructs a map with an entry for each column in the "from" set

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -464,8 +464,8 @@ func (f *FuncDepSet) HasMax1Row() bool {
 	return f.hasKey == strictKey && f.key.Empty()
 }
 
-// ClearKey marks the FD set as having no strict key. If there was a strict key,
-// it becomes a lax key.
+// DowngradeKey marks the FD set as having no strict key. If there was a strict
+// key, it becomes a lax key.
 func (f *FuncDepSet) DowngradeKey() {
 	if f.hasKey == strictKey {
 		f.hasKey = laxKey
@@ -1215,6 +1215,7 @@ func (f *FuncDepSet) ensureKeyClosure(cols opt.ColSet) {
 		closure := f.ComputeClosure(f.key)
 		if !cols.SubsetOf(closure) {
 			cols = cols.Difference(closure)
+
 			// If we have a strict key, we add a strict dependency; otherwise we add a
 			// lax dependency.
 			strict := f.hasKey == strictKey
@@ -1283,6 +1284,8 @@ func (f *FuncDepSet) Verify() {
 	}
 }
 
+// StringOnlyFDs returns a string representation of the FDs (without the key
+// information).
 func (f FuncDepSet) StringOnlyFDs() string {
 	var b strings.Builder
 	f.formatFDs(&b)

--- a/pkg/sql/opt/props/func_dep_test.go
+++ b/pkg/sql/opt/props/func_dep_test.go
@@ -315,6 +315,16 @@ func TestFuncDeps_AddLaxKey(t *testing.T) {
 	verifyFD(t, empty, "lax-key(); ()~~>(1)")
 	testColsAreStrictKey(t, empty, c(), false)
 	testColsAreLaxKey(t, empty, c(), true)
+
+	// Verify that a shorter lax key overwrites a longer lax key (but not
+	// vice-versa).
+	abcde := &props.FuncDepSet{}
+	abcde.AddLaxKey(c(2, 3), c(1, 2, 3, 4, 5))
+	verifyFD(t, abcde, "lax-key(2,3); (2,3)~~>(1,4,5)")
+	abcde.AddLaxKey(c(1), c(1, 2, 3, 4, 5))
+	verifyFD(t, abcde, "lax-key(1); (2,3)~~>(1,4,5), (1)~~>(2-5)")
+	abcde.AddLaxKey(c(4, 5), c(1, 2, 3, 4, 5))
+	verifyFD(t, abcde, "lax-key(1); (2,3)~~>(1,4,5), (1)~~>(2-5), (4,5)~~>(1-3)")
 }
 
 func TestFuncDeps_MakeMax1Row(t *testing.T) {
@@ -739,6 +749,7 @@ func TestFuncDeps_AddEquivFrom(t *testing.T) {
 func TestFuncDeps_MakeProduct(t *testing.T) {
 	// Union dependencies and removed columns and keys:
 	//   CREATE TABLE abcde (a INT PRIMARY KEY, b INT, c INT, d INT, e INT)
+	//   CREATE UNIQUE INDEX ON abcde (b, c)
 	//   CREATE TABLE mnpq (m INT, n INT, p INT, q INT, PRIMARY KEY (m, n))
 	//   SELECT * FROM (SELECT a, b, c FROM abcde WHERE d=e), (SELECT m, n FROM mnpq WHERE p=q)
 	product := makeAbcdeFD(t)
@@ -759,7 +770,7 @@ func TestFuncDeps_MakeProduct(t *testing.T) {
 	product.MakeProduct(mnpq)
 	verifyFD(t, product, "key(1,10,11); ()-->(2,12), (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(13)")
 
-	// Key only on left side:
+	// Strict key on left side, no key on right side:
 	//   SELECT * FROM abcde, (SELECT p, q FROM mnpq)
 	product = makeAbcdeFD(t)
 	mnpq = makeMnpqFD(t)
@@ -767,14 +778,75 @@ func TestFuncDeps_MakeProduct(t *testing.T) {
 	product.MakeProduct(mnpq)
 	verifyFD(t, product, "(1)-->(2-5), (2,3)~~>(1,4,5)")
 	testColsAreStrictKey(t, product, c(1, 2, 3, 4, 5, 12, 13), false)
+	testColsAreLaxKey(t, product, c(1, 2, 3, 4, 5, 12, 13), false)
 
-	// Key only on right side:
+	// No key on left side, Strict key on right side.
 	//   SELECT * FROM (SELECT d, e FROM abcde), mnpq
 	product = makeAbcdeFD(t)
 	product.ProjectCols(c(4, 5))
 	product.MakeProduct(makeMnpqFD(t))
 	verifyFD(t, product, "(10,11)-->(12,13)")
 	testColsAreStrictKey(t, product, c(4, 5, 10, 11, 12, 13), false)
+	testColsAreLaxKey(t, product, c(1, 2, 3, 4, 5, 12, 13), false)
+
+	// Strict key on left side, lax key on right side:
+	//   CREATE UNIQUE INDEX ON mnpq (p)
+	//   SELECT * FROM abcde, (SELECT p, q FROM mnpq)
+	product = makeAbcdeFD(t)
+	mnpq = makeMnpqFD(t)
+	mnpq.AddLaxKey(c(12), c(10, 11, 12, 13))
+	mnpq.ProjectCols(c(12, 13))
+	product.MakeProduct(mnpq)
+	verifyFD(t, product, "lax-key(1,12,13); (1)-->(2-5), (2,3)~~>(1,4,5), (12)~~>(13)")
+	testColsAreStrictKey(t, product, c(1, 2, 3, 4, 5, 12, 13), false)
+	testColsAreLaxKey(t, product, c(1, 12), true)
+
+	// Lax key on left side, strict key on right side:
+	//   SELECT * FROM (SELECT b, c, d, e FROM abcde), mnpq
+	product = makeAbcdeFD(t)
+	product.ProjectCols(c(2, 3, 4, 5))
+	mnpq = makeMnpqFD(t)
+	product.MakeProduct(mnpq)
+	verifyFD(t, product, "lax-key(2-5,10,11); (2,3)~~>(4,5), (10,11)-->(12,13)")
+	testColsAreStrictKey(t, product, c(1, 2, 3, 4, 5, 10, 11, 12, 13), false)
+	testColsAreLaxKey(t, product, c(2, 3, 10, 11), true)
+
+	// Lax key on left side, lax key on right side:
+	//   CREATE UNIQUE INDEX ON mnpq (p)
+	//   SELECT * FROM (SELECT b, c, d, e FROM abcde), (SELECT p, q FROM mnpq)
+	product = makeAbcdeFD(t)
+	product.ProjectCols(c(2, 3, 4, 5))
+	mnpq = makeMnpqFD(t)
+	mnpq.AddLaxKey(c(12), c(10, 11, 12, 13))
+	mnpq.ProjectCols(c(12, 13))
+	product.MakeProduct(mnpq)
+	verifyFD(t, product, "lax-key(2-5,12,13); (2,3)~~>(4,5), (12)~~>(13)")
+	testColsAreStrictKey(t, product, c(2, 3, 4, 5, 12, 13), false)
+	testColsAreLaxKey(t, product, c(2, 3, 12), true)
+
+	// Lax key on left side, no key on right side:
+	//   SELECT * FROM (SELECT b, c, d, e FROM abcde), (SELECT p, q FROM mnpq)
+	product = makeAbcdeFD(t)
+	product.ProjectCols(c(2, 3, 4, 5))
+	mnpq = makeMnpqFD(t)
+	mnpq.ProjectCols(c(12, 13))
+	product.MakeProduct(mnpq)
+	verifyFD(t, product, "(2,3)~~>(4,5)")
+	testColsAreStrictKey(t, product, c(2, 3, 4, 5, 12, 13), false)
+	testColsAreLaxKey(t, product, c(2, 3, 4, 5, 12, 13), false)
+
+	// No key on left side, lax key on right side:
+	//   CREATE UNIQUE INDEX ON mnpq (p)
+	//   SELECT * FROM (SELECT d, e FROM abcde), (SELECT p, q FROM mnpq)
+	product = makeAbcdeFD(t)
+	product.ProjectCols(c(4, 5))
+	mnpq = makeMnpqFD(t)
+	mnpq.AddLaxKey(c(12), c(10, 11, 12, 13))
+	mnpq.ProjectCols(c(12, 13))
+	product.MakeProduct(mnpq)
+	verifyFD(t, product, "(12)~~>(13)")
+	testColsAreStrictKey(t, product, c(4, 5, 12, 13), false)
+	testColsAreLaxKey(t, product, c(4, 5, 12, 13), false)
 }
 
 func TestFuncDeps_MakeApply(t *testing.T) {

--- a/pkg/sql/opt/props/func_dep_test.go
+++ b/pkg/sql/opt/props/func_dep_test.go
@@ -36,7 +36,7 @@ func TestFuncDeps_ColsAreKey(t *testing.T) {
 	loj.AddConstants(util.MakeFastIntSet(3))
 	loj.MakeOuter(nullExtendedCols, util.MakeFastIntSet(1, 10, 11))
 	loj.AddEquivalency(1, 10)
-	verifyFD(t, loj, "(10,11): ()-->(3), (1)-->(2,4,5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (12,13)~~>(14), (1,10,11)-->(14), (1)==(10), (10)==(1)")
+	verifyFD(t, loj, "key(10,11); ()-->(3), (1)-->(2,4,5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (12,13)~~>(14), (1,10,11)-->(14), (1)==(10), (10)==(1)")
 
 	testcases := []struct {
 		cols   opt.ColSet
@@ -253,7 +253,7 @@ func TestFuncDeps_AddStrictKey(t *testing.T) {
 	mnpq := makeMnpqFD(t)
 	allCols := util.MakeFastIntSet(10, 11, 12, 13)
 	mnpq.AddStrictKey(util.MakeFastIntSet(12), allCols)
-	verifyFD(t, mnpq, "(12): (10,11)-->(12,13), (12)-->(10,11,13)")
+	verifyFD(t, mnpq, "key(12); (10,11)-->(12,13), (12)-->(10,11,13)")
 	testColsAreStrictKey(t, mnpq, util.MakeFastIntSet(12), true)
 	testColsAreStrictKey(t, mnpq, util.MakeFastIntSet(13), false)
 	testColsAreStrictKey(t, mnpq, util.MakeFastIntSet(10, 11), true)
@@ -261,14 +261,14 @@ func TestFuncDeps_AddStrictKey(t *testing.T) {
 	// SELECT DISTINCT ON (m, n, p) m, n, p, q FROM mnpq
 	mnpq = makeMnpqFD(t)
 	mnpq.AddStrictKey(util.MakeFastIntSet(10, 11, 12), allCols)
-	verifyFD(t, mnpq, "(10,11): (10,11)-->(12,13)")
+	verifyFD(t, mnpq, "key(10,11); (10,11)-->(12,13)")
 	testColsAreStrictKey(t, mnpq, util.MakeFastIntSet(10, 11), true)
 	testColsAreStrictKey(t, mnpq, util.MakeFastIntSet(11, 12), false)
 
 	// SELECT DISTINCT ON (n, p, q) m, n, p, q FROM mnpq
 	mnpq = makeMnpqFD(t)
 	mnpq.AddStrictKey(util.MakeFastIntSet(11, 12, 13), allCols)
-	verifyFD(t, mnpq, "(10,11): (10,11)-->(12,13), (11-13)-->(10)")
+	verifyFD(t, mnpq, "key(10,11); (10,11)-->(12,13), (11-13)-->(10)")
 	testColsAreStrictKey(t, mnpq, util.MakeFastIntSet(11, 12, 13), true)
 	testColsAreStrictKey(t, mnpq, util.MakeFastIntSet(11, 12), false)
 	testColsAreStrictKey(t, mnpq, util.MakeFastIntSet(10, 11), true)
@@ -278,14 +278,14 @@ func TestFuncDeps_AddStrictKey(t *testing.T) {
 	allCols = util.MakeFastIntSet(1, 2)
 	ab := &props.FuncDepSet{}
 	ab.AddStrictKey(allCols, allCols)
-	verifyFD(t, ab, "(1,2): ")
+	verifyFD(t, ab, "key(1,2)")
 	testColsAreStrictKey(t, ab, util.MakeFastIntSet(1, 2), true)
 	testColsAreStrictKey(t, ab, util.MakeFastIntSet(1), false)
 
 	// Empty key.
 	empty := &props.FuncDepSet{}
 	empty.AddStrictKey(opt.ColSet{}, util.MakeFastIntSet(1))
-	verifyFD(t, empty, "(): ()-->(1)")
+	verifyFD(t, empty, "key(); ()-->(1)")
 	testColsAreStrictKey(t, empty, util.MakeFastIntSet(), true)
 	testColsAreStrictKey(t, empty, util.MakeFastIntSet(1), true)
 }
@@ -296,7 +296,7 @@ func TestFuncDeps_AddLaxKey(t *testing.T) {
 	mnpq := makeMnpqFD(t)
 	allCols := util.MakeFastIntSet(10, 11, 12, 13)
 	mnpq.AddLaxKey(util.MakeFastIntSet(12), allCols)
-	verifyFD(t, mnpq, "(10,11): (10,11)-->(12,13), (12)~~>(10,11,13)")
+	verifyFD(t, mnpq, "key(10,11); (10,11)-->(12,13), (12)~~>(10,11,13)")
 	testColsAreStrictKey(t, mnpq, util.MakeFastIntSet(12), false)
 	testColsAreLaxKey(t, mnpq, util.MakeFastIntSet(12), true)
 	testColsAreLaxKey(t, mnpq, util.MakeFastIntSet(10, 11), true)
@@ -304,17 +304,17 @@ func TestFuncDeps_AddLaxKey(t *testing.T) {
 	// CREATE UNIQUE INDEX idx ON mnpq (m, n, p)
 	mnpq = makeMnpqFD(t)
 	mnpq.AddLaxKey(util.MakeFastIntSet(10, 11, 12), allCols)
-	verifyFD(t, mnpq, "(10,11): (10,11)-->(12,13)")
+	verifyFD(t, mnpq, "key(10,11); (10,11)-->(12,13)")
 	testColsAreStrictKey(t, mnpq, util.MakeFastIntSet(10, 11), true)
 	testColsAreLaxKey(t, mnpq, util.MakeFastIntSet(10, 11), true)
 	testColsAreLaxKey(t, mnpq, util.MakeFastIntSet(10, 11, 12), true)
 
-	// No key.
+	// Empty key.
 	empty := &props.FuncDepSet{}
 	empty.AddLaxKey(opt.ColSet{}, util.MakeFastIntSet(1))
-	verifyFD(t, empty, "()~~>(1)")
+	verifyFD(t, empty, "lax-key(); ()~~>(1)")
 	testColsAreStrictKey(t, empty, util.MakeFastIntSet(), false)
-	testColsAreLaxKey(t, empty, util.MakeFastIntSet(), false)
+	testColsAreLaxKey(t, empty, util.MakeFastIntSet(), true)
 }
 
 func TestFuncDeps_MakeMax1Row(t *testing.T) {
@@ -323,13 +323,13 @@ func TestFuncDeps_MakeMax1Row(t *testing.T) {
 	// SELECT * FROM abcde LIMIT 1
 	abcde := makeAbcdeFD(t)
 	abcde.MakeMax1Row(util.MakeFastIntSet(1, 2, 3, 4, 5))
-	verifyFD(t, abcde, "(): ()-->(1-5)")
+	verifyFD(t, abcde, "key(); ()-->(1-5)")
 	testColsAreStrictKey(t, abcde, util.MakeFastIntSet(), true)
 
 	// No columns.
 	abcde = makeAbcdeFD(t)
 	abcde.MakeMax1Row(opt.ColSet{})
-	verifyFD(t, abcde, "(): ")
+	verifyFD(t, abcde, "key()")
 	testColsAreStrictKey(t, abcde, util.MakeFastIntSet(), true)
 }
 
@@ -339,11 +339,11 @@ func TestFuncDeps_MakeNotNull(t *testing.T) {
 	// SELECT * FROM abcde WHERE b IS NOT NULL
 	abcde := makeAbcdeFD(t)
 	abcde.MakeNotNull(util.MakeFastIntSet(2))
-	verifyFD(t, abcde, "(1): (1)-->(2-5), (2,3)~~>(1,4,5)")
+	verifyFD(t, abcde, "key(1); (1)-->(2-5), (2,3)~~>(1,4,5)")
 
 	// SELECT * FROM abcde WHERE b IS NOT NULL AND c IS NOT NULL
 	abcde.MakeNotNull(util.MakeFastIntSet(2, 3))
-	verifyFD(t, abcde, "(1): (1)-->(2-5), (2,3)-->(1,4,5)")
+	verifyFD(t, abcde, "key(1); (1)-->(2-5), (2,3)-->(1,4,5)")
 
 	// CREATE TABLE abcde (a INT PRIMARY KEY, b INT, c INT, d INT, e INT)
 	// CREATE UNIQUE INDEX ON abcde (b, c)
@@ -352,11 +352,11 @@ func TestFuncDeps_MakeNotNull(t *testing.T) {
 	nullExtendedCols := util.MakeFastIntSet(10, 11, 12, 13)
 	loj := makeProductFD(t)
 	loj.AddConstants(util.MakeFastIntSet(1, 2, 10, 12))
-	verifyFD(t, loj, "(11): ()-->(1-5,10,12), (11)-->(13)")
+	verifyFD(t, loj, "key(11); ()-->(1-5,10,12), (11)-->(13)")
 	loj.MakeOuter(nullExtendedCols, util.MakeFastIntSet(1, 2, 10, 11, 12))
-	verifyFD(t, loj, "(11): ()-->(1-5), (11)-->(10,12,13), ()~~>(10,12)")
+	verifyFD(t, loj, "key(11); ()-->(1-5), (11)-->(10,12,13), ()~~>(10,12)")
 	loj.MakeNotNull(util.MakeFastIntSet(1, 2, 12))
-	verifyFD(t, loj, "(11): ()-->(1-5,12), (11)-->(10,13), ()~~>(10)")
+	verifyFD(t, loj, "key(11); ()-->(1-5,12), (11)-->(10,13), ()~~>(10)")
 
 	// Test MakeNotNull triggering key reduction.
 	//   SELECT * FROM (SELECT DISTINCT b, c, d, e FROM abcde) WHERE b IS NOT NULL AND c IS NOT NULL
@@ -364,9 +364,18 @@ func TestFuncDeps_MakeNotNull(t *testing.T) {
 	abcde = makeAbcdeFD(t)
 	abcde.ProjectCols(allCols)
 	abcde.AddStrictKey(allCols, allCols)
-	verifyFD(t, abcde, "(2-5): (2,3)~~>(4,5)")
+	verifyFD(t, abcde, "key(2-5); (2,3)~~>(4,5)")
 	abcde.MakeNotNull(util.MakeFastIntSet(2, 3))
-	verifyFD(t, abcde, "(2,3): (2,3)-->(4,5)")
+	verifyFD(t, abcde, "key(2,3); (2,3)-->(4,5)")
+
+	// Test lax key to strong key conversion.
+	abc := &props.FuncDepSet{}
+	abc.AddLaxKey(util.MakeFastIntSet(2, 3), util.MakeFastIntSet(1, 2, 3))
+	verifyFD(t, abc, "lax-key(2,3); (2,3)~~>(1)")
+	abc.MakeNotNull(util.MakeFastIntSet(2))
+	verifyFD(t, abc, "lax-key(2,3); (2,3)~~>(1)")
+	abc.MakeNotNull(util.MakeFastIntSet(2, 3))
+	verifyFD(t, abc, "key(2,3); (2,3)-->(1)")
 }
 
 func TestFuncDeps_AddEquivalency(t *testing.T) {
@@ -383,7 +392,7 @@ func TestFuncDeps_AddEquivalency(t *testing.T) {
 	bmcn.AddEquivalency(2, 10)
 	bmcn.AddEquivalency(3, 11)
 	bmcn.AddEquivalency(4, 4)
-	verifyFD(t, &bmcn, "(1): (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (2)==(10), (10)==(2), (3)==(11), (11)==(3)")
+	verifyFD(t, &bmcn, "key(1); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (2)==(10), (10)==(2), (3)==(11), (11)==(3)")
 	testColsAreStrictKey(t, &bmcn, util.MakeFastIntSet(2, 3, 4, 5, 10, 11, 12, 13), false)
 
 	// SELECT * FROM abcde, mnpq WHERE a=m AND a=n
@@ -391,7 +400,7 @@ func TestFuncDeps_AddEquivalency(t *testing.T) {
 	amn.CopyFrom(product)
 	amn.AddEquivalency(1, 10)
 	amn.AddEquivalency(1, 11)
-	verifyFD(t, &amn, "(11): (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(10,11), (10)==(1,11), (11)==(1,10)")
+	verifyFD(t, &amn, "key(11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(10,11), (10)==(1,11), (11)==(1,10)")
 	testColsAreStrictKey(t, &amn, util.MakeFastIntSet(1), true)
 	testColsAreStrictKey(t, &amn, util.MakeFastIntSet(10), true)
 	testColsAreStrictKey(t, &amn, util.MakeFastIntSet(11), true)
@@ -403,9 +412,9 @@ func TestFuncDeps_AddEquivalency(t *testing.T) {
 	ab := &props.FuncDepSet{}
 	ab.AddStrictKey(util.MakeFastIntSet(1), allCols)
 	ab.AddLaxKey(util.MakeFastIntSet(2), allCols)
-	verifyFD(t, ab, "(1): (1)-->(2), (2)~~>(1)")
+	verifyFD(t, ab, "key(1); (1)-->(2), (2)~~>(1)")
 	ab.AddEquivalency(1, 2)
-	verifyFD(t, ab, "(1): (1)==(2), (2)==(1)")
+	verifyFD(t, ab, "key(1); (1)==(2), (2)==(1)")
 	testColsAreStrictKey(t, ab, util.MakeFastIntSet(2), true)
 
 	// Multiple equivalencies + constant.
@@ -413,7 +422,7 @@ func TestFuncDeps_AddEquivalency(t *testing.T) {
 	cnst := makeJoinFD(t)
 	cnst.AddEquivalency(10, 11)
 	cnst.AddConstants(util.MakeFastIntSet(11))
-	verifyFD(t, cnst, "(): ()-->(1-5,10-13), (1)==(10,11), (10)==(1,11), (11)==(1,10)")
+	verifyFD(t, cnst, "key(); ()-->(1-5,10-13), (1)==(10,11), (10)==(1,11), (11)==(1,10)")
 }
 
 func TestFuncDeps_AddConstants(t *testing.T) {
@@ -422,9 +431,9 @@ func TestFuncDeps_AddConstants(t *testing.T) {
 	// SELECT * FROM abcde WHERE c>2
 	abcde := makeAbcdeFD(t)
 	abcde.AddConstants(util.MakeFastIntSet(2))
-	verifyFD(t, abcde, "(1): ()-->(2), (1)-->(3-5), (2,3)~~>(1,4,5)")
+	verifyFD(t, abcde, "key(1); ()-->(2), (1)-->(3-5), (2,3)~~>(1,4,5)")
 	abcde.MakeNotNull(util.MakeFastIntSet(2, 3))
-	verifyFD(t, abcde, "(1): ()-->(2), (1)-->(3-5), (2,3)-->(1,4,5)")
+	verifyFD(t, abcde, "key(1); ()-->(2), (1)-->(3-5), (2,3)-->(1,4,5)")
 	testColsAreStrictKey(t, abcde, util.MakeFastIntSet(3), true)
 
 	// CREATE TABLE wxyz (w INT, x INT, y INT, z INT, PRIMARY KEY(w, x, y, z))
@@ -433,7 +442,7 @@ func TestFuncDeps_AddConstants(t *testing.T) {
 	xyz := &props.FuncDepSet{}
 	xyz.AddStrictKey(allCols, allCols)
 	xyz.AddConstants(util.MakeFastIntSet(2, 3))
-	verifyFD(t, xyz, "(1,4): ()-->(2,3)")
+	verifyFD(t, xyz, "key(1,4); ()-->(2,3)")
 	testColsAreStrictKey(t, xyz, util.MakeFastIntSet(2, 3), false)
 
 	// SELECT * FROM (SELECT * FROM wxyz WHERE x=1) WHERE y=2
@@ -444,29 +453,29 @@ func TestFuncDeps_AddConstants(t *testing.T) {
 	xyz.MakeNotNull(util.MakeFastIntSet(2))
 	xyz.AddConstants(util.MakeFastIntSet(3))
 	xyz.MakeNotNull(util.MakeFastIntSet(2, 3))
-	verifyFD(t, xyz, "(1,4): ()-->(2,3)")
+	verifyFD(t, xyz, "key(1,4); ()-->(2,3)")
 
 	// SELECT * FROM (SELECT * FROM abcde WHERE b IS NOT NULL AND c IS NOT NULL) WHERE b=1
 	abcde = makeAbcdeFD(t)
 	abcde.MakeNotNull(util.MakeFastIntSet(2, 3))
-	verifyFD(t, abcde, "(1): (1)-->(2-5), (2,3)-->(1,4,5)")
+	verifyFD(t, abcde, "key(1); (1)-->(2-5), (2,3)-->(1,4,5)")
 	abcde.AddConstants(util.MakeFastIntSet(2))
-	verifyFD(t, abcde, "(1): ()-->(2), (1)-->(3-5), (3)-->(1,4,5)")
+	verifyFD(t, abcde, "key(1); ()-->(2), (1)-->(3-5), (3)-->(1,4,5)")
 
 	// SELECT * FROM (SELECT * FROM abcde WHERE b IS NOT NULL AND c IS NOT NULL) WHERE b=1 AND c=2
 	abcde = makeAbcdeFD(t)
 	abcde.MakeNotNull(util.MakeFastIntSet(2, 3))
 	abcde.AddConstants(util.MakeFastIntSet(2, 3))
-	verifyFD(t, abcde, "(): ()-->(1-5)")
+	verifyFD(t, abcde, "key(); ()-->(1-5)")
 
 	// CREATE TABLE mnpq (m INT, n INT, p INT, q INT, PRIMARY KEY (m, n))
 	// SELECT a, m, n FROM abcde, mnpq WHERE a=m AND n IS NULL
 	var am props.FuncDepSet
 	am.CopyFrom(makeJoinFD(t))
 	am.AddConstants(util.MakeFastIntSet(11))
-	verifyFD(t, &am, "(10): ()-->(11), (1)-->(2-5), (2,3)~~>(1,4,5), (10)-->(12,13), (1)==(10), (10)==(1)")
+	verifyFD(t, &am, "key(10); ()-->(11), (1)-->(2-5), (2,3)~~>(1,4,5), (10)-->(12,13), (1)==(10), (10)==(1)")
 	am.ProjectCols(util.MakeFastIntSet(1, 10, 11))
-	verifyFD(t, &am, "(10): ()-->(11), (1)==(10), (10)==(1)")
+	verifyFD(t, &am, "key(10); ()-->(11), (1)==(10), (10)==(1)")
 	testColsAreStrictKey(t, &am, util.MakeFastIntSet(1), true)
 	testColsAreStrictKey(t, &am, util.MakeFastIntSet(1, 10), true)
 
@@ -476,7 +485,7 @@ func TestFuncDeps_AddConstants(t *testing.T) {
 	eqConst.CopyFrom(makeJoinFD(t))
 	eqConst.AddConstants(util.MakeFastIntSet(10))
 	eqConst.MakeNotNull(util.MakeFastIntSet(10))
-	verifyFD(t, &eqConst, "(11): ()-->(1-5,10), (11)-->(12,13), (1)==(10), (10)==(1)")
+	verifyFD(t, &eqConst, "key(11); ()-->(1-5,10), (11)-->(12,13), (1)==(10), (10)==(1)")
 	testColsAreStrictKey(t, &eqConst, util.MakeFastIntSet(1, 2, 3, 10, 12), false)
 }
 
@@ -494,18 +503,18 @@ func TestFuncDeps_AddSynthesizedCol(t *testing.T) {
 	var abdef props.FuncDepSet
 	abdef.CopyFrom(abcde)
 	abdef.AddSynthesizedCol(util.MakeFastIntSet(2, 3), 6)
-	verifyFD(t, &abdef, "(1): (1)-->(2-5), (2,3)~~>(1,4,5), (2,3)-->(6)")
+	verifyFD(t, &abdef, "key(1); (1)-->(2-5), (2,3)~~>(1,4,5), (2,3)-->(6)")
 	abdef.ProjectCols(util.MakeFastIntSet(1, 2, 4, 5, 6))
-	verifyFD(t, &abdef, "(1): (1)-->(2,4-6)")
+	verifyFD(t, &abdef, "key(1); (1)-->(2,4-6)")
 
 	// Add another synthesized column, based on the first synthesized column.
 	abdef.AddSynthesizedCol(util.MakeFastIntSet(6), 7)
-	verifyFD(t, &abdef, "(1): (1)-->(2,4-6), (6)-->(7)")
+	verifyFD(t, &abdef, "key(1); (1)-->(2,4-6), (6)-->(7)")
 	testColsAreStrictKey(t, &abdef, util.MakeFastIntSet(2, 3), false)
 
 	// Add a constant synthesized column, not based on any other column.
 	abdef.AddSynthesizedCol(opt.ColSet{}, 8)
-	verifyFD(t, &abdef, "(1): ()-->(8), (1)-->(2,4-6), (6)-->(7)")
+	verifyFD(t, &abdef, "key(1); ()-->(8), (1)-->(2,4-6), (6)-->(7)")
 	testColsAreStrictKey(t, &abdef, util.MakeFastIntSet(2, 3, 4, 5, 6, 7, 8), false)
 
 	// Remove columns and add computed column.
@@ -515,20 +524,40 @@ func TestFuncDeps_AddSynthesizedCol(t *testing.T) {
 	var anb1 props.FuncDepSet
 	anb1.CopyFrom(makeJoinFD(t))
 	anb1.AddSynthesizedCol(util.MakeFastIntSet(2), 100)
-	verifyFD(t, &anb1, "(10,11): (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(10), (10)==(1), (2)-->(100)")
+	verifyFD(t, &anb1, "key(10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(10), (10)==(1), (2)-->(100)")
 	anb1.ProjectCols(util.MakeFastIntSet(1, 11, 100))
-	verifyFD(t, &anb1, "(1,11): (1)-->(100)")
+	verifyFD(t, &anb1, "key(1,11); (1)-->(100)")
 	testColsAreStrictKey(t, &anb1, util.MakeFastIntSet(1, 11, 100), true)
 }
 
 func TestFuncDeps_ProjectCols(t *testing.T) {
+	foo := &props.FuncDepSet{}
+	all := util.MakeFastIntSet(1, 2, 3, 4)
+	foo.AddStrictKey(util.MakeFastIntSet(1), all)
+	foo.AddLaxKey(util.MakeFastIntSet(2, 3), all)
+	foo.AddLaxKey(util.MakeFastIntSet(4), all)
+	verifyFD(t, foo, "key(1); (1)-->(2-4), (2,3)~~>(1,4), (4)~~>(1-3)")
+	foo.ProjectCols(util.MakeFastIntSet(2, 3, 4))
+	verifyFD(t, foo, "lax-key(2-4); (2,3)~~>(4), (4)~~>(2,3)")
+	foo.MakeNotNull(util.MakeFastIntSet(2, 3, 4))
+	verifyFD(t, foo, "key(4); (2,3)-->(4), (4)-->(2,3)")
+
+	x := makeAbcdeFD(t)
+	x.ProjectCols(util.MakeFastIntSet(2, 3))
+	verifyFD(t, x, "lax-key(2,3)")
+
+	x = makeAbcdeFD(t)
+	x.MakeNotNull(util.MakeFastIntSet(2, 3))
+	x.ProjectCols(util.MakeFastIntSet(2, 3))
+	verifyFD(t, x, "key(2,3)")
+
 	// Remove column from lax dependency.
 	//   CREATE TABLE abcde (a INT PRIMARY KEY, b INT, c INT, d INT, e INT)
 	//   CREATE UNIQUE INDEX ON abcde (b, c)
 	//   SELECT a, c, d, e FROM abcde
 	abde := makeAbcdeFD(t)
 	abde.ProjectCols(util.MakeFastIntSet(1, 3, 4, 5))
-	verifyFD(t, abde, "(1): (1)-->(3-5)")
+	verifyFD(t, abde, "key(1); (1)-->(3-5)")
 
 	// Try removing columns that are only dependants (i.e. never determinants).
 	//   CREATE TABLE mnpq (m INT, n INT, p INT, q INT, PRIMARY KEY (m, n))
@@ -537,7 +566,7 @@ func TestFuncDeps_ProjectCols(t *testing.T) {
 	var abcmn props.FuncDepSet
 	abcmn.CopyFrom(makeJoinFD(t))
 	abcmn.ProjectCols(util.MakeFastIntSet(1, 2, 3, 10, 11))
-	verifyFD(t, &abcmn, "(10,11): (1)-->(2,3), (2,3)~~>(1,10), (1)==(10), (10)==(1)")
+	verifyFD(t, &abcmn, "key(10,11); (1)-->(2,3), (2,3)~~>(1,10), (1)==(10), (10)==(1)")
 	testColsAreStrictKey(t, &abcmn, util.MakeFastIntSet(1, 11), true)
 	testColsAreStrictKey(t, &abcmn, util.MakeFastIntSet(2, 3), false)
 
@@ -546,22 +575,22 @@ func TestFuncDeps_ProjectCols(t *testing.T) {
 	abcde := makeAbcdeFD(t)
 	abcde.AddConstants(util.MakeFastIntSet(2))
 	abcde.MakeNotNull(util.MakeFastIntSet(2, 3))
-	verifyFD(t, abcde, "(1): ()-->(2), (1)-->(3-5), (2,3)-->(1,4,5)")
+	verifyFD(t, abcde, "key(1); ()-->(2), (1)-->(3-5), (2,3)-->(1,4,5)")
 	abcde.ProjectCols(util.MakeFastIntSet(1, 3, 4, 5))
-	verifyFD(t, abcde, "(1): (1)-->(3-5), (3)-->(1,4,5)")
+	verifyFD(t, abcde, "key(1); (1)-->(3-5), (3)-->(1,4,5)")
 
 	// Remove key columns, but expect another key to be found.
 	//   SELECT b, c, n FROM abcde, mnpq WHERE a=m AND b IS NOT NULL AND c IS NOT NULL
 	switchKey := makeJoinFD(t)
 	switchKey.MakeNotNull(util.MakeFastIntSet(2, 3))
-	verifyFD(t, switchKey, "(10,11): (1)-->(2-5), (2,3)-->(1,4,5), (10,11)-->(12,13), (1)==(10), (10)==(1)")
+	verifyFD(t, switchKey, "key(10,11); (1)-->(2-5), (2,3)-->(1,4,5), (10,11)-->(12,13), (1)==(10), (10)==(1)")
 	switchKey.ProjectCols(util.MakeFastIntSet(2, 3, 11))
-	verifyFD(t, switchKey, "(2,3,11): ")
+	verifyFD(t, switchKey, "key(2,3,11)")
 
 	// Remove column from every determinant and ensure that all FDs go away.
 	//   SELECT d FROM abcde, mnpq WHERE a=m AND 1=1 AND n=2
 	noKey := makeJoinFD(t)
-	verifyFD(t, noKey, "(10,11): (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(10), (10)==(1)")
+	verifyFD(t, noKey, "key(10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(10), (10)==(1)")
 	noKey.ProjectCols(util.MakeFastIntSet(2, 11))
 	verifyFD(t, noKey, "")
 	testColsAreStrictKey(t, noKey, util.MakeFastIntSet(), false)
@@ -571,8 +600,9 @@ func TestFuncDeps_ProjectCols(t *testing.T) {
 	var bcden props.FuncDepSet
 	bcden.CopyFrom(makeJoinFD(t))
 	bcden.ProjectCols(util.MakeFastIntSet(2, 3, 4, 5, 11, 12, 13))
-	verifyFD(t, &bcden, "(2,3)~~>(4,5)")
+	verifyFD(t, &bcden, "lax-key(2-5,11-13); (2,3)~~>(4,5)")
 	testColsAreStrictKey(t, &bcden, util.MakeFastIntSet(2, 3, 4, 5, 11, 12, 13), false)
+	testColsAreLaxKey(t, &bcden, util.MakeFastIntSet(2, 3, 4, 5, 11, 12, 13), true)
 
 	// Remove remainder of columns (N rows, 0 cols projected).
 	bcden.ProjectCols(opt.ColSet{})
@@ -582,16 +612,16 @@ func TestFuncDeps_ProjectCols(t *testing.T) {
 	//   SELECT d FROM abcde, mnpq WHERE a=m AND a=1 AND n=1
 	oneRow := makeJoinFD(t)
 	oneRow.AddConstants(util.MakeFastIntSet(1, 11))
-	verifyFD(t, oneRow, "(): ()-->(1-5,10-13), (1)==(10), (10)==(1)")
+	verifyFD(t, oneRow, "key(); ()-->(1-5,10-13), (1)==(10), (10)==(1)")
 	oneRow.ProjectCols(util.MakeFastIntSet(4))
-	verifyFD(t, oneRow, "(): ()-->(4)")
+	verifyFD(t, oneRow, "key(); ()-->(4)")
 
 	// Remove column that has equivalent substitute.
 	//   SELECT e, one FROM (SELECT *, d+1 AS one FROM abcde) WHERE d=e
 	abcde = makeAbcdeFD(t)
 	abcde.AddSynthesizedCol(util.MakeFastIntSet(4), 6)
 	abcde.AddEquivalency(4, 5)
-	verifyFD(t, abcde, "(1): (1)-->(2-5), (2,3)~~>(1,4,5), (4)-->(6), (4)==(5), (5)==(4)")
+	verifyFD(t, abcde, "key(1); (1)-->(2-5), (2,3)~~>(1,4,5), (4)-->(6), (4)==(5), (5)==(4)")
 	abcde.ProjectCols(util.MakeFastIntSet(5, 6))
 	verifyFD(t, abcde, "(5)-->(6)")
 
@@ -600,24 +630,67 @@ func TestFuncDeps_ProjectCols(t *testing.T) {
 	//   SELECT d, e FROM abcde WHERE b=d AND c=e
 	abcde = makeAbcdeFD(t)
 	abcde.AddEquivalency(2, 4)
-	verifyFD(t, abcde, "(1): (1)-->(2-5), (2,3)~~>(1,4,5), (2)==(4), (4)==(2)")
+	verifyFD(t, abcde, "key(1); (1)-->(2-5), (2,3)~~>(1,4,5), (2)==(4), (4)==(2)")
 	abcde.ProjectCols(util.MakeFastIntSet(3, 4, 5))
-	verifyFD(t, abcde, "(3,4)~~>(5)")
+	verifyFD(t, abcde, "lax-key(3-5); (3,4)~~>(5)")
 
 	// Equivalent substitution results in (4,5)~~>(4,5), which is eliminated.
 	//   SELECT d, e FROM abcde WHERE b=d AND c=e
 	abcde = makeAbcdeFD(t)
 	abcde.AddEquivalency(2, 4)
 	abcde.AddEquivalency(3, 5)
-	verifyFD(t, abcde, "(1): (1)-->(2-5), (2,3)~~>(1,4,5), (2)==(4), (4)==(2), (3)==(5), (5)==(3)")
+	verifyFD(t, abcde, "key(1); (1)-->(2-5), (2,3)~~>(1,4,5), (2)==(4), (4)==(2), (3)==(5), (5)==(3)")
 	abcde.ProjectCols(util.MakeFastIntSet(4, 5))
-	verifyFD(t, abcde, "")
+	verifyFD(t, abcde, "lax-key(4,5)")
 
 	// Use ProjectCols to add columns (make sure key is extended).
 	//   SELECT d, e FROM abcde WHERE b=d AND c=e
 	abcde = makeAbcdeFD(t)
 	abcde.ProjectCols(util.MakeFastIntSet(1, 2, 3, 4, 5, 6, 7))
-	verifyFD(t, abcde, "(1): (1)-->(2-7), (2,3)~~>(1,4,5)")
+	verifyFD(t, abcde, "key(1); (1)-->(2-7), (2,3)~~>(1,4,5)")
+
+	// Verify lax keys are retained (and can later become keys) when the key is
+	// projected away.
+	abcde = &props.FuncDepSet{}
+	abcde.AddStrictKey(util.MakeFastIntSet(1), util.MakeFastIntSet(1, 2, 3, 4, 5))
+	abcde.AddLaxKey(util.MakeFastIntSet(2), util.MakeFastIntSet(1, 2, 3, 4, 5))
+	abcde.AddLaxKey(util.MakeFastIntSet(3, 4), util.MakeFastIntSet(1, 2, 3, 4, 5))
+	verifyFD(t, abcde, "key(1); (1)-->(2-5), (2)~~>(1,3-5), (3,4)~~>(1,2,5)")
+	abcde.ProjectCols(util.MakeFastIntSet(2, 3, 4, 5))
+	verifyFD(t, abcde, "lax-key(2-5); (2)~~>(3-5), (3,4)~~>(2,5)")
+	testColsAreLaxKey(t, abcde, util.MakeFastIntSet(2), true)
+	testColsAreLaxKey(t, abcde, util.MakeFastIntSet(3, 4), true)
+
+	copy := &props.FuncDepSet{}
+	copy.CopyFrom(abcde)
+
+	// Verify that lax keys convert to strong keys.
+	abcde.MakeNotNull(util.MakeFastIntSet(2))
+	verifyFD(t, abcde, "key(2); (2)-->(3-5), (3,4)~~>(2,5)")
+
+	abcde.CopyFrom(copy)
+	abcde.MakeNotNull(util.MakeFastIntSet(3, 4))
+	verifyFD(t, abcde, "key(3,4); (2)~~>(3-5), (3,4)-->(2,5)")
+
+	abcde.CopyFrom(copy)
+	abcde.MakeNotNull(util.MakeFastIntSet(3))
+	verifyFD(t, abcde, "lax-key(2-5); (2)~~>(3-5), (3,4)~~>(2,5)")
+
+	// Verify that lax keys are retained after we project more columns away.
+	abcde.CopyFrom(copy)
+	abcde.ProjectCols(util.MakeFastIntSet(2, 3))
+	verifyFD(t, abcde, "lax-key(2,3); (2)~~>(3)")
+	testColsAreLaxKey(t, abcde, util.MakeFastIntSet(2), true)
+	abcde.MakeNotNull(util.MakeFastIntSet(2))
+	verifyFD(t, abcde, "key(2); (2)-->(3)")
+
+	abcde.CopyFrom(copy)
+	abcde.ProjectCols(util.MakeFastIntSet(3, 4, 5))
+	verifyFD(t, abcde, "lax-key(3-5); (3,4)~~>(5)")
+	testColsAreLaxKey(t, abcde, util.MakeFastIntSet(3, 4), true)
+	abcde.MakeNotNull(util.MakeFastIntSet(3, 4))
+	verifyFD(t, abcde, "key(3,4); (3,4)-->(5)")
+	testColsAreStrictKey(t, abcde, util.MakeFastIntSet(3, 4), true)
 }
 
 func TestFuncDeps_AddFrom(t *testing.T) {
@@ -626,20 +699,20 @@ func TestFuncDeps_AddFrom(t *testing.T) {
 	//   CREATE UNIQUE INDEX ON abcde (b, c)
 	abcde := makeAbcdeFD(t)
 	abcde.ProjectCols(util.MakeFastIntSet(1, 2, 4))
-	verifyFD(t, abcde, "(1): (1)-->(2,4)")
+	verifyFD(t, abcde, "key(1); (1)-->(2,4)")
 	abcde.AddFrom(makeAbcdeFD(t))
 	abcde.AddStrictKey(util.MakeFastIntSet(1), util.MakeFastIntSet(1, 2, 3, 4, 5))
-	verifyFD(t, abcde, "(1): (1)-->(2-5), (2,3)~~>(1,4,5)")
+	verifyFD(t, abcde, "key(1); (1)-->(2-5), (2,3)~~>(1,4,5)")
 	testColsAreStrictKey(t, abcde, util.MakeFastIntSet(1), true)
 
 	// Remove strict dependency, then add it back.
 	abcde = makeAbcdeFD(t)
 	abcde.MakeNotNull(util.MakeFastIntSet(2, 3))
 	abcde.ProjectCols(util.MakeFastIntSet(2, 3))
-	verifyFD(t, abcde, "(2,3): ")
+	verifyFD(t, abcde, "key(2,3)")
 	abcde.AddFrom(makeAbcdeFD(t))
 	abcde.AddStrictKey(util.MakeFastIntSet(2, 3), util.MakeFastIntSet(1, 2, 3, 4, 5))
-	verifyFD(t, abcde, "(2,3): (1)-->(2-5), (2,3)-->(1,4,5)")
+	verifyFD(t, abcde, "key(2,3); (1)-->(2-5), (2,3)-->(1,4,5)")
 	testColsAreStrictKey(t, abcde, util.MakeFastIntSet(1), true)
 }
 
@@ -651,7 +724,7 @@ func TestFuncDeps_AddEquivFrom(t *testing.T) {
 	mnpq := makeMnpqFD(t)
 	product.MakeProduct(mnpq)
 	product.AddEquivalency(1, 10)
-	verifyFD(t, product, "(10,11): (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(10), (10)==(1)")
+	verifyFD(t, product, "key(10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(10), (10)==(1)")
 
 	var equiv props.FuncDepSet
 	equiv.AddEquivFrom(product)
@@ -675,7 +748,7 @@ func TestFuncDeps_MakeProduct(t *testing.T) {
 	mnpq.AddEquivalency(12, 13)
 	mnpq.ProjectCols(util.MakeFastIntSet(10, 11))
 	product.MakeProduct(mnpq)
-	verifyFD(t, product, "(1,10,11): (1)-->(2,3), (2,3)~~>(1)")
+	verifyFD(t, product, "key(1,10,11); (1)-->(2,3), (2,3)~~>(1)")
 
 	// Constants on both sides.
 	//   SELECT * FROM (SELECT * FROM abcde b=1), (SELECT * FROM mnpq WHERE p=1)
@@ -684,7 +757,7 @@ func TestFuncDeps_MakeProduct(t *testing.T) {
 	mnpq = makeMnpqFD(t)
 	mnpq.AddConstants(util.MakeFastIntSet(12))
 	product.MakeProduct(mnpq)
-	verifyFD(t, product, "(1,10,11): ()-->(2,12), (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(13)")
+	verifyFD(t, product, "key(1,10,11); ()-->(2,12), (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(13)")
 
 	// Key only on left side:
 	//   SELECT * FROM abcde, (SELECT p, q FROM mnpq)
@@ -715,9 +788,9 @@ func TestFuncDeps_MakeApply(t *testing.T) {
 	abcde := makeAbcdeFD(t)
 	mnpq := makeMnpqFD(t)
 	mnpq.MakeMax1Row(util.MakeFastIntSet(10, 11, 12, 13))
-	verifyFD(t, mnpq, "(): ()-->(10-13)")
+	verifyFD(t, mnpq, "key(); ()-->(10-13)")
 	abcde.MakeApply(mnpq)
-	verifyFD(t, abcde, "(1): (1)-->(2-5,10-13), (2,3)~~>(1,4,5)")
+	verifyFD(t, abcde, "key(1); (1)-->(2-5,10-13), (2,3)~~>(1,4,5)")
 
 	// SELECT *
 	// FROM abcde
@@ -726,9 +799,9 @@ func TestFuncDeps_MakeApply(t *testing.T) {
 	abcde = makeAbcdeFD(t)
 	mnpq = makeMnpqFD(t)
 	mnpq.AddConstants(util.MakeFastIntSet(10, 12))
-	verifyFD(t, mnpq, "(11): ()-->(10,12), (11)-->(13)")
+	verifyFD(t, mnpq, "key(11); ()-->(10,12), (11)-->(13)")
 	abcde.MakeApply(mnpq)
-	verifyFD(t, abcde, "(1,11): (1)-->(2-5), (2,3)~~>(1,4,5), (1,11)-->(10,12,13)")
+	verifyFD(t, abcde, "key(1,11); (1)-->(2-5), (2,3)~~>(1,4,5), (1,11)-->(10,12,13)")
 
 	// SELECT *
 	// FROM abcde
@@ -738,9 +811,9 @@ func TestFuncDeps_MakeApply(t *testing.T) {
 	mnpq = makeMnpqFD(t)
 	mnpq.AddConstants(util.MakeFastIntSet(10))
 	mnpq.AddEquivalency(12, 13)
-	verifyFD(t, mnpq, "(11): ()-->(10), (11)-->(12,13), (12)==(13), (13)==(12)")
+	verifyFD(t, mnpq, "key(11); ()-->(10), (11)-->(12,13), (12)==(13), (13)==(12)")
 	abcde.MakeApply(mnpq)
-	verifyFD(t, abcde, "(1,11): (1)-->(2-5), (2,3)~~>(1,4,5), (1,11)-->(10,12,13), (12)==(13), (13)==(12)")
+	verifyFD(t, abcde, "key(1,11); (1)-->(2-5), (2,3)~~>(1,4,5), (1,11)-->(10,12,13), (12)==(13), (13)==(12)")
 
 	// No key in outer relation.
 	//   SELECT *
@@ -752,7 +825,7 @@ func TestFuncDeps_MakeApply(t *testing.T) {
 	mnpq = makeMnpqFD(t)
 	mnpq.AddConstants(util.MakeFastIntSet(11))
 	mnpq.AddEquivalency(12, 13)
-	verifyFD(t, mnpq, "(10): ()-->(11), (10)-->(12,13), (12)==(13), (13)==(12)")
+	verifyFD(t, mnpq, "key(10); ()-->(11), (10)-->(12,13), (12)==(13), (13)==(12)")
 	abcde.MakeApply(mnpq)
 	verifyFD(t, abcde, "(2,3)~~>(4,5), (12)==(13), (13)==(12)")
 
@@ -781,9 +854,9 @@ func TestFuncDeps_MakeOuter(t *testing.T) {
 	mnpq := makeMnpqFD(t)
 	mnpq.AddSynthesizedCol(util.MakeFastIntSet(12, 13), 14)
 	loj.MakeProduct(mnpq)
-	verifyFD(t, loj, "(1,10,11): (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (12,13)-->(14)")
+	verifyFD(t, loj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (12,13)-->(14)")
 	loj.MakeOuter(nullExtendedCols, util.MakeFastIntSet(1, 10, 11))
-	verifyFD(t, loj, "(1,10,11): (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (12,13)~~>(14), (1,10,11)-->(14)")
+	verifyFD(t, loj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (12,13)~~>(14), (1,10,11)-->(14)")
 
 	// One determinant column in null-supplying side is not null.
 	//   SELECT * FROM abcde LEFT OUTER JOIN (SELECT *, m+q FROM mnpq) ON True
@@ -792,9 +865,9 @@ func TestFuncDeps_MakeOuter(t *testing.T) {
 	mnpq = makeMnpqFD(t)
 	mnpq.AddSynthesizedCol(util.MakeFastIntSet(10, 13), 14)
 	loj.MakeProduct(mnpq)
-	verifyFD(t, loj, "(1,10,11): (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (10,13)-->(14)")
+	verifyFD(t, loj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (10,13)-->(14)")
 	loj.MakeOuter(nullExtendedCols, util.MakeFastIntSet(1, 10, 11))
-	verifyFD(t, loj, "(1,10,11): (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (10,13)-->(14)")
+	verifyFD(t, loj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (10,13)-->(14)")
 
 	// Add constants on both sides of outer join.
 	//   SELECT * FROM abcde RIGHT OUTER JOIN mnpq ON b=1 AND c=1 AND p=1
@@ -803,9 +876,9 @@ func TestFuncDeps_MakeOuter(t *testing.T) {
 	roj.MakeProduct(makeMnpqFD(t))
 	roj.AddConstants(util.MakeFastIntSet(2, 3, 12))
 	roj.MakeNotNull(util.MakeFastIntSet(2, 3, 12))
-	verifyFD(t, roj, "(10,11): ()-->(2,3,12), (1)-->(4,5), (2,3)-->(1,4,5), (10,11)-->(13)")
+	verifyFD(t, roj, "key(10,11); ()-->(2,3,12), (1)-->(4,5), (2,3)-->(1,4,5), (10,11)-->(13)")
 	roj.MakeOuter(nullExtendedCols, util.MakeFastIntSet(1, 2, 3, 10, 11, 12))
-	verifyFD(t, roj, "(10,11): ()-->(12), (1)-->(4,5), (2,3)-->(1,4,5), (10,11)-->(1-5,13), ()~~>(2,3)")
+	verifyFD(t, roj, "key(10,11); ()-->(12), (1)-->(4,5), (2,3)-->(1,4,5), (10,11)-->(1-5,13), ()~~>(2,3)")
 
 	// Test equivalency on both sides of outer join.
 	//   SELECT * FROM abcde RIGHT OUTER JOIN mnpq ON b=c AND c=d AND m=p AND m=q
@@ -816,9 +889,9 @@ func TestFuncDeps_MakeOuter(t *testing.T) {
 	roj.AddEquivalency(3, 4)
 	roj.AddEquivalency(10, 12)
 	roj.AddEquivalency(10, 13)
-	verifyFD(t, roj, "(1,10,11): (1)-->(2-5), (2,3)~~>(1,5), (10,11)-->(12,13), (2)==(3,4), (3)==(2,4), (4)==(2,3), (10)==(12,13), (12)==(10,13), (13)==(10,12)")
+	verifyFD(t, roj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,5), (10,11)-->(12,13), (2)==(3,4), (3)==(2,4), (4)==(2,3), (10)==(12,13), (12)==(10,13), (13)==(10,12)")
 	roj.MakeOuter(nullExtendedCols, util.MakeFastIntSet(1, 2, 3, 10, 11, 13))
-	verifyFD(t, roj, "(1,10,11): (1)-->(2-5), (2,3)~~>(1,5), (10,11)-->(12,13), (2)==(3,4), (3)==(2,4), (4)==(2,3), (10)==(12,13), (12)==(10,13), (13)==(10,12)")
+	verifyFD(t, roj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,5), (10,11)-->(12,13), (2)==(3,4), (3)==(2,4), (4)==(2,3), (10)==(12,13), (12)==(10,13), (13)==(10,12)")
 
 	// Test equivalency that crosses join boundary.
 	//   SELECT * FROM abcde RIGHT OUTER JOIN mnpq ON a=m
@@ -826,9 +899,9 @@ func TestFuncDeps_MakeOuter(t *testing.T) {
 	roj = makeAbcdeFD(t)
 	roj.MakeProduct(makeMnpqFD(t))
 	roj.AddEquivalency(1, 10)
-	verifyFD(t, roj, "(10,11): (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(10), (10)==(1)")
+	verifyFD(t, roj, "key(10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(10), (10)==(1)")
 	roj.MakeOuter(nullExtendedCols, util.MakeFastIntSet(1, 10, 11))
-	verifyFD(t, roj, "(10,11): (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(1-5,12,13), (1)~~>(10)")
+	verifyFD(t, roj, "key(10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(1-5,12,13), (1)~~>(10)")
 
 	// Test equivalency that includes columns from both sides of join boundary.
 	//   SELECT * FROM abcde RIGHT OUTER JOIN mnpq ON a=m AND a=b
@@ -837,9 +910,9 @@ func TestFuncDeps_MakeOuter(t *testing.T) {
 	roj.MakeProduct(makeMnpqFD(t))
 	roj.AddEquivalency(1, 10)
 	roj.AddEquivalency(1, 2)
-	verifyFD(t, roj, "(10,11): (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(2,10), (10)==(1,2), (2)==(1,10)")
+	verifyFD(t, roj, "key(10,11); (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(2,10), (10)==(1,2), (2)==(1,10)")
 	roj.MakeOuter(nullExtendedCols, util.MakeFastIntSet(1, 2, 10, 11))
-	verifyFD(t, roj, "(10,11): (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(1-5,12,13), (1)==(2), (2)==(1), (1)~~>(10), (2)~~>(10)")
+	verifyFD(t, roj, "key(10,11); (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(1-5,12,13), (1)==(2), (2)==(1), (1)~~>(10), (2)~~>(10)")
 
 	// Test multiple calls to MakeOuter, where the first creates determinant with
 	// columns from both sides of join.
@@ -849,11 +922,11 @@ func TestFuncDeps_MakeOuter(t *testing.T) {
 	roj = makeAbcdeFD(t)
 	roj.AddConstants(util.MakeFastIntSet(2))
 	roj.MakeProduct(makeMnpqFD(t))
-	verifyFD(t, roj, "(1,10,11): ()-->(2), (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(12,13)")
+	verifyFD(t, roj, "key(1,10,11); ()-->(2), (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(12,13)")
 	roj.MakeOuter(nullExtendedCols, util.MakeFastIntSet(1, 2, 10, 11))
-	verifyFD(t, roj, "(1,10,11): (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), ()~~>(2), (1,10,11)-->(2)")
+	verifyFD(t, roj, "key(1,10,11); (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), ()~~>(2), (1,10,11)-->(2)")
 	roj.MakeOuter(nullExtendedCols2, util.MakeFastIntSet(1, 2, 10, 11))
-	verifyFD(t, roj, "(1,10,11): (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), ()~~>(2), (1,10,11)-->(2)")
+	verifyFD(t, roj, "key(1,10,11); (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), ()~~>(2), (1,10,11)-->(2)")
 
 	// Join keyless relations with nullable columns.
 	//   SELECT * FROM (SELECT d, e, d+e FROM abcde) LEFT JOIN (SELECT p, q, p+q FROM mnpq) ON True
@@ -906,9 +979,9 @@ func makeAbcdeFD(t *testing.T) *props.FuncDepSet {
 	allCols := util.MakeFastIntSet(1, 2, 3, 4, 5)
 	abcde := &props.FuncDepSet{}
 	abcde.AddStrictKey(util.MakeFastIntSet(1), allCols)
-	verifyFD(t, abcde, "(1): (1)-->(2-5)")
+	verifyFD(t, abcde, "key(1); (1)-->(2-5)")
 	abcde.AddLaxKey(util.MakeFastIntSet(2, 3), allCols)
-	verifyFD(t, abcde, "(1): (1)-->(2-5), (2,3)~~>(1,4,5)")
+	verifyFD(t, abcde, "key(1); (1)-->(2-5), (2,3)~~>(1,4,5)")
 	testColsAreStrictKey(t, abcde, util.MakeFastIntSet(1), true)
 	testColsAreStrictKey(t, abcde, util.MakeFastIntSet(2, 3), false)
 	testColsAreStrictKey(t, abcde, util.MakeFastIntSet(1, 2), true)
@@ -925,7 +998,7 @@ func makeMnpqFD(t *testing.T) *props.FuncDepSet {
 	mnpq := &props.FuncDepSet{}
 	mnpq.AddStrictKey(util.MakeFastIntSet(10, 11), allCols)
 	mnpq.MakeNotNull(util.MakeFastIntSet(10, 11))
-	verifyFD(t, mnpq, "(10,11): (10,11)-->(12,13)")
+	verifyFD(t, mnpq, "key(10,11); (10,11)-->(12,13)")
 	testColsAreStrictKey(t, mnpq, util.MakeFastIntSet(10), false)
 	testColsAreStrictKey(t, mnpq, util.MakeFastIntSet(10, 11), true)
 	testColsAreStrictKey(t, mnpq, util.MakeFastIntSet(10, 11, 12), true)
@@ -938,7 +1011,7 @@ func makeMnpqFD(t *testing.T) *props.FuncDepSet {
 func makeProductFD(t *testing.T) *props.FuncDepSet {
 	product := makeAbcdeFD(t)
 	product.MakeProduct(makeMnpqFD(t))
-	verifyFD(t, product, "(1,10,11): (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13)")
+	verifyFD(t, product, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13)")
 	testColsAreStrictKey(t, product, util.MakeFastIntSet(1), false)
 	testColsAreStrictKey(t, product, util.MakeFastIntSet(10, 11), false)
 	testColsAreStrictKey(t, product, util.MakeFastIntSet(1, 10, 11), true)
@@ -953,9 +1026,9 @@ func makeJoinFD(t *testing.T) *props.FuncDepSet {
 	// Start with cartesian product FD and add equivalency to it.
 	join := makeProductFD(t)
 	join.AddEquivalency(1, 10)
-	verifyFD(t, join, "(10,11): (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(10), (10)==(1)")
+	verifyFD(t, join, "key(10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(10), (10)==(1)")
 	join.ProjectCols(util.MakeFastIntSet(1, 2, 3, 4, 5, 10, 11, 12, 13))
-	verifyFD(t, join, "(10,11): (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(10), (10)==(1)")
+	verifyFD(t, join, "key(10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(10), (10)==(1)")
 	testColsAreStrictKey(t, join, util.MakeFastIntSet(1, 11), true)
 	testColsAreStrictKey(t, join, util.MakeFastIntSet(1, 10), false)
 	testColsAreStrictKey(t, join, util.MakeFastIntSet(1, 10, 11), true)
@@ -975,13 +1048,20 @@ func verifyFD(t *testing.T, f *props.FuncDepSet, expected string) {
 
 	f.Verify()
 
-	if key, ok := f.Key(); ok {
+	if key, ok := f.StrictKey(); ok {
 		testColsAreStrictKey(t, f, key, true)
 		if !key.Empty() {
 			testColsAreStrictKey(t, f, opt.ColSet{}, false)
 		}
 		closure := f.ComputeClosure(key)
 		testColsAreStrictKey(t, f, closure, true)
+	} else if key, ok := f.LaxKey(); ok {
+		testColsAreLaxKey(t, f, key, true)
+		if !key.Empty() {
+			testColsAreLaxKey(t, f, opt.ColSet{}, false)
+		}
+		closure := f.ComputeClosure(key)
+		testColsAreLaxKey(t, f, closure, true)
 	} else {
 		testColsAreStrictKey(t, f, opt.ColSet{}, false)
 	}

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -797,9 +797,11 @@ sort
       │         │    │         │    │    │    ├── select
       │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
       │         │    │         │    │    │    │    ├── has-placeholder
+      │         │    │         │    │    │    │    ├── key: (18-20)
       │         │    │         │    │    │    │    ├── ordering: +18
       │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
       │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │         │    │         │    │    │    │    │    ├── lax-key: (18-20)
       │         │    │         │    │    │    │    │    └── ordering: +18
       │         │    │         │    │    │    │    └── filters
       │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
@@ -951,9 +953,11 @@ sort
       │         │    │    │    ├── select
       │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
       │         │    │    │    │    ├── has-placeholder
+      │         │    │    │    │    ├── key: (26-28)
       │         │    │    │    │    ├── ordering: +26
       │         │    │    │    │    ├── scan instance_type_projects@secondary
       │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) project_id:27(string) instance_type_projects.deleted:28(bool)
+      │         │    │    │    │    │    ├── lax-key: (26-28)
       │         │    │    │    │    │    └── ordering: +26
       │         │    │    │    │    └── filters
       │         │    │    │    │         ├── instance_type_projects.deleted = $3 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
@@ -1126,9 +1130,11 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │    │    │    │    ├── select
  │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
  │    │         │    │    │    │    │    │    ├── has-placeholder
+ │    │         │    │    │    │    │    │    ├── key: (18-20)
  │    │         │    │    │    │    │    │    ├── ordering: +18
  │    │         │    │    │    │    │    │    ├── scan instance_type_projects@secondary
  │    │         │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+ │    │         │    │    │    │    │    │    │    ├── lax-key: (18-20)
  │    │         │    │    │    │    │    │    │    └── ordering: +18
  │    │         │    │    │    │    │    │    └── filters
  │    │         │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
@@ -1304,9 +1310,11 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │    │    │    │    ├── select
  │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
  │    │         │    │    │    │    │    │    ├── has-placeholder
+ │    │         │    │    │    │    │    │    ├── key: (18-20)
  │    │         │    │    │    │    │    │    ├── ordering: +18
  │    │         │    │    │    │    │    │    ├── scan instance_type_projects@secondary
  │    │         │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+ │    │         │    │    │    │    │    │    │    ├── lax-key: (18-20)
  │    │         │    │    │    │    │    │    │    └── ordering: +18
  │    │         │    │    │    │    │    │    └── filters
  │    │         │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
@@ -2003,9 +2011,11 @@ sort
       │         │    │         │    │    │    ├── select
       │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
       │         │    │         │    │    │    │    ├── has-placeholder
+      │         │    │         │    │    │    │    ├── key: (18-20)
       │         │    │         │    │    │    │    ├── ordering: +18
       │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
       │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │         │    │         │    │    │    │    │    ├── lax-key: (18-20)
       │         │    │         │    │    │    │    │    └── ordering: +18
       │         │    │         │    │    │    │    └── filters
       │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
@@ -2180,9 +2190,11 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │    │    │    │    ├── select
  │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
  │    │         │    │    │    │    │    │    ├── has-placeholder
+ │    │         │    │    │    │    │    │    ├── key: (18-20)
  │    │         │    │    │    │    │    │    ├── ordering: +18
  │    │         │    │    │    │    │    │    ├── scan instance_type_projects@secondary
  │    │         │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+ │    │         │    │    │    │    │    │    │    ├── lax-key: (18-20)
  │    │         │    │    │    │    │    │    │    └── ordering: +18
  │    │         │    │    │    │    │    │    └── filters
  │    │         │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
@@ -2502,9 +2514,11 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │    ├── select
  │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
  │    │         │    │         │    │    │    │    ├── has-placeholder
+ │    │         │    │         │    │    │    │    ├── key: (18-20)
  │    │         │    │         │    │    │    │    ├── ordering: +18
  │    │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
  │    │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+ │    │         │    │         │    │    │    │    │    ├── lax-key: (18-20)
  │    │         │    │         │    │    │    │    │    └── ordering: +18
  │    │         │    │         │    │    │    │    └── filters
  │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
@@ -2892,9 +2906,11 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │         │    │    │    ├── select
  │    │         │    │         │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) instance_type_projects.project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
  │    │         │    │         │    │    │         │    │    │    │    ├── has-placeholder
+ │    │         │    │         │    │    │         │    │    │    │    ├── key: (18-20)
  │    │         │    │         │    │    │         │    │    │    │    ├── ordering: +18
  │    │         │    │         │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
  │    │         │    │         │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) instance_type_projects.project_id:19(string) instance_type_projects.deleted:20(bool)
+ │    │         │    │         │    │    │         │    │    │    │    │    ├── lax-key: (18-20)
  │    │         │    │         │    │    │         │    │    │    │    │    └── ordering: +18
  │    │         │    │         │    │    │         │    │    │    │    └── filters
  │    │         │    │         │    │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
@@ -2944,8 +2960,10 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │    ├── select
  │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) instance_type_projects.project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
  │    │         │    │         │    │    │    │    ├── has-placeholder
+ │    │         │    │         │    │    │    │    ├── key: (26-28)
  │    │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
- │    │         │    │         │    │    │    │    │    └── columns: instance_type_projects.instance_type_id:26(int!null) instance_type_projects.project_id:27(string) instance_type_projects.deleted:28(bool)
+ │    │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) instance_type_projects.project_id:27(string) instance_type_projects.deleted:28(bool)
+ │    │         │    │         │    │    │    │    │    └── lax-key: (26-28)
  │    │         │    │         │    │    │    │    └── filters
  │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $4 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
  │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $5 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
@@ -3138,9 +3156,11 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │    ├── select
  │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
  │    │         │    │         │    │    │    │    ├── has-placeholder
+ │    │         │    │         │    │    │    │    ├── key: (18-20)
  │    │         │    │         │    │    │    │    ├── ordering: +18
  │    │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
  │    │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+ │    │         │    │         │    │    │    │    │    ├── lax-key: (18-20)
  │    │         │    │         │    │    │    │    │    └── ordering: +18
  │    │         │    │         │    │    │    │    └── filters
  │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]

--- a/pkg/sql/opt/xform/testdata/ruleprops/orderings
+++ b/pkg/sql/opt/xform/testdata/ruleprops/orderings
@@ -24,6 +24,7 @@ SELECT * FROM abc
 ----
 scan abc
  ├── columns: a:1(int) b:2(int) c:3(int)
+ ├── lax-key: (1-3)
  ├── fd: (3)~~>(1,2)
  ├── prune: (1-3)
  └── interesting orderings: (+1,+2) (+3)
@@ -33,6 +34,7 @@ SELECT a, c FROM abc
 ----
 scan abc
  ├── columns: a:1(int) c:3(int)
+ ├── lax-key: (1,3)
  ├── fd: (3)~~>(1)
  ├── prune: (1,3)
  └── interesting orderings: (+1) (+3)
@@ -42,6 +44,7 @@ SELECT b, c FROM abc
 ----
 scan abc
  ├── columns: b:2(int) c:3(int)
+ ├── lax-key: (2,3)
  ├── fd: (3)~~>(2)
  ├── prune: (2,3)
  └── interesting orderings: (+3)
@@ -53,6 +56,7 @@ SELECT a, c FROM abc
 ----
 project
  ├── columns: a:1(int) c:3(int)
+ ├── lax-key: (1,3)
  ├── fd: (3)~~>(1)
  ├── prune: (1,3)
  ├── interesting orderings: (+1) (+3)
@@ -68,6 +72,7 @@ SELECT b, c FROM abc
 ----
 project
  ├── columns: b:2(int) c:3(int)
+ ├── lax-key: (2,3)
  ├── fd: (3)~~>(2)
  ├── prune: (2,3)
  ├── interesting orderings: (+3)
@@ -109,6 +114,7 @@ group-by
  ├── interesting orderings: (+3)
  ├── scan abc
  │    ├── columns: b:2(int) c:3(int)
+ │    ├── lax-key: (2,3)
  │    ├── fd: (3)~~>(2)
  │    ├── prune: (2,3)
  │    └── interesting orderings: (+3)
@@ -129,11 +135,13 @@ group-by
  ├── prune: (5)
  ├── sort
  │    ├── columns: a:1(int) b:2(int) c:3(int)
+ │    ├── lax-key: (1-3)
  │    ├── fd: (3)~~>(1,2)
  │    ├── ordering: +1 opt(2,3)
  │    ├── prune: (1-3)
  │    └── scan abc
  │         ├── columns: a:1(int) b:2(int) c:3(int)
+ │         ├── lax-key: (1-3)
  │         ├── fd: (3)~~>(1,2)
  │         └── prune: (1-3)
  └── aggregations
@@ -152,6 +160,7 @@ scalar-group-by
  ├── prune: (5-7)
  ├── scan abc
  │    ├── columns: a:1(int) b:2(int) c:3(int)
+ │    ├── lax-key: (1-3)
  │    ├── fd: (3)~~>(1,2)
  │    ├── prune: (1-3)
  │    └── interesting orderings: (+1,+2) (+3)
@@ -169,6 +178,7 @@ SELECT * FROM abc WHERE a = 1
 ----
 index-join abc
  ├── columns: a:1(int!null) b:2(int) c:3(int)
+ ├── lax-key: (2,3)
  ├── fd: ()-->(1), (3)~~>(2)
  ├── prune: (2,3)
  ├── interesting orderings: (+4) (+1,+2,+4)
@@ -187,6 +197,7 @@ SELECT * FROM abc ORDER BY a LIMIT 10
 index-join abc
  ├── columns: a:1(int) b:2(int) c:3(int)
  ├── cardinality: [0 - 10]
+ ├── lax-key: (1-3)
  ├── fd: (3)~~>(1,2)
  ├── ordering: +1
  ├── prune: (2,3)
@@ -207,17 +218,20 @@ limit
  ├── columns: a:1(int) b:2(int) c:3(int)
  ├── internal-ordering: +2
  ├── cardinality: [0 - 10]
+ ├── lax-key: (1-3)
  ├── fd: (3)~~>(1,2)
  ├── ordering: +2
  ├── prune: (1,3)
  ├── interesting orderings: (+2)
  ├── sort
  │    ├── columns: a:1(int) b:2(int) c:3(int)
+ │    ├── lax-key: (1-3)
  │    ├── fd: (3)~~>(1,2)
  │    ├── ordering: +2
  │    ├── prune: (1-3)
  │    └── scan abc
  │         ├── columns: a:1(int) b:2(int) c:3(int)
+ │         ├── lax-key: (1-3)
  │         ├── fd: (3)~~>(1,2)
  │         └── prune: (1-3)
  └── const: 10 [type=int]
@@ -228,17 +242,20 @@ SELECT * FROM abc ORDER BY a OFFSET 10
 offset
  ├── columns: a:1(int) b:2(int) c:3(int)
  ├── internal-ordering: +1
+ ├── lax-key: (1-3)
  ├── fd: (3)~~>(1,2)
  ├── ordering: +1
  ├── prune: (2,3)
  ├── interesting orderings: (+1)
  ├── sort
  │    ├── columns: a:1(int) b:2(int) c:3(int)
+ │    ├── lax-key: (1-3)
  │    ├── fd: (3)~~>(1,2)
  │    ├── ordering: +1
  │    ├── prune: (1-3)
  │    └── scan abc
  │         ├── columns: a:1(int) b:2(int) c:3(int)
+ │         ├── lax-key: (1-3)
  │         ├── fd: (3)~~>(1,2)
  │         └── prune: (1-3)
  └── const: 10 [type=int]
@@ -267,16 +284,19 @@ SELECT * FROM abc JOIN xyz ON a=x
 ----
 inner-join
  ├── columns: a:1(int!null) b:2(int) c:3(int) x:5(int!null) y:6(int) z:7(int)
+ ├── lax-key: (2,3,5-7)
  ├── fd: (3)~~>(1,2), (5,6)~~>(7), (1)==(5), (5)==(1)
  ├── prune: (2,3,6,7)
  ├── interesting orderings: (+1,+2) (+3) (+7) (+5,+6)
  ├── scan abc
  │    ├── columns: a:1(int) b:2(int) c:3(int)
+ │    ├── lax-key: (1-3)
  │    ├── fd: (3)~~>(1,2)
  │    ├── prune: (1-3)
  │    └── interesting orderings: (+1,+2) (+3)
  ├── scan xyz
  │    ├── columns: x:5(int) y:6(int) z:7(int)
+ │    ├── lax-key: (5-7)
  │    ├── fd: (5,6)~~>(7)
  │    ├── prune: (5-7)
  │    └── interesting orderings: (+7) (+5,+6)


### PR DESCRIPTION
#### opt: improve func deps to remember lax keys

Currently `FuncDepSet` remembers a strict key. When a `FuncDepSet` has
a strict key, adding lax keys only adds the lax FDs. If the key is
projected away, we no longer have the information of what lax keys we
had.

This can be seen even in simple cases like:
```
CREATE TABLE ab (a INT, b INT, UNIQUE INDEX(a,b))
SELECT a, b FROM ab WHERE a IS NOT NULL AND b IS NOT NULL
```
In this case, we won't know that `a,b` is a lax key at the level of
the scan (and thus a key at the level of the select).

This change fixes this by making `FuncDepSet` remember a lax key (when
it has no strict key). The `hasKey` bool is changed to an enum
indicating the kind of key. Most importantly, when we project and the
remaining columns no longer form a strict key, but they form a lax
key, this key will be retained.

Note that it's not important which lax key we remember - the important
thing is to know when there is *some* lax key; the FDs take care of
the rest.

Fixes #31628.

Release note (performance improvement): The optimizer can determine
more keys in certain cases involving unique indexes, potentially
resulting in better plans.

#### opt: make func dep test more readable

Replace `util.MakeFastIntSet` with a short wrapper `c()`.

Release note: None