### PR TITLE
opt: Convert InnerJoinApply + Zip to ProjectSet

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -181,8 +181,8 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	case *memo.MergeJoinExpr:
 		ep, err = b.buildMergeJoin(t)
 
-	case *memo.ZipExpr:
-		ep, err = b.buildZip(t)
+	case *memo.ProjectSetExpr:
+		ep, err = b.buildProjectSet(t)
 
 	default:
 		if opt.IsSetOp(e) {
@@ -194,10 +194,6 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 			break
 		}
 		if opt.IsJoinApplyOp(e) {
-			if e.Child(1).Op() == opt.ZipOp {
-				ep, err = b.buildProjectSet(e)
-				break
-			}
 			return execPlan{}, b.decorrelationError()
 		}
 		return execPlan{}, errors.Errorf("unsupported relational op %s", e.Op())
@@ -896,88 +892,48 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 	return res, nil
 }
 
-// initZipBuild builds the expressions in a Zip operation and initializes the
-// data structures needed to build a projectSetNode.
-// Note: this function modifies outputCols.
-func (b *Builder) initZipBuild(
-	zip *memo.ZipExpr, outputCols opt.ColMap, scalarCtx buildScalarCtx,
-) (tree.TypedExprs, sqlbase.ResultColumns, []int, opt.ColMap, error) {
-	exprs := make(tree.TypedExprs, len(zip.Funcs))
-	numColsPerGen := make([]int, len(exprs))
-	var err error
-	for i, child := range zip.Funcs {
-		exprs[i], err = b.buildScalar(&scalarCtx, child)
-		if err != nil {
-			return nil, nil, nil, opt.ColMap{}, err
-		}
-
-		if fn, ok := child.(*memo.FunctionExpr); ok && fn.Properties.Class == tree.GeneratorClass {
-			numColsPerGen[i] = len(fn.Properties.ReturnLabels)
-		} else {
-			numColsPerGen[i] = 1
-		}
+func (b *Builder) buildProjectSet(projectSet *memo.ProjectSetExpr) (execPlan, error) {
+	input, err := b.buildRelational(projectSet.Input)
+	if err != nil {
+		return execPlan{}, err
 	}
 
+	zip := projectSet.Zip
 	md := b.mem.Metadata()
-	resultCols := make(sqlbase.ResultColumns, len(zip.Cols))
-	for i, col := range zip.Cols {
-		resultCols[i].Name = md.ColumnLabel(col)
-		resultCols[i].Typ = md.ColumnType(col)
+	scalarCtx := input.makeBuildScalarCtx()
+
+	exprs := make(tree.TypedExprs, len(zip))
+	zipCols := make(sqlbase.ResultColumns, 0, len(zip))
+	numColsPerGen := make([]int, len(zip))
+
+	ep := execPlan{outputCols: input.outputCols}
+	n := ep.outputCols.Len()
+
+	for i := range zip {
+		item := &zip[i]
+		exprs[i], err = b.buildScalar(&scalarCtx, item.Func)
+		if err != nil {
+			return execPlan{}, err
+		}
+
+		for _, col := range item.Cols {
+			zipCols = append(zipCols, sqlbase.ResultColumn{
+				Name: md.ColumnLabel(col),
+				Typ:  md.ColumnType(col),
+			})
+
+			ep.outputCols.Set(int(col), n)
+			n++
+		}
+
+		numColsPerGen[i] = len(item.Cols)
 	}
 
-	numInputCols := outputCols.Len()
-	for i, col := range zip.Cols {
-		outputCols.Set(int(col), i+numInputCols)
-	}
-
-	return exprs, resultCols, numColsPerGen, outputCols, nil
-}
-
-func (b *Builder) buildZip(zip *memo.ZipExpr) (execPlan, error) {
-	exprs, resultCols, numColsPerGen, outputCols, err := b.initZipBuild(
-		zip, opt.ColMap{}, buildScalarCtx{},
-	)
+	ep.root, err = b.factory.ConstructProjectSet(input.root, exprs, zipCols, numColsPerGen)
 	if err != nil {
 		return execPlan{}, err
 	}
 
-	// This is an uncorrelated Zip, so the input to the ProjectSet node is empty.
-	input, err := b.factory.ConstructValues([][]tree.TypedExpr{{}}, nil)
-	if err != nil {
-		return execPlan{}, err
-	}
-
-	node, err := b.factory.ConstructProjectSet(input, exprs, resultCols, numColsPerGen)
-	if err != nil {
-		return execPlan{}, err
-	}
-
-	ep := execPlan{root: node}
-	ep.outputCols = outputCols
-	return ep, nil
-}
-
-func (b *Builder) buildProjectSet(join memo.RelExpr) (execPlan, error) {
-	input, err := b.buildRelational(join.Child(0).(memo.RelExpr))
-	if err != nil {
-		return execPlan{}, err
-	}
-
-	ctx := input.makeBuildScalarCtx()
-	exprs, resultCols, numColsPerGen, outputCols, err := b.initZipBuild(
-		join.Child(1).(*memo.ZipExpr), input.outputCols, ctx,
-	)
-	if err != nil {
-		return execPlan{}, err
-	}
-
-	node, err := b.factory.ConstructProjectSet(input.root, exprs, resultCols, numColsPerGen)
-	if err != nil {
-		return execPlan{}, err
-	}
-
-	ep := execPlan{root: node}
-	ep.outputCols = outputCols
 	return ep, nil
 }
 

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -182,6 +182,27 @@ func (n AggregationsExpr) OutputCols() opt.ColSet {
 	return colSet
 }
 
+// OuterCols returns the set of outer columns needed by any of the zip
+// expressions.
+func (n ZipExpr) OuterCols(mem *Memo) opt.ColSet {
+	var colSet opt.ColSet
+	for i := range n {
+		colSet.UnionWith(n[i].ScalarProps(mem).OuterCols)
+	}
+	return colSet
+}
+
+// OutputCols returns the set of columns constructed by the Zip expression.
+func (n ZipExpr) OutputCols() opt.ColSet {
+	var colSet opt.ColSet
+	for i := range n {
+		for _, col := range n[i].Cols {
+			colSet.Add(int(col))
+		}
+	}
+	return colSet
+}
+
 // TupleOrdinal is an ordinal index into an expression of type Tuple. It is
 // used by the ColumnAccess scalar expression.
 type TupleOrdinal uint32

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -352,7 +352,7 @@ func (f *ExprFmtCtx) formatScalar(scalar opt.ScalarExpr, tp treeprinter.Node) {
 		f.Buffer.Reset()
 		propsExpr := scalar
 		switch scalar.Op() {
-		case opt.FiltersItemOp, opt.ProjectionsItemOp, opt.AggregationsItemOp:
+		case opt.FiltersItemOp, opt.ProjectionsItemOp, opt.AggregationsItemOp, opt.ZipItemOp:
 			// Use properties from the item, but otherwise omit it from output.
 			scalar = scalar.Child(0).(opt.ScalarExpr)
 		}

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -533,6 +533,14 @@ func (h *hasher) HashAggregationsExpr(val AggregationsExpr) {
 	}
 }
 
+func (h *hasher) HashZipExpr(val ZipExpr) {
+	for i := range val {
+		item := &val[i]
+		h.HashColList(item.Cols)
+		h.HashScalarExpr(item.Func)
+	}
+}
+
 // ----------------------------------------------------------------------
 //
 // Equality functions
@@ -769,6 +777,18 @@ func (h *hasher) IsAggregationsExprEqual(l, r AggregationsExpr) bool {
 	}
 	for i := range l {
 		if l[i].Col != r[i].Col || l[i].Agg != r[i].Agg {
+			return false
+		}
+	}
+	return true
+}
+
+func (h *hasher) IsZipExprEqual(l, r ZipExpr) bool {
+	if len(l) != len(r) {
+		return false
+	}
+	for i := range l {
+		if !l[i].Cols.Equals(r[i].Cols) || l[i].Func != r[i].Func {
 			return false
 		}
 	}

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -888,35 +888,59 @@ func (b *logicalPropsBuilder) buildRowNumberProps(rowNum *RowNumberExpr, rel *pr
 	}
 }
 
-func (b *logicalPropsBuilder) buildZipProps(zip *ZipExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, zip, &rel.Shared)
+func (b *logicalPropsBuilder) buildProjectSetProps(
+	projectSet *ProjectSetExpr, rel *props.Relational,
+) {
+	BuildSharedProps(b.mem, projectSet, &rel.Shared)
+
+	inputProps := projectSet.Input.Relational()
 
 	// Output Columns
 	// --------------
-	// Output columns are stored in the definition.
-	rel.OutputCols = zip.Cols.ToSet()
+	// Output columns are the union between the output columns from the Zip and
+	// the input.
+	rel.OutputCols = projectSet.Zip.OutputCols()
+	rel.OutputCols.UnionWith(inputProps.OutputCols)
 
 	// Not Null Columns
 	// ----------------
-	// All columns are assumed to be nullable.
+	// Inherit not null columns from input. All other columns are assumed to be
+	// nullable.
+	rel.NotNullCols = inputProps.NotNullCols.Copy()
 
 	// Outer Columns
 	// -------------
-	// Outer columns were already derived by buildSharedProps.
+	// Outer columns were derived by BuildSharedProps; remove any that are bound
+	// by input columns.
+	rel.OuterCols.DifferenceWith(inputProps.OutputCols)
 
 	// Functional Dependencies
 	// -----------------------
-	// Zip operator has an empty FD set.
+	// Start with copy of FuncDepSet. Since ProjectSet is a lateral cross join
+	// between the input and the functional zip (which has an empty FD set), call
+	// MakeApply with an empty FD set. Then add outer columns, modify with
+	// any additional not-null columns, and possibly simplify by calling
+	// ProjectCols.
+	rel.FuncDeps.CopyFrom(&inputProps.FuncDeps)
+	rel.FuncDeps.MakeApply(&props.FuncDepSet{})
+	addOuterColsToFuncDep(rel.OuterCols, &rel.FuncDeps)
+	rel.FuncDeps.MakeNotNull(rel.NotNullCols)
+	rel.FuncDeps.ProjectCols(rel.OutputCols)
 
 	// Cardinality
 	// -----------
-	// Don't make any assumptions about cardinality of output.
-	rel.Cardinality = props.AnyCardinality
+	// Don't make any assumptions about cardinality of ProjectSet unless the
+	// input cardinality is zero.
+	if inputProps.Cardinality == props.ZeroCardinality {
+		rel.Cardinality = props.ZeroCardinality
+	} else {
+		rel.Cardinality = props.AnyCardinality
+	}
 
 	// Statistics
 	// ----------
 	if !b.disableStats {
-		b.sb.buildZip(zip, rel)
+		b.sb.buildProjectSet(projectSet, rel)
 	}
 }
 
@@ -964,6 +988,11 @@ func (b *logicalPropsBuilder) buildAggregationsItemProps(
 ) {
 	item.Typ = item.Agg.DataType()
 	BuildSharedProps(b.mem, item.Agg, &scalar.Shared)
+}
+
+func (b *logicalPropsBuilder) buildZipItemProps(item *ZipItem, scalar *props.Scalar) {
+	item.Typ = item.Func.DataType()
+	BuildSharedProps(b.mem, item.Func, &scalar.Shared)
 }
 
 // BuildSharedProps fills in the shared properties derived from the given

--- a/pkg/sql/opt/memo/testdata/logprops/srfs
+++ b/pkg/sql/opt/memo/testdata/logprops/srfs
@@ -1,0 +1,93 @@
+exec-ddl
+CREATE TABLE xy (x INT PRIMARY KEY, y INT)
+----
+TABLE xy
+ ├── x int not null
+ ├── y int
+ └── INDEX primary
+      └── x int not null
+
+exec-ddl
+CREATE TABLE uv (u INT, v INT NOT NULL)
+----
+TABLE uv
+ ├── u int
+ ├── v int not null
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+opt
+SELECT generate_series(0,1) FROM (SELECT * FROM xy LIMIT 0)
+----
+project-set
+ ├── columns: generate_series:3(int)
+ ├── cardinality: [0 - 0]
+ ├── side-effects
+ ├── values
+ │    ├── cardinality: [0 - 0]
+ │    └── key: ()
+ └── zip
+      └── function: generate_series [type=int, side-effects]
+           ├── const: 0 [type=int]
+           └── const: 1 [type=int]
+
+opt
+SELECT (SELECT unnest(ARRAY[1,2,y,v]) FROM xy WHERE x = u) FROM uv
+----
+project
+ ├── columns: unnest:7(int)
+ ├── side-effects
+ ├── prune: (7)
+ ├── left-join-apply
+ │    ├── columns: u:1(int) v:2(int!null) unnest:6(int)
+ │    ├── side-effects
+ │    ├── reject-nulls: (6)
+ │    ├── scan uv
+ │    │    ├── columns: u:1(int) v:2(int!null)
+ │    │    └── prune: (1,2)
+ │    ├── max1-row
+ │    │    ├── columns: unnest:6(int)
+ │    │    ├── outer: (1,2)
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── side-effects
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(6)
+ │    │    └── project
+ │    │         ├── columns: unnest:6(int)
+ │    │         ├── outer: (1,2)
+ │    │         ├── side-effects
+ │    │         ├── prune: (6)
+ │    │         └── project-set
+ │    │              ├── columns: x:4(int!null) y:5(int) unnest:6(int)
+ │    │              ├── outer: (1,2)
+ │    │              ├── side-effects
+ │    │              ├── fd: ()-->(4,5)
+ │    │              ├── select
+ │    │              │    ├── columns: x:4(int!null) y:5(int)
+ │    │              │    ├── outer: (1)
+ │    │              │    ├── cardinality: [0 - 1]
+ │    │              │    ├── key: ()
+ │    │              │    ├── fd: ()-->(4,5)
+ │    │              │    ├── prune: (5)
+ │    │              │    ├── interesting orderings: (+4)
+ │    │              │    ├── scan xy
+ │    │              │    │    ├── columns: x:4(int!null) y:5(int)
+ │    │              │    │    ├── key: (4)
+ │    │              │    │    ├── fd: (4)-->(5)
+ │    │              │    │    ├── prune: (4,5)
+ │    │              │    │    └── interesting orderings: (+4)
+ │    │              │    └── filters
+ │    │              │         └── eq [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+ │    │              │              ├── variable: x [type=int]
+ │    │              │              └── variable: u [type=int]
+ │    │              └── zip
+ │    │                   └── function: unnest [type=int, outer=(2,5), side-effects]
+ │    │                        └── array: [type=int[]]
+ │    │                             ├── const: 1 [type=int]
+ │    │                             ├── const: 2 [type=int]
+ │    │                             ├── variable: y [type=int]
+ │    │                             └── variable: v [type=int]
+ │    └── filters (true)
+ └── projections
+      └── variable: unnest [type=int, outer=(6)]

--- a/pkg/sql/opt/memo/testdata/stats/srfs
+++ b/pkg/sql/opt/memo/testdata/stats/srfs
@@ -1,4 +1,13 @@
-opt
+exec-ddl
+CREATE TABLE xy (x INT PRIMARY KEY, y INT)
+----
+TABLE xy
+ ├── x int not null
+ ├── y int
+ └── INDEX primary
+      └── x int not null
+
+opt colstat=1 colstat=2 colstat=3 colstat=4 colstat=5
 SELECT a.*, b.*, c.* FROM upper('abc') a
 JOIN ROWS FROM (upper('def'), generate_series(1, 3), upper('ghi')) b ON true
 JOIN generate_series(1, 4) c ON true
@@ -6,28 +15,53 @@ JOIN generate_series(1, 4) c ON true
 inner-join
  ├── columns: a:1(string) upper:2(string) generate_series:3(int) upper:4(string) c:5(int)
  ├── side-effects
- ├── stats: [rows=100]
+ ├── stats: [rows=100, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=90, distinct(3)=7, null(3)=1, distinct(4)=1, null(4)=90, distinct(5)=7, null(5)=1]
  ├── inner-join
  │    ├── columns: upper:1(string) upper:2(string) generate_series:3(int) upper:4(string)
  │    ├── side-effects
- │    ├── stats: [rows=10]
- │    ├── zip
+ │    ├── stats: [rows=10, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=9, distinct(3)=7, null(3)=0.1, distinct(4)=1, null(4)=9]
+ │    ├── project-set
  │    │    ├── columns: upper:2(string) generate_series:3(int) upper:4(string)
  │    │    ├── side-effects
- │    │    ├── stats: [rows=10]
- │    │    ├── upper('def') [type=string]
- │    │    ├── generate_series(1, 3) [type=int]
- │    │    └── upper('ghi') [type=string]
- │    ├── zip
+ │    │    ├── stats: [rows=10, distinct(2)=1, null(2)=9, distinct(3)=7, null(3)=0.1, distinct(4)=1, null(4)=9]
+ │    │    ├── values
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── stats: [rows=1]
+ │    │    │    ├── key: ()
+ │    │    │    └── tuple [type=tuple]
+ │    │    └── zip
+ │    │         ├── function: upper [type=string]
+ │    │         │    └── const: 'def' [type=string]
+ │    │         ├── function: generate_series [type=int, side-effects]
+ │    │         │    ├── const: 1 [type=int]
+ │    │         │    └── const: 3 [type=int]
+ │    │         └── function: upper [type=string]
+ │    │              └── const: 'ghi' [type=string]
+ │    ├── project-set
  │    │    ├── columns: upper:1(string)
- │    │    ├── stats: [rows=1]
- │    │    └── upper('abc') [type=string]
+ │    │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ │    │    ├── values
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── stats: [rows=1]
+ │    │    │    ├── key: ()
+ │    │    │    └── tuple [type=tuple]
+ │    │    └── zip
+ │    │         └── function: upper [type=string]
+ │    │              └── const: 'abc' [type=string]
  │    └── filters (true)
- ├── zip
+ ├── project-set
  │    ├── columns: generate_series:5(int)
  │    ├── side-effects
- │    ├── stats: [rows=10]
- │    └── generate_series(1, 4) [type=int]
+ │    ├── stats: [rows=10, distinct(5)=7, null(5)=0.1]
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── stats: [rows=1]
+ │    │    ├── key: ()
+ │    │    └── tuple [type=tuple]
+ │    └── zip
+ │         └── function: generate_series [type=int, side-effects]
+ │              ├── const: 1 [type=int]
+ │              └── const: 4 [type=int]
  └── filters (true)
 
 opt
@@ -37,19 +71,268 @@ distinct-on
  ├── columns: a:1(string) b:2(int)
  ├── grouping columns: upper:1(string) generate_series:2(int)
  ├── side-effects
- ├── stats: [rows=1, distinct(1,2)=1, null(1,2)=0.199]
+ ├── stats: [rows=7, distinct(1,2)=7, null(1,2)=0.1]
  ├── key: (1,2)
  └── inner-join
       ├── columns: upper:1(string) generate_series:2(int)
       ├── side-effects
-      ├── stats: [rows=10, distinct(1,2)=1, null(1,2)=0.199]
-      ├── zip
+      ├── stats: [rows=10, distinct(1,2)=7, null(1,2)=0.1]
+      ├── project-set
       │    ├── columns: generate_series:2(int)
       │    ├── side-effects
-      │    ├── stats: [rows=10, distinct(2)=1, null(2)=0.1]
-      │    └── generate_series(1, 2) [type=int]
-      ├── zip
+      │    ├── stats: [rows=10, distinct(2)=7, null(2)=0.1]
+      │    ├── values
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── stats: [rows=1]
+      │    │    ├── key: ()
+      │    │    └── tuple [type=tuple]
+      │    └── zip
+      │         └── function: generate_series [type=int, side-effects]
+      │              ├── const: 1 [type=int]
+      │              └── const: 2 [type=int]
+      ├── project-set
       │    ├── columns: upper:1(string)
-      │    ├── stats: [rows=1, distinct(1)=1, null(1)=0.01]
-      │    └── upper('abc') [type=string]
+      │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+      │    ├── values
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── stats: [rows=1]
+      │    │    ├── key: ()
+      │    │    └── tuple [type=tuple]
+      │    └── zip
+      │         └── function: upper [type=string]
+      │              └── const: 'abc' [type=string]
       └── filters (true)
+
+opt colstat=3 colstat=(1,2,3)
+SELECT unnest(ARRAY[x,y]) FROM xy
+----
+project
+ ├── columns: unnest:3(int)
+ ├── side-effects
+ ├── stats: [rows=10000, distinct(3)=700, null(3)=100, distinct(1-3)=10000, null(1-3)=199]
+ └── project-set
+      ├── columns: x:1(int!null) y:2(int) unnest:3(int)
+      ├── side-effects
+      ├── stats: [rows=10000, distinct(3)=700, null(3)=100, distinct(1-3)=10000, null(1-3)=199]
+      ├── fd: (1)-->(2)
+      ├── scan xy
+      │    ├── columns: x:1(int!null) y:2(int)
+      │    ├── stats: [rows=1000, distinct(1,2)=990, null(1,2)=10]
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── zip
+           └── function: unnest [type=int, outer=(1,2), side-effects]
+                └── ARRAY[x, y] [type=int[]]
+
+opt colstat=3 colstat=4 colstat=(3, 4) colstat=(1, 3) colstat=(2, 4)
+SELECT xy.*, generate_series(x, y), generate_series(0, 1) FROM xy
+----
+project-set
+ ├── columns: x:1(int!null) y:2(int) generate_series:3(int) generate_series:4(int)
+ ├── side-effects
+ ├── stats: [rows=10000, distinct(3)=700, null(3)=100, distinct(4)=7, null(4)=100, distinct(1,3)=10000, null(1,3)=100, distinct(2,4)=700, null(2,4)=199, distinct(3,4)=4900, null(3,4)=199]
+ ├── fd: (1)-->(2)
+ ├── scan xy
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── zip
+      ├── function: generate_series [type=int, outer=(1,2), side-effects]
+      │    ├── variable: x [type=int]
+      │    └── variable: y [type=int]
+      └── function: generate_series [type=int, side-effects]
+           ├── const: 0 [type=int]
+           └── const: 1 [type=int]
+
+exec-ddl
+CREATE TABLE articles (
+  id INT PRIMARY KEY,
+  body STRING,
+  description STRING,
+  title STRING,
+  slug STRING,
+  tag_list STRING[],
+  user_id STRING,
+  created_at TIMESTAMP,
+  updated_at TIMESTAMP
+)
+----
+TABLE articles
+ ├── id int not null
+ ├── body string
+ ├── description string
+ ├── title string
+ ├── slug string
+ ├── tag_list string[]
+ ├── user_id string
+ ├── created_at timestamp
+ ├── updated_at timestamp
+ └── INDEX primary
+      └── id int not null
+
+# The following queries test the statistics for four different types of Zip
+# functions:
+#   1. correlated scalar functions -- upper(title)
+#   2. correlated generator functions -- unnest(tag_list)
+#   4. uncorrelated scalar functions -- lower('ABC')
+#   3. uncorrelated generator functions -- generate_series(0,1)
+#
+# They need to be tested with different queries at the moment due to
+# limitations with our testing infrastructure.
+
+opt
+SELECT id FROM articles WHERE title = ANY(
+  SELECT upper FROM ROWS FROM (upper(title), unnest(tag_list), generate_series(0,1), lower('ABC'))
+)
+----
+distinct-on
+ ├── columns: id:1(int!null)
+ ├── grouping columns: id:1(int!null)
+ ├── side-effects
+ ├── stats: [rows=95.617925, distinct(1)=95.617925, null(1)=0]
+ ├── key: (1)
+ └── select
+      ├── columns: id:1(int!null) title:4(string!null) tag_list:6(string[]) upper:10(string!null) unnest:11(string) generate_series:12(int) lower:13(string)
+      ├── side-effects
+      ├── stats: [rows=100, distinct(1)=95.617925, null(1)=0, distinct(4)=100, null(4)=0, distinct(10)=100, null(10)=0]
+      ├── fd: (1)-->(4,6), (4)==(10), (10)==(4)
+      ├── project-set
+      │    ├── columns: id:1(int!null) title:4(string) tag_list:6(string[]) upper:10(string) unnest:11(string) generate_series:12(int) lower:13(string)
+      │    ├── side-effects
+      │    ├── stats: [rows=10000, distinct(1)=1000, null(1)=0, distinct(4)=100, null(4)=100, distinct(10)=100, null(10)=9000]
+      │    ├── fd: (1)-->(4,6)
+      │    ├── scan articles
+      │    │    ├── columns: id:1(int!null) title:4(string) tag_list:6(string[])
+      │    │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(4)=100, null(4)=10]
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(4,6)
+      │    └── zip
+      │         ├── function: upper [type=string, outer=(4)]
+      │         │    └── variable: title [type=string]
+      │         ├── function: unnest [type=string, outer=(6), side-effects]
+      │         │    └── variable: tag_list [type=string[]]
+      │         ├── function: generate_series [type=int, side-effects]
+      │         │    ├── const: 0 [type=int]
+      │         │    └── const: 1 [type=int]
+      │         └── function: lower [type=string]
+      │              └── const: 'ABC' [type=string]
+      └── filters
+           └── title = upper [type=bool, outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
+
+opt
+SELECT id FROM articles WHERE title = ANY(
+  SELECT unnest FROM ROWS FROM (upper(title), unnest(tag_list), generate_series(0,1), lower('ABC'))
+)
+----
+distinct-on
+ ├── columns: id:1(int!null)
+ ├── grouping columns: id:1(int!null)
+ ├── side-effects
+ ├── stats: [rows=14.1942265, distinct(1)=14.1942265, null(1)=0]
+ ├── key: (1)
+ └── select
+      ├── columns: id:1(int!null) title:4(string!null) tag_list:6(string[]) upper:10(string) unnest:11(string!null) generate_series:12(int) lower:13(string)
+      ├── side-effects
+      ├── stats: [rows=14.2857143, distinct(1)=14.1942265, null(1)=0, distinct(4)=14.2857143, null(4)=0, distinct(11)=14.2857143, null(11)=0]
+      ├── fd: (1)-->(4,6), (4)==(11), (11)==(4)
+      ├── project-set
+      │    ├── columns: id:1(int!null) title:4(string) tag_list:6(string[]) upper:10(string) unnest:11(string) generate_series:12(int) lower:13(string)
+      │    ├── side-effects
+      │    ├── stats: [rows=10000, distinct(1)=1000, null(1)=0, distinct(4)=100, null(4)=100, distinct(11)=700, null(11)=100]
+      │    ├── fd: (1)-->(4,6)
+      │    ├── scan articles
+      │    │    ├── columns: id:1(int!null) title:4(string) tag_list:6(string[])
+      │    │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(4)=100, null(4)=10]
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(4,6)
+      │    └── zip
+      │         ├── function: upper [type=string, outer=(4)]
+      │         │    └── variable: title [type=string]
+      │         ├── function: unnest [type=string, outer=(6), side-effects]
+      │         │    └── variable: tag_list [type=string[]]
+      │         ├── function: generate_series [type=int, side-effects]
+      │         │    ├── const: 0 [type=int]
+      │         │    └── const: 1 [type=int]
+      │         └── function: lower [type=string]
+      │              └── const: 'ABC' [type=string]
+      └── filters
+           └── title = unnest [type=bool, outer=(4,11), constraints=(/4: (/NULL - ]; /11: (/NULL - ]), fd=(4)==(11), (11)==(4)]
+
+opt
+SELECT id FROM articles WHERE id = ANY(
+  SELECT generate_series FROM ROWS FROM (upper(title), unnest(tag_list), generate_series(0,1), lower('ABC'))
+)
+----
+distinct-on
+ ├── columns: id:1(int!null)
+ ├── grouping columns: id:1(int!null)
+ ├── side-effects
+ ├── stats: [rows=7, distinct(1)=7, null(1)=0]
+ ├── key: (1)
+ └── select
+      ├── columns: id:1(int!null) title:4(string) tag_list:6(string[]) upper:10(string) unnest:11(string) generate_series:12(int!null) lower:13(string)
+      ├── side-effects
+      ├── stats: [rows=10, distinct(1)=7, null(1)=0, distinct(12)=7, null(12)=0]
+      ├── fd: (1)-->(4,6), (1)==(12), (12)==(1)
+      ├── project-set
+      │    ├── columns: id:1(int!null) title:4(string) tag_list:6(string[]) upper:10(string) unnest:11(string) generate_series:12(int) lower:13(string)
+      │    ├── side-effects
+      │    ├── stats: [rows=10000, distinct(1)=1000, null(1)=0, distinct(12)=7, null(12)=100]
+      │    ├── fd: (1)-->(4,6)
+      │    ├── scan articles
+      │    │    ├── columns: id:1(int!null) title:4(string) tag_list:6(string[])
+      │    │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(4,6)
+      │    └── zip
+      │         ├── function: upper [type=string, outer=(4)]
+      │         │    └── variable: title [type=string]
+      │         ├── function: unnest [type=string, outer=(6), side-effects]
+      │         │    └── variable: tag_list [type=string[]]
+      │         ├── function: generate_series [type=int, side-effects]
+      │         │    ├── const: 0 [type=int]
+      │         │    └── const: 1 [type=int]
+      │         └── function: lower [type=string]
+      │              └── const: 'ABC' [type=string]
+      └── filters
+           └── id = generate_series [type=bool, outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
+
+opt
+SELECT id FROM articles WHERE title = ANY(
+  SELECT lower FROM ROWS FROM (upper(title), unnest(tag_list), generate_series(0,1), lower('ABC'))
+)
+----
+distinct-on
+ ├── columns: id:1(int!null)
+ ├── grouping columns: id:1(int!null)
+ ├── side-effects
+ ├── stats: [rows=95.617925, distinct(1)=95.617925, null(1)=0]
+ ├── key: (1)
+ └── select
+      ├── columns: id:1(int!null) title:4(string!null) tag_list:6(string[]) upper:10(string) unnest:11(string) generate_series:12(int) lower:13(string!null)
+      ├── side-effects
+      ├── stats: [rows=100, distinct(1)=95.617925, null(1)=0, distinct(4)=1, null(4)=0, distinct(13)=1, null(13)=0]
+      ├── fd: (1)-->(4,6), (4)==(13), (13)==(4)
+      ├── project-set
+      │    ├── columns: id:1(int!null) title:4(string) tag_list:6(string[]) upper:10(string) unnest:11(string) generate_series:12(int) lower:13(string)
+      │    ├── side-effects
+      │    ├── stats: [rows=10000, distinct(1)=1000, null(1)=0, distinct(4)=100, null(4)=100, distinct(13)=1, null(13)=9000]
+      │    ├── fd: (1)-->(4,6)
+      │    ├── scan articles
+      │    │    ├── columns: id:1(int!null) title:4(string) tag_list:6(string[])
+      │    │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(4)=100, null(4)=10]
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(4,6)
+      │    └── zip
+      │         ├── function: upper [type=string, outer=(4)]
+      │         │    └── variable: title [type=string]
+      │         ├── function: unnest [type=string, outer=(6), side-effects]
+      │         │    └── variable: tag_list [type=string[]]
+      │         ├── function: generate_series [type=int, side-effects]
+      │         │    ├── const: 0 [type=int]
+      │         │    └── const: 1 [type=int]
+      │         └── function: lower [type=string]
+      │              └── const: 'ABC' [type=string]
+      └── filters
+           └── title = lower [type=bool, outer=(4,13), constraints=(/4: (/NULL - ]; /13: (/NULL - ]), fd=(4)==(13), (13)==(4)]

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -754,6 +754,34 @@ func (c *CustomFuncs) LimitGeMaxRows(limit tree.Datum, input memo.RelExpr) bool 
 
 // ----------------------------------------------------------------------
 //
+// ProjectSet Rules
+//   Custom match and replace functions used with ProjectSet rules.
+//
+// ----------------------------------------------------------------------
+
+// IsZipCorrelated returns true if any element in the zip references
+// any of the given columns.
+func (c *CustomFuncs) IsZipCorrelated(zip memo.ZipExpr, cols opt.ColSet) bool {
+	for i := range zip {
+		if zip[i].ScalarProps(c.mem).OuterCols.Intersects(cols) {
+			return true
+		}
+	}
+	return false
+}
+
+// ZipOuterCols returns the union of all outer columns from the given
+// zip expressions.
+func (c *CustomFuncs) ZipOuterCols(zip memo.ZipExpr) opt.ColSet {
+	var colSet opt.ColSet
+	for i := range zip {
+		colSet.UnionWith(zip[i].ScalarProps(c.mem).OuterCols)
+	}
+	return colSet
+}
+
+// ----------------------------------------------------------------------
+//
 // Boolean Rules
 //   Custom match and replace functions used with bool.opt rules.
 //

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -45,6 +45,29 @@
 =>
 (ConstructNonApplyJoin (OpName) $left $right $on)
 
+# DecorrelateProjectSet pulls an input relation outside of a ProjectSet if the
+# input is not correlated with any of the functions in the ProjectSet. The
+# input is then cross-joined with a new ProjectSet, which contains the same
+# functions but has an empty input (a unary VALUES node).
+#
+# The advantage of this transformation is it means each of the functions in the
+# ProjectSet only need to be executed once in total, instead of once for each
+# input row.
+[DecorrelateProjectSet, Normalize]
+(ProjectSet
+    $input:^(Values)
+    $zip:* & ^(IsZipCorrelated $zip (OutputCols $input))
+)
+=>
+(InnerJoin
+    $input
+    (ProjectSet
+        (ConstructNoColsRow)
+        $zip
+    )
+    []
+)
+
 # TryDecorrelateSelect "pushes down" the join apply into the select operator,
 # in order to eliminate any correlation between the select filter list and the
 # left side of the join, and also to keep "digging" down to find and eliminate
@@ -445,7 +468,7 @@
     $right:* &
         (HasOuterCols $right) &
         (CanHaveZeroRows $right) & # Let EliminateExistsGroupBy match instead.
-        (GroupBy | DistinctOn | Project)
+        (GroupBy | DistinctOn | Project | ProjectSet)
     $on:*
 )
 =>
@@ -495,38 +518,31 @@
     (MakeOrderedGrouping (KeyCols $newLeft) $ordering)
 )
 
