### PR TITLE
storage/engine: allow specifying lower bounds

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -612,6 +612,7 @@ DBIterState DBIterPrev(DBIterator* iter, bool skip_current_key_versions) {
   return DBIterGetState(iter);
 }
 
+void DBIterSetLowerBound(DBIterator* iter, DBKey key) { iter->SetLowerBound(key); }
 void DBIterSetUpperBound(DBIterator* iter, DBKey key) { iter->SetUpperBound(key); }
 
 DBStatus DBMerge(DBSlice existing, DBSlice update, DBString* new_value, bool full_merge) {

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -53,6 +53,7 @@ typedef struct {
 
 typedef struct {
   bool prefix;
+  DBKey lower_bound;
   DBKey upper_bound;
   bool with_stats;
   DBTimestamp min_timestamp_hint;
@@ -242,6 +243,9 @@ DBIterState DBIterNext(DBIterator* iter, bool skip_current_key_versions);
 // current key are skipped. After this call, DBIterValid() returns 1
 // iff the iterator was not positioned at the first key.
 DBIterState DBIterPrev(DBIterator* iter, bool skip_current_key_versions);
+
+// DBIterSetLowerBound updates this iterator's lower bound.
+void DBIterSetLowerBound(DBIterator* iter, DBKey key);
 
 // DBIterSetUpperBound updates this iterator's upper bound.
 void DBIterSetUpperBound(DBIterator* iter, DBKey key);

--- a/c-deps/libroach/iterator.cc
+++ b/c-deps/libroach/iterator.cc
@@ -23,7 +23,9 @@ DBIterator::DBIterator(std::atomic<int64_t>* iters, DBIterOptions iter_options) 
   read_opts.prefix_same_as_start = iter_options.prefix;
   read_opts.total_order_seek = !iter_options.prefix;
 
+  SetLowerBound(iter_options.lower_bound);
   SetUpperBound(iter_options.upper_bound);
+  read_opts.iterate_lower_bound = &lower_bound;
   read_opts.iterate_upper_bound = &upper_bound;
 
   if (!EmptyTimestamp(iter_options.min_timestamp_hint) ||
@@ -68,6 +70,16 @@ DBIterator::DBIterator(std::atomic<int64_t>* iters, DBIterOptions iter_options) 
 DBIterator::~DBIterator() {
   --(*iters_count);
 }
+
+void DBIterator::SetLowerBound(DBKey key) {
+  if (key.key.data == NULL) {
+    lower_bound_str = kMinKey.data();
+  } else {
+    lower_bound_str = EncodeKey(key);
+  }
+  lower_bound = lower_bound_str;
+}
+
 
 void DBIterator::SetUpperBound(DBKey key) {
   if (key.key.data == NULL) {

--- a/c-deps/libroach/iterator.h
+++ b/c-deps/libroach/iterator.h
@@ -23,6 +23,7 @@
 struct DBIterator {
   DBIterator(std::atomic<int64_t>* iters, DBIterOptions iter_options);
   ~DBIterator();
+  void SetLowerBound(DBKey key);
   void SetUpperBound(DBKey key);
 
   std::atomic<int64_t>* const iters_count;
@@ -32,6 +33,8 @@ struct DBIterator {
   std::unique_ptr<IteratorStats> stats;
 
   rocksdb::ReadOptions read_opts;
+  std::string lower_bound_str;
   std::string upper_bound_str;
+  rocksdb::Slice lower_bound;
   rocksdb::Slice upper_bound;
 };

--- a/c-deps/libroach/keys.h
+++ b/c-deps/libroach/keys.h
@@ -10,6 +10,7 @@ const rocksdb::Slice kLocalRangeIDPrefix("\x01\x69", 2);
 const rocksdb::Slice kLocalRangeIDReplicatedInfix("\x72", 1);
 const rocksdb::Slice kLocalRangeAppliedStateSuffix("\x72\x61\x73\x6b", 4);
 const rocksdb::Slice kMeta2KeyMax("\x03\xff\xff", 3);
+const rocksdb::Slice kMinKey("", 0);
 const rocksdb::Slice kMaxKey("\xff\xff", 2);
 
 const std::vector<std::pair<rocksdb::Slice, rocksdb::Slice> > kSortedNoSplitSpans = {

--- a/pkg/keys/gen_cpp_keys.go
+++ b/pkg/keys/gen_cpp_keys.go
@@ -73,6 +73,7 @@ namespace cockroach {
 	genKey(keys.LocalRangeIDReplicatedInfix, "LocalRangeIDReplicatedInfix")
 	genKey(keys.LocalRangeAppliedStateSuffix, "LocalRangeAppliedStateSuffix")
 	genKey(keys.Meta2KeyMax, "Meta2KeyMax")
+	genKey(keys.MinKey, "MinKey")
 	genKey(keys.MaxKey, "MaxKey")
 	fmt.Fprintf(f, "\n")
 

--- a/pkg/storage/batcheval/cmd_refresh_range.go
+++ b/pkg/storage/batcheval/cmd_refresh_range.go
@@ -60,7 +60,7 @@ func RefreshRange(
 	log.VEventf(ctx, 2, "refresh %s @[%s-%s]", args.Span(), h.Txn.OrigTimestamp, h.Txn.Timestamp)
 	intents, err := engine.MVCCIterateUsingIter(
 		ctx,
-		batch,
+		iter,
 		args.Key,
 		args.EndKey,
 		h.Txn.Timestamp,
@@ -68,7 +68,6 @@ func RefreshRange(
 		true,  /* tombstones */
 		nil,   /* txn */
 		false, /* reverse */
-		iter,
 		func(kv roachpb.KeyValue) (bool, error) {
 			if ts := kv.Value.Timestamp; !ts.Less(h.Txn.OrigTimestamp) {
 				return true, errors.Errorf("encountered recently written key %s @%s", kv.Key, ts)

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -135,10 +135,14 @@ type IterOptions struct {
 	// but iteration (using Next) over keys without the same user-key
 	// prefix will not work correctly (keys may be skipped).
 	Prefix bool
-	// UpperBound gives this iterator an upper bound. Attempts to Seek or Next
-	// past this point will invalidate the iterator. UpperBound must be provided
-	// unless Prefix is true, in which case the end of the prefix will be used as
-	// the upper bound.
+	// LowerBound gives this iterator an inclusive lower bound. Attempts to
+	// SeekReverse or Prev to a key that is strictly less than the bound will
+	// invalidate the iterator.
+	LowerBound roachpb.Key
+	// UpperBound gives this iterator an exclusive upper bound. Attempts to Seek
+	// or Next to a key that is greater than or equal to the bound will invalidate
+	// the iterator. UpperBound must be provided unless Prefix is true, in which
+	// case the end of the prefix will be used as the upper bound.
 	UpperBound roachpb.Key
 	// If WithStats is true, the iterator accumulates RocksDB performance
 	// counters over its lifetime which can be queried via `Stats()`.

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1705,6 +1705,7 @@ func mvccScanInternal(
 		// }
 
 		iter = engine.NewIterator(IterOptions{
+			LowerBound: key,
 			UpperBound: endKey,
 			WithStats:  withStats,
 		})
@@ -2010,7 +2011,10 @@ func MVCCIterate(
 	f func(roachpb.KeyValue) (bool, error),
 ) ([]roachpb.Intent, error) {
 	// Get a new iterator.
-	iter := engine.NewIterator(IterOptions{UpperBound: endKey})
+	iter := engine.NewIterator(IterOptions{
+		LowerBound: startKey,
+		UpperBound: endKey,
+	})
 	defer iter.Close()
 
 	return MVCCIterateUsingIter(

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1679,7 +1679,6 @@ func MVCCDeleteRange(
 // scan (based on the last key returned) if kv data is returned.
 func mvccScanInternal(
 	ctx context.Context,
-	engine Reader,
 	iter Iterator,
 	key,
 	endKey roachpb.Key,
@@ -1694,31 +1693,8 @@ func mvccScanInternal(
 		return nil, 0, nil, nil, emptyKeyError()
 	}
 
-	var ownIter bool
-	var withStats bool
-	if iter == nil {
-		// TODO(tschottdorf): re-enable this once performance is confirmed to not
-		// take a 10x hit on large count(*) queries.
-
-		// if sp := opentracing.SpanFromContext(ctx); sp != nil && !tracing.IsBlackHoleSpan(sp) {
-		// 	withStats = true
-		// }
-
-		iter = engine.NewIterator(IterOptions{
-			LowerBound: key,
-			UpperBound: endKey,
-			WithStats:  withStats,
-		})
-		ownIter = true
-	}
 	kvData, numKvs, intentData, err := iter.MVCCScan(
 		key, endKey, max, timestamp, txn, consistent, reverse, tombstones)
-	if withStats {
-		log.Eventf(ctx, "engine stats: %+v", iter.Stats())
-	}
-	if ownIter {
-		iter.Close()
-	}
 	if err != nil {
 		return nil, 0, nil, nil, err
 	}
@@ -1746,7 +1722,6 @@ func mvccScanInternal(
 // returns the found keys and values in batch format.
 func mvccScanToBytes(
 	ctx context.Context,
-	engine Reader,
 	iter Iterator,
 	key,
 	endKey roachpb.Key,
@@ -1761,7 +1736,7 @@ func mvccScanToBytes(
 		return nil, 0, &roachpb.Span{Key: key, EndKey: endKey}, nil, nil
 	}
 	kvData, numKvs, resumeSpan, intents, err := mvccScanInternal(
-		ctx, engine, iter, key, endKey, max, timestamp, consistent, tombstones, txn, reverse)
+		ctx, iter, key, endKey, max, timestamp, consistent, tombstones, txn, reverse)
 	if err != nil {
 		return nil, 0, resumeSpan, nil, err
 	}
@@ -1786,7 +1761,6 @@ func mvccScanToBytes(
 // returns the found keys and values in a slice of roachpb.KeyValue.
 func mvccScanToKvs(
 	ctx context.Context,
-	engine Reader,
 	iter Iterator,
 	key,
 	endKey roachpb.Key,
@@ -1801,7 +1775,7 @@ func mvccScanToKvs(
 		return nil, &roachpb.Span{Key: key, EndKey: endKey}, nil, nil
 	}
 	kvData, numKvs, resumeSpan, intents, err := mvccScanInternal(
-		ctx, engine, iter, key, endKey, max, timestamp, consistent, tombstones, txn, reverse)
+		ctx, iter, key, endKey, max, timestamp, consistent, tombstones, txn, reverse)
 	if err != nil {
 		return nil, resumeSpan, nil, err
 	}
@@ -1943,7 +1917,9 @@ func MVCCScan(
 	consistent bool,
 	txn *roachpb.Transaction,
 ) ([]roachpb.KeyValue, *roachpb.Span, []roachpb.Intent, error) {
-	return mvccScanToKvs(ctx, engine, nil, key, endKey, max, timestamp,
+	iter := engine.NewIterator(IterOptions{LowerBound: key, UpperBound: endKey})
+	defer iter.Close()
+	return mvccScanToKvs(ctx, iter, key, endKey, max, timestamp,
 		consistent, false /* tombstones */, txn, false /* reverse */)
 }
 
@@ -1958,7 +1934,9 @@ func MVCCScanToBytes(
 	consistent bool,
 	txn *roachpb.Transaction,
 ) ([]byte, int64, *roachpb.Span, []roachpb.Intent, error) {
-	return mvccScanToBytes(ctx, engine, nil, key, endKey, max, timestamp,
+	iter := engine.NewIterator(IterOptions{LowerBound: key, UpperBound: endKey})
+	defer iter.Close()
+	return mvccScanToBytes(ctx, iter, key, endKey, max, timestamp,
 		consistent, false /* tombstones */, txn, false /* reverse */)
 }
 
@@ -1975,7 +1953,9 @@ func MVCCReverseScan(
 	consistent bool,
 	txn *roachpb.Transaction,
 ) ([]roachpb.KeyValue, *roachpb.Span, []roachpb.Intent, error) {
-	return mvccScanToKvs(ctx, engine, nil, key, endKey, max, timestamp,
+	iter := engine.NewIterator(IterOptions{LowerBound: key, UpperBound: endKey})
+	defer iter.Close()
+	return mvccScanToKvs(ctx, iter, key, endKey, max, timestamp,
 		consistent, false /* tombstones */, txn, true /* reverse */)
 }
 
@@ -1991,7 +1971,9 @@ func MVCCReverseScanToBytes(
 	consistent bool,
 	txn *roachpb.Transaction,
 ) ([]byte, int64, *roachpb.Span, []roachpb.Intent, error) {
-	return mvccScanToBytes(ctx, engine, nil, key, endKey, max, timestamp,
+	iter := engine.NewIterator(IterOptions{LowerBound: key, UpperBound: endKey})
+	defer iter.Close()
+	return mvccScanToBytes(ctx, iter, key, endKey, max, timestamp,
 		consistent, false /* tombstones */, txn, true /* reverse */)
 }
 
@@ -2002,7 +1984,7 @@ func MVCCReverseScanToBytes(
 func MVCCIterate(
 	ctx context.Context,
 	engine Reader,
-	startKey, endKey roachpb.Key,
+	key, endKey roachpb.Key,
 	timestamp hlc.Timestamp,
 	consistent bool,
 	tombstones bool,
@@ -2010,30 +1992,23 @@ func MVCCIterate(
 	reverse bool,
 	f func(roachpb.KeyValue) (bool, error),
 ) ([]roachpb.Intent, error) {
-	// Get a new iterator.
-	iter := engine.NewIterator(IterOptions{
-		LowerBound: startKey,
-		UpperBound: endKey,
-	})
+	iter := engine.NewIterator(IterOptions{LowerBound: key, UpperBound: endKey})
 	defer iter.Close()
-
-	return MVCCIterateUsingIter(
-		ctx, engine, startKey, endKey, timestamp, consistent, tombstones, txn, reverse, iter, f,
-	)
+	return MVCCIterateUsingIter(ctx, iter, key, endKey, timestamp, consistent,
+		tombstones, txn, reverse, f)
 }
 
 // MVCCIterateUsingIter iterates over the key range [start,end) using the
 // supplied iterator. See comments for MVCCIterate.
 func MVCCIterateUsingIter(
 	ctx context.Context,
-	engine Reader,
+	iter Iterator,
 	startKey, endKey roachpb.Key,
 	timestamp hlc.Timestamp,
 	consistent bool,
 	tombstones bool,
 	txn *roachpb.Transaction,
 	reverse bool,
-	iter Iterator,
 	f func(roachpb.KeyValue) (bool, error),
 ) ([]roachpb.Intent, error) {
 	var intents []roachpb.Intent
@@ -2042,7 +2017,7 @@ func MVCCIterateUsingIter(
 	for {
 		const maxKeysPerScan = 1000
 		kvs, resume, newIntents, err := mvccScanToKvs(
-			ctx, engine, iter, startKey, endKey, maxKeysPerScan, timestamp, consistent, tombstones, txn, reverse)
+			ctx, iter, startKey, endKey, maxKeysPerScan, timestamp, consistent, tombstones, txn, reverse)
 		if err != nil {
 			switch tErr := err.(type) {
 			case *roachpb.WriteIntentError:


### PR DESCRIPTION
**storage/engine: allow specifying lower bounds**

In #26872 it was mandated that all iterators be either prefix iterators
or explicitly set an upper bound. This vastly improved performance with
range tombstones.

For completeness, we need to specify lower bounds on iterators that scan
in reverse. (This was left out of #26872 so that it could merge ASAP.)
This commit adds the necessary plumbing, and applies appropriate lower
bounds in the two code paths that perform reverse iteration.

---

**storage: improve layering of mvcc scan/iterate functions**

mvccScanInternal previously took both a Reader and an Iterator. If the
Iterator was nil, it would use the Reader to create itself an Iterator;
otherwise, it would use Iterator and entirely ignore Reader.

This was impressively confusing. Just teach all of mvccScanInternal's
callers (there are only five) to create an iterator if they don't have
one already.

We could further reduce duplication by collapsing all scan variants
(MVCCScanToBytes, MVCCReverseScan) into one function, MVCCScan, that
takes a ScanOptions struct, but that cleanup is left to a future commit.

---

@jordanlewis this should improve your life when you get back to #31909.