### PR TITLE
kv: allow parallelization of scans with limits where scans don't span ranges

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
@@ -28,6 +28,7 @@ export default function (props: GraphDashboardProps) {
       <Axis label="batches">
         <Metric name="cr.node.distsender.batches" title="Batches" nonNegativeRate />
         <Metric name="cr.node.distsender.batches.partial" title="Partial Batches" nonNegativeRate />
+        <Metric name="cr.node.distsender.batches.serial" title="Serialized Batches" nonNegativeRate />
       </Axis>
     </LineGraph>,
 


### PR DESCRIPTION
Previously any limit configured for a batch via `BatchHeader.MaxSpanRequestKeys`
would serialize requests to successive ranges. This change adds a nuance to
still allow parallelization in the event that none of the requests to be sent
to the next range appear to be spanning the two adjacent ranges.

Release note: performance improvement for queries in the form of `SELECT ... WHERE <key> IN (V1, V2, ..., Vn)` or `DELETE ... WHERE <key> IN (V1, V2, ..., Vn)`, where there are secondary indices.