### PR TITLE
sql: add new colencoding package with val decoders

### DIFF
--- a/pkg/sql/colencoding/value_encoding.go
+++ b/pkg/sql/colencoding/value_encoding.go
@@ -1,0 +1,99 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package colencoding
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/pkg/errors"
+)
+
+// DecodeTableValueToCol decodes a value encoded by EncodeTableValue, writing
+// the result to the idx'th position of the input exec.ColVec.
+// See the analog in sqlbase/column_type_encoding.go.
+func DecodeTableValueToCol(
+	vec exec.ColVec,
+	idx uint16,
+	typ encoding.Type,
+	dataOffset int,
+	valTyp *sqlbase.ColumnType,
+	b []byte,
+) ([]byte, error) {
+	// NULL is special because it is a valid value for any type.
+	if typ == encoding.Null {
+		vec.SetNull(idx)
+		return b[dataOffset:], nil
+	}
+	// Bool is special because the value is stored in the value tag.
+	if valTyp.SemanticType != sqlbase.ColumnType_BOOL {
+		b = b[dataOffset:]
+	}
+	return decodeUntaggedDatumToCol(vec, idx, valTyp, b)
+}
+
+// decodeUntaggedDatum is used to decode a Datum whose type is known,
+// and which doesn't have a value tag (either due to it having been
+// consumed already or not having one in the first place). It writes the result
+// to the idx'th position of the input exec.ColVec.
+//
+// This is used to decode datums encoded using value encoding.
+//
+// If t is types.Bool, the value tag must be present, as its value is encoded in
+// the tag directly.
+// See the analog in sqlbase/column_type_encoding.go.
+func decodeUntaggedDatumToCol(
+	vec exec.ColVec, idx uint16, t *sqlbase.ColumnType, buf []byte,
+) ([]byte, error) {
+	var err error
+	switch t.SemanticType {
+	case sqlbase.ColumnType_BOOL:
+		var b bool
+		// A boolean's value is encoded in its tag directly, so we don't have an
+		// "Untagged" version of this function.
+		buf, b, err = encoding.DecodeBoolValue(buf)
+		vec.Bool()[idx] = b
+	case sqlbase.ColumnType_BYTES, sqlbase.ColumnType_STRING, sqlbase.ColumnType_NAME:
+		var data []byte
+		buf, data, err = encoding.DecodeUntaggedBytesValue(buf)
+		vec.Bytes()[idx] = data
+	case sqlbase.ColumnType_DATE, sqlbase.ColumnType_OID:
+		var i int64
+		buf, i, err = encoding.DecodeUntaggedIntValue(buf)
+		vec.Int64()[idx] = i
+	case sqlbase.ColumnType_FLOAT:
+		var f float64
+		buf, f, err = encoding.DecodeUntaggedFloatValue(buf)
+		vec.Float64()[idx] = f
+	case sqlbase.ColumnType_INT:
+		var i int64
+		buf, i, err = encoding.DecodeUntaggedIntValue(buf)
+		switch t.Width {
+		case 8:
+			vec.Int8()[idx] = int8(i)
+		case 16:
+			vec.Int16()[idx] = int16(i)
+		case 32:
+			vec.Int32()[idx] = int32(i)
+		case 0, 64:
+			vec.Int64()[idx] = i
+		default:
+			return buf, errors.Errorf("unknown integer width %d", t.Width)
+		}
+	default:
+		return buf, errors.Errorf("couldn't decode type %s", t)
+	}
+	return buf, err
+}

--- a/pkg/sql/colencoding/value_encoding_test.go
+++ b/pkg/sql/colencoding/value_encoding_test.go
@@ -1,0 +1,75 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package colencoding
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestDecodeTableValueToCol(t *testing.T) {
+	rng, _ := randutil.NewPseudoRand()
+	var buf []byte
+	var scratch []byte
+	nCols := 1000
+	datums := make([]tree.Datum, nCols)
+	colTyps := make([]sqlbase.ColumnType, nCols)
+	typs := make([]types.T, nCols)
+	for i := 0; i < nCols; i++ {
+		ct := sqlbase.RandColumnType(rng)
+		et := types.FromColumnType(ct)
+		if et == types.Unhandled {
+			i--
+			continue
+		}
+		datum := sqlbase.RandDatum(rng, ct, false /* nullOk */)
+		colTyps[i] = ct
+		typs[i] = et
+		datums[i] = datum
+		var err error
+		fmt.Println(datum)
+		buf, err = sqlbase.EncodeTableValue(buf, sqlbase.ColumnID(encoding.NoColumnID), datum, scratch)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	batch := exec.NewMemBatchWithSize(typs, 1)
+	for i := 0; i < nCols; i++ {
+		typeOffset, dataOffset, _, typ, err := encoding.DecodeValueTag(buf)
+		fmt.Println(typ)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf, err = DecodeTableValueToCol(batch.ColVec(i), 0 /* rowIdx */, typ,
+			dataOffset, &colTyps[i], buf[typeOffset:])
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// TODO(jordan): should actually compare the outputs as well, but this is a
+		// decent enough smoke test.
+	}
+
+	if len(buf) != 0 {
+		t.Fatalf("leftover bytes %s", buf)
+	}
+}

--- a/pkg/sql/exec/colbatch.go
+++ b/pkg/sql/exec/colbatch.go
@@ -57,9 +57,9 @@ func NewMemBatch(types []types.T) ColBatch {
 	return b
 }
 
-// newMemBatchWithSize allocates a new in-memory ColBatch with the given column
+// NewMemBatchWithSize allocates a new in-memory ColBatch with the given column
 // size. Use for operators that have a precisely-sized output batch.
-func newMemBatchWithSize(types []types.T, size int) ColBatch {
+func NewMemBatchWithSize(types []types.T, size int) ColBatch {
 	b := &memBatch{}
 	b.b = make([]ColVec, len(types))
 

--- a/pkg/sql/exec/count.go
+++ b/pkg/sql/exec/count.go
@@ -35,7 +35,7 @@ func NewCountOp(input Operator) Operator {
 	c := &countOp{
 		input: input,
 	}
-	c.internalBatch = newMemBatchWithSize([]types.T{types.Int64}, 1)
+	c.internalBatch = NewMemBatchWithSize([]types.T{types.Int64}, 1)
 	return c
 }
 


### PR DESCRIPTION
In order to support decoding directly into columnar format from the
bytes returned from MVCCScan, new copies of all decoders need to be
introduced that write directly into column batches instead of returning
Datums.

This new file, value_encoding.go, is a copy of the relevant portions of
the value decoders from column_type_encoding.go.

Release note: None