### PR TITLE
 sql: unreserve MINVALUE and MAXVALUE

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -373,7 +373,7 @@ on_conflict ::=
 	| 'ON' 'CONFLICT' opt_conf_expr 'DO' 'NOTHING'
 
 a_expr ::=
-	( c_expr | '+' a_expr | '-' a_expr | '~' a_expr | 'NOT' a_expr | 'NOT' a_expr | 'DEFAULT' | 'MAXVALUE' | 'MINVALUE' ) ( ( 'TYPECAST' cast_target | 'TYPEANNOTATE' typename | 'COLLATE' collation_name | '+' a_expr | '-' a_expr | '*' a_expr | '/' a_expr | 'FLOORDIV' a_expr | '%' a_expr | '^' a_expr | '#' a_expr | '&' a_expr | '|' a_expr | '<' a_expr | '>' a_expr | '?' a_expr | 'JSON_SOME_EXISTS' a_expr | 'JSON_ALL_EXISTS' a_expr | 'CONTAINS' a_expr | 'CONTAINED_BY' a_expr | '=' a_expr | 'CONCAT' a_expr | 'LSHIFT' a_expr | 'RSHIFT' a_expr | 'FETCHVAL' a_expr | 'FETCHTEXT' a_expr | 'FETCHVAL_PATH' a_expr | 'FETCHTEXT_PATH' a_expr | 'REMOVE_PATH' a_expr | 'INET_CONTAINED_BY_OR_EQUALS' a_expr | 'INET_CONTAINS_OR_CONTAINED_BY' a_expr | 'INET_CONTAINS_OR_EQUALS' a_expr | 'LESS_EQUALS' a_expr | 'GREATER_EQUALS' a_expr | 'NOT_EQUALS' a_expr | 'AND' a_expr | 'OR' a_expr | 'LIKE' a_expr | 'LIKE' a_expr 'ESCAPE' a_expr | 'NOT' 'LIKE' a_expr | 'NOT' 'LIKE' a_expr 'ESCAPE' a_expr | 'ILIKE' a_expr | 'ILIKE' a_expr 'ESCAPE' a_expr | 'NOT' 'ILIKE' a_expr | 'NOT' 'ILIKE' a_expr 'ESCAPE' a_expr | 'SIMILAR' 'TO' a_expr | 'SIMILAR' 'TO' a_expr 'ESCAPE' a_expr | 'NOT' 'SIMILAR' 'TO' a_expr | 'NOT' 'SIMILAR' 'TO' a_expr 'ESCAPE' a_expr | '~' a_expr | 'NOT_REGMATCH' a_expr | 'REGIMATCH' a_expr | 'NOT_REGIMATCH' a_expr | 'IS' 'NAN' | 'IS' 'NOT' 'NAN' | 'IS' 'NULL' | 'ISNULL' | 'IS' 'NOT' 'NULL' | 'NOTNULL' | 'IS' 'TRUE' | 'IS' 'NOT' 'TRUE' | 'IS' 'FALSE' | 'IS' 'NOT' 'FALSE' | 'IS' 'UNKNOWN' | 'IS' 'NOT' 'UNKNOWN' | 'IS' 'DISTINCT' 'FROM' a_expr | 'IS' 'NOT' 'DISTINCT' 'FROM' a_expr | 'IS' 'OF' '(' type_list ')' | 'IS' 'NOT' 'OF' '(' type_list ')' | 'BETWEEN' opt_asymmetric b_expr 'AND' a_expr | 'NOT' 'BETWEEN' opt_asymmetric b_expr 'AND' a_expr | 'BETWEEN' 'SYMMETRIC' b_expr 'AND' a_expr | 'NOT' 'BETWEEN' 'SYMMETRIC' b_expr 'AND' a_expr | 'IN' in_expr | 'NOT' 'IN' in_expr | subquery_op sub_type a_expr ) )*
+	( c_expr | '+' a_expr | '-' a_expr | '~' a_expr | 'NOT' a_expr | 'NOT' a_expr | 'DEFAULT' ) ( ( 'TYPECAST' cast_target | 'TYPEANNOTATE' typename | 'COLLATE' collation_name | '+' a_expr | '-' a_expr | '*' a_expr | '/' a_expr | 'FLOORDIV' a_expr | '%' a_expr | '^' a_expr | '#' a_expr | '&' a_expr | '|' a_expr | '<' a_expr | '>' a_expr | '?' a_expr | 'JSON_SOME_EXISTS' a_expr | 'JSON_ALL_EXISTS' a_expr | 'CONTAINS' a_expr | 'CONTAINED_BY' a_expr | '=' a_expr | 'CONCAT' a_expr | 'LSHIFT' a_expr | 'RSHIFT' a_expr | 'FETCHVAL' a_expr | 'FETCHTEXT' a_expr | 'FETCHVAL_PATH' a_expr | 'FETCHTEXT_PATH' a_expr | 'REMOVE_PATH' a_expr | 'INET_CONTAINED_BY_OR_EQUALS' a_expr | 'INET_CONTAINS_OR_CONTAINED_BY' a_expr | 'INET_CONTAINS_OR_EQUALS' a_expr | 'LESS_EQUALS' a_expr | 'GREATER_EQUALS' a_expr | 'NOT_EQUALS' a_expr | 'AND' a_expr | 'OR' a_expr | 'LIKE' a_expr | 'LIKE' a_expr 'ESCAPE' a_expr | 'NOT' 'LIKE' a_expr | 'NOT' 'LIKE' a_expr 'ESCAPE' a_expr | 'ILIKE' a_expr | 'ILIKE' a_expr 'ESCAPE' a_expr | 'NOT' 'ILIKE' a_expr | 'NOT' 'ILIKE' a_expr 'ESCAPE' a_expr | 'SIMILAR' 'TO' a_expr | 'SIMILAR' 'TO' a_expr 'ESCAPE' a_expr | 'NOT' 'SIMILAR' 'TO' a_expr | 'NOT' 'SIMILAR' 'TO' a_expr 'ESCAPE' a_expr | '~' a_expr | 'NOT_REGMATCH' a_expr | 'REGIMATCH' a_expr | 'NOT_REGIMATCH' a_expr | 'IS' 'NAN' | 'IS' 'NOT' 'NAN' | 'IS' 'NULL' | 'ISNULL' | 'IS' 'NOT' 'NULL' | 'NOTNULL' | 'IS' 'TRUE' | 'IS' 'NOT' 'TRUE' | 'IS' 'FALSE' | 'IS' 'NOT' 'FALSE' | 'IS' 'UNKNOWN' | 'IS' 'NOT' 'UNKNOWN' | 'IS' 'DISTINCT' 'FROM' a_expr | 'IS' 'NOT' 'DISTINCT' 'FROM' a_expr | 'IS' 'OF' '(' type_list ')' | 'IS' 'NOT' 'OF' '(' type_list ')' | 'BETWEEN' opt_asymmetric b_expr 'AND' a_expr | 'NOT' 'BETWEEN' opt_asymmetric b_expr 'AND' a_expr | 'BETWEEN' 'SYMMETRIC' b_expr 'AND' a_expr | 'NOT' 'BETWEEN' 'SYMMETRIC' b_expr 'AND' a_expr | 'IN' in_expr | 'NOT' 'IN' in_expr | subquery_op sub_type a_expr ) )*
 
 reset_session_stmt ::=
 	'RESET' session_var
@@ -624,7 +624,9 @@ unreserved_keyword ::=
 	| 'LOW'
 	| 'MATCH'
 	| 'MATERIALIZED'
+	| 'MAXVALUE'
 	| 'MINUTE'
+	| 'MINVALUE'
 	| 'MONTH'
 	| 'NAMES'
 	| 'NAN'
@@ -1459,8 +1461,6 @@ type_func_name_keyword ::=
 
 cockroachdb_extra_type_func_name_keyword ::=
 	'FAMILY'
-	| 'MAXVALUE'
-	| 'MINVALUE'
 
 cockroachdb_extra_reserved_keyword ::=
 	'INDEX'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -810,8 +810,8 @@ kv_option_list ::=
 
 complex_table_pattern ::=
 	complex_db_object_name
-	| name '.' unrestricted_name '.' '*'
-	| name '.' '*'
+	| db_object_name_component '.' unrestricted_name '.' '*'
+	| db_object_name_component '.' '*'
 	| '*'
 
 table_pattern ::=
@@ -1095,11 +1095,11 @@ set_clause ::=
 	| multiple_set_clause
 
 simple_db_object_name ::=
-	name
+	db_object_name_component
 
 complex_db_object_name ::=
-	name '.' unrestricted_name
-	| name '.' unrestricted_name '.' unrestricted_name
+	db_object_name_component '.' unrestricted_name
+	| db_object_name_component '.' unrestricted_name '.' unrestricted_name
 
 non_reserved_word ::=
 	'identifier'
@@ -1112,6 +1112,11 @@ kv_option ::=
 	| name
 	| 'SCONST' '=' string_or_placeholder
 	| 'SCONST'
+
+db_object_name_component ::=
+	name
+	| cockroachdb_extra_type_func_name_keyword
+	| cockroachdb_extra_reserved_keyword
 
 unrestricted_name ::=
 	'identifier'
@@ -1432,7 +1437,6 @@ multiple_set_clause ::=
 type_func_name_keyword ::=
 	'COLLATION'
 	| 'CROSS'
-	| 'FAMILY'
 	| 'FULL'
 	| 'INNER'
 	| 'ILIKE'
@@ -1441,14 +1445,22 @@ type_func_name_keyword ::=
 	| 'JOIN'
 	| 'LEFT'
 	| 'LIKE'
-	| 'MAXVALUE'
-	| 'MINVALUE'
 	| 'NATURAL'
 	| 'NOTNULL'
 	| 'OUTER'
 	| 'OVERLAPS'
 	| 'RIGHT'
 	| 'SIMILAR'
+	| cockroachdb_extra_type_func_name_keyword
+
+cockroachdb_extra_type_func_name_keyword ::=
+	'FAMILY'
+	| 'MAXVALUE'
+	| 'MINVALUE'
+
+cockroachdb_extra_reserved_keyword ::=
+	'INDEX'
+	| 'NOTHING'
 
 reserved_keyword ::=
 	'ALL'
@@ -1492,7 +1504,6 @@ reserved_keyword ::=
 	| 'GROUP'
 	| 'HAVING'
 	| 'IN'
-	| 'INDEX'
 	| 'INITIALLY'
 	| 'INTERSECT'
 	| 'INTO'
@@ -1502,7 +1513,6 @@ reserved_keyword ::=
 	| 'LOCALTIME'
 	| 'LOCALTIMESTAMP'
 	| 'NOT'
-	| 'NOTHING'
 	| 'NULL'
 	| 'OFFSET'
 	| 'ON'
@@ -1531,6 +1541,7 @@ reserved_keyword ::=
 	| 'WHERE'
 	| 'WINDOW'
 	| 'WITH'
+	| cockroachdb_extra_reserved_keyword
 
 transaction_iso_level ::=
 	'ISOLATION' 'LEVEL' iso_level
@@ -1651,9 +1662,9 @@ interval ::=
 
 column_path_with_star ::=
 	column_path
-	| name '.' unrestricted_name '.' unrestricted_name '.' '*'
-	| name '.' unrestricted_name '.' '*'
-	| name '.' '*'
+	| db_object_name_component '.' unrestricted_name '.' unrestricted_name '.' '*'
+	| db_object_name_component '.' unrestricted_name '.' '*'
+	| db_object_name_component '.' '*'
 
 func_expr ::=
 	func_application filter_clause over_clause
@@ -2050,9 +2061,9 @@ interval_qualifier ::=
 	| 'MINUTE' 'TO' interval_second
 
 prefixed_column_path ::=
-	name '.' unrestricted_name
-	| name '.' unrestricted_name '.' unrestricted_name
-	| name '.' unrestricted_name '.' unrestricted_name '.' unrestricted_name
+	db_object_name_component '.' unrestricted_name
+	| db_object_name_component '.' unrestricted_name '.' unrestricted_name
+	| db_object_name_component '.' unrestricted_name '.' unrestricted_name '.' unrestricted_name
 
 func_name ::=
 	type_function_name

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1052,7 +1052,7 @@ to_or_eq ::=
 
 var_value ::=
 	a_expr
-	| 'ON'
+	| extra_var_value
 
 opt_on_targets_roles ::=
 	'ON' targets_roles
@@ -1420,6 +1420,10 @@ offset_clause ::=
 
 generic_set ::=
 	var_name to_or_eq var_list
+
+extra_var_value ::=
+	'ON'
+	| cockroachdb_extra_reserved_keyword
 
 targets_roles ::=
 	'ROLE' name_list

