### PR TITLE
storage: adjust raft log size correctly when replacing sideloaded entries

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4334,11 +4334,12 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		purgeTerm := rd.Entries[0].Term - 1
 		lastPurge := prevLastIndex // old end of the log, include in deletion
 		for i := firstPurge; i <= lastPurge; i++ {
-			err := r.raftMu.sideloaded.Purge(ctx, i, purgeTerm)
+			size, err := r.raftMu.sideloaded.Purge(ctx, i, purgeTerm)
 			if err != nil && errors.Cause(err) != errSideloadedFileNotFound {
 				const expl = "while purging index %d"
 				return stats, expl, errors.Wrapf(err, expl, i)
 			}
+			raftLogSize -= size
 		}
 	}
 
@@ -4347,6 +4348,11 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	r.mu.Lock()
 	r.mu.lastIndex = lastIndex
 	r.mu.lastTerm = lastTerm
+	if raftLogSize < 0 {
+		// Might have gone negative during sideloaded.Purge above if node was
+		// recently restarted.
+		raftLogSize = 0
+	}
 	r.mu.raftLogSize = raftLogSize
 	var becameLeader bool
 	if r.mu.leaderID != leaderID {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4333,14 +4333,17 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		firstPurge := rd.Entries[0].Index // first new entry written
 		purgeTerm := rd.Entries[0].Term - 1
 		lastPurge := prevLastIndex // old end of the log, include in deletion
-		for i := firstPurge; i <= lastPurge; i++ {
-			size, err := r.raftMu.sideloaded.Purge(ctx, i, purgeTerm)
-			if err != nil && errors.Cause(err) != errSideloadedFileNotFound {
-				const expl = "while purging index %d"
-				return stats, expl, errors.Wrapf(err, expl, i)
-			}
-			raftLogSize -= size
+		purgedSize, err := maybePurgeSideloaded(ctx, r.raftMu.sideloaded, firstPurge, lastPurge, purgeTerm)
+		if err != nil {
+			const expl = "while purging sideloaded storage"
+			return stats, expl, err
 		}
+		raftLogSize -= purgedSize
+		if raftLogSize < 0 {
+			// Might have gone negative if node was recently restarted.
+			raftLogSize = 0
+		}
+
 	}
 
 	// Update protected state - last index, last term, raft log size, and raft
@@ -4348,11 +4351,6 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	r.mu.Lock()
 	r.mu.lastIndex = lastIndex
 	r.mu.lastTerm = lastTerm
-	if raftLogSize < 0 {
-		// Might have gone negative during sideloaded.Purge above if node was
-		// recently restarted.
-		raftLogSize = 0
-	}
 	r.mu.raftLogSize = raftLogSize
 	var becameLeader bool
 	if r.mu.leaderID != leaderID {

--- a/pkg/storage/replica_sideload.go
+++ b/pkg/storage/replica_sideload.go
@@ -44,7 +44,9 @@ type sideloadStorage interface {
 	// remove any leftover files at the same index and earlier terms, but
 	// is not required to do so. When no file at the given index and term
 	// exists, returns errSideloadedFileNotFound.
-	Purge(_ context.Context, index, term uint64) error
+	//
+	// Returns the total size of the purged payloads.
+	Purge(_ context.Context, index, term uint64) (int64, error)
 	// Clear files that may have been written by this sideloadStorage.
 	Clear(context.Context) error
 	// TruncateTo removes all files belonging to an index strictly smaller than

--- a/pkg/storage/replica_sideload.go
+++ b/pkg/storage/replica_sideload.go
@@ -253,3 +253,20 @@ func assertSideloadedRaftCommandInlined(ctx context.Context, ent *raftpb.Entry) 
 		log.Fatalf(ctx, "found thin sideloaded raft command: %+v", command)
 	}
 }
+
+// maybePurgeSideloaded removes [firstIndex, ..., lastIndex] at the given term
+// and returns the total number of bytes removed. Nonexistent entries are
+// silently skipped over.
+func maybePurgeSideloaded(
+	ctx context.Context, ss sideloadStorage, firstIndex, lastIndex uint64, term uint64,
+) (int64, error) {
+	var totalSize int64
+	for i := firstIndex; i <= lastIndex; i++ {
+		size, err := ss.Purge(ctx, i, term)
+		if err != nil && errors.Cause(err) != errSideloadedFileNotFound {
+			return totalSize, err
+		}
+		totalSize += size
+	}
+	return totalSize, nil
+}

--- a/pkg/storage/replica_sideload_disk.go
+++ b/pkg/storage/replica_sideload_disk.go
@@ -109,18 +109,32 @@ func (ss *diskSideloadStorage) filename(ctx context.Context, index, term uint64)
 	return filepath.Join(ss.dir, fmt.Sprintf("i%d.t%d", index, term))
 }
 
