### PR TITLE
storage: avoid blocking the command queue for scans with limits

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -3028,7 +3028,7 @@ func (ct *cmdQCancelTest) insertCmds(instrs []cancelInstr) {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		ba := instr.req()
-		spanSet, err := collectSpans(roachpb.RangeDescriptor{}, ba)
+		spanSet, _, err := collectSpans(roachpb.RangeDescriptor{}, ba)
 		if err != nil {
 			ct.Fatal(err)
 		}


### PR DESCRIPTION
SQL has a tendancy to create scans which cover a range's entire key
span, though looking only to return a finite number of results. These
requests end up blocking writes in the command queue, which block
other reads, causing requsets to effectively serialize. In reality,
when there is a scan with a limit, the actual affected key span ends
up being a small subset of the range's key span.

This change creates a new "pre-evaluation" execution path for read-
only requests. When pre-evaluating, the batch still interacts with
the command queue, but it neither waits for pre-requisites nor causes
successor, dependent write batches from waiting on it. Instead, any
prereqs or dependents are tracked while the read-only batch is
immediately evaluated without blocking. On successful evaluation,
the actual span(s) covered and recorded in the read-only batch's
`BatchResponse` are compared to the pre-requisite and dependent
commands. If there is no overlap, the timestamp cache is updated and
the read-only batch response returned to the caller. If there is
overlap, then the read-only batch is re-executed, but with the
pre-evaluation option disabled, so that it proceeds to interact with
the command queue in the traditional fashion, waiting on prereqs
and making dependents wait on it.

Release note: improved performance on workloads which mix OLAP queries
with updates.