### PR TITLE
storage: clean up colocation of leaseholder and raft leader

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -9795,13 +9795,6 @@ func (q *testQuiescer) ownsValidLeaseRLocked(ts hlc.Timestamp) bool {
 	return q.ownsValidLease
 }
 
-func (q *testQuiescer) maybeTransferRaftLeader(
-	ctx context.Context, status *raft.Status, ts hlc.Timestamp,
-) {
-	// Nothing to do here. We test Raft leadership transfer in
-	// TestTransferRaftLeadership.
-}
-
 func TestShouldReplicaQuiesce(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 


### PR DESCRIPTION
When the Raft leader is not colocated with the leaseholder, we transfer
the Raft leadership to the leaseholder, as long as the leaseholder has
not fallen behind on applying log entries.

There are two important places where we want to perform this check:

  1. when we apply a new lease, in case the lease has changed hands;
  2. on every tick, to catch cases where were unable to transfer Raft leadership
     immediately because the leaseholder had fallen behind.

Instead of duplicating this logic in both places, share a helper
function. Also hoist the on-tick check out of shouldReplicaQuiesce.
Though that function is called on every tick, it was an extremely
non-obvious place to be checking for leadership/leaseholder colocation.

Release note: None