### PR TITLE
release-2.1: distsql: handle implicit key cols in lookup joins

### DIFF
--- a/pkg/sql/distsqlrun/indexjoiner.go
+++ b/pkg/sql/distsqlrun/indexjoiner.go
@@ -208,7 +208,8 @@ func (ij *indexJoiner) generateSpan(row sqlbase.EncDatumRow) (roachpb.Span, erro
 	keyRow := row[:numKeyCols]
 	types := ij.input.OutputTypes()[:numKeyCols]
 	key, err := sqlbase.MakeKeyFromEncDatums(
-		types, keyRow, &ij.desc, &ij.desc.PrimaryIndex, ij.keyPrefix, &ij.alloc)
+		ij.keyPrefix, keyRow, types, ij.desc.PrimaryIndex.ColumnDirections, &ij.desc,
+		&ij.desc.PrimaryIndex, &ij.alloc)
 	if err != nil {
 		return roachpb.Span{}, err
 	}

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -88,6 +88,8 @@ type joinReader struct {
 	// indexTypes is an array of the types of the index we're looking up into,
 	// in the order of the columns in that index.
 	indexTypes []sqlbase.ColumnType
+	// indexDirs is an array of the directions for the index's key columns.
+	indexDirs []sqlbase.IndexDescriptor_Direction
 
 	// These fields are set only for lookup joins on secondary indexes which
 	// require an additional primary index lookup.
@@ -154,13 +156,16 @@ func newJoinReader(
 	}
 	jr.colIdxMap = jr.desc.ColumnIdxMap()
 
-	jr.indexTypes = make([]sqlbase.ColumnType, len(jr.index.ColumnIDs))
-	indexCols := make([]uint32, len(jr.index.ColumnIDs))
+	var columnIDs []sqlbase.ColumnID
+	columnIDs, jr.indexDirs = jr.index.FullColumnIDs()
+	indexCols := make([]uint32, len(columnIDs))
+	jr.indexTypes = make([]sqlbase.ColumnType, len(columnIDs))
 	columnTypes := jr.desc.ColumnTypes()
-	for i, columnID := range jr.index.ColumnIDs {
+	for i, columnID := range columnIDs {
 		indexCols[i] = uint32(columnID)
 		jr.indexTypes[i] = columnTypes[jr.colIdxMap[columnID]]
 	}
+
 	if err := jr.joinerBase.init(
 		jr,
 		flowCtx,
@@ -313,7 +318,7 @@ func (jr *joinReader) neededRightCols() util.FastIntSet {
 // If lookup columns are specified will use those to collect the relevant
 // columns. Otherwise the first rows are assumed to correspond with the index.
 func (jr *joinReader) generateKey(row sqlbase.EncDatumRow) (roachpb.Key, error) {
-	numKeyCols := len(jr.index.ColumnIDs)
+	numKeyCols := len(jr.indexTypes)
 	numLookupCols := len(jr.lookupCols)
 
 	if numLookupCols > numKeyCols {
@@ -326,7 +331,8 @@ func (jr *joinReader) generateKey(row sqlbase.EncDatumRow) (roachpb.Key, error) 
 		jr.indexKeyRow = append(jr.indexKeyRow, row[id])
 	}
 	return sqlbase.MakeKeyFromEncDatums(
-		jr.indexTypes[:numLookupCols], jr.indexKeyRow, &jr.desc, jr.index, jr.indexKeyPrefix, &jr.alloc)
+		jr.indexKeyPrefix, jr.indexKeyRow, jr.indexTypes[:numLookupCols], jr.indexDirs, &jr.desc,
+		jr.index, &jr.alloc)
 }
 
 // Next is part of the RowSource interface.
@@ -593,8 +599,8 @@ func (jr *joinReader) primaryLookup(
 			values[i] = row[jr.colIdxMap[columnID]]
 		}
 		key, err := sqlbase.MakeKeyFromEncDatums(
-			jr.primaryColumnTypes, values, &jr.desc, &jr.desc.PrimaryIndex, jr.primaryKeyPrefix,
-			&jr.alloc)
+			jr.primaryKeyPrefix, values, jr.primaryColumnTypes, jr.desc.PrimaryIndex.ColumnDirections,
+			&jr.desc, &jr.desc.PrimaryIndex, &jr.alloc)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/distsqlrun/zigzagjoiner.go
+++ b/pkg/sql/distsqlrun/zigzagjoiner.go
@@ -326,10 +326,12 @@ func (z *zigzagJoiner) Start(ctx context.Context) context.Context {
 // zigzagJoinerInfo contains all the information that needs to be
 // stored for each side of the join.
 type zigzagJoinerInfo struct {
-	fetcher sqlbase.RowFetcher
-	alloc   *sqlbase.DatumAlloc
-	table   *sqlbase.TableDescriptor
-	index   *sqlbase.IndexDescriptor
+	fetcher    sqlbase.RowFetcher
+	alloc      *sqlbase.DatumAlloc
+	table      *sqlbase.TableDescriptor
+	index      *sqlbase.IndexDescriptor
+	indexTypes []sqlbase.ColumnType
+	indexDirs  []sqlbase.IndexDescriptor_Direction
 
 	// Stores one batch of matches at a time. When all the rows are collected
 	// the cartesian product of the containers will be emitted.
@@ -368,6 +370,17 @@ func (z *zigzagJoiner) setupInfo(spec *ZigzagJoinerSpec, side int, colOffset int
 		info.index = &info.table.Indexes[indexID-1]
 	}
 
+	var columnIDs []sqlbase.ColumnID
+	columnIDs, info.indexDirs = info.index.FullColumnIDs()
+	info.indexTypes = make([]sqlbase.ColumnType, len(columnIDs))
+	indexCols := make([]uint32, len(columnIDs))
+	columnTypes := info.table.ColumnTypes()
+	colIdxMap := info.table.ColumnIdxMap()
+	for i, columnID := range columnIDs {
+		indexCols[i] = uint32(columnID)
+		info.indexTypes[i] = columnTypes[colIdxMap[columnID]]
+	}
+
 	// Add the outputted columns.
 	neededCols := util.MakeFastIntSet()
 	outCols := z.out.neededColumns()
@@ -377,7 +390,6 @@ func (z *zigzagJoiner) setupInfo(spec *ZigzagJoinerSpec, side int, colOffset int
 	}
 
 	// Add the fixed columns.
-	indexCols := append(info.index.ColumnIDs, info.index.ExtraColumnIDs...)
 	for i := 0; i < len(info.fixedValues); i++ {
 		neededCols.Add(int(indexCols[i]) - 1)
 	}
@@ -492,60 +504,25 @@ func (z *zigzagJoiner) extractEqDatums(row sqlbase.EncDatumRow, side int) sqlbas
 	return eqCols
 }
 
-// explicitTypes partitions the column types based on whether the column is
-// an explicit or implicit part of the index.
-func (z *zigzagJoiner) explicitTypes() []sqlbase.ColumnType {
-	curInfo := z.infos[z.side]
-	indexDescriptor := curInfo.index
-	allTypes := curInfo.table.ColumnTypes()
-	explicitTypes := make([]sqlbase.ColumnType, len(indexDescriptor.ColumnIDs))
-	for i, id := range indexDescriptor.ColumnIDs {
-		explicitTypes[i] = allTypes[id-1]
-	}
-	return explicitTypes
-}
-
-// separateNeededDatums partitions the column datums based on whether the column is
-// an explicit or implicit part of the index.
-func (z *zigzagJoiner) separateNeededDatums() (sqlbase.EncDatumRow, sqlbase.EncDatumRow) {
+// Generates a Key, corresponding to the current `z.baseRow` in
+// the index on the current side.
+func (z *zigzagJoiner) produceKeyFromBaseRow() (roachpb.Key, error) {
 	info := z.infos[z.side]
-	fixedDatums := info.fixedValues
-	neededDatums := fixedDatums
+	neededDatums := info.fixedValues
 	if z.baseRow != nil {
 		eqDatums := z.extractEqDatums(z.baseRow, z.prevSide())
 		neededDatums = append(neededDatums, eqDatums...)
 	}
-	indexDescriptor := info.index
-	explicitDatums := make(sqlbase.EncDatumRow, 0, len(indexDescriptor.ColumnIDs))
-	implicitDatums := make(sqlbase.EncDatumRow, 0, len(indexDescriptor.ExtraColumnIDs))
-	for i := range neededDatums {
-		if i < cap(explicitDatums) {
-			explicitDatums = append(explicitDatums, neededDatums[i])
-		} else {
-			implicitDatums = append(implicitDatums, neededDatums[i])
-		}
-	}
-	return explicitDatums, implicitDatums
-}
-
-// Generates a Key, corresponding to the current `z.baseRow` in
-// the index on the current side.
-func (z *zigzagJoiner) produceKeyFromBaseRow() (roachpb.Key, error) {
-	explicitNeededDatums, implicitNeededDatums := z.separateNeededDatums()
-	explicitTypes := z.explicitTypes()
-	explicitTypes = explicitTypes[:len(explicitNeededDatums)]
-
-	info := z.infos[z.side]
 
 	// Construct correct row by concatenating right fixed datums with
 	// primary key extracted from `row`.
-	key, err := sqlbase.MakeFullKeyFromEncDatums(
-		explicitTypes,
-		explicitNeededDatums,
-		implicitNeededDatums,
+	key, err := sqlbase.MakeKeyFromEncDatums(
+		info.prefix,
+		neededDatums,
+		info.indexTypes[:len(neededDatums)],
+		info.indexDirs,
 		info.table,
 		info.index,
-		info.prefix,
 		info.alloc,
 	)
 	return key, err

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -406,3 +406,80 @@ query IIII
 SELECT * FROM source JOIN child ON source.a = child.a
 ----
 1 1 2 3
+
+###########################################################
+#  LOOKUP JOINS ON IMPLICIT INDEX KEY COLUMNS             #
+#  https://github.com/cockroachdb/cockroach/issues/31777  #
+###########################################################
+statement ok
+CREATE TABLE t (a INT, b INT, c INT, d INT, e INT)
+
+statement ok
+CREATE TABLE u (a INT, b INT, c INT, d INT, e INT, PRIMARY KEY (a DESC, b, c))
+
+statement ok
+INSERT INTO t VALUES
+  (1, 2, 3, 4, 5)
+
+statement ok
+INSERT INTO u VALUES
+  (1, 2, 3, 4, 5),
+  (2, 3, 4, 5, 6),
+  (3, 4, 5, 6, 7)
+
+# Test index with all primary key columns implicit.
+statement ok
+CREATE INDEX idx ON u (d)
+
+query I
+SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e = 5
+----
+1
+
+# Test unique version of same index. (Lookup join should not use column a.)
+statement ok
+DROP INDEX u@idx
+
+statement ok
+CREATE UNIQUE INDEX idx ON u (d)
+
+query I
+SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e = 5
+----
+1
+
+# Test index with first primary key column explicit and the rest implicit.
+statement ok
+DROP INDEX u@idx CASCADE
+
+statement ok
+CREATE INDEX idx ON u (d, a)
+
+query I
+SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = u.b WHERE t.e = 5
+----
+1
+
+# Test index with middle primary key column explicit and the rest implicit.
+statement ok
+DROP INDEX u@idx
+
+statement ok
+CREATE INDEX idx ON u (d, b)
+
+query I
+SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = u.b WHERE t.e = 5
+----
+1
+
+# Test index with last primary key column explicit and the rest implicit.
+statement ok
+DROP INDEX u@idx
+
+statement ok
+CREATE INDEX idx ON u (d, c)
+
+query I
+SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.d = u.d WHERE t.e = 5
+----
+1

--- a/pkg/sql/lookup_join.go
+++ b/pkg/sql/lookup_join.go
@@ -76,12 +76,18 @@ func (lj *lookupJoinNode) startExec(params runParams) error {
 		plan: lj.input,
 	}
 
+	indexColIDs := lj.table.index.ColumnIDs
+	if !lj.table.index.Unique {
+		// Add implicit key columns.
+		indexColIDs = append(indexColIDs, lj.table.index.ExtraColumnIDs...)
+	}
+
 	// The lookup side may not output all the index columns on which we are doing
 	// the lookup. We need them to be produced so that we can refer to them in the
 	// join predicate. So we find any such instances and adjust the scan node
 	// accordingly.
 	for i := range lj.keyCols {
-		colID := lj.table.index.ColumnIDs[i]
+		colID := indexColIDs[i]
 		if _, ok := lj.table.colIdxMap[colID]; !ok {
 			// Tricky case: the lookup join doesn't output this column so we can't
 			// refer to it; we have to add it.
@@ -124,7 +130,7 @@ func (lj *lookupJoinNode) startExec(params runParams) error {
 
 	// Program the equalities implied by keyCols.
 	for i := range lj.keyCols {
-		colID := lj.table.index.ColumnIDs[i]
+		colID := indexColIDs[i]
 		pred.addEquality(leftSrc.info, lj.keyCols[i], rightSrc.info, lj.table.colIdxMap[colID])
 	}
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -413,3 +413,117 @@ render          ·         ·              (c, d)     ·
       └── scan  ·         ·              (c)        ·
 ·               table     small@primary  ·          ·
 ·               spans     ALL            ·          ·
+
+###########################################################
+#  LOOKUP JOINS ON IMPLICIT INDEX KEY COLUMNS             #
+#  https://github.com/cockroachdb/cockroach/issues/31777  #
+###########################################################
+statement ok
+CREATE TABLE t (a INT, b INT, c INT, d INT, e INT)
+
+statement ok
+CREATE TABLE u (a INT, b INT, c INT, d INT, e INT, PRIMARY KEY (a DESC, b, c))
+
+# Test index with all primary key columns implicit.
+statement ok
+CREATE INDEX idx ON u (d)
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e = 5
+----
+render            ·         ·          (a)              ·
+ │                render 0  a          ·                ·
+ └── lookup-join  ·         ·          (a, d, e, a, d)  ·
+      │           type      inner      ·                ·
+      ├── scan    ·         ·          (a, d, e)        ·
+      │           table     t@primary  ·                ·
+      │           spans     ALL        ·                ·
+      │           filter    e = 5      ·                ·
+      └── scan    ·         ·          (a, d)           ·
+·                 table     u@idx      ·                ·
+
+# Test unique version of same index. (Lookup join should not use column a.)
+statement ok
+DROP INDEX u@idx
+
+statement ok
+CREATE UNIQUE INDEX idx ON u (d)
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e = 5
+----
+render            ·         ·          (a)              ·
+ │                render 0  a          ·                ·
+ └── lookup-join  ·         ·          (a, d, e, a, d)  ·
+      │           type      inner      ·                ·
+      │           pred      @1 = @4    ·                ·
+      ├── scan    ·         ·          (a, d, e)        ·
+      │           table     t@primary  ·                ·
+      │           spans     ALL        ·                ·
+      │           filter    e = 5      ·                ·
+      └── scan    ·         ·          (a, d)           ·
+·                 table     u@idx      ·                ·
+
+# Test index with first primary key column explicit and the rest implicit.
+statement ok
+DROP INDEX u@idx CASCADE
+
+statement ok
+CREATE INDEX idx ON u (d, a)
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = u.b WHERE t.e = 5
+----
+render            ·         ·          (a)                    ·
+ │                render 0  a          ·                      ·
+ └── lookup-join  ·         ·          (a, b, d, e, a, b, d)  ·
+      │           type      inner      ·                      ·
+      ├── scan    ·         ·          (a, b, d, e)           ·
+      │           table     t@primary  ·                      ·
+      │           spans     ALL        ·                      ·
+      │           filter    e = 5      ·                      ·
+      └── scan    ·         ·          (a, b, d)              ·
+·                 table     u@idx      ·                      ·
+
+# Test index with middle primary key column explicit and the rest implicit.
+statement ok
+DROP INDEX u@idx
+
+statement ok
+CREATE INDEX idx ON u (d, b)
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = u.b WHERE t.e = 5
+----
+render            ·         ·          (a)                    ·
+ │                render 0  a          ·                      ·
+ └── lookup-join  ·         ·          (a, b, d, e, a, b, d)  ·
+      │           type      inner      ·                      ·
+      ├── scan    ·         ·          (a, b, d, e)           ·
+      │           table     t@primary  ·                      ·
+      │           spans     ALL        ·                      ·
+      │           filter    e = 5      ·                      ·
+      └── scan    ·         ·          (a, b, d)              ·
+·                 table     u@idx      ·                      ·
+
+# Test index with last primary key column explicit and the rest implicit.
+statement ok
+DROP INDEX u@idx
+
+statement ok
+CREATE INDEX idx ON u (d, c)
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.d = u.d WHERE t.e = 5
+----
+render            ·         ·          (a)              ·
+ │                render 0  a          ·                ·
+ └── lookup-join  ·         ·          (a, d, e, a, d)  ·
+      │           type      inner      ·                ·
+      │           pred      @1 = @4    ·                ·
+      ├── scan    ·         ·          (a, d, e)        ·
+      │           table     t@primary  ·                ·
+      │           spans     ALL        ·                ·
+      │           filter    e = 5      ·                ·
+      └── scan    ·         ·          (a, d)           ·
+·                 table     u@idx      ·                ·

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -475,7 +475,10 @@ func (n *scanNode) computePhysicalProps(
 		if i < exactPrefix {
 			pp.addConstantColumn(idx)
 		} else {
-			dir := dirs[i]
+			dir, err := dirs[i].ToEncodingDirection()
+			if err != nil {
+				panic(err)
+			}
 			if reverse {
 				dir = dir.Reverse()
 			}

--- a/pkg/sql/sqlbase/index_encoding.go
+++ b/pkg/sql/sqlbase/index_encoding.go
@@ -144,26 +144,24 @@ func (d directions) get(i int) (encoding.Direction, error) {
 	return encoding.Ascending, nil
 }
 
-// MakeKeyFromEncDatums creates a key by concatenating keyPrefix with the
-// encodings of the given EncDatum values. The values correspond to
-// index.ColumnIDs.
+// MakeKeyFromEncDatums creates an index key by concatenating keyPrefix with the
+// encodings of the given EncDatum values. The values, types, and dirs
+// parameters should be specified in the same order as the index key columns and
+// may be a prefix.
 //
 // If a table or index is interleaved, `encoding.interleavedSentinel` is used
 // in place of the family id (a varint) to signal the next component of the
 // key.  An example of one level of interleaving (a parent):
 // /<parent_table_id>/<parent_index_id>/<field_1>/<field_2>/NullDesc/<table_id>/<index_id>/<field_3>/<family>
-//
-// Note that ExtraColumnIDs are not encoded, so the result isn't always a
-// full index key.
 func MakeKeyFromEncDatums(
-	types []ColumnType,
+	keyPrefix []byte,
 	values EncDatumRow,
+	types []ColumnType,
+	dirs []IndexDescriptor_Direction,
 	tableDesc *TableDescriptor,
 	index *IndexDescriptor,
-	keyPrefix []byte,
 	alloc *DatumAlloc,
 ) (roachpb.Key, error) {
-	dirs := index.ColumnDirections
 	// Values may be a prefix of the index columns.
 	if len(values) > len(dirs) {
 		return nil, errors.Errorf("%d values, %d directions", len(values), len(dirs))
@@ -243,56 +241,6 @@ func appendEncDatumsToKey(
 		if err != nil {
 			return nil, err
 		}
-	}
-	return key, nil
-}
-
-// MakeFullKeyFromEncDatums creates a key by concatenating keyPrefix
-// with the encodings of the explicit EncDatum values followed by the
-// encodings of the implicit datum values. These values correspond to
-// index.ColumnIDs and index.ExtraColumnIDs respectively.
-//
-// Note: MakeKeyFromEncDatums does not allow you to create a key
-// specifying the ExtraColumnIDs, so the result may not be a full
-// key. This function allows you to create a key by specifying the
-// values for the ExtraColumnID values as the implicitValues.
-func MakeFullKeyFromEncDatums(
-	explicitTypes []ColumnType,
-	explicitValues EncDatumRow,
-	implicitValues EncDatumRow,
-	tableDesc *TableDescriptor,
-	index *IndexDescriptor,
-	keyPrefix []byte,
-	alloc *DatumAlloc,
-) (roachpb.Key, error) {
-	prefix, err := MakeKeyFromEncDatums(explicitTypes, explicitValues, tableDesc, index, keyPrefix, alloc)
-	if err != nil {
-		return nil, err
-	}
-
-	primaryIndex := tableDesc.PrimaryIndex
-	extraColumns := index.ExtraColumnIDs
-	// PrimaryImplicitIdxs maps the position of the implicit column in the key
-	// to the appropriate column in the primary index.
-	primaryImplicitIdxs := make([]int, len(extraColumns))
-	for i, id := range extraColumns {
-		for j, primaryID := range primaryIndex.ColumnIDs {
-			if id == primaryID {
-				primaryImplicitIdxs[i] = j
-			}
-		}
-	}
-	implicitDirs := make([]IndexDescriptor_Direction, len(primaryImplicitIdxs))
-	for i, idx := range primaryImplicitIdxs {
-		implicitDirs[i] = primaryIndex.ColumnDirections[idx]
-	}
-	implicitTypes := make([]ColumnType, len(extraColumns))
-	for i, id := range extraColumns {
-		implicitTypes[i] = tableDesc.ColumnTypes()[id]
-	}
-	key, err := appendEncDatumsToKey(prefix, implicitTypes, implicitValues, implicitDirs, alloc)
-	if err != nil {
-		return nil, err
 	}
 	return key, nil
 }
@@ -389,7 +337,7 @@ func DecodeIndexKey(
 	index *IndexDescriptor,
 	types []ColumnType,
 	vals []EncDatum,
-	colDirs []encoding.Direction,
+	colDirs []IndexDescriptor_Direction,
 	key []byte,
 ) (remainingKey []byte, matches bool, _ error) {
 	key, _, _, err := DecodeTableIDIndexID(key)
@@ -407,7 +355,7 @@ func DecodeIndexKeyWithoutTableIDIndexIDPrefix(
 	index *IndexDescriptor,
 	types []ColumnType,
 	vals []EncDatum,
-	colDirs []encoding.Direction,
+	colDirs []IndexDescriptor_Direction,
 	key []byte,
 ) (remainingKey []byte, matches bool, _ error) {
 	var decodedTableID ID
@@ -528,7 +476,7 @@ func consumeIndexKeyWithoutTableIDIndexIDPrefix(
 // values are stored in the vals. If this slice is nil, the direction
 // used will default to encoding.Ascending.
 func DecodeKeyVals(
-	types []ColumnType, vals []EncDatum, directions []encoding.Direction, key []byte,
+	types []ColumnType, vals []EncDatum, directions []IndexDescriptor_Direction, key []byte,
 ) ([]byte, error) {
 	if directions != nil && len(directions) != len(vals) {
 		return nil, errors.Errorf("encoding directions doesn't parallel vals: %d vs %d.",
@@ -536,7 +484,7 @@ func DecodeKeyVals(
 	}
 	for j := range vals {
 		enc := DatumEncoding_ASCENDING_KEY
-		if directions != nil && (directions[j] == encoding.Descending) {
+		if directions != nil && (directions[j] == IndexDescriptor_DESC) {
 			enc = DatumEncoding_DESCENDING_KEY
 		}
 		var err error
@@ -574,13 +522,7 @@ func ExtractIndexKey(
 		return nil, err
 	}
 	values := make([]EncDatum, len(index.ColumnIDs))
-	dirs := make([]encoding.Direction, len(index.ColumnIDs))
-	for i, dir := range index.ColumnDirections {
-		dirs[i], err = dir.ToEncodingDirection()
-		if err != nil {
-			return nil, err
-		}
-	}
+	dirs := index.ColumnDirections
 	if len(index.Interleave.Ancestors) > 0 {
 		// TODO(dan): In the interleaved index case, we parse the key twice; once to
 		// find the index id so we can look up the descriptor, and once to extract
@@ -606,10 +548,10 @@ func ExtractIndexKey(
 		return nil, err
 	}
 	extraValues := make([]EncDatum, len(index.ExtraColumnIDs))
-	dirs = make([]encoding.Direction, len(index.ExtraColumnIDs))
+	dirs = make([]IndexDescriptor_Direction, len(index.ExtraColumnIDs))
 	for i := range index.ExtraColumnIDs {
 		// Implicit columns are always encoded Ascending.
-		dirs[i] = encoding.Ascending
+		dirs[i] = IndexDescriptor_ASC
 	}
 	extraKey := key
 	if index.Unique {

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -57,7 +57,7 @@ type tableInfo struct {
 	desc             *TableDescriptor
 	index            *IndexDescriptor
 	isSecondaryIndex bool
-	indexColumnDirs  []encoding.Direction
+	indexColumnDirs  []IndexDescriptor_Direction
 	// equivSignature is an equivalence class for each unique table-index
 	// pair. It allows us to check if an index key belongs to a given
 	// table-index.

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -264,25 +264,18 @@ func (desc *IndexDescriptor) ContainsColumnID(colID ColumnID) bool {
 // FullColumnIDs returns the index column IDs including any extra (implicit or
 // stored (old STORING encoding)) column IDs for non-unique indexes. It also
 // returns the direction with which each column was encoded.
-func (desc *IndexDescriptor) FullColumnIDs() ([]ColumnID, []encoding.Direction) {
-	dirs := make([]encoding.Direction, 0, len(desc.ColumnIDs))
-	for _, dir := range desc.ColumnDirections {
-		convertedDir, err := dir.ToEncodingDirection()
-		if err != nil {
-			panic(err)
-		}
-		dirs = append(dirs, convertedDir)
-	}
+func (desc *IndexDescriptor) FullColumnIDs() ([]ColumnID, []IndexDescriptor_Direction) {
 	if desc.Unique {
-		return desc.ColumnIDs, dirs
+		return desc.ColumnIDs, desc.ColumnDirections
 	}
 	// Non-unique indexes have some of the primary-key columns appended to
 	// their key.
 	columnIDs := append([]ColumnID(nil), desc.ColumnIDs...)
 	columnIDs = append(columnIDs, desc.ExtraColumnIDs...)
+	dirs := append([]IndexDescriptor_Direction(nil), desc.ColumnDirections...)
 	for range desc.ExtraColumnIDs {
 		// Extra columns are encoded in ascending order.
-		dirs = append(dirs, encoding.Ascending)
+		dirs = append(dirs, IndexDescriptor_ASC)
 	}
 	return columnIDs, dirs
 }

--- a/pkg/sql/sqlbase/table_test.go
+++ b/pkg/sql/sqlbase/table_test.go
@@ -108,13 +108,7 @@ func decodeIndex(
 		return nil, err
 	}
 	values := make([]EncDatum, len(index.ColumnIDs))
-	colDirs := make([]encoding.Direction, len(index.ColumnDirections))
-	for i, dir := range index.ColumnDirections {
-		colDirs[i], err = dir.ToEncodingDirection()
-		if err != nil {
-			return nil, err
-		}
-	}
+	colDirs := index.ColumnDirections
 	_, ok, err := DecodeIndexKey(tableDesc, index, types, values, colDirs, key)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Backport 1/1 commits from #31792.

/cc @cockroachdb/release

---

Non-unique indexes implicitly include all primary key columns in their
keys. The optimizer takes advantage of this when planning lookup joins,
but joinreader was not aware of this and only considered explicit key
columns, which caused an error upon execution ("2 lookup columns
specified, expecting at most 1"). I added joinreader logic to handle
this case.

Fixes #31777 

Release note (bug fix): Fixed a mismatch between lookup join planning
and execution, which could cause queries to fail with the error, "X
lookup columns specified, expecting at most Y."
