### PR TITLE
build: add optimizer tests to nightly testrace tests

### DIFF
--- a/build/teamcity-testlogicrace.sh
+++ b/build/teamcity-testlogicrace.sh
@@ -16,3 +16,40 @@ build/builder.sh env \
 	2>&1 \
 	| tee artifacts/testlogicrace.log \
 	| go-test-teamcity
+
+# Run each of the optimizer tests again with randomized alternate query plans.
+
+# Perturb the cost of each expression by up to 90%.
+build/builder.sh env \
+	make testrace \
+	PKG=./pkg/sql/logictest \
+	TESTS='^TestLogic/local-opt$$' \
+	TESTFLAGS='-optimizer-cost-perturbation=0.9 -v' \
+	ENABLE_ROCKSDB_ASSERTIONS=1 \
+	2>&1 \
+	| tee artifacts/altplan-testlogicrace.log \
+	| go-test-teamcity
+
+LOGICTESTS=`ls -A pkg/sql/logictest/testdata/logic_test/`
+
+# Exclude the following tests when running with -disable-opt-rule-probability.
+# These files either do not use the opt configurations or contain queries that
+# rely on normalization rules for optimization, to avoid out-of-memory errors,
+# or for subquery decorrelation.
+EXCLUDE="(cluster_version|distsql_.*|explain_analyze.*|feature_counts|join|\
+optimizer|orms|sequences_distsql|show_trace|subquery_correlated)"
+
+# Disable each rule with 50% probability.
+for file in $LOGICTESTS; do
+	  if [[ ! "$file" =~ (^|[[:space:]])${EXCLUDE}($|[[:space:]]) ]]; then
+	      build/builder.sh env \
+	        make testrace \
+	        PKG=./pkg/sql/logictest \
+	        TESTS='^TestLogic/local-opt/'${file}'$$' \
+	        TESTFLAGS='-disable-opt-rule-probability=0.5 -v' \
+	        ENABLE_ROCKSDB_ASSERTIONS=1 \
+	        2>&1 \
+	        | tee artifacts/disablerules-testlogicrace-${file}.log \
+	        | go-test-teamcity
+	  fi
+done


### PR DESCRIPTION
This commit adds nightly tests for running the testrace logic tests with
two different flags which create alternate query plans:

 `-optimizer-cost-perturbation=p`

    This flag randomly perturbs the cost of each expression in the
    optimizer by at most p. In other words, if the cost of an expression
    is c, the perturbed cost will be in the range [c - p * c, c + p * c).
    This flag allows us to test that alternate plans created by exploration
    rules are logically equivalent to the lowest cost plan.

 `-disable-opt-rule-probability=p`

    This flag randomly disables each transformation rule in the optimizer
    with probability p. This flag allows us to test that alternate plans
    created by disabling certain rules are logically equivalent to the
    plan that would be created with all rules enabled.

Fixes #31969

Release note: None