### PR TITLE
storage: disable merge queue in internal storage tests

### DIFF
--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -176,9 +176,10 @@ func createTestStoreWithoutStart(t testing.TB, stopper *stop.Stopper, cfg *Store
 	// so just disable the scanner for all tests that use this function
 	// instead of figuring out exactly which tests need it.
 	cfg.TestingKnobs.DisableScanner = true
-	// The scanner affects background operations; we must also disable
-	// the split queue separately to cover event-driven splits.
+	// The scanner affects background operations; we must also disable the split
+	// and merge queues separately to cover event-driven splits and merges.
 	cfg.TestingKnobs.DisableSplitQueue = true
+	cfg.TestingKnobs.DisableMergeQueue = true
 	eng := engine.NewInMem(roachpb.Attributes{}, 10<<20)
 	stopper.AddCloser(eng)
 	cfg.Transport = NewDummyRaftTransport(cfg.Settings)


### PR DESCRIPTION
The dummy replicas that several internal storage tests create are not
fully initialized and segfault if they end up in any of the store's
internal queues. The tests were properly keeping these replicas out of
the split queue but were not taught to keep these replicas of the
recently-added merge queue.

Fix #31640.
Fix #31665.

Release note: None