### PR TITLE
sql: introduce MutableTableDescriptor struct

### DIFF
--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -47,12 +47,12 @@ func parseTableDesc(createTableStmt string) (*sqlbase.TableDescriptor, error) {
 	st := cluster.MakeTestingClusterSettings()
 	const parentID = sqlbase.ID(keys.MaxReservedDescID + 1)
 	const tableID = sqlbase.ID(keys.MaxReservedDescID + 2)
-	tableDesc, err := importccl.MakeSimpleTableDescriptor(
+	mutDesc, err := importccl.MakeSimpleTableDescriptor(
 		ctx, st, createTable, parentID, tableID, importccl.NoFKs, hlc.UnixNano())
 	if err != nil {
 		return nil, err
 	}
-	return tableDesc, tableDesc.ValidateTable(st)
+	return mutDesc.TableDesc(), mutDesc.TableDesc().ValidateTable(st)
 }
 
 func parseValues(tableDesc *sqlbase.TableDescriptor, values string) ([]sqlbase.EncDatumRow, error) {

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1461,7 +1461,7 @@ func BenchmarkConvertRecord(b *testing.B) {
 		}
 	}()
 
-	c := &csvInputReader{recordCh: recordCh, tableDesc: tableDesc}
+	c := &csvInputReader{recordCh: recordCh, tableDesc: tableDesc.TableDesc()}
 	// start up workers.
 	for i := 0; i < runtime.NumCPU(); i++ {
 		group.Go(func() error {

--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -157,7 +157,7 @@ func Load(
 			// rejected during restore.
 			st := cluster.MakeTestingClusterSettings()
 
-			affected := make(map[sqlbase.ID]*sqlbase.TableDescriptor)
+			affected := make(map[sqlbase.ID]*sqlbase.MutableTableDescriptor)
 			// A nil txn is safe because it is only used by sql.MakeTableDesc, which
 			// only uses txn for resolving FKs and interleaved tables, neither of which
 			// are present here. Ditto for the schema accessor.
@@ -170,7 +170,7 @@ func Load(
 				return backupccl.BackupDescriptor{}, errors.Wrap(err, "make table desc")
 			}
 
-			tableDesc = &desc
+			tableDesc = desc.TableDesc()
 			tableDescs[tableName] = tableDesc
 			backup.Descriptors = append(backup.Descriptors, sqlbase.Descriptor{
 				Union: &sqlbase.Descriptor_Table{Table: tableDesc},

--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -74,10 +74,10 @@ func descForTable(
 	if err != nil {
 		t.Fatalf("could not interpret %q: %v", create, err)
 	}
-	if err := fixDescriptorFKState(table); err != nil {
+	if err := fixDescriptorFKState(table.TableDesc()); err != nil {
 		t.Fatal(err)
 	}
-	return table
+	return table.TableDesc()
 }
 
 func TestMysqldumpDataReader(t *testing.T) {
@@ -173,7 +173,7 @@ func TestMysqldumpSchemaReader(t *testing.T) {
 	referencedSimple := descForTable(t, readFile(t, `simple.cockroach-schema.sql`), expectedParent, 52, NoFKs)
 	fks := fkHandler{
 		allowed:  true,
-		resolver: fkResolver(map[string]*sqlbase.TableDescriptor{referencedSimple.Name: referencedSimple}),
+		resolver: fkResolver(map[string]*sqlbase.MutableTableDescriptor{referencedSimple.Name: sql.NewMutableTableDescriptor(*referencedSimple)}),
 	}
 
 	t.Run("simple", func(t *testing.T) {

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -245,9 +245,9 @@ func readPostgresCreateTable(
 					return nil, err
 				}
 				fks.resolver[desc.Name] = &desc
-				ret = append(ret, &desc)
+				ret = append(ret, desc.TableDesc())
 			}
-			backrefs := make(map[sqlbase.ID]*sqlbase.TableDescriptor)
+			backrefs := make(map[sqlbase.ID]*sqlbase.MutableTableDescriptor)
 			for _, create := range createTbl {
 				if create == nil {
 					continue
@@ -260,7 +260,7 @@ func readPostgresCreateTable(
 				}
 				fks.resolver[desc.Name] = desc
 				backrefs[desc.ID] = desc
-				ret = append(ret, desc)
+				ret = append(ret, desc.TableDesc())
 			}
 			for name, constraints := range tableFKs {
 				desc := fks.resolver[name]
@@ -272,7 +272,7 @@ func readPostgresCreateTable(
 						return nil, err
 					}
 				}
-				if err := fixDescriptorFKState(desc); err != nil {
+				if err := fixDescriptorFKState(desc.TableDesc()); err != nil {
 					return nil, err
 				}
 			}

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -125,11 +125,12 @@ func (t *partitioningTest) parse() error {
 		}
 		st := cluster.MakeTestingClusterSettings()
 		const parentID, tableID = keys.MinUserDescID, keys.MinUserDescID + 1
-		t.parsed.tableDesc, err = importccl.MakeSimpleTableDescriptor(
+		mutDesc, err := importccl.MakeSimpleTableDescriptor(
 			ctx, st, createTable, parentID, tableID, importccl.NoFKs, hlc.UnixNano())
 		if err != nil {
 			return err
 		}
+		t.parsed.tableDesc = mutDesc.TableDesc()
 		if err := t.parsed.tableDesc.ValidateTable(st); err != nil {
 			return err
 		}

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -72,7 +72,7 @@ func (n *alterIndexNode) startExec(params runParams) error {
 			)
 			err = deleteRemovedPartitionZoneConfigs(
 				params.ctx, params.p.txn,
-				n.tableDesc, n.indexDesc,
+				n.tableDesc.TableDesc(), n.indexDesc,
 				&n.indexDesc.Partitioning, &partitioning,
 				params.extendedEvalCtx.ExecCfg,
 			)

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -173,11 +173,12 @@ func (p *planner) MemberOfWithAdminOption(
 	ctx context.Context, member string,
 ) (map[string]bool, error) {
 	// Lookup table version.
-	tableDesc, _, err := p.PhysicalSchemaAccessor().GetObjectDesc(&roleMembersTableName,
+	objDesc, _, err := p.PhysicalSchemaAccessor().GetObjectDesc(&roleMembersTableName,
 		p.ObjectLookupFlags(ctx, true /*required*/))
 	if err != nil {
 		return nil, err
 	}
+	tableDesc := objDesc.TableDesc()
 	tableVersion := tableDesc.Version
 
 	// We loop in case the table version changes while we're looking up memberships.

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -199,7 +199,7 @@ func (n *createTableNode) startExec(params runParams) error {
 		// Instantiate a row inserter and table writer. It has a 1-1
 		// mapping to the definitions in the descriptor.
 		ri, err := row.MakeInserter(
-			params.p.txn, &desc, nil, desc.Columns, row.SkipFKs, &params.p.alloc)
+			params.p.txn, desc.TableDesc(), nil, desc.Columns, row.SkipFKs, &params.p.alloc)
 		if err != nil {
 			return err
 		}
@@ -388,7 +388,7 @@ func ResolveFK(
 		}
 	}
 
-	target, err := ResolveExistingObject(ctx, sc, &d.Table, true /*required*/, requireTableDesc)
+	target, err := ResolveMutableExistingObject(ctx, sc, &d.Table, true /*required*/, requireTableDesc)
 	if err != nil {
 		return err
 	}
@@ -483,7 +483,7 @@ func ResolveFK(
 	if d.Actions.Delete == tree.SetNull || d.Actions.Update == tree.SetNull {
 		for _, sourceColumn := range srcCols {
 			if !sourceColumn.Nullable {
-				col := qualifyFKColErrorWithDB(ctx, txn, tbl, sourceColumn.Name)
+				col := qualifyFKColErrorWithDB(ctx, txn, tbl.TableDesc(), sourceColumn.Name)
 				return pgerror.NewErrorf(pgerror.CodeInvalidForeignKeyError,
 					"cannot add a SET NULL cascading action on column %q which has a NOT NULL constraint", col,
 				)
@@ -496,7 +496,7 @@ func ResolveFK(
 	if d.Actions.Delete == tree.SetDefault || d.Actions.Update == tree.SetDefault {
 		for _, sourceColumn := range srcCols {
 			if sourceColumn.DefaultExpr == nil {
-				col := qualifyFKColErrorWithDB(ctx, txn, tbl, sourceColumn.Name)
+				col := qualifyFKColErrorWithDB(ctx, txn, tbl.TableDesc(), sourceColumn.Name)
 				return pgerror.NewErrorf(pgerror.CodeInvalidForeignKeyError,
 					"cannot add a SET DEFAULT cascading action on column %q which has no DEFAULT expression", col,
 				)
@@ -750,7 +750,7 @@ func (p *planner) finalizeInterleave(
 		ancestorTable = desc
 	} else {
 		var err error
-		ancestorTable, err = sqlbase.GetTableDescFromID(ctx, p.txn, ancestor.TableID)
+		ancestorTable, err = p.Tables().getMutableTableVersionByID(ctx, ancestor.TableID, p.txn)
 		if err != nil {
 			return err
 		}
@@ -808,6 +808,12 @@ var CreatePartitioningCCL = func(
 		"creating or manipulating partitions requires a CCL binary"))
 }
 
+// NewMutableTableDescriptor returns a MutableTableDescriptor from the
+// given TableDescriptor.
+func NewMutableTableDescriptor(tbl sqlbase.TableDescriptor) *sqlbase.MutableTableDescriptor {
+	return &sqlbase.MutableTableDescriptor{TableDescriptor: tbl}
+}
+
 // InitTableDescriptor returns a blank TableDescriptor.
 func InitTableDescriptor(
 	id, parentID sqlbase.ID,
@@ -815,7 +821,7 @@ func InitTableDescriptor(
 	creationTime hlc.Timestamp,
 	privileges *sqlbase.PrivilegeDescriptor,
 ) sqlbase.MutableTableDescriptor {
-	return sqlbase.MutableTableDescriptor{
+	return *NewMutableTableDescriptor(sqlbase.TableDescriptor{
 		ID:               id,
 		Name:             name,
 		ParentID:         parentID,
@@ -823,7 +829,7 @@ func InitTableDescriptor(
 		Version:          1,
 		ModificationTime: creationTime,
 		Privileges:       privileges,
-	}
+	})
 }
 
 // makeTableDescIfAs is the MakeTableDesc method for when we have a table
@@ -1115,7 +1121,7 @@ func MakeTableDesc(
 	// table.
 	fkResolver := &fkSelfResolver{
 		SchemaResolver: vt,
-		newTableDesc:   &desc,
+		newTableDesc:   desc.TableDesc(),
 		newTableName:   &n.Table,
 	}
 

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -237,7 +237,7 @@ func (p *planner) accumulateDependentTables(
 ) error {
 	for _, ref := range desc.DependedOnBy {
 		dependentTables[ref.ID] = true
-		dependentDesc, err := sqlbase.GetTableDescFromID(ctx, p.txn, ref.ID)
+		dependentDesc, err := p.Tables().getMutableTableVersionByID(ctx, ref.ID, p.txn)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -139,7 +139,7 @@ func (p *planner) dropIndexByName(
 	for _, s := range zone.Subzones {
 		if s.IndexID != uint32(idx.ID) {
 			_, err = GenerateSubzoneSpans(
-				p.ExecCfg().Settings, p.ExecCfg().ClusterID(), tableDesc, zone.Subzones, false /* newSubzones */)
+				p.ExecCfg().Settings, p.ExecCfg().ClusterID(), tableDesc.TableDesc(), zone.Subzones, false /* newSubzones */)
 			if sqlbase.IsCCLRequiredError(err) {
 				return sqlbase.NewCCLRequiredError(fmt.Errorf("schema change requires a CCL binary "+
 					"because table %q has at least one remaining index or partition with a zone config",

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -111,7 +111,7 @@ func (p *planner) changePrivileges(
 			descKey := sqlbase.MakeDescMetadataKey(descriptor.GetID())
 			b.Put(descKey, sqlbase.WrapDescriptor(descriptor))
 
-		case *sqlbase.TableDescriptor:
+		case *sqlbase.MutableTableDescriptor:
 			if !d.Dropped() {
 				if err := p.writeSchemaChangeToBatch(
 					ctx, d, sqlbase.InvalidMutationID, b); err != nil {

--- a/pkg/sql/logical_schema_accessors.go
+++ b/pkg/sql/logical_schema_accessors.go
@@ -66,7 +66,7 @@ func (l *LogicalSchemaAccessor) GetObjectNames(
 // GetObjectDesc implements the ObjectAccessor interface.
 func (l *LogicalSchemaAccessor) GetObjectDesc(
 	name *ObjectName, flags ObjectLookupFlags,
-) (*ObjectDescriptor, *DatabaseDescriptor, error) {
+) (ObjectDescriptor, *DatabaseDescriptor, error) {
 	if scEntry, ok := l.vt.getVirtualSchemaEntry(name.Schema()); ok {
 		tableName := name.Table()
 		if t, ok := scEntry.defs[tableName]; ok {

--- a/pkg/sql/relocate.go
+++ b/pkg/sql/relocate.go
@@ -104,7 +104,7 @@ func (p *planner) Relocate(ctx context.Context, n *tree.Relocate) (planNode, err
 
 	return &relocateNode{
 		relocateLease: n.RelocateLease,
-		tableDesc:     tableDesc,
+		tableDesc:     tableDesc.TableDesc(),
 		index:         index,
 		rows:          rows,
 		run: relocateRun{

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -90,14 +90,15 @@ func (n *renameDatabaseNode) startExec(params runParams) error {
 	}
 	lookupFlags.required = false
 	for i := range tbNames {
-		tbDesc, _, err := phyAccessor.GetObjectDesc(&tbNames[i],
+		objDesc, _, err := phyAccessor.GetObjectDesc(&tbNames[i],
 			ObjectLookupFlags{CommonLookupFlags: lookupFlags})
 		if err != nil {
 			return err
 		}
-		if tbDesc == nil {
+		if objDesc == nil {
 			continue
 		}
+		tbDesc := objDesc.TableDesc()
 		if len(tbDesc.DependedOnBy) > 0 {
 			viewDesc, err := sqlbase.GetTableDescFromID(ctx, p.txn, tbDesc.DependedOnBy[0].ID)
 			if err != nil {

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -93,7 +93,39 @@ func GetObjectNames(
 // if no object is found.
 func ResolveExistingObject(
 	ctx context.Context, sc SchemaResolver, tn *ObjectName, required bool, requiredType requiredType,
-) (res *ObjectDescriptor, err error) {
+) (res *TableDescriptor, err error) {
+	desc, err := resolveExistingObjectImpl(ctx, sc, tn, required, false /* requiredMutable */, requiredType)
+	if err != nil || desc == nil {
+		return nil, err
+	}
+	return desc.(*TableDescriptor), nil
+}
+
+// ResolveMutableExistingObject looks up an existing mutable object.
+// If required is true, an error is returned if the object does not exist.
+// Optionally, if a desired descriptor type is specified, that type is checked.
+//
+// The object name is modified in-place with the result of the name
+// resolution, if successful. It is not modified in case of error or
+// if no object is found.
+func ResolveMutableExistingObject(
+	ctx context.Context, sc SchemaResolver, tn *ObjectName, required bool, requiredType requiredType,
+) (res *MutableTableDescriptor, err error) {
+	desc, err := resolveExistingObjectImpl(ctx, sc, tn, required, true /* requiredMutable */, requiredType)
+	if err != nil || desc == nil {
+		return nil, err
+	}
+	return desc.(*MutableTableDescriptor), nil
+}
+
+func resolveExistingObjectImpl(
+	ctx context.Context,
+	sc SchemaResolver,
+	tn *ObjectName,
+	required bool,
+	requiredMutable bool,
+	requiredType requiredType,
+) (res tree.NameResolutionResult, err error) {
 	found, descI, err := tn.ResolveExisting(ctx, sc, sc.CurrentDatabase(), sc.CurrentSearchPath())
 	if err != nil {
 		return nil, err
@@ -104,22 +136,31 @@ func ResolveExistingObject(
 		}
 		return nil, nil
 	}
-	desc := descI.(*ObjectDescriptor)
+	obj := descI.(ObjectDescriptor)
+
 	goodType := true
 	switch requiredType {
 	case requireTableDesc:
-		goodType = desc.IsTable()
+		goodType = obj.TableDesc().IsTable()
 	case requireViewDesc:
-		goodType = desc.IsView()
+		goodType = obj.TableDesc().IsView()
 	case requireTableOrViewDesc:
-		goodType = desc.IsTable() || desc.IsView()
+		goodType = obj.TableDesc().IsTable() || obj.TableDesc().IsView()
 	case requireSequenceDesc:
-		goodType = desc.IsSequence()
+		goodType = obj.TableDesc().IsSequence()
 	}
 	if !goodType {
 		return nil, sqlbase.NewWrongObjectTypeError(tn, requiredTypeNames[requiredType])
 	}
-	return desc, nil
+
+	if requiredMutable {
+		if mutDesc, ok := descI.(*MutableTableDescriptor); ok {
+			return mutDesc, nil
+		}
+		return NewMutableTableDescriptor(*descI.(*TableDescriptor)), nil
+	}
+
+	return obj.TableDesc(), nil
 }
 
 // runWithOptions sets the provided resolution flags for the
@@ -150,7 +191,7 @@ func (p *planner) ResolveMutableTableDescriptor(
 	ctx context.Context, tn *ObjectName, required bool, requiredType requiredType,
 ) (table *MutableTableDescriptor, err error) {
 	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		table, err = ResolveExistingObject(ctx, p, tn, required, requiredType)
+		table, err = ResolveMutableExistingObject(ctx, p, tn, required, requiredType)
 	})
 	return table, err
 }
@@ -291,8 +332,7 @@ func getDescriptorsFromTargetList(
 			return nil, err
 		}
 		for i := range tableNames {
-			descriptor, _, err := p.LogicalSchemaAccessor().GetObjectDesc(&tableNames[i],
-				p.ObjectLookupFlags(ctx, true /*required*/))
+			descriptor, err := ResolveMutableExistingObject(ctx, p, &tableNames[i], true, anyDescType)
 			if err != nil {
 				return nil, err
 			}
@@ -328,17 +368,19 @@ func (p *planner) getQualifiedTableName(
 // error will be returned, otherwise the TableName and descriptor
 // returned will be nil.
 func findTableContainingIndex(
-	sc SchemaAccessor,
+	ctx context.Context,
+	sc SchemaResolver,
 	dbName, scName string,
 	idxName tree.UnrestrictedName,
 	lookupFlags CommonLookupFlags,
 ) (result *tree.TableName, desc *MutableTableDescriptor, err error) {
-	dbDesc, err := sc.GetDatabaseDesc(dbName, lookupFlags)
+	sa := sc.LogicalSchemaAccessor()
+	dbDesc, err := sa.GetDatabaseDesc(dbName, lookupFlags)
 	if dbDesc == nil || err != nil {
 		return nil, nil, err
 	}
 
-	tns, err := sc.GetObjectNames(dbDesc, scName,
+	tns, err := sa.GetObjectNames(dbDesc, scName,
 		DatabaseListFlags{CommonLookupFlags: lookupFlags, explicitPrefix: true})
 	if err != nil {
 		return nil, nil, err
@@ -349,7 +391,7 @@ func findTableContainingIndex(
 	tblLookupFlags.required = false
 	for i := range tns {
 		tn := &tns[i]
-		tableDesc, _, err := sc.GetObjectDesc(tn, tblLookupFlags)
+		tableDesc, err := ResolveMutableExistingObject(ctx, sc, tn, true, anyDescType)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -402,7 +444,7 @@ func expandIndexName(
 	tn = &index.Table
 	if !index.SearchTable {
 		// The index and its table prefix must exist already. Resolve the table.
-		desc, err = ResolveExistingObject(ctx, sc, tn, requireTable, requireTableDesc)
+		desc, err = ResolveMutableExistingObject(ctx, sc, tn, requireTable, requireTableDesc)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -438,8 +480,7 @@ func expandIndexName(
 
 		lookupFlags := sc.CommonLookupFlags(ctx, requireTable)
 		var foundTn *tree.TableName
-		foundTn, desc, err = findTableContainingIndex(
-			sc.LogicalSchemaAccessor(), tn.Catalog(), tn.Schema(), index.Index, lookupFlags)
+		foundTn, desc, err = findTableContainingIndex(ctx, sc, tn.Catalog(), tn.Schema(), index.Index, lookupFlags)
 		if err != nil {
 			return nil, nil, err
 		} else if foundTn != nil {

--- a/pkg/sql/scatter.go
+++ b/pkg/sql/scatter.go
@@ -97,11 +97,11 @@ func (p *planner) Scatter(ctx context.Context, n *tree.Scatter) (planNode, error
 			}
 		}
 
-		span.Key, err = getRowKey(tableDesc, index, fromVals)
+		span.Key, err = getRowKey(tableDesc.TableDesc(), index, fromVals)
 		if err != nil {
 			return nil, err
 		}
-		span.EndKey, err = getRowKey(tableDesc, index, toVals)
+		span.EndKey, err = getRowKey(tableDesc.TableDesc(), index, toVals)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -45,9 +45,6 @@ type (
 	// UncachedDatabaseDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	UncachedDatabaseDescriptor = sqlbase.DatabaseDescriptor
-	// ObjectDescriptor is provided for convenience and to make the
-	// interface definitions below more intuitive.
-	ObjectDescriptor = sqlbase.TableDescriptor
 	// MutableTableDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	MutableTableDescriptor = sqlbase.MutableTableDescriptor
@@ -68,6 +65,14 @@ type (
 	// definitions below more intuitive.
 	TableNames = tree.TableNames
 )
+
+// ObjectDescriptor provides table information for results from a name lookup.
+type ObjectDescriptor interface {
+	tree.NameResolutionResult
+
+	// TableDesc returns the underlying table descriptor.
+	TableDesc() *TableDescriptor
+}
 
 // SchemaAccessor provides access to database descriptors.
 type SchemaAccessor interface {
@@ -95,7 +100,7 @@ type SchemaAccessor interface {
 	// It is not guaranteed to be non-nil even if the first return value
 	// is non-nil.  Callers that need a database descriptor can use that
 	// to avoid an extra roundtrip through a DatabaseAccessor.
-	GetObjectDesc(name *ObjectName, flags ObjectLookupFlags) (*ObjectDescriptor, *DatabaseDescriptor, error)
+	GetObjectDesc(name *ObjectName, flags ObjectLookupFlags) (ObjectDescriptor, *DatabaseDescriptor, error)
 }
 
 // CommonLookupFlags is the common set of flags for the various accessor interfaces.

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -177,11 +177,12 @@ func (n *scrubNode) startScrubDatabase(ctx context.Context, p *planner, name *tr
 
 	for i := range tbNames {
 		tableName := &tbNames[i]
-		tableDesc, _, err := p.LogicalSchemaAccessor().GetObjectDesc(
+		objDesc, _, err := p.LogicalSchemaAccessor().GetObjectDesc(
 			tableName, p.ObjectLookupFlags(ctx, true /*required*/))
 		if err != nil {
 			return err
 		}
+		tableDesc := objDesc.TableDesc()
 		// Skip non-tables and don't throw an error if we encounter one.
 		if !tableDesc.IsTable() {
 			continue

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -79,7 +79,7 @@ func (p *planner) Split(ctx context.Context, n *tree.Split) (planNode, error) {
 
 	return &splitNode{
 		force:     p.SessionData().ForceSplitAt,
-		tableDesc: tableDesc,
+		tableDesc: tableDesc.TableDesc(),
 		index:     index,
 		rows:      rows,
 	}, nil

--- a/pkg/sql/sqlbase/metadata.go
+++ b/pkg/sql/sqlbase/metadata.go
@@ -54,6 +54,8 @@ type DescriptorProto interface {
 func WrapDescriptor(descriptor DescriptorProto) *Descriptor {
 	desc := &Descriptor{}
 	switch t := descriptor.(type) {
+	case *MutableTableDescriptor:
+		desc.Union = &Descriptor_Table{Table: &t.TableDescriptor}
 	case *TableDescriptor:
 		desc.Union = &Descriptor_Table{Table: t}
 	case *DatabaseDescriptor:

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -105,7 +105,9 @@ type MutationID uint32
 
 // MutableTableDescriptor is a custom type for TableDescriptors
 // going through mutations.
-type MutableTableDescriptor = TableDescriptor
+type MutableTableDescriptor struct {
+	TableDescriptor
+}
 
 // InvalidMutationID is the uninitialised mutation id.
 const InvalidMutationID MutationID = 0
@@ -2515,4 +2517,14 @@ func (desc *TableDescriptor) FindAllReferences() (map[ID]struct{}, error) {
 		refs[c.ID] = struct{}{}
 	}
 	return refs, nil
+}
+
+// TableDesc implements the ObjectDescriptor interface.
+func (desc *TableDescriptor) TableDesc() *TableDescriptor {
+	return desc
+}
+
+// TableDesc implements the ObjectDescriptor interface.
+func (desc *MutableTableDescriptor) TableDesc() *TableDescriptor {
+	return &desc.TableDescriptor
 }

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -40,7 +40,7 @@ func CreateTestTableDescriptor(
 	}
 	semaCtx := tree.MakeSemaContext(false /* privileged */)
 	evalCtx := tree.MakeTestingEvalContext(st)
-	return MakeTableDesc(
+	desc, err := MakeTableDesc(
 		ctx,
 		nil, /* txn */
 		nil, /* vt */
@@ -53,6 +53,7 @@ func CreateTestTableDescriptor(
 		&semaCtx,
 		&evalCtx,
 	)
+	return desc.TableDescriptor, err
 }
 
 func makeTestingExtendedEvalContext(st *cluster.Settings) extendedEvalContext {

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -72,12 +72,7 @@ var roleMembersTableName = tree.MakeTableName("system", "role_members")
 // BumpRoleMembershipTableVersion increases the table version for the
 // role membership table.
 func (p *planner) BumpRoleMembershipTableVersion(ctx context.Context) error {
-	var tableDesc *TableDescriptor
-	var err error
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		tableDesc, _, err = p.PhysicalSchemaAccessor().GetObjectDesc(&roleMembersTableName,
-			p.ObjectLookupFlags(ctx, true /*required*/))
-	})
+	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, &roleMembersTableName, true, anyDescType)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -111,7 +111,7 @@ func (t virtualSchemaTable) initVirtualTableDesc(
 
 	// Virtual tables never use SERIAL so we need not process SERIAL
 	// types here.
-	return MakeTableDesc(
+	mutDesc, err := MakeTableDesc(
 		ctx,
 		nil, /* txn */
 		nil, /* vt */
@@ -125,6 +125,7 @@ func (t virtualSchemaTable) initVirtualTableDesc(
 		nil, /* semaCtx */
 		nil, /* evalCtx */
 	)
+	return mutDesc.TableDescriptor, err
 }
 
 // getSchema is part of the virtualSchemaDef interface.
@@ -143,7 +144,7 @@ func (v virtualSchemaView) initVirtualTableDesc(
 
 	create := stmt.(*tree.CreateView)
 
-	return MakeViewTableDesc(
+	mutDesc, err := MakeViewTableDesc(
 		create,
 		v.resultColumns,
 		0,
@@ -153,6 +154,7 @@ func (v virtualSchemaView) initVirtualTableDesc(
 		nil, // semaCtx
 		nil, // evalCtx
 	)
+	return mutDesc.TableDescriptor, err
 }
 
 // virtualSchemas holds a slice of statically registered virtualSchema objects.

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -249,9 +249,13 @@ func zoneSpecifierNotFoundError(zs tree.ZoneSpecifier) error {
 // Returns res = nil if the zone specifier is not for a table or index.
 func (p *planner) resolveTableForZone(
 	ctx context.Context, zs *tree.ZoneSpecifier,
-) (res *MutableTableDescriptor, err error) {
+) (res *TableDescriptor, err error) {
 	if zs.TargetsIndex() {
-		_, res, err = expandMutableIndexName(ctx, p, &zs.TableOrIndex, true /* requireTable */)
+		var mutRes *MutableTableDescriptor
+		_, mutRes, err = expandMutableIndexName(ctx, p, &zs.TableOrIndex, true /* requireTable */)
+		if mutRes != nil {
+			res = mutRes.TableDesc()
+		}
 	} else if zs.TargetsTable() {
 		p.runWithOptions(resolveFlags{skipCache: true}, func() {
 			res, err = ResolveExistingObject(


### PR DESCRIPTION
Replace the type alias which made MutableTableDescriptor and
TableDescriptor equivalent types with a struct that embeds
TableDescriptor. This forces any write of a table descriptor for schema
changes to use this struct.

Release note: None