-# TryDecorrelateZip "pushes down" an outer InnerJoinApply operator into an inner
-# InnerJoinApply operator, in hopes of eliminating any correlation between the
-# Zip operator and the outer InnerJoinApply operator. Eventually, the hope is to
-# trigger the DecorrelateJoin pattern to turn JoinApply operators into non-apply
-# Join operators.
-#
-# This rule only matches Zip as $innerRight because other relational operators
-# can decorrelate by pushing parent joins down into an input operand. But Zip
-# does not have an input operand of its own, and so it uses InnerJoinApply as a
-# proxy for that, and pushes other operators down through that instead.
-#
-# TODO(andyk): Consider creating a single ProjectSet relational operator, rather
-#              than using InnerJoinApply + Zip, which seems fragile.
-[TryDecorrelateZip, Normalize]
+# TryDecorrelateProjectSet "pushes down" an InnerJoinApply operator into a
+# ProjectSet operator, in hopes of eliminating any correlation between the
+# ProjectSet operator and the InnerJoinApply operator. Eventually, the
+# hope is to trigger the DecorrelateJoin pattern to turn JoinApply operators
+# into non-apply Join operators.
+[TryDecorrelateProjectSet, Normalize]
 (InnerJoinApply
     $left:*
-    (InnerJoinApply
-        $innerLeft:*
-        $innerRight:(Zip)
-        $innerOn:*
+    (ProjectSet
+        $input:*
+        $zip:*
     )
     $on:*
 )
 =>
-(InnerJoinApply
-    (InnerJoinApply
-        $left
-        $innerLeft
-        []
+(Select
+    (ProjectSet
+        (InnerJoinApply
+            $left
+            $input
+            []
+        )
+        $zip
     )
-    $innerRight
-    (ConcatFilters $on $innerOn)
+    $on
 )
 
 # HoistSelectExists extracts existential subqueries from Select filters,
@@ -646,18 +662,19 @@
 =>
 (HoistValuesSubquery $rows $cols)
 
-# HoistZipSubquery extracts subqueries from zipped functions and joins them with
-# the Zip operator using an Apply join. This and other subquery hoisting
+# HoistProjectSetSubquery extracts subqueries from zipped functions and joins
+# them with the ProjectSet operator's input. This and other subquery hoisting
 # patterns create a single, top-level relational query with no nesting.
 #
 # This rule is marked as low priority for the same reason as HoistSelectExists.
-[HoistZipSubquery, Normalize, LowPriority]
-(Zip
-    $funcs:[ ... $item:* & (HasHoistableSubquery $item) ... ]
-    $cols:*
+[HoistProjectSetSubquery, Normalize, LowPriority]
+(ProjectSet
+    $input:*
+    $zip:[ ... $item:* & (HasHoistableSubquery $item) ... ]
 )
 =>
-(HoistZipSubquery $funcs $cols)
+(HoistProjectSetSubquery $input $zip)
+
 
 # NormalizeSelectAnyFilter rewrites an Any expression that is a top-level
 # conjunct in Select filters, turning it into an Exists expression. Any can be

--- a/pkg/sql/opt/norm/rules/prune_cols.opt
+++ b/pkg/sql/opt/norm/rules/prune_cols.opt
@@ -338,3 +338,28 @@
     (PruneCols $input $needed)
     $explainPrivate
 )
+
+# PruneProjectSetCols discards ProjectSet columns that are never used.
+[PruneProjectSetCols, Normalize]
+(Project
+    $input:(ProjectSet $innerInput:* $zip:*)
+    $projections:*
+    $passthrough:* &
+        (CanPruneCols
+            $input
+            $needed:(UnionCols3
+                (ZipOuterCols $zip)
+                (ProjectionOuterCols $projections)
+                $passthrough
+            )
+        )
+)
+=>
+(Project
+    (ProjectSet
+      (PruneCols $innerInput $needed)
+      $zip
+    )
+    $projections
+    $passthrough
+)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -83,6 +83,105 @@ anti-join (merge)
  └── filters (true)
 
 # --------------------------------------------------
+# DecorrelateProjectSet
+# --------------------------------------------------
+
+opt expect=DecorrelateProjectSet
+SELECT generate_series(0, 5) FROM xy
+----
+inner-join
+ ├── columns: generate_series:3(int)
+ ├── side-effects
+ ├── scan xy
+ ├── project-set
+ │    ├── columns: generate_series:3(int)
+ │    ├── side-effects
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── tuple [type=tuple]
+ │    └── zip
+ │         └── function: generate_series [type=int, side-effects]
+ │              ├── const: 0 [type=int]
+ │              └── const: 5 [type=int]
+ └── filters (true)
+
+opt expect=DecorrelateProjectSet
+SELECT * FROM a WHERE i IN (SELECT generate_series(k, i) FROM xy)
+----
+semi-join-apply
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ ├── side-effects
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── inner-join
+ │    ├── columns: generate_series:8(int)
+ │    ├── outer: (1,2)
+ │    ├── side-effects
+ │    ├── scan xy
+ │    ├── project-set
+ │    │    ├── columns: generate_series:8(int)
+ │    │    ├── outer: (1,2)
+ │    │    ├── side-effects
+ │    │    ├── values
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    └── tuple [type=tuple]
+ │    │    └── zip
+ │    │         └── function: generate_series [type=int, outer=(1,2), side-effects]
+ │    │              ├── variable: k [type=int]
+ │    │              └── variable: i [type=int]
+ │    └── filters (true)
+ └── filters
+      └── i = generate_series [type=bool, outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+
+opt expect=DecorrelateProjectSet
+SELECT generate_series(0, (SELECT generate_series(1,0) FROM xy)) FROM uv
+----
+inner-join
+ ├── columns: generate_series:6(int)
+ ├── side-effects
+ ├── scan uv
+ ├── project-set
+ │    ├── columns: generate_series:6(int)
+ │    ├── side-effects
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── tuple [type=tuple]
+ │    └── zip
+ │         └── function: generate_series [type=int, side-effects]
+ │              ├── const: 0 [type=int]
+ │              └── subquery [type=int]
+ │                   └── max1-row
+ │                        ├── columns: generate_series:5(int)
+ │                        ├── cardinality: [0 - 1]
+ │                        ├── side-effects
+ │                        ├── key: ()
+ │                        ├── fd: ()-->(5)
+ │                        └── inner-join
+ │                             ├── columns: generate_series:5(int)
+ │                             ├── side-effects
+ │                             ├── scan xy
+ │                             ├── project-set
+ │                             │    ├── columns: generate_series:5(int)
+ │                             │    ├── side-effects
+ │                             │    ├── values
+ │                             │    │    ├── cardinality: [1 - 1]
+ │                             │    │    ├── key: ()
+ │                             │    │    └── tuple [type=tuple]
+ │                             │    └── zip
+ │                             │         └── function: generate_series [type=int, side-effects]
+ │                             │              ├── const: 1 [type=int]
+ │                             │              └── const: 0 [type=int]
+ │                             └── filters (true)
+ └── filters (true)
+
+# --------------------------------------------------
 # TryDecorrelateSelect
 # --------------------------------------------------
 opt expect=TryDecorrelateSelect
@@ -1068,37 +1167,6 @@ project
       │         └── k = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
       └── filters
            └── u IS DISTINCT FROM i [type=bool, outer=(3,6)]
-
-opt expect=TryDecorrelateInnerLeftJoin
-SELECT generate_series(1, (SELECT u FROM uv WHERE u=x))
-FROM xy
-----
-project
- ├── columns: generate_series:5(int)
- ├── side-effects
- └── inner-join-apply
-      ├── columns: x:1(int!null) u:3(int) generate_series:5(int)
-      ├── side-effects
-      ├── left-join (merge)
-      │    ├── columns: x:1(int!null) u:3(int)
-      │    ├── left ordering: +1
-      │    ├── right ordering: +3
-      │    ├── key: (1,3)
-      │    ├── scan xy
-      │    │    ├── columns: x:1(int!null)
-      │    │    ├── key: (1)
-      │    │    └── ordering: +1
-      │    ├── scan uv
-      │    │    ├── columns: u:3(int!null)
-      │    │    ├── key: (3)
-      │    │    └── ordering: +3
-      │    └── filters (true)
-      ├── zip
-      │    ├── columns: generate_series:5(int)
-      │    ├── outer: (3)
-      │    ├── side-effects
-      │    └── generate_series(1, u) [type=int]
-      └── filters (true)
 
 # --------------------------------------------------
 # TryDecorrelateGroupBy
@@ -2087,6 +2155,35 @@ project
       │         └── COALESCE(u, 10) [type=int, outer=(8)]
       └── filters
            └── x = computed [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
+
+# Right input of SemiJoin is ProjectSet.
+opt expect=TryDecorrelateSemiJoin
+SELECT * FROM xy WHERE EXISTS(SELECT generate_series(x, 10), generate_series(y, 10))
+----
+group-by
+ ├── columns: x:1(int!null) y:2(int)
+ ├── grouping columns: x:1(int!null)
+ ├── side-effects
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── project-set
+ │    ├── columns: x:1(int!null) y:2(int) generate_series:3(int) generate_series:4(int)
+ │    ├── side-effects
+ │    ├── fd: (1)-->(2)
+ │    ├── scan xy
+ │    │    ├── columns: x:1(int!null) y:2(int)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    └── zip
+ │         ├── function: generate_series [type=int, outer=(1), side-effects]
+ │         │    ├── variable: x [type=int]
+ │         │    └── const: 10 [type=int]
+ │         └── function: generate_series [type=int, outer=(2), side-effects]
+ │              ├── variable: y [type=int]
+ │              └── const: 10 [type=int]
+ └── aggregations
+      └── const-agg [type=int, outer=(2)]
+           └── variable: y [type=int]
 
 # --------------------------------------------------
 # TryDecorrelateLimitOne
@@ -3741,16 +3838,16 @@ project
  └── projections
       └── variable: column1 [type=bool, outer=(8)]
 
-# --------------------------------------------------
-# HoistZipSubquery and TryDecorrelateZip
-# --------------------------------------------------
-opt expect=(HoistZipSubquery,TryDecorrelateZip)
+# ---------------------------------------------------
+# HoistProjectSetSubquery + TryDecorrelateProjectSet
+# ---------------------------------------------------
+opt expect=HoistProjectSetSubquery
 SELECT generate_series(1, (SELECT v FROM uv WHERE u=x)) FROM xy
 ----
 project
  ├── columns: generate_series:5(int)
  ├── side-effects
- └── inner-join-apply
+ └── project-set
       ├── columns: v:4(int) generate_series:5(int)
       ├── side-effects
       ├── project
@@ -3771,66 +3868,61 @@ project
       │         │    ├── fd: (3)-->(4)
       │         │    └── ordering: +3
       │         └── filters (true)
-      ├── zip
-      │    ├── columns: generate_series:5(int)
-      │    ├── outer: (4)
-      │    ├── side-effects
-      │    └── generate_series(1, v) [type=int]
-      └── filters (true)
+      └── zip
+           └── function: generate_series [type=int, outer=(4), side-effects]
+                ├── const: 1 [type=int]
+                └── variable: v [type=int]
 
 # Zip correlation within EXISTS.
-opt expect=HoistZipSubquery
+opt expect=(HoistProjectSetSubquery,TryDecorrelateSemiJoin,TryDecorrelateProjectSet)
 SELECT * FROM xy WHERE EXISTS(SELECT * FROM generate_series(1, (SELECT v FROM uv WHERE u=x)))
 ----
-semi-join-apply
+group-by
  ├── columns: x:1(int!null) y:2(int)
+ ├── grouping columns: x:1(int!null)
  ├── side-effects
  ├── key: (1)
  ├── fd: (1)-->(2)
- ├── scan xy
- │    ├── columns: x:1(int!null) y:2(int)
- │    ├── key: (1)
- │    └── fd: (1)-->(2)
- ├── inner-join-apply
- │    ├── columns: v:4(int) generate_series:5(int)
- │    ├── outer: (1)
+ ├── project-set
+ │    ├── columns: x:1(int!null) y:2(int) v:4(int) generate_series:5(int)
  │    ├── side-effects
+ │    ├── fd: (1)-->(2)
  │    ├── project
- │    │    ├── columns: v:4(int)
- │    │    ├── outer: (1)
- │    │    ├── cardinality: [1 - ]
- │    │    └── right-join
- │    │         ├── columns: u:3(int) v:4(int)
- │    │         ├── outer: (1)
- │    │         ├── cardinality: [1 - ]
- │    │         ├── key: (3)
- │    │         ├── fd: (3)-->(4)
+ │    │    ├── columns: x:1(int!null) y:2(int) v:4(int)
+ │    │    ├── fd: (1)-->(2)
+ │    │    └── left-join (merge)
+ │    │         ├── columns: x:1(int!null) y:2(int) u:3(int) v:4(int)
+ │    │         ├── left ordering: +1
+ │    │         ├── right ordering: +3
+ │    │         ├── key: (1,3)
+ │    │         ├── fd: (1)-->(2), (3)-->(4)
+ │    │         ├── scan xy
+ │    │         │    ├── columns: x:1(int!null) y:2(int)
+ │    │         │    ├── key: (1)
+ │    │         │    ├── fd: (1)-->(2)
+ │    │         │    └── ordering: +1
  │    │         ├── scan uv
  │    │         │    ├── columns: u:3(int!null) v:4(int)
  │    │         │    ├── key: (3)
- │    │         │    └── fd: (3)-->(4)
- │    │         ├── values
- │    │         │    ├── cardinality: [1 - 1]
- │    │         │    ├── key: ()
- │    │         │    └── tuple [type=tuple]
- │    │         └── filters
- │    │              └── u = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
- │    ├── zip
- │    │    ├── columns: generate_series:5(int)
- │    │    ├── outer: (4)
- │    │    ├── side-effects
- │    │    └── generate_series(1, v) [type=int]
- │    └── filters (true)
- └── filters (true)
+ │    │         │    ├── fd: (3)-->(4)
+ │    │         │    └── ordering: +3
+ │    │         └── filters (true)
+ │    └── zip
+ │         └── function: generate_series [type=int, outer=(4), side-effects]
+ │              ├── const: 1 [type=int]
+ │              └── variable: v [type=int]
+ └── aggregations
+      └── const-agg [type=int, outer=(2)]
+           └── variable: y [type=int]
 
 # Function contains multiple subqueries in arguments.
-opt expect=HoistZipSubquery
+opt expect=HoistProjectSetSubquery
 SELECT generate_series((select y FROM xy WHERE x=k), (SELECT v FROM uv WHERE u=k)) FROM a
 ----
 project
  ├── columns: generate_series:10(int)
  ├── side-effects
- └── inner-join-apply
+ └── project-set
       ├── columns: y:7(int) v:9(int) generate_series:10(int)
       ├── side-effects
       ├── project
@@ -3866,15 +3958,13 @@ project
       │         │    ├── fd: (8)-->(9)
       │         │    └── ordering: +8
       │         └── filters (true)
-      ├── zip
-      │    ├── columns: generate_series:10(int)
-      │    ├── outer: (7,9)
-      │    ├── side-effects
-      │    └── generate_series(y, v) [type=int]
-      └── filters (true)
+      └── zip
+           └── function: generate_series [type=int, outer=(7,9), side-effects]
+                ├── variable: y [type=int]
+                └── variable: v [type=int]
 
 # Multiple functions.
-opt expect=HoistZipSubquery
+opt expect=HoistProjectSetSubquery
 SELECT
     generate_series(1, (SELECT v FROM uv WHERE u=k)),
     information_schema._pg_expandarray(ARRAY[(SELECT x FROM xy WHERE x=k)])
@@ -3883,7 +3973,7 @@ FROM a
 project
  ├── columns: generate_series:8(int) information_schema._pg_expandarray:13(tuple{int AS x, int AS n})
  ├── side-effects
- ├── inner-join-apply
+ ├── project-set
  │    ├── columns: k:1(int!null) v:7(int) generate_series:8(int) xy.x:9(int) x:11(int) n:12(int)
  │    ├── side-effects
  │    ├── left-join (merge)
@@ -3915,15 +4005,226 @@ project
  │    │    │    ├── key: (9)
  │    │    │    └── ordering: +9
  │    │    └── filters (true)
- │    ├── zip
- │    │    ├── columns: generate_series:8(int) x:11(int) n:12(int)
- │    │    ├── outer: (7,9)
- │    │    ├── side-effects
- │    │    ├── generate_series(1, v) [type=int]
- │    │    └── information_schema._pg_expandarray(ARRAY[xy.x]) [type=tuple{int AS x, int AS n}]
- │    └── filters (true)
+ │    └── zip
+ │         ├── function: generate_series [type=int, outer=(7), side-effects]
+ │         │    ├── const: 1 [type=int]
+ │         │    └── variable: v [type=int]
+ │         └── function: information_schema._pg_expandarray [type=tuple{int AS x, int AS n}, outer=(9), side-effects]
+ │              └── ARRAY[xy.x] [type=int[]]
  └── projections
       └── ((x, n) AS x, n) [type=tuple{int AS x, int AS n}, outer=(11,12)]
+
+exec-ddl
+CREATE TABLE articles (
+  id INT PRIMARY KEY,
+  body STRING,
+  description STRING,
+  title STRING,
+  slug STRING,
+  tag_list STRING[],
+  user_id STRING,
+  created_at TIMESTAMP,
+  updated_at TIMESTAMP
+)
+----
+TABLE articles
+ ├── id int not null
+ ├── body string
+ ├── description string
+ ├── title string
+ ├── slug string
+ ├── tag_list string[]
+ ├── user_id string
+ ├── created_at timestamp
+ ├── updated_at timestamp
+ └── INDEX primary
+      └── id int not null
+
+# Regression test for #31706.
+opt expect=(TryDecorrelateSemiJoin,TryDecorrelateProjectSet)
+SELECT a0.id, a0.body, a0.description, a0.title, a0.slug, a0.tag_list, a0.user_id, a0.created_at, a0.updated_at
+    FROM articles AS a0
+   WHERE EXISTS(SELECT * FROM unnest(a0.tag_list) AS tag WHERE tag = 'dragons')
+ORDER BY a0.created_at
+   LIMIT 10
+  OFFSET 0;
+----
+limit
+ ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp)
+ ├── internal-ordering: +8
+ ├── cardinality: [0 - 10]
+ ├── side-effects
+ ├── key: (1)
+ ├── fd: (1)-->(2-9)
+ ├── ordering: +8
+ ├── offset
+ │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp)
+ │    ├── internal-ordering: +8
+ │    ├── side-effects
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-9)
+ │    ├── ordering: +8
+ │    ├── sort
+ │    │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp)
+ │    │    ├── side-effects
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-9)
+ │    │    ├── ordering: +8
+ │    │    └── group-by
+ │    │         ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp)
+ │    │         ├── grouping columns: id:1(int!null)
+ │    │         ├── side-effects
+ │    │         ├── key: (1)
+ │    │         ├── fd: (1)-->(2-9)
+ │    │         ├── select
+ │    │         │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp) unnest:10(string!null)
+ │    │         │    ├── side-effects
+ │    │         │    ├── fd: ()-->(10), (1)-->(2-9)
+ │    │         │    ├── project-set
+ │    │         │    │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp) unnest:10(string)
+ │    │         │    │    ├── side-effects
+ │    │         │    │    ├── fd: (1)-->(2-9)
+ │    │         │    │    ├── scan articles
+ │    │         │    │    │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp)
+ │    │         │    │    │    ├── key: (1)
+ │    │         │    │    │    └── fd: (1)-->(2-9)
+ │    │         │    │    └── zip
+ │    │         │    │         └── function: unnest [type=string, outer=(6), side-effects]
+ │    │         │    │              └── variable: tag_list [type=string[]]
+ │    │         │    └── filters
+ │    │         │         └── unnest = 'dragons' [type=bool, outer=(10), constraints=(/10: [/'dragons' - /'dragons']; tight), fd=()-->(10)]
+ │    │         └── aggregations
+ │    │              ├── const-agg [type=string, outer=(2)]
+ │    │              │    └── variable: body [type=string]
+ │    │              ├── const-agg [type=string, outer=(3)]
+ │    │              │    └── variable: description [type=string]
+ │    │              ├── const-agg [type=string, outer=(4)]
+ │    │              │    └── variable: title [type=string]
+ │    │              ├── const-agg [type=string, outer=(5)]
+ │    │              │    └── variable: slug [type=string]
+ │    │              ├── const-agg [type=string[], outer=(6)]
+ │    │              │    └── variable: tag_list [type=string[]]
+ │    │              ├── const-agg [type=string, outer=(7)]
+ │    │              │    └── variable: user_id [type=string]
+ │    │              ├── const-agg [type=timestamp, outer=(8)]
+ │    │              │    └── variable: created_at [type=timestamp]
+ │    │              └── const-agg [type=timestamp, outer=(9)]
+ │    │                   └── variable: updated_at [type=timestamp]
+ │    └── const: 0 [type=int]
+ └── const: 10 [type=int]
+
+opt expect=TryDecorrelateProjectSet
+SELECT * FROM articles, xy WHERE EXISTS(
+  SELECT * FROM ROWS FROM (generate_series(x, id), length(title), upper(title), unnest(tag_list))
+)
+----
+project
+ ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp) x:10(int!null) y:11(int)
+ ├── side-effects
+ ├── key: (1,10)
+ ├── fd: (1)-->(2-9), (10)-->(11), (1,10)-->(2-9,11)
+ └── select
+      ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp) x:10(int!null) y:11(int) true_agg:17(bool!null)
+      ├── side-effects
+      ├── key: (1,10)
+      ├── fd: (1)-->(2-9), (10)-->(11), (1,10)-->(2-9,11,17)
+      ├── group-by
+      │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp) x:10(int!null) y:11(int) true_agg:17(bool)
+      │    ├── grouping columns: id:1(int!null) x:10(int!null)
+      │    ├── side-effects
+      │    ├── key: (1,10)
+      │    ├── fd: (1)-->(2-9), (10)-->(11), (1,10)-->(2-9,11,17)
+      │    ├── project
+      │    │    ├── columns: true:16(bool!null) id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp) x:10(int!null) y:11(int)
+      │    │    ├── side-effects
+      │    │    ├── fd: ()-->(16), (1)-->(2-9), (10)-->(11)
+      │    │    ├── project-set
+      │    │    │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp) x:10(int!null) y:11(int) generate_series:12(int) length:13(int) upper:14(string) unnest:15(string)
+      │    │    │    ├── side-effects
+      │    │    │    ├── fd: (1)-->(2-9), (10)-->(11)
+      │    │    │    ├── inner-join
+      │    │    │    │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp) x:10(int!null) y:11(int)
+      │    │    │    │    ├── key: (1,10)
+      │    │    │    │    ├── fd: (1)-->(2-9), (10)-->(11)
+      │    │    │    │    ├── scan articles
+      │    │    │    │    │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp)
+      │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    └── fd: (1)-->(2-9)
+      │    │    │    │    ├── scan xy
+      │    │    │    │    │    ├── columns: x:10(int!null) y:11(int)
+      │    │    │    │    │    ├── key: (10)
+      │    │    │    │    │    └── fd: (10)-->(11)
+      │    │    │    │    └── filters (true)
+      │    │    │    └── zip
+      │    │    │         ├── function: generate_series [type=int, outer=(1,10), side-effects]
+      │    │    │         │    ├── variable: x [type=int]
+      │    │    │         │    └── variable: id [type=int]
+      │    │    │         ├── function: length [type=int, outer=(4)]
+      │    │    │         │    └── variable: title [type=string]
+      │    │    │         ├── function: upper [type=string, outer=(4)]
+      │    │    │         │    └── variable: title [type=string]
+      │    │    │         └── function: unnest [type=string, outer=(6), side-effects]
+      │    │    │              └── variable: tag_list [type=string[]]
+      │    │    └── projections
+      │    │         └── true [type=bool]
+      │    └── aggregations
+      │         ├── const-not-null-agg [type=bool, outer=(16)]
+      │         │    └── variable: true [type=bool]
+      │         ├── const-agg [type=int, outer=(11)]
+      │         │    └── variable: y [type=int]
+      │         ├── const-agg [type=string, outer=(2)]
+      │         │    └── variable: body [type=string]
+      │         ├── const-agg [type=string, outer=(3)]
+      │         │    └── variable: description [type=string]
+      │         ├── const-agg [type=string, outer=(4)]
+      │         │    └── variable: title [type=string]
+      │         ├── const-agg [type=string, outer=(5)]
+      │         │    └── variable: slug [type=string]
+      │         ├── const-agg [type=string[], outer=(6)]
+      │         │    └── variable: tag_list [type=string[]]
+      │         ├── const-agg [type=string, outer=(7)]
+      │         │    └── variable: user_id [type=string]
+      │         ├── const-agg [type=timestamp, outer=(8)]
+      │         │    └── variable: created_at [type=timestamp]
+      │         └── const-agg [type=timestamp, outer=(9)]
+      │              └── variable: updated_at [type=timestamp]
+      └── filters
+           └── true_agg IS NOT NULL [type=bool, outer=(17), constraints=(/17: (/NULL - ]; tight)]
+
+opt expect=TryDecorrelateProjectSet
+SELECT id FROM articles WHERE title = ANY(
+  SELECT unnest FROM ROWS FROM (upper(title), unnest(tag_list), generate_series(0,1), lower('ABC'))
+)
+----
+distinct-on
+ ├── columns: id:1(int!null)
+ ├── grouping columns: id:1(int!null)
+ ├── side-effects
+ ├── key: (1)
+ └── select
+      ├── columns: id:1(int!null) title:4(string!null) tag_list:6(string[]) upper:10(string) unnest:11(string!null) generate_series:12(int) lower:13(string)
+      ├── side-effects
+      ├── fd: (1)-->(4,6), (4)==(11), (11)==(4)
+      ├── project-set
+      │    ├── columns: id:1(int!null) title:4(string) tag_list:6(string[]) upper:10(string) unnest:11(string) generate_series:12(int) lower:13(string)
+      │    ├── side-effects
+      │    ├── fd: (1)-->(4,6)
+      │    ├── scan articles
+      │    │    ├── columns: id:1(int!null) title:4(string) tag_list:6(string[])
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(4,6)
+      │    └── zip
+      │         ├── function: upper [type=string, outer=(4)]
+      │         │    └── variable: title [type=string]
+      │         ├── function: unnest [type=string, outer=(6), side-effects]
+      │         │    └── variable: tag_list [type=string[]]
+      │         ├── function: generate_series [type=int, side-effects]
+      │         │    ├── const: 0 [type=int]
+      │         │    └── const: 1 [type=int]
+      │         └── function: lower [type=string]
+      │              └── const: 'ABC' [type=string]
+      └── filters
+           └── title = unnest [type=bool, outer=(4,11), constraints=(/4: (/NULL - ]; /11: (/NULL - ]), fd=(4)==(11), (11)==(4)]
 
 # --------------------------------------------------
 # NormalizeSelectAnyFilter + NormalizeJoinAnyFilter

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1554,3 +1554,49 @@ explain
            ├── key: (1)
            ├── fd: ()-->(2), (1)-->(3), (3)-->(1)
            └── ordering: +3 opt(2)
