### PR TITLE
storageccl: fix buglet serializing params back to flags

### DIFF
--- a/pkg/ccl/storageccl/export_storage.go
+++ b/pkg/ccl/storageccl/export_storage.go
@@ -878,13 +878,7 @@ func parseWorkloadConfig(uri *url.URL) (*roachpb.ExportStorage_Workload, error) 
 	}
 	for k, vs := range q {
 		for _, v := range vs {
-			var flag string
-			if len(v) > 0 {
-				flag = `--` + k + `=` + v
-			} else {
-				flag = `--` + k
-			}
-			c.Flags = append(c.Flags, flag)
+			c.Flags = append(c.Flags, `--`+k+`=`+v)
 		}
 	}
 	return c, nil

--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -320,7 +320,11 @@ func csvServerPaths(
 			`version`:   []string{gen.Meta().Version},
 		}
 		if f, ok := gen.(workload.Flagser); ok {
-			f.Flags().VisitAll(func(f *pflag.Flag) {
+			flags := f.Flags()
+			flags.VisitAll(func(f *pflag.Flag) {
+				if flags.Meta[f.Name].RuntimeOnly {
+					return
+				}
 				params[f.Name] = append(params[f.Name], f.Value.String())
 			})
 		}

--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -37,12 +37,14 @@ const fixtureTestGenRows = 10
 type fixtureTestGen struct {
 	flags workload.Flags
 	val   string
+	empty string
 }
 
 func makeTestWorkload() workload.Flagser {
 	g := &fixtureTestGen{}
 	g.flags.FlagSet = pflag.NewFlagSet(`fx`, pflag.ContinueOnError)
 	g.flags.StringVar(&g.val, `val`, `default`, `The value for each row`)
+	g.flags.StringVar(&g.empty, `empty`, ``, `An empty flag`)
 	return g
 }
 


### PR DESCRIPTION
It seems I was too clever when serializing the url parameters as flags
in experimental-workload. Omitting the "=value" when value was empty was
causing the next flag to be intrepreted as the flag value.

While investigating, noticed that csvServerPaths was unnecessarily
including runtime only flags, which is also fixed here. No test since by
definition, the generated fixture should be the same (and it will work
if they're included, the generated urls are just more noisy).

Release note: None