### PR TITLE
release-2.1: opt: fix panic when ROWS FROM used with non-function

### DIFF
--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -93,13 +93,16 @@ func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 			panic(builderError{err})
 		}
 		texpr := inScope.resolveType(expr, types.Any)
-		def, err := texpr.(*tree.FuncExpr).Func.Resolve(b.semaCtx.SearchPath)
-		if err != nil {
-			panic(builderError{err})
+
+		var def *tree.FunctionDefinition
+		if funcExpr, ok := texpr.(*tree.FuncExpr); ok {
+			if def, err = funcExpr.Func.Resolve(b.semaCtx.SearchPath); err != nil {
+				panic(builderError{err})
+			}
 		}
 
 		var outCol *scopeColumn
-		if def.Class != tree.GeneratorClass || len(def.ReturnLabels) == 1 {
+		if def == nil || def.Class != tree.GeneratorClass || len(def.ReturnLabels) == 1 {
 			outCol = b.addColumn(outScope, label, texpr.ResolvedType(), texpr)
 		}
 

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -924,3 +924,12 @@ build
 SELECT 0, information_schema._pg_expandarray(ARRAY[0]) GROUP BY 1
 ----
 error (42803): column "x" must appear in the GROUP BY clause or be used in an aggregate function
+
+# Regression test for #31755.
+build
+SELECT * FROM ROWS FROM (CAST('string' AS SERIAL2[])) AS ident
+----
+zip
+ ├── columns: ident:1(int[])
+ └── cast: SERIAL2[] [type=int[]]
+      └── const: 'string' [type=string]


### PR DESCRIPTION
Backport 1/1 commits from #31765.

/cc @cockroachdb/release

---

Prior to this patch, the `optbuilder` was assuming that any expression
inside a `ROWS FROM` clause was a function. This caused a panic when a
non-function expression such as `CAST` was used with `ROWS FROM`.
This commit fixes that assumption.

Fixes #31755

Release note (bug fix): Fixed a panic caused by an incorrect assumption
in the SQL optimizer code that ROWS FROM clauses contain only functions.