+
+# --------------------------------------------------
+# PruneProjectSetCols
+# --------------------------------------------------
+opt expect=PruneProjectSetCols
+SELECT a, b, generate_series(c, 10) FROM abcde
+----
+project
+ ├── columns: a:1(int!null) b:2(int) generate_series:6(int)
+ ├── side-effects
+ ├── fd: (1)-->(2)
+ └── project-set
+      ├── columns: a:1(int!null) b:2(int) c:3(int) generate_series:6(int)
+      ├── side-effects
+      ├── fd: (1)-->(2,3), (2,3)~~>(1)
+      ├── scan abcde@bc
+      │    ├── columns: a:1(int!null) b:2(int) c:3(int)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2,3), (2,3)~~>(1)
+      └── zip
+           └── function: generate_series [type=int, outer=(3), side-effects]
+                ├── variable: c [type=int]
+                └── const: 10 [type=int]
+
+opt expect=PruneProjectSetCols
+SELECT k FROM a WHERE EXISTS(SELECT * FROM ROWS FROM (generate_series(i, k), length(s)))
+----
+distinct-on
+ ├── columns: k:1(int!null)
+ ├── grouping columns: k:1(int!null)
+ ├── side-effects
+ ├── key: (1)
+ └── project-set
+      ├── columns: k:1(int!null) i:2(int) s:4(string) generate_series:5(int) length:6(int)
+      ├── side-effects
+      ├── fd: (1)-->(2,4)
+      ├── scan a
+      │    ├── columns: k:1(int!null) i:2(int) s:4(string)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2,4)
+      └── zip
+           ├── function: generate_series [type=int, outer=(1,2), side-effects]
+           │    ├── variable: i [type=int]
+           │    └── variable: k [type=int]
+           └── function: length [type=int, outer=(4)]
+                └── variable: s [type=string]

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -670,28 +670,24 @@ define RowNumberPrivate {
 	ColID ColumnID
 }
 
