### PR TITLE
exec: generate projection and selection ops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -694,7 +694,10 @@ PROTOBUF_TARGETS := bin/.go_protobuf_sources bin/.gw_protobuf_sources bin/.cpp_p
 
 DOCGEN_TARGETS := bin/.docgen_bnfs bin/.docgen_functions
 
-EXECGEN_TARGETS = pkg/sql/exec/rowstovec.og.go
+EXECGEN_TARGETS = \
+  pkg/sql/exec/projection_ops.og.go \
+  pkg/sql/exec/rowstovec.og.go \
+  pkg/sql/exec/selection_ops.og.go
 
 OPTGEN_TARGETS = \
 	pkg/sql/opt/memo/expr.og.go \

--- a/pkg/sql/exec/execgen/cmd/execgen/overloads.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/overloads.go
@@ -1,0 +1,96 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+var binaryOpName = map[tree.BinaryOperator]string{
+	tree.Plus:  "Plus",
+	tree.Minus: "Minus",
+	tree.Mult:  "Mult",
+	tree.Div:   "Div",
+}
+
+var comparisonOpName = map[tree.ComparisonOperator]string{
+	tree.EQ: "EQ",
+	tree.NE: "NE",
+	tree.LT: "LT",
+	tree.LE: "LE",
+	tree.GT: "GT",
+	tree.GE: "GE",
+}
+
+var binaryOpInfix = map[tree.BinaryOperator]string{
+	tree.Plus:  "+",
+	tree.Minus: "-",
+	tree.Mult:  "*",
+	tree.Div:   "/",
+}
+
+var comparisonOpInfix = map[tree.ComparisonOperator]string{
+	tree.EQ: "==",
+	tree.NE: "!=",
+	tree.LT: "<",
+	tree.LE: "<=",
+	tree.GT: ">",
+	tree.GE: ">=",
+}
+
+type overload struct {
+	Name    string
+	OpStr   string
+	LTyp    types.T
+	RTyp    types.T
+	RGoType string
+	RetTyp  types.T
+}
+
+var binaryOpOverloads []overload
+var comparisonOpOverloads []overload
+
+func init() {
+	// Build overload definitions.
+	inputTypes := []types.T{
+		types.Int8, types.Int16, types.Int32, types.Int64, types.Float32, types.Float64}
+	binOps := []tree.BinaryOperator{tree.Plus, tree.Minus, tree.Mult, tree.Div}
+	cmpOps := []tree.ComparisonOperator{tree.EQ, tree.NE, tree.LT, tree.LE, tree.GT, tree.GE}
+	for _, t := range inputTypes {
+		for _, op := range binOps {
+			ov := overload{
+				Name:    binaryOpName[op],
+				OpStr:   binaryOpInfix[op],
+				LTyp:    t,
+				RTyp:    t,
+				RGoType: t.GoTypeName(),
+				RetTyp:  t,
+			}
+			binaryOpOverloads = append(binaryOpOverloads, ov)
+		}
+		for _, op := range cmpOps {
+			ov := overload{
+				Name:    comparisonOpName[op],
+				OpStr:   comparisonOpInfix[op],
+				LTyp:    t,
+				RTyp:    t,
+				RGoType: t.GoTypeName(),
+				RetTyp:  types.Bool,
+			}
+			comparisonOpOverloads = append(comparisonOpOverloads, ov)
+		}
+	}
+}

