### PR TITLE
storage: prevent subsumed replicas from quiescing

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -1973,8 +1973,6 @@ func TestStoreRangeMergeAbandonedFollowers(t *testing.T) {
 func TestStoreRangeMergeAbandonedFollowersAutomaticallyGarbageCollected(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("this test occasionally flakes if the RHS quiesces")
-
 	ctx := context.Background()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableReplicateQueue = true


### PR DESCRIPTION
Suppose the LHS replica of a merge never applies the merge trigger on
one of the involved stores. The corresponding RHS will become orphaned
and need to be cleaned up by the replica GC queue. If the range is
unquiesced, the RHS replica will, within a few hundred milliseconds, try
to contact its peers, receive a RangeNotFound error, and add itself to
the GC queue. If, however, the range is quiescent, it will not notice
that its peers have gone away, and it may not be picked up for
processing by the replica GC queue for ReplicaGCQueueInactivityThreshold
(10 days!).

Avoid this problem by preventing ranges that either are in the process
of subsuming or have been subsumed from quiescing.

Note that a similar problem occurs if a node is rebooted with orphaned
replicas, as the replicas will be dormant after the reboot and will not
notice if their peers have gone away. Fixing this problem is left to
a later commit.

Release note: None