### PR TITLE
build: bin/roachtest depends on execgen files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1423,7 +1423,7 @@ logictest-bins := bin/logictest bin/logictestopt bin/logictestccl
 #
 # TODO(benesch): Derive this automatically. This is getting out of hand.
 bin/workload bin/docgen bin/execgen bin/roachtest $(logictest-bins): $(SQLPARSER_TARGETS) $(PROTOBUF_TARGETS)
-bin/workload bin/roachtest $(logictest-bins): $(C_LIBS_CCL) $(CGO_FLAGS_FILES)
+bin/workload bin/roachtest $(logictest-bins): $(C_LIBS_CCL) $(CGO_FLAGS_FILES) $(EXECGEN_TARGETS)
 bin/roachtest bin/logictestopt: $(OPTGEN_TARGETS)
 
 $(bins): bin/%: bin/%.d | bin/prereqs bin/.submodules-initialized


### PR DESCRIPTION
make bin/roachtest was broken without a make build first. This should
fix it.

Release note: None