### PR TITLE
exec: add count operator

### DIFF
--- a/pkg/sql/exec/colbatch.go
+++ b/pkg/sql/exec/colbatch.go
@@ -57,6 +57,20 @@ func NewMemBatch(types []types.T) ColBatch {
 	return b
 }
 
+// newMemBatchWithSize allocates a new in-memory ColBatch with the given column
+// size. Use for operators that have a precisely-sized output batch.
+func newMemBatchWithSize(types []types.T, size int) ColBatch {
+	b := &memBatch{}
+	b.b = make([]ColVec, len(types))
+
+	for i, t := range types {
+		b.b[i] = newMemColumn(t, size)
+	}
+	b.sel = make([]uint16, size)
+
+	return b
+}
+
 type memBatch struct {
 	// length of batch or sel in tuples
 	n uint16

--- a/pkg/sql/exec/count.go
+++ b/pkg/sql/exec/count.go
@@ -1,0 +1,65 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+// countOp is an operator that counts the number of input rows it receives,
+// consuming its entire input and outputting a batch with a single integer
+// column containing a single integer, the count of rows received from the
+// upstream.
+type countOp struct {
+	input Operator
+
+	internalBatch ColBatch
+	done          bool
+	count         int64
+}
+
+// NewCountOp returns a new count operator that counts the rows in its input.
+func NewCountOp(input Operator) Operator {
+	c := &countOp{
+		input: input,
+	}
+	c.internalBatch = newMemBatchWithSize([]types.T{types.Int64}, 1)
+	return c
+}
+
+func (c *countOp) Init() {
+	c.input.Init()
+	// Our output is always just one row.
+	c.internalBatch.SetLength(1)
+	c.count = 0
+	c.done = false
+}
+
+func (c *countOp) Next() ColBatch {
+	if c.done {
+		c.internalBatch.SetLength(0)
+		return c.internalBatch
+	}
+	for {
+		bat := c.input.Next()
+		length := bat.Length()
+		if length == 0 {
+			c.done = true
+			c.internalBatch.ColVec(0).Int64()[0] = c.count
+			return c.internalBatch
+		}
+		c.count += int64(length)
+	}
+}

--- a/pkg/sql/exec/count_test.go
+++ b/pkg/sql/exec/count_test.go
@@ -1,0 +1,47 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+func TestCount(t *testing.T) {
+	tcs := []struct {
+		tuples   tuples
+		expected tuples
+	}{
+		{
+			tuples:   tuples{{1}, {1}},
+			expected: tuples{{2}},
+		},
+		{
+			tuples:   tuples{{1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}},
+			expected: tuples{{10}},
+		},
+	}
+	for _, tc := range tcs {
+		runTests(t, tc.tuples, []types.T{}, func(t *testing.T, input Operator) {
+			count := NewCountOp(input)
+			out := newOpTestOutput(count, []int{0}, tc.expected)
+
+			if err := out.Verify(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -95,7 +95,6 @@ func newOpTestInput(batchSize uint16, tuples tuples, extraCols ...types.T) *opTe
 		tuples:    tuples,
 		extraCols: extraCols,
 	}
-	ret.Init()
 	return ret
 }
 
@@ -109,7 +108,6 @@ func newOpTestSelInput(
 		tuples:    tuples,
 		extraCols: extraCols,
 	}
-	ret.Init()
 	return ret
 }
 
@@ -192,6 +190,7 @@ type opTestOutput struct {
 // to verify on the given column indices that the output is exactly equal to
 // the expected tuples.
 func newOpTestOutput(input Operator, cols []int, expected tuples) *opTestOutput {
+	input.Init()
 	return &opTestOutput{
 		input:    input,
 		cols:     cols,


### PR DESCRIPTION
It counts the number of tuples in its input.

Release note: None