### PR TITLE
exec: specify the number of returned batches in repeatableBatchSource

### DIFF
--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -270,8 +270,10 @@ func assertTuplesEquals(expected tuples, actual tuples) error {
 // repeatableBatchSource is an Operator that returns the same batch forever.
 type repeatableBatchSource struct {
 	internalBatch ColBatch
+	batchLen      uint16
 
-	batchLen uint16
+	batchesToReturn int
+	batchesReturned int
 }
 
 var _ Operator = &repeatableBatchSource{}
@@ -287,11 +289,21 @@ func newRepeatableBatchSource(batch ColBatch) *repeatableBatchSource {
 
 func (s *repeatableBatchSource) Next() ColBatch {
 	s.internalBatch.SetSelection(false)
-	s.internalBatch.SetLength(s.batchLen)
+	s.batchesReturned++
+	if s.batchesToReturn != 0 && s.batchesReturned > s.batchesToReturn {
+		s.internalBatch.SetLength(0)
+	} else {
+		s.internalBatch.SetLength(s.batchLen)
+	}
 	return s.internalBatch
 }
 
 func (s *repeatableBatchSource) Init() {}
+
+func (s *repeatableBatchSource) resetBatchesToReturn(b int) {
+	s.batchesToReturn = b
+	s.batchesReturned = 0
+}
 
 func TestOpTestInputOutput(t *testing.T) {
 	input := tuples{


### PR DESCRIPTION
This is necessary for operators that change the shape of their data
(i.e. one next call could only return when the input is exhausted)

Release note: None