### PR TITLE
exec: columnarized N:1 inner hash joiner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -698,7 +698,9 @@ EXECGEN_TARGETS = \
   pkg/sql/exec/distinct.og.go \
   pkg/sql/exec/projection_ops.og.go \
   pkg/sql/exec/rowstovec.og.go \
-  pkg/sql/exec/selection_ops.og.go
+  pkg/sql/exec/selection_ops.og.go \
+  pkg/sql/exec/colvec.og.go \
+  pkg/sql/exec/hashjoiner.og.go
 
 OPTGEN_TARGETS = \
 	pkg/sql/opt/memo/expr.og.go \

--- a/pkg/sql/exec/count_test.go
+++ b/pkg/sql/exec/count_test.go
@@ -35,8 +35,8 @@ func TestCount(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		runTests(t, tc.tuples, []types.T{}, func(t *testing.T, input Operator) {
-			count := NewCountOp(input)
+		runTests(t, []tuples{tc.tuples}, []types.T{}, func(t *testing.T, input []Operator) {
+			count := NewCountOp(input[0])
 			out := newOpTestOutput(count, []int{0}, tc.expected)
 
 			if err := out.Verify(); err != nil {

--- a/pkg/sql/exec/distinct_test.go
+++ b/pkg/sql/exec/distinct_test.go
@@ -52,8 +52,8 @@ func TestSortedDistinct(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		runTests(t, tc.tuples, []types.T{}, func(t *testing.T, input Operator) {
-			distinct, err := NewOrderedDistinct(input, tc.distinctCols, tc.colTypes)
+		runTests(t, []tuples{tc.tuples}, []types.T{}, func(t *testing.T, input []Operator) {
+			distinct, err := NewOrderedDistinct(input[0], tc.distinctCols, tc.colTypes)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/exec/execgen/cmd/execgen/colvec_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/colvec_gen.go
@@ -1,0 +1,127 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"io"
+	"text/template"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+const colVecTemplate = `
+package exec
+
+import (
+  "fmt"
+	
+	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+func (m *memColumn) Append(
+	vec ColVec, colType types.T, toLength uint64, fromLength uint16,
+) {
+	switch colType {
+		{{range .}}
+		case types.{{.ExecType}}:
+			m.col = append(m.{{.ExecType}}()[:toLength], vec.{{.ExecType}}()[:fromLength]...)
+		{{end}}
+		default:
+			panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+}
+
+func (m *memColumn) AppendWithSel(
+	vec ColVec, sel []uint16, batchSize uint16, colType types.T, toLength uint64,
+) {
+	switch colType {
+	{{range .}}
+	case types.{{.ExecType}}:
+		toCol := append(m.{{.ExecType}}()[:toLength], make([]{{.GoType}}, batchSize)...)
+		fromCol := vec.{{.ExecType}}()
+
+		for i := uint16(0); i < batchSize; i++ {
+      toCol[uint64(i) + toLength] = fromCol[sel[i]]
+		}
+
+		m.col = toCol
+	{{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+}
+
+func (m *memColumn) CopyWithSelInt64(
+	vec ColVec, sel []uint64, nSel uint16, colType types.T,
+) {
+	// todo (changangela): handle the case when nSel > ColBatchSize
+	switch colType {
+	{{range .}}
+	case types.{{.ExecType}}:
+		toCol := m.{{.ExecType}}()
+		fromCol := vec.{{.ExecType}}()
+		for i := uint16(0); i < nSel; i++ {
+			toCol[i] = fromCol[sel[i]]
+		}
+	{{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+}
+
+func (m *memColumn) CopyWithSelInt16(vec ColVec, sel []uint16, nSel uint16, colType types.T) {
+	switch colType {
+	{{range .}}
+	case types.{{.ExecType}}:
+		toCol := m.{{.ExecType}}()
+		fromCol := vec.{{.ExecType}}()
+		for i := uint16(0); i < nSel; i++ {
+			toCol[i] = fromCol[sel[i]]
+		}
+	{{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+}
+`
+
+type colVecGen struct {
+	ExecType string
+	GoType   string
+}
+
+func genColVec(wr io.Writer) error {
+	// Build list of all exec types.
+	var gens []colVecGen
+	for _, t := range types.AllTypes {
+		gen := colVecGen{
+			ExecType: t.String(),
+			GoType:   t.GoTypeName(),
+		}
+		gens = append(gens, gen)
+	}
+
+	tmpl, err := template.New("colVecTemplate").Parse(colVecTemplate)
+	if err != nil {
+		return err
+	}
+
+	return tmpl.Execute(wr, gens)
+}
+
+func init() {
+	registerGenerator(genColVec, "colvec.og.go")
+}

--- a/pkg/sql/exec/execgen/cmd/execgen/hashjoiner_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/hashjoiner_gen.go
@@ -1,0 +1,192 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"io"
+	"text/template"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+const hashJoinerTemplate = `
+package exec
+
+import (
+  "fmt"
+	"bytes"
+	"math"
+	
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+// rehash takes a element of a key (tuple representing a row of equality
+// column values) at a given column and computes a new hash by applying a
+// transformation to the existing hash.
+func (ht *hashTable) rehash(
+	buckets []uint64, keyIdx int, t types.T, col ColVec, nKeys uint64, sel []uint16,
+) {
+	switch t {
+	{{range .}}
+		case types.{{.ExecType}}:
+			keys := col.{{.ExecType}}()
+			if sel != nil {
+		  	for i := uint64(0); i < nKeys; i++ {
+					{{if eq .ExecType "Bool"}}
+						if keys[sel[i]] {
+							buckets[i] = buckets[i]*31 + 1
+						}
+					{{else if eq .ExecType "Bytes"}}
+					  hash := 1
+					  for b := range keys[sel[i]] {
+					  	hash = hash*31 + b
+					  }
+					  buckets[i] = buckets[i]*31 + uint64(hash)
+					{{else if (eq .ExecType "Float32")}}
+						buckets[i] = buckets[i]*31 + uint64(math.Float32bits(keys[sel[i]]))
+					{{else if (eq .ExecType "Float64")}}
+						buckets[i] = buckets[i]*31 + math.Float64bits(keys[sel[i]])
+					{{else if (eq .ExecType "Decimal")}}
+						d, err := keys[sel[i]].Float64()
+						if err != nil {
+							panic(fmt.Sprintf("%v", err))
+						}
+						buckets[i] = buckets[i]*31 + math.Float64bits(d)
+					{{else}}
+					  buckets[i] = buckets[i]*31 + uint64(keys[sel[i]])
+					{{end}}
+				}
+			} else {
+		  	for i := uint64(0); i < nKeys; i++ {
+					{{if eq .ExecType "Bool"}}
+						if keys[i] {
+							buckets[i] = buckets[i]*31 + 1
+						}
+					{{else if eq .ExecType "Bytes"}}
+						hash := 1
+						for b := range keys[i] {
+							hash = hash*31 + b
+						}
+						buckets[i] = buckets[i]*31 + uint64(hash)
+					{{else if (eq .ExecType "Float32")}}
+						buckets[i] = buckets[i]*31 + uint64(math.Float32bits(keys[i]))
+					{{else if (eq .ExecType "Float64")}}
+						buckets[i] = buckets[i]*31 + math.Float64bits(keys[i])
+					{{else if (eq .ExecType "Decimal")}}
+						d, err := keys[i].Float64()
+						if err != nil {
+							panic(fmt.Sprintf("%v", err))
+						}
+						buckets[i] = buckets[i]*31 + math.Float64bits(d)
+					{{else}}
+						buckets[i] = buckets[i]*31 + uint64(keys[i])
+					{{end}}
+				}
+			}
+	{{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", t))
+	}
+}
+
+// checkCol determines if the current key column in the groupID buckets
+// matches the specified equality column key. If there is a match, then the key
+// is added to differs. If the bucket has reached the end, the key is rejected.
+func (prober *hashJoinProber) checkCol(t types.T, keyColIdx int, nToCheck uint16, sel []uint16) {
+	switch t {
+	{{range .}}
+		case types.{{.ExecType}}:
+			buildKeys := prober.ht.vals[prober.ht.keyCols[keyColIdx]].{{.ExecType}}()
+			probeKeys := prober.keys[keyColIdx].{{.ExecType}}()
+
+			if sel != nil {
+				for i := uint16(0); i < nToCheck; i++ {
+					// keyID of 0 is reserved to represent the end of the next chain.
+					if keyID := prober.groupID[prober.toCheck[i]]; keyID != 0 {
+						// the build table key (calculated using keys[keyID - 1] = key) is
+						// compared to the corresponding probe table to determine if a match is
+						// found.
+						{{if eq .ExecType "Bytes"}}
+							if !bytes.Equal(buildKeys[keyID-1], probeKeys[sel[prober.toCheck[i]]]) {
+								prober.differs[prober.toCheck[i]] = true
+							}
+						{{else if (eq .ExecType "Decimal")}}
+							if buildKeys[keyID-1].Cmp(&probeKeys[sel[prober.toCheck[i]]]) != 0 {
+								prober.differs[prober.toCheck[i]] = true
+							}
+						{{else}}
+							if buildKeys[keyID-1] != probeKeys[sel[prober.toCheck[i]]] {
+								prober.differs[prober.toCheck[i]] = true
+							}
+						{{end}}
+					}
+				}
+			} else {
+				for i := uint16(0); i < nToCheck; i++ {
+					// keyID of 0 is reserved to represent the end of the next chain.
+					if keyID := prober.groupID[prober.toCheck[i]]; keyID != 0 {
+						// the build table key (calculated using keys[keyID - 1] = key) is
+						// compared to the corresponding probe table to determine if a match is
+						// found.
+						{{if eq .ExecType "Bytes"}}
+							if !bytes.Equal(buildKeys[keyID-1], probeKeys[prober.toCheck[i]]) {
+								prober.differs[prober.toCheck[i]] = true
+							}
+						{{else if (eq .ExecType "Decimal")}}
+							if buildKeys[keyID-1].Cmp(&probeKeys[prober.toCheck[i]]) != 0 {
+								prober.differs[prober.toCheck[i]] = true
+							}
+						{{else}}
+							if buildKeys[keyID-1] != probeKeys[prober.toCheck[i]] {
+								prober.differs[prober.toCheck[i]] = true
+							}
+						{{end}}
+					}
+				}
+			}
+	{{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", t))
+	}
+}
+`
+
+type hashJoinerGen struct {
+	ExecType string
+	GoType   string
+}
+
+func genHashJoinerDistinct(wr io.Writer) error {
+	// Build list of all exec types.
+	var gens []hashJoinerGen
+	for _, t := range types.AllTypes {
+		gen := hashJoinerGen{
+			ExecType: t.String(),
+			GoType:   t.GoTypeName(),
+		}
+		gens = append(gens, gen)
+	}
+
+	tmpl, err := template.New("hashJoinerTemplate").Parse(hashJoinerTemplate)
+	if err != nil {
+		return err
+	}
+
+	return tmpl.Execute(wr, gens)
+}
+
+func init() {
+	registerGenerator(genHashJoinerDistinct, "hashjoiner.og.go")
+}

--- a/pkg/sql/exec/hashjoiner.go
+++ b/pkg/sql/exec/hashjoiner.go
@@ -1,0 +1,632 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+// todo(changangela): support rehashing instead of large fixed bucket size
+const hashTableBucketSize = 1 << 16
+
+// hashJoinerState represents the state of the processor.
+type hashJoinerState int
+
+const (
+
+	// hjBuilding represents the state the hashJoiner when it is in the build
+	// phase. Output columns from the build table are stored and a hash map is
+	// constructed from its equality columns.
+	hjBuilding = iota
+
+	// hjProbing represents the state the hashJoiner is in when it is in the probe
+	// phase. Probing is done in batches and the against the stored hash map.
+	hjProbing
+)
+
+// hashJoinerSpec is the specification for a hash joiner processor. The hash
+// joiner performs an inner join on the left and right's equal columns and
+// returns combined left and right output columns.
+type hashJoinerSpec struct {
+	// left and right are the specifications of the two input table sources to
+	// the hash joiner.
+	left  hashJoinerSourceSpec
+	right hashJoinerSourceSpec
+
+	// buildRightSide indicates whether or not the build table is the right side.
+	// By default, this flag is false and the build table is the left side.
+	buildRightSide bool
+}
+
+type hashJoinerSourceSpec struct {
+	// eqCols specify the indices of the source tables equality column during the
+	// hash join.
+	eqCols []int
+
+	// outCols specify the indices of the columns that should be outputted by the
+	// hash joiner.
+	outCols []int
+
+	// sourceTypes specify the types of the input columns of the source table for
+	// the hash joiner.
+	sourceTypes []types.T
+
+	// source specifies the input operator to the hash join.
+	source Operator
+}
+
+// hashJoinEqInnerDistinctOp performs a hash join on the input tables equality
+// columns. It requires that the build table's equality columns only contain
+// distinct values, otherwise the behavior is undefined. An inner join is
+// performed and there is no guarantee on the ordering of the output columns.
+//
+// Before the build phase, all equality and output columns from the build table
+// are collected and stored.
+//
+// In the vectorized implementation of the build phase, the following tasks are
+// performed:
+// 1. The bucket number (hash value) of each key tuple is computed and stored
+//    into a buckets array.
+// 2. The values in the buckets array is normalized to fit within the hash table
+//    bucketSize.
+// 3. The bucket-chaining hash table organization is prepared with the computed
+//    buckets.
+//
+// In the vectorized implementation of the probe phrase, the following tasks are
+// performed:
+// 1. Compute the bucket number for each probe rows key tuple and store the
+//    results into the buckets array.
+// 2. In order to find the position of these key tuples in the hash table:
+// - First find the first element in the bucket's linked list for each key tuple
+//   and store it in the groupID array. Initialize the toCheck array with the
+//   full sequence of input indices (0...batchSize - 1).
+// - While toCheck is not empty, each element in toCheck represents a position
+//   of the key tuples for which the key has not yet been found in the hash
+//   table. Perform a multi-column equality check to see if the key columns
+//   match that of the build table's key columns at groupID.
+// - Update the differs array to store whether or not the probe's key tuple
+//   matched the corresponding build's key tuple.
+// - Select the indices that differed and store them into toCheck since they
+//   need to be further processed.
+// - For the differing tuples, find the next ID in that bucket of the hash table
+//   and put it into the groupID array.
+// 3. Now, groupID for every probe's key tuple contains the index of the
+//    matching build's key tuple in the hash table. Use it to project output
+//    columns from the has table to build the resulting batch.
+
+type hashJoinEqInnerDistinctOp struct {
+	// spec, if not nil, holds the specification for the current hash joiner
+	// process.
+	spec hashJoinerSpec
+
+	// ht holds the hashTable that is populated during the build
+	// phase and used during the probe phase.
+	ht *hashTable
+
+	// prober, if not nil, stores the batch prober used by the hashJoiner in the
+	// probe phase.
+	prober *hashJoinProber
+
+	// runningState stores the current state hashJoiner.
+	runningState hashJoinerState
+}
+
+var _ Operator = &hashJoinEqInnerDistinctOp{}
+
+func (hj *hashJoinEqInnerDistinctOp) Init() {
+	hj.spec.left.source.Init()
+	hj.spec.right.source.Init()
+
+	nOutCols := len(hj.spec.left.outCols) + len(hj.spec.right.outCols)
+	if nOutCols == 0 {
+		panic("no output columns specified for hash joiner")
+	}
+
+	// Prepare the hashTable using the specified side as the build table. Prepare
+	// the prober using the other side as the probe table.
+	if hj.spec.buildRightSide {
+		hj.ht = makeHashTable(hashTableBucketSize, hj.spec.right.sourceTypes, hj.spec.right.eqCols, hj.spec.right.outCols)
+		hj.prober = makeHashJoinProber(hj.ht, hj.spec.left, hj.spec.right.sourceTypes, hj.spec.right.outCols, true)
+	} else {
+		hj.ht = makeHashTable(hashTableBucketSize, hj.spec.left.sourceTypes, hj.spec.left.eqCols, hj.spec.left.outCols)
+		hj.prober = makeHashJoinProber(hj.ht, hj.spec.right, hj.spec.left.sourceTypes, hj.spec.left.outCols, false)
+	}
+
+	hj.runningState = hjBuilding
+}
+
+func (hj *hashJoinEqInnerDistinctOp) Next() ColBatch {
+	switch hj.runningState {
+	case hjBuilding:
+		hj.build()
+		fallthrough
+	case hjProbing:
+		return hj.prober.probe()
+	default:
+		panic("hash joiner in unhandled state")
+	}
+}
+
+func (hj *hashJoinEqInnerDistinctOp) build() {
+	builder := makeHashJoinBuilder(hj.ht)
+
+	if hj.spec.buildRightSide {
+		builder.exec(hj.spec.right.source, hj.spec.right.eqCols, hj.spec.right.outCols)
+	} else {
+		builder.exec(hj.spec.left.source, hj.spec.left.eqCols, hj.spec.left.outCols)
+	}
+
+	hj.runningState = hjProbing
+}
+
+// hashTable is a structure used by the hash joiner to store the build table
+// batches. Keys are stored according to the encoding of the equality column,
+// which point to the corresponding output keyID. The keyID is calculated
+// using the below equation:
+//
+// keyID = keys.indexOf(key) + 1
+//
+// and inversely:
+//
+// keys[keyID - 1] = key
+//
+// The table can then be probed in column batches to find at most one matching
+// row per column batch row.
+type hashTable struct {
+	// first stores the keyID of the first key that resides in each bucket. This
+	// keyID is used to determine the corresponding equality column key as well
+	// as output column values.
+	first []uint64
+
+	// next is a densely-packed list that stores the keyID of the next key in the
+	// hash table bucket chain, where an id of 0 is reserved to represent end of
+	// chain.
+	next []uint64
+
+	// vals stores the union of the equality and output columns of the left
+	// table. A key tuple is defined as the elements in each row of vals that
+	// makes up the equality columns. The ID of a key at any index of vals is
+	// index + 1.
+	vals []ColVec
+
+	// keyCols stores the indices of vals which are key columns.
+	keyCols []int
+	// keyTypes stores the corresponding types of the key columns.
+	keyTypes []types.T
+
+	// outCols stores the indices of vals which are output columns.
+	outCols []int
+	// outTypes stores the corresponding type of each output column.
+	outTypes []types.T
+
+	// size returns the total number of keyCols the hashTable currently stores.
+	size uint64
+	// bucketSize returns the number of buckets the hashTable employs. This is
+	// equivalent to the size of first.
+	bucketSize uint64
+}
+
+func makeHashTable(
+	bucketSize uint64, sourceTypes []types.T, eqCols []int, outCols []int,
+) *hashTable {
+	// Compute the union of eqCols and outCols and compress vals to only keep the
+	// important columns.
+	nCols := len(sourceTypes)
+	keepCol := make([]bool, nCols)
+	compressed := make([]int, nCols)
+
+	for _, colIdx := range eqCols {
+		keepCol[colIdx] = true
+	}
+
+	for _, colIdx := range outCols {
+		keepCol[colIdx] = true
+	}
+
+	// Extract the important columns and discard the rest.
+	cols := make([]ColVec, 0)
+	nKeep := 0
+	for i := 0; i < nCols; i++ {
+		if keepCol[i] {
+			cols = append(cols, newMemColumn(sourceTypes[i], 0))
+			compressed[i] = nKeep
+			nKeep++
+		}
+	}
+
+	// Extract and types and indices of the eqCols and outCols.
+	nKeys := len(eqCols)
+	keyTypes := make([]types.T, nKeys)
+	keys := make([]int, nKeys)
+	for i, colIdx := range eqCols {
+		keyTypes[i] = sourceTypes[colIdx]
+		keys[i] = compressed[colIdx]
+	}
+
+	nOutCols := len(outCols)
+	outTypes := make([]types.T, nOutCols)
+	outs := make([]int, nOutCols)
+	for i, colIdx := range outCols {
+		outTypes[i] = sourceTypes[colIdx]
+		outs[i] = compressed[colIdx]
+	}
+
+	return &hashTable{
+		first: make([]uint64, bucketSize),
+
+		vals: cols,
+
+		keyCols:  keys,
+		keyTypes: keyTypes,
+
+		outCols:  outs,
+		outTypes: outTypes,
+
+		bucketSize: bucketSize,
+	}
+}
+
+// loadBatch appends a new batch of keys and outputs to the existing keys and
+// output columns.
+func (ht *hashTable) loadBatch(batch ColBatch, eqCols []int, outCols []int) {
+	batchSize := batch.Length()
+	sel := batch.Selection()
+
+	if sel != nil {
+		for i, colIdx := range eqCols {
+			ht.vals[ht.keyCols[i]].AppendWithSel(batch.ColVec(colIdx), sel, batchSize, ht.keyTypes[i], ht.size)
+		}
+
+		for i, colIdx := range outCols {
+			ht.vals[ht.outCols[i]].AppendWithSel(batch.ColVec(colIdx), sel, batchSize, ht.outTypes[i], ht.size)
+		}
+	} else {
+		for i, colIdx := range eqCols {
+			ht.vals[ht.keyCols[i]].Append(batch.ColVec(colIdx), ht.keyTypes[i], ht.size, batchSize)
+		}
+
+		for i, colIdx := range outCols {
+			ht.vals[ht.outCols[i]].Append(batch.ColVec(colIdx), ht.outTypes[i], ht.size, batchSize)
+		}
+	}
+
+	ht.size += uint64(batchSize)
+}
+
+// initHash, rehash, and finalizeHash work together to compute the hash value
+// for an individual key tuple which represents a row's equality columns. Since this
+// key is a tuple of various types, rehash is used to apply a transformation on
+// the resulting hash value based on an element of the key of a specified type.
+//
+// The current integer tuple hashing heuristic is based off of Java's
+// Arrays.hashCode(int[]) and only supports int8, int16, int32, and int64
+// elements. float32 and float64 are hashed according to their respective 32-bit
+// and 64-bit integer representation. bool keys are hashed as a 1 for true and 0
+// for false. bytes are hashed as an array of int8 integers.
+//
+// initHash initializes the hash value of each key to its initial state for
+// rehashing purposes.
+func (ht *hashTable) initHash(buckets []uint64, nKeys uint64) {
+	for i := uint64(0); i < nKeys; i++ {
+		buckets[i] = 1
+	}
+}
+
+// rehash takes a element of a key (tuple representing a row of equality
+// column values) at a given column and computes a new hash by applying a
+// transformation to the existing hash. This function is generated by execgen.
+
+// finalizeHash takes each key's hash value and applies a final transformation
+// onto it so that it fits within the hashTable's bucket size.
+func (ht *hashTable) finalizeHash(buckets []uint64, nKeys uint64) {
+	for i := uint64(0); i < nKeys; i++ {
+		// Since bucketSize is a power of 2, modulo bucketSize could be optimized
+		// into a bitwise operation which improves benchmark performance by 20%.
+		// In effect, the following code is equivalent to (but faster than):
+		// buckets[i] = buckets[i] % ht.bucketSize
+		buckets[i] = buckets[i] & (ht.bucketSize - 1)
+	}
+}
+
+// computeBuckets computes the hash value of each key and stores the result in
+// buckets.
+func (ht *hashTable) computeBuckets(buckets []uint64, keys []ColVec, nKeys uint64, sel []uint16) {
+	ht.initHash(buckets, nKeys)
+	for i, t := range ht.keyTypes {
+		ht.rehash(buckets, i, t, keys[i], nKeys, sel)
+	}
+	ht.finalizeHash(buckets, nKeys)
+}
+
+// insertKeys builds the hash map from the compute hash values.
+func (ht *hashTable) insertKeys(buckets []uint64) {
+	ht.next = make([]uint64, ht.size+1)
+
+	for id := uint64(1); id <= ht.size; id++ {
+		// keyID is stored into corresponding hash bucket at the front of the next
+		// chain.
+		ht.next[id] = ht.first[buckets[id-1]]
+		ht.first[buckets[id-1]] = id
+	}
+}
+
+// hashJoinBuilder is used by the hashJoiner during the build phase. It
+// pre-loads all batches from the build relation before building the hash table.
+type hashJoinBuilder struct {
+	ht *hashTable
+}
+
+func makeHashJoinBuilder(ht *hashTable) *hashJoinBuilder {
+	return &hashJoinBuilder{
+		ht: ht,
+	}
+}
+
+// exec executes the entirety of the hash table build phase using the source as
+// the build relation. The source operator is entirely consumed in the process.
+func (builder *hashJoinBuilder) exec(source Operator, eqCols []int, outCols []int) {
+	for {
+		batch := source.Next()
+
+		if batch.Length() == 0 {
+			break
+		}
+
+		builder.ht.loadBatch(batch, eqCols, outCols)
+	}
+
+	// buckets is used to store the computed hash value of each key.
+	nKeys := len(eqCols)
+	keyCols := make([]ColVec, nKeys)
+	for i := 0; i < nKeys; i++ {
+		keyCols[i] = builder.ht.vals[builder.ht.keyCols[i]]
+	}
+
+	buckets := make([]uint64, builder.ht.size)
+	builder.ht.computeBuckets(buckets, keyCols, builder.ht.size, nil)
+	builder.ht.insertKeys(buckets)
+}
+
+// hashJoinProber is used by the hashJoinEqInnerDistinctOp during the probe phase. It
+// operates on a single batch of obtained from the probe relation and probes the
+// hashTable to construct the resulting output batch.
+type hashJoinProber struct {
+	ht *hashTable
+
+	// batch stores the resulting output batch that is constructed and returned
+	// for every input batch during the probe phase.
+	batch ColBatch
+
+	// groupID stores the keyID that maps to the joining rows of the build table.
+	// The ith element of groupID stores the keyID of the build table that
+	// corresponds to the ith key in the probe table.
+	groupID []uint64
+	// toCheck stores the indices of the eqCol rows that have yet to be found or
+	// rejected.
+	toCheck []uint16
+
+	// differs stores whether the key at any index differs with the build table
+	// key.
+	differs []bool
+
+	buildIdx []uint64
+	probeIdx []uint16
+
+	// keyCols stores the equality columns on the probe table for a single batch.
+	keys []ColVec
+	// buckets is used to store the computed hash value of each key in a single
+	// batch.
+	buckets []uint64
+
+	// spec holds the specifications for the source operator used in the probe
+	// phase.
+	spec hashJoinerSourceSpec
+
+	//nBuildCols stores the number of columns in the build table.
+	nBuildCols int
+	// buildOutCols stores the indices of the output columns for the build table.
+	buildOutCols []int
+
+	// probeLeftSide indicates whether the prober is probing on the left source or
+	// the right source.
+	probeLeftSide bool
+}
+
+func makeHashJoinProber(
+	ht *hashTable,
+	probe hashJoinerSourceSpec,
+	buildColTypes []types.T,
+	buildOutCols []int,
+	probeLeftSide bool,
+) *hashJoinProber {
+	// Prepare the output batch by allocating with the correct column types.
+	var outColTypes []types.T
+	if probeLeftSide {
+		outColTypes = append(probe.sourceTypes, buildColTypes...)
+	} else {
+		outColTypes = append(buildColTypes, probe.sourceTypes...)
+	}
+
+	return &hashJoinProber{
+		ht: ht,
+
+		batch: NewMemBatch(outColTypes),
+
+		groupID: make([]uint64, ColBatchSize),
+		toCheck: make([]uint16, ColBatchSize),
+		differs: make([]bool, ColBatchSize),
+
+		buildIdx: make([]uint64, ColBatchSize),
+		probeIdx: make([]uint16, ColBatchSize),
+
+		keys:    make([]ColVec, len(probe.eqCols)),
+		buckets: make([]uint64, ColBatchSize),
+
+		spec: probe,
+
+		nBuildCols:   len(buildColTypes),
+		buildOutCols: buildOutCols,
+
+		probeLeftSide: probeLeftSide,
+	}
+}
+
+// probe returns a ColBatch with N + M columns where N is the number of left
+// source columns and M is the number of right source columns. The first N
+// columns correspond to the respective left source columns, followed by the
+// right source columns as the last M elements. Even though all the columns are
+// present in the result, only the specified output columns store relevant
+// information. The remaining columns are there as dummy columns and their
+// states are undefined.
+func (prober *hashJoinProber) probe() ColBatch {
+	prober.batch.SetLength(0)
+
+	for {
+		batch := prober.spec.source.Next()
+		batchSize := batch.Length()
+
+		if batchSize == 0 {
+			break
+		}
+
+		for i, colIdx := range prober.spec.eqCols {
+			prober.keys[i] = batch.ColVec(colIdx)
+		}
+
+		sel := batch.Selection()
+
+		// initialize groupID with the initial hash buckets and toCheck with all
+		// applicable indices.
+		prober.lookupInitial(batchSize, sel)
+		nToCheck := batchSize
+
+		// continue searching along the hash table next chains for the corresponding
+		// buckets. If the key is found or end of next chain is reached, the key is
+		// removed from the toCheck array.
+		for nToCheck > 0 {
+			nToCheck = prober.check(nToCheck, sel)
+			prober.findNext(nToCheck)
+		}
+
+		prober.collectResults(batch, batchSize, sel)
+
+		// since is possible for the hash join to return an empty group, we should
+		// loop until we have a non-empty output batch, or an empty input batch.
+		// Otherwise, the client will assume that the ColBatch is completely
+		// consumed when it isn't.
+		if prober.batch.Length() > 0 {
+			// todo (changangela): add buffering to return batches of equal length on
+			// each call to Next()
+			break
+		}
+	}
+
+	return prober.batch
+}
+
+// lookupInitial finds the corresponding hash table buckets for the equality
+// column of the batch and stores the results in groupID. It also initializes
+// toCheck with all indices in the range [0, batchSize).
+func (prober *hashJoinProber) lookupInitial(batchSize uint16, sel []uint16) {
+	prober.ht.computeBuckets(prober.buckets, prober.keys, uint64(batchSize), sel)
+	for i := uint16(0); i < batchSize; i++ {
+		prober.groupID[i] = prober.ht.first[prober.buckets[i]]
+		prober.toCheck[i] = i
+	}
+}
+
+// check determines if the current key in the groupID buckets matches the
+// equality column key. If there is a match, then the key is removed from
+// toCheck. If the bucket has reached the end, the key is rejected. The toCheck
+// list is reconstructed to only hold the indices of the eqCol keys that have
+// not been found. The new length of toCheck is returned by this function.
+func (prober *hashJoinProber) check(nToCheck uint16, sel []uint16) uint16 {
+	for i, t := range prober.ht.keyTypes {
+		prober.checkCol(t, i, nToCheck, sel)
+	}
+
+	// select the indices that differ and put them into toCheck.
+	nDiffers := uint16(0)
+	for i := uint16(0); i < nToCheck; i++ {
+		if prober.differs[prober.toCheck[i]] {
+			prober.differs[prober.toCheck[i]] = false
+			prober.toCheck[nDiffers] = prober.toCheck[i]
+			nDiffers++
+		}
+	}
+
+	return nDiffers
+}
+
+// findNext determines the id of the next key inside the groupID buckets for
+// each equality column key in toCheck.
+func (prober *hashJoinProber) findNext(nToCheck uint16) {
+	for i := uint16(0); i < nToCheck; i++ {
+		prober.groupID[prober.toCheck[i]] = prober.ht.next[prober.groupID[prober.toCheck[i]]]
+	}
+}
+
+// collectResults prepares the batch with the joined output columns where the
+// build row index for each probe row is given in the groupID slice.
+func (prober *hashJoinProber) collectResults(batch ColBatch, batchSize uint16, sel []uint16) {
+	nResults := uint16(0)
+
+	if sel != nil {
+		for i := uint16(0); i < batchSize; i++ {
+			if prober.groupID[i] != 0 {
+				// Index of keys and outputs in the hash table is calculated as ID - 1.
+				prober.buildIdx[nResults] = prober.groupID[i] - 1
+				prober.probeIdx[nResults] = sel[i]
+				nResults++
+			}
+		}
+	} else {
+		for i := uint16(0); i < batchSize; i++ {
+			if prober.groupID[i] != 0 {
+				// Index of keys and outputs in the hash table is calculated as ID - 1.
+				prober.buildIdx[nResults] = prober.groupID[i] - 1
+				prober.probeIdx[nResults] = i
+				nResults++
+			}
+		}
+	}
+
+	// Stitch together the resulting inner join rows and add them to the output
+	// batch with the left table columns preceding right table columns.
+	var buildColOffset, probeColOffset int
+	if prober.probeLeftSide {
+		buildColOffset = len(prober.spec.sourceTypes)
+		probeColOffset = 0
+	} else {
+		buildColOffset = 0
+		probeColOffset = prober.nBuildCols
+	}
+
+	for i, colIdx := range prober.buildOutCols {
+		outCol := prober.batch.ColVec(colIdx + buildColOffset)
+		valCol := prober.ht.vals[prober.ht.outCols[i]]
+		colType := prober.ht.outTypes[i]
+		outCol.CopyWithSelInt64(valCol, prober.buildIdx, nResults, colType)
+	}
+
+	for _, colIdx := range prober.spec.outCols {
+		outCol := prober.batch.ColVec(colIdx + probeColOffset)
+		valCol := batch.ColVec(colIdx)
+		colType := prober.spec.sourceTypes[colIdx]
+		outCol.CopyWithSelInt16(valCol, prober.probeIdx, nResults, colType)
+	}
+
+	prober.batch.SetLength(nResults)
+}

--- a/pkg/sql/exec/hashjoiner_test.go
+++ b/pkg/sql/exec/hashjoiner_test.go
@@ -1,0 +1,437 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/apd"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestHashJoinerInt64(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Set up the apd.Decimal values used in tests.
+	floats := []float64{0.314, 3.14, 31.4, 314}
+	decs := make([]apd.Decimal, len(floats))
+	for i, f := range floats {
+		_, err := decs[i].SetFloat64(f)
+		if err != nil {
+			panic(fmt.Sprintf("%v", err))
+		}
+	}
+
+	tcs := []struct {
+		leftTypes  []types.T
+		rightTypes []types.T
+
+		leftTuples  tuples
+		rightTuples tuples
+
+		leftEqCols  []int
+		rightEqCols []int
+
+		leftOutCols  []int
+		rightOutCols []int
+
+		buildRightSide bool
+
+		expectedTuples tuples
+	}{
+		{
+			// Test handling of various output column types.
+			leftTypes:  []types.T{types.Bool, types.Int64, types.Bytes, types.Int64},
+			rightTypes: []types.T{types.Int64, types.Float64, types.Int32},
+
+			leftTuples: tuples{
+				{false, 5, "a", 10},
+				{true, 3, "b", 30},
+				{false, 2, "foo", 20},
+				{false, 6, "bar", 50},
+			},
+			rightTuples: tuples{
+				{1, 1.1, int32(1)},
+				{2, 2.2, int32(2)},
+				{3, 3.3, int32(4)},
+				{4, 4.4, int32(8)},
+				{5, 5.5, int32(16)},
+			},
+
+			leftEqCols:   []int{1},
+			rightEqCols:  []int{0},
+			leftOutCols:  []int{1, 2},
+			rightOutCols: []int{0, 2},
+
+			expectedTuples: tuples{
+				{2, "foo", 2, int32(2)},
+				{3, "b", 3, int32(4)},
+				{5, "a", 5, int32(16)},
+			},
+		},
+		{
+			leftTypes:  []types.T{types.Int64},
+			rightTypes: []types.T{types.Int64},
+
+			// Reverse engineering hash table hash heuristic to find key values that
+			// hash to the same bucket.
+			leftTuples: tuples{
+				{0},
+				{hashTableBucketSize},
+				{hashTableBucketSize * 2},
+				{hashTableBucketSize * 3},
+			},
+			rightTuples: tuples{
+				{0},
+				{hashTableBucketSize},
+				{hashTableBucketSize * 3},
+			},
+
+			leftEqCols:   []int{0},
+			rightEqCols:  []int{0},
+			leftOutCols:  []int{0},
+			rightOutCols: []int{},
+
+			expectedTuples: tuples{
+				{0},
+				{hashTableBucketSize},
+				{hashTableBucketSize * 3},
+			},
+		},
+		{
+			leftTypes:  []types.T{types.Int64},
+			rightTypes: []types.T{types.Int64},
+
+			// Test a N:1 inner join where the right side key has duplicate values.
+			leftTuples: tuples{
+				{0},
+				{1},
+				{2},
+				{3},
+				{4},
+			},
+			rightTuples: tuples{
+				{1},
+				{1},
+				{1},
+				{2},
+				{2},
+			},
+
+			leftEqCols:   []int{0},
+			rightEqCols:  []int{0},
+			leftOutCols:  []int{0},
+			rightOutCols: []int{0},
+
+			expectedTuples: tuples{
+				{1, 1},
+				{1, 1},
+				{1, 1},
+				{2, 2},
+				{2, 2},
+			},
+		},
+		{
+			leftTypes:  []types.T{types.Int64, types.Int64, types.Int64},
+			rightTypes: []types.T{types.Int64, types.Int64, types.Int64},
+
+			// Test inner join on multiple equality columns.
+			leftTuples: tuples{
+				{0, 0, 10},
+				{0, 1, 20},
+				{0, 2, 30},
+				{1, 1, 40},
+				{1, 2, 50},
+				{2, 0, 60},
+				{2, 1, 70},
+			},
+			rightTuples: tuples{
+				{0, 100, 2},
+				{1, 200, 1},
+				{2, 300, 0},
+				{2, 400, 1},
+			},
+
+			leftEqCols:   []int{0, 1},
+			rightEqCols:  []int{0, 2},
+			leftOutCols:  []int{0, 1, 2},
+			rightOutCols: []int{1},
+
+			expectedTuples: tuples{
+				{0, 2, 30, 100},
+				{1, 1, 40, 200},
+				{2, 0, 60, 300},
+				{2, 1, 70, 400},
+			},
+		},
+		{
+			leftTypes:  []types.T{types.Int64, types.Int64, types.Int64},
+			rightTypes: []types.T{types.Int64, types.Int64},
+
+			// Test multiple column with values that hash to the same bucket.
+			leftTuples: tuples{
+				{10, 0, 0},
+				{20, 0, hashTableBucketSize},
+				{40, hashTableBucketSize, 0},
+				{50, hashTableBucketSize, hashTableBucketSize},
+				{60, hashTableBucketSize * 2, 0},
+				{70, hashTableBucketSize * 2, hashTableBucketSize},
+			},
+			rightTuples: tuples{
+				{0, hashTableBucketSize},
+				{hashTableBucketSize * 2, hashTableBucketSize},
+				{0, 0},
+				{0, hashTableBucketSize * 2},
+			},
+
+			leftEqCols:   []int{1, 2},
+			rightEqCols:  []int{0, 1},
+			leftOutCols:  []int{0, 1, 2},
+			rightOutCols: []int{},
+
+			expectedTuples: tuples{
+				{20, 0, hashTableBucketSize},
+				{70, hashTableBucketSize * 2, hashTableBucketSize},
+				{10, 0, 0},
+			},
+		},
+		{
+			leftTypes:  []types.T{types.Bytes, types.Bool, types.Int8, types.Int16, types.Int32, types.Int64, types.Bytes},
+			rightTypes: []types.T{types.Int64, types.Int32, types.Int16, types.Int8, types.Bool, types.Bytes},
+
+			// Test multiple equality columns of different types.
+			leftTuples: tuples{
+				{"foo", false, int8(10), int16(100), int32(1000), int64(10000), "aaa"},
+				{"foo", true, 10, 100, 1000, 10000, "bbb"},
+				{"foo1", false, 10, 100, 1000, 10000, "ccc"},
+				{"foo", false, 20, 100, 1000, 10000, "ddd"},
+				{"foo", false, 10, 200, 1000, 10000, "eee"},
+				{"bar", true, 30, 300, 3000, 30000, "fff"},
+			},
+			rightTuples: tuples{
+				{int64(10000), int32(1000), int16(100), int8(10), false, "foo1"},
+				{10000, 1000, 100, 10, false, "foo"},
+				{30000, 3000, 300, 30, true, "bar"},
+				{10000, 1000, 100, 20, false, "foo"},
+				{30000, 3000, 300, 30, false, "bar"},
+				{10000, 1000, 100, 10, false, "random"},
+			},
+
+			leftEqCols:   []int{0, 1, 2, 3, 4, 5},
+			rightEqCols:  []int{5, 4, 3, 2, 1, 0},
+			leftOutCols:  []int{6},
+			rightOutCols: []int{},
+
+			expectedTuples: tuples{
+				{"ccc"},
+				{"aaa"},
+				{"fff"},
+				{"ddd"},
+			},
+		},
+		{
+			leftTypes:  []types.T{types.Float32, types.Float64},
+			rightTypes: []types.T{types.Float64, types.Float32},
+
+			// Test equality columns of type float.
+			leftTuples: tuples{
+				{float32(1.1), float64(33.333)},
+				{float32(1.1), float64(44.4444)},
+				{float32(2.22), float64(55.55555)},
+				{float32(2.22), float64(44.4444)},
+			},
+			rightTuples: tuples{
+				{float64(44.4444), float32(2.22)},
+				{float64(55.55555), float32(1.1)},
+				{float64(33.333), float32(1.1)},
+			},
+
+			leftEqCols:   []int{0, 1},
+			rightEqCols:  []int{1, 0},
+			leftOutCols:  []int{0, 1},
+			rightOutCols: []int{},
+
+			expectedTuples: tuples{
+				{float32(2.22), float64(44.4444)},
+				{float32(1.1), float64(33.333)},
+			},
+		},
+		{
+			leftTypes:  []types.T{types.Int64, types.Int64, types.Int64, types.Int64},
+			rightTypes: []types.T{types.Int64, types.Int64, types.Int64, types.Int64},
+
+			// Test use right side as build table.
+			leftTuples: tuples{
+				{2, 4, 8, 16},
+				{3, 3, 2, 2},
+				{3, 7, 2, 1},
+				{5, 4, 3, 2},
+			},
+			rightTuples: tuples{
+				{1, 3, 5, 7},
+				{1, 1, 1, 1},
+				{1, 2, 3, 4},
+			},
+
+			leftEqCols:   []int{2, 0},
+			rightEqCols:  []int{1, 2},
+			leftOutCols:  []int{0, 1, 2, 3},
+			rightOutCols: []int{0, 1, 2, 3},
+
+			buildRightSide: true,
+
+			expectedTuples: tuples{
+				{3, 3, 2, 2, 1, 2, 3, 4},
+				{3, 7, 2, 1, 1, 2, 3, 4},
+				{5, 4, 3, 2, 1, 3, 5, 7},
+			},
+		},
+		{
+			leftTypes:  []types.T{types.Decimal},
+			rightTypes: []types.T{types.Decimal},
+
+			// Test types.Decimal type as equality column.
+			leftTuples: tuples{
+				{decs[0]},
+				{decs[1]},
+				{decs[2]},
+			},
+			rightTuples: tuples{
+				{decs[2]},
+				{decs[3]},
+				{decs[0]},
+			},
+
+			leftEqCols:   []int{0},
+			rightEqCols:  []int{0},
+			leftOutCols:  []int{},
+			rightOutCols: []int{0},
+
+			expectedTuples: tuples{
+				{decs[2]},
+				{decs[0]},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		inputs := []tuples{tc.leftTuples, tc.rightTuples}
+		runTests(t, inputs, []types.T{types.Bool}, func(t *testing.T, sources []Operator) {
+			leftSource, rightSource := sources[0], sources[1]
+
+			spec := hashJoinerSpec{
+				left: hashJoinerSourceSpec{
+					eqCols:      tc.leftEqCols,
+					outCols:     tc.leftOutCols,
+					sourceTypes: tc.leftTypes,
+					source:      leftSource,
+				},
+
+				right: hashJoinerSourceSpec{
+					eqCols:      tc.rightEqCols,
+					outCols:     tc.rightOutCols,
+					sourceTypes: tc.rightTypes,
+					source:      rightSource,
+				},
+
+				buildRightSide: tc.buildRightSide,
+			}
+
+			hj := &hashJoinEqInnerDistinctOp{
+				spec: spec,
+			}
+
+			nOutCols := len(tc.leftOutCols) + len(tc.rightOutCols)
+			nLeftOutCols := len(tc.leftOutCols)
+			nLeftCols := len(tc.leftTypes)
+
+			cols := make([]int, nOutCols)
+			copy(cols, tc.leftOutCols)
+
+			for i, colIdx := range tc.rightOutCols {
+				cols[i+nLeftOutCols] = colIdx + nLeftCols
+			}
+
+			out := newOpTestOutput(hj, cols, tc.expectedTuples)
+
+			if err := out.Verify(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func BenchmarkHashJoiner(b *testing.B) {
+	nCols := 4
+	sourceTypes := make([]types.T, nCols)
+
+	for colIdx := 0; colIdx < nCols; colIdx++ {
+		sourceTypes[colIdx] = types.Int64
+	}
+
+	batch := NewMemBatch(sourceTypes)
+
+	for colIdx := 0; colIdx < nCols; colIdx++ {
+		col := batch.ColVec(colIdx).Int64()
+		for i := 0; i < ColBatchSize; i++ {
+			col[i] = int64(i)
+		}
+	}
+
+	batch.SetLength(ColBatchSize)
+
+	for _, nBatches := range []int{1 << 1, 1 << 2, 1 << 4, 1 << 8, 1 << 12, 1 << 16} {
+		b.Run(fmt.Sprintf("rows=%d", nBatches*ColBatchSize), func(b *testing.B) {
+			// 8 (bytes / int64) * nBatches (number of batches) * ColBatchSize (rows /
+			// batch) * nCols (number of columns / row) * 2 (number of sources).
+			b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols * 2))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				leftSource := newFiniteBatchSource(batch, nBatches)
+				rightSource := newRepeatableBatchSource(batch)
+
+				spec := hashJoinerSpec{
+					left: hashJoinerSourceSpec{
+						eqCols:      []int{0, 2},
+						outCols:     []int{0, 1},
+						sourceTypes: sourceTypes,
+						source:      leftSource,
+					},
+
+					right: hashJoinerSourceSpec{
+						eqCols:      []int{1, 3},
+						outCols:     []int{2, 3},
+						sourceTypes: sourceTypes,
+						source:      rightSource,
+					},
+				}
+
+				hj := &hashJoinEqInnerDistinctOp{
+					spec: spec,
+				}
+
+				hj.Init()
+
+				for i := 0; i < nBatches; i++ {
+					hj.Next()
+				}
+			}
+		})
+	}
+}

--- a/pkg/sql/exec/projection_ops_test.go
+++ b/pkg/sql/exec/projection_ops_test.go
@@ -22,9 +22,9 @@ import (
 )
 
 func TestProjPlusInt64Int64ConstOp(t *testing.T) {
-	runTests(t, tuples{{1}, {2}}, []types.T{types.Int64}, func(t *testing.T, input Operator) {
+	runTests(t, []tuples{{{1}, {2}}}, []types.T{types.Int64}, func(t *testing.T, input []Operator) {
 		op := projPlusInt64Int64ConstOp{
-			input:     input,
+			input:     input[0],
 			colIdx:    0,
 			constArg:  1,
 			outputIdx: 1,
@@ -38,9 +38,9 @@ func TestProjPlusInt64Int64ConstOp(t *testing.T) {
 }
 
 func TestProjPlusInt64Int64Op(t *testing.T) {
-	runTests(t, tuples{{1, 2}, {3, 4}}, []types.T{types.Int64}, func(t *testing.T, input Operator) {
+	runTests(t, []tuples{{{1, 2}, {3, 4}}}, []types.T{types.Int64}, func(t *testing.T, input []Operator) {
 		op := projPlusInt64Int64Op{
-			input:     input,
+			input:     input[0],
 			col1Idx:   0,
 			col2Idx:   1,
 			outputIdx: 2,

--- a/pkg/sql/exec/selection_ops_test.go
+++ b/pkg/sql/exec/selection_ops_test.go
@@ -23,9 +23,9 @@ import (
 
 func TestSelLTInt64Int64ConstOp(t *testing.T) {
 	tups := tuples{{0}, {1}, {2}}
-	runTests(t, tups, nil /* extraTypes */, func(t *testing.T, input Operator) {
+	runTests(t, []tuples{tups}, nil /* extraTypes */, func(t *testing.T, input []Operator) {
 		op := selLTInt64Int64ConstOp{
-			input:    input,
+			input:    input[0],
 			colIdx:   0,
 			constArg: 2,
 		}
@@ -44,9 +44,9 @@ func TestSelLTInt64Int64(t *testing.T) {
 		{1, 0},
 		{1, 1},
 	}
-	runTests(t, tups, nil /* extraTypes */, func(t *testing.T, input Operator) {
+	runTests(t, []tuples{tups}, nil /* extraTypes */, func(t *testing.T, input []Operator) {
 		op := selLTInt64Int64Op{
-			input:   input,
+			input:   input[0],
 			col1Idx: 0,
 			col2Idx: 1,
 		}

--- a/pkg/sql/exec/simple_project_test.go
+++ b/pkg/sql/exec/simple_project_test.go
@@ -61,8 +61,8 @@ func TestSimpleProjectOp(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		runTests(t, tc.tuples, []types.T{}, func(t *testing.T, input Operator) {
-			count := NewSimpleProjectOp(input, tc.colsToKeep)
+		runTests(t, []tuples{tc.tuples}, []types.T{}, func(t *testing.T, input []Operator) {
+			count := NewSimpleProjectOp(input[0], tc.colsToKeep)
 			out := newOpTestOutput(count, []int{0, 1}, tc.expected)
 
 			if err := out.Verify(); err != nil {
@@ -72,8 +72,8 @@ func TestSimpleProjectOp(t *testing.T) {
 	}
 
 	// Empty projection.
-	runTests(t, tuples{{1, 2, 3}, {1, 2, 3}}, []types.T{}, func(t *testing.T, input Operator) {
-		count := NewSimpleProjectOp(input, nil)
+	runTests(t, []tuples{{{1, 2, 3}, {1, 2, 3}}}, []types.T{}, func(t *testing.T, input []Operator) {
+		count := NewSimpleProjectOp(input[0], nil)
 		out := newOpTestOutput(count, []int{}, tuples{{}, {}})
 		if err := out.Verify(); err != nil {
 			t.Fatal(err)

--- a/pkg/sql/exec/sum_int_test.go
+++ b/pkg/sql/exec/sum_int_test.go
@@ -131,9 +131,9 @@ func TestSumInt(t *testing.T) {
 	for _, tc := range testCases {
 		tc.name = fmt.Sprintf("%s/Random", tc.name)
 		t.Run(tc.name, func(t *testing.T) {
-			runTests(t, tc.input, nil, func(t *testing.T, input Operator) {
+			runTests(t, []tuples{tc.input}, nil, func(t *testing.T, input []Operator) {
 				a := &sumInt64Agg{
-					input: input,
+					input: input[0],
 				}
 				outputBatchSize := tc.outputBatchSize
 				if outputBatchSize == 0 {

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -34,23 +34,27 @@ type tuples []tuple
 
 // runTests is a helper that automatically runs your tests with varied batch
 // sizes and with and without a random selection vector.
-// Provide a test function that takes an input Operator, which will give back
-// the tuples provided in batches.
+// Provide a test function that takes a list of input Operators, which will give
+// back the tuples provided in batches.
 func runTests(
-	t *testing.T, tups tuples, extraTypes []types.T, test func(t *testing.T, input Operator),
+	t *testing.T, tups []tuples, extraTypes []types.T, test func(t *testing.T, inputs []Operator),
 ) {
 	rng, _ := randutil.NewPseudoRand()
 
 	for _, batchSize := range []uint16{1, 2, 3, 16, 1024} {
 		for _, useSel := range []bool{false, true} {
 			t.Run(fmt.Sprintf("batchSize=%d/sel=%t", batchSize, useSel), func(t *testing.T) {
-				var tupleSource Operator
+				inputSources := make([]Operator, len(tups))
 				if useSel {
-					tupleSource = newOpTestSelInput(rng, batchSize, tups, extraTypes...)
+					for i, tup := range tups {
+						inputSources[i] = newOpTestSelInput(rng, batchSize, tup, extraTypes...)
+					}
 				} else {
-					tupleSource = newOpTestInput(batchSize, tups, extraTypes...)
+					for i, tup := range tups {
+						inputSources[i] = newOpTestInput(batchSize, tup, extraTypes...)
+					}
 				}
-				test(t, tupleSource)
+				test(t, inputSources)
 			})
 		}
 	}
@@ -144,7 +148,7 @@ func (s *opTestInput) Next() ColBatch {
 	tupleLen := len(tups[0])
 	for i := range tups {
 		if len(tups[i]) != tupleLen {
-			panic(fmt.Sprintf("mismatched tuple lens: found %+v expected %d cols",
+			panic(fmt.Sprintf("mismatched tuple lens: found %+v expected %d vals",
 				tups[i], tupleLen))
 		}
 	}
@@ -153,6 +157,7 @@ func (s *opTestInput) Next() ColBatch {
 		s.rng.Shuffle(len(s.selection), func(i, j int) {
 			s.selection[i], s.selection[j] = s.selection[j], s.selection[i]
 		})
+
 		s.batch.SetSelection(true)
 		copy(s.batch.Selection(), s.selection)
 	} else {
@@ -191,6 +196,7 @@ type opTestOutput struct {
 // the expected tuples.
 func newOpTestOutput(input Operator, cols []int, expected tuples) *opTestOutput {
 	input.Init()
+
 	return &opTestOutput{
 		input:    input,
 		cols:     cols,
@@ -246,7 +252,7 @@ func assertTupleEquals(expected tuple, actual tuple) error {
 		return errors.Errorf("expected:\n%+v\n actual:\n%+v\n", expected, actual)
 	}
 	for i := 0; i < len(actual); i++ {
-		if reflect.ValueOf(actual[i]).Convert(reflect.TypeOf(expected[i])).Interface() != expected[i] {
+		if !reflect.DeepEqual(reflect.ValueOf(actual[i]).Convert(reflect.TypeOf(expected[i])).Interface(), expected[i]) {
 			return errors.Errorf("expected:\n%+v\n actual:\n%+v\n", expected, actual)
 		}
 	}
@@ -304,15 +310,48 @@ func (s *repeatableBatchSource) resetBatchesToReturn(b int) {
 	s.batchesReturned = 0
 }
 
-func TestOpTestInputOutput(t *testing.T) {
-	input := tuples{
-		{1, 2, 100},
-		{1, 3, -3},
-		{0, 4, 5},
-		{1, 5, 0},
+// finiteBatchSource is an Operator that returns the same batch a specified
+// number of times.
+type finiteBatchSource struct {
+	repeatableBatch *repeatableBatchSource
+
+	usableCount int
+}
+
+var _ Operator = &finiteBatchSource{}
+
+// newFiniteBatchSource returns a new Operator initialized to return its input
+// batch a specified number of times.
+func newFiniteBatchSource(batch ColBatch, usableCount int) *finiteBatchSource {
+	return &finiteBatchSource{
+		repeatableBatch: newRepeatableBatchSource(batch),
+		usableCount:     usableCount,
 	}
-	runTests(t, input, nil, func(t *testing.T, in Operator) {
-		out := newOpTestOutput(in, []int{0, 1, 2}, input)
+}
+
+func (f *finiteBatchSource) Init() {
+	f.repeatableBatch.Init()
+}
+
+func (f *finiteBatchSource) Next() ColBatch {
+	if f.usableCount > 0 {
+		f.usableCount--
+		return f.repeatableBatch.Next()
+	}
+	return NewMemBatch([]types.T{})
+}
+
+func TestOpTestInputOutput(t *testing.T) {
+	inputs := []tuples{
+		{
+			{1, 2, 100},
+			{1, 3, -3},
+			{0, 4, 5},
+			{1, 5, 0},
+		},
+	}
+	runTests(t, inputs, nil, func(t *testing.T, sources []Operator) {
+		out := newOpTestOutput(sources[0], []int{0, 1, 2}, inputs[0])
 
 		if err := out.Verify(); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Fixes #31375.

This operator performs a N-1 vectorized int64 inner hash join where the left input source's equality column must be unique.

For now, the equality columns must be `int64` values because none of the other types have hash/rehash functions implemented.

Benchmark results:
```
BenchmarkHashJoiner/rows=2048-8         	   10000	    169744 ns/op	 772.17 MB/s
BenchmarkHashJoiner/rows=4096-8         	    5000	    274218 ns/op	 955.97 MB/s
BenchmarkHashJoiner/rows=16384-8        	    2000	    897532 ns/op	1168.29 MB/s
BenchmarkHashJoiner/rows=262144-8       	     100	  13079283 ns/op	1282.73 MB/s
BenchmarkHashJoiner/rows=4194304-8      	       5	 200591222 ns/op	1338.22 MB/s
BenchmarkHashJoiner/rows=67108864-8     	       1	6687757443 ns/op	 642.21 MB/s
PASS
ok  	github.com/cockroachdb/cockroach/pkg/sql/exec	16.227s
```