### PR TITLE
server: avoid deadlocking call to (*grpc.Server).Stop

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1298,8 +1298,6 @@ func (s *adminServer) Drain(req *serverpb.DrainRequest, stream serverpb.Admin_Dr
 		return nil
 	}
 
-	s.server.grpc.Stop()
-
 	go func() {
 		// The explicit closure here allows callers.Lookup() to return something
 		// sensible referring to this file (otherwise it ends up in runtime


### PR DESCRIPTION
This can deadlock if we don't also shut down the listener, which happens
only when we stop the stopper. At the same time, triggering the stopper
already also shuts down the grpc server.

Fixes #31690.

Release note: None