### PR TITLE
ui: fix navbar overlap on short windows

### DIFF
--- a/pkg/ui/styl/layout/navigation-bar.styl
+++ b/pkg/ui/styl/layout/navigation-bar.styl
@@ -36,14 +36,13 @@ $subnav-underline-height = 3px
   border-right 1px solid $table-border-color
   margin 0
   padding 0
-  display block
+  display flex
+  flex-direction column
+  justify-content space-between
+  overflow-y scroll
 
 .navigation-bar__list
   width 100%
-
-  &--bottom
-    position absolute
-    bottom 0
 
   li
     width 100%


### PR DESCRIPTION
Fixes #31557

Previously:
![image](https://user-images.githubusercontent.com/7341/47112874-89a95900-d225-11e8-8bb9-847f3ec63e74.png)

Now:
![navbar-short](https://user-images.githubusercontent.com/793969/48424421-a0fa3a00-e730-11e8-9be2-bfbf73cf4968.png)
![navbar-medium](https://user-images.githubusercontent.com/793969/48424420-a0fa3a00-e730-11e8-8da7-d23ca6b746a1.png)
<img width="114" alt="navbar-tall" src="https://user-images.githubusercontent.com/793969/48424422-a0fa3a00-e730-11e8-894d-da9712eb4c64.png">
