### PR TITLE
sql: cleanup AS OF SYSTEM TIME query descriptor cache lookup

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -199,9 +199,8 @@ func (p *planner) getTableScanByRef(
 	scanVisibility scanVisibility,
 ) (planDataSource, error) {
 	flags := ObjectLookupFlags{CommonLookupFlags{
-		txn:            p.txn,
-		avoidCached:    p.avoidCachedDescriptors,
-		fixedTimestamp: p.semaCtx.AsOfTimestamp != nil,
+		txn:         p.txn,
+		avoidCached: p.avoidCachedDescriptors,
 	},
 	}
 	desc, err := p.Tables().getTableVersionByID(ctx, sqlbase.ID(tref.TableID), flags)

--- a/pkg/sql/physical_schema_accessors.go
+++ b/pkg/sql/physical_schema_accessors.go
@@ -131,11 +131,17 @@ func (a UncachedPhysicalAccessor) GetObjectDesc(
 	if err != nil {
 		return nil, nil, err
 	}
+
 	if found {
-		// We have a descriptor. Is it in the right state? We'll keep if
-		// in the ADD state.
+		// We have a descriptor. Is it in the right state? We'll keep it if
+		// it is in the ADD state.
 		if err := filterTableState(desc); err == nil || err == errTableAdding {
-			return desc, dbDesc, nil
+			// Immediately after a RENAME an old name still points to the
+			// descriptor during the drain phase for the name. Do not
+			// return a descriptor during draining.
+			if nameMatchesTable(desc, dbDesc.ID, name.Table()) {
+				return desc, dbDesc, nil
+			}
 		}
 	}
 

--- a/pkg/sql/rename_test.go
+++ b/pkg/sql/rename_test.go
@@ -225,7 +225,7 @@ CREATE TABLE test.t (a INT PRIMARY KEY);
 	// Check that the old name is not usable outside of the transaction now
 	// that the node doesn't have a lease on it anymore (committing the txn
 	// should have released the lease on the version of the descriptor with the
-	// old name), even thoudh the name mapping still exists.
+	// old name), even though the name mapping still exists.
 	lease := s.LeaseManager().(*LeaseManager).tableNames.get(tableDesc.ID, "t", s.Clock().Now())
 	if lease != nil {
 		t.Fatalf(`still have lease on "t"`)

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -283,11 +283,10 @@ func (p *planner) LookupObject(
 
 func (p *planner) CommonLookupFlags(ctx context.Context, required bool) CommonLookupFlags {
 	return CommonLookupFlags{
-		ctx:            ctx,
-		txn:            p.txn,
-		required:       required,
-		avoidCached:    p.avoidCachedDescriptors,
-		fixedTimestamp: p.semaCtx.AsOfTimestamp != nil,
+		ctx:         ctx,
+		txn:         p.txn,
+		required:    required,
+		avoidCached: p.avoidCachedDescriptors,
 	}
 }
 

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -111,8 +111,6 @@ type CommonLookupFlags struct {
 	required bool
 	// if avoidCached is set, lookup will avoid the cache (if any).
 	avoidCached bool
-	// set to true if the transaction has a fixed timestamp.
-	fixedTimestamp bool
 }
 
 // DatabaseLookupFlags is the flag struct suitable for GetDatabaseDesc().


### PR DESCRIPTION
This change removes the fixedTimestamp bit introduced in #31716

It also explains problem #18354 with LeaseManager.Acquire() through
a comment and implements a work around bypassing the cache and
reading the descriptor directly from the store.

It also fixes a problem with UncachedPhysicalAccessor.GetObjectDesc
tested through TestTxnCanStillResolveOldName.

related to #30967

fixes #18354
fixes #19925

Release note: None