### PR TITLE
sql: don't re-decode index keys when unnecessary

### DIFF
--- a/pkg/bench/bench_test.go
+++ b/pkg/bench/bench_test.go
@@ -168,6 +168,51 @@ func BenchmarkCount(b *testing.B) {
 	})
 }
 
+func BenchmarkCountTwoCF(b *testing.B) {
+	if testing.Short() {
+		b.Skip("short flag")
+	}
+	defer log.Scope(b).Close(b)
+	ForEachDB(b, func(b *testing.B, db *gosql.DB) {
+		defer func() {
+			if _, err := db.Exec(`DROP TABLE IF EXISTS bench.count`); err != nil {
+				b.Fatal(err)
+			}
+		}()
+
+		if _, err := db.Exec(
+			`CREATE TABLE bench.count (k INT PRIMARY KEY, v TEXT, FAMILY(k), FAMILY(v))`); err != nil {
+			b.Fatal(err)
+		}
+
+		var buf bytes.Buffer
+		val := 0
+		for i := 0; i < 100; i++ {
+			buf.Reset()
+			buf.WriteString(`INSERT INTO bench.count VALUES `)
+			for j := 0; j < 1000; j++ {
+				if j > 0 {
+					buf.WriteString(", ")
+				}
+				fmt.Fprintf(&buf, "(%d, '%s')", val, strconv.Itoa(val))
+				val++
+			}
+			if _, err := db.Exec(buf.String()); err != nil {
+				b.Fatal(err)
+			}
+		}
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			if _, err := db.Exec("SELECT count(*) FROM bench.count"); err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.StopTimer()
+	})
+}
+
 func BenchmarkSort(b *testing.B) {
 	if testing.Short() {
 		b.Skip("short flag")

--- a/pkg/bench/bench_test.go
+++ b/pkg/bench/bench_test.go
@@ -181,7 +181,7 @@ func BenchmarkCountTwoCF(b *testing.B) {
 		}()
 
 		if _, err := db.Exec(
-			`CREATE TABLE bench.count (k INT PRIMARY KEY, v TEXT, FAMILY(k), FAMILY(v))`); err != nil {
+			`CREATE TABLE bench.count (k INT PRIMARY KEY, v TEXT, FAMILY (k), FAMILY (v))`); err != nil {
 			b.Fatal(err)
 		}
 

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -16,7 +16,6 @@ package row_test
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -161,7 +160,6 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 		INSERT INTO child VALUES ('1', '10'), ('2', '20');
 		SELECT cluster_logical_timestamp();
 	END;`).Scan(&ts1)
-	fmt.Println(sqlDB.QueryStr(t, `SELECT * FROM parent`))
 
 	if actual, expected := kvsToRows(slurpUserDataKVs(t, store.Engine())), []rowWithMVCCMetadata{
 		{[]string{`1`, `a`, `a`, `a`}, false, ts1},
@@ -179,7 +177,6 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 		UPDATE child SET f = '21' WHERE e = '2';
 		SELECT cluster_logical_timestamp();
 	END;`).Scan(&ts2)
-	fmt.Println(sqlDB.QueryStr(t, `SELECT * FROM parent`))
 
 	if actual, expected := kvsToRows(slurpUserDataKVs(t, store.Engine())), []rowWithMVCCMetadata{
 		{[]string{`1`, `NULL`, `NULL`, `NULL`}, false, ts2},


### PR DESCRIPTION
Previously, in multi column family tables, the row fetcher would
unconditionally decode the prefix of every key, then check to see if
that prefix was identical to the last prefix to determine whether or not
a new row was found.

This commit reverses the order - first we check the prefix, so that if
it's identical to the last prefix, we can completely skip decoding the
key.

Fixes #21565.

```
name                     old time/op    new time/op    delta
CountTwoCF/Cockroach-24    51.3ms ± 1%    50.4ms ± 1%  -1.70%  (p=0.000 n=10+9)

name                     old alloc/op   new alloc/op   delta
CountTwoCF/Cockroach-24    6.97MB ± 0%    6.98MB ± 0%    ~     (p=0.515 n=10+8)

name                     old allocs/op  new allocs/op  delta
CountTwoCF/Cockroach-24     1.99k ± 2%     1.99k ± 1%    ~     (p=0.828 n=10+8)
```

I'm not sure why the benchmark results don't look better. In local
testing, I see more like a 10% improvement. Either way, this is an
unambiguous win.

Release note: None