### PR TITLE
storageccl: update azure sdk to remove panics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,12 +26,12 @@
   version = "0.1.7"
 
 [[projects]]
-  branch = "master"
-  digest = "1:44ccea63fc921ce3e49bb0832df9b3a3bca219f3990e76d58f7b7f2884e0ebdc"
+  digest = "1:c4a5edf3b0f38e709a78dcc945997678a364c2b5adfd48842a3dd349c352f833"
   name = "github.com/Azure/azure-storage-blob-go"
-  packages = ["2017-07-29/azblob"]
+  packages = ["azblob"]
   pruneopts = "UT"
-  revision = "197d1c0aea1b9eedbbaee0a1a32bf81e879bde80"
+  revision = "5152f14ace1c6db66bd9cb57840703a8358fa7bc"
+  version = "0.3.0"
 
 [[projects]]
   branch = "master"
@@ -1638,7 +1638,7 @@
   analyzer-version = 1
   input-imports = [
     "cloud.google.com/go/storage",
-    "github.com/Azure/azure-storage-blob-go/2017-07-29/azblob",
+    "github.com/Azure/azure-storage-blob-go/azblob",
     "github.com/MichaelTJones/walk",
     "github.com/PuerkitoBio/goquery",
     "github.com/Shopify/sarama",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -75,12 +75,6 @@ ignored = [
   name = "github.com/satori/go.uuid"
   version = "v1.2.0"
 
-# Use master until 0562badec5489e409f1b18596e3f77a309420a84 is in a
-# tagged release.
-[[constraint]]
-  name = "github.com/Azure/azure-storage-blob-go"
-  branch = "master"
-
 # We want https://github.com/go-yaml/yaml/pull/381
 [[constraint]]
   name = "gopkg.in/yaml.v2"

--- a/pkg/ccl/storageccl/export_storage.go
+++ b/pkg/ccl/storageccl/export_storage.go
@@ -28,7 +28,7 @@ import (
 	"google.golang.org/api/option"
 
 	gcs "cloud.google.com/go/storage"
-	"github.com/Azure/azure-storage-blob-go/2017-07-29/azblob"
+	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -777,7 +777,10 @@ func makeAzureStorage(
 	if conf == nil {
 		return nil, errors.Errorf("azure upload requested but info missing")
 	}
-	credential := azblob.NewSharedKeyCredential(conf.AccountName, conf.AccountKey)
+	credential, err := azblob.NewSharedKeyCredential(conf.AccountName, conf.AccountKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "azure credential")
+	}
 	p := azblob.NewPipeline(credential, azblob.PipelineOptions{})
 	u, err := url.Parse(fmt.Sprintf("https://%s.blob.core.windows.net", conf.AccountName))
 	if err != nil {


### PR DESCRIPTION
Fixes #31972

Release note (bug fix): Fixed a panic when specifying incorrectly encoded
Azure credentials.