### PR TITLE
[wip] sql: agg/window fns share a parent mem account

### DIFF
--- a/pkg/sql/exec/execgen/cmd/execgen/main.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/main.go
@@ -84,7 +84,7 @@ func (g *execgen) run(args ...string) bool {
 		gen := generators[file]
 		if gen == nil {
 			g.reportError(errors.Errorf("unrecognized filename: %s", file))
-			return false
+			return true
 		}
 		if err := g.generate(gen, out); err != nil {
 			g.reportError(err)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -394,19 +396,19 @@ func (ef *execFactory) addAggregations(n *groupNode, aggregations []exec.AggInfo
 		agg := &aggregations[i]
 		builtin := agg.Builtin
 		var renderIdx int
-		var aggFn func(*tree.EvalContext, tree.Datums) tree.AggregateFunc
+		var aggFn func(*mon.BoundAccount, *tree.EvalContext, tree.Datums) tree.AggregateFunc
 
 		switch len(agg.ArgCols) {
 		case 0:
 			renderIdx = noRenderIdx
-			aggFn = func(evalCtx *tree.EvalContext, arguments tree.Datums) tree.AggregateFunc {
-				return builtin.AggregateFunc([]types.T{}, evalCtx, arguments)
+			aggFn = func(acc *mon.BoundAccount, evalCtx *tree.EvalContext, arguments tree.Datums) tree.AggregateFunc {
+				return builtin.AggregateFunc([]types.T{}, acc, evalCtx, arguments)
 			}
 
 		case 1:
 			renderIdx = int(agg.ArgCols[0])
-			aggFn = func(evalCtx *tree.EvalContext, arguments tree.Datums) tree.AggregateFunc {
-				return builtin.AggregateFunc([]types.T{inputCols[renderIdx].Typ}, evalCtx, arguments)
+			aggFn = func(acc *mon.BoundAccount, evalCtx *tree.EvalContext, arguments tree.Datums) tree.AggregateFunc {
+				return builtin.AggregateFunc([]types.T{inputCols[renderIdx].Typ}, acc, evalCtx, arguments)
 			}
 
 		default:

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -1215,25 +1217,27 @@ func (node *FuncExpr) ResolvedOverload() *Overload {
 
 // GetAggregateConstructor exposes the AggregateFunc field for use by
 // the group node in package sql.
-func (node *FuncExpr) GetAggregateConstructor() func(*EvalContext, Datums) AggregateFunc {
+func (node *FuncExpr) GetAggregateConstructor() 
+	func(*mon.BoundAccount, *EvalContext, Datums) AggregateFunc,
+ {
 	if node.fn == nil || node.fn.AggregateFunc == nil {
 		return nil
 	}
-	return func(evalCtx *EvalContext, arguments Datums) AggregateFunc {
+	return func(acc *mon.BoundAccount, evalCtx *EvalContext, arguments Datums) AggregateFunc {
 		types := typesOfExprs(node.Exprs)
-		return node.fn.AggregateFunc(types, evalCtx, arguments)
+		return node.fn.AggregateFunc(types, acc, evalCtx, arguments)
 	}
 }
 
 // GetWindowConstructor returns a window function constructor if the
 // FuncExpr is a built-in window function.
-func (node *FuncExpr) GetWindowConstructor() func(*EvalContext) WindowFunc {
+func (node *FuncExpr) GetWindowConstructor() func(*mon.BoundAccount, *EvalContext) WindowFunc {
 	if node.fn == nil || node.fn.WindowFunc == nil {
 		return nil
 	}
-	return func(evalCtx *EvalContext) WindowFunc {
+	return func(acc *mon.BoundAccount, evalCtx *EvalContext) WindowFunc {
 		types := typesOfExprs(node.Exprs)
-		return node.fn.WindowFunc(types, evalCtx)
+		return node.fn.WindowFunc(types, acc, evalCtx)
 	}
 }
 

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/pkg/errors"
@@ -47,11 +49,14 @@ type Overload struct {
 	// might be more appropriate.
 	Info string
 
-	AggregateFunc func([]types.T, *EvalContext, Datums) AggregateFunc
-	WindowFunc    func([]types.T, *EvalContext) WindowFunc
+	AggregateFunc AggregateFuncConstructor
+	WindowFunc    WindowFuncConstructor
 	Fn            func(*EvalContext, Datums) (Datum, error)
 	Generator     GeneratorFactory
 }
+
+type AggregateFuncConstructor func([]types.T, *mon.BoundAccount, *EvalContext, Datums) AggregateFunc
+type WindowFuncConstructor func([]types.T, *mon.BoundAccount, *EvalContext) WindowFunc
 
 // params implements the overloadImpl interface.
 func (b Overload) params() TypeList { return b.Types }

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -797,7 +797,7 @@ func (n *windowNode) computeWindows(ctx context.Context, evalCtx *tree.EvalConte
 		//   * Segment Tree
 		// See Leis et al. [http://www.vldb.org/pvldb/vol8/p1058-leis.pdf]
 		for _, partition := range partitions {
-			builtin := windowFn.expr.GetWindowConstructor()(evalCtx)
+			builtin := windowFn.expr.GetWindowConstructor()(&n.run.windowsAcc, evalCtx)
 			defer builtin.Close(ctx, evalCtx)
 
 			var peerGrouper tree.PeerGroupChecker


### PR DESCRIPTION
Previously, aggregate and window functions would request a bound account
from an ambient EvalContext if they needed to track memory. This was
unfortunate because of the scope of an aggregate function: one per
aggregate per each bucket in the aggregation. It led to lots of extra
bound accounts being created and requesting memory from the parent
monitor, for no reason.

Now, the functions simply use a passed-in memory account, leaving it up
to the constructors which account to pass in.

Release note: None