### PR TITLE
storage: unskip TestSpanResolverUsesCaches

### DIFF
--- a/pkg/sql/distsqlplan/span_resolver_test.go
+++ b/pkg/sql/distsqlplan/span_resolver_test.go
@@ -41,7 +41,6 @@ import (
 // state of caches.
 func TestSpanResolverUsesCaches(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#13525")
 	tc := testcluster.StartTestCluster(t, 4,
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationManual,


### PR DESCRIPTION
This is no longer flaky, perhaps as a result of #31013.

Verified via:

    $ roachprod create tobias-stress -n 10 --gce-machine-type=n1-standard-8 --local-ssd=false
    $ make roachprod-stressrace PKG=./pkg/sql/distsqlplan TESTS=TestSpanResolverUsesCaches CLUSTER=tobias-stress
    ...
    8431 runs so far, 0 failures, over 15m15s

Release note: None