### PR TITLE
storage: avoid re-processing replicas in up-replicate purgatory when senseless

### DIFF
--- a/pkg/gossip/keys.go
+++ b/pkg/gossip/keys.go
@@ -157,6 +157,21 @@ func MakeStoreKey(storeID roachpb.StoreID) string {
 	return MakeKey(KeyStorePrefix, storeID.String())
 }
 
+// StoreIDFromKey attempts to extract a StoreID from the provided key after
+// stripping the provided prefix. Returns an error if the key is not of the
+// correct type or is not parsable.
+func StoreIDFromKey(storeKey string) (roachpb.StoreID, error) {
+	trimmedKey, err := removePrefixFromKey(storeKey, KeyStorePrefix)
+	if err != nil {
+		return 0, err
+	}
+	storeID, err := strconv.ParseInt(trimmedKey, 10 /* base */, 64 /* bitSize */)
+	if err != nil {
+		return 0, errors.Wrapf(err, "failed parsing StoreID from key %q", storeKey)
+	}
+	return roachpb.StoreID(storeID), nil
+}
+
 // MakeDeadReplicasKey returns the dead replicas gossip key for the given store.
 func MakeDeadReplicasKey(storeID roachpb.StoreID) string {
 	return MakeKey(KeyDeadReplicasPrefix, storeID.String())

--- a/pkg/gossip/keys_test.go
+++ b/pkg/gossip/keys_test.go
@@ -59,3 +59,37 @@ func TestNodeIDFromKey(t *testing.T) {
 		})
 	}
 }
+
+func TestStoreIDFromKey(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		key     string
+		storeID roachpb.StoreID
+		success bool
+	}{
+		{MakeStoreKey(0), 0, true},
+		{MakeStoreKey(1), 1, true},
+		{MakeStoreKey(123), 123, true},
+		{MakeStoreKey(123) + "foo", 0, false},
+		{"foo" + MakeStoreKey(123), 0, false},
+		{KeyStorePrefix, 0, false},
+		{"123", 0, false},
+		{MakePrefixPattern(KeyStorePrefix), 0, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.key, func(t *testing.T) {
+			storeID, err := StoreIDFromKey(tc.key)
+			if err != nil {
+				if tc.success {
+					t.Errorf("expected success, got error: %s", err)
+				}
+			} else if !tc.success {
+				t.Errorf("expected failure, got storeID %d", storeID)
+			} else if storeID != tc.storeID {
+				t.Errorf("expected StoreID=%d, got %d", tc.storeID, storeID)
+			}
+		})
+	}
+}

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -169,7 +169,16 @@ func newReplicateQueue(store *Store, g *gossip.Gossip, allocator Allocator) *rep
 	// Register gossip and node liveness callbacks to signal that
 	// replicas in purgatory might be retried.
 	if g != nil { // gossip is nil for some unittests
-		g.RegisterCallback(gossip.MakePrefixPattern(gossip.KeyStorePrefix), func(_ string, _ roachpb.Value) {
+		g.RegisterCallback(gossip.MakePrefixPattern(gossip.KeyStorePrefix), func(key string, _ roachpb.Value) {
+			if !rq.store.IsStarted() {
+				return
+			}
+			// Because updates to our store's own descriptor won't affect
+			// replicas in purgatory, skip updating the purgatory channel
+			// in this case.
+			if storeID, err := gossip.StoreIDFromKey(key); err == nil && storeID == rq.store.StoreID() {
+				return
+			}
 			updateFn()
 		})
 	}


### PR DESCRIPTION
Updates to our own store's descriptor should not trigger replicas which are
in the up-replicate purgatory queue to re-process. This is particularly salient
in the case of single node clusters.

Release note: None