--- a/pkg/sql/parser/all_keywords.awk
+++ b/pkg/sql/parser/all_keywords.awk
@@ -21,9 +21,9 @@ BEGIN {
       category = "C"
   } else if ($1 == "unreserved_keyword:") {
       category = "U"
-  } else if ($1 == "type_func_name_keyword:") {
+  } else if ($1 == "type_func_name_keyword:" || $1 == "cockroachdb_extra_type_func_name_keyword:") {
       category = "T"
-  } else if ($1 == "reserved_keyword:") {
+  } else if ($1 == "reserved_keyword:" || $1 == "cockroachdb_extra_reserved_keyword:") {
       category ="R"
   } else {
       print "unknown keyword type:", $1 >>"/dev/stderr"
@@ -36,7 +36,7 @@ BEGIN {
   keyword = 0
 }
 
-{
+/^ *\|? *[A-Z]/ {
   if (keyword && $NF != "") {
       printf("\"%s\": {%s, \"%s\"},\n", tolower($NF), $NF, category) | sort
   }

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -198,7 +198,6 @@ func TestParse(t *testing.T) {
 		{`CREATE TABLE a (b INT CONSTRAINT c REFERENCES d)`},
 
 		{`CREATE TABLE a (b INT) PARTITION BY LIST (b) (PARTITION p1 VALUES IN (1, DEFAULT), PARTITION p2 VALUES IN ((1, 2), (3, 4)))`},
-		{`CREATE TABLE a (b INT) PARTITION BY RANGE (b) (PARTITION p1 VALUES FROM (MINVALUE) TO (1), PARTITION p2 VALUES FROM (2, MAXVALUE) TO (4, 4), PARTITION p3 VALUES FROM (4, 4) TO (MAXVALUE))`},
 		// This monstrosity was added on the assumption that it's more readable
 		// than all on one line. Feel free to rip it out if you come across it
 		// and disagree.
@@ -1842,10 +1841,19 @@ func TestParse2(t *testing.T) {
 			`CREATE TABLE "index" (x INT)`},
 		{`CREATE TABLE NOTHING (x INT)`,
 			`CREATE TABLE "nothing" (x INT)`},
+
+		// Ensure MINVALUE/MAXVALUE are not reserved.
 		{`CREATE TABLE MINVALUE (x INT)`,
-			`CREATE TABLE "minvalue" (x INT)`},
+			`CREATE TABLE minvalue (x INT)`},
 		{`CREATE TABLE MAXVALUE (x INT)`,
-			`CREATE TABLE "maxvalue" (x INT)`},
+			`CREATE TABLE maxvalue (x INT)`},
+		{`CREATE TABLE foo (MINVALUE INT)`,
+			`CREATE TABLE foo (minvalue INT)`},
+		{`CREATE TABLE foo (MAXVALUE INT)`,
+			`CREATE TABLE foo (maxvalue INT)`},
+
+		{`CREATE TABLE a (b INT) PARTITION BY RANGE (b) (PARTITION p1 VALUES FROM (MINVALUE) TO (1), PARTITION p2 VALUES FROM (2, MAXVALUE) TO (4, 4), PARTITION p3 VALUES FROM (4, 4) TO (MAXVALUE))`,
+			`CREATE TABLE a (b INT) PARTITION BY RANGE (b) (PARTITION p1 VALUES FROM (minvalue) TO (1), PARTITION p2 VALUES FROM (2, maxvalue) TO (4, 4), PARTITION p3 VALUES FROM (4, 4) TO (maxvalue))`},
 	}
 	for _, d := range testData {
 		stmts, err := parser.Parse(d.sql)

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1831,6 +1831,18 @@ func TestParse2(t *testing.T) {
 		{`ALTER TABLE a ALTER b DROP NOT NULL`, `ALTER TABLE a ALTER COLUMN b DROP NOT NULL`},
 		{`ALTER TABLE a ALTER b TYPE INT`, `ALTER TABLE a ALTER COLUMN b SET DATA TYPE INT`},
 		{`EXPLAIN ANALYZE SELECT 1`, `EXPLAIN ANALYZE (DISTSQL) SELECT 1`},
+
+		// Regression for #31589
+		{`CREATE TABLE FAMILY (x INT)`,
+			`CREATE TABLE "family" (x INT)`},
+		{`CREATE TABLE INDEX (x INT)`,
+			`CREATE TABLE "index" (x INT)`},
+		{`CREATE TABLE NOTHING (x INT)`,
+			`CREATE TABLE "nothing" (x INT)`},
+		{`CREATE TABLE MINVALUE (x INT)`,
+			`CREATE TABLE "minvalue" (x INT)`},
+		{`CREATE TABLE MAXVALUE (x INT)`,
+			`CREATE TABLE "maxvalue" (x INT)`},
 	}
 	for _, d := range testData {
 		stmts, err := parser.Parse(d.sql)

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1832,6 +1832,9 @@ func TestParse2(t *testing.T) {
 		{`ALTER TABLE a ALTER b TYPE INT`, `ALTER TABLE a ALTER COLUMN b SET DATA TYPE INT`},
 		{`EXPLAIN ANALYZE SELECT 1`, `EXPLAIN ANALYZE (DISTSQL) SELECT 1`},
 
+		{`SET a = INDEX`, `SET a = "index"`},
+		{`SET a = NOTHING`, `SET a = "nothing"`},
+
 		// Regression for #31589
 		{`CREATE TABLE FAMILY (x INT)`,
 			`CREATE TABLE "family" (x INT)`},

--- a/pkg/sql/parser/reserved_keywords.awk
+++ b/pkg/sql/parser/reserved_keywords.awk
@@ -3,12 +3,12 @@
   next
 }
 
-/^type_func_name_keyword:/ {
+/^(cockroachdb_extra_)?type_func_name_keyword:/ {
   reserved_keyword = 1
   next
 }
 
-/^reserved_keyword:/ {
+/^(cockroachdb_extra_)?reserved_keyword:/ {
   reserved_keyword = 1
   next
 }

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6890,14 +6890,6 @@ a_expr:
   {
     $$.val = tree.DefaultVal{}
   }
-| MAXVALUE
-  {
-    $$.val = tree.MaxVal{}
-  }
-| MINVALUE
-  {
-    $$.val = tree.MinVal{}
-  }
 // The UNIQUE predicate is a standard SQL feature but not yet implemented
 // in PostgreSQL (as of 10.5).
 | UNIQUE '(' error { return unimplemented(sqllex, "UNIQUE predicate") }
@@ -8488,7 +8480,9 @@ unreserved_keyword:
 | LOW
 | MATCH
 | MATERIALIZED
+| MAXVALUE
 | MINUTE
+| MINVALUE
 | MONTH
 | NAMES
 | NAN
@@ -8714,11 +8708,8 @@ type_func_name_keyword:
 // Adding keywords here creates non-resolvable incompatibilities with
 // postgres clients.
 //
-// TODO(dan): Make MINVALUE/MAXVALUE less reserved.
 cockroachdb_extra_type_func_name_keyword:
   FAMILY
-| MAXVALUE
-| MINVALUE
 
 // Reserved keyword --- these keywords are usable only as a unrestricted_name.
 //

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -774,6 +774,7 @@ func newNameFromStr(s string) *tree.Name {
 
 %type <str> database_name index_name opt_index_name column_name insert_column_item statistics_name window_name
 %type <str> family_name opt_family_name table_alias_name constraint_name target_name zone_name partition_name collation_name
+%type <str> db_object_name_component
 %type <*tree.UnresolvedName> table_name sequence_name type_name view_name db_object_name simple_db_object_name complex_db_object_name
 %type <*tree.UnresolvedName> table_pattern complex_table_pattern
 %type <*tree.UnresolvedName> column_path prefixed_column_path column_path_with_star
@@ -919,8 +920,8 @@ func newNameFromStr(s string) *tree.Name {
 %type <tree.Expr> string_or_placeholder
 %type <tree.Expr> string_or_placeholder_list
 
-%type <str> unreserved_keyword type_func_name_keyword
-%type <str> col_name_keyword reserved_keyword
+%type <str> unreserved_keyword type_func_name_keyword cockroachdb_extra_type_func_name_keyword
+%type <str> col_name_keyword reserved_keyword cockroachdb_extra_reserved_keyword
 
 %type <tree.ConstraintTableDef> table_constraint constraint_elem
 %type <tree.TableDef> index_def
@@ -8045,11 +8046,11 @@ table_pattern:
 // every pattern not composed of a single identifier.
 complex_table_pattern:
   complex_db_object_name
-| name '.' unrestricted_name '.' '*'
+| db_object_name_component '.' unrestricted_name '.' '*'
   {
      $$.val = &tree.UnresolvedName{Star: true, NumParts: 3, Parts: tree.NameParts{"", $3, $1}}
   }
-| name '.' '*'
+| db_object_name_component '.' '*'
   {
      $$.val = &tree.UnresolvedName{Star: true, NumParts: 2, Parts: tree.NameParts{"", $1}}
   }
@@ -8212,15 +8213,15 @@ column_path:
 | prefixed_column_path
 
 prefixed_column_path:
-  name '.' unrestricted_name
+  db_object_name_component '.' unrestricted_name
   {
       $$.val = &tree.UnresolvedName{NumParts:2, Parts: tree.NameParts{$3,$1}}
   }
-| name '.' unrestricted_name '.' unrestricted_name
+| db_object_name_component '.' unrestricted_name '.' unrestricted_name
   {
       $$.val = &tree.UnresolvedName{NumParts:3, Parts: tree.NameParts{$5,$3,$1}}
   }
-| name '.' unrestricted_name '.' unrestricted_name '.' unrestricted_name
+| db_object_name_component '.' unrestricted_name '.' unrestricted_name '.' unrestricted_name
   {
       $$.val = &tree.UnresolvedName{NumParts:4, Parts: tree.NameParts{$7,$5,$3,$1}}
   }
@@ -8234,15 +8235,15 @@ prefixed_column_path:
 // The single unqualified star is handled separately by target_elem.
 column_path_with_star:
   column_path
-| name '.' unrestricted_name '.' unrestricted_name '.' '*'
+| db_object_name_component '.' unrestricted_name '.' unrestricted_name '.' '*'
   {
     $$.val = &tree.UnresolvedName{Star:true, NumParts:4, Parts: tree.NameParts{"",$5,$3,$1}}
   }
-| name '.' unrestricted_name '.' '*'
+| db_object_name_component '.' unrestricted_name '.' '*'
   {
     $$.val = &tree.UnresolvedName{Star:true, NumParts:3, Parts: tree.NameParts{"",$3,$1}}
   }
-| name '.' '*'
+| db_object_name_component '.' '*'
   {
     $$.val = &tree.UnresolvedName{Star:true, NumParts:2, Parts: tree.NameParts{"",$1}}
   }
@@ -8273,7 +8274,7 @@ db_object_name:
 // simple_db_object_name is the part of db_object_name that recognizes
 // simple identifiers.
 simple_db_object_name:
-  name
+  db_object_name_component
   {
     $$.val = &tree.UnresolvedName{NumParts:1, Parts: tree.NameParts{$1}}
   }
@@ -8283,15 +8284,23 @@ simple_db_object_name:
 // It is split away from db_object_name in order to enable the definition
 // of table_pattern.
 complex_db_object_name:
-  name '.' unrestricted_name
+  db_object_name_component '.' unrestricted_name
   {
     $$.val = &tree.UnresolvedName{NumParts:2, Parts: tree.NameParts{$3,$1}}
   }
-| name '.' unrestricted_name '.' unrestricted_name
+| db_object_name_component '.' unrestricted_name '.' unrestricted_name
   {
     $$.val = &tree.UnresolvedName{NumParts:3, Parts: tree.NameParts{$5,$3,$1}}
   }
 
+// DB object name component -- this cannot not include any reserved
+// keyword because of ambiguity after FROM, but we've been too lax
+// with reserved keywords and made INDEX and FAMILY reserved, so we're
+// trying to gain them back here.
+db_object_name_component:
+  name
+| cockroachdb_extra_type_func_name_keyword
+| cockroachdb_extra_reserved_keyword
 
 // General name --- names that can be column, table, etc names.
 name:
@@ -8660,11 +8669,12 @@ col_name_keyword:
 // productions in a_expr to support the goofy SQL9x argument syntax.
 // - thomas 2000-11-28
 //
-// TODO(dan): see if we can move MAXVALUE and MINVALUE to a less restricted list
+// *** DO NOT ADD COCKROACHDB-SPECIFIC KEYWORDS HERE ***
+//
+// See cockroachdb_extra_type_func_name_keyword below.
 type_func_name_keyword:
   COLLATION
 | CROSS
-| FAMILY
 | FULL
 | INNER
 | ILIKE
@@ -8673,19 +8683,37 @@ type_func_name_keyword:
 | JOIN
 | LEFT
 | LIKE
-| MAXVALUE
-| MINVALUE
 | NATURAL
 | NOTNULL
 | OUTER
 | OVERLAPS
 | RIGHT
 | SIMILAR
+| cockroachdb_extra_type_func_name_keyword
+
+// CockroachDB-specific keywords that can be used in type/function
+// identifiers.
+//
+// *** REFRAIN FROM ADDING KEYWORDS HERE ***
+//
+// Adding keywords here creates non-resolvable incompatibilities with
+// postgres clients.
+//
+// TODO(dan): Make MINVALUE/MAXVALUE less reserved.
+cockroachdb_extra_type_func_name_keyword:
+  FAMILY
+| MAXVALUE
+| MINVALUE
 
 // Reserved keyword --- these keywords are usable only as a unrestricted_name.
 //
 // Keywords appear here if they could not be distinguished from variable, type,
-// or function names in some contexts. Don't put things here unless forced to.
+// or function names in some contexts.
+//
+// *** NEVER ADD KEYWORDS HERE ***
+//
+// See cockroachdb_extra_reserved_keyword below.
+//
 reserved_keyword:
   ALL
 | ANALYSE
@@ -8728,7 +8756,6 @@ reserved_keyword:
 | GROUP
 | HAVING
 | IN
-| INDEX
 | INITIALLY
 | INTERSECT
 | INTO
@@ -8738,7 +8765,6 @@ reserved_keyword:
 | LOCALTIME
 | LOCALTIMESTAMP
 | NOT
-| NOTHING
 | NULL
 | OFFSET
 | ON
@@ -8767,5 +8793,17 @@ reserved_keyword:
 | WHERE
 | WINDOW
 | WITH
+| cockroachdb_extra_reserved_keyword
+
+// Reserved keywords in CockroachDB, in addition to those reserved in
+// PostgreSQL.
+//
+// *** REFRAIN FROM ADDING KEYWORDS HERE ***
+//
+// Adding keywords here creates non-resolvable incompatibilities with
+// postgres clients.
+cockroachdb_extra_reserved_keyword:
+  INDEX
+| NOTHING
 
 %%

--- a/pkg/sql/parser/unreserved_keywords.awk
+++ b/pkg/sql/parser/unreserved_keywords.awk
@@ -1,4 +1,4 @@
-/^reserved_keyword:/ {
+/^(cockroachdb_extra_)?reserved_keyword:/ {
   keyword = 0
   next
 }

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -699,19 +699,19 @@ func (node DefaultVal) Format(ctx *FmtCtx) {
 // ResolvedType implements the TypedExpr interface.
 func (DefaultVal) ResolvedType() types.T { return nil }
 
-// MaxVal represents the MAXVALUE expression.
-type MaxVal struct{}
+// PartitionMaxVal represents the MAXVALUE expression.
+type PartitionMaxVal struct{}
 
 // Format implements the NodeFormatter interface.
-func (node MaxVal) Format(ctx *FmtCtx) {
+func (node PartitionMaxVal) Format(ctx *FmtCtx) {
 	ctx.WriteString("MAXVALUE")
 }
 
-// MinVal represents the MINVALUE expression.
-type MinVal struct{}
+// PartitionMinVal represents the MINVALUE expression.
+type PartitionMinVal struct{}
 
 // Format implements the NodeFormatter interface.
-func (node MinVal) Format(ctx *FmtCtx) {
+func (node PartitionMinVal) Format(ctx *FmtCtx) {
 	ctx.WriteString("MINVALUE")
 }
 
@@ -1700,8 +1700,8 @@ func (node *TupleStar) String() string        { return AsString(node) }
 func (node *AnnotateTypeExpr) String() string { return AsString(node) }
 func (node *UnaryExpr) String() string        { return AsString(node) }
 func (node DefaultVal) String() string        { return AsString(node) }
-func (node MaxVal) String() string            { return AsString(node) }
-func (node MinVal) String() string            { return AsString(node) }
+func (node PartitionMaxVal) String() string   { return AsString(node) }
+func (node PartitionMinVal) String() string   { return AsString(node) }
 func (node *Placeholder) String() string      { return AsString(node) }
 func (node dNull) String() string             { return AsString(node) }
 func (list *NameList) String() string         { return AsString(list) }

--- a/pkg/sql/sem/tree/testdata/pretty/create_partition_range.align-deindent.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/create_partition_range.align-deindent.golden
@@ -20,7 +20,7 @@ PARTITION BY RANGE (
 ) (
 	PARTITION graduated VALUES
 		FROM (
-			MINVALUE
+			minvalue
 		)
 		TO (
 			'2017-08-15'
@@ -30,7 +30,7 @@ PARTITION BY RANGE (
 			'2017-08-15'
 		)
 		TO (
-			MAXVALUE
+			maxvalue
 		)
 )
 
@@ -53,7 +53,7 @@ PARTITION BY RANGE (
 ) (
 	PARTITION graduated VALUES
 		FROM (
-			MINVALUE
+			minvalue
 		)
 		TO (
 			'2017-08-15'
@@ -63,7 +63,7 @@ PARTITION BY RANGE (
 			'2017-08-15'
 		)
 		TO (
-			MAXVALUE
+			maxvalue
 		)
 )
 
@@ -85,7 +85,7 @@ PARTITION BY RANGE (
 ) (
 	PARTITION graduated VALUES
 		FROM (
-			MINVALUE
+			minvalue
 		)
 		TO (
 			'2017-08-15'
@@ -95,7 +95,7 @@ PARTITION BY RANGE (
 			'2017-08-15'
 		)
 		TO (
-			MAXVALUE
+			maxvalue
 		)
 )
 
@@ -116,7 +116,7 @@ PARTITION BY RANGE (
 ) (
 	PARTITION graduated VALUES
 		FROM (
-			MINVALUE
+			minvalue
 		)
 		TO (
 			'2017-08-15'
@@ -126,7 +126,7 @@ PARTITION BY RANGE (
 			'2017-08-15'
 		)
 		TO (
-			MAXVALUE
+			maxvalue
 		)
 )
 
@@ -146,7 +146,7 @@ PARTITION BY RANGE (
 ) (
 	PARTITION graduated VALUES
 		FROM (
-			MINVALUE
+			minvalue
 		)
 		TO (
 			'2017-08-15'
@@ -156,7 +156,7 @@ PARTITION BY RANGE (
 			'2017-08-15'
 		)
 		TO (
-			MAXVALUE
+			maxvalue
 		)
 )
 
@@ -176,7 +176,7 @@ PARTITION BY RANGE (
 ) (
 	PARTITION graduated VALUES
 		FROM (
-			MINVALUE
+			minvalue
 		)
 		TO (
 			'2017-08-15'
@@ -185,7 +185,7 @@ PARTITION BY RANGE (
 		FROM (
 			'2017-08-15'
 		)
-		TO (MAXVALUE)
+		TO (maxvalue)
 )
 
 23:
@@ -203,7 +203,7 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES
-		FROM (MINVALUE)
+		FROM (minvalue)
 		TO (
 			'2017-08-15'
 		),
@@ -211,7 +211,7 @@ PARTITION BY RANGE (
 		FROM (
 			'2017-08-15'
 		)
-		TO (MAXVALUE)
+		TO (maxvalue)
 )
 
 26:
@@ -229,13 +229,13 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES
-		FROM (MINVALUE)
+		FROM (minvalue)
 		TO ('2017-08-15'),
 	PARTITION current VALUES
 		FROM (
 			'2017-08-15'
 		)
-		TO (MAXVALUE)
+		TO (maxvalue)
 )
 
 27:
@@ -253,11 +253,11 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES
-		FROM (MINVALUE)
+		FROM (minvalue)
 		TO ('2017-08-15'),
 	PARTITION current VALUES
 		FROM ('2017-08-15')
-		TO (MAXVALUE)
+		TO (maxvalue)
 )
 
 34:
@@ -274,11 +274,11 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES
-		FROM (MINVALUE)
+		FROM (minvalue)
 		TO ('2017-08-15'),
 	PARTITION current VALUES
 		FROM ('2017-08-15')
-		TO (MAXVALUE)
+		TO (maxvalue)
 )
 
 35:
@@ -295,13 +295,13 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES
-		FROM (MINVALUE)
+		FROM (minvalue)
 		TO ('2017-08-15'),
 	PARTITION current VALUES FROM (
 								'2017-08-15'
 	                         )
 	                         TO (
-								MAXVALUE
+								maxvalue
 	                         )
 )
 
@@ -319,7 +319,7 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES FROM (
-								MINVALUE
+								minvalue
 	                           )
 	                           TO (
 								'2017-08-15'
@@ -328,7 +328,7 @@ PARTITION BY RANGE (
 								'2017-08-15'
 	                         )
 	                         TO (
-								MAXVALUE
+								maxvalue
 	                         )
 )
 
@@ -346,7 +346,7 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES FROM (
-								MINVALUE
+								minvalue
 	                           )
 	                           TO (
 								'2017-08-15'
@@ -354,7 +354,7 @@ PARTITION BY RANGE (
 	PARTITION current VALUES FROM (
 								'2017-08-15'
 	                         )
-	                         TO (MAXVALUE)
+	                         TO (maxvalue)
 )
 
 46:
@@ -370,14 +370,14 @@ CREATE TABLE students_by_range (
 PARTITION BY RANGE (
 	expected_graduation_date
 ) (
-	PARTITION graduated VALUES FROM (MINVALUE)
+	PARTITION graduated VALUES FROM (minvalue)
 	                           TO (
 								'2017-08-15'
 	                           ),
 	PARTITION current VALUES FROM (
 								'2017-08-15'
 	                         )
-	                         TO (MAXVALUE)
+	                         TO (maxvalue)
 )
 
 47:
@@ -391,14 +391,14 @@ CREATE TABLE students_by_range (
 	PRIMARY KEY (expected_graduation_date, id)
 )
 PARTITION BY RANGE (expected_graduation_date) (
-	PARTITION graduated VALUES FROM (MINVALUE)
+	PARTITION graduated VALUES FROM (minvalue)
 	                           TO (
 								'2017-08-15'
 	                           ),
 	PARTITION current VALUES FROM (
 								'2017-08-15'
 	                         )
-	                         TO (MAXVALUE)
+	                         TO (maxvalue)
 )
 
 48:
@@ -412,12 +412,12 @@ CREATE TABLE students_by_range (
 	PRIMARY KEY (expected_graduation_date, id)
 )
 PARTITION BY RANGE (expected_graduation_date) (
-	PARTITION graduated VALUES FROM (MINVALUE)
+	PARTITION graduated VALUES FROM (minvalue)
 	                           TO (
 								'2017-08-15'
 	                           ),
 	PARTITION current VALUES FROM ('2017-08-15')
-	                         TO (MAXVALUE)
+	                         TO (maxvalue)
 )
 
 49:
@@ -431,10 +431,10 @@ CREATE TABLE students_by_range (
 	PRIMARY KEY (expected_graduation_date, id)
 )
 PARTITION BY RANGE (expected_graduation_date) (
-	PARTITION graduated VALUES FROM (MINVALUE)
+	PARTITION graduated VALUES FROM (minvalue)
 	                           TO ('2017-08-15'),
 	PARTITION current VALUES FROM ('2017-08-15')
-	                         TO (MAXVALUE)
+	                         TO (maxvalue)
 )
 
 62:
@@ -448,9 +448,9 @@ CREATE TABLE students_by_range (
 	PRIMARY KEY (expected_graduation_date, id)
 )
 PARTITION BY RANGE (expected_graduation_date) (
-	PARTITION graduated VALUES FROM (MINVALUE)
+	PARTITION graduated VALUES FROM (minvalue)
 	                           TO ('2017-08-15'),
-	PARTITION current VALUES FROM ('2017-08-15') TO (MAXVALUE)
+	PARTITION current VALUES FROM ('2017-08-15') TO (maxvalue)
 )
 
 65:
@@ -464,25 +464,25 @@ CREATE TABLE students_by_range (
 	PRIMARY KEY (expected_graduation_date, id)
 )
 PARTITION BY RANGE (expected_graduation_date) (
-	PARTITION graduated VALUES FROM (MINVALUE) TO ('2017-08-15'),
-	PARTITION current VALUES FROM ('2017-08-15') TO (MAXVALUE)
+	PARTITION graduated VALUES FROM (minvalue) TO ('2017-08-15'),
+	PARTITION current VALUES FROM ('2017-08-15') TO (maxvalue)
 )
 
 160:
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE TABLE students_by_range (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (expected_graduation_date, id))
 PARTITION BY RANGE (expected_graduation_date) (
-	PARTITION graduated VALUES FROM (MINVALUE) TO ('2017-08-15'),
-	PARTITION current VALUES FROM ('2017-08-15') TO (MAXVALUE)
+	PARTITION graduated VALUES FROM (minvalue) TO ('2017-08-15'),
+	PARTITION current VALUES FROM ('2017-08-15') TO (maxvalue)
 )
 
 168:
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE TABLE students_by_range (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (expected_graduation_date, id))
-PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current VALUES FROM ('2017-08-15') TO (MAXVALUE))
+PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current VALUES FROM ('2017-08-15') TO (maxvalue))
 
 329:
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-CREATE TABLE students_by_range (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (expected_graduation_date, id)) PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current VALUES FROM ('2017-08-15') TO (MAXVALUE))
+CREATE TABLE students_by_range (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (expected_graduation_date, id)) PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current VALUES FROM ('2017-08-15') TO (maxvalue))
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/create_partition_range.align-only.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/create_partition_range.align-only.golden
@@ -20,7 +20,7 @@ PARTITION BY RANGE (
 ) (
 	PARTITION graduated VALUES
 		FROM (
-			MINVALUE
+			minvalue
 		)
 		TO (
 			'2017-08-15'
@@ -30,7 +30,7 @@ PARTITION BY RANGE (
 			'2017-08-15'
 		)
 		TO (
-			MAXVALUE
+			maxvalue
 		)
 )
 
@@ -53,7 +53,7 @@ PARTITION BY RANGE (
 ) (
 	PARTITION graduated VALUES
 		FROM (
-			MINVALUE
+			minvalue
 		)
 		TO (
 			'2017-08-15'
@@ -63,7 +63,7 @@ PARTITION BY RANGE (
 			'2017-08-15'
 		)
 		TO (
-			MAXVALUE
+			maxvalue
 		)
 )
 
@@ -85,7 +85,7 @@ PARTITION BY RANGE (
 ) (
 	PARTITION graduated VALUES
 		FROM (
-			MINVALUE
+			minvalue
 		)
 		TO (
 			'2017-08-15'
@@ -95,7 +95,7 @@ PARTITION BY RANGE (
 			'2017-08-15'
 		)
 		TO (
-			MAXVALUE
+			maxvalue
 		)
 )
 
@@ -116,7 +116,7 @@ PARTITION BY RANGE (
 ) (
 	PARTITION graduated VALUES
 		FROM (
-			MINVALUE
+			minvalue
 		)
 		TO (
 			'2017-08-15'
@@ -126,7 +126,7 @@ PARTITION BY RANGE (
 			'2017-08-15'
 		)
 		TO (
-			MAXVALUE
+			maxvalue
 		)
 )
 
@@ -146,7 +146,7 @@ PARTITION BY RANGE (
 ) (
 	PARTITION graduated VALUES
 		FROM (
-			MINVALUE
+			minvalue
 		)
 		TO (
 			'2017-08-15'
@@ -156,7 +156,7 @@ PARTITION BY RANGE (
 			'2017-08-15'
 		)
 		TO (
-			MAXVALUE
+			maxvalue
 		)
 )
 
@@ -176,7 +176,7 @@ PARTITION BY RANGE (
 ) (
 	PARTITION graduated VALUES
 		FROM (
-			MINVALUE
+			minvalue
 		)
 		TO (
 			'2017-08-15'
@@ -185,7 +185,7 @@ PARTITION BY RANGE (
 		FROM (
 			'2017-08-15'
 		)
-		TO (MAXVALUE)
+		TO (maxvalue)
 )
 
 23:
@@ -203,7 +203,7 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES
-		FROM (MINVALUE)
+		FROM (minvalue)
 		TO (
 			'2017-08-15'
 		),
@@ -211,7 +211,7 @@ PARTITION BY RANGE (
 		FROM (
 			'2017-08-15'
 		)
-		TO (MAXVALUE)
+		TO (maxvalue)
 )
 
 26:
@@ -229,13 +229,13 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES
-		FROM (MINVALUE)
+		FROM (minvalue)
 		TO ('2017-08-15'),
 	PARTITION current VALUES
 		FROM (
 			'2017-08-15'
 		)
-		TO (MAXVALUE)
+		TO (maxvalue)
 )
 
 27:
@@ -253,11 +253,11 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES
-		FROM (MINVALUE)
+		FROM (minvalue)
 		TO ('2017-08-15'),
 	PARTITION current VALUES
 		FROM ('2017-08-15')
-		TO (MAXVALUE)
+		TO (maxvalue)
 )
 
 34:
@@ -274,11 +274,11 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES
-		FROM (MINVALUE)
+		FROM (minvalue)
 		TO ('2017-08-15'),
 	PARTITION current VALUES
 		FROM ('2017-08-15')
-		TO (MAXVALUE)
+		TO (maxvalue)
 )
 
 35:
@@ -295,13 +295,13 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES
-		FROM (MINVALUE)
+		FROM (minvalue)
 		TO ('2017-08-15'),
 	PARTITION current VALUES FROM (
 								'2017-08-15'
 	                         )
 	                         TO (
-								MAXVALUE
+								maxvalue
 	                         )
 )
 
@@ -319,7 +319,7 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES FROM (
-								MINVALUE
+								minvalue
 	                           )
 	                           TO (
 								'2017-08-15'
@@ -328,7 +328,7 @@ PARTITION BY RANGE (
 								'2017-08-15'
 	                         )
 	                         TO (
-								MAXVALUE
+								maxvalue
 	                         )
 )
 
@@ -346,7 +346,7 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES FROM (
-								MINVALUE
+								minvalue
 	                           )
 	                           TO (
 								'2017-08-15'
@@ -354,7 +354,7 @@ PARTITION BY RANGE (
 	PARTITION current VALUES FROM (
 								'2017-08-15'
 	                         )
-	                         TO (MAXVALUE)
+	                         TO (maxvalue)
 )
 
 46:
@@ -370,14 +370,14 @@ CREATE TABLE students_by_range (
 PARTITION BY RANGE (
 	expected_graduation_date
 ) (
-	PARTITION graduated VALUES FROM (MINVALUE)
+	PARTITION graduated VALUES FROM (minvalue)
 	                           TO (
 								'2017-08-15'
 	                           ),
 	PARTITION current VALUES FROM (
 								'2017-08-15'
 	                         )
-	                         TO (MAXVALUE)
+	                         TO (maxvalue)
 )
 
 47:
@@ -391,14 +391,14 @@ CREATE TABLE students_by_range (
 	PRIMARY KEY (expected_graduation_date, id)
 )
 PARTITION BY RANGE (expected_graduation_date) (
-	PARTITION graduated VALUES FROM (MINVALUE)
+	PARTITION graduated VALUES FROM (minvalue)
 	                           TO (
 								'2017-08-15'
 	                           ),
 	PARTITION current VALUES FROM (
 								'2017-08-15'
 	                         )
-	                         TO (MAXVALUE)
+	                         TO (maxvalue)
 )
 
 48:
@@ -412,12 +412,12 @@ CREATE TABLE students_by_range (
 	PRIMARY KEY (expected_graduation_date, id)
 )
 PARTITION BY RANGE (expected_graduation_date) (
-	PARTITION graduated VALUES FROM (MINVALUE)
+	PARTITION graduated VALUES FROM (minvalue)
 	                           TO (
 								'2017-08-15'
 	                           ),
 	PARTITION current VALUES FROM ('2017-08-15')
-	                         TO (MAXVALUE)
+	                         TO (maxvalue)
 )
 
 49:
@@ -431,10 +431,10 @@ CREATE TABLE students_by_range (
 	PRIMARY KEY (expected_graduation_date, id)
 )
 PARTITION BY RANGE (expected_graduation_date) (
-	PARTITION graduated VALUES FROM (MINVALUE)
+	PARTITION graduated VALUES FROM (minvalue)
 	                           TO ('2017-08-15'),
 	PARTITION current VALUES FROM ('2017-08-15')
-	                         TO (MAXVALUE)
+	                         TO (maxvalue)
 )
 
 62:
@@ -448,9 +448,9 @@ CREATE TABLE students_by_range (
 	PRIMARY KEY (expected_graduation_date, id)
 )
 PARTITION BY RANGE (expected_graduation_date) (
-	PARTITION graduated VALUES FROM (MINVALUE)
+	PARTITION graduated VALUES FROM (minvalue)
 	                           TO ('2017-08-15'),
-	PARTITION current VALUES FROM ('2017-08-15') TO (MAXVALUE)
+	PARTITION current VALUES FROM ('2017-08-15') TO (maxvalue)
 )
 
 65:
@@ -464,25 +464,25 @@ CREATE TABLE students_by_range (
 	PRIMARY KEY (expected_graduation_date, id)
 )
 PARTITION BY RANGE (expected_graduation_date) (
-	PARTITION graduated VALUES FROM (MINVALUE) TO ('2017-08-15'),
-	PARTITION current VALUES FROM ('2017-08-15') TO (MAXVALUE)
+	PARTITION graduated VALUES FROM (minvalue) TO ('2017-08-15'),
+	PARTITION current VALUES FROM ('2017-08-15') TO (maxvalue)
 )
 
 160:
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE TABLE students_by_range (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (expected_graduation_date, id))
 PARTITION BY RANGE (expected_graduation_date) (
-	PARTITION graduated VALUES FROM (MINVALUE) TO ('2017-08-15'),
-	PARTITION current VALUES FROM ('2017-08-15') TO (MAXVALUE)
+	PARTITION graduated VALUES FROM (minvalue) TO ('2017-08-15'),
+	PARTITION current VALUES FROM ('2017-08-15') TO (maxvalue)
 )
 
 168:
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE TABLE students_by_range (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (expected_graduation_date, id))
-PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current VALUES FROM ('2017-08-15') TO (MAXVALUE))
+PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current VALUES FROM ('2017-08-15') TO (maxvalue))
 
 329:
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-CREATE TABLE students_by_range (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (expected_graduation_date, id)) PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current VALUES FROM ('2017-08-15') TO (MAXVALUE))
+CREATE TABLE students_by_range (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (expected_graduation_date, id)) PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current VALUES FROM ('2017-08-15') TO (maxvalue))
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/create_partition_range.ref.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/create_partition_range.ref.golden
@@ -20,7 +20,7 @@ PARTITION BY RANGE (
 ) (
 	PARTITION graduated VALUES
 		FROM (
-			MINVALUE
+			minvalue
 		)
 		TO (
 			'2017-08-15'
@@ -30,7 +30,7 @@ PARTITION BY RANGE (
 			'2017-08-15'
 		)
 		TO (
-			MAXVALUE
+			maxvalue
 		)
 )
 
@@ -53,7 +53,7 @@ PARTITION BY RANGE (
 ) (
 	PARTITION graduated VALUES
 		FROM (
-			MINVALUE
+			minvalue
 		)
 		TO (
 			'2017-08-15'
@@ -63,7 +63,7 @@ PARTITION BY RANGE (
 			'2017-08-15'
 		)
 		TO (
-			MAXVALUE
+			maxvalue
 		)
 )
 
@@ -85,7 +85,7 @@ PARTITION BY RANGE (
 ) (
 	PARTITION graduated VALUES
 		FROM (
-			MINVALUE
+			minvalue
 		)
 		TO (
 			'2017-08-15'
@@ -95,7 +95,7 @@ PARTITION BY RANGE (
 			'2017-08-15'
 		)
 		TO (
-			MAXVALUE
+			maxvalue
 		)
 )
 
@@ -116,7 +116,7 @@ PARTITION BY RANGE (
 ) (
 	PARTITION graduated VALUES
 		FROM (
-			MINVALUE
+			minvalue
 		)
 		TO (
 			'2017-08-15'
@@ -126,7 +126,7 @@ PARTITION BY RANGE (
 			'2017-08-15'
 		)
 		TO (
-			MAXVALUE
+			maxvalue
 		)
 )
 
@@ -146,7 +146,7 @@ PARTITION BY RANGE (
 ) (
 	PARTITION graduated VALUES
 		FROM (
-			MINVALUE
+			minvalue
 		)
 		TO (
 			'2017-08-15'
@@ -156,7 +156,7 @@ PARTITION BY RANGE (
 			'2017-08-15'
 		)
 		TO (
-			MAXVALUE
+			maxvalue
 		)
 )
 
@@ -176,7 +176,7 @@ PARTITION BY RANGE (
 ) (
 	PARTITION graduated VALUES
 		FROM (
-			MINVALUE
+			minvalue
 		)
 		TO (
 			'2017-08-15'
@@ -185,7 +185,7 @@ PARTITION BY RANGE (
 		FROM (
 			'2017-08-15'
 		)
-		TO (MAXVALUE)
+		TO (maxvalue)
 )
 
 23:
@@ -203,7 +203,7 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES
-		FROM (MINVALUE)
+		FROM (minvalue)
 		TO (
 			'2017-08-15'
 		),
@@ -211,7 +211,7 @@ PARTITION BY RANGE (
 		FROM (
 			'2017-08-15'
 		)
-		TO (MAXVALUE)
+		TO (maxvalue)
 )
 
 26:
@@ -229,13 +229,13 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES
-		FROM (MINVALUE)
+		FROM (minvalue)
 		TO ('2017-08-15'),
 	PARTITION current VALUES
 		FROM (
 			'2017-08-15'
 		)
-		TO (MAXVALUE)
+		TO (maxvalue)
 )
 
 27:
@@ -253,11 +253,11 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES
-		FROM (MINVALUE)
+		FROM (minvalue)
 		TO ('2017-08-15'),
 	PARTITION current VALUES
 		FROM ('2017-08-15')
-		TO (MAXVALUE)
+		TO (maxvalue)
 )
 
 34:
@@ -274,11 +274,11 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES
-		FROM (MINVALUE)
+		FROM (minvalue)
 		TO ('2017-08-15'),
 	PARTITION current VALUES
 		FROM ('2017-08-15')
-		TO (MAXVALUE)
+		TO (maxvalue)
 )
 
 41:
@@ -295,10 +295,10 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES
-		FROM (MINVALUE)
+		FROM (minvalue)
 		TO ('2017-08-15'),
 	PARTITION current VALUES
-		FROM ('2017-08-15') TO (MAXVALUE)
+		FROM ('2017-08-15') TO (maxvalue)
 )
 
 42:
@@ -315,9 +315,9 @@ PARTITION BY RANGE (
 	expected_graduation_date
 ) (
 	PARTITION graduated VALUES
-		FROM (MINVALUE) TO ('2017-08-15'),
+		FROM (minvalue) TO ('2017-08-15'),
 	PARTITION current VALUES
-		FROM ('2017-08-15') TO (MAXVALUE)
+		FROM ('2017-08-15') TO (maxvalue)
 )
 
 47:
@@ -332,9 +332,9 @@ CREATE TABLE students_by_range (
 )
 PARTITION BY RANGE (expected_graduation_date) (
 	PARTITION graduated VALUES
-		FROM (MINVALUE) TO ('2017-08-15'),
+		FROM (minvalue) TO ('2017-08-15'),
 	PARTITION current VALUES
-		FROM ('2017-08-15') TO (MAXVALUE)
+		FROM ('2017-08-15') TO (maxvalue)
 )
 
 62:
@@ -349,8 +349,8 @@ CREATE TABLE students_by_range (
 )
 PARTITION BY RANGE (expected_graduation_date) (
 	PARTITION graduated VALUES
-		FROM (MINVALUE) TO ('2017-08-15'),
-	PARTITION current VALUES FROM ('2017-08-15') TO (MAXVALUE)
+		FROM (minvalue) TO ('2017-08-15'),
+	PARTITION current VALUES FROM ('2017-08-15') TO (maxvalue)
 )
 
 65:
@@ -364,25 +364,25 @@ CREATE TABLE students_by_range (
 	PRIMARY KEY (expected_graduation_date, id)
 )
 PARTITION BY RANGE (expected_graduation_date) (
-	PARTITION graduated VALUES FROM (MINVALUE) TO ('2017-08-15'),
-	PARTITION current VALUES FROM ('2017-08-15') TO (MAXVALUE)
+	PARTITION graduated VALUES FROM (minvalue) TO ('2017-08-15'),
+	PARTITION current VALUES FROM ('2017-08-15') TO (maxvalue)
 )
 
 160:
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE TABLE students_by_range (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (expected_graduation_date, id))
 PARTITION BY RANGE (expected_graduation_date) (
-	PARTITION graduated VALUES FROM (MINVALUE) TO ('2017-08-15'),
-	PARTITION current VALUES FROM ('2017-08-15') TO (MAXVALUE)
+	PARTITION graduated VALUES FROM (minvalue) TO ('2017-08-15'),
+	PARTITION current VALUES FROM ('2017-08-15') TO (maxvalue)
 )
 
 168:
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE TABLE students_by_range (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (expected_graduation_date, id))
-PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current VALUES FROM ('2017-08-15') TO (MAXVALUE))
+PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current VALUES FROM ('2017-08-15') TO (maxvalue))
 
 329:
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-CREATE TABLE students_by_range (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (expected_graduation_date, id)) PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current VALUES FROM ('2017-08-15') TO (MAXVALUE))
+CREATE TABLE students_by_range (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (expected_graduation_date, id)) PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current VALUES FROM ('2017-08-15') TO (maxvalue))
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/create_subpartition.align-deindent.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/create_subpartition.align-deindent.golden
@@ -27,7 +27,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_au VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -37,7 +37,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		),
 	PARTITION north_america VALUES IN (
@@ -49,7 +49,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_us VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -59,7 +59,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		)
 )
@@ -90,7 +90,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_au VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -100,7 +100,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		),
 	PARTITION north_america VALUES IN (
@@ -112,7 +112,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_us VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -122,7 +122,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		)
 )
@@ -152,7 +152,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_au VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -162,7 +162,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		),
 	PARTITION north_america VALUES IN (
@@ -174,7 +174,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_us VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -184,7 +184,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		)
 )
@@ -213,7 +213,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_au VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -223,7 +223,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		),
 	PARTITION north_america VALUES IN (
@@ -235,7 +235,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_us VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -245,7 +245,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		)
 )
@@ -273,7 +273,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_au VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -283,7 +283,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		),
 	PARTITION north_america VALUES IN (
@@ -295,7 +295,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_us VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -305,7 +305,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		)
 )
@@ -331,7 +331,7 @@ PARTITION BY LIST (country) (
 		) (
 			PARTITION graduated_au VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -340,7 +340,7 @@ PARTITION BY LIST (country) (
 				FROM (
 					'2017-08-15'
 				)
-				TO (MAXVALUE)
+				TO (maxvalue)
 		),
 	PARTITION north_america VALUES IN (
 		'US',
@@ -351,7 +351,7 @@ PARTITION BY LIST (country) (
 		) (
 			PARTITION graduated_us VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -360,7 +360,7 @@ PARTITION BY LIST (country) (
 				FROM (
 					'2017-08-15'
 				)
-				TO (MAXVALUE)
+				TO (maxvalue)
 		)
 )
 
@@ -384,7 +384,7 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_au VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO (
 					'2017-08-15'
 				),
@@ -392,7 +392,7 @@ PARTITION BY LIST (country) (
 				FROM (
 					'2017-08-15'
 				)
-				TO (MAXVALUE)
+				TO (maxvalue)
 		),
 	PARTITION north_america VALUES IN (
 		'US',
@@ -402,7 +402,7 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_us VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO (
 					'2017-08-15'
 				),
@@ -410,7 +410,7 @@ PARTITION BY LIST (country) (
 				FROM (
 					'2017-08-15'
 				)
-				TO (MAXVALUE)
+				TO (maxvalue)
 		)
 )
 
@@ -433,13 +433,13 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_au VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO ('2017-08-15'),
 			PARTITION current_au VALUES
 				FROM (
 					'2017-08-15'
 				)
-				TO (MAXVALUE)
+				TO (maxvalue)
 		),
 	PARTITION north_america VALUES IN (
 		'US',
@@ -449,13 +449,13 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_us VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO ('2017-08-15'),
 			PARTITION current_us VALUES
 				FROM (
 					'2017-08-15'
 				)
-				TO (MAXVALUE)
+				TO (maxvalue)
 		)
 )
 
@@ -477,11 +477,11 @@ PARTITION BY LIST (country) (
 		expected_graduation_date
 	  ) (
 		PARTITION graduated_au VALUES
-			FROM (MINVALUE)
+			FROM (minvalue)
 			TO ('2017-08-15'),
 		PARTITION current_au VALUES
 			FROM ('2017-08-15')
-			TO (MAXVALUE)
+			TO (maxvalue)
 	  ),
 	PARTITION north_america VALUES IN (
 		'US',
@@ -491,11 +491,11 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_us VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO ('2017-08-15'),
 			PARTITION current_us VALUES
 				FROM ('2017-08-15')
-				TO (MAXVALUE)
+				TO (maxvalue)
 		)
 )
 
@@ -517,11 +517,11 @@ PARTITION BY LIST (country) (
 		expected_graduation_date
 	  ) (
 		PARTITION graduated_au VALUES
-			FROM (MINVALUE)
+			FROM (minvalue)
 			TO ('2017-08-15'),
 		PARTITION current_au VALUES
 			FROM ('2017-08-15')
-			TO (MAXVALUE)
+			TO (maxvalue)
 	  ),
 	PARTITION north_america VALUES IN (
 		'US',
@@ -530,11 +530,11 @@ PARTITION BY LIST (country) (
 		expected_graduation_date
 	  ) (
 		PARTITION graduated_us VALUES
-			FROM (MINVALUE)
+			FROM (minvalue)
 			TO ('2017-08-15'),
 		PARTITION current_us VALUES
 			FROM ('2017-08-15')
-			TO (MAXVALUE)
+			TO (maxvalue)
 	  )
 )
 
@@ -556,13 +556,13 @@ PARTITION BY LIST (country) (
 		expected_graduation_date
 	  ) (
 		PARTITION graduated_au VALUES
-			FROM (MINVALUE)
+			FROM (minvalue)
 			TO ('2017-08-15'),
 		PARTITION current_au VALUES FROM (
 										'2017-08-15'
 		                            )
 		                            TO (
-										MAXVALUE
+										maxvalue
 		                            )
 	  ),
 	PARTITION north_america VALUES IN (
@@ -572,13 +572,13 @@ PARTITION BY LIST (country) (
 		expected_graduation_date
 	  ) (
 		PARTITION graduated_us VALUES
-			FROM (MINVALUE)
+			FROM (minvalue)
 			TO ('2017-08-15'),
 		PARTITION current_us VALUES FROM (
 										'2017-08-15'
 		                            )
 		                            TO (
-										MAXVALUE
+										maxvalue
 		                            )
 	  )
 )
@@ -601,7 +601,7 @@ PARTITION BY LIST (country) (
 		expected_graduation_date
 	  ) (
 		PARTITION graduated_au VALUES FROM (
-										MINVALUE
+										minvalue
 		                              )
 		                              TO (
 										'2017-08-15'
@@ -610,7 +610,7 @@ PARTITION BY LIST (country) (
 										'2017-08-15'
 		                            )
 		                            TO (
-										MAXVALUE
+										maxvalue
 		                            )
 	  ),
 	PARTITION north_america VALUES IN (
@@ -620,7 +620,7 @@ PARTITION BY LIST (country) (
 		expected_graduation_date
 	  ) (
 		PARTITION graduated_us VALUES FROM (
-										MINVALUE
+										minvalue
 		                              )
 		                              TO (
 										'2017-08-15'
@@ -629,7 +629,7 @@ PARTITION BY LIST (country) (
 										'2017-08-15'
 		                            )
 		                            TO (
-										MAXVALUE
+										maxvalue
 		                            )
 	  )
 )
@@ -652,7 +652,7 @@ PARTITION BY LIST (country) (
 		expected_graduation_date
 	  ) (
 		PARTITION graduated_au VALUES FROM (
-										MINVALUE
+										minvalue
 		                              )
 		                              TO (
 										'2017-08-15'
@@ -660,7 +660,7 @@ PARTITION BY LIST (country) (
 		PARTITION current_au VALUES FROM (
 										'2017-08-15'
 		                            )
-		                            TO (MAXVALUE)
+		                            TO (maxvalue)
 	  ),
 	PARTITION north_america VALUES IN (
 		'US',
@@ -669,7 +669,7 @@ PARTITION BY LIST (country) (
 		expected_graduation_date
 	  ) (
 		PARTITION graduated_us VALUES FROM (
-										MINVALUE
+										minvalue
 		                              )
 		                              TO (
 										'2017-08-15'
@@ -677,7 +677,7 @@ PARTITION BY LIST (country) (
 		PARTITION current_us VALUES FROM (
 										'2017-08-15'
 		                            )
-		                            TO (MAXVALUE)
+		                            TO (maxvalue)
 	  )
 )
 
@@ -696,27 +696,27 @@ PARTITION BY LIST (country) (
 		'AU',
 		'NZ'
 	) PARTITION BY RANGE (expected_graduation_date) (
-		PARTITION graduated_au VALUES FROM (MINVALUE)
+		PARTITION graduated_au VALUES FROM (minvalue)
 		                              TO (
 										'2017-08-15'
 		                              ),
 		PARTITION current_au VALUES FROM (
 										'2017-08-15'
 		                            )
-		                            TO (MAXVALUE)
+		                            TO (maxvalue)
 	  ),
 	PARTITION north_america VALUES IN (
 		'US',
 		'CA'
 	) PARTITION BY RANGE (expected_graduation_date) (
-		PARTITION graduated_us VALUES FROM (MINVALUE)
+		PARTITION graduated_us VALUES FROM (minvalue)
 		                              TO (
 										'2017-08-15'
 		                              ),
 		PARTITION current_us VALUES FROM (
 										'2017-08-15'
 		                            )
-		                            TO (MAXVALUE)
+		                            TO (maxvalue)
 	  )
 )
 
@@ -735,23 +735,23 @@ PARTITION BY LIST (country) (
 		'AU',
 		'NZ'
 	) PARTITION BY RANGE (expected_graduation_date) (
-		PARTITION graduated_au VALUES FROM (MINVALUE)
+		PARTITION graduated_au VALUES FROM (minvalue)
 		                              TO (
 										'2017-08-15'
 		                              ),
 		PARTITION current_au VALUES FROM ('2017-08-15')
-		                            TO (MAXVALUE)
+		                            TO (maxvalue)
 	  ),
 	PARTITION north_america VALUES IN (
 		'US',
 		'CA'
 	) PARTITION BY RANGE (expected_graduation_date) (
-		PARTITION graduated_us VALUES FROM (MINVALUE)
+		PARTITION graduated_us VALUES FROM (minvalue)
 		                              TO (
 										'2017-08-15'
 		                              ),
 		PARTITION current_us VALUES FROM ('2017-08-15')
-		                            TO (MAXVALUE)
+		                            TO (maxvalue)
 	  )
 )
 
@@ -770,19 +770,19 @@ PARTITION BY LIST (country) (
 		'AU',
 		'NZ'
 	) PARTITION BY RANGE (expected_graduation_date) (
-		PARTITION graduated_au VALUES FROM (MINVALUE)
+		PARTITION graduated_au VALUES FROM (minvalue)
 		                              TO ('2017-08-15'),
 		PARTITION current_au VALUES FROM ('2017-08-15')
-		                            TO (MAXVALUE)
+		                            TO (maxvalue)
 	  ),
 	PARTITION north_america VALUES IN (
 		'US',
 		'CA'
 	) PARTITION BY RANGE (expected_graduation_date) (
-		PARTITION graduated_us VALUES FROM (MINVALUE)
+		PARTITION graduated_us VALUES FROM (minvalue)
 		                              TO ('2017-08-15'),
 		PARTITION current_us VALUES FROM ('2017-08-15')
-		                            TO (MAXVALUE)
+		                            TO (maxvalue)
 	  )
 )
 
@@ -801,7 +801,7 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES
-													FROM (MINVALUE)
+													FROM (minvalue)
 													TO (
 														'2017-08-15'
 													),
@@ -809,16 +809,16 @@ PARTITION BY LIST (country) (
 													FROM (
 														'2017-08-15'
 													)
-													TO (MAXVALUE)
+													TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN (
 		'US',
 		'CA'
 	) PARTITION BY RANGE (expected_graduation_date) (
-		PARTITION graduated_us VALUES FROM (MINVALUE)
+		PARTITION graduated_us VALUES FROM (minvalue)
 		                              TO ('2017-08-15'),
 		PARTITION current_us VALUES FROM ('2017-08-15')
-		                            TO (MAXVALUE)
+		                            TO (maxvalue)
 	  )
 )
 
@@ -837,7 +837,7 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES
-													FROM (MINVALUE)
+													FROM (minvalue)
 													TO (
 														'2017-08-15'
 													),
@@ -845,15 +845,15 @@ PARTITION BY LIST (country) (
 													FROM (
 														'2017-08-15'
 													)
-													TO (MAXVALUE)
+													TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN (
 		'US',
 		'CA'
 	) PARTITION BY RANGE (expected_graduation_date) (
-		PARTITION graduated_us VALUES FROM (MINVALUE)
+		PARTITION graduated_us VALUES FROM (minvalue)
 		                              TO ('2017-08-15'),
-		PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)
+		PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)
 	  )
 )
 
@@ -872,21 +872,21 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES
-													FROM (MINVALUE)
+													FROM (minvalue)
 													TO ('2017-08-15'),
 												PARTITION current_au VALUES
 													FROM (
 														'2017-08-15'
 													)
-													TO (MAXVALUE)
+													TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN (
 		'US',
 		'CA'
 	) PARTITION BY RANGE (expected_graduation_date) (
-		PARTITION graduated_us VALUES FROM (MINVALUE)
+		PARTITION graduated_us VALUES FROM (minvalue)
 		                              TO ('2017-08-15'),
-		PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)
+		PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)
 	  )
 )
 
