### PR TITLE
storage: deflake TestStoreRangeMergeSlowUnabandonedFollower_WithSplit

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -1771,17 +1771,8 @@ func TestStoreRangeMergeSlowUnabandonedFollower_WithSplit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Remove and GC the LHS replica on store2. This ensures that the RHS replica
-	// on store2 will never be subsumed, because the merge trigger will never be
-	// applied by the LHS.
+	// Remove the LHS replica from store2.
 	mtc.unreplicateRange(lhsDesc.RangeID, 2)
-	lhsRepl2 := store2.LookupReplica(lhsDesc.StartKey)
-	if err := store2.ManualReplicaGC(lhsRepl2); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := store2.GetReplica(lhsDesc.RangeID); err == nil {
-		t.Fatal("lhs replica not destroyed on store2")
-	}
 
 	// Transfer the lease on the new RHS to store2 and wait for it to apply. This
 	// will force its replica to of the new RHS to become up to date, which


### PR DESCRIPTION
Since 4aa93e5, we are more proactive about GC'ing orphaned
replicas--proactive enough that TestStoreRangeMergeSlowUnabandoned-
Follower_WithSplit and the new event-driven GC race to clean up store2's
replica of LHS. This causes the test to flake if it loses the race.

Teach the test to sit back and let event-driven GC clean up the LHS
replica. This removes the flakiness and makes for a better test.

Fix #31996.

Release note: None