### PR TITLE
sql: add experimental_vectorize settings

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -59,6 +59,7 @@
 <tr><td><code>server.time_until_store_dead</code></td><td>duration</td><td><code>5m0s</code></td><td>the time after which if there is no new gossiped information about a store, it is considered dead</td></tr>
 <tr><td><code>server.web_session_timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that a newly created web session will be valid</td></tr>
 <tr><td><code>sql.defaults.distsql</code></td><td>enumeration</td><td><code>1</code></td><td>default distributed SQL execution mode [off = 0, auto = 1, on = 2, 2.0-off = 3, 2.0-auto = 4]</td></tr>
+<tr><td><code>sql.defaults.experimental_vectorize</code></td><td>boolean</td><td><code>false</code></td><td>default experimental_vectorize mode</td></tr>
 <tr><td><code>sql.defaults.optimizer</code></td><td>enumeration</td><td><code>1</code></td><td>default cost-based optimizer mode [off = 0, on = 1, local = 2]</td></tr>
 <tr><td><code>sql.defaults.serial_normalization</code></td><td>enumeration</td><td><code>0</code></td><td>default handling of SERIAL in table definitions [rowid = 0, virtual_sequence = 1, sql_sequence = 2]</td></tr>
 <tr><td><code>sql.distsql.distribute_index_joins</code></td><td>boolean</td><td><code>true</code></td><td>if set, for index joins we instantiate a join reader on every node that has a stream; if not set, we use a single join reader</td></tr>

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -115,6 +115,14 @@ var OptimizerClusterMode = settings.RegisterEnumSetting(
 	},
 )
 