@@ -905,17 +905,17 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES
-													FROM (MINVALUE)
+													FROM (minvalue)
 													TO ('2017-08-15'),
 												PARTITION current_au VALUES
 													FROM ('2017-08-15')
-													TO (MAXVALUE)
+													TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES
-														FROM (MINVALUE)
+														FROM (minvalue)
 														TO (
 															'2017-08-15'
 														),
@@ -923,7 +923,7 @@ PARTITION BY LIST (country) (
 														FROM (
 															'2017-08-15'
 														)
-														TO (MAXVALUE)
+														TO (maxvalue)
 	                                               )
 )
 
@@ -942,23 +942,23 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES
-													FROM (MINVALUE)
+													FROM (minvalue)
 													TO ('2017-08-15'),
 												PARTITION current_au VALUES
 													FROM ('2017-08-15')
-													TO (MAXVALUE)
+													TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES
-														FROM (MINVALUE)
+														FROM (minvalue)
 														TO ('2017-08-15'),
 													PARTITION current_us VALUES
 														FROM (
 															'2017-08-15'
 														)
-														TO (MAXVALUE)
+														TO (maxvalue)
 	                                               )
 )
 
@@ -977,21 +977,21 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES
-													FROM (MINVALUE)
+													FROM (minvalue)
 													TO ('2017-08-15'),
 												PARTITION current_au VALUES
 													FROM ('2017-08-15')
