### PR TITLE
exec: coalescer

### DIFF
--- a/pkg/sql/exec/coalescer.go
+++ b/pkg/sql/exec/coalescer.go
@@ -1,0 +1,97 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+// coalescerOp consumes the input operator and coalesces the resulting batches
+// to return full batches of ColBatchSize.
+type coalescerOp struct {
+	input      Operator
+	inputTypes []types.T
+
+	group  ColBatch
+	buffer ColBatch
+}
+
+var _ Operator = &coalescerOp{}
+
+// NewCoalescerOp creates a new coalescer operator on the given input operator
+// with the given column types.
+func NewCoalescerOp(input Operator, colTypes []types.T) Operator {
+	return &coalescerOp{
+		input:      input,
+		inputTypes: colTypes,
+	}
+}
+
+func (p *coalescerOp) Init() {
+	p.input.Init()
+	p.group = NewMemBatch(p.inputTypes)
+	p.buffer = NewMemBatch(p.inputTypes)
+}
+
+func (p *coalescerOp) Next() ColBatch {
+	tempBatch := p.group
+	p.group = p.buffer
+
+	p.buffer = tempBatch
+	p.buffer.SetLength(0)
+
+	for p.group.Length() < ColBatchSize {
+		leftover := ColBatchSize - p.group.Length()
+		batch := p.input.Next()
+		batchSize := batch.Length()
+
+		if batchSize == 0 {
+			break
+		}
+
+		sel := batch.Selection()
+
+		for i, t := range p.inputTypes {
+			toCol := p.group.ColVec(i)
+			fromCol := batch.ColVec(i)
+
+			if batchSize <= leftover {
+				if sel != nil {
+					toCol.AppendWithSel(fromCol, sel, batchSize, t, uint64(p.group.Length()))
+				} else {
+					toCol.Append(fromCol, t, uint64(p.group.Length()), batchSize)
+				}
+			} else {
+				bufferCol := p.buffer.ColVec(i)
+				if sel != nil {
+					toCol.AppendWithSel(fromCol, sel, leftover, t, uint64(p.group.Length()))
+					bufferCol.CopyWithSelInt16(fromCol, sel[leftover:batchSize], batchSize-leftover, t)
+				} else {
+					toCol.Append(fromCol, t, uint64(p.group.Length()), leftover)
+					bufferCol.Copy(fromCol, int(leftover), int(batchSize), t)
+				}
+			}
+		}
+
+		if batchSize <= leftover {
+			p.group.SetLength(p.group.Length() + batchSize)
+		} else {
+			p.group.SetLength(ColBatchSize)
+			p.buffer.SetLength(batchSize - leftover)
+		}
+	}
+
+	return p.group
+}

