### PR TITLE
storage: deflake TestNodeLivenessStatusMap

### DIFF
--- a/pkg/storage/node_liveness_test.go
+++ b/pkg/storage/node_liveness_test.go
@@ -824,6 +824,7 @@ func TestNodeLivenessStatusMap(t *testing.T) {
 
 	log.Infof(ctx, "waiting for node statuses")
 	tc.WaitForNodeStatuses(t)
+	tc.WaitForNodeLiveness(t)
 	log.Infof(ctx, "waiting done")
 
 	firstServer := tc.Server(0).(*server.TestServer)


### PR DESCRIPTION
Add `TestCluster.WaitForNodeLiveness` so that tests which use
decommissioning can avoid decommissioning nodes which have not had a
chance to persist a node liveness entry.

Fixes #31666

Release note: None