-# Zip represents a functional zip over generators a,b,c, which returns tuples of
+# ProjectSet represents a relational operator which zips through a list of
+# generators for every row of the input.
+#
+# As a reminder, a functional zip over generators a,b,c returns tuples of
 # values from a,b,c picked "simultaneously". NULLs are used when a generator is
-# "shorter" than another. In SQL, these generators can be either a generator
-# function such as generate_series(), or a scalar function such as
-# upper(). For example, consider this query:
+# "shorter" than another.  For example:
 #
-#    SELECT * FROM ROWS FROM (generate_series(0, 1), upper('abc'));
+#    zip([1,2,3], ['a','b']) = [(1,'a'), (2,'b'), (3, null)]
 #
-# It is equivalent to (Zip [(Function generate_series), (Function upper)]).
-# It produces:
+# ProjectSet corresponds to a relational operator project(R, a, b, c, ...)
+# which, for each row in R, produces all the rows produced by zip(a, b, c, ...)
+# with the values of R prefixed. Formally, this performs a lateral cross join
+# of R with zip(a,b,c).
 #
-#     generate_series | upper
-#    -----------------+-------
-#                   0 | ABC
-#                   1 | NULL
-#
-# In the Zip operation, Funcs represents the list of functions, and Cols
-# represents the columns output by the functions. Funcs and Cols might not be
-# the same length since a single function may output multiple columns
-# (e.g., pg_get_keywords() outputs three columns).
+# See the Zip header for more details.
 [Relational]