--- a/pkg/sql/exec/coalescer_test.go
+++ b/pkg/sql/exec/coalescer_test.go
@@ -1,0 +1,112 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+func TestCoalescer(t *testing.T) {
+	// Large tuple number for coalescing.
+	nRows := ColBatchSize*3 + 7
+	large := make(tuples, nRows)
+	largeTypes := []types.T{types.Int64}
+
+	for i := 0; i < nRows; i++ {
+		large[i] = tuple{int64(i)}
+	}
+
+	tcs := []struct {
+		colTypes []types.T
+		tuples   tuples
+	}{
+		{
+			colTypes: []types.T{types.Int64, types.Bytes},
+			tuples: tuples{
+				{0, "0"},
+				{1, "1"},
+				{2, "2"},
+				{3, "3"},
+				{4, "4"},
+				{5, "5"},
+			},
+		},
+		{
+			colTypes: largeTypes,
+			tuples:   large,
+		},
+	}
+
+	for _, tc := range tcs {
+		runTests(t, []tuples{tc.tuples}, []types.T{}, func(t *testing.T, input []Operator) {
+			coalescer := NewCoalescerOp(input[0], tc.colTypes)
+
+			colIndices := make([]int, len(tc.colTypes))
+			for i := 0; i < len(colIndices); i++ {
+				colIndices[i] = i
+			}
+
+			out := newOpTestOutput(coalescer, colIndices, tc.tuples)
+
+			if err := out.Verify(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func BenchmarkCoalescer(b *testing.B) {
+	// The input operator to the coalescer returns a batch of random size from [1,
+	// ColBatchSize) each time.
+	nCols := 4
+	sourceTypes := make([]types.T, nCols)
+
+	for colIdx := 0; colIdx < nCols; colIdx++ {
+		sourceTypes[colIdx] = types.Int64
+	}
+
+	batch := NewMemBatch(sourceTypes)
+
+	for colIdx := 0; colIdx < nCols; colIdx++ {
+		col := batch.ColVec(colIdx).Int64()
+		for i := 0; i < ColBatchSize; i++ {
+			col[i] = int64(i)
+		}
+	}
+
+	for _, nBatches := range []int{1 << 1, 1 << 2, 1 << 4, 1 << 8, 1 << 12, 1 << 16} {
+		b.Run(fmt.Sprintf("rows=%d", nBatches*ColBatchSize), func(b *testing.B) {
+			b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				source := newRandomLengthBatchSource(batch)
+
+				co := &coalescerOp{
+					input:      source,
+					inputTypes: sourceTypes,
+				}
+
+				co.Init()
+
+				for i := 0; i < nBatches; i++ {
+					co.Next()
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added a coalescer operator that consumes an input operator and returns batches of `ColBatchSize` (except possibly for the final batch). This PR builds off of #31703.

Relevant files are:
`coalescer.go`
`coalescer_test.go`
`distinct_test.go`
`hash_joiner_test.go`

**Update**

I added a benchmark for the coalescer alone without wrapping any other operators. The input operator is a `randomLengthBatchSource` which basically returns a batch of random length each time.

Benchmark results:
```
BenchmarkCoalescer/rows=2048-8         	   50000	     34381 ns/op	1906.14 MB/s
BenchmarkCoalescer/rows=4096-8         	   50000	     39697 ns/op	3301.75 MB/s
BenchmarkCoalescer/rows=16384-8        	   20000	     66461 ns/op	7888.59 MB/s
BenchmarkCoalescer/rows=262144-8       	    3000	    547398 ns/op	15324.50 MB/s
BenchmarkCoalescer/rows=4194304-8      	     200	   9278840 ns/op	14464.92 MB/s
BenchmarkCoalescer/rows=67108864-8     	      10	 130599237 ns/op	16443.31 MB/s
```

**Old benchmark results**

I benchmarked this operator with `BenchmarkSortedDistinct` and the performance suffered a (4-8)x speed decrease. (The `sortedDistinct` operator does not currently do any internal batching so this may not be a the best comparison.)

```
BenchmarkSortedDistinct/coalesce=false/rows=2048-8         	  200000	      6102 ns/op	8054.91 MB/s
BenchmarkSortedDistinct/coalesce=false/rows=4096-8         	  200000	     11426 ns/op	8603.31 MB/s
BenchmarkSortedDistinct/coalesce=false/rows=16384-8        	   30000	     46409 ns/op	8472.84 MB/s
BenchmarkSortedDistinct/coalesce=false/rows=262144-8       	    2000	    716523 ns/op	8780.53 MB/s
BenchmarkSortedDistinct/coalesce=false/rows=4194304-8      	     100	  11177254 ns/op	9006.08 MB/s
BenchmarkSortedDistinct/coalesce=false/rows=67108864-8     	      10	 178655224 ns/op	9015.20 MB/s
BenchmarkSortedDistinct/coalesce=true/rows=2048-8          	   50000	     37696 ns/op	1303.88 MB/s
BenchmarkSortedDistinct/coalesce=true/rows=4096-8          	   30000	     58784 ns/op	1672.28 MB/s
BenchmarkSortedDistinct/coalesce=true/rows=16384-8         	   10000	    193118 ns/op	2036.14 MB/s
BenchmarkSortedDistinct/coalesce=true/rows=262144-8        	     500	   2742046 ns/op	2294.44 MB/s
BenchmarkSortedDistinct/coalesce=true/rows=4194304-8       	      30	  43854379 ns/op	2295.40 MB/s
BenchmarkSortedDistinct/coalesce=true/rows=67108864-8      	       2	 696012860 ns/op	2314.06 MB/s
```

Benchmark with `HashJoiner`. Not too sure why but the `rows=67108864-8` case is inherently faster the second time it runs (faster by 2x):
```
pkg: github.com/cockroachdb/cockroach/pkg/sql/exec
BenchmarkHashJoiner/coalesce=false/rows=2048-8         	   10000	    184756 ns/op	 709.43 MB/s
BenchmarkHashJoiner/coalesce=false/rows=4096-8         	    5000	    303386 ns/op	 864.06 MB/s
BenchmarkHashJoiner/coalesce=false/rows=16384-8        	    2000	   1006625 ns/op	1041.67 MB/s
BenchmarkHashJoiner/coalesce=false/rows=262144-8       	     100	  14699456 ns/op	1141.35 MB/s
BenchmarkHashJoiner/coalesce=false/rows=4194304-8      	       5	 217515533 ns/op	1234.10 MB/s
BenchmarkHashJoiner/coalesce=false/rows=67108864-8     	       1	7778556421 ns/op	 552.15 MB/s
BenchmarkHashJoiner/coalesce=true/rows=2048-8          	    5000	    225784 ns/op	 580.52 MB/s
BenchmarkHashJoiner/coalesce=true/rows=4096-8          	    3000	    362674 ns/op	 722.81 MB/s
BenchmarkHashJoiner/coalesce=true/rows=16384-8         	    1000	   1180055 ns/op	 888.58 MB/s
BenchmarkHashJoiner/coalesce=true/rows=262144-8        	     100	  16197670 ns/op	1035.78 MB/s
BenchmarkHashJoiner/coalesce=true/rows=4194304-8       	       5	 252784557 ns/op	1061.91 MB/s
BenchmarkHashJoiner/coalesce=true/rows=67108864-8      	       1	4575272688 ns/op	 938.73 MB/s
```