### PR TITLE
jepsen: ignore java ssh client exceptions

### DIFF
--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -228,7 +228,7 @@ cd /mnt/data1/jepsen/cockroachdb && set -eo pipefail && \
 		ignoreErr := false
 		if err := runE(c, ctx, controller,
 			`grep "Oh jeez, I'm sorry, Jepsen broke. Here's why" /mnt/data1/jepsen/cockroachdb/invoke.log -A1 `+
-				`| grep -e BrokenBarrierException -e InterruptedException`,
+				`| grep -e BrokenBarrierException -e InterruptedException -e com.jcraft.jsch.JSchException`,
 		); err == nil {
 			logf("Recognized BrokenBarrier or InterruptedException. " +
 				"Ignoring it and considering the test successful. See #30527.")


### PR DESCRIPTION
Stack traces looking like below seem to be a fact of life; tracked in
the issue below.
java.util.concurrent.ExecutionException: com.jcraft.jsch.JSchException: java.lang.NullPointerException
        at java.util.concurrent.FutureTask.report(FutureTask.java:122) ~[na:1.8.0_181]
        at java.util.concurrent.FutureTask.get(FutureTask.java:192) ~[na:1.8.0_181]

Touches #26082

Release note: None