### PR TITLE
exec: add sumInt64Agg

### DIFF
--- a/pkg/sql/distsqlrun/columnarizer.go
+++ b/pkg/sql/distsqlrun/columnarizer.go
@@ -55,11 +55,7 @@ func newColumnarizer(flowCtx *FlowCtx, processorID int32, input RowSource) (*col
 }
 
 func (c *columnarizer) Init() {
-	outputTypes := c.OutputTypes()
-	typs := make([]types.T, len(outputTypes))
-	for i := range typs {
-		typs[i] = types.FromColumnType(outputTypes[i])
-	}
+	typs := types.FromColumnTypes(c.OutputTypes())
 	c.batch = exec.NewMemBatch(typs)
 	c.buffered = make(sqlbase.EncDatumRows, exec.ColBatchSize)
 	for i := range c.buffered {

--- a/pkg/sql/exec/sum_int64_agg.go
+++ b/pkg/sql/exec/sum_int64_agg.go
@@ -1,0 +1,169 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+// sumInt64Agg takes two input columns, one bool column which specifies whether
+// the current position is a new group and a corresponding batch of int64s. It
+// outputs in one column the sum of each group.
+type sumInt64Agg struct {
+	input Operator
+
+	scratch struct {
+		// ColBatch is the batch to return.
+		ColBatch
+		// vec points at the only column in ColBatch that we are updating.
+		vec []int64
+	}
+
+	// carry is non-zero if we have an accumulated sum from the last batch but we
+	// were unable to output it to the output batch.
+	carry int64
+
+	// nextBatch is set when the batch we are returning hits the size limit. This
+	// variable will point to the remaining upstream batch that needs to be
+	// processed in the next iteration.
+	nextBatch ColBatch
+	resumeIdx uint16
+
+	// outputBatchSize is ColBatchSize by default.
+	outputBatchSize uint16
+}
+
+var _ Operator = &sumInt64Agg{}
+
+func (a *sumInt64Agg) initWithBatchSize(batchSize uint16) {
+	a.scratch.ColBatch = NewMemBatch([]types.T{types.Int64})
+	a.scratch.vec = a.scratch.ColBatch.ColVec(0).Int64()
+	a.outputBatchSize = batchSize
+	a.input.Init()
+}
+
+func (a *sumInt64Agg) Init() {
+	a.initWithBatchSize(ColBatchSize)
+}
+
+// next is a utility function that abstracts the behavior of resuming a batch
+// if the aggregator's output capacity is hit.
+func (a *sumInt64Agg) next() (uint16, ColBatch) {
+	if a.nextBatch != nil {
+		resumeIdx := a.resumeIdx
+		nextBatch := a.nextBatch
+		a.resumeIdx = 0
+		a.nextBatch = nil
+		return resumeIdx, nextBatch
+	}
+	a.resumeIdx = 0
+	return a.resumeIdx, a.input.Next()
+}
+
+var zeroInt64Batch = make([]int64, ColBatchSize)
+
+// Next returns the next ColBatch.
+func (a *sumInt64Agg) Next() ColBatch {
+	// curIdx acts as a cursor over the output batch.
+	curIdx := -1
+	// Re-initialize the output batch.
+	copy(a.scratch.vec, zeroInt64Batch[:a.outputBatchSize])
+	for curIdx < int(a.outputBatchSize) {
+		resumeIdx, batch := a.next()
+		if batch.Length() == 0 {
+			// Finalize the last batch.
+			curIdx++
+			break
+		}
+
+		groups, ints, sel := batch.ColVec(0).Bool(), batch.ColVec(1).Int64(), batch.Selection()
+
+		if curIdx == -1 {
+			// When curIdx == -1, the output batch has not been touched. We need to
+			// determine what state we are in and perform any initialization needed.
+			if resumeIdx != 0 {
+				// We hit a new group in the last iteration and had no capacity to
+				// initialize the sum in the output batch. This initial value is set in
+				// the carry value.
+				a.scratch.vec[0] = a.carry
+			}
+			firstIdx := uint16(0)
+			if len(sel) > 0 {
+				firstIdx = sel[0]
+			}
+			// We overwrite the indicator of a new group if there is one in the groups
+			// to be processed to avoid incrementing curIdx.
+			if groups[firstIdx] {
+				groups[firstIdx] = false
+			}
+			curIdx = 0
+		}
+
+		// toSum represents the last value read from the ints to sum. On every
+		// iteration of the loop, the value that was previously read is added to the
+		// current position in the output batch. The reason one cannot increment the
+		// current index when finding a new group and then write the sum to it is
+		// that in the case where we find a new group when we are at the end of the
+		// current batch, incrementing the index and accessing the output buffer
+		// would result in a panic. In these cases, we save the sum into a.carry
+		// and add it to the new output buffer on the next call to Next().
+		// TODO(asubiotto): Slicing the input column/selection vector would be more
+		// efficient. We could also allocate 2*ColBatchSize for the output batch to
+		// not have to worry about bounds checking the output batch.
+		toSum := int64(0)
+		if sel != nil {
+			for ; resumeIdx < batch.Length() && curIdx < int(a.outputBatchSize); resumeIdx++ {
+				i := sel[resumeIdx]
+				a.scratch.vec[curIdx] += toSum
+				// This if statement is optimized out. See
+				// https://github.com/golang/go/issues/6011#issuecomment-254303032
+				x := 0
+				if groups[i] {
+					x = 1
+				}
+				curIdx += x
+				toSum = ints[i]
+			}
+		} else {
+			i := resumeIdx
+			for ; i < batch.Length() && curIdx < int(a.outputBatchSize); i++ {
+				a.scratch.vec[curIdx] += toSum
+				// This if statement is optimized out. See
+				// https://github.com/golang/go/issues/6011#issuecomment-254303032
+				x := 0
+				if groups[i] {
+					x = 1
+				}
+				curIdx += x
+				toSum = ints[i]
+			}
+			resumeIdx = i
+		}
+
+		if curIdx == int(a.outputBatchSize) {
+			// We hit a new group but do not have space in the output batch to add
+			// it.
+			a.resumeIdx = resumeIdx
+			a.nextBatch = batch
+			a.carry = toSum
+		} else {
+			// curIdx is valid, flush the sum and loop again.
+			a.scratch.vec[curIdx] += toSum
+		}
+	}
+
+	a.scratch.SetLength(uint16(curIdx))
+	return a.scratch
+}

--- a/pkg/sql/exec/sum_int_test.go
+++ b/pkg/sql/exec/sum_int_test.go
@@ -1,0 +1,189 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestSumInt(t *testing.T) {
+	testCases := []struct {
+		input    []tuple
+		expected []tuple
+		// batchSize if not 0 is passed in to newOpTestInput to divide the input.
+		batchSize       uint16
+		outputBatchSize uint16
+		name            string
+	}{
+		{
+			input: tuples{
+				{true, 1},
+			},
+			expected: tuples{
+				{1},
+			},
+			batchSize:       1,
+			outputBatchSize: 1,
+			name:            "OneTuple",
+		},
+		{
+			input: tuples{
+				{true, 1},
+				{false, 2},
+			},
+			expected: tuples{
+				{3},
+			},
+			name: "OneBatchOneGroup",
+		},
+		{
+			input: tuples{
+				{true, 1},
+				{false, 0},
+				{true, 3},
+				{true, 1},
+			},
+			expected: tuples{
+				{1},
+				{3},
+				{1},
+			},
+			name: "OneBatchMultiGroup",
+		},
+		{
+			input: tuples{
+				{true, 1},
+				{false, 2},
+				{false, 3},
+				{true, 4},
+				{false, 5},
+			},
+			expected: tuples{
+				{6},
+				{9},
+			},
+			batchSize: 1,
+			name:      "CarryBetweenInputBatches",
+		},
+		{
+			input: tuples{
+				{true, 1},
+				{false, 2},
+				{false, 3},
+				{false, 4},
+				{true, 5},
+				{true, 6},
+			},
+			expected: tuples{
+				{10},
+				{5},
+				{6},
+			},
+			batchSize:       3,
+			outputBatchSize: 1,
+			name:            "CarryBetweenOutputBatches",
+		},
+	}
+
+	// Run tests with deliberate batch sizes and no selection vectors.
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			batchSize := tc.batchSize
+			if batchSize == 0 {
+				batchSize = ColBatchSize
+			}
+
+			outputBatchSize := tc.outputBatchSize
+			if outputBatchSize == 0 {
+				outputBatchSize = ColBatchSize
+			}
+
+			tupleSource := newOpTestInput(batchSize, tc.input)
+			a := &sumInt64Agg{
+				input: tupleSource,
+			}
+			a.initWithBatchSize(outputBatchSize)
+
+			out := newOpTestOutput(a, []int{0}, tc.expected)
+			if err := out.Verify(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+
+	// Run test with random selection vectors and different batch sizes.
+	for _, tc := range testCases {
+		tc.name = fmt.Sprintf("%s/Random", tc.name)
+		t.Run(tc.name, func(t *testing.T) {
+			runTests(t, tc.input, nil, func(t *testing.T, input Operator) {
+				a := &sumInt64Agg{
+					input: input,
+				}
+				outputBatchSize := tc.outputBatchSize
+				if outputBatchSize == 0 {
+					outputBatchSize = ColBatchSize
+				}
+				a.initWithBatchSize(outputBatchSize)
+
+				out := newOpTestOutput(a, []int{0}, tc.expected)
+				if err := out.Verify(); err != nil {
+					t.Fatal(err)
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkSumInt(b *testing.B) {
+	rng, _ := randutil.NewPseudoRand()
+
+	for _, groupSize := range []int{1, 2, ColBatchSize / 2, ColBatchSize} {
+		for _, numInputBatches := range []int{1, 2, 32, 64} {
+			batch := NewMemBatch([]types.T{types.Bool, types.Int64})
+			groups, ints := batch.ColVec(0).Bool(), batch.ColVec(1).Int64()
+			for i := 0; i < ColBatchSize; i++ {
+				ints[i] = rng.Int63()
+				groups[i] = false
+				if groupSize == 1 || i%groupSize == 0 {
+					groups[i] = true
+				}
+			}
+			batch.SetLength(ColBatchSize)
+			source := newRepeatableBatchSource(batch)
+
+			a := &sumInt64Agg{
+				input: source,
+			}
+			a.Init()
+
+			b.Run(
+				fmt.Sprintf("groupSize=%d/numInputBatches=%d", groupSize, numInputBatches),
+				func(b *testing.B) {
+					// Only count the int64 column.
+					b.SetBytes(int64(8 * ColBatchSize * numInputBatches))
+					for i := 0; i < b.N; i++ {
+						source.resetBatchesToReturn(numInputBatches)
+						// Exhaust aggregator until all batches have been read.
+						for b := a.Next(); b.Length() != 0; b = a.Next() {
+						}
+					}
+				})
+		}
+	}
+}

--- a/pkg/sql/exec/types/types.go
+++ b/pkg/sql/exec/types/types.go
@@ -76,6 +76,16 @@ func FromColumnType(ct sqlbase.ColumnType) T {
 	return Unhandled
 }
 
+// FromColumnTypes calls FromColumnType on each element of cts, returning the
+// resulting slice.
+func FromColumnTypes(cts []sqlbase.ColumnType) []T {
+	typs := make([]T, len(cts))
+	for i := range typs {
+		typs[i] = FromColumnType(cts[i])
+	}
+	return typs
+}
+
 // FromGoType returns the type for a Go value, if applicable. Shouldn't be used at
 // runtime.
 func FromGoType(v interface{}) T {

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -270,8 +270,10 @@ func assertTuplesEquals(expected tuples, actual tuples) error {
 // repeatableBatchSource is an Operator that returns the same batch forever.
 type repeatableBatchSource struct {
 	internalBatch ColBatch
+	batchLen      uint16
 
-	batchLen uint16
+	batchesToReturn int
+	batchesReturned int
 }
 
 var _ Operator = &repeatableBatchSource{}
@@ -287,11 +289,21 @@ func newRepeatableBatchSource(batch ColBatch) *repeatableBatchSource {
 
 func (s *repeatableBatchSource) Next() ColBatch {
 	s.internalBatch.SetSelection(false)
-	s.internalBatch.SetLength(s.batchLen)
+	s.batchesReturned++
+	if s.batchesToReturn != 0 && s.batchesReturned > s.batchesToReturn {
+		s.internalBatch.SetLength(0)
+	} else {
+		s.internalBatch.SetLength(s.batchLen)
+	}
 	return s.internalBatch
 }
 
 func (s *repeatableBatchSource) Init() {}
+
+func (s *repeatableBatchSource) resetBatchesToReturn(b int) {
+	s.batchesToReturn = b
+	s.batchesReturned = 0
+}
 
 func TestOpTestInputOutput(t *testing.T) {
 	input := tuples{


### PR DESCRIPTION
This operator consumes a column of bools and a column of int64s, where the bools indicate a new group. For each group, this operator accumulates the sum of the associated int64s.

This operator will be templated later.

```
BenchmarkSumInt/groupSize=1/numInputBatches=1-8         	  200000	      6643 ns/op	1233.13 MB/s
BenchmarkSumInt/groupSize=1/numInputBatches=2-8         	  100000	     12689 ns/op	1291.11 MB/s
BenchmarkSumInt/groupSize=1/numInputBatches=32-8        	   10000	    190247 ns/op	1377.91 MB/s
BenchmarkSumInt/groupSize=1/numInputBatches=64-8        	    5000	    401202 ns/op	1306.79 MB/s
BenchmarkSumInt/groupSize=2/numInputBatches=1-8         	  200000	      6610 ns/op	1239.29 MB/s
BenchmarkSumInt/groupSize=2/numInputBatches=2-8         	  100000	     12240 ns/op	1338.46 MB/s
BenchmarkSumInt/groupSize=2/numInputBatches=32-8        	   10000	    177775 ns/op	1474.58 MB/s
BenchmarkSumInt/groupSize=2/numInputBatches=64-8        	    5000	    351800 ns/op	1490.30 MB/s
BenchmarkSumInt/groupSize=512/numInputBatches=1-8       	  200000	      6737 ns/op	1215.90 MB/s
BenchmarkSumInt/groupSize=512/numInputBatches=2-8       	  200000	     11735 ns/op	1396.10 MB/s
BenchmarkSumInt/groupSize=512/numInputBatches=32-8      	   10000	    161915 ns/op	1619.02 MB/s
BenchmarkSumInt/groupSize=512/numInputBatches=64-8      	    5000	    321052 ns/op	1633.03 MB/s
BenchmarkSumInt/groupSize=1024/numInputBatches=1-8      	  200000	      6707 ns/op	1221.38 MB/s
BenchmarkSumInt/groupSize=1024/numInputBatches=2-8      	  200000	     11795 ns/op	1388.99 MB/s
BenchmarkSumInt/groupSize=1024/numInputBatches=32-8     	   10000	    159267 ns/op	1645.93 MB/s
BenchmarkSumInt/groupSize=1024/numInputBatches=64-8     	    5000	    318549 ns/op	1645.86 MB/s
```