### PR TITLE
scripts/gceworker: ssh into node after starting

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -56,8 +56,11 @@ case "${cmd}" in
     ;;
     start)
     gcloud compute instances start "${NAME}"
+    echo "waiting for node to finish starting..."
     # Wait for vm and sshd to start up.
-    retry gcloud compute ssh "${NAME}" --command=true
+    retry gcloud compute ssh "${NAME}" --command=true || true
+    # SSH into the node, since that's probably why we started it.
+    gcloud compute ssh "${NAME}" --ssh-flag="-A" "$@"
     ;;
     stop)
     gcloud compute instances stop "${NAME}"


### PR DESCRIPTION
This changes the 'start' command to also ssh into the worker.
I and others have found we often switch tasks while waiting for start and then forget to ssh in immediately after.
By the time we return, it has stopped due to inactivity with no one ssh'ed in.

Release note: none.