### PR TITLE
opt: Fix DetachMemo bug

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -247,7 +247,9 @@ func (ex *connExecutor) prepare(
 	//   1. Size of the query string and prepared struct.
 	//   2. Size of the prepared memo, if using the cost-based optimizer.
 	size := int64(len(prepared.Str) + int(unsafe.Sizeof(*prepared)))
-	size += prepared.Memo.MemoryEstimate()
+	if prepared.Memo != nil {
+		size += prepared.Memo.MemoryEstimate()
+	}
 	if err := prepared.memAcc.Grow(ctx, size); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/opt/norm/factory_test.go
+++ b/pkg/sql/opt/norm/factory_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package norm
+package norm_test
 
 import (
 	"testing"
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
@@ -29,7 +30,7 @@ import (
 // operator is created.
 func TestSimplifyFilters(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
-	var f Factory
+	var f norm.Factory
 	f.Init(&evalCtx)
 
 	cat := createFiltersCatalog(t)

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -110,15 +110,13 @@ func (o *Optimizer) Init(evalCtx *tree.EvalContext) {
 	}
 }
 
-// DetachMemo copies the memo from the optimizer to the given memo, and then
-// clears the optimizer's copy of the memo so that reuse of the optimizer will
-// not impact the detached copy. In addition, the optimizer is reinitialized so
-// that it cannot be used with a detached memo. This method is used to extract
-// a read-only memo during the PREPARE phase.
-func (o *Optimizer) DetachMemo(to *memo.Memo) {
-	*to = *o.mem
-	*o.mem = memo.Memo{}
+// DetachMemo extracts the memo from the optimizer, and then re-initializes the
+// optimizer so that its reuse will not impact the detached memo. This method is
+// used to extract a read-only memo during the PREPARE phase.
+func (o *Optimizer) DetachMemo() *memo.Memo {
+	detach := o.f.DetachMemo()
 	o.Init(o.evalCtx)
+	return detach
 }
 
 // Factory returns a factory interface that the caller uses to construct an

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -43,7 +43,7 @@ type PreparedStatement struct {
 	// Memo is the memoized data structure constructed by the cost-based optimizer
 	// during prepare of a SQL statement. It can significantly speed up execution
 	// if it is used by the optimizer as a starting point.
-	Memo memo.Memo
+	Memo *memo.Memo
 	// TypeHints contains the types of the placeholders set by the client. It
 	// dictates how input parameters for those placeholders will be parsed. If a
 	// placeholder has no type hint, it will be populated during type checking.


### PR DESCRIPTION
During the PREPARE phase, a Memo is detached from the Optimizer and copied
into the prepared statement. However, because the Memo was embedded in the
Optimizer, the expressions within the Memo were still pointing to that Memo
rather than the prepared Memo.

The fix is to always allocate the Memo on the heap rather than embedding it.
DetachMemo simply extracts the pointer, which is stored in the prepared
statement.

Release note: None