### PR TITLE
build: fix typo in protobuf compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1038,7 +1038,7 @@ UI_PROTOS_CCL := $(UI_JS_CCL) $(UI_TS_CCL)
 
 UI_JS_OSS := pkg/ui/src/js/protos.js
 UI_TS_OSS := pkg/ui/src/js/protos.d.ts
-UI_PROTOS_OSS := $(UI_JS) $(UI_TS)
+UI_PROTOS_OSS := $(UI_JS_OSS) $(UI_TS_OSS)
 
 CPP_PROTOS := $(filter %/roachpb/metadata.proto %/roachpb/data.proto %/roachpb/internal.proto %/engine/enginepb/mvcc.proto %/engine/enginepb/mvcc3.proto %/engine/enginepb/file_registry.proto %/engine/enginepb/rocksdb.proto %/hlc/legacy_timestamp.proto %/hlc/timestamp.proto %/unresolved_addr.proto,$(GO_PROTOS))
 CPP_HEADERS := $(subst ./pkg,$(CPP_PROTO_ROOT),$(CPP_PROTOS:%.proto=%.pb.h))


### PR DESCRIPTION
UI_PROTOS_OSS was referring to non-existent variables UI_JS and UI_TS.
Use the correct names, UI_JS_OSS and UI_TS_OSS.

Fix #31655.

Release note: None