### PR TITLE
ui: Include username in sessions debug page links

### DIFF
--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -299,8 +299,16 @@ export default function Debug() {
           />
         </DebugTableRow>
         <DebugTableRow title="Sessions">
-          <DebugTableLink name="Local Sessions" url="/_status/local_sessions" />
-          <DebugTableLink name="All Sessions" url="/_status/sessions" />
+          <DebugTableLink
+            name="Local Sessions"
+            url="/_status/local_sessions?username=root"
+            note="/_status/local_sessions?username=[user]"
+          />
+          <DebugTableLink
+            name="All Sessions"
+            url="/_status/sessions?username=root"
+            note="/_status/sessions?username=[user]"
+          />
         </DebugTableRow>
         <DebugTableRow title="Cluster Wide">
           <DebugTableLink name="Raft" url="/_status/raft" />


### PR DESCRIPTION
The page lists no results if provided with an empty user.

Arguably, the endpoint should assume a user (presumably root?) if one
isn't provided. If you think that'd be a better change, I'm happy that
to go that route instead.

Release note (admin ui change): Include username parameter in link to
SQL Sessions debug page.