### PR TITLE
ui: add node id to debug index page

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1599,6 +1599,7 @@ func (s *Server) Start(ctx context.Context) error {
 		ui.Handler(ui.Config{
 			ExperimentalUseLogin: s.cfg.EnableWebSessionAuthentication,
 			LoginEnabled:         s.cfg.RequireWebSession(),
+			NodeID:               &s.nodeIDContainer,
 			GetUser: func(ctx context.Context) *string {
 				if u, ok := ctx.Value(webSessionUserKey{}).(string); ok {
 					return &u

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -937,9 +937,10 @@ Binary built without web UI.
 			expected := fmt.Sprintf(
 				htmlTemplate,
 				fmt.Sprintf(
-					`{"ExperimentalUseLogin":false,"LoginEnabled":false,"LoggedInUser":null,"Tag":"%s","Version":"%s"}`,
+					`{"ExperimentalUseLogin":false,"LoginEnabled":false,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d"}`,
 					build.GetInfo().Tag,
 					build.VersionPrefix(),
+					1,
 				),
 			)
 			if respString != expected {
@@ -971,17 +972,19 @@ Binary built without web UI.
 			{
 				loggedInClient,
 				fmt.Sprintf(
-					`{"ExperimentalUseLogin":true,"LoginEnabled":true,"LoggedInUser":"authentic_user","Tag":"%s","Version":"%s"}`,
+					`{"ExperimentalUseLogin":true,"LoginEnabled":true,"LoggedInUser":"authentic_user","Tag":"%s","Version":"%s","NodeID":"%d"}`,
 					build.GetInfo().Tag,
 					build.VersionPrefix(),
+					1,
 				),
 			},
 			{
 				loggedOutClient,
 				fmt.Sprintf(
-					`{"ExperimentalUseLogin":true,"LoginEnabled":true,"LoggedInUser":null,"Tag":"%s","Version":"%s"}`,
+					`{"ExperimentalUseLogin":true,"LoginEnabled":true,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d"}`,
 					build.GetInfo().Tag,
 					build.VersionPrefix(),
+					1,
 				),
 			},
 		}

--- a/pkg/ui/ccl/src/views/shared/components/licenseType/index.tsx
+++ b/pkg/ui/ccl/src/views/shared/components/licenseType/index.tsx
@@ -8,18 +8,13 @@
 
 import React from "react";
 
+import DebugAnnotation from "src/views/shared/components/debugAnnotation";
 import swapByLicense from "src/views/shared/containers/licenseSwap";
 import OSSLicenseType from "oss/src/views/shared/components/licenseType";
 
 class CCLLicenseType extends React.Component<{}, {}> {
   render() {
-    return (
-      <div>
-        <span className="license-type__label">License type:</span>
-        {" "}
-        <span className="license-type__license">CCL</span>
-      </div>
-    );
+    return <DebugAnnotation label="License type" value="CCL" />;
   }
 }
 

--- a/pkg/ui/src/util/dataFromServer.ts
+++ b/pkg/ui/src/util/dataFromServer.ts
@@ -18,6 +18,7 @@ export interface DataFromServer {
   LoggedInUser: string;
   Tag: string;
   Version: string;
+  NodeID: string;
 }
 
 // Tell TypeScript about `window.dataFromServer`, which is set in a script

--- a/pkg/ui/src/views/reports/containers/debug/debug.styl
+++ b/pkg/ui/src/views/reports/containers/debug/debug.styl
@@ -26,7 +26,7 @@
 .debug-header
   position relative
 
-.debug-header__license-type
+.debug-header__annotations
   position absolute
   top 0
   right 0

--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -16,6 +16,8 @@ import _ from "lodash";
 import React from "react";
 import { Helmet } from "react-helmet";
 
+import { getDataFromServer } from "src/util/dataFromServer";
+import DebugAnnotation from "src/views/shared/components/debugAnnotation";
 import InfoBox from "src/views/shared/components/infoBox";
 import LicenseType from "src/views/shared/components/licenseType";
 import { PanelSection, PanelTitle, PanelPair, Panel } from "src/views/shared/components/panelSection";
@@ -23,6 +25,8 @@ import { PanelSection, PanelTitle, PanelPair, Panel } from "src/views/shared/com
 import "./debug.styl";
 
 const COMMUNITY_URL = "https://www.cockroachlabs.com/community/";
+
+const NODE_ID = getDataFromServer().NodeID;
 
 function DebugTableLink(props: { name: string, url: string, note?: string }) {
   return (
@@ -96,8 +100,9 @@ export default function Debug() {
           </p>
         </InfoBox>
 
-        <div className="debug-header__license-type">
+        <div className="debug-header__annotations">
           <LicenseType />
+          <DebugAnnotation label="Web server" value={ `n${NODE_ID}` } />
         </div>
       </div>
       <PanelSection>

--- a/pkg/ui/src/views/shared/components/debugAnnotation/debugAnnotation.styl
+++ b/pkg/ui/src/views/shared/components/debugAnnotation/debugAnnotation.styl
@@ -12,15 +12,12 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-import React from "react";
+@require "~styl/base/palette.styl"
 
-import DebugAnnotation from "src/views/shared/components/debugAnnotation";
+.debug-annotation__label
+  color $body-color
+  font-size 14px
 
-/**
- * LicenseType is an indicator showing the current build license.
- */
-export default class LicenseType extends React.Component<{}, {}> {
-  render() {
-    return <DebugAnnotation label="License type" value="OSS" />;
-  }
-}
+.debug-annotation__value
+  color black
+  font-size 14px

--- a/pkg/ui/src/views/shared/components/debugAnnotation/index.tsx
+++ b/pkg/ui/src/views/shared/components/debugAnnotation/index.tsx
@@ -12,12 +12,26 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-@require "~styl/base/palette.styl"
+import React from "react";
 
-.license-type__label
-  color $body-color
-  font-size 14px
+import "./debugAnnotation.styl";
 
-.license-type__license
-  color black
-  font-size 14px
+export interface DebugAnnotationProps {
+  label: string;
+  value: string;
+}
+
+/**
+ * DebugAnnotation is an indicator showing a bit of information on the debug page.
+ */
+export default class DebugAnnotation extends React.Component<DebugAnnotationProps> {
+  render() {
+    return (
+      <h3>
+        <span className="debug-annotation__label">{ this.props.label }:</span>
+        {" "}
+        <span className="debug-annotation__value">{ this.props.value }</span>
+      </h3>
+    );
+  }
+}

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	assetfs "github.com/elazarl/go-bindata-assetfs"
@@ -95,6 +96,7 @@ type indexHTMLArgs struct {
 	LoggedInUser         *string
 	Tag                  string
 	Version              string
+	NodeID               string
 }
 
 // bareIndexHTML is used in place of indexHTMLTemplate when the binary is built
@@ -109,6 +111,7 @@ Binary built without web UI.
 type Config struct {
 	ExperimentalUseLogin bool
 	LoginEnabled         bool
+	NodeID               *base.NodeIDContainer
 	GetUser              func(ctx context.Context) *string
 }
 
@@ -140,6 +143,7 @@ func Handler(cfg Config) http.Handler {
 			LoggedInUser:         cfg.GetUser(r.Context()),
 			Tag:                  buildInfo.Tag,
 			Version:              build.VersionPrefix(),
+			NodeID:               cfg.NodeID.String(),
 		}); err != nil {
 			err = errors.Wrap(err, "templating index.html")
 			http.Error(w, err.Error(), 500)


### PR DESCRIPTION
<img width="960" alt="screen shot 2018-10-24 at 5 25 17 pm" src="https://user-images.githubusercontent.com/793969/47462966-e4592c80-d7b2-11e8-996c-54bb09c13974.png">

ui: extract debug annotation from license type

Release note: None

ui: add node id to debug index page

Fixes: #31540
Release note (admin ui change): Add the current node ID to the debug index
page, to help identify the current node when viewing the web UI through
a load balancer.