-													TO (MAXVALUE)
+													TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES
-														FROM (MINVALUE)
+														FROM (minvalue)
 														TO ('2017-08-15'),
 													PARTITION current_us VALUES
 														FROM ('2017-08-15')
-														TO (MAXVALUE)
+														TO (maxvalue)
 	                                               )
 )
 
@@ -1010,24 +1010,24 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES
-													FROM (MINVALUE)
+													FROM (minvalue)
 													TO ('2017-08-15'),
 												PARTITION current_au VALUES FROM (
 																				'2017-08-15'
 												                            )
 												                            TO (
-																				MAXVALUE
+																				maxvalue
 												                            )
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES
-														FROM (MINVALUE)
+														FROM (minvalue)
 														TO ('2017-08-15'),
 													PARTITION current_us VALUES
 														FROM ('2017-08-15')
-														TO (MAXVALUE)
+														TO (maxvalue)
 	                                               )
 )
 
@@ -1046,7 +1046,7 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES FROM (
-																				MINVALUE
+																				minvalue
 												                              )
 												                              TO (
 																				'2017-08-15'
@@ -1055,18 +1055,18 @@ PARTITION BY LIST (country) (
 																				'2017-08-15'
 												                            )
 												                            TO (
-																				MAXVALUE
+																				maxvalue
 												                            )
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES
-														FROM (MINVALUE)
+														FROM (minvalue)
 														TO ('2017-08-15'),
 													PARTITION current_us VALUES
 														FROM ('2017-08-15')
-														TO (MAXVALUE)
+														TO (maxvalue)
 	                                               )
 )
 
