### PR TITLE
storage: move addsstable command to open-source codebase

### DIFF
--- a/pkg/ccl/changefeedccl/poller.go
+++ b/pkg/ccl/changefeedccl/poller.go
@@ -15,7 +15,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/intervalccl"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
@@ -514,7 +513,7 @@ func (p *poller) slurpSST(ctx context.Context, sst []byte, schemaTimestamp hlc.T
 	}
 
 	var scratch bufalloc.ByteAllocator
-	it, err := engineccl.NewMemSSTIterator(sst, false /* verify */)
+	it, err := engine.NewMemSSTIterator(sst, false /* verify */)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/changefeedccl/table_history.go
+++ b/pkg/ccl/changefeedccl/table_history.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -251,7 +250,7 @@ func fetchTableDescriptorVersions(
 	var tableDescs []*sqlbase.TableDescriptor
 	for _, file := range res.(*roachpb.ExportResponse).Files {
 		if err := func() error {
-			it, err := engineccl.NewMemSSTIterator(file.SST, false /* verify */)
+			it, err := engine.NewMemSSTIterator(file.SST, false /* verify */)
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -17,7 +17,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -164,7 +163,7 @@ func AddSSTable(ctx context.Context, db *client.DB, start, end roachpb.Key, sstB
 func addSplitSSTable(
 	ctx context.Context, db *client.DB, sstBytes []byte, start, splitKey roachpb.Key,
 ) error {
-	iter, err := engineccl.NewMemSSTIterator(sstBytes, false)
+	iter, err := engine.NewMemSSTIterator(sstBytes, false)
 	if err != nil {
 		return err
 	}
@@ -281,7 +280,7 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 			}
 		}
 
-		iter, err := engineccl.NewMemSSTIterator(fileContents, false)
+		iter, err := engine.NewMemSSTIterator(fileContents, false)
 		if err != nil {
 			return nil, err
 		}
@@ -297,7 +296,7 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 	defer batcher.Close()
 
 	startKeyMVCC, endKeyMVCC := engine.MVCCKey{Key: args.DataSpan.Key}, engine.MVCCKey{Key: args.DataSpan.EndKey}
-	iter := engineccl.MakeMultiIterator(iters)
+	iter := engine.MakeMultiIterator(iters)
 	defer iter.Close()
 	var keyScratch, valueScratch []byte
 

--- a/pkg/storage/batcheval/cmd_add_sstable_test.go
+++ b/pkg/storage/batcheval/cmd_add_sstable_test.go
@@ -1,12 +1,18 @@
 // Copyright 2017 The Cockroach Authors.
 //
-// Licensed as a CockroachDB Enterprise file under the Cockroach Community
-// License (the "License"); you may not use this file except in compliance with
-// the License. You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
 
-package storageccl
+package batcheval_test
 
 import (
 	"bytes"
@@ -345,7 +351,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 			},
 			Stats: &enginepb.MVCCStats{},
 		}
-		_, err := evalAddSSTable(ctx, e, cArgs, nil)
+		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}

--- a/pkg/storage/batcheval/main_test.go
+++ b/pkg/storage/batcheval/main_test.go
@@ -1,0 +1,42 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package batcheval_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go
+
+func init() {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+}
+func TestMain(m *testing.M) {
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+
+	code := m.Run()
+
+	os.Exit(code)
+}

--- a/pkg/storage/engine/sst_iterator_test.go
+++ b/pkg/storage/engine/sst_iterator_test.go
@@ -1,12 +1,18 @@
 // Copyright 2017 The Cockroach Authors.
 //
-// Licensed as a CockroachDB Enterprise file under the Cockroach Community
-// License (the "License"); you may not use this file except in compliance with
-// the License. You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
 
-package engineccl
+package engine
 
 import (
 	"io/ioutil"
@@ -14,19 +20,18 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
-func runTestSSTIterator(t *testing.T, iter engine.SimpleIterator, allKVs []engine.MVCCKeyValue) {
+func runTestSSTIterator(t *testing.T, iter SimpleIterator, allKVs []MVCCKeyValue) {
 	// Drop the first kv so we can test Seek.
 	expected := allKVs[1:]
 
 	// Run the test multiple times to check re-Seeking.
 	for i := 0; i < 3; i++ {
-		var kvs []engine.MVCCKeyValue
+		var kvs []MVCCKeyValue
 		for iter.Seek(expected[0].Key); ; iter.Next() {
 			ok, err := iter.Valid()
 			if err != nil {
@@ -35,8 +40,8 @@ func runTestSSTIterator(t *testing.T, iter engine.SimpleIterator, allKVs []engin
 			if !ok {
 				break
 			}
-			kv := engine.MVCCKeyValue{
-				Key: engine.MVCCKey{
+			kv := MVCCKeyValue{
+				Key: MVCCKey{
 					Key:       append([]byte(nil), iter.UnsafeKey().Key...),
 					Timestamp: iter.UnsafeKey().Timestamp,
 				},
@@ -59,15 +64,15 @@ func runTestSSTIterator(t *testing.T, iter engine.SimpleIterator, allKVs []engin
 func TestSSTIterator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sst, err := engine.MakeRocksDBSstFileWriter()
+	sst, err := MakeRocksDBSstFileWriter()
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
 	defer sst.Close()
-	var allKVs []engine.MVCCKeyValue
+	var allKVs []MVCCKeyValue
 	for i := byte(0); i < 10; i++ {
-		kv := engine.MVCCKeyValue{
-			Key: engine.MVCCKey{
+		kv := MVCCKeyValue{
+			Key: MVCCKey{
 				Key:       []byte{i},
 				Timestamp: hlc.Timestamp{WallTime: int64(i)},
 			},
@@ -112,18 +117,18 @@ func TestSSTIterator(t *testing.T) {
 func TestCockroachComparer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	keyAMetadata := engine.EncodeKey(engine.MVCCKey{
+	keyAMetadata := EncodeKey(MVCCKey{
 		Key: []byte("a"),
 	})
-	keyA2 := engine.EncodeKey(engine.MVCCKey{
+	keyA2 := EncodeKey(MVCCKey{
 		Key:       []byte("a"),
 		Timestamp: hlc.Timestamp{WallTime: 2},
 	})
-	keyA1 := engine.EncodeKey(engine.MVCCKey{
+	keyA1 := EncodeKey(MVCCKey{
 		Key:       []byte("a"),
 		Timestamp: hlc.Timestamp{WallTime: 1},
 	})
-	keyB2 := engine.EncodeKey(engine.MVCCKey{
+	keyB2 := EncodeKey(MVCCKey{
 		Key:       []byte("b"),
 		Timestamp: hlc.Timestamp{WallTime: 2},
 	})


### PR DESCRIPTION
The plans to use addsstable for non-enterprise bulk operations will
require it be in open source builds.

This moves the command's implementation from the CCL codebase to the
open source codebase, along with the helpers for iterating SSTs and
the multi-terator, as both of these are used to verify SSTs during the
add command evaluation.

Release note: none.