### PR TITLE
release-2.1: opt: Decorrelate Zip with correlated EXISTS subquery

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -196,3 +196,59 @@ EXPLAIN (VERBOSE) SELECT
   jsonb_array_elements( (SELECT gg.data->'members' FROM groups gg WHERE gg.data->>'name' = g.data->>'name') )
 FROM
   groups g
+
+statement ok
+CREATE TABLE articles (
+  id INT PRIMARY KEY,
+  body STRING,
+  description STRING,
+  title STRING,
+  slug STRING,
+  tag_list STRING[],
+  user_id STRING,
+  created_at TIMESTAMP,
+  updated_at TIMESTAMP
+)
+
+# Regression test for #31706.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT a0.id, a0.body, a0.description, a0.title, a0.slug, a0.tag_list, a0.user_id, a0.created_at, a0.updated_at
+    FROM articles AS a0
+   WHERE EXISTS(SELECT * FROM unnest(a0.tag_list) AS tag WHERE tag = 'dragons')
+ORDER BY a0.created_at
+   LIMIT 10
+  OFFSET 0;
+----
+limit                                 ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          +created_at
+ │                                    count        10                         ·                                                                                        ·
+ │                                    offset       0                          ·                                                                                        ·
+ └── sort                             ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          +created_at
+      │                               order        +created_at                ·                                                                                        ·
+      └── group                       ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          ·
+           │                          aggregate 0  id                         ·                                                                                        ·
+           │                          aggregate 1  any_not_null(body)         ·                                                                                        ·
+           │                          aggregate 2  any_not_null(description)  ·                                                                                        ·
+           │                          aggregate 3  any_not_null(title)        ·                                                                                        ·
+           │                          aggregate 4  any_not_null(slug)         ·                                                                                        ·
+           │                          aggregate 5  any_not_null(tag_list)     ·                                                                                        ·
+           │                          aggregate 6  any_not_null(user_id)      ·                                                                                        ·
+           │                          aggregate 7  any_not_null(created_at)   ·                                                                                        ·
+           │                          aggregate 8  any_not_null(updated_at)   ·                                                                                        ·
+           │                          group by     @1                         ·                                                                                        ·
+           └── render                 ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          ·
+                │                     render 0     id                         ·                                                                                        ·
+                │                     render 1     body                       ·                                                                                        ·
+                │                     render 2     description                ·                                                                                        ·
+                │                     render 3     title                      ·                                                                                        ·
+                │                     render 4     slug                       ·                                                                                        ·
+                │                     render 5     tag_list                   ·                                                                                        ·
+                │                     render 6     user_id                    ·                                                                                        ·
+                │                     render 7     created_at                 ·                                                                                        ·
+                │                     render 8     updated_at                 ·                                                                                        ·
+                └── filter            ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at, unnest)  ·
+                     │                filter       unnest = 'dragons'         ·                                                                                        ·
+                     └── project set  ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at, unnest)  ·
+                          │           render 0     unnest(@6)                 ·                                                                                        ·
+                          └── scan    ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          ·
+·                                     table        articles@primary           ·                                                                                        ·
+·                                     spans        ALL                        ·                                                                                        ·

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -457,7 +457,37 @@
     $right:* &
         (HasOuterCols $right) &
         (CanHaveZeroRows $right) & # Let EliminateExistsGroupBy match instead.
