### PR TITLE
sql: rename column for SHOW STATISTICS

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -44,13 +44,13 @@ statement ok
 CREATE STATISTICS s1 ON a FROM data
 
 query TTIII colnames
-SELECT table_name, column_names, row_count, distinct_count, null_count FROM [SHOW STATISTICS FOR TABLE data]
+SELECT statistics_name, column_names, row_count, distinct_count, null_count FROM [SHOW STATISTICS FOR TABLE data]
 ----
-table_name  column_names  row_count  distinct_count  null_count
-s1          {"a"}         10000      10              0
+statistics_name  column_names  row_count  distinct_count  null_count
+s1               {"a"}         10000      10              0
 
 let $hist_id_1
-SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE data] WHERE table_name = 's1'
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE data] WHERE statistics_name = 's1'
 
 query TII colnames
 SHOW HISTOGRAM $hist_id_1
@@ -71,11 +71,11 @@ statement ok
 CREATE STATISTICS "" ON b FROM data
 
 query TTIII colnames
-SELECT table_name, column_names, row_count, distinct_count, null_count FROM [SHOW STATISTICS FOR TABLE data]
+SELECT statistics_name, column_names, row_count, distinct_count, null_count FROM [SHOW STATISTICS FOR TABLE data]
 ----
-table_name  column_names  row_count  distinct_count  null_count
-s1          {"a"}         10000      10              0
-NULL        {"b"}         10000      10              0
+statistics_name  column_names  row_count  distinct_count  null_count
+s1               {"a"}         10000      10              0
+NULL             {"b"}         10000      10              0
 
 # Verify that we can package statistics into a json object and later restore them.
 let $json_stats
@@ -88,30 +88,30 @@ statement ok
 ALTER TABLE data INJECT STATISTICS '$json_stats'
 
 query TTIII colnames
-SELECT table_name, column_names, row_count, distinct_count, null_count FROM [SHOW STATISTICS FOR TABLE data]
+SELECT statistics_name, column_names, row_count, distinct_count, null_count FROM [SHOW STATISTICS FOR TABLE data]
 ----
-table_name  column_names  row_count  distinct_count  null_count
-s1          {"a"}         10000      10              0
-NULL        {"b"}         10000      10              0
+statistics_name  column_names  row_count  distinct_count  null_count
+s1               {"a"}         10000      10              0
+NULL             {"b"}         10000      10              0
 
 # Verify that any other statistics are blown away when we INJECT.
 statement ok
 CREATE STATISTICS s3 ON c FROM data
 
 query TTIII colnames
-SELECT table_name, column_names, row_count, distinct_count, null_count FROM [SHOW STATISTICS FOR TABLE data]
+SELECT statistics_name, column_names, row_count, distinct_count, null_count FROM [SHOW STATISTICS FOR TABLE data]
 ----
-table_name  column_names  row_count  distinct_count  null_count
-s1          {"a"}         10000      10              0
-NULL        {"b"}         10000      10              0
-s3          {"c"}         10000      10              0
+statistics_name  column_names  row_count  distinct_count  null_count
+s1               {"a"}         10000      10              0
+NULL             {"b"}         10000      10              0
+s3               {"c"}         10000      10              0
 
 statement ok
 ALTER TABLE data INJECT STATISTICS '$json_stats'
 
 query TTIII colnames
-SELECT table_name, column_names, row_count, distinct_count, null_count FROM [SHOW STATISTICS FOR TABLE data]
+SELECT statistics_name, column_names, row_count, distinct_count, null_count FROM [SHOW STATISTICS FOR TABLE data]
 ----
-table_name  column_names  row_count  distinct_count  null_count
-s1          {"a"}         10000      10              0
-NULL        {"b"}         10000      10              0
+statistics_name  column_names  row_count  distinct_count  null_count
+s1               {"a"}         10000      10              0
+NULL             {"b"}         10000      10              0

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -27,7 +27,7 @@ import (
 )
 
 var showTableStatsColumns = sqlbase.ResultColumns{
-	{Name: "table_name", Typ: types.String},
+	{Name: "statistics_name", Typ: types.String},
 	{Name: "column_names", Typ: types.TArray{Typ: types.String}},
 	{Name: "created", Typ: types.Timestamp},
 	{Name: "row_count", Typ: types.Int},


### PR DESCRIPTION
The column was incorrectly renamed to `table_name`. Correcting to
`statistics_name` (the plural sounds a bit strange but this is
consistent with `CREATE STATISTICS`; each row is a "statistics
object").

Release note (sql change): The first column name returned by SHOW
STATISTICS was incorrect and was changed to "statistics_name".

CC @lhirata 