### PR TITLE
rfc: push parallel commits logic into txnCommitter interceptor 

### DIFF
--- a/docs/RFCS/20180324_parallel_commit.md
+++ b/docs/RFCS/20180324_parallel_commit.md
@@ -3,7 +3,7 @@
 - Start Date: 2018-30-24
 - Authors: Tobias Schottdorf, Nathan VanBenschoten
 - RFC PR: #24194
-- Cockroach Issue: TBD
+- Cockroach Issue: #30999
 
 # Summary
 


### PR DESCRIPTION
This change updates the parallel commits RFC to move most logic
into the TxnCoordSender instead of keeping it in the `DistSender`.
In doing so, it avoids breaking an abstraction boundary and pushing
more transactional logic into a component that should hardly know
about transactions at all.

It does so by introducing a new `txnInterceptor` called `txnCommitter`.
The component is in charge of handling parallel commits. It transforms
`EndTransaction` requests, populates PromisedWrites, and kicks off the
async COMMIT request.

The change also updates the RFC to reflect the state of the world post-txn pipelining.