### PR TITLE
storage: pick up fix for Raft uncommitted entry size tracking

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1339,14 +1339,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b66436e3c460ee4a9fab4f7dc473c36c51d3263e04838756378e72cc90058b6c"
+  digest = "1:6830d356b8696fd4e7f09b57245dff696d19de8449ba589866e3783e80347e3e"
   name = "go.etcd.io/etcd"
   packages = [
     "raft",
     "raft/raftpb",
   ]
   pruneopts = "UT"
-  revision = "dac8c6fcc05ba42a8032d5b720f6c1704965c269"
+  revision = "b42b39446bc1b563ba58aceda53b6ecad87d73f9"
 
 [[projects]]
   digest = "1:f163a34487229f36dfdb298191d8e17c0e3e6a899aa2cddb020f2ac61ca364ab"


### PR DESCRIPTION
Waiting for the upstream PR

https://github.com/etcd-io/etcd/pull/10199

to merge, but this is going to be what the result will look like.

----

The tracking of the uncommitted portion of the log had a bug where
it wasn't releasing everything as it should've. As a result, over
time, all proposals would be dropped. We're hitting this way earlier
in our import tests, which propose large proposals. As an intentional
implementation detail, a proposal that itself exceeds the max
uncommitted log size is allowed only if the uncommitted log is empty.
Due to the leak, we weren't ever hitting this case and so AddSSTable
commands were often dropped indefinitely.

Fixes #31184.
Fixes #28693.
Fixes #31642.

Optimistically:
Fixes #31675.
Fixes #31654.
Fixes #31446.

Release note: None