### PR TITLE
changefeedccl: flush less

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -16,15 +16,17 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-var changefeedPollInterval = settings.RegisterDurationSetting(
+var changefeedPollInterval = settings.RegisterNonNegativeDurationSetting(
 	"changefeed.experimental_poll_interval",
 	"polling interval for the prototype changefeed implementation",
 	1*time.Second,
@@ -159,6 +161,7 @@ func kvsToRows(
 // advance the changefeed and which returns span-level resolved timestamp
 // updates. The returned closure is not threadsafe.
 func emitEntries(
+	settings *cluster.Settings,
 	details jobspb.ChangefeedDetails,
 	encoder Encoder,
 	sink Sink,
@@ -198,12 +201,15 @@ func emitEntries(
 		return nil
 	}
 
+	var lastFlush time.Time
+	// TODO(dan): We could keep these in a spanFrontier to eliminate dups.
+	var resolvedSpans []jobspb.ResolvedSpan
+
 	return func(ctx context.Context) ([]jobspb.ResolvedSpan, error) {
 		inputs, err := inputFn(ctx)
 		if err != nil {
 			return nil, err
 		}
-		var resolvedSpans []jobspb.ResolvedSpan
 		for _, input := range inputs {
 			if input.row.datums != nil {
 				if err := emitRowFn(ctx, input.row); err != nil {
@@ -214,24 +220,41 @@ func emitEntries(
 				resolvedSpans = append(resolvedSpans, *input.resolved)
 			}
 		}
-		if len(resolvedSpans) > 0 {
-			// Make sure to flush the sink before forwarding resolved spans,
-			// otherwise, we could lose buffered messages and violate the
-			// at-least-once guarantee. This is also true for checkpointing the
-			// resolved spans in the job progress.
-			//
-			// TODO(dan): We'll probably want some rate limiting on these
-			// flushes.
-			if err := sink.Flush(ctx); err != nil {
+
+		// Use the poll interval as a rough approximation of how
+		// latency-sensitive the changefeed user is. The current poller
+		// implementation means we emit a changefeed-level resolved timestamps
+		// to the user once per changefeedPollInterval. This buffering adds on
+		// average timeBetweenFlushes/2 to that latency. With timeBetweenFlushes
+		// and changefeedPollInterval both set to 1s, TPCC was seeing about 100x
+		// more time spent emitting than flushing. Dividing by 5 tries to
+		// balance these a bit, but ultimately is fairly unprincipled.
+		//
+		// NB: As long as we periodically get new span-level resolved timestamps
+		// from the poller (which should always happen, even if the watched data
+		// is not changing), then this is sufficient and we don't have to do
+		// anything fancy with timers.
+		timeBetweenFlushes := changefeedPollInterval.Get(&settings.SV) / 5
+		if len(resolvedSpans) == 0 || timeutil.Since(lastFlush) < timeBetweenFlushes {
+			return nil, nil
+		}
+
+		// Make sure to flush the sink before forwarding resolved spans,
+		// otherwise, we could lose buffered messages and violate the
+		// at-least-once guarantee. This is also true for checkpointing the
+		// resolved spans in the job progress.
+		if err := sink.Flush(ctx); err != nil {
+			return nil, err
+		}
+		lastFlush = timeutil.Now()
+		if knobs.AfterSinkFlush != nil {
+			if err := knobs.AfterSinkFlush(); err != nil {
 				return nil, err
 			}
-			if knobs.AfterSinkFlush != nil {
-				if err := knobs.AfterSinkFlush(); err != nil {
-					return nil, err
-				}
-			}
 		}
-		return resolvedSpans, nil
+		ret := append([]jobspb.ResolvedSpan(nil), resolvedSpans...)
+		resolvedSpans = resolvedSpans[:0]
+		return ret, nil
 	}
 }
 

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -158,7 +158,7 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 	if cfKnobs, ok := ca.flowCtx.TestingKnobs().Changefeed.(*TestingKnobs); ok {
 		knobs = *cfKnobs
 	}
-	ca.tickFn = emitEntries(ca.spec.Feed, ca.encoder, ca.sink, rowsFn, knobs)
+	ca.tickFn = emitEntries(ca.flowCtx.Settings, ca.spec.Feed, ca.encoder, ca.sink, rowsFn, knobs)
 
 	// Give errCh enough buffer both possible errors from supporting goroutines,
 	// but only the first one is ever used.

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -139,7 +139,7 @@ func createBenchmarkChangefeed(
 		m:        th,
 	}
 	rowsFn := kvsToRows(s.LeaseManager().(*sql.LeaseManager), details, buf.Get)
-	tickFn := emitEntries(details, encoder, sink, rowsFn, TestingKnobs{})
+	tickFn := emitEntries(s.ClusterSettings(), details, encoder, sink, rowsFn, TestingKnobs{})
 
 	ctx, cancel := context.WithCancel(ctx)
 	go func() { _ = poller.Run(ctx) }()


### PR DESCRIPTION
For correctness, changeAggreagator needs to flush kafka before
forwarding a span-level resolved timestamp to changeFrontier. Before
this change, it was flushing once before every span-level resolved
timestamp. On TPCC-1000, there were about 2000 of these per second,
which meant we were spending more time flushing kafka than writing to
it. (This is especially bad because it blocks Next calls.)

This change batches span-level resolved timestamps for some amount of
time, before flushing once and emitting them all. This adds ~20% delay
to the changefeed-level timestamp from being emitted to the user
slightly, but we now spend almost no time flushing.

Along with #32023, optimistically:
Closes #31001

Release note (bug fix): CHANGEFEEDs now spend dramatically less time
flushing kafka writes