### PR TITLE
cli: Added the cli commands `exit` and `quit` to quit the cli.

### DIFF
--- a/pkg/cli/interactive_tests/test_local_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_local_cmds.tcl
@@ -34,6 +34,26 @@ spawn $argv sql --format=tsv
 eexpect root@
 end_test
 
+start_test "Check that quit terminates the client."
+send "quit\r"
+eexpect eof
+spawn $argv sql --format=tsv
+eexpect root@
+end_test
+
+start_test "Check that quit does not terminate the client in the middle of a statement."
+send "select\rquit\r;\r"
+eexpect "column \"quit\" does not exist"
+eexpect root@
+end_test
+
+start_test "Check that exit terminates the client."
+send "exit\r"
+eexpect eof
+spawn $argv sql --format=tsv
+eexpect root@
+end_test
+
 start_test "Check that \\| reads statements."
 send "\\| echo 'select '; echo '38 + 4;'\r"
 eexpect 42

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -193,7 +193,7 @@ const (
 func printCliHelp() {
 	fmt.Printf(`You are using 'cockroach sql', CockroachDB's lightweight SQL client.
 Type:
-  \q to exit        (Ctrl+C/Ctrl+D also supported)
+  \q, quit, exit    exit the shell (Ctrl+C/Ctrl+D also supported)
   \! CMD            run an external command and print its results on standard output.
   \| CMD            run an external command and run its output as SQL statements.
   \set [NAME]       set a client-side flag or (without argument) print the current settings.
@@ -968,9 +968,12 @@ func (c *cliState) doProcessFirstLine(startState, nextState cliStateEnum) cliSta
 		// Ignore empty lines, just continue reading if it isn't interactive mode.
 		return startState
 
-	case "help", "quit", "exit":
+	case "help":
 		printCliHelp()
 		return startState
+
+	case "exit", "quit":
+		return cliStop
 	}
 
 	return nextState


### PR DESCRIPTION
Fixes #31878.
