### PR TITLE
cdc: Fix/Roachtest for CRDB Chaos

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -164,7 +164,7 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 	// but only the first one is ever used.
 	ca.errCh = make(chan error, 2)
 	ca.pollerDoneCh = make(chan struct{})
-	go func(ctx context.Context) {
+	if err := ca.flowCtx.Stopper().RunAsyncTask(ctx, "changefeed-poller", func(ctx context.Context) {
 		defer close(ca.pollerDoneCh)
 		var err error
 		if storage.RangefeedEnabled.Get(&ca.flowCtx.Settings.SV) {
@@ -177,7 +177,10 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 		// state stateTrailingMeta`), so return the error via a channel.
 		ca.errCh <- err
 		ca.cancel()
-	}(ctx)
+	}); err != nil {
+		ca.errCh <- err
+		ca.cancel()
+	}
 
 	return ctx
 }

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -330,6 +330,14 @@ func (r *Registry) maybeCancelJobs(ctx context.Context, nl NodeLiveness) {
 	if !liveness.IsLive(r.lenientNow(), r.clock.MaxOffset()) {
 		r.cancelAll(ctx)
 		r.mu.epoch = liveness.Epoch
+		return
+	}
+
+	// Finally, we cancel all jobs if the stopper is quiescing.
+	select {
+	case <-r.stopper.ShouldQuiesce():
+		r.cancelAll(ctx)
+	default:
 	}
 }
 

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -139,6 +139,11 @@ func (ctx *FlowCtx) TestingKnobs() TestingKnobs {
 	return ctx.testingKnobs
 }
 
+// Stopper returns the stopper for this flowCtx.
+func (ctx *FlowCtx) Stopper() *stop.Stopper {
+	return ctx.stopper
+}
+
 type flowStatus int
 
 // Flow status indicators.


### PR DESCRIPTION
Adds functionality to allow changefeeds to continue in the presence of
Kafka chaos; specifically, rpc errors from the distSQL flow are now
considered retryable.

Runs the existing TPCC roachtest with CRDB chaos (CRDB nodes being
randomly taken offline).  This is an alternative to the existing Kafka
chaos test, which tests the system when kafka is randomly taken offline.
This new test exercises the new retry pathway.

Resolves #28639

Release note: None