### PR TITLE
roachtest: make loggers thread-safe

### DIFF
--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -70,7 +70,11 @@ func (t testWrapper) logger() *logger {
 }
 
 func TestClusterMonitor(t *testing.T) {
-	logger := &logger{stdout: os.Stdout, stderr: os.Stderr}
+	cfg := &loggerConfig{stdout: os.Stdout, stderr: os.Stderr}
+	logger, err := cfg.newLogger("" /* path */)
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Run(`success`, func(t *testing.T) {
 		c := &cluster{t: testWrapper{t}, l: logger}
 		m := newMonitor(context.Background(), c)


### PR DESCRIPTION
Before this patch, a logger could not really be used by multiple
goroutines as access to the underlying File was not synchronized. One
could get truncated log lines.
This patch fixes this by moving the logger to internally use the
standard log.Logger. By using that lib, we now get filenames/line
numbers and times in the log files.
Another change is that prefixes (either configured explicitly on a
logger config or implicitly for a ChildLogger) are only applied to
Printf()/Errorf() log lines. They are not applied when a logger is used
as a raw io.Writer (e.g. when redirecting the output of a subcommand).
Besides simplifying the code, I think this is saner: when something is
outputting 1000 lines, it's unclear whether each line should have an
ugly prefix. I think it fair that if one askes for a raw output stream,
it gets a raw output stream with no magic (other than tee-ing between a
file and potentially os.Stdout).

Release note: None