### PR TITLE
release-2.1: sql: Fix flake in TestCancelDistSQLQuery

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1137,7 +1137,7 @@ func (s *Store) AdminRelocateRange(
 			for _, candidate := range candidates {
 				store, ok := storeMap[candidate.StoreID]
 				if !ok {
-					return fmt.Errorf("cannot up-repliate to s%d; missing gossiped StoreDescriptor", candidate.StoreID)
+					return fmt.Errorf("cannot up-replicate to s%d; missing gossiped StoreDescriptor", candidate.StoreID)
 				}
 				candidateDescs = append(candidateDescs, *store)
 			}


### PR DESCRIPTION
Backport 2/2 commits from #30598.

/cc @cockroachdb/release

Fixes #31667.

---

By retrying the ALTER TABLE RELOCATE statement on failure. Hooking into
the first store's StorePool to wait until it has the second store's
StoreDescriptor would also work, but would involve seriously violating
reasonable encapsulation practices. This has the same effect.

Fixes #30491

Release note: None

Also: Fix typo in AdminRelocateRange error message