@@ -1085,7 +1085,7 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES FROM (
-																				MINVALUE
+																				minvalue
 												                              )
 												                              TO (
 																				'2017-08-15'
@@ -1094,20 +1094,20 @@ PARTITION BY LIST (country) (
 																				'2017-08-15'
 												                            )
 												                            TO (
-																				MAXVALUE
+																				maxvalue
 												                            )
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES
-														FROM (MINVALUE)
+														FROM (minvalue)
 														TO ('2017-08-15'),
 													PARTITION current_us VALUES FROM (
 																					'2017-08-15'
 													                            )
 													                            TO (
-																					MAXVALUE
+																					maxvalue
 													                            )
 	                                               )
 )
@@ -1127,7 +1127,7 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES FROM (
-																				MINVALUE
+																				minvalue
 												                              )
 												                              TO (
 																				'2017-08-15'
@@ -1136,14 +1136,14 @@ PARTITION BY LIST (country) (
 																				'2017-08-15'
 												                            )
 												                            TO (
-																				MAXVALUE
+																				maxvalue
 												                            )
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES FROM (
-																					MINVALUE
+																					minvalue
 													                              )
 													                              TO (
 																					'2017-08-15'
@@ -1152,7 +1152,7 @@ PARTITION BY LIST (country) (
 																					'2017-08-15'
 													                            )
 													                            TO (
-																					MAXVALUE
+																					maxvalue
 													                            )
 	                                               )
 )
