### PR TITLE
opt: Clear interner in Memo.Init

### DIFF
--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -153,6 +153,7 @@ type Memo struct {
 // IsStale method for more details).
 func (m *Memo) Init(evalCtx *tree.EvalContext) {
 	m.metadata.Init()
+	m.interner.Clear()
 	m.logPropsBuilder.init(evalCtx, m)
 
 	m.rootExpr = nil


### PR DESCRIPTION
Fix bug where the interner is not being cleared in Memo.Init. This
manifested as a panic in opt_test in cases where Optimizer.Optimize is
never called (e.g. when only optbuilding).

Release note: None