### PR TITLE
storage: don't log benign queue errors

### DIFF
--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/causer"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -766,6 +767,23 @@ func (bq *baseQueue) processReplica(queueCtx context.Context, repl *Replica) err
 	return nil
 }
 
+type benignError struct {
+	error
+}
+
+var _ causer.Causer = &benignError{}
+
+func (be *benignError) Cause() error {
+	return be.error
+}
+
+func isBenign(err error) bool {
+	return causer.Visit(err, func(err error) bool {
+		_, ok := err.(*benignError)
+		return ok
+	})
+}
+
 // finishProcessingReplica handles the completion of a replica process attempt.
 // It removes the replica from the replica set and may re-enqueue the replica or
 // add it to purgatory.
@@ -787,7 +805,12 @@ func (bq *baseQueue) finishProcessingReplica(
 
 	// Handle failures.
 	if err != nil {
-		// Increment failures metric to capture all error.
+		benign := isBenign(err)
+
+		// Increment failures metric.
+		//
+		// TODO(tschottdorf): once we start asserting zero failures in tests
+		// (and production), move benign failures into a dedicated category.
 		bq.failures.Inc(1)
 
 		// Determine whether a failure is a purgatory error. If it is, add
@@ -799,8 +822,10 @@ func (bq *baseQueue) finishProcessingReplica(
 			return
 		}
 
-		// If not a purgatory error, log.
-		log.Error(ctx, err)
+		// If not a benign or purgatory error, log.
+		if !benign {
+			log.Error(ctx, err)
+		}
 	}
 
 	// Maybe add replica back into queue, if requested.

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -6950,9 +6950,12 @@ func (r *Replica) setPendingSnapshotIndex(index uint64) error {
 	// snapshots on the same replica which is disallowed.
 	if (index == 1 && r.mu.pendingSnapshotIndex != 0) ||
 		(index > 1 && r.mu.pendingSnapshotIndex != 1) {
-		return errors.Errorf(
+		// NB: this path can be hit if the replicate queue and scatter work
+		// concurrently. It's still good to return an error to avoid duplicating
+		// work, but we make it a benign one (so that it isn't logged).
+		return &benignError{errors.Errorf(
 			"%s: can't set pending snapshot index to %d; pending snapshot already present: %d",
-			r, index, r.mu.pendingSnapshotIndex)
+			r, index, r.mu.pendingSnapshotIndex)}
 	}
 	r.mu.pendingSnapshotIndex = index
 	return nil

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
+	"github.com/cockroachdb/cockroach/pkg/util/causer"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -170,8 +171,8 @@ func (r *Replica) AdminSplit(
 		}
 
 		reply, lastErr = r.adminSplitWithDescriptor(ctx, args, r.Desc())
-		// On seeing a ConditionFailedError or an AmbiguousResultError, retry the
-		// command with the updated descriptor.
+		// On seeing a ConditionFailedError or an AmbiguousResultError, retry
+		// the command with the updated descriptor.
 		switch errors.Cause(lastErr).(type) {
 		case *roachpb.ConditionFailedError:
 		case *roachpb.AmbiguousResultError:
@@ -375,7 +376,9 @@ func (r *Replica) adminSplitWithDescriptor(
 		// ConditionFailedError in the error detail so that the command can be
 		// retried.
 		if msg, ok := maybeDescriptorChangedError(desc, err); ok {
-			err = errors.Wrap(err, msg)
+			// NB: we have to wrap the existing error here as consumers of this
+			// code look at the root cause to sniff out the changed descriptor.
+			err = &benignError{errors.Wrap(err, msg)}
 		}
 		return reply, errors.Wrapf(err, "split at key %s failed", splitKey)
 	}
@@ -647,6 +650,7 @@ func waitForReplicasInit(
 }
 
 type snapshotError struct {
+	// NB: don't implement Cause() on this type without also updating IsSnapshotError.
 	cause error
 }
 
@@ -657,8 +661,10 @@ func (s *snapshotError) Error() string {
 // IsSnapshotError returns true iff the error indicates a preemptive
 // snapshot failed.
 func IsSnapshotError(err error) bool {
-	_, ok := err.(*snapshotError)
-	return ok
+	return causer.Visit(err, func(err error) bool {
+		_, ok := errors.Cause(err).(*snapshotError)
+		return ok
+	})
 }
 
 // ChangeReplicas adds or removes a replica of a range. The change is performed
@@ -913,7 +919,7 @@ func (r *Replica) changeReplicas(
 	}); err != nil {
 		log.Event(ctx, err.Error())
 		if msg, ok := maybeDescriptorChangedError(desc, err); ok {
-			return errors.Wrapf(err, "change replicas of r%d failed: %s", rangeID, msg)
+			err = &benignError{errors.New(msg)}
 		}
 		return errors.Wrapf(err, "change replicas of r%d failed", rangeID)
 	}
@@ -954,7 +960,9 @@ func (r *Replica) sendSnapshot(
 
 	status := r.RaftStatus()
 	if status == nil {
-		return errors.New("raft status not initialized")
+		// This code path is sometimes hit during scatter for replicas that
+		// haven't woken up yet.
+		return &benignError{errors.New("raft status not initialized")}
 	}
 
 	req := SnapshotRequest_Header{

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -380,8 +380,10 @@ func (rq *replicateQueue) processOneChange(
 		log.VEventf(ctx, 3, "filtered unremovable replicas from %v to get %v as candidates for removal",
 			desc.Replicas, candidates)
 		if len(candidates) == 0 {
-			return false, errors.Errorf("no removable replicas from range that needs a removal: %s",
-				rangeRaftProgress(repl.RaftStatus(), desc.Replicas))
+			// After rapid upreplication, the candidates for removal could still be catching up.
+			// Mark this error as benign so it doesn't create confusion in the logs.
+			return false, &benignError{errors.Errorf("no removable replicas from range that needs a removal: %s",
+				rangeRaftProgress(repl.RaftStatus(), desc.Replicas))}
 		}
 		removeReplica, details, err := rq.allocator.RemoveTarget(ctx, zone, candidates, rangeInfo)
 		if err != nil {

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -616,7 +616,7 @@ func sendSnapshot(
 			if len(resp.Message) > 0 {
 				declinedMsg = resp.Message
 			}
-			return errors.Errorf("%s: remote declined %s: %s", to, snap, declinedMsg)
+			return &benignError{errors.Errorf("%s: remote declined %s: %s", to, snap, declinedMsg)}
 		}
 		storePool.throttle(throttleFailed, to.StoreID)
 		return errors.Errorf("%s: programming error: remote declined required %s: %s",

--- a/pkg/util/causer/causer.go
+++ b/pkg/util/causer/causer.go
@@ -1,0 +1,42 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package causer
+
+// A Causer is an error that wraps a causing error (which in turn could be
+// another Causer). A Causer is usually constructed via errors.Wrap or Wrapf.
+type Causer interface {
+	error
+	Cause() error
+}
+
+// Visit walks along the chain of errors until it encounters the first one that
+// does not implement Causer. The visitor is invoked with each error visited
+// until there are no more errors to visit or the visitor returns true (which is
+// then the return value of Visit as well). Returns false when the visitor never
+// returns true or if the initial error is nil.
+// Calling this method on a cyclic error chain results in an infinite loop.
+func Visit(err error, f func(error) bool) bool {
+	for err != nil {
+		if f(err) {
+			return true
+		}
+		cause, ok := err.(Causer)
+		if !ok {
+			return false
+		}
+		err = cause.Cause()
+	}
+	return false
+}

--- a/pkg/util/causer/causer_test.go
+++ b/pkg/util/causer/causer_test.go
@@ -1,0 +1,53 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package causer
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/pkg/errors"
+)
+
+type fooErr struct {
+	error
+}
+
+func isFoo(err error) bool {
+	return Visit(err, func(err error) bool {
+		_, ok := err.(*fooErr)
+		return ok
+	})
+}
+
+func TestCauserVisit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	loudErr := errors.Wrap(errors.New("root cause"), "this happened")
+	quietErr := errors.Wrap(errors.Wrap(&fooErr{loudErr}, "foo"), "bar")
+
+	if isFoo(loudErr) {
+		t.Fatal("non-benign error marked as benign")
+	}
+	if !isFoo(&fooErr{errors.New("foo")}) {
+		t.Fatal("foo error not recognized as such")
+	}
+	if !isFoo(quietErr) {
+		t.Fatal("wrapped foo error not recognized as such")
+	}
+	if isFoo(nil) {
+		t.Fatal("nil error should not be foo")
+	}
+}


### PR DESCRIPTION
This is a WIP that I'll have to complete when more pressing issues have been
addressed.

----

Queues can run into a variety of errors which are "harmless" in nature
(assuming they are not permanent).

Introduce a mechanism to detect such errors and avoid having them
increment the error metrics (and pollute the logs).

Touches #31373.

Release note: None