### PR TITLE
roachtest: update the hibernate blacklist with a new passing test

### DIFF
--- a/pkg/cmd/roachtest/hibernate_blacklist.go
+++ b/pkg/cmd/roachtest/hibernate_blacklist.go
@@ -256,7 +256,6 @@ var hibernateBlackList2_2 = blacklist{
 	"org.hibernate.test.jpa.lock.RepeatableReadTest.testStaleNonVersionedInstanceFoundOnLock":                                                                                        "31671",
 	"org.hibernate.test.jpa.lock.RepeatableReadTest.testStaleVersionedInstanceFoundOnLock":                                                                                           "6583",
 	"org.hibernate.test.legacy.ABCProxyTest.testSubclassing":                                                                                                                         "6583",
-	"org.hibernate.test.legacy.FooBarTest.testCollectionsInSelect":                                                                                                                   "31777",
 	"org.hibernate.test.legacy.FooBarTest.testOnCascadeDelete":                                                                                                                       "unknown",
 	"org.hibernate.test.legacy.FooBarTest.testQuery":                                                                                                                                 "unknown",
 	"org.hibernate.test.legacy.FooBarTest.testVersioning":                                                                                                                            "6583",


### PR DESCRIPTION
Fixes #31943.

Release note: None