### PR TITLE
storage: fix buglet in raft log size computation

### DIFF
--- a/pkg/storage/batcheval/cmd_truncate_log.go
+++ b/pkg/storage/batcheval/cmd_truncate_log.go
@@ -82,7 +82,7 @@ func TruncateLog(
 	}
 
 	start := engine.MakeMVCCMetadataKey(keys.RaftLogKey(rangeID, firstIndex))
-	end := engine.MakeMVCCMetadataKey(keys.RaftLogKey(rangeID, args.Index).PrefixEnd())
+	end := engine.MakeMVCCMetadataKey(keys.RaftLogKey(rangeID, args.Index))
 
 	var ms enginepb.MVCCStats
 	if cArgs.EvalCtx.ClusterSettings().Version.IsActive(cluster.VersionRaftLogTruncationBelowRaft) {

--- a/pkg/storage/raft_log_queue_test.go
+++ b/pkg/storage/raft_log_queue_test.go
@@ -17,9 +17,14 @@ package storage
 import (
 	"context"
 	"fmt"
+	"math"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/raft"
@@ -222,6 +227,28 @@ func TestGetTruncatableIndexes(t *testing.T) {
 	if bOldest >= cOldest {
 		t.Errorf("expected oldestIndex to increase, instead it changed from %d -> %d", bOldest, cOldest)
 	}
+
+	func() {
+		r.raftMu.Lock()
+		defer r.raftMu.Unlock()
+		r.mu.Lock()
+		raftLogSize := r.mu.raftLogSize
+		r.mu.Unlock()
+		start := engine.MakeMVCCMetadataKey(keys.RaftLogKey(r.RangeID, 1))
+		end := engine.MakeMVCCMetadataKey(keys.RaftLogKey(r.RangeID, math.MaxUint64))
+
+		var ms enginepb.MVCCStats
+		iter := store.engine.NewIterator(engine.IterOptions{UpperBound: end.Key})
+		defer iter.Close()
+		ms, err := iter.ComputeStats(start, end, 0 /* nowNanos */)
+		if err != nil {
+			t.Fatal(err)
+		}
+		actualRaftLogSize := ms.SysBytes
+		if actualRaftLogSize != raftLogSize {
+			t.Fatalf("replica claims raft log size %d, but computed %d", raftLogSize, actualRaftLogSize)
+		}
+	}()
 
 	// Again, enable the raft log scanner and and force a truncation. This time
 	// we expect no truncation to occur.


### PR DESCRIPTION
When computing by how much a log truncation would reduce the size of the
Raft log, we were erroneously including the first untruncated index in
the computation, resulting in subtracting "just a little extra" (or a
lot, depending on the size of the spuriously included entry).
It's unlikely that this would've had any real consequences.

Adapted a test to catch this change since none did.

Release note: None