@@ -1172,7 +1172,7 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES FROM (
-																				MINVALUE
+																				minvalue
 												                              )
 												                              TO (
 																				'2017-08-15'
@@ -1180,13 +1180,13 @@ PARTITION BY LIST (country) (
 												PARTITION current_au VALUES FROM (
 																				'2017-08-15'
 												                            )
-												                            TO (MAXVALUE)
+												                            TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES FROM (
-																					MINVALUE
+																					minvalue
 													                              )
 													                              TO (
 																					'2017-08-15'
@@ -1195,7 +1195,7 @@ PARTITION BY LIST (country) (
 																					'2017-08-15'
 													                            )
 													                            TO (
-																					MAXVALUE
+																					maxvalue
 													                            )
 	                                               )
 )
@@ -1214,20 +1214,20 @@ PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (
 												expected_graduation_date
 	                                           ) (
-												PARTITION graduated_au VALUES FROM (MINVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue)
 												                              TO (
 																				'2017-08-15'
 												                              ),
 												PARTITION current_au VALUES FROM (
 																				'2017-08-15'
 												                            )
-												                            TO (MAXVALUE)
+												                            TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES FROM (
-																					MINVALUE
+																					minvalue
 													                              )
 													                              TO (
 																					'2017-08-15'
@@ -1235,7 +1235,7 @@ PARTITION BY LIST (country) (
 													PARTITION current_us VALUES FROM (
 																					'2017-08-15'
 													                            )
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1251,20 +1251,20 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue)
 												                              TO (
 																				'2017-08-15'
 												                              ),
 												PARTITION current_au VALUES FROM (
 																				'2017-08-15'
 												                            )
-												                            TO (MAXVALUE)
+												                            TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES FROM (
-																					MINVALUE
+																					minvalue
 													                              )
 													                              TO (
 																					'2017-08-15'
@@ -1272,7 +1272,7 @@ PARTITION BY LIST (country) (
 													PARTITION current_us VALUES FROM (
 																					'2017-08-15'
 													                            )
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1288,18 +1288,18 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue)
 												                              TO (
 																				'2017-08-15'
 												                              ),
 												PARTITION current_au VALUES FROM ('2017-08-15')
-												                            TO (MAXVALUE)
+												                            TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES FROM (
-																					MINVALUE
+																					minvalue
 													                              )
 													                              TO (
 																					'2017-08-15'
@@ -1307,7 +1307,7 @@ PARTITION BY LIST (country) (
 													PARTITION current_us VALUES FROM (
 																					'2017-08-15'
 													                            )
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1323,16 +1323,16 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue)
 												                              TO ('2017-08-15'),
 												PARTITION current_au VALUES FROM ('2017-08-15')
-												                            TO (MAXVALUE)
+												                            TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES FROM (
-																					MINVALUE
+																					minvalue
 													                              )
 													                              TO (
 																					'2017-08-15'
@@ -1340,7 +1340,7 @@ PARTITION BY LIST (country) (
 													PARTITION current_us VALUES FROM (
 																					'2017-08-15'
 													                            )
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1356,22 +1356,22 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue)
 												                              TO ('2017-08-15'),
 												PARTITION current_au VALUES FROM ('2017-08-15')
-												                            TO (MAXVALUE)
+												                            TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
-													PARTITION graduated_us VALUES FROM (MINVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue)
 													                              TO (
 																					'2017-08-15'
 													                              ),
 													PARTITION current_us VALUES FROM (
 																					'2017-08-15'
 													                            )
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1387,20 +1387,20 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue)
 												                              TO ('2017-08-15'),
 												PARTITION current_au VALUES FROM ('2017-08-15')
-												                            TO (MAXVALUE)
+												                            TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (
-													PARTITION graduated_us VALUES FROM (MINVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue)
 													                              TO (
 																					'2017-08-15'
 													                              ),
 													PARTITION current_us VALUES FROM (
 																					'2017-08-15'
 													                            )
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1416,18 +1416,18 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue)
 												                              TO ('2017-08-15'),
 												PARTITION current_au VALUES FROM ('2017-08-15')
-												                            TO (MAXVALUE)
+												                            TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (
-													PARTITION graduated_us VALUES FROM (MINVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue)
 													                              TO (
 																					'2017-08-15'
 													                              ),
 													PARTITION current_us VALUES FROM ('2017-08-15')
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1443,16 +1443,16 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue)
 												                              TO ('2017-08-15'),
 												PARTITION current_au VALUES FROM ('2017-08-15')
-												                            TO (MAXVALUE)
+												                            TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (
-													PARTITION graduated_us VALUES FROM (MINVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue)
 													                              TO ('2017-08-15'),
 													PARTITION current_us VALUES FROM ('2017-08-15')
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1468,15 +1468,15 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue)
 												                              TO ('2017-08-15'),
-												PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)
+												PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (
-													PARTITION graduated_us VALUES FROM (MINVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue)
 													                              TO ('2017-08-15'),
 													PARTITION current_us VALUES FROM ('2017-08-15')
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1492,14 +1492,14 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'),
-												PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'),
+												PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (
-													PARTITION graduated_us VALUES FROM (MINVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue)
 													                              TO ('2017-08-15'),
 													PARTITION current_us VALUES FROM ('2017-08-15')
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1515,13 +1515,13 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'),
-												PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'),
+												PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (
-													PARTITION graduated_us VALUES FROM (MINVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue)
 													                              TO ('2017-08-15'),
-													PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)
+													PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)
 	                                               )
 )
 
@@ -1537,12 +1537,12 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'),
-												PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'),
+												PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (
-													PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'),
-													PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'),
+													PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)
 	                                               )
 )
 
@@ -1551,12 +1551,12 @@ PARTITION BY LIST (country) (
 CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (country, expected_graduation_date, id))
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'),
-												PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'),
+												PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (
-													PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'),
-													PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'),
+													PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)
 	                                               )
 )
 
@@ -1564,10 +1564,10 @@ PARTITION BY LIST (country) (
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (country, expected_graduation_date, id))
 PARTITION BY LIST (country) (
-	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)),
+	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (
-													PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'),
-													PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'),
+													PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)
 	                                               )
 )
 
@@ -1575,17 +1575,17 @@ PARTITION BY LIST (country) (
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (country, expected_graduation_date, id))
 PARTITION BY LIST (country) (
-	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)),
-	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE))
+	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)),
+	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue))
 )
 
 470:
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (country, expected_graduation_date, id))
-PARTITION BY LIST (country) (PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)), PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)))
+PARTITION BY LIST (country) (PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)), PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)))
 
 631:
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (country, expected_graduation_date, id)) PARTITION BY LIST (country) (PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)), PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)))
+CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (country, expected_graduation_date, id)) PARTITION BY LIST (country) (PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)), PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)))
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/create_subpartition.align-only.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/create_subpartition.align-only.golden
@@ -27,7 +27,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_au VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -37,7 +37,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		),
 	PARTITION north_america VALUES IN (
@@ -49,7 +49,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_us VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -59,7 +59,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		)
 )
@@ -90,7 +90,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_au VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -100,7 +100,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		),
 	PARTITION north_america VALUES IN (
@@ -112,7 +112,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_us VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -122,7 +122,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		)
 )
@@ -152,7 +152,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_au VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -162,7 +162,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		),
 	PARTITION north_america VALUES IN (
@@ -174,7 +174,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_us VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -184,7 +184,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		)
 )
@@ -213,7 +213,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_au VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -223,7 +223,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		),
 	PARTITION north_america VALUES IN (
@@ -235,7 +235,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_us VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -245,7 +245,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		)
 )
@@ -273,7 +273,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_au VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -283,7 +283,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		),
 	PARTITION north_america VALUES IN (
@@ -295,7 +295,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_us VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -305,7 +305,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		)
 )
@@ -331,7 +331,7 @@ PARTITION BY LIST (country) (
 		) (
 			PARTITION graduated_au VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -340,7 +340,7 @@ PARTITION BY LIST (country) (
 				FROM (
 					'2017-08-15'
 				)
-				TO (MAXVALUE)
+				TO (maxvalue)
 		),
 	PARTITION north_america VALUES IN (
 		'US',
@@ -351,7 +351,7 @@ PARTITION BY LIST (country) (
 		) (
 			PARTITION graduated_us VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -360,7 +360,7 @@ PARTITION BY LIST (country) (
 				FROM (
 					'2017-08-15'
 				)
-				TO (MAXVALUE)
+				TO (maxvalue)
 		)
 )
 
@@ -384,7 +384,7 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_au VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO (
 					'2017-08-15'
 				),
@@ -392,7 +392,7 @@ PARTITION BY LIST (country) (
 				FROM (
 					'2017-08-15'
 				)
-				TO (MAXVALUE)
+				TO (maxvalue)
 		),
 	PARTITION north_america VALUES IN (
 		'US',
@@ -402,7 +402,7 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_us VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO (
 					'2017-08-15'
 				),
@@ -410,7 +410,7 @@ PARTITION BY LIST (country) (
 				FROM (
 					'2017-08-15'
 				)
-				TO (MAXVALUE)
+				TO (maxvalue)
 		)
 )
 
@@ -433,13 +433,13 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_au VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO ('2017-08-15'),
 			PARTITION current_au VALUES
 				FROM (
 					'2017-08-15'
 				)
-				TO (MAXVALUE)
+				TO (maxvalue)
 		),
 	PARTITION north_america VALUES IN (
 		'US',
@@ -449,13 +449,13 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_us VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO ('2017-08-15'),
 			PARTITION current_us VALUES
 				FROM (
 					'2017-08-15'
 				)
-				TO (MAXVALUE)
+				TO (maxvalue)
 		)
 )
 
@@ -477,11 +477,11 @@ PARTITION BY LIST (country) (
 		expected_graduation_date
 	  ) (
 		PARTITION graduated_au VALUES
-			FROM (MINVALUE)
+			FROM (minvalue)
 			TO ('2017-08-15'),
 		PARTITION current_au VALUES
 			FROM ('2017-08-15')
-			TO (MAXVALUE)
+			TO (maxvalue)
 	  ),
 	PARTITION north_america VALUES IN (
 		'US',
@@ -491,11 +491,11 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_us VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO ('2017-08-15'),
 			PARTITION current_us VALUES
 				FROM ('2017-08-15')
-				TO (MAXVALUE)
+				TO (maxvalue)
 		)
 )
 
@@ -517,11 +517,11 @@ PARTITION BY LIST (country) (
 		expected_graduation_date
 	  ) (
 		PARTITION graduated_au VALUES
-			FROM (MINVALUE)
+			FROM (minvalue)
 			TO ('2017-08-15'),
 		PARTITION current_au VALUES
 			FROM ('2017-08-15')
-			TO (MAXVALUE)
+			TO (maxvalue)
 	  ),
 	PARTITION north_america VALUES IN (
 		'US',
@@ -530,11 +530,11 @@ PARTITION BY LIST (country) (
 		expected_graduation_date
 	  ) (
 		PARTITION graduated_us VALUES
-			FROM (MINVALUE)
+			FROM (minvalue)
 			TO ('2017-08-15'),
 		PARTITION current_us VALUES
 			FROM ('2017-08-15')
-			TO (MAXVALUE)
+			TO (maxvalue)
 	  )
 )
 
@@ -556,13 +556,13 @@ PARTITION BY LIST (country) (
 		expected_graduation_date
 	  ) (
 		PARTITION graduated_au VALUES
-			FROM (MINVALUE)
+			FROM (minvalue)
 			TO ('2017-08-15'),
 		PARTITION current_au VALUES FROM (
 										'2017-08-15'
 		                            )
 		                            TO (
-										MAXVALUE
+										maxvalue
 		                            )
 	  ),
 	PARTITION north_america VALUES IN (
@@ -572,13 +572,13 @@ PARTITION BY LIST (country) (
 		expected_graduation_date
 	  ) (
 		PARTITION graduated_us VALUES
-			FROM (MINVALUE)
+			FROM (minvalue)
 			TO ('2017-08-15'),
 		PARTITION current_us VALUES FROM (
 										'2017-08-15'
 		                            )
 		                            TO (
-										MAXVALUE
+										maxvalue
 		                            )
 	  )
 )
