### PR TITLE
roachtest: run tpcc consistency checks

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -119,6 +119,9 @@ func runTPCC(ctx context.Context, t *test, c *cluster, opts tpccOptions) {
 		m.Go(opts.During)
 	}
 	m.Wait()
+
+	c.Run(ctx, workloadNode, fmt.Sprintf(
+		"./workload check tpcc --warehouses=%d {pgurl:1}", opts.Warehouses))
 }
 
 func registerTPCC(r *registry) {


### PR DESCRIPTION
The TPC-C roachtest was only running the "audit" checks, which verify
that the TPC-C load generated transaction mixes that satisfy the TPC-C
specification. It's even more importnat to run the "consistency" checks,
which look for isolation anomalies.

These checks are somewhat expensive, especially with many warehouses,
but these roachtests are designed to be long running, so it's ok.

Release note: None