### PR TITLE
libroach: don't re-compare every key with end key

### DIFF
--- a/c-deps/libroach/mvcc.h
+++ b/c-deps/libroach/mvcc.h
@@ -136,7 +136,7 @@ template <bool reverse> class mvccScanner {
       if (!iterSeek(EncodeKey(start_key_, 0, 0))) {
         return results_;
       }
-      for (; cur_key_.compare(end_key_) < 0;) {
+      for (;;) {
         if (!getAndAdvance()) {
           break;
         }


### PR DESCRIPTION
Previously, during scan, every key was always compared with the end key
to see if we could finish. However, RocksDB is already configured to do
this exact thing every time we have an end key, so we're doubling the
work that needs to get done there for no reason.

Seems to have a decent effect.

    name                                                  old time/op    new time/op    delta
    MVCCScan_RocksDB/rows=10000/versions=1/valueSize=8-8    3.54ms ± 1%    3.43ms ± 1%  -3.14%  (p=0.000 n=10+10)

    name                                                  old speed      new speed      delta
    MVCCScan_RocksDB/rows=10000/versions=1/valueSize=8-8  22.6MB/s ± 1%  23.3MB/s ± 1%  +3.25%  (p=0.000 n=10+10)

    name                                                  old alloc/op   new alloc/op   delta
    MVCCScan_RocksDB/rows=10000/versions=1/valueSize=8-8    1.04MB ± 0%    1.04MB ± 0%    ~     (p=1.000 n=10+10)

    name                                                  old allocs/op  new allocs/op  delta
    MVCCScan_RocksDB/rows=10000/versions=1/valueSize=8-8      3.00 ± 0%      3.00 ± 0%    ~     (all equal)

Release note: None