### PR TITLE
roachpb: InitPut requests no longer needRefresh

### DIFF
--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -2150,7 +2150,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *client.Txn) error {
 				// Advance timestamp. This also creates a refresh span which
 				// will prevent the txn from committing without a refresh.
-				if err := txn.InitPut(ctx, "a", "put", false); err != nil {
+				if err := txn.DelRange(ctx, "a", "b"); err != nil {
 					return err
 				}
 				// Make the final batch large enough such that if we accounted

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -965,23 +965,19 @@ func (*ConditionalPutRequest) flags() int {
 
 // InitPut, like ConditionalPut, effectively reads and may not write.
 // It also may return the actual data read on ConditionFailedErrors,
-// so must update the timestamp cache on errors.
-//
-// Unlike CPut, InitPuts require a refresh because they may execute
-// successfully without leaving an intent (i.e., when the existing
-// value is equal to the proposed value).
-// TODO(nvanbenschoten): As of #27302, this is no longer true. We
-// can remove needsRefresh in v2.2, at which point no node in a
-// cluster can be running a binary without the referenced change.
+// so must update the timestamp cache on errors. InitPuts do not require
+// a refresh because on write-too-old errors, they return an error
+// immediately instead of continuing a serializable transaction to be
+// retried at end transaction.
 func (*InitPutRequest) flags() int {
-	return isRead | isWrite | isTxn | isTxnWrite | updatesReadTSCache | updatesTSCacheOnError | needsRefresh | consultsTSCache
+	return isRead | isWrite | isTxn | isTxnWrite | updatesReadTSCache | updatesTSCacheOnError | consultsTSCache
 }
 
 // Increment reads the existing value, but always leaves an intent so
-// it does not need to update the timestamp cache. It also does not
-// require refresh because on write-too-old errors experienced during
-// serializable transactions, increment returns the error instead of
-// continuing the transaction.
+// it does not need to update the timestamp cache. Increments do not
+// require a refresh because on write-too-old errors, they return an
+// error immediately instead of continuing a serializable transaction
+// to be retried at end transaction.
 func (*IncrementRequest) flags() int {
 	return isRead | isWrite | isTxn | isTxnWrite | consultsTSCache
 }

--- a/pkg/roachpb/batch_test.go
+++ b/pkg/roachpb/batch_test.go
@@ -265,8 +265,8 @@ func TestRefreshSpanIterate(t *testing.T) {
 		return true
 	}
 	ba.RefreshSpanIterate(&br, fn)
-	// Only the conditional put isn't considered a read span.
-	expReadSpans := []Span{testCases[2].span, testCases[4].span, testCases[5].span, testCases[6].span}
+	// The conditional put and init put are not considered read spans.
+	expReadSpans := []Span{testCases[4].span, testCases[5].span, testCases[6].span}
 	expWriteSpans := []Span{testCases[7].span}
 	if !reflect.DeepEqual(expReadSpans, readSpans) {
 		t.Fatalf("unexpected read spans: expected %+v, found = %+v", expReadSpans, readSpans)
@@ -291,7 +291,6 @@ func TestRefreshSpanIterate(t *testing.T) {
 	writeSpans = []Span{}
 	ba.RefreshSpanIterate(&br, fn)
 	expReadSpans = []Span{
-		{Key: Key("a-initput")},
 		{Key("a"), Key("b")},
 		{Key: Key("b")},
 		{Key("e"), Key("f")},


### PR DESCRIPTION
Closes #30077.

This change reverts the primary change in #22965, which is no longer needed
because of #27302. Before #27302, `InitPuts` needed a refresh because it was
possible for them to read a key but not end up writing anything. This is no
longer the case - they will either return an error immediately (see #22899)
or write an intent.

This change is safe to make in 2.2 because all requirements for it are in
2.1 binaries.

Release note: None