--- a/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
@@ -1,0 +1,109 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"io"
+	"text/template"
+)
+
+const projTemplate = `
+package exec
+
+{{define "opConstName"}}proj{{.Name}}{{.LTyp}}{{.RTyp}}ConstOp{{end}}
+{{define "opName"}}proj{{.Name}}{{.LTyp}}{{.RTyp}}Op{{end}}
+
+{{range .}}
+
+type {{template "opConstName" .}} struct {
+	input Operator
+
+	colIdx   int
+	constArg {{.RGoType}}
+
+	outputIdx int
+}
+
+func (p *{{template "opConstName" .}}) Next() ColBatch {
+	batch := p.input.Next()
+	projCol := batch.ColVec(p.outputIdx).{{.RetTyp}}()[:ColBatchSize]
+	col := batch.ColVec(p.colIdx).{{.LTyp}}()[:ColBatchSize]
+	n := batch.Length()
+	if sel := batch.Selection(); sel != nil {
+		for _, i := range sel {
+			projCol[i] = col[i] {{.OpStr}} p.constArg
+		}
+	} else {
+		col = col[:n]
+		for i, v := range col {
+			projCol[i] = v {{.OpStr}} p.constArg
+		}
+	}
+	return batch
+}
+
+func (p {{template "opConstName" .}}) Init() {
+	p.input.Init()
+}
+
+type {{template "opName" .}} struct {
+	input Operator
+
+	col1Idx int
+	col2Idx int
+
+	outputIdx int
+}
+
+func (p *{{template "opName" .}}) Next() ColBatch {
+	batch := p.input.Next()
+	projCol := batch.ColVec(p.outputIdx).{{.RetTyp}}()[:ColBatchSize]
+	col1 := batch.ColVec(p.col1Idx).{{.LTyp}}()[:ColBatchSize]
+	col2 := batch.ColVec(p.col2Idx).{{.RTyp}}()[:ColBatchSize]
+	n := batch.Length()
+	if sel := batch.Selection(); sel != nil {
+		for _, i := range sel {
+			projCol[i] = col1[i] {{.OpStr}} col2[i]
+		}
+	} else {
+		col1 = col1[:n]
+		for i, v := range col1 {
+			projCol[i] = v {{.OpStr}} col2[i]
+		}
+	}
+	return batch
+}
+
+func (p {{template "opName" .}}) Init() {
+	p.input.Init()
+}
+
+{{end}}
+`
+
+func genProjectionOps(wr io.Writer) error {
+	tmpl, err := template.New("projection_ops").Parse(projTemplate)
+	if err != nil {
+		return err
+	}
+	var allOverloads []overload
+	allOverloads = append(allOverloads, binaryOpOverloads...)
+	allOverloads = append(allOverloads, comparisonOpOverloads...)
+	return tmpl.Execute(wr, allOverloads)
+}
+
+func init() {
+	registerGenerator(genProjectionOps, "projection_ops.og.go")
+}

--- a/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
@@ -1,0 +1,137 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"io"
+	"text/template"
+)
+
+const selTemplate = `
+package exec
+
+{{define "opConstName"}}sel{{.Name}}{{.LTyp}}{{.RTyp}}ConstOp{{end}}
+{{define "opName"}}sel{{.Name}}{{.LTyp}}{{.RTyp}}Op{{end}}
+
+{{range .}}
+
+type {{template "opConstName" .}} struct {
+	input Operator
+
+	colIdx   int
+	constArg {{.RGoType}}
+}
+
+func (p *{{template "opConstName" .}}) Next() ColBatch {
+	for {
+		batch := p.input.Next()
+		if batch.Length() == 0 {
+			return batch
+		}
+
+		col := batch.ColVec(p.colIdx).{{.LTyp}}()[:ColBatchSize]
+		var idx uint16
+		n := batch.Length()
+		if sel := batch.Selection(); sel != nil {
+			sel := sel[:n]
+			for _, i := range sel {
+				if col[i] {{.OpStr}} p.constArg {
+					sel[idx] = i
+					idx++
+				}
+			}
+		} else {
+			batch.SetSelection(true)
+			sel := batch.Selection()
+			for i := uint16(0); i < n; i++ {
+				if col[i] {{.OpStr}} p.constArg {
+					sel[idx] = i
+					idx++
+				}
+			}
+		}
+		if idx > 0 {
+			batch.SetLength(idx)
+			return batch
+		}
+	}
+}
+
+func (p {{template "opConstName" .}}) Init() {
+	p.input.Init()
+}
+
+type {{template "opName" .}} struct {
+	input Operator
+
+	col1Idx int
+	col2Idx int
+}
+
+func (p *{{template "opName" .}}) Next() ColBatch {
+	for {
+		batch := p.input.Next()
+		if batch.Length() == 0 {
+			return batch
+		}
+
+		col1 := batch.ColVec(p.col1Idx).{{.LTyp}}()[:ColBatchSize]
+		col2 := batch.ColVec(p.col2Idx).{{.RTyp}}()[:ColBatchSize]
+		n := batch.Length()
+
+		var idx uint16
+		if sel := batch.Selection(); sel != nil {
+			sel := sel[:n]
+			for _, i := range sel {
+				if col1[i] {{.OpStr}} col2[i] {
+					sel[idx] = i
+					idx++
+				}
+			}
+		} else {
+			batch.SetSelection(true)
+			sel := batch.Selection()
+			for i := uint16(0); i < n; i++ {
+				if col1[i] {{.OpStr}} col2[i] {
+					sel[idx] = i
+					idx++
+				}
+			}
+		}
+		if idx > 0 {
+			batch.SetLength(idx)
+			return batch
+		}
+	}
+}
+
+func (p {{template "opName" .}}) Init() {
+	p.input.Init()
+}
+
+{{end}}
+`
+
+func genSelectionOps(wr io.Writer) error {
+	tmpl, err := template.New("selection_ops").Parse(selTemplate)
+	if err != nil {
+		return err
+	}
+	return tmpl.Execute(wr, comparisonOpOverloads)
+}
+
+func init() {
+	registerGenerator(genSelectionOps, "selection_ops.og.go")
+}

