### PR TITLE
exec: support more decimal, bytes, bool ops

### DIFF
--- a/pkg/sql/exec/distinct_tmpl.go
+++ b/pkg/sql/exec/distinct_tmpl.go
@@ -26,7 +26,10 @@ package exec
 import (
 	"bytes"
 
+	"github.com/cockroachdb/apd"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/pkg/errors"
 )
 
@@ -55,6 +58,12 @@ func NewOrderedDistinct(input Operator, distinctCols []uint32, typs []types.T) (
 // Dummy import to pull in "bytes" package.
 var _ bytes.Buffer
 
+// Dummy import to pull in "apd" package.
+var _ apd.Decimal
+
+// Dummy import to pull in "tree" package.
+var _ tree.Datum
+
 // _GOTYPE is the template Go type variable for this operator. It will be
 // replaced by the Go type equivalent for each type in types.T, for example
 // int64 for types.Int64.
@@ -64,9 +73,9 @@ type _GOTYPE interface{}
 // types.Foo for each type Foo in the types.T type.
 const _TYPES_T = Unhandled
 
-// _EQUALITY_FN is the template equality function for types that have an
-// equality function and not an infix operator.
-func _EQUALITY_FN(_ interface{}, _ interface{}) bool {
+// _ASSIGN_NE is the template equality function for assigning the first input
+// to the result of the second input != the third input.
+func _ASSIGN_NE(_, _, _ string) bool {
 	panic("")
 }
 
@@ -155,11 +164,7 @@ func (p *sortedDistinct_TYPEOp) Next() ColBatch {
 			// Note that not inlining this unique var actually makes a non-trivial
 			// performance difference.
 			var unique bool
-			// {{if eq .EqualityFunction ""}}
-			unique = v != lastVal
-			// {{else}}
-			unique = !_EQUALITY_FN(v, lastVal)
-			// {{end}}
+			_ASSIGN_NE("unique", "v", "lastVal")
 			outputCol[i] = outputCol[i] || unique
 			lastVal = v
 		}
@@ -172,11 +177,7 @@ func (p *sortedDistinct_TYPEOp) Next() ColBatch {
 			// Note that not inlining this unique var actually makes a non-trivial
 			// performance difference.
 			var unique bool
-			// {{if eq .EqualityFunction ""}}
-			unique = v != lastVal
-			// {{else}}
-			unique = !_EQUALITY_FN(v, lastVal)
-			// {{end}}
+			_ASSIGN_NE("unique", "v", "lastVal")
 			outputCol[i] = outputCol[i] || unique
 			lastVal = v
 		}

--- a/pkg/sql/exec/execgen/cmd/execgen/overloads.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/overloads.go
@@ -15,6 +15,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
@@ -42,6 +44,13 @@ var binaryOpInfix = map[tree.BinaryOperator]string{
 	tree.Div:   "/",
 }
 
+var binaryOpDecMethod = map[tree.BinaryOperator]string{
+	tree.Plus:  "Add",
+	tree.Minus: "Sub",
+	tree.Mult:  "Mul",
+	tree.Div:   "Quo",
+}
+
 var comparisonOpInfix = map[tree.ComparisonOperator]string{
 	tree.EQ: "==",
 	tree.NE: "!=",
@@ -52,45 +61,183 @@ var comparisonOpInfix = map[tree.ComparisonOperator]string{
 }
 
 type overload struct {
-	Name    string
+	Name string
+	// Only one of CmpOp and BinOp will be set, depending on whether the overload
+	// is a binary operator or a comparison operator.
+	CmpOp tree.ComparisonOperator
+	BinOp tree.BinaryOperator
+	// OpStr is the string form of whichever of CmpOp and BinOp are set.
 	OpStr   string
 	LTyp    types.T
 	RTyp    types.T
 	RGoType string
 	RetTyp  types.T
+
+	AssignFunc assignFunc
 }
 
-var binaryOpOverloads []overload
-var comparisonOpOverloads []overload
+type assignFunc func(op overload, target, l, r string) string
+
+var binaryOpOverloads []*overload
+var comparisonOpOverloads []*overload
+
+// comparsionOpToOverloads maps a comparison operator to all of the overloads
+// that implement it.
+var comparisonOpToOverloads map[tree.ComparisonOperator][]*overload
+
+// Assign produces a Go source string that assigns the "target" variable to the
+// result of applying the overload to the two inputs, l and r.
+//
+// For example, an overload that implemented the int64 plus operation, when fed
+// the inputs "x", "a", "b", would produce the string "x = a + b".
+func (o overload) Assign(target, l, r string) string {
+	if o.AssignFunc != nil {
+		if ret := o.AssignFunc(o, target, l, r); ret != "" {
+			return ret
+		}
+	}
+	// Default assign form assumes an infix operator.
+	return fmt.Sprintf("%s = %s %s %s", target, l, o.OpStr, r)
+}
 
 func init() {
-	// Build overload definitions.
-	inputTypes := []types.T{
-		types.Int8, types.Int16, types.Int32, types.Int64, types.Float32, types.Float64}
+	registerTypeCustomizers()
+
+	// Build overload definitions for basic types.
+	inputTypes := types.AllTypes
 	binOps := []tree.BinaryOperator{tree.Plus, tree.Minus, tree.Mult, tree.Div}
 	cmpOps := []tree.ComparisonOperator{tree.EQ, tree.NE, tree.LT, tree.LE, tree.GT, tree.GE}
+	comparisonOpToOverloads = make(map[tree.ComparisonOperator][]*overload, len(comparisonOpName))
 	for _, t := range inputTypes {
+		customizer := typeCustomizers[t]
 		for _, op := range binOps {
-			ov := overload{
+			// Skip types that don't have associated binary ops.
+			switch t {
+			case types.Bytes, types.Bool:
+				continue
+			}
+			ov := &overload{
 				Name:    binaryOpName[op],
+				BinOp:   op,
 				OpStr:   binaryOpInfix[op],
 				LTyp:    t,
 				RTyp:    t,
 				RGoType: t.GoTypeName(),
 				RetTyp:  t,
 			}
+			if customizer != nil {
+				if b, ok := customizer.(binOpTypeCustomizer); ok {
+					ov.AssignFunc = b.getBinOpAssignFunc()
+				}
+			}
 			binaryOpOverloads = append(binaryOpOverloads, ov)
 		}
 		for _, op := range cmpOps {
-			ov := overload{
+			opStr := comparisonOpInfix[op]
+			ov := &overload{
 				Name:    comparisonOpName[op],
-				OpStr:   comparisonOpInfix[op],
+				CmpOp:   op,
+				OpStr:   opStr,
 				LTyp:    t,
 				RTyp:    t,
 				RGoType: t.GoTypeName(),
 				RetTyp:  types.Bool,
 			}
+			if customizer != nil {
+				if b, ok := customizer.(cmpOpTypeCustomizer); ok {
+					ov.AssignFunc = b.getCmpOpAssignFunc()
+				}
+			}
 			comparisonOpOverloads = append(comparisonOpOverloads, ov)
+			comparisonOpToOverloads[op] = append(comparisonOpToOverloads[op], ov)
 		}
 	}
 }
+
+// typeCustomizer is a marker interface for something that implements one or
+// more of binOpTypeCustomizer and cmpOpTypeCustomizer.
+//
+// A type customizer allows custom templating behavior for a particular type
+// that doesn't permit the ordinary Go assignment (x = y), comparison
+// (==, <, etc) or binary operator (+, -, etc) semantics.
+type typeCustomizer interface{}
+
+var typeCustomizers map[types.T]typeCustomizer
+
+// registerTypeCustomizer registers a particular type customizer to a type, for
+// usage by templates.
+func registerTypeCustomizer(t types.T, customizer typeCustomizer) {
+	typeCustomizers[t] = customizer
+}
+
+// binOpTypeCustomizer is a type customizer that changes how the templater
+// produces binary operator output for a particular type.
+type binOpTypeCustomizer interface {
+	getBinOpAssignFunc() assignFunc
+}
+
+// cmpOpTypeCustomizer is a type customizer that changes how the templater
+// produces comparison operator output for a particular type.
+type cmpOpTypeCustomizer interface {
+	getCmpOpAssignFunc() assignFunc
+}
+
+// boolCustomizer is necessary since bools don't support < <= > >= in Go.
+type boolCustomizer struct{}
+
+// bytesCustomizer is necessary since []byte doesn't support comparison ops in
+// Go - bytes.Compare and so on have to be used.
+type bytesCustomizer struct{}
+
+// decimalCustomizer is necessary since apd.Decimal doesn't have infix operator
+// support for binary or comparison operators, and also doesn't have normal
+// variable-set semantics.
+type decimalCustomizer struct{}
+
+func (boolCustomizer) getCmpOpAssignFunc() assignFunc {
+	return func(op overload, target, l, r string) string {
+		switch op.CmpOp {
+		case tree.EQ, tree.NE:
+			return ""
+		}
+		return fmt.Sprintf("%s = tree.CompareBools(%s, %s) %s 0",
+			target, l, r, op.OpStr)
+	}
+}
+
+func (bytesCustomizer) getCmpOpAssignFunc() assignFunc {
+	return func(op overload, target, l, r string) string {
+		switch op.CmpOp {
+		case tree.EQ:
+			return fmt.Sprintf("%s = bytes.Equal(%s, %s)", target, l, r)
+		case tree.NE:
+			return fmt.Sprintf("%s = !bytes.Equal(%s, %s)", target, l, r)
+		}
+		return fmt.Sprintf("%s = bytes.Compare(%s, %s) %s 0",
+			target, l, r, op.OpStr)
+	}
+}
+
+func (decimalCustomizer) getCmpOpAssignFunc() assignFunc {
+	return func(op overload, target, l, r string) string {
+		return fmt.Sprintf("%s = tree.CompareDecimals(&%s, &%s) %s 0",
+			target, l, r, op.OpStr)
+	}
+}
+
+func (decimalCustomizer) getBinOpAssignFunc() assignFunc {
+	return func(op overload, target, l, r string) string {
+		return fmt.Sprintf("if _, err := tree.DecimalCtx.%s(&%s, &%s, &%s); err != nil { panic(err) }",
+			binaryOpDecMethod[op.BinOp], target, l, r)
+	}
+}
+
+func registerTypeCustomizers() {
+	typeCustomizers = make(map[types.T]typeCustomizer)
+	registerTypeCustomizer(types.Bool, boolCustomizer{})
+	registerTypeCustomizer(types.Bytes, bytesCustomizer{})
+	registerTypeCustomizer(types.Decimal, decimalCustomizer{})
+}
+
+// Avoid unused warning for Assign, which is only used in templates.
+var _ = overload{}.Assign

--- a/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
@@ -22,6 +22,11 @@ import (
 const selTemplate = `
 package exec
 
+import "bytes"
+
+import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+import "github.com/cockroachdb/apd"
+
 {{define "opConstName"}}sel{{.Name}}{{.LTyp}}{{.RTyp}}ConstOp{{end}}
 {{define "opName"}}sel{{.Name}}{{.LTyp}}{{.RTyp}}Op{{end}}
 
@@ -47,7 +52,9 @@ func (p *{{template "opConstName" .}}) Next() ColBatch {
 		if sel := batch.Selection(); sel != nil {
 			sel := sel[:n]
 			for _, i := range sel {
-				if col[i] {{.OpStr}} p.constArg {
+				var cmp bool
+				{{(.Assign "cmp" "col[i]" "p.constArg")}}
+				if cmp {
 					sel[idx] = i
 					idx++
 				}
@@ -56,7 +63,9 @@ func (p *{{template "opConstName" .}}) Next() ColBatch {
 			batch.SetSelection(true)
 			sel := batch.Selection()
 			for i := uint16(0); i < n; i++ {
-				if col[i] {{.OpStr}} p.constArg {
+				var cmp bool
+				{{(.Assign "cmp" "col[i]" "p.constArg")}}
+				if cmp {
 					sel[idx] = i
 					idx++
 				}
@@ -95,7 +104,9 @@ func (p *{{template "opName" .}}) Next() ColBatch {
 		if sel := batch.Selection(); sel != nil {
 			sel := sel[:n]
 			for _, i := range sel {
-				if col1[i] {{.OpStr}} col2[i] {
+				var cmp bool
+				{{(.Assign "cmp" "col1[i]" "col2[i]")}}
+				if cmp {
 					sel[idx] = i
 					idx++
 				}
@@ -104,7 +115,9 @@ func (p *{{template "opName" .}}) Next() ColBatch {
 			batch.SetSelection(true)
 			sel := batch.Selection()
 			for i := uint16(0); i < n; i++ {
-				if col1[i] {{.OpStr}} col2[i] {
+				var cmp bool
+				{{(.Assign "cmp" "col1[i]" "col2[i]")}}
+				if cmp {
 					sel[idx] = i
 					idx++
 				}

--- a/pkg/sql/exec/types/types.go
+++ b/pkg/sql/exec/types/types.go
@@ -137,6 +137,8 @@ func (t T) GoTypeName() string {
 		return "bool"
 	case Bytes:
 		return "[]byte"
+	case Decimal:
+		return "apd.Decimal"
 	case Int8:
 		return "int8"
 	case Int16:
@@ -153,20 +155,3 @@ func (t T) GoTypeName() string {
 		panic(fmt.Sprintf("unhandled type %d", t))
 	}
 }
-
-// EqualityFunction returns the name of the non-infix equality function for a
-// given type, if it exists. For example, the type Int64 has an infix equality
-// method, ==, so it doesn't have a case for EqualityFunction. But Bytes, since
-// it's implemented with the Go type []byte, is compared with bytes.Equal, so
-// it has a definition here.
-func (t T) EqualityFunction() string {
-	switch t {
-	case Bytes:
-		return "bytes.Equal"
-	}
-	return ""
-}
-
-// Suppress unused warning - we use this function in template code, which the
-// unused checker doesn't notice.
-var _ = Unhandled.EqualityFunction

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -365,10 +365,15 @@ func (d *DBool) Compare(ctx *EvalContext, other Datum) int {
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
-	if !*d && *v {
+	return CompareBools(bool(*d), bool(*v))
+}
+
+// CompareBools compares the input bools according to the SQL comparison rules.
+func CompareBools(d, v bool) int {
+	if !d && v {
 		return -1
 	}
-	if *d && !*v {
+	if d && !v {
 		return 1
 	}
 	return 0
@@ -919,6 +924,12 @@ func (d *DDecimal) Compare(ctx *EvalContext, other Datum) int {
 	default:
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
+	return CompareDecimals(&d.Decimal, v)
+}
+
+// CompareDecimals compares 2 apd.Decimals according to the SQL comparison
+// rules, making sure that NaNs sort first.
+func CompareDecimals(d *apd.Decimal, v *apd.Decimal) int {
 	// NaNs sort first in SQL.
 	if dn, vn := d.Form == apd.NaN, v.Form == apd.NaN; dn && !vn {
 		return -1


### PR DESCRIPTION
Add support for non-infix comparisons and binary operators in
projection, selection and distinct ops.

Release note: None