### PR TITLE
util: Send only last metric value to Graphite

### DIFF
--- a/pkg/util/metric/graphite_exporter.go
+++ b/pkg/util/metric/graphite_exporter.go
@@ -69,5 +69,10 @@ func (ge *GraphiteExporter) Push(ctx context.Context, endpoint string) error {
 	}); err != nil {
 		return err
 	}
+	// Regardless of whether Push() errors, clear metrics. Only latest metrics
+	// are pushed. If there is an error, this will cause a gap in receiver. The
+	// receiver associates timestamp with when metric arrived, so storing missed
+	// metrics has no benefit.
+	defer ge.pm.clearMetrics()
 	return b.Push()
 }

--- a/pkg/util/metric/prometheus_exporter.go
+++ b/pkg/util/metric/prometheus_exporter.go
@@ -89,9 +89,8 @@ func (pm *PrometheusExporter) PrintAsText(w io.Writer) error {
 		if _, err := expfmt.MetricFamilyToText(w, family); err != nil {
 			return err
 		}
-		// Clear metrics for reuse.
-		family.Metric = []*prometheusgo.Metric{}
 	}
+	pm.clearMetrics()
 	return nil
 }
 
@@ -107,4 +106,12 @@ func (pm *PrometheusExporter) Gather() ([]*prometheusgo.MetricFamily, error) {
 		i++
 	}
 	return v, nil
+}
+
+// Clear metrics for reuse.
+func (pm *PrometheusExporter) clearMetrics() {
+	for _, family := range pm.families {
+		// Set to nil to avoid allocation if the family never gets any metrics.
+		family.Metric = nil
+	}
 }

--- a/pkg/util/metric/prometheus_exporter_test.go
+++ b/pkg/util/metric/prometheus_exporter_test.go
@@ -85,4 +85,34 @@ func TestPrometheusExporter(t *testing.T) {
 			}
 		}
 	}
+
+	// Test Gather
+	families, err := pe.Gather()
+	if err != nil {
+		t.Errorf("unexpected error from Gather(): %v", err)
+	}
+	for _, fam := range families {
+		if len(fam.Metric) == 0 {
+			t.Errorf("gathered %s has no data points", fam.GetName())
+		}
+	}
+
+	// Test clearMetrics
+	pe.clearMetrics()
+	for _, fam := range pe.families {
+		if numPoints := len(fam.Metric); numPoints != 0 {
+			t.Errorf("%s has %d data points, want 0", fam.GetName(), numPoints)
+		}
+	}
+	// Check families returned by Gather are empty, right after calling clearMetrics
+	// before another call to scrape.
+	families, err = pe.Gather()
+	if err != nil {
+		t.Errorf("unexpected error from Gather(): %v", err)
+	}
+	for _, fam := range families {
+		if num := len(fam.Metric); num != 0 {
+			t.Errorf("gathered %s has %d data points but expect none", fam.GetName(), num)
+		}
+	}
 }


### PR DESCRIPTION
Cockroach was emitting a ridiculously large number of metrics per minute
because an instance of PrometheusExporter was being reused without
clearing it after every iteration.

Release note:
Fix bug in graphite metrics sender where cockroach was collecting and
sending all data points since startup instead of only the latest data
point.