### PR TITLE
release-2.1: sql/distsqlrun: avoid span use after finish

### DIFF
--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -639,7 +639,6 @@ func (f *Flow) Cleanup(ctx context.Context) {
 		log.Infof(ctx, "cleaning up")
 	}
 	sp := opentracing.SpanFromContext(ctx)
-	sp.Finish()
 	// Local flows do not get registered.
 	if !f.isLocal() && f.status != FlowNotStarted {
 		f.flowRegistry.UnregisterFlow(f.id)
@@ -648,6 +647,7 @@ func (f *Flow) Cleanup(ctx context.Context) {
 	f.ctxCancel()
 	f.doneFn()
 	f.doneFn = nil
+	sp.Finish()
 }
 
 // cancel iterates through all unconnected streams of this flow and marks them canceled.


### PR DESCRIPTION
Backport 1/1 commits from #31658.

No evidence that this has caused a problem in practice, but the fix is trivial.

/cc @cockroachdb/release

---

At verbosity 1 and higher, canceling a context may log via
`util/contextutil.wrap()`. Avoid finishing the span embedded in the
context until after the context is canceled.

Fixes #30010

Release note: None
