### PR TITLE
release-2.1: c-deps: bump RocksDB to pick up range deletion fixes

### DIFF
--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -1389,9 +1389,9 @@ func TestRocksDBDeleteRangeCompaction(t *testing.T) {
 	// sstable being deleted. Prior to the hack in dbClearRange, all of the
 	// sstables would be compacted resulting in 2 L6 sstables with different
 	// boundaries than the ones below.
-	_ = db.CompactRange(makeKey("c", 0), makeKey("c", numEntries), false)
+	_ = db.CompactRange(makeKey("c", 1), makeKey("c", numEntries), false)
 	verifySSTables(`
-5: "a000000000" - "a000000000"
+5: "a000000000" - "c000000000"
 6: "a000000000" - "a000009999"
 6: "b000000000" - "b000009999"
 `)

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -1389,9 +1389,9 @@ func TestRocksDBDeleteRangeCompaction(t *testing.T) {
 	// sstable being deleted. Prior to the hack in dbClearRange, all of the
 	// sstables would be compacted resulting in 2 L6 sstables with different
 	// boundaries than the ones below.
-	_ = db.CompactRange(makeKey("c", 1), makeKey("c", numEntries), false)
+	_ = db.CompactRange(makeKey("c", 0), makeKey("c", numEntries), false)
 	verifySSTables(`
-5: "a000000000" - "c000000000"
+5: "a000000000" - "a000000000"
 6: "a000000000" - "a000009999"
 6: "b000000000" - "b000009999"
 `)


### PR DESCRIPTION
Backport:
  * 1/1 commits from "c-deps: bump RocksDB to pick up more range deletion fixes" (#31700)
  * 1/1 commits from "c-deps: bump RocksDB to pick up perf fix" (#32007)

#32007 is a relatively small change which fixes a performance gotcha introduced in #31700. We could conceivably leave it out of the backport. 

Fixes #31752

/cc @cockroachdb/release
