### PR TITLE
storage/engine: allow SplitKey to be inlined

### DIFF
--- a/c-deps/libroach/encoding.cc
+++ b/c-deps/libroach/encoding.cc
@@ -185,20 +185,6 @@ std::string EncodeKey(const rocksdb::Slice& key, int64_t wall_time, int32_t logi
 // ordering as these keys do not sort lexicographically correctly.
 std::string EncodeKey(DBKey k) { return EncodeKey(ToSlice(k.key), k.wall_time, k.logical); }
 
-WARN_UNUSED_RESULT bool SplitKey(rocksdb::Slice buf, rocksdb::Slice* key,
-                                 rocksdb::Slice* timestamp) {
-  if (buf.empty()) {
-    return false;
-  }
-  const char ts_size = buf[buf.size() - 1];
-  if (ts_size >= buf.size()) {
-    return false;
-  }
-  *key = rocksdb::Slice(buf.data(), buf.size() - ts_size - 1);
-  *timestamp = rocksdb::Slice(key->data() + key->size(), ts_size);
-  return true;
-}
-
 WARN_UNUSED_RESULT bool DecodeTimestamp(rocksdb::Slice* timestamp, int64_t* wall_time,
                                         int32_t* logical) {
   uint64_t w;

--- a/c-deps/libroach/encoding.h
+++ b/c-deps/libroach/encoding.h
@@ -69,8 +69,20 @@ std::string EncodeKey(DBKey k);
 // SplitKey splits an MVCC key into key and timestamp slices. See also
 // DecodeKey if you want to decode the timestamp. Returns true on
 // success and false on any decoding error.
-WARN_UNUSED_RESULT bool SplitKey(rocksdb::Slice buf, rocksdb::Slice* key,
-                                 rocksdb::Slice* timestamp);
+WARN_UNUSED_RESULT inline bool SplitKey(rocksdb::Slice buf, rocksdb::Slice* key,
+                                        rocksdb::Slice* timestamp) {
+  if (buf.empty()) {
+    return false;
+  }
+  const char ts_size = buf[buf.size() - 1];
+  if (ts_size >= buf.size()) {
+    return false;
+  }
+  *key = rocksdb::Slice(buf.data(), buf.size() - ts_size - 1);
+  *timestamp = rocksdb::Slice(key->data() + key->size(), ts_size);
+  return true;
+}
+
 
 // DecodeTimestamp an MVCC encoded timestamp. Returns true on success
 // and false on any decoding error.


### PR DESCRIPTION
Move SplitKey to a header so that it can be inlined by the compiler. This
yields a 5% speedup on an MVCCScan benchmark:

	name                                                  old time/op    new time/op    delta
	MVCCScan_RocksDB/rows=10000/versions=1/valueSize=8-8    2.20ms ± 2%    2.10ms ± 2%  -4.43%  (p=0.000 n=10+9)

	name                                                  old speed      new speed      delta
	MVCCScan_RocksDB/rows=10000/versions=1/valueSize=8-8  36.4MB/s ± 2%  38.1MB/s ± 2%  +4.63%  (p=0.000 n=10+9)

	name                                                  old alloc/op   new alloc/op   delta
	MVCCScan_RocksDB/rows=10000/versions=1/valueSize=8-8    1.04MB ± 0%    1.04MB ± 0%    ~     (p=0.986 n=10+10)

	name                                                  old allocs/op  new allocs/op  delta
	MVCCScan_RocksDB/rows=10000/versions=1/valueSize=8-8      3.00 ± 0%      3.00 ± 0%    ~     (all equal)

Release note: None

Based on a late-night hacking session with @jordanlewis and @nvanbenschoten.