### PR TITLE
cdc: Re-enable Fingerprint Validator

### DIFF
--- a/pkg/ccl/changefeedccl/validations_test.go
+++ b/pkg/ccl/changefeedccl/validations_test.go
@@ -72,8 +72,7 @@ func TestValidations(t *testing.T) {
 
 			v := Validators{
 				NewOrderValidator(`bank`),
-				// TODO(mrtracy): Disabled by #30902. Re-enabling is tracked by #31110.
-				// NewFingerprintValidator(db, `bank`, `fprint`, bank.Partitions()),
+				NewFingerprintValidator(db, `bank`, `fprint`, bank.Partitions()),
 			}
 			sqlDB.Exec(t, `CREATE TABLE fprint (id INT PRIMARY KEY, balance INT, payload STRING)`)
 			for {

--- a/pkg/ccl/changefeedccl/validator_test.go
+++ b/pkg/ccl/changefeedccl/validator_test.go
@@ -167,6 +167,7 @@ func TestFingerprintValidator(t *testing.T) {
 	t.Run(`missed_initial`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE missed_initial (k INT PRIMARY KEY, v INT)`)
 		v := NewFingerprintValidator(sqlDB.DB, `foo`, `missed_initial`, []string{`p`})
+		noteResolved(t, v, `p`, ts[0])
 		// Intentionally missing {"k":1,"v":1} at ts[1].
 		v.NoteRow(ignored, `[1]`, `{"k":1,"v":2}`, ts[2])
 		v.NoteRow(ignored, `[1]`, `{"k":2,"v":2}`, ts[2])
@@ -179,6 +180,7 @@ func TestFingerprintValidator(t *testing.T) {
 	t.Run(`missed_middle`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE missed_middle (k INT PRIMARY KEY, v INT)`)
 		v := NewFingerprintValidator(sqlDB.DB, `foo`, `missed_middle`, []string{`p`})
+		noteResolved(t, v, `p`, ts[0])
 		v.NoteRow(ignored, `[1]`, `{"k":1,"v":1}`, ts[1])
 		// Intentionally missing {"k":1,"v":2} at ts[2].
 		v.NoteRow(ignored, `[1]`, `{"k":2,"v":2}`, ts[2])
@@ -190,6 +192,28 @@ func TestFingerprintValidator(t *testing.T) {
 			`fingerprints did not match at `+ts[3].Prev().AsOfSystemTime()+
 				`: 1099511631581 vs 1099511631582`,
 		)
+	})
+	t.Run(`missed_end`, func(t *testing.T) {
+		sqlDB.Exec(t, `CREATE TABLE missed_end (k INT PRIMARY KEY, v INT)`)
+		v := NewFingerprintValidator(sqlDB.DB, `foo`, `missed_end`, []string{`p`})
+		noteResolved(t, v, `p`, ts[0])
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":1}`, ts[1])
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":2}`, ts[2])
+		v.NoteRow(ignored, `[1]`, `{"k":2,"v":2}`, ts[2])
+		// Intentionally missing {"k":1,"v":3} at ts[3].
+		noteResolved(t, v, `p`, ts[3])
+		assertValidatorFailures(t, v,
+			`fingerprints did not match at `+ts[3].AsOfSystemTime()+
+				`: 1099511631580 vs 1099511631581`,
+		)
+	})
+	t.Run(`initial_scan`, func(t *testing.T) {
+		sqlDB.Exec(t, `CREATE TABLE initial_scan (k INT PRIMARY KEY, v INT)`)
+		v := NewFingerprintValidator(sqlDB.DB, `foo`, `initial_scan`, []string{`p`})
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":3}`, ts[4])
+		v.NoteRow(ignored, `[1]`, `{"k":2,"v":2}`, ts[4])
+		noteResolved(t, v, `p`, ts[4])
+		assertValidatorFailures(t, v)
 	})
 	t.Run(`unknown_partition`, func(t *testing.T) {
 		v := NewFingerprintValidator(sqlDB.DB, `foo`, `unknown_partition`, []string{`p`})

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -229,8 +229,7 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 		var numResolved, rowsSinceResolved int
 		v := changefeedccl.Validators{
 			changefeedccl.NewOrderValidator(`bank`),
-			// TODO(mrtracy): Disabled by #30902. Re-enabling is tracked by #31110.
-			// changefeedccl.NewFingerprintValidator(sqlDB.DB, `bank`, `fprint`, tc.partitions),
+			changefeedccl.NewFingerprintValidator(db, `bank`, `fprint`, tc.partitions),
 		}
 		if _, err := db.Exec(
 			`CREATE TABLE fprint (id INT PRIMARY KEY, balance INT, payload STRING)`,


### PR DESCRIPTION
Fingerprint validator was previously disabled due to its lack of support
for "initial scan" situations. This commit fixes fingerprint validator
  to support initial scans correctly and re-enables the validator in
  tests that were using it.

Resolves #31110

Release note: None