### PR TITLE
exec: add date and decimal types

### DIFF
--- a/pkg/sql/colencoding/value_encoding.go
+++ b/pkg/sql/colencoding/value_encoding.go
@@ -73,6 +73,8 @@ func decodeUntaggedDatumToCol(
 		var i int64
 		buf, i, err = encoding.DecodeUntaggedIntValue(buf)
 		vec.Int64()[idx] = i
+	case sqlbase.ColumnType_DECIMAL:
+		buf, err = encoding.DecodeIntoUntaggedDecimalValue(&vec.Decimal()[idx], buf)
 	case sqlbase.ColumnType_FLOAT:
 		var f float64
 		buf, f, err = encoding.DecodeUntaggedFloatValue(buf)

--- a/pkg/sql/exec/colvec.go
+++ b/pkg/sql/exec/colvec.go
@@ -38,7 +38,7 @@ type ColVec interface {
 	Int64() []int64
 	// Float32 returns a float32 slice.
 	Float32() []float32
-	// Float64 returns an float64 slice.
+	// Float64 returns a float64 slice.
 	Float64() []float64
 	// Bytes returns a []byte slice.
 	Bytes() [][]byte

--- a/pkg/sql/exec/colvec.go
+++ b/pkg/sql/exec/colvec.go
@@ -17,6 +17,8 @@ package exec
 import (
 	"fmt"
 
+	"github.com/cockroachdb/apd"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 )
 
@@ -42,6 +44,9 @@ type ColVec interface {
 	Float64() []float64
 	// Bytes returns a []byte slice.
 	Bytes() [][]byte
+	// TODO(jordan): should this be [][]byte?
+	// Decimal returns an apd.Decimal slice.
+	Decimal() []apd.Decimal
 
 	// Col returns the raw, typeless backing storage for this ColVec.
 	Col() interface{}
@@ -87,8 +92,10 @@ func newMemColumn(t types.T, n int) memColumn {
 		return memColumn{col: make([]float32, n)}
 	case types.Float64:
 		return memColumn{col: make([]float64, n)}
+	case types.Decimal:
+		return memColumn{col: make([]apd.Decimal, n)}
 	default:
-		panic(fmt.Sprintf("unhandled type %d", t))
+		panic(fmt.Sprintf("unhandled type %s", t))
 	}
 }
 
@@ -136,6 +143,10 @@ func (m memColumn) Float64() []float64 {
 
 func (m memColumn) Bytes() [][]byte {
 	return m.col.([][]byte)
+}
+
+func (m memColumn) Decimal() []apd.Decimal {
+	return m.col.([]apd.Decimal)
 }
 
 func (m memColumn) Col() interface{} {

--- a/pkg/sql/exec/execgen/cmd/execgen/rowstovec_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/rowstovec_gen.go
@@ -153,6 +153,8 @@ func getDatumToPhysicalFn(ct sqlbase.ColumnType) string {
 		return "int64(datum.(*tree.DOid).DInt)"
 	case sqlbase.ColumnType_STRING, sqlbase.ColumnType_NAME:
 		return "encoding.UnsafeConvertStringToBytes(string(*datum.(*tree.DString)))"
+	case sqlbase.ColumnType_DECIMAL:
+		return "datum.(*tree.DDecimal).Decimal"
 	}
 	panic(fmt.Sprintf("unhandled ColumnType %s", ct.String()))
 }

--- a/pkg/sql/exec/execgen/cmd/execgen/rowstovec_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/rowstovec_gen.go
@@ -145,6 +145,8 @@ func getDatumToPhysicalFn(ct sqlbase.ColumnType) string {
 			return "int64(*datum.(*tree.DInt))"
 		}
 		panic(fmt.Sprintf("unhandled INT width %d", ct.Width))
+	case sqlbase.ColumnType_DATE:
+		return "int64(*datum.(*tree.DDate))"
 	case sqlbase.ColumnType_FLOAT:
 		return "float64(*datum.(*tree.DFloat))"
 	case sqlbase.ColumnType_OID:

--- a/pkg/sql/exec/rowstovec_test.go
+++ b/pkg/sql/exec/rowstovec_test.go
@@ -97,3 +97,26 @@ func TestEncDatumRowsToColVecString(t *testing.T) {
 		t.Errorf("expected vector %+v, got %+v", expected, vec)
 	}
 }
+
+func TestEncDatumRowsToColVecDecimal(t *testing.T) {
+	nRows := 3
+	rows := make(sqlbase.EncDatumRows, nRows)
+	expected := newMemColumn(types.Decimal, 3)
+	for i, s := range []string{"1.0000", "-3.12", "NaN"} {
+		var err error
+		dec, err := tree.ParseDDecimal(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows[i] = sqlbase.EncDatumRow{sqlbase.EncDatum{Datum: dec}}
+		expected.Decimal()[i] = dec.Decimal
+	}
+	vec := newMemColumn(types.Decimal, 3)
+	ct := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_DECIMAL}
+	if err := EncDatumRowsToColVec(rows, vec, 0 /* columnIdx */, &ct, &alloc); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(vec, expected) {
+		t.Errorf("expected vector %+v, got %+v", expected, vec)
+	}
+}

--- a/pkg/sql/exec/types/t_string.go
+++ b/pkg/sql/exec/types/t_string.go
@@ -4,9 +4,9 @@ package types
 
 import "strconv"
 
-const _T_name = "BoolBytesInt8Int16Int32Int64Float32Float64Unhandled"
+const _T_name = "BoolBytesDecimalInt8Int16Int32Int64Float32Float64Unhandled"
 
-var _T_index = [...]uint8{0, 4, 9, 13, 18, 23, 28, 35, 42, 51}
+var _T_index = [...]uint8{0, 4, 9, 16, 20, 25, 30, 35, 42, 49, 58}
 
 func (i T) String() string {
 	if i < 0 || i >= T(len(_T_index)-1) {

--- a/pkg/sql/exec/types/types.go
+++ b/pkg/sql/exec/types/types.go
@@ -56,6 +56,8 @@ func FromColumnType(ct sqlbase.ColumnType) T {
 		return Bool
 	case sqlbase.ColumnType_BYTES, sqlbase.ColumnType_STRING, sqlbase.ColumnType_NAME:
 		return Bytes
+	case sqlbase.ColumnType_DATE, sqlbase.ColumnType_OID:
+		return Int64
 	case sqlbase.ColumnType_INT:
 		switch ct.Width {
 		case 8:
@@ -68,8 +70,6 @@ func FromColumnType(ct sqlbase.ColumnType) T {
 			return Int64
 		}
 		panic(fmt.Sprintf("integer with unknown width %d", ct.Width))
-	case sqlbase.ColumnType_OID:
-		return Int64
 	case sqlbase.ColumnType_FLOAT:
 		return Float64
 	}

--- a/pkg/sql/exec/types/types.go
+++ b/pkg/sql/exec/types/types.go
@@ -17,6 +17,8 @@ package types
 import (
 	"fmt"
 
+	"github.com/cockroachdb/apd"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
@@ -30,6 +32,8 @@ const (
 	Bool T = iota
 	// Bytes is a column of type []byte
 	Bytes
+	// Decimal is a column of type apd.Decimal
+	Decimal
 	// Int8 is a column of type int8
 	Int8
 	// Int16 is a column of type int16
@@ -58,6 +62,8 @@ func FromColumnType(ct sqlbase.ColumnType) T {
 		return Bytes
 	case sqlbase.ColumnType_DATE, sqlbase.ColumnType_OID:
 		return Int64
+	case sqlbase.ColumnType_DECIMAL:
+		return Decimal
 	case sqlbase.ColumnType_INT:
 		switch ct.Width {
 		case 8:
@@ -108,6 +114,8 @@ func FromGoType(v interface{}) T {
 		return Bytes
 	case string:
 		return Bytes
+	case apd.Decimal:
+		return Decimal
 	default:
 		panic(fmt.Sprintf("type %T not supported yet", t))
 	}

--- a/pkg/util/encoding/decimal.go
+++ b/pkg/util/encoding/decimal.go
@@ -623,55 +623,61 @@ func encodeNonsortingDecimalValueWithoutExp(digits []big.Word, buf []byte) []byt
 // of the encoded value is.
 func DecodeNonsortingDecimal(buf []byte, tmp []byte) (apd.Decimal, error) {
 	var dec apd.Decimal
+	err := DecodeIntoNonsortingDecimal(&dec, buf, tmp)
+	return dec, err
+}
 
+// DecodeIntoNonsortingDecimal is like DecodeNonsortingDecimal, but it operates
+// on the passed-in *apd.Decimal instead of producing a new one.
+func DecodeIntoNonsortingDecimal(dec *apd.Decimal, buf []byte, tmp []byte) error {
 	switch buf[0] {
 	case decimalNaN:
 		dec.Form = apd.NaN
-		return dec, nil
+		return nil
 	case decimalNegativeInfinity:
 		dec.Form = apd.Infinite
 		dec.Negative = true
-		return dec, nil
+		return nil
 	case decimalInfinity:
 		dec.Form = apd.Infinite
-		return dec, nil
+		return nil
 	case decimalZero:
-		return dec, nil
+		return nil
 	}
 
 	dec.Form = apd.Finite
 	switch {
 	case buf[0] == decimalNegLarge:
-		if err := decodeNonsortingDecimalValue(&dec, false, buf[1:], tmp); err != nil {
-			return apd.Decimal{}, err
+		if err := decodeNonsortingDecimalValue(dec, false, buf[1:], tmp); err != nil {
+			return err
 		}
 		dec.Negative = true
-		return dec, nil
+		return nil
 	case buf[0] == decimalNegMedium:
-		decodeNonsortingDecimalValueWithoutExp(&dec, buf[1:], tmp)
+		decodeNonsortingDecimalValueWithoutExp(dec, buf[1:], tmp)
 		dec.Negative = true
-		return dec, nil
+		return nil
 	case buf[0] == decimalNegSmall:
-		if err := decodeNonsortingDecimalValue(&dec, true, buf[1:], tmp); err != nil {
-			return apd.Decimal{}, err
+		if err := decodeNonsortingDecimalValue(dec, true, buf[1:], tmp); err != nil {
+			return err
 		}
 		dec.Negative = true
-		return dec, nil
+		return nil
 	case buf[0] == decimalPosSmall:
-		if err := decodeNonsortingDecimalValue(&dec, true, buf[1:], tmp); err != nil {
-			return apd.Decimal{}, err
+		if err := decodeNonsortingDecimalValue(dec, true, buf[1:], tmp); err != nil {
+			return err
 		}
-		return dec, nil
+		return nil
 	case buf[0] == decimalPosMedium:
-		decodeNonsortingDecimalValueWithoutExp(&dec, buf[1:], tmp)
-		return dec, nil
+		decodeNonsortingDecimalValueWithoutExp(dec, buf[1:], tmp)
+		return nil
 	case buf[0] == decimalPosLarge:
-		if err := decodeNonsortingDecimalValue(&dec, false, buf[1:], tmp); err != nil {
-			return apd.Decimal{}, err
+		if err := decodeNonsortingDecimalValue(dec, false, buf[1:], tmp); err != nil {
+			return err
 		}
-		return dec, nil
+		return nil
 	default:
-		return apd.Decimal{}, errors.Errorf("unknown prefix of the encoded byte slice: %q", buf)
+		return errors.Errorf("unknown decimal prefix of the encoded byte slice: %q", buf)
 	}
 }
 

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -2077,6 +2077,19 @@ func DecodeUntaggedDecimalValue(b []byte) (remaining []byte, d apd.Decimal, err 
 	return b[int(i):], d, err
 }
 
+// DecodeIntoUntaggedDecimalValue is like DecodeUntaggedDecimalValue except it
+// writes the new Decimal into the input apd.Decimal pointer, which must be
+// non-nil.
+func DecodeIntoUntaggedDecimalValue(d *apd.Decimal, b []byte) (remaining []byte, err error) {
+	var i uint64
+	b, _, i, err = DecodeNonsortingStdlibUvarint(b)
+	if err != nil {
+		return b, err
+	}
+	err = DecodeIntoNonsortingDecimal(d, b[:int(i)], nil)
+	return b[int(i):], err
+}
+
 // DecodeDurationValue decodes a value encoded by EncodeUntaggedDurationValue.
 func DecodeDurationValue(b []byte) (remaining []byte, d duration.Duration, err error) {
 	b, err = decodeValueTypeAssert(b, Duration)


### PR DESCRIPTION
Date is just an Int64, so no work to do there.

Decimal maps to `apd.Decimal`. It's a bit unfortunate as I don't think the columnar representation will help `apd.Decimal` operations as much as they would native datatypes, but not sure what else we can do.