--- a/pkg/sql/exec/projection_ops_test.go
+++ b/pkg/sql/exec/projection_ops_test.go
@@ -1,0 +1,108 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestProjPlusInt64Int64ConstOp(t *testing.T) {
+	runTests(t, tuples{{1}, {2}}, []types.T{types.Int64}, func(t *testing.T, input Operator) {
+		op := projPlusInt64Int64ConstOp{
+			input:     input,
+			colIdx:    0,
+			constArg:  1,
+			outputIdx: 1,
+		}
+		op.Init()
+		out := newOpTestOutput(&op, []int{0, 1}, tuples{{1, 2}, {2, 3}})
+		if err := out.Verify(); err != nil {
+			t.Error(err)
+		}
+	})
+}
+
+func TestProjPlusInt64Int64Op(t *testing.T) {
+	runTests(t, tuples{{1, 2}, {3, 4}}, []types.T{types.Int64}, func(t *testing.T, input Operator) {
+		op := projPlusInt64Int64Op{
+			input:     input,
+			col1Idx:   0,
+			col2Idx:   1,
+			outputIdx: 2,
+		}
+		op.Init()
+		out := newOpTestOutput(&op, []int{0, 1, 2}, tuples{{1, 2, 3}, {3, 4, 7}})
+		if err := out.Verify(); err != nil {
+			t.Error(err)
+		}
+	})
+}
+
+func BenchmarkProjPlusInt64Int64ConstOp(b *testing.B) {
+	rng, _ := randutil.NewPseudoRand()
+
+	batch := NewMemBatch([]types.T{types.Int64, types.Int64})
+	col := batch.ColVec(0).Int64()
+	for i := int64(0); i < ColBatchSize; i++ {
+		col[i] = rng.Int63()
+	}
+	batch.SetLength(ColBatchSize)
+	source := newRepeatableBatchSource(batch)
+	source.Init()
+
+	plusOp := &projPlusInt64Int64ConstOp{
+		input:     source,
+		colIdx:    0,
+		constArg:  rng.Int63(),
+		outputIdx: 1,
+	}
+	plusOp.Init()
+
+	b.SetBytes(int64(8 * ColBatchSize))
+	for i := 0; i < b.N; i++ {
+		plusOp.Next()
+	}
+}
+
+func BenchmarkProjPlusInt64Int64Op(b *testing.B) {
+	rng, _ := randutil.NewPseudoRand()
+
+	batch := NewMemBatch([]types.T{types.Int64, types.Int64, types.Int64})
+	col1 := batch.ColVec(0).Int64()
+	col2 := batch.ColVec(1).Int64()
+	for i := int64(0); i < ColBatchSize; i++ {
+		col1[i] = rng.Int63()
+		col2[i] = rng.Int63()
+	}
+	batch.SetLength(ColBatchSize)
+	source := newRepeatableBatchSource(batch)
+	source.Init()
+
+	plusOp := &projPlusInt64Int64Op{
+		input:     source,
+		col1Idx:   0,
+		col2Idx:   1,
+		outputIdx: 2,
+	}
+	plusOp.Init()
+
+	b.SetBytes(int64(8 * ColBatchSize * 2))
+	for i := 0; i < b.N; i++ {
+		plusOp.Next()
+	}
+}

