### PR TITLE
storage: de-flake TestPushTxnHeartbeatTimeout

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -5685,8 +5685,8 @@ func TestPushTxnHeartbeatTimeout(t *testing.T) {
 
 	for i, test := range testCases {
 		key := roachpb.Key(fmt.Sprintf("key-%d", i))
-		pushee := newTransaction(fmt.Sprintf("test-%d", i), key, 1, enginepb.SERIALIZABLE, tc.Clock())
-		pusher := newTransaction("pusher", key, 1, enginepb.SERIALIZABLE, tc.Clock())
+		pushee := newTransaction(fmt.Sprintf("test-%d", i), key, roachpb.MaxUserPriority, enginepb.SERIALIZABLE, tc.Clock())
+		pusher := newTransaction("pusher", key, roachpb.MinUserPriority, enginepb.SERIALIZABLE, tc.Clock())
 
 		// First, establish "start" of existing pushee's txn via BeginTransaction.
 		if test.heartbeat != (hlc.Timestamp{}) {


### PR DESCRIPTION
The pusher and pushee txn used in this test used randomized priorities,
which could sometimes lead to a successful push when one wasn't
expected.

Fixes #31859.

Release note: None