### PR TITLE
storage: deflake TestRaftSSTableSideloadingProposal

### DIFF
--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -651,7 +651,7 @@ func TestRaftSSTableSideloadingSideload(t *testing.T) {
 
 func makeInMemSideloaded(repl *Replica) {
 	repl.raftMu.Lock()
-	repl.raftMu.sideloaded = mustNewInMemSideloadStorage(repl.RangeID, 0, "")
+	repl.raftMu.sideloaded = mustNewInMemSideloadStorage(repl.RangeID, 0, repl.store.engine.GetAuxiliaryDir())
 	repl.raftMu.Unlock()
 }
 


### PR DESCRIPTION
Due to not passing a directory, sideloaded files for all concurrently
running processes would use the same one and would run into each other.

Fixes #31962.

Release note: None