### PR TITLE
exec: add discard operator

### DIFF
--- a/pkg/sql/exec/colbatch.go
+++ b/pkg/sql/exec/colbatch.go
@@ -90,3 +90,22 @@ func (m *memBatch) SetSelection(b bool) {
 func (m *memBatch) SetLength(n uint16) {
 	m.n = n
 }
+
+// projectingBatch is a ColBatch that applies a simple projection to another,
+// underlying batch, discarding all columns but the ones in its projection
+// slice, in order.
+type projectingBatch struct {
+	ColBatch
+
+	projection []uint32
+}
+
+func newProjectionBatch(projection []uint32) *projectingBatch {
+	return &projectingBatch{
+		projection: projection,
+	}
+}
+
+func (b *projectingBatch) ColVec(i int) ColVec {
+	return b.ColBatch.ColVec(int(b.projection[i]))
+}

--- a/pkg/sql/exec/simple_project.go
+++ b/pkg/sql/exec/simple_project.go
@@ -1,0 +1,44 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+// simpleProjectOp is an operator that implements "simple projection" - removal of
+// columns that aren't needed by later operators.
+type simpleProjectOp struct {
+	input Operator
+
+	batch *projectingBatch
+}
+
+// NewSimpleProjectOp returns a new simpleProjectOp that applies a simple
+// projection on the columns in its input batch, returning a new batch with only
+// the columns in the projection slice, in order.
+func NewSimpleProjectOp(input Operator, projection []uint32) Operator {
+	return &simpleProjectOp{
+		input: input,
+		batch: newProjectionBatch(projection),
+	}
+}
+
+func (d *simpleProjectOp) Init() {
+	d.input.Init()
+}
+
+func (d *simpleProjectOp) Next() ColBatch {
+	batch := d.input.Next()
+	d.batch.ColBatch = batch
+
+	return d.batch
+}

--- a/pkg/sql/exec/simple_project_test.go
+++ b/pkg/sql/exec/simple_project_test.go
@@ -1,0 +1,82 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+func TestSimpleProjectOp(t *testing.T) {
+	tcs := []struct {
+		tuples     tuples
+		expected   tuples
+		colsToKeep []uint32
+	}{
+		{
+			colsToKeep: []uint32{0, 2},
+			tuples: tuples{
+				{1, 2, 3},
+				{1, 2, 3},
+			},
+			expected: tuples{
+				{1, 3},
+				{1, 3},
+			},
+		},
+		{
+			colsToKeep: []uint32{0, 1},
+			tuples: tuples{
+				{1, 2, 3},
+				{1, 2, 3},
+			},
+			expected: tuples{
+				{1, 2},
+				{1, 2},
+			},
+		},
+		{
+			colsToKeep: []uint32{2, 1},
+			tuples: tuples{
+				{1, 2, 3},
+				{1, 2, 3},
+			},
+			expected: tuples{
+				{3, 2},
+				{3, 2},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		runTests(t, tc.tuples, []types.T{}, func(t *testing.T, input Operator) {
+			count := NewSimpleProjectOp(input, tc.colsToKeep)
+			out := newOpTestOutput(count, []int{0, 1}, tc.expected)
+
+			if err := out.Verify(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+
+	// Empty projection.
+	runTests(t, tuples{{1, 2, 3}, {1, 2, 3}}, []types.T{}, func(t *testing.T, input Operator) {
+		count := NewSimpleProjectOp(input, nil)
+		out := newOpTestOutput(count, []int{}, tuples{{}, {}})
+		if err := out.Verify(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}


### PR DESCRIPTION
The discard operator discards all but a given set of columns. This
implements the "simple project" operation that DistSQL expects for its
projected columns PostProcessSpec.

Release note: None