### PR TITLE
storage: lazily load storage.Replica objects

### DIFF
--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -4965,7 +4965,7 @@ func makeDescriptor(storeList []roachpb.StoreID) roachpb.RangeDescriptor {
 func TestAllocatorComputeActionNoStorePool(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	a := MakeAllocator(nil /* storePool */, nil /* rpcContext */)
+	a := MakeAllocator(nil /* storePool */, nil /* nodeLatencyFn */)
 	action, priority := a.ComputeAction(context.Background(), &config.ZoneConfig{NumReplicas: proto.Int32(0)}, RangeInfo{})
 	if action != AllocatorNoop {
 		t.Errorf("expected AllocatorNoop, but got %v", action)

--- a/pkg/storage/client_metrics_test.go
+++ b/pkg/storage/client_metrics_test.go
@@ -274,17 +274,17 @@ func TestStoreMetrics(t *testing.T) {
 	replica := mtc.stores[0].LookupReplica(roachpb.RKey("z"))
 	mtc.replicateRange(replica.RangeID, 1, 2)
 
-	// Verify stats on store1 after replication.
-	verifyStats(t, mtc, 1)
+	// Verify stats after replication.
+	verifyStats(t, mtc, 0, 1, 2)
 
 	// Add some data to the "right" range.
 	dataKey := []byte("z")
 	if _, err := mtc.dbs[0].Inc(context.TODO(), dataKey, 5); err != nil {
 		t.Fatal(err)
 	}
-	mtc.waitForValues(roachpb.Key("z"), []int64{5, 5, 5})
+	mtc.waitForValues(roachpb.Key(dataKey), []int64{5, 5, 5})
 
-	// Verify all stats on stores after addition.
+	// Verify all stats after addition.
 	verifyStats(t, mtc, 0, 1, 2)
 
 	// Create a transaction statement that fails. Regression test for #4969.

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2809,11 +2809,12 @@ func TestStoreRangeMoveDecommissioning(t *testing.T) {
 	sc.TestingKnobs.DisableReplicaRebalancing = true
 	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
-	mtc.Start(t, 6)
+	zone := config.DefaultSystemZoneConfig()
+	mtc.Start(t, int(*zone.NumReplicas+1))
 	mtc.initGossipNetwork()
 
-	// Replicate the range to 2 more stores. Note that there are 4 stores in the
-	// cluster leaving an extra store available as a replication target once the
+	// Replicate the range to more stores. Note that there is an extra
+	// store in the cluster available as a replication target once the
 	// replica on the dead node is removed.
 	replica := mtc.stores[0].LookupReplica(roachpb.RKeyMin)
 	mtc.replicateRange(replica.RangeID, 1, 2)

--- a/pkg/storage/client_status_test.go
+++ b/pkg/storage/client_status_test.go
@@ -74,10 +74,20 @@ func TestComputeStatsForKeySpan(t *testing.T) {
 		expectedRanges int
 		expectedKeys   int64
 	}{
+		// All ranges.
 		{"a", "i", 4, 6},
+		// Subset of ranges including first.
 		{"a", "c", 1, 3},
-		{"b", "e", 2, 5},
+		// Middle subset of ranges.
+		{"c", "g", 2, 2},
+		// Subset of ranges including last.
 		{"e", "i", 2, 1},
+		// Offset into starting range (a-c), which should be included.
+		{"b", "e", 2, 5},
+		// Offset into ending range (g-i), which should be included.
+		{"e", "h", 2, 1},
+		// Offset into starting and ending ranges.
+		{"b", "h", 4, 6},
 	} {
 		start, end := tcase.startKey, tcase.endKey
 		result, err := mtc.stores[0].ComputeStatsForKeySpan(

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -162,9 +162,9 @@ func makeGCQueueScore(
 	repl.mu.Lock()
 	ms := *repl.mu.state.Stats
 	gcThreshold := *repl.mu.state.GCThreshold
+	desc := repl.mu.state.Desc
+	zone := repl.mu.zone
 	repl.mu.Unlock()
-
-	desc, zone := repl.DescAndZone()
 
 	// Use desc.RangeID for fuzzing the final score, so that different ranges
 	// have slightly different priorities and even symmetrical workloads don't

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -51,7 +51,7 @@ import (
 func (s *Store) AddReplica(repl *Replica) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := s.addReplicaInternalLocked(repl); err != nil {
+	if err := s.addReplicaShimInternalLocked(&ReplicaShim{replica: repl}); err != nil {
 		return err
 	}
 	s.metrics.ReplicaCount.Inc(1)
@@ -248,15 +248,21 @@ func (s *Store) ReservationCount() int {
 	return len(s.snapshotApplySem)
 }
 
-// AssertInvariants verifies that the store's bookkeping is self-consistent. It
+// AssertInvariants verifies that the store's bookkeeping is self-consistent. It
 // is only valid to call this method when there is no in-flight traffic to the
 // store (e.g., after the store is shut down).
 func (s *Store) AssertInvariants() {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	s.mu.replicas.Range(func(_ int64, p unsafe.Pointer) bool {
+	s.mu.replicaShims.Range(func(_ int64, p unsafe.Pointer) bool {
 		ctx := s.cfg.AmbientCtx.AnnotateCtx(context.Background())
-		repl := (*Replica)(p)
+		shim := (*ReplicaShim)(p)
+		shim.Lock()
+		repl := shim.replica
+		shim.Unlock()
+		if repl == nil {
+			return true // skip and keep iterating
+		}
 		// We would normally need to hold repl.raftMu. Otherwise we can observe an
 		// initialized replica that is not in s.replicasByKey, e.g., if we race with
 		// a goroutine that is currently initializing repl. The lock ordering makes
@@ -264,7 +270,7 @@ func (s *Store) AssertInvariants() {
 		// called only when there is no in-flight traffic to the store, at which
 		// point acquiring repl.raftMu is unnecessary.
 		if repl.IsInitialized() {
-			if ex := s.mu.replicasByKey.Get(repl); ex != repl {
+			if ex := s.mu.replicasByKey.Get(repl); ex.(*ReplicaShim).replica != repl {
 				log.Fatalf(ctx, "%v misplaced in replicasByKey; found %v instead", repl, ex)
 			}
 		} else if _, ok := s.mu.uninitReplicas[repl.RangeID]; !ok {
@@ -605,13 +611,13 @@ func WatchForDisappearingReplicas(t testing.TB, store *Store) {
 		default:
 		}
 
-		store.mu.replicas.Range(func(k int64, v unsafe.Pointer) bool {
+		store.mu.replicaShims.Range(func(k int64, v unsafe.Pointer) bool {
 			m[k] = struct{}{}
 			return true
 		})
 
 		for k := range m {
-			if _, ok := store.mu.replicas.Load(k); !ok {
+			if _, ok := store.mu.replicaShims.Load(k); !ok {
 				t.Fatalf("r%d disappeared from Store.mu.replicas map", k)
 			}
 		}

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -65,6 +65,12 @@ var (
 		Measurement: "Replicas",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaResidentCount = metric.Metadata{
+		Name:        "replicas.resident",
+		Help:        "Number of resident replicas",
+		Measurement: "Replicas",
+		Unit:        metric.Unit_COUNT,
+	}
 
 	// Range metrics.
 	metaRangeCount = metric.Metadata{
@@ -931,6 +937,7 @@ type StoreMetrics struct {
 	RaftLeaderNotLeaseHolderCount *metric.Gauge
 	LeaseHolderCount              *metric.Gauge
 	QuiescentCount                *metric.Gauge
+	ResidentCount                 *metric.Gauge
 
 	// Range metrics.
 	RangeCount                *metric.Gauge
@@ -1131,6 +1138,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RaftLeaderNotLeaseHolderCount: metric.NewGauge(metaRaftLeaderNotLeaseHolderCount),
 		LeaseHolderCount:              metric.NewGauge(metaLeaseHolderCount),
 		QuiescentCount:                metric.NewGauge(metaQuiescentCount),
+		ResidentCount:                 metric.NewGauge(metaResidentCount),
 
 		// Range metrics.
 		RangeCount:                metric.NewGauge(metaRangeCount),

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -350,6 +350,9 @@ type Replica struct {
 		// Is the range quiescent? Quiescent ranges are not Tick()'d and unquiesce
 		// whenever a Raft operation is performed.
 		quiescent bool
+		// Behind indicates the range is quiescent but still has
+		// replica(s) not fully caught up.
+		quiescentButBehind bool
 		// mergeComplete is non-nil if a merge is in-progress, in which case any
 		// requests should be held until the completion of the merge is signaled by
 		// the closing of the channel.
@@ -3929,6 +3932,7 @@ func (r *Replica) unquiesceWithOptionsLocked(campaignOnWake bool) {
 			log.Infof(ctx, "unquiescing %d", r.RangeID)
 		}
 		r.mu.quiescent = false
+		r.mu.quiescentButBehind = false // may not be true, but behind is only valid when quiescent
 		r.store.unquiescedReplicas.Lock()
 		r.store.unquiescedReplicas.m[r.RangeID] = struct{}{}
 		r.store.unquiescedReplicas.Unlock()
@@ -4755,6 +4759,7 @@ func (r *Replica) quiesceAndNotifyLocked(ctx context.Context, status *raft.Statu
 		commit := status.Commit
 		quiesce := true
 		if prog.Match < status.Commit {
+			r.mu.quiescentButBehind = true
 			commit = prog.Match
 			quiesce = false
 		}
@@ -6974,6 +6979,29 @@ func (r *Replica) startKey() roachpb.RKey {
 // Less implements the btree.Item interface.
 func (r *Replica) Less(i btree.Item) bool {
 	return r.startKey().Less(i.(rangeKeyItem).startKey())
+}
+
+// ReplicaCapacity contains details on the replica storage.
+type ReplicaCapacity struct {
+	Leaseholder bool
+	Stats       enginepb.MVCCStats
+	QPS, WPS    float64
+}
+
+// Capacity returns the current capacity info for the replica.
+func (r *Replica) Capacity(now hlc.Timestamp) ReplicaCapacity {
+	var cap ReplicaCapacity
+	if r.OwnsValidLease(now) {
+		cap.Leaseholder = true
+	}
+	cap.Stats = r.GetMVCCStats()
+	if qps, dur := r.leaseholderStats.avgQPS(); dur >= MinStatsDuration {
+		cap.QPS = qps
+	}
+	if wps, dur := r.writeStats.avgQPS(); dur >= MinStatsDuration {
+		cap.WPS = wps
+	}
+	return cap
 }
 
 // ReplicaMetrics contains details on the current status of the replica.

--- a/pkg/storage/replica_rankings.go
+++ b/pkg/storage/replica_rankings.go
@@ -17,6 +17,7 @@ package storage
 import (
 	"container/heap"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
@@ -26,8 +27,8 @@ const (
 )
 
 type replicaWithStats struct {
-	repl *Replica
-	qps  float64
+	rangeID roachpb.RangeID
+	qps     float64
 	// TODO(a-robinson): Include writes-per-second and logicalBytes of storage?
 }
 

--- a/pkg/storage/replica_rankings_test.go
+++ b/pkg/storage/replica_rankings_test.go
@@ -51,8 +51,8 @@ func TestReplicaRankings(t *testing.T) {
 
 		for i, replQPS := range tc.replicasByQPS {
 			acc.addReplica(replicaWithStats{
-				repl: &Replica{RangeID: roachpb.RangeID(i)},
-				qps:  replQPS,
+				rangeID: roachpb.RangeID(i),
+				qps:     replQPS,
 			})
 		}
 		rr.update(acc)

--- a/pkg/storage/replica_shim.go
+++ b/pkg/storage/replica_shim.go
@@ -1,0 +1,251 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/google/btree"
+)
+
+type nonResidentReplica struct {
+	desc               *roachpb.RangeDescriptor
+	stats              enginepb.MVCCStats
+	zone               *config.ZoneConfig
+	leader             bool
+	lease              roachpb.Lease
+	quiescentButBehind bool
+}
+
+// ReplicaShim holds either a RangeDescriptor or an initialized
+// Replica object, depending on whether the replica is non-resident or
+// resident in memory, respectively.
+type ReplicaShim struct {
+	syncutil.Mutex
+	replica *Replica // non-nil if resident
+
+	// nonResidentReplica not valid if replica is non-nil.
+	nonResidentReplica
+}
+
+var _ KeyRange = &ReplicaShim{}
+var _ btree.Item = &ReplicaShim{}
+
+// RangeID returns the shim range ID.
+func (rs *ReplicaShim) RangeID() roachpb.RangeID {
+	rs.Lock()
+	defer rs.Unlock()
+	if rs.replica != nil {
+		return rs.replica.RangeID
+	}
+	return rs.desc.RangeID
+}
+
+// Desc returns the replica's descriptor. Note that this method
+// will acquire the replica's mutex if resident.
+func (rs *ReplicaShim) Desc() *roachpb.RangeDescriptor {
+	rs.Lock()
+	defer rs.Unlock()
+	if rs.replica != nil {
+		return rs.replica.Desc()
+	}
+	return rs.desc
+}
+
+// GetMVCCStats returns the replica's or shim's MVCC stats.
+func (rs *ReplicaShim) GetMVCCStats() enginepb.MVCCStats {
+	rs.Lock()
+	defer rs.Unlock()
+	if rs.replica != nil {
+		return rs.replica.GetMVCCStats()
+	}
+	return rs.stats
+}
+
+// SetZoneConfig sets the replica's zone config.
+func (rs *ReplicaShim) SetZoneConfig(zone *config.ZoneConfig) {
+	rs.Lock()
+	defer rs.Unlock()
+	if rs.replica != nil {
+		rs.replica.SetZoneConfig(zone)
+	} else {
+		rs.zone = zone
+	}
+}
+
+// ContainsKey returns whether this range contains the specified key.
+func (rs *ReplicaShim) ContainsKey(key roachpb.Key) bool {
+	rs.Lock()
+	defer rs.Unlock()
+	if rs.replica != nil {
+		return rs.replica.ContainsKey(key)
+	}
+	return storagebase.ContainsKey(*rs.desc, key)
+}
+
+// QuiescentButBehind returns whether the range was quiesced while one
+// or more replicas on non-live nodes were behind.
+func (rs *ReplicaShim) QuiescentButBehind() bool {
+	rs.Lock()
+	defer rs.Unlock()
+	if repl := rs.replica; repl != nil {
+		repl.mu.RLock()
+		defer repl.mu.RUnlock()
+		return repl.mu.quiescentButBehind
+	}
+	return rs.quiescentButBehind
+}
+
+// GetReplicaIfResident returns the replica if resident, or else nil.
+func (rs *ReplicaShim) GetReplicaIfResident() *Replica {
+	rs.Lock()
+	defer rs.Unlock()
+	return rs.replica
+}
+
+// GetReplica returns the replica if resident, or else loads the
+// replica to make it resident and potentially returns an error on
+// failure to initialize.
+func (rs *ReplicaShim) GetReplica(s *Store) (*Replica, error) {
+	rs.Lock()
+	defer rs.Unlock()
+	if rs.replica != nil {
+		return rs.replica, nil
+	}
+	replica, err := NewReplica(rs.desc, s, 0)
+	if err != nil {
+		return nil, err
+	}
+	replica.SetZoneConfig(rs.zone)
+	rs.replica = replica
+	rs.nonResidentReplica = nonResidentReplica{}
+	return rs.replica, nil
+}
+
+/*
+// MaybeMakeNonResident frees the replica and reduces the shim to
+// holding just the range descriptor, if possible. Returns whether the
+// shim was dehydrated.
+func (rs *ReplicaShim) MaybeMakeNonResident() bool {
+	rs.Lock()
+	defer rs.Unlock()
+	repl := rs.replica
+	if repl == nil {
+		return false
+	}
+	repl.mu.RLock()
+	defer repl.mu.RLock()
+	// Only make non-resident if the replica is in a proper state.
+	if !repl.mu.quiescent ||
+		repl.mu.draining ||
+		repl.mu.destroyStatus.reason != destroyReasonAlive ||
+		repl.mu.state.Lease.Type() != roachpb.LeaseEpoch ||
+		repl.mu.mergeComplete != nil ||
+		!repl.isInitializedRLocked() {
+		return false
+	}
+	rs.replica = nil
+	rs.desc = repl.mu.state.Desc
+	rs.stats = *repl.mu.state.Stats
+	rs.zone = repl.mu.zone
+	rs.leader = isRaftLeader(repl.raftStatusRLocked())
+	rs.lease = *repl.mu.state.Lease
+	rs.quiescentButBehind = repl.mu.quiescentButBehind
+	return true
+}
+*/
+
+// Capacity returns the replica's latest capacity info if resident.
+// Otherwise, a ReplicaCapacity struct is synthesized from information
+// the shim has about the non-resident replica.
+func (rs *ReplicaShim) Capacity(
+	storeID roachpb.StoreID, now hlc.Timestamp, livenessMap IsLiveMap,
+) ReplicaCapacity {
+	rs.Lock()
+	defer rs.Unlock()
+	if rep := rs.replica; rep != nil {
+		return rep.Capacity(now)
+	}
+	_, holder := rs.leaseInfoLocked(storeID, livenessMap)
+	return ReplicaCapacity{
+		Leaseholder: holder,
+		Stats:       rs.stats,
+	}
+}
+
+// Metrics returns the replica and its latest metrics if
+// resident. Otherwise, returns nil and a ReplicaMetrics object
+// synthesized from information the shim has about the non-resident
+// replica.
+func (rs *ReplicaShim) Metrics(
+	ctx context.Context,
+	storeID roachpb.StoreID,
+	timestamp hlc.Timestamp,
+	livenessMap IsLiveMap,
+	availableNodes int,
+) (*Replica, ReplicaMetrics) {
+	rs.Lock()
+	defer rs.Unlock()
+	if rep := rs.replica; rep != nil {
+		return rep, rep.Metrics(ctx, timestamp, livenessMap, availableNodes)
+	}
+	valid, holder := rs.leaseInfoLocked(storeID, livenessMap)
+	rangeCounter, unavailable, underreplicated :=
+		calcRangeCounter(storeID, rs.desc, livenessMap, *rs.zone.NumReplicas, availableNodes)
+	return nil, ReplicaMetrics{
+		Leader:          rs.leader,
+		LeaseValid:      valid,
+		Leaseholder:     holder,
+		LeaseType:       roachpb.LeaseEpoch,
+		Quiescent:       true, // non-resident replicas are always quiescent
+		RangeCounter:    rangeCounter,
+		Unavailable:     unavailable,
+		Underreplicated: underreplicated,
+	}
+}
+
+func (rs *ReplicaShim) leaseInfoLocked(
+	storeID roachpb.StoreID, livenessMap IsLiveMap,
+) (valid, holder bool) {
+	if rs.lease.Type() == roachpb.LeaseEpoch && livenessMap != nil {
+		entry := livenessMap[rs.lease.Replica.NodeID]
+		valid = entry.IsLive && entry.Epoch == rs.lease.Epoch
+		holder = rs.lease.Replica.StoreID == storeID
+	}
+	return
+}
+
+// startKey implements the rangeKeyItem interface.
+func (rs *ReplicaShim) startKey() roachpb.RKey {
+	return rs.Desc().StartKey
+}
+
+// Less implements the btree.Item interface.
+func (rs *ReplicaShim) Less(i btree.Item) bool {
+	return rs.startKey().Less(i.(rangeKeyItem).startKey())
+}
+
+func (rs *ReplicaShim) String() string {
+	desc := rs.Desc()
+	return fmt.Sprintf("range=%d [%s-%s) (shim)",
+		desc.RangeID, desc.StartKey, desc.EndKey)
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -263,19 +263,21 @@ func (e *NotBootstrappedError) Error() string {
 // to visit replicas in increasing RangeID order.
 type storeReplicaVisitor struct {
 	store   *Store
-	repls   []*Replica // Replicas to be visited
-	ordered bool       // Option to visit replicas in sorted order
-	visited int        // Number of visited ranges, -1 before first call to Visit()
+	shims   []*ReplicaShim // Replicas to be visited
+	ordered bool           // Option to visit replicas in sorted order
+	visited int            // Number of visited ranges, -1 before first call to Visit()
 }
 
 // Len implements sort.Interface.
-func (rs storeReplicaVisitor) Len() int { return len(rs.repls) }
+func (rs storeReplicaVisitor) Len() int { return len(rs.shims) }
 
 // Less implements sort.Interface.
-func (rs storeReplicaVisitor) Less(i, j int) bool { return rs.repls[i].RangeID < rs.repls[j].RangeID }
+func (rs storeReplicaVisitor) Less(i, j int) bool {
+	return rs.shims[i].RangeID() < rs.shims[j].RangeID()
+}
 
 // Swap implements sort.Interface.
-func (rs storeReplicaVisitor) Swap(i, j int) { rs.repls[i], rs.repls[j] = rs.repls[j], rs.repls[i] }
+func (rs storeReplicaVisitor) Swap(i, j int) { rs.shims[i], rs.shims[j] = rs.shims[j], rs.shims[i] }
 
 // newStoreReplicaVisitor constructs a storeReplicaVisitor.
 func newStoreReplicaVisitor(store *Store) *storeReplicaVisitor {
@@ -291,14 +293,27 @@ func (rs *storeReplicaVisitor) InOrder() *storeReplicaVisitor {
 	return rs
 }
 
-// Visit calls the visitor with each Replica until false is returned.
+// Visit calls the visitor with each Replica until false is
+// returned. ALL replicas are visited, including ones which are
+// currently non-resident.
 func (rs *storeReplicaVisitor) Visit(visitor func(*Replica) bool) {
+	rs.visitImpl(false /* onlyResident */, visitor)
+}
+
+// Visit calls the visitor with each Replica until false is
+// returned. Only those replicas which are currently resident
+// will be visited.
+func (rs *storeReplicaVisitor) VisitResident(visitor func(*Replica) bool) {
+	rs.visitImpl(true /* onlyResident */, visitor)
+}
+
+func (rs *storeReplicaVisitor) visitImpl(onlyResident bool, visitor func(*Replica) bool) {
 	// Copy the range IDs to a slice so that we iterate over some (possibly
 	// stale) view of all Replicas without holding the Store lock. In particular,
 	// no locks are acquired during the copy process.
-	rs.repls = nil
-	rs.store.mu.replicas.Range(func(k int64, v unsafe.Pointer) bool {
-		rs.repls = append(rs.repls, (*Replica)(v))
+	rs.shims = nil
+	rs.store.mu.replicaShims.Range(func(k int64, v unsafe.Pointer) bool {
+		rs.shims = append(rs.shims, (*ReplicaShim)(v))
 		return true
 	})
 
@@ -318,11 +333,31 @@ func (rs *storeReplicaVisitor) Visit(visitor func(*Replica) bool) {
 	}
 
 	rs.visited = 0
-	for _, repl := range rs.repls {
+	for _, shim := range rs.shims {
 		// TODO(tschottdorf): let the visitor figure out if something's been
 		// destroyed once we return errors from mutexes (#9190). After all, it
 		// can still happen with this code.
 		rs.visited++
+
+		var repl *Replica
+		if onlyResident {
+			shim.Lock()
+			repl = shim.replica
+			shim.Unlock()
+			if repl == nil {
+				continue
+			}
+		} else {
+			var err error
+			repl, err = rs.store.GetReplica(shim.RangeID())
+			if err != nil {
+				if _, ok := err.(*roachpb.RangeNotFoundError); !ok {
+					log.Errorf(context.TODO(), "%s: unable to load replica %s: %s", rs.store, shim, err)
+				}
+				continue
+			}
+		}
+
 		repl.mu.RLock()
 		destroyed := repl.mu.destroyStatus
 		initialized := repl.isInitializedRLocked()
@@ -339,10 +374,10 @@ func (rs *storeReplicaVisitor) Visit(visitor func(*Replica) bool) {
 //
 // TODO(tschottdorf): this method has highly doubtful semantics.
 func (rs *storeReplicaVisitor) EstimatedCount() int {
-	if rs.visited <= 0 {
+	if rs.visited < 0 {
 		return rs.store.ReplicaCount()
 	}
-	return len(rs.repls) - rs.visited
+	return len(rs.shims) - rs.visited
 }
 
 type raftRequestInfo struct {
@@ -517,10 +552,10 @@ type Store struct {
 
 	mu struct {
 		syncutil.RWMutex
-		// Map of replicas by Range ID (map[roachpb.RangeID]*Replica). This
-		// includes `uninitReplicas`. May be read without holding Store.mu.
-		replicas syncutil.IntMap
-		// A btree key containing objects of type *Replica or *ReplicaPlaceholder.
+		// Map of replica shims by Range ID (map[roachpb.RangeID]*ReplicaShim).
+		// This includes `uninitReplicas`. May be read without holding Store.mu.
+		replicaShims syncutil.IntMap
+		// A btree key containing objects of type *ReplicaShim or *ReplicaPlaceholder.
 		// Both types have an associated key range; the btree is keyed on their
 		// start keys.
 		replicasByKey  *btree.BTree
@@ -546,7 +581,7 @@ type Store struct {
 	// queues might more naturally belong in Replica, but are kept separate to
 	// avoid reworking the locking in getOrCreateReplica which requires
 	// Replica.raftMu to be held while a replica is being inserted into
-	// Store.mu.replicas.
+	// Store.mu.replicaShims.
 	replicaQueues syncutil.IntMap // map[roachpb.RangeID]*raftRequestQueue
 
 	scheduler *raftScheduler
@@ -922,7 +957,7 @@ const raftLeadershipTransferWait = 5 * time.Second
 func (s *Store) SetDraining(drain bool) {
 	s.draining.Store(drain)
 	if !drain {
-		newStoreReplicaVisitor(s).Visit(func(r *Replica) bool {
+		newStoreReplicaVisitor(s).VisitResident(func(r *Replica) bool {
 			r.mu.Lock()
 			r.mu.draining = false
 			r.mu.Unlock()
@@ -1151,7 +1186,7 @@ func IterateRangeDescriptors(
 	ctx context.Context, eng engine.Reader, fn func(desc roachpb.RangeDescriptor) (bool, error),
 ) error {
 	log.Event(ctx, "beginning range descriptor iteration")
-	// Iterator over all range-local key-based data.
+	// Iterator over range-local descriptor data.
 	start := keys.RangeDescriptorKey(roachpb.RKeyMin)
 	end := keys.RangeDescriptorKey(roachpb.RKeyMax)
 
@@ -1177,6 +1212,10 @@ func IterateRangeDescriptors(
 		return fn(desc)
 	}
 
+	// The iteration ignores uncommitted versions (consistent=false).
+	// Uncommitted intents which have been abandoned due to a split
+	// crashing halfway will simply be resolved on the next split
+	// attempt. They can otherwise be ignored.
 	_, err := engine.MVCCIterate(ctx, eng, start, end, hlc.MaxTimestamp,
 		engine.MVCCScanOptions{Inconsistent: true}, kvToDesc)
 	log.Eventf(ctx, "iterated over %d keys to find %d range descriptors (by suffix: %v)",
@@ -1246,62 +1285,8 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	now := s.cfg.Clock.Now()
 	s.startedAt = now.WallTime
 
-	// Iterate over all range descriptors, ignoring uncommitted versions
-	// (consistent=false). Uncommitted intents which have been abandoned
-	// due to a split crashing halfway will simply be resolved on the
-	// next split attempt. They can otherwise be ignored.
-
-	// TODO(peter): While we have to iterate to find the replica descriptors
-	// serially, we can perform the migrations and replica creation
-	// concurrently. Note that while we can perform this initialization
-	// concurrently, all of the initialization must be performed before we start
-	// listening for Raft messages and starting the process Raft loop.
-	err = IterateRangeDescriptors(ctx, s.engine,
-		func(desc roachpb.RangeDescriptor) (bool, error) {
-			if !desc.IsInitialized() {
-				return false, errors.Errorf("found uninitialized RangeDescriptor: %+v", desc)
-			}
-
-			rep, err := NewReplica(&desc, s, 0)
-			if err != nil {
-				return false, err
-			}
-
-			// We can't lock s.mu across NewReplica due to the lock ordering
-			// constraint (*Replica).raftMu < (*Store).mu. See the comment on
-			// (Store).mu.
-			s.mu.Lock()
-			err = s.addReplicaInternalLocked(rep)
-			s.mu.Unlock()
-			if err != nil {
-				return false, err
-			}
-
-			// Add this range and its stats to our counter.
-			s.metrics.ReplicaCount.Inc(1)
-			s.metrics.addMVCCStats(rep.GetMVCCStats())
-
-			if _, ok := desc.GetReplicaDescriptor(s.StoreID()); !ok {
-				// We are no longer a member of the range, but we didn't GC the replica
-				// before shutting down. Add the replica to the GC queue.
-				if added, err := s.replicaGCQueue.Add(rep, replicaGCPriorityRemoved); err != nil {
-					log.Errorf(ctx, "%s: unable to add replica to GC queue: %s", rep, err)
-				} else if added {
-					log.Infof(ctx, "%s: added to replica GC queue", rep)
-				}
-			}
-
-			// Note that we do not create raft groups at this time; they will be created
-			// on-demand the first time they are needed. This helps reduce the amount of
-			// election-related traffic in a cold start.
-			// Raft initialization occurs when we propose a command on this range or
-			// receive a raft message addressed to it.
-			// TODO(bdarnell): Also initialize raft groups when read leases are needed.
-			// TODO(bdarnell): Scan all ranges at startup for unapplied log entries
-			// and initialize those groups.
-			return false, nil
-		})
-	if err != nil {
+	// Initialize shims for each replica which the store contains.
+	if err = s.initializeReplicaShims(ctx); err != nil {
 		return err
 	}
 
@@ -1362,7 +1347,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 
 	if s.replicateQueue != nil {
 		s.storeRebalancer = NewStoreRebalancer(
-			s.cfg.AmbientCtx, s.cfg.Settings, s.replicateQueue, s.replRankings)
+			s.cfg.AmbientCtx, s.cfg.Settings, s.replicateQueue, s.replRankings, s.GetReplica)
 		s.storeRebalancer.Start(ctx, s.stopper)
 	}
 
@@ -1374,6 +1359,124 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	// Set the started flag (for unittests).
 	atomic.StoreInt32(&s.started, 1)
 
+	return nil
+}
+
+// initializeReplicaShims iterates in parallel over both replica
+// MVCCStats (via range applied state or legacy stats as appropriate)
+// and local range descriptors. The two iterations are joined to yield
+// replica shims for each range which this store contains.
+func (s *Store) initializeReplicaShims(ctx context.Context) error {
+	iterBegin := timeutil.Now()
+
+	// First, collect all replica applied states in a single
+	// iteration. We'll match these to the range descriptors when
+	// creating replica shims.
+	statsDone := make(chan error, 1)
+	statsMap := map[roachpb.RangeID]enginepb.MVCCStats{}
+	go func() {
+		var as enginepb.RangeAppliedState
+		var ms enginepb.MVCCStats
+		start := keys.LocalRangeIDPrefix.AsRawKey()
+		end := keys.LocalRangeIDPrefix.PrefixEnd().AsRawKey()
+		_, err := engine.MVCCIterate(ctx, s.engine, start, end, hlc.MaxTimestamp,
+			engine.MVCCScanOptions{}, func(kv roachpb.KeyValue) (bool, error) {
+				id, _, suffix, _, err := keys.DecodeRangeIDKey(kv.Key)
+				if err != nil {
+					return false, err
+				}
+				// Handle both the range applied state and any legacy stats. If
+				// both exist, use the range applied state.
+				if suffix.Equal(keys.LocalRangeAppliedStateSuffix) {
+					if err := kv.Value.GetProto(&as); err != nil {
+						return false, err
+					}
+					statsMap[id] = as.RangeStats.ToStats()
+				} else if suffix.Equal(keys.LocalRangeStatsLegacySuffix) {
+					// Never replace the range applied state with a legacy stats value.
+					if _, ok := statsMap[id]; !ok {
+						if err := kv.Value.GetProto(&ms); err != nil {
+							return false, err
+						}
+						statsMap[id] = ms
+					}
+				}
+				return false, nil
+			})
+		statsDone <- err
+	}()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Iterate over range descriptors and create replica shims for each.
+	err := IterateRangeDescriptors(ctx, s.engine,
+		func(desc roachpb.RangeDescriptor) (bool, error) {
+			if !desc.IsInitialized() {
+				return false, errors.Errorf("found uninitialized RangeDescriptor: %+v", desc)
+			}
+
+			shim := &ReplicaShim{
+				nonResidentReplica: nonResidentReplica{
+					desc: &desc,
+					zone: config.DefaultZoneConfigRef(),
+				},
+			}
+			if err := s.addReplicaShimInternalLocked(shim); err != nil {
+				return false, err
+			}
+
+			// Add this range and its stats to our metrics.
+			s.metrics.ReplicaCount.Inc(1)
+
+			// Note that we do not create raft groups at this time; they will be created
+			// on-demand the first time they are needed. This helps reduce the amount of
+			// election-related traffic in a cold start.
+			// Raft initialization occurs when we propose a command on this range or
+			// receive a raft message addressed to it.
+			// TODO(bdarnell): Also initialize raft groups when read leases are needed.
+			// TODO(bdarnell): Scan all ranges at startup for unapplied log entries
+			// and initialize those groups.
+			return false, nil
+		})
+	if err != nil {
+		return err
+	}
+
+	// Wait for the MVCC stats reading to complete.
+	if err = <-statsDone; err != nil {
+		return err
+	}
+	// Now, associate stats with each replica shim. Additionally,
+	// schedule replicas for GC if not present in the range descriptor.
+	s.mu.replicaShims.Range(func(_ int64, v unsafe.Pointer) bool {
+		shim := (*ReplicaShim)(v)
+		shim.Lock()
+		desc := shim.desc
+		stats, ok := statsMap[desc.RangeID]
+		if !ok {
+			log.Fatalf(ctx, "unable to determine MVCC stats for range %s", desc)
+		}
+		shim.stats = stats
+		shim.Unlock()
+		s.metrics.addMVCCStats(stats)
+
+		if _, ok := desc.GetReplicaDescriptor(s.StoreID()); !ok {
+			// We are no longer a member of the range, but we didn't GC the replica
+			// before shutting down. Add the replica to the GC queue.
+			if rep, err := s.GetReplica(desc.RangeID); err != nil {
+				log.Errorf(ctx, "unable to load GC'able replica for range %d: %s", desc.RangeID, err)
+			} else if added, err := s.replicaGCQueue.Add(rep, replicaGCPriorityRemoved); err != nil {
+				log.Errorf(ctx, "%s: unable to add replica to GC queue: %s", rep, err)
+			} else if added {
+				log.Infof(ctx, "%s: added to replica GC queue", rep)
+			}
+		}
+
+		return true // more
+	})
+
+	log.Infof(ctx, "initialized %d replicas in %s", s.metrics.ReplicaCount.Value(), timeutil.Since(iterBegin))
 	return nil
 }
 
@@ -1608,20 +1711,29 @@ func (s *Store) systemGossipUpdate(sysCfg *config.SystemConfig) {
 		log.Event(ctx, "computed initial metrics")
 	})
 
-	// For every range, update its zone config and check if it needs to
-	// be split or merged.
-	newStoreReplicaVisitor(s).Visit(func(repl *Replica) bool {
-		key := repl.Desc().StartKey
-		zone, err := sysCfg.GetZoneConfigForKey(key)
+	// For every range, update its zone config. If the zone config has
+	// changed, potentially add the replica to the background processing
+	// queues (merge, split, replicate, etc.).
+	s.mu.replicaShims.Range(func(_ int64, v unsafe.Pointer) bool {
+		shim := (*ReplicaShim)(v)
+		desc := shim.Desc()
+		zone, err := sysCfg.GetZoneConfigForKey(desc.StartKey)
 		if err != nil {
 			if log.V(1) {
-				log.Infof(context.TODO(), "failed to get zone config for key %s", key)
+				log.Infof(context.TODO(), "failed to get zone config for key %s", desc.StartKey)
 			}
 			zone = config.DefaultZoneConfigRef()
 		}
-		repl.SetZoneConfig(zone)
-		s.mergeQueue.MaybeAdd(repl, s.cfg.Clock.Now())
-		s.splitQueue.MaybeAdd(repl, s.cfg.Clock.Now())
+		shim.SetZoneConfig(zone)
+		// To avoid making every replica resident every time the system
+		// config is gossiped, check the shim's descriptor against zones
+		// to determine if a split is required before making the replica
+		// resident to add it to the split queue.
+		if sysCfg.NeedsSplit(desc.StartKey, desc.EndKey) {
+			if repl := s.mustGetReplica(context.TODO(), shim.RangeID()); repl != nil {
+				s.splitQueue.MaybeAdd(repl, s.cfg.Clock.Now())
+			}
+		}
 		return true // more
 	})
 }
@@ -1923,12 +2035,31 @@ func checkEngineEmpty(ctx context.Context, eng engine.Engine) error {
 	return nil
 }
 
-// GetReplica fetches a replica by Range ID. Returns an error if no replica is found.
+// GetReplica fetches a replica by Range ID. If the replica is currently
+// non-resident, it is initialized. Returns an error if no replica is found.
 func (s *Store) GetReplica(rangeID roachpb.RangeID) (*Replica, error) {
-	if value, ok := s.mu.replicas.Load(int64(rangeID)); ok {
-		return (*Replica)(value), nil
+	if value, ok := s.mu.replicaShims.Load(int64(rangeID)); ok {
+		shim := (*ReplicaShim)(value)
+		return shim.GetReplica(s)
 	}
 	return nil, roachpb.NewRangeNotFoundError(rangeID, s.StoreID())
+}
+
+// mustGetReplica fetches a replica by Range ID. Any error
+// initializing the replica will result in a fatal error. Returns the
+// replica, which may be nil if the specified rangeID wasn't found on
+// this store.
+func (s *Store) mustGetReplica(ctx context.Context, rangeID roachpb.RangeID) *Replica {
+	r, err := s.GetReplica(rangeID)
+	if err != nil {
+		switch err.(type) {
+		case *roachpb.RangeNotFoundError:
+			return nil
+		default:
+			log.Fatalf(ctx, "failed to fetch replica for range %d: %s", rangeID, err)
+		}
+	}
+	return r
 }
 
 // LookupReplica looks up the replica that contains the specified key. It
@@ -1936,17 +2067,17 @@ func (s *Store) GetReplica(rangeID roachpb.RangeID) (*Replica, error) {
 func (s *Store) LookupReplica(key roachpb.RKey) *Replica {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	var repl *Replica
+	var shim *ReplicaShim
 	s.mu.replicasByKey.DescendLessOrEqual(rangeBTreeKey(key), func(item btree.Item) bool {
-		repl, _ = item.(*Replica)
+		shim, _ = item.(*ReplicaShim)
 		// Stop iterating immediately. The first item we see is the only one that
 		// can possibly contain key.
 		return false
 	})
-	if repl == nil || !repl.Desc().ContainsKey(key) {
+	if shim == nil || !shim.ContainsKey(key.AsRawKey()) {
 		return nil
 	}
-	return repl
+	return s.mustGetReplica(context.TODO(), shim.RangeID())
 }
 
 // lookupPrecedingReplica finds the replica in this store that immediately
@@ -1961,11 +2092,12 @@ func (s *Store) lookupPrecedingReplica(key roachpb.RKey) *Replica {
 	defer s.mu.RUnlock()
 	var repl *Replica
 	s.mu.replicasByKey.DescendLessOrEqual(rangeBTreeKey(key), func(item btree.Item) bool {
-		if r, ok := item.(*Replica); ok && !r.ContainsKey(key.AsRawKey()) {
-			repl = r
-			return false // stop iterating
+		if shim, ok := item.(*ReplicaShim); ok && !shim.ContainsKey(key.AsRawKey()) {
+			if repl = s.mustGetReplica(context.TODO(), shim.RangeID()); repl != nil {
+				return false // stop iterating
+			}
 		}
-		return true // keep iterating
+		return true // keep iterating if we haven't found a replica
 	})
 	return repl
 }
@@ -1991,8 +2123,8 @@ func (s *Store) getOverlappingKeyRangeLocked(rngDesc *roachpb.RangeDescriptor) K
 // RaftStatus returns the current raft status of the local replica of
 // the given range.
 func (s *Store) RaftStatus(rangeID roachpb.RangeID) *raft.Status {
-	if value, ok := s.mu.replicas.Load(int64(rangeID)); ok {
-		return (*Replica)(value).RaftStatus()
+	if repl, err := s.GetReplica(rangeID); err == nil {
+		return repl.RaftStatus()
 	}
 	return nil
 }
@@ -2296,13 +2428,26 @@ func (s *Store) SplitRange(
 	leftRepl.leaseholderStats.resetRequestCounts()
 	leftRepl.writeStats.splitRequestCounts(rightRepl.writeStats)
 
-	if err := s.addReplicaInternalLocked(rightRepl); err != nil {
+	// Look up existing replica shim; this might have been added as an
+	// uninitialized replica previously.
+	var shim *ReplicaShim
+	if value, ok := s.mu.replicaShims.Load(int64(rightRepl.RangeID)); ok {
+		shim = (*ReplicaShim)(value)
+		// Note that we never allow a replica to be made non-resident if
+		// it's uninitialized, so it will not be nil in this case.
+		if shim.replica != rightRepl {
+			return errors.Errorf("%s: replica already exists", shim)
+		}
+	} else {
+		shim = &ReplicaShim{replica: rightRepl}
+	}
+	if err := s.addReplicaShimInternalLocked(shim); err != nil {
 		return errors.Errorf("unable to add replica %v: %s", rightRepl, err)
 	}
 
-	// Update the replica's cached byte thresholds. This is a no-op if the system
-	// config is not available, in which case we rely on the next gossip update
-	// to perform the update.
+	// Update the zone for the new replica. This is a no-op if the
+	// system config is not available, in which case we rely on the next
+	// gossip update to perform the update.
 	if err := rightRepl.updateRangeInfo(rightRepl.Desc()); err != nil {
 		return err
 	}
@@ -2407,25 +2552,27 @@ func (s *Store) MergeRange(
 	return nil
 }
 
-// addReplicaInternalLocked adds the replica to the replicas map and the
-// replicasByKey btree. Returns an error if a replica with
-// the same Range ID or a KeyRange that overlaps has already been added to
-// this store. addReplicaInternalLocked requires that the store lock is held.
-func (s *Store) addReplicaInternalLocked(repl *Replica) error {
-	if !repl.IsInitialized() {
-		return errors.Errorf("attempted to add uninitialized replica %s", repl)
+// addReplicaShimInternalLocked adds the replica shim to the replicas
+// map and the replicasByKey btree. Returns an error if a replica with
+// the same Range ID or a KeyRange that overlaps has already been
+// added to this store. addReplicaShimInternalLocked requires that the
+// store lock is held.
+func (s *Store) addReplicaShimInternalLocked(shim *ReplicaShim) error {
+	desc := shim.Desc()
+	if !desc.IsInitialized() {
+		return errors.Errorf("attempted to add uninitialized %s", shim)
 	}
 
-	if err := s.addReplicaToRangeMapLocked(repl); err != nil {
+	if err := s.addReplicaShimToRangeMapLocked(shim); err != nil {
 		return err
 	}
 
-	if exRange := s.getOverlappingKeyRangeLocked(repl.Desc()); exRange != nil {
-		return errors.Errorf("%s: cannot addReplicaInternalLocked; range %s has overlapping range %s", s, repl, exRange.Desc())
+	if exRange := s.getOverlappingKeyRangeLocked(desc); exRange != nil {
+		return errors.Errorf("%s: %s has overlapping key span %s", s, shim, exRange.Desc())
 	}
 
-	if exRngItem := s.mu.replicasByKey.ReplaceOrInsert(repl); exRngItem != nil {
-		return errors.Errorf("%s: cannot addReplicaInternalLocked; range for key %v already exists in replicasByKey btree", s,
+	if exRngItem := s.mu.replicasByKey.ReplaceOrInsert(shim); exRngItem != nil {
+		return errors.Errorf("%s: range for key %v already exists in replicasByKey btree", s,
 			exRngItem.(KeyRange).startKey())
 	}
 
@@ -2486,22 +2633,25 @@ func (s *Store) removePlaceholderLocked(ctx context.Context, rngID roachpb.Range
 	return false // appease the compiler
 }
 
-// addReplicaToRangeMapLocked adds the replica to the replicas map.
-func (s *Store) addReplicaToRangeMapLocked(repl *Replica) error {
-	// It's ok for the replica to exist in the replicas map as long as it is the
-	// same replica object. This occurs during splits where the right-hand side
-	// is added to the replicas map before it is initialized.
-	if existing, loaded := s.mu.replicas.LoadOrStore(
-		int64(repl.RangeID), unsafe.Pointer(repl)); loaded && (*Replica)(existing) != repl {
-		return errors.Errorf("%s: replica already exists", repl)
+// addReplicaShimToRangeMapLocked adds the replica shim to the
+// replicaShims map.
+func (s *Store) addReplicaShimToRangeMapLocked(shim *ReplicaShim) error {
+	rangeID := shim.RangeID()
+	if existing, loaded := s.mu.replicaShims.LoadOrStore(int64(rangeID), unsafe.Pointer(shim)); loaded {
+		// It's ok for the shim to exist in the replicaShims map as long as it
+		// is the same object. This occurs during splits where the right-hand side
+		// is added to the map before it is initialized.
+		if shim != (*ReplicaShim)(existing) {
+			return errors.Errorf("replica for %d already exists", rangeID)
+		}
 	}
-	// Check whether the replica is unquiesced but not in the map. This
-	// can happen during splits and merges, where the uninitialized (but
-	// also unquiesced) replica is removed from the unquiesced replica
-	// map in advance of this method being called.
+	// Check whether the replica is unquiesced, and add it to the map if
+	// so. This can happen during splits and merges, where the
+	// uninitialized (but also unquiesced) replica is removed from the
+	// unquiesced replica map in advance of this method being called.
 	s.unquiescedReplicas.Lock()
-	if _, ok := s.unquiescedReplicas.m[repl.RangeID]; !repl.mu.quiescent && !ok {
-		s.unquiescedReplicas.m[repl.RangeID] = struct{}{}
+	if repl := shim.replica; repl != nil && !repl.mu.quiescent {
+		s.unquiescedReplicas.m[rangeID] = struct{}{}
 	}
 	s.unquiescedReplicas.Unlock()
 	return nil
@@ -2552,21 +2702,23 @@ func (s *Store) removeReplicaImpl(
 	}
 	rep.mu.Unlock()
 
-	if _, err := s.GetReplica(rep.RangeID); err != nil {
-		return err
-	}
-
 	// During merges, the context might have the subsuming range, so we explicitly
 	// log the replica to be removed.
 	log.Infof(ctx, "removing replica r%d/%d", rep.RangeID, replicaID)
 
+	v, ok := s.mu.replicaShims.Load(int64(desc.RangeID))
+	if !ok {
+		return roachpb.NewRangeNotFoundError(desc.RangeID, rep.store.StoreID())
+	}
+	shim := (*ReplicaShim)(v)
+
 	s.mu.Lock()
-	if placeholder := s.getOverlappingKeyRangeLocked(desc); placeholder != rep {
+	if placeholder := s.getOverlappingKeyRangeLocked(desc); placeholder != shim {
 		// This is a fatal error because uninitialized replicas shouldn't make it
 		// this far. This method will need some changes when we introduce GC of
 		// uninitialized replicas.
 		s.mu.Unlock()
-		log.Fatalf(ctx, "replica %+v unexpectedly overlapped by %+v", rep, placeholder)
+		log.Fatalf(ctx, "replica %+v unexpectedly overlapped by %+v", shim, placeholder)
 	}
 	// Adjust stats before calling Destroy. This can be called before or after
 	// Destroy, but this configuration helps avoid races in stat verification
@@ -2602,7 +2754,7 @@ func (s *Store) removeReplicaImpl(
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.unlinkReplicaByRangeIDLocked(rep.RangeID)
-	if placeholder := s.mu.replicasByKey.Delete(rep); placeholder != rep {
+	if placeholder := s.mu.replicasByKey.Delete(shim); placeholder != shim {
 		// We already checked that our replica was present in replicasByKey
 		// above. Nothing should have been able to change that.
 		log.Fatalf(ctx, "replica %+v unexpectedly overlapped by %+v", rep, placeholder)
@@ -2630,7 +2782,7 @@ func (s *Store) unlinkReplicaByRangeIDLocked(rangeID roachpb.RangeID) {
 	s.unquiescedReplicas.Unlock()
 	delete(s.mu.uninitReplicas, rangeID)
 	s.replicaQueues.Delete(int64(rangeID))
-	s.mu.replicas.Delete(int64(rangeID))
+	s.mu.replicaShims.Delete(int64(rangeID))
 }
 
 // maybeMarkReplicaInitializedLocked should be called whenever a previously
@@ -2651,10 +2803,14 @@ func (s *Store) maybeMarkReplicaInitializedLocked(ctx context.Context, repl *Rep
 	delete(s.mu.uninitReplicas, rangeID)
 
 	if exRange := s.getOverlappingKeyRangeLocked(repl.Desc()); exRange != nil {
-		return errors.Errorf("%s: cannot initialize replica; range %s has overlapping range %s",
+		return errors.Errorf("%s: cannot initialize replica; range %s has overlapping key span %s",
 			s, repl, exRange.Desc())
 	}
-	if exRngItem := s.mu.replicasByKey.ReplaceOrInsert(repl); exRngItem != nil {
+	value, ok := s.mu.replicaShims.Load(int64(repl.RangeID))
+	if !ok {
+		return errors.Errorf("unable to locate shim for initialized replica %s", repl)
+	}
+	if exRngItem := s.mu.replicasByKey.ReplaceOrInsert((*ReplicaShim)(value)); exRngItem != nil {
 		return errors.Errorf("range for key %v already exists in replicasByKey btree",
 			(exRngItem.(*Replica)).startKey())
 	}
@@ -2691,6 +2847,11 @@ func (s *Store) Capacity(useCached bool) (roachpb.StoreCapacity, error) {
 	}
 
 	now := s.cfg.Clock.Now()
+	var livenessMap IsLiveMap
+	if s.cfg.NodeLiveness != nil {
+		livenessMap = s.cfg.NodeLiveness.GetIsLiveMap()
+	}
+
 	var leaseCount int32
 	var rangeCount int32
 	var logicalBytes int64
@@ -2700,32 +2861,32 @@ func (s *Store) Capacity(useCached bool) (roachpb.StoreCapacity, error) {
 	bytesPerReplica := make([]float64, 0, replicaCount)
 	writesPerReplica := make([]float64, 0, replicaCount)
 	rankingsAccumulator := s.replRankings.newAccumulator()
-	newStoreReplicaVisitor(s).Visit(func(r *Replica) bool {
+	s.mu.replicaShims.Range(func(_ int64, v unsafe.Pointer) bool {
 		rangeCount++
-		if r.OwnsValidLease(now) {
+
+		shim := (*ReplicaShim)(v)
+		capacity := shim.Capacity(s.Ident.StoreID, now, livenessMap)
+		if capacity.Leaseholder {
 			leaseCount++
 		}
-		mvccStats := r.GetMVCCStats()
-		logicalBytes += mvccStats.Total()
-		bytesPerReplica = append(bytesPerReplica, float64(mvccStats.Total()))
+		statsTotal := capacity.Stats.Total()
+		logicalBytes += statsTotal
+		bytesPerReplica = append(bytesPerReplica, float64(statsTotal))
 		// TODO(a-robinson): How dangerous is it that these numbers will be
 		// incorrectly low the first time or two it gets gossiped when a store
 		// starts? We can't easily have a countdown as its value changes like for
 		// leases/replicas.
-		var qps float64
-		if avgQPS, dur := r.leaseholderStats.avgQPS(); dur >= MinStatsDuration {
-			qps = avgQPS
-			totalQueriesPerSecond += avgQPS
-			// TODO(a-robinson): Calculate percentiles for qps? Get rid of other percentiles?
+		// TODO(a-robinson): Calculate percentiles for qps? Get rid of other percentiles?
+		totalQueriesPerSecond += capacity.QPS
+		totalWritesPerSecond += capacity.WPS
+		writesPerReplica = append(writesPerReplica, capacity.WPS)
+
+		if capacity.QPS > 0 {
+			rankingsAccumulator.addReplica(replicaWithStats{
+				rangeID: shim.RangeID(),
+				qps:     capacity.QPS,
+			})
 		}
-		if wps, dur := r.writeStats.avgQPS(); dur >= MinStatsDuration {
-			totalWritesPerSecond += wps
-			writesPerReplica = append(writesPerReplica, wps)
-		}
-		rankingsAccumulator.addReplica(replicaWithStats{
-			repl: r,
-			qps:  qps,
-		})
 		return true
 	})
 	capacity.RangeCount = rangeCount
@@ -2745,16 +2906,9 @@ func (s *Store) Capacity(useCached bool) (roachpb.StoreCapacity, error) {
 	return capacity, nil
 }
 
-// ReplicaCount returns the number of replicas contained by this store. This
-// method is O(n) in the number of replicas and should not be called from
-// performance critical code.
+// ReplicaCount returns the number of replicas contained by this store.
 func (s *Store) ReplicaCount() int {
-	var count int
-	s.mu.replicas.Range(func(_ int64, _ unsafe.Pointer) bool {
-		count++
-		return true
-	})
-	return count
+	return int(s.metrics.ReplicaCount.Value())
 }
 
 // Registry returns the store registry.
@@ -2800,18 +2954,25 @@ func (s *Store) deadReplicas() roachpb.StoreDeadReplicas {
 	// TODO(bram): does this need to visit all the replicas? Could we just use the
 	// store pool to locate any dead replicas on this store directly?
 	var deadReplicas []roachpb.ReplicaIdent
-	s.mu.replicas.Range(func(k int64, v unsafe.Pointer) bool {
-		r := (*Replica)(v)
-		r.mu.RLock()
-		corrupted := r.mu.destroyStatus.reason == destroyReasonCorrupted
-		desc := r.mu.state.Desc
-		r.mu.RUnlock()
-		replicaDesc, ok := desc.GetReplicaDescriptor(s.Ident.StoreID)
-		if ok && corrupted {
-			deadReplicas = append(deadReplicas, roachpb.ReplicaIdent{
-				RangeID: desc.RangeID,
-				Replica: replicaDesc,
-			})
+	s.mu.replicaShims.Range(func(k int64, v unsafe.Pointer) bool {
+		shim := (*ReplicaShim)(v)
+		var corrupted bool
+		var desc *roachpb.RangeDescriptor
+		shim.Lock()
+		if repl := shim.replica; repl != nil {
+			repl.mu.RLock()
+			corrupted = repl.mu.destroyStatus.reason == destroyReasonCorrupted
+			desc = repl.mu.state.Desc
+			repl.mu.RUnlock()
+		}
+		shim.Unlock()
+		if corrupted {
+			if replicaDesc, ok := desc.GetReplicaDescriptor(s.Ident.StoreID); ok {
+				deadReplicas = append(deadReplicas, roachpb.ReplicaIdent{
+					RangeID: desc.RangeID,
+					Replica: replicaDesc,
+				})
+			}
 		}
 		return true
 	})
@@ -3725,13 +3886,12 @@ func (s *Store) processRequestQueue(ctx context.Context, rangeID roachpb.RangeID
 }
 
 func (s *Store) processReady(ctx context.Context, rangeID roachpb.RangeID) {
-	value, ok := s.mu.replicas.Load(int64(rangeID))
-	if !ok {
+	r := s.mustGetReplica(ctx, rangeID)
+	if r == nil {
 		return
 	}
 
 	start := timeutil.Now()
-	r := (*Replica)(value)
 	stats, expl, err := r.handleRaftReady(noSnap)
 	if err != nil {
 		log.Fatalf(ctx, "%s: %s", log.Safe(expl), err) // TODO(bdarnell)
@@ -3764,14 +3924,13 @@ func (s *Store) processReady(ctx context.Context, rangeID roachpb.RangeID) {
 }
 
 func (s *Store) processTick(ctx context.Context, rangeID roachpb.RangeID) bool {
-	value, ok := s.mu.replicas.Load(int64(rangeID))
-	if !ok {
+	r := s.mustGetReplica(ctx, rangeID)
+	if r == nil {
 		return false
 	}
 	livenessMap, _ := s.livenessMap.Load().(IsLiveMap)
 
 	start := timeutil.Now()
-	r := (*Replica)(value)
 	exists, err := r.tick(livenessMap)
 	if err != nil {
 		log.Error(ctx, err)
@@ -3792,14 +3951,19 @@ func (s *Store) nodeIsLiveCallback(nodeID roachpb.NodeID) {
 	// Update the liveness map.
 	s.livenessMap.Store(s.cfg.NodeLiveness.GetIsLiveMap())
 
-	s.mu.replicas.Range(func(k int64, v unsafe.Pointer) bool {
-		r := (*Replica)(v)
-		for _, rep := range r.Desc().Replicas {
-			if rep.NodeID == nodeID {
-				r.unquiesce()
+	s.mu.replicaShims.Range(func(k int64, v unsafe.Pointer) bool {
+		shim := (*ReplicaShim)(v)
+		if shim.QuiescentButBehind() {
+			for _, repDesc := range shim.Desc().Replicas {
+				if repDesc.NodeID == nodeID {
+					if repl := s.mustGetReplica(context.TODO(), shim.RangeID()); repl != nil {
+						repl.unquiesce()
+					}
+					break
+				}
 			}
 		}
-		return true
+		return true // more
 	})
 }
 
@@ -3932,13 +4096,13 @@ func (s *Store) sendQueuedHeartbeatsToNode(
 
 	if !s.cfg.Transport.SendAsync(chReq) {
 		for _, beat := range beats {
-			if value, ok := s.mu.replicas.Load(int64(beat.RangeID)); ok {
-				(*Replica)(value).addUnreachableRemoteReplica(beat.ToReplicaID)
+			if repl := s.mustGetReplica(ctx, beat.RangeID); repl != nil {
+				repl.addUnreachableRemoteReplica(beat.ToReplicaID)
 			}
 		}
 		for _, resp := range resps {
-			if value, ok := s.mu.replicas.Load(int64(resp.RangeID)); ok {
-				(*Replica)(value).addUnreachableRemoteReplica(resp.ToReplicaID)
+			if repl := s.mustGetReplica(ctx, resp.RangeID); repl != nil {
+				repl.addUnreachableRemoteReplica(resp.ToReplicaID)
 			}
 		}
 		return 0
@@ -4007,8 +4171,7 @@ func (s *Store) tryGetOrCreateReplica(
 	creatingReplica *roachpb.ReplicaDescriptor,
 ) (_ *Replica, created bool, _ error) {
 	// The common case: look up an existing (initialized) replica.
-	if value, ok := s.mu.replicas.Load(int64(rangeID)); ok {
-		repl := (*Replica)(value)
+	if repl := s.mustGetReplica(ctx, rangeID); repl != nil {
 		repl.raftMu.Lock() // not unlocked
 		repl.mu.Lock()
 		defer repl.mu.Unlock()
@@ -4071,11 +4234,11 @@ func (s *Store) tryGetOrCreateReplica(
 	// Store.mu to maintain lock ordering invariant.
 	repl.mu.Lock()
 	repl.mu.minReplicaID = tombstone.NextReplicaID
-	// Add the range to range map, but not replicasByKey since the range's start
+	// Add new shim to map, but not replicasByKey since the range's start
 	// key is unknown. The range will be added to replicasByKey later when a
 	// snapshot is applied. After unlocking Store.mu above, another goroutine
 	// might have snuck in and created the replica, so we retry on error.
-	if err := s.addReplicaToRangeMapLocked(repl); err != nil {
+	if err := s.addReplicaShimToRangeMapLocked(&ReplicaShim{replica: repl}); err != nil {
 		repl.mu.Unlock()
 		s.mu.Unlock()
 		repl.raftMu.Unlock()
@@ -4116,18 +4279,9 @@ func (s *Store) updateCapacityGauges() error {
 	return nil
 }
 
-// updateReplicationGauges counts a number of simple replication statistics for
-// the ranges in this store.
-// TODO(bram): #4564 It may be appropriate to compute these statistics while
-// scanning ranges. An ideal solution would be to create incremental events
-// whenever availability changes.
+// updateReplicationGauges counts a number of simple replication
+// statistics for the ranges in this store.
 func (s *Store) updateReplicationGauges(ctx context.Context) error {
-	// Load the system config.
-	cfg := s.Gossip().GetSystemConfig()
-	if cfg == nil {
-		return errors.Errorf("%s: system config not yet available", s)
-	}
-
 	var (
 		raftLeaderCount               int64
 		leaseHolderCount              int64
@@ -4135,6 +4289,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		leaseEpochCount               int64
 		raftLeaderNotLeaseHolderCount int64
 		quiescentCount                int64
+		residentCount                 int64
 		averageQueriesPerSecond       float64
 		averageWritesPerSecond        float64
 
@@ -4151,8 +4306,8 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	}
 	availableNodes := s.AvailableNodeCount()
 
-	newStoreReplicaVisitor(s).Visit(func(rep *Replica) bool {
-		metrics := rep.Metrics(ctx, timestamp, livenessMap, availableNodes)
+	s.mu.replicaShims.Range(func(_ int64, v unsafe.Pointer) bool {
+		rep, metrics := (*ReplicaShim)(v).Metrics(ctx, s.Ident.StoreID, timestamp, livenessMap, availableNodes)
 		if metrics.Leader {
 			raftLeaderCount++
 			if metrics.LeaseValid && !metrics.Leaseholder {
@@ -4182,11 +4337,14 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 			}
 		}
 		behindCount += metrics.BehindCount
-		if qps, dur := rep.leaseholderStats.avgQPS(); dur >= MinStatsDuration {
-			averageQueriesPerSecond += qps
-		}
-		if wps, dur := rep.writeStats.avgQPS(); dur >= MinStatsDuration {
-			averageWritesPerSecond += wps
+		if rep != nil {
+			residentCount++
+			if qps, dur := rep.leaseholderStats.avgQPS(); dur >= MinStatsDuration {
+				averageQueriesPerSecond += qps
+			}
+			if wps, dur := rep.writeStats.avgQPS(); dur >= MinStatsDuration {
+				averageWritesPerSecond += wps
+			}
 		}
 		return true // more
 	})
@@ -4197,6 +4355,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	s.metrics.LeaseExpirationCount.Update(leaseExpirationCount)
 	s.metrics.LeaseEpochCount.Update(leaseEpochCount)
 	s.metrics.QuiescentCount.Update(quiescentCount)
+	s.metrics.ResidentCount.Update(residentCount)
 	s.metrics.AverageQueriesPerSecond.Update(averageQueriesPerSecond)
 	s.metrics.AverageWritesPerSecond.Update(averageWritesPerSecond)
 	s.recordNewPerSecondStats(averageQueriesPerSecond, averageWritesPerSecond)
@@ -4262,20 +4421,35 @@ type StoreKeySpanStats struct {
 	ApproximateDiskBytes uint64
 }
 
-// ComputeStatsForKeySpan computes the aggregated MVCCStats for all replicas on
-// this store which contain any keys in the supplied range.
+// ComputeStatsForKeySpan computes the aggregated MVCCStats for all
+// replicas on this store which overlap the supplied range.
 func (s *Store) ComputeStatsForKeySpan(startKey, endKey roachpb.RKey) (StoreKeySpanStats, error) {
 	var result StoreKeySpanStats
 
-	newStoreReplicaVisitor(s).Visit(func(repl *Replica) bool {
-		desc := repl.Desc()
-		if bytes.Compare(startKey, desc.EndKey) >= 0 || bytes.Compare(desc.StartKey, endKey) >= 0 {
+	// Descend one iteration so we can include the first overlapping range.
+	s.mu.replicasByKey.DescendLessOrEqual(rangeBTreeKey(startKey),
+		func(item btree.Item) bool {
+			kr := item.(KeyRange)
+			if startKey.Less(kr.Desc().EndKey) {
+				startKey = kr.Desc().StartKey
+			}
+			return false
+		})
+
+	// Now ascend until we encounter a range which is not overlapping.
+	s.mu.replicasByKey.AscendGreaterOrEqual(rangeBTreeKey(startKey),
+		func(item btree.Item) bool {
+			kr := item.(KeyRange)
+			if !kr.Desc().StartKey.Less(endKey) {
+				// The range is outside of the requested key span.
+				return false
+			}
+			if shim, ok := item.(*ReplicaShim); ok {
+				result.ReplicaCount++
+				result.MVCC.Add(shim.GetMVCCStats())
+			}
 			return true // continue
-		}
-		result.MVCC.Add(repl.GetMVCCStats())
-		result.ReplicaCount++
-		return true
-	})
+		})
 
 	var err error
 	result.ApproximateDiskBytes, err = s.engine.ApproximateDiskBytes(startKey.AsRawKey(), endKey.AsRawKey())

--- a/pkg/storage/store_rebalancer.go
+++ b/pkg/storage/store_rebalancer.go
@@ -114,6 +114,8 @@ const (
 	LBRebalancingLeasesAndReplicas
 )
 
+type getReplicaFunc func(roachpb.RangeID) (*Replica, error)
+
 // StoreRebalancer is responsible for examining how the associated store's load
 // compares to the load on other stores in the cluster and transferring leases
 // or replicas away if the local store is overloaded.
@@ -131,6 +133,7 @@ type StoreRebalancer struct {
 	rq              *replicateQueue
 	replRankings    *replicaRankings
 	getRaftStatusFn func(replica *Replica) *raft.Status
+	getReplicaFn    getReplicaFunc
 }
 
 // NewStoreRebalancer creates a StoreRebalancer to work in tandem with the
@@ -140,6 +143,7 @@ func NewStoreRebalancer(
 	st *cluster.Settings,
 	rq *replicateQueue,
 	replRankings *replicaRankings,
+	getReplicaFn getReplicaFunc,
 ) *StoreRebalancer {
 	sr := &StoreRebalancer{
 		AmbientContext: ambientCtx,
@@ -150,6 +154,7 @@ func NewStoreRebalancer(
 		getRaftStatusFn: func(replica *Replica) *raft.Status {
 			return replica.RaftStatus()
 		},
+		getReplicaFn: getReplicaFn,
 	}
 	sr.AddLogTag("store-rebalancer", nil)
 	sr.rq.store.metrics.registry.AddMetricStruct(&sr.metrics)
@@ -245,16 +250,19 @@ func (sr *StoreRebalancer) rebalanceStore(
 		replWithStats, target, considerForRebalance := sr.chooseLeaseToTransfer(
 			ctx, &hottestRanges, localDesc, storeList, storeMap, qpsMinThreshold, qpsMaxThreshold)
 		replicasToMaybeRebalance = append(replicasToMaybeRebalance, considerForRebalance...)
-		if replWithStats.repl == nil {
+		if replWithStats.rangeID == 0 {
 			break
+		}
+		repl, err := sr.getReplicaFn(replWithStats.rangeID)
+		if err != nil {
+			log.Errorf(ctx, "unable to get replica for range ID %d: %v", replWithStats.rangeID, err)
+			continue
 		}
 
 		log.VEventf(ctx, 1, "transferring r%d (%.2f qps) to s%d to better balance load",
-			replWithStats.repl.RangeID, replWithStats.qps, target.StoreID)
-		replCtx, cancel := context.WithTimeout(replWithStats.repl.AnnotateCtx(ctx), sr.rq.processTimeout)
-		if err := sr.rq.transferLease(
-			replCtx, replWithStats.repl, target, replWithStats.qps,
-		); err != nil {
+			repl.RangeID, replWithStats.qps, target.StoreID)
+		replCtx, cancel := context.WithTimeout(repl.AnnotateCtx(ctx), sr.rq.processTimeout)
+		if err := sr.rq.transferLease(replCtx, repl, target, replWithStats.qps); err != nil {
 			cancel()
 			log.Errorf(replCtx, "unable to transfer lease to s%d: %v", target.StoreID, err)
 			continue
@@ -303,17 +311,22 @@ func (sr *StoreRebalancer) rebalanceStore(
 			storeMap,
 			qpsMinThreshold,
 			qpsMaxThreshold)
-		if replWithStats.repl == nil {
+		if replWithStats.rangeID == 0 {
 			log.Infof(ctx,
 				"ran out of replicas worth transferring and qps (%.2f) is still above desired threshold (%.2f); will check again soon",
 				localDesc.Capacity.QueriesPerSecond, qpsMaxThreshold)
 			return
 		}
+		repl, err := sr.getReplicaFn(replWithStats.rangeID)
+		if err != nil {
+			log.Errorf(ctx, "unable to get replica for range ID %d: %v", replWithStats.rangeID, err)
+			continue
+		}
 
-		descBeforeRebalance := replWithStats.repl.Desc()
+		descBeforeRebalance := repl.Desc()
 		log.VEventf(ctx, 1, "rebalancing r%d (%.2f qps) from %v to %v to better balance load",
-			replWithStats.repl.RangeID, replWithStats.qps, descBeforeRebalance.Replicas, targets)
-		replCtx, cancel := context.WithTimeout(replWithStats.repl.AnnotateCtx(ctx), sr.rq.processTimeout)
+			repl.RangeID, replWithStats.qps, descBeforeRebalance.Replicas, targets)
+		replCtx, cancel := context.WithTimeout(repl.AnnotateCtx(ctx), sr.rq.processTimeout)
 		if err := sr.rq.store.AdminRelocateRange(replCtx, *descBeforeRebalance, targets); err != nil {
 			cancel()
 			log.Errorf(replCtx, "unable to relocate range to %v: %v", targets, err)
@@ -373,11 +386,16 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 		*hottestRanges = (*hottestRanges)[1:]
 
 		// We're all out of replicas.
-		if replWithStats.repl == nil {
+		if replWithStats.rangeID == 0 {
 			return replicaWithStats{}, roachpb.ReplicaDescriptor{}, considerForRebalance
 		}
+		repl, err := sr.getReplicaFn(replWithStats.rangeID)
+		if err != nil {
+			log.Errorf(ctx, "unable to get replica for range ID %d: %v", replWithStats.rangeID, err)
+			continue
+		}
 
-		if shouldNotMoveAway(ctx, replWithStats, localDesc, now, minQPS) {
+		if shouldNotMoveAway(ctx, repl, replWithStats, localDesc, now, minQPS) {
 			continue
 		}
 
@@ -389,11 +407,11 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 		if replWithStats.qps < localDesc.Capacity.QueriesPerSecond*minQPSFraction &&
 			float64(localDesc.Capacity.LeaseCount) <= storeList.candidateLeases.mean {
 			log.VEventf(ctx, 5, "r%d's %.2f qps is too little to matter relative to s%d's %.2f total qps",
-				replWithStats.repl.RangeID, replWithStats.qps, localDesc.StoreID, localDesc.Capacity.QueriesPerSecond)
+				repl.RangeID, replWithStats.qps, localDesc.StoreID, localDesc.Capacity.QueriesPerSecond)
 			continue
 		}
 
-		desc, zone := replWithStats.repl.DescAndZone()
+		desc, zone := repl.DescAndZone()
 		log.VEventf(ctx, 3, "considering lease transfer for r%d with %.2f qps",
 			desc.RangeID, replWithStats.qps)
 
@@ -424,7 +442,7 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 			}
 
 			if raftStatus == nil {
-				raftStatus = sr.getRaftStatusFn(replWithStats.repl)
+				raftStatus = sr.getRaftStatusFn(repl)
 			}
 			if replicaIsBehind(raftStatus, candidate.ReplicaID) {
 				log.VEventf(ctx, 3, "%v is behind or this store isn't the raft leader for r%d; raftStatus: %v",
@@ -446,7 +464,7 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 				*localDesc,
 				candidate.StoreID,
 				desc.Replicas,
-				replWithStats.repl.leaseholderStats,
+				repl.leaseholderStats,
 			) {
 				log.VEventf(ctx, 3, "r%d is on s%d due to follow-the-workload; skipping",
 					desc.RangeID, localDesc.StoreID)
@@ -479,11 +497,16 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 		replWithStats := (*hottestRanges)[0]
 		*hottestRanges = (*hottestRanges)[1:]
 
-		if replWithStats.repl == nil {
+		if replWithStats.rangeID == 0 {
 			return replicaWithStats{}, nil
 		}
+		repl, err := sr.getReplicaFn(replWithStats.rangeID)
+		if err != nil {
+			log.Errorf(ctx, "unable to get replica for range ID %d: %v", replWithStats.rangeID, err)
+			continue
+		}
 
-		if shouldNotMoveAway(ctx, replWithStats, localDesc, now, minQPS) {
+		if shouldNotMoveAway(ctx, repl, replWithStats, localDesc, now, minQPS) {
 			continue
 		}
 
@@ -495,11 +518,11 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 		if replWithStats.qps < localDesc.Capacity.QueriesPerSecond*minQPSFraction &&
 			float64(localDesc.Capacity.RangeCount) <= storeList.candidateRanges.mean {
 			log.VEventf(ctx, 5, "r%d's %.2f qps is too little to matter relative to s%d's %.2f total qps",
-				replWithStats.repl.RangeID, replWithStats.qps, localDesc.StoreID, localDesc.Capacity.QueriesPerSecond)
+				repl.RangeID, replWithStats.qps, localDesc.StoreID, localDesc.Capacity.QueriesPerSecond)
 			continue
 		}
 
-		desc, zone := replWithStats.repl.DescAndZone()
+		desc, zone := repl.DescAndZone()
 		log.VEventf(ctx, 3, "considering replica rebalance for r%d with %.2f qps",
 			desc.RangeID, replWithStats.qps)
 
@@ -534,7 +557,7 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 		}
 
 		// Then pick out which new stores to add the remaining replicas to.
-		rangeInfo := rangeInfoForRepl(replWithStats.repl, desc)
+		rangeInfo := rangeInfoForRepl(repl, desc)
 		// Make sure to use the same qps measurement throughout everything we do.
 		rangeInfo.QueriesPerSecond = replWithStats.qps
 		options := sr.rq.allocator.scorerOptions()
@@ -608,7 +631,7 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 			}
 			if replicaID != 0 {
 				if raftStatus == nil {
-					raftStatus = sr.getRaftStatusFn(replWithStats.repl)
+					raftStatus = sr.getRaftStatusFn(repl)
 				}
 				if replicaIsBehind(raftStatus, replicaID) {
 					continue
@@ -628,18 +651,19 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 
 func shouldNotMoveAway(
 	ctx context.Context,
+	repl *Replica,
 	replWithStats replicaWithStats,
 	localDesc *roachpb.StoreDescriptor,
 	now hlc.Timestamp,
 	minQPS float64,
 ) bool {
-	if !replWithStats.repl.OwnsValidLease(now) {
-		log.VEventf(ctx, 3, "store doesn't own the lease for r%d", replWithStats.repl.RangeID)
+	if !repl.OwnsValidLease(now) {
+		log.VEventf(ctx, 3, "store doesn't own the lease for r%d", replWithStats.rangeID)
 		return true
 	}
 	if localDesc.Capacity.QueriesPerSecond-replWithStats.qps < minQPS {
 		log.VEventf(ctx, 3, "moving r%d's %.2f qps would bring s%d below the min threshold (%.2f)",
-			replWithStats.repl.RangeID, replWithStats.qps, localDesc.StoreID, minQPS)
+			replWithStats.rangeID, replWithStats.qps, localDesc.StoreID, minQPS)
 		return true
 	}
 	return false
@@ -665,13 +689,13 @@ func shouldNotMoveTo(
 		if newCandidateQPS > maxQPS {
 			log.VEventf(ctx, 3,
 				"r%d's %.2f qps would push s%d over the max threshold (%.2f) with %.2f qps afterwards",
-				replWithStats.repl.RangeID, replWithStats.qps, candidateStore, maxQPS, newCandidateQPS)
+				replWithStats.rangeID, replWithStats.qps, candidateStore, maxQPS, newCandidateQPS)
 			return true
 		}
 	} else if newCandidateQPS > meanQPS {
 		log.VEventf(ctx, 3,
 			"r%d's %.2f qps would push s%d over the mean (%.2f) with %.2f qps afterwards",
-			replWithStats.repl.RangeID, replWithStats.qps, candidateStore, meanQPS, newCandidateQPS)
+			replWithStats.rangeID, replWithStats.qps, candidateStore, meanQPS, newCandidateQPS)
 		return true
 	}
 

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -567,9 +567,9 @@ func TestReplicasByKey(t *testing.T) {
 		expectedErrorOnAdd string
 	}{
 		// [a,c) is contained in [KeyMin, e)
-		{nil, 2, roachpb.RKey("a"), roachpb.RKey("c"), ".*has overlapping range"},
+		{nil, 2, roachpb.RKey("a"), roachpb.RKey("c"), ".*has overlapping key span"},
 		// [c,f) partially overlaps with [KeyMin, e)
-		{nil, 3, roachpb.RKey("c"), roachpb.RKey("f"), ".*has overlapping range"},
+		{nil, 3, roachpb.RKey("c"), roachpb.RKey("f"), ".*has overlapping key span"},
 		// [e, f) is disjoint from [KeyMin, e)
 		{nil, 4, roachpb.RKey("e"), roachpb.RKey("f"), ""},
 	}
@@ -1387,8 +1387,12 @@ func TestStoreSetRangesMaxBytes(t *testing.T) {
 	}
 
 	// Set zone configs.
-	config.TestingSetZoneConfig(baseID, config.ZoneConfig{RangeMaxBytes: proto.Int64(1 << 20)})
-	config.TestingSetZoneConfig(baseID+2, config.ZoneConfig{RangeMaxBytes: proto.Int64(2 << 20)})
+	zoneBase := *config.EmptyCompleteZoneConfig()
+	zoneBase.RangeMaxBytes = proto.Int64(1 << 20)
+	zoneBase2 := *config.EmptyCompleteZoneConfig()
+	zoneBase2.RangeMaxBytes = proto.Int64(2 << 20)
+	config.TestingSetZoneConfig(baseID, zoneBase)
+	config.TestingSetZoneConfig(baseID+2, zoneBase2)
 
 	// Despite faking the zone configs, we still need to have a system config
 	// entry so that the store picks up the new zone configs. This new system
@@ -1401,9 +1405,9 @@ func TestStoreSetRangesMaxBytes(t *testing.T) {
 	}
 
 	testutils.SucceedsSoon(t, func() error {
-		for _, test := range testData {
+		for i, test := range testData {
 			if mb := test.repl.GetMaxBytes(); mb != test.expMaxBytes {
-				return errors.Errorf("range max bytes values did not change to %d; got %d", test.expMaxBytes, mb)
+				return errors.Errorf("%d: range max bytes values did not change to %d; got %d", i, test.expMaxBytes, mb)
 			}
 		}
 		return nil

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -105,6 +105,7 @@ export default function (props: GraphDashboardProps) {
       <Axis label="replicas">
         <Metric name="cr.store.replicas" title="Replicas" />
         <Metric name="cr.store.replicas.quiescent" title="Quiescent" />
+        <Metric name="cr.store.replicas.resident" title="Resident" />
       </Axis>
     </LineGraph>,
 


### PR DESCRIPTION
More than several tens of thousands of `Replica` objects can take
substantial time at server startup to initialize. This change introduces
a `ReplicaShim` object which contains a pointer to the `Replica` which is
non-nil if resident. Otherwise, a set of other values including a ref to
the appropriate zone config, `MVCCStats` and a handful of other properties
necessary to accurately compute stats even when a replica is not-resident.

Release note (performance improvement): faster startup whena node contains
many replicas.