### PR TITLE
distsql: handle implicit key cols in lookup joins

### DIFF
--- a/pkg/sql/distsqlrun/indexjoiner.go
+++ b/pkg/sql/distsqlrun/indexjoiner.go
@@ -204,7 +204,8 @@ func (ij *indexJoiner) generateSpan(row sqlbase.EncDatumRow) (roachpb.Span, erro
 	keyRow := row[:numKeyCols]
 	types := ij.input.OutputTypes()[:numKeyCols]
 	key, err := sqlbase.MakeKeyFromEncDatums(
-		types, keyRow, &ij.desc, &ij.desc.PrimaryIndex, ij.keyPrefix, &ij.alloc)
+		ij.keyPrefix, keyRow, types, ij.desc.PrimaryIndex.ColumnDirections, &ij.desc,
+		&ij.desc.PrimaryIndex, &ij.alloc)
 	if err != nil {
 		return roachpb.Span{}, err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -406,3 +406,80 @@ query IIII
 SELECT * FROM source JOIN child ON source.a = child.a
 ----
 1 1 2 3
+
+###########################################################
+#  LOOKUP JOINS ON IMPLICIT INDEX KEY COLUMNS             #
+#  https://github.com/cockroachdb/cockroach/issues/31777  #
+###########################################################
+statement ok
+CREATE TABLE t (a INT, b INT, c INT, d INT, e INT)
+
+statement ok
+CREATE TABLE u (a INT, b INT, c INT, d INT, e INT, PRIMARY KEY (a DESC, b, c))
+
+statement ok
+INSERT INTO t VALUES
+  (1, 2, 3, 4, 5)
+
+statement ok
+INSERT INTO u VALUES
+  (1, 2, 3, 4, 5),
+  (2, 3, 4, 5, 6),
+  (3, 4, 5, 6, 7)
+
+# Test index with all primary key columns implicit.
+statement ok
+CREATE INDEX idx ON u (d)
+
+query I
+SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e = 5
+----
+1
+
+# Test unique version of same index. (Lookup join should not use column a.)
+statement ok
+DROP INDEX u@idx
+
+statement ok
+CREATE UNIQUE INDEX idx ON u (d)
+
+query I
+SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e = 5
+----
+1
+
+# Test index with first primary key column explicit and the rest implicit.
+statement ok
+DROP INDEX u@idx CASCADE
+
+statement ok
+CREATE INDEX idx ON u (d, a)
+
+query I
+SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = u.b WHERE t.e = 5
+----
+1
+
+# Test index with middle primary key column explicit and the rest implicit.
+statement ok
+DROP INDEX u@idx
+
+statement ok
+CREATE INDEX idx ON u (d, b)
+
+query I
+SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = u.b WHERE t.e = 5
+----
+1
+
+# Test index with last primary key column explicit and the rest implicit.
+statement ok
+DROP INDEX u@idx
+
+statement ok
+CREATE INDEX idx ON u (d, c)
+
+query I
+SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.d = u.d WHERE t.e = 5
+----
+1

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -413,3 +413,117 @@ render          ·         ·              (c, d)     ·
       └── scan  ·         ·              (c)        ·
 ·               table     small@primary  ·          ·
 ·               spans     ALL            ·          ·
+
+###########################################################
+#  LOOKUP JOINS ON IMPLICIT INDEX KEY COLUMNS             #
+#  https://github.com/cockroachdb/cockroach/issues/31777  #
+###########################################################
+statement ok
+CREATE TABLE t (a INT, b INT, c INT, d INT, e INT)
+
+statement ok
+CREATE TABLE u (a INT, b INT, c INT, d INT, e INT, PRIMARY KEY (a DESC, b, c))
+
+# Test index with all primary key columns implicit.
+statement ok
+CREATE INDEX idx ON u (d)
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e = 5
+----
+render            ·         ·          (a)              ·
+ │                render 0  a          ·                ·
+ └── lookup-join  ·         ·          (a, d, e, a, d)  ·
+      │           type      inner      ·                ·
+      ├── scan    ·         ·          (a, d, e)        ·
+      │           table     t@primary  ·                ·
+      │           spans     ALL        ·                ·
+      │           filter    e = 5      ·                ·
+      └── scan    ·         ·          (a, d)           ·
+·                 table     u@idx      ·                ·
+
+# Test unique version of same index. (Lookup join should not use column a.)
+statement ok
+DROP INDEX u@idx
+
+statement ok
+CREATE UNIQUE INDEX idx ON u (d)
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e = 5
+----
+render            ·         ·          (a)              ·
+ │                render 0  a          ·                ·
+ └── lookup-join  ·         ·          (a, d, e, a, d)  ·
+      │           type      inner      ·                ·
+      │           pred      @1 = @4    ·                ·
+      ├── scan    ·         ·          (a, d, e)        ·
+      │           table     t@primary  ·                ·
+      │           spans     ALL        ·                ·
+      │           filter    e = 5      ·                ·
+      └── scan    ·         ·          (a, d)           ·
+·                 table     u@idx      ·                ·
+
+# Test index with first primary key column explicit and the rest implicit.
+statement ok
+DROP INDEX u@idx CASCADE
+
+statement ok
+CREATE INDEX idx ON u (d, a)
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = u.b WHERE t.e = 5
+----
+render            ·         ·          (a)                    ·
+ │                render 0  a          ·                      ·
+ └── lookup-join  ·         ·          (a, b, d, e, a, b, d)  ·
+      │           type      inner      ·                      ·
+      ├── scan    ·         ·          (a, b, d, e)           ·
+      │           table     t@primary  ·                      ·
+      │           spans     ALL        ·                      ·
+      │           filter    e = 5      ·                      ·
+      └── scan    ·         ·          (a, b, d)              ·
+·                 table     u@idx      ·                      ·
+
+# Test index with middle primary key column explicit and the rest implicit.
+statement ok
+DROP INDEX u@idx
+
+statement ok
+CREATE INDEX idx ON u (d, b)
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = u.b WHERE t.e = 5
+----
+render            ·         ·          (a)                    ·
+ │                render 0  a          ·                      ·
+ └── lookup-join  ·         ·          (a, b, d, e, a, b, d)  ·
+      │           type      inner      ·                      ·
+      ├── scan    ·         ·          (a, b, d, e)           ·
+      │           table     t@primary  ·                      ·
+      │           spans     ALL        ·                      ·
+      │           filter    e = 5      ·                      ·
+      └── scan    ·         ·          (a, b, d)              ·
+·                 table     u@idx      ·                      ·
+
+# Test index with last primary key column explicit and the rest implicit.
+statement ok
+DROP INDEX u@idx
+
+statement ok
+CREATE INDEX idx ON u (d, c)
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.d = u.d WHERE t.e = 5
+----
+render            ·         ·          (a)              ·
+ │                render 0  a          ·                ·
+ └── lookup-join  ·         ·          (a, d, e, a, d)  ·
+      │           type      inner      ·                ·
+      │           pred      @1 = @4    ·                ·
+      ├── scan    ·         ·          (a, d, e)        ·
+      │           table     t@primary  ·                ·
+      │           spans     ALL        ·                ·
+      │           filter    e = 5      ·                ·
+      └── scan    ·         ·          (a, d)           ·
+·                 table     u@idx      ·                ·

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -58,7 +58,7 @@ type tableInfo struct {
 	desc             *sqlbase.TableDescriptor
 	index            *sqlbase.IndexDescriptor
 	isSecondaryIndex bool
-	indexColumnDirs  []encoding.Direction
+	indexColumnDirs  []sqlbase.IndexDescriptor_Direction
 	// equivSignature is an equivalence class for each unique table-index
 	// pair. It allows us to check if an index key belongs to a given
 	// table-index.

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -479,7 +479,10 @@ func (n *scanNode) computePhysicalProps(
 		if i < exactPrefix {
 			pp.addConstantColumn(idx)
 		} else {
-			dir := dirs[i]
+			dir, err := dirs[i].ToEncodingDirection()
+			if err != nil {
+				panic(err)
+			}
 			if reverse {
 				dir = dir.Reverse()
 			}

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -273,25 +273,18 @@ func (desc *IndexDescriptor) ContainsColumnID(colID ColumnID) bool {
 // FullColumnIDs returns the index column IDs including any extra (implicit or
 // stored (old STORING encoding)) column IDs for non-unique indexes. It also
 // returns the direction with which each column was encoded.
-func (desc *IndexDescriptor) FullColumnIDs() ([]ColumnID, []encoding.Direction) {
-	dirs := make([]encoding.Direction, 0, len(desc.ColumnIDs))
-	for _, dir := range desc.ColumnDirections {
-		convertedDir, err := dir.ToEncodingDirection()
-		if err != nil {
-			panic(err)
-		}
-		dirs = append(dirs, convertedDir)
-	}
+func (desc *IndexDescriptor) FullColumnIDs() ([]ColumnID, []IndexDescriptor_Direction) {
 	if desc.Unique {
-		return desc.ColumnIDs, dirs
+		return desc.ColumnIDs, desc.ColumnDirections
 	}
 	// Non-unique indexes have some of the primary-key columns appended to
 	// their key.
 	columnIDs := append([]ColumnID(nil), desc.ColumnIDs...)
 	columnIDs = append(columnIDs, desc.ExtraColumnIDs...)
+	dirs := append([]IndexDescriptor_Direction(nil), desc.ColumnDirections...)
 	for range desc.ExtraColumnIDs {
 		// Extra columns are encoded in ascending order.
-		dirs = append(dirs, encoding.Ascending)
+		dirs = append(dirs, IndexDescriptor_ASC)
 	}
 	return columnIDs, dirs
 }

--- a/pkg/sql/sqlbase/table_test.go
+++ b/pkg/sql/sqlbase/table_test.go
@@ -108,13 +108,7 @@ func decodeIndex(
 		return nil, err
 	}
 	values := make([]EncDatum, len(index.ColumnIDs))
-	colDirs := make([]encoding.Direction, len(index.ColumnDirections))
-	for i, dir := range index.ColumnDirections {
-		colDirs[i], err = dir.ToEncodingDirection()
-		if err != nil {
-			return nil, err
-		}
-	}
+	colDirs := index.ColumnDirections
 	_, ok, err := DecodeIndexKey(tableDesc, index, types, values, colDirs, key)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Non-unique indexes implicitly include all primary key columns in their
keys. The optimizer takes advantage of this when planning lookup joins,
but joinreader was not aware of this and only considered explicit key
columns, which caused an error upon execution ("2 lookup columns
specified, expecting at most 1"). I added joinreader logic to handle
this case.

Fixes #31777 

Release note (bug fix): Fixed a mismatch between lookup join planning
and execution, which could cause queries to fail with the error, "X
lookup columns specified, expecting at most Y."