### PR TITLE
release-2.1: opt: fix selectivity estimates for index constraints

### DIFF
--- a/pkg/sql/opt/constraint/constraint.go
+++ b/pkg/sql/opt/constraint/constraint.go
@@ -448,6 +448,28 @@ func (c *Constraint) ExactPrefix(evalCtx *tree.EvalContext) int {
 	}
 }
 
+// ConstrainedColumns returns the number of columns which are constrained by
+// the Constraint. For example:
+//   /a/b/c: [/1/1 - /1] [/3 - /3]
+// has 2 constrained columns. This may be less than the total number of columns
+// in the constraint, especially if it represents an index constraint.
+func (c *Constraint) ConstrainedColumns(evalCtx *tree.EvalContext) int {
+	count := 0
+	for i := 0; i < c.Spans.Count(); i++ {
+		sp := c.Spans.Get(i)
+		start := sp.StartKey()
+		end := sp.EndKey()
+		if start.Length() > count {
+			count = start.Length()
+		}
+		if end.Length() > count {
+			count = end.Length()
+		}
+	}
+
+	return count
+}
+
 // Prefix returns the length of the longest prefix of columns for which all the
 // spans have the same start and end values. For example:
 //   /a/b/c: [/1/1/1 - /1/1/2] [/3/3/3 - /3/3/4]

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -246,15 +246,60 @@ index-join a
  ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
  └── select
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=111.111111]
+      ├── stats: [rows=37.037037]
       ├── key: (1)
       ├── fd: (1)-->(3,4), (3,4)-->(1)
       ├── scan a@secondary
       │    ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
       │    ├── constraint: /-3/4: [ - /'foobar'/5.0] [/'foo' - /'bar'/5.0]
-      │    ├── stats: [rows=1000]
+      │    ├── stats: [rows=333.333333]
       │    ├── key: (1)
       │    └── fd: (1)-->(3,4), (3,4)-->(1)
       └── filters [type=bool, outer=(3,4), constraints=(/4: (/NULL - /5.0])]
            ├── (s <= 'foo') OR (s >= 'foobar') [type=bool, outer=(3)]
            └── d <= 5.0 [type=bool, outer=(4), constraints=(/4: (/NULL - /5.0]; tight)]
+
+exec-ddl
+CREATE TABLE abcde (
+  a INT PRIMARY KEY,
+  b INT,
+  c STRING,
+  d INT,
+  e INT,
+  INDEX bad(b, d),
+  INDEX good(b, c, d)
+)
+----
+TABLE abcde
+ ├── a int not null
+ ├── b int
+ ├── c string
+ ├── d int
+ ├── e int
+ ├── INDEX primary
+ │    └── a int not null
+ ├── INDEX bad
+ │    ├── b int
+ │    ├── d int
+ │    └── a int not null
+ └── INDEX good
+      ├── b int
+      ├── c string
+      ├── d int
+      └── a int not null
+
+# Regression test for #31929. Ensure that the good index is chosen.
+opt
+SELECT * FROM abcde WHERE b = 1 AND c LIKE '+1-1000%'
+----
+index-join abcde
+ ├── columns: a:1(int!null) b:2(int!null) c:3(string) d:4(int) e:5(int)
+ ├── stats: [rows=3.33333333, distinct(2)=1]
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3-5)
+ └── scan abcde@good
+      ├── columns: a:1(int!null) b:2(int!null) c:3(string!null) d:4(int)
+      ├── constraint: /2/3/4/1: [/1/'+1-1000' - /1/'+1-1001')
+      ├── stats: [rows=1.11111111, distinct(2)=1]
+      ├── key: (1)
+      └── fd: ()-->(2), (1)-->(3,4)

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -206,7 +206,7 @@ project
       ├── scan idx@yz
       │    ├── columns: y:2(int!null) z:3(int)
       │    ├── constraint: /-2/3/1: (/4/NULL - /NULL)
-      │    └── stats: [rows=333.333333]
+      │    └── stats: [rows=298.65282]
       └── filters [type=bool, outer=(3), constraints=(/3: (/NULL - /9]; tight)]
            └── z < 10 [type=bool, outer=(3), constraints=(/3: (/NULL - /9]; tight)]
 

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -590,7 +590,7 @@ GenerateIndexScans
               └── f > 100.0 [type=bool, outer=(3), constraints=(/3: [/100.00000000000001 - ]; tight)]
 ================================================================================
 GenerateConstrainedScans
-  Cost: 10.83
+  Cost: 3.63
 ================================================================================
    project
     ├── columns: s:4(string!null) k:1(int!null)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -601,7 +601,7 @@ memo (optimized, ~13KB)
  ├── G1: (select G2 G4) (select G3 G4)
  │    └── "[presentation: k:1,u:2,v:3,j:4]"
  │         ├── best: (select G3 G4)
- │         └── cost: 411.20
+ │         └── cost: 45.69
  ├── G2: (scan b)
  │    └── ""
  │         ├── best: (scan b)
@@ -609,12 +609,12 @@ memo (optimized, ~13KB)
  ├── G3: (index-join G5 b,cols=(1-4))
  │    └── ""
  │         ├── best: (index-join G5 b,cols=(1-4))
- │         └── cost: 410.40
+ │         └── cost: 45.60
  ├── G4: (filters G6 G7)
  ├── G5: (scan b@u,cols=(1,2),constrained)
  │    └── ""
  │         ├── best: (scan b@u,cols=(1,2),constrained)
- │         └── cost: 83.20
+ │         └── cost: 9.24
  ├── G6: (gt G9 G8)
  ├── G7: (lt G9 G10)
  ├── G8: (tuple G11 G12 G13)


### PR DESCRIPTION
Backport 1/1 commits from #31937.

/cc @cockroachdb/release

---

Unlike the constraints found in Select and Join filters, an index
constraint may represent multiple conjuncts. Therefore, the selectivity
estimate for a Scan should account for the selectivity of each
constrained column in the index constraint. This commit fixes the
selectivity estimation in the optimizer to properly account for
each constrained column in a Scan.

Fixes #31929

Release note (bug fix): In some cases the optimizer was choosing
the wrong index for a scan because of incorrect selectivity
estimation. This estimation error has been fixed.
