### PR TITLE
roachtest: add nodeSpec.String()

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -495,6 +495,14 @@ type nodeSpec struct {
 	Lifetime time.Duration
 }
 
+func (s *nodeSpec) String() string {
+	str := fmt.Sprintf("n%dcpu%d", s.Count, s.CPUs)
+	if s.Geo {
+		str += "-geo"
+	}
+	return str
+}
+
 func (s *nodeSpec) args() []string {
 	var args []string
 


### PR DESCRIPTION
To be used for cluster naming, among others.

Release note: None