### PR TITLE
sql: let AS OF SYSTEM TIME requests use table descriptor cache

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -343,7 +343,6 @@ func (ex *connExecutor) execStmtInOpenState(
 		}
 		if ts != nil {
 			p.semaCtx.AsOfTimestamp = ts
-			p.avoidCachedDescriptors = true
 			ex.state.mu.txn.SetFixedTimestamp(ctx, *ts)
 		}
 	} else {
@@ -362,7 +361,6 @@ func (ex *connExecutor) execStmtInOpenState(
 					ex.state.mu.txn.OrigTimestamp()))
 			}
 			p.semaCtx.AsOfTimestamp = ts
-			p.avoidCachedDescriptors = true
 		}
 	}
 

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -198,10 +198,6 @@ func (ex *connExecutor) prepare(
 		}
 		if protoTS != nil {
 			p.semaCtx.AsOfTimestamp = protoTS
-			// We can't use cached descriptors anywhere in this query, because
-			// we want the descriptors at the timestamp given, not the latest
-			// known to the cache.
-			p.avoidCachedDescriptors = true
 			txn.SetFixedTimestamp(ctx, *protoTS)
 		}
 

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -201,7 +201,12 @@ func (p *planner) getTableScanByRef(
 	indexFlags *tree.IndexFlags,
 	scanVisibility scanVisibility,
 ) (planDataSource, error) {
-	flags := ObjectLookupFlags{CommonLookupFlags{txn: p.txn, avoidCached: p.avoidCachedDescriptors}}
+	flags := ObjectLookupFlags{CommonLookupFlags{
+		txn:            p.txn,
+		avoidCached:    p.avoidCachedDescriptors,
+		fixedTimestamp: p.semaCtx.AsOfTimestamp != nil,
+	},
+	}
 	desc, err := p.Tables().getTableVersionByID(ctx, sqlbase.ID(tref.TableID), flags)
 	if err != nil {
 		return planDataSource{}, errors.Wrapf(err, "%s", tree.ErrString(tref))

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -508,8 +508,7 @@ func (s LeaseStore) getForExpiration(
 	var table *tableVersionState
 	err := s.execCfg.DB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		descKey := sqlbase.MakeDescMetadataKey(id)
-		prevTimestamp := expiration
-		prevTimestamp.WallTime--
+		prevTimestamp := expiration.Prev()
 		txn.SetFixedTimestamp(ctx, prevTimestamp)
 		var desc sqlbase.Descriptor
 		if err := txn.GetProto(ctx, descKey, &desc); err != nil {
@@ -756,7 +755,7 @@ func (m *LeaseManager) readOlderVersionForTimestamp(
 		afterIdx := 0
 		// Walk back the versions to find one that is valid for the timestamp.
 		for i := len(t.mu.active.data) - 1; i >= 0; i-- {
-			// Check to see if the ModififcationTime is valid.
+			// Check to see if the ModificationTime is valid.
 			if table := t.mu.active.data[i]; !timestamp.Less(table.ModificationTime) {
 				if timestamp.Less(table.expiration) {
 					// Existing valid table version.

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -241,10 +241,11 @@ func (p *planner) LookupObject(
 
 func (p *planner) CommonLookupFlags(ctx context.Context, required bool) CommonLookupFlags {
 	return CommonLookupFlags{
-		ctx:         ctx,
-		txn:         p.txn,
-		required:    required,
-		avoidCached: p.avoidCachedDescriptors,
+		ctx:            ctx,
+		txn:            p.txn,
+		required:       required,
+		avoidCached:    p.avoidCachedDescriptors,
+		fixedTimestamp: p.semaCtx.AsOfTimestamp != nil,
 	}
 }
 

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -106,6 +106,8 @@ type CommonLookupFlags struct {
 	required bool
 	// if avoidCached is set, lookup will avoid the cache (if any).
 	avoidCached bool
+	// set to true if the transaction has a fixed timestamp.
+	fixedTimestamp bool
 }
 
 // DatabaseLookupFlags is the flag struct suitable for GetDatabaseDesc().

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -269,7 +269,7 @@ func (p *planner) truncateTable(
 	}
 	newTableDesc.Mutations = nil
 	newTableDesc.GCMutations = nil
-
+	newTableDesc.ModificationTime = p.txn.CommitTimestamp()
 	tKey := tableKey{parentID: newTableDesc.ParentID, name: newTableDesc.Name}
 	key := tKey.Key()
 	if err := p.createDescriptorWithID(


### PR DESCRIPTION
This change also fixes a problem where TRUNCATE was not
setting the ModificationTime on the descriptor.

This change also fixes a bug where we were not using
Timestamp.Prev() to compute the previous timestamp
when reading the previous version of a descriptor.

This change disables the use of the descriptor cache
when AS OF SYSTEM TIME is for a timestamp before
a DROP or a TRUNCATE on a table because of a bug
in AcquireByName().

fixes #30967

Release note (sql change): Speedup AS OF SYSTEM TIME requests by
letting them use the table descriptor cache.