-define Zip {
-    Funcs ScalarListExpr
-    Cols  ColList
+define ProjectSet {
+    Input RelExpr
+    Zip   ZipExpr
 }
+

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -232,6 +232,55 @@ define FiltersItem {
     scalar ScalarProps
 }
 
+# Zip represents a functional zip over generators a,b,c, which returns tuples of
+# values from a,b,c picked "simultaneously". NULLs are used when a generator is
+# "shorter" than another. In SQL, these generators can be either generator
+# functions such as generate_series(), or scalar functions or expressions such
+# as upper() or CAST. For example, consider this query:
+#
+#    SELECT * FROM ROWS FROM (generate_series(0, 1), upper('abc'));
+#
+# It is equivalent to:
+#
+#    (Zip [
+#            (ZipItem (Function generate_series)),
+#            (ZipItem (Function upper))
+#         ]
+#    )
+#
+# It produces:
+#
+#     generate_series | upper
+#    -----------------+-------
+#                   0 | ABC
+#                   1 | NULL
+#
+[Scalar, List]
+define Zip {
+}
+
+# ZipItem contains a generator function or scalar expression that is contained
+# in a Zip. See the Zip header for more details.
+[Scalar, ListItem]
+define ZipItem {
+    Func ScalarExpr
+
+    _ ZipItemPrivate
+}
+
+# ZipItemPrivate contains the list of output columns for the generator function
+# or scalar expression in a ZipItem, as well as a set of lazily-populated
+# scalar properties that apply to the ZipItem. Cols is a list since a single
+# function may output multiple columns (e.g., pg_get_keywords() outputs three
+# columns).
+[Private]
+define ZipItemPrivate {
+    Cols ColList
+
+    # Lazily populated.
+    scalar ScalarProps
+}
+
 # And is the boolean conjunction operator that evalutes to true only if both of
 # its conditions evaluate to true.
 [Scalar, Boolean]

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -188,8 +188,8 @@ func (b *Builder) renameSource(as tree.AliasClause, scope *scope) {
 		noColNameSpecified := len(colAlias) == 0
 		if scope.isAnonymousTable() && noColNameSpecified {
 			// SRFs and scalar functions used as a data source are always wrapped in
-			// a Zip operation.
-			if zip, ok := scope.expr.(*memo.ZipExpr); ok && zip.Relational().OutputCols.Len() == 1 {
+			// a ProjectSet operation.
+			if ps, ok := scope.expr.(*memo.ProjectSetExpr); ok && ps.Relational().OutputCols.Len() == 1 {
 				colAlias = tree.NameList{as.Alias}
 			}
 		}

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -2858,16 +2858,14 @@ SELECT array_agg(generate_series(1, 2))
 ----
 scalar-group-by
  ├── columns: array_agg:2(int[])
- ├── inner-join-apply
+ ├── project-set
  │    ├── columns: generate_series:1(int)
  │    ├── values
  │    │    └── tuple [type=tuple]
- │    ├── zip
- │    │    ├── columns: generate_series:1(int)
- │    │    └── function: generate_series [type=int]
- │    │         ├── const: 1 [type=int]
- │    │         └── const: 2 [type=int]
- │    └── filters (true)
+ │    └── zip
+ │         └── function: generate_series [type=int]
+ │              ├── const: 1 [type=int]
+ │              └── const: 2 [type=int]
  └── aggregations
       └── array-agg [type=int[]]
            └── variable: generate_series [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -421,11 +421,14 @@ sort
  ├── ordering: +1
  └── project
       ├── columns: array:2(int[]) generate_series:1(int)
-      ├── zip
+      ├── project-set
       │    ├── columns: generate_series:1(int)
-      │    └── function: generate_series [type=int]
-      │         ├── const: 1 [type=int]
-      │         └── const: 1 [type=int]
+      │    ├── values
+      │    │    └── tuple [type=tuple]
+      │    └── zip
+      │         └── function: generate_series [type=int]
+      │              ├── const: 1 [type=int]
+      │              └── const: 1 [type=int]
       └── projections
            └── array: [type=int[]]
                 └── variable: generate_series [type=int]
@@ -438,11 +441,14 @@ sort
  ├── ordering: +1
  └── project
       ├── columns: array:2(int[]) generate_series:1(int)
-      ├── zip
+      ├── project-set
       │    ├── columns: generate_series:1(int)
-      │    └── function: generate_series [type=int]
-      │         ├── const: 1 [type=int]
-      │         └── const: 1 [type=int]
+      │    ├── values
+      │    │    └── tuple [type=tuple]
+      │    └── zip
+      │         └── function: generate_series [type=int]
+      │              ├── const: 1 [type=int]
+      │              └── const: 1 [type=int]
       └── projections
            └── array: [type=int[]]
                 └── variable: generate_series [type=int]
@@ -455,11 +461,14 @@ sort
  ├── ordering: +3
  └── project
       ├── columns: array:2(int[]) column3:3(int) generate_series:1(int)
-      ├── zip
+      ├── project-set
       │    ├── columns: generate_series:1(int)
-      │    └── function: generate_series [type=int]
-      │         ├── const: 1 [type=int]
-      │         └── const: 1 [type=int]
+      │    ├── values
+      │    │    └── tuple [type=tuple]
+      │    └── zip
+      │         └── function: generate_series [type=int]
+      │              ├── const: 1 [type=int]
+      │              └── const: 1 [type=int]
       └── projections
            ├── array: [type=int[]]
            │    └── variable: generate_series [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -926,16 +926,14 @@ project
            │         ├── sort
            │         │    ├── columns: generate_series:1(int)
            │         │    ├── ordering: -1
-           │         │    └── inner-join-apply
+           │         │    └── project-set
            │         │         ├── columns: generate_series:1(int)
            │         │         ├── values
            │         │         │    └── tuple [type=tuple]
-           │         │         ├── zip
-           │         │         │    ├── columns: generate_series:1(int)
-           │         │         │    └── function: generate_series [type=int]
-           │         │         │         ├── const: 1 [type=int]
-           │         │         │         └── const: 100 [type=int]
-           │         │         └── filters (true)
+           │         │         └── zip
+           │         │              └── function: generate_series [type=int]
+           │         │                   ├── const: 1 [type=int]
+           │         │                   └── const: 100 [type=int]
            │         └── aggregations
            │              └── array-agg [type=int[]]
            │                   └── variable: generate_series [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -5,57 +5,75 @@
 build
 SELECT * FROM generate_series(1, 3)
 ----
-zip
+project-set
  ├── columns: generate_series:1(int)
- └── function: generate_series [type=int]
-      ├── const: 1 [type=int]
-      └── const: 3 [type=int]
+ ├── values
+ │    └── tuple [type=tuple]
+ └── zip
+      └── function: generate_series [type=int]
+           ├── const: 1 [type=int]
+           └── const: 3 [type=int]
 
 build
 SELECT * FROM generate_series(1, 2), generate_series(1, 2)
 ----
 inner-join
  ├── columns: generate_series:1(int) generate_series:2(int)
- ├── zip
+ ├── project-set
  │    ├── columns: generate_series:1(int)
- │    └── function: generate_series [type=int]
- │         ├── const: 1 [type=int]
- │         └── const: 2 [type=int]
- ├── zip
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    └── zip
+ │         └── function: generate_series [type=int]
+ │              ├── const: 1 [type=int]
+ │              └── const: 2 [type=int]
+ ├── project-set
  │    ├── columns: generate_series:2(int)
- │    └── function: generate_series [type=int]
- │         ├── const: 1 [type=int]
- │         └── const: 2 [type=int]
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    └── zip
+ │         └── function: generate_series [type=int]
+ │              ├── const: 1 [type=int]
+ │              └── const: 2 [type=int]
  └── filters (true)
 
 build
 SELECT * FROM pg_catalog.generate_series(1, 3)
 ----
-zip
+project-set
  ├── columns: generate_series:1(int)
- └── function: generate_series [type=int]
-      ├── const: 1 [type=int]
-      └── const: 3 [type=int]
+ ├── values
+ │    └── tuple [type=tuple]
+ └── zip
+      └── function: generate_series [type=int]
+           ├── const: 1 [type=int]
+           └── const: 3 [type=int]
 
 build
 SELECT * FROM generate_series(1, 1) AS c(x)
 ----
-zip
+project-set
  ├── columns: x:1(int)
- └── function: generate_series [type=int]
-      ├── const: 1 [type=int]
-      └── const: 1 [type=int]
+ ├── values
+ │    └── tuple [type=tuple]
+ └── zip
+      └── function: generate_series [type=int]
+           ├── const: 1 [type=int]
+           └── const: 1 [type=int]
 
 build
 SELECT * FROM generate_series(1, 1) WITH ORDINALITY AS c(x, y)
 ----
 row-number
  ├── columns: x:1(int) y:2(int!null)
- └── zip
+ └── project-set
       ├── columns: generate_series:1(int)
-      └── function: generate_series [type=int]
-           ├── const: 1 [type=int]
-           └── const: 1 [type=int]
+      ├── values
+      │    └── tuple [type=tuple]
+      └── zip
+           └── function: generate_series [type=int]
+                ├── const: 1 [type=int]
+                └── const: 1 [type=int]
 
 build
 SELECT * FROM (VALUES (1)) LIMIT generate_series(1, 3)
@@ -67,19 +85,17 @@ error: generate_series(): generator functions are not allowed in LIMIT
 build
 SELECT generate_series(1, 2), generate_series(3, 4)
 ----
-inner-join-apply
+project-set
  ├── columns: generate_series:1(int) generate_series:2(int)
  ├── values
  │    └── tuple [type=tuple]
- ├── zip
- │    ├── columns: generate_series:1(int) generate_series:2(int)
- │    ├── function: generate_series [type=int]
- │    │    ├── const: 1 [type=int]
- │    │    └── const: 2 [type=int]
- │    └── function: generate_series [type=int]
- │         ├── const: 3 [type=int]
- │         └── const: 4 [type=int]
- └── filters (true)
+ └── zip
+      ├── function: generate_series [type=int]
+      │    ├── const: 1 [type=int]
+      │    └── const: 2 [type=int]
+      └── function: generate_series [type=int]
+           ├── const: 3 [type=int]
+           └── const: 4 [type=int]
 
 exec-ddl
 CREATE TABLE t (a string)
@@ -114,16 +130,22 @@ project
       │    │    └── columns: b:3(string) u.rowid:4(int!null)
       │    ├── inner-join
       │    │    ├── columns: generate_series:5(int) generate_series:6(int)
-      │    │    ├── zip
+      │    │    ├── project-set
       │    │    │    ├── columns: generate_series:5(int)
-      │    │    │    └── function: generate_series [type=int]
-      │    │    │         ├── const: 1 [type=int]
-      │    │    │         └── const: 2 [type=int]
-      │    │    ├── zip
+      │    │    │    ├── values
+      │    │    │    │    └── tuple [type=tuple]
+      │    │    │    └── zip
+      │    │    │         └── function: generate_series [type=int]
+      │    │    │              ├── const: 1 [type=int]
+      │    │    │              └── const: 2 [type=int]
+      │    │    ├── project-set
       │    │    │    ├── columns: generate_series:6(int)
-      │    │    │    └── function: generate_series [type=int]
-      │    │    │         ├── const: 3 [type=int]
-      │    │    │         └── const: 4 [type=int]
+      │    │    │    ├── values
+      │    │    │    │    └── tuple [type=tuple]
+      │    │    │    └── zip
+      │    │    │         └── function: generate_series [type=int]
+      │    │    │              ├── const: 3 [type=int]
+      │    │    │              └── const: 4 [type=int]
       │    │    └── filters (true)
       │    └── filters (true)
       └── filters (true)
@@ -133,11 +155,14 @@ SELECT 3 + x FROM generate_series(1,2) AS a(x)
 ----
 project
  ├── columns: "?column?":2(int)
- ├── zip
+ ├── project-set
  │    ├── columns: generate_series:1(int)
- │    └── function: generate_series [type=int]
- │         ├── const: 1 [type=int]
- │         └── const: 2 [type=int]
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    └── zip
+ │         └── function: generate_series [type=int]
+ │              ├── const: 1 [type=int]
+ │              └── const: 2 [type=int]
  └── projections
       └── plus [type=int]
            ├── const: 3 [type=int]
@@ -148,16 +173,14 @@ SELECT 3 + (3 * generate_series(1,3))
 ----
 project
  ├── columns: "?column?":2(int)
- ├── inner-join-apply
+ ├── project-set
  │    ├── columns: generate_series:1(int)
  │    ├── values
  │    │    └── tuple [type=tuple]
- │    ├── zip
- │    │    ├── columns: generate_series:1(int)
- │    │    └── function: generate_series [type=int]
- │    │         ├── const: 1 [type=int]
- │    │         └── const: 3 [type=int]
- │    └── filters (true)
+ │    └── zip
+ │         └── function: generate_series [type=int]
+ │              ├── const: 1 [type=int]
+ │              └── const: 3 [type=int]
  └── projections
       └── plus [type=int]
            ├── const: 3 [type=int]
@@ -170,48 +193,47 @@ project
 build
 SELECT * from unnest(ARRAY[1,2])
 ----
-zip
+project-set
  ├── columns: unnest:1(int)
- └── function: unnest [type=int]
-      └── array: [type=int[]]
-           ├── const: 1 [type=int]
-           └── const: 2 [type=int]
+ ├── values
+ │    └── tuple [type=tuple]
+ └── zip
+      └── function: unnest [type=int]
+           └── array: [type=int[]]
+                ├── const: 1 [type=int]
+                └── const: 2 [type=int]
 
 build
 SELECT unnest(ARRAY[1,2]), unnest(ARRAY['a', 'b'])
 ----
-inner-join-apply
+project-set
  ├── columns: unnest:1(int) unnest:2(string)
  ├── values
  │    └── tuple [type=tuple]
- ├── zip
- │    ├── columns: unnest:1(int) unnest:2(string)
- │    ├── function: unnest [type=int]
- │    │    └── array: [type=int[]]
- │    │         ├── const: 1 [type=int]
- │    │         └── const: 2 [type=int]
- │    └── function: unnest [type=string]
- │         └── array: [type=string[]]
- │              ├── const: 'a' [type=string]
- │              └── const: 'b' [type=string]
- └── filters (true)
+ └── zip
+      ├── function: unnest [type=int]
+      │    └── array: [type=int[]]
+      │         ├── const: 1 [type=int]
+      │         └── const: 2 [type=int]
+      └── function: unnest [type=string]
+           └── array: [type=string[]]
+                ├── const: 'a' [type=string]
+                └── const: 'b' [type=string]
 
 build
 SELECT unnest(ARRAY[3,4]) - 2
 ----
 project
  ├── columns: "?column?":2(int)
- ├── inner-join-apply
+ ├── project-set
  │    ├── columns: unnest:1(int)
  │    ├── values
  │    │    └── tuple [type=tuple]
- │    ├── zip
- │    │    ├── columns: unnest:1(int)
- │    │    └── function: unnest [type=int]
- │    │         └── array: [type=int[]]
- │    │              ├── const: 3 [type=int]
- │    │              └── const: 4 [type=int]
- │    └── filters (true)
+ │    └── zip
+ │         └── function: unnest [type=int]
+ │              └── array: [type=int[]]
+ │                   ├── const: 3 [type=int]
+ │                   └── const: 4 [type=int]
  └── projections
       └── minus [type=int]
            ├── variable: unnest [type=int]
@@ -222,20 +244,18 @@ SELECT 1 + generate_series(0, 1), unnest(ARRAY[2, 4]) - 1
 ----
 project
  ├── columns: "?column?":3(int) "?column?":4(int)
- ├── inner-join-apply
+ ├── project-set
  │    ├── columns: generate_series:1(int) unnest:2(int)
  │    ├── values
  │    │    └── tuple [type=tuple]
- │    ├── zip
- │    │    ├── columns: generate_series:1(int) unnest:2(int)
- │    │    ├── function: generate_series [type=int]
- │    │    │    ├── const: 0 [type=int]
- │    │    │    └── const: 1 [type=int]
- │    │    └── function: unnest [type=int]
- │    │         └── array: [type=int[]]
- │    │              ├── const: 2 [type=int]
- │    │              └── const: 4 [type=int]
- │    └── filters (true)
+ │    └── zip
+ │         ├── function: generate_series [type=int]
+ │         │    ├── const: 0 [type=int]
+ │         │    └── const: 1 [type=int]
+ │         └── function: unnest [type=int]
+ │              └── array: [type=int[]]
+ │                   ├── const: 2 [type=int]
+ │                   └── const: 4 [type=int]
  └── projections
       ├── plus [type=int]
       │    ├── const: 1 [type=int]
@@ -249,18 +269,16 @@ SELECT ascii(unnest(ARRAY['a', 'b', 'c']));
 ----
 project
  ├── columns: ascii:2(int)
- ├── inner-join-apply
+ ├── project-set
  │    ├── columns: unnest:1(string)
  │    ├── values
  │    │    └── tuple [type=tuple]
- │    ├── zip
- │    │    ├── columns: unnest:1(string)
- │    │    └── function: unnest [type=string]
- │    │         └── array: [type=string[]]
- │    │              ├── const: 'a' [type=string]
- │    │              ├── const: 'b' [type=string]
- │    │              └── const: 'c' [type=string]
- │    └── filters (true)
+ │    └── zip
+ │         └── function: unnest [type=string]
+ │              └── array: [type=string[]]
+ │                   ├── const: 'a' [type=string]
+ │                   ├── const: 'b' [type=string]
+ │                   └── const: 'c' [type=string]
  └── projections
       └── function: ascii [type=int]
            └── variable: unnest [type=string]
@@ -278,19 +296,17 @@ SELECT generate_series(1, 3) + generate_series(1, 3)
 ----
 project
  ├── columns: "?column?":3(int)
- ├── inner-join-apply
+ ├── project-set
  │    ├── columns: generate_series:1(int) generate_series:2(int)
  │    ├── values
  │    │    └── tuple [type=tuple]
- │    ├── zip
- │    │    ├── columns: generate_series:1(int) generate_series:2(int)
- │    │    ├── function: generate_series [type=int]
- │    │    │    ├── const: 1 [type=int]
- │    │    │    └── const: 3 [type=int]
- │    │    └── function: generate_series [type=int]
- │    │         ├── const: 1 [type=int]
- │    │         └── const: 3 [type=int]
- │    └── filters (true)
+ │    └── zip
+ │         ├── function: generate_series [type=int]
+ │         │    ├── const: 1 [type=int]
+ │         │    └── const: 3 [type=int]
+ │         └── function: generate_series [type=int]
+ │              ├── const: 1 [type=int]
+ │              └── const: 3 [type=int]
  └── projections
       └── plus [type=int]
            ├── variable: generate_series [type=int]
@@ -307,73 +323,75 @@ error (42703): column "generate_series" does not exist
 build
 SELECT * from generate_series(1, (select * from generate_series(1, 0)))
 ----
-zip
+project-set
  ├── columns: generate_series:2(int)
- └── function: generate_series [type=int]
-      ├── const: 1 [type=int]
-      └── subquery [type=int]
-           └── max1-row
-                ├── columns: generate_series:1(int)
-                └── zip
+ ├── values
+ │    └── tuple [type=tuple]
+ └── zip
+      └── function: generate_series [type=int]
+           ├── const: 1 [type=int]
+           └── subquery [type=int]
+                └── max1-row
                      ├── columns: generate_series:1(int)
-                     └── function: generate_series [type=int]
-                          ├── const: 1 [type=int]
-                          └── const: 0 [type=int]
+                     └── project-set
+                          ├── columns: generate_series:1(int)
+                          ├── values
+                          │    └── tuple [type=tuple]
+                          └── zip
+                               └── function: generate_series [type=int]
+                                    ├── const: 1 [type=int]
+                                    └── const: 0 [type=int]
 
 # The following query is designed to produce a null array argument to unnest
 # in a way that the type system can't detect before evaluation.
 build
 SELECT unnest((SELECT current_schemas((SELECT isnan((SELECT round(3.4, (SELECT generate_series(1, 0)))))))));
 ----
-inner-join-apply
+project-set
  ├── columns: unnest:5(string)
  ├── values
  │    └── tuple [type=tuple]
- ├── zip
- │    ├── columns: unnest:5(string)
- │    └── function: unnest [type=string]
- │         └── subquery [type=string[]]
- │              └── max1-row
- │                   ├── columns: current_schemas:4(string[])
- │                   └── project
- │                        ├── columns: current_schemas:4(string[])
- │                        ├── values
- │                        │    └── tuple [type=tuple]
- │                        └── projections
- │                             └── function: current_schemas [type=string[]]
- │                                  └── subquery [type=bool]
- │                                       └── max1-row
- │                                            ├── columns: isnan:3(bool)
- │                                            └── project
- │                                                 ├── columns: isnan:3(bool)
- │                                                 ├── values
- │                                                 │    └── tuple [type=tuple]
- │                                                 └── projections
- │                                                      └── function: isnan [type=bool]
- │                                                           └── subquery [type=decimal]
- │                                                                └── max1-row
- │                                                                     ├── columns: round:2(decimal)
- │                                                                     └── project
- │                                                                          ├── columns: round:2(decimal)
- │                                                                          ├── values
- │                                                                          │    └── tuple [type=tuple]
- │                                                                          └── projections
- │                                                                               └── function: round [type=decimal]
- │                                                                                    ├── const: 3.4 [type=decimal]
- │                                                                                    └── subquery [type=int]
- │                                                                                         └── max1-row
- │                                                                                              ├── columns: generate_series:1(int)
- │                                                                                              └── inner-join-apply
- │                                                                                                   ├── columns: generate_series:1(int)
- │                                                                                                   ├── values
- │                                                                                                   │    └── tuple [type=tuple]
- │                                                                                                   ├── zip
- │                                                                                                   │    ├── columns: generate_series:1(int)
- │                                                                                                   │    └── function: generate_series [type=int]
- │                                                                                                   │         ├── const: 1 [type=int]
- │                                                                                                   │         └── const: 0 [type=int]
- │                                                                                                   └── filters (true)
- └── filters (true)
+ └── zip
+      └── function: unnest [type=string]
+           └── subquery [type=string[]]
+                └── max1-row
+                     ├── columns: current_schemas:4(string[])
+                     └── project
+                          ├── columns: current_schemas:4(string[])
+                          ├── values
+                          │    └── tuple [type=tuple]
+                          └── projections
+                               └── function: current_schemas [type=string[]]
+                                    └── subquery [type=bool]
+                                         └── max1-row
+                                              ├── columns: isnan:3(bool)
+                                              └── project
+                                                   ├── columns: isnan:3(bool)
+                                                   ├── values
+                                                   │    └── tuple [type=tuple]
+                                                   └── projections
+                                                        └── function: isnan [type=bool]
+                                                             └── subquery [type=decimal]
+                                                                  └── max1-row
+                                                                       ├── columns: round:2(decimal)
+                                                                       └── project
+                                                                            ├── columns: round:2(decimal)
+                                                                            ├── values
+                                                                            │    └── tuple [type=tuple]
+                                                                            └── projections
+                                                                                 └── function: round [type=decimal]
+                                                                                      ├── const: 3.4 [type=decimal]
+                                                                                      └── subquery [type=int]
+                                                                                           └── max1-row
+                                                                                                ├── columns: generate_series:1(int)
+                                                                                                └── project-set
+                                                                                                     ├── columns: generate_series:1(int)
+                                                                                                     ├── values
+                                                                                                     │    └── tuple [type=tuple]
+                                                                                                     └── zip
+                                                                                                          └── function: generate_series [type=int]
+                                                                                                               ├── const: 1 [type=int]
+                                                                                                               └── const: 0 [type=int]
 
 # pg_get_keywords
 
@@ -386,9 +404,12 @@ sort
  ├── ordering: +1
  └── select
       ├── columns: word:1(string!null) catcode:2(string) catdesc:3(string)
-      ├── zip
+      ├── project-set
       │    ├── columns: word:1(string) catcode:2(string) catdesc:3(string)
-      │    └── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
+      │    ├── values
+      │    │    └── tuple [type=tuple]
+      │    └── zip
+      │         └── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
       └── filters
            └── in [type=bool]
                 ├── variable: word [type=string]
@@ -407,21 +428,30 @@ limit
  ├── columns: a:1(int) b:2(int) word:3(string) catcode:4(string) catdesc:5(string)
  ├── inner-join
  │    ├── columns: generate_series:1(int) unnest:2(int) word:3(string) catcode:4(string) catdesc:5(string)
- │    ├── zip
+ │    ├── project-set
  │    │    ├── columns: generate_series:1(int)
- │    │    └── function: generate_series [type=int]
- │    │         ├── const: 1 [type=int]
- │    │         └── const: 1 [type=int]
+ │    │    ├── values
+ │    │    │    └── tuple [type=tuple]
+ │    │    └── zip
+ │    │         └── function: generate_series [type=int]
+ │    │              ├── const: 1 [type=int]
+ │    │              └── const: 1 [type=int]
  │    ├── inner-join
  │    │    ├── columns: unnest:2(int) word:3(string) catcode:4(string) catdesc:5(string)
- │    │    ├── zip
+ │    │    ├── project-set
  │    │    │    ├── columns: unnest:2(int)
- │    │    │    └── function: unnest [type=int]
- │    │    │         └── array: [type=int[]]
- │    │    │              └── const: 1 [type=int]
- │    │    ├── zip
+ │    │    │    ├── values
+ │    │    │    │    └── tuple [type=tuple]
+ │    │    │    └── zip
+ │    │    │         └── function: unnest [type=int]
+ │    │    │              └── array: [type=int[]]
+ │    │    │                   └── const: 1 [type=int]
+ │    │    ├── project-set
  │    │    │    ├── columns: word:3(string) catcode:4(string) catdesc:5(string)
- │    │    │    └── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
+ │    │    │    ├── values
+ │    │    │    │    └── tuple [type=tuple]
+ │    │    │    └── zip
+ │    │    │         └── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
  │    │    └── filters (true)
  │    └── filters (true)
  └── const: 0 [type=int]
@@ -434,14 +464,12 @@ limit
  ├── columns: "?column?":4(string!null) pg_get_keywords:5(tuple{string AS word, string AS catcode, string AS catdesc}) "?column?":6(string!null)
  ├── project
  │    ├── columns: "?column?":4(string!null) pg_get_keywords:5(tuple{string AS word, string AS catcode, string AS catdesc}) "?column?":6(string!null)
- │    ├── inner-join-apply
+ │    ├── project-set
  │    │    ├── columns: word:1(string) catcode:2(string) catdesc:3(string)
  │    │    ├── values
  │    │    │    └── tuple [type=tuple]
- │    │    ├── zip
- │    │    │    ├── columns: word:1(string) catcode:2(string) catdesc:3(string)
- │    │    │    └── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
- │    │    └── filters (true)
+ │    │    └── zip
+ │    │         └── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
  │    └── projections
  │         ├── const: 'a' [type=string]
  │         ├── tuple [type=tuple{string AS word, string AS catcode, string AS catdesc}]
@@ -458,14 +486,12 @@ limit
  ├── columns: "?column?":4(string!null) b:5(tuple{string AS word, string AS catcode, string AS catdesc}) "?column?":6(string!null)
  ├── project
  │    ├── columns: "?column?":4(string!null) b:5(tuple{string AS word, string AS catcode, string AS catdesc}) "?column?":6(string!null)
- │    ├── inner-join-apply
+ │    ├── project-set
  │    │    ├── columns: word:1(string) catcode:2(string) catdesc:3(string)
  │    │    ├── values
  │    │    │    └── tuple [type=tuple]
- │    │    ├── zip
- │    │    │    ├── columns: word:1(string) catcode:2(string) catdesc:3(string)
- │    │    │    └── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
- │    │    └── filters (true)
+ │    │    └── zip
+ │    │         └── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
  │    └── projections
  │         ├── const: 'a' [type=string]
  │         ├── tuple [type=tuple{string AS word, string AS catcode, string AS catdesc}]
@@ -484,12 +510,11 @@ limit
  ├── columns: "?column?":1(string!null) b:2(tuple) "?column?":3(string!null)
  ├── project
  │    ├── columns: "?column?":1(string!null) b:2(tuple) "?column?":3(string!null)
- │    ├── inner-join-apply
+ │    ├── project-set
  │    │    ├── values
  │    │    │    └── tuple [type=tuple]
- │    │    ├── zip
- │    │    │    └── function: crdb_internal.unary_table [type=tuple]
- │    │    └── filters (true)
+ │    │    └── zip
+ │    │         └── function: crdb_internal.unary_table [type=tuple]
  │    └── projections
  │         ├── const: 'a' [type=string]
  │         ├── tuple [type=tuple]
@@ -502,10 +527,13 @@ limit
 build
 SELECT * FROM upper('abc')
 ----
-zip
+project-set
  ├── columns: upper:1(string)
- └── function: upper [type=string]
-      └── const: 'abc' [type=string]
+ ├── values
+ │    └── tuple [type=tuple]
+ └── zip
+      └── function: upper [type=string]
+           └── const: 'abc' [type=string]
 
 # current_schema
 
@@ -514,9 +542,12 @@ SELECT * FROM current_schema() WITH ORDINALITY AS a(b)
 ----
 row-number
  ├── columns: b:1(string) ordinality:2(int!null)
- └── zip
+ └── project-set
       ├── columns: current_schema:1(string)
-      └── function: current_schema [type=string]
+      ├── values
+      │    └── tuple [type=tuple]
+      └── zip
+           └── function: current_schema [type=string]
 
 # expandArray
 
@@ -525,17 +556,15 @@ SELECT information_schema._pg_expandarray(ARRAY['b', 'a'])
 ----
 project
  ├── columns: information_schema._pg_expandarray:3(tuple{string AS x, int AS n})
- ├── inner-join-apply
+ ├── project-set
  │    ├── columns: x:1(string) n:2(int)
  │    ├── values
  │    │    └── tuple [type=tuple]
- │    ├── zip
- │    │    ├── columns: x:1(string) n:2(int)
- │    │    └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
- │    │         └── array: [type=string[]]
- │    │              ├── const: 'b' [type=string]
- │    │              └── const: 'a' [type=string]
- │    └── filters (true)
+ │    └── zip
+ │         └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
+ │              └── array: [type=string[]]
+ │                   ├── const: 'b' [type=string]
+ │                   └── const: 'a' [type=string]
  └── projections
       └── tuple [type=tuple{string AS x, int AS n}]
            ├── variable: x [type=string]
@@ -544,12 +573,15 @@ project
 build
 SELECT * FROM information_schema._pg_expandarray(ARRAY['b', 'a'])
 ----
-zip
+project-set
  ├── columns: x:1(string) n:2(int)
- └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
-      └── array: [type=string[]]
-           ├── const: 'b' [type=string]
-           └── const: 'a' [type=string]
+ ├── values
+ │    └── tuple [type=tuple]
+ └── zip
+      └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
+           └── array: [type=string[]]
+                ├── const: 'b' [type=string]
+                └── const: 'a' [type=string]
 
 # srf_accessor
 
@@ -573,18 +605,16 @@ SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).*
 ----
 project
  ├── columns: x:3(string) n:4(int)
- ├── inner-join-apply
+ ├── project-set
  │    ├── columns: x:1(string) n:2(int)
  │    ├── values
  │    │    └── tuple [type=tuple]
- │    ├── zip
- │    │    ├── columns: x:1(string) n:2(int)
- │    │    └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
- │    │         └── array: [type=string[]]
- │    │              ├── const: 'c' [type=string]
- │    │              ├── const: 'b' [type=string]
- │    │              └── const: 'a' [type=string]
- │    └── filters (true)
+ │    └── zip
+ │         └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
+ │              └── array: [type=string[]]
+ │                   ├── const: 'c' [type=string]
+ │                   ├── const: 'b' [type=string]
+ │                   └── const: 'a' [type=string]
  └── projections
       ├── column-access: 0 [type=string]
       │    └── tuple [type=tuple{string AS x, int AS n}]
@@ -600,18 +630,16 @@ SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).x
 ----
 project
  ├── columns: x:3(string)
- ├── inner-join-apply
+ ├── project-set
  │    ├── columns: x:1(string) n:2(int)
  │    ├── values
  │    │    └── tuple [type=tuple]
- │    ├── zip
- │    │    ├── columns: x:1(string) n:2(int)
- │    │    └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
- │    │         └── array: [type=string[]]
- │    │              ├── const: 'c' [type=string]
- │    │              ├── const: 'b' [type=string]
- │    │              └── const: 'a' [type=string]
- │    └── filters (true)
+ │    └── zip
+ │         └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
+ │              └── array: [type=string[]]
+ │                   ├── const: 'c' [type=string]
+ │                   ├── const: 'b' [type=string]
+ │                   └── const: 'a' [type=string]
  └── projections
       └── column-access: 0 [type=string]
            └── tuple [type=tuple{string AS x, int AS n}]
@@ -628,8 +656,25 @@ SELECT temp.n from information_schema._pg_expandarray(ARRAY['c','b','a']) AS tem
 ----
 project
  ├── columns: n:2(int)
- └── zip
+ └── project-set
       ├── columns: x:1(string) n:2(int)
+      ├── values
+      │    └── tuple [type=tuple]
+      └── zip
+           └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
+                └── array: [type=string[]]
+                     ├── const: 'c' [type=string]
+                     ├── const: 'b' [type=string]
+                     └── const: 'a' [type=string]
+
+build
+SELECT temp.* from information_schema._pg_expandarray(ARRAY['c','b','a']) AS temp;
+----
+project-set
+ ├── columns: x:1(string) n:2(int)
+ ├── values
+ │    └── tuple [type=tuple]
+ └── zip
       └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
            └── array: [type=string[]]
                 ├── const: 'c' [type=string]
@@ -637,59 +682,57 @@ project
                 └── const: 'a' [type=string]
 
 build
-SELECT temp.* from information_schema._pg_expandarray(ARRAY['c','b','a']) AS temp;
-----
-zip
- ├── columns: x:1(string) n:2(int)
- └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
-      └── array: [type=string[]]
-           ├── const: 'c' [type=string]
-           ├── const: 'b' [type=string]
-           └── const: 'a' [type=string]
-
-build
 SELECT * from information_schema._pg_expandarray(ARRAY['c','b','a']) AS temp;
 ----
-zip
+project-set
  ├── columns: x:1(string) n:2(int)
- └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
-      └── array: [type=string[]]
-           ├── const: 'c' [type=string]
-           ├── const: 'b' [type=string]
-           └── const: 'a' [type=string]
+ ├── values
+ │    └── tuple [type=tuple]
+ └── zip
+      └── function: information_schema._pg_expandarray [type=tuple{string AS x, int AS n}]
+           └── array: [type=string[]]
+                ├── const: 'c' [type=string]
+                ├── const: 'b' [type=string]
+                └── const: 'a' [type=string]
 
 # generate_subscripts
 
 build
 SELECT * FROM generate_subscripts(ARRAY[3,2,1])
 ----
-zip
+project-set
  ├── columns: generate_subscripts:1(int)
- └── function: generate_subscripts [type=int]
-      └── array: [type=int[]]
-           ├── const: 3 [type=int]
-           ├── const: 2 [type=int]
-           └── const: 1 [type=int]
+ ├── values
+ │    └── tuple [type=tuple]
+ └── zip
+      └── function: generate_subscripts [type=int]
+           └── array: [type=int[]]
+                ├── const: 3 [type=int]
+                ├── const: 2 [type=int]
+                └── const: 1 [type=int]
 
 # Zip with multiple SRFs.
 build
 SELECT * FROM
 ROWS FROM (generate_series(0, 1), generate_series(1, 3), pg_get_keywords(), unnest(ARRAY['a', 'b', 'c']))
 ----
-zip
+project-set
  ├── columns: generate_series:1(int) generate_series:2(int) word:3(string) catcode:4(string) catdesc:5(string) unnest:6(string)
- ├── function: generate_series [type=int]
- │    ├── const: 0 [type=int]
- │    └── const: 1 [type=int]
- ├── function: generate_series [type=int]
- │    ├── const: 1 [type=int]
- │    └── const: 3 [type=int]
- ├── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
- └── function: unnest [type=string]
-      └── array: [type=string[]]
-           ├── const: 'a' [type=string]
-           ├── const: 'b' [type=string]
-           └── const: 'c' [type=string]
+ ├── values
+ │    └── tuple [type=tuple]
+ └── zip
+      ├── function: generate_series [type=int]
+      │    ├── const: 0 [type=int]
+      │    └── const: 1 [type=int]
+      ├── function: generate_series [type=int]
+      │    ├── const: 1 [type=int]
+      │    └── const: 3 [type=int]
+      ├── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
+      └── function: unnest [type=string]
+           └── array: [type=string[]]
+                ├── const: 'a' [type=string]
+                ├── const: 'b' [type=string]
+                └── const: 'c' [type=string]
 
 # Don't rename columns if the zip contains two functions.
 build
@@ -701,24 +744,33 @@ inner-join
  ├── columns: a:1(string) upper:2(string) generate_series:3(int) c:4(int)
  ├── inner-join
  │    ├── columns: upper:1(string) upper:2(string) generate_series:3(int)
- │    ├── zip
+ │    ├── project-set
  │    │    ├── columns: upper:1(string)
- │    │    └── function: upper [type=string]
- │    │         └── const: 'abc' [type=string]
- │    ├── zip
+ │    │    ├── values
+ │    │    │    └── tuple [type=tuple]
+ │    │    └── zip
+ │    │         └── function: upper [type=string]
+ │    │              └── const: 'abc' [type=string]
+ │    ├── project-set
  │    │    ├── columns: upper:2(string) generate_series:3(int)
- │    │    ├── function: upper [type=string]
- │    │    │    └── const: 'def' [type=string]
- │    │    └── function: generate_series [type=int]
- │    │         ├── const: 1 [type=int]
- │    │         └── const: 3 [type=int]
+ │    │    ├── values
+ │    │    │    └── tuple [type=tuple]
+ │    │    └── zip
+ │    │         ├── function: upper [type=string]
+ │    │         │    └── const: 'def' [type=string]
+ │    │         └── function: generate_series [type=int]
+ │    │              ├── const: 1 [type=int]
+ │    │              └── const: 3 [type=int]
  │    └── filters
  │         └── true [type=bool]
- ├── zip
+ ├── project-set
  │    ├── columns: generate_series:4(int)
- │    └── function: generate_series [type=int]
- │         ├── const: 1 [type=int]
- │         └── const: 4 [type=int]
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    └── zip
+ │         └── function: generate_series [type=int]
+ │              ├── const: 1 [type=int]
+ │              └── const: 4 [type=int]
  └── filters
       └── true [type=bool]
 
@@ -764,17 +816,15 @@ project
                                ├── columns: generate_series:8(int)
                                ├── project
                                │    ├── columns: generate_series:8(int)
-                               │    └── inner-join-apply
+                               │    └── project-set
                                │         ├── columns: b:6(string) u.rowid:7(int!null) generate_series:8(int)
                                │         ├── scan u
                                │         │    └── columns: b:6(string) u.rowid:7(int!null)
-                               │         ├── zip
-                               │         │    ├── columns: generate_series:8(int)
-                               │         │    └── function: generate_series [type=int]
-                               │         │         ├── const: 0 [type=int]
-                               │         │         └── cast: INT [type=int]
-                               │         │              └── variable: b [type=string]
-                               │         └── filters (true)
+                               │         └── zip
+                               │              └── function: generate_series [type=int]
+                               │                   ├── const: 0 [type=int]
+                               │                   └── cast: INT [type=int]
+                               │                        └── variable: b [type=string]
                                └── const: 1 [type=int]
 
 build
@@ -782,38 +832,34 @@ SELECT generate_series((SELECT generate_subscripts(ARRAY[a, a||b]) FROM t, u), 1
 ----
 project
  ├── columns: generate_series:8(int)
- └── inner-join-apply
+ └── project-set
       ├── columns: t.a:1(string) t.rowid:2(int!null) generate_series:8(int)
       ├── scan t
       │    └── columns: t.a:1(string) t.rowid:2(int!null)
-      ├── zip
-      │    ├── columns: generate_series:8(int)
-      │    └── function: generate_series [type=int]
-      │         ├── subquery [type=int]
-      │         │    └── max1-row
-      │         │         ├── columns: generate_subscripts:7(int)
-      │         │         └── project
-      │         │              ├── columns: generate_subscripts:7(int)
-      │         │              └── inner-join-apply
-      │         │                   ├── columns: t.a:3(string) t.rowid:4(int!null) b:5(string) u.rowid:6(int!null) generate_subscripts:7(int)
-      │         │                   ├── inner-join
-      │         │                   │    ├── columns: t.a:3(string) t.rowid:4(int!null) b:5(string) u.rowid:6(int!null)
-      │         │                   │    ├── scan t
-      │         │                   │    │    └── columns: t.a:3(string) t.rowid:4(int!null)
-      │         │                   │    ├── scan u
-      │         │                   │    │    └── columns: b:5(string) u.rowid:6(int!null)
-      │         │                   │    └── filters (true)
-      │         │                   ├── zip
-      │         │                   │    ├── columns: generate_subscripts:7(int)
-      │         │                   │    └── function: generate_subscripts [type=int]
-      │         │                   │         └── array: [type=string[]]
-      │         │                   │              ├── variable: t.a [type=string]
-      │         │                   │              └── concat [type=string]
-      │         │                   │                   ├── variable: t.a [type=string]
-      │         │                   │                   └── variable: b [type=string]
-      │         │                   └── filters (true)
-      │         └── const: 100 [type=int]
-      └── filters (true)
+      └── zip
+           └── function: generate_series [type=int]
+                ├── subquery [type=int]
+                │    └── max1-row
+                │         ├── columns: generate_subscripts:7(int)
+                │         └── project
+                │              ├── columns: generate_subscripts:7(int)
+                │              └── project-set
+                │                   ├── columns: t.a:3(string) t.rowid:4(int!null) b:5(string) u.rowid:6(int!null) generate_subscripts:7(int)
+                │                   ├── inner-join
+                │                   │    ├── columns: t.a:3(string) t.rowid:4(int!null) b:5(string) u.rowid:6(int!null)
+                │                   │    ├── scan t
+                │                   │    │    └── columns: t.a:3(string) t.rowid:4(int!null)
+                │                   │    ├── scan u
+                │                   │    │    └── columns: b:5(string) u.rowid:6(int!null)
+                │                   │    └── filters (true)
+                │                   └── zip
+                │                        └── function: generate_subscripts [type=int]
+                │                             └── array: [type=string[]]
+                │                                  ├── variable: t.a [type=string]
+                │                                  └── concat [type=string]
+                │                                       ├── variable: t.a [type=string]
+                │                                       └── variable: b [type=string]
+                └── const: 100 [type=int]
 
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, j JSON, k JSON, m JSON, n JSON)
@@ -837,30 +883,26 @@ FROM a
 ----
 project
  ├── columns: json_array_elements:6(jsonb) jsonb_each:19(tuple{string AS key, jsonb AS value}) jsonb_object_keys:20(string) generate_series:21(int)
- ├── inner-join-apply
+ ├── project-set
  │    ├── columns: a.x:1(int!null) a.j:2(jsonb) a.k:3(jsonb) a.m:4(jsonb) a.n:5(jsonb) json_array_elements:6(jsonb)
  │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.j:2(jsonb) a.k:3(jsonb) a.m:4(jsonb) a.n:5(jsonb)
- │    ├── zip
- │    │    ├── columns: json_array_elements:6(jsonb)
- │    │    └── function: json_array_elements [type=jsonb]
- │    │         └── variable: a.j [type=jsonb]
- │    └── filters (true)
+ │    └── zip
+ │         └── function: json_array_elements [type=jsonb]
+ │              └── variable: a.j [type=jsonb]
  └── projections
       ├── subquery [type=tuple{string AS key, jsonb AS value}]
       │    └── max1-row
       │         ├── columns: jsonb_each:9(tuple{string AS key, jsonb AS value})
       │         └── project
       │              ├── columns: jsonb_each:9(tuple{string AS key, jsonb AS value})
-      │              ├── inner-join-apply
+      │              ├── project-set
       │              │    ├── columns: key:7(string) value:8(jsonb)
       │              │    ├── values
       │              │    │    └── tuple [type=tuple]
-      │              │    ├── zip
-      │              │    │    ├── columns: key:7(string) value:8(jsonb)
-      │              │    │    └── function: jsonb_each [type=tuple{string AS key, jsonb AS value}]
-      │              │    │         └── variable: a.k [type=jsonb]
-      │              │    └── filters (true)
+      │              │    └── zip
+      │              │         └── function: jsonb_each [type=tuple{string AS key, jsonb AS value}]
+      │              │              └── variable: a.k [type=jsonb]
       │              └── projections
       │                   └── tuple [type=tuple{string AS key, jsonb AS value}]
       │                        ├── variable: key [type=string]
@@ -870,44 +912,41 @@ project
       │         ├── columns: jsonb_object_keys:15(string)
       │         └── project
       │              ├── columns: jsonb_object_keys:15(string)
-      │              └── inner-join-apply
+      │              └── project-set
       │                   ├── columns: a.x:10(int!null) a.j:11(jsonb) a.k:12(jsonb) a.m:13(jsonb) a.n:14(jsonb) jsonb_object_keys:15(string)
       │                   ├── scan a
       │                   │    └── columns: a.x:10(int!null) a.j:11(jsonb) a.k:12(jsonb) a.m:13(jsonb) a.n:14(jsonb)
-      │                   ├── zip
-      │                   │    ├── columns: jsonb_object_keys:15(string)
-      │                   │    └── function: jsonb_object_keys [type=string]
-      │                   │         └── variable: a.m [type=jsonb]
-      │                   └── filters (true)
+      │                   └── zip
+      │                        └── function: jsonb_object_keys [type=string]
+      │                             └── variable: a.m [type=jsonb]
       └── subquery [type=int]
            └── max1-row
                 ├── columns: generate_series:18(int)
-                └── inner-join-apply
+                └── project-set
                      ├── columns: generate_series:18(int)
                      ├── values
                      │    └── tuple [type=tuple]
-                     ├── zip
-                     │    ├── columns: generate_series:18(int)
-                     │    └── function: generate_series [type=int]
-                     │         ├── subquery [type=int]
-                     │         │    └── max1-row
-                     │         │         ├── columns: generate_series:17(int)
-                     │         │         └── project
-                     │         │              ├── columns: generate_series:17(int)
-                     │         │              └── inner-join-apply
-                     │         │                   ├── columns: jsonb_array_elements_text:16(string) generate_series:17(int)
-                     │         │                   ├── zip
-                     │         │                   │    ├── columns: jsonb_array_elements_text:16(string)
-                     │         │                   │    └── function: jsonb_array_elements_text [type=string]
-                     │         │                   │         └── variable: a.n [type=jsonb]
-                     │         │                   ├── zip
-                     │         │                   │    ├── columns: generate_series:17(int)
-                     │         │                   │    └── function: generate_series [type=int]
-                     │         │                   │         ├── variable: a.x [type=int]
-                     │         │                   │         └── const: 100 [type=int]
-                     │         │                   └── filters (true)
-                     │         └── const: 1000 [type=int]
-                     └── filters (true)
+                     └── zip
+                          └── function: generate_series [type=int]
+                               ├── subquery [type=int]
+                               │    └── max1-row
+                               │         ├── columns: generate_series:17(int)
+                               │         └── project
+                               │              ├── columns: generate_series:17(int)
+                               │              └── project-set
+                               │                   ├── columns: jsonb_array_elements_text:16(string) generate_series:17(int)
+                               │                   ├── project-set
+                               │                   │    ├── columns: jsonb_array_elements_text:16(string)
+                               │                   │    ├── values
+                               │                   │    │    └── tuple [type=tuple]
+                               │                   │    └── zip
+                               │                   │         └── function: jsonb_array_elements_text [type=string]
+                               │                   │              └── variable: a.n [type=jsonb]
+                               │                   └── zip
+                               │                        └── function: generate_series [type=int]
+                               │                             ├── variable: a.x [type=int]
+                               │                             └── const: 100 [type=int]
+                               └── const: 1000 [type=int]
 
 # Regression test for #30412.
 build
@@ -929,7 +968,10 @@ error (42803): column "x" must appear in the GROUP BY clause or be used in an ag
 build
 SELECT * FROM ROWS FROM (CAST('string' AS SERIAL2[])) AS ident
 ----
-zip
+project-set
  ├── columns: ident:1(int[])
- └── cast: SERIAL2[] [type=int[]]
-      └── const: 'string' [type=string]
+ ├── values
+ │    └── tuple [type=tuple]
+ └── zip
+      └── cast: SERIAL2[] [type=int[]]
+           └── const: 'string' [type=string]

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -139,8 +139,8 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *props.Physical) m
 	case opt.RowNumberOp:
 		cost = c.computeRowNumberCost(candidate.(*memo.RowNumberExpr))
 
-	case opt.ZipOp:
-		cost = c.computeZipCost(candidate.(*memo.ZipExpr))
+	case opt.ProjectSetOp:
+		cost = c.computeProjectSetCost(candidate.(*memo.ProjectSetExpr))
 
 	case opt.ExplainOp:
 		// Technically, the cost of an Explain operation is independent of the cost
@@ -358,9 +358,9 @@ func (c *coster) computeRowNumberCost(rowNum *memo.RowNumberExpr) memo.Cost {
 	return cost
 }
 
-func (c *coster) computeZipCost(zip *memo.ZipExpr) memo.Cost {
+func (c *coster) computeProjectSetCost(projectSet *memo.ProjectSetExpr) memo.Cost {
 	// Add the CPU cost of emitting the rows.
-	cost := memo.Cost(zip.Relational().Stats.RowCount) * cpuCostFactor
+	cost := memo.Cost(projectSet.Relational().Stats.RowCount) * cpuCostFactor
 	return cost
 }
 

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -801,10 +801,16 @@ project
  │    │    │    ├── columns: column5:5(uuid) json_array_elements:4(jsonb)
  │    │    │    ├── side-effects
  │    │    │    ├── fd: (4)-->(5)
- │    │    │    ├── zip
+ │    │    │    ├── project-set
  │    │    │    │    ├── columns: json_array_elements:4(jsonb)
  │    │    │    │    ├── side-effects
- │    │    │    │    └── json_array_elements('[{"person_id": "8e5dc104-9f38-4255-9283-fd080be16c57", "product_id": "a739c2d3-edec-413b-88d8-9c31d0414b1e"}, {"person_id": "308686c4-7415-4c2d-92d5-25b39a1c84e2", "product_id": "3f12802d-5b0f-43d7-a0d0-12ac8e88cb18"}]') [type=jsonb]
+ │    │    │    │    ├── values
+ │    │    │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    └── tuple [type=tuple]
+ │    │    │    │    └── zip
+ │    │    │    │         └── function: json_array_elements [type=jsonb, side-effects]
+ │    │    │    │              └── const: '[{"person_id": "8e5dc104-9f38-4255-9283-fd080be16c57", "product_id": "a739c2d3-edec-413b-88d8-9c31d0414b1e"}, {"person_id": "308686c4-7415-4c2d-92d5-25b39a1c84e2", "product_id": "3f12802d-5b0f-43d7-a0d0-12ac8e88cb18"}]' [type=jsonb]
  │    │    │    └── projections
  │    │    │         └── (json_array_elements->>'secondary_id')::UUID [type=uuid, outer=(4)]
  │    │    └── filters (true)


### PR DESCRIPTION
This commit creates a new relational operator called ProjectSet,
which zips through a list of generators for every row of the input.

As a reminder, a functional zip over generators a,b,c returns tuples of
values from a,b,c picked "simultaneously". NULLs are used when a generator is
"shorter" than another.  For example:

   zip([1,2,3], ['a','b']) = [(1,'a'), (2,'b'), (3, null)]

ProjectSet corresponds to a relational operator project(R, a, b, c, ...)
which, for each row in R, produces all the rows produced by zip(a, b, c, ...)
with the values of R prefixed. Formally, this performs a lateral cross join
of R with zip(a,b,c).

This operator replaces Zip, which was a non-standard relational operator in
the optimizer. Zip had to be joined with its input via an InnerJoinApply cross
join, which caused some difficulties in creating decorrelation patterns. As a
result, certain queries were not decorrelated that should have been fairly
easy to decorrelate.

As part of this commit, the decorrelation patterns have been updated to
allow decorrelation of generator functions inside EXISTS.

Fixes #31706

Release note (sql change): Many queries containing a correlated EXISTS
subquery with a generator function can now be decorrelated and executed
successfully. Previously, these queries caused a decorrelation error.