### PR TITLE
workload: forbid dependencies on c-deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1423,7 +1423,8 @@ logictest-bins := bin/logictest bin/logictestopt bin/logictestccl
 #
 # TODO(benesch): Derive this automatically. This is getting out of hand.
 bin/workload bin/docgen bin/execgen bin/roachtest $(logictest-bins): $(SQLPARSER_TARGETS) $(PROTOBUF_TARGETS)
-bin/workload bin/roachtest $(logictest-bins): $(C_LIBS_CCL) $(CGO_FLAGS_FILES) $(EXECGEN_TARGETS)
+bin/workload bin/roachtest $(logictest-bins): $(EXECGEN_TARGETS)
+bin/roachtest $(logictest-bins): $(C_LIBS_CCL) $(CGO_FLAGS_FILES)
 bin/roachtest bin/logictestopt: $(OPTGEN_TARGETS)
 
 $(bins): bin/%: bin/%.d | bin/prereqs bin/.submodules-initialized

--- a/pkg/cmd/workload/dep_test.go
+++ b/pkg/cmd/workload/dep_test.go
@@ -1,0 +1,32 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestNoLinkForbidden(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// We want workload to be lightweight. Ensure it doesn't depend on c-deps,
+	// which are slow to compile and bloat the binary.
+	buildutil.VerifyNoImports(t, "github.com/cockroachdb/cockroach/pkg/cmd/workload",
+		true /* cgo */, []string{"c-deps"}, nil /* forbiddenPrefixes */)
+}


### PR DESCRIPTION
This was recently fixed by #31325, and we don't want it to regress. It
also means we no longer need to build c-deps when building bin/workload.

Release note: None