### PR TITLE
storage: Specify range ID in all store rebalancer logs

### DIFF
--- a/pkg/storage/store_rebalancer.go
+++ b/pkg/storage/store_rebalancer.go
@@ -427,14 +427,15 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 				raftStatus = sr.getRaftStatusFn(replWithStats.repl)
 			}
 			if replicaIsBehind(raftStatus, candidate.ReplicaID) {
-				log.VEventf(ctx, 3, "%v is behind or this store isn't the raft leader; raftStatus: %v",
-					candidate, raftStatus)
+				log.VEventf(ctx, 3, "%v is behind or this store isn't the raft leader for r%d; raftStatus: %v",
+					candidate, desc.RangeID, raftStatus)
 				continue
 			}
 
 			preferred := sr.rq.allocator.preferredLeaseholders(zone, desc.Replicas)
 			if len(preferred) > 0 && !storeHasReplica(candidate.StoreID, preferred) {
-				log.VEventf(ctx, 3, "s%d not a preferred leaseholder; preferred: %v", candidate.StoreID, preferred)
+				log.VEventf(ctx, 3, "s%d not a preferred leaseholder for r%d; preferred: %v",
+					candidate.StoreID, desc.RangeID, preferred)
 				continue
 			}
 


### PR DESCRIPTION
These were pretty easy to figure out given the context around them, but
made it so that they wouldn't show up when you grep the logs by rangeID.

Release note: None

As observed on #31744.