@@ -601,7 +601,7 @@ PARTITION BY LIST (country) (
 		expected_graduation_date
 	  ) (
 		PARTITION graduated_au VALUES FROM (
-										MINVALUE
+										minvalue
 		                              )
 		                              TO (
 										'2017-08-15'
@@ -610,7 +610,7 @@ PARTITION BY LIST (country) (
 										'2017-08-15'
 		                            )
 		                            TO (
-										MAXVALUE
+										maxvalue
 		                            )
 	  ),
 	PARTITION north_america VALUES IN (
@@ -620,7 +620,7 @@ PARTITION BY LIST (country) (
 		expected_graduation_date
 	  ) (
 		PARTITION graduated_us VALUES FROM (
-										MINVALUE
+										minvalue
 		                              )
 		                              TO (
 										'2017-08-15'
@@ -629,7 +629,7 @@ PARTITION BY LIST (country) (
 										'2017-08-15'
 		                            )
 		                            TO (
-										MAXVALUE
+										maxvalue
 		                            )
 	  )
 )
@@ -652,7 +652,7 @@ PARTITION BY LIST (country) (
 		expected_graduation_date
 	  ) (
 		PARTITION graduated_au VALUES FROM (
-										MINVALUE
+										minvalue
 		                              )
 		                              TO (
 										'2017-08-15'
@@ -660,7 +660,7 @@ PARTITION BY LIST (country) (
 		PARTITION current_au VALUES FROM (
 										'2017-08-15'
 		                            )
-		                            TO (MAXVALUE)
+		                            TO (maxvalue)
 	  ),
 	PARTITION north_america VALUES IN (
 		'US',
@@ -669,7 +669,7 @@ PARTITION BY LIST (country) (
 		expected_graduation_date
 	  ) (
 		PARTITION graduated_us VALUES FROM (
-										MINVALUE
+										minvalue
 		                              )
 		                              TO (
 										'2017-08-15'
@@ -677,7 +677,7 @@ PARTITION BY LIST (country) (
 		PARTITION current_us VALUES FROM (
 										'2017-08-15'
 		                            )
-		                            TO (MAXVALUE)
+		                            TO (maxvalue)
 	  )
 )
 
@@ -696,27 +696,27 @@ PARTITION BY LIST (country) (
 		'AU',
 		'NZ'
 	) PARTITION BY RANGE (expected_graduation_date) (
-		PARTITION graduated_au VALUES FROM (MINVALUE)
+		PARTITION graduated_au VALUES FROM (minvalue)
 		                              TO (
 										'2017-08-15'
 		                              ),
 		PARTITION current_au VALUES FROM (
 										'2017-08-15'
 		                            )
-		                            TO (MAXVALUE)
+		                            TO (maxvalue)
 	  ),
 	PARTITION north_america VALUES IN (
 		'US',
 		'CA'
 	) PARTITION BY RANGE (expected_graduation_date) (
-		PARTITION graduated_us VALUES FROM (MINVALUE)
+		PARTITION graduated_us VALUES FROM (minvalue)
 		                              TO (
 										'2017-08-15'
 		                              ),
 		PARTITION current_us VALUES FROM (
 										'2017-08-15'
 		                            )
-		                            TO (MAXVALUE)
+		                            TO (maxvalue)
 	  )
 )
 
@@ -735,23 +735,23 @@ PARTITION BY LIST (country) (
 		'AU',
 		'NZ'
 	) PARTITION BY RANGE (expected_graduation_date) (
-		PARTITION graduated_au VALUES FROM (MINVALUE)
+		PARTITION graduated_au VALUES FROM (minvalue)
 		                              TO (
 										'2017-08-15'
 		                              ),
 		PARTITION current_au VALUES FROM ('2017-08-15')
-		                            TO (MAXVALUE)
+		                            TO (maxvalue)
 	  ),
 	PARTITION north_america VALUES IN (
 		'US',
 		'CA'
 	) PARTITION BY RANGE (expected_graduation_date) (
-		PARTITION graduated_us VALUES FROM (MINVALUE)
+		PARTITION graduated_us VALUES FROM (minvalue)
 		                              TO (
 										'2017-08-15'
 		                              ),
 		PARTITION current_us VALUES FROM ('2017-08-15')
-		                            TO (MAXVALUE)
+		                            TO (maxvalue)
 	  )
 )
 
@@ -770,19 +770,19 @@ PARTITION BY LIST (country) (
 		'AU',
 		'NZ'
 	) PARTITION BY RANGE (expected_graduation_date) (
-		PARTITION graduated_au VALUES FROM (MINVALUE)
+		PARTITION graduated_au VALUES FROM (minvalue)
 		                              TO ('2017-08-15'),
 		PARTITION current_au VALUES FROM ('2017-08-15')
-		                            TO (MAXVALUE)
+		                            TO (maxvalue)
 	  ),
 	PARTITION north_america VALUES IN (
 		'US',
 		'CA'
 	) PARTITION BY RANGE (expected_graduation_date) (
-		PARTITION graduated_us VALUES FROM (MINVALUE)
+		PARTITION graduated_us VALUES FROM (minvalue)
 		                              TO ('2017-08-15'),
 		PARTITION current_us VALUES FROM ('2017-08-15')
-		                            TO (MAXVALUE)
+		                            TO (maxvalue)
 	  )
 )
 
@@ -801,7 +801,7 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES
-													FROM (MINVALUE)
+													FROM (minvalue)
 													TO (
 														'2017-08-15'
 													),
@@ -809,16 +809,16 @@ PARTITION BY LIST (country) (
 													FROM (
 														'2017-08-15'
 													)
-													TO (MAXVALUE)
+													TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN (
 		'US',
 		'CA'
 	) PARTITION BY RANGE (expected_graduation_date) (
-		PARTITION graduated_us VALUES FROM (MINVALUE)
+		PARTITION graduated_us VALUES FROM (minvalue)
 		                              TO ('2017-08-15'),
 		PARTITION current_us VALUES FROM ('2017-08-15')
-		                            TO (MAXVALUE)
+		                            TO (maxvalue)
 	  )
 )
 
@@ -837,7 +837,7 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES
-													FROM (MINVALUE)
+													FROM (minvalue)
 													TO (
 														'2017-08-15'
 													),
@@ -845,15 +845,15 @@ PARTITION BY LIST (country) (
 													FROM (
 														'2017-08-15'
 													)
-													TO (MAXVALUE)
+													TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN (
 		'US',
 		'CA'
 	) PARTITION BY RANGE (expected_graduation_date) (
-		PARTITION graduated_us VALUES FROM (MINVALUE)
+		PARTITION graduated_us VALUES FROM (minvalue)
 		                              TO ('2017-08-15'),
-		PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)
+		PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)
 	  )
 )
 
@@ -872,21 +872,21 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES
-													FROM (MINVALUE)
+													FROM (minvalue)
 													TO ('2017-08-15'),
 												PARTITION current_au VALUES
 													FROM (
 														'2017-08-15'
 													)
-													TO (MAXVALUE)
+													TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN (
 		'US',
 		'CA'
 	) PARTITION BY RANGE (expected_graduation_date) (
-		PARTITION graduated_us VALUES FROM (MINVALUE)
+		PARTITION graduated_us VALUES FROM (minvalue)
 		                              TO ('2017-08-15'),
-		PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)
+		PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)
 	  )
 )
 
@@ -905,17 +905,17 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES
-													FROM (MINVALUE)
+													FROM (minvalue)
 													TO ('2017-08-15'),
 												PARTITION current_au VALUES
 													FROM ('2017-08-15')
-													TO (MAXVALUE)
+													TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES
-														FROM (MINVALUE)
+														FROM (minvalue)
 														TO (
 															'2017-08-15'
 														),
@@ -923,7 +923,7 @@ PARTITION BY LIST (country) (
 														FROM (
 															'2017-08-15'
 														)
-														TO (MAXVALUE)
+														TO (maxvalue)
 	                                               )
 )
 
@@ -942,23 +942,23 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES
-													FROM (MINVALUE)
+													FROM (minvalue)
 													TO ('2017-08-15'),
 												PARTITION current_au VALUES
 													FROM ('2017-08-15')
-													TO (MAXVALUE)
+													TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES
-														FROM (MINVALUE)
+														FROM (minvalue)
 														TO ('2017-08-15'),
 													PARTITION current_us VALUES
 														FROM (
 															'2017-08-15'
 														)
-														TO (MAXVALUE)
+														TO (maxvalue)
 	                                               )
 )
 
@@ -977,21 +977,21 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES
-													FROM (MINVALUE)
+													FROM (minvalue)
 													TO ('2017-08-15'),
 												PARTITION current_au VALUES
 													FROM ('2017-08-15')
-													TO (MAXVALUE)
+													TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES
-														FROM (MINVALUE)
+														FROM (minvalue)
 														TO ('2017-08-15'),
 													PARTITION current_us VALUES
 														FROM ('2017-08-15')
-														TO (MAXVALUE)
+														TO (maxvalue)
 	                                               )
 )
 
@@ -1010,24 +1010,24 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES
-													FROM (MINVALUE)
+													FROM (minvalue)
 													TO ('2017-08-15'),
 												PARTITION current_au VALUES FROM (
 																				'2017-08-15'
 												                            )
 												                            TO (
-																				MAXVALUE
+																				maxvalue
 												                            )
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES
-														FROM (MINVALUE)
+														FROM (minvalue)
 														TO ('2017-08-15'),
 													PARTITION current_us VALUES
 														FROM ('2017-08-15')
-														TO (MAXVALUE)
+														TO (maxvalue)
 	                                               )
 )
 
@@ -1046,7 +1046,7 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES FROM (
-																				MINVALUE
+																				minvalue
 												                              )
 												                              TO (
 																				'2017-08-15'
@@ -1055,18 +1055,18 @@ PARTITION BY LIST (country) (
 																				'2017-08-15'
 												                            )
 												                            TO (
-																				MAXVALUE
+																				maxvalue
 												                            )
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES
-														FROM (MINVALUE)
+														FROM (minvalue)
 														TO ('2017-08-15'),
 													PARTITION current_us VALUES
 														FROM ('2017-08-15')
-														TO (MAXVALUE)
+														TO (maxvalue)
 	                                               )
 )
 
@@ -1085,7 +1085,7 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES FROM (
-																				MINVALUE
+																				minvalue
 												                              )
 												                              TO (
 																				'2017-08-15'
@@ -1094,20 +1094,20 @@ PARTITION BY LIST (country) (
 																				'2017-08-15'
 												                            )
 												                            TO (
-																				MAXVALUE
+																				maxvalue
 												                            )
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES
-														FROM (MINVALUE)
+														FROM (minvalue)
 														TO ('2017-08-15'),
 													PARTITION current_us VALUES FROM (
 																					'2017-08-15'
 													                            )
 													                            TO (
-																					MAXVALUE
+																					maxvalue
 													                            )
 	                                               )
 )
@@ -1127,7 +1127,7 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES FROM (
-																				MINVALUE
+																				minvalue
 												                              )
 												                              TO (
 																				'2017-08-15'
@@ -1136,14 +1136,14 @@ PARTITION BY LIST (country) (
 																				'2017-08-15'
 												                            )
 												                            TO (
-																				MAXVALUE
+																				maxvalue
 												                            )
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES FROM (
-																					MINVALUE
+																					minvalue
 													                              )
 													                              TO (
 																					'2017-08-15'
@@ -1152,7 +1152,7 @@ PARTITION BY LIST (country) (
 																					'2017-08-15'
 													                            )
 													                            TO (
-																					MAXVALUE
+																					maxvalue
 													                            )
 	                                               )
 )
@@ -1172,7 +1172,7 @@ PARTITION BY LIST (country) (
 												expected_graduation_date
 	                                           ) (
 												PARTITION graduated_au VALUES FROM (
-																				MINVALUE
+																				minvalue
 												                              )
 												                              TO (
 																				'2017-08-15'
@@ -1180,13 +1180,13 @@ PARTITION BY LIST (country) (
 												PARTITION current_au VALUES FROM (
 																				'2017-08-15'
 												                            )
-												                            TO (MAXVALUE)
+												                            TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES FROM (
-																					MINVALUE
+																					minvalue
 													                              )
 													                              TO (
 																					'2017-08-15'
@@ -1195,7 +1195,7 @@ PARTITION BY LIST (country) (
 																					'2017-08-15'
 													                            )
 													                            TO (
-																					MAXVALUE
+																					maxvalue
 													                            )
 	                                               )
 )
@@ -1214,20 +1214,20 @@ PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (
 												expected_graduation_date
 	                                           ) (
-												PARTITION graduated_au VALUES FROM (MINVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue)
 												                              TO (
 																				'2017-08-15'
 												                              ),
 												PARTITION current_au VALUES FROM (
 																				'2017-08-15'
 												                            )
-												                            TO (MAXVALUE)
+												                            TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES FROM (
-																					MINVALUE
+																					minvalue
 													                              )
 													                              TO (
 																					'2017-08-15'
@@ -1235,7 +1235,7 @@ PARTITION BY LIST (country) (
 													PARTITION current_us VALUES FROM (
 																					'2017-08-15'
 													                            )
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1251,20 +1251,20 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue)
 												                              TO (
 																				'2017-08-15'
 												                              ),
 												PARTITION current_au VALUES FROM (
 																				'2017-08-15'
 												                            )
-												                            TO (MAXVALUE)
+												                            TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES FROM (
-																					MINVALUE
+																					minvalue
 													                              )
 													                              TO (
 																					'2017-08-15'
@@ -1272,7 +1272,7 @@ PARTITION BY LIST (country) (
 													PARTITION current_us VALUES FROM (
 																					'2017-08-15'
 													                            )
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1288,18 +1288,18 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue)
 												                              TO (
 																				'2017-08-15'
 												                              ),
 												PARTITION current_au VALUES FROM ('2017-08-15')
-												                            TO (MAXVALUE)
+												                            TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES FROM (
-																					MINVALUE
+																					minvalue
 													                              )
 													                              TO (
 																					'2017-08-15'
@@ -1307,7 +1307,7 @@ PARTITION BY LIST (country) (
 													PARTITION current_us VALUES FROM (
 																					'2017-08-15'
 													                            )
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1323,16 +1323,16 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue)
 												                              TO ('2017-08-15'),
 												PARTITION current_au VALUES FROM ('2017-08-15')
-												                            TO (MAXVALUE)
+												                            TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
 													PARTITION graduated_us VALUES FROM (
-																					MINVALUE
+																					minvalue
 													                              )
 													                              TO (
 																					'2017-08-15'
@@ -1340,7 +1340,7 @@ PARTITION BY LIST (country) (
 													PARTITION current_us VALUES FROM (
 																					'2017-08-15'
 													                            )
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1356,22 +1356,22 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue)
 												                              TO ('2017-08-15'),
 												PARTITION current_au VALUES FROM ('2017-08-15')
-												                            TO (MAXVALUE)
+												                            TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (
 													expected_graduation_date
 	                                               ) (
-													PARTITION graduated_us VALUES FROM (MINVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue)
 													                              TO (
 																					'2017-08-15'
 													                              ),
 													PARTITION current_us VALUES FROM (
 																					'2017-08-15'
 													                            )
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1387,20 +1387,20 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue)
 												                              TO ('2017-08-15'),
 												PARTITION current_au VALUES FROM ('2017-08-15')
-												                            TO (MAXVALUE)
+												                            TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (
-													PARTITION graduated_us VALUES FROM (MINVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue)
 													                              TO (
 																					'2017-08-15'
 													                              ),
 													PARTITION current_us VALUES FROM (
 																					'2017-08-15'
 													                            )
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1416,18 +1416,18 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue)
 												                              TO ('2017-08-15'),
 												PARTITION current_au VALUES FROM ('2017-08-15')
-												                            TO (MAXVALUE)
+												                            TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (
-													PARTITION graduated_us VALUES FROM (MINVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue)
 													                              TO (
 																					'2017-08-15'
 													                              ),
 													PARTITION current_us VALUES FROM ('2017-08-15')
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1443,16 +1443,16 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue)
 												                              TO ('2017-08-15'),
 												PARTITION current_au VALUES FROM ('2017-08-15')
-												                            TO (MAXVALUE)
+												                            TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (
-													PARTITION graduated_us VALUES FROM (MINVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue)
 													                              TO ('2017-08-15'),
 													PARTITION current_us VALUES FROM ('2017-08-15')
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1468,15 +1468,15 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue)
 												                              TO ('2017-08-15'),
-												PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)
+												PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (
-													PARTITION graduated_us VALUES FROM (MINVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue)
 													                              TO ('2017-08-15'),
 													PARTITION current_us VALUES FROM ('2017-08-15')
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1492,14 +1492,14 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'),
-												PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'),
+												PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (
-													PARTITION graduated_us VALUES FROM (MINVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue)
 													                              TO ('2017-08-15'),
 													PARTITION current_us VALUES FROM ('2017-08-15')
-													                            TO (MAXVALUE)
+													                            TO (maxvalue)
 	                                               )
 )
 
@@ -1515,13 +1515,13 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'),
-												PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'),
+												PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (
-													PARTITION graduated_us VALUES FROM (MINVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue)
 													                              TO ('2017-08-15'),
-													PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)
+													PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)
 	                                               )
 )
 
@@ -1537,12 +1537,12 @@ CREATE TABLE students (
 )
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'),
-												PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'),
+												PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (
-													PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'),
-													PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'),
+													PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)
 	                                               )
 )
 
@@ -1551,12 +1551,12 @@ PARTITION BY LIST (country) (
 CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (country, expected_graduation_date, id))
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (
-												PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'),
-												PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)
+												PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'),
+												PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)
 	                                           ),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (
-													PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'),
-													PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'),
+													PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)
 	                                               )
 )
 
