### PR TITLE
ui: jobs page: render API call errors

### DIFF
--- a/pkg/ui/src/views/shared/components/loading/index.styl
+++ b/pkg/ui/src/views/shared/components/loading/index.styl
@@ -1,0 +1,20 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+@require "~styl/base/palette.styl"
+
+.loading-error
+  padding 10px
+  background $notification-alert-fill-color
+  border-radius 5px

--- a/pkg/ui/src/views/shared/components/loading/index.styl
+++ b/pkg/ui/src/views/shared/components/loading/index.styl
@@ -16,5 +16,6 @@
 
 .loading-error
   padding 10px
+  border thin solid $notification-alert-border-color
   background $notification-alert-fill-color
   border-radius 5px

--- a/pkg/ui/src/views/shared/components/loading/index.tsx
+++ b/pkg/ui/src/views/shared/components/loading/index.tsx
@@ -19,8 +19,7 @@ import "./index.styl";
 
 interface LoadingProps {
   loading: boolean;
-  error?: Error;
-  renderError?: (err: Error) => React.ReactNode;
+  error?: Error | null;
   className?: string;
   image?: string;
   render: () => React.ReactNode;
@@ -39,20 +38,12 @@ export default function Loading(props: LoadingProps) {
   // Check for `error` before `loading`, since tests for `loading` often return
   // true even if CachedDataReducer has an error and is no longer really "loading".
   if (props.error) {
-    if (props.renderError) {
-      return (
-        <React.Fragment>
-          {props.renderError(props.error)}
-        </React.Fragment>
-      );
-    } else {
-      return (
-        <div className="loading-error">
-          <p>An error was encountered while loading this data:</p>
-          <pre>{props.error.message}</pre>
-        </div>
-      );
-    }
+    return (
+      <div className="loading-error">
+        <p>An error was encountered while loading this data:</p>
+        <pre>{props.error.message}</pre>
+      </div>
+    );
   }
   if (props.loading) {
     return <div className={className} style={image} />;

--- a/pkg/ui/src/views/shared/components/loading/index.tsx
+++ b/pkg/ui/src/views/shared/components/loading/index.tsx
@@ -15,9 +15,12 @@
 import React from "react";
 
 import spinner from "assets/spinner.gif";
+import "./index.styl";
 
 interface LoadingProps {
   loading: boolean;
+  error?: Error;
+  renderError?: (err: Error) => React.ReactNode;
   className?: string;
   image?: string;
   render: () => React.ReactNode;
@@ -33,12 +36,30 @@ export default function Loading(props: LoadingProps) {
   const image = {
     "backgroundImage": `url(${imageURL})`,
   };
+  // Check for `error` before `loading`, since tests for `loading` often return
+  // true even if CachedDataReducer has an error and is no longer really "loading".
+  if (props.error) {
+    if (props.renderError) {
+      return (
+        <React.Fragment>
+          {props.renderError(props.error)}
+        </React.Fragment>
+      );
+    } else {
+      return (
+        <div className="loading-error">
+          <p>An error was encountered while loading this data:</p>
+          <pre>{props.error.message}</pre>
+        </div>
+      );
+    }
+  }
   if (props.loading) {
     return <div className={className} style={image} />;
   }
   return (
     <React.Fragment>
-      { props.render() }
+      {props.render()}
     </React.Fragment>
   );
 }


### PR DESCRIPTION
In the case of a timeout, instead of seeing a spinner forever, you'd see:
![image](https://user-images.githubusercontent.com/7341/47521881-2db48500-d862-11e8-8262-43a43d956e8f.png)

And in a 500 response from the backend, instead of a spinner forever you'd see:
![image](https://user-images.githubusercontent.com/7341/47521743-d1e9fc00-d861-11e8-89af-35289dc9412e.png)

We can improve the error messages themselves in a separate PR.

This the `Loading` component error rendering functionality introduced here can be used on other pages as well.

Fixes #31396