+// VectorizeClusterMode controls the cluster default for when automatic
+// vectorization is enabled.
+var VectorizeClusterMode = settings.RegisterBoolSetting(
+	"sql.defaults.experimental_vectorize",
+	"default experimental_vectorize mode",
+	false,
+)
+
 // DistSQLClusterExecMode controls the cluster default for when DistSQL is used.
 var DistSQLClusterExecMode = settings.RegisterEnumSetting(
 	"sql.defaults.distsql",
@@ -1620,6 +1628,10 @@ func (m *sessionDataMutator) SetForceSplitAt(val bool) {
 
 func (m *sessionDataMutator) SetZigzagJoinEnabled(val bool) {
 	m.data.ZigzagJoinEnabled = val
+}
+
+func (m *sessionDataMutator) SetVectorize(val bool) {
+	m.data.Vectorize = val
 }
 
 func (m *sessionDataMutator) SetOptimizerMode(val sessiondata.OptimizerMode) {

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1338,6 +1338,7 @@ experimental_force_lookup_join     off           NULL      NULL        NULL     
 experimental_force_split_at        off           NULL      NULL        NULL        string
 experimental_force_zigzag_join     off           NULL      NULL        NULL        string
 experimental_serial_normalization  rowid         NULL      NULL        NULL        string
+experimental_vectorize             off           NULL      NULL        NULL        string
 extra_float_digits                 0             NULL      NULL        NULL        string
 integer_datetimes                  on            NULL      NULL        NULL        string
 intervalstyle                      postgres      NULL      NULL        NULL        string
@@ -1380,6 +1381,7 @@ experimental_force_lookup_join     off           NULL  user     NULL      off   
 experimental_force_split_at        off           NULL  user     NULL      off           off
 experimental_force_zigzag_join     off           NULL  user     NULL      off           off
 experimental_serial_normalization  rowid         NULL  user     NULL      rowid         rowid
+experimental_vectorize             off           NULL  user     NULL      off           off
 extra_float_digits                 0             NULL  user     NULL      0             2
 integer_datetimes                  on            NULL  user     NULL      on            on
 intervalstyle                      postgres      NULL  user     NULL      postgres      postgres
@@ -1418,6 +1420,7 @@ experimental_force_lookup_join     NULL    NULL     NULL     NULL        NULL
 experimental_force_split_at        NULL    NULL     NULL     NULL        NULL
 experimental_force_zigzag_join     NULL    NULL     NULL     NULL        NULL
 experimental_serial_normalization  NULL    NULL     NULL     NULL        NULL
+experimental_vectorize             NULL    NULL     NULL     NULL        NULL
 extra_float_digits                 NULL    NULL     NULL     NULL        NULL
 integer_datetimes                  NULL    NULL     NULL     NULL        NULL
 intervalstyle                      NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -37,6 +37,7 @@ experimental_force_lookup_join     off
 experimental_force_split_at        off
 experimental_force_zigzag_join     off
 experimental_serial_normalization  rowid
+experimental_vectorize             off
 extra_float_digits                 0
 integer_datetimes                  on
 intervalstyle                      postgres

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -171,7 +171,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'database'
       └── values  ·       ·
-·                 size    2 columns, 34 rows
+·                 size    2 columns, 35 rows
 
 query TTT
 EXPLAIN SHOW TIME ZONE
@@ -180,7 +180,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'timezone'
       └── values  ·       ·
-·                 size    2 columns, 34 rows
+·                 size    2 columns, 35 rows
 
 query TTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -189,7 +189,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'default_transaction_isolation'
       └── values  ·       ·
-·                 size    2 columns, 34 rows
+·                 size    2 columns, 35 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -198,7 +198,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'transaction_isolation'
       └── values  ·       ·
-·                 size    2 columns, 34 rows
+·                 size    2 columns, 35 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -207,7 +207,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'transaction_priority'
       └── values  ·       ·
-·                 size    2 columns, 34 rows
+·                 size    2 columns, 35 rows
 
 query TTT
 EXPLAIN SHOW COLUMNS FROM foo

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -162,7 +162,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'database'
       └── values  ·       ·
-·                 size    2 columns, 34 rows
+·                 size    2 columns, 35 rows
 
 query TTT
 EXPLAIN SHOW TIME ZONE
@@ -171,7 +171,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'timezone'
       └── values  ·       ·
-·                 size    2 columns, 34 rows
+·                 size    2 columns, 35 rows
 
 query TTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -180,7 +180,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'default_transaction_isolation'
       └── values  ·       ·
-·                 size    2 columns, 34 rows
+·                 size    2 columns, 35 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -189,7 +189,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'transaction_isolation'
       └── values  ·       ·
-·                 size    2 columns, 34 rows
+·                 size    2 columns, 35 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -198,7 +198,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'transaction_priority'
       └── values  ·       ·
-·                 size    2 columns, 34 rows
+·                 size    2 columns, 35 rows
 
 query TTT
 EXPLAIN SHOW COLUMNS FROM foo

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -80,6 +80,8 @@ type SessionData struct {
 	// DurationAdditionMode enables math compatibility options to be enabled.
 	// TODO(bob): Remove this once the 2.2 release branch is cut.
 	DurationAdditionMode duration.AdditionMode
+	// Vectorize enables automatic planning of vectorized operators.
+	Vectorize bool
 }
 
 // DataConversionConfig contains the parameters that influence

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -325,6 +325,25 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`experimental_vectorize`: {
+		GetStringVal: makeBoolGetStringValFn(`experimental_vectorize`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := parsePostgresBool(s)
+			if err != nil {
+				return err
+			}
+			m.SetVectorize(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.Vectorize)
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(VectorizeClusterMode.Get(sv))
+		},
+	},
+
+	// CockroachDB extension.
 	`optimizer`: {
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
 			mode, ok := sessiondata.OptimizerModeFromString(s)


### PR DESCRIPTION
Add the experimental_vectorize session setting, which will control
whether or not automatic best effort planning of columnar execution
operators is enabled.

Add the sql.defaults.experimentaL_vectorize cluster setting, which
controls the default setting of experimental_vectorize for new sessions.

Release note: None