@@ -1564,10 +1564,10 @@ PARTITION BY LIST (country) (
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (country, expected_graduation_date, id))
 PARTITION BY LIST (country) (
-	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)),
+	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)),
 	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (
-													PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'),
-													PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)
+													PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'),
+													PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)
 	                                               )
 )
 
@@ -1575,17 +1575,17 @@ PARTITION BY LIST (country) (
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (country, expected_graduation_date, id))
 PARTITION BY LIST (country) (
-	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)),
-	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE))
+	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)),
+	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue))
 )
 
 470:
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (country, expected_graduation_date, id))
-PARTITION BY LIST (country) (PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)), PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)))
+PARTITION BY LIST (country) (PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)), PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)))
 
 631:
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (country, expected_graduation_date, id)) PARTITION BY LIST (country) (PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)), PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)))
+CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (country, expected_graduation_date, id)) PARTITION BY LIST (country) (PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)), PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)))
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/create_subpartition.ref.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/create_subpartition.ref.golden
@@ -27,7 +27,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_au VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -37,7 +37,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		),
 	PARTITION north_america VALUES IN (
@@ -49,7 +49,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_us VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -59,7 +59,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		)
 )
@@ -90,7 +90,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_au VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -100,7 +100,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		),
 	PARTITION north_america VALUES IN (
@@ -112,7 +112,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_us VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -122,7 +122,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		)
 )
@@ -152,7 +152,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_au VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -162,7 +162,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		),
 	PARTITION north_america VALUES IN (
@@ -174,7 +174,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_us VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -184,7 +184,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		)
 )
@@ -213,7 +213,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_au VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -223,7 +223,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		),
 	PARTITION north_america VALUES IN (
@@ -235,7 +235,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_us VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -245,7 +245,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		)
 )
@@ -273,7 +273,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_au VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -283,7 +283,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		),
 	PARTITION north_america VALUES IN (
@@ -295,7 +295,7 @@ PARTITION BY LIST (
 		) (
 			PARTITION graduated_us VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -305,7 +305,7 @@ PARTITION BY LIST (
 					'2017-08-15'
 				)
 				TO (
-					MAXVALUE
+					maxvalue
 				)
 		)
 )
@@ -331,7 +331,7 @@ PARTITION BY LIST (country) (
 		) (
 			PARTITION graduated_au VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -340,7 +340,7 @@ PARTITION BY LIST (country) (
 				FROM (
 					'2017-08-15'
 				)
-				TO (MAXVALUE)
+				TO (maxvalue)
 		),
 	PARTITION north_america VALUES IN (
 		'US',
@@ -351,7 +351,7 @@ PARTITION BY LIST (country) (
 		) (
 			PARTITION graduated_us VALUES
 				FROM (
-					MINVALUE
+					minvalue
 				)
 				TO (
 					'2017-08-15'
@@ -360,7 +360,7 @@ PARTITION BY LIST (country) (
 				FROM (
 					'2017-08-15'
 				)
-				TO (MAXVALUE)
+				TO (maxvalue)
 		)
 )
 
@@ -384,7 +384,7 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_au VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO (
 					'2017-08-15'
 				),
@@ -392,7 +392,7 @@ PARTITION BY LIST (country) (
 				FROM (
 					'2017-08-15'
 				)
-				TO (MAXVALUE)
+				TO (maxvalue)
 		),
 	PARTITION north_america VALUES IN (
 		'US',
@@ -402,7 +402,7 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_us VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO (
 					'2017-08-15'
 				),
@@ -410,7 +410,7 @@ PARTITION BY LIST (country) (
 				FROM (
 					'2017-08-15'
 				)
-				TO (MAXVALUE)
+				TO (maxvalue)
 		)
 )
 
@@ -433,13 +433,13 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_au VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO ('2017-08-15'),
 			PARTITION current_au VALUES
 				FROM (
 					'2017-08-15'
 				)
-				TO (MAXVALUE)
+				TO (maxvalue)
 		),
 	PARTITION north_america VALUES IN (
 		'US',
@@ -449,13 +449,13 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_us VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO ('2017-08-15'),
 			PARTITION current_us VALUES
 				FROM (
 					'2017-08-15'
 				)
-				TO (MAXVALUE)
+				TO (maxvalue)
 		)
 )
 
@@ -478,11 +478,11 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_au VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO ('2017-08-15'),
 			PARTITION current_au VALUES
 				FROM ('2017-08-15')
-				TO (MAXVALUE)
+				TO (maxvalue)
 		),
 	PARTITION north_america VALUES IN (
 		'US',
@@ -492,11 +492,11 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_us VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO ('2017-08-15'),
 			PARTITION current_us VALUES
 				FROM ('2017-08-15')
-				TO (MAXVALUE)
+				TO (maxvalue)
 		)
 )
 
@@ -516,11 +516,11 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_au VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO ('2017-08-15'),
 			PARTITION current_au VALUES
 				FROM ('2017-08-15')
-				TO (MAXVALUE)
+				TO (maxvalue)
 		),
 	PARTITION north_america VALUES IN (
 		'US',
@@ -530,11 +530,11 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_us VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO ('2017-08-15'),
 			PARTITION current_us VALUES
 				FROM ('2017-08-15')
-				TO (MAXVALUE)
+				TO (maxvalue)
 		)
 )
 
@@ -554,10 +554,10 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_au VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO ('2017-08-15'),
 			PARTITION current_au VALUES
-				FROM ('2017-08-15') TO (MAXVALUE)
+				FROM ('2017-08-15') TO (maxvalue)
 		),
 	PARTITION north_america VALUES IN (
 		'US',
@@ -567,10 +567,10 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_us VALUES
-				FROM (MINVALUE)
+				FROM (minvalue)
 				TO ('2017-08-15'),
 			PARTITION current_us VALUES
-				FROM ('2017-08-15') TO (MAXVALUE)
+				FROM ('2017-08-15') TO (maxvalue)
 		)
 )
 
@@ -590,18 +590,18 @@ PARTITION BY LIST (country) (
 			expected_graduation_date
 		) (
 			PARTITION graduated_au VALUES
-				FROM (MINVALUE) TO ('2017-08-15'),
+				FROM (minvalue) TO ('2017-08-15'),
 			PARTITION current_au VALUES
-				FROM ('2017-08-15') TO (MAXVALUE)
+				FROM ('2017-08-15') TO (maxvalue)
 		),
 	PARTITION north_america VALUES IN ('US', 'CA')
 		PARTITION BY RANGE (
 			expected_graduation_date
 		) (
 			PARTITION graduated_us VALUES
-				FROM (MINVALUE) TO ('2017-08-15'),
+				FROM (minvalue) TO ('2017-08-15'),
 			PARTITION current_us VALUES
-				FROM ('2017-08-15') TO (MAXVALUE)
+				FROM ('2017-08-15') TO (maxvalue)
 		)
 )
 
@@ -619,16 +619,16 @@ PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ')
 		PARTITION BY RANGE (expected_graduation_date) (
 			PARTITION graduated_au VALUES
-				FROM (MINVALUE) TO ('2017-08-15'),
+				FROM (minvalue) TO ('2017-08-15'),
 			PARTITION current_au VALUES
-				FROM ('2017-08-15') TO (MAXVALUE)
+				FROM ('2017-08-15') TO (maxvalue)
 		),
 	PARTITION north_america VALUES IN ('US', 'CA')
 		PARTITION BY RANGE (expected_graduation_date) (
 			PARTITION graduated_us VALUES
-				FROM (MINVALUE) TO ('2017-08-15'),
+				FROM (minvalue) TO ('2017-08-15'),
 			PARTITION current_us VALUES
-				FROM ('2017-08-15') TO (MAXVALUE)
+				FROM ('2017-08-15') TO (maxvalue)
 		)
 )
 
@@ -646,14 +646,14 @@ PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ')
 		PARTITION BY RANGE (expected_graduation_date) (
 			PARTITION graduated_au VALUES
-				FROM (MINVALUE) TO ('2017-08-15'),
-			PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)
+				FROM (minvalue) TO ('2017-08-15'),
+			PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)
 		),
 	PARTITION north_america VALUES IN ('US', 'CA')
 		PARTITION BY RANGE (expected_graduation_date) (
 			PARTITION graduated_us VALUES
-				FROM (MINVALUE) TO ('2017-08-15'),
-			PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)
+				FROM (minvalue) TO ('2017-08-15'),
+			PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)
 		)
 )
 
@@ -670,13 +670,13 @@ CREATE TABLE students (
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ')
 		PARTITION BY RANGE (expected_graduation_date) (
-			PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'),
-			PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)
+			PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'),
+			PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)
 		),
 	PARTITION north_america VALUES IN ('US', 'CA')
 		PARTITION BY RANGE (expected_graduation_date) (
-			PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'),
-			PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)
+			PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'),
+			PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)
 		)
 )
 
@@ -686,13 +686,13 @@ CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, exp
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ')
 		PARTITION BY RANGE (expected_graduation_date) (
-			PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'),
-			PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)
+			PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'),
+			PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)
 		),
 	PARTITION north_america VALUES IN ('US', 'CA')
 		PARTITION BY RANGE (expected_graduation_date) (
-			PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'),
-			PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)
+			PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'),
+			PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)
 		)
 )
 
@@ -702,11 +702,11 @@ CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, exp
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ')
 		PARTITION BY RANGE (expected_graduation_date) (
-			PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'),
-			PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)
+			PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'),
+			PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)
 		),
 	PARTITION north_america VALUES IN ('US', 'CA')
-		PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE))
+		PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue))
 )
 
 183:
@@ -714,35 +714,35 @@ PARTITION BY LIST (country) (
 CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (country, expected_graduation_date, id))
 PARTITION BY LIST (country) (
 	PARTITION australia VALUES IN ('AU', 'NZ')
-		PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)),
+		PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)),
 	PARTITION north_america VALUES IN ('US', 'CA')
-		PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE))
+		PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue))
 )
 
 222:
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (country, expected_graduation_date, id))
 PARTITION BY LIST (country) (
-	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)),
+	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)),
 	PARTITION north_america VALUES IN ('US', 'CA')
-		PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE))
+		PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue))
 )
 
 225:
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (country, expected_graduation_date, id))
 PARTITION BY LIST (country) (
-	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)),
-	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE))
+	PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)),
+	PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue))
 )
 
 470:
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (country, expected_graduation_date, id))
-PARTITION BY LIST (country) (PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)), PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)))
+PARTITION BY LIST (country) (PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)), PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)))
 
 631:
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (country, expected_graduation_date, id)) PARTITION BY LIST (country) (PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)), PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)))
+CREATE TABLE students (id SERIAL, name STRING, email STRING, country STRING, expected_graduation_date DATE, PRIMARY KEY (country, expected_graduation_date, id)) PARTITION BY LIST (country) (PARTITION australia VALUES IN ('AU', 'NZ') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_au VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (maxvalue)), PARTITION north_america VALUES IN ('US', 'CA') PARTITION BY RANGE (expected_graduation_date) (PARTITION graduated_us VALUES FROM (minvalue) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (maxvalue)))
 
 

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1161,12 +1161,12 @@ func (expr DefaultVal) TypeCheck(_ *SemaContext, desired types.T) (TypedExpr, er
 }
 
 // TypeCheck implements the Expr interface.
-func (expr MinVal) TypeCheck(_ *SemaContext, desired types.T) (TypedExpr, error) {
+func (expr PartitionMinVal) TypeCheck(_ *SemaContext, desired types.T) (TypedExpr, error) {
 	return nil, errInvalidMinUsage
 }
 
 // TypeCheck implements the Expr interface.
-func (expr MaxVal) TypeCheck(_ *SemaContext, desired types.T) (TypedExpr, error) {
+func (expr PartitionMaxVal) TypeCheck(_ *SemaContext, desired types.T) (TypedExpr, error) {
 	return nil, errInvalidMaxUsage
 }
 

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -593,10 +593,10 @@ func (expr *ColumnItem) Walk(_ Visitor) Expr {
 func (expr DefaultVal) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
-func (expr MaxVal) Walk(_ Visitor) Expr { return expr }
+func (expr PartitionMaxVal) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
-func (expr MinVal) Walk(_ Visitor) Expr { return expr }
+func (expr PartitionMinVal) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
 func (expr *NumVal) Walk(_ Visitor) Expr { return expr }

--- a/pkg/sql/sqlbase/partition.go
+++ b/pkg/sql/sqlbase/partition.go
@@ -41,9 +41,9 @@ func (c PartitionSpecialValCode) String() string {
 	case PartitionDefaultVal:
 		return (tree.DefaultVal{}).String()
 	case PartitionMinVal:
-		return (tree.MinVal{}).String()
+		return (tree.PartitionMinVal{}).String()
 	case PartitionMaxVal:
-		return (tree.MaxVal{}).String()
+		return (tree.PartitionMaxVal{}).String()
 	}
 	panic("unreachable")
 }


### PR DESCRIPTION
First two commits from  #31725 and  #31731.

The keywords MINVALUE and MAXVALUE had been marked as reserved away
from being a valid column name to accommodate the CockroachDB-specific
"PARTITIONING" syntax.

This is unfortunate because these two words are perfectly fine English
names for things people may want to have as attributes in their
relations.

This patch removes the limitation by unreserving the two keywords and
handling the special words in the planning code for the partitioning
feature. In every other context the two words are not treated
specially and handled like any possible column name / identifier.

Release note (sql change): It is now again possible to use the
keywords MINVALUE and MAXVALUE as column names, for compatibility with
PostgreSQL.