### PR TITLE
opt: (non-index) constraints for LIKE, SIMILAR TO

### DIFF
--- a/pkg/sql/opt/idxconstraint/testdata/strings
+++ b/pkg/sql/opt/idxconstraint/testdata/strings
@@ -66,7 +66,13 @@ index-constraints vars=(string) index=(@1)
 [/'ABC' - /'ABC']
 
 index-constraints vars=(string) index=(@1)
-@1 SIMILAR TO '(ABC|ABCDEF)%'
+@1 SIMILAR TO '(ABC|ABCDEF).*'
 ----
 [/'ABC' - /'ABD')
-Remaining filter: @1 SIMILAR TO '(ABC|ABCDEF)%'
+Remaining filter: @1 SIMILAR TO '(ABC|ABCDEF).*'
+
+index-constraints vars=(string) index=(@1)
+@1 SIMILAR TO '.*'
+----
+[/'' - ]
+Remaining filter: @1 SIMILAR TO '.*'

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -195,13 +195,13 @@ opt
 SELECT * FROM a WHERE x > 1.5
 ----
 select
- ├── columns: x:1(int) y:2(int)
+ ├── columns: x:1(int!null) y:2(int)
  ├── prune: (2)
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
  └── filters
-      └── gt [type=bool, outer=(1)]
+      └── gt [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
            ├── variable: x [type=int]
            └── const: 1.5 [type=decimal]
 
@@ -1014,3 +1014,224 @@ select
                 └── tuple [type=tuple{int, int}]
                      ├── const: 1 [type=int]
                      └── const: 2 [type=int]
+
+# Tests for string operators (LIKE, SIMILAR TO).
+opt
+SELECT * FROM kuv WHERE v LIKE 'ABC%'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── like [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'); tight)]
+           ├── variable: v [type=string]
+           └── const: 'ABC%' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v LIKE 'ABC_'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── like [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'))]
+           ├── variable: v [type=string]
+           └── const: 'ABC_' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v LIKE 'ABC%Z'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── like [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'))]
+           ├── variable: v [type=string]
+           └── const: 'ABC%Z' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v LIKE 'ABC'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── like [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABC']; tight), fd=()-->(3)]
+           ├── variable: v [type=string]
+           └── const: 'ABC' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v LIKE '%'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── like [type=bool, outer=(3), constraints=(/3: (/NULL - ])]
+           ├── variable: v [type=string]
+           └── const: '%' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v LIKE '%XY'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── like [type=bool, outer=(3), constraints=(/3: (/NULL - ])]
+           ├── variable: v [type=string]
+           └── const: '%XY' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v SIMILAR TO 'ABC.*'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── similar-to [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'))]
+           ├── variable: v [type=string]
+           └── const: 'ABC.*' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v SIMILAR TO 'ABC.*Z'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── similar-to [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'))]
+           ├── variable: v [type=string]
+           └── const: 'ABC.*Z' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v SIMILAR TO 'ABC'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── similar-to [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABC']; tight), fd=()-->(3)]
+           ├── variable: v [type=string]
+           └── const: 'ABC' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v SIMILAR TO '(ABC|ABCDEF).*'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── similar-to [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'))]
+           ├── variable: v [type=string]
+           └── const: '(ABC|ABCDEF).*' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v SIMILAR TO '.*'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── similar-to [type=bool, outer=(3), constraints=(/3: [/'' - ])]
+           ├── variable: v [type=string]
+           └── const: '.*' [type=string]

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -343,25 +343,22 @@ select
       ├── d_id = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
       └── d_name = 'bobs_burgers' [type=bool, outer=(3), constraints=(/3: [/'bobs_burgers' - /'bobs_burgers']; tight), fd=()-->(3)]
 
-# In this case we expect to use unknownFilterSelectivity
-# to estimate the selectivity on d_name, and use
-# the ratio of current/input distinct counts for d_id
 norm
 SELECT * FROM district WHERE d_id = 1 and d_name LIKE 'bob'
 ----
 select
- ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string)
- ├── stats: [rows=3.33333333, distinct(1)=1, null(1)=0, distinct(2)=2.87528606, null(2)=0]
+ ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string!null)
+ ├── stats: [rows=0.1, distinct(1)=0.1, null(1)=0, distinct(2)=0.0995511979, null(2)=0, distinct(3)=0.1, null(3)=0]
  ├── key: (2)
- ├── fd: ()-->(1), (2)-->(3)
+ ├── fd: ()-->(1,3)
  ├── scan district
  │    ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string)
- │    ├── stats: [rows=100, distinct(1)=10, null(1)=0, distinct(2)=10, null(2)=0]
+ │    ├── stats: [rows=100, distinct(1)=10, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=100, null(3)=0]
  │    ├── key: (1,2)
  │    └── fd: (1,2)-->(3)
  └── filters
       ├── d_id = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
-      └── d_name LIKE 'bob' [type=bool, outer=(3)]
+      └── d_name LIKE 'bob' [type=bool, outer=(3), constraints=(/3: [/'bob' - /'bob']; tight), fd=()-->(3)]
 
 # This tests selectivityFromReducedCols.
 # Since (1,2)-->(3) in order to use selectivityFromReducedCols,

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -362,41 +362,41 @@ FROM a
 WHERE NOT(s LIKE 'foo') AND NOT(s NOT LIKE 'foo') AND NOT(s ILIKE 'foo') AND NOT(s NOT ILIKE 'foo')
 ----
 select
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string!null) j:5(jsonb)
  ├── key: (1)
- ├── fd: (1)-->(2-5)
+ ├── fd: ()-->(4), (1)-->(2,3,5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      ├── s NOT LIKE 'foo' [type=bool, outer=(4)]
-      ├── s LIKE 'foo' [type=bool, outer=(4)]
-      ├── s NOT ILIKE 'foo' [type=bool, outer=(4)]
-      └── s ILIKE 'foo' [type=bool, outer=(4)]
+      ├── s NOT LIKE 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
+      ├── s LIKE 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+      ├── s NOT ILIKE 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
+      └── s ILIKE 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
 
 # SimilarTo comparisons.
 opt expect=NegateComparison
 SELECT * FROM a WHERE NOT(s SIMILAR TO 'foo') AND NOT(s NOT SIMILAR TO 'foo')
 ----
 select
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string!null) j:5(jsonb)
  ├── key: (1)
- ├── fd: (1)-->(2-5)
+ ├── fd: ()-->(4), (1)-->(2,3,5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      ├── s NOT SIMILAR TO 'foo' [type=bool, outer=(4)]
-      └── s SIMILAR TO 'foo' [type=bool, outer=(4)]
+      ├── s NOT SIMILAR TO 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
+      └── s SIMILAR TO 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
 # RegMatch comparisons.
 opt expect=NegateComparison
 SELECT * FROM a WHERE NOT(s ~ 'foo') AND NOT(s !~ 'foo') AND NOT(s ~* 'foo') AND NOT (s !~* 'foo')
 ----
 select
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string!null) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
@@ -404,10 +404,10 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      ├── s !~ 'foo' [type=bool, outer=(4)]
-      ├── s ~ 'foo' [type=bool, outer=(4)]
-      ├── s !~* 'foo' [type=bool, outer=(4)]
-      └── s ~* 'foo' [type=bool, outer=(4)]
+      ├── s !~ 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
+      ├── s ~ 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
+      ├── s !~* 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
+      └── s ~* 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
 
 opt expect-not=NegateComparison
 SELECT * FROM a WHERE

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -802,7 +802,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── k > 1.0 [type=bool, outer=(1)]
+      └── k > 1.0 [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
 
 # Ensure the rest of normalization does its work and we move things around appropriately.
 opt expect=UnifyComparisonTypes
@@ -838,7 +838,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── k > 1.1 [type=bool, outer=(1)]
+      └── k > 1.1 [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
 
 # -0 can generate spans
 opt expect=UnifyComparisonTypes
@@ -863,7 +863,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── k > NaN [type=bool, outer=(1)]
+      └── k > NaN [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
 
 # IS/IS NOT
 # We do not do the unification here (the rule matches on Const and NULL is its
@@ -930,7 +930,7 @@ project
  ├── columns: k:1(int!null)
  ├── key: (1)
  └── select
-      ├── columns: k:1(int!null) tz:4(timestamptz)
+      ├── columns: k:1(int!null) tz:4(timestamptz!null)
       ├── key: (1)
       ├── fd: (1)-->(4)
       ├── scan e@secondary
@@ -939,7 +939,7 @@ project
       │    ├── key: (1)
       │    └── fd: (1)-->(4)
       └── filters
-           └── tz > '2017-11-12 07:35:01+00:00' [type=bool, outer=(4)]
+           └── tz > '2017-11-12 07:35:01+00:00' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
 
 opt expect=UnifyComparisonTypes
 SELECT k FROM e WHERE tz > '2017-11-12 07:35:01+00:00'::TIMESTAMP
@@ -985,7 +985,7 @@ project
       │    ├── key: (1)
       │    └── fd: (1)-->(5)
       └── filters
-           └── d < '2018-07-08 00:00:01+00:00' [type=bool, outer=(5)]
+           └── d < '2018-07-08 00:00:01+00:00' [type=bool, outer=(5), constraints=(/5: (/NULL - ])]
 
 # NULL value.
 opt

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -182,7 +182,7 @@ SELECT sum(kv.w) FROM kv GROUP BY lower(s) HAVING lower(kv.s) LIKE 'test%'
 project
  ├── columns: sum:5(decimal)
  └── select
-      ├── columns: sum:5(decimal) column6:6(string)
+      ├── columns: sum:5(decimal) column6:6(string!null)
       ├── group-by
       │    ├── columns: sum:5(decimal) column6:6(string)
       │    ├── grouping columns: column6:6(string)

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -543,7 +543,7 @@ project
       │         │    │    │    │    │    └── fd: (1)-->(3,5,6)
       │         │    │    │    │    └── filters
       │         │    │    │    │         ├── p_size = 15 [type=bool, outer=(6), constraints=(/6: [/15 - /15]; tight), fd=()-->(6)]
-      │         │    │    │    │         └── p_type LIKE '%BRASS' [type=bool, outer=(5)]
+      │         │    │    │    │         └── p_type LIKE '%BRASS' [type=bool, outer=(5), constraints=(/5: (/NULL - ])]
       │         │    │    │    └── filters
       │         │    │    │         └── p_partkey = partsupp.ps_partkey [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
       │         │    │    └── filters
@@ -1331,7 +1331,7 @@ sort
       │    │    │         ├── s_suppkey = l_suppkey [type=bool, outer=(10,19), constraints=(/10: (/NULL - ]; /19: (/NULL - ]), fd=(10)==(19), (19)==(10)]
       │    │    │         └── s_nationkey = n_nationkey [type=bool, outer=(13,47), constraints=(/13: (/NULL - ]; /47: (/NULL - ]), fd=(13)==(47), (47)==(13)]
       │    │    └── filters
-      │    │         └── p_name LIKE '%green%' [type=bool, outer=(2)]
+      │    │         └── p_name LIKE '%green%' [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
       │    └── projections
       │         ├── extract('year', o_orderdate) [type=int, outer=(42)]
       │         └── (l_extendedprice * (1.0 - l_discount)) - (ps_supplycost * l_quantity) [type=float, outer=(21-23,36)]
@@ -1744,7 +1744,7 @@ sort
       │    │    │    │    ├── key: (9)
       │    │    │    │    └── fd: (9)-->(10,17)
       │    │    │    └── filters
-      │    │    │         └── o_comment NOT LIKE '%special%requests%' [type=bool, outer=(17)]
+      │    │    │         └── o_comment NOT LIKE '%special%requests%' [type=bool, outer=(17), constraints=(/17: (/NULL - ])]
       │    │    └── filters
       │    │         └── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
       │    └── aggregations
@@ -2013,7 +2013,7 @@ sort
       │    │    │    │    ├── fd: (15)-->(21)
       │    │    │    │    └── ordering: +15
       │    │    │    └── filters
-      │    │    │         └── s_comment LIKE '%Customer%Complaints%' [type=bool, outer=(21)]
+      │    │    │         └── s_comment LIKE '%Customer%Complaints%' [type=bool, outer=(21), constraints=(/21: (/NULL - ])]
       │    │    └── filters (true)
       │    ├── select
       │    │    ├── columns: p_partkey:6(int!null) p_brand:9(string!null) p_type:10(string!null) p_size:11(int!null)
@@ -2025,7 +2025,7 @@ sort
       │    │    │    └── fd: (6)-->(9-11)
       │    │    └── filters
       │    │         ├── p_brand != 'Brand#45' [type=bool, outer=(9), constraints=(/9: (/NULL - /'Brand#45') [/e'Brand#45\x00' - ]; tight)]
-      │    │         ├── p_type NOT LIKE 'MEDIUM POLISHED %' [type=bool, outer=(10)]
+      │    │         ├── p_type NOT LIKE 'MEDIUM POLISHED %' [type=bool, outer=(10), constraints=(/10: (/NULL - ])]
       │    │         └── p_size IN (3, 9, 14, 19, 23, 36, 45, 49) [type=bool, outer=(11), constraints=(/11: [/3 - /3] [/9 - /9] [/14 - /14] [/19 - /19] [/23 - /23] [/36 - /36] [/45 - /45] [/49 - /49]; tight)]
       │    └── filters
       │         └── p_partkey = ps_partkey [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
@@ -2455,7 +2455,7 @@ sort
            │    │    │    │    ├── key: (17)
            │    │    │    │    └── fd: (17)-->(18)
            │    │    │    └── filters
-           │    │    │         └── p_name LIKE 'forest%' [type=bool, outer=(18)]
+           │    │    │         └── p_name LIKE 'forest%' [type=bool, outer=(18), constraints=(/18: [/'forest' - /'foresu'); tight)]
            │    │    └── filters
            │    │         └── ps_partkey = p_partkey [type=bool, outer=(12,17), constraints=(/12: (/NULL - ]; /17: (/NULL - ]), fd=(12)==(17), (17)==(12)]
            │    └── filters


### PR DESCRIPTION
Adding constraint builder support for `LikeOp` and `SimilarToOp`. Also
improving the logic to still try to determine not-null constraints if
`buildSingleColumnConstraintConst` fails to come up with a constraint.

Related to #31929.

Release note: None