-        (GroupBy | DistinctOn | Project)
+        (GroupBy | DistinctOn | Project | Zip)
+    $on:*
+)
+=>
+(GroupBy
+    (InnerJoinApply
+        $newLeft:(EnsureKey $left)
+        $right
+        $on
+    )
+    (MakeAggCols ConstAgg (NonKeyCols $newLeft))
+    (MakeGroupByDef (KeyCols $newLeft))
+)
+
+# TryDecorrelateSemiJoinZip maps a SemiJoin over an InnerJoin/Zip complex to
+# an equivalent GroupBy/InnerJoin complex in hopes of triggering further rules
+# that will ultimately decorrelate the query. Once this rule fires, a
+# corresponding InnerJoin decorrelation rule will match
+# (i.e. TryDecorrelateZip).
+#
+# Citations: [5]
+[TryDecorrelateSemiJoinZip, Normalize]
+(SemiJoin | SemiJoinApply
+    $left:*
+    $right:* &
+        (HasOuterCols $right) &
+        (InnerJoin | InnerJoinApply
+            *
+            (Zip)
+            *
+        )
     $on:*
 )
 =>

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -26,7 +26,7 @@
 [PushFilterIntoJoinLeftAndRight, Normalize]
 (InnerJoin | SemiJoin
     $left:* & ^(HasOuterCols $left)
-    $right:* & ^(HasOuterCols $right)
+    $right:* & ^(Zip) & ^(HasOuterCols $right)
     $filters:(Filters
         $list:[
             ...
@@ -95,7 +95,7 @@
 (InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply |
  SemiJoin | SemiJoinApply | AntiJoin | AntiJoinApply
     $left:*
-    $right:*
+    $right:* & ^(Zip)
     $filters:(Filters
         $list:[
             ...
@@ -166,7 +166,7 @@
 (InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply |
  SemiJoin | SemiJoinApply | AntiJoin | AntiJoinApply
     $left:*
-    $right:*
+    $right:* & ^(Zip)
     $on:(Filters $list:[
         ...
         $condition:* & (IsBoundBy $condition $rightCols:(OutputCols $right))

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -106,7 +106,7 @@
     $input:(InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply |
             SemiJoin | SemiJoinApply | AntiJoin | AntiJoinApply
         $left:*
-        $right:*
+        $right:* & ^(Zip)
         $on:*
     )
     (Filters
@@ -146,7 +146,7 @@
 (Select
     $input:(InnerJoin | InnerJoinApply | RightJoin | RightJoinApply
         $left:*
-        $right:*
+        $right:* & ^(Zip)
         $on:*
     )
     (Filters
@@ -223,7 +223,7 @@
 (Select
     $input:(InnerJoin | InnerJoinApply | RightJoin | RightJoinApply
         $left:*
-        $right:*
+        $right:* & ^(Zip)
         $on:*
     )
     $filter:(Filters $list:[

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -2124,6 +2124,103 @@ project
       └── filters [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
            └── x = computed [type=bool, outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ])]
 
+exec-ddl
+CREATE TABLE articles (
+  id INT PRIMARY KEY,
+  body STRING,
+  description STRING,
+  title STRING,
+  slug STRING,
+  tag_list STRING[],
+  user_id STRING,
+  created_at TIMESTAMP,
+  updated_at TIMESTAMP
+)
+----
+TABLE articles
+ ├── id int not null
+ ├── body string
+ ├── description string
+ ├── title string
+ ├── slug string
+ ├── tag_list string[]
+ ├── user_id string
+ ├── created_at timestamp
+ ├── updated_at timestamp
+ └── INDEX primary
+      └── id int not null
+
+# Regression test for #31706. Right input of SemiJoin is Zip.
+opt expect=TryDecorrelateSemiJoin
+SELECT a0.id, a0.body, a0.description, a0.title, a0.slug, a0.tag_list, a0.user_id, a0.created_at, a0.updated_at
+    FROM articles AS a0
+   WHERE EXISTS(SELECT * FROM unnest(a0.tag_list) AS tag WHERE tag = 'dragons')
+ORDER BY a0.created_at
+   LIMIT 10
+  OFFSET 0;
+----
+limit
+ ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp)
+ ├── internal-ordering: +8
+ ├── cardinality: [0 - 10]
+ ├── side-effects
+ ├── key: (1)
+ ├── fd: (1)-->(2-9)
+ ├── ordering: +8
+ ├── offset
+ │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp)
+ │    ├── internal-ordering: +8
+ │    ├── side-effects
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-9)
+ │    ├── ordering: +8
+ │    ├── sort
+ │    │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp)
+ │    │    ├── side-effects
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-9)
+ │    │    ├── ordering: +8
+ │    │    └── group-by
+ │    │         ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp)
+ │    │         ├── grouping columns: id:1(int!null)
+ │    │         ├── side-effects
+ │    │         ├── key: (1)
+ │    │         ├── fd: (1)-->(2-9)
+ │    │         ├── inner-join-apply
+ │    │         │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp) unnest:10(string)
+ │    │         │    ├── side-effects
+ │    │         │    ├── fd: ()-->(10), (1)-->(2-9)
+ │    │         │    ├── scan articles
+ │    │         │    │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp)
+ │    │         │    │    ├── key: (1)
+ │    │         │    │    └── fd: (1)-->(2-9)
+ │    │         │    ├── zip
+ │    │         │    │    ├── columns: unnest:10(string)
+ │    │         │    │    ├── outer: (6)
+ │    │         │    │    ├── side-effects
+ │    │         │    │    └── unnest(tag_list) [type=string, outer=(6), side-effects]
+ │    │         │    └── filters [type=bool, outer=(10), constraints=(/10: [/'dragons' - /'dragons']; tight), fd=()-->(10)]
+ │    │         │         └── unnest = 'dragons' [type=bool, outer=(10), constraints=(/10: [/'dragons' - /'dragons']; tight)]
+ │    │         └── aggregations [outer=(2-9)]
+ │    │              ├── const-agg [type=string, outer=(2)]
+ │    │              │    └── variable: body [type=string, outer=(2)]
+ │    │              ├── const-agg [type=string, outer=(3)]
+ │    │              │    └── variable: description [type=string, outer=(3)]
+ │    │              ├── const-agg [type=string, outer=(4)]
+ │    │              │    └── variable: title [type=string, outer=(4)]
+ │    │              ├── const-agg [type=string, outer=(5)]
+ │    │              │    └── variable: slug [type=string, outer=(5)]
+ │    │              ├── const-agg [type=string[], outer=(6)]
+ │    │              │    └── variable: tag_list [type=string[], outer=(6)]
+ │    │              ├── const-agg [type=string, outer=(7)]
+ │    │              │    └── variable: user_id [type=string, outer=(7)]
+ │    │              ├── const-agg [type=timestamp, outer=(8)]
+ │    │              │    └── variable: created_at [type=timestamp, outer=(8)]
+ │    │              └── const-agg [type=timestamp, outer=(9)]
+ │    │                   └── variable: updated_at [type=timestamp, outer=(9)]
+ │    └── const: 0 [type=int]
+ └── const: 10 [type=int]
+
 # --------------------------------------------------
 # TryDecorrelateLimitOne
 # --------------------------------------------------
@@ -3778,9 +3875,9 @@ project
  └── projections [outer=(8)]
       └── variable: column1 [type=bool, outer=(8)]
 
-# --------------------------------------------------
-# HoistZipSubquery and TryDecorrelateZip
-# --------------------------------------------------
+# ------------------------------------------------------------------
+# HoistZipSubquery, TryDecorrelateSemiJoinZip and TryDecorrelateZip
+# ------------------------------------------------------------------
 opt expect=(HoistZipSubquery,TryDecorrelateZip)
 SELECT generate_series(1, (SELECT v FROM uv WHERE u=x)) FROM xy
 ----
@@ -3817,49 +3914,49 @@ project
       └── true [type=bool]
 
 # Zip correlation within EXISTS.
-opt expect=HoistZipSubquery
+opt expect=(HoistZipSubquery,TryDecorrelateSemiJoinZip,TryDecorrelateZip)
 SELECT * FROM xy WHERE EXISTS(SELECT * FROM generate_series(1, (SELECT v FROM uv WHERE u=x)))
 ----
-semi-join-apply
+group-by
  ├── columns: x:1(int!null) y:2(int)
+ ├── grouping columns: x:1(int!null)
  ├── side-effects
  ├── key: (1)
  ├── fd: (1)-->(2)
- ├── scan xy
- │    ├── columns: x:1(int!null) y:2(int)
- │    ├── key: (1)
- │    └── fd: (1)-->(2)
  ├── inner-join-apply
- │    ├── columns: v:4(int) generate_series:5(int)
- │    ├── outer: (1)
+ │    ├── columns: x:1(int!null) y:2(int) v:4(int) generate_series:5(int)
  │    ├── side-effects
+ │    ├── fd: (1)-->(2)
  │    ├── project
- │    │    ├── columns: v:4(int)
- │    │    ├── outer: (1)
- │    │    ├── cardinality: [1 - ]
- │    │    └── right-join
- │    │         ├── columns: u:3(int) v:4(int)
- │    │         ├── outer: (1)
- │    │         ├── cardinality: [1 - ]
- │    │         ├── key: (3)
- │    │         ├── fd: (3)-->(4)
+ │    │    ├── columns: x:1(int!null) y:2(int) v:4(int)
+ │    │    ├── fd: (1)-->(2)
+ │    │    └── left-join (merge)
+ │    │         ├── columns: x:1(int!null) y:2(int) u:3(int) v:4(int)
+ │    │         ├── key: (1,3)
+ │    │         ├── fd: (1)-->(2), (3)-->(4)
+ │    │         ├── scan xy
+ │    │         │    ├── columns: x:1(int!null) y:2(int)
+ │    │         │    ├── key: (1)
+ │    │         │    ├── fd: (1)-->(2)
+ │    │         │    └── ordering: +1
  │    │         ├── scan uv
  │    │         │    ├── columns: u:3(int!null) v:4(int)
  │    │         │    ├── key: (3)
- │    │         │    └── fd: (3)-->(4)
- │    │         ├── values
- │    │         │    ├── cardinality: [1 - 1]
- │    │         │    ├── key: ()
- │    │         │    └── tuple [type=tuple]
- │    │         └── filters [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
- │    │              └── u = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ])]
+ │    │         │    ├── fd: (3)-->(4)
+ │    │         │    └── ordering: +3
+ │    │         └── merge-on
+ │    │              ├── left ordering: +1
+ │    │              ├── right ordering: +3
+ │    │              └── true [type=bool]
  │    ├── zip
  │    │    ├── columns: generate_series:5(int)
  │    │    ├── outer: (4)
  │    │    ├── side-effects
  │    │    └── generate_series(1, v) [type=int, outer=(4), side-effects]
  │    └── true [type=bool]
- └── true [type=bool]
+ └── aggregations [outer=(2)]
+      └── const-agg [type=int, outer=(2)]
+           └── variable: y [type=int, outer=(2)]
 
 # Function contains multiple subqueries in arguments.
 opt expect=HoistZipSubquery


### PR DESCRIPTION
Backport 1/1 commits from #31922.

/cc @cockroachdb/release

---

This commit enables decorrelation of generator functions inside `EXISTS`.
It adds a new decorrelation rule called `TryDecorrelateSemiJoinZip`, which
is similar to the existing `TryDecorrelateSemiJoin` rule, but applies if
the right side of the join contains a `Zip` operator.

In addition, this commit prevents filters from being pushed down around
a `Zip`, and ensures that `InnerJoinApply` ON conditions are not lost
in the execbuilder.

This commit actually bears little resemblance to the commit being cherry-
picked from master, since that commit replaced the `Zip` operator with a
new operator called `ProjectSet`. Although that is a better approach than
the approach taken in this commit, the amount of effort required to
backport the new operator was prohibitive.

Fixes #31706

Release note (sql change): Many queries containing a correlated EXISTS
subquery with a generator function can now be decorrelated and executed
successfully. Previously, these queries caused a decorrelation error.
