### PR TITLE
opt/sql: support (some) vtables in test catalog

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/vtable"
 )
 
 const (
@@ -199,16 +200,8 @@ func validateInformationSchemaTable(table *sqlbase.TableDescriptor) error {
 	return nil
 }
 
-// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-administrable-role-authorizations.html
-// MySQL:    missing
 var informationSchemaAdministrableRoleAuthorizations = virtualSchemaTable{
-	schema: `
-CREATE TABLE information_schema.administrable_role_authorizations (
-	GRANTEE      STRING NOT NULL,
-	ROLE_NAME    STRING NOT NULL,
-	IS_GRANTABLE STRING NOT NULL
-);
-`,
+	schema: vtable.InformationSchemaAdministrableRoleAuthorizations,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		currentUser := p.SessionData().User
 		memberMap, err := p.MemberOfWithAdminOption(ctx, currentUser)
@@ -236,16 +229,8 @@ CREATE TABLE information_schema.administrable_role_authorizations (
 	},
 }
 
-// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-applicable-roles.html
-// MySQL:    missing
 var informationSchemaApplicableRoles = virtualSchemaTable{
-	schema: `
-CREATE TABLE information_schema.applicable_roles (
-	GRANTEE      STRING NOT NULL,
-	ROLE_NAME    STRING NOT NULL,
-	IS_GRANTABLE STRING NOT NULL
-);
-`,
+	schema: vtable.InformationSchemaApplicableRoles,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		currentUser := p.SessionData().User
 		memberMap, err := p.MemberOfWithAdminOption(ctx, currentUser)
@@ -269,21 +254,8 @@ CREATE TABLE information_schema.applicable_roles (
 	},
 }
 
-// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-column-privileges.html
-// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/column-privileges-table.html
 var informationSchemaColumnPrivileges = virtualSchemaTable{
-	schema: `
-CREATE TABLE information_schema.column_privileges (
-	GRANTOR        STRING,
-	GRANTEE        STRING NOT NULL,
-	TABLE_CATALOG  STRING NOT NULL,
-	TABLE_SCHEMA   STRING NOT NULL,
-	TABLE_NAME     STRING NOT NULL,
-	COLUMN_NAME    STRING NOT NULL,
-	PRIVILEGE_TYPE STRING NOT NULL,
-	IS_GRANTABLE   STRING
-);
-`,
+	schema: vtable.InformationSchemaColumnPrivileges,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, virtualMany, func(db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor) error {
 			dbNameStr := tree.NewDString(db.Name)
@@ -314,33 +286,8 @@ CREATE TABLE information_schema.column_privileges (
 	},
 }
 
-// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-columns.html
-// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/columns-table.html
 var informationSchemaColumnsTable = virtualSchemaTable{
-	schema: `
-CREATE TABLE information_schema.columns (
-	TABLE_CATALOG            STRING NOT NULL,
-	TABLE_SCHEMA             STRING NOT NULL,
-	TABLE_NAME               STRING NOT NULL,
-	COLUMN_NAME              STRING NOT NULL,
-	ORDINAL_POSITION         INT NOT NULL,
-	COLUMN_DEFAULT           STRING,
-	IS_NULLABLE              STRING NOT NULL,
-	DATA_TYPE                STRING NOT NULL,
-	CHARACTER_MAXIMUM_LENGTH INT,
-	CHARACTER_OCTET_LENGTH   INT,
-	NUMERIC_PRECISION        INT,
-	NUMERIC_PRECISION_RADIX  INT,
-	NUMERIC_SCALE            INT,
-	DATETIME_PRECISION       INT,
-	CHARACTER_SET_CATALOG    STRING,
-	CHARACTER_SET_SCHEMA     STRING,
-	CHARACTER_SET_NAME       STRING,
-	GENERATION_EXPRESSION    STRING,          -- MySQL/CockroachDB extension.
-	IS_HIDDEN                STRING NOT NULL, -- CockroachDB extension for SHOW COLUMNS / dump.
-	CRDB_SQL_TYPE            STRING NOT NULL  -- CockroachDB extension for SHOW COLUMNS / dump.
-);
-`,
+	schema: vtable.InformationSchemaColumns,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, virtualMany, func(db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor) error {
 			dbNameStr := tree.NewDString(db.Name)
@@ -1167,18 +1114,8 @@ var (
 	tableTypeView       = tree.NewDString("VIEW")
 )
 
-// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-tables.html
-// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/tables-table.html
 var informationSchemaTablesTable = virtualSchemaTable{
-	schema: `
-CREATE TABLE information_schema.tables (
-	TABLE_CATALOG      STRING NOT NULL,
-	TABLE_SCHEMA       STRING NOT NULL,
-	TABLE_NAME         STRING NOT NULL,
-	TABLE_TYPE         STRING NOT NULL,
-	IS_INSERTABLE_INTO STRING NOT NULL,
-	VERSION            INT
-);`,
+	schema: vtable.InformationSchemaTables,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, virtualMany,
 			func(db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor) error {

--- a/pkg/sql/opt/memo/testdata/logprops/virtual-scan
+++ b/pkg/sql/opt/memo/testdata/logprops/virtual-scan
@@ -1,39 +1,7 @@
-exec-ddl
-CREATE TABLE system.information_schema.schemata (
-	CATALOG_NAME               STRING NOT NULL,
-	SCHEMA_NAME                STRING NOT NULL,
-	DEFAULT_CHARACTER_SET_NAME STRING,
-	SQL_PATH                   STRING
-)
-----
-TABLE schemata
- ├── catalog_name string not null
- ├── schema_name string not null
- ├── default_character_set_name string
- └── sql_path string
-
-exec-ddl
-CREATE TABLE system.information_schema.tables (
-	TABLE_CATALOG      STRING NOT NULL,
-	TABLE_SCHEMA       STRING NOT NULL,
-	TABLE_NAME         STRING NOT NULL,
-	TABLE_TYPE         STRING NOT NULL,
-	IS_INSERTABLE_INTO STRING NOT NULL,
-	VERSION            INT
-)
-----
-TABLE tables
- ├── table_catalog string not null
- ├── table_schema string not null
- ├── table_name string not null
- ├── table_type string not null
- ├── is_insertable_into string not null
- └── version int
-
 build
 SELECT catalog_name, sql_path
-FROM (SELECT * FROM system.information_schema.schemata WHERE SCHEMA_NAME='public')
-LEFT JOIN system.information_schema.tables
+FROM (SELECT * FROM information_schema.schemata WHERE SCHEMA_NAME='public')
+LEFT JOIN information_schema.tables
 ON CATALOG_NAME=TABLE_CATALOG AND SCHEMA_NAME=TABLE_SCHEMA
 ----
 project
@@ -46,13 +14,13 @@ project
       ├── select
       │    ├── columns: catalog_name:1(string) schema_name:2(string!null) default_character_set_name:3(string) sql_path:4(string)
       │    ├── fd: ()-->(2)
-      │    ├── virtual-scan system.information_schema.schemata
+      │    ├── virtual-scan t.information_schema.schemata
       │    │    └── columns: catalog_name:1(string) schema_name:2(string) default_character_set_name:3(string) sql_path:4(string)
       │    └── filters
       │         └── eq [type=bool, outer=(2), constraints=(/2: [/'public' - /'public']; tight), fd=()-->(2)]
       │              ├── variable: schema_name [type=string]
       │              └── const: 'public' [type=string]
-      ├── virtual-scan system.information_schema.tables
+      ├── virtual-scan t.information_schema.tables
       │    └── columns: table_catalog:5(string) table_schema:6(string) table_name:7(string) table_type:8(string) is_insertable_into:9(string) version:10(int)
       └── filters
            └── and [type=bool, outer=(1,2,5,6), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /5: (/NULL - ]; /6: (/NULL - ])]

--- a/pkg/sql/opt/optbuilder/testdata/virtual-scan
+++ b/pkg/sql/opt/optbuilder/testdata/virtual-scan
@@ -1,0 +1,18 @@
+build
+SELECT * FROM information_schema.does_not_exist
+----
+error: no data source matches prefix: "information_schema.public.does_not_exist"
+
+build
+SELECT * FROM information_schema.columns
+----
+virtual-scan t.information_schema.columns
+ └── columns: table_catalog:1(string) table_schema:2(string) table_name:3(string) column_name:4(string) ordinal_position:5(int) column_default:6(string) is_nullable:7(string) data_type:8(string) character_maximum_length:9(int) character_octet_length:10(int) numeric_precision:11(int) numeric_precision_radix:12(int) numeric_scale:13(int) datetime_precision:14(int) character_set_catalog:15(string) character_set_schema:16(string) character_set_name:17(string) generation_expression:18(string) is_hidden:19(string) crdb_sql_type:20(string)
+
+# Since we lazily create these, the name resolution codepath is slightly
+# different on the second resolution.
+build
+SELECT * FROM information_schema.columns
+----
+virtual-scan t.information_schema.columns
+ └── columns: table_catalog:1(string) table_schema:2(string) table_name:3(string) column_name:4(string) ordinal_position:5(int) column_default:6(string) is_nullable:7(string) data_type:8(string) character_maximum_length:9(int) character_octet_length:10(int) numeric_precision:11(int) numeric_precision_radix:12(int) numeric_scale:13(int) datetime_precision:14(int) character_set_catalog:15(string) character_set_schema:16(string) character_set_name:17(string) generation_expression:18(string) is_hidden:19(string) crdb_sql_type:20(string)

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -55,9 +55,9 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 
 	tab := &Table{TabFingerprint: tc.nextFingerprint(), TabName: stmt.Table, Catalog: tc}
 
-	// Assume that every table in the "system" catalog is a virtual table. This
-	// is a simplified assumption for testing purposes.
-	if stmt.Table.CatalogName == "system" {
+	// Assume that every table in the "system" or "information_schema" catalog
+	// is a virtual table. This is a simplified assumption for testing purposes.
+	if stmt.Table.CatalogName == "system" || stmt.Table.SchemaName == "information_schema" {
 		tab.IsVirtual = true
 	}
 

--- a/pkg/sql/opt/testutils/testcat/vtable.go
+++ b/pkg/sql/opt/testutils/testcat/vtable.go
@@ -1,0 +1,72 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package testcat
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/vtable"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+var informationSchemaMap = map[string]*tree.CreateTable{}
+
+var informationSchemaTables = []string{
+	vtable.InformationSchemaColumns,
+	vtable.InformationSchemaAdministrableRoleAuthorizations,
+	vtable.InformationSchemaApplicableRoles,
+	vtable.InformationSchemaColumnPrivileges,
+	vtable.InformationSchemaSchemata,
+	vtable.InformationSchemaTables,
+}
+
+func init() {
+	// Build a map that maps the names of the various information_schema tables
+	// to their CREATE TABLE AST.
+	for _, table := range informationSchemaTables {
+		parsed, err := parser.ParseOne(table)
+		if err != nil {
+			panic(fmt.Sprintf("error initializing virtual table map: %s", err))
+		}
+
+		ct, ok := parsed.(*tree.CreateTable)
+		if !ok {
+			panic("virtual table schemas must be CREATE TABLE statements")
+		}
+
+		ct.Table.SchemaName = tree.Name("information_schema")
+		ct.Table.ExplicitSchema = true
+
+		ct.Table.CatalogName = testDB
+		ct.Table.ExplicitCatalog = true
+
+		name := ct.Table
+		informationSchemaMap[name.TableName.String()] = ct
+	}
+}
+
+// Resolve returns true and the AST node describing the virtual table referenced.
+// TODO(justin): make this complete for all virtual tables.
+func resolveVTable(name *tree.TableName) (*tree.CreateTable, bool) {
+	switch name.SchemaName {
+	case "information_schema":
+		schema, ok := informationSchemaMap[name.TableName.String()]
+		return schema, ok
+	}
+
+	return nil, false
+}

--- a/pkg/sql/opt/xform/testdata/coster/virtual-scan
+++ b/pkg/sql/opt/xform/testdata/coster/virtual-scan
@@ -1,26 +1,12 @@
-exec-ddl
-CREATE TABLE system.information_schema.schemata (
-	CATALOG_NAME               STRING NOT NULL,
-	SCHEMA_NAME                STRING NOT NULL,
-	DEFAULT_CHARACTER_SET_NAME STRING,
-	SQL_PATH                   STRING
-)
-----
-TABLE schemata
- ├── catalog_name string not null
- ├── schema_name string not null
- ├── default_character_set_name string
- └── sql_path string
-
 opt
-SELECT * FROM system.information_schema.schemata WHERE SCHEMA_NAME='public'
+SELECT * FROM information_schema.schemata WHERE SCHEMA_NAME='public'
 ----
 select
  ├── columns: catalog_name:1(string) schema_name:2(string!null) default_character_set_name:3(string) sql_path:4(string)
  ├── stats: [rows=10, distinct(2)=1, null(2)=0]
  ├── cost: 20
  ├── fd: ()-->(2)
- ├── virtual-scan system.information_schema.schemata
+ ├── virtual-scan t.information_schema.schemata
  │    ├── columns: catalog_name:1(string) schema_name:2(string) default_character_set_name:3(string) sql_path:4(string)
  │    ├── stats: [rows=1000, distinct(2)=100, null(2)=0]
  │    └── cost: 10

--- a/pkg/sql/vtable/information_schema.go
+++ b/pkg/sql/vtable/information_schema.go
@@ -1,0 +1,105 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package vtable
+
+// InformationSchemaColumns describes the schema of the
+// information_schema.columns table.
+// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-columns.html
+// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/columns-table.html
+const InformationSchemaColumns = `
+CREATE TABLE information_schema.columns (
+	TABLE_CATALOG            STRING NOT NULL,
+	TABLE_SCHEMA             STRING NOT NULL,
+	TABLE_NAME               STRING NOT NULL,
+	COLUMN_NAME              STRING NOT NULL,
+	ORDINAL_POSITION         INT NOT NULL,
+	COLUMN_DEFAULT           STRING,
+	IS_NULLABLE              STRING NOT NULL,
+	DATA_TYPE                STRING NOT NULL,
+	CHARACTER_MAXIMUM_LENGTH INT,
+	CHARACTER_OCTET_LENGTH   INT,
+	NUMERIC_PRECISION        INT,
+	NUMERIC_PRECISION_RADIX  INT,
+	NUMERIC_SCALE            INT,
+	DATETIME_PRECISION       INT,
+	CHARACTER_SET_CATALOG    STRING,
+	CHARACTER_SET_SCHEMA     STRING,
+	CHARACTER_SET_NAME       STRING,
+	GENERATION_EXPRESSION    STRING,          -- MySQL/CockroachDB extension.
+	IS_HIDDEN                STRING NOT NULL, -- CockroachDB extension for SHOW COLUMNS / dump.
+	CRDB_SQL_TYPE            STRING NOT NULL  -- CockroachDB extension for SHOW COLUMNS / dump.
+);`
+
+// InformationSchemaAdministrableRoleAuthorizations describes the schema of the
+// information_schema.administrable_role_authorizations table.
+// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-administrable-role-authorizations.html
+// MySQL:    missing
+const InformationSchemaAdministrableRoleAuthorizations = `
+CREATE TABLE information_schema.administrable_role_authorizations (
+	GRANTEE      STRING NOT NULL,
+	ROLE_NAME    STRING NOT NULL,
+	IS_GRANTABLE STRING NOT NULL
+);`
+
+// InformationSchemaApplicableRoles describes the schema of the
+// information_schema.applicable_roles table.
+// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-applicable-roles.html
+// MySQL:    missing
+const InformationSchemaApplicableRoles = `
+CREATE TABLE information_schema.applicable_roles (
+	GRANTEE      STRING NOT NULL,
+	ROLE_NAME    STRING NOT NULL,
+	IS_GRANTABLE STRING NOT NULL
+);`
+
+// InformationSchemaColumnPrivileges describes the schema of the
+// information_schema.column_privileges table.
+// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-column-privileges.html
+// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/column-privileges-table.html
+const InformationSchemaColumnPrivileges = `
+CREATE TABLE information_schema.column_privileges (
+	GRANTOR        STRING,
+	GRANTEE        STRING NOT NULL,
+	TABLE_CATALOG  STRING NOT NULL,
+	TABLE_SCHEMA   STRING NOT NULL,
+	TABLE_NAME     STRING NOT NULL,
+	COLUMN_NAME    STRING NOT NULL,
+	PRIVILEGE_TYPE STRING NOT NULL,
+	IS_GRANTABLE   STRING
+);`
+
+// InformationSchemaSchemata describes the schema of the
+// information_schema.schemata table.
+const InformationSchemaSchemata = `
+CREATE TABLE information_schema.schemata (
+	CATALOG_NAME               STRING NOT NULL,
+	SCHEMA_NAME                STRING NOT NULL,
+	DEFAULT_CHARACTER_SET_NAME STRING,
+	SQL_PATH                   STRING
+);`
+
+// InformationSchemaTables describes the schema of the
+// information_schema.tables table.
+// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-tables.html
+// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/tables-table.html
+const InformationSchemaTables = `
+CREATE TABLE information_schema.tables (
+	TABLE_CATALOG      STRING NOT NULL,
+	TABLE_SCHEMA       STRING NOT NULL,
+	TABLE_NAME         STRING NOT NULL,
+	TABLE_TYPE         STRING NOT NULL,
+	IS_INSERTABLE_INTO STRING NOT NULL,
+	VERSION            INT
+);`


### PR DESCRIPTION
This change creates a new (incomplete) package `vtable` with two main
exports:

* The raw CREATE TABLE statements describing each virtual table, so that
  the existing mechanisms involving virtual tables can continue as they
  are, and
* a `Resolve` function which takes a TableName and gives back a
  CreateTable AST node, intended to be used by the test catalog to allow
  use of virtual tables in opt tests.

I only did a couple at the moment to see what people thought of the
approach. I considered not exposing the CREATE TABLE statements directly
and instead only exposing some kind of resolution mechanism, but I think
this method allows us to
1. Change as little as possible in the existing vtable codepaths (just
   changing a string literal to a variable reference), and
2. keep editor suport to easily jump to the definition of a vtable from
   the existing points.

The machinery is then used in the test catalog, which lazily populates
itself with the definition of a virtual table if one is referenced. This
change will make testing certain types of statements (like SHOW) much
easier.

Release note: None