-func (ss *diskSideloadStorage) Purge(ctx context.Context, index, term uint64) error {
+func (ss *diskSideloadStorage) Purge(ctx context.Context, index, term uint64) (int64, error) {
 	return ss.purgeFile(ctx, ss.filename(ctx, index, term))
 }
 
-func (ss *diskSideloadStorage) purgeFile(ctx context.Context, filename string) error {
+func (ss *diskSideloadStorage) purgeFile(ctx context.Context, filename string) (int64, error) {
+	// TODO(tschottdorf): this should all be done through the env. As written,
+	// the sizes returned here will be wrong if encryption is one. We want the
+	// size of the unencrypted payload.
+	//
+	// See #31913.
+	info, err := os.Stat(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, errSideloadedFileNotFound
+		}
+		return 0, err
+	}
+	size := info.Size()
+
 	if err := ss.eng.DeleteFile(filename); err != nil {
 		if os.IsNotExist(err) {
-			return errSideloadedFileNotFound
+			return 0, errSideloadedFileNotFound
 		}
-		return err
+		return 0, err
 	}
-	return nil
+	return size, nil
 }
 
 func (ss *diskSideloadStorage) Clear(_ context.Context) error {
@@ -150,15 +164,12 @@ func (ss *diskSideloadStorage) TruncateTo(ctx context.Context, index uint64) (in
 		if i >= index {
 			continue
 		}
-		var fi os.FileInfo
-		if fi, err = os.Stat(match); err != nil {
-			return size, errors.Wrapf(err, "while purging %q", match)
-		}
-		if err := ss.purgeFile(ctx, match); err != nil {
+		fileSize, err := ss.purgeFile(ctx, match)
+		if err != nil {
 			return size, errors.Wrapf(err, "while purging %q", match)
 		}
 		deleted++
-		size += fi.Size()
+		size += fileSize
 	}
 
 	if deleted == len(matches) {

--- a/pkg/storage/replica_sideload_disk.go
+++ b/pkg/storage/replica_sideload_disk.go
@@ -115,7 +115,7 @@ func (ss *diskSideloadStorage) Purge(ctx context.Context, index, term uint64) (i
 
 func (ss *diskSideloadStorage) purgeFile(ctx context.Context, filename string) (int64, error) {
 	// TODO(tschottdorf): this should all be done through the env. As written,
-	// the sizes returned here will be wrong if encryption is one. We want the
+	// the sizes returned here will be wrong if encryption is on. We want the
 	// size of the unencrypted payload.
 	//
 	// See #31913.

--- a/pkg/storage/replica_sideload_inmem.go
+++ b/pkg/storage/replica_sideload_inmem.go
@@ -85,13 +85,14 @@ func (ss *inMemSideloadStorage) Filename(_ context.Context, index, term uint64) 
 	return filepath.Join(ss.prefix, fmt.Sprintf("i%d.t%d", index, term)), nil
 }
 
-func (ss *inMemSideloadStorage) Purge(_ context.Context, index, term uint64) error {
+func (ss *inMemSideloadStorage) Purge(_ context.Context, index, term uint64) (int64, error) {
 	k := ss.key(index, term)
 	if _, ok := ss.m[k]; !ok {
-		return errSideloadedFileNotFound
+		return 0, errSideloadedFileNotFound
 	}
+	size := int64(len(ss.m[k]))
 	delete(ss.m, k)
-	return nil
+	return size, nil
 }
 
 func (ss *inMemSideloadStorage) Clear(_ context.Context) error {

--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -184,7 +184,8 @@ func testSideloadingSideloadedStorage(
 		{
 			err: errSideloadedFileNotFound,
 			fun: func() error {
-				return ss.Purge(ctx, 123, 456)
+				_, err := ss.Purge(ctx, 123, 456)
+				return err
 			},
 		},
 		{

--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -362,6 +362,37 @@ func testSideloadingSideloadedStorage(
 	}
 
 	assertCreated(false)
+
+	// Repopulate with a few entries at indexes=1,2,4 and term 10 to test `maybePurgeSideloaded`
+	// with.
+	for index := uint64(1); index < 5; index++ {
+		if index == 3 {
+			continue
+		}
+		payload := []byte(strings.Repeat("x", 1+int(index)))
+		if err := ss.Put(ctx, index, 10, payload); err != nil {
+			t.Fatalf("%d: %s", index, err)
+		}
+	}
+
+	// Term too high and too low, respectively. Shouldn't delete anything.
+	for _, term := range []uint64{9, 11} {
+		if size, err := maybePurgeSideloaded(ctx, ss, 1, 10, term); err != nil || size != 0 {
+			t.Fatalf("expected noop for term %d, got (%d, %v)", term, size, err)
+		}
+	}
+	// This should delete 2 and 4. Index == size+1, so expect 6.
+	if size, err := maybePurgeSideloaded(ctx, ss, 2, 4, 10); err != nil || size != 8 {
+		t.Fatalf("unexpectedly got (%d, %v)", size, err)
+	}
+	// This should delete 1 (the lone survivor).
+	if size, err := maybePurgeSideloaded(ctx, ss, 0, 100, 10); err != nil || size != 2 {
+		t.Fatalf("unexpectedly got (%d, %v)", size, err)
+	}
+	// Nothing left.
+	if size, err := maybePurgeSideloaded(ctx, ss, 0, 100, 10); err != nil || size != 0 {
+		t.Fatalf("expected noop, got (%d, %v)", size, err)
+	}
 }
 
 func TestRaftSSTableSideloadingInline(t *testing.T) {


### PR DESCRIPTION
This follows up on a comment of @nvanbenschoten in #31914 which highlighted yet
another potential (though hopefully rare) source of raft log size not being
reduced correctly.

Release note: None