### PR TITLE
sql: check uncommitted tables for created tables in same txn

### DIFF
--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -173,7 +173,7 @@ func TestMysqldumpSchemaReader(t *testing.T) {
 	referencedSimple := descForTable(t, readFile(t, `simple.cockroach-schema.sql`), expectedParent, 52, NoFKs)
 	fks := fkHandler{
 		allowed:  true,
-		resolver: fkResolver(map[string]*sqlbase.MutableTableDescriptor{referencedSimple.Name: sql.NewMutableTableDescriptor(*referencedSimple)}),
+		resolver: fkResolver(map[string]*sqlbase.MutableTableDescriptor{referencedSimple.Name: sql.NewMutableTableDescriptor(*referencedSimple, sqlbase.TableDescriptor{})}),
 	}
 
 	t.Run("simple", func(t *testing.T) {

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -611,7 +611,7 @@ func columnBackfillInTxn(
 	// All the FKs here are guaranteed to be created in the same transaction
 	// or else this table would be created in the ADD state.
 	for k := range fkTables {
-		if !tc.isCreatedTable(k) {
+		if t := tc.getUncommittedTableByID(k); t == nil || !t.IsNewTable() {
 			return errors.Errorf(
 				"table %s not created in the same transaction as id = %d", tableDesc.Name, k)
 		}

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -97,9 +97,6 @@ func doCreateSequence(
 		return err
 	}
 
-	// Remember the new descriptor for further uses in the same transaction.
-	params.p.Tables().addCreatedTable(id)
-
 	// Initialize the sequence value.
 	seqValueKey := keys.MakeSequenceKey(uint32(id))
 	b := &client.Batch{}

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -157,7 +157,7 @@ func (n *createViewNode) startExec(params runParams) error {
 		backrefID := updated.desc.ID
 		backRefMutable := params.p.Tables().getUncommittedTableByID(backrefID)
 		if backRefMutable == nil {
-			backRefMutable = NewMutableTableDescriptor(*updated.desc)
+			backRefMutable = NewMutableTableDescriptor(*updated.desc, *updated.desc)
 		}
 		for _, dep := range updated.deps {
 			// The logical plan constructor merely registered the dependencies.

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -130,7 +130,7 @@ func (p *planner) createDescriptorWithID(
 		mutDesc = d
 		isTable = true
 	case *sqlbase.TableDescriptor:
-		mutDesc = NewMutableTableDescriptor(*d)
+		mutDesc = NewMutableTableDescriptor(*d, sqlbase.TableDescriptor{})
 		isTable = true
 	}
 

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -157,7 +157,8 @@ func resolveExistingObjectImpl(
 		if mutDesc, ok := descI.(*MutableTableDescriptor); ok {
 			return mutDesc, nil
 		}
-		return NewMutableTableDescriptor(*descI.(*TableDescriptor)), nil
+		tbl := *descI.(*TableDescriptor)
+		return NewMutableTableDescriptor(tbl, tbl), nil
 	}
 
 	return obj.TableDesc(), nil

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -107,6 +107,9 @@ type MutationID uint32
 // going through mutations.
 type MutableTableDescriptor struct {
 	TableDescriptor
+
+	// ClusterVersion represents the version of the table descriptor read from the store.
+	ClusterVersion TableDescriptor
 }
 
 // InvalidMutationID is the uninitialised mutation id.
@@ -2116,6 +2119,12 @@ func (desc *TableDescriptor) Dropped() bool {
 // Adding returns true if the table is being added.
 func (desc *TableDescriptor) Adding() bool {
 	return desc.State == TableDescriptor_ADD
+}
+
+// IsNewTable returns true if the table was created in the current
+// transaction.
+func (desc *MutableTableDescriptor) IsNewTable() bool {
+	return desc.ClusterVersion.ID == InvalidID
 }
 
 // HasDrainingNames returns true if a draining name exists.

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -155,9 +155,6 @@ type TableCollection struct {
 	// table is marked dropped.
 	uncommittedTables []*sqlbase.MutableTableDescriptor
 
-	// Map of tables created in the transaction.
-	createdTables map[sqlbase.ID]struct{}
-
 	// databaseCache is used as a cache for database names.
 	// TODO(andrei): get rid of it and replace it with a leasing system for
 	// database descriptors.
@@ -398,7 +395,7 @@ func (tc *TableCollection) getMutableTableVersionByID(
 	if err != nil {
 		return nil, err
 	}
-	return NewMutableTableDescriptor(*table), nil
+	return NewMutableTableDescriptor(*table, *table), nil
 }
 
 func (tc *TableCollection) releaseLeases(ctx context.Context) {
@@ -417,7 +414,6 @@ func (tc *TableCollection) releaseLeases(ctx context.Context) {
 func (tc *TableCollection) releaseTables(ctx context.Context) {
 	tc.releaseLeases(ctx)
 	tc.uncommittedTables = nil
-	tc.createdTables = nil
 	tc.uncommittedDatabases = nil
 	tc.releaseAllDescriptors()
 }
@@ -470,19 +466,6 @@ func (tc *TableCollection) addUncommittedTable(desc sqlbase.MutableTableDescript
 	tc.releaseAllDescriptors()
 }
 
-func (tc *TableCollection) addCreatedTable(id sqlbase.ID) {
-	if tc.createdTables == nil {
-		tc.createdTables = make(map[sqlbase.ID]struct{})
-	}
-	tc.createdTables[id] = struct{}{}
-	tc.releaseAllDescriptors()
-}
-
-func (tc *TableCollection) isCreatedTable(id sqlbase.ID) bool {
-	_, ok := tc.createdTables[id]
-	return ok
-}
-
 // returns all the idVersion pairs that have undergone a schema change.
 // Returns nil for no schema changes. The version returned for each
 // schema change is Version - 2, because that's the one that will be
@@ -491,7 +474,7 @@ func (tc *TableCollection) isCreatedTable(id sqlbase.ID) bool {
 func (tc *TableCollection) getTablesWithNewVersion() []IDVersion {
 	var tables []IDVersion
 	for _, table := range tc.uncommittedTables {
-		if !tc.isCreatedTable(table.ID) {
+		if !table.IsNewTable() {
 			tables = append(tables, IDVersion{
 				name: table.Name,
 				id:   table.ID,
@@ -803,7 +786,7 @@ func (p *planner) writeTableDescToBatch(
 		return pgerror.NewAssertionErrorf("virtual descriptors cannot be stored, found: %v", tableDesc)
 	}
 
-	if p.Tables().isCreatedTable(tableDesc.ID) {
+	if tableDesc.IsNewTable() {
 		if err := runSchemaChangesInTxn(ctx,
 			p.txn,
 			p.Tables(),

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -191,7 +191,7 @@ func (p *planner) truncateTable(
 		return err
 	}
 	tableDesc.DropJobID = dropJobID
-	newTableDesc := NewMutableTableDescriptor(tableDesc.TableDescriptor)
+	newTableDesc := NewMutableTableDescriptor(tableDesc.TableDescriptor, sqlbase.TableDescriptor{})
 	newTableDesc.ReplacementOf = sqlbase.TableDescriptor_Replacement{
 		ID: id, Time: p.txn.CommitTimestamp(),
 	}
@@ -273,8 +273,6 @@ func (p *planner) truncateTable(
 		ctx, key, newID, newTableDesc, p.ExtendedEvalContext().Settings); err != nil {
 		return err
 	}
-
-	p.Tables().addCreatedTable(newID)
 
 	// Copy the zone config.
 	b = &client.Batch{}


### PR DESCRIPTION
Add a new field to MutableTableDescriptor which describes the table
schema as seen by the cluster outside of the current transaction. This
change also removes createdTables set in the table collection, and
checks if a table has been created in the same transaction if the
outside view of the table is nil.

Release note: None