### PR TITLE
roachtest: add tpcc w/ 11 nodes a 32 cpus

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -767,6 +767,15 @@ func registerTPCCBench(r *registry) {
 			EstimatedMax:   12000,
 			LoadConfig:     singlePartitionedLoadgen,
 		},
+
+		// Requested by @awoods87.
+		{
+			Nodes: 11,
+			CPUs:  32,
+
+			LoadWarehouses: 10000,
+			EstimatedMax:   8000,
+		},
 	}
 
 	for _, b := range specs {


### PR DESCRIPTION
This is a configuration that @awoods187 and I want to make sure we can
get performance numbers for.

Release note: None