### PR TITLE
opt: add testing infrastructure to perturb plan cost

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -365,6 +365,10 @@ var (
 	disableOptRuleProbability = flag.Float64(
 		"disable-opt-rule-probability", 0,
 		"disable transformation rules in the cost-based optimizer with the given probability.")
+	optimizerCostPerturbation = flag.Float64(
+		"optimizer-cost-perturbation", 0,
+		"randomly perturb the estimated cost of each expression in the query tree by at most the "+
+			"given fraction for the purpose of creating alternate query plans in the optimizer.")
 )
 
 type testClusterConfig struct {
@@ -953,6 +957,7 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 					AssertUnaryExprReturnTypes:      true,
 					AssertFuncExprReturnTypes:       true,
 					DisableOptimizerRuleProbability: *disableOptRuleProbability,
+					OptimizerCostPerturbation:       *optimizerCostPerturbation,
 				},
 				Upgrade: &server.UpgradeTestingKnobs{
 					DisableUpgrade: cfg.disableUpgrade,

--- a/pkg/sql/logictest/testdata/logic_test/ordinality
+++ b/pkg/sql/logictest/testdata/logic_test/ordinality
@@ -33,7 +33,7 @@ SELECT max(ordinality) FROM foo WITH ORDINALITY
 ----
 2
 
-query TITI
+query TITI rowsort
 SELECT * FROM foo WITH ORDINALITY AS a, foo WITH ORDINALITY AS b
 ----
 a 1 a 1

--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -118,7 +118,7 @@ SELECT * FROM generate_series('2017-11-11 00:00:00'::TIMESTAMP, '2017-11-11 03:0
 ----
 generate_series
 
-query II colnames
+query II colnames,rowsort
 SELECT * FROM generate_series(1, 2), generate_series(1, 2)
 ----
 generate_series  generate_series
@@ -213,7 +213,7 @@ a    b     generate_series generate_series
 cat  bird  1               3
 cat  bird  2               4
 
-query TTII colnames
+query TTII colnames,rowsort
 SELECT t.*, u.*, a.*, b.* FROM t, u, generate_series(1, 2) AS a, generate_series(3, 4) AS b
 ----
 a    b     a  b

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -100,7 +100,7 @@ func (o *Optimizer) Init(evalCtx *tree.EvalContext) {
 	o.f.Init(evalCtx)
 	o.mem = o.f.Memo()
 	o.explorer.init(o)
-	o.defaultCoster.Init(o.mem)
+	o.defaultCoster.Init(o.mem, evalCtx.TestingKnobs.OptimizerCostPerturbation)
 	o.coster = &o.defaultCoster
 	o.stateMap = make(map[groupStateKey]*groupState)
 	o.matchedRule = nil

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2401,6 +2401,10 @@ type EvalContextTestingKnobs struct {
 	// DisableOptimizerRuleProbability is the probability that any given
 	// transformation rule in the optimizer is disabled.
 	DisableOptimizerRuleProbability float64
+	// OptimizerCostPerturbation is used to randomly perturb the estimated
+	// cost of each expression in the query tree for the purpose of creating
+	// alternate query plans in the optimizer.
+	OptimizerCostPerturbation float64
 }
 
 var _ base.ModuleTestingKnobs = &EvalContextTestingKnobs{}


### PR DESCRIPTION
This commit adds testing infrastructure for randomly perturbing the
cost of expressions in the optimizer. The goal is to test that
alternate plans produced by the optimizer are logically equivalent.
It can be used to test that the logic tests still pass with alternate
query plans as follows:
```
  > make test PKG=./pkg/sql/logictest/... TESTS='TestLogic/local-opt/.*' \
    TESTFLAGS='-optimizer-cost-perturbation=0.5'
```
This test indicates the cost of each expression in the optimizer will
be perturbed by at most 50%. In other words, if the cost of an expression
is `c`, the perturbed cost will be in the range `[c - 0.5 * c, c + 0.5 * c]`.
The value of `-optimizer-cost-perturbation` can be any real floating point
value.

Note that this new infrastructure is complementary to the existing
infrastructure for disabling rules in the optimizer, which is tested with
the flag `-disable-opt-rule-probability`. `-optimizer-cost-perturbation` adds
the ability to test alternate plans produced by different exploration rules,
which cannot be tested by `-disable-opt-rule-probability`.

Fixes #31969

Release note: None