### PR TITLE
exec: get rid of Bools and Bytes; add some testing utils

### DIFF
--- a/pkg/sql/distsqlrun/columnarizer.go
+++ b/pkg/sql/distsqlrun/columnarizer.go
@@ -60,7 +60,7 @@ func (c *columnarizer) Init() {
 	for i := range typs {
 		typs[i] = types.FromColumnType(outputTypes[i])
 	}
-	c.batch = exec.NewMemBatch(typs...)
+	c.batch = exec.NewMemBatch(typs)
 	c.buffered = make(sqlbase.EncDatumRows, exec.ColBatchSize)
 	for i := range c.buffered {
 		c.buffered[i] = make(sqlbase.EncDatumRow, len(typs))

--- a/pkg/sql/distsqlrun/materializer.go
+++ b/pkg/sql/distsqlrun/materializer.go
@@ -132,7 +132,7 @@ func (m *materializer) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 			ct := types[outIdx]
 			switch ct.SemanticType {
 			case sqlbase.ColumnType_BOOL:
-				if col.Bool().At(rowIdx) {
+				if col.Bool()[rowIdx] {
 					m.row[outIdx].Datum = tree.DBoolTrue
 				} else {
 					m.row[outIdx].Datum = tree.DBoolFalse

--- a/pkg/sql/distsqlrun/materializer.go
+++ b/pkg/sql/distsqlrun/materializer.go
@@ -151,9 +151,9 @@ func (m *materializer) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 			case sqlbase.ColumnType_FLOAT:
 				m.row[outIdx].Datum = m.da.NewDFloat(tree.DFloat(col.Float64()[rowIdx]))
 			case sqlbase.ColumnType_BYTES:
-				m.row[outIdx].Datum = m.da.NewDBytes(tree.DBytes(col.Bytes().At(rowIdx)))
+				m.row[outIdx].Datum = m.da.NewDBytes(tree.DBytes(col.Bytes()[rowIdx]))
 			case sqlbase.ColumnType_STRING:
-				b := col.Bytes().At(rowIdx)
+				b := col.Bytes()[rowIdx]
 				m.row[outIdx].Datum = m.da.NewDString(tree.DString(*(*string)(unsafe.Pointer(&b))))
 			}
 		}

--- a/pkg/sql/exec/colbatch.go
+++ b/pkg/sql/exec/colbatch.go
@@ -33,6 +33,8 @@ type ColBatch interface {
 	// densely-packed list of the indices in each column that have not been
 	// filtered out by a previous step.
 	Selection() []uint16
+	// SetSelection sets whether this batch is using its selection vector or not.
+	SetSelection(bool)
 }
 
 var _ ColBatch = &memBatch{}
@@ -43,7 +45,7 @@ const ColBatchSize = 1024
 
 // NewMemBatch allocates a new in-memory ColBatch.
 // TODO(jordan): pool these allocations.
-func NewMemBatch(types ...types.T) ColBatch {
+func NewMemBatch(types []types.T) ColBatch {
 	b := &memBatch{}
 	b.b = make([]ColVec, len(types))
 
@@ -79,6 +81,10 @@ func (m *memBatch) Selection() []uint16 {
 		return nil
 	}
 	return m.sel
+}
+
+func (m *memBatch) SetSelection(b bool) {
+	m.useSel = b
 }
 
 func (m *memBatch) SetLength(n uint16) {

--- a/pkg/sql/exec/colvec.go
+++ b/pkg/sql/exec/colvec.go
@@ -42,6 +42,9 @@ type ColVec interface {
 	Float64() []float64
 	// Bytes returns a []byte slice.
 	Bytes() [][]byte
+
+	// Col returns the raw, typeless backing storage for this ColVec.
+	Col() interface{}
 }
 
 // Nulls represents a list of potentially nullable values.
@@ -133,4 +136,8 @@ func (m memColumn) Float64() []float64 {
 
 func (m memColumn) Bytes() [][]byte {
 	return m.col.([][]byte)
+}
+
+func (m memColumn) Col() interface{} {
+	return m.col
 }

--- a/pkg/sql/exec/colvec.go
+++ b/pkg/sql/exec/colvec.go
@@ -40,8 +40,8 @@ type ColVec interface {
 	Float32() []float32
 	// Float64 returns an float64 slice.
 	Float64() []float64
-	// Bytes returns a Bytes object, allowing retrieval of multiple byte slices.
-	Bytes() Bytes
+	// Bytes returns a []byte slice.
+	Bytes() [][]byte
 }
 
 // Nulls represents a list of potentially nullable values.
@@ -59,14 +59,6 @@ type Nulls interface {
 	Rank(i uint16) uint16
 }
 
-// Bytes is an interface that represents a list of byte slices.
-type Bytes interface {
-	// At returns the ith byte slice in the list.
-	At(i uint16) []byte
-	// Set sets the ith byte slice in the list to b.
-	Set(i uint16, b []byte)
-}
-
 var _ ColVec = memColumn{}
 
 // memColumn is a simple pass-through implementation of ColVec that just casts
@@ -81,7 +73,7 @@ func newMemColumn(t types.T, n int) memColumn {
 	case types.Bool:
 		return memColumn{col: make([]bool, n)}
 	case types.Bytes:
-		return memColumn{col: newMemBytes(n)}
+		return memColumn{col: make([][]byte, n)}
 	case types.Int16:
 		return memColumn{col: make([]int16, n)}
 	case types.Int32:
@@ -139,22 +131,6 @@ func (m memColumn) Float64() []float64 {
 	return m.col.([]float64)
 }
 
-func (m memColumn) Bytes() Bytes {
-	return m.col.(memBytes)
-}
-
-var _ Bytes = memBytes{}
-
-type memBytes [][]byte
-
-func newMemBytes(n int) memBytes {
-	return make([][]byte, n)
-}
-
-func (m memBytes) At(i uint16) []byte {
-	return m[i]
-}
-
-func (m memBytes) Set(i uint16, b []byte) {
-	m[i] = b
+func (m memColumn) Bytes() [][]byte {
+	return m.col.([][]byte)
 }

--- a/pkg/sql/exec/colvec.go
+++ b/pkg/sql/exec/colvec.go
@@ -27,7 +27,7 @@ type ColVec interface {
 
 	// TODO(jordan): is a bitmap or slice of bools better?
 	// Bool returns a bool list.
-	Bool() Bools
+	Bool() []bool
 	// Int8 returns an int8 slice.
 	Int8() []int8
 	// Int16 returns an int16 slice.
@@ -59,14 +59,6 @@ type Nulls interface {
 	Rank(i uint16) uint16
 }
 
-// Bools is an interface that represents a list of bools.
-type Bools interface {
-	// At returns the ith bool in the list.
-	At(i uint16) bool
-	// Set sets the ith bool in the list to b.
-	Set(i uint16, b bool)
-}
-
 // Bytes is an interface that represents a list of byte slices.
 type Bytes interface {
 	// At returns the ith byte slice in the list.
@@ -87,7 +79,7 @@ type memColumn struct {
 func newMemColumn(t types.T, n int) memColumn {
 	switch t {
 	case types.Bool:
-		return memColumn{col: newMemBools(n)}
+		return memColumn{col: make([]bool, n)}
 	case types.Bytes:
 		return memColumn{col: newMemBytes(n)}
 	case types.Int16:
@@ -119,8 +111,8 @@ func (m memColumn) Rank(i uint16) uint16 {
 	return i
 }
 
-func (m memColumn) Bool() Bools {
-	return m.col.(memBools)
+func (m memColumn) Bool() []bool {
+	return m.col.([]bool)
 }
 
 func (m memColumn) Int8() []int8 {
@@ -149,22 +141,6 @@ func (m memColumn) Float64() []float64 {
 
 func (m memColumn) Bytes() Bytes {
 	return m.col.(memBytes)
-}
-
-var _ Bools = memBools{}
-
-type memBools []bool
-
-func newMemBools(n int) memBools {
-	return make([]bool, n)
-}
-
-func (m memBools) At(i uint16) bool {
-	return m[i]
-}
-
-func (m memBools) Set(i uint16, b bool) {
-	m[i] = b
 }
 
 var _ Bytes = memBytes{}

--- a/pkg/sql/exec/execgen/cmd/execgen/rowstovec_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/rowstovec_gen.go
@@ -109,7 +109,7 @@ func genRowsToVec(wr io.Writer) error {
 				Width:        width,
 				ExecType:     t.String(),
 				// TODO(solon): Determine the following fields via reflection.
-				HasSetMethod:      t == types.Bool || t == types.Bytes,
+				HasSetMethod:      t == types.Bytes,
 				DatumToPhysicalFn: getDatumToPhysicalFn(ct),
 			}
 			columnConversions = append(columnConversions, conversion)

--- a/pkg/sql/exec/execgen/cmd/execgen/rowstovec_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/rowstovec_gen.go
@@ -61,11 +61,7 @@ func EncDatumRowsToColVec(
 			if datum == tree.DNull {
 				vec.SetNull(i)
 			} else {
-				{{if .HasSetMethod}}
-				col.Set(i, {{.DatumToPhysicalFn}})
-				{{else}}
 				col[i] = {{.DatumToPhysicalFn}}
-				{{end}}
 			}
 		}
 		return nil
@@ -85,9 +81,6 @@ type columnConversion struct {
 	// ExecType is the exec.T to which we're converting. It should correspond to
 	// a method name on exec.ColVec.
 	ExecType string
-	// HasSetMethod is true if the ColVec is an interface with a Set method rather
-	// than just a slice.
-	HasSetMethod bool
 	// DatumToPhysicalFn is a stringified function for converting a datum to the
 	// physical type used in the column vector.
 	DatumToPhysicalFn string
@@ -105,11 +98,9 @@ func genRowsToVec(wr io.Writer) error {
 				continue
 			}
 			conversion := columnConversion{
-				SemanticType: "ColumnType_" + name,
-				Width:        width,
-				ExecType:     t.String(),
-				// TODO(solon): Determine the following fields via reflection.
-				HasSetMethod:      t == types.Bytes,
+				SemanticType:      "ColumnType_" + name,
+				Width:             width,
+				ExecType:          t.String(),
 				DatumToPhysicalFn: getDatumToPhysicalFn(ct),
 			}
 			columnConversions = append(columnConversions, conversion)

--- a/pkg/sql/exec/rowstovec_test.go
+++ b/pkg/sql/exec/rowstovec_test.go
@@ -91,8 +91,8 @@ func TestEncDatumRowsToColVecString(t *testing.T) {
 		t.Fatal(err)
 	}
 	expected := newMemColumn(types.Bytes, 2)
-	expected.Bytes().Set(0, []byte("foo"))
-	expected.Bytes().Set(1, []byte("bar"))
+	expected.Bytes()[0] = []byte("foo")
+	expected.Bytes()[1] = []byte("bar")
 	if !reflect.DeepEqual(vec, expected) {
 		t.Errorf("expected vector %+v, got %+v", expected, vec)
 	}

--- a/pkg/sql/exec/rowstovec_test.go
+++ b/pkg/sql/exec/rowstovec_test.go
@@ -45,8 +45,8 @@ func TestEncDatumRowsToColVecBool(t *testing.T) {
 		t.Fatal(err)
 	}
 	expected := newMemColumn(types.Bool, 2)
-	expected.Bool().Set(0, false)
-	expected.Bool().Set(1, true)
+	expected.Bool()[0] = false
+	expected.Bool()[1] = true
 	if !reflect.DeepEqual(vec, expected) {
 		t.Errorf("expected vector %+v, got %+v", expected, vec)
 	}
@@ -55,8 +55,8 @@ func TestEncDatumRowsToColVecBool(t *testing.T) {
 	if err := EncDatumRowsToColVec(rows, vec, 1 /* columnIdx */, &ct, &alloc); err != nil {
 		t.Fatal(err)
 	}
-	expected.Bool().Set(0, true)
-	expected.Bool().Set(1, false)
+	expected.Bool()[0] = true
+	expected.Bool()[1] = false
 	if !reflect.DeepEqual(vec, expected) {
 		t.Errorf("expected vector %+v, got %+v", expected, vec)
 	}

--- a/pkg/sql/exec/types/types.go
+++ b/pkg/sql/exec/types/types.go
@@ -75,3 +75,30 @@ func FromColumnType(ct sqlbase.ColumnType) T {
 	}
 	return Unhandled
 }
+
+// FromGoType returns the type for a Go value, if applicable. Shouldn't be used at
+// runtime.
+func FromGoType(v interface{}) T {
+	switch t := v.(type) {
+	case int8:
+		return Int8
+	case int16:
+		return Int16
+	case int32:
+		return Int32
+	case int, int64:
+		return Int64
+	case bool:
+		return Bool
+	case float32:
+		return Float32
+	case float64:
+		return Float64
+	case []byte:
+		return Bytes
+	case string:
+		return Bytes
+	default:
+		panic(fmt.Sprintf("type %T not supported yet", t))
+	}
+}

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -1,0 +1,265 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/pkg/errors"
+)
+
+// tuple represents a row with any-type columns.
+type tuple []interface{}
+
+// tuples represents a table of a single type.
+type tuples []tuple
+
+// opTestInput is an Operator that columnarizes test input in the form of tuples
+// of arbitrary Go types. It's meant to be used in Operator unit tests in
+// conjunction with opTestOutput like the following:
+//
+// inputTuples := tuples{
+//   {1,2,3.3,true},
+//   {5,6,7.0,false},
+// }
+// tupleSource := newOpTestInput(inputTuples, types.Bool)
+// opUnderTest := newFooOp(tupleSource, ...)
+// output := newOpTestOutput(opUnderTest, expectedOutputTuples)
+// if err := output.Verify(); err != nil {
+//     t.Fatal(err)
+// }
+type opTestInput struct {
+	typs      []types.T
+	extraCols []types.T
+	tuples    tuples
+	batch     ColBatch
+}
+
+var _ Operator = &opTestInput{}
+
+// newOpTestInput returns a new opTestInput, with the given input tuples and
+// the given extra column types. The input tuples are translated into types
+// automatically, using simple rules (e.g. integers always become Int64).
+// The extraCols slice represents any extra columns that the batch must have
+// for output or temp columns for operators in the test.
+func newOpTestInput(tuples tuples, extraCols ...types.T) *opTestInput {
+	ret := &opTestInput{
+		tuples:    tuples,
+		extraCols: extraCols,
+	}
+	ret.Init()
+	return ret
+}
+
+func (s *opTestInput) Init() {
+	if len(s.tuples) == 0 {
+		panic("empty tuple source")
+	}
+	tup := s.tuples[0]
+	typs := make([]types.T, len(tup))
+	for i := range tup {
+		typs[i] = types.FromGoType(tup[i])
+	}
+	s.typs = typs
+	s.batch = NewMemBatch(append(typs, s.extraCols...))
+}
+
+func (s *opTestInput) Next() ColBatch {
+	if len(s.tuples) == 0 {
+		s.batch.SetLength(0)
+		return s.batch
+	}
+	batchSize := uint16(ColBatchSize)
+	if len(s.tuples) < int(batchSize) {
+		batchSize = uint16(len(s.tuples))
+	}
+	tups := s.tuples[:batchSize]
+	s.tuples = s.tuples[batchSize:]
+
+	tupleLen := len(tups[0])
+	for i := range tups {
+		if len(tups[i]) != tupleLen {
+			panic(fmt.Sprintf("mismatched tuple lens: found %+v expected %d cols",
+				tups[i], tupleLen))
+		}
+	}
+	for i := range s.typs {
+		vec := s.batch.ColVec(i)
+		// Automatically convert the Go values into exec.Type slice elements using
+		// reflection. This is slow, but acceptable for tests.
+		col := reflect.ValueOf(vec.Col())
+		for j := uint16(0); j < batchSize; j++ {
+			col.Index(int(j)).Set(
+				reflect.ValueOf(tups[j][i]).Convert(reflect.TypeOf(vec.Col()).Elem()))
+		}
+	}
+
+	s.batch.SetLength(batchSize)
+	s.batch.SetSelection(false)
+	return s.batch
+}
+
+// opTestOutput is a test verification struct that ensures its input batches
+// match some expected output tuples.
+type opTestOutput struct {
+	input    Operator
+	cols     []int
+	expected tuples
+
+	curIdx uint16
+	batch  ColBatch
+}
+
+// newOpTestOutput returns a new opTestOutput, initialized with the given input
+// to verify on the given column indices that the output is exactly equal to
+// the expected tuples.
+func newOpTestOutput(input Operator, cols []int, expected tuples) *opTestOutput {
+	return &opTestOutput{
+		input:    input,
+		cols:     cols,
+		expected: expected,
+	}
+}
+
+func (r *opTestOutput) next() tuple {
+	if r.batch == nil || r.curIdx >= r.batch.Length() {
+		// Get a fresh batch.
+		r.batch = r.input.Next()
+		if r.batch.Length() == 0 {
+			return nil
+		}
+		r.curIdx = 0
+	}
+	ret := make(tuple, len(r.cols))
+	out := reflect.ValueOf(ret)
+	curIdx := r.curIdx
+	if sel := r.batch.Selection(); sel != nil {
+		curIdx = sel[curIdx]
+	}
+	for outIdx, colIdx := range r.cols {
+		vec := r.batch.ColVec(colIdx)
+		col := reflect.ValueOf(vec.Col())
+		out.Index(outIdx).Set(col.Index(int(curIdx)))
+	}
+	r.curIdx++
+	return ret
+}
+
+// Verify ensures that the input to this opTestOutput produced the same results
+// as the ones expected in the opTestOutput's expected tuples, using a slow,
+// reflection-based comparison method, returning an error if the input isn't
+// equal to the expected.
+func (r *opTestOutput) Verify() error {
+	var actual tuples
+	for {
+		tup := r.next()
+		if tup == nil {
+			break
+		}
+		actual = append(actual, tup)
+	}
+	return assertTuplesEquals(r.expected, actual)
+}
+
+// assertTupleEquals asserts that two tuples are equal, using a slow,
+// reflection-based method to do the assertion. Reflection is used so that
+// values can be compared in a type-agnostic way.
+func assertTupleEquals(expected tuple, actual tuple) error {
+	if len(expected) != len(actual) {
+		return errors.Errorf("expected:\n%+v\n actual:\n%+v\n", expected, actual)
+	}
+	for i := 0; i < len(actual); i++ {
+		if reflect.ValueOf(actual[i]).Convert(reflect.TypeOf(expected[i])).Interface() != expected[i] {
+			return errors.Errorf("expected:\n%+v\n actual:\n%+v\n", expected, actual)
+		}
+	}
+	return nil
+}
+
+// assertTuplesEquals asserts that two sets of tuples are equal.
+func assertTuplesEquals(expected tuples, actual tuples) error {
+	if len(expected) != len(actual) {
+		return errors.Errorf("expected %+v, actual %+v", expected, actual)
+	}
+	for i, t := range expected {
+		if err := assertTupleEquals(t, actual[i]); err != nil {
+			return errors.Wrapf(err, "expected %+v, actual %+v:\n", expected, actual)
+		}
+	}
+	return nil
+}
+
+// repeatableBatchSource is an Operator that returns the same batch forever.
+type repeatableBatchSource struct {
+	internalBatch ColBatch
+
+	batchLen uint16
+}
+
+var _ Operator = &repeatableBatchSource{}
+
+// newRepeatableBatchSource returns a new Operator initialized to return
+// its input batch forever.
+func newRepeatableBatchSource(batch ColBatch) *repeatableBatchSource {
+	return &repeatableBatchSource{
+		internalBatch: batch,
+		batchLen:      batch.Length(),
+	}
+}
+
+func (s *repeatableBatchSource) Next() ColBatch {
+	s.internalBatch.SetSelection(false)
+	s.internalBatch.SetLength(s.batchLen)
+	return s.internalBatch
+}
+
+func (s *repeatableBatchSource) Init() {}
+
+func TestOpTestInputOutput(t *testing.T) {
+	input := tuples{
+		{1, 2, 100},
+		{1, 3, -3},
+		{0, 4, 5},
+		{1, 5, 0},
+	}
+	in := newOpTestInput(input)
+	out := newOpTestOutput(in, []int{0, 1, 2}, input)
+
+	if err := out.Verify(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRepeatableBatchSource(t *testing.T) {
+	batch := NewMemBatch([]types.T{types.Int64})
+	batchLen := uint16(10)
+	batch.SetLength(batchLen)
+	input := newRepeatableBatchSource(batch)
+
+	b := input.Next()
+	b.SetLength(0)
+	b.SetSelection(true)
+
+	b = input.Next()
+	if b.Length() != batchLen {
+		t.Fatalf("expected repeatableBatchSource to reset batch length to %d, found %d", batchLen, b.Length())
+	}
+	if b.Selection() != nil {
+		t.Fatalf("expected repeatableBatchSource to reset selection vector, found %+v", b.Selection())
+	}
+}


### PR DESCRIPTION
opTestInput and opTestOutput allow testing operators without having to
construct ColBatches by hand, with a natural syntax inspired by
ProcessorTestCase.

Also, get rid of `Bools` in favor of `[]bool`, and `Bytes` in favor of `[][]byte`, as it's up to 4x slower at least on the Distinct benchmark.

Split from #31693.
Based on #31554.