### PR TITLE
release-2.1: storagebase: hide the kv.range_merge.queue_enabled setting

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -31,7 +31,6 @@
 <tr><td><code>kv.raft_log.synchronize</code></td><td>boolean</td><td><code>true</code></td><td>set to true to synchronize on Raft log writes to persistent storage ('false' risks data loss)</td></tr>
 <tr><td><code>kv.range.backpressure_range_size_multiplier</code></td><td>float</td><td><code>2</code></td><td>multiple of range_max_bytes that a range is allowed to grow to without splitting before writes to that range are blocked, or 0 to disable</td></tr>
 <tr><td><code>kv.range_descriptor_cache.size</code></td><td>integer</td><td><code>1000000</code></td><td>maximum number of entries in the range descriptor and leaseholder caches</td></tr>
-<tr><td><code>kv.range_merge.queue_enabled</code></td><td>boolean</td><td><code>false</code></td><td>whether the automatic merge queue is enabled</td></tr>
 <tr><td><code>kv.rangefeed.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, rangefeed registration is enabled</td></tr>
 <tr><td><code>kv.snapshot_rebalance.max_rate</code></td><td>byte size</td><td><code>2.0 MiB</code></td><td>the rate limit (bytes/sec) to use for rebalance snapshots</td></tr>
 <tr><td><code>kv.snapshot_recovery.max_rate</code></td><td>byte size</td><td><code>8.0 MiB</code></td><td>the rate limit (bytes/sec) to use for recovery snapshots</td></tr>

--- a/pkg/storage/merge_queue.go
+++ b/pkg/storage/merge_queue.go
@@ -46,11 +46,15 @@ const (
 
 // MergeQueueEnabled is a setting that controls whether the merge queue is
 // enabled.
-var MergeQueueEnabled = settings.RegisterBoolSetting(
-	"kv.range_merge.queue_enabled",
-	"whether the automatic merge queue is enabled",
-	false,
-)
+var MergeQueueEnabled = func() *settings.BoolSetting {
+	s := settings.RegisterBoolSetting(
+		"kv.range_merge.queue_enabled",
+		"whether the automatic merge queue is enabled (EXPERIMENTAL)",
+		false,
+	)
+	s.Hide()
+	return s
+}()
 
 // MergeQueueInterval is a setting that controls how often the merge queue waits
 // between processing replicas.


### PR DESCRIPTION
Since range merges have a known bug that can permanently brick a node,
hide the setting so that unsuspecting users don't turn them on.

Release note: None