### PR TITLE
backport-2.1: storage: correctly handle empty forwarded proposals

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4013,6 +4013,13 @@ func (r *Replica) shouldDropForwardedProposalLocked(req *RaftMessageRequest) boo
 	for _, e := range req.Message.Entries {
 		switch e.Type {
 		case raftpb.EntryNormal:
+			if len(e.Data) == 0 {
+				// Don't drop empty proposals. We don't really expect those to come in from
+				// remote nodes (as they're proposed by new leaders), but it does happen.
+				// Whether these are dropped or not should not matter. We opt to not drop
+				// them.
+				return false
+			}
 			cmdID, _ := DecodeRaftCommand(e.Data)
 			if _, ok := r.mu.remoteProposals[cmdID]; !ok {
 				// Untracked remote proposal. Don't drop.
@@ -4047,6 +4054,11 @@ func (r *Replica) maybeTrackForwardedProposalLocked(rg *raft.RawNode, req *RaftM
 	for _, e := range req.Message.Entries {
 		switch e.Type {
 		case raftpb.EntryNormal:
+			if len(e.Data) == 0 {
+				// Ignore empty proposals, which are different than proposals
+				// with no data. These are sent on leadership changes.
+				continue
+			}
 			cmdID, data := DecodeRaftCommand(e.Data)
 			if len(data) == 0 {
 				// An empty command is proposed to unquiesce a range and

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -8395,7 +8395,7 @@ func TestReplicaShouldDropForwardedProposal(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	cmdSeen, cmdNotSeen := makeIDKey(), makeIDKey()
-	data, noData := []byte("data"), []byte("")
+	data := []byte("data")
 
 	testCases := []struct {
 		name                string
@@ -8404,6 +8404,30 @@ func TestReplicaShouldDropForwardedProposal(t *testing.T) {
 		expDrop             bool
 		expRemotePropsAfter int
 	}{
+		{
+			name:   "empty proposal (nil):",
+			leader: true,
+			msg: raftpb.Message{
+				Type: raftpb.MsgProp,
+				Entries: []raftpb.Entry{
+					{Type: raftpb.EntryNormal, Data: nil},
+				},
+			},
+			expDrop:             false,
+			expRemotePropsAfter: 1,
+		},
+		{
+			name:   "empty proposal (zero)",
+			leader: true,
+			msg: raftpb.Message{
+				Type: raftpb.MsgProp,
+				Entries: []raftpb.Entry{
+					{Type: raftpb.EntryNormal, Data: []byte{}},
+				},
+			},
+			expDrop:             false,
+			expRemotePropsAfter: 1,
+		},
 		{
 			name:   "new proposal",
 			leader: true,
@@ -8442,12 +8466,12 @@ func TestReplicaShouldDropForwardedProposal(t *testing.T) {
 			expRemotePropsAfter: 2,
 		},
 		{
-			name:   "empty proposal",
+			name:   "proposal with no data (not an empty proposal)",
 			leader: true,
 			msg: raftpb.Message{
 				Type: raftpb.MsgProp,
 				Entries: []raftpb.Entry{
-					{Type: raftpb.EntryNormal, Data: encodeRaftCommandV1(cmdNotSeen, noData)},
+					{Type: raftpb.EntryNormal, Data: encodeRaftCommandV1(cmdNotSeen, nil)},
 				},
 			},
 			expDrop:             false,


### PR DESCRIPTION
Fixes #31050.
Closes #31066.

The code assumed that an empty proposal would be a command ID with empty data, but it's also possible that the entire slice is empty (command IDs+data is our encoding; Raft itself emits an entry with completely blank data).

This is the backport of https://github.com/cockroachdb/cockroach/pull/31066, which no longer needs to be merged into master. The only changes in this PR are that I addressed my comments from https://github.com/cockroachdb/cockroach/pull/31066#pullrequestreview-162664935.

Release note: None