--- a/pkg/sql/exec/selection_ops_test.go
+++ b/pkg/sql/exec/selection_ops_test.go
@@ -1,0 +1,111 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestSelLTInt64Int64ConstOp(t *testing.T) {
+	tups := tuples{{0}, {1}, {2}}
+	runTests(t, tups, nil /* extraTypes */, func(t *testing.T, input Operator) {
+		op := selLTInt64Int64ConstOp{
+			input:    input,
+			colIdx:   0,
+			constArg: 2,
+		}
+		op.Init()
+		out := newOpTestOutput(&op, []int{0}, tuples{{0}, {1}})
+		if err := out.Verify(); err != nil {
+			t.Error(err)
+		}
+	})
+}
+
+func TestSelLTInt64Int64(t *testing.T) {
+	tups := tuples{
+		{0, 0},
+		{0, 1},
+		{1, 0},
+		{1, 1},
+	}
+	runTests(t, tups, nil /* extraTypes */, func(t *testing.T, input Operator) {
+		op := selLTInt64Int64Op{
+			input:   input,
+			col1Idx: 0,
+			col2Idx: 1,
+		}
+		op.Init()
+		out := newOpTestOutput(&op, []int{0, 1}, tuples{{0, 1}})
+		if err := out.Verify(); err != nil {
+			t.Error(err)
+		}
+	})
+}
+
+func BenchmarkSelLTInt64Int64ConstOp(b *testing.B) {
+	rng, _ := randutil.NewPseudoRand()
+
+	batch := NewMemBatch([]types.T{types.Int64})
+	col := batch.ColVec(0).Int64()
+	for i := int64(0); i < ColBatchSize; i++ {
+		col[i] = rng.Int63()
+	}
+	batch.SetLength(ColBatchSize)
+	source := newRepeatableBatchSource(batch)
+	source.Init()
+
+	plusOp := &selLTInt64Int64ConstOp{
+		input:    source,
+		colIdx:   0,
+		constArg: rng.Int63(),
+	}
+	plusOp.Init()
+
+	b.SetBytes(int64(8 * ColBatchSize))
+	for i := 0; i < b.N; i++ {
+		plusOp.Next()
+	}
+}
+
+func BenchmarkSelLTInt64Int64Op(b *testing.B) {
+	rng, _ := randutil.NewPseudoRand()
+
+	batch := NewMemBatch([]types.T{types.Int64, types.Int64})
+	col1 := batch.ColVec(0).Int64()
+	col2 := batch.ColVec(1).Int64()
+	for i := int64(0); i < ColBatchSize; i++ {
+		col1[i] = rng.Int63()
+		col2[i] = rng.Int63()
+	}
+	batch.SetLength(ColBatchSize)
+	source := newRepeatableBatchSource(batch)
+	source.Init()
+
+	plusOp := &selLTInt64Int64Op{
+		input:   source,
+		col1Idx: 0,
+		col2Idx: 1,
+	}
+	plusOp.Init()
+
+	b.SetBytes(int64(8 * ColBatchSize * 2))
+	for i := 0; i < b.N; i++ {
+		plusOp.Next()
+	}
+}

--- a/pkg/sql/exec/types/types.go
+++ b/pkg/sql/exec/types/types.go
@@ -102,3 +102,27 @@ func FromGoType(v interface{}) T {
 		panic(fmt.Sprintf("type %T not supported yet", t))
 	}
 }
+
+// GoTypeName returns the stringified Go type for an exec type.
+func (t T) GoTypeName() string {
+	switch t {
+	case Bool:
+		return "bool"
+	case Bytes:
+		return "[]byte"
+	case Int8:
+		return "int8"
+	case Int16:
+		return "int16"
+	case Int32:
+		return "int32"
+	case Int64:
+		return "int64"
+	case Float32:
+		return "float32"
+	case Float64:
+		return "float64"
+	default:
+		panic(fmt.Sprintf("unhandled type %d", t))
+	}
+}


### PR DESCRIPTION
An initial collection of projection and selection operations is now
auto-generated via execgen.

Int64 benchmarks:
```
BenchmarkProjPlusInt64Int64ConstOp-4   	 3000000	       554 ns/op	14767.10 MB/s
BenchmarkProjPlusInt64Int64Op-4        	 3000000	       581 ns/op	28188.13 MB/s
BenchmarkSelLTInt64Int64ConstOp-4      	 2000000	       666 ns/op	12290.12 MB/s
BenchmarkSelLTInt64Int64Op-4           	 2000000	       857 ns/op	19115.31 MB/s
```

Release note: None