### PR TITLE
sql,telemetry: report built-in function name in eval failures

### DIFF
--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -296,6 +296,11 @@ func TestReportUsage(t *testing.T) {
 		) {
 			t.Fatal(err)
 		}
+		if _, err := db.Exec(`SELECT crdb_internal.set_vmodule('invalid')`); !testutils.IsError(
+			err, "comma-separated list",
+		) {
+			t.Fatal(err)
+		}
 		// If the vtable ever gets supported, change to pick one that is not supported yet.
 		if _, err := db.Exec(`SELECT * FROM pg_catalog.pg_stat_wal_receiver`); !testutils.IsError(
 			err, "virtual schema table not implemented",
@@ -528,7 +533,11 @@ func TestReportUsage(t *testing.T) {
 		"unimplemented.#9148":                                10,
 		"internalerror.":                                     10,
 		"othererror.builtins.go":                             10,
+		"othererror." +
+			pgerror.CodeDataExceptionError +
+			".crdb_internal.set_vmodule()": 10,
 		"errorcodes.blah":                                    10,
+		"errorcodes." + pgerror.CodeDataExceptionError:       10,
 		"errorcodes." + pgerror.CodeInternalError:            10,
 		"errorcodes." + pgerror.CodeSyntaxError:              10,
 		"errorcodes." + pgerror.CodeFeatureNotSupportedError: 10,
@@ -664,6 +673,7 @@ func TestReportUsage(t *testing.T) {
 		`[true,false,true] SELECT _ / _`,
 		`[true,false,true] SELECT crdb_internal.force_assertion_error(_)`,
 		`[true,false,true] SELECT crdb_internal.force_error(_, $1)`,
+		`[true,false,true] SELECT crdb_internal.set_vmodule(_)`,
 		`[true,true,false] SELECT * FROM _ WHERE (_ = _) AND (_ = _)`,
 		`[true,true,false] SELECT * FROM _ WHERE (_ = length($1::STRING)) OR (_ = $2)`,
 		`[true,true,false] SELECT _ FROM _ WHERE (_ = _) AND (lower(_) = lower(_))`,
@@ -708,6 +718,7 @@ func TestReportUsage(t *testing.T) {
 			`SELECT _ / _`,
 			`SELECT crdb_internal.force_assertion_error(_)`,
 			`SELECT crdb_internal.force_error(_, $1)`,
+			`SELECT crdb_internal.set_vmodule(_)`,
 			`SET CLUSTER SETTING "server.time_until_store_dead" = _`,
 			`SET CLUSTER SETTING "diagnostics.reporting.send_crash_reports" = _`,
 			`SET application_name = _`,

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3570,7 +3570,7 @@ func (expr *FuncExpr) Eval(ctx *EvalContext) (Datum, error) {
 		if fName == `crdb_internal.force_error` {
 			return nil, err
 		}
-		return nil, errors.Wrapf(err, "%s()", fName)
+		return nil, pgerror.Wrap(err, pgerror.CodeDataExceptionError, fName+"()")
 	}
 	if ctx.TestingKnobs.AssertFuncExprReturnTypes {
 		if err := ensureExpectedType(expr.fn.FixedReturnType(), res); err != nil {


### PR DESCRIPTION
Requested by @awoods187 

Prior to this patch, if any built-in function was producing a
non-pgerror error object it would be reported in telemetry as
`othererror.eval.go:3573`.

This patch fixes this by ensuring the function name is included and
the error reported as a pg "data error",
e.g. `othererror.22000.somefunction()`.

In addition, this patch extends the connExecutor error handling code
to always include a `pgerror.Error`'s `InternalCommand` in telemetry
if set, not just when the code is "internal error" or "syntax error".

Release note (sql change): CockroachDB will now include the name of
the SQL built-in function in collected statistics upon evaluation
errors.