### PR TITLE
changefeedccl: fix "experimental-avro" -> "experimental_avro" typo

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -53,7 +53,7 @@ const (
 	optEnvelopeDiff    envelopeType = `diff`
 
 	optFormatJSON formatType = `json`
-	optFormatAvro formatType = `experimental-avro`
+	optFormatAvro formatType = `experimental_avro`
 
 	sinkParamTopicPrefix      = `topic_prefix`
 	sinkParamSchemaTopic      = `schema_topic`


### PR DESCRIPTION
The schemes use "-"s but everything else uses "_"s, so switch this one
for consistency. 2.1.0 will ship with this typo, but we don't offer
backward compatibility guarantees on experimental features, so we don't
maintain it here.

Release note (backwards-incompatible change): The CHANGEFEED
"experimental